### PR TITLE
Fix Windows build. Move signal handling to reflection.

### DIFF
--- a/SS14.Server/Program.cs
+++ b/SS14.Server/Program.cs
@@ -31,9 +31,7 @@ namespace SS14.Server
             string strVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
             LogManager.Log("Server Version " + strVersion + " -> Ready");
 
-            #if __MonoCS__
             SignalHander.InstallSignals();
-            #endif
 
             main._server.MainLoop();
         }

--- a/SS14.Server/Signals.cs
+++ b/SS14.Server/Signals.cs
@@ -1,9 +1,11 @@
-using Mono.Unix;
-using Mono.Unix.Native;
 using SS14.Shared.IoC;
+using SS14.Shared.ServerEnums;
+using SS14.Server.Services.Log;
 using SS14.Server.Interfaces;
 using System;
 using System.Threading;
+using System.Reflection;
+using System.IO;
 
 // TODO: thread safety.
 namespace SS14.Server
@@ -14,30 +16,105 @@ namespace SS14.Server
 
         public static void InstallSignals()
         {
-            UnixSignal[] signals = new UnixSignal[] {
-                new UnixSignal (Mono.Unix.Native.Signum.SIGTERM),
-                new UnixSignal (Mono.Unix.Native.Signum.SIGINT)
-            };
-
-            SignalThread = new Thread(() =>
+            bool runningOnMono = Type.GetType ("Mono.Runtime") != null;
+            if (!runningOnMono)
             {
-                while (true)
-                {
-                    int index = UnixSignal.WaitAny(signals, -1);
-                    Signum signum = signals[index].Signum;
-                    switch (signum)
-                    {
-                        case Signum.SIGTERM:
-                        case Signum.SIGINT:
-                            IoCManager.Resolve<ISS14Server>().Shutdown(string.Format("{0} received", signum.ToString()));
-                            break;
-                    }
-                }
-            });
+                return;
+            }
+            try
+            {
+                // Reflection is fun.
+                var assembly = FindMonoPosix();
+                LogManager.Log("Successfully loaded Mono.Posix. Registering signal handlers...", LogLevel.Debug);
 
-            SignalThread.IsBackground = true;
-            SignalThread.Name = "signal handler"; 
-            SignalThread.Start();
+                Type signalType = assembly.GetType("Mono.Unix.UnixSignal");
+                // Mono.Unix.UnixSignal[]
+                Type signalArrayType = signalType.MakeArrayType();
+                Type signumType = assembly.GetType("Mono.Unix.Native.Signum");
+
+                var SIGTERM = Enum.Parse(signumType, "SIGTERM");
+                var SIGINT = Enum.Parse(signumType, "SIGINT");
+
+                // int UnixSignal.WaitAny(UnixSignal[])
+                var WaitAny = signalType.GetMethod("WaitAny", new Type[] { signalArrayType });
+                // UnixSignal.Signum
+                var Signum = signalType.GetProperty("Signum");
+
+                Array signals = Array.CreateInstance(signalType, 2);
+                signals.SetValue(Activator.CreateInstance(signalType, SIGTERM), 0);
+                signals.SetValue(Activator.CreateInstance(signalType, SIGINT), 1);
+
+                SignalThread = new Thread(() =>
+                {
+                    while (true)
+                    {
+                        object[] args = new object[] {
+                                signals
+                        };
+                        // int UnixSignal.WaitAny(UnixSignal[])
+                        int index = (int)WaitAny.Invoke(null, args);
+                        // signals[index].Signum
+                        string signum = Signum.GetValue(signals.GetValue(index), null).ToString();
+
+                        // Can't use switch with reflection. Shame.
+                        // Tried to compare the objects directly. Didn't work.
+                        // String it is.
+                        if (signum == "SIGINT" || signum == "SIGTERM")
+                        {
+                            IoCManager.Resolve<ISS14Server>().Shutdown(string.Format("{0} received", signum));
+                        }
+                    }
+                });
+
+                SignalThread.IsBackground = true;
+                SignalThread.Name = "signal handler";
+                SignalThread.Start();
+
+            }
+            catch (Exception e)
+            {
+                LogManager.Log(string.Format("Running on mono but couldn't register signal handlers: {0}", e), LogLevel.Error);
+            }
+        }
+
+        private static Assembly FindMonoPosix()
+        {
+            // This works don't touch it.
+            // Well it works on MacOS. Can't speak about Linux.
+            return Assembly.Load("../Mono.Posix.dll");
         }
     }
 }
+
+// Reference for the code when including Mono.Posix directly.
+// Obviously not possible anymore since we load the DLL manually.
+/*
+
+//using Mono.Unix;
+//using Mono.Unix.Native;
+
+UnixSignal[] signals = new UnixSignal[] {
+    new UnixSignal (Mono.Unix.Native.Signum.SIGTERM),
+    new UnixSignal (Mono.Unix.Native.Signum.SIGINT)
+};
+
+SignalThread = new Thread(() =>
+{
+    while (true)
+    {
+        int index = UnixSignal.WaitAny(signals, -1);
+        Signum signum = signals[index].Signum;
+        switch (signum)
+        {
+            case Signum.SIGTERM:
+            case Signum.SIGINT:
+                IoCManager.Resolve<ISS14Server>().Shutdown(string.Format("{0} received", signum.ToString()));
+                break;
+        }
+    }
+});
+
+SignalThread.IsBackground = true;
+SignalThread.Name = "signal handler";
+SignalThread.Start();
+    */

--- a/SS14.Server/SpaceStation14_Server.csproj
+++ b/SS14.Server/SpaceStation14_Server.csproj
@@ -107,7 +107,6 @@
       <Name>System.Xml.Linq</Name>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Mono.Posix" Condition="'$(__MonoCS__)' == ''"/>
     <Reference Include="CommandLine">
       <HintPath>..\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
     </Reference>
@@ -175,7 +174,7 @@
     <Compile Include="SS14Server.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Signals.cs" Condition="'$(__MonoCS__)' == ''">
+    <Compile Include="Signals.cs">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Timing\MainLoopTimer.cs">

--- a/SS14.Server/server_config.xml
+++ b/SS14.Server/server_config.xml
@@ -11,5 +11,5 @@
   <gameType>Game</gameType>
   <serverMapName>SavedMap</serverMapName>
   <serverWelcomeMessage>Hello and have a great fucking day!</serverWelcomeMessage>
-  <LogLevel>Information</LogLevel>
+  <LogLevel>Debug</LogLevel>
 </PersistentConfiguration>


### PR DESCRIPTION
Oh also sets the default log level to debug.

While fixing the Windows build that broke because my MSBUILD conditional was wrong, came across this SO answer:

http://stackoverflow.com/a/329072/4678631

So I realized I should follow this philosophy. Whether this is a misguided effort is debatable.