### PR TITLE
Mark MapIndices as Obsolete

### DIFF
--- a/Robust.Shared/Map/MapIndices.cs
+++ b/Robust.Shared/Map/MapIndices.cs
@@ -12,6 +12,7 @@ namespace Robust.Shared.Map
     /// </summary>
     [PublicAPI]
     [Serializable, NetSerializable]
+    [Obsolete("Use Vector2i instead")]
     public readonly struct MapIndices : IEquatable<MapIndices>
     {
         /// <summary>


### PR DESCRIPTION
The tyranny of MapIndices ends here.