### PR TITLE
Game state netcode improvements

### DIFF
--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Robust.Server.Interfaces.GameObjects;
 using Robust.Server.Interfaces.Timing;
@@ -192,11 +192,6 @@ namespace Robust.Server.GameObjects
         {
             var compStates = new List<ComponentState>();
             var changed = new List<ComponentChanged>();
-
-            if (entityUid == new EntityUid(295))
-            {
-
-            }
 
             foreach (var comp in compMan.GetNetComponents(entityUid))
             {

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -202,8 +202,12 @@ namespace Robust.Server.GameObjects
             {
                 DebugTools.Assert(comp.Initialized);
 
-                //Ticks start at 1
-                //DebugTools.Assert(comp.CreationTick != GameTick.Zero && comp.LastModifiedTick != GameTick.Zero);
+                // NOTE: When LastModifiedTick or CreationTick are 0 it means that the relevant data is
+                // "not different from entity creation".
+                // i.e. when the client spawns the entity and loads the entity prototype,
+                // the data it deserializes from the prototype SHOULD be equal
+                // to what the component state / ComponentChanged would send.
+                // As such, we can avoid sending this data in this case since the client "already has it".
 
                 if (comp.NetSyncEnabled && comp.LastModifiedTick != GameTick.Zero && comp.LastModifiedTick >= fromTick)
                     compStates.Add(comp.GetComponentState());

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Robust.Server.Interfaces.GameObjects;
 using Robust.Server.Interfaces.Timing;
@@ -59,7 +59,7 @@ namespace Robust.Server.GameObjects
                 // As such, we can reset the modified ticks to Zero,
                 // which indicates "not different from client's own deserialization".
                 // So the initial data for the component or even the creation doesn't have to be sent over the wire.
-                foreach (var component in newEntity.GetAllComponents())
+                foreach (var component in ComponentManager.GetNetComponents(newEntity.Uid))
                 {
                     ((Component)component).ClearTicks();
                 }

--- a/Robust.Shared/GameObjects/Component.cs
+++ b/Robust.Shared/GameObjects/Component.cs
@@ -207,6 +207,8 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public virtual void HandleComponentState(ComponentState curState, ComponentState nextState) { }
 
+        // these two methods clear the LastModifiedTick/CreationTick to mark it as "not different from prototype load".
+        // This is used as optimization in the game state system to avoid sending redundant component data.
         internal virtual void ClearTicks()
         {
             LastModifiedTick = GameTick.Zero;

--- a/Robust.Shared/GameObjects/Component.cs
+++ b/Robust.Shared/GameObjects/Component.cs
@@ -100,6 +100,8 @@ namespace Robust.Shared.GameObjects
 
             if (Deleted)
                 throw new InvalidOperationException("Cannot Add a Deleted component!");
+
+            CreationTick = Owner.EntityManager.CurrentTick;
         }
 
         /// <inheritdoc />
@@ -115,8 +117,6 @@ namespace Robust.Shared.GameObjects
                 throw new InvalidOperationException("Cannot Initialize a Deleted component!");
 
             Initialized = true;
-
-            CreationTick = Owner.EntityManager.CurrentTick;
         }
 
         /// <summary>
@@ -206,5 +206,16 @@ namespace Robust.Shared.GameObjects
 
         /// <inheritdoc />
         public virtual void HandleComponentState(ComponentState curState, ComponentState nextState) { }
+
+        internal virtual void ClearTicks()
+        {
+            LastModifiedTick = GameTick.Zero;
+            ClearCreationTick();
+        }
+
+        internal void ClearCreationTick()
+        {
+            CreationTick = GameTick.Zero;
+        }
     }
 }

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -171,5 +171,14 @@ namespace Robust.Shared.GameObjects
             //    s => _prototypes.Index<EntityPrototype>(s),
             //    p => p.ID);
         }
+
+        internal override void ClearTicks()
+        {
+            // Do not clear modified ticks.
+            // MetaDataComponent is used in the game state system to carry initial data like prototype ID.
+            // So it ALWAYS has to be sent.
+            // (Creation can still be cleared though)
+            ClearCreationTick();
+        }
     }
 }

--- a/Robust.Shared/Network/Messages/MsgState.cs
+++ b/Robust.Shared/Network/Messages/MsgState.cs
@@ -11,13 +11,25 @@ namespace Robust.Shared.Network.Messages
 {
     public class MsgState : NetMessage
     {
+        // If a state is large enough we send it ReliableUnordered instead.
+        // This is to avoid states being so large that they consistently fail to reach the other end
+        // (due to being in many parts).
+        public const int ReliableThreshold = 1300;
+
         #region REQUIRED
+
         public static readonly MsgGroups GROUP = MsgGroups.Entity;
         public static readonly string NAME = nameof(MsgState);
-        public MsgState(INetChannel channel) : base(NAME, GROUP) { }
+
+        public MsgState(INetChannel channel) : base(NAME, GROUP)
+        {
+        }
+
         #endregion
 
         public GameState State { get; set; }
+
+        private bool _hasWritten;
 
         public override void ReadFromBuffer(NetIncomingMessage buffer)
         {
@@ -40,10 +52,41 @@ namespace Robust.Shared.Network.Messages
             {
                 DebugTools.Assert(stateStream.Length <= Int32.MaxValue);
                 serializer.Serialize(stateStream, State);
-                buffer.WriteVariableInt32((int)stateStream.Length);
+                buffer.WriteVariableInt32((int) stateStream.Length);
                 buffer.Write(stateStream.ToArray());
             }
+
+            _hasWritten = false;
             MsgSize = buffer.LengthBytes;
+        }
+
+        /// <summary>
+        ///     Whether this state message is large enough to warrant being sent reliably.
+        ///     This is only valid after
+        /// </summary>
+        /// <returns></returns>
+        public bool ShouldSendReliably()
+        {
+            // This check will be true in integration tests.
+            // TODO: Maybe handle this better so that packet loss integration testing can be done?
+            if (!_hasWritten)
+            {
+                return true;
+            }
+            return MsgSize > ReliableThreshold;
+        }
+
+        public override NetDeliveryMethod DeliveryMethod
+        {
+            get
+            {
+                if (ShouldSendReliably())
+                {
+                    return NetDeliveryMethod.ReliableUnordered;
+                }
+
+                return base.DeliveryMethod;
+            }
         }
     }
 }

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -739,7 +739,7 @@ namespace Robust.Shared.Network
             foreach (var peer in _netPeers)
             {
                 var packet = BuildMessage(message, peer);
-                var method = GetMethod(message.MsgGroup);
+                var method = message.DeliveryMethod;
                 if (peer.ConnectionsCount == 0)
                 {
                     continue;
@@ -758,7 +758,8 @@ namespace Robust.Shared.Network
 
             var peer = channel.Connection.Peer;
             var packet = BuildMessage(message, peer);
-            peer.SendMessage(packet, channel.Connection, NetDeliveryMethod.ReliableOrdered);
+            var method = message.DeliveryMethod;
+            peer.SendMessage(packet, channel.Connection, method);
         }
 
         /// <inheritdoc />
@@ -788,7 +789,7 @@ namespace Robust.Shared.Network
 
             var peer = _netPeers[0];
             var packet = BuildMessage(message, peer);
-            var method = GetMethod(message.MsgGroup);
+            var method = message.DeliveryMethod;
             peer.SendMessage(packet, peer.Connections[0], method);
         }
 
@@ -832,22 +833,6 @@ namespace Robust.Shared.Network
         public event EventHandler<NetChannelArgs> Disconnect;
 
         #endregion Events
-
-        private static NetDeliveryMethod GetMethod(MsgGroups group)
-        {
-            switch (group)
-            {
-                case MsgGroups.Entity:
-                    return NetDeliveryMethod.Unreliable;
-                case MsgGroups.Core:
-                case MsgGroups.String:
-                case MsgGroups.Command:
-                case MsgGroups.EntityEvent:
-                    return NetDeliveryMethod.ReliableUnordered;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(group), group, null);
-            }
-        }
 
         private enum ClientConnectionState
         {

--- a/Robust.Shared/Network/NetMessage.cs
+++ b/Robust.Shared/Network/NetMessage.cs
@@ -1,4 +1,5 @@
-﻿using Lidgren.Network;
+﻿using System;
+using Lidgren.Network;
 using Robust.Shared.Interfaces.Network;
 
 namespace Robust.Shared.Network
@@ -86,5 +87,24 @@ namespace Robust.Shared.Network
         /// </summary>
         /// <param name="buffer">The buffer of the new packet being serialized.</param>
         public abstract void WriteToBuffer(NetOutgoingMessage buffer);
+
+        public virtual NetDeliveryMethod DeliveryMethod
+        {
+            get
+            {
+                switch (MsgGroup)
+                {
+                    case MsgGroups.Entity:
+                        return NetDeliveryMethod.Unreliable;
+                    case MsgGroups.Core:
+                    case MsgGroups.String:
+                    case MsgGroups.Command:
+                    case MsgGroups.EntityEvent:
+                        return NetDeliveryMethod.ReliableUnordered;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #976 

Reduces bandwidth usage of the netcode significantly and avoids spamming huge game states at Lidgren reliably.