### PR TITLE
Add support for diagonal RSI sprites

### DIFF
--- a/Robust.Client/Graphics/RSI/RSI.State.cs
+++ b/Robust.Client/Graphics/RSI/RSI.State.cs
@@ -57,6 +57,7 @@ namespace Robust.Client.Graphics
             {
                 Dir1,
                 Dir4,
+                Dir8,
             }
 
             public enum Direction : byte
@@ -65,6 +66,10 @@ namespace Robust.Client.Graphics
                 North = 1,
                 East = 2,
                 West = 3,
+                SouthEast = 4,
+                SouthWest = 5,
+                NorthEast = 6,
+                NorthWest = 7,
             }
 
             public (Texture icon, float delay) GetFrame(Direction direction, int frame)
@@ -90,7 +95,7 @@ namespace Robust.Client.Graphics
                 {
                     return GetFrame(Direction.South, 0).icon;
                 }
-                return GetFrame(dir.Convert(), 0).icon;
+                return GetFrame(dir.Convert(Directions), 0).icon;
             }
         }
     }

--- a/Robust.Client/ResourceManagement/ResourceTypes/RSIResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/RSIResource.cs
@@ -86,6 +86,9 @@ namespace Robust.Client.ResourceManagement
                     case 4:
                         directions = RSI.State.DirectionType.Dir4;
                         break;
+                    case 8:
+                        directions = RSI.State.DirectionType.Dir8;
+                        break;
                     default:
                         throw new RSILoadException($"Invalid direction: {dirValue}");
                 }

--- a/Robust.Client/Utility/DirExt.cs
+++ b/Robust.Client/Utility/DirExt.cs
@@ -22,23 +22,60 @@ namespace Robust.Client.Utility
 
                 case RSIDirection.West:
                     return Direction.West;
+
+                case RSIDirection.SouthEast:
+                    return Direction.SouthEast;
+
+                case RSIDirection.SouthWest:
+                    return Direction.SouthWest;
+
+                case RSIDirection.NorthEast:
+                    return Direction.NorthEast;
+
+                case RSIDirection.NorthWest:
+                    return Direction.NorthWest;
             }
 
             throw new ArgumentException($"Unknown RSI dir: {dir}.", nameof(dir));
         }
 
-        public static RSIDirection Convert(this Direction dir)
+        /// <summary>
+        /// 'Rounds' a diagonal direction down to a cardinal direction
+        /// </summary>
+        /// <param name="dir">The direction to round</param>
+        /// <returns><paramref name="dir"/> if it's a cardinal direction, otherwise either north or
+        /// south.</returns>
+        public static RSIDirection RoundToCardinal(this RSIDirection dir)
         {
             switch (dir)
             {
+                case RSIDirection.NorthEast:
+                case RSIDirection.NorthWest:
+                    return RSIDirection.North;
+
+                case RSIDirection.SouthEast:
+                case RSIDirection.SouthWest:
+                    return RSIDirection.South;
+
+                default:
+                    return dir;
+            }
+        }
+
+        public static RSIDirection Convert(this Direction dir, RSI.State.DirectionType type)
+        {
+            // Round down to a four-way direction if appropriate
+            if (type != RSI.State.DirectionType.Dir8)
+            {
+                return dir.Convert(RSI.State.DirectionType.Dir8).RoundToCardinal();
+            }
+
+            switch (dir)
+            {
                 case Direction.North:
-                case Direction.NorthEast:
-                case Direction.NorthWest:
                     return RSIDirection.North;
 
                 case Direction.South:
-                case Direction.SouthEast:
-                case Direction.SouthWest:
                     return RSIDirection.South;
 
                 case Direction.East:
@@ -46,6 +83,18 @@ namespace Robust.Client.Utility
 
                 case Direction.West:
                     return RSIDirection.West;
+
+                case Direction.SouthEast:
+                    return RSIDirection.SouthEast;
+
+                case Direction.SouthWest:
+                    return RSIDirection.SouthWest;
+
+                case Direction.NorthEast:
+                    return RSIDirection.NorthEast;
+
+                case Direction.NorthWest:
+                    return RSIDirection.NorthWest;
             }
 
             throw new ArgumentException($"Unknown dir: {dir}.", nameof(dir));


### PR DESCRIPTION
See [RSI.py#1](https://github.com/space-wizards/RSI.py/pull/1) for the other side of this.

This allows the game to load and use diagonal sprites.