### PR TITLE
Map & Grid Entities

### DIFF
--- a/Robust.Client/GameObjects/ClientComponentFactory.cs
+++ b/Robust.Client/GameObjects/ClientComponentFactory.cs
@@ -4,6 +4,7 @@ using Robust.Client.GameObjects.Components.UserInterface;
 using Robust.Client.Interfaces.GameObjects;
 using Robust.Client.Interfaces.GameObjects.Components;
 using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects.Components.Map;
 using Robust.Shared.GameObjects.Components.Transform;
 using Robust.Shared.GameObjects.Components.UserInterface;
 using Robust.Shared.Interfaces.GameObjects.Components;
@@ -22,6 +23,12 @@ namespace Robust.Client.GameObjects
             // Required for the engine to work
             Register<TransformComponent>();
             RegisterReference<TransformComponent, ITransformComponent>();
+
+            Register<MapComponent>();
+            RegisterReference<MapComponent, IMapComponent>();
+
+            Register<MapGridComponent>();
+            RegisterReference<MapGridComponent, IMapGridComponent>();
 
             Register<CollidableComponent>();
             RegisterReference<CollidableComponent, IPhysBody>();

--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -186,38 +186,42 @@ namespace Robust.Client.GameObjects
 
         public override IEntity CreateEntityUninitialized(string prototypeName, GridCoordinates coordinates)
         {
-            var newEnt = CreateEntity(prototypeName, NewClientEntityUid());
-            newEnt.Transform.GridPosition = coordinates;
-            return newEnt;
+            var newEntity = CreateEntity(prototypeName, NewClientEntityUid());
+            if (coordinates.GridID != GridId.Nullspace)
+            {
+                var gridEntityId = _mapManager.GetGrid(coordinates.GridID).GridEntity;
+                newEntity.Transform.AttachParent(GetEntity(gridEntityId));
+                newEntity.Transform.LocalPosition = coordinates.Position;
+            }
+            return newEntity;
         }
 
         public override IEntity CreateEntityUninitialized(string prototypeName, MapCoordinates coordinates)
         {
-            var newEnt = CreateEntity(prototypeName, NewClientEntityUid());
-            newEnt.Transform.MapPosition = coordinates;
-            return newEnt;
+            var newEntity = CreateEntity(prototypeName, NewClientEntityUid());
+            if (coordinates.MapId != MapId.Nullspace)
+            {
+                newEntity.Transform.AttachParent(_mapManager.GetMapEntity(coordinates.MapId));
+                newEntity.Transform.WorldPosition = coordinates.Position;
+            }
+            return newEntity;
         }
 
         public override IEntity SpawnEntity(string protoName, GridCoordinates coordinates)
         {
-            var ent = CreateEntity(protoName, NewClientEntityUid());
-            ent.Transform.GridPosition = coordinates;
-            InitializeAndStartEntity(ent);
-            return ent;
+            return SpawnEntityNoMapInit(protoName, coordinates);
         }
 
         public override IEntity SpawnEntityNoMapInit(string protoName, GridCoordinates coordinates)
         {
-            return SpawnEntity(protoName, coordinates);
+            var newEnt = CreateEntityUninitialized(protoName, coordinates);
+            InitializeAndStartEntity((Entity)newEnt);
+            return newEnt;
         }
 
         public override IEntity SpawnEntityAt(string entityType, GridCoordinates coordinates)
         {
-            var entity = CreateEntity(entityType, NewClientEntityUid());
-            entity.Transform.GridPosition = coordinates;
-            InitializeAndStartEntity(entity);
-
-            return entity;
+            return SpawnEntity(entityType, coordinates);
         }
 
         private EntityUid NewClientEntityUid()

--- a/Robust.Server/BaseServer.cs
+++ b/Robust.Server/BaseServer.cs
@@ -224,6 +224,8 @@ namespace Robust.Server
             _serializer.Initialize();
 
             // Initialize Tier 2 services
+            IoCManager.Resolve<IGameTiming>().InSimulation = true;
+
             _stateManager.Initialize();
             _entities.Initialize();
             IoCManager.Resolve<IPlayerManager>().Initialize(MaxPlayers);
@@ -268,6 +270,8 @@ namespace Robust.Server
 
             // set GameLoop.Running to false to return from this function.
             _mainLoop.Run();
+
+            _time.InSimulation = true;
             Cleanup();
         }
 

--- a/Robust.Server/GameObjects/Components/Container/Container.cs
+++ b/Robust.Server/GameObjects/Components/Container/Container.cs
@@ -3,6 +3,7 @@ using JetBrains.Annotations;
 using Robust.Server.GameObjects.EntitySystemMessages;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Server.Interfaces.GameObjects;
+using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects.Components;
 using Robust.Shared.Maths;
@@ -125,14 +126,12 @@ namespace Robust.Server.GameObjects.Components.Container
 
             var transform = toinsert.Transform;
 
-            // The transform.Parent.Owner != Owner is there because map deserialization of containers still uses Insert()
-            // In which case the child is already parented. To us. Don't reject him hand him to the orphanage.
-            // Perhaps making it not use Insert() is a good idea but eh.
-            if (transform.Parent == null // Only true if Parent is the map entity
-                || !transform.Parent.Owner.TryGetComponent(out IContainerManager containerManager)
-                || !containerManager.Remove(toinsert))
+            if (transform.Parent == null) // Only true if Parent is the map entity
+                return false;
+
+            if(ContainerHelpers.TryGetContainer(transform.Parent.Owner, out var containerManager) && !containerManager.Remove(toinsert))
             {
-                // Can't detach the entity from its parent, can't insert.
+                // Can't remove from existing container, can't insert.
                 return false;
             }
             InternalInsert(toinsert);

--- a/Robust.Server/GameObjects/Components/Container/Container.cs
+++ b/Robust.Server/GameObjects/Components/Container/Container.cs
@@ -4,6 +4,7 @@ using Robust.Server.GameObjects.EntitySystemMessages;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Server.Interfaces.GameObjects;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Interfaces.GameObjects.Components;
 using Robust.Shared.Maths;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
@@ -98,6 +99,21 @@ namespace Robust.Server.GameObjects.Components.Container
             Manager = manager;
         }
 
+        private static bool RecursiveFindContainerMan(ITransformComponent transform,
+            out IContainerManager containerManager)
+        {
+            if (transform == null)
+            {
+                containerManager = default;
+                return false;
+            }
+
+            if (transform.Owner.TryGetComponent(out containerManager))
+                return true;
+
+            return RecursiveFindContainerMan(transform.Parent, out containerManager);
+        }
+
         /// <inheritdoc />
         public bool Insert(IEntity toinsert)
         {
@@ -108,10 +124,14 @@ namespace Robust.Server.GameObjects.Components.Container
                 return false;
 
             var transform = toinsert.Transform;
+
             // The transform.Parent.Owner != Owner is there because map deserialization of containers still uses Insert()
             // In which case the child is already parented. To us. Don't reject him hand him to the orphanage.
             // Perhaps making it not use Insert() is a good idea but eh.
-            if (!transform.IsMapTransform && transform.Parent.Owner != Owner && !transform.Parent.Owner.GetComponent<IContainerManager>().Remove(toinsert))
+            if (transform.Parent == null // Only true if Parent is the map entity
+                || transform.Parent.Owner == Owner
+                || !transform.Parent.Owner.TryGetComponent(out IContainerManager containerManager)
+                || !containerManager.Remove(toinsert))
             {
                 // Can't detach the entity from its parent, can't insert.
                 return false;

--- a/Robust.Server/GameObjects/Components/Container/Container.cs
+++ b/Robust.Server/GameObjects/Components/Container/Container.cs
@@ -129,7 +129,6 @@ namespace Robust.Server.GameObjects.Components.Container
             // In which case the child is already parented. To us. Don't reject him hand him to the orphanage.
             // Perhaps making it not use Insert() is a good idea but eh.
             if (transform.Parent == null // Only true if Parent is the map entity
-                || transform.Parent.Owner == Owner
                 || !transform.Parent.Owner.TryGetComponent(out IContainerManager containerManager)
                 || !containerManager.Remove(toinsert))
             {

--- a/Robust.Server/GameObjects/Components/Container/ContainerManagerComponent.cs
+++ b/Robust.Server/GameObjects/Components/Container/ContainerManagerComponent.cs
@@ -114,6 +114,16 @@ namespace Robust.Server.GameObjects.Components.Container
             return true;
         }
 
+        public bool ContainsEntity(IEntity entity)
+        {
+            foreach (var container in EntityContainers.Values)
+            {
+                return !container.Deleted && container.Contains(entity);
+            }
+
+            return false;
+        }
+
         public void ForceRemove(IEntity entity)
         {
             foreach (var container in EntityContainers.Values)
@@ -142,7 +152,7 @@ namespace Robust.Server.GameObjects.Components.Container
                     return containers.Remove(entity);
                 }
             }
-            return false;
+            return true; // If we don't contain the entity, it will always be removed
         }
 
         public override void OnRemove()

--- a/Robust.Server/GameObjects/EntitySystems/PhysicsSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/PhysicsSystem.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Robust.Server.Interfaces.Timing;
+using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.Interfaces.GameObjects;
@@ -64,7 +65,7 @@ namespace Robust.Server.GameObjects.EntitySystems
             }
 
             var transform = entity.Transform;
-            if (transform.Parent != null)
+            if (ContainerHelpers.IsInContainer(transform.Owner))
             {
                 transform.Parent.Owner.SendMessage(transform, new RelayMovementEntityMessage(entity));
                 velocity.LinearVelocity = Vector2.Zero;

--- a/Robust.Server/GameObjects/ServerComponentFactory.cs
+++ b/Robust.Server/GameObjects/ServerComponentFactory.cs
@@ -3,6 +3,7 @@ using Robust.Server.GameObjects.Components.Markers;
 using Robust.Server.GameObjects.Components.UserInterface;
 using Robust.Server.Interfaces.GameObjects;
 using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects.Components.Map;
 using Robust.Shared.GameObjects.Components.Transform;
 using Robust.Shared.GameObjects.Components.UserInterface;
 using Robust.Shared.Interfaces.GameObjects.Components;
@@ -20,6 +21,12 @@ namespace Robust.Server.GameObjects
             // Required for the engine to work
             Register<TransformComponent>();
             RegisterReference<TransformComponent, ITransformComponent>();
+
+            Register<MapComponent>();
+            RegisterReference<MapComponent, IMapComponent>();
+
+            Register<MapGridComponent>();
+            RegisterReference<MapGridComponent, IMapGridComponent>();
 
             RegisterIgnore("Icon");
             RegisterIgnore("Occluder");

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -30,14 +30,23 @@ namespace Robust.Server.GameObjects
         public override IEntity CreateEntityUninitialized(string prototypeName, GridCoordinates coordinates)
         {
             var newEntity = CreateEntity(prototypeName);
-            newEntity.Transform.GridPosition = coordinates;
+            if(coordinates.GridID != GridId.Nullspace)
+            {
+                var gridEntityId = _mapManager.GetGrid(coordinates.GridID).GridEntity;
+                newEntity.Transform.AttachParent(GetEntity(gridEntityId));
+                newEntity.Transform.LocalPosition = coordinates.Position;
+            }
             return newEntity;
         }
 
         public override IEntity CreateEntityUninitialized(string prototypeName, MapCoordinates coordinates)
         {
             var newEntity = CreateEntity(prototypeName);
-            newEntity.Transform.MapPosition = coordinates;
+            if(coordinates.MapId != MapId.Nullspace)
+            {
+                newEntity.Transform.AttachParent(_mapManager.GetMapEntity(coordinates.MapId));
+                newEntity.Transform.WorldPosition = coordinates.Position;
+            }
             return newEntity;
         }
 
@@ -50,18 +59,16 @@ namespace Robust.Server.GameObjects
 
         public override IEntity SpawnEntityNoMapInit(string protoName, GridCoordinates coordinates)
         {
-            var newEnt = CreateEntity(protoName);
-            newEnt.Transform.GridPosition = coordinates;
-            InitializeAndStartEntity(newEnt);
+            var newEnt = CreateEntityUninitialized(protoName, coordinates);
+            InitializeAndStartEntity((Entity)newEnt);
             return newEnt;
         }
 
         /// <inheritdoc />
         public override IEntity SpawnEntityAt(string entityType, GridCoordinates coordinates)
         {
-            var entity = CreateEntity(entityType);
-            entity.Transform.GridPosition = coordinates;
-            InitializeAndStartEntity(entity);
+            var entity = CreateEntityUninitialized(entityType, coordinates);
+            InitializeAndStartEntity((Entity)entity);
             var grid = _mapManager.GetGrid(coordinates.GridID);
             if (_pauseManager.IsMapInitialized(grid.ParentMapId))
             {

--- a/Robust.Shared/Containers/ContainerHelpers.cs
+++ b/Robust.Shared/Containers/ContainerHelpers.cs
@@ -19,12 +19,11 @@ namespace Robust.Shared.Containers
             DebugTools.Assert(entity != null);
             DebugTools.Assert(!entity.Deleted);
 
-            //TODO: This code needs to check if the entity is actually inside one of the containerManager's containers.
-            // We make the assumption that if a parent entity has a containerManager, the child is inside
-            // one of the containers. Notice the recursion starts at the Owner of the passed in entity, this
+            // Notice the recursion starts at the Owner of the passed in entity, this
             // allows containers inside containers (toolboxes in lockers).
             if (entity.Transform.Parent != null)
-                return TryGetManagerComp(entity.Transform.Parent.Owner, out _);
+                if (TryGetManagerComp(entity.Transform.Parent.Owner, out var containerComp))
+                    return containerComp.ContainsEntity(entity);
 
             return false;
         }

--- a/Robust.Shared/Containers/ContainerHelpers.cs
+++ b/Robust.Shared/Containers/ContainerHelpers.cs
@@ -1,0 +1,47 @@
+﻿using Robust.Server.Interfaces.GameObjects;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Containers
+{
+    /// <summary>
+    /// Helper functions for the container system.
+    /// </summary>
+    public static class ContainerHelpers
+    {
+        /// <summary>
+        /// Am I inside a container?
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <returns></returns>
+        public static bool IsInContainer(IEntity entity)
+        {
+            DebugTools.Assert(entity != null);
+            DebugTools.Assert(!entity.Deleted);
+
+            //TODO: This code needs to check if the entity is actually inside one of the containerManager's containers.
+            // We make the assumption that if a parent entity has a containerManager, the child is inside
+            // one of the containers. Notice the recursion starts at the Owner of the passed in entity, this
+            // allows containers inside containers (toolboxes in lockers).
+            if (entity.Transform.Parent != null)
+                return TryGetManagerComp(entity.Transform.Parent.Owner, out _);
+
+            return false;
+        }
+
+        private static bool TryGetManagerComp(IEntity entity, out IContainerManager manager)
+        {
+            DebugTools.Assert(entity != null);
+            DebugTools.Assert(!entity.Deleted);
+
+            if (entity.TryGetComponent(out manager))
+                return true;
+
+            // RECURSION ALERT
+            if (entity.Transform.Parent != null)
+                return TryGetManagerComp(entity.Transform.Parent.Owner, out manager);
+
+            return false;
+        }
+    }
+}

--- a/Robust.Shared/Containers/ContainerHelpers.cs
+++ b/Robust.Shared/Containers/ContainerHelpers.cs
@@ -28,6 +28,16 @@ namespace Robust.Shared.Containers
             return false;
         }
 
+
+        public static bool TryGetContainer(IEntity entity, out IContainerManager manager)
+        {
+            if (entity.Transform.Parent != null && TryGetManagerComp(entity.Transform.Parent.Owner, out manager))
+                return true;
+
+            manager = default;
+            return false;
+        }
+
         private static bool TryGetManagerComp(IEntity entity, out IContainerManager manager)
         {
             DebugTools.Assert(entity != null);

--- a/Robust.Shared/GameObjects/Components/Map/MapComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Map/MapComponent.cs
@@ -1,4 +1,6 @@
-﻿using Robust.Shared.Map;
+﻿using System;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Map;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
 

--- a/Robust.Shared/GameObjects/Components/Map/MapComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Map/MapComponent.cs
@@ -1,0 +1,37 @@
+﻿using Robust.Shared.Interfaces.Map;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
+
+namespace Robust.Shared.GameObjects.Components.Map
+{
+    /// <summary>
+    ///     Represents a world map inside the ECS system.
+    /// </summary>
+    public interface IMapComponent
+    {
+        IMap WorldMap { get; }
+    }
+
+    /// <inheritdoc cref="IMapComponent"/>
+    public class MapComponent : Component, IMapComponent
+    {
+        [Dependency] private readonly IMapManager _mapManager;
+
+        private MapId _mapIndex;
+
+        /// <inheritdoc />
+        public override string Name => "Map";
+
+        /// <inheritdoc />
+        public IMap WorldMap => _mapManager.GetMap(_mapIndex);
+        
+        /// <inheritdoc />
+        public override void ExposeData(ObjectSerializer serializer)
+        {
+            base.ExposeData(serializer);
+
+            serializer.DataField(ref _mapIndex, "index", MapId.Nullspace);
+        }
+    }
+}

--- a/Robust.Shared/GameObjects/Components/Map/MapComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Map/MapComponent.cs
@@ -7,9 +7,10 @@ namespace Robust.Shared.GameObjects.Components.Map
     /// <summary>
     ///     Represents a world map inside the ECS system.
     /// </summary>
-    public interface IMapComponent
+    public interface IMapComponent : IComponent
     {
         MapId WorldMap { get; }
+        void ClearMapId();
     }
 
     /// <inheritdoc cref="IMapComponent"/>
@@ -22,14 +23,62 @@ namespace Robust.Shared.GameObjects.Components.Map
         public override string Name => "Map";
 
         /// <inheritdoc />
-        public MapId WorldMap => _mapIndex;
-        
+        public override uint? NetID => NetIDs.MAP_MAP;
+
+        /// <inheritdoc />
+        public override Type StateType => typeof(MapComponentState);
+
+        /// <inheritdoc />
+        public MapId WorldMap
+        {
+            get => _mapIndex;
+            internal set => _mapIndex = value;
+        }
+
+        public void ClearMapId()
+        {
+            _mapIndex = MapId.Nullspace;
+        }
+
+
+        /// <inheritdoc />
+        public override ComponentState GetComponentState()
+        {
+            return new MapComponentState(_mapIndex);
+        }
+
+        /// <inheritdoc />
+        public override void HandleComponentState(ComponentState curState, ComponentState nextState)
+        {
+            base.HandleComponentState(curState, nextState);
+
+            if (!(curState is MapComponentState state))
+                return;
+
+            _mapIndex = state.MapId;
+        }
+
         /// <inheritdoc />
         public override void ExposeData(ObjectSerializer serializer)
         {
             base.ExposeData(serializer);
 
             serializer.DataField(ref _mapIndex, "index", MapId.Nullspace);
+        }
+    }
+
+    /// <summary>
+    ///     Serialized state of a <see cref="MapGridComponentState"/>.
+    /// </summary>
+    [Serializable, NetSerializable]
+    internal class MapComponentState : ComponentState
+    {
+        public MapId MapId { get; }
+
+        public MapComponentState(MapId mapId)
+            : base(NetIDs.MAP_MAP)
+        {
+            MapId = mapId;
         }
     }
 }

--- a/Robust.Shared/GameObjects/Components/Map/MapComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Map/MapComponent.cs
@@ -1,7 +1,6 @@
-﻿using Robust.Shared.Interfaces.Map;
-using Robust.Shared.IoC;
-using Robust.Shared.Map;
+﻿using Robust.Shared.Map;
 using Robust.Shared.Serialization;
+using Robust.Shared.ViewVariables;
 
 namespace Robust.Shared.GameObjects.Components.Map
 {
@@ -10,21 +9,20 @@ namespace Robust.Shared.GameObjects.Components.Map
     /// </summary>
     public interface IMapComponent
     {
-        IMap WorldMap { get; }
+        MapId WorldMap { get; }
     }
 
     /// <inheritdoc cref="IMapComponent"/>
     public class MapComponent : Component, IMapComponent
     {
-        [Dependency] private readonly IMapManager _mapManager;
-
+        [ViewVariables(VVAccess.ReadOnly)]
         private MapId _mapIndex;
 
         /// <inheritdoc />
         public override string Name => "Map";
 
         /// <inheritdoc />
-        public IMap WorldMap => _mapManager.GetMap(_mapIndex);
+        public MapId WorldMap => _mapIndex;
         
         /// <inheritdoc />
         public override void ExposeData(ObjectSerializer serializer)

--- a/Robust.Shared/GameObjects/Components/Map/MapGridComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Map/MapGridComponent.cs
@@ -2,6 +2,7 @@
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Map;
 using Robust.Shared.IoC;
+using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
@@ -45,6 +46,17 @@ namespace Robust.Shared.GameObjects.Components.Map
 
         /// <inheritdoc />
         public IMapGrid Grid => _mapManager.GetGrid(_gridIndex);
+
+        public override void OnRemove()
+        {
+            if(_mapManager.GridExists(_gridIndex))
+            {
+                Logger.DebugS("map", $"Entity {Owner.Uid} removed grid component, removing bound grid {_gridIndex}");
+                _mapManager.DeleteGrid(_gridIndex);
+            }
+
+            base.OnRemove();
+        }
 
         /// <inheritdoc />
         public override ComponentState GetComponentState()

--- a/Robust.Shared/GameObjects/Components/Map/MapGridComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Map/MapGridComponent.cs
@@ -1,15 +1,18 @@
-﻿using Robust.Shared.Interfaces.Map;
+﻿using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Interfaces.Map;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization;
+using Robust.Shared.ViewVariables;
 
 namespace Robust.Shared.GameObjects.Components.Map
 {
     /// <summary>
     ///     Represents a map grid inside the ECS system.
     /// </summary>
-    internal interface IMapGridComponent
+    internal interface IMapGridComponent : IComponent
     {
+        GridId GridIndex { get; }
         IMapGrid Grid { get; }
     }
 
@@ -18,10 +21,18 @@ namespace Robust.Shared.GameObjects.Components.Map
     {
         [Dependency] private readonly IMapManager _mapManager;
 
+        [ViewVariables(VVAccess.ReadOnly)]
         private GridId _gridIndex;
 
         /// <inheritdoc />
         public override string Name => "MapGrid";
+
+        /// <inheritdoc />
+        public GridId GridIndex
+        {
+            get => _gridIndex;
+            internal set => _gridIndex = value;
+        }
 
         /// <inheritdoc />
         public IMapGrid Grid => _mapManager.GetGrid(_gridIndex);

--- a/Robust.Shared/GameObjects/Components/Map/MapGridComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Map/MapGridComponent.cs
@@ -1,0 +1,37 @@
+﻿using Robust.Shared.Interfaces.Map;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
+
+namespace Robust.Shared.GameObjects.Components.Map
+{
+    /// <summary>
+    ///     Represents a map grid inside the ECS system.
+    /// </summary>
+    internal interface IMapGridComponent
+    {
+        IMapGrid Grid { get; }
+    }
+
+    /// <inheritdoc cref="IMapGridComponent"/>
+    public class MapGridComponent : Component, IMapGridComponent
+    {
+        [Dependency] private readonly IMapManager _mapManager;
+
+        private GridId _gridIndex;
+
+        /// <inheritdoc />
+        public override string Name => "MapGrid";
+
+        /// <inheritdoc />
+        public IMapGrid Grid => _mapManager.GetGrid(_gridIndex);
+
+        /// <inheritdoc />
+        public override void ExposeData(ObjectSerializer serializer)
+        {
+            base.ExposeData(serializer);
+
+            serializer.DataField(ref _gridIndex, "index", GridId.Nullspace);
+        }
+    }
+}

--- a/Robust.Shared/GameObjects/Components/Map/MapGridComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Map/MapGridComponent.cs
@@ -16,6 +16,7 @@ namespace Robust.Shared.GameObjects.Components.Map
     {
         GridId GridIndex { get; }
         IMapGrid Grid { get; }
+        void ClearGridId();
     }
 
     /// <inheritdoc cref="IMapGridComponent"/>
@@ -47,12 +48,20 @@ namespace Robust.Shared.GameObjects.Components.Map
         /// <inheritdoc />
         public IMapGrid Grid => _mapManager.GetGrid(_gridIndex);
 
+        public void ClearGridId()
+        {
+            _gridIndex = GridId.Nullspace;
+        }
+
         public override void OnRemove()
         {
-            if(_mapManager.GridExists(_gridIndex))
+            if(GridIndex != GridId.Nullspace) // MapManager won't let us delete nullspace, no point trying
             {
-                Logger.DebugS("map", $"Entity {Owner.Uid} removed grid component, removing bound grid {_gridIndex}");
-                _mapManager.DeleteGrid(_gridIndex);
+                if(_mapManager.GridExists(_gridIndex))
+                {
+                    Logger.DebugS("map", $"Entity {Owner.Uid} removed grid component, removing bound grid {_gridIndex}");
+                    _mapManager.DeleteGrid(_gridIndex);
+                }
             }
 
             base.OnRemove();

--- a/Robust.Shared/GameObjects/Components/NetIDs.cs
+++ b/Robust.Shared/GameObjects/Components/NetIDs.cs
@@ -2,6 +2,8 @@
 {
     public static class NetIDs
     {
+        public const uint MAP_MAP = 1;
+        public const uint MAP_GRID = 2;
         public const uint META_DATA = 4;
         public const uint TRANSFORM = 5;
         public const uint PHYSICS = 6;

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -2,6 +2,7 @@
  using System.Collections.Generic;
  using System.Linq;
  using Robust.Shared.Animations;
+ using Robust.Shared.Containers;
  using Robust.Shared.Enums;
  using Robust.Shared.GameObjects.Components.Map;
  using Robust.Shared.GameObjects.EntitySystemMessages;
@@ -175,7 +176,7 @@
             }
         }
 
-        public bool IsMapTransform => Parent == null;
+        public bool IsMapTransform => !ContainerHelpers.IsInContainer(Owner);
 
         /// <inheritdoc />
         [ViewVariables(VVAccess.ReadWrite)]
@@ -493,7 +494,7 @@
         /// </summary>
         public bool ContainsEntity(ITransformComponent entityTransform)
         {
-            if (entityTransform.IsMapTransform) //Is the entity on the map
+            if (entityTransform.Parent == null) //Is the entity the scene root
             {
                 return false;
             }

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -512,10 +512,6 @@
                 var rebuildMatrices = false;
                 if (Parent?.Owner?.Uid != newParentId)
                 {
-#if _DELME
-                    DetachParent();
-#endif
-
                     if (newParentId.HasValue && newParentId.Value.IsValid())
                     {
                         var newParent = Owner.EntityManager.GetEntity(newParentId.Value);
@@ -599,12 +595,6 @@
 
             // there really is no point trying to cache this because it will only be used in one frame
             var pos = GetLocalPosition();
-
-#if _DELME
-            if (!_parent.IsValid())
-                pos = Vector2.Zero;
-#endif
-
             var rot = GetLocalRotation().Theta;
 
             var posMat = Matrix3.CreateTranslation(pos);
@@ -622,12 +612,6 @@
 
             // there really is no point trying to cache this because it will only be used in one frame
             var pos = GetLocalPosition();
-
-#if _DELME
-            if (!_parent.IsValid()) // Root node
-                pos = Vector2.Zero;
-#endif
-
             var rot = GetLocalRotation().Theta;
 
             var posMat = Matrix3.CreateTranslation(pos);

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -379,16 +379,6 @@
         }
 
         /// <inheritdoc />
-        public override void Initialize()
-        {
-            base.Initialize();
-
-            // Entities should not be spawned into nullspace
-            DebugTools.Assert(MapID != MapId.Nullspace);
-            DebugTools.Assert(GridID != GridId.Nullspace);
-        }
-
-        /// <inheritdoc />
         protected override void Startup()
         {
             base.Startup();

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -229,6 +229,10 @@
                     // Eh.
                     if (_mapManager.TryGetGrid(GridID, out var grid))
                     {
+                        // prevents infinite recursion, we ARE the grid's transform
+                        if (grid.GridEntity == Owner.Uid)
+                            return GetLocalPosition();
+
                         return grid.LocalToWorld(GetLocalPosition());
                     }
                     return GetLocalPosition();

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -478,7 +478,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"{Name} ({Uid}, {Prototype.ID})";
+            return $"{Name} ({Uid}, {Prototype?.ID})";
         }
     }
 }

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -401,6 +401,7 @@ namespace Robust.Shared.GameObjects
             {
                 if (!TryGetComponent(kvStates.Key, out var component))
                 {
+                    DebugTools.Assert("Component does not exist for state.");
                     continue;
                 }
 

--- a/Robust.Shared/Interfaces/GameObjects/Components/IContainerManager.cs
+++ b/Robust.Shared/Interfaces/GameObjects/Components/IContainerManager.cs
@@ -53,6 +53,8 @@ namespace Robust.Server.Interfaces.GameObjects
         /// <returns>True if the container was found, false otherwise.</returns>
         bool TryGetContainer(string id, out IContainer container);
 
+        bool ContainsEntity(IEntity entity);
+
         void ForceRemove(IEntity entity);
     }
 }

--- a/Robust.Shared/Interfaces/Map/IMapManager.cs
+++ b/Robust.Shared/Interfaces/Map/IMapManager.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
+using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Timing;
@@ -65,6 +67,9 @@ namespace Robust.Shared.Interfaces.Map
         /// <param name="mapID">The map ID to check existance of.</param>
         /// <returns>True if the map exists, false otherwise.</returns>
         bool MapExists(MapId mapID);
+
+        EntityUid GetMapEntityId(MapId mapId);
+        IEntity GetMapEntity(MapId mapId);
 
         IEnumerable<MapId> GetAllMapIds();
 

--- a/Robust.Shared/Map/IMapGrid.cs
+++ b/Robust.Shared/Map/IMapGrid.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Robust.Shared.GameObjects;
 using Robust.Shared.GameObjects.Components.Transform;
 using Robust.Shared.Maths;
 
@@ -21,6 +22,8 @@ namespace Robust.Shared.Map
         ///     The integer ID of the map this grid is currently located within.
         /// </summary>
         MapId ParentMapId { get; set; }
+
+        EntityUid GridEntity { get; }
 
         /// <summary>
         ///     The identifier of this grid.

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -92,13 +92,19 @@ namespace Robust.Shared.Map
         {
             get
             {
+                if(IsDefaultGrid) // Default grids cannot be moved.
+                    return Vector2.Zero;
+
                 //TODO: Make grids real parents of entities.
                 if(GridEntity.IsValid())
-                return IoCManager.Resolve<IEntityManager>().GetEntity(GridEntity).Transform.WorldPosition;
+                    return IoCManager.Resolve<IEntityManager>().GetEntity(GridEntity).Transform.WorldPosition;
                 return Vector2.Zero;
             }
             set
             {
+                if (IsDefaultGrid) // Default grids cannot be moved.
+                    return;
+
                 IoCManager.Resolve<IEntityManager>().GetEntity(GridEntity).Transform.WorldPosition = value;
                 LastModifiedTick = _mapManager.GameTiming.CurTick;
             }

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Robust.Shared.GameObjects;
 using Robust.Shared.GameObjects.Components.Transform;
 using Robust.Shared.Maths;
 using Robust.Shared.Timing;
@@ -27,6 +28,8 @@ namespace Robust.Shared.Map
 
         /// <inheritdoc />
         public MapId ParentMapId { get; set; }
+
+        public EntityUid GridEntity { get; internal set; }
 
         /// <summary>
         ///     Grid chunks than make up this grid.

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameObjects.Components.Transform;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.IoC;
 using Robust.Shared.Maths;
 using Robust.Shared.Timing;
 
@@ -88,10 +90,16 @@ namespace Robust.Shared.Map
         /// <inheritdoc />
         public Vector2 WorldPosition
         {
-            get => _worldPosition;
+            get
+            {
+                //TODO: Make grids real parents of entities.
+                if(GridEntity.IsValid())
+                return IoCManager.Resolve<IEntityManager>().GetEntity(GridEntity).Transform.WorldPosition;
+                return Vector2.Zero;
+            }
             set
             {
-                _worldPosition = value;
+                IoCManager.Resolve<IEntityManager>().GetEntity(GridEntity).Transform.WorldPosition = value;
                 LastModifiedTick = _mapManager.GameTiming.CurTick;
             }
         }

--- a/Robust.Shared/Map/MapManager.Network.cs
+++ b/Robust.Shared/Map/MapManager.Network.cs
@@ -5,6 +5,7 @@ using Robust.Shared.GameObjects.Components.Map;
 using Robust.Shared.GameStates;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.IoC;
+using Robust.Shared.Log;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -193,7 +194,10 @@ namespace Robust.Shared.Map
                     if(!grid.GridEntity.IsClientSide())
                         continue;
 
-                    _entityManager.GetEntity(grid.GridEntity).Delete();
+                    var cEntity = _entityManager.GetEntity(grid.GridEntity);
+                    var cGridComp = cEntity.GetComponent<IMapGridComponent>();
+                    cGridComp.ClearGridId();
+                    cEntity.Delete();
 
                     var gridComps = _entityManager.ComponentManager.GetAllComponents<IMapGridComponent>();
                     foreach (var gridComp in gridComps)
@@ -201,6 +205,7 @@ namespace Robust.Shared.Map
                         if (gridComp.GridIndex == kvNewGrid.Key)
                         {
                             grid.GridEntity = gridComp.Owner.Uid;
+                            Logger.DebugS("map", $"Grid {grid.Index} pivoted bound entity from {cEntity.Uid} to {grid.GridEntity}.");
                             break;
                         }
                     }

--- a/Robust.Shared/Map/MapManager.cs
+++ b/Robust.Shared/Map/MapManager.cs
@@ -107,13 +107,16 @@ namespace Robust.Shared.Map
         /// <inheritdoc />
         public void DeleteMap(MapId mapID)
         {
+            if (mapID == MapId.Nullspace)
+            {
+                Logger.DebugS("map", "Blocked deletion of nullspace map.");
+                return;
+            }
+
             if (!_maps.Contains(mapID))
             {
                 throw new InvalidOperationException($"Attempted to delete nonexistant map '{mapID}'");
             }
-
-            if(mapID == MapId.Nullspace)
-                throw new InvalidOperationException("Trying to delete nullspace.");
 
             // grids are cached because Delete modifies collection
             foreach (var grid in GetAllMapGrids(mapID).ToList())
@@ -220,7 +223,7 @@ namespace Robust.Shared.Map
             _grids.Add(actualID, grid);
             Logger.DebugS("map", $"Creating new grid {actualID}");
 
-            if(actualID != GridId.Nullspace)
+            if(actualID != GridId.Nullspace) // nullspace default grid is not bound to an entity
             {
                 // the entity may already exist from map deserialization
                 IMapGridComponent result = null;
@@ -300,10 +303,11 @@ namespace Robust.Shared.Map
 
         public void DeleteGrid(GridId gridID)
         {
-            var grid = _grids[gridID];
+            // nullspace grid cannot be deleted
+            if(gridID == GridId.Nullspace)
+                return;
 
-            if(GetDefaultGridId(grid.ParentMapId) == gridID)
-                throw new InvalidOperationException($"Tried to delete the default grid {gridID} of map {grid.ParentMapId}");
+            var grid = _grids[gridID];
 
             grid.Dispose();
             _grids.Remove(grid.Index);

--- a/Robust.Shared/Map/MapManager.cs
+++ b/Robust.Shared/Map/MapManager.cs
@@ -126,6 +126,12 @@ namespace Robust.Shared.Map
             _maps.Remove(mapID);
             _mapCreationTick.Remove(mapID);
 
+            var ent = _mapEntities[mapID];
+            if(_entityManager.TryGetEntity(ent, out var mapEnt))
+                mapEnt.Delete();
+
+            _mapEntities.Remove(mapID);
+
             if (_netManager.IsClient)
                 return;
 
@@ -252,7 +258,7 @@ namespace Robust.Shared.Map
 
             if (GridExists(actualID))
             {
-                throw new InvalidOperationException($"A map with ID {actualID} already exists");
+                throw new InvalidOperationException($"A grid with ID {actualID} already exists");
             }
 
             if (HighestGridID.Value < actualID.Value)
@@ -358,7 +364,10 @@ namespace Robust.Shared.Map
 
             if (_defaultGrids.ContainsKey(grid.ParentMapId))
                 _defaultGrids.Remove(grid.ParentMapId);
-            
+
+            if(_entityManager.TryGetEntity(grid.GridEntity, out var gridEnt))
+                gridEnt.Delete();
+
             OnGridRemoved?.Invoke(gridID);
 
             if (_netManager.IsServer)

--- a/Robust.Shared/Map/MapManager.cs
+++ b/Robust.Shared/Map/MapManager.cs
@@ -190,11 +190,14 @@ namespace Robust.Shared.Map
                 }
                 else
                 {
-                    var newEnt = _entityManager.CreateEntityUninitialized(null, GridCoordinates.Nullspace);
+                    var newEnt = (Entity)_entityManager.CreateEntityUninitialized(null, GridCoordinates.Nullspace);
                     _mapEntities.Add(actualID, newEnt.Uid);
 
                     var mapComp = newEnt.AddComponent<MapComponent>();
                     mapComp.WorldMap = actualID;
+                    newEnt.Initialize();
+                    newEnt.InitializeComponents();
+                    newEnt.StartAllComponents();
                     Logger.DebugS("map", $"Binding map {actualID} to entity {newEnt.Uid}");
                 }
             }
@@ -290,7 +293,7 @@ namespace Robust.Shared.Map
                 }
                 else
                 {
-                    var newEnt = _entityManager.CreateEntityUninitialized(null, new MapCoordinates(Vector2.Zero, currentMapID));
+                    var newEnt = (Entity)_entityManager.CreateEntityUninitialized(null, new MapCoordinates(Vector2.Zero, currentMapID));
                     grid.GridEntity = newEnt.Uid;
 
                     Logger.DebugS("map", $"Binding grid {actualID} to entity {grid.GridEntity}");
@@ -299,6 +302,10 @@ namespace Robust.Shared.Map
                     gridComp.GridIndex = grid.Index;
 
                     newEnt.Transform.AttachParent(_entityManager.GetEntity(_mapEntities[currentMapID]));
+
+                    newEnt.Initialize();
+                    newEnt.InitializeComponents();
+                    newEnt.StartAllComponents();
                 }
             }
 

--- a/Robust.UnitTesting/Client/GameObjects/Components/Transform_Test.cs
+++ b/Robust.UnitTesting/Client/GameObjects/Components/Transform_Test.cs
@@ -68,10 +68,10 @@ namespace Robust.UnitTesting.Client.GameObjects.Components
             var parentTrans = parent.Transform;
             var childTrans = child.Transform;
 
-            var compState = new TransformComponent.TransformComponentState(new Vector2(5, 5), GridB.Index, new Angle(0), EntityUid.Invalid);
+            var compState = new TransformComponent.TransformComponentState(new Vector2(5, 5), GridB.Index, new Angle(0), GridB.GridEntity);
             parentTrans.HandleComponentState(compState, null);
 
-            compState = new TransformComponent.TransformComponentState(new Vector2(6, 6), GridB.Index, new Angle(0), EntityUid.Invalid);
+            compState = new TransformComponent.TransformComponentState(new Vector2(6, 6), GridB.Index, new Angle(0), GridB.GridEntity);
             childTrans.HandleComponentState(compState, null);
             // World pos should be 6, 6 now.
 
@@ -105,7 +105,7 @@ namespace Robust.UnitTesting.Client.GameObjects.Components
             var node2Trans = node2.Transform;
             var node3Trans = node3.Transform;
 
-            var compState = new TransformComponent.TransformComponentState(new Vector2(6, 6), GridB.Index, Angle.FromDegrees(135), EntityUid.Invalid);
+            var compState = new TransformComponent.TransformComponentState(new Vector2(6, 6), GridB.Index, Angle.FromDegrees(135), GridB.GridEntity);
             node1Trans.HandleComponentState(compState, null);
             compState = new TransformComponent.TransformComponentState(new Vector2(1, 1), GridB.Index, Angle.FromDegrees(45), node1.Uid);
             node2Trans.HandleComponentState(compState, null);

--- a/Robust.UnitTesting/Server/GameObjects/Components/Container_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/Components/Container_Test.cs
@@ -88,7 +88,7 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
             container.Insert(inserted);
             owner.Delete();
             // Make sure inserted was detached.
-            Assert.That(transform.IsMapTransform, Is.True);
+            Assert.That(transform.Deleted, Is.True);
         }
 
         const string PROTOTYPES = @"

--- a/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
@@ -98,7 +98,8 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
 
             childTrans.DetachParent();
 
-            Assert.That(childTrans.GridPosition, Is.EqualTo(oldLpos));
+            // the gridId won't match, because we just detached from the grid entity
+            Assert.That(childTrans.GridPosition.Position, Is.EqualTo(oldLpos.Position));
             Assert.That(childTrans.WorldPosition, Is.EqualTo(oldWpos));
         }
 


### PR DESCRIPTION
Adds entities to the scene tree that represent the Map and Grids. The Map entity is always the root node of the tree, by convention Grid entities are always parented to the map entity. This allows us to use the transform parenting system to easily manipulate large branches of objects around the tree. This PR removes the need for the "DefaultGrid", which was an artifact of the original coordinate system. Entire grids and all their attached entities can be moved between maps by just changing their parent.

A normal scene graph looks something like this now:
```
MapEntity
   |- GridEntity
   |    |- StationObjectEntity
   |    \- StationObjectEntity
   |- FloatingObjectEntity
   \- FloatingObjectEntity
```
With the old coordinate system, there was no concept of a root node of the scene tree, so most entities were orphan nodes without a parent. This does not work with the new system, and now entities are required to specify which map (root node) they are being placed on at the time of their creation. Currently it is not possible to spawn an entity into nullspace, this restriction can be removed if needed. It is now not possible to have a non-map entity without a parent.