### PR TITLE
Fix client `CurTime` jumps

### DIFF
--- a/Robust.Shared/Timing/GameTiming.cs
+++ b/Robust.Shared/Timing/GameTiming.cs
@@ -186,7 +186,12 @@ namespace Robust.Shared.Timing
         {
             var (cachedTime, lastTimeTick) = _cachedCurTimeInfo;
 
-            var newTime = cachedTime + (TickPeriod * (CurTick.Value - lastTimeTick.Value));
+            TimeSpan newTime;
+
+            if (CurTick.Value >= lastTimeTick.Value)
+              newTime = cachedTime + (TickPeriod * (CurTick.Value - lastTimeTick.Value));
+            else
+              newTime = cachedTime - (TickPeriod * (lastTimeTick.Value - CurTick.Value));
 
             _cachedCurTimeInfo = (newTime, CurTick);
         }


### PR DESCRIPTION
I was an idiot who forgot to take into account underflow when thinking about tick calculations, because they are `uints`. This was causing time reversal to make `CurTime` jump by massive amounts.

It's now fixed.