### PR TITLE
Make more light properties animatable

### DIFF
--- a/Robust.Client/Animations/AnimationTrackProperty.cs
+++ b/Robust.Client/Animations/AnimationTrackProperty.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Robust.Shared.Animations;
 using Robust.Shared.Maths;
@@ -86,7 +86,7 @@ namespace Robust.Client.Animations
 
         protected abstract void ApplyProperty(object context, object value);
 
-        private static object InterpolateLinear(object a, object b, float t)
+        protected static object InterpolateLinear(object a, object b, float t)
         {
             switch (a)
             {
@@ -112,7 +112,7 @@ namespace Robust.Client.Animations
             }
         }
 
-        private static object InterpolateCubic(object preA, object a, object b, object postB, float t)
+        protected static object InterpolateCubic(object preA, object a, object b, object postB, float t)
         {
             switch (a)
             {

--- a/Robust.Client/GameObjects/Components/Light/PointLightComponent.cs
+++ b/Robust.Client/GameObjects/Components/Light/PointLightComponent.cs
@@ -10,6 +10,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
+using System;
 
 namespace Robust.Client.GameObjects
 {
@@ -125,7 +126,7 @@ namespace Robust.Client.GameObjects
             get => _radius;
             set
             {
-                _radius = value;
+                _radius = MathF.Max(value, 0.01f); // setting radius to 0 causes exceptions, so just use a value close enough to zero that it's unnoticeable.
                 Owner.EntityManager.EventBus.RaiseEvent(EventSource.Local, new PointLightRadiusChangedMessage(this));
             }
         }

--- a/Robust.Client/GameObjects/Components/Light/PointLightComponent.cs
+++ b/Robust.Client/GameObjects/Components/Light/PointLightComponent.cs
@@ -21,6 +21,7 @@ namespace Robust.Client.GameObjects
         internal bool TreeUpdateQueued { get; set; }
 
         [ViewVariables(VVAccess.ReadWrite)]
+        [Animatable]
         public Color Color
         {
             get => _color;
@@ -35,6 +36,7 @@ namespace Robust.Client.GameObjects
         }
 
         [ViewVariables(VVAccess.ReadWrite)]
+        [Animatable]
         public bool Enabled
         {
             get => _enabled;
@@ -73,6 +75,7 @@ namespace Robust.Client.GameObjects
         public Texture? Mask { get; set; }
 
         [ViewVariables(VVAccess.ReadWrite)]
+        [Animatable]
         public float Energy
         {
             get => _energy;


### PR DESCRIPTION
5 properties can now be animated on point lights:

- Radius
- Rotation
- Enabled
- Color
- Energy

Maybe Enabled doesn't have to be something animatable since energy can be set to low values to achieve the same results.

Also, i made a couple methods in AnimationTrackProperty protected instead of private so inheriting classes can use those.