### PR TITLE
Establish standard format for runtime log naming and future-proof it until the human race perishes

### DIFF
--- a/SS14.Server/BaseServer.cs
+++ b/SS14.Server/BaseServer.cs
@@ -291,7 +291,7 @@ namespace SS14.Server
 
             // Wrtie down exception log
             var logPath = _config.GetCVar<string>("log.path");
-            var pathToWrite = Path.Combine(PathHelpers.ExecutableRelativeFile(logPath), "Runtime_" + DateTime.Now.ToString("yyyyy_MM_dd") + ".txt");
+            var pathToWrite = Path.Combine(PathHelpers.ExecutableRelativeFile(logPath), "Runtime-" + DateTime.Now.ToString("yyyy-MM-dd-THH-mm-ss") + ".txt");
             File.WriteAllText(pathToWrite, runtimeLog.Display(), Encoding.UTF8);
 
             //TODO: This should prob shutdown all managers in a loop.

--- a/SS14.Server/BaseServer.cs
+++ b/SS14.Server/BaseServer.cs
@@ -291,7 +291,7 @@ namespace SS14.Server
 
             // Wrtie down exception log
             var logPath = _config.GetCVar<string>("log.path");
-            var pathToWrite = Path.Combine(PathHelpers.ExecutableRelativeFile(logPath), "Runtime-" + DateTime.Now.ToShortDateString() + ".txt");
+            var pathToWrite = Path.Combine(PathHelpers.ExecutableRelativeFile(logPath), "Runtime_" + DateTime.Now.ToString("yyyyy_MM_dd") + ".txt");
             File.WriteAllText(pathToWrite, runtimeLog.Display(), Encoding.UTF8);
 
             //TODO: This should prob shutdown all managers in a loop.


### PR DESCRIPTION
This PR establishes the format "Runtime-yyyy-MM-dd-THH-mm-dd.txt" for runtime logs from the server, preventing locale from messing with string escape characters and causing directory runtimes at next line. ~I've replaced the dash with an underscore as they can cause problems in some shells such as windows CLI.~ Dashes are staying because whoever has a shell that complains needs to get a new one.

~~**_I have most importantly made sure that SS14 can live on until the year of our Lord God Emperor and veritable saviour 99,999 Anno Domini of the Gregorian Calendar by extending the runtime-log-naming  year range to 5 digits._**~~ 
~~_Let the meme PRs begin if they haven't already_~~

4 digits so logs will display until 9999, godspeed future maintainers.