### PR TITLE
Add PlayerSession exclude for audiosystem

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/AudioSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/AudioSystem.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using JetBrains.Annotations;
 using Robust.Server.Interfaces.Player;
 using Robust.Shared.Audio;
 using Robust.Shared.GameObjects;
@@ -64,7 +63,8 @@ namespace Robust.Server.GameObjects.EntitySystems
         /// <param name="filename">The resource path to the OGG Vorbis file to play.</param>
         /// <param name="audioParams"></param>
         /// <param name="predicate">The predicate that will be used to send the audio to players, or null to send to everyone.</param>
-        public AudioSourceServer PlayGlobal(string filename, AudioParams? audioParams = null, Func<IPlayerSession, bool>? predicate = null)
+        /// <param name="excludedSession">Session that won't receive the audio message.</param>
+        public AudioSourceServer PlayGlobal(string filename, AudioParams? audioParams = null, Func<IPlayerSession, bool>? predicate = null, IPlayerSession? excludedSession = null)
         {
             var id = CacheIdentifier();
             var msg = new PlayAudioGlobalMessage
@@ -74,16 +74,23 @@ namespace Robust.Server.GameObjects.EntitySystems
                 Identifier = id
             };
 
-            if (predicate == null)
+            if (predicate == null && excludedSession == null)
             {
                 RaiseNetworkEvent(msg);
                 return new AudioSourceServer(this, id);
             }
 
-            var players = _playerManager.GetPlayersBy(predicate);
+            var players = predicate != null ? _playerManager.GetPlayersBy(predicate) : _playerManager.GetAllPlayers();
 
-            foreach(var player in players)
+            for (var i = players.Count - 1; i >= 0; i--)
             {
+                var player = players[i];
+                if (player == excludedSession)
+                {
+                    players.RemoveAt(i);
+                    continue;
+                }
+                   
                 RaiseNetworkEvent(msg, player.ConnectedClient);
             }
 
@@ -98,7 +105,8 @@ namespace Robust.Server.GameObjects.EntitySystems
         /// <param name="entity">The entity "emitting" the audio.</param>
         /// <param name="audioParams"></param>
         /// <param name="range">The max range at which the audio will be heard. Less than or equal to 0 to send to every player.</param>
-        public AudioSourceServer PlayFromEntity(string filename, IEntity entity, AudioParams? audioParams = null, int range = AudioDistanceRange)
+        /// <param name="excludedSession">Sessions that won't receive the audio message.</param>
+        public AudioSourceServer PlayFromEntity(string filename, IEntity entity, AudioParams? audioParams = null, int range = AudioDistanceRange, IPlayerSession? excludedSession = null)
         {
             var id = CacheIdentifier();
 
@@ -111,16 +119,23 @@ namespace Robust.Server.GameObjects.EntitySystems
                 Identifier = id,
             };
 
-            if (range <= 0)
+            if (range <= 0 && excludedSession == null)
             {
                 RaiseNetworkEvent(msg);
                 return new AudioSourceServer(this, id);
             }
 
-            var players = _playerManager.GetPlayersInRange(entity.Transform.GridPosition, range);
+            var players = range > 0.0f ? _playerManager.GetPlayersInRange(entity.Transform.GridPosition, range) : _playerManager.GetAllPlayers();
 
-            foreach(var player in players)
+            for (var i = players.Count - 1; i >= 0; i--)
             {
+                var player = players[i];
+                if (player == excludedSession)
+                {
+                    players.RemoveAt(i);
+                    continue;
+                }
+                   
                 RaiseNetworkEvent(msg, player.ConnectedClient);
             }
 
@@ -134,7 +149,8 @@ namespace Robust.Server.GameObjects.EntitySystems
         /// <param name="coordinates">The coordinates at which to play the audio.</param>
         /// <param name="audioParams"></param>
         /// <param name="range">The max range at which the audio will be heard. Less than or equal to 0 to send to every player.</param>
-        public AudioSourceServer PlayAtCoords(string filename, GridCoordinates coordinates, AudioParams? audioParams = null, int range = AudioDistanceRange)
+        /// <param name="excludedSession">Session that won't receive the audio message.</param>
+        public AudioSourceServer PlayAtCoords(string filename, GridCoordinates coordinates, AudioParams? audioParams = null, int range = AudioDistanceRange, IPlayerSession? excludedSession = null)
         {
             var id = CacheIdentifier();
             var msg = new PlayAudioPositionalMessage
@@ -145,16 +161,23 @@ namespace Robust.Server.GameObjects.EntitySystems
                 Identifier = id
             };
 
-            if (range <= 0)
+            if (range <= 0 && excludedSession == null)
             {
                 RaiseNetworkEvent(msg);
                 return new AudioSourceServer(this, id);
             }
 
-            var players = _playerManager.GetPlayersInRange(coordinates, range);
+            var players = range > 0.0f ? _playerManager.GetPlayersInRange(coordinates, range) : _playerManager.GetAllPlayers();
 
-            foreach(var player in players)
+            for (var i = players.Count - 1; i >= 0; i--)
             {
+                var player = players[i];
+                if (player == excludedSession)
+                {
+                    players.RemoveAt(i);
+                    continue;
+                }
+                   
                 RaiseNetworkEvent(msg, player.ConnectedClient);
             }
 


### PR DESCRIPTION
Allows audio to be predicted client-side and excluded from the server sending out the message to them.
The exclusion part is up to the individual systems to implement.

I wasn't 100% on whether changes should be made to the player manager to faciliate this.