### PR TITLE
Add Control.SetOnlyStyleClass

### DIFF
--- a/Robust.Client/UserInterface/Control.Styling.cs
+++ b/Robust.Client/UserInterface/Control.Styling.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Robust.Shared.ViewVariables;
 
@@ -57,6 +57,13 @@ namespace Robust.Client.UserInterface
         public void RemoveStyleClass(string className)
         {
             _styleClasses.Remove(className);
+            Restyle();
+        }
+
+        public void SetOnlyStyleClass(string className)
+        {
+            _styleClasses.Clear();
+            _styleClasses.Add(className);
             Restyle();
         }
 


### PR DESCRIPTION
This clears the hash set of style classes and adds the one passed to the function. This allows controls to easily switch their active StyleClass. Normally you would need to repeatedly call `Control.AddStyleClass` and `Control.RemoveStyleClass` and keep track of the active StyleClass in your own code.