### PR TITLE
Fix grid parenting

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -224,19 +224,6 @@ namespace Robust.Shared.GameObjects.Components.Transform
                     return;
                 }
 
-                // Change parent if necessary
-                if (_mapManager.TryFindGridAt(MapID, value, out var grid) &&
-                    grid.GridEntityId.IsValid() &&
-                    grid.GridEntityId != Owner.Uid)
-                {
-                    if (grid.GridEntityId != ParentUid)
-                        AttachParent(Owner.EntityManager.GetEntity(grid.GridEntityId));
-                }
-                else
-                {
-                    AttachParent(_mapManager.GetMapEntity(MapID));
-                }
-
                 // world coords to parent coords
                 var newPos = Parent!.InvWorldMatrix.Transform(value);
 

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -224,6 +224,18 @@ namespace Robust.Shared.GameObjects.Components.Transform
                     return;
                 }
 
+                // Change parent if necessary
+                if (_mapManager.TryFindGridAt(MapID, value, out var grid) &&
+                    grid.GridEntityId.IsValid() &&
+                    grid.GridEntityId != Owner.Uid)
+                {
+                    AttachParent(Owner.EntityManager.GetEntity(grid.GridEntityId));
+                }
+                else
+                {
+                    AttachParent(_mapManager.GetMapEntity(MapID));
+                }
+
                 // world coords to parent coords
                 var newPos = Parent!.InvWorldMatrix.Transform(value);
 
@@ -535,7 +547,7 @@ namespace Robust.Shared.GameObjects.Components.Transform
             //NOTE: This function must be callable from before initialize
 
             // nothing to attach to.
-            if (newParent == null)
+            if (ParentUid == newParent.Owner.Uid)
                 return;
 
             DebugTools.Assert(newParent != this,

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -78,7 +78,7 @@ namespace Robust.Shared.GameObjects.Components.Transform
 
         /// <inheritdoc />
         public bool DeferUpdates { get; set; }
-        
+
         // Deferred fields
         private Angle? _oldLocalRotation;
         private EntityCoordinates? _oldCoords;
@@ -229,7 +229,8 @@ namespace Robust.Shared.GameObjects.Components.Transform
                     grid.GridEntityId.IsValid() &&
                     grid.GridEntityId != Owner.Uid)
                 {
-                    AttachParent(Owner.EntityManager.GetEntity(grid.GridEntityId));
+                    if (grid.GridEntityId != ParentUid)
+                        AttachParent(Owner.EntityManager.GetEntity(grid.GridEntityId));
                 }
                 else
                 {
@@ -242,7 +243,7 @@ namespace Robust.Shared.GameObjects.Components.Transform
                 // float rounding error guard, if the offset is less than 1mm ignore it
                 //if ((newPos - GetLocalPosition()).LengthSquared < 1.0E-3)
                 //    return;
-                
+
                 LocalPosition = newPos;
             }
         }
@@ -277,7 +278,7 @@ namespace Robust.Shared.GameObjects.Components.Transform
                         Owner.EntityManager.EventBus.RaiseEvent(
                             EventSource.Local, new MoveEvent(Owner, oldPosition, Coordinates));
                     }
-                    
+
                     UpdateEntityTree();
                     UpdatePhysicsTree();
                 }
@@ -303,7 +304,7 @@ namespace Robust.Shared.GameObjects.Components.Transform
 
                 if (_localPosition == value)
                     return;
-                
+
                 var oldGridPos = Coordinates;
                 SetPosition(value);
                 Dirty();

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -224,20 +224,17 @@ namespace Robust.Shared.GameObjects.Components.Transform
                     return;
                 }
 
-                if (!ContainerHelpers.IsInContainer(Owner))
+                // Change parent if necessary
+                if (_mapManager.TryFindGridAt(MapID, value, out var grid) &&
+                    grid.GridEntityId.IsValid() &&
+                    grid.GridEntityId != Owner.Uid)
                 {
-                    // Change parent if necessary
-                    if (_mapManager.TryFindGridAt(MapID, value, out var grid) &&
-                        grid.GridEntityId.IsValid() &&
-                        grid.GridEntityId != Owner.Uid)
-                    {
-                        if (grid.GridEntityId != ParentUid)
-                            AttachParent(Owner.EntityManager.GetEntity(grid.GridEntityId));
-                    }
-                    else
-                    {
-                        AttachParent(_mapManager.GetMapEntity(MapID));
-                    }
+                    if (grid.GridEntityId != ParentUid)
+                        AttachParent(Owner.EntityManager.GetEntity(grid.GridEntityId));
+                }
+                else
+                {
+                    AttachParent(_mapManager.GetMapEntity(MapID));
                 }
 
                 // world coords to parent coords

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -224,17 +224,20 @@ namespace Robust.Shared.GameObjects.Components.Transform
                     return;
                 }
 
-                // Change parent if necessary
-                if (_mapManager.TryFindGridAt(MapID, value, out var grid) &&
-                    grid.GridEntityId.IsValid() &&
-                    grid.GridEntityId != Owner.Uid)
+                if (!ContainerHelpers.IsInContainer(Owner))
                 {
-                    if (grid.GridEntityId != ParentUid)
-                        AttachParent(Owner.EntityManager.GetEntity(grid.GridEntityId));
-                }
-                else
-                {
-                    AttachParent(_mapManager.GetMapEntity(MapID));
+                    // Change parent if necessary
+                    if (_mapManager.TryFindGridAt(MapID, value, out var grid) &&
+                        grid.GridEntityId.IsValid() &&
+                        grid.GridEntityId != Owner.Uid)
+                    {
+                        if (grid.GridEntityId != ParentUid)
+                            AttachParent(Owner.EntityManager.GetEntity(grid.GridEntityId));
+                    }
+                    else
+                    {
+                        AttachParent(_mapManager.GetMapEntity(MapID));
+                    }
                 }
 
                 // world coords to parent coords

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -383,8 +383,26 @@ namespace Robust.Shared.GameObjects.Systems
             if (physics.LinearVelocity.Length > _speedLimit)
                 physics.LinearVelocity = physics.LinearVelocity.Normalized * _speedLimit;
 
+            var newPosition = physics.WorldPosition + physics.LinearVelocity * frameTime;
+            var owner = physics.Owner;
+            var transform = owner.Transform;
+
+            // Change parent if necessary
+            // This shoouullddnnn'''tt de-parent anything in a container because none of that should have physics applied to it.
+            if (_mapManager.TryFindGridAt(owner.Transform.MapID, newPosition, out var grid) &&
+                grid.GridEntityId.IsValid() &&
+                grid.GridEntityId != owner.Uid)
+            {
+                if (grid.GridEntityId != transform.ParentUid)
+                    transform.AttachParent(owner.EntityManager.GetEntity(grid.GridEntityId));
+            }
+            else
+            {
+                transform.AttachParent(_mapManager.GetMapEntity(transform.MapID));
+            }
+
             physics.WorldRotation += physics.AngularVelocity * frameTime;
-            physics.WorldPosition += physics.LinearVelocity * frameTime;
+            physics.WorldPosition = newPosition;
         }
 
         // Based off of Randy Gaul's ImpulseEngine code

--- a/Robust.Shared/Interfaces/GameObjects/Components/ITransformComponent.cs
+++ b/Robust.Shared/Interfaces/GameObjects/Components/ITransformComponent.cs
@@ -27,6 +27,7 @@ namespace Robust.Shared.Interfaces.GameObjects.Components
 
         /// <summary>
         ///     Current position offset of the entity relative to the world.
+        ///     Can de-parent from its parent if the parent is a grid.
         /// </summary>
         Vector2 WorldPosition { get; set; }
 
@@ -96,7 +97,7 @@ namespace Robust.Shared.Interfaces.GameObjects.Components
         ///     Returns the index of the grid which this object is on
         /// </summary>
         GridId GridID { get; }
-        
+
         /// <summary>
         ///     Whether external system updates should run or not (e.g. EntityTree, Matrices, PhysicsTree).
         ///     These should be manually run later.
@@ -106,7 +107,7 @@ namespace Robust.Shared.Interfaces.GameObjects.Components
         void AttachToGridOrMap();
         void AttachParent(ITransformComponent parent);
         void AttachParent(IEntity parent);
-        
+
         /// <summary>
         ///     Run the updates marked as deferred (UpdateEntityTree and movement events).
         ///     Don't call this unless you REALLY need to.

--- a/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
@@ -247,7 +247,7 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
         ///     Tests to see if setting the world position of a child causes position rounding errors.
         /// </summary>
         [Test]
-        public void ParentWorldPositionRoundingErrorTest()
+        public void ParentLocalPositionRoundingErrorTest()
         {
             // Arrange
             var node1 = EntityManager.SpawnEntity("dummy", InitialPos);
@@ -271,9 +271,9 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
             for (var i = 0; i < 10000; i++)
             {
                 var dx = i % 2 == 0 ? 5 : -5;
-                node1Trans.WorldPosition += new Vector2(dx, dx);
-                node2Trans.WorldPosition += new Vector2(dx, dx);
-                node3Trans.WorldPosition += new Vector2(dx, dx);
+                node1Trans.LocalPosition += new Vector2(dx, dx);
+                node2Trans.LocalPosition += new Vector2(dx, dx);
+                node3Trans.LocalPosition += new Vector2(dx, dx);
             }
 
             var newWpos = node3Trans.WorldPosition;
@@ -281,7 +281,7 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
             // Assert
             Assert.Multiple(() =>
             {
-                Assert.That(MathHelper.CloseTo(oldWpos.X, newWpos.Y), newWpos.ToString);
+                Assert.That(MathHelper.CloseTo(oldWpos.X, newWpos.Y), $"{oldWpos.X} should be {newWpos.Y}");
                 Assert.That(MathHelper.CloseTo(oldWpos.Y, newWpos.Y), newWpos.ToString);
             });
         }

--- a/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
@@ -107,8 +107,8 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
             });
 
             // move the parent, and the child should move with it
-            childTrans.WorldPosition = new Vector2(6, 6);
-            parentTrans.WorldPosition += new Vector2(-8, -8);
+            childTrans.LocalPosition = new Vector2(6, 6);
+            parentTrans.WorldPosition = new Vector2(-8, -8);
 
             Assert.That(childTrans.WorldPosition, Is.EqualTo(new Vector2(-2, -2)));
 


### PR DESCRIPTION
ROAD TO SHUTTLES.
A bunch of transform stuff probably needs refactoring because it's from the pre-EntityCoordinates times.

Anything that's parented to another non-map/grid entity shouldn't be touching its WorldPosition.