### PR TITLE
Wraps missing members of SFML's Font and Glyph types.

### DIFF
--- a/SS14.Client.Graphics/Sprites/Font.cs
+++ b/SS14.Client.Graphics/Sprites/Font.cs
@@ -1,5 +1,8 @@
-using System;
+﻿using System;
 using System.IO;
+using OpenTK;
+using SFML.Graphics;
+using SS14.Shared.Maths;
 using SFont = SFML.Graphics.Font;
 
 namespace SS14.Client.Graphics.Sprites
@@ -7,6 +10,72 @@ namespace SS14.Client.Graphics.Sprites
     public class Font : IDisposable
     {
         public readonly SFont SFMLFont;
+
+        /// <summary>
+        /// Get a glyph in the font
+        /// </summary>
+        /// <param name="codePoint">Unicode code point of the character to get</param>
+        /// <param name="characterSize">Character size</param>
+        /// <param name="bold">Retrieve the bold version or the regular one?</param>
+        /// <param name="outlineThickness">Thickness of outline (when != 0 the glyph will not be filled)</param>
+        /// <returns>The glyph corresponding to the character</returns>
+        public Glyph GetGlyph(uint codePoint, uint characterSize, bool bold, float outlineThickness)
+        {
+            return new Glyph(SFMLFont.GetGlyph(codePoint, characterSize, bold, outlineThickness));
+        }
+
+        /// <summary>
+        /// Get the kerning offset between two glyphs
+        /// </summary>
+        /// <param name="first">Unicode code point of the first character</param>
+        /// <param name="second">Unicode code point of the second character</param>
+        /// <param name="characterSize">Character size</param>
+        /// <returns>Kerning offset, in pixels</returns>
+        public float GetKerning(uint first, uint second, uint characterSize)
+        {
+            return SFMLFont.GetKerning(first, second, characterSize);
+        }
+
+        /// <summary>
+        /// Get spacing between two consecutive lines
+        /// </summary>
+        /// <param name="characterSize">Character size</param>
+        /// <returns>Line spacing, in pixels</returns>
+        public float GetLineSpacing(uint characterSize)
+        {
+            return SFMLFont.GetLineSpacing(characterSize);
+        }
+
+        /// <summary>
+        /// Get the position of the underline
+        /// </summary>
+        /// <param name="characterSize">Character size</param>
+        /// <returns>Underline position, in pixels</returns>
+        public float GetUnderlinePosition(uint characterSize)
+        {
+            return SFMLFont.GetUnderlinePosition(characterSize);
+        }
+
+        /// <summary>
+        /// Get the thickness of the underline
+        /// </summary>
+        /// <param name="characterSize">Character size</param>
+        /// <returns>Underline thickness, in pixels</returns>
+        public float GetUnderlineThickness(uint characterSize)
+        {
+            return SFMLFont.GetUnderlineThickness(characterSize);
+        }
+
+        /// <summary>
+        /// Get the texture containing the glyphs of a given size
+        /// </summary>
+        /// <param name="characterSize">Character size</param>
+        /// <returns>Texture storing the glyphs for the given size</returns>
+        public Textures.Texture GetTexture(uint characterSize)
+        {
+            var texture = SFMLFont.GetTexture(characterSize);
+            return new Textures.Texture(texture);
+        }
 
         internal Font(SFont font)
         {
@@ -38,5 +107,41 @@ namespace SS14.Client.Graphics.Sprites
         public void Dispose() => SFMLFont.Dispose();
 
         public string Family => SFMLFont.GetInfo().Family;
+    }
+
+    /// <summary>
+    /// Structure describing a glyph (a visual character)
+    /// </summary>
+    public struct Glyph
+    {
+        private SFML.Graphics.Glyph _glyph;
+
+        /// <summary>Offset to move horizontally to the next character</summary>
+        public float Advance => _glyph.Advance;
+
+        /// <summary>Bounding rectangle of the glyph, in coordinates relative to the baseline</summary>
+        public Box2 Bounds
+        {
+            get
+            {
+                var bounds = _glyph.Bounds;
+                return Box2.FromDimensions(0, 0, bounds.Width, bounds.Height);
+            }
+        }
+
+        /// <summary>Texture coordinates of the glyph inside the font's texture</summary>
+        public Box2i TextureRect
+        {
+            get
+            {
+                var rect = _glyph.TextureRect;
+                return Box2i.FromDimensions(0, 0, rect.Width, rect.Height);
+            }
+        }
+
+        internal Glyph(SFML.Graphics.Glyph glyph)
+        {
+            _glyph = glyph;
+        }
     }
 }

--- a/SpaceStation14.sln
+++ b/SpaceStation14.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
+VisualStudioVersion = 15.0.27004.2005
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lidgren.Network", "Lidgren.Network\Lidgren.Network.csproj", "{59250BAF-0000-0000-0000-000000000000}"
 EndProject
@@ -123,6 +123,9 @@ Global
 		{31D24303-F6A9-4D53-BB03-A73EDCB3186D} = {600F7C3B-7142-4EEF-BE13-824BC4548D0D}
 		{D17DE83D-A592-461F-8AF2-53F9E22E1D0F} = {600F7C3B-7142-4EEF-BE13-824BC4548D0D}
 		{46786269-57B9-48E7-AA4F-8F4D84609FE6} = {600F7C3B-7142-4EEF-BE13-824BC4548D0D}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {57757344-0FF4-4842-8A68-141CAA18A35D}
 	EndGlobalSection
 	GlobalSection(Performance) = preSolution
 		HasPerformanceSessions = true


### PR DESCRIPTION
Wraps SFML.Graphics.Glyph struct, and adds the rest of the SFML.Graphics.Font functions to the existing wrapper.