### PR TITLE
Fix client reconnect after getting disconnected

### DIFF
--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -548,7 +548,14 @@ namespace Robust.Shared.Network
             _channels.Remove(connection);
 
             if (IsClient)
+            {
+                connection.Peer.Shutdown(reason);
+                _toCleanNetPeers.Add(connection.Peer);
                 _strings.Reset();
+
+                _cancelConnectTokenSource?.Cancel();
+                _clientConnectionState = ClientConnectionState.NotConnecting;
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Client was unable to reconnect to server after being disconnected from the server side.

The _clientConnectionState wasn't reset to NotConnecting when disconnected by the server (compared to the client disconnecting from the server).