### PR TITLE
Fix GridPosition set breaking when value.GridID is invalid

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -208,8 +208,16 @@ namespace Robust.Shared.GameObjects.Components.Transform
 
                 if (value.GridID != GridID)
                 {
-                    var newGrid = _mapManager.GetGrid(value.GridID);
-                    AttachParent(_entityManager.GetEntity(newGrid.GridEntityId));
+                    if (value.GridID != GridId.Invalid)
+                    {
+                        var newGrid = _mapManager.GetGrid(value.GridID);
+                        AttachParent(_entityManager.GetEntity(newGrid.GridEntityId));
+                    }
+                    else
+                    {
+                        var map = _mapManager.GetMapEntity(MapID);
+                        AttachParent(map);
+                    }
                 }
 
                 // world coords to parent coords


### PR DESCRIPTION
Fixes errors when GridPosition is set to GridId.Invalid.

This fixes dropping items when the player GridID is GridId.Invalid.

If there's a better way to get the map then that should probably be used. Such as being able to get the map that the GridCoordinates are being set from so that there isn't any weird functionality when teleporting through space maps.