### PR TITLE
Unhardcode content pack locations.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,7 @@ install:
 - ps: if (-Not $env:APPVEYOR_PULL_REQUEST_NUMBER) { cinst msbuild-sonarqube-runner }
 
 before_build:
+- cmd: py -3.5 Resources\buildResourcePack.py --resources-dir .\Resources --out .\Resources\ResourcePack.zip --atlas-tool .\Tools\AtlasTool.exe --no-animations --to-stderr
 - cmd: nuget restore SpaceStation14.sln
 - ps: if (-Not $env:APPVEYOR_PULL_REQUEST_NUMBER) { MSBuild.SonarQube.Runner.exe begin /k:"ss14" /d:"sonar.host.url=https://sonarqube.com" /d:"sonar.login=$env:sonarqubekey" /d:"sonar.organization=space-wizards" }
 
@@ -25,4 +26,3 @@ build:
 
 after_build:
 - ps: if (-Not $env:APPVEYOR_PULL_REQUEST_NUMBER) { MSBuild.SonarQube.Runner.exe end /d:"sonar.login=$env:sonarqubekey" }
-- cmd: py -3.5 Resources\buildResourcePack.py --resources-dir .\Resources --out .\Resources\ResourcePack.zip --atlas-tool .\Tools\AtlasTool.exe --no-animations --to-stderr

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ before_install:
   - if [ $TRAVIS_OS_NAME = osx ]; then brew update && brew install python3; fi
 
 before_script:
-- "python3 ./Resources/buildResourcePack.py --resources-dir ./Resources --out ./Resources/ResourcePack.zip --no-atlas --no-animations --to-stderr"
 - "nuget restore SpaceStation14.sln"
 
 script:
+- "python3 ./Resources/buildResourcePack.py --resources-dir ./Resources --out ./Resources/ResourcePack.zip --no-atlas --no-animations --to-stderr"
 - "msbuild /p:Configuration=Release /p:HEADLESS=1 SpaceStation14.sln"
 - "cd packages/NUnit.ConsoleRunner.3.6.1/tools"
 - "mono --debug nunit3-console.exe ../../../bin/UnitTesting/SS14.UnitTesting.dll"

--- a/SS14.Client/SS14.Client.csproj
+++ b/SS14.Client/SS14.Client.csproj
@@ -189,6 +189,12 @@
       <SubType>Code</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\Resources\EngineContentPack.zip">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\Resources\ResourcePack.zip">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/SS14.Server/BaseServer.cs
+++ b/SS14.Server/BaseServer.cs
@@ -216,7 +216,7 @@ namespace SS14.Server
             _resources.MountContentDirectory(@"");
 
             //mount the engine content pack
-            _resources.MountContentPack(@"../../Resources/EngineContentPack.zip");
+            _resources.MountContentPack(@"EngineContentPack.zip");
 
             //mount the default game ContentPack defined in config
             _resources.MountDefaultContentPack();

--- a/SS14.Server/SS14.Server.csproj
+++ b/SS14.Server/SS14.Server.csproj
@@ -174,6 +174,12 @@
       <SubType>Code</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\Resources\EngineContentPack.zip">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\Resources\ResourcePack.zip">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
     <Compile Include="CommandLineArgs.cs" />
     <Compile Include="Chat\ChatManager.cs" />

--- a/SS14.Shared/ContentPack/ResourceManager.cs
+++ b/SS14.Shared/ContentPack/ResourceManager.cs
@@ -21,8 +21,7 @@ namespace SS14.Shared.ContentPack
         /// <inheritdoc />
         public void Initialize()
         {
-            _config.RegisterCVar("resource.pack", Path.Combine("..", "..", "Resources", "ResourcePack.zip"),
-                CVarFlags.ARCHIVE);
+            _config.RegisterCVar("resource.pack", "ResourcePack.zip", CVarFlags.ARCHIVE);
             _config.RegisterCVar("resource.password", string.Empty, CVarFlags.SERVER | CVarFlags.REPLICATED);
         }
 
@@ -47,12 +46,6 @@ namespace SS14.Shared.ContentPack
         /// <inheritdoc />
         public void MountContentPack(string pack, string password = null)
         {
-            if (AppDomain.CurrentDomain.GetAssemblyByName("SS14.UnitTesting") != null)
-            {
-                var debugPath = "..";
-                pack = Path.Combine(debugPath, pack);
-            }
-
             pack = PathHelpers.ExecutableRelativeFile(pack);
 
             var packInfo = new FileInfo(pack);


### PR DESCRIPTION
The previous hardcoded path was causing problems for the content repo.
Now the content packs are loaded from the executable directory.
The build system copies the pack from the `Resources/` folder now.