### PR TITLE
Bug/placement not blocking mouseclicks

### DIFF
--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -113,6 +113,15 @@ namespace Robust.Client.Input
         }
 
         /// <inheritdoc />
+        public void ToggleBindingsForKey(Key key, bool enabled)
+        {
+            foreach (var binding in GetKeyBindingsForKey(key))
+            {
+                binding.Enabled = enabled;
+            }
+        }
+
+        /// <inheritdoc />
         public void KeyDown(KeyEventArgs args)
         {
             if (!Enabled || args.Key == Key.Unknown)
@@ -239,6 +248,11 @@ namespace Robust.Client.Input
 
         private bool SetBindState(KeyBinding binding, BoundKeyState state, bool uiOnly=false)
         {
+            if (!binding.Enabled)
+            {
+                return false;
+            }
+
             binding.State = state;
 
             var eventArgs = new BoundKeyEventArgs(binding.Function, binding.State,
@@ -398,6 +412,13 @@ namespace Robust.Client.Input
             _bindings.Insert(pos, binding);
         }
 
+        private List<KeyBinding> GetKeyBindingsForKey(Key key)
+        {
+            return _bindings
+            .Where(x => x.PackedKeyCombo.BaseKey == key)
+            .ToList();
+        }
+
         /// <inheritdoc />
         public IKeyBinding GetKeyBinding(BoundKeyFunction function)
         {
@@ -462,18 +483,21 @@ namespace Robust.Client.Input
 
             public int Priority { get; internal set; }
 
+            public bool Enabled { get; set; }
+
             public KeyBinding(InputManager inputManager, BoundKeyFunction function,
                 KeyBindingType bindingType,
                 Key baseKey,
                 bool canFocus, bool canRepeat, int priority, Key mod1 = Key.Unknown,
                 Key mod2 = Key.Unknown,
-                Key mod3 = Key.Unknown)
+                Key mod3 = Key.Unknown, bool enabled = true)
             {
                 Function = function;
                 BindingType = bindingType;
                 CanFocus = canFocus;
                 CanRepeat = canRepeat;
                 Priority = priority;
+                Enabled = enabled;
                 _inputManager = inputManager;
 
                 PackedKeyCombo = new PackedKeyCombo(baseKey, mod1, mod2, mod3);

--- a/Robust.Client/Interfaces/Input/IInputManager.cs
+++ b/Robust.Client/Interfaces/Input/IInputManager.cs
@@ -28,6 +28,14 @@ namespace Robust.Client.Interfaces.Input
         void KeyUp(KeyEventArgs e);
 
         /// <summary>
+        /// Enables or disables every key binding that is bound to the given key
+        /// Does not respect modifier keys
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="enabled">Whether the bindings get disabled or enabled</param>
+        public void ToggleBindingsForKey(Keyboard.Key key, bool enabled);
+
+        /// <summary>
         /// Registers a new key binding in the input manager.
         /// </summary>
         /// <param name="function">The function the key binding is bound to.</param>

--- a/Robust.Client/Interfaces/Input/IKeyBinding.cs
+++ b/Robust.Client/Interfaces/Input/IKeyBinding.cs
@@ -9,6 +9,8 @@ namespace Robust.Client.Interfaces.Input
         BoundKeyFunction Function { get; }
         KeyBindingType BindingType { get; }
 
+        public bool Enabled { get; set; }
+
         /// <summary>
         ///     Gets a user-presentable, localized & keyboard-adjusted string for which buttons the user has to press.
         /// </summary>

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -320,6 +320,7 @@ namespace Robust.Client.Placement
             IsActive = false;
             Eraser = false;
             PlacementOffset = Vector2i.Zero;
+            _inputManager.ToggleBindingsForKey(Input.Keyboard.Key.MouseLeft, true);
         }
 
         public void Rotate()
@@ -398,6 +399,7 @@ namespace Robust.Client.Placement
             {
                 IsActive = true;
                 Eraser = true;
+                PreventMouseInput();
             }
             else Clear();
         }
@@ -409,6 +411,7 @@ namespace Robust.Client.Placement
                 IsActive = true;
                 Eraser = true;
                 Hijack = hijack;
+                PreventMouseInput();
             }
             else Clear();
         }
@@ -432,6 +435,8 @@ namespace Robust.Client.Placement
 
             var modeType = _modeDictionary.First(pair => pair.Key.Equals(CurrentPermission.PlacementOption)).Value;
             CurrentMode = (PlacementMode) Activator.CreateInstance(modeType, this)!;
+
+            PreventMouseInput();
 
             if (hijack != null)
             {
@@ -516,6 +521,15 @@ namespace Robust.Client.Placement
 
             PlacementType = PlacementTypes.None;
             return true;
+        }
+
+        /// <summary>
+        /// Prevents mouse input other than placing
+        /// </summary>
+        private void PreventMouseInput()
+        {
+            _inputManager.ToggleBindingsForKey(Input.Keyboard.Key.MouseLeft, false);
+            _inputManager.GetKeyBinding(EngineKeyFunctions.EditorPlaceObject).Enabled = true;
         }
 
         private void Render(DrawingHandleWorld handle)


### PR DESCRIPTION
fixes space-wizards/space-station-14#1562
fixes space-wizards/space-station-14#1369

Solved the problem by blocking all key bindings for `MouseLeft` except for `EngineKeyFunctions.EditorPlaceObject` when placing or erasing

