### PR TITLE
Fix ScrollBar overshot when frame time is long

### DIFF
--- a/Robust.Client/UserInterface/Controls/ScrollBar.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollBar.cs
@@ -72,7 +72,7 @@ namespace Robust.Client.UserInterface.Controls
             else
             {
                 _updating = true;
-                Value = MathHelper.Lerp(Value, ValueTarget, args.DeltaSeconds * 15);
+                Value = MathHelper.Lerp(Value, ValueTarget, Math.Min(args.DeltaSeconds * 15, 1));
                 _updating = false;
             }
         }


### PR DESCRIPTION
If the client is lagging, the ScrollBar will bounce back and forth instead of stopping where it should.