### PR TITLE
Load internal shaders from files instead of embedding them, allow reloading

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -29,11 +29,18 @@ namespace Robust.Client.Graphics.Clyde
         private GLBuffer _occlusionEbo;
         private GLHandle _occlusionVao;
 
+        private bool _lightingInit;
+
         private unsafe void InitLighting()
         {
             LoadLightingShaders();
 
             RegenerateLightingRenderTargets();
+
+            if (_lightingInit)
+            {
+                return;
+            }
 
             // Occlusion VAO.
             // Only handles positions, no other vertex data necessary.
@@ -61,10 +68,17 @@ namespace Robust.Client.Graphics.Clyde
 
         private void LoadLightingShaders()
         {
+            _fovCalculationProgram?.Delete();
+
             var depthVert = ReadInternalShader("shadow-depth.vert");
             var depthFrag = ReadInternalShader("shadow-depth.frag");
 
             _fovCalculationProgram = _compileProgram(depthVert, depthFrag, "Shadow Depth Program");
+
+            if (_fovDebugShaderInstance != null)
+            {
+                return;
+            }
 
             var debugShader = _resourceCache.GetResource<ShaderSourceResource>("/Shaders/Internal/depth-debug.swsl");
             _fovDebugShaderInstance = (ClydeShaderInstance) InstanceShader(debugShader.ClydeHandle);
@@ -338,4 +352,5 @@ namespace Robust.Client.Graphics.Clyde
             RegenerateLightingRenderTargets();
         }
     }
+
 }

--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -61,8 +61,8 @@ namespace Robust.Client.Graphics.Clyde
 
         private void LoadLightingShaders()
         {
-            var depthVert = ReadEmbeddedShader("shadow-depth.vert");
-            var depthFrag = ReadEmbeddedShader("shadow-depth.frag");
+            var depthVert = ReadInternalShader("shadow-depth.vert");
+            var depthFrag = ReadInternalShader("shadow-depth.frag");
 
             _fovCalculationProgram = _compileProgram(depthVert, depthFrag, "Shadow Depth Program");
 

--- a/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
@@ -107,6 +107,8 @@ namespace Robust.Client.Graphics.Clyde
 
         private void LoadStockShaders()
         {
+            _lightShader?.Delete();
+
             _shaderWrapCodeDefaultFrag = ReadInternalShader("base-default.frag");
             _shaderWrapCodeDefaultVert = ReadInternalShader("base-default.vert");
 

--- a/Robust.Client/Graphics/Clyde/Clyde.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.cs
@@ -80,6 +80,11 @@ namespace Robust.Client.Graphics.Clyde
             return true;
         }
 
+        public void ReloadShaders()
+        {
+            InitLightingAndShaders();
+        }
+
         public void FrameProcess(FrameEventArgs eventArgs)
         {
             _renderTime += eventArgs.DeltaSeconds;
@@ -148,7 +153,7 @@ namespace Robust.Client.Graphics.Clyde
             GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
 
             LoadStockTextures();
-            LoadStockShaders();
+            InitLightingAndShaders();
 
             CreateMiscGLObjects();
 
@@ -156,10 +161,14 @@ namespace Robust.Client.Graphics.Clyde
 
             GL.Viewport(0, 0, ScreenSize.X, ScreenSize.Y);
 
-            InitLighting();
-
             // Quickly do a render with _drawingSplash = true so the screen isn't blank.
             Render();
+        }
+
+        private void InitLightingAndShaders()
+        {
+            LoadStockShaders();
+            InitLighting();
         }
 
         private unsafe void CreateMiscGLObjects()

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -44,6 +44,11 @@ namespace Robust.Client.Graphics.Clyde
             return true;
         }
 
+        public void ReloadShaders()
+        {
+            // Nada.
+        }
+
 #pragma warning disable CS0067
         public override event Action<WindowResizedEventArgs> OnWindowResized;
 #pragma warning restore CS0067

--- a/Robust.Client/Graphics/Clyde/ReloadShadersCommand.cs
+++ b/Robust.Client/Graphics/Clyde/ReloadShadersCommand.cs
@@ -1,0 +1,26 @@
+using Robust.Client.GameStates;
+using Robust.Client.Interfaces.Console;
+using Robust.Client.Interfaces.Graphics;
+using Robust.Client.Interfaces.Graphics.Overlays;
+using Robust.Shared.IoC;
+
+namespace Robust.Client.Graphics.Clyde
+{
+    class ReloadShadersCommand : IConsoleCommand
+    {
+        public string Command => "reload_shaders";
+        public string Help => "reload_shaders";
+        public string Description => "Reload shaders and reinitialize lighting.";
+
+        public bool Execute(IDebugConsole console, params string[] args)
+        {
+
+            console.AddLine("Reloading shaders and reinitializing lighting...");
+            IoCManager.Resolve<IClyde>().ReloadShaders();
+            console.AddLine("Done.");
+
+            return false;
+        }
+    }
+
+}

--- a/Robust.Client/Interfaces/Graphics/IClyde.cs
+++ b/Robust.Client/Interfaces/Graphics/IClyde.cs
@@ -21,6 +21,9 @@ namespace Robust.Client.Interfaces.Graphics
 
         IRenderTarget CreateRenderTarget(Vector2i size, RenderTargetFormatParameters format,
             TextureSampleParameters? sampleParameters = null, string name = null);
+
+        void ReloadShaders();
+
     }
 
     // TODO: Maybe implement IDisposable for render targets. I got lazy and didn't.

--- a/Robust.Client/Robust.Client.csproj
+++ b/Robust.Client/Robust.Client.csproj
@@ -40,7 +40,9 @@
       <LogicalName>Robust.Client.Graphics.RSI.RSISchema.json</LogicalName>
     </EmbeddedResource>
 
-    <EmbeddedResource Include="Graphics\Clyde\Shaders\*" />
+    <Content Include="Graphics\Clyde\Shaders\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="..\MSBuild\Robust.Engine.targets" />
   <PropertyGroup>


### PR DESCRIPTION
Adds `reload_shaders` command to reload internal shaders.

Could be extended to only reload *changed* shaders, and reload shaders other than the internal ones.