### PR TITLE
Remove selector support in the RSI format

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1188,7 +1188,7 @@ namespace Robust.Client.GameObjects
                     }
                     else
                     {
-                        var stateid = new RSI.StateId(layerDatum.State, RSI.Selectors.None);
+                        var stateid = new RSI.StateId(layerDatum.State);
                         layer.State = stateid;
                         if (theRsi.TryGetState(stateid, out var state))
                         {

--- a/Robust.Client/Graphics/RSI/RSI.State.cs
+++ b/Robust.Client/Graphics/RSI/RSI.State.cs
@@ -1,6 +1,7 @@
 ﻿using System;
-using Robust.Shared.Maths;
+
 using Robust.Client.Utility;
+using Robust.Shared.Maths;
 using Robust.Shared.Utility;
 
 namespace Robust.Client.Graphics

--- a/Robust.Client/Graphics/RSI/RSI.cs
+++ b/Robust.Client/Graphics/RSI/RSI.cs
@@ -1,7 +1,8 @@
-﻿using Robust.Shared.Maths;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections;
+
+using Robust.Shared.Maths;
 using Robust.Shared.ViewVariables;
 
 namespace Robust.Client.Graphics
@@ -50,30 +51,23 @@ namespace Robust.Client.Graphics
             return GetEnumerator();
         }
 
-        [Flags]
-        public enum Selectors
-        {
-            None = 0,
-        }
-
         /// <summary>
-        ///     Represents a name+selector pair used to reference states in an RSI.
+        ///     Represents an ID used to reference states in an RSI.
+        ///     Kept around as a simple wrapper around the state Name, to avoid breaking existing code.
         /// </summary>
         public struct StateId : IEquatable<StateId>
         {
             public readonly string Name;
-            public readonly Selectors Selectors;
 
-            public StateId(string name, Selectors selectors = Selectors.None)
+            public StateId(string name)
             {
                 Name = name;
-                Selectors = selectors;
             }
 
             /// <summary>
             ///     Effectively the "null" of <c>StateId</c>, because you can't have a null for structs.
             /// </summary>
-            public static readonly StateId Invalid = new StateId(null, Selectors.None);
+            public static readonly StateId Invalid = new StateId(null);
             public bool IsValid => Name != null;
 
             public override string ToString()
@@ -83,7 +77,7 @@ namespace Robust.Client.Graphics
 
             public static implicit operator StateId(string key)
             {
-                return new StateId(key, Selectors.None);
+                return new StateId(key);
             }
 
             public override bool Equals(object obj)
@@ -93,7 +87,7 @@ namespace Robust.Client.Graphics
 
             public bool Equals(StateId id)
             {
-                return id.Name == Name && id.Selectors == Selectors;
+                return id.Name == Name;
             }
 
             public static bool operator ==(StateId a, StateId b)
@@ -108,7 +102,7 @@ namespace Robust.Client.Graphics
 
             public override int GetHashCode()
             {
-                return Name.GetHashCode() ^ (int)Selectors;
+                return Name.GetHashCode();
             }
         }
     }

--- a/Robust.Client/Graphics/RSI/RSISchema.json
+++ b/Robust.Client/Graphics/RSI/RSISchema.json
@@ -20,10 +20,6 @@
             "type": "object",
             "properties": {
                 "name": {"type": "string"},
-                "select": {
-                    "type": "array",
-                    "items": {"type": "string"}
-                },
                 "flags": {"type": "object"}, //To be de-serialized as a Dictionary
                 "directions": {"$ref": "#/definitions/directions"},
                 "delays": {

--- a/Robust.Client/ResourceManagement/ResourceTypes/RSIResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/RSIResource.cs
@@ -1,16 +1,18 @@
-﻿using Newtonsoft.Json.Linq;
-using NJsonSchema;
-using Robust.Client.Graphics;
-using Robust.Client.Interfaces.ResourceManagement;
-using Robust.Shared.Log;
-using Robust.Shared.Maths;
-using Robust.Shared.Utility;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+
+using Robust.Client.Graphics;
+using Robust.Client.Interfaces.ResourceManagement;
 using Robust.Client.Utility;
+using Robust.Shared.Log;
+using Robust.Shared.Maths;
+using Robust.Shared.Utility;
+
+using Newtonsoft.Json.Linq;
+using NJsonSchema;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 


### PR DESCRIPTION
Removes all support for selectors in the RSI format. This is part of the cleanup described in #906. 

The `StateID` class has been kept around as a simple wrapper for the state `Name`, it serves no other function than to avoid breaking existing code. If consensus show this is less than ideal, preexisting code can be modified and this class can be removed.

[Sister PR.](https://github.com/space-wizards/RSI.py/pull/2)