### PR TITLE
DebugTools.Assert

### DIFF
--- a/SS14.Client/BaseClient.cs
+++ b/SS14.Client/BaseClient.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using SS14.Client.Interfaces;
 using SS14.Client.Interfaces.Player;
 using SS14.Client.Interfaces.State;
@@ -12,6 +11,7 @@ using SS14.Shared.Log;
 using SS14.Shared.Network;
 using SS14.Shared.Network.Messages;
 using SS14.Shared.Players;
+using SS14.Shared.Utility;
 
 namespace SS14.Client
 {
@@ -53,8 +53,8 @@ namespace SS14.Client
         /// <inheritdoc />
         public void ConnectToServer(string ip, ushort port)
         {
-            Debug.Assert(RunLevel < ClientRunLevel.Connecting);
-            Debug.Assert(!_net.IsConnected);
+            DebugTools.Assert(RunLevel < ClientRunLevel.Connecting);
+            DebugTools.Assert(!_net.IsConnected);
 
             _net.Startup();
 
@@ -65,8 +65,8 @@ namespace SS14.Client
         /// <inheritdoc />
         public void DisconnectFromServer(string reason)
         {
-            Debug.Assert(RunLevel > ClientRunLevel.Initialize);
-            Debug.Assert(_net.IsConnected);
+            DebugTools.Assert(RunLevel > ClientRunLevel.Initialize);
+            DebugTools.Assert(_net.IsConnected);
 
             // run level changed in OnNetDisconnect()
             // are both of these *really* needed?
@@ -96,7 +96,7 @@ namespace SS14.Client
         /// <param name="session">Session of the player.</param>
         private void OnPlayerJoinedServer(PlayerSession session)
         {
-            Debug.Assert(RunLevel < ClientRunLevel.Connected);
+            DebugTools.Assert(RunLevel < ClientRunLevel.Connected);
             OnRunLevelChanged(ClientRunLevel.Connected);
 
             PlayerJoinedServer?.Invoke(this, new PlayerEventArgs(session));
@@ -108,7 +108,7 @@ namespace SS14.Client
         /// <param name="session">Session of the player.</param>
         private void OnPlayerJoinedLobby(PlayerSession session)
         {
-            Debug.Assert(RunLevel >= ClientRunLevel.Connected);
+            DebugTools.Assert(RunLevel >= ClientRunLevel.Connected);
             OnRunLevelChanged(ClientRunLevel.Lobby);
 
             PlayerJoinedLobby?.Invoke(this, new PlayerEventArgs(session));
@@ -120,7 +120,7 @@ namespace SS14.Client
         /// <param name="session">Session of the player.</param>
         private void OnPlayerJoinedGame(PlayerSession session)
         {
-            Debug.Assert(RunLevel >= ClientRunLevel.Lobby);
+            DebugTools.Assert(RunLevel >= ClientRunLevel.Lobby);
             OnRunLevelChanged(ClientRunLevel.Ingame);
 
             PlayerJoinedGame?.Invoke(this, new PlayerEventArgs(session));
@@ -133,13 +133,13 @@ namespace SS14.Client
 
         private void OnConnectFailed(object sender, NetConnectFailArgs args)
         {
-            Debug.Assert(RunLevel == ClientRunLevel.Connecting);
+            DebugTools.Assert(RunLevel == ClientRunLevel.Connecting);
             Reset();
         }
 
         private void OnNetDisconnect(object sender, NetChannelArgs args)
         {
-            Debug.Assert(RunLevel > ClientRunLevel.Initialize);
+            DebugTools.Assert(RunLevel > ClientRunLevel.Initialize);
 
             PlayerLeaveServer?.Invoke(this, new PlayerEventArgs(_playMan.LocalPlayer.Session));
 

--- a/SS14.Client/GameObjects/Components/Icon/IconComponent.cs
+++ b/SS14.Client/GameObjects/Components/Icon/IconComponent.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using SS14.Client.Graphics;
+﻿using SS14.Client.Graphics;
 using SS14.Client.Interfaces.ResourceManagement;
 using SS14.Client.ResourceManagement;
 using SS14.Shared.GameObjects;
@@ -7,7 +6,6 @@ using SS14.Shared.IoC;
 using SS14.Shared.Log;
 using SS14.Shared.Serialization;
 using SS14.Shared.Utility;
-using YamlDotNet.RepresentationModel;
 
 namespace SS14.Client.GameObjects
 {
@@ -34,7 +32,7 @@ namespace SS14.Client.GameObjects
         private static IDirectionalTextureProvider TextureForConfig(ObjectSerializer serializer)
         {
             var resc = IoCManager.Resolve<IResourceCache>();
-            Debug.Assert(serializer.Reading);
+            DebugTools.Assert(serializer.Reading);
 
             if (serializer.TryGetCacheData<IDirectionalTextureProvider>(SerializationCache, out var dirTex))
             {

--- a/SS14.Client/Player/PlayerManager.cs
+++ b/SS14.Client/Player/PlayerManager.cs
@@ -15,6 +15,7 @@ using SS14.Shared.Interfaces.Network;
 using SS14.Shared.IoC;
 using SS14.Shared.Network;
 using SS14.Shared.Network.Messages;
+using SS14.Shared.Utility;
 
 namespace SS14.Client.Player
 {
@@ -123,9 +124,9 @@ namespace SS14.Client.Player
                 // This happens when the server says "nothing changed!"
                 return;
             }
-            Debug.Assert(_network.IsConnected, "Received player state without being connected?");
-            Debug.Assert(LocalPlayer != null, "Call Startup()");
-            Debug.Assert(LocalPlayer.Session != null, "Received player state before Session finished setup.");
+            DebugTools.Assert(_network.IsConnected, "Received player state without being connected?");
+            DebugTools.Assert(LocalPlayer != null, "Call Startup()");
+            DebugTools.Assert(LocalPlayer.Session != null, "Received player state before Session finished setup.");
 
             var myState = list.FirstOrDefault(s => s.Index == LocalPlayer.Index);
 
@@ -206,7 +207,7 @@ namespace SS14.Client.Player
                 {
                     if (info.Uuid != cSession.Uuid) // not the same player
                     {
-                        Debug.Assert(LocalPlayer.Index != info.Index, "my uuid should not change");
+                        DebugTools.Assert(LocalPlayer.Index != info.Index, "my uuid should not change");
                         dirty = true;
 
                         _sessions.Remove(info.Index);
@@ -230,7 +231,7 @@ namespace SS14.Client.Player
                 // clear slot, player left
                 else if (cSession != null)
                 {
-                    Debug.Assert(LocalPlayer.Index != i, "I'm still connected to the server, but i left?");
+                    DebugTools.Assert(LocalPlayer.Index != i, "I'm still connected to the server, but i left?");
                     dirty = true;
 
                     _sessions.Remove(cSession.Index);
@@ -239,7 +240,7 @@ namespace SS14.Client.Player
                 // add new session to slot
                 else if (info != null)
                 {
-                    Debug.Assert(LocalPlayer.Index != info.Index || LocalPlayer.Session == null, "I already have a session, why am i getting a new one?");
+                    DebugTools.Assert(LocalPlayer.Index != info.Index || LocalPlayer.Session == null, "I already have a session, why am i getting a new one?");
                     dirty = true;
 
                     var newSession = new PlayerSession(info.Index, info.Uuid);

--- a/SS14.Server/Player/PlayerManager.cs
+++ b/SS14.Server/Player/PlayerManager.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using SS14.Server.Interfaces;
 using SS14.Server.Interfaces.GameObjects;
@@ -12,11 +11,11 @@ using SS14.Shared.Interfaces.GameObjects.Components;
 using SS14.Shared.Interfaces.Network;
 using SS14.Shared.Interfaces.Reflection;
 using SS14.Shared.IoC;
-using SS14.Shared.Log;
 using SS14.Shared.Map;
 using SS14.Shared.Network;
 using SS14.Shared.Network.Messages;
 using SS14.Shared.Players;
+using SS14.Shared.Utility;
 
 namespace SS14.Server.Player
 {
@@ -105,7 +104,7 @@ namespace SS14.Server.Player
         /// <inheritdoc />
         public IPlayerSession GetSessionById(PlayerIndex index)
         {
-            Debug.Assert(0 <= index && index <= MaxPlayers);
+            DebugTools.Assert(0 <= index && index <= MaxPlayers);
             return _sessions[index];
         }
 
@@ -221,7 +220,7 @@ namespace SS14.Server.Player
 
             session.PlayerStatusChanged += (obj, sessionArgs) => OnPlayerStatusChanged(session, sessionArgs.OldStatus, sessionArgs.NewStatus);
 
-            Debug.Assert(_sessions[pos] == null);
+            DebugTools.Assert(_sessions[pos] == null);
             _sessionCount++;
             _sessions[pos] = session;
         }
@@ -239,10 +238,10 @@ namespace SS14.Server.Player
             var session = GetSessionByChannel(args.Channel);
 
             // make sure nothing got messed up during the life of the session
-            Debug.Assert(_sessionCount > 0);
-            Debug.Assert(0 <= session.Index && session.Index <= MaxPlayers);
-            Debug.Assert(_sessions[session.Index] != null);
-            Debug.Assert(_sessions[session.Index].ConnectedClient.ConnectionId == args.Channel.ConnectionId);
+            DebugTools.Assert(_sessionCount > 0);
+            DebugTools.Assert(0 <= session.Index && session.Index <= MaxPlayers);
+            DebugTools.Assert(_sessions[session.Index] != null);
+            DebugTools.Assert(_sessions[session.Index].ConnectedClient.ConnectionId == args.Channel.ConnectionId);
 
             //Detach the entity and (don't)delete it.
             session.OnDisconnect();
@@ -252,7 +251,7 @@ namespace SS14.Server.Player
 
         private int GetFirstOpenIndex()
         {
-            Debug.Assert(PlayerCount <= MaxPlayers);
+            DebugTools.Assert(PlayerCount <= MaxPlayers);
 
             if (PlayerCount == MaxPlayers)
                 return -1;
@@ -261,7 +260,7 @@ namespace SS14.Server.Player
                 if (_sessions[i] == null)
                     return i;
 
-            Debug.Assert(true, "Why was a slot not found? There should be one.");
+            DebugTools.Assert("Why was a slot not found? There should be one.");
             return -1;
         }
 

--- a/SS14.Shared/Map/MapManager.Network.cs
+++ b/SS14.Shared/Map/MapManager.Network.cs
@@ -8,6 +8,7 @@ using SS14.Shared.Interfaces.Network;
 using SS14.Shared.IoC;
 using SS14.Shared.Log;
 using SS14.Shared.Network.Messages;
+using SS14.Shared.Utility;
 
 namespace SS14.Shared.Map
 {
@@ -27,7 +28,7 @@ namespace SS14.Shared.Map
             if (_netManager.IsClient)
                 return;
 
-            Debug.Assert(_netManager.IsServer, "Why is the client calling this?");
+            DebugTools.Assert(_netManager.IsServer, "Why is the client calling this?");
 
             Logger.Info(channel.RemoteAddress + ": Sending map");
 
@@ -139,7 +140,7 @@ namespace SS14.Shared.Map
         /// <param name="message">The message containing a serialized map and tileDefines.</param>
         private void HandleTileMap(MsgMap message)
         {
-            Debug.Assert(_netManager.IsClient, "Why is the server calling this?");
+            DebugTools.Assert(_netManager.IsClient, "Why is the server calling this?");
 
             _gridsReceived++;
 
@@ -197,7 +198,7 @@ namespace SS14.Shared.Map
         /// <param name="message">The message containing the info.</param>
         private void HandleTileUpdate(MsgMap message)
         {
-            Debug.Assert(_netManager.IsClient, "Why is the server calling this?");
+            DebugTools.Assert(_netManager.IsClient, "Why is the server calling this?");
 
             var x = message.SingleTurf.X;
             var y = message.SingleTurf.Y;
@@ -209,7 +210,7 @@ namespace SS14.Shared.Map
 
         private void CollectMapInfo(MsgMap message)
         {
-            Debug.Assert(_netManager.IsClient, "Why is the server calling this?");
+            DebugTools.Assert(_netManager.IsClient, "Why is the server calling this?");
 
             _gridsToReceive = message.MapGridsToSend;
 

--- a/SS14.Shared/Map/TileDefinition.cs
+++ b/SS14.Shared/Map/TileDefinition.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using SS14.Shared.Interfaces.Map;
+using SS14.Shared.Utility;
 
 namespace SS14.Shared.Map
 {
@@ -12,7 +13,7 @@ namespace SS14.Shared.Map
         {
             get
             {
-                Debug.Assert(_tileId != ushort.MaxValue);
+                DebugTools.Assert(_tileId != ushort.MaxValue);
                 return _tileId;
             }
         }

--- a/SS14.Shared/Network/NetManager.cs
+++ b/SS14.Shared/Network/NetManager.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using Lidgren.Network;
 using SS14.Shared.Configuration;
@@ -8,6 +7,7 @@ using SS14.Shared.Interfaces.Configuration;
 using SS14.Shared.Interfaces.Network;
 using SS14.Shared.IoC;
 using SS14.Shared.Log;
+using SS14.Shared.Utility;
 
 namespace SS14.Shared.Network
 {
@@ -171,7 +171,7 @@ namespace SS14.Shared.Network
                 return;
 
             // server on the other hand needs it to be running
-            Debug.Assert(_netPeer != null);
+            DebugTools.Assert(_netPeer != null);
 
             NetIncomingMessage msg;
             while ((msg = _netPeer.ReadMessage()) != null)
@@ -217,9 +217,9 @@ namespace SS14.Shared.Network
         /// <inheritdoc />
         public void ClientConnect(string host, int port)
         {
-            Debug.Assert(_netPeer != null);
-            Debug.Assert(!IsServer, "Should never be called on the server.");
-            Debug.Assert(!IsConnected);
+            DebugTools.Assert(_netPeer != null);
+            DebugTools.Assert(!IsServer, "Should never be called on the server.");
+            DebugTools.Assert(!IsConnected);
 
             if (_netPeer.ConnectionsCount > 0)
                 ClientDisconnect("Client left server.");
@@ -231,13 +231,13 @@ namespace SS14.Shared.Network
         /// <inheritdoc />
         public void ClientDisconnect(string reason)
         {
-            Debug.Assert(IsClient, "Should never be called on the server.");
+            DebugTools.Assert(IsClient, "Should never be called on the server.");
 
             if (_netPeer == null)
                 return;
 
             // Client should never have more than one connection.
-            Debug.Assert(_netPeer.ConnectionsCount <= 1);
+            DebugTools.Assert(_netPeer.ConnectionsCount <= 1);
 
             foreach (var connection in _netPeer.Connections)
             {

--- a/SS14.Shared/Network/StringTable.cs
+++ b/SS14.Shared/Network/StringTable.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using Lidgren.Network;
 using SS14.Shared.Interfaces.Network;
+using SS14.Shared.Utility;
 
 namespace SS14.Shared.Network
 {
@@ -46,7 +46,7 @@ namespace SS14.Shared.Network
         /// </summary>
         public void Initialize(INetManager network, InitCallback callback = null)
         {
-            Debug.Assert(!_initialized);
+            DebugTools.Assert(!_initialized);
 
             _callback = callback;
             _network = network;
@@ -145,7 +145,7 @@ namespace SS14.Shared.Network
         /// <returns>The ID of the added string.</returns>
         public void AddStringFixed(int id, string str)
         {
-            Debug.Assert(_network != null, "You need to call Initialize.");
+            DebugTools.Assert(_network != null, "You need to call Initialize.");
 
             // The client should receive the table from the server, not add their own.
             if (_network.IsClient)

--- a/SS14.Shared/SS14.Shared.csproj
+++ b/SS14.Shared/SS14.Shared.csproj
@@ -275,6 +275,7 @@
     <Compile Include="Timing\GameLoop.cs" />
     <Compile Include="Timing\IStopwatch.cs" />
     <Compile Include="Timing\Stopwatch.cs" />
+    <Compile Include="Utility\DebugTools.cs" />
     <Compile Include="Utility\ResourcePath.cs" />
     <Compile Include="Utility\QuadTree.cs" />
     <Compile Include="Reflection\ReflectAttribute.cs" />

--- a/SS14.Shared/Utility/DebugTools.cs
+++ b/SS14.Shared/Utility/DebugTools.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace SS14.Shared.Utility
+{
+    public static class DebugTools
+    {
+        /// <summary>
+        ///     An assertion that will always <see langword="throw" /> an exception.
+        /// </summary>
+        /// <param name="message">Exception message.</param>
+        [Conditional("DEBUG")]
+        public static void Assert(string message)
+        {
+            throw new DebugAssertException(message);
+        }
+
+        /// <summary>
+        ///     An assertion that will <see langword="throw" /> an exception if the
+        ///     <paramref name="condition" /> is not true.
+        /// </summary>
+        /// <param name="condition">Condition that must be true.</param>
+        [Conditional("DEBUG")]
+        public static void Assert(bool condition)
+        {
+            if (!condition)
+                throw new DebugAssertException();
+        }
+
+        /// <summary>
+        ///     An assertion that will <see langword="throw" /> an exception if the
+        ///     <paramref name="condition" /> is not true.
+        /// </summary>
+        /// <param name="condition">Condition that must be true.</param>
+        /// <param name="message">Exception message.</param>
+        [Conditional("DEBUG")]
+        public static void Assert(bool condition, string message)
+        {
+            if (!condition)
+                throw new DebugAssertException(message);
+        }
+    }
+
+    public class DebugAssertException : Exception
+    {
+        public DebugAssertException() { }
+        public DebugAssertException(string message) : base(message) { }
+    }
+}


### PR DESCRIPTION
Added a new DebugTools.Assert function to replace the System Assert. The System assert does not work well on mono, and was not gracefully handled by Visual Studio. This version now throws a unique exception when it fails, instead of the popup window. You can setup Visual Studio to break whenever the exception is thrown. The call sites to the new Assert are still removed in release builds, similar to the System version.

This resolves #569 without needing to add a trace listener.