### PR TITLE
Disable lighting by default on MacOS and Unix.

### DIFF
--- a/SS14.Client/State/States/GameScreen.cs
+++ b/SS14.Client/State/States/GameScreen.cs
@@ -132,6 +132,11 @@ namespace SS14.Client.State.States
 
         public GameScreen(IDictionary<Type, object> managers) : base(managers)
         {
+            if (Environment.OSVersion.Platform == PlatformID.MacOSX || Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                // Disable lighting on non-Windows versions by default because the rendering is broken.
+                bFullVision = true;
+            }
         }
 
         #region IState Members


### PR DESCRIPTION
The rendering doesn't work at all and it's better that it defaults off for now. It can still be enabled with F6 in game.