### PR TITLE
Add ghosts layer between mobs and overlays

### DIFF
--- a/Robust.Shared/GameObjects/ComponentEnums.cs
+++ b/Robust.Shared/GameObjects/ComponentEnums.cs
@@ -20,6 +20,7 @@
         Objects = 7,
         Items = 8,
         Mobs = 9,
-        Overlays = 10,
+        Ghosts = 10,
+        Overlays = 11,
     }
 }


### PR DESCRIPTION
Add a specific layer for the ghost.

For reference, SS13 ghosts layer is 6, vs 4 for the mob layer.