### PR TITLE
Set ResourcePath and SpriteSpecifier inheritors as NetSerializable

### DIFF
--- a/Robust.Shared/Utility/ResourcePath.cs
+++ b/Robust.Shared/Utility/ResourcePath.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
+using Robust.Shared.Serialization;
 
 namespace Robust.Shared.Utility
 {
@@ -12,7 +13,7 @@ namespace Robust.Shared.Utility
     ///     Provides object-oriented path manipulation for resource paths.
     ///     ResourcePaths are immutable.
     /// </summary>
-    [PublicAPI]
+    [PublicAPI, Serializable, NetSerializable]
     public sealed class ResourcePath : IEquatable<ResourcePath>
     {
         /// <summary>

--- a/Robust.Shared/Utility/SpriteSpecifier.cs
+++ b/Robust.Shared/Utility/SpriteSpecifier.cs
@@ -30,6 +30,7 @@ namespace Robust.Shared.Utility
             throw new InvalidOperationException();
         }
 
+        [Serializable, NetSerializable]
         public sealed class Rsi : SpriteSpecifier
         {
             public readonly ResourcePath RsiPath;
@@ -42,6 +43,7 @@ namespace Robust.Shared.Utility
             }
         }
 
+        [Serializable, NetSerializable]
         public sealed class Texture : SpriteSpecifier
         {
             public readonly ResourcePath TexturePath;


### PR DESCRIPTION
Fixes a crash when right clicking a toolbox below your character