### PR TITLE
Makes the .editorconfig set to utf-8-bom

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
-charset = utf-8
+charset = utf-8-bom
 
 [*.{csproj,xml,yml,dll.config}]
 indent_size = 2


### PR DESCRIPTION
Visual Studio appears extremely stubborn on saving as UTF-8 with a BOM.