### PR TITLE
PlayerManager method to get PlayerSessions that meet a condition

### DIFF
--- a/Robust.Server/Interfaces/Player/IPlayerManager.cs
+++ b/Robust.Server/Interfaces/Player/IPlayerManager.cs
@@ -64,6 +64,7 @@ namespace Robust.Server.Interfaces.Player
 
         void DetachAll();
         List<IPlayerSession> GetPlayersInRange(GridCoordinates worldPos, int range);
+        List<IPlayerSession> GetPlayersBy(Func<IPlayerSession, bool> predicate);
         List<IPlayerSession> GetAllPlayers();
         List<PlayerState> GetPlayerStates(GameTick fromTick);
     }

--- a/Robust.Server/Player/PlayerManager.cs
+++ b/Robust.Server/Player/PlayerManager.cs
@@ -7,6 +7,7 @@ using Robust.Server.Interfaces.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.GameStates;
 using Robust.Shared.Input;
+using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Map;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.Interfaces.Reflection;
@@ -204,6 +205,22 @@ namespace Robust.Server.Player
                 return
                     _sessions.Values.Where(x => x.AttachedEntity != null &&
                                                 worldPos.InRange(_mapManager, x.AttachedEntity.Transform.GridPosition, range))
+                        .Cast<IPlayerSession>()
+                        .ToList();
+            }
+            finally
+            {
+                _sessionsLock.ExitReadLock();
+            }
+        }
+
+        public List<IPlayerSession> GetPlayersBy(Func<IPlayerSession, bool> predicate)
+        {
+            _sessionsLock.EnterReadLock();
+            try
+            {
+                return
+                    _sessions.Values.Where(predicate)
                         .Cast<IPlayerSession>()
                         .ToList();
             }

--- a/Robust.Server/Player/PlayerSession.cs
+++ b/Robust.Server/Player/PlayerSession.cs
@@ -92,7 +92,6 @@ namespace Robust.Server.Player
             AttachedEntity = a;
             a.SendMessage(actorComponent, new PlayerAttachedMsg(this));
             a.EntityManager.EventBus.RaiseEvent(EventSource.Local, new PlayerAttachSystemMessage(a, this));
-            SetAttachedEntityName();
             UpdatePlayerState();
         }
 


### PR DESCRIPTION
Required by: https://github.com/space-wizards/space-station-14/pull/799
And now entities that get a mind attached won't get their names replaced by the player's username anymore.