### PR TITLE
VV numeric field display attribute

### DIFF
--- a/Robust.Client/ViewVariables/Editors/ViewVariablesPropertyEditorKeyValuePair.cs
+++ b/Robust.Client/ViewVariables/Editors/ViewVariablesPropertyEditorKeyValuePair.cs
@@ -1,6 +1,7 @@
-using Robust.Client.UserInterface;
+﻿using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.IoC;
+using Robust.Shared.ViewVariables;
 
 namespace Robust.Client.ViewVariables.Editors
 {
@@ -32,8 +33,8 @@ namespace Robust.Client.ViewVariables.Editors
             WireReference(propertyEditorK, valueK!);
             WireReference(propertyEditorV, valueV!);
 
-            var controlK = propertyEditorK.Initialize(valueK, true);
-            var controlV = propertyEditorV.Initialize(valueV, true);
+            var controlK = propertyEditorK.Initialize(valueK, true, NumericDisplay.None);
+            var controlV = propertyEditorV.Initialize(valueV, true, NumericDisplay.None);
 
             hBox.AddChild(controlK);
             hBox.AddChild(controlV);

--- a/Robust.Client/ViewVariables/Traits/ViewVariablesTraitEnumerable.cs
+++ b/Robust.Client/ViewVariables/Traits/ViewVariablesTraitEnumerable.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
@@ -161,7 +161,7 @@ namespace Robust.Client.ViewVariables.Traits
                     editor = Instance.ViewVariablesManager.PropertyFor(type);
                 }
 
-                var control = editor.Initialize(element, true);
+                var control = editor.Initialize(element, true, NumericDisplay.None);
                 if (editor is ViewVariablesPropertyEditorReference refEditor)
                 {
                     if (_networked)

--- a/Robust.Client/ViewVariables/ViewVariablesPropertyControl.cs
+++ b/Robust.Client/ViewVariables/ViewVariablesPropertyControl.cs
@@ -89,7 +89,7 @@ namespace Robust.Client.ViewVariables
                 editor = _viewVariablesManager.PropertyFor(type);
             }
 
-            var view = editor.Initialize(member.Value, !member.Editable);
+            var view = editor.Initialize(member.Value, !member.Editable, member.Display);
             if (view.SizeFlagsHorizontal != SizeFlags.FillExpand)
             {
                 NameLabel.SizeFlagsHorizontal = SizeFlags.FillExpand;

--- a/Robust.Client/ViewVariables/ViewVariablesPropertyEditor.cs
+++ b/Robust.Client/ViewVariables/ViewVariablesPropertyEditor.cs
@@ -1,7 +1,8 @@
-using System;
+﻿using System;
 using System.ComponentModel;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
+using Robust.Shared.ViewVariables;
 
 namespace Robust.Client.ViewVariables
 {
@@ -17,9 +18,12 @@ namespace Robust.Client.ViewVariables
 
         protected bool ReadOnly { get; private set; }
 
-        public Control Initialize(object? value, bool readOnly)
+        protected NumericDisplay DisplayOverride { get; private set; }
+
+        public Control Initialize(object? value, bool readOnly, NumericDisplay memberDisplay)
         {
             ReadOnly = readOnly;
+            DisplayOverride = memberDisplay;
             return MakeUI(value);
         }
 

--- a/Robust.Server/ViewVariables/Traits/ViewVariablesTraitMembers.cs
+++ b/Robust.Server/ViewVariables/Traits/ViewVariablesTraitMembers.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -42,6 +42,8 @@ namespace Robust.Server.ViewVariables.Traits
                     continue;
                 }
 
+                var display = property.GetCustomAttribute<ViewVariablesNumericAttribute>();
+
                 dataList.Add(new ViewVariablesBlobMembers.MemberData
                 {
                     Editable = attr.Access == VVAccess.ReadWrite,
@@ -49,7 +51,8 @@ namespace Robust.Server.ViewVariables.Traits
                     Type = property.PropertyType.AssemblyQualifiedName,
                     TypePretty = TypeAbbreviation.Abbreviate(property.PropertyType),
                     Value = property.GetValue(Session.Object),
-                    PropertyIndex = _members.Count
+                    PropertyIndex = _members.Count,
+                    Display = display?.DisplayMethod ?? NumericDisplay.None
                 });
                 _members.Add(property);
             }
@@ -62,6 +65,8 @@ namespace Robust.Server.ViewVariables.Traits
                     continue;
                 }
 
+                var display = field.GetCustomAttribute<ViewVariablesNumericAttribute>();
+
                 dataList.Add(new ViewVariablesBlobMembers.MemberData
                 {
                     Editable = attr.Access == VVAccess.ReadWrite,
@@ -69,7 +74,8 @@ namespace Robust.Server.ViewVariables.Traits
                     Type = field.FieldType.AssemblyQualifiedName,
                     TypePretty = TypeAbbreviation.Abbreviate(field.FieldType),
                     Value = field.GetValue(Session.Object),
-                    PropertyIndex = _members.Count
+                    PropertyIndex = _members.Count,
+                    Display = display?.DisplayMethod ?? NumericDisplay.None
                 });
                 _members.Add(field);
             }

--- a/Robust.Shared/ViewVariables/ViewVariablesBlob.cs
+++ b/Robust.Shared/ViewVariables/ViewVariablesBlob.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using Robust.Shared.Interfaces.GameObjects;
@@ -135,6 +135,11 @@ namespace Robust.Shared.ViewVariables
             ///     otherwise it's a meta token like <see cref="ServerValueTypeToken"/> or <see cref="ReferenceToken"/>.
             /// </summary>
             public object Value { get; set; }
+
+            /// <summary>
+            /// Display override for numeric types.
+            /// </summary>
+            public NumericDisplay Display { get; set; }
         }
     }
 

--- a/Robust.Shared/ViewVariables/ViewVariablesNumericAttribute.cs
+++ b/Robust.Shared/ViewVariables/ViewVariablesNumericAttribute.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace Robust.Shared.ViewVariables
+{
+    /// <summary>
+    /// Attribute to change how a numeric property is displayed to the user.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    internal class ViewVariablesNumericAttribute : Attribute
+    {
+        public readonly NumericDisplay DisplayMethod;
+
+        public ViewVariablesNumericAttribute(NumericDisplay displayMethod)
+        {
+            DisplayMethod = displayMethod;
+        }
+    }
+
+    public enum NumericDisplay
+    {
+        None,
+        Generic,
+        Hex,
+        Flags
+    }
+}


### PR DESCRIPTION
Adds the ability to mark numeric fields an properties with info about how to display the number in the UI (dec, hex, bin). These are the backend changes to make displaying an int as a set of bit flags possible.

![collision groups UI](https://user-images.githubusercontent.com/1685952/89108335-6e084600-d3ec-11ea-9331-42580e87c610.png)
