### PR TITLE
UI Range Check

### DIFF
--- a/SS14.Client/GameObjects/Components/UserInterface/ClientUserInterfaceComponent.cs
+++ b/SS14.Client/GameObjects/Components/UserInterface/ClientUserInterfaceComponent.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using SS14.Shared.GameObjects;
 using SS14.Shared.GameObjects.Components.UserInterface;
@@ -61,7 +61,7 @@ namespace SS14.Client.GameObjects.Components.UserInterface
                             break;
 
                         case CloseBoundInterfaceMessage _:
-                            Close(wrapped.UiKey);
+                            Close(wrapped.UiKey, true);
                             break;
 
                         default:
@@ -86,15 +86,16 @@ namespace SS14.Client.GameObjects.Components.UserInterface
             boundInterface.Open();
             _openInterfaces[wrapped.UiKey] = boundInterface;
         }
-
-        internal void Close(object uiKey)
+        
+        internal void Close(object uiKey, bool remoteCall)
         {
             if (!_openInterfaces.TryGetValue(uiKey, out var boundUserInterface))
             {
                 return;
             }
 
-            SendMessage(new CloseBoundInterfaceMessage(), uiKey);
+            if(!remoteCall)
+                SendMessage(new CloseBoundInterfaceMessage(), uiKey);
             _openInterfaces.Remove(uiKey);
             boundUserInterface.Dispose();
         }
@@ -151,7 +152,7 @@ namespace SS14.Client.GameObjects.Components.UserInterface
         /// </summary>
         protected void Close()
         {
-            Owner.Close(UiKey);
+            Owner.Close(UiKey, false);
         }
 
         /// <summary>

--- a/SS14.Server/GameObjects/Components/UserInterface/ServerUserInterfaceComponent.cs
+++ b/SS14.Server/GameObjects/Components/UserInterface/ServerUserInterfaceComponent.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using SS14.Server.Interfaces.Player;
 using SS14.Shared.Enums;
@@ -21,6 +21,11 @@ namespace SS14.Server.GameObjects.Components.UserInterface
     {
         private readonly Dictionary<object, BoundUserInterface> _interfaces =
             new Dictionary<object, BoundUserInterface>();
+
+        /// <summary>
+        ///     Enumeration of all the interfaces this component provides.
+        /// </summary>
+        public IEnumerable<BoundUserInterface> Interfaces => _interfaces.Values;
 
         public override void ExposeData(ObjectSerializer serializer)
         {
@@ -94,6 +99,11 @@ namespace SS14.Server.GameObjects.Components.UserInterface
         public ServerUserInterfaceComponent Owner { get; }
         private readonly HashSet<IPlayerSession> _subscribedSessions = new HashSet<IPlayerSession>();
         private BoundUserInterfaceState _lastState;
+
+        /// <summary>
+        ///     All of the sessions currently subscribed to this UserInterface.
+        /// </summary>
+        public IEnumerable<IPlayerSession> SubscribedSessions => _subscribedSessions;
 
         public event Action<BoundUserInterfaceMessage> OnReceiveMessage;
 
@@ -172,7 +182,7 @@ namespace SS14.Server.GameObjects.Components.UserInterface
                 throw new ArgumentNullException(nameof(session));
             }
 
-            if (_subscribedSessions.Contains(session))
+            if (!_subscribedSessions.Contains(session))
             {
                 return;
             }

--- a/SS14.Server/GameObjects/EntitySystems/UserInterfaceSystem.cs
+++ b/SS14.Server/GameObjects/EntitySystems/UserInterfaceSystem.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using SS14.Server.GameObjects.Components.UserInterface;
+using SS14.Server.Interfaces.Player;
+using SS14.Shared.GameObjects;
+using SS14.Shared.GameObjects.Systems;
+using SS14.Shared.Interfaces.GameObjects.Components;
+
+namespace SS14.Server.GameObjects.EntitySystems
+{
+    internal class UserInterfaceSystem : EntitySystem
+    {
+        private const float MaxWindowRange = 2;
+        private const float MaxWindowRangeSquared = MaxWindowRange * MaxWindowRange;
+
+        private readonly List<IPlayerSession> _sessionCache = new List<IPlayerSession>();
+
+        /// <inheritdoc />
+        public override void Initialize()
+        {
+            EntityQuery = new TypeEntityQuery(typeof(ServerUserInterfaceComponent));
+        }
+
+        /// <inheritdoc />
+        public override void Update(float frameTime)
+        {
+            foreach (var entity in RelevantEntities)
+            {
+                var uiComp = entity.GetComponent<ServerUserInterfaceComponent>();
+
+                CheckRange(entity.Transform, uiComp);
+            }
+        }
+
+        /// <summary>
+        ///     Verify that the subscribed clients are still in range of the entity.
+        /// </summary>
+        /// <param name="transformComp">Transform Component of the entity being checked.</param>
+        /// <param name="uiComp">UserInterface Component of entity being checked.</param>
+        private void CheckRange(ITransformComponent transformComp, ServerUserInterfaceComponent uiComp)
+        {
+            foreach (var ui in uiComp.Interfaces)
+            {
+                // We have to cache the set of sessions because Unsubscribe modifies the original.
+                _sessionCache.Clear();
+                _sessionCache.AddRange(ui.SubscribedSessions);
+
+                if (_sessionCache.Count == 0)
+                    continue;
+
+                var uiPos = transformComp.WorldPosition;
+                var uiMap = transformComp.MapID;
+
+                foreach (var session in _sessionCache)
+                {
+                    var attachedEntity = session.AttachedEntity;
+
+                    // The component manages the set of sessions, so this invalid session should be removed soon.
+                    if (attachedEntity == null || !attachedEntity.IsValid())
+                        continue;
+
+                    if (uiMap != attachedEntity.Transform.MapID)
+                    {
+                        ui.Close(session);
+                        continue;
+                    }
+
+                    var distanceSquared = (uiPos - attachedEntity.Transform.WorldPosition).LengthSquared;
+                    if (distanceSquared > MaxWindowRangeSquared)
+                        ui.Close(session);
+                }
+            }
+        }
+    }
+}

--- a/SS14.Server/SS14.Server.csproj
+++ b/SS14.Server/SS14.Server.csproj
@@ -124,6 +124,7 @@
     <Compile Include="GameObjects\Components\UserInterface\ServerUserInterfaceComponent.cs" />
     <Compile Include="GameObjects\EntitySystems\InputSystem.cs" />
     <Compile Include="GameObjects\EntitySystems\MoverSystem.cs" />
+    <Compile Include="GameObjects\EntitySystems\UserInterfaceSystem.cs" />
     <Compile Include="Interfaces\Player\IPlayerData.cs" />
     <Compile Include="Player\PlayerData.cs" />
     <Compile Include="Prototypes\ServerPrototypeManager.cs" />


### PR DESCRIPTION
Clients are now properly unsubscribed from entities when they move out of range. This prevents clients from being able to control entities from across the map.