### PR TITLE
Make transformstate actually check equals

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -717,7 +717,7 @@ namespace Robust.Shared.GameObjects.Components.Transform
                     rebuildMatrices = true;
                 }
 
-                if (_localPosition != newState.LocalPosition)
+                if (!_localPosition.EqualsApprox(newState.LocalPosition, 0.0001))
                 {
                     var oldPos = Coordinates;
                     SetPosition(newState.LocalPosition);


### PR DESCRIPTION
Floating point amirite

This raises a MoveEvent on the eventbus so saves a bit on component states being applied.