### PR TITLE
Entitiy Queries & TypeFactory

### DIFF
--- a/SS14.Client/Console/Commands/Debug.cs
+++ b/SS14.Client/Console/Commands/Debug.cs
@@ -40,9 +40,9 @@ namespace SS14.Client.Console.Commands
 
         public bool Execute(IDebugConsole console, params string[] args)
         {
-            var entitymanager = IoCManager.Resolve<IEntityManager>();
+            var entityManager = IoCManager.Resolve<IEntityManager>();
 
-            foreach (var e in entitymanager.GetEntities(new ComponentEntityQuery()))
+            foreach (var e in entityManager.GetEntities())
             {
                 console.AddLine($"entity {e.Uid}, {e.Prototype.ID}, {e.Transform.GridPosition}.", ChatChannel.Default,
                     Color.White);

--- a/SS14.Client/GameController/GameController.IoC.cs
+++ b/SS14.Client/GameController/GameController.IoC.cs
@@ -110,6 +110,7 @@ namespace SS14.Client
             IoCManager.Register<ITimerManager, TimerManager>();
             IoCManager.Register<ITaskManager, TaskManager>();
             IoCManager.Register<IRuntimeLog, RuntimeLog>();
+            IoCManager.Register<IDynamicTypeFactory, DynamicTypeFactory>();
 
             // Client stuff.
             IoCManager.Register<IReflectionManager, ClientReflectionManager>();

--- a/SS14.Server/Program.cs
+++ b/SS14.Server/Program.cs
@@ -118,6 +118,7 @@ namespace SS14.Server
             IoCManager.Register<ILogManager, LogManager>();
             IoCManager.Register<ITaskManager, TaskManager>();
             IoCManager.Register<IRuntimeLog, RuntimeLog>();
+            IoCManager.Register<IDynamicTypeFactory, DynamicTypeFactory>();
 
             // Server stuff.
             IoCManager.Register<IEntityManager, ServerEntityManager>();

--- a/SS14.Shared/GameObjects/ComponentManager.cs
+++ b/SS14.Shared/GameObjects/ComponentManager.cs
@@ -130,9 +130,9 @@ namespace SS14.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public void RemoveComponent(EntityUid uid, uint netID)
+        public void RemoveComponent(EntityUid uid, uint netId)
         {
-            var comp = GetComponent(uid, netID);
+            var comp = GetComponent(uid, netId);
             RemoveComponentDeferred(comp as Component);
         }
 
@@ -243,12 +243,12 @@ namespace SS14.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public bool HasComponent(EntityUid uid, uint netID)
+        public bool HasComponent(EntityUid uid, uint netId)
         {
             if (!_netComponents.TryGetValue(uid, out var comp))
                 return false;
 
-            return comp.ContainsKey(netID);
+            return comp.ContainsKey(netId);
         }
 
         /// <inheritdoc />
@@ -273,10 +273,10 @@ namespace SS14.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public IComponent GetComponent(EntityUid uid, uint netID)
+        public IComponent GetComponent(EntityUid uid, uint netId)
         {
             var netDict = _netComponents[uid];
-            return netDict[netID];
+            return netDict[netId];
         }
 
         /// <inheritdoc />
@@ -310,11 +310,11 @@ namespace SS14.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public bool TryGetComponent(EntityUid uid, uint netID, out IComponent component)
+        public bool TryGetComponent(EntityUid uid, uint netId, out IComponent component)
         {
             if (_netComponents.TryGetValue(uid, out var netDict))
             {
-                if (netDict != null && netDict.TryGetValue(netID, out var comp))
+                if (netDict != null && netDict.TryGetValue(netId, out var comp))
                 {
                     component = comp;
                     return true;
@@ -368,7 +368,6 @@ namespace SS14.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        [Obsolete]
         public IEnumerable<T> GetAllComponents<T>()
             where T : IComponent
         {
@@ -377,7 +376,15 @@ namespace SS14.Shared.GameObjects
 
             return Enumerable.Empty<T>();
         }
+        
+        /// <inheritdoc />
+        public IEnumerable<IComponent> GetAllComponents(Type type)
+        {
+            if (_dictComponents.TryGetValue(type, out var typeDict))
+                return typeDict.Values;
 
+            return Enumerable.Empty<IComponent>();
+        }
         #endregion
     }
 }

--- a/SS14.Shared/GameObjects/Entity.cs
+++ b/SS14.Shared/GameObjects/Entity.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using SS14.Shared.Serialization;
 using SS14.Shared.Interfaces.GameObjects;
 using SS14.Shared.Interfaces.Network;
 using SS14.Shared.IoC;
 using SS14.Shared.Interfaces.GameObjects.Components;
-using SS14.Shared.Utility;
 using SS14.Shared.ViewVariables;
 
 namespace SS14.Shared.GameObjects
@@ -252,16 +250,6 @@ namespace SS14.Shared.GameObjects
 
         #endregion IEntity Members
 
-        #region Entity Systems
-
-        /// <inheritdoc />
-        public bool Match(IEntityQuery query)
-        {
-            return query.Match(this);
-        }
-
-        #endregion Entity Systems
-
         #region Components
 
         /// <summary>
@@ -327,9 +315,9 @@ namespace SS14.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public IComponent GetComponent(uint netID)
+        public IComponent GetComponent(uint netId)
         {
-            return EntityManager.ComponentManager.GetComponent(Uid, netID);
+            return EntityManager.ComponentManager.GetComponent(Uid, netId);
         }
 
         /// <inheritdoc />
@@ -346,9 +334,9 @@ namespace SS14.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public bool TryGetComponent(uint netID, out IComponent component)
+        public bool TryGetComponent(uint netId, out IComponent component)
         {
-            return EntityManager.ComponentManager.TryGetComponent(Uid, netID, out component);
+            return EntityManager.ComponentManager.TryGetComponent(Uid, netId, out component);
         }
 
         /// <inheritdoc />
@@ -388,6 +376,10 @@ namespace SS14.Shared.GameObjects
 
         #region GameState
 
+        /// <summary>
+        ///     Applies an entity state to this entity.
+        /// </summary>
+        /// <param name="state">State to apply.</param>
         internal void HandleEntityState(EntityState state)
         {
             Name = state.StateData.Name;
@@ -443,12 +435,15 @@ namespace SS14.Shared.GameObjects
         /// <returns></returns>
         private List<ComponentState> GetComponentStates(uint fromTick)
         {
-            return GetAllComponents()
+            return GetComponentInstances()
                 .Where(c => c.NetID != null && c.NetSyncEnabled && c.LastModifiedTick >= fromTick)
                 .Select(component => component.GetComponentState())
                 .ToList();
         }
 
+        /// <summary>
+        ///     Marks this entity as dirty so that the networking will sync it with clients.
+        /// </summary>
         public void Dirty()
         {
             LastModifiedTick = EntityManager.CurrentTick;
@@ -456,6 +451,7 @@ namespace SS14.Shared.GameObjects
 
         #endregion GameState
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return $"{Name} ({Uid}, {Prototype.ID})";

--- a/SS14.Shared/GameObjects/EntityManager.cs
+++ b/SS14.Shared/GameObjects/EntityManager.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using SS14.Shared.Interfaces.GameObjects;
-using SS14.Shared.Interfaces.GameObjects.Components;
 using SS14.Shared.Interfaces.Network;
 using SS14.Shared.Interfaces.Timing;
 using SS14.Shared.IoC;
@@ -14,21 +13,22 @@ using SS14.Shared.Utility;
 
 namespace SS14.Shared.GameObjects
 {
+    /// <inheritdoc />
     public abstract class EntityManager : IEntityManager
     {
         #region Dependencies
 
         [Dependency]
-        protected readonly IEntityNetworkManager EntityNetworkManager;
+        private readonly IEntityNetworkManager EntityNetworkManager;
 
         [Dependency]
-        protected readonly IPrototypeManager PrototypeManager;
+        private readonly IPrototypeManager PrototypeManager;
 
         [Dependency]
         protected readonly IEntitySystemManager EntitySystemManager;
 
         [Dependency]
-        protected readonly IComponentFactory ComponentFactory;
+        private readonly IComponentFactory ComponentFactory;
 
         [Dependency]
         private readonly INetManager _network;
@@ -41,11 +41,18 @@ namespace SS14.Shared.GameObjects
 
         #endregion Dependencies
 
+        /// <inheritdoc />
         public uint CurrentTick => _gameTiming.CurTick;
 
+        /// <inheritdoc />
         public IComponentManager ComponentManager => _componentManager;
+
+        /// <inheritdoc />
         public IEntityNetworkManager EntityNetManager => EntityNetworkManager;
 
+        /// <summary>
+        ///     All entities currently stored in the manager.
+        /// </summary>
         protected readonly Dictionary<EntityUid, IEntity> Entities = new Dictionary<EntityUid, IEntity>();
 
         /// <summary>
@@ -149,7 +156,7 @@ namespace SS14.Shared.GameObjects
 
         public IEnumerable<IEntity> GetEntities(IEntityQuery query)
         {
-            return GetEntities().Where(e => e.Match(query));
+            return query.Match(this);
         }
 
         public IEnumerable<IEntity> GetEntitiesAt(Vector2 position)

--- a/SS14.Shared/GameObjects/EntitySystemManager.cs
+++ b/SS14.Shared/GameObjects/EntitySystemManager.cs
@@ -15,6 +15,9 @@ namespace SS14.Shared.GameObjects
         [Dependency]
         private readonly IReflectionManager ReflectionManager;
 
+        [Dependency]
+        private readonly IDynamicTypeFactory _typeFactory;
+
         /// <summary>
         /// Maps system types to instances.
         /// </summary>
@@ -88,7 +91,7 @@ namespace SS14.Shared.GameObjects
             {
                 Logger.DebugS("go.sys", "Initializing entity system {0}", type);
                 //Force initialization of all systems
-                var instance = (IEntitySystem)Activator.CreateInstance(type);
+                var instance = (IEntitySystem)_typeFactory.CreateInstance(type);
                 AddSystem(instance);
                 instance.RegisterMessageTypes();
                 instance.SubscribeEvents();

--- a/SS14.Shared/Interfaces/GameObjects/IComponentManager.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IComponentManager.cs
@@ -182,9 +182,16 @@ namespace SS14.Shared.Interfaces.GameObjects
         ///     Returns ALL component instances of a specified type.
         /// </summary>
         /// <typeparam name="T">Type to filter.</typeparam>
-        /// <returns>All components that are a specified type.</returns>
+        /// <returns>All components that are the specified type.</returns>
         IEnumerable<T> GetAllComponents<T>()
             where T : IComponent;
+
+        /// <summary>
+        ///      Returns ALL component instances of a specified type.
+        /// </summary>
+        /// <param name="type">Type to filter.</param>
+        /// <returns>All components that are the specified type.</returns>
+        IEnumerable<IComponent> GetAllComponents(Type type);
 
         /// <summary>
         ///     Culls all components from the collection that are marked as deleted. This needs to be called often.

--- a/SS14.Shared/Interfaces/GameObjects/IEntity.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IEntity.cs
@@ -53,15 +53,6 @@ namespace SS14.Shared.Interfaces.GameObjects
         bool IsValid();
 
         /// <summary>
-        ///     "Matches" this entity with the provided entity query, returning whether or not the query matched.
-        ///     This is effectively equivalent to calling <see cref="IEntityQuery.Match(IEntity)" /> with this entity.
-        ///     The matching logic depends on the implementation of entity query used.
-        /// </summary>
-        /// <param name="query">The query to match this entity with.</param>
-        /// <returns>True if the query matched, false otherwise.</returns>
-        bool Match(IEntityQuery query);
-
-        /// <summary>
         ///     The entity's transform component.
         /// </summary>
         ITransformComponent Transform { get; }

--- a/SS14.Shared/Interfaces/GameObjects/IEntityManager.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IEntityManager.cs
@@ -8,6 +8,9 @@ namespace SS14.Shared.Interfaces.GameObjects
 {
     public interface IEntityManager
     {
+        /// <summary>
+        ///     The current simulation tick being processed.
+        /// </summary>
         uint CurrentTick { get; }
 
         void Initialize();

--- a/SS14.Shared/Interfaces/GameObjects/IEntityQuery.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IEntityQuery.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace SS14.Shared.Interfaces.GameObjects
 {
@@ -18,5 +14,12 @@ namespace SS14.Shared.Interfaces.GameObjects
         /// <param name="entity">The entity to test.</param>
         /// <returns>True if the entity is included in this query, false otherwise</returns>
         bool Match(IEntity entity);
+
+        /// <summary>
+        /// Matches every entity in an EntityManager to see if it passes the criteria.
+        /// </summary>
+        /// <param name="entityMan">An EntityManager containing a set of entities.</param>
+        /// <returns>Enumeration of all entities that successfully matched the criteria.</returns>
+        IEnumerable<IEntity> Match(IEntityManager entityMan);
     }
 }

--- a/SS14.Shared/IoC/DependencyCollection.cs
+++ b/SS14.Shared/IoC/DependencyCollection.cs
@@ -176,6 +176,14 @@ namespace SS14.Shared.IoC
                 // Not using Resolve<T>() because we're literally building it right now.
                 if (!_services.ContainsKey(field.FieldType))
                 {
+                    // A hard-coded special case so the DependencyCollection can inject itself.
+                    // This is not put into the services so it can be overridden if needed.
+                    if (field.FieldType == typeof(IDependencyCollection))
+                    {
+                        field.SetValue(obj, this);
+                        continue;
+                    }
+
                     throw new UnregisteredDependencyException(obj.GetType(), field.FieldType, field.Name);
                 }
 

--- a/SS14.Shared/IoC/DynamicTypeFactory.cs
+++ b/SS14.Shared/IoC/DynamicTypeFactory.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using JetBrains.Annotations;
+
+namespace SS14.Shared.IoC
+{
+    /// <summary>
+    ///     The sole purpose of this factory is to create arbitrary objects that have their
+    ///     dependencies resolved. If you think you need Activator.CreateInstance(), use this
+    ///     factory instead.
+    /// </summary>
+    [PublicAPI]
+    public interface IDynamicTypeFactory
+    {
+        /// <summary>
+        ///     Constructs a new instance of the given type with Dependencies resolved.
+        ///     The type MUST have a parameterless constructor.
+        /// </summary>
+        /// <param name="type">Type of object to instantiate.</param>
+        /// <returns>Newly created object.</returns>
+        object CreateInstance(Type type);
+
+        /// <summary>
+        ///     Constructs a new instance of the given type with Dependencies resolved.
+        /// </summary>
+        /// <typeparam name="T">Type of object to instantiate.</typeparam>
+        /// <returns>Newly created object.</returns>
+        T CreateInstance<T>()
+            where T : new();
+    }
+
+    /// <inheritdoc />
+    internal class DynamicTypeFactory : IDynamicTypeFactory
+    {
+        // https://blog.ploeh.dk/2012/03/15/ImplementinganAbstractFactory/
+
+        [Dependency]
+        private readonly IDependencyCollection _dependencies;
+
+        /// <inheritdoc />
+        public object CreateInstance(Type type)
+        {
+            if(type == null)
+                throw new ArgumentNullException(nameof(type));
+
+            var instance = Activator.CreateInstance(type);
+            _dependencies.InjectDependencies(instance);
+            return instance;
+        }
+
+        /// <inheritdoc />
+        public T CreateInstance<T>()
+            where T : new()
+        {
+            var instance = new T();
+            _dependencies.InjectDependencies(instance);
+            return instance;
+        }
+    }
+}

--- a/SS14.Shared/SS14.Shared.csproj
+++ b/SS14.Shared/SS14.Shared.csproj
@@ -179,6 +179,7 @@
     <Compile Include="GameStates\GameState.cs" />
     <Compile Include="GameStates\PlayerState.cs" />
     <Compile Include="IoC\DependencyCollection.cs" />
+    <Compile Include="IoC\DynamicTypeFactory.cs" />
     <Compile Include="IoC\Exceptions\ImplementationConstructorException.cs" />
     <Compile Include="Enums\Lighting.cs" />
     <Compile Include="IoC\IDependencyCollection.cs" />

--- a/SS14.UnitTesting/SS14UnitTest.cs
+++ b/SS14.UnitTesting/SS14UnitTest.cs
@@ -187,6 +187,7 @@ namespace SS14.UnitTesting
             IoCManager.Register<ILogManager, LogManager>();
             IoCManager.Register<ITaskManager, TaskManager>();
             IoCManager.Register<IRuntimeLog, RuntimeLog>();
+            IoCManager.Register<IDynamicTypeFactory, DynamicTypeFactory>();
 
             switch (Project)
             {


### PR DESCRIPTION
* Fixed bug where duplicate component instances were being sent in an EntityState. This should help network traffic a bit.
* Changed how EntityQueries worked resulting in a 3x perf increase for the EntitySystemManager.Update() method. (43% -> 14% Total CPU Time, Debug Build)
* Removed the useless giant ComponentEntityQuery. It should have never existed. Use the PredicateQuery if you need complex boolean logic (hint: you won't).
* Added the new IDynamicTypeFactory to IoC for instantiating arbitrary types. This removes the need for Activator.CreateInstance() and IoCManager.InjectDependencies() anywhere in code.
* Allowed the DependencyCollection to be able to inject itself as a dependency. This is required for a very specific use case (abstract factories), **DO NOT PASS AROUND THE CONTAINER AS A DEPENDENCY**.
* Utilized IDynamicTypeFactory in ComponentManager as an example of its use.