### PR TITLE
De-lagging clickcode - pt 1

### DIFF
--- a/SS14.Client.GameObjects/Component/Renderable/AnimatedSpriteComponent.cs
+++ b/SS14.Client.GameObjects/Component/Renderable/AnimatedSpriteComponent.cs
@@ -2,6 +2,7 @@
 using SFML.System;
 using SS14.Client.Graphics;
 using SS14.Client.Graphics.Sprite;
+using SS14.Client.Graphics.texture;
 using SS14.Client.Interfaces.GOC;
 using SS14.Client.Interfaces.Map;
 using SS14.Client.Interfaces.Resource;

--- a/SS14.Client.GameObjects/Component/Renderable/AnimatedSpriteComponent.cs
+++ b/SS14.Client.GameObjects/Component/Renderable/AnimatedSpriteComponent.cs
@@ -212,11 +212,15 @@ namespace SS14.Client.GameObjects
             if (spritePosition.X < 0 || spritePosition.Y < 0)
                 return false;
 
-            // Copy the texture to image
-            var img = spriteToCheck.Texture.CopyToImage();
-            // Check if the clicked pixel is opaque
-            if (img.GetPixel((uint)spritePosition.X, (uint)spritePosition.Y).A == 0)
+            IResourceManager _resManager = IoCManager.Resolve<IResourceManager>();
+            Dictionary<Texture, string> tmp = _resManager.textureToKey;
+            if(!tmp.ContainsKey(spriteToCheck.Texture)) return false; //if it doesn't exist, something's fucked
+            string textureKey = tmp[spriteToCheck.Texture];
+            bool[,] opacityMap = TextureCache.Textures[textureKey].Item2; //get our clickthrough 'map'
+            if(!opacityMap[spritePosition.X, spritePosition.Y]) // Check if the clicked pixel is opaque
+            {
                 return false;
+            }
 
             return true;
         }

--- a/SS14.Client.GameObjects/Component/Renderable/AnimatedSpriteComponent.cs
+++ b/SS14.Client.GameObjects/Component/Renderable/AnimatedSpriteComponent.cs
@@ -215,7 +215,7 @@ namespace SS14.Client.GameObjects
 
             IResourceManager _resManager = IoCManager.Resolve<IResourceManager>();
             Dictionary<Texture, string> tmp = _resManager.textureToKey;
-            if(!tmp.ContainsKey(spriteToCheck.Texture)) return false; //if it doesn't exist, something's fucked
+            if(!tmp.ContainsKey(spriteToCheck.Texture)) { return false; } //if it doesn't exist, something's fucked
             string textureKey = tmp[spriteToCheck.Texture];
             bool[,] opacityMap = TextureCache.Textures[textureKey].Item2; //get our clickthrough 'map'
             if(!opacityMap[spritePosition.X, spritePosition.Y]) // Check if the clicked pixel is opaque

--- a/SS14.Client.GameObjects/Component/Renderable/AnimatedSpriteComponent.cs
+++ b/SS14.Client.GameObjects/Component/Renderable/AnimatedSpriteComponent.cs
@@ -214,7 +214,7 @@ namespace SS14.Client.GameObjects
                 return false;
 
             IResourceManager _resManager = IoCManager.Resolve<IResourceManager>();
-            Dictionary<Texture, string> tmp = _resManager.textureToKey;
+            Dictionary<Texture, string> tmp = _resManager.TextureToKey;
             if(!tmp.ContainsKey(spriteToCheck.Texture)) { return false; } //if it doesn't exist, something's fucked
             string textureKey = tmp[spriteToCheck.Texture];
             bool[,] opacityMap = TextureCache.Textures[textureKey].Item2; //get our clickthrough 'map'

--- a/SS14.Client.GameObjects/Component/Renderable/SpriteComponent.cs
+++ b/SS14.Client.GameObjects/Component/Renderable/SpriteComponent.cs
@@ -253,7 +253,7 @@ namespace SS14.Client.GameObjects
 
             IResourceManager _resManager = IoCManager.Resolve<IResourceManager>();
             Dictionary<Texture, string> tmp = _resManager.textureToKey;
-            if(!tmp.ContainsKey(spriteToCheck.Texture)) return false; //if it doesn't exist, something's fucked
+            if(!tmp.ContainsKey(spriteToCheck.Texture)) { return false; } //if it doesn't exist, something's fucked
             string textureKey = tmp[spriteToCheck.Texture];
             bool[,] opacityMap = TextureCache.Textures[textureKey].Item2; //get our clickthrough 'map'
             if(!opacityMap[spritePosition.X, spritePosition.Y]) // Check if the clicked pixel is opaque

--- a/SS14.Client.GameObjects/Component/Renderable/SpriteComponent.cs
+++ b/SS14.Client.GameObjects/Component/Renderable/SpriteComponent.cs
@@ -2,6 +2,7 @@
 using SFML.Graphics;
 using SFML.System;
 using SS14.Client.Graphics;
+using SS14.Client.Graphics.texture;
 using SS14.Client.Interfaces.GOC;
 using SS14.Client.Interfaces.Resource;
 using SS14.Shared;
@@ -250,11 +251,15 @@ namespace SS14.Client.GameObjects
             if (spritePosition.X < 0 || spritePosition.Y < 0)
                 return false;
 
-            // Copy the texture to image
-            var img = spriteToCheck.Texture.CopyToImage();
-            // Check if the clicked pixel is opaque
-            if (img.GetPixel((uint)spritePosition.X, (uint)spritePosition.Y).A == 0)
+            IResourceManager _resManager = IoCManager.Resolve<IResourceManager>();
+            Dictionary<Texture, string> tmp = _resManager.textureToKey;
+            if(!tmp.ContainsKey(spriteToCheck.Texture)) return false; //if it doesn't exist, something's fucked
+            string textureKey = tmp[spriteToCheck.Texture];
+            bool[] clickthrough = TextureCache.Textures[textureKey].Item2; //get our clickthrough 'map'
+            if(!clickthrough[spritePosition.Y * spritePosition.X]) // Check if the clicked pixel is opaque
+            {
                 return false;
+            }
 
             return true;
         }

--- a/SS14.Client.GameObjects/Component/Renderable/SpriteComponent.cs
+++ b/SS14.Client.GameObjects/Component/Renderable/SpriteComponent.cs
@@ -255,8 +255,8 @@ namespace SS14.Client.GameObjects
             Dictionary<Texture, string> tmp = _resManager.textureToKey;
             if(!tmp.ContainsKey(spriteToCheck.Texture)) return false; //if it doesn't exist, something's fucked
             string textureKey = tmp[spriteToCheck.Texture];
-            bool[] clickthrough = TextureCache.Textures[textureKey].Item2; //get our clickthrough 'map'
-            if(!clickthrough[spritePosition.Y * spritePosition.X]) // Check if the clicked pixel is opaque
+            bool[,] opacityMap = TextureCache.Textures[textureKey].Item2; //get our clickthrough 'map'
+            if(!opacityMap[spritePosition.X, spritePosition.Y]) // Check if the clicked pixel is opaque
             {
                 return false;
             }

--- a/SS14.Client.GameObjects/Component/Renderable/SpriteComponent.cs
+++ b/SS14.Client.GameObjects/Component/Renderable/SpriteComponent.cs
@@ -252,7 +252,7 @@ namespace SS14.Client.GameObjects
                 return false;
 
             IResourceManager _resManager = IoCManager.Resolve<IResourceManager>();
-            Dictionary<Texture, string> tmp = _resManager.textureToKey;
+            Dictionary<Texture, string> tmp = _resManager.TextureToKey;
             if(!tmp.ContainsKey(spriteToCheck.Texture)) { return false; } //if it doesn't exist, something's fucked
             string textureKey = tmp[spriteToCheck.Texture];
             bool[,] opacityMap = TextureCache.Textures[textureKey].Item2; //get our clickthrough 'map'

--- a/SS14.Client.Graphics/Sprite/SpriteInfo.cs
+++ b/SS14.Client.Graphics/Sprite/SpriteInfo.cs
@@ -2,6 +2,11 @@
 
 namespace SS14.Client.Graphics.Sprite
 {
+    public static class Limits
+    {
+        public const byte ClickthroughLimit = 64;
+    }
+
     public struct SpriteInfo
     {
         public string Name;

--- a/SS14.Client.Graphics/Sprite/SpriteInfo.cs
+++ b/SS14.Client.Graphics/Sprite/SpriteInfo.cs
@@ -4,7 +4,7 @@ namespace SS14.Client.Graphics.Sprite
 {
     public static class Limits
     {
-        public const byte ClickthroughLimit = 64;
+        public const byte ClickthroughLimit = 64; //default alpha for limiting clickthrough on sprites; will probably be template-dependent later on
     }
 
     public struct SpriteInfo

--- a/SS14.Client.Graphics/texture/TextureCache.cs
+++ b/SS14.Client.Graphics/texture/TextureCache.cs
@@ -6,22 +6,22 @@ namespace SS14.Client.Graphics.texture
 {
     public static class TextureCache
     {
-        private static Dictionary<string, Tuple<SFMLTexture, bool[]>> _textures = null;
+        private static Dictionary<string, Tuple<SFMLTexture, bool[,]>> _textures = null;
 
-        public static Dictionary<string, Tuple<SFMLTexture, bool[]>> Textures
+        public static Dictionary<string, Tuple<SFMLTexture, bool[,]>> Textures
         {
             get { return _textures; }
         }
         static TextureCache()
         {
-            _textures = new Dictionary<string, Tuple<SFMLTexture, bool[]>>();
+            _textures = new Dictionary<string, Tuple<SFMLTexture, bool[,]>>();
         }
-        public static bool Add(string name, SFMLTexture image, bool[] arr)
+        public static bool Add(string name, SFMLTexture image, bool[,] arr)
         {
             if (_textures.ContainsKey(name))
                 return true;
 
-            _textures.Add(name, new Tuple<SFMLTexture, bool[]>(new SFMLTexture(image), arr));
+            _textures.Add(name, new Tuple<SFMLTexture, bool[,]>(new SFMLTexture(image), arr));
 
             return true;
         }

--- a/SS14.Client.Graphics/texture/TextureCache.cs
+++ b/SS14.Client.Graphics/texture/TextureCache.cs
@@ -1,43 +1,27 @@
-﻿using SS14.Client.Graphics.Collection;
-using SFMLTexture = SFML.Graphics.Texture;
+﻿using SFMLTexture = SFML.Graphics.Texture;
+using System.Collections.Generic;
+using System;
 
 namespace SS14.Client.Graphics.texture
 {
-    public class TextureList : BaseCollection<SFMLTexture>
-    {
-        public SFMLTexture this[int index]
-        {
-            get { return GetItem(index); }
-        }
-
-        public SFMLTexture this[string key]
-        {
-            get { return GetItem(key); }
-        }
-        public void Add(string name, SFMLTexture tex)
-        {
-            AddItem(name, tex);
-        }
-        internal TextureList() : base(16, false) {}
-    }
     public static class TextureCache
     {
-        private static TextureList _textures = null;
+        private static Dictionary<string, Tuple<SFMLTexture, bool[]>> _textures = null;
 
-        public static TextureList Textures
+        public static Dictionary<string, Tuple<SFMLTexture, bool[]>> Textures
         {
             get { return _textures; }
         }
         static TextureCache()
         {
-            _textures = new TextureList();
+            _textures = new Dictionary<string, Tuple<SFMLTexture, bool[]>>();
         }
-        public static bool Add(string name, SFMLTexture image)
+        public static bool Add(string name, SFMLTexture image, bool[] arr)
         {
-            if (_textures.Contains(name))
+            if (_textures.ContainsKey(name))
                 return true;
 
-            _textures.Add(name, new SFMLTexture(image));
+            _textures.Add(name, new Tuple<SFMLTexture, bool[]>(new SFMLTexture(image), arr));
 
             return true;
         }

--- a/SS14.Client.Interfaces/Resource/IResourceManager.cs
+++ b/SS14.Client.Interfaces/Resource/IResourceManager.cs
@@ -2,11 +2,17 @@
 using SS14.Client.Graphics.Shader;
 using SS14.Client.Graphics.Sprite;
 using SS14.Shared.GameObjects;
+using System.Collections.Generic;
 
 namespace SS14.Client.Interfaces.Resource
 {
     public interface IResourceManager
     {
+        Dictionary<Texture, string> textureToKey
+        {
+            get;
+        }
+
         void LoadResourceZip(string path = null, string pw = null);
         void ClearLists();
         Sprite GetSpriteFromImage(string key);

--- a/SS14.Client.Interfaces/Resource/IResourceManager.cs
+++ b/SS14.Client.Interfaces/Resource/IResourceManager.cs
@@ -8,11 +8,7 @@ namespace SS14.Client.Interfaces.Resource
 {
     public interface IResourceManager
     {
-        Dictionary<Texture, string> textureToKey
-        {
-            get;
-        }
-
+        Dictionary<Texture, string> textureToKey { get; }
         void LoadResourceZip(string path = null, string pw = null);
         void ClearLists();
         Sprite GetSpriteFromImage(string key);

--- a/SS14.Client.Interfaces/Resource/IResourceManager.cs
+++ b/SS14.Client.Interfaces/Resource/IResourceManager.cs
@@ -8,7 +8,7 @@ namespace SS14.Client.Interfaces.Resource
 {
     public interface IResourceManager
     {
-        Dictionary<Texture, string> textureToKey { get; }
+        Dictionary<Texture, string> TextureToKey { get; }
         void LoadResourceZip(string path = null, string pw = null);
         void ClearLists();
         Sprite GetSpriteFromImage(string key);

--- a/SS14.Client.Services/ResourceManagment/ResourceManagerZip.cs
+++ b/SS14.Client.Services/ResourceManagment/ResourceManagerZip.cs
@@ -37,7 +37,7 @@ namespace SS14.Client.Services.Resources
         private readonly List<string> supportedImageExtensions = new List<string> {".png"};
 
         private readonly Dictionary<Texture, string> _textureToKey = new Dictionary<Texture, string>();
-        public Dictionary<Texture, string> textureToKey => _textureToKey;
+        public Dictionary<Texture, string> TextureToKey => _textureToKey;
 
         public int done = 0;
 

--- a/SS14.Client.Services/ResourceManagment/ResourceManagerZip.cs
+++ b/SS14.Client.Services/ResourceManagment/ResourceManagerZip.cs
@@ -37,10 +37,7 @@ namespace SS14.Client.Services.Resources
         private readonly List<string> supportedImageExtensions = new List<string> {".png"};
 
         private readonly Dictionary<Texture, string> _textureToKey = new Dictionary<Texture, string>();
-        public Dictionary<Texture, string> textureToKey
-        {
-            get { return _textureToKey; }
-        }
+        public Dictionary<Texture, string> textureToKey => _textureToKey;
 
         public int done = 0;
 
@@ -282,8 +279,7 @@ namespace SS14.Client.Services.Resources
                 memStream.Position = 0;
 
                 Image img = new Image(memStream);
-                bool[] clickthrough = new bool[img.Size.X * img.Size.Y];
-                int pos = 0; //easier than to calculate the position every time down in the loops
+                bool[,] opacityMap = new bool[img.Size.X, img.Size.Y];
                 for(int y = 0; y < img.Size.Y; y++)
                 {
                     for(int x = 0; x < img.Size.X; x++)
@@ -291,17 +287,17 @@ namespace SS14.Client.Services.Resources
                         Color pColor = img.GetPixel(Convert.ToUInt32(x), Convert.ToUInt32(y));
                         if(pColor.A > Limits.ClickthroughLimit)
                         {
-                            clickthrough[pos] = true;
+                            opacityMap[x, y] = true;
                         }
                         else
                         {
-                            clickthrough[pos] = false;
+                            opacityMap[x, y] = false;
                         }
                     }
                 }
 
                 Texture loadedImg = new Texture(memStream);
-                TextureCache.Add(ResourceName, loadedImg, clickthrough);
+                TextureCache.Add(ResourceName, loadedImg, opacityMap);
                 _textureToKey.Add(loadedImg, ResourceName);
 
                 memStream.Close();

--- a/SS14.Client.Services/ResourceManagment/ResourceManagerZip.cs
+++ b/SS14.Client.Services/ResourceManagment/ResourceManagerZip.cs
@@ -33,9 +33,14 @@ namespace SS14.Client.Services.Resources
         private readonly Dictionary<string, SpriteInfo> _spriteInfos = new Dictionary<string, SpriteInfo>();
         private readonly Dictionary<string, Sprite> _sprites = new Dictionary<string, Sprite>();
         private readonly Dictionary<string, AnimationCollection> _animationCollections = new Dictionary<string, AnimationCollection>(); 
-        private readonly Dictionary<string, AnimatedSprite> _animatedSprites = new Dictionary<string, AnimatedSprite>(); 
+        private readonly Dictionary<string, AnimatedSprite> _animatedSprites = new Dictionary<string, AnimatedSprite>();
         private readonly List<string> supportedImageExtensions = new List<string> {".png"};
-       
+
+        private readonly Dictionary<Texture, string> _textureToKey = new Dictionary<Texture, string>();
+        public Dictionary<Texture, string> textureToKey
+        {
+            get { return _textureToKey; }
+        }
 
         public int done = 0;
 
@@ -263,8 +268,8 @@ namespace SS14.Client.Services.Resources
         {
             string ResourceName = Path.GetFileNameWithoutExtension(imageEntry.Name).ToLowerInvariant();
 
-            if (TextureCache.Textures.Contains(ResourceName))
-                return TextureCache.Textures[ResourceName];
+            if (TextureCache.Textures.ContainsKey(ResourceName))
+                return TextureCache.Textures[ResourceName].Item1;
 
             var byteBuffer = new byte[zipBufferSize];
 
@@ -276,8 +281,28 @@ namespace SS14.Client.Services.Resources
                 StreamUtils.Copy(zipStream, memStream, byteBuffer);
                 memStream.Position = 0;
 
+                Image img = new Image(memStream);
+                bool[] clickthrough = new bool[img.Size.X * img.Size.Y];
+                int pos = 0; //easier than to calculate the position every time down in the loops
+                for(int y = 0; y < img.Size.Y; y++)
+                {
+                    for(int x = 0; x < img.Size.X; x++)
+                    {
+                        Color pColor = img.GetPixel(Convert.ToUInt32(x), Convert.ToUInt32(y));
+                        if(pColor.A > Limits.ClickthroughLimit)
+                        {
+                            clickthrough[pos] = true;
+                        }
+                        else
+                        {
+                            clickthrough[pos] = false;
+                        }
+                    }
+                }
+
                 Texture loadedImg = new Texture(memStream);
-                TextureCache.Add(ResourceName, loadedImg);
+                TextureCache.Add(ResourceName, loadedImg, clickthrough);
+                _textureToKey.Add(loadedImg, ResourceName);
 
                 memStream.Close();
                 zipStream.Close();
@@ -478,10 +503,10 @@ namespace SS14.Client.Services.Resources
 
                 string imageName = splitResourceName[0].ToLowerInvariant();
 
-                if (!TextureCache.Textures.Contains(splitResourceName[0]))
+                if (!TextureCache.Textures.ContainsKey(imageName))
                     continue; //Image for this sprite does not exist. Possibly set to defered later.
 
-                Texture atlasTex = TextureCache.Textures[splitResourceName[0]];
+                Texture atlasTex = TextureCache.Textures[imageName].Item1;
                 //Grab the image for the sprite from the cache.
 
                 var info = new SpriteInfo();

--- a/SS14.Server.Interfaces/SS14.Server.Interfaces.csproj
+++ b/SS14.Server.Interfaces/SS14.Server.Interfaces.csproj
@@ -250,7 +250,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Commands\" />
-    <Folder Include="NewFolder1\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
   <PropertyGroup>


### PR DESCRIPTION
Removes one of the most costly parts of clickcode, the copy of textures from the GPU VRAM to RAM to check for opaque pixels. Also removes a stray folder in a project. This reduces lag on click significantly, with a bit still left over - a WIP. I have no real way of testing this, but it compiles - hurray?

Oh, and the limit for considering a pixel clickthrough is currently an alpha of 64, easily changed.