### PR TITLE
Implement corner collision resolution

### DIFF
--- a/Robust.Client/Console/Commands/Debug.cs
+++ b/Robust.Client/Console/Commands/Debug.cs
@@ -758,7 +758,7 @@ namespace Robust.Client.Console.Commands
 
         public static Dictionary<string, FileSystemWatcher> _watchers;
 
-        public static ConcurrentDictionary<string, bool> _reloadShadersQueued = new ConcurrentDictionary<string, bool>();
+        public static ConcurrentDictionary<string, bool> _reloadShadersQueued = new ConcurrentDictionary<string, bool>(1,4);
 
         public bool Execute(IDebugConsole console, params string[] args)
         {
@@ -779,13 +779,13 @@ namespace Robust.Client.Console.Commands
                     var stringComparer = PathHelpers.IsFileSystemCaseSensitive()
                         ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
 
-                    var reversePathResolution = new ConcurrentDictionary<string, HashSet<ResourcePath>>(stringComparer);
+                    var reversePathResolution = new ConcurrentDictionary<string, HashSet<ResourcePath>>(1,4,stringComparer);
 
                     var syncCtx = SynchronizationContext.Current;
 
                     var shaderCount = 0;
                     var created = 0;
-                    var dirs = new ConcurrentDictionary<string, SortedSet<string>>(stringComparer);
+                    var dirs = new ConcurrentDictionary<string, SortedSet<string>>(1,4,stringComparer);
                     foreach (var (path, src) in resC.GetAllResources<ShaderSourceResource>())
                     {
                         if (!resC.TryGetDiskFilePath(path, out var fullPath))

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -503,7 +503,7 @@ namespace Robust.Shared.GameObjects
         #region Entity DynamicTree
 
         private readonly ConcurrentDictionary<MapId, DynamicTree<IEntity>> _entityTreesPerMap =
-            new ConcurrentDictionary<MapId, DynamicTree<IEntity>>();
+            new ConcurrentDictionary<MapId, DynamicTree<IEntity>>(1,4);
 
         public virtual bool UpdateEntityTree(IEntity entity)
         {

--- a/Robust.Shared/Physics/PhysicsManager.cs
+++ b/Robust.Shared/Physics/PhysicsManager.cs
@@ -73,7 +73,7 @@ namespace Robust.Shared.Physics
 
             // octagonal surface normals; create 8 regions, a third of each of the 4 faces is flat
             // corners are treated as curved during resolution, making players feel somewhat pill shaped
-            const float faceToCornerBias = 1/3f; // higher is more square, higher is more pill shaped
+            const float faceToCornerBias = 1/3f; // higher is more square, lower is more pill shaped
             if (MathF.Abs(x) < faceToCornerBias) x = 0;
             if (MathF.Abs(y) < faceToCornerBias) y = 0;
 


### PR DESCRIPTION
change CalculateNormal to apply rounded collision resolution to corners

reduce concurrency on concurrent dictionaries

add TODO for container mass

minor refactor of GetCollidingEntities, and don't re-enumerate modifiers in an inner loop