### PR TITLE
Implemented erasing rectangular areas

### DIFF
--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -494,22 +494,24 @@ namespace Robust.Client.Placement
 
         private bool CurrentEraserMouseCoordinates(out EntityCoordinates coordinates)
         {
-            var map = MapId.Nullspace;
             var ent = PlayerManager.LocalPlayer?.ControlledEntity;
-            if (ent != null)
-            {
-                map = ent.Transform.MapID;
-            }
-
-            if (map == MapId.Nullspace || !Eraser)
+            if (ent == null)
             {
                 coordinates = new EntityCoordinates();
                 return false;
             }
-
-            coordinates = EntityCoordinates.FromMap(ent.EntityManager, MapManager,
-                eyeManager.ScreenToMap(new ScreenCoordinates(_inputManager.MouseScreenPosition)));
-            return true;
+            else
+            {
+                var map = ent.Transform.MapID;
+                if (map == MapId.Nullspace || !Eraser)
+                {
+                    coordinates = new EntityCoordinates();
+                    return false;
+                }
+                coordinates = EntityCoordinates.FromMap(ent.EntityManager, MapManager,
+                    eyeManager.ScreenToMap(new ScreenCoordinates(_inputManager.MouseScreenPosition)));
+                return true;
+            }
         }
 
         /// <inheritdoc />

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Robust.Client.ResourceManagement;
@@ -22,7 +22,6 @@ using Robust.Shared.Utility;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using Robust.Shared.Log;
-using Robust.Client.Graphics.Shaders;
 
 namespace Robust.Client.Placement
 {
@@ -618,7 +617,7 @@ namespace Robust.Client.Placement
                 if (EraserRect.HasValue)
                 {
                     handle.UseShader(_drawingShader);
-                    handle.DrawRect(EraserRect.Value, new Color(255, 0, 0, 100));
+                    handle.DrawRect(EraserRect.Value, new Color(255, 0, 0, 50));
                 }
                 return;
             }

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -506,7 +506,7 @@ namespace Robust.Client.Placement
         private bool CurrentEraserMouseCoordinates(out EntityCoordinates coordinates)
         {
             var map = MapId.Nullspace;
-            var ent = PlayerManager.LocalPlayer!.ControlledEntity;
+            var ent = PlayerManager.LocalPlayer?.ControlledEntity;
             if (ent != null)
             {
                 map = ent.Transform.MapID;
@@ -518,7 +518,7 @@ namespace Robust.Client.Placement
                 return false;
             }
 
-            coordinates = EntityCoordinates.FromMap(ent!.EntityManager, MapManager,
+            coordinates = EntityCoordinates.FromMap(ent.EntityManager, MapManager,
                 eyeManager.ScreenToMap(new ScreenCoordinates(_inputManager.MouseScreenPosition)));
             return true;
         }

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -22,6 +22,7 @@ using Robust.Shared.Utility;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using Robust.Shared.Log;
+using Robust.Client.Graphics.Shaders;
 
 namespace Robust.Client.Placement
 {
@@ -93,6 +94,11 @@ namespace Robust.Client.Placement
         public Box2? EraserRect { get; set; }
 
         /// <summary>
+        /// Drawing shader for drawing without being affected by lighting
+        /// </summary>
+        private ShaderInstance? _drawingShader { get; set; }
+
+        /// <summary>
         /// The texture we use to show from our placement manager to represent the entity to place
         /// </summary>
         public List<IDirectionalTextureProvider>? CurrentTextures { get; set; }
@@ -159,6 +165,8 @@ namespace Robust.Client.Placement
 
         public void Initialize()
         {
+            _drawingShader = _prototypeManager.Index<ShaderPrototype>("unshaded").Instance();
+
             NetworkManager.RegisterNetMessage<MsgPlacement>(MsgPlacement.NAME, HandlePlacementMessage);
 
             _modeDictionary.Clear();
@@ -605,11 +613,11 @@ namespace Robust.Client.Placement
 
         private void Render(DrawingHandleWorld handle)
         {
-
             if (CurrentMode == null || !IsActive)
             {
                 if (EraserRect.HasValue)
                 {
+                    handle.UseShader(_drawingShader);
                     handle.DrawRect(EraserRect.Value, new Color(255, 0, 0, 100));
                 }
                 return;

--- a/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
+++ b/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
@@ -201,6 +201,7 @@ namespace Robust.Client.UserInterface.CustomControls
         private void OnEraseButtonToggled(BaseButton.ButtonToggledEventArgs args)
         {
             placementManager.ToggleEraser();
+            OverrideMenu.Disabled = args.Pressed;
         }
 
         private void BuildEntityList(string? searchStr = null)
@@ -510,6 +511,7 @@ namespace Robust.Client.UserInterface.CustomControls
             }
 
             EraseButton.Pressed = false;
+            OverrideMenu.Disabled = false;
         }
 
         private class DoNotMeasure : Control

--- a/Robust.Server/Placement/PlacementManager.cs
+++ b/Robust.Server/Placement/PlacementManager.cs
@@ -208,54 +208,13 @@ namespace Robust.Server.Placement
         private void HandleRectRemoveReq(MsgPlacement msg)
         {
             EntityCoordinates start = msg.EntityCoordinates;
-            EntityCoordinates end = msg.EndEntityCoordinates;
-            EntityCoordinates center = new EntityCoordinates(start.EntityId, (start.Position + end.Position) / 2.0f);
-            // Optimization for rect checks without adding a new method
-            float xSize = MathF.Abs(start.X - end.X);
-            float ySize = MathF.Abs(start.Y - end.Y);
-            if (xSize > ySize)
+            Vector2 rectSize = msg.RectSize;
+            foreach (IEntity entity in _entityManager.GetEntitiesIntersecting(start.GetMapId(_entityManager),
+                new Box2(start.Position, start.Position + rectSize)))
             {
-                float low, high;
-                if (start.Y > end.Y)
-                {
-                    low = end.Y;
-                    high = start.Y;
-                }
-                else
-                {
-                    low = start.Y;
-                    high = end.Y;
-                }
-                foreach (IEntity entity in _entityManager.GetEntitiesInRange(center, xSize))
-                {
-                    if (entity.Deleted || entity.HasComponent<IMapGridComponent>() || entity.HasComponent<IActorComponent>())
-                        continue;
-                    if (entity.Transform.Coordinates.Y < low || entity.Transform.Coordinates.Y > high)
-                        continue;
-                    _entityManager.DeleteEntity(entity);
-                }
-            }
-            else
-            {
-                float low, high;
-                if (start.X > end.X)
-                {
-                    low = end.X;
-                    high = start.X;
-                }
-                else
-                {
-                    low = start.X;
-                    high = end.X;
-                }
-                foreach (IEntity entity in _entityManager.GetEntitiesInRange(center, ySize))
-                {
-                    if (entity.Deleted || entity.HasComponent<IMapGridComponent>() || entity.HasComponent<IActorComponent>())
-                        continue;
-                    if (entity.Transform.Coordinates.X < low || entity.Transform.Coordinates.X > high)
-                        continue;
-                    _entityManager.DeleteEntity(entity);
-                }
+                if (entity.Deleted || entity.HasComponent<IMapGridComponent>() || entity.HasComponent<IActorComponent>())
+                    continue;
+                entity.Delete();
             }
         }
 

--- a/Robust.Shared/Enums/NetworkEnums.cs
+++ b/Robust.Shared/Enums/NetworkEnums.cs
@@ -7,6 +7,7 @@
         PlacementFailed,
         RequestPlacement,
         RequestEntRemove,
+        RequestRectRemove,
     }
 
     public enum SessionStatus : byte

--- a/Robust.Shared/Network/Messages/MsgPlacement.cs
+++ b/Robust.Shared/Network/Messages/MsgPlacement.cs
@@ -29,6 +29,7 @@ namespace Robust.Shared.Network.Messages
         public int Range { get; set; }
         public string ObjType { get; set; }
         public string AlignOption { get; set; }
+        public EntityCoordinates EndEntityCoordinates { get; set; }
 
         public override void ReadFromBuffer(NetIncomingMessage buffer)
         {
@@ -56,6 +57,10 @@ namespace Robust.Shared.Network.Messages
                     throw new NotImplementedException();
                 case PlacementManagerMessage.RequestEntRemove:
                     EntityUid = new EntityUid(buffer.ReadInt32());
+                    break;
+                case PlacementManagerMessage.RequestRectRemove:
+                    EntityCoordinates = buffer.ReadEntityCoordinates();
+                    EndEntityCoordinates = buffer.ReadEntityCoordinates();
                     break;
             }
         }
@@ -86,6 +91,10 @@ namespace Robust.Shared.Network.Messages
                     throw new NotImplementedException();
                 case PlacementManagerMessage.RequestEntRemove:
                     buffer.Write((int)EntityUid);
+                    break;
+                case PlacementManagerMessage.RequestRectRemove:
+                    buffer.Write(EntityCoordinates);
+                    buffer.Write(EndEntityCoordinates);
                     break;
             }
         }

--- a/Robust.Shared/Network/Messages/MsgPlacement.cs
+++ b/Robust.Shared/Network/Messages/MsgPlacement.cs
@@ -29,7 +29,7 @@ namespace Robust.Shared.Network.Messages
         public int Range { get; set; }
         public string ObjType { get; set; }
         public string AlignOption { get; set; }
-        public EntityCoordinates EndEntityCoordinates { get; set; }
+        public Vector2 RectSize { get; set; }
 
         public override void ReadFromBuffer(NetIncomingMessage buffer)
         {
@@ -60,7 +60,7 @@ namespace Robust.Shared.Network.Messages
                     break;
                 case PlacementManagerMessage.RequestRectRemove:
                     EntityCoordinates = buffer.ReadEntityCoordinates();
-                    EndEntityCoordinates = buffer.ReadEntityCoordinates();
+                    RectSize = buffer.ReadVector2();
                     break;
             }
         }
@@ -94,7 +94,7 @@ namespace Robust.Shared.Network.Messages
                     break;
                 case PlacementManagerMessage.RequestRectRemove:
                     buffer.Write(EntityCoordinates);
-                    buffer.Write(EndEntityCoordinates);
+                    buffer.Write(RectSize);
                     break;
             }
         }


### PR DESCRIPTION
- Ctrl+Click can now be used (the same way as for grid placing) while erasing to delete entities in a free rectangular area (ignores entities with either IMapComponent or IActorComponent)
- Disabled the placing options drop-down menu while erasing to avoid confusion (?)

Fixes space-wizards/space-station-14#666