### PR TITLE
Make IConGroupController and ConGroupIndex public

### DIFF
--- a/Robust.Server/Console/ConGroupIndex.cs
+++ b/Robust.Server/Console/ConGroupIndex.cs
@@ -1,6 +1,6 @@
 ﻿namespace Robust.Server.Console
 {
-    internal struct ConGroupIndex
+    public struct ConGroupIndex
     {
         public int Index { get; }
 

--- a/Robust.Server/Console/IConGroupController.cs
+++ b/Robust.Server/Console/IConGroupController.cs
@@ -1,8 +1,8 @@
-using Robust.Server.Interfaces.Player;
+﻿using Robust.Server.Interfaces.Player;
 
 namespace Robust.Server.Console
 {
-    internal interface IConGroupController
+    public interface IConGroupController
     {
         void Initialize();
 


### PR DESCRIPTION
These should be public so they can be used in content to check if players are in the right group (admin, mod, etc) before doing certain things. Required by PR 380 in content (https://github.com/space-wizards/space-station-14/pull/380).