### PR TITLE
Correct ray casting

### DIFF
--- a/Robust.Shared/Physics/DynamicTree.cs
+++ b/Robust.Shared/Physics/DynamicTree.cs
@@ -604,18 +604,19 @@ namespace Robust.Shared.Physics
 
                 var item = node.Item;
 
-                if (!approx)
-                {
-                    var preciseAabb = _extractAabb(item);
-
-                    if (!ray.Intersects(preciseAabb, out dist, out hit))
-                    {
-                        continue;
-                    }
-                }
-
                 if (node.IsLeaf)
                 {
+
+                    if (!approx)
+                    {
+                        var preciseAabb = _extractAabb(item);
+
+                        if (!ray.Intersects(preciseAabb, out dist, out hit))
+                        {
+                            continue;
+                        }
+                    }
+
                     any = true;
 
                     var carryOn = callback(ref node.Item, hit, dist);


### PR DESCRIPTION
hotfix for ray intersections invoking _extractAabb too early

fix raycasting, minor formatting

remove a Debug.WriteLine