### PR TITLE
Remove some IComponent type bounds, component shutdown event.

### DIFF
--- a/SS14.Shared/GameObjects/Component.cs
+++ b/SS14.Shared/GameObjects/Component.cs
@@ -29,8 +29,13 @@ namespace SS14.Shared.GameObjects
         public virtual Type StateType => typeof(ComponentState);
 
         /// <inheritdoc />
+        event Action<ComponentShutdownEventArgs> OnShutdown;
+
+        /// <inheritdoc />
         public virtual void OnRemove()
         {
+            OnShutdown?.Invoke(new ComponentShutdownEventArgs(this));
+            OnShutdown = null;
             Shutdown();
 
             //Send us to the manager so it knows we're dead.

--- a/SS14.Shared/GameObjects/Component.cs
+++ b/SS14.Shared/GameObjects/Component.cs
@@ -29,7 +29,7 @@ namespace SS14.Shared.GameObjects
         public virtual Type StateType => typeof(ComponentState);
 
         /// <inheritdoc />
-        event Action<ComponentShutdownEventArgs> OnShutdown;
+        public event Action<ComponentShutdownEventArgs> OnShutdown;
 
         /// <inheritdoc />
         public virtual void OnRemove()

--- a/SS14.Shared/GameObjects/ComponentFactory.cs
+++ b/SS14.Shared/GameObjects/ComponentFactory.cs
@@ -109,7 +109,7 @@ namespace SS14.Shared.GameObjects
             }
         }
 
-        public void RegisterReference<TTarget, TInterface>() where TTarget : TInterface, IComponent, new() where TInterface : IComponent
+        public void RegisterReference<TTarget, TInterface>() where TTarget : TInterface, IComponent, new()
         {
             if (!types.ContainsKey(typeof(TTarget)))
             {

--- a/SS14.Shared/GameObjects/Entity.cs
+++ b/SS14.Shared/GameObjects/Entity.cs
@@ -323,12 +323,12 @@ namespace SS14.Shared.GameObjects
             RemoveComponent(GetComponent(type));
         }
 
-        public void RemoveComponent<T>() where T : IComponent
+        public void RemoveComponent<T>()
         {
-            RemoveComponent(GetComponent<T>());
+            RemoveComponent((IComponent)GetComponent<T>());
         }
 
-        public bool HasComponent<T>() where T : IComponent
+        public bool HasComponent<T>()
         {
             return HasComponent(typeof(T));
         }
@@ -343,7 +343,7 @@ namespace SS14.Shared.GameObjects
             return _netIDs.ContainsKey(netID);
         }
 
-        public T GetComponent<T>() where T : IComponent
+        public T GetComponent<T>()
         {
             return (T)_componentReferences[typeof(T)];
         }
@@ -358,7 +358,7 @@ namespace SS14.Shared.GameObjects
             return _netIDs[netID];
         }
 
-        public bool TryGetComponent<T>(out T component) where T : class, IComponent
+        public bool TryGetComponent<T>(out T component) where T : class
         {
             if (!_componentReferences.ContainsKey(typeof(T)))
             {
@@ -397,7 +397,7 @@ namespace SS14.Shared.GameObjects
             return _components;
         }
 
-        public IEnumerable<T> GetComponents<T>() where T : IComponent
+        public IEnumerable<T> GetComponents<T>()
         {
             return _components.OfType<T>();
         }

--- a/SS14.Shared/Interfaces/GameObjects/IComponent.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IComponent.cs
@@ -68,6 +68,13 @@ namespace SS14.Shared.Interfaces.GameObjects
         void Initialize();
 
         /// <summary>
+        /// Invoked whenever the entity is shut down (removed from an entity or deleted).
+        /// </summary>
+        /// <seealso cref="OnRemove" />
+        /// <seealso cref="Shutdown" />
+        event Action<ComponentShutdownEventArgs> OnShutdown;
+
+        /// <summary>
         ///     Shuts down the component. The is called Automatically by OnRemove.
         /// </summary>
         void Shutdown();
@@ -112,5 +119,15 @@ namespace SS14.Shared.Interfaces.GameObjects
         /// </summary>
         /// <param name="state"></param>
         void HandleComponentState(ComponentState state);
+    }
+
+    public class ComponentShutdownEventArgs : EventArgs
+    {
+        public readonly IComponent Component;
+
+        public ComponentShutdownEventArgs(IComponent component)
+        {
+            Component = component;
+        }
     }
 }

--- a/SS14.Shared/Interfaces/GameObjects/IComponentFactory.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IComponentFactory.cs
@@ -76,7 +76,7 @@ namespace SS14.Shared.Interfaces.GameObjects
         /// Registers <typeparamref name="TTarget" /> to be referenced when
         /// <typeparamref name="TInterface"/> is used in methods like <see cref="IEntity.GetComponent{T}"/>
         /// </summary>
-        void RegisterReference<TTarget, TInterface>() where TTarget : TInterface, IComponent, new() where TInterface : IComponent;
+        void RegisterReference<TTarget, TInterface>() where TTarget : TInterface, IComponent, new();
 
         /// <summary>
         /// Gets a new component instantiated of the specified type.

--- a/SS14.Shared/Interfaces/GameObjects/IEntity.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IEntity.cs
@@ -101,14 +101,14 @@ namespace SS14.Shared.Interfaces.GameObjects
         ///     Without needing to have the component itself.
         /// </summary>
         /// <typeparam name="T">The component reference type to remove.</typeparam>
-        void RemoveComponent<T>() where T : IComponent;
+        void RemoveComponent<T>();
 
         /// <summary>
         ///     Checks to see if the entity has a component of the specified type.
         /// </summary>
         /// <typeparam name="T">The component reference type to check.</typeparam>
         /// <returns>True if the entity has a component of type <typeparamref name="T" />, false otherwise.</returns>
-        bool HasComponent<T>() where T : IComponent;
+        bool HasComponent<T>();
 
         /// <summary>
         ///     Checks to see ift he entity has a component of the specified type.
@@ -125,7 +125,7 @@ namespace SS14.Shared.Interfaces.GameObjects
         /// <exception cref="Shared.GameObjects.UnknownComponentException">
         ///     Thrown if there is no component with the specified type.
         /// </exception>
-        T GetComponent<T>() where T : IComponent;
+        T GetComponent<T>();
 
         /// <summary>
         ///     Retrieves the component of the specified type.
@@ -155,7 +155,7 @@ namespace SS14.Shared.Interfaces.GameObjects
         /// <typeparam name="T">The component reference type to attempt to fetch.</typeparam>
         /// <param name="component">The component, if it was found. Null otherwise.</param>
         /// <returns>True if a component with specified type was found.</returns>
-        bool TryGetComponent<T>(out T component) where T : class, IComponent;
+        bool TryGetComponent<T>(out T component) where T : class;
 
         /// <summary>
         ///     Attempt to retrieve the component with specified type,
@@ -193,7 +193,7 @@ namespace SS14.Shared.Interfaces.GameObjects
         /// </summary>
         /// <typeparam name="T">The type that components must implement.</typeparam>
         /// <returns>An enumerable over the found components.</returns>
-        IEnumerable<T> GetComponents<T>() where T : IComponent;
+        IEnumerable<T> GetComponents<T>();
         void SendMessage(object sender, ComponentMessageType type, params object[] args);
 
         /// <summary>


### PR DESCRIPTION
Methods like `GetComponent<T>` don't require `T` to implement `IComponent` anymore.

Added an event to `IComponent` that is invoked whenever the component is shut down.