### PR TITLE
Gravity

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/PhysicsSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/PhysicsSystem.cs
@@ -98,6 +98,7 @@ namespace Robust.Server.GameObjects.EntitySystems
             int velocityConsumerCount;
             float totalMass;
             Vector2 lowestMovement;
+            bool hasGravity = mapManager.GetGrid(entity.Transform.GridID).HasGravity;
             do
             {
                 velocityConsumerCount = velocityConsumers.Count;
@@ -107,9 +108,13 @@ namespace Robust.Server.GameObjects.EntitySystems
                 float totalFriction = 0;
                 foreach (var consumer in velocityConsumers)
                 {
+                    var movement = lowestMovement;
                     totalMass += consumer.Mass;
-                    totalFriction += GetFriction(tileDefinitionManager, mapManager, consumer.Owner);
-                    var movement = lowestMovement * velocity.Mass / (totalMass != 0 ? totalMass + (totalMass * totalFriction) : 1);
+                    if (hasGravity)
+                    {
+                        totalFriction += GetFriction(tileDefinitionManager, mapManager, consumer.Owner);
+                        movement *= velocity.Mass / (totalMass != 0 ? totalMass + (totalMass * totalFriction) : 1);
+                    }
                     consumer.AngularVelocity = velocity.AngularVelocity;
                     consumer.LinearVelocity = movement;
                     copy.Add(CalculateMovement(tileDefinitionManager, mapManager, consumer, frameTime, consumer.Owner) / frameTime);

--- a/Robust.Server/GameObjects/EntitySystems/PhysicsSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/PhysicsSystem.cs
@@ -98,7 +98,9 @@ namespace Robust.Server.GameObjects.EntitySystems
             int velocityConsumerCount;
             float totalMass;
             Vector2 lowestMovement;
-            bool hasGravity = mapManager.GetGrid(entity.Transform.GridID).HasGravity;
+            var tile =
+                mapManager.GetGrid(entity.Transform.GridID).GetTileRef(entity.Transform.GridPosition).Tile;
+            bool hasGravity = mapManager.GetGrid(entity.Transform.GridID).HasGravity && !tile.IsEmpty;
             do
             {
                 velocityConsumerCount = velocityConsumers.Count;

--- a/Robust.Shared/Map/IMapGrid.cs
+++ b/Robust.Shared/Map/IMapGrid.cs
@@ -56,6 +56,11 @@ namespace Robust.Shared.Map
         Vector2 WorldPosition { get; set; }
 
         /// <summary>
+        ///     Whether or not this grid has gravity
+        /// </summary>
+        bool HasGravity { get; set; }
+
+        /// <summary>
         ///     Is this located at a position on the center grid of snap positions, accepts local coordinates
         /// </summary>
         bool OnSnapCenter(Vector2 position);
@@ -129,7 +134,7 @@ namespace Robust.Shared.Map
         void RemoveFromSnapGridCell(GridCoordinates worldPos, SnapGridOffset offset, SnapGridComponent snap);
 
         #endregion SnapGridAccess
-        
+
         #region Transforms
 
         /// <summary>
@@ -157,7 +162,7 @@ namespace Robust.Shared.Map
         /// <param name="posLocal">The local vector with this grid as origin.</param>
         /// <returns>The world-space vector with global origin.</returns>
         Vector2 LocalToWorld(Vector2 posLocal);
-        
+
         /// <summary>
         ///     Transforms World position into grid tile indices.
         /// </summary>

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -32,6 +32,8 @@ namespace Robust.Shared.Map
 
         public EntityUid GridEntityId { get; internal set; }
 
+        public bool HasGravity { get; set; }
+
         /// <summary>
         ///     Grid chunks than make up this grid.
         /// </summary>
@@ -56,6 +58,7 @@ namespace Robust.Shared.Map
             SnapSize = snapSize;
             ParentMapId = parentMapId;
             LastModifiedTick = CreatedTick = _mapManager.GameTiming.CurTick;
+            HasGravity = false;
         }
 
         /// <summary>

--- a/Robust.Shared/Physics/PhysicsManager.cs
+++ b/Robust.Shared/Physics/PhysicsManager.cs
@@ -99,10 +99,10 @@ namespace Robust.Shared.Physics
                 foreach (var mods in collisionmodifiers)
                 {
                     preventcollision |= mods.PreventCollide(otherCollidable);
-                    foreach (var othermods in othercollisionmodifiers)
-                    {
-                        preventcollision |= othermods.PreventCollide(collidable);
-                    }
+                }
+                foreach (var othermods in othercollisionmodifiers)
+                {
+                    preventcollision |= othermods.PreventCollide(collidable);
                 }
                 if (preventcollision)
                 {

--- a/Robust.Shared/Physics/PhysicsManager.cs
+++ b/Robust.Shared/Physics/PhysicsManager.cs
@@ -92,11 +92,17 @@ namespace Robust.Shared.Physics
                     continue;
                 }
 
+                var othercollisionmodifiers = otherCollidable.Owner.GetAllComponents<ICollideSpecial>();
+
                 //Provides component level overrides for collision behavior based on the entity we are trying to collide with
                 var preventcollision = false;
                 foreach (var mods in collisionmodifiers)
                 {
                     preventcollision |= mods.PreventCollide(otherCollidable);
+                    foreach (var othermods in othercollisionmodifiers)
+                    {
+                        preventcollision |= othermods.PreventCollide(collidable);
+                    }
                 }
                 if (preventcollision)
                 {


### PR DESCRIPTION
Link to relevant content PR: https://github.com/space-wizards/space-station-14/pull/841

### What this PR does

In order to add Gravity to SS14, a few minor engine changes must be made:
- Each grid should keep track of whether or not it has gravity
- The physics system should not apply friction to moving objects in zero gravity

In addition, I fixed a bug involving asymmetric collisions. This bug would happen whenever two objects collided, one of which had a `PreventCollide` override that returned true, and the other that did not. The former would not collide with the later, but the later would still act as if it had collided with the former.

#### Completion Checklist
- [X] Grid has a gravity property
- [X] Friction is not applied to objects moving in zero gravity
- [X] Space will always have zero gravity