### PR TITLE
TransformComponent.MapID returns null instead of throwing

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -89,7 +89,8 @@
                 if (_parent.IsValid())
                     return Parent.GridID;
 
-                throw new InvalidOperationException("Transform node does not exist inside scene tree!");
+                // Transform node does not exist inside scene tree
+                return GridId.Nullspace;
             }
         }
 

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -66,7 +66,8 @@
                 if (Owner.TryGetComponent(out IMapComponent mapComp))
                     return mapComp.WorldMap;
 
-                throw new InvalidOperationException("Transform node does not exist inside scene tree!");
+                // Transform node does not exist inside scene tree
+                return MapId.Nullspace;
             }
         }
 
@@ -339,10 +340,6 @@
                                 AttachParent(gridEnt);
                             }
                         }
-                        else
-                        {
-                            DebugTools.Assert("My location is unknown!");
-                        }
                     }
                 }
                 else
@@ -413,7 +410,7 @@
             Parent = newMapEntity.Transform;
             MapPosition = mapPos;
 
-            
+
 
             Dirty();
         }


### PR DESCRIPTION
Because I need to spawn an entity in nullspace for character preview.
`GridID` also throws currently, should I change that as well even if I don't need it?