### PR TITLE
Rework entity initialization.

### DIFF
--- a/SS14.Server/BaseServer.cs
+++ b/SS14.Server/BaseServer.cs
@@ -227,10 +227,10 @@ namespace SS14.Server
 
             IoCManager.Resolve<IConsoleShell>().Initialize();
             IoCManager.Resolve<IConGroupController>().Initialize();
+            _entities.Startup();
 
             AssemblyLoader.BroadcastRunLevel(AssemblyLoader.RunLevel.PostInit);
 
-            _entities.Startup();
             IoCManager.Resolve<IStatusHost>().Start();
 
             return false;

--- a/SS14.Server/Interfaces/GameObjects/IServerEntityManagerInternal.cs
+++ b/SS14.Server/Interfaces/GameObjects/IServerEntityManagerInternal.cs
@@ -6,17 +6,12 @@ namespace SS14.Server.Interfaces.GameObjects
 {
     interface IServerEntityManagerInternal : IServerEntityManager
     {
-        /// <summary>
-        ///     Creates a new entity from a prototype and allocates an UID,
-        ///     but does not load data yet.
-        /// </summary>
         IEntity AllocEntity(string prototypeName, EntityUid? uid = null);
 
-        /// <summary>
-        ///     "Finishes" construction on an entity created by <see cref="AllocEntity" />.
-        /// </summary>
-        /// <param name="entity">The entity to finish construction on.</param>
-        /// <param name="context">An optional context that can be used to control the construction process.</param>
-        void FinishEntity(IEntity entity, IEntityFinishContext context = null);
+        void FinishEntityLoad(IEntity entity, IEntityLoadContext context = null);
+
+        void FinishEntityInitialization(IEntity entity);
+
+        void FinishEntityStartup(IEntity entity);
     }
 }

--- a/SS14.Server/Interfaces/GameObjects/IServerEntityManagerInternal.cs
+++ b/SS14.Server/Interfaces/GameObjects/IServerEntityManagerInternal.cs
@@ -6,6 +6,9 @@ namespace SS14.Server.Interfaces.GameObjects
 {
     interface IServerEntityManagerInternal : IServerEntityManager
     {
+        // These methods are used by the map loader to do multi-stage entity construction during map load.
+        // I would recommend you refer to the MapLoader for usage.
+
         IEntity AllocEntity(string prototypeName, EntityUid? uid = null);
 
         void FinishEntityLoad(IEntity entity, IEntityLoadContext context = null);

--- a/SS14.Server/Maps/MapLoader.cs
+++ b/SS14.Server/Maps/MapLoader.cs
@@ -177,12 +177,14 @@ namespace SS14.Server.Maps
         /// <summary>
         ///     Handles the primary bulk of state during the map serialization process.
         /// </summary>
-        private class MapContext : YamlObjectSerializer.Context, IEntityFinishContext
+        private class MapContext : YamlObjectSerializer.Context, IEntityLoadContext
         {
             [Dependency]
             private readonly IMapManager _mapManager;
             [Dependency]
             private readonly ITileDefinitionManager _tileDefinitionManager;
+            [Dependency]
+            private readonly IServerEntityManagerInternal _serverEntityManager;
 
             public readonly Dictionary<GridId, int> GridIDMap = new Dictionary<GridId, int>();
             public readonly List<IMapGrid> Grids = new List<IMapGrid>();
@@ -223,7 +225,9 @@ namespace SS14.Server.Maps
 
                 // Entities are allocated in a separate step so entity UID cross references can be resolved.
                 AllocEntities();
-                FinishEntities();
+                FinishEntitiesLoad();
+                FinishEntitiesInitialization();
+                FinishEntitiesStartup();
             }
 
             void ReadMetaSection()
@@ -271,12 +275,10 @@ namespace SS14.Server.Maps
             void AllocEntities()
             {
                 var entities = RootNode.GetNode<YamlSequenceNode>("entities");
-                var entityMan = IoCManager.Resolve<IServerEntityManagerInternal>();
-
                 foreach (var entityDef in entities.Cast<YamlMappingNode>())
                 {
                     var type = entityDef.GetNode("type").AsString();
-                    var entity = entityMan.AllocEntity(type);
+                    var entity = _serverEntityManager.AllocEntity(type);
                     Entities.Add(entity);
                     if (entityDef.TryGetNode("name", out var nameNode))
                     {
@@ -285,14 +287,13 @@ namespace SS14.Server.Maps
                 }
             }
 
-            void FinishEntities()
+            void FinishEntitiesLoad()
             {
-                var entities = RootNode.GetNode<YamlSequenceNode>("entities");
-                var entityMan = IoCManager.Resolve<IServerEntityManagerInternal>();
+                var entityData = RootNode.GetNode<YamlSequenceNode>("entities");
 
-                foreach (var (entity, data) in Entities.Zip(entities, (a, b) => (a, (YamlMappingNode)b)))
+                foreach (var (entity, data) in Entities.Zip(entityData, (a, b) => (a, (YamlMappingNode)b)))
                 {
-                    CurrentReadingEntity = (YamlMappingNode)data;
+                    CurrentReadingEntity = data;
                     CurrentReadingEntityComponents = new Dictionary<string, YamlMappingNode>();
                     if (data.TryGetNode("components", out YamlSequenceNode componentList))
                     {
@@ -301,7 +302,24 @@ namespace SS14.Server.Maps
                             CurrentReadingEntityComponents[compData["type"].AsString()] = (YamlMappingNode)compData;
                         }
                     }
-                    entityMan.FinishEntity(entity, this);
+
+                    _serverEntityManager.FinishEntityLoad(entity, this);
+                }
+            }
+
+            void FinishEntitiesInitialization()
+            {
+                foreach (var entity in Entities)
+                {
+                    _serverEntityManager.FinishEntityInitialization(entity);
+                }
+            }
+
+            void FinishEntitiesStartup()
+            {
+                foreach (var entity in Entities)
+                {
+                    _serverEntityManager.FinishEntityStartup(entity);
                 }
             }
 
@@ -363,8 +381,7 @@ namespace SS14.Server.Maps
 
             void PopulateEntityList()
             {
-                var entMgr = IoCManager.Resolve<IEntityManager>();
-                foreach (var entity in entMgr.GetEntities())
+                foreach (var entity in _serverEntityManager.GetEntities())
                 {
                     if (IsMapSavable(entity))
                     {
@@ -507,7 +524,7 @@ namespace SS14.Server.Maps
                 return false;
             }
 
-            ObjectSerializer IEntityFinishContext.GetComponentSerializer(string componentName, YamlMappingNode protoData)
+            ObjectSerializer IEntityLoadContext.GetComponentSerializer(string componentName, YamlMappingNode protoData)
             {
                 if (CurrentReadingEntityComponents == null)
                 {

--- a/SS14.Server/Maps/MapLoader.cs
+++ b/SS14.Server/Maps/MapLoader.cs
@@ -219,14 +219,24 @@ namespace SS14.Server.Maps
             // Deserialization
             public void Deserialize()
             {
+                // First we load map meta data like version.
                 ReadMetaSection();
+
+                // Load grids.
                 ReadTileMapSection();
                 ReadGridSection();
 
-                // Entities are allocated in a separate step so entity UID cross references can be resolved.
+                // Entities are first allocated. This allows us to know the future UID of all entities on the map before
+                // even ExposeData is loaded. This allows us to resolve serialized EntityUid instances correctly.
                 AllocEntities();
+
+                // Actually instance components and run ExposeData on them.
                 FinishEntitiesLoad();
+
+                // Run Initialize on all components.
                 FinishEntitiesInitialization();
+
+                // Run Startup on all components.
                 FinishEntitiesStartup();
             }
 
@@ -242,6 +252,7 @@ namespace SS14.Server.Maps
 
             void ReadTileMapSection()
             {
+                // Load tile mapping so that we can map the stored tile IDs into the ones actually used at runtime.
                 _tileMap = new Dictionary<ushort, string>();
 
                 var tileMap = RootNode.GetNode<YamlMappingNode>("tilemap");
@@ -524,6 +535,7 @@ namespace SS14.Server.Maps
                 return false;
             }
 
+            // Create custom object serializers that will correctly allow data to be overriden by the map file.
             ObjectSerializer IEntityLoadContext.GetComponentSerializer(string componentName, YamlMappingNode protoData)
             {
                 if (CurrentReadingEntityComponents == null)

--- a/SS14.Shared/Interfaces/GameObjects/IEntityLoadContext.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IEntityLoadContext.cs
@@ -4,7 +4,7 @@ using YamlDotNet.RepresentationModel;
 
 namespace SS14.Shared.Interfaces.GameObjects
 {
-    interface IEntityFinishContext
+    interface IEntityLoadContext
     {
         ObjectSerializer GetComponentSerializer(string componentName, YamlMappingNode protoData);
         IEnumerable<string> GetExtraComponentTypes();

--- a/SS14.Shared/Interfaces/GameObjects/IEntityLoadContext.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IEntityLoadContext.cs
@@ -4,9 +4,20 @@ using YamlDotNet.RepresentationModel;
 
 namespace SS14.Shared.Interfaces.GameObjects
 {
-    interface IEntityLoadContext
+    /// <summary>
+    ///     Interface used to allow the map loader to override prototype data with map data.
+    /// </summary>
+    internal interface IEntityLoadContext
     {
+        /// <summary>
+        ///     Gets the serializer used to ExposeData a specific component.
+        /// </summary>
         ObjectSerializer GetComponentSerializer(string componentName, YamlMappingNode protoData);
+
+        /// <summary>
+        ///     Gets extra component names that must also be instantiated on top of the ones defined in the prototype,
+        ///     (and then deserialized with <see cref="GetComponentSerializer"/>)
+        /// </summary>
         IEnumerable<string> GetExtraComponentTypes();
     }
 }

--- a/SS14.Shared/Interfaces/GameObjects/IEntityManager.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IEntityManager.cs
@@ -26,19 +26,11 @@ namespace SS14.Shared.Interfaces.GameObjects
         #region Entity Management
 
         /// <summary>
-        /// Creates an uninitialized entity.
-        /// </summary>
-        /// <param name="protoName">Prototype template to use. If this is null, the entity will only have an
-        /// uninitialized TransformComponent inside.</param>
-        /// <returns>Newly created entity.</returns>
-        IEntity CreateEntity(string protoName);
-
-        /// <summary>
         /// Spawns an initialized entity at the default location.
         /// </summary>
         /// <param name="protoName"></param>
         /// <returns></returns>
-        Entity SpawnEntity(string protoName);
+        IEntity SpawnEntity(string protoName);
 
         /// <summary>
         /// Spawns an entity at a specific position

--- a/SS14.Shared/Prototypes/EntityPrototype.cs
+++ b/SS14.Shared/Prototypes/EntityPrototype.cs
@@ -403,7 +403,7 @@ namespace SS14.Shared.GameObjects
             }
         }
 
-        internal Entity AllocEntity(EntityUid uid, IEntityManager manager, IEntityNetworkManager networkManager)
+        internal Entity AllocEntity(EntityUid uid, IEntityManager manager)
         {
             var entity = (Entity)Activator.CreateInstance(ClassType ?? typeof(Entity));
 
@@ -415,7 +415,7 @@ namespace SS14.Shared.GameObjects
             return entity;
         }
 
-        internal void FinishEntity(Entity entity, IComponentFactory factory, IEntityFinishContext context)
+        internal void LoadEntity(Entity entity, IComponentFactory factory, IEntityLoadContext context)
         {
             YamlObjectSerializer.Context defaultContext = null;
             if (context == null)

--- a/SS14.Shared/SS14.Shared.csproj
+++ b/SS14.Shared/SS14.Shared.csproj
@@ -375,7 +375,7 @@
     <Compile Include="Interfaces\Serialization\IExposeData.cs" />
     <Compile Include="Serialization\ObjectSerializer.cs" />
     <Compile Include="Serialization\YamlObjectSerializer.cs" />
-    <Compile Include="Interfaces\GameObjects\IEntityFinishContext.cs" />
+    <Compile Include="Interfaces\GameObjects\IEntityLoadContext.cs" />
     <Compile Include="GameObjects\Components\Transform\TransformComponent.cs" />
     <Compile Include="GameObjects\Systems\EntitySystem.cs" />
     <Compile Include="Interfaces\GameObjects\Systems\IEntitySystem.cs" />


### PR DESCRIPTION
Map loading now correctly processes entity load stages:
1. First all entities are allocated. This allocates the entity and gives
   it a UID, nothing more. No user code is executed.
2. Then all entities are loaded. This runs ExposeData on components.
3. Then all entities are initialized. This runs Initialize.
4. Then all entities are started. This runs Startup.

Entity spawning methods on IEntityManager now actually set position
before Initialize.

Also cleaned up a lot of spaghetti.

This fixes the crash when restarting the round.