### PR TITLE
Texture Loading Performance

### DIFF
--- a/SS14.Client.Graphics/texture/TextureCache.cs
+++ b/SS14.Client.Graphics/texture/TextureCache.cs
@@ -1,4 +1,4 @@
-using SFMLTexture = SFML.Graphics.Texture;
+﻿using SFMLTexture = SFML.Graphics.Texture;
 using SFML.Graphics;
 using System.Collections.Generic;
 
@@ -8,19 +8,17 @@ namespace SS14.Client.Graphics.TexHelpers
     {
         public SFMLTexture Texture;
         public Image Image;
-        public bool[,] Opacity;
 
-        public TextureInfo(SFMLTexture tex, Image img, bool[,] opacity)
+        public TextureInfo(SFMLTexture tex, Image img)
         {
             Texture = tex;
             Image = img;
-            Opacity = opacity;
         }
     }
 
     public static class TextureCache
     {
-        private static Dictionary<string, TextureInfo> _textures = null;
+        private static Dictionary<string, TextureInfo> _textures;
 
         public static Dictionary<string, TextureInfo> Textures
         {

--- a/SS14.Client/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
@@ -177,13 +177,10 @@ namespace SS14.Client.GameObjects
             Dictionary<Texture, string> tmp = resCache.TextureToKey;
             if (!tmp.ContainsKey(spriteToCheck.Texture)) { return false; } //if it doesn't exist, something's fucked
             string textureKey = tmp[spriteToCheck.Texture];
-            bool[,] opacityMap = TextureCache.Textures[textureKey].Opacity; //get our clickthrough 'map'
-            if (!opacityMap[spritePosition.X, spritePosition.Y]) // Check if the clicked pixel is opaque
-            {
-                return false;
-            }
+            var opacityMap = TextureCache.Textures[textureKey].Image; //get our clickthrough 'map'
 
-            return true;
+            // Check if the clicked pixel is opaque
+            return opacityMap.GetPixel((uint) spritePosition.X, (uint) spritePosition.Y).A <= Limits.ClickthroughLimit;
         }
 
         public override void LoadParameters(YamlMappingNode mapping)

--- a/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -16,6 +16,7 @@ using SS14.Shared.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using SS14.Client.Graphics.Sprite;
 using SS14.Shared.Maths;
 using YamlDotNet.RepresentationModel;
 using Vector2i = SS14.Shared.Maths.Vector2i;
@@ -249,13 +250,10 @@ namespace SS14.Client.GameObjects
             Dictionary<Texture, string> tmp = resCache.TextureToKey;
             if (!tmp.ContainsKey(spriteToCheck.Texture)) { return false; } //if it doesn't exist, something's fucked
             string textureKey = tmp[spriteToCheck.Texture];
-            bool[,] opacityMap = TextureCache.Textures[textureKey].Opacity; //get our clickthrough 'map'
-            if (!opacityMap[spritePosition.X, spritePosition.Y]) // Check if the clicked pixel is opaque
-            {
-                return false;
-            }
+            var opacityMap = TextureCache.Textures[textureKey].Image; //get our clickthrough 'map'
 
-            return true;
+            // Check if the clicked pixel is opaque
+            return opacityMap.GetPixel((uint)spritePosition.X, (uint)spritePosition.Y).A <= Limits.ClickthroughLimit;
         }
 
         public bool SpriteExists(string key)

--- a/SS14.Client/ResourceManagement/ResourceCache.cs
+++ b/SS14.Client/ResourceManagement/ResourceCache.cs
@@ -310,36 +310,8 @@ namespace SS14.Client.Resources
             }
 
             Image img = new Image(stream);
-            var size = img.Size;
-            var pixels = img.Pixels;
-            bool[,] opacityMap = new bool[size.X, size.Y];
-
-            for (int y = 0; y < size.Y; y++)
-            {
-                for (int x = 0; x < size.X; x++)
-                {
-                    //Color pColor = img.GetPixel(Convert.ToUInt32(x), Convert.ToUInt32(y));
-                    //byte alpha = pColor.A;
-
-                    var pixel = (y * size.X) + x;
-                    byte alpha = pixels[ pixel * 4 + 3 ];
-
-                    //if(salpha != qalpha)
-                        //throw new Exception();
-
-                    if (alpha > Limits.ClickthroughLimit)
-                    {
-                        opacityMap[x, y] = true;
-                    }
-                    else
-                    {
-                        opacityMap[x, y] = false;
-                    }
-                }
-            }
-
-            Texture texture = new Texture(img);
-            TextureInfo tmp = new TextureInfo(texture, img, opacityMap);
+            var texture = new Texture(img);
+            TextureInfo tmp = new TextureInfo(texture, img);
             TextureCache.Add(name, tmp);
             _textureToKey.Add(texture, name);
 
@@ -562,9 +534,9 @@ namespace SS14.Client.Resources
             return sprite;
         }
 
-        #endregion Resource Loading & Disposal
+#endregion Resource Loading & Disposal
 
-        #region Resource Retrieval
+#region Resource Retrieval
 
         /// <summary>
         ///  <para>Retrieves the Image with the given key from the Resource list and returns it as a Sprite.</para>
@@ -679,9 +651,9 @@ namespace SS14.Client.Resources
         }
 
 
-        #endregion Resource Retrieval
+#endregion Resource Retrieval
 
-        #endregion OldCode
+#endregion OldCode
 
         /// <summary>
         /// fetches the resource from the cache.

--- a/SS14.Client/ResourceManagement/ResourceCache.cs
+++ b/SS14.Client/ResourceManagement/ResourceCache.cs
@@ -310,13 +310,24 @@ namespace SS14.Client.Resources
             }
 
             Image img = new Image(stream);
-            bool[,] opacityMap = new bool[img.Size.X, img.Size.Y];
-            for (int y = 0; y < img.Size.Y; y++)
+            var size = img.Size;
+            var pixels = img.Pixels;
+            bool[,] opacityMap = new bool[size.X, size.Y];
+
+            for (int y = 0; y < size.Y; y++)
             {
-                for (int x = 0; x < img.Size.X; x++)
+                for (int x = 0; x < size.X; x++)
                 {
-                    Color pColor = img.GetPixel(Convert.ToUInt32(x), Convert.ToUInt32(y));
-                    if (pColor.A > Limits.ClickthroughLimit)
+                    //Color pColor = img.GetPixel(Convert.ToUInt32(x), Convert.ToUInt32(y));
+                    //byte alpha = pColor.A;
+
+                    var pixel = (y * size.X) + x;
+                    byte alpha = pixels[ pixel * 4 + 3 ];
+
+                    //if(salpha != qalpha)
+                        //throw new Exception();
+
+                    if (alpha > Limits.ClickthroughLimit)
                     {
                         opacityMap[x, y] = true;
                     }
@@ -728,9 +739,11 @@ namespace SS14.Client.Resources
             // stop this, we failed
             if (tempRes.Fallback != null && tempRes.Fallback != path)
             {
-                TryGetResource(tempRes.Fallback, out T fallbackRes);
-                resource = fallbackRes;
-                return true;
+                if (TryGetResource(tempRes.Fallback, out T fallbackRes))
+                {
+                    resource = fallbackRes;
+                    return true;
+                }
             }
 
             resource = default(T);

--- a/SS14.Client/ResourceManagement/SpriteResource.cs
+++ b/SS14.Client/ResourceManagement/SpriteResource.cs
@@ -2,7 +2,6 @@
 using SFML.Graphics;
 using SS14.Client.Interfaces.Resource;
 using SS14.Client.ResourceManagment;
-using SS14.Client.Resources;
 
 namespace SS14.Client.ResourceManagement
 {
@@ -11,6 +10,9 @@ namespace SS14.Client.ResourceManagement
     /// </summary>
     public class SpriteResource : BaseResource
     {
+        /// <inheritdoc />
+        public override string Fallback => @"Textures/noSprite.png";
+
         /// <summary>
         /// The contained SFML Sprite.
         /// </summary>
@@ -33,6 +35,11 @@ namespace SS14.Client.ResourceManagement
         public override void Dispose()
         {
             Sprite.Dispose();
+        }
+
+        public static implicit operator Sprite(SpriteResource res)
+        {
+            return res.Sprite;
         }
     }
 }


### PR DESCRIPTION
Reworked the alpha clicking, removed the useless clickmaps, and gained about 20% faster load times according to the profiler.

The Texture ctor in ResourceCache.LoadTextureFrom is still taking up about 55% of the total loading time of the client. Do we really need to load every texture in the VFS into GPU memory before the client window opens?