### PR TITLE
ResourceManager Config Directory

### DIFF
--- a/SS14.Shared/ContentPack/ResourceManager.cs
+++ b/SS14.Shared/ContentPack/ResourceManager.cs
@@ -15,14 +15,26 @@ namespace SS14.Shared.ContentPack
     /// </summary>
     public class ResourceManager : IResourceManager
     {
-        [Dependency] private readonly IConfigurationManager _config;
+        private const string DataFolderName = "Space Station 14";
 
+        [Dependency]
+        private readonly IConfigurationManager _config;
+
+        private DirectoryInfo _configRoot;
         private readonly List<IContentRoot> _contentRoots = new List<IContentRoot>();
+
+        /// <inheritdoc />
+        public string ConfigDirectory => _configRoot.FullName;
 
         /// <inheritdoc />
         public void Initialize()
         {
             _config.RegisterCVar("resource.pack", "ResourcePack.zip", CVar.ARCHIVE);
+
+            var configRoot = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            configRoot = Path.Combine(configRoot, DataFolderName);
+            configRoot = Path.GetFullPath(configRoot);
+            _configRoot = Directory.CreateDirectory(configRoot);
         }
 
         /// <inheritdoc />
@@ -103,7 +115,7 @@ namespace SS14.Shared.ContentPack
         }
 
         /// <inheritdoc />
-        public IEnumerable<string> FindFiles(string path)
+        public IEnumerable<string> ContentFindFiles(string path)
         {
             // some LINQ magic
             return _contentRoots

--- a/SS14.Shared/Interfaces/IResourceManager.cs
+++ b/SS14.Shared/Interfaces/IResourceManager.cs
@@ -59,6 +59,12 @@ namespace SS14.Shared.Interfaces
         /// </summary>
         /// <param name="path">Directory to search inside of.</param>
         /// <returns>Enumeration of all relative file paths of the files found.</returns>
-        IEnumerable<string> FindFiles(string path);
+        IEnumerable<string> ContentFindFiles(string path);
+
+        /// <summary>
+        ///     Absolute path to the configuration directory for the game. If you are writing any files,
+        ///     they need to be inside of this directory.
+        /// </summary>
+        string ConfigDirectory { get; }
     }
 }

--- a/SS14.Shared/Prototypes/PrototypeManager.cs
+++ b/SS14.Shared/Prototypes/PrototypeManager.cs
@@ -176,7 +176,7 @@ namespace SS14.Shared.Prototypes
         /// <inheritdoc />
         public void LoadDirectory(string path)
         {
-            foreach (var filePath in _resources.FindFiles(path))
+            foreach (var filePath in _resources.ContentFindFiles(path))
             {
                 using (var reader = new StreamReader(_resources.ContentFileRead(filePath), Encoding.UTF8))
                 {


### PR DESCRIPTION
Giving permission to the game to write to the location it is installed at is a bad idea. The Resource manager now provides a path to a safe place to write all your user data and config files. This PR does not set up a API for content, I want to wait until we have map loading/saving and a resource pack cache fully working before a directory structure and Read/Write locations are enforced.