### PR TITLE
Allow drawing unfilled circles, remove extra (0, 0) point

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
@@ -299,7 +299,7 @@ namespace Robust.Client.Graphics.Clyde
                     _renderHandle.UseShader(shader);
                 }
 
-                public override void DrawCircle(Vector2 position, float radius, Color color)
+                public override void DrawCircle(Vector2 position, float radius, Color color, bool filled = true)
                 {
                     // TODO: Implement this.
                 }

--- a/Robust.Client/Graphics/Drawing/DrawingHandleBase.cs
+++ b/Robust.Client/Graphics/Drawing/DrawingHandleBase.cs
@@ -87,7 +87,7 @@ namespace Robust.Client.Graphics.Drawing
             }
         }
 
-        public abstract void DrawCircle(Vector2 position, float radius, Color color);
+        public abstract void DrawCircle(Vector2 position, float radius, Color color, bool filled = true);
 
         public abstract void DrawLine(Vector2 from, Vector2 to, Color color);
     }

--- a/Robust.Client/Graphics/Drawing/DrawingHandleScreen.cs
+++ b/Robust.Client/Graphics/Drawing/DrawingHandleScreen.cs
@@ -23,12 +23,11 @@ namespace Robust.Client.Graphics.Drawing
             DrawTextureRectRegion(texture, rect, null, modulate);
         }
 
-        public override void DrawCircle(Vector2 position, float radius, Color color)
+        public override void DrawCircle(Vector2 position, float radius, Color color, bool filled = true)
         {
             const int segments = 64;
-            Span<Vector2> buffer = stackalloc Vector2[segments + 2];
+            Span<Vector2> buffer = stackalloc Vector2[segments + 1];
 
-            buffer[0] = position;
             for (var i = 0; i <= segments; i++)
             {
                 var angle = i / (float) segments * MathHelper.TwoPi;
@@ -37,7 +36,8 @@ namespace Robust.Client.Graphics.Drawing
                 buffer[i] = position + pos * radius;
             }
 
-            DrawPrimitives(DrawPrimitiveTopology.TriangleFan, buffer, color);
+            DrawPrimitiveTopology type = filled ? DrawPrimitiveTopology.TriangleFan : DrawPrimitiveTopology.LineStrip;
+            DrawPrimitives(type, buffer, color);
         }
     }
 }


### PR DESCRIPTION
1. The original triangle-fan creator seems to be designed to create a central point and build a fan around it, but due to a missing `+ 1`, this didn't work as likely intended. But it worked fine since circles are convex and (0, 0) would (presumably) create a CCW triangle and get culled.
This PR cleans it up to keep the drawing method acting the same as it is presently and remove the (0, 0) point generated by the misalignment.
2. This adds the ability to draw unfilled circles via an optional parameter, `filled`, that defaults to `true`. (With the (0, 0) point removed, this is just a change of primitive type.)

NOTE: This is a commit off of the checked-out RobustToolbox of an SS14 PR ( space-wizards/space-station-14#961 ).
The change in commit has *not* been committed, I recall reading that one is not supposed to do that.
The visual element this is being used for is optional and will be commented out in the next commit to that PR. If that's an issue, please comment.