### PR TITLE
Fix missing NetSerializer and Old DLL links

### DIFF
--- a/SS14.Client/SS14.Client.csproj
+++ b/SS14.Client/SS14.Client.csproj
@@ -143,7 +143,7 @@
     <Reference Include="NetSerializer">
       <Name>NetSerializer</Name>
       <HintPath>..\Third-Party\NetSerializer.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp">
       <Name>Microsoft.CSharp</Name>

--- a/SS14.Server/SS14.Server.csproj
+++ b/SS14.Server/SS14.Server.csproj
@@ -121,7 +121,7 @@
     <Reference Include="NetSerializer">
       <Name>NetSerializer</Name>
       <HintPath>..\Third-Party\NetSerializer.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.ServiceModel">
       <Name>System.ServiceModel</Name>

--- a/SS14.Shared/GameObjects/EntitySystemManager.cs
+++ b/SS14.Shared/GameObjects/EntitySystemManager.cs
@@ -13,7 +13,6 @@ namespace SS14.Shared.GameObjects
 {
     public class EntitySystemManager
     {
-        private readonly List<Type> _systemTypes;
         private readonly Dictionary<Type, EntitySystem> _systems = new Dictionary<Type, EntitySystem>();
         private readonly Dictionary<Type, EntitySystem> _systemMessageTypes = new Dictionary<Type, EntitySystem>();
         private EntityManager _entityManager;
@@ -24,33 +23,6 @@ namespace SS14.Shared.GameObjects
         public EntitySystemManager(EntityManager em)
         {
             _entityManager = em;
-            _systemTypes = new List<Type>();
-            switch (em.EngineType)
-            {
-                case EngineType.Client:
-                    _systemTypes.AddRange(
-                        Assembly.LoadFrom("SS14.Client.GameObjects.dll").GetTypes().Where(
-                            t => typeof(EntitySystem).IsAssignableFrom(t)));
-                    break;
-                case EngineType.Server:
-                    _systemTypes.AddRange(
-                        Assembly.LoadFrom("SS14.Server.GameObjects.dll").GetTypes().Where(
-                            t => typeof (EntitySystem).IsAssignableFrom(t)));
-                    break;
-            }
-
-            foreach (Type type in _systemTypes)
-            {
-                if (type == typeof(EntitySystem))
-                    continue; //Don't run the base EntitySystem.
-                //Force initialization of all systems
-                var instance = (EntitySystem)Activator.CreateInstance(type, _entityManager, this);
-                MethodInfo generic = typeof(EntitySystemManager).GetMethod("AddSystem").MakeGenericMethod(type);
-                generic.Invoke(this, new[] { instance });
-                instance.RegisterMessageTypes();
-                instance.SubscribeEvents();
-
-            }
         }
 
         public void RegisterMessageType<T>(EntitySystem regSystem) where T : EntitySystemMessage

--- a/SS14.Shared/IoC/IoCManager.cs
+++ b/SS14.Shared/IoC/IoCManager.cs
@@ -21,7 +21,21 @@ namespace SS14.Shared.IoC
         {
             foreach (var assembly in assemblies)
             {
-                ServiceTypes.AddRange(assembly.GetTypes());
+                
+                try
+                {
+                    var assTypes = assembly.GetTypes();
+                    ServiceTypes.AddRange(assembly.GetTypes());
+                }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    // now look at ex.LoaderExceptions - this is an Exception[], so:
+                    foreach (Exception inner in ex.LoaderExceptions)
+                    {
+                        throw inner;
+                    }
+                }
+                
             }
 
             SortTypes();


### PR DESCRIPTION
Had some ReflectionTypeLoadExceptions on launching the server and client.
Also in the entity manager it was trying to load types from ss14.server|client.gameobjects.dll.
