### PR TITLE
spritecomp will ignore state/texture attribute when layers are defined

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1116,7 +1116,7 @@ namespace Robust.Client.GameObjects
             var layerData =
                 serializer.ReadDataField("layers", new List<PrototypeLayerData>());
 
-            {
+            if(layerData.Count == 0){
                 var baseState = serializer.ReadDataField<string?>("state", null);
                 var texturePath = serializer.ReadDataField<string?>("texture", null);
 

--- a/Robust.Server/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Server/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -418,7 +418,7 @@ namespace Robust.Server.GameObjects
             var layerData =
                 serializer.ReadDataField<List<PrototypeLayerData>>("layers", new List<PrototypeLayerData>());
 
-            {
+            if(layerData.Count == 0){
                 var baseState = serializer.ReadDataField<string?>("state", null);
                 var texturePath = serializer.ReadDataField<string?>("texture", null);
 


### PR DESCRIPTION
what it says on the tin. imo this is the only logical behaviour

