### PR TITLE
Deleting AttachedEntity Crash Fix

### DIFF
--- a/Robust.Server/GameObjects/Components/Actor/BasicActorComponent.cs
+++ b/Robust.Server/GameObjects/Components/Actor/BasicActorComponent.cs
@@ -3,6 +3,7 @@ using Robust.Server.Interfaces.GameObjects;
 using Robust.Server.Interfaces.Player;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 
 namespace Robust.Server.GameObjects
@@ -13,6 +14,17 @@ namespace Robust.Server.GameObjects
 
         [ViewVariables]
         public IPlayerSession playerSession { get; internal set; }
+
+        public override void Shutdown()
+        {
+            base.Shutdown();
+
+            DebugTools.AssertNotNull(playerSession);
+
+            // Warning: careful here, Detach removes this component, make sure this is after the base shutdown
+            // to prevent infinite recursion
+            playerSession.DetachFromEntity();
+        }
     }
 
     /// <summary>

--- a/Robust.Server/Player/PlayerSession.cs
+++ b/Robust.Server/Player/PlayerSession.cs
@@ -107,16 +107,27 @@ namespace Robust.Server.Player
         /// <inheritdoc />
         public void DetachFromEntity()
         {
-            if (AttachedEntity == null)
-            {
+            if(AttachedEntity == null)
                 return;
+
+            if (AttachedEntity.Deleted)
+            {
+                throw new InvalidOperationException("Tried to detach player, but my entity does not exist!");
             }
 
-            AttachedEntity.SendMessage(AttachedEntity.GetComponent<BasicActorComponent>(), new PlayerDetachedMsg(this));
-            AttachedEntity.EntityManager.RaiseEvent(this, new PlayerDetachedSystemMessage(AttachedEntity));
-            AttachedEntity.RemoveComponent<BasicActorComponent>();
-            AttachedEntity = null;
-            UpdatePlayerState();
+            if (AttachedEntity.TryGetComponent<BasicActorComponent>(out var actor))
+            {
+                AttachedEntity.SendMessage(actor, new PlayerDetachedMsg(this));
+                AttachedEntity.EntityManager.RaiseEvent(this, new PlayerDetachedSystemMessage(AttachedEntity));
+                AttachedEntity.RemoveComponent<BasicActorComponent>();
+                AttachedEntity = null;
+                UpdatePlayerState();
+            }
+            else
+            {
+                throw new InvalidOperationException("Tried to detach player, but entity does not have ActorComponent!");
+            }
+
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixes game crashing because the player entity got deleted. The session holds an instance of IEntity, and wasn't being notified if the entity was deleted.