### PR TITLE
Entity Interpolation

### DIFF
--- a/SS14.Client/BaseClient.cs
+++ b/SS14.Client/BaseClient.cs
@@ -191,6 +191,7 @@ namespace SS14.Client
         private void OnLocalStatusChanged(object obj, StatusEventArgs eventArgs)
         {
             // player finished fully connecting to the server.
+            // OldStatus is used here because it can go from connecting-> connected or connecting-> ingame
             if (eventArgs.OldStatus == SessionStatus.Connecting)
             {
                 OnPlayerJoinedServer(_playMan.LocalPlayer.Session);
@@ -206,7 +207,7 @@ namespace SS14.Client
 
         private void OnRunLevelChanged(ClientRunLevel newRunLevel)
         {
-            Logger.Debug($"[ENG] Runlevel changed to: {newRunLevel}");
+            Logger.DebugS("client", $"Runlevel changed to: {newRunLevel}");
             var args = new RunLevelChangedEventArgs(RunLevel, newRunLevel);
             RunLevel = newRunLevel;
             RunLevelChanged?.Invoke(this, args);
@@ -219,9 +220,25 @@ namespace SS14.Client
     public enum ClientRunLevel
     {
         Error = 0,
+
+        /// <summary>
+        ///     The client has not started connecting to a server (on main menu).
+        /// </summary>
         Initialize,
+
+        /// <summary>
+        ///     The client started connecting to the server, and is in the process of building the session.
+        /// </summary>
         Connecting,
+
+        /// <summary>
+        ///     The client has successfully finished connecting to the server.
+        /// </summary>
         Connected,
+
+        /// <summary>
+        ///     The client is now in the game, moving around.
+        /// </summary>
         InGame,
     }
 

--- a/SS14.Client/BaseClient.cs
+++ b/SS14.Client/BaseClient.cs
@@ -9,6 +9,7 @@ using SS14.Shared.Enums;
 using SS14.Shared.Interfaces.Configuration;
 using SS14.Shared.Interfaces.Map;
 using SS14.Shared.Interfaces.Network;
+using SS14.Shared.Interfaces.Timing;
 using SS14.Shared.IoC;
 using SS14.Shared.Log;
 using SS14.Shared.Network;
@@ -33,10 +34,17 @@ namespace SS14.Client
         [Dependency]
         private readonly IConfigurationManager _configManager;
 
-        [Dependency] private readonly IClientEntityManager _entityManager;
+        [Dependency]
+        private readonly IClientEntityManager _entityManager;
 
-        [Dependency] private readonly IMapManager _mapManager;
-        [Dependency] private readonly IDiscordRichPresence _discord;
+        [Dependency]
+        private readonly IMapManager _mapManager;
+
+        [Dependency]
+        private readonly IDiscordRichPresence _discord;
+
+        [Dependency]
+        private readonly IGameTiming _timing;
 
         /// <inheritdoc />
         public ushort DefaultPort { get; } = 1212;
@@ -167,6 +175,9 @@ namespace SS14.Client
             info.ServerName = msg.ServerName;
             info.ServerMaxPlayers = msg.ServerMaxPlayers;
             info.SessionId = msg.PlayerSessionId;
+            info.TickRate = msg.TickRate;
+            _timing.TickRate = msg.TickRate;
+            Logger.InfoS("client", $"Tickrate changed to: {msg.TickRate}");
 
             _discord.Update(info.ServerName, info.SessionId.Username, info.ServerMaxPlayers.ToString());
             // start up player management
@@ -272,6 +283,8 @@ namespace SS14.Client
         ///     Max number of players that are allowed in the server at one time.
         /// </summary>
         public int ServerMaxPlayers { get; set; }
+
+        public byte TickRate { get; internal set; }
 
         public NetSessionId SessionId { get; set; }
     }

--- a/SS14.Client/BaseClient.cs
+++ b/SS14.Client/BaseClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using SS14.Client.Interfaces;
 using SS14.Client.Interfaces.GameObjects;
+using SS14.Client.Interfaces.GameStates;
 using SS14.Client.Interfaces.State;
 using SS14.Client.Interfaces.Utility;
 using SS14.Client.Player;
@@ -45,6 +46,9 @@ namespace SS14.Client
 
         [Dependency]
         private readonly IGameTiming _timing;
+
+        [Dependency]
+        private readonly IClientGameStateManager _gameStates;
 
         /// <inheritdoc />
         public ushort DefaultPort { get; } = 1212;
@@ -159,6 +163,8 @@ namespace SS14.Client
 
             _stateManager.RequestStateChange<MainScreen>();
 
+            _timing.Paused = true;
+            _gameStates.Shutdown();
             _playMan.Shutdown();
             _entityManager.Shutdown();
             _mapManager.Shutdown();

--- a/SS14.Client/GameController.cs
+++ b/SS14.Client/GameController.cs
@@ -219,6 +219,12 @@ namespace SS14.Client
             _taskManager.ProcessPendingTasks();
             _userInterfaceManager.Update(eventArgs);
             _stateManager.Update(eventArgs);
+
+            if (_client.RunLevel >= ClientRunLevel.Connected)
+            {
+                _gameStateManager.ApplyGameState();
+            }
+
             AssemblyLoader.BroadcastUpdate(AssemblyLoader.UpdateLevel.PostEngine, eventArgs.Elapsed);
         }
 

--- a/SS14.Client/GameController/GameController.Godot.cs
+++ b/SS14.Client/GameController/GameController.Godot.cs
@@ -211,6 +211,7 @@ namespace SS14.Client
 
             public TimeSpan TickRemainder { get; set; }
             public uint CurFrame { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public bool FastForward { get; set; } //TODO: Not implemented
 
             public void ResetRealTime()
             {

--- a/SS14.Client/GameController/GameController.Godot.cs
+++ b/SS14.Client/GameController/GameController.Godot.cs
@@ -212,6 +212,7 @@ namespace SS14.Client
             public TimeSpan TickRemainder { get; set; }
             public uint CurFrame { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
             public bool FastForward { get; set; } //TODO: Not implemented
+            public float TickTimingAdjustment { get; set; } = 1; //TODO: Not implemented
 
             public void ResetRealTime()
             {

--- a/SS14.Client/GameController/GameController.Godot.cs
+++ b/SS14.Client/GameController/GameController.Godot.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using Godot;
 using SS14.Client.GodotGlue;
 using SS14.Client.Input;
 using SS14.Client.Interfaces;
 using SS14.Client.Utility;
-using SS14.Shared.ContentPack;
 using SS14.Shared.Interfaces.Timing;
 using SS14.Shared.IoC;
 using SS14.Shared.Timing;
@@ -51,7 +49,7 @@ namespace SS14.Client
             {
                 if (!_gameTimingGodotGodot.Paused)
                 {
-                    _gameTimingGodotGodot.CurTick++;
+                    _gameTimingGodotGodot.CurTick = new GameTick(_gameTimingGodotGodot.CurTick.Value + 1);
                     Update(delta);
                 }
             }
@@ -201,7 +199,7 @@ namespace SS14.Client
 
             public double FramesPerSecondAvg => Godot.Performance.GetMonitor(Performance.Monitor.TimeFps);
 
-            public uint CurTick { get; set; }
+            public GameTick CurTick { get; set; }
             public int TickRate
             {
                 get => Godot.Engine.IterationsPerSecond;
@@ -226,7 +224,7 @@ namespace SS14.Client
             private TimeSpan CalcCurTime()
             {
                 // calculate simulation CurTime
-                var time = TimeSpan.FromTicks(TickPeriod.Ticks * CurTick);
+                var time = TimeSpan.FromTicks(TickPeriod.Ticks * CurTick.Value);
 
                 if (!InSimulation) // rendering can draw frames between ticks
                     return time + TickRemainder;

--- a/SS14.Client/GameController/GameController.Godot.cs
+++ b/SS14.Client/GameController/GameController.Godot.cs
@@ -200,9 +200,10 @@ namespace SS14.Client
             public double FramesPerSecondAvg => Godot.Performance.GetMonitor(Performance.Monitor.TimeFps);
 
             public GameTick CurTick { get; set; }
-            public int TickRate
+
+            public byte TickRate
             {
-                get => Godot.Engine.IterationsPerSecond;
+                get => (byte) Godot.Engine.IterationsPerSecond;
                 set => Godot.Engine.IterationsPerSecond = value;
             }
 

--- a/SS14.Client/GameObjects/ClientEntityManager.cs
+++ b/SS14.Client/GameObjects/ClientEntityManager.cs
@@ -111,31 +111,32 @@ namespace SS14.Client.GameObjects
             Started = true;
         }
 
-        public void ApplyEntityStates(IEnumerable<EntityState> entityStates, IEnumerable<EntityUid> deletions)
+        public void ApplyEntityStates(IEnumerable<EntityState> curEntStates, IEnumerable<EntityUid> deletions, List<EntityState> nextEntStates)
         {
-            var toApply = new List<(Entity, EntityState)>();
+            var toApply = new List<(Entity, EntityState, EntityState)>();
             var toInitialize = new List<Entity>();
-            foreach (var es in entityStates)
+            foreach (var es in curEntStates)
             {
+                var nextState = nextEntStates?.Find(s => s.StateData.Uid == es.StateData.Uid);
                 //Todo defer component state result processing until all entities are loaded and initialized...
                 //Known entities
                 if (Entities.TryGetValue(es.StateData.Uid, out var entity))
                 {
-                    toApply.Add(((Entity)entity, es));
+                    toApply.Add(((Entity)entity, es, nextState));
                 }
                 else //Unknown entities
                 {
                     var newEntity = CreateEntity(es.StateData.TemplateName, es.StateData.Uid);
                     newEntity.Name = es.StateData.Name;
-                    toApply.Add((newEntity, es));
+                    toApply.Add((newEntity, es, nextState));
                     toInitialize.Add(newEntity);
                 }
             }
 
             // Make sure this is done after all entities have been instantiated.
-            foreach (var (entity, es) in toApply)
+            foreach (var (entity, es, nextState) in toApply)
             {
-                entity.HandleEntityState(es);
+                entity.HandleEntityState(es, nextState);
             }
 
             foreach (var id in deletions)

--- a/SS14.Client/GameObjects/ClientEntityManager.cs
+++ b/SS14.Client/GameObjects/ClientEntityManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using SS14.Client.Interfaces.GameObjects;
 using SS14.Shared.GameObjects;
@@ -115,6 +116,7 @@ namespace SS14.Client.GameObjects
         {
             var toApply = new Dictionary<IEntity, (EntityState, EntityState)>();
             var toInitialize = new List<Entity>();
+            deletions = deletions ?? new EntityUid[0];
 
             if (curEntStates != null && curEntStates.Count != 0)
             {

--- a/SS14.Client/GameObjects/ClientEntityManager.cs
+++ b/SS14.Client/GameObjects/ClientEntityManager.cs
@@ -111,14 +111,13 @@ namespace SS14.Client.GameObjects
             Started = true;
         }
 
-        public void ApplyEntityStates(IEnumerable<EntityState> entityStates, IEnumerable<EntityUid> deletions, float serverTime)
+        public void ApplyEntityStates(IEnumerable<EntityState> entityStates, IEnumerable<EntityUid> deletions)
         {
             var toApply = new List<(Entity, EntityState)>();
             var toInitialize = new List<Entity>();
             foreach (var es in entityStates)
             {
                 //Todo defer component state result processing until all entities are loaded and initialized...
-                es.ReceivedTime = serverTime;
                 //Known entities
                 if (Entities.TryGetValue(es.StateData.Uid, out var entity))
                 {

--- a/SS14.Client/GameObjects/Components/Appearance/AppearanceComponent.cs
+++ b/SS14.Client/GameObjects/Components/Appearance/AppearanceComponent.cs
@@ -77,9 +77,9 @@ namespace SS14.Client.GameObjects
             AppearanceDirty = true;
         }
 
-        public override void HandleComponentState(ComponentState state)
+        public override void HandleComponentState(ComponentState curState, ComponentState nextState)
         {
-            var actualState = (AppearanceComponentState)state;
+            var actualState = (AppearanceComponentState)curState;
             data = actualState.Data;
             AppearanceDirty = true;
         }

--- a/SS14.Client/GameObjects/Components/Appearance/AppearanceComponent.cs
+++ b/SS14.Client/GameObjects/Components/Appearance/AppearanceComponent.cs
@@ -79,6 +79,9 @@ namespace SS14.Client.GameObjects
 
         public override void HandleComponentState(ComponentState curState, ComponentState nextState)
         {
+            if (curState == null)
+                return;
+
             var actualState = (AppearanceComponentState)curState;
             data = actualState.Data;
             AppearanceDirty = true;

--- a/SS14.Client/GameObjects/Components/Collidable/CollidableComponent.cs
+++ b/SS14.Client/GameObjects/Components/Collidable/CollidableComponent.cs
@@ -115,6 +115,9 @@ namespace SS14.Client.GameObjects
         /// <inheritdoc />
         public override void HandleComponentState(ComponentState curState, ComponentState nextState)
         {
+            if (curState == null)
+                return;
+
             var newState = (CollidableComponentState) curState;
 
             // edge triggered

--- a/SS14.Client/GameObjects/Components/Collidable/CollidableComponent.cs
+++ b/SS14.Client/GameObjects/Components/Collidable/CollidableComponent.cs
@@ -113,9 +113,9 @@ namespace SS14.Client.GameObjects
         }
 
         /// <inheritdoc />
-        public override void HandleComponentState(ComponentState state)
+        public override void HandleComponentState(ComponentState curState, ComponentState nextState)
         {
-            var newState = (CollidableComponentState) state;
+            var newState = (CollidableComponentState) curState;
 
             // edge triggered
             if (newState.CollisionEnabled == _collisionEnabled)

--- a/SS14.Client/GameObjects/Components/Light/PointLightComponent.cs
+++ b/SS14.Client/GameObjects/Components/Light/PointLightComponent.cs
@@ -204,6 +204,9 @@ namespace SS14.Client.GameObjects
         /// <inheritdoc />
         public override void HandleComponentState(ComponentState curState, ComponentState nextState)
         {
+            if (curState == null)
+                return;
+
             var newState = (PointLightComponentState) curState;
             State = newState.State;
             Color = newState.Color;

--- a/SS14.Client/GameObjects/Components/Light/PointLightComponent.cs
+++ b/SS14.Client/GameObjects/Components/Light/PointLightComponent.cs
@@ -1,22 +1,14 @@
 ﻿using System;
-using System.Runtime.Remoting.Messaging;
-using SS14.Client.Graphics.Lighting;
-using SS14.Client.Interfaces.GameObjects.Components;
 using SS14.Client.Interfaces.Graphics.Lighting;
 using SS14.Client.Interfaces.ResourceManagement;
 using SS14.Client.ResourceManagement;
-using SS14.Shared;
 using SS14.Shared.Enums;
 using SS14.Shared.GameObjects;
 using SS14.Shared.Interfaces.GameObjects.Components;
 using SS14.Shared.IoC;
-using SS14.Shared.Log;
-using SS14.Shared.Map;
 using SS14.Shared.Maths;
 using SS14.Shared.Utility;
 using SS14.Shared.ViewVariables;
-using YamlDotNet.RepresentationModel;
-using YamlDotNet.Serialization;
 using ObjectSerializer = SS14.Shared.Serialization.ObjectSerializer;
 
 namespace SS14.Client.GameObjects
@@ -210,9 +202,9 @@ namespace SS14.Client.GameObjects
         }
 
         /// <inheritdoc />
-        public override void HandleComponentState(ComponentState state)
+        public override void HandleComponentState(ComponentState curState, ComponentState nextState)
         {
-            var newState = (PointLightComponentState) state;
+            var newState = (PointLightComponentState) curState;
             State = newState.State;
             Color = newState.Color;
             Light.ModeClass = newState.Mode;

--- a/SS14.Client/GameObjects/Components/Physics/PhysicsComponent.cs
+++ b/SS14.Client/GameObjects/Components/Physics/PhysicsComponent.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using SS14.Shared.GameObjects;
-using SS14.Shared.Interfaces.GameObjects;
 using SS14.Shared.Log;
 using SS14.Shared.Maths;
 using SS14.Shared.ViewVariables;
@@ -46,9 +45,9 @@ namespace SS14.Client.GameObjects
         }
 
         /// <inheritdoc />
-        public override void HandleComponentState(ComponentState state)
+        public override void HandleComponentState(ComponentState curState, ComponentState nextState)
         {
-            var newState = (PhysicsComponentState)state;
+            var newState = (PhysicsComponentState)curState;
             Mass = newState.Mass;
             Velocity = newState.Velocity;
         }

--- a/SS14.Client/GameObjects/Components/Physics/PhysicsComponent.cs
+++ b/SS14.Client/GameObjects/Components/Physics/PhysicsComponent.cs
@@ -47,6 +47,9 @@ namespace SS14.Client.GameObjects
         /// <inheritdoc />
         public override void HandleComponentState(ComponentState curState, ComponentState nextState)
         {
+            if (curState == null)
+                return;
+
             var newState = (PhysicsComponentState)curState;
             Mass = newState.Mass;
             Velocity = newState.Velocity;

--- a/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -10,7 +10,6 @@ using SS14.Client.Utility;
 using SS14.Shared.GameObjects;
 using SS14.Shared.GameObjects.Components.Renderable;
 using SS14.Shared.Interfaces.GameObjects;
-using SS14.Shared.Interfaces.Serialization;
 using SS14.Shared.IoC;
 using SS14.Shared.Log;
 using SS14.Shared.Maths;
@@ -23,7 +22,6 @@ using System.Linq;
 using System.Text;
 using SS14.Shared.Interfaces.Reflection;
 using SS14.Shared.ViewVariables;
-using YamlDotNet.RepresentationModel;
 using VS = Godot.VisualServer;
 
 namespace SS14.Client.GameObjects
@@ -1573,9 +1571,9 @@ namespace SS14.Client.GameObjects
             }
         }
 
-        public override void HandleComponentState(ComponentState state)
+        public override void HandleComponentState(ComponentState curState, ComponentState nextState)
         {
-            var thestate = (SpriteComponentState) state;
+            var thestate = (SpriteComponentState) curState;
 
             Visible = thestate.Visible;
             DrawDepth = thestate.DrawDepth;

--- a/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1573,6 +1573,9 @@ namespace SS14.Client.GameObjects
 
         public override void HandleComponentState(ComponentState curState, ComponentState nextState)
         {
+            if (curState == null)
+                return;
+
             var thestate = (SpriteComponentState) curState;
 
             Visible = thestate.Visible;

--- a/SS14.Client/GameStates/ClientGameStateManager.cs
+++ b/SS14.Client/GameStates/ClientGameStateManager.cs
@@ -129,6 +129,14 @@ namespace SS14.Client.GameStates
             else if (_stateBuffer.Count <= 3 + ratio) // absolute minimum is 3 states in buffer for the system to work (last, cur, next)
             {
                 _timing.FastForward = false;
+
+                if (!_waitingForFull && _stateBuffer.Count < 3 + ratio)
+                {
+                    // TODO: This is really bad, it causes the view and player to jerk back every so often. Come up with a better solution.
+                    // we are ahead of the target buffer size, delay a tick by replaying the last one
+                    // hopefully a new state will get processed soon!
+                    _timing.CurTick = new GameTick(_timing.CurTick.Value - 1);
+                }
             }
         }
 

--- a/SS14.Client/GameStates/ClientGameStateManager.cs
+++ b/SS14.Client/GameStates/ClientGameStateManager.cs
@@ -38,6 +38,7 @@ namespace SS14.Client.GameStates
         [Dependency]
         private readonly IConfigurationManager _config;
 
+        /// <inheritdoc />
         public void Initialize()
         {
             _network.RegisterNetMessage<MsgState>(MsgState.NAME, HandleStateMessage);
@@ -46,6 +47,14 @@ namespace SS14.Client.GameStates
 
             if(!_config.IsCVarRegistered("net.state_buffer"))
                 _config.RegisterCVar("net.state_buffer", 1, CVar.ARCHIVE);
+        }
+
+        /// <inheritdoc />
+        public void Shutdown()
+        {
+            _stateBuffer.Clear();
+            _lastFullState = null;
+            _waitingForFull = true;
         }
 
         private void RunLevelChanged(object sender, RunLevelChangedEventArgs args)

--- a/SS14.Client/GameStates/ClientGameStateManager.cs
+++ b/SS14.Client/GameStates/ClientGameStateManager.cs
@@ -1,4 +1,5 @@
-﻿using SS14.Client.Interfaces;
+﻿using System.Collections.Generic;
+using SS14.Client.Interfaces;
 using SS14.Client.Interfaces.GameObjects;
 using SS14.Client.Interfaces.GameStates;
 using SS14.Shared.GameStates;
@@ -7,74 +8,218 @@ using SS14.Shared.IoC;
 using SS14.Shared.Log;
 using SS14.Shared.Network.Messages;
 using SS14.Client.Player;
+using SS14.Shared.GameObjects;
 using SS14.Shared.Interfaces.Map;
+using SS14.Shared.Interfaces.Timing;
 using SS14.Shared.Timing;
+using SS14.Shared.Utility;
 
 namespace SS14.Client.GameStates
 {
     public class ClientGameStateManager : IClientGameStateManager
     {
-        private GameTick GameSequence;
-
+        private readonly List<GameState> _stateBuffer = new List<GameState>();
+        private GameState _lastFullState;
+        private bool _waitingForFull = true;
+        
         [Dependency]
-        private readonly IClientNetManager networkManager;
+        private readonly IClientEntityManager _entities;
         [Dependency]
-        private readonly IClientEntityManager entityManager;
+        private readonly IPlayerManager _players;
         [Dependency]
-        private readonly IPlayerManager playerManager;
+        private readonly IClientNetManager _network;
         [Dependency]
-        private readonly IClientNetManager netManager;
-        [Dependency]
-        private readonly IBaseClient baseClient;
+        private readonly IBaseClient _client;
         [Dependency]
         private readonly IMapManager _mapManager;
+        [Dependency]
+        private readonly IGameTiming _timing;
 
         public void Initialize()
         {
-            netManager.RegisterNetMessage<MsgState>(MsgState.NAME, HandleStateMessage);
-            netManager.RegisterNetMessage<MsgStateAck>(MsgStateAck.NAME);
-            baseClient.RunLevelChanged += RunLevelChanged;
+            _network.RegisterNetMessage<MsgState>(MsgState.NAME, HandleStateMessage);
+            _network.RegisterNetMessage<MsgStateAck>(MsgStateAck.NAME);
+            _client.RunLevelChanged += RunLevelChanged;
         }
 
         private void RunLevelChanged(object sender, RunLevelChangedEventArgs args)
         {
             if (args.NewLevel == ClientRunLevel.Initialize)
             {
-                GameSequence = GameTick.Zero;
+                // We JUST left a server or the client started up, Reset everything.
+                _stateBuffer.Clear();
             }
         }
 
-        public void HandleStateMessage(MsgState message)
+        private void HandleStateMessage(MsgState message)
         {
             var state = message.State;
-            if (GameSequence < state.FromSequence)
-            {
-                Logger.ErrorS("net.state", "Got a game state that's too new to handle!");
-            }
-            if (GameSequence > state.ToSequence)
-            {
-                Logger.WarningS("net.state", "Got a game state that's too old to handle!");
-                return;
-            }
+
+            // we always ack everything we receive, even if it is late
             AckGameState(state.ToSequence);
 
-            state.GameTime = 0;//(float)timing.CurTime.TotalSeconds;
-            ApplyGameState(state);
+            // any state from tick 0 is a full state, and needs to be handled different
+            if (state.FromSequence == GameTick.Zero)
+            {
+                // this is a newer full state, so discard the older one.
+                if(_lastFullState == null || (_lastFullState != null && _lastFullState.ToSequence < state.ToSequence))
+                {
+                    _lastFullState = state;
+                    Logger.InfoS("net", $"Received Full GameState: to={state.ToSequence}, sz={0}");
+                    return;
+                }
+            }
+
+            // NOTE: DispatchTick will be modifying CurTick, this is NOT thread safe.
+            var lastTick = new GameTick(_timing.CurTick.Value - 1);
+
+            if (state.ToSequence <= lastTick && !_waitingForFull) // CurTick isn't set properly when WaitingForFull
+            {
+                Logger.DebugS("net.state", $"Received Old GameState: cTick={_timing.CurTick}, fSeq={state.FromSequence}, tSeq={state.ToSequence}, sz={0}, buf={_stateBuffer.Count}");
+                return;
+            }
+            
+            for (var i = 0; i < _stateBuffer.Count; i++)
+            {
+                var iState = _stateBuffer[i];
+
+                if (state.ToSequence != iState.ToSequence)
+                    continue;
+
+                if (iState.Extrapolated)
+                {
+                    _stateBuffer.RemoveSwap(i); // remove the fake extrapolated state
+                    break; // break from the loop, add the new state normally
+                }
+
+                Logger.DebugS("net.state", $"Received Dupe GameState: cTick={_timing.CurTick}, fSeq={state.FromSequence}, tSeq={state.ToSequence}, sz={0}, buf={_stateBuffer.Count}");
+                return;
+            }
+            
+            _stateBuffer.Add(state);
+            Logger.DebugS("net.state", $"Received New GameState: cTick={_timing.CurTick}, fSeq={state.FromSequence}, tSeq={state.ToSequence}, sz={0}, buf={_stateBuffer.Count}");
+        }
+
+        public void ApplyGameState()
+        {
+            //TODO: completely skip this tick and freeze the sim if false
+            if(CalculateNextStates(_timing.CurTick, out var curState, out var nextState))
+            {
+                Logger.DebugS("net.state", $"Applying State: cTick={_timing.CurTick}, ext={curState.Extrapolated} fSeq={curState.FromSequence}, tSeq={curState.ToSequence}, sz={0}, buf={_stateBuffer.Count}");
+                ApplyGameState(curState);
+            }
+        }
+
+        private bool CalculateNextStates(GameTick curTick, out GameState curState, out GameState nextState)
+        {
+            if (_waitingForFull)
+            {
+                if (_lastFullState != null)
+                {
+                    Logger.DebugS("net", $"Resync CurTick to: {_lastFullState.ToSequence}");
+                    curTick = _timing.CurTick = _lastFullState.ToSequence;
+                }
+
+                var nextTick = new GameTick(curTick.Value + 1);
+
+                // we are waiting to get a full state, and the next state
+                if (_lastFullState != null)
+                {
+                    nextState = null;
+                    for (var i = 0; i < _stateBuffer.Count; i++)
+                    {
+                        var state = _stateBuffer[i];
+                        if (state.ToSequence == nextTick)
+                        {
+                            nextState = state;
+                            break;
+                        }
+                    }
+
+                    if (nextState != null)
+                    {
+                        curState = _lastFullState;
+                        _waitingForFull = false;
+                        return true;
+                    }
+                }
+
+                // We just have to wait...
+                curState = default;
+                nextState = default;
+                return false;
+            }
+            else // this will be how almost all states are calculated
+            {
+                var lastTick = new GameTick(curTick.Value - 1);
+                var nextTick = new GameTick(curTick.Value + 1);
+
+                curState = null;
+                nextState = null;
+
+                for (var i = 0; i < _stateBuffer.Count; i++)
+                {
+                    var state = _stateBuffer[i];
+
+                    if (state.FromSequence == lastTick && state.ToSequence == curTick)
+                    {
+                        curState = state;
+                        _stateBuffer.RemoveSwap(i);
+                        i--;
+                    }
+                    else if (state.FromSequence == curTick && state.ToSequence == nextTick)
+                    {
+                        nextState = state;
+                        _stateBuffer.RemoveSwap(i);
+                        i--;
+                    }
+                    else if(state.ToSequence < lastTick) // remove any old states we find to keep the buffer clean
+                    {
+                        _stateBuffer.RemoveSwap(i);
+                        i--;
+                    }
+                }
+
+                // we found both the states to lerp between, this should be true almost always.
+                if (curState != null && nextState != null)
+                    return true;
+
+                if (curState == null)
+                {
+                    curState = ExtrapolateState(lastTick, curTick);
+                    _stateBuffer.Add(curState);
+                }
+
+                if (nextState == null)
+                {
+                    nextState = ExtrapolateState(curTick, nextTick);
+                    _stateBuffer.Add(nextState);
+                }
+
+                return true;
+            }
+        }
+
+        private GameState ExtrapolateState(GameTick fromSequence, GameTick toSequence)
+        {
+            //TODO: Make me work!
+           var state = new GameState(fromSequence, toSequence, null, null, null, null);
+           state.Extrapolated = true;
+           return state;
         }
 
         private void AckGameState(GameTick sequence)
         {
-            var msg = networkManager.CreateNetMessage<MsgStateAck>();
+            var msg = _network.CreateNetMessage<MsgStateAck>();
             msg.Sequence = sequence;
-            networkManager.ClientSendMessage(msg);
-            GameSequence = sequence;
+            _network.ClientSendMessage(msg);
         }
 
         private void ApplyGameState(GameState gameState)
         {
             _mapManager.ApplyGameStatePre(gameState.MapData);
-            entityManager.ApplyEntityStates(gameState.EntityStates, gameState.EntityDeletions, gameState.GameTime);
-            playerManager.ApplyPlayerStates(gameState.PlayerStates);
+            _entities.ApplyEntityStates(gameState.EntityStates, gameState.EntityDeletions);
+            _players.ApplyPlayerStates(gameState.PlayerStates);
             _mapManager.ApplyGameStatePost(gameState.MapData);
         }
     }

--- a/SS14.Client/GameStates/ClientGameStateManager.cs
+++ b/SS14.Client/GameStates/ClientGameStateManager.cs
@@ -46,10 +46,10 @@ namespace SS14.Client.GameStates
             _client.RunLevelChanged += RunLevelChanged;
 
             if(!_config.IsCVarRegistered("net.interp"))
-                _config.RegisterCVar("net.interp", true, CVar.ARCHIVE);
+                _config.RegisterCVar("net.interp", false, CVar.ARCHIVE);
 
             if (!_config.IsCVarRegistered("net.interp_ratio"))
-                _config.RegisterCVar("net.interp_ratio", 1, CVar.ARCHIVE);
+                _config.RegisterCVar("net.interp_ratio", 0, CVar.ARCHIVE);
         }
 
         /// <inheritdoc />

--- a/SS14.Client/GameStates/ClientGameStateManager.cs
+++ b/SS14.Client/GameStates/ClientGameStateManager.cs
@@ -1,24 +1,20 @@
 ﻿using SS14.Client.Interfaces;
 using SS14.Client.Interfaces.GameObjects;
 using SS14.Client.Interfaces.GameStates;
-using SS14.Shared;
 using SS14.Shared.GameStates;
 using SS14.Shared.Interfaces.Network;
-using SS14.Shared.Interfaces.Serialization;
-using SS14.Shared.Interfaces.Timing;
 using SS14.Shared.IoC;
 using SS14.Shared.Log;
 using SS14.Shared.Network.Messages;
-using System.Collections.Generic;
-using System.Linq;
 using SS14.Client.Player;
 using SS14.Shared.Interfaces.Map;
+using SS14.Shared.Timing;
 
 namespace SS14.Client.GameStates
 {
     public class ClientGameStateManager : IClientGameStateManager
     {
-        private uint GameSequence;
+        private GameTick GameSequence;
 
         [Dependency]
         private readonly IClientNetManager networkManager;
@@ -44,7 +40,7 @@ namespace SS14.Client.GameStates
         {
             if (args.NewLevel == ClientRunLevel.Initialize)
             {
-                GameSequence = 0;
+                GameSequence = GameTick.Zero;
             }
         }
 
@@ -66,7 +62,7 @@ namespace SS14.Client.GameStates
             ApplyGameState(state);
         }
 
-        private void AckGameState(uint sequence)
+        private void AckGameState(GameTick sequence)
         {
             var msg = networkManager.CreateNetMessage<MsgStateAck>();
             msg.Sequence = sequence;

--- a/SS14.Client/GameStates/ClientGameStateManager.cs
+++ b/SS14.Client/GameStates/ClientGameStateManager.cs
@@ -107,7 +107,7 @@ namespace SS14.Client.GameStates
             if(CalculateNextStates(_timing.CurTick, out var curState, out var nextState))
             {
                 Logger.DebugS("net.state", $"Applying State:  ext={curState.Extrapolated}, cTick={_timing.CurTick}, fSeq={curState.FromSequence}, tSeq={curState.ToSequence}, buf={_stateBuffer.Count}");
-                ApplyGameState(curState);
+                ApplyGameState(curState, nextState);
             }
         }
 
@@ -216,12 +216,12 @@ namespace SS14.Client.GameStates
             _network.ClientSendMessage(msg);
         }
 
-        private void ApplyGameState(GameState gameState)
+        private void ApplyGameState(GameState curState, GameState nextState)
         {
-            _mapManager.ApplyGameStatePre(gameState.MapData);
-            _entities.ApplyEntityStates(gameState.EntityStates, gameState.EntityDeletions);
-            _players.ApplyPlayerStates(gameState.PlayerStates);
-            _mapManager.ApplyGameStatePost(gameState.MapData);
+            _mapManager.ApplyGameStatePre(curState.MapData);
+            _entities.ApplyEntityStates(curState.EntityStates, curState.EntityDeletions, nextState.EntityStates);
+            _players.ApplyPlayerStates(curState.PlayerStates);
+            _mapManager.ApplyGameStatePost(curState.MapData);
         }
     }
 }

--- a/SS14.Client/GameStates/NetGraphOverlay.cs
+++ b/SS14.Client/GameStates/NetGraphOverlay.cs
@@ -25,6 +25,7 @@ namespace SS14.Client.GameStates
 
         protected override void Draw(DrawingHandle handle)
         {
+            //TODO: Make me actually work!
             handle.DrawLine(new Vector2(50,50), new Vector2(100,100), Color.Green);
             DrawString((DrawingHandleScreen)handle, _font, new Vector2(60, 50), "Hello World!");
         }

--- a/SS14.Client/GameStates/NetGraphOverlay.cs
+++ b/SS14.Client/GameStates/NetGraphOverlay.cs
@@ -1,7 +1,10 @@
-﻿using SS14.Client.Graphics.Drawing;
+﻿using SS14.Client.Graphics;
+using SS14.Client.Graphics.Drawing;
 using SS14.Client.Graphics.Overlays;
 using SS14.Client.Interfaces.Console;
 using SS14.Client.Interfaces.Graphics.Overlays;
+using SS14.Client.Interfaces.ResourceManagement;
+using SS14.Client.ResourceManagement;
 using SS14.Shared.IoC;
 using SS14.Shared.Maths;
 
@@ -11,14 +14,30 @@ namespace SS14.Client.GameStates
     {
         public override OverlaySpace Space => OverlaySpace.ScreenSpace;
 
+        private Font _font;
+
         public NetGraphOverlay() : base(nameof(NetGraphOverlay))
         {
             IoCManager.InjectDependencies(this);
+            var cache = IoCManager.Resolve<IResourceCache>();
+            _font = new VectorFont(cache.GetResource<FontResource>("/Nano/NotoSans/NotoSans-Regular.ttf"), 10);
         }
 
         protected override void Draw(DrawingHandle handle)
         {
             handle.DrawLine(new Vector2(50,50), new Vector2(100,100), Color.Green);
+            DrawString((DrawingHandleScreen)handle, _font, new Vector2(60, 50), "Hello World!");
+        }
+
+        private void DrawString(DrawingHandleScreen handle, Font font, Vector2 pos, string str)
+        {
+            var baseLine = new Vector2(pos.X, font.Ascent + pos.Y);
+
+            foreach (var chr in str)
+            {
+                var advance = font.DrawChar(handle, chr, baseLine, Color.White);
+                baseLine += new Vector2(advance, 0);
+            }
         }
 
         private class NetShowGraph : IConsoleCommand

--- a/SS14.Client/GameStates/NetGraphOverlay.cs
+++ b/SS14.Client/GameStates/NetGraphOverlay.cs
@@ -1,0 +1,62 @@
+﻿using SS14.Client.Graphics.Drawing;
+using SS14.Client.Graphics.Overlays;
+using SS14.Client.Interfaces.Console;
+using SS14.Client.Interfaces.Graphics.Overlays;
+using SS14.Shared.IoC;
+using SS14.Shared.Maths;
+
+namespace SS14.Client.GameStates
+{
+    internal class NetGraphOverlay : Overlay
+    {
+        public override OverlaySpace Space => OverlaySpace.ScreenSpace;
+
+        public NetGraphOverlay() : base(nameof(NetGraphOverlay))
+        {
+            IoCManager.InjectDependencies(this);
+        }
+
+        protected override void Draw(DrawingHandle handle)
+        {
+            handle.DrawLine(new Vector2(50,50), new Vector2(100,100), Color.Green);
+        }
+
+        private class NetShowGraph : IConsoleCommand
+        {
+            public string Command => "net_graph";
+            public string Help => "net_graph <0|1>";
+            public string Description => "Toggles the net statistics pannel.";
+
+            public bool Execute(IDebugConsole console, params string[] args)
+            {
+                if (args.Length != 1)
+                {
+                    console.AddLine("Invalid argument amount. Expected 2 arguments.", Color.Red);
+                    return false;
+                }
+
+                if (!byte.TryParse(args[0], out var iValue))
+                {
+                    console.AddLine("Invalid argument: Needs to be 0 or 1.");
+                    return false;
+                }
+
+                var bValue = iValue > 0;
+                var overlayMan = IoCManager.Resolve<IOverlayManager>();
+
+                if(bValue && !overlayMan.HasOverlay(nameof(NetGraphOverlay)))
+                {
+                    overlayMan.AddOverlay(new NetGraphOverlay());
+                    console.AddLine("Enabled network overlay.");
+                }
+                else if(overlayMan.HasOverlay(nameof(NetGraphOverlay)))
+                {
+                    overlayMan.RemoveOverlay(nameof(NetGraphOverlay));
+                    console.AddLine("Disabled network overlay.");
+                }
+                
+                return false;
+            }
+        } 
+    }
+}

--- a/SS14.Client/GameStates/NetGraphOverlay.cs
+++ b/SS14.Client/GameStates/NetGraphOverlay.cs
@@ -40,7 +40,7 @@ namespace SS14.Client.GameStates
             }
         }
 
-        private class NetShowGraph : IConsoleCommand
+        private class NetShowGraphCommand : IConsoleCommand
         {
             public string Command => "net_graph";
             public string Help => "net_graph <0|1>";

--- a/SS14.Client/GameStates/NetInterpOverlay.cs
+++ b/SS14.Client/GameStates/NetInterpOverlay.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using SS14.Client.GameObjects;
+using SS14.Client.Graphics.Drawing;
+using SS14.Client.Graphics.Overlays;
+using SS14.Client.Graphics.Shaders;
+using SS14.Client.Interfaces.Console;
+using SS14.Client.Interfaces.Graphics.ClientEye;
+using SS14.Client.Interfaces.Graphics.Overlays;
+using SS14.Shared.Interfaces.GameObjects;
+using SS14.Shared.Interfaces.GameObjects.Components;
+using SS14.Shared.Interfaces.Timing;
+using SS14.Shared.IoC;
+using SS14.Shared.Maths;
+using SS14.Shared.Prototypes;
+
+namespace SS14.Client.GameStates
+{
+    internal class NetInterpOverlay : Overlay
+    {
+        [Dependency] private readonly IComponentManager _componentManager;
+        [Dependency] private readonly IEyeManager _eyeManager;
+        [Dependency] private readonly IPrototypeManager _prototypeManager;
+
+        public override OverlaySpace Space => OverlaySpace.WorldSpace;
+
+        public NetInterpOverlay() : base(nameof(NetInterpOverlay))
+        {
+            IoCManager.InjectDependencies(this);
+            Shader = _prototypeManager.Index<ShaderPrototype>("unshaded").Instance();
+        }
+        protected override void Draw(DrawingHandle handle)
+        {
+            var worldHandle = (DrawingHandleWorld) handle;
+            var viewport = _eyeManager.GetWorldViewport();
+            foreach (var boundingBox in _componentManager.GetAllComponents<ClientBoundingBoxComponent>())
+            {
+                // all entities have a TransformComponent
+                var transform = boundingBox.Owner.Transform;
+
+                // if not on the same map, continue
+                if (transform.MapID != _eyeManager.CurrentMap || !transform.IsMapTransform)
+                    continue;
+
+                // This entity isn't lerping, no need to draw debug info for it
+                if(transform.LocalPosition == transform.LerpDestination)
+                    continue;
+
+                var aabb = boundingBox.AABB;
+
+                // if not on screen, or too small, continue
+                if (!aabb.Translated(transform.WorldPosition).Intersects(viewport) || aabb.IsEmpty())
+                    continue;
+                
+                var timing = IoCManager.Resolve<IGameTiming>();
+                timing.InSimulation = true;
+                
+                var boxOffset = transform.LerpDestination - transform.LocalPosition;
+                var boxPosWorld = transform.WorldPosition + boxOffset;
+                
+                timing.InSimulation = false;
+
+                worldHandle.DrawLine(transform.WorldPosition, boxPosWorld, Color.Yellow);
+                worldHandle.DrawRect(aabb.Translated(boxPosWorld), Color.Yellow.WithAlpha(0.5f), false);
+
+            }
+        }
+
+        private class NetShowInterpCommand : IConsoleCommand
+        {
+            public string Command => "net_draw_interp";
+            public string Help => "net_draw_interp <0|1>";
+            public string Description => "Toggles the debug drawing of the network interpolation.";
+
+            public bool Execute(IDebugConsole console, params string[] args)
+            {
+                if (args.Length != 1)
+                {
+                    console.AddLine("Invalid argument amount. Expected 2 arguments.", Color.Red);
+                    return false;
+                }
+
+                if (!byte.TryParse(args[0], out var iValue))
+                {
+                    console.AddLine("Invalid argument: Needs to be 0 or 1.");
+                    return false;
+                }
+
+                var bValue = iValue > 0;
+                var overlayMan = IoCManager.Resolve<IOverlayManager>();
+
+                if (bValue && !overlayMan.HasOverlay(nameof(NetInterpOverlay)))
+                {
+                    overlayMan.AddOverlay(new NetInterpOverlay());
+                    console.AddLine("Enabled network interp overlay.");
+                }
+                else if (overlayMan.HasOverlay(nameof(NetInterpOverlay)))
+                {
+                    overlayMan.RemoveOverlay(nameof(NetInterpOverlay));
+                    console.AddLine("Disabled network interp overlay.");
+                }
+
+                return false;
+            }
+        }
+    }
+}

--- a/SS14.Client/Interfaces/GameObjects/IClientEntityManager.cs
+++ b/SS14.Client/Interfaces/GameObjects/IClientEntityManager.cs
@@ -12,6 +12,6 @@ namespace SS14.Client.Interfaces.GameObjects
         IEnumerable<IEntity> GetEntitiesIntersecting(MapId mapId, Box2 position);
         IEnumerable<IEntity> GetEntitiesIntersecting(MapId mapId, Vector2 position);
         bool AnyEntitiesIntersecting(MapId mapId, Box2 box);
-        void ApplyEntityStates(IEnumerable<EntityState> entityStates, IEnumerable<EntityUid> deletions, float serverTime);
+        void ApplyEntityStates(IEnumerable<EntityState> entityStates, IEnumerable<EntityUid> deletions);
     }
 }

--- a/SS14.Client/Interfaces/GameObjects/IClientEntityManager.cs
+++ b/SS14.Client/Interfaces/GameObjects/IClientEntityManager.cs
@@ -12,6 +12,6 @@ namespace SS14.Client.Interfaces.GameObjects
         IEnumerable<IEntity> GetEntitiesIntersecting(MapId mapId, Box2 position);
         IEnumerable<IEntity> GetEntitiesIntersecting(MapId mapId, Vector2 position);
         bool AnyEntitiesIntersecting(MapId mapId, Box2 box);
-        void ApplyEntityStates(IEnumerable<EntityState> curEntStates, IEnumerable<EntityUid> deletions, List<EntityState> nextEntStates);
+        void ApplyEntityStates(List<EntityState> curEntStates, IEnumerable<EntityUid> deletions, List<EntityState> nextEntStates);
     }
 }

--- a/SS14.Client/Interfaces/GameObjects/IClientEntityManager.cs
+++ b/SS14.Client/Interfaces/GameObjects/IClientEntityManager.cs
@@ -12,6 +12,6 @@ namespace SS14.Client.Interfaces.GameObjects
         IEnumerable<IEntity> GetEntitiesIntersecting(MapId mapId, Box2 position);
         IEnumerable<IEntity> GetEntitiesIntersecting(MapId mapId, Vector2 position);
         bool AnyEntitiesIntersecting(MapId mapId, Box2 box);
-        void ApplyEntityStates(IEnumerable<EntityState> entityStates, IEnumerable<EntityUid> deletions);
+        void ApplyEntityStates(IEnumerable<EntityState> curEntStates, IEnumerable<EntityUid> deletions, List<EntityState> nextEntStates);
     }
 }

--- a/SS14.Client/Interfaces/GameStates/IClientGameStateManager.cs
+++ b/SS14.Client/Interfaces/GameStates/IClientGameStateManager.cs
@@ -3,6 +3,7 @@
     public interface IClientGameStateManager
     {
         void Initialize();
+        void Shutdown();
 
         void ApplyGameState();
     }

--- a/SS14.Client/Interfaces/GameStates/IClientGameStateManager.cs
+++ b/SS14.Client/Interfaces/GameStates/IClientGameStateManager.cs
@@ -1,11 +1,9 @@
-﻿using SS14.Shared.GameStates;
-using SS14.Shared.Network.Messages;
-using System.Collections.Generic;
-
-namespace SS14.Client.Interfaces.GameStates
+﻿namespace SS14.Client.Interfaces.GameStates
 {
     public interface IClientGameStateManager
     {
         void Initialize();
+
+        void ApplyGameState();
     }
 }

--- a/SS14.Client/Player/LocalPlayer.cs
+++ b/SS14.Client/Player/LocalPlayer.cs
@@ -131,7 +131,15 @@ namespace SS14.Client.Player
         /// </summary>
         public void SwitchState(SessionStatus newStatus)
         {
-            var args = new StatusEventArgs(Session.Status, newStatus);
+            SwitchState(Session.Status, newStatus);
+        }
+
+        /// <summary>
+        ///     Changes the state of the session. This overload allows you to spoof the oldStatus, use with caution.
+        /// </summary>
+        public void SwitchState(SessionStatus oldStatus, SessionStatus newStatus)
+        {
+            var args = new StatusEventArgs(oldStatus, newStatus);
             Session.Status = newStatus;
             StatusChanged?.Invoke(this, args);
         }

--- a/SS14.Client/Player/PlayerManager.cs
+++ b/SS14.Client/Player/PlayerManager.cs
@@ -192,6 +192,9 @@ namespace SS14.Client.Player
                     if (state.SessionId == LocalPlayer.SessionId)
                     {
                         LocalPlayer.Session = newSession;
+
+                        // We just connected to the server, hurray!
+                        LocalPlayer.SwitchState(SessionStatus.Connecting, newSession.Status);
                     }
                 }
             }

--- a/SS14.Client/SS14.Client.csproj
+++ b/SS14.Client/SS14.Client.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Console\Commands\QuitCommand.cs" />
     <Compile Include="Console\Commands\Debug.cs" />
     <Compile Include="GameStates\ClientGameStateManager.cs" />
+    <Compile Include="GameStates\NetGraphOverlay.cs" />
     <Compile Include="Graphics\CanvasLayers.cs" />
     <Compile Include="Graphics\Clyde\Clyde.Audio.cs" />
     <Compile Include="Graphics\Clyde\Clyde.AudioFormats.OggVorbis.cs" />

--- a/SS14.Client/SS14.Client.csproj
+++ b/SS14.Client/SS14.Client.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Console\Commands\Debug.cs" />
     <Compile Include="GameStates\ClientGameStateManager.cs" />
     <Compile Include="GameStates\NetGraphOverlay.cs" />
+    <Compile Include="GameStates\NetInterpOverlay.cs" />
     <Compile Include="Graphics\CanvasLayers.cs" />
     <Compile Include="Graphics\Clyde\Clyde.Audio.cs" />
     <Compile Include="Graphics\Clyde\Clyde.AudioFormats.OggVorbis.cs" />

--- a/SS14.Client/State/States/GameScreen.cs
+++ b/SS14.Client/State/States/GameScreen.cs
@@ -1,5 +1,4 @@
-﻿using SS14.Client.Console;
-using SS14.Client.Input;
+﻿using SS14.Client.Input;
 using SS14.Client.Interfaces.GameObjects;
 using SS14.Client.Interfaces.GameObjects.Components;
 using SS14.Client.Interfaces.Graphics.ClientEye;
@@ -10,7 +9,6 @@ using SS14.Client.UserInterface.CustomControls;
 using SS14.Shared.GameObjects;
 using SS14.Shared.Input;
 using SS14.Shared.Interfaces.GameObjects;
-using SS14.Shared.Interfaces.GameObjects.Components;
 using SS14.Shared.IoC;
 using SS14.Shared.Map;
 using System.Collections.Generic;

--- a/SS14.Server/BaseServer.cs
+++ b/SS14.Server/BaseServer.cs
@@ -284,7 +284,7 @@ namespace SS14.Server
             cfgMgr.RegisterCVar("game.maxplayers", 32, CVar.ARCHIVE);
             cfgMgr.RegisterCVar("game.type", GameType.Game);
 
-            _time.TickRate = _config.GetCVar<int>("net.tickrate");
+            _time.TickRate = (byte)_config.GetCVar<int>("net.tickrate");
 
             Logger.InfoS("srv", $"Name: {ServerName}");
             Logger.InfoS("srv", $"TickRate: {_time.TickRate}({_time.TickPeriod.TotalMilliseconds:0.00}ms)");

--- a/SS14.Server/GameObjects/ServerEntityManager.cs
+++ b/SS14.Server/GameObjects/ServerEntityManager.cs
@@ -2,13 +2,12 @@
 using SS14.Server.Interfaces.GameObjects;
 using SS14.Shared.GameObjects;
 using SS14.Shared.Interfaces.GameObjects;
-using SS14.Shared.Interfaces.GameObjects.Components;
 using SS14.Shared.Interfaces.Map;
 using SS14.Shared.IoC;
 using SS14.Shared.Map;
 using SS14.Shared.Maths;
 using SS14.Shared.Prototypes;
-using SS14.Shared.Serialization;
+using SS14.Shared.Timing;
 
 namespace SS14.Server.GameObjects
 {
@@ -25,7 +24,7 @@ namespace SS14.Server.GameObjects
         [Dependency]
         private readonly IMapManager _mapManager;
 
-        private readonly List<(uint tick, EntityUid uid)> DeletionHistory = new List<(uint, EntityUid)>();
+        private readonly List<(GameTick tick, EntityUid uid)> DeletionHistory = new List<(GameTick, EntityUid)>();
 
         public override IEntity SpawnEntity(string protoName)
         {
@@ -79,7 +78,7 @@ namespace SS14.Server.GameObjects
         }
 
         /// <inheritdoc />
-        public List<EntityState> GetEntityStates(uint fromTick)
+        public List<EntityState> GetEntityStates(GameTick fromTick)
         {
             var stateEntities = new List<EntityState>();
             foreach (IEntity entity in GetEntities())
@@ -103,7 +102,7 @@ namespace SS14.Server.GameObjects
             DeletionHistory.Add((CurrentTick, e.Uid));
         }
 
-        public List<EntityUid> GetDeletedEntities(uint fromTick)
+        public List<EntityUid> GetDeletedEntities(GameTick fromTick)
         {
             List<EntityUid> list = new List<EntityUid>();
             foreach ((var tick, var id) in DeletionHistory)
@@ -117,7 +116,7 @@ namespace SS14.Server.GameObjects
             return list;
         }
 
-        public void CullDeletionHistory(uint toTick)
+        public void CullDeletionHistory(GameTick toTick)
         {
             DeletionHistory.RemoveAll(hist => hist.tick <= toTick);
         }

--- a/SS14.Server/GameStates/ServerGameStateManager.cs
+++ b/SS14.Server/GameStates/ServerGameStateManager.cs
@@ -78,7 +78,7 @@ namespace SS14.Server.GameStates
             }
 
             var entities = _entityManager.GetEntityStates(oldestAck);
-            var players = _playerManager.GetPlayerStates();
+            var players = _playerManager.GetPlayerStates(oldestAck);
             var deletions = _entityManager.GetDeletedEntities(oldestAck);
             var mapData = _mapManager.GetStateData(oldestAck);
 

--- a/SS14.Server/GameStates/ServerGameStateManager.cs
+++ b/SS14.Server/GameStates/ServerGameStateManager.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using SS14.Server.Interfaces.GameObjects;
 using SS14.Server.Interfaces.GameState;
 using SS14.Server.Interfaces.Player;
@@ -10,6 +9,7 @@ using SS14.Shared.Interfaces.Network;
 using SS14.Shared.Interfaces.Timing;
 using SS14.Shared.IoC;
 using SS14.Shared.Network.Messages;
+using SS14.Shared.Timing;
 using SS14.Shared.Utility;
 
 namespace SS14.Server.GameStates
@@ -17,9 +17,9 @@ namespace SS14.Server.GameStates
     public class ServerGameStateManager : IServerGameStateManager
     {
         // Mapping of net UID of clients -> last known acked state.
-        private readonly Dictionary<long, uint> ackedStates = new Dictionary<long, uint>();
+        private readonly Dictionary<long, GameTick> ackedStates = new Dictionary<long, GameTick>();
 
-        private uint lastOldestAck = 0;
+        private GameTick lastOldestAck = GameTick.Zero;
 
         [Dependency]
         private IServerEntityManager _entityManager;
@@ -41,7 +41,7 @@ namespace SS14.Server.GameStates
             _networkManager.RegisterNetMessage<MsgStateAck>(MsgStateAck.NAME, HandleStateAck);
         }
 
-        private void Ack(long uniqueIdentifier, uint stateAcked)
+        private void Ack(long uniqueIdentifier, GameTick stateAcked)
         {
             ackedStates[uniqueIdentifier] = stateAcked;
         }
@@ -53,17 +53,17 @@ namespace SS14.Server.GameStates
             if (!_networkManager.IsConnected)
             {
                 // Prevent deletions piling up if we have no clients.
-                _entityManager.CullDeletionHistory(uint.MaxValue);
-                _mapManager.CullDeletionHistory(uint.MaxValue);
+                _entityManager.CullDeletionHistory(GameTick.MaxValue);
+                _mapManager.CullDeletionHistory(GameTick.MaxValue);
                 return;
             }
 
-            var oldestAck = uint.MaxValue;
+            var oldestAck = GameTick.MaxValue;
             foreach (var connection in _networkManager.Channels)
             {
                 if (!ackedStates.TryGetValue(connection.ConnectionId, out var ack))
                 {
-                    ackedStates.Add(connection.ConnectionId, 0);
+                    ackedStates.Add(connection.ConnectionId, GameTick.Zero);
                 }
                 else if (ack < oldestAck)
                 {

--- a/SS14.Server/Interfaces/GameObjects/IServerEntityManager.cs
+++ b/SS14.Server/Interfaces/GameObjects/IServerEntityManager.cs
@@ -4,6 +4,7 @@ using SS14.Shared.Map;
 using System.Collections.Generic;
 using SS14.Shared.Maths;
 using SS14.Shared.Serialization;
+using SS14.Shared.Timing;
 
 namespace SS14.Server.Interfaces.GameObjects
 {
@@ -70,18 +71,18 @@ namespace SS14.Server.Interfaces.GameObjects
         /// <summary>
         ///     Gets all entity states that have been modified after and including the provided tick.
         /// </summary>
-        List<EntityState> GetEntityStates(uint fromTick);
+        List<EntityState> GetEntityStates(GameTick fromTick);
 
         // Keep track of deleted entities so we can sync deletions with the client.
         /// <summary>
         ///     Gets a list of all entity UIDs that were deleted between <paramref name="fromTick" /> and now.
         /// </summary>
-        List<EntityUid> GetDeletedEntities(uint fromTick);
+        List<EntityUid> GetDeletedEntities(GameTick fromTick);
 
         /// <summary>
         ///     Remove deletion history.
         /// </summary>
         /// <param name="toTick">The last tick to delete the history for. Inclusive.</param>
-        void CullDeletionHistory(uint toTick);
+        void CullDeletionHistory(GameTick toTick);
     }
 }

--- a/SS14.Server/Interfaces/GameObjects/IServerEntityManagerInternal.cs
+++ b/SS14.Server/Interfaces/GameObjects/IServerEntityManagerInternal.cs
@@ -1,6 +1,5 @@
-using SS14.Shared.GameObjects;
+﻿using SS14.Shared.GameObjects;
 using SS14.Shared.Interfaces.GameObjects;
-using SS14.Shared.Serialization;
 
 namespace SS14.Server.Interfaces.GameObjects
 {

--- a/SS14.Server/Interfaces/Player/IPlayerManager.cs
+++ b/SS14.Server/Interfaces/Player/IPlayerManager.cs
@@ -8,6 +8,7 @@ using SS14.Shared.Interfaces.Network;
 using SS14.Shared.Map;
 using SS14.Shared.Network;
 using SS14.Shared.Players;
+using SS14.Shared.Timing;
 
 namespace SS14.Server.Interfaces.Player
 {
@@ -64,6 +65,6 @@ namespace SS14.Server.Interfaces.Player
         void DetachAll();
         List<IPlayerSession> GetPlayersInRange(GridCoordinates worldPos, int range);
         List<IPlayerSession> GetAllPlayers();
-        List<PlayerState> GetPlayerStates();
+        List<PlayerState> GetPlayerStates(GameTick fromTick);
     }
 }

--- a/SS14.Server/Player/PlayerManager.cs
+++ b/SS14.Server/Player/PlayerManager.cs
@@ -3,20 +3,17 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using SS14.Server.Interfaces;
-using SS14.Server.Interfaces.GameObjects;
 using SS14.Server.Interfaces.Player;
 using SS14.Shared.Enums;
 using SS14.Shared.GameStates;
 using SS14.Shared.Input;
-using SS14.Shared.Interfaces.GameObjects;
-using SS14.Shared.Interfaces.GameObjects.Components;
 using SS14.Shared.Interfaces.Network;
 using SS14.Shared.Interfaces.Reflection;
+using SS14.Shared.Interfaces.Timing;
 using SS14.Shared.IoC;
 using SS14.Shared.Map;
 using SS14.Shared.Network;
 using SS14.Shared.Network.Messages;
-using SS14.Shared.Players;
 using SS14.Shared.Utility;
 
 namespace SS14.Server.Player
@@ -28,7 +25,8 @@ namespace SS14.Server.Player
     {
         [Dependency]
         private readonly IBaseServer _baseServer;
-
+        [Dependency]
+        private readonly IGameTiming _timing;
         [Dependency]
         private readonly IServerNetManager _network;
         [Dependency]
@@ -326,6 +324,7 @@ namespace SS14.Server.Player
 
             netMsg.ServerName = _baseServer.ServerName;
             netMsg.ServerMaxPlayers = _baseServer.MaxPlayers;
+            netMsg.TickRate = _timing.TickRate;
             netMsg.PlayerSessionId = session.SessionId;
 
             message.MsgChannel.SendMessage(netMsg);

--- a/SS14.Server/Player/PlayerManager.cs
+++ b/SS14.Server/Player/PlayerManager.cs
@@ -14,6 +14,7 @@ using SS14.Shared.IoC;
 using SS14.Shared.Map;
 using SS14.Shared.Network;
 using SS14.Shared.Network.Messages;
+using SS14.Shared.Timing;
 using SS14.Shared.Utility;
 
 namespace SS14.Server.Player
@@ -34,7 +35,7 @@ namespace SS14.Server.Player
 
         public BoundKeyMap KeyMap { get; private set; }
 
-        private bool NeedsStateUpdate;
+        private GameTick _lastStateUpdate;
 
         private readonly ReaderWriterLockSlim _sessionsLock = new ReaderWriterLockSlim();
 
@@ -234,14 +235,15 @@ namespace SS14.Server.Player
         /// <summary>
         ///     Gets all player states in the server.
         /// </summary>
+        /// <param name="fromTick"></param>
         /// <returns></returns>
-        public List<PlayerState> GetPlayerStates()
+        public List<PlayerState> GetPlayerStates(GameTick fromTick)
         {
-            if (!NeedsStateUpdate)
+            if (_lastStateUpdate < fromTick)
             {
                 return null;
             }
-            NeedsStateUpdate = false;
+
             _sessionsLock.EnterReadLock();
             try
             {
@@ -365,7 +367,7 @@ namespace SS14.Server.Player
 
         public void Dirty()
         {
-            NeedsStateUpdate = true;
+            _lastStateUpdate = _timing.CurTick;
         }
 
         public IPlayerData GetPlayerData(NetSessionId sessionId)

--- a/SS14.Server/Player/PlayerManager.cs
+++ b/SS14.Server/Player/PlayerManager.cs
@@ -335,6 +335,12 @@ namespace SS14.Server.Player
             var channel = message.MsgChannel;
             var players = GetAllPlayers().ToArray();
             var netMsg = channel.CreateNetMessage<MsgPlayerList>();
+            
+            // client session is complete, set their status accordingly.
+            // This is done before the packet is built, so that the client
+            // can see themselves Connected.
+            var session = GetSessionByChannel(channel);
+            session.Status = SessionStatus.Connected;
 
             var list = new List<PlayerState>();
             foreach (var client in players)
@@ -355,10 +361,6 @@ namespace SS14.Server.Player
             netMsg.PlyCount = (byte)list.Count;
 
             channel.SendMessage(netMsg);
-
-            // client session is complete
-            var session = GetSessionByChannel(channel);
-            session.Status = SessionStatus.Connected;
         }
 
         public void Dirty()

--- a/SS14.Server/server_config.toml
+++ b/SS14.Server/server_config.toml
@@ -6,7 +6,7 @@ level = 1
 enabled = false
 
 [net]
-tickrate = 60
+tickrate = 10
 port = 1212
 bindto = "::,0.0.0.0"
 

--- a/SS14.Shared.Maths/Angle.cs
+++ b/SS14.Shared.Maths/Angle.cs
@@ -172,6 +172,19 @@ namespace SS14.Shared.Maths
         }
 
         /// <summary>
+        ///     Similar to Lerp but makes sure the angle wraps around to 360 degrees.
+        /// </summary>
+        public static Angle Lerp(in Angle a, in Angle b, float factor)
+        {
+            var degA = FloatMath.RadToDeg * Angle.Reduce(a);
+            var degB = FloatMath.RadToDeg * Angle.Reduce(b);
+            var delta = FloatMath.Repeat((float) (degB - degA), 360);
+            if (delta > 180)
+                delta -= 360;
+            return new Angle(FloatMath.DegToRad * (degA + delta * FloatMath.Clamp01(factor)));
+        }
+
+        /// <summary>
         ///     Constructs a new angle, from degrees instead of radians.
         /// </summary>
         /// <param name="degrees">The angle in degrees.</param>

--- a/SS14.Shared.Maths/FloatMath.cs
+++ b/SS14.Shared.Maths/FloatMath.cs
@@ -62,6 +62,11 @@ namespace SS14.Shared.Maths
             return Math.Max(a, b);
         }
 
+        /// <summary>
+        /// Returns the largest integer smaller to or equal to f.
+        /// </summary>
+        public static float Floor(float f) => (float)Math.Floor(f);
+
         public const float Pi = (float) Math.PI;
 
         public static float ToDegrees(float radians)
@@ -120,6 +125,24 @@ namespace SS14.Shared.Maths
         public static float Lerp(float a, float b, float blend)
         {
             return a + (b - a) * blend;
+        }
+
+        // Clamps value between 0 and 1 and returns value
+        public static float Clamp01(float value)
+        {
+            if (value < 0F)
+                return 0F;
+
+            if (value > 1F)
+                return 1F;
+
+            return value;
+        }
+
+        // Loops the value t, so that it is never larger than length and never smaller than 0.
+        public static float Repeat(float t, float length)
+        {
+            return Clamp(t - Floor(t / length) * length, 0.0f, length);
         }
     }
 }

--- a/SS14.Shared.Maths/Vector2.cs
+++ b/SS14.Shared.Maths/Vector2.cs
@@ -235,6 +235,17 @@ namespace SS14.Shared.Maths
             );
         }
 
+        public static Vector2 LerpClamped(in Vector2 a, in Vector2 b, float factor)
+        {
+            if (factor <= 0)
+                return a;
+
+            if (factor >= 1)
+                return b;
+
+            return Lerp(a, b, factor);
+        }
+
         public void Deconstruct(out float x, out float y)
         {
             x = X;

--- a/SS14.Shared/GameObjects/Component.cs
+++ b/SS14.Shared/GameObjects/Component.cs
@@ -181,8 +181,6 @@ namespace SS14.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public virtual void HandleComponentState(ComponentState state)
-        {
-        }
+        public virtual void HandleComponentState(ComponentState curState, ComponentState nextState) { }
     }
 }

--- a/SS14.Shared/GameObjects/Component.cs
+++ b/SS14.Shared/GameObjects/Component.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 using SS14.Shared.Interfaces.GameObjects;
 using SS14.Shared.Interfaces.Network;
 using SS14.Shared.Reflection;
 using SS14.Shared.Serialization;
+using SS14.Shared.Timing;
 using SS14.Shared.ViewVariables;
-using YamlDotNet.RepresentationModel;
 
 namespace SS14.Shared.GameObjects
 {
@@ -60,7 +59,7 @@ namespace SS14.Shared.GameObjects
         public bool Deleted { get; private set; }
 
         [ViewVariables]
-        public uint LastModifiedTick { get; private set; }
+        public GameTick LastModifiedTick { get; private set; }
 
         /// <inheritdoc />
         public virtual void OnRemove()

--- a/SS14.Shared/GameObjects/ComponentState.cs
+++ b/SS14.Shared/GameObjects/ComponentState.cs
@@ -6,25 +6,11 @@ namespace SS14.Shared.GameObjects
     [Serializable, NetSerializable]
     public class ComponentState
     {
-        [NonSerialized]
-        private float _receivedTime;
-
-        public float ReceivedTime
-        {
-            get => _receivedTime;
-            set => _receivedTime = value;
-        }
-
         public uint NetID { get; }
-        
 
         public ComponentState(uint netID)
         {
             NetID = netID;
-        }
-
-        public ComponentState()
-        {
         }
     }
 }

--- a/SS14.Shared/GameObjects/Components/BoundingBox/BoundingBoxComponent.cs
+++ b/SS14.Shared/GameObjects/Components/BoundingBox/BoundingBoxComponent.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using SS14.Shared.Interfaces.GameObjects.Components;
 using SS14.Shared.Maths;
 using SS14.Shared.Serialization;
 using SS14.Shared.ViewVariables;
@@ -58,9 +57,9 @@ namespace SS14.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public override void HandleComponentState(ComponentState state)
+        public override void HandleComponentState(ComponentState curState, ComponentState nextState)
         {
-            AABB = ((BoundingBoxComponentState)state).AABB;
+            AABB = ((BoundingBoxComponentState)curState).AABB;
         }
 
         /// <inheritdoc />

--- a/SS14.Shared/GameObjects/Components/BoundingBox/BoundingBoxComponent.cs
+++ b/SS14.Shared/GameObjects/Components/BoundingBox/BoundingBoxComponent.cs
@@ -59,6 +59,9 @@ namespace SS14.Shared.GameObjects
         /// <inheritdoc />
         public override void HandleComponentState(ComponentState curState, ComponentState nextState)
         {
+            if(curState == null)
+                return;
+
             AABB = ((BoundingBoxComponentState)curState).AABB;
         }
 

--- a/SS14.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/SS14.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -8,11 +8,9 @@ using SS14.Shared.Interfaces.GameObjects.Components;
 using SS14.Shared.Interfaces.Map;
  using SS14.Shared.Interfaces.Timing;
  using SS14.Shared.IoC;
- using SS14.Shared.Log;
  using SS14.Shared.Map;
 using SS14.Shared.Maths;
 using SS14.Shared.Serialization;
- using SS14.Shared.Utility;
  using SS14.Shared.ViewVariables;
 
 namespace SS14.Shared.GameObjects.Components.Transform
@@ -402,11 +400,6 @@ namespace SS14.Shared.GameObjects.Components.Transform
         /// <inheritdoc />
         public override void HandleComponentState(ComponentState curState, ComponentState nextState)
         {
-            var curTrans = curState as TransformComponentState;
-            var nextTrans = nextState as TransformComponentState;
-
-            Logger.DebugS("ent", $"cTick={(curTrans != null? curTrans.LocalPosition.ToString():"-")}, nTick={(nextTrans!=null?nextTrans.LocalPosition.ToString():"-")}");
-
             if (curState != null)
             {
                 var newState = (TransformComponentState) curState;
@@ -479,26 +472,25 @@ namespace SS14.Shared.GameObjects.Components.Transform
 
         protected virtual Vector2 GetLocalPosition()
         {
-            IGameTiming timing = IoCManager.Resolve<IGameTiming>();
-            if(timing.InSimulation || _localPosition == _nextPosition)
+            IGameTiming gameTiming = IoCManager.Resolve<IGameTiming>();
+            if(gameTiming.InSimulation || _localPosition == _nextPosition)
                 return _localPosition;
 
-            return Vector2.Lerp(_localPosition, _nextPosition, (float) (timing.TickRemainder.TotalSeconds / timing.TickPeriod.TotalSeconds));
+            return Vector2.Lerp(_localPosition, _nextPosition, (float) (gameTiming.TickRemainder.TotalSeconds / gameTiming.TickPeriod.TotalSeconds));
         }
 
         protected virtual Angle GetLocalRotation()
         {
-            IGameTiming timing = IoCManager.Resolve<IGameTiming>();
-            if (timing.InSimulation || _localRotation == _nextRotation)
+            IGameTiming gameTiming = IoCManager.Resolve<IGameTiming>();
+            if (gameTiming.InSimulation || _localRotation == _nextRotation)
                 return _localRotation;
 
-            return Angle.Lerp(_localRotation, _nextRotation, (float)(timing.TickRemainder.TotalSeconds / timing.TickPeriod.TotalSeconds));
+            return Angle.Lerp(_localRotation, _nextRotation, (float)(gameTiming.TickRemainder.TotalSeconds / gameTiming.TickPeriod.TotalSeconds));
         }
 
         protected virtual Matrix3 GetWorldMatrix()
         {
-            IGameTiming timing = IoCManager.Resolve<IGameTiming>();
-            if (timing.InSimulation)
+            if (IoCManager.Resolve<IGameTiming>().InSimulation)
                 return _worldMatrix;
 
             // there really is no point trying to cache this because it will only be used in one frame
@@ -515,8 +507,7 @@ namespace SS14.Shared.GameObjects.Components.Transform
 
         protected virtual Matrix3 GetWorldMatrixInv()
         {
-            IGameTiming timing = IoCManager.Resolve<IGameTiming>();
-            if (timing.InSimulation)
+            if (IoCManager.Resolve<IGameTiming>().InSimulation)
                 return _invWorldMatrix;
 
             // there really is no point trying to cache this because it will only be used in one frame

--- a/SS14.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/SS14.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -76,7 +76,6 @@ namespace SS14.Shared.GameObjects.Components.Transform
             get => GetLocalRotation();
             set
             {
-                DebugTools.Assert(IoCManager.Resolve<IGameTiming>().InSimulation);
                 SetRotation(value);
                 RebuildMatrices();
                 Dirty();
@@ -97,7 +96,6 @@ namespace SS14.Shared.GameObjects.Components.Transform
             }
             set
             {
-                DebugTools.Assert(IoCManager.Resolve<IGameTiming>().InSimulation);
                 var current = WorldRotation;
                 var diff = value - current;
                 LocalRotation += diff;
@@ -178,7 +176,6 @@ namespace SS14.Shared.GameObjects.Components.Transform
             }
             set
             {
-                DebugTools.Assert(IoCManager.Resolve<IGameTiming>().InSimulation);
                 if (_parent.IsValid())
                 {
                     if (value.GridID != _gridID)
@@ -236,7 +233,6 @@ namespace SS14.Shared.GameObjects.Components.Transform
             }
             set
             {
-                DebugTools.Assert(IoCManager.Resolve<IGameTiming>().InSimulation);
                 if (_parent.IsValid())
                 {
                     // world coords to parent coords
@@ -282,19 +278,11 @@ namespace SS14.Shared.GameObjects.Components.Transform
         public IEnumerable<ITransformComponent> Children => _children.Select(u => Owner.EntityManager.GetEntity(u).Transform);
 
         /// <inheritdoc />
-        public Vector2 LerpDestination
-        {
-            get
-            {
-                return _nextPosition;
-            }
-        }
+        public Vector2 LerpDestination => _nextPosition;
 
         /// <inheritdoc />
         public override void OnRemove()
         {
-            DebugTools.Assert(IoCManager.Resolve<IGameTiming>().InSimulation);
-
             DetachParent();
 
             foreach (var child in _children.ToArray())
@@ -312,8 +300,6 @@ namespace SS14.Shared.GameObjects.Components.Transform
         /// </summary>
         public virtual void DetachParent()
         {
-            DebugTools.Assert(IoCManager.Resolve<IGameTiming>().InSimulation);
-
             // nothing to do
             if (Parent == null)
                 return;

--- a/SS14.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/SS14.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -279,7 +279,16 @@ namespace SS14.Shared.GameObjects.Components.Transform
 
         [ViewVariables]
         public IEnumerable<ITransformComponent> Children => _children.Select(u => Owner.EntityManager.GetEntity(u).Transform);
-        
+
+        /// <inheritdoc />
+        public Vector2 LerpDestination
+        {
+            get
+            {
+                return _nextPosition;
+            }
+        }
+
         /// <inheritdoc />
         public override void OnRemove()
         {

--- a/SS14.Shared/GameObjects/Entity.cs
+++ b/SS14.Shared/GameObjects/Entity.cs
@@ -377,37 +377,68 @@ namespace SS14.Shared.GameObjects
 
         #region GameState
 
+        private readonly Dictionary<uint, (ComponentState curState, ComponentState nextState)> _compStateWork
+            = new Dictionary<uint, (ComponentState curState, ComponentState nextState)>();
+
         /// <summary>
         ///     Applies an entity state to this entity.
         /// </summary>
         /// <param name="curState">State to apply.</param>
         internal void HandleEntityState(EntityState curState, EntityState nextState)
         {
-            Name = curState.StateData.Name;
-            var synchedComponentTypes = curState.StateData.SynchedComponentTypes;
-            foreach (var t in synchedComponentTypes)
-            {
-                if (HasComponent(t.Item1) && GetComponent(t.Item1).Name != t.Item2)
-                    RemoveComponent(GetComponent(t.Item1));
+            _compStateWork.Clear();
 
-                if (!HasComponent(t.Item1))
+            if (curState != null)
+            {
+                Name = curState.StateData.Name;
+                var synchedComponentTypes = curState.StateData.SynchedComponentTypes;
+                foreach (var t in synchedComponentTypes)
                 {
-                    var newComp = (Component)IoCManager.Resolve<IComponentFactory>().GetComponent(t.Item2);
-                    newComp.Owner = this;
-                    AddComponent(newComp, true);
+                    if (HasComponent(t.Item1) && GetComponent(t.Item1).Name != t.Item2)
+                        RemoveComponent(GetComponent(t.Item1));
+
+                    if (!HasComponent(t.Item1))
+                    {
+                        var newComp = (Component) IoCManager.Resolve<IComponentFactory>().GetComponent(t.Item2);
+                        newComp.Owner = this;
+                        AddComponent(newComp, true);
+                    }
+                }
+                
+                foreach (var compState in curState.ComponentStates)
+                {
+                    _compStateWork[compState.NetID] = (compState, null);
                 }
             }
 
-            foreach (var compState in curState.ComponentStates)
+            if(nextState?.ComponentStates != null)
             {
-                if (!TryGetComponent(compState.NetID, out var component))
-                    continue;
+                foreach (var compState in nextState.ComponentStates)
+                {
+                    if (_compStateWork.TryGetValue(compState.NetID, out var state))
+                    {
+                        _compStateWork[compState.NetID] = (state.curState, compState);
+                    }
+                    else
+                    {
+                        _compStateWork[compState.NetID] = (null, compState);
+                    }
+                }
+            }
 
-                if (compState.GetType() != component.StateType)
-                    throw new InvalidOperationException($"Incorrect component state type: {component.StateType}, component: {component.GetType()}");
-
-                var nextCompState = nextState?.ComponentStates?.Find(s => s.NetID == compState.NetID);
-                component.HandleComponentState(compState, nextCompState);
+            foreach (var kvStates in _compStateWork)
+            {
+                if (TryGetComponent(kvStates.Key, out var component))
+                {
+                    if (kvStates.Value.curState == null || kvStates.Value.curState.GetType() == component.StateType)
+                    {
+                        component.HandleComponentState(kvStates.Value.curState, kvStates.Value.nextState);
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException($"Incorrect component state type: {component.StateType}, component: {component.GetType()}");
+                    }
+                }
             }
         }
 

--- a/SS14.Shared/GameObjects/Entity.cs
+++ b/SS14.Shared/GameObjects/Entity.cs
@@ -5,6 +5,7 @@ using SS14.Shared.Interfaces.GameObjects;
 using SS14.Shared.Interfaces.Network;
 using SS14.Shared.IoC;
 using SS14.Shared.Interfaces.GameObjects.Components;
+using SS14.Shared.Timing;
 using SS14.Shared.ViewVariables;
 
 namespace SS14.Shared.GameObjects
@@ -47,7 +48,7 @@ namespace SS14.Shared.GameObjects
 
         /// <inheritdoc />
         [ViewVariables]
-        public uint LastModifiedTick { get; private set; }
+        public GameTick LastModifiedTick { get; private set; }
 
         /// <inheritdoc />
         [ViewVariables(VVAccess.ReadWrite)]
@@ -412,7 +413,7 @@ namespace SS14.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public EntityState GetEntityState(uint fromTick)
+        public EntityState GetEntityState(GameTick fromTick)
         {
             var compStates = GetComponentStates(fromTick);
 
@@ -433,7 +434,7 @@ namespace SS14.Shared.GameObjects
         ///     Server-side method to get the state of all our components
         /// </summary>
         /// <returns></returns>
-        private List<ComponentState> GetComponentStates(uint fromTick)
+        private List<ComponentState> GetComponentStates(GameTick fromTick)
         {
             return GetComponentInstances()
                 .Where(c => c.NetID != null && c.NetSyncEnabled && c.LastModifiedTick >= fromTick)

--- a/SS14.Shared/GameObjects/Entity.cs
+++ b/SS14.Shared/GameObjects/Entity.cs
@@ -400,8 +400,6 @@ namespace SS14.Shared.GameObjects
 
             foreach (var compState in state.ComponentStates)
             {
-                compState.ReceivedTime = state.ReceivedTime;
-
                 if (!TryGetComponent(compState.NetID, out var component))
                     continue;
 

--- a/SS14.Shared/GameObjects/Entity.cs
+++ b/SS14.Shared/GameObjects/Entity.cs
@@ -380,11 +380,11 @@ namespace SS14.Shared.GameObjects
         /// <summary>
         ///     Applies an entity state to this entity.
         /// </summary>
-        /// <param name="state">State to apply.</param>
-        internal void HandleEntityState(EntityState state)
+        /// <param name="curState">State to apply.</param>
+        internal void HandleEntityState(EntityState curState, EntityState nextState)
         {
-            Name = state.StateData.Name;
-            var synchedComponentTypes = state.StateData.SynchedComponentTypes;
+            Name = curState.StateData.Name;
+            var synchedComponentTypes = curState.StateData.SynchedComponentTypes;
             foreach (var t in synchedComponentTypes)
             {
                 if (HasComponent(t.Item1) && GetComponent(t.Item1).Name != t.Item2)
@@ -398,7 +398,7 @@ namespace SS14.Shared.GameObjects
                 }
             }
 
-            foreach (var compState in state.ComponentStates)
+            foreach (var compState in curState.ComponentStates)
             {
                 if (!TryGetComponent(compState.NetID, out var component))
                     continue;
@@ -406,7 +406,8 @@ namespace SS14.Shared.GameObjects
                 if (compState.GetType() != component.StateType)
                     throw new InvalidOperationException($"Incorrect component state type: {component.StateType}, component: {component.GetType()}");
 
-                component.HandleComponentState(compState);
+                var nextCompState = nextState?.ComponentStates?.Find(s => s.NetID == compState.NetID);
+                component.HandleComponentState(compState, nextCompState);
             }
         }
 

--- a/SS14.Shared/GameObjects/EntityManager.cs
+++ b/SS14.Shared/GameObjects/EntityManager.cs
@@ -9,6 +9,7 @@ using SS14.Shared.Map;
 using SS14.Shared.Maths;
 using SS14.Shared.Network.Messages;
 using SS14.Shared.Prototypes;
+using SS14.Shared.Timing;
 using SS14.Shared.Utility;
 
 namespace SS14.Shared.GameObjects
@@ -42,7 +43,7 @@ namespace SS14.Shared.GameObjects
         #endregion Dependencies
 
         /// <inheritdoc />
-        public uint CurrentTick => _gameTiming.CurTick;
+        public GameTick CurrentTick => _gameTiming.CurTick;
 
         /// <inheritdoc />
         public IComponentManager ComponentManager => _componentManager;

--- a/SS14.Shared/GameObjects/EntityState.cs
+++ b/SS14.Shared/GameObjects/EntityState.cs
@@ -8,15 +8,7 @@ namespace SS14.Shared.GameObjects
     public class EntityState
     {
         public EntityStateData StateData { get; set; }
-        [NonSerialized]
-        private float _receivedTime;
         public List<ComponentState> ComponentStates { get; }
-
-        public float ReceivedTime
-        {
-            get => _receivedTime;
-            set => _receivedTime = value;
-        }
 
         public EntityState(EntityUid uid, List<ComponentState> componentStates, string templateName, string name, List<Tuple<uint, string>> synchedComponentTypes)
         {

--- a/SS14.Shared/GameStates/GameState.cs
+++ b/SS14.Shared/GameStates/GameState.cs
@@ -2,6 +2,7 @@
 using SS14.Shared.Serialization;
 using System;
 using System.Collections.Generic;
+using SS14.Shared.Timing;
 
 namespace SS14.Shared.GameStates
 {
@@ -19,7 +20,7 @@ namespace SS14.Shared.GameStates
         /// <summary>
         /// Constructor!
         /// </summary>
-        public GameState(uint fromSequence, uint toSequence, List<EntityState> entities, List<PlayerState> players, List<EntityUid> deletions, GameStateMapData mapData)
+        public GameState(GameTick fromSequence, GameTick toSequence, List<EntityState> entities, List<PlayerState> players, List<EntityUid> deletions, GameStateMapData mapData)
         {
             FromSequence = fromSequence;
             ToSequence = toSequence;
@@ -29,8 +30,8 @@ namespace SS14.Shared.GameStates
             MapData = mapData;
         }
 
-        public readonly uint FromSequence;
-        public readonly uint ToSequence;
+        public readonly GameTick FromSequence;
+        public readonly GameTick ToSequence;
 
         public readonly List<EntityState> EntityStates;
         public readonly List<PlayerState> PlayerStates;

--- a/SS14.Shared/GameStates/GameState.cs
+++ b/SS14.Shared/GameStates/GameState.cs
@@ -9,13 +9,12 @@ namespace SS14.Shared.GameStates
     [Serializable, NetSerializable]
     public class GameState
     {
-        [NonSerialized] private float _gameTime;
-
-        public float GameTime
-        {
-            get => _gameTime;
-            set => _gameTime = value;
-        }
+        /// <summary>
+        ///     An extrapolated state that was created artificially by the client.
+        ///     It does not contain any real data from the server.
+        /// </summary>
+        [field:NonSerialized]
+        public bool Extrapolated { get; set; }
 
         /// <summary>
         /// Constructor!

--- a/SS14.Shared/Input/InputCmdMessage.cs
+++ b/SS14.Shared/Input/InputCmdMessage.cs
@@ -2,6 +2,7 @@
 using SS14.Shared.GameObjects;
 using SS14.Shared.Map;
 using SS14.Shared.Serialization;
+using SS14.Shared.Timing;
 
 namespace SS14.Shared.Input
 {
@@ -14,7 +15,7 @@ namespace SS14.Shared.Input
         /// <summary>
         ///     Client tick this was created.
         /// </summary>
-        public uint Tick { get; }
+        public GameTick Tick { get; }
 
         /// <summary>
         ///     The function this command is changing.
@@ -26,7 +27,7 @@ namespace SS14.Shared.Input
         /// </summary>
         /// <param name="tick">Client tick this was created.</param>
         /// <param name="inputFunctionId">Function this command is changing.</param>
-        public InputCmdMessage(uint tick, KeyFunctionId inputFunctionId)
+        public InputCmdMessage(GameTick tick, KeyFunctionId inputFunctionId)
         {
             Tick = tick;
             InputFunctionId = inputFunctionId;
@@ -50,7 +51,7 @@ namespace SS14.Shared.Input
         /// <param name="tick">Client tick this was created.</param>
         /// <param name="inputFunctionId">Function this command is changing.</param>
         /// <param name="state">New state of the Input Function.</param>
-        public StateInputCmdMessage(uint tick, KeyFunctionId inputFunctionId, BoundKeyState state)
+        public StateInputCmdMessage(GameTick tick, KeyFunctionId inputFunctionId, BoundKeyState state)
             : base(tick, inputFunctionId)
         {
             State = state;
@@ -68,7 +69,7 @@ namespace SS14.Shared.Input
         /// </summary>
         /// <param name="tick">Client tick this was created.</param>
         /// <param name="inputFunctionId">Function this command is changing.</param>
-        public EventInputCmdMessage(uint tick, KeyFunctionId inputFunctionId)
+        public EventInputCmdMessage(GameTick tick, KeyFunctionId inputFunctionId)
             : base(tick, inputFunctionId) { }
     }
 
@@ -94,7 +95,7 @@ namespace SS14.Shared.Input
         /// <param name="tick">Client tick this was created.</param>
         /// <param name="inputFunctionId">Function this command is changing.</param>
         /// <param name="coordinates">Local Coordinates of the pointer when the command was created.</param>
-        public PointerInputCmdMessage(uint tick, KeyFunctionId inputFunctionId, GridCoordinates coordinates)
+        public PointerInputCmdMessage(GameTick tick, KeyFunctionId inputFunctionId, GridCoordinates coordinates)
             : this(tick, inputFunctionId, coordinates, EntityUid.Invalid) { }
 
         /// <summary>
@@ -104,7 +105,7 @@ namespace SS14.Shared.Input
         /// <param name="inputFunctionId">Function this command is changing.</param>
         /// <param name="coordinates">Local Coordinates of the pointer when the command was created.</param>
         /// <param name="uid">Entity that was under the pointer when the command was created.</param>
-        public PointerInputCmdMessage(uint tick, KeyFunctionId inputFunctionId, GridCoordinates coordinates, EntityUid uid)
+        public PointerInputCmdMessage(GameTick tick, KeyFunctionId inputFunctionId, GridCoordinates coordinates, EntityUid uid)
             : base(tick, inputFunctionId)
         {
             Coordinates = coordinates;
@@ -145,7 +146,8 @@ namespace SS14.Shared.Input
         /// <param name="inputFunctionId">Function this command is changing.</param>
         /// <param name="state">New state of the Input Function.</param>
         /// <param name="coordinates">Local Coordinates of the pointer when the command was created.</param>
-        public FullInputCmdMessage(uint tick, KeyFunctionId inputFunctionId, BoundKeyState state, GridCoordinates coordinates, ScreenCoordinates screenCoordinates)
+        /// <param name="screenCoordinates"></param>
+        public FullInputCmdMessage(GameTick tick, KeyFunctionId inputFunctionId, BoundKeyState state, GridCoordinates coordinates, ScreenCoordinates screenCoordinates)
             : this(tick, inputFunctionId, state, coordinates, screenCoordinates, EntityUid.Invalid) { }
 
         /// <summary>
@@ -155,8 +157,9 @@ namespace SS14.Shared.Input
         /// <param name="inputFunctionId">Function this command is changing.</param>
         /// <param name="state">New state of the Input Function.</param>
         /// <param name="coordinates">Local Coordinates of the pointer when the command was created.</param>
+        /// <param name="screenCoordinates"></param>
         /// <param name="uid">Entity that was under the pointer when the command was created.</param>
-        public FullInputCmdMessage(uint tick, KeyFunctionId inputFunctionId, BoundKeyState state, GridCoordinates coordinates, ScreenCoordinates screenCoordinates, EntityUid uid)
+        public FullInputCmdMessage(GameTick tick, KeyFunctionId inputFunctionId, BoundKeyState state, GridCoordinates coordinates, ScreenCoordinates screenCoordinates, EntityUid uid)
             : base(tick, inputFunctionId)
         {
             State = state;

--- a/SS14.Shared/Interfaces/GameObjects/Components/ITransformComponent.cs
+++ b/SS14.Shared/Interfaces/GameObjects/Components/ITransformComponent.cs
@@ -82,6 +82,11 @@ namespace SS14.Shared.Interfaces.GameObjects.Components
         bool VisibleWhileParented { get; set; }
 
         /// <summary>
+        ///
+        /// </summary>
+        Vector2 LerpDestination { get; }
+
+        /// <summary>
         ///     Finds the transform located on the map or in nullspace
         /// </summary>
         ITransformComponent GetMapTransform();

--- a/SS14.Shared/Interfaces/GameObjects/Components/ITransformComponent.cs
+++ b/SS14.Shared/Interfaces/GameObjects/Components/ITransformComponent.cs
@@ -37,11 +37,6 @@ namespace SS14.Shared.Interfaces.GameObjects.Components
         MapCoordinates MapPosition { get; }
 
         /// <summary>
-        ///     Invoked when the entity is rotated.
-        /// </summary>
-        event Action<Angle> OnRotate;
-
-        /// <summary>
         ///     Current rotation offset of the entity.
         /// </summary>
         Angle LocalRotation { get; set; }

--- a/SS14.Shared/Interfaces/GameObjects/IComponent.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IComponent.cs
@@ -3,7 +3,6 @@ using SS14.Shared.GameObjects;
 using SS14.Shared.Interfaces.Network;
 using SS14.Shared.Serialization;
 using SS14.Shared.Timing;
-using YamlDotNet.RepresentationModel;
 
 namespace SS14.Shared.Interfaces.GameObjects
 {
@@ -129,7 +128,8 @@ namespace SS14.Shared.Interfaces.GameObjects
         /// <summary>
         ///     Handles an incoming component state from the server.
         /// </summary>
-        /// <param name="state"></param>
-        void HandleComponentState(ComponentState state);
+        /// <param name="curState"></param>
+        /// <param name="nextState"></param>
+        void HandleComponentState(ComponentState curState, ComponentState nextState);
     }
 }

--- a/SS14.Shared/Interfaces/GameObjects/IComponent.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IComponent.cs
@@ -2,6 +2,7 @@
 using SS14.Shared.GameObjects;
 using SS14.Shared.Interfaces.Network;
 using SS14.Shared.Serialization;
+using SS14.Shared.Timing;
 using YamlDotNet.RepresentationModel;
 
 namespace SS14.Shared.Interfaces.GameObjects
@@ -76,7 +77,7 @@ namespace SS14.Shared.Interfaces.GameObjects
         /// <summary>
         ///     This is the last game tick Dirty() was called.
         /// </summary>
-        uint LastModifiedTick { get; }
+        GameTick LastModifiedTick { get; }
 
         /// <summary>
         ///     Called when the component is removed from an entity.

--- a/SS14.Shared/Interfaces/GameObjects/IComponent.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IComponent.cs
@@ -2,6 +2,7 @@
 using SS14.Shared.GameObjects;
 using SS14.Shared.Interfaces.Network;
 using SS14.Shared.Serialization;
+using SS14.Shared.Timing;
 
 namespace SS14.Shared.Interfaces.GameObjects
 {

--- a/SS14.Shared/Interfaces/GameObjects/IEntity.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IEntity.cs
@@ -3,13 +3,13 @@ using System.Collections.Generic;
 using SS14.Shared.GameObjects;
 using SS14.Shared.Interfaces.GameObjects.Components;
 using SS14.Shared.Interfaces.Network;
-using SS14.Shared.Interfaces.Serialization;
+using SS14.Shared.Timing;
 
 namespace SS14.Shared.Interfaces.GameObjects
 {
     public interface IEntity
     {
-        uint LastModifiedTick { get; }
+        GameTick LastModifiedTick { get; }
 
         IEntityManager EntityManager { get; }
 
@@ -204,7 +204,7 @@ namespace SS14.Shared.Interfaces.GameObjects
         ///     Serverside method to prepare an entity state object
         /// </summary>
         /// <returns></returns>
-        EntityState GetEntityState(uint fromTick);
+        EntityState GetEntityState(GameTick fromTick);
 
         void SubscribeEvent<T>(EntityEventHandler<EntityEventArgs> evh, IEntityEventSubscriber s)
             where T : EntityEventArgs;

--- a/SS14.Shared/Interfaces/GameObjects/IEntityManager.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IEntityManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using SS14.Shared.GameObjects;
 using SS14.Shared.Map;
 using SS14.Shared.Maths;
+using SS14.Shared.Timing;
 
 namespace SS14.Shared.Interfaces.GameObjects
 {
@@ -11,7 +12,7 @@ namespace SS14.Shared.Interfaces.GameObjects
         /// <summary>
         ///     The current simulation tick being processed.
         /// </summary>
-        uint CurrentTick { get; }
+        GameTick CurrentTick { get; }
 
         void Initialize();
         void Startup();

--- a/SS14.Shared/Interfaces/Map/IMapManager.cs
+++ b/SS14.Shared/Interfaces/Map/IMapManager.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using SS14.Shared.GameStates;
-using SS14.Shared.Interfaces.Network;
 using SS14.Shared.Map;
+using SS14.Shared.Timing;
 
 namespace SS14.Shared.Interfaces.Map
 {
@@ -100,8 +100,8 @@ namespace SS14.Shared.Interfaces.Map
         /// </summary>
         event EventHandler<MapEventArgs> MapDestroyed;
 
-        GameStateMapData GetStateData(uint fromTick);
-        void CullDeletionHistory(uint uptoTick);
+        GameStateMapData GetStateData(GameTick fromTick);
+        void CullDeletionHistory(GameTick uptoTick);
 
         // Two methods here, so that new grids etc can be made BEFORE entities get states applied,
         // but old ones can be deleted after.

--- a/SS14.Shared/Interfaces/Network/INetManager.cs
+++ b/SS14.Shared/Interfaces/Network/INetManager.cs
@@ -30,7 +30,7 @@ namespace SS14.Shared.Interfaces.Network
         bool IsConnected { get; }
 
         /// <summary>
-        ///     Network traffic statistics for the locl NetChannel.
+        ///     Network traffic statistics for the local NetChannel.
         /// </summary>
         NetworkStats Statistics { get; }
 

--- a/SS14.Shared/Interfaces/Timing/IGameTiming.cs
+++ b/SS14.Shared/Interfaces/Timing/IGameTiming.cs
@@ -83,6 +83,14 @@ namespace SS14.Shared.Interfaces.Timing
         TimeSpan TickRemainder { get; set; }
 
         /// <summary>
+        /// If the client simulation has lagged and the states are backed up in the queue, the
+        /// the RealTime between ticks needs to temporarily increase to clean out the queue. This allows the
+        /// client to catch up with the server, otherwise it will forever run behind the server.
+        /// Note that this does no change any in-simulation timing.
+        /// </summary>
+        bool FastForward { get; set; }
+
+        /// <summary>
         ///     Ends the 'lap' of the timer, updating frame time info.
         /// </summary>
         void StartFrame();

--- a/SS14.Shared/Interfaces/Timing/IGameTiming.cs
+++ b/SS14.Shared/Interfaces/Timing/IGameTiming.cs
@@ -83,12 +83,14 @@ namespace SS14.Shared.Interfaces.Timing
         TimeSpan TickRemainder { get; set; }
 
         /// <summary>
-        /// If the client simulation has lagged and the states are backed up in the queue, the
-        /// the RealTime between ticks needs to temporarily increase to clean out the queue. This allows the
-        /// client to catch up with the server, otherwise it will forever run behind the server.
-        /// Note that this does no change any in-simulation timing.
+        ///     If the client clock is a little behind or ahead of the server, you can
+        ///     use the to adjust the timing of the clock speed. The default value is 0,
+        ///     and you can run the clock from -1 (almost stopped) to 1 (almost no delay).
+        ///     This has no effect on in-simulation timing, and only changes the speed at which
+        ///     the simulation progresses in relation to Real time. Don't mess with this unless
+        ///     you know what you are doing. DO NOT TOUCH THIS ON SERVER.
         /// </summary>
-        bool FastForward { get; set; }
+        float TickTimingAdjustment { get; set; }
 
         /// <summary>
         ///     Ends the 'lap' of the timer, updating frame time info.

--- a/SS14.Shared/Interfaces/Timing/IGameTiming.cs
+++ b/SS14.Shared/Interfaces/Timing/IGameTiming.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using SS14.Shared.Timing;
 
 namespace SS14.Shared.Interfaces.Timing
 {
@@ -64,7 +65,7 @@ namespace SS14.Shared.Interfaces.Timing
         /// <summary>
         ///     The current simulation tick being processed.
         /// </summary>
-        uint CurTick { get; set; }
+        GameTick CurTick { get; set; }
 
         /// <summary>
         ///     The target ticks/second of the simulation.

--- a/SS14.Shared/Interfaces/Timing/IGameTiming.cs
+++ b/SS14.Shared/Interfaces/Timing/IGameTiming.cs
@@ -70,7 +70,7 @@ namespace SS14.Shared.Interfaces.Timing
         /// <summary>
         ///     The target ticks/second of the simulation.
         /// </summary>
-        int TickRate { get; set; }
+        byte TickRate { get; set; }
 
         /// <summary>
         ///     The length of a tick at the current TickRate. 1/TickRate.

--- a/SS14.Shared/Map/MapManager.Chunk.cs
+++ b/SS14.Shared/Map/MapManager.Chunk.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using SS14.Shared.GameObjects.Components.Transform;
 using SS14.Shared.Interfaces.Map;
 using SS14.Shared.Maths;
+using SS14.Shared.Timing;
 
 namespace SS14.Shared.Map
 {
@@ -15,7 +15,7 @@ namespace SS14.Shared.Map
         /// </summary>
         internal class Chunk : IMapChunk
         {
-            internal uint LastModifiedTick { get; private set; }
+            internal GameTick LastModifiedTick { get; private set; }
             private readonly MapGrid _grid;
             private readonly MapIndices _gridIndices;
             private readonly MapManager _mapManager;

--- a/SS14.Shared/Map/MapManager.Map.cs
+++ b/SS14.Shared/Map/MapManager.Map.cs
@@ -1,6 +1,7 @@
 ﻿using SS14.Shared.Interfaces.Map;
 using SS14.Shared.Maths;
 using System.Collections.Generic;
+using SS14.Shared.Timing;
 
 namespace SS14.Shared.Map
 {
@@ -8,7 +9,7 @@ namespace SS14.Shared.Map
     {
         class Map : IMap
         {
-            public uint CreatedTick { get; }
+            public GameTick CreatedTick { get; }
             public IMapGrid DefaultGrid { get; set; }
             public MapId Index { get; }
             private readonly MapManager _mapManager;

--- a/SS14.Shared/Map/MapManager.MapGrid.cs
+++ b/SS14.Shared/Map/MapManager.MapGrid.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using SS14.Shared.GameObjects.Components.Transform;
 using SS14.Shared.Interfaces.Map;
 using SS14.Shared.Maths;
+using SS14.Shared.Timing;
 
 namespace SS14.Shared.Map
 {
@@ -10,8 +11,8 @@ namespace SS14.Shared.Map
     {
         public class MapGrid : IMapGrid
         {
-            public uint CreatedTick { get; }
-            public uint LastModifiedTick { get; internal set; }
+            public GameTick CreatedTick { get; }
+            public GameTick LastModifiedTick { get; internal set; }
             public bool IsDefaultGrid => Map.DefaultGrid == this;
             public IMap Map => _mapManager.GetMap(MapID);
             public MapId MapID { get; private set; }

--- a/SS14.Shared/Map/MapManager.Network.cs
+++ b/SS14.Shared/Map/MapManager.Network.cs
@@ -10,6 +10,7 @@ using SS14.Shared.Interfaces.Network;
 using SS14.Shared.IoC;
 using SS14.Shared.Log;
 using SS14.Shared.Network.Messages;
+using SS14.Shared.Timing;
 using SS14.Shared.Utility;
 
 namespace SS14.Shared.Map
@@ -18,7 +19,7 @@ namespace SS14.Shared.Map
     {
         [Dependency] private readonly INetManager _netManager;
 
-        public GameStateMapData GetStateData(uint fromTick)
+        public GameStateMapData GetStateData(GameTick fromTick)
         {
             var gridDatums = new Dictionary<GridId, GameStateMapData.GridDatum>();
             foreach (var grid in _grids.Values)
@@ -67,7 +68,7 @@ namespace SS14.Shared.Map
             return new GameStateMapData(gridDatums, gridDeletionsData, mapDeletionsData, mapCreations, gridCreations);
         }
 
-        public void CullDeletionHistory(uint uptoTick)
+        public void CullDeletionHistory(GameTick uptoTick)
         {
             _mapDeletionHistory.RemoveAll(t => t.tick < uptoTick);
             _gridDeletionHistory.RemoveAll(t => t.tick < uptoTick);

--- a/SS14.Shared/Map/MapManager.Network.cs
+++ b/SS14.Shared/Map/MapManager.Network.cs
@@ -78,6 +78,10 @@ namespace SS14.Shared.Map
         {
             DebugTools.Assert(_netManager.IsClient, "Only the client should call this.");
 
+            // There was no map data this tick, so nothing to do.
+            if(data == null)
+                return;
+
             // First we need to figure out all the NEW MAPS.
             // And make their default grids too.
             foreach (var (mapId, gridId) in data.CreatedMaps)
@@ -150,6 +154,9 @@ namespace SS14.Shared.Map
         public void ApplyGameStatePost(GameStateMapData data)
         {
             DebugTools.Assert(_netManager.IsClient, "Only the client should call this.");
+
+            if(data == null) // if there is no data, there is nothing to do!
+                return;
 
             foreach (var grid in data.DeletedGrids)
             {

--- a/SS14.Shared/Map/MapManager.cs
+++ b/SS14.Shared/Map/MapManager.cs
@@ -1,13 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using SS14.Shared.Enums;
 using SS14.Shared.Interfaces.Map;
 using SS14.Shared.Interfaces.Timing;
 using SS14.Shared.IoC;
-using SS14.Shared.Log;
-using SS14.Shared.Maths;
-using SS14.Shared.Network.Messages;
+using SS14.Shared.Timing;
 using SS14.Shared.Utility;
 
 namespace SS14.Shared.Map
@@ -53,8 +50,8 @@ namespace SS14.Shared.Map
 
         private readonly Dictionary<GridId, MapGrid> _grids = new Dictionary<GridId, MapGrid>();
 
-        private readonly List<(uint tick, GridId gridId)> _gridDeletionHistory = new List<(uint, GridId)>();
-        private readonly List<(uint tick, MapId mapId)> _mapDeletionHistory = new List<(uint, MapId)>();
+        private readonly List<(GameTick tick, GridId gridId)> _gridDeletionHistory = new List<(GameTick, GridId)>();
+        private readonly List<(GameTick tick, MapId mapId)> _mapDeletionHistory = new List<(GameTick, MapId)>();
 
         public void PostInject()
         {

--- a/SS14.Shared/Network/Messages/MsgServerInfo.cs
+++ b/SS14.Shared/Network/Messages/MsgServerInfo.cs
@@ -1,6 +1,5 @@
 ﻿using Lidgren.Network;
 using SS14.Shared.Interfaces.Network;
-using SS14.Shared.Players;
 
 namespace SS14.Shared.Network.Messages
 {
@@ -14,12 +13,14 @@ namespace SS14.Shared.Network.Messages
 
         public string ServerName { get; set; }
         public int ServerMaxPlayers { get; set; }
+        public byte TickRate { get; set; }
         public NetSessionId PlayerSessionId { get; set; }
 
         public override void ReadFromBuffer(NetIncomingMessage buffer)
         {
             ServerName = buffer.ReadString();
             ServerMaxPlayers = buffer.ReadInt32();
+            TickRate = buffer.ReadByte();
             PlayerSessionId = new NetSessionId(buffer.ReadString());
         }
 
@@ -27,6 +28,7 @@ namespace SS14.Shared.Network.Messages
         {
             buffer.Write(ServerName);
             buffer.Write(ServerMaxPlayers);
+            buffer.Write(TickRate);
             buffer.Write(PlayerSessionId.Username);
         }
     }

--- a/SS14.Shared/Network/Messages/MsgState.cs
+++ b/SS14.Shared/Network/Messages/MsgState.cs
@@ -1,5 +1,4 @@
-﻿using ICSharpCode.SharpZipLib.GZip;
-using Lidgren.Network;
+﻿using Lidgren.Network;
 using SS14.Shared.GameStates;
 using SS14.Shared.Interfaces.Network;
 using SS14.Shared.Interfaces.Serialization;
@@ -20,6 +19,7 @@ namespace SS14.Shared.Network.Messages
 
         public override void ReadFromBuffer(NetIncomingMessage buffer)
         {
+            MsgSize = buffer.LengthBytes;
             var length = buffer.ReadInt32();
             var stateData = buffer.ReadBytes(length);
             using (var stateStream = new MemoryStream(stateData))
@@ -38,6 +38,7 @@ namespace SS14.Shared.Network.Messages
                 buffer.Write((int)stateStream.Length);
                 buffer.Write(stateStream.ToArray());
             }
+            MsgSize = buffer.LengthBytes;
         }
     }
 }

--- a/SS14.Shared/Network/Messages/MsgStateAck.cs
+++ b/SS14.Shared/Network/Messages/MsgStateAck.cs
@@ -1,5 +1,6 @@
 ﻿using Lidgren.Network;
 using SS14.Shared.Interfaces.Network;
+using SS14.Shared.Timing;
 
 namespace SS14.Shared.Network.Messages
 {
@@ -11,16 +12,16 @@ namespace SS14.Shared.Network.Messages
         public MsgStateAck(INetChannel channel) : base(NAME, GROUP) { }
         #endregion
 
-        public uint Sequence { get; set; }
+        public GameTick Sequence { get; set; }
 
         public override void ReadFromBuffer(NetIncomingMessage buffer)
         {
-            Sequence = buffer.ReadUInt32();
+            Sequence = new GameTick(buffer.ReadUInt32());
         }
 
         public override void WriteToBuffer(NetOutgoingMessage buffer)
         {
-            buffer.Write(Sequence);
+            buffer.Write(Sequence.Value);
         }
     }
 }

--- a/SS14.Shared/Network/NetManager.cs
+++ b/SS14.Shared/Network/NetManager.cs
@@ -147,7 +147,6 @@ namespace SS14.Shared.Network
                 _config.RegisterCVar("net.server", "127.0.0.1", CVar.ARCHIVE);
                 _config.RegisterCVar("net.updaterate", 20, CVar.ARCHIVE);
                 _config.RegisterCVar("net.cmdrate", 30, CVar.ARCHIVE);
-                _config.RegisterCVar("net.interpolation", 0.1f, CVar.ARCHIVE);
                 _config.RegisterCVar("net.rate", 10240, CVar.REPLICATED | CVar.ARCHIVE);
             }
             else

--- a/SS14.Shared/Network/NetMessage.cs
+++ b/SS14.Shared/Network/NetMessage.cs
@@ -55,6 +55,11 @@ namespace SS14.Shared.Network
         public INetChannel MsgChannel { get; set; }
 
         /// <summary>
+        ///     The size of this packet in bytes.
+        /// </summary>
+        public int MsgSize { get; set; }
+
+        /// <summary>
         /// Constructs an instance of the NetMessage.
         /// </summary>
         /// <param name="name">String identifier of the message type.</param>

--- a/SS14.Shared/SS14.Shared.csproj
+++ b/SS14.Shared/SS14.Shared.csproj
@@ -237,6 +237,7 @@
     <Compile Include="Players\ICommonSession.cs" />
     <Compile Include="Timing\FrameEventArgs.cs" />
     <Compile Include="Timing\GameLoop.cs" />
+    <Compile Include="Timing\GameTick.cs" />
     <Compile Include="Timing\IStopwatch.cs" />
     <Compile Include="Timing\Stopwatch.cs" />
     <Compile Include="Utility\DebugTools.cs" />

--- a/SS14.Shared/Timing/GameLoop.cs
+++ b/SS14.Shared/Timing/GameLoop.cs
@@ -118,14 +118,18 @@ namespace SS14.Shared.Timing
 
                     // update the simulation
                     simFrameEvent.SetDeltaSeconds((float)_timing.FrameTime.TotalSeconds);
+#if RELEASE
                     try
                     {
+#endif
                         Tick?.Invoke(this, simFrameEvent);
+#if RELEASE
                     }
                     catch (Exception exp)
                     {
                         _runtimeLog.LogException(exp, "GameLoop Tick");
                     }
+#endif
                     _timing.CurTick = new GameTick(_timing.CurTick.Value + 1);
 
                     if (SingleStep)

--- a/SS14.Shared/Timing/GameLoop.cs
+++ b/SS14.Shared/Timing/GameLoop.cs
@@ -61,9 +61,6 @@ namespace SS14.Shared.Timing
 
             Running = true;
 
-            // maximum number of ticks to queue before the loop slows down.
-            var maxTime = TimeSpan.FromTicks(_timing.TickPeriod.Ticks * MaxQueuedTicks);
-
             var realFrameEvent = new MutableFrameEventArgs(0);
             var simFrameEvent = new MutableFrameEventArgs(0);
 
@@ -71,6 +68,8 @@ namespace SS14.Shared.Timing
 
             while (Running)
             {
+                // maximum number of ticks to queue before the loop slows down.
+                var maxTime = TimeSpan.FromTicks(_timing.TickPeriod.Ticks * MaxQueuedTicks);
 
                 var accumulator = _timing.RealTime - _lastTick;
 

--- a/SS14.Shared/Timing/GameLoop.cs
+++ b/SS14.Shared/Timing/GameLoop.cs
@@ -106,11 +106,20 @@ namespace SS14.Shared.Timing
                 }
                 _timing.InSimulation = true;
 
+                var extraTick = _timing.FastForward;
+
                 // run the simulation for every accumulated tick
                 while (accumulator >= _timing.TickPeriod)
                 {
-                    accumulator -= _timing.TickPeriod;
-                    _lastTick += _timing.TickPeriod;
+                    if(!extraTick)
+                    {
+                        accumulator -= _timing.TickPeriod;
+                        _lastTick += _timing.TickPeriod;
+                    }
+                    else
+                    {
+                        extraTick = false;
+                    }
 
                     // only run the simulation if unpaused, but still use up the accumulated time
                     if (_timing.Paused)

--- a/SS14.Shared/Timing/GameLoop.cs
+++ b/SS14.Shared/Timing/GameLoop.cs
@@ -127,7 +127,7 @@ namespace SS14.Shared.Timing
                     {
                         _runtimeLog.LogException(exp, "GameLoop Tick");
                     }
-                    _timing.CurTick++;
+                    _timing.CurTick = new GameTick(_timing.CurTick.Value + 1);
 
                     if (SingleStep)
                         _timing.Paused = true;

--- a/SS14.Shared/Timing/GameTick.cs
+++ b/SS14.Shared/Timing/GameTick.cs
@@ -1,0 +1,63 @@
+﻿using System;
+
+namespace SS14.Shared.Timing
+{
+    /// <summary>
+    ///     Wraps a game tick value.
+    /// </summary>
+    [Serializable]
+    public readonly struct GameTick : IEquatable<GameTick>, IComparable<GameTick>
+    {
+        public readonly uint Value;
+
+        /// <summary>
+        ///     Constructs a new instance of <c>GameTick</c>.
+        /// </summary>
+        /// <param name="value"></param>
+        public GameTick(uint value)
+        {
+            Value = value;
+        }
+
+        /// <inheritdoc />
+        public bool Equals(GameTick other)
+        {
+            return Value == other.Value;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            return obj is GameTick other && Equals(other);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return (int) Value;
+        }
+
+        /// <summary>
+        ///     Check for equality by value between two objects.
+        /// </summary>
+        public static bool operator ==(GameTick a, GameTick b)
+        {
+            return a.Value == b.Value;
+        }
+
+        /// <summary>
+        ///     Check for inequality by value between two objects.
+        /// </summary>
+        public static bool operator !=(GameTick a, GameTick b)
+        {
+            return a.Value != b.Value;
+        }
+
+        /// <inheritdoc />
+        public int CompareTo(GameTick other)
+        {
+            return Value.CompareTo(other.Value);
+        }
+    }
+}

--- a/SS14.Shared/Timing/GameTick.cs
+++ b/SS14.Shared/Timing/GameTick.cs
@@ -68,5 +68,11 @@ namespace SS14.Shared.Timing
         public static bool operator >=(GameTick a, GameTick b) => a.Value >= b.Value;
         public static bool operator <(GameTick a, GameTick b) => a.Value < b.Value;
         public static bool operator <=(GameTick a, GameTick b) => a.Value <= b.Value;
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
     }
 }

--- a/SS14.Shared/Timing/GameTick.cs
+++ b/SS14.Shared/Timing/GameTick.cs
@@ -1,13 +1,17 @@
 ﻿using System;
+using SS14.Shared.Serialization;
 
 namespace SS14.Shared.Timing
 {
     /// <summary>
     ///     Wraps a game tick value.
     /// </summary>
-    [Serializable]
+    [Serializable, NetSerializable]
     public readonly struct GameTick : IEquatable<GameTick>, IComparable<GameTick>
     {
+        public static readonly GameTick Zero = new GameTick(0);
+        public static readonly GameTick MaxValue = new GameTick(uint.MaxValue);
+
         public readonly uint Value;
 
         /// <summary>
@@ -59,5 +63,10 @@ namespace SS14.Shared.Timing
         {
             return Value.CompareTo(other.Value);
         }
+
+        public static bool operator >(GameTick a, GameTick b) => a.Value > b.Value;
+        public static bool operator >=(GameTick a, GameTick b) => a.Value >= b.Value;
+        public static bool operator <(GameTick a, GameTick b) => a.Value < b.Value;
+        public static bool operator <=(GameTick a, GameTick b) => a.Value <= b.Value;
     }
 }

--- a/SS14.Shared/Timing/GameTiming.cs
+++ b/SS14.Shared/Timing/GameTiming.cs
@@ -83,7 +83,7 @@ namespace SS14.Shared.Timing
         /// <summary>
         ///     The target ticks/second of the simulation.
         /// </summary>
-        public int TickRate { get; set; }
+        public byte TickRate { get; set; }
 
         /// <summary>
         ///     The length of a tick at the current TickRate. 1/TickRate.

--- a/SS14.Shared/Timing/GameTiming.cs
+++ b/SS14.Shared/Timing/GameTiming.cs
@@ -103,6 +103,9 @@ namespace SS14.Shared.Timing
         /// </summary>
         public uint CurFrame { get; set; } = 1;
 
+        /// <inheritdoc />
+        public bool FastForward { get; set; }
+
         /// <summary>
         ///     Ends the 'lap' of the timer, updating frame time info.
         /// </summary>

--- a/SS14.Shared/Timing/GameTiming.cs
+++ b/SS14.Shared/Timing/GameTiming.cs
@@ -78,7 +78,7 @@ namespace SS14.Shared.Timing
         /// <summary>
         ///     The current simulation tick being processed.
         /// </summary>
-        public uint CurTick { get; set; }
+        public GameTick CurTick { get; set; }
 
         /// <summary>
         ///     The target ticks/second of the simulation.
@@ -135,7 +135,7 @@ namespace SS14.Shared.Timing
         private TimeSpan CalcCurTime()
         {
             // calculate simulation CurTime
-            var time = TimeSpan.FromTicks(TickPeriod.Ticks * CurTick);
+            var time = TimeSpan.FromTicks(TickPeriod.Ticks * CurTick.Value);
 
             if (!InSimulation) // rendering can draw frames between ticks
                 return time + TickRemainder;

--- a/SS14.Shared/Timing/GameTiming.cs
+++ b/SS14.Shared/Timing/GameTiming.cs
@@ -104,7 +104,7 @@ namespace SS14.Shared.Timing
         public uint CurFrame { get; set; } = 1;
 
         /// <inheritdoc />
-        public bool FastForward { get; set; }
+        public float TickTimingAdjustment { get; set; } = 0;
 
         /// <summary>
         ///     Ends the 'lap' of the timer, updating frame time info.

--- a/SS14.UnitTesting/Client/GameObjects/Components/Transform_Test.cs
+++ b/SS14.UnitTesting/Client/GameObjects/Components/Transform_Test.cs
@@ -1,16 +1,12 @@
 ﻿using System.IO;
 using NUnit.Framework;
-using SS14.Client.GameObjects;
 using SS14.Client.Interfaces.GameObjects;
-using SS14.Server.GameObjects;
-using SS14.Server.Interfaces.GameObjects;
 using SS14.Shared.GameObjects;
 using SS14.Shared.GameObjects.Components.Transform;
 using SS14.Shared.Interfaces.GameObjects;
 using SS14.Shared.Interfaces.GameObjects.Components;
 using SS14.Shared.Interfaces.Map;
 using SS14.Shared.IoC;
-using SS14.Shared.Map;
 using SS14.Shared.Maths;
 using SS14.Shared.Prototypes;
 
@@ -75,16 +71,16 @@ namespace SS14.UnitTesting.Client.GameObjects.Components
             var childTrans = child.Transform;
 
             var compState = new TransformComponent.TransformComponentState(new Vector2(5, 5), GridB.Index, new Angle(0), EntityUid.Invalid);
-            parentTrans.HandleComponentState(compState);
+            parentTrans.HandleComponentState(compState, null);
 
             compState = new TransformComponent.TransformComponentState(new Vector2(6, 6), GridB.Index, new Angle(0), EntityUid.Invalid);
-            childTrans.HandleComponentState(compState);
+            childTrans.HandleComponentState(compState, null);
             // World pos should be 6, 6 now.
 
             // Act
             var oldWpos = childTrans.WorldPosition;
             compState = new TransformComponent.TransformComponentState(new Vector2(1, 1), GridB.Index, new Angle(0), parent.Uid);
-            childTrans.HandleComponentState(compState);
+            childTrans.HandleComponentState(compState, null);
             var newWpos = childTrans.WorldPosition;
 
             // Assert
@@ -111,11 +107,11 @@ namespace SS14.UnitTesting.Client.GameObjects.Components
             var node3Trans = node3.Transform;
 
             var compState = new TransformComponent.TransformComponentState(new Vector2(6, 6), GridB.Index, Angle.FromDegrees(135), EntityUid.Invalid);
-            node1Trans.HandleComponentState(compState);
+            node1Trans.HandleComponentState(compState, null);
             compState = new TransformComponent.TransformComponentState(new Vector2(1, 1), GridB.Index, Angle.FromDegrees(45), node1.Uid);
-            node2Trans.HandleComponentState(compState);
+            node2Trans.HandleComponentState(compState, null);
             compState = new TransformComponent.TransformComponentState(new Vector2(0, 0), GridB.Index, Angle.FromDegrees(45), node2.Uid);
-            node3Trans.HandleComponentState(compState);
+            node3Trans.HandleComponentState(compState, null);
 
             // Act
             var result = node3Trans.WorldRotation;

--- a/SS14.UnitTesting/SS14.UnitTesting.csproj
+++ b/SS14.UnitTesting/SS14.UnitTesting.csproj
@@ -67,7 +67,7 @@
     <PackageReference Include="Smocks.ExtensionPackage">
       <Version>0.7.5-beta2</Version>
     </PackageReference>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="YamlDotNet" Version="5.0.1" />

--- a/SS14.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
+++ b/SS14.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
@@ -5,6 +5,7 @@ using SS14.Server.Interfaces.GameObjects;
 using SS14.Shared.GameObjects.Components.Transform;
 using SS14.Shared.Interfaces.GameObjects.Components;
 using SS14.Shared.Interfaces.Map;
+using SS14.Shared.Interfaces.Timing;
 using SS14.Shared.IoC;
 using SS14.Shared.Map;
 using SS14.Shared.Maths;
@@ -41,7 +42,7 @@ namespace SS14.UnitTesting.Server.GameObjects.Components
             var manager = IoCManager.Resolve<IPrototypeManager>();
             manager.LoadFromStream(new StringReader(PROTOTYPES));
             manager.Resync();
-
+            
             // build the net dream
             MapA = MapManager.CreateMap();
             GridA = MapA.CreateGrid();
@@ -242,6 +243,8 @@ namespace SS14.UnitTesting.Server.GameObjects.Components
         [Test]
         public void ParentRotationRoundingErrorTest()
         {
+            IoCManager.Resolve<IGameTiming>().InSimulation = true;
+
             // Arrange
             var node1 = EntityManager.SpawnEntity("dummy");
             var node2 = EntityManager.SpawnEntity("dummy");

--- a/SS14.UnitTesting/Shared/Timing/GameLoop_Test.cs
+++ b/SS14.UnitTesting/Shared/Timing/GameLoop_Test.cs
@@ -35,7 +35,7 @@ namespace SS14.UnitTesting.Shared.Timing
 
             // Assert
             Assert.That(callCount, Is.EqualTo(1));
-            Assert.That(gameTiming.CurTick, Is.EqualTo(1));
+            Assert.That(gameTiming.CurTick, Is.EqualTo(new GameTick(1)));
             Assert.That(gameTiming.Paused, Is.True); // it will pause itself after running each tick
             Assert.That(loop.SingleStep, Is.True); // still true
         }

--- a/SS14.UnitTesting/Shared/Timing/GameTiming_Test.cs
+++ b/SS14.UnitTesting/Shared/Timing/GameTiming_Test.cs
@@ -80,7 +80,7 @@ namespace SS14.UnitTesting.Shared.Timing
             //NOTE: TickRate can cause a slight rounding error in TickPeriod reciprocal calculation from repeating decimals depending
             // on the value chosen.
             gameTiming.TickRate = 20;
-            gameTiming.CurTick = 60;
+            gameTiming.CurTick = new GameTick(60);
 
             // Act
             gameTiming.StartFrame();
@@ -107,7 +107,7 @@ namespace SS14.UnitTesting.Shared.Timing
             var gameTiming = GameTimingFactory(newStopwatch.Object);
             gameTiming.InSimulation = false;
             gameTiming.TickRate = 20;
-            gameTiming.CurTick = 60;
+            gameTiming.CurTick = new GameTick(60);
             gameTiming.TickRemainder = TimeSpan.FromTicks(TimeSpan.TicksPerSecond / 2); // half a second
 
             // Act
@@ -137,7 +137,7 @@ namespace SS14.UnitTesting.Shared.Timing
 
             // Act
             gameTiming.StartFrame();
-            gameTiming.CurTick++;
+            gameTiming.CurTick = new GameTick(gameTiming.CurTick.Value + 1);
             gameTiming.StartFrame();
             var result = gameTiming.FrameTime;
 


### PR DESCRIPTION
* Adds entity interpolation to the game. [Here is an explanation](https://www.youtube.com/watch?v=DoexBWfjWUg).
* Added the `net.interp` cvar to enable/disable the entire feature. It is disabled by default because it causes `1/Tickrate` movement lag for the player. Clientside movement prediction will solve this.
* Added the `net.interp_ratio` cvar. This is an integer of how many extra states to buffer. Other games call this "network smoothing". This also causes `1/Tickrate` input lag for every state buffered.
* The IGameTiming.InSimulation field can now be used to enable/disable interpolation transparently. This is set automatically by the game loop.
* Tickrate is now officially 10. This is to ease up of the network bandwidth, and the interpolation hides the jitter when moving.