### PR TITLE
Fix prototype loader to work with case sensitivity

### DIFF
--- a/SS14.Client/GameController.cs
+++ b/SS14.Client/GameController.cs
@@ -80,7 +80,7 @@ namespace SS14.Client
 
             //Initialization of private members
             var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
-            prototypeManager.LoadDirectory(PathHelpers.ExecutableRelativeFile("prototypes"));
+            prototypeManager.LoadDirectory(PathHelpers.ExecutableRelativeFile("Prototypes"));
             prototypeManager.Resync();
             _networkManager.Initialize();
             _netGrapher.Initialize();

--- a/SS14.Server/SS14Server.cs
+++ b/SS14.Server/SS14Server.cs
@@ -497,7 +497,7 @@ namespace SS14.Server
             LoadSettings();
 
             var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
-            prototypeManager.LoadDirectory(PathHelpers.ExecutableRelativeFile("prototypes"));
+            prototypeManager.LoadDirectory(PathHelpers.ExecutableRelativeFile("Prototypes"));
             prototypeManager.Resync();
             IoCManager.Resolve<ISS14NetServer>().Start();
             IoCManager.Resolve<IChatManager>().Initialize(this);


### PR DESCRIPTION
Didn't like case sensitive filesystems like on Linux. The prototypes
folder was "Prototypes" but it was looking for "prototypes".