### PR TITLE
Content prefixes for the reflection manager.

### DIFF
--- a/SS14.Client/Reflection/ClientReflectionManager.cs
+++ b/SS14.Client/Reflection/ClientReflectionManager.cs
@@ -11,6 +11,13 @@ namespace SS14.Client.Reflection
     /// </summary>
     public sealed class ClientReflectionManager : ReflectionManager
     {
-        protected override IEnumerable<string> TypePrefixes => new[] {"", "SS14.Client.", "SS14.Shared."};
+        protected override IEnumerable<string> TypePrefixes => new[]
+        {
+            "",
+            "SS14.Client.",
+            "SS14.Shared.",
+            "Content.Shared.",
+            "Content.Client."
+        };
     }
 }

--- a/SS14.Server/Reflection/ServerReflectionManager.cs
+++ b/SS14.Server/Reflection/ServerReflectionManager.cs
@@ -11,6 +11,13 @@ namespace SS14.Server.Reflection
     /// </summary>
     public sealed class ServerReflectionManager : ReflectionManager
     {
-        protected override IEnumerable<string> TypePrefixes => new[] { "", "SS14.Server.", "SS14.Shared." };
+        protected override IEnumerable<string> TypePrefixes => new[]
+        {
+            "",
+            "SS14.Server.",
+            "SS14.Shared.",
+            "Content.Shared.",
+            "Content.Server."
+        };
     }
 }


### PR DESCRIPTION
Allows doing class: Prototypes.DiscoBall instead of Content.Client.Prototypes.DiscoBall