### PR TITLE
Fix missing IoCTarget

### DIFF
--- a/SS14.Server.Services/Round/RoundManager.cs
+++ b/SS14.Server.Services/Round/RoundManager.cs
@@ -1,9 +1,11 @@
 ﻿using SS14.Server.Interfaces.GameMode;
 using SS14.Server.Interfaces.Player;
 using SS14.Server.Interfaces.Round;
+using SS14.Shared.IoC;
 
 namespace SS14.Server.Services.Round
 {
+    [IoCTarget]
     internal class RoundManager : IRoundManager
     {
         private bool _ready;


### PR DESCRIPTION
Missing `[IoCTarget]` on RoundManager.cs
Remake of #161 