### PR TITLE
Logging API cleanup.

### DIFF
--- a/SS14.Client/Console/Commands/LogCommands.cs
+++ b/SS14.Client/Console/Commands/LogCommands.cs
@@ -60,7 +60,7 @@ namespace SS14.Client.Console.Commands
             var message = args[2]; // yes this doesn't support spaces idgaf.
             var level = (LogLevel)Enum.Parse(typeof(LogLevel), levelname);
 
-            Logger.LogS(name, message, level);
+            Logger.LogS(level, name, message);
             return false;
         }
     }

--- a/SS14.Server/BaseServer.cs
+++ b/SS14.Server/BaseServer.cs
@@ -166,12 +166,12 @@ namespace SS14.Server
             catch (System.Net.Sockets.SocketException)
             {
                 var port = netMan.Port;
-                Logger.Log($"Unable to setup networking manager. Check port {port} is not already in use!, shutting down...", LogLevel.Fatal);
+                Logger.Fatal($"Unable to setup networking manager. Check port {port} is not already in use!, shutting down...");
                 Environment.Exit(1);
             }
             catch (Exception e)
             {
-                Logger.Log($"Unable to setup networking manager. Unknown exception: {e}, shutting down...", LogLevel.Fatal);
+                Logger.Fatal($"Unable to setup networking manager. Unknown exception: {e}, shutting down...");
                 Environment.Exit(1);
             }
 

--- a/SS14.Server/Program.cs
+++ b/SS14.Server/Program.cs
@@ -64,7 +64,7 @@ namespace SS14.Server
 
             if (server.Start())
             {
-                Logger.Log("Server -> Can not start server", LogLevel.Fatal);
+                Logger.Fatal("Server -> Can not start server");
                 //Not like you'd see this, haha. Perhaps later for logging.
                 Environment.Exit(0);
             }

--- a/SS14.Server/ServerConsole/Commands/LogCommands.cs
+++ b/SS14.Server/ServerConsole/Commands/LogCommands.cs
@@ -63,7 +63,7 @@ namespace SS14.Server.ServerConsole.Commands
             var message = args[2]; // yes this doesn't support spaces idgaf.
             var level = (LogLevel)Enum.Parse(typeof(LogLevel), levelname);
 
-            Logger.LogS(name, message, level);
+            Logger.LogS(level, name, message, level);
             return;
         }
     }

--- a/SS14.Server/Signals.cs
+++ b/SS14.Server/Signals.cs
@@ -14,7 +14,7 @@ namespace SS14.Server
 
         public static void InstallSignals()
         {
-            bool runningOnMono = Type.GetType ("Mono.Runtime") != null;
+            bool runningOnMono = Type.GetType("Mono.Runtime") != null;
             if (!runningOnMono)
             {
                 return;
@@ -23,7 +23,7 @@ namespace SS14.Server
             {
                 // Reflection is fun.
                 var assembly = FindMonoPosix();
-                Logger.Log("Successfully loaded Mono.Posix. Registering signal handlers...", LogLevel.Debug);
+                Logger.Debug("Successfully loaded Mono.Posix. Registering signal handlers...");
 
                 Type signalType = assembly.GetType("Mono.Unix.UnixSignal");
                 // Mono.Unix.UnixSignal[]
@@ -71,7 +71,7 @@ namespace SS14.Server
             }
             catch (Exception e)
             {
-                Logger.Log(string.Format("Running on mono but couldn't register signal handlers: {0}", e), LogLevel.Error);
+                Logger.Error("Running on mono but couldn't register signal handlers: {0}", e);
             }
         }
 

--- a/SS14.Shared/Interfaces/Log/ISawmill.cs
+++ b/SS14.Shared/Interfaces/Log/ISawmill.cs
@@ -34,7 +34,12 @@ namespace SS14.Shared.Interfaces.Log
         /// <summary>
         ///     Log a message, taking in a format string and format list using the regular <see cref="string.Format" /> syntax.
         /// </summary>
-        void Log(string message, LogLevel level = LogLevel.Info, params object[] args);
+        void Log(LogLevel level, string message, params object[] args);
+
+        /// <summary>
+        ///     Log a message.
+        /// </summary>
+        void Log(LogLevel level, string message);
 
         /// <summary>
         ///     Log a message as debug, taking in a format string and format list using the regular <see cref="string.Format" /> syntax.
@@ -43,16 +48,33 @@ namespace SS14.Shared.Interfaces.Log
         void Debug(string message, params object[] args);
 
         /// <summary>
+        ///     Log a message as debug.
+        /// </summary>
+        /// <seealso cref="Log" />
+        void Debug(string message);
+
+        /// <summary>
         ///     Log a message as info, taking in a format string and format list using the regular <see cref="string.Format" /> syntax.
         /// </summary>
         /// <seealso cref="Log" />
         void Info(string message, params object[] args);
 
         /// <summary>
+        ///     Log a message as info.
+        /// </summary>
+        /// <seealso cref="Log" />
+        void Info(string message);
+
+        /// <summary>
         ///     Log a message as warning, taking in a format string and format list using the regular <see cref="string.Format" /> syntax.
         /// </summary>
         /// <seealso cref="Log" />
         void Warning(string message, params object[] args);
+        /// <summary>
+        ///     Log a message as warning, taking in a format string and format list using the regular <see cref="string.Format" /> syntax.
+        /// </summary>
+        /// <seealso cref="Log" />
+        void Warning(string message);
 
         /// <summary>
         ///     Log a message as error, taking in a format string and format list using the regular <see cref="string.Format" /> syntax.
@@ -61,9 +83,21 @@ namespace SS14.Shared.Interfaces.Log
         void Error(string message, params object[] args);
 
         /// <summary>
+        ///     Log a message as error.
+        /// </summary>
+        /// <seealso cref="Log" />
+        void Error(string message);
+
+        /// <summary>
         ///     Log a message as fatal, taking in a format string and format list using the regular <see cref="string.Format" /> syntax.
         /// </summary>
         /// <seealso cref="Log" />
         void Fatal(string message, params object[] args);
+
+        /// <summary>
+        ///     Log a message as fatal.
+        /// </summary>
+        /// <seealso cref="Log" />
+        void Fatal(string message);
     }
 }

--- a/SS14.Shared/Log/LogManager.Sawmill.cs
+++ b/SS14.Shared/Log/LogManager.Sawmill.cs
@@ -44,9 +44,14 @@ namespace SS14.Shared.Log
                 handlers.Remove(handler);
             }
 
-            public void Log(string message, LogLevel level, params object[] args)
+            public void Log(LogLevel level, string message, params object[] args)
             {
-                var msg = new LogMessage(string.Format(message, args), level, Name);
+                Log(level, string.Format(message, args));
+            }
+
+            public void Log(LogLevel level, string message)
+            {
+                var msg = new LogMessage(message, level, Name);
                 LogInternal(ref msg);
             }
 
@@ -76,27 +81,52 @@ namespace SS14.Shared.Log
 
             public void Debug(string message, params object[] args)
             {
-                Log(message, LogLevel.Debug, args);
+                Log(LogLevel.Debug, message, args);
+            }
+
+            public void Debug(string message)
+            {
+                Log(LogLevel.Debug, message);
             }
 
             public void Info(string message, params object[] args)
             {
-                Log(message, LogLevel.Info, args);
+                Log(LogLevel.Info, message, args);
+            }
+
+            public void Info(string message)
+            {
+                Log(LogLevel.Info, message);
             }
 
             public void Warning(string message, params object[] args)
             {
-                Log(message, LogLevel.Warning, args);
+                Log(LogLevel.Warning, message, args);
+            }
+
+            public void Warning(string message)
+            {
+                Log(LogLevel.Warning, message);
             }
 
             public void Error(string message, params object[] args)
             {
-                Log(message, LogLevel.Error, args);
+                Log(LogLevel.Error, message, args);
+            }
+
+            public void Error(string message)
+            {
+                Log(LogLevel.Error, message);
             }
 
             public void Fatal(string message, params object[] args)
             {
-                Log(message, LogLevel.Fatal, args);
+                Log(LogLevel.Fatal, message, args);
+            }
+
+            public void Fatal(string message)
+            {
+                Log(LogLevel.Fatal, message);
             }
         }
     }

--- a/SS14.Shared/Log/Logger.cs
+++ b/SS14.Shared/Log/Logger.cs
@@ -35,78 +35,155 @@ namespace SS14.Shared.Log
         /// <summary>
         ///     Log a message, taking in a format string and format list using the regular <see cref="string.Format" /> syntax.
         /// </summary>
-        public static void LogS(string sawmillname, string message, LogLevel logLevel, params object[] args)
+        public static void LogS(LogLevel logLevel, string sawmillname, string message, params object[] args)
         {
             var sawmill = LogManagerSingleton.GetSawmill(sawmillname);
-            sawmill.Log(message, logLevel, args);
+            sawmill.Log(logLevel, message, args);
+        }
+
+        /// <summary>
+        ///     Log a message.
+        /// </summary>
+        public static void LogS(LogLevel logLevel, string sawmillname, string message)
+        {
+            var sawmill = LogManagerSingleton.GetSawmill(sawmillname);
+            sawmill.Log(logLevel, message);
         }
 
         /// <summary>
         /// Log a message, taking in a format string and format list using the regular <see cref="string.Format" /> syntax.
         /// </summary>
-        public static void Log(string message, LogLevel logLevel, params object[] args)
+        public static void Log(LogLevel logLevel, string message, params object[] args)
         {
-            LogManagerSingleton.RootSawmill.Log(message, logLevel, args);
+            LogManagerSingleton.RootSawmill.Log(logLevel, message, args);
+        }
+
+        /// <summary>
+        /// Log a message.
+        /// </summary>
+        public static void Log(LogLevel logLevel, string message)
+        {
+            LogManagerSingleton.RootSawmill.Log(logLevel, message);
         }
 
         /// <summary>
         /// Log a message as debug, taking in a format string and format list using the regular <see cref="string.Format" /> syntax.
         /// </summary>
         /// <seealso cref="Log" />
-        public static void DebugS(string sawmill, string message, params object[] args) => LogS(sawmill, message, LogLevel.Debug, args);
+        public static void DebugS(string sawmill, string message, params object[] args) => LogS(LogLevel.Debug, sawmill, message, args);
+
+        /// <summary>
+        /// Log a message as debug.
+        /// </summary>
+        /// <seealso cref="Log" />
+        public static void DebugS(string sawmill, string message) => LogS(LogLevel.Debug, sawmill, message);
 
         /// <summary>
         /// Log a message as debug, taking in a format string and format list using the regular <see cref="string.Format" /> syntax.
         /// </summary>
         /// <seealso cref="Log" />
-        public static void Debug(string message, params object[] args) => Log(message, LogLevel.Debug, args);
+        public static void Debug(string message, params object[] args) => Log(LogLevel.Debug, message, args);
+
+        /// <summary>
+        /// Log a message as debug.
+        /// </summary>
+        /// <seealso cref="Log" />
+        public static void Debug(string message) => Log(LogLevel.Debug, message);
 
         /// <summary>
         /// Log a message as info, taking in a format string and format list using the regular <see cref="string.Format" /> syntax.
         /// </summary>
         /// <seealso cref="Log" />
-        public static void InfoS(string sawmill, string message, params object[] args) => LogS(sawmill, message, LogLevel.Info, args);
+        public static void InfoS(string sawmill, string message, params object[] args) => LogS(LogLevel.Info, sawmill, message, args);
+
+        /// <summary>
+        /// Log a message as info.
+        /// </summary>
+        /// <seealso cref="Log" />
+        public static void InfoS(string sawmill, string message) => LogS(LogLevel.Info, sawmill, message);
 
         /// <summary>
         /// Log a message as info, taking in a format string and format list using the regular <see cref="string.Format" /> syntax.
         /// </summary>
         /// <seealso cref="Log" />
-        public static void Info(string message, params object[] args) => Log(message, LogLevel.Info, args);
+        public static void Info(string message, params object[] args) => Log(LogLevel.Info, message, args);
+
+        /// <summary>
+        /// Log a message as info.
+        /// </summary>
+        /// <seealso cref="Log" />
+        public static void Info(string message) => Log(LogLevel.Info, message);
 
         /// <summary>
         /// Log a message as warning, taking in a format string and format list using the regular <see cref="string.Format" /> syntax.
         /// </summary>
         /// <seealso cref="Log" />
-        public static void WarningS(string sawmill, string message, params object[] args) => LogS(sawmill, message, LogLevel.Warning, args);
+        public static void WarningS(string sawmill, string message, params object[] args) => LogS(LogLevel.Warning, sawmill, message, args);
+
+        /// <summary>
+        /// Log a message as warning.
+        /// </summary>
+        /// <seealso cref="Log" />
+        public static void WarningS(string sawmill, string message) => LogS(LogLevel.Warning, sawmill, message);
 
         /// <summary>
         /// Log a message as warning, taking in a format string and format list using the regular <see cref="string.Format" /> syntax.
         /// </summary>
         /// <seealso cref="Log" />
-        public static void Warning(string message, params object[] args) => Log(message, LogLevel.Warning, args);
+        public static void Warning(string message, params object[] args) => Log(LogLevel.Warning, message, args);
+
+        /// <summary>
+        /// Log a message as warning.
+        /// </summary>
+        /// <seealso cref="Log" />
+        public static void Warning(string message) => Log(LogLevel.Warning, message);
 
         /// <summary>
         /// Log a message as error, taking in a format string and format list using the regular <see cref="string.Format" /> syntax.
         /// </summary>
         /// <seealso cref="Log" />
-        public static void ErrorS(string sawmill, string message, params object[] args) => LogS(sawmill, message, LogLevel.Error, args);
+        public static void ErrorS(string sawmill, string message, params object[] args) => LogS(LogLevel.Error, sawmill, message, args);
+
+        /// <summary>
+        /// Log a message as error.
+        /// </summary>
+        /// <seealso cref="Log" />
+        public static void ErrorS(string sawmill, string message) => LogS(LogLevel.Error, sawmill, message);
 
         /// <summary>
         /// Log a message as error, taking in a format string and format list using the regular <see cref="string.Format" /> syntax.
         /// </summary>
         /// <seealso cref="Log" />
-        public static void Error(string message, params object[] args) => Log(message, LogLevel.Error, args);
+        public static void Error(string message, params object[] args) => Log(LogLevel.Error, message, args);
+
+        /// <summary>
+        /// Log a message as error.
+        /// </summary>
+        /// <seealso cref="Log" />
+        public static void Error(string message) => Log(LogLevel.Error, message);
 
         /// <summary>
         /// Log a message as fatal, taking in a format string and format list using the regular <see cref="string.Format" /> syntax.
         /// </summary>
         /// <seealso cref="Log" />
-        public static void FatalS(string sawmill, string message, params object[] args) => LogS(sawmill, message, LogLevel.Fatal, args);
+        public static void FatalS(string sawmill, string message, params object[] args) => LogS(LogLevel.Fatal, sawmill, message, args);
+
+        /// <summary>
+        /// Log a message as fatal.
+        /// </summary>
+        /// <seealso cref="Log" />
+        public static void FatalS(string sawmill, string message) => LogS(LogLevel.Fatal, sawmill, message);
 
         /// <summary>
         /// Log a message as fatal, taking in a format string and format list using the regular <see cref="string.Format" /> syntax.
         /// </summary>
         /// <seealso cref="Log" />
-        public static void Fatal(string message, params object[] args) => Log(message, LogLevel.Fatal, args);
+        public static void Fatal(string message, params object[] args) => Log(LogLevel.Fatal, message, args);
+
+        /// <summary>
+        /// Log a message as fatal.
+        /// </summary>
+        /// <seealso cref="Log" />
+        public static void Fatal(string message) => Log(LogLevel.Fatal, message);
     }
 }


### PR DESCRIPTION
Added versions of the log calls not doing formatting.
Moved the LogLevel argument for .Log() to be first.