### PR TITLE
Made Point Light Radius Animatable

### DIFF
--- a/Robust.Client/GameObjects/Components/Light/PointLightComponent.cs
+++ b/Robust.Client/GameObjects/Components/Light/PointLightComponent.cs
@@ -116,6 +116,7 @@ namespace Robust.Client.GameObjects
         ///     Radius, in meters.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
+        [Animatable]
         public float Radius
         {
             get => _radius;


### PR DESCRIPTION
Add `Animatable` as a tag for `PointLightComponent.Radius` to allow for more fun lighting behaviors. 