### PR TITLE
Fix string.Format errors that would cause exceptions.

### DIFF
--- a/SS14.Client.Services/UserInterface/Components/DebugConsole.cs
+++ b/SS14.Client.Services/UserInterface/Components/DebugConsole.cs
@@ -245,7 +245,7 @@ namespace SS14.Client.Services.UserInterface.Components
 
                 var instance = Activator.CreateInstance(t, null) as IConsoleCommand;
                 if (commands.ContainsKey(instance.Command))
-                    throw new Exception(string.Format("Command already registered: {}", instance.Command));
+                    throw new Exception(string.Format("Command already registered: {0}", instance.Command));
 
                 commands[instance.Command] = instance;
             }

--- a/SS14.Server.Services/Chat/ChatManager.cs
+++ b/SS14.Server.Services/Chat/ChatManager.cs
@@ -191,7 +191,7 @@ namespace SS14.Server.Services.Chat
                 IChatCommand instance = (IChatCommand)Activator.CreateInstance(t, null);
                 if (_commands.ContainsKey(instance.Command))
                 {
-                    LogManager.Log(string.Format("Command has duplicate name: {}", instance.Command), Shared.ServerEnums.LogLevel.Error);
+                    LogManager.Log(string.Format("Command has duplicate name: {0}", instance.Command), Shared.ServerEnums.LogLevel.Error);
                     continue;
                 }
                 _commands[instance.Command] = instance;


### PR DESCRIPTION
String format in C# does not take empty curly braces.
Also someone broke appveyor