### PR TITLE
Add check to solve UIClick upbind not getting sent to Controls

### DIFF
--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -300,7 +300,11 @@ namespace Robust.Client.UserInterface
                 args.PointerLocation.Position - control.GlobalPixelPosition);
 
             _doGuiInput(control, guiArgs, (c, ev) => c.KeyBindUp(ev));
-            _controlFocused = null;
+
+            if (guiArgs.Handled || args.Function == EngineKeyFunctions.UIClick)
+            {
+                _controlFocused = null;
+            }
 
             // Always mark this as handled.
             // The only case it should not be is if we do not have a control to click on,


### PR DESCRIPTION
Specifically button highlighting not getting cleared and updated due to `EngineKeyFunctions.UIClick` not getting triggered because `EngineKeyFunctions.Use` set `_controlFocused` to `null` before it processed the `UIClick`.