### PR TITLE
Small textbox changes

### DIFF
--- a/SS14.Client.Services/UserInterface/Components/Chatbox.cs
+++ b/SS14.Client.Services/UserInterface/Components/Chatbox.cs
@@ -285,6 +285,13 @@ namespace SS14.Client.Services.UserInterface.Components
                 return true;
             }
 
+            if (e.Code == Keyboard.Key.Return && input.Text == "" && Active)
+            {
+                Active = false;
+
+                return true;
+            }
+
             return input.KeyDown(e);
         }
 

--- a/SS14.Client.Services/UserInterface/Components/Chatbox.cs
+++ b/SS14.Client.Services/UserInterface/Components/Chatbox.cs
@@ -243,6 +243,13 @@ namespace SS14.Client.Services.UserInterface.Components
                 return true;
             }
 
+            if (input.Focus == true && !Active)
+            {
+                Active = true;
+
+                return true;
+            }
+
             if (!Active)
             {
                 return false;


### PR DESCRIPTION
(1) Currently the only way to exit the chatbox once you've selected it is to send a non-null message. That's not really intuitive. This allows the user to exit the chatbox focus by pressing ENTER if there's nothing typed in the input.

(2) Right now you can click on the chatbox and the input will have a cursor appear as if you can type in it, but you can't: you still have to press T to start chatting. That's unintuitive and maybe unintended. This gives focus to the input when the chatbox is clicked to allow typing right away.

I'd like to also make it so clicking the input also lets you type - right now nothing happens. I just haven't been able to figure out how to do that yet. Putting this up so other people can give advice/try themselves.