### PR TITLE
Polar coordinate lighting implementation

### DIFF
--- a/Resources/Shaders/Internal/shadow_cast_shared.swsl
+++ b/Resources/Shaders/Internal/shadow_cast_shared.swsl
@@ -2,56 +2,13 @@
 
 const highp float PI = 3.1415926535897932384626433; // That enough digits?
 
-// Because the shadow map is projected as a SQUARE, not a circle.
-// We can't just use some atan magic to undo the projection.
-// This matrix is the projection matrix used to create the projection
-// so we can use that to "reverse engineer" the position.
-uniform highp mat4 shadowMatrix;
-
 // This returns a vec2 because of VSM moments.
-highp vec2 occludeDepth(highp vec2 diff, sampler2D shadowMap, highp float mapOffsetY)
+highp vec2 occludeDepth(highp vec2 rel, sampler2D shadowMap, highp float mapOffsetY)
 {
-    highp float angle = atan(diff.y, -diff.x) + PI + radians(135.0);
-#ifdef HAS_MOD
-    angle = mod(angle, 2.0 * PI);
-#else
-    angle -= floor(angle / (2.0 * PI)) * (2.0 * PI);
-#endif
-
-    highp vec2 shadowPoint;
-    highp float shadowMapOffset;
-
-    // Find quadrant the point is in and select correct horizontal offset in shadow map based on this.
-    // We also have to manually apply rotation to shadowPoint to accomodate for each quadrant actually being rotated.
-    if (angle < radians(90.0)) // Top
-    {
-        shadowPoint = diff;
-        shadowMapOffset = 0.0;
-    }
-    else if (angle < radians(180.0)) // Right
-    {
-        shadowPoint = vec2(-diff.y, diff.x);
-        shadowMapOffset = 0.25;
-    }
-    else if (angle < radians(270.0)) // Bottom
-    {
-        shadowPoint = -diff;
-        shadowMapOffset = 0.50;
-    }
-    else // Left
-    {
-        shadowPoint = vec2(diff.y, -diff.x);
-        shadowMapOffset = 0.75;
-    }
-
-    // Run shadow point through shadow matrix.
-    highp vec4 s = shadowMatrix * vec4(shadowPoint, 0.0, 1.0);
-    // Undo NDC coordinates to get a 0 -> 1 representing the x coordinates of the "screen".
-    // Which we then map to the texture.
-    s.xyz /= s.w;
-    highp float su = s.x * 0.5 + 0.5;
-
-    return zClydeShadowDepthUnpack(texture2D(shadowMap, vec2(su / 4.0 + shadowMapOffset, mapOffsetY)));
+    // It's a circle now, because it's faster to compute.
+    highp float deflect = (atan(rel.y, -rel.x) / PI);
+    highp float mapOffsetX = (deflect + 1.0) / 2.0;
+    return zClydeShadowDepthUnpack(texture2D(shadowMap, vec2(mapOffsetX, mapOffsetY)));
 }
 
 bool doesOcclude(highp vec2 diff, sampler2D shadowMap, highp float mapOffsetY, highp float bias)

--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -44,10 +44,6 @@ namespace Robust.Client.Graphics.Clyde
         private ClydeHandle _wallBleedBlurShaderHandle;
         private ClydeHandle _mergeWallLayerShaderHandle;
 
-        // Projection matrix used while rendering FOV.
-        // We keep this around so we can reverse the effects while overlaying actual FOV.
-        private Matrix4 _fovProjection;
-
         // Sampler used to sample the FovTexture with linear filtering, used in the lighting FOV pass
         // (it uses VSM unlike final FOV).
         private GLHandle _fovFilterSampler;
@@ -63,6 +59,7 @@ namespace Robust.Client.Graphics.Clyde
 
         // Actual GL objects used for rendering.
         private GLBuffer _occlusionVbo = default!;
+        private GLBuffer _occlusionVIVbo = default!;
         private GLBuffer _occlusionEbo = default!;
         private GLHandle _occlusionVao;
 
@@ -91,8 +88,6 @@ namespace Robust.Client.Graphics.Clyde
         private readonly (PointLightComponent light, Vector2 pos)[] _lightsToRenderList
             = new (PointLightComponent light, Vector2 pos)[MaxLightsPerScene];
 
-        private readonly Matrix4[] _shadowMatrices = new Matrix4[MaxLightsPerScene];
-
         private unsafe void InitLighting()
         {
             LoadLightingShaders();
@@ -106,14 +101,24 @@ namespace Robust.Client.Graphics.Clyde
 
                 ObjectLabelMaybe(ObjectLabelIdentifier.VertexArray, _occlusionVao, nameof(_occlusionVao));
 
+                // aPos
                 _occlusionVbo = new GLBuffer(this, BufferTarget.ArrayBuffer, BufferUsageHint.DynamicDraw,
                     nameof(_occlusionVbo));
+                GL.VertexAttribPointer(0, 4, VertexAttribPointerType.Float, false, sizeof(Vector4), IntPtr.Zero);
+                GL.EnableVertexAttribArray(0);
 
+                CheckGlError();
+
+                // subVertex
+                _occlusionVIVbo = new GLBuffer(this, BufferTarget.ArrayBuffer, BufferUsageHint.DynamicDraw,
+                    nameof(_occlusionVIVbo));
+                GL.VertexAttribPointer(1, 2, VertexAttribPointerType.UnsignedByte, true, sizeof(byte) * 2, IntPtr.Zero);
+                GL.EnableVertexAttribArray(1);
+
+                // index
                 _occlusionEbo = new GLBuffer(this, BufferTarget.ElementArrayBuffer, BufferUsageHint.DynamicDraw,
                     nameof(_occlusionEbo));
 
-                GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, sizeof(Vector3), IntPtr.Zero);
-                GL.EnableVertexAttribArray(0);
                 CheckGlError();
             }
 
@@ -167,7 +172,8 @@ namespace Robust.Client.Graphics.Clyde
             var depthFrag = ReadEmbeddedShader("shadow-depth.frag");
 
             (string, uint)[] attribLocations = {
-                ("aPos", 0)
+                ("aPos", 0),
+                ("subVertex", 1)
             };
 
             _fovCalculationProgram = _compileProgram(depthVert, depthFrag, attribLocations, "Shadow Depth Program");
@@ -216,12 +222,12 @@ namespace Robust.Client.Graphics.Clyde
                 GL.CullFace(CullFaceMode.Back);
                 CheckGlError();
 
-                DrawOcclusionDepth(eye.Position.Position, _fovRenderTarget.Size.X, maxDist, 0, out _fovProjection);
+                DrawOcclusionDepth(eye.Position.Position, _fovRenderTarget.Size.X, maxDist, 0);
 
                 GL.CullFace(CullFaceMode.Front);
                 CheckGlError();
 
-                DrawOcclusionDepth(eye.Position.Position, _fovRenderTarget.Size.X, maxDist, 1, out _fovProjection);
+                DrawOcclusionDepth(eye.Position.Position, _fovRenderTarget.Size.X, maxDist, 1);
             }
 
             FinalizeDepthDraw();
@@ -234,72 +240,34 @@ namespace Robust.Client.Graphics.Clyde
         /// <param name="width">The width of the current framebuffer.</param>
         /// <param name="maxDist">The maximum distance of this light.</param>
         /// <param name="viewportY">Y index of the row to render the depth at in the framebuffer.</param>
-        /// <param name="projMatrix">
-        ///     Projection matrix necessary to later un-project the depth map when applying it.
         /// </param>
-        private void DrawOcclusionDepth(Vector2 lightPos, int width, float maxDist, int viewportY,
-            out Matrix4 projMatrix)
+        private void DrawOcclusionDepth(Vector2 lightPos, int width, float maxDist, int viewportY)
         {
-            projMatrix = default; // Gets overriden below.
-
-            var (posX, posY) = lightPos;
-            var lightMatrix = Matrix4.CreateTranslation(-posX, -posY, 0);
-
             // The light is now the center of the universe.
-            _fovCalculationProgram.SetUniform("shadowLightMatrix", lightMatrix, false);
+            _fovCalculationProgram.SetUniform("shadowLightCentre", lightPos);
 
-            var baseProj = Matrix4.CreatePerspectiveFieldOfView(
-                MathHelper.DegreesToRadians(90),
-                1,
-                maxDist / 1000,
-                maxDist * 1.1f);
+            // Shift viewport around so we write to the correct quadrant of the depth map.
+            GL.Viewport(0, viewportY, width, 1);
+            CheckGlError();
 
-            var step = width / 4;
-
-            GL.Disable(EnableCap.Blend);
-
-            for (var i = 0; i < 4; i++)
-            {
-                // The occlusion geometry has to be rotated for every orientation and also corrected
-                // so that the 2D coordinates make more sense in 3D.
-                // These quaternions do that.
-                // They're just two 90 degree rotations around (at most) 2 of the axes of rotation but uhhh.
-                // I couldn't get LookRotation to work, ok?
-                var orientation = i switch
-                {
-                    0 => new Quaternion(-0.707f, 0, 0, 0.707f),
-                    1 => new Quaternion(0.5f, -0.5f, -0.5f, -0.5f),
-                    2 => new Quaternion(0, 0.707f, 0.707f, 0),
-                    3 => new Quaternion(-0.5f, -0.5f, -0.5f, 0.5f),
-                    _ => default
-                };
-
-                var rotMatrix = Matrix4.Rotate(orientation);
-                var proj = rotMatrix * baseProj;
-
-                if (i == 0)
-                {
-                    // First projection matrix is necessary to undo the projection inside the application shader.
-                    // So store it.
-                    projMatrix = proj;
-                }
-
-                _fovCalculationProgram.SetUniform("shadowProjectionMatrix", proj, false);
-                // Shift viewport around so we write to the correct quadrant of the depth map.
-                GL.Viewport(step * i, viewportY, step, 1);
-                CheckGlError();
-
-                GL.DrawElements(GetQuadGLPrimitiveType(), _occlusionDataLength, DrawElementsType.UnsignedShort, 0);
-                CheckGlError();
-                _debugStats.LastGLDrawCalls += 1;
-            }
-
-            GL.Enable(EnableCap.Blend);
+            // Make two draw calls. This allows a faked "generation" of additional polygons.
+            _fovCalculationProgram.SetUniform("shadowOverlapSide", 0.0f);
+            GL.DrawElements(GetQuadGLPrimitiveType(), _occlusionDataLength, DrawElementsType.UnsignedShort, 0);
+            CheckGlError();
+            _debugStats.LastGLDrawCalls += 1;
+            // Yup, it's the other draw call.
+            _fovCalculationProgram.SetUniform("shadowOverlapSide", 1.0f);
+            GL.DrawElements(GetQuadGLPrimitiveType(), _occlusionDataLength, DrawElementsType.UnsignedShort, 0);
+            CheckGlError();
+            _debugStats.LastGLDrawCalls += 1;
         }
 
         private void PrepareDepthDraw(LoadedRenderTarget target)
         {
             const float arbitraryDistanceMax = 1234;
+
+            GL.Disable(EnableCap.Blend);
+            CheckGlError();
 
             GL.Enable(EnableCap.DepthTest);
             CheckGlError();
@@ -317,7 +285,14 @@ namespace Robust.Client.Graphics.Clyde
             CheckGlError();
             GL.ClearDepth(1);
             CheckGlError();
-            GL.ClearColor(arbitraryDistanceMax, arbitraryDistanceMax * arbitraryDistanceMax, 0, 1);
+            if (_hasGLFloatFramebuffers)
+            {
+                GL.ClearColor(arbitraryDistanceMax, arbitraryDistanceMax * arbitraryDistanceMax, 0, 1);
+            }
+            else
+            {
+                GL.ClearColor(1, 1, 1, 1);
+            }
             CheckGlError();
             GL.Clear(ClearBufferMask.DepthBufferBit | ClearBufferMask.ColorBufferBit);
             CheckGlError();
@@ -332,9 +307,15 @@ namespace Robust.Client.Graphics.Clyde
 
         private void FinalizeDepthDraw()
         {
+            GL.Disable(EnableCap.CullFace);
+            CheckGlError();
+
+            GL.DepthMask(false);
+            CheckGlError();
             GL.Disable(EnableCap.DepthTest);
             CheckGlError();
-            GL.Disable(EnableCap.CullFace);
+
+            GL.Enable(EnableCap.Blend);
             CheckGlError();
         }
 
@@ -365,7 +346,7 @@ namespace Robust.Client.Graphics.Clyde
                     {
                         var (light, lightPos) = lights[i];
 
-                        DrawOcclusionDepth(lightPos, ShadowMapSize, light.Radius, i, out _shadowMatrices[i]);
+                        DrawOcclusionDepth(lightPos, ShadowMapSize, light.Radius, i);
                     }
                 }
 
@@ -445,7 +426,6 @@ namespace Robust.Client.Graphics.Clyde
 
                 lightShader.SetUniformMaybe("lightCenter", lightPos);
                 lightShader.SetUniformMaybe("lightIndex", (i + 0.5f) / ShadowTexture.Height);
-                lightShader.SetUniformMaybe("shadowMatrix", _shadowMatrices[i], false);
 
                 var offset = new Vector2(component.Radius, component.Radius);
 
@@ -641,7 +621,6 @@ namespace Robust.Client.Graphics.Clyde
             SetTexture(TextureUnit.Texture0, FovTexture);
 
             fovShader.SetUniformTextureMaybe(UniIMainTexture, TextureUnit.Texture0);
-            fovShader.SetUniformMaybe("shadowMatrix", _fovProjection, false);
             fovShader.SetUniformMaybe("center", eye.Position.Position);
 
             DrawBlit(viewport, fovShader);
@@ -675,7 +654,6 @@ namespace Robust.Client.Graphics.Clyde
             }
 
             fovShader.SetUniformTextureMaybe(UniIMainTexture, TextureUnit.Texture0);
-            fovShader.SetUniformMaybe("shadowMatrix", _fovProjection, false);
             fovShader.SetUniformMaybe("center", eye.Position.Position);
 
             DrawBlit(viewport, fovShader);
@@ -712,11 +690,13 @@ namespace Robust.Client.Graphics.Clyde
             // TODO: Yes this function throws and index exception if you reach maxOccluders.
 
             const int maxOccluders = 2048;
-            const float polygonHeight = 500;
 
             using var _ = DebugGroup(nameof(UpdateOcclusionGeometry));
 
-            var arrayBuffer = ArrayPool<Vector3>.Shared.Rent(maxOccluders * 8);
+            // 16 = 4 vertices * 4 directions
+            var arrayBuffer = ArrayPool<Vector4>.Shared.Rent(maxOccluders * 4 * 4);
+            // multiplied by 2 (it's a vector2 of bytes)
+            var arrayVIBuffer = ArrayPool<byte>.Shared.Rent(maxOccluders * 2 * 4 * 4);
             var indexBuffer = ArrayPool<ushort>.Shared.Rent(maxOccluders * GetQuadBatchIndexCount() * 4);
 
             var arrayMaskBuffer = ArrayPool<Vector2>.Shared.Rent(maxOccluders * 4);
@@ -729,6 +709,7 @@ namespace Robust.Client.Graphics.Clyde
                 var occluderTree = occluderSystem.GetOccluderTreeForMap(map);
 
                 var ai = 0;
+                var avi = 0;
                 var ami = 0;
                 var ii = 0;
                 var imi = 0;
@@ -752,24 +733,11 @@ namespace Robust.Client.Graphics.Clyde
                     var (brX, brY) = worldTransform.Transform(box.TopRight);
                     var (blX, blY) = worldTransform.Transform(box.BottomRight);
 
-                    // Vertices used as main occlusion geometry.
-                    // We always send all of these (see below) to keep code complexity down.
-                    ushort vTLH = (ushort) (ai + 0);
-                    arrayBuffer[ai + 0] = new Vector3(tlX, tlY, polygonHeight);
-                    ushort vTLL = (ushort) (ai + 1);
-                    arrayBuffer[ai + 1] = new Vector3(tlX, tlY, -polygonHeight);
-                    ushort vTRH = (ushort) (ai + 2);
-                    arrayBuffer[ai + 2] = new Vector3(trX, trY, polygonHeight);
-                    ushort vTRL = (ushort) (ai + 3);
-                    arrayBuffer[ai + 3] = new Vector3(trX, trY, -polygonHeight);
-                    ushort vBRH = (ushort) (ai + 4);
-                    arrayBuffer[ai + 4] = new Vector3(brX, brY, polygonHeight);
-                    ushort vBRL = (ushort) (ai + 5);
-                    arrayBuffer[ai + 5] = new Vector3(brX, brY, -polygonHeight);
-                    ushort vBLH = (ushort) (ai + 6);
-                    arrayBuffer[ai + 6] = new Vector3(blX, blY, polygonHeight);
-                    ushort vBLL = (ushort) (ai + 7);
-                    arrayBuffer[ai + 7] = new Vector3(blX, blY, -polygonHeight);
+                    // Faces.
+                    var faceN = new Vector4(tlX, tlY, trX, trY);
+                    var faceE = new Vector4(trX, trY, brX, brY);
+                    var faceS = new Vector4(brX, brY, blX, blY);
+                    var faceW = new Vector4(blX, blY, tlX, tlY);
 
                     //
                     // Buckle up.
@@ -820,33 +788,49 @@ namespace Robust.Client.Graphics.Clyde
                     var brV = dBrX < 0 && !eo || dBrY > 0 && !so;
 
                     // Handle faces, rules described above.
-                    // Note that faces are drawn with their 'normals' facing in the described direction in 3D space.
-                    // That is, they're clockwise "as viewed from the outside".
-                    // (When changing things to QuadBatchIndexWrite,
-                    // I described the behaviour correctly in this comment and then failed to implement it - 20kdc)
+                    // Note that "from above" it should be clockwise.
+                    // Further handling is in the shadow depth vertex shader.
+                    // (I have broken this so many times. - 20kdc)
+
+                    void WriteFaceOfBuffer(Vector4 vec)
+                    {
+                        var aiBase = ai;
+                        for (byte vi = 0; vi < 4; vi++)
+                        {
+                            arrayBuffer[ai++] = vec;
+                            // generates the sequence:
+                            // DddD
+                            // HHhh
+                            // deflection
+                            arrayVIBuffer[avi++] = (byte) ((((vi + 1) & 2) != 0) ? 0 : 255);
+                            // height
+                            arrayVIBuffer[avi++] = (byte) (((vi & 2) != 0) ? 0 : 255);
+                        }
+                        QuadBatchIndexWrite(indexBuffer, ref ii, (ushort) aiBase);
+                    }
 
                     // North face (TL/TR)
                     if (!no || !tlV && !trV)
                     {
-                        QuadBatchIndexWrite(indexBuffer, ref ii, vTRH, vTLH, vTLL, vTRL);
+                        WriteFaceOfBuffer(faceN);
                     }
 
                     // East face (TR/BR)
                     if (!eo || !brV && !trV)
                     {
-                        QuadBatchIndexWrite(indexBuffer, ref ii, vBRH, vTRH, vTRL, vBRL);
+                        WriteFaceOfBuffer(faceE);
                     }
 
                     // South face (BR/BL)
                     if (!so || !brV && !blV)
                     {
-                        QuadBatchIndexWrite(indexBuffer, ref ii, vBLH, vBRH, vBRL, vBLL);
+                        WriteFaceOfBuffer(faceS);
                     }
 
                     // West face (BL/TL)
                     if (!wo || !blV && !tlV)
                     {
-                        QuadBatchIndexWrite(indexBuffer, ref ii, vTLH, vBLH, vBLL, vTLL);
+                        WriteFaceOfBuffer(faceW);
                     }
 
                     // Generate mask geometry.
@@ -858,7 +842,6 @@ namespace Robust.Client.Graphics.Clyde
                     // Generate mask indices.
                     QuadBatchIndexWrite(indexMaskBuffer, ref imi, (ushort) ami);
 
-                    ai += 8;
                     ami += 4;
 
                     return true;
@@ -872,6 +855,7 @@ namespace Robust.Client.Graphics.Clyde
                 CheckGlError();
 
                 _occlusionVbo.Reallocate(arrayBuffer.AsSpan(..ai));
+                _occlusionVIVbo.Reallocate(arrayVIBuffer.AsSpan(..avi));
                 _occlusionEbo.Reallocate(indexBuffer.AsSpan(..ii));
 
                 BindVertexArray(_occlusionMaskVao.Handle);
@@ -882,9 +866,10 @@ namespace Robust.Client.Graphics.Clyde
             }
             finally
             {
-                ArrayPool<Vector3>.Shared.Return(arrayBuffer);
-                ArrayPool<Vector2>.Shared.Return(arrayMaskBuffer);
+                ArrayPool<Vector4>.Shared.Return(arrayBuffer);
+                ArrayPool<byte>.Shared.Return(arrayVIBuffer);
                 ArrayPool<ushort>.Shared.Return(indexBuffer);
+                ArrayPool<Vector2>.Shared.Return(arrayMaskBuffer);
                 ArrayPool<ushort>.Shared.Return(indexMaskBuffer);
             }
         }

--- a/Robust.Client/Graphics/Clyde/Shaders/shadow-depth.frag
+++ b/Robust.Client/Graphics/Clyde/Shaders/shadow-depth.frag
@@ -1,16 +1,26 @@
-varying highp vec2 pos;
+
+// xy: A, zw: B
+varying highp vec4 fragPos;
+// x: actual angle, y: horizontal (1) / vertical (-1)
+varying highp vec2 fragAngle;
 
 void main()
 {
-    highp vec2 adjustedPos = pos;
-    if (!gl_FrontFacing)
-    {
-        // Slightly bias back faces inwards.
-        // This fixes being able to see a few no-lighting pixels (like space)
-        // "behind" walls at certain angles/positions.
-        //adjustedPos -= sign(adjustedPos) * 1.5/32.0;
+    // Stuff that needs to be inferred to avoid interpolation issues.
+    highp vec2 rayNormal = vec2(cos(fragAngle.x), -sin(fragAngle.x));
+
+    // Depth calculation accounting for interpolation.
+    highp float dist;
+
+    if (fragAngle.y > 0.0) {
+        // Line is horizontal
+        dist = abs(fragPos.y / rayNormal.y);
+    } else {
+        // Line is vertical
+        dist = abs(fragPos.x / rayNormal.x);
     }
-    highp float dist = length(adjustedPos);
+
+    // Main body.
 #ifdef HAS_DFDX
     highp float dx = dFdx(dist);
     highp float dy = dFdy(dist); // I'm aware derivative of y makes no sense here but oh well.

--- a/Robust.Client/Graphics/Clyde/Shaders/shadow-depth.vert
+++ b/Robust.Client/Graphics/Clyde/Shaders/shadow-depth.vert
@@ -1,14 +1,79 @@
-/*layout (location = 0)*/ attribute vec3 aPos;
+// Polar-coordinate mapper.
+// While inspired by https://www.gamasutra.com/blogs/RobWare/20180226/313491/Fast_2D_shadows_in_Unity_using_1D_shadow_mapping.php ,
+//  has one major difference:
+// The assumption here is that the shadow sampling must be reduced.
+// The original cardinal-direction mapper as written by PJB used 4 separate views.
+// As such, it's still an increase in performance to only render 2 views.
+// And as such, a line can be split across the 2 views.
+
+// xy: A, zw: B
+attribute vec4 aPos;
+// x: deflection(0=A/1=B) y: height
+attribute vec2 subVertex;
 
 varying vec2 pos;
 
 // Note: This is *not* the standard projectionMatrix!
-uniform mat4 shadowProjectionMatrix;
-uniform mat4 shadowLightMatrix;
+uniform vec2 shadowLightCentre;
+
+uniform float shadowOverlapSide;
+
+// this constant ought to be moved to z-library
+// also deal with the reference to it in shadow_cast_shared
+const highp float PI = 3.1415926535897932384626433;
+
+float calcX(vec2 rel)
+{
+    return atan(rel.y, -rel.x) / PI;
+}
 
 void main()
 {
-    vec4 rel = shadowLightMatrix * vec4(aPos, 1.0);
-    gl_Position = shadowProjectionMatrix * rel;
-    pos = rel.xy;
+    // aPos is clockwise, but we need anticlockwise so swap it here
+    vec2 pA = aPos.zw - shadowLightCentre;
+    vec2 pB = aPos.xy - shadowLightCentre;
+    float xA = calcX(pA);
+    float xB = calcX(pB);
+
+    // We need to reliably detect a clip, as opposed to, say, a backdrawn face.
+    // So a clip is when the angular area is >= 180 degrees (which is not possible with a quad and always occurs when wrapping)
+    if (abs(xA - xB) >= 1.0)
+    {
+        // Oh no! It clipped...
+        if (xA > xB)
+        {
+            // ...such that xA is on the right side and xB is on the left!
+            if (shadowOverlapSide > 0.5)
+            {
+                // ...move the left boundary past the left edge!
+                xA -= 2.0;
+            }
+            else
+            {
+                // ...move the right boundary past the right edge!
+                xB += 2.0;
+            }
+        }
+        else
+        {
+            // ...such that xA is on the left side and xB is on the right!
+            if (shadowOverlapSide > 0.5)
+            {
+                // ...move the left boundary past the right edge!
+                xA += 2.0;
+            }
+            else
+            {
+                // ...move the right boundary past the left edge!
+                xB -= 2.0;
+            }
+        }
+    }
+
+    pos = mix(pA, pB, subVertex.x);
+
+    // Implement a depth divide here for now
+    float depth = 1.0 - (1.0 / length(pos));
+
+    gl_Position = vec4(mix(xA, xB, subVertex.x), mix(1.0, -1.0, subVertex.y), depth, 1.0);
 }


### PR DESCRIPTION
This was actually ready for ages but I never PR'd it.
Or if I did I forgot or it was closed or something. IDK.
Following screenshots were taken with `--cvar net.predict=false` for more accurate performance information.

BEFORE COMMIT:
![image](https://user-images.githubusercontent.com/22304167/95788592-bc32a300-0cd3-11eb-8a6c-050803c1cc6f.png)

AFTER COMMIT:
![image](https://user-images.githubusercontent.com/22304167/95789040-aec9e880-0cd4-11eb-8787-9b5e7ac52d90.png)

PR credits:
+ PJB brought up the idea of using polar coordinates
+ https://www.gamasutra.com/blogs/RobWare/20180226/313491/Fast_2D_shadows_in_Unity_using_1D_shadow_mapping.php was referenced but not used in full

Important notes:
+ Visible (if small) difference in performance on this hardware
+ Shadows/fov "bend" with circular outlines. This is not a resolution problem, it's a lack of proper correction - interpolation of depth over angles is being done linearly, which is incorrect. For lighting I doubt this matters, especially given wall blend blur. For FOV a solution would be good.
+ Discord user "Abraham" appears to have performance problems with lighting that take them down from 25FPS to 8FPS. It's possible that the depthmap rendering is having more of an effect than it should on their hardware, and this may help mitigate that.
+ The approach by RobWare used to solve the aliasing problem (making the shadowmap larger and requiring two shadow samples) was *not used* due to differing performance priorities - instead a 'double-strike' rendering of the depthmap was used.
+ Ultimately this set of tradeoffs should guarantee that polar coordinates will have superior performance unless atan is incredibly worse-performing - the depthmap draw calls are halved (rather than quartered), but as a result, occludeDepth (called once per pixel on every single sprite) is simpler.