### PR TITLE
EntityCoordinates

### DIFF
--- a/Robust.Client/UserInterface/CustomControls/DebugCoordsPanel.cs
+++ b/Robust.Client/UserInterface/CustomControls/DebugCoordsPanel.cs
@@ -111,12 +111,12 @@ Mouse Pos:
                 var playerWorldOffset = entityTransform.MapPosition;
                 var playerScreen = eyeManager.WorldToScreen(playerWorldOffset.Position);
 
-                var playerGridPos = playerManager.LocalPlayer.ControlledEntity.Transform.GridPosition;
+                var playerCoordinates = playerManager.LocalPlayer.ControlledEntity.Transform.Coordinates;
 
                 stringBuilder.AppendFormat(@"    Screen: {0}
     {1}
     {2}
-    EntityUid: {3}", playerScreen, playerWorldOffset, playerGridPos, entityTransform.Owner.Uid);
+    EntityUid: {3}", playerScreen, playerWorldOffset, playerCoordinates, entityTransform.Owner.Uid);
             }
 
             if (controlHovered != null)

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -294,16 +294,6 @@ namespace Robust.Shared.GameObjects.Components.Transform
                     var newEntity = _entityManager.GetEntity(value.EntityId);
                     AttachParent(newEntity);
                 }
-                else
-                {
-                    var worldCoords = value.ToMapPos(_entityManager);
-
-                    var newPos = Parent!.InvWorldMatrix.Transform(worldCoords);
-
-                    // float rounding error guard, if the offset is less than 1mm ignore it
-                    if ((newPos - _localPosition).LengthSquared < 10.0E-3)
-                        return;
-                }
 
                 _localPosition = value.Position;
 

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -284,7 +284,11 @@ namespace Robust.Shared.GameObjects.Components.Transform
         [ViewVariables(VVAccess.ReadWrite)]
         public EntityCoordinates Coordinates
         {
-            get => new EntityCoordinates(_parent.IsValid() ? _parent : Owner.Uid, LocalPosition);
+            get
+            {
+                var valid = _parent.IsValid();
+                return new EntityCoordinates(valid ? _parent : Owner.Uid, valid ? LocalPosition : Vector2.Zero);
+            }
             set
             {
                 var oldPosition = GridPosition;

--- a/Robust.Shared/Interfaces/GameObjects/Components/ITransformComponent.cs
+++ b/Robust.Shared/Interfaces/GameObjects/Components/ITransformComponent.cs
@@ -28,6 +28,11 @@ namespace Robust.Shared.Interfaces.GameObjects.Components
         GridCoordinates GridPosition { get; set; }
 
         /// <summary>
+        ///     Position offset of this entity relative to its parent.
+        /// </summary>
+        EntityCoordinates Coordinates { get; set; }
+
+        /// <summary>
         ///     Current position offset of the entity relative to the world.
         /// </summary>
         Vector2 WorldPosition { get; set; }

--- a/Robust.Shared/Map/Coordinates.cs
+++ b/Robust.Shared/Map/Coordinates.cs
@@ -601,21 +601,7 @@ namespace Robust.Shared.Map
         /// <returns>Grid Id this entity is on or <see cref="GridId.Invalid"/></returns>
         public GridId GetGridId(IEntityManager entityManager)
         {
-            var parent = EntityId;
-            while (parent.IsValid())
-            {
-                var entity = entityManager.GetEntity(parent);
-                if (entity.TryGetComponent(out IMapGridComponent? mapGrid))
-                {
-                    return mapGrid.GridIndex;
-                }
-
-                var newParentUid = entity.Transform.ParentUid;
-                if(!newParentUid.IsValid())
-                    return GridId.Invalid;
-            }
-
-            return GridId.Invalid;
+            return !IsValid(entityManager) ? GridId.Invalid : entityManager.GetEntity(EntityId).Transform.GridID;
         }
 
         /// <summary>

--- a/Robust.Shared/Map/Coordinates.cs
+++ b/Robust.Shared/Map/Coordinates.cs
@@ -460,7 +460,7 @@ namespace Robust.Shared.Map
         ///     Location of the Y axis local to the parent.
         /// </summary>
         public float Y => Position.Y;
-        
+
         /// <summary>
         ///     Constructs a new instance of <see cref="EntityCoordinates"/>.
         /// </summary>
@@ -533,7 +533,7 @@ namespace Robust.Shared.Map
         }
 
         /// <summary>
-        ///    Creates EntityCoordinates given a parent and some MapCoordinates.
+        ///    Creates EntityCoordinates given a parent Uid and some MapCoordinates.
         /// </summary>
         /// <param name="entityManager">Entity Manager containing the entity Id.</param>
         /// <param name="parentUid"></param>
@@ -548,7 +548,7 @@ namespace Robust.Shared.Map
         }
 
         /// <summary>
-        ///
+        ///    Creates a set of EntityCoordinates given some MapCoordinates.
         /// </summary>
         /// <param name="entityManager"></param>
         /// <param name="mapManager"></param>
@@ -563,7 +563,7 @@ namespace Robust.Shared.Map
         }
 
         /// <summary>
-        /// Converts a set of <seealso cref="EntityCoordinates"/> into a set of <seealso cref="GridCoordinates"/>.
+        ///     Converts a set of <seealso cref="EntityCoordinates"/> into a set of <seealso cref="GridCoordinates"/>.
         /// </summary>
         /// <param name="entityManager">Entity manager that contains the <see cref="EntityId"/>.</param>
         /// <param name="coordinates">Coordinates being converted to <see cref="GridCoordinates"/>. The <see cref="EntityId"/>
@@ -581,12 +581,24 @@ namespace Robust.Shared.Map
             return new GridCoordinates(coordinates.Position, gridComp.GridIndex);
         }
 
+        /// <summary>
+        ///     Creates a set of EntityCoordinates given some GridCoordinates.
+        /// </summary>
+        /// <param name="mapManager"></param>
+        /// <param name="coordinates"></param>
+        /// <returns></returns>
         public static EntityCoordinates FromGrid(IMapManager mapManager, GridCoordinates coordinates)
         {
             var grid = mapManager.GetGrid(coordinates.GridID);
             return new EntityCoordinates(grid.GridEntityId, coordinates.Position);
         }
 
+        /// <summary>
+        ///     Returns the Grid Id this entity is on.
+        ///     If none of the ancestors are a grid, returns <see cref="GridId.Invalid"/> grid instead.
+        /// </summary>
+        /// <param name="entityManager">Entity Manager that contains the parent's Id</param>
+        /// <returns>Grid Id this entity is on or <see cref="GridId.Invalid"/></returns>
         public GridId GetGridId(IEntityManager entityManager)
         {
             var parent = EntityId;

--- a/Robust.Shared/Map/Coordinates.cs
+++ b/Robust.Shared/Map/Coordinates.cs
@@ -475,6 +475,12 @@ namespace Robust.Shared.Map
             Position = position;
         }
 
+        public EntityCoordinates(EntityUid entityId, float x, float y)
+        {
+            EntityId = entityId;
+            Position = new Vector2(x, y);
+        }
+
         /// <summary>
         ///     Verifies that this set of coordinates can be currently resolved to a location.
         /// </summary>
@@ -615,6 +621,17 @@ namespace Robust.Shared.Map
         {
             var grid = mapManager.GetGrid(coordinates.GridID);
             return new EntityCoordinates(grid.GridEntityId, coordinates.Position);
+        }
+
+        /// <summary>
+        ///     Returns an new set of EntityCoordinates with the same <see cref="EntityId"/>
+        ///     but on a different position.
+        /// </summary>
+        /// <param name="newPosition">The position the new EntityCoordinates will be in</param>
+        /// <returns>A new set of EntityCoordinates with the specified position and same <see cref="EntityId"/> as this one.</returns>
+        public EntityCoordinates WithPosition(Vector2 newPosition)
+        {
+            return new EntityCoordinates(EntityId, newPosition);
         }
 
         /// <summary>

--- a/Robust.UnitTesting/Shared/Map/EntityCoordinates_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/EntityCoordinates_Tests.cs
@@ -112,7 +112,24 @@ namespace Robust.UnitTesting.Shared.Map
             var mapEntity = mapManager.CreateNewMapEntity(mapId);
 
             Assert.That(mapEntity.Transform.ParentUid.IsValid(), Is.False);
-            Assert.That(mapEntity.Transform.Coordinates.EntityId == mapEntity.Uid, Is.True);
+            Assert.That(mapEntity.Transform.Coordinates.EntityId, Is.EqualTo(mapEntity.Uid));
+        }
+
+        /// <summary>
+        ///     Even if we change the local position of an entity without a parent,
+        ///     EntityCoordinates should still return offset 0.
+        /// </summary>
+        [Test]
+        public void NoParent_OffsetZero()
+        {
+            var mapManager = IoCManager.Resolve<IMapManager>();
+
+            var mapId = mapManager.CreateMap();
+            var mapEntity = mapManager.CreateNewMapEntity(mapId);
+            Assert.That(mapEntity.Transform.Coordinates.Position, Is.EqualTo(Vector2.Zero));
+
+            mapEntity.Transform.LocalPosition = Vector2.One;
+            Assert.That(mapEntity.Transform.Coordinates.Position, Is.EqualTo(Vector2.Zero));
         }
 
         [Test]

--- a/Robust.UnitTesting/Shared/Map/EntityCoordinates_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/EntityCoordinates_Tests.cs
@@ -1,12 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using Moq;
 using NUnit.Framework;
+using Robust.Server.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Interfaces.Map;
+using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
+using Robust.Shared.Prototypes;
 using Is = Robust.UnitTesting.Is;
 
 // ReSharper disable InconsistentNaming
@@ -14,60 +19,158 @@ using Is = Robust.UnitTesting.Is;
 namespace Robust.UnitTesting.Shared.Map
 {
     [TestFixture, Parallelizable, TestOf(typeof(EntityCoordinates))]
-    public class EntityCoordinates_Tests
+    public class EntityCoordinates_Tests : RobustUnitTest
     {
+        private const string PROTOTYPES = @"
+- type: entity
+  name: dummy
+  id: dummy
+  components:
+  - type: Transform";
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            var entityManager = IoCManager.Resolve<IEntityManager>();
+            entityManager.Initialize();
+
+            var mapManager = IoCManager.Resolve<IMapManager>();
+
+            mapManager.Initialize();
+            mapManager.Startup();
+
+            var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
+            prototypeManager.LoadFromStream(new StringReader(PROTOTYPES));
+            prototypeManager.Resync();
+        }
+
         /// <summary>
-        /// Passing an invalid entity ID into the constructor makes the coordinates invalid.
+        ///     Passing an invalid entity ID into the constructor makes it throw.
         /// </summary>
         [Test]
         public void IsValid_InvalidEntId_False()
         {
-            // Arrange
-            var mockEntityMan = new Mock<IEntityManager>();
-            var coords = new EntityCoordinates(EntityUid.Invalid, Vector2.Zero);
-
-            // Act
-            var result = coords.IsValid(mockEntityMan.Object);
-
-            // Assert
-            Assert.That(result, Is.False);
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var _ = new EntityCoordinates(EntityUid.Invalid, Vector2.Zero);
+            });
         }
 
         /// <summary>
-        /// Passing an valid but nonexistent entity ID into the constructor makes the coordinates invalid.
+        ///     Deleting the parent entity should make the coordinates invalid.
         /// </summary>
         [Test]
         public void IsValid_EntityDeleted_False()
         {
-            // Arrange
-            var mockEntityMan = new Mock<IEntityManager>();
-            var coords = new EntityCoordinates(new EntityUid(1), Vector2.Zero);
+            var entityManager = IoCManager.Resolve<IEntityManager>();
+            var mapManager = IoCManager.Resolve<IMapManager>();
 
-            // Act
-            var result = coords.IsValid(mockEntityMan.Object);
+            var mapId = mapManager.CreateMap();
+            var mapEntity = mapManager.CreateNewMapEntity(mapId);
+            var newEnt = entityManager.CreateEntityUninitialized("dummy", new MapCoordinates(Vector2.Zero, mapId));
 
-            // Assert
+            var coords = newEnt.Transform.Coordinates;
+
+            var result = coords.IsValid(entityManager);
+
+            Assert.That(result, Is.True);
+
+            mapEntity.Delete();
+
+            result = coords.IsValid(entityManager);
+
             Assert.That(result, Is.False);
         }
 
         /// <summary>
-        /// Passing an valid but nonexistent entity ID into the constructor makes the coordinates invalid.
+        ///     Passing a valid entity ID into the constructor with infinite numbers makes it throw.
         /// </summary>
         [TestCase(float.NaN, float.NaN)]
         [TestCase(0, float.NaN)]
         [TestCase(float.NaN, 0)]
         public void IsValid_NonFiniteVector_False(float x, float y)
         {
-            // Arrange
-            var mockEntityMan = new Mock<IEntityManager>();
-            mockEntityMan.Setup(m => m.EntityExists(It.IsAny<EntityUid>())).Returns(true);
-            var coords = new EntityCoordinates(new EntityUid(1), new Vector2(x, y));
+            var entityManager = IoCManager.Resolve<IEntityManager>();
+            var mapManager = IoCManager.Resolve<IMapManager>();
 
-            // Act
-            var result = coords.IsValid(mockEntityMan.Object);
+            var mapId = mapManager.CreateMap();
+            var mapEntity = mapManager.CreateNewMapEntity(mapId);
 
-            // Assert
-            Assert.That(result, Is.False);
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                var newEnt = entityManager.CreateEntityUninitialized("dummy", new MapCoordinates(new Vector2(x, y), mapId));
+                var coords = newEnt.Transform.Coordinates;
+            });
+        }
+
+        [Test]
+        public void EntityCoordinates_Map()
+        {
+            var mapManager = IoCManager.Resolve<IMapManager>();
+
+            var mapId = mapManager.CreateMap();
+            var mapEntity = mapManager.CreateNewMapEntity(mapId);
+
+            Assert.That(mapEntity.Transform.ParentUid.IsValid(), Is.False);
+            Assert.That(mapEntity.Transform.Coordinates.EntityId == mapEntity.Uid, Is.True);
+        }
+
+        [Test]
+        public void GetGridId_Map()
+        {
+            var entityManager = IoCManager.Resolve<IEntityManager>();
+            var mapManager = IoCManager.Resolve<IMapManager>();
+
+            var mapId = mapManager.CreateMap();
+            var mapEntity = mapManager.CreateNewMapEntity(mapId);
+            var newEnt = entityManager.CreateEntityUninitialized("dummy", new MapCoordinates(Vector2.Zero, mapId));
+
+            Assert.That(mapEntity.Transform.Coordinates.GetGridId(entityManager), Is.EqualTo(GridId.Invalid));
+            Assert.That(newEnt.Transform.Coordinates.GetGridId(entityManager), Is.EqualTo(GridId.Invalid));
+            Assert.That(newEnt.Transform.Coordinates.EntityId, Is.EqualTo(mapEntity.Uid));
+        }
+
+        [Test]
+        public void GetGridId_Grid()
+        {
+            var entityManager = IoCManager.Resolve<IEntityManager>();
+            var mapManager = IoCManager.Resolve<IMapManager>();
+
+            var mapId = mapManager.CreateMap();
+            var grid = mapManager.CreateGrid(mapId);
+            var gridEnt = entityManager.GetEntity(grid.GridEntityId);
+            var newEnt = entityManager.CreateEntityUninitialized("dummy", new GridCoordinates(Vector2.Zero, grid.Index));
+
+            // Grids aren't parented to other grids.
+            Assert.That(gridEnt.Transform.Coordinates.GetGridId(entityManager), Is.EqualTo(GridId.Invalid));
+            Assert.That(newEnt.Transform.Coordinates.GetGridId(entityManager), Is.EqualTo(grid.Index));
+            Assert.That(newEnt.Transform.Coordinates.EntityId, Is.EqualTo(gridEnt.Uid));
+        }
+
+        [Test]
+        [TestCase(0, 0, 0, 0)]
+        [TestCase(5, 0, 0, 0)]
+        [TestCase(5, 0, 0, 5)]
+        [TestCase(-5, 5, 5, -5)]
+        [TestCase(100, -500, -200, -300)]
+        public void ToMap_MoveGrid(float x1, float y1, float x2, float y2)
+        {
+            var gridPos = new Vector2(x1, y1);
+            var entPos = new Vector2(x2, y2);
+
+            var entityManager = IoCManager.Resolve<IEntityManager>();
+            var mapManager = IoCManager.Resolve<IMapManager>();
+
+            var mapId = mapManager.CreateMap();
+            var grid = mapManager.CreateGrid(mapId);
+            var gridEnt = entityManager.GetEntity(grid.GridEntityId);
+            var newEnt = entityManager.CreateEntityUninitialized("dummy", new GridCoordinates(entPos, grid.Index));
+
+            Assert.That(newEnt.Transform.Coordinates.ToMap(entityManager), Is.EqualTo(new MapCoordinates(entPos, mapId)));
+
+            gridEnt.Transform.LocalPosition += gridPos;
+
+            Assert.That(newEnt.Transform.Coordinates.ToMap(entityManager), Is.EqualTo(new MapCoordinates(entPos + gridPos, mapId)));
         }
     }
 }

--- a/Robust.UnitTesting/Shared/Map/EntityCoordinates_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/EntityCoordinates_Tests.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Moq;
+using NUnit.Framework;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Is = Robust.UnitTesting.Is;
+
+// ReSharper disable InconsistentNaming
+// ReSharper disable AccessToStaticMemberViaDerivedType
+namespace Robust.UnitTesting.Shared.Map
+{
+    [TestFixture, Parallelizable, TestOf(typeof(EntityCoordinates))]
+    public class EntityCoordinates_Tests
+    {
+        /// <summary>
+        /// Passing an invalid entity ID into the constructor makes the coordinates invalid.
+        /// </summary>
+        [Test]
+        public void IsValid_InvalidEntId_False()
+        {
+            // Arrange
+            var mockEntityMan = new Mock<IEntityManager>();
+            var coords = new EntityCoordinates(EntityUid.Invalid, Vector2.Zero);
+
+            // Act
+            var result = coords.IsValid(mockEntityMan.Object);
+
+            // Assert
+            Assert.That(result, Is.False);
+        }
+
+        /// <summary>
+        /// Passing an valid but nonexistent entity ID into the constructor makes the coordinates invalid.
+        /// </summary>
+        [Test]
+        public void IsValid_EntityDeleted_False()
+        {
+            // Arrange
+            var mockEntityMan = new Mock<IEntityManager>();
+            var coords = new EntityCoordinates(new EntityUid(1), Vector2.Zero);
+
+            // Act
+            var result = coords.IsValid(mockEntityMan.Object);
+
+            // Assert
+            Assert.That(result, Is.False);
+        }
+
+        /// <summary>
+        /// Passing an valid but nonexistent entity ID into the constructor makes the coordinates invalid.
+        /// </summary>
+        [TestCase(float.NaN, float.NaN)]
+        [TestCase(0, float.NaN)]
+        [TestCase(float.NaN, 0)]
+        public void IsValid_NonFiniteVector_False(float x, float y)
+        {
+            // Arrange
+            var mockEntityMan = new Mock<IEntityManager>();
+            mockEntityMan.Setup(m => m.EntityExists(It.IsAny<EntityUid>())).Returns(true);
+            var coords = new EntityCoordinates(new EntityUid(1), new Vector2(x, y));
+
+            // Act
+            var result = coords.IsValid(mockEntityMan.Object);
+
+            // Assert
+            Assert.That(result, Is.False);
+        }
+    }
+}


### PR DESCRIPTION
Supersedes #1273
Polishes `EntityCoordinates` a bit, adds some useful methods to it, unit tests and makes Transform have `EntityCoordinates`
I'd like to get this merged as soon as possible so we can start moving stuff over.