### PR TITLE
Adds a frame counter to timing debug monitor

### DIFF
--- a/SS14.Client/GameController/GameController.Godot.cs
+++ b/SS14.Client/GameController/GameController.Godot.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Godot;
 using SS14.Client.GodotGlue;
@@ -211,6 +211,7 @@ namespace SS14.Client
             public TimeSpan TickPeriod => TimeSpan.FromTicks((long)(1.0 / TickRate * TimeSpan.TicksPerSecond));
 
             public TimeSpan TickRemainder { get; set; }
+            public uint CurFrame { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
             public void ResetRealTime()
             {

--- a/SS14.Client/GameController/GameController.Standalone.cs
+++ b/SS14.Client/GameController/GameController.Standalone.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Runtime.Remoting.Channels;
 using SS14.Client.Interfaces;
@@ -46,25 +46,13 @@ namespace SS14.Client
                 SleepMode = Mode == DisplayMode.Headless ? SleepMode.Delay : SleepMode.None
             };
 
-            /*
-            var start = DateTime.Now;
-            var frames = 0;
-            */
-
             _mainLoop.Tick += (sender, args) => Update(args.DeltaSeconds);
+
             if (Mode == DisplayMode.Clyde)
             {
                 _mainLoop.Render += (sender, args) =>
                 {
-                    /*
-                    frames++;
-                    if ((DateTime.Now - start).TotalSeconds >= 1)
-                    {
-                        Logger.Info(frames.ToString());
-                        start = DateTime.Now;
-                        frames = 0;
-                    }
-                    */
+                    _gameTimingHeadless.CurFrame++;
                     _clyde.Render(new FrameEventArgs(args.DeltaSeconds));
                 };
                 _mainLoop.Input += (sender, args) => _clyde.ProcessInput(new FrameEventArgs(args.DeltaSeconds));

--- a/SS14.Client/UserInterface/CustomControls/DebugTimePanel.cs
+++ b/SS14.Client/UserInterface/CustomControls/DebugTimePanel.cs
@@ -1,4 +1,4 @@
-using SS14.Client.Graphics.Drawing;
+﻿using SS14.Client.Graphics.Drawing;
 using SS14.Client.Interfaces.ResourceManagement;
 using SS14.Client.ResourceManagement;
 using SS14.Client.UserInterface.Controls;
@@ -54,7 +54,7 @@ namespace SS14.Client.UserInterface.CustomControls
             }
 
             _contents.Text = $@"Paused: {_gameTiming.Paused}, CurTick: {_gameTiming.CurTick},
-CurTime: {_gameTiming.CurTime}, RealTime: {_gameTiming.RealTime}";
+CurTime: {_gameTiming.CurTime}, RealTime: {_gameTiming.RealTime}, CurFrame: {_gameTiming.CurFrame}";
 
             MinimumSizeChanged();
         }

--- a/SS14.Shared/Interfaces/Timing/IGameTiming.cs
+++ b/SS14.Shared/Interfaces/Timing/IGameTiming.cs
@@ -49,6 +49,14 @@ namespace SS14.Shared.Interfaces.Timing
         TimeSpan RealFrameTimeStdDev { get; }
 
         /// <summary>
+        ///     Current graphics frame since init OpenGL which is taken as frame 1. Useful to set a conditional breakpoint on specific frames, and
+        ///     syncrhonize with OGL debugging tools that capture frames. Depending on the tools used, this frame
+        ///     number will vary between 1 frame more or less due to how that tool is counting frames,
+        ///     i.e. starting from 0 or 1, having a separate counter, etc. Available in timing debug panel.
+        /// </summary>
+        uint CurFrame { get; set; }
+
+        /// <summary>
         ///     Average real FPS over the last 50 frames.
         /// </summary>
         double FramesPerSecondAvg { get; }

--- a/SS14.Shared/Interfaces/Timing/IGameTiming.cs
+++ b/SS14.Shared/Interfaces/Timing/IGameTiming.cs
@@ -50,7 +50,7 @@ namespace SS14.Shared.Interfaces.Timing
 
         /// <summary>
         ///     Current graphics frame since init OpenGL which is taken as frame 1. Useful to set a conditional breakpoint on specific frames, and
-        ///     syncrhonize with OGL debugging tools that capture frames. Depending on the tools used, this frame
+        ///     synchronize with OGL debugging tools that capture frames. Depending on the tools used, this frame
         ///     number will vary between 1 frame more or less due to how that tool is counting frames,
         ///     i.e. starting from 0 or 1, having a separate counter, etc. Available in timing debug panel.
         /// </summary>

--- a/SS14.Shared/Timing/GameTiming.cs
+++ b/SS14.Shared/Timing/GameTiming.cs
@@ -96,6 +96,14 @@ namespace SS14.Shared.Timing
         public TimeSpan TickRemainder { get; set; }
 
         /// <summary>
+        ///     Current graphics frame since init OpenGL which is taken as frame 1, from swapbuffer to swapbuffer. Useful to set a
+        ///     conditional breakpoint on specific frames, and syncrhonize with OGL debugging tools that capture frames.
+        ///     Depending on the tools used, this frame number will vary between 1 frame more or less due to how that tool is counting frames,
+        ///     i.e. starting from 0 or 1, having a separate counter, etc. Available in timing debug panel.
+        /// </summary>
+        public uint CurFrame { get; set; } = 1;
+
+        /// <summary>
         ///     Ends the 'lap' of the timer, updating frame time info.
         /// </summary>
         public void StartFrame()

--- a/SS14.Shared/Timing/GameTiming.cs
+++ b/SS14.Shared/Timing/GameTiming.cs
@@ -97,7 +97,7 @@ namespace SS14.Shared.Timing
 
         /// <summary>
         ///     Current graphics frame since init OpenGL which is taken as frame 1, from swapbuffer to swapbuffer. Useful to set a
-        ///     conditional breakpoint on specific frames, and syncrhonize with OGL debugging tools that capture frames.
+        ///     conditional breakpoint on specific frames, and synchronize with OGL debugging tools that capture frames.
         ///     Depending on the tools used, this frame number will vary between 1 frame more or less due to how that tool is counting frames,
         ///     i.e. starting from 0 or 1, having a separate counter, etc. Available in timing debug panel.
         /// </summary>


### PR DESCRIPTION
Use case explained in its documentation. I could probably make it a long in case someone runs at thousands of fps for days, or make it debug only.