### PR TITLE
GetAllPlayers() doesn't return nulls

### DIFF
--- a/SS14.Server/ClientConsoleHost/Commands/PlayerCommands.cs
+++ b/SS14.Server/ClientConsoleHost/Commands/PlayerCommands.cs
@@ -63,9 +63,6 @@ namespace SS14.Server.ClientConsoleHost.Commands
 
             foreach (IPlayerSession p in players)
             {
-                if(p == null)
-                    continue;
-
                 sb.Append($"  {p.Index,3}");
                 sb.Append($"  {p.Name,20}");
                 sb.AppendLine(string.Format("  {0,16}{1,12}{2,14}{3,9}",

--- a/SS14.Server/Player/PlayerManager.cs
+++ b/SS14.Server/Player/PlayerManager.cs
@@ -168,7 +168,7 @@ namespace SS14.Server.Player
         /// <returns></returns>
         public List<IPlayerSession> GetAllPlayers()
         {
-            return _sessions.Cast<IPlayerSession>().ToList();
+            return _sessions.Where(x => x!= null).Cast<IPlayerSession>().ToList();
         }
 
         /// <summary>


### PR DESCRIPTION
`_sessions` is an array that obviously gets initialized with nulls, so `GetAllPlayers` would previously return a mixed bag of nulls and players.
This caused the `listplayers` server command to throw a good old NPE.
I also removed the now-superfluous null check from the client's `listplayers` (which I haven't got to work either way, yet, but that's probably unrelated).