### PR TITLE
Add SharpZipLib to SS14_Server

### DIFF
--- a/SS14.Client.Services/SS14.Client.Services.csproj
+++ b/SS14.Client.Services/SS14.Client.Services.csproj
@@ -78,6 +78,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.CSharp">
       <Name>Microsoft.CSharp</Name>
     </Reference>
@@ -119,9 +123,6 @@
     </Reference>
     <Reference Include="System.Xml.Linq">
       <Name>System.Xml.Linq</Name>
-    </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -485,6 +486,7 @@
     <Compile Include="Utility\RobustSortedDrawing.cs">
       <SubType>Code</SubType>
     </Compile>
+    <None Include="app.config" />
     <None Include="MessageLogging\messageLoggerService.config">
     </None>
     <EmbeddedResource Include="_EmbeddedBaseResources\bluehigh.ttf">

--- a/SS14.Client.Services/app.config
+++ b/SS14.Client.Services/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.86.0.518" newVersion="0.86.0.518" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/SS14.Client/app.config
+++ b/SS14.Client/app.config
@@ -1,18 +1,24 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup useLegacyV2RuntimeActivationPolicy="true">
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />
   </startup>
   <runtime>
-    <loadFromRemoteSources enabled="true"/>
+    <loadFromRemoteSources enabled="true" />
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.86.0.518" newVersion="0.86.0.518" />
+      </dependentAssembly>
+    </assemblyBinding>
   </runtime>
   <system.serviceModel>
     <bindings>
       <netNamedPipeBinding>
         <binding name="NetNamedPipeBinding_IMessageLoggerService" closeTimeout="00:01:00" openTimeout="00:01:00" receiveTimeout="00:10:00" sendTimeout="00:01:00" transactionFlow="true" transferMode="Buffered" transactionProtocol="OleTransactions" hostNameComparisonMode="StrongWildcard" maxBufferPoolSize="524288" maxBufferSize="65536" maxConnections="10" maxReceivedMessageSize="65536">
-          <readerQuotas maxDepth="32" maxStringContentLength="8192" maxArrayLength="16384" maxBytesPerRead="4096" maxNameTableCharCount="16384"/>
+          <readerQuotas maxDepth="32" maxStringContentLength="8192" maxArrayLength="16384" maxBytesPerRead="4096" maxNameTableCharCount="16384" />
           <security mode="Transport">
-            <transport protectionLevel="EncryptAndSign"/>
+            <transport protectionLevel="EncryptAndSign" />
           </security>
         </binding>
       </netNamedPipeBinding>
@@ -20,7 +26,7 @@
     <client>
       <endpoint address="net.pipe://messageloggerservice/log" binding="netNamedPipeBinding" bindingConfiguration="NetNamedPipeBinding_IMessageLoggerService" contract="IMessageLoggerService" name="NetNamedPipeBinding_IMessageLoggerService">
         <identity>
-          <userPrincipalName value="Arxus\William Schaller"/>
+          <userPrincipalName value="Arxus\William Schaller" />
         </identity>
       </endpoint>
     </client>

--- a/SS14.Server/SpaceStation14_Server.csproj
+++ b/SS14.Server/SpaceStation14_Server.csproj
@@ -79,6 +79,10 @@
       <HintPath>..\Third-Party\CSScriptLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="sfmlnet-system-2, Version=2.1.0.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Third-Party\sfmlnet-system-2.dll</HintPath>

--- a/SS14.Server/app.config
+++ b/SS14.Server/app.config
@@ -1,12 +1,12 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <system.serviceModel>
     <bindings>
       <netNamedPipeBinding>
         <binding name="NetNamedPipeBinding_IMessageLoggerService" closeTimeout="00:01:00" openTimeout="00:01:00" receiveTimeout="00:10:00" sendTimeout="00:01:00" transactionFlow="false" transferMode="Buffered" transactionProtocol="OleTransactions" hostNameComparisonMode="StrongWildcard" maxBufferPoolSize="524288" maxBufferSize="65536" maxConnections="10" maxReceivedMessageSize="65536">
-          <readerQuotas maxDepth="32" maxStringContentLength="8192" maxArrayLength="16384" maxBytesPerRead="4096" maxNameTableCharCount="16384"/>
+          <readerQuotas maxDepth="32" maxStringContentLength="8192" maxArrayLength="16384" maxBytesPerRead="4096" maxNameTableCharCount="16384" />
           <security mode="Transport">
-            <transport protectionLevel="EncryptAndSign"/>
+            <transport protectionLevel="EncryptAndSign" />
           </security>
         </binding>
       </netNamedPipeBinding>
@@ -14,12 +14,20 @@
     <client>
       <endpoint address="net.pipe://messageloggerservice/log" binding="netNamedPipeBinding" bindingConfiguration="NetNamedPipeBinding_IMessageLoggerService" contract="IMessageLoggerService" name="NetNamedPipeBinding_IMessageLoggerService">
         <identity>
-          <userPrincipalName value="Arxus-64\William Schaller"/>
+          <userPrincipalName value="Arxus-64\William Schaller" />
         </identity>
       </endpoint>
     </client>
   </system.serviceModel>
   <startup useLegacyV2RuntimeActivationPolicy="true">
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />
   </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.86.0.518" newVersion="0.86.0.518" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/SS14.Server/packages.config
+++ b/SS14.Server/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommandLineParser" version="1.9.71" targetFramework="net451" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net451" />
 </packages>

--- a/SS14.UnitTesting/SS14.UnitTesting.csproj
+++ b/SS14.UnitTesting/SS14.UnitTesting.csproj
@@ -161,6 +161,7 @@
     <Content Include="CSFML\csfml-window-2.dll" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Choose>

--- a/SS14.UnitTesting/app.config
+++ b/SS14.UnitTesting/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.86.0.518" newVersion="0.86.0.518" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
Fixes a crash when loading into the game, the server crashes due to missing library.
```
Unhandled Exception: System.IO.FileNotFoundException: Could not load file or assembly 'ICSharpCode.SharpZipLib, Version=0.85.4.369, Culture=neutral, PublicKeyToken=1b03e6acf1164f73' or one of its dependencies. The system cannot find the file specified.
   at BsDiffLib.BinaryPatchUtility.Create(Byte[] oldData, Byte[] newData, Stream output)
   at SS14.Shared.GameStateDelta.Create(GameState fromState, GameState toState) in C:\Users\PsyKzz\Documents\Development\space-station-14\SS14.Shared\GameStateDelta.cs:line 37
   at SS14.Shared.GameStates.GameState.Delta(GameState fromState, GameState toState) in C:\Users\PsyKzz\Documents\Development\space-station-14\SS14.Shared\GameStates\GameState.cs:line 69
   at SS14.Shared.GameStates.GameState.op_Subtraction(GameState toState, GameState fromState) in C:\Users\PsyKzz\Documents\Development\space-station-14\SS14.Shared\GameStates\GameState.cs:line 40
   at SS14.Server.Services.GameState.GameStateManager.GetDelta(NetConnection client, UInt32 state) in C:\Users\PsyKzz\Documents\Development\space-station-14\SS14.Server.Services\GameState\GameStateManager.cs:line 45
   at SS14.Server.SS14Server.SendGameStateUpdate(Boolean force, Boolean forceFullState) in C:\Users\PsyKzz\Documents\Development\space-station-14\SS14.Server\SS14Server.cs:line 411
   at SS14.Server.SS14Server.Update(Single frameTime) in C:\Users\PsyKzz\Documents\Development\space-station-14\SS14.Server\SS14Server.cs:line 352
   at SS14.Server.SS14Server.DoMainLoopStuff() in C:\Users\PsyKzz\Documents\Development\space-station-14\SS14.Server\SS14Server.cs:line 242
   at SS14.Server.SS14Server.MainLoop() in C:\Users\PsyKzz\Documents\Development\space-station-14\SS14.Server\SS14Server.cs:line 190
   at SS14.Server.EntryPoint.Main(String[] args) in C:\Users\PsyKzz\Documents\Development\space-station-14\SS14.Server\Program.cs:line 36

```