### PR TITLE
Don't initialize dummyicon appearance

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1834,9 +1834,9 @@ namespace Robust.Client.GameObjects
             if (prototype.Components.TryGetValue("Appearance", out _))
             {
                 var appearanceComponent = dummy.AddComponent<AppearanceComponent>();
-                appearanceComponent.Initialize();
                 foreach (var layer in appearanceComponent.Visualizers)
                 {
+                    layer.InitializeEntity(dummy);
                     layer.OnChangeData(appearanceComponent);
                 }
             }


### PR DESCRIPTION
Originally I thought it'd make it easier if appearancecomponent were ever updated buuuttt I went to add tests for the dummyicon and this turned out to be a hindrance.