### PR TITLE
Fix map deserialized entities not being included in OccluderSystem

### DIFF
--- a/Robust.Shared/GameObjects/Components/Light/OccluderComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Light/OccluderComponent.cs
@@ -45,6 +45,13 @@ namespace Robust.Shared.GameObjects
             }
         }
 
+        protected override void Startup()
+        {
+            base.Startup();
+
+            EntitySystem.Get<OccluderSystem>().UpdateEntity(Owner);
+        }
+
         public override void ExposeData(ObjectSerializer serializer)
         {
             base.ExposeData(serializer);

--- a/Robust.Shared/GameObjects/Systems/OccluderSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/OccluderSystem.cs
@@ -107,7 +107,7 @@ namespace Robust.Shared.GameObjects.Systems
             }
         }
 
-        private void UpdateEntity(IEntity entity)
+        internal void UpdateEntity(IEntity entity)
         {
             if (entity.TryGetComponent(out OccluderComponent? occluder))
             {

--- a/Robust.Shared/GameObjects/Systems/OccluderSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/OccluderSystem.cs
@@ -32,7 +32,6 @@ namespace Robust.Shared.GameObjects.Systems
             _mapManager.MapCreated += MapManagerOnMapCreated;
             _mapManager.MapDestroyed += MapManagerOnMapDestroyed;
 
-            SubscribeLocalEvent<EntityInitializedMessage>(EntInitialized);
             SubscribeLocalEvent<EntMapIdChangedMessage>(EntMapIdChanged);
             SubscribeLocalEvent<MoveEvent>(EntMoved);
             SubscribeLocalEvent<EntParentChangedMessage>(EntParentChanged);
@@ -106,11 +105,6 @@ namespace Robust.Shared.GameObjects.Systems
                 oldTree?.Remove(occluder);
                 newTree?.AddOrUpdate(occluder);
             }
-        }
-
-        private void EntInitialized(EntityInitializedMessage ev)
-        {
-            UpdateEntity(ev.Entity);
         }
 
         private void UpdateEntity(IEntity entity)

--- a/Robust.Shared/GameObjects/Systems/OccluderSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/OccluderSystem.cs
@@ -32,6 +32,7 @@ namespace Robust.Shared.GameObjects.Systems
             _mapManager.MapCreated += MapManagerOnMapCreated;
             _mapManager.MapDestroyed += MapManagerOnMapDestroyed;
 
+            SubscribeLocalEvent<EntityInitializedMessage>(EntInitialized);
             SubscribeLocalEvent<EntMapIdChangedMessage>(EntMapIdChanged);
             SubscribeLocalEvent<MoveEvent>(EntMoved);
             SubscribeLocalEvent<EntParentChangedMessage>(EntParentChanged);
@@ -105,6 +106,11 @@ namespace Robust.Shared.GameObjects.Systems
                 oldTree?.Remove(occluder);
                 newTree?.AddOrUpdate(occluder);
             }
+        }
+
+        private void EntInitialized(EntityInitializedMessage ev)
+        {
+            UpdateEntity(ev.Entity);
         }
 
         private void UpdateEntity(IEntity entity)


### PR DESCRIPTION
Because when OccluderSystem gets the event for saltern, entities are parented but their transforms are not initialized which means that the occluder system cant loop through Transform.Children.

This is only an issue on the server.

Needed for https://github.com/space-wizards/space-station-14/pull/2253 and for unoccluded checks to work in general.