### PR TITLE
Fix hardcoded resource path preventing client from starting on Unix

### DIFF
--- a/SS14.Client/ResourceManagment/ResourceManagerZip.cs
+++ b/SS14.Client/ResourceManagment/ResourceManagerZip.cs
@@ -91,7 +91,7 @@ namespace SS14.Client.Resources
         {
             var cfgMgr = _configurationManager;
 
-            cfgMgr.RegisterCVar("res.pack", @"../../Resources/ResourcePack.zip", CVarFlags.ARCHIVE);
+            cfgMgr.RegisterCVar("res.pack", Path.Combine("..","..","Resources","ResourcePack.zip"), CVarFlags.ARCHIVE);
             cfgMgr.RegisterCVar("res.password", String.Empty, CVarFlags.SERVER | CVarFlags.REPLICATED);
 
             string zipPath = path ?? _configurationManager.GetCVar<string>("res.pack");

--- a/SS14.Client/ResourceManagment/ResourceManagerZip.cs
+++ b/SS14.Client/ResourceManagment/ResourceManagerZip.cs
@@ -100,7 +100,7 @@ namespace SS14.Client.Resources
             if (AppDomain.CurrentDomain.GetAssemblyByName("SS14.UnitTesting") != null)
             {
                 string debugPath = "..";
-                zipPath = Path.Combine(zipPath, debugPath);
+                zipPath = Path.Combine(debugPath, zipPath);
             }
 
             zipPath = PathHelpers.ExecutableRelativeFile(zipPath);

--- a/SS14.Client/ResourceManagment/ResourceManagerZip.cs
+++ b/SS14.Client/ResourceManagment/ResourceManagerZip.cs
@@ -99,9 +99,8 @@ namespace SS14.Client.Resources
 
             if (AppDomain.CurrentDomain.GetAssemblyByName("SS14.UnitTesting") != null)
             {
-                string debugPath = "..\\";
-                debugPath += zipPath;
-                zipPath = debugPath;
+                string debugPath = "..";
+                zipPath = Path.Combine(zipPath, debugPath);
             }
 
             zipPath = PathHelpers.ExecutableRelativeFile(zipPath);

--- a/SS14.Shared/Utility/PathHelpers.cs
+++ b/SS14.Shared/Utility/PathHelpers.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System;
 using System.Reflection;
 using System.Collections.Generic;
@@ -22,7 +22,7 @@ namespace SS14.Shared.Utility
         /// </summary>
         public static string ExecutableRelativeFile(string file)
         {
-            return Path.Combine(GetExecutableDirectory(), file);
+            return Path.GetFullPath(Path.Combine(GetExecutableDirectory(), file));
         }
 
         public static string AssemblyRelativeFile(string file, Assembly assembly)


### PR DESCRIPTION
Fixes #260
Tested in Windows, but I don't have Unix things handy
**Don't ever use dir separators in code**
~~Also as I noted in that issue, the (client|server)_config.xml files also have Windows-specific dir separators in them to specify the path to this same file. Same with client_config.toml.~~ that's what I get for skimming and making assumptions
Why do we have so many dead files, actually?