### PR TITLE
Virtualize all NetIDs to reduce network traffic

### DIFF
--- a/Robust.Shared/GameObjects/Component.cs
+++ b/Robust.Shared/GameObjects/Component.cs
@@ -205,7 +205,7 @@ namespace Robust.Shared.GameObjects
             if (NetID == null)
                 throw new InvalidOperationException($"Cannot make state for component without Net ID: {GetType()}");
 
-            return new ComponentState(NetID.Value);
+            return new NetIdComponentState(NetID.Value);
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/ComponentState.cs
+++ b/Robust.Shared/GameObjects/ComponentState.cs
@@ -3,14 +3,30 @@ using System;
 
 namespace Robust.Shared.GameObjects
 {
-    [Serializable, NetSerializable]
-    public class ComponentState
-    {
-        public uint NetID { get; }
 
-        public ComponentState(uint netID)
+    [Serializable, NetSerializable]
+    public abstract class ComponentState
+    {
+
+        public abstract uint NetID { get; }
+
+        protected ComponentState()
         {
-            NetID = netID;
         }
+
     }
+
+    [Serializable, NetSerializable]
+    internal sealed class NetIdComponentState : ComponentState
+    {
+
+        public override uint NetID { get; }
+
+        public NetIdComponentState(uint netId)
+        {
+            NetID = netId;
+        }
+
+    }
+
 }

--- a/Robust.Shared/GameObjects/Components/Appearance/SharedAppearanceComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Appearance/SharedAppearanceComponent.cs
@@ -29,7 +29,8 @@ namespace Robust.Shared.GameObjects.Components.Appearance
         {
             public readonly Dictionary<object, object> Data;
 
-            public AppearanceComponentState(Dictionary<object, object> data) : base(NetIDs.APPEARANCE)
+            public override uint NetID => NetIDs.APPEARANCE;
+            public AppearanceComponentState(Dictionary<object, object> data)
             {
                 Data = data;
             }

--- a/Robust.Shared/GameObjects/Components/ClickableComponentState.cs
+++ b/Robust.Shared/GameObjects/Components/ClickableComponentState.cs
@@ -13,7 +13,8 @@ namespace Robust.Shared.GameObjects.Components
     {
         public Box2? LocalBounds { get; }
 
-        public ClickableComponentState(Box2? localBounds) : base(NetIDs.CLICKABLE)
+        public override uint NetID => NetIDs.CLICKABLE;
+        public ClickableComponentState(Box2? localBounds)
         {
             LocalBounds = localBounds;
         }

--- a/Robust.Shared/GameObjects/Components/Collidable/CollidableComponentState.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/CollidableComponentState.cs
@@ -11,9 +11,9 @@ namespace Robust.Shared.GameObjects.Components
         public readonly bool CanCollide;
         public readonly BodyStatus Status;
         public readonly List<IPhysShape> PhysShapes;
+        public override uint NetID => NetIDs.COLLIDABLE;
 
         public CollidableComponentState(bool canCollide, BodyStatus status, List<IPhysShape> physShapes)
-            : base(NetIDs.COLLIDABLE)
         {
             CanCollide = canCollide;
             Status = status;

--- a/Robust.Shared/GameObjects/Components/Containers/SharedContainerManagerComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Containers/SharedContainerManagerComponent.cs
@@ -28,7 +28,8 @@ namespace Robust.Shared.GameObjects.Components.Containers
         {
             public Dictionary<string,(bool, List<EntityUid>)> Containers { get; }
 
-            public ContainerManagerComponentState(Dictionary<string, (bool, List<EntityUid>)> containers) : base(NetIDs.CONTAINER_MANAGER)
+            public override uint NetID => NetIDs.CONTAINER_MANAGER;
+            public ContainerManagerComponentState(Dictionary<string, (bool, List<EntityUid>)> containers)
             {
                 Containers = containers;
             }

--- a/Robust.Shared/GameObjects/Components/Light/OccluderComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Light/OccluderComponent.cs
@@ -67,7 +67,8 @@ namespace Robust.Shared.GameObjects
             public bool Enabled { get; }
             public Box2 BoundingBox { get; }
 
-            public OccluderComponentState(bool enabled, Box2 boundingBox) : base(NetIDs.OCCLUDER)
+            public override uint NetID => NetIDs.OCCLUDER;
+            public OccluderComponentState(bool enabled, Box2 boundingBox)
             {
                 Enabled = enabled;
                 BoundingBox = boundingBox;

--- a/Robust.Shared/GameObjects/Components/Light/PointLightComponentState.cs
+++ b/Robust.Shared/GameObjects/Components/Light/PointLightComponentState.cs
@@ -12,9 +12,9 @@ namespace Robust.Shared.GameObjects
 
         public readonly float Radius;
         public readonly Vector2 Offset;
+        public override uint NetID => NetIDs.POINT_LIGHT;
 
         public PointLightComponentState(bool enabled, Color color, float radius, Vector2 offset)
-            : base(NetIDs.POINT_LIGHT)
         {
             Enabled = enabled;
             Color = color;

--- a/Robust.Shared/GameObjects/Components/Map/MapComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Map/MapComponent.cs
@@ -76,9 +76,9 @@ namespace Robust.Shared.GameObjects.Components.Map
     internal class MapComponentState : ComponentState
     {
         public MapId MapId { get; }
+        public override uint NetID => NetIDs.MAP_MAP;
 
         public MapComponentState(MapId mapId)
-            : base(NetIDs.MAP_MAP)
         {
             MapId = mapId;
         }

--- a/Robust.Shared/GameObjects/Components/Map/MapGridComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Map/MapGridComponent.cs
@@ -99,12 +99,14 @@ namespace Robust.Shared.GameObjects.Components.Map
         /// </summary>
         public GridId GridIndex { get; }
 
+        public override uint NetID => NetIDs.MAP_GRID;
+
+
         /// <summary>
         ///     Constructs a new instance of <see cref="MapGridComponentState"/>.
         /// </summary>
         /// <param name="gridIndex">Index of the grid this component is linked to.</param>
         public MapGridComponentState(GridId gridIndex)
-            : base(NetIDs.MAP_GRID)
         {
             GridIndex = gridIndex;
         }

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -26,6 +26,9 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         public string? PrototypeId { get; }
 
+        public override uint NetID => NetIDs.META_DATA;
+
+
         /// <summary>
         ///     Constructs a new instance of <see cref="MetaDataComponentState"/>.
         /// </summary>
@@ -33,7 +36,6 @@ namespace Robust.Shared.GameObjects
         /// <param name="description">The in-game description of this entity.</param>
         /// <param name="prototypeId">The prototype this entity was created from, if any.</param>
         public MetaDataComponentState(string? name, string? description, string? prototypeId)
-            : base(NetIDs.META_DATA)
         {
             Name = name;
             Description = description;

--- a/Robust.Shared/GameObjects/Components/Physics/PhysicsComponentState.cs
+++ b/Robust.Shared/GameObjects/Components/Physics/PhysicsComponentState.cs
@@ -25,13 +25,15 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         public readonly float AngularVelocity;
 
+        public override uint NetID => NetIDs.PHYSICS;
+
+
         /// <summary>
         ///     Constructs a new state snapshot of a PhysicsComponent.
         /// </summary>
         /// <param name="mass">Current Mass of the entity.</param>
         /// <param name="velocity">Current Velocity of the entity.</param>
         public PhysicsComponentState(float mass, Vector2 linearVelocity, float angularVelocity)
-            : base(NetIDs.PHYSICS)
         {
             Mass = (int) Math.Round(mass *1000); // rounds kg to nearest gram
             LinearVelocity = linearVelocity;

--- a/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
@@ -30,6 +30,7 @@ namespace Robust.Shared.GameObjects.Components.Renderable
             public readonly string BaseRsiPath;
             public readonly List<PrototypeLayerData> Layers;
             public readonly uint RenderOrder;
+            public override uint NetID => NetIDs.SPRITE;
 
             public SpriteComponentState(
                 bool visible,
@@ -42,7 +43,6 @@ namespace Robust.Shared.GameObjects.Components.Renderable
                 string baseRsiPath,
                 List<PrototypeLayerData> layers,
                 uint renderOrder)
-                : base(NetIDs.SPRITE)
             {
                 Visible = visible;
                 DrawDepth = drawDepth;

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -772,6 +772,9 @@ namespace Robust.Shared.GameObjects.Components.Transform
             /// </summary>
             public readonly Angle Rotation;
 
+            public override uint NetID => NetIDs.TRANSFORM;
+
+
             /// <summary>
             ///     Constructs a new state snapshot of a TransformComponent.
             /// </summary>
@@ -779,7 +782,6 @@ namespace Robust.Shared.GameObjects.Components.Transform
             /// <param name="rotation">Current direction offset of this entity.</param>
             /// <param name="parentId">Current parent transform of this entity.</param>
             public TransformComponentState(Vector2 localPosition, Angle rotation, EntityUid? parentId)
-                : base(NetIDs.TRANSFORM)
             {
                 LocalPosition = localPosition;
                 Rotation = rotation;


### PR DESCRIPTION
The serializer encodes the runtime type, so we can take advantage of it to reduce network usage