### PR TITLE
Update Linux Readme

### DIFF
--- a/readme.linux.md
+++ b/readme.linux.md
@@ -1,28 +1,23 @@
 # Linux Compiling Guide #
 
 ## Dependencies ##
-
-There is a good chance you can install these with your package manager.
-
-* Mono
-* SFML and CSFML binding (http://www.sfml-dev.org/download.php)
-
-  The version of SFML and SFML.Net bindings should match. Else the mouse cursor can be stuck or other horrible things can happen.
-
-  The SFML.Net included in the sources currently is for SFML 2.2. If you have a different SFML version you can download the corresponding SFML.Net libraries from the project's homepage and replace the files in `Third-Party` (before compile) or `bin/Client` (after compile). For some reason SFML.Net 2.3 can't be downloaded from the homepage, you have to compile it yourself.
+Python 3.6.2
+SFML 2.4 
+CSFML 2.4
 
 ## Compiling ##
 
-Just run
-```
-xbuild
-```
-in the root directory. The results will be in the `bin` directory.
+cd path/to/SpaceStation14
 
-After compiling copy the `sfmlnet-*.dll.config` files to the bin/Client directory.
-```
-cp Third-Party/sfmlnet-*.dll.config bin/Client
-```
+python RUN_THIS.py
+
+cd Resources
+
+wget http://84.195.252.227/static/ResourcePack.zip
+
+open solution
+
+build
 
 ## Run ##
 
@@ -40,8 +35,7 @@ System.DllNotFoundException: csfml-graphics-2
 .
 .
 ```
-
-Then you either forgot to copy the `sfmlnet-*.dll.config` files after compiling or your csfml library is in a non-standard location. If the latter, adjust the `sfmlnet-*.dll.config` files to point to the right libraries.
+You forgot SFML or CSFML. Install the packages
 
 ### Server ###
 ```


### PR DESCRIPTION
how2build on linux like a pro

In a large bowl, dissolve yeast in warm water. Add the sugar, salt, oil and 3 cups flour. Beat until smooth. Stir in enough remaining flour, 1/2 cup at a time, to form a soft dough.
Turn onto a floured surface; knead until smooth and elastic, about 8-10 minutes. Place in a greased bowl, turning once to grease the top. Cover and let rise in a warm place until doubled, about 1-1/2 hours.
Punch dough down. Turn onto a lightly floured surface; divide dough in half. Shape each into a loaf. Place in two greased 9x5-in. loaf pans. Cover and let rise until doubled, about 30-45 minutes.
Bake at 375° for 30-35 minutes or until golden brown and bread sounds hollow when tapped. Remove from pans to wire racks to cool. Yield: 2 loaves (16 slices each).