### PR TITLE
Increase default vv window size for convenience

### DIFF
--- a/Robust.Client/ViewVariables/ViewVariablesManager.cs
+++ b/Robust.Client/ViewVariables/ViewVariablesManager.cs
@@ -27,6 +27,7 @@ namespace Robust.Client.ViewVariables
 #pragma warning restore 649
 
         private uint _nextReqId = 1;
+        private readonly Vector2i _defaultWindowSize = (640, 420);
 
         private readonly Dictionary<ViewVariablesInstance, SS14Window> _windows =
             new Dictionary<ViewVariablesInstance, SS14Window>();
@@ -209,7 +210,7 @@ namespace Robust.Client.ViewVariables
             window.OnClose += () => _closeInstance(instance, false);
             _windows.Add(instance, window);
             window.Open();
-            LayoutContainer.SetSize(window, (500, 300));
+            LayoutContainer.SetSize(window, _defaultWindowSize);
         }
 
         public async void OpenVV(ViewVariablesObjectSelector selector)
@@ -250,7 +251,7 @@ namespace Robust.Client.ViewVariables
             window.OnClose += () => _closeInstance(instance, false);
             _windows.Add(instance, window);
             window.Open();
-            LayoutContainer.SetSize(window, (500, 300));
+            LayoutContainer.SetSize(window, _defaultWindowSize);
         }
 
         public Task<ViewVariablesRemoteSession> RequestSession(ViewVariablesObjectSelector selector)


### PR DESCRIPTION
Makes all tabs and information visible by default instead of needing to resize vv windows to see everything. 

Before:
![Content Client_Oncn3KO80l](https://user-images.githubusercontent.com/8206401/73623710-f52a5c00-460b-11ea-9da8-ed324a0d4fca.png)

After:
![Content Client_jIUBqruLlc](https://user-images.githubusercontent.com/8206401/73623716-fcea0080-460b-11ea-8736-ebab4f2f0dc4.png)

This is pretty subjective, and some windows will still have info cutoff, but I find it useful since I frequently have to resize vv windows.