### PR TITLE
Fix crash when playing audio on grid that does not exist

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
@@ -204,6 +204,12 @@ namespace Robust.Client.GameObjects.EntitySystems
                         break;
 
                     case PlayAudioPositionalMessage posmsg:
+                        if (!_mapManager.GridExists(posmsg.Coordinates.GridID))
+                        {
+                            Logger.Error($"Server tried to play sound on grid {posmsg.Coordinates.GridID.Value}, which does not exist. Ignoring.");
+                            break;
+                        }
+
                         Play(posmsg.FileName, posmsg.Coordinates, posmsg.AudioParams);
                         break;
                 }


### PR DESCRIPTION
Adds a check to the `PlayAudioPositionalMessage` case of client `AudioSystem` to make sure the grid it's playing on actually exists. If it doesn't, an error is logged and the message is ignored instead of crashing the client.