### PR TITLE
Add system for using flag names in YAML

### DIFF
--- a/Robust.Shared/Interfaces/Serialization/ICustomFormatManager.cs
+++ b/Robust.Shared/Interfaces/Serialization/ICustomFormatManager.cs
@@ -1,0 +1,73 @@
+﻿using Robust.Shared.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Robust.Shared.Interfaces.Serialization
+{
+    /// <summary>
+    /// Provides information about custom serialization formats used by certain fields.
+    /// </summary>
+    public interface ICustomFormatManager
+    {
+        /// <summary>
+        /// Get a custom <c>int</c> format in terms of enum flags, chosen by a tag type.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The tag type to select the representation with. To understand more about how
+        /// tag types are used, see the <see cref="FlagsForAttribute"/>.
+        /// </typeparam>
+        /// <returns>
+        /// A custom serialization format for int values, chosen by the tag type.
+        /// </returns>
+        public WithFormat<int> FlagFormat<T>();
+    }
+
+
+    /// <summary>
+    /// Interface for controlling custom value representation in an abstract storage medium.
+    /// </summary>
+    public abstract class WithFormat<T>
+    {
+        /// <summary>
+        /// The underlying type used for representation in the storage medium.
+        /// </summary>
+        public abstract Type Format { get; }
+
+        public abstract T FromCustomFormat(object obj);
+        public abstract object ToCustomFormat(T t);
+
+        /// <summary>
+        /// Get the corresponding YAML serializer for the custom representation.
+        /// </summary>
+        public virtual YamlObjectSerializer.TypeSerializer GetYamlSerializer()
+        {
+            return new YamlCustomFormatSerializer<T>(this);
+        }
+
+        private class DoNothing<T> : WithFormat<T>
+        {
+            public override Type Format => typeof(T);
+            public override T FromCustomFormat(object obj) { return (T)obj; }
+            public override object ToCustomFormat(T t) { return t; }
+
+            private static YamlCustomFormatSerializer<T> _serializer;
+
+            internal DoNothing()
+            {
+                if (_serializer == null)
+                    _serializer = new YamlCustomFormatSerializer<T>(this);
+            }
+
+            public override YamlObjectSerializer.TypeSerializer GetYamlSerializer()
+            {
+                return _serializer;
+            }
+        }
+
+        /// <summary>
+        /// The identity format i.e. the format which represents a value as itself.
+        /// </summary>
+        public static readonly WithFormat<T> NoFormat = new DoNothing<T>();
+    }
+}

--- a/Robust.Shared/Serialization/CustomFormatManager.cs
+++ b/Robust.Shared/Serialization/CustomFormatManager.cs
@@ -1,0 +1,179 @@
+﻿using Robust.Shared.Interfaces.Reflection;
+using Robust.Shared.Interfaces.Serialization;
+using Robust.Shared.IoC;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Robust.Shared.Serialization
+{
+    /// <inheritdoc cref="ICustomFormatManager"/>
+    public class CustomFormatManager : ICustomFormatManager
+    {
+        private Dictionary<Type, WithFormat<int>> _flagFormatters = new Dictionary<Type, WithFormat<int>>();
+
+        public WithFormat<int> FlagFormat<T>()
+        {
+            if (!_flagFormatters.TryGetValue(typeof(T), out var formatter))
+            {
+                formatter = new WithFlagRepresentation(GetFlag<T>());
+                _flagFormatters.Add(typeof(T), formatter);
+            }
+
+            return formatter;
+        }
+
+        /// <summary>
+        /// Get the enum flag type for the given tag <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The tag type to use for finding the flag representation. To learn more,
+        /// see the <see cref="FlagsForAttribute"/>.
+        /// </typeparam>
+        /// <exception cref="FlagSerializerException">
+        /// Thrown if:
+        /// <list type="bullet">
+        /// <item>
+        /// <description>The tag type corresponds to no enum flag representation.</description>
+        /// </item>
+        /// <item>
+        /// <description>The tag type corresponds to more than one enum flag representation.</description>
+        /// </item>
+        /// <item>
+        /// <description>The tag type corresponds to a non-enum representation.</description>
+        /// </item>
+        /// <item>
+        /// <description>The tag type corresponds to a non-int enum representation.</description>
+        /// </item>
+        /// <item>
+        /// <description>The tag type corresponds to a non-bitflag int enum representation.</description>
+        /// </item>
+        /// </list>
+        /// </exception>
+        /// <returns>
+        /// The unique int-backed bitflag enum type for the given tag.
+        /// </returns>
+        private Type GetFlag<T>()
+        {
+            var reflectionManager = IoCManager.Resolve<IReflectionManager>();
+
+            Type flagType = null;
+
+            foreach (Type bitflagType in reflectionManager.FindTypesWithAttribute<FlagsForAttribute>())
+            {
+                foreach (var flagsforAttribute in bitflagType.GetCustomAttributes<FlagsForAttribute>(true))
+                {
+                    if (typeof(T) == flagsforAttribute.Tag)
+                    {
+                        if (flagType != null)
+                        {
+                            throw new NotSupportedException($"Multiple bitflag enums declared for the tag {flagsforAttribute.Tag}.");
+                        }
+
+                        if (!bitflagType.IsEnum)
+                        {
+                            throw new FlagSerializerException($"Could not create FlagSerializer for non-enum {bitflagType}.");
+                        }
+
+                        if (Enum.GetUnderlyingType(bitflagType) != typeof(int))
+                        {
+                            throw new FlagSerializerException($"Could not create FlagSerializer for non-int enum {bitflagType}.");
+                        }
+
+                        if (!bitflagType.GetCustomAttributes<FlagsAttribute>(false).Any())
+                        {
+                            throw new FlagSerializerException($"Could not create FlagSerializer for non-bitflag enum {bitflagType}.");
+                        }
+
+
+                        flagType = bitflagType;
+                    }
+                }
+            }
+
+            if (flagType == null)
+            {
+                throw new FlagSerializerException($"Found no type marked with a `FlagsForAttribute(typeof({typeof(T)}))`.");
+            }
+
+            return flagType;
+        }
+    }
+
+    /// <summary>
+    /// <c>int</c> representation in terms of some enum flag type.
+    /// </summary>
+    public class WithFlagRepresentation : WithFormat<int>
+    {
+        private Type _flagType;
+        public Type FlagType => _flagType;
+
+        private YamlFlagSerializer _serializer;
+
+        public WithFlagRepresentation(Type flagType)
+        {
+            _flagType = flagType;
+            _serializer = new YamlFlagSerializer(_flagType, this);
+
+        }
+
+        public override YamlObjectSerializer.TypeSerializer GetYamlSerializer()
+        {
+            return _serializer;
+        }
+
+        public override Type Format => typeof(List<string>);
+
+        public override int FromCustomFormat(object obj)
+        {
+            var flagNames = (List<string>)obj;
+            var flags = 0;
+
+            foreach (var flagName in flagNames)
+            {
+                flags |= (int)Enum.Parse(_flagType, flagName);
+            }
+
+            return flags;
+        }
+
+        public override object ToCustomFormat(int flags)
+        {
+            var flagNames = new List<string>();
+
+            // Assumption: a bitflag enum has a constructor for every bit value such that
+            // that bit is set in some other constructor i.e. if a 1 appears somewhere in
+            // the bits of one of the enum constructors, there is an enum constructor which
+            // is 1 just in that position.
+            //
+            // Otherwise, this code may throw an exception
+            var maxFlagValue = ((int[])Enum.GetValues(_flagType)).Max();
+
+            for (var bitIndex = 1; bitIndex <= maxFlagValue; bitIndex = bitIndex << 1)
+            {
+                if ((bitIndex & flags) == bitIndex)
+                {
+                    var flagName = Enum.GetName(_flagType, bitIndex);
+
+                    if (flagName == null)
+                    {
+                        throw new FlagSerializerException($"No bitflag corresponding to bit {bitIndex} in {_flagType}, but it was set anyways.");
+                    }
+
+                    flagNames.Add(flagName);
+                }
+            }
+
+            return flagNames;
+        }
+    }
+
+    internal sealed class FlagSerializerException : Exception
+    {
+        public FlagSerializerException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/Robust.Shared/Serialization/ObjectSerializer.cs
+++ b/Robust.Shared/Serialization/ObjectSerializer.cs
@@ -1,7 +1,8 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Robust.Shared.Interfaces.Reflection;
+using Robust.Shared.Interfaces.Serialization;
 using Robust.Shared.IoC;
 
 namespace Robust.Shared.Serialization

--- a/Robust.Shared/Serialization/ObjectSerializer.cs
+++ b/Robust.Shared/Serialization/ObjectSerializer.cs
@@ -42,7 +42,21 @@ namespace Robust.Shared.Serialization
         /// <param name="defaultValue">A default value. Used if the field does not exist while reading or to know if writing would be redundant.</param>
         /// <param name="alwaysWrite">If true, always write this field to map saving, even if it matches the default.</param>
         /// <typeparam name="T">The type of the field that will be read/written.</typeparam>
-        public abstract void DataField<T>(ref T value, string name, T defaultValue, bool alwaysWrite = false);
+        public void DataField<T>(ref T value, string name, T defaultValue, bool alwaysWrite = false)
+        {
+            DataField<T>(ref value, name, defaultValue, WithFormat<T>.NoFormat, alwaysWrite);
+        }
+
+        /// <summary>
+        ///     Writes or reads a simple field by reference.
+        /// </summary>
+        /// <param name="value">The reference to the field that will be read/written into.</param>
+        /// <param name="name">The name of the field in the serialization medium. Most likely the name in YAML.</param>
+        /// <param name="defaultValue">A default value. Used if the field does not exist while reading or to know if writing would be redundant.</param>
+        /// <param name="withFormat">The formatter to use for representing this particular value in the medium.</param>
+        /// <param name="alwaysWrite">If true, always write this field to map saving, even if it matches the default.</param>
+        /// <typeparam name="T">The type of the field that will be read/written.</typeparam>
+        public abstract void DataField<T>(ref T value, string name, T defaultValue, WithFormat<T> withFormat, bool alwaysWrite = false);
 
         /// <summary>
         ///     Writes or reads a field or property via reflection.

--- a/Robust.Shared/Serialization/YamlCustomFormatSerializer.cs
+++ b/Robust.Shared/Serialization/YamlCustomFormatSerializer.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using YamlDotNet.Core;
+using YamlDotNet.RepresentationModel;
+
+namespace Robust.Shared.Serialization
+{
+    /// <summary>
+    /// Helper for doing custom value representation in YAML.
+    /// </summary>
+    /// <typeparam name="T">The type for which this gives a custom representation.</typeparam>
+    public class YamlCustomFormatSerializer<T> : YamlObjectSerializer.TypeSerializer
+    {
+        private readonly WithFormat<T> _formatter;
+
+        public YamlCustomFormatSerializer(WithFormat<T> formatter)
+        {
+            _formatter = formatter;
+        }
+
+        public override object NodeToType(Type _type, YamlNode node, YamlObjectSerializer serializer)
+        {
+            return _formatter.FromCustomFormat(serializer.NodeToType(_formatter.Format, node));
+        }
+
+        public override YamlNode TypeToNode(object obj, YamlObjectSerializer serializer)
+        {
+            var t = (T)obj;
+            return serializer.TypeToNode(_formatter.ToCustomFormat(t));
+        }
+    }
+
+    /// <summary>
+    /// Conveniece class for static access to custom formatters.
+    /// </summary>
+    public static class WithFormat
+    {
+        // This is concurrent because it can possibly be updated from multiple threads
+        // calling WithFormat at the same time.
+        private static readonly ConcurrentDictionary<Type, WithFormat<int>> _flagFormatters = new ConcurrentDictionary<Type, WithFormat<int>>();
+
+        public static WithFormat<int> Flags<T>()
+        {
+            return _flagFormatters.GetOrAdd(typeof(T), _type => new WithFlagRepresentation<T>());
+        }
+    }
+
+    /// <summary>
+    /// Interface for controlling custom value representation in an abstract storage medium.
+    /// </summary>
+    public abstract class WithFormat<T>
+    {
+        /// <summary>
+        /// The underlying type used for representation in the storage medium.
+        /// </summary>
+        public abstract Type Format { get; }
+
+        public abstract T FromCustomFormat(object obj);
+        public abstract object ToCustomFormat(T t);
+
+        /// <summary>
+        /// Get the corresponding YAML serializer for the custom representation.
+        /// </summary>
+        public virtual YamlObjectSerializer.TypeSerializer GetYamlSerializer()
+        {
+            return new YamlCustomFormatSerializer<T>(this);
+        }
+
+        private class DoNothing<T> : WithFormat<T>
+        {
+            public override Type Format => typeof(T);
+            public override T FromCustomFormat(object obj) { return (T)obj; }
+            public override object ToCustomFormat(T t) { return t; }
+
+            private static YamlCustomFormatSerializer<T> _serializer;
+
+            internal DoNothing()
+            {
+                if (_serializer == null)
+                    _serializer = new YamlCustomFormatSerializer<T>(this);
+            }
+
+            public override YamlObjectSerializer.TypeSerializer GetYamlSerializer()
+            {
+                return _serializer;
+            }
+        }
+
+        /// <summary>
+        /// The identity format i.e. the format which represents a value as itself.
+        /// </summary>
+        public static readonly WithFormat<T> NoFormat = new DoNothing<T>();
+    }
+}

--- a/Robust.Shared/Serialization/YamlCustomFormatSerializer.cs
+++ b/Robust.Shared/Serialization/YamlCustomFormatSerializer.cs
@@ -1,3 +1,5 @@
+﻿using Robust.Shared.Interfaces.Serialization;
+using Robust.Shared.IoC;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -37,60 +39,9 @@ namespace Robust.Shared.Serialization
     /// </summary>
     public static class WithFormat
     {
-        // This is concurrent because it can possibly be updated from multiple threads
-        // calling WithFormat at the same time.
-        private static readonly ConcurrentDictionary<Type, WithFormat<int>> _flagFormatters = new ConcurrentDictionary<Type, WithFormat<int>>();
-
         public static WithFormat<int> Flags<T>()
         {
-            return _flagFormatters.GetOrAdd(typeof(T), _type => new WithFlagRepresentation<T>());
+            return IoCManager.Resolve<ICustomFormatManager>().FlagFormat<T>();
         }
-    }
-
-    /// <summary>
-    /// Interface for controlling custom value representation in an abstract storage medium.
-    /// </summary>
-    public abstract class WithFormat<T>
-    {
-        /// <summary>
-        /// The underlying type used for representation in the storage medium.
-        /// </summary>
-        public abstract Type Format { get; }
-
-        public abstract T FromCustomFormat(object obj);
-        public abstract object ToCustomFormat(T t);
-
-        /// <summary>
-        /// Get the corresponding YAML serializer for the custom representation.
-        /// </summary>
-        public virtual YamlObjectSerializer.TypeSerializer GetYamlSerializer()
-        {
-            return new YamlCustomFormatSerializer<T>(this);
-        }
-
-        private class DoNothing<T> : WithFormat<T>
-        {
-            public override Type Format => typeof(T);
-            public override T FromCustomFormat(object obj) { return (T)obj; }
-            public override object ToCustomFormat(T t) { return t; }
-
-            private static YamlCustomFormatSerializer<T> _serializer;
-
-            internal DoNothing()
-            {
-                if (_serializer == null)
-                    _serializer = new YamlCustomFormatSerializer<T>(this);
-            }
-
-            public override YamlObjectSerializer.TypeSerializer GetYamlSerializer()
-            {
-                return _serializer;
-            }
-        }
-
-        /// <summary>
-        /// The identity format i.e. the format which represents a value as itself.
-        /// </summary>
-        public static readonly WithFormat<T> NoFormat = new DoNothing<T>();
     }
 }

--- a/Robust.Shared/Serialization/YamlCustomFormatSerializer.cs
+++ b/Robust.Shared/Serialization/YamlCustomFormatSerializer.cs
@@ -33,7 +33,7 @@ namespace Robust.Shared.Serialization
     }
 
     /// <summary>
-    /// Conveniece class for static access to custom formatters.
+    /// Convenience class for static access to custom formatters.
     /// </summary>
     public static class WithFormat
     {

--- a/Robust.Shared/Serialization/YamlFlagSerializer.cs
+++ b/Robust.Shared/Serialization/YamlFlagSerializer.cs
@@ -160,15 +160,17 @@ namespace Robust.Shared.Serialization
                             {
                                 if (_flagType != null)
                                 {
-                                    throw new NotSupportedException(
-                                        String.Format(
-                                            "Multiple bitflag enums declared for the tag {0}.",
-                                            flagsforAttribute.Tag));
+                                    throw new NotSupportedException($"Multiple bitflag enums declared for the tag {flagsforAttribute.Tag}.");
                                 }
 
                                 if (!bitflagType.IsEnum)
                                 {
-                                    throw new FlagSerializerException($"Could not create FlagSerializer for non-enum bitflagType {bitflagType}.");
+                                    throw new FlagSerializerException($"Could not create FlagSerializer for non-enum {bitflagType}.");
+                                }
+
+                                if (Enum.GetUnderlyingType(bitflagType) != typeof(int))
+                                {
+                                    throw new FlagSerializerException($"Could not create FlagSerializer for non-int enum {bitflagType}.");
                                 }
 
                                 if (!bitflagType.GetCustomAttributes<FlagsAttribute>(false).Any())

--- a/Robust.Shared/Serialization/YamlFlagSerializer.cs
+++ b/Robust.Shared/Serialization/YamlFlagSerializer.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using YamlDotNet.Core;
+using YamlDotNet.RepresentationModel;
+
+namespace Robust.Shared.Serialization
+{
+    internal class YamlFlagSerializer
+    {
+        private readonly Type _flagType;
+
+        public YamlFlagSerializer(Type type)
+        {
+            if (!type.IsEnum)
+            {
+                throw new FlagSerializerException($"Could not create FlagSerializer for non-enum type {type}.");
+            }
+
+            if (!type.GetCustomAttributes(typeof(FlagsAttribute), false).Any())
+            {
+                throw new FlagSerializerException($"Could not create FlagSerializer for non-bitflag enum {type}.");
+            }
+
+            _flagType = type;
+        }
+
+        public int NodeToFlags(YamlNode node, YamlObjectSerializer objectSerializer)
+        {
+            // Fallback to just a number, if it's not in flag format yet
+            // This is a hack, but it's only for legacy representations, so it's not so bad
+            if (node is YamlScalarNode)
+            {
+                return (int)objectSerializer.NodeToType(typeof(int), null, node);
+            }
+
+
+            var flagNames = (List<string>)objectSerializer.NodeToType(typeof(List<string>), null, node);
+            var flags = 0;
+
+            foreach (var flagName in flagNames)
+            {
+                flags |= (int)Enum.Parse(_flagType, flagName);
+            }
+
+            return flags;
+        }
+
+        public YamlNode FlagsToNode(int flags, YamlObjectSerializer objectSerializer)
+        {
+            var flagNames = new List<string>();
+
+            if (flags == 0)
+            {
+                var zeroName = Enum.GetName(_flagType, 0);
+
+                // If there's no name for 0, just write 0
+                if (zeroName == null)
+                {
+                    return objectSerializer.TypeToNode(0, null);
+                }
+
+                flagNames.Add(zeroName);
+            } else {
+                // Assumption: a bitflag enum has a constructor for every bit value such that
+                // that bit is set in some other constructor i.e. if a 1 appears somewhere in
+                // the bits of one of the enum constructors, there is an enum constructor which
+                // is 1 just in that position.
+                //
+                // Otherwise, this code may throw an exception
+                var maxFlagValue = ((int[])Enum.GetValues(_flagType)).Max();
+
+                for(var bitIndex = 1; bitIndex <= maxFlagValue; bitIndex = bitIndex << 1)
+                {
+                    if ((bitIndex & flags) == bitIndex)
+                    {
+                        var flagName = Enum.GetName(_flagType, bitIndex);
+
+                        if (flagName == null)
+                        {
+                            throw new FlagSerializerException($"No bitflag corresponding to bit {bitIndex} in {_flagType}, but it was set anyways.");
+                        }
+
+                        flagNames.Add(flagName);
+                    }
+                }
+            }
+
+            return objectSerializer.TypeToNode(flagNames, null);
+        }
+    }
+
+    internal sealed class FlagSerializerException : Exception
+    {
+        public FlagSerializerException(string message) : base(message)
+        {
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Enum, AllowMultiple = true, Inherited = false)]
+    public class FlagsForAttribute : Attribute
+    {
+        private readonly string _fieldName;
+        public string FieldName => _fieldName;
+
+        public FlagsForAttribute(string fieldName)
+        {
+            _fieldName = fieldName;
+        }
+    }
+}

--- a/Robust.Shared/SharedIoC.cs
+++ b/Robust.Shared/SharedIoC.cs
@@ -1,4 +1,4 @@
-using Robust.Shared.Asynchronous;
+﻿using Robust.Shared.Asynchronous;
 using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
 using Robust.Shared.Exceptions;
@@ -43,6 +43,7 @@ namespace Robust.Shared
             IoCManager.Register<INetManager, NetManager>();
             IoCManager.Register<IPhysicsManager, PhysicsManager>();
             IoCManager.Register<IRobustSerializer, RobustSerializer>();
+            IoCManager.Register<ICustomFormatManager, CustomFormatManager>();
             IoCManager.Register<IRuntimeLog, RuntimeLog>();
             IoCManager.Register<ITaskManager, TaskManager>();
             IoCManager.Register<ITimerManager, TimerManager>();

--- a/Robust.UnitTesting/Shared/Serialization/YamlFlagSerializer_Test.cs
+++ b/Robust.UnitTesting/Shared/Serialization/YamlFlagSerializer_Test.cs
@@ -9,10 +9,9 @@ using YamlDotNet.RepresentationModel;
 
 namespace Robust.UnitTesting.Shared.Serialization
 {
-    [Parallelizable(ParallelScope.All | ParallelScope.Fixtures)]
     [TestFixture]
     [TestOf(typeof(YamlFlagSerializer))]
-    class YamlFlagSerializer_Test
+    class YamlFlagSerializer_Test : RobustUnitTest
     {
         public sealed class GenericFlagTag {}
         public sealed class GenericFlagWithZeroTag {}

--- a/Robust.UnitTesting/Shared/Serialization/YamlFlagSerializer_Test.cs
+++ b/Robust.UnitTesting/Shared/Serialization/YamlFlagSerializer_Test.cs
@@ -14,6 +14,9 @@ namespace Robust.UnitTesting.Shared.Serialization
     [TestOf(typeof(YamlFlagSerializer))]
     class YamlFlagSerializer_Test
     {
+        public sealed class GenericFlagTag {}
+        public sealed class GenericFlagWithZeroTag {}
+
         [Test]
         public void SerializeOneFlagTest()
         {
@@ -23,7 +26,7 @@ namespace Robust.UnitTesting.Shared.Serialization
             var serializer = YamlObjectSerializer.NewWriter(mapping);
 
             // Act
-            serializer.DataField(ref data, "generic_flags", 0);
+            serializer.DataField(ref data, "generic_flags", 0, WithFormat.Flags<GenericFlagTag>());
 
             // Assert
             var result = YamlObjectSerializer_Test.NodeToYamlText(mapping);
@@ -39,7 +42,7 @@ namespace Robust.UnitTesting.Shared.Serialization
             var serializer = YamlObjectSerializer.NewReader(rootNode);
 
             // Act
-            serializer.DataField(ref data, "generic_flags", 0);
+            serializer.DataField(ref data, "generic_flags", 0, WithFormat.Flags<GenericFlagTag>());
 
             // Assert
             Assert.That(data, Is.EqualTo((int)GenericFlags.One));
@@ -54,7 +57,7 @@ namespace Robust.UnitTesting.Shared.Serialization
             var serializer = YamlObjectSerializer.NewWriter(mapping);
 
             // Act
-            serializer.DataField(ref data, "generic_flags", 0);
+            serializer.DataField(ref data, "generic_flags", 0, WithFormat.Flags<GenericFlagTag>());
 
             // Assert
             var result = YamlObjectSerializer_Test.NodeToYamlText(mapping);
@@ -70,7 +73,7 @@ namespace Robust.UnitTesting.Shared.Serialization
             var serializer = YamlObjectSerializer.NewReader(rootNode);
 
             // Act
-            serializer.DataField(ref data, "generic_flags", 0);
+            serializer.DataField(ref data, "generic_flags", 0, WithFormat.Flags<GenericFlagTag>());
 
             // Assert
             Assert.That(data, Is.EqualTo((int)GenericFlags.Five));
@@ -85,7 +88,7 @@ namespace Robust.UnitTesting.Shared.Serialization
             var serializer = YamlObjectSerializer.NewWriter(mapping);
 
             // Act
-            serializer.DataField(ref data, "generic_flags", 0, alwaysWrite: true);
+            serializer.DataField(ref data, "generic_flags", 0, WithFormat.Flags<GenericFlagTag>(), alwaysWrite: true);
 
             // Assert
             var result = YamlObjectSerializer_Test.NodeToYamlText(mapping);
@@ -101,7 +104,7 @@ namespace Robust.UnitTesting.Shared.Serialization
             var serializer = YamlObjectSerializer.NewReader(rootNode);
 
             // Act
-            serializer.DataField(ref data, "generic_flags", 0);
+            serializer.DataField(ref data, "generic_flags", 0, WithFormat.Flags<GenericFlagTag>());
 
             // Assert
             Assert.That(data, Is.EqualTo(0));
@@ -121,7 +124,7 @@ namespace Robust.UnitTesting.Shared.Serialization
             var serializer = YamlObjectSerializer.NewWriter(mapping);
 
             // Act
-            serializer.DataField(ref data, "generic_flags_with_zero", 0, alwaysWrite: true);
+            serializer.DataField(ref data, "generic_flags_with_zero", 0, WithFormat.Flags<GenericFlagWithZeroTag>(), alwaysWrite: true);
 
             // Assert
             var result = YamlObjectSerializer_Test.NodeToYamlText(mapping);
@@ -137,7 +140,7 @@ namespace Robust.UnitTesting.Shared.Serialization
             var serializer = YamlObjectSerializer.NewReader(rootNode);
 
             // Act
-            serializer.DataField(ref data, "generic_flags_with_zero", 0);
+            serializer.DataField(ref data, "generic_flags_with_zero", 0, WithFormat.Flags<GenericFlagWithZeroTag>());
 
             // Assert
             Assert.That(data, Is.EqualTo(0));
@@ -152,7 +155,7 @@ namespace Robust.UnitTesting.Shared.Serialization
             var serializer = YamlObjectSerializer.NewWriter(mapping);
 
             // Act
-            serializer.DataField(ref data, "generic_flags_with_zero", 0);
+            serializer.DataField(ref data, "generic_flags_with_zero", 0, WithFormat.Flags<GenericFlagWithZeroTag>());
 
             // Assert
             var result = YamlObjectSerializer_Test.NodeToYamlText(mapping);
@@ -163,7 +166,7 @@ namespace Robust.UnitTesting.Shared.Serialization
         private const string SerializedTwoWithZeroFlag = "generic_flags_with_zero:\n- Two\n...\n";
 
         [Flags]
-        [FlagsFor("generic_flags")]
+        [FlagsFor(typeof(GenericFlagTag))]
         private enum GenericFlags
         {
             One = 1,
@@ -173,7 +176,7 @@ namespace Robust.UnitTesting.Shared.Serialization
         }
 
         [Flags]
-        [FlagsFor("generic_flags_with_zero")]
+        [FlagsFor(typeof(GenericFlagWithZeroTag))]
         private enum FlagsWithZero
         {
             None = 0,

--- a/Robust.UnitTesting/Shared/Serialization/YamlFlagSerializer_Test.cs
+++ b/Robust.UnitTesting/Shared/Serialization/YamlFlagSerializer_Test.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using Robust.Shared.Maths;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+using YamlDotNet.RepresentationModel;
+
+namespace Robust.UnitTesting.Shared.Serialization
+{
+    [Parallelizable(ParallelScope.All | ParallelScope.Fixtures)]
+    [TestFixture]
+    [TestOf(typeof(YamlFlagSerializer))]
+    class YamlFlagSerializer_Test
+    {
+        [Test]
+        public void SerializeOneFlagTest()
+        {
+            // Arrange
+            var data = (int)GenericFlags.One;
+            var mapping = new YamlMappingNode();
+            var serializer = YamlObjectSerializer.NewWriter(mapping);
+
+            // Act
+            serializer.DataField(ref data, "generic_flags", 0);
+
+            // Assert
+            var result = YamlObjectSerializer_Test.NodeToYamlText(mapping);
+            Assert.That(result, Is.EqualTo(SerializedOneFlag));
+        }
+
+        [Test]
+        public void DeserializeOneFlagTest()
+        {
+            // Arrange
+            var data = 0;
+            var rootNode = YamlObjectSerializer_Test.YamlTextToNode(SerializedOneFlag);
+            var serializer = YamlObjectSerializer.NewReader(rootNode);
+
+            // Act
+            serializer.DataField(ref data, "generic_flags", 0);
+
+            // Assert
+            Assert.That(data, Is.EqualTo((int)GenericFlags.One));
+        }
+
+        [Test]
+        public void SerializeFiveFlagTest()
+        {
+            // Arrange
+            var data = (int)GenericFlags.Five;
+            var mapping = new YamlMappingNode();
+            var serializer = YamlObjectSerializer.NewWriter(mapping);
+
+            // Act
+            serializer.DataField(ref data, "generic_flags", 0);
+
+            // Assert
+            var result = YamlObjectSerializer_Test.NodeToYamlText(mapping);
+            Assert.That(result, Is.EqualTo(SerializedFiveFlag));
+        }
+
+        [Test]
+        public void DeserializeFiveFlagTest()
+        {
+            // Arrange
+            var data = 0;
+            var rootNode = YamlObjectSerializer_Test.YamlTextToNode(SerializedFiveFlag);
+            var serializer = YamlObjectSerializer.NewReader(rootNode);
+
+            // Act
+            serializer.DataField(ref data, "generic_flags", 0);
+
+            // Assert
+            Assert.That(data, Is.EqualTo((int)GenericFlags.Five));
+        }
+
+        [Test]
+        public void SerializeZeroWithoutFlagTest()
+        {
+            // Arrange
+            var data = 0;
+            var mapping = new YamlMappingNode();
+            var serializer = YamlObjectSerializer.NewWriter(mapping);
+
+            // Act
+            serializer.DataField(ref data, "generic_flags", 0, alwaysWrite: true);
+
+            // Assert
+            var result = YamlObjectSerializer_Test.NodeToYamlText(mapping);
+            Assert.That(result, Is.EqualTo(SerializedZeroNum));
+        }
+
+        [Test]
+        public void DeserializeZeroWithoutFlagTest()
+        {
+            // Arrange
+            var data = 0;
+            var rootNode = YamlObjectSerializer_Test.YamlTextToNode(SerializedZeroNum);
+            var serializer = YamlObjectSerializer.NewReader(rootNode);
+
+            // Act
+            serializer.DataField(ref data, "generic_flags", 0);
+
+            // Assert
+            Assert.That(data, Is.EqualTo(0));
+        }
+
+        private const string SerializedOneFlag = "generic_flags:\n- One\n...\n";
+        private const string SerializedFiveFlag = "generic_flags:\n- One\n- Four\n...\n";
+        private const string SerializedZeroNum = "generic_flags: 0\n...\n";
+
+        [Test]
+        public void SerializeZeroWithFlagTest()
+        {
+            // Arrange
+            var data = 0;
+            var mapping = new YamlMappingNode();
+            var serializer = YamlObjectSerializer.NewWriter(mapping);
+
+            // Act
+            serializer.DataField(ref data, "generic_flags_with_zero", 0, alwaysWrite: true);
+
+            // Assert
+            var result = YamlObjectSerializer_Test.NodeToYamlText(mapping);
+            Assert.That(result, Is.EqualTo(SerializedZeroFlag));
+        }
+
+        [Test]
+        public void DeserializeZeroWithFlagTest()
+        {
+            // Arrange
+            var data = 0;
+            var rootNode = YamlObjectSerializer_Test.YamlTextToNode(SerializedZeroFlag);
+            var serializer = YamlObjectSerializer.NewReader(rootNode);
+
+            // Act
+            serializer.DataField(ref data, "generic_flags_with_zero", 0);
+
+            // Assert
+            Assert.That(data, Is.EqualTo(0));
+        }
+
+        private const string SerializedZeroFlag = "generic_flags_with_zero:\n- None\n...\n";
+
+        [Flags]
+        [FlagsFor("generic_flags")]
+        private enum GenericFlags
+        {
+            One = 1,
+            Two = 2,
+            Four = 4,
+            Five = 5,
+        }
+
+        [Flags]
+        [FlagsFor("generic_flags_with_zero")]
+        private enum FlagsWithZero
+        {
+            None = 0,
+            One = 1,
+            Two = 2,
+            Four = 4,
+            Five = 5,
+        }
+    }
+}

--- a/Robust.UnitTesting/Shared/Serialization/YamlFlagSerializer_Test.cs
+++ b/Robust.UnitTesting/Shared/Serialization/YamlFlagSerializer_Test.cs
@@ -58,7 +58,7 @@ namespace Robust.UnitTesting.Shared.Serialization
 
             // Assert
             var result = YamlObjectSerializer_Test.NodeToYamlText(mapping);
-            Assert.That(result, Is.EqualTo(SerializedFiveFlag));
+            Assert.That(result, Is.EqualTo(SerializedOneFourFlag));
         }
 
         [Test]
@@ -108,7 +108,8 @@ namespace Robust.UnitTesting.Shared.Serialization
         }
 
         private const string SerializedOneFlag = "generic_flags:\n- One\n...\n";
-        private const string SerializedFiveFlag = "generic_flags:\n- One\n- Four\n...\n";
+        private const string SerializedOneFourFlag = "generic_flags:\n- One\n- Four\n...\n";
+        private const string SerializedFiveFlag = "generic_flags:\n- Five\n...\n";
         private const string SerializedZeroNum = "generic_flags: 0\n...\n";
 
         [Test]
@@ -142,7 +143,24 @@ namespace Robust.UnitTesting.Shared.Serialization
             Assert.That(data, Is.EqualTo(0));
         }
 
+        [Test]
+        public void SerializeNonZeroWithZeroFlagDoesntShowZeroTest()
+        {
+            // Arrange
+            var data = (int)FlagsWithZero.Two;
+            var mapping = new YamlMappingNode();
+            var serializer = YamlObjectSerializer.NewWriter(mapping);
+
+            // Act
+            serializer.DataField(ref data, "generic_flags_with_zero", 0);
+
+            // Assert
+            var result = YamlObjectSerializer_Test.NodeToYamlText(mapping);
+            Assert.That(result, Is.EqualTo(SerializedTwoWithZeroFlag));
+        }
+
         private const string SerializedZeroFlag = "generic_flags_with_zero:\n- None\n...\n";
+        private const string SerializedTwoWithZeroFlag = "generic_flags_with_zero:\n- Two\n...\n";
 
         [Flags]
         [FlagsFor("generic_flags")]

--- a/Robust.UnitTesting/Shared/Serialization/YamlObjectSerializer_Test.cs
+++ b/Robust.UnitTesting/Shared/Serialization/YamlObjectSerializer_Test.cs
@@ -124,7 +124,7 @@ namespace Robust.UnitTesting.Shared.Serialization
         private readonly Dictionary<string, int> SerializableDict = new Dictionary<string, int> { { "val1", 1 }, { "val2", 2 } };
 
         // serializes a node tree into text
-        private static string NodeToYamlText(YamlNode root)
+        internal static string NodeToYamlText(YamlNode root)
         {
             var document = new YamlDocument(root);
 
@@ -142,7 +142,7 @@ namespace Robust.UnitTesting.Shared.Serialization
         }
 
         // deserializes yaml text, loads the first document, and returns the first entity
-        private static YamlMappingNode YamlTextToNode(string text)
+        internal static YamlMappingNode YamlTextToNode(string text)
         {
             using (var stream = new MemoryStream())
             {


### PR DESCRIPTION
It's now possible to hook an enum into the serialization and deserialization of a field in `DataField`, using an attribute. This allows for bitflags in the engine to be defined in the content, in a way that lets content creators write flag names in prototype YAML.

This works by annotating an enum with the [FlagsFor(<tagtype>)] attribute, which the YamlObjectSerializer picks up through the ReflectionManager to use as a special serializer for fields with the right invocation with that tag type.

Fixes #974.