### PR TITLE
Split HandleMessage into local and networked variants, add ICommonSession parameter to the latter

### DIFF
--- a/Robust.Client/GameObjects/Components/Light/PointLightComponent.cs
+++ b/Robust.Client/GameObjects/Components/Light/PointLightComponent.cs
@@ -7,6 +7,7 @@ using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.IoC;
 using Robust.Shared.Maths;
+using Robust.Shared.Players;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
 
@@ -117,10 +118,20 @@ namespace Robust.Client.GameObjects
         }
 
         /// <inheritdoc />
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null,
-            IComponent component = null)
+        public override void HandleMessage(ComponentMessage message, IComponent component)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleMessage(message, component);
+
+            if ((message is ParentChangedMessage msg))
+            {
+                HandleTransformParentChanged(msg);
+            }
+        }
+
+        /// <inheritdoc />
+        public override void HandleNetworkMessage(ComponentMessage message, INetChannel netChannel, ICommonSession session = null)
+        {
+            base.HandleNetworkMessage(message, netChannel, session);
 
             if ((message is ParentChangedMessage msg))
             {

--- a/Robust.Client/GameObjects/Components/Light/PointLightComponent.cs
+++ b/Robust.Client/GameObjects/Components/Light/PointLightComponent.cs
@@ -128,17 +128,6 @@ namespace Robust.Client.GameObjects
             }
         }
 
-        /// <inheritdoc />
-        public override void HandleNetworkMessage(ComponentMessage message, INetChannel netChannel, ICommonSession session = null)
-        {
-            base.HandleNetworkMessage(message, netChannel, session);
-
-            if ((message is ParentChangedMessage msg))
-            {
-                HandleTransformParentChanged(msg);
-            }
-        }
-
         private void HandleTransformParentChanged(ParentChangedMessage obj)
         {
             // TODO: this does not work for things nested multiply layers deep.

--- a/Robust.Client/GameObjects/Components/UserInterface/ClientUserInterfaceComponent.cs
+++ b/Robust.Client/GameObjects/Components/UserInterface/ClientUserInterfaceComponent.cs
@@ -45,41 +45,6 @@ namespace Robust.Client.GameObjects.Components.UserInterface
             _interfaceData = interfaceData;
         }
 
-        public override void HandleMessage(ComponentMessage message, IComponent component)
-        {
-            base.HandleMessage(message, component);
-
-            switch (message)
-            {
-                case BoundInterfaceMessageWrapMessage wrapped:
-                    // Double nested switches who needs readability anyways.
-                    switch (wrapped.Message)
-                    {
-                        case OpenBoundInterfaceMessage _:
-                            if (_openInterfaces.ContainsKey(wrapped.UiKey))
-                            {
-                                return;
-                            }
-
-                            OpenInterface(wrapped);
-                            break;
-
-                        case CloseBoundInterfaceMessage _:
-                            Close(wrapped.UiKey, true);
-                            break;
-
-                        default:
-                            if (_openInterfaces.TryGetValue(wrapped.UiKey, out var bi))
-                            {
-                                bi.InternalReceiveMessage(wrapped.Message);
-                            }
-                            break;
-                    }
-
-                    break;
-            }
-        }
-
         public override void HandleNetworkMessage(ComponentMessage message, INetChannel netChannel,
             ICommonSession session = null)
         {

--- a/Robust.Server/GameObjects/Components/Physics/PhysicsComponent.cs
+++ b/Robust.Server/GameObjects/Components/Physics/PhysicsComponent.cs
@@ -130,27 +130,6 @@ namespace Robust.Server.GameObjects
             }
         }
 
-        public override void HandleNetworkMessage(ComponentMessage message, INetChannel netChannel, ICommonSession session = null)
-        {
-            base.HandleNetworkMessage(message, netChannel, session);
-
-            switch (message)
-            {
-                case BumpedEntMsg msg:
-                    if (Anchored)
-                    {
-                        return;
-                    }
-
-                    if (!msg.Entity.TryGetComponent(out PhysicsComponent physicsComponent))
-                    {
-                        return;
-                    }
-                    physicsComponent.AddVelocityConsumer(this);
-                    break;
-            }
-        }
-
         private List<PhysicsComponent> VelocityConsumers { get; } = new List<PhysicsComponent>();
 
         public List<PhysicsComponent> GetVelocityConsumers()

--- a/Robust.Server/GameObjects/Components/Physics/PhysicsComponent.cs
+++ b/Robust.Server/GameObjects/Components/Physics/PhysicsComponent.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
+using Robust.Shared.Players;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
 
@@ -108,9 +109,30 @@ namespace Robust.Server.GameObjects
             return new PhysicsComponentState(_mass, _linVelocity);
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null)
+        public override void HandleMessage(ComponentMessage message, IComponent component)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleMessage(message, component);
+
+            switch (message)
+            {
+                case BumpedEntMsg msg:
+                    if (Anchored)
+                    {
+                        return;
+                    }
+
+                    if (!msg.Entity.TryGetComponent(out PhysicsComponent physicsComponent))
+                    {
+                        return;
+                    }
+                    physicsComponent.AddVelocityConsumer(this);
+                    break;
+            }
+        }
+
+        public override void HandleNetworkMessage(ComponentMessage message, INetChannel netChannel, ICommonSession session = null)
+        {
+            base.HandleNetworkMessage(message, netChannel, session);
 
             switch (message)
             {

--- a/Robust.Server/GameObjects/Components/UserInterface/ServerUserInterfaceComponent.cs
+++ b/Robust.Server/GameObjects/Components/UserInterface/ServerUserInterfaceComponent.cs
@@ -9,6 +9,7 @@ using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
+using Robust.Shared.Players;
 using Robust.Shared.Serialization;
 
 namespace Robust.Server.GameObjects.Components.UserInterface
@@ -68,27 +69,25 @@ namespace Robust.Server.GameObjects.Components.UserInterface
             SendNetworkMessage(new BoundInterfaceMessageWrapMessage(message, uiKey), session.ConnectedClient);
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null,
-            IComponent component = null)
+        public override void HandleNetworkMessage(ComponentMessage message, INetChannel netChannel, ICommonSession session = null)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleNetworkMessage(message, netChannel, session);
 
             switch (message)
             {
                 case BoundInterfaceMessageWrapMessage wrapped:
-                    if (netChannel == null)
+                    if (session == null)
                     {
-                        throw new ArgumentNullException(nameof(netChannel));
+                        throw new ArgumentNullException(nameof(session));
                     }
 
-                    var session = _playerManager.GetSessionById(netChannel.SessionId);
                     if (!_interfaces.TryGetValue(wrapped.UiKey, out var @interface))
                     {
                         Logger.DebugS("go.comp.ui", "Got BoundInterfaceMessageWrapMessage for unknown UI key: {0}",
                             wrapped.UiKey);
                         return;
                     }
-                    @interface.ReceiveMessage(wrapped.Message, session);
+                    @interface.ReceiveMessage(wrapped.Message, session as IPlayerSession);
                     break;
             }
         }

--- a/Robust.Server/GameObjects/ServerEntityNetworkManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityNetworkManager.cs
@@ -139,7 +139,9 @@ namespace Robust.Server.GameObjects
             switch (message.Type)
             {
                 case EntityMessageType.ComponentMessage:
-                    ReceivedComponentMessage?.Invoke(this, new NetworkComponentMessage(message));
+                    // Get player session
+                    var session = _playerManager.GetSessionByChannel(message.MsgChannel);
+                    ReceivedComponentMessage?.Invoke(this, new NetworkComponentMessage(message, session));
                     return;
 
                 case EntityMessageType.SystemMessage:

--- a/Robust.Server/GameObjects/ServerEntityNetworkManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityNetworkManager.cs
@@ -139,7 +139,6 @@ namespace Robust.Server.GameObjects
             switch (message.Type)
             {
                 case EntityMessageType.ComponentMessage:
-                    // Get player session
                     ReceivedComponentMessage?.Invoke(this, new NetworkComponentMessage(message, player));
                     return;
 

--- a/Robust.Server/GameObjects/ServerEntityNetworkManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityNetworkManager.cs
@@ -140,8 +140,7 @@ namespace Robust.Server.GameObjects
             {
                 case EntityMessageType.ComponentMessage:
                     // Get player session
-                    var session = _playerManager.GetSessionByChannel(message.MsgChannel);
-                    ReceivedComponentMessage?.Invoke(this, new NetworkComponentMessage(message, session));
+                    ReceivedComponentMessage?.Invoke(this, new NetworkComponentMessage(message, player));
                     return;
 
                 case EntityMessageType.SystemMessage:

--- a/Robust.Shared/GameObjects/Component.cs
+++ b/Robust.Shared/GameObjects/Component.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
+using Robust.Shared.Players;
 using Robust.Shared.Reflection;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
@@ -193,7 +194,10 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public virtual void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null) { }
+        public virtual void HandleMessage(ComponentMessage message, IComponent component) { }
+
+        /// <inheritdoc />
+        public virtual void HandleNetworkMessage(ComponentMessage message, INetChannel netChannel, ICommonSession session = null) { }
 
         /// <inheritdoc />
         public virtual ComponentState GetComponentState()

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -5,6 +5,7 @@ using Robust.Shared.GameObjects.Components;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.Interfaces.GameObjects.Components;
+using Robust.Shared.Players;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
@@ -205,7 +206,7 @@ namespace Robust.Shared.GameObjects
             foreach (var component in components)
             {
                 if (owner != component)
-                    component.HandleMessage(message, null, owner);
+                    component.HandleMessage(message, owner);
             }
         }
 

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -12,6 +12,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
+using Robust.Shared.Players;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -344,19 +345,20 @@ namespace Robust.Shared.GameObjects
         {
             var compMsg = netMsg.Message;
             var compChannel = netMsg.Channel;
+            var session = netMsg.Session;
             compMsg.Remote = true;
 
             var uid = netMsg.EntityUid;
             if (compMsg.Directed)
             {
                 if (_componentManager.TryGetComponent(uid, netMsg.NetId, out var component))
-                    component.HandleMessage(compMsg, compChannel);
+                    component.HandleNetworkMessage(compMsg, compChannel, session);
             }
             else
             {
                 foreach (var component in _componentManager.GetComponents(uid))
                 {
-                    component.HandleMessage(compMsg, compChannel);
+                    component.HandleNetworkMessage(compMsg, compChannel, session);
                 }
             }
         }

--- a/Robust.Shared/GameObjects/NetworkComponentMessage.cs
+++ b/Robust.Shared/GameObjects/NetworkComponentMessage.cs
@@ -1,5 +1,6 @@
 ﻿using Robust.Shared.Interfaces.Network;
 using Robust.Shared.Network.Messages;
+using Robust.Shared.Players;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.GameObjects
@@ -32,10 +33,15 @@ namespace Robust.Shared.GameObjects
         public readonly ComponentMessage Message;
 
         /// <summary>
+        /// If the message is from the client, the client's session.
+        /// </summary>
+        public readonly ICommonSession Session;
+
+        /// <summary>
         /// Constructs a new instance of <see cref="NetworkComponentMessage"/>.
         /// </summary>
         /// <param name="netMsg">Raw network message containing the component message.</param>
-        public NetworkComponentMessage(MsgEntity netMsg)
+        public NetworkComponentMessage(MsgEntity netMsg, ICommonSession session = null)
         {
             DebugTools.Assert(netMsg.Type == EntityMessageType.ComponentMessage);
 
@@ -43,6 +49,7 @@ namespace Robust.Shared.GameObjects
             EntityUid = netMsg.EntityUid;
             NetId = netMsg.NetId;
             Message = netMsg.ComponentMessage;
+            Session = session;
         }
     }
 

--- a/Robust.Shared/Interfaces/GameObjects/IComponent.cs
+++ b/Robust.Shared/Interfaces/GameObjects/IComponent.cs
@@ -1,6 +1,7 @@
 ﻿using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.Network;
+using Robust.Shared.Players;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 
@@ -104,13 +105,19 @@ namespace Robust.Shared.Interfaces.GameObjects
         void ExposeData(ObjectSerializer serializer);
 
         /// <summary>
-        ///     Handles an incoming component message.
+        ///     Handles a local incoming component message.
         /// </summary>
         /// <param name="message">Incoming event message.</param>
-        /// <param name="netChannel">If this originates from a remote client, this is the channel it came from. If it
-        /// originates locally, this is null.</param>
-        /// <param name="component">If the message originates from a local component, this is the component that sent it.</param>
-        void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null);
+        /// <param name="component">The local component that sent the message.</param>
+        void HandleMessage(ComponentMessage message, IComponent component);
+
+        /// <summary>
+        ///     Handles an incoming component message from the server.
+        /// </summary>
+        /// <param name="message">Incoming event message.</param>
+        /// <param name="netChannel">The channel of the remote client that sent the message.</param>
+        /// <param name="session">The session data for the player who sent this message. Null if this is a client.</param>
+        void HandleNetworkMessage(ComponentMessage message, INetChannel netChannel, ICommonSession session = null);
 
         /// <summary>
         ///     Get the component's state for replicating on the client.


### PR DESCRIPTION
Fixes #704. 
 
### What this PR does
Split the HandleMessage function for `IComponent` into two distinct functions, one for processing a local component message and one for processing a component message sent by a remote peer. It also adds a `Session` field to `NetworkComponentMessage`, which is null by default but can be specified by the `ServerEntityNetworkManager` as the session for the client who sent the component message.

The components which define a custom `HandleMessage` routine have also been updated. I still need to create a separate PR for the content repo that updates the components in there.