### PR TITLE
EntityStates

### DIFF
--- a/Robust.Client/BaseClient.cs
+++ b/Robust.Client/BaseClient.cs
@@ -162,7 +162,7 @@ namespace Robust.Client
 
             _stateManager.RequestStateChange<MainScreen>();
 
-            _gameStates.Shutdown();
+            _gameStates.Reset();
             _playMan.Shutdown();
             _entityManager.Shutdown();
             _mapManager.Shutdown();

--- a/Robust.Client/GameObjects/ClientComponentFactory.cs
+++ b/Robust.Client/GameObjects/ClientComponentFactory.cs
@@ -15,6 +15,14 @@ namespace Robust.Client.GameObjects
     {
         public ClientComponentFactory()
         {
+            // Required for the engine to work
+            Register<MetaDataComponent>();
+            RegisterReference<MetaDataComponent, IMetaDataComponent>();
+
+            // Required for the engine to work
+            Register<TransformComponent>();
+            RegisterReference<TransformComponent, ITransformComponent>();
+
             Register<CollidableComponent>();
             RegisterReference<CollidableComponent, ICollidable>();
             RegisterReference<CollidableComponent, ICollidableComponent>();
@@ -22,8 +30,6 @@ namespace Robust.Client.GameObjects
             RegisterIgnore("KeyBindingInput");
             Register<PointLightComponent>();
             Register<PhysicsComponent>();
-            Register<TransformComponent>();
-            RegisterReference<TransformComponent, ITransformComponent>();
 
             Register<InputComponent>();
 

--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Robust.Client.Interfaces.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects;
@@ -120,14 +121,14 @@ namespace Robust.Client.GameObjects
                 foreach (var es in curEntStates)
                 {
                     //Known entities
-                    if (Entities.TryGetValue(es.StateData.Uid, out var entity))
+                    if (Entities.TryGetValue(es.Uid, out var entity))
                     {
                         toApply.Add(entity, (es, null));
                     }
                     else //Unknown entities
                     {
-                        var newEntity = CreateEntity(es.StateData.TemplateName, es.StateData.Uid);
-                        newEntity.Name = es.StateData.Name;
+                        var metaState = (MetaDataComponentState)es.ComponentStates.First(c => c.NetID == NetIDs.META_DATA);
+                        var newEntity = CreateEntity(metaState.PrototypeId, es.Uid);
                         toApply.Add(newEntity, (es, null));
                         toInitialize.Add(newEntity);
                     }
@@ -138,7 +139,7 @@ namespace Robust.Client.GameObjects
             {
                 foreach (var es in nextEntStates)
                 {
-                    if (Entities.TryGetValue(es.StateData.Uid, out var entity))
+                    if (Entities.TryGetValue(es.Uid, out var entity))
                     {
                         if (toApply.TryGetValue(entity, out var state))
                         {

--- a/Robust.Client/Interfaces/GameStates/IClientGameStateManager.cs
+++ b/Robust.Client/Interfaces/GameStates/IClientGameStateManager.cs
@@ -1,10 +1,38 @@
 ﻿namespace Robust.Client.Interfaces.GameStates
 {
+    /// <summary>
+    ///     Engine service that provides processing and management of game states.
+    /// </summary>
     public interface IClientGameStateManager
     {
-        void Initialize();
-        void Shutdown();
+        /// <summary>
+        ///     Minimum number of states needed in the buffer for everything to work.
+        /// </summary>
+        /// <remarks>
+        ///     With interpolation enabled minimum is 3 states in buffer for the system to work (last, cur, next).
+        ///     Without interpolation enabled minimum is 2 states in buffer for the system to work (last, cur).
+        /// </remarks>
+        int MinBufferSize { get; }
 
+        /// <summary>
+        ///     The number of states the system is trying to keep in the buffer. This will always
+        ///     be greater or equal to <see cref="MinBufferSize"/>.
+        /// </summary>
+        int TargetBufferSize { get; }
+
+        /// <summary>
+        ///     One time initialization of the service.
+        /// </summary>
+        void Initialize();
+
+        /// <summary>
+        ///     Resets the service back to its initial state.
+        /// </summary>
+        void Reset();
+
+        /// <summary>
+        ///     Applies the game state for this tick.
+        /// </summary>
         void ApplyGameState();
     }
 }

--- a/Robust.Server/GameObjects/ServerComponentFactory.cs
+++ b/Robust.Server/GameObjects/ServerComponentFactory.cs
@@ -1,5 +1,4 @@
-﻿using Robust.Server.GameObjects.Components;
-using Robust.Server.GameObjects.Components.Container;
+﻿using Robust.Server.GameObjects.Components.Container;
 using Robust.Server.GameObjects.Components.Markers;
 using Robust.Server.GameObjects.Components.UserInterface;
 using Robust.Server.Interfaces.GameObjects;
@@ -14,6 +13,14 @@ namespace Robust.Server.GameObjects
     {
         public ServerComponentFactory()
         {
+            // Required for the engine to work
+            Register<MetaDataComponent>();
+            RegisterReference<MetaDataComponent, IMetaDataComponent>();
+
+            // Required for the engine to work
+            Register<TransformComponent>();
+            RegisterReference<TransformComponent, ITransformComponent>();
+
             RegisterIgnore("Icon");
             RegisterIgnore("Occluder");
             RegisterIgnore("Eye");
@@ -31,8 +38,6 @@ namespace Robust.Server.GameObjects
             Register<ParticleSystemComponent>();
             Register<PhysicsComponent>();
             Register<SpriteComponent>();
-            Register<TransformComponent>();
-            RegisterReference<TransformComponent, ITransformComponent>();
 
             Register<ClickableComponent>();
             RegisterReference<ClickableComponent, IClickableComponent>();

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -15,47 +15,70 @@ using Robust.Shared.Utility;
 
 namespace Robust.Server.GameStates
 {
+    /// <inheritdoc />
     public class ServerGameStateManager : IServerGameStateManager
     {
         // Mapping of net UID of clients -> last known acked state.
-        private readonly Dictionary<long, GameTick> ackedStates = new Dictionary<long, GameTick>();
+        private readonly Dictionary<long, GameTick> _ackedStates = new Dictionary<long, GameTick>();
+        private GameTick _lastOldestAck = GameTick.Zero;
 
-        private GameTick lastOldestAck = GameTick.Zero;
+        [Dependency] private readonly IServerEntityManager _entityManager;
+        [Dependency] private readonly IGameTiming _gameTiming;
+        [Dependency] private readonly IServerNetManager _networkManager;
+        [Dependency] private readonly IPlayerManager _playerManager;
+        [Dependency] private readonly IMapManager _mapManager;
 
-        [Dependency]
-        private IServerEntityManager _entityManager;
-
-        [Dependency]
-        private IGameTiming _gameTiming;
-
-        [Dependency]
-        private IServerNetManager _networkManager;
-
-        [Dependency]
-        private IPlayerManager _playerManager;
-
-        [Dependency] private IMapManager _mapManager;
-
+        /// <inheritdoc />
         public void Initialize()
         {
             _networkManager.RegisterNetMessage<MsgState>(MsgState.NAME);
             _networkManager.RegisterNetMessage<MsgStateAck>(MsgStateAck.NAME, HandleStateAck);
 
+            _networkManager.Connected += HandleClientConnected;
             _networkManager.Disconnect += HandleClientDisconnect;
         }
-
+        
+        private void HandleClientConnected(object sender, NetChannelArgs e)
+        {
+            if(!_ackedStates.ContainsKey(e.Channel.ConnectionId))
+                _ackedStates.Add(e.Channel.ConnectionId, GameTick.Zero);
+            else
+                _ackedStates[e.Channel.ConnectionId] = GameTick.Zero;
+        }
+        
         private void HandleClientDisconnect(object sender, NetChannelArgs e)
         {
-            if (ackedStates.ContainsKey(e.Channel.ConnectionId))
-                ackedStates.Remove(e.Channel.ConnectionId);
+            if (_ackedStates.ContainsKey(e.Channel.ConnectionId))
+                _ackedStates.Remove(e.Channel.ConnectionId);
+        }
+
+        private void HandleStateAck(MsgStateAck msg)
+        {
+            Ack(msg.MsgChannel.ConnectionId, msg.Sequence);
         }
 
         private void Ack(long uniqueIdentifier, GameTick stateAcked)
         {
-            if(ackedStates.ContainsKey(uniqueIdentifier))
-                ackedStates[uniqueIdentifier] = stateAcked;
+            DebugTools.Assert(_networkManager.IsServer);
+
+            if (_ackedStates.TryGetValue(uniqueIdentifier, out var lastAck))
+            {
+                if (stateAcked > lastAck) // most of the time this is true
+                {
+                    _ackedStates[uniqueIdentifier] = stateAcked;
+                }
+                else if (stateAcked == GameTick.Zero) // client signaled they need a full state
+                {
+                    //Performance/Abuse: Should this be rate limited?
+                    _ackedStates[uniqueIdentifier] = GameTick.Zero;
+                }
+                //else stateAcked was out of order or client is being silly, just ignore
+            }
+            else
+                DebugTools.Assert("How did the client send us an ack without being connected?");
         }
 
+        /// <inheritdoc />
         public void SendGameStateUpdate()
         {
             DebugTools.Assert(_networkManager.IsServer);
@@ -69,54 +92,48 @@ namespace Robust.Server.GameStates
             }
 
             var oldestAck = GameTick.MaxValue;
-            foreach (var connection in _networkManager.Channels)
+            foreach (var channel in _networkManager.Channels)
             {
-                if (!ackedStates.TryGetValue(connection.ConnectionId, out var ack))
-                {
-                    ackedStates.Add(connection.ConnectionId, GameTick.Zero);
-                }
-                else if (ack < oldestAck)
-                {
-                    oldestAck = ack;
-                }
-            }
-
-            // If there are no clients FULLY connected to the server (no channels),
-            // or server has been running for 2.2 years
-            if (oldestAck == GameTick.MaxValue)
-            {
-                return; // don't need to worry about states.
-            }
-
-            if (oldestAck > lastOldestAck)
-            {
-                lastOldestAck = oldestAck;
-                _entityManager.CullDeletionHistory(oldestAck);
-            }
-
-            var entities = _entityManager.GetEntityStates(oldestAck);
-            var players = _playerManager.GetPlayerStates(oldestAck);
-            var deletions = _entityManager.GetDeletedEntities(oldestAck);
-            var mapData = _mapManager.GetStateData(oldestAck);
-
-            var state = new GameState(oldestAck, _gameTiming.CurTick, entities, players, deletions, mapData);
-
-            foreach (var c in _networkManager.Channels)
-            {
-                var session = _playerManager.GetSessionByChannel(c);
-
-                if (session == null || session.Status != SessionStatus.InGame)
+                var session = _playerManager.GetSessionByChannel(channel);
+                if (session == null || session.Status != SessionStatus.InGame) // client still joining, maybe iterate over sessions instead?
                     continue;
 
+                if (!_ackedStates.TryGetValue(channel.ConnectionId, out var lastAck))
+                {
+                    DebugTools.Assert("Why does this channel not have an entry?");
+                }
+                
+                //TODO: Cull these based on client view rectangle, remember the issues with transform parenting
+                var entities = _entityManager.GetEntityStates(lastAck);
+                var players = _playerManager.GetPlayerStates(lastAck);
+                var deletions = _entityManager.GetDeletedEntities(lastAck);
+                var mapData = _mapManager.GetStateData(lastAck);
+
+                // lastAck varies with each client based on lag and such, we can't just make 1 global state and send it to everyone
+                var state = new GameState(lastAck, _gameTiming.CurTick, entities, players, deletions, mapData);
+
+                // actually send the state
                 var stateUpdateMessage = _networkManager.CreateNetMessage<MsgState>();
                 stateUpdateMessage.State = state;
-                _networkManager.ServerSendMessage(stateUpdateMessage, c);
-            }
-        }
+                _networkManager.ServerSendMessage(stateUpdateMessage, channel);
 
-        private void HandleStateAck(MsgStateAck msg)
-        {
-            Ack(msg.MsgChannel.ConnectionId, msg.Sequence);
+                // we are not going to send a full state every tick (rip bandwidth) until they ack, so assume they receive it
+                // and start the deltas from the full state.
+                // the client will signal to us if they need another one.
+                if (lastAck == GameTick.Zero)
+                    _ackedStates[channel.ConnectionId] = _gameTiming.CurTick;
+
+                if (lastAck < oldestAck)
+                    oldestAck = lastAck;
+            }
+
+            // keep the deletion history buffers clean
+            if (oldestAck > _lastOldestAck)
+            {
+                _lastOldestAck = oldestAck;
+                _entityManager.CullDeletionHistory(oldestAck);
+                _mapManager.CullDeletionHistory(oldestAck);
+            }
         }
     }
 }

--- a/Robust.Server/Interfaces/GameState/IServerGameStateManager.cs
+++ b/Robust.Server/Interfaces/GameState/IServerGameStateManager.cs
@@ -1,12 +1,18 @@
-﻿using System.Collections.Generic;
-using Robust.Shared.GameStates;
-using Robust.Shared.Interfaces.Network;
-
-namespace Robust.Server.Interfaces.GameState
+﻿namespace Robust.Server.Interfaces.GameState
 {
+    /// <summary>
+    ///     Engine service that provides creating and dispatching of game states.
+    /// </summary>
     public interface IServerGameStateManager
     {
+        /// <summary>
+        ///     One time initialization of the service.
+        /// </summary>
         void Initialize();
+
+        /// <summary>
+        ///     Create and dispatch game states to all connected sessions.
+        /// </summary>
         void SendGameStateUpdate();
     }
 }

--- a/Robust.Shared/GameObjects/Component.cs
+++ b/Robust.Shared/GameObjects/Component.cs
@@ -59,6 +59,9 @@ namespace Robust.Shared.GameObjects
         public bool Deleted { get; private set; }
 
         [ViewVariables]
+        public GameTick CreationTick { get; private set; }
+
+        [ViewVariables]
         public GameTick LastModifiedTick { get; private set; }
 
         /// <inheritdoc />
@@ -99,6 +102,8 @@ namespace Robust.Shared.GameObjects
                 throw new InvalidOperationException("Cannot Initialize a Deleted component!");
 
             Initialized = true;
+
+            CreationTick = Owner.EntityManager.CurrentTick;
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -92,10 +92,14 @@ namespace Robust.Shared.GameObjects
             }
             set
             {
-                if(_entityName == value)
+                var newValue = value;
+                if (_entityPrototype != null && _entityPrototype.Name == newValue)
+                    newValue = null;
+
+                if (_entityName == newValue)
                     return;
 
-                _entityName = value;
+                _entityName = newValue;
                 Dirty();
             }
         }
@@ -112,10 +116,14 @@ namespace Robust.Shared.GameObjects
             }
             set
             {
-                if(_entityDescription == value)
+                var newValue = value;
+                if (_entityPrototype != null && _entityPrototype.Description == newValue)
+                    newValue = null;
+
+                if(_entityDescription == newValue)
                     return;
 
-                _entityDescription = value;
+                _entityDescription = newValue;
                 Dirty();
             }
         }

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using Robust.Shared.IoC;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.ViewVariables;
+
+namespace Robust.Shared.GameObjects
+{
+    [Serializable, NetSerializable]
+    public class MetaDataComponentState : ComponentState
+    {
+        public string Name { get; }
+        public string Description { get; }
+        public string PrototypeId { get; }
+
+        public MetaDataComponentState(uint netID, string name, string description, string prototypeId) : base(netID)
+        {
+            Name = name;
+            Description = description;
+            PrototypeId = prototypeId;
+        }
+    }
+
+    /// <summary>
+    ///     Contains meta data about this entity that isn't component specific.
+    /// </summary>
+    public interface IMetaDataComponent
+    {
+        /// <summary>
+        ///     The in-game name of this entity.
+        /// </summary>
+        string EntityName { get; set; }
+
+        /// <summary>
+        ///     The in-game description of this entity.
+        /// </summary>
+        string EntityDescription { get; set; }
+
+        /// <summary>
+        ///     The prototype this entity was created from, if any.
+        /// </summary>
+        EntityPrototype EntityPrototype { get; set; }
+    }
+
+    class MetaDataComponent : Component, IMetaDataComponent
+    {
+        [Dependency] private readonly IPrototypeManager _prototypes;
+
+        private string _entityName;
+        private string _entityDescription;
+        private EntityPrototype _entityPrototype;
+
+        /// <inheritdoc />
+        public override string Name => "MetaData";
+
+        /// <inheritdoc />
+        public override uint? NetID => NetIDs.META_DATA;
+
+        /// <inheritdoc />
+        public override Type StateType => typeof(MetaDataComponentState);
+
+        /// <inheritdoc />
+        [ViewVariables(VVAccess.ReadWrite)]
+        public string EntityName
+        {
+            get => _entityName;
+            set
+            {
+                if(_entityName == value)
+                    return;
+
+                _entityName = value;
+                Dirty();
+            }
+        }
+
+        /// <inheritdoc />
+        [ViewVariables(VVAccess.ReadWrite)]
+        public string EntityDescription
+        {
+            get
+            {
+                if (_entityDescription == null)
+                    return EntityPrototype.Description;
+                return _entityDescription;
+            }
+            set
+            {
+                if(_entityDescription == value)
+                    return;
+
+                _entityDescription = value;
+                Dirty();
+            }
+        }
+
+        /// <inheritdoc />
+        [ViewVariables]
+        public EntityPrototype EntityPrototype
+        {
+            get => _entityPrototype;
+            set
+            {
+                _entityPrototype = value;
+                Dirty();
+            }
+        }
+
+        /// <inheritdoc />
+        public override ComponentState GetComponentState()
+        {
+            return new MetaDataComponentState(NetID.Value, _entityName, _entityDescription, EntityPrototype.ID);
+        }
+
+        public override void HandleComponentState(ComponentState curState, ComponentState nextState)
+        {
+            base.HandleComponentState(curState, nextState);
+            
+            if (!(curState is MetaDataComponentState state))
+                return;
+
+            _entityName = state.Name;
+            _entityDescription = state.Description;
+            _entityPrototype = _prototypes.Index<EntityPrototype>(state.PrototypeId);
+        }
+    }
+}

--- a/Robust.Shared/GameObjects/Components/NetIDs.cs
+++ b/Robust.Shared/GameObjects/Components/NetIDs.cs
@@ -5,6 +5,7 @@
         public const uint BASIC_MOVER = 1;
         public const uint SLAVE_MOVER = 2;
         public const uint PLAYER_INPUT_MOVER = 3;
+        public const uint META_DATA = 4;
         public const uint TRANSFORM = 5;
         public const uint PHYSICS = 6;
         public const uint PARTICLE_SYSTEM = 7;

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -381,24 +381,32 @@ namespace Robust.Shared.GameObjects
         internal void HandleEntityState(EntityState curState, EntityState nextState)
         {
             _compStateWork.Clear();
-
-            if (curState != null)
+            
+            if(curState?.ComponentChanges != null)
             {
-                Name = curState.StateData.Name;
-                var synchedComponentTypes = curState.StateData.SynchedComponentTypes;
-                foreach (var t in synchedComponentTypes)
+                foreach (var compChange in curState.ComponentChanges)
                 {
-                    if (HasComponent(t.Item1) && GetComponent(t.Item1).Name != t.Item2)
-                        RemoveComponent(GetComponent(t.Item1));
-
-                    if (!HasComponent(t.Item1))
+                    if (compChange.Deleted)
                     {
-                        var newComp = (Component) IoCManager.Resolve<IComponentFactory>().GetComponent(t.Item2);
+                        if (TryGetComponent(compChange.NetID, out var comp))
+                        {
+                            RemoveComponent(comp);
+                        }
+                    }
+                    else
+                    {
+                        if (HasComponent(compChange.NetID))
+                            continue;
+
+                        var newComp = (Component) IoCManager.Resolve<IComponentFactory>().GetComponent(compChange.ComponentName);
                         newComp.Owner = this;
                         AddComponent(newComp, true);
                     }
                 }
+            }
 
+            if(curState?.ComponentStates != null)
+            {
                 foreach (var compState in curState.ComponentStates)
                 {
                     _compStateWork[compState.NetID] = (compState, null);
@@ -440,17 +448,21 @@ namespace Robust.Shared.GameObjects
         public EntityState GetEntityState(GameTick fromTick)
         {
             var compStates = GetComponentStates(fromTick);
+            
+            var addedComponents = EntityManager.ComponentManager.GetNetComponents(Uid)
+                .Where(c => c.CreationTick >= fromTick && !c.Deleted)
+                .Select(c => ComponentChanged.Added(c.NetID.Value, c.Name));
 
-            var synchedComponentTypes = EntityManager.ComponentManager.GetNetComponents(Uid)
-                .Select(t => new Tuple<uint, string>(t.NetID.Value, t.Name))
-                .ToList();
+            var removedComponents = EntityManager.ComponentManager.GetNetComponents(Uid)
+                .Where(c => c.Deleted && c.LastModifiedTick >= fromTick)
+                .Select(s => ComponentChanged.Removed(s.NetID.Value));
+
+            var changedComponents = addedComponents.Concat(removedComponents).ToList();
 
             var es = new EntityState(
                 Uid,
-                compStates,
-                Prototype.ID,
-                Name,
-                synchedComponentTypes);
+                changedComponents,
+                compStates);
             return es;
         }
 

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -15,8 +15,6 @@ namespace Robust.Shared.GameObjects
     {
         #region Members
 
-        private string _name;
-
         /// <inheritdoc />
         public IEntityManager EntityManager { get; private set; }
 
@@ -26,25 +24,19 @@ namespace Robust.Shared.GameObjects
 
         /// <inheritdoc />
         [ViewVariables]
-        public EntityPrototype Prototype { get; internal set; }
-
-        /// <inheritdoc />
-        [ViewVariables]
-        public string Description
+        public EntityPrototype Prototype
         {
-            get
-            {
-                if (_description == null)
-                    return Prototype.Description;
-                return _description;
-            }
-            set => _description = value;
+            get => MetaData.EntityPrototype;
+            internal set => MetaData.EntityPrototype = value;
         }
 
-        /// <summary>
-        /// Private value which can override the prototype value for the description
-        /// </summary>
-        private string _description;
+        /// <inheritdoc />
+        [ViewVariables(VVAccess.ReadWrite)]
+        public string Description
+        {
+            get => MetaData.EntityDescription;
+            set => MetaData.EntityDescription = value;
+        }
 
         /// <inheritdoc />
         [ViewVariables]
@@ -55,12 +47,8 @@ namespace Robust.Shared.GameObjects
         [ViewVariables(VVAccess.ReadWrite)]
         public string Name
         {
-            get => _name;
-            set
-            {
-                _name = value;
-                Dirty();
-            }
+            get => MetaData.EntityName;
+            set => MetaData.EntityName = value;
         }
 
         /// <inheritdoc />
@@ -75,6 +63,11 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         [ViewVariables]
         public ITransformComponent Transform => _transform ?? (_transform = GetComponent<ITransformComponent>());
+
+        private IMetaDataComponent _metaData;
+        /// <inheritdoc />
+        [ViewVariables]
+        public IMetaDataComponent MetaData => _metaData ?? (_metaData = GetComponent<IMetaDataComponent>());
 
         #endregion Members
 

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -247,7 +247,7 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <summary>
-        ///     Allocates and entity and loads components but does not do initialization.
+        ///     Allocates an entity and loads components but does not do initialization.
         /// </summary>
         private protected Entity CreateEntity(string prototypeName, EntityUid? uid = null)
         {

--- a/Robust.Shared/Interfaces/GameObjects/IComponent.cs
+++ b/Robust.Shared/Interfaces/GameObjects/IComponent.cs
@@ -75,6 +75,11 @@ namespace Robust.Shared.Interfaces.GameObjects
         void Dirty();
 
         /// <summary>
+        ///     This is the tick the component was created.
+        /// </summary>
+        GameTick CreationTick { get; }
+
+        /// <summary>
         ///     This is the last game tick Dirty() was called.
         /// </summary>
         GameTick LastModifiedTick { get; }

--- a/Robust.Shared/Interfaces/GameObjects/IEntity.cs
+++ b/Robust.Shared/Interfaces/GameObjects/IEntity.cs
@@ -58,6 +58,11 @@ namespace Robust.Shared.Interfaces.GameObjects
         ITransformComponent Transform { get; }
 
         /// <summary>
+        ///     The MetaData Component of this entity.
+        /// </summary>
+        IMetaDataComponent MetaData { get; }
+
+        /// <summary>
         ///     Public method to add a component to an entity.
         ///     Calls the component's onAdd method, which also adds it to the component manager.
         /// </summary>

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -409,6 +409,10 @@ namespace Robust.Shared.GameObjects
 
             entity.SetManagers(manager);
             entity.SetUid(uid);
+
+            // allocate the required MetaDataComponent
+            manager.ComponentManager.AddComponent<MetaDataComponent>(entity);
+
             entity.Prototype = this;
             entity.Name = Name;
 

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -414,7 +414,6 @@ namespace Robust.Shared.GameObjects
             manager.ComponentManager.AddComponent<MetaDataComponent>(entity);
 
             entity.Prototype = this;
-            entity.Name = Name;
 
             return entity;
         }

--- a/Robust.Shared/Robust.Shared.csproj
+++ b/Robust.Shared/Robust.Shared.csproj
@@ -126,6 +126,7 @@
     <Compile Include="GameObjects\ComponentMessage.cs" />
     <Compile Include="GameObjects\ComponentMessages\Messages.cs" />
     <Compile Include="GameObjects\Components\Appearance\SharedAppearanceComponent.cs" />
+    <Compile Include="GameObjects\Components\MetaDataComponent.cs" />
     <Compile Include="GameObjects\Components\UserInterface\SharedUserInterfaceComponent.cs" />
     <Compile Include="GameObjects\EntitySystemMessages\AudioMessages.cs" />
     <Compile Include="GameObjects\EntitySystemMessages\EffectMessage.cs" />

--- a/Robust.UnitTesting/Robust.UnitTesting.csproj
+++ b/Robust.UnitTesting/Robust.UnitTesting.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Server\GameObjects\Components\Transform_Test.cs" />
     <Compile Include="Shared\ContentPack\ResourceManagerTest.cs" />
     <Compile Include="Shared\GameObjects\ComponentManager_Test.cs" />
+    <Compile Include="Shared\GameObjects\EntityState_Tests.cs" />
     <Compile Include="Shared\IoC\IoCManager_Test.cs" />
     <Compile Include="Shared\Maths\Angle_Test.cs" />
     <Compile Include="Shared\Maths\UIBox2i_Test.cs" />

--- a/Robust.UnitTesting/RobustUnitTest.cs
+++ b/Robust.UnitTesting/RobustUnitTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
 using Robust.Client;
@@ -158,6 +159,15 @@ namespace Robust.UnitTesting
                 GetConfigurationManager = IoCManager.Resolve<IConfigurationManager>();
                 GetConfigurationManager.LoadFromFile(PathHelpers.ExecutableRelativeFile("./client_config.toml"));
             }
+
+            // Required components for the engine to work
+            var compFactory = IoCManager.Resolve<IComponentFactory>();
+            if (!compFactory.AllRegisteredTypes.Contains(typeof(MetaDataComponent)))
+            {
+                compFactory.Register<MetaDataComponent>();
+                compFactory.RegisterReference<MetaDataComponent, IMetaDataComponent>();
+            }
+
 
             /*
             if (NeedsResourcePack)

--- a/Robust.UnitTesting/Shared/GameObjects/EntityState_Tests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityState_Tests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using Robust.Server.Reflection;
+using Robust.Shared.ContentPack;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Interfaces.Reflection;
+using Robust.Shared.Interfaces.Serialization;
+using Robust.Shared.IoC;
+using Robust.Shared.Serialization;
+
+namespace Robust.UnitTesting.Shared.GameObjects
+{
+    [TestFixture, Serializable]
+    class EntityState_Tests
+    {
+        /// <summary>
+        ///     Used to measure the size of <see cref="object"/>s in bytes. This is not actually a test,
+        ///     but a useful benchmark tool, so i'm leaving it here.
+        /// </summary>
+        [Test]
+        public void ComponentChangedSerialized()
+        {
+            var container = new DependencyCollection();
+            container.Register<IReflectionManager, ServerReflectionManager>();
+            container.Register<IRobustSerializer, RobustSerializer>();
+            container.BuildGraph();
+
+            container.Resolve<IReflectionManager>().LoadAssemblies(AppDomain.CurrentDomain.GetAssemblyByName("Robust.Shared"));
+
+            var serializer = container.Resolve<IRobustSerializer>();
+            serializer.Initialize();
+
+            byte[] array;
+            using(var stream = new MemoryStream())
+            {
+                var payload = new EntityState(new EntityUid(512), new List<ComponentChanged>(), new List<ComponentState>());
+
+                serializer.Serialize(stream, payload);
+                array = stream.ToArray();
+            }
+
+            Assert.Pass($"Size in Bytes: {array.Length.ToString()}");
+        }
+    }
+}


### PR DESCRIPTION
* Adds the new MetaDataComponent to the engine that holds data which isn't specific to another component, like name and the prototypeId.
* Massive reduction of network bandwidth for a moving object. From 280 Bytes/tick to 48 Bytes/tick. Mainly by redesigning the EntityStates.
* (Hopefully) fixed a lot of the issues with multiple clients connecting to the server. Server networking should not break anymore when someone leaves.