### PR TITLE
Reworked how friction impacts velocity.

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/PhysicsSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/PhysicsSystem.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 using Robust.Server.Interfaces.Timing;
 using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
@@ -7,9 +6,9 @@ using Robust.Shared.GameObjects.Components;
 using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Map;
-using Robust.Shared.Interfaces.Physics;
 using Robust.Shared.IoC;
 using Robust.Shared.Maths;
+using System.Collections.Generic;
 
 namespace Robust.Server.GameObjects.EntitySystems
 {
@@ -198,7 +197,6 @@ namespace Robust.Server.GameObjects.EntitySystems
                         movement = new Vector2(0, 0);
                     }
                 }
-                //movement = GetFriction(tileDefinitionManager, mapManager, velocity, entity, movement, collider);
             }
 
             return movement;
@@ -213,17 +211,6 @@ namespace Robust.Server.GameObjects.EntitySystems
                 var tile = grid.GetTileRef(location.GridPosition);
                 var tileDef = tileDefinitionManager[tile.Tile.TypeId];
                 return tileDef.Friction;
-                //    if (tileDef.Friction != 0)
-                //    {
-                //        movement -= movement * tileDef.Friction;
-                //        if (movement.LengthSquared <= velocity.Mass * Epsilon / (1 - tileDef.Friction))
-                //        {
-                //            movement = Vector2.Zero;
-                //        }
-                //    }
-                //}
-
-                //return movement;
             }
             return 0;
         }


### PR DESCRIPTION
Fixes issue: https://github.com/space-wizards/space-station-14/issues/375

Changes how friction works.
Leads to being able to push two lockers but with a more significant slowdown than before.
Pushing more than two might still be possible on low friction surfaces.

Old way:
- Calculate movement then find own floor and reduce movement by the friction fraction.
![svlhUJk9f0](https://user-images.githubusercontent.com/7510010/76147748-c4709300-609f-11ea-8a30-6e402c4ddc00.gif)
![MKLYAOTGx2](https://user-images.githubusercontent.com/7510010/76147798-2c26de00-60a0-11ea-9aa5-9353c88472de.gif)

New way:
- Add together all frictions, just like all masses, and increase total mass based on total friction for the purpose of calculating the resulting speed.
![8Svl5ASH4t](https://user-images.githubusercontent.com/7510010/76147746-b458b380-609f-11ea-8e10-89f15da11624.gif)
![3to29p7GoZ](https://user-images.githubusercontent.com/7510010/76147789-203b1c00-60a0-11ea-96d1-fdc7b7dd0bf3.gif)