### PR TITLE
Fix bug with InteractionOutline on larger sprites

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.cs
@@ -221,7 +221,7 @@ namespace Robust.Client.Graphics.Clyde
             GL.BindBufferBase(BufferRangeTarget.UniformBuffer, UniformConstantsBindingIndex,
                 UniformConstantsUBO.ObjectHandle);
 
-            EntityPostRenderTarget = CreateRenderTarget(Vector2i.One * 4 * EyeManager.PixelsPerMeter,
+            EntityPostRenderTarget = CreateRenderTarget(Vector2i.One * 8 * EyeManager.PixelsPerMeter,
                 new RenderTargetFormatParameters(RenderTargetColorFormat.Rgba8Srgb, true),
                 name: nameof(EntityPostRenderTarget));
         }


### PR DESCRIPTION
Sprites larger than 32x32 get cropped to 32x32 if the entity has an `InteractionOutlineComponent` and is moused-over. To fix this issue, I simply doubled the size for Clyde's `EntityPostRenderTarget`. Now, the interaction outline shader can work for sprites as big as 96x96.