### PR TITLE
Fix lasers changing DrawingHandleWorld transform

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/EffectSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/EffectSystem.cs
@@ -1,5 +1,4 @@
 ﻿using Robust.Client.Graphics;
-using Robust.Client.Graphics.ClientEye;
 using Robust.Client.Graphics.Drawing;
 using Robust.Client.Interfaces.Graphics.ClientEye;
 using Robust.Client.Interfaces.ResourceManagement;
@@ -352,12 +351,13 @@ namespace Robust.Client.GameObjects
                         currentShader = newShader;
                     }
 
-                    worldHandle.SetTransform(
-                        effect.Coordinates.ToMapPos(_mapManager),
-                        new Angle(-effect.Rotation), effect.Size);
                     var effectSprite = effect.EffectSprite;
-                    worldHandle.DrawTexture(effectSprite,
-                        -((Vector2) effectSprite.Size / EyeManager.PixelsPerMeter) / 2, ToColor(effect.Color));
+                    var effectOrigin = effect.Coordinates.ToMapPos(_mapManager);
+                    var effectArea = Box2.CenteredAround(effectOrigin, effect.Size);
+
+                    var rotatedBox = new Box2Rotated(effectArea, effect.Rotation, effectOrigin);
+
+                    worldHandle.DrawTextureRect(effectSprite, rotatedBox, ToColor(effect.Color));
                 }
             }
         }

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -204,7 +204,8 @@ namespace Robust.Client.Graphics.Clyde
                     var box = Box2i.FromDimensions(rounded, EntityPostRenderTarget.Size);
 
                     _renderHandle.DrawTexture(EntityPostRenderTarget.Texture,
-                        new Box2Rotated(box.BottomLeft, box.TopRight), Color.White, null);
+                        box.BottomLeft, box.BottomRight, box.TopLeft, box.TopRight,
+                        Color.White, null);
 
                     _renderHandle.SetSpace(CurrentSpace.WorldSpace);
                     _renderHandle.UseShader(null);

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -203,8 +203,8 @@ namespace Robust.Client.Graphics.Clyde
 
                     var box = Box2i.FromDimensions(rounded, EntityPostRenderTarget.Size);
 
-                    _renderHandle.DrawTexture(EntityPostRenderTarget.Texture, box.BottomLeft,
-                        box.TopRight, Color.White, null, 0);
+                    _renderHandle.DrawTexture(EntityPostRenderTarget.Texture,
+                        new Box2Rotated(box.BottomLeft, box.TopRight), Color.White, null);
 
                     _renderHandle.SetSpace(CurrentSpace.WorldSpace);
                     _renderHandle.UseShader(null);

--- a/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics.ClientEye;
@@ -42,8 +42,7 @@ namespace Robust.Client.Graphics.Clyde
                 _clyde.DrawResetViewTransform();
             }
 
-            public void DrawTexture(Texture texture, Vector2 a, Vector2 b, Color modulate, UIBox2? subRegion,
-                Angle angle)
+            public void DrawTexture(Texture texture, Box2Rotated drawRegion, Color modulate, UIBox2? subRegion)
             {
                 if (texture is AtlasTexture atlas)
                 {
@@ -63,7 +62,7 @@ namespace Robust.Client.Graphics.Clyde
 
                 var clydeTexture = (ClydeTexture) texture;
 
-                _clyde.DrawTexture(clydeTexture.TextureId, a, b, modulate, subRegion, angle);
+                _clyde.DrawTexture(clydeTexture.TextureId, drawRegion, modulate, subRegion);
             }
 
             public void SetScissor(UIBox2i? scissorBox)
@@ -275,8 +274,8 @@ namespace Robust.Client.Graphics.Clyde
                     Color? modulate = null)
                 {
                     var color = (modulate ?? Color.White) * Modulate;
-                    _renderHandle.DrawTexture(texture, rect.TopLeft, rect.BottomRight, color,
-                        subRegion, 0);
+                    _renderHandle.DrawTexture(texture, new Box2Rotated(rect.TopLeft, rect.BottomRight), color,
+                        subRegion);
                 }
             }
 
@@ -344,7 +343,7 @@ namespace Robust.Client.Graphics.Clyde
                 {
                     var color = (modulate ?? Color.White) * Modulate;
 
-                    _renderHandle.DrawTexture(texture, rect.BottomLeft, rect.TopRight, color, subRegion, 0);
+                    _renderHandle.DrawTexture(texture, new Box2Rotated(rect), color, subRegion);
                 }
 
                 public override void DrawTextureRectRegion(Texture texture, in Box2Rotated rect,
@@ -352,8 +351,7 @@ namespace Robust.Client.Graphics.Clyde
                 {
                     var color = (modulate ?? Color.White) * Modulate;
 
-                    _renderHandle.DrawTexture(texture, rect.Box.BottomLeft, rect.Box.TopRight, color, subRegion,
-                        (float) rect.Rotation);
+                    _renderHandle.DrawTexture(texture, rect, color, subRegion);
                 }
 
                 public override void DrawPrimitives(DrawPrimitiveTopology primitiveTopology, ReadOnlySpan<Vector2> vertices,

--- a/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
@@ -42,7 +42,7 @@ namespace Robust.Client.Graphics.Clyde
                 _clyde.DrawResetViewTransform();
             }
 
-            public void DrawTexture(Texture texture, Box2Rotated drawRegion, Color modulate, UIBox2? subRegion)
+            public void DrawTexture(Texture texture, Vector2 bl, Vector2 br, Vector2 tl, Vector2 tr, Color modulate, UIBox2? subRegion)
             {
                 if (texture is AtlasTexture atlas)
                 {
@@ -62,7 +62,7 @@ namespace Robust.Client.Graphics.Clyde
 
                 var clydeTexture = (ClydeTexture) texture;
 
-                _clyde.DrawTexture(clydeTexture.TextureId, drawRegion, modulate, subRegion);
+                _clyde.DrawTexture(clydeTexture.TextureId, bl, br, tl, tr, modulate, subRegion);
             }
 
             public void SetScissor(UIBox2i? scissorBox)
@@ -274,8 +274,8 @@ namespace Robust.Client.Graphics.Clyde
                     Color? modulate = null)
                 {
                     var color = (modulate ?? Color.White) * Modulate;
-                    _renderHandle.DrawTexture(texture, new Box2Rotated(rect.TopLeft, rect.BottomRight), color,
-                        subRegion);
+                    _renderHandle.DrawTexture(texture, rect.TopLeft, rect.TopRight,
+                        rect.BottomLeft, rect.BottomRight, color, subRegion);
                 }
             }
 
@@ -343,7 +343,8 @@ namespace Robust.Client.Graphics.Clyde
                 {
                     var color = (modulate ?? Color.White) * Modulate;
 
-                    _renderHandle.DrawTexture(texture, new Box2Rotated(rect), color, subRegion);
+                    _renderHandle.DrawTexture(texture, rect.BottomLeft, rect.BottomRight,
+                        rect.TopLeft, rect.TopRight, color, subRegion);
                 }
 
                 public override void DrawTextureRectRegion(Texture texture, in Box2Rotated rect,
@@ -351,7 +352,8 @@ namespace Robust.Client.Graphics.Clyde
                 {
                     var color = (modulate ?? Color.White) * Modulate;
 
-                    _renderHandle.DrawTexture(texture, rect, color, subRegion);
+                    _renderHandle.DrawTexture(texture, rect.BottomLeft, rect.BottomRight,
+                        rect.TopLeft, rect.TopRight, color, subRegion);
                 }
 
                 public override void DrawPrimitives(DrawPrimitiveTopology primitiveTopology, ReadOnlySpan<Vector2> vertices,

--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -458,8 +458,7 @@ namespace Robust.Client.Graphics.Clyde
             AllocRenderCommand(RenderCommandType.ResetViewMatrix);
         }
 
-        private void DrawTexture(ClydeHandle texture, Vector2 a, Vector2 b, Color modulate, UIBox2? subRegion,
-            Angle angle)
+        private void DrawTexture(ClydeHandle texture, in Box2Rotated drawRegion, Color modulate, UIBox2? subRegion)
         {
             EnsureBatchState(texture, modulate, true, BatchPrimitiveType.TriangleFan, _queuedShader);
 
@@ -489,24 +488,10 @@ namespace Robust.Client.Graphics.Clyde
                 }
             }
 
-            Vector2 bl;
-            Vector2 br;
-            Vector2 tr;
-            Vector2 tl;
-            if (angle == Angle.Zero)
-            {
-                bl = _currentModelMatrix.Transform(a);
-                br = _currentModelMatrix.Transform(new Vector2(b.X, a.Y));
-                tr = _currentModelMatrix.Transform(b);
-                tl = _currentModelMatrix.Transform(new Vector2(a.X, b.Y));
-            }
-            else
-            {
-                bl = _currentModelMatrix.Transform(angle.RotateVec(a));
-                br = _currentModelMatrix.Transform(angle.RotateVec(new Vector2(b.X, a.Y)));
-                tr = _currentModelMatrix.Transform(angle.RotateVec(b));
-                tl = _currentModelMatrix.Transform(angle.RotateVec(new Vector2(a.X, b.Y)));
-            }
+            Vector2 bl = _currentModelMatrix.Transform(drawRegion.BottomLeft);
+            Vector2 br = _currentModelMatrix.Transform(drawRegion.BottomRight);
+            Vector2 tr = _currentModelMatrix.Transform(drawRegion.TopRight);
+            Vector2 tl = _currentModelMatrix.Transform(drawRegion.TopLeft);
 
             // TODO: split batch if necessary.
             var vIdx = BatchVertexIndex;

--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -458,7 +458,7 @@ namespace Robust.Client.Graphics.Clyde
             AllocRenderCommand(RenderCommandType.ResetViewMatrix);
         }
 
-        private void DrawTexture(ClydeHandle texture, in Box2Rotated drawRegion, Color modulate, UIBox2? subRegion)
+        private void DrawTexture(ClydeHandle texture, Vector2 bl, Vector2 br, Vector2 tl, Vector2 tr, Color modulate, UIBox2? subRegion)
         {
             EnsureBatchState(texture, modulate, true, BatchPrimitiveType.TriangleFan, _queuedShader);
 
@@ -488,10 +488,10 @@ namespace Robust.Client.Graphics.Clyde
                 }
             }
 
-            Vector2 bl = _currentModelMatrix.Transform(drawRegion.BottomLeft);
-            Vector2 br = _currentModelMatrix.Transform(drawRegion.BottomRight);
-            Vector2 tr = _currentModelMatrix.Transform(drawRegion.TopRight);
-            Vector2 tl = _currentModelMatrix.Transform(drawRegion.TopLeft);
+            bl = _currentModelMatrix.Transform(bl);
+            br = _currentModelMatrix.Transform(br);
+            tr = _currentModelMatrix.Transform(tr);
+            tl = _currentModelMatrix.Transform(tl);
 
             // TODO: split batch if necessary.
             var vIdx = BatchVertexIndex;

--- a/Robust.Shared.Maths/Box2Rotated.cs
+++ b/Robust.Shared.Maths/Box2Rotated.cs
@@ -10,26 +10,35 @@ namespace Robust.Shared.Maths
     {
         public readonly Box2 Box;
         public readonly Angle Rotation;
-        public readonly Vector2 Position;
+        /// <summary>
+        /// The point about which the rotation occurs.
+        /// </summary>
+        public readonly Vector2 Origin;
 
         /// <summary>
         ///     A 1x1 unit box with the origin centered and identity rotation.
         /// </summary>
         public static readonly Box2Rotated UnitCentered = new Box2Rotated(Box2.UnitCentered, Angle.Zero, Vector2.Zero);
 
-        public Vector2 BottomRight => Position + Rotation.RotateVec(new Vector2(Box.Right, Box.Bottom));
-        public Vector2 TopLeft => Position + Rotation.RotateVec(new Vector2(Box.Left, Box.Top));
-        public Vector2 TopRight => Position + Rotation.RotateVec(new Vector2(Box.Right, Box.Top));
-        public Vector2 BottomLeft => Position + Rotation.RotateVec(new Vector2(Box.Left, Box.Bottom));
+        public Vector2 BottomRight => Origin + Rotation.RotateVec(Box.BottomRight - Origin);
+        public Vector2 TopLeft => Origin + Rotation.RotateVec(Box.TopLeft - Origin);
+        public Vector2 TopRight => Origin + Rotation.RotateVec(Box.TopRight - Origin);
+        public Vector2 BottomLeft => Origin + Rotation.RotateVec(Box.BottomLeft - Origin);
+
+        public Box2Rotated(Vector2 bottomLeft, Vector2 topRight)
+            : this(new Box2(bottomLeft, topRight)) { }
+
+        public Box2Rotated(Box2 box)
+            : this(box, 0) { }
 
         public Box2Rotated(Box2 box, Angle rotation)
             : this(box, rotation, Vector2.Zero) { }
 
-        public Box2Rotated(Box2 box, Angle rotation, Vector2 position)
+        public Box2Rotated(Box2 box, Angle rotation, Vector2 origin)
         {
             Box = box;
             Rotation = rotation;
-            Position = position;
+            Origin = origin;
         }
 
         /// <summary>


### PR DESCRIPTION
Lasers were manipulating the global drawing transform instead of just rendering in the correct direction. They have been changed to use a rotated box.

Fixed an issue with Clyde not respecting the way Box2Rotated rotates, which was not allowing for the behaviour needed to draw lasers. This has added some overhead to rendering, but hopefully not too much. It can always be optimized later.

Fixes #1065.

## Why did I touch Clyde code?

It assumed that all rotations were about the origin. To make things worse, it was bypassing `Box2Rotated`'s coordinate system and doing manual rotations itself. Both of these things were incorrect, and they meant that lasers (as well as general offset rotated effects) couldn't be implemented.

## Why did I change `Box2Rotated`?

I don't think the old API made much sense, and nothing was using it. It assumed the `Box2` was graphed from the rotation origin. That might be faster, but it was also more confusing.