### PR TITLE
Fix physics anchored status not being synced to the client

### DIFF
--- a/Robust.Shared/GameObjects/Components/Physics/PhysicsComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Physics/PhysicsComponent.cs
@@ -113,6 +113,9 @@ namespace Robust.Shared.GameObjects.Components
                                 !IoCManager.Resolve<IPhysicsManager>()
                                     .IsWeightless(Owner.Transform.GridPosition);
 
+        /// <summary>
+        ///     Whether or not the entity is anchored in place.
+        /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         public bool Anchored
         {
@@ -121,6 +124,7 @@ namespace Robust.Shared.GameObjects.Components
             {
                 _anchored = value;
                 AnchoredChanged?.Invoke();
+                Dirty();
             }
         }
 
@@ -149,7 +153,7 @@ namespace Robust.Shared.GameObjects.Components
         /// <inheritdoc />
         public override ComponentState GetComponentState()
         {
-            return new PhysicsComponentState(_mass, LinearVelocity, AngularVelocity);
+            return new PhysicsComponentState(_mass, LinearVelocity, AngularVelocity, Anchored);
         }
 
         public void RemoveController()
@@ -180,6 +184,7 @@ namespace Robust.Shared.GameObjects.Components
             LinearVelocity = newState.LinearVelocity;
             // Logger.Debug($"{IGameTiming.TickStampStatic}: [{Owner}] {LinearVelocity}");
             AngularVelocity = newState.AngularVelocity;
+            Anchored = newState.Anchored;
             // TODO: Does it make sense to reset controllers here?
             // This caused space movement to break in content and I'm not 100% sure this is a good fix.
             // Look man the CM test is in 5 hours cut me some slack.

--- a/Robust.Shared/GameObjects/Components/Physics/PhysicsComponentState.cs
+++ b/Robust.Shared/GameObjects/Components/Physics/PhysicsComponentState.cs
@@ -17,17 +17,22 @@ namespace Robust.Shared.GameObjects.Components
 
         public readonly Vector2 LinearVelocity;
         public readonly float AngularVelocity;
+        public readonly bool Anchored;
 
         /// <summary>
         ///     Constructs a new state snapshot of a PhysicsComponent.
         /// </summary>
         /// <param name="mass">Current Mass of the entity.</param>
-        public PhysicsComponentState(float mass, Vector2 linearVelocity, float angularVelocity)
+        /// <param name="linearVelocity">Current linear velocity of the entity in meters per second.</param>
+        /// <param name="angularVelocity">Current angular velocity of the entity in radians per sec.</param>
+        /// <param name="anchored">Whether or not the entity is anchored in place.</param>
+        public PhysicsComponentState(float mass, Vector2 linearVelocity, float angularVelocity, bool anchored)
             : base(NetIDs.PHYSICS)
         {
             LinearVelocity = linearVelocity;
             AngularVelocity = angularVelocity;
             Mass = (int) Math.Round(mass *1000); // rounds kg to nearest gram
+            Anchored = anchored;
         }
     }
 }


### PR DESCRIPTION
Fixes the client thinking it can push entities that it can't, specially noticeable with low mass entities.