### PR TITLE
Fix TickRate causing CurTime jumps

### DIFF
--- a/Robust.Client/BaseClient.cs
+++ b/Robust.Client/BaseClient.cs
@@ -195,6 +195,7 @@ namespace Robust.Client
         private void HandleSetTickRate(MsgSetTickRate message)
         {
             _timing.TickRate = message.NewTickRate;
+            Logger.InfoS("client", $"Tickrate changed to: {message.NewTickRate}");
         }
 
         private void OnLocalStatusChanged(object obj, StatusEventArgs eventArgs)

--- a/Robust.Shared/Timing/GameTiming.cs
+++ b/Robust.Shared/Timing/GameTiming.cs
@@ -47,7 +47,10 @@ namespace Robust.Shared.Timing
         // tick that the value was calculated for. The next time CurTime is
         // calculated, it should only try to monotonically increase both of
         // these values
-        private (TimeSpan, GameTick) _cachedCurTimeInfo = (TimeSpan.Zero, GameTick.Zero);
+        //
+        // Notice that it starts from GameTick 1  - the "first tick" has no impact
+        // on timing
+        private (TimeSpan, GameTick) _cachedCurTimeInfo = (TimeSpan.Zero, GameTick.First);
 
         /// <summary>
         ///     The current synchronized uptime of the simulation. Use this for in-game timing. This can be rewound for

--- a/Robust.UnitTesting/Shared/Timing/GameTiming_Test.cs
+++ b/Robust.UnitTesting/Shared/Timing/GameTiming_Test.cs
@@ -80,7 +80,7 @@ namespace Robust.UnitTesting.Shared.Timing
             //NOTE: TickRate can cause a slight rounding error in TickPeriod reciprocal calculation from repeating decimals depending
             // on the value chosen.
             gameTiming.TickRate = 20;
-            gameTiming.CurTick = new GameTick(60);
+            gameTiming.CurTick = new GameTick(61); // 1 + 60, because 1 is the first tick
 
             // Act
             gameTiming.StartFrame();
@@ -107,7 +107,7 @@ namespace Robust.UnitTesting.Shared.Timing
             var gameTiming = GameTimingFactory(newStopwatch.Object);
             gameTiming.InSimulation = false;
             gameTiming.TickRate = 20;
-            gameTiming.CurTick = new GameTick(60);
+            gameTiming.CurTick = new GameTick(61); // 1 + 60, because 1 is the first tick
             gameTiming.TickRemainder = TimeSpan.FromTicks(TimeSpan.TicksPerSecond / 2); // half a second
 
             // Act
@@ -207,6 +207,8 @@ namespace Robust.UnitTesting.Shared.Timing
 
             var field = typeof(GameTiming).GetField("_realTimer", BindingFlags.NonPublic | BindingFlags.Instance);
             field.SetValue(timing, stopwatch);
+
+            Assert.That(timing.CurTime, Is.EqualTo(TimeSpan.Zero));
 
             return timing;
         }


### PR DESCRIPTION
Fixes #1104 .

Getting the current time, or changing the tick rate, now caches the last tick and the timestamp at that tick. This means that new ticks are only cumulative on top of older ticks already used for time calculations, and tick rate no longer retrospectively changes the effective time period of ticks from a different tick rate.

Confirmed fixed with a bike horn.