### PR TITLE
Grid tile lookup system

### DIFF
--- a/Robust.Server/GameObjects/EntitySystemMessages/EntityDeletedMessage.cs
+++ b/Robust.Server/GameObjects/EntitySystemMessages/EntityDeletedMessage.cs
@@ -1,0 +1,15 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.Interfaces.GameObjects;
+
+namespace Robust.Server.GameObjects.EntitySystemMessages
+{
+    public sealed class EntityDeletedMessage : EntitySystemMessage
+    {
+        public IEntity Entity { get; }
+        
+        public EntityDeletedMessage(IEntity entity)
+        {
+            Entity = entity;
+        }
+    }
+}

--- a/Robust.Server/GameObjects/EntitySystemMessages/EntityTileMessage.cs
+++ b/Robust.Server/GameObjects/EntitySystemMessages/EntityTileMessage.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Robust.Server.GameObjects.EntitySystemMessages
+{
+    /// <summary>
+    ///     Event for when the intersecting MapIndices of an entity changes.
+    ///     Not called for space (given no tiles).
+    /// </summary>
+    /// <remarks>
+    ///    List is empty if it's no longer intersecting any.
+    /// </remarks>
+    public sealed class TileLookupUpdateMessage : EntitySystemMessage
+    {
+        public Dictionary<GridId, List<MapIndices>>? NewIndices { get; }
+
+        public TileLookupUpdateMessage(Dictionary<GridId, List<MapIndices>>? indices)
+        {
+            NewIndices = indices;
+        }
+    }
+}

--- a/Robust.Server/GameObjects/EntitySystems/TileLookup/GridTileLookupChunk.cs
+++ b/Robust.Server/GameObjects/EntitySystems/TileLookup/GridTileLookupChunk.cs
@@ -1,0 +1,33 @@
+using Robust.Shared.Map;
+
+namespace Robust.Server.GameObjects.EntitySystems.TileLookup
+{
+    internal sealed class GridTileLookupChunk
+    {
+        internal const byte ChunkSize = 16;
+
+        internal GridId GridId { get; }
+        internal MapIndices Indices { get; }
+        
+        private GridTileLookupNode[,] _nodes = new GridTileLookupNode[ChunkSize,ChunkSize];
+        
+        internal GridTileLookupChunk(GridId gridId, MapIndices indices)
+        {
+            GridId = gridId;
+            Indices = indices;
+
+            for (var x = 0; x < ChunkSize; x++)
+            {
+                for (var y = 0; y < ChunkSize; y++)
+                {
+                    _nodes[x, y] = new GridTileLookupNode(this, new MapIndices(Indices.X + x, Indices.Y + y));
+                }
+            }
+        }
+
+        internal GridTileLookupNode GetNode(MapIndices nodeIndices)
+        {
+            return _nodes[nodeIndices.X - Indices.X, nodeIndices.Y - Indices.Y];
+        }
+    }
+}

--- a/Robust.Server/GameObjects/EntitySystems/TileLookup/GridTileLookupNode.cs
+++ b/Robust.Server/GameObjects/EntitySystems/TileLookup/GridTileLookupNode.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Map;
+
+namespace Robust.Server.GameObjects.EntitySystems.TileLookup
+{
+    internal sealed class GridTileLookupNode
+    {
+        internal GridTileLookupChunk ParentChunk { get; }
+        
+        internal MapIndices Indices { get; }
+
+        internal IEnumerable<IEntity> Entities
+        {
+            get
+            {
+                foreach (var entity in _entities)
+                {
+                    if (!entity.Deleted)
+                        yield return entity;
+                }
+            }
+        }
+
+        private readonly HashSet<IEntity> _entities = new HashSet<IEntity>();
+
+        internal GridTileLookupNode(GridTileLookupChunk parentChunk, MapIndices indices)
+        {
+            ParentChunk = parentChunk;
+            Indices = indices;
+        }
+        
+        internal void AddEntity(IEntity entity)
+        {
+            _entities.Add(entity);
+        }
+
+        internal void RemoveEntity(IEntity entity)
+        {
+            _entities.Remove(entity);
+        }
+    }
+}

--- a/Robust.Server/GameObjects/EntitySystems/TileLookup/GridTileLookupSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/TileLookup/GridTileLookupSystem.cs
@@ -1,0 +1,362 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Robust.Server.GameObjects.EntitySystemMessages;
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects.Components;
+using Robust.Shared.GameObjects.Components.Transform;
+using Robust.Shared.GameObjects.EntitySystemMessages;
+using Robust.Shared.GameObjects.Systems;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Interfaces.Map;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+
+namespace Robust.Server.GameObjects.EntitySystems.TileLookup
+{
+    /// <summary>
+    ///     Stores what entities intersect a particular tile.
+    /// </summary>
+    [UsedImplicitly]
+    public sealed class GridTileLookupSystem : EntitySystem
+    {
+        [Dependency] private readonly IMapManager _mapManager = default!;
+        
+        private readonly Dictionary<GridId, Dictionary<MapIndices, GridTileLookupChunk>> _graph = 
+                     new Dictionary<GridId, Dictionary<MapIndices, GridTileLookupChunk>>();
+
+        /// <summary>
+        ///     Need to store the nodes for each entity because if the entity is deleted its transform is no longer valid.
+        /// </summary>
+        private readonly Dictionary<IEntity, HashSet<GridTileLookupNode>> _lastKnownNodes = 
+                     new Dictionary<IEntity, HashSet<GridTileLookupNode>>();
+
+        /// <summary>
+        ///     Yields all of the entities intersecting a particular entity's tiles.
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <returns></returns>
+        public IEnumerable<IEntity> GetEntitiesIntersecting(IEntity entity)
+        {
+            if (entity.Transform.GridID == GridId.Invalid)
+            {
+                throw new InvalidOperationException("Can't get grid tile intersecting entities for invalid grid");
+            }
+        
+            foreach (var node in GetOrCreateNodes(entity))
+            {
+                foreach (var ent in node.Entities)
+                {
+                    yield return ent;
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Yields all of the entities intersecting a particular MapIndices
+        /// </summary>
+        /// <param name="gridId"></param>
+        /// <param name="gridIndices"></param>
+        /// <returns></returns>
+        public IEnumerable<IEntity> GetEntitiesIntersecting(GridId gridId, MapIndices gridIndices)
+        {
+            if (gridId == GridId.Invalid)
+            {
+                throw new InvalidOperationException("Can't get grid tile intersecting entities for invalid grid");
+            }
+            
+            if (!_graph.TryGetValue(gridId, out var chunks))
+            {
+                throw new InvalidOperationException("Unable to find grid for TileLookup");
+            }
+
+            var chunkIndices = GetChunkIndices(gridIndices);
+
+            if (!chunks.TryGetValue(chunkIndices, out var chunk))
+            {
+                yield break;
+            }
+
+            foreach (var entity in chunk.GetNode(gridIndices).Entities)
+            {
+                yield return entity;
+            }
+        }
+
+        private GridTileLookupChunk GetOrCreateChunk(GridId gridId, MapIndices indices)
+        {
+            var chunkIndices = GetChunkIndices(indices);
+
+            if (!_graph.TryGetValue(gridId, out var gridChunks))
+            {
+                gridChunks = new Dictionary<MapIndices, GridTileLookupChunk>();
+                _graph[gridId] = gridChunks;
+            }
+
+            if (!gridChunks.TryGetValue(chunkIndices, out var chunk))
+            {
+                chunk = new GridTileLookupChunk(gridId, chunkIndices);
+                gridChunks[chunkIndices] = chunk;
+            }
+
+            return chunk;
+        }
+
+        private MapIndices GetChunkIndices(MapIndices indices)
+        {
+            return new MapIndices(
+                (int) (Math.Floor((float) indices.X / GridTileLookupChunk.ChunkSize) * GridTileLookupChunk.ChunkSize),
+                (int) (Math.Floor((float) indices.Y / GridTileLookupChunk.ChunkSize) * GridTileLookupChunk.ChunkSize));
+        }
+
+        private HashSet<GridTileLookupNode> GetOrCreateNodes(IEntity entity)
+        {
+            if (_lastKnownNodes.TryGetValue(entity, out var nodes))
+            {
+                return nodes;
+            }
+
+            if (entity.Deleted)
+            {
+                throw new InvalidOperationException($"Can't get nodes for deleted entity {entity.Name}!");
+            }
+            
+            var grids = GetEntityIndices(entity);
+            var results = new HashSet<GridTileLookupNode>();
+
+            foreach (var (grid, indices) in grids)
+            {
+                foreach (var index in indices)
+                {
+                    results.Add(GetOrCreateNode(grid, index));
+                }
+            }
+
+            _lastKnownNodes[entity] = results;
+            return results;
+        }
+
+        private HashSet<GridTileLookupNode> GetOrCreateNodes(GridCoordinates gridCoordinates, Box2 box)
+        {
+            if (gridCoordinates.GridID == GridId.Invalid)
+            {
+                throw new InvalidOperationException("Cannot get TileLookup nodes for an InvalidGrid!");
+            }
+            
+            var results = new HashSet<GridTileLookupNode>();
+            
+            foreach (var grid in _mapManager.FindGridsIntersecting(_mapManager.GetGrid(gridCoordinates.GridID).ParentMapId, box))
+            {
+                foreach (var tile in grid.GetTilesIntersecting(box))
+                {
+                    results.Add(GetOrCreateNode(grid.Index, tile.GridIndices));
+                }
+            }
+            
+            return results;
+        }
+
+        /// <summary>
+        ///     Return the corresponding TileLookupNode for these indices
+        /// </summary>
+        /// <param name="gridId"></param>
+        /// <param name="indices"></param>
+        /// <returns></returns>
+        private GridTileLookupNode GetOrCreateNode(GridId gridId, MapIndices indices)
+        {
+            var chunk = GetOrCreateChunk(gridId, indices);
+
+            return chunk.GetNode(indices);
+        }
+
+        /// <summary>
+        ///     Get the relevant GridId and MapIndices for this entity for lookup.
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <returns></returns>
+        private Dictionary<GridId, List<MapIndices>> GetEntityIndices(IEntity entity)
+        {
+            var entityBounds = GetEntityBox(entity);
+            var results = new Dictionary<GridId, List<MapIndices>>();
+            
+            foreach (var grid in _mapManager.FindGridsIntersecting(entity.Transform.MapID, GetEntityBox(entity)))
+            {
+                var indices = new List<MapIndices>();
+
+                foreach (var tile in grid.GetTilesIntersecting(entityBounds))
+                {
+                    indices.Add(tile.GridIndices);
+                }
+                
+                results[grid.Index] = indices;
+            }
+            
+            return results;
+        }
+
+        private Box2 GetEntityBox(IEntity entity)
+        {
+            // Need to clip the aabb as anything with an edge intersecting another tile might be picked up, such as walls.
+            if (entity.TryGetComponent(out ICollidableComponent? collidableComponent))
+                return new Box2(collidableComponent.WorldAABB.BottomLeft + 0.01f, collidableComponent.WorldAABB.TopRight - 0.01f);
+
+            // Don't want to accidentally get neighboring tiles unless we're near an edge
+            return Box2.CenteredAround(entity.Transform.GridPosition.Position, Vector2.One / 2);
+        }
+
+        public override void Initialize()
+        {
+            SubscribeLocalEvent<MoveEvent>(HandleEntityMove);
+            SubscribeLocalEvent<EntityInitializedMessage>(HandleEntityInitialized);
+            SubscribeLocalEvent<EntityDeletedMessage>(HandleEntityDeleted);
+            _mapManager.OnGridRemoved += HandleGridRemoval;
+        }
+
+        private void HandleEntityInitialized(EntityInitializedMessage message)
+        {
+            HandleEntityAdd(message.Entity);
+        }
+
+        private void HandleEntityDeleted(EntityDeletedMessage message)
+        {
+            HandleEntityRemove(message.Entity);
+        }
+
+        public override void Shutdown()
+        {
+            base.Shutdown();
+            _mapManager.OnGridRemoved -= HandleGridRemoval;
+        }
+
+        private void HandleGridRemoval(GridId gridId)
+        {
+            var toRemove = new List<IEntity>();
+            
+            foreach (var (entity, _) in _lastKnownNodes)
+            {
+                if (entity.Transform.GridID == gridId)
+                    toRemove.Add(entity);
+            }
+
+            foreach (var entity in toRemove)
+            {
+                _lastKnownNodes.Remove(entity);
+            }
+            
+            _graph.Remove(gridId);
+        }
+
+        /// <summary>
+        ///     Tries to add the entity to the relevant TileLookupNode
+        /// </summary>
+        /// The node will filter it to the correct category (if possible)
+        /// <param name="entity"></param>
+        private void HandleEntityAdd(IEntity entity)
+        {
+            if (entity.Deleted || entity.Transform.GridID == GridId.Invalid)
+            {
+                return;
+            }
+
+            var entityNodes = GetOrCreateNodes(entity);
+            var newIndices = new Dictionary<GridId, List<MapIndices>>();
+            
+            foreach (var node in entityNodes)
+            {
+                node.AddEntity(entity);
+                if (!newIndices.TryGetValue(node.ParentChunk.GridId, out var existing))
+                {
+                    existing = new List<MapIndices>();
+                    newIndices[node.ParentChunk.GridId] = existing;
+                }
+                
+                existing.Add(node.Indices);
+            }
+
+            _lastKnownNodes[entity] = entityNodes;
+            EntityManager.EventBus.RaiseEvent(EventSource.Local, new TileLookupUpdateMessage(newIndices));
+        }
+
+        /// <summary>
+        ///     Removes this entity from all of the applicable nodes.
+        /// </summary>
+        /// <param name="entity"></param>
+        private void HandleEntityRemove(IEntity entity)
+        {
+            if (_lastKnownNodes.TryGetValue(entity, out var nodes))
+            {
+                foreach (var node in nodes)
+                {
+                    node.RemoveEntity(entity);
+                }
+            }
+
+            _lastKnownNodes.Remove(entity);
+            EntityManager.EventBus.RaiseEvent(EventSource.Local, new TileLookupUpdateMessage(null));
+        }
+
+        /// <summary>
+        ///     When an entity moves around we'll remove it from its old node and add it to its new node (if applicable)
+        /// </summary>
+        /// <param name="moveEvent"></param>
+        private void HandleEntityMove(MoveEvent moveEvent)
+        {
+            if (moveEvent.Sender.Deleted || moveEvent.NewPosition.GridID == GridId.Invalid)
+            {
+                HandleEntityRemove(moveEvent.Sender);
+                return;
+            }
+
+            if (!_lastKnownNodes.TryGetValue(moveEvent.Sender, out var oldNodes))
+            {
+                return;
+            }
+
+            // Memory leak protection
+            var gridBounds = _mapManager.GetGrid(moveEvent.Sender.Transform.GridID).WorldBounds;
+            if (!gridBounds.Contains(moveEvent.Sender.Transform.WorldPosition))
+            {
+                HandleEntityRemove(moveEvent.Sender);
+                return;
+            }
+
+            var bounds = GetEntityBox(moveEvent.Sender);
+            var newNodes = GetOrCreateNodes(moveEvent.NewPosition, bounds);
+
+            if (oldNodes.Count == newNodes.Count && oldNodes.SetEquals(newNodes))
+            {
+                return;
+            }
+            
+            var toRemove = oldNodes.Where(oldNode => !newNodes.Contains(oldNode));
+            var toAdd = newNodes.Where(newNode => !oldNodes.Contains(newNode));
+
+            foreach (var node in toRemove)
+            {
+                node.RemoveEntity(moveEvent.Sender);
+            }
+
+            foreach (var node in toAdd)
+            {
+                node.AddEntity(moveEvent.Sender);
+            }
+
+            var newIndices = new Dictionary<GridId, List<MapIndices>>();
+            foreach (var node in newNodes)
+            {
+                if (!newIndices.TryGetValue(node.ParentChunk.GridId, out var existing))
+                {
+                    existing = new List<MapIndices>();
+                    newIndices[node.ParentChunk.GridId] = existing;
+                }
+                
+                existing.Add(node.Indices);
+            }
+
+            _lastKnownNodes[moveEvent.Sender] = newNodes;
+            EntityManager.EventBus.RaiseEvent(EventSource.Local, new TileLookupUpdateMessage(newIndices));
+        }
+    }
+}

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -5,12 +5,14 @@ using System.Threading;
 using Prometheus;
 using Robust.Server.GameObjects.Components;
 using Robust.Server.GameObjects.Components.Container;
+using Robust.Server.GameObjects.EntitySystemMessages;
 using Robust.Server.Interfaces.GameObjects;
 using Robust.Server.Interfaces.Player;
 using Robust.Server.Interfaces.Timing;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameObjects.Components;
 using Robust.Shared.GameObjects.Components.Transform;
+using Robust.Shared.GameObjects.EntitySystemMessages;
 using Robust.Shared.Interfaces.Configuration;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Map;
@@ -122,7 +124,7 @@ namespace Robust.Server.GameObjects
             {
                 entity.RunMapInit();
             }
-
+            
             return entity;
         }
 
@@ -700,7 +702,7 @@ namespace Robust.Server.GameObjects
         public override void DeleteEntity(IEntity e)
         {
             base.DeleteEntity(e);
-
+            EventBus.RaiseEvent(EventSource.Local, new EntityDeletedMessage(e));
             _deletionHistory.Add((CurrentTick, e.Uid));
         }
 

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects.Components;
+using Robust.Shared.GameObjects.EntitySystemMessages;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.Interfaces.GameObjects.Components;
@@ -169,9 +170,9 @@ namespace Robust.Shared.GameObjects
             }
 
 #endif
-
             Initialized = true;
             Initializing = false;
+            EntityManager.EventBus.RaiseEvent(EventSource.Local, new EntityInitializedMessage(this));
         }
 
         /// <summary>

--- a/Robust.Shared/GameObjects/EntitySystemMessages/EntityInitializedMessage.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/EntityInitializedMessage.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.Interfaces.GameObjects;
+
+namespace Robust.Shared.GameObjects.EntitySystemMessages
+{
+    public sealed class EntityInitializedMessage : EntitySystemMessage
+    {
+        public IEntity Entity { get; }
+        
+        public EntityInitializedMessage(IEntity entity)
+        {
+            Entity = entity;
+        }
+    }
+}


### PR DESCRIPTION
To be used for tile-based systems such as atmos and pathfinding (once I refactor it).

Entity intersecting tiles are cached as they move so the lookups are faster than creating and querying dynamic trees.

The current IEntityManager uses the entity's MapCoordinates for GetEntitiesIntersecting but I used the bounds here as it seemed more appropriate.