### PR TITLE
Fix input handling and stop input when a cmd returns true

### DIFF
--- a/Robust.Shared/Input/Binding/InputCmdHandler.cs
+++ b/Robust.Shared/Input/Binding/InputCmdHandler.cs
@@ -157,11 +157,9 @@ namespace Robust.Shared.Input.Binding
             switch (msg.State)
             {
                 case BoundKeyState.Up:
-                    _disabled?.Invoke(session, msg.Coordinates, msg.Uid);
-                    return true;
+                    return _disabled?.Invoke(session, msg.Coordinates, msg.Uid) == true;
                 case BoundKeyState.Down:
-                    _enabled?.Invoke(session, msg.Coordinates, msg.Uid);
-                    return true;
+                    return _enabled?.Invoke(session, msg.Coordinates, msg.Uid) == true;
             }
 
             //Client Sanitization: unknown key state, just ignore


### PR DESCRIPTION
This sets up the data needed for GameScreen in Content to tell InputManager that the input was handled. This prevents the next hotkey with the same combination from being triggered.