### PR TITLE
Fixes appveyor clone

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,12 +10,10 @@ pull_requests:
   do_not_increment_build_number: true
 
 image: Visual Studio 2017
-clone_depth: 10
 install:
 - ps: if (-Not $env:APPVEYOR_PULL_REQUEST_NUMBER) { cinst msbuild-sonarqube-runner }
 
 before_build:
-- cmd: git fetch --unshallow
 - cmd: py -3.5 RUN_THIS.py --no-prompt
 - cmd: py -3.5 Resources\buildResourcePack.py --resources-dir .\Resources --out .\Resources\ResourcePack.zip --atlas-tool .\Tools\AtlasTool.exe --no-animations --to-stderr
 - cmd: nuget restore SpaceStation14.sln


### PR DESCRIPTION
GitHub absolutely despises it when you shallow clone then fetch. See here: https://github.com/cocoapods/cocoapods/issues/4989