### PR TITLE
Empty config bug fixed (Issue #51)

### DIFF
--- a/SS14.Client.Services/Configuration/ConfigurationManager.cs
+++ b/SS14.Client.Services/Configuration/ConfigurationManager.cs
@@ -17,17 +17,18 @@ namespace SS14.Client.Services.Configuration
             if (File.Exists(configFile))
             {
                 _configFile = configFile;
-                var configLoader = new XmlSerializer(typeof (PlayerConfiguration));
+                var configLoader = new XmlSerializer(typeof(PlayerConfiguration));
                 StreamReader configReader = File.OpenText(configFile);
-                var config = (PlayerConfiguration) configLoader.Deserialize(configReader);
+                var config = (PlayerConfiguration)configLoader.Deserialize(configReader);
                 configReader.Close();
                 Configuration = config;
 
-                config.ResourcePack=SS14.Shared.Utility.PlatformTools.SanePath(config.ResourcePack);
+                config.ResourcePack = SS14.Shared.Utility.PlatformTools.SanePath(config.ResourcePack);
 
             }
             else
             {
+                SetDefaultConfiguration();
                 //if (LogManager.Singleton != null) LogManager.Singleton.LogMessage("ConfigManager: Could not load config. File not found. " + ConfigFileLoc);
             }
         }
@@ -167,6 +168,11 @@ namespace SS14.Client.Services.Configuration
 
         #endregion
 
+        private void SetDefaultConfiguration()
+        {
+            Configuration = new PlayerConfiguration();
+        }
+
         private void Save()
         {
             if (Configuration == null)
@@ -175,7 +181,7 @@ namespace SS14.Client.Services.Configuration
             }
             else
             {
-                var configSaver = new XmlSerializer(typeof (PlayerConfiguration));
+                var configSaver = new XmlSerializer(typeof(PlayerConfiguration));
                 StreamWriter configWriter = File.CreateText(_configFile);
                 configSaver.Serialize(configWriter, Configuration);
                 configWriter.Flush();

--- a/SS14.Server.Services/Configuration/ConfigurationManager.cs
+++ b/SS14.Server.Services/Configuration/ConfigurationManager.cs
@@ -12,6 +12,7 @@ namespace SS14.Server.Services.Configuration
     public sealed class ConfigurationManager : IServerConfigurationManager, IService
     {
         private string ConfigFile;
+        private string _defaultPath = "./server_config.xml"; //Default path for later saving purposes when there is no file
         public PersistentConfiguration Configuration;
 
         #region IConfigurationManager Members
@@ -20,15 +21,16 @@ namespace SS14.Server.Services.Configuration
         {
             if (File.Exists(ConfigFileLoc))
             {
-                var ConfigLoader = new XmlSerializer(typeof (PersistentConfiguration));
+                var ConfigLoader = new XmlSerializer(typeof(PersistentConfiguration));
                 StreamReader ConfigReader = File.OpenText(ConfigFileLoc);
-                var Config = (PersistentConfiguration) ConfigLoader.Deserialize(ConfigReader);
+                var Config = (PersistentConfiguration)ConfigLoader.Deserialize(ConfigReader);
                 ConfigReader.Close();
                 Configuration = Config;
                 ConfigFile = ConfigFileLoc;
             }
             else
             {
+                SetDefaultConfiguration();
                 //if (LogManager.Singleton != null) LogManager.Singleton.LogMessage("ConfigurationManager: Could not load config. File not found. " + ConfigFileLoc);
             }
         }
@@ -138,6 +140,13 @@ namespace SS14.Server.Services.Configuration
         }
 
         #endregion
+
+
+        private void SetDefaultConfiguration()
+        {
+            Configuration = new PersistentConfiguration();
+            ConfigFile = _defaultPath;
+        }
 
         public void LoadResources()
         {


### PR DESCRIPTION
Hello,

Since this is my first commit and still don't have all the scope of the project in my head, I wanted to start with a pretty easy thing.

PersistentConfiguration and PlayerConfiguration classes have default values for their properties, so, when there is no config file, a new instance of the corresponding class will be created.

There is also a default path string in server ConfigurationManager for later saving purposes.
