### PR TITLE
Fix viewport size on window creation for OS-imposed sizes

### DIFF
--- a/SS14.Client/Graphics/Clyde/Clyde.cs
+++ b/SS14.Client/Graphics/Clyde/Clyde.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -288,6 +288,8 @@ namespace SS14.Client.Graphics.Clyde
             _drawingSplash = true;
 
             _renderHandle = new RenderHandle(this);
+
+            GL.Viewport(0, 0, _window.Width, _window.Height);
 
             Render(null);
         }


### PR DESCRIPTION
Adds a call to viewport on opengl init in order to properly initialize the viewport size when the OS imposes a window size on window creation. Fixes Windows OS tablet mode-imposed window sizes.

That System diff is a bug.