### PR TITLE
ServerEntityNetworkManager doesn't dispatch messages if the client got disconnected

### DIFF
--- a/Robust.Server/GameObjects/ServerEntityNetworkManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityNetworkManager.cs
@@ -127,7 +127,7 @@ namespace Robust.Server.GameObjects
         private void DispatchEntityNetworkMessage(MsgEntity message)
         {
             // Don't try to retrieve the session if the client disconnected
-            if (!message.MsgChannel.NetPeer.IsConnected)
+            if (!message.MsgChannel.IsConnected)
             {
                 return;
             }

--- a/Robust.Server/GameObjects/ServerEntityNetworkManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityNetworkManager.cs
@@ -126,6 +126,12 @@ namespace Robust.Server.GameObjects
 
         private void DispatchEntityNetworkMessage(MsgEntity message)
         {
+            // Don't try to retrieve the session if the client disconnected
+            if (!message.MsgChannel.NetPeer.IsConnected)
+            {
+                return;
+            }
+
             var player = _playerManager.GetSessionByChannel(message.MsgChannel);
 
             if (message.Sequence != 0)

--- a/Robust.Shared/Interfaces/Network/INetChannel.cs
+++ b/Robust.Shared/Interfaces/Network/INetChannel.cs
@@ -36,6 +36,11 @@ namespace Robust.Shared.Interfaces.Network
         short Ping { get; }
 
         /// <summary>
+        ///     Whether or not the channel is currently connected to a remote peer.
+        /// </summary>
+        bool IsConnected { get; }
+
+        /// <summary>
         ///     Creates a new NetMessage to be filled up and sent.
         /// </summary>
         /// <typeparam name="T">The derived NetMessage type to send.</typeparam>

--- a/Robust.Shared/Network/NetChannel.cs
+++ b/Robust.Shared/Network/NetChannel.cs
@@ -24,6 +24,9 @@ namespace Robust.Shared.Network
         public short Ping => (short) Math.Round(_connection.AverageRoundtripTime * 1000);
 
         /// <inheritdoc />
+        public bool IsConnected => _connection.Status == NetConnectionStatus.Connected;
+
+        /// <inheritdoc />
         public IPEndPoint RemoteEndPoint => _connection.RemoteEndPoint;
 
         /// <summary>

--- a/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
@@ -299,6 +299,8 @@ namespace Robust.UnitTesting
                 public int ConnectionUid { get; }
                 long INetChannel.ConnectionId => ConnectionUid;
 
+                public bool IsConnected { get; }
+
                 // TODO: Should this port value make sense?
                 public IPEndPoint RemoteEndPoint { get; } = new IPEndPoint(IPAddress.Loopback, 1212);
                 public NetSessionId SessionId { get; }

--- a/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
@@ -313,6 +313,7 @@ namespace Robust.UnitTesting
                     ConnectionUid = uid;
                     SessionId = sessionId;
                     OtherChannel = otherChannel;
+                    IsConnected = true;
                 }
 
                 public IntegrationNetChannel(IntegrationNetManager owner, ChannelWriter<object> otherChannel, int uid,


### PR DESCRIPTION
Fixes #1029.

### What this PR does
Fixes a bug where the ServerEntityNetworkManager would attempt to retrieve the session of a disconnected client when dispatching messages.