### PR TITLE
Add bytes or sbytes to enum where available 

### DIFF
--- a/OpenToolkit.GraphicsLibraryFramework/Enums/InputAction.cs
+++ b/OpenToolkit.GraphicsLibraryFramework/Enums/InputAction.cs
@@ -13,7 +13,7 @@ namespace OpenToolkit.GraphicsLibraryFramework
     /// Defines event information for <see cref="GLFWCallbacks.KeyCallback"/>
     /// or <see cref="GLFWCallbacks.MouseButtonCallback"/>.
     /// </summary>
-    public enum InputAction
+    public enum InputAction : byte
     {
         /// <summary>
         /// The key or mouse button was released.

--- a/OpenToolkit.GraphicsLibraryFramework/Enums/KeyModifiers.cs
+++ b/OpenToolkit.GraphicsLibraryFramework/Enums/KeyModifiers.cs
@@ -15,7 +15,7 @@ namespace OpenToolkit.GraphicsLibraryFramework
     /// Key modifiers, such as Shift or CTRL.
     /// </summary>
     [Flags]
-    public enum KeyModifiers
+    public enum KeyModifiers : byte
     {
         /// <summary>
         /// if one or more Shift keys were held down.

--- a/OpenToolkit.GraphicsLibraryFramework/Enums/Keys.cs
+++ b/OpenToolkit.GraphicsLibraryFramework/Enums/Keys.cs
@@ -12,7 +12,7 @@ namespace OpenToolkit.GraphicsLibraryFramework
     /// <summary>
     /// Specifies key codes and modifiers in US keyboard layout.
     /// </summary>
-    public enum Keys
+    public enum Keys : short
     {
         /// <summary>
         /// An unknown key.

--- a/OpenToolkit.GraphicsLibraryFramework/Enums/MouseButton.cs
+++ b/OpenToolkit.GraphicsLibraryFramework/Enums/MouseButton.cs
@@ -3,7 +3,7 @@ namespace OpenToolkit.GraphicsLibraryFramework
     /// <summary>
     ///     Specifies the buttons of a mouse.
     /// </summary>
-    public enum MouseButton
+    public enum MouseButton : byte
     {
         /// <summary>
         ///     The first button.

--- a/Robust.Client/Audio/Midi/MidiRenderer.cs
+++ b/Robust.Client/Audio/Midi/MidiRenderer.cs
@@ -14,7 +14,7 @@ using MidiEvent = NFluidsynth.MidiEvent;
 
 namespace Robust.Client.Audio.Midi
 {
-    public enum MidiRendererStatus
+    public enum MidiRendererStatus : byte
     {
         None,
         Input,

--- a/Robust.Client/BaseClient.cs
+++ b/Robust.Client/BaseClient.cs
@@ -223,7 +223,7 @@ namespace Robust.Client
     /// <summary>
     ///     Enumeration of the run levels of the BaseClient.
     /// </summary>
-    public enum ClientRunLevel
+    public enum ClientRunLevel : byte
     {
         Error = 0,
 

--- a/Robust.Client/GameController.cs
+++ b/Robust.Client/GameController.cs
@@ -355,7 +355,7 @@ namespace Robust.Client
         }
 
 
-        internal enum DisplayMode
+        internal enum DisplayMode : byte
         {
             Headless,
             Clyde,

--- a/Robust.Client/Graphics/Clyde/Clyde.Constants.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Constants.cs
@@ -35,7 +35,7 @@ namespace Robust.Client.Graphics.Clyde
         // To be clear: You shouldn't change this. This just helps with understanding where Primitive Restart is being used.
         private const ushort PrimitiveRestartIndex = ushort.MaxValue;
 
-        private enum Renderer
+        private enum Renderer : short
         {
             // Default: Try all supported renderers (not necessarily the renderers shown here)
             Default = default,

--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -970,7 +970,7 @@ namespace Robust.Client.Graphics.Clyde
             public Color Color;
         }
 
-        private enum RenderCommandType
+        private enum RenderCommandType : byte
         {
             DrawBatch,
 

--- a/Robust.Client/Graphics/ClydeBase.cs
+++ b/Robust.Client/Graphics/ClydeBase.cs
@@ -8,7 +8,7 @@ using Robust.Shared.Maths;
 
 namespace Robust.Client.Graphics
 {
-    public enum WindowMode
+    public enum WindowMode : byte
     {
         Windowed = 0,
         Fullscreen = 1,

--- a/Robust.Client/Graphics/Drawing/DrawPrimitiveTopology.cs
+++ b/Robust.Client/Graphics/Drawing/DrawPrimitiveTopology.cs
@@ -6,7 +6,7 @@ namespace Robust.Client.Graphics.Drawing
     /// <remarks>
     ///     See <see href="https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#drawing-point-lists">Vulkan's documentation</see> for descriptions of all these modes.
     /// </remarks>
-    public enum DrawPrimitiveTopology
+    public enum DrawPrimitiveTopology : byte
     {
         PointList,
         TriangleList,

--- a/Robust.Client/Graphics/Drawing/StyleBox.cs
+++ b/Robust.Client/Graphics/Drawing/StyleBox.cs
@@ -318,7 +318,7 @@ namespace Robust.Client.Graphics.Drawing
         ///     Describes margins of a style box.
         /// </summary>
         [Flags]
-        public enum Margin
+        public enum Margin : byte
         {
             None = 0,
 

--- a/Robust.Client/Graphics/Drawing/StyleBoxTexture.cs
+++ b/Robust.Client/Graphics/Drawing/StyleBoxTexture.cs
@@ -329,7 +329,7 @@ namespace Robust.Client.Graphics.Drawing
         /// <summary>
         ///     Specifies how to stretch the sides and center of the style box.
         /// </summary>
-        public enum StretchMode
+        public enum StretchMode : byte
         {
             Stretch,
             Tile,

--- a/Robust.Client/Graphics/Overlays/Overlay.cs
+++ b/Robust.Client/Graphics/Overlays/Overlay.cs
@@ -98,7 +98,7 @@ namespace Robust.Client.Graphics.Overlays
     ///     Determines in which canvas layers an overlay gets drawn.
     /// </summary>
     [Flags]
-    public enum OverlaySpace
+    public enum OverlaySpace : byte
     {
         /// <summary>
         ///     Used for matching bit flags.

--- a/Robust.Client/Graphics/Shaders/Params.cs
+++ b/Robust.Client/Graphics/Shaders/Params.cs
@@ -1,6 +1,6 @@
 ﻿namespace Robust.Client.Graphics.Shaders
 {
-    public enum ShaderParamType
+    public enum ShaderParamType : byte
     {
         // Can this even happen?
         Void = 0,

--- a/Robust.Client/Graphics/Shaders/ParsedShader.cs
+++ b/Robust.Client/Graphics/Shaders/ParsedShader.cs
@@ -106,7 +106,7 @@ namespace Robust.Client.Graphics.Shaders
 
 
     [SuppressMessage("ReSharper", "InconsistentNaming")]
-    internal enum ShaderDataType
+    internal enum ShaderDataType : byte
     {
         Void,
         Bool,
@@ -160,7 +160,7 @@ namespace Robust.Client.Graphics.Shaders
             }
             return Type.GetNativeType();
         }
-        
+
         public bool TypePrecisionConsistent()
         {
             return Type.TypeHasPrecision() == (Precision != ShaderPrecisionQualifier.None);
@@ -190,7 +190,7 @@ namespace Robust.Client.Graphics.Shaders
                     throw new ArgumentOutOfRangeException(nameof(qualifier), qualifier, null);
             }
         }
-        
+
         public static bool TypeHasPrecision(this ShaderDataType type)
         {
             return
@@ -232,13 +232,13 @@ namespace Robust.Client.Graphics.Shaders
         };
     }
 
-    internal enum ShaderLightMode
+    internal enum ShaderLightMode : byte
     {
         Default = 0,
         Unshaded = 1,
     }
 
-    internal enum ShaderBlendMode
+    internal enum ShaderBlendMode : byte
     {
         None,
         Mix,
@@ -247,7 +247,7 @@ namespace Robust.Client.Graphics.Shaders
         Multiply
     }
 
-    internal enum ShaderPreset
+    internal enum ShaderPreset : byte
     {
         Default,
         Raw
@@ -255,7 +255,7 @@ namespace Robust.Client.Graphics.Shaders
 
     // Yeah I had no idea what to name this.
     [Flags]
-    internal enum ShaderParameterQualifiers
+    internal enum ShaderParameterQualifiers : byte
     {
         None = 0,
         In = 1,
@@ -263,7 +263,7 @@ namespace Robust.Client.Graphics.Shaders
         Inout = 3,
     }
 
-    internal enum ShaderPrecisionQualifier
+    internal enum ShaderPrecisionQualifier : byte
     {
         None = 0,
         Low = 1,

--- a/Robust.Client/Graphics/Shaders/ShaderParser.Tokenizer.cs
+++ b/Robust.Client/Graphics/Shaders/ShaderParser.Tokenizer.cs
@@ -593,7 +593,7 @@ namespace Robust.Client.Graphics.Shaders
             public Symbols Symbol { get; }
         }
 
-        private enum Symbols
+        private enum Symbols : byte
         {
             Semicolon,
             Comma,

--- a/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
+++ b/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
@@ -296,7 +296,7 @@ namespace Robust.Client.Graphics.Shaders
             }
         }
 
-        private enum ShaderKind
+        private enum ShaderKind : byte
         {
             Source,
             Canvas

--- a/Robust.Client/Graphics/Texture.cs
+++ b/Robust.Client/Graphics/Texture.cs
@@ -189,7 +189,7 @@ namespace Robust.Client.Graphics
     ///     Controls behavior when reading texture coordinates outside 0-1, which usually wraps the texture somehow.
     /// </summary>
     [PublicAPI]
-    public enum TextureWrapMode
+    public enum TextureWrapMode : byte
     {
         /// <summary>
         ///     Do not wrap, instead clamp to edge.

--- a/Robust.Client/Input/InputDevices.cs
+++ b/Robust.Client/Input/InputDevices.cs
@@ -10,7 +10,7 @@ namespace Robust.Client.Input
         /// <summary>
         ///     Represents one of three mouse buttons.
         /// </summary>
-        public enum Button
+        public enum Button : byte
         {
             Left = 1,
             Middle = 2,

--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -764,14 +764,14 @@ namespace Robust.Client.Input
         }
     }
 
-    public enum KeyBindingType
+    public enum KeyBindingType : byte
     {
         Unknown = 0,
         State,
         Toggle,
     }
 
-    public enum CommandState
+    public enum CommandState : byte
     {
         Unknown = 0,
         Enabled,

--- a/Robust.Client/Interfaces/Graphics/ClydeDebugLayers.cs
+++ b/Robust.Client/Interfaces/Graphics/ClydeDebugLayers.cs
@@ -1,6 +1,6 @@
 namespace Robust.Client.Interfaces.Graphics
 {
-    internal enum ClydeDebugLayers
+    internal enum ClydeDebugLayers : byte
     {
         None,
         Fov,

--- a/Robust.Client/Interfaces/Graphics/ClydeStockTexture.cs
+++ b/Robust.Client/Interfaces/Graphics/ClydeStockTexture.cs
@@ -1,6 +1,6 @@
 namespace Robust.Client.Interfaces.Graphics
 {
-    internal enum ClydeStockTexture
+    internal enum ClydeStockTexture : byte
     {
         White,
         Black,

--- a/Robust.Client/Interfaces/Graphics/RenderTargetColorFormat.cs
+++ b/Robust.Client/Interfaces/Graphics/RenderTargetColorFormat.cs
@@ -3,7 +3,7 @@ namespace Robust.Client.Interfaces.Graphics
     /// <summary>
     ///     Formats for the color component of a render target.
     /// </summary>
-    public enum RenderTargetColorFormat
+    public enum RenderTargetColorFormat : byte
     {
         /// <summary>
         ///     8 bits per channel linear RGBA.

--- a/Robust.Client/Interfaces/Graphics/ScreenshotType.cs
+++ b/Robust.Client/Interfaces/Graphics/ScreenshotType.cs
@@ -1,6 +1,6 @@
 namespace Robust.Client.Interfaces.Graphics
 {
-    public enum ScreenshotType
+    public enum ScreenshotType : byte
     {
         BeforeUI,
         AfterUI

--- a/Robust.Client/Interfaces/Graphics/StandardCursorShape.cs
+++ b/Robust.Client/Interfaces/Graphics/StandardCursorShape.cs
@@ -3,7 +3,7 @@ namespace Robust.Client.Interfaces.Graphics
     /// <summary>
     ///     OS-standard cursor shapes.
     /// </summary>
-    public enum StandardCursorShape
+    public enum StandardCursorShape : byte
     {
         /// <summary>
         /// The standard arrow shape. Used in almost all situations.

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -618,7 +618,7 @@ namespace Robust.Client.Placement
             NetworkManager.ClientSendMessage(message);
         }
 
-        public enum PlacementTypes
+        public enum PlacementTypes : byte
         {
             None = 0,
             Line = 1,

--- a/Robust.Client/UserInterface/Control.Cursor.cs
+++ b/Robust.Client/UserInterface/Control.Cursor.cs
@@ -11,7 +11,7 @@ namespace Robust.Client.UserInterface
         /// <summary>
         ///     Default common cursor shapes available in the UI.
         /// </summary>
-        public enum CursorShape
+        public enum CursorShape: byte
         {
             Arrow,
             IBeam,

--- a/Robust.Client/UserInterface/Control.cs
+++ b/Robust.Client/UserInterface/Control.cs
@@ -757,7 +757,7 @@ namespace Robust.Client.UserInterface
         /// <summary>
         ///     Mode that will be tested when testing controls to invoke mouse button events on.
         /// </summary>
-        public enum MouseFilterMode
+        public enum MouseFilterMode : byte
         {
             /// <summary>
             ///     The control will be able to receive mouse buttons events.

--- a/Robust.Client/UserInterface/Controls/BaseButton.cs
+++ b/Robust.Client/UserInterface/Controls/BaseButton.cs
@@ -318,7 +318,7 @@ namespace Robust.Client.UserInterface.Controls
             }
         }
 
-        public enum DrawModeEnum
+        public enum DrawModeEnum : byte
         {
             Normal = 0,
             Pressed = 1,
@@ -361,7 +361,7 @@ namespace Robust.Client.UserInterface.Controls
         /// <summary>
         ///     For use with <see cref="BaseButton.Mode"/>.
         /// </summary>
-        public enum ActionMode
+        public enum ActionMode : byte
         {
             /// <summary>
             ///     <see cref="BaseButton.OnPressed"/> fires when the mouse button causing them is pressed down.

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -210,7 +210,7 @@ namespace Robust.Client.UserInterface.Controls
             return new Vector2(minWidth, minHeight);
         }
 
-        public enum AlignMode
+        public enum AlignMode : byte
         {
             /// <summary>
             ///     Controls are laid out from the begin of the box container.

--- a/Robust.Client/UserInterface/Controls/GridContainer.cs
+++ b/Robust.Client/UserInterface/Controls/GridContainer.cs
@@ -557,13 +557,13 @@ namespace Robust.Client.UserInterface.Controls
         }
     }
 
-    public enum Dimension
+    public enum Dimension : byte
     {
         Column,
         Row
     }
 
-    public enum LimitType
+    public enum LimitType : byte
     {
         /// <summary>
         /// Defined number of rows or columns

--- a/Robust.Client/UserInterface/Controls/ItemList.cs
+++ b/Robust.Client/UserInterface/Controls/ItemList.cs
@@ -570,7 +570,7 @@ namespace Robust.Client.UserInterface.Controls
             }
         }
 
-        public enum ItemListSelectMode
+        public enum ItemListSelectMode : byte
         {
             None,
             Single,

--- a/Robust.Client/UserInterface/Controls/Label.cs
+++ b/Robust.Client/UserInterface/Controls/Label.cs
@@ -194,7 +194,7 @@ namespace Robust.Client.UserInterface.Controls
             }
         }
 
-        public enum AlignMode
+        public enum AlignMode : byte
         {
             Left = 0,
             Center = 1,
@@ -202,7 +202,7 @@ namespace Robust.Client.UserInterface.Controls
             Fill = 3
         }
 
-        public enum VAlignMode
+        public enum VAlignMode : byte
         {
             Top = 0,
             Center = 1,

--- a/Robust.Client/UserInterface/Controls/LineEdit.cs
+++ b/Robust.Client/UserInterface/Controls/LineEdit.cs
@@ -711,7 +711,7 @@ namespace Robust.Client.UserInterface.Controls
             return CharClass.Other;
         }
 
-        private enum CharClass
+        private enum CharClass : byte
         {
             Other,
             AlphaNumeric,

--- a/Robust.Client/UserInterface/Controls/ScrollBar.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollBar.cs
@@ -225,7 +225,7 @@ namespace Robust.Client.UserInterface.Controls
             return _getGrabberStyleBox()?.MinimumSize ?? Vector2.Zero;
         }
 
-        protected enum OrientationMode
+        protected enum OrientationMode : byte
         {
             Horizontal,
             Vertical

--- a/Robust.Client/UserInterface/Controls/SplitContainer.cs
+++ b/Robust.Client/UserInterface/Controls/SplitContainer.cs
@@ -230,7 +230,7 @@ namespace Robust.Client.UserInterface.Controls
         /// <summary>
         /// Defines how user-initiated moving of the split should work
         /// </summary>
-        public enum SplitResizeMode
+        public enum SplitResizeMode : sbyte
         {
             /// <summary>
             /// Don't allow user to move the split.
@@ -249,7 +249,7 @@ namespace Robust.Client.UserInterface.Controls
         /// <summary>
         /// Defines how the split position should be determined
         /// </summary>
-        private enum SplitState
+        private enum SplitState : byte
         {
             /// <summary>
             /// Automatically adjust the split based on the width of the children

--- a/Robust.Client/UserInterface/Controls/TextureRect.cs
+++ b/Robust.Client/UserInterface/Controls/TextureRect.cs
@@ -175,7 +175,7 @@ namespace Robust.Client.UserInterface.Controls
             }
         }
 
-        public enum StretchMode
+        public enum StretchMode : byte
         {
             /// <summary>
             ///     The texture is stretched to fit the entire area of the control.

--- a/Robust.Client/UserInterface/CustomControls/BaseWindow.cs
+++ b/Robust.Client/UserInterface/CustomControls/BaseWindow.cs
@@ -255,7 +255,7 @@ namespace Robust.Client.UserInterface.CustomControls
         }
 
         [Flags]
-        protected enum DragMode
+        protected enum DragMode : byte
         {
             None = 0,
             Move = 1,

--- a/Robust.Client/ViewVariables/Editors/VVPropEditorNumeric.cs
+++ b/Robust.Client/ViewVariables/Editors/VVPropEditorNumeric.cs
@@ -67,7 +67,7 @@ namespace Robust.Client.ViewVariables.Editors
             return convert.ToString(CultureInfo.InvariantCulture);
         }
 
-        public enum NumberType
+        public enum NumberType : byte
         {
             Byte,
             SByte,

--- a/Robust.Client/ViewVariables/Editors/VVPropEditorUIBox2.cs
+++ b/Robust.Client/ViewVariables/Editors/VVPropEditorUIBox2.cs
@@ -174,7 +174,7 @@ namespace Robust.Client.ViewVariables.Editors
             return hBoxContainer;
         }
 
-        public enum BoxType
+        public enum BoxType : byte
         {
             Box2,
             Box2i,

--- a/Robust.Server/BaseServer.cs
+++ b/Robust.Server/BaseServer.cs
@@ -582,7 +582,7 @@ namespace Robust.Server
     /// <summary>
     ///     Type of game currently running.
     /// </summary>
-    public enum GameType
+    public enum GameType : byte
     {
         MapEditor = 0,
         Game,

--- a/Robust.Shared.Maths/Color.cs
+++ b/Robust.Shared.Maths/Color.cs
@@ -1009,7 +1009,7 @@ namespace Robust.Shared.Maths
         }
 
         [PublicAPI]
-        public enum BlendFactor
+        public enum BlendFactor : byte
         {
             Zero,
             One,

--- a/Robust.Shared.Maths/Direction.cs
+++ b/Robust.Shared.Maths/Direction.cs
@@ -3,7 +3,7 @@
 namespace Robust.Shared.Maths
 {
     [Flags]
-    public enum Direction
+    public enum Direction : sbyte
     {
         Invalid = -1,
         East = 0,

--- a/Robust.Shared/Animations/AnimationInterpolationMode.cs
+++ b/Robust.Shared/Animations/AnimationInterpolationMode.cs
@@ -3,7 +3,7 @@ namespace Robust.Shared.Animations
     /// <summary>
     ///     Specifies how animated properties are interpolated between two keyframes.
     /// </summary>
-    public enum AnimationInterpolationMode
+    public enum AnimationInterpolationMode: byte
     {
         /// <summary>
         ///     Use a linear interpolation for supported values.

--- a/Robust.Shared/Configuration/CVar.cs
+++ b/Robust.Shared/Configuration/CVar.cs
@@ -6,7 +6,7 @@ namespace Robust.Shared.Configuration
     /// Extra flags for changing the behavior of a config var.
     /// </summary>
     [Flags]
-    public enum CVar
+    public enum CVar : short
     {
         /// <summary>
         /// No special flags.

--- a/Robust.Shared/ContentPack/AssemblyTypeChecker.Config.cs
+++ b/Robust.Shared/ContentPack/AssemblyTypeChecker.Config.cs
@@ -106,7 +106,7 @@ namespace Robust.Shared.ContentPack
             public Dictionary<string, TypeConfig>? NestedTypes;
         }
 
-        private enum InheritMode
+        private enum InheritMode : byte
         {
             // Allow if All is set, block otherwise
             Default,

--- a/Robust.Shared/ContentPack/AssemblyTypeChecker.cs
+++ b/Robust.Shared/ContentPack/AssemblyTypeChecker.cs
@@ -838,7 +838,7 @@ namespace Robust.Shared.ContentPack
         }
 
         [Flags]
-        public enum DumpFlags
+        public enum DumpFlags : byte
         {
             None = 0,
             Types = 1,

--- a/Robust.Shared/ContentPack/ModRunLevel.cs
+++ b/Robust.Shared/ContentPack/ModRunLevel.cs
@@ -3,7 +3,7 @@
     /// <summary>
     ///     Run levels of the Content entry point.
     /// </summary>
-    public enum ModRunLevel
+    public enum ModRunLevel: byte
     {
         Error = 0,
         Init = 1,

--- a/Robust.Shared/ContentPack/ModUpdateLevel.cs
+++ b/Robust.Shared/ContentPack/ModUpdateLevel.cs
@@ -3,7 +3,7 @@
     /// <summary>
     ///     Levels at which point the content assemblies are getting updates.
     /// </summary>
-    public enum ModUpdateLevel
+    public enum ModUpdateLevel : byte
     {
         /// <summary>
         ///     This update is called before the main state manager on process frames.

--- a/Robust.Shared/Enums/NetworkEnums.cs
+++ b/Robust.Shared/Enums/NetworkEnums.cs
@@ -1,6 +1,6 @@
 ﻿namespace Robust.Shared.Enums
 {
-    public enum PlacementManagerMessage
+    public enum PlacementManagerMessage : byte
     {
         StartPlacement,
         CancelPlacement,
@@ -18,7 +18,7 @@
         Disconnected
     }
 
-    public enum NetworkDataType
+    public enum NetworkDataType: byte
     {
         d_enum,
         d_bool,

--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Collision.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Collision.cs
@@ -505,7 +505,7 @@ namespace Robust.Shared.GameObjects.Components
     }
 
     [Serializable, NetSerializable]
-    public enum BodyStatus
+    public enum BodyStatus: byte
     {
         OnGround,
         InAir

--- a/Robust.Shared/GameObjects/Components/Transform/SnapGridComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/SnapGridComponent.cs
@@ -196,7 +196,7 @@ namespace Robust.Shared.GameObjects.Components.Transform
         }
     }
 
-    public enum SnapGridOffset
+    public enum SnapGridOffset: byte
     {
         /// <summary>
         ///     Center snap grid (wires, pipes, ...).

--- a/Robust.Shared/GameObjects/EntityEventBus.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.cs
@@ -83,7 +83,7 @@ namespace Robust.Shared.GameObjects
     }
 
     [Flags]
-    public enum EventSource
+    public enum EventSource : byte
     {
         None    = 0b0000,
         Local   = 0b0001,

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -672,7 +672,7 @@ namespace Robust.Shared.GameObjects
 
     }
 
-    public enum EntityMessageType
+    public enum EntityMessageType : byte
     {
         Error = 0,
         ComponentMessage,

--- a/Robust.Shared/Interfaces/GameObjects/IComponentFactory.cs
+++ b/Robust.Shared/Interfaces/GameObjects/IComponentFactory.cs
@@ -10,7 +10,7 @@ namespace Robust.Shared.Interfaces.GameObjects
     /// This distinction is important because prototypes are shared across client and server, but the two might have different components.
     /// </summary>
     /// <seealso cref="IComponentFactory" />
-    public enum ComponentAvailability
+    public enum ComponentAvailability : byte
     {
         /// <summary>
         /// The component is available and can be instantiated.
@@ -213,7 +213,7 @@ namespace Robust.Shared.Interfaces.GameObjects
         /// <param name="registration">The registration if found, null otherwise.</param>
         /// <returns>true it found, false otherwise.</returns>
         bool TryGetRegistration(IComponent component, [NotNullWhen(true)] out IComponentRegistration? registration);
-        
+
         /// <summary>
         ///     Automatically create registrations for all components with a <see cref="RegisterComponentAttribute" />
         /// </summary>

--- a/Robust.Shared/Interfaces/Network/IClientNetManager.cs
+++ b/Robust.Shared/Interfaces/Network/IClientNetManager.cs
@@ -43,7 +43,7 @@ namespace Robust.Shared.Interfaces.Network
         void ClientDisconnect(string reason);
     }
 
-    public enum ClientConnectionState
+    public enum ClientConnectionState : byte
     {
         /// <summary>
         ///     We are not connected and not trying to get connected either. Quite lonely huh.

--- a/Robust.Shared/Interfaces/Network/NetMessageAccept.cs
+++ b/Robust.Shared/Interfaces/Network/NetMessageAccept.cs
@@ -6,7 +6,7 @@ namespace Robust.Shared.Interfaces.Network
     ///     Defines on which side of the network a net message can be accepted.
     /// </summary>
     [Flags]
-    public enum NetMessageAccept
+    public enum NetMessageAccept : byte
     {
         None = 0,
 

--- a/Robust.Shared/Localization/Macros/Attributes.cs
+++ b/Robust.Shared/Localization/Macros/Attributes.cs
@@ -6,7 +6,7 @@ namespace Robust.Shared.Localization.Macros
     /// <summary>
     /// Genders for grammatical usage only.
     /// </summary>
-    public enum Gender
+    public enum Gender : byte
     {
         Epicene,
         Female,

--- a/Robust.Shared/Log/LogLevel.cs
+++ b/Robust.Shared/Log/LogLevel.cs
@@ -6,7 +6,7 @@ namespace Robust.Shared.Log
     ///     The value associated with the level determines the order in which they are filtered,
     ///     Under the default <see cref="LogManager"/>.
     /// </remarks>
-    public enum LogLevel
+    public enum LogLevel : byte
     {
         /// <summary>
         ///     When you're *really* trying to track down that bug.

--- a/Robust.Shared/Network/AuthMode.cs
+++ b/Robust.Shared/Network/AuthMode.cs
@@ -1,6 +1,6 @@
 ﻿namespace Robust.Shared.Network
 {
-    public enum AuthMode
+    public enum AuthMode : byte
     {
         Optional = 0,
         Required = 1,

--- a/Robust.Shared/Network/NetMessage.cs
+++ b/Robust.Shared/Network/NetMessage.cs
@@ -9,7 +9,7 @@ namespace Robust.Shared.Network
     /// <summary>
     /// The group the message belongs to, used for statistics and packet channels.
     /// </summary>
-    public enum MsgGroups
+    public enum MsgGroups : byte
     {
         /// <summary>
         /// Error state, the message needs to set a different one.

--- a/Robust.Shared/Noise/FastNoise.cs
+++ b/Robust.Shared/Noise/FastNoise.cs
@@ -46,7 +46,7 @@ namespace Robust.Shared.Noise
         private const MethodImplOptions FN_INLINE = MethodImplOptions.AggressiveInlining;
         private const int FN_CELLULAR_INDEX_MAX = 3;
 
-        public enum NoiseType
+        public enum NoiseType : byte
         {
             Value,
             ValueFractal,
@@ -60,28 +60,28 @@ namespace Robust.Shared.Noise
             CubicFractal
         };
 
-        public enum Interp
+        public enum Interp : byte
         {
             Linear,
             Hermite,
             Quintic
         };
 
-        public enum FractalType
+        public enum FractalType : byte
         {
             FBM,
             Billow,
             RigidMulti
         };
 
-        public enum CellularDistanceFunction
+        public enum CellularDistanceFunction : byte
         {
             Euclidean,
             Manhattan,
             Natural
         };
 
-        public enum CellularReturnType
+        public enum CellularReturnType : byte
         {
             CellValue,
             NoiseLookup,

--- a/Robust.Shared/Noise/NoiseGenerator.cs
+++ b/Robust.Shared/Noise/NoiseGenerator.cs
@@ -8,7 +8,7 @@ namespace Robust.Shared.Noise
     public sealed class NoiseGenerator
     {
         [PublicAPI]
-        public enum NoiseType
+        public enum NoiseType : byte
         {
             Fbm = 0,
             Ridged = 1

--- a/Robust.Shared/Physics/BodyType.cs
+++ b/Robust.Shared/Physics/BodyType.cs
@@ -7,7 +7,7 @@ namespace Robust.Shared.Physics
     ///     The properties of physical body. This determines how collisions will effect this body.
     /// </summary>
     [Serializable, NetSerializable]
-    public enum BodyType
+    public enum BodyType : byte
     {
         /// <summary>
         ///     Will not be processed by the collision system. Basically "out of phase" with the world.

--- a/Robust.Shared/Timing/GameLoop.cs
+++ b/Robust.Shared/Timing/GameLoop.cs
@@ -282,7 +282,7 @@ namespace Robust.Shared.Timing
     /// <summary>
     ///     Methods the GameLoop can use to limit the Update rate.
     /// </summary>
-    public enum SleepMode
+    public enum SleepMode : sbyte
     {
         /// <summary>
         ///     Thread will not yield to the scheduler or sleep, and consume 100% cpu. Use this if you are

--- a/Robust.Shared/Utility/QuadTree.cs
+++ b/Robust.Shared/Utility/QuadTree.cs
@@ -512,7 +512,7 @@ namespace Robust.Shared.Utility
         }
     }
 
-    public enum DiRectangleFion : int
+    public enum DiRectangleFion : byte
     {
         NW = 0,
         NE = 1,

--- a/Robust.Shared/ViewVariables/ViewVariablesAttribute.cs
+++ b/Robust.Shared/ViewVariables/ViewVariablesAttribute.cs
@@ -21,7 +21,7 @@ namespace Robust.Shared.ViewVariables
         }
     }
 
-    public enum VVAccess
+    public enum VVAccess : byte
     {
         /// <summary>
         ///     This property can only be read, not written.

--- a/Robust.Shared/ViewVariables/ViewVariablesTraits.cs
+++ b/Robust.Shared/ViewVariables/ViewVariablesTraits.cs
@@ -8,7 +8,7 @@ namespace Robust.Shared.ViewVariables
     ///     Pre-defined simple VV traits used by the engine.
     /// </summary>
     [Serializable, NetSerializable]
-    public enum ViewVariablesTraits
+    public enum ViewVariablesTraits : byte
     {
         /// <summary>
         ///     This object has VV-accessible members (field or property with the <see cref="ViewVariablesAttribute"/>.

--- a/Robust.UnitTesting/RobustUnitTest.cs
+++ b/Robust.UnitTesting/RobustUnitTest.cs
@@ -16,7 +16,7 @@ using Robust.Shared.Utility;
 
 namespace Robust.UnitTesting
 {
-    public enum UnitTestProject
+    public enum UnitTestProject : byte
     {
         Server,
         Client

--- a/Robust.UnitTesting/Shared/Maths/NumericsHelpers_Test.cs
+++ b/Robust.UnitTesting/Shared/Maths/NumericsHelpers_Test.cs
@@ -29,7 +29,7 @@ namespace Robust.UnitTesting.Shared.Maths
         }
 
         [Flags]
-        enum Intrinsics
+        enum Intrinsics : byte
         {
             None = 0,
             Sse  = 1 << 1,

--- a/Robust.UnitTesting/Shared/Prototypes/PrototypeManager_Test.cs
+++ b/Robust.UnitTesting/Shared/Prototypes/PrototypeManager_Test.cs
@@ -98,7 +98,7 @@ namespace Robust.UnitTesting.Shared.Prototypes
             Assert.That(prototype.PlacementMode, Is.EqualTo("SnapgridCenter"));
         }
 
-        private enum YamlTestEnum
+        private enum YamlTestEnum : byte
         {
             Foo,
             Bar


### PR DESCRIPTION
Fixes #973 

Sets all enums to be `byte` sized (or `sbyte` where possible).

There were a few exceptions that didn't allow YamlSerializer to pass.