### PR TITLE
TileDefinition Prototypes

### DIFF
--- a/SS14.Server/server_config.toml
+++ b/SS14.Server/server_config.toml
@@ -12,7 +12,7 @@ allowdupeip = true
 
 [game]
 hostname = "MyServer"
-mapname = "SavedEntities.xml"
+mapname = "stationstation"
 maxplayers = 32
 type = 1
 welcomemsg = "Welcome to the server!"

--- a/SS14.Shared/Map/DefaultTileDefinitions.cs
+++ b/SS14.Shared/Map/DefaultTileDefinitions.cs
@@ -1,4 +1,10 @@
-﻿namespace SS14.Shared.Map
+﻿using SS14.Shared.Interfaces.Map;
+using SS14.Shared.IoC;
+using SS14.Shared.Prototypes;
+using SS14.Shared.Utility;
+using YamlDotNet.RepresentationModel;
+
+namespace SS14.Shared.Map
 {
     /// <summary>
     ///     Default TileDefinition of a Floor
@@ -38,6 +44,20 @@
             IsCollidable = false;
             IsGasVolume = true;
             IsVentedIntoSpace = true;
+        }
+    }
+
+    // Instantiated by the Prototype system through reflection.
+    [Prototype("tile")]
+    public sealed class PrototypeTileDefinition : TileDefinition, IPrototype
+    {
+        public void LoadFrom(YamlMappingNode mapping)
+        {
+            Name = mapping.GetNode("name").ToString();
+            SpriteName = mapping.GetNode("texture").ToString();
+            
+            // register us with the tile system
+            Register(IoCManager.Resolve<ITileDefinitionManager>());
         }
     }
 }

--- a/SS14.Shared/Map/TileDefinition.cs
+++ b/SS14.Shared/Map/TileDefinition.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics;
 using SS14.Shared.Interfaces.Map;
-using SS14.Shared.IoC;
 
 namespace SS14.Shared.Map
 {
@@ -44,6 +43,9 @@ namespace SS14.Shared.Map
         /// </summary>
         /// <param name="data">Optional per-tile data.</param>
         /// <returns></returns>
-        public Tile Create(ushort data = 0) { return new Tile(TileId, data); }
+        public Tile Create(ushort data = 0)
+        {
+            return new Tile(TileId, data);
+        }
     }
 }

--- a/SS14.Shared/Map/TileDefinitionManager.cs
+++ b/SS14.Shared/Map/TileDefinitionManager.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using SS14.Shared.Interfaces.Map;
-using SS14.Shared.Network.Messages;
 
 namespace SS14.Shared.Map
 {
     public class TileDefinitionManager : ITileDefinitionManager
     {
-        //[Dependency]
-        //private readonly IResourceManager resourceManager;
         private readonly List<ITileDefinition> _tileDefs;
         private readonly Dictionary<string, ITileDefinition> _tileNames;
         private readonly Dictionary<ITileDefinition, ushort> _tileIds;
@@ -36,13 +33,13 @@ namespace SS14.Shared.Map
                 throw new InvalidOperationException($"TileDefinition is already registered: {tileDef.GetType()}, id: {id}");
             }
 
-            string name = tileDef.Name;
+            var name = tileDef.Name;
             if (_tileNames.ContainsKey(name))
             {
                 throw new ArgumentException("Another tile definition with the same name has already been registered.", nameof(tileDef));
             }
 
-            id = checked((ushort)_tileDefs.Count);
+            id = checked((ushort) _tileDefs.Count);
             _tileDefs.Add(tileDef);
             _tileNames[name] = tileDef;
             _tileIds[tileDef] = id;


### PR DESCRIPTION
TileDefinitions can now be loaded through the prototype system.
The server now uses the config file to figure out which map to load.