### PR TITLE
Cleanup: Fix grid lookups performed just to get map IDs

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/EffectSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/EffectSystem.cs
@@ -372,7 +372,7 @@ namespace Robust.Client.GameObjects
                 foreach (var effect in _owner._Effects)
                 {
                     if (effect.AttachedEntity?.Transform.MapID != player?.Transform.MapID &&
-                        _mapManager.GetGrid(effect.Coordinates.GetGridId(_entityManager)).ParentMapId != map)
+                        effect.Coordinates.GetMapId(_entityManager) != map)
                     {
                         continue;
                     }

--- a/Robust.Server/GameObjects/EntitySystems/TileLookup/GridTileLookupSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/TileLookup/GridTileLookupSystem.cs
@@ -154,7 +154,7 @@ namespace Robust.Server.GameObjects.EntitySystems.TileLookup
         {
             var results = new HashSet<GridTileLookupNode>();
 
-            foreach (var grid in _mapManager.FindGridsIntersecting(_mapManager.GetGrid(coordinates.GetGridId(EntityManager)).ParentMapId, box))
+            foreach (var grid in _mapManager.FindGridsIntersecting(coordinates.GetMapId(EntityManager), box))
             {
                 foreach (var tile in grid.GetTilesIntersecting(box))
                 {

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -362,7 +362,7 @@ namespace Robust.Shared.Map
         /// <inheritdoc />
         public Vector2i SnapGridCellFor(EntityCoordinates coords, SnapGridOffset offset)
         {
-            DebugTools.Assert(ParentMapId == _mapManager.GetGrid(coords.GetGridId(_entityManager)).ParentMapId);
+            DebugTools.Assert(ParentMapId == coords.GetMapId(_entityManager));
 
             var local = WorldToLocal(coords.ToMapPos(_entityManager));
             return SnapGridCellFor(local, offset);


### PR DESCRIPTION
NOTE: This commit assumes that `mapManager.GetGrid(effect.Coordinates.GetGridId(_entityManager)).ParentMapId` is equivalent to `effect.Coordinates.GetMapId(_entityManager)` but the latter won't crash when no grid is available.
Please do not merge if this is incorrect.
This is sort of a sequel to last time, https://github.com/space-wizards/space-station-14/pull/2624