### PR TITLE
Fix the entity spawn panel clear button

### DIFF
--- a/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
+++ b/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
@@ -186,6 +186,7 @@ namespace Robust.Client.UserInterface.CustomControls
         private void OnClearButtonPressed(BaseButton.ButtonEventArgs args)
         {
             SearchBar.Clear();
+            BuildEntityList("");
         }
 
         private void OnEraseButtonToggled(BaseButton.ButtonToggledEventArgs args)


### PR DESCRIPTION
The entity spawn panel clear button causes nothing to show up. This fixes that so it rebuilds the entity list with an empty search. Fixes [#484 on the content repo](https://github.com/space-wizards/space-station-14/issues/484)