### PR TITLE
Reliable Coordinates

### DIFF
--- a/Robust.Shared.Maths/FloatHelpers.cs
+++ b/Robust.Shared.Maths/FloatHelpers.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Robust.Shared.Maths
+{
+    /// <summary>
+    /// Helper functions for floating point math.
+    /// </summary>
+    public static class FloatHelpers
+    {
+        /// <summary>
+        /// Determines whether the specified value is finite (zero, subnormal, or normal).
+        /// </summary>
+        /// <param name="val">A single precision floating-point number.</param>
+        /// <returns><see langword ="true" /> if the value is finite, <see langword ="false" /> otherwise.</returns>
+        public static bool IsFinite(this float val)
+        {
+            return float.IsFinite(val);
+        }
+    }
+}

--- a/Robust.Shared.Maths/Vector2.cs
+++ b/Robust.Shared.Maths/Vector2.cs
@@ -94,6 +94,15 @@ namespace Robust.Shared.Maths
         }
 
         /// <summary>
+        /// Determines whether the length of the vector is finite (zero, subnormal, or normal).
+        /// </summary>
+        /// <returns><see langword ="true" /> if the vector is finite, <see langword ="false" /> otherwise.</returns>
+        public bool IsFinite()
+        {
+            return float.IsFinite(X) && float.IsFinite(Y);
+        }
+
+        /// <summary>
         ///     Subtracts a vector from another, returning a new vector.
         /// </summary>
         /// <param name="a">Vector to subtract from.</param>

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -281,12 +281,14 @@ namespace Robust.Shared.GameObjects.Components.Transform
             }
         }
 
+        /// <inheritdoc />
         [ViewVariables(VVAccess.ReadWrite)]
-        public MapCoordinates MapPosition
-        {
-            get => new MapCoordinates(WorldPosition, MapID);
-        }
+        public MapCoordinates MapPosition => new MapCoordinates(WorldPosition, MapID);
 
+        /// <inheritdoc />
+        public ReliableCoordinates ReliablePosition => new ReliableCoordinates(_mapManager, MapPosition);
+
+        /// <inheritdoc />
         [ViewVariables(VVAccess.ReadWrite)]
         [Animatable]
         public Vector2 LocalPosition

--- a/Robust.Shared/Interfaces/GameObjects/Components/ITransformComponent.cs
+++ b/Robust.Shared/Interfaces/GameObjects/Components/ITransformComponent.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using JetBrains.Annotations;
 using Robust.Shared.Animations;
-using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
@@ -26,6 +24,12 @@ namespace Robust.Shared.Interfaces.GameObjects.Components
         ///     Position offset of this entity relative to the grid it's on.
         /// </summary>
         GridCoordinates GridPosition { get; set; }
+
+        /// <summary>
+        ///     Current reliable position of the entity. If the entity is on a grid,
+        ///     <see cref="GridCoordinates"/> will be available.
+        /// </summary>
+        ReliableCoordinates ReliablePosition { get; }
 
         /// <summary>
         ///     Current position offset of the entity relative to the world.


### PR DESCRIPTION
A new ReliableCoordinates struct that tries as hard as it can to resolve it's location. It provides sanity checks on it's fields when resolving the map or grid position, so no more NaN/infinity propagation, and verifies the grid/map actually exists. This is really useful for sending over the network, because locations that cannot be resolved on the server when a grid is deleted are gracefully dropped. TransformComponent has a property to generate ReliableCoordinates for an entity.

As part of the sanitization, this adds an IsFinite() float helper, and an IsFinite() function on Vector2. Of course we don't check these on incoming network messages, so hopefully these new functions will be useful in the future.