### PR TITLE
Stop redundant appearance data from being sent

### DIFF
--- a/Robust.Server/GameObjects/Components/Appearance/AppearanceComponent.cs
+++ b/Robust.Server/GameObjects/Components/Appearance/AppearanceComponent.cs
@@ -14,12 +14,18 @@ namespace Robust.Server.GameObjects
 
         public override void SetData(string key, object value)
         {
+            if (data.TryGetValue(key, out var existing) && existing.Equals(value))
+                return;
+
             data[key] = value;
             Dirty();
         }
 
         public override void SetData(Enum key, object value)
         {
+            if (data.TryGetValue(key, out var existing) && existing.Equals(value))
+                return;
+
             data[key] = value;
             Dirty();
         }


### PR DESCRIPTION
As I was flying around medical on saltern I noticed my net_graph was going up, annnddd turns out the medical scanners were updating their appearance every tick.

Medical scanner probably needs a re-work on a few things to make it a bit more performant and fix some bugs.