### PR TITLE
More configurable lighting (also, "Rounded" mode for Range)

### DIFF
--- a/Resources/Shaders/Internal/light-hard.swsl
+++ b/Resources/Shaders/Internal/light-hard.swsl
@@ -1,0 +1,11 @@
+#include "/Shaders/Internal/light_shared.swsl"
+
+highp float createOcclusion(highp vec2 diff)
+{
+    highp float ourDist = length(diff);
+
+    highp vec2 occlDist = occludeDepth(diff, shadowMap, lightIndex);
+
+    return smoothstep(0.1, 1.0, ChebyshevUpperBound(occlDist, ourDist));
+}
+

--- a/Resources/Shaders/Internal/light-soft.swsl
+++ b/Resources/Shaders/Internal/light-soft.swsl
@@ -1,0 +1,30 @@
+#include "/Shaders/Internal/light_shared.swsl"
+
+highp float createOcclusion(highp vec2 diff)
+{
+    // Calculate vector perpendicular to light vector.
+    // So we can sample it to get a decent soft shadow?
+    highp vec2 perpendicular = normalize(cross(vec3(diff, 0.0), vec3(0.0, 0.0, 1.0)).xy) * 1.0 / 32.0;
+
+    highp float ourDist = length(diff);
+
+    highp vec2 occlDist = occludeDepth(diff, shadowMap, lightIndex);
+
+    // Change soft shadow size based on distance from primary occluder.
+    highp float distRatio = (ourDist - occlDist.x) / occlDist.x / 2.0;
+
+    perpendicular *= distRatio;
+
+    // Totally not hacky PCF on top of VSM.
+    highp float occlusion = smoothstep(0.1, 1.0, ChebyshevUpperBound(occlDist, ourDist));
+
+    occlusion += shadowContrib(diff + perpendicular);
+    occlusion += shadowContrib(diff - perpendicular);
+    occlusion += shadowContrib(diff + perpendicular * 2.0);
+    occlusion += shadowContrib(diff - perpendicular * 2.0);
+    occlusion += shadowContrib(diff + perpendicular * 3.0);
+    occlusion += shadowContrib(diff - perpendicular * 3.0);
+
+    return occlusion / 7.0;
+}
+

--- a/Resources/Shaders/Internal/light_shared.swsl
+++ b/Resources/Shaders/Internal/light_shared.swsl
@@ -38,30 +38,8 @@ void fragment()
 
     highp vec2 diff = worldPosition - lightCenter;
 
-    // Calculate vector perpendicular to light vector.
-    // So we can sample it to get a decent soft shadow?
-    highp vec2 perpendicular = normalize(cross(vec3(diff, 0.0), vec3(0.0, 0.0, 1.0)).xy) * 1.0 / 32.0;
-
-    highp float ourDist = length(diff);
-
-    highp vec2 occlDist = occludeDepth(diff, shadowMap, lightIndex);
-
-    // Change soft shadow size based on distance from primary occluder.
-    highp float distRatio = (ourDist - occlDist.x) / occlDist.x / 2.0;
-
-    perpendicular *= distRatio;
-
     // Totally not hacky PCF on top of VSM.
-    highp float occlusion = smoothstep(0.1, 1.0, ChebyshevUpperBound(occlDist, ourDist));
-
-    occlusion += shadowContrib(diff + perpendicular);
-    occlusion += shadowContrib(diff - perpendicular);
-    occlusion += shadowContrib(diff + perpendicular * 2.0);
-    occlusion += shadowContrib(diff - perpendicular * 2.0);
-    occlusion += shadowContrib(diff + perpendicular * 3.0);
-    occlusion += shadowContrib(diff - perpendicular * 3.0);
-
-    occlusion /= 7.0;
+    highp float occlusion = createOcclusion(diff);
 
     if (occlusion == 0.0)
     {
@@ -76,3 +54,4 @@ void fragment()
 
     COLOR = vec4(lightColor.rgb, val * occlusion);
 }
+

--- a/Robust.Client/Graphics/Clyde/Clyde.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.cs
@@ -59,7 +59,8 @@ namespace Robust.Client.Graphics.Clyde
 
         private GLShaderProgram? _currentProgram;
 
-        private bool _quartResLights = true;
+        private int _lightmapDivider = 2;
+        private bool _enableSoftShadows = true;
 
         private bool _checkGLErrors;
 
@@ -124,7 +125,8 @@ namespace Robust.Client.Graphics.Clyde
         protected override void ReadConfig()
         {
             base.ReadConfig();
-            _quartResLights = !_configurationManager.GetCVar<bool>("display.highreslights");
+            _lightmapDivider = _configurationManager.GetCVar<int>("display.lightmapdivider");
+            _enableSoftShadows = _configurationManager.GetCVar<bool>("display.softshadows");
         }
 
         protected override void ReloadConfig()

--- a/Robust.Client/Graphics/ClydeBase.cs
+++ b/Robust.Client/Graphics/ClydeBase.cs
@@ -35,7 +35,8 @@ namespace Robust.Client.Graphics
             _configurationManager.RegisterCVar(CVarWindowMode, (int) WindowMode, CVar.ARCHIVE, _windowModeChanged);
             _configurationManager.RegisterCVar("display.width", 1280);
             _configurationManager.RegisterCVar("display.height", 720);
-            _configurationManager.RegisterCVar("display.highreslights", false, onValueChanged: HighResLightsChanged);
+            _configurationManager.RegisterCVar("display.lightmapdivider", 2, onValueChanged: LightmapDividerChanged);
+            _configurationManager.RegisterCVar("display.softshadows", true, onValueChanged: SoftShadowsChanged);
             _configurationManager.RegisterCVar("audio.device", "");
         }
 
@@ -76,7 +77,11 @@ namespace Robust.Client.Graphics
         {
         }
 
-        protected virtual void HighResLightsChanged(bool newValue)
+        protected virtual void LightmapDividerChanged(int newValue)
+        {
+        }
+
+        protected virtual void SoftShadowsChanged(bool newValue)
         {
         }
     }

--- a/Robust.Client/UserInterface/Controls/Range.cs
+++ b/Robust.Client/UserInterface/Controls/Range.cs
@@ -11,6 +11,7 @@ namespace Robust.Client.UserInterface.Controls
         private float _minValue;
         private float _value;
         private float _page;
+        private bool _rounded;
 
         public event Action<Range>? OnValueChanged;
 
@@ -21,7 +22,7 @@ namespace Robust.Client.UserInterface.Controls
 
         public void SetAsRatio(float value)
         {
-            Value = value * (_maxValue - _minValue) + _minValue;
+            Value = ClampValue(value * (_maxValue - _minValue) + _minValue);
         }
 
         [ViewVariables]
@@ -73,6 +74,17 @@ namespace Robust.Client.UserInterface.Controls
             }
         }
 
+        [ViewVariables]
+        public virtual bool Rounded
+        {
+            get => _rounded;
+            set
+            {
+                _rounded = value;
+                _ensureValueClamped();
+            }
+        }
+
         private void _ensureValueClamped()
         {
             var newValue = ClampValue(_value);
@@ -86,6 +98,10 @@ namespace Robust.Client.UserInterface.Controls
         [Pure]
         protected float ClampValue(float value)
         {
+            if (_rounded)
+            {
+                value = MathF.Round(value);
+            }
             return MathHelper.Clamp(value, _minValue, _maxValue-_page);
         }
     }

--- a/Robust.Client/UserInterface/CustomControls/OptionsMenu.cs
+++ b/Robust.Client/UserInterface/CustomControls/OptionsMenu.cs
@@ -53,13 +53,13 @@ namespace Robust.Client.UserInterface.CustomControls
 
             VSyncCheckBox.Pressed = configManager.GetCVar<bool>("display.vsync");
             FullscreenCheckBox.Pressed = ConfigIsFullscreen;
-            LightingPresetOption.SelectId(ConfigLightingQuality);
+            LightingPresetOption.SelectId(GetConfigLightingQuality());
         }
 
         private void OnApplyButtonPressed(BaseButton.ButtonEventArgs args)
         {
             configManager.SetCVar("display.vsync", VSyncCheckBox.Pressed);
-            ConfigLightingQuality = LightingPresetOption.SelectedId;
+            SetConfigLightingQuality(LightingPresetOption.SelectedId);
             configManager.SetCVar("display.windowmode",
                 (int) (FullscreenCheckBox.Pressed ? WindowMode.Fullscreen : WindowMode.Windowed));
             configManager.SaveToFile();
@@ -81,58 +81,55 @@ namespace Robust.Client.UserInterface.CustomControls
         {
             var isVSyncSame = VSyncCheckBox.Pressed == configManager.GetCVar<bool>("display.vsync");
             var isFullscreenSame = FullscreenCheckBox.Pressed == ConfigIsFullscreen;
-            var isLightingQualitySame = LightingPresetOption.SelectedId == ConfigLightingQuality;
+            var isLightingQualitySame = LightingPresetOption.SelectedId == GetConfigLightingQuality();
             ApplyButton.Disabled = isVSyncSame && isFullscreenSame && isLightingQualitySame;
         }
 
         private bool ConfigIsFullscreen =>
             configManager.GetCVar<int>("display.windowmode") == (int) WindowMode.Fullscreen;
 
-        private int ConfigLightingQuality
+        private int GetConfigLightingQuality()
         {
-            get
+            var val = configManager.GetCVar<int>("display.lightmapdivider");
+            var soft = configManager.GetCVar<bool>("display.softshadows");
+            if (val >= 8)
             {
-                var val = configManager.GetCVar<int>("display.lightmapdivider");
-                var soft = configManager.GetCVar<bool>("display.softshadows");
-                if (val >= 8)
-                {
-                    return 0;
-                }
-                else if ((val >= 2) && !soft)
-                {
-                    return 1;
-                }
-                else if (val >= 2)
-                {
-                    return 2;
-                }
-                else
-                {
-                    return 3;
-                }
+                return 0;
             }
-            set
+            else if ((val >= 2) && !soft)
             {
-                if (value == 0)
-                {
-                    configManager.SetCVar("display.lightmapdivider", 8);
-                    configManager.SetCVar("display.softshadows", false);
-                }
-                else if (value == 1)
-                {
-                    configManager.SetCVar("display.lightmapdivider", 2);
-                    configManager.SetCVar("display.softshadows", false);
-                }
-                else if (value == 2)
-                {
-                    configManager.SetCVar("display.lightmapdivider", 2);
-                    configManager.SetCVar("display.softshadows", true);
-                }
-                else
-                {
-                    configManager.SetCVar("display.lightmapdivider", 1);
-                    configManager.SetCVar("display.softshadows", true);
-                }
+                return 1;
+            }
+            else if (val >= 2)
+            {
+                return 2;
+            }
+            else
+            {
+                return 3;
+            }
+        }
+        private void SetConfigLightingQuality(int value)
+        {
+            if (value == 0)
+            {
+                configManager.SetCVar("display.lightmapdivider", 8);
+                configManager.SetCVar("display.softshadows", false);
+            }
+            else if (value == 1)
+            {
+                configManager.SetCVar("display.lightmapdivider", 2);
+                configManager.SetCVar("display.softshadows", false);
+            }
+            else if (value == 2)
+            {
+                configManager.SetCVar("display.lightmapdivider", 2);
+                configManager.SetCVar("display.softshadows", true);
+            }
+            else
+            {
+                configManager.SetCVar("display.lightmapdivider", 1);
+                configManager.SetCVar("display.softshadows", true);
             }
         }
     }

--- a/Robust.Client/UserInterface/CustomControls/OptionsMenu.cs
+++ b/Robust.Client/UserInterface/CustomControls/OptionsMenu.cs
@@ -111,25 +111,24 @@ namespace Robust.Client.UserInterface.CustomControls
         }
         private void SetConfigLightingQuality(int value)
         {
-            if (value == 0)
+            switch (value)
             {
-                configManager.SetCVar("display.lightmapdivider", 8);
-                configManager.SetCVar("display.softshadows", false);
-            }
-            else if (value == 1)
-            {
-                configManager.SetCVar("display.lightmapdivider", 2);
-                configManager.SetCVar("display.softshadows", false);
-            }
-            else if (value == 2)
-            {
-                configManager.SetCVar("display.lightmapdivider", 2);
-                configManager.SetCVar("display.softshadows", true);
-            }
-            else
-            {
-                configManager.SetCVar("display.lightmapdivider", 1);
-                configManager.SetCVar("display.softshadows", true);
+                case 0:
+                    configManager.SetCVar("display.lightmapdivider", 8);
+                    configManager.SetCVar("display.softshadows", false);
+                    break;
+                case 1:
+                    configManager.SetCVar("display.lightmapdivider", 2);
+                    configManager.SetCVar("display.softshadows", false);
+                    break;
+                case 2:
+                    configManager.SetCVar("display.lightmapdivider", 2);
+                    configManager.SetCVar("display.softshadows", true);
+                    break;
+                case 3:
+                    configManager.SetCVar("display.lightmapdivider", 1);
+                    configManager.SetCVar("display.softshadows", true);
+                    break;
             }
         }
     }


### PR DESCRIPTION
This makes lighting resolution more configurable, switching the backend config option to being based on the amount the screen size is divided by, switching the frontend to using a slider with 3 places (/8, /2, and /1), and adding a "Soft Shadows" option.

In practice the Soft Shadows option does a lot by itself as PJB predicted, but disabling it seems to sometimes have worse effects on quality than lowering lighting resolution to /8, which gives a similar speed benefit.

Compare these 3 screenshots to get what I mean by this (options visible in the screenshot, taken under GLES2):
![image](https://user-images.githubusercontent.com/22304167/92046592-d1ceb780-ed7a-11ea-8384-8e4f3ac2d96c.png)
![image](https://user-images.githubusercontent.com/22304167/92046609-dabf8900-ed7a-11ea-9c0e-4e2e91f9b744.png)
![image](https://user-images.githubusercontent.com/22304167/92046776-325df480-ed7b-11ea-808f-254bcabf1319.png)
