### PR TITLE
Fix crash when minimizing game window

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
@@ -292,8 +292,11 @@ namespace Robust.Client.Graphics.Clyde
             var oldSize = _framebufferSize;
             GLFW.GetFramebufferSize(window, out var fbW, out var fbH);
             _framebufferSize = (fbW, fbH);
-
             _windowSize = (width, height);
+
+            if(fbW == 0 || fbH == 0 || width == 0 || height == 0)
+                return;
+
             _pixelRatio = _framebufferSize / _windowSize;
 
             GL.Viewport(0, 0, fbW, fbH);


### PR DESCRIPTION
Returns early in `Clyde.OnGlfwWindowSize()` if the window or framebuffer width or height = 0 to avoid dividing by zero and crashing. Checks the vector components individually instead of using `someVector2i.Equals(Vector2i.Zero)` because you can end up in a situation where width is non-zero and height is zero if you manually resize the window instead of using the minimize button.

Fixes #930 