### PR TITLE
Unparent transform fix.

### DIFF
--- a/SS14.Server/GameObjects/Components/Container/Container.cs
+++ b/SS14.Server/GameObjects/Components/Container/Container.cs
@@ -120,12 +120,14 @@ namespace SS14.Server.GameObjects.Components.Container
         /// <inheritdoc />
         public virtual bool CanInsert(IEntity toinsert)
         {
+            // cannot insert into itself.
+            if (Owner == toinsert)
+                return false;
+
             // Crucial, prevent circular insertion.
-            if (toinsert.Transform.ContainsEntity(Owner.Transform))
-            {
-                throw new InvalidOperationException("Attempt to insert entity into one of its children.");
-            }
-            return true;
+            return !toinsert.Transform.ContainsEntity(Owner.Transform);
+
+            //Improvement: Traverse the entire tree to make sure we are not creating a loop.
         }
 
         /// <inheritdoc />
@@ -150,7 +152,7 @@ namespace SS14.Server.GameObjects.Components.Container
         /// <summary>
         /// Implement to remove the reference you used to store the entity
         /// </summary>
-        /// <param name="toinsert"></param>
+        /// <param name="toremove"></param>
         protected abstract void InternalRemove(IEntity toremove);
 
         /// <inheritdoc />

--- a/SS14.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/SS14.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -280,7 +280,7 @@ namespace SS14.Shared.GameObjects.Components.Transform
             Parent = null;
 
             // switch position back to grid coords
-            _position = localPosition.Position;
+            SetPosition(localPosition.Position);
 
             Dirty();
         }

--- a/SS14.UnitTesting/Server/GameObjects/Components/Container_Test.cs
+++ b/SS14.UnitTesting/Server/GameObjects/Components/Container_Test.cs
@@ -73,7 +73,7 @@ namespace SS14.UnitTesting.Server.GameObjects
             Assert.That(transform.Parent.Owner, Is.EqualTo(owner));
 
             var container2 = ContainerManagerComponent.Create<Container>("dummy", inserted);
-            Assert.That(() => container2.Insert(owner), Throws.InvalidOperationException);
+            Assert.That(container2.Insert(owner), Is.False);
 
             var success = container.Remove(inserted);
             Assert.That(success, Is.True);


### PR DESCRIPTION
Fixed bug where Godot node is not being sync'd with SS14 transform when unparenting.

This solves the issue where *sometimes* a weapon dropped will be placed at 0,0 instead of the mouse location.

This also fixed the issue with CanInsert() throwing an exception (https://github.com/space-wizards/space-station-14-content/issues/128), now it properly returns false.