### PR TITLE
IsIntersecting method for EntityManager

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -407,20 +407,9 @@ namespace Robust.Shared.GameObjects
 
             foreach (var entity in newResults)
             {
-                if (entity.TryGetComponent(out ICollidableComponent? component))
+                if (Intersecting(entity, position))
                 {
-                    if (component.WorldAABB.Contains(position))
-                        yield return entity;
-                }
-                else
-                {
-                    var transform = entity.Transform;
-                    var entPos = transform.WorldPosition;
-                    if (MathHelper.CloseTo(entPos.X, position.X)
-                        && MathHelper.CloseTo(entPos.Y, position.Y))
-                    {
-                        yield return entity;
-                    }
+                    yield return entity;
                 }
             }
         }
@@ -447,6 +436,34 @@ namespace Robust.Shared.GameObjects
             }
 
             return GetEntitiesIntersecting(entity.Transform.GridPosition, approximate);
+        }
+
+        /// <inheritdoc />
+        public bool IsIntersecting(IEntity entityOne, IEntity entityTwo)
+        {
+            var position = entityOne.Transform.MapPosition.Position;
+            return Intersecting(entityTwo, position);
+        }
+
+        private bool Intersecting(IEntity entity, Vector2 mapPosition)
+        {
+            if (entity.TryGetComponent(out ICollidableComponent? component))
+            {
+                if (component.WorldAABB.Contains(mapPosition))
+                    return true;
+            }
+            else
+            {
+                var transform = entity.Transform;
+                var entPos = transform.WorldPosition;
+                if (MathHelper.CloseTo(entPos.X, mapPosition.X)
+                    && MathHelper.CloseTo(entPos.Y, mapPosition.Y))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/Interfaces/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/Interfaces/GameObjects/IEntityManager.cs
@@ -179,6 +179,14 @@ namespace Robust.Shared.Interfaces.GameObjects
         IEnumerable<IEntity> GetEntitiesInRange(IEntity entity, float range, bool approximate = false);
 
         /// <summary>
+        /// Gets whether two entities are intersecting each other
+        /// </summary>
+        /// <param name="entityOne"></param>
+        /// <param name="entityTwo"></param>
+        /// <returns></returns>
+        public bool IsIntersecting(IEntity entityOne, IEntity entityTwo);
+        
+        /// <summary>
         /// Gets entities within a certain *square* range of this bounding box
         /// </summary>
         /// <param name="mapID"></param>


### PR DESCRIPTION
Will be useful to optimise some content-side systems that are calling GetEntitiesIntersecting when they don't need to.