### PR TITLE
Add a check in OnContextChanged to fix some crashes and refactored BaseButton

### DIFF
--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -72,7 +72,7 @@ namespace Robust.Client.Input
             foreach (var function in args.OldContext.Except(args.NewContext))
             {
                 var bind = _bindings.Find(binding => binding.Function == function);
-                if (bind == null)
+                if (bind == null || bind.State == BoundKeyState.Up)
                 {
                     continue;
                 }

--- a/Robust.Client/UserInterface/Controls/BaseButton.cs
+++ b/Robust.Client/UserInterface/Controls/BaseButton.cs
@@ -96,18 +96,18 @@ namespace Robust.Client.UserInterface.Controls
                 {
                     return DrawModeEnum.Disabled;
                 }
-
-                if (Pressed || _attemptingPress)
+                else if (Pressed || _attemptingPress)
                 {
                     return DrawModeEnum.Pressed;
                 }
-
-                if (IsHovered)
+                else if (IsHovered)
                 {
                     return DrawModeEnum.Hover;
                 }
-
-                return DrawModeEnum.Normal;
+                else
+                {
+                    return DrawModeEnum.Normal;
+                }
             }
         }
 
@@ -177,7 +177,7 @@ namespace Robust.Client.UserInterface.Controls
         {
             base.KeyBindUp(args);
 
-            if (Disabled)
+            if (Disabled || (!_enableAllKeybinds && !args.CanFocus))
             {
                 return;
             }
@@ -186,7 +186,8 @@ namespace Robust.Client.UserInterface.Controls
             OnButtonUp?.Invoke(buttonEventArgs);
 
             var drawMode = DrawMode;
-            if (Mode == ActionMode.Release && _attemptingPress)
+            if (Mode == ActionMode.Release && _attemptingPress &&
+                this == UserInterfaceManagerInternal.MouseGetControl(args.PointerLocation.Position))
             {
                 if (ToggleMode)
                 {

--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -259,7 +259,7 @@ namespace Robust.Client.UserInterface
         {
             _resetTooltipTimer();
             // Update which control is considered hovered.
-            var newHovered = _controlFocused ?? MouseGetControl(mouseMoveEventArgs.Position);
+            var newHovered = MouseGetControl(mouseMoveEventArgs.Position);
             if (newHovered != CurrentlyHovered)
             {
                 _clearTooltip();


### PR DESCRIPTION
Fixes crashes due to double input. (e.g. the Quit button in the Esc menu.)