### PR TITLE
Hot reloading for YAML files

### DIFF
--- a/Robust.Server/Console/Commands/ReloadCommand.cs
+++ b/Robust.Server/Console/Commands/ReloadCommand.cs
@@ -1,0 +1,41 @@
+using JetBrains.Annotations;
+using Robust.Server.Interfaces.Console;
+using Robust.Server.Interfaces.Player;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Robust.Server.Console.Commands
+{
+    [UsedImplicitly]
+    public class ReloadCommand: IClientCommand
+    {
+        public string Command => "reload";
+
+        public string Description => "Reloads all entity prototypes and updates entities in-game accordingly";
+
+        public string Help => "";
+
+        public void Execute(IConsoleShell shell, IPlayerSession player, string[] args)
+        {
+            var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
+            var entityManager = IoCManager.Resolve<IEntityManager>();
+
+            // Clear all prototypes
+            prototypeManager.Clear();
+            prototypeManager.ReloadPrototypeTypes();
+            prototypeManager.LoadDirectory(new ResourcePath(@"/Prototypes/"));
+            prototypeManager.Resync();
+
+            foreach (var prototype in prototypeManager.EnumeratePrototypes<EntityPrototype>())
+            {
+                foreach (var entity in entityManager.GetEntities(new PredicateEntityQuery(e => e.Prototype != null && e.Prototype.ID == prototype.ID)))
+                {
+                    prototype.UpdateEntity(entity as Entity);
+                }
+            }
+        }
+    }
+}

--- a/Robust.Server/Console/Commands/ReloadCommand.cs
+++ b/Robust.Server/Console/Commands/ReloadCommand.cs
@@ -21,21 +21,8 @@ namespace Robust.Server.Console.Commands
         public void Execute(IConsoleShell shell, IPlayerSession player, string[] args)
         {
             var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
-            var entityManager = IoCManager.Resolve<IEntityManager>();
 
-            // Clear all prototypes
-            prototypeManager.Clear();
-            prototypeManager.ReloadPrototypeTypes();
-            prototypeManager.LoadDirectory(new ResourcePath(@"/Prototypes/"));
-            prototypeManager.Resync();
-
-            foreach (var prototype in prototypeManager.EnumeratePrototypes<EntityPrototype>())
-            {
-                foreach (var entity in entityManager.GetEntities(new PredicateEntityQuery(e => e.Prototype != null && e.Prototype.ID == prototype.ID)))
-                {
-                    prototype.UpdateEntity(entity as Entity);
-                }
-            }
+            prototypeManager.ReloadPrototypes();
         }
     }
 }

--- a/Robust.Shared/ContentPack/ResourceManager.cs
+++ b/Robust.Shared/ContentPack/ResourceManager.cs
@@ -311,6 +311,17 @@ namespace Robust.Shared.ContentPack
             }
         }
 
+        public IEnumerable<ResourcePath> GetContentRoots()
+        {
+            foreach (var (_, root) in _contentRoots)
+            {
+                if (root is DirLoader loader)
+                {
+                    yield return new ResourcePath(loader.GetPath(new ResourcePath(@"/")));
+                }
+            }
+        }
+
         internal static bool IsPathValid(ResourcePath path)
         {
             var asString = path.ToString();

--- a/Robust.Shared/Interfaces/Resources/IResourceManager.cs
+++ b/Robust.Shared/Interfaces/Resources/IResourceManager.cs
@@ -126,6 +126,12 @@ namespace Robust.Shared.Interfaces.Resources
         IEnumerable<ResourcePath> ContentFindFiles(string path);
 
         /// <summary>
+        ///     Returns a list of paths to all top-level content directories
+        /// </summary>
+        /// <returns></returns>
+        IEnumerable<ResourcePath> GetContentRoots();
+
+        /// <summary>
         ///     TODO: TEMPORARY: We need this because Godot can't load most resources without the disk easily.
         ///     Actually, seems like JetBrains Rider has trouble loading PBD files passed into AppDomain.Load too.
         ///     Hrm.

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -60,6 +60,10 @@ namespace Robust.Shared.Prototypes
         /// </summary>
         void Clear();
         /// <summary>
+        ///     Reload all prototype types.
+        /// </summary>
+        void ReloadPrototypeTypes();
+        /// <summary>
         /// Syncs all inter-prototype data. Call this when operations adding new prototypes are done.
         /// </summary>
         void Resync();
@@ -269,7 +273,7 @@ namespace Robust.Shared.Prototypes
             ReloadPrototypeTypes();
         }
 
-        private void ReloadPrototypeTypes()
+        public void ReloadPrototypeTypes()
         {
             Clear();
             foreach (var type in ReflectionManager.GetAllChildren<IPrototype>())


### PR DESCRIPTION
Closes #1064.

This will allow you to reload prototype files while in game, which will update the game accordingly. It will be possible to do this both automatically and manually via the `reload` command.

## To do
- [X] Implement reloading for entity prototypes
- [X] Preserve the state of entity components if they have been modified since their creation
- [ ] Implement reloading for other prototype variants
- [ ] Make reloading automatic, which can be enabled/disabled in `server_config.toml`
- [ ] Send messages so that things get updated client-side too