### PR TITLE
AlignWithClosestGridTile extension for EntityCoordinates

### DIFF
--- a/Robust.Client/Placement/Modes/AlignTileAny.cs
+++ b/Robust.Client/Placement/Modes/AlignTileAny.cs
@@ -15,57 +15,11 @@ namespace Robust.Client.Placement.Modes
         {
             const float SearchBoxSize = 1.5f; // size of search box in meters
 
-            MouseCoords = ScreenToCursorGrid(mouseScreen);
+            MouseCoords = ScreenToCursorGrid(mouseScreen).AlignWithClosestGridTile(SearchBoxSize, pManager.EntityManager, pManager.MapManager);
 
             var gridId = MouseCoords.GetGridId(pManager.EntityManager);
 
-            IMapGrid? mapGrid = null;
-
-            if (!gridId.IsValid() || !pManager.MapManager.TryGetGrid(gridId, out mapGrid))
-            {
-                // create a box around the cursor
-                var gridSearchBox = Box2.UnitCentered.Scale(SearchBoxSize).Translated(MouseCoords.Position);
-
-                // find grids in search box
-                var gridsInArea = pManager.MapManager.FindGridsIntersecting(MouseCoords.GetMapId(pManager.EntityManager), gridSearchBox);
-
-                // find closest grid intersecting our search box.
-                IMapGrid? closest = null;
-                var distance = float.PositiveInfinity;
-                var intersect = new Box2();
-                foreach (var grid in gridsInArea)
-                {
-                    // figure out closest intersect
-                    var gridIntersect = gridSearchBox.Intersect(grid.WorldBounds);
-                    var gridDist = (gridIntersect.Center - MouseCoords.Position).LengthSquared;
-
-                    if (gridDist >= distance)
-                        continue;
-
-                    distance = gridDist;
-                    closest = grid;
-                    intersect = gridIntersect;
-                }
-
-                if (closest != null) // stick to existing grid
-                {
-                    // round to nearest cardinal dir
-                    var normal = new Angle(MouseCoords.Position - intersect.Center).GetCardinalDir().ToVec();
-
-                    // round coords to center of tile
-                    var tileIndices = closest.WorldToTile(intersect.Center);
-                    var tileCenterWorld = closest.GridTileToWorldPos(tileIndices);
-
-                    // move mouse one tile out along normal
-                    var newTilePos = tileCenterWorld + normal * closest.TileSize;
-
-                    MouseCoords = new EntityCoordinates(closest.GridEntityId, closest.WorldToLocal(newTilePos));
-                    mapGrid = closest;
-                }
-                //else free place
-            }
-
-            if (mapGrid == null)
+            if (!pManager.MapManager.TryGetGrid(gridId, out var mapGrid))
                 return;
 
             CurrentTile = mapGrid.GetTileRef(MouseCoords);

--- a/Robust.Shared/GameObjects/Components/Timers/TimerExtensions.cs
+++ b/Robust.Shared/GameObjects/Components/Timers/TimerExtensions.cs
@@ -55,6 +55,9 @@ namespace Robust.Shared.GameObjects.Components.Timers
         /// <param name="cancellationToken"></param>
         public static void SpawnTimer(this IEntity entity, int milliseconds, Action onFired, CancellationToken cancellationToken = default)
         {
+            if (entity.Deleted)
+                return;
+
             entity
                 .EnsureComponent<TimerComponent>()
                 .Spawn(milliseconds, onFired, cancellationToken);

--- a/Robust.Shared/Map/CoordinatesExtensions.cs
+++ b/Robust.Shared/Map/CoordinatesExtensions.cs
@@ -25,9 +25,7 @@ namespace Robust.Shared.Map
 
             var gridId = coords.GetGridId(entityManager);
 
-            IMapGrid? mapGrid = null;
-
-            if (!gridId.IsValid() || !mapManager.TryGetGrid(gridId, out mapGrid))
+            if (!gridId.IsValid() || !mapManager.TryGetGrid(gridId, out _))
             {
                 // create a box around the cursor
                 var gridSearchBox = Box2.UnitCentered.Scale(searchBoxSize).Translated(coords.Position);

--- a/Robust.Shared/Map/CoordinatesExtensions.cs
+++ b/Robust.Shared/Map/CoordinatesExtensions.cs
@@ -25,7 +25,7 @@ namespace Robust.Shared.Map
 
             var gridId = coords.GetGridId(entityManager);
 
-            if (!gridId.IsValid() || !mapManager.TryGetGrid(gridId, out _))
+            if (!gridId.IsValid() || !mapManager.GridExists(gridId))
             {
                 // create a box around the cursor
                 var gridSearchBox = Box2.UnitCentered.Scale(searchBoxSize).Translated(coords.Position);

--- a/Robust.Shared/Map/CoordinatesExtensions.cs
+++ b/Robust.Shared/Map/CoordinatesExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.Interfaces.Map;
+﻿using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Interfaces.Map;
 using Robust.Shared.IoC;
 using Robust.Shared.Maths;
 
@@ -12,8 +13,64 @@ namespace Robust.Shared.Map
 
             var grid = mapManager.GetGrid(gridId);
             var tile = grid.TileSize;
-            
+
             return new EntityCoordinates(grid.GridEntityId, (vector.X * tile, vector.Y * tile));
+        }
+
+        public static EntityCoordinates AlignWithClosestGridTile(this EntityCoordinates coordinates, float searchBoxSize = 1.5f, IEntityManager? entityManager = null, IMapManager? mapManager = null)
+        {
+            var coords = coordinates;
+            entityManager ??= IoCManager.Resolve<IEntityManager>();
+            mapManager ??= IoCManager.Resolve<IMapManager>();
+
+            var gridId = coords.GetGridId(entityManager);
+
+            IMapGrid? mapGrid = null;
+
+            if (!gridId.IsValid() || !mapManager.TryGetGrid(gridId, out mapGrid))
+            {
+                // create a box around the cursor
+                var gridSearchBox = Box2.UnitCentered.Scale(searchBoxSize).Translated(coords.Position);
+
+                // find grids in search box
+                var gridsInArea = mapManager.FindGridsIntersecting(coords.GetMapId(entityManager), gridSearchBox);
+
+                // find closest grid intersecting our search box.
+                IMapGrid? closest = null;
+                var distance = float.PositiveInfinity;
+                var intersect = new Box2();
+                foreach (var grid in gridsInArea)
+                {
+                    // figure out closest intersect
+                    var gridIntersect = gridSearchBox.Intersect(grid.WorldBounds);
+                    var gridDist = (gridIntersect.Center - coords.Position).LengthSquared;
+
+                    if (gridDist >= distance)
+                        continue;
+
+                    distance = gridDist;
+                    closest = grid;
+                    intersect = gridIntersect;
+                }
+
+                if (closest != null) // stick to existing grid
+                {
+                    // round to nearest cardinal dir
+                    var normal = new Angle(coords.Position - intersect.Center).GetCardinalDir().ToVec();
+
+                    // round coords to center of tile
+                    var tileIndices = closest.WorldToTile(intersect.Center);
+                    var tileCenterWorld = closest.GridTileToWorldPos(tileIndices);
+
+                    // move mouse one tile out along normal
+                    var newTilePos = tileCenterWorld + normal * closest.TileSize;
+
+                    coords = new EntityCoordinates(closest.GridEntityId, closest.WorldToLocal(newTilePos));
+                }
+                //else free place
+            }
+
+            return coords;
         }
     }
 }


### PR DESCRIPTION
Used for aligning an EntityCoordinates to the closest grid. Does the same as the `AlignTileAny` placement mode.
Also fixes component exception when adding a timer component to a deleted entity.