### PR TITLE
Fix entity spawnlist background

### DIFF
--- a/SS14.Client.Services/UserInterface/Components/EntitySpawnSelectButton.cs
+++ b/SS14.Client.Services/UserInterface/Components/EntitySpawnSelectButton.cs
@@ -91,8 +91,7 @@ namespace SS14.Client.Services.UserInterface.Components
         {
            CluwneLib.drawRectangle(ClientArea.Left, ClientArea.Top, ClientArea.Width, ClientArea.Height,
                                                        selected ? new SFML.Graphics.Color(34, 139, 34) : new SFML.Graphics.Color(255, 250, 240));
-           CluwneLib.drawRectangle(ClientArea.Left, ClientArea.Top, ClientArea.Width, ClientArea.Height,
-                                                 Color.Black);
+
             objectSprite.Draw();
             name.Draw();
         }


### PR DESCRIPTION
Fixes the issue in #67 
> Spawn Entity menu renders the background of the items black
![image](https://cloud.githubusercontent.com/assets/1134201/25782699/e2cf3e10-3347-11e7-9534-7b426cbac097.png)
