### PR TITLE
Fixes opening client console crashing server.

### DIFF
--- a/SS14.Client/UserInterface/Components/DebugConsole.cs
+++ b/SS14.Client/UserInterface/Components/DebugConsole.cs
@@ -12,6 +12,7 @@ using SS14.Shared.Reflection;
 using SS14.Shared.Utility;
 using System;
 using System.Collections.Generic;
+using SS14.Shared.Network.Messages;
 using Vector2i = SS14.Shared.Maths.Vector2i;
 
 namespace SS14.Client.UserInterface.Components
@@ -252,9 +253,10 @@ namespace SS14.Client.UserInterface.Components
             if (!netMgr.IsConnected)
                 return;
 
-            NetOutgoingMessage outMsg = netMgr.CreateMessage();
-            outMsg.Write((byte)NetMessages.ConsoleCommandRegister);
-            netMgr.ClientSendMessage(outMsg, NetDeliveryMethod.ReliableUnordered);
+            var msg = netMgr.CreateNetMessage<MsgConCmdReg>();
+            // empty message to request commands
+            netMgr.ClientSendMessage(msg, NetDeliveryMethod.ReliableUnordered);
+            
             sentCommandRequestToServer = true;
         }
 

--- a/SS14.Shared/Network/Messages/MsgConCmdReg.cs
+++ b/SS14.Shared/Network/Messages/MsgConCmdReg.cs
@@ -29,7 +29,9 @@ namespace SS14.Shared.Network.Messages
 
         public override void ReadFromBuffer(NetIncomingMessage buffer)
         {
-            for (ushort i = buffer.ReadUInt16(); i > 0; i--)
+            var cmdCount = buffer.ReadUInt16();
+            Commands = new Command[cmdCount];
+            for (var i = 0; i < cmdCount; i++)
             {
                 Commands[i] = new Command()
                 {
@@ -42,6 +44,9 @@ namespace SS14.Shared.Network.Messages
 
         public override void WriteToBuffer(NetOutgoingMessage buffer)
         {
+            if(Commands == null) // client leaves comands as null to request from server
+                Commands = new Command[0];
+
             buffer.Write((UInt16)Commands.Length);
             foreach (var command in Commands)
             {

--- a/SS14.Shared/Network/NetManager.cs
+++ b/SS14.Shared/Network/NetManager.cs
@@ -359,9 +359,9 @@ namespace SS14.Shared.Network
             {
                 instance.ReadFromBuffer(msg);
             }
-            catch (NetException e)
+            catch (Exception e) // yes, we want to catch ALL exeptions for security
             {
-                Logger.Warning($"[NET] {address}: Failed to deserialize packet: {e.Message}");
+                Logger.Warning($"[NET] {address}: Failed to deserialize {packetType.Name} packet: {e.Message}");
             }
 
             if (!_callbacks.TryGetValue(packetType, out ProcessMessage callback))


### PR DESCRIPTION
Solves issues in https://github.com/space-wizards/space-station-14/issues/442.

The first issues was that the `Commands` array was not being allocated before use, causing the NullRefException in release mode. The second issue was that the client was using the old network message system, and sending malformed packets, causing the buffer overrun that the server was properly catching and logging.