### PR TITLE
MapLoader - Catch Entity Error

### DIFF
--- a/SS14.Server/Maps/MapLoader.cs
+++ b/SS14.Server/Maps/MapLoader.cs
@@ -248,13 +248,21 @@ namespace SS14.Server.Maps
                 var yamlEnt = (YamlMappingNode) yamlNode;
 
                 var protoName = yamlEnt["id"].ToString();
-                var entity = _entityMan.SpawnEntity(protoName);
 
-                _protoMan.LoadData(entity, yamlEnt);
+                try
+                {
+                    var entity = _entityMan.SpawnEntity(protoName);
 
-                // overwrite local position in the BP to the new map/grid ID
-                var transform = entity.GetComponent<IServerTransformComponent>();
-                transform.LocalPosition = new LocalCoordinates(transform.LocalPosition.Position, gridId, map.Index);
+                    _protoMan.LoadData(entity, yamlEnt);
+
+                    // overwrite local position in the BP to the new map/grid ID
+                    var transform = entity.GetComponent<IServerTransformComponent>();
+                    transform.LocalPosition = new LocalCoordinates(transform.LocalPosition.Position, gridId, map.Index);
+                }
+                catch (Exception e)
+                {
+                    Logger.Error($"[MAP] Error creating entity \"{protoName}\": {e.Message}");
+                }
             }
         }
     }


### PR DESCRIPTION
MapLoader now catches any errors when creating an entity (like missing prototypes) and prints them to the console instead of crashing the program.