### PR TITLE
Make AddComponent load default DataField values

### DIFF
--- a/Robust.Shared/GameObjects/ComponentManager.cs
+++ b/Robust.Shared/GameObjects/ComponentManager.cs
@@ -129,7 +129,7 @@ namespace Robust.Shared.GameObjects
                 ComponentAdded?.Invoke(this, new ComponentEventArgs(component));
             }
 
-            // component.ExposeData(DefaultValueSerializer.Reader());
+            component.ExposeData(DefaultValueSerializer.Reader());
 
             component.OnAdd();
 

--- a/Robust.Shared/GameObjects/ComponentManager.cs
+++ b/Robust.Shared/GameObjects/ComponentManager.cs
@@ -83,7 +83,7 @@ namespace Robust.Shared.GameObjects
             if (component.Owner != entity)
                 throw new InvalidOperationException("Component is not owned by entity.");
 
-            component.ExposeData(new EmptySerializer());
+            component.ExposeData(DefaultValueSerializer.Reader());
 
             // get interface aliases for mapping
             var reg = _componentFactory.GetRegistration(component);

--- a/Robust.Shared/GameObjects/ComponentManager.cs
+++ b/Robust.Shared/GameObjects/ComponentManager.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Exceptions;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.GameObjects.Components;
 using Robust.Shared.IoC;
+using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.GameObjects
@@ -81,6 +82,8 @@ namespace Robust.Shared.GameObjects
 
             if (component.Owner != entity)
                 throw new InvalidOperationException("Component is not owned by entity.");
+
+            component.ExposeData(new EmptySerializer());
 
             // get interface aliases for mapping
             var reg = _componentFactory.GetRegistration(component);

--- a/Robust.Shared/GameObjects/ComponentManager.cs
+++ b/Robust.Shared/GameObjects/ComponentManager.cs
@@ -83,8 +83,6 @@ namespace Robust.Shared.GameObjects
             if (component.Owner != entity)
                 throw new InvalidOperationException("Component is not owned by entity.");
 
-            component.ExposeData(DefaultValueSerializer.Reader());
-
             // get interface aliases for mapping
             var reg = _componentFactory.GetRegistration(component);
 
@@ -130,6 +128,8 @@ namespace Robust.Shared.GameObjects
 
                 ComponentAdded?.Invoke(this, new ComponentEventArgs(component));
             }
+
+            // component.ExposeData(DefaultValueSerializer.Reader());
 
             component.OnAdd();
 

--- a/Robust.Shared/Serialization/DefaultValueSerializer.cs
+++ b/Robust.Shared/Serialization/DefaultValueSerializer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using Robust.Shared.Interfaces.Serialization;
 
@@ -20,7 +21,8 @@ namespace Robust.Shared.Serialization
         {
             if (Reading)
             {
-                value = defaultValue;
+                if (EqualityComparer<T>.Default.Equals(value, default))
+                  value = defaultValue;
             }
         }
 
@@ -46,7 +48,8 @@ namespace Robust.Shared.Serialization
         {
             if (Reading)
             {
-                value = defaultValue;
+                if (EqualityComparer<TTarget>.Default.Equals(value, default))
+                  value = defaultValue;
             }
         }
 

--- a/Robust.Shared/Serialization/DefaultValueSerializer.cs
+++ b/Robust.Shared/Serialization/DefaultValueSerializer.cs
@@ -4,8 +4,18 @@ using Robust.Shared.Interfaces.Serialization;
 
 namespace Robust.Shared.Serialization
 {
-    public sealed class EmptySerializer : ObjectSerializer
+    public sealed class DefaultValueSerializer : ObjectSerializer
     {
+        public static DefaultValueSerializer Reader()
+        {
+            return new DefaultValueSerializer()
+            {
+                Reading = true,
+            };
+        }
+
+        private DefaultValueSerializer() {}
+
         public override void DataField<T>(ref T value, string name, T defaultValue, WithFormat<T> withFormat, bool alwaysWrite = false)
         {
             if (Reading)

--- a/Robust.Shared/Serialization/DefaultValueSerializer.cs
+++ b/Robust.Shared/Serialization/DefaultValueSerializer.cs
@@ -32,7 +32,7 @@ namespace Robust.Shared.Serialization
         public override bool TryReadDataField<T>(string name, WithFormat<T> format, out T value)
         {
             value = default;
-            return true;
+            return false;
         }
 
         public override void DataField<TTarget, TSource>(

--- a/Robust.Shared/Serialization/EmptySerializer.cs
+++ b/Robust.Shared/Serialization/EmptySerializer.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Linq.Expressions;
+using Robust.Shared.Interfaces.Serialization;
+
+namespace Robust.Shared.Serialization
+{
+    public sealed class EmptySerializer : ObjectSerializer
+    {
+        public override void DataField<T>(ref T value, string name, T defaultValue, WithFormat<T> withFormat, bool alwaysWrite = false)
+        {
+            if (Reading)
+            {
+                value = defaultValue;
+            }
+        }
+
+        public override T ReadDataField<T>(string name, T defaultValue)
+        {
+            return defaultValue;
+        }
+
+        public override bool TryReadDataField<T>(string name, WithFormat<T> format, out T value)
+        {
+            value = default;
+            return true;
+        }
+
+        public override void DataField<TRoot, T>(TRoot root, Expression<Func<TRoot,T>> expr, string name, T defaultValue, bool alwaysWrite = false)
+        {
+        }
+        
+        public override void DataField<TTarget, TSource>(
+            ref TTarget value,
+            string name,
+            TTarget defaultValue,
+            Func<TSource, TTarget> ReadConvertFunc,
+            Func<TTarget, TSource> WriteConvertFunc = null,
+            bool alwaysWrite = false
+        )
+        {
+            if (Reading)
+            {
+                value = defaultValue;
+            }
+        }
+
+        public override void DataReadFunction<T>(string name, T defaultValue, ReadFunctionDelegate<T> func)
+        {
+            if (Reading)
+            {
+                func(defaultValue);
+            }
+        }
+        
+        public override void DataWriteFunction<T>(string name, T defaultValue, WriteFunctionDelegate<T> func, bool alwaysWrite = false)
+        {
+        }
+    }
+}

--- a/Robust.Shared/Serialization/EmptySerializer.cs
+++ b/Robust.Shared/Serialization/EmptySerializer.cs
@@ -25,10 +25,6 @@ namespace Robust.Shared.Serialization
             return true;
         }
 
-        public override void DataField<TRoot, T>(TRoot root, Expression<Func<TRoot,T>> expr, string name, T defaultValue, bool alwaysWrite = false)
-        {
-        }
-        
         public override void DataField<TTarget, TSource>(
             ref TTarget value,
             string name,

--- a/Robust.Shared/Serialization/YamlObjectSerializer.cs
+++ b/Robust.Shared/Serialization/YamlObjectSerializer.cs
@@ -150,43 +150,6 @@ namespace Robust.Shared.Serialization
         }
 
 
-        public override void DataField<TRoot, T>(TRoot o, Expression<Func<TRoot,T>> expr, string name, T defaultValue, bool alwaysWrite = false)
-        {
-            if (o == null)
-            {
-                throw new ArgumentNullException(nameof(o));
-            }
-
-            if (expr == null)
-            {
-                throw new ArgumentNullException(nameof(expr));
-            }
-
-            if (!(expr.Body is MemberExpression mExpr))
-            {
-                throw new NotSupportedException("Cannot handle expressions of types other than MemberExpression.");
-            }
-
-
-            WriteFunctionDelegate<T> getter;
-            ReadFunctionDelegate<T> setter;
-            switch (mExpr.Member)
-            {
-                case FieldInfo fi:
-                    getter = () => (T) fi.GetValue(o);
-                    setter = v => fi.SetValue(o, v);
-                    break;
-                case PropertyInfo pi:
-                    getter = () => (T) pi.GetValue(o);
-                    setter = v => pi.SetValue(o, v);
-                    break;
-                default:
-                    throw new NotSupportedException("Cannot handle member expressions of types other than FieldInfo or PropertyInfo.");
-            }
-
-            DataReadWriteFunction(name, defaultValue, setter, getter, alwaysWrite);
-        }
-
         /// <inheritdoc />
         public override void DataFieldCached<T>(ref T value, string name, T defaultValue, WithFormat<T> format, bool alwaysWrite = false)
         {


### PR DESCRIPTION
Attempts to fix #1082 .

This adds a new `ObjectSerializer` which only tries to write in the default `DataField` values for unset fields.

This **breaks the content!** `BodyManagerComponent` tries to load some data into string vars, but those vars are set to `""`, not `null`, so the default value isn't loaded (because the var is "set"). This can be fixed by changing `string templateName = "";` to `string templateName = null;` and the same for `presetName`.

### Why only overwrite unset fields?

Because the prototype loader loads the component data before it calls `AddComponent`, so if the default value serializer overwrite all fields it would end up overriding the prototype values.

### Other changes

Moved a method from `YamlObjectSerializer` to the base class `ObjectSerializer`, because it was YAML-agnostic and the new serializer benefits from sharing the implementation.