### PR TITLE
GLES2: Support for GL_OES_standard_derivatives (fixes wall brightening when available)

### DIFF
--- a/Resources/Shaders/Internal/shadow_cast_shared.swsl
+++ b/Resources/Shaders/Internal/shadow_cast_shared.swsl
@@ -12,7 +12,7 @@ uniform highp mat4 shadowMatrix;
 highp vec2 occludeDepth(highp vec2 diff, sampler2D shadowMap, highp float mapOffsetY)
 {
     highp float angle = atan(diff.y, -diff.x) + PI + radians(135.0);
-#ifdef HAS_DFDX
+#ifdef HAS_MOD
     angle = mod(angle, 2.0 * PI);
 #else
     angle -= floor(angle / (2.0 * PI)) * (2.0 * PI);

--- a/Robust.Client/Graphics/Clyde/Clyde.GLFeatures.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.GLFeatures.cs
@@ -22,6 +22,7 @@ namespace Robust.Client.Graphics.Clyde
         private bool _hasGLMapBufferOes;
         private bool _hasGLMapBufferRange;
         private bool _hasGLPixelBufferObjects;
+        private bool _hasGLStandardDerivatives;
 
         private bool _hasGLFenceSync;
 
@@ -66,6 +67,7 @@ namespace Robust.Client.Graphics.Clyde
                 CheckGLCap(ref _hasGLMapBuffer, "map_buffer", (2, 0));
                 CheckGLCap(ref _hasGLMapBufferRange, "map_buffer_range", (3, 0));
                 CheckGLCap(ref _hasGLPixelBufferObjects, "pixel_buffer_object", (2, 1));
+                CheckGLCap(ref _hasGLStandardDerivatives, "standard_derivatives", (2, 1));
             }
             else
             {
@@ -77,6 +79,7 @@ namespace Robust.Client.Graphics.Clyde
                 CheckGLCap(ref _hasGLMapBufferOes, "map_buffer_oes", exts: "GL_OES_mapbuffer");
                 CheckGLCap(ref _hasGLMapBufferRange, "map_buffer_range", (3, 0));
                 CheckGLCap(ref _hasGLPixelBufferObjects, "pixel_buffer_object", (3, 0));
+                CheckGLCap(ref _hasGLStandardDerivatives, "standard_derivatives", (3, 0), "GL_OES_standard_derivatives");
             }
 
             // TODO: Enable these on ES 3.0
@@ -122,7 +125,8 @@ namespace Robust.Client.Graphics.Clyde
                 "map_buffer",
                 "map_buffer_range",
                 "pixel_buffer_object",
-                "map_buffer_oes"
+                "map_buffer_oes",
+                "standard_derivatives"
             };
 
             foreach (var cvar in cvars)

--- a/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
@@ -141,12 +141,21 @@ namespace Robust.Client.Graphics.Clyde
             GLShader? vertexShader = null;
             GLShader? fragmentShader = null;
 
-            var versionHeader = "#version 140\n#define HAS_DFDX\n";
+            var versionHeader = "#version 140\n#define HAS_MOD\n";
 
             if (_isGLES)
             {
                 // GLES2 uses a different GLSL versioning scheme to desktop GL.
                 versionHeader = "#version 100\n#define HAS_VARYING_ATTRIBUTE\n";
+                if (_hasGLStandardDerivatives)
+                {
+                    versionHeader += "#extension GL_OES_standard_derivatives : enable\n";
+                }
+            }
+
+            if (_hasGLStandardDerivatives)
+            {
+                versionHeader += "#define HAS_DFDX\n";
             }
 
             if (_hasGLFloatFramebuffers)


### PR DESCRIPTION
This uses GL\_OES\_standard\_derivatives where supported to actually support derivatives properly where they are available, which solves visual issues caused by placeholder values.
(Obviously if the functions aren't available on the GPU then someone either needs to work out how to implement them, or if that can't be done, the visual issues will remain in that case. Only so much can be done about this.)