### PR TITLE
Fixed server crash

### DIFF
--- a/SGO/EntitySystems/InteractionSystem.cs
+++ b/SGO/EntitySystems/InteractionSystem.cs
@@ -92,7 +92,8 @@ namespace SGO.EntitySystems
 
         private bool DoEmptyHandToActorInteraction(Entity user, Entity obj)
         {
-            throw new NotImplementedException();
+            //throw new NotImplementedException();
+            return true;
         }
 
         private bool DoHandsToLargeObjectInteraction(Entity user, Entity obj)


### PR DESCRIPTION
Server was going down after a few clicks on the player due to NotImplementedException. Fixed it, still need DoEmptyHandToActorInteraction (mob interacting) done properly, but now it is at least not crashing
