### PR TITLE
Change BaseWindow and SS14Window to open where they previously closed

### DIFF
--- a/Robust.Client/UserInterface/CustomControls/BaseWindow.cs
+++ b/Robust.Client/UserInterface/CustomControls/BaseWindow.cs
@@ -14,6 +14,9 @@ namespace Robust.Client.UserInterface.CustomControls
         private DragMode CurrentDrag = DragMode.None;
         private Vector2 DragOffsetTopLeft;
         private Vector2 DragOffsetBottomRight;
+
+        protected bool _firstTimeOpened = true;
+
         public bool Resizable { get; set; } = true;
         public bool IsOpen => Parent != null;
 
@@ -210,15 +213,32 @@ namespace Robust.Client.UserInterface.CustomControls
 
         public void OpenCentered()
         {
-            LayoutContainer.SetSize(this, CombinedMinimumSize);
-            Open();
-            LayoutContainer.SetPosition(this, (Parent!.Size - Size) / 2);
+            if (_firstTimeOpened)
+            {
+                LayoutContainer.SetSize(this, CombinedMinimumSize);
+                Open();
+                LayoutContainer.SetPosition(this, (Parent!.Size - Size) / 2);
+                _firstTimeOpened = false;
+            }
+            else
+            {
+                Open();
+            }
         }
 
         public void OpenToLeft()
         {
-            Open();
-            LayoutContainer.SetPosition(this, (0, (Parent!.Size.Y - Size.Y) / 2));
+            if (_firstTimeOpened)
+            {
+                LayoutContainer.SetSize(this, CombinedMinimumSize);
+                Open();
+                LayoutContainer.SetPosition(this, (0, (Parent!.Size.Y - Size.Y) / 2));
+                _firstTimeOpened = false;
+            }
+            else
+            {
+                Open();
+            }
         }
 
         protected virtual void Opened()

--- a/Robust.Client/UserInterface/CustomControls/SS14Window.cs
+++ b/Robust.Client/UserInterface/CustomControls/SS14Window.cs
@@ -77,11 +77,6 @@ namespace Robust.Client.UserInterface.CustomControls
             });
 
             CloseButton.OnPressed += CloseButtonPressed;
-
-            if (CustomSize != null)
-            {
-                LayoutContainer.SetSize(this, CustomSize.Value);
-            }
         }
 
         public MarginContainer Contents { get; private set; }
@@ -96,6 +91,16 @@ namespace Robust.Client.UserInterface.CustomControls
         protected override Vector2 CalculateMinimumSize()
         {
             return Vector2.ComponentMax(ContentsMinimumSize, base.CalculateMinimumSize());
+        }
+
+        protected override void Opened()
+        {
+            base.Opened();
+
+            if (_firstTimeOpened && CustomSize != null)
+            {
+                LayoutContainer.SetSize(this, CustomSize.Value);
+            }
         }
 
         private Label TitleLabel;


### PR DESCRIPTION
First open will be top left, centered, or left vertically centered. The subsequent calls to open will open the window at the position the window was closed at.

Fixes SS14Window not following CustomSize.