### PR TITLE
Sprite Clicking Rework

### DIFF
--- a/SS14.Client/GameObjects/AnimatedSprite.cs
+++ b/SS14.Client/GameObjects/AnimatedSprite.cs
@@ -58,15 +58,15 @@ namespace SS14.Client.Graphics.Sprite
 
         #region Sprite passthrough methods
 
-        public Box2i AABB
-        {
-            get
-            {
-                if (_currentSprite != null)
-                    return _currentSprite.TextureRect.Convert();
-                return new Box2i();
-            }
-        }
+        /// <summary>
+        ///     Sub-rectangle of the texture to use as the sprite. This is NOT the local bounds of the sprite.
+        /// </summary>
+        public Box2i TextureRect => _currentSprite?.TextureRect.Convert() ?? new Box2i();
+
+        /// <summary>
+        ///     Local bounding box of the sprite, with the origin at the top left.
+        /// </summary>
+        public Box2 LocalAABB => _currentSprite?.GetLocalBounds().Convert() ?? new Box2();
 
         public bool HorizontalFlip { get; set; }
 

--- a/SS14.Client/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
@@ -42,14 +42,10 @@ namespace SS14.Client.GameObjects
 
         public override Type StateType => typeof(AnimatedSpriteComponentState);
 
-        public float Bottom
-        {
-            get
-            {
-                return Owner.GetComponent<ITransformComponent>().Position.Y +
-                       (sprite.TextureRect.Height / 2);
-            }
-        }
+        /// <summary>
+        ///     Center of the Y axis of the sprite bounds in world coords.
+        /// </summary>
+        public float Bottom => Owner.GetComponent<ITransformComponent>().Position.Y + sprite.LocalAABB.Height / 2;
 
         public Box2 AverageAABB
         {

--- a/SS14.Client/GameObjects/Components/Renderable/ParticleSystemComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/ParticleSystemComponent.cs
@@ -30,9 +30,9 @@ namespace SS14.Client.GameObjects
         #endregion Variables.
 
         #region Properties
-        public Box2 AverageAABB => AABB;
+        public Box2 AverageAABB => LocalAABB;
 
-        public Box2 AABB => new Box2();
+        public Box2 LocalAABB => new Box2();
 
         #endregion Properties
 

--- a/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -58,9 +58,11 @@ namespace SS14.Client.GameObjects
 
         #region ISpriteComponent Members
 
-        public Box2 AverageAABB => AABB;
+        public Box2 AverageAABB => LocalAABB;
 
-        public Box2 AABB
+
+
+        public Box2 LocalAABB
         {
             get
             {
@@ -262,8 +264,8 @@ namespace SS14.Client.GameObjects
             var texRect = spriteToCheck.TextureRect;
 
             // Get the clicked position relative to the texture
-            var spritePosition = new Vector2i((int)(worldPos.X - AABB.Left + texRect.Left),
-                                              (int)(worldPos.Y - AABB.Top + texRect.Top));
+            var spritePosition = new Vector2i((int)(worldPos.X - LocalAABB.Left + texRect.Left),
+                                              (int)(worldPos.Y - LocalAABB.Top + texRect.Top));
 
             if (spritePosition.X < 0 || spritePosition.Y < 0)
                 return false;
@@ -362,7 +364,7 @@ namespace SS14.Client.GameObjects
             }
 
             //Draw AABB
-            var aabb = AABB;
+            var aabb = LocalAABB;
             if (CluwneLib.Debug.DebugColliders)
                 CluwneLib.drawRectangle((int)(renderPos.X - aabb.Width / 2), (int)(renderPos.Y - aabb.Height / 2), aabb.Width, aabb.Height, Color4.Blue);
         }

--- a/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -231,12 +231,33 @@ namespace SS14.Client.GameObjects
             Sprite spriteToCheck = GetActiveDirectionalSprite();
             var bounds = spriteToCheck.GetLocalBounds();
 
+            // local screen coords
+            var localBounds = spriteToCheck.GetLocalBounds().Convert();
+
+            // local world coords
+            var scale = CluwneLib.Window.Camera.PixelsPerMeter;
+            var worldBounds = new Box2(
+                localBounds.Left / scale,
+                localBounds.Top / scale,
+                localBounds.Right / scale,
+                localBounds.Bottom / scale);
+
+            // move the origin from top left to center
+            worldBounds = worldBounds.Translated(new Vector2(-worldBounds.Width / 2, -worldBounds.Height / 2));
+
+            // absolute world coords
+            worldBounds = worldBounds.Translated(Owner.GetComponent<ITransformComponent>().Position);
+
+            // check if clicked inside of the rectangle
+            if (!worldBounds.Contains(worldPos))
+                return false;
+
+            /*
             var AABB =
                 Box2.FromDimensions(
                     Owner.GetComponent<ITransformComponent>().Position.X - (bounds.Width / 2),
                     Owner.GetComponent<ITransformComponent>().Position.Y - (bounds.Height / 2), bounds.Width, bounds.Height);
-            if (!AABB.Contains(new Vector2(worldPos.X, worldPos.Y))) return false;
-
+*/
             // Get the sprite's position within the texture
             var texRect = spriteToCheck.TextureRect;
 

--- a/SS14.Client/GameObjects/Components/Renderable/WearableAnimatedSpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/WearableAnimatedSpriteComponent.cs
@@ -68,7 +68,7 @@ namespace SS14.Client.GameObjects
             }
         }
 
-        public override Box2 AABB
+        public override Box2 LocalAABB
         {
             get
             {
@@ -77,7 +77,7 @@ namespace SS14.Client.GameObjects
                     var bounds = GetCurrentSprite().GetLocalBounds();
                     return Box2.FromDimensions(0, 0, bounds.Width, bounds.Height);
                 }
-                return base.AABB;
+                return base.LocalAABB;
             }
         }
 
@@ -141,7 +141,7 @@ namespace SS14.Client.GameObjects
             }
 
             //Draw AABB
-            var aabb = AABB;
+            var aabb = LocalAABB;
             if (CluwneLib.Debug.DebugColliders)
                 CluwneLib.drawRectangle((int)(renderPos.X - aabb.Width / 2), (int)(renderPos.Y - aabb.Height / 2), aabb.Width, aabb.Height, Color4.Blue);
 

--- a/SS14.Client/Interfaces/GameObjects/IRenderableComponent.cs
+++ b/SS14.Client/Interfaces/GameObjects/IRenderableComponent.cs
@@ -1,4 +1,4 @@
-using OpenTK;
+﻿using OpenTK;
 using SFML.Graphics;
 using SFML.System;
 using SS14.Shared.GameObjects;
@@ -12,7 +12,7 @@ namespace SS14.Client.Interfaces.GameObjects
         DrawDepth DrawDepth { get; set; }
         float Bottom { get; }
         void Render(Vector2 topLeft, Vector2 bottomRight);
-        Box2 AABB { get; }
+        Box2 LocalAABB { get; }
         Box2 AverageAABB { get; }
         bool IsSlaved();
         void SetMaster(IEntity m);

--- a/SS14.Client/Interfaces/GameObjects/ISpriteComponent.cs
+++ b/SS14.Client/Interfaces/GameObjects/ISpriteComponent.cs
@@ -1,4 +1,4 @@
-using OpenTK;
+﻿using OpenTK;
 using SFML.Graphics;
 using SS14.Shared.Interfaces.GameObjects;
 using System.Collections.Generic;
@@ -7,7 +7,7 @@ namespace SS14.Client.Interfaces.GameObjects
 {
     public interface ISpriteComponent : IComponent
     {
-        Box2 AABB { get; }
+        Box2 LocalAABB { get; }
         Sprite GetCurrentSprite();
         Sprite GetSprite(string spriteKey);
         List<Sprite> GetAllSprites();

--- a/SS14.Client/State/States/GameScreen.cs
+++ b/SS14.Client/State/States/GameScreen.cs
@@ -635,7 +635,7 @@ namespace SS14.Client.State.States
             // Check whether click is outside our 1.5 tile range
             float checkDistance = 1.5f * MapManager.TileSize;
             var dist = PlayerManager.ControlledEntity.GetComponent<ITransformComponent>().Position - entToClick.GetComponent<ITransformComponent>().Position;
-            if (dist.Length > checkDistance)
+            if (dist.LengthSquared > checkDistance * checkDistance)
                 return;
 
             var clickable = entToClick.GetComponent<IClientClickableComponent>();

--- a/SS14.Shared/GameObjects/EntityManager.cs
+++ b/SS14.Shared/GameObjects/EntityManager.cs
@@ -140,7 +140,7 @@ namespace SS14.Shared.GameObjects
 
         public void DeleteEntity(int entityUid)
         {
-            if (!TryGetEntity(entityUid, out var entity))
+            if (TryGetEntity(entityUid, out var entity))
             {
                 DeleteEntity(entity);
             }

--- a/SS14.Shared/Maths/Box2Ext.cs
+++ b/SS14.Shared/Maths/Box2Ext.cs
@@ -16,12 +16,28 @@ namespace SS14.Shared.Maths
         {
             return Math.Abs(me.Width) < Epsilon && Math.Abs(me.Height) < Epsilon;
         }
+
         public static bool Encloses(this Box2 outer, Box2 inner)
         {
             return outer.Left <= inner.Left
-                && inner.Right <= outer.Right
-                && outer.Top <= inner.Top
-                && inner.Bottom <= outer.Bottom;
+                   && inner.Right <= outer.Right
+                   && outer.Top <= inner.Top
+                   && inner.Bottom <= outer.Bottom;
+        }
+
+        /// <summary>
+        ///     Uniformly scales the box by a given scalar.
+        /// </summary>
+        /// <param name="me">Box2 to scale.</param>
+        /// <param name="scalar">Value to scale the box by.</param>
+        /// <returns>Scaled box.</returns>
+        public static Box2 Scale(this Box2 me, float scalar)
+        {
+            return new Box2(
+                me.Left * scalar,
+                me.Top * scalar,
+                me.Right * scalar,
+                me.Bottom * scalar);
         }
     }
 }


### PR DESCRIPTION
I completely remade the WasClicked() functions for the sprite components. Bounding boxes and Transparency click filtering properly works now. I added lots of comments and simple steps to help whoever is going to be looking at the code a year from now. This fixes https://github.com/space-wizards/space-station-14/issues/411.

Box2 get a new Scale() helper function.

Entity deleting bug was fixed on the client, so the GUI entity eraser works again.