### PR TITLE
GLES2 users, assemble!

### DIFF
--- a/Resources/Shaders/Internal/default-sprite.swsl
+++ b/Resources/Shaders/Internal/default-sprite.swsl
@@ -1,7 +1,7 @@
 
 
 void fragment() {
-    COLOR = texture(TEXTURE, UV);
+    COLOR = texture2D(TEXTURE, UV);
 }
 
 

--- a/Resources/Shaders/Internal/default-sprite.swsl
+++ b/Resources/Shaders/Internal/default-sprite.swsl
@@ -1,7 +1,7 @@
 
 
 void fragment() {
-    COLOR = texture2D(TEXTURE, UV);
+    COLOR = zTexture(UV);
 }
 
 

--- a/Resources/Shaders/Internal/depth-debug.swsl
+++ b/Resources/Shaders/Internal/depth-debug.swsl
@@ -24,6 +24,6 @@ void fragment()
     angle = mod(angle, 2.0 * PI);
     angle /= (PI * 2.0);
 
-    highp float val = texture2D(TEXTURE, vec2(angle, 0.5)).r / 8.0;
+    highp float val = zTexture(vec2(angle, 0.5)).r / 8.0;
     COLOR = vec4(vec3(toLinear(val)), 0.5);
 }

--- a/Resources/Shaders/Internal/depth-debug.swsl
+++ b/Resources/Shaders/Internal/depth-debug.swsl
@@ -1,10 +1,15 @@
-float toLinear(float sRGB)
+mediump float toLinear(mediump float sRGB)
 {
+    mediump float higher = pow((sRGB + 0.055)/1.055, 2.4);
+    mediump float lower = sRGB/12.92;
+#ifdef HAS_BOOL_MIX
     bool cutoff = sRGB < 0.04045;
-    float higher = pow((sRGB + 0.055)/1.055, 2.4);
-    float lower = sRGB/12.92;
-
     return mix(higher, lower, cutoff);
+#else
+    // Fake it; this is 0.0 if 'lower' should be used, 1.0 if 'higher' should be used
+    mediump float s = max(0.0, sign(sRGB - 0.04045));
+    return mix(lower, higher, s);
+#endif
 }
 
 void fragment()
@@ -12,13 +17,13 @@ void fragment()
     // NOTE: This shader does NOT work correctly!!!
     // This assumes the depth is projected onto a circle, which it IS NOT.
 
-    float PI = 3.1415;
-    vec2 uv = (UV * 2) - 1;
-    float angle = atan(uv.y, -uv.x) + PI + radians(135.0);
+    highp float PI = 3.1415;
+    highp vec2 uv = (UV * 2.0) - 1.0;
+    highp float angle = atan(uv.y, -uv.x) + PI + radians(135.0);
 
-    angle = mod(angle, 2 * PI);
-    angle /= (PI * 2);
+    angle = mod(angle, 2.0 * PI);
+    angle /= (PI * 2.0);
 
-    float val = texture(TEXTURE, vec2(angle, 0.5)).r / 8;
+    highp float val = texture2D(TEXTURE, vec2(angle, 0.5)).r / 8.0;
     COLOR = vec4(vec3(toLinear(val)), 0.5);
 }

--- a/Resources/Shaders/Internal/fov-lighting.swsl
+++ b/Resources/Shaders/Internal/fov-lighting.swsl
@@ -2,16 +2,16 @@ preset raw;
 
 #include "/Shaders/Internal/shadow_cast_shared.swsl"
 
-const float g_MinVariance = 0;
+const highp float g_MinVariance = 0.0;
 
-varying vec2 worldPosition;
+varying highp vec2 worldPosition;
 
 // Center of the FOV, in world coordinates.
-uniform vec2 center;
+uniform highp vec2 center;
 
 void vertex()
 {
-    vec3 transformed = modelMatrix * vec3(VERTEX, 1.0);
+    highp vec3 transformed = modelMatrix * vec3(VERTEX, 1.0);
     worldPosition = transformed.xy;
     transformed = projectionMatrix * viewMatrix * transformed;
 
@@ -20,13 +20,13 @@ void vertex()
 
 void fragment()
 {
-    vec2 diff = worldPosition - center;
+    highp vec2 diff = worldPosition - center;
 
-    float ourDist = length(diff);
+    highp float ourDist = length(diff);
 
-    vec2 occlDist = occludeDepth(diff, TEXTURE, 0.25);
+    highp vec2 occlDist = occludeDepth(diff, TEXTURE, 0.25);
 
-    float occlusion = ChebyshevUpperBound(occlDist, ourDist);
+    highp float occlusion = ChebyshevUpperBound(occlDist, ourDist);
 
-    COLOR = vec4(0, 0, 0, 1 - occlusion);
+    COLOR = vec4(0.0, 0.0, 0.0, 1.0 - occlusion);
 }

--- a/Resources/Shaders/Internal/fov.swsl
+++ b/Resources/Shaders/Internal/fov.swsl
@@ -2,16 +2,16 @@ preset raw;
 
 #include "/Shaders/Internal/shadow_cast_shared.swsl"
 
-const float g_MinVariance = 0;
+const highp float g_MinVariance = 0.0;
 
-varying vec2 worldPosition;
+varying highp vec2 worldPosition;
 
 // Center of the FOV, in world coordinates.
-uniform vec2 center;
+uniform highp vec2 center;
 
 void vertex()
 {
-    vec3 transformed = modelMatrix * vec3(VERTEX, 1.0);
+    highp vec3 transformed = modelMatrix * vec3(VERTEX, 1.0);
     worldPosition = transformed.xy;
     transformed = projectionMatrix * viewMatrix * transformed;
 
@@ -20,11 +20,11 @@ void vertex()
 
 void fragment()
 {
-    vec2 diff = worldPosition - center;
+    highp vec2 diff = worldPosition - center;
 
-    float ourDist = length(diff);
+    highp float ourDist = length(diff);
 
-    float occlDist = occludeDepth(diff, TEXTURE, 0.75).r;
+    highp float occlDist = occludeDepth(diff, TEXTURE, 0.75).r;
 
     // *Very* simple biased shadow check for FOV.
     if (!doesOcclude(diff, TEXTURE, 0.75, -0.75/32.0))
@@ -32,5 +32,5 @@ void fragment()
         discard;
     }
 
-    COLOR = vec4(0, 0, 0, 1);
+    COLOR = vec4(0.0, 0.0, 0.0, 1.0);
 }

--- a/Resources/Shaders/Internal/light.swsl
+++ b/Resources/Shaders/Internal/light.swsl
@@ -40,28 +40,28 @@ void fragment()
 
     // Calculate vector perpendicular to light vector.
     // So we can sample it to get a decent soft shadow?
-    highp vec2 perpendicular = normalize(cross(vec3(diff, 0), vec3(0, 0, 1)).xy) * 1.0 / 32.0;
+    highp vec2 perpendicular = normalize(cross(vec3(diff, 0.0), vec3(0.0, 0.0, 1.0)).xy) * 1.0 / 32.0;
 
     highp float ourDist = length(diff);
 
     highp vec2 occlDist = occludeDepth(diff, shadowMap, lightIndex);
 
     // Change soft shadow size based on distance from primary occluder.
-    highp float distRatio = (ourDist - occlDist.x) / occlDist.x / 2;
+    highp float distRatio = (ourDist - occlDist.x) / occlDist.x / 2.0;
 
     perpendicular *= distRatio;
 
     // Totally not hacky PCF on top of VSM.
-    highp float occlusion = smoothstep(0.1, 1, ChebyshevUpperBound(occlDist, ourDist));
+    highp float occlusion = smoothstep(0.1, 1.0, ChebyshevUpperBound(occlDist, ourDist));
 
     occlusion += shadowContrib(diff + perpendicular);
     occlusion += shadowContrib(diff - perpendicular);
-    occlusion += shadowContrib(diff + perpendicular * 2);
-    occlusion += shadowContrib(diff - perpendicular * 2);
-    occlusion += shadowContrib(diff + perpendicular * 3);
-    occlusion += shadowContrib(diff - perpendicular * 3);
+    occlusion += shadowContrib(diff + perpendicular * 2.0);
+    occlusion += shadowContrib(diff - perpendicular * 2.0);
+    occlusion += shadowContrib(diff + perpendicular * 3.0);
+    occlusion += shadowContrib(diff - perpendicular * 3.0);
 
-    occlusion /= 7;
+    occlusion /= 7.0;
 
     if (occlusion == 0.0)
     {
@@ -69,7 +69,7 @@ void fragment()
     }
 
     highp float dist = dot(diff, diff) + LIGHTING_HEIGHT;
-    highp float val = clamp((1 - clamp(sqrt(dist) / lightRange, 0, 1)) * (1 / (sqrt(dist + 1))), 0, 1);
+    highp float val = clamp((1.0 - clamp(sqrt(dist) / lightRange, 0.0, 1.0)) * (1.0 / (sqrt(dist + 1.0))), 0.0, 1.0);
 
     val *= lightPower;
     val *= mask;

--- a/Resources/Shaders/Internal/light.swsl
+++ b/Resources/Shaders/Internal/light.swsl
@@ -34,7 +34,7 @@ highp float shadowContrib(highp vec2 diff)
 
 void fragment()
 {
-    highp float mask = texture2D(TEXTURE, UV).r;
+    highp float mask = zTexture(UV).r;
 
     highp vec2 diff = worldPosition - lightCenter;
 

--- a/Resources/Shaders/Internal/light.swsl
+++ b/Resources/Shaders/Internal/light.swsl
@@ -2,57 +2,57 @@ preset raw;
 
 #include "/Shaders/Internal/shadow_cast_shared.swsl"
 
-const float LIGHTING_HEIGHT = 1;
+const highp float LIGHTING_HEIGHT = 1.0;
 
-const float g_MinVariance = 0;
+const highp float g_MinVariance = 0.0;
 
-varying vec2 worldPosition;
+varying highp vec2 worldPosition;
 
-uniform vec4 lightColor;
+uniform highp vec4 lightColor;
 // Position of the light, in world coordinates.
-uniform vec2 lightCenter;
-uniform float lightRange;
-uniform float lightPower;
-uniform float lightIndex;
+uniform highp vec2 lightCenter;
+uniform highp float lightRange;
+uniform highp float lightPower;
+uniform highp float lightIndex;
 uniform sampler2D shadowMap;
 
 void vertex()
 {
-    vec3 transformed = modelMatrix * vec3(VERTEX, 1.0);
+    highp vec3 transformed = modelMatrix * vec3(VERTEX, 1.0);
     worldPosition = transformed.xy;
     transformed = projectionMatrix * viewMatrix * transformed;
 
     VERTEX = transformed.xy;
 }
 
-float shadowContrib(vec2 diff)
+highp float shadowContrib(highp vec2 diff)
 {
-    float dist = length(diff);
+    highp float dist = length(diff);
 
-    return smoothstep(0, 1, ChebyshevUpperBound(occludeDepth(diff, shadowMap, lightIndex), dist));
+    return smoothstep(0.0, 1.0, ChebyshevUpperBound(occludeDepth(diff, shadowMap, lightIndex), dist));
 }
 
 void fragment()
 {
-    float mask = texture(TEXTURE, UV).r;
+    highp float mask = texture2D(TEXTURE, UV).r;
 
-    vec2 diff = worldPosition - lightCenter;
+    highp vec2 diff = worldPosition - lightCenter;
 
     // Calculate vector perpendicular to light vector.
     // So we can sample it to get a decent soft shadow?
-    vec2 perpendicular = normalize(cross(vec3(diff, 0), vec3(0, 0, 1)).xy) * 1.0 / 32.0;
+    highp vec2 perpendicular = normalize(cross(vec3(diff, 0), vec3(0, 0, 1)).xy) * 1.0 / 32.0;
 
-    float ourDist = length(diff);
+    highp float ourDist = length(diff);
 
-    vec2 occlDist = occludeDepth(diff, shadowMap, lightIndex);
+    highp vec2 occlDist = occludeDepth(diff, shadowMap, lightIndex);
 
     // Change soft shadow size based on distance from primary occluder.
-    float distRatio = (ourDist - occlDist.x) / occlDist.x / 2;
+    highp float distRatio = (ourDist - occlDist.x) / occlDist.x / 2;
 
     perpendicular *= distRatio;
 
     // Totally not hacky PCF on top of VSM.
-    float occlusion = smoothstep(0.1, 1, ChebyshevUpperBound(occlDist, ourDist));
+    highp float occlusion = smoothstep(0.1, 1, ChebyshevUpperBound(occlDist, ourDist));
 
     occlusion += shadowContrib(diff + perpendicular);
     occlusion += shadowContrib(diff - perpendicular);
@@ -68,8 +68,8 @@ void fragment()
         discard;
     }
 
-    float dist = dot(diff, diff) + LIGHTING_HEIGHT;
-    float val = clamp((1 - clamp(sqrt(dist) / lightRange, 0, 1)) * (1 / (sqrt(dist + 1))), 0, 1);
+    highp float dist = dot(diff, diff) + LIGHTING_HEIGHT;
+    highp float val = clamp((1 - clamp(sqrt(dist) / lightRange, 0, 1)) * (1 / (sqrt(dist + 1))), 0, 1);
 
     val *= lightPower;
     val *= mask;

--- a/Resources/Shaders/Internal/shadow_cast_shared.swsl
+++ b/Resources/Shaders/Internal/shadow_cast_shared.swsl
@@ -8,17 +8,6 @@ const highp float PI = 3.1415926535897932384626433; // That enough digits?
 // so we can use that to "reverse engineer" the position.
 uniform highp mat4 shadowMatrix;
 
-// BE SURE TO CHECK THE CORRESPONDING UNPACK CODE in shadow-depth.frag
-// Also, it'd be nice if these functions were put into some sort of common code
-// FF1616 dummy (used when we have float textures)
-highp vec2 ffTwoUnpack(highp vec4 val) {
-#ifdef HAS_FLOAT_TEXTURES
-    return val.xy;
-#else
-	return (val.xy * 255.0) + val.zw;
-#endif
-}
-
 // This returns a vec2 because of VSM moments.
 highp vec2 occludeDepth(highp vec2 diff, sampler2D shadowMap, highp float mapOffsetY)
 {
@@ -62,7 +51,7 @@ highp vec2 occludeDepth(highp vec2 diff, sampler2D shadowMap, highp float mapOff
     s.xyz /= s.w;
     highp float su = s.x * 0.5 + 0.5;
 
-    return ffTwoUnpack(texture2D(shadowMap, vec2(su / 4.0 + shadowMapOffset, mapOffsetY)));
+    return zClydeShadowDepthUnpack(texture2D(shadowMap, vec2(su / 4.0 + shadowMapOffset, mapOffsetY)));
 }
 
 bool doesOcclude(highp vec2 diff, sampler2D shadowMap, highp float mapOffsetY, highp float bias)

--- a/Resources/Shaders/Internal/shadow_cast_shared.swsl
+++ b/Resources/Shaders/Internal/shadow_cast_shared.swsl
@@ -8,6 +8,17 @@ const highp float PI = 3.1415926535897932384626433; // That enough digits?
 // so we can use that to "reverse engineer" the position.
 uniform highp mat4 shadowMatrix;
 
+// BE SURE TO CHECK THE CORRESPONDING UNPACK CODE in shadow-depth.frag
+// Also, it'd be nice if these functions were put into some sort of common code
+// FF1616 dummy (used when we have float textures)
+highp vec2 ffTwoUnpack(highp vec4 val) {
+#ifdef HAS_FLOAT_TEXTURES
+    return val.xy;
+#else
+	return (val.xy * 255.0) + val.zw;
+#endif
+}
+
 // This returns a vec2 because of VSM moments.
 highp vec2 occludeDepth(highp vec2 diff, sampler2D shadowMap, highp float mapOffsetY)
 {
@@ -51,7 +62,7 @@ highp vec2 occludeDepth(highp vec2 diff, sampler2D shadowMap, highp float mapOff
     s.xyz /= s.w;
     highp float su = s.x * 0.5 + 0.5;
 
-    return texture2D(shadowMap, vec2(su / 4.0 + shadowMapOffset, mapOffsetY)).rg;
+    return ffTwoUnpack(texture2D(shadowMap, vec2(su / 4.0 + shadowMapOffset, mapOffsetY)));
 }
 
 bool doesOcclude(highp vec2 diff, sampler2D shadowMap, highp float mapOffsetY, highp float bias)

--- a/Resources/Shaders/Internal/shadow_cast_shared.swsl
+++ b/Resources/Shaders/Internal/shadow_cast_shared.swsl
@@ -1,22 +1,22 @@
 // Shared code necessary for using depth casting like FOV and shadows.
 
-const float PI = 3.1415926535897932384626433; // That enough digits?
+const highp float PI = 3.1415926535897932384626433; // That enough digits?
 
 // Because the shadow map is projected as a SQUARE, not a circle.
 // We can't just use some atan magic to undo the projection.
 // This matrix is the projection matrix used to create the projection
 // so we can use that to "reverse engineer" the position.
-uniform mat4 shadowMatrix;
+uniform highp mat4 shadowMatrix;
 
 // This returns a vec2 because of VSM moments.
-vec2 occludeDepth(vec2 diff, sampler2D shadowMap, float mapOffsetY)
+highp vec2 occludeDepth(highp vec2 diff, sampler2D shadowMap, highp float mapOffsetY)
 {
-    float angle = atan(diff.y, -diff.x) + PI + radians(135.0);
+    highp float angle = atan(diff.y, -diff.x) + PI + radians(135.0);
 
     angle = mod(angle, 2 * PI);
 
-    vec2 shadowPoint;
-    float shadowMapOffset;
+    highp vec2 shadowPoint;
+    highp float shadowMapOffset;
 
     // Find quadrant the point is in and select correct horizontal offset in shadow map based on this.
     // We also have to manually apply rotation to shadowPoint to accomodate for each quadrant actually being rotated.
@@ -42,16 +42,16 @@ vec2 occludeDepth(vec2 diff, sampler2D shadowMap, float mapOffsetY)
     }
 
     // Run shadow point through shadow matrix.
-    vec4 s = shadowMatrix * vec4(shadowPoint, 0.0, 1.0);
+    highp vec4 s = shadowMatrix * vec4(shadowPoint, 0.0, 1.0);
     // Undo NDC coordinates to get a 0 -> 1 representing the x coordinates of the "screen".
     // Which we then map to the texture.
     s.xyz /= s.w;
-    float su = s.x * 0.5 + 0.5;
+    highp float su = s.x * 0.5 + 0.5;
 
-    return texture(shadowMap, vec2(su / 4 + shadowMapOffset, mapOffsetY)).rg;
+    return texture2D(shadowMap, vec2(su / 4 + shadowMapOffset, mapOffsetY)).rg;
 }
 
-bool doesOcclude(vec2 diff, sampler2D shadowMap, float mapOffsetY, float bias)
+bool doesOcclude(highp vec2 diff, sampler2D shadowMap, highp float mapOffsetY, highp float bias)
 {
     float ourDist = length(diff);
 
@@ -59,15 +59,15 @@ bool doesOcclude(vec2 diff, sampler2D shadowMap, float mapOffsetY, float bias)
 }
 
 // Use this for VSM shadow casting stuff.
-float ChebyshevUpperBound(vec2 moments, float t)
+highp float ChebyshevUpperBound(highp vec2 moments, highp float t)
 {
     // One-tailed inequality valid if t > Moments.x
-    float p = float(t <= moments.x);
+    highp float p = float(t <= moments.x);
     // Compute variance.
-    float variance = moments.y - (moments.x * moments.x);
+    highp float variance = moments.y - (moments.x * moments.x);
     variance = max(variance, g_MinVariance);
     // Compute probabilistic upper bound.
-    float d = t - moments.x;
-    float p_max = variance / (variance + d*d);
+    highp float d = t - moments.x;
+    highp float p_max = variance / (variance + d*d);
     return max(p, p_max);
 }

--- a/Resources/Shaders/Internal/shadow_cast_shared.swsl
+++ b/Resources/Shaders/Internal/shadow_cast_shared.swsl
@@ -12,8 +12,11 @@ uniform highp mat4 shadowMatrix;
 highp vec2 occludeDepth(highp vec2 diff, sampler2D shadowMap, highp float mapOffsetY)
 {
     highp float angle = atan(diff.y, -diff.x) + PI + radians(135.0);
-
-    angle = mod(angle, 2 * PI);
+#ifdef HAS_DFDX
+    angle = mod(angle, 2.0 * PI);
+#else
+    angle -= floor(angle / (2.0 * PI)) * (2.0 * PI);
+#endif
 
     highp vec2 shadowPoint;
     highp float shadowMapOffset;
@@ -23,7 +26,7 @@ highp vec2 occludeDepth(highp vec2 diff, sampler2D shadowMap, highp float mapOff
     if (angle < radians(90.0)) // Top
     {
         shadowPoint = diff;
-        shadowMapOffset = 0;
+        shadowMapOffset = 0.0;
     }
     else if (angle < radians(180.0)) // Right
     {
@@ -48,12 +51,12 @@ highp vec2 occludeDepth(highp vec2 diff, sampler2D shadowMap, highp float mapOff
     s.xyz /= s.w;
     highp float su = s.x * 0.5 + 0.5;
 
-    return texture2D(shadowMap, vec2(su / 4 + shadowMapOffset, mapOffsetY)).rg;
+    return texture2D(shadowMap, vec2(su / 4.0 + shadowMapOffset, mapOffsetY)).rg;
 }
 
 bool doesOcclude(highp vec2 diff, sampler2D shadowMap, highp float mapOffsetY, highp float bias)
 {
-    float ourDist = length(diff);
+    highp float ourDist = length(diff);
 
     return occludeDepth(diff, shadowMap, mapOffsetY).x + bias < ourDist;
 }

--- a/Resources/Shaders/Internal/wall-bleed-blur.swsl
+++ b/Resources/Shaders/Internal/wall-bleed-blur.swsl
@@ -30,11 +30,11 @@ void vertex()
 void fragment()
 {
     // Very simple gaussian blur.
-    highp vec4 sum = texture2D(TEXTURE, pos) * 0.375;
-    sum += texture2D(TEXTURE, blurPos1.xy) * 0.25;
-    sum += texture2D(TEXTURE, blurPos1.zw) * 0.25;
-    sum += texture2D(TEXTURE, blurPos2.xy) * 0.0625;
-    sum += texture2D(TEXTURE, blurPos2.zw) * 0.0625;
+    highp vec4 sum = zTexture(pos) * 0.375;
+    sum += zTexture(blurPos1.xy) * 0.25;
+    sum += zTexture(blurPos1.zw) * 0.25;
+    sum += zTexture(blurPos2.xy) * 0.0625;
+    sum += zTexture(blurPos2.zw) * 0.0625;
 
     // We actually "add" energy to the wall here while blurring with the * 1.2.
     // Keep in mind that the wall is pitch black right now

--- a/Resources/Shaders/Internal/wall-bleed-blur.swsl
+++ b/Resources/Shaders/Internal/wall-bleed-blur.swsl
@@ -1,20 +1,20 @@
 preset raw;
 
-uniform vec2 direction;
-uniform vec2 size;
-uniform float radius;
+uniform highp vec2 direction;
+uniform highp vec2 size;
+uniform highp float radius;
 
-varying vec2 pos;
-varying vec4 blurPos1;
-varying vec4 blurPos2;
+varying highp vec2 pos;
+varying highp vec4 blurPos1;
+varying highp vec4 blurPos2;
 
 
 void vertex()
 {
-    float aspect = size.y / size.x;
-    float horRadius = aspect * radius;
+    highp float aspect = size.y / size.x;
+    highp float horRadius = aspect * radius;
 
-    vec2 offset = vec2(horRadius, radius) * direction;
+    highp vec2 offset = vec2(horRadius, radius) * direction;
 
     VERTEX = apply_mvp(VERTEX);
 
@@ -30,11 +30,11 @@ void vertex()
 void fragment()
 {
     // Very simple gaussian blur.
-    vec4 sum = texture(TEXTURE, pos) * 0.375;
-    sum += texture(TEXTURE, blurPos1.xy) * 0.25;
-    sum += texture(TEXTURE, blurPos1.zw) * 0.25;
-    sum += texture(TEXTURE, blurPos2.xy) * 0.0625;
-    sum += texture(TEXTURE, blurPos2.zw) * 0.0625;
+    highp vec4 sum = texture2D(TEXTURE, pos) * 0.375;
+    sum += texture2D(TEXTURE, blurPos1.xy) * 0.25;
+    sum += texture2D(TEXTURE, blurPos1.zw) * 0.25;
+    sum += texture2D(TEXTURE, blurPos2.xy) * 0.0625;
+    sum += texture2D(TEXTURE, blurPos2.zw) * 0.0625;
 
     // We actually "add" energy to the wall here while blurring with the * 1.2.
     // Keep in mind that the wall is pitch black right now

--- a/Resources/Shaders/Internal/wall-bleed-blur.swsl
+++ b/Resources/Shaders/Internal/wall-bleed-blur.swsl
@@ -18,12 +18,12 @@ void vertex()
 
     VERTEX = apply_mvp(VERTEX);
 
-    pos = (VERTEX + vec2(1)) / 2;
+    pos = (VERTEX + vec2(1.0)) / 2.0;
 
     blurPos1.xy = pos + offset;
     blurPos1.zw = pos - offset;
-    blurPos2.xy = pos + offset * 2;
-    blurPos2.zw = pos - offset * 2;
+    blurPos2.xy = pos + offset * 2.0;
+    blurPos2.zw = pos - offset * 2.0;
 }
 
 

--- a/Resources/Shaders/Internal/wall-merge.swsl
+++ b/Resources/Shaders/Internal/wall-merge.swsl
@@ -1,16 +1,16 @@
 preset raw;
 
-varying vec2 pos;
+varying highp vec2 pos;
 
 void vertex()
 {
     VERTEX = (projectionMatrix * viewMatrix * vec3(VERTEX, 1.0)).xy;
 
-    pos = (VERTEX + vec2(1)) / 2;
+    pos = (VERTEX + vec2(1.0)) / 2.0;
 }
 
 
 void fragment()
 {
-    COLOR = texture(TEXTURE, pos);
+    COLOR = texture2D(TEXTURE, pos);
 }

--- a/Resources/Shaders/Internal/wall-merge.swsl
+++ b/Resources/Shaders/Internal/wall-merge.swsl
@@ -12,5 +12,5 @@ void vertex()
 
 void fragment()
 {
-    COLOR = texture2D(TEXTURE, pos);
+    COLOR = zTexture(pos);
 }

--- a/Robust.Client/Graphics/Clyde/Clyde.Constants.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Constants.cs
@@ -34,8 +34,11 @@ namespace Robust.Client.Graphics.Clyde
 
         private enum Renderer
         {
+            // Default: Try all supported renderers (not necessarily the renderers shown here)
             Default = default,
-            OpenGL31 = 1,
+            OpenGL33 = 1,
+            OpenGL31 = 2,
+            OpenGLES2 = 3,
             Explode = -1,
         }
     }

--- a/Robust.Client/Graphics/Clyde/Clyde.Constants.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Constants.cs
@@ -32,6 +32,9 @@ namespace Robust.Client.Graphics.Clyde
         private const int BindingIndexProjView = 0;
         private const int BindingIndexUniformConstants = 1;
 
+        // To be clear: You shouldn't change this. This just helps with understanding where Primitive Restart is being used.
+        private const ushort PrimitiveRestartIndex = ushort.MaxValue;
+
         private enum Renderer
         {
             // Default: Try all supported renderers (not necessarily the renderers shown here)

--- a/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
@@ -34,6 +34,7 @@ namespace Robust.Client.Graphics.Clyde
             SetTexture(TextureUnit.Texture1, _lightingReady ? _currentViewport!.LightRenderTarget.Texture : _stockTextureWhite);
 
             var (gridProgram, _) = ActivateShaderInstance(_defaultShader.Handle);
+            SetupGlobalUniformsImmediate(gridProgram, (ClydeTexture) _tileDefinitionManager.TileTextureAtlas);
 
             gridProgram.SetUniformTextureMaybe(UniIMainTexture, TextureUnit.Texture0);
             gridProgram.SetUniformTextureMaybe(UniILightTexture, TextureUnit.Texture1);

--- a/Robust.Client/Graphics/Clyde/Clyde.Helpers.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Helpers.cs
@@ -47,8 +47,7 @@ namespace Robust.Client.Graphics.Clyde
         {
             ProjViewUBO.Apply(program);
             UniformConstantsUBO.Apply(program);
-            program.SetUniformMaybe("TEXTURE_SRGB", 0.0f);
-            program.SetUniformMaybe("FRAMEBUFFER_SRGB", 0.0f);
+            program.SetUniformMaybe("SRGB_EMU_CONFIG", new Vector2(1.0f, 1.0f));
         }
 
         // Gets the primitive type required by QuadBatchIndexWrite.

--- a/Robust.Client/Graphics/Clyde/Clyde.Helpers.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Helpers.cs
@@ -41,13 +41,21 @@ namespace Robust.Client.Graphics.Clyde
             };
         }
 
-        // Sets up uniforms (temporary, this should be moved to GLShaderProgram.Use)
+        // Sets up uniforms (It'd be nice to move this, or make some contextual stuff implicit, but things got complicated.)
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void TempSetupUniformBlockEmulator(GLShaderProgram program)
+        private void SetupGlobalUniformsImmediate(GLShaderProgram program, ClydeTexture? tex)
+        {
+            SetupGlobalUniformsImmediate(program, (tex != null) ? tex.IsSrgb : false);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void SetupGlobalUniformsImmediate(GLShaderProgram program, bool texIsSrgb)
         {
             ProjViewUBO.Apply(program);
             UniformConstantsUBO.Apply(program);
-            program.SetUniformMaybe("SRGB_EMU_CONFIG", new Vector2(1.0f, 1.0f));
+            if (!_hasGLSrgb)
+            {
+                program.SetUniformMaybe("SRGB_EMU_CONFIG", new Vector2(texIsSrgb ? 1 : 0, _currentBoundRenderTarget.IsSrgb ? 1 : 0));
+            }
         }
 
         // Gets the primitive type required by QuadBatchIndexWrite.

--- a/Robust.Client/Graphics/Clyde/Clyde.Helpers.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Helpers.cs
@@ -45,7 +45,7 @@ namespace Robust.Client.Graphics.Clyde
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SetupGlobalUniformsImmediate(GLShaderProgram program, ClydeTexture? tex)
         {
-            SetupGlobalUniformsImmediate(program, (tex != null) ? tex.IsSrgb : false);
+            SetupGlobalUniformsImmediate(program, tex?.IsSrgb ?? false);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SetupGlobalUniformsImmediate(GLShaderProgram program, bool texIsSrgb)

--- a/Robust.Client/Graphics/Clyde/Clyde.Helpers.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Helpers.cs
@@ -47,6 +47,8 @@ namespace Robust.Client.Graphics.Clyde
         {
             ProjViewUBO.Apply(program);
             UniformConstantsUBO.Apply(program);
+            program.SetUniformMaybe("TEXTURE_SRGB", 0.0f);
+            program.SetUniformMaybe("FRAMEBUFFER_SRGB", 0.0f);
         }
 
         // Gets the primitive type required by QuadBatchIndexWrite.

--- a/Robust.Client/Graphics/Clyde/Clyde.Helpers.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Helpers.cs
@@ -1,5 +1,8 @@
 using OpenToolkit.Graphics.OpenGL4;
 using Robust.Shared.Maths;
+using System.Runtime.CompilerServices;
+using System;
+using System.Buffers;
 
 namespace Robust.Client.Graphics.Clyde
 {
@@ -36,6 +39,70 @@ namespace Robust.Client.Graphics.Clyde
                 PixelInternalFormat.R8 => 1,
                 _ => 0
             };
+        }
+
+        // Sets up uniforms (temporary, this should be moved to GLShaderProgram.Use)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void TempSetupUniformBlockEmulator(GLShaderProgram program)
+        {
+            ProjViewUBO.Apply(program);
+            UniformConstantsUBO.Apply(program);
+        }
+
+        // Gets the primitive type required by QuadBatchIndexWrite.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private BatchPrimitiveType GetQuadBatchPrimitiveType()
+        {
+            return _hasGLPrimitiveRestart ? BatchPrimitiveType.TriangleFan : BatchPrimitiveType.TriangleList;
+        }
+
+        // Gets the PrimitiveType version of GetQuadBatchPrimitiveType
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private PrimitiveType GetQuadGLPrimitiveType()
+        {
+            return _hasGLPrimitiveRestart ? PrimitiveType.TriangleFan : PrimitiveType.Triangles;
+        }
+
+        // Gets the amount of indices required by QuadBatchIndexWrite.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int GetQuadBatchIndexCount()
+        {
+            // PR: Need 5 indices per quad: 4 to draw the quad with triangle strips and another one as primitive restart.
+            // no PR: Need 6 indices per quad: 2 triangles
+            return _hasGLPrimitiveRestart ? 5 : 6;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void QuadBatchIndexWrite(Span<ushort> indexData, ref int nIdx, ushort tIdx)
+        {
+            QuadBatchIndexWrite(indexData, ref nIdx, tIdx, (ushort) (tIdx + 1), (ushort) (tIdx + 2), (ushort) (tIdx + 3));
+        }
+
+        // Writes a quad into the index buffer. Note that the 'middle line' is from tIdx0 to tIdx2.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void QuadBatchIndexWrite(Span<ushort> indexData, ref int nIdx, ushort tIdx0, ushort tIdx1, ushort tIdx2, ushort tIdx3)
+        {
+            if (_hasGLPrimitiveRestart)
+            {
+                // PJB's fancy triangle fan isolated to a quad with primitive restart
+                indexData[nIdx + 0] = tIdx0;
+                indexData[nIdx + 1] = tIdx1;
+                indexData[nIdx + 2] = tIdx2;
+                indexData[nIdx + 3] = tIdx3;
+                indexData[nIdx + 4] = PrimitiveRestartIndex;
+                nIdx += 5;
+            }
+            else
+            {
+                // 20kdc's boring two separate triangles
+                indexData[nIdx + 0] = tIdx0;
+                indexData[nIdx + 1] = tIdx1;
+                indexData[nIdx + 2] = tIdx2;
+                indexData[nIdx + 3] = tIdx0;
+                indexData[nIdx + 4] = tIdx2;
+                indexData[nIdx + 5] = tIdx3;
+                nIdx += 6;
+            }
         }
     }
 }

--- a/Robust.Client/Graphics/Clyde/Clyde.Layout.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Layout.cs
@@ -52,7 +52,7 @@ namespace Robust.Client.Graphics.Clyde
 
         [StructLayout(LayoutKind.Explicit, Size = 28 * sizeof(float))]
         [PublicAPI]
-        private struct ProjViewMatrices
+        private struct ProjViewMatrices : IAppliableUniformSet
         {
             [FieldOffset(0 * sizeof(float))] public Vector3 ProjMatrixC0;
             [FieldOffset(4 * sizeof(float))] public Vector3 ProjMatrixC1;
@@ -73,11 +73,25 @@ namespace Robust.Client.Graphics.Clyde
                 ViewMatrixC1 = new Vector3(viewMatrix.R0C1, viewMatrix.R1C1, viewMatrix.R2C1);
                 ViewMatrixC2 = new Vector3(viewMatrix.R0C2, viewMatrix.R1C2, viewMatrix.R2C2);
             }
+
+            public void Apply(Clyde clyde, GLShaderProgram program)
+            {
+                program.SetUniformMaybe("projectionMatrix", new Matrix3(
+                    ProjMatrixC0.X, ProjMatrixC1.X, ProjMatrixC2.X,
+                    ProjMatrixC0.Y, ProjMatrixC1.Y, ProjMatrixC2.Y,
+                    ProjMatrixC0.Z, ProjMatrixC1.Z, ProjMatrixC2.Z
+                ));
+                program.SetUniformMaybe("viewMatrix", new Matrix3(
+                    ViewMatrixC0.X, ViewMatrixC1.X, ViewMatrixC2.X,
+                    ViewMatrixC0.Y, ViewMatrixC1.Y, ViewMatrixC2.Y,
+                    ViewMatrixC0.Z, ViewMatrixC1.Z, ViewMatrixC2.Z
+                ));
+            }
         }
 
         [StructLayout(LayoutKind.Explicit, Size = sizeof(float) * 4)]
         [PublicAPI]
-        private struct UniformConstants
+        private struct UniformConstants : IAppliableUniformSet
         {
             [FieldOffset(0)] public Vector2 ScreenPixelSize;
             [FieldOffset(2 * sizeof(float))] public float Time;
@@ -86,6 +100,12 @@ namespace Robust.Client.Graphics.Clyde
             {
                 ScreenPixelSize = screenPixelSize;
                 Time = time;
+            }
+
+            public void Apply(Clyde clyde, GLShaderProgram program)
+            {
+                program.SetUniformMaybe("SCREEN_PIXEL_SIZE", ScreenPixelSize);
+                program.SetUniformMaybe("TIME", Time);
             }
         }
     }

--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -771,29 +771,31 @@ namespace Robust.Client.Graphics.Clyde
                     // Handle faces, rules described above.
                     // Note that faces are drawn with their 'normals' facing in the described direction in 3D space.
                     // That is, they're clockwise "as viewed from the outside".
+                    // (When changing things to QuadBatchIndexWrite,
+                    // I described the behaviour correctly in this comment and then failed to implement it - 20kdc)
 
                     // North face (TL/TR)
                     if (!no || !tlV && !trV)
                     {
-                        QuadBatchIndexWrite(indexBuffer, ref ii, vTRL, vTLL, vTLH, vTRH);
+                        QuadBatchIndexWrite(indexBuffer, ref ii, vTRH, vTLH, vTLL, vTRL);
                     }
 
                     // East face (TR/BR)
                     if (!eo || !brV && !trV)
                     {
-                        QuadBatchIndexWrite(indexBuffer, ref ii, vBRL, vTRL, vTRH, vBRH);
+                        QuadBatchIndexWrite(indexBuffer, ref ii, vBRH, vTRH, vTRL, vBRL);
                     }
 
                     // South face (BR/BL)
                     if (!so || !brV && !blV)
                     {
-                        QuadBatchIndexWrite(indexBuffer, ref ii, vBLL, vBRL, vBRH, vBLH);
+                        QuadBatchIndexWrite(indexBuffer, ref ii, vBLH, vBRH, vBRL, vBLL);
                     }
 
                     // West face (BL/TL)
                     if (!wo || !blV && !tlV)
                     {
-                        QuadBatchIndexWrite(indexBuffer, ref ii, vTLL, vBLL, vBLH, vTLH);
+                        QuadBatchIndexWrite(indexBuffer, ref ii, vTLH, vBLH, vBLL, vTLL);
                     }
 
                     // Generate mask geometry.

--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -133,7 +133,7 @@ namespace Robust.Client.Graphics.Clyde
 
             // FOV FBO.
             _fovRenderTarget = CreateRenderTarget((FovMapSize, 2),
-                new RenderTargetFormatParameters(_hasGLFancyFloatFormats ? RenderTargetColorFormat.RG32F : RenderTargetColorFormat.Rgba8, true),
+                new RenderTargetFormatParameters(_hasGLFloatFramebuffers ? RenderTargetColorFormat.RG32F : RenderTargetColorFormat.Rgba8, true),
                 new TextureSampleParameters {WrapMode = TextureWrapMode.Repeat},
                 nameof(_fovRenderTarget));
 
@@ -148,7 +148,7 @@ namespace Robust.Client.Graphics.Clyde
 
             // Shadow FBO.
             _shadowRenderTarget = CreateRenderTarget((ShadowMapSize, MaxLightsPerScene),
-                new RenderTargetFormatParameters(_hasGLFancyFloatFormats ? RenderTargetColorFormat.RG32F : RenderTargetColorFormat.Rgba8, true),
+                new RenderTargetFormatParameters(_hasGLFloatFramebuffers ? RenderTargetColorFormat.RG32F : RenderTargetColorFormat.Rgba8, true),
                 new TextureSampleParameters {WrapMode = TextureWrapMode.Repeat, Filter = true},
                 nameof(_shadowRenderTarget));
         }
@@ -841,7 +841,7 @@ namespace Robust.Client.Graphics.Clyde
 
             var lightMapSize = GetLightMapSize(viewport.Size);
             var lightMapSizeQuart = GetLightMapSize(viewport.Size, true);
-            var lightMapColorFormat = _hasGLFancyFloatFormats ? RenderTargetColorFormat.R11FG11FB10F : RenderTargetColorFormat.Rgba8;
+            var lightMapColorFormat = _hasGLFloatFramebuffers ? RenderTargetColorFormat.R11FG11FB10F : RenderTargetColorFormat.Rgba8;
             var lightMapSampleParameters = new TextureSampleParameters {Filter = true};
 
             viewport.LightRenderTarget?.Dispose();

--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -295,7 +295,7 @@ namespace Robust.Client.Graphics.Clyde
             GL.Enable(EnableCap.CullFace);
             GL.FrontFace(FrontFaceDirection.Cw);
 
-            GL.BindFramebuffer(FramebufferTarget.Framebuffer, target.FramebufferHandle.Handle);
+            BindRenderTargetImmediate(target);
             GL.ClearDepth(1);
             GL.ClearColor(arbitraryDistanceMax, arbitraryDistanceMax * arbitraryDistanceMax, 0, 1);
             GL.Clear(ClearBufferMask.DepthBufferBit | ClearBufferMask.ColorBufferBit);
@@ -304,7 +304,7 @@ namespace Robust.Client.Graphics.Clyde
 
             _fovCalculationProgram.Use();
 
-            TempSetupUniformBlockEmulator(_fovCalculationProgram);
+            SetupGlobalUniformsImmediate(_fovCalculationProgram, null);
         }
 
         private static void FinalizeDepthDraw()
@@ -346,7 +346,7 @@ namespace Robust.Client.Graphics.Clyde
                 FinalizeDepthDraw();
             }
 
-            GL.BindFramebuffer(FramebufferTarget.Framebuffer, RtToLoaded(viewport.LightRenderTarget).FramebufferHandle.Handle);
+            BindRenderTargetImmediate(RtToLoaded(viewport.LightRenderTarget));
             GLClearColor(Color.FromSrgb(AmbientLightColor));
             GL.Clear(ClearBufferMask.ColorBufferBit);
 
@@ -356,7 +356,7 @@ namespace Robust.Client.Graphics.Clyde
             var lightShader = _loadedShaders[_lightShaderHandle].Program;
             lightShader.Use();
 
-            TempSetupUniformBlockEmulator(lightShader);
+            SetupGlobalUniformsImmediate(lightShader, ShadowTexture);
 
             SetTexture(TextureUnit.Texture1, ShadowTexture);
             lightShader.SetUniformTextureMaybe("shadowMap", TextureUnit.Texture1);
@@ -512,7 +512,7 @@ namespace Robust.Client.Graphics.Clyde
             var shader = _loadedShaders[_wallBleedBlurShaderHandle].Program;
             shader.Use();
 
-            TempSetupUniformBlockEmulator(shader);
+            SetupGlobalUniformsImmediate(shader, viewport.LightRenderTarget.Texture);
 
             shader.SetUniformMaybe("size", (Vector2) viewport.WallBleedIntermediateRenderTarget1.Size);
             shader.SetUniformTextureMaybe(UniIMainTexture, TextureUnit.Texture0);
@@ -571,9 +571,10 @@ namespace Robust.Client.Graphics.Clyde
             var shader = _loadedShaders[_mergeWallLayerShaderHandle].Program;
             shader.Use();
 
-            TempSetupUniformBlockEmulator(shader);
-
             var tex = viewport.WallBleedIntermediateRenderTarget2.Texture;
+
+            SetupGlobalUniformsImmediate(shader, tex);
+
             SetTexture(TextureUnit.Texture0, tex);
 
             shader.SetUniformTextureMaybe(UniIMainTexture, TextureUnit.Texture0);
@@ -593,7 +594,7 @@ namespace Robust.Client.Graphics.Clyde
             var fovShader = _loadedShaders[_fovShaderHandle].Program;
             fovShader.Use();
 
-            TempSetupUniformBlockEmulator(fovShader);
+            SetupGlobalUniformsImmediate(fovShader, FovTexture);
 
             SetTexture(TextureUnit.Texture0, FovTexture);
 
@@ -611,7 +612,7 @@ namespace Robust.Client.Graphics.Clyde
             var fovShader = _loadedShaders[_fovLightShaderHandle].Program;
             fovShader.Use();
 
-            TempSetupUniformBlockEmulator(fovShader);
+            SetupGlobalUniformsImmediate(fovShader, FovTexture);
 
             SetTexture(TextureUnit.Texture0, FovTexture);
 

--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -133,7 +133,7 @@ namespace Robust.Client.Graphics.Clyde
 
             // FOV FBO.
             _fovRenderTarget = CreateRenderTarget((FovMapSize, 2),
-                new RenderTargetFormatParameters(RenderTargetColorFormat.RG32F, true),
+                new RenderTargetFormatParameters(_hasGLFancyFloatFormats ? RenderTargetColorFormat.Rgba8 : RenderTargetColorFormat.RG32F, true),
                 new TextureSampleParameters {WrapMode = TextureWrapMode.Repeat},
                 nameof(_fovRenderTarget));
 
@@ -148,7 +148,7 @@ namespace Robust.Client.Graphics.Clyde
 
             // Shadow FBO.
             _shadowRenderTarget = CreateRenderTarget((ShadowMapSize, MaxLightsPerScene),
-                new RenderTargetFormatParameters(RenderTargetColorFormat.RG32F, true),
+                new RenderTargetFormatParameters(_hasGLFancyFloatFormats ? RenderTargetColorFormat.Rgba8 : RenderTargetColorFormat.RG32F, true),
                 new TextureSampleParameters {WrapMode = TextureWrapMode.Repeat, Filter = true},
                 nameof(_shadowRenderTarget));
         }
@@ -245,6 +245,8 @@ namespace Robust.Client.Graphics.Clyde
 
             var step = width / 4;
 
+            GL.Disable(EnableCap.Blend);
+
             for (var i = 0; i < 4; i++)
             {
                 // The occlusion geometry has to be rotated for every orientation and also corrected
@@ -278,6 +280,8 @@ namespace Robust.Client.Graphics.Clyde
                 GL.DrawElements(GetQuadGLPrimitiveType(), _occlusionDataLength, DrawElementsType.UnsignedShort, 0);
                 _debugStats.LastGLDrawCalls += 1;
             }
+
+            GL.Enable(EnableCap.Blend);
         }
 
         private void PrepareDepthDraw(LoadedRenderTarget target)

--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -235,7 +235,7 @@ namespace Robust.Client.Graphics.Clyde
             var lightMatrix = Matrix4.CreateTranslation(-posX, -posY, 0);
 
             // The light is now the center of the universe.
-            _fovCalculationProgram.SetUniform("lightMatrix", lightMatrix, false);
+            _fovCalculationProgram.SetUniform("shadowLightMatrix", lightMatrix, false);
 
             var baseProj = Matrix4.CreatePerspectiveFieldOfView(
                 MathHelper.DegreesToRadians(90),
@@ -271,7 +271,7 @@ namespace Robust.Client.Graphics.Clyde
                     projMatrix = proj;
                 }
 
-                _fovCalculationProgram.SetUniform("projectionMatrix", proj, false);
+                _fovCalculationProgram.SetUniform("shadowProjectionMatrix", proj, false);
                 // Shift viewport around so we write to the correct quadrant of the depth map.
                 GL.Viewport(step * i, viewportY, step, 1);
 

--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -133,7 +133,7 @@ namespace Robust.Client.Graphics.Clyde
 
             // FOV FBO.
             _fovRenderTarget = CreateRenderTarget((FovMapSize, 2),
-                new RenderTargetFormatParameters(_hasGLFancyFloatFormats ? RenderTargetColorFormat.Rgba8 : RenderTargetColorFormat.RG32F, true),
+                new RenderTargetFormatParameters(_hasGLFancyFloatFormats ? RenderTargetColorFormat.RG32F : RenderTargetColorFormat.Rgba8, true),
                 new TextureSampleParameters {WrapMode = TextureWrapMode.Repeat},
                 nameof(_fovRenderTarget));
 
@@ -148,7 +148,7 @@ namespace Robust.Client.Graphics.Clyde
 
             // Shadow FBO.
             _shadowRenderTarget = CreateRenderTarget((ShadowMapSize, MaxLightsPerScene),
-                new RenderTargetFormatParameters(_hasGLFancyFloatFormats ? RenderTargetColorFormat.Rgba8 : RenderTargetColorFormat.RG32F, true),
+                new RenderTargetFormatParameters(_hasGLFancyFloatFormats ? RenderTargetColorFormat.RG32F : RenderTargetColorFormat.Rgba8, true),
                 new TextureSampleParameters {WrapMode = TextureWrapMode.Repeat, Filter = true},
                 nameof(_shadowRenderTarget));
         }
@@ -840,7 +840,7 @@ namespace Robust.Client.Graphics.Clyde
 
             var lightMapSize = GetLightMapSize(viewport.Size);
             var lightMapSizeQuart = GetLightMapSize(viewport.Size, true);
-            const RenderTargetColorFormat lightMapColorFormat = RenderTargetColorFormat.R11FG11FB10F;
+            var lightMapColorFormat = _hasGLFancyFloatFormats ? RenderTargetColorFormat.R11FG11FB10F : RenderTargetColorFormat.Rgba8;
             var lightMapSampleParameters = new TextureSampleParameters {Filter = true};
 
             viewport.LightRenderTarget?.Dispose();

--- a/Robust.Client/Graphics/Clyde/Clyde.RenderTargets.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.RenderTargets.cs
@@ -6,6 +6,7 @@ using OpenToolkit.Graphics.OpenGL4;
 using Robust.Client.Interfaces.Graphics;
 using Robust.Shared.Maths;
 using Robust.Shared.Utility;
+using Robust.Shared.Log;
 
 // ReSharper disable once IdentifierTypo
 using RTCF = Robust.Client.Interfaces.Graphics.RenderTargetColorFormat;
@@ -86,6 +87,7 @@ namespace Robust.Client.Graphics.Clyde
                         case RTCF.RG32F:
                         case RTCF.R11FG11FB10F:
                         case RTCF.Rgba16F:
+                            Logger.WarningS("clyde.ogl", "The framebuffer {0} [{1}] is trying to be floating-point when that's not supported. Forcing Rgba8.", name == null ? "[unnamed]" : name, size);
                             colorFormat = RTCF.Rgba8;
                             break;
                     }

--- a/Robust.Client/Graphics/Clyde/Clyde.RenderTargets.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.RenderTargets.cs
@@ -87,7 +87,7 @@ namespace Robust.Client.Graphics.Clyde
                     colorFormat = RTCF.Rgba8;
                 }
                 // This isn't good
-                if (!_hasGLFancyFloatFormats)
+                if (!_hasGLFloatFramebuffers)
                 {
                     switch (colorFormat)
                     {
@@ -121,7 +121,7 @@ namespace Robust.Client.Graphics.Clyde
                 GL.TexImage2D(TextureTarget.Texture2D, 0, internalFormat, width, height, 0, pixFormat,
                     pixType, IntPtr.Zero);
 
-                if (!_hasGLES)
+                if (!_isGLES)
                 {
                     GL.FramebufferTexture(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0,
                         texture.Handle,

--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -225,6 +225,8 @@ namespace Robust.Client.Graphics.Clyde
             program.SetUniformMaybe(UniIModulate, command.Modulate);
             program.SetUniformMaybe(UniITexturePixelSize, Vector2.One / loadedTexture.Size);
 
+            ProjViewUBO.Apply(program);
+            UniformConstantsUBO.Apply(program);
 
             var primitiveType = MapPrimitiveType(command.PrimitiveType);
             if (command.Indexed)

--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -72,8 +72,8 @@ namespace Robust.Client.Graphics.Clyde
         // Buffers and data for the batching system. Written into during (queue) and processed during (submit).
         private readonly Vertex2D[] BatchVertexData = new Vertex2D[MaxBatchQuads * 4];
 
-        // Need 5 indices per quad: 4 to draw the quad with triangle strips and another one as primitive restart.
-        private readonly ushort[] BatchIndexData = new ushort[MaxBatchQuads * 5];
+        // Only write from InitRenderingBatchBuffers!
+        private ushort[] BatchIndexData;
         private int BatchVertexIndex;
         private int BatchIndexIndex;
 
@@ -98,6 +98,11 @@ namespace Robust.Client.Graphics.Clyde
         private bool _isStencilling;
 
         private readonly RefList<RenderCommand> _queuedRenderCommands = new RefList<RenderCommand>();
+
+        private void InitRenderingBatchBuffers()
+        {
+            BatchIndexData = new ushort[MaxBatchQuads * GetQuadBatchIndexCount()];
+        }
 
         /// <summary>
         ///     Updates uniform constants shared to all shaders, such as time and pixel size.
@@ -224,9 +229,6 @@ namespace Robust.Client.Graphics.Clyde
 
             program.SetUniformMaybe(UniIModulate, command.Modulate);
             program.SetUniformMaybe(UniITexturePixelSize, Vector2.One / loadedTexture.Size);
-
-            ProjViewUBO.Apply(program);
-            UniformConstantsUBO.Apply(program);
 
             var primitiveType = MapPrimitiveType(command.PrimitiveType);
             if (command.Indexed)
@@ -355,6 +357,8 @@ namespace Robust.Client.Graphics.Clyde
             program.Use();
 
             // Assign shader parameters to uniform since they may be dirty.
+            TempSetupUniformBlockEmulator(program);
+
             foreach (var (name, value) in instance.Parameters)
             {
                 if (!program.HasUniform(name))
@@ -458,7 +462,7 @@ namespace Robust.Client.Graphics.Clyde
         private void DrawTexture(ClydeHandle texture, Vector2 bl, Vector2 br, Vector2 tl, Vector2 tr, in Color modulate,
             in Box2 sr)
         {
-            EnsureBatchState(texture, modulate, true, BatchPrimitiveType.TriangleFan, _queuedShader);
+            EnsureBatchState(texture, modulate, true, GetQuadBatchPrimitiveType(), _queuedShader);
 
             bl = _currentMatrixModel.Transform(bl);
             br = _currentMatrixModel.Transform(br);
@@ -472,14 +476,7 @@ namespace Robust.Client.Graphics.Clyde
             BatchVertexData[vIdx + 2] = new Vertex2D(tr, sr.TopRight);
             BatchVertexData[vIdx + 3] = new Vertex2D(tl, sr.TopLeft);
             BatchVertexIndex += 4;
-            var nIdx = BatchIndexIndex;
-            var tIdx = (ushort) vIdx;
-            BatchIndexData[nIdx + 0] = tIdx;
-            BatchIndexData[nIdx + 1] = (ushort) (tIdx + 1);
-            BatchIndexData[nIdx + 2] = (ushort) (tIdx + 2);
-            BatchIndexData[nIdx + 3] = (ushort) (tIdx + 3);
-            BatchIndexData[nIdx + 4] = ushort.MaxValue;
-            BatchIndexIndex += 5;
+            QuadBatchIndexWrite(BatchIndexData, ref BatchIndexIndex, (ushort) vIdx);
 
             _debugStats.LastClydeDrawCalls += 1;
         }
@@ -498,7 +495,7 @@ namespace Robust.Client.Graphics.Clyde
             {
                 var o = BatchIndexIndex + i;
                 var index = indices[i];
-                if (index != ushort.MaxValue) // Don't offset primitive restart.
+                if (index != PrimitiveRestartIndex) // Don't offset primitive restart.
                 {
                     index = (ushort) (index + BatchVertexIndex);
                 }

--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -206,6 +206,7 @@ namespace Robust.Client.Graphics.Clyde
             GL.BindVertexArray(BatchVAO.Handle);
 
             var (program, loaded) = ActivateShaderInstance(command.ShaderInstance);
+            SetupGlobalUniformsImmediate(program, loadedTexture.IsSrgb);
 
             GL.ActiveTexture(TextureUnit.Texture0);
             GL.BindTexture(TextureTarget.Texture2D, loadedTexture.OpenGLObject.Handle);
@@ -357,8 +358,6 @@ namespace Robust.Client.Graphics.Clyde
             program.Use();
 
             // Assign shader parameters to uniform since they may be dirty.
-            TempSetupUniformBlockEmulator(program);
-
             foreach (var (name, value) in instance.Parameters)
             {
                 if (!program.HasUniform(name))

--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -73,7 +73,7 @@ namespace Robust.Client.Graphics.Clyde
         private readonly Vertex2D[] BatchVertexData = new Vertex2D[MaxBatchQuads * 4];
 
         // Only write from InitRenderingBatchBuffers!
-        private ushort[] BatchIndexData;
+        private ushort[] BatchIndexData = default!;
         private int BatchVertexIndex;
         private int BatchIndexIndex;
 

--- a/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
@@ -16,6 +16,8 @@ namespace Robust.Client.Graphics.Clyde
     {
         private ClydeShaderInstance _defaultShader = default!;
 
+        private string _shaderLibrary = default!;
+
         private string _shaderWrapCodeDefaultFrag = default!;
         private string _shaderWrapCodeDefaultVert = default!;
 
@@ -108,6 +110,8 @@ namespace Robust.Client.Graphics.Clyde
 
         private void LoadStockShaders()
         {
+            _shaderLibrary = ReadEmbeddedShader("z-library.glsl");
+
             _shaderWrapCodeDefaultFrag = ReadEmbeddedShader("base-default.frag");
             _shaderWrapCodeDefaultVert = ReadEmbeddedShader("base-default.vert");
 
@@ -150,13 +154,18 @@ namespace Robust.Client.Graphics.Clyde
                 versionHeader += "#define HAS_FLOAT_TEXTURES\n";
             }
 
+            if (_hasGLSrgb)
+            {
+                versionHeader += "#define HAS_SRGB\n";
+            }
+
             if (_hasGLUniformBuffers)
             {
                 versionHeader += "#define HAS_UNIFORM_BUFFERS\n";
             }
 
-            vertexSource = versionHeader + vertexSource;
-            fragmentSource = versionHeader + fragmentSource;
+            vertexSource = versionHeader + _shaderLibrary + vertexSource;
+            fragmentSource = versionHeader + _shaderLibrary + fragmentSource;
 
             try
             {

--- a/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
@@ -131,6 +131,22 @@ namespace Robust.Client.Graphics.Clyde
             GLShader? vertexShader = null;
             GLShader? fragmentShader = null;
 
+            var versionHeader = "#version 140\n#define HAS_DFDX\n";
+
+            if (_hasGLES)
+            {
+                // GLES2 uses a different GLSL versioning scheme to desktop GL.
+                versionHeader = "#version 100\n";
+            }
+
+            if (_hasGLUniformBuffers)
+            {
+                versionHeader += "#define HAS_UNIFORM_BUFFERS\n";
+            }
+
+            vertexSource = versionHeader + vertexSource;
+            fragmentSource = versionHeader + fragmentSource;
+
             try
             {
                 try
@@ -139,8 +155,9 @@ namespace Robust.Client.Graphics.Clyde
                 }
                 catch (ShaderCompilationException e)
                 {
+                    System.IO.File.WriteAllText("error.glsl", vertexSource);
                     throw new ShaderCompilationException(
-                        "Failed to compile vertex shader, see inner for details.", e);
+                        "Failed to compile vertex shader, see inner for details (and error.glsl for formatted source).", e);
                 }
 
                 try
@@ -149,8 +166,9 @@ namespace Robust.Client.Graphics.Clyde
                 }
                 catch (ShaderCompilationException e)
                 {
+                    System.IO.File.WriteAllText("error.glsl", fragmentSource);
                     throw new ShaderCompilationException(
-                        "Failed to compile fragment shader, see inner for details.", e);
+                        "Failed to compile fragment shader, see inner for details (and error.glsl for formatted source).", e);
                 }
 
                 var program = new GLShaderProgram(this, name);
@@ -205,8 +223,8 @@ namespace Robust.Client.Graphics.Clyde
 
             foreach (var (name, varying) in shader.Varyings)
             {
-                varyingsFragment.AppendFormat("in {0} {1};\n", varying.Type.GetNativeType(), name);
-                varyingsVertex.AppendFormat("out {0} {1};\n", varying.Type.GetNativeType(), name);
+                varyingsFragment.AppendFormat("varying {0} {1};\n", varying.Type.GetNativeType(), name);
+                varyingsVertex.AppendFormat("varying {0} {1};\n", varying.Type.GetNativeType(), name);
             }
 
             ShaderFunctionDefinition? fragmentMain = null;

--- a/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
@@ -54,8 +54,11 @@ namespace Robust.Client.Graphics.Clyde
 
             var program = _compileProgram(vertBody, fragBody, BaseShaderAttribLocations, name);
 
-            program.BindBlock(UniProjViewMatrices, BindingIndexProjView);
-            program.BindBlock(UniUniformConstants, BindingIndexUniformConstants);
+            if (_hasGLUniformBuffers)
+            {
+                program.BindBlock(UniProjViewMatrices, BindingIndexProjView);
+                program.BindBlock(UniUniformConstants, BindingIndexUniformConstants);
+            }
 
             var loaded = new LoadedShader
             {
@@ -84,8 +87,11 @@ namespace Robust.Client.Graphics.Clyde
 
             loaded.Program = program;
 
-            program.BindBlock(UniProjViewMatrices, BindingIndexProjView);
-            program.BindBlock(UniUniformConstants, BindingIndexUniformConstants);
+            if (_hasGLUniformBuffers)
+            {
+                program.BindBlock(UniProjViewMatrices, BindingIndexProjView);
+                program.BindBlock(UniUniformConstants, BindingIndexUniformConstants);
+            }
         }
 
         public ShaderInstance InstanceShader(ClydeHandle handle)

--- a/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
@@ -143,13 +143,13 @@ namespace Robust.Client.Graphics.Clyde
 
             var versionHeader = "#version 140\n#define HAS_DFDX\n";
 
-            if (_hasGLES)
+            if (_isGLES)
             {
                 // GLES2 uses a different GLSL versioning scheme to desktop GL.
                 versionHeader = "#version 100\n";
             }
 
-            if (_hasGLFancyFloatFormats)
+            if (_hasGLFloatFramebuffers)
             {
                 versionHeader += "#define HAS_FLOAT_TEXTURES\n";
             }

--- a/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
@@ -145,6 +145,11 @@ namespace Robust.Client.Graphics.Clyde
                 versionHeader = "#version 100\n";
             }
 
+            if (_hasGLFancyFloatFormats)
+            {
+                versionHeader += "#define HAS_FLOAT_TEXTURES\n";
+            }
+
             if (_hasGLUniformBuffers)
             {
                 versionHeader += "#define HAS_UNIFORM_BUFFERS\n";

--- a/Robust.Client/Graphics/Clyde/Clyde.Textures.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Textures.cs
@@ -79,7 +79,9 @@ namespace Robust.Client.Graphics.Clyde
 
             if (pixelType == typeof(Rgba32))
             {
-                internalFormat = actualParams.Srgb ? PixelInternalFormat.Srgb8Alpha8 : PixelInternalFormat.Rgba8;
+                // Note that if _hasGLSrgb is off, we import an sRGB texture as non-sRGB.
+                // Shaders are expected to compensate for this
+                internalFormat = (actualParams.Srgb && _hasGLSrgb) ? PixelInternalFormat.Srgb8Alpha8 : PixelInternalFormat.Rgba8;
                 pixelDataFormat = PixelFormat.Rgba;
                 pixelDataType = PixelType.UnsignedByte;
             }

--- a/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
@@ -158,7 +158,6 @@ namespace Robust.Client.Graphics.Clyde
 #endif
             GLFW.WindowHint(WindowHintString.X11ClassName, "SS14");
             GLFW.WindowHint(WindowHintString.X11InstanceName, "SS14");
-            GLFW.WindowHint(WindowHintBool.SrgbCapable, true);
 
             var renderer = (Renderer) _configurationManager.GetCVar<int>("display.renderer");
 
@@ -261,6 +260,7 @@ namespace Robust.Client.Graphics.Clyde
                     GLFW.WindowHint(WindowHintClientApi.ClientApi, ClientApi.OpenGlApi);
                     GLFW.WindowHint(WindowHintContextApi.ContextCreationApi, ContextApi.NativeContextApi);
                     GLFW.WindowHint(WindowHintOpenGlProfile.OpenGlProfile, OpenGlProfile.Core);
+                    GLFW.WindowHint(WindowHintBool.SrgbCapable, true);
                 }
                 else if (r == Renderer.OpenGL31)
                 {
@@ -270,6 +270,7 @@ namespace Robust.Client.Graphics.Clyde
                     GLFW.WindowHint(WindowHintClientApi.ClientApi, ClientApi.OpenGlApi);
                     GLFW.WindowHint(WindowHintContextApi.ContextCreationApi, ContextApi.NativeContextApi);
                     GLFW.WindowHint(WindowHintOpenGlProfile.OpenGlProfile, OpenGlProfile.Any);
+                    GLFW.WindowHint(WindowHintBool.SrgbCapable, true);
                 }
                 else if (r == Renderer.OpenGLES2)
                 {
@@ -281,6 +282,7 @@ namespace Robust.Client.Graphics.Clyde
                     // (It may be an idea to make this a configuration cvar)
                     GLFW.WindowHint(WindowHintContextApi.ContextCreationApi, ContextApi.EglContextApi);
                     GLFW.WindowHint(WindowHintOpenGlProfile.OpenGlProfile, OpenGlProfile.Any);
+                    GLFW.WindowHint(WindowHintBool.SrgbCapable, false);
                 }
                 _glfwWindow = GLFW.CreateWindow(width, height, string.Empty, monitor, null);
             }

--- a/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
@@ -164,9 +164,8 @@ namespace Robust.Client.Graphics.Clyde
 
             Span<Renderer> renderers = (renderer == Renderer.Default) ? stackalloc Renderer[] {
                 Renderer.OpenGL33,
-                Renderer.OpenGL31
-                // This isn't supported at this time.
-                // Renderer.OpenGLES2
+                Renderer.OpenGL31,
+                Renderer.OpenGLES2
             } : stackalloc Renderer[] {renderer};
             
             foreach (Renderer r in renderers)
@@ -175,6 +174,8 @@ namespace Robust.Client.Graphics.Clyde
 
                 if (_glfwWindow != null)
                 {
+                    renderer = r;
+                    _hasGLES = renderer == Renderer.OpenGLES2;
                     break;
                 }
                 // Window failed to init due to error.

--- a/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
@@ -174,7 +174,7 @@ namespace Robust.Client.Graphics.Clyde
                 if (_glfwWindow != null)
                 {
                     renderer = r;
-                    _hasGLES = renderer == Renderer.OpenGLES2;
+                    _isGLES = renderer == Renderer.OpenGLES2;
                     break;
                 }
                 // Window failed to init due to error.

--- a/Robust.Client/Graphics/Clyde/Clyde.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.cs
@@ -323,7 +323,7 @@ namespace Robust.Client.Graphics.Clyde
             void CheckGLCap(ref bool cap, string capName, int majorMin, int minorMin, bool forceDisableOnES, params string[] exts)
             {
                 // Check if feature is available from the GL context.
-                cap = CompareVersion(major, minor, majorMin, minorMin) || extensions.Overlaps(exts);
+                cap = CompareVersion(majorMin, minorMin, major, minor) || extensions.Overlaps(exts);
 
                 var prev = cap;
                 var cVarName = $"display.ogl_block_{capName}";
@@ -347,7 +347,7 @@ namespace Robust.Client.Graphics.Clyde
             Logger.DebugS("clyde.ogl", "OpenGL capabilities:");
 
             CheckGLCap(ref _hasGLKhrDebug, "khr_debug", 4, 2, false, "GL_KHR_debug");
-            CheckGLCap(ref _hasGLSamplerObjects, "sampler_objects", 3, 3, false, "GL_ARB_sampler_objects");
+            CheckGLCap(ref _hasGLSamplerObjects, "sampler_objects", 3, 3, true, "GL_ARB_sampler_objects");
             CheckGLCap(ref _hasGLTextureSwizzle, "texture_swizzle", 3, 3, true, "GL_ARB_texture_swizzle",
                 "GL_EXT_texture_swizzle");
             CheckGLCap(ref _hasGLVertexArrayObject, "vertex_array_object", 3, 0, false, "GL_OES_vertex_array_object",
@@ -446,9 +446,11 @@ namespace Robust.Client.Graphics.Clyde
                     break;
                 case DebugSeverity.DebugSeverityHigh:
                     sawmill.Error(contents);
+                    // throw new ArgumentOutOfRangeException("TEST TEST TEST", severity, null);
                     break;
                 case DebugSeverity.DebugSeverityMedium:
                     sawmill.Error(contents);
+                    // throw new ArgumentOutOfRangeException("TEST TEST TEST", severity, null);
                     break;
                 case DebugSeverity.DebugSeverityLow:
                     sawmill.Warning(contents);

--- a/Robust.Client/Graphics/Clyde/Clyde.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.cs
@@ -41,8 +41,8 @@ namespace Robust.Client.Graphics.Clyde
         [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
         [Dependency] private readonly IGameTiming _gameTiming = default!;
 
-        private GLBuffer ProjViewUBO = default!;
-        private GLBuffer UniformConstantsUBO = default!;
+        private GLUniformBuffer<ProjViewMatrices> ProjViewUBO = default!;
+        private GLUniformBuffer<UniformConstants> UniformConstantsUBO = default!;
 
         private RenderTexture EntityPostRenderTarget = default!;
 
@@ -282,18 +282,8 @@ namespace Robust.Client.Graphics.Clyde
                     sizeof(ushort) * BatchIndexData.Length, nameof(BatchEBO));
             }
 
-            ProjViewUBO = new GLBuffer(this, BufferTarget.UniformBuffer, BufferUsageHint.StreamDraw,
-                nameof(ProjViewUBO));
-            ProjViewUBO.Reallocate(sizeof(ProjViewMatrices));
-
-            GL.BindBufferBase(BufferRangeTarget.UniformBuffer, BindingIndexProjView, ProjViewUBO.ObjectHandle);
-
-            UniformConstantsUBO = new GLBuffer(this, BufferTarget.UniformBuffer, BufferUsageHint.StreamDraw,
-                nameof(UniformConstantsUBO));
-            UniformConstantsUBO.Reallocate(sizeof(UniformConstants));
-
-            GL.BindBufferBase(BufferRangeTarget.UniformBuffer, BindingIndexUniformConstants,
-                UniformConstantsUBO.ObjectHandle);
+            ProjViewUBO = new GLUniformBuffer<ProjViewMatrices>(this, BindingIndexProjView, nameof(ProjViewUBO));
+            UniformConstantsUBO = new GLUniformBuffer<UniformConstants>(this, BindingIndexUniformConstants, nameof(UniformConstantsUBO));
 
             EntityPostRenderTarget = CreateRenderTarget(Vector2i.One * 8 * EyeManager.PixelsPerMeter,
                 new RenderTargetFormatParameters(RenderTargetColorFormat.Rgba8Srgb, true),

--- a/Robust.Client/Graphics/Clyde/Clyde.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.cs
@@ -70,9 +70,9 @@ namespace Robust.Client.Graphics.Clyde
         private bool _hasGLReadFramebuffer;
         private bool _hasGLUniformBuffers;
         private bool _hasGLVertexArrayObject;
-        private bool _hasGLFancyFloatFormats;
+        private bool _hasGLFloatFramebuffers;
         // This is updated from Clyde.Windowing.
-        private bool _hasGLES;
+        private bool _isGLES;
 
         private readonly List<(ScreenshotType type, Action<Image<Rgb24>> callback)> _queuedScreenshots
             = new List<(ScreenshotType, Action<Image<Rgb24>>)>();
@@ -186,7 +186,7 @@ namespace Robust.Client.Graphics.Clyde
             var major = 2;
             var minor = 0;
 
-            if (!_hasGLES)
+            if (!_isGLES)
             {
                 major = GL.GetInteger(GetPName.MajorVersion);
                 minor = GL.GetInteger(GetPName.MinorVersion);
@@ -312,7 +312,7 @@ namespace Robust.Client.Graphics.Clyde
             var major = 0;
             var minor = 0;
 
-            if (!_hasGLES)
+            if (!_isGLES)
             {
                 major = GL.GetInteger(GetPName.MajorVersion);
                 minor = GL.GetInteger(GetPName.MinorVersion);
@@ -333,7 +333,7 @@ namespace Robust.Client.Graphics.Clyde
                     Logger.DebugS("clyde.ogl", $"  {cVarName} SET, BLOCKING {capName} (was: {prev})");
                 }
 
-                if (_hasGLES && forceDisableOnES)
+                if (_isGLES && forceDisableOnES)
                 {
                     cap = false;
                     Logger.DebugS("clyde.ogl", $"  On GLES, BLOCKING {capName}");
@@ -350,12 +350,12 @@ namespace Robust.Client.Graphics.Clyde
                 "GL_EXT_texture_swizzle");
             CheckGLCap(ref _hasGLVertexArrayObject, "vertex_array_object", 3, 0, false, "GL_OES_vertex_array_object",
                 "GL_ARB_vertex_array_object");
-            _hasGLSrgb = !_hasGLES;
-            _hasGLReadFramebuffer = !_hasGLES;
-            _hasGLPrimitiveRestart = !_hasGLES;
-            _hasGLUniformBuffers = !_hasGLES;
-            _hasGLFancyFloatFormats = !_hasGLES;
-            Logger.DebugS("clyde.ogl", $"  GLES: {_hasGLES}");
+            _hasGLSrgb = !_isGLES;
+            _hasGLReadFramebuffer = !_isGLES;
+            _hasGLPrimitiveRestart = !_isGLES;
+            _hasGLUniformBuffers = !_isGLES;
+            _hasGLFloatFramebuffers = !_isGLES;
+            Logger.DebugS("clyde.ogl", $"  GLES: {_isGLES}");
         }
 
         private static bool CompareVersion(int majorA, int minorA, int majorB, int minorB)
@@ -462,7 +462,7 @@ namespace Robust.Client.Graphics.Clyde
 
         private HashSet<string> GetGLExtensions()
         {
-            if (!_hasGLES)
+            if (!_isGLES)
             {
                 var extensions = new HashSet<string>();
                 var extensionsText = "";
@@ -478,7 +478,7 @@ namespace Robust.Client.Graphics.Clyde
                     extensionsText += extension;
                     extensions.Add(extension);
                 }
-                Logger.DebugS("clyde.ogl", "OpenGL Extensions: {0}", extensions);
+                Logger.DebugS("clyde.ogl", "OpenGL Extensions: {0}", extensionsText);
                 return extensions;
             }
             else

--- a/Robust.Client/Graphics/Clyde/Clyde.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.cs
@@ -202,10 +202,6 @@ namespace Robust.Client.Graphics.Clyde
                 GL.Enable(EnableCap.PrimitiveRestart);
                 GL.PrimitiveRestartIndex(PrimitiveRestartIndex);
             }
-            else
-            {
-                Logger.WarningS("clyde.ogl", "NO PRIMITIVE RESTART! Things will probably go terribly, terribly wrong (no fallback path yet)");
-            }
             if (!_hasGLVertexArrayObject)
             {
                 Logger.WarningS("clyde.ogl", "NO VERTEX ARRAY OBJECTS! Things will probably go terribly, terribly wrong (no fallback path yet)");

--- a/Robust.Client/Graphics/Clyde/Clyde.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.cs
@@ -200,7 +200,7 @@ namespace Robust.Client.Graphics.Clyde
             if (_hasGLPrimitiveRestart)
             {
                 GL.Enable(EnableCap.PrimitiveRestart);
-                GL.PrimitiveRestartIndex(ushort.MaxValue);
+                GL.PrimitiveRestartIndex(PrimitiveRestartIndex);
             }
             else
             {
@@ -211,6 +211,9 @@ namespace Robust.Client.Graphics.Clyde
                 Logger.WarningS("clyde.ogl", "NO VERTEX ARRAY OBJECTS! Things will probably go terribly, terribly wrong (no fallback path yet)");
             }
             GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
+
+            // Primitive Restart's presence or lack thereof changes the amount of required memory.
+            InitRenderingBatchBuffers();
 
             Logger.DebugS("clyde.ogl", "Loading stock textures...");
 
@@ -317,7 +320,7 @@ namespace Robust.Client.Graphics.Clyde
                 minor = GL.GetInteger(GetPName.MinorVersion);
             }
 
-            void CheckGLCap(ref bool cap, string capName, int majorMin, int minorMin, params string[] exts)
+            void CheckGLCap(ref bool cap, string capName, int majorMin, int minorMin, bool forceDisableOnES, params string[] exts)
             {
                 // Check if feature is available from the GL context.
                 cap = CompareVersion(major, minor, majorMin, minorMin) || extensions.Overlaps(exts);
@@ -332,16 +335,22 @@ namespace Robust.Client.Graphics.Clyde
                     Logger.DebugS("clyde.ogl", $"  {cVarName} SET, BLOCKING {capName} (was: {prev})");
                 }
 
-                Logger.DebugS("clyde.ogl", $"  {capName}: {_hasGLKhrDebug}");
+                if (_hasGLES && forceDisableOnES)
+                {
+                    cap = false;
+                    Logger.DebugS("clyde.ogl", $"  On GLES, BLOCKING {capName}");
+                }
+
+                Logger.DebugS("clyde.ogl", $"  {capName}: {cap}");
             }
 
             Logger.DebugS("clyde.ogl", "OpenGL capabilities:");
 
-            CheckGLCap(ref _hasGLKhrDebug, "khr_debug", 4, 2, "GL_KHR_debug");
-            CheckGLCap(ref _hasGLSamplerObjects, "sampler_objects", 3, 3, "GL_ARB_sampler_objects");
-            CheckGLCap(ref _hasGLTextureSwizzle, "texture_swizzle", 3, 3, "GL_ARB_texture_swizzle",
+            CheckGLCap(ref _hasGLKhrDebug, "khr_debug", 4, 2, false, "GL_KHR_debug");
+            CheckGLCap(ref _hasGLSamplerObjects, "sampler_objects", 3, 3, false, "GL_ARB_sampler_objects");
+            CheckGLCap(ref _hasGLTextureSwizzle, "texture_swizzle", 3, 3, true, "GL_ARB_texture_swizzle",
                 "GL_EXT_texture_swizzle");
-            CheckGLCap(ref _hasGLVertexArrayObject, "vertex_array_object", 3, 0, "GL_OES_vertex_array_object",
+            CheckGLCap(ref _hasGLVertexArrayObject, "vertex_array_object", 3, 0, false, "GL_OES_vertex_array_object",
                 "GL_ARB_vertex_array_object");
             _hasGLSrgb = !_hasGLES;
             _hasGLReadFramebuffer = !_hasGLES;

--- a/Robust.Client/Graphics/Clyde/Clyde.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.cs
@@ -456,11 +456,9 @@ namespace Robust.Client.Graphics.Clyde
                     break;
                 case DebugSeverity.DebugSeverityHigh:
                     sawmill.Error(contents);
-                    // throw new ArgumentOutOfRangeException("TEST TEST TEST", severity, null);
                     break;
                 case DebugSeverity.DebugSeverityMedium:
                     sawmill.Error(contents);
-                    // throw new ArgumentOutOfRangeException("TEST TEST TEST", severity, null);
                     break;
                 case DebugSeverity.DebugSeverityLow:
                     sawmill.Warning(contents);

--- a/Robust.Client/Graphics/Clyde/Clyde.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.cs
@@ -88,12 +88,14 @@ namespace Robust.Client.Graphics.Clyde
             var window = new RenderWindow(this, windowRid);
             var loadedData = new LoadedRenderTarget
             {
-                IsWindow = true
+                IsWindow = true,
+                IsSrgb = true
             };
             _renderTargets.Add(windowRid, loadedData);
 
             _mainWindowRenderTarget = window;
             _currentRenderTarget = RtToLoaded(window);
+            _currentBoundRenderTarget = _currentRenderTarget;
         }
 
         public override bool Initialize()

--- a/Robust.Client/Graphics/Clyde/Clyde.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.cs
@@ -458,18 +458,34 @@ namespace Robust.Client.Graphics.Clyde
 
         private static DebugProc? _debugMessageCallbackInstance;
 
-        private static HashSet<string> GetGLExtensions()
+        private HashSet<string> GetGLExtensions()
         {
-            var extensions = new HashSet<string>();
-
-            var count = GL.GetInteger(GetPName.NumExtensions);
-            for (var i = 0; i < count; i++)
+            if (!_hasGLES)
             {
-                var extension = GL.GetString(StringNameIndexed.Extensions, i);
-                extensions.Add(extension);
+                var extensions = new HashSet<string>();
+                var extensionsText = "";
+                // Desktop OpenGL uses this API to discourage static buffers
+                var count = GL.GetInteger(GetPName.NumExtensions);
+                for (var i = 0; i < count; i++)
+                {
+                    if (i != 0)
+                    {
+                        extensionsText += " ";
+                    }
+                    var extension = GL.GetString(StringNameIndexed.Extensions, i);
+                    extensionsText += extension;
+                    extensions.Add(extension);
+                }
+                Logger.DebugS("clyde.ogl", "OpenGL Extensions: {0}", extensions);
+                return extensions;
             }
-
-            return extensions;
+            else
+            {
+                // GLES uses the (old?) API
+                var extensions = GL.GetString(StringName.Extensions);
+                Logger.DebugS("clyde.ogl", "OpenGL Extensions: {0}", extensions);
+                return new HashSet<string>(extensions.Split(' '));
+            }
         }
 
         [Conditional("DEBUG")]

--- a/Robust.Client/Graphics/Clyde/GLObjects/Clyde.ShaderProgram.cs
+++ b/Robust.Client/Graphics/Clyde/GLObjects/Clyde.ShaderProgram.cs
@@ -222,12 +222,15 @@ namespace Robust.Client.Graphics.Clyde
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private static unsafe void SetUniformDirect(int slot, in Matrix3 value)
+            private static unsafe void SetUniformDirect(int uniformId, in Matrix3 value, bool transpose=true)
             {
-                fixed (Matrix3* ptr = &value)
+                Matrix3 tmpTranspose = value;
+                if (transpose)
                 {
-                    GL.UniformMatrix3(slot, 1, true, (float*) ptr);
+                    // transposition not supported on GLES2, & no access to _hasGLES
+                    tmpTranspose.Transpose();
                 }
+                GL.UniformMatrix3(uniformId, 1, false, (float*) &tmpTranspose);
             }
 
             public void SetUniform(string uniformName, in Matrix4 matrix, bool transpose=true)
@@ -239,10 +242,13 @@ namespace Robust.Client.Graphics.Clyde
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private static unsafe void SetUniformDirect(int uniformId, in Matrix4 value, bool transpose=true)
             {
-                fixed (Matrix4* ptr = &value)
+                Matrix4 tmpTranspose = value;
+                if (transpose)
                 {
-                    GL.UniformMatrix4(uniformId, 1, transpose, (float*) ptr);
+                    // transposition not supported on GLES2, & no access to _hasGLES
+                    tmpTranspose.Transpose();
                 }
+                GL.UniformMatrix4(uniformId, 1, false, (float*) &tmpTranspose);
             }
 
             public void SetUniform(string uniformName, in Vector4 vector)

--- a/Robust.Client/Graphics/Clyde/GLObjects/Clyde.ShaderProgram.cs
+++ b/Robust.Client/Graphics/Clyde/GLObjects/Clyde.ShaderProgram.cs
@@ -250,7 +250,7 @@ namespace Robust.Client.Graphics.Clyde
                     // transposition not supported on GLES2, & no access to _hasGLES
                     tmpTranspose.Transpose();
                 }
-                GL.UniformMatrix3(uniformId, 1, false, (float*) &tmpTranspose);
+                GL.UniformMatrix3(slot, 1, false, (float*) &tmpTranspose);
                 _clyde.CheckGlError();
             }
 

--- a/Robust.Client/Graphics/Clyde/GLObjects/Clyde.ShaderProgram.cs
+++ b/Robust.Client/Graphics/Clyde/GLObjects/Clyde.ShaderProgram.cs
@@ -111,7 +111,7 @@ namespace Robust.Client.Graphics.Clyde
             {
                 if (!TryGetUniform(name, out var result))
                 {
-                    ThrowCouldNotGetUniform();
+                    ThrowCouldNotGetUniform(name);
                 }
 
                 return result;
@@ -121,7 +121,7 @@ namespace Robust.Client.Graphics.Clyde
             {
                 if (!TryGetUniform(id, out var result))
                 {
-                    ThrowCouldNotGetUniform();
+                    ThrowCouldNotGetUniform($"[id {id}]");
                 }
 
                 return result;
@@ -204,6 +204,12 @@ namespace Robust.Client.Graphics.Clyde
             }
 
             public void SetUniform(string uniformName, float single)
+            {
+                var uniformId = GetUniform(uniformName);
+                GL.Uniform1(uniformId, single);
+            }
+
+            public void SetUniform(int uniformName, float single)
             {
                 var uniformId = GetUniform(uniformName);
                 GL.Uniform1(uniformId, single);
@@ -321,6 +327,12 @@ namespace Robust.Client.Graphics.Clyde
             }
 
             public void SetUniform(string uniformName, in Vector2 vector)
+            {
+                var uniformId = GetUniform(uniformName);
+                SetUniformDirect(uniformId, vector);
+            }
+
+            public void SetUniform(int uniformName, in Vector2 vector)
             {
                 var uniformId = GetUniform(uniformName);
                 SetUniformDirect(uniformId, vector);
@@ -471,9 +483,9 @@ namespace Robust.Client.Graphics.Clyde
                 }
             }
 
-            private static void ThrowCouldNotGetUniform()
+            private static void ThrowCouldNotGetUniform(string name)
             {
-                throw new ArgumentException("Could not get uniform!");
+                throw new ArgumentException($"Could not get uniform \"{name}\"!");
             }
         }
     }

--- a/Robust.Client/Graphics/Clyde/GLObjects/Clyde.UniformBuffer.cs
+++ b/Robust.Client/Graphics/Clyde/GLObjects/Clyde.UniformBuffer.cs
@@ -54,22 +54,6 @@ namespace Robust.Client.Graphics.Clyde
             ///     Updates the buffer contents.
             /// </summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public void Reallocate(Span<T> data)
-            {
-                if (_implUBO != null)
-                {
-                    _implUBO.Reallocate(data);
-                }
-                else
-                {
-                    _implMirror = data[0];
-                }
-            }
-
-            /// <summary>
-            ///     Updates the buffer contents.
-            /// </summary>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void Reallocate(in T data)
             {
                 if (_implUBO != null)

--- a/Robust.Client/Graphics/Clyde/GLObjects/Clyde.UniformBuffer.cs
+++ b/Robust.Client/Graphics/Clyde/GLObjects/Clyde.UniformBuffer.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using OpenToolkit.Graphics.OpenGL4;
+using Robust.Shared.Utility;
+
+namespace Robust.Client.Graphics.Clyde
+{
+    internal partial class Clyde
+    {
+        /// <summary>
+        ///     Represents some set of uniforms that can be backed by a uniform buffer or by regular uniforms.
+        ///     Implies you're using this on a properly setup struct.
+        /// </summary>
+        private interface IAppliableUniformSet
+        {
+            /// <summary>
+            ///     Applies the uniform set directly to a program.
+            /// </summary>
+            void Apply(Clyde clyde, GLShaderProgram program);
+        }
+
+        /// <summary>
+        ///     Represents some set of uniforms that can be backed by a uniform buffer or by regular uniforms.
+        /// </summary>
+        private class GLUniformBuffer<T> where T : unmanaged, IAppliableUniformSet
+        {
+            private readonly Clyde _clyde;
+
+            /// <summary>
+            ///     GPU Buffer (only used when uniform buffers are available)
+            /// </summary>
+            private GLBuffer? _implUBO = null;
+
+            /// <summary>
+            ///     Mirror (only used when uniform buffers are unavailable)
+            /// </summary>
+            private T _implMirror;
+
+            public GLUniformBuffer(Clyde clyde, int index, string? name = null)
+            {
+                _clyde = clyde;
+                if (_clyde._hasGLUniformBuffers)
+                {
+                    _implUBO = new GLBuffer(_clyde, BufferTarget.UniformBuffer, BufferUsageHint.StreamDraw, name);
+                    unsafe {
+                        _implUBO.Reallocate(sizeof(T));
+                    }
+                    GL.BindBufferBase(BufferRangeTarget.UniformBuffer, index, (int) _implUBO.ObjectHandle);
+                }
+            }
+
+            /// <summary>
+            ///     Updates the buffer contents.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void Reallocate(Span<T> data)
+            {
+                if (_implUBO != null)
+                {
+                    _implUBO.Reallocate(data);
+                }
+                else
+                {
+                    _implMirror = data[0];
+                }
+            }
+
+            /// <summary>
+            ///     Updates the buffer contents.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void Reallocate(in T data)
+            {
+                if (_implUBO != null)
+                {
+                    _implUBO.Reallocate(data);
+                }
+                else
+                {
+                    _implMirror = data;
+                }
+            }
+
+            /// <summary>
+            ///     This is important for use on GLES2 - it ensures the uniforms in the specific program are up-to-date.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void Apply(GLShaderProgram program)
+            {
+                if (_implUBO == null)
+                {
+                    _implMirror.Apply(_clyde, program);
+                }
+            }
+        }
+    }
+}

--- a/Robust.Client/Graphics/Clyde/Shaders/base-default.frag
+++ b/Robust.Client/Graphics/Clyde/Shaders/base-default.frag
@@ -1,35 +1,36 @@
-#version 140
-
-out vec4 FragColor;
-
-in vec2 UV;
-in vec2 Pos;
+varying highp vec2 UV;
+varying highp vec2 Pos;
 
 uniform sampler2D TEXTURE;
 uniform sampler2D lightMap;
-uniform vec4 modulate;
+uniform highp vec4 modulate;
 
+#ifdef HAS_UNIFORM_BUFFERS
 layout (std140) uniform uniformConstants
 {
     vec2 SCREEN_PIXEL_SIZE;
     float TIME;
 };
+#else
+uniform highp vec2 SCREEN_PIXEL_SIZE;
+uniform highp float TIME;
+#endif
 
-uniform vec2 TEXTURE_PIXEL_SIZE;
+uniform highp vec2 TEXTURE_PIXEL_SIZE;
 
 #line 1000
 // [SHADER_HEADER_CODE]
 
 void main()
 {
-    vec4 FRAGCOORD = gl_FragCoord;
+    highp vec4 FRAGCOORD = gl_FragCoord;
 
-    vec4 COLOR;
+    lowp vec4 COLOR;
 
     #line 10000
     // [SHADER_CODE]
 
-    vec3 lightSample = texture(lightMap, Pos).rgb;
+    lowp vec3 lightSample = texture2D(lightMap, Pos).rgb;
 
-    FragColor = COLOR * modulate * vec4(lightSample, 1);
+    gl_FragColor = COLOR * modulate * vec4(lightSample, 1.0);
 }

--- a/Robust.Client/Graphics/Clyde/Shaders/base-default.frag
+++ b/Robust.Client/Graphics/Clyde/Shaders/base-default.frag
@@ -1,22 +1,8 @@
 varying highp vec2 UV;
 varying highp vec2 Pos;
 
-uniform sampler2D TEXTURE;
 uniform sampler2D lightMap;
 uniform highp vec4 modulate;
-
-#ifdef HAS_UNIFORM_BUFFERS
-layout (std140) uniform uniformConstants
-{
-    vec2 SCREEN_PIXEL_SIZE;
-    float TIME;
-};
-#else
-uniform highp vec2 SCREEN_PIXEL_SIZE;
-uniform highp float TIME;
-#endif
-
-uniform highp vec2 TEXTURE_PIXEL_SIZE;
 
 #line 1000
 // [SHADER_HEADER_CODE]
@@ -32,5 +18,5 @@ void main()
 
     lowp vec3 lightSample = texture2D(lightMap, Pos).rgb;
 
-    gl_FragColor = COLOR * modulate * vec4(lightSample, 1.0);
+    gl_FragColor = zAdjustResult(COLOR * modulate * vec4(lightSample, 1.0));
 }

--- a/Robust.Client/Graphics/Clyde/Shaders/base-default.vert
+++ b/Robust.Client/Graphics/Clyde/Shaders/base-default.vert
@@ -9,24 +9,6 @@ varying vec2 Pos;
 // Maybe we should merge these CPU side.
 // idk yet.
 uniform mat3 modelMatrix;
-#ifdef HAS_UNIFORM_BUFFERS
-layout (std140) uniform projectionViewMatrices
-{
-    mat3 projectionMatrix;
-    mat3 viewMatrix;
-};
-
-layout (std140) uniform uniformConstants
-{
-    vec2 SCREEN_PIXEL_SIZE;
-    float TIME;
-};
-#else
-uniform mat3 projectionMatrix;
-uniform mat3 viewMatrix;
-uniform vec2 SCREEN_PIXEL_SIZE;
-uniform float TIME;
-#endif
 
 // Allows us to do texture atlassing with texture coordinates 0->1
 // Input texture coordinates get mapped to this range.

--- a/Robust.Client/Graphics/Clyde/Shaders/base-default.vert
+++ b/Robust.Client/Graphics/Clyde/Shaders/base-default.vert
@@ -1,16 +1,15 @@
-#version 140
-
 // Vertex position.
-/*layout (location = 0)*/ in vec2 aPos;
+/*layout (location = 0)*/ attribute vec2 aPos;
 // Texture coordinates.
-/*layout (location = 1)*/ in vec2 tCoord;
+/*layout (location = 1)*/ attribute vec2 tCoord;
 
-out vec2 UV;
-out vec2 Pos;
+varying vec2 UV;
+varying vec2 Pos;
 
 // Maybe we should merge these CPU side.
 // idk yet.
 uniform mat3 modelMatrix;
+#ifdef HAS_UNIFORM_BUFFERS
 layout (std140) uniform projectionViewMatrices
 {
     mat3 projectionMatrix;
@@ -22,6 +21,12 @@ layout (std140) uniform uniformConstants
     vec2 SCREEN_PIXEL_SIZE;
     float TIME;
 };
+#else
+uniform mat3 projectionMatrix;
+uniform mat3 viewMatrix;
+uniform vec2 SCREEN_PIXEL_SIZE;
+uniform float TIME;
+#endif
 
 // Allows us to do texture atlassing with texture coordinates 0->1
 // Input texture coordinates get mapped to this range.
@@ -37,13 +42,13 @@ void main()
     // [SHADER_CODE]
 
     // Pixel snapping to avoid sampling issues on nvidia.
-    VERTEX += 1;
-    VERTEX /= SCREEN_PIXEL_SIZE*2;
+    VERTEX += 1.0;
+    VERTEX /= SCREEN_PIXEL_SIZE*2.0;
     VERTEX = floor(VERTEX + 0.5);
-    VERTEX *= SCREEN_PIXEL_SIZE*2;
-    VERTEX -= 1;
+    VERTEX *= SCREEN_PIXEL_SIZE*2.0;
+    VERTEX -= 1.0;
 
     gl_Position = vec4(VERTEX, 0.0, 1.0);
-    Pos = (VERTEX + 1) / 2;
+    Pos = (VERTEX + 1.0) / 2.0;
     UV = mix(modifyUV.xy, modifyUV.zw, tCoord);
 }

--- a/Robust.Client/Graphics/Clyde/Shaders/base-raw.frag
+++ b/Robust.Client/Graphics/Clyde/Shaders/base-raw.frag
@@ -1,21 +1,7 @@
 varying highp vec2 UV;
 
-uniform sampler2D TEXTURE;
 uniform sampler2D lightMap;
 uniform highp vec4 modulate;
-
-#ifdef HAS_UNIFORM_BUFFERS
-layout (std140) uniform uniformConstants
-{
-    vec2 SCREEN_PIXEL_SIZE;
-    float TIME;
-};
-#else
-uniform highp vec2 SCREEN_PIXEL_SIZE;
-uniform highp float TIME;
-#endif
-
-uniform highp vec2 TEXTURE_PIXEL_SIZE;
 
 // [SHADER_HEADER_CODE]
 
@@ -27,5 +13,5 @@ void main()
 
     // [SHADER_CODE]
 
-    gl_FragColor = COLOR;
+    gl_FragColor = zAdjustResult(COLOR);
 }

--- a/Robust.Client/Graphics/Clyde/Shaders/base-raw.frag
+++ b/Robust.Client/Graphics/Clyde/Shaders/base-raw.frag
@@ -1,18 +1,19 @@
-#version 140
-
-out vec4 FragColor;
-
-in vec2 UV;
+varying highp vec2 UV;
 
 uniform sampler2D TEXTURE;
 uniform sampler2D lightMap;
-uniform vec4 modulate;
+uniform highp vec4 modulate;
 
+#ifdef HAS_UNIFORM_BUFFERS
 layout (std140) uniform uniformConstants
 {
     vec2 SCREEN_PIXEL_SIZE;
     float TIME;
 };
+#else
+uniform highp vec2 SCREEN_PIXEL_SIZE;
+uniform highp float TIME;
+#endif
 
 uniform vec2 TEXTURE_PIXEL_SIZE;
 
@@ -20,11 +21,11 @@ uniform vec2 TEXTURE_PIXEL_SIZE;
 
 void main()
 {
-    vec4 FRAGCOORD = gl_FragCoord;
+    highp vec4 FRAGCOORD = gl_FragCoord;
 
-    vec4 COLOR = vec4(0);
+    lowp vec4 COLOR = vec4(0.0);
 
     // [SHADER_CODE]
 
-    FragColor = COLOR;
+    gl_FragColor = COLOR;
 }

--- a/Robust.Client/Graphics/Clyde/Shaders/base-raw.frag
+++ b/Robust.Client/Graphics/Clyde/Shaders/base-raw.frag
@@ -15,7 +15,7 @@ uniform highp vec2 SCREEN_PIXEL_SIZE;
 uniform highp float TIME;
 #endif
 
-uniform vec2 TEXTURE_PIXEL_SIZE;
+uniform highp vec2 TEXTURE_PIXEL_SIZE;
 
 // [SHADER_HEADER_CODE]
 

--- a/Robust.Client/Graphics/Clyde/Shaders/base-raw.vert
+++ b/Robust.Client/Graphics/Clyde/Shaders/base-raw.vert
@@ -8,25 +8,6 @@ varying vec2 UV;
 // Maybe we should merge these CPU side.
 // idk yet.
 uniform mat3 modelMatrix;
-#ifdef HAS_UNIFORM_BUFFERS
-layout (std140) uniform projectionViewMatrices
-{
-    mat3 projectionMatrix;
-    mat3 viewMatrix;
-};
-
-layout (std140) uniform uniformConstants
-{
-    vec2 SCREEN_PIXEL_SIZE;
-    float TIME;
-};
-#else
-uniform mat3 projectionMatrix;
-uniform mat3 viewMatrix;
-
-uniform vec2 SCREEN_PIXEL_SIZE;
-uniform float TIME;
-#endif
 
 // Allows us to do texture atlassing with texture coordinates 0->1
 // Input texture coordinates get mapped to this range.

--- a/Robust.Client/Graphics/Clyde/Shaders/base-raw.vert
+++ b/Robust.Client/Graphics/Clyde/Shaders/base-raw.vert
@@ -1,15 +1,14 @@
-#version 140
-
 // Vertex position.
-/*layout (location = 0)*/ in vec2 aPos;
+/*layout (location = 0)*/ attribute vec2 aPos;
 // Texture coordinates.
-/*layout (location = 1)*/ in vec2 tCoord;
+/*layout (location = 1)*/ attribute vec2 tCoord;
 
-out vec2 UV;
+varying vec2 UV;
 
 // Maybe we should merge these CPU side.
 // idk yet.
 uniform mat3 modelMatrix;
+#ifdef HAS_UNIFORM_BUFFERS
 layout (std140) uniform projectionViewMatrices
 {
     mat3 projectionMatrix;
@@ -21,6 +20,13 @@ layout (std140) uniform uniformConstants
     vec2 SCREEN_PIXEL_SIZE;
     float TIME;
 };
+#else
+uniform mat3 projectionMatrix;
+uniform mat3 viewMatrix;
+
+uniform vec2 SCREEN_PIXEL_SIZE;
+uniform float TIME;
+#endif
 
 // Allows us to do texture atlassing with texture coordinates 0->1
 // Input texture coordinates get mapped to this range.
@@ -28,11 +34,11 @@ uniform vec4 modifyUV;
 
 vec2 pixel_snap(vec2 vertex)
 {
-    vertex += 1;
-    vertex /= SCREEN_PIXEL_SIZE*2;
+    vertex += 1.0;
+    vertex /= SCREEN_PIXEL_SIZE*2.0;
     vertex = floor(vertex + 0.5);
-    vertex *= SCREEN_PIXEL_SIZE*2;
-    vertex -= 1;
+    vertex *= SCREEN_PIXEL_SIZE*2.0;
+    vertex -= 1.0;
 
     return vertex;
 }

--- a/Robust.Client/Graphics/Clyde/Shaders/shadow-depth.frag
+++ b/Robust.Client/Graphics/Clyde/Shaders/shadow-depth.frag
@@ -1,12 +1,8 @@
-#version 140
-
-in vec2 pos;
-
-/*layout(location = 0)*/ out vec4 depth;
+varying highp vec2 pos;
 
 void main()
 {
-    vec2 adjustedPos = pos;
+    highp vec2 adjustedPos = pos;
     if (!gl_FrontFacing)
     {
         // Slightly bias back faces inwards.
@@ -14,9 +10,14 @@ void main()
         // "behind" walls at certain angles/positions.
         //adjustedPos -= sign(adjustedPos) * 1.5/32.0;
     }
-    float dist = length(adjustedPos);
-    float dx = dFdx(dist);
-    float dy = dFdy(dist); // I'm aware derivative of y makes no sense here but oh well.
-    depth = vec4(dist, dist * dist + 0.25 * (dx*dx + dy*dy), 0, 1);
+    highp float dist = length(adjustedPos);
+#ifdef HAS_DFDX
+    highp float dx = dFdx(dist);
+    highp float dy = dFdy(dist); // I'm aware derivative of y makes no sense here but oh well.
+#else
+    highp float dx = 1.0;
+    highp float dy = 1.0;
+#endif
+    gl_FragColor = vec4(dist, dist * dist + 0.25 * (dx*dx + dy*dy), 0.0, 1.0);
 }
 

--- a/Robust.Client/Graphics/Clyde/Shaders/shadow-depth.frag
+++ b/Robust.Client/Graphics/Clyde/Shaders/shadow-depth.frag
@@ -1,17 +1,5 @@
 varying highp vec2 pos;
 
-// BE SURE TO CHECK THE CORRESPONDING UNPACK CODE AT:
-//  RobustToolbox/Resources/Shaders/Internal/shadow_cast_shared.swsl
-// Also, it'd be nice if these functions were put into some sort of common code
-lowp vec4 ffTwoPack(highp vec2 val) {
-#ifdef HAS_FLOAT_TEXTURES
-    return vec4(val, 0.0, 1.0);
-#else
-    highp vec2 valH = floor(val);
-    return vec4(valH / 255.0, val - valH);
-#endif
-}
-
 void main()
 {
     highp vec2 adjustedPos = pos;
@@ -30,6 +18,6 @@ void main()
     highp float dx = 1.0;
     highp float dy = 1.0;
 #endif
-    gl_FragColor = ffTwoPack(vec2(dist, dist * dist + 0.25 * (dx*dx + dy*dy)));
+    gl_FragColor = zClydeShadowDepthPack(vec2(dist, dist * dist + 0.25 * (dx*dx + dy*dy)));
 }
 

--- a/Robust.Client/Graphics/Clyde/Shaders/shadow-depth.frag
+++ b/Robust.Client/Graphics/Clyde/Shaders/shadow-depth.frag
@@ -1,5 +1,17 @@
 varying highp vec2 pos;
 
+// BE SURE TO CHECK THE CORRESPONDING UNPACK CODE AT:
+//  RobustToolbox/Resources/Shaders/Internal/shadow_cast_shared.swsl
+// Also, it'd be nice if these functions were put into some sort of common code
+lowp vec4 ffTwoPack(highp vec2 val) {
+#ifdef HAS_FLOAT_TEXTURES
+    return vec4(val, 0.0, 1.0);
+#else
+    highp vec2 valH = floor(val);
+    return vec4(valH / 255.0, val - valH);
+#endif
+}
+
 void main()
 {
     highp vec2 adjustedPos = pos;
@@ -18,6 +30,6 @@ void main()
     highp float dx = 1.0;
     highp float dy = 1.0;
 #endif
-    gl_FragColor = vec4(dist, dist * dist + 0.25 * (dx*dx + dy*dy), 0.0, 1.0);
+    gl_FragColor = ffTwoPack(vec2(dist, dist * dist + 0.25 * (dx*dx + dy*dy)));
 }
 

--- a/Robust.Client/Graphics/Clyde/Shaders/shadow-depth.vert
+++ b/Robust.Client/Graphics/Clyde/Shaders/shadow-depth.vert
@@ -1,15 +1,13 @@
-#version 140
+/*layout (location = 0)*/ attribute vec3 aPos;
 
-/*layout (location = 0)*/ in vec3 aPos;
-
-out vec2 pos;
+varying vec2 pos;
 
 uniform mat4 projectionMatrix;
 uniform mat4 lightMatrix;
 
 void main()
 {
-    vec4 rel = lightMatrix * vec4(aPos, 1);
+    vec4 rel = lightMatrix * vec4(aPos, 1.0);
     gl_Position = projectionMatrix * rel;
     pos = rel.xy;
 }

--- a/Robust.Client/Graphics/Clyde/Shaders/shadow-depth.vert
+++ b/Robust.Client/Graphics/Clyde/Shaders/shadow-depth.vert
@@ -2,12 +2,13 @@
 
 varying vec2 pos;
 
-uniform mat4 projectionMatrix;
-uniform mat4 lightMatrix;
+// Note: This is *not* the standard projectionMatrix!
+uniform mat4 shadowProjectionMatrix;
+uniform mat4 shadowLightMatrix;
 
 void main()
 {
-    vec4 rel = lightMatrix * vec4(aPos, 1.0);
-    gl_Position = projectionMatrix * rel;
+    vec4 rel = shadowLightMatrix * vec4(aPos, 1.0);
+    gl_Position = shadowProjectionMatrix * rel;
     pos = rel.xy;
 }

--- a/Robust.Client/Graphics/Clyde/Shaders/z-library.glsl
+++ b/Robust.Client/Graphics/Clyde/Shaders/z-library.glsl
@@ -47,5 +47,64 @@ highp vec4 zToSrgb(highp vec4 sRGB)
     return vec4(mix(lower, higher, s), sRGB.a);
 }
 
+// -- uniforms --
+
+#ifdef HAS_UNIFORM_BUFFERS
+layout (std140) uniform projectionViewMatrices
+{
+    mat3 projectionMatrix;
+    mat3 viewMatrix;
+};
+
+layout (std140) uniform uniformConstants
+{
+    vec2 SCREEN_PIXEL_SIZE;
+    float TIME;
+};
+#else
+uniform highp mat3 projectionMatrix;
+uniform highp mat3 viewMatrix;
+uniform highp vec2 SCREEN_PIXEL_SIZE;
+uniform highp float TIME;
+#endif
+
+uniform sampler2D TEXTURE;
+uniform highp vec2 TEXTURE_PIXEL_SIZE;
+
+// -- srgb emulation --
+
+#ifdef HAS_SRGB
+highp vec4 zTexture(highp vec2 uv)
+{
+    return texture2D(TEXTURE, uv);
+}
+
+highp vec4 zAdjustResult(highp vec4 col)
+{
+    return col;
+}
+#else
+uniform lowp vec2 SRGB_EMU_CONFIG;
+
+highp vec4 zTexture(highp vec2 uv)
+{
+    highp vec4 col = texture2D(TEXTURE, uv);
+    if (SRGB_EMU_CONFIG.x > 0.5)
+    {
+        return zFromSrgb(col);
+    }
+    return col;
+}
+
+highp vec4 zAdjustResult(highp vec4 col)
+{
+    if (SRGB_EMU_CONFIG.y > 0.5)
+    {
+        return zToSrgb(col);
+    }
+    return col;
+}
+#endif
+
 // -- Utilities End --
 

--- a/Robust.Client/Graphics/Clyde/Shaders/z-library.glsl
+++ b/Robust.Client/Graphics/Clyde/Shaders/z-library.glsl
@@ -29,5 +29,23 @@ highp vec2 zClydeShadowDepthUnpack(highp vec4 val) {
 #endif
 }
 
+// -- srgb/linear conversion core --
+
+highp vec4 zFromSrgb(highp vec4 sRGB)
+{
+    highp vec3 higher = pow((sRGB.rgb + 0.055) / 1.055, vec3(2.4));
+    highp vec3 lower = sRGB.rgb / 12.92;
+    highp vec3 s = max(vec3(0.0), sign(sRGB.rgb - 0.04045));
+    return vec4(mix(lower, higher, s), sRGB.a);
+}
+
+highp vec4 zToSrgb(highp vec4 sRGB)
+{
+    highp vec3 higher = (pow(sRGB.rgb, vec3(0.41666666666667)) * 1.055) - 0.055;
+    highp vec3 lower = sRGB.rgb * 12.92;
+    highp vec3 s = max(vec3(0.0), sign(sRGB.rgb - 0.0031308));
+    return vec4(mix(lower, higher, s), sRGB.a);
+}
+
 // -- Utilities End --
 

--- a/Robust.Client/Graphics/Clyde/Shaders/z-library.glsl
+++ b/Robust.Client/Graphics/Clyde/Shaders/z-library.glsl
@@ -1,0 +1,33 @@
+
+// -- Utilities Start --
+
+// It's literally just called the Z-Library for alphabetical ordering reasons.
+//  - 20kdc
+
+// -- shadow depth --
+
+// If float textures are supported, puts the values in the R/G fields.
+// This assumes RG32F format.
+// If float textures are NOT supported.
+// This assumes RGBA8 format.
+// Operational range is "whatever works for FOV depth"
+highp vec4 zClydeShadowDepthPack(highp vec2 val) {
+#ifdef HAS_FLOAT_TEXTURES
+    return vec4(val, 0.0, 1.0);
+#else
+    highp vec2 valH = floor(val);
+    return vec4(valH / 255.0, val - valH);
+#endif
+}
+
+// Inverts the previous function.
+highp vec2 zClydeShadowDepthUnpack(highp vec4 val) {
+#ifdef HAS_FLOAT_TEXTURES
+    return val.xy;
+#else
+    return (val.xy * 255.0) + val.zw;
+#endif
+}
+
+// -- Utilities End --
+

--- a/Robust.Client/Graphics/Shaders/ParsedShader.cs
+++ b/Robust.Client/Graphics/Shaders/ParsedShader.cs
@@ -35,7 +35,7 @@ namespace Robust.Client.Graphics.Shaders
 
     internal sealed class ShaderFunctionDefinition
     {
-        public ShaderFunctionDefinition(string name, ShaderDataType returnType,
+        public ShaderFunctionDefinition(string name, ShaderDataTypeFull returnType,
             IReadOnlyList<ShaderFunctionParameter> parameters, string body)
         {
             Name = name;
@@ -45,14 +45,14 @@ namespace Robust.Client.Graphics.Shaders
         }
 
         public string Name { get; }
-        public ShaderDataType ReturnType { get; }
+        public ShaderDataTypeFull ReturnType { get; }
         public IReadOnlyList<ShaderFunctionParameter> Parameters { get; }
         public string Body { get; }
     }
 
     internal sealed class ShaderFunctionParameter
     {
-        public ShaderFunctionParameter(string name, ShaderDataType type, ShaderParameterQualifiers qualifiers)
+        public ShaderFunctionParameter(string name, ShaderDataTypeFull type, ShaderParameterQualifiers qualifiers)
         {
             Name = name;
             Type = type;
@@ -60,25 +60,25 @@ namespace Robust.Client.Graphics.Shaders
         }
 
         public string Name { get; }
-        public ShaderDataType Type { get; }
+        public ShaderDataTypeFull Type { get; }
         public ShaderParameterQualifiers Qualifiers { get; }
     }
 
     internal sealed class ShaderVaryingDefinition
     {
-        public ShaderVaryingDefinition(string name, ShaderDataType type)
+        public ShaderVaryingDefinition(string name, ShaderDataTypeFull type)
         {
             Name = name;
             Type = type;
         }
 
         public string Name { get; }
-        public ShaderDataType Type { get; }
+        public ShaderDataTypeFull Type { get; }
     }
 
     internal sealed class ShaderUniformDefinition
     {
-        public ShaderUniformDefinition(string name, ShaderDataType type, string? defaultValue)
+        public ShaderUniformDefinition(string name, ShaderDataTypeFull type, string? defaultValue)
         {
             Name = name;
             Type = type;
@@ -86,13 +86,13 @@ namespace Robust.Client.Graphics.Shaders
         }
 
         public string Name { get; }
-        public ShaderDataType Type { get; }
+        public ShaderDataTypeFull Type { get; }
         public string? DefaultValue { get; }
     }
 
     internal sealed class ShaderConstantDefinition
     {
-        public ShaderConstantDefinition(string name, ShaderDataType type, string value)
+        public ShaderConstantDefinition(string name, ShaderDataTypeFull type, string value)
         {
             Name = name;
             Type = type;
@@ -100,7 +100,7 @@ namespace Robust.Client.Graphics.Shaders
         }
 
         public string Name { get; }
-        public ShaderDataType Type { get; }
+        public ShaderDataTypeFull Type { get; }
         public string Value { get; }
     }
 
@@ -133,6 +133,40 @@ namespace Robust.Client.Graphics.Shaders
         USampler2D,
     }
 
+    internal sealed class ShaderDataTypeFull
+    {
+        public ShaderDataTypeFull(ShaderDataType type, ShaderPrecisionQualifier prec)
+        {
+            Type = type;
+            Precision = prec;
+        }
+
+        public ShaderDataType Type { get; }
+        public ShaderPrecisionQualifier Precision { get; }
+
+        public string GetNativeType()
+        {
+            if (Precision == ShaderPrecisionQualifier.Low)
+            {
+                return "lowp " + Type.GetNativeType();
+            }
+            else if (Precision == ShaderPrecisionQualifier.Medium)
+            {
+                return "mediump " + Type.GetNativeType();
+            }
+            else if (Precision == ShaderPrecisionQualifier.High)
+            {
+                return "highp " + Type.GetNativeType();
+            }
+            return Type.GetNativeType();
+        }
+        
+        public bool TypePrecisionConsistent()
+        {
+            return Type.TypeHasPrecision() == (Precision != ShaderPrecisionQualifier.None);
+        }
+    }
+
     internal static class ShaderEnumExt
     {
         public static string GetNativeType(this ShaderDataType type)
@@ -155,6 +189,18 @@ namespace Robust.Client.Graphics.Shaders
                 default:
                     throw new ArgumentOutOfRangeException(nameof(qualifier), qualifier, null);
             }
+        }
+        
+        public static bool TypeHasPrecision(this ShaderDataType type)
+        {
+            return
+                (type == ShaderDataType.Float) ||
+                (type == ShaderDataType.Vec2) ||
+                (type == ShaderDataType.Vec3) ||
+                (type == ShaderDataType.Vec4) ||
+                (type == ShaderDataType.Mat2) ||
+                (type == ShaderDataType.Mat3) ||
+                (type == ShaderDataType.Mat4);
         }
 
         [SuppressMessage("ReSharper", "StringLiteralTypo")]
@@ -215,5 +261,13 @@ namespace Robust.Client.Graphics.Shaders
         In = 1,
         Out = 2,
         Inout = 3,
+    }
+
+    internal enum ShaderPrecisionQualifier
+    {
+        None = 0,
+        Low = 1,
+        Medium = 2,
+        High = 3
     }
 }

--- a/Robust.Client/Graphics/Shaders/ShaderParser.Tokenizer.cs
+++ b/Robust.Client/Graphics/Shaders/ShaderParser.Tokenizer.cs
@@ -105,12 +105,30 @@ namespace Robust.Client.Graphics.Shaders
             _currentParser!.EatWhitespace();
             var word = _parseWord();
 
-            if (word.Word != "include")
+            if (word.Word == "include")
+            {
+                HandleInclude();
+            }
+            else if (word.Word == "ifdef")
+            {
+                HandleVerbatimProcessor(word);
+            }
+            else if (word.Word == "endif")
+            {
+                HandleVerbatimProcessor(word);
+            }
+            else if (word.Word == "ifndef")
+            {
+                HandleVerbatimProcessor(word);
+            }
+            else if (word.Word == "else")
+            {
+                HandleVerbatimProcessor(word);
+            }
+            else
             {
                 throw new ShaderParseException($"Unknown preprocessor directive '{word.Word}'");
             }
-
-            HandleInclude();
         }
 
         private void HandleInclude()
@@ -144,6 +162,17 @@ namespace Robust.Client.Graphics.Shaders
             using var reader = new StreamReader(stream, EncodingHelpers.UTF8);
 
             PushTokenize(reader, pathString);
+        }
+
+        private void HandleVerbatimProcessor(TokenWord word)
+        {
+            var basis = "#" + word.Word + " ";
+            while (!_currentParser!.IsEOL())
+            {
+                basis += _currentParser.Take();
+            }
+            basis += '\n';
+            _tokens.Add(new TokenWord(basis, word.Position));
         }
 
         private TokenSymbol _parseSymbol(char chr)

--- a/Robust.Client/Graphics/Shaders/ShaderParser.cs
+++ b/Robust.Client/Graphics/Shaders/ShaderParser.cs
@@ -196,15 +196,9 @@ namespace Robust.Client.Graphics.Shaders
 
         private void _parseFunction()
         {
+            var retType = _parseShaderType();
+
             var token = _takeToken();
-            if (!(token is TokenWord typeToken))
-            {
-                throw new ShaderParseException("Expected type.", token?.Position);
-            }
-
-            var retType = _parseShaderType(typeToken);
-
-            token = _takeToken();
             if (!(token is TokenWord nameToken))
             {
                 throw new ShaderParseException("Expected function name.", token?.Position);
@@ -268,7 +262,8 @@ namespace Robust.Client.Graphics.Shaders
                         paramTypeToken = paramTypeTokenForReal;
                     }
 
-                    var paramType = _parseShaderType(paramTypeToken);
+                    _revToken();
+                    var paramType = _parseShaderType();
 
                     token = _takeToken();
                     if (!(token is TokenWord paramNameToken))
@@ -344,13 +339,7 @@ namespace Robust.Client.Graphics.Shaders
         private void _parseUniform()
         {
             _takeToken();
-            var typeToken = _takeToken();
-            if (!(typeToken is TokenWord wordType))
-            {
-                throw new ShaderParseException("Expected type.", typeToken?.Position);
-            }
-
-            var type = _parseShaderType(wordType);
+            var type = _parseShaderType();
 
             var nameToken = _takeToken();
             if (!(nameToken is TokenWord wordName))
@@ -406,13 +395,7 @@ namespace Robust.Client.Graphics.Shaders
         private void ParseConstant()
         {
             _takeToken();
-            var typeToken = _takeToken();
-            if (!(typeToken is TokenWord wordType))
-            {
-                throw new ShaderParseException("Expected type.", typeToken?.Position);
-            }
-
-            var type = _parseShaderType(wordType);
+            var type = _parseShaderType();
 
             var nameToken = _takeToken();
             if (!(nameToken is TokenWord wordName))
@@ -454,13 +437,7 @@ namespace Robust.Client.Graphics.Shaders
         private void _parseVarying()
         {
             _takeToken();
-            var typeToken = _takeToken();
-            if (!(typeToken is TokenWord wordType))
-            {
-                throw new ShaderParseException("Expected type.", typeToken?.Position);
-            }
-
-            var type = _parseShaderType(wordType);
+            var type = _parseShaderType();
 
             var nameToken = _takeToken();
             if (!(nameToken is TokenWord wordName))
@@ -502,15 +479,53 @@ namespace Robust.Client.Graphics.Shaders
             return _tokens[_tokenIndex++];
         }
 
-        private static ShaderDataType _parseShaderType(TokenWord word)
+        private void _revToken()
         {
-            if (_shaderTypeMap.TryGetValue(word.Word, out var ret))
+            if (_tokenIndex == 0)
             {
-                return ret;
+                throw new ShaderParseException("Managed to get parser to reverse off of the start");
             }
-
-            throw new ShaderParseException("Expected <type>", word.Position);
+            _tokenIndex--;
         }
+
+        private ShaderDataTypeFull _parseShaderType()
+        {
+            var precision = ShaderPrecisionQualifier.None;
+            while (true) {
+                var typeToken = _takeToken();
+                if (!(typeToken is TokenWord wordType))
+                {
+                    throw new ShaderParseException("Expected type or precision", typeToken?.Position);
+                }
+
+                if (_shaderTypePrecisionMap.TryGetValue(wordType.Word, out var tmprc))
+                {
+                    precision = tmprc;
+                    continue;
+                }
+
+                if (_shaderTypeMap.TryGetValue(wordType.Word, out var ret))
+                {
+                    var result = new ShaderDataTypeFull(ret, precision);
+                    if (!result.TypePrecisionConsistent())
+                    {
+                        throw new ShaderParseException($"Type {ret} cannot accept precision {precision}", wordType.Position);
+                    }
+                    return result;
+                }
+
+                throw new ShaderParseException("Expected type or precision", wordType.Position);
+            }
+        }
+
+        [SuppressMessage("ReSharper", "StringLiteralTypo")]
+        private static readonly Dictionary<string, ShaderPrecisionQualifier> _shaderTypePrecisionMap =
+            new Dictionary<string, ShaderPrecisionQualifier>
+            {
+                {"lowp", ShaderPrecisionQualifier.Low},
+                {"mediump", ShaderPrecisionQualifier.Medium},
+                {"highp", ShaderPrecisionQualifier.High}
+            };
 
         [SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static readonly Dictionary<string, ShaderDataType> _shaderTypeMap =

--- a/Robust.Client/Graphics/Shaders/ShaderParser.cs
+++ b/Robust.Client/Graphics/Shaders/ShaderParser.cs
@@ -594,7 +594,7 @@ namespace Robust.Client.Graphics.Shaders
 
             public override string ToString()
             {
-                return $"({LineStart}:{LineEnd}:{ColumnStart}:{ColumnEnd})";
+                return $"({FileName}:{LineStart}:{LineEnd}:{ColumnStart}:{ColumnEnd})";
             }
         }
     }

--- a/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
+++ b/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
@@ -221,7 +221,7 @@ namespace Robust.Client.Graphics.Shaders
                 }
             }
 
-            source += "void fragment() {\n    COLOR = texture2D(TEXTURE, UV);\n}";
+            source += "void fragment() {\n    COLOR = zTexture(UV);\n}";
 
             var preset = ShaderParser.Parse(source, _resourceCache);
             CompiledCanvasShader = _clyde.LoadShader(preset, $"canvas_preset_{ID}");

--- a/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
+++ b/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
@@ -170,7 +170,7 @@ namespace Robust.Client.Graphics.Shaders
                         continue;
                     }
 
-                    var value = _parseUniformValue(item.Value, uniformDefinition.Type);
+                    var value = _parseUniformValue(item.Value, uniformDefinition.Type.Type);
                     ShaderParams.Add(name, value);
                 }
             }
@@ -221,7 +221,7 @@ namespace Robust.Client.Graphics.Shaders
                 }
             }
 
-            source += "void fragment() {\n    COLOR = texture(TEXTURE, UV);\n}";
+            source += "void fragment() {\n    COLOR = texture2D(TEXTURE, UV);\n}";
 
             var preset = ShaderParser.Parse(source, _resourceCache);
             CompiledCanvasShader = _clyde.LoadShader(preset, $"canvas_preset_{ID}");

--- a/Robust.Client/UserInterface/CustomControls/BaseWindow.cs
+++ b/Robust.Client/UserInterface/CustomControls/BaseWindow.cs
@@ -217,7 +217,10 @@ namespace Robust.Client.UserInterface.CustomControls
             {
                 LayoutContainer.SetSize(this, CombinedMinimumSize);
                 Open();
-                LayoutContainer.SetPosition(this, (Parent!.Size - Size) / 2);
+                // An explaination: The BadOpenGLVersionWindow was showing up off the top-left corner of the screen.
+                // Basically, if OpenCentered happens super-early, RootControl doesn't get time to layout children.
+                // But we know that this is always going to be one of the roots anyway for now.
+                LayoutContainer.SetPosition(this, (UserInterfaceManager.RootControl.Size - Size) / 2);
                 _firstTimeOpened = false;
             }
             else


### PR DESCRIPTION
NOTE: This *requires* the companion 20kdc/space-station-14 branch "the-second-one". https://github.com/space-wizards/space-station-14/pull/1956
This adds support for OpenGL ES 2 to the renderer.
This allows supporting older hardware or hardware with buggy OpenGL 3 drivers.
The usage of OpenGL ES in particular allows usage of the core profile, allows using ANGLE, which may provide some bug-isolation.
Note that the current implementation requires some OpenGL ES 2 extensions (which will generally be present in desktop implementations, i.e. via ANGLE) like Vertex Array Objects and Non-Power Of Two textures.