### PR TITLE
Add StyleBox overrides to ProgressBar

### DIFF
--- a/Robust.Client/UserInterface/Controls/ProgressBar.cs
+++ b/Robust.Client/UserInterface/Controls/ProgressBar.cs
@@ -43,26 +43,26 @@ namespace Robust.Client.UserInterface.Controls
         }
 
         [Pure]
-        private StyleBoxFlat _getBackground()
+        private StyleBox _getBackground()
         {
             if (BackgroundStyleBoxOverride != null)
             {
                 return BackgroundStyleBoxOverride;
             }
 
-            TryGetStyleProperty(StylePropertyBackground, out StyleBoxFlat ret);
+            TryGetStyleProperty(StylePropertyBackground, out StyleBox ret);
             return ret;
         }
 
         [Pure]
-        private StyleBoxFlat _getForeground()
+        private StyleBox _getForeground()
         {
             if (ForegroundStyleBoxOverride != null)
             {
                 return ForegroundStyleBoxOverride;
             }
 
-            TryGetStyleProperty(StylePropertyForeground, out StyleBoxFlat ret);
+            TryGetStyleProperty(StylePropertyForeground, out StyleBox ret);
             return ret;
         }
 

--- a/Robust.Client/UserInterface/Controls/ProgressBar.cs
+++ b/Robust.Client/UserInterface/Controls/ProgressBar.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics.Contracts;
 using Robust.Client.Graphics.Drawing;
 using Robust.Shared.Maths;
@@ -11,6 +11,9 @@ namespace Robust.Client.UserInterface.Controls
         public const string StylePropertyBackground = "background";
         public const string StylePropertyForeground = "foreground";
 
+        private StyleBoxFlat _backgroundStyleBoxOverride;
+        private StyleBoxFlat _foregroundStyleBoxOverride;
+
         public ProgressBar()
         {
         }
@@ -19,17 +22,47 @@ namespace Robust.Client.UserInterface.Controls
         {
         }
 
-        [Pure]
-        private StyleBox _getBackground()
+        public StyleBoxFlat BackgroundStyleBoxOverride
         {
-            TryGetStyleProperty(StylePropertyBackground, out StyleBox ret);
+            get => _backgroundStyleBoxOverride;
+            set
+            {
+                _backgroundStyleBoxOverride = value;
+                MinimumSizeChanged();
+            }
+        }
+
+        public StyleBoxFlat ForegroundStyleBoxOverride
+        {
+            get => _foregroundStyleBoxOverride;
+            set
+            {
+                _foregroundStyleBoxOverride = value;
+                MinimumSizeChanged();
+            }
+        }
+
+        [Pure]
+        private StyleBoxFlat _getBackground()
+        {
+            if (BackgroundStyleBoxOverride != null)
+            {
+                return BackgroundStyleBoxOverride;
+            }
+
+            TryGetStyleProperty(StylePropertyBackground, out StyleBoxFlat ret);
             return ret;
         }
 
         [Pure]
-        private StyleBox _getForeground()
+        private StyleBoxFlat _getForeground()
         {
-            TryGetStyleProperty(StylePropertyForeground, out StyleBox ret);
+            if (ForegroundStyleBoxOverride != null)
+            {
+                return ForegroundStyleBoxOverride;
+            }
+
+            TryGetStyleProperty(StylePropertyForeground, out StyleBoxFlat ret);
             return ret;
         }
 

--- a/Robust.Client/UserInterface/Controls/ProgressBar.cs
+++ b/Robust.Client/UserInterface/Controls/ProgressBar.cs
@@ -11,8 +11,8 @@ namespace Robust.Client.UserInterface.Controls
         public const string StylePropertyBackground = "background";
         public const string StylePropertyForeground = "foreground";
 
-        private StyleBoxFlat _backgroundStyleBoxOverride;
-        private StyleBoxFlat _foregroundStyleBoxOverride;
+        private StyleBox _backgroundStyleBoxOverride;
+        private StyleBox _foregroundStyleBoxOverride;
 
         public ProgressBar()
         {
@@ -22,7 +22,7 @@ namespace Robust.Client.UserInterface.Controls
         {
         }
 
-        public StyleBoxFlat BackgroundStyleBoxOverride
+        public StyleBox BackgroundStyleBoxOverride
         {
             get => _backgroundStyleBoxOverride;
             set
@@ -32,7 +32,7 @@ namespace Robust.Client.UserInterface.Controls
             }
         }
 
-        public StyleBoxFlat ForegroundStyleBoxOverride
+        public StyleBox ForegroundStyleBoxOverride
         {
             get => _foregroundStyleBoxOverride;
             set


### PR DESCRIPTION
This adds foreground and background style box overrides to `ProgressBar` primarily so it's colors can be changed easily. The overrides are `StyleBoxFlat` types instead of `StyleBox` as `StyleBox` doesn't have a color property. `ProgressBar._getBackground` and `ProgressBar._getForeground` were also changed to return `StyleBoxFlat` instead of `StyleBox` to keep things simple rather than interchangeably using the two types throughout the class.