### PR TITLE
Add nullable API methods for getting components and user interfaces

### DIFF
--- a/Robust.Server/GameObjects/Components/UserInterface/ServerUserInterfaceComponent.cs
+++ b/Robust.Server/GameObjects/Components/UserInterface/ServerUserInterfaceComponent.cs
@@ -59,7 +59,7 @@ namespace Robust.Server.GameObjects.Components.UserInterface
             return _interfaces.TryGetValue(uiKey, out boundUserInterface);
         }
 
-        public BoundUserInterface? TryGetBoundUserInterface(object uiKey)
+        public BoundUserInterface? GetBoundUserInterfaceOrNull(object uiKey)
         {
             return TryGetBoundUserInterface(uiKey, out var boundUserInterface)
                 ? boundUserInterface

--- a/Robust.Server/GameObjects/Components/UserInterface/ServerUserInterfaceComponent.cs
+++ b/Robust.Server/GameObjects/Components/UserInterface/ServerUserInterfaceComponent.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using JetBrains.Annotations;
 using Robust.Server.GameObjects.EntitySystems;
 using Robust.Server.Interfaces.Player;
 using Robust.Server.Player;
@@ -9,13 +10,10 @@ using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameObjects.Components.UserInterface;
 using Robust.Shared.GameObjects.Systems;
-using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
-using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Players;
 using Robust.Shared.Serialization;
-using Robust.Shared.Utility;
 
 namespace Robust.Server.GameObjects.Components.UserInterface
 {
@@ -24,6 +22,7 @@ namespace Robust.Server.GameObjects.Components.UserInterface
     ///     Bound user interfaces are indexed with an enum or string key identifier.
     /// </summary>
     /// <seealso cref="BoundUserInterface"/>
+    [PublicAPI]
     public sealed class ServerUserInterfaceComponent : SharedUserInterfaceComponent
     {
         private readonly Dictionary<object, BoundUserInterface> _interfaces =
@@ -58,6 +57,13 @@ namespace Robust.Server.GameObjects.Components.UserInterface
         public bool TryGetBoundUserInterface(object uiKey, [NotNullWhen(true)] out BoundUserInterface? boundUserInterface)
         {
             return _interfaces.TryGetValue(uiKey, out boundUserInterface);
+        }
+
+        public BoundUserInterface? TryGetBoundUserInterface(object uiKey)
+        {
+            return TryGetBoundUserInterface(uiKey, out var boundUserInterface)
+                ? boundUserInterface
+                : null;
         }
 
         public bool HasBoundUserInterface(object uiKey)
@@ -99,6 +105,7 @@ namespace Robust.Server.GameObjects.Components.UserInterface
     /// <summary>
     ///     Represents an entity-bound interface that can be opened by multiple players at once.
     /// </summary>
+    [PublicAPI]
     public sealed class BoundUserInterface
     {
         private bool _isActive;
@@ -355,6 +362,7 @@ namespace Robust.Server.GameObjects.Components.UserInterface
         }
     }
 
+    [PublicAPI]
     public class ServerBoundUserInterfaceMessage
     {
         public BoundUserInterfaceMessage Message { get; }

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using JetBrains.Annotations;
 using Robust.Shared.GameObjects.Components;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
@@ -293,6 +294,11 @@ namespace Robust.Shared.GameObjects
             return EntityManager.ComponentManager.TryGetComponent(Uid, out component);
         }
 
+        public T TryGetComponent<T>() where T : IComponent
+        {
+            return TryGetComponent(out T component) ? component : default!;
+        }
+
         /// <inheritdoc />
         public bool TryGetComponent(Type type, [NotNullWhen(true)] out IComponent? component)
         {
@@ -301,12 +307,22 @@ namespace Robust.Shared.GameObjects
             return EntityManager.ComponentManager.TryGetComponent(Uid, type, out component);
         }
 
+        public IComponent? TryGetComponent(Type type)
+        {
+            return TryGetComponent(type, out var component) ? component : null;
+        }
+
         /// <inheritdoc />
         public bool TryGetComponent(uint netId, [NotNullWhen(true)] out IComponent? component)
         {
             DebugTools.Assert(!Deleted, "Tried to get component on a deleted entity.");
 
             return EntityManager.ComponentManager.TryGetComponent(Uid, netId, out component);
+        }
+
+        public IComponent? TryGetComponent(uint netId)
+        {
+            return TryGetComponent(netId, out var component) ? component : null;
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -294,9 +294,10 @@ namespace Robust.Shared.GameObjects
             return EntityManager.ComponentManager.TryGetComponent(Uid, out component);
         }
 
-        public T TryGetComponent<T>() where T : IComponent
+        [return: MaybeNull]
+        public T GetComponentOrNull<T>() where T : IComponent
         {
-            return TryGetComponent(out T component) ? component : default!;
+            return TryGetComponent(out T component) ? component : default;
         }
 
         /// <inheritdoc />
@@ -307,7 +308,7 @@ namespace Robust.Shared.GameObjects
             return EntityManager.ComponentManager.TryGetComponent(Uid, type, out component);
         }
 
-        public IComponent? TryGetComponent(Type type)
+        public IComponent? GetComponentOrNull(Type type)
         {
             return TryGetComponent(type, out var component) ? component : null;
         }
@@ -320,7 +321,7 @@ namespace Robust.Shared.GameObjects
             return EntityManager.ComponentManager.TryGetComponent(Uid, netId, out component);
         }
 
-        public IComponent? TryGetComponent(uint netId)
+        public IComponent? GetComponentOrNull(uint netId)
         {
             return TryGetComponent(netId, out var component) ? component : null;
         }

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -294,10 +294,9 @@ namespace Robust.Shared.GameObjects
             return EntityManager.ComponentManager.TryGetComponent(Uid, out component);
         }
 
-        [return: MaybeNull]
-        public T GetComponentOrNull<T>() where T : IComponent
+        public T? GetComponentOrNull<T>() where T : class
         {
-            return TryGetComponent(out T component) ? component : default;
+            return TryGetComponent(out T? component) ? component : default;
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/Interfaces/GameObjects/IEntity.cs
+++ b/Robust.Shared/Interfaces/GameObjects/IEntity.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects.Components;
 using Robust.Shared.Interfaces.Network;
@@ -94,7 +95,7 @@ namespace Robust.Shared.Interfaces.GameObjects
         /// <summary>
         ///     Checks to see ift he entity has a component of the specified type.
         /// </summary>
-        /// <param name="t">The component reference type to check.</param>
+        /// <param name="type">The component reference type to check.</param>
         /// <returns></returns>
         bool HasComponent(Type type);
 
@@ -140,6 +141,15 @@ namespace Robust.Shared.Interfaces.GameObjects
 
         /// <summary>
         ///     Attempt to retrieve the component with specified type,
+        ///     returning it if it was found.
+        /// </summary>
+        /// <typeparam name="T">The component reference type to attempt to fetch.</typeparam>
+        /// <returns>The component, if it was found. Null otherwise.</returns>
+        [CanBeNull]
+        T TryGetComponent<T>() where T : IComponent;
+
+        /// <summary>
+        ///     Attempt to retrieve the component with specified type,
         ///     writing it to the <paramref name="component" /> out parameter if it was found.
         /// </summary>
         /// <param name="type">The component reference type to attempt to fetch.</param>
@@ -148,13 +158,29 @@ namespace Robust.Shared.Interfaces.GameObjects
         bool TryGetComponent(Type type, [NotNullWhen(true)] out IComponent? component);
 
         /// <summary>
+        ///     Attempt to retrieve the component with specified type,
+        ///     returning it if it was found.
+        /// </summary>
+        /// <param name="type">The component reference type to attempt to fetch.</param>
+        /// <returns>The component, if it was found. Null otherwise.</returns>
+        IComponent? TryGetComponent(Type type);
+
+        /// <summary>
         ///     Attempt to retrieve the component with specified network ID,
         ///     writing it to the <paramref name="component" /> out parameter if it was found.
         /// </summary>
-        /// <param name="type">The component net ID to attempt to fetch.</param>
+        /// <param name="netId">The component net ID to attempt to fetch.</param>
         /// <param name="component">The component, if it was found. Null otherwise.</param>
         /// <returns>True if a component with specified net ID was found.</returns>
-        bool TryGetComponent(uint netID, [NotNullWhen(true)] out IComponent? component);
+        bool TryGetComponent(uint netId, [NotNullWhen(true)] out IComponent? component);
+
+        /// <summary>
+        ///     Attempt to retrieve the component with specified network ID,
+        ///     returning it if it was found.
+        /// </summary>
+        /// <param name="netId">The component net ID to attempt to fetch.</param>
+        /// <returns>The component, if it was found. Null otherwise.</returns>
+        IComponent? TryGetComponent(uint netId);
 
         /// <summary>
         ///     Used by the entity manager to delete the entity.

--- a/Robust.Shared/Interfaces/GameObjects/IEntity.cs
+++ b/Robust.Shared/Interfaces/GameObjects/IEntity.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects.Components;
 using Robust.Shared.Interfaces.Network;
@@ -145,8 +144,8 @@ namespace Robust.Shared.Interfaces.GameObjects
         /// </summary>
         /// <typeparam name="T">The component reference type to attempt to fetch.</typeparam>
         /// <returns>The component, if it was found. Null otherwise.</returns>
-        [CanBeNull]
-        T TryGetComponent<T>() where T : IComponent;
+        [return: MaybeNull]
+        T GetComponentOrNull<T>() where T : IComponent;
 
         /// <summary>
         ///     Attempt to retrieve the component with specified type,
@@ -163,7 +162,7 @@ namespace Robust.Shared.Interfaces.GameObjects
         /// </summary>
         /// <param name="type">The component reference type to attempt to fetch.</param>
         /// <returns>The component, if it was found. Null otherwise.</returns>
-        IComponent? TryGetComponent(Type type);
+        IComponent? GetComponentOrNull(Type type);
 
         /// <summary>
         ///     Attempt to retrieve the component with specified network ID,
@@ -180,7 +179,7 @@ namespace Robust.Shared.Interfaces.GameObjects
         /// </summary>
         /// <param name="netId">The component net ID to attempt to fetch.</param>
         /// <returns>The component, if it was found. Null otherwise.</returns>
-        IComponent? TryGetComponent(uint netId);
+        IComponent? GetComponentOrNull(uint netId);
 
         /// <summary>
         ///     Used by the entity manager to delete the entity.

--- a/Robust.Shared/Interfaces/GameObjects/IEntity.cs
+++ b/Robust.Shared/Interfaces/GameObjects/IEntity.cs
@@ -144,8 +144,7 @@ namespace Robust.Shared.Interfaces.GameObjects
         /// </summary>
         /// <typeparam name="T">The component reference type to attempt to fetch.</typeparam>
         /// <returns>The component, if it was found. Null otherwise.</returns>
-        [return: MaybeNull]
-        T GetComponentOrNull<T>() where T : IComponent;
+        T? GetComponentOrNull<T>() where T : class;
 
         /// <summary>
         ///     Attempt to retrieve the component with specified type,

--- a/RobustToolbox.sln.DotSettings
+++ b/RobustToolbox.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=BYOND/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=olde/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Needed for a future pr that tests adding all components to an entity.

Because writing this is getting a bit old:
```cs
private BoundUserInterface? UserInterface =>
            Owner.TryGetComponent(out ServerUserInterfaceComponent ui) &&
            ui.TryGetBoundUserInterface(MagicMirrorUiKey.Key, out var boundUi)
                ? boundUi
                : null;
```

Instead of:
```cs
private BoundUserInterface? UserInterface => Owner.TryGetComponent<ServerUserInterfaceComponent>()?.TryGetBoundUserInterface(MagicMirrorUiKey.Key);
```

Would definitely help with the transition from components assuming that other components exist.