### PR TITLE
[Ready] Fix server runtimes log exception

### DIFF
--- a/SS14.Server/BaseServer.cs
+++ b/SS14.Server/BaseServer.cs
@@ -291,7 +291,7 @@ namespace SS14.Server
 
             // Wrtie down exception log
             var logPath = _config.GetCVar<string>("log.path");
-            var pathToWrite = Path.Combine(PathHelpers.ExecutableRelativeFile(logPath), "Runtime-", DateTime.Now.ToShortDateString());
+            var pathToWrite = Path.Combine(PathHelpers.ExecutableRelativeFile(logPath), "Runtime-" + DateTime.Now.ToShortDateString() + ".txt");
             File.WriteAllText(pathToWrite, runtimeLog.Display(), Encoding.UTF8);
 
             //TODO: This should prob shutdown all managers in a loop.


### PR DESCRIPTION
Fixes missing directory exception when writing the server runtimes log. Not sure if you intended to create a new directory for runtimes or just create a file name with this structure, but since it has a dash in it I assumed it's the name.