### PR TITLE
Change buttons to use MouseFilterMode.Stop

### DIFF
--- a/Robust.Client/UserInterface/Controls/BaseButton.cs
+++ b/Robust.Client/UserInterface/Controls/BaseButton.cs
@@ -188,7 +188,7 @@ namespace Robust.Client.UserInterface.Controls
 
         protected BaseButton()
         {
-            MouseFilter = MouseFilterMode.Pass;
+            MouseFilter = MouseFilterMode.Stop;
         }
 
         protected virtual void DrawModeChanged()


### PR DESCRIPTION
This changes buttons so that they always stop input when clicked. This fixes canceling a click on the X button of a SS14Window by blocking it from selecting the window and moving that at the same time.