### PR TITLE
Introduce DynamicTree, Separate Ray from CollisionRay

### DIFF
--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -142,6 +142,7 @@ namespace Robust.Client.GameObjects
         {
             var newEnt = CreateEntityUninitialized(protoName, coordinates);
             InitializeAndStartEntity((Entity)newEnt);
+            UpdateEntityTree(newEnt);
             return newEnt;
         }
 
@@ -150,6 +151,7 @@ namespace Robust.Client.GameObjects
         {
             var entity = CreateEntityUninitialized(protoName, coordinates);
             InitializeAndStartEntity((Entity)entity);
+            UpdateEntityTree(entity);
             return entity;
         }
 

--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -88,6 +88,11 @@ namespace Robust.Client.GameObjects
                 HandleEntityState(entity.EntityManager.ComponentManager, entity, kvStates.Value.Item1, kvStates.Value.Item2);
             }
 
+            foreach (var kvp in toApply)
+            {
+                UpdateEntityTree(kvp.Key);
+            }
+
             foreach (var id in deletions)
             {
                 DeleteEntity(id);
@@ -101,6 +106,11 @@ namespace Robust.Client.GameObjects
             foreach (var entity in toInitialize)
             {
                 StartEntity(entity);
+            }
+
+            foreach (var entity in toInitialize)
+            {
+                UpdateEntityTree(entity);
             }
         }
 

--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -424,6 +424,11 @@ namespace Robust.Server.Maps
             {
                 foreach (var entity in Entities)
                 {
+                    _serverEntityManager.UpdateEntityTree(entity);
+                }
+
+                foreach (var entity in Entities)
+                {
                     _serverEntityManager.FinishEntityStartup(entity);
                 }
             }

--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -431,6 +431,11 @@ namespace Robust.Server.Maps
                 {
                     _serverEntityManager.FinishEntityStartup(entity);
                 }
+
+                foreach (var entity in Entities)
+                {
+                    _serverEntityManager.UpdateEntityTree(entity);
+                }
             }
 
             // Serialization

--- a/Robust.Shared.Maths/Box2.cs
+++ b/Robust.Shared.Maths/Box2.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 
 namespace Robust.Shared.Maths
 {
@@ -113,22 +114,33 @@ namespace Robust.Shared.Maths
             return new Box2();
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsEmpty()
         {
             return FloatMath.CloseTo(Width, 0.0f) && FloatMath.CloseTo(Height, 0.0f);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Encloses(in Box2 inner)
         {
             return this.Left < inner.Left && this.Bottom < inner.Bottom && this.Right > inner.Right &&
-                   this.Top > inner.Top;
+                this.Top > inner.Top;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Contains(in Box2 inner)
+            => Left <= inner.Left
+                && Bottom <= inner.Bottom
+                && Right >= inner.Right
+                && Top >= inner.Top;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Contains(float x, float y)
         {
             return Contains(new Vector2(x, y));
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Contains(Vector2 point, bool closedRegion = true)
         {
             var xOk = closedRegion
@@ -211,5 +223,41 @@ namespace Robust.Shared.Maths
         {
             return $"({Left}, {Bottom}, {Right}, {Top})";
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static float Area(in Box2 box)
+            => box.Width * box.Height;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Perimeter(in Box2 box)
+            => (box.Width + box.Height) * 2;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Box2 Combine(in Box2 a, in Box2 b)
+            => new Box2(
+                MathF.Min(a.Left, b.Left),
+                MathF.Min(a.Bottom, b.Bottom),
+                MathF.Max(a.Right, b.Right),
+                MathF.Max(a.Top, b.Top)
+            );
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Box2 Combine(in Vector2 a, in Vector2 b)
+            => new Box2(
+                MathF.Min(a.X, b.X),
+                MathF.Min(a.Y, b.Y),
+                MathF.Max(a.X, b.X),
+                MathF.Max(a.Y, b.Y)
+            );
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Box2 Grow(in Box2 box, float range)
+            => new Box2(
+                box.Left - range,
+                box.Bottom - range,
+                box.Right + range,
+                box.Top + range
+            );
+
     }
 }

--- a/Robust.Shared.Maths/Box2.cs
+++ b/Robust.Shared.Maths/Box2.cs
@@ -77,6 +77,7 @@ namespace Robust.Shared.Maths
                    other.Left <= this.Right;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Box2 Enlarged(float size)
         {
             return new Box2(Left - size, Bottom - size, Right + size, Top + size);
@@ -101,6 +102,7 @@ namespace Robust.Shared.Maths
         /// <summary>
         ///     Returns the smallest rectangle that contains both of the rectangles.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Box2 Union(in Box2 other)
         {
             var left   = Math.Min(Left,   other.Left);
@@ -233,30 +235,12 @@ namespace Robust.Shared.Maths
             => (box.Width + box.Height) * 2;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Box2 Combine(in Box2 a, in Box2 b)
-            => new Box2(
-                MathF.Min(a.Left, b.Left),
-                MathF.Min(a.Bottom, b.Bottom),
-                MathF.Max(a.Right, b.Right),
-                MathF.Max(a.Top, b.Top)
-            );
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Box2 Combine(in Vector2 a, in Vector2 b)
+        public static Box2 Union(in Vector2 a, in Vector2 b)
             => new Box2(
                 MathF.Min(a.X, b.X),
                 MathF.Min(a.Y, b.Y),
                 MathF.Max(a.X, b.X),
                 MathF.Max(a.Y, b.Y)
-            );
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Box2 Grow(in Box2 box, float range)
-            => new Box2(
-                box.Left - range,
-                box.Bottom - range,
-                box.Right + range,
-                box.Top + range
             );
 
     }

--- a/Robust.Shared/GameObjects/Components/Collidable/CollidableComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/CollidableComponent.cs
@@ -74,6 +74,9 @@ namespace Robust.Shared.GameObjects.Components
                 {
                     shape.ApplyState();
                 }
+
+                UpdateEntityTree();
+                Dirty();
             }
         }
 
@@ -170,6 +173,7 @@ namespace Robust.Shared.GameObjects.Components
         void IPhysBody.Bumped(IEntity bumpedby)
         {
             SendMessage(new BumpedEntMsg(bumpedby));
+            UpdateEntityTree();
         }
 
         /// <inheritdoc />
@@ -217,5 +221,7 @@ namespace Robust.Shared.GameObjects.Components
 
             return _physicsManager.TryCollide(Owner, offset, bump);
         }
+
+        private void UpdateEntityTree() => Owner.EntityManager.UpdateEntityTree(Owner);
     }
 }

--- a/Robust.Shared/GameObjects/Components/Collidable/CollidableComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/CollidableComponent.cs
@@ -222,6 +222,6 @@ namespace Robust.Shared.GameObjects.Components
             return _physicsManager.TryCollide(Owner, offset, bump);
         }
 
-        private void UpdateEntityTree() => Owner.EntityManager.UpdateEntityTree(Owner);
+        private bool UpdateEntityTree() => Owner.EntityManager.UpdateEntityTree(Owner);
     }
 }

--- a/Robust.Shared/GameObjects/Components/Transform/SnapGridComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/SnapGridComponent.cs
@@ -33,11 +33,17 @@ namespace Robust.Shared.GameObjects.Components.Transform
         public SnapGridOffset Offset => _offset;
 
         /// <inheritdoc />
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            UpdatePosition();
+        }
+
+        /// <inheritdoc />
         protected override void Startup()
         {
             base.Startup();
-
-            UpdatePosition();
         }
 
         /// <inheritdoc />
@@ -98,28 +104,54 @@ namespace Robust.Shared.GameObjects.Components.Transform
             return $"ofs/pos: {Offset}/{Position}";
         }
 
-        MapIndices SnapGridPosAt(Direction dir)
+        MapIndices SnapGridPosAt(Direction dir, int dist = 1)
         {
             switch (dir)
             {
                 case Direction.East:
-                    return Position + new MapIndices(1, 0);
+                    return Position + new MapIndices(dist, 0);
                 case Direction.SouthEast:
-                    return Position + new MapIndices(1, -1);
+                    return Position + new MapIndices(dist, -dist);
                 case Direction.South:
-                    return Position + new MapIndices(0, -1);
+                    return Position + new MapIndices(0, -dist);
                 case Direction.SouthWest:
-                    return Position + new MapIndices(-1, -1);
+                    return Position + new MapIndices(-dist, -dist);
                 case Direction.West:
-                    return Position + new MapIndices(-1, 0);
+                    return Position + new MapIndices(-dist, 0);
                 case Direction.NorthWest:
-                    return Position + new MapIndices(-1, 1);
+                    return Position + new MapIndices(-dist, dist);
                 case Direction.North:
-                    return Position + new MapIndices(0, 1);
+                    return Position + new MapIndices(0, dist);
                 case Direction.NorthEast:
-                    return Position + new MapIndices(1, 1);
+                    return Position + new MapIndices(dist, dist);
                 default:
                     throw new NotImplementedException();
+            }
+        }
+
+        public IEnumerable<SnapGridComponent> GetCardinalNeighborCells()
+        {
+            var grid = _mapManager.GetGrid(Owner.Transform.GridID);
+            foreach (var cell in grid.GetSnapGridCell(Position, Offset))
+                yield return cell;
+            foreach (var cell in grid.GetSnapGridCell(Position + new MapIndices(0, 1), Offset))
+                yield return cell;
+            foreach (var cell in grid.GetSnapGridCell(Position + new MapIndices(0, -1), Offset))
+                yield return cell;
+            foreach (var cell in grid.GetSnapGridCell(Position + new MapIndices(1, 0), Offset))
+                yield return cell;
+            foreach (var cell in grid.GetSnapGridCell(Position + new MapIndices(-1, 0), Offset))
+                yield return cell;
+        }
+
+        public IEnumerable<SnapGridComponent> GetCellsInSquareArea(int n = 1)
+        {
+            var grid = _mapManager.GetGrid(Owner.Transform.GridID);
+            for (var y = -n; y <= n; ++y)
+            for (var x = -n; x <= n; ++x)
+            {
+                foreach (var cell in grid.GetSnapGridCell(Position + new MapIndices(x, y), Offset))
+                    yield return cell;
             }
         }
 

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -100,6 +100,7 @@ namespace Robust.Shared.GameObjects.Components.Transform
 
                 SetRotation(value);
                 RebuildMatrices();
+                UpdateEntityTree();
                 Dirty();
             }
         }
@@ -221,14 +222,15 @@ namespace Robust.Shared.GameObjects.Components.Transform
 
                 SetPosition(newPos);
 
-                Dirty();
-
                 //TODO: This is a hack, look into WHY we can't call GridPosition before the comp is Running
                 if (Running)
                 {
                     RebuildMatrices();
                     Owner.SendMessage(this, new MoveMessage(GridPosition, value));
                 }
+
+                UpdateEntityTree();
+                Dirty();
             }
         }
 
@@ -267,9 +269,11 @@ namespace Robust.Shared.GameObjects.Components.Transform
                     return;
 
                 SetPosition(newPos);
-                Dirty();
 
                 RebuildMatrices();
+                UpdateEntityTree();
+                Dirty();
+
                 Owner.SendMessage(this, new MoveMessage(GridPosition, new GridCoordinates(GetLocalPosition(), GridID)));
             }
         }
@@ -296,6 +300,7 @@ namespace Robust.Shared.GameObjects.Components.Transform
                 var oldPos = GridPosition;
                 SetPosition(value);
                 RebuildMatrices();
+                UpdateEntityTree();
                 Dirty();
                 Owner.SendMessage(this, new MoveMessage(oldPos, GridPosition));
             }
@@ -321,6 +326,8 @@ namespace Robust.Shared.GameObjects.Components.Transform
             // If it cannot, then this is an orphan entity, and an exception will be thrown.
             // DO NOT REMOVE THIS LINE
             var _ = MapID;
+
+            UpdateEntityTree();
         }
 
         /// <inheritdoc />
@@ -330,6 +337,8 @@ namespace Robust.Shared.GameObjects.Components.Transform
 
             // Keep the cached matrices in sync with the fields.
             RebuildMatrices();
+            UpdateEntityTree();
+            Dirty();
         }
 
         /// <inheritdoc />
@@ -379,7 +388,7 @@ namespace Robust.Shared.GameObjects.Components.Transform
             Parent = newMapEntity.Transform;
             MapPosition = mapPos;
 
-
+            UpdateEntityTree();
             Dirty();
         }
 
@@ -408,6 +417,7 @@ namespace Robust.Shared.GameObjects.Components.Transform
             // offset position from world to parent
             SetPosition(parent.InvWorldMatrix.Transform(GetLocalPosition()));
             RebuildMatrices();
+            UpdateEntityTree();
             Dirty();
         }
 
@@ -526,6 +536,9 @@ namespace Robust.Shared.GameObjects.Components.Transform
                 _nextRotation = ((TransformComponentState) nextState).Rotation;
             else
                 _nextRotation = _localRotation; // this should cause the lerp to do nothing
+
+            UpdateEntityTree();
+            Dirty();
         }
 
         // Hooks for GodotTransformComponent go here.
@@ -616,6 +629,8 @@ namespace Robust.Shared.GameObjects.Components.Transform
 
             _invWorldMatrix = itransMat;
         }
+
+        private void UpdateEntityTree() => _entityManager.UpdateEntityTree(Owner);
 
         public string GetDebugString()
         {

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -630,7 +630,7 @@ namespace Robust.Shared.GameObjects.Components.Transform
             _invWorldMatrix = itransMat;
         }
 
-        private void UpdateEntityTree() => _entityManager.UpdateEntityTree(Owner);
+        private bool UpdateEntityTree() => _entityManager.UpdateEntityTree(Owner);
 
         public string GetDebugString()
         {

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Robust.Shared.GameObjects.Components;
@@ -80,7 +80,6 @@ namespace Robust.Shared.GameObjects
         private IMetaDataComponent _metaData;
 
         private bool _initializing;
-
         /// <inheritdoc />
         [ViewVariables]
         public IMetaDataComponent MetaData => _metaData ?? (_metaData = GetComponent<IMetaDataComponent>());

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using Robust.Shared.GameObjects.Components;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.Interfaces.GameObjects.Components;
@@ -55,7 +57,16 @@ namespace Robust.Shared.GameObjects
         public bool Initialized { get; private set; }
 
         [ViewVariables]
-        public bool Initializing { get; private set; }
+        public bool Initializing {
+            get => _initializing;
+            private set {
+                _initializing = value;
+                if (value)
+                {
+                    EntityManager.UpdateEntityTree(this);
+                }
+            }
+        }
 
         /// <inheritdoc />
         [ViewVariables]
@@ -67,6 +78,9 @@ namespace Robust.Shared.GameObjects
         public ITransformComponent Transform => _transform ?? (_transform = GetComponent<ITransformComponent>());
 
         private IMetaDataComponent _metaData;
+
+        private bool _initializing;
+
         /// <inheritdoc />
         [ViewVariables]
         public IMetaDataComponent MetaData => _metaData ?? (_metaData = GetComponent<IMetaDataComponent>());
@@ -159,6 +173,20 @@ namespace Robust.Shared.GameObjects
             // Startup() can modify _components
             // TODO: This code can only handle additions to the list. Is there a better way?
             var components = EntityManager.ComponentManager.GetComponents(Uid);
+
+            foreach (var t in components.OfType<ITransformComponent>())
+            {
+                if (t.Initialized && !t.Deleted)
+                    t.Running = true;
+            }
+            foreach (var t in components.OfType<ICollidableComponent>())
+            {
+                if (t.Initialized && !t.Deleted)
+                    t.Running = true;
+            }
+
+            EntityManager.UpdateEntityTree(this);
+
             foreach (var t in components)
             {
                 var comp = (Component)t;

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -1,14 +1,20 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
 using Robust.Shared.GameObjects.Components;
 using Robust.Shared.GameObjects.Components.Transform;
 using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Interfaces.GameObjects.Components;
 using Robust.Shared.Interfaces.Map;
 using Robust.Shared.Interfaces.Timing;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Network.Messages;
+using Robust.Shared.Physics;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -44,12 +50,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         ///     All entities currently stored in the manager.
         /// </summary>
-        protected readonly Dictionary<EntityUid, IEntity> Entities = new Dictionary<EntityUid, IEntity>();
-
-        /// <summary>
-        /// List of all entities, used for iteration.
-        /// </summary>
-        protected readonly List<Entity> _allEntities = new List<Entity>();
+        protected readonly ConcurrentDictionary<EntityUid, IEntity> Entities = new ConcurrentDictionary<EntityUid, IEntity>();
 
         protected readonly Queue<IncomingEntityMessage> NetworkMessageBuffer = new Queue<IncomingEntityMessage>();
 
@@ -159,12 +160,9 @@ namespace Robust.Shared.GameObjects
 
         public IEnumerable<IEntity> GetEntities()
         {
-            // Manual index loop to allow adding to the list while iterating.
-            // ReSharper disable once ForCanBeConvertedToForeach
-            // ReSharper disable once LoopCanBeConvertedToQuery
-            for (var i = 0; i < _allEntities.Count; i++)
+            // now safe to iterate while adding/removing
+            foreach (var entity in Entities.Values)
             {
-                var entity = _allEntities[i];
                 if (entity.Deleted)
                 {
                     continue;
@@ -252,7 +250,7 @@ namespace Robust.Shared.GameObjects
             _componentManager.AddComponent<TransformComponent>(entity);
 
             Entities[entity.Uid] = entity;
-            _allEntities.Add(entity);
+            UpdateEntityTree(entity);
 
             return entity;
         }
@@ -296,19 +294,15 @@ namespace Robust.Shared.GameObjects
             // Culling happens in updates.
             // It doesn't matter because to-be culled entities can't be accessed.
             // This should prevent most cases of "somebody is iterating while we're removing things"
-            for (var i = 0; i < _allEntities.Count; i++)
+            foreach (var entity in GetEntities())
             {
-                var entity = _allEntities[i];
                 if (!entity.Deleted)
                 {
                     continue;
                 }
 
-                _allEntities.RemoveSwap(i);
-                Entities.Remove(entity.Uid);
-
-                // Process the one we just swapped next.
-                i--;
+                Entities.Remove(entity.Uid, out _);
+                RemoveFromEntityTrees(entity);
             }
         }
 
@@ -426,26 +420,18 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public IEnumerable<IEntity> GetEntitiesIntersecting(MapId mapId, Box2 position)
-        {
-            foreach (var entity in GetEntities())
-            {
-                var transform = entity.Transform;
-                if (transform.MapID != mapId)
-                    continue;
+        public IEnumerable<IEntity> GetEntitiesIntersecting(MapId mapId, Box2 position) {
 
-                if (entity.TryGetComponent<ICollidableComponent>(out var component))
+            var newResults = _entityTreesPerMap[mapId].Query(position); // .ToArray();
+
+            foreach (var entity in newResults)
+            {
+                if (entity.Deleted)
                 {
-                    if (position.Intersects(component.WorldAABB))
-                        yield return entity;
+                    continue;
                 }
-                else
-                {
-                    if (position.Contains(transform.WorldPosition))
-                    {
-                        yield return entity;
-                    }
-                }
+
+                yield return entity;
             }
         }
 
@@ -507,7 +493,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public IEnumerable<IEntity> GetEntitiesInRange(MapId mapId, Box2 box, float range)
         {
-            var aabb = new Box2(box.Left - range, box.Top - range, box.Right + range, box.Bottom + range);
+            var aabb = Box2.Grow(box, range);
             return GetEntitiesIntersecting(mapId, aabb);
         }
 
@@ -538,6 +524,70 @@ namespace Robust.Shared.GameObjects
                     yield return entity;
             }
         }
+
+        #endregion
+
+
+        #region Entity DynamicTree
+
+
+        private ConcurrentDictionary<MapId, DynamicTree<IEntity>> _entityTreesPerMap = new ConcurrentDictionary<MapId, DynamicTree<IEntity>>();
+
+        public void UpdateEntityTree(IEntity entity) {
+
+            if (entity.Deleted)
+            {
+                RemoveFromEntityTrees(entity);
+                return;
+            }
+
+            if (!entity.Initialized || !Entities.ContainsKey(entity.Uid))
+            {
+                return;
+            }
+
+            var transform = entity.TryGetComponent(out ITransformComponent tx) ? tx : null;
+
+            if (transform == null || !transform.Initialized)
+            {
+                RemoveFromEntityTrees(entity);
+                return;
+            }
+
+            var mapId = transform.MapID;
+
+            var entTree = _entityTreesPerMap.GetOrAdd(mapId, EntityTreeFactory);
+
+            entTree.AddOrUpdate(entity);
+        }
+
+        private void RemoveFromEntityTrees(IEntity entity) {
+            foreach (var mapId in _mapManager.GetAllMapIds()) {
+                if (_entityTreesPerMap.TryGetValue(mapId, out var entTree)) {
+                    entTree.Remove(entity);
+                }
+            }
+        }
+
+        private static DynamicTree<IEntity> EntityTreeFactory(MapId _) =>
+            new DynamicTree<IEntity>(
+                GetWorldAabbFromEntity,
+                capacity: 16,
+                growthFunc: x => x == 16 ? 3840 : x + 256
+            );
+
+        private static Box2 GetWorldAabbFromEntity(in IEntity ent)
+        {
+            if (ent.Deleted)
+                return new Box2(0,0,0,0);
+
+            if (ent.TryGetComponent(out ICollidableComponent collider))
+                return collider.WorldAABB;
+
+            var pos = ent.Transform.WorldPosition;
+            return new Box2(pos, pos);
+        }
+
 
         #endregion
     }

--- a/Robust.Shared/Interfaces/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/Interfaces/GameObjects/IEntityManager.cs
@@ -194,7 +194,7 @@ namespace Robust.Shared.Interfaces.GameObjects
 
         #region Spatial Updates
 
-        void UpdateEntityTree(IEntity entity);
+        bool UpdateEntityTree(IEntity entity);
 
         #endregion
 

--- a/Robust.Shared/Interfaces/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/Interfaces/GameObjects/IEntityManager.cs
@@ -118,7 +118,7 @@ namespace Robust.Shared.Interfaces.GameObjects
 
         #region Spatial Queries
 
-        IEnumerable<IEntity> GetEntitiesAt(Vector2 position);
+        IEnumerable<IEntity> GetEntitiesAt(MapId mapId, Vector2 position);
 
         /// <summary>
         /// Checks if any entity is intersecting the box

--- a/Robust.Shared/Interfaces/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/Interfaces/GameObjects/IEntityManager.cs
@@ -191,5 +191,12 @@ namespace Robust.Shared.Interfaces.GameObjects
         IEnumerable<IEntity> GetEntitiesInArc(GridCoordinates coordinates, float range, Angle direction, float arcWidth);
 
         #endregion
+
+        #region Spatial Updates
+
+        void UpdateEntityTree(IEntity entity);
+
+        #endregion
+
     }
 }

--- a/Robust.Shared/Interfaces/Physics/IPhysicsManager.cs
+++ b/Robust.Shared/Interfaces/Physics/IPhysicsManager.cs
@@ -33,7 +33,7 @@ namespace Robust.Shared.Interfaces.Physics
         /// <param name="maxLength">Maximum length of the ray in meters.</param>
         /// <param name="ignoredEnt">A single entity that can be ignored by the RayCast. Useful if the ray starts inside the body of an entity.</param>
         /// <returns>A result object describing the hit, if any.</returns>
-        RayCastResults IntersectRay(MapId mapId, Ray ray, float maxLength = 50, IEntity ignoredEnt = null);
+        RayCastResults IntersectRay(MapId mapId, CollisionRay ray, float maxLength = 50, IEntity ignoredEnt = null);
 
         event Action<DebugRayData> DebugDrawRay;
     }

--- a/Robust.Shared/Physics/BroadPhaseNaive.cs
+++ b/Robust.Shared/Physics/BroadPhaseNaive.cs
@@ -148,7 +148,7 @@ namespace Robust.Shared.Physics
         }
 
         /// <inheritdoc />
-        public void RayCast(RayCastCallback callback, MapId mapId, in Ray ray, float maxLength = 25)
+        public void RayCast(RayCastCallback callback, MapId mapId, in CollisionRay ray, float maxLength = 25)
         {
             var minDist = maxLength;
             for (var i = 0; i < _nodes.Length; i++)

--- a/Robust.Shared/Physics/CollisionRay.cs
+++ b/Robust.Shared/Physics/CollisionRay.cs
@@ -1,0 +1,106 @@
+using Robust.Shared.Map;
+using Robust.Shared.Utility;
+using System;
+
+namespace Robust.Shared.Maths
+{
+    /// <summary>
+    ///     A representation of a 2D ray.
+    /// </summary>
+    [Serializable]
+    public readonly struct CollisionRay : IEquatable<CollisionRay> {
+
+        private readonly Ray _ray;
+
+        private readonly int _collisionMask;
+
+        /// <summary>
+        ///     Specifies the starting point of the ray.
+        /// </summary>
+        public Vector2 Position => _ray.Position;
+
+        /// <summary>
+        ///     Specifies the direction the ray is pointing.
+        /// </summary>
+        public Vector2 Direction => _ray.Direction;
+
+        public int CollisionMask => _collisionMask;
+
+        /// <summary>
+        ///     Creates a new instance of a Ray.
+        /// </summary>
+        /// <param name="position">Starting position of the ray.</param>
+        /// <param name="direction">Unit direction vector that the ray is pointing.</param>
+        public CollisionRay(Vector2 position, Vector2 direction, int collisionMask)
+        {
+            _ray = new Ray(position, direction);
+            _collisionMask = collisionMask;
+
+        }
+
+        #region Intersect Tests
+
+        public bool Intersects(Box2 box, out float distance, out Vector2 hitPos)
+            => _ray.Intersects(box, out distance, out hitPos);
+
+        #endregion
+
+        #region Equality
+
+        /// <summary>
+        ///     Determines if this Ray and another Ray are equivalent.
+        /// </summary>
+        /// <param name="other">Ray to compare to.</param>
+        public bool Equals(CollisionRay other)
+        {
+            return Position.Equals(other.Position) && Direction.Equals(other.Direction);
+        }
+
+        /// <summary>
+        ///     Determines if this ray and another object is equivalent.
+        /// </summary>
+        /// <param name="obj">Object to compare to.</param>
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            return obj is CollisionRay ray && Equals(ray);
+        }
+
+        /// <summary>
+        ///     Calculates the hash code of this Ray.
+        /// </summary>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Position.GetHashCode() * 397) ^ Direction.GetHashCode();
+            }
+        }
+
+        /// <summary>
+        ///     Determines if two instances of Ray are equal.
+        /// </summary>
+        /// <param name="a">Ray on the left side of the operator.</param>
+        /// <param name="b">Ray on the right side of the operator.</param>
+        public static bool operator ==(CollisionRay a, CollisionRay b)
+        {
+            return a.Equals(b);
+        }
+
+        /// <summary>
+        ///     Determines if two instances of Ray are not equal.
+        /// </summary>
+        /// <param name="a">Ray on the left side of the operator.</param>
+        /// <param name="b">Ray on the right side of the operator.</param>
+        public static bool operator !=(CollisionRay a, CollisionRay b)
+        {
+            return !(a == b);
+        }
+
+        #endregion
+
+        public static implicit operator Ray(CollisionRay a)
+            => a._ray;
+
+    }
+}

--- a/Robust.Shared/Physics/DynamicTree.Node.cs
+++ b/Robust.Shared/Physics/DynamicTree.Node.cs
@@ -1,0 +1,70 @@
+/*
+ * Initially based on Box2D by Erin Catto, license follows;
+ *
+ * Copyright (c) 2009 Erin Catto http://www.box2d.org
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Robust.Shared.Maths;
+
+namespace Robust.Shared.Physics
+{
+
+    public partial class DynamicTree<T>
+    {
+
+        public struct Node
+        {
+
+            public Box2 Aabb;
+
+            public Proxy Parent;
+
+            public Proxy Child1, Child2;
+
+            public int Height;
+
+            public T Item;
+
+            public bool IsLeaf
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => Child2 == Proxy.Free;
+            }
+
+            public bool IsFree
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => Height == -1;
+            }
+
+            public override string ToString()
+                => $@"Parent: {(Parent == Proxy.Free ? "None" : Parent.ToString())}, {
+                    (IsLeaf
+                        ? Height == 0
+                            ? $"Leaf: {Item}"
+                            : $"Leaf (invalid height of {Height}): {Item}"
+                        : IsFree
+                            ? "Free"
+                            : $"Branch at height {Height}, children: {Child1} and {Child2}")}";
+
+        }
+
+    }
+
+}

--- a/Robust.Shared/Physics/DynamicTree.Proxy.cs
+++ b/Robust.Shared/Physics/DynamicTree.Proxy.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Robust.Shared.Physics
+{
+
+    public partial class DynamicTree
+    {
+
+        public readonly struct Proxy : IEquatable<Proxy>, IComparable<Proxy>
+        {
+
+            private readonly int _value;
+
+            public static Proxy Free
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => new Proxy(-1);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public Proxy(int v) => _value = v;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool Equals(Proxy other)
+                => _value == other._value;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public int CompareTo(Proxy other)
+                => _value.CompareTo(other._value);
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public override bool Equals(object obj)
+                => obj is Proxy other && Equals(other);
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public override int GetHashCode() => _value;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static implicit operator int(Proxy n) => n._value;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator Proxy(int v) => new Proxy(v);
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool operator ==(Proxy a, Proxy b) => a._value == b._value;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool operator !=(Proxy a, Proxy b) => a._value != b._value;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool operator >(Proxy a, Proxy b) => a._value > b._value;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool operator <(Proxy a, Proxy b) => a._value < b._value;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool operator >=(Proxy a, Proxy b) => a._value >= b._value;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool operator <=(Proxy a, Proxy b) => a._value <= b._value;
+
+            public override string ToString()
+                => _value.ToString();
+
+        }
+
+    }
+
+}

--- a/Robust.Shared/Physics/DynamicTree.cs
+++ b/Robust.Shared/Physics/DynamicTree.cs
@@ -348,9 +348,9 @@ namespace Robust.Shared.Physics
 
             var movedDist = newBox.Center - oldBox.Center;
 
-            var fattenedNewBox = Box2.Grow(newBox, AabbExtendSize);
+            var fattenedNewBox = newBox.Enlarged(AabbExtendSize);
 
-            fattenedNewBox = Box2.Combine(newBox, fattenedNewBox.Translated(movedDist));
+            fattenedNewBox = newBox.Union(fattenedNewBox.Translated(movedDist));
 
             Assert(fattenedNewBox.Contains(newBox));
 
@@ -617,7 +617,7 @@ namespace Robust.Shared.Physics
             var v = new Vector2(-r.Y, r.X);
             var absV = new Vector2(MathF.Abs(r.Y), MathF.Abs(r.X));
 
-            var aabb = Box2.Combine(start, end);
+            var aabb = Box2.Union(start, end);
 
             var stack = new Stack<Proxy>(256);
 
@@ -803,7 +803,7 @@ namespace Robust.Shared.Physics
                     {
                         ref var aabbJ = ref _nodes[proxies[j]].Aabb;
 
-                        var cost = Box2.Perimeter(Box2.Combine(aabbI, aabbJ));
+                        var cost = Box2.Perimeter(aabbI.Union(aabbJ));
 
                         if (cost >= minCost)
                         {
@@ -828,7 +828,7 @@ namespace Robust.Shared.Physics
                 parentNode.Child1 = child1;
                 parentNode.Child2 = child2;
                 parentNode.Height = Math.Max(child1Node.Height, child2Node.Height) + 1;
-                parentNode.Aabb = Box2.Combine(child1Node.Aabb, child2Node.Aabb);
+                parentNode.Aabb = child1Node.Aabb.Union(child2Node.Aabb);
                 parentNode.Parent = Proxy.Free;
 
                 child1Node.Parent = parent;
@@ -1068,7 +1068,7 @@ namespace Robust.Shared.Physics
                 ref var child2Node = ref _nodes[child2];
                 ref var indexAabb = ref indexNode.Aabb;
                 var indexPeri = Box2.Perimeter(indexAabb);
-                var combinedAabb = Box2.Combine(indexAabb, leafAabb);
+                var combinedAabb = indexAabb.Union(leafAabb);
                 var combinedPeri = Box2.Perimeter(combinedAabb);
                 var cost = 2 * combinedPeri;
                 var inheritCost = 2 * (combinedPeri - indexPeri);
@@ -1093,7 +1093,7 @@ namespace Robust.Shared.Physics
 
             ref var newParentNode = ref _nodes[newParent];
             newParentNode.Parent = oldParent;
-            newParentNode.Aabb = Box2.Combine(leafAabb, siblingNode.Aabb);
+            newParentNode.Aabb = leafAabb.Union(siblingNode.Aabb);
             newParentNode.Height = 1 + siblingNode.Height;
 
             ref var proxyNode = ref _nodes[leaf];
@@ -1199,7 +1199,7 @@ namespace Robust.Shared.Physics
                 ref var child2Node = ref _nodes[child2];
 
                 indexNode.Height = Math.Max(child1Node.Height, child2Node.Height) + 1;
-                indexNode.Aabb = Box2.Combine(child1Node.Aabb, child2Node.Aabb);
+                indexNode.Aabb = child1Node.Aabb.Union(child2Node.Aabb);
 
                 index = indexNode.Parent;
             }
@@ -1271,8 +1271,8 @@ namespace Robust.Shared.Physics
                     c.Child2 = iF;
                     a.Child2 = iG;
                     g.Parent = iA;
-                    a.Aabb = Box2.Combine(b.Aabb, g.Aabb);
-                    c.Aabb = Box2.Combine(a.Aabb, f.Aabb);
+                    a.Aabb = b.Aabb.Union(g.Aabb);
+                    c.Aabb = a.Aabb.Union(f.Aabb);
 
                     a.Height = Math.Max(b.Height, g.Height) + 1;
                     c.Height = Math.Max(a.Height, f.Height) + 1;
@@ -1282,8 +1282,8 @@ namespace Robust.Shared.Physics
                     c.Child2 = iG;
                     a.Child2 = iF;
                     f.Parent = iA;
-                    a.Aabb = Box2.Combine(b.Aabb, f.Aabb);
-                    c.Aabb = Box2.Combine(a.Aabb, g.Aabb);
+                    a.Aabb = b.Aabb.Union(f.Aabb);
+                    c.Aabb = a.Aabb.Union(g.Aabb);
 
                     a.Height = Math.Max(b.Height, f.Height) + 1;
                     c.Height = Math.Max(a.Height, g.Height) + 1;
@@ -1335,8 +1335,8 @@ namespace Robust.Shared.Physics
                     b.Child2 = iD;
                     a.Child1 = iE;
                     e.Parent = iA;
-                    a.Aabb = Box2.Combine(c.Aabb, e.Aabb);
-                    b.Aabb = Box2.Combine(a.Aabb, d.Aabb);
+                    a.Aabb = c.Aabb.Union(e.Aabb);
+                    b.Aabb = a.Aabb.Union(d.Aabb);
 
                     a.Height = Math.Max(c.Height, e.Height) + 1;
                     b.Height = Math.Max(a.Height, d.Height) + 1;
@@ -1346,8 +1346,8 @@ namespace Robust.Shared.Physics
                     b.Child2 = iE;
                     a.Child1 = iD;
                     d.Parent = iA;
-                    a.Aabb = Box2.Combine(c.Aabb, d.Aabb);
-                    b.Aabb = Box2.Combine(a.Aabb, e.Aabb);
+                    a.Aabb = c.Aabb.Union(d.Aabb);
+                    b.Aabb = a.Aabb.Union(e.Aabb);
 
                     a.Height = Math.Max(c.Height, d.Height) + 1;
                     b.Height = Math.Max(a.Height, e.Height) + 1;
@@ -1363,10 +1363,7 @@ namespace Robust.Shared.Physics
         private float EstimateCost(in Box2 baseAabb, in Node node)
         {
             var cost = Box2.Perimeter(
-                Box2.Combine(
-                    baseAabb,
-                    node.Aabb
-                )
+                baseAabb.Union(node.Aabb)
             );
 
             if (!node.IsLeaf)

--- a/Robust.Shared/Physics/DynamicTree.cs
+++ b/Robust.Shared/Physics/DynamicTree.cs
@@ -284,6 +284,17 @@ namespace Robust.Shared.Physics
         private bool TryGetProxy(in T item, out Proxy proxy)
             => _nodeLookup.TryGetValue(item, out proxy);
 
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Box2? GetNodeBounds(T item)
+            => TryGetProxy(item, out var proxy) ? _nodes[proxy].Aabb : (Box2?) null;
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Box2? GetNodeBounds(in T item)
+            => TryGetProxy(item, out var proxy) ? _nodes[proxy].Aabb : (Box2?) null;
+
+
         public bool Remove(in T item)
         {
             if (!_nodeLookup.TryRemove(item, out var proxy))
@@ -316,7 +327,7 @@ namespace Robust.Shared.Physics
 
             Assert(Contains(item));
 
-            var leafNode = _nodes[leaf];
+            ref var leafNode = ref _nodes[leaf];
 
             Assert(leafNode.IsLeaf);
 
@@ -336,6 +347,8 @@ namespace Robust.Shared.Physics
             var fattenedNewBox = Box2.Grow(newBox, AabbExtendSize);
 
             fattenedNewBox = Box2.Combine(newBox, fattenedNewBox.Translated(movedDist));
+
+            Assert(fattenedNewBox.Contains(newBox));
 
             RemoveLeaf(leaf);
 
@@ -1380,15 +1393,10 @@ namespace Robust.Shared.Physics
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void AddOrUpdate(T item)
-        {
-            if (!Update(item))
-            {
-                Add(item);
-            }
-        }
+        public bool AddOrUpdate(T item) => Update(item) || Add(item);
 
         [Conditional("DEBUG_DYNAMIC_TREE")]
+        [Conditional("DEBUG_DYNAMIC_TREE_ASSERTS")]
         [DebuggerNonUserCode] [DebuggerHidden] [DebuggerStepThrough]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Assert(bool assertion, [CallerMemberName] string member = default, [CallerFilePath] string file = default, [CallerLineNumber] int line = default)

--- a/Robust.Shared/Physics/DynamicTree.cs
+++ b/Robust.Shared/Physics/DynamicTree.cs
@@ -105,7 +105,8 @@ namespace Robust.Shared.Physics
             lastNode.Height = -1;
         }
 
-        public int Capacity {
+        public int Capacity
+        {
             get => _nodes.Length;
             set => EnsureCapacity(value);
         }

--- a/Robust.Shared/Physics/DynamicTree.cs
+++ b/Robust.Shared/Physics/DynamicTree.cs
@@ -1,0 +1,1325 @@
+/*
+ * Initially based on Box2D by Erin Catto, license follows;
+ *
+ * Copyright (c) 2009 Erin Catto http://www.box2d.org
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
+using Robust.Shared.Maths;
+
+namespace Robust.Shared.Physics
+{
+
+    [PublicAPI]
+    public abstract partial class DynamicTree
+    {
+
+        public const int MinimumCapacity = 16;
+
+        protected const float AabbMultiplier = 2f;
+
+        protected readonly float AabbExtendSize;
+
+        protected readonly Func<int, int> GrowthFunc;
+
+        protected DynamicTree(float aabbExtendSize, Func<int, int> growthFunc)
+        {
+            AabbExtendSize = aabbExtendSize;
+            GrowthFunc = growthFunc ?? DefaultGrowthFunc;
+        }
+
+        // box2d grows by *2, here we're being somewhat more linear
+        private static int DefaultGrowthFunc(int x)
+            => x + 256;
+
+    }
+
+    [PublicAPI]
+    [DebuggerDisplay("{" + nameof(DebuggerDisplay) + "}")]
+    public sealed partial class DynamicTree<T>
+        : DynamicTree, ICollection<T>
+    {
+
+        public delegate Box2 ExtractAabbDelegate(in T value);
+
+        public delegate bool QueryCallbackDelegate(ref T value);
+
+        public delegate bool RayQueryCallbackDelegate(ref T value, in Vector2 point, float distFromOrigin);
+
+        private readonly IEqualityComparer<T> _equalityComparer;
+
+        private readonly ExtractAabbDelegate _extractAabb;
+
+        private Proxy _freeNodes;
+
+        // avoids "Collection was modified; enumeration operation may not execute."
+        private ConcurrentDictionary<T, Proxy> _nodeLookup;
+
+        private Node[] _nodes;
+
+        private Proxy _root;
+
+        public DynamicTree(ExtractAabbDelegate extractAabbFunc, IEqualityComparer<T> comparer = null, float aabbExtendSize = 1f / 32, int capacity = 256, Func<int, int> growthFunc = null)
+            : base(aabbExtendSize, growthFunc)
+        {
+            _extractAabb = extractAabbFunc;
+            _equalityComparer = comparer ?? EqualityComparer<T>.Default;
+            capacity = Math.Max(MinimumCapacity, capacity);
+
+            _root = Proxy.Free;
+
+            _nodeLookup = new ConcurrentDictionary<T, Proxy>();
+            _nodes = new Node[capacity];
+
+            var l = Capacity - 1;
+            for (var i = 0; i < l; ++i)
+            {
+                ref var node = ref _nodes[i];
+                node.Parent = (Proxy) (i + 1);
+                node.Height = -1;
+            }
+
+            ref var lastNode = ref _nodes[l];
+
+            lastNode.Parent = Proxy.Free;
+            lastNode.Height = -1;
+        }
+
+        private int Capacity => _nodes.Length;
+
+        public int Height
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _root == Proxy.Free ? 0 : _nodes[_root].Height;
+        }
+
+        public int MaxBalance
+        {
+            [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.NoInlining)]
+            get
+            {
+                var maxBal = 0;
+
+                for (var i = 0; i < Capacity; ++i)
+                {
+                    ref var node = ref _nodes[i];
+                    if (node.Height <= 1)
+                    {
+                        continue;
+                    }
+
+                    ref var child1Node = ref _nodes[node.Child1];
+                    ref var child2Node = ref _nodes[node.Child2];
+
+                    var bal = Math.Abs(child2Node.Height - child1Node.Height);
+                    maxBal = Math.Max(maxBal, bal);
+                }
+
+                return maxBal;
+            }
+        }
+
+        public float AreaRatio
+        {
+            [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.NoInlining)]
+            get
+            {
+                if (_root == Proxy.Free)
+                {
+                    return 0;
+                }
+
+                ref var rootNode = ref _nodes[_root];
+                var rootPeri = Box2.Perimeter(rootNode.Aabb);
+
+                var totalPeri = 0f;
+
+                for (var i = 0; i < Capacity; ++i)
+                {
+                    ref var node = ref _nodes[i];
+                    if (node.Height < 0)
+                    {
+                        continue;
+                    }
+
+                    totalPeri += Box2.Perimeter(node.Aabb);
+                }
+
+                return totalPeri / rootPeri;
+            }
+        }
+
+        public string DebuggerDisplay
+            => $"Count = {Count}, Capacity = {Capacity}, Height = {Height}";
+
+        private IEnumerable<(Proxy, Node)> DebugAllocatedNodesEnumerable
+        {
+            get
+            {
+                for (var i = 0; i < _nodes.Length; i++)
+                {
+                    var node = _nodes[i];
+                    if (!node.IsFree)
+                    {
+                        yield return ((Proxy) i, node);
+                    }
+                }
+            }
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        private (Proxy, Node)[] DebugAllocatedNodes
+        {
+            get
+            {
+                var data = new (Proxy, Node)[Count];
+                var i = 0;
+                foreach (var x in DebugAllocatedNodesEnumerable)
+                {
+                    data[i++] = x;
+                }
+
+                return data;
+            }
+        }
+
+        public IEnumerator<T> GetEnumerator()
+            => _nodeLookup.Keys.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
+
+        public void Clear()
+        {
+            var capacity = Capacity;
+
+            Count = 0;
+            _nodes = new Node[capacity];
+            _root = Proxy.Free;
+
+            _nodeLookup = new ConcurrentDictionary<T, Proxy>();
+            _nodes = new Node[capacity];
+
+            var l = Capacity - 1;
+            for (var i = 0; i < l; ++i)
+            {
+                ref var node = ref _nodes[i];
+                node.Parent = (Proxy) (i + 1);
+                node.Height = -1;
+            }
+
+            ref var lastNode = ref _nodes[l];
+
+            lastNode.Parent = Proxy.Free;
+            lastNode.Height = -1;
+        }
+
+        public bool Contains(T item)
+            => item != null && _nodeLookup.ContainsKey(item);
+
+        public void CopyTo(T[] array, int arrayIndex)
+            => _nodeLookup.Keys.CopyTo(array, arrayIndex);
+
+        public int Count { get; private set; }
+
+        public bool IsReadOnly
+            => false;
+
+        void ICollection<T>.Add(T item)
+            => Add(item);
+
+        bool ICollection<T>.Remove(T item)
+            => Remove(item);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Add(in T item)
+            => CreateProxy(_extractAabb(item), item);
+
+        private bool TryGetProxy(in T item, out Proxy proxy)
+            => _nodeLookup.TryGetValue(item, out proxy);
+
+        public bool Remove(in T item)
+        {
+            if (!TryGetProxy(item, out var proxy))
+            {
+                return false;
+            }
+
+            DestroyProxy(proxy);
+
+            _nodeLookup.Remove(item, out _);
+
+            Assert(!Contains(item));
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.NoInlining)]
+        private Proxy CreateProxy(in Box2 box, in T item)
+        {
+            var proxy = AllocateNode();
+
+            ref var node = ref _nodes[proxy];
+            node.Aabb = new Box2(
+                box.Left - AabbExtendSize,
+                box.Bottom - AabbExtendSize,
+                box.Right + AabbExtendSize,
+                box.Top + AabbExtendSize
+            );
+            node.Item = item;
+
+            InsertLeaf(proxy);
+
+            _nodeLookup[item] = proxy;
+
+            Assert(Contains(item));
+
+            return proxy;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void DestroyProxy(Proxy proxy)
+        {
+            RemoveLeaf(proxy);
+            FreeNode(proxy);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.NoInlining)]
+        public bool Update(in T item)
+        {
+            if (!TryGetProxy(item, out var leaf))
+            {
+                return false;
+            }
+
+            var leafNode = _nodes[leaf];
+
+            Assert(leafNode.IsLeaf);
+
+            var oldBox = leafNode.Aabb;
+
+            var newBox = _extractAabb(item);
+
+            if (leafNode.Aabb.Contains(newBox))
+            {
+                return false;
+            }
+
+            var movedDist = newBox.Center - oldBox.Center;
+
+            var fattenedNewBox = Box2.Grow(newBox, AabbExtendSize);
+
+            fattenedNewBox = Box2.Combine(newBox, fattenedNewBox.Translated(movedDist));
+
+            RemoveLeaf(leaf);
+
+            leafNode.Aabb = fattenedNewBox;
+
+            InsertLeaf(leaf);
+
+            Assert(Contains(item));
+
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private ref T GetValue(Proxy proxy)
+            => ref _nodes[proxy].Item;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private ref Box2 GetAabb(Proxy proxy)
+            => ref _nodes[proxy].Aabb;
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.NoInlining)]
+        public bool Query(QueryCallbackDelegate callback, in Box2 aabb)
+        {
+            var stack = new Stack<Proxy>(256);
+
+            stack.Push(_root);
+
+            var any = false;
+
+            while (stack.Count > 0)
+            {
+                var proxy = stack.Pop();
+
+                if (proxy == Proxy.Free)
+                {
+                    continue;
+                }
+
+                ref var node = ref _nodes[proxy];
+
+                if (!node.Aabb.Intersects(aabb))
+                {
+                    continue;
+                }
+
+                if (!node.IsLeaf)
+                {
+                    if (node.Child1 != Proxy.Free)
+                    {
+                        stack.Push(node.Child1);
+                    }
+
+                    if (node.Child2 != Proxy.Free)
+                    {
+                        stack.Push(node.Child2);
+                    }
+
+                    continue;
+                }
+
+                if (!callback(ref node.Item))
+                {
+                    return true;
+                }
+
+                any = true;
+            }
+
+            return any;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.NoInlining)]
+        public bool Query(QueryCallbackDelegate callback, in Vector2 point)
+        {
+            var stack = new Stack<Proxy>(256);
+
+            stack.Push(_root);
+
+            var any = false;
+
+            while (stack.Count > 0)
+            {
+                var proxy = stack.Pop();
+
+                if (proxy == Proxy.Free)
+                {
+                    continue;
+                }
+
+                ref var node = ref _nodes[proxy];
+
+                if (!node.Aabb.Contains(point))
+                {
+                    continue;
+                }
+
+                if (!node.IsLeaf)
+                {
+                    if (node.Child1 != Proxy.Free)
+                    {
+                        stack.Push(node.Child1);
+                    }
+
+                    if (node.Child2 != Proxy.Free)
+                    {
+                        stack.Push(node.Child2);
+                    }
+
+                    continue;
+                }
+
+                if (!callback(ref node.Item))
+                {
+                    return true;
+                }
+
+                any = true;
+            }
+
+            return any;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.NoInlining)]
+        public IEnumerable<T> Query(Box2 aabb)
+        {
+            var stack = new Stack<Proxy>(256);
+
+            stack.Push(_root);
+
+            var any = false;
+
+            while (stack.Count > 0)
+            {
+                var proxy = stack.Pop();
+
+                if (proxy == Proxy.Free)
+                {
+                    continue;
+                }
+
+                // note: non-ref stack local copy here
+                var node = _nodes[proxy];
+
+                if (!node.Aabb.Intersects(aabb))
+                {
+                    continue;
+                }
+
+                if (!node.IsLeaf)
+                {
+                    if (node.Child1 != Proxy.Free)
+                    {
+                        stack.Push(node.Child1);
+                    }
+
+                    if (node.Child2 != Proxy.Free)
+                    {
+                        stack.Push(node.Child2);
+                    }
+
+                    continue;
+                }
+
+                yield return node.Item;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.NoInlining)]
+        public IEnumerable<T> Query(Vector2 point)
+        {
+            var stack = new Stack<Proxy>(256);
+
+            stack.Push(_root);
+
+            var any = false;
+
+            while (stack.Count > 0)
+            {
+                var proxy = stack.Pop();
+
+                if (proxy == Proxy.Free)
+                {
+                    continue;
+                }
+
+                // note: non-ref stack local copy here
+                var node = _nodes[proxy];
+
+                if (!node.Aabb.Contains(point))
+                {
+                    continue;
+                }
+
+                if (!node.IsLeaf)
+                {
+                    if (node.Child1 != Proxy.Free)
+                    {
+                        stack.Push(node.Child1);
+                    }
+
+                    if (node.Child2 != Proxy.Free)
+                    {
+                        stack.Push(node.Child2);
+                    }
+
+                    continue;
+                }
+
+                yield return node.Item;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.NoInlining)]
+        public bool Query(QueryCallbackDelegate callback, in Vector2 start, in Vector2 end)
+        {
+            var r = (end - start).Normalized;
+
+            var v = new Vector2(-r.Y, r.X);
+            var absV = new Vector2(MathF.Abs(r.Y), MathF.Abs(r.X));
+
+            var aabb = Box2.Combine(start, end);
+
+            var stack = new Stack<Proxy>(256);
+
+            stack.Push(_root);
+
+            var any = false;
+
+            while (stack.Count > 0)
+            {
+                var proxy = stack.Pop();
+
+                if (proxy == Proxy.Free)
+                {
+                    continue;
+                }
+
+                ref var node = ref _nodes[proxy];
+
+                if (!node.Aabb.Intersects(aabb))
+                {
+                    continue;
+                }
+
+                var c = node.Aabb.Center;
+                var h = (node.Aabb.BottomRight - node.Aabb.TopLeft) * .5f;
+
+                var separation = MathF.Abs(Dot(v, start - c) - Dot(absV, h));
+
+                if (separation > 0)
+                {
+                    continue;
+                }
+
+                if (node.IsLeaf)
+                {
+                    any = true;
+
+                    var carryOn = callback(ref node.Item);
+
+                    if (!carryOn)
+                    {
+                        return true;
+                    }
+                }
+                else
+                {
+                    if (node.Child1 != Proxy.Free)
+                    {
+                        stack.Push(node.Child1);
+                    }
+
+                    if (node.Child2 != Proxy.Free)
+                    {
+                        stack.Push(node.Child2);
+                    }
+                }
+            }
+
+            return any;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static float Dot(in Vector2 a, in Vector2 b)
+            => a.X * b.X + a.Y * b.Y;
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.NoInlining)]
+        public bool Query(RayQueryCallbackDelegate callback, in Vector2 start, in Vector2 dir)
+        {
+            var stack = new Stack<Proxy>(256);
+
+            stack.Push(_root);
+
+            var any = false;
+
+            var ray = new Ray(start, dir);
+
+            while (stack.Count > 0)
+            {
+                var proxy = stack.Pop();
+
+                if (proxy == Proxy.Free)
+                {
+                    continue;
+                }
+
+                ref var node = ref _nodes[proxy];
+
+                if (!ray.Intersects(node.Aabb, out var dist, out var hit))
+                {
+                    continue;
+                }
+
+                if (node.IsLeaf)
+                {
+                    any = true;
+
+                    var carryOn = callback(ref node.Item, hit, dist);
+
+                    if (!carryOn)
+                    {
+                        return true;
+                    }
+                }
+                else
+                {
+                    if (node.Child1 != Proxy.Free)
+                    {
+                        stack.Push(node.Child1);
+                    }
+
+                    if (node.Child2 != Proxy.Free)
+                    {
+                        stack.Push(node.Child2);
+                    }
+                }
+            }
+
+            return any;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.NoInlining)]
+        public void RebuildOptimal(int free = 0)
+        {
+            var proxies = new Proxy[Count + free];
+            var count = 0;
+
+            for (var i = 0; i < Capacity; ++i)
+            {
+                ref var node = ref _nodes[i];
+                if (node.Height < 0)
+                {
+                    continue;
+                }
+
+                var proxy = (Proxy) i;
+                if (node.IsLeaf)
+                {
+                    node.Parent = Proxy.Free;
+                    proxies[count++] = proxy;
+                }
+                else
+                {
+                    FreeNode(proxy);
+                }
+            }
+
+            while (count > 1)
+            {
+                var minCost = float.MaxValue;
+
+                var iMin = -1;
+                var jMin = -1;
+
+                for (var i = 0; i < count; ++i)
+                {
+                    ref var aabbI = ref _nodes[proxies[i]].Aabb;
+
+                    for (var j = i + 1; j < count; ++j)
+                    {
+                        ref var aabbJ = ref _nodes[proxies[j]].Aabb;
+
+                        var cost = Box2.Perimeter(Box2.Combine(aabbI, aabbJ));
+
+                        if (cost >= minCost)
+                        {
+                            continue;
+                        }
+
+                        iMin = i;
+                        jMin = j;
+                        minCost = cost;
+                    }
+                }
+
+                var child1 = proxies[iMin];
+                var child2 = proxies[jMin];
+
+                var parent = AllocateNode();
+
+                ref var child1Node = ref _nodes[child1];
+                ref var child2Node = ref _nodes[child2];
+                ref var parentNode = ref _nodes[parent];
+
+                parentNode.Child1 = child1;
+                parentNode.Child2 = child2;
+                parentNode.Height = Math.Max(child1Node.Height, child2Node.Height) + 1;
+                parentNode.Aabb = Box2.Combine(child1Node.Aabb, child2Node.Aabb);
+                parentNode.Parent = Proxy.Free;
+
+                child1Node.Parent = parent;
+                child2Node.Parent = parent;
+
+                proxies[jMin] = proxies[count - 1];
+                proxies[iMin] = parent;
+                --count;
+            }
+
+            _root = proxies[0];
+
+            Validate();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.NoInlining)]
+        public void ShiftOrigin(in Vector2 newOrigin)
+        {
+            for (var i = 0; i < Capacity; ++i)
+            {
+                ref var node = ref _nodes[i];
+                node.Aabb = new Box2(
+                    node.Aabb.BottomLeft - newOrigin,
+                    node.Aabb.TopRight - newOrigin
+                );
+            }
+        }
+
+        /// <remarks>
+        ///     If allocation occurs, references to <see cref="Node" />s will be invalid.
+        /// </remarks>
+        private Proxy AllocateNode()
+        {
+            if (_freeNodes == Proxy.Free)
+            {
+                var newNodeCap = GrowthFunc(Capacity);
+
+                if (newNodeCap <= Capacity)
+                {
+                    throw new InvalidOperationException("Growth function returned invalid new capacity, must be greater than current capacity.");
+                }
+
+                EnsureCapacity(newNodeCap);
+            }
+
+            var alloc = _freeNodes;
+            ref var allocNode = ref _nodes[alloc];
+            Assert(allocNode.IsFree);
+            _freeNodes = allocNode.Parent;
+            Assert(_freeNodes == -1 || _nodes[_freeNodes].IsFree);
+            allocNode.Parent = Proxy.Free;
+            allocNode.Child1 = Proxy.Free;
+            allocNode.Child2 = Proxy.Free;
+            allocNode.Height = 0;
+            ++Count;
+            return alloc;
+        }
+
+        private void EnsureCapacity(int newCapacity)
+        {
+            if (newCapacity <= Capacity)
+            {
+                return;
+            }
+
+            var oldNodes = _nodes;
+
+            _nodes = new Node[newCapacity];
+
+            Array.Copy(oldNodes, _nodes, Count);
+
+            var l = Capacity - 1;
+            for (var i = Count; i < l; ++i)
+            {
+                ref var node = ref _nodes[i];
+                node.Parent = (Proxy) (i + 1);
+                node.Height = -1;
+            }
+
+            ref var lastNode = ref _nodes[l];
+            lastNode.Parent = Proxy.Free;
+            lastNode.Height = -1;
+            _freeNodes = (Proxy) Count;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void FreeNode(Proxy proxy)
+        {
+            ref var node = ref _nodes[proxy];
+            node.Parent = _freeNodes;
+            node.Height = -1;
+            node.Child1 = Proxy.Free;
+            node.Child2 = Proxy.Free;
+            node.Item = default;
+            _freeNodes = proxy;
+            --Count;
+        }
+
+        [Conditional("DEBUG_DYNAMIC_TREE")]
+        private void Validate()
+        {
+            Validate(_root);
+
+            var freeCount = 0;
+            var freeIndex = _freeNodes;
+            while (freeIndex != Proxy.Free)
+            {
+                Assert(0 <= freeIndex);
+                Assert(freeIndex < Capacity);
+                freeIndex = _nodes[freeIndex].Parent;
+                ++freeCount;
+            }
+
+            Assert(Height == ComputeHeight());
+
+            Assert(Count + freeCount == Capacity);
+        }
+
+        [Conditional("DEBUG_DYNAMIC_TREE")]
+        private void Validate(Proxy proxy)
+        {
+            if (proxy == Proxy.Free) return;
+
+            ref var node = ref _nodes[proxy];
+
+            if (proxy == _root)
+            {
+                Assert(node.Parent == Proxy.Free);
+            }
+
+            var child1 = node.Child1;
+            var child2 = node.Child2;
+
+            if (node.IsLeaf)
+            {
+                Assert(child1 == Proxy.Free);
+                Assert(child2 == Proxy.Free);
+                Assert(node.Height == 0);
+                return;
+            }
+
+            Assert(0 <= child1);
+            Assert(child1 < Capacity);
+            Assert(0 <= child2);
+            Assert(child2 < Capacity);
+
+            ref var child1Node = ref _nodes[child1];
+            ref var child2Node = ref _nodes[child2];
+
+            Assert(child1Node.Parent == proxy);
+            Assert(child2Node.Parent == proxy);
+
+            var height1 = child1Node.Height;
+            var height2 = child2Node.Height;
+
+            var height = 1 + Math.Max(height1, height2);
+
+            Assert(node.Height == height);
+
+            ref var aabb = ref node.Aabb;
+            Assert(aabb.Contains(child1Node.Aabb));
+            Assert(aabb.Contains(child2Node.Aabb));
+
+            Validate(child1);
+            Validate(child2);
+        }
+
+        [Conditional("DEBUG_DYNAMIC_TREE")]
+        private void ValidateHeight(Proxy proxy)
+        {
+            if (proxy == Proxy.Free)
+            {
+                return;
+            }
+
+            ref var node = ref _nodes[proxy];
+
+            if (node.IsLeaf)
+            {
+                Assert(node.Height == 0);
+                return;
+            }
+
+            var child1 = node.Child1;
+            var child2 = node.Child2;
+            ref var child1Node = ref _nodes[child1];
+            ref var child2Node = ref _nodes[child2];
+
+            var height1 = child1Node.Height;
+            var height2 = child2Node.Height;
+
+            var height = 1 + Math.Max(height1, height2);
+
+            Assert(node.Height == height);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.NoInlining)]
+        private void InsertLeaf(Proxy leaf)
+        {
+            if (_root == Proxy.Free)
+            {
+                _root = leaf;
+                _nodes[_root].Parent = Proxy.Free;
+                return;
+            }
+
+            Validate();
+
+            ref var leafNode = ref _nodes[leaf];
+
+            _nodeLookup[leafNode.Item] = leaf;
+
+            ref var leafAabb = ref leafNode.Aabb;
+
+            var index = _root;
+#if DEBUG
+            var loopCount = 0;
+#endif
+            for (;;)
+            {
+#if DEBUG
+                Assert(loopCount++ < Capacity * 2);
+#endif
+
+                ref var indexNode = ref _nodes[index];
+                if (indexNode.IsLeaf) break;
+
+                // assert no loops
+                Assert(_nodes[indexNode.Child1].Child1 != index);
+                Assert(_nodes[indexNode.Child1].Child2 != index);
+                Assert(_nodes[indexNode.Child2].Child1 != index);
+                Assert(_nodes[indexNode.Child2].Child2 != index);
+
+                var child1 = indexNode.Child1;
+                var child2 = indexNode.Child2;
+                ref var child1Node = ref _nodes[child1];
+                ref var child2Node = ref _nodes[child2];
+                ref var indexAabb = ref indexNode.Aabb;
+                var indexPeri = Box2.Perimeter(indexAabb);
+                var combinedAabb = Box2.Combine(indexAabb, leafAabb);
+                var combinedPeri = Box2.Perimeter(combinedAabb);
+                var cost = 2 * combinedPeri;
+                var inheritCost = 2 * (combinedPeri - indexPeri);
+
+                var cost1 = EstimateCost(leafAabb, child1Node) + inheritCost;
+                var cost2 = EstimateCost(leafAabb, child2Node) + inheritCost;
+
+                if (cost < cost1 && cost < cost2)
+                {
+                    break;
+                }
+
+                index = cost1 < cost2 ? child1 : child2;
+            }
+
+            var newParent = AllocateNode();
+
+            var sibling = index;
+            ref var siblingNode = ref _nodes[sibling];
+
+            var oldParent = siblingNode.Parent;
+
+            ref var newParentNode = ref _nodes[newParent];
+            newParentNode.Parent = oldParent;
+            newParentNode.Aabb = Box2.Combine(leafAabb, siblingNode.Aabb);
+            newParentNode.Height = 1 + siblingNode.Height;
+
+            ref var proxyNode = ref _nodes[leaf];
+            if (oldParent != Proxy.Free)
+            {
+                ref var oldParentNode = ref _nodes[oldParent];
+
+                if (oldParentNode.Child1 == sibling)
+                {
+                    oldParentNode.Child1 = newParent;
+                }
+                else
+                {
+                    oldParentNode.Child2 = newParent;
+                }
+
+                newParentNode.Child1 = sibling;
+                newParentNode.Child2 = leaf;
+                siblingNode.Parent = newParent;
+                proxyNode.Parent = newParent;
+            }
+            else
+            {
+                newParentNode.Child1 = sibling;
+                newParentNode.Child2 = leaf;
+                siblingNode.Parent = newParent;
+                proxyNode.Parent = newParent;
+                _root = newParent;
+            }
+
+            Balance(proxyNode.Parent);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.NoInlining)]
+        private void RemoveLeaf(Proxy leaf)
+        {
+            if (leaf == _root)
+            {
+                _root = Proxy.Free;
+                return;
+            }
+
+            Validate();
+
+            ref var leafNode = ref _nodes[leaf];
+
+            _nodeLookup.TryRemove(leafNode.Item, out _);
+
+            var parent = leafNode.Parent;
+            ref var parentNode = ref _nodes[parent];
+            var grandParent = parentNode.Parent;
+            var sibling = parentNode.Child1 == leaf
+                ? parentNode.Child2
+                : parentNode.Child1;
+            ref var siblingNode = ref _nodes[sibling];
+
+            if (grandParent == Proxy.Free)
+            {
+                _root = Proxy.Free;
+                siblingNode.Parent = Proxy.Free;
+                FreeNode(parent);
+                return;
+            }
+
+            ref var grandParentNode = ref _nodes[grandParent];
+            if (grandParentNode.Child1 == parent)
+            {
+                grandParentNode.Child1 = sibling;
+            }
+            else
+            {
+                grandParentNode.Child2 = sibling;
+            }
+
+            siblingNode.Parent = grandParent;
+            FreeNode(parent);
+
+            Balance(grandParent);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.NoInlining)]
+        private void Balance(Proxy index)
+        {
+            while (index != Proxy.Free)
+            {
+                index = BalanceStep(index);
+
+                ref var indexNode = ref _nodes[index];
+
+                var child1 = indexNode.Child1;
+                var child2 = indexNode.Child2;
+
+                Assert(child1 != Proxy.Free);
+                Assert(child2 != Proxy.Free);
+
+                ref var child1Node = ref _nodes[child1];
+                ref var child2Node = ref _nodes[child2];
+
+                indexNode.Height = Math.Max(child1Node.Height, child2Node.Height) + 1;
+                indexNode.Aabb = Box2.Combine(child1Node.Aabb, child2Node.Aabb);
+
+                index = indexNode.Parent;
+            }
+
+            Validate();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private Proxy BalanceStep(Proxy iA)
+        {
+            ref var a = ref _nodes[iA];
+
+            if (a.IsLeaf || a.Height < 2)
+            {
+                return iA;
+            }
+
+            var iB = a.Child1;
+            var iC = a.Child2;
+            Assert(iA != iB);
+            Assert(iA != iC);
+            Assert(iB != iC);
+
+            ref var b = ref _nodes[iB];
+            ref var c = ref _nodes[iC];
+
+            var balance = c.Height - b.Height;
+
+            // Rotate C up
+            if (balance > 1)
+            {
+                var iF = c.Child1;
+                var iG = c.Child2;
+                Assert(iC != iF);
+                Assert(iC != iG);
+                Assert(iF != iG);
+
+                ref var f = ref _nodes[iF];
+                ref var g = ref _nodes[iG];
+
+                // A <> C
+
+                // this creates a loop ...
+                c.Child1 = iA;
+                c.Parent = a.Parent;
+                a.Parent = iC;
+
+                if (c.Parent == Proxy.Free)
+                {
+                    _root = iC;
+                }
+                else
+                {
+                    ref var cParent = ref _nodes[c.Parent];
+                    if (cParent.Child1 == iA)
+                    {
+                        cParent.Child1 = iC;
+                    }
+                    else
+                    {
+                        Assert(cParent.Child2 == iA);
+                        cParent.Child2 = iC;
+                    }
+                }
+
+                // Rotate
+                if (f.Height > g.Height)
+                {
+                    c.Child2 = iF;
+                    a.Child2 = iG;
+                    g.Parent = iA;
+                    a.Aabb = Box2.Combine(b.Aabb, g.Aabb);
+                    c.Aabb = Box2.Combine(a.Aabb, f.Aabb);
+
+                    a.Height = Math.Max(b.Height, g.Height) + 1;
+                    c.Height = Math.Max(a.Height, f.Height) + 1;
+                }
+                else
+                {
+                    c.Child2 = iG;
+                    a.Child2 = iF;
+                    f.Parent = iA;
+                    a.Aabb = Box2.Combine(b.Aabb, f.Aabb);
+                    c.Aabb = Box2.Combine(a.Aabb, g.Aabb);
+
+                    a.Height = Math.Max(b.Height, f.Height) + 1;
+                    c.Height = Math.Max(a.Height, g.Height) + 1;
+                }
+
+                return iC;
+            }
+
+            // Rotate B up
+            if (balance < -1)
+            {
+                var iD = b.Child1;
+                var iE = b.Child2;
+                Assert(iB != iD);
+                Assert(iB != iE);
+                Assert(iD != iE);
+
+                ref var d = ref _nodes[iD];
+                ref var e = ref _nodes[iE];
+
+                // A <> B
+
+                // this creates a loop ...
+                b.Child1 = iA;
+                b.Parent = a.Parent;
+                a.Parent = iB;
+
+                if (b.Parent == Proxy.Free)
+                {
+                    _root = iB;
+                }
+                else
+                {
+                    ref var bParent = ref _nodes[b.Parent];
+                    if (bParent.Child1 == iA)
+                    {
+                        bParent.Child1 = iB;
+                    }
+                    else
+                    {
+                        Assert(bParent.Child2 == iA);
+                        bParent.Child2 = iB;
+                    }
+                }
+
+                // Rotate
+                if (d.Height > e.Height)
+                {
+                    b.Child2 = iD;
+                    a.Child1 = iE;
+                    e.Parent = iA;
+                    a.Aabb = Box2.Combine(c.Aabb, e.Aabb);
+                    b.Aabb = Box2.Combine(a.Aabb, d.Aabb);
+
+                    a.Height = Math.Max(c.Height, e.Height) + 1;
+                    b.Height = Math.Max(a.Height, d.Height) + 1;
+                }
+                else
+                {
+                    b.Child2 = iE;
+                    a.Child1 = iD;
+                    d.Parent = iA;
+                    a.Aabb = Box2.Combine(c.Aabb, d.Aabb);
+                    b.Aabb = Box2.Combine(a.Aabb, e.Aabb);
+
+                    a.Height = Math.Max(c.Height, d.Height) + 1;
+                    b.Height = Math.Max(a.Height, e.Height) + 1;
+                }
+
+                return iB;
+            }
+
+            return iA;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private float EstimateCost(in Box2 baseAabb, in Node node)
+        {
+            var cost = Box2.Perimeter(
+                Box2.Combine(
+                    baseAabb,
+                    node.Aabb
+                )
+            );
+
+            if (!node.IsLeaf)
+            {
+                cost -= Box2.Perimeter(node.Aabb);
+            }
+
+            return cost;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int ComputeHeight()
+            => ComputeHeight(_root);
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.NoInlining)]
+        private int ComputeHeight(Proxy proxy)
+        {
+            ref var node = ref _nodes[proxy];
+            if (node.IsLeaf)
+            {
+                return 0;
+            }
+
+            return Math.Max(
+                ComputeHeight(node.Child1),
+                ComputeHeight(node.Child2)
+            ) + 1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AddOrUpdate(T item)
+        {
+            if (!Update(item))
+            {
+                Add(item);
+            }
+        }
+
+        [Conditional("DEBUG_DYNAMIC_TREE")]
+        [DebuggerNonUserCode] [DebuggerHidden] [DebuggerStepThrough]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Assert(bool assertion, [CallerMemberName] string member = default, [CallerFilePath] string file = default, [CallerLineNumber] int line = default)
+        {
+            if (assertion) return;
+
+            var msg = $"Assertion failure in {member} ({file}:{line})";
+            Debug.Print(msg);
+            Debugger.Break();
+            throw new InvalidOperationException(msg);
+        }
+
+    }
+
+}

--- a/Robust.Shared/Physics/DynamicTree.cs
+++ b/Robust.Shared/Physics/DynamicTree.cs
@@ -105,7 +105,10 @@ namespace Robust.Shared.Physics
             lastNode.Height = -1;
         }
 
-        private int Capacity => _nodes.Length;
+        public int Capacity {
+            get => _nodes.Length;
+            set => EnsureCapacity(value);
+        }
 
         public int Height
         {
@@ -883,7 +886,7 @@ namespace Robust.Shared.Physics
             return alloc;
         }
 
-        private void EnsureCapacity(int newCapacity)
+        public void EnsureCapacity(int newCapacity)
         {
             if (newCapacity <= Capacity)
             {

--- a/Robust.Shared/Physics/IBroadPhase.cs
+++ b/Robust.Shared/Physics/IBroadPhase.cs
@@ -42,7 +42,7 @@ namespace Robust.Shared.Physics
         bool Test(int proxyA, int proxyB);
 
         // Raycast
-        void RayCast(RayCastCallback callback, MapId mapId, in Ray ray, float maxLength = 25);
+        void RayCast(RayCastCallback callback, MapId mapId, in CollisionRay ray, float maxLength = 25);
 
         // Update
         void Update(BroadPhaseCallback callback);

--- a/Robust.Shared/Physics/PhysicsManager.cs
+++ b/Robust.Shared/Physics/PhysicsManager.cs
@@ -194,7 +194,7 @@ namespace Robust.Shared.Physics
         }
 
         /// <inheritdoc />
-        public RayCastResults IntersectRay(MapId mapId, Ray ray, float maxLength = 50, IEntity ignoredEnt = null)
+        public RayCastResults IntersectRay(MapId mapId, CollisionRay ray, float maxLength = 50, IEntity ignoredEnt = null)
         {
             RayCastResults rayResults = default;
 

--- a/Robust.Shared/Physics/Ray.cs
+++ b/Robust.Shared/Physics/Ray.cs
@@ -12,7 +12,6 @@ namespace Robust.Shared.Maths
     {
         private readonly Vector2 _position;
         private readonly Vector2 _direction;
-        private readonly int _collisionMask;
 
         /// <summary>
         ///     Specifies the starting point of the ray.
@@ -24,18 +23,15 @@ namespace Robust.Shared.Maths
         /// </summary>
         public Vector2 Direction => _direction;
 
-        public int CollisionMask => _collisionMask;
-
         /// <summary>
         ///     Creates a new instance of a Ray.
         /// </summary>
         /// <param name="position">Starting position of the ray.</param>
         /// <param name="direction">Unit direction vector that the ray is pointing.</param>
-        public Ray(Vector2 position, Vector2 direction, int collisionMask)
+        public Ray(Vector2 position, Vector2 direction)
         {
             _position = position;
             _direction = direction;
-            _collisionMask = collisionMask;
 
             DebugTools.Assert(FloatMath.CloseTo(_direction.LengthSquared, 1));
 

--- a/Robust.UnitTesting/Shared/Maths/Ray_Test.cs
+++ b/Robust.UnitTesting/Shared/Maths/Ray_Test.cs
@@ -12,7 +12,7 @@ namespace Robust.UnitTesting.Shared.Maths
         public void RayIntersectsBoxTest()
         {
             var box = new Box2(new Vector2(5, 5), new Vector2(10, -5));
-            var ray = new Ray(new Vector2(0, 1), Vector2.UnitX, 1);
+            var ray = new Ray(new Vector2(0, 1), Vector2.UnitX);
 
             var result = ray.Intersects(box, out var dist, out var hitPos);
 

--- a/Robust.UnitTesting/Shared/Physics/CollisionManager_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/CollisionManager_Test.cs
@@ -162,7 +162,7 @@ namespace Robust.UnitTesting.Shared.Physics
         {
             // Arrange
             var box = new Box2(5, -5, 10, 6);
-            var ray = new Ray(new Vector2(0, 1), Vector2.UnitX, 1);
+            var ray = new CollisionRay(new Vector2(0, 1), Vector2.UnitX, 1);
             var manager = new PhysicsManager();
 
             var mock = new Mock<IPhysBody>();
@@ -189,7 +189,7 @@ namespace Robust.UnitTesting.Shared.Physics
         {
             // Arrange
             var box = new Box2(5, -5, 10, 6);
-            var ray = new Ray(new Vector2(4.99999f, 1), Vector2.UnitY, 1);
+            var ray = new CollisionRay(new Vector2(4.99999f, 1), Vector2.UnitY, 1);
             var manager = new PhysicsManager();
 
             var mock = new Mock<IPhysBody>();

--- a/Robust.UnitTesting/Shared/Physics/DynamicTree_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/DynamicTree_Test.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using Robust.Shared.Maths;
+using Robust.Shared.Physics;
+
+namespace Robust.UnitTesting.Shared.Physics
+{
+
+    [TestFixture]
+    [TestOf(typeof(DynamicTree<>))]
+    public class DynamicTree_Test
+    {
+
+        private static Box2[] aabbs1 =
+        {
+            Box2.Grow(default, 1), //2x2 square
+            Box2.Grow(default, 2), //4x4 square
+            new Box2(-3, 3, -3, 3), // point off to the bottom left
+            new Box2(-3, -3, -3, -3), // point off to the top left
+            new Box2(3, 3, 3, 3), // point off to the bottom right
+            new Box2(3, -3, 3, -3), // point off to the top right
+            Box2.Grow(default, 1), //2x2 square
+            Box2.Grow(default, 2), //4x4 square
+            Box2.Grow(default, 1), //2x2 square
+            Box2.Grow(default, 2), //4x4 square
+            Box2.Grow(default, 1), //2x2 square
+            Box2.Grow(default, 2), //4x4 square
+            Box2.Grow(default, 1), //2x2 square
+            Box2.Grow(default, 2), //4x4 square
+            Box2.Grow(default, 3), //6x6 square
+            new Box2(-3, 3, -3, 3), // point off to the bottom left
+            new Box2(-3, -3, -3, -3), // point off to the top left
+            new Box2(3, 3, 3, 3), // point off to the bottom right
+            new Box2(3, -3, 3, -3), // point off to the top right
+        };
+
+        private static Box2[] aabbs2 =
+        {
+            Box2.Grow(default, 3), //6x6 square
+            Box2.Grow(default, 1), //2x2 square
+            Box2.Grow(default, 2), //4x4 square
+            new Box2(-3, 3, -3, 3), // point off to the bottom left
+            new Box2(-3, -3, -3, -3), // point off to the top left
+            new Box2(3, 3, 3, 3), // point off to the bottom right
+            new Box2(3, -3, 3, -3), // point off to the top right
+            new Box2(-3, 3, -3, 3), // point off to the bottom left
+            new Box2(-3, -3, -3, -3), // point off to the top left
+            new Box2(3, 3, 3, 3), // point off to the bottom right
+            new Box2(3, -3, 3, -3), // point off to the top right
+            new Box2(-3, 3, -3, 3), // point off to the bottom left
+            new Box2(-3, -3, -3, -3), // point off to the top left
+            new Box2(3, 3, 3, 3), // point off to the bottom right
+            new Box2(3, -3, 3, -3), // point off to the top right
+            Box2.Grow(default, 2), //4x4 square
+            Box2.Grow(default, 1), //2x2 square
+            Box2.Grow(default, 2), //4x4 square
+            Box2.Grow(default, 1), //2x2 square
+        };
+
+        [Test]
+        public void AddAndGrow()
+        {
+            var dt = new DynamicTree<int>((in int x) => aabbs1[x], capacity: 16, growthFunc: x => x += 2);
+
+            var initCap = dt.Capacity;
+
+            Assert.AreEqual(16, initCap);
+
+            Assert.Multiple(() =>
+            {
+                for (var i = 0; i < aabbs1.Length; ++i)
+                {
+                    Assert.True(dt.Add(i), $"Add {i}");
+                }
+            });
+
+            Assert.That(dt.Capacity, Is.AtLeast(initCap));
+        }
+
+        [Test]
+        public void AddDuplicates()
+        {
+            var dt = new DynamicTree<int>((in int x) => aabbs1[x], capacity: 16, growthFunc: x => x += 2);
+
+            Assert.Multiple(() =>
+            {
+                for (var i = 0; i < aabbs1.Length; ++i)
+                {
+                    Assert.True(dt.Add(i), $"Add {i}");
+                }
+            });
+
+            Assert.Multiple(() =>
+            {
+                for (var i = 0; i < aabbs1.Length; ++i)
+                {
+                    Assert.False(dt.Add(i), $"Add Dupe {i}");
+                }
+            });
+        }
+
+        [Test]
+        public void RemoveMissingWhileEmpty()
+        {
+            var dt = new DynamicTree<int>((in int x) => aabbs1[x], capacity: 16, growthFunc: x => x += 2);
+
+            Assert.Multiple(() =>
+            {
+                for (var i = 0; i < aabbs1.Length; ++i)
+                {
+                    Assert.False(dt.Remove(i), $"Remove {i}");
+                }
+            });
+        }
+
+        [Test]
+        public void UpdateMissingWhileEmpty()
+        {
+            var dt = new DynamicTree<int>((in int x) => aabbs1[x], capacity: 16, growthFunc: x => x += 2);
+
+            Assert.Multiple(() =>
+            {
+                for (var i = 0; i < aabbs1.Length; ++i)
+                {
+                    Assert.False(dt.Update(i), $"Update {i}");
+                }
+            });
+        }
+
+        [Test]
+        public void RemoveMissingNotEmpty()
+        {
+            var dt = new DynamicTree<int>((in int x) => aabbs1[x], capacity: 16, growthFunc: x => x += 2);
+
+            Assert.Multiple(() =>
+            {
+                for (var i = 0; i < aabbs1.Length; ++i)
+                {
+                    Assert.True(dt.Add(i), $"Add {i}");
+                }
+            });
+
+            Assert.Multiple(() =>
+            {
+                for (var i = aabbs1.Length; i < aabbs1.Length + aabbs2.Length; ++i)
+                {
+                    Assert.False(dt.Remove(i), $"Remove {i}");
+                }
+            });
+        }
+
+        [Test]
+        public void UpdateMissingNotEmpty()
+        {
+            var dt = new DynamicTree<int>((in int x) => aabbs1[x], capacity: 16, growthFunc: x => x += 2);
+
+            Assert.Multiple(() =>
+            {
+                for (var i = 0; i < aabbs1.Length; ++i)
+                {
+                    Assert.True(dt.Add(i), $"Add {i}");
+                }
+            });
+
+            Assert.Multiple(() => {
+                for (var i = aabbs1.Length; i < aabbs1.Length + aabbs2.Length; ++i)
+                {
+                    Assert.False(dt.Update(i), $"Update {i}");
+                }
+            });
+        }
+
+        [Test]
+        public void AddThenUpdate()
+        {
+            var aabbs = aabbs1;
+            var dt = new DynamicTree<int>((in int x) => aabbs[x], capacity: 16, growthFunc: x => x += 2);
+
+            Assert.Multiple(() =>
+            {
+                for (var i = 0; i < aabbs.Length; ++i)
+                {
+                    Assert.True(dt.Add(i), $"Add {i}");
+                }
+            });
+            aabbs = aabbs2;
+
+            Assert.Multiple(() => {
+                for (var i = 0; i < aabbs.Length; ++i)
+                {
+                    if (aabbs1[i].Contains(aabbs2[i]))
+                    {
+                        Assert.False(dt.Update(i), $"Update {i}");
+                    }
+                    else
+                    {
+                        Assert.True(dt.Update(i), $"Update {i}");
+                    }
+                }
+            });
+        }
+
+        [Test]
+        public void AddThenRemove()
+        {
+            var aabbs = aabbs1;
+            var dt = new DynamicTree<int>((in int x) => aabbs[x], capacity: 16, growthFunc: x => x += 2);
+
+            Assert.Multiple(() =>
+            {
+                for (var i = 0; i < aabbs.Length; ++i)
+                {
+                    Assert.True(dt.Add(i), $"Add {i}");
+                }
+            });
+            aabbs = aabbs2;
+
+            Assert.Multiple(() =>
+            {
+                for (var i = 0; i < aabbs.Length; ++i)
+                {
+                    Assert.True(dt.Remove(i), $"Remove {i}");
+                }
+            });
+        }
+
+        [Test]
+        public void AddThenUpdateThenRemove()
+        {
+            var aabbs = aabbs1;
+            var dt = new DynamicTree<int>((in int x) => aabbs[x], capacity: 16, growthFunc: x => x += 2);
+
+            Assert.Multiple(() =>
+            {
+                for (var i = 0; i < aabbs.Length; ++i)
+                {
+                    Assert.True(dt.Add(i), $"Add {i}");
+                }
+            });
+            aabbs = aabbs2;
+
+            Assert.Multiple(() =>
+            {
+                for (var i = 0; i < aabbs.Length; ++i) {
+                    if (aabbs1[i].Contains(aabbs2[i]))
+                    {
+                        Assert.False(dt.Update(i), $"Update {i}");
+                    }
+                    else
+                    {
+                        Assert.True(dt.Update(i), $"Update {i}");
+                    }
+                }
+            });
+
+            Assert.Multiple(() => {
+                for (var i = 0; i < aabbs.Length; ++i)
+                {
+                    Assert.True(dt.Remove(i), $"Remove {i}");
+                }
+            });
+        }
+
+        [Test]
+        public void AddAndQuery() {
+            var dt = new DynamicTree<int>((in int x) => aabbs1[x], capacity: 16, growthFunc: x => x += 2);
+
+            Assert.Multiple(() =>
+            {
+                for (var i = 0; i < aabbs1.Length; ++i)
+                {
+                    Assert.True(dt.Add(i), $"Add {i}");
+                }
+            });
+
+            var point = new Vector2(0, 0);
+
+            var containers = Enumerable.Range(0, aabbs1.Length)
+                .Where(x => aabbs1[x].Contains(point))
+                .OrderBy(x => x).ToArray();
+
+            var results = dt.Query(point)
+                .OrderBy(x => x).ToArray();
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(containers.Length, results.Length, "Length");
+                var l = Math.Min(containers.Length, results.Length);
+                for (var i = 0; i < l; ++i)
+                {
+                    Assert.AreEqual(containers[i], results[i]);
+                }
+            });
+        }
+
+        // TODO: other Box2, Ray, Point query method tests
+    }
+
+}

--- a/Robust.UnitTesting/Shared/Physics/DynamicTree_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/DynamicTree_Test.cs
@@ -14,21 +14,21 @@ namespace Robust.UnitTesting.Shared.Physics
 
         private static Box2[] aabbs1 =
         {
-            Box2.Grow(default, 1), //2x2 square
-            Box2.Grow(default, 2), //4x4 square
+            ((Box2) default).Enlarged(1), //2x2 square
+            ((Box2) default).Enlarged(2), //4x4 square
             new Box2(-3, 3, -3, 3), // point off to the bottom left
             new Box2(-3, -3, -3, -3), // point off to the top left
             new Box2(3, 3, 3, 3), // point off to the bottom right
             new Box2(3, -3, 3, -3), // point off to the top right
-            Box2.Grow(default, 1), //2x2 square
-            Box2.Grow(default, 2), //4x4 square
-            Box2.Grow(default, 1), //2x2 square
-            Box2.Grow(default, 2), //4x4 square
-            Box2.Grow(default, 1), //2x2 square
-            Box2.Grow(default, 2), //4x4 square
-            Box2.Grow(default, 1), //2x2 square
-            Box2.Grow(default, 2), //4x4 square
-            Box2.Grow(default, 3), //6x6 square
+            ((Box2) default).Enlarged(1), //2x2 square
+            ((Box2) default).Enlarged(2), //4x4 square
+            ((Box2) default).Enlarged(1), //2x2 square
+            ((Box2) default).Enlarged(2), //4x4 square
+            ((Box2) default).Enlarged(1), //2x2 square
+            ((Box2) default).Enlarged(2), //4x4 square
+            ((Box2) default).Enlarged(1), //2x2 square
+            ((Box2) default).Enlarged(2), //4x4 square
+            ((Box2) default).Enlarged(3), //6x6 square
             new Box2(-3, 3, -3, 3), // point off to the bottom left
             new Box2(-3, -3, -3, -3), // point off to the top left
             new Box2(3, 3, 3, 3), // point off to the bottom right
@@ -37,9 +37,9 @@ namespace Robust.UnitTesting.Shared.Physics
 
         private static Box2[] aabbs2 =
         {
-            Box2.Grow(default, 3), //6x6 square
-            Box2.Grow(default, 1), //2x2 square
-            Box2.Grow(default, 2), //4x4 square
+            ((Box2) default).Enlarged(3), //6x6 square
+            ((Box2) default).Enlarged(1), //2x2 square
+            ((Box2) default).Enlarged(2), //4x4 square
             new Box2(-3, 3, -3, 3), // point off to the bottom left
             new Box2(-3, -3, -3, -3), // point off to the top left
             new Box2(3, 3, 3, 3), // point off to the bottom right
@@ -52,10 +52,10 @@ namespace Robust.UnitTesting.Shared.Physics
             new Box2(-3, -3, -3, -3), // point off to the top left
             new Box2(3, 3, 3, 3), // point off to the bottom right
             new Box2(3, -3, 3, -3), // point off to the top right
-            Box2.Grow(default, 2), //4x4 square
-            Box2.Grow(default, 1), //2x2 square
-            Box2.Grow(default, 2), //4x4 square
-            Box2.Grow(default, 1), //2x2 square
+            ((Box2) default).Enlarged(2), //4x4 square
+            ((Box2) default).Enlarged(1), //2x2 square
+            ((Box2) default).Enlarged(2), //4x4 square
+            ((Box2) default).Enlarged(1), //2x2 square
         };
 
         [Test]


### PR DESCRIPTION
Separates Rays from CollisionRays, removing collision masking from Ray.

There will be a companion PR to replace constructors of Ray with CollisionRay.