### PR TITLE
Fix string null check

### DIFF
--- a/SS14.Client.Graphics/Render/RenderImage.cs
+++ b/SS14.Client.Graphics/Render/RenderImage.cs
@@ -172,7 +172,8 @@ namespace SS14.Client.Graphics.Render
         /// <param name="key"></param>
         private void CheckIfKeyIsNull(string key)
         {
-            if (key.Equals(null))
+            // string.Equals(null) always returns false, so don't use it here
+            if (key == null)
             {
                 throw new Exception("key Cannot be null!");
             }
@@ -355,6 +356,6 @@ namespace SS14.Client.Graphics.Render
         }
 
         #endregion
-        
+
     }
 }


### PR DESCRIPTION
string.Equals(object) returns false if object is null, so it's not useful for checking whether a string is null.

https://msdn.microsoft.com/en-us/library/fkfd9eh8(v=vs.110).aspx