### PR TITLE
Add to OptionButton and SpinBox

### DIFF
--- a/Robust.Client/UserInterface/Controls/OptionButton.cs
+++ b/Robust.Client/UserInterface/Controls/OptionButton.cs
@@ -14,6 +14,8 @@ namespace Robust.Client.UserInterface.Controls
 
         public event Action<ItemSelectedEventArgs> OnItemSelected;
 
+        public string Prefix { get; set; }
+
         public void AddItem(Texture icon, string label, int? id = null)
         {
             AddItem(label, id);
@@ -112,7 +114,7 @@ namespace Robust.Client.UserInterface.Controls
             prev.Button.Pressed = false;
             var data = _buttonData[idx];
             SelectedId = data.Id;
-            Text = data.Text;
+            Text = Prefix + data.Text;
             data.Button.Pressed = true;
         }
 
@@ -177,6 +179,7 @@ namespace Robust.Client.UserInterface.Controls
 
         public OptionButton()
         {
+            Prefix = "";
             OnPressed += _onPressed;
             _popup = new Popup();
             UserInterfaceManager.ModalRoot.AddChild(_popup);

--- a/Robust.Client/UserInterface/Controls/SpinBox.cs
+++ b/Robust.Client/UserInterface/Controls/SpinBox.cs
@@ -1,7 +1,6 @@
-﻿using Robust.Client.Graphics.Drawing;
-using Robust.Shared.Maths;
+﻿using Robust.Shared.Maths;
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 
 namespace Robust.Client.UserInterface.Controls
 {
@@ -15,10 +14,22 @@ namespace Robust.Client.UserInterface.Controls
         private List<Button> _rightButtons = new List<Button>();
         private int _stepSize = 1;
 
+        /// <summary>
+        ///     Determines whether the SpinBox value gets changed by the input text.
+        /// </summary>
+        public Func<int, bool> IsValid { get; set; }
+
         public int Value
         {
             get => int.TryParse(_lineEdit.Text, out int i) ? i : 0;
-            set => _lineEdit.Text = value.ToString();
+            set
+            {
+                if (IsValid != null && !IsValid(value))
+                {
+                    return;
+                }
+                _lineEdit.Text = value.ToString();
+            }
         }
 
         public SpinBox() : base()


### PR DESCRIPTION
Prefix for OptionButton is for adding text before the selected option like 'Category: '.

Validation is for setting the limits of the SpinBox number range.