### PR TITLE
Physics caching go brrt

### DIFF
--- a/Robust.Client/Physics/PhysicsSystem.cs
+++ b/Robust.Client/Physics/PhysicsSystem.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Annotations;
-using Robust.Shared.GameObjects.Components;
 using Robust.Shared.GameObjects.Systems;
-using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Timing;
 using Robust.Shared.IoC;
 
@@ -14,7 +10,6 @@ namespace Robust.Client.Physics
     public class PhysicsSystem : SharedPhysicsSystem
     {
         [Dependency] private readonly IGameTiming _gameTiming = default!;
-        [Dependency] private readonly IComponentManager _componentManager = default!;
 
         private TimeSpan _lastRem;
 
@@ -22,7 +17,7 @@ namespace Robust.Client.Physics
         {
             _lastRem = _gameTiming.CurTime;
 
-            SimulateWorld(frameTime, EntityManager.ComponentManager.EntityQuery<ICollidableComponent>().ToList(), !_gameTiming.InSimulation || !_gameTiming.IsFirstTimePredicted);
+            SimulateWorld(frameTime, !_gameTiming.InSimulation || !_gameTiming.IsFirstTimePredicted);
         }
 
         public override void FrameUpdate(float frameTime)
@@ -34,14 +29,7 @@ namespace Robust.Client.Physics
 
             var diff = _gameTiming.TickRemainder - _lastRem;
             _lastRem = _gameTiming.TickRemainder;
-            SimulateWorld((float) diff.TotalSeconds, ActuallyRelevant(), true);
-        }
-
-        private List<ICollidableComponent> ActuallyRelevant()
-        {
-            var relevant = _componentManager.EntityQuery<ICollidableComponent>().Where(p => p.Predict)
-                .ToList();
-            return relevant;
+            SimulateWorld((float) diff.TotalSeconds, true);
         }
     }
 }

--- a/Robust.Server/GameObjects/EntitySystems/PhysicsSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/PhysicsSystem.cs
@@ -11,11 +11,7 @@ namespace Robust.Server.GameObjects.EntitySystems
         /// <inheritdoc />
         public override void Update(float frameTime)
         {
-            var collidableComponents = EntityManager.ComponentManager
-                .EntityQuery<ICollidableComponent>()
-                .ToList();
-
-            SimulateWorld(frameTime, collidableComponents, false);
+            SimulateWorld(frameTime, false);
         }
     }
 }

--- a/Robust.Shared/GameObjects/ComponentMessages/Messages.cs
+++ b/Robust.Shared/GameObjects/ComponentMessages/Messages.cs
@@ -14,11 +14,6 @@ namespace Robust.Shared.GameObjects
         }
     }
 
-    public class EntityMovementMessage : ComponentMessage
-    {
-        public EntityMovementMessage() { }
-    }
-
     /// <summary>
     ///     The entity transform parent has been changed.
     /// </summary>

--- a/Robust.Shared/GameObjects/Components/Collidable/CollidableComponent.Physics.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/CollidableComponent.Physics.cs
@@ -332,7 +332,20 @@ namespace Robust.Shared.GameObjects.Components
         public event Action? AnchoredChanged;
 
         [ViewVariables(VVAccess.ReadWrite)]
-        public bool Predict { get; set; }
+        public bool Predict
+        {
+            get => _predict;
+            set
+            {
+                if (_predict == value)
+                    return;
+
+                _predict = value;
+                Owner.EntityManager.EventBus.RaiseEvent(EventSource.Local, new CollidableUpdateMessage(this));
+            }
+        }
+
+        private bool _predict;
 
         Dictionary<Type, VirtualController> ICollidableComponent.Controllers
         {

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -77,6 +77,13 @@ namespace Robust.Shared.GameObjects.Components.Transform
         }
 
         /// <inheritdoc />
+        public bool DeferUpdates { get; set; }
+        
+        // Deferred fields
+        private Angle? _oldLocalRotation;
+        private EntityCoordinates? _oldCoords;
+
+        /// <inheritdoc />
         [ViewVariables(VVAccess.ReadWrite)]
         [Animatable]
         public Angle LocalRotation
@@ -92,12 +99,20 @@ namespace Robust.Shared.GameObjects.Components.Transform
                 // Set _nextRotation to null to break any active lerps if this is a client side prediction.
                 _nextRotation = null;
                 SetRotation(value);
-                Owner.EntityManager.EventBus.RaiseEvent(
-                    EventSource.Local, new RotateEvent(Owner, oldRotation, _localRotation));
-                RebuildMatrices();
                 Dirty();
-                UpdateEntityTree();
-                UpdatePhysicsTree();
+
+                if (!DeferUpdates)
+                {
+                    RebuildMatrices();
+                    UpdateEntityTree();
+                    UpdatePhysicsTree();
+                    Owner.EntityManager.EventBus.RaiseEvent(
+                        EventSource.Local, new RotateEvent(Owner, oldRotation, _localRotation));
+                }
+                else
+                {
+                    _oldLocalRotation ??= oldRotation;
+                }
             }
         }
 
@@ -239,18 +254,25 @@ namespace Robust.Shared.GameObjects.Components.Transform
                 }
 
                 _localPosition = value.Position;
-
-                //TODO: This is a hack, look into WHY we can't call GridPosition before the comp is Running
-                if (Running)
-                {
-                    RebuildMatrices();
-                    Owner.EntityManager.EventBus.RaiseEvent(
-                        EventSource.Local, new MoveEvent(Owner, oldPosition, Coordinates));
-                }
-
                 Dirty();
-                UpdateEntityTree();
-                UpdatePhysicsTree();
+
+                if (!DeferUpdates)
+                {
+                    //TODO: This is a hack, look into WHY we can't call GridPosition before the comp is Running
+                    if (Running)
+                    {
+                        RebuildMatrices();
+                        Owner.EntityManager.EventBus.RaiseEvent(
+                            EventSource.Local, new MoveEvent(Owner, oldPosition, Coordinates));
+                    }
+                    
+                    UpdateEntityTree();
+                    UpdatePhysicsTree();
+                }
+                else
+                {
+                    _oldCoords ??= oldPosition;
+                }
             }
         }
 
@@ -268,12 +290,42 @@ namespace Robust.Shared.GameObjects.Components.Transform
                 _nextPosition = null;
                 var oldGridPos = Coordinates;
                 SetPosition(value);
-                RebuildMatrices();
                 Dirty();
-                UpdateEntityTree();
-                UpdatePhysicsTree();
+
+                if (!DeferUpdates)
+                {
+                    RebuildMatrices();
+                    UpdateEntityTree();
+                    UpdatePhysicsTree();
+                    Owner.EntityManager.EventBus.RaiseEvent(
+                        EventSource.Local, new MoveEvent(Owner, oldGridPos, Coordinates));
+                }
+                else
+                {
+                    _oldCoords ??= oldGridPos;
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public void RunCollidableDeferred()
+        {
+            RebuildMatrices();
+            UpdateEntityTree();
+            UpdatePhysicsTree();
+
+            if (_oldCoords != null)
+            {
                 Owner.EntityManager.EventBus.RaiseEvent(
-                    EventSource.Local, new MoveEvent(Owner, oldGridPos, Coordinates));
+                    EventSource.Local, new MoveEvent(Owner, _oldCoords.Value, Coordinates));
+                _oldCoords = null;
+            }
+
+            if (_oldLocalRotation != null)
+            {
+                Owner.EntityManager.EventBus.RaiseEvent(
+                    EventSource.Local, new RotateEvent(Owner, _oldLocalRotation.Value, _localRotation));
+                _oldLocalRotation = null;
             }
         }
 

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -73,17 +73,14 @@ namespace Robust.Shared.GameObjects.Systems
         private void ProcessQueue()
         {
             // At this stage only the dynamictree cares about asleep bodies
-            
+            // Implicitly awake bodies so don't need to check .Awake again
+            // Controllers should wake their body up (inside)
             foreach (var collidable in _queuedUpdates)
             {
-                if (collidable.Awake)
-                {
-                    if (collidable.Predict)
-                        _predictedAwakeBodies.Add(collidable);
-                    
-                    _awakeBodies.Add(collidable);
-                    
-                }
+                if (collidable.Predict)
+                    _predictedAwakeBodies.Add(collidable);
+                
+                _awakeBodies.Add(collidable);
 
                 if (collidable.Controllers.Count > 0 && !_controllers.ContainsKey(collidable))
                     _controllers.Add(collidable, collidable.Controllers.Values);

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -6,7 +6,6 @@ using Robust.Shared.Interfaces.Map;
 using Robust.Shared.Interfaces.Physics;
 using Robust.Shared.Interfaces.Random;
 using Robust.Shared.Interfaces.Timing;
-using Robust.Shared.Log;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using DependencyAttribute = Robust.Shared.IoC.DependencyAttribute;
@@ -24,28 +23,98 @@ namespace Robust.Shared.GameObjects.Systems
         private const float Epsilon = 1.0e-6f;
 
         private readonly List<Manifold> _collisionCache = new List<Manifold>();
+        
+        /// <summary>
+        ///     Collidable objects that are awake and usable for world simulation.
+        /// </summary>
         private readonly HashSet<ICollidableComponent> _awakeBodies = new HashSet<ICollidableComponent>();
 
         /// <summary>
-        /// Simulates the physical world for a given amount of time.
+        ///     Collidable objects that are awake and predicted and usable for world simulation.
+        /// </summary>
+        private readonly HashSet<ICollidableComponent> _predictedAwakeBodies = new HashSet<ICollidableComponent>();
+
+        /// <summary>
+        ///     VirtualControllers on applicable ICollidableComponents
+        /// </summary>
+        private Dictionary<ICollidableComponent, IEnumerable<VirtualController>> _controllers = 
+            new Dictionary<ICollidableComponent, IEnumerable<VirtualController>>();
+        
+        // We'll defer changes to ICollidable until each step is done.
+        private readonly List<ICollidableComponent> _queuedDeletions = new List<ICollidableComponent>();
+        private readonly List<ICollidableComponent> _queuedUpdates = new List<ICollidableComponent>();
+        
+        /// <summary>
+        ///     Updates to EntityTree etc. that are deferred until the end of physics.
+        /// </summary>
+        private readonly HashSet<ICollidableComponent> _deferredUpdates = new HashSet<ICollidableComponent>();
+
+        public override void Initialize()
+        {
+            base.Initialize();
+            SubscribeLocalEvent<CollidableUpdateMessage>(HandleCollidableUpdateMessage);
+        }
+
+        private void HandleCollidableUpdateMessage(CollidableUpdateMessage message)
+        {
+            if (message.Component.Deleted || !message.Component.Awake)
+            {
+                _queuedDeletions.Add(message.Component);
+            }
+            else
+            {
+                _queuedUpdates.Add(message.Component);
+            }
+        }
+
+        /// <summary>
+        ///     Process the changes to cached ICollidables
+        /// </summary>
+        private void ProcessQueue()
+        {
+            // At this stage only the dynamictree cares about asleep bodies
+            
+            foreach (var collidable in _queuedUpdates)
+            {
+                if (collidable.Awake)
+                {
+                    if (collidable.Predict)
+                        _predictedAwakeBodies.Add(collidable);
+                    
+                    _awakeBodies.Add(collidable);
+                    
+                }
+
+                if (collidable.Controllers.Count > 0 && !_controllers.ContainsKey(collidable))
+                    _controllers.Add(collidable, collidable.Controllers.Values);
+
+            }
+            
+            _queuedUpdates.Clear();
+
+            foreach (var collidable in _queuedDeletions)
+            {
+                _awakeBodies.Remove(collidable);
+                _predictedAwakeBodies.Remove(collidable);
+                _controllers.Remove(collidable);
+            }
+            
+            _queuedDeletions.Clear();
+        }
+
+        /// <summary>
+        ///     Simulates the physical world for a given amount of time.
         /// </summary>
         /// <param name="deltaTime">Delta Time in seconds of how long to simulate the world.</param>
-        /// <param name="physicsComponents">List of all possible physics bodes </param>
         /// <param name="prediction">Should only predicted entities be considered in this simulation step?</param>
-        protected void SimulateWorld(float deltaTime, List<ICollidableComponent> physicsComponents, bool prediction)
+        protected void SimulateWorld(float deltaTime, bool prediction)
         {
-            _awakeBodies.Clear();
-
-            foreach (var body in physicsComponents)
+            var simulatedBodies = prediction ? _predictedAwakeBodies : _awakeBodies;
+            
+            ProcessQueue();
+            
+            foreach (var body in simulatedBodies)
             {
-                if(prediction && !body.Predict)
-                    continue;
-
-                if(!body.Awake)
-                    continue;
-
-                _awakeBodies.Add(body);
-
                 // running prediction updates will not cause a body to go to sleep.
                 if(!prediction)
                     body.SleepAccumulator++;
@@ -80,27 +149,27 @@ namespace Robust.Shared.GameObjects.Systems
             }
 
             // Calculate collisions and store them in the cache
-            ProcessCollisions(physicsComponents);
-
+            ProcessCollisions(_awakeBodies);
+            
             // Remove all entities that were deleted during collision handling
-            physicsComponents.RemoveAll(p => p.Deleted);
+            ProcessQueue();
 
             // Process frictional forces
-            foreach (var physics in physicsComponents)
+            foreach (var physics in _awakeBodies)
             {
                 ProcessFriction(physics, deltaTime);
             }
-
-            foreach (var physics in physicsComponents)
+            
+            foreach (var (_, controllers) in _controllers)
             {
-                foreach (var controller in physics.Controllers.Values)
+                foreach (var controller in controllers)
                 {
                     controller.UpdateAfterProcessing();
                 }
             }
-
+            
             // Remove all entities that were deleted due to the controller
-            physicsComponents.RemoveAll(p => p.Deleted);
+            ProcessQueue();
 
             const int solveIterationsAt60 = 4;
 
@@ -116,14 +185,10 @@ namespace Robust.Shared.GameObjects.Systems
 
             for (var i = 0; i < divisions; i++)
             {
-                foreach (var physics in physicsComponents)
+                foreach (var collidable in simulatedBodies)
                 {
-                    // TODO: Remove this once we are not sending *every* body to the solver
-                    if(prediction && !physics.Predict)
-                        continue;
-
-                    if(physics.Awake && physics.CanMove())
-                        UpdatePosition(physics, deltaTime / divisions);
+                    if(collidable.CanMove())
+                        UpdatePosition(collidable, deltaTime / divisions);
                 }
 
                 for (var j = 0; j < divisions; ++j)
@@ -134,18 +199,25 @@ namespace Robust.Shared.GameObjects.Systems
                     }
                 }
             }
+
+            // As we also defer the updates for the _collisionCache we need to update all entities
+            foreach (var collidable in _deferredUpdates)
+            {
+                var transform = collidable.Owner.Transform;
+                transform.DeferUpdates = false;
+                transform.RunCollidableDeferred();
+            }
+            
+            _deferredUpdates.Clear();
         }
 
         // Runs collision behavior and updates cache
-        private void ProcessCollisions(IEnumerable<ICollidableComponent> bodies)
+        private void ProcessCollisions(IEnumerable<ICollidableComponent> awakeBodies)
         {
             _collisionCache.Clear();
             var combinations = new HashSet<(EntityUid, EntityUid)>();
-            foreach (var aCollidable in bodies)
+            foreach (var aCollidable in awakeBodies)
             {
-                if(!aCollidable.Awake)
-                    continue;
-
                 foreach (var b in _physicsManager.GetCollidingEntities(aCollidable, Vector2.Zero))
                 {
                     var aUid = aCollidable.Entity.Uid;
@@ -281,29 +353,28 @@ namespace Robust.Shared.GameObjects.Systems
             body.LinearVelocity += frictionVelocityChange;
         }
 
-        private static void UpdatePosition(IPhysBody body, float frameTime)
+        private void UpdatePosition(ICollidableComponent collidable, float frameTime)
         {
-            var ent = body.Entity;
+            var ent = collidable.Entity;
 
-            if (!body.CanMove() || (body.LinearVelocity.LengthSquared < Epsilon && MathF.Abs(body.AngularVelocity) < Epsilon))
+            if (!collidable.CanMove() || (collidable.LinearVelocity.LengthSquared < Epsilon && MathF.Abs(collidable.AngularVelocity) < Epsilon))
                 return;
 
-            if (body.LinearVelocity != Vector2.Zero)
+            if (collidable.LinearVelocity != Vector2.Zero)
             {
-                var entityMoveMessage = new EntityMovementMessage();
-                ent.SendMessage(ent.Transform, entityMoveMessage);
-
                 if (ContainerHelpers.IsInContainer(ent))
                 {
                     var relayEntityMoveMessage = new RelayMovementEntityMessage(ent);
                     ent.Transform.Parent!.Owner.SendMessage(ent.Transform, relayEntityMoveMessage);
                     // This prevents redundant messages from being sent if solveIterations > 1 and also simulates the entity "colliding" against the locker door when it opens.
-                    body.LinearVelocity = Vector2.Zero;
+                    collidable.LinearVelocity = Vector2.Zero;
                 }
             }
-
-            body.WorldRotation += body.AngularVelocity * frameTime;
-            body.WorldPosition += body.LinearVelocity * frameTime;
+            
+            collidable.Owner.Transform.DeferUpdates = true;
+            _deferredUpdates.Add(collidable);
+            collidable.WorldRotation += collidable.AngularVelocity * frameTime;
+            collidable.WorldPosition += collidable.LinearVelocity * frameTime;
         }
 
         // Based off of Randy Gaul's ImpulseEngine code
@@ -327,9 +398,18 @@ namespace Robust.Shared.GameObjects.Systems
                 done = false;
                 var correction = collision.Normal * Math.Abs(penetration) * percent;
                 if (collision.A.CanMove())
+                {
+                    collision.A.Owner.Transform.DeferUpdates = true;
+                    _deferredUpdates.Add(collision.A);
                     collision.A.Owner.Transform.WorldPosition -= correction;
+                }
+
                 if (collision.B.CanMove())
+                {
+                    collision.B.Owner.Transform.DeferUpdates = true;
+                    _deferredUpdates.Add(collision.B);
                     collision.B.Owner.Transform.WorldPosition += correction;
+                }
             }
 
             return done;

--- a/Robust.Shared/Interfaces/GameObjects/Components/ITransformComponent.cs
+++ b/Robust.Shared/Interfaces/GameObjects/Components/ITransformComponent.cs
@@ -96,10 +96,25 @@ namespace Robust.Shared.Interfaces.GameObjects.Components
         ///     Returns the index of the grid which this object is on
         /// </summary>
         GridId GridID { get; }
+        
+        /// <summary>
+        ///     Whether external system updates should run or not (e.g. EntityTree, Matrices, PhysicsTree).
+        ///     These should be manually run later.
+        /// </summary>
+        bool DeferUpdates { get; set; }
 
         void AttachToGridOrMap();
         void AttachParent(ITransformComponent parent);
         void AttachParent(IEntity parent);
+        
+        /// <summary>
+        ///     Run the updates marked as deferred (UpdateEntityTree and movement events).
+        ///     Don't call this unless you REALLY need to.
+        /// </summary>
+        /// <remarks>
+        ///    Physics optimisation so these aren't spammed during physics updates.
+        /// </remarks>
+        void RunCollidableDeferred();
 
         IEnumerable<ITransformComponent> Children { get; }
         int ChildCount { get; }


### PR DESCRIPTION
Hope I didn't leave any grid 0 bugs in here...

Benefits from:
1. No more ToList() being called for SimulateWorld which is like 10% perf (a little bit of that was GC pressure).
2. Awake bodies being cached. This was like 25%.
3. There was like 5 iterations over all collidables which was reduced to have less duplication (ProcessQueue).
4. Deferred some Transform stuff which was another 25% or so.

Didn't notice any bugs when playtesting in game... there's room for more improvement though idle physics is under power system now.

Old client allocations:
<img width="800" alt="old_client_allocs" src="https://user-images.githubusercontent.com/31366439/95335913-b3b92180-08fb-11eb-9dc8-5c0b99b79913.PNG">

New client allocations:
<img width="777" alt="new_client_allocs" src="https://user-images.githubusercontent.com/31366439/95335920-b6b41200-08fb-11eb-9060-16f0f3274b5a.PNG">

Old client perf:
<img width="564" alt="old_client_physics" src="https://user-images.githubusercontent.com/31366439/95335963-c59ac480-08fb-11eb-99c9-220405e4cc77.PNG">

New client perf:
<img width="548" alt="new_client_physics" src="https://user-images.githubusercontent.com/31366439/95335946-c03d7a00-08fb-11eb-8a08-5c8be0ff633a.PNG">

~double framerate on my laptop conservatively