### PR TITLE
Minor physics optimisation

### DIFF
--- a/Robust.Shared/Interfaces/Physics/IPhysicsManager.cs
+++ b/Robust.Shared/Interfaces/Physics/IPhysicsManager.cs
@@ -128,22 +128,7 @@ namespace Robust.Shared.Interfaces.Physics
         public readonly Vector2 Normal;
         public readonly bool Hard;
 
-        public Vector2 RelativeVelocity
-        {
-            get
-            {
-                if (A != null)
-                {
-                    if (B != null)
-                        return B.LinearVelocity - A.LinearVelocity;
-                    return -A.LinearVelocity;
-                }
-
-                if (B != null)
-                    return B.LinearVelocity;
-                return Vector2.Zero;
-            }
-        }
+        public Vector2 RelativeVelocity => B.LinearVelocity - A.LinearVelocity;
 
         public bool Unresolved => Vector2.Dot(RelativeVelocity, Normal) < 0 && Hard;
 

--- a/Robust.Shared/Physics/PhysicsManager.cs
+++ b/Robust.Shared/Physics/PhysicsManager.cs
@@ -106,8 +106,8 @@ namespace Robust.Shared.Physics
             if (!aP.CanMove() && !bP.CanMove()) return Vector2.Zero;
 
             var restitution = 0.01f;
-            var normal = CalculateNormal(manifold.A, manifold.B);
-            var rV = bP.LinearVelocity - aP.LinearVelocity;
+            var normal = manifold.Normal;
+            var rV = manifold.RelativeVelocity;
 
             var vAlongNormal = Vector2.Dot(rV, normal);
             if (vAlongNormal > 0)
@@ -116,11 +116,6 @@ namespace Robust.Shared.Physics
             }
 
             var impulse = -(1.0f + restitution) * vAlongNormal;
-            // So why the 100.0f instead of 0.0f? Well, because the other object needs to have SOME mass value,
-            // or otherwise the physics object can actually sink in slightly to the physics-less object.
-            // (the 100.0f is equivalent to a mass of 0.01kg)
-            // TODO: If one of the objects has infinite mass then this should just cancel out their impulse.
-            // Needs further testing.
             impulse /= aP.InvMass + bP.InvMass;
 
             return manifold.Normal * impulse;


### PR DESCRIPTION
It's the shuffle for every single collision which seemed less than ideal when you can just use a random index. Rest is just cleanup.

Mainly spotted after I connected to USW and was wondering why my FPS was 0.01 as below:

![image](https://user-images.githubusercontent.com/31366439/97130436-8ee6fa00-1795-11eb-8670-97dafc68d3d2.png)

Still a WIP overall.
