### PR TITLE
Remove SS14.Shared.Bsdiff from submodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "SS14.Shared.Bsdiff"]
-	path = SS14.Shared.Bsdiff
-	url = https://github.com/space-wizards/ss14.shared.bsdiff.git


### PR DESCRIPTION
Seems it's not really needed anymore. It can easily be brought back in the future if it's ever needed again.