### PR TITLE
EntitySystem Event Refactor

### DIFF
--- a/Robust.Client/GameObjects/ClientEntityNetworkManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityNetworkManager.cs
@@ -78,7 +78,7 @@ namespace Robust.Client.GameObjects
                     return;
 
                 case EntityMessageType.SystemMessage:
-                    _entityManager.EventBus.RaiseEvent(message.SystemMessage);
+                    _entityManager.EventBus.RaiseEvent(EventSource.Network, message.SystemMessage);
                     return;
             }
         }

--- a/Robust.Client/GameObjects/ClientEntityNetworkManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityNetworkManager.cs
@@ -78,7 +78,7 @@ namespace Robust.Client.GameObjects
                     return;
 
                 case EntityMessageType.SystemMessage:
-                    _entityManager.EventBus.RaiseEvent(this, message.SystemMessage);
+                    _entityManager.EventBus.RaiseEvent(message.SystemMessage);
                     return;
             }
         }

--- a/Robust.Client/GameObjects/ClientEntityNetworkManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityNetworkManager.cs
@@ -78,7 +78,7 @@ namespace Robust.Client.GameObjects
                     return;
 
                 case EntityMessageType.SystemMessage:
-                    _entitySystemManager.HandleSystemMessage(message);
+                    _entityManager.EventBus.RaiseEvent(this, message.SystemMessage);
                     return;
             }
         }

--- a/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
@@ -6,7 +6,6 @@ using Robust.Shared.Audio;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.Interfaces.GameObjects;
-using Robust.Shared.Interfaces.Network;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Client.Interfaces.Graphics;
@@ -14,7 +13,6 @@ using Robust.Shared.Interfaces.Map;
 using Robust.Shared.Map;
 using Robust.Shared.Utility;
 using System.Collections.Generic;
-using System.IO;
 using JetBrains.Annotations;
 
 namespace Robust.Client.GameObjects.EntitySystems
@@ -23,26 +21,52 @@ namespace Robust.Client.GameObjects.EntitySystems
     public class AudioSystem : EntitySystem
     {
 #pragma warning disable 649
-        [Dependency] private readonly IResourceCache resourceCache;
+        [Dependency] private readonly IResourceCache _resourceCache;
         [Dependency] private readonly IMapManager _mapManager;
         [Dependency] private readonly IClydeAudio _clyde;
 #pragma warning restore 649
 
-        private readonly List<PlayingStream> PlayingClydeStreams = new List<PlayingStream>();
+        private readonly List<PlayingStream> _playingClydeStreams = new List<PlayingStream>();
 
-        public override void RegisterMessageTypes()
+        /// <inheritdoc />
+        public override void Initialize()
         {
-            base.RegisterMessageTypes();
+            SubscribeEvent<PlayAudioEntityMessage>(PlayAudioEntityHandler);
+            SubscribeEvent<PlayAudioGlobalMessage>(PlayAudioGlobalHandler);
+            SubscribeEvent<PlayAudioPositionalMessage>(PlayAudioPositionalHandler);
+        }
 
-            RegisterMessageType<PlayAudioEntityMessage>();
-            RegisterMessageType<PlayAudioGlobalMessage>();
-            RegisterMessageType<PlayAudioPositionalMessage>();
+        private void PlayAudioPositionalHandler(object sender, PlayAudioPositionalMessage ev)
+        {
+            if (!_mapManager.GridExists(ev.Coordinates.GridID))
+            {
+                Logger.Error($"Server tried to play sound on grid {ev.Coordinates.GridID.Value}, which does not exist. Ignoring.");
+                return;
+            }
+
+            Play(ev.FileName, ev.Coordinates, ev.AudioParams);
+        }
+
+        private void PlayAudioGlobalHandler(object sender, PlayAudioGlobalMessage ev)
+        {
+            Play(ev.FileName, ev.AudioParams);
+        }
+
+        private void PlayAudioEntityHandler(object sender, PlayAudioEntityMessage ev)
+        {
+            if (!EntityManager.TryGetEntity(ev.EntityUid, out var entity))
+            {
+                Logger.Error($"Server tried to play audio file {ev.FileName} on entity {ev.EntityUid} which does not exist.");
+                return;
+            }
+
+            Play(ev.FileName, entity, ev.AudioParams);
         }
 
         public override void FrameUpdate(float frameTime)
         {
             // Update positions of streams every frame.
-            foreach (var stream in PlayingClydeStreams)
+            foreach (var stream in _playingClydeStreams)
             {
                 if (!stream.Source.IsPlaying)
                 {
@@ -62,7 +86,7 @@ namespace Robust.Client.GameObjects.EntitySystems
                 }
             }
 
-            PlayingClydeStreams.RemoveAll(p => p.Done);
+            _playingClydeStreams.RemoveAll(p => p.Done);
         }
 
         /// <summary>
@@ -72,7 +96,13 @@ namespace Robust.Client.GameObjects.EntitySystems
         /// <param name="audioParams"></param>
         public IPlayingAudioStream Play(string filename, AudioParams? audioParams = null)
         {
-            return Play(resourceCache.GetResource<AudioResource>(new ResourcePath(filename)), audioParams);
+            if (_resourceCache.TryGetResource<AudioResource>(new ResourcePath(filename), out var audio))
+            {
+                return Play(audio, audioParams);
+            }
+
+            Logger.Error($"Server tried to play audio file {filename} which does not exist.");
+            return default;
         }
 
         /// <summary>
@@ -91,7 +121,7 @@ namespace Robust.Client.GameObjects.EntitySystems
             {
                 Source = source
             };
-            PlayingClydeStreams.Add(playing);
+            _playingClydeStreams.Add(playing);
             return playing;
         }
 
@@ -103,7 +133,13 @@ namespace Robust.Client.GameObjects.EntitySystems
         /// <param name="audioParams"></param>
         public IPlayingAudioStream Play(string filename, IEntity entity, AudioParams? audioParams = null)
         {
-            return Play(resourceCache.GetResource<AudioResource>(new ResourcePath(filename)), entity, audioParams);
+            if (_resourceCache.TryGetResource<AudioResource>(new ResourcePath(filename), out var audio))
+            {
+                return Play(audio, entity, audioParams);
+            }
+
+            Logger.Error($"Server tried to play audio file {filename} which does not exist.");
+            return default;
         }
 
         /// <summary>
@@ -124,7 +160,7 @@ namespace Robust.Client.GameObjects.EntitySystems
                 Source = source,
                 TrackingEntity = entity,
             };
-            PlayingClydeStreams.Add(playing);
+            _playingClydeStreams.Add(playing);
             return playing;
         }
 
@@ -136,7 +172,13 @@ namespace Robust.Client.GameObjects.EntitySystems
         /// <param name="audioParams"></param>
         public IPlayingAudioStream Play(string filename, GridCoordinates coordinates, AudioParams? audioParams = null)
         {
-            return Play(resourceCache.GetResource<AudioResource>(new ResourcePath(filename)), coordinates, audioParams);
+            if(_resourceCache.TryGetResource<AudioResource>(new ResourcePath(filename), out var audio))
+            {
+                return Play(audio, coordinates, audioParams);
+            }
+
+            Logger.Error($"Server tried to play audio file {filename} which does not exist.");
+            return default;
         }
 
         /// <summary>
@@ -158,7 +200,7 @@ namespace Robust.Client.GameObjects.EntitySystems
                 Source = source,
                 TrackingCoordinates = coordinates,
             };
-            PlayingClydeStreams.Add(playing);
+            _playingClydeStreams.Add(playing);
             return playing;
         }
 
@@ -173,51 +215,6 @@ namespace Robust.Client.GameObjects.EntitySystems
             source.SetVolume(audioParams.Value.Volume);
             source.SetPlaybackPosition(audioParams.Value.PlayOffsetSeconds);
             source.IsLooping = audioParams.Value.Loop;
-        }
-
-        public override void HandleNetMessage(INetChannel channel, EntitySystemMessage message)
-        {
-            base.HandleNetMessage(channel, message);
-
-            if (!(message is AudioMessage msg))
-            {
-                return;
-            }
-
-            try
-            {
-                switch (message)
-                {
-                    case PlayAudioGlobalMessage globalmsg:
-                        Play(globalmsg.FileName, globalmsg.AudioParams);
-                        break;
-
-                    case PlayAudioEntityMessage entitymsg:
-                        if (!EntityManager.TryGetEntity(entitymsg.EntityUid, out var entity))
-                        {
-                            Logger.Error(
-                                $"Server tried to play audio file {entitymsg.FileName} on entity {entitymsg.EntityUid} which does not exist.");
-                            break;
-                        }
-
-                        Play(entitymsg.FileName, entity, entitymsg.AudioParams);
-                        break;
-
-                    case PlayAudioPositionalMessage posmsg:
-                        if (!_mapManager.GridExists(posmsg.Coordinates.GridID))
-                        {
-                            Logger.Error($"Server tried to play sound on grid {posmsg.Coordinates.GridID.Value}, which does not exist. Ignoring.");
-                            break;
-                        }
-
-                        Play(posmsg.FileName, posmsg.Coordinates, posmsg.AudioParams);
-                        break;
-                }
-            }
-            catch (FileNotFoundException)
-            {
-                Logger.Error($"Server tried to play audio file {msg.FileName} which does not exist.");
-            }
         }
 
         private class PlayingStream : IPlayingAudioStream

--- a/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
@@ -31,9 +31,9 @@ namespace Robust.Client.GameObjects.EntitySystems
         /// <inheritdoc />
         public override void Initialize()
         {
-            SubscribeEvent<PlayAudioEntityMessage>(PlayAudioEntityHandler);
-            SubscribeEvent<PlayAudioGlobalMessage>(PlayAudioGlobalHandler);
-            SubscribeEvent<PlayAudioPositionalMessage>(PlayAudioPositionalHandler);
+            SubscribeNetworkEvent<PlayAudioEntityMessage>(PlayAudioEntityHandler);
+            SubscribeNetworkEvent<PlayAudioGlobalMessage>(PlayAudioGlobalHandler);
+            SubscribeNetworkEvent<PlayAudioPositionalMessage>(PlayAudioPositionalHandler);
         }
 
         private void PlayAudioPositionalHandler(PlayAudioPositionalMessage ev)

--- a/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
@@ -36,7 +36,7 @@ namespace Robust.Client.GameObjects.EntitySystems
             SubscribeEvent<PlayAudioPositionalMessage>(PlayAudioPositionalHandler);
         }
 
-        private void PlayAudioPositionalHandler(object sender, PlayAudioPositionalMessage ev)
+        private void PlayAudioPositionalHandler(PlayAudioPositionalMessage ev)
         {
             if (!_mapManager.GridExists(ev.Coordinates.GridID))
             {
@@ -47,12 +47,12 @@ namespace Robust.Client.GameObjects.EntitySystems
             Play(ev.FileName, ev.Coordinates, ev.AudioParams);
         }
 
-        private void PlayAudioGlobalHandler(object sender, PlayAudioGlobalMessage ev)
+        private void PlayAudioGlobalHandler(PlayAudioGlobalMessage ev)
         {
             Play(ev.FileName, ev.AudioParams);
         }
 
-        private void PlayAudioEntityHandler(object sender, PlayAudioEntityMessage ev)
+        private void PlayAudioEntityHandler(PlayAudioEntityMessage ev)
         {
             if (!EntityManager.TryGetEntity(ev.EntityUid, out var entity))
             {

--- a/Robust.Client/GameObjects/EntitySystems/EffectSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/EffectSystem.cs
@@ -39,7 +39,7 @@ namespace Robust.Client.GameObjects
         {
             base.Initialize();
 
-            SubscribeEvent<EffectSystemMessage>((sender, ev) => CreateEffect(ev));
+            SubscribeEvent<EffectSystemMessage>(CreateEffect);
 
             var overlay = new EffectOverlay(this, prototypeManager, _mapManager);
             overlayManager.AddOverlay(overlay);

--- a/Robust.Client/GameObjects/EntitySystems/EffectSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/EffectSystem.cs
@@ -39,7 +39,8 @@ namespace Robust.Client.GameObjects
         {
             base.Initialize();
 
-            SubscribeEvent<EffectSystemMessage>(CreateEffect);
+            SubscribeNetworkEvent<EffectSystemMessage>(CreateEffect);
+            SubscribeLocalEvent<EffectSystemMessage>(CreateEffect);
 
             var overlay = new EffectOverlay(this, prototypeManager, _mapManager);
             overlayManager.AddOverlay(overlay);

--- a/Robust.Client/GameObjects/EntitySystems/EffectSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/EffectSystem.cs
@@ -4,10 +4,8 @@ using Robust.Client.Graphics.Drawing;
 using Robust.Client.Interfaces.Graphics.ClientEye;
 using Robust.Client.Interfaces.ResourceManagement;
 using Robust.Client.ResourceManagement;
-using Robust.Shared.GameObjects;
 using Robust.Shared.GameObjects.EntitySystemMessages;
 using Robust.Shared.GameObjects.Systems;
-using Robust.Shared.Interfaces.Network;
 using Robust.Shared.Interfaces.Timing;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
@@ -41,6 +39,8 @@ namespace Robust.Client.GameObjects
         {
             base.Initialize();
 
+            SubscribeEvent<EffectSystemMessage>((sender, ev) => CreateEffect(ev));
+
             var overlay = new EffectOverlay(this, prototypeManager, _mapManager);
             overlayManager.AddOverlay(overlay);
         }
@@ -50,25 +50,6 @@ namespace Robust.Client.GameObjects
             base.Shutdown();
 
             overlayManager.RemoveOverlay("EffectSystem");
-        }
-
-        public override void RegisterMessageTypes()
-        {
-            base.RegisterMessageTypes();
-
-            RegisterMessageType<EffectSystemMessage>();
-        }
-
-        public override void HandleNetMessage(INetChannel channel, EntitySystemMessage message)
-        {
-            base.HandleNetMessage(channel, message);
-
-            switch (message)
-            {
-                case EffectSystemMessage msg:
-                    CreateEffect(msg);
-                    break;
-            }
         }
 
         public void CreateEffect(EffectSystemMessage message)

--- a/Robust.Client/GameObjects/EntitySystems/InputSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/InputSystem.cs
@@ -67,7 +67,7 @@ namespace Robust.Client.GameObjects.EntitySystems
 
         public override void Initialize()
         {
-            SubscribeEvent<PlayerAttachSysMessage>(OnAttachedEntityChanged);
+            SubscribeLocalEvent<PlayerAttachSysMessage>(OnAttachedEntityChanged);
         }
 
         private void OnAttachedEntityChanged(PlayerAttachSysMessage message)

--- a/Robust.Client/GameObjects/EntitySystems/InputSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/InputSystem.cs
@@ -65,22 +65,16 @@ namespace Robust.Client.GameObjects.EntitySystems
             RaiseNetworkEvent(message);
         }
 
-        /// <inheritdoc />
-        public override void SubscribeEvents()
+        public override void Initialize()
         {
-            base.SubscribeEvents();
-
             SubscribeEvent<PlayerAttachSysMessage>(OnAttachedEntityChanged);
         }
 
-        private void OnAttachedEntityChanged(object sender, EntitySystemMessage message)
+        private void OnAttachedEntityChanged(object sender, PlayerAttachSysMessage message)
         {
-            if(!(message is PlayerAttachSysMessage msg))
-                return;
-
-            if (msg.AttachedEntity != null) // attach
+            if (message.AttachedEntity != null) // attach
             {
-                SetEntityContextActive(_inputManager, msg.AttachedEntity);
+                SetEntityContextActive(_inputManager, message.AttachedEntity);
             }
             else // detach
             {

--- a/Robust.Client/GameObjects/EntitySystems/InputSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/InputSystem.cs
@@ -70,7 +70,7 @@ namespace Robust.Client.GameObjects.EntitySystems
             SubscribeEvent<PlayerAttachSysMessage>(OnAttachedEntityChanged);
         }
 
-        private void OnAttachedEntityChanged(object sender, PlayerAttachSysMessage message)
+        private void OnAttachedEntityChanged(PlayerAttachSysMessage message)
         {
             if (message.AttachedEntity != null) // attach
             {

--- a/Robust.Client/Player/LocalPlayer.cs
+++ b/Robust.Client/Player/LocalPlayer.cs
@@ -2,6 +2,7 @@
 using Robust.Client.GameObjects;
 using Robust.Client.GameObjects.EntitySystems;
 using Robust.Shared.Enums;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.Configuration;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
@@ -84,7 +85,7 @@ namespace Robust.Client.Player
             entity.SendMessage(null, new PlayerAttachedMsg());
 
             // notify ECS Systems
-            ControlledEntity.EntityManager.EventBus.RaiseEvent(new PlayerAttachSysMessage(ControlledEntity));
+            ControlledEntity.EntityManager.EventBus.RaiseEvent(EventSource.Local, new PlayerAttachSysMessage(ControlledEntity));
         }
 
         /// <summary>
@@ -99,7 +100,7 @@ namespace Robust.Client.Player
                 previous.SendMessage(null, new PlayerDetachedMsg());
 
                 // notify ECS Systems
-                previous.EntityManager.EventBus.RaiseEvent(new PlayerAttachSysMessage(null));
+                previous.EntityManager.EventBus.RaiseEvent(EventSource.Local, new PlayerAttachSysMessage(null));
             }
 
             ControlledEntity = null;

--- a/Robust.Client/Player/LocalPlayer.cs
+++ b/Robust.Client/Player/LocalPlayer.cs
@@ -84,7 +84,7 @@ namespace Robust.Client.Player
             entity.SendMessage(null, new PlayerAttachedMsg());
 
             // notify ECS Systems
-            ControlledEntity.EntityManager.EventBus.RaiseEvent(this, new PlayerAttachSysMessage(ControlledEntity));
+            ControlledEntity.EntityManager.EventBus.RaiseEvent(new PlayerAttachSysMessage(ControlledEntity));
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace Robust.Client.Player
                 previous.SendMessage(null, new PlayerDetachedMsg());
 
                 // notify ECS Systems
-                previous.EntityManager.EventBus.RaiseEvent(this, new PlayerAttachSysMessage(null));
+                previous.EntityManager.EventBus.RaiseEvent(new PlayerAttachSysMessage(null));
             }
 
             ControlledEntity = null;

--- a/Robust.Server/GameObjects/Components/Container/Container.cs
+++ b/Robust.Server/GameObjects/Components/Container/Container.cs
@@ -139,7 +139,7 @@ namespace Robust.Server.GameObjects.Components.Container
         {
             DebugTools.Assert(!Deleted);
 
-            Owner.EntityManager.EventBus.RaiseEvent(new EntInsertedIntoContainerMessage(toinsert, this));
+            Owner.EntityManager.EventBus.RaiseEvent(EventSource.Local, new EntInsertedIntoContainerMessage(toinsert, this));
             Manager.Owner.SendMessage(Manager, new ContainerContentsModifiedMessage(this, toinsert, false));
             Manager.Dirty();
         }
@@ -198,7 +198,7 @@ namespace Robust.Server.GameObjects.Components.Container
             DebugTools.Assert(Manager != null);
             DebugTools.Assert(toremove != null && toremove.IsValid());
 
-            Owner?.EntityManager.EventBus.RaiseEvent(new EntRemovedFromContainerMessage(toremove, this));
+            Owner?.EntityManager.EventBus.RaiseEvent(EventSource.Local, new EntRemovedFromContainerMessage(toremove, this));
 
             Manager.Owner.SendMessage(Manager, new ContainerContentsModifiedMessage(this, toremove, true));
             Manager.Dirty();

--- a/Robust.Server/GameObjects/Components/Container/Container.cs
+++ b/Robust.Server/GameObjects/Components/Container/Container.cs
@@ -139,7 +139,7 @@ namespace Robust.Server.GameObjects.Components.Container
         {
             DebugTools.Assert(!Deleted);
 
-            Owner.EntityManager.EventBus.RaiseEvent(Owner, new EntInsertedIntoContainerMessage(toinsert, this));
+            Owner.EntityManager.EventBus.RaiseEvent(new EntInsertedIntoContainerMessage(toinsert, this));
             Manager.Owner.SendMessage(Manager, new ContainerContentsModifiedMessage(this, toinsert, false));
             Manager.Dirty();
         }
@@ -198,7 +198,7 @@ namespace Robust.Server.GameObjects.Components.Container
             DebugTools.Assert(Manager != null);
             DebugTools.Assert(toremove != null && toremove.IsValid());
 
-            Owner?.EntityManager.EventBus.RaiseEvent(Owner, new EntRemovedFromContainerMessage(toremove, this));
+            Owner?.EntityManager.EventBus.RaiseEvent(new EntRemovedFromContainerMessage(toremove, this));
 
             Manager.Owner.SendMessage(Manager, new ContainerContentsModifiedMessage(this, toremove, true));
             Manager.Dirty();

--- a/Robust.Server/GameObjects/EntitySystems/ContainerSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/ContainerSystem.cs
@@ -8,7 +8,7 @@ namespace Robust.Server.GameObjects.EntitySystems
     {
         public override void Initialize()
         {
-            SubscribeEvent<EntParentChangedMessage>(HandleParentChanged);
+            SubscribeLocalEvent<EntParentChangedMessage>(HandleParentChanged);
         }
 
         // Eject entities from their parent container if the parent change is done by the transform only.

--- a/Robust.Server/GameObjects/EntitySystems/ContainerSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/ContainerSystem.cs
@@ -12,7 +12,7 @@ namespace Robust.Server.GameObjects.EntitySystems
         }
 
         // Eject entities from their parent container if the parent change is done by the transform only.
-        private static void HandleParentChanged(object sender, EntParentChangedMessage message)
+        private static void HandleParentChanged(EntParentChangedMessage message)
         {
             var oldParentEntity = message.OldParent;
 

--- a/Robust.Server/GameObjects/EntitySystems/ContainerSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/ContainerSystem.cs
@@ -1,4 +1,4 @@
-using Robust.Shared.GameObjects.EntitySystemMessages;
+﻿using Robust.Shared.GameObjects.EntitySystemMessages;
 using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.Interfaces.GameObjects.Components;
 
@@ -6,10 +6,8 @@ namespace Robust.Server.GameObjects.EntitySystems
 {
     internal sealed class ContainerSystem : EntitySystem
     {
-        public override void SubscribeEvents()
+        public override void Initialize()
         {
-            base.SubscribeEvents();
-
             SubscribeEvent<EntParentChangedMessage>(HandleParentChanged);
         }
 

--- a/Robust.Server/GameObjects/EntitySystems/InputSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/InputSystem.cs
@@ -3,10 +3,8 @@ using System.Collections.Generic;
 using Robust.Server.Interfaces.Player;
 using Robust.Server.Player;
 using Robust.Shared.Enums;
-using Robust.Shared.GameObjects;
 using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.Input;
-using Robust.Shared.Interfaces.Network;
 using Robust.Shared.IoC;
 
 namespace Robust.Server.GameObjects.EntitySystems
@@ -29,14 +27,9 @@ namespace Robust.Server.GameObjects.EntitySystems
         public ICommandBindMapping BindMap => _bindMap;
 
         /// <inheritdoc />
-        public override void RegisterMessageTypes()
-        {
-            RegisterMessageType<FullInputCmdMessage>();
-        }
-
-        /// <inheritdoc />
         public override void Initialize()
         {
+            SubscribeEvent<FullInputCmdMessage>((sender, ev) => InputMessageHandler(ev));
             _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
         }
 
@@ -46,9 +39,12 @@ namespace Robust.Server.GameObjects.EntitySystems
             _playerManager.PlayerStatusChanged -= OnPlayerStatusChanged;
         }
 
-        /// <inheritdoc />
-        public override void HandleNetMessage(INetChannel channel, EntitySystemMessage message)
+        private void InputMessageHandler(InputCmdMessage message)
         {
+            var channel = message.NetChannel;
+            if(channel == null)
+                return;
+
             if (!(message is FullInputCmdMessage msg))
                 return;
 

--- a/Robust.Server/GameObjects/EntitySystems/InputSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/InputSystem.cs
@@ -29,7 +29,7 @@ namespace Robust.Server.GameObjects.EntitySystems
         /// <inheritdoc />
         public override void Initialize()
         {
-            SubscribeEvent<FullInputCmdMessage>(InputMessageHandler);
+            SubscribeNetworkEvent<FullInputCmdMessage>(InputMessageHandler);
             _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
         }
 

--- a/Robust.Server/GameObjects/EntitySystems/InputSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/InputSystem.cs
@@ -29,7 +29,7 @@ namespace Robust.Server.GameObjects.EntitySystems
         /// <inheritdoc />
         public override void Initialize()
         {
-            SubscribeEvent<FullInputCmdMessage>((sender, ev) => InputMessageHandler(ev));
+            SubscribeEvent<FullInputCmdMessage>(InputMessageHandler);
             _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
         }
 

--- a/Robust.Server/GameObjects/ServerEntityNetworkManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityNetworkManager.cs
@@ -102,7 +102,7 @@ namespace Robust.Server.GameObjects
                     return;
 
                 case EntityMessageType.SystemMessage:
-                    _entitySystemManager.HandleSystemMessage(message);
+                    _entityManager.EventBus.RaiseEvent(this, message.SystemMessage);
                     return;
             }
         }

--- a/Robust.Server/GameObjects/ServerEntityNetworkManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityNetworkManager.cs
@@ -102,7 +102,7 @@ namespace Robust.Server.GameObjects
                     return;
 
                 case EntityMessageType.SystemMessage:
-                    _entityManager.EventBus.RaiseEvent(message.SystemMessage);
+                    _entityManager.EventBus.RaiseEvent(EventSource.Network, message.SystemMessage);
                     return;
             }
         }

--- a/Robust.Server/GameObjects/ServerEntityNetworkManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityNetworkManager.cs
@@ -102,7 +102,7 @@ namespace Robust.Server.GameObjects
                     return;
 
                 case EntityMessageType.SystemMessage:
-                    _entityManager.EventBus.RaiseEvent(this, message.SystemMessage);
+                    _entityManager.EventBus.RaiseEvent(message.SystemMessage);
                     return;
             }
         }

--- a/Robust.Server/Player/PlayerSession.cs
+++ b/Robust.Server/Player/PlayerSession.cs
@@ -91,7 +91,7 @@ namespace Robust.Server.Player
             actorComponent.playerSession = this;
             AttachedEntity = a;
             a.SendMessage(actorComponent, new PlayerAttachedMsg(this));
-            a.EntityManager.EventBus.RaiseEvent(this, new PlayerAttachSystemMessage(a, this));
+            a.EntityManager.EventBus.RaiseEvent(new PlayerAttachSystemMessage(a, this));
             SetAttachedEntityName();
             UpdatePlayerState();
         }
@@ -110,7 +110,7 @@ namespace Robust.Server.Player
             if (AttachedEntity.TryGetComponent<BasicActorComponent>(out var actor))
             {
                 AttachedEntity.SendMessage(actor, new PlayerDetachedMsg(this));
-                AttachedEntity.EntityManager.EventBus.RaiseEvent(this, new PlayerDetachedSystemMessage(AttachedEntity));
+                AttachedEntity.EntityManager.EventBus.RaiseEvent(new PlayerDetachedSystemMessage(AttachedEntity));
                 AttachedEntity.RemoveComponent<BasicActorComponent>();
                 AttachedEntity = null;
                 UpdatePlayerState();

--- a/Robust.Server/Player/PlayerSession.cs
+++ b/Robust.Server/Player/PlayerSession.cs
@@ -71,7 +71,7 @@ namespace Robust.Server.Player
         [ViewVariables]
         public NetSessionId SessionId { get; }
 
-        readonly PlayerData _data;
+        private readonly PlayerData _data;
         [ViewVariables] public IPlayerData Data => _data;
 
         /// <inheritdoc />
@@ -91,7 +91,7 @@ namespace Robust.Server.Player
             actorComponent.playerSession = this;
             AttachedEntity = a;
             a.SendMessage(actorComponent, new PlayerAttachedMsg(this));
-            a.EntityManager.EventBus.RaiseEvent(new PlayerAttachSystemMessage(a, this));
+            a.EntityManager.EventBus.RaiseEvent(EventSource.Local, new PlayerAttachSystemMessage(a, this));
             SetAttachedEntityName();
             UpdatePlayerState();
         }
@@ -110,7 +110,7 @@ namespace Robust.Server.Player
             if (AttachedEntity.TryGetComponent<BasicActorComponent>(out var actor))
             {
                 AttachedEntity.SendMessage(actor, new PlayerDetachedMsg(this));
-                AttachedEntity.EntityManager.EventBus.RaiseEvent(new PlayerDetachedSystemMessage(AttachedEntity));
+                AttachedEntity.EntityManager.EventBus.RaiseEvent(EventSource.Local, new PlayerDetachedSystemMessage(AttachedEntity));
                 AttachedEntity.RemoveComponent<BasicActorComponent>();
                 AttachedEntity = null;
                 UpdatePlayerState();

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Robust.Shared.Animations;
 using Robust.Shared.Containers;
-using Robust.Shared.Enums;
 using Robust.Shared.GameObjects.Components.Map;
 using Robust.Shared.GameObjects.EntitySystemMessages;
 using Robust.Shared.Interfaces.GameObjects;
@@ -13,7 +12,6 @@ using Robust.Shared.Interfaces.Timing;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
-using Robust.Shared.Physics;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
@@ -143,7 +141,7 @@ namespace Robust.Shared.GameObjects.Components.Transform
                 var entMessage = new EntParentChangedMessage(Owner, Parent?.Owner);
                 var compMessage = new ParentChangedMessage(value?.Owner, Parent?.Owner);
                 _parent = value?.Owner.Uid ?? EntityUid.Invalid;
-                Owner.EntityManager.EventBus.RaiseEvent(entMessage);
+                Owner.EntityManager.EventBus.RaiseEvent(EventSource.Local, entMessage);
                 Owner.SendMessage(this, compMessage);
             }
         }

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -143,7 +143,7 @@ namespace Robust.Shared.GameObjects.Components.Transform
                 var entMessage = new EntParentChangedMessage(Owner, Parent?.Owner);
                 var compMessage = new ParentChangedMessage(value?.Owner, Parent?.Owner);
                 _parent = value?.Owner.Uid ?? EntityUid.Invalid;
-                Owner.EntityManager.EventBus.RaiseEvent(Owner, entMessage);
+                Owner.EntityManager.EventBus.RaiseEvent(entMessage);
                 Owner.SendMessage(this, compMessage);
             }
         }

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -236,7 +236,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public void RaiseEvent(EntityEventArgs toRaise)
         {
-            EntityManager.EventBus.RaiseEvent(this, toRaise);
+            EntityManager.EventBus.RaiseEvent(toRaise);
         }
 
         #endregion Entity Events

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Robust.Shared.GameObjects.Components;
@@ -216,30 +216,6 @@ namespace Robust.Shared.GameObjects
         }
 
         #endregion Component Messaging
-
-        #region Entity Events
-
-        /// <inheritdoc />
-        public void SubscribeEvent<T>(EntityEventHandler<EntityEventArgs> evh, IEntityEventSubscriber s)
-            where T : EntityEventArgs
-        {
-            EntityManager.EventBus.SubscribeEvent(evh, s);
-        }
-
-        /// <inheritdoc />
-        public void UnsubscribeEvent<T>(IEntityEventSubscriber s)
-            where T : EntityEventArgs
-        {
-            EntityManager.EventBus.UnsubscribeEvent<T>(s);
-        }
-
-        /// <inheritdoc />
-        public void RaiseEvent(EntityEventArgs toRaise)
-        {
-            EntityManager.EventBus.RaiseEvent(toRaise);
-        }
-
-        #endregion Entity Events
 
         #region Components
 

--- a/Robust.Shared/GameObjects/EntityEvents.cs
+++ b/Robust.Shared/GameObjects/EntityEvents.cs
@@ -4,7 +4,7 @@ namespace Robust.Shared.GameObjects
 {
     public interface IEntityEventSubscriber { }
 
-    public delegate void EntityEventHandler<in T>(object sender, T ev)
+    public delegate void EntityEventHandler<in T>(T ev)
         where T : EntityEventArgs;
 
     public class EntityEventArgs : EventArgs { }

--- a/Robust.Shared/GameObjects/EntitySystemManager.cs
+++ b/Robust.Shared/GameObjects/EntitySystemManager.cs
@@ -6,78 +6,40 @@ using Robust.Shared.Interfaces.GameObjects.Systems;
 using Robust.Shared.Interfaces.Reflection;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
-using Robust.Shared.Network.Messages;
 
 namespace Robust.Shared.GameObjects
 {
     public class EntitySystemManager : IEntitySystemManager
     {
-        [Dependency]
 #pragma warning disable 649
-        private readonly IReflectionManager ReflectionManager;
-
-        [Dependency]
-        private readonly IDynamicTypeFactory _typeFactory;
+        [Dependency] private readonly IReflectionManager _reflectionManager;
+        [Dependency] private readonly IDynamicTypeFactory _typeFactory;
+        [Dependency] private readonly IEntityManager _entityManager;
 #pragma warning restore 649
 
         /// <summary>
         /// Maps system types to instances.
         /// </summary>
-        private readonly Dictionary<Type, IEntitySystem> Systems = new Dictionary<Type, IEntitySystem>();
-
-        /// <summary>
-        /// Maps child types of <see cref="EntitySystemMessage"/> to the system that will be receiving them.
-        /// </summary>
-        private readonly Dictionary<Type, IEntitySystem> SystemMessageTypes = new Dictionary<Type, IEntitySystem>();
-
-        /// <exception cref="InvalidOperationException">Thrown if the specified type is already registered by another system.</exception>
-        /// <exception cref="InvalidEntitySystemException">Thrown if the entity system instance is not registered with this <see cref="EntitySystemManager"/></exception>
-        /// <exception cref="ArgumentNullException">Thrown if the provided system is null.</exception>
-        public void RegisterMessageType<T>(IEntitySystem regSystem)
-            where T : EntitySystemMessage
-        {
-            if (regSystem == null)
-            {
-                throw new ArgumentNullException(nameof(regSystem));
-            }
-
-            Type type = typeof(T);
-
-            if (!Systems.ContainsValue(regSystem))
-            {
-                throw new InvalidEntitySystemException();
-            }
-
-            if (SystemMessageTypes.ContainsKey(type))
-            {
-                throw new InvalidOperationException(
-                    string.Format(
-                        "Duplicate EntitySystemMessage registration: {0} is already registered by {1}.",
-                        type,
-                        SystemMessageTypes[type].GetType()));
-            }
-
-            SystemMessageTypes.Add(type, regSystem);
-        }
+        private readonly Dictionary<Type, IEntitySystem> _systems = new Dictionary<Type, IEntitySystem>();
 
         /// <exception cref="InvalidEntitySystemException">Thrown if the provided type is not registered.</exception>
         public T GetEntitySystem<T>()
             where T : IEntitySystem
         {
-            Type type = typeof(T);
-            if (!Systems.ContainsKey(type))
+            var type = typeof(T);
+            if (!_systems.ContainsKey(type))
             {
                 throw new InvalidEntitySystemException();
             }
 
-            return (T)Systems[type];
+            return (T)_systems[type];
         }
 
         /// <inheritdoc />
         public bool TryGetEntitySystem<T>(out T entitySystem)
             where T : IEntitySystem
         {
-            if (Systems.TryGetValue(typeof(T), out var system))
+            if (_systems.TryGetValue(typeof(T), out var system))
             {
                 entitySystem = (T) system;
                 return true;
@@ -87,74 +49,69 @@ namespace Robust.Shared.GameObjects
             return false;
         }
 
+        /// <inheritdoc />
         public void Initialize()
         {
-            foreach (Type type in ReflectionManager.GetAllChildren<IEntitySystem>())
+            foreach (var type in _reflectionManager.GetAllChildren<IEntitySystem>())
             {
                 Logger.DebugS("go.sys", "Initializing entity system {0}", type);
                 //Force initialization of all systems
                 var instance = _typeFactory.CreateInstance<IEntitySystem>(type);
                 AddSystem(instance);
-                instance.RegisterMessageTypes();
-                instance.SubscribeEvents();
             }
 
-            foreach (IEntitySystem system in Systems.Values)
+            foreach (var system in _systems.Values)
+            {
                 system.Initialize();
+            }
         }
 
         private void AddSystem(IEntitySystem system)
         {
             var type = system.GetType();
-            if (Systems.ContainsKey(type))
+            if (_systems.ContainsKey(type))
             {
                 RemoveSystem(system);
             }
 
-            Systems.Add(type, system);
+            _systems.Add(type, system);
         }
 
         private void RemoveSystem(IEntitySystem system)
         {
             var type = system.GetType();
-            if (Systems.ContainsKey(type))
+            if (_systems.ContainsKey(type))
             {
-                Systems[type].Shutdown();
-                Systems.Remove(type);
+                _systems[type].Shutdown();
+                _entityManager.EventBus.UnsubscribeEvents(_systems[type]);
+                _systems.Remove(type);
             }
         }
 
+        /// <inheritdoc />
         public void Shutdown()
         {
             // System.Values is modified by RemoveSystem
-            var values = Systems.Values.ToArray();
+            var values = _systems.Values.ToArray();
             foreach (var system in values)
             {
                 RemoveSystem(system);
             }
-
-            SystemMessageTypes.Clear();
         }
 
-        public void HandleSystemMessage(MsgEntity sysMsg)
-        {
-            foreach (var current in SystemMessageTypes.Where(x => x.Key == sysMsg.SystemMessage.GetType()))
-            {
-                current.Value.HandleNetMessage(sysMsg.MsgChannel, sysMsg.SystemMessage);
-            }
-        }
-
+        /// <inheritdoc />
         public void Update(float frameTime)
         {
-            foreach (IEntitySystem system in Systems.Values)
+            foreach (var system in _systems.Values)
             {
                 system.Update(frameTime);
             }
         }
 
+        /// <inheritdoc />
         public void FrameUpdate(float frameTime)
         {
-            foreach (IEntitySystem system in Systems.Values)
+            foreach (var system in _systems.Values)
             {
                 system.FrameUpdate(frameTime);
             }

--- a/Robust.Shared/GameObjects/EntitySystemMessages/EntitySystemMessage.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/EntitySystemMessage.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Robust.Shared.Players;
+using Robust.Shared.Interfaces.Network;
 using Robust.Shared.Serialization;
 
 namespace Robust.Shared.GameObjects
@@ -8,7 +8,14 @@ namespace Robust.Shared.GameObjects
     public class EntitySystemMessage : EntityEventArgs
     {
         /// <summary>
-        ///     Entity this message is raised for.
+        /// Remote network channel this message came from.
+        /// If this is null, the message was raised locally.
+        /// </summary>
+        [field: NonSerialized]
+        public INetChannel NetChannel { get; set; }
+
+        /// <summary>
+        /// Entity this message is raised for.
         /// </summary>
         public EntityUid Owner { get; set; }
     }

--- a/Robust.Shared/GameObjects/Systems/EntitySystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntitySystem.cs
@@ -53,12 +53,12 @@ namespace Robust.Shared.GameObjects.Systems
 
         protected void RaiseEvent(EntitySystemMessage message)
         {
-            EntityManager.EventBus.RaiseEvent(this, message);
+            EntityManager.EventBus.RaiseEvent(message);
         }
 
         protected void QueueEvent(EntitySystemMessage message)
         {
-            EntityManager.EventBus.QueueEvent(this, message);
+            EntityManager.EventBus.QueueEvent(message);
         }
 
         protected void RaiseNetworkEvent(EntitySystemMessage message)

--- a/Robust.Shared/Interfaces/GameObjects/IEntity.cs
+++ b/Robust.Shared/Interfaces/GameObjects/IEntity.cs
@@ -195,14 +195,6 @@ namespace Robust.Shared.Interfaces.GameObjects
         /// <param name="message">Message to send.</param>
         void SendNetworkMessage(IComponent owner, ComponentMessage message, INetChannel channel = null);
 
-        void SubscribeEvent<T>(EntityEventHandler<EntityEventArgs> evh, IEntityEventSubscriber s)
-            where T : EntityEventArgs;
-
-        void UnsubscribeEvent<T>(IEntityEventSubscriber s)
-            where T : EntityEventArgs;
-
-        void RaiseEvent(EntityEventArgs toRaise);
-
         void Dirty();
     }
 }

--- a/Robust.Shared/Interfaces/GameObjects/IEntitySystemManager.cs
+++ b/Robust.Shared/Interfaces/GameObjects/IEntitySystemManager.cs
@@ -1,7 +1,4 @@
-﻿using Robust.Shared.IoC;
-using Robust.Shared.GameObjects;
-using Robust.Shared.Interfaces.GameObjects.Systems;
-using Robust.Shared.Network.Messages;
+﻿using Robust.Shared.Interfaces.GameObjects.Systems;
 
 namespace Robust.Shared.Interfaces.GameObjects
 {
@@ -15,26 +12,12 @@ namespace Robust.Shared.Interfaces.GameObjects
     /// <item>
     /// <description>Periodically ticking them through <see cref="IEntitySystem.Update(float)"/>.</description>
     /// </item>
-    /// <item>
-    /// <description>
-    /// Relaying <see cref="EntitySystemData"/> messages from the network through
-    /// <see cref="IEntitySystem.HandleNetMessage"/>.
-    /// </description>
-    /// </item>
     /// </list>
     /// Periodically ticks <see cref="IEntitySystem"/> instances.
     /// </remarks>
     /// <seealso cref="IEntitySystem"/>
     public interface IEntitySystemManager
     {
-        /// <summary>
-        /// Register an <see cref="EntitySystemMessage"/> type to be sent to the specified system.
-        /// </summary>
-        /// <typeparam name="T">The type of system message that will be relayed.</typeparam>
-        /// <param name="regSystem">The <see cref="IEntitySystem"/> that will be receiving the messages.</param>
-        /// <seealso cref="HandleSystemMessage(EntitySystemData)"/>
-        void RegisterMessageType<T>(IEntitySystem regSystem) where T : EntitySystemMessage;
-
         /// <summary>
         /// Get an entity system of the specified type.
         /// </summary>
@@ -61,14 +44,6 @@ namespace Robust.Shared.Interfaces.GameObjects
         /// </summary>
         /// <seealso cref="IEntitySystem.Shutdown"/>
         void Shutdown();
-
-        /// <summary>
-        /// Handle an <see cref="EntitySystemData"/> by routing it to the registered <see cref="IEntitySystem"/>.
-        /// </summary>
-        /// <param name="sysMsg">The message to route.</param>
-        /// <seealso cref="RegisterMessageType{T}(IEntitySystem)"/>
-        /// <seealso cref="IEntitySystem.HandleNetMessage"/>
-        void HandleSystemMessage(MsgEntity sysMsg);
 
         /// <summary>
         /// Update all systems.

--- a/Robust.Shared/Interfaces/GameObjects/Systems/IEntitySystem.cs
+++ b/Robust.Shared/Interfaces/GameObjects/Systems/IEntitySystem.cs
@@ -1,6 +1,4 @@
 ﻿using Robust.Shared.GameObjects;
-using Robust.Shared.Interfaces.Network;
-using Robust.Shared.Players;
 
 namespace Robust.Shared.Interfaces.GameObjects.Systems
 {
@@ -10,12 +8,8 @@ namespace Robust.Shared.Interfaces.GameObjects.Systems
     ///     They have a set of entities to run over and run every once in a while.
     ///     They get managed by an <see cref="IEntitySystemManager" />.
     /// </summary>
-    public interface IEntitySystem
+    public interface IEntitySystem : IEntityEventSubscriber
     {
-        void RegisterMessageTypes();
-
-        void SubscribeEvents();
-
         /// <summary>
         ///     Called once when the system is created to initialize its state.
         /// </summary>
@@ -25,13 +19,6 @@ namespace Robust.Shared.Interfaces.GameObjects.Systems
         ///     Called once before the system is destroyed so that the system can clean up.
         /// </summary>
         void Shutdown();
-
-        /// <summary>
-        /// Handler for all incoming network messages.
-        /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="message"></param>
-        void HandleNetMessage(INetChannel channel, EntitySystemMessage message);
 
         /// <summary>
         ///     Called once per frame/tick to update the system.

--- a/Robust.Shared/Network/Messages/MsgEntity.cs
+++ b/Robust.Shared/Network/Messages/MsgEntity.cs
@@ -40,6 +40,7 @@ namespace Robust.Shared.Network.Messages
                     using (var stream = new MemoryStream(buffer.ReadBytes(messageLength)))
                     {
                         SystemMessage = serializer.Deserialize<EntitySystemMessage>(stream);
+                        SystemMessage.NetChannel = MsgChannel;
                     }
                 }
                     break;

--- a/Robust.UnitTesting/Shared/GameObjects/EntityEventBus_Tests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityEventBus_Tests.cs
@@ -34,7 +34,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var bus = new EntityEventBus();
 
             // Act
-            void Code() => bus.SubscribeEvent<TestEventArgs>((sender, ev) => {}, null);
+            void Code() => bus.SubscribeEvent<TestEventArgs>(ev => {}, null);
 
             //Assert: this should do nothing
             Assert.Throws<ArgumentNullException>(Code);
@@ -52,14 +52,14 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var subscriber = new TestEventSubscriber();
 
             int delegateCallCount = 0;
-            void Handler(object sender, TestEventArgs ev) => delegateCallCount++;
+            void Handler(TestEventArgs ev) => delegateCallCount++;
 
             // 2 subscriptions 1 handler
             bus.SubscribeEvent<TestEventArgs>(Handler, subscriber);
             bus.SubscribeEvent<TestEventArgs>(Handler, subscriber);
 
             // Act
-            bus.RaiseEvent(null, new TestEventArgs());
+            bus.RaiseEvent(new TestEventArgs());
 
             //Assert
             Assert.That(delegateCallCount, Is.EqualTo(1));
@@ -79,11 +79,11 @@ namespace Robust.UnitTesting.Shared.GameObjects
             int delFooCount = 0;
             int delBarCount = 0;
 
-            bus.SubscribeEvent<TestEventArgs>((sender, ev) => delFooCount++, subscriber);
-            bus.SubscribeEvent<TestEventArgs>((sender, ev) => delBarCount++, subscriber);
+            bus.SubscribeEvent<TestEventArgs>(ev => delFooCount++, subscriber);
+            bus.SubscribeEvent<TestEventArgs>(ev => delBarCount++, subscriber);
 
             // Act
-            bus.RaiseEvent(null, new TestEventArgs());
+            bus.RaiseEvent(new TestEventArgs());
 
             // Assert
             Assert.That(delFooCount, Is.EqualTo(1));
@@ -103,17 +103,17 @@ namespace Robust.UnitTesting.Shared.GameObjects
             int delFooCount = 0;
             int delBarCount = 0;
 
-            bus.SubscribeEvent<TestEventArgs>((sender, ev) => delFooCount++, subscriber);
-            bus.SubscribeEvent<TestEventTwoArgs>((sender, ev) => delBarCount++, subscriber);
+            bus.SubscribeEvent<TestEventArgs>(ev => delFooCount++, subscriber);
+            bus.SubscribeEvent<TestEventTwoArgs>(ev => delBarCount++, subscriber);
 
             // Act & Assert
-            bus.RaiseEvent(null, new TestEventArgs());
+            bus.RaiseEvent(new TestEventArgs());
             Assert.That(delFooCount, Is.EqualTo(1));
             Assert.That(delBarCount, Is.EqualTo(0));
 
             delFooCount = delBarCount = 0;
 
-            bus.RaiseEvent(null, new TestEventTwoArgs());
+            bus.RaiseEvent(new TestEventTwoArgs());
             Assert.That(delFooCount, Is.EqualTo(0));
             Assert.That(delBarCount, Is.EqualTo(1));
         }
@@ -128,7 +128,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var bus = new EntityEventBus();
             var subscriber = new TestEventSubscriber();
 
-            void Handler(object sender, TestEventArgs ev) { }
+            void Handler(TestEventArgs ev) { }
 
             bus.SubscribeEvent<TestEventArgs>(Handler, subscriber);
             bus.UnsubscribeEvent<TestEventArgs>(subscriber);
@@ -181,7 +181,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var bus = new EntityEventBus();
 
             // Act
-            void Code() => bus.RaiseEvent(null, null);
+            void Code() => bus.RaiseEvent(null);
 
             // Assert
             Assert.Throws<ArgumentNullException>(Code);
@@ -198,10 +198,10 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var subscriber = new TestEventSubscriber();
 
             int delCalledCount = 0;
-            bus.SubscribeEvent<TestEventTwoArgs>(((sender, ev) => delCalledCount++), subscriber);
+            bus.SubscribeEvent<TestEventTwoArgs>(ev => delCalledCount++, subscriber);
 
             // Act
-            bus.RaiseEvent(null, new TestEventArgs());
+            bus.RaiseEvent(new TestEventArgs());
 
             // Assert
             Assert.That(delCalledCount, Is.EqualTo(0));
@@ -218,13 +218,13 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var subscriber = new TestEventSubscriber();
 
             int delCallCount = 0;
-            void Handler(object sender, TestEventArgs ev) => delCallCount++;
+            void Handler(TestEventArgs ev) => delCallCount++;
 
             bus.SubscribeEvent<TestEventArgs>(Handler, subscriber);
             bus.UnsubscribeEvent<TestEventArgs>(subscriber);
 
             // Act
-            bus.RaiseEvent(null, new TestEventArgs());
+            bus.RaiseEvent(new TestEventArgs());
 
             // Assert
             Assert.That(delCallCount, Is.EqualTo(0));
@@ -273,13 +273,13 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var subscriber = new TestEventSubscriber();
 
             int delCallCount = 0;
-            void Handler(object sender, TestEventArgs ev) => delCallCount++;
+            void Handler(TestEventArgs ev) => delCallCount++;
 
             bus.SubscribeEvent<TestEventArgs>(Handler, subscriber);
             bus.UnsubscribeEvents(subscriber);
 
             // Act
-            bus.RaiseEvent(null, new TestEventArgs());
+            bus.RaiseEvent(new TestEventArgs());
 
             // Assert
             Assert.That(delCallCount, Is.EqualTo(0));
@@ -295,7 +295,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var bus = new EntityEventBus();
 
             // Act
-            void Code() => bus.QueueEvent(null, null);
+            void Code() => bus.QueueEvent(null);
 
             // Assert
             Assert.Throws<ArgumentNullException>(Code);
@@ -312,12 +312,12 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var subscriber = new TestEventSubscriber();
 
             int delCallCount = 0;
-            void Handler(object sender, TestEventArgs ev) => delCallCount++;
+            void Handler(TestEventArgs ev) => delCallCount++;
 
             bus.SubscribeEvent<TestEventArgs>(Handler, subscriber);
 
             // Act
-            bus.QueueEvent(null, new TestEventArgs());
+            bus.QueueEvent(new TestEventArgs());
 
             // Assert
             Assert.That(delCallCount, Is.EqualTo(0));
@@ -334,10 +334,10 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var subscriber = new TestEventSubscriber();
 
             int delCallCount = 0;
-            void Handler(object sender, TestEventArgs ev) => delCallCount++;
+            void Handler(TestEventArgs ev) => delCallCount++;
 
             bus.SubscribeEvent<TestEventArgs>(Handler, subscriber);
-            bus.QueueEvent(null, new TestEventArgs());
+            bus.QueueEvent(new TestEventArgs());
 
             // Act
             bus.ProcessEventQueue();

--- a/Robust.UnitTesting/Shared/GameObjects/EntityEventBus_Tests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityEventBus_Tests.cs
@@ -18,7 +18,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var subscriber = new TestEventSubscriber();
 
             // Act
-            void Code() => bus.SubscribeEvent((EntityEventHandler<TestEventArgs>) null, subscriber);
+            void Code() => bus.SubscribeEvent(EventSource.Local, subscriber, (EntityEventHandler<TestEventArgs>) null);
             
             //Assert
             Assert.Throws<ArgumentNullException>(Code);
@@ -34,7 +34,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var bus = new EntityEventBus();
 
             // Act
-            void Code() => bus.SubscribeEvent<TestEventArgs>(ev => {}, null);
+            void Code() => bus.SubscribeEvent<TestEventArgs>(EventSource.Local, null, ev => {});
 
             //Assert: this should do nothing
             Assert.Throws<ArgumentNullException>(Code);
@@ -55,11 +55,11 @@ namespace Robust.UnitTesting.Shared.GameObjects
             void Handler(TestEventArgs ev) => delegateCallCount++;
 
             // 2 subscriptions 1 handler
-            bus.SubscribeEvent<TestEventArgs>(Handler, subscriber);
-            bus.SubscribeEvent<TestEventArgs>(Handler, subscriber);
+            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, Handler);
+            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, Handler);
 
             // Act
-            bus.RaiseEvent(new TestEventArgs());
+            bus.RaiseEvent(EventSource.Local, new TestEventArgs());
 
             //Assert
             Assert.That(delegateCallCount, Is.EqualTo(1));
@@ -79,11 +79,11 @@ namespace Robust.UnitTesting.Shared.GameObjects
             int delFooCount = 0;
             int delBarCount = 0;
 
-            bus.SubscribeEvent<TestEventArgs>(ev => delFooCount++, subscriber);
-            bus.SubscribeEvent<TestEventArgs>(ev => delBarCount++, subscriber);
+            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, ev => delFooCount++);
+            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, ev => delBarCount++);
 
             // Act
-            bus.RaiseEvent(new TestEventArgs());
+            bus.RaiseEvent(EventSource.Local, new TestEventArgs());
 
             // Assert
             Assert.That(delFooCount, Is.EqualTo(1));
@@ -103,17 +103,17 @@ namespace Robust.UnitTesting.Shared.GameObjects
             int delFooCount = 0;
             int delBarCount = 0;
 
-            bus.SubscribeEvent<TestEventArgs>(ev => delFooCount++, subscriber);
-            bus.SubscribeEvent<TestEventTwoArgs>(ev => delBarCount++, subscriber);
+            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, ev => delFooCount++);
+            bus.SubscribeEvent<TestEventTwoArgs>(EventSource.Local, subscriber, ev => delBarCount++);
 
             // Act & Assert
-            bus.RaiseEvent(new TestEventArgs());
+            bus.RaiseEvent(EventSource.Local, new TestEventArgs());
             Assert.That(delFooCount, Is.EqualTo(1));
             Assert.That(delBarCount, Is.EqualTo(0));
 
             delFooCount = delBarCount = 0;
 
-            bus.RaiseEvent(new TestEventTwoArgs());
+            bus.RaiseEvent(EventSource.Local, new TestEventTwoArgs());
             Assert.That(delFooCount, Is.EqualTo(0));
             Assert.That(delBarCount, Is.EqualTo(1));
         }
@@ -130,11 +130,11 @@ namespace Robust.UnitTesting.Shared.GameObjects
 
             void Handler(TestEventArgs ev) { }
 
-            bus.SubscribeEvent<TestEventArgs>(Handler, subscriber);
-            bus.UnsubscribeEvent<TestEventArgs>(subscriber);
+            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, Handler);
+            bus.UnsubscribeEvent<TestEventArgs>(EventSource.Local, subscriber);
 
             // Act
-            bus.UnsubscribeEvent<TestEventArgs>(subscriber);
+            bus.UnsubscribeEvent<TestEventArgs>(EventSource.Local, subscriber);
 
             // Assert: Does not throw
         }
@@ -150,7 +150,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var subscriber = new TestEventSubscriber();
 
             // Act
-            bus.UnsubscribeEvent<TestEventArgs>(subscriber);
+            bus.UnsubscribeEvent<TestEventArgs>(EventSource.Local, subscriber);
 
             // Assert: Does not throw
         }
@@ -165,7 +165,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var bus = new EntityEventBus();
 
             // Act
-            void Code() => bus.UnsubscribeEvent<TestEventArgs>(null);
+            void Code() => bus.UnsubscribeEvent<TestEventArgs>(EventSource.Local, null);
 
             // Assert
             Assert.Throws<ArgumentNullException>(Code);
@@ -181,7 +181,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var bus = new EntityEventBus();
 
             // Act
-            void Code() => bus.RaiseEvent(null);
+            void Code() => bus.RaiseEvent(EventSource.Local, null);
 
             // Assert
             Assert.Throws<ArgumentNullException>(Code);
@@ -198,10 +198,10 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var subscriber = new TestEventSubscriber();
 
             int delCalledCount = 0;
-            bus.SubscribeEvent<TestEventTwoArgs>(ev => delCalledCount++, subscriber);
+            bus.SubscribeEvent<TestEventTwoArgs>(EventSource.Local, subscriber, ev => delCalledCount++);
 
             // Act
-            bus.RaiseEvent(new TestEventArgs());
+            bus.RaiseEvent(EventSource.Local, new TestEventArgs());
 
             // Assert
             Assert.That(delCalledCount, Is.EqualTo(0));
@@ -220,11 +220,11 @@ namespace Robust.UnitTesting.Shared.GameObjects
             int delCallCount = 0;
             void Handler(TestEventArgs ev) => delCallCount++;
 
-            bus.SubscribeEvent<TestEventArgs>(Handler, subscriber);
-            bus.UnsubscribeEvent<TestEventArgs>(subscriber);
+            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, Handler);
+            bus.UnsubscribeEvent<TestEventArgs>(EventSource.Local, subscriber);
 
             // Act
-            bus.RaiseEvent(new TestEventArgs());
+            bus.RaiseEvent(EventSource.Local, new TestEventArgs());
 
             // Assert
             Assert.That(delCallCount, Is.EqualTo(0));
@@ -275,11 +275,11 @@ namespace Robust.UnitTesting.Shared.GameObjects
             int delCallCount = 0;
             void Handler(TestEventArgs ev) => delCallCount++;
 
-            bus.SubscribeEvent<TestEventArgs>(Handler, subscriber);
+            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, Handler);
             bus.UnsubscribeEvents(subscriber);
 
             // Act
-            bus.RaiseEvent(new TestEventArgs());
+            bus.RaiseEvent(EventSource.Local, new TestEventArgs());
 
             // Assert
             Assert.That(delCallCount, Is.EqualTo(0));
@@ -295,7 +295,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var bus = new EntityEventBus();
 
             // Act
-            void Code() => bus.QueueEvent(null);
+            void Code() => bus.QueueEvent(EventSource.Local, null);
 
             // Assert
             Assert.Throws<ArgumentNullException>(Code);
@@ -314,10 +314,10 @@ namespace Robust.UnitTesting.Shared.GameObjects
             int delCallCount = 0;
             void Handler(TestEventArgs ev) => delCallCount++;
 
-            bus.SubscribeEvent<TestEventArgs>(Handler, subscriber);
+            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, Handler);
 
             // Act
-            bus.QueueEvent(new TestEventArgs());
+            bus.QueueEvent(EventSource.Local, new TestEventArgs());
 
             // Assert
             Assert.That(delCallCount, Is.EqualTo(0));
@@ -336,8 +336,8 @@ namespace Robust.UnitTesting.Shared.GameObjects
             int delCallCount = 0;
             void Handler(TestEventArgs ev) => delCallCount++;
 
-            bus.SubscribeEvent<TestEventArgs>(Handler, subscriber);
-            bus.QueueEvent(new TestEventArgs());
+            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, Handler);
+            bus.QueueEvent(EventSource.Local, new TestEventArgs());
 
             // Act
             bus.ProcessEventQueue();


### PR DESCRIPTION
Removes the ancient ECS System event code, now Systems use the more advanced EventBus. Now two Systems can subscribe to the same event 😮. No more terrible switch case to handle events. `EntitySystem.RegisterMessageTypes()` and `EntitySystem.SubscribeEvents()` functions were removed, all event subscriptions should go inside `EntitySystem.Initialize()`. Subscriptions are automatically unsubscribed when the System is shut down. Those two functions were completely redundant, this helps simplify the API a lot.

The async `AwaitEvent<T>()` method was moved to the EventBus, so now you can wait for *any* event. The property `EntitySystemMessage.NetChannel` was added, if this property is not null then the event was raised remotely.