### PR TITLE
Standardize Render and Update args

### DIFF
--- a/SS14.Client/GameController.cs
+++ b/SS14.Client/GameController.cs
@@ -194,12 +194,11 @@ namespace SS14.Client
 
         private void CluwneLibIdle(object sender, FrameEventArgs e)
         {
-
             _networkManager.UpdateNetwork();
             _stateManager.Update(e);
 
-            _userInterfaceManager.Update(e.FrameDeltaTime);
-            _userInterfaceManager.Render();
+            _userInterfaceManager.Update(e);
+            _userInterfaceManager.Render(e);
 
             _netGrapher.Update();
         }

--- a/SS14.Client/Interfaces/State/IStateManager.cs
+++ b/SS14.Client/Interfaces/State/IStateManager.cs
@@ -11,7 +11,7 @@ namespace SS14.Client.Interfaces.State
     {
         IState CurrentState { get; }
         void RequestStateChange<T>() where T : IState;
-        void Update(FrameEventArgs args);
+        void Update(FrameEventArgs e);
         void KeyDown(KeyEventArgs e);
         void KeyUp(KeyEventArgs e);
         void MouseUp(MouseButtonEventArgs e);

--- a/SS14.Client/Interfaces/UserInterface/IUserInterfaceManager.cs
+++ b/SS14.Client/Interfaces/UserInterface/IUserInterfaceManager.cs
@@ -1,5 +1,6 @@
 ﻿using Lidgren.Network;
 using SFML.Window;
+using SS14.Client.Graphics.Event;
 using SS14.Client.Interfaces.Console;
 using SS14.Client.Interfaces.GOC;
 using SS14.Shared;
@@ -26,8 +27,8 @@ namespace SS14.Client.Interfaces.UserInterface
         /// Remove focus, but only if the target is currently focused.
         /// </summary>
         void RemoveFocus(IGuiComponent target);
-        void Update(float frameTime);
-        void Render();
+        void Update(FrameEventArgs e);
+        void Render(FrameEventArgs e);
 
         void ToggleMoveMode();
 

--- a/SS14.Client/State/States/LobbyMenu.cs
+++ b/SS14.Client/State/States/LobbyMenu.cs
@@ -424,7 +424,7 @@ namespace SS14.Client.State.States
         public void Render(FrameEventArgs e)
         {
             _background.Draw();
-            UserInterfaceManager.Render();
+            UserInterfaceManager.Render(e);
         }
 
         public void FormResize()

--- a/SS14.Client/State/States/LobbyScreen.cs
+++ b/SS14.Client/State/States/LobbyScreen.cs
@@ -110,7 +110,7 @@ namespace SS14.Client.State.States
                 pos += 20;
             }
 
-            UserInterfaceManager.Render();
+            UserInterfaceManager.Render(e);
         }
 
         public void FormResize()
@@ -127,7 +127,7 @@ namespace SS14.Client.State.States
 
         public void Update(FrameEventArgs e)
         {
-            UserInterfaceManager.Update(e.FrameDeltaTime);
+            UserInterfaceManager.Update(e);
             if (_playerListTime.CompareTo(DateTime.Now) < 0)
             {
                 NetOutgoingMessage playerListMsg = NetworkManager.CreateMessage();

--- a/SS14.Client/State/States/OptionsMenu.cs
+++ b/SS14.Client/State/States/OptionsMenu.cs
@@ -148,7 +148,7 @@ namespace SS14.Client.State.States
             var bounds = _ticketBg.GetLocalBounds();
             _ticketBg.SetTransformToRect(new IntRect(0, (int)(CluwneLib.Screen.Size.Y / 2f - bounds.Height / 2f), (int)bounds.Width, (int)bounds.Height));
             _ticketBg.Draw();
-            UserInterfaceManager.Render();
+            UserInterfaceManager.Render(e);
         }
 
         public void FormResize()
@@ -293,7 +293,7 @@ namespace SS14.Client.State.States
         public void Update(FrameEventArgs e)
         {
             _chkFullscreen.Value = ConfigurationManager.GetFullscreen();
-            UserInterfaceManager.Update(e.FrameDeltaTime);
+            UserInterfaceManager.Update(e);
         }
 
         #endregion

--- a/SS14.Client/UserInterface/UserInterfaceManager.cs
+++ b/SS14.Client/UserInterface/UserInterfaceManager.cs
@@ -3,6 +3,7 @@ using SFML.Graphics;
 using SFML.System;
 using SFML.Window;
 using SS14.Client.Graphics;
+using SS14.Client.Graphics.Event;
 using SS14.Client.Interfaces.Configuration;
 using SS14.Client.Interfaces.Console;
 using SS14.Client.Interfaces.GOC;
@@ -458,21 +459,21 @@ namespace SS14.Client.UserInterface
         /// <summary>
         ///  Updates the logic of UI components.
         /// </summary>
-        public void Update(float frameTime)
+        public void Update(FrameEventArgs e)
         {
-            if (_console.IsVisible()) _console.Update(frameTime);
+            if (_console.IsVisible()) _console.Update(e.FrameDeltaTime);
 
             if (moveMode && movingComp != null)
                 movingComp.Position = (MousePos - dragOffset);
 
             foreach (IGuiComponent component in _components)
-                component.Update(frameTime);
+                component.Update(e.FrameDeltaTime);
         }
 
         /// <summary>
         ///  Renders UI components to screen.
         /// </summary>
-        public void Render()
+        public void Render(FrameEventArgs e)
         {
             IOrderedEnumerable<IGuiComponent> renderList = from IGuiComponent comp in _components
                                                            where comp.IsVisible()


### PR DESCRIPTION
Using frameEventArgs instead of randomly using `float frametime`