### PR TITLE
Implement ContainerButton and refactor buttons

### DIFF
--- a/Robust.Client/State/States/MainMenu.cs
+++ b/Robust.Client/State/States/MainMenu.cs
@@ -228,10 +228,7 @@ namespace Robust.Client.State.States
                 var layout = new LayoutContainer();
                 AddChild(layout);
 
-                var vBox = new VBoxContainer
-                {
-                    StyleIdentifier = "mainMenuVBox",
-                };
+                var vBox = new VBoxContainer();
 
                 layout.AddChild(vBox);
                 LayoutContainer.SetAnchorPreset(vBox, LayoutContainer.LayoutPreset.TopRight);
@@ -263,7 +260,8 @@ namespace Robust.Client.State.States
                 JoinPublicServerButton = new Button
                 {
                     Text = "Join Public Server",
-                    TextAlign = Button.AlignMode.Center,
+                    StyleIdentifier = "mainMenu",
+                    TextAlign = Label.AlignMode.Center,
 #if !FULL_RELEASE
                     Disabled = true,
                     ToolTip = "Cannot connect to public server with a debug build."
@@ -287,7 +285,8 @@ namespace Robust.Client.State.States
                 DirectConnectButton = new Button
                 {
                     Text = "Direct Connect",
-                    TextAlign = Button.AlignMode.Center
+                    TextAlign = Label.AlignMode.Center,
+                    StyleIdentifier = "mainMenu",
                 };
 
                 vBox.AddChild(DirectConnectButton);
@@ -298,7 +297,8 @@ namespace Robust.Client.State.States
                 OptionsButton = new Button
                 {
                     Text = "Options",
-                    TextAlign = Button.AlignMode.Center
+                    TextAlign = Label.AlignMode.Center,
+                    StyleIdentifier = "mainMenu",
                 };
 
                 vBox.AddChild(OptionsButton);
@@ -306,7 +306,8 @@ namespace Robust.Client.State.States
                 QuitButton = new Button
                 {
                     Text = "Quit",
-                    TextAlign = Button.AlignMode.Center
+                    TextAlign = Label.AlignMode.Center,
+                    StyleIdentifier = "mainMenu",
                 };
 
                 vBox.AddChild(QuitButton);

--- a/Robust.Client/State/States/MainMenu.cs
+++ b/Robust.Client/State/States/MainMenu.cs
@@ -228,7 +228,10 @@ namespace Robust.Client.State.States
                 var layout = new LayoutContainer();
                 AddChild(layout);
 
-                var vBox = new VBoxContainer();
+                var vBox = new VBoxContainer
+                {
+                    StyleIdentifier = "mainMenuVBox"
+                };
 
                 layout.AddChild(vBox);
                 LayoutContainer.SetAnchorPreset(vBox, LayoutContainer.LayoutPreset.TopRight);

--- a/Robust.Client/UserInterface/Control.Styling.cs
+++ b/Robust.Client/UserInterface/Control.Styling.cs
@@ -210,7 +210,7 @@ namespace Robust.Client.UserInterface
 
             public IEnumerator<string> GetEnumerator()
             {
-                return _owner.StyleClasses.GetEnumerator();
+                return _owner._styleClasses.GetEnumerator();
             }
 
             IEnumerator IEnumerable.GetEnumerator()

--- a/Robust.Client/UserInterface/Controls/BaseButton.cs
+++ b/Robust.Client/UserInterface/Controls/BaseButton.cs
@@ -211,9 +211,9 @@ namespace Robust.Client.UserInterface.Controls
                 if (ToggleMode)
                 {
                     // Can't un press a radio button directly.
-                    if (Group == null || !_pressed)
+                    if (Group == null || !Pressed)
                     {
-                        _pressed = !_pressed;
+                        Pressed = !Pressed;
                         OnPressed?.Invoke(buttonEventArgs);
                         OnToggled?.Invoke(new ButtonToggledEventArgs(Pressed, this, args));
                         UnsetOtherGroupButtons();
@@ -249,11 +249,11 @@ namespace Robust.Client.UserInterface.Controls
                 this == UserInterfaceManagerInternal.MouseGetControl(args.PointerLocation.Position))
             {
                 // Can't un press a radio button directly.
-                if (Group == null || !_pressed)
+                if (Group == null || !Pressed)
                 {
                     if (ToggleMode)
                     {
-                        _pressed = !_pressed;
+                        Pressed = !Pressed;
                     }
 
                     OnPressed?.Invoke(buttonEventArgs);
@@ -283,7 +283,7 @@ namespace Robust.Client.UserInterface.Controls
             {
                 if (button != this && button.Pressed)
                 {
-                    button._pressed = false;
+                    button.Pressed = false;
                     button.DrawModeChanged();
                 }
             }

--- a/Robust.Client/UserInterface/Controls/Button.cs
+++ b/Robust.Client/UserInterface/Controls/Button.cs
@@ -1,34 +1,26 @@
-﻿using System;
-using Robust.Client.Graphics;
-using Robust.Client.Graphics.Drawing;
-using Robust.Shared.Maths;
-using Robust.Shared.ViewVariables;
+﻿using Robust.Shared.ViewVariables;
+using static Robust.Client.UserInterface.Controls.Label;
 
 namespace Robust.Client.UserInterface.Controls
 {
     /// <summary>
     ///     Most common button type that draws text in a fancy box.
     /// </summary>
-    public class Button : BaseButton
+    public class Button : ContainerButton
     {
-        public const string StylePropertyStyleBox = "stylebox";
-        public const string StylePseudoClassNormal = "normal";
-        public const string StylePseudoClassHover = "hover";
-        public const string StylePseudoClassDisabled = "disabled";
-        public const string StylePseudoClassPressed = "pressed";
-        private int? _textWidthCache;
-        private string _text;
+        public Label Label { get; }
 
-        public Button()
+        public Button() : base()
         {
-            DrawModeChanged();
+            Label = new Label();
+            AddChild(Label);
         }
 
         /// <summary>
         ///     How to align the text inside the button.
         /// </summary>
         [ViewVariables]
-        public AlignMode TextAlign { get; set; } = AlignMode.Center;
+        public AlignMode TextAlign { get => Label.Align; set => Label.Align = value; }
 
         /// <summary>
         ///     If true, the button will allow shrinking and clip text
@@ -36,231 +28,12 @@ namespace Robust.Client.UserInterface.Controls
         ///     If false, the minimum size will always fit the contained text.
         /// </summary>
         [ViewVariables]
-        public bool ClipText { get; set; }
+        public bool ClipText { get => Label.ClipText; set => Label.ClipText = value; }
 
         /// <summary>
         ///     The text displayed by the button.
         /// </summary>
         [ViewVariables]
-        public string Text
-        {
-            get => _text;
-            set
-            {
-                _text = value;
-                _textWidthCache = null;
-                MinimumSizeChanged();
-            }
-        }
-
-        private StyleBox ActualStyleBox
-        {
-            get
-            {
-                if (TryGetStyleProperty(StylePropertyStyleBox, out StyleBox box))
-                {
-                    return box;
-                }
-
-                return UserInterfaceManager.ThemeDefaults.ButtonStyle;
-            }
-        }
-
-        public Font ActualFont
-        {
-            get
-            {
-                if (TryGetStyleProperty("font", out Font font))
-                {
-                    return font;
-                }
-
-                return UserInterfaceManager.ThemeDefaults.DefaultFont;
-            }
-        }
-
-        public Color ActualFontColor
-        {
-            get
-            {
-                if (TryGetStyleProperty("font-color", out Color fontColor))
-                {
-                    return fontColor;
-                }
-
-                return FontColorOverride ?? Color.White;
-            }
-        }
-
-        public Color? FontColorOverride { get; set; }
-        public Color? FontColorDisabledOverride { get; set; }
-        public Color? FontColorHoverOverride { get; set; }
-        public Color? FontColorPressedOverride { get; set; }
-
-        public enum AlignMode
-        {
-            /// <summary>
-            ///     Text is aligned to the left of the button.
-            /// </summary>
-            Left = 0,
-
-            /// <summary>
-            ///     Text is aligned to the center of the button.
-            /// </summary>
-            Center = 1,
-
-            /// <summary>
-            ///     Text is aligned to the right of the button.
-            /// </summary>
-            Right = 2
-        }
-
-        protected internal override void Draw(DrawingHandleScreen handle)
-        {
-            base.Draw(handle);
-
-            var style = ActualStyleBox;
-            var drawBox = PixelSizeBox;
-            style.Draw(handle, drawBox);
-
-            if (_text == null)
-            {
-                return;
-            }
-
-            var contentBox = style.GetContentBox(drawBox);
-            DrawTextInternal(handle, contentBox);
-        }
-
-        protected void DrawTextInternal(DrawingHandleScreen handle, UIBox2 box)
-        {
-            var width = EnsureWidthCache();
-            var font = ActualFont;
-            int drawOffset;
-
-            if (box.Width < width)
-            {
-                drawOffset = 0;
-            }
-            else
-            {
-                switch (TextAlign)
-                {
-                    case AlignMode.Left:
-                        drawOffset = 0;
-                        break;
-                    case AlignMode.Center:
-                        drawOffset = (int) (box.Width - width) / 2;
-                        break;
-                    case AlignMode.Right:
-                        drawOffset = (int) (box.Width - width);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-            }
-
-            var color = ActualFontColor;
-            var offsetY = (int) (box.Height - font.GetHeight(UIScale)) / 2;
-            var baseLine = new Vector2i(drawOffset, offsetY + font.GetAscent(UIScale)) + box.TopLeft;
-
-            foreach (var chr in _text)
-            {
-                if (!font.TryGetCharMetrics(chr, UIScale, out var metrics))
-                {
-                    continue;
-                }
-
-                if (!(ClipText && (baseLine.X < box.Left || baseLine.X + metrics.Advance > box.Right)))
-                {
-                    font.DrawChar(handle, chr, baseLine, UIScale, color);
-                }
-
-                baseLine += (metrics.Advance, 0);
-            }
-        }
-
-        protected override Vector2 CalculateMinimumSize()
-        {
-            var style = ActualStyleBox;
-            var font = ActualFont;
-
-            var fontHeight = font.GetHeight(UIScale) / UIScale;
-
-            if (ClipText)
-            {
-                return (0, fontHeight) + style.MinimumSize / UIScale;
-            }
-
-            var width = EnsureWidthCache();
-
-            return (width / UIScale, fontHeight) + style.MinimumSize / UIScale;
-        }
-
-        protected override void DrawModeChanged()
-        {
-            switch (DrawMode)
-            {
-                case DrawModeEnum.Normal:
-                    SetOnlyStylePseudoClass(StylePseudoClassNormal);
-                    break;
-                case DrawModeEnum.Pressed:
-                    SetOnlyStylePseudoClass(StylePseudoClassPressed);
-                    break;
-                case DrawModeEnum.Hover:
-                    SetOnlyStylePseudoClass(StylePseudoClassHover);
-                    break;
-                case DrawModeEnum.Disabled:
-                    SetOnlyStylePseudoClass(StylePseudoClassDisabled);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
-
-        protected int EnsureWidthCache()
-        {
-            if (_textWidthCache.HasValue)
-            {
-                return _textWidthCache.Value;
-            }
-
-            if (_text == null)
-            {
-                _textWidthCache = 0;
-                return 0;
-            }
-
-            var font = ActualFont;
-
-            var textWidth = 0;
-            foreach (var chr in _text)
-            {
-                var metrics = font.GetCharMetrics(chr, UIScale);
-                if (metrics == null)
-                {
-                    continue;
-                }
-
-                textWidth += metrics.Value.Advance;
-            }
-
-            _textWidthCache = textWidth;
-            return textWidth;
-        }
-
-        protected override void StylePropertiesChanged()
-        {
-            _textWidthCache = null;
-
-            base.StylePropertiesChanged();
-        }
-
-        protected internal override void UIScaleChanged()
-        {
-            _textWidthCache = null;
-
-            base.UIScaleChanged();
-        }
+        public string Text { get => Label.Text; set => Label.Text = value; }
     }
 }

--- a/Robust.Client/UserInterface/Controls/Button.cs
+++ b/Robust.Client/UserInterface/Controls/Button.cs
@@ -8,11 +8,16 @@ namespace Robust.Client.UserInterface.Controls
     /// </summary>
     public class Button : ContainerButton
     {
+        public const string StyleClassButton = "button";
+
         public Label Label { get; }
 
         public Button() : base()
         {
-            Label = new Label();
+            Label = new Label
+            {
+                StyleClasses = { StyleClassButton }
+            };
             AddChild(Label);
         }
 

--- a/Robust.Client/UserInterface/Controls/CheckBox.cs
+++ b/Robust.Client/UserInterface/Controls/CheckBox.cs
@@ -1,69 +1,76 @@
-using Robust.Client.Graphics;
-using Robust.Client.Graphics.Drawing;
-using Robust.Shared.Maths;
+﻿using Robust.Shared.ViewVariables;
+using static Robust.Client.UserInterface.Controls.Label;
 
 namespace Robust.Client.UserInterface.Controls
 {
     /// <summary>
     ///     A type of toggleable button that also has a checkbox.
     /// </summary>
-    public class CheckBox : Button
+    public class CheckBox : ContainerButton
     {
-        public const string StylePropertyIcon = "icon";
-        public const string StylePropertyHSeparation = "hseparation";
+        public const string StyleIdentifierCheckBoxChecked = "checkBoxChecked";
+        public const string StyleIdentifierCheckBoxUnchecked = "checkBoxUnchecked";
 
-        public CheckBox()
+        public Label Label { get; }
+        public TextureRect TextureRect { get; }
+
+        public CheckBox() : base()
         {
             ToggleMode = true;
+
+            var hBox = new HBoxContainer
+            {
+                MouseFilter = MouseFilterMode.Ignore
+            };
+            AddChild(hBox);
+
+            TextureRect = new TextureRect
+            {
+                MouseFilter = MouseFilterMode.Ignore,
+                StyleIdentifier = StyleIdentifierCheckBoxUnchecked
+            };
+            hBox.AddChild(TextureRect);
+
+            Label = new Label
+            {
+                MouseFilter = MouseFilterMode.Ignore
+            };
+            hBox.AddChild(Label);
         }
 
-        protected internal override void Draw(DrawingHandleScreen handle)
+        protected override void DrawModeChanged()
         {
-            var offset = 0;
-            var icon = _getIcon();
-            if (icon != null)
+            base.DrawModeChanged();
+
+            if (TextureRect == null)
             {
-                offset += _getIcon().Width + _getHSeparation();
-                var vOffset = (PixelHeight - _getIcon().Height) / 2;
-                handle.DrawTextureRectRegion(icon, UIBox2.FromDimensions((0, vOffset), icon.Size * UIScale));
+                return;
             }
 
-            var box = new UIBox2(offset, 0, PixelWidth, PixelHeight);
-            DrawTextInternal(handle, box);
+            if (Pressed)
+                TextureRect.StyleIdentifier = StyleIdentifierCheckBoxChecked;
+            else
+                TextureRect.StyleIdentifier = StyleIdentifierCheckBoxUnchecked;
         }
 
-        protected override Vector2 CalculateMinimumSize()
-        {
-            var minSize = _getIcon()?.Size / UIScale ?? Vector2.Zero;
-            var font = ActualFont;
+        /// <summary>
+        ///     How to align the text inside the button.
+        /// </summary>
+        [ViewVariables]
+        public AlignMode TextAlign { get => Label.Align; set => Label.Align = value; }
 
-            if (!string.IsNullOrWhiteSpace(Text) && !ClipText)
-            {
-                minSize += (EnsureWidthCache() / UIScale + _getHSeparation() / UIScale, 0);
-            }
-            minSize = Vector2.ComponentMax(minSize, (0, font.GetHeight(UIScale) / UIScale));
+        /// <summary>
+        ///     If true, the button will allow shrinking and clip text
+        ///     to prevent the text from going outside the bounds of the button.
+        ///     If false, the minimum size will always fit the contained text.
+        /// </summary>
+        [ViewVariables]
+        public bool ClipText { get => Label.ClipText; set => Label.ClipText = value; }
 
-            return minSize;
-        }
-
-        private Texture _getIcon()
-        {
-            if (TryGetStyleProperty(StylePropertyIcon, out Texture tex))
-            {
-                return tex;
-            }
-
-            return null;
-        }
-
-        private int _getHSeparation()
-        {
-            if (TryGetStyleProperty(StylePropertyHSeparation, out int hSep))
-            {
-                return hSep;
-            }
-
-            return 0;
-        }
+        /// <summary>
+        ///     The text displayed by the button.
+        /// </summary>
+        [ViewVariables]
+        public string Text { get => Label.Text; set => Label.Text = value; }
     }
 }

--- a/Robust.Client/UserInterface/Controls/CheckBox.cs
+++ b/Robust.Client/UserInterface/Controls/CheckBox.cs
@@ -8,8 +8,8 @@ namespace Robust.Client.UserInterface.Controls
     /// </summary>
     public class CheckBox : ContainerButton
     {
-        public const string StyleIdentifierCheckBoxChecked = "checkBoxChecked";
-        public const string StyleIdentifierCheckBoxUnchecked = "checkBoxUnchecked";
+        public const string StyleClassCheckBox = "checkBox";
+        public const string StyleClassCheckBoxChecked = "checkBoxChecked";
 
         public Label Label { get; }
         public TextureRect TextureRect { get; }
@@ -20,14 +20,15 @@ namespace Robust.Client.UserInterface.Controls
 
             var hBox = new HBoxContainer
             {
+                StyleClasses = { StyleClassCheckBox },
                 MouseFilter = MouseFilterMode.Ignore
             };
             AddChild(hBox);
 
             TextureRect = new TextureRect
             {
-                MouseFilter = MouseFilterMode.Ignore,
-                StyleIdentifier = StyleIdentifierCheckBoxUnchecked
+                StyleClasses = { StyleClassCheckBox },
+                MouseFilter = MouseFilterMode.Ignore
             };
             hBox.AddChild(TextureRect);
 
@@ -42,15 +43,13 @@ namespace Robust.Client.UserInterface.Controls
         {
             base.DrawModeChanged();
 
-            if (TextureRect == null)
+            if (TextureRect != null)
             {
-                return;
+                if (Pressed)
+                    TextureRect.AddStyleClass(StyleClassCheckBoxChecked);
+                else
+                    TextureRect.RemoveStyleClass(StyleClassCheckBoxChecked);
             }
-
-            if (Pressed)
-                TextureRect.StyleIdentifier = StyleIdentifierCheckBoxChecked;
-            else
-                TextureRect.StyleIdentifier = StyleIdentifierCheckBoxUnchecked;
         }
 
         /// <summary>

--- a/Robust.Client/UserInterface/Controls/ContainerButton.cs
+++ b/Robust.Client/UserInterface/Controls/ContainerButton.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using Robust.Client.Graphics.Drawing;
+using Robust.Shared.Maths;
+
+namespace Robust.Client.UserInterface.Controls
+{
+    public class ContainerButton : BaseButton
+    {
+        public const string StylePropertyStyleBox = "stylebox";
+        public const string StylePseudoClassNormal = "normal";
+        public const string StylePseudoClassPressed = "pressed";
+        public const string StylePseudoClassHover = "hover";
+        public const string StylePseudoClassDisabled = "disabled";
+
+        public ContainerButton()
+        {
+            DrawModeChanged();
+        }
+
+        private StyleBox ActualStyleBox
+        {
+            get
+            {
+                if (TryGetStyleProperty(StylePropertyStyleBox, out StyleBox box))
+                {
+                    return box;
+                }
+
+                return UserInterfaceManager.ThemeDefaults.ButtonStyle;
+            }
+        }
+        protected override void LayoutUpdateOverride()
+        {
+            var contentBox = ActualStyleBox.GetContentBox(PixelSizeBox);
+            foreach (var child in Children)
+            {
+                FitChildInBox(child, contentBox);
+            }
+        }
+
+        protected internal override void Draw(DrawingHandleScreen handle)
+        {
+            base.Draw(handle);
+
+            var style = ActualStyleBox;
+            var drawBox = PixelSizeBox;
+            style.Draw(handle, drawBox);
+        }
+
+        protected override Vector2 CalculateMinimumSize()
+        {
+            var min = Vector2.Zero;
+            foreach (var child in Children)
+            {
+                min = Vector2.ComponentMax(min, child.CombinedMinimumSize);
+            }
+
+            return min + ActualStyleBox.MinimumSize / UIScale;
+        }
+
+        protected override void DrawModeChanged()
+        {
+            switch (DrawMode)
+            {
+                case DrawModeEnum.Normal:
+                    SetOnlyStylePseudoClass(StylePseudoClassNormal);
+                    break;
+                case DrawModeEnum.Pressed:
+                    SetOnlyStylePseudoClass(StylePseudoClassPressed);
+                    break;
+                case DrawModeEnum.Hover:
+                    SetOnlyStylePseudoClass(StylePseudoClassHover);
+                    break;
+                case DrawModeEnum.Disabled:
+                    SetOnlyStylePseudoClass(StylePseudoClassDisabled);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+    }
+}

--- a/Robust.Client/UserInterface/Controls/ContainerButton.cs
+++ b/Robust.Client/UserInterface/Controls/ContainerButton.cs
@@ -29,6 +29,7 @@ namespace Robust.Client.UserInterface.Controls
                 return UserInterfaceManager.ThemeDefaults.ButtonStyle;
             }
         }
+
         protected override void LayoutUpdateOverride()
         {
             var contentBox = ActualStyleBox.GetContentBox(PixelSizeBox);

--- a/Robust.Client/UserInterface/Controls/Label.cs
+++ b/Robust.Client/UserInterface/Controls/Label.cs
@@ -16,12 +16,14 @@ namespace Robust.Client.UserInterface.Controls
     {
         public const string StylePropertyFontColor = "font-color";
         public const string StylePropertyFont = "font";
+        public const string StylePropertyAlignMode = "alignMode";
 
         private int _cachedTextHeight;
         private readonly List<int> _cachedTextWidths = new List<int>();
         private bool _textDimensionCacheValid;
         private string _text;
         private bool _clipText;
+        private AlignMode _align;
 
         public Label()
         {
@@ -56,7 +58,18 @@ namespace Robust.Client.UserInterface.Controls
             }
         }
 
-        [ViewVariables] public AlignMode Align { get; set; }
+        [ViewVariables] public AlignMode Align {
+            get
+            {
+                if (TryGetStyleProperty<AlignMode>(StylePropertyAlignMode, out var alignMode))
+                {
+                    return alignMode;
+                }
+
+                return _align;
+            }
+            set => _align = value;
+        }
 
         [ViewVariables] public VAlignMode VAlign { get; set; }
 

--- a/Robust.Client/UserInterface/Controls/MenuBar.cs
+++ b/Robust.Client/UserInterface/Controls/MenuBar.cs
@@ -102,7 +102,7 @@ namespace Robust.Client.UserInterface.Controls
                             Text = menuButton.Text,
                             ClipText = true,
                             Disabled = menuButton.Disabled,
-                            TextAlign = Button.AlignMode.Left
+                            TextAlign = Label.AlignMode.Left
                         };
                         pushButton.OnPressed += _ => menuButton.OnPressed?.Invoke();
                         container.AddChild(pushButton);

--- a/Robust.Client/UserInterface/Controls/OptionButton.cs
+++ b/Robust.Client/UserInterface/Controls/OptionButton.cs
@@ -2,11 +2,13 @@
 using System.Collections.Generic;
 using Robust.Client.Graphics;
 using Robust.Shared.Maths;
+using static Robust.Client.UserInterface.Controls.Label;
 
 namespace Robust.Client.UserInterface.Controls
 {
     public class OptionButton : ContainerButton
     {
+        public const string StyleClassOptionButton = "optionButton";
         public const string StyleClassOptionTriangle = "optionTriangle";
 
         private List<ButtonData> _buttonData = new List<ButtonData>();
@@ -37,6 +39,7 @@ namespace Robust.Client.UserInterface.Controls
 
             _label = new Label
             {
+                StyleClasses = { StyleClassOptionButton },
                 SizeFlagsHorizontal = SizeFlags.FillExpand,
                 MouseFilter = MouseFilterMode.Ignore
             };

--- a/Robust.Client/UserInterface/Controls/OptionButton.cs
+++ b/Robust.Client/UserInterface/Controls/OptionButton.cs
@@ -26,7 +26,6 @@ namespace Robust.Client.UserInterface.Controls
 
             var hBox = new HBoxContainer
             {
-                SizeFlagsHorizontal = SizeFlags.FillExpand,
                 MouseFilter = MouseFilterMode.Ignore
             };
             AddChild(hBox);

--- a/Robust.Client/UserInterface/Controls/OptionButton.cs
+++ b/Robust.Client/UserInterface/Controls/OptionButton.cs
@@ -5,16 +5,52 @@ using Robust.Shared.Maths;
 
 namespace Robust.Client.UserInterface.Controls
 {
-    public class OptionButton : Button
+    public class OptionButton : ContainerButton
     {
+        public const string StyleClassOptionTriangle = "optionTriangle";
+
         private List<ButtonData> _buttonData = new List<ButtonData>();
         private Dictionary<int, int> _idMap = new Dictionary<int, int>();
         private Popup _popup;
         private VBoxContainer _popupVBox;
+        private Label _label;
 
         public event Action<ItemSelectedEventArgs> OnItemSelected;
 
         public string Prefix { get; set; }
+
+        public OptionButton()
+        {
+            Prefix = "";
+            OnPressed += _onPressed;
+
+            var hBox = new HBoxContainer
+            {
+                SizeFlagsHorizontal = SizeFlags.FillExpand,
+                MouseFilter = MouseFilterMode.Ignore
+            };
+            AddChild(hBox);
+
+            _popup = new Popup();
+            UserInterfaceManager.ModalRoot.AddChild(_popup);
+            _popupVBox = new VBoxContainer();
+            _popup.AddChild(_popupVBox);
+
+            _label = new Label
+            {
+                SizeFlagsHorizontal = SizeFlags.FillExpand,
+                MouseFilter = MouseFilterMode.Ignore
+            };
+            hBox.AddChild(_label);
+
+            var textureRect = new TextureRect
+            {
+                StyleClasses = { StyleClassOptionTriangle },
+                SizeFlagsVertical = SizeFlags.ShrinkCenter,
+                MouseFilter = MouseFilterMode.Ignore
+            };
+            hBox.AddChild(textureRect);
+        }
 
         public void AddItem(Texture icon, string label, int? id = null)
         {
@@ -116,7 +152,7 @@ namespace Robust.Client.UserInterface.Controls
             }
             var data = _buttonData[idx];
             SelectedId = data.Id;
-            Text = Prefix + data.Text;
+            _label.Text = Prefix + data.Text;
             data.Button.Pressed = true;
         }
 
@@ -165,7 +201,7 @@ namespace Robust.Client.UserInterface.Controls
             data.Text = text;
             if (SelectedId == data.Id)
             {
-                Text = text;
+                _label.Text = text;
             }
 
             data.Button.Text = text;
@@ -177,16 +213,6 @@ namespace Robust.Client.UserInterface.Controls
             var (minX, minY) = _popupVBox.CombinedMinimumSize;
             var box = UIBox2.FromDimensions(globalPos, (Math.Max(minX, Width), minY));
             _popup.Open(box);
-        }
-
-        public OptionButton()
-        {
-            Prefix = "";
-            OnPressed += _onPressed;
-            _popup = new Popup();
-            UserInterfaceManager.ModalRoot.AddChild(_popup);
-            _popupVBox = new VBoxContainer();
-            _popup.AddChild(_popupVBox);
         }
 
         protected override void Dispose(bool disposing)

--- a/Robust.Client/UserInterface/Controls/Popup.cs
+++ b/Robust.Client/UserInterface/Controls/Popup.cs
@@ -21,11 +21,12 @@ namespace Robust.Client.UserInterface.Controls
                 UserInterfaceManagerInternal.RemoveModal(this);
             }
 
-            if (box != null)
+            if (box != null && _desiredSize != box.Value.Size)
             {
                 PopupContainer.SetPopupOrigin(this, box.Value.TopLeft);
 
                 _desiredSize = box.Value.Size;
+                MinimumSizeChanged();
             }
 
             Visible = true;

--- a/Robust.Client/UserInterface/Controls/TextureRect.cs
+++ b/Robust.Client/UserInterface/Controls/TextureRect.cs
@@ -10,6 +10,8 @@ namespace Robust.Client.UserInterface.Controls
     /// </summary>
     public class TextureRect : Control
     {
+        public const string StylePropertyTexture = "texture";
+
         private bool _canShrink;
         private Texture _texture;
         private Vector2 _textureScale = Vector2.One;
@@ -69,34 +71,40 @@ namespace Robust.Client.UserInterface.Controls
         {
             base.Draw(handle);
 
-            if (_texture == null)
+            var texture = _texture;
+
+            if (texture == null)
             {
-                return;
+                TryGetStyleProperty(StylePropertyTexture, out texture);
+                if (texture == null)
+                {
+                    return;
+                }
             }
 
             switch (Stretch)
             {
                 case StretchMode.Scale:
-                    handle.DrawTextureRect(_texture,
+                    handle.DrawTextureRect(texture,
                         UIBox2.FromDimensions(Vector2.Zero, PixelSize));
                     break;
                 case StretchMode.Tile:
                 // TODO: Implement Tile.
                 case StretchMode.Keep:
-                    handle.DrawTextureRect(_texture,
-                        UIBox2.FromDimensions(Vector2.Zero, _texture.Size * _textureScale * UIScale));
+                    handle.DrawTextureRect(texture,
+                        UIBox2.FromDimensions(Vector2.Zero, texture.Size * _textureScale * UIScale));
                     break;
                 case StretchMode.KeepCentered:
                 {
-                    var position = (PixelSize - _texture.Size * _textureScale * UIScale) / 2;
-                    handle.DrawTextureRect(_texture, UIBox2.FromDimensions(position, _texture.Size * _textureScale * UIScale));
+                    var position = (PixelSize - texture.Size * _textureScale * UIScale) / 2;
+                    handle.DrawTextureRect(texture, UIBox2.FromDimensions(position, texture.Size * _textureScale * UIScale));
                     break;
                 }
 
                 case StretchMode.KeepAspect:
                 case StretchMode.KeepAspectCentered:
                 {
-                    var (texWidth, texHeight) = _texture.Size * _textureScale;
+                    var (texWidth, texHeight) = texture.Size * _textureScale;
                     var width = texWidth * (PixelSize.Y / texHeight);
                     var height = (float)PixelSize.Y;
                     if (width > PixelSize.X)
@@ -112,19 +120,19 @@ namespace Robust.Client.UserInterface.Controls
                         position = (PixelSize - size) / 2;
                     }
 
-                    handle.DrawTextureRectRegion(_texture, UIBox2.FromDimensions(position, size));
+                    handle.DrawTextureRectRegion(texture, UIBox2.FromDimensions(position, size));
                     break;
                 }
 
                 case StretchMode.KeepAspectCovered:
-                    var texSize = _texture.Size * _textureScale;
+                    var texSize = texture.Size * _textureScale;
                     // Calculate the scale necessary to fit width and height to control size.
                     var (scaleX, scaleY) = PixelSize / texSize;
                     // Use whichever scale is greater.
                     var scale = Math.Max(scaleX, scaleY);
                     // Offset inside the actual texture.
                     var offset = (texSize - PixelSize) / scale / 2f;
-                    handle.DrawTextureRectRegion(_texture, PixelSizeBox, UIBox2.FromDimensions(offset, PixelSize / scale));
+                    handle.DrawTextureRectRegion(texture, PixelSizeBox, UIBox2.FromDimensions(offset, PixelSize / scale));
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -179,12 +187,19 @@ namespace Robust.Client.UserInterface.Controls
 
         protected override Vector2 CalculateMinimumSize()
         {
-            if (_texture == null || CanShrink)
+            var texture = _texture;
+
+            if (texture == null)
+            {
+                TryGetStyleProperty(StylePropertyTexture, out texture);
+            }
+
+            if (texture == null || CanShrink)
             {
                 return Vector2.Zero;
             }
 
-            return Texture.Size * TextureScale;
+            return texture.Size * TextureScale;
         }
     }
 }

--- a/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
+++ b/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
@@ -116,7 +116,6 @@ namespace Robust.Client.UserInterface.CustomControls
 
                             (OverrideMenu = new OptionButton
                             {
-                                ToggleMode = false,
                                 SizeFlagsHorizontal = SizeFlags.FillExpand,
                                 ToolTip = _loc.GetString("Override placement")
                             })

--- a/Robust.Client/UserInterface/CustomControls/OptionsMenu.cs
+++ b/Robust.Client/UserInterface/CustomControls/OptionsMenu.cs
@@ -39,7 +39,7 @@ namespace Robust.Client.UserInterface.CustomControls
 
             ApplyButton = new Button
             {
-                Text = "Apply", TextAlign = Button.AlignMode.Center,
+                Text = "Apply", TextAlign = Label.AlignMode.Center,
                 SizeFlagsVertical = SizeFlags.ShrinkCenter
             };
             vBox.AddChild(ApplyButton);

--- a/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceEntity.cs
+++ b/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceEntity.cs
@@ -124,7 +124,7 @@ namespace Robust.Client.ViewVariables.Instances
             var componentList = _entity.GetAllComponents().OrderBy(c => c.GetType().ToString());
             foreach (var component in componentList)
             {
-                var button = new Button {Text = TypeAbbreviation.Abbreviate(component.GetType().ToString()), TextAlign = Button.AlignMode.Left};
+                var button = new Button {Text = TypeAbbreviation.Abbreviate(component.GetType().ToString()), TextAlign = Label.AlignMode.Left};
                 button.OnPressed += args => { ViewVariablesManager.OpenVV(component); };
                 clientComponents.AddChild(button);
             }
@@ -220,7 +220,7 @@ namespace Robust.Client.ViewVariables.Instances
             componentsBlob.ComponentTypes.Sort();
             foreach (var componentType in componentsBlob.ComponentTypes.OrderBy(t => t.Stringified))
             {
-                var button = new Button {Text = componentType.Stringified, TextAlign = Button.AlignMode.Left};
+                var button = new Button {Text = componentType.Stringified, TextAlign = Label.AlignMode.Left};
                 button.OnPressed += args =>
                 {
                     ViewVariablesManager.OpenVV(


### PR DESCRIPTION
Implements ContainerButton which is a button that resizes to fit the Controls it is a parent of.

Refactors OptionButton to use ContainerButton so that an inverted triangle can be added to make it more obvious that the button is an OptionButton.

Content side is space-wizards/space-station-14#700

Part of fixing #859