### PR TITLE
Use CannyFastMath

### DIFF
--- a/Lidgren.Network/Encryption/NetBlockEncryptionBase.cs
+++ b/Lidgren.Network/Encryption/NetBlockEncryptionBase.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Lidgren.Network
 {

--- a/Lidgren.Network/Lidgren.Network.csproj
+++ b/Lidgren.Network/Lidgren.Network.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Configurations>Debug;Release</Configurations>
@@ -8,4 +8,8 @@
     <SonarQubeExclude>true</SonarQubeExclude>
     <DefineConstants>$(DefineConstants);USE_RELEASE_STATISTICS</DefineConstants>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="CannyFastMath" Version="1.0.2" />
+  </ItemGroup>
 </Project>

--- a/Lidgren.Network/NetBigInteger.cs
+++ b/Lidgren.Network/NetBigInteger.cs
@@ -3,6 +3,9 @@ using System.Text;
 using System.Collections;
 using System.Diagnostics;
 using System.Globalization;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Lidgren.Network
 {

--- a/Lidgren.Network/NetBuffer.Write.cs
+++ b/Lidgren.Network/NetBuffer.Write.cs
@@ -24,6 +24,9 @@ using System.Net;
 using System.Reflection;
 using System.Text;
 using System.Runtime.InteropServices;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Lidgren.Network
 {

--- a/Lidgren.Network/NetUtility.cs
+++ b/Lidgren.Network/NetUtility.cs
@@ -30,6 +30,9 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using System.Security.Cryptography;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Lidgren.Network
 {
@@ -352,9 +355,9 @@ namespace Lidgren.Network
 		{
 			if (bytes < 4000) // 1-4 kb is printed in bytes
 				return bytes + " bytes";
-			if (bytes < 1000 * 1000) // 4-999 kb is printed in kb
-				return Math.Round(((double)bytes / 1000.0), 2) + " kilobytes";
-			return Math.Round(((double)bytes / (1000.0 * 1000.0)), 2) + " megabytes"; // else megabytes
+			if (bytes < 1000000) // 4-999 kb is printed in kb
+				return $"{Math.Round(bytes / 1000.0):F2} kilobytes";
+			return $"{Math.Round(bytes / 1000000D):F2} megabytes"; // else megabytes
 		}
 
 		internal static int RelativeSequenceNumber(int nr, int expected)

--- a/Robust.Client/GameObjects/EntitySystems/EffectSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/EffectSystem.cs
@@ -254,9 +254,9 @@ namespace Robust.Client.GameObjects
                     var radius = positionRelativeToEmitter.Length;
                     if (radius > 0)
                     {
-                        var theta = (float) Math.Atan2(positionRelativeToEmitter.Y, positionRelativeToEmitter.X);
+                        var theta = (float) MathF.Atan2(positionRelativeToEmitter.Y, positionRelativeToEmitter.X);
                         theta += TangentialVelocity * frameTime;
-                        deltaPosition += new Vector2(radius * (float) Math.Cos(theta), radius * (float) Math.Sin(theta))
+                        deltaPosition += new Vector2(radius * (float) MathF.Cos(theta), radius * (float) MathF.Sin(theta))
                                          - positionRelativeToEmitter;
                     }
                 }

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -229,7 +229,7 @@ namespace Robust.Client.GameStates
 
             var ping = _network.ServerChannel!.Ping / 1000f; // seconds.
             var targetTick = _timing.CurTick.Value + _processor.TargetBufferSize +
-                             (int) Math.Ceiling(_timing.TickRate * ping) + PredictSize;
+                             (int) MathF.Ceiling(_timing.TickRate * ping) + PredictSize;
 
             //Logger.DebugS("State", $"Predicting from {_lastProcessedTick} to {targetTick}");
 

--- a/Robust.Client/Graphics/Clyde/Audio/Clyde.Audio.cs
+++ b/Robust.Client/Graphics/Clyde/Audio/Clyde.Audio.cs
@@ -401,15 +401,15 @@ namespace Robust.Client.Graphics.Clyde
             public void SetVolume(float decibels)
             {
                 _checkDisposed();
-                AL.Source(SourceHandle, ALSourcef.Gain, (float) Math.Pow(10, decibels / 10));
+                AL.Source(SourceHandle, ALSourcef.Gain, (float) MathF.Pow(10, decibels / 10));
                 _checkAlError();
             }
 
             public void SetOcclusion(float blocks)
             {
                 _checkDisposed();
-                var cutoff = (float) Math.Exp(-blocks * 1);
-                float gain = (float) Math.Pow(cutoff, 0.1);
+                var cutoff = (float) MathF.Exp(-blocks * 1);
+                float gain = (float) MathF.Pow(cutoff, 0.1f);
                 if (FilterHandle == 0)
                 {
                     FilterHandle = EFX.GenFilter();
@@ -587,15 +587,15 @@ namespace Robust.Client.Graphics.Clyde
             {
                 _checkDisposed();
                 // ReSharper disable once PossibleInvalidOperationException
-                AL.Source(SourceHandle!.Value, ALSourcef.Gain, (float) Math.Pow(10, decibels / 10));
+                AL.Source(SourceHandle!.Value, ALSourcef.Gain, (float) MathF.Pow(10, decibels / 10));
                 _checkAlError();
             }
 
             public void SetOcclusion(float blocks)
             {
                 _checkDisposed();
-                var cutoff = (float) Math.Exp(-blocks * 1.5);
-                float gain = (float) Math.Pow(cutoff, 0.1);
+                var cutoff = (float) MathF.Exp(-blocks * 1.5f);
+                float gain = (float) MathF.Pow(cutoff, 0.1f);
                 if (FilterHandle == 0)
                 {
                     FilterHandle = EFX.GenFilter();

--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -203,7 +203,7 @@ namespace Robust.Client.Graphics.Clyde
             {
                 // Calculate maximum distance for the projection based on screen size.
                 var screenSizeCut = ScreenSize / EyeManager.PixelsPerMeter;
-                var maxDist = (float) Math.Max(screenSizeCut.X, screenSizeCut.Y);
+                var maxDist = (float) MathF.Max(screenSizeCut.X, screenSizeCut.Y);
 
                 // FOV is rendered twice.
                 // Once with back face culling like regular lighting.

--- a/Robust.Client/Graphics/FontManager.cs
+++ b/Robust.Client/Graphics/FontManager.cs
@@ -117,11 +117,11 @@ namespace Robust.Client.Graphics
             //  but preferring to increase width if necessary.
             var atlasEntriesHorizontal = (int) Math.Ceiling(Math.Sqrt(count));
             var atlasEntriesVertical =
-                (int) Math.Ceiling(count / (float) atlasEntriesHorizontal);
+                (int) MathF.Ceiling(count / (float) atlasEntriesHorizontal);
             var atlasDimX =
-                (int) Math.Ceiling(atlasEntriesHorizontal * maxGlyphSize.X / 4f) * 4;
+                (int) MathF.Ceiling(atlasEntriesHorizontal * maxGlyphSize.X / 4f) * 4;
             var atlasDimY =
-                (int) Math.Ceiling(atlasEntriesVertical * maxGlyphSize.Y / 4f) * 4;
+                (int) MathF.Ceiling(atlasEntriesVertical * maxGlyphSize.Y / 4f) * 4;
 
             using (var atlas = new Image<A8>(atlasDimX, atlasDimY))
             {

--- a/Robust.Client/Map/ClydeTileDefinitionManager.cs
+++ b/Robust.Client/Map/ClydeTileDefinitionManager.cs
@@ -11,6 +11,9 @@ using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Client.Map
 {
@@ -45,7 +48,7 @@ namespace Robust.Client.Map
             const int tileSize = EyeManager.PixelsPerMeter;
 
             var dimensionX = (int) Math.Ceiling(Math.Sqrt(defList.Count));
-            var dimensionY = (int) Math.Ceiling((float) defList.Count / dimensionX);
+            var dimensionY = (int) Math.Ceiling((double) defList.Count / dimensionX);
 
             var sheet = new Image<Rgba32>(dimensionX * tileSize, dimensionY * tileSize);
 

--- a/Robust.Client/Placement/Modes/AlignSnapgridBorder.cs
+++ b/Robust.Client/Placement/Modes/AlignSnapgridBorder.cs
@@ -28,8 +28,8 @@ namespace Robust.Client.Placement.Modes
 
                 var position = pManager.eyeManager.ScreenToMap(Vector2.Zero);
 
-                var gridstartx = (float) Math.Round(position.X / snapSize, MidpointRounding.AwayFromZero) * snapSize;
-                var gridstarty = (float) Math.Round(position.Y / snapSize, MidpointRounding.AwayFromZero) * snapSize;
+                var gridstartx = (float) MathF.Round(position.X / snapSize, MidpointRounding.AwayFromZero) * snapSize;
+                var gridstarty = (float) MathF.Round(position.Y / snapSize, MidpointRounding.AwayFromZero) * snapSize;
                 var gridstart = pManager.eyeManager.WorldToScreen(
                     new Vector2( //Find snap grid closest to screen origin and convert back to screen coords
                         gridstartx,
@@ -64,8 +64,8 @@ namespace Robust.Client.Placement.Modes
             onGrid = true;
 
             var mouselocal = new Vector2( //Round local coordinates onto the snap grid
-                (float) Math.Round(MouseCoords.X / (double) snapSize, MidpointRounding.AwayFromZero) * snapSize,
-                (float) Math.Round(MouseCoords.Y / (double) snapSize, MidpointRounding.AwayFromZero) * snapSize);
+                (float) MathF.Round(MouseCoords.X / snapSize, MidpointRounding.AwayFromZero) * snapSize,
+                (float) MathF.Round(MouseCoords.Y / snapSize, MidpointRounding.AwayFromZero) * snapSize);
 
             //Convert back to original world and screen coordinates after applying offset
             MouseCoords =

--- a/Robust.Client/Placement/Modes/AlignSnapgridCenter.cs
+++ b/Robust.Client/Placement/Modes/AlignSnapgridCenter.cs
@@ -25,8 +25,8 @@ namespace Robust.Client.Placement.Modes
                 var position = pManager.eyeManager.ScreenToMap(Vector2.Zero);
 
                 var gridstart = pManager.eyeManager.WorldToScreen(new Vector2( //Find snap grid closest to screen origin and convert back to screen coords
-                    (float)(Math.Round(position.X / snapSize - 0.5f, MidpointRounding.AwayFromZero) + 0.5f) * snapSize,
-                    (float)(Math.Round(position.Y / snapSize - 0.5f, MidpointRounding.AwayFromZero) + 0.5f) * snapSize));
+                    (float)(MathF.Round(position.X / snapSize - 0.5f, MidpointRounding.AwayFromZero) + 0.5f) * snapSize,
+                    (float)(MathF.Round(position.Y / snapSize - 0.5f, MidpointRounding.AwayFromZero) + 0.5f) * snapSize));
                 for (var a = gridstart.X; a < viewportSize.X; a += snapSize * 32) //Iterate through screen creating gridlines
                 {
                     var from = ScreenToWorld(new Vector2(a, 0));
@@ -54,8 +54,8 @@ namespace Robust.Client.Placement.Modes
             onGrid = true;
 
             var mouseLocal = new Vector2( //Round local coordinates onto the snap grid
-                (float)(Math.Round((MouseCoords.Position.X / (double)snapSize - 0.5f), MidpointRounding.AwayFromZero) + 0.5) * snapSize,
-                (float)(Math.Round((MouseCoords.Position.Y / (double)snapSize - 0.5f), MidpointRounding.AwayFromZero) + 0.5) * snapSize);
+                (float)(MathF.Round((MouseCoords.Position.X / snapSize - 0.5f), MidpointRounding.AwayFromZero) + 0.5) * snapSize,
+                (float)(MathF.Round((MouseCoords.Position.Y / snapSize - 0.5f), MidpointRounding.AwayFromZero) + 0.5) * snapSize);
 
             //Adjust mouseCoords to new calculated position
             MouseCoords = new GridCoordinates(mouseLocal + new Vector2(pManager.PlacementOffset.X, pManager.PlacementOffset.Y), MouseCoords.GridID);

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using Robust.Shared.Maths;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Client.UserInterface.Controls
 {
@@ -191,7 +194,7 @@ namespace Robust.Client.UserInterface.Controls
 
                     first = false;
 
-                    minWidth = Math.Max(minWidth, childWidth);
+                    minWidth = MathF.Max(minWidth, childWidth);
                 }
                 else
                 {
@@ -203,7 +206,7 @@ namespace Robust.Client.UserInterface.Controls
 
                     first = false;
 
-                    minHeight = Math.Max(minHeight, childHeight);
+                    minHeight = MathF.Max(minHeight, childHeight);
                 }
             }
 

--- a/Robust.Client/UserInterface/Controls/LineEdit.cs
+++ b/Robust.Client/UserInterface/Controls/LineEdit.cs
@@ -228,12 +228,12 @@ namespace Robust.Client.UserInterface.Controls
 
                 if (_lastMousePosition < contentBox.Left)
                 {
-                    _drawOffset = Math.Max(0, _drawOffset - (int) Math.Ceiling(args.DeltaSeconds / MouseScrollDelay));
+                    _drawOffset = Math.Max(0, _drawOffset - (int) MathF.Ceiling(args.DeltaSeconds / MouseScrollDelay));
                 }
                 else if (_lastMousePosition > contentBox.Right)
                 {
                     // Will get clamped inside rendering code.
-                    _drawOffset += (int) Math.Ceiling(args.DeltaSeconds / MouseScrollDelay);
+                    _drawOffset += (int) MathF.Ceiling(args.DeltaSeconds / MouseScrollDelay);
                 }
 
                 var index = GetIndexAtPos(_lastMousePosition.Clamp(contentBox.Left, contentBox.Right));

--- a/Robust.Client/UserInterface/Controls/ScrollBar.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollBar.cs
@@ -158,10 +158,10 @@ namespace Robust.Client.UserInterface.Controls
         private UIBox2 _getGrabberBox()
         {
             var grabberOffset = GetAsRatio() * _getOrientationSize();
-            grabberOffset = (float) Math.Round(grabberOffset);
+            grabberOffset = (float) MathF.Round(grabberOffset);
 
             var grabberEnd = (Value + Page - MinValue) / (MaxValue - MinValue) * _getOrientationSize() + _getGrabberBoxMinSize();
-            grabberEnd = (float) Math.Round(grabberEnd);
+            grabberEnd = (float) MathF.Round(grabberEnd);
 
             if (_orientation == OrientationMode.Horizontal)
             {

--- a/Robust.Client/UserInterface/Controls/ScrollContainer.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollContainer.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Diagnostics.Contracts;
 using Robust.Shared.Maths;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Client.UserInterface.Controls
 {
@@ -149,25 +152,25 @@ namespace Robust.Client.UserInterface.Controls
 
                 if (!_vScrollEnabled)
                 {
-                    totalY = Math.Max(totalY, child.CombinedMinimumSize.Y);
+                    totalY = MathF.Max(totalY, child.CombinedMinimumSize.Y);
                 }
 
                 if (!_hScrollEnabled)
                 {
-                    totalX = Math.Max(totalX, child.CombinedMinimumSize.X);
+                    totalX = MathF.Max(totalX, child.CombinedMinimumSize.X);
                 }
             }
 
             if (_vScrollEnabled)
             {
                 totalX += _vScrollBar.CombinedMinimumSize.X;
-                totalY = Math.Max(_vScrollBar.CombinedMinimumSize.Y, totalY);
+                totalY = MathF.Max(_vScrollBar.CombinedMinimumSize.Y, totalY);
             }
 
             if (_hScrollEnabled)
             {
                 totalY += _hScrollBar.CombinedMinimumSize.Y;
-                totalX = Math.Max(_vScrollBar.CombinedMinimumSize.X, totalX);
+                totalX = MathF.Max(_vScrollBar.CombinedMinimumSize.X, totalX);
             }
 
             return new Vector2(totalX, totalY);

--- a/Robust.Client/UserInterface/Controls/SplitContainer.cs
+++ b/Robust.Client/UserInterface/Controls/SplitContainer.cs
@@ -1,5 +1,8 @@
 using System;
 using Robust.Shared.Maths;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Client.UserInterface.Controls
 {
@@ -79,7 +82,7 @@ namespace Robust.Client.UserInterface.Controls
 
             if (Vertical)
             {
-                var width = Math.Max(firstSizeX, secondSizeX);
+                var width = MathF.Max(firstSizeX, secondSizeX);
                 var height = firstSizeY + Separation + secondSizeY;
 
                 return (width, height);
@@ -87,7 +90,7 @@ namespace Robust.Client.UserInterface.Controls
             else
             {
                 var width = firstSizeX + Separation + secondSizeX;
-                var height = Math.Max(firstSizeY, secondSizeY);
+                var height = MathF.Max(firstSizeY, secondSizeY);
 
                 return (width, height);
             }

--- a/Robust.Client/UserInterface/Controls/TabContainer.cs
+++ b/Robust.Client/UserInterface/Controls/TabContainer.cs
@@ -342,7 +342,7 @@ namespace Robust.Client.UserInterface.Controls
                 var activeSize = active?.MinimumSize ?? Vector2.Zero;
                 var inactiveSize = inactive?.MinimumSize ?? Vector2.Zero;
 
-                headerSize = (int) Math.Max(activeSize.Y, inactiveSize.Y);
+                headerSize = (int) MathF.Max(activeSize.Y, inactiveSize.Y);
                 headerSize += font.GetHeight(UIScale);
             }
 

--- a/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
+++ b/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
@@ -230,7 +230,7 @@ namespace Robust.Client.UserInterface.CustomControls
             // Calculate index of first prototype to render based on current scroll.
             var height = MeasureButton.CombinedMinimumSize.Y + PrototypeListContainer.Separation;
             var offset = -PrototypeList.Position.Y;
-            var startIndex = (int) Math.Floor(offset / height);
+            var startIndex = (int) MathF.Floor(offset / height);
             PrototypeList.ItemOffset = startIndex;
 
             var (prevStart, prevEnd) = _lastPrototypeIndices;

--- a/Robust.Shared.Maths/Angle.cs
+++ b/Robust.Shared.Maths/Angle.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using JetBrains.Annotations;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Shared.Maths
 {
@@ -52,28 +55,28 @@ namespace Robust.Shared.Maths
             return new Vector2((float) x, (float) y);
         }
 
-        private const double Segment = 2 * Math.PI / 8.0; // Cut the circle into 8 pieces
+        private const double Segment = 2 * Math.π / 8.0; // Cut the circle into 8 pieces
         private const double Offset = Segment / 2.0; // offset the pieces by 1/2 their size
 
         public Direction GetDir()
         {
-            var ang = Theta % (2 * Math.PI);
+            var ang = Theta % (2 * Math.π);
 
             if (ang < 0.0f) // convert -PI > PI to 0 > 2PI
-                ang += 2 * (float) Math.PI;
+                ang += (2 * Math.π);
 
             return (Direction) (Math.Floor((ang + Offset) / Segment) % 8);
         }
 
-        private const double CardinalSegment = 2 * Math.PI / 4.0; // Cut the circle into 4 pieces
+        private const double CardinalSegment = 2 * Math.π / 4.0; // Cut the circle into 4 pieces
         private const double CardinalOffset = CardinalSegment / 2.0; // offset the pieces by 1/2 their size
 
         public Direction GetCardinalDir()
         {
-            var ang = Theta % (2 * Math.PI);
+            var ang = Theta % (2 * Math.π);
 
             if (ang < 0.0f) // convert -PI > PI to 0 > 2PI
-                ang += 2 * (float) Math.PI;
+                ang += (2 * Math.π);
 
             return (Direction) (Math.Floor((ang + CardinalOffset) / CardinalSegment) * 2 % 8);
         }
@@ -149,8 +152,8 @@ namespace Robust.Shared.Maths
         private static double Reduce(double theta)
         {
             // int truncates value (round to 0)
-            var aTurns = (int) (theta / (2 * Math.PI));
-            return theta - aTurns * (2 * Math.PI);
+            var aTurns = (int) (theta / (2 * Math.π));
+            return theta - aTurns * (2 * Math.π);
         }
 
         /// <inheritdoc />
@@ -197,7 +200,7 @@ namespace Robust.Shared.Maths
             if (theta >= 0)
                 return theta;
 
-            return theta + 2 * Math.PI;
+            return theta + 2 * Math.π;
         }
 
         /// <summary>

--- a/Robust.Shared.Maths/Box2.cs
+++ b/Robust.Shared.Maths/Box2.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Shared.Maths
 {
@@ -34,8 +37,8 @@ namespace Robust.Shared.Maths
         public Vector2 TopLeft => new Vector2(Left, Top);
         public Vector2 TopRight => new Vector2(Right, Top);
         public Vector2 BottomLeft => new Vector2(Left, Bottom);
-        public float Width => Math.Abs(Right - Left);
-        public float Height => Math.Abs(Bottom - Top);
+        public float Width => MathF.Abs(Right - Left);
+        public float Height => MathF.Abs(Bottom - Top);
         public Vector2 Size => new Vector2(Width, Height);
         public Vector2 Center => BottomLeft + Size / 2;
 
@@ -88,10 +91,10 @@ namespace Robust.Shared.Maths
         /// </summary>
         public Box2 Intersect(in Box2 other)
         {
-            var left = Math.Max(Left, other.Left);
-            var right = Math.Min(Right, other.Right);
-            var bottom = Math.Max(Bottom, other.Bottom);
-            var top = Math.Min(Top, other.Top);
+            var left = MathF.Max(Left, other.Left);
+            var right = MathF.Min(Right, other.Right);
+            var bottom = MathF.Max(Bottom, other.Bottom);
+            var top = MathF.Min(Top, other.Top);
 
             if (left <= right && bottom <= top)
                 return new Box2(left, bottom, right, top);
@@ -105,10 +108,10 @@ namespace Robust.Shared.Maths
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Box2 Union(in Box2 other)
         {
-            var left = Math.Min(Left, other.Left);
-            var right = Math.Max(Right, other.Right);
-            var bottom = Math.Min(Bottom, other.Bottom);
-            var top = Math.Max(Top, other.Top);
+            var left = MathF.Min(Left, other.Left);
+            var right = MathF.Max(Right, other.Right);
+            var bottom = MathF.Min(Bottom, other.Bottom);
+            var top = MathF.Max(Top, other.Top);
 
             if (left <= right && bottom <= top)
                 return new Box2(left, bottom, right, top);
@@ -251,10 +254,10 @@ namespace Robust.Shared.Maths
             var (x, y) = vec;
 
             return new Box2(
-                Math.Min(x, Left),
-                Math.Min(y, Bottom),
-                Math.Max(x, Right),
-                Math.Max(y, Top));
+                MathF.Min(x, Left),
+                MathF.Min(y, Bottom),
+                MathF.Max(x, Right),
+                MathF.Max(y, Top));
         }
     }
 }

--- a/Robust.Shared.Maths/Box2Rotated.cs
+++ b/Robust.Shared.Maths/Box2Rotated.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Shared.Maths
 {

--- a/Robust.Shared.Maths/Box2i.cs
+++ b/Robust.Shared.Maths/Box2i.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Shared.Maths
 {

--- a/Robust.Shared.Maths/Color.cs
+++ b/Robust.Shared.Maths/Color.cs
@@ -307,17 +307,17 @@ namespace Robust.Shared.Maths
             if (srgb.R <= 0.04045f)
                 r = srgb.R / 12.92f;
             else
-                r = (float) Math.Pow((srgb.R + 0.055f) / (1.0f + 0.055f), 2.4f);
+                r = (float) MathF.Pow((srgb.R + 0.055f) / (1.0f + 0.055f), 2.4f);
 
             if (srgb.G <= 0.04045f)
                 g = srgb.G / 12.92f;
             else
-                g = (float) Math.Pow((srgb.G + 0.055f) / (1.0f + 0.055f), 2.4f);
+                g = (float) MathF.Pow((srgb.G + 0.055f) / (1.0f + 0.055f), 2.4f);
 
             if (srgb.B <= 0.04045f)
                 b = srgb.B / 12.92f;
             else
-                b = (float) Math.Pow((srgb.B + 0.055f) / (1.0f + 0.055f), 2.4f);
+                b = (float) MathF.Pow((srgb.B + 0.055f) / (1.0f + 0.055f), 2.4f);
 #endif
 
             return new Color(r, g, b, srgb.A);
@@ -353,17 +353,17 @@ namespace Robust.Shared.Maths
             if (rgb.R <= 0.0031308)
                 r = 12.92f * rgb.R;
             else
-                r = (1.0f + 0.055f) * (float) Math.Pow(rgb.R, 1.0f / 2.4f) - 0.055f;
+                r = (1.0f + 0.055f) * (float) MathF.Pow(rgb.R, 1.0f / 2.4f) - 0.055f;
 
             if (rgb.G <= 0.0031308)
                 g = 12.92f * rgb.G;
             else
-                g = (1.0f + 0.055f) * (float) Math.Pow(rgb.G, 1.0f / 2.4f) - 0.055f;
+                g = (1.0f + 0.055f) * (float) MathF.Pow(rgb.G, 1.0f / 2.4f) - 0.055f;
 
             if (rgb.B <= 0.0031308)
                 b = 12.92f * rgb.B;
             else
-                b = (1.0f + 0.055f) * (float) Math.Pow(rgb.B, 1.0f / 2.4f) - 0.055f;
+                b = (1.0f + 0.055f) * (float) MathF.Pow(rgb.B, 1.0f / 2.4f) - 0.055f;
 #endif
 
             return new Color(r, g, b, rgb.A);

--- a/Robust.Shared.Maths/Direction.cs
+++ b/Robust.Shared.Maths/Direction.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Shared.Maths
 {
@@ -19,7 +22,7 @@ namespace Robust.Shared.Maths
     /// </summary>
     public static class DirectionExtensions
     {
-        private const double Segment = 2 * Math.PI / 8.0; // Cut the circle into 8 pieces
+        private const double Segment = 2 * Math.π / 8.0; // Cut the circle into 8 pieces
         private const double Offset = Segment / 2.0; // offset the pieces by 1/2 their size
 
         /// <summary>
@@ -41,8 +44,8 @@ namespace Robust.Shared.Maths
         {
             var ang = Segment * (int) dir;
 
-            if (ang > Math.PI) // convert 0 > 2PI to -PI > +PI
-                ang -= 2 * Math.PI;
+            if (ang > Math.π) // convert 0 > 2PI to -PI > +PI
+                ang -= 2 * Math.π;
 
             return ang;
         }

--- a/Robust.Shared.Maths/FloatMath.cs
+++ b/Robust.Shared.Maths/FloatMath.cs
@@ -1,11 +1,14 @@
 ﻿using System;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Shared.Maths
 {
     public static class FloatMath
     {
-        public const float RadToDeg = (float) (180.0 / Math.PI);
-        public const float DegToRad = (float) (Math.PI / 180.0);
+        public const float RadToDeg = (float) (180.0 / Math.π);
+        public const float DegToRad = (float) (Math.π / 180.0);
 
         /// <summary>
         /// Returns the largest integer smaller to or equal to f.
@@ -27,15 +30,15 @@ namespace Robust.Shared.Maths
         public static bool CloseTo(float a, float b, double tolerance = .00001)
         {
             var epsilon =
-                Math.Max(Math.Max(Math.Abs(a), Math.Abs(b)) * tolerance,
+                Math.Max(MathF.Max(MathF.Abs(a), MathF.Abs(b)) * tolerance,
                     tolerance); // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
-            return Math.Abs(a - b) <= epsilon;
+            return MathF.Abs(a - b) <= epsilon;
         }
 
         public static bool CloseTo(float a, double b, double tolerance = .00001)
         {
             var epsilon =
-                Math.Max(Math.Max(Math.Abs(a), Math.Abs(b)) * tolerance,
+                Math.Max(Math.Max(MathF.Abs(a), Math.Abs(b)) * tolerance,
                     tolerance); // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
             return Math.Abs(a - b) <= epsilon;
         }

--- a/Robust.Shared.Maths/MathHelper.cs
+++ b/Robust.Shared.Maths/MathHelper.cs
@@ -12,6 +12,9 @@
 
 using System;
 using System.Diagnostics;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Shared.Maths
 {
@@ -172,7 +175,7 @@ namespace Robust.Shared.Maths
         /// <returns>The angle expressed in radians</returns>
         public static float DegreesToRadians(float degrees)
         {
-            const float degToRad = (float) Math.PI / 180.0f;
+            const float degToRad = (float) (Math.π / 180.0f);
             return degrees * degToRad;
         }
 
@@ -183,7 +186,7 @@ namespace Robust.Shared.Maths
         /// <returns>The angle expressed in degrees</returns>
         public static float RadiansToDegrees(float radians)
         {
-            const float radToDeg = 180.0f / (float) Math.PI;
+            const float radToDeg = (float) (180.0f / Math.π);
             return radians * radToDeg;
         }
 
@@ -194,7 +197,7 @@ namespace Robust.Shared.Maths
         /// <returns>The angle expressed in radians</returns>
         public static double DegreesToRadians(double degrees)
         {
-            const double degToRad = Math.PI / 180.0;
+            const double degToRad = Math.π / 180.0;
             return degrees * degToRad;
         }
 
@@ -205,7 +208,7 @@ namespace Robust.Shared.Maths
         /// <returns>The angle expressed in degrees</returns>
         public static double RadiansToDegrees(double radians)
         {
-            const double radToDeg = 180.0 / Math.PI;
+            const double radToDeg = 180.0 / Math.π;
             return radians * radToDeg;
         }
 
@@ -243,12 +246,12 @@ namespace Robust.Shared.Maths
 
         public static float Min(float a, float b, float c, float d)
         {
-            return Math.Min(a, Math.Min(b, Math.Min(c, d)));
+            return MathF.Min(a, MathF.Min(b, MathF.Min(c, d)));
         }
 
         public static float Max(float a, float b, float c, float d)
         {
-            return Math.Max(a, Math.Max(b, Math.Max(c, d)));
+            return MathF.Max(a, MathF.Max(b, MathF.Max(c, d)));
         }
 
         /// <summary>
@@ -257,7 +260,7 @@ namespace Robust.Shared.Maths
         /// <returns>THe median.</returns>
         public static float Median(float a, float b, float c)
         {
-            return Math.Max(Math.Min(a, b), Math.Min(Math.Max(a, b), c));
+            return MathF.Max(MathF.Min(a, b), MathF.Min(MathF.Max(a, b), c));
         }
 
         #endregion MinMax

--- a/Robust.Shared.Maths/Matrix3.cs
+++ b/Robust.Shared.Maths/Matrix3.cs
@@ -26,6 +26,9 @@ SOFTWARE.
 
 using System;
 using System.Runtime.InteropServices;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Shared.Maths
 {
@@ -886,8 +889,8 @@ namespace Robust.Shared.Maths
         public void Rotate(float angle)
         {
             var angleRadians = MathHelper.DegreesToRadians(angle);
-            var sin = (float) Math.Sin(angleRadians);
-            var cos = (float) Math.Cos(angleRadians);
+            var sin = (float) MathF.Sin(angleRadians);
+            var cos = (float) MathF.Cos(angleRadians);
 
             var r0c0 = cos * R0C0 + sin * R1C0;
             var r0c1 = cos * R0C1 + sin * R1C1;
@@ -923,8 +926,8 @@ namespace Robust.Shared.Maths
         public void Rotate(float angle, out Matrix3 result)
         {
             var angleRadians = MathHelper.DegreesToRadians(angle);
-            var sin = (float) Math.Sin(angleRadians);
-            var cos = (float) Math.Cos(angleRadians);
+            var sin = (float) MathF.Sin(angleRadians);
+            var cos = (float) MathF.Cos(angleRadians);
 
             result.R0C0 = cos * R0C0 + sin * R1C0;
             result.R0C1 = cos * R0C1 + sin * R1C1;
@@ -940,8 +943,8 @@ namespace Robust.Shared.Maths
         public static void Rotate(ref Matrix3 matrix, float angle, out Matrix3 result)
         {
             var angleRadians = MathHelper.DegreesToRadians(angle);
-            var sin = (float) Math.Sin(angleRadians);
-            var cos = (float) Math.Cos(angleRadians);
+            var sin = (float) MathF.Sin(angleRadians);
+            var cos = (float) MathF.Cos(angleRadians);
 
             result.R0C0 = cos * matrix.R0C0 + sin * matrix.R1C0;
             result.R0C1 = cos * matrix.R0C1 + sin * matrix.R1C1;
@@ -957,8 +960,8 @@ namespace Robust.Shared.Maths
         public static void RotateMatrix(float angle, out Matrix3 result)
         {
             var angleRadians = MathHelper.DegreesToRadians(angle);
-            var sin = (float) Math.Sin(angleRadians);
-            var cos = (float) Math.Cos(angleRadians);
+            var sin = (float) MathF.Sin(angleRadians);
+            var cos = (float) MathF.Cos(angleRadians);
 
             result.R0C0 = cos;
             result.R0C1 = sin;

--- a/Robust.Shared.Maths/Matrix4.cs
+++ b/Robust.Shared.Maths/Matrix4.cs
@@ -27,6 +27,9 @@ SOFTWARE.
 
 using System;
 using System.Runtime.InteropServices;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Shared.Maths
 {
@@ -336,8 +339,8 @@ namespace Robust.Shared.Maths
         /// <param name="result">A matrix instance.</param>
         public static void CreateFromAxisAngle(Vector3 axis, float angle, out Matrix4 result)
         {
-            var cos = (float) Math.Cos(-angle);
-            var sin = (float) Math.Sin(-angle);
+            var cos = (float) MathF.Cos(-angle);
+            var sin = (float) MathF.Sin(-angle);
             var t = 1.0f - cos;
 
             axis.Normalize();
@@ -371,8 +374,8 @@ namespace Robust.Shared.Maths
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationX(float angle, out Matrix4 result)
         {
-            var cos = (float) Math.Cos(angle);
-            var sin = (float) Math.Sin(angle);
+            var cos = (float) MathF.Cos(angle);
+            var sin = (float) MathF.Sin(angle);
 
             result.Row0 = Vector4.UnitX;
             result.Row1 = new Vector4(0.0f, cos, sin, 0.0f);
@@ -398,8 +401,8 @@ namespace Robust.Shared.Maths
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationY(float angle, out Matrix4 result)
         {
-            var cos = (float) Math.Cos(angle);
-            var sin = (float) Math.Sin(angle);
+            var cos = (float) MathF.Cos(angle);
+            var sin = (float) MathF.Sin(angle);
 
             result.Row0 = new Vector4(cos, 0.0f, -sin, 0.0f);
             result.Row1 = Vector4.UnitY;
@@ -425,8 +428,8 @@ namespace Robust.Shared.Maths
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationZ(float angle, out Matrix4 result)
         {
-            var cos = (float) Math.Cos(angle);
-            var sin = (float) Math.Sin(angle);
+            var cos = (float) MathF.Cos(angle);
+            var sin = (float) MathF.Sin(angle);
 
             result.Row0 = new Vector4(cos, sin, 0.0f, 0.0f);
             result.Row1 = new Vector4(-sin, cos, 0.0f, 0.0f);
@@ -600,7 +603,7 @@ namespace Robust.Shared.Maths
         /// </exception>
         public static void CreatePerspectiveFieldOfView(float fovy, float aspect, float zNear, float zFar, out Matrix4 result)
         {
-            if (fovy <= 0 || fovy > Math.PI)
+            if (fovy <= 0 || fovy > Math.π)
                 throw new ArgumentOutOfRangeException("fovy");
             if (aspect <= 0)
                 throw new ArgumentOutOfRangeException("aspect");
@@ -609,7 +612,7 @@ namespace Robust.Shared.Maths
             if (zFar <= 0)
                 throw new ArgumentOutOfRangeException("zFar");
 
-            var yMax = zNear * (float) Math.Tan(0.5f * fovy);
+            var yMax = zNear * (float) MathF.Tan(0.5f * fovy);
             var yMin = -yMax;
             var xMin = yMin * aspect;
             var xMax = yMax * aspect;

--- a/Robust.Shared.Maths/Quaternion.cs
+++ b/Robust.Shared.Maths/Quaternion.cs
@@ -28,6 +28,9 @@ SOFTWARE.
 using System;
 using System.Runtime.InteropServices;
 using System.Xml.Serialization;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Shared.Maths
 {
@@ -187,8 +190,8 @@ namespace Robust.Shared.Maths
 
             var result = new Vector4();
 
-            result.W = 2.0f * (float) Math.Acos(q.W); // angle
-            var den = (float) Math.Sqrt(1.0 - q.W * q.W);
+            result.W = 2.0f * (float) MathF.Acos(q.W); // angle
+            var den = (float) MathF.Sqrt(1.0f - q.W * q.W);
             if (den > 0.0001f)
             {
                 result.Xyz = q.Xyz / den;
@@ -211,7 +214,7 @@ namespace Robust.Shared.Maths
         /// Gets the length (magnitude) of the quaternion.
         /// </summary>
         /// <seealso cref="LengthSquared"/>
-        public float Length => (float) Math.Sqrt(W * W + Xyz.LengthSquared);
+        public float Length => (float) MathF.Sqrt(W * W + Xyz.LengthSquared);
 
         #endregion public float Length
 
@@ -256,8 +259,8 @@ namespace Robust.Shared.Maths
 
         #region Fields
 
-        private const float RadToDeg = (float) (180.0 / Math.PI);
-        private const float DegToRad = (float) (Math.PI / 180.0);
+        private const float RadToDeg = (float) (180.0 / Math.π);
+        private const float DegToRad = (float) (Math.π / 180.0);
 
         /// <summary>
         /// Defines the identity quaternion.
@@ -490,8 +493,8 @@ namespace Robust.Shared.Maths
 
             angle *= 0.5f;
             axis.Normalize();
-            result.Xyz = axis * (float) Math.Sin(angle);
-            result.W = (float) Math.Cos(angle);
+            result.Xyz = axis * (float) MathF.Sin(angle);
+            result.W = (float) MathF.Cos(angle);
 
             return Normalize(result);
         }
@@ -545,11 +548,11 @@ namespace Robust.Shared.Maths
             if (cosHalfAngle < 0.99f)
             {
                 // do proper slerp for big angles
-                var halfAngle = (float) Math.Acos(cosHalfAngle);
-                var sinHalfAngle = (float) Math.Sin(halfAngle);
+                var halfAngle = (float) MathF.Acos(cosHalfAngle);
+                var sinHalfAngle = (float) MathF.Sin(halfAngle);
                 var oneOverSinHalfAngle = 1.0f / sinHalfAngle;
-                blendA = (float) Math.Sin(halfAngle * (1.0f - blend)) * oneOverSinHalfAngle;
-                blendB = (float) Math.Sin(halfAngle * blend) * oneOverSinHalfAngle;
+                blendA = (float) MathF.Sin(halfAngle * (1.0f - blend)) * oneOverSinHalfAngle;
+                blendB = (float) MathF.Sin(halfAngle * blend) * oneOverSinHalfAngle;
             }
             else
             {
@@ -576,7 +579,7 @@ namespace Robust.Shared.Maths
                 return to;
             }
 
-            var t = Math.Min(1f, maxDegreesDelta / num);
+            var t = MathF.Min(1f, maxDegreesDelta / num);
             return Slerp(from, to, t);
         }
 
@@ -614,7 +617,7 @@ namespace Robust.Shared.Maths
             var quaternion = new Quaternion();
             if (num8 > 0f)
             {
-                var num = (float) Math.Sqrt(num8 + 1f);
+                var num = (float) MathF.Sqrt(num8 + 1f);
                 quaternion.w = num * 0.5f;
                 num = 0.5f / num;
                 quaternion.X = (m12 - m21) * num;
@@ -625,7 +628,7 @@ namespace Robust.Shared.Maths
 
             if (m00 >= m11 && m00 >= m22)
             {
-                var num7 = (float) Math.Sqrt(1f + m00 - m11 - m22);
+                var num7 = (float) MathF.Sqrt(1f + m00 - m11 - m22);
                 var num4 = 0.5f / num7;
                 quaternion.X = 0.5f * num7;
                 quaternion.Y = (m01 + m10) * num4;
@@ -636,7 +639,7 @@ namespace Robust.Shared.Maths
 
             if (m11 > m22)
             {
-                var num6 = (float) Math.Sqrt(1f + m11 - m00 - m22);
+                var num6 = (float) MathF.Sqrt(1f + m11 - m00 - m22);
                 var num3 = 0.5f / num6;
                 quaternion.X = (m10 + m01) * num3;
                 quaternion.Y = 0.5f * num6;
@@ -645,7 +648,7 @@ namespace Robust.Shared.Maths
                 return quaternion;
             }
 
-            var num5 = (float) Math.Sqrt(1f + m22 - m00 - m11);
+            var num5 = (float) MathF.Sqrt(1f + m22 - m00 - m11);
             var num2 = 0.5f / num5;
             quaternion.X = (m20 + m02) * num2;
             quaternion.Y = (m21 + m12) * num2;
@@ -673,7 +676,7 @@ namespace Robust.Shared.Maths
             {
                 // singularity at north pole
                 v.Y = (float) (2f * Math.Atan2(rotation.y, rotation.x));
-                v.X = (float) (Math.PI / 2);
+                v.X = (float) (Math.π / 2);
                 v.Z = 0;
                 return NormalizeAngles(v * RadToDeg);
             }
@@ -682,15 +685,15 @@ namespace Robust.Shared.Maths
             {
                 // singularity at south pole
                 v.Y = (float) (-2f * Math.Atan2(rotation.y, rotation.x));
-                v.X = (float) (-Math.PI / 2);
+                v.X = (float) (-Math.π / 2);
                 v.Z = 0;
                 return NormalizeAngles(v * RadToDeg);
             }
 
             var q = new Quaternion(rotation.w, rotation.z, rotation.x, rotation.y);
-            v.Y = (float) Math.Atan2(2f * q.x * q.w + 2f * q.y * q.z, 1 - 2f * (q.z * q.z + q.w * q.w)); // Yaw
-            v.X = (float) Math.Asin(2f * (q.x * q.z - q.w * q.y)); // Pitch
-            v.Z = (float) Math.Atan2(2f * q.x * q.y + 2f * q.z * q.w, 1 - 2f * (q.y * q.y + q.z * q.z)); // Roll
+            v.Y = (float) MathF.Atan2(2f * q.x * q.w + 2f * q.y * q.z, 1 - 2f * (q.z * q.z + q.w * q.w)); // Yaw
+            v.X = (float) MathF.Asin(2f * (q.x * q.z - q.w * q.y)); // Pitch
+            v.Z = (float) MathF.Atan2(2f * q.x * q.y + 2f * q.z * q.w, 1 - 2f * (q.y * q.y + q.z * q.z)); // Roll
             return NormalizeAngles(v * RadToDeg);
         }
 

--- a/Robust.Shared.Maths/Robust.Shared.Maths.csproj
+++ b/Robust.Shared.Maths/Robust.Shared.Maths.csproj
@@ -16,5 +16,6 @@
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Condition="'$(TargetFramework)' == 'net472'" Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+    <PackageReference Include="CannyFastMath" Version="1.0.2" />
   </ItemGroup>
 </Project>

--- a/Robust.Shared.Maths/UIBox2.cs
+++ b/Robust.Shared.Maths/UIBox2.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Shared.Maths
 {
@@ -33,8 +36,8 @@ namespace Robust.Shared.Maths
         public Vector2 TopLeft => new Vector2(Left, Top);
         public Vector2 TopRight => new Vector2(Right, Top);
         public Vector2 BottomLeft => new Vector2(Left, Bottom);
-        public float Width => Math.Abs(Right - Left);
-        public float Height => Math.Abs(Top - Bottom);
+        public float Width => MathF.Abs(Right - Left);
+        public float Height => MathF.Abs(Top - Bottom);
         public Vector2 Size => new Vector2(Width, Height);
         public Vector2 Center => TopLeft + Size / 2;
 

--- a/Robust.Shared.Maths/UIBox2i.cs
+++ b/Robust.Shared.Maths/UIBox2i.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Shared.Maths
 {

--- a/Robust.Shared.Maths/Vector2.cs
+++ b/Robust.Shared.Maths/Vector2.cs
@@ -1,5 +1,9 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
+
 
 namespace Robust.Shared.Maths
 {
@@ -54,11 +58,7 @@ namespace Robust.Shared.Maths
         /// <summary>
         ///     Gets the length (magnitude) of the vector.
         /// </summary>
-#if NETCOREAPP
         public float Length => MathF.Sqrt(LengthSquared);
-#else
-        public float Length => (float) Math.Sqrt(LengthSquared);
-#endif
 
         /// <summary>
         ///     Gets the squared length of the vector.
@@ -80,7 +80,7 @@ namespace Robust.Shared.Maths
 
         public Vector2 Rounded()
         {
-            return new Vector2((float) Math.Round(X), (float) Math.Round(Y));
+            return new Vector2((float) MathF.Round(X), (float) MathF.Round(Y));
         }
 
         /// <summary>

--- a/Robust.Shared.Maths/Vector2i.cs
+++ b/Robust.Shared.Maths/Vector2i.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using Newtonsoft.Json;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Shared.Maths
 {

--- a/Robust.Shared.Maths/Vector3.cs
+++ b/Robust.Shared.Maths/Vector3.cs
@@ -28,6 +28,9 @@ SOFTWARE.
 using System;
 using System.Runtime.InteropServices;
 using System.Xml.Serialization;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Shared.Maths
 {
@@ -138,11 +141,7 @@ namespace Robust.Shared.Maths
         /// Gets the length (magnitude) of the vector.
         /// </summary>
         /// <seealso cref="LengthSquared"/>
-#if NETCOREAPP
         public float Length => MathF.Sqrt(LengthSquared);
-#else
-        public float Length => (float) Math.Sqrt(LengthSquared);
-#endif
         #endregion
 
         #region public float LengthSquared
@@ -897,7 +896,7 @@ namespace Robust.Shared.Maths
         /// <remarks>Note that the returned angle is never bigger than the constant Pi.</remarks>
         public static float CalculateAngle(Vector3 first, Vector3 second)
         {
-            return (float) Math.Acos(Dot(first, second) / (first.Length * second.Length));
+            return (float) MathF.Acos(Dot(first, second) / (first.Length * second.Length));
         }
 
         /// <summary>Calculates the angle (in radians) between two vectors.</summary>
@@ -908,7 +907,7 @@ namespace Robust.Shared.Maths
         public static void CalculateAngle(ref Vector3 first, ref Vector3 second, out float result)
         {
             Dot(ref first, ref second, out var temp);
-            result = (float) Math.Acos(temp / (first.Length * second.Length));
+            result = (float) MathF.Acos(temp / (first.Length * second.Length));
         }
 
         #endregion

--- a/Robust.Shared.Maths/Vector4.cs
+++ b/Robust.Shared.Maths/Vector4.cs
@@ -27,6 +27,9 @@ SOFTWARE.
 using System;
 using System.Runtime.InteropServices;
 using System.Xml.Serialization;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Shared.Maths
 {
@@ -203,11 +206,7 @@ namespace Robust.Shared.Maths
         /// Gets the length (magnitude) of the vector.
         /// </summary>
         /// <seealso cref="LengthSquared"/>
-#if NETCOREAPP
         public float Length => MathF.Sqrt(LengthSquared);
-#else
-        public float Length => (float) Math.Sqrt(LengthSquared);
-#endif
 
         #endregion public float Length
 

--- a/Robust.Shared/GameObjects/Components/Physics/PhysicsComponentState.cs
+++ b/Robust.Shared/GameObjects/Components/Physics/PhysicsComponentState.cs
@@ -33,7 +33,7 @@ namespace Robust.Shared.GameObjects
         public PhysicsComponentState(float mass, Vector2 linearVelocity, float angularVelocity)
             : base(NetIDs.PHYSICS)
         {
-            Mass = (int) Math.Round(mass *1000); // rounds kg to nearest gram
+            Mass = (int) MathF.Round(mass *1000); // rounds kg to nearest gram
             LinearVelocity = linearVelocity;
             AngularVelocity = angularVelocity;
         }

--- a/Robust.Shared/Noise/FastNoise.cs
+++ b/Robust.Shared/Noise/FastNoise.cs
@@ -38,6 +38,9 @@ using FN_DECIMAL = System.Single;
 #endif
 using System;
 using System.Runtime.CompilerServices;
+using CannyFastMath;
+using Math = CannyFastMath.Math;
+using MathF = CannyFastMath.MathF;
 
 namespace Robust.Shared.Noise
 {
@@ -1132,7 +1135,7 @@ namespace Robust.Shared.Noise
         private FN_DECIMAL SingleValueFractalBillow(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z)
         {
             int seed = m_seed;
-            FN_DECIMAL sum = Math.Abs(SingleValue(seed, x, y, z)) * 2 - 1;
+            FN_DECIMAL sum = MathF.Abs(SingleValue(seed, x, y, z)) * 2 - 1;
             FN_DECIMAL amp = 1;
 
             for (int i = 1; i < m_octaves; i++)
@@ -1142,7 +1145,7 @@ namespace Robust.Shared.Noise
                 z *= m_lacunarity;
 
                 amp *= m_gain;
-                sum += (Math.Abs(SingleValue(++seed, x, y, z)) * 2 - 1) * amp;
+                sum += (MathF.Abs(SingleValue(++seed, x, y, z)) * 2 - 1) * amp;
             }
 
             return sum * m_fractalBounding;
@@ -1151,7 +1154,7 @@ namespace Robust.Shared.Noise
         private FN_DECIMAL SingleValueFractalRigidMulti(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z)
         {
             int seed = m_seed;
-            FN_DECIMAL sum = 1 - Math.Abs(SingleValue(seed, x, y, z));
+            FN_DECIMAL sum = 1 - MathF.Abs(SingleValue(seed, x, y, z));
             FN_DECIMAL amp = 1;
 
             for (int i = 1; i < m_octaves; i++)
@@ -1161,7 +1164,7 @@ namespace Robust.Shared.Noise
                 z *= m_lacunarity;
 
                 amp *= m_gain;
-                sum -= (1 - Math.Abs(SingleValue(++seed, x, y, z))) * amp;
+                sum -= (1 - MathF.Abs(SingleValue(++seed, x, y, z))) * amp;
             }
 
             return sum;
@@ -1252,7 +1255,7 @@ namespace Robust.Shared.Noise
         private FN_DECIMAL SingleValueFractalBillow(FN_DECIMAL x, FN_DECIMAL y)
         {
             int seed = m_seed;
-            FN_DECIMAL sum = Math.Abs(SingleValue(seed, x, y)) * 2 - 1;
+            FN_DECIMAL sum = MathF.Abs(SingleValue(seed, x, y)) * 2 - 1;
             FN_DECIMAL amp = 1;
 
             for (int i = 1; i < m_octaves; i++)
@@ -1260,7 +1263,7 @@ namespace Robust.Shared.Noise
                 x *= m_lacunarity;
                 y *= m_lacunarity;
                 amp *= m_gain;
-                sum += (Math.Abs(SingleValue(++seed, x, y)) * 2 - 1) * amp;
+                sum += (MathF.Abs(SingleValue(++seed, x, y)) * 2 - 1) * amp;
             }
 
             return sum * m_fractalBounding;
@@ -1269,7 +1272,7 @@ namespace Robust.Shared.Noise
         private FN_DECIMAL SingleValueFractalRigidMulti(FN_DECIMAL x, FN_DECIMAL y)
         {
             int seed = m_seed;
-            FN_DECIMAL sum = 1 - Math.Abs(SingleValue(seed, x, y));
+            FN_DECIMAL sum = 1 - MathF.Abs(SingleValue(seed, x, y));
             FN_DECIMAL amp = 1;
 
             for (int i = 1; i < m_octaves; i++)
@@ -1278,7 +1281,7 @@ namespace Robust.Shared.Noise
                 y *= m_lacunarity;
 
                 amp *= m_gain;
-                sum -= (1 - Math.Abs(SingleValue(++seed, x, y))) * amp;
+                sum -= (1 - MathF.Abs(SingleValue(++seed, x, y))) * amp;
             }
 
             return sum;
@@ -1362,7 +1365,7 @@ namespace Robust.Shared.Noise
         private FN_DECIMAL SinglePerlinFractalBillow(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z)
         {
             int seed = m_seed;
-            FN_DECIMAL sum = Math.Abs(SinglePerlin(seed, x, y, z)) * 2 - 1;
+            FN_DECIMAL sum = MathF.Abs(SinglePerlin(seed, x, y, z)) * 2 - 1;
             FN_DECIMAL amp = 1;
 
             for (int i = 1; i < m_octaves; i++)
@@ -1372,7 +1375,7 @@ namespace Robust.Shared.Noise
                 z *= m_lacunarity;
 
                 amp *= m_gain;
-                sum += (Math.Abs(SinglePerlin(++seed, x, y, z)) * 2 - 1) * amp;
+                sum += (MathF.Abs(SinglePerlin(++seed, x, y, z)) * 2 - 1) * amp;
             }
 
             return sum * m_fractalBounding;
@@ -1381,7 +1384,7 @@ namespace Robust.Shared.Noise
         private FN_DECIMAL SinglePerlinFractalRigidMulti(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z)
         {
             int seed = m_seed;
-            FN_DECIMAL sum = 1 - Math.Abs(SinglePerlin(seed, x, y, z));
+            FN_DECIMAL sum = 1 - MathF.Abs(SinglePerlin(seed, x, y, z));
             FN_DECIMAL amp = 1;
 
             for (int i = 1; i < m_octaves; i++)
@@ -1391,7 +1394,7 @@ namespace Robust.Shared.Noise
                 z *= m_lacunarity;
 
                 amp *= m_gain;
-                sum -= (1 - Math.Abs(SinglePerlin(++seed, x, y, z))) * amp;
+                sum -= (1 - MathF.Abs(SinglePerlin(++seed, x, y, z))) * amp;
             }
 
             return sum;
@@ -1493,7 +1496,7 @@ namespace Robust.Shared.Noise
         private FN_DECIMAL SinglePerlinFractalBillow(FN_DECIMAL x, FN_DECIMAL y)
         {
             int seed = m_seed;
-            FN_DECIMAL sum = Math.Abs(SinglePerlin(seed, x, y)) * 2 - 1;
+            FN_DECIMAL sum = MathF.Abs(SinglePerlin(seed, x, y)) * 2 - 1;
             FN_DECIMAL amp = 1;
 
             for (int i = 1; i < m_octaves; i++)
@@ -1502,7 +1505,7 @@ namespace Robust.Shared.Noise
                 y *= m_lacunarity;
 
                 amp *= m_gain;
-                sum += (Math.Abs(SinglePerlin(++seed, x, y)) * 2 - 1) * amp;
+                sum += (MathF.Abs(SinglePerlin(++seed, x, y)) * 2 - 1) * amp;
             }
 
             return sum * m_fractalBounding;
@@ -1511,7 +1514,7 @@ namespace Robust.Shared.Noise
         private FN_DECIMAL SinglePerlinFractalRigidMulti(FN_DECIMAL x, FN_DECIMAL y)
         {
             int seed = m_seed;
-            FN_DECIMAL sum = 1 - Math.Abs(SinglePerlin(seed, x, y));
+            FN_DECIMAL sum = 1 - MathF.Abs(SinglePerlin(seed, x, y));
             FN_DECIMAL amp = 1;
 
             for (int i = 1; i < m_octaves; i++)
@@ -1520,7 +1523,7 @@ namespace Robust.Shared.Noise
                 y *= m_lacunarity;
 
                 amp *= m_gain;
-                sum -= (1 - Math.Abs(SinglePerlin(++seed, x, y))) * amp;
+                sum -= (1 - MathF.Abs(SinglePerlin(++seed, x, y))) * amp;
             }
 
             return sum;
@@ -1609,7 +1612,7 @@ namespace Robust.Shared.Noise
         private FN_DECIMAL SingleSimplexFractalBillow(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z)
         {
             int seed = m_seed;
-            FN_DECIMAL sum = Math.Abs(SingleSimplex(seed, x, y, z)) * 2 - 1;
+            FN_DECIMAL sum = MathF.Abs(SingleSimplex(seed, x, y, z)) * 2 - 1;
             FN_DECIMAL amp = 1;
 
             for (int i = 1; i < m_octaves; i++)
@@ -1619,7 +1622,7 @@ namespace Robust.Shared.Noise
                 z *= m_lacunarity;
 
                 amp *= m_gain;
-                sum += (Math.Abs(SingleSimplex(++seed, x, y, z)) * 2 - 1) * amp;
+                sum += (MathF.Abs(SingleSimplex(++seed, x, y, z)) * 2 - 1) * amp;
             }
 
             return sum * m_fractalBounding;
@@ -1628,7 +1631,7 @@ namespace Robust.Shared.Noise
         private FN_DECIMAL SingleSimplexFractalRigidMulti(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z)
         {
             int seed = m_seed;
-            FN_DECIMAL sum = 1 - Math.Abs(SingleSimplex(seed, x, y, z));
+            FN_DECIMAL sum = 1 - MathF.Abs(SingleSimplex(seed, x, y, z));
             FN_DECIMAL amp = 1;
 
             for (int i = 1; i < m_octaves; i++)
@@ -1638,7 +1641,7 @@ namespace Robust.Shared.Noise
                 z *= m_lacunarity;
 
                 amp *= m_gain;
-                sum -= (1 - Math.Abs(SingleSimplex(++seed, x, y, z))) * amp;
+                sum -= (1 - MathF.Abs(SingleSimplex(++seed, x, y, z))) * amp;
             }
 
             return sum;
@@ -1687,7 +1690,7 @@ namespace Robust.Shared.Noise
         private FN_DECIMAL SingleSimplexFractalBillow(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z, FN_DECIMAL w)
         {
             int seed = m_seed;
-            FN_DECIMAL sum = Math.Abs(SingleSimplex(seed, x, y, z, w)) * 2 - 1;
+            FN_DECIMAL sum = MathF.Abs(SingleSimplex(seed, x, y, z, w)) * 2 - 1;
             FN_DECIMAL amp = 1;
 
             for (int i = 1; i < m_octaves; i++)
@@ -1698,7 +1701,7 @@ namespace Robust.Shared.Noise
                 w *= m_lacunarity;
 
                 amp *= m_gain;
-                sum += (Math.Abs(SingleSimplex(++seed, x, y, z, w)) * 2 - 1) * amp;
+                sum += (MathF.Abs(SingleSimplex(++seed, x, y, z, w)) * 2 - 1) * amp;
             }
 
             return sum * m_fractalBounding;
@@ -1707,7 +1710,7 @@ namespace Robust.Shared.Noise
         private FN_DECIMAL SingleSimplexFractalRigidMulti(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z, FN_DECIMAL w)
         {
             int seed = m_seed;
-            FN_DECIMAL sum = 1 - Math.Abs(SingleSimplex(seed, x, y, z, w));
+            FN_DECIMAL sum = 1 - MathF.Abs(SingleSimplex(seed, x, y, z, w));
             FN_DECIMAL amp = 1;
 
             for (int i = 1; i < m_octaves; i++)
@@ -1718,7 +1721,7 @@ namespace Robust.Shared.Noise
                 w *= m_lacunarity;
 
                 amp *= m_gain;
-                sum -= (1 - Math.Abs(SingleSimplex(++seed, x, y, z, w))) * amp;
+                sum -= (1 - MathF.Abs(SingleSimplex(++seed, x, y, z, w))) * amp;
             }
 
             return sum;
@@ -1895,7 +1898,7 @@ namespace Robust.Shared.Noise
         private FN_DECIMAL SingleSimplexFractalBillow(FN_DECIMAL x, FN_DECIMAL y)
         {
             int seed = m_seed;
-            FN_DECIMAL sum = Math.Abs(SingleSimplex(seed, x, y)) * 2 - 1;
+            FN_DECIMAL sum = MathF.Abs(SingleSimplex(seed, x, y)) * 2 - 1;
             FN_DECIMAL amp = 1;
 
             for (int i = 1; i < m_octaves; i++)
@@ -1904,7 +1907,7 @@ namespace Robust.Shared.Noise
                 y *= m_lacunarity;
 
                 amp *= m_gain;
-                sum += (Math.Abs(SingleSimplex(++seed, x, y)) * 2 - 1) * amp;
+                sum += (MathF.Abs(SingleSimplex(++seed, x, y)) * 2 - 1) * amp;
             }
 
             return sum * m_fractalBounding;
@@ -1913,7 +1916,7 @@ namespace Robust.Shared.Noise
         private FN_DECIMAL SingleSimplexFractalRigidMulti(FN_DECIMAL x, FN_DECIMAL y)
         {
             int seed = m_seed;
-            FN_DECIMAL sum = 1 - Math.Abs(SingleSimplex(seed, x, y));
+            FN_DECIMAL sum = 1 - MathF.Abs(SingleSimplex(seed, x, y));
             FN_DECIMAL amp = 1;
 
             for (int i = 1; i < m_octaves; i++)
@@ -1922,7 +1925,7 @@ namespace Robust.Shared.Noise
                 y *= m_lacunarity;
 
                 amp *= m_gain;
-                sum -= (1 - Math.Abs(SingleSimplex(++seed, x, y))) * amp;
+                sum -= (1 - MathF.Abs(SingleSimplex(++seed, x, y))) * amp;
             }
 
             return sum;
@@ -2157,7 +2160,7 @@ namespace Robust.Shared.Noise
         private FN_DECIMAL SingleCubicFractalBillow(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z)
         {
             int seed = m_seed;
-            FN_DECIMAL sum = Math.Abs(SingleCubic(seed, x, y, z)) * 2 - 1;
+            FN_DECIMAL sum = MathF.Abs(SingleCubic(seed, x, y, z)) * 2 - 1;
             FN_DECIMAL amp = 1;
             int i = 0;
 
@@ -2168,7 +2171,7 @@ namespace Robust.Shared.Noise
                 z *= m_lacunarity;
 
                 amp *= m_gain;
-                sum += (Math.Abs(SingleCubic(++seed, x, y, z)) * 2 - 1) * amp;
+                sum += (MathF.Abs(SingleCubic(++seed, x, y, z)) * 2 - 1) * amp;
             }
 
             return sum * m_fractalBounding;
@@ -2177,7 +2180,7 @@ namespace Robust.Shared.Noise
         private FN_DECIMAL SingleCubicFractalRigidMulti(FN_DECIMAL x, FN_DECIMAL y, FN_DECIMAL z)
         {
             int seed = m_seed;
-            FN_DECIMAL sum = 1 - Math.Abs(SingleCubic(seed, x, y, z));
+            FN_DECIMAL sum = 1 - MathF.Abs(SingleCubic(seed, x, y, z));
             FN_DECIMAL amp = 1;
             int i = 0;
 
@@ -2188,7 +2191,7 @@ namespace Robust.Shared.Noise
                 z *= m_lacunarity;
 
                 amp *= m_gain;
-                sum -= (1 - Math.Abs(SingleCubic(++seed, x, y, z))) * amp;
+                sum -= (1 - MathF.Abs(SingleCubic(++seed, x, y, z))) * amp;
             }
 
             return sum;
@@ -2306,7 +2309,7 @@ namespace Robust.Shared.Noise
         private FN_DECIMAL SingleCubicFractalBillow(FN_DECIMAL x, FN_DECIMAL y)
         {
             int seed = m_seed;
-            FN_DECIMAL sum = Math.Abs(SingleCubic(seed, x, y)) * 2 - 1;
+            FN_DECIMAL sum = MathF.Abs(SingleCubic(seed, x, y)) * 2 - 1;
             FN_DECIMAL amp = 1;
             int i = 0;
 
@@ -2316,7 +2319,7 @@ namespace Robust.Shared.Noise
                 y *= m_lacunarity;
 
                 amp *= m_gain;
-                sum += (Math.Abs(SingleCubic(++seed, x, y)) * 2 - 1) * amp;
+                sum += (MathF.Abs(SingleCubic(++seed, x, y)) * 2 - 1) * amp;
             }
 
             return sum * m_fractalBounding;
@@ -2325,7 +2328,7 @@ namespace Robust.Shared.Noise
         private FN_DECIMAL SingleCubicFractalRigidMulti(FN_DECIMAL x, FN_DECIMAL y)
         {
             int seed = m_seed;
-            FN_DECIMAL sum = 1 - Math.Abs(SingleCubic(seed, x, y));
+            FN_DECIMAL sum = 1 - MathF.Abs(SingleCubic(seed, x, y));
             FN_DECIMAL amp = 1;
             int i = 0;
 
@@ -2335,7 +2338,7 @@ namespace Robust.Shared.Noise
                 y *= m_lacunarity;
 
                 amp *= m_gain;
-                sum -= (1 - Math.Abs(SingleCubic(++seed, x, y))) * amp;
+                sum -= (1 - MathF.Abs(SingleCubic(++seed, x, y))) * amp;
             }
 
             return sum;
@@ -2451,7 +2454,7 @@ namespace Robust.Shared.Noise
                                 FN_DECIMAL vecY = yi - y + vec.y * m_cellularJitter;
                                 FN_DECIMAL vecZ = zi - z + vec.z * m_cellularJitter;
 
-                                FN_DECIMAL newDistance = Math.Abs(vecX) + Math.Abs(vecY) + Math.Abs(vecZ);
+                                FN_DECIMAL newDistance = MathF.Abs(vecX) + MathF.Abs(vecY) + MathF.Abs(vecZ);
 
                                 if (newDistance < distance)
                                 {
@@ -2478,7 +2481,7 @@ namespace Robust.Shared.Noise
                                 FN_DECIMAL vecY = yi - y + vec.y * m_cellularJitter;
                                 FN_DECIMAL vecZ = zi - z + vec.z * m_cellularJitter;
 
-                                FN_DECIMAL newDistance = (Math.Abs(vecX) + Math.Abs(vecY) + Math.Abs(vecZ)) +
+                                FN_DECIMAL newDistance = (MathF.Abs(vecX) + MathF.Abs(vecY) + MathF.Abs(vecZ)) +
                                                          (vecX * vecX + vecY * vecY + vecZ * vecZ);
 
                                 if (newDistance < distance)
@@ -2538,8 +2541,8 @@ namespace Robust.Shared.Noise
                                 FN_DECIMAL newDistance = vecX * vecX + vecY * vecY + vecZ * vecZ;
 
                                 for (int i = m_cellularDistanceIndex1; i > 0; i--)
-                                    distance[i] = Math.Max(Math.Min(distance[i], newDistance), distance[i - 1]);
-                                distance[0] = Math.Min(distance[0], newDistance);
+                                    distance[i] = MathF.Max(MathF.Min(distance[i], newDistance), distance[i - 1]);
+                                distance[0] = MathF.Min(distance[0], newDistance);
                             }
                         }
                     }
@@ -2558,11 +2561,11 @@ namespace Robust.Shared.Noise
                                 FN_DECIMAL vecY = yi - y + vec.y * m_cellularJitter;
                                 FN_DECIMAL vecZ = zi - z + vec.z * m_cellularJitter;
 
-                                FN_DECIMAL newDistance = Math.Abs(vecX) + Math.Abs(vecY) + Math.Abs(vecZ);
+                                FN_DECIMAL newDistance = MathF.Abs(vecX) + MathF.Abs(vecY) + MathF.Abs(vecZ);
 
                                 for (int i = m_cellularDistanceIndex1; i > 0; i--)
-                                    distance[i] = Math.Max(Math.Min(distance[i], newDistance), distance[i - 1]);
-                                distance[0] = Math.Min(distance[0], newDistance);
+                                    distance[i] = MathF.Max(MathF.Min(distance[i], newDistance), distance[i - 1]);
+                                distance[0] = MathF.Min(distance[0], newDistance);
                             }
                         }
                     }
@@ -2581,12 +2584,12 @@ namespace Robust.Shared.Noise
                                 FN_DECIMAL vecY = yi - y + vec.y * m_cellularJitter;
                                 FN_DECIMAL vecZ = zi - z + vec.z * m_cellularJitter;
 
-                                FN_DECIMAL newDistance = (Math.Abs(vecX) + Math.Abs(vecY) + Math.Abs(vecZ)) +
+                                FN_DECIMAL newDistance = (MathF.Abs(vecX) + MathF.Abs(vecY) + MathF.Abs(vecZ)) +
                                                          (vecX * vecX + vecY * vecY + vecZ * vecZ);
 
                                 for (int i = m_cellularDistanceIndex1; i > 0; i--)
-                                    distance[i] = Math.Max(Math.Min(distance[i], newDistance), distance[i - 1]);
-                                distance[0] = Math.Min(distance[0], newDistance);
+                                    distance[i] = MathF.Max(MathF.Min(distance[i], newDistance), distance[i - 1]);
+                                distance[0] = MathF.Min(distance[0], newDistance);
                             }
                         }
                     }
@@ -2672,7 +2675,7 @@ namespace Robust.Shared.Noise
                             FN_DECIMAL vecX = xi - x + vec.x * m_cellularJitter;
                             FN_DECIMAL vecY = yi - y + vec.y * m_cellularJitter;
 
-                            FN_DECIMAL newDistance = (Math.Abs(vecX) + Math.Abs(vecY));
+                            FN_DECIMAL newDistance = (MathF.Abs(vecX) + MathF.Abs(vecY));
 
                             if (newDistance < distance)
                             {
@@ -2694,7 +2697,7 @@ namespace Robust.Shared.Noise
                             FN_DECIMAL vecX = xi - x + vec.x * m_cellularJitter;
                             FN_DECIMAL vecY = yi - y + vec.y * m_cellularJitter;
 
-                            FN_DECIMAL newDistance = (Math.Abs(vecX) + Math.Abs(vecY)) + (vecX * vecX + vecY * vecY);
+                            FN_DECIMAL newDistance = (MathF.Abs(vecX) + MathF.Abs(vecY)) + (vecX * vecX + vecY * vecY);
 
                             if (newDistance < distance)
                             {
@@ -2747,8 +2750,8 @@ namespace Robust.Shared.Noise
                             FN_DECIMAL newDistance = vecX * vecX + vecY * vecY;
 
                             for (int i = m_cellularDistanceIndex1; i > 0; i--)
-                                distance[i] = Math.Max(Math.Min(distance[i], newDistance), distance[i - 1]);
-                            distance[0] = Math.Min(distance[0], newDistance);
+                                distance[i] = MathF.Max(MathF.Min(distance[i], newDistance), distance[i - 1]);
+                            distance[0] = MathF.Min(distance[0], newDistance);
                         }
                     }
 
@@ -2763,11 +2766,11 @@ namespace Robust.Shared.Noise
                             FN_DECIMAL vecX = xi - x + vec.x * m_cellularJitter;
                             FN_DECIMAL vecY = yi - y + vec.y * m_cellularJitter;
 
-                            FN_DECIMAL newDistance = Math.Abs(vecX) + Math.Abs(vecY);
+                            FN_DECIMAL newDistance = MathF.Abs(vecX) + MathF.Abs(vecY);
 
                             for (int i = m_cellularDistanceIndex1; i > 0; i--)
-                                distance[i] = Math.Max(Math.Min(distance[i], newDistance), distance[i - 1]);
-                            distance[0] = Math.Min(distance[0], newDistance);
+                                distance[i] = MathF.Max(MathF.Min(distance[i], newDistance), distance[i - 1]);
+                            distance[0] = MathF.Min(distance[0], newDistance);
                         }
                     }
 
@@ -2782,11 +2785,11 @@ namespace Robust.Shared.Noise
                             FN_DECIMAL vecX = xi - x + vec.x * m_cellularJitter;
                             FN_DECIMAL vecY = yi - y + vec.y * m_cellularJitter;
 
-                            FN_DECIMAL newDistance = (Math.Abs(vecX) + Math.Abs(vecY)) + (vecX * vecX + vecY * vecY);
+                            FN_DECIMAL newDistance = (MathF.Abs(vecX) + MathF.Abs(vecY)) + (vecX * vecX + vecY * vecY);
 
                             for (int i = m_cellularDistanceIndex1; i > 0; i--)
-                                distance[i] = Math.Max(Math.Min(distance[i], newDistance), distance[i - 1]);
-                            distance[0] = Math.Min(distance[0], newDistance);
+                                distance[i] = MathF.Max(MathF.Min(distance[i], newDistance), distance[i - 1]);
+                            distance[0] = MathF.Min(distance[0], newDistance);
                         }
                     }
 


### PR DESCRIPTION
Use CannyFastMath in various places (but not everywhere).

Even in some places that don't really matter.

Fix some float/double miscasts.

Make Lidgren use netcoreapp3.1 to use CannyFastMath and reduce overhead of netstandard aliasing.

Probably doesn't benefit that much, can revert parts.

Physics and entity queries probably benefit the most.