### PR TITLE
Fix accidental integer division.

### DIFF
--- a/SS14.Client/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
@@ -67,8 +67,8 @@ namespace SS14.Client.GameObjects
             {
                 var tileSize = IoCManager.Resolve<IMapManager>().TileSize;
 
-                return Box2.FromDimensions(0, 0, sprite.AABB.Width / tileSize,
-                                      sprite.AABB.Height / tileSize);
+                return Box2.FromDimensions(0, 0, sprite.AABB.Width / (float)tileSize,
+                                                 sprite.AABB.Height / (float)tileSize);
             }
         }
 


### PR DESCRIPTION
`AnimatedSpriteComponent.AABB` used integer division, fixed now.