### PR TITLE
Deterministic RobustMappedStringSerializer

### DIFF
--- a/Robust.Server/BaseServer.cs
+++ b/Robust.Server/BaseServer.cs
@@ -285,7 +285,7 @@ namespace Robust.Server
             //IoCManager.Resolve<IMapLoader>().LoadedMapData +=
             //    IoCManager.Resolve<IRobustMappedStringSerializer>().AddStrings;
             IoCManager.Resolve<IPrototypeManager>().LoadedData +=
-                IoCManager.Resolve<IRobustMappedStringSerializer>().AddStrings;
+                (yaml, name) => _stringSerializer.AddStrings(yaml);
 
             // Initialize Tier 2 services
             IoCManager.Resolve<IGameTiming>().InSimulation = true;

--- a/Robust.Server/BaseServer.cs
+++ b/Robust.Server/BaseServer.cs
@@ -80,6 +80,7 @@ namespace Robust.Server
         [Dependency] private readonly IWatchdogApi _watchdogApi = default!;
         [Dependency] private readonly IScriptHost _scriptHost = default!;
         [Dependency] private readonly IMetricsManager _metricsManager = default!;
+        [Dependency] private readonly IRobustMappedStringSerializer _stringSerializer = default!;
 
         private readonly Stopwatch _uptimeStopwatch = new Stopwatch();
 
@@ -320,6 +321,8 @@ namespace Robust.Server
             AppDomain.CurrentDomain.ProcessExit += ProcessExiting;
 
             _watchdogApi.Initialize();
+
+            _stringSerializer.LockStrings();
 
             return false;
         }

--- a/Robust.Shared/Interfaces/Serialization/IRobustMappedStringSerializer.cs
+++ b/Robust.Shared/Interfaces/Serialization/IRobustMappedStringSerializer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using NetSerializer;
 using Newtonsoft.Json.Linq;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.Network.Messages;
@@ -13,6 +14,11 @@ namespace Robust.Shared.Serialization
     [PublicAPI]
     internal interface IRobustMappedStringSerializer
     {
+        /// <summary>
+        ///     The type serializer to register with NetSerializer.
+        /// </summary>
+        ITypeSerializer TypeSerializer { get; }
+
         /// <summary>
         /// Starts the handshake from the server end of the given channel,
         /// sending a <see cref="MsgMapStrServerHandshake"/>.
@@ -94,5 +100,7 @@ namespace Robust.Shared.Serialization
         ///     and generate the strings package that can be sent to clients.
         /// </summary>
         void LockStrings();
+
+        void Initialize();
     }
 }

--- a/Robust.Shared/Interfaces/Serialization/IRobustMappedStringSerializer.cs
+++ b/Robust.Shared/Interfaces/Serialization/IRobustMappedStringSerializer.cs
@@ -67,8 +67,7 @@ namespace Robust.Shared.Serialization
         /// Strings are taken from YAML anchors, tags, and leaf nodes.
         /// </remarks>
         /// <param name="yaml">The YAML to collect strings from.</param>
-        /// <param name="name">The stream name. Only used for logging.</param>
-        void AddStrings(YamlStream yaml, string name);
+        void AddStrings(YamlStream yaml);
 
         /// <summary>
         /// Add strings from the given <see cref="JObject"/> to the mapping.
@@ -77,15 +76,13 @@ namespace Robust.Shared.Serialization
         /// Strings are taken from JSON property names and string nodes.
         /// </remarks>
         /// <param name="obj">The JSON to collect strings from.</param>
-        /// <param name="name">The stream name. Only used for logging.</param>
-        void AddStrings(JObject obj, string name);
+        void AddStrings(JObject obj);
 
         /// <summary>
         /// Add strings from the given enumeration to the mapping.
         /// </summary>
         /// <param name="strings">The strings to add.</param>
-        /// <param name="providerName">The source provider of the strings to be logged.</param>
-        void AddStrings(IEnumerable<string> strings, string providerName);
+        void AddStrings(IEnumerable<string> strings);
 
         /// <summary>
         /// See <see cref="RobustMappedStringSerializer.OnClientCompleteHandshake"/>.

--- a/Robust.Shared/Interfaces/Serialization/IRobustMappedStringSerializer.cs
+++ b/Robust.Shared/Interfaces/Serialization/IRobustMappedStringSerializer.cs
@@ -1,114 +1,30 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using NetSerializer;
 using Newtonsoft.Json.Linq;
 using Robust.Shared.Interfaces.Network;
+using Robust.Shared.Network.Messages;
 using YamlDotNet.RepresentationModel;
 
 namespace Robust.Shared.Serialization
 {
-
     [PublicAPI]
-    public interface IRobustMappedStringSerializer
+    internal interface IRobustMappedStringSerializer
     {
-
         /// <summary>
         /// Starts the handshake from the server end of the given channel,
-        /// sending a <see cref="MsgRobustMappedStringsSerializerServerHandshake"/>.
+        /// sending a <see cref="MsgMapStrServerHandshake"/>.
         /// </summary>
         /// <param name="channel">The network channel to perform the handshake over.</param>
         /// <remarks>
         /// Locks the string mapping if this is the first time the server is
         /// performing the handshake.
         /// </remarks>
-        /// <seealso cref="MsgRobustMappedStringsSerializerClientHandshake"/>
-        /// <seealso cref="MsgRobustMappedStringsSerializerStrings"/>
+        /// <seealso cref="MsgMapStrClientHandshake"/>
+        /// <seealso cref="MsgMapStrStrings"/>
         Task Handshake(INetChannel channel);
-
-        /// <summary>
-        /// Performs the setup so that the serializer can perform the string-
-        /// exchange protocol.
-        /// </summary>
-        /// <remarks>
-        /// The string-exchange protocol is started by the server when the
-        /// client first connects. The server sends the client a hash of the
-        /// string mapping; the client checks that hash against any local
-        /// caches; and if necessary, the client requests a new copy of the
-        /// mapping from the server.
-        ///
-        /// Uncached flow: <code>
-        /// Client      |      Server
-        /// | &lt;-------------- Hash |
-        /// | Need Strings ------&gt; |
-        /// | &lt;----------- Strings |
-        /// | Dont Need Strings -&gt; |
-        /// </code>
-        ///
-        /// Cached flow: <code>
-        /// Client      |      Server
-        /// | &lt;-------------- Hash |
-        /// | Dont Need Strings -&gt; |
-        /// </code>
-        ///
-        /// Verification failure flow: <code>
-        /// Client      |      Server
-        /// | &lt;-------------- Hash |
-        /// | Need Strings ------&gt; |
-        /// | &lt;----------- Strings |
-        /// + Hash Failed          |
-        /// | Need Strings ------&gt; |
-        /// | &lt;----------- Strings |
-        /// | Dont Need Strings -&gt; |
-        ///  </code>
-        ///
-        /// NOTE: Verification failure flow is currently not implemented.
-        /// </remarks>
-        /// <param name="net">
-        /// The <see cref="INetManager"/> to perform the protocol steps over.
-        /// </param>
-        /// <seealso cref="MsgRobustMappedStringsSerializerServerHandshake"/>
-        /// <seealso cref="MsgRobustMappedStringsSerializerClientHandshake"/>
-        /// <seealso cref="MsgRobustMappedStringsSerializerStrings"/>
-        /// <seealso cref="RobustMappedStringSerializer.HandleServerHandshake"/>
-        /// <seealso cref="RobustMappedStringSerializer.HandleClientHandshake"/>
-        /// <seealso cref="RobustMappedStringSerializer.HandleStringsMessage"/>
-        /// <seealso cref="RobustMappedStringSerializer.OnClientCompleteHandshake"/>
-        void NetworkInitialize(INetManager net);
-
-        /// <summary>
-        /// Writes a strings package to a stream.
-        /// </summary>
-        /// <param name="stream">A writable stream.</param>
-        /// <exception cref="NotImplementedException">Overly long string in strings package.</exception>
-        void WriteStringPackage(Stream stream);
-
-        /// <summary>
-        /// Converts a URL-safe Base64 string into a byte array.
-        /// </summary>
-        /// <param name="s">A base64url formed string.</param>
-        /// <returns>The represented byte array.</returns>
-        byte[] ConvertFromBase64Url(string s);
-
-        IReadOnlyList<String> MappedStrings { get; }
-
-        /// <summary>
-        /// Whether the string mapping is decided, and cannot be changed.
-        /// </summary>
-        /// <value>
-        /// <para>
-        /// While <c>false</c>, strings can be added to the mapping, but
-        /// it cannot be saved to a cache.
-        /// </para>
-        /// <para>
-        /// While <c>true</c>, the mapping cannot be modified, but can be
-        /// shared between the server and client and saved to a cache.
-        /// </para>
-        /// </value>
-        bool LockMappedStrings { get; set; }
 
         /// <value>
         /// The hash of the string mapping.
@@ -116,7 +32,7 @@ namespace Robust.Shared.Serialization
         /// <exception cref="InvalidOperationException">
         /// Thrown if the mapping is not locked.
         /// </exception>
-        byte[] MappedStringsHash { get; }
+        ReadOnlySpan<byte> MappedStringsHash { get; }
 
         /// <summary>
         /// Add a string to the constant mapping.
@@ -135,7 +51,7 @@ namespace Robust.Shared.Serialization
         /// <exception cref="InvalidOperationException">
         /// Thrown if the string is not normalized (<see cref="String.IsNormalized()"/>).
         /// </exception>
-        bool AddString(string str);
+        void AddString(string str);
 
         /// <summary>
         /// Add the constant strings from an <see cref="Assembly"/> to the
@@ -165,14 +81,6 @@ namespace Robust.Shared.Serialization
         void AddStrings(JObject obj, string name);
 
         /// <summary>
-        /// Remove all strings from the mapping, completely resetting it.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if the mapping is locked.
-        /// </exception>
-        void ClearStrings();
-
-        /// <summary>
         /// Add strings from the given enumeration to the mapping.
         /// </summary>
         /// <param name="strings">The strings to add.</param>
@@ -180,50 +88,10 @@ namespace Robust.Shared.Serialization
         void AddStrings(IEnumerable<string> strings, string providerName);
 
         /// <summary>
-        /// Implements <see cref="ITypeSerializer.Handles"/>.
-        /// Specifies that this implementation handles strings.
-        /// </summary>
-        bool Handles(Type type);
-
-        /// <summary>
-        /// Implements <see cref="ITypeSerializer.GetSubtypes"/>.
-        /// </summary>
-        IEnumerable<Type> GetSubtypes(Type type);
-
-        /// <summary>
-        /// Implements <see cref="IStaticTypeSerializer.GetStaticWriter"/>.
-        /// </summary>
-        /// <seealso cref="RobustMappedStringSerializer.WriteMappedString"/>
-        MethodInfo GetStaticWriter(Type type);
-
-        /// <summary>
-        /// Implements <see cref="IStaticTypeSerializer.GetStaticReader"/>.
-        /// </summary>
-        /// <seealso cref="RobustMappedStringSerializer.ReadMappedString"/>
-        MethodInfo GetStaticReader(Type type);
-
-        /// <summary>
-        /// Write the encoding of the given string to the stream.
-        /// </summary>
-        /// <param name="stream">The stream to write to.</param>
-        /// <param name="value"> The (possibly null) string to write.</param>
-        void WriteMappedString(Stream stream, string? value);
-
-        /// <summary>
-        /// Try to read a string from the given stream.
-        /// </summary>
-        /// <param name="stream">The stream to read from.</param>
-        /// <param name="value"> The (possibly null) string read.</param>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if the mapping is not locked.
-        /// </exception>
-        void ReadMappedString(Stream stream, out string? value);
-
-        /// <summary>
         /// See <see cref="RobustMappedStringSerializer.OnClientCompleteHandshake"/>.
         /// </summary>
         event Action? ClientHandshakeComplete;
 
+        void LockStrings();
     }
-
 }

--- a/Robust.Shared/Interfaces/Serialization/IRobustMappedStringSerializer.cs
+++ b/Robust.Shared/Interfaces/Serialization/IRobustMappedStringSerializer.cs
@@ -89,6 +89,10 @@ namespace Robust.Shared.Serialization
         /// </summary>
         event Action? ClientHandshakeComplete;
 
+        /// <summary>
+        ///     Lock the string mapping so that no new strings may be added,
+        ///     and generate the strings package that can be sent to clients.
+        /// </summary>
         void LockStrings();
     }
 }

--- a/Robust.Shared/Localization/LocalizationManager.cs
+++ b/Robust.Shared/Localization/LocalizationManager.cs
@@ -17,6 +17,7 @@ namespace Robust.Shared.Localization
     {
         [Dependency] private readonly IResourceManager _resourceManager = default!;
         [Dependency] private readonly ITextMacroFactory _textMacroFactory = default!;
+        [Dependency] private readonly IRobustMappedStringSerializer _stringSerializer = default!;
 
         private readonly Dictionary<CultureInfo, Catalog> _catalogs = new Dictionary<CultureInfo, Catalog>();
         private CultureInfo? _defaultCulture;
@@ -164,8 +165,8 @@ namespace Robust.Shared.Localization
             {
                 _readEntry(entry, catalog);
             }
-            IoCManager.Resolve<IRobustMappedStringSerializer>()
-                .AddStrings(yamlStream, filePath.ToString());
+
+            _stringSerializer.AddStrings(yamlStream);
         }
 
         private static void _readEntry(YamlMappingNode entry, Catalog catalog)

--- a/Robust.Shared/Network/Messages/MsgMapStrClientHandshake.cs
+++ b/Robust.Shared/Network/Messages/MsgMapStrClientHandshake.cs
@@ -1,9 +1,9 @@
 using JetBrains.Annotations;
 using Lidgren.Network;
 using Robust.Shared.Interfaces.Network;
-using Robust.Shared.Network;
+using Robust.Shared.Serialization;
 
-namespace Robust.Shared.Serialization
+namespace Robust.Shared.Network.Messages
 {
 
     /// <summary>
@@ -20,11 +20,11 @@ namespace Robust.Shared.Serialization
     /// </remarks>
     /// <seealso cref="RobustMappedStringSerializer.NetworkInitialize"/>
     [UsedImplicitly]
-    internal class MsgRobustMappedStringsSerializerClientHandshake : NetMessage
+    internal class MsgMapStrClientHandshake : NetMessage
     {
 
-        public MsgRobustMappedStringsSerializerClientHandshake(INetChannel ch)
-            : base(nameof(MsgRobustMappedStringsSerializerClientHandshake), MsgGroups.Core)
+        public MsgMapStrClientHandshake(INetChannel ch)
+            : base(nameof(MsgMapStrClientHandshake), MsgGroups.Core)
         {
         }
 

--- a/Robust.Shared/Network/Messages/MsgMapStrServerHandshake.cs
+++ b/Robust.Shared/Network/Messages/MsgMapStrServerHandshake.cs
@@ -2,9 +2,9 @@ using System;
 using JetBrains.Annotations;
 using Lidgren.Network;
 using Robust.Shared.Interfaces.Network;
-using Robust.Shared.Network;
+using Robust.Shared.Serialization;
 
-namespace Robust.Shared.Serialization
+namespace Robust.Shared.Network.Messages
 {
 
     /// <summary>
@@ -15,11 +15,11 @@ namespace Robust.Shared.Serialization
     /// </summary>
     /// <seealso cref="RobustMappedStringSerializer.NetworkInitialize"/>
     [UsedImplicitly]
-    internal class MsgRobustMappedStringsSerializerServerHandshake : NetMessage
+    internal class MsgMapStrServerHandshake : NetMessage
     {
 
-        public MsgRobustMappedStringsSerializerServerHandshake(INetChannel ch)
-            : base(nameof(MsgRobustMappedStringsSerializerServerHandshake), MsgGroups.Core)
+        public MsgMapStrServerHandshake(INetChannel ch)
+            : base(nameof(MsgMapStrServerHandshake), MsgGroups.Core)
         {
         }
 

--- a/Robust.Shared/Network/Messages/MsgMapStrStrings.cs
+++ b/Robust.Shared/Network/Messages/MsgMapStrStrings.cs
@@ -1,12 +1,10 @@
 using System;
-using System.Buffers;
-using System.IO;
 using JetBrains.Annotations;
 using Lidgren.Network;
 using Robust.Shared.Interfaces.Network;
-using Robust.Shared.Network;
+using Robust.Shared.Serialization;
 
-namespace Robust.Shared.Serialization
+namespace Robust.Shared.Network.Messages
 {
 
     /// <summary>
@@ -16,11 +14,11 @@ namespace Robust.Shared.Serialization
     /// </summary>
     /// <seealso cref="RobustMappedStringSerializer.NetworkInitialize"/>
     [UsedImplicitly]
-    internal class MsgRobustMappedStringsSerializerStrings : NetMessage
+    internal class MsgMapStrStrings : NetMessage
     {
 
-        public MsgRobustMappedStringsSerializerStrings(INetChannel ch)
-            : base(nameof(MsgRobustMappedStringsSerializerStrings), MsgGroups.Core)
+        public MsgMapStrStrings(INetChannel ch)
+            : base(nameof(MsgMapStrStrings), MsgGroups.Core)
         {
         }
 

--- a/Robust.Shared/Robust.Shared.csproj
+++ b/Robust.Shared/Robust.Shared.csproj
@@ -38,8 +38,14 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Input\CommandBindMapping.cs" />
+    <Compile Update="Serialization\RobustMappedStringSerializer.MappedStringDict.cs">
+      <DependentUpon>RobustMappedStringSerializer.cs</DependentUpon>
+    </Compile>
     <Compile Update="Serialization\RobustSerializer.Handshake.cs">
       <DependentUpon>RobustSerializer.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Serialization\RobustMappedStringSerializer.MappedStringDict.cs">
+      <DependentUpon>RobustMappedStringSerializer.cs</DependentUpon>
     </Compile>
   </ItemGroup>
   <Import Project="..\MSBuild\Robust.Engine.targets" />

--- a/Robust.Shared/Serialization/RobustMappedStringSerializer.MappedStringDict.cs
+++ b/Robust.Shared/Serialization/RobustMappedStringSerializer.MappedStringDict.cs
@@ -1,0 +1,549 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Text;
+using NetSerializer;
+using Newtonsoft.Json.Linq;
+using Robust.Shared.Interfaces.Log;
+using Robust.Shared.Utility;
+using YamlDotNet.RepresentationModel;
+
+namespace Robust.Shared.Serialization
+{
+    internal partial class RobustMappedStringSerializer
+    {
+        internal sealed class MappedStringDict
+        {
+            private readonly ISawmill _sawmill;
+            public bool Locked { get; set; }
+
+            // All the mapped strings.
+            // The dict is an array of indices into the array.
+            private string[]? _mappedStrings;
+            private Dictionary<string, int>? _stringMapping;
+
+            // When constructing the mapped strings server side, it can be done in multiple threads at once.
+            // To avoid lock contention, each thread will lock to add a single list.
+            // This then gets flattened when the final list gets made.
+            private readonly List<List<string>> _buildingBatches = new List<List<string>>();
+
+            public int StringCount => _mappedStrings?.Length ?? 0;
+
+            public MappedStringDict(ISawmill sawmill)
+            {
+                _sawmill = sawmill;
+            }
+
+            public void FinalizeMapping()
+            {
+                Locked = true;
+
+                // Flatten string mapping, remove duplicates, and sort.
+                _mappedStrings = _buildingBatches
+                    .SelectMany(p => p)
+                    .Distinct()
+                    .OrderBy(p => p)
+                    .ToArray();
+
+                // Create dictionary.
+                _stringMapping = GenMapDict(_mappedStrings);
+            }
+
+            private static Dictionary<string, int> GenMapDict(string[] strings)
+            {
+                var dict = new Dictionary<string, int>();
+                for (var i = 0; i < strings.Length; i++)
+                {
+                    dict.Add(strings[i], i);
+                }
+
+                return dict;
+            }
+
+            public (byte[] mapHash, byte[] package) GeneratePackage()
+            {
+                DebugTools.Assert(Locked);
+                DebugTools.AssertNotNull(_mappedStrings);
+
+                var memoryStream = new MemoryStream();
+                WriteStringPackage(_mappedStrings!, memoryStream, out var hash);
+                var package = memoryStream.ToArray();
+
+                return (hash, package);
+            }
+
+            public int LoadFromPackage(Stream stream, out byte[] hash)
+            {
+                _mappedStrings = ReadStringPackage(stream, out hash).ToArray();
+                _stringMapping = GenMapDict(_mappedStrings);
+
+                return _mappedStrings.Length;
+            }
+
+            private static List<string> ReadStringPackage(Stream stream, out byte[] hash)
+            {
+                var list = new List<string>();
+                var buf = ArrayPool<byte>.Shared.Rent(4096);
+                var hasher = IncrementalHash.CreateHash(PackHashAlgo);
+                using var zs = new DeflateStream(stream, CompressionMode.Decompress, true);
+                using var hasherStream = new HasherStream(zs, hasher, true);
+
+                var count = ReadCompressedUnsignedInt(hasherStream, out _);
+                for (var i = 0; i < count; ++i)
+                {
+                    var l = (int) ReadCompressedUnsignedInt(hasherStream, out _);
+                    var y = hasherStream.Read(buf, 0, l);
+                    if (y != l)
+                    {
+                        throw new InvalidDataException($"Could not read the full length of string #{i}.");
+                    }
+
+                    var str = Encoding.UTF8.GetString(buf, 0, l);
+                    list.Add(str);
+                }
+
+                hash = hasher.GetHashAndReset();
+                return list;
+            }
+
+
+            /// <summary>
+            /// Writes a strings package to a stream.
+            /// </summary>
+            /// <param name="stream">A writable stream.</param>
+            /// <exception cref="NotImplementedException">Overly long string in strings package.</exception>
+            private static void WriteStringPackage(string[] strings, Stream stream, out byte[] hash)
+            {
+                // ReSharper disable once SuggestVarOrType_Elsewhere
+                Span<byte> buf = stackalloc byte[MaxMappedStringSize];
+
+                var hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA512);
+
+                using (var zs = new DeflateStream(stream, CompressionLevel.Optimal, true))
+                {
+                    using var hasherStream = new HasherStream(zs, hasher, true);
+                    WriteCompressedUnsignedInt(hasherStream, (uint) strings.Length);
+
+                    foreach (var str in strings)
+                    {
+                        DebugTools.Assert(str.Length < MaxMappedStringSize);
+
+                        var l = Encoding.UTF8.GetBytes(str, buf);
+
+                        if (l >= MaxMappedStringSize)
+                        {
+                            throw new NotImplementedException("Overly long string in strings package.");
+                        }
+
+                        WriteCompressedUnsignedInt(hasherStream, (uint) l);
+                        hasherStream.Write(buf[..l]);
+                    }
+                }
+
+                hash = hasher.GetHashAndReset();
+            }
+
+
+            /// <summary>
+            /// Remove all strings from the mapping, completely resetting it.
+            /// </summary>
+            /// <exception cref="InvalidOperationException">
+            /// Thrown if the mapping is locked.
+            /// </exception>
+            public void ClearStrings()
+            {
+                if (Locked)
+                {
+                    throw new InvalidOperationException("Mapped strings are locked, will not clear.");
+                }
+
+                _buildingBatches.Clear();
+                _mappedStrings = null;
+                _stringMapping = null;
+            }
+
+            /// <summary>
+            /// Add a string to the constant mapping.
+            /// </summary>
+            /// <remarks>
+            /// If the string has multiple detectable subcomponents, such as a
+            /// filepath, it may result in more than one string being added to
+            /// the mapping. As string parts are commonly sent as subsets or
+            /// scoped names, this increases the likelyhood of a successful
+            /// string mapping.
+            /// </remarks>
+            /// <returns>
+            /// <c>true</c> if the string was added to the mapping for the first
+            /// time, <c>false</c> otherwise.
+            /// </returns>
+            /// <exception cref="InvalidOperationException">
+            /// Thrown if the string is not normalized (<see cref="String.IsNormalized()"/>).
+            /// </exception>
+            public void AddSingleString(string str)
+            {
+                if (Locked)
+                {
+                    throw new InvalidOperationException("Mapped strings are locked, will not add.");
+                }
+
+                var batch = new List<string>();
+                AddStringInternal(str, batch);
+                CommitBatch(batch);
+            }
+
+            /// <summary>
+            /// Add the constant strings from an <see cref="Assembly"/> to the
+            /// mapping.
+            /// </summary>
+            /// <param name="asm">The assembly from which to collect constant strings.</param>
+            [MethodImpl(MethodImplOptions.Synchronized)]
+            public unsafe void AddStrings(Assembly asm)
+            {
+                if (Locked)
+                {
+                    throw new InvalidOperationException("Mapped strings are locked, will not add.");
+                }
+
+                var batch = new List<string>();
+                var sw = Stopwatch.StartNew();
+                if (asm.TryGetRawMetadata(out var blob, out var len))
+                {
+                    var reader = new MetadataReader(blob, len);
+                    var usrStrHandle = default(UserStringHandle);
+                    do
+                    {
+                        var userStr = reader.GetUserString(usrStrHandle);
+                        if (userStr != "")
+                        {
+                            // Because these strings are in a loaded assembly they're already interned.
+                            // This intern call retrieves the interned instance.
+                            AddStringInternal(string.Intern(userStr.Normalize()), batch);
+                        }
+
+                        usrStrHandle = reader.GetNextHandle(usrStrHandle);
+                    } while (usrStrHandle != default);
+
+                    var strHandle = default(StringHandle);
+                    do
+                    {
+                        var str = reader.GetString(strHandle);
+                        if (str != "")
+                        {
+                            // Ditto about interning.
+                            AddStringInternal(string.Intern(str.Normalize()), batch);
+                        }
+
+                        strHandle = reader.GetNextHandle(strHandle);
+                    } while (strHandle != default);
+                }
+
+                CommitBatch(batch);
+
+                var added = batch.Count;
+                _sawmill.Debug($"Mapping {added} strings from {asm.GetName().Name} took {sw.ElapsedMilliseconds}ms.");
+            }
+
+            /// <summary>
+            /// Add strings from the given <see cref="YamlStream"/> to the mapping.
+            /// </summary>
+            /// <remarks>
+            /// Strings are taken from YAML anchors, tags, and leaf nodes.
+            /// </remarks>
+            /// <param name="yaml">The YAML to collect strings from.</param>
+            /// <param name="name">The stream name. Only used for logging.</param>
+            [MethodImpl(MethodImplOptions.Synchronized)]
+            public void AddStrings(YamlStream yaml, string name)
+            {
+                if (Locked)
+                {
+                    throw new InvalidOperationException("Mapped strings are locked, will not add.");
+                }
+
+                var batch = new List<string>();
+                var sw = Stopwatch.StartNew();
+                foreach (var doc in yaml)
+                {
+                    foreach (var node in doc.AllNodes)
+                    {
+                        var a = node.Anchor;
+                        if (!string.IsNullOrEmpty(a))
+                        {
+                            AddStringInternal(a, batch);
+                        }
+
+                        var t = node.Tag;
+                        if (!string.IsNullOrEmpty(t))
+                        {
+                            AddStringInternal(t, batch);
+                        }
+
+                        if (!(node is YamlScalarNode scalar))
+                            continue;
+
+                        var v = scalar.Value;
+                        if (string.IsNullOrEmpty(v))
+                        {
+                            continue;
+                        }
+
+                        AddStringInternal(v, batch);
+                    }
+                }
+
+                CommitBatch(batch);
+
+                var added = batch.Count;
+                _sawmill.Debug($"Mapping {added} string candidates from {name} took {sw.ElapsedMilliseconds}ms.");
+            }
+
+            /// <summary>
+            /// Add strings from the given <see cref="JObject"/> to the mapping.
+            /// </summary>
+            /// <remarks>
+            /// Strings are taken from JSON property names and string nodes.
+            /// </remarks>
+            /// <param name="obj">The JSON to collect strings from.</param>
+            /// <param name="name">The stream name. Only used for logging.</param>
+            public void AddStrings(JObject obj, string name)
+            {
+                if (Locked)
+                {
+                    throw new InvalidOperationException("Mapped strings are locked, will not add.");
+                }
+
+                var batch = new List<string>();
+                var sw = Stopwatch.StartNew();
+                foreach (var node in obj.DescendantsAndSelf())
+                {
+                    switch (node)
+                    {
+                        case JValue value:
+                        {
+                            if (value.Type != JTokenType.String)
+                            {
+                                continue;
+                            }
+
+                            var v = value.Value?.ToString();
+                            if (string.IsNullOrEmpty(v))
+                            {
+                                continue;
+                            }
+
+                            AddStringInternal(v, batch);
+                            break;
+                        }
+                        case JProperty prop:
+                        {
+                            var propName = prop.Name;
+                            if (string.IsNullOrEmpty(propName))
+                            {
+                                continue;
+                            }
+
+                            AddStringInternal(propName, batch);
+                            break;
+                        }
+                    }
+                }
+
+                CommitBatch(batch);
+
+                var added = batch.Count;
+                _sawmill.Debug($"Mapping {added} strings from {name} took {sw.ElapsedMilliseconds}ms.");
+            }
+
+            /// <summary>
+            /// Add strings from the given enumeration to the mapping.
+            /// </summary>
+            /// <param name="strings">The strings to add.</param>
+            /// <param name="providerName">The source provider of the strings to be logged.</param>
+            [MethodImpl(MethodImplOptions.Synchronized)]
+            public void AddStrings(IEnumerable<string> strings, string providerName)
+            {
+                if (Locked)
+                {
+                    throw new InvalidOperationException("Mapped strings are locked, will not add.");
+                }
+
+                var batch = new List<string>();
+                foreach (var str in strings)
+                {
+                    AddStringInternal(str, batch);
+                }
+
+                CommitBatch(batch);
+                _sawmill.Debug($"Mapping {batch.Count} strings from {providerName}.");
+            }
+
+            private static void AddStringInternal(string str, List<string> batch)
+            {
+                if (string.IsNullOrEmpty(str))
+                {
+                    return;
+                }
+
+                if (!str.IsNormalized())
+                {
+                    throw new InvalidOperationException("Only normalized strings may be added.");
+                }
+
+                if (str.Length >= MaxMappedStringSize) return;
+
+                if (str.Length <= MinMappedStringSize) return;
+
+                str = str.Trim();
+
+                if (str.Length <= MinMappedStringSize) return;
+
+                str = str.Replace(Environment.NewLine, "\n");
+
+                if (str.Length <= MinMappedStringSize) return;
+
+                var symTrimmedStr = str.Trim(TrimmableSymbolChars);
+                if (symTrimmedStr != str)
+                {
+                    AddStringInternal(symTrimmedStr, batch);
+                }
+
+                if (str.Contains('/'))
+                {
+                    var parts = str.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                    for (var i = 0; i < parts.Length; ++i)
+                    {
+                        for (var l = 1; l <= parts.Length - i; ++l)
+                        {
+                            var subStr = string.Join('/', parts.Skip(i).Take(l));
+                            batch.Add(subStr);
+
+                            if (!subStr.Contains('.'))
+                            {
+                                continue;
+                            }
+
+                            var subParts = subStr.Split('.', StringSplitOptions.RemoveEmptyEntries);
+                            for (var si = 0; si < subParts.Length; ++si)
+                            {
+                                for (var sl = 1; sl <= subParts.Length - si; ++sl)
+                                {
+                                    var subSubStr = string.Join('.', subParts.Skip(si).Take(sl));
+                                    // ReSharper disable once InvertIf
+                                    batch.Add(subSubStr);
+                                }
+                            }
+                        }
+                    }
+                }
+                else if (str.Contains("_"))
+                {
+                    foreach (var substr in str.Split("_"))
+                    {
+                        AddStringInternal(substr, batch);
+                    }
+                }
+                else if (str.Contains(" "))
+                {
+                    foreach (var substr in str.Split(" "))
+                    {
+                        if (substr == str) continue;
+
+                        AddStringInternal(substr, batch);
+                    }
+                }
+                else
+                {
+                    var parts = RxSymbolSplitter.Split(str);
+                    foreach (var substr in parts)
+                    {
+                        if (substr == str) continue;
+
+                        AddStringInternal(substr, batch);
+                    }
+
+                    for (var si = 0; si < parts.Length; ++si)
+                    {
+                        for (var sl = 1; sl <= parts.Length - si; ++sl)
+                        {
+                            var subSubStr = String.Concat(parts.Skip(si).Take(sl));
+                            batch.Add(subSubStr);
+                        }
+                    }
+                }
+
+                batch.Add(str);
+            }
+
+            // See normally I would call this method "AddBatch" but "commit batch" sounds cooler than it is.
+            private void CommitBatch(List<string> batch)
+            {
+                lock (_buildingBatches)
+                {
+                    _buildingBatches.Add(batch);
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void WriteMappedString(Stream stream, string? value)
+            {
+                DebugTools.Assert(Locked);
+
+                if (value == null)
+                {
+                    WriteCompressedUnsignedInt(stream, MappedNull);
+                    return;
+                }
+
+                if (_stringMapping!.TryGetValue(value, out var mapping))
+                {
+#if DEBUG
+                    if (mapping >= _mappedStrings!.Length || mapping < 0)
+                    {
+                        throw new InvalidOperationException(
+                            "A string mapping outside of the mapped string table was encountered.");
+                    }
+#endif
+                    WriteCompressedUnsignedInt(stream, (uint) mapping + FirstMappedIndexStart);
+                    //Logger.DebugS("szr", $"Encoded mapped string: {value}");
+                    return;
+                }
+
+                // indicate not mapped
+                WriteCompressedUnsignedInt(stream, UnmappedString);
+
+                Primitives.WritePrimitive(stream, value);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void ReadMappedString(Stream stream, out string? value)
+            {
+                DebugTools.Assert(Locked);
+
+                var mapIndex = ReadCompressedUnsignedInt(stream, out _);
+                if (mapIndex == MappedNull)
+                {
+                    value = null;
+                    return;
+                }
+
+                if (mapIndex == UnmappedString)
+                {
+                    // not mapped
+                    Primitives.ReadPrimitive(stream, out value);
+                    return;
+                }
+
+                value = _mappedStrings![(int) mapIndex - FirstMappedIndexStart];
+                //Logger.DebugS("szr", $"Decoded mapped string: {value}");
+            }
+        }
+    }
+}

--- a/Robust.Shared/Serialization/RobustMappedStringSerializer.MappedStringDict.cs
+++ b/Robust.Shared/Serialization/RobustMappedStringSerializer.MappedStringDict.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Buffers;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;

--- a/Robust.Shared/Serialization/RobustMappedStringSerializer.cs
+++ b/Robust.Shared/Serialization/RobustMappedStringSerializer.cs
@@ -134,6 +134,8 @@ namespace Robust.Shared.Serialization
             );
 
 
+        public ITypeSerializer TypeSerializer => this;
+
         /// <summary>
         /// Starts the handshake from the server end of the given channel,
         /// sending a <see cref="MsgMapStrServerHandshake"/>.
@@ -575,7 +577,7 @@ namespace Robust.Shared.Serialization
         /// <param name="value"> The (possibly null) string to write.</param>
         private static void StaticWriteMappedString(Stream stream, string? value)
         {
-            var mss = IoCManager.Resolve<RobustMappedStringSerializer>();
+            var mss = (RobustMappedStringSerializer) IoCManager.Resolve<IRobustMappedStringSerializer>();
             mss._dict.WriteMappedString(stream, value);
         }
         /// <summary>
@@ -589,7 +591,7 @@ namespace Robust.Shared.Serialization
         /// </exception>
         private static void StaticReadMappedString(Stream stream, out string? value)
         {
-            var mss = IoCManager.Resolve<RobustMappedStringSerializer>();
+            var mss = (RobustMappedStringSerializer) IoCManager.Resolve<IRobustMappedStringSerializer>();
             mss._dict.ReadMappedString(stream, out value);
         }
 

--- a/Robust.Shared/Serialization/RobustMappedStringSerializer.cs
+++ b/Robust.Shared/Serialization/RobustMappedStringSerializer.cs
@@ -21,6 +21,7 @@ using Robust.Shared.Log;
 using Robust.Shared.Network.Messages;
 using Robust.Shared.Utility;
 using YamlDotNet.RepresentationModel;
+using static Robust.Shared.Utility.Base64Helpers;
 
 namespace Robust.Shared.Serialization
 {
@@ -460,51 +461,6 @@ namespace Robust.Shared.Serialization
         }
 
         /// <summary>
-        /// Converts a byte array such as a hash to a Base64 representation that is URL safe.
-        /// </summary>
-        /// <param name="data"></param>
-        /// <returns>A base64url string form of the byte array.</returns>
-        private static string ConvertToBase64Url(byte[]? data)
-        {
-            return data == null ? "" : ConvertToBase64Url(Convert.ToBase64String(data));
-        }
-
-        /// <summary>
-        /// Converts a a Base64 string to one that is URL safe.
-        /// </summary>
-        /// <returns>A base64url formed string.</returns>
-        private static string ConvertToBase64Url(string b64Str)
-        {
-            if (b64Str is null)
-            {
-                throw new ArgumentNullException(nameof(b64Str));
-            }
-
-            var cut = b64Str[^1] == '=' ? b64Str[^2] == '=' ? 2 : 1 : 0;
-            b64Str = new StringBuilder(b64Str).Replace('+', '-').Replace('/', '_').ToString(0, b64Str.Length - cut);
-            return b64Str;
-        }
-
-        /// <summary>
-        /// Converts a URL-safe Base64 string into a byte array.
-        /// </summary>
-        /// <param name="s">A base64url formed string.</param>
-        /// <returns>The represented byte array.</returns>
-        public byte[] ConvertFromBase64Url(string s)
-        {
-            var l = s.Length % 3;
-            var sb = new StringBuilder(s);
-            sb.Replace('-', '+').Replace('_', '/');
-            for (var i = 0; i < l; ++i)
-            {
-                sb.Append('=');
-            }
-
-            s = sb.ToString();
-            return Convert.FromBase64String(s);
-        }
-
-        /// <summary>
         /// Add a string to the constant mapping.
         /// </summary>
         /// <remarks>
@@ -525,7 +481,7 @@ namespace Robust.Shared.Serialization
         {
             if (!_net.IsClient)
             {
-                _dict.AddSingleString(str);
+                _dict.AddString(str);
             }
         }
 
@@ -534,7 +490,6 @@ namespace Robust.Shared.Serialization
         /// mapping.
         /// </summary>
         /// <param name="asm">The assembly from which to collect constant strings.</param>
-        [MethodImpl(MethodImplOptions.Synchronized)]
         public void AddStrings(Assembly asm)
         {
             if (!_net.IsClient)
@@ -550,13 +505,11 @@ namespace Robust.Shared.Serialization
         /// Strings are taken from YAML anchors, tags, and leaf nodes.
         /// </remarks>
         /// <param name="yaml">The YAML to collect strings from.</param>
-        /// <param name="name">The stream name. Only used for logging.</param>
-        [MethodImpl(MethodImplOptions.Synchronized)]
-        public void AddStrings(YamlStream yaml, string name)
+        public void AddStrings(YamlStream yaml)
         {
             if (!_net.IsClient)
             {
-                _dict.AddStrings(yaml, name);
+                _dict.AddStrings(yaml);
             }
         }
 
@@ -567,12 +520,11 @@ namespace Robust.Shared.Serialization
         /// Strings are taken from JSON property names and string nodes.
         /// </remarks>
         /// <param name="obj">The JSON to collect strings from.</param>
-        /// <param name="name">The stream name. Only used for logging.</param>
-        public void AddStrings(JObject obj, string name)
+        public void AddStrings(JObject obj)
         {
             if (!_net.IsClient)
             {
-                _dict.AddStrings(obj, name);
+                _dict.AddStrings(obj);
             }
         }
 
@@ -580,13 +532,11 @@ namespace Robust.Shared.Serialization
         /// Add strings from the given enumeration to the mapping.
         /// </summary>
         /// <param name="strings">The strings to add.</param>
-        /// <param name="providerName">The source provider of the strings to be logged.</param>
-        [MethodImpl(MethodImplOptions.Synchronized)]
-        public void AddStrings(IEnumerable<string> strings, string providerName)
+        public void AddStrings(IEnumerable<string> strings)
         {
             if (!_net.IsClient)
             {
-                _dict.AddStrings(strings, providerName);
+                _dict.AddStrings(strings);
             }
         }
 

--- a/Robust.Shared/Serialization/RobustMappedStringSerializer.cs
+++ b/Robust.Shared/Serialization/RobustMappedStringSerializer.cs
@@ -1,14 +1,9 @@
 using System;
-using System.Buffers;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
-using System.Reflection.Metadata;
-using System.Reflection.Metadata.Ecma335;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
@@ -23,12 +18,12 @@ using Robust.Shared.Interfaces.Log;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
+using Robust.Shared.Network.Messages;
 using Robust.Shared.Utility;
 using YamlDotNet.RepresentationModel;
 
 namespace Robust.Shared.Serialization
 {
-
     /// <summary>
     /// Serializer which manages a mapping of pre-loaded strings to constant
     /// values, for message compression. The mapping is shared between the
@@ -47,1037 +42,8 @@ namespace Robust.Shared.Serialization
     /// send the constant value instead - and at the other end, the
     /// serializer can use the same mapping to recover the original string.
     /// </remarks>
-    public class RobustMappedStringSerializer : IStaticTypeSerializer, IRobustMappedStringSerializer
+    internal partial class RobustMappedStringSerializer : IStaticTypeSerializer, IRobustMappedStringSerializer
     {
-
-        private INetManager? _net;
-
-        // I don't want to create 50 line changes in this commit so...
-        // ReSharper disable once InconsistentNaming
-        private ISawmill LogSzr = default!;
-
-        private readonly HashSet<INetChannel> _incompleteHandshakes = new HashSet<INetChannel>();
-
-        /// <summary>
-        /// Starts the handshake from the server end of the given channel,
-        /// sending a <see cref="MsgRobustMappedStringsSerializerServerHandshake"/>.
-        /// </summary>
-        /// <param name="channel">The network channel to perform the handshake over.</param>
-        /// <remarks>
-        /// Locks the string mapping if this is the first time the server is
-        /// performing the handshake.
-        /// </remarks>
-        /// <seealso cref="MsgRobustMappedStringsSerializerClientHandshake"/>
-        /// <seealso cref="MsgRobustMappedStringsSerializerStrings"/>
-        public async Task Handshake(INetChannel channel)
-        {
-            var net = channel.NetPeer;
-
-            if (net.IsClient)
-            {
-                return;
-            }
-
-            if (!LockMappedStrings)
-            {
-                LockMappedStrings = true;
-                LogSzr.Debug($"Locked in at {_mappedStrings.Count} mapped strings.");
-            }
-
-            _incompleteHandshakes.Add(channel);
-
-            var message = net.CreateNetMessage<MsgRobustMappedStringsSerializerServerHandshake>();
-            message.Hash = MappedStringsHash;
-            net.ServerSendMessage(message, channel);
-
-            while (_incompleteHandshakes.Contains(channel))
-            {
-                await Task.Delay(1);
-            }
-
-            LogSzr.Debug($"Completed handshake with {channel.RemoteEndPoint.Address}.");
-        }
-
-        /// <summary>
-        /// Performs the setup so that the serializer can perform the string-
-        /// exchange protocol.
-        /// </summary>
-        /// <remarks>
-        /// The string-exchange protocol is started by the server when the
-        /// client first connects. The server sends the client a hash of the
-        /// string mapping; the client checks that hash against any local
-        /// caches; and if necessary, the client requests a new copy of the
-        /// mapping from the server.
-        ///
-        /// Uncached flow: <code>
-        /// Client      |      Server
-        /// | &lt;-------------- Hash |
-        /// | Need Strings ------&gt; |
-        /// | &lt;----------- Strings |
-        /// | Dont Need Strings -&gt; |
-        /// </code>
-        ///
-        /// Cached flow: <code>
-        /// Client      |      Server
-        /// | &lt;-------------- Hash |
-        /// | Dont Need Strings -&gt; |
-        /// </code>
-        ///
-        /// Verification failure flow: <code>
-        /// Client      |      Server
-        /// | &lt;-------------- Hash |
-        /// | Need Strings ------&gt; |
-        /// | &lt;----------- Strings |
-        /// + Hash Failed          |
-        /// | Need Strings ------&gt; |
-        /// | &lt;----------- Strings |
-        /// | Dont Need Strings -&gt; |
-        ///  </code>
-        ///
-        /// NOTE: Verification failure flow is currently not implemented.
-        /// </remarks>
-        /// <param name="net">
-        /// The <see cref="INetManager"/> to perform the protocol steps over.
-        /// </param>
-        /// <seealso cref="MsgRobustMappedStringsSerializerServerHandshake"/>
-        /// <seealso cref="MsgRobustMappedStringsSerializerClientHandshake"/>
-        /// <seealso cref="MsgRobustMappedStringsSerializerStrings"/>
-        /// <seealso cref="HandleServerHandshake"/>
-        /// <seealso cref="HandleClientHandshake"/>
-        /// <seealso cref="HandleStringsMessage"/>
-        /// <seealso cref="OnClientCompleteHandshake"/>
-        public void NetworkInitialize(INetManager net)
-        {
-            _net = net;
-
-            net.RegisterNetMessage<MsgRobustMappedStringsSerializerServerHandshake>(
-                nameof(MsgRobustMappedStringsSerializerServerHandshake),
-                msg => HandleServerHandshake(net, msg));
-
-            net.RegisterNetMessage<MsgRobustMappedStringsSerializerClientHandshake>(
-                nameof(MsgRobustMappedStringsSerializerClientHandshake),
-                msg => HandleClientHandshake(net, msg));
-
-            net.RegisterNetMessage<MsgRobustMappedStringsSerializerStrings>(
-                nameof(MsgRobustMappedStringsSerializerStrings),
-                msg => HandleStringsMessage(net, msg));
-        }
-
-        /// <summary>
-        /// Handles the reception, verification of a strings package
-        /// and subsequent mapping of strings and initiator of
-        /// receipt response.
-        ///
-        /// Uncached flow: <code>
-        /// Client      |      Server
-        /// | &lt;-------------- Hash |
-        /// | Need Strings ------&gt; |
-        /// | &lt;----------- Strings |
-        /// | Dont Need Strings -&gt; | &lt;- you are here on client
-        ///
-        /// Verification failure flow: <code>
-        /// Client      |      Server
-        /// | &lt;-------------- Hash |
-        /// | Need Strings ------&gt; |
-        /// | &lt;----------- Strings |
-        /// + Hash Failed          | &lt;- you are here on client
-        /// | Need Strings ------&gt; |
-        /// | &lt;----------- Strings |
-        /// | Dont Need Strings -&gt; | &lt;- you are here on client
-        ///  </code>
-        ///
-        /// NOTE: Verification failure flow is currently not implemented.
-        /// </code>
-        /// </summary>
-        /// <exception cref="InvalidOperationException">Unable to verify strings package by hash.</exception>
-        /// <seealso cref="NetworkInitialize"/>
-        private void HandleStringsMessage(INetManager net, MsgRobustMappedStringsSerializerStrings msgRobustMappedStringsSerializer)
-        {
-            if (net.IsServer)
-            {
-                LogSzr.Error("Received strings from client.");
-                return;
-            }
-
-            LockMappedStrings = false;
-            ClearStrings();
-            DebugTools.Assert(msgRobustMappedStringsSerializer.Package != null, "msg.Package != null");
-            LoadStrings(new MemoryStream(msgRobustMappedStringsSerializer.Package!, false));
-            var checkHash = CalculateHash(msgRobustMappedStringsSerializer.Package!);
-            if (!checkHash.SequenceEqual(ServerHash))
-            {
-                // TODO: retry sending MsgClientHandshake with NeedsStrings = false
-                throw new InvalidOperationException("Unable to verify strings package by hash." + $"\n{ConvertToBase64Url(checkHash)} vs. {ConvertToBase64Url(ServerHash)}");
-            }
-
-            _stringMapHash = ServerHash;
-            LockMappedStrings = true;
-
-            LogSzr.Debug($"Locked in at {_mappedStrings.Count} mapped strings.");
-
-            WriteStringCache();
-
-            // ok we're good now
-            var channel = msgRobustMappedStringsSerializer.MsgChannel;
-            OnClientCompleteHandshake(net, channel);
-        }
-
-        /// <summary>
-        /// Interpret a client's handshake, either sending a package
-        /// of strings or completing the handshake.
-        ///
-        /// Uncached flow: <code>
-        /// Client      |      Server
-        /// | &lt;-------------- Hash |
-        /// | Need Strings ------&gt; | &lt;- you are here on server
-        /// | &lt;----------- Strings |
-        /// | Dont Need Strings -&gt; | &lt;- you are here on server
-        /// </code>
-        ///
-        /// Cached flow: <code>
-        /// Client      |      Server
-        /// | &lt;-------------- Hash |
-        /// | Dont Need Strings -&gt; | &lt;- you are here on server
-        /// </code>
-        ///
-        /// Verification failure flow: <code>
-        /// Client      |      Server
-        /// | &lt;-------------- Hash |
-        /// | Need Strings ------&gt; | &lt;- you are here on server
-        /// | &lt;----------- Strings |
-        /// + Hash Failed          |
-        /// | Need Strings ------&gt; | &lt;- you are here on server
-        /// | &lt;----------- Strings |
-        /// | Dont Need Strings -&gt; |
-        ///  </code>
-        ///
-        /// NOTE: Verification failure flow is currently not implemented.
-        /// </summary>
-        /// <seealso cref="NetworkInitialize"/>
-        private void HandleClientHandshake(INetManager net, MsgRobustMappedStringsSerializerClientHandshake msgRobustMappedStringsSerializer)
-        {
-            if (net.IsClient)
-            {
-                LogSzr.Error("Received client handshake on client.");
-                return;
-            }
-
-            LogSzr.Debug($"Received handshake from {msgRobustMappedStringsSerializer.MsgChannel.RemoteEndPoint.Address}.");
-
-            if (!msgRobustMappedStringsSerializer.NeedsStrings)
-            {
-                LogSzr.Debug($"Completing handshake with {msgRobustMappedStringsSerializer.MsgChannel.RemoteEndPoint.Address}.");
-                _incompleteHandshakes.Remove(msgRobustMappedStringsSerializer.MsgChannel);
-                return;
-            }
-
-            // TODO: count and limit number of requests to send strings during handshake
-
-            var strings = msgRobustMappedStringsSerializer.MsgChannel.NetPeer.CreateNetMessage<MsgRobustMappedStringsSerializerStrings>();
-            using (var ms = new MemoryStream())
-            {
-                WriteStringPackage(ms);
-                ms.Position = 0;
-                strings.Package = ms.ToArray();
-                LogSzr.Debug($"Sending {ms.Length} bytes sized mapped strings package to {msgRobustMappedStringsSerializer.MsgChannel.RemoteEndPoint.Address}.");
-            }
-
-            msgRobustMappedStringsSerializer.MsgChannel.SendMessage(strings);
-        }
-
-        /// <summary>
-        /// Interpret a server's handshake, either requesting a package
-        /// of strings or completing the handshake.
-        ///
-        /// Uncached flow: <code>
-        /// Client      |      Server
-        /// | &lt;-------------- Hash | &lt;- you are here on client
-        /// | Need Strings ------&gt; |
-        /// | &lt;----------- Strings |
-        /// | Dont Need Strings -&gt; |
-        /// </code>
-        ///
-        /// Cached flow: <code>
-        /// Client      |      Server
-        /// | &lt;-------------- Hash | &lt;- you are here on client
-        /// | Dont Need Strings -&gt; |
-        /// </code>
-        ///
-        /// Verification failure flow: <code>
-        /// Client      |      Server
-        /// | &lt;-------------- Hash | &lt;- you are here on client
-        /// | Need Strings ------&gt; |
-        /// | &lt;----------- Strings |
-        /// + Hash Failed          |
-        /// | Need Strings ------&gt; |
-        /// | &lt;----------- Strings |
-        /// | Dont Need Strings -&gt; |
-        ///  </code>
-        ///
-        /// NOTE: Verification failure flow is currently not implemented.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">Mapped strings are locked.</exception>
-        /// <seealso cref="NetworkInitialize"/>
-        private void HandleServerHandshake(INetManager net, MsgRobustMappedStringsSerializerServerHandshake msgRobustMappedStringsSerializer)
-        {
-            if (net.IsServer)
-            {
-                LogSzr.Error("Received server handshake on server.");
-                return;
-            }
-
-            ServerHash = msgRobustMappedStringsSerializer.Hash;
-            LockMappedStrings = false;
-
-            if (LockMappedStrings)
-            {
-                throw new InvalidOperationException("Mapped strings are locked.");
-            }
-
-            ClearStrings();
-
-            var hashStr = ConvertToBase64Url(Convert.ToBase64String(msgRobustMappedStringsSerializer.Hash!));
-
-            LogSzr.Debug($"Received server handshake with hash {hashStr}.");
-
-            var fileName = CacheForHash(hashStr);
-            if (!File.Exists(fileName))
-            {
-                LogSzr.Debug($"No string cache for {hashStr}.");
-                var handshake = net.CreateNetMessage<MsgRobustMappedStringsSerializerClientHandshake>();
-                LogSzr.Debug("Asking server to send mapped strings.");
-                handshake.NeedsStrings = true;
-                msgRobustMappedStringsSerializer.MsgChannel.SendMessage(handshake);
-            }
-            else
-            {
-                LogSzr.Debug($"We had a cached string map that matches {hashStr}.");
-                using var file = File.OpenRead(fileName);
-                var added = LoadStrings(file);
-
-                _stringMapHash = msgRobustMappedStringsSerializer.Hash!;
-                LogSzr.Debug($"Read {added} strings from cache {hashStr}.");
-                LockMappedStrings = true;
-                LogSzr.Debug($"Locked in at {_mappedStrings.Count} mapped strings.");
-                // ok we're good now
-                var channel = msgRobustMappedStringsSerializer.MsgChannel;
-                OnClientCompleteHandshake(net, channel);
-            }
-        }
-
-        /// <summary>
-        /// Inform the server that the client has a complete copy of the
-        /// mapping, and alert other code that the handshake is over.
-        /// </summary>
-        /// <seealso cref="ClientHandshakeComplete"/>
-        /// <seealso cref="NetworkInitialize"/>
-        private void OnClientCompleteHandshake(INetManager net, INetChannel channel)
-        {
-            LogSzr.Debug("Letting server know we're good to go.");
-            var handshake = net.CreateNetMessage<MsgRobustMappedStringsSerializerClientHandshake>();
-            handshake.NeedsStrings = false;
-            channel.SendMessage(handshake);
-
-            if (ClientHandshakeComplete == null)
-            {
-                LogSzr.Warning("There's no handler attached to ClientHandshakeComplete.");
-            }
-
-            ClientHandshakeComplete?.Invoke();
-        }
-
-        /// <summary>
-        /// Gets the cache file associated with the given hash.
-        /// </summary>
-        /// <param name="hashStr">The hash to look up the cache for.</param>
-        /// <returns>
-        /// The filename where the cache for the given hash would be. The
-        /// file itself may or may not exist. If it does not exist, no cache
-        /// was made for the given hash.
-        /// </returns>
-        private string CacheForHash(string hashStr)
-            => PathHelpers.ExecutableRelativeFile($"strings-{hashStr}");
-
-        /// <summary>
-        ///  Saves the string cache to a file based on it's hash.
-        /// </summary>
-        private void WriteStringCache()
-        {
-            var hashStr = Convert.ToBase64String(MappedStringsHash);
-            hashStr = ConvertToBase64Url(hashStr);
-
-            var fileName = CacheForHash(hashStr);
-            using var file = File.OpenWrite(fileName);
-            WriteStringPackage(file);
-
-            LogSzr.Debug($"Wrote string cache {hashStr}.");
-        }
-
-        private byte[]? _mappedStringsPackage;
-
-        private byte[] MappedStringsPackage => LockMappedStrings
-            ? _mappedStringsPackage ??= WriteStringPackage()
-            : throw new InvalidOperationException("Mapped strings must be locked.");
-
-        /// <summary>
-        /// Writes strings to a package and converts to an array of bytes.
-        /// </summary>
-        /// <remarks>
-        /// This is invoked by accessing <see cref="MappedStringsPackage"/> for the first time.
-        /// </remarks>
-        private byte[] WriteStringPackage()
-        {
-            using var ms = new MemoryStream();
-            WriteStringPackage(ms);
-            return ms.ToArray();
-        }
-
-        /// <summary>
-        /// Writes a strings package to a stream.
-        /// </summary>
-        /// <param name="stream">A writable stream.</param>
-        /// <exception cref="NotImplementedException">Overly long string in strings package.</exception>
-        public void WriteStringPackage(Stream stream)
-        {
-            // ReSharper disable once SuggestVarOrType_Elsewhere
-            Span<byte> buf = stackalloc byte[MaxMappedStringSize];
-            var sw = Stopwatch.StartNew();
-            var enc = Encoding.UTF8.GetEncoder();
-
-            using (var zs = new DeflateStream(stream, CompressionLevel.Optimal, true))
-            {
-                var bytesWritten = WriteCompressedUnsignedInt(zs, (uint) MappedStrings.Count);
-                foreach (var str in MappedStrings)
-                {
-                    if (str.Length >= MaxMappedStringSize)
-                    {
-                        throw new NotImplementedException("Overly long string in strings package.");
-                    }
-
-                    var l = enc.GetBytes(str, buf, true);
-
-                    if (l >= MaxMappedStringSize)
-                    {
-                        throw new NotImplementedException("Overly long string in strings package.");
-                    }
-
-                    bytesWritten += WriteCompressedUnsignedInt(zs, (uint) l);
-
-                    zs.Write(buf.Slice(0,l));
-
-                    bytesWritten += l;
-
-                    enc.Reset();
-                }
-
-                zs.Write(BitConverter.GetBytes(bytesWritten));
-                zs.Flush();
-            }
-
-            LogSzr.Debug($"Wrote {MappedStrings.Count} strings to package in {sw.ElapsedMilliseconds}ms.");
-        }
-
-        /// <summary>
-        /// Loads a strings package from a stream.
-        /// </summary>
-        /// <remarks>
-        /// Uses <see cref="ReadStringPackage"/> to extract strings and adds them to the mapping.
-        /// </remarks>
-        /// <param name="stream">A readable stream.</param>
-        /// <returns>The number of strings loaded.</returns>
-        /// <exception cref="InvalidOperationException">Mapped strings are locked, will not load.</exception>
-        /// <exception cref="InvalidDataException">Did not read all bytes in package!</exception>
-        private int LoadStrings(Stream stream)
-        {
-            if (LockMappedStrings)
-            {
-                throw new InvalidOperationException("Mapped strings are locked, will not load.");
-            }
-
-            var started = MappedStrings.Count;
-            foreach (var str in ReadStringPackage(stream))
-            {
-                _stringMapping[str] = _mappedStrings.Count;
-                _mappedStrings.Add(str);
-            }
-
-            if (stream.CanSeek && stream.CanRead)
-            {
-                if (stream.Position != stream.Length)
-                {
-                    throw new InvalidDataException("Did not read all bytes in package!");
-                }
-            }
-
-            var added = MappedStrings.Count - started;
-            return added;
-        }
-
-        /// <summary>
-        /// Reads the contents of a strings package.
-        /// </summary>
-        /// <remarks>
-        /// Does not add strings to the current mapping.
-        /// </remarks>
-        /// <param name="stream">A readable stream.</param>
-        /// <returns>Strings from within the package.</returns>
-        /// <exception cref="InvalidDataException">Could not read the full length of string #N.</exception>
-        private IEnumerable<string> ReadStringPackage(Stream stream)
-        {
-            var buf = ArrayPool<byte>.Shared.Rent(65536);
-            var sw = Stopwatch.StartNew();
-            using var zs = new DeflateStream(stream, CompressionMode.Decompress);
-
-            var c = ReadCompressedUnsignedInt(zs, out var x);
-            var bytesRead = x;
-            for (var i = 0; i < c; ++i)
-            {
-                var l = (int) ReadCompressedUnsignedInt(zs, out x);
-                bytesRead += x;
-                var y = zs.Read(buf, 0, l);
-                if (y != l)
-                {
-                    throw new InvalidDataException($"Could not read the full length of string #{i}.");
-                }
-
-                bytesRead += y;
-                var str = Encoding.UTF8.GetString(buf, 0, l);
-                yield return str;
-            }
-
-            zs.Read(buf, 0, 4);
-            var checkBytesRead = BitConverter.ToInt32(buf, 0);
-            if (checkBytesRead != bytesRead)
-            {
-                throw new InvalidDataException("Could not verify package was read correctly.");
-            }
-
-            LogSzr.Debug($"Read package of {c} strings in {sw.ElapsedMilliseconds}ms.");
-        }
-
-        /// <summary>
-        /// Converts a byte array such as a hash to a Base64 representation that is URL safe.
-        /// </summary>
-        /// <param name="data"></param>
-        /// <returns>A base64url string form of the byte array.</returns>
-        private string ConvertToBase64Url(byte[]? data)
-            => data == null ? "" : ConvertToBase64Url(Convert.ToBase64String(data));
-
-        /// <summary>
-        /// Converts a a Base64 string to one that is URL safe.
-        /// </summary>
-        /// <returns>A base64url formed string.</returns>
-        private string ConvertToBase64Url(string b64Str)
-        {
-            if (b64Str is null)
-            {
-                throw new ArgumentNullException(nameof(b64Str));
-            }
-
-            var cut = b64Str[^1] == '=' ? b64Str[^2] == '=' ? 2 : 1 : 0;
-            b64Str = new StringBuilder(b64Str).Replace('+', '-').Replace('/', '_').ToString(0, b64Str.Length - cut);
-            return b64Str;
-        }
-
-        /// <summary>
-        /// Converts a URL-safe Base64 string into a byte array.
-        /// </summary>
-        /// <param name="s">A base64url formed string.</param>
-        /// <returns>The represented byte array.</returns>
-        public byte[] ConvertFromBase64Url(string s)
-        {
-            var l = s.Length % 3;
-            var sb = new StringBuilder(s);
-            sb.Replace('-', '+').Replace('_', '/');
-            for (var i = 0; i < l; ++i)
-            {
-                sb.Append('=');
-            }
-
-            s = sb.ToString();
-            return Convert.FromBase64String(s);
-        }
-
-        public byte[]? ServerHash;
-
-        private readonly List<string> _mappedStrings = new List<string>();
-
-        private readonly Dictionary<string, int> _stringMapping = new Dictionary<string, int>();
-
-        public IReadOnlyList<String> MappedStrings => new ReadOnlyCollection<string>(_mappedStrings);
-
-        /// <summary>
-        /// Whether the string mapping is decided, and cannot be changed.
-        /// </summary>
-        /// <value>
-        /// <para>
-        /// While <c>false</c>, strings can be added to the mapping, but
-        /// it cannot be saved to a cache.
-        /// </para>
-        /// <para>
-        /// While <c>true</c>, the mapping cannot be modified, but can be
-        /// shared between the server and client and saved to a cache.
-        /// </para>
-        /// </value>
-        public bool LockMappedStrings { get; set; }
-
-        private readonly Regex _rxSymbolSplitter
-            = new Regex(
-                @"(?<=[^\s\W])(?=[A-Z]) # Match for split at start of new capital letter
-                            |(?<=[^0-9\s\W])(?=[0-9]) # Match for split before spans of numbers
-                            |(?<=[A-Za-z0-9])(?=_) # Match for a split before an underscore
-                            |(?=[.\\\/,#$?!@|&*()^`""'`~[\]{}:;\-]) # Match for a split after symbols
-                            |(?<=[.\\\/,#$?!@|&*()^`""'`~[\]{}:;\-]) # Match for a split before symbols too",
-                RegexOptions.CultureInvariant
-                | RegexOptions.Compiled
-                | RegexOptions.IgnorePatternWhitespace
-            );
-
-        /// <summary>
-        /// Add a string to the constant mapping.
-        /// </summary>
-        /// <remarks>
-        /// If the string has multiple detectable subcomponents, such as a
-        /// filepath, it may result in more than one string being added to
-        /// the mapping. As string parts are commonly sent as subsets or
-        /// scoped names, this increases the likelyhood of a successful
-        /// string mapping.
-        /// </remarks>
-        /// <returns>
-        /// <c>true</c> if the string was added to the mapping for the first
-        /// time, <c>false</c> otherwise.
-        /// </returns>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if the string is not normalized (<see cref="String.IsNormalized()"/>).
-        /// </exception>
-        public bool AddString(string str)
-        {
-            if (LockMappedStrings)
-            {
-                if (_net!.IsClient)
-                {
-                    //LogSzr.Debug("On client and mapped strings are locked, will not add.");
-                    return false;
-                }
-
-                //throw new InvalidOperationException("Mapped strings are locked, will not add.");
-                LogSzr.Debug("On server and mapped strings are locked, will not add.");
-                return false;
-            }
-
-            if (String.IsNullOrEmpty(str))
-            {
-                return false;
-            }
-
-            if (!str.IsNormalized())
-            {
-                throw new InvalidOperationException("Only normalized strings may be added.");
-            }
-
-            if (_stringMapping.ContainsKey(str))
-            {
-                return false;
-            }
-
-            if (str.Length >= MaxMappedStringSize) return false;
-
-            if (str.Length <= MinMappedStringSize) return false;
-
-            str = str.Trim();
-
-            if (str.Length <= MinMappedStringSize) return false;
-
-            str = str.Replace(Environment.NewLine, "\n");
-
-            if (str.Length <= MinMappedStringSize) return false;
-
-            var symTrimmedStr = str.Trim(TrimmableSymbolChars);
-            if (symTrimmedStr != str)
-            {
-                AddString(symTrimmedStr);
-            }
-
-            if (str.Contains('/'))
-            {
-                var parts = str.Split('/', StringSplitOptions.RemoveEmptyEntries);
-                for (var i = 0; i < parts.Length; ++i)
-                {
-                    for (var l = 1; l <= parts.Length - i; ++l)
-                    {
-                        var subStr = String.Join('/', parts.Skip(i).Take(l));
-                        if (_stringMapping.TryAdd(subStr, _mappedStrings.Count))
-                        {
-                            _mappedStrings.Add(subStr);
-                        }
-
-                        if (!subStr.Contains('.'))
-                        {
-                            continue;
-                        }
-
-                        var subParts = subStr.Split('.', StringSplitOptions.RemoveEmptyEntries);
-                        for (var si = 0; si < subParts.Length; ++si)
-                        {
-                            for (var sl = 1; sl <= subParts.Length - si; ++sl)
-                            {
-                                var subSubStr = String.Join('.', subParts.Skip(si).Take(sl));
-                                // ReSharper disable once InvertIf
-                                if (_stringMapping.TryAdd(subSubStr, _mappedStrings.Count))
-                                {
-                                    _mappedStrings.Add(subSubStr);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            else if (str.Contains("_"))
-            {
-                foreach (var substr in str.Split("_"))
-                {
-                    AddString(substr);
-                }
-            }
-            else if (str.Contains(" "))
-            {
-                foreach (var substr in str.Split(" "))
-                {
-                    if (substr == str) continue;
-
-                    AddString(substr);
-                }
-            }
-            else
-            {
-                var parts = _rxSymbolSplitter.Split(str);
-                foreach (var substr in parts)
-                {
-                    if (substr == str) continue;
-
-                    AddString(substr);
-                }
-
-                for (var si = 0; si < parts.Length; ++si)
-                {
-                    for (var sl = 1; sl <= parts.Length - si; ++sl)
-                    {
-                        var subSubStr = String.Concat(parts.Skip(si).Take(sl));
-                        if (_stringMapping.TryAdd(subSubStr, _mappedStrings.Count))
-                        {
-                            _mappedStrings.Add(subSubStr);
-                        }
-                    }
-                }
-            }
-
-            if (_stringMapping.TryAdd(str, _mappedStrings.Count))
-            {
-                _mappedStrings.Add(str);
-            }
-
-            _stringMapHash = null;
-            _mappedStringsPackage = null;
-            return true;
-        }
-
-        /// <summary>
-        /// Add the constant strings from an <see cref="Assembly"/> to the
-        /// mapping.
-        /// </summary>
-        /// <param name="asm">The assembly from which to collect constant strings.</param>
-        [MethodImpl(MethodImplOptions.Synchronized)]
-        public unsafe void AddStrings(Assembly asm)
-        {
-            if (LockMappedStrings)
-            {
-                if (_net!.IsClient)
-                {
-                    //LogSzr.Debug("On client and mapped strings are locked, will not add.");
-                    return;
-                }
-
-                //throw new InvalidOperationException("Mapped strings are locked, will not add .");
-                LogSzr.Debug("On server and mapped strings are locked, will not add.");
-                return;
-            }
-
-            var started = MappedStrings.Count;
-            var sw = Stopwatch.StartNew();
-            if (asm.TryGetRawMetadata(out var blob, out var len))
-            {
-                var reader = new MetadataReader(blob, len);
-                var usrStrHandle = default(UserStringHandle);
-                do
-                {
-                    var userStr = reader.GetUserString(usrStrHandle);
-                    if (userStr != "")
-                    {
-                        AddString(String.Intern(userStr.Normalize()));
-                    }
-
-                    usrStrHandle = reader.GetNextHandle(usrStrHandle);
-                } while (usrStrHandle != default);
-
-                var strHandle = default(StringHandle);
-                do
-                {
-                    var str = reader.GetString(strHandle);
-                    if (str != "")
-                    {
-                        AddString(String.Intern(str.Normalize()));
-                    }
-
-                    strHandle = reader.GetNextHandle(strHandle);
-                } while (strHandle != default);
-            }
-
-            var added = MappedStrings.Count - started;
-            LogSzr.Debug($"Mapping {added} strings from {asm.GetName().Name} took {sw.ElapsedMilliseconds}ms.");
-        }
-
-        /// <summary>
-        /// Add strings from the given <see cref="YamlStream"/> to the mapping.
-        /// </summary>
-        /// <remarks>
-        /// Strings are taken from YAML anchors, tags, and leaf nodes.
-        /// </remarks>
-        /// <param name="yaml">The YAML to collect strings from.</param>
-        /// <param name="name">The stream name. Only used for logging.</param>
-        [MethodImpl(MethodImplOptions.Synchronized)]
-        public void AddStrings(YamlStream yaml, string name)
-        {
-            if (LockMappedStrings)
-            {
-                if (_net!.IsClient)
-                {
-                    //LogSzr.Debug("On client and mapped strings are locked, will not add.");
-                    return;
-                }
-
-                //throw new InvalidOperationException("Mapped strings are locked, will not add.");
-                LogSzr.Debug("On server and mapped strings are locked, will not add.");
-                return;
-            }
-
-            var started = MappedStrings.Count;
-            var sw = Stopwatch.StartNew();
-            foreach (var doc in yaml)
-            {
-                foreach (var node in doc.AllNodes)
-                {
-                    var a = node.Anchor;
-                    if (!String.IsNullOrEmpty(a))
-                    {
-                        AddString(a);
-                    }
-
-                    var t = node.Tag;
-                    if (!String.IsNullOrEmpty(t))
-                    {
-                        AddString(t);
-                    }
-
-                    switch (node)
-                    {
-                        case YamlScalarNode scalar:
-                        {
-                            var v = scalar.Value;
-                            if (String.IsNullOrEmpty(v))
-                            {
-                                continue;
-                            }
-
-                            AddString(v);
-                            break;
-                        }
-                    }
-                }
-            }
-
-            var added = MappedStrings.Count - started;
-            LogSzr.Debug($"Mapping {added} strings from {name} took {sw.ElapsedMilliseconds}ms.");
-        }
-
-        /// <summary>
-        /// Add strings from the given <see cref="JObject"/> to the mapping.
-        /// </summary>
-        /// <remarks>
-        /// Strings are taken from JSON property names and string nodes.
-        /// </remarks>
-        /// <param name="obj">The JSON to collect strings from.</param>
-        /// <param name="name">The stream name. Only used for logging.</param>
-        public void AddStrings(JObject obj, string name)
-        {
-            if (LockMappedStrings)
-            {
-                if (_net!.IsClient)
-                {
-                    //LogSzr.Debug("On client and mapped strings are locked, will not add.");
-                    return;
-                }
-
-                //throw new InvalidOperationException("Mapped strings are locked, will not add.");
-                LogSzr.Debug("On server and mapped strings are locked, will not add.");
-                return;
-            }
-
-            var started = MappedStrings.Count;
-            var sw = Stopwatch.StartNew();
-            foreach (var node in obj.DescendantsAndSelf())
-            {
-                switch (node)
-                {
-                    case JValue value:
-                    {
-                        if (value.Type != JTokenType.String)
-                        {
-                            continue;
-                        }
-
-                        var v = value.Value?.ToString();
-                        if (String.IsNullOrEmpty(v))
-                        {
-                            continue;
-                        }
-
-                        AddString(v);
-                        break;
-                    }
-                    case JProperty prop:
-                    {
-                        var propName = prop.Name;
-                        if (String.IsNullOrEmpty(propName))
-                        {
-                            continue;
-                        }
-
-                        AddString(propName);
-                        break;
-                    }
-                }
-            }
-
-            var added = MappedStrings.Count - started;
-            LogSzr.Debug($"Mapping {added} strings from {name} took {sw.ElapsedMilliseconds}ms.");
-        }
-
-        /// <summary>
-        /// Remove all strings from the mapping, completely resetting it.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if the mapping is locked.
-        /// </exception>
-        public void ClearStrings()
-        {
-            if (LockMappedStrings)
-            {
-                throw new InvalidOperationException("Mapped strings are locked, will not clear.");
-            }
-
-            _mappedStrings.Clear();
-            _stringMapping.Clear();
-            _stringMapHash = null;
-        }
-
-        /// <summary>
-        /// Add strings from the given enumeration to the mapping.
-        /// </summary>
-        /// <param name="strings">The strings to add.</param>
-        /// <param name="providerName">The source provider of the strings to be logged.</param>
-        [MethodImpl(MethodImplOptions.Synchronized)]
-        public void AddStrings(IEnumerable<string> strings, string providerName)
-        {
-            if (LockMappedStrings)
-            {
-                if (_net!.IsClient)
-                {
-                    //LogSzr.Debug("On client and mapped strings are locked, will not add.");
-                    return;
-                }
-
-                //throw new InvalidOperationException("Mapped strings are locked, will not add.");
-                LogSzr.Debug("On server and mapped strings are locked, will not add.");
-                return;
-            }
-
-            var started = MappedStrings.Count;
-            foreach (var str in strings)
-            {
-                AddString(str);
-            }
-
-            var added = MappedStrings.Count - started;
-            LogSzr.Debug($"Mapping {added} strings from {providerName}.");
-        }
-
-        private byte[]? _stringMapHash;
-
-        /// <value>
-        /// The hash of the string mapping.
-        /// </value>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if the mapping is not locked.
-        /// </exception>
-        public byte[] MappedStringsHash => _stringMapHash ??= CalculateMappedStringsHash();
-
-        private byte[] CalculateMappedStringsHash()
-        {
-            if (!LockMappedStrings)
-            {
-                throw new InvalidOperationException("String table should be locked before attempting to retrieve hash.");
-            }
-
-            var sw = Stopwatch.StartNew();
-
-            var hash = CalculateHash(MappedStringsPackage);
-
-            LogSzr.Debug($"Hashing {MappedStrings.Count} strings took {sw.ElapsedMilliseconds}ms.");
-            LogSzr.Debug($"Size: {MappedStringsPackage.Length} bytes, Hash: {ConvertToBase64Url(hash)}");
-            return hash;
-        }
-
-        /// <summary>
-        /// Creates a SHA512 hash of the given array of bytes.
-        /// </summary>
-        /// <param name="data">An array of bytes to be hashed.</param>
-        /// <returns>A 512-bit (64-byte) hash result as an array of bytes.</returns>
-        /// <exception cref="ArgumentNullException"></exception>
-        private byte[] CalculateHash(byte[] data)
-        {
-            if (data is null)
-            {
-                throw new ArgumentNullException(nameof(data));
-            }
-
-            using var hasher = SHA512.Create();
-            var hash = hasher.ComputeHash(data);
-            return hash;
-        }
-
-        /// <summary>
-        /// Implements <see cref="ITypeSerializer.Handles"/>.
-        /// Specifies that this implementation handles strings.
-        /// </summary>
-        public bool Handles(Type type) => type == typeof(string);
-
-        /// <summary>
-        /// Implements <see cref="ITypeSerializer.GetSubtypes"/>.
-        /// </summary>
-        public IEnumerable<Type> GetSubtypes(Type type) => Type.EmptyTypes;
-
-        /// <summary>
-        /// Implements <see cref="IStaticTypeSerializer.GetStaticWriter"/>.
-        /// </summary>
-        /// <seealso cref="WriteMappedString"/>
-        public MethodInfo GetStaticWriter(Type type) => WriteMappedStringMethodInfo;
-
-        /// <summary>
-        /// Implements <see cref="IStaticTypeSerializer.GetStaticReader"/>.
-        /// </summary>
-        /// <seealso cref="ReadMappedString"/>
-        public MethodInfo GetStaticReader(Type type) => ReadMappedStringMethodInfo;
-
         private delegate void WriteStringDelegate(Stream stream, string? value);
 
         private delegate void ReadStringDelegate(Stream stream, out string? value);
@@ -1132,6 +98,526 @@ namespace Robust.Shared.Serialization
         /// </remarks>
         private const int FirstMappedIndexStart = 2;
 
+        private static readonly HashAlgorithmName PackHashAlgo = HashAlgorithmName.SHA512;
+
+        [IoC.Dependency] private readonly INetManager _net = default!;
+
+        // I don't want to create 50 line changes in this commit so...
+        // ReSharper disable once InconsistentNaming
+        private ISawmill LogSzr = default!;
+
+        private MappedStringDict _dict = default!;
+
+        private readonly HashSet<INetChannel> _incompleteHandshakes = new HashSet<INetChannel>();
+
+        private byte[]? _mappedStringsPackage;
+        private byte[]? _serverHash;
+        private byte[]? _stringMapHash;
+
+        /// <value>
+        /// The hash of the string mapping.
+        /// </value>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the mapping is not locked.
+        /// </exception>
+        public ReadOnlySpan<byte> MappedStringsHash => _stringMapHash;
+
+        private static readonly Regex RxSymbolSplitter
+            = new Regex(
+                @"(?<=[^\s\W])(?=[A-Z]) # Match for split at start of new capital letter
+                            |(?<=[^0-9\s\W])(?=[0-9]) # Match for split before spans of numbers
+                            |(?<=[A-Za-z0-9])(?=_) # Match for a split before an underscore
+                            |(?=[.\\\/,#$?!@|&*()^`""'`~[\]{}:;\-]) # Match for a split after symbols
+                            |(?<=[.\\\/,#$?!@|&*()^`""'`~[\]{}:;\-]) # Match for a split before symbols too",
+                RegexOptions.CultureInvariant
+                | RegexOptions.Compiled
+                | RegexOptions.IgnorePatternWhitespace
+            );
+
+
+        /// <summary>
+        /// Starts the handshake from the server end of the given channel,
+        /// sending a <see cref="MsgMapStrServerHandshake"/>.
+        /// </summary>
+        /// <param name="channel">The network channel to perform the handshake over.</param>
+        /// <remarks>
+        /// Locks the string mapping if this is the first time the server is
+        /// performing the handshake.
+        /// </remarks>
+        /// <seealso cref="MsgMapStrClientHandshake"/>
+        /// <seealso cref="MsgMapStrStrings"/>
+        public async Task Handshake(INetChannel channel)
+        {
+            DebugTools.Assert(_net.IsServer);
+            DebugTools.Assert(_dict.Locked);
+
+            _incompleteHandshakes.Add(channel);
+
+            var message = _net.CreateNetMessage<MsgMapStrServerHandshake>();
+            message.Hash = _stringMapHash;
+            _net.ServerSendMessage(message, channel);
+
+            while (_incompleteHandshakes.Contains(channel))
+            {
+                await Task.Delay(1);
+            }
+
+            LogSzr.Debug($"Completed handshake with {channel.RemoteEndPoint.Address}.");
+        }
+
+        /// <summary>
+        /// Performs the setup so that the serializer can perform the string-
+        /// exchange protocol.
+        /// </summary>
+        /// <remarks>
+        /// The string-exchange protocol is started by the server when the
+        /// client first connects. The server sends the client a hash of the
+        /// string mapping; the client checks that hash against any local
+        /// caches; and if necessary, the client requests a new copy of the
+        /// mapping from the server.
+        ///
+        /// Uncached flow: <code>
+        /// Client      |      Server
+        /// | &lt;-------------- Hash |
+        /// | Need Strings ------&gt; |
+        /// | &lt;----------- Strings |
+        /// | Dont Need Strings -&gt; |
+        /// </code>
+        ///
+        /// Cached flow: <code>
+        /// Client      |      Server
+        /// | &lt;-------------- Hash |
+        /// | Dont Need Strings -&gt; |
+        /// </code>
+        ///
+        /// Verification failure flow: <code>
+        /// Client      |      Server
+        /// | &lt;-------------- Hash |
+        /// | Need Strings ------&gt; |
+        /// | &lt;----------- Strings |
+        /// + Hash Failed          |
+        /// | Need Strings ------&gt; |
+        /// | &lt;----------- Strings |
+        /// | Dont Need Strings -&gt; |
+        ///  </code>
+        ///
+        /// NOTE: Verification failure flow is currently not implemented.
+        /// </remarks>
+        /// <param name="net">
+        /// The <see cref="INetManager"/> to perform the protocol steps over.
+        /// </param>
+        /// <seealso cref="MsgMapStrServerHandshake"/>
+        /// <seealso cref="MsgMapStrClientHandshake"/>
+        /// <seealso cref="MsgMapStrStrings"/>
+        /// <seealso cref="HandleServerHandshake"/>
+        /// <seealso cref="HandleClientHandshake"/>
+        /// <seealso cref="HandleStringsMessage"/>
+        /// <seealso cref="OnClientCompleteHandshake"/>
+        private void NetworkInitialize()
+        {
+            _net.RegisterNetMessage<MsgMapStrServerHandshake>(nameof(MsgMapStrServerHandshake), HandleServerHandshake);
+            _net.RegisterNetMessage<MsgMapStrClientHandshake>(nameof(MsgMapStrClientHandshake), HandleClientHandshake);
+            _net.RegisterNetMessage<MsgMapStrStrings>(nameof(MsgMapStrStrings), HandleStringsMessage);
+        }
+
+        /// <summary>
+        /// Handles the reception, verification of a strings package
+        /// and subsequent mapping of strings and initiator of
+        /// receipt response.
+        ///
+        /// Uncached flow: <code>
+        /// Client      |      Server
+        /// | &lt;-------------- Hash |
+        /// | Need Strings ------&gt; |
+        /// | &lt;----------- Strings |
+        /// | Dont Need Strings -&gt; | &lt;- you are here on client
+        ///
+        /// Verification failure flow: <code>
+        /// Client      |      Server
+        /// | &lt;-------------- Hash |
+        /// | Need Strings ------&gt; |
+        /// | &lt;----------- Strings |
+        /// + Hash Failed          | &lt;- you are here on client
+        /// | Need Strings ------&gt; |
+        /// | &lt;----------- Strings |
+        /// | Dont Need Strings -&gt; | &lt;- you are here on client
+        ///  </code>
+        ///
+        /// NOTE: Verification failure flow is currently not implemented.
+        /// </code>
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Unable to verify strings package by hash.</exception>
+        /// <seealso cref="NetworkInitialize"/>
+        private void HandleStringsMessage(MsgMapStrStrings msg)
+        {
+            if (_net.IsServer)
+            {
+                // Reason should show up on disconnect logs.
+                msg.MsgChannel.Disconnect("MsgMapStrStrings sent to server.");
+                return;
+            }
+
+            DebugTools.AssertNotNull(msg.Package);
+            DebugTools.AssertNotNull(_serverHash);
+
+            var packageStream = new MemoryStream(msg.Package!, false);
+            _dict.LoadFromPackage(packageStream, out var hash);
+
+            if (!hash.SequenceEqual(_serverHash!))
+            {
+                // TODO: retry sending MsgClientHandshake with NeedsStrings = false
+                throw new InvalidOperationException("Unable to verify strings package by hash." +
+                                                    $"\n{ConvertToBase64Url(hash)} vs. {ConvertToBase64Url(_serverHash)}");
+            }
+
+            _stringMapHash = _serverHash;
+
+            LogSzr.Debug($"Locked in at {_dict.StringCount} mapped strings.");
+
+            packageStream.Position = 0;
+            WriteStringCache(packageStream);
+
+            // ok we're good now
+            var channel = msg.MsgChannel;
+            OnClientCompleteHandshake(_net, channel);
+        }
+
+        /// <summary>
+        /// Interpret a client's handshake, either sending a package
+        /// of strings or completing the handshake.
+        ///
+        /// Uncached flow: <code>
+        /// Client      |      Server
+        /// | &lt;-------------- Hash |
+        /// | Need Strings ------&gt; | &lt;- you are here on server
+        /// | &lt;----------- Strings |
+        /// | Dont Need Strings -&gt; | &lt;- you are here on server
+        /// </code>
+        ///
+        /// Cached flow: <code>
+        /// Client      |      Server
+        /// | &lt;-------------- Hash |
+        /// | Dont Need Strings -&gt; | &lt;- you are here on server
+        /// </code>
+        ///
+        /// Verification failure flow: <code>
+        /// Client      |      Server
+        /// | &lt;-------------- Hash |
+        /// | Need Strings ------&gt; | &lt;- you are here on server
+        /// | &lt;----------- Strings |
+        /// + Hash Failed          |
+        /// | Need Strings ------&gt; | &lt;- you are here on server
+        /// | &lt;----------- Strings |
+        /// | Dont Need Strings -&gt; |
+        ///  </code>
+        ///
+        /// NOTE: Verification failure flow is currently not implemented.
+        /// </summary>
+        /// <seealso cref="NetworkInitialize"/>
+        private void HandleClientHandshake(MsgMapStrClientHandshake msgMapStr)
+        {
+            DebugTools.Assert(_net.IsServer);
+            DebugTools.Assert(_dict.Locked);
+
+            LogSzr.Debug($"Received handshake from {msgMapStr.MsgChannel.RemoteEndPoint.Address}.");
+
+            if (!msgMapStr.NeedsStrings)
+            {
+                LogSzr.Debug($"Completing handshake with {msgMapStr.MsgChannel.RemoteEndPoint.Address}.");
+                _incompleteHandshakes.Remove(msgMapStr.MsgChannel);
+                return;
+            }
+
+            // TODO: count and limit number of requests to send strings during handshake
+
+            var strings = _net.CreateNetMessage<MsgMapStrStrings>();
+            strings.Package = _mappedStringsPackage;
+            LogSzr.Debug(
+                $"Sending {_mappedStringsPackage!.Length} bytes sized mapped strings package to {msgMapStr.MsgChannel.SessionId}.");
+
+            _net.ServerSendMessage(strings, msgMapStr.MsgChannel);
+        }
+
+        /// <summary>
+        /// Interpret a server's handshake, either requesting a package
+        /// of strings or completing the handshake.
+        ///
+        /// Uncached flow: <code>
+        /// Client      |      Server
+        /// | &lt;-------------- Hash | &lt;- you are here on client
+        /// | Need Strings ------&gt; |
+        /// | &lt;----------- Strings |
+        /// | Dont Need Strings -&gt; |
+        /// </code>
+        ///
+        /// Cached flow: <code>
+        /// Client      |      Server
+        /// | &lt;-------------- Hash | &lt;- you are here on client
+        /// | Dont Need Strings -&gt; |
+        /// </code>
+        ///
+        /// Verification failure flow: <code>
+        /// Client      |      Server
+        /// | &lt;-------------- Hash | &lt;- you are here on client
+        /// | Need Strings ------&gt; |
+        /// | &lt;----------- Strings |
+        /// + Hash Failed          |
+        /// | Need Strings ------&gt; |
+        /// | &lt;----------- Strings |
+        /// | Dont Need Strings -&gt; |
+        ///  </code>
+        ///
+        /// NOTE: Verification failure flow is currently not implemented.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Mapped strings are locked.</exception>
+        /// <seealso cref="NetworkInitialize"/>
+        private void HandleServerHandshake(MsgMapStrServerHandshake msgMapStr)
+        {
+            if (_net.IsServer)
+            {
+                LogSzr.Error("Received server handshake on server.");
+                return;
+            }
+
+            _serverHash = msgMapStr.Hash;
+
+            var hashStr = ConvertToBase64Url(msgMapStr.Hash!);
+
+            LogSzr.Debug($"Received server handshake with hash {hashStr}.");
+
+            var fileName = CacheForHash(hashStr);
+            if (!File.Exists(fileName))
+            {
+                LogSzr.Debug($"No string cache for {hashStr}.");
+                var handshake = _net.CreateNetMessage<MsgMapStrClientHandshake>();
+                LogSzr.Debug("Asking server to send mapped strings.");
+                handshake.NeedsStrings = true;
+                msgMapStr.MsgChannel.SendMessage(handshake);
+            }
+            else
+            {
+                LogSzr.Debug($"We had a cached string map that matches {hashStr}.");
+                using var file = File.OpenRead(fileName);
+                var added = _dict.LoadFromPackage(file, out _);
+
+                _stringMapHash = msgMapStr.Hash!;
+                LogSzr.Debug($"Read {added} strings from cache {hashStr}.");
+                LogSzr.Debug($"Locked in at {_dict.StringCount} mapped strings.");
+                // ok we're good now
+                var channel = msgMapStr.MsgChannel;
+                OnClientCompleteHandshake(_net, channel);
+            }
+        }
+
+        /// <summary>
+        /// Inform the server that the client has a complete copy of the
+        /// mapping, and alert other code that the handshake is over.
+        /// </summary>
+        /// <seealso cref="ClientHandshakeComplete"/>
+        /// <seealso cref="NetworkInitialize"/>
+        private void OnClientCompleteHandshake(INetManager net, INetChannel channel)
+        {
+            LogSzr.Debug("Letting server know we're good to go.");
+            var handshake = net.CreateNetMessage<MsgMapStrClientHandshake>();
+            handshake.NeedsStrings = false;
+            channel.SendMessage(handshake);
+
+            if (ClientHandshakeComplete == null)
+            {
+                LogSzr.Warning("There's no handler attached to ClientHandshakeComplete.");
+            }
+
+            ClientHandshakeComplete?.Invoke();
+        }
+
+        /// <summary>
+        /// Gets the cache file associated with the given hash.
+        /// </summary>
+        /// <param name="hashStr">The hash to look up the cache for.</param>
+        /// <returns>
+        /// The filename where the cache for the given hash would be. The
+        /// file itself may or may not exist. If it does not exist, no cache
+        /// was made for the given hash.
+        /// </returns>
+        private static string CacheForHash(string hashStr)
+        {
+            return PathHelpers.ExecutableRelativeFile($"strings-{hashStr}");
+        }
+
+        /// <summary>
+        ///  Saves the string cache to a file based on it's hash.
+        /// </summary>
+        private void WriteStringCache(Stream stream)
+        {
+            var hashStr = Convert.ToBase64String(MappedStringsHash);
+            hashStr = ConvertToBase64Url(hashStr);
+
+            var fileName = CacheForHash(hashStr);
+            using var file = File.OpenWrite(fileName);
+            stream.CopyTo(file);
+
+            LogSzr.Debug($"Wrote string cache {hashStr}.");
+        }
+
+        /// <summary>
+        /// Converts a byte array such as a hash to a Base64 representation that is URL safe.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns>A base64url string form of the byte array.</returns>
+        private static string ConvertToBase64Url(byte[]? data)
+        {
+            return data == null ? "" : ConvertToBase64Url(Convert.ToBase64String(data));
+        }
+
+        /// <summary>
+        /// Converts a a Base64 string to one that is URL safe.
+        /// </summary>
+        /// <returns>A base64url formed string.</returns>
+        private static string ConvertToBase64Url(string b64Str)
+        {
+            if (b64Str is null)
+            {
+                throw new ArgumentNullException(nameof(b64Str));
+            }
+
+            var cut = b64Str[^1] == '=' ? b64Str[^2] == '=' ? 2 : 1 : 0;
+            b64Str = new StringBuilder(b64Str).Replace('+', '-').Replace('/', '_').ToString(0, b64Str.Length - cut);
+            return b64Str;
+        }
+
+        /// <summary>
+        /// Converts a URL-safe Base64 string into a byte array.
+        /// </summary>
+        /// <param name="s">A base64url formed string.</param>
+        /// <returns>The represented byte array.</returns>
+        public byte[] ConvertFromBase64Url(string s)
+        {
+            var l = s.Length % 3;
+            var sb = new StringBuilder(s);
+            sb.Replace('-', '+').Replace('_', '/');
+            for (var i = 0; i < l; ++i)
+            {
+                sb.Append('=');
+            }
+
+            s = sb.ToString();
+            return Convert.FromBase64String(s);
+        }
+
+        /// <summary>
+        /// Add a string to the constant mapping.
+        /// </summary>
+        /// <remarks>
+        /// If the string has multiple detectable subcomponents, such as a
+        /// filepath, it may result in more than one string being added to
+        /// the mapping. As string parts are commonly sent as subsets or
+        /// scoped names, this increases the likelyhood of a successful
+        /// string mapping.
+        /// </remarks>
+        /// <returns>
+        /// <c>true</c> if the string was added to the mapping for the first
+        /// time, <c>false</c> otherwise.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the string is not normalized (<see cref="String.IsNormalized()"/>).
+        /// </exception>
+        public void AddString(string str)
+        {
+            if (!_net.IsClient)
+            {
+                _dict.AddSingleString(str);
+            }
+        }
+
+        /// <summary>
+        /// Add the constant strings from an <see cref="Assembly"/> to the
+        /// mapping.
+        /// </summary>
+        /// <param name="asm">The assembly from which to collect constant strings.</param>
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public void AddStrings(Assembly asm)
+        {
+            if (!_net.IsClient)
+            {
+                _dict.AddStrings(asm);
+            }
+        }
+
+        /// <summary>
+        /// Add strings from the given <see cref="YamlStream"/> to the mapping.
+        /// </summary>
+        /// <remarks>
+        /// Strings are taken from YAML anchors, tags, and leaf nodes.
+        /// </remarks>
+        /// <param name="yaml">The YAML to collect strings from.</param>
+        /// <param name="name">The stream name. Only used for logging.</param>
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public void AddStrings(YamlStream yaml, string name)
+        {
+            if (!_net.IsClient)
+            {
+                _dict.AddStrings(yaml, name);
+            }
+        }
+
+        /// <summary>
+        /// Add strings from the given <see cref="JObject"/> to the mapping.
+        /// </summary>
+        /// <remarks>
+        /// Strings are taken from JSON property names and string nodes.
+        /// </remarks>
+        /// <param name="obj">The JSON to collect strings from.</param>
+        /// <param name="name">The stream name. Only used for logging.</param>
+        public void AddStrings(JObject obj, string name)
+        {
+            if (!_net.IsClient)
+            {
+                _dict.AddStrings(obj, name);
+            }
+        }
+
+        /// <summary>
+        /// Add strings from the given enumeration to the mapping.
+        /// </summary>
+        /// <param name="strings">The strings to add.</param>
+        /// <param name="providerName">The source provider of the strings to be logged.</param>
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public void AddStrings(IEnumerable<string> strings, string providerName)
+        {
+            if (!_net.IsClient)
+            {
+                _dict.AddStrings(strings, providerName);
+            }
+        }
+
+        /// <summary>
+        /// Implements <see cref="ITypeSerializer.Handles"/>.
+        /// Specifies that this implementation handles strings.
+        /// </summary>
+        bool ITypeSerializer.Handles(Type type) => type == typeof(string);
+
+        /// <summary>
+        /// Implements <see cref="ITypeSerializer.GetSubtypes"/>.
+        /// </summary>
+        IEnumerable<Type> ITypeSerializer.GetSubtypes(Type type) => Type.EmptyTypes;
+
+        /// <summary>
+        /// Implements <see cref="IStaticTypeSerializer.GetStaticWriter"/>.
+        /// </summary>
+        /// <seealso cref="WriteMappedString"/>
+        MethodInfo IStaticTypeSerializer.GetStaticWriter(Type type)
+        {
+            return WriteMappedStringMethodInfo;
+        }
+
+        /// <summary>
+        /// Implements <see cref="IStaticTypeSerializer.GetStaticReader"/>.
+        /// </summary>
+        /// <seealso cref="ReadMappedString"/>
+        MethodInfo IStaticTypeSerializer.GetStaticReader(Type type)
+        {
+            return ReadMappedStringMethodInfo;
+        }
 
         /// <summary>
         /// Write the encoding of the given string to the stream.
@@ -1139,49 +625,11 @@ namespace Robust.Shared.Serialization
         /// </summary>
         /// <param name="stream">The stream to write to.</param>
         /// <param name="value"> The (possibly null) string to write.</param>
-        public static void StaticWriteMappedString(Stream stream, string? value)
+        private static void StaticWriteMappedString(Stream stream, string? value)
         {
-            var mss = IoCManager.Resolve<IRobustMappedStringSerializer>();
-            mss.WriteMappedString(stream, value);
+            var mss = IoCManager.Resolve<RobustMappedStringSerializer>();
+            mss._dict.WriteMappedString(stream, value);
         }
-
-        /// <summary>
-        /// Write the encoding of the given string to the stream.
-        /// </summary>
-        /// <param name="stream">The stream to write to.</param>
-        /// <param name="value"> The (possibly null) string to write.</param>
-        public void WriteMappedString(Stream stream, string? value)
-        {
-            if (!LockMappedStrings)
-            {
-                LogSzr.Warning("Performing unlocked string mapping.");
-            }
-
-            if (value == null)
-            {
-                WriteCompressedUnsignedInt(stream, MappedNull);
-                return;
-            }
-
-            if (_stringMapping.TryGetValue(value, out var mapping))
-            {
-#if DEBUG
-                if (mapping >= _mappedStrings.Count || mapping < 0)
-                {
-                    throw new InvalidOperationException("A string mapping outside of the mapped string table was encountered.");
-                }
-#endif
-                WriteCompressedUnsignedInt(stream, (uint) mapping + FirstMappedIndexStart);
-                //Logger.DebugS("szr", $"Encoded mapped string: {value}");
-                return;
-            }
-
-            // indicate not mapped
-            WriteCompressedUnsignedInt(stream, UnmappedString);
-
-            Primitives.WritePrimitive(stream, value);
-        }
-
         /// <summary>
         /// Try to read a string from the given stream.
         /// Static form of <see cref="ReadMappedString"/> for use by <see cref="NetSerializer"/>.
@@ -1191,43 +639,10 @@ namespace Robust.Shared.Serialization
         /// <exception cref="InvalidOperationException">
         /// Thrown if the mapping is not locked.
         /// </exception>
-        public static void StaticReadMappedString(Stream stream, out string? value)
+        private static void StaticReadMappedString(Stream stream, out string? value)
         {
-            var mss = IoCManager.Resolve<IRobustMappedStringSerializer>();
-            mss.ReadMappedString(stream, out value);
-        }
-
-        /// <summary>
-        /// Try to read a string from the given stream.
-        /// </summary>
-        /// <param name="stream">The stream to read from.</param>
-        /// <param name="value"> The (possibly null) string read.</param>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if the mapping is not locked.
-        /// </exception>
-        public void ReadMappedString(Stream stream, out string? value)
-        {
-            if (!LockMappedStrings)
-            {
-                throw new InvalidOperationException("Not performing unlocked string mapping.");
-            }
-
-            var mapIndex = ReadCompressedUnsignedInt(stream, out _);
-            if (mapIndex == MappedNull)
-            {
-                value = null;
-                return;
-            }
-
-            if (mapIndex == UnmappedString)
-            {
-                // not mapped
-                Primitives.ReadPrimitive(stream, out value);
-                return;
-            }
-
-            value = _mappedStrings[(int) mapIndex - FirstMappedIndexStart];
-            //Logger.DebugS("szr", $"Decoded mapped string: {value}");
+            var mss = IoCManager.Resolve<RobustMappedStringSerializer>();
+            mss._dict.ReadMappedString(stream, out value);
         }
 
         // TODO: move the below methods to some stream helpers class
@@ -1306,10 +721,32 @@ namespace Robust.Shared.Serialization
         /// </summary>
         public event Action? ClientHandshakeComplete;
 
-        public void InitLogging()
+        public void LockStrings()
+        {
+            var sw = Stopwatch.StartNew();
+            _dict.FinalizeMapping();
+
+            LogSzr.Debug($"Finalized string mapping of size {_dict.StringCount} in {sw.ElapsedMilliseconds}ms");
+            sw.Restart();
+
+            (_stringMapHash, _mappedStringsPackage) = _dict.GeneratePackage();
+
+            LogSzr.Debug($"Wrote string package in {sw.ElapsedMilliseconds}ms");
+            LogSzr.Debug($"String hash is {ConvertToBase64Url(_stringMapHash)}");
+        }
+
+        public void Initialize()
         {
             LogSzr = Logger.GetSawmill("szr");
+            _dict = new MappedStringDict(LogSzr);
+
+            if (_net.IsClient)
+            {
+                // Client cannot make its own string dictionaries, lock immediately.
+                _dict.Locked = true;
+            }
+
+            NetworkInitialize();
         }
     }
-
 }

--- a/Robust.Shared/Serialization/RobustSerializer.cs
+++ b/Robust.Shared/Serialization/RobustSerializer.cs
@@ -19,7 +19,7 @@ namespace Robust.Shared.Serialization
     {
         [Dependency] private readonly IReflectionManager _reflectionManager = default!;
         [Dependency] private readonly INetManager _netManager = default!;
-        [Dependency] private readonly RobustMappedStringSerializer _mappedStringSerializer = default!;
+        [Dependency] private readonly IRobustMappedStringSerializer _mappedStringSerializer = default!;
 
         private readonly Lazy<ISawmill> _lazyLogSzr = new Lazy<ISawmill>(() => Logger.GetSawmill("szr"));
 
@@ -82,7 +82,7 @@ namespace Robust.Shared.Serialization
 
             var settings = new Settings
             {
-                CustomTypeSerializers = new ITypeSerializer[] {_mappedStringSerializer}
+                CustomTypeSerializers = new[] {_mappedStringSerializer.TypeSerializer}
             };
             _serializer = new Serializer(types, settings);
             _serializableTypes = new HashSet<Type>(_serializer.GetTypeMap().Keys);

--- a/Robust.Shared/Serialization/RobustSerializer.cs
+++ b/Robust.Shared/Serialization/RobustSerializer.cs
@@ -17,9 +17,9 @@ namespace Robust.Shared.Serialization
 
     public partial class RobustSerializer : IRobustSerializer
     {
-
         [Dependency] private readonly IReflectionManager _reflectionManager = default!;
         [Dependency] private readonly INetManager _netManager = default!;
+        [Dependency] private readonly RobustMappedStringSerializer _mappedStringSerializer = default!;
 
         private readonly Lazy<ISawmill> _lazyLogSzr = new Lazy<ISawmill>(() => Logger.GetSawmill("szr"));
 
@@ -29,8 +29,6 @@ namespace Robust.Shared.Serialization
         private Serializer _serializer = default!;
 
         private HashSet<Type> _serializableTypes = default!;
-
-        private readonly RobustMappedStringSerializer _mappedStringSerializer = new RobustMappedStringSerializer();
 
         private static Type[] AlwaysNetSerializable => new[]
         {
@@ -61,8 +59,6 @@ namespace Robust.Shared.Serialization
 
         public void Initialize()
         {
-            IoCManager.RegisterInstance<IRobustMappedStringSerializer>(_mappedStringSerializer);
-
             var types = _reflectionManager.FindTypesWithAttribute<NetSerializableAttribute>().ToList();
 #if !FULL_RELEASE
             // confirm only shared types are marked for serialization, no client & server only types
@@ -82,7 +78,7 @@ namespace Robust.Shared.Serialization
 
             types.AddRange(AlwaysNetSerializable);
 
-            _mappedStringSerializer.InitLogging();
+            _mappedStringSerializer.Initialize();
 
             var settings = new Settings
             {
@@ -91,13 +87,6 @@ namespace Robust.Shared.Serialization
             _serializer = new Serializer(types, settings);
             _serializableTypes = new HashSet<Type>(_serializer.GetTypeMap().Keys);
             LogSzr.Info($"Serializer Types Hash: {_serializer.GetSHA256()}");
-
-            if (_netManager.IsClient)
-            {
-                _mappedStringSerializer.LockMappedStrings = true;
-            }
-
-            _mappedStringSerializer.NetworkInitialize(_netManager);
         }
 
         public void Serialize(Stream stream, object toSerialize)

--- a/Robust.Shared/SharedIoC.cs
+++ b/Robust.Shared/SharedIoC.cs
@@ -50,6 +50,8 @@ namespace Robust.Shared
             IoCManager.Register<ITimerManager, TimerManager>();
             IoCManager.Register<IRobustRandom, RobustRandom>();
             IoCManager.Register<ITextMacroFactory, TextMacroFactory>();
+            IoCManager.Register<IRobustMappedStringSerializer, RobustMappedStringSerializer>();
+            IoCManager.Register<RobustMappedStringSerializer, RobustMappedStringSerializer>();
         }
     }
 }

--- a/Robust.Shared/SharedIoC.cs
+++ b/Robust.Shared/SharedIoC.cs
@@ -51,7 +51,6 @@ namespace Robust.Shared
             IoCManager.Register<IRobustRandom, RobustRandom>();
             IoCManager.Register<ITextMacroFactory, TextMacroFactory>();
             IoCManager.Register<IRobustMappedStringSerializer, RobustMappedStringSerializer>();
-            IoCManager.Register<RobustMappedStringSerializer, RobustMappedStringSerializer>();
         }
     }
 }

--- a/Robust.Shared/Utility/Base64Helpers.cs
+++ b/Robust.Shared/Utility/Base64Helpers.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Text;
+
+namespace Robust.Shared.Utility
+{
+    internal static class Base64Helpers
+    {
+        /// <summary>
+        /// Converts a byte array such as a hash to a Base64 representation that is URL safe.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns>A base64url string form of the byte array.</returns>
+        public static string ConvertToBase64Url(byte[]? data)
+        {
+            return data == null ? "" : ConvertToBase64Url(Convert.ToBase64String(data));
+        }
+
+        /// <summary>
+        /// Converts a a Base64 string to one that is URL safe.
+        /// </summary>
+        /// <returns>A base64url formed string.</returns>
+        public static string ConvertToBase64Url(string b64Str)
+        {
+            if (b64Str is null)
+            {
+                throw new ArgumentNullException(nameof(b64Str));
+            }
+
+            var cut = b64Str[^1] == '=' ? b64Str[^2] == '=' ? 2 : 1 : 0;
+            b64Str = new StringBuilder(b64Str).Replace('+', '-').Replace('/', '_').ToString(0, b64Str.Length - cut);
+            return b64Str;
+        }
+
+        /// <summary>
+        /// Converts a URL-safe Base64 string into a byte array.
+        /// </summary>
+        /// <param name="s">A base64url formed string.</param>
+        /// <returns>The represented byte array.</returns>
+        public static byte[] ConvertFromBase64Url(string s)
+        {
+            var l = s.Length % 3;
+            var sb = new StringBuilder(s);
+            sb.Replace('-', '+').Replace('_', '/');
+            for (var i = 0; i < l; ++i)
+            {
+                sb.Append('=');
+            }
+
+            s = sb.ToString();
+            return Convert.FromBase64String(s);
+        }
+
+    }
+}

--- a/Robust.Shared/Utility/HasherStream.cs
+++ b/Robust.Shared/Utility/HasherStream.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+
+namespace Robust.Shared.Utility
+{
+    /// <summary>
+    ///     Stream that passes through data to/from another stream while running a <see cref="IncrementalHash"/> on it.
+    /// </summary>
+    internal sealed class HasherStream : Stream
+    {
+        private readonly Stream _wrapping;
+        private readonly IncrementalHash _hash;
+        private readonly bool _leaveOpen;
+
+        public HasherStream(Stream wrapping, IncrementalHash hash, bool leaveOpen=false)
+        {
+            _wrapping = wrapping;
+            _hash = hash;
+            _leaveOpen = leaveOpen;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!_leaveOpen)
+            {
+                _wrapping.Dispose();
+            }
+        }
+
+        public override ValueTask DisposeAsync()
+        {
+            if (!_leaveOpen)
+            {
+                return _wrapping.DisposeAsync();
+            }
+
+            return default;
+        }
+
+        public override void Flush()
+        {
+            _wrapping.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = _wrapping.Read(buffer, offset, count);
+
+            if (read > 0)
+            {
+                _hash.AppendData(buffer, offset, read);
+            }
+
+            return read;
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            var read = _wrapping.Read(buffer);
+
+            if (read > 0)
+            {
+                _hash.AppendData(buffer[..read]);
+            }
+
+            return read;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _hash.AppendData(buffer, offset, count);
+            _wrapping.Write(buffer, offset, count);
+        }
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            _hash.AppendData(buffer);
+            _wrapping.Write(buffer);
+        }
+
+        public override bool CanRead => _wrapping.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => _wrapping.CanWrite;
+        public override long Length => _wrapping.Length;
+
+        public override long Position
+        {
+            get => _wrapping.Position;
+            set => throw new NotSupportedException();
+        }
+    }
+}

--- a/Robust.Shared/Utility/HasherStream.cs
+++ b/Robust.Shared/Utility/HasherStream.cs
@@ -68,6 +68,14 @@ namespace Robust.Shared.Utility
             return read;
         }
 
+        public override int ReadByte()
+        {
+            Span<byte> span = stackalloc byte[1];
+            var read = Read(span);
+
+            return read == 0 ? -1 : span[0];
+        }
+
         public override long Seek(long offset, SeekOrigin origin)
         {
             throw new NotSupportedException();
@@ -88,6 +96,12 @@ namespace Robust.Shared.Utility
         {
             _hash.AppendData(buffer);
             _wrapping.Write(buffer);
+        }
+
+        public override void WriteByte(byte value)
+        {
+            Span<byte> span = stackalloc byte[] {value};
+            Write(span);
         }
 
         public override bool CanRead => _wrapping.CanRead;

--- a/Robust.UnitTesting/Shared/GameObjects/EntityState_Tests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityState_Tests.cs
@@ -36,6 +36,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             container.Register<INetManager, NetManager>();
             container.Register<IReflectionManager, ServerReflectionManager>();
             container.Register<IRobustSerializer, RobustSerializer>();
+            container.Register<IRobustMappedStringSerializer, RobustMappedStringSerializer>();
             container.BuildGraph();
 
             container.Resolve<IReflectionManager>().LoadAssemblies(AppDomain.CurrentDomain.GetAssemblyByName("Robust.Shared"));
@@ -46,6 +47,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
 
             var serializer = container.Resolve<IRobustSerializer>();
             serializer.Initialize();
+            IoCManager.Resolve<IRobustMappedStringSerializer>().LockStrings();
 
             byte[] array;
             using(var stream = new MemoryStream())


### PR DESCRIPTION
It's now deterministic independent of order, and also performs better (who knew that putting `Synchronized` on the method that takes a long amount of time and will be contended as hell could be bad for multithreaded performance?)

Fixes #1249 