### PR TITLE
Instanced IoCManager

### DIFF
--- a/SS14.Shared/IoC/DependencyAttribute.cs
+++ b/SS14.Shared/IoC/DependencyAttribute.cs
@@ -19,7 +19,7 @@ namespace SS14.Shared.IoC
     /// If you would like to run code after the dependencies have been injected, use <see cref="IPostInjectInit" />
     /// </para>
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Field)]
     public class DependencyAttribute : Attribute
     {
     }

--- a/SS14.Shared/IoC/DependencyCollection.cs
+++ b/SS14.Shared/IoC/DependencyCollection.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Reflection;
+using SS14.Shared.IoC.Exceptions;
+using SS14.Shared.Utility;
+
+namespace SS14.Shared.IoC
+{
+    /// <inheritdoc />
+    internal class DependencyCollection : IDependencyCollection
+    {
+        /// <summary>
+        /// Dictionary that maps the types passed to <see cref="Resolve{T}"/> to their implementation.
+        /// </summary>
+        private readonly Dictionary<Type, object> _services = new Dictionary<Type, object>();
+
+        /// <summary>
+        /// The types interface types mapping to their registered implementations.
+        /// This is pulled from to make a service if it doesn't exist yet.
+        /// </summary>
+        private readonly Dictionary<Type, Type> _resolveTypes = new Dictionary<Type, Type>();
+
+        /// <inheritdoc />
+        public void Register<TInterface, TImplementation>(bool overwrite = false)
+            where TImplementation : class, TInterface, new()
+        {
+            var interfaceType = typeof(TInterface);
+            if (_resolveTypes.ContainsKey(interfaceType))
+            {
+                if (!overwrite)
+                {
+                    throw new InvalidOperationException
+                    (
+                        string.Format("Attempted to register already registered interface {0}. New implementation: {1}, Old implementation: {2}",
+                        interfaceType, typeof(TImplementation), _resolveTypes[interfaceType]
+                    ));
+                }
+
+                if (_services.ContainsKey(interfaceType))
+                {
+                    throw new InvalidOperationException($"Attempted to overwrite already instantiated interface {interfaceType}.");
+                }
+            }
+
+            _resolveTypes[interfaceType] = typeof(TImplementation);
+        }
+
+        /// <inheritdoc />
+        public void Clear()
+        {
+            foreach (var service in _services.Values.OfType<IDisposable>().Distinct())
+            {
+                try
+                {
+                    service.Dispose();
+                }
+                catch (Exception e)
+                {
+                    // DON'T use the logger since it might be dead already.
+                    System.Console.WriteLine($"Caught exception inside {service.GetType()} dispose! {e}");
+                }
+            }
+            _services.Clear();
+            _resolveTypes.Clear();
+        }
+
+        /// <inheritdoc />
+        [Pure]
+        public T Resolve<T>()
+        {
+            return (T)ResolveType(typeof(T));
+        }
+
+        /// <inheritdoc />
+        [Pure]
+        public object ResolveType(Type type)
+        {
+            if (_services.TryGetValue(type, out var value))
+            {
+                return value;
+            }
+
+            if (_resolveTypes.ContainsKey(type))
+            {
+                // If we have the type registered but not created that means we haven't been told to initialize the graph yet.
+                throw new InvalidOperationException($"Attempted to resolve type {type} before the object graph for it has been populated.");
+            }
+
+            throw new UnregisteredTypeException(type);
+
+        }
+
+        /// <inheritdoc />
+        public void BuildGraph()
+        {
+            // List of all objects we need to inject dependencies into.
+            var injectList = new List<object>();
+
+            // First we build every type we have registered but isn't yet built.
+            // This allows us to run this after the content assembly has been loaded.
+            foreach (KeyValuePair<Type, Type> currentType in _resolveTypes.Where(p => !_services.ContainsKey(p.Key)))
+            {
+                // Find a potential dupe by checking other registered types that have already been instantiated that have the same instance type.
+                // Can't catch ourselves because we're not instantiated.
+                // Ones that aren't yet instantiated are about to be and will find us instead.
+                KeyValuePair<Type, Type> dupeType = _resolveTypes.FirstOrDefault(p => _services.ContainsKey(p.Key) && p.Value == currentType.Value);
+
+                // Interface key can't be null so since KeyValuePair<> is a struct,
+                // this effectively checks whether we found something.
+                if (dupeType.Key != null)
+                {
+                    // We have something with the same instance type, use that.
+                    _services[currentType.Key] = _services[dupeType.Key];
+                    continue;
+                }
+
+                try
+                {
+                    var instance = Activator.CreateInstance(currentType.Value);
+                    _services[currentType.Key] = instance;
+                    injectList.Add(instance);
+                }
+                catch (TargetInvocationException e)
+                {
+                    throw new ImplementationConstructorException(currentType.Value, e.InnerException);
+                }
+            }
+
+            // Graph built, go over ones that need injection.
+            foreach (var implementation in injectList)
+            {
+                InjectDependencies(implementation);
+            }
+
+            foreach (var injectedItem in injectList.OfType<IPostInjectInit>())
+            {
+                injectedItem.PostInject();
+            }
+        }
+
+        /// <inheritdoc />
+        public void InjectDependencies(object obj)
+        {
+            foreach (var field in obj.GetType().GetAllFields()
+                            .Where(p => Attribute.GetCustomAttribute(p, typeof(DependencyAttribute)) != null))
+            {
+                // Not using Resolve<T>() because we're literally building it right now.
+                if (!_services.ContainsKey(field.FieldType))
+                {
+                    throw new UnregisteredDependencyException(obj.GetType(), field.FieldType, field.Name);
+                }
+
+                // Quick note: this DOES work with read only fields, though it may be a CLR implementation detail.
+                field.SetValue(obj, _services[field.FieldType]);
+            }
+        }
+    }
+}

--- a/SS14.Shared/IoC/Exceptions/ImplementationConstructorException.cs
+++ b/SS14.Shared/IoC/Exceptions/ImplementationConstructorException.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SS14.Shared.IoC.Exceptions
 {

--- a/SS14.Shared/IoC/IDependencyCollection.cs
+++ b/SS14.Shared/IoC/IDependencyCollection.cs
@@ -1,6 +1,5 @@
-﻿using SS14.Shared.IoC.Exceptions;
-using System;
-using System.Diagnostics.Contracts;
+﻿using System;
+using SS14.Shared.IoC.Exceptions;
 
 namespace SS14.Shared.IoC
 {
@@ -24,12 +23,10 @@ namespace SS14.Shared.IoC
     /// </para>
     /// </remarks>
     /// <seealso cref="Interfaces.Reflection.IReflectionManager"/>
-    public static class IoCManager
+    public interface IDependencyCollection
     {
-        private static readonly IDependencyCollection _container = new DependencyCollection();
-
         /// <summary>
-        /// Registers an interface to an implementation, to make it accessible to <see cref="Resolve{T}"/>
+        /// Registers an interface to an implementation, to make it accessible to <see cref="DependencyCollection.Resolve{T}"/>
         /// </summary>
         /// <typeparam name="TInterface">The type that will be resolvable.</typeparam>
         /// <typeparam name="TImplementation">The type that will be constructed as implementation.</typeparam>
@@ -39,23 +36,16 @@ namespace SS14.Shared.IoC
         /// </param>
         /// <exception cref="InvalidOperationException">
         /// Thrown if <paramref name="overwrite"/> is false and <typeparamref name="TInterface"/> has been registered before,
-        /// or if an already instantiated interface (by <see cref="BuildGraph"/>) is attempting to be overwriten.
+        /// or if an already instantiated interface (by <see cref="DependencyCollection.BuildGraph"/>) is attempting to be overwritten.
         /// </exception>
-        public static void Register<TInterface, TImplementation>(bool overwrite = false)
-            where TImplementation : class, TInterface, new()
-        {
-            _container.Register<TInterface, TImplementation>(overwrite);
-        }
+        void Register<TInterface, TImplementation>(bool overwrite = false) where TImplementation : class, TInterface, new();
 
         /// <summary>
         /// Clear all services and types.
         /// Use this between unit tests and on program shutdown.
         /// If a service implements <see cref="IDisposable"/>, <see cref="IDisposable.Dispose"/> will be called on it.
         /// </summary>
-        public static void Clear()
-        {
-            _container.Clear();
-        }
+        void Clear();
 
         /// <summary>
         /// Resolve a dependency manually.
@@ -65,11 +55,7 @@ namespace SS14.Shared.IoC
         /// Thrown if the resolved type hasn't been created yet
         /// because the object graph still needs to be constructed for it.
         /// </exception>
-        [Pure]
-        public static T Resolve<T>()
-        {
-            return (T)ResolveType(typeof(T));
-        }
+        T Resolve<T>();
 
         /// <summary>
         /// Resolve a dependency manually.
@@ -79,20 +65,13 @@ namespace SS14.Shared.IoC
         /// Thrown if the resolved type hasn't been created yet
         /// because the object graph still needs to be constructed for it.
         /// </exception>
-        [Pure]
-        public static object ResolveType(Type type)
-        {
-            return _container.ResolveType(type);
-        }
+        object ResolveType(Type type);
 
         /// <summary>
         /// Initializes the object graph by building every object and resolving all dependencies.
         /// </summary>
-        /// <seealso cref="InjectDependencies(object)"/>
-        public static void BuildGraph()
-        {
-            _container.BuildGraph();
-        }
+        /// <seealso cref="DependencyCollection.InjectDependencies"/>
+        void BuildGraph();
 
         /// <summary>
         ///     Injects dependencies into all fields with <see cref="DependencyAttribute"/> on the provided object.
@@ -105,10 +84,7 @@ namespace SS14.Shared.IoC
         /// <exception cref="UnregisteredDependencyException">
         ///     Thrown if a dependency field on the object is not registered.
         /// </exception>
-        /// <seealso cref="BuildGraph"/>
-        public static void InjectDependencies(object obj)
-        {
-            _container.InjectDependencies(obj);
-        }
+        /// <seealso cref="DependencyCollection.BuildGraph"/>
+        void InjectDependencies(object obj);
     }
 }

--- a/SS14.Shared/IoC/IDependencyCollection.cs
+++ b/SS14.Shared/IoC/IDependencyCollection.cs
@@ -27,6 +27,7 @@ namespace SS14.Shared.IoC
     {
         /// <summary>
         /// Registers an interface to an implementation, to make it accessible to <see cref="DependencyCollection.Resolve{T}"/>
+        /// <see cref="IDependencyCollection.BuildGraph"/> MUST be called after this method to make the new interface available.
         /// </summary>
         /// <typeparam name="TInterface">The type that will be resolvable.</typeparam>
         /// <typeparam name="TImplementation">The type that will be constructed as implementation.</typeparam>
@@ -38,7 +39,23 @@ namespace SS14.Shared.IoC
         /// Thrown if <paramref name="overwrite"/> is false and <typeparamref name="TInterface"/> has been registered before,
         /// or if an already instantiated interface (by <see cref="DependencyCollection.BuildGraph"/>) is attempting to be overwritten.
         /// </exception>
-        void Register<TInterface, TImplementation>(bool overwrite = false) where TImplementation : class, TInterface, new();
+        void Register<TInterface, TImplementation>(bool overwrite = false)
+            where TImplementation : class, TInterface, new();
+
+        /// <summary>
+        ///     Registers an interface to an existing instance of an implementation,
+        ///     making it accessible to <see cref="IDependencyCollection.Resolve{T}"/>.
+        ///     Unlike <see cref="IDependencyCollection.Register{TInterface, TImplementation}"/>,
+        ///     <see cref="IDependencyCollection.BuildGraph"/> does not need to be called after registering an instance.
+        /// </summary>
+        /// <typeparam name="TInterface">The type that will be resolvable.</typeparam>
+        /// <typeparam name="TImplementation">The type that will be constructed as implementation.</typeparam>
+        /// <param name="implementation">The existing instance to use as the implementation.</param>
+        /// <param name="overwrite">
+        /// If true, do not throw an <see cref="InvalidOperationException"/> if an interface is already registered,
+        /// replace the current implementation instead.
+        /// </param>
+        void RegisterInstance<TInterface>(object implementation, bool overwrite = false);
 
         /// <summary>
         /// Clear all services and types.

--- a/SS14.Shared/IoC/IoCManager.cs
+++ b/SS14.Shared/IoC/IoCManager.cs
@@ -39,12 +39,30 @@ namespace SS14.Shared.IoC
         /// </param>
         /// <exception cref="InvalidOperationException">
         /// Thrown if <paramref name="overwrite"/> is false and <typeparamref name="TInterface"/> has been registered before,
-        /// or if an already instantiated interface (by <see cref="BuildGraph"/>) is attempting to be overwriten.
+        /// or if an already instantiated interface (by <see cref="BuildGraph"/>) is attempting to be overwritten.
         /// </exception>
         public static void Register<TInterface, TImplementation>(bool overwrite = false)
             where TImplementation : class, TInterface, new()
         {
             _container.Register<TInterface, TImplementation>(overwrite);
+        }
+
+        /// <summary>
+        ///     Registers an interface to an existing instance of an implementation,
+        ///     making it accessible to <see cref="IDependencyCollection.Resolve{T}"/>.
+        ///     Unlike <see cref="IDependencyCollection.Register{TInterface, TImplementation}"/>,
+        ///     <see cref="IDependencyCollection.BuildGraph"/> does not need to be called after registering an instance.
+        /// </summary>
+        /// <typeparam name="TInterface">The type that will be resolvable.</typeparam>
+        /// <typeparam name="TImplementation">The type that will be constructed as implementation.</typeparam>
+        /// <param name="implementation">The existing instance to use as the implementation.</param>
+        /// <param name="overwrite">
+        /// If true, do not throw an <see cref="InvalidOperationException"/> if an interface is already registered,
+        /// replace the current implementation instead.
+        /// </param>
+        public static void RegisterInstance<TInterface>(object implementation, bool overwrite = false)
+        {
+            _container.RegisterInstance<TInterface>(implementation, overwrite);
         }
 
         /// <summary>
@@ -68,7 +86,7 @@ namespace SS14.Shared.IoC
         [Pure]
         public static T Resolve<T>()
         {
-            return (T)ResolveType(typeof(T));
+            return _container.Resolve<T>();
         }
 
         /// <summary>

--- a/SS14.Shared/IoC/IoCManager.cs
+++ b/SS14.Shared/IoC/IoCManager.cs
@@ -56,25 +56,25 @@ namespace SS14.Shared.IoC
         /// </exception>
         public static void Register<TInterface, TImplementation>(bool overwrite = false) where TImplementation : class, TInterface, new()
         {
-            var InterfaceType = typeof(TInterface);
-            if (ResolveTypes.ContainsKey(InterfaceType))
+            var interfaceType = typeof(TInterface);
+            if (ResolveTypes.ContainsKey(interfaceType))
             {
                 if (!overwrite)
                 {
                     throw new InvalidOperationException
                     (
                         string.Format("Attempted to register already registered interface {0}. New implementation: {1}, Old implementation: {2}",
-                        InterfaceType, typeof(TImplementation), ResolveTypes[InterfaceType]
+                        interfaceType, typeof(TImplementation), ResolveTypes[interfaceType]
                     ));
                 }
 
-                if (Services.ContainsKey(InterfaceType))
+                if (Services.ContainsKey(interfaceType))
                 {
-                    throw new InvalidOperationException($"Attempted to overwrite already instantiated interface {InterfaceType}.");
+                    throw new InvalidOperationException($"Attempted to overwrite already instantiated interface {interfaceType}.");
                 }
             }
 
-            ResolveTypes[InterfaceType] = typeof(TImplementation);
+            ResolveTypes[interfaceType] = typeof(TImplementation);
         }
 
         /// <summary>

--- a/SS14.Shared/SS14.Shared.csproj
+++ b/SS14.Shared/SS14.Shared.csproj
@@ -174,8 +174,10 @@
     <Compile Include="Interfaces\Timing\IGameTiming.cs" />
     <Compile Include="GameStates\GameState.cs" />
     <Compile Include="GameStates\PlayerState.cs" />
+    <Compile Include="IoC\DependencyCollection.cs" />
     <Compile Include="IoC\Exceptions\ImplementationConstructorException.cs" />
     <Compile Include="Enums\Lighting.cs" />
+    <Compile Include="IoC\IDependencyCollection.cs" />
     <Compile Include="Log\ConsoleLogHandler.cs" />
     <Compile Include="Log\FileLogHandler.cs" />
     <Compile Include="Log\LogLevel.cs" />

--- a/SS14.UnitTesting/SS14.UnitTesting.csproj
+++ b/SS14.UnitTesting/SS14.UnitTesting.csproj
@@ -59,6 +59,12 @@
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Smocks">
+      <Version>0.7.3</Version>
+    </PackageReference>
+    <PackageReference Include="Smocks.ExtensionPackage">
+      <Version>0.7.5-beta2</Version>
+    </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/SS14.UnitTesting/Shared/IoC/IoCManager_Test.cs
+++ b/SS14.UnitTesting/Shared/IoC/IoCManager_Test.cs
@@ -6,9 +6,10 @@ using Moq;
 
 namespace SS14.UnitTesting.Shared.IoC
 {
-    [TestFixture]
-    [TestOf(typeof(IoCManager))]
-    [Parallelizable]
+    /// <remarks>
+    /// This fixture CAN NOT be parallelized, because <see cref="IoCManager"/> is a static singleton.
+    /// </remarks>
+    [TestFixture, TestOf(typeof(IoCManager))]
     public class IoCManager_Test
     {
         [SetUp]


### PR DESCRIPTION
I took the functionality of `IoCManager` and moved it into a non-static class. This new class is called `DependencyCollection`. The static `IoCManager` is now just a proxy to a `DependencyCollection` singleton. I also added the ability to directly register instances into the collection. The Smocks library was added to `SS14.UnitTesting`.

This is super useful for unit testing, because now you can register mock instances directly into the collection and then other services can resolve them. You can also apply a shim to static `IoCManager` calls and handle them properly. Because the collection is instanced, we can now run tests in parallel (with a shim) that modify `IoCManager`. The Smocks library gives us the ability to shim static method calls.