### PR TITLE
GameLoop Refactor

### DIFF
--- a/SS14.Server/BaseServer.cs
+++ b/SS14.Server/BaseServer.cs
@@ -36,6 +36,7 @@ using SS14.Server.Interfaces.Maps;
 using SS14.Server.Player;
 using SS14.Shared.Enums;
 using SS14.Shared.Reflection;
+using SS14.Shared.Timing;
 
 namespace SS14.Server
 {
@@ -69,7 +70,7 @@ namespace SS14.Server
         [Dependency]
         private readonly IGameStateManager _stateManager;
 
-        private bool _active;
+        private GameLoop _mainLoop;
         private ServerRunLevel _runLevel;
 
         private TimeSpan _lastTitleUpdate;
@@ -118,7 +119,8 @@ namespace SS14.Server
                 Logger.Log("[SRV] Shutting down...");
             else
                 Logger.Log($"[SRV] {reason}, shutting down...");
-            _active = false;
+
+            _mainLoop.Running = false;
         }
 
         /// <inheritdoc />
@@ -216,8 +218,7 @@ namespace SS14.Server
             consoleManager.Initialize();
 
             OnRunLevelChanged(ServerRunLevel.PreGame);
-
-            _active = true;
+            
             return false;
         }
 
@@ -227,80 +228,33 @@ namespace SS14.Server
         /// <inheritdoc />
         public void MainLoop()
         {
-            // maximum number of ticks to queue before the loop slows down.
-            const int maxTicks = 5;
+            _mainLoop = new GameLoop(_time);
+            _mainLoop.SleepMode = SleepMode.Delay;
 
-            _time.ResetRealTime();
-            var maxTime = TimeSpan.FromTicks(_time.TickPeriod.Ticks * maxTicks);
+            _mainLoop.Tick += (sender, args) => Update(args.DeltaSeconds);
 
-            while (_active)
-            {
-                var accumulator = _time.RealTime - _lastTick;
-
-                // If the game can't keep up, limit time.
-                if (accumulator > maxTime)
-                {
-                    // limit accumulator to max time.
-                    accumulator = maxTime;
-
-                    // pull lastTick up to the current realTime
-                    // This will slow down the simulation, but if we are behind from a
-                    // lag spike hopefully it will be able to catch up.
-                    _lastTick = _time.RealTime - maxTime;
-
-                    // announce we are falling behind
-                    if ((_time.RealTime - _lastKeepUpAnnounce).TotalSeconds >= 15.0)
-                    {
-                        Logger.Warning("[SRV] MainLoop: Cannot keep up!");
-                        _lastKeepUpAnnounce = _time.RealTime;
-                    }
-                }
-
-                // process the CLI console of the program
-                IoCManager.Resolve<IConsoleManager>().Update();
-
-                _time.InSimulation = true;
-
-                // run the simulation for every accumulated tick
-                while (accumulator >= _time.TickPeriod)
-                {
-                    accumulator -= _time.TickPeriod;
-                    _lastTick += _time.TickPeriod;
-                    _time.StartFrame();
-
-                    // only run the sim if unpaused, but still use up the accumulated time
-                    if (!_time.Paused)
-                    {
-                        Update((float)_time.FrameTime.TotalSeconds);
-                        _time.CurTick++;
-                    }
-                }
-
-                // if not paused, save how far between ticks we are so interpolation works
-                if (!_time.Paused)
-                    _time.TickRemainder = accumulator;
-
-                _time.InSimulation = false;
-
-                // every 1 second update stats in the console window title
-                if ((_time.RealTime - _lastTitleUpdate).TotalSeconds > 1.0)
-                {
-                    var netStats = UpdateBps();
-                    Console.Title = string.Format("FPS: {0:N2} SD:{1:N2}ms | Net: ({2}) | Memory: {3:N0} KiB",
-                        Math.Round(_time.FramesPerSecondAvg, 2),
-                        _time.RealFrameTimeStdDev.TotalMilliseconds,
-                        netStats,
-                        Process.GetCurrentProcess().PrivateMemorySize64 >> 10);
-                    _lastTitleUpdate = _time.RealTime;
-                }
-                
-                // Set this to 1 if you want to be nice and give the rest of the timeslice up to the os scheduler.
-                // Set this to 0 if you want to use 100% cpu, but still cooperate with the scheduler.
-                // comment this out if you want to be 'that thread' and hog 100% cpu.
-                Thread.Sleep(1);
-            }
+            // set GameLoop.Running to false to return from this function.
+            _mainLoop.Run();
 
             Cleanup();
+        }
+
+        /// <summary>
+        ///     Updates the console window title with performance statistics.
+        /// </summary>
+        private void UpdateTitle()
+        {
+            // every 1 second update stats in the console window title
+            if ((_time.RealTime - _lastTitleUpdate).TotalSeconds < 1.0)
+                return;
+
+            var netStats = UpdateBps();
+            Console.Title = string.Format("FPS: {0:N2} SD: {1:N2}ms | Net: ({2}) | Memory: {3:N0} KiB",
+                Math.Round(_time.FramesPerSecondAvg, 2),
+                _time.RealFrameTimeStdDev.TotalMilliseconds,
+                netStats,
+                Process.GetCurrentProcess().PrivateMemorySize64 >> 10);
+            _lastTitleUpdate = _time.RealTime;
         }
 
         /// <summary>
@@ -381,6 +335,8 @@ namespace SS14.Server
 
         private void Update(float frameTime)
         {
+            UpdateTitle();
+
             IoCManager.Resolve<IServerNetManager>().ProcessPackets();
 
             AssemblyLoader.BroadcastUpdate(AssemblyLoader.UpdateLevel.PreEngine, frameTime);

--- a/SS14.Shared/Interfaces/Timing/IGameTiming.cs
+++ b/SS14.Shared/Interfaces/Timing/IGameTiming.cs
@@ -16,13 +16,7 @@ namespace SS14.Shared.Interfaces.Timing
         ///     Is the simulation currently paused?
         /// </summary>
         bool Paused { get; set; }
-
-        /// <summary>
-        ///     How fast time passes in the simulation compared to RealTime. 1.0 = 100%, 0.25 = 25% (slow mo).
-        ///     Minimum timescale is 0.1, max is 2.0.
-        /// </summary>
-        double TimeScale { get; set; }
-
+        
         /// <summary>
         ///     The current synchronized uptime of the simulation. Use this for in-game timing. This can be rewound for
         ///     prediction, and is affected by Paused and TimeScale.

--- a/SS14.Shared/Properties/AssemblyInfo.cs
+++ b/SS14.Shared/Properties/AssemblyInfo.cs
@@ -40,7 +40,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("0.1")]
 
 // The following allows another friend assembly access to the types marked as internal.
-#if DEBUG
 [assembly: InternalsVisibleTo("SS14.UnitTesting")] // Gives access to Unit test project
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")] // Gives access to Castle(Moq)
-#endif

--- a/SS14.Shared/Properties/AssemblyInfo.cs
+++ b/SS14.Shared/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-using System.Reflection;
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -37,3 +38,9 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("0.1.*")]
 [assembly: AssemblyFileVersion("0.1")]
+
+// The following allows another friend assembly access to the types marked as internal.
+#if DEBUG
+[assembly: InternalsVisibleTo("SS14.UnitTesting")] // Gives access to Unit test project
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")] // Gives access to Castle(Moq)
+#endif

--- a/SS14.Shared/SS14.Shared.csproj
+++ b/SS14.Shared/SS14.Shared.csproj
@@ -240,6 +240,8 @@
     <Compile Include="Input\KeyFunctions.cs" />
     <Compile Include="Physics\RayCastResults.cs" />
     <Compile Include="Players\PlayerIndex.cs" />
+    <Compile Include="Timing\FrameEventArgs.cs" />
+    <Compile Include="Timing\GameLoop.cs" />
     <Compile Include="Timing\IStopwatch.cs" />
     <Compile Include="Timing\Stopwatch.cs" />
     <Compile Include="Utility\QuadTree.cs" />

--- a/SS14.Shared/SS14.Shared.csproj
+++ b/SS14.Shared/SS14.Shared.csproj
@@ -240,6 +240,8 @@
     <Compile Include="Input\KeyFunctions.cs" />
     <Compile Include="Physics\RayCastResults.cs" />
     <Compile Include="Players\PlayerIndex.cs" />
+    <Compile Include="Timing\IStopwatch.cs" />
+    <Compile Include="Timing\Stopwatch.cs" />
     <Compile Include="Utility\QuadTree.cs" />
     <Compile Include="Reflection\ReflectAttribute.cs" />
     <Compile Include="Serialization\NetSerializableAttribute.cs" />

--- a/SS14.Shared/Timing/FrameEventArgs.cs
+++ b/SS14.Shared/Timing/FrameEventArgs.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+namespace SS14.Shared.Timing
+{
+    /// <summary>
+    ///     Arguments of the GameLoop frame event.
+    /// </summary>
+    public class FrameEventArgs : EventArgs
+    {
+        /// <summary>
+        ///     Seconds passed since this event was last called.
+        /// </summary>
+        public float DeltaSeconds { get; protected set; }
+
+        /// <summary>
+        ///     Constructs an instance of this object.
+        /// </summary>
+        /// <param name="deltaSeconds">Seconds passed since this event was last called.</param>
+        public FrameEventArgs(float deltaSeconds)
+        {
+            DeltaSeconds = deltaSeconds;
+        }
+    }
+
+    /// <summary>
+    ///     A mutable version of <see cref="FrameEventArgs"/>.
+    /// </summary>
+    internal class MutableFrameEventArgs : FrameEventArgs
+    {
+        /// <summary>
+        ///     Constructs an instance of this object.
+        /// </summary>
+        /// <param name="deltaSeconds">Seconds passed since this event was last called.</param>
+        public MutableFrameEventArgs(float deltaSeconds)
+            : base(deltaSeconds) { }
+
+        /// <summary>
+        ///     Sets the seconds passed since this event was last called.
+        /// </summary>
+        public void SetDeltaSeconds(float seconds)
+        {
+            DeltaSeconds = seconds;
+        }
+    }
+}

--- a/SS14.Shared/Timing/GameLoop.cs
+++ b/SS14.Shared/Timing/GameLoop.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using SS14.Shared.Interfaces.Timing;
+using SS14.Shared.Log;
+
+namespace SS14.Shared.Timing
+{
+    /// <summary>
+    ///     Manages the main game loop for a GameContainer.
+    /// </summary>
+    public class GameLoop
+    {
+        private readonly IGameTiming _timing;
+        private TimeSpan _lastTick; // last wall time tick
+        private TimeSpan _lastKeepUp; // last wall time keep up announcement
+
+        public event EventHandler<FrameEventArgs> Input;
+        public event EventHandler<FrameEventArgs> Tick;
+        public event EventHandler<FrameEventArgs> Update;
+        public event EventHandler<FrameEventArgs> Render;
+
+        public bool SingleStep { get; set; } = false;
+        public bool Running { get; set; }
+        public int MaxQueuedTicks { get; set; } = 5;
+
+        public GameLoop(IGameTiming timing)
+        {
+            _timing = timing;
+        }
+
+        public void Run()
+        {
+            if(_timing.TickRate <= 0)
+                throw new InvalidOperationException("TickRate must be greater than 0.");
+
+            Running = true;
+
+            // maximum number of ticks to queue before the loop slows down.
+            _timing.ResetRealTime();
+            var maxTime = TimeSpan.FromTicks(_timing.TickPeriod.Ticks * MaxQueuedTicks);
+
+            var realFrameEvent = new MutableFrameEventArgs(0);
+            var simFrameEvent = new MutableFrameEventArgs(0);
+
+            while (Running)
+            {
+                var accumulator = _timing.RealTime - _lastTick;
+
+                // If the game can't keep up, limit time.
+                if (accumulator > maxTime)
+                {
+                    // limit accumulator to max time.
+                    accumulator = maxTime;
+
+                    // pull lastTick up to the current realTime
+                    // This will slow down the simulation, but if we are behind from a
+                    // lag spike hopefully it will be able to catch up.
+                    _lastTick = _timing.RealTime - maxTime;
+
+                    // announce we are falling behind
+                    if ((_timing.RealTime - _lastKeepUp).TotalSeconds >= 15.0)
+                    {
+                        Logger.Warning("[ENG] MainLoop: Cannot keep up!");
+                        _lastKeepUp = _timing.RealTime;
+                    }
+                }
+                _timing.StartFrame();
+                
+                realFrameEvent.SetDeltaSeconds((float)_timing.RealFrameTime.TotalSeconds);
+
+                // process Net/KB/Mouse input
+                Input?.Invoke(this, realFrameEvent);
+
+                _timing.InSimulation = true;
+
+                // run the simulation for every accumulated tick
+                while (accumulator >= _timing.TickPeriod)
+                {
+                    accumulator -= _timing.TickPeriod;
+                    _lastTick += _timing.TickPeriod;
+
+                    // only run the simulation if unpaused, but still use up the accumulated time
+                    if (_timing.Paused)
+                        continue;
+
+                    // update the simulation
+                    simFrameEvent.SetDeltaSeconds((float)_timing.FrameTime.TotalSeconds);
+                    Tick?.Invoke(this, simFrameEvent);
+                    _timing.CurTick++;
+
+                    if (SingleStep)
+                        _timing.Paused = true;
+                }
+
+                // if not paused, save how close to the next tick we are so interpolation works
+                if (!_timing.Paused)
+                    _timing.TickRemainder = accumulator;
+
+                _timing.InSimulation = false;
+
+                // update out of the simulation
+                simFrameEvent.SetDeltaSeconds((float)_timing.FrameTime.TotalSeconds);
+                Update?.Invoke(this, simFrameEvent);
+
+                // render the simulation
+                Render?.Invoke(this, realFrameEvent);
+            }
+        }
+    }
+}

--- a/SS14.Shared/Timing/GameLoop.cs
+++ b/SS14.Shared/Timing/GameLoop.cs
@@ -57,11 +57,12 @@ namespace SS14.Shared.Timing
             Running = true;
 
             // maximum number of ticks to queue before the loop slows down.
-            _timing.ResetRealTime();
             var maxTime = TimeSpan.FromTicks(_timing.TickPeriod.Ticks * MaxQueuedTicks);
 
             var realFrameEvent = new MutableFrameEventArgs(0);
             var simFrameEvent = new MutableFrameEventArgs(0);
+
+            _timing.ResetRealTime();
 
             while (Running)
             {

--- a/SS14.Shared/Timing/GameTiming.cs
+++ b/SS14.Shared/Timing/GameTiming.cs
@@ -38,22 +38,22 @@ namespace SS14.Shared.Timing
         ///     Is the simulation currently paused?
         /// </summary>
         public bool Paused { get; set; }
-        
+
         /// <summary>
         ///     The current synchronized uptime of the simulation. Use this for in-game timing. This can be rewound for
         ///     prediction, and is affected by Paused and TimeScale.
         /// </summary>
-        public TimeSpan CurTime { get; private set; }
+        public TimeSpan CurTime => CalcCurTime();
 
         /// <summary>
         ///     The current real uptime of the simulation. Use this for UI and out of game timing.
         /// </summary>
         public TimeSpan RealTime => _realTimer.Elapsed;
-        
+
         /// <summary>
         ///     The simulated time it took to render the last frame.
         /// </summary>
-        public TimeSpan FrameTime { get; private set; }
+        public TimeSpan FrameTime => CalcFrameTime();
 
         /// <summary>
         ///     The real time it took to render the last frame.
@@ -109,22 +109,29 @@ namespace SS14.Shared.Timing
             if (_realFrameTimes.Count >= NumFrames)
                 _realFrameTimes.RemoveAt(0);
             _realFrameTimes.Add(RealFrameTime.Ticks);
+        }
 
+        private TimeSpan CalcFrameTime()
+        {
             // calculate simulation FrameTime
             if (InSimulation)
             {
-                FrameTime = TimeSpan.FromTicks(TickPeriod.Ticks);
+                return TimeSpan.FromTicks(TickPeriod.Ticks);
             }
             else
             {
-                FrameTime = Paused ? TimeSpan.Zero : RealFrameTime;
+                return Paused ? TimeSpan.Zero : RealFrameTime;
             }
+        }
 
+        private TimeSpan CalcCurTime()
+        {
             // calculate simulation CurTime
-            CurTime = TimeSpan.FromTicks(TickPeriod.Ticks * CurTick);
+            var time = TimeSpan.FromTicks(TickPeriod.Ticks * CurTick);
 
             if (!InSimulation) // rendering can draw frames between ticks
-                CurTime = CurTime + TickRemainder;
+                return time + TickRemainder;
+            return time;
         }
 
         /// <summary>

--- a/SS14.Shared/Timing/GameTiming.cs
+++ b/SS14.Shared/Timing/GameTiming.cs
@@ -26,7 +26,6 @@ namespace SS14.Shared.Timing
             _realTimer.Start();
 
             Paused = false;
-            TimeScale = 1.0f;
             TickRate = NumFrames;
         }
 
@@ -39,11 +38,6 @@ namespace SS14.Shared.Timing
         ///     Is the simulation currently paused?
         /// </summary>
         public bool Paused { get; set; }
-
-        /// <summary>
-        ///     How fast time passes in the simulation compared to RealTime. 1.0 = 100%, 0.25 = 25% (slow mo).
-        /// </summary>
-        public double TimeScale { get; set; }
         
         /// <summary>
         ///     The current synchronized uptime of the simulation. Use this for in-game timing. This can be rewound for
@@ -119,7 +113,7 @@ namespace SS14.Shared.Timing
             // calculate simulation FrameTime
             if (InSimulation)
             {
-                FrameTime = TimeSpan.FromTicks((long)(TickPeriod.Ticks * TimeScale));
+                FrameTime = TimeSpan.FromTicks(TickPeriod.Ticks);
             }
             else
             {

--- a/SS14.Shared/Timing/IStopwatch.cs
+++ b/SS14.Shared/Timing/IStopwatch.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace SS14.Shared.Timing
+{
+    /// <summary>
+    ///     Provides a set of methods and properties that you can use to accurately
+    ///     measure elapsed time.
+    /// </summary>
+    internal interface IStopwatch
+    {
+        /// <summary>
+        ///     Gets the total elapsed time measured by the current instance.
+        /// </summary>
+        TimeSpan Elapsed { get; }
+
+        /// <summary>
+        ///     Stops time interval measurement, resets the elapsed time to zero,
+        ///     and starts measuring elapsed time.
+        /// </summary>
+        void Restart();
+
+        /// <summary>
+        ///     Starts, or resumes, measuring elapsed time for an interval.
+        /// </summary>
+        void Start();
+    }
+}

--- a/SS14.Shared/Timing/Stopwatch.cs
+++ b/SS14.Shared/Timing/Stopwatch.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace SS14.Shared.Timing
+{
+    /// <summary>
+    ///     Provides a set of methods and properties that you can use to accurately
+    ///     measure elapsed time.
+    /// </summary>
+    internal class Stopwatch : IStopwatch
+    {
+        private readonly System.Diagnostics.Stopwatch _stopwatch;
+
+        /// <summary>
+        ///     Constructs a new instance of this object.
+        /// </summary>
+        public Stopwatch()
+        {
+            _stopwatch = new System.Diagnostics.Stopwatch();
+        }
+
+        /// <summary>
+        ///     Gets the total elapsed time measured by the current instance.
+        /// </summary>
+        public TimeSpan Elapsed => _stopwatch.Elapsed;
+
+        /// <summary>
+        ///     Starts, or resumes, measuring elapsed time for an interval.
+        /// </summary>
+        public void Start()
+        {
+            _stopwatch.Start();
+        }
+
+        /// <summary>
+        ///     Stops time interval measurement, resets the elapsed time to zero,
+        ///     and starts measuring elapsed time.
+        /// </summary>
+        public void Restart()
+        {
+            _stopwatch.Restart();
+        }
+    }
+}

--- a/SS14.UnitTesting/SS14.UnitTesting.csproj
+++ b/SS14.UnitTesting/SS14.UnitTesting.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Shared\Prototypes\PrototypeManager_Test.cs" />
     <Compile Include="Shared\Reflection\ReflectionManager_Test.cs" />
     <Compile Include="Shared\Serialization\NetSerializableAttribute_Test.cs" />
+    <Compile Include="Shared\Timing\GameLoop_Test.cs" />
     <Compile Include="Shared\Timing\GameTiming_Test.cs" />
     <Compile Include="Shared\Utility\CollectionExtensions_Test.cs" />
     <Compile Include="Shared\Utility\YamlHelpers_Test.cs" />

--- a/SS14.UnitTesting/SS14.UnitTesting.csproj
+++ b/SS14.UnitTesting/SS14.UnitTesting.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Shared\Prototypes\PrototypeManager_Test.cs" />
     <Compile Include="Shared\Reflection\ReflectionManager_Test.cs" />
     <Compile Include="Shared\Serialization\NetSerializableAttribute_Test.cs" />
+    <Compile Include="Shared\Timing\GameTiming_Test.cs" />
     <Compile Include="Shared\Utility\CollectionExtensions_Test.cs" />
     <Compile Include="Shared\Utility\YamlHelpers_Test.cs" />
     <Compile Include="Shared\ColorUtils_Test.cs" />

--- a/SS14.UnitTesting/SS14UnitTest.cs
+++ b/SS14.UnitTesting/SS14UnitTest.cs
@@ -62,6 +62,7 @@ using SS14.Shared.Timers;
 using SS14.Server.Interfaces.Maps;
 using SS14.Server.Maps;
 using SS14.Shared.Maths;
+using FrameEventArgs = SS14.Client.Graphics.FrameEventArgs;
 
 namespace SS14.UnitTesting
 {

--- a/SS14.UnitTesting/Shared/Timing/GameLoop_Test.cs
+++ b/SS14.UnitTesting/Shared/Timing/GameLoop_Test.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Reflection;
+using Moq;
+using NUnit.Framework;
+using SS14.Shared.Interfaces.Timing;
+using SS14.Shared.Timing;
+
+namespace SS14.UnitTesting.Shared.Timing
+{
+    [TestFixture]
+    [TestOf(typeof(GameLoop))]
+    class GameLoop_Test
+    {
+        /// <summary>
+        ///     With single step enabled, the game loop should run 1 tick and then pause again.
+        /// </summary>
+        [Test]
+        [Timeout(1000)] // comment this out if you want to debug
+        public void SingleStepTest()
+        {
+            // Arrange
+            var elapsedVal = TimeSpan.FromSeconds(Math.PI);
+            var newStopwatch = new Mock<IStopwatch>();
+            newStopwatch.SetupGet(p => p.Elapsed).Returns(elapsedVal);
+            var gameTiming = GameTimingFactory(newStopwatch.Object);
+            var loop = new GameLoop(gameTiming);
+
+            var callCount = 0;
+            loop.Tick += (sender, args) => callCount++;
+            loop.Render += (sender, args) => loop.Running = false; // break the endless loop for testing
+
+            // Act
+            loop.SingleStep = true;
+            loop.Run();
+
+            // Assert
+            Assert.That(callCount, Is.EqualTo(1));
+            Assert.That(gameTiming.CurTick, Is.EqualTo(1));
+            Assert.That(gameTiming.Paused, Is.True); // it will pause itself after running each tick
+            Assert.That(loop.SingleStep, Is.True); // still true
+        }
+
+        private static IGameTiming GameTimingFactory(IStopwatch stopwatch)
+        {
+            var timing = new GameTiming();
+
+            var field = typeof(GameTiming).GetField("_realTimer", BindingFlags.Static | BindingFlags.NonPublic);
+            field.SetValue(null, stopwatch);
+
+            return timing;
+        }
+    }
+}

--- a/SS14.UnitTesting/Shared/Timing/GameTiming_Test.cs
+++ b/SS14.UnitTesting/Shared/Timing/GameTiming_Test.cs
@@ -1,0 +1,212 @@
+﻿using System;
+using System.Reflection;
+using Moq;
+using NUnit.Framework;
+using SS14.Shared.Interfaces.Timing;
+using SS14.Shared.Timing;
+
+namespace SS14.UnitTesting.Shared.Timing
+{
+    [TestFixture]
+    [TestOf(typeof(GameTiming))]
+    class GameTiming_Test
+    {
+        /// <summary>
+        ///     Checks that IGameTiming.RealTime returns the real(wall) uptime since the stopwatch was started.
+        /// </summary>
+        /// <remarks>
+        ///     This is unaffected by pausing or timescale, and has nothing to do with the simulation. This should be used for
+        ///     out-of-simulation timing, for example sound timing, UI timing, input timing, etc.
+        /// </remarks>
+        [Test]
+        public void RealTimeTest()
+        {
+            // Arrange
+            var elapsedVal = TimeSpan.FromSeconds(Math.PI);
+            var newStopwatch = new Mock<IStopwatch>();
+            newStopwatch.SetupGet(p => p.Elapsed).Returns(elapsedVal);
+            var gameTiming = GameTimingFactory(newStopwatch.Object);
+
+            // Act
+            var result = gameTiming.RealTime;
+
+            // Assert
+            Assert.That(result, Is.EqualTo(elapsedVal));
+        }
+
+        /// <summary>
+        ///     Checks that IGameTiming.RealFrameTime returns the real(wall) delta time between the two most recent calls to
+        ///     IGameTiming.StartFrame().
+        /// </summary>
+        /// <remarks>
+        ///     This is unaffected by pausing or timescale, and has nothing to do with the simulation. This value is used
+        ///     by the profiling functions.
+        /// </remarks>
+        [Test]
+        public void RealFrameTimeTest()
+        {
+            // Arrange
+            var elapsedVal = TimeSpan.FromSeconds(3);
+            var newStopwatch = new Mock<IStopwatch>();
+            newStopwatch.SetupGet(p => p.Elapsed).Returns(() => elapsedVal);
+            var gameTiming = GameTimingFactory(newStopwatch.Object);
+            gameTiming.StartFrame(); // changes last time from 0 to 3
+
+            // Act
+            elapsedVal = TimeSpan.FromSeconds(5);
+            gameTiming.StartFrame();
+            var result = gameTiming.RealFrameTime;
+
+            // Assert
+            Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(2))); // 5 - 3 = 2
+        }
+
+        /// <summary>
+        ///     Checks that IGameTiming.CurTime returns the current simulation uptime when inside the simulation.
+        /// </summary>
+        /// <remarks>
+        ///     This value is affected by pausing and timescale. This value is derived from CurTick and TickRate, and is unaffected
+        ///     by RealTime. All simulation code should be using this value to measure uptime.
+        /// </remarks>
+        [Test]
+        public void InSimCurTimeTest()
+        {
+            // Arrange
+            var newStopwatch = new Mock<IStopwatch>();
+            var gameTiming = GameTimingFactory(newStopwatch.Object);
+            gameTiming.InSimulation = true;
+
+            //NOTE: TickRate can cause a slight rounding error in TickPeriod reciprocal calculation from repeating decimals depending
+            // on the value chosen.
+            gameTiming.TickRate = 20;
+            gameTiming.CurTick = 60;
+
+            // Act
+            gameTiming.StartFrame();
+            var result = gameTiming.CurTime;
+
+            // Assert
+            var expected = TimeSpan.FromTicks(TimeSpan.TicksPerSecond * 3);
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        ///     Checks that IGameTiming.CurTime returns the current simulation time + fractional tick time when outside the
+        ///     simulation.
+        /// </summary>
+        /// <remarks>
+        ///     This is the same thing as in-simulation CurTime, but also adds the fractional tick to the time. This is useful
+        ///     for the renderer to be able to transparently cause the simulation to extrapolate between CurTick and CurTick + 1.
+        /// </remarks>
+        [Test]
+        public void OutSimCurTimeTest()
+        {
+            // Arrange
+            var newStopwatch = new Mock<IStopwatch>();
+            var gameTiming = GameTimingFactory(newStopwatch.Object);
+            gameTiming.InSimulation = false;
+            gameTiming.TickRate = 20;
+            gameTiming.CurTick = 60;
+            gameTiming.TickRemainder = TimeSpan.FromTicks(TimeSpan.TicksPerSecond / 2); // half a second
+
+            // Act
+            gameTiming.StartFrame();
+            var result = gameTiming.CurTime;
+
+            // Assert
+            var expected = TimeSpan.FromSeconds(3.5);
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        ///     Checks that IGameTiming.FrameTime returns the simulated delta time between the two most recent calls to IGameTiming.StartFrame().
+        /// </summary>
+        /// <remarks>
+        ///     This value is not affected by pausing. This value is derived from TimeScale and TickRate, and is unaffected
+        ///     by RealTime. There is no lag or jitter inside the simulation. The FrameTime is always exactly TickPeriod * TimeScale.
+        /// </remarks>
+        [Test]
+        public void InSimFrameTimeTest()
+        {
+            // Arrange
+            var newStopwatch = new Mock<IStopwatch>();
+            var gameTiming = GameTimingFactory(newStopwatch.Object);
+            gameTiming.InSimulation = true;
+            gameTiming.TickRate = 20; // simulation still runs at 20tps
+            gameTiming.TimeScale = 0.5; // but the passage of time is half of RealTime.
+
+            // Act
+            gameTiming.StartFrame();
+            var result = gameTiming.FrameTime;
+
+            // Assert
+            var expected = TimeSpan.FromTicks((long)(TimeSpan.TicksPerSecond * (1/20.0) * 0.5));
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        ///     Checks that IGameTiming.FrameTime returns the real delta time between the two most recent calls to IGameTiming.StartFrame().
+        /// </summary>
+        /// <remarks>
+        ///     When outside the simulation, FrameTime returns the same value as RealFrameTime. This allows rendering code to also use 
+        ///     the FrameTime property instead of RealFrameTime.
+        /// </remarks>
+        [Test]
+        public void OutSimFrameTimeTest()
+        {
+            // Arrange
+            var elapsedVal = TimeSpan.FromSeconds(3);
+            var newStopwatch = new Mock<IStopwatch>();
+            newStopwatch.SetupGet(p => p.Elapsed).Returns(() => elapsedVal);
+            var gameTiming = GameTimingFactory(newStopwatch.Object);
+            gameTiming.InSimulation = false;
+            gameTiming.StartFrame(); // changes last time from 0 to 3
+
+            // Act
+            elapsedVal = TimeSpan.FromSeconds(5);
+            gameTiming.StartFrame();
+            var result = gameTiming.FrameTime;
+
+            // Assert
+            Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(2))); // 5 - 3 = 2
+        }
+
+        /// <summary>
+        ///     Checks that IGameTiming.FrameTime returns zero when outside the simulation, and the simulation is paused.
+        /// </summary>
+        /// <remarks>
+        ///     If the simulation is paused, then the update loop should not be ran. When rendering calls code that uses FrameTime
+        ///     while paused, time never passed since the last frame, and FrameTime should always return 0.
+        /// </remarks>
+        [Test]
+        public void OutSimFrameTimePausedTest()
+        {
+            // Arrange
+            var elapsedVal = TimeSpan.FromSeconds(3);
+            var newStopwatch = new Mock<IStopwatch>();
+            newStopwatch.SetupGet(p => p.Elapsed).Returns(() => elapsedVal);
+            var gameTiming = GameTimingFactory(newStopwatch.Object);
+            gameTiming.InSimulation = false;
+            gameTiming.StartFrame(); // changes last time from 0 to 3
+            gameTiming.Paused = true;
+
+            // Act
+            elapsedVal = TimeSpan.FromSeconds(5); // RealTime increases
+            gameTiming.StartFrame();
+            var result = gameTiming.FrameTime;
+
+            // Assert
+            Assert.That(result, Is.EqualTo(TimeSpan.Zero)); // But simulation time never increases.
+        }
+
+        private IGameTiming GameTimingFactory(IStopwatch stopwatch)
+        {
+            var timing = new GameTiming();
+
+            var field = typeof(GameTiming).GetField("_realTimer", BindingFlags.Static | BindingFlags.NonPublic);
+            field.SetValue(this, stopwatch);
+
+            return timing;
+        }
+    }
+}

--- a/SS14.UnitTesting/Shared/Timing/GameTiming_Test.cs
+++ b/SS14.UnitTesting/Shared/Timing/GameTiming_Test.cs
@@ -199,12 +199,12 @@ namespace SS14.UnitTesting.Shared.Timing
             Assert.That(result, Is.EqualTo(TimeSpan.Zero)); // But simulation time never increases.
         }
 
-        private IGameTiming GameTimingFactory(IStopwatch stopwatch)
+        private static IGameTiming GameTimingFactory(IStopwatch stopwatch)
         {
             var timing = new GameTiming();
 
             var field = typeof(GameTiming).GetField("_realTimer", BindingFlags.Static | BindingFlags.NonPublic);
-            field.SetValue(this, stopwatch);
+            field.SetValue(null, stopwatch);
 
             return timing;
         }


### PR DESCRIPTION
Wraps the `System.Diagnostics.Stopwatch` in a class so that it can be used as a dependency. Adds some unit tests to the `GameTiming` class. Extracted the `GameLoop` class from `BaseClient` and `GameController`. Added single-step unit test to `GameLoop`.

Removed `TimeScale` property from `GameTiming`, making it work would be too much effort for something that will prob never be used.

Exposed the internal types in `SS14.Shared` to `SS14.UnitTesting` ~~in debug builds~~.