### PR TITLE
Fix UI keybinds when not a printable character

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
@@ -104,6 +104,18 @@ namespace Robust.Client.Graphics.Clyde
             return GLFW.GetKeyScancode(Keyboard.ConvertGlfwKeyReverse(key));
         }
 
+        public static bool IsKeyPrintable(Keyboard.Key key)
+        {
+            var glfwKey = Keyboard.ConvertGlfwKeyReverse(key);
+            if (glfwKey < 0)
+                return false;
+            var scancode = GLFW.GetKeyScancode(glfwKey);
+            if (scancode <= 0)
+                return false;
+            var name = GLFW.GetKeyName(glfwKey, scancode);
+            return name != null;
+        }
+
         private List<Exception>? _glfwExceptionList;
         private bool _isMinimized;
 

--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -310,7 +310,9 @@ namespace Robust.Client.Input
             binding.State = state;
 
             var eventArgs = new BoundKeyEventArgs(binding.Function, binding.State,
-                new ScreenCoordinates(MouseScreenPosition), binding.CanFocus);
+                new ScreenCoordinates(MouseScreenPosition), binding.CanFocus,
+                binding.Mod1 == Key.Unknown && binding.Mod2 == Key.Unknown && binding.Mod3 == Key.Unknown &&
+                Graphics.Clyde.Clyde.IsKeyPrintable(binding.BaseKey));
 
             UIKeyBindStateChanged?.Invoke(eventArgs);
             if (state == BoundKeyState.Up || !eventArgs.Handled && !uiOnly)

--- a/Robust.Client/UserInterface/Control.Input.cs
+++ b/Robust.Client/UserInterface/Control.Input.cs
@@ -79,8 +79,8 @@ namespace Robust.Client.UserInterface
         public Vector2 RelativePixelPosition { get; internal set; }
 
         public GUIBoundKeyEventArgs(BoundKeyFunction function, BoundKeyState state, ScreenCoordinates pointerLocation,
-            bool canFocus, Vector2 relativePosition, Vector2 relativePixelPosition)
-            : base(function, state, pointerLocation, canFocus)
+            bool canFocus, bool printable, Vector2 relativePosition, Vector2 relativePixelPosition)
+            : base(function, state, pointerLocation, canFocus, false)
         {
             RelativePosition = relativePosition;
             RelativePixelPosition = relativePixelPosition;

--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -287,7 +287,7 @@ namespace Robust.Client.UserInterface
             }
 
             var guiArgs = new GUIBoundKeyEventArgs(args.Function, args.State, args.PointerLocation, args.CanFocus,
-                args.PointerLocation.Position / UIScale - control.GlobalPosition,
+                args.Printable, args.PointerLocation.Position / UIScale - control.GlobalPosition,
                 args.PointerLocation.Position - control.GlobalPixelPosition);
 
             _doGuiInput(control, guiArgs, (c, ev) => c.KeyBindDown(ev));
@@ -307,7 +307,7 @@ namespace Robust.Client.UserInterface
             }
 
             var guiArgs = new GUIBoundKeyEventArgs(args.Function, args.State, args.PointerLocation, args.CanFocus,
-                args.PointerLocation.Position / UIScale - control.GlobalPosition,
+                args.Printable, args.PointerLocation.Position / UIScale - control.GlobalPosition,
                 args.PointerLocation.Position - control.GlobalPixelPosition);
 
             _doGuiInput(control, guiArgs, (c, ev) => c.KeyBindUp(ev));

--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -763,7 +763,7 @@ namespace Robust.Client.UserInterface
         /// <param name="args">Event data values for a bound key state change.</param>
         private void OnUIKeyBindStateChanged(BoundKeyEventArgs args)
         {
-            if (!args.CanFocus && KeyboardFocused != null)
+            if (!args.CanFocus && KeyboardFocused != null && args.Printable)
             {
                 args.Handle();
             }

--- a/Robust.Shared/Input/BoundKeyEventArgs.cs
+++ b/Robust.Shared/Input/BoundKeyEventArgs.cs
@@ -28,6 +28,11 @@ namespace Robust.Shared.Input
         /// </summary>
         public bool CanFocus { get; internal set; }
 
+        /// <summary>
+        ///     Whether the Bound key is a printable character.
+        /// </summary>
+        public bool Printable { get; internal set; }
+
         public bool Handled { get; private set; }
 
         /// <summary>
@@ -36,12 +41,13 @@ namespace Robust.Shared.Input
         /// <param name="function">Bound key that that is changing.</param>
         /// <param name="state">New state of the function.</param>
         /// <param name="pointerLocation">Current Pointer location in screen coordinates.</param>
-        public BoundKeyEventArgs(BoundKeyFunction function, BoundKeyState state, ScreenCoordinates pointerLocation, bool canFocus)
+        public BoundKeyEventArgs(BoundKeyFunction function, BoundKeyState state, ScreenCoordinates pointerLocation, bool canFocus, bool printable)
         {
             Function = function;
             State = state;
             PointerLocation = pointerLocation;
             CanFocus = canFocus;
+            Printable = printable;
         }
 
         /// <summary>

--- a/Robust.Shared/Input/BoundKeyEventArgs.cs
+++ b/Robust.Shared/Input/BoundKeyEventArgs.cs
@@ -30,6 +30,7 @@ namespace Robust.Shared.Input
 
         /// <summary>
         ///     Whether the Bound key is a printable character.
+        ///     Used for checking whether hotkey should be blocked so that hotkeys don't get triggered when using UserInterfaceManager.TextEntered.
         /// </summary>
         public bool Printable { get; internal set; }
 

--- a/Robust.UnitTesting/Client/UserInterface/UserInterfaceManagerTest.cs
+++ b/Robust.UnitTesting/Client/UserInterface/UserInterfaceManagerTest.cs
@@ -65,7 +65,7 @@ namespace Robust.UnitTesting.Client.UserInterface
             control1.ForceRunLayoutUpdate();
 
             var mouseEvent = new BoundKeyEventArgs(EngineKeyFunctions.Use, BoundKeyState.Down,
-                new Robust.Shared.Map.ScreenCoordinates(30, 30), true);
+                new Robust.Shared.Map.ScreenCoordinates(30, 30), true, false);
 
             var control2Fired = false;
             var control3Fired = false;

--- a/Robust.UnitTesting/Client/UserInterface/UserInterfaceManagerTest.cs
+++ b/Robust.UnitTesting/Client/UserInterface/UserInterfaceManagerTest.cs
@@ -244,7 +244,7 @@ namespace Robust.UnitTesting.Client.UserInterface
             var pos = new Robust.Shared.Map.ScreenCoordinates(30, 30);
 
             var mouseEvent = new GUIBoundKeyEventArgs(EngineKeyFunctions.Use, BoundKeyState.Down,
-                pos, true, pos.Position / 1 - control.GlobalPosition, pos.Position - control.GlobalPixelPosition);
+                pos, true, false, pos.Position / 1 - control.GlobalPosition, pos.Position - control.GlobalPixelPosition);
 
             _userInterfaceManager.KeyBindDown(mouseEvent);
 


### PR DESCRIPTION
Tentative fix for UI keybinds
Fixes space-wizards/space-station-14#2143

There's three ways I can think of doing this. Static like I have it here, non-static and include Clyde in InputManager, or pass Printable from Clyde all the way down to InputManager.

The things that should work are LineEdit hotkeys, NT Block Game hotkeys, and typing keys (e.g. WASD) in LineEdit without triggering hotkeys like moving the character.