### PR TITLE
Adds SpriteKey value to SpriteComponent

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -115,7 +115,7 @@ namespace Robust.Client.GameObjects
         /// <summary>
         ///     We will allow for unique interactions with other objects with the same key.
         /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
+        [ViewVariables(VVAccess.ReadOnly)]
         public string SpriteKey => _spriteKey;
 
         private RSI _baseRsi;

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -30,6 +30,7 @@ namespace Robust.Client.GameObjects
         IComponentDebug
     {
         private bool _visible = true;
+        private string _spriteKey;
 
         [ViewVariables(VVAccess.ReadWrite)]
         public bool Visible
@@ -110,6 +111,12 @@ namespace Robust.Client.GameObjects
         }
 
         private bool _directional = true;
+
+        /// <summary>
+        ///     We will allow for unique interactions with other objects with the same key.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        public string SpriteKey => _spriteKey;
 
         private RSI _baseRsi;
 
@@ -1110,6 +1117,7 @@ namespace Robust.Client.GameObjects
             serializer.DataFieldCached(ref color, "color", Color.White);
             serializer.DataFieldCached(ref _directional, "directional", true);
             serializer.DataFieldCached(ref _visible, "visible", true);
+            serializer.DataFieldCached(ref _spriteKey, "key", "");
 
             // TODO: Writing?
             if (!serializer.Reading)


### PR DESCRIPTION
Made for https://github.com/space-wizards/space-station-14/pull/1013

While I'm aware it might seem strange to assign an engine variable for my changes specifically in the above PR I believe it's a good idea to allow for sprite components to contain keys for use with other interacting components.