### PR TITLE
IMap Serialization

### DIFF
--- a/SS14.Server/Interfaces/Maps/IMapLoader.cs
+++ b/SS14.Server/Interfaces/Maps/IMapLoader.cs
@@ -7,5 +7,8 @@ namespace SS14.Server.Interfaces.Maps
     {
         void LoadBlueprint(IMap map, GridId newId, string path);
         void SaveBlueprint(IMap map, GridId gridId, string yamlPath);
+
+        void LoadMap(MapId mapId, string path);
+        void SaveMap(IMap map, string yamlPath);
     }
 }

--- a/SS14.Server/Maps/MapLoader.cs
+++ b/SS14.Server/Maps/MapLoader.cs
@@ -18,6 +18,8 @@ namespace SS14.Server.Maps
     /// </summary>
     public class MapLoader : IMapLoader
     {
+        private const int MapFormatVersion = 1;
+
         [Dependency]
         private IResourceManager _resMan;
 
@@ -26,21 +28,13 @@ namespace SS14.Server.Maps
 
         [Dependency]
         private IPrototypeManager _protoMan;
-        
+
         /// <inheritdoc />
         public void SaveBlueprint(IMap map, GridId gridId, string yamlPath)
         {
             var grid = map.GetGrid(gridId);
 
-            var root = new YamlSequenceNode();
-
-            var node = YamlGridSerializer.SerializeGrid(grid);
-            root.Add(node);
-
-            var entMan = IoCManager.Resolve<IServerEntityManager>();
-            var ents = new YamlEntitySerializer();
-            entMan.SaveGridEntities(ents, gridId);
-            root.Add(ents.GetRootNode());
+            var root = SaveBpNode(grid);
 
             var document = new YamlDocument(root);
 
@@ -64,7 +58,7 @@ namespace SS14.Server.Maps
         public void LoadBlueprint(IMap map, GridId newId, string path)
         {
             var rootPath = _resMan.ConfigDirectory;
-            var comb = Path.Combine(rootPath,"./" , path);
+            var comb = Path.Combine(rootPath, "./", path);
             var fullPath = Path.GetFullPath(comb);
 
             TextReader reader;
@@ -90,30 +84,145 @@ namespace SS14.Server.Maps
                 reader = new StreamReader(fullPath);
             }
 
-            Logger.Info($"[MAP] Loading Grid: {path}");
-
-            var stream = new YamlStream();
-            stream.Load(reader);
-
-            foreach (var document in stream.Documents)
+            using (reader)
             {
-                LoadBpDocument(map, newId, document);
+                Logger.Info($"[MAP] Loading Grid: {path}");
+
+                var stream = new YamlStream();
+                stream.Load(reader);
+
+                foreach (var document in stream.Documents)
+                {
+                    var root = (YamlSequenceNode) document.RootNode;
+                    LoadBpNode(map, newId, root);
+                }
             }
         }
 
-        private void LoadBpDocument(IMap map, GridId newId, YamlDocument document)
+        /// <inheritdoc />
+        public void SaveMap(IMap map, string yamlPath)
         {
-            var root = (YamlSequenceNode) document.RootNode;
+            var root = new YamlMappingNode();
 
+            root.Add("format", MapFormatVersion.ToString());
+            root.Add("name", "DemoStation");
+            root.Add("author", "Space-Wizards");
+
+            // save grids
+            var gridMap = new YamlMappingNode();
+            root.Add("grids", gridMap);
+
+            foreach (var grid in map.GetAllGrids())
+            {
+                var gridBpNode = SaveBpNode(grid);
+                gridMap.Add(grid.Index.ToString(), gridBpNode);
+            }
+
+            var document = new YamlDocument(root);
+
+            var rootPath = _resMan.ConfigDirectory;
+            var path = Path.Combine(rootPath, "./", yamlPath);
+            var fullPath = Path.GetFullPath(path);
+
+            var dir = Path.GetDirectoryName(fullPath);
+            Directory.CreateDirectory(dir ?? throw new InvalidOperationException("Full YamlPath was null."));
+
+            using (var writer = new StreamWriter(fullPath))
+            {
+                var stream = new YamlStream();
+
+                stream.Add(document);
+                stream.Save(writer);
+            }
+        }
+
+        /// <inheritdoc />
+        public void LoadMap(MapId mapId, string path)
+        {
+            var rootPath = _resMan.ConfigDirectory;
+            var comb = Path.Combine(rootPath, "./", path);
+            var fullPath = Path.GetFullPath(comb);
+
+            TextReader reader;
+
+            // try user
+            if (!File.Exists(fullPath))
+            {
+                Logger.Info($"[MAP] No user blueprint found: {fullPath}");
+
+                // fallback to content
+                if (_resMan.TryContentFileRead(path, out var contentReader))
+                {
+                    reader = new StreamReader(contentReader);
+                }
+                else
+                {
+                    Logger.Error($"[MAP] No blueprint found: {path}");
+                    return;
+                }
+            }
+            else
+            {
+                reader = new StreamReader(fullPath);
+            }
+
+            using (reader)
+            {
+                Logger.Info($"[MAP] Loading Map: {path}");
+
+                var stream = new YamlStream();
+                stream.Load(reader);
+
+                foreach (var document in stream.Documents)
+                {
+                    var root = (YamlMappingNode)document.RootNode;
+                    var map = IoCManager.Resolve<IMapManager>().CreateMap(mapId);
+                    LoadMapNode(map, root);
+                }
+            }
+        }
+
+        private static YamlSequenceNode SaveBpNode(IMapGrid grid)
+        {
+            var root = new YamlSequenceNode();
+
+            var node = YamlGridSerializer.SerializeGrid(grid);
+            root.Add(node);
+
+            var entMan = IoCManager.Resolve<IServerEntityManager>();
+            var ents = new YamlEntitySerializer();
+            entMan.SaveGridEntities(ents, grid.Index);
+            root.Add(ents.GetRootNode());
+            return root;
+        }
+
+        private void LoadMapNode(IMap map, YamlMappingNode rootNode)
+        {
+            var gridSeq = (YamlMappingNode)rootNode["grids"];
+
+            foreach (var kvGrid in gridSeq)
+            {
+                var gridId = int.Parse(kvGrid.Key.ToString());
+                var gridNode = (YamlSequenceNode)kvGrid.Value;
+
+                LoadBpNode(map, new GridId(gridId), gridNode);
+            }
+        }
+
+        private void LoadBpNode(IMap map, GridId newId, YamlSequenceNode root)
+        {
             foreach (var yamlNode in root.Children)
             {
                 var mapNode = (YamlMappingNode) yamlNode;
 
                 if (mapNode.Children.TryGetValue("grid", out var gridNode))
                 {
+                    // default grid always exists, and cannot be modified, no point loading it
+                    if(newId == GridId.DefaultGrid)
+                        continue;
+
                     var gridMap = (YamlMappingNode) gridNode;
                     LoadGridNode(map, newId, gridMap);
-                    
                 }
                 else if (mapNode.Children.TryGetValue("entities", out var entNode))
                 {
@@ -124,18 +233,18 @@ namespace SS14.Server.Maps
 
         private static void LoadGridNode(IMap map, GridId newId, YamlMappingNode gridNode)
         {
-                var info = (YamlMappingNode)gridNode["settings"];
-                var chunk = (YamlSequenceNode)gridNode["chunks"];
+            var info = (YamlMappingNode) gridNode["settings"];
+            var chunk = (YamlSequenceNode) gridNode["chunks"];
 
-                YamlGridSerializer.DeserializeGrid(map, newId, info, chunk);
+            YamlGridSerializer.DeserializeGrid(map, newId, info, chunk);
         }
 
         private void LoadEntNode(IMap map, GridId gridId, YamlSequenceNode entNode)
         {
             foreach (var yamlNode in entNode.Children)
             {
-                var yamlEnt = (YamlMappingNode)yamlNode;
-                
+                var yamlEnt = (YamlMappingNode) yamlNode;
+
                 var protoName = yamlEnt["id"].ToString();
                 var entity = _entityMan.SpawnEntity(protoName);
 

--- a/SS14.Server/ServerConsole/Commands/MapCommands.cs
+++ b/SS14.Server/ServerConsole/Commands/MapCommands.cs
@@ -26,6 +26,10 @@ namespace SS14.Server.ServerConsole.Commands
             var mapID = new MapId(intMapId);
             var gridId = new GridId(intGridId);
 
+            // no saving null space
+            if(mapID == MapId.Nullspace)
+                return;
+
             // no saving default grid
             if (gridId == GridId.DefaultGrid)
                 return;
@@ -48,9 +52,68 @@ namespace SS14.Server.ServerConsole.Commands
         public string Command => "loadbp";
         public string Description => "Loads a blueprint from disk into the game.";
         public string Help => "loadbp <MapID> <GridID> <Path>";
+
         public void Execute(params string[] args)
         {
             //TODO: Make me work after placement can create new grids.
+        }
+    }
+
+    public class SaveMap : IConsoleCommand
+    {
+        public string Command => "savemap";
+        public string Description => "Serializes a map to disk.";
+        public string Help => "savemap <MapID> <Path>";
+
+        public void Execute(params string[] args)
+        {
+            if (args.Length < 1)
+                return;
+
+            if (!int.TryParse(args[0], out var intMapId))
+                return;
+
+            var mapID = new MapId(intMapId);
+
+            // no saving null space
+            if (mapID == MapId.Nullspace)
+                return;
+
+            var mapManager = IoCManager.Resolve<IMapManager>();
+            if (!mapManager.TryGetMap(mapID, out var map))
+                return;
+
+            // TODO: Parse path
+            IoCManager.Resolve<IMapLoader>().SaveMap(map, "Maps/Demo/DemoMap.yaml");
+        }
+    }
+
+    public class LoadMap : IConsoleCommand
+    {
+        public string Command => "loadmap";
+        public string Description => "Loads a map from disk into the game.";
+        public string Help => "loadmap <MapID> <Path>";
+
+        public void Execute(params string[] args)
+        {
+            if (args.Length < 1)
+                return;
+
+            if (!int.TryParse(args[0], out var intMapId))
+                return;
+
+            var mapID = new MapId(intMapId);
+
+            // no loading null space
+            if (mapID == MapId.Nullspace)
+                return;
+
+            var mapManager = IoCManager.Resolve<IMapManager>();
+            if(mapManager.MapExists(mapID))
+                return;
+
+            // TODO: Parse path
+            IoCManager.Resolve<IMapLoader>().LoadMap(mapID, "Maps/Demo/DemoMap.yaml");
         }
     }
 }

--- a/SS14.Shared/GameObjects/Serialization/YamlEntitySerializer.cs
+++ b/SS14.Shared/GameObjects/Serialization/YamlEntitySerializer.cs
@@ -15,11 +15,12 @@ namespace SS14.Shared.GameObjects.Serialization
     {
         private static readonly Dictionary<Type, TypeSerializer> _typeSerializers;
         private static readonly StructSerializer _structSerializer;
-        
+
+        private bool _setDefaults;
+
         private readonly YamlSequenceNode _root;
         private YamlMappingNode _entMap;
         private YamlSequenceNode _compSeq;
-
         private YamlMappingNode _curMap;
 
         static YamlEntitySerializer()
@@ -40,10 +41,11 @@ namespace SS14.Shared.GameObjects.Serialization
             _root = new YamlSequenceNode();
         }
 
-        public YamlEntitySerializer(YamlMappingNode entMap)
+        public YamlEntitySerializer(YamlMappingNode entMap, bool setDefaults = true)
         {
             Reading = true;
             _curMap = entMap;
+            _setDefaults = setDefaults;
         }
         
         public override void EntityHeader()
@@ -103,7 +105,7 @@ namespace SS14.Shared.GameObjects.Serialization
                 {
                     value = (T)NodeToType(typeof(T), node);
                 }
-                else
+                else if(_setDefaults)
                 {
                     value = defaultValue;
                 }
@@ -263,7 +265,7 @@ namespace SS14.Shared.GameObjects.Serialization
             hexColor += color.BByte << 8;
             hexColor += color.AByte;
 
-            return new YamlScalarNode(hexColor.ToString("X"));
+            return new YamlScalarNode("#" + hexColor.ToString("X"));
         }
     }
 

--- a/SS14.Shared/Prototypes/PrototypeManager.cs
+++ b/SS14.Shared/Prototypes/PrototypeManager.cs
@@ -135,7 +135,7 @@ namespace SS14.Shared.Prototypes
         public void LoadData(IEntity entity, YamlMappingNode node)
         {
             var ent = entity as Entity;
-            ent.ExposeData(new YamlEntitySerializer(node));
+            ent.ExposeData(new YamlEntitySerializer(node, false));
         }
 
         public void Resync()


### PR DESCRIPTION
You can now save/load full maps. A map is pretty much a collection of blueprints and some meta data. Server concmds for save/load map have been added.

Entity serializers now have an optional constructor arg for preventing the default value to be written to a field if the node is not found. This allows you to call ExposeData multiple times without overwriting the default prototype values.

Color custom serializer hex values were fixed.

This PR resolves #194 
This PR resolves #512 