### PR TITLE
Fix UI keybinds stopping after the first

### DIFF
--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -64,7 +64,7 @@ namespace Robust.Client.Input
         public IInputContextContainer Contexts { get; } = new InputContextContainer();
 
         /// <inheritdoc />
-        public event Action<BoundKeyEventArgs>? UIKeyBindStateChanged;
+        public event Func<BoundKeyEventArgs, bool>? UIKeyBindStateChanged;
 
         /// <inheritdoc />
         public event Action<BoundKeyEventArgs>? KeyBindStateChanged;
@@ -312,8 +312,10 @@ namespace Robust.Client.Input
             var eventArgs = new BoundKeyEventArgs(binding.Function, binding.State,
                 new ScreenCoordinates(MouseScreenPosition), binding.CanFocus);
 
-            UIKeyBindStateChanged?.Invoke(eventArgs);
-            if (state == BoundKeyState.Up || !eventArgs.Handled && !uiOnly)
+            var handled = UIKeyBindStateChanged?.Invoke(eventArgs);
+            if (state == BoundKeyState.Up
+                || !(handled == true || eventArgs.Handled)
+                && !uiOnly)
             {
                 var cmd = GetInputCommand(binding.Function);
                 // TODO: Allow input commands to still get forwarded to server if necessary.

--- a/Robust.Client/Interfaces/Input/IInputManager.cs
+++ b/Robust.Client/Interfaces/Input/IInputManager.cs
@@ -63,7 +63,7 @@ namespace Robust.Client.Interfaces.Input
         /// <summary>
         ///     UIKeyBindStateChanged is called when a keybind is found.
         /// </summary>
-        event Action<BoundKeyEventArgs> UIKeyBindStateChanged;
+        event Func<BoundKeyEventArgs, bool> UIKeyBindStateChanged;
 
         /// <summary>
         ///     If UIKeyBindStateChanged did not handle the BoundKeyEvent, KeyBindStateChanged is called.

--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -761,13 +761,8 @@ namespace Robust.Client.UserInterface
         ///     Converts
         /// </summary>
         /// <param name="args">Event data values for a bound key state change.</param>
-        private void OnUIKeyBindStateChanged(BoundKeyEventArgs args)
+        private bool OnUIKeyBindStateChanged(BoundKeyEventArgs args)
         {
-            if (!args.CanFocus && KeyboardFocused != null)
-            {
-                args.Handle();
-            }
-
             if (args.State == BoundKeyState.Down)
             {
                 KeyBindDown(args);
@@ -776,6 +771,12 @@ namespace Robust.Client.UserInterface
             {
                 KeyBindUp(args);
             }
+
+            if (!args.CanFocus && KeyboardFocused != null)
+            {
+                return true;
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
Fixes space-wizards/space-station-14#2143

The things that should work are LineEdit hotkeys, NT Block Game hotkeys, and typing keys (e.g. WASD) in LineEdit without triggering hotkeys like moving the character.