### PR TITLE
Change Reference -> Ref in VV

### DIFF
--- a/Robust.Client/ViewVariables/Editors/ViewVariablesPropertyEditorReference.cs
+++ b/Robust.Client/ViewVariables/Editors/ViewVariablesPropertyEditorReference.cs
@@ -28,7 +28,7 @@ namespace Robust.Client.ViewVariables.Editors
 
             var button = new Button
             {
-                Text = $"Reference: {toString}",
+                Text = $"Ref: {toString}",
                 ClipText = true,
                 SizeFlagsHorizontal = Control.SizeFlags.FillExpand
             };

--- a/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceEntity.cs
+++ b/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceEntity.cs
@@ -77,7 +77,7 @@ namespace Robust.Client.ViewVariables.Instances
                     headBox.AddChild(new Label {Text = stringified, ClipText = true});
                     headBox.AddChild(new Label
                     {
-                        Text = type.FullName,
+                        Text = TypeAbbreviation.Abbreviate(type.FullName),
                     //    FontOverride = smallFont,
                         FontColorOverride = Color.DarkGray,
                         ClipText = true
@@ -86,7 +86,7 @@ namespace Robust.Client.ViewVariables.Instances
                 }
                 else
                 {
-                    top = new Label {Text = stringified};
+                    top = new Label {Text = TypeAbbreviation.Abbreviate(stringified)};
                 }
 
                 if (_entity.TryGetComponent(out ISpriteComponent sprite))

--- a/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceObject.cs
+++ b/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceObject.cs
@@ -27,7 +27,14 @@ namespace Robust.Client.ViewVariables.Instances
             Object = obj;
             var type = obj.GetType();
 
-            _wrappingInit(window, obj.ToString(), TypeAbbreviation.Abbreviate(type.ToString()));
+            var title = obj.ToString();
+            var subtitle = TypeAbbreviation.Abbreviate(type.ToString());
+            if (title == obj.GetType().FullName) {
+                title = TypeAbbreviation.Abbreviate(title);
+                subtitle = ""; // This would just be the type again - not helpful
+            }
+
+            _wrappingInit(window, title, subtitle);
             foreach (var trait in TraitsFor(ViewVariablesManager.TraitIdsFor(type)))
             {
                 trait.Initialize(this);

--- a/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceObject.cs
+++ b/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceObject.cs
@@ -5,6 +5,7 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Client.ViewVariables.Traits;
 using Robust.Shared.ViewVariables;
+using Robust.Shared.Utility;
 
 namespace Robust.Client.ViewVariables.Instances
 {
@@ -26,7 +27,7 @@ namespace Robust.Client.ViewVariables.Instances
             Object = obj;
             var type = obj.GetType();
 
-            _wrappingInit(window, obj.ToString(), type.ToString());
+            _wrappingInit(window, obj.ToString(), TypeAbbreviation.Abbreviate(type.ToString()));
             foreach (var trait in TraitsFor(ViewVariablesManager.TraitIdsFor(type)))
             {
                 trait.Initialize(this);

--- a/Robust.Client/ViewVariables/ViewVariablesInstance.cs
+++ b/Robust.Client/ViewVariables/ViewVariablesInstance.cs
@@ -101,7 +101,7 @@ namespace Robust.Client.ViewVariables
                     Editable = access == VVAccess.ReadWrite,
                     Name = memberInfo.Name,
                     Type = memberType.AssemblyQualifiedName,
-                    TypePretty = memberType.ToString(),
+                    TypePretty = TypeAbbreviation.Abbreviate(memberType.ToString()),
                     Value = value
                 };
 

--- a/Robust.Server/ViewVariables/Traits/ViewVariablesTraitMembers.cs
+++ b/Robust.Server/ViewVariables/Traits/ViewVariablesTraitMembers.cs
@@ -46,7 +46,7 @@ namespace Robust.Server.ViewVariables.Traits
                     Editable = attr.Access == VVAccess.ReadWrite,
                     Name = property.Name,
                     Type = property.PropertyType.AssemblyQualifiedName,
-                    TypePretty = property.PropertyType.ToString(),
+                    TypePretty = TypeAbbreviation.Abbreviate(property.PropertyType.ToString()),
                     Value = property.GetValue(Session.Object),
                     PropertyIndex = _members.Count
                 });
@@ -66,7 +66,7 @@ namespace Robust.Server.ViewVariables.Traits
                     Editable = attr.Access == VVAccess.ReadWrite,
                     Name = field.Name,
                     Type = field.FieldType.AssemblyQualifiedName,
-                    TypePretty = field.FieldType.ToString(),
+                    TypePretty = TypeAbbreviation.Abbreviate(field.FieldType.ToString()),
                     Value = field.GetValue(Session.Object),
                     PropertyIndex = _members.Count
                 });

--- a/Robust.Server/ViewVariables/ViewVariablesSession.cs
+++ b/Robust.Server/ViewVariables/ViewVariablesSession.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Robust.Server.ViewVariables.Traits;
 using Robust.Shared.Interfaces.Serialization;
 using Robust.Shared.Network;
+using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 
 namespace Robust.Server.ViewVariables
@@ -59,7 +60,7 @@ namespace Robust.Server.ViewVariables
                 return new ViewVariablesBlobMetadata
                 {
                     ObjectType = ObjectType.AssemblyQualifiedName,
-                    ObjectTypePretty = ObjectType.ToString(),
+                    ObjectTypePretty = TypeAbbreviation.Abbreviate(ObjectType.ToString()),
                     Stringified = Object.ToString(),
                     Traits = new List<object>(Host.TraitIdsFor(ObjectType))
                 };


### PR DESCRIPTION
Fixes #984.

Since `1ab703325fdd3a363fe29ab5421771cf45ef4803` already abbreviated types where possible, the only remaining part of the issue was shortening `Reference` to `Ref` in the menu.