### PR TITLE
Error is now thrown if entity prototype defines a component twice

### DIFF
--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -513,6 +513,7 @@ namespace Robust.Shared.GameObjects
             if (Components.Keys.Contains(type))
             {
                 Log.Logger.Error($"Component of type '{type}' defined twice in prototype {ID}!");
+                return;
             }
 
             var copy = new YamlMappingNode(mapping.AsEnumerable());

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -509,6 +509,12 @@ namespace Robust.Shared.GameObjects
                     return;
             }
 
+            // Has this type already been added?
+            if (Components.Keys.Contains(type))
+            {
+                Log.Logger.Error($"Component of type '{type}' defined twice in prototype {ID}!");
+            }
+
             var copy = new YamlMappingNode(mapping.AsEnumerable());
             // TODO: figure out a better way to exclude the type node.
             // Also maybe deep copy this? Right now it's pretty error prone.


### PR DESCRIPTION
Closes #1033.