### PR TITLE
Use Kestler for StatusHost

### DIFF
--- a/Robust.Server/Interfaces/ServerStatus/IStatusHost.cs
+++ b/Robust.Server/Interfaces/ServerStatus/IStatusHost.cs
@@ -1,11 +1,11 @@
 using System;
-using System.Net;
 using System.Net.Http;
+using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json.Linq;
 
 namespace Robust.Server.Interfaces.ServerStatus
 {
-    public delegate bool StatusHostHandler(HttpMethod method, HttpListenerRequest request, HttpListenerResponse response);
+    public delegate bool StatusHostHandler(HttpMethod method, HttpRequest request, HttpResponse response);
 
     public interface IStatusHost
     {

--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -13,6 +13,8 @@
   <Import Project="..\MSBuild\Robust.DefineConstants.targets" />
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.2.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.1" />
     <PackageReference Include="YamlDotNet" Version="8.1.0" />
   </ItemGroup>

--- a/Robust.Server/ServerStatus/StatusHost.Handlers.cs
+++ b/Robust.Server/ServerStatus/StatusHost.Handlers.cs
@@ -1,0 +1,137 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Robust.Shared.Log;
+using Robust.Shared.Utility;
+
+namespace Robust.Server.ServerStatus
+{
+
+    internal sealed partial class StatusHost
+    {
+
+        private void RegisterHandlers()
+        {
+            AddHandler(HandleTeapot);
+            AddHandler(HandleStatus);
+            AddHandler(HandleInfo);
+        }
+
+        private static bool HandleTeapot(HttpMethod method, HttpRequest request, HttpResponse response)
+        {
+            if (!method.IsGetLike() || request.Path != "/teapot")
+            {
+                return false;
+            }
+
+            response.StatusCode = StatusCodes.Status418ImATeapot;
+            response.Respond("I am a teapot.", StatusCodes.Status418ImATeapot);
+            return true;
+        }
+
+        private bool HandleStatus(HttpMethod method, HttpRequest request, HttpResponse response)
+        {
+            if (!method.IsGetLike() || request.Path != "/status")
+            {
+                return false;
+            }
+
+            if (OnStatusRequest == null)
+            {
+                Logger.WarningS(Sawmill, "OnStatusRequest is not set, responding with a 501.");
+                response.Respond("Not Implemented", HttpStatusCode.NotImplemented);
+                return true;
+            }
+
+            response.StatusCode = (int) HttpStatusCode.OK;
+            response.ContentType = "application/json";
+
+            if (method == HttpMethod.Head)
+            {
+                return true;
+            }
+
+            var jObject = new JObject();
+
+            OnStatusRequest?.Invoke(jObject);
+
+            using var streamWriter = new StreamWriter(response.Body, EncodingHelpers.UTF8);
+
+            using var jsonWriter = new JsonTextWriter(streamWriter);
+
+            JsonSerializer.Serialize(jsonWriter, jObject);
+
+            jsonWriter.Flush();
+
+            return true;
+        }
+
+        private bool HandleInfo(HttpMethod method, HttpRequest request, HttpResponse response)
+        {
+            if (!method.IsGetLike() || request.Path != "/info")
+            {
+                return false;
+            }
+
+            response.StatusCode = (int) HttpStatusCode.OK;
+            response.ContentType = "application/json";
+
+            if (method == HttpMethod.Head)
+            {
+                return true;
+            }
+
+            var downloadUrlWindows = _configurationManager.GetCVar<string>("build.download_url_windows");
+
+            JObject buildInfo;
+
+            if (downloadUrlWindows == null)
+            {
+                buildInfo = null;
+            }
+            else
+            {
+                buildInfo = new JObject
+                {
+                    ["download_urls"] = new JObject
+                    {
+                        ["Windows"] = downloadUrlWindows,
+                        ["MacOS"] = _configurationManager.GetCVar<string>("build.download_url_macos"),
+                        ["Linux"] = _configurationManager.GetCVar<string>("build.download_url_linux")
+                    },
+                    ["fork_id"] = _configurationManager.GetCVar<string>("build.fork_id"),
+                    ["version"] = _configurationManager.GetCVar<string>("build.version"),
+                    ["hashes"] = new JObject
+                    {
+                        ["Windows"] = _configurationManager.GetCVar<string>("build.hash_windows"),
+                        ["MacOS"] = _configurationManager.GetCVar<string>("build.hash_macos"),
+                        ["Linux"] = _configurationManager.GetCVar<string>("build.hash_linux"),
+                    },
+                };
+            }
+
+            var jObject = new JObject
+            {
+                ["connect_address"] = _configurationManager.GetCVar<string>("status.connectaddress"),
+                ["build"] = buildInfo
+            };
+
+            OnInfoRequest?.Invoke(jObject);
+
+            using var streamWriter = new StreamWriter(response.Body, EncodingHelpers.UTF8);
+
+            using var jsonWriter = new JsonTextWriter(streamWriter);
+
+            JsonSerializer.Serialize(jsonWriter, jObject);
+
+            jsonWriter.Flush();
+
+            return true;
+        }
+
+    }
+
+}

--- a/Robust.Server/ServerStatus/StatusHost.HttpContext.cs
+++ b/Robust.Server/ServerStatus/StatusHost.HttpContext.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Options;
+using Robust.Shared.Interfaces.Log;
+using Robust.Shared.IoC;
+using Robust.Shared.Log;
+
+namespace Robust.Server.ServerStatus
+{
+
+    internal sealed partial class StatusHost
+    {
+
+        private HttpContextFactory _ctxFactory;
+
+        public HttpContext CreateContext(IFeatureCollection contextFeatures) => _ctxFactory.Create(contextFeatures);
+
+        public void DisposeContext(HttpContext context, Exception exception)
+        {
+            if (exception != null)
+            {
+                Logger.ErrorS(Sawmill, $"Context disposed due to exception: {exception}");
+            }
+
+            _ctxFactory.Dispose(context);
+        }
+
+        private static HttpContextFactory CreateHttpContextFactory()
+        {
+            var ctxFacOptions = Options.Create(new FormOptions
+            {
+            });
+            var ctxFactory = new HttpContextFactory(ctxFacOptions, new HttpContextAccessor());
+            return ctxFactory;
+        }
+
+        private void InitHttpContextThread()
+        {
+            if (SynchronizationContext.Current == _syncCtx)
+            {
+                // maybe assert instead?
+                return;
+            }
+
+            IoCManager.Clear();
+            ILogManager logMgr = null;
+            WaitSync(() =>
+            {
+                logMgr = IoCManager.Resolve<ILogManager>();
+            }, ApplicationStopping);
+            IoCManager.InitThread();
+            if (logMgr != null)
+            {
+                IoCManager.RegisterInstance<ILogManager>(logMgr);
+            }
+
+            IoCManager.BuildGraph();
+        }
+
+    }
+
+}

--- a/Robust.Server/ServerStatus/StatusHost.Lifetime.cs
+++ b/Robust.Server/ServerStatus/StatusHost.Lifetime.cs
@@ -1,0 +1,50 @@
+using System.Threading;
+
+namespace Robust.Server.ServerStatus
+{
+
+    internal sealed partial class StatusHost
+    {
+
+        private readonly CancellationTokenSource _startedSource = new CancellationTokenSource();
+
+        private readonly CancellationTokenSource _stoppedSource = new CancellationTokenSource();
+
+        private readonly CancellationTokenSource _stoppingSource = new CancellationTokenSource();
+
+        public void StopApplication() => Dispose();
+
+        /// <summary>
+        /// Triggered when the application host has fully started and is about to wait
+        /// for a graceful shutdown.
+        /// </summary>
+        public CancellationToken ApplicationStarted => _startedSource.Token;
+
+        /// <summary>
+        /// Triggered when the application host is performing a graceful shutdown.
+        /// Request may still be in flight. Shutdown will block until this event completes.
+        /// </summary>
+        public CancellationToken ApplicationStopping => _stoppingSource.Token;
+
+        /// <summary>
+        /// Triggered when the application host is performing a graceful shutdown.
+        /// All requests should be complete at this point. Shutdown will block
+        /// until this event completes.
+        /// </summary>
+        public CancellationToken ApplicationStopped => _stoppedSource.Token;
+
+        public void Dispose()
+        {
+            if (_stoppingSource.IsCancellationRequested)
+            {
+                return;
+            }
+
+            _stoppingSource.Cancel();
+            _server.StopAsync(ApplicationStopped);
+            _stoppedSource.Cancel();
+        }
+
+    }
+
+}

--- a/Robust.Server/ServerStatus/StatusHost.Lifetime.cs
+++ b/Robust.Server/ServerStatus/StatusHost.Lifetime.cs
@@ -14,35 +14,48 @@ namespace Robust.Server.ServerStatus
 
         public void StopApplication() => Dispose();
 
+
+        private static CancellationTokenSource _cancelled;
+        private static CancellationToken GetCancelledToken()
+        {
+            if (_cancelled == null)
+            {
+                _cancelled = new CancellationTokenSource();
+                _cancelled.Cancel();
+            }
+
+            return _cancelled.Token;
+        }
+
         /// <summary>
         /// Triggered when the application host has fully started and is about to wait
         /// for a graceful shutdown.
         /// </summary>
-        public CancellationToken ApplicationStarted => _startedSource.Token;
+        public CancellationToken ApplicationStarted => _startedSource?.Token ?? GetCancelledToken();
 
         /// <summary>
         /// Triggered when the application host is performing a graceful shutdown.
         /// Request may still be in flight. Shutdown will block until this event completes.
         /// </summary>
-        public CancellationToken ApplicationStopping => _stoppingSource.Token;
+        public CancellationToken ApplicationStopping => _stoppingSource?.Token ?? GetCancelledToken();
 
         /// <summary>
         /// Triggered when the application host is performing a graceful shutdown.
         /// All requests should be complete at this point. Shutdown will block
         /// until this event completes.
         /// </summary>
-        public CancellationToken ApplicationStopped => _stoppedSource.Token;
+        public CancellationToken ApplicationStopped => _stoppedSource?.Token ?? GetCancelledToken();
 
         public void Dispose()
         {
-            if (_stoppingSource.IsCancellationRequested)
+            if (_stoppingSource?.IsCancellationRequested ?? true)
             {
                 return;
             }
 
-            _stoppingSource.Cancel();
-            _server.StopAsync(ApplicationStopped);
-            _stoppedSource.Cancel();
+            _stoppingSource?.Cancel();
+            _server?.StopAsync(ApplicationStopped);
+            _stoppedSource?.Cancel();
         }
 
     }

--- a/Robust.Server/ServerStatus/StatusHost.Logging.cs
+++ b/Robust.Server/ServerStatus/StatusHost.Logging.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using Robust.Shared.Interfaces.Log;
+using Robust.Shared.IoC;
+using Robust.Shared.Log;
+using Microsoft.Extensions.Logging;
+using LogLevel = Robust.Shared.Log.LogLevel;
+
+namespace Robust.Server.ServerStatus
+{
+
+    internal sealed partial class StatusHost
+    {
+
+        private Dictionary<string, SawmillWrapper> _sawmillCache = new Dictionary<string, SawmillWrapper>();
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            if (!_sawmillCache.TryGetValue(categoryName, out var wrapper))
+            {
+                var newCatName = categoryName;
+                if (newCatName.StartsWith("Microsoft.AspNetCore.Server.Kestrel"))
+                {
+                    newCatName = "http";
+                }
+                else
+                {
+                    newCatName = newCatName.Replace("Microsoft.AspNetCore.", "aspnet.");
+                }
+
+                wrapper = new SawmillWrapper(Logger.GetSawmill($"{Sawmill}.{newCatName}"));
+                _sawmillCache[categoryName] = wrapper;
+            }
+
+            return wrapper;
+        }
+
+        public void AddProvider(ILoggerProvider provider)
+            => throw new NotImplementedException();
+
+        private static void ConfigureSawmills()
+        {
+            var logMgr = IoCManager.Resolve<ILogManager>();
+            logMgr.GetSawmill("statushost.http").Level = LogLevel.Warning;
+            logMgr.GetSawmill("statushost.aspnet").Level = LogLevel.Warning;
+        }
+
+    }
+
+}

--- a/Robust.Server/ServerStatus/StatusHost.SawmillWrapper.cs
+++ b/Robust.Server/ServerStatus/StatusHost.SawmillWrapper.cs
@@ -1,0 +1,36 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Robust.Shared.Interfaces.Log;
+
+namespace Robust.Server.ServerStatus
+{
+
+    internal sealed partial class StatusHost
+    {
+
+        private class SawmillWrapper : ILogger
+        {
+
+            private ISawmill _sawmill;
+
+            public SawmillWrapper(ISawmill sawmill)
+                => _sawmill = sawmill;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+                => _sawmill.Log((Shared.Log.LogLevel) (int) logLevel, formatter(state, exception));
+
+            public bool IsEnabled(LogLevel logLevel)
+                => (int) logLevel >= (int) (_sawmill.Level ?? (Shared.Log.LogLevel) 0);
+
+            public IDisposable BeginScope<TState>(TState state)
+                => new DummyDisposable();
+
+            // @formatter:off
+            private struct DummyDisposable : IDisposable { public void Dispose() { } }
+            // @formatter:on
+
+        }
+
+    }
+
+}

--- a/Robust.Server/ServerStatus/StatusHost.Sync.cs
+++ b/Robust.Server/ServerStatus/StatusHost.Sync.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading;
+
+namespace Robust.Server.ServerStatus
+{
+
+    internal sealed partial class StatusHost
+    {
+
+        private SynchronizationContext _syncCtx;
+
+        public void DeferSync(Action a)
+        {
+            if (ExecuteInlineIfOnSyncCtx(a))
+            {
+                return;
+            }
+
+            _syncCtx.Post(x => ((Action) x)(), a);
+        }
+
+        public void WaitSync(Action a, CancellationToken ct = default)
+        {
+            if (ExecuteInlineIfOnSyncCtx(a))
+            {
+                return;
+            }
+
+            // throws not implemented
+            //_syncCtx.Send(x => ((Action) x)(), a);
+
+            using var e = new ManualResetEventSlim(false, 0);
+            _syncCtx.Post(_ =>
+            {
+                a();
+                // ReSharper disable once AccessToDisposedClosure
+                e.Set();
+            }, null);
+            e.Wait(ct);
+        }
+
+        private bool ExecuteInlineIfOnSyncCtx(Action a)
+        {
+            if (_syncCtx == SynchronizationContext.Current)
+            {
+                a();
+                return true;
+            }
+
+            return false;
+        }
+
+    }
+
+}

--- a/Robust.Server/ServerStatus/StatusHost.cs
+++ b/Robust.Server/ServerStatus/StatusHost.cs
@@ -1,9 +1,17 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Robust.Server.Interfaces.ServerStatus;
@@ -11,7 +19,6 @@ using Robust.Shared.Configuration;
 using Robust.Shared.Interfaces.Configuration;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
-using Robust.Shared.Utility;
 
 // This entire file is NIHing a REST server because pulling in libraries is effort.
 // Also it was fun to write.
@@ -19,28 +26,138 @@ using Robust.Shared.Utility;
 
 namespace Robust.Server.ServerStatus
 {
-    internal sealed class StatusHost : IStatusHost, IDisposable
+
+    internal sealed partial class StatusHost
+        : IStatusHost, IDisposable,
+            IHttpApplication<HttpContext>,
+            IApplicationLifetime,
+            ILoggerFactory
     {
+
+        private const string Sawmill = "statushost";
+
+        private static readonly JsonSerializer JsonSerializer = new JsonSerializer();
+
+        private readonly List<StatusHostHandler> _handlers = new List<StatusHostHandler>();
+
 #pragma warning disable 649
         [Dependency] private IConfigurationManager _configurationManager;
 #pragma warning restore 649
 
-        // See this SO post for inspiration: https://stackoverflow.com/a/4673210
+        private KestrelServer _server;
 
-        private HttpListener _listener;
-        private Thread _listenerThread;
-        private ManualResetEventSlim _stop;
-        public event Action<JObject> OnStatusRequest;
-        public event Action<JObject> OnInfoRequest;
-
-        private readonly List<StatusHostHandler> _handlers = new List<StatusHostHandler>();
-
-        public void AddHandler(StatusHostHandler handler)
+        public Task ProcessRequestAsync(HttpContext context)
         {
-            _handlers.Add(handler);
+            var response = context.Response;
+            var request = context.Request;
+            var method = new HttpMethod(request.Method);
+            InitHttpContextThread();
+
+            Logger.InfoS(Sawmill, $"{method} {context.Request.Path} from " +
+                $"{context.Connection.RemoteIpAddress}:{context.Connection.RemotePort}");
+
+            try
+            {
+                foreach (var handler in _handlers)
+                {
+                    if (handler(method, request, response))
+                    {
+                        return Task.CompletedTask;
+                    }
+                }
+
+                // No handler returned true, assume no handlers care about this.
+                // 404.
+                response.Respond("Not Found", HttpStatusCode.NotFound);
+            }
+            catch (Exception e)
+            {
+                response.Respond("Internal Server Error", HttpStatusCode.InternalServerError);
+                Logger.ErrorS(Sawmill, $"Exception in StatusHost: {e}");
+            }
+
+            Logger.DebugS(Sawmill, $"{method} {context.Request.Path} {context.Response.StatusCode} " +
+                $"{(HttpStatusCode) context.Response.StatusCode} to {context.Connection.RemoteIpAddress}:{context.Connection.RemotePort}");
+
+            return Task.CompletedTask;
         }
 
+        public event Action<JObject> OnStatusRequest;
+
+        public event Action<JObject> OnInfoRequest;
+
+        public void AddHandler(StatusHostHandler handler) => _handlers.Add(handler);
+
         public void Start()
+        {
+            RegisterCVars();
+
+            if (!_configurationManager.GetCVar<bool>("status.enabled"))
+            {
+                return;
+            }
+
+            ConfigureSawmills();
+
+            _ctxFactory = CreateHttpContextFactory();
+
+            var kestrelOpts = new KestrelServerOptions
+            {
+                AllowSynchronousIO = true,
+                ApplicationSchedulingMode = SchedulingMode.ThreadPool
+            };
+
+            kestrelOpts.Listen(GetBinding());
+
+            _server = new KestrelServer(
+                Options.Create(
+                    kestrelOpts
+                ),
+                GetSocketTransportFactory(),
+                this
+            );
+
+            RegisterHandlers();
+
+            _server.StartAsync(this, ApplicationStopping);
+
+            _syncCtx = SynchronizationContext.Current;
+
+            if (_syncCtx == null)
+            {
+                SynchronizationContext.SetSynchronizationContext(_syncCtx = new SynchronizationContext());
+            }
+        }
+
+        private IPEndPoint GetBinding()
+        {
+            var binding = _configurationManager.GetCVar<string>("status.bind").Split(':');
+            var ipAddrStr = binding[0];
+            if (ipAddrStr == "+" || ipAddrStr == "*")
+            {
+                ipAddrStr = "0.0.0.0";
+            }
+
+            var ipAddress = IPAddress.Parse(ipAddrStr);
+            var port = int.Parse(binding[1]);
+            var ipEndPoint = new IPEndPoint(ipAddress, port);
+            return ipEndPoint;
+        }
+
+        private SocketTransportFactory GetSocketTransportFactory()
+        {
+            var transportFactory = new SocketTransportFactory(
+                Options.Create(new SocketTransportOptions
+                {
+                    IOQueueCount = 42
+                }),
+                this,
+                this
+            );
+            return transportFactory;
+        }
+
+        private void RegisterCVars()
         {
             _configurationManager.RegisterCVar("status.enabled", true, CVar.ARCHIVE);
             _configurationManager.RegisterCVar("status.bind", "*:1212", CVar.ARCHIVE);
@@ -54,212 +171,8 @@ namespace Robust.Server.ServerStatus
             _configurationManager.RegisterCVar("build.hash_windows", (string) null, CVar.ARCHIVE);
             _configurationManager.RegisterCVar("build.hash_macos", (string) null, CVar.ARCHIVE);
             _configurationManager.RegisterCVar("build.hash_linux", (string) null, CVar.ARCHIVE);
-
-            if (!_configurationManager.GetCVar<bool>("status.enabled"))
-            {
-                return;
-            }
-
-            _stop = new ManualResetEventSlim();
-            _listener = new HttpListener();
-            _listener.Prefixes.Add($"http://{_configurationManager.GetCVar<string>("status.bind")}/");
-            _listener.Start();
-            _listenerThread = new Thread(_worker)
-            {
-                Name = "REST API Thread",
-                IsBackground = true,
-                Priority = ThreadPriority.BelowNormal
-            };
-            _listenerThread.Start();
-
-            AddHandler(_handleTeapot);
-            AddHandler(_handleStatus);
-            AddHandler(_handleInfo);
         }
 
-        public void Dispose()
-        {
-            if (_stop == null)
-            {
-                return;
-            }
-
-            _stop.Set();
-            _listenerThread.Join(1000);
-            _listener.Stop();
-        }
-
-        private void _worker()
-        {
-            while (_listener.IsListening)
-            {
-                var context = _listener.BeginGetContext(ar =>
-                {
-                    var actualContext = _listener.EndGetContext(ar);
-                    _processRequest(actualContext);
-                }, null);
-
-                if (0 == WaitHandle.WaitAny(new[] {_stop.WaitHandle, context.AsyncWaitHandle}))
-                {
-                    return;
-                }
-            }
-        }
-
-        private void _processRequest(HttpListenerContext context)
-        {
-            _processRequestInternal(context);
-            Logger.DebugS("statushost", "{0} -> {1} {2}",
-                context.Request.Url.AbsolutePath,
-                context.Response.StatusCode,
-                context.Response.StatusDescription);
-        }
-
-        private void _processRequestInternal(HttpListenerContext context)
-        {
-            var response = context.Response;
-            var request = context.Request;
-            var method = new HttpMethod(request.HttpMethod);
-
-            try
-            {
-                foreach (var handler in _handlers)
-                {
-                    if (handler(method, request, response))
-                    {
-                        return;
-                    }
-                }
-
-                // No handler returned true, assume no handlers care about this.
-                // 404.
-                response.Respond(method, "404 Not Found", HttpStatusCode.NotFound, "text/plain");
-            }
-            catch (Exception e)
-            {
-                response.Respond(method, "500 Internal Server Error", HttpStatusCode.InternalServerError, "text/plain");
-                Logger.ErrorS("statushost", "Exception in StatusHost: {0}", e);
-            }
-        }
-
-
-        private static bool _handleTeapot(HttpMethod method, HttpListenerRequest request, HttpListenerResponse response)
-        {
-            if (!method.IsGetLike() || request.Url.AbsolutePath != "/teapot")
-            {
-                return false;
-            }
-
-            response.Respond(method, "The requested entity body is short and stout.", (HttpStatusCode) 418,
-                "text/plain");
-            return true;
-        }
-
-        private bool _handleStatus(HttpMethod method, HttpListenerRequest request, HttpListenerResponse response)
-        {
-            if (!method.IsGetLike() || request.Url.AbsolutePath != "/status")
-            {
-                return false;
-            }
-
-            if (OnStatusRequest == null)
-            {
-                Logger.WarningS("statushost", "OnStatusRequest is not set, responding with a 501.");
-                response.Respond(method, "", HttpStatusCode.NotImplemented, "text/plain");
-                return true;
-            }
-
-            response.StatusCode = (int) HttpStatusCode.OK;
-            response.StatusDescription = "OK";
-            response.ContentType = "application/json";
-            response.ContentEncoding = EncodingHelpers.UTF8;
-
-            if (method == HttpMethod.Head)
-            {
-                response.Close();
-                return true;
-            }
-
-            var jObject = new JObject();
-            OnStatusRequest.Invoke(jObject);
-            using (var streamWriter = new StreamWriter(response.OutputStream, EncodingHelpers.UTF8))
-            using (var jsonWriter = new JsonTextWriter(streamWriter))
-            {
-                var serializer = new JsonSerializer();
-                serializer.Serialize(jsonWriter, jObject);
-                jsonWriter.Flush();
-            }
-
-            response.Close();
-
-            return true;
-        }
-
-        private bool _handleInfo(HttpMethod method, HttpListenerRequest request, HttpListenerResponse response)
-        {
-            if (!method.IsGetLike() || request.Url.AbsolutePath != "/info")
-            {
-                return false;
-            }
-
-            response.StatusCode = (int) HttpStatusCode.OK;
-            response.StatusDescription = "OK";
-            response.ContentType = "application/json";
-            response.ContentEncoding = EncodingHelpers.UTF8;
-
-            if (method == HttpMethod.Head)
-            {
-                response.Close();
-                return true;
-            }
-
-
-            var downloadUrlWindows = _configurationManager.GetCVar<string>("build.download_url_windows");
-            JObject buildInfo;
-            if (downloadUrlWindows == null)
-            {
-                buildInfo = null;
-            }
-            else
-            {
-                buildInfo = new JObject
-                {
-                    ["download_urls"] = new JObject
-                    {
-                        ["Windows"] = downloadUrlWindows,
-                        ["MacOS"] = _configurationManager.GetCVar<string>("build.download_url_macos"),
-                        ["Linux"] = _configurationManager.GetCVar<string>("build.download_url_linux")
-                    },
-                    ["fork_id"] = _configurationManager.GetCVar<string>("build.fork_id"),
-                    ["version"] = _configurationManager.GetCVar<string>("build.version"),
-                    ["hashes"] = new JObject
-                    {
-                        ["Windows"] = _configurationManager.GetCVar<string>("build.hash_windows"),
-                        ["MacOS"] = _configurationManager.GetCVar<string>("build.hash_macos"),
-                        ["Linux"] = _configurationManager.GetCVar<string>("build.hash_linux"),
-                    },
-                };
-            }
-
-            var jObject = new JObject
-            {
-                ["connect_address"] = _configurationManager.GetCVar<string>("status.connectaddress"),
-                ["build"] = buildInfo
-            };
-
-            OnInfoRequest?.Invoke(jObject);
-
-            using (var streamWriter = new StreamWriter(response.OutputStream, EncodingHelpers.UTF8))
-            using (var jsonWriter = new JsonTextWriter(streamWriter))
-            {
-                var serializer = new JsonSerializer();
-                serializer.Serialize(jsonWriter, jObject);
-                jsonWriter.Flush();
-            }
-
-            response.Close();
-
-            return true;
-        }
     }
+
 }


### PR DESCRIPTION
Implements StatusHost as a minimal Kestler based HTTP micro-service.

Break apart and organizes StatusHost class into some partial classes.

Uses managed sockets, does not use http.sys on windows.

Works cross-platform.

Will need a companion commit to update MoMMI. (https://github.com/space-wizards/space-station-14/pull/678)

Please test on platforms...

- [x] Windows
- [ ] Mac
- [x] Linux