### PR TITLE
Makes spawnlist use prototype ID if prototype name is null or empty

### DIFF
--- a/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
+++ b/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
@@ -295,7 +295,7 @@ namespace Robust.Client.UserInterface.CustomControls
                 Index = index // We track this index purely for debugging.
             };
             button.ActualButton.OnToggled += OnItemButtonToggled;
-            button.EntityLabel.Text = prototype.Name;
+            button.EntityLabel.Text = string.IsNullOrEmpty(prototype.Name) ? prototype.ID : prototype.Name;
 
             if (prototype == SelectedPrototype)
             {


### PR DESCRIPTION
Generally prototypes should have a name, but if this is not the case for whatever reason, the spawnlist will use the prototype ID instead.