### PR TITLE
Fix StyleBox

### DIFF
--- a/Robust.Client/UserInterface/Control.Layout.cs
+++ b/Robust.Client/UserInterface/Control.Layout.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using JetBrains.Annotations;
 using Robust.Shared.Maths;
 using Robust.Shared.Utility;
@@ -365,7 +365,7 @@ namespace Robust.Client.UserInterface
             }
             else if ((child.SizeFlagsHorizontal & SizeFlags.Fill) != 0)
             {
-                newSizeX = box.Width;
+                newSizeX = Math.Max(box.Width, newSizeX);
             }
 
             var newPosY = box.Top;
@@ -381,7 +381,7 @@ namespace Robust.Client.UserInterface
             }
             else if ((child.SizeFlagsVertical & SizeFlags.Fill) != 0)
             {
-                newSizeY = box.Height;
+                newSizeY = Math.Max(box.Height, newSizeY);
             }
 
             child.Position = new Vector2(newPosX, newPosY);


### PR DESCRIPTION
FitChildInBox overwrote CustomMinimumSize when SizeFlags.Fill was set leading to children being smaller than they should be.

Can someone help test?
Might be a fix for space-wizards/space-station-14#638