### PR TITLE
Missing `[IoCTarget]` on RoundManager

### DIFF
--- a/SS14.Server.Services/Round/RoundManager.cs
+++ b/SS14.Server.Services/Round/RoundManager.cs
@@ -4,6 +4,7 @@ using SS14.Server.Interfaces.Round;
 
 namespace SS14.Server.Services.Round
 {
+    [IoCTarget]
     internal class RoundManager : IRoundManager
     {
         private bool _ready;


### PR DESCRIPTION
Trying to compile and this is failing under IoCManager.