### PR TITLE
Protect IgnoresAccessChecksTo, Add Task Scheduler Context, Lock on Console Log Flushing

### DIFF
--- a/Robust.Client/GameController.cs
+++ b/Robust.Client/GameController.cs
@@ -331,6 +331,10 @@ namespace Robust.Client
                 args.SetObserved(); // don't crash
 #endif
             };
+
+#if !DEBUG
+            ConsoleLogHandler.TryDetachFromConsoleWindow();
+#endif
         }
 
         private string GetUserDataDir()

--- a/Robust.Client/Utility/IgnoresAccessChecksToAttribute.cs
+++ b/Robust.Client/Utility/IgnoresAccessChecksToAttribute.cs
@@ -1,22 +1,3 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: IgnoresAccessChecksTo("SixLabors.ImageSharp")]
-
-namespace System.Runtime.CompilerServices {
-
-    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
-    public class IgnoresAccessChecksToAttribute : Attribute {
-
-        // ReSharper disable once InconsistentNaming
-        private readonly string assemblyName;
-
-        // ReSharper disable once ConvertToAutoProperty
-        public string AssemblyName
-            => assemblyName;
-
-        public IgnoresAccessChecksToAttribute(string assemblyName)
-            => this.assemblyName = assemblyName;
-
-    }
-
-}

--- a/Robust.Server/Program.cs
+++ b/Robust.Server/Program.cs
@@ -26,8 +26,6 @@ namespace Robust.Server
             Start(args);
         }
 
-        private static Thread? _offMainThread;
-
         internal static void Start(string[] args, bool contentStart = false)
         {
             if (_hasStarted)

--- a/Robust.Server/Program.cs
+++ b/Robust.Server/Program.cs
@@ -42,6 +42,8 @@ namespace Robust.Server
 
             ThreadPool.SetMinThreads(Environment.ProcessorCount * 2, Environment.ProcessorCount);
 
+            // this sets up TaskScheduler.Current for new tasks to be scheduled off the main thread
+            // the LongRunning option causes it to not be scheduled on the thread pool, so it's just a plain thread with a task context
             new TaskFactory(
                     CancellationToken.None,
                     TaskCreationOptions.LongRunning,

--- a/Robust.Server/Program.cs
+++ b/Robust.Server/Program.cs
@@ -53,6 +53,7 @@ namespace Robust.Server
 
         private static void ParsedMain(CommandLineArgs args, bool contentStart)
         {
+            Thread.CurrentThread.Name = "Main Thread";
             IoCManager.InitThread();
             ServerIoC.RegisterIoC();
             IoCManager.BuildGraph();

--- a/Robust.Shared/Asynchronous/RobustTaskScheduler.cs
+++ b/Robust.Shared/Asynchronous/RobustTaskScheduler.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Robust.Shared.Asynchronous
+{
+
+    /// <summary>
+    /// An implementation of TaskScheduler that uses the ThreadPool scheduler
+    /// </summary>
+    public sealed class RobustTaskScheduler : TaskScheduler
+    {
+
+        public static readonly RobustTaskScheduler Instance = new RobustTaskScheduler();
+
+        private RobustTaskScheduler()
+        {
+            // private
+        }
+
+        public static void Execute(object? o)
+        {
+            switch (o)
+            {
+                case IThreadPoolWorkItem w:
+                    w.Execute();
+                    break;
+                case ValueTask v:
+                    Instance.TryExecuteTask(v.AsTask());
+                    break;
+                case Task t:
+                    Instance.TryExecuteTask(t);
+                    break;
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        /// <summary>
+        /// Schedules a task to the ThreadPool.
+        /// </summary>
+        /// <param name="task">The task to schedule.</param>
+        protected override void QueueTask(Task task)
+        {
+            if (task.IsCompleted) return;
+
+            var options = task.CreationOptions;
+            if ((options & TaskCreationOptions.LongRunning) == 0)
+            {
+                ThreadPool.UnsafeQueueUserWorkItem((IThreadPoolWorkItem) task, false);
+            }
+            else
+            {
+                var wantsToBeFair = (task.CreationOptions & TaskCreationOptions.PreferFairness) != 0;
+                new Thread(Execute)
+                {
+                    Name = "Long Running Task",
+                    Priority = wantsToBeFair ? ThreadPriority.BelowNormal : ThreadPriority.AboveNormal,
+                    IsBackground = true
+                }.Start(task);
+            }
+        }
+
+        /// <summary>
+        /// This internal function will do this:
+        ///   (1) If the task had previously been queued, attempt to pop it and return false if that fails.
+        ///   (2) Return whether the task is executed
+        ///
+        /// IMPORTANT NOTE: TryExecuteTaskInline will NOT throw task exceptions itself. Any wait code path using this function needs
+        /// to account for exceptions that need to be propagated, and throw themselves accordingly.
+        /// </summary>
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+        {
+            return task.IsCompleted;
+        }
+
+        protected override bool TryDequeue(Task task) => false;
+
+        protected override IEnumerable<Task> GetScheduledTasks() => Enumerable.Empty<Task>();
+
+    }
+
+}

--- a/Robust.Shared/IgnoreAccessChecksToAttribute.cs
+++ b/Robust.Shared/IgnoreAccessChecksToAttribute.cs
@@ -1,0 +1,22 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: IgnoresAccessChecksTo("SixLabors.ImageSharp")]
+
+namespace System.Runtime.CompilerServices {
+
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    internal class IgnoresAccessChecksToAttribute : Attribute {
+
+        // ReSharper disable once InconsistentNaming
+        private readonly string assemblyName;
+
+        // ReSharper disable once ConvertToAutoProperty
+        public string AssemblyName
+            => assemblyName;
+
+        public IgnoresAccessChecksToAttribute(string assemblyName)
+            => this.assemblyName = assemblyName;
+
+    }
+
+}


### PR DESCRIPTION
Move Impl of IgnoreAccessChecksToAttribute to Robust.Shared, make it internal

launch server into task scheduler context with custom task scheduler that does not run things inline / on the main thread