### PR TITLE
Change connection's time to be UTC, and improve NetUserId to implicitly convert from Guid

### DIFF
--- a/Robust.Server/Console/Commands/PlayerCommands.cs
+++ b/Robust.Server/Console/Commands/PlayerCommands.cs
@@ -112,7 +112,7 @@ namespace Robust.Server.Console.Commands
                 sb.AppendLine(string.Format("{4,20} {1,12} {2,14:hh\\:mm\\:ss} {3,9} {0,20}",
                     p.ConnectedClient.RemoteEndPoint,
                     p.Status.ToString(),
-                    DateTime.Now - p.ConnectedTime,
+                    DateTime.UtcNow - p.ConnectedTime,
                     p.ConnectedClient.Ping + "ms",
                     p.Name));
             }

--- a/Robust.Server/Player/PlayerSession.cs
+++ b/Robust.Server/Player/PlayerSession.cs
@@ -128,7 +128,7 @@ namespace Robust.Server.Player
         /// <inheritdoc />
         public void OnConnect()
         {
-            ConnectedTime = DateTime.Now;
+            ConnectedTime = DateTime.UtcNow;
             Status = SessionStatus.Connected;
             UpdatePlayerState();
         }

--- a/Robust.Shared/Network/NetUserId.cs
+++ b/Robust.Shared/Network/NetUserId.cs
@@ -13,34 +13,24 @@ namespace Robust.Shared.Network
             UserId = userId;
         }
 
-        public override bool Equals(object? obj)
-        {
-            return obj is NetUserId id && Equals(id);
-        }
+        public override bool Equals(object? obj) =>
+        obj switch {
+            Guid id => Equals(id),
+            NetUserId id => Equals(id),
+            _ => false,
+        };
 
-        public bool Equals(NetUserId other)
-        {
-            return UserId == other.UserId;
-        }
+        public bool Equals(NetUserId other) => UserId == other.UserId;
 
-        public override int GetHashCode()
-        {
-            return UserId.GetHashCode();
-        }
+        public override int GetHashCode() => UserId.GetHashCode();
 
-        public override string ToString()
-        {
-            return UserId.ToString();
-        }
+        public override string ToString() => UserId.ToString();
 
-        public static bool operator ==(NetUserId id1, NetUserId id2)
-        {
-            return id1.Equals(id2);
-        }
+        public static bool operator ==(NetUserId id1, NetUserId id2) => id1.Equals(id2);
 
-        public static bool operator !=(NetUserId id1, NetUserId id2)
-        {
-            return !(id1 == id2);
-        }
+        public static bool operator !=(NetUserId id1, NetUserId id2) => !(id1 == id2);
+
+        public static implicit operator Guid(NetUserId id) => id.UserId;
+        public static explicit operator NetUserId(Guid id) => new(id);
     }
 }


### PR DESCRIPTION
Not sure on why exactly the latter exists as it is. I am guessing to enforce data handling through type system? Either way, a more C# native way of handling conversion to and from GUID would work better than having to access a field. 

And time should always be handled in UTC unless it's directly user facing and/or has to depend on timezone.