### PR TITLE
Prototypes now use ResourceManager.

### DIFF
--- a/SS14.Client/GameController.cs
+++ b/SS14.Client/GameController.cs
@@ -99,7 +99,7 @@ namespace SS14.Client
 
             _serializer.Initialize();
             var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
-            prototypeManager.LoadDirectory(PathHelpers.ExecutableRelativeFile("Resources/Prototypes"));
+            prototypeManager.LoadDirectory(@"Prototypes");
             prototypeManager.Resync();
             _networkManager.Initialize(false);
             _netGrapher.Initialize();

--- a/SS14.Client/ResourceManagement/ResourceCache.cs
+++ b/SS14.Client/ResourceManagement/ResourceCache.cs
@@ -65,7 +65,7 @@ namespace SS14.Client.Resources
         {
             _resources.Initialize();
 
-            _resources.MountContentDirectory("");
+            _resources.MountContentDirectory(@"./Resources/");
 
             _resources.MountContentPack(@"./EngineContentPack.zip");
         }

--- a/SS14.Server/BaseServer.cs
+++ b/SS14.Server/BaseServer.cs
@@ -208,7 +208,7 @@ namespace SS14.Server
             // Set up the VFS
             _resources.Initialize();
 
-            _resources.MountContentDirectory(@"");
+            _resources.MountContentDirectory(@"./Resources/");
 
             //mount the engine content pack
             _resources.MountContentPack(@"EngineContentPack.zip");
@@ -225,7 +225,7 @@ namespace SS14.Server
             // because of 'reasons' this has to be called after the last assembly is loaded
             // otherwise the prototypes will be cleared
             var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
-            prototypeManager.LoadDirectory(PathHelpers.ExecutableRelativeFile("Resources/Prototypes"));
+            prototypeManager.LoadDirectory(@"Prototypes");
             prototypeManager.Resync();
 
             var clientConsole = IoCManager.Resolve<IClientConsoleHost>();

--- a/SS14.Shared/ContentPack/AssemblyLoader.cs
+++ b/SS14.Shared/ContentPack/AssemblyLoader.cs
@@ -22,6 +22,11 @@ namespace SS14.Shared.ContentPack
             Init = 1
         }
 
+        /// <summary>
+        ///     Loaded assemblies.
+        /// </summary>
+        private static readonly List<ModInfo> _mods = new List<ModInfo>();
+
         static AssemblyLoader()
         {
             // Make it attempt to use already loaded assemblies,
@@ -35,17 +40,10 @@ namespace SS14.Shared.ContentPack
             foreach (var mod in _mods)
             {
                 if (mod.GameAssembly.FullName == args.Name)
-                {
                     return mod.GameAssembly;
-                }
             }
             return null;
         }
-
-        /// <summary>
-        ///     Loaded assemblies.
-        /// </summary>
-        private static readonly List<ModInfo> _mods = new List<ModInfo>();
 
         /// <summary>
         ///     Gets an assembly by name from the given AppDomain.

--- a/SS14.Shared/ContentPack/AssemblyTypeChecker.cs
+++ b/SS14.Shared/ContentPack/AssemblyTypeChecker.cs
@@ -154,7 +154,7 @@ namespace SS14.Shared.ContentPack
             "OpenTK.Vector3h",
             "OpenTK.Vector4",
             "OpenTK.Vector4d",
-            "OpenTK.Vector4h",
+            "OpenTK.Vector4h"
         };
 
         /// <summary>
@@ -208,12 +208,16 @@ namespace SS14.Shared.ContentPack
                     // Assemblies are guilty until proven innocent in a court of law.
                     var safe = false;
                     foreach (var typeName in _typeWhiteList)
+                    {
                         if (typeRef.FullName.StartsWith(typeName))
                             safe = true;
+                    }
 
                     foreach (var typeName in _typeBlackList)
+                    {
                         if (typeRef.FullName.StartsWith(typeName))
                             safe = false;
+                    }
 
                     if (safe)
                         continue;

--- a/SS14.Shared/ContentPack/AssemblyTypeChecker.cs
+++ b/SS14.Shared/ContentPack/AssemblyTypeChecker.cs
@@ -154,7 +154,7 @@ namespace SS14.Shared.ContentPack
             "OpenTK.Vector3h",
             "OpenTK.Vector4",
             "OpenTK.Vector4d",
-            "OpenTK.Vector4h"
+            "OpenTK.Vector4h",
         };
 
         /// <summary>

--- a/SS14.Shared/ContentPack/DirLoader.cs
+++ b/SS14.Shared/ContentPack/DirLoader.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 
 namespace SS14.Shared.ContentPack
 {
@@ -35,6 +36,17 @@ namespace SS14.Shared.ContentPack
 
             var bytes = File.ReadAllBytes(fullPath);
             return new MemoryStream(bytes, false);
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<string> FindFiles(string path)
+        {
+            var fullPath = Path.GetFullPath(Path.Combine(_directory.FullName, path));
+            var paths = PathHelpers.GetFiles(fullPath);
+
+            // GetFiles returns full paths, we want them relative to root
+            foreach (var filePath in paths)
+                yield return filePath.Substring(_directory.FullName.Length);
         }
     }
 }

--- a/SS14.Shared/ContentPack/DirLoader.cs
+++ b/SS14.Shared/ContentPack/DirLoader.cs
@@ -46,7 +46,9 @@ namespace SS14.Shared.ContentPack
 
             // GetFiles returns full paths, we want them relative to root
             foreach (var filePath in paths)
+            {
                 yield return filePath.Substring(_directory.FullName.Length);
+            }
         }
     }
 }

--- a/SS14.Shared/ContentPack/IContentRoot.cs
+++ b/SS14.Shared/ContentPack/IContentRoot.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 
 namespace SS14.Shared.ContentPack
 {
@@ -19,5 +20,12 @@ namespace SS14.Shared.ContentPack
         /// <param name="relPath">Relative path from the root directory.</param>
         /// <returns>A stream of the file loaded into memory.</returns>
         MemoryStream GetFile(string relPath);
+
+        /// <summary>
+        ///     Recursively finds all files in a directory and all sub directories.
+        /// </summary>
+        /// <param name="path">Directory to search inside of.</param>
+        /// <returns>Enumeration of all relative file paths of the files found.</returns>
+        IEnumerable<string> FindFiles(string path);
     }
 }

--- a/SS14.Shared/ContentPack/PackLoader.cs
+++ b/SS14.Shared/ContentPack/PackLoader.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using ICSharpCode.SharpZipLib.Zip;
 using SS14.Shared.Log;
 
@@ -51,6 +52,16 @@ namespace SS14.Shared.ContentPack
             }
 
             return memStream;
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<string> FindFiles(string path)
+        {
+            foreach (ZipEntry zipEntry in _zip)
+            {
+                if (zipEntry.IsFile && zipEntry.Name.StartsWith(path))
+                    yield return zipEntry.Name;
+            }
         }
     }
 }

--- a/SS14.Shared/ContentPack/PathHelpers.cs
+++ b/SS14.Shared/ContentPack/PathHelpers.cs
@@ -13,7 +13,7 @@ namespace SS14.Shared.ContentPack
         /// <summary>
         ///     Get the full directory path that the executable is located in.
         /// </summary>
-        public static string GetExecutableDirectory()
+        private static string GetExecutableDirectory()
         {
             var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
             var path = new Uri(assembly.CodeBase).LocalPath;
@@ -28,13 +28,6 @@ namespace SS14.Shared.ContentPack
             return Path.GetFullPath(Path.Combine(GetExecutableDirectory(), file));
         }
 
-        //TODO: What is this supposed to be doing... path isn't even used... FIX ME
-        public static string AssemblyRelativeFile(string file, Assembly assembly)
-        {
-            var path = new Uri(assembly.CodeBase).LocalPath;
-            return Path.Combine(GetExecutableDirectory(), file);
-        }
-
         /// <summary>
         ///     Recursively gets all files in a directory and all sub directories.
         /// </summary>
@@ -42,39 +35,18 @@ namespace SS14.Shared.ContentPack
         /// <returns>Enumerable of all file paths in that directory and sub directories.</returns>
         public static IEnumerable<string> GetFiles(string path)
         {
-            return GetFiles(path, e => Console.WriteLine(e));
-        }
-
-        //TODO:  onError isn't used... FIX ME
-        // Source: http://stackoverflow.com/a/929418/4678631
-        public static IEnumerable<string> GetFiles(string path, Action<Exception> onError)
-        {
             var queue = new Queue<string>();
             queue.Enqueue(path);
+
             while (queue.Count > 0)
             {
                 path = queue.Dequeue();
-                try
-                {
-                    foreach (var subDir in Directory.GetDirectories(path))
-                        queue.Enqueue(subDir);
-                }
-                catch (Exception ex)
-                {
-                    Console.Error.WriteLine(ex);
-                }
-                string[] files = null;
-                try
-                {
-                    files = Directory.GetFiles(path);
-                }
-                catch (Exception ex)
-                {
-                    Console.Error.WriteLine(ex);
-                }
-                if (files != null)
-                    for (var i = 0; i < files.Length; i++)
-                        yield return files[i];
+
+                foreach (var subDir in Directory.GetDirectories(path))
+                    queue.Enqueue(subDir);
+
+                foreach (var file in Directory.GetFiles(path))
+                    yield return file;
             }
         }
     }

--- a/SS14.Shared/ContentPack/PathHelpers.cs
+++ b/SS14.Shared/ContentPack/PathHelpers.cs
@@ -43,10 +43,14 @@ namespace SS14.Shared.ContentPack
                 path = queue.Dequeue();
 
                 foreach (var subDir in Directory.GetDirectories(path))
+                {
                     queue.Enqueue(subDir);
+                }
 
                 foreach (var file in Directory.GetFiles(path))
+                {
                     yield return file;
+                }
             }
         }
     }

--- a/SS14.Shared/ContentPack/ResourceManager.cs
+++ b/SS14.Shared/ContentPack/ResourceManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using SS14.Shared.Configuration;
 using SS14.Shared.Interfaces;
 using SS14.Shared.Interfaces.Configuration;
@@ -99,6 +100,16 @@ namespace SS14.Shared.ContentPack
         public bool ContentFileExists(string path)
         {
             throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<string> FindFiles(string path)
+        {
+            // some LINQ magic
+            return _contentRoots
+                .Select(root => root.FindFiles(path)) // get a collection of strings (paths) from each root
+                .SelectMany(x => x) // merge the collections together to one big collection of strings
+                .Distinct(); // remove duplicate strings
         }
     }
 }

--- a/SS14.Shared/Interfaces/IResourceManager.cs
+++ b/SS14.Shared/Interfaces/IResourceManager.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 
 namespace SS14.Shared.Interfaces
 {
@@ -8,47 +9,56 @@ namespace SS14.Shared.Interfaces
     public interface IResourceManager
     {
         /// <summary>
-        /// Sets the manager up so that the base game can run.
+        ///     Sets the manager up so that the base game can run.
         /// </summary>
         void Initialize();
 
         /// <summary>
-        /// Loads the default content pack from the configuration file into the VFS.
+        ///     Loads the default content pack from the configuration file into the VFS.
         /// </summary>
         void MountDefaultContentPack();
 
         /// <summary>
-        /// Loads a content pack from disk into the VFS.
+        ///     Loads a content pack from disk into the VFS. The path is relative to
+        ///     the executable location on disk.
         /// </summary>
         /// <param name="pack"></param>
         void MountContentPack(string pack);
 
         /// <summary>
-        /// Adds a directory to search inside of to the VFS.
+        ///     Adds a directory to search inside of to the VFS. The directory is relative to
+        ///     the executable location on disk.
         /// </summary>
         /// <param name="path"></param>
         void MountContentDirectory(string path);
-        
+
         /// <summary>
-        /// Read a file from the mounted content roots.
+        ///     Read a file from the mounted content roots.
         /// </summary>
         /// <param name="path"></param>
         /// <returns></returns>
         MemoryStream ContentFileRead(string path);
 
         /// <summary>
-        /// Check if a file exists in any of the mounted content roots.
+        ///     Check if a file exists in any of the mounted content roots.
         /// </summary>
         /// <param name="path"></param>
         /// <returns></returns>
         bool ContentFileExists(string path);
 
         /// <summary>
-        /// Try to read a file from the mounted content roots.
+        ///     Try to read a file from the mounted content roots.
         /// </summary>
         /// <param name="path"></param>
         /// <param name="fileStream"></param>
         /// <returns></returns>
         bool TryContentFileRead(string path, out MemoryStream fileStream);
+
+        /// <summary>
+        ///     Recursively finds all files in a directory and all sub directories.
+        /// </summary>
+        /// <param name="path">Directory to search inside of.</param>
+        /// <returns>Enumeration of all relative file paths of the files found.</returns>
+        IEnumerable<string> FindFiles(string path);
     }
 }

--- a/SS14.UnitTesting/SS14UnitTest.cs
+++ b/SS14.UnitTesting/SS14UnitTest.cs
@@ -170,7 +170,7 @@ namespace SS14.UnitTesting
             {
                 //ConfigurationManager setup
                 GetConfigurationManager = IoCManager.Resolve<IConfigurationManager>();
-                GetConfigurationManager.LoadFromFile(PathHelpers.AssemblyRelativeFile("./client_config.toml", Assembly.GetExecutingAssembly()));
+                GetConfigurationManager.LoadFromFile(PathHelpers.ExecutableRelativeFile("./client_config.toml"));
             }
 
             if (NeedsResourcePack)


### PR DESCRIPTION
"./Resources/" folder is now mounted instead of "./" in the ResourceManager. This keeps it in line with the zip pack directory tree.
Prototypes now use the ResourceManager.
Added FindFiles(string path) to recursively find files in the ResourceManager.
General FileHelper bug fixing and cleanup.

This fixes https://github.com/space-wizards/space-station-14/issues/318.