### PR TITLE
Entity Component Shutdown Fix.

### DIFF
--- a/SS14.Client/GameObjects/Components/Collidable/CollidableComponent.cs
+++ b/SS14.Client/GameObjects/Components/Collidable/CollidableComponent.cs
@@ -63,7 +63,7 @@ namespace SS14.Client.GameObjects
         /// <summary>
         ///     removes the AABB from the CollisionManager.
         /// </summary>
-        public override void OnRemove()
+        public override void Shutdown()
         {
             if (collisionEnabled)
             {
@@ -71,7 +71,7 @@ namespace SS14.Client.GameObjects
                 cm.RemoveCollidable(this);
             }
 
-            base.OnRemove();
+            base.Shutdown();
         }
 
         /// <summary>

--- a/SS14.Client/GameObjects/Components/Input/KeyBindingInputComponent.cs
+++ b/SS14.Client/GameObjects/Components/Input/KeyBindingInputComponent.cs
@@ -33,15 +33,6 @@ namespace SS14.Client.GameObjects
             //Set up keystates
         }
 
-        public override void OnRemove()
-        {
-            base.OnRemove();
-
-            var keyBindingManager = IoCManager.Resolve<IKeyBindingManager>();
-            keyBindingManager.BoundKeyDown -= KeyDown;
-            keyBindingManager.BoundKeyUp -= KeyUp;
-        }
-
         public override void OnAdd(IEntity owner)
         {
             base.OnAdd(owner);

--- a/SS14.Client/GameObjects/Components/Light/PointLightComponent.cs
+++ b/SS14.Client/GameObjects/Components/Light/PointLightComponent.cs
@@ -135,12 +135,12 @@ namespace SS14.Client.GameObjects
                 ModeClass = LightModeClass.Constant;
             }
         }
-
-        public override void OnRemove()
+        
+        public override void Shutdown()
         {
             Owner.GetComponent<ITransformComponent>().OnMove -= OnMove;
             IoCManager.Resolve<ILightManager>().RemoveLight(Light);
-            base.OnRemove();
+            base.Shutdown();
         }
 
         private void OnMove(object sender, VectorEventArgs args)

--- a/SS14.Client/GameObjects/Components/Renderable/ParticleSystemComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/ParticleSystemComponent.cs
@@ -55,11 +55,11 @@ namespace SS14.Client.GameObjects
             transform.OnMove += OnMove;
         }
 
-        public override void OnRemove()
+        public override void Shutdown()
         {
             var transform = Owner.GetComponent<ITransformComponent>();
             transform.OnMove -= OnMove;
-            base.OnRemove();
+            base.Shutdown();
         }
 
         public override void Update(float frameTime)

--- a/SS14.Server/GameObjects/Components/Collidable/CollidableComponent.cs
+++ b/SS14.Server/GameObjects/Components/Collidable/CollidableComponent.cs
@@ -68,12 +68,11 @@ namespace SS14.Server.GameObjects
         /// <summary>
         ///     Removes the AABB from the collisionmanager.
         /// </summary>
-        public override void OnRemove()
+        public override void Shutdown()
         {
             var cm = IoCManager.Resolve<ICollisionManager>();
             cm.RemoveCollidable(this);
-
-            base.OnRemove();
+            base.Shutdown();
         }
 
         public bool TryCollision(Vector2 offset, bool bump = false)

--- a/SS14.Shared/GameObjects/Component.cs
+++ b/SS14.Shared/GameObjects/Component.cs
@@ -34,10 +34,6 @@ namespace SS14.Shared.GameObjects
         /// <inheritdoc />
         public virtual void OnRemove()
         {
-            OnShutdown?.Invoke(new ComponentShutdownEventArgs(this));
-            OnShutdown = null;
-            Shutdown();
-
             //Send us to the manager so it knows we're dead.
             IoCManager.Resolve<IComponentManager>().RemoveComponent(this);
             Owner = null;
@@ -62,6 +58,8 @@ namespace SS14.Shared.GameObjects
         /// <inheritdoc />
         public virtual void Shutdown()
         {
+            OnShutdown?.Invoke(new ComponentShutdownEventArgs(this));
+            OnShutdown = null;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Now when an Entity is Shutdown(), components are actually Shutdown() and OnRemoved()'d properly.
I also moved various component cleanup code from OnRemove to Shutdown, because most of the cleanup code was referencing other components that *could* already be removed.

This fixes issues with particles, collidables, and lights not being cleaned up when their controlling component was removed. This should fix https://github.com/space-wizards/space-station-14/issues/179.