### PR TITLE
Internal shaders as content, live shader reloading for rapid dev

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -29,11 +29,18 @@ namespace Robust.Client.Graphics.Clyde
         private GLBuffer _occlusionEbo;
         private GLHandle _occlusionVao;
 
+        private bool _lightingInit;
+
         private unsafe void InitLighting()
         {
             LoadLightingShaders();
 
             RegenerateLightingRenderTargets();
+
+            if (_lightingInit)
+            {
+                return;
+            }
 
             // Occlusion VAO.
             // Only handles positions, no other vertex data necessary.
@@ -57,14 +64,23 @@ namespace Robust.Client.Graphics.Clyde
                 new TextureSampleParameters {WrapMode = TextureWrapMode.Repeat}, "FOV depth render target");
 
             _fovDepthTextureObject = _fovRenderTarget.Texture;
+
+            _lightingInit = true;
         }
 
         private void LoadLightingShaders()
         {
-            var depthVert = ReadEmbeddedShader("shadow-depth.vert");
-            var depthFrag = ReadEmbeddedShader("shadow-depth.frag");
+            _fovCalculationProgram?.Delete();
+
+            var depthVert = ReadInternalShader("shadow-depth.vert");
+            var depthFrag = ReadInternalShader("shadow-depth.frag");
 
             _fovCalculationProgram = _compileProgram(depthVert, depthFrag, "Shadow Depth Program");
+
+            if (_fovDebugShaderInstance != null)
+            {
+                return;
+            }
 
             var debugShader = _resourceCache.GetResource<ShaderSourceResource>("/Shaders/Internal/depth-debug.swsl");
             _fovDebugShaderInstance = (ClydeShaderInstance) InstanceShader(debugShader.ClydeHandle);

--- a/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
 using OpenTK.Graphics.OpenGL4;
 using Robust.Client.Graphics.Shaders;
@@ -106,11 +107,13 @@ namespace Robust.Client.Graphics.Clyde
 
         private void LoadStockShaders()
         {
-            _shaderWrapCodeDefaultFrag = ReadEmbeddedShader("base-default.frag");
-            _shaderWrapCodeDefaultVert = ReadEmbeddedShader("base-default.vert");
+            _lightShader?.Delete();
 
-            _shaderWrapCodeRawVert = ReadEmbeddedShader("base-raw.vert");
-            _shaderWrapCodeRawFrag = ReadEmbeddedShader("base-raw.frag");
+            _shaderWrapCodeDefaultFrag = ReadInternalShader("base-default.frag");
+            _shaderWrapCodeDefaultVert = ReadInternalShader("base-default.vert");
+
+            _shaderWrapCodeRawVert = ReadInternalShader("base-raw.vert");
+            _shaderWrapCodeRawFrag = ReadInternalShader("base-raw.frag");
 
             var defaultLoadedShader = _resourceCache
                 .GetResource<ShaderSourceResource>("/Shaders/Internal/default-sprite.swsl").ClydeHandle;
@@ -119,20 +122,30 @@ namespace Robust.Client.Graphics.Clyde
 
             _queuedShader = _defaultShader.Handle;
 
-            var lightVert = ReadEmbeddedShader("light.vert");
-            var lightFrag = ReadEmbeddedShader("light.frag");
+            var lightVert = ReadInternalShader("light.vert");
+            var lightFrag = ReadInternalShader("light.frag");
 
             _lightShader = _compileProgram(lightVert, lightFrag, "_lightShader");
         }
 
-        private string ReadEmbeddedShader(string fileName)
+        private string GetInternalShaderPath(string fileName)
         {
-            var assembly = typeof(Clyde).Assembly;
-            using var stream = assembly.GetManifestResourceStream($"Robust.Client.Graphics.Clyde.Shaders.{fileName}");
-            DebugTools.AssertNotNull(stream);
-            using var reader = new StreamReader(stream, EncodingHelpers.UTF8);
-            return reader.ReadToEnd();
+#if DEBUG
+            // for hot reload
+            var devPath = Path.Combine(Path.GetDirectoryName(GetCodeFilePath()), "Shaders", fileName);
+            if (File.Exists(devPath))
+            {
+                return devPath;
+            }
+#endif
+            return Path.Combine("Graphics", "Clyde", "Shaders", fileName);
         }
+
+        private string ReadInternalShader(string fileName) => File.ReadAllText(GetInternalShaderPath(fileName));
+
+#if DEBUG
+        private string GetCodeFilePath([CallerFilePath] string filePath = default) => filePath;
+#endif
 
         private GLShaderProgram _compileProgram(string vertexSource, string fragmentSource, string name = null)
         {

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -44,6 +44,16 @@ namespace Robust.Client.Graphics.Clyde
             return true;
         }
 
+        public void ReloadShaders()
+        {
+            // Nada.
+        }
+
+        public void WatchShadersAndReload(bool enabled)
+        {
+            // Nada.
+        }
+
 #pragma warning disable CS0067
         public override event Action<WindowResizedEventArgs> OnWindowResized;
 #pragma warning restore CS0067

--- a/Robust.Client/Interfaces/Graphics/IClyde.cs
+++ b/Robust.Client/Interfaces/Graphics/IClyde.cs
@@ -21,6 +21,11 @@ namespace Robust.Client.Interfaces.Graphics
 
         IRenderTarget CreateRenderTarget(Vector2i size, RenderTargetFormatParameters format,
             TextureSampleParameters? sampleParameters = null, string name = null);
+
+        void ReloadShaders();
+
+        void WatchShadersAndReload(bool enabled);
+
     }
 
     // TODO: Maybe implement IDisposable for render targets. I got lazy and didn't.

--- a/Robust.Client/Robust.Client.csproj
+++ b/Robust.Client/Robust.Client.csproj
@@ -40,7 +40,9 @@
       <LogicalName>Robust.Client.Graphics.RSI.RSISchema.json</LogicalName>
     </EmbeddedResource>
 
-    <EmbeddedResource Include="Graphics\Clyde\Shaders\*" />
+    <Content Include="Graphics\Clyde\Shaders\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="..\MSBuild\Robust.Engine.targets" />
   <PropertyGroup>


### PR DESCRIPTION
improves shader reloading functionality to include internal shaders

adds live file watcher based shader reloading (`rldshader +watch`)

groups clyde lighting and internal shader init together

allows init to be run multiple times to allow reloading

adds ReloadShaders and WatchShadersAndReload to IClyde for internal shader reloading

moves internal shaders out of embedding to content