### PR TITLE
Reliable networked ECS Events.

### DIFF
--- a/Robust.Shared/Network/Messages/MsgEntity.cs
+++ b/Robust.Shared/Network/Messages/MsgEntity.cs
@@ -13,7 +13,7 @@ namespace Robust.Shared.Network.Messages
     public class MsgEntity : NetMessage
     {
         #region REQUIRED
-        public static readonly MsgGroups GROUP = MsgGroups.Entity;
+        public static readonly MsgGroups GROUP = MsgGroups.EntityEvent;
         public static readonly string NAME = nameof(MsgEntity);
         public MsgEntity(INetChannel channel) : base(NAME, GROUP) { }
         #endregion

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -707,6 +707,7 @@ namespace Robust.Shared.Network
                 case MsgGroups.Core:
                 case MsgGroups.String:
                 case MsgGroups.Command:
+                case MsgGroups.EntityEvent:
                     return NetDeliveryMethod.ReliableUnordered;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(group), group, null);

--- a/Robust.Shared/Network/NetMessage.cs
+++ b/Robust.Shared/Network/NetMessage.cs
@@ -32,6 +32,11 @@ namespace Robust.Shared.Network
         /// A command message from client -> server.
         /// </summary>
         Command,
+
+        /// <summary>
+        /// ECS Events between the server and the client.
+        /// </summary>
+        EntityEvent,
     }
 
     /// <summary>


### PR DESCRIPTION
ECS Events are now sent as reliable, and have their own message category. This solves the problem of lost messages, causing things like ViewVariables and input to break.

This Resolves space-wizards/RobustToolbox/issues/766.