### PR TITLE
Fix movement

### DIFF
--- a/SS14.Shared/GameObjects/EntitySystemManager.cs
+++ b/SS14.Shared/GameObjects/EntitySystemManager.cs
@@ -23,16 +23,14 @@ namespace SS14.Shared.GameObjects
         public EntitySystemManager(EntityManager em)
         {
             _entityManager = em;
-            List<Type> _systemTypes = new List<Type>();
-
-            _systemTypes.AddRange(
-                Assembly.GetEntryAssembly().GetTypes().Where(
-                    t => typeof(EntitySystem).IsAssignableFrom(t)));
+            List<Type> _systemTypes = Assembly.GetEntryAssembly().GetTypes().Where(
+                t => typeof(EntitySystem).IsAssignableFrom(t))
 
             foreach (Type type in _systemTypes)
             {
                 if (type == typeof(EntitySystem))
                     continue; //Don't run the base EntitySystem.
+                
                 //Force initialization of all systems
                 var instance = (EntitySystem)Activator.CreateInstance(type, _entityManager, this);
                 MethodInfo generic = typeof(EntitySystemManager).GetMethod("AddSystem").MakeGenericMethod(type);

--- a/SS14.Shared/GameObjects/EntitySystemManager.cs
+++ b/SS14.Shared/GameObjects/EntitySystemManager.cs
@@ -13,7 +13,6 @@ namespace SS14.Shared.GameObjects
 {
     public class EntitySystemManager
     {
-        private readonly List<Type> _systemTypes;
         private readonly Dictionary<Type, EntitySystem> _systems = new Dictionary<Type, EntitySystem>();
         private readonly Dictionary<Type, EntitySystem> _systemMessageTypes = new Dictionary<Type, EntitySystem>();
         private EntityManager _entityManager;
@@ -24,7 +23,7 @@ namespace SS14.Shared.GameObjects
         public EntitySystemManager(EntityManager em)
         {
             _entityManager = em;
-            _systemTypes = new List<Type>();
+            List<Type> _systemTypes = new List<Type>();
 
             _systemTypes.AddRange(
                 Assembly.GetEntryAssembly().GetTypes().Where(


### PR DESCRIPTION
Entity systems were not being populated on server / client.

This hacks them back in via the similar method that they had before.
Ideally this can be replace at some point, but at least we have our movement back.

Fixes #193 
Fixes #192 