### PR TITLE
Add config var loading from environment variables

### DIFF
--- a/Robust.Client/GameController.cs
+++ b/Robust.Client/GameController.cs
@@ -20,6 +20,7 @@ using Robust.Client.Utility;
 using Robust.Client.ViewVariables;
 using Robust.Shared;
 using Robust.Shared.Asynchronous;
+using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
 using Robust.Shared.Interfaces.Configuration;
 using Robust.Shared.Interfaces.Log;
@@ -106,6 +107,8 @@ namespace Robust.Client
                     _configurationManager.SetSaveFile(configFile);
                 }
             }
+
+            _configurationManager.OverrideConVars(EnvironmentVariables.GetEnvironmentCVars());
 
             if (_commandLineArgs != null)
             {

--- a/Robust.Server/BaseServer.cs
+++ b/Robust.Server/BaseServer.cs
@@ -136,6 +136,8 @@ namespace Robust.Server
                 }
             }
 
+            _config.OverrideConVars(EnvironmentVariables.GetEnvironmentCVars());
+
             if (_commandLineArgs != null)
             {
                 _config.OverrideConVars(_commandLineArgs.CVars);

--- a/Robust.Shared/Configuration/ConfigurationManager.cs
+++ b/Robust.Shared/Configuration/ConfigurationManager.cs
@@ -247,7 +247,7 @@ namespace Robust.Shared.Configuration
             return cVar.Value?.GetType() ?? typeof(string);
         }
 
-        public void OverrideConVars(IReadOnlyCollection<(string key, string value)> cVars)
+        public void OverrideConVars(IEnumerable<(string key, string value)> cVars)
         {
             foreach (var (key, value) in cVars)
             {

--- a/Robust.Shared/Configuration/EnvironmentVariables.cs
+++ b/Robust.Shared/Configuration/EnvironmentVariables.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+
+namespace Robust.Shared.Configuration
+{
+    public static class EnvironmentVariables
+    {
+        /// <summary>
+        /// The environment variable for configuring CVar overrides. The value
+        /// of the variable should be passed as key-value equalities separated by
+        /// semicolons.
+        /// </summary>
+        public const string ConfigVarEnvironmentVariable = "ROBUST_CVARS";
+
+        /// <summary>
+        /// Get the CVar overrides defined in the relevant environment variable.
+        /// </summary>
+        public static IEnumerable<(string, string)> GetEnvironmentCVars()
+        {
+            var eVarString = Environment.GetEnvironmentVariable(ConfigVarEnvironmentVariable);
+
+            if (eVarString == null)
+            {
+                yield break;
+            }
+
+            foreach (var cVarPair in eVarString.Split(';', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var pairParts = cVarPair.Split('=', 2);
+                yield return (pairParts[0], pairParts[1]);
+            }
+        }
+    }
+}

--- a/Robust.Shared/Interfaces/Configuration/IConfigurationManager.cs
+++ b/Robust.Shared/Interfaces/Configuration/IConfigurationManager.cs
@@ -64,6 +64,6 @@ namespace Robust.Shared.Interfaces.Configuration
         /// <param name="name">The name of the CVar</param>
         Type GetCVarType(string name);
 
-        void OverrideConVars(IReadOnlyCollection<(string key, string value)> cVars);
+        void OverrideConVars(IEnumerable<(string key, string value)> cVars);
     }
 }


### PR DESCRIPTION
Fixes #1075.

This is probably the crudest way to do it, but it works. The environment variables `ROBUST_CVARS` now allows for configuring cvars. Its value should be specified as a semicolon-separated list of cvar assignments, like `cvar.first=1;cvar.second=true;...`.