### PR TITLE
Make IMapGridComponent public instead of internal

### DIFF
--- a/Robust.Shared/GameObjects/Components/Map/MapGridComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Map/MapGridComponent.cs
@@ -12,7 +12,7 @@ namespace Robust.Shared.GameObjects.Components.Map
     /// <summary>
     ///     Represents a map grid inside the ECS system.
     /// </summary>
-    internal interface IMapGridComponent : IComponent
+    public interface IMapGridComponent : IComponent
     {
         GridId GridIndex { get; }
         IMapGrid Grid { get; }


### PR DESCRIPTION
For conveyors in https://github.com/space-wizards/space-station-14/pull/1367 to not move entire grids.