### PR TITLE
Adds custom YAML serializer for ints in terms of named constants

### DIFF
--- a/Robust.Shared/Interfaces/Serialization/ICustomFormatManager.cs
+++ b/Robust.Shared/Interfaces/Serialization/ICustomFormatManager.cs
@@ -21,6 +21,18 @@ namespace Robust.Shared.Interfaces.Serialization
         /// A custom serialization format for int values, chosen by the tag type.
         /// </returns>
         public WithFormat<int> FlagFormat<T>();
+
+        /// <summary>
+        /// Get a custom <c>int</c> format in terms of enum constants, chosen by a tag type.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The tag type to select the representation with. To understand more about how
+        /// tag types are used, see the <see cref="ConstantsForAttribute"/>.
+        /// </typeparam>
+        /// <returns>
+        /// A custom serialization format for int values, chosen by the tag type.
+        /// </returns>
+        public WithFormat<int> ConstantFormat<T>();
     }
 
 

--- a/Robust.Shared/Serialization/YamlConstantSerializer.cs
+++ b/Robust.Shared/Serialization/YamlConstantSerializer.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using YamlDotNet.Core;
+using YamlDotNet.RepresentationModel;
+
+using Robust.Shared.Interfaces.Reflection;
+using Robust.Shared.Interfaces.Serialization;
+using Robust.Shared.IoC;
+
+namespace Robust.Shared.Serialization
+{
+    /// <summary>
+    /// Serializer for converting integer to/from named constant representation in YAML.
+    ///
+    /// This serializes an integer value as a named constant, based on the values of some
+    /// enum type.
+    /// </summary>
+    internal class YamlConstantSerializer : YamlCustomFormatSerializer<int>
+    {
+        private readonly Type _constantType;
+
+        /// <summary>
+        /// Create a YamlConstantSerializer using the given bitflag representation type.
+        /// </summary>
+        /// <param name="type">
+        /// The enum for which the constructors will be used to represent constant values.
+        /// </param>
+        /// </exception>
+        public YamlConstantSerializer(Type type, WithFormat<int> formatter) : base(formatter)
+        {
+            _constantType = type;
+        }
+
+        /// <summary>
+        /// Turn a YAML node into an integer value of the corresponding constant.
+        /// </summary>
+        public override object NodeToType(Type type, YamlNode node, YamlObjectSerializer objectSerializer)
+        {
+            try
+            {
+                // First try to deserialize a legacy integer value
+                return (int)objectSerializer.NodeToType(typeof(int), node);
+            }
+            catch (ArgumentException e)
+            {
+                return base.NodeToType(type, node, objectSerializer);
+            }
+
+        }
+
+        /// <summary>
+        /// Turn an integer into a YAML node with the corresponding constant name.
+        /// </summary>
+        /// <returns>
+        /// A string node of the constant corresponding to the given value.
+        /// </returns>
+        /// <exception cref="ConstantSerializerException">
+        /// Thrown if there is no corresponding constant name to the value passed in.
+        /// </exception>
+        public override YamlNode TypeToNode(object obj, YamlObjectSerializer objectSerializer)
+        {
+            return base.TypeToNode(obj, objectSerializer);
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Enum, AllowMultiple = true, Inherited = false)]
+    /// <summary>
+    /// Attribute for marking an enum type as being the constant representation for a field.
+    ///
+    /// Some fields are arbitrary ints, but it's helpful for readability to have them be
+    /// named constants instead. This allows for that.
+    ///
+    /// NB: AllowMultiple is <c>true</c> - don't assume the same representation cannot
+    /// be reused between multiple fields.
+    /// </summary>
+    public class ConstantsForAttribute : Attribute
+    {
+        private readonly Type _tag;
+        public Type Tag => _tag;
+
+        // NB: This is not generic because C# does not allow generic attributes
+
+        /// <summary>
+        /// An attribute with tag type <paramref name="tag"/>
+        /// </summary>
+        /// <param name="tag">
+        /// An arbitrary tag type used for coordinating between the data field and the
+        /// representation. Not actually used for serialization/deserialization.
+        /// </param>
+        public ConstantsForAttribute(Type tag)
+        {
+            _tag = tag;
+        }
+    }
+}

--- a/Robust.Shared/Serialization/YamlCustomFormatSerializer.cs
+++ b/Robust.Shared/Serialization/YamlCustomFormatSerializer.cs
@@ -43,5 +43,10 @@ namespace Robust.Shared.Serialization
         {
             return IoCManager.Resolve<ICustomFormatManager>().FlagFormat<T>();
         }
+
+        public static WithFormat<int> Constants<T>()
+        {
+            return IoCManager.Resolve<ICustomFormatManager>().ConstantFormat<T>();
+        }
     }
 }

--- a/Robust.UnitTesting/Shared/Serialization/YamlConstantSerializer_Test.cs
+++ b/Robust.UnitTesting/Shared/Serialization/YamlConstantSerializer_Test.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using Robust.Shared.Maths;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+using YamlDotNet.RepresentationModel;
+
+namespace Robust.UnitTesting.Shared.Serialization
+{
+    [TestFixture]
+    [TestOf(typeof(YamlConstantSerializer))]
+    class YamlConstantSerializer_Test : RobustUnitTest
+    {
+        public sealed class GenericConstantTag {}
+
+        [Test]
+        public void SerializeOneConstantTest()
+        {
+            // Arrange
+            var data = (int)GenericConstants.One;
+            var mapping = new YamlMappingNode();
+            var serializer = YamlObjectSerializer.NewWriter(mapping);
+
+            // Act
+            serializer.DataField(ref data, "generic_constants", 0, WithFormat.Constants<GenericConstantTag>());
+
+            // Assert
+            var result = YamlObjectSerializer_Test.NodeToYamlText(mapping);
+            Assert.That(result, Is.EqualTo(SerializedOneConstant));
+        }
+
+        [Test]
+        public void DeserializeOneConstantTest()
+        {
+            // Arrange
+            var data = 0;
+            var rootNode = YamlObjectSerializer_Test.YamlTextToNode(SerializedOneConstant);
+            var serializer = YamlObjectSerializer.NewReader(rootNode);
+
+            // Act
+            serializer.DataField(ref data, "generic_constants", 0, WithFormat.Constants<GenericConstantTag>());
+
+            // Assert
+            Assert.That(data, Is.EqualTo((int)GenericConstants.One));
+        }
+
+        [Test]
+        public void DeserializeLegacyFormatTest()
+        {
+            // Arrange
+            var data = 0;
+            var rootNode = YamlObjectSerializer_Test.YamlTextToNode(SerializedThree);
+            var serializer = YamlObjectSerializer.NewReader(rootNode);
+
+            // Act
+            serializer.DataField(ref data, "generic_constants", 0, WithFormat.Constants<GenericConstantTag>());
+
+            // Assert
+            Assert.That(data, Is.EqualTo((int)GenericConstants.Three));
+        }
+
+        private const string SerializedOneConstant = "generic_constants: One\n...\n";
+        private const string SerializedThree = "generic_constants: 3\n...\n";
+
+        [ConstantsFor(typeof(GenericConstantTag))]
+        private enum GenericConstants
+        {
+            One = 1,
+            Three = 3,
+        }
+    }
+}


### PR DESCRIPTION
This PR brought to you by copy, paste, find, and replace.

This allows for ints to be serialized in terms of the constructor names of an enum.

This is intended for pulling `DrawDepth` out of the engine, where it is currently defined, into the content, while still allowing YAML files to define the draw depth in terms of the names.