### PR TITLE
Adds logout command, tweaks login

### DIFF
--- a/Robust.Server/Console/ConsoleShell.cs
+++ b/Robust.Server/Console/ConsoleShell.cs
@@ -219,9 +219,10 @@ namespace Robust.Server.Console
 
                 // WE ARE AT THE BRIDGE OF DEATH
                 if (shell.ElevateShell(player, args[0]))
+                {
                     shell.SendText(player, "Logged in.");
                     return;
-
+                }
                 // CAST INTO THE GORGE OF ETERNAL PERIL
                 Logger.WarningS(
                     "con.auth",
@@ -271,8 +272,10 @@ namespace Robust.Server.Console
 
                 // WE ARE AT THE BRIDGE OF DEATH
                 if (shell.ElevateShellHost(player, args[0]))
+                {
                     shell.SendText(player, "Logged in as host.");
                     return;
+                }
 
                 // CAST INTO THE GORGE OF ETERNAL PERIL
                 Logger.WarningS(

--- a/Robust.Server/Console/ConsoleShell.cs
+++ b/Robust.Server/Console/ConsoleShell.cs
@@ -186,13 +186,14 @@ namespace Robust.Server.Console
                 throw new ArgumentNullException(nameof(session));
 
             var realPass = _configMan.GetCVar<string>("console.password");
+            var hostPass = _configMan.GetCVar<string>("console.hostpassword");
 
             // password disabled
             if (string.IsNullOrWhiteSpace(realPass))
                 return false;
 
             // wrong password
-            if (password != realPass)
+            if (password != realPass && password != hostPass)
                 return false;
 
             // success!
@@ -219,6 +220,7 @@ namespace Robust.Server.Console
 
                 // WE ARE AT THE BRIDGE OF DEATH
                 if (shell.ElevateShell(player, args[0]))
+                    shell.SendText(player, "Logged in.");
                     return;
 
                 // CAST INTO THE GORGE OF ETERNAL PERIL
@@ -270,6 +272,7 @@ namespace Robust.Server.Console
 
                 // WE ARE AT THE BRIDGE OF DEATH
                 if (shell.ElevateShellHost(player, args[0]))
+                    shell.SendText(player, "Logged in as host.");
                     return;
 
                 // CAST INTO THE GORGE OF ETERNAL PERIL
@@ -279,6 +282,25 @@ namespace Robust.Server.Console
 
                 var net = IoCManager.Resolve<IServerNetManager>();
                 net.DisconnectChannel(player.ConnectedClient, "Failed login authentication.");
+            }
+        }
+
+        private class LogoutCommand : IClientCommand
+        {
+            public string Command => "logout";
+            public string Description => "Demotes the client to player permission group.";
+            public string Help => "logout";
+
+            public void Execute(IConsoleShell shell, IPlayerSession? player, string[] args)
+            {
+                // system console can't log in to itself, and is pointless anyways
+                if (player == null)
+                    return;
+
+                var groupController = IoCManager.Resolve<IConGroupController>();
+                groupController.SetGroup(player, new ConGroupIndex(1));
+                shell.SendText(player, "Logged out.");
+
             }
         }
 

--- a/Robust.Server/Console/ConsoleShell.cs
+++ b/Robust.Server/Console/ConsoleShell.cs
@@ -210,7 +210,6 @@ namespace Robust.Server.Console
 
             public void Execute(IConsoleShell shell, IPlayerSession? player, string[] args)
             {
-                // system console can't log in to itself, and is pointless anyways
                 if (player == null)
                     return;
 


### PR DESCRIPTION
Adds a logout command, which demotes host/admin to player. Not as intricate as a proper deadmin command should be (booting aghost back to body, removing admin chat filter button, etc aren't dealt with) but it is useful for testing things.

Also adds feedback to successful login and allows you to use the host password for admin login, since I mix them up sometimes.

Required by: space-wizards/space-station-14#1320