### PR TITLE
Remove InjectDependencies Calls

### DIFF
--- a/SS14.Client/Console/Commands/Debug.cs
+++ b/SS14.Client/Console/Commands/Debug.cs
@@ -9,6 +9,7 @@ using SS14.Client.Interfaces;
 using SS14.Client.Interfaces.Console;
 using SS14.Client.Interfaces.Debugging;
 using SS14.Client.Interfaces.Graphics.Lighting;
+using SS14.Client.Interfaces.Placement;
 using SS14.Client.Interfaces.ResourceManagement;
 using SS14.Client.Interfaces.State;
 using SS14.Client.Interfaces.UserInterface;
@@ -27,6 +28,7 @@ using SS14.Shared.Interfaces.Resources;
 using SS14.Shared.IoC;
 using SS14.Shared.Map;
 using SS14.Shared.Maths;
+using SS14.Shared.Prototypes;
 using SS14.Shared.Utility;
 using SS14.Shared.ViewVariables;
 
@@ -175,7 +177,7 @@ namespace SS14.Client.Console.Commands
 
         public bool Execute(IDebugConsole console, params string[] args)
         {
-            var window = new EntitySpawnWindow();
+            var window = new EntitySpawnWindow(IoCManager.Resolve<IPlacementManager>(), IoCManager.Resolve<IPrototypeManager>(), IoCManager.Resolve<IResourceCache>());
             window.AddToScreen();
             return false;
         }

--- a/SS14.Client/Console/Commands/Debug.cs
+++ b/SS14.Client/Console/Commands/Debug.cs
@@ -8,6 +8,7 @@ using System.Text;
 using SS14.Client.Interfaces;
 using SS14.Client.Interfaces.Console;
 using SS14.Client.Interfaces.Debugging;
+using SS14.Client.Interfaces.Graphics;
 using SS14.Client.Interfaces.Graphics.Lighting;
 using SS14.Client.Interfaces.Placement;
 using SS14.Client.Interfaces.ResourceManagement;
@@ -177,7 +178,7 @@ namespace SS14.Client.Console.Commands
 
         public bool Execute(IDebugConsole console, params string[] args)
         {
-            var window = new EntitySpawnWindow(IoCManager.Resolve<IPlacementManager>(), IoCManager.Resolve<IPrototypeManager>(), IoCManager.Resolve<IResourceCache>());
+            var window = new EntitySpawnWindow(IoCManager.Resolve<IDisplayManager>(), IoCManager.Resolve<IPlacementManager>(), IoCManager.Resolve<IPrototypeManager>(), IoCManager.Resolve<IResourceCache>());
             window.AddToScreen();
             return false;
         }
@@ -459,7 +460,7 @@ namespace SS14.Client.Console.Commands
 
         public bool Execute(IDebugConsole console, params string[] args)
         {
-            var window = new SS14Window("UITest");
+            var window = new SS14Window(IoCManager.Resolve<IDisplayManager>(), "UITest");
             window.AddToScreen();
             var scroll = new ScrollContainer();
             window.Contents.AddChild(scroll);

--- a/SS14.Client/Debugging/DebugDrawing.cs
+++ b/SS14.Client/Debugging/DebugDrawing.cs
@@ -1,16 +1,13 @@
 ﻿using SS14.Client.GameObjects;
-using SS14.Client.Graphics.ClientEye;
 using SS14.Client.Graphics.Drawing;
 using SS14.Client.Graphics.Overlays;
 using SS14.Client.Graphics.Shaders;
 using SS14.Client.Interfaces.Debugging;
 using SS14.Client.Interfaces.Graphics.ClientEye;
 using SS14.Client.Interfaces.Graphics.Overlays;
-using SS14.Shared.GameObjects;
 using SS14.Shared.Interfaces.GameObjects;
 using SS14.Shared.Interfaces.GameObjects.Components;
 using SS14.Shared.IoC;
-using SS14.Shared.Log;
 using SS14.Shared.Maths;
 using SS14.Shared.Prototypes;
 
@@ -18,9 +15,12 @@ namespace SS14.Client.Debugging
 {
     public class DebugDrawing : IDebugDrawing
     {
-        [Dependency] readonly IOverlayManager _overlayManager;
+        [Dependency] private readonly IOverlayManager _overlayManager;
+        [Dependency] private readonly IComponentManager _componentManager;
+        [Dependency] private readonly IEyeManager _eyeManager;
+        [Dependency] private readonly IPrototypeManager _prototypeManager;
 
-        private bool _debugColliders = false;
+        private bool _debugColliders;
 
         public bool DebugColliders
         {
@@ -36,7 +36,7 @@ namespace SS14.Client.Debugging
 
                 if (value)
                 {
-                    _overlayManager.AddOverlay(new CollidableOverlay());
+                    _overlayManager.AddOverlay(new CollidableOverlay(_componentManager, _eyeManager, _prototypeManager));
                 }
                 else
                 {
@@ -47,15 +47,19 @@ namespace SS14.Client.Debugging
 
         private class CollidableOverlay : Overlay
         {
-            [Dependency] private readonly IComponentManager _componentManager;
-            [Dependency] private readonly IEyeManager _eyeManager;
-            [Dependency] private readonly IPrototypeManager _prototypeManager;
+            private readonly IComponentManager _componentManager;
+            private readonly IEyeManager _eyeManager;
+            private readonly IPrototypeManager _prototypeManager;
 
             public override OverlaySpace Space => OverlaySpace.WorldSpace;
 
-            public CollidableOverlay() : base(nameof(CollidableOverlay))
+            public CollidableOverlay(IComponentManager compMan, IEyeManager eyeMan, IPrototypeManager protoMan)
+                : base(nameof(CollidableOverlay))
             {
-                IoCManager.InjectDependencies(this);
+                _componentManager = compMan;
+                _eyeManager = eyeMan;
+                _prototypeManager = protoMan;
+
                 Shader = _prototypeManager.Index<ShaderPrototype>("unshaded").Instance();
             }
 

--- a/SS14.Client/GameObjects/ClientEntityNetworkManager.cs
+++ b/SS14.Client/GameObjects/ClientEntityNetworkManager.cs
@@ -9,9 +9,9 @@ namespace SS14.Client.GameObjects
 {
     public class ClientEntityNetworkManager : IEntityNetworkManager
     {
-        [Dependency]
-        private readonly IClientNetManager _network;
-
+        [Dependency] private readonly IClientNetManager _network;
+        [Dependency] private readonly IEntitySystemManager _entitySystemManager;
+        
         /// <summary>
         /// Sends a message to the relevant system(s) server side.
         /// </summary>
@@ -74,9 +74,8 @@ namespace SS14.Client.GameObjects
                     // TODO: Handle this.
                     break;
 
-                case EntityMessageType.SystemMessage: //TODO: Not happy with this resolving the entmgr everytime a message comes in.
-                    var manager = IoCManager.Resolve<IEntitySystemManager>();
-                    manager.HandleSystemMessage(message);
+                case EntityMessageType.SystemMessage:
+                    _entitySystemManager.HandleSystemMessage(message);
                     break;
             }
             return null;

--- a/SS14.Client/GameObjects/Components/Appearance/AppearanceComponent.cs
+++ b/SS14.Client/GameObjects/Components/Appearance/AppearanceComponent.cs
@@ -15,12 +15,13 @@ namespace SS14.Client.GameObjects
     {
         private Dictionary<object, object> data = new Dictionary<object, object>();
         internal List<AppearanceVisualizer> Visualizers = new List<AppearanceVisualizer>();
+        [Dependency] private static readonly IReflectionManager _reflectionManager;
 
         public bool AppearanceDirty { get; internal set; } = false;
 
         static AppearanceComponent()
         {
-            YamlObjectSerializer.RegisterTypeSerializer(typeof(AppearanceVisualizer), new VisualizerTypeSerializer());
+            YamlObjectSerializer.RegisterTypeSerializer(typeof(AppearanceVisualizer), new VisualizerTypeSerializer(_reflectionManager));
         }
 
         public override void SetData(string key, object value)
@@ -101,9 +102,15 @@ namespace SS14.Client.GameObjects
 
         class VisualizerTypeSerializer : YamlObjectSerializer.TypeSerializer
         {
+            private readonly IReflectionManager _reflectionManager;
+
+            public VisualizerTypeSerializer(IReflectionManager reflectionManager)
+            {
+                _reflectionManager = reflectionManager;
+            }
+
             public override object NodeToType(Type type, YamlNode node, YamlObjectSerializer serializer)
             {
-                var refl = IoCManager.Resolve<IReflectionManager>();
                 var mapping = (YamlMappingNode)node;
                 var nodeType = mapping.GetNode("type");
                 switch (nodeType.AsString())
@@ -111,7 +118,7 @@ namespace SS14.Client.GameObjects
                     case SpriteLayerToggle.NAME:
                         var keyString = mapping.GetNode("key").AsString();
                         object key;
-                        if (refl.TryParseEnumReference(keyString, out var @enum))
+                        if (_reflectionManager.TryParseEnumReference(keyString, out var @enum))
                         {
                             key = @enum;
                         }
@@ -123,7 +130,7 @@ namespace SS14.Client.GameObjects
                         return new SpriteLayerToggle(key, layer);
 
                     default:
-                        var visType = refl.LooseGetType(nodeType.AsString());
+                        var visType = _reflectionManager.LooseGetType(nodeType.AsString());
                         if (!typeof(AppearanceVisualizer).IsAssignableFrom(visType))
                         {
                             throw new InvalidOperationException();

--- a/SS14.Client/GameObjects/Components/Collidable/CollidableComponent.cs
+++ b/SS14.Client/GameObjects/Components/Collidable/CollidableComponent.cs
@@ -13,6 +13,8 @@ namespace SS14.Client.GameObjects
 {
     public class CollidableComponent : Component, ICollidableComponent
     {
+        [Dependency] private readonly IPhysicsManager _physicsManager;
+
         private bool _collisionIsActuallyEnabled;
         private bool _collisionEnabled;
 
@@ -92,8 +94,7 @@ namespace SS14.Client.GameObjects
 
             if (_collisionEnabled && !_collisionIsActuallyEnabled)
             {
-                var cm = IoCManager.Resolve<IPhysicsManager>();
-                cm.AddCollidable(this);
+                _physicsManager.AddCollidable(this);
                 _collisionIsActuallyEnabled = true;
             }
         }
@@ -105,8 +106,7 @@ namespace SS14.Client.GameObjects
         {
             if (_collisionEnabled)
             {
-                var cm = IoCManager.Resolve<IPhysicsManager>();
-                cm.RemoveCollidable(this);
+                _physicsManager.RemoveCollidable(this);
             }
 
             base.Shutdown();
@@ -130,7 +130,7 @@ namespace SS14.Client.GameObjects
         /// <inheritdoc />
         public bool TryCollision(Vector2 offset, bool bump = false)
         {
-            return IoCManager.Resolve<IPhysicsManager>().TryCollide(Owner, offset, bump);
+            return _physicsManager.TryCollide(Owner, offset, bump);
         }
 
         /// <summary>
@@ -140,8 +140,7 @@ namespace SS14.Client.GameObjects
         {
             _collisionEnabled = true;
             _collisionIsActuallyEnabled = true;
-            var cm = IoCManager.Resolve<IPhysicsManager>();
-            cm.AddCollidable(this);
+            _physicsManager.AddCollidable(this);
         }
 
         /// <summary>
@@ -151,8 +150,7 @@ namespace SS14.Client.GameObjects
         {
             _collisionEnabled = false;
             _collisionIsActuallyEnabled = false;
-            var cm = IoCManager.Resolve<IPhysicsManager>();
-            cm.RemoveCollidable(this);
+            _physicsManager.RemoveCollidable(this);
         }
     }
 }

--- a/SS14.Client/GameObjects/Components/Eye/EyeComponent.cs
+++ b/SS14.Client/GameObjects/Components/Eye/EyeComponent.cs
@@ -16,7 +16,7 @@ namespace SS14.Client.GameObjects
         private Eye eye;
 
         // Horrible hack to get around ordering issues.
-        private bool setCurrentOnInitialize = false;
+        private bool setCurrentOnInitialize;
         private Vector2 setZoomOnInitialize = Vector2.One;
         private Vector2 offset = Vector2.Zero;
 

--- a/SS14.Client/GameObjects/Components/Input/ClickableComponent.cs
+++ b/SS14.Client/GameObjects/Components/Input/ClickableComponent.cs
@@ -1,5 +1,4 @@
-﻿using SS14.Client.Graphics.Shaders;
-using SS14.Client.Interfaces.GameObjects;
+﻿using SS14.Client.Interfaces.GameObjects;
 using SS14.Client.Interfaces.GameObjects.Components;
 using SS14.Shared.GameObjects;
 using SS14.Shared.Input;

--- a/SS14.Client/GameObjects/Components/Light/PointLightComponent.cs
+++ b/SS14.Client/GameObjects/Components/Light/PointLightComponent.cs
@@ -1,22 +1,14 @@
 ﻿using System;
-using System.Runtime.Remoting.Messaging;
-using SS14.Client.Graphics.Lighting;
-using SS14.Client.Interfaces.GameObjects.Components;
 using SS14.Client.Interfaces.Graphics.Lighting;
 using SS14.Client.Interfaces.ResourceManagement;
 using SS14.Client.ResourceManagement;
-using SS14.Shared;
 using SS14.Shared.Enums;
 using SS14.Shared.GameObjects;
 using SS14.Shared.Interfaces.GameObjects.Components;
 using SS14.Shared.IoC;
-using SS14.Shared.Log;
-using SS14.Shared.Map;
 using SS14.Shared.Maths;
 using SS14.Shared.Utility;
 using SS14.Shared.ViewVariables;
-using YamlDotNet.RepresentationModel;
-using YamlDotNet.Serialization;
 using ObjectSerializer = SS14.Shared.Serialization.ObjectSerializer;
 
 namespace SS14.Client.GameObjects
@@ -28,7 +20,8 @@ namespace SS14.Client.GameObjects
         public override Type StateType => typeof(PointLightComponentState);
 
         private ILight Light;
-        [Dependency] private ILightManager lightManager;
+        [Dependency] private readonly ILightManager lightManager;
+        [Dependency] private readonly IResourceCache _resourceCache;
 
         [ViewVariables(VVAccess.ReadWrite)]
         public Color Color
@@ -127,8 +120,7 @@ namespace SS14.Client.GameObjects
             set
             {
                 radius = FloatMath.Clamp(value, 2, 10);
-                var mgr = IoCManager.Resolve<IResourceCache>();
-                var tex = mgr.GetResource<TextureResource>(new ResourcePath("/Textures/Effects/Light/") /
+                var tex = _resourceCache.GetResource<TextureResource>(new ResourcePath("/Textures/Effects/Light/") /
                                                            $"lighting_falloff_{(int) radius}.png");
 
                 if (GameController.OnGodot)
@@ -184,14 +176,10 @@ namespace SS14.Client.GameObjects
 
         public override void ExposeData(ObjectSerializer serializer)
         {
-            if (lightManager == null)
-            {
-                // First in the init stack so...
-                // FIXME: This is terrible.
-                lightManager = IoCManager.Resolve<ILightManager>();
-                Light = lightManager.MakeLight();
-            }
-
+            // First in the init stack so...
+            // FIXME: This is terrible.
+            Light?.Dispose();
+            Light = lightManager.MakeLight();
             serializer.DataReadWriteFunction("offset", Vector2.Zero, vec => Offset = vec, () => Offset);
             serializer.DataReadWriteFunction("radius", 5f, radius => Radius = radius, () => Radius);
             serializer.DataReadWriteFunction("color", Color.White, col => Color = col, () => Color);

--- a/SS14.Client/GameObjects/Components/Occluder/OccluderComponent.cs
+++ b/SS14.Client/GameObjects/Components/Occluder/OccluderComponent.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using SS14.Client.Interfaces.GameObjects.Components;
-using SS14.Client.Interfaces.Graphics.Lighting;
+﻿using SS14.Client.Interfaces.Graphics.Lighting;
 using SS14.Shared.GameObjects;
-using SS14.Shared.Interfaces.GameObjects.Components;
 using SS14.Shared.IoC;
-using SS14.Shared.Utility;
-using YamlDotNet.RepresentationModel;
-using SS14.Client.Graphics.Lighting;
 using SS14.Shared.Maths;
 using SS14.Shared.Serialization;
 using SS14.Client.Graphics.ClientEye;
@@ -46,7 +40,6 @@ namespace SS14.Client.GameObjects
         public override void Initialize()
         {
             base.Initialize();
-            IoCManager.InjectDependencies(this);
 
             var transform = Owner.Transform;
             SnapGrid = Owner.GetComponent<SnapGridComponent>();

--- a/SS14.Client/GameObjects/Components/Physics/PhysicsComponent.cs
+++ b/SS14.Client/GameObjects/Components/Physics/PhysicsComponent.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using SS14.Shared.GameObjects;
-using SS14.Shared.Interfaces.GameObjects;
 using SS14.Shared.Log;
 using SS14.Shared.Maths;
 using SS14.Shared.ViewVariables;

--- a/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -10,7 +10,6 @@ using SS14.Client.Utility;
 using SS14.Shared.GameObjects;
 using SS14.Shared.GameObjects.Components.Renderable;
 using SS14.Shared.Interfaces.GameObjects;
-using SS14.Shared.Interfaces.Serialization;
 using SS14.Shared.IoC;
 using SS14.Shared.Log;
 using SS14.Shared.Maths;
@@ -23,7 +22,6 @@ using System.Linq;
 using System.Text;
 using SS14.Shared.Interfaces.Reflection;
 using SS14.Shared.ViewVariables;
-using YamlDotNet.RepresentationModel;
 using VS = Godot.VisualServer;
 
 namespace SS14.Client.GameObjects
@@ -214,8 +212,9 @@ namespace SS14.Client.GameObjects
 
         private Godot.Node2D SceneNode;
 
-        private IResourceCache resourceCache;
-        private IPrototypeManager prototypes;
+        [Dependency] private readonly IResourceCache resourceCache;
+        [Dependency] private readonly IPrototypeManager prototypes;
+        [Dependency] private readonly IReflectionManager reflectionManager;
 
         [ViewVariables(VVAccess.ReadWrite)] RSI.State.Direction LastDir;
         [ViewVariables(VVAccess.ReadWrite)] private bool _recalcDirections = false;
@@ -234,8 +233,8 @@ namespace SS14.Client.GameObjects
         private static Shader _defaultShader;
 
         [ViewVariables]
-        private static Shader DefaultShader => _defaultShader ??
-                                               (_defaultShader = IoCManager.Resolve<IPrototypeManager>()
+        private Shader DefaultShader => _defaultShader ??
+                                               (_defaultShader = prototypes
                                                    .Index<ShaderPrototype>("shaded")
                                                    .Instance());
 
@@ -1302,10 +1301,7 @@ namespace SS14.Client.GameObjects
             serializer.DataFieldCached(ref color, "color", Color.White);
             serializer.DataFieldCached(ref _directional, "directional", true);
             serializer.DataFieldCached(ref _visible, "visible", true);
-
-            prototypes = IoCManager.Resolve<IPrototypeManager>();
-            resourceCache = IoCManager.Resolve<IResourceCache>();
-
+            
             // TODO: Writing?
             if (!serializer.Reading)
             {
@@ -1361,8 +1357,6 @@ namespace SS14.Client.GameObjects
                     });
                 }
             }
-
-            var reflectionManager = IoCManager.Resolve<IReflectionManager>();
 
             foreach (var layerDatum in layerData)
             {

--- a/SS14.Client/GameObjects/Components/Transform/GodotTransformComponent.cs
+++ b/SS14.Client/GameObjects/Components/Transform/GodotTransformComponent.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using SS14.Client.Graphics.ClientEye;
+﻿using SS14.Client.Graphics.ClientEye;
 using SS14.Client.Interfaces;
 using SS14.Client.Interfaces.GameObjects.Components;
 using SS14.Client.Utility;
@@ -16,7 +15,10 @@ namespace SS14.Client.GameObjects
 
         IGodotTransformComponent IGodotTransformComponent.Parent => (IGodotTransformComponent)Parent;
 
-        bool visibleWhileParented = false;
+        private bool visibleWhileParented;
+
+        [Dependency] private readonly ISceneTreeHolder _sceneTreeHolder;
+
         public override bool VisibleWhileParented
         {
             get => visibleWhileParented;
@@ -66,21 +68,19 @@ namespace SS14.Client.GameObjects
 
             ((IGodotTransformComponent)Parent)?.SceneNode?.RemoveChild(SceneNode);
             base.DetachParent();
-            var holder = IoCManager.Resolve<ISceneTreeHolder>();
-            holder.WorldRoot.AddChild(SceneNode);
+            _sceneTreeHolder.WorldRoot.AddChild(SceneNode);
             UpdateSceneVisibility();
         }
 
         public override void OnAdd()
         {
             base.OnAdd();
-            var holder = IoCManager.Resolve<ISceneTreeHolder>();
             SceneNode = new Godot.Node2D
             {
                 Name = $"Transform {Owner.Uid} ({Owner.Name})",
                 Rotation = MathHelper.PiOver2
             };
-            holder.WorldRoot.AddChild(SceneNode);
+            _sceneTreeHolder.WorldRoot.AddChild(SceneNode);
         }
 
         public override void OnRemove()

--- a/SS14.Client/GameObjects/Components/UserInterface/ClientUserInterfaceComponent.cs
+++ b/SS14.Client/GameObjects/Components/UserInterface/ClientUserInterfaceComponent.cs
@@ -16,6 +16,7 @@ namespace SS14.Client.GameObjects.Components.UserInterface
             new Dictionary<object, BoundUserInterface>();
 
         private Dictionary<object, PrototypeData> _interfaceData;
+        [Dependency] private readonly IReflectionManager _reflectionManager;
 
         public override void ExposeData(ObjectSerializer serializer)
         {
@@ -79,9 +80,8 @@ namespace SS14.Client.GameObjects.Components.UserInterface
         private void OpenInterface(BoundInterfaceMessageWrapMessage wrapped)
         {
             var data = _interfaceData[wrapped.UiKey];
-            var reflectionManager = IoCManager.Resolve<IReflectionManager>();
             // TODO: This type should be cached, but I'm too lazy.
-            var type = reflectionManager.LooseGetType(data.ClientType);
+            var type = _reflectionManager.LooseGetType(data.ClientType);
             var boundInterface = (BoundUserInterface) Activator.CreateInstance(type, this, wrapped.UiKey);
             boundInterface.Open();
             _openInterfaces[wrapped.UiKey] = boundInterface;

--- a/SS14.Client/GameObjects/EntitySystems/AppearanceSystem.cs
+++ b/SS14.Client/GameObjects/EntitySystems/AppearanceSystem.cs
@@ -1,6 +1,4 @@
 ﻿using SS14.Shared.GameObjects.Systems;
-using SS14.Shared.Interfaces.GameObjects;
-using SS14.Shared.IoC;
 using SS14.Shared.GameObjects;
 
 namespace SS14.Client.GameObjects.EntitySystems

--- a/SS14.Client/GameObjects/EntitySystems/AudioSystem.cs
+++ b/SS14.Client/GameObjects/EntitySystems/AudioSystem.cs
@@ -22,13 +22,12 @@ namespace SS14.Client.GameObjects.EntitySystems
 {
     public class AudioSystem : EntitySystem
     {
-        [Dependency] ISceneTreeHolder sceneTree;
-
-        [Dependency] IResourceCache resourceCache;
+        [Dependency] private readonly ISceneTreeHolder sceneTree;
+        [Dependency] private readonly IResourceCache resourceCache;
 
         private IClyde _clyde;
 
-        private uint LastPlayKey = 0;
+        private uint LastPlayKey;
 
         private readonly Dictionary<uint, PlayingGodotStream> PlayingGodotStreams =
             new Dictionary<uint, PlayingGodotStream>();
@@ -38,7 +37,6 @@ namespace SS14.Client.GameObjects.EntitySystems
         public override void Initialize()
         {
             base.Initialize();
-            IoCManager.InjectDependencies(this);
             if (GameController.Mode == GameController.DisplayMode.Clyde)
             {
                 _clyde = IoCManager.Resolve<IClyde>();
@@ -88,6 +86,7 @@ namespace SS14.Client.GameObjects.EntitySystems
         ///     Play an audio file globally, without position.
         /// </summary>
         /// <param name="filename">The resource path to the OGG Vorbis file to play.</param>
+        /// <param name="audioParams"></param>
         public void Play(string filename, AudioParams? audioParams = null)
         {
             Play(resourceCache.GetResource<AudioResource>(new ResourcePath(filename)), audioParams);
@@ -97,6 +96,7 @@ namespace SS14.Client.GameObjects.EntitySystems
         ///     Play an audio stream globally, without position.
         /// </summary>
         /// <param name="stream">The audio stream to play.</param>
+        /// <param name="audioParams"></param>
         public void Play(AudioStream stream, AudioParams? audioParams = null)
         {
             if (GameController.Mode == GameController.DisplayMode.Clyde)
@@ -146,6 +146,7 @@ namespace SS14.Client.GameObjects.EntitySystems
         /// </summary>
         /// <param name="filename">The resource path to the OGG Vorbis file to play.</param>
         /// <param name="entity">The entity "emitting" the audio.</param>
+        /// <param name="audioParams"></param>
         public void Play(string filename, IEntity entity, AudioParams? audioParams = null)
         {
             Play(resourceCache.GetResource<AudioResource>(new ResourcePath(filename)), entity, audioParams);
@@ -156,6 +157,7 @@ namespace SS14.Client.GameObjects.EntitySystems
         /// </summary>
         /// <param name="stream">The audio stream to play.</param>
         /// <param name="entity">The entity "emitting" the audio.</param>
+        /// <param name="audioParams"></param>
         public void Play(AudioStream stream, IEntity entity, AudioParams? audioParams = null)
         {
             if (GameController.Mode == GameController.DisplayMode.Clyde)
@@ -208,6 +210,7 @@ namespace SS14.Client.GameObjects.EntitySystems
         /// </summary>
         /// <param name="filename">The resource path to the OGG Vorbis file to play.</param>
         /// <param name="coordinates">The coordinates at which to play the audio.</param>
+        /// <param name="audioParams"></param>
         public void Play(string filename, GridCoordinates coordinates, AudioParams? audioParams = null)
         {
             Play(resourceCache.GetResource<AudioResource>(new ResourcePath(filename)), coordinates, audioParams);
@@ -216,8 +219,9 @@ namespace SS14.Client.GameObjects.EntitySystems
         /// <summary>
         ///     Play an audio stream at a static position.
         /// </summary>
-        /// <param name="filename">The audio stream to play.</param>
+        /// <param name="stream">The audio stream to play.</param>
         /// <param name="coordinates">The coordinates at which to play the audio.</param>
+        /// <param name="audioParams"></param>
         public void Play(AudioStream stream, GridCoordinates coordinates, AudioParams? audioParams = null)
         {
             if (GameController.Mode == GameController.DisplayMode.Clyde)

--- a/SS14.Client/GameObjects/EntitySystems/EffectSystem.cs
+++ b/SS14.Client/GameObjects/EntitySystems/EffectSystem.cs
@@ -24,23 +24,19 @@ namespace SS14.Client.GameObjects
 {
     public class EffectSystem : EntitySystem
     {
-        [Dependency] IGameTiming gameTiming;
-
-        [Dependency] IResourceCache resourceCache;
-
-        [Dependency] IEyeManager eyeManager;
-
-        [Dependency] IOverlayManager overlayManager;
+        [Dependency] private readonly IGameTiming gameTiming;
+        [Dependency] private readonly IResourceCache resourceCache;
+        [Dependency] private readonly IEyeManager eyeManager;
+        [Dependency] private readonly IOverlayManager overlayManager;
+        [Dependency] private readonly IPrototypeManager prototypeManager;
 
         private readonly List<Effect> _Effects = new List<Effect>();
-        private TimeSpan lasttimeprocessed = TimeSpan.Zero;
 
         public override void Initialize()
         {
             base.Initialize();
-            IoCManager.InjectDependencies(this);
 
-            var overlay = new EffectOverlay(this);
+            var overlay = new EffectOverlay(this, prototypeManager);
             overlayManager.AddOverlay(overlay);
         }
 
@@ -98,8 +94,6 @@ namespace SS14.Client.GameObjects
 
         public override void FrameUpdate(float frameTime)
         {
-            lasttimeprocessed = IoCManager.Resolve<IGameTiming>().CurTime;
-
             for (int i = 0; i < _Effects.Count; i++)
             {
                 var effect = _Effects[i];
@@ -291,10 +285,10 @@ namespace SS14.Client.GameObjects
             private readonly Shader _unshadedShader;
             private readonly EffectSystem _owner;
 
-            public EffectOverlay(EffectSystem owner) : base("EffectSystem")
+            public EffectOverlay(EffectSystem owner, IPrototypeManager protoMan) : base("EffectSystem")
             {
                 _owner = owner;
-                _unshadedShader = IoCManager.Resolve<IPrototypeManager>().Index<ShaderPrototype>("unshaded").Instance();
+                _unshadedShader = protoMan.Index<ShaderPrototype>("unshaded").Instance();
             }
 
             protected override void Draw(DrawingHandle handle)

--- a/SS14.Client/GameObjects/EntitySystems/InputSystem.cs
+++ b/SS14.Client/GameObjects/EntitySystems/InputSystem.cs
@@ -17,6 +17,9 @@ namespace SS14.Client.GameObjects.EntitySystems
     /// </summary>
     public class InputSystem : EntitySystem
     {
+        [Dependency] private readonly IInputManager _inputManager;
+        [Dependency] private readonly IPlayerManager _playerManager;
+
         private readonly IPlayerCommandStates _cmdStates = new PlayerCommandStates();
         private readonly CommandBindMapping _bindMap = new CommandBindMapping();
 
@@ -60,20 +63,18 @@ namespace SS14.Client.GameObjects.EntitySystems
             SubscribeEvent<PlayerAttachSysMessage>(OnAttachedEntityChanged);
         }
 
-        private static void OnAttachedEntityChanged(object sender, EntitySystemMessage message)
+        private void OnAttachedEntityChanged(object sender, EntitySystemMessage message)
         {
             if(!(message is PlayerAttachSysMessage msg))
                 return;
 
-            var inputMan = IoCManager.Resolve<IInputManager>();
-
             if (msg.AttachedEntity != null) // attach
             {
-                SetEntityContextActive(inputMan, msg.AttachedEntity);
+                SetEntityContextActive(_inputManager, msg.AttachedEntity);
             }
             else // detach
             {
-                inputMan.Contexts.SetActiveContext(InputContextContainer.DefaultContextName);
+                _inputManager.Contexts.SetActiveContext(InputContextContainer.DefaultContextName);
             }
         }
 
@@ -103,10 +104,7 @@ namespace SS14.Client.GameObjects.EntitySystems
         /// </summary>
         public void SetEntityContextActive()
         {
-            var inputMan = IoCManager.Resolve<IInputManager>();
-            var localPlayer = IoCManager.Resolve<IPlayerManager>().LocalPlayer;
-
-            SetEntityContextActive(inputMan, localPlayer.ControlledEntity);
+            SetEntityContextActive(_inputManager, _playerManager.LocalPlayer.ControlledEntity);
         }
     }
 

--- a/SS14.Client/GameObjects/EntitySystems/SpriteSystem.cs
+++ b/SS14.Client/GameObjects/EntitySystems/SpriteSystem.cs
@@ -1,8 +1,6 @@
 ﻿using SS14.Client.Interfaces.GameObjects.Components;
 using SS14.Shared.GameObjects;
 using SS14.Shared.GameObjects.Systems;
-using SS14.Shared.Interfaces.GameObjects;
-using SS14.Shared.IoC;
 
 namespace SS14.Client.GameObjects.EntitySystems
 {

--- a/SS14.Client/Placement/PlacementManager.cs
+++ b/SS14.Client/Placement/PlacementManager.cs
@@ -561,7 +561,7 @@ namespace SS14.Client.Placement
         {
             var prototype = _prototypeManager.Index<EntityPrototype>(templateName);
 
-            CurrentBaseSprite = IconComponent.GetPrototypeIcon(prototype);
+            CurrentBaseSprite = IconComponent.GetPrototypeIcon(prototype, ResourceCache);
             CurrentPrototype = prototype;
 
             IsActive = true;

--- a/SS14.Client/State/StateManager.cs
+++ b/SS14.Client/State/StateManager.cs
@@ -2,12 +2,15 @@
 using SS14.Client.Interfaces.State;
 using SS14.Shared.Log;
 using System;
+using SS14.Shared.IoC;
 
 namespace SS14.Client.State
 {
     public class StateManager : IStateManager
     {
-        public State CurrentState { get; private set; } = null;
+        [Dependency] private readonly IDynamicTypeFactory _typeFactory;
+
+        public State CurrentState { get; private set; }
 
         #region Updates & Statechanges
 
@@ -43,7 +46,7 @@ namespace SS14.Client.State
         {
             Logger.Debug($"Switching to state {type}");
 
-            State newState = (State)Activator.CreateInstance(type);
+            var newState = (State)_typeFactory.CreateInstance(type);
 
             CurrentState?.Shutdown();
 

--- a/SS14.Client/State/States/GameScreen.cs
+++ b/SS14.Client/State/States/GameScreen.cs
@@ -13,9 +13,13 @@ using SS14.Shared.IoC;
 using SS14.Shared.Map;
 using System.Collections.Generic;
 using System.Linq;
+using SS14.Client.Console;
 using SS14.Client.GameObjects.EntitySystems;
+using SS14.Client.Interfaces.ResourceManagement;
 using SS14.Client.Player;
+using SS14.Shared.Interfaces.Map;
 using SS14.Shared.Interfaces.Timing;
+using SS14.Shared.Prototypes;
 
 namespace SS14.Client.State.States
 {
@@ -33,6 +37,10 @@ namespace SS14.Client.State.States
         [Dependency] private readonly IEyeManager eyeManager;
         [Dependency] private readonly IEntitySystemManager entitySystemManager;
         [Dependency] private readonly IGameTiming timing;
+        [Dependency] private readonly IClientConsole _console;
+        [Dependency] private readonly IPrototypeManager prototypeManager;
+        [Dependency] private readonly IResourceCache resourceCache;
+        [Dependency] private readonly ITileDefinitionManager __tileDefinitionManager;
 
         private EscapeMenu escapeMenu;
         private IEntity lastHoveredEntity;
@@ -41,7 +49,7 @@ namespace SS14.Client.State.States
         {
             inputManager.KeyBindStateChanged += OnKeyBindStateChanged;
 
-            escapeMenu = new EscapeMenu
+            escapeMenu = new EscapeMenu(_console, __tileDefinitionManager, placementManager, prototypeManager, resourceCache)
             {
                 Visible = false
             };

--- a/SS14.Client/State/States/GameScreen.cs
+++ b/SS14.Client/State/States/GameScreen.cs
@@ -15,8 +15,10 @@ using System.Collections.Generic;
 using System.Linq;
 using SS14.Client.Console;
 using SS14.Client.GameObjects.EntitySystems;
+using SS14.Client.Interfaces.Graphics;
 using SS14.Client.Interfaces.ResourceManagement;
 using SS14.Client.Player;
+using SS14.Shared.Interfaces.Configuration;
 using SS14.Shared.Interfaces.Map;
 using SS14.Shared.Interfaces.Timing;
 using SS14.Shared.Prototypes;
@@ -40,7 +42,9 @@ namespace SS14.Client.State.States
         [Dependency] private readonly IClientConsole _console;
         [Dependency] private readonly IPrototypeManager prototypeManager;
         [Dependency] private readonly IResourceCache resourceCache;
-        [Dependency] private readonly ITileDefinitionManager __tileDefinitionManager;
+        [Dependency] private readonly ITileDefinitionManager _tileDefinitionManager;
+        [Dependency] private readonly IDisplayManager _displayManager;
+        [Dependency] private readonly IConfigurationManager _configurationManager;
 
         private EscapeMenu escapeMenu;
         private IEntity lastHoveredEntity;
@@ -49,7 +53,8 @@ namespace SS14.Client.State.States
         {
             inputManager.KeyBindStateChanged += OnKeyBindStateChanged;
 
-            escapeMenu = new EscapeMenu(_console, __tileDefinitionManager, placementManager, prototypeManager, resourceCache)
+            escapeMenu = new EscapeMenu(_displayManager,_console, _tileDefinitionManager,
+                placementManager, prototypeManager, resourceCache, _configurationManager)
             {
                 Visible = false
             };

--- a/SS14.Client/State/States/GameScreen.cs
+++ b/SS14.Client/State/States/GameScreen.cs
@@ -1,5 +1,4 @@
-﻿using SS14.Client.Console;
-using SS14.Client.Input;
+﻿using SS14.Client.Input;
 using SS14.Client.Interfaces.GameObjects;
 using SS14.Client.Interfaces.GameObjects.Components;
 using SS14.Client.Interfaces.Graphics.ClientEye;
@@ -10,7 +9,6 @@ using SS14.Client.UserInterface.CustomControls;
 using SS14.Shared.GameObjects;
 using SS14.Shared.Input;
 using SS14.Shared.Interfaces.GameObjects;
-using SS14.Shared.Interfaces.GameObjects.Components;
 using SS14.Shared.IoC;
 using SS14.Shared.Map;
 using System.Collections.Generic;
@@ -23,34 +21,24 @@ namespace SS14.Client.State.States
 {
     // OH GOD.
     // Ok actually it's fine.
+    // Instantiated dynamically through the StateManager, Dependencies will be resolved.
     public sealed partial class GameScreen : State
     {
-        [Dependency]
-        readonly IClientEntityManager _entityManager;
-        [Dependency]
-        readonly IComponentManager _componentManager;
-        [Dependency]
-        readonly IInputManager inputManager;
-        [Dependency]
-        readonly IPlayerManager playerManager;
-        [Dependency]
-        readonly IUserInterfaceManager userInterfaceManager;
-        [Dependency]
-        readonly IPlacementManager placementManager;
-        [Dependency]
-        readonly IEyeManager eyeManager;
-        [Dependency]
-        private readonly IEntitySystemManager entitySystemManager;
-        [Dependency]
-        private readonly IGameTiming timing;
+        [Dependency] private readonly IClientEntityManager _entityManager;
+        [Dependency] private readonly IComponentManager _componentManager;
+        [Dependency] private readonly IInputManager inputManager;
+        [Dependency] private readonly IPlayerManager playerManager;
+        [Dependency] private readonly IUserInterfaceManager userInterfaceManager;
+        [Dependency] private readonly IPlacementManager placementManager;
+        [Dependency] private readonly IEyeManager eyeManager;
+        [Dependency] private readonly IEntitySystemManager entitySystemManager;
+        [Dependency] private readonly IGameTiming timing;
 
         private EscapeMenu escapeMenu;
         private IEntity lastHoveredEntity;
 
         public override void Startup()
         {
-            IoCManager.InjectDependencies(this);
-
             inputManager.KeyBindStateChanged += OnKeyBindStateChanged;
 
             escapeMenu = new EscapeMenu

--- a/SS14.Client/State/States/MainMenu.cs
+++ b/SS14.Client/State/States/MainMenu.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text.RegularExpressions;
 using SS14.Client.Interfaces;
+using SS14.Client.Interfaces.Graphics;
 using SS14.Client.Interfaces.ResourceManagement;
 using SS14.Client.Interfaces.UserInterface;
 using SS14.Client.UserInterface;
@@ -31,6 +32,7 @@ namespace SS14.Client.State.States
         [Dependency] private readonly IConfigurationManager _configurationManager;
         [Dependency] private readonly IGameControllerProxy _controllerProxy;
         [Dependency] private readonly IResourceCache _resourceCache;
+        [Dependency] private readonly IDisplayManager _displayManager;
 
         private MainMenuControl _mainMenuControl;
         private OptionsMenu OptionsMenu;
@@ -53,7 +55,7 @@ namespace SS14.Client.State.States
 
             _client.RunLevelChanged += RunLevelChanged;
 
-            OptionsMenu = new OptionsMenu
+            OptionsMenu = new OptionsMenu(_displayManager, _configurationManager)
             {
                 Visible = false,
             };

--- a/SS14.Client/UserInterface/CustomControls/DebugConsole.cs
+++ b/SS14.Client/UserInterface/CustomControls/DebugConsole.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using Newtonsoft.Json;
 using SS14.Client.Console;
 using SS14.Client.Graphics.Drawing;
@@ -11,7 +10,6 @@ using SS14.Client.UserInterface.Controls;
 using SS14.Client.Utility;
 using SS14.Shared.Console;
 using SS14.Shared.Interfaces.Resources;
-using SS14.Shared.IoC;
 using SS14.Shared.Maths;
 using SS14.Shared.Utility;
 
@@ -27,25 +25,31 @@ namespace SS14.Client.UserInterface.CustomControls
     {
         private const int MaxHistorySize = 100;
 
-        [Dependency] private readonly IClientConsole console;
-        [Dependency] private readonly IResourceManager _resourceManager;
+        private readonly IClientConsole _console;
+        private readonly IResourceManager _resourceManager;
 
         private static readonly ResourcePath HistoryPath = new ResourcePath("/debug_console_history.json");
 
         private LineEdit CommandBar;
         private OutputPanel Output;
 
-        public IReadOnlyDictionary<string, IConsoleCommand> Commands => console.Commands;
+        public IReadOnlyDictionary<string, IConsoleCommand> Commands => _console.Commands;
         private readonly ConcurrentQueue<FormattedMessage> _messageQueue = new ConcurrentQueue<FormattedMessage>();
 
         private readonly List<string> CommandHistory = new List<string>();
         private int _historyPosition;
         private bool _currentCommandEdited;
 
-        protected override void Initialize()
+        public DebugConsole(IClientConsole console, IResourceManager resMan)
         {
-            IoCManager.InjectDependencies(this);
+            _console = console;
+            _resourceManager = resMan;
 
+            PerformLayout();
+        }
+        
+        private void PerformLayout()
+        {
             Visible = false;
 
             AnchorRight = 1f;
@@ -72,9 +76,9 @@ namespace SS14.Client.UserInterface.CustomControls
             CommandBar.OnTextEntered += CommandEntered;
             CommandBar.OnTextChanged += CommandBarOnOnTextChanged;
 
-            console.AddString += (_, args) => AddLine(args.Text, args.Channel, args.Color);
-            console.AddFormatted += (_, args) => AddFormattedLine(args.Message);
-            console.ClearText += (_, args) => Clear();
+            _console.AddString += (_, args) => AddLine(args.Text, args.Channel, args.Color);
+            _console.AddFormatted += (_, args) => AddFormattedLine(args.Message);
+            _console.ClearText += (_, args) => Clear();
 
             _loadHistoryFromDisk();
         }
@@ -107,7 +111,7 @@ namespace SS14.Client.UserInterface.CustomControls
         {
             if (!string.IsNullOrWhiteSpace(args.Text))
             {
-                console.ProcessCommand(args.Text);
+                _console.ProcessCommand(args.Text);
                 CommandBar.Clear();
                 if (CommandHistory.Count == 0 || CommandHistory[CommandHistory.Count - 1] != args.Text)
                 {

--- a/SS14.Client/UserInterface/CustomControls/DebugCoordsPanel.cs
+++ b/SS14.Client/UserInterface/CustomControls/DebugCoordsPanel.cs
@@ -3,9 +3,6 @@ using SS14.Client.Graphics;
 using SS14.Client.Interfaces.Graphics.ClientEye;
 using SS14.Client.Interfaces.Input;
 using SS14.Client.UserInterface.Controls;
-using SS14.Shared.Interfaces.GameObjects.Components;
-using SS14.Shared.IoC;
-using SS14.Shared.Reflection;
 using SS14.Shared.Map;
 using SS14.Shared.Maths;
 using SS14.Client.Interfaces.ResourceManagement;
@@ -22,21 +19,43 @@ namespace SS14.Client.UserInterface.CustomControls
 {
     internal class DebugCoordsPanel : Panel
     {
-        [Dependency] readonly IPlayerManager playerManager;
-        [Dependency] readonly IEyeManager eyeManager;
-        [Dependency] readonly IInputManager inputManager;
-        [Dependency] readonly IResourceCache resourceCache;
-        [Dependency] readonly IStateManager stateManager;
-
-        [Dependency] private readonly IDisplayManager _displayManager;
+        private readonly IPlayerManager playerManager;
+        private readonly IEyeManager eyeManager;
+        private readonly IInputManager inputManager;
+        private readonly IResourceCache resourceCache;
+        private readonly IStateManager stateManager;
+        private readonly IDisplayManager _displayManager;
 
         private Label contents;
+
+        //TODO: Think about a factory for this
+        public DebugCoordsPanel(
+            IPlayerManager playerMan,
+            IEyeManager eyeMan,
+            IInputManager inputMan,
+            IResourceCache resCache,
+            IStateManager stateMan,
+            IDisplayManager displayMan)
+        {
+            playerManager = playerMan;
+            eyeManager = eyeMan;
+            inputManager = inputMan;
+            resourceCache = resCache;
+            stateManager = stateMan;
+            _displayManager = displayMan;
+
+            PerformLayout();
+        }
 
         protected override void Initialize()
         {
             base.Initialize();
-            IoCManager.InjectDependencies(this);
 
+            contents = new Label();
+        }
+
+        private void PerformLayout()
+        {
             SizeFlagsHorizontal = SizeFlags.None;
 
             contents = new Label

--- a/SS14.Client/UserInterface/CustomControls/DebugMonitors.cs
+++ b/SS14.Client/UserInterface/CustomControls/DebugMonitors.cs
@@ -1,22 +1,53 @@
+﻿using SS14.Client.Interfaces.Graphics;
+using SS14.Client.Interfaces.Graphics.ClientEye;
+using SS14.Client.Interfaces.Input;
+using SS14.Client.Interfaces.ResourceManagement;
+using SS14.Client.Interfaces.State;
 using SS14.Client.UserInterface.Controls;
 using SS14.Client.Interfaces.UserInterface;
-using SS14.Shared.Reflection;
+using SS14.Client.Player;
+using SS14.Shared.Interfaces.Network;
+using SS14.Shared.Interfaces.Timing;
 
 namespace SS14.Client.UserInterface.CustomControls
 {
     public class DebugMonitors : VBoxContainer, IDebugMonitors
     {
-        public bool ShowFPS { get => FPSCounter.Visible; set => FPSCounter.Visible = value; }
-        public bool ShowCoords { get => DebugCoordsPanel.Visible; set => DebugCoordsPanel.Visible = value; }
+        public bool ShowFPS { get => _fpsCounter.Visible; set => _fpsCounter.Visible = value; }
+        public bool ShowCoords { get => _debugCoordsPanel.Visible; set => _debugCoordsPanel.Visible = value; }
         public bool ShowNet { get => _debugNetPanel.Visible; set => _debugNetPanel.Visible = value; }
         public bool ShowTime { get => _timeDebug.Visible; set => _timeDebug.Visible = value; }
         public bool ShowFrameGraph { get => _frameGraph.Visible; set => _frameGraph.Visible = value; }
 
-        private FPSCounter FPSCounter;
-        private DebugCoordsPanel DebugCoordsPanel;
+        private FPSCounter _fpsCounter;
+        private DebugCoordsPanel _debugCoordsPanel;
         private DebugNetPanel _debugNetPanel;
         private DebugTimePanel _timeDebug;
         private FrameGraph _frameGraph;
+
+        private readonly IGameTiming _gameTiming;
+        private readonly IPlayerManager _playerManager;
+        private readonly IEyeManager _eyeManager;
+        private readonly IInputManager _inputManager;
+        private readonly IResourceCache _resourceCache;
+        private readonly IStateManager _stateManager;
+        private readonly IDisplayManager _displayManager;
+        private readonly IClientNetManager _netManager;
+
+        //TODO: Think about a factory for this
+        public DebugMonitors(IGameTiming gameTiming, IPlayerManager playerManager, IEyeManager eyeManager, IInputManager inputManager, IResourceCache resourceCache, IStateManager stateManager, IDisplayManager displayManager, IClientNetManager netManager)
+        {
+            _gameTiming = gameTiming;
+            _playerManager = playerManager;
+            _eyeManager = eyeManager;
+            _inputManager = inputManager;
+            _resourceCache = resourceCache;
+            _stateManager = stateManager;
+            _displayManager = displayManager;
+            _netManager = netManager;
+
+            PerformLayout();
+        }
 
         protected override void Initialize()
         {
@@ -28,23 +59,27 @@ namespace SS14.Client.UserInterface.CustomControls
 
             MarginLeft = 2;
             MarginTop = 2;
+        }
 
-            FPSCounter = new FPSCounter();
-            AddChild(FPSCounter);
+        private void PerformLayout()
+        {
+            _fpsCounter = new FPSCounter(_gameTiming);
+            AddChild(_fpsCounter);
 
-            DebugCoordsPanel = new DebugCoordsPanel();
-            AddChild(DebugCoordsPanel);
+            _debugCoordsPanel = new DebugCoordsPanel(_playerManager, _eyeManager, _inputManager,
+                _resourceCache, _stateManager, _displayManager);
+            AddChild(_debugCoordsPanel);
 
-            _debugNetPanel = new DebugNetPanel();
+            _debugNetPanel = new DebugNetPanel(_netManager, _gameTiming, _resourceCache);
             AddChild(_debugNetPanel);
 
-            _timeDebug = new DebugTimePanel
+            _timeDebug = new DebugTimePanel(_resourceCache, _gameTiming)
             {
                 Visible = false,
             };
             AddChild(_timeDebug);
 
-            _frameGraph = new FrameGraph();
+            _frameGraph = new FrameGraph(_gameTiming);
             AddChild(_frameGraph);
         }
     }

--- a/SS14.Client/UserInterface/CustomControls/DebugNetPanel.cs
+++ b/SS14.Client/UserInterface/CustomControls/DebugNetPanel.cs
@@ -15,17 +15,12 @@ namespace SS14.Client.UserInterface.CustomControls
     {
         // Float so I don't have to cast it to prevent integer division down below.
         const float ONE_KIBIBYTE = 1024;
-
-        [Dependency]
+        
         private readonly IClientNetManager NetManager;
-
-        [Dependency]
         private readonly IGameTiming GameTiming;
-        [Dependency]
         private readonly IResourceCache resourceCache;
-
+        
         private TimeSpan LastUpdate;
-
         private Label contents;
 
         // These are ints in the stats.
@@ -36,11 +31,23 @@ namespace SS14.Client.UserInterface.CustomControls
         private long LastSentPackets;
         private long LastReceivedPackets;
 
+        public DebugNetPanel(IClientNetManager netMan, IGameTiming gameTiming, IResourceCache resCache)
+        {
+            NetManager = netMan;
+            GameTiming = gameTiming;
+            resourceCache = resCache;
+
+            PerformLayout();
+        }
         protected override void Initialize()
         {
             base.Initialize();
-            IoCManager.InjectDependencies(this);
 
+            contents = new Label();
+        }
+
+        private void PerformLayout()
+        {
             SizeFlagsHorizontal = SizeFlags.None;
 
             contents = new Label

--- a/SS14.Client/UserInterface/CustomControls/DebugNetPanel.cs
+++ b/SS14.Client/UserInterface/CustomControls/DebugNetPanel.cs
@@ -5,7 +5,6 @@ using SS14.Client.ResourceManagement;
 using SS14.Client.UserInterface.Controls;
 using SS14.Shared.Interfaces.Network;
 using SS14.Shared.Interfaces.Timing;
-using SS14.Shared.IoC;
 using SS14.Shared.Maths;
 using SS14.Shared.Utility;
 

--- a/SS14.Client/UserInterface/CustomControls/DebugTimePanel.cs
+++ b/SS14.Client/UserInterface/CustomControls/DebugTimePanel.cs
@@ -3,7 +3,6 @@ using SS14.Client.Interfaces.ResourceManagement;
 using SS14.Client.ResourceManagement;
 using SS14.Client.UserInterface.Controls;
 using SS14.Shared.Interfaces.Timing;
-using SS14.Shared.IoC;
 using SS14.Shared.Maths;
 using SS14.Shared.Utility;
 

--- a/SS14.Client/UserInterface/CustomControls/DebugTimePanel.cs
+++ b/SS14.Client/UserInterface/CustomControls/DebugTimePanel.cs
@@ -11,19 +11,28 @@ namespace SS14.Client.UserInterface.CustomControls
 {
     public class DebugTimePanel : Panel
     {
-        [Dependency]
         private readonly IResourceCache _resourceCache;
-
-        [Dependency]
         private readonly IGameTiming _gameTiming;
 
         private Label _contents;
 
+        public DebugTimePanel(IResourceCache resourceCache, IGameTiming gameTiming)
+        {
+            _resourceCache = resourceCache;
+            _gameTiming = gameTiming;
+
+            PerformLayout();
+        }
+
         protected override void Initialize()
         {
             base.Initialize();
-            IoCManager.InjectDependencies(this);
 
+            _contents = new Label();
+        }
+
+        private void PerformLayout()
+        {
             _contents = new Label
             {
                 FontOverride = _resourceCache.GetResource<FontResource>(new ResourcePath("/Fonts/CALIBRI.TTF"))

--- a/SS14.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
+++ b/SS14.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using SS14.Client.GameObjects;
 using SS14.Client.Interfaces.Placement;
+using SS14.Client.Interfaces.ResourceManagement;
 using SS14.Client.UserInterface.Controls;
 using SS14.Shared.Enums;
 using SS14.Shared.GameObjects;
@@ -18,6 +19,7 @@ namespace SS14.Client.UserInterface.CustomControls
 
         [Dependency] private readonly IPlacementManager placementManager;
         [Dependency] private readonly IPrototypeManager prototypeManager;
+        [Dependency] private readonly IResourceCache resourceCache;
 
         private Control HSplitContainer;
         private Control PrototypeList;
@@ -158,7 +160,7 @@ namespace SS14.Client.UserInterface.CustomControls
                 button.ActualButton.OnToggled += OnItemButtonToggled;
                 container.GetChild<Label>("Label").Text = prototype.Name;
 
-                var tex = IconComponent.GetPrototypeIcon(prototype);
+                var tex = IconComponent.GetPrototypeIcon(prototype, resourceCache);
                 var rect = container.GetChild("TextureWrap").GetChild<TextureRect>("TextureRect");
                 if (tex != null)
                 {

--- a/SS14.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
+++ b/SS14.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
@@ -6,7 +6,6 @@ using SS14.Client.Interfaces.ResourceManagement;
 using SS14.Client.UserInterface.Controls;
 using SS14.Shared.Enums;
 using SS14.Shared.GameObjects;
-using SS14.Shared.IoC;
 using SS14.Shared.Maths;
 using SS14.Shared.Prototypes;
 using SS14.Shared.Utility;
@@ -17,9 +16,9 @@ namespace SS14.Client.UserInterface.CustomControls
     {
         protected override ResourcePath ScenePath => new ResourcePath("/Scenes/Placement/EntitySpawnPanel.tscn");
 
-        [Dependency] private readonly IPlacementManager placementManager;
-        [Dependency] private readonly IPrototypeManager prototypeManager;
-        [Dependency] private readonly IResourceCache resourceCache;
+        private readonly IPlacementManager placementManager;
+        private readonly IPrototypeManager prototypeManager;
+        private readonly IResourceCache resourceCache;
 
         private Control HSplitContainer;
         private Control PrototypeList;
@@ -48,12 +47,19 @@ namespace SS14.Client.UserInterface.CustomControls
 
         private EntitySpawnButton SelectedButton;
 
+        public EntitySpawnWindow(IPlacementManager placementManager, IPrototypeManager prototypeManager, IResourceCache resourceCache)
+        {
+            this.placementManager = placementManager;
+            this.prototypeManager = prototypeManager;
+            this.resourceCache = resourceCache;
+
+            PerformLayout();
+        }
+
         protected override void Initialize()
         {
             base.Initialize();
-
-            IoCManager.InjectDependencies(this);
-
+            
             // Get all the controls.
             HSplitContainer = Contents.GetChild("HSplitContainer");
             PrototypeList = HSplitContainer.GetChild("PrototypeListScrollContainer").GetChild("PrototypeList");
@@ -75,7 +81,10 @@ namespace SS14.Client.UserInterface.CustomControls
 
             EraseButton = buttons.GetChild<Button>("EraseButton");
             EraseButton.OnToggled += OnEraseButtonToggled;
+        }
 
+        private void PerformLayout()
+        {
             BuildEntityList();
 
             placementManager.PlacementCanceled += OnPlacementCanceled;

--- a/SS14.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
+++ b/SS14.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using SS14.Client.GameObjects;
+using SS14.Client.Interfaces.Graphics;
 using SS14.Client.Interfaces.Placement;
 using SS14.Client.Interfaces.ResourceManagement;
 using SS14.Client.UserInterface.Controls;
@@ -47,7 +48,9 @@ namespace SS14.Client.UserInterface.CustomControls
 
         private EntitySpawnButton SelectedButton;
 
-        public EntitySpawnWindow(IPlacementManager placementManager, IPrototypeManager prototypeManager, IResourceCache resourceCache)
+        public EntitySpawnWindow(IDisplayManager displayManager, IPlacementManager placementManager,
+            IPrototypeManager prototypeManager,
+            IResourceCache resourceCache) : base(displayManager)
         {
             this.placementManager = placementManager;
             this.prototypeManager = prototypeManager;

--- a/SS14.Client/UserInterface/CustomControls/EscapeMenu.cs
+++ b/SS14.Client/UserInterface/CustomControls/EscapeMenu.cs
@@ -1,19 +1,20 @@
-﻿using SS14.Client.Interfaces.State;
-using SS14.Client.Interfaces.UserInterface;
-using SS14.Client.UserInterface.Controls;
-using SS14.Client.State.States;
-using SS14.Shared.Interfaces.Network;
-using SS14.Shared.IoC;
-using SS14.Shared.Reflection;
+﻿using SS14.Client.UserInterface.Controls;
 using SS14.Client.Console;
+using SS14.Client.Interfaces.Placement;
+using SS14.Client.Interfaces.ResourceManagement;
+using SS14.Shared.Interfaces.Map;
+using SS14.Shared.Prototypes;
 using SS14.Shared.Utility;
 
 namespace SS14.Client.UserInterface.CustomControls
 {
     public class EscapeMenu : SS14Window
     {
-        [Dependency]
-        readonly IClientConsole console;
+        private readonly IClientConsole _console;
+        private readonly ITileDefinitionManager __tileDefinitionManager;
+        private readonly IPlacementManager _placementManager;
+        private readonly IPrototypeManager _prototypeManager;
+        private readonly IResourceCache _resourceCache;
 
         protected override ResourcePath ScenePath => new ResourcePath("/Scenes/EscapeMenu/EscapeMenu.tscn");
         private BaseButton QuitButton;
@@ -21,6 +22,20 @@ namespace SS14.Client.UserInterface.CustomControls
         private BaseButton SpawnEntitiesButton;
         private BaseButton SpawnTilesButton;
         private OptionsMenu optionsMenu;
+        
+        public EscapeMenu(
+            IClientConsole console,
+            ITileDefinitionManager tileDefinitionManager,
+            IPlacementManager placementManager,
+            IPrototypeManager prototypeManager,
+            IResourceCache resourceCache)
+        {
+            _console = console;
+            __tileDefinitionManager = tileDefinitionManager;
+            _placementManager = placementManager;
+            _prototypeManager = prototypeManager;
+            _resourceCache = resourceCache;
+        }
 
         protected override void Initialize()
         {
@@ -34,9 +49,7 @@ namespace SS14.Client.UserInterface.CustomControls
 
             Resizable = false;
             HideOnClose = true;
-
-            IoCManager.InjectDependencies(this);
-
+            
             QuitButton = Contents.GetChild<BaseButton>("QuitButton");
             QuitButton.OnPressed += OnQuitButtonClicked;
 
@@ -52,7 +65,7 @@ namespace SS14.Client.UserInterface.CustomControls
 
         private void OnQuitButtonClicked(BaseButton.ButtonEventArgs args)
         {
-            console.ProcessCommand("disconnect");
+            _console.ProcessCommand("disconnect");
             Dispose();
         }
 
@@ -63,14 +76,14 @@ namespace SS14.Client.UserInterface.CustomControls
 
         private void OnSpawnEntitiesButtonClicked(BaseButton.ButtonEventArgs args)
         {
-            var window = new EntitySpawnWindow();
+            var window = new EntitySpawnWindow(_placementManager, _prototypeManager, _resourceCache);
             window.AddToScreen();
             window.OpenToLeft();
         }
 
         private void OnSpawnTilesButtonClicked(BaseButton.ButtonEventArgs args)
         {
-            var window = new TileSpawnWindow();
+            var window = new TileSpawnWindow(__tileDefinitionManager, _placementManager);
             window.AddToScreen();
             window.OpenToLeft();
         }

--- a/SS14.Client/UserInterface/CustomControls/EscapeMenu.cs
+++ b/SS14.Client/UserInterface/CustomControls/EscapeMenu.cs
@@ -1,7 +1,9 @@
 ﻿using SS14.Client.UserInterface.Controls;
 using SS14.Client.Console;
+using SS14.Client.Interfaces.Graphics;
 using SS14.Client.Interfaces.Placement;
 using SS14.Client.Interfaces.ResourceManagement;
+using SS14.Shared.Interfaces.Configuration;
 using SS14.Shared.Interfaces.Map;
 using SS14.Shared.Prototypes;
 using SS14.Shared.Utility;
@@ -15,6 +17,8 @@ namespace SS14.Client.UserInterface.CustomControls
         private readonly IPlacementManager _placementManager;
         private readonly IPrototypeManager _prototypeManager;
         private readonly IResourceCache _resourceCache;
+        private readonly IDisplayManager _displayManager;
+        private readonly IConfigurationManager _configSystem;
 
         protected override ResourcePath ScenePath => new ResourcePath("/Scenes/EscapeMenu/EscapeMenu.tscn");
         private BaseButton QuitButton;
@@ -22,26 +26,29 @@ namespace SS14.Client.UserInterface.CustomControls
         private BaseButton SpawnEntitiesButton;
         private BaseButton SpawnTilesButton;
         private OptionsMenu optionsMenu;
-        
-        public EscapeMenu(
+
+        public EscapeMenu(IDisplayManager displayManager,
             IClientConsole console,
             ITileDefinitionManager tileDefinitionManager,
             IPlacementManager placementManager,
             IPrototypeManager prototypeManager,
-            IResourceCache resourceCache)
+            IResourceCache resourceCache,
+            IConfigurationManager configSystem) : base(displayManager)
         {
+            _configSystem = configSystem;
+            _displayManager = displayManager;
             _console = console;
             __tileDefinitionManager = tileDefinitionManager;
             _placementManager = placementManager;
             _prototypeManager = prototypeManager;
             _resourceCache = resourceCache;
+
+            PerformLayout();
         }
 
-        protected override void Initialize()
+        private void PerformLayout()
         {
-            base.Initialize();
-
-            optionsMenu = new OptionsMenu
+            optionsMenu = new OptionsMenu(_displayManager, _configSystem)
             {
                 Visible = false
             };
@@ -49,7 +56,7 @@ namespace SS14.Client.UserInterface.CustomControls
 
             Resizable = false;
             HideOnClose = true;
-            
+
             QuitButton = Contents.GetChild<BaseButton>("QuitButton");
             QuitButton.OnPressed += OnQuitButtonClicked;
 
@@ -76,14 +83,14 @@ namespace SS14.Client.UserInterface.CustomControls
 
         private void OnSpawnEntitiesButtonClicked(BaseButton.ButtonEventArgs args)
         {
-            var window = new EntitySpawnWindow(_placementManager, _prototypeManager, _resourceCache);
+            var window = new EntitySpawnWindow(_displayManager, _placementManager, _prototypeManager, _resourceCache);
             window.AddToScreen();
             window.OpenToLeft();
         }
 
         private void OnSpawnTilesButtonClicked(BaseButton.ButtonEventArgs args)
         {
-            var window = new TileSpawnWindow(__tileDefinitionManager, _placementManager);
+            var window = new TileSpawnWindow(__tileDefinitionManager, _placementManager, _displayManager);
             window.AddToScreen();
             window.OpenToLeft();
         }

--- a/SS14.Client/UserInterface/CustomControls/FPSCounter.cs
+++ b/SS14.Client/UserInterface/CustomControls/FPSCounter.cs
@@ -1,13 +1,18 @@
 ﻿using SS14.Client.UserInterface.Controls;
 using SS14.Shared.Interfaces.Timing;
-using SS14.Shared.IoC;
 using SS14.Shared.Maths;
-using SS14.Shared.Reflection;
 
 namespace SS14.Client.UserInterface.CustomControls
 {
     public class FPSCounter : Label
     {
+        private readonly IGameTiming _gameTiming;
+
+        public FPSCounter(IGameTiming gameTiming)
+        {
+            _gameTiming = gameTiming;
+        }
+
         protected override void Initialize()
         {
             base.Initialize();
@@ -26,7 +31,7 @@ namespace SS14.Client.UserInterface.CustomControls
                 return;
             }
 
-            var fps = IoCManager.Resolve<IGameTiming>().FramesPerSecondAvg;
+            var fps = _gameTiming.FramesPerSecondAvg;
             Text = $"FPS: {fps:N1}";
         }
     }

--- a/SS14.Client/UserInterface/CustomControls/FrameGraph.cs
+++ b/SS14.Client/UserInterface/CustomControls/FrameGraph.cs
@@ -1,13 +1,12 @@
-using SS14.Client.Graphics.Drawing;
+﻿using SS14.Client.Graphics.Drawing;
 using SS14.Shared.Interfaces.Timing;
-using SS14.Shared.IoC;
 using SS14.Shared.Maths;
 
 namespace SS14.Client.UserInterface.CustomControls
 {
     public sealed class FrameGraph : Control
     {
-        [Dependency] private readonly IGameTiming _gameTiming;
+        private readonly IGameTiming _gameTiming;
 
         /// <summary>
         ///     How many frames we show at once.
@@ -36,12 +35,15 @@ namespace SS14.Client.UserInterface.CustomControls
         // Position of the last frame in the ring buffer.
         private int _frameIndex;
 
+        public FrameGraph(IGameTiming gameTiming)
+        {
+            _gameTiming = gameTiming;
+        }
+
         protected override void Initialize()
         {
             base.Initialize();
-
-            IoCManager.InjectDependencies(this);
-
+            
             SizeFlagsHorizontal = SizeFlags.None;
         }
 

--- a/SS14.Client/UserInterface/CustomControls/OptionsMenu.cs
+++ b/SS14.Client/UserInterface/CustomControls/OptionsMenu.cs
@@ -1,12 +1,8 @@
-using SS14.Client.Graphics;
+﻿using SS14.Client.Graphics;
 using SS14.Client.Interfaces.Graphics;
 using SS14.Client.UserInterface.Controls;
-using SS14.Client.Utility;
 using SS14.Shared.Interfaces.Configuration;
-using SS14.Shared.IoC;
 using SS14.Shared.Maths;
-using SS14.Shared.Reflection;
-using SS14.Shared.Utility;
 
 namespace SS14.Client.UserInterface.CustomControls
 {
@@ -16,9 +12,18 @@ namespace SS14.Client.UserInterface.CustomControls
         private CheckBox VSyncCheckBox;
         private CheckBox FullscreenCheckBox;
         private CheckBox HighResLightsCheckBox;
-        private IConfigurationManager configManager;
+        private readonly IConfigurationManager configManager;
+        private readonly IDisplayManager _displayManager;
 
         protected override Vector2? CustomSize => (180, 160);
+
+        public OptionsMenu(IDisplayManager displayMan, IConfigurationManager configMan) : base(displayMan)
+        {
+            _displayManager = displayMan;
+            configManager = configMan;
+
+            PerformLayout();
+        }
 
         protected override void Initialize()
         {
@@ -27,9 +32,10 @@ namespace SS14.Client.UserInterface.CustomControls
             HideOnClose = true;
 
             Title = "Options";
+        }
 
-            configManager = IoCManager.Resolve<IConfigurationManager>();
-
+        private void PerformLayout()
+        {
             var vBox = new VBoxContainer();
             Contents.AddChild(vBox);
             vBox.SetAnchorAndMarginPreset(LayoutPreset.Wide);
@@ -67,7 +73,7 @@ namespace SS14.Client.UserInterface.CustomControls
                 (int) (FullscreenCheckBox.Pressed ? WindowMode.Fullscreen : WindowMode.Windowed));
             configManager.SaveToFile();
             UpdateApplyButton();
-            IoCManager.Resolve<IDisplayManager>().ReloadConfig();
+            _displayManager.ReloadConfig();
         }
 
         private void OnCheckBoxToggled(BaseButton.ButtonToggledEventArgs args)

--- a/SS14.Client/UserInterface/CustomControls/SS14Window.cs
+++ b/SS14.Client/UserInterface/CustomControls/SS14Window.cs
@@ -3,7 +3,6 @@ using SS14.Shared.Maths;
 using System;
 using SS14.Client.Interfaces.Graphics;
 using SS14.Client.Utility;
-using SS14.Shared.IoC;
 using SS14.Shared.Utility;
 
 namespace SS14.Client.UserInterface.CustomControls
@@ -16,16 +15,18 @@ namespace SS14.Client.UserInterface.CustomControls
         public const string StyleClassWindowHeader = "windowHeader";
         public const string StyleClassWindowCloseButton = "windowCloseButton";
 
-        [Dependency] private readonly IDisplayManager _displayManager;
+        private readonly IDisplayManager _displayManager;
 
         protected virtual Vector2? CustomSize => null;
 
-        public SS14Window() : base()
+        public SS14Window(IDisplayManager displayMan) : base()
         {
+            _displayManager = displayMan;
         }
 
-        public SS14Window(string name) : base(name)
+        public SS14Window(IDisplayManager displayMan, string name) : base(name)
         {
+            _displayManager = displayMan;
         }
 
         [Flags]
@@ -87,8 +88,6 @@ namespace SS14.Client.UserInterface.CustomControls
         protected override void Initialize()
         {
             base.Initialize();
-
-            IoCManager.InjectDependencies(this);
 
             var header = GetChild<Panel>("Header");
             CloseButton = header.GetChild<TextureButton>("CloseButton");

--- a/SS14.Client/UserInterface/CustomControls/TileSpawnWindow.cs
+++ b/SS14.Client/UserInterface/CustomControls/TileSpawnWindow.cs
@@ -2,8 +2,6 @@
 using SS14.Client.UserInterface.Controls;
 using SS14.Shared.Enums;
 using SS14.Shared.Interfaces.Map;
-using SS14.Shared.IoC;
-using SS14.Shared.Reflection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,11 +12,9 @@ namespace SS14.Client.UserInterface.CustomControls
     internal class TileSpawnWindow : SS14Window
     {
         protected override ResourcePath ScenePath => new ResourcePath("/Scenes/Placement/TileSpawnPanel.tscn");
-
-        [Dependency]
-        private readonly ITileDefinitionManager tileDefinitionManager;
-        [Dependency]
-        private readonly IPlacementManager placementManager;
+        
+        private readonly ITileDefinitionManager __tileDefinitionManager;
+        private readonly IPlacementManager _placementManager;
 
         private Control TileList;
         private LineEdit SearchBar;
@@ -26,12 +22,16 @@ namespace SS14.Client.UserInterface.CustomControls
 
         private TileSpawnButton SelectedButton;
 
-        protected override void Initialize()
+        public TileSpawnWindow(ITileDefinitionManager tileDefinitionManager, IPlacementManager placementManager)
         {
-            base.Initialize();
+            __tileDefinitionManager = tileDefinitionManager;
+            _placementManager = placementManager;
 
-            IoCManager.InjectDependencies(this);
+            PerformLayout();
+        }
 
+        private void PerformLayout()
+        {
             // Get all the controls.
             var HSplitContainer = Contents.GetChild("HSplitContainer");
             TileList = HSplitContainer.GetChild("TileListScrollContainer").GetChild("TileList");
@@ -44,7 +44,7 @@ namespace SS14.Client.UserInterface.CustomControls
 
             BuildTileList();
 
-            placementManager.PlacementCanceled += OnPlacementCanceled;
+            _placementManager.PlacementCanceled += OnPlacementCanceled;
         }
 
         protected override void Dispose(bool disposing)
@@ -53,7 +53,7 @@ namespace SS14.Client.UserInterface.CustomControls
 
             if (disposing)
             {
-                placementManager.PlacementCanceled -= OnPlacementCanceled;
+                _placementManager.PlacementCanceled -= OnPlacementCanceled;
             }
         }
 
@@ -72,7 +72,7 @@ namespace SS14.Client.UserInterface.CustomControls
         {
             TileList.DisposeAllChildren();
 
-            IEnumerable<ITileDefinition> tileDefs = tileDefinitionManager;
+            IEnumerable<ITileDefinition> tileDefs = __tileDefinitionManager;
 
             if (!string.IsNullOrEmpty(searchStr))
             {
@@ -122,7 +122,7 @@ namespace SS14.Client.UserInterface.CustomControls
             if (SelectedButton == item)
             {
                 SelectedButton = null;
-                placementManager.Clear();
+                _placementManager.Clear();
                 return;
             }
             else if (SelectedButton != null)
@@ -140,7 +140,7 @@ namespace SS14.Client.UserInterface.CustomControls
                 IsTile = true
             };
 
-            placementManager.BeginPlacing(newObjInfo);
+            _placementManager.BeginPlacing(newObjInfo);
             SelectedButton = item;
         }
     }

--- a/SS14.Client/UserInterface/CustomControls/TileSpawnWindow.cs
+++ b/SS14.Client/UserInterface/CustomControls/TileSpawnWindow.cs
@@ -5,6 +5,7 @@ using SS14.Shared.Interfaces.Map;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using SS14.Client.Interfaces.Graphics;
 using SS14.Shared.Utility;
 
 namespace SS14.Client.UserInterface.CustomControls
@@ -22,7 +23,8 @@ namespace SS14.Client.UserInterface.CustomControls
 
         private TileSpawnButton SelectedButton;
 
-        public TileSpawnWindow(ITileDefinitionManager tileDefinitionManager, IPlacementManager placementManager)
+        public TileSpawnWindow(ITileDefinitionManager tileDefinitionManager, IPlacementManager placementManager,
+            IDisplayManager displayManager) : base(displayManager)
         {
             __tileDefinitionManager = tileDefinitionManager;
             _placementManager = placementManager;

--- a/SS14.Client/UserInterface/UserInterfaceManager.cs
+++ b/SS14.Client/UserInterface/UserInterfaceManager.cs
@@ -1,19 +1,26 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using SS14.Client.Console;
 using SS14.Client.Graphics;
 using SS14.Client.Graphics.Clyde;
 using SS14.Client.Graphics.Drawing;
 using SS14.Client.Input;
 using SS14.Client.Interfaces;
 using SS14.Client.Interfaces.Graphics;
+using SS14.Client.Interfaces.Graphics.ClientEye;
 using SS14.Client.Interfaces.Input;
+using SS14.Client.Interfaces.ResourceManagement;
+using SS14.Client.Interfaces.State;
 using SS14.Client.Interfaces.UserInterface;
+using SS14.Client.Player;
 using SS14.Client.UserInterface.Controls;
 using SS14.Client.UserInterface.CustomControls;
 using SS14.Client.Utility;
-using SS14.Shared.Configuration;
 using SS14.Shared.Input;
+using SS14.Shared.Interfaces.Network;
+using SS14.Shared.Interfaces.Resources;
+using SS14.Shared.Interfaces.Timing;
 using SS14.Shared.IoC;
 using SS14.Shared.Maths;
 
@@ -24,6 +31,14 @@ namespace SS14.Client.UserInterface
         [Dependency] private readonly ISceneTreeHolder _sceneTreeHolder;
         [Dependency] private readonly IInputManager _inputManager;
         [Dependency] private readonly IDisplayManager _displayManager;
+        [Dependency] private readonly IClientConsole _console;
+        [Dependency] private readonly IResourceManager _resourceManager;
+        [Dependency] private readonly IGameTiming _gameTiming;
+        [Dependency] private readonly IPlayerManager _playerManager;
+        [Dependency] private readonly IEyeManager _eyeManager;
+        [Dependency] private readonly IResourceCache _resourceCache;
+        [Dependency] private readonly IStateManager _stateManager;
+        [Dependency] private readonly IClientNetManager _netManager;
 
         public UITheme ThemeDefaults { get; private set; }
         public Stylesheet Stylesheet { get; set; }
@@ -58,10 +73,11 @@ namespace SS14.Client.UserInterface
 
             _initializeCommon();
 
-            DebugConsole = new DebugConsole();
+            DebugConsole = new DebugConsole(_console, _resourceManager);
             RootControl.AddChild(DebugConsole);
 
-            _debugMonitors = new DebugMonitors();
+            _debugMonitors = new DebugMonitors(_gameTiming, _playerManager, _eyeManager, _inputManager,
+                _resourceCache, _stateManager, _displayManager, _netManager);
             RootControl.AddChild(_debugMonitors);
 
             _inputManager.SetInputCommand(EngineKeyFunctions.ShowDebugMonitors,

--- a/SS14.Client/UserInterface/UserInterfaceManager.cs
+++ b/SS14.Client/UserInterface/UserInterfaceManager.cs
@@ -326,7 +326,8 @@ namespace SS14.Client.UserInterface
 
         public void Popup(string contents, string title = "Alert!")
         {
-            var popup = new SS14Window {Title = title};
+            var popup = new SS14Window(_displayManager)
+                {Title = title};
             popup.Contents.AddChild(new Label {Text = contents});
             popup.AddToScreen();
         }

--- a/SS14.Client/ViewVariables/Instances/ViewVariablesInstanceObject.cs
+++ b/SS14.Client/ViewVariables/Instances/ViewVariablesInstanceObject.cs
@@ -1,16 +1,9 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using SS14.Client.Graphics;
+﻿using System.Collections.Generic;
 using SS14.Client.Interfaces.ResourceManagement;
-using SS14.Client.ResourceManagement;
 using SS14.Client.UserInterface;
 using SS14.Client.UserInterface.Controls;
 using SS14.Client.UserInterface.CustomControls;
-using SS14.Client.ViewVariables.Editors;
 using SS14.Client.ViewVariables.Traits;
-using SS14.Shared.IoC;
-using SS14.Shared.Utility;
 using SS14.Shared.ViewVariables;
 
 namespace SS14.Client.ViewVariables.Instances
@@ -18,16 +11,15 @@ namespace SS14.Client.ViewVariables.Instances
     internal class ViewVariablesInstanceObject : ViewVariablesInstance
     {
         private TabContainer _tabs;
-        private int _tabCount = 0;
+        private int _tabCount;
 
         private readonly List<ViewVariablesTrait> _traits = new List<ViewVariablesTrait>();
 
         public ViewVariablesRemoteSession Session { get; private set; }
         public object Object { get; private set; }
 
-        public ViewVariablesInstanceObject(IViewVariablesManagerInternal vvm) : base(vvm)
-        {
-        }
+        public ViewVariablesInstanceObject(IViewVariablesManagerInternal vvm, IResourceCache resCache)
+            : base(vvm, resCache) { }
 
         public override void Initialize(SS14Window window, object obj)
         {
@@ -113,12 +105,12 @@ namespace SS14.Client.ViewVariables.Instances
             }
         }
 
-        private static List<ViewVariablesTrait> TraitsFor(ICollection<object> traitData)
+        private List<ViewVariablesTrait> TraitsFor(ICollection<object> traitData)
         {
             var list = new List<ViewVariablesTrait>(traitData.Count);
             if (traitData.Contains(ViewVariablesTraits.Members))
             {
-                list.Add(new ViewVariablesTraitMembers());
+                list.Add(new ViewVariablesTraitMembers(ViewVariablesManager, _resourceCache));
             }
 
             if (traitData.Contains(ViewVariablesTraits.Enumerable))

--- a/SS14.Client/ViewVariables/Traits/ViewVariablesTraitMembers.cs
+++ b/SS14.Client/ViewVariables/Traits/ViewVariablesTraitMembers.cs
@@ -1,3 +1,4 @@
+﻿using SS14.Client.Interfaces.ResourceManagement;
 using SS14.Client.UserInterface.Controls;
 using SS14.Client.ViewVariables.Editors;
 using SS14.Client.ViewVariables.Instances;
@@ -8,6 +9,9 @@ namespace SS14.Client.ViewVariables.Traits
 {
     internal class ViewVariablesTraitMembers : ViewVariablesTrait
     {
+        private readonly IViewVariablesManagerInternal _vvm;
+        private readonly IResourceCache _resourceCache;
+
         private VBoxContainer _memberList;
 
         public override void Initialize(ViewVariablesInstanceObject instance)
@@ -17,6 +21,12 @@ namespace SS14.Client.ViewVariables.Traits
             instance.AddTab("Members", _memberList);
         }
 
+        public ViewVariablesTraitMembers(IViewVariablesManagerInternal vvm, IResourceCache resourceCache)
+        {
+            _resourceCache = resourceCache;
+            _vvm = vvm;
+        }
+
         public override async void Refresh()
         {
             _memberList.DisposeAllChildren();
@@ -24,7 +34,7 @@ namespace SS14.Client.ViewVariables.Traits
             if (Instance.Object != null)
             {
                 foreach (var control in ViewVariablesInstance.LocalPropertyList(Instance.Object,
-                    Instance.ViewVariablesManager))
+                    Instance.ViewVariablesManager, _resourceCache))
                 {
                     _memberList.AddChild(control);
                 }
@@ -39,7 +49,7 @@ namespace SS14.Client.ViewVariables.Traits
                 var otherStyle = false;
                 foreach (var propertyData in blob.Members)
                 {
-                    var propertyEdit = new ViewVariablesPropertyControl();
+                    var propertyEdit = new ViewVariablesPropertyControl(_vvm, _resourceCache);
                     propertyEdit.SetStyle(otherStyle = !otherStyle);
                     var editor = propertyEdit.SetProperty(propertyData);
                     // TODO: should this maybe not be hardcoded?

--- a/SS14.Client/ViewVariables/ViewVariablesInstance.cs
+++ b/SS14.Client/ViewVariables/ViewVariablesInstance.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
 using SS14.Client.Graphics;
@@ -21,10 +21,12 @@ namespace SS14.Client.ViewVariables
     internal abstract class ViewVariablesInstance
     {
         public readonly IViewVariablesManagerInternal ViewVariablesManager;
+        protected readonly IResourceCache _resourceCache;
 
-        protected ViewVariablesInstance(IViewVariablesManagerInternal vvm)
+        protected ViewVariablesInstance(IViewVariablesManagerInternal vvm, IResourceCache resCache)
         {
             ViewVariablesManager = vvm;
+            _resourceCache = resCache;
         }
 
         /// <summary>
@@ -53,7 +55,8 @@ namespace SS14.Client.ViewVariables
         {
         }
 
-        protected internal static IEnumerable<Control> LocalPropertyList(object obj, IViewVariablesManagerInternal vvm)
+        protected internal static IEnumerable<Control> LocalPropertyList(object obj, IViewVariablesManagerInternal vvm,
+            IResourceCache resCache)
         {
             var styleOther = false;
             var type = obj.GetType();
@@ -97,7 +100,7 @@ namespace SS14.Client.ViewVariables
                     Value = value
                 };
 
-                var propertyEdit = new ViewVariablesPropertyControl();
+                var propertyEdit = new ViewVariablesPropertyControl(vvm, resCache);
                 propertyEdit.SetStyle(styleOther = !styleOther);
                 var editor = propertyEdit.SetProperty(data);
                 editor.OnValueChanged += onValueChanged;

--- a/SS14.Client/ViewVariables/ViewVariablesManager.cs
+++ b/SS14.Client/ViewVariables/ViewVariablesManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using SS14.Client.Interfaces.Graphics;
 using SS14.Client.Interfaces.ResourceManagement;
 using SS14.Client.UserInterface.Controls;
 using SS14.Client.UserInterface.CustomControls;
@@ -23,6 +24,7 @@ namespace SS14.Client.ViewVariables
         [Dependency] private readonly IClientNetManager _netManager;
         [Dependency] private readonly IResourceCache _resourceCache;
         [Dependency] private readonly IEntityManager _entityManager;
+        [Dependency] private readonly IDisplayManager _displayManager;
 
         private uint _nextReqId = 1;
 
@@ -187,7 +189,7 @@ namespace SS14.Client.ViewVariables
                 instance = new ViewVariablesInstanceObject(this, _resourceCache);
             }
 
-            var window = new SS14Window("VV") {Title = "View Variables"};
+            var window = new SS14Window(_displayManager, "VV") {Title = "View Variables"};
             instance.Initialize(window, obj);
             window.AddToScreen();
             window.OnClose += () => _closeInstance(instance, false);
@@ -196,7 +198,7 @@ namespace SS14.Client.ViewVariables
 
         public async void OpenVV(ViewVariablesObjectSelector selector)
         {
-            var window = new SS14Window("VV") {Title = "View Variables"};
+            var window = new SS14Window(_displayManager, "VV") {Title = "View Variables"};
             var loadingLabel = new Label {Text = "Retrieving remote object data from server..."};
             window.Contents.AddChild(loadingLabel);
             window.AddToScreen();

--- a/SS14.Client/ViewVariables/ViewVariablesManager.cs
+++ b/SS14.Client/ViewVariables/ViewVariablesManager.cs
@@ -1,14 +1,11 @@
-using System;
-using System.Collections;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
+using SS14.Client.Interfaces.ResourceManagement;
 using SS14.Client.UserInterface.Controls;
 using SS14.Client.UserInterface.CustomControls;
 using SS14.Client.ViewVariables.Editors;
 using SS14.Client.ViewVariables.Instances;
-using SS14.Client.ViewVariables.Traits;
 using SS14.Shared.Interfaces.GameObjects;
 using SS14.Shared.Interfaces.Network;
 using SS14.Shared.IoC;
@@ -16,7 +13,6 @@ using SS14.Shared.Log;
 using SS14.Shared.Map;
 using SS14.Shared.Maths;
 using SS14.Shared.Network.Messages;
-using SS14.Shared.Utility;
 using SS14.Shared.ViewVariables;
 using NumberType = SS14.Client.ViewVariables.Editors.ViewVariablesPropertyEditorNumeric.NumberType;
 
@@ -25,6 +21,8 @@ namespace SS14.Client.ViewVariables
     internal class ViewVariablesManager : ViewVariablesManagerShared, IViewVariablesManagerInternal
     {
         [Dependency] private readonly IClientNetManager _netManager;
+        [Dependency] private readonly IResourceCache _resourceCache;
+        [Dependency] private readonly IEntityManager _entityManager;
 
         private uint _nextReqId = 1;
 
@@ -39,8 +37,6 @@ namespace SS14.Client.ViewVariables
 
         private readonly Dictionary<uint, TaskCompletionSource<ViewVariablesBlob>> _requestedData
             = new Dictionary<uint, TaskCompletionSource<ViewVariablesBlob>>();
-
-        private readonly Dictionary<Type, HashSet<object>> _cachedTraits = new Dictionary<Type, HashSet<object>>();
 
         public void Initialize()
         {
@@ -184,11 +180,11 @@ namespace SS14.Client.ViewVariables
             ViewVariablesInstance instance;
             if (obj is IEntity entity && !entity.Deleted)
             {
-                instance = new ViewVariablesInstanceEntity(this);
+                instance = new ViewVariablesInstanceEntity(this, _resourceCache, _entityManager);
             }
             else
             {
-                instance = new ViewVariablesInstanceObject(this);
+                instance = new ViewVariablesInstanceObject(this, _resourceCache);
             }
 
             var window = new SS14Window("VV") {Title = "View Variables"};
@@ -225,11 +221,11 @@ namespace SS14.Client.ViewVariables
             ViewVariablesInstance instance;
             if (type != null && typeof(IEntity).IsAssignableFrom(type))
             {
-                instance = new ViewVariablesInstanceEntity(this);
+                instance = new ViewVariablesInstanceEntity(this, _resourceCache, _entityManager);
             }
             else
             {
-                instance = new ViewVariablesInstanceObject(this);
+                instance = new ViewVariablesInstanceObject(this, _resourceCache);
             }
 
             loadingLabel.Dispose();

--- a/SS14.Client/ViewVariables/ViewVariablesPropertyControl.cs
+++ b/SS14.Client/ViewVariables/ViewVariablesPropertyControl.cs
@@ -28,12 +28,12 @@ namespace SS14.Client.ViewVariables
         {
             _viewVariablesManager = viewVars;
             _resourceCache = resourceCache;
+
+            PerformLayout();
         }
 
-        protected override void Initialize()
+        private void PerformLayout()
         {
-            base.Initialize();
-
             MouseFilter = MouseFilterMode.Stop;
             ToolTip = "Click to expand";
             CustomMinimumSize = new Vector2(0, 25);

--- a/SS14.Client/ViewVariables/ViewVariablesPropertyControl.cs
+++ b/SS14.Client/ViewVariables/ViewVariablesPropertyControl.cs
@@ -1,6 +1,4 @@
-using System;
-using System.Net.Http.Headers;
-using System.Reflection;
+﻿using System;
 using SS14.Client.Graphics;
 using SS14.Client.Graphics.Drawing;
 using SS14.Client.Interfaces.ResourceManagement;
@@ -8,8 +6,6 @@ using SS14.Client.ResourceManagement;
 using SS14.Client.UserInterface;
 using SS14.Client.UserInterface.Controls;
 using SS14.Client.ViewVariables.Editors;
-using SS14.Shared.Interfaces.Reflection;
-using SS14.Shared.IoC;
 using SS14.Shared.Maths;
 using SS14.Shared.Utility;
 using SS14.Shared.ViewVariables;
@@ -25,13 +21,18 @@ namespace SS14.Client.ViewVariables
 
         private Label _bottomLabel;
 
-        [Dependency] private IViewVariablesManagerInternal _viewVariablesManager;
+        private readonly IViewVariablesManagerInternal _viewVariablesManager;
+        private readonly IResourceCache _resourceCache;
+
+        public ViewVariablesPropertyControl(IViewVariablesManagerInternal viewVars, IResourceCache resourceCache)
+        {
+            _viewVariablesManager = viewVars;
+            _resourceCache = resourceCache;
+        }
 
         protected override void Initialize()
         {
             base.Initialize();
-
-            IoCManager.InjectDependencies(this);
 
             MouseFilter = MouseFilterMode.Stop;
             ToolTip = "Click to expand";
@@ -49,8 +50,7 @@ namespace SS14.Client.ViewVariables
             };
             VBox.AddChild(BottomContainer);
 
-            var resc = IoCManager.Resolve<IResourceCache>();
-            var smallFont = new VectorFont(resc.GetResource<FontResource>("/Fonts/CALIBRI.TTF"), 10);
+            var smallFont = new VectorFont(_resourceCache.GetResource<FontResource>("/Fonts/CALIBRI.TTF"), 10);
 
             _bottomLabel = new Label
             {

--- a/SS14.Server/GameObjects/Components/Collidable/CollidableComponent.cs
+++ b/SS14.Server/GameObjects/Components/Collidable/CollidableComponent.cs
@@ -15,12 +15,12 @@ namespace SS14.Server.GameObjects
 {
     public class CollidableComponent : Component, ICollidableComponent
     {
+        [Dependency] private readonly IPhysicsManager _physicsManager;
+
         private bool _collisionEnabled;
         private bool _isHardCollidable;
         private int _collisionLayer; //bitfield
         private int _collisionMask; //bitfield
-
-        private IPhysicsManager _physicsManager => IoCManager.Resolve<IPhysicsManager>();
 
         /// <inheritdoc />
         public override string Name => "Collidable";
@@ -126,15 +126,13 @@ namespace SS14.Server.GameObjects
         {
             base.Startup();
 
-            var cm = _physicsManager;
-            cm.AddCollidable(this);
+            _physicsManager.AddCollidable(this);
         }
 
         /// <inheritdoc />
         public override void Shutdown()
         {
-            var cm = _physicsManager;
-            cm.RemoveCollidable(this);
+            _physicsManager.RemoveCollidable(this);
 
             base.Shutdown();
         }

--- a/SS14.Server/GameObjects/Components/Container/Container.cs
+++ b/SS14.Server/GameObjects/Components/Container/Container.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using SS14.Shared.Interfaces.GameObjects;
 using SS14.Server.Interfaces.GameObjects;
-using SS14.Shared.Interfaces.GameObjects.Components;
-using SS14.Shared.IoC;
 using SS14.Shared.ViewVariables;
 
 namespace SS14.Server.GameObjects.Components.Container

--- a/SS14.Server/GameObjects/Components/Container/ContainerManagerComponent.cs
+++ b/SS14.Server/GameObjects/Components/Container/ContainerManagerComponent.cs
@@ -16,8 +16,9 @@ namespace SS14.Server.GameObjects.Components.Container
     {
         public override string Name => "ContainerContainer";
 
-        private readonly Dictionary<string, IContainer> EntityContainers = new Dictionary<string, IContainer>();
+        [Dependency] private readonly IReflectionManager _reflectionManager;
 
+        private readonly Dictionary<string, IContainer> EntityContainers = new Dictionary<string, IContainer>();
         private Dictionary<string, List<EntityUid>> _entitiesWaitingResolve;
 
         /// <summary>
@@ -140,10 +141,9 @@ namespace SS14.Server.GameObjects.Components.Container
                 if (serializer.TryReadDataField<Dictionary<string, ContainerPrototypeData>>("containers", out var data))
                 {
                     _entitiesWaitingResolve = new Dictionary<string, List<EntityUid>>();
-                    var reflectionManager = IoCManager.Resolve<IReflectionManager>();
                     foreach (var (key, datum) in data)
                     {
-                        var type = reflectionManager.LooseGetType(datum.Type);
+                        var type = _reflectionManager.LooseGetType(datum.Type);
                         MakeContainer(key, type);
 
                         if (datum.Entities.Count == 0)

--- a/SS14.Server/GameObjects/Components/Physics/PhysicsComponent.cs
+++ b/SS14.Server/GameObjects/Components/Physics/PhysicsComponent.cs
@@ -1,10 +1,8 @@
-﻿using System.Linq;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using SS14.Shared.GameObjects;
 using SS14.Shared.Interfaces.GameObjects;
 using SS14.Shared.Interfaces.Network;
 using SS14.Shared.Interfaces.Physics;
-using SS14.Shared.IoC;
 using SS14.Shared.Log;
 using SS14.Shared.Maths;
 using SS14.Shared.Serialization;
@@ -81,8 +79,6 @@ namespace SS14.Server.GameObjects
                 _anchored = value;
             }
         }
-
-        private IPhysicsManager _physicsManager => IoCManager.Resolve<IPhysicsManager>();
 
         /// <inheritdoc />
         public override void Initialize()

--- a/SS14.Server/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/SS14.Server/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using SS14.Server.Interfaces.GameObjects;
 using SS14.Shared.GameObjects;
 using SS14.Shared.GameObjects.Components.Renderable;
@@ -9,7 +8,6 @@ using SS14.Shared.Maths;
 using SS14.Shared.Serialization;
 using SS14.Shared.Utility;
 using SS14.Shared.ViewVariables;
-using YamlDotNet.RepresentationModel;
 
 namespace SS14.Server.GameObjects
 {

--- a/SS14.Server/GameObjects/Components/UserInterface/ServerUserInterfaceComponent.cs
+++ b/SS14.Server/GameObjects/Components/UserInterface/ServerUserInterfaceComponent.cs
@@ -19,9 +19,11 @@ namespace SS14.Server.GameObjects.Components.UserInterface
     /// <seealso cref="BoundUserInterface"/>
     public sealed class ServerUserInterfaceComponent : SharedUserInterfaceComponent
     {
+        [Dependency] private readonly IPlayerManager _playerManager;
+
         private readonly Dictionary<object, BoundUserInterface> _interfaces =
             new Dictionary<object, BoundUserInterface>();
-
+        
         /// <summary>
         ///     Enumeration of all the interfaces this component provides.
         /// </summary>
@@ -76,7 +78,7 @@ namespace SS14.Server.GameObjects.Components.UserInterface
                         throw new ArgumentNullException(nameof(netChannel));
                     }
 
-                    var session = IoCManager.Resolve<IPlayerManager>().GetSessionById(netChannel.SessionId);
+                    var session = _playerManager.GetSessionById(netChannel.SessionId);
                     if (!_interfaces.TryGetValue(wrapped.UiKey, out var @interface))
                     {
                         Logger.DebugS("go.comp.ui", "Got BoundInterfaceMessageWrapMessage for unknown UI key: {0}",

--- a/SS14.Server/GameObjects/EntitySystems/AudioSystem.cs
+++ b/SS14.Server/GameObjects/EntitySystems/AudioSystem.cs
@@ -12,6 +12,7 @@ namespace SS14.Server.GameObjects.EntitySystems
         ///     Play an audio file globally, without position.
         /// </summary>
         /// <param name="filename">The resource path to the OGG Vorbis file to play.</param>
+        /// <param name="audioParams"></param>
         public void Play(string filename, AudioParams? audioParams = null)
         {
             var msg = new PlayAudioGlobalMessage
@@ -27,6 +28,7 @@ namespace SS14.Server.GameObjects.EntitySystems
         /// </summary>
         /// <param name="filename">The resource path to the OGG Vorbis file to play.</param>
         /// <param name="entity">The entity "emitting" the audio.</param>
+        /// <param name="audioParams"></param>
         public void Play(string filename, IEntity entity, AudioParams? audioParams = null)
         {
             var msg = new PlayAudioEntityMessage
@@ -43,6 +45,7 @@ namespace SS14.Server.GameObjects.EntitySystems
         /// </summary>
         /// <param name="filename">The resource path to the OGG Vorbis file to play.</param>
         /// <param name="coordinates">The coordinates at which to play the audio.</param>
+        /// <param name="audioParams"></param>
         public void Play(string filename, GridCoordinates coordinates, AudioParams? audioParams = null)
         {
             var msg = new PlayAudioPositionalMessage

--- a/SS14.Server/GameObjects/EntitySystems/EffectSystem.cs
+++ b/SS14.Server/GameObjects/EntitySystems/EffectSystem.cs
@@ -1,10 +1,8 @@
 ﻿using DataStructures;
-using SS14.Shared.GameObjects;
 using SS14.Shared.GameObjects.EntitySystemMessages;
 using SS14.Shared.GameObjects.Systems;
 using SS14.Shared.Interfaces.Timing;
 using SS14.Shared.IoC;
-using System;
 using System.Collections.Generic;
 
 namespace SS14.Server.GameObjects.EntitySystems
@@ -14,6 +12,8 @@ namespace SS14.Server.GameObjects.EntitySystems
     /// </summary>
     public class EffectSystem : EntitySystem
     {
+        [Dependency] private readonly IGameTiming _timing;
+
         /// <summary>
         /// Priority queue sorted by how soon the effect will die, we remove messages from the front of the queue during update until caught up
         /// </summary>
@@ -30,10 +30,8 @@ namespace SS14.Server.GameObjects.EntitySystems
 
         public override void Update(float frameTime)
         {
-            var gametime = IoCManager.Resolve<IGameTiming>().CurTime;
-
             //Take elements from front of priority queue until they are old
-            while (_CurrentEffects.Count != 0 && _CurrentEffects.Peek().DeathTime < gametime)
+            while (_CurrentEffects.Count != 0 && _CurrentEffects.Peek().DeathTime < _timing.CurTime)
             {
                 _CurrentEffects.Take();
             }

--- a/SS14.Server/GameObjects/EntitySystems/InputSystem.cs
+++ b/SS14.Server/GameObjects/EntitySystems/InputSystem.cs
@@ -16,6 +16,8 @@ namespace SS14.Server.GameObjects.EntitySystems
     /// </summary>
     public class InputSystem : EntitySystem
     {
+        [Dependency] private readonly IPlayerManager _playerManager;
+
         private readonly Dictionary<IPlayerSession, IPlayerCommandStates> _playerInputs = new Dictionary<IPlayerSession, IPlayerCommandStates>();
         private readonly CommandBindMapping _bindMap = new CommandBindMapping();
 
@@ -33,13 +35,13 @@ namespace SS14.Server.GameObjects.EntitySystems
         /// <inheritdoc />
         public override void Initialize()
         {
-            IoCManager.Resolve<IPlayerManager>().PlayerStatusChanged += OnPlayerStatusChanged;
+            _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
         }
 
         /// <inheritdoc />
         public override void Shutdown()
         {
-            IoCManager.Resolve<IPlayerManager>().PlayerStatusChanged -= OnPlayerStatusChanged;
+            _playerManager.PlayerStatusChanged -= OnPlayerStatusChanged;
         }
 
         /// <inheritdoc />
@@ -49,10 +51,10 @@ namespace SS14.Server.GameObjects.EntitySystems
                 return;
 
             //Client Sanitization: out of bounds functionID
-            if (!IoCManager.Resolve<IPlayerManager>().KeyMap.TryGetKeyFunction(msg.InputFunctionId, out var function))
+            if (!_playerManager.KeyMap.TryGetKeyFunction(msg.InputFunctionId, out var function))
                 return;
 
-            var session = IoCManager.Resolve<IPlayerManager>().GetSessionByChannel(channel);
+            var session = _playerManager.GetSessionByChannel(channel);
 
             //Client Sanitization: bad enum key state value
             if (!Enum.IsDefined(typeof(BoundKeyState), msg.State))

--- a/SS14.Server/GameObjects/EntitySystems/PhysicsSystem.cs
+++ b/SS14.Server/GameObjects/EntitySystems/PhysicsSystem.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using SS14.Server.Interfaces.Timing;
 using SS14.Shared.GameObjects;
 using SS14.Shared.GameObjects.Systems;
@@ -13,21 +12,14 @@ namespace SS14.Server.GameObjects.EntitySystems
 {
     internal class PhysicsSystem : EntitySystem
     {
-        private IPauseManager _pauseManager;
-        private IPhysicsManager _physicsManager;
+        [Dependency] private readonly IPauseManager _pauseManager;
+        [Dependency] private readonly IPhysicsManager _physicsManager;
+
         private const float Epsilon = 1.0e-6f;
 
         public PhysicsSystem()
         {
             EntityQuery = new TypeEntityQuery(typeof(PhysicsComponent));
-        }
-
-        public override void Initialize()
-        {
-            base.Initialize();
-           
-            _pauseManager = IoCManager.Resolve<IPauseManager>();
-            _physicsManager = IoCManager.Resolve<IPhysicsManager>();
         }
 
         /// <inheritdoc />

--- a/SS14.Shared/GameObjects/ComponentFactory.cs
+++ b/SS14.Shared/GameObjects/ComponentFactory.cs
@@ -2,11 +2,14 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using SS14.Shared.IoC;
 
 namespace SS14.Shared.GameObjects
 {
     public class ComponentFactory : IComponentFactory
     {
+        [Dependency] private readonly IDynamicTypeFactory _typeFactory;
+
         private class ComponentRegistration : IComponentRegistration
         {
             public string Name { get; }
@@ -177,7 +180,7 @@ namespace SS14.Shared.GameObjects
             {
                 throw new InvalidOperationException($"{componentType} is not a registered component.");
             }
-            return (IComponent)Activator.CreateInstance(types[componentType].Type);
+            return (IComponent)_typeFactory.CreateInstance(types[componentType].Type);
         }
 
         public T GetComponent<T>() where T : IComponent, new()
@@ -186,12 +189,12 @@ namespace SS14.Shared.GameObjects
             {
                 throw new InvalidOperationException($"{typeof(T)} is not a registered component.");
             }
-            return (T)Activator.CreateInstance(types[typeof(T)].Type);
+            return (T)_typeFactory.CreateInstance(types[typeof(T)].Type);
         }
 
         public IComponent GetComponent(string componentName)
         {
-            return (IComponent)Activator.CreateInstance(GetRegistration(componentName).Type);
+            return (IComponent)_typeFactory.CreateInstance(GetRegistration(componentName).Type);
         }
 
         public IComponentRegistration GetRegistration(string componentName)

--- a/SS14.Shared/GameObjects/Components/Appearance/SharedAppearanceComponent.cs
+++ b/SS14.Shared/GameObjects/Components/Appearance/SharedAppearanceComponent.cs
@@ -1,9 +1,6 @@
 ﻿using SS14.Shared.Serialization;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SS14.Shared.GameObjects.Components.Appearance
 {

--- a/SS14.Shared/GameObjects/Components/BoundingBox/BoundingBoxComponent.cs
+++ b/SS14.Shared/GameObjects/Components/BoundingBox/BoundingBoxComponent.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using SS14.Shared.Interfaces.GameObjects.Components;
 using SS14.Shared.Maths;
 using SS14.Shared.Serialization;
 using SS14.Shared.ViewVariables;

--- a/SS14.Shared/GameObjects/Components/Transform/SnapGridComponent.cs
+++ b/SS14.Shared/GameObjects/Components/Transform/SnapGridComponent.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using SS14.Shared.Interfaces.GameObjects;
@@ -21,6 +21,7 @@ namespace SS14.Shared.GameObjects.Components.Transform
 
         private bool IsSet;
         private SnapGridOffset _offset = SnapGridOffset.Center;
+        [Dependency] private readonly IMapManager _mapManager;
 
         public event Action OnPositionChanged;
 
@@ -43,8 +44,7 @@ namespace SS14.Shared.GameObjects.Components.Transform
             Owner.Transform.OnMove -= OnTransformMove;
             if (IsSet)
             {
-                var mapMan = IoCManager.Resolve<IMapManager>();
-                if (!mapMan.TryGetGrid(Owner.Transform.GridID, out var grid))
+                if (!_mapManager.TryGetGrid(Owner.Transform.GridID, out var grid))
                 {
                     Logger.WarningS(LogCategory, "Entity {0} snapgrid didn't find grid {1}. Race condition?", Owner.Uid, Owner.Transform.GridID);
                     return;
@@ -69,8 +69,7 @@ namespace SS14.Shared.GameObjects.Components.Transform
         /// </summary>
         public IEnumerable<IEntity> GetInDir(Direction dir)
         {
-            var mapMan = IoCManager.Resolve<IMapManager>();
-            var grid = mapMan.GetGrid(Owner.Transform.GridID);
+            var grid = _mapManager.GetGrid(Owner.Transform.GridID);
             var pos = SnapGridPosAt(dir);
 
             return grid.GetSnapGridCell(pos, Offset).Select(s => s.Owner);
@@ -109,8 +108,7 @@ namespace SS14.Shared.GameObjects.Components.Transform
 
         private void UpdatePosition()
         {
-            var mapMan = IoCManager.Resolve<IMapManager>();
-            if (!mapMan.TryGetGrid(Owner.Transform.GridID, out var grid))
+            if (!_mapManager.TryGetGrid(Owner.Transform.GridID, out var grid))
             {
                 Logger.WarningS(LogCategory, "Entity {0} snapgrid didn't find grid {1}. Race condition?", Owner.Uid, Owner.Transform.GridID);
                 return;

--- a/SS14.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/SS14.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -27,6 +27,8 @@ namespace SS14.Shared.GameObjects.Components.Transform
         [ViewVariables]
         private readonly List<EntityUid> _children = new List<EntityUid>();
 
+        [Dependency] private readonly IMapManager _mapManager;
+
         /// <inheritdoc />
         public event EventHandler<MoveEventArgs> OnMove;
 
@@ -51,7 +53,7 @@ namespace SS14.Shared.GameObjects.Components.Transform
                 // Work around a client-side race condition of the grids not being synced yet.
                 // Maybe it's better to fix the race condition instead.
                 // Eh.
-                if (IoCManager.Resolve<IMapManager>().TryGetGrid(GridID, out var grid))
+                if (_mapManager.TryGetGrid(GridID, out var grid))
                 {
                     return grid.MapID;
                 }
@@ -220,7 +222,7 @@ namespace SS14.Shared.GameObjects.Components.Transform
                     // Work around a client-side race condition of the grids not being synced yet.
                     // Maybe it's better to fix the race condition instead.
                     // Eh.
-                    if (IoCManager.Resolve<IMapManager>().TryGetGrid(GridID, out var grid))
+                    if (_mapManager.TryGetGrid(GridID, out var grid))
                     {
                         return grid.ConvertToWorld(_position);
                     }
@@ -243,7 +245,7 @@ namespace SS14.Shared.GameObjects.Components.Transform
                 else
                 {
                     SetPosition(value);
-                    _recurseSetGridId(IoCManager.Resolve<IMapManager>().GetMap(MapID).FindGridAt(_position).Index);
+                    _recurseSetGridId(_mapManager.GetMap(MapID).FindGridAt(_position).Index);
                 }
 
                 Dirty();
@@ -482,7 +484,7 @@ namespace SS14.Shared.GameObjects.Components.Transform
             {
                 // transform localPosition from parent coords to world coords
                 var worldPos = Parent.WorldMatrix.Transform(localPosition);
-                var grid = IoCManager.Resolve<IMapManager>().GetGrid(gridId);
+                var grid = _mapManager.GetGrid(gridId);
                 var lc = new GridCoordinates(worldPos, grid.MapID);
 
                 // then to parent grid coords

--- a/SS14.Shared/GameObjects/Systems/EntitySystem.cs
+++ b/SS14.Shared/GameObjects/Systems/EntitySystem.cs
@@ -13,14 +13,17 @@ namespace SS14.Shared.GameObjects.Systems
     /// <summary>
     ///     A subsystem that acts on all components of a type at once.
     /// </summary>
+    /// <remarks>
+    ///     This class is instantiated by the <c>EntitySystemManager</c>, and any IoC Dependencies will be resolved.
+    /// </remarks>
     [Reflect(false)]
     public abstract class EntitySystem : IEntityEventSubscriber, IEntitySystem
     {
-        protected readonly IEntityManager EntityManager;
-        protected readonly IEntitySystemManager EntitySystemManager;
-        protected readonly IEntityNetworkManager EntityNetworkManager;
-        protected IEntityQuery EntityQuery;
+        [Dependency] protected readonly IEntityManager EntityManager;
+        [Dependency] protected readonly IEntitySystemManager EntitySystemManager;
+        [Dependency] protected readonly IEntityNetworkManager EntityNetworkManager;
 
+        protected IEntityQuery EntityQuery;
         protected IEnumerable<IEntity> RelevantEntities => EntityManager.GetEntities(EntityQuery);
 
         private readonly Dictionary<Type, (CancellationTokenRegistration, TaskCompletionSource<EntitySystemMessage>)>
@@ -29,9 +32,9 @@ namespace SS14.Shared.GameObjects.Systems
 
         protected EntitySystem()
         {
-            EntityManager = IoCManager.Resolve<IEntityManager>();
-            EntitySystemManager = IoCManager.Resolve<IEntitySystemManager>();
-            EntityNetworkManager = IoCManager.Resolve<IEntityNetworkManager>();
+            //EntityManager = IoCManager.Resolve<IEntityManager>();
+            //EntitySystemManager = IoCManager.Resolve<IEntitySystemManager>();
+            //EntityNetworkManager = IoCManager.Resolve<IEntityNetworkManager>();
         }
 
         public virtual void RegisterMessageTypes()

--- a/SS14.Shared/Interfaces/GameObjects/IComponent.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IComponent.cs
@@ -2,13 +2,13 @@
 using SS14.Shared.GameObjects;
 using SS14.Shared.Interfaces.Network;
 using SS14.Shared.Serialization;
-using YamlDotNet.RepresentationModel;
 
 namespace SS14.Shared.Interfaces.GameObjects
 {
     /// <remarks>
     ///     Base component for the ECS system.
     ///     All discoverable implementations of IComponent must override the <see cref="Name" />.
+    ///     Instances are dynamically instantiated by a <c>ComponentFactory</c>, and will have their IoC Dependencies resolved.
     /// </remarks>
     public interface IComponent : IEntityEventSubscriber
     {

--- a/SS14.UnitTesting/SS14UnitTest.cs
+++ b/SS14.UnitTesting/SS14UnitTest.cs
@@ -8,6 +8,7 @@ using SS14.Client.Debugging;
 using SS14.Client.GameObjects;
 using SS14.Client.GameStates;
 using SS14.Client.Graphics;
+using SS14.Client.Graphics.ClientEye;
 using SS14.Client.Graphics.Overlays;
 using SS14.Client.Input;
 using SS14.Client.Interfaces;
@@ -15,6 +16,7 @@ using SS14.Client.Interfaces.Debugging;
 using SS14.Client.Interfaces.GameObjects;
 using SS14.Client.Interfaces.GameStates;
 using SS14.Client.Interfaces.Graphics;
+using SS14.Client.Interfaces.Graphics.ClientEye;
 using SS14.Client.Interfaces.Graphics.Overlays;
 using SS14.Client.Interfaces.Input;
 using SS14.Client.Interfaces.ResourceManagement;
@@ -227,6 +229,7 @@ namespace SS14.UnitTesting
                     IoCManager.Register<IViewVariablesManager, ViewVariablesManager>();
                     IoCManager.Register<IClipboardManager, ClipboardManagerUnsupported>();
                     IoCManager.Register<IDiscordRichPresence, DiscordRichPresence>();
+                    IoCManager.Register<IEyeManager, EyeManager>();
                     break;
 
                 case UnitTestProject.Server:
@@ -254,6 +257,7 @@ namespace SS14.UnitTesting
                     IoCManager.Register<IConGroupController, ConGroupController>();
                     IoCManager.Register<IStatusHost, StatusHost>();
                     IoCManager.Register<IPauseManager, PauseManager>();
+                    IoCManager.Register<IServerEntityManagerInternal, ServerEntityManager>();
                     break;
 
                 default:

--- a/SS14.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
+++ b/SS14.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
@@ -16,6 +16,8 @@ namespace SS14.UnitTesting.Server.GameObjects.Components
     [TestOf(typeof(TransformComponent))]
     class Transform_Test : SS14UnitTest
     {
+        public override UnitTestProject Project => UnitTestProject.Server;
+
         private IServerEntityManager EntityManager;
         private IMapManager MapManager;
 


### PR DESCRIPTION
This PR focuses on removing the static `IoCManager.InjectDependencies(this)` calls from all engine code. Along the way, any files touched also had any static `IoCManager.Resolve()` calls removed. Some of the UI classes have a lot of dependencies injected into their constructors now, which we may want to address at a later time. Redesigning the entire thing to actually enforce SRP and remove the logic-in-constructor anti-pattern in UI controls was outside the scope of this PR.

`States` (game scenes like main menu), `Components`, and `EntitySystems` now have dependencies injected into them from the DI container. There is no reason to use any static IoC calls in these classes, or any of their child objects.