### PR TITLE
Fix GodotSignalSubscriber leakage.

### DIFF
--- a/SS14.Client.Godot/SignalSubscriber/BaseGodotSignalSubscriber.cs
+++ b/SS14.Client.Godot/SignalSubscriber/BaseGodotSignalSubscriber.cs
@@ -4,7 +4,7 @@
 // It's not clean but do you have a better idea?
 namespace SS14.Client.GodotGlue
 {
-    public abstract class BaseGodotSignalSubscriber : Godot.Object
+    public abstract class BaseGodotSignalSubscriber : Godot.Reference
     {
         public void Connect(Godot.Object obj, string signal)
         {


### PR DESCRIPTION
Every signal subscriber was getting leaked because I didn't know how Godot's memory model works. This is fixed now.