### PR TITLE
Tick Logic Timing and Bandwidth Improvements

### DIFF
--- a/Robust.Client/GameObjects/Components/Physics/PhysicsComponent.cs
+++ b/Robust.Client/GameObjects/Components/Physics/PhysicsComponent.cs
@@ -23,7 +23,7 @@ namespace Robust.Client.GameObjects
         public override Type StateType => typeof(PhysicsComponentState);
 
         /// <summary>
-        ///     Current mass of the entity.
+        ///     Current mass of the entity in kg.
         /// </summary>
         [ViewVariables]
         public float Mass { get; private set; }
@@ -51,7 +51,7 @@ namespace Robust.Client.GameObjects
                 return;
 
             var newState = (PhysicsComponentState)curState;
-            Mass = newState.Mass;
+            Mass = newState.Mass / 1000f; // gram to kilogram
             Velocity = newState.Velocity;
         }
     }

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -53,7 +53,7 @@ namespace Robust.Client.GameStates
                 _config.RegisterCVar("net.interp_ratio", 0, CVar.ARCHIVE);
 
             if (!_config.IsCVarRegistered("net.logging"))
-                _config.RegisterCVar("net.logging", false, CVar.ARCHIVE);
+                _config.RegisterCVar("net.logging", false, CVar.ARCHIVE, b => _logging = b);
 
             _logging = _config.GetCVar<bool>("net.logging");
         }

--- a/Robust.Server/GameObjects/Components/Physics/PhysicsComponent.cs
+++ b/Robust.Server/GameObjects/Components/Physics/PhysicsComponent.cs
@@ -50,6 +50,9 @@ namespace Robust.Server.GameObjects
             get => _linVelocity;
             set
             {
+                if(_linVelocity == value)
+                    return;
+
                 _linVelocity = value;
                 Dirty();
             }
@@ -62,7 +65,14 @@ namespace Robust.Server.GameObjects
         public float AngularVelocity
         {
             get => _angVelocity;
-            set => _angVelocity = value;
+            set
+            {
+                if(_angVelocity.Equals(value))
+                    return;
+
+                _angVelocity = value;
+                Dirty();
+            }
         }
 
         [ViewVariables(VVAccess.ReadWrite)]

--- a/Robust.Server/GameObjects/EntitySystems/PhysicsSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/PhysicsSystem.cs
@@ -97,6 +97,10 @@ namespace Robust.Server.GameObjects.EntitySystems
         private static void DoMovement(IEntity entity, float frameTime)
         {
             var velocity = entity.GetComponent<PhysicsComponent>();
+
+            if(velocity.LinearVelocity.LengthSquared < Epsilon && velocity.AngularVelocity < Epsilon)
+                return;
+
             float angImpulse = 0;
             if (velocity.AngularVelocity > Epsilon)
             {

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -83,10 +83,8 @@ namespace Robust.Server.GameObjects
             var stateEntities = new List<EntityState>();
             foreach (IEntity entity in GetEntities())
             {
-                if (entity.LastModifiedTick < fromTick)
-                {
+                if (entity.LastModifiedTick <= fromTick)
                     continue;
-                }
 
                 EntityState entityState = entity.GetEntityState(fromTick);
                 stateEntities.Add(entityState);

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -92,7 +92,8 @@ namespace Robust.Server.GameObjects
                 stateEntities.Add(entityState);
             }
 
-            return stateEntities;
+            // no point sending an empty collection
+            return stateEntities.Count == 0 ? default : stateEntities;
         }
 
         public override void DeleteEntity(IEntity e)
@@ -113,7 +114,8 @@ namespace Robust.Server.GameObjects
                 }
             }
 
-            return list;
+            // no point sending an empty collection
+            return list.Count == 0 ? default : list;
         }
 
         public void CullDeletionHistory(GameTick toTick)

--- a/Robust.Shared/GameObjects/Components/Physics/PhysicsComponentState.cs
+++ b/Robust.Shared/GameObjects/Components/Physics/PhysicsComponentState.cs
@@ -11,9 +11,9 @@ namespace Robust.Shared.GameObjects
     public class PhysicsComponentState : ComponentState
     {
         /// <summary>
-        ///     Current mass of the entity.
+        ///     Current mass of the entity, stored in grams.
         /// </summary>
-        public readonly float Mass;
+        public readonly int Mass;
 
         /// <summary>
         ///     Current velocity of the entity.
@@ -28,7 +28,7 @@ namespace Robust.Shared.GameObjects
         public PhysicsComponentState(float mass, Vector2 velocity)
             : base(NetIDs.PHYSICS)
         {
-            Mass = mass;
+            Mass = (int) Math.Round(mass *1000); // rounds kg to nearest gram
             Velocity = velocity;
         }
     }

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -76,6 +76,9 @@ namespace Robust.Shared.GameObjects.Components.Transform
             get => GetLocalRotation();
             set
             {
+                if (GetLocalRotation() == value)
+                    return;
+
                 SetRotation(value);
                 RebuildMatrices();
                 Dirty();
@@ -101,7 +104,6 @@ namespace Robust.Shared.GameObjects.Components.Transform
                 LocalRotation += diff;
             }
         }
-
 
         /// <summary>
         ///     Current parent entity of this entity.
@@ -153,7 +155,6 @@ namespace Robust.Shared.GameObjects.Components.Transform
         }
 
         public bool IsMapTransform => Parent == null;
-
 
         public virtual bool VisibleWhileParented { set; get; }
 
@@ -242,10 +243,16 @@ namespace Robust.Shared.GameObjects.Components.Transform
                     if ((newPos - GetLocalPosition()).LengthSquared < 10.0E-3)
                         return;
 
+                    if (_localPosition == newPos)
+                        return;
+
                     SetPosition(newPos);
                 }
                 else
                 {
+                    if (_localPosition == value)
+                        return;
+
                     SetPosition(value);
                     _recurseSetGridId(_mapManager.GetMap(MapID).FindGridAt(GetLocalPosition()).Index);
                 }

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -22,8 +22,8 @@ namespace Robust.Shared.GameObjects.Components.Transform
         private Angle _localRotation; // local rotation
         private GridId _gridID;
 
-        private Matrix3 _worldMatrix;
-        private Matrix3 _invWorldMatrix;
+        private Matrix3 _worldMatrix = Matrix3.Identity;
+        private Matrix3 _invWorldMatrix = Matrix3.Identity;
 
         private Vector2 _nextPosition;
         private Angle _nextRotation;

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -48,7 +48,8 @@ namespace Robust.Shared.GameObjects
 
         /// <inheritdoc />
         [ViewVariables]
-        public GameTick LastModifiedTick { get; private set; }
+        // Every entity starts at tick 1, because they are conceptually created in the time between 0->1
+        public GameTick LastModifiedTick { get; private set; } = new GameTick(1);
 
         /// <inheritdoc />
         [ViewVariables(VVAccess.ReadWrite)]

--- a/Robust.Shared/Map/MapManager.Network.cs
+++ b/Robust.Shared/Map/MapManager.Network.cs
@@ -65,6 +65,17 @@ namespace Robust.Shared.Map
                 grid => new GameStateMapData.GridCreationDatum(grid.ChunkSize, grid.SnapSize,
                     grid.IsDefaultGrid));
 
+            // no point sending empty collections
+            if (gridDatums.Count        == 0) gridDatums        = default;
+            if (gridDeletionsData.Count == 0) gridDeletionsData = default;
+            if (mapDeletionsData.Count  == 0) mapDeletionsData  = default;
+            if (mapCreations.Count      == 0) mapCreations      = default;
+            if (gridCreations.Count     == 0) gridCreations     = default;
+
+            // no point even creating an empty map state if no data
+            if (gridDatums == null && gridDeletionsData == null && mapDeletionsData == null && mapCreations == null && gridCreations == null)
+                return default;
+
             return new GameStateMapData(gridDatums, gridDeletionsData, mapDeletionsData, mapCreations, gridCreations);
         }
 
@@ -84,71 +95,80 @@ namespace Robust.Shared.Map
 
             // First we need to figure out all the NEW MAPS.
             // And make their default grids too.
-            foreach (var (mapId, gridId) in data.CreatedMaps)
+            if(data.CreatedMaps != null)
             {
-                if (_maps.ContainsKey(mapId))
+                foreach (var (mapId, gridId) in data.CreatedMaps)
                 {
-                    continue;
-                }
-                var gridCreation = data.CreatedGrids[gridId];
-                DebugTools.Assert(gridCreation.IsTheDefault);
+                    if (_maps.ContainsKey(mapId))
+                    {
+                        continue;
+                    }
+                    var gridCreation = data.CreatedGrids[gridId];
+                    DebugTools.Assert(gridCreation.IsTheDefault);
 
-                var newMap = new Map(this, mapId);
-                _maps.Add(mapId, newMap);
-                MapCreated?.Invoke(this, new MapEventArgs(newMap));
-                newMap.DefaultGrid = CreateGrid(newMap.Index, gridId, gridCreation.ChunkSize, gridCreation.SnapSize);
+                    var newMap = new Map(this, mapId);
+                    _maps.Add(mapId, newMap);
+                    MapCreated?.Invoke(this, new MapEventArgs(newMap));
+                    newMap.DefaultGrid = CreateGrid(newMap.Index, gridId, gridCreation.ChunkSize, gridCreation.SnapSize);
+                }
             }
 
             // Then make all the other grids.
-            foreach (var (gridId, creationDatum) in data.CreatedGrids)
+            if(data.CreatedGrids != null)
             {
-                if (creationDatum.IsTheDefault || _grids.ContainsKey(gridId))
+                foreach (var (gridId, creationDatum) in data.CreatedGrids)
                 {
-                    continue;
-                }
+                    if (creationDatum.IsTheDefault || _grids.ContainsKey(gridId))
+                    {
+                        continue;
+                    }
 
-                CreateGrid(data.GridData[gridId].Coordinates.MapId, gridId, creationDatum.ChunkSize,
-                    creationDatum.SnapSize);
+                    CreateGrid(data.GridData[gridId].Coordinates.MapId, gridId, creationDatum.ChunkSize,
+                        creationDatum.SnapSize);
+                }
             }
 
-            SuppressOnTileChanged = true;
-            // Ok good all the grids and maps exist now.
-            foreach (var (gridId, gridDatum) in data.GridData)
+            if(data.GridData != null)
             {
-                var grid = _grids[gridId];
-                if (grid.MapID != gridDatum.Coordinates.MapId)
+                SuppressOnTileChanged = true;
+                // Ok good all the grids and maps exist now.
+                foreach (var (gridId, gridDatum) in data.GridData)
                 {
-                    throw new NotImplementedException("Moving grids between maps is not yet implemented");
-                }
-
-                grid.WorldPosition = gridDatum.Coordinates.Position;
-
-                var modified = new List<(MapIndices position, Tile tile)>();
-                foreach (var chunkData in gridDatum.ChunkData)
-                {
-                    var chunk = grid.GetChunk(chunkData.Index);
-                    DebugTools.Assert(chunkData.TileData.Length == grid.ChunkSize * grid.ChunkSize);
-
-                    var counter = 0;
-                    for (ushort x = 0; x < grid.ChunkSize; x++)
-                    for (ushort y = 0; y < grid.ChunkSize; y++)
+                    var grid = _grids[gridId];
+                    if (grid.MapID != gridDatum.Coordinates.MapId)
                     {
-                        var tile = chunkData.TileData[counter++];
-                        if (chunk.GetTile(x, y).Tile != tile)
+                        throw new NotImplementedException("Moving grids between maps is not yet implemented");
+                    }
+
+                    grid.WorldPosition = gridDatum.Coordinates.Position;
+
+                    var modified = new List<(MapIndices position, Tile tile)>();
+                    foreach (var chunkData in gridDatum.ChunkData)
+                    {
+                        var chunk = grid.GetChunk(chunkData.Index);
+                        DebugTools.Assert(chunkData.TileData.Length == grid.ChunkSize * grid.ChunkSize);
+
+                        var counter = 0;
+                        for (ushort x = 0; x < grid.ChunkSize; x++)
+                        for (ushort y = 0; y < grid.ChunkSize; y++)
                         {
-                            chunk.SetTile(x, y, tile);
-                            modified.Add((new MapIndices(chunk.X * grid.ChunkSize + x, chunk.Y * grid.ChunkSize + y), tile));
+                            var tile = chunkData.TileData[counter++];
+                            if (chunk.GetTile(x, y).Tile != tile)
+                            {
+                                chunk.SetTile(x, y, tile);
+                                modified.Add((new MapIndices(chunk.X * grid.ChunkSize + x, chunk.Y * grid.ChunkSize + y), tile));
+                            }
                         }
+                    }
+
+                    if (modified.Count != 0)
+                    {
+                        GridChanged?.Invoke(this, new GridChangedEventArgs(grid, modified));
                     }
                 }
 
-                if (modified.Count != 0)
-                {
-                    GridChanged?.Invoke(this, new GridChangedEventArgs(grid, modified));
-                }
+                SuppressOnTileChanged = false;
             }
-
-            SuppressOnTileChanged = false;
         }
 
         public void ApplyGameStatePost(GameStateMapData data)
@@ -158,19 +178,25 @@ namespace Robust.Shared.Map
             if(data == null) // if there is no data, there is nothing to do!
                 return;
 
-            foreach (var grid in data.DeletedGrids)
+            if(data.DeletedGrids != null)
             {
-                if (_grids.ContainsKey(grid))
+                foreach (var grid in data.DeletedGrids)
                 {
-                    DeleteGrid(grid);
+                    if (_grids.ContainsKey(grid))
+                    {
+                        DeleteGrid(grid);
+                    }
                 }
             }
 
-            foreach (var map in data.DeletedMaps)
+            if(data.DeletedMaps != null)
             {
-                if (_maps.ContainsKey(map))
+                foreach (var map in data.DeletedMaps)
                 {
-                    DeleteMap(map);
+                    if (_maps.ContainsKey(map))
+                    {
+                        DeleteMap(map);
+                    }
                 }
             }
         }

--- a/Robust.Shared/Timing/GameTiming.cs
+++ b/Robust.Shared/Timing/GameTiming.cs
@@ -78,7 +78,7 @@ namespace Robust.Shared.Timing
         /// <summary>
         ///     The current simulation tick being processed.
         /// </summary>
-        public GameTick CurTick { get; set; }
+        public GameTick CurTick { get; set; } = new GameTick(1); // Time always starts on the first tick
 
         /// <summary>
         ///     The target ticks/second of the simulation.

--- a/Robust.UnitTesting/ApproxEqualityConstraint.cs
+++ b/Robust.UnitTesting/ApproxEqualityConstraint.cs
@@ -18,6 +18,26 @@ namespace Robust.UnitTesting
         {
             if (!(Expected is IApproxEquatable<TActual> equatable))
             {
+                if (Expected is float f1 && actual is float f2)
+                {
+                    if (Tolerance != null)
+                    {
+                        return new ConstraintResult(this, actual, FloatMath.CloseTo(f1, f2, Tolerance.Value));
+                    }
+
+                    return new ConstraintResult(this, actual, FloatMath.CloseTo(f1, f2));
+                }
+
+                if (Expected is double d1 && actual is float d2)
+                {
+                    if (Tolerance != null)
+                    {
+                        return new ConstraintResult(this, actual, FloatMath.CloseTo(d1, d2, Tolerance.Value));
+                    }
+
+                    return new ConstraintResult(this, actual, FloatMath.CloseTo(d1, d2));
+                }
+
                 return new ConstraintResult(this, actual, false);
             }
 

--- a/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
@@ -53,6 +53,13 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
             //NOTE: The grids have not moved, so we can assert worldpos == localpos for the test
         }
 
+        [SetUp]
+        public void ClearSimulation()
+        {
+            // One of the tests changes this so we use this to ensure it doesn't get passed to other tests.
+            IoCManager.Resolve<IGameTiming>().InSimulation = false;
+        }
+
         [Test]
         public void ParentMapSwitchTest()
         {
@@ -193,8 +200,8 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
 
             //Assert
             var result = node4Trans.WorldPosition;
-            Assert.That(FloatMath.CloseTo(result.X, -2), result.ToString);
-            Assert.That(FloatMath.CloseTo(result.Y, 0), result.ToString);
+            Assert.That(result.X, new ApproxEqualityConstraint(-2f));
+            Assert.That(result.Y, new ApproxEqualityConstraint(0f));
         }
 
         /// <summary>

--- a/Robust.UnitTesting/Shared/Timing/GameLoop_Test.cs
+++ b/Robust.UnitTesting/Shared/Timing/GameLoop_Test.cs
@@ -9,7 +9,7 @@ namespace Robust.UnitTesting.Shared.Timing
 {
     [TestFixture]
     [TestOf(typeof(GameLoop))]
-    class GameLoop_Test
+    class GameLoop_Test : RobustUnitTest
     {
         /// <summary>
         ///     With single step enabled, the game loop should run 1 tick and then pause again.
@@ -35,7 +35,7 @@ namespace Robust.UnitTesting.Shared.Timing
 
             // Assert
             Assert.That(callCount, Is.EqualTo(1));
-            Assert.That(gameTiming.CurTick, Is.EqualTo(new GameTick(1)));
+            Assert.That(gameTiming.CurTick, Is.EqualTo(new GameTick(2)));
             Assert.That(gameTiming.Paused, Is.True); // it will pause itself after running each tick
             Assert.That(loop.SingleStep, Is.True); // still true
         }


### PR DESCRIPTION
Code was changed so that time starts at tick zero, and all entities are initialized in the space between tick 0 to 1. This was a solution to the fact fromSequence was including entities with lastStateUpdate tick one less than the actual sequence number. This is purely an issue about when exactly the game does its logic relative to the tick signals, ie positive or negative edge of the tick. Right now the game is set up to run the game logic on the positive edge of a Tick (enforced by GameLoop).

The second big part is that an empty collection takes 5ish bytes more than a null collection in the NetSerializer, even though they are conceptually the same thing in a game state. This PR puts null checks around everything and allows GameStates to have whole sections of itself null. This reduced the payload size of an empty game state from 49B to 15B.

This PR also fixes the bug where the physics system marks every movable entity as dirty every tick.