### PR TITLE
Add check to LineEdit cursor position

### DIFF
--- a/Robust.Client/UserInterface/Controls/LineEdit.cs
+++ b/Robust.Client/UserInterface/Controls/LineEdit.cs
@@ -394,7 +394,7 @@ namespace Robust.Client.UserInterface.Controls
                 // Same but left side.
                 var distanceLeft = clickPosX - lastChrPostX;
                 // If the mouse is closer to the left of the glyph we lower the index one, so we select before that glyph.
-                if (distanceRight > distanceLeft)
+                if (index > 0 && distanceRight > distanceLeft)
                 {
                     index -= 1;
                 }


### PR DESCRIPTION
Add a check so that `_cursorPosition` doesn't get set to `-1` when clicking on the left of the 0th char.

Fixes space-wizards/space-station-14#693