### PR TITLE
Add collidable events back in

### DIFF
--- a/Robust.Shared/GameObjects/Components/Collidable/CollidableComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/CollidableComponent.cs
@@ -117,7 +117,11 @@ namespace Robust.Shared.GameObjects.Components
         public bool CanCollide
         {
             get => _canCollide;
-            set => _canCollide = value;
+            set
+            {
+                _canCollide = value;
+                Owner.EntityManager.EventBus.RaiseEvent(EventSource.Local, new CollisionChangeEvent(Owner.Uid, _canCollide));
+            }
         }
 
         /// <summary>
@@ -165,6 +169,8 @@ namespace Robust.Shared.GameObjects.Components
             // normally ExposeData would create this
             if (_physShapes == null)
                 _physShapes = new List<IPhysShape> { new PhysShapeAabb() };
+            
+            Owner.EntityManager.EventBus.RaiseEvent(EventSource.Local, new CollisionChangeEvent(Owner.Uid, _canCollide));
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/Components/Collidable/CollisionChangeEvent.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/CollisionChangeEvent.cs
@@ -1,0 +1,14 @@
+namespace Robust.Shared.GameObjects.Components
+{
+    public class CollisionChangeEvent : EntitySystemMessage
+    {
+        public EntityUid Owner { get; }
+        public bool CanCollide { get; }
+
+        public CollisionChangeEvent(EntityUid owner, bool canCollide)
+        {
+            Owner = owner;
+            CanCollide = canCollide;
+        }
+    }
+}


### PR DESCRIPTION
Pathfinding graph uses it to track when collision is enabled / disabled