### PR TITLE
Tile Placement Improvements

### DIFF
--- a/Robust.Client/Graphics/ClientEye/EyeManager.cs
+++ b/Robust.Client/Graphics/ClientEye/EyeManager.cs
@@ -77,7 +77,8 @@ namespace Robust.Client.Graphics.ClientEye
 
         public ScreenCoordinates WorldToScreen(GridCoordinates point)
         {
-            return new ScreenCoordinates(WorldToScreen(point.Position));
+            var worldCoords = _mapManager.GetGrid(point.GridID).LocalToWorld(point);
+            return new ScreenCoordinates(WorldToScreen(worldCoords.Position));
         }
 
         public GridCoordinates ScreenToWorld(ScreenCoordinates point)

--- a/Robust.Client/Placement/Modes/AlignSimilar.cs
+++ b/Robust.Client/Placement/Modes/AlignSimilar.cs
@@ -15,7 +15,7 @@ namespace Robust.Client.Placement.Modes
 
         public override void AlignPlacementMode(ScreenCoordinates mouseScreen)
         {
-            MouseCoords = ScreenToPlayerGrid(mouseScreen);
+            MouseCoords = ScreenToCursorGrid(mouseScreen);
             var mapGrid = pManager.MapManager.GetGrid(MouseCoords.GridID);
             CurrentTile = mapGrid.GetTileRef(MouseCoords);
 

--- a/Robust.Client/Placement/Modes/AlignSnapgridBorder.cs
+++ b/Robust.Client/Placement/Modes/AlignSnapgridBorder.cs
@@ -54,7 +54,7 @@ namespace Robust.Client.Placement.Modes
 
         public override void AlignPlacementMode(ScreenCoordinates mouseScreen)
         {
-            MouseCoords = ScreenToPlayerGrid(mouseScreen);
+            MouseCoords = ScreenToCursorGrid(mouseScreen);
 
             snapSize = pManager.MapManager.GetGrid(MouseCoords.GridID).SnapSize; //Find snap size.
             GridDistancing = snapSize;

--- a/Robust.Client/Placement/Modes/AlignSnapgridCenter.cs
+++ b/Robust.Client/Placement/Modes/AlignSnapgridCenter.cs
@@ -44,7 +44,7 @@ namespace Robust.Client.Placement.Modes
 
         public override void AlignPlacementMode(ScreenCoordinates mouseScreen)
         {
-            MouseCoords = ScreenToPlayerGrid(mouseScreen);
+            MouseCoords = ScreenToCursorGrid(mouseScreen);
 
             snapSize = pManager.MapManager.GetGrid(MouseCoords.GridID).SnapSize; //Find snap size.
             GridDistancing = snapSize;

--- a/Robust.Client/Placement/Modes/AlignTileAny.cs
+++ b/Robust.Client/Placement/Modes/AlignTileAny.cs
@@ -20,9 +20,13 @@ namespace Robust.Client.Placement.Modes
 
             if (pManager.CurrentPermission.IsTile)
             {
-                MouseCoords = new GridCoordinates(CurrentTile.X + tileSize / 2,
-                    CurrentTile.Y + tileSize / 2,
-                    MouseCoords.GridID);
+                if(!mapGrid.IsDefaultGrid)
+                {
+                    MouseCoords = new GridCoordinates(CurrentTile.X + tileSize / 2,
+                        CurrentTile.Y + tileSize / 2,
+                        MouseCoords.GridID);
+                }
+                // else we don't modify coords
             }
             else
             {

--- a/Robust.Client/Placement/Modes/AlignTileAny.cs
+++ b/Robust.Client/Placement/Modes/AlignTileAny.cs
@@ -11,7 +11,7 @@ namespace Robust.Client.Placement.Modes
 
         public override void AlignPlacementMode(ScreenCoordinates mouseScreen)
         {
-            MouseCoords = ScreenToPlayerGrid(mouseScreen);
+            MouseCoords = ScreenToCursorGrid(mouseScreen);
 
             var mapGrid = pManager.MapManager.GetGrid(MouseCoords.GridID);
             CurrentTile = mapGrid.GetTileRef(MouseCoords);

--- a/Robust.Client/Placement/Modes/AlignTileDense.cs
+++ b/Robust.Client/Placement/Modes/AlignTileDense.cs
@@ -11,7 +11,7 @@ namespace Robust.Client.Placement.Modes
 
         public override void AlignPlacementMode(ScreenCoordinates mouseScreen)
         {
-            MouseCoords = ScreenToPlayerGrid(mouseScreen);
+            MouseCoords = ScreenToCursorGrid(mouseScreen);
 
             var mapGrid = pManager.MapManager.GetGrid(MouseCoords.GridID);
             CurrentTile = mapGrid.GetTileRef(MouseCoords);

--- a/Robust.Client/Placement/Modes/AlignTileEmpty.cs
+++ b/Robust.Client/Placement/Modes/AlignTileEmpty.cs
@@ -14,7 +14,7 @@ namespace Robust.Client.Placement.Modes
 
         public override void AlignPlacementMode(ScreenCoordinates mouseScreen)
         {
-            MouseCoords = ScreenToPlayerGrid(mouseScreen);
+            MouseCoords = ScreenToCursorGrid(mouseScreen);
 
             var mapGrid = pManager.MapManager.GetGrid(MouseCoords.GridID);
             CurrentTile = mapGrid.GetTileRef(MouseCoords);

--- a/Robust.Client/Placement/Modes/AlignTileNonDense.cs
+++ b/Robust.Client/Placement/Modes/AlignTileNonDense.cs
@@ -11,7 +11,7 @@ namespace Robust.Client.Placement.Modes
 
         public override void AlignPlacementMode(ScreenCoordinates mouseScreen)
         {
-            MouseCoords = ScreenToPlayerGrid(mouseScreen);
+            MouseCoords = ScreenToCursorGrid(mouseScreen);
 
             var mapGrid = pManager.MapManager.GetGrid(MouseCoords.GridID);
             CurrentTile = mapGrid.GetTileRef(MouseCoords);

--- a/Robust.Client/Placement/Modes/AlignWall.cs
+++ b/Robust.Client/Placement/Modes/AlignWall.cs
@@ -11,7 +11,7 @@ namespace Robust.Client.Placement.Modes
 
         public override void AlignPlacementMode(ScreenCoordinates mouseScreen)
         {
-            MouseCoords = ScreenToPlayerGrid(mouseScreen);
+            MouseCoords = ScreenToCursorGrid(mouseScreen);
             CurrentTile = pManager.MapManager.GetGrid(MouseCoords.GridID).GetTileRef(MouseCoords);
 
             if (pManager.CurrentPermission.IsTile)

--- a/Robust.Client/Placement/Modes/PlaceFree.cs
+++ b/Robust.Client/Placement/Modes/PlaceFree.cs
@@ -8,7 +8,7 @@ namespace Robust.Client.Placement.Modes
 
         public override void AlignPlacementMode(ScreenCoordinates mouseScreen)
         {
-            MouseCoords = ScreenToPlayerGrid(mouseScreen);
+            MouseCoords = ScreenToCursorGrid(mouseScreen);
             CurrentTile = pManager.MapManager.GetGrid(MouseCoords.GridID).GetTileRef(MouseCoords);
         }
 

--- a/Robust.Client/Placement/Modes/PlaceNearby.cs
+++ b/Robust.Client/Placement/Modes/PlaceNearby.cs
@@ -10,7 +10,7 @@ namespace Robust.Client.Placement.Modes
 
         public override void AlignPlacementMode(ScreenCoordinates mouseScreen)
         {
-            MouseCoords = ScreenToPlayerGrid(mouseScreen);
+            MouseCoords = ScreenToCursorGrid(mouseScreen);
             CurrentTile = pManager.MapManager.GetGrid(MouseCoords.GridID).GetTileRef(MouseCoords);
         }
 

--- a/Robust.Client/Placement/PlacementMode.cs
+++ b/Robust.Client/Placement/PlacementMode.cs
@@ -107,7 +107,8 @@ namespace Robust.Client.Placement
             var size = SpriteToDraw.Size;
             foreach (var coordinate in locationcollection)
             {
-                var pos = coordinate.Position - (size/(float)EyeManager.PIXELSPERMETER) / 2f;
+                var worldPos = pManager.MapManager.GetGrid(coordinate.GridID).LocalToWorld(coordinate).Position;
+                var pos = worldPos - (size/(float)EyeManager.PIXELSPERMETER) / 2f;
                 var color = IsValidPosition(coordinate) ? ValidPlaceColor : InvalidPlaceColor;
                 handle.DrawTexture(SpriteToDraw, pos, color);
             }
@@ -206,7 +207,8 @@ namespace Robust.Client.Placement
 
         protected Vector2 ScreenToWorld(Vector2 point)
         {
-            return pManager.eyeManager.ScreenToWorld(point).Position;
+            var gridCoords = pManager.eyeManager.ScreenToWorld(point);
+            return gridCoords.ToWorld(pManager.MapManager).Position;
         }
 
         protected Vector2 WorldToScreen(Vector2 point)
@@ -214,11 +216,9 @@ namespace Robust.Client.Placement
             return pManager.eyeManager.WorldToScreen(point);
         }
 
-        protected GridCoordinates ScreenToPlayerGrid(ScreenCoordinates coords)
+        protected GridCoordinates ScreenToCursorGrid(ScreenCoordinates coords)
         {
-            var worldPos = ScreenToWorld(coords.Position);
-            var entityGrid = pManager.PlayerManager.LocalPlayer.ControlledEntity.Transform.GridID;
-            return new GridCoordinates(worldPos, entityGrid);
+            return pManager.eyeManager.ScreenToWorld(coords.Position);
         }
     }
 }

--- a/Robust.Server/Placement/PlacementManager.cs
+++ b/Robust.Server/Placement/PlacementManager.cs
@@ -151,7 +151,7 @@ namespace Robust.Server.Placement
             else // create a new grid
             {
                 var newGrid = map.CreateGrid();
-                newGrid.WorldPosition = position;
+                newGrid.WorldPosition = position + (newGrid.TileSize / 2f); // assume bottom left tile origin
                 var tilePos = newGrid.WorldToTile(position);
                 newGrid.SetTile(tilePos, new Tile(tileType));
             }

--- a/Robust.Server/Placement/PlacementManager.cs
+++ b/Robust.Server/Placement/PlacementManager.cs
@@ -143,8 +143,29 @@ namespace Robust.Server.Placement
 
             if (closest != null) // stick to existing grid
             {
-                var normal = new Angle(position - intersect.Center).GetCardinalDir().ToVec(); // round to nearest cardinal dir
-                var newTilePos = position + normal * closest.TileSize;
+                // round to nearest cardinal dir
+                var normal = new Angle(position - intersect.Center).GetCardinalDir().ToVec();
+
+                // round coords to center of tile
+                var tileIndices = closest.WorldToTile(intersect.Center);
+                var tileCenterLocal = closest.GridTileToLocal(tileIndices);
+                var tileCenterWorld = tileCenterLocal.ToWorld(_mapManager).Position;
+
+                // move mouse one tile out along normal
+                var newTilePos = tileCenterWorld + normal * closest.TileSize;
+
+                // you can always remove a tile
+                if(Tile.Empty.TypeId != tileType)
+                {
+                    var tileBounds = Box2.UnitCentered.Scale(closest.TileSize).Translated(newTilePos);
+
+                    var collideCount = map.FindGridsIntersecting(tileBounds).Count();
+
+                    // prevent placing a tile if it overlaps more than one grid
+                    if(collideCount > 1)
+                        return;
+                }
+
                 var pos = closest.WorldToTile(position);
                 closest.SetTile(pos, new Tile(tileType));
             }

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -228,7 +228,7 @@ namespace Robust.Shared.GameObjects.Components.Transform
                     // Eh.
                     if (_mapManager.TryGetGrid(GridID, out var grid))
                     {
-                        return grid.ConvertToWorld(GetLocalPosition());
+                        return grid.LocalToWorld(GetLocalPosition());
                     }
                     return GetLocalPosition();
                 }

--- a/Robust.Shared/Map/IMapGrid.cs
+++ b/Robust.Shared/Map/IMapGrid.cs
@@ -150,8 +150,8 @@ namespace Robust.Shared.Map
         /// </summary>
         /// <param name="posLocal">The local vector with this grid as origin.</param>
         /// <returns>The world-space vector with global origin.</returns>
-        Vector2 ConvertToWorld(Vector2 posLocal);
-
+        Vector2 LocalToWorld(Vector2 posLocal);
+        
         /// <summary>
         ///     Transforms World position into grid tile indices.
         /// </summary>

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -349,7 +349,7 @@ namespace Robust.Shared.Map
         }
 
         /// <inheritdoc />
-        public Vector2 ConvertToWorld(Vector2 posLocal)
+        public Vector2 LocalToWorld(Vector2 posLocal)
         {
             return posLocal + WorldPosition;
         }


### PR DESCRIPTION
This changes how tiles are placed with the map editor. Now the placement square will stick to and align with the grid that the cursor is near. When not near a grid, it will default to free placement. Now tiles cannot be placed when they would overlap two grids.

[Here is a video demonstrating it.](https://cdn.discordapp.com/attachments/310555209753690112/575411844261478411/2019-05-07_12-58-40.mp4)