### PR TITLE
Automatically log in people connecting from localhost.

### DIFF
--- a/SS14.Server/server_config.toml
+++ b/SS14.Server/server_config.toml
@@ -25,3 +25,7 @@ welcomemsg = "Welcome to the server!"
 width = 120
 height = 60
 password = "honk"
+# If this is true, people connecting from this machine (loopback)
+# will automatically be elevated to full admin privileges.
+# This literally works by checking if address == 127.0.0.1 || address == ::1
+loginlocal = true


### PR DESCRIPTION
This can be disabled with a config value, which should be done for production servers, but for local testing this is very convenient.