### PR TITLE
Client name change command

### DIFF
--- a/SS14.Client/BaseClient.cs
+++ b/SS14.Client/BaseClient.cs
@@ -40,10 +40,8 @@ namespace SS14.Client
         /// <inheritdoc />
         public ServerInfo GameInfo { get; private set; }
 
-        /// <summary>
-        /// A player name to use when connecting to the server instead of the one found in the configuration.
-        /// </summary>
-        public string PlayerNameForDebug = null;
+        /// <inheritdoc />
+        public string PlayerNameOverride { get; set; }
 
         /// <inheritdoc />
         public void Initialize()
@@ -68,7 +66,7 @@ namespace SS14.Client
             _net.Startup();
 
             OnRunLevelChanged(ClientRunLevel.Connecting);
-            _net.ClientConnect(ip, port, PlayerNameForDebug ?? _configManager.GetCVar<string>("player.name"));
+            _net.ClientConnect(ip, port, PlayerNameOverride ?? _configManager.GetCVar<string>("player.name"));
         }
 
         /// <inheritdoc />

--- a/SS14.Client/BaseClient.cs
+++ b/SS14.Client/BaseClient.cs
@@ -40,6 +40,11 @@ namespace SS14.Client
         /// <inheritdoc />
         public ServerInfo GameInfo { get; private set; }
 
+        /// <summary>
+        /// A player name to use when connecting to the server instead of the one found in the configuration.
+        /// </summary>
+        public string PlayerNameForDebug = null;
+
         /// <inheritdoc />
         public void Initialize()
         {
@@ -63,7 +68,7 @@ namespace SS14.Client
             _net.Startup();
 
             OnRunLevelChanged(ClientRunLevel.Connecting);
-            _net.ClientConnect(ip, port, _configManager.GetCVar<string>("player.name"));
+            _net.ClientConnect(ip, port, PlayerNameForDebug ?? _configManager.GetCVar<string>("player.name"));
         }
 
         /// <inheritdoc />

--- a/SS14.Client/Console/Commands/Debug.cs
+++ b/SS14.Client/Console/Commands/Debug.cs
@@ -19,8 +19,6 @@ using System.Globalization;
 using SS14.Shared.Interfaces.Map;
 using SS14.Shared.GameObjects.Components.Transform;
 using System.Linq;
-using SS14.Client.Interfaces.GameObjects;
-using SS14.Shared.Interfaces.Configuration;
 
 namespace SS14.Client.Console.Commands
 {

--- a/SS14.Client/Console/Commands/Debug.cs
+++ b/SS14.Client/Console/Commands/Debug.cs
@@ -20,6 +20,7 @@ using SS14.Shared.Interfaces.Map;
 using SS14.Shared.GameObjects.Components.Transform;
 using System.Linq;
 using SS14.Client.Interfaces.GameObjects;
+using SS14.Shared.Interfaces.Configuration;
 
 namespace SS14.Client.Console.Commands
 {
@@ -287,6 +288,32 @@ namespace SS14.Client.Console.Commands
             foreach (var entity in grid.GetSnapGridCell(indices, offset))
             {
                 console.AddLine(entity.Owner.Uid.ToString());
+            }
+
+            return false;
+        }
+    }
+
+    class SetPlayerName : IConsoleCommand
+    {
+        public string Command => "overrideplayername";
+        public string Description => "Changes the name used when attempting to connect to the server.";
+        public string Help => Command + " <name>";
+
+        public bool Execute(IDebugConsole console, params string[] args)
+        {
+            var client = IoCManager.Resolve<IBaseClient>();
+
+            if (client is BaseClient bc)
+            {
+                var oldName = bc.PlayerNameForDebug;
+                bc.PlayerNameForDebug = args[0];
+
+                console.AddLine($"Overriding player name to \"{args[0]}\".", Color.White);
+            }
+            else
+            {
+                console.AddLine($"Cannot override name for client {client}.", Color.White);
             }
 
             return false;

--- a/SS14.Client/Console/Commands/Debug.cs
+++ b/SS14.Client/Console/Commands/Debug.cs
@@ -301,18 +301,9 @@ namespace SS14.Client.Console.Commands
         public bool Execute(IDebugConsole console, params string[] args)
         {
             var client = IoCManager.Resolve<IBaseClient>();
+            client.PlayerNameOverride = args[0];
 
-            if (client is BaseClient bc)
-            {
-                var oldName = bc.PlayerNameForDebug;
-                bc.PlayerNameForDebug = args[0];
-
-                console.AddLine($"Overriding player name to \"{args[0]}\".", Color.White);
-            }
-            else
-            {
-                console.AddLine($"Cannot override name for client {client}.", Color.White);
-            }
+            console.AddLine($"Overriding player name to \"{args[0]}\".", Color.White);
 
             return false;
         }

--- a/SS14.Client/Interfaces/IBaseClient.cs
+++ b/SS14.Client/Interfaces/IBaseClient.cs
@@ -24,6 +24,11 @@ namespace SS14.Client.Interfaces
         ServerInfo GameInfo { get; }
 
         /// <summary>
+        /// A player name to use when connecting to the server instead of the one found in the configuration.
+        /// </summary>
+        string PlayerNameOverride { get; set; }
+
+        /// <summary>
         ///     Raised when the client RunLevel is changed.
         /// </summary>
         event EventHandler<RunLevelChangedEventArgs> RunLevelChanged;


### PR DESCRIPTION
Adds member field to BaseClient to hold onto override name string. Figured that was the closest place to the usage, so why not stick it there.
On connecting to the server, the client will prefer to use that name, if it's set, over the name from the configuration.

Adds client console command to set that field.

Fixes #660 