### PR TITLE
Fix even more physics jank

### DIFF
--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Collision.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Collision.cs
@@ -76,7 +76,7 @@ namespace Robust.Shared.GameObjects.Components
             {
                 if (_sleepAccumulator == value)
                     return;
-                
+
                 _sleepAccumulator = value;
                 Awake = _physicsManager.SleepTimeThreshold > SleepAccumulator;
             }
@@ -130,6 +130,7 @@ namespace Robust.Shared.GameObjects.Components
             serializer.DataField(ref _bodyType, "bodyType", BodyType.Static);
             serializer.DataField(ref _physShapes, "shapes", new List<IPhysShape> {new PhysShapeAabb()});
             serializer.DataField(ref _anchored, "anchored", true);
+            serializer.DataField(ref _mass, "mass", 1.0f);
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
@@ -22,6 +22,11 @@ namespace Robust.Shared.GameObjects.Components
         Vector2 Momentum { get; set; }
 
         /// <summary>
+        ///     Apply an impulse to an entity. Velocity += impulse / InvMass.
+        /// </summary>
+        void ApplyImpulse(Vector2 impulse);
+
+        /// <summary>
         ///     The current status of the object
         /// </summary>
         BodyStatus Status { get; set; }
@@ -190,7 +195,7 @@ namespace Robust.Shared.GameObjects.Components
         /// </summary>
         public float InvMass
         {
-            get => Mass > 0 ? 1f / Mass : 0f;
+            get => CanMove() ? Mass : 0.0f; // Infinite mass, hopefully you didn't fuck up physics anywhere.
             set => Mass = value > 0 ? 1f / value : 0f;
         }
 
@@ -245,6 +250,11 @@ namespace Robust.Shared.GameObjects.Components
         {
             get => _friction;
             set => _friction = value;
+        }
+
+        public void ApplyImpulse(Vector2 impulse)
+        {
+            LinearVelocity += impulse * InvMass;
         }
 
         /// <summary>

--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
@@ -505,7 +505,7 @@ namespace Robust.Shared.GameObjects.Components
         /// <inheritdoc />
         public bool CanMove()
         {
-            return !Anchored && !Mass.Equals(0) && !Deleted;
+            return !Anchored && Mass > 0;
         }
     }
 }

--- a/Robust.Shared/Physics/PhysicsManager.cs
+++ b/Robust.Shared/Physics/PhysicsManager.cs
@@ -95,12 +95,12 @@ namespace Robust.Shared.Physics
         {
             var aP = manifold.A;
             var bP = manifold.B;
-            if (aP == null && bP == null) return Vector2.Zero;
+
+            if (!aP.CanMove() && !bP.CanMove()) return Vector2.Zero;
+
             var restitution = 0.01f;
             var normal = CalculateNormal(manifold.A, manifold.B);
-            var rV = aP != null
-                ? bP != null ? bP.LinearVelocity - aP.LinearVelocity : -aP.LinearVelocity
-                : bP!.LinearVelocity;
+            var rV = bP.LinearVelocity - aP.LinearVelocity;
 
             var vAlongNormal = Vector2.Dot(rV, normal);
             if (vAlongNormal > 0)
@@ -112,8 +112,8 @@ namespace Robust.Shared.Physics
             // So why the 100.0f instead of 0.0f? Well, because the other object needs to have SOME mass value,
             // or otherwise the physics object can actually sink in slightly to the physics-less object.
             // (the 100.0f is equivalent to a mass of 0.01kg)
-            impulse /= (aP != null && aP.Mass > 0.0f ? 1 / aP.Mass : 100.0f) +
-                       (bP != null && bP.Mass > 0.0f ? 1 / bP.Mass : 100.0f);
+            impulse /= aP.InvMass + bP.InvMass;
+
             return manifold.Normal * impulse;
         }
 

--- a/Robust.Shared/Physics/PhysicsManager.cs
+++ b/Robust.Shared/Physics/PhysicsManager.cs
@@ -112,6 +112,8 @@ namespace Robust.Shared.Physics
             // So why the 100.0f instead of 0.0f? Well, because the other object needs to have SOME mass value,
             // or otherwise the physics object can actually sink in slightly to the physics-less object.
             // (the 100.0f is equivalent to a mass of 0.01kg)
+            // TODO: If one of the objects has infinite mass then this should just cancel out their impulse.
+            // Needs further testing.
             impulse /= aP.InvMass + bP.InvMass;
 
             return manifold.Normal * impulse;


### PR DESCRIPTION
tl;dr because I accidentally deleted my last description: Looked at Randy Gaul's code more and used InvMass more here in the SolveCollisionImpulse step. This means less FixClipping needed so less jitter. Stuff still occasionally phases through walls but I'm a lot happier with it in game.

Could also adjust CanMove so it only checks Anchored probably as the other checks are redundant.

I also had mass serialize as well because it wasn't being done. It also has my eye fix (mainly because it was making testing ingame easier with it applied).

[fizix.zip](https://github.com/space-wizards/RobustToolbox/files/5391066/fizix.zip)

zip with old and new physics applied (hopefully it's obvious which is which).