### PR TITLE
Turns INetSerializableType into NetSerializableAttribute

### DIFF
--- a/SS14.Shared/GameObjects/ComponentState.cs
+++ b/SS14.Shared/GameObjects/ComponentState.cs
@@ -3,8 +3,8 @@ using System;
 
 namespace SS14.Shared.GameObjects
 {
-    [Serializable]
-    public class ComponentState : INetSerializableType
+    [Serializable, NetSerializable]
+    public class ComponentState
     {
         [NonSerialized]
         public float ReceivedTime;

--- a/SS14.Shared/GameObjects/EntityState.cs
+++ b/SS14.Shared/GameObjects/EntityState.cs
@@ -1,11 +1,11 @@
-using SS14.Shared.Serialization;
+﻿using SS14.Shared.Serialization;
 using System;
 using System.Collections.Generic;
 
 namespace SS14.Shared.GameObjects
 {
-    [Serializable]
-    public class EntityState : INetSerializableType
+    [Serializable, NetSerializable]
+    public class EntityState
     {
         public EntityStateData StateData;
         [NonSerialized]
@@ -25,8 +25,8 @@ namespace SS14.Shared.GameObjects
         }
     }
 
-    [Serializable]
-    public struct EntityStateData : INetSerializableType
+    [Serializable, NetSerializable]
+    public struct EntityStateData
     {
         public string Name;
         public string TemplateName;

--- a/SS14.Shared/GameObjects/EntitySystemMessage/EntitySystemMessage.cs
+++ b/SS14.Shared/GameObjects/EntitySystemMessage/EntitySystemMessage.cs
@@ -1,10 +1,10 @@
-using SS14.Shared.Serialization;
+﻿using SS14.Shared.Serialization;
 using System;
 
 namespace SS14.Shared.GameObjects
 {
-    [Serializable]
-    public class EntitySystemMessage : INetSerializableType
+    [Serializable, NetSerializable]
+    public class EntitySystemMessage
     {
         public EntitySystemMessage()
         {

--- a/SS14.Shared/GameStateDelta.cs
+++ b/SS14.Shared/GameStateDelta.cs
@@ -1,5 +1,4 @@
 ﻿using BsDiffLib;
-using Lidgren.Network;
 using SS14.Shared.GameStates;
 using SS14.Shared.Interfaces.Serialization;
 using SS14.Shared.IoC;
@@ -9,8 +8,8 @@ using System.IO;
 
 namespace SS14.Shared
 {
-    [Serializable]
-    public class GameStateDelta : INetSerializableType
+    [Serializable, NetSerializable]
+    public class GameStateDelta
     {
         public readonly MemoryStream deltaBytes = new MemoryStream();
         public uint FromSequence;

--- a/SS14.Shared/GameStates/GameState.cs
+++ b/SS14.Shared/GameStates/GameState.cs
@@ -1,17 +1,15 @@
-﻿using Lidgren.Network;
-using SS14.Shared.GameObjects;
+﻿using SS14.Shared.GameObjects;
 using SS14.Shared.Interfaces.Serialization;
 using SS14.Shared.IoC;
 using SS14.Shared.Serialization;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 
 namespace SS14.Shared.GameStates
 {
-    [Serializable]
-    public class GameState : INetSerializableType
+    [Serializable, NetSerializable]
+    public class GameState
     {
         [NonSerialized] private bool _serialized;
         [NonSerialized] private MemoryStream _serializedData;

--- a/SS14.Shared/GameStates/PlayerState.cs
+++ b/SS14.Shared/GameStates/PlayerState.cs
@@ -1,10 +1,10 @@
-using SS14.Shared.Serialization;
+﻿using SS14.Shared.Serialization;
 using System;
 
 namespace SS14.Shared.GameStates
 {
-    [Serializable]
-    public class PlayerState : INetSerializableType
+    [Serializable, NetSerializable]
+    public class PlayerState
     {
         public int? ControlledEntity;
         public string Name;

--- a/SS14.Shared/Interfaces/Reflection/IReflectionManager.cs
+++ b/SS14.Shared/Interfaces/Reflection/IReflectionManager.cs
@@ -53,6 +53,13 @@ namespace SS14.Shared.Interfaces.Reflection
         Type GetType(string name);
 
         /// <summary>
+        /// Finds all Types in all Assemblies that have a specific Attribute.
+        /// </summary>
+        /// <typeparam name="T">Attribute to search for.</typeparam>
+        /// <returns>Enumeration of all types with the specified attribute.</returns>
+        IEnumerable<Type> FindTypesWithAttribute<T>();
+
+        /// <summary>
         /// Loads assemblies into the manager and get all the types.
         /// </summary>
         void LoadAssemblies(IEnumerable<Assembly> assemblies);

--- a/SS14.Shared/Reflection/ReflectionManager.cs
+++ b/SS14.Shared/Reflection/ReflectionManager.cs
@@ -59,5 +59,18 @@ namespace SS14.Shared.Reflection
 
             return null;
         }
+
+        /// <inheritdoc />
+        public IEnumerable<Type> FindTypesWithAttribute<T>()
+        {
+            var types = new List<Type>();
+
+            foreach (var assembly in Assemblies)
+            {
+                types.AddRange(assembly.GetTypes().Where(type => Attribute.IsDefined(type, typeof(T))));
+            }
+
+            return types;
+        }
     }
 }

--- a/SS14.Shared/SS14.Shared.csproj
+++ b/SS14.Shared/SS14.Shared.csproj
@@ -227,8 +227,8 @@
     <Compile Include="PostProcessingEffects.cs" />
     <Compile Include="QuadTree.cs" />
     <Compile Include="Reflection\ReflectAttribute.cs" />
+    <Compile Include="Serialization\NetSerializableAttribute.cs" />
     <Compile Include="Serialization\SS14Serializer.cs" />
-    <Compile Include="Serialization\INetSerializableType.cs" />
     <Compile Include="ServerEnums\RunLevel.cs" />
     <Compile Include="SessionStatusEnum.cs" />
     <Compile Include="Timing\GameTiming.cs" />

--- a/SS14.Shared/Serialization/INetSerializableType.cs
+++ b/SS14.Shared/Serialization/INetSerializableType.cs
@@ -1,6 +1,0 @@
-namespace SS14.Shared.Serialization
-{
-    public interface INetSerializableType
-    {
-    }
-}

--- a/SS14.Shared/Serialization/NetSerializableAttribute.cs
+++ b/SS14.Shared/Serialization/NetSerializableAttribute.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace SS14.Shared.Serialization
+{
+    /// <summary>
+    /// This attribute marks an object as able to be serialized by SS14's NetSerializer. It is required that objects
+    /// that have this Attribute also have the <see cref="SerializableAttribute"/>. You can use 
+    /// <see cref="NonSerializedAttribute"/> to mark a field as non-serialized. Child classes are also NetSerializable.
+    /// See the <see href="https://github.com/tomba/netserializer/blob/master/Doc.md">NetSerializer Documentation</see>
+    /// for more info.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+    public class NetSerializableAttribute : Attribute
+    {
+    }
+}

--- a/SS14.Shared/Serialization/SS14Serializer.cs
+++ b/SS14.Shared/Serialization/SS14Serializer.cs
@@ -19,7 +19,7 @@ namespace SS14.Shared.Serialization
 
         public void Initialize()
         {
-            var types = reflectionManager.GetAllChildren<INetSerializableType>();
+            var types = reflectionManager.FindTypesWithAttribute<NetSerializableAttribute>();
             var settings = new Settings()
             {
                 CustomTypeSerializers = new ITypeSerializer[] { new OpenTKTypeSerializer() }

--- a/SS14.UnitTesting/SS14.UnitTesting.csproj
+++ b/SS14.UnitTesting/SS14.UnitTesting.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Shared\Math\Direction_Test.cs" />
     <Compile Include="Shared\Prototypes\PrototypeManager_Test.cs" />
     <Compile Include="Shared\Reflection\ReflectionManager_Test.cs" />
+    <Compile Include="Shared\Serialization\NetSerializableAttribute_Test.cs" />
     <Compile Include="Shared\Utility\CollectionExtensions_Test.cs" />
     <Compile Include="Shared\Utility\YamlHelpers_Test.cs" />
     <Compile Include="Shared\ColorUtils_Test.cs" />

--- a/SS14.UnitTesting/Shared/Serialization/NetSerializableAttribute_Test.cs
+++ b/SS14.UnitTesting/Shared/Serialization/NetSerializableAttribute_Test.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using NUnit.Framework;
+using SS14.Shared.Interfaces.Reflection;
+using SS14.Shared.IoC;
+using SS14.Shared.Serialization;
+
+namespace SS14.UnitTesting.Shared.Serialization
+{
+    [TestFixture]
+    class NetSerializableAttribute_Test : SS14UnitTest
+    {
+        private IReflectionManager _reflection;
+
+        [OneTimeSetUp]
+        public void TestFixtureSetup()
+        {
+            _reflection = IoCManager.Resolve<IReflectionManager>();
+        }
+        
+        [Test]
+        public void AllNetSerializableObjectsHaveSerializableAttribute()
+        {
+            var types = _reflection.FindTypesWithAttribute<NetSerializableAttribute>();
+
+            foreach (var type in types)
+            {
+                Assert.IsTrue(Attribute.IsDefined(type, typeof(NetSerializableAttribute), true), 
+                    $"{type.FullName} has {nameof(NetSerializableAttribute)}, but not the required {nameof(SerializableAttribute)}.");
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
INetSerializableType was being used as an Attribute, might as well make it one. As an added bonus we get the new shiny FindTypesWithAttribute<T>().