### PR TITLE
1464 Ignore text functions if no keyboard is focused

### DIFF
--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -131,8 +131,7 @@ namespace Robust.Client.Input
             foreach (var binding in _bindings)
             {
                 // check if our binding is even in the active context
-                if (!Contexts.ActiveContext.FunctionExistsHierarchy(binding.Function)
-                    || (_userInterfaceManagerInternal.KeyboardFocused == null && binding.Function.FunctionName.Contains("Text")))
+                if (!Contexts.ActiveContext.FunctionExistsHierarchy(binding.Function))
                 {
                     continue;
                 }
@@ -153,6 +152,10 @@ namespace Robust.Client.Input
                     {
                         // kill any lower level matches
                         UpBind(binding);
+                    }
+                    else
+                    {
+                        bindsDown.Add(binding);
                     }
                 }
             }

--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -131,8 +131,11 @@ namespace Robust.Client.Input
             foreach (var binding in _bindings)
             {
                 // check if our binding is even in the active context
-                if (!Contexts.ActiveContext.FunctionExistsHierarchy(binding.Function))
+                if (!Contexts.ActiveContext.FunctionExistsHierarchy(binding.Function)
+                    || (_userInterfaceManagerInternal.KeyboardFocused == null && binding.Function.FunctionName.Contains("Text")))
+                {
                     continue;
+                }
 
                 if (PackedMatchesPressedState(binding.PackedKeyCombo))
                 {


### PR DESCRIPTION
Fixes https://github.com/space-wizards/space-station-14/issues/1464

If there's no keyboard focused, ignore all commands that have "Text". IE: TextSelectAll which makes control A not moving left.