### PR TITLE
Lighting: Polar Coordinates fix: Sparkle-Be-Gone

### DIFF
--- a/Robust.Client/Console/Commands/Debug.cs
+++ b/Robust.Client/Console/Commands/Debug.cs
@@ -729,6 +729,20 @@ namespace Robust.Client.Console.Commands
         }
     }
 
+    internal class ToggleHardFOV : IConsoleCommand
+    {
+        public string Command => "togglehardfov";
+        public string Description => "Toggles hard fov for client (for debugging space-station-14#2353).";
+        public string Help => "togglehardfov";
+
+        public bool Execute(IDebugConsole console, params string[] args)
+        {
+            var mgr = IoCManager.Resolve<ILightManager>();
+            mgr.DrawHardFov = !mgr.DrawHardFov;
+            return false;
+        }
+    }
+
     internal class ToggleShadows : IConsoleCommand
     {
         public string Command => "toggleshadows";

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -297,7 +297,7 @@ namespace Robust.Client.Graphics.Clyde
 
                     RenderOverlays(OverlaySpace.WorldSpace);
 
-                    if (_lightManager.Enabled && eye.DrawFov)
+                    if (_lightManager.Enabled && _lightManager.DrawHardFov && eye.DrawFov)
                     {
                         ApplyFovToBuffer(viewport, eye);
                     }

--- a/Robust.Client/Graphics/Lighting/LightManager.cs
+++ b/Robust.Client/Graphics/Lighting/LightManager.cs
@@ -6,5 +6,6 @@ namespace Robust.Client.Graphics.Lighting
     {
         public bool Enabled { get; set; } = true;
         public bool DrawShadows { get; set; } = true;
+        public bool DrawHardFov { get; set; } = true;
     }
 }

--- a/Robust.Client/Interfaces/Graphics/Lighting/ILightManager.cs
+++ b/Robust.Client/Interfaces/Graphics/Lighting/ILightManager.cs
@@ -4,5 +4,6 @@
     {
         bool Enabled { get; set; }
         bool DrawShadows { get; set; }
+        bool DrawHardFov { get; set; }
     }
 }


### PR DESCRIPTION
Deals with rendering issues seen in space-wizards/space-station-14#2353
Also adds a new debugging command, `togglehardfov` which disables 'hard' FOV (useful for debugging this sort of thing in future)
Both screenshots that follow were taken with hard FOV off to show the core of the problem.
Before:
![image](https://user-images.githubusercontent.com/22304167/96859680-b10d0f00-1459-11eb-8e67-1ee1072ae042.png)
After:
![image](https://user-images.githubusercontent.com/22304167/96859779-d00ba100-1459-11eb-9bd0-fa85e7230308.png)
