### PR TITLE
Refactor entity initialization and fix doc comments.

### DIFF
--- a/SS14.Client/GameObjects/ClientEntityManager.cs
+++ b/SS14.Client/GameObjects/ClientEntityManager.cs
@@ -33,15 +33,50 @@ namespace SS14.Client.GameObjects
             }
         }
 
-        public override void InitializeEntities()
+        public void Initialize()
         {
             if (Initialized)
             {
                 throw new InvalidOperationException("InitializeEntities() called multiple times");
             }
-            base.InitializeEntities();
+            InitializeEntities();
             EntitySystemManager.Initialize();
             Initialized = true;
+        }
+
+        public void ApplyEntityStates(IEnumerable<EntityState> entityStates, float serverTime)
+        {
+            var entityKeys = new HashSet<int>();
+            foreach (EntityState es in entityStates)
+            {
+                //Todo defer component state result processing until all entities are loaded and initialized...
+                es.ReceivedTime = serverTime;
+                entityKeys.Add(es.StateData.Uid);
+                //Known entities
+                if (_entities.TryGetValue(es.StateData.Uid, out var entity))
+                {
+                    entity.HandleEntityState(es);
+                }
+                else //Unknown entities
+                {
+                    IEntity newEntity = SpawnEntity(es.StateData.TemplateName, es.StateData.Uid);
+                    newEntity.Name = es.StateData.Name;
+                    newEntity.HandleEntityState(es);
+                }
+            }
+
+            //Delete entities that exist here but don't exist in the entity states
+            int[] toDelete = _entities.Keys.Where(k => !entityKeys.Contains(k)).ToArray();
+            foreach (int k in toDelete)
+            {
+                DeleteEntity(k);
+            }
+
+            // After the first set of states comes in we do the initialization.
+            if (!Initialized)
+            {
+                Initialize();
+            }
         }
     }
 }

--- a/SS14.Client/Interfaces/GameObjects/IClientEntityManager.cs
+++ b/SS14.Client/Interfaces/GameObjects/IClientEntityManager.cs
@@ -1,5 +1,6 @@
 ﻿using OpenTK;
 using SFML.System;
+using SS14.Shared.GameObjects;
 using SS14.Shared.Interfaces.GameObjects;
 using SS14.Shared.IoC;
 using System.Collections.Generic;
@@ -9,5 +10,6 @@ namespace SS14.Client.Interfaces.GameObjects
     public interface IClientEntityManager : IEntityManager
     {
         IEnumerable<IEntity> GetEntitiesInRange(Vector2 position, float Range);
+        void ApplyEntityStates(IEnumerable<EntityState> entityStates, float serverTime);
     }
 }

--- a/SS14.Server/GameObjects/ServerEntityManager.cs
+++ b/SS14.Server/GameObjects/ServerEntityManager.cs
@@ -65,7 +65,7 @@ namespace SS14.Server.GameObjects
         /// <summary>
         /// Load all entities from SavedEntities.xml
         /// </summary>
-        public override void LoadEntities()
+        public void LoadEntities()
         {
             XElement tmp;
             try

--- a/SS14.Server/Interfaces/GameObjects/IServerEntityManager.cs
+++ b/SS14.Server/Interfaces/GameObjects/IServerEntityManager.cs
@@ -9,8 +9,9 @@ namespace SS14.Server.Interfaces.GameObjects
     public interface IServerEntityManager : IEntityManager
     {
         void Initialize();
+        void LoadEntities();
         void SaveEntities();
-        IEntity SpawnEntity(string template, int uid = -1);
+        IEntity SpawnEntity(string template, int? uid = null);
         IEntity SpawnEntityAt(string entityTemplateName, Vector2 vector2);
         List<EntityState> GetEntityStates();
     }

--- a/SS14.Shared/GameObjects/Component.cs
+++ b/SS14.Shared/GameObjects/Component.cs
@@ -49,6 +49,12 @@ namespace SS14.Shared.GameObjects
         }
 
         /// <inheritdoc />
+        public virtual void Initialize()
+        {
+
+        }
+
+        /// <inheritdoc />
         public virtual void Shutdown()
         {
         }

--- a/SS14.Shared/Interfaces/GameObjects/IComponent.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IComponent.cs
@@ -62,6 +62,12 @@ namespace SS14.Shared.Interfaces.GameObjects
         void OnAdd(IEntity owner);
 
         /// <summary>
+        ///     Called when all of the entity's other components have been added and are available,
+        ///     But are not necessarily initialized yet.
+        /// </summary>
+        void Initialize();
+
+        /// <summary>
         ///     Shuts down the component. The is called Automatically by OnRemove.
         /// </summary>
         void Shutdown();

--- a/SS14.Shared/Interfaces/GameObjects/IEntity.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IEntity.cs
@@ -14,66 +14,190 @@ namespace SS14.Shared.Interfaces.GameObjects
         IEntityNetworkManager EntityNetworkManager { get; }
         IEntityManager EntityManager { get; }
 
+        /// <summary>
+        ///     The name of this entity.
+        ///     This is the actual IC display name.
+        /// </summary>
         string Name { get; set; }
-        int Uid { get; set; }
 
+        /// <summary>
+        ///     The unique ID of this entity.
+        ///     Unique IDs are unique per entity,
+        ///     and correspond to counterparts across the network.
+        /// </summary>
+        int Uid { get; }
+
+        /// <summary>
+        ///     Whether this entity has fully initialized.
+        /// </summary>
         bool Initialized { get; set; }
 
+        /// <summary>
+        ///     The prototype that was used to create this entity.
+        /// </summary>
         EntityPrototype Prototype { get; set; }
+
+        /// <summary>
+        ///     Fired when the entity is deleted.
+        /// </summary>
         event EntityShutdownEvent OnShutdown;
 
         /// <summary>
-        /// Called after the entity is construted by its prototype to load parameters
-        /// from the prototype's <c>data</c> field.
+        ///     Initialize the entity's UID. This can only be called once.
+        /// </summary>
+        /// <param name="newUid">The new UID.</param>
+        /// <exception cref="InvalidOperationException">
+        ///     Thrown if the method is called and the entity already has a UID.
+        /// </exception>
+        void SetUid(int newUid);
+
+        /// <summary>
+        ///     Sets fundamental managers after the entity has been created.
         /// </summary>
         /// <remarks>
-        /// This method does not get called in case no data field is provided.
+        ///     This is a separate method because C# makes constructors painful.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        ///     Thrown if the method is called and the entity already has initialized managers.
+        /// </exception>
+        void SetManagers(IEntityManager entityManager, IEntityNetworkManager networkManager);
+
+        /// <summary>
+        ///     Called after the entity is construted by its prototype to load parameters
+        ///     from the prototype's <c>data</c> field.
+        /// </summary>
+        /// <remarks>
+        ///     This method does not get called in case no data field is provided.
         /// </remarks>
         /// <param name="parameters">The mapping representing the <c>data</c> field.</param>
         void LoadData(YamlMappingNode parameters);
 
         /// <summary>
-        /// Match
-        ///
-        /// Allows us to fetch entities with a defined SET of components
+        ///     "Matches" this entity with the provided entity query, returning whether or not the query matched.
+        ///     This is effectively equivalent to calling <see cref="IEntityQuery.Match(IEntity)" /> with this entity.
+        ///     The matching logic depends on the implementation of entity query used.
         /// </summary>
-        /// <param name="query"></param>
-        /// <returns></returns>
+        /// <param name="query">The query to match this entity with.</param>
+        /// <returns>True if the query matched, false otherwise.</returns>
         bool Match(IEntityQuery query);
 
         /// <summary>
-        /// Public method to add a component to an entity.
-        /// Calls the component's onAdd method, which also adds it to the component manager.
+        ///     Public method to add a component to an entity.
+        ///     Calls the component's onAdd method, which also adds it to the component manager.
         /// </summary>
-        /// <param name="component">The component.</param>
+        /// <param name="component">The component to add.</param>
         void AddComponent(IComponent component);
 
         /// <summary>
-        /// Public method to remove a component from an entity.
-        /// Calls the onRemove method of the component, which handles removing it
-        /// from the component manager and shutting down the component.
+        ///     Public method to remove a component from an entity.
+        ///     Calls the onRemove method of the component, which handles removing it
+        ///     from the component manager and shutting down the component.
         /// </summary>
-        /// <param name="family"></param>
+        /// <param name="component">The component to remove.</param>
         void RemoveComponent(IComponent component);
 
+        /// <summary>
+        ///     Removes the component with the specified reference type,
+        ///     Without needing to have the component itself.
+        /// </summary>
+        /// <typeparam name="T">The component reference type to remove.</typeparam>
         void RemoveComponent<T>() where T : IComponent;
 
+        /// <summary>
+        ///     Checks to see if the entity has a component of the specified type.
+        /// </summary>
+        /// <typeparam name="T">The component reference type to check.</typeparam>
+        /// <returns>True if the entity has a component of type <typeparamref name="T" />, false otherwise.</returns>
         bool HasComponent<T>() where T : IComponent;
+
+        /// <summary>
+        ///     Checks to see ift he entity has a component of the specified type.
+        /// </summary>
+        /// <param name="t">The component reference type to check.</param>
+        /// <returns></returns>
         bool HasComponent(Type t);
+
+        /// <summary>
+        ///     Retrieves the component of the specified type.
+        /// </summary>
+        /// <typeparam name="T">The component reference type to fetch.</typeparam>
+        /// <returns>The retrieved component.</returns>
+        /// <exception cref="Shared.GameObjects.UnknownComponentException">
+        ///     Thrown if there is no component with the specified type.
+        /// </exception>
         T GetComponent<T>() where T : IComponent;
+
+        /// <summary>
+        ///     Retrieves the component of the specified type.
+        /// </summary>
+        /// <param name="type">The component reference type to fetch.</param>
+        /// <returns>The retrieved component.</returns>
+        /// <exception cref="Shared.GameObjects.UnknownComponentException">
+        ///     Thrown if there is no component with the specified type.
+        /// </exception>
         IComponent GetComponent(Type type);
+
+        /// <summary>
+        ///     Retrieves the component with the specified network ID.
+        /// </summary>
+        /// <param name="netID">The net ID of the component to retrieve.</param>
+        /// <returns>The component with the provided net ID.</returns>
+        /// <seealso cref="IComponent.NetID" />
+        /// <exception cref="Shared.GameObjects.UnknownComponentException">
+        ///     Thrown if there is no component with the specified net ID.
+        /// </exception>
         IComponent GetComponent(uint netID);
+
+        /// <summary>
+        ///     Attempt to retrieve the component with specified type,
+        ///     writing it to the <paramref name="component" /> out parameter if it was found.
+        /// </summary>
+        /// <typeparam name="T">The component reference type to attempt to fetch.</typeparam>
+        /// <param name="component">The component, if it was found. Null otherwise.</param>
+        /// <returns>True if a component with specified type was found.</returns>
         bool TryGetComponent<T>(out T component) where T : class, IComponent;
+
+        /// <summary>
+        ///     Attempt to retrieve the component with specified type,
+        ///     writing it to the <paramref name="component" /> out parameter if it was found.
+        /// </summary>
+        /// <param name="type">The component reference type to attempt to fetch.</param>
+        /// <param name="component">The component, if it was found. Null otherwise.</param>
+        /// <returns>True if a component with specified type was found.</returns>
         bool TryGetComponent(Type type, out IComponent component);
+
+        /// <summary>
+        ///     Attempt to retrieve the component with specified network ID,
+        ///     writing it to the <paramref name="component" /> out parameter if it was found.
+        /// </summary>
+        /// <param name="type">The component net ID to attempt to fetch.</param>
+        /// <param name="component">The component, if it was found. Null otherwise.</param>
+        /// <returns>True if a component with specified net ID was found.</returns>
         bool TryGetComponent(uint netID, out IComponent component);
 
+        /// <summary>
+        ///     Used by the entity manager to delete the entity.
+        ///     Do not call directly.
+        /// </summary>
         void Shutdown();
+
+        /// <summary>
+        ///     Returns all components on the entity.
+        /// </summary>
+        /// <returns>An enumerable of components on the entity.</returns>
         IEnumerable<IComponent> GetComponents();
+
+        /// <summary>
+        ///     Returns all components that are assignable to <typeparamref name="T"/>.
+        ///     This does not go by component references.
+        /// </summary>
+        /// <typeparam name="T">The type that components must implement.</typeparam>
+        /// <returns>An enumerable over the found components.</returns>
         IEnumerable<T> GetComponents<T>() where T : IComponent;
         void SendMessage(object sender, ComponentMessageType type, params object[] args);
 
         /// <summary>
-        /// Allows components to send messages
+        ///     Allows components to send messages
         /// </summary>
         /// <param name="sender">the component doing the sending</param>
         /// <param name="type">the type of message</param>
@@ -82,12 +206,12 @@ namespace SS14.Shared.Interfaces.GameObjects
                          params object[] args);
 
         /// <summary>
-        /// Requests Description string from components and returns it. If no component answers, returns default description from template.
+        ///     Requests Description string from components and returns it. If no component answers, returns default description from template.
         /// </summary>
         string GetDescriptionString(); //This needs to go here since it can not be bound to any single component.
 
         /// <summary>
-        /// Sends a message to the counterpart component on the server side
+        ///     Sends a message to the counterpart component on the server side
         /// </summary>
         /// <param name="component">Sending component</param>
         /// <param name="method">Net Delivery Method</param>
@@ -95,7 +219,7 @@ namespace SS14.Shared.Interfaces.GameObjects
         void SendComponentNetworkMessage(IComponent component, NetDeliveryMethod method, params object[] messageParams);
 
         /// <summary>
-        /// Sends a message to the counterpart component on the server side
+        ///     Sends a message to the counterpart component on the server side
         /// </summary>
         /// <param name="component">Sending component</param>
         /// <param name="method">Net Delivery Method</param>
@@ -105,20 +229,25 @@ namespace SS14.Shared.Interfaces.GameObjects
                                                  NetConnection recipient, params object[] messageParams);
 
         /// <summary>
-        /// Sets up variables and shite
+        ///     Called when the entity has all components initialized.
         /// </summary>
         void Initialize();
+
+        /// <summary>
+        ///     Called after the entity has loaded data and components, but before the components are initialized.
+        /// </summary>
+        void PreInitialize();
 
         void HandleNetworkMessage(IncomingEntityMessage message);
 
         /// <summary>
-        /// Client method to handle an entity state object
+        ///     Client method to handle an entity state object
         /// </summary>
         /// <param name="state"></param>
         void HandleEntityState(EntityState state);
 
         /// <summary>
-        /// Serverside method to prepare an entity state object
+        ///     Serverside method to prepare an entity state object
         /// </summary>
         /// <returns></returns>
         EntityState GetEntityState();

--- a/SS14.Shared/Interfaces/GameObjects/IEntityManager.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IEntityManager.cs
@@ -9,8 +9,6 @@ namespace SS14.Shared.Interfaces.GameObjects
 {
     public interface IEntityManager
     {
-        void InitializeEntities();
-        void LoadEntities();
         void Shutdown();
         void Update(float frameTime);
         void HandleEntityNetworkMessage(NetIncomingMessage msg);
@@ -77,11 +75,5 @@ namespace SS14.Shared.Interfaces.GameObjects
         void RemoveSubscribedEvents(IEntityEventSubscriber subscriber);
 
         #endregion ComponentEvents
-
-        #region State stuff
-
-        void ApplyEntityStates(List<EntityState> entityStates, float serverTime);
-
-        #endregion State stuff
     }
 }

--- a/SS14.Shared/Prototypes/EntityPrototype.cs
+++ b/SS14.Shared/Prototypes/EntityPrototype.cs
@@ -245,22 +245,23 @@ namespace SS14.Shared.GameObjects
         }
 
         /// <summary>
-        /// Creates an entity from this template
+        /// Creates an entity from this prototype.
+        /// Do not call this directly, use the server entity manager instead.
         /// </summary>
         /// <returns></returns>
-        public IEntity CreateEntity(IEntityManager manager, IEntityNetworkManager networkManager, IComponentFactory componentFactory)
+        public IEntity CreateEntity(int uid, IEntityManager manager, IEntityNetworkManager networkManager, IComponentFactory componentFactory)
         {
-            var entity = (IEntity)Activator.CreateInstance(ClassType, manager, networkManager, componentFactory);
+            var entity = (IEntity)Activator.CreateInstance(ClassType);
 
+            entity.SetManagers(manager, networkManager);
+            entity.SetUid(uid);
             entity.Name = Name;
             entity.Prototype = this;
 
             foreach (KeyValuePair<string, YamlMappingNode> componentData in Components)
             {
                 IComponent component = componentFactory.GetComponent(componentData.Key);
-
                 component.LoadParameters(componentData.Value);
-
                 entity.AddComponent(component);
             }
 


### PR DESCRIPTION
Entities now initialize in a few stages. First all their components are added, then `entity.PreInitialize()` is called, then all components are initialized, then `entity.Initialize()` is called.

This multi-level initialization system should hopefully be more powerful and make things like prefetching components easier.

Also what the crap WAS the old init system even?

Also removes the use of constructors completely, thus making it not painful to override entities and make initialization fully interface bound and not rely on type-unsafe constructor arguments. 