### PR TITLE
Fix issue651 and370

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -838,6 +838,13 @@ namespace Robust.Client.Graphics.Clyde
                     return cmp;
                 }
 
+                cmp = b.Owner.Transform.WorldPosition.Y.CompareTo(a.Owner.Transform.WorldPosition.Y);
+
+                if (cmp != 0)
+                {
+                    return cmp;
+                }
+
                 return a.Owner.Uid.CompareTo(b.Owner.Uid);
             }
         }

--- a/Robust.Shared/GameObjects/ComponentEnums.cs
+++ b/Robust.Shared/GameObjects/ComponentEnums.cs
@@ -18,8 +18,8 @@
         WallTops = 5,
         WallMountedItems = 6,
         Objects = 7,
-        Mobs = 8,
-        Items = 9,
+        Items = 8,
+        Mobs = 9,
         Overlays = 10,
     }
 }


### PR DESCRIPTION
Fixes https://github.com/space-wizards/space-station-14/issues/651 by adding a Y comparison to the SpriteDrawingOrderComparer.

Switches Mobs and Items values in DrawDepth enum to solve https://github.com/space-wizards/space-station-14/issues/370
Fix to this relies on other PR (https://github.com/space-wizards/space-station-14/pull/788) that sets DrawDepth to Mobs in human entity.