### PR TITLE
Cleanup chat rendering

### DIFF
--- a/SS14.Client.Services/UserInterface/Components/Chatbox.cs
+++ b/SS14.Client.Services/UserInterface/Components/Chatbox.cs
@@ -201,6 +201,12 @@ namespace SS14.Client.Services.UserInterface.Components
                 label.Update(0);
                 last_y = label.ClientArea.Bottom();
                 components.Add(label);
+
+                // If the message had newlines adjust the bottom to fix the extra lines
+                if (message.Split('\n').Length > 0)
+                {
+                    last_y += 12 * (message.Split('\n').Length - 1);
+                }
             }
 
             if (atBottom)

--- a/SS14.Client.Services/UserInterface/Components/Chatbox.cs
+++ b/SS14.Client.Services/UserInterface/Components/Chatbox.cs
@@ -27,7 +27,7 @@ namespace SS14.Client.Services.UserInterface.Components
 
         // private const int MaxHistory = 20;
         // private const int MaxLines = 10;
-        private const int MaxLinePixelLength = 450;
+        private const int MaxLinePixelLength = 500;
 
         private readonly Dictionary<ChatChannel, SFML.Graphics.Color> _chatColors;
 
@@ -72,6 +72,8 @@ namespace SS14.Client.Services.UserInterface.Components
 
         public Chatbox(string uniqueName, Vector2i size, IResourceManager resourceManager) : base(uniqueName, size, resourceManager)
         {
+            scrollbarH.SetVisible(false);
+
             Position = new Vector2i((int)CluwneLib.CurrentClippingViewport.Width - (int)Size.X - 10, 10);
 
             // ClientArea = new IntRect(Position.X, Position.Y, (int) Size.X, (int) Size.Y);
@@ -97,9 +99,9 @@ namespace SS14.Client.Services.UserInterface.Components
                 [ChatChannel.Visual] = Color.Yellow,
             };
 
-            this.BackgroundColor = new SFML.Graphics.Color(128, 128, 128, 100);
-            this.DrawBackground = true;
-            this.DrawBorder = true;
+            BackgroundColor = new SFML.Graphics.Color(128, 128, 128, 100);
+            DrawBackground = true;
+            DrawBorder = true;
         }
 
         private bool Active
@@ -120,7 +122,6 @@ namespace SS14.Client.Services.UserInterface.Components
             }
         }
 
-        //
         private IEnumerable<string> CheckInboundMessage(string message)
         {
             var lineList = new List<string>();
@@ -188,7 +189,7 @@ namespace SS14.Client.Services.UserInterface.Components
 
             foreach (string content in CheckInboundMessage(message))
             {
-                var label = new Label(content, "MICROGBE", _resourceManager)
+                var label = new Label(content, "CALABRI", _resourceManager)
                 {
                     Position = new Vector2i(5, last_y),
                     Text =

--- a/SS14.Client.Services/UserInterface/Components/Chatbox.cs
+++ b/SS14.Client.Services/UserInterface/Components/Chatbox.cs
@@ -185,6 +185,8 @@ namespace SS14.Client.Services.UserInterface.Components
         {
             if (_disposing) return;
 
+            int lineHeight = 12;
+
             bool atBottom = scrollbarV.Value >= scrollbarV.max;
 
             foreach (string content in CheckInboundMessage(message))
@@ -194,7 +196,7 @@ namespace SS14.Client.Services.UserInterface.Components
                     Position = new Vector2i(5, last_y),
                     Text =
                     {
-                        Size = new Vector2i(ClientArea.Width - 10, 12),
+                        Size = new Vector2i(ClientArea.Width - 10, lineHeight),
                         Color = _chatColors[channel],
                     }
                 };
@@ -205,7 +207,7 @@ namespace SS14.Client.Services.UserInterface.Components
                 // If the message had newlines adjust the bottom to fix the extra lines
                 if (message.Split('\n').Length > 0)
                 {
-                    last_y += 12 * (message.Split('\n').Length - 1);
+                    last_y += lineHeight * (message.Split('\n').Length - 1);
                 }
             }
 

--- a/SS14.Client.Services/UserInterface/Components/ScrollableContainer.cs
+++ b/SS14.Client.Services/UserInterface/Components/ScrollableContainer.cs
@@ -99,7 +99,7 @@ namespace SS14.Client.Services.UserInterface.Components
 
             scrollbarH.max = (int)max_x - ClientArea.Width +
                              (max_y > clippingRI.Height ? scrollbarV.ClientArea.Width : 0);
-            if (max_x > clippingRI.Height) scrollbarH.SetVisible(true);
+            if (max_x > clippingRI.Width) scrollbarH.SetVisible(true);
             else scrollbarH.SetVisible(false);
 
             scrollbarV.max = (int)max_y - ClientArea.Height +

--- a/SS14.Server.Services/Chat/ChatManager.cs
+++ b/SS14.Server.Services/Chat/ChatManager.cs
@@ -200,12 +200,13 @@ namespace SS14.Server.Services.Chat
 
         private void SendToPlayersInRange(NetOutgoingMessage message, int? entityId)
         {
+            int withinRange = 512;
             if (entityId == null)
                 return;
             List<NetConnection> recipients =
                 IoCManager.Resolve<IPlayerManager>().GetPlayersInRange(
                     _serverMain.EntityManager.GetEntity((int)entityId).GetComponent<ITransformComponent>(
-                        ComponentFamily.Transform).Position, 512).Select(p => p.ConnectedClient).ToList();
+                        ComponentFamily.Transform).Position, withinRange).Select(p => p.ConnectedClient).ToList();
             IoCManager.Resolve<ISS14NetServer>().SendToMany(message, recipients);
         }
 

--- a/SS14.Server.Services/Chat/ChatManager.cs
+++ b/SS14.Server.Services/Chat/ChatManager.cs
@@ -40,12 +40,14 @@ namespace SS14.Server.Services.Chat
 
         public void HandleNetMessage(NetIncomingMessage message)
         {
-            //Read the chat message and pass it on
             var channel = (ChatChannel)message.ReadByte();
             string text = message.ReadString();
+
             IClient client = _serverMain.GetClient(message.SenderConnection);
-            string name = client.PlayerName;
-            LogManager.Log("CHAT- Channel " + channel.ToString() + " - Player " + name + "Message: " + text + "\n");
+            string playerName = client.PlayerName;
+
+            LogManager.Log("CHAT:: Channel: " + channel.ToString() + " :: Player: " + playerName + " :: Message: " + text, Shared.ServerEnums.LogLevel.Debug);
+
             var entityId = IoCManager.Resolve<IPlayerManager>().GetSessionByConnection(message.SenderConnection).AttachedEntityUid;
 
             bool hasChannelIdentifier = false;
@@ -54,12 +56,13 @@ namespace SS14.Server.Services.Chat
             if (hasChannelIdentifier)
                 text = text.Substring(1);
             text = text.Trim(); // Remove whitespace
+
             if (text[0] == '/')
-                ProcessCommand(text, name, channel, entityId, client);
+                ProcessCommand(text, playerName, channel, entityId, client);
             else if (text[0] == '*')
-                ProcessEmote(text, name, channel, entityId, message.SenderConnection);
+                ProcessEmote(text, playerName, channel, entityId, message.SenderConnection);
             else
-                SendChatMessage(channel, text, name, entityId);
+                SendChatMessage(channel, text, playerName, entityId);
         }
 
         public void SendChatMessage(ChatChannel channel, string text, string name, int? entityId)


### PR DESCRIPTION
Cleans up the chat logging in console (set to debug, otherwise its going to be way too much logging).
Also changed the font as the pixel count for word wrapping assumes a different font and was causing issues.

Also fixed incorrectly set vertical scrollbar on chatboxes.

![image](https://cloud.githubusercontent.com/assets/1134201/25783643/93f36978-3357-11e7-9e3b-10185f41460b.png)

![image](https://cloud.githubusercontent.com/assets/1134201/25783650/b13d6f24-3357-11e7-98ce-61cee681072c.png)

