### PR TITLE
ECS Event Bus Queue

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -335,6 +335,11 @@ namespace Robust.Shared.GameObjects
 
         public void RaiseEvent(object sender, EntityEventArgs toRaise)
         {
+            ProcessSingleEvent(new Tuple<object, EntityEventArgs>(sender, toRaise));
+        }
+
+        public void QueueEvent(object sender, EntityEventArgs toRaise)
+        {
             _eventQueue.Enqueue(new Tuple<object, EntityEventArgs>(sender, toRaise));
         }
 

--- a/Robust.Shared/GameObjects/Systems/EntitySystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntitySystem.cs
@@ -98,6 +98,11 @@ namespace Robust.Shared.GameObjects.Systems
             EntityManager.RaiseEvent(this, message);
         }
 
+        protected void QueueEvent(EntitySystemMessage message)
+        {
+            EntityManager.QueueEvent(this, message);
+        }
+
         protected void RaiseNetworkEvent(EntitySystemMessage message)
         {
             EntityNetworkManager.SendSystemNetworkMessage(message);

--- a/Robust.Shared/Interfaces/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/Interfaces/GameObjects/IEntityManager.cs
@@ -133,6 +133,7 @@ namespace Robust.Shared.Interfaces.GameObjects
         void UnsubscribeEvent(Type eventType, Delegate evh, IEntityEventSubscriber s);
 
         void RaiseEvent(object sender, EntityEventArgs toRaise);
+        void QueueEvent(object sender, EntityEventArgs toRaise);
 
         void RemoveSubscribedEvents(IEntityEventSubscriber subscriber);
 


### PR DESCRIPTION
Events raised on the ECS event bus with `IEntityManager.RaiseEvent()` are now dispatched immediately. Most events will use this, because they will want the effects to be immediately available on the same tick. This also makes debugging easy because the stack trace will stay intact.

This also adds a new `IEntityManager.QueueEvent()` method that queues the event for the next tick. I doubt anything will use this, but I left the functionality there if it is needed.