### PR TITLE
This is how you look on linux

### DIFF
--- a/Resources/shaders/reductionEffect/HorizontalReduction.frag
+++ b/Resources/shaders/reductionEffect/HorizontalReduction.frag
@@ -1,4 +1,4 @@
-#version 130
+#version 120
 uniform sampler2D texture;
 uniform float TextureDimensions;
 

--- a/SS14.Client.Graphics/CluwneLib.cs
+++ b/SS14.Client.Graphics/CluwneLib.cs
@@ -151,11 +151,12 @@ namespace SS14.Client.Graphics
 
 
             //Hook OpenTK into SFMLs Opengl 
-            var wi = OpenTK.Platform.Utilities.CreateWindowsWindowInfo(Screen.SystemHandle);
-            var ctx = new OpenTK.Graphics.GraphicsContext(OpenTK.Graphics.GraphicsMode.Default, wi);
-            ctx.MakeCurrent(wi);
-            ctx.LoadAll();
-        }
+	    OpenTK.Toolkit.Init(new OpenTK.ToolkitOptions{
+                // Non-Native backend doesn't have a default GetAddress method
+		Backend = OpenTK.PlatformBackend.PreferNative
+	    });
+	    new GraphicsContext(OpenTK.ContextHandle.Zero, null);
+	}
        
         public static void RequestGC(Action action)
         {

--- a/SS14.Client/GameController.cs
+++ b/SS14.Client/GameController.cs
@@ -277,6 +277,7 @@ namespace SS14.Client
                 CluwneLib.RefreshVideoSettings += SetupCluwne;
                 onetime = false;
             }
+            CluwneLib.Screen.SetMouseCursorVisible(false);
             CluwneLib.Screen.BackgroundColor = Color.Black;
             CluwneLib.Screen.Resized += MainWindowResizeEnd;
             CluwneLib.Screen.Closed += MainWindowRequestClose;

--- a/SS14.Shared/Utility/BitStream.resx
+++ b/SS14.Shared/Utility/BitStream.resx
@@ -27,16 +27,16 @@
 			</xsd:complexType>
 		</xsd:element>
 	</xsd:schema>
-	<resheader name="ResMimeType">
+	<resheader name="resmimetype">
 		<value>text/microsoft-resx</value>
 	</resheader>
-	<resheader name="Version">
+	<resheader name="version">
 		<value>1.0.0.0</value>
 	</resheader>
-	<resheader name="Reader">
+	<resheader name="reader">
 		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
 	</resheader>
-	<resheader name="Writer">
+	<resheader name="writer">
 		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
 	</resheader>
 	<data name="Argument_DifferentBitStreamLengths">

--- a/Third-Party/sfmlnet-graphics-2.dll.config
+++ b/Third-Party/sfmlnet-graphics-2.dll.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <dllmap os="linux" dll="csfml-graphics-2" target="libcsfml-graphics.so"/>
+  <dllmap os="linux" dll="csfml-window-2" target="libcsfml-window.so"/>
+</configuration>

--- a/Third-Party/sfmlnet-system-2.dll.config
+++ b/Third-Party/sfmlnet-system-2.dll.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <dllmap os="linux" dll="csfml-system-2" target="libcsfml-system.so"/>
+</configuration>

--- a/Third-Party/sfmlnet-window-2.dll.config
+++ b/Third-Party/sfmlnet-window-2.dll.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <dllmap os="linux" dll="csfml-window-2" target="libcsfml-window.so"/>
+</configuration>


### PR DESCRIPTION
More specifically it's on Arch Linux.

![ss14](https://cloud.githubusercontent.com/assets/1443881/12049241/0ea27cc0-aee5-11e5-8754-7f787674c50e.jpg)

The options menu doesn't look right though:
![options](https://cloud.githubusercontent.com/assets/1443881/12049367/75988b26-aee6-11e5-8721-aa5b48a60f7b.jpg)

It took me a day because I'm new to C#, mono, monodevelop and there was a couple of problems.
- UnitTesting is not working in Monodevelop. It sais "This project type is not supported by Monodevelop". Ignored it.
- [NEED HELP] Added dllmap configs for sfml.net libraries. I just put them in Third-Party/ now. I have to copy them to bin/Client after compile. I don't know how can I do it with the project file.
- Had to compile a newer version of sfml.net. I have csfml 2.3 but the included sfml.net was for an older version probably. Without the new version the mouse cursor was stucked. (Maybe this was the input problem I read about on reddit)
