### PR TITLE
MetaDataComponent and the ExposeData Bug

### DIFF
--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -166,7 +166,9 @@ namespace Robust.Shared.GameObjects
 
             serializer.DataField(ref _entityName, "name", string.Empty);
             serializer.DataField(ref _entityDescription, "desc", string.Empty);
-            serializer.DataField(ref _entityPrototype, "proto", null);
+            serializer.DataField(ref _entityPrototype, "proto", null,
+                s => _prototypes.Index<EntityPrototype>(s),
+                p => p.ID);
         }
     }
 }


### PR DESCRIPTION
Fixes ExposeData issue in MetaDataComponent.

The component should be saving and loading the name of the prototype, not the prototype itself.