### PR TITLE
Fix crash from destruction of containers containing containers

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/PhysicsSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/PhysicsSystem.cs
@@ -37,8 +37,14 @@ namespace Robust.Server.GameObjects.EntitySystems
 
         private void SimulateWorld(float frameTime, IEnumerable<IEntity> entities)
         {
+            // simulation can introduce deleted entities into the query results
             foreach (var entity in entities)
             {
+                if (entity.Deleted)
+                {
+                    continue;
+                }
+
                 if (_pauseManager.IsEntityPaused(entity))
                 {
                     continue;
@@ -49,6 +55,11 @@ namespace Robust.Server.GameObjects.EntitySystems
 
             foreach (var entity in entities)
             {
+                if (entity.Deleted)
+                {
+                    continue;
+                }
+
                 DoMovement(entity, frameTime);
             }
         }


### PR DESCRIPTION
Fix containers containing containers being destroyed/deleted and deleting their contents causing unexpected attempts to access deleted child entities