### PR TITLE
Add delete key behavior to LineEdit

### DIFF
--- a/Robust.Client/Input/EngineContexts.cs
+++ b/Robust.Client/Input/EngineContexts.cs
@@ -37,6 +37,7 @@ namespace Robust.Client.Input
             common.AddFunction(EngineKeyFunctions.TextHistoryNext);
             common.AddFunction(EngineKeyFunctions.TextReleaseFocus);
             common.AddFunction(EngineKeyFunctions.TextScrollToBottom);
+            common.AddFunction(EngineKeyFunctions.TextDelete);
 
             var editor = contexts.New("editor", common);
             editor.AddFunction(EngineKeyFunctions.EditorLinePlace);

--- a/Robust.Client/UserInterface/Controls/LineEdit.cs
+++ b/Robust.Client/UserInterface/Controls/LineEdit.cs
@@ -346,7 +346,7 @@ namespace Robust.Client.UserInterface.Controls
                 }
                 else if (args.Function == EngineKeyFunctions.TextDelete)
                 {
-                    if (_cursorPosition + 1 > _text.Length || !Editable)
+                    if (_cursorPosition >= _text.Length || !Editable)
                         return;
 
                     _text = _text.Remove(_cursorPosition, 1);

--- a/Robust.Client/UserInterface/Controls/LineEdit.cs
+++ b/Robust.Client/UserInterface/Controls/LineEdit.cs
@@ -344,6 +344,15 @@ namespace Robust.Client.UserInterface.Controls
                         InsertAtCursor(clipboard.GetText());
                     }
                 }
+                else if (args.Function == EngineKeyFunctions.TextDelete)
+                {
+                    if (_cursorPosition + 1 > _text.Length || !Editable)
+                        return;
+
+                    _text = _text.Remove(_cursorPosition, 1);
+                    OnTextChanged?.Invoke(new LineEditEventArgs(this, _text));
+                    _updatePseudoClass();
+                }
             }
             else
             {

--- a/Robust.Shared/Input/KeyFunctions.cs
+++ b/Robust.Shared/Input/KeyFunctions.cs
@@ -42,6 +42,7 @@ namespace Robust.Shared.Input
         public static readonly BoundKeyFunction TextHistoryNext = "TextHistoryNext";
         public static readonly BoundKeyFunction TextReleaseFocus = "TextReleaseFocus";
         public static readonly BoundKeyFunction TextScrollToBottom = "TextScrollToBottom";
+        public static readonly BoundKeyFunction TextDelete = "TextDelete";
     }
 
     [Serializable, NetSerializable]


### PR DESCRIPTION
Pressing delete will now delete the character in front of your LineEdit cursor like usual. Will create small PR on the content repo that completes this shortly after this one.