### PR TITLE
Feature/the macro

### DIFF
--- a/Robust.Shared/GameObjects/Components/GrammarComponent.cs
+++ b/Robust.Shared/GameObjects/Components/GrammarComponent.cs
@@ -8,7 +8,7 @@ namespace Robust.Shared.GameObjects.Components
     /// <summary>
     /// Holds the necessary information to generate text related to the entity.
     /// </summary>
-    [RegisterComponent, Serializable, NetSerializable]
+    [RegisterComponent]
     public class GrammarComponent: Component, IProperNamable
     {
         public sealed override string Name => "Grammar";

--- a/Robust.Shared/GameObjects/Components/GrammarComponent.cs
+++ b/Robust.Shared/GameObjects/Components/GrammarComponent.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Robust.Shared.Localization.Macros;
+using Robust.Shared.Serialization;
+using Robust.Shared.ViewVariables;
+
+namespace Robust.Shared.GameObjects.Components
+{
+    /// <summary>
+    /// Holds the necessary information to generate text related to the entity.
+    /// </summary>
+    [RegisterComponent, Serializable, NetSerializable]
+    public class GrammarComponent: Component, IPropernamable
+    {
+        public sealed override string Name => "Grammar";
+
+        public sealed override uint? NetID => NetIDs.GRAMMAR;
+
+        private bool _proper;
+
+        [ViewVariables(VVAccess.ReadWrite)]
+        public bool Proper
+        {
+            get => _proper;
+            set
+            {
+                _proper = value;
+                Dirty();
+            }
+        }
+
+        public override void ExposeData(ObjectSerializer serializer)
+        {
+            serializer.DataField(this, x => x.Proper, "proper", false);
+        }
+
+        public override ComponentState GetComponentState()
+        {
+            return new GrammarComponentState(Proper);
+        }
+
+        public override void HandleComponentState(ComponentState curState, ComponentState nextState)
+        {
+            if (!(curState is GrammarComponentState cast))
+                return;
+
+            Proper = cast.Proper;
+        }
+
+        [Serializable, NetSerializable]
+        protected sealed class GrammarComponentState : ComponentState
+        {
+            public GrammarComponentState(bool proper) : base(NetIDs.GRAMMAR)
+            {
+                Proper = proper;
+            }
+
+            public bool Proper { get; }
+        }
+    }
+}

--- a/Robust.Shared/GameObjects/Components/GrammarComponent.cs
+++ b/Robust.Shared/GameObjects/Components/GrammarComponent.cs
@@ -9,7 +9,7 @@ namespace Robust.Shared.GameObjects.Components
     /// Holds the necessary information to generate text related to the entity.
     /// </summary>
     [RegisterComponent, Serializable, NetSerializable]
-    public class GrammarComponent: Component, IPropernamable
+    public class GrammarComponent: Component, IProperNamable
     {
         public sealed override string Name => "Grammar";
 
@@ -38,7 +38,7 @@ namespace Robust.Shared.GameObjects.Components
             return new GrammarComponentState(Proper);
         }
 
-        public override void HandleComponentState(ComponentState curState, ComponentState nextState)
+        public override void HandleComponentState(ComponentState? curState, ComponentState? nextState)
         {
             if (!(curState is GrammarComponentState cast))
                 return;

--- a/Robust.Shared/GameObjects/Components/NetIDs.cs
+++ b/Robust.Shared/GameObjects/Components/NetIDs.cs
@@ -15,5 +15,6 @@
         public const uint USERINTERFACE = 24;
         public const uint CONTAINER_MANAGER = 25;
         public const uint OCCLUDER = 26;
+        public const uint GRAMMAR = 27;
     }
 }

--- a/Robust.Shared/Localization/Macros/Attributes.cs
+++ b/Robust.Shared/Localization/Macros/Attributes.cs
@@ -34,20 +34,20 @@ namespace Robust.Shared.Localization.Macros
         }
     }
 
-    public interface IPropernamable
+    public interface IProperNamable
     {
         public bool Proper => false;
 
-        public static bool GetProperOrFalse(object argument)
+        public static bool GetProperOrFalse(object? argument)
         {
             // FIXME The Entity special case is not really good
             if (argument is IEntity entity)
             {
                 // FIXME And this is not really better.
-                return Enumerable.FirstOrDefault(entity.GetAllComponents<IPropernamable>())?.Proper ?? false;
+                return entity.GetAllComponents<IProperNamable>().FirstOrDefault()?.Proper ?? false;
             }
 
-            return (argument as IPropernamable)?.Proper ?? false;
+            return (argument as IProperNamable)?.Proper ?? false;
         }
     }
 }

--- a/Robust.Shared/Localization/Macros/Attributes.cs
+++ b/Robust.Shared/Localization/Macros/Attributes.cs
@@ -33,4 +33,21 @@ namespace Robust.Shared.Localization.Macros
                 return (argument as IGenderable)?.Gender ?? Gender.Epicene;
         }
     }
+
+    public interface IPropernamable
+    {
+        public bool Proper => false;
+
+        public static bool GetProperOrFalse(object argument)
+        {
+            // FIXME The Entity special case is not really good
+            if (argument is IEntity entity)
+            {
+                // FIXME And this is not really better.
+                return Enumerable.FirstOrDefault(entity.GetAllComponents<IPropernamable>())?.Proper ?? false;
+            }
+
+            return (argument as IPropernamable)?.Proper ?? false;
+        }
+    }
 }

--- a/Robust.Shared/Localization/Macros/English/EnglishMacros.cs
+++ b/Robust.Shared/Localization/Macros/English/EnglishMacros.cs
@@ -93,11 +93,14 @@
     [RegisterTextMacro("theName", "en")]
     public class TheName : ITextMacro
     {
+        private readonly NameMacro _nameMacro = new NameMacro();
+
         public string Format(object argument)
         {
+            var name = _nameMacro.Format(argument);
             return IPropernamable.GetProperOrFalse(argument)
-                ? argument.ToString()
-                : "the " + argument.ToString();
+                ? name
+                : "the " + name;
         }
     }
 }

--- a/Robust.Shared/Localization/Macros/English/EnglishMacros.cs
+++ b/Robust.Shared/Localization/Macros/English/EnglishMacros.cs
@@ -95,10 +95,10 @@
     {
         private readonly NameMacro _nameMacro = new NameMacro();
 
-        public string Format(object argument)
+        public string Format(object? argument)
         {
             var name = _nameMacro.Format(argument);
-            return IPropernamable.GetProperOrFalse(argument)
+            return IProperNamable.GetProperOrFalse(argument)
                 ? name
                 : "the " + name;
         }

--- a/Robust.Shared/Localization/Macros/English/EnglishMacros.cs
+++ b/Robust.Shared/Localization/Macros/English/EnglishMacros.cs
@@ -1,4 +1,4 @@
-﻿namespace Robust.Shared.Localization.Macros
+﻿namespace Robust.Shared.Localization.Macros.English
 {
     [RegisterTextMacro("they", "en")]
     public class They : ITextMacro

--- a/Robust.Shared/Localization/Macros/English/EnglishMacros.cs
+++ b/Robust.Shared/Localization/Macros/English/EnglishMacros.cs
@@ -89,4 +89,15 @@
             };
         }
     }
+
+    [RegisterTextMacro("theName", "en")]
+    public class TheName : ITextMacro
+    {
+        public string Format(object argument)
+        {
+            return IPropernamable.GetProperOrFalse(argument)
+                ? argument.ToString()
+                : "the " + argument.ToString();
+        }
+    }
 }

--- a/Robust.Shared/Localization/Macros/GeneralMacros.cs
+++ b/Robust.Shared/Localization/Macros/GeneralMacros.cs
@@ -1,0 +1,14 @@
+﻿using Robust.Shared.Interfaces.GameObjects;
+
+namespace Robust.Shared.Localization.Macros
+{
+    [RegisterTextMacro("name")]
+    public class NameMacro: ITextMacro
+    {
+        public string Format(object argument)
+        {
+            // TODO Make entity inherit "INameable" something?
+            return (argument as IEntity)?.Name ?? argument.ToString();
+        }
+    }
+}

--- a/Robust.Shared/Localization/Macros/GeneralMacros.cs
+++ b/Robust.Shared/Localization/Macros/GeneralMacros.cs
@@ -5,10 +5,10 @@ namespace Robust.Shared.Localization.Macros
     [RegisterTextMacro("name")]
     public class NameMacro: ITextMacro
     {
-        public string Format(object argument)
+        public string Format(object? argument)
         {
             // TODO Make entity inherit "INameable" something?
-            return (argument as IEntity)?.Name ?? argument.ToString();
+            return (argument as IEntity)?.Name ?? argument?.ToString() ?? "<null>";
         }
     }
 }

--- a/Robust.Shared/Localization/Macros/MacroFormatter.cs
+++ b/Robust.Shared/Localization/Macros/MacroFormatter.cs
@@ -20,7 +20,7 @@ namespace Robust.Shared.Localization.Macros
                 return string.Format(fallbackProvider, "{0}", arg);
 
             bool capitalized = char.IsUpper(format[0]);
-            string lowerCasedFunctionName = format.ToLower();
+            string lowerCasedFunctionName = char.ToLower(format[0]) + format.Substring(1);
 
             if (!Macros.TryGetValue(lowerCasedFunctionName, out var grammarFunction))
                 return string.Format(fallbackProvider, "{0:" + format + '}', arg);

--- a/Robust.UnitTesting/Shared/Localization/Macros/EnglishMacros_test.cs
+++ b/Robust.UnitTesting/Shared/Localization/Macros/EnglishMacros_test.cs
@@ -7,7 +7,7 @@ namespace Robust.UnitTesting.Shared.Localization.Macros
     [TestFixture, Parallelizable]
     public class EnglishMacros_test
     {
-        private struct Subject : IGenderable, IPropernamable
+        private struct Subject : IGenderable, IProperNamable
         {
             public string Name;
 

--- a/Robust.UnitTesting/Shared/Localization/Macros/EnglishMacros_test.cs
+++ b/Robust.UnitTesting/Shared/Localization/Macros/EnglishMacros_test.cs
@@ -7,16 +7,19 @@ namespace Robust.UnitTesting.Shared.Localization.Macros
     [TestFixture, Parallelizable]
     public class EnglishMacros_test
     {
-        private struct Subject : IGenderable
+        private struct Subject : IGenderable, IPropernamable
         {
             public string Name;
 
             public Gender Gender { get; set; }
 
-            public Subject(string name, Gender gender)
+            public bool Proper { get; set; }
+
+            public Subject(string name, Gender gender, bool proper)
             {
                 Name = name;
                 Gender = gender;
+                Proper = proper;
             }
 
             public override string ToString()
@@ -25,10 +28,10 @@ namespace Robust.UnitTesting.Shared.Localization.Macros
             }
         }
 
-        private readonly Subject female = new Subject("Lisa", Gender.Female);
-        private readonly Subject male = new Subject("Bob", Gender.Male);
-        private readonly Subject epicene = new Subject("Michel", Gender.Epicene);
-        private readonly Subject neuter = new Subject("D.O.O.R.K.N.O.B.", Gender.Neuter);
+        private readonly Subject female = new Subject("Lisa", Gender.Female, true);
+        private readonly Subject male = new Subject("Bob", Gender.Male, true);
+        private readonly Subject epicene = new Subject("Michel", Gender.Epicene, true);
+        private readonly Subject neuter = new Subject("D.O.O.R.K.N.O.B.", Gender.Neuter, true);
 
         public void TestThey()
         {
@@ -87,6 +90,16 @@ namespace Robust.UnitTesting.Shared.Localization.Macros
             Assert.AreEqual("he's", sut.Format(male));
             Assert.AreEqual("they're", sut.Format(epicene));
             Assert.AreEqual("it's", sut.Format(neuter));
+        }
+
+        [Test]
+        public void TestTheName()
+        {
+            var cpu = new Subject("CPU", Gender.Neuter, false);
+            ITextMacro sut = new TheName();
+            Assert.AreEqual("The CPU", sut.CapitalizedFormat(cpu));
+            Assert.AreEqual("the CPU", sut.Format(cpu));
+            Assert.AreEqual(male.Name, sut.Format(male));
         }
     }
 }

--- a/Robust.UnitTesting/Shared/Localization/Macros/EnglishMacros_test.cs
+++ b/Robust.UnitTesting/Shared/Localization/Macros/EnglishMacros_test.cs
@@ -1,0 +1,92 @@
+﻿using NUnit.Framework;
+using Robust.Shared.Localization.Macros;
+using Robust.Shared.Localization.Macros.English;
+
+namespace Robust.UnitTesting.Shared.Localization.Macros
+{
+    [TestFixture, Parallelizable]
+    public class EnglishMacros_test
+    {
+        private struct Subject : IGenderable
+        {
+            public string Name;
+
+            public Gender Gender { get; set; }
+
+            public Subject(string name, Gender gender)
+            {
+                Name = name;
+                Gender = gender;
+            }
+
+            public override string ToString()
+            {
+                return Name;
+            }
+        }
+
+        private readonly Subject female = new Subject("Lisa", Gender.Female);
+        private readonly Subject male = new Subject("Bob", Gender.Male);
+        private readonly Subject epicene = new Subject("Michel", Gender.Epicene);
+        private readonly Subject neuter = new Subject("D.O.O.R.K.N.O.B.", Gender.Neuter);
+
+        public void TestThey()
+        {
+            ITextMacro sut = new They();
+            Assert.AreEqual("She", sut.CapitalizedFormat(female));
+            Assert.AreEqual("he", sut.Format(male));
+            Assert.AreEqual("they", sut.Format(epicene));
+            Assert.AreEqual("it", sut.Format(neuter));
+        }
+
+        [Test]
+        public void TestTheir()
+        {
+            var sut = new Their();
+            Assert.AreEqual("her", sut.Format(female));
+            Assert.AreEqual("his", sut.Format(male));
+            Assert.AreEqual("their", sut.Format(epicene));
+            Assert.AreEqual("its", sut.Format(neuter));
+        }
+
+        [Test]
+        public void TestTheirs()
+        {
+            var sut = new Theirs();
+            Assert.AreEqual("hers", sut.Format(female));
+            Assert.AreEqual("his", sut.Format(male));
+            Assert.AreEqual("theirs", sut.Format(epicene));
+            Assert.AreEqual("its", sut.Format(neuter));
+        }
+
+        [Test]
+        public void TestThem()
+        {
+            var sut = new Them();
+            Assert.AreEqual("her", sut.Format(female));
+            Assert.AreEqual("him", sut.Format(male));
+            Assert.AreEqual("them", sut.Format(epicene));
+            Assert.AreEqual("it", sut.Format(neuter));
+        }
+
+        [Test]
+        public void TestThemself()
+        {
+            var sut = new Themself();
+            Assert.AreEqual("herself", sut.Format(female));
+            Assert.AreEqual("himself", sut.Format(male));
+            Assert.AreEqual("themself", sut.Format(epicene));
+            Assert.AreEqual("itself", sut.Format(neuter));
+        }
+
+        [Test]
+        public void TestTheyre()
+        {
+            ITextMacro sut = new Theyre();
+            Assert.AreEqual("She's", sut.CapitalizedFormat(female));
+            Assert.AreEqual("he's", sut.Format(male));
+            Assert.AreEqual("they're", sut.Format(epicene));
+            Assert.AreEqual("it's", sut.Format(neuter));
+        }
+    }
+}

--- a/Robust.UnitTesting/Shared/Localization/Macros/MacroFormatProvider_tests.cs
+++ b/Robust.UnitTesting/Shared/Localization/Macros/MacroFormatProvider_tests.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using NUnit.Framework;
 using Robust.Shared.Localization.Macros;
+using Robust.Shared.Localization.Macros.English;
 
 namespace Robust.UnitTesting.Shared.Localization.Macros
 {


### PR DESCRIPTION
Add TheName macro : expands to "The" followed by the name. I did not find a usage for a "the" alone macro, tell me if there is any.

I added a GrammarComponent to store the `Proper` information. By default, if the grammar component is missing, the name is improper.
Pros :
- It is not intrusive.

Cons:
- You have to add a component if you want to change the default behavior.
- It changes from SS13 where the default behavior was guessed from the capitalization of the 

Usage: `Loc.GetString("You hide {0:theName} in the plant.", eventArgs.Using)`

Closes #1083