### PR TITLE
Changes PointLightComponent radius from an int to a float.

### DIFF
--- a/Robust.Server/GameObjects/Components/Light/PointLightComponent.cs
+++ b/Robust.Server/GameObjects/Components/Light/PointLightComponent.cs
@@ -9,7 +9,7 @@ namespace Robust.Server.GameObjects
     {
         private Color _color;
         private bool _enabled;
-        private int _radius;
+        private float _radius;
         private Vector2 _offset;
 
         public override string Name => "PointLight";
@@ -38,7 +38,7 @@ namespace Robust.Server.GameObjects
         }
 
         [ViewVariables(VVAccess.ReadWrite)]
-        public int Radius
+        public float Radius
         {
             get => _radius;
             set


### PR DESCRIPTION
Allows you to use decimals when making a `radius:`

No idea why this wasn't a float but was probably a godot limitation.