### PR TITLE
Make login command use host role instead of admin role

### DIFF
--- a/Robust.Server/Console/ConGroupController.cs
+++ b/Robust.Server/Console/ConGroupController.cs
@@ -59,7 +59,7 @@ namespace Robust.Server.Console
                 var address = session.ConnectedClient.RemoteEndPoint.Address;
                 if (Equals(address, IPAddress.Loopback) || Equals(address, IPAddress.IPv6Loopback))
                 {
-                    SetGroup(session, new ConGroupIndex(_configurationManager.GetCVar<int>("console.adminGroup")));
+                    SetGroup(session, new ConGroupIndex(_configurationManager.GetCVar<int>("console.hostGroup")));
                     UpdateClientData(session);
                 }
             }

--- a/Robust.Server/Console/ConsoleShell.cs
+++ b/Robust.Server/Console/ConsoleShell.cs
@@ -60,13 +60,13 @@ namespace Robust.Server.Console
         /// <inheritdoc />
         public void Initialize()
         {
-            // register console admin global password. DO NOT ADD THE REPLICATED FLAG
+            // register console host global password. DO NOT ADD THE REPLICATED FLAG
             if (!_configMan.IsCVarRegistered("console.password"))
                 _configMan.RegisterCVar("console.password", string.Empty,
                     CVar.ARCHIVE | CVar.SERVER | CVar.NOT_CONNECTED);
 
-            if (!_configMan.IsCVarRegistered("console.adminGroup"))
-                _configMan.RegisterCVar("console.adminGroup", 100, CVar.ARCHIVE | CVar.SERVER);
+            if (!_configMan.IsCVarRegistered("console.hostGroup"))
+                _configMan.RegisterCVar("console.hostGroup", 200, CVar.ARCHIVE | CVar.SERVER);
 
             ReloadCommands();
 
@@ -190,7 +190,7 @@ namespace Robust.Server.Console
                 return false;
 
             // success!
-            _groupController.SetGroup(session, new ConGroupIndex(_configMan.GetCVar<int>("console.adminGroup")));
+            _groupController.SetGroup(session, new ConGroupIndex(_configMan.GetCVar<int>("console.hostGroup")));
 
             return true;
         }
@@ -198,7 +198,7 @@ namespace Robust.Server.Console
         private class LoginCommand : IClientCommand
         {
             public string Command => "login";
-            public string Description => "Elevates client to admin permission group.";
+            public string Description => "Elevates client to host permission group.";
             public string Help => "login";
 
             public void Execute(IConsoleShell shell, IPlayerSession player, string[] args)


### PR DESCRIPTION
Requires [content #683](https://github.com/space-wizards/space-station-14/pull/683). Makes login console command use new host role. Has a few commands that may be useful for debugging that the administrator role doesn't have.