### PR TITLE
Box2Rotated & Vector2 Rotation

### DIFF
--- a/Robust.Shared.Maths/Angle.cs
+++ b/Robust.Shared.Maths/Angle.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 
 namespace Robust.Shared.Maths
 {
@@ -75,6 +76,21 @@ namespace Robust.Shared.Maths
                 ang += 2 * (float) Math.PI;
 
             return (Direction) (Math.Floor((ang + CardinalOffset) / CardinalSegment) * 2 % 8);
+        }
+
+        /// <summary>
+        ///     Rotates the vector counter-clockwise around its origin by the value of Theta.
+        /// </summary>
+        /// <param name="vec">Vector to rotate.</param>
+        /// <returns>New rotated vector.</returns>
+        [Pure]
+        public Vector2 RotateVec(in Vector2 vec)
+        {
+            var (x, y) = vec;
+            var dx = Math.Cos(Theta) * x - Math.Sin(Theta) * y;
+            var dy = Math.Sin(Theta) * x + Math.Cos(Theta) * y;
+
+            return new Vector2((float)dx, (float)dy);
         }
 
         public bool EqualsApprox(Angle other, double tolerance)

--- a/Robust.Shared.Maths/Box2Rotated.cs
+++ b/Robust.Shared.Maths/Box2Rotated.cs
@@ -1,0 +1,80 @@
+﻿using System;
+
+namespace Robust.Shared.Maths
+{
+    /// <summary>
+    ///     This type contains a <see cref="Box2"/> and a rotation <see cref="Angle"/> in world space.
+    /// </summary>
+    [Serializable]
+    public readonly struct Box2Rotated : IEquatable<Box2Rotated>
+    {
+        public readonly Box2 Box;
+        public readonly Angle Rotation;
+
+        /// <summary>
+        ///     A 1x1 unit box with the origin centered and identity rotation.
+        /// </summary>
+        public static readonly Box2Rotated UnitCentered = new Box2Rotated(Box2.UnitCentered, Angle.Zero);
+
+        public Vector2 BottomRight => Rotation.RotateVec(new Vector2(Box.Right, Box.Bottom));
+        public Vector2 TopLeft => Rotation.RotateVec(new Vector2(Box.Left, Box.Top));
+        public Vector2 TopRight => Rotation.RotateVec(new Vector2(Box.Right, Box.Top));
+        public Vector2 BottomLeft => Rotation.RotateVec(new Vector2(Box.Left, Box.Bottom));
+
+        public Box2Rotated(Box2 box, Angle rotation)
+        {
+            Box = box;
+            Rotation = rotation;
+        }
+
+        #region Equality
+
+        /// <inheritdoc />
+        public bool Equals(Box2Rotated other)
+        {
+            return Box.Equals(other.Box) && Rotation.Equals(other.Rotation);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            return obj is Box2Rotated other && Equals(other);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Box.GetHashCode() * 397) ^ Rotation.GetHashCode();
+            }
+        }
+
+        /// <summary>
+        ///     Check for equality by value between two <see cref="Box2Rotated"/>.
+        /// </summary>
+        public static bool operator ==(Box2Rotated a, Box2Rotated b)
+        {
+            return a.Equals(b);
+        }
+
+        /// <summary>
+        ///     Check for inequality by value between two <see cref="Box2Rotated"/>.
+        /// </summary>
+        public static bool operator !=(Box2Rotated a, Box2Rotated b)
+        {
+            return !a.Equals(b);
+        }
+
+        #endregion
+
+        /// <summary>
+        ///     Returns a string representation of this type.
+        /// </summary>
+        public override string ToString()
+        {
+            return $"{Box.ToString()}, {Rotation.ToString()}";
+        }
+    }
+}

--- a/Robust.UnitTesting/Shared/Maths/Angle_Test.cs
+++ b/Robust.UnitTesting/Shared/Maths/Angle_Test.cs
@@ -148,5 +148,17 @@ namespace Robust.UnitTesting.Shared.Maths
 
             Assert.That(target.GetCardinalDir(), Is.EqualTo(test.Item3));
         }
+
+        [Test]
+        public void TestAngleRotateVec()
+        {
+            var angle = new Angle(MathHelper.Pi / 6);
+            var vec = new Vector2(0.5f, 0.5f);
+
+            var result = angle.RotateVec(vec);
+
+            Assert.That(FloatMath.CloseTo(result.X, 0.183013f), Is.True, result.X.ToString);
+            Assert.That(FloatMath.CloseTo(result.Y, 0.683013f), Is.True, result.Y.ToString);
+        }
     }
 }

--- a/Robust.UnitTesting/Shared/Maths/Angle_Test.cs
+++ b/Robust.UnitTesting/Shared/Maths/Angle_Test.cs
@@ -157,8 +157,7 @@ namespace Robust.UnitTesting.Shared.Maths
 
             var result = angle.RotateVec(vec);
 
-            Assert.That(FloatMath.CloseTo(result.X, 0.183013f), Is.True, result.X.ToString);
-            Assert.That(FloatMath.CloseTo(result.Y, 0.683013f), Is.True, result.Y.ToString);
+            Assert.That(result, new ApproxEqualityConstraint(new Vector2(0.183013f, 0.683013f)));
         }
     }
 }


### PR DESCRIPTION
* Adds the Box2Rotated struct for holding a box rotated in worldspace. IDK how useful this will be, we will see.
* Adds a function to rotate a Vector2 by an Angle. Now you don't have to explicity build a rotation matrix to rotate a vector!