### PR TITLE
Improves debug mode perf & look

### DIFF
--- a/Resources/Prototypes/Entities/Mobs.yml
+++ b/Resources/Prototypes/Entities/Mobs.yml
@@ -14,7 +14,7 @@
     sizeX: 0.9
     sizeY: 0.9
     offsetY: 0.6
-    
+
   - type: ParticleSystem
   - type: Physics
     mass: 5

--- a/SS14.Client.Graphics/Sprites/RectangleShape.cs
+++ b/SS14.Client.Graphics/Sprites/RectangleShape.cs
@@ -22,5 +22,11 @@ namespace SS14.Client.Graphics.Sprites
         {
             Texture = shape.Texture;
         }
+
+        public Vector2 Size
+        {
+            get => SFMLRectangleShape.Size.Convert();
+            set => SFMLRectangleShape.Size = value.Convert();
+        }
     }
 }

--- a/SS14.Client.Graphics/Sprites/TextSprite.cs
+++ b/SS14.Client.Graphics/Sprites/TextSprite.cs
@@ -68,8 +68,16 @@ namespace SS14.Client.Graphics.Sprites
 
         public void Draw(IRenderTarget target, RenderStates states)
         {
-            SFMLTextSprite.Position = new Vector2f(Position.X, Position.Y);
-            SFMLTextSprite.FillColor = FillColor.Convert();
+            if (Shadowed)
+            {
+                var oldPos = SFMLTextSprite.Position;
+                var oldColor = SFMLTextSprite.FillColor;
+                SFMLTextSprite.Position += ShadowOffset.Convert();
+                SFMLTextSprite.FillColor = ShadowColor.Convert();
+                SFMLTextSprite.Draw(target.SFMLTarget, states.SFMLRenderStates);
+                SFMLTextSprite.Position = oldPos;
+                SFMLTextSprite.FillColor = oldColor;
+            }
             SFMLTextSprite.Draw(target.SFMLTarget, states.SFMLRenderStates);
 
             if (CluwneLib.Debug.DebugTextboxes)
@@ -113,9 +121,9 @@ namespace SS14.Client.Graphics.Sprites
 
         #region Accessors
 
-        public Color ShadowColor { get; set; }
+        public Color ShadowColor { get; set; } = Color.Black;
         public bool Shadowed { get; set; } = false;
-        public Vector2 ShadowOffset { get; set; }
+        public Vector2 ShadowOffset { get; set; } = new Vector2(1, 1);
 
         public Color FillColor
         {

--- a/SS14.Client/GameObjects/Components/Collidable/CollidableComponent.cs
+++ b/SS14.Client/GameObjects/Components/Collidable/CollidableComponent.cs
@@ -6,6 +6,8 @@ using SS14.Shared.Interfaces.GameObjects.Components;
 using SS14.Shared.Interfaces.Physics;
 using SS14.Shared.IoC;
 using SS14.Shared.Maths;
+using SS14.Shared.Utility;
+using YamlDotNet.RepresentationModel;
 using Vector2 = SS14.Shared.Maths.Vector2;
 
 namespace SS14.Client.GameObjects
@@ -15,7 +17,7 @@ namespace SS14.Client.GameObjects
         // no client side collision support for now
         private bool collisionEnabled;
 
-        public Color DebugColor { get; } = Color.Red;
+        public Color DebugColor { get; private set; } = Color.Red;
 
         /// <inheritdoc />
         public override string Name => "Collidable";
@@ -146,6 +148,16 @@ namespace SS14.Client.GameObjects
             collisionEnabled = false;
             var cm = IoCManager.Resolve<ICollisionManager>();
             cm.RemoveCollidable(this);
+        }
+
+        public override void LoadParameters(YamlMappingNode mapping)
+        {
+            base.LoadParameters(mapping);
+
+            if (mapping.TryGetNode("DebugColor", out var node))
+            {
+                DebugColor = node.AsHexColor();
+            }
         }
     }
 }

--- a/SS14.Client/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
@@ -286,13 +286,6 @@ namespace SS14.Client.GameObjects
             {
                 component.Render(topLeft, bottomRight);
             }
-
-            //Draw AABB
-            var aabb = LocalAABB;
-
-            if (_speechBubble != null)
-                _speechBubble.Draw(CluwneLib.WorldToScreen(Owner.GetComponent<ITransformComponent>().WorldPosition),
-                                   new Vector2(), aabb);
         }
 
         /// <inheritdoc />

--- a/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -383,11 +383,6 @@ namespace SS14.Client.GameObjects
             {
                 component.Render(topLeft, bottomRight);
             }
-
-            //Draw AABB
-            var aabb = LocalAABB;
-            if (CluwneLib.Debug.DebugColliders)
-                CluwneLib.drawRectangle((int)(renderPos.X - aabb.Width / 2), (int)(renderPos.Y - aabb.Height / 2), aabb.Width, aabb.Height, Color4.Blue);
         }
 
         public void SetSpriteCenter(string sprite, Vector2 center)

--- a/SS14.Client/GameObjects/Components/Renderable/WearableAnimatedSpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/WearableAnimatedSpriteComponent.cs
@@ -138,11 +138,6 @@ namespace SS14.Client.GameObjects
             {
                 component.Render(topLeft, bottomRight);
             }
-
-            //Draw AABB
-            var aabb = LocalAABB;
-            if (CluwneLib.Debug.DebugColliders)
-                CluwneLib.drawRectangle((int)(renderPos.X - aabb.Width / 2), (int)(renderPos.Y - aabb.Height / 2), aabb.Width, aabb.Height, Color4.Blue);
         }
     }
 }

--- a/SS14.Client/State/States/GameScreen.cs
+++ b/SS14.Client/State/States/GameScreen.cs
@@ -1381,7 +1381,7 @@ Character Pos:
 Mouse Pos:
     Pixel: {mouseWorldOffset.X} / {mouseWorldOffset.Y}
     World: {mouseTile.X} / {mouseTile.Y}
-    Screen: {mouseScreenPos.X} / {mouseScreenPos.Y},
+    Screen: {mouseScreenPos.X} / {mouseScreenPos.Y}
     Grid: {mousepos.GridID}
     Map: {mousepos.MapID}";
 

--- a/SS14.Client/State/States/GameScreen.cs
+++ b/SS14.Client/State/States/GameScreen.cs
@@ -117,6 +117,8 @@ namespace SS14.Client.State.States
 
         #endregion Lighting
 
+        private GameScreenDebug DebugManager;
+
         #endregion Variables
 
         public GameScreen(IDictionary<Type, object> managers) : base(managers)
@@ -170,6 +172,8 @@ namespace SS14.Client.State.States
             InitializeSpriteBatches();
             InitalizeLighting();
             InitializeGUI();
+
+            DebugManager = new GameScreenDebug(this);
         }
 
         private void InitializeRenderTargets()
@@ -361,7 +365,7 @@ namespace SS14.Client.State.States
                 else
                     LightScene();
 
-                RenderDebug(vp, map);
+                DebugManager.RenderDebug(vp, map);
 
                 //Render the placement manager shit
                 PlacementManager.Render();
@@ -408,72 +412,6 @@ namespace SS14.Client.State.States
             }
 
             _overlayTarget.Blit(0, 0, _tilesTarget.Width, _tilesTarget.Height, Color.White, BlitterSizeMode.Crop);
-        }
-
-        private void RenderDebug(Box2 viewport, int argMap)
-        {
-            if (debugWallOccluders || debugPlayerShadowMap)
-                _occluderDebugTarget.Blit(0, 0, _occluderDebugTarget.Width / 4, _occluderDebugTarget.Height / 4, Color.White, BlitterSizeMode.Scale);
-
-            if (CluwneLib.Debug.DebugColliders)
-            {
-                var collidables =
-                    _componentManager.GetComponents<CollidableComponent>()
-                    .Where(c => c.MapID == argMap)
-                    .Select(c => new { Color = c.DebugColor, AABB = c.Owner.GetComponent<BoundingBoxComponent>().WorldAABB })
-                    .Where(c => !c.AABB.IsEmpty() && c.AABB.Intersects(viewport));
-
-                foreach (var bounds in collidables)
-                {
-                    var box = CluwneLib.WorldToScreen(bounds.AABB);
-                    CluwneLib.drawRectangle((int)box.Left, (int)box.Top, (int)box.Width, (int)box.Height,
-                        bounds.Color.WithAlpha(64));
-                    CluwneLib.drawHollowRectangle((int)box.Left, (int)box.Top, (int)box.Width, (int)box.Height, 1f,
-                        bounds.Color.WithAlpha(128));
-                }
-            }
-            if (CluwneLib.Debug.DebugGridDisplay)
-            {
-                int startX = 10;
-                int startY = 10;
-                CluwneLib.drawRectangle(startX, startY, 200, 300,
-                        Color.Blue.WithAlpha(64));
-
-                // Player position debug
-                Vector2 playerWorldOffset = PlayerManager.ControlledEntity.GetComponent<ITransformComponent>().WorldPosition;
-                Vector2 playerTile = CluwneLib.WorldToTile(playerWorldOffset);
-                Vector2 playerScreen = CluwneLib.WorldToScreen(playerWorldOffset);
-                var font = ResourceCache.GetResource<FontResource>(@"Fonts/bluehigh.ttf").Font;
-                CluwneLib.drawText(15, 15, "Postioning Debug", 14, Color.White, font);
-                CluwneLib.drawText(15, 30, "Character Pos", 14, Color.White, font);
-                CluwneLib.drawText(15, 45, String.Format("Pixel: {0} / {1}", playerWorldOffset.X, playerWorldOffset.Y), 14, Color.White, font);
-                CluwneLib.drawText(15, 60, String.Format("World: {0} / {1}", playerTile.X, playerTile.Y), 14, Color.White, font);
-                CluwneLib.drawText(15, 75, String.Format("Screen: {0} / {1}", playerScreen.X, playerScreen.Y), 14, Color.White, font);
-
-                // Mouse position debug
-                Vector2i mouseScreenPos = (Vector2i)MousePosScreen.Position;
-                var mousepos = CluwneLib.ScreenToCoordinates(MousePosScreen);
-                Vector2 mouseWorldOffset = mousepos.ToWorld().Position;
-                Vector2 mouseTile = CluwneLib.WorldToTile(mouseWorldOffset);
-                CluwneLib.drawText(15, 120, "Mouse Pos", 14, Color.White, font);
-                CluwneLib.drawText(15, 135, String.Format("Pixel: {0} / {1}", mouseWorldOffset.X, mouseWorldOffset.Y), 14, Color.White, font);
-                CluwneLib.drawText(15, 150, String.Format("World: {0} / {1}", mouseTile.X, mouseTile.Y), 14, Color.White, font);
-                CluwneLib.drawText(15, 165, String.Format("Screen: {0} / {1}", mouseScreenPos.X, mouseScreenPos.Y), 14, Color.White, font);
-                CluwneLib.drawText(15, 180, String.Format("Grid, Map: {0} / {1}", mousepos.GridID, mousepos.MapID), 14, Color.White, font);
-            }
-
-            if (CluwneLib.Debug.DebugFPS)
-            {
-                var font = ResourceCache.GetResource<FontResource>(@"Fonts/bluehigh.ttf").Font;
-                var fps = Math.Round(IoCManager.Resolve<IGameTiming>().FramesPerSecondAvg, 2);
-                int startY = 10;
-                if (CluwneLib.Debug.DebugGridDisplay)
-                {
-                    startY += 300;
-                }
-
-                CluwneLib.drawText(10, startY, $"FPS: {fps}", 14, Color.White, font);
-            }
         }
 
         public void Shutdown()
@@ -1352,5 +1290,118 @@ namespace SS14.Client.State.States
         }
 
         #endregion Nested type: ClickData
+
+        class GameScreenDebug
+        {
+            public readonly GameScreen Parent;
+            private RectangleShape DebugDisplayBackground;
+            private RectangleShape ColliderDebug;
+            private TextSprite PositionDebugText;
+            private TextSprite FPSText;
+
+            public GameScreenDebug(GameScreen parent)
+            {
+                Parent = parent;
+                DebugDisplayBackground = new RectangleShape()
+                {
+                    Position = new Vector2(10, 10),
+                    Size = new Vector2(180, 180),
+                    FillColor = Color.Blue.WithAlpha(64),
+                };
+
+                ColliderDebug = new RectangleShape()
+                {
+                    OutlineThickness = 1f,
+                };
+
+                var font = Parent.ResourceCache.GetResource<FontResource>(@"Fonts/bluehigh.ttf").Font;
+                PositionDebugText = new TextSprite("", font, 14)
+                {
+                    Position = new Vector2(15, 15),
+                    FillColor = Color.White,
+                    Shadowed = true,
+                };
+
+                FPSText = new TextSprite("", font, 14)
+                {
+                    FillColor = Color.White,
+                    Shadowed = true,
+                };
+            }
+
+            public void RenderDebug(Box2 viewport, int argMap)
+            {
+                if (CluwneLib.Debug.DebugColliders)
+                {
+                    Color lastColor = default(Color);
+                    foreach (var component in Parent._componentManager.GetComponents<CollidableComponent>())
+                    {
+                        if (component.MapID != argMap)
+                        {
+                            continue;
+                        }
+                        var bounds = component.Owner.GetComponent<BoundingBoxComponent>();
+                        if (bounds.WorldAABB.IsEmpty() || !bounds.WorldAABB.Intersects(viewport))
+                        {
+                            continue;
+                        }
+                        var box = CluwneLib.WorldToScreen(bounds.WorldAABB);
+                        ColliderDebug.Position = new Vector2(box.Left, box.Top);
+                        ColliderDebug.Size = new Vector2(box.Width, box.Height);
+                        if (lastColor != component.DebugColor)
+                        {
+                            lastColor = component.DebugColor;
+                            ColliderDebug.FillColor = lastColor.WithAlpha(64);
+                            ColliderDebug.OutlineColor = lastColor.WithAlpha(128);
+                        }
+                        ColliderDebug.Draw();
+                    }
+
+                }
+                if (CluwneLib.Debug.DebugGridDisplay)
+                {
+                    DebugDisplayBackground.Draw();
+
+                    // Player position debug
+                    Vector2 playerWorldOffset = Parent.PlayerManager.ControlledEntity.GetComponent<ITransformComponent>().WorldPosition;
+                    Vector2 playerTile = CluwneLib.WorldToTile(playerWorldOffset);
+                    Vector2 playerScreen = CluwneLib.WorldToScreen(playerWorldOffset);
+
+                    Vector2i mouseScreenPos = (Vector2i)Parent.MousePosScreen.Position;
+                    var mousepos = CluwneLib.ScreenToCoordinates(Parent.MousePosScreen);
+                    Vector2 mouseWorldOffset = mousepos.ToWorld().Position;
+                    Vector2 mouseTile = CluwneLib.WorldToTile(mouseWorldOffset);
+
+                    PositionDebugText.Text = $@"Positioning Debug:
+Character Pos:
+    Pixel: {playerWorldOffset.X} / {playerWorldOffset.Y}
+    World: {playerTile.X} / {playerTile.Y}
+    Screen: {playerScreen.X} / {playerScreen.Y}
+
+Mouse Pos:
+    Pixel: {mouseWorldOffset.X} / {mouseWorldOffset.Y}
+    World: {mouseTile.X} / {mouseTile.Y}
+    Screen: {mouseScreenPos.X} / {mouseScreenPos.Y},
+    Grid: {mousepos.GridID}
+    Map: {mousepos.MapID}";
+
+                    PositionDebugText.Draw();
+                }
+
+                if (CluwneLib.Debug.DebugFPS)
+                {
+                    var fps = Math.Round(IoCManager.Resolve<IGameTiming>().FramesPerSecondAvg, 2);
+                    int startY = 10;
+                    if (CluwneLib.Debug.DebugGridDisplay)
+                    {
+                        startY += (int)DebugDisplayBackground.Size.Y;
+                    }
+
+                    FPSText.Text = $"FPS: {fps}";
+                    FPSText.Position = new Vector2(10, startY);
+                    FPSText.Draw();
+                }
+            }
+        }
     }
 }

--- a/SS14.Shared/Physics/CollisionManager.cs
+++ b/SS14.Shared/Physics/CollisionManager.cs
@@ -122,8 +122,8 @@ namespace SS14.Shared.Physics
                     .SelectMany(b => b.GetPoints()) // Get all of the points
                     .Select(p => p.ParentAABB) // Expand points to distinct AABBs
                     .Distinct()
-                    .Where(aabb => aabb.Collidable.WorldAABB != collider.WorldAABB && 
-                           aabb.Collidable.WorldAABB.Intersects(colliderAABB) && 
+                    .Where(aabb => aabb.Collidable.WorldAABB != collider.WorldAABB &&
+                           aabb.Collidable.WorldAABB.Intersects(colliderAABB) &&
                            aabb.Collidable.MapID == collider.MapID); //try all of the AABBs against the target rect.
 
             //try all of the AABBs against the target rect.

--- a/SS14.Shared/Utility/YamlHelpers.cs
+++ b/SS14.Shared/Utility/YamlHelpers.cs
@@ -136,7 +136,7 @@ namespace SS14.Shared.Utility
         }
 
         /// <summary>
-        /// Attempts to fetch a node like <See cref="GetNode{T}" />,
+        /// Attempts to fetch a node like <see cref="GetNode{T}" />,
         /// but does not throw a <c>KeyNotFoundException</c> if the node doesn't exist.
         /// Instead it returns whether the node was successfully found.
         /// </summary>
@@ -162,7 +162,7 @@ namespace SS14.Shared.Utility
         }
 
         /// <summary>
-        /// Attempts to fetch a node like <See cref="GetNode" />,
+        /// Attempts to fetch a node like <see cref="GetNode" />,
         /// but does not throw a <c>KeyNotFoundException</c> if the node doesn't exist.
         /// Instead it returns whether the node was successfully found.
         /// </summary>


### PR DESCRIPTION
Debug mode no langer tanks FPS by caching the used rectangle and text shapes. The LINQ removal probably helped too.

Sprite AABB debug has been removed since sprite AABBs aren't used anymore.

Implemented text shadowing, which is now used by the debug text to make it more readable.

Implemented collidable debug color from prototypes.

![image](https://user-images.githubusercontent.com/8107459/31851874-c2061708-b66e-11e7-91f6-4ccfeeddac15.png)

Who knew that building a gazillion rectangles and text sprites and destroying them immediately was bad on performance?!