### PR TITLE
Add searching by component name to View Variables

### DIFF
--- a/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceEntity.cs
+++ b/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceEntity.cs
@@ -142,6 +142,16 @@ namespace Robust.Client.ViewVariables.Instances
 
             _clientComponentsSearchBar.OnTextChanged += OnClientComponentsSearchBarChanged;
 
+            // See engine#636 for why the Distinct() call.
+            var componentList = _entity.GetAllComponents().OrderBy(c => c.GetType().ToString());
+
+            foreach (var component in componentList)
+            {
+                var button = new Button {Text = TypeAbbreviation.Abbreviate(component.GetType()), TextAlign = Label.AlignMode.Left};
+                button.OnPressed += args => { ViewVariablesManager.OpenVV(component); };
+                _clientComponents.AddChild(button);
+            }
+
             if (!_entity.Uid.IsClientSide())
             {
                 _serverVariables = new VBoxContainer {SeparationOverride = 0};

--- a/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceEntity.cs
+++ b/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceEntity.cs
@@ -328,6 +328,13 @@ namespace Robust.Client.ViewVariables.Instances
             var componentsBlob = await ViewVariablesManager.RequestData<ViewVariablesBlobEntityComponents>(_entitySession, new ViewVariablesRequestEntityComponents());
 
             _serverComponents.DisposeAllChildren();
+            
+            _serverComponents.AddChild(_serverComponentsSearchBar = new LineEdit
+            {
+                PlaceHolder = Loc.GetString("Search"),
+                SizeFlagsHorizontal = SizeFlags.FillExpand
+            });
+            
             componentsBlob.ComponentTypes.Sort();
 
             var componentTypes = componentsBlob.ComponentTypes.AsEnumerable();

--- a/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceEntity.cs
+++ b/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceEntity.cs
@@ -334,6 +334,8 @@ namespace Robust.Client.ViewVariables.Instances
                 PlaceHolder = Loc.GetString("Search"),
                 SizeFlagsHorizontal = SizeFlags.FillExpand
             });
+
+            _serverComponentsSearchBar.OnTextChanged += OnServerComponentsSearchBarChanged;
             
             componentsBlob.ComponentTypes.Sort();
 


### PR DESCRIPTION
Requires https://github.com/space-wizards/RobustToolbox/pull/1414

Should probably separate the search bar from the component list first before merging.

![EWJ2cG0lbB](https://user-images.githubusercontent.com/10968691/99825430-539ed780-2b57-11eb-944d-917a38955bf8.gif)
