### PR TITLE
Fix the server not setting IsConnected to false for disconnecting clients in integration tests

### DIFF
--- a/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
@@ -168,6 +168,7 @@ namespace Robust.UnitTesting
                                     Disconnect?.Invoke(this, new NetDisconnectedArgs(channel, string.Empty));
 
                                     _channels.Remove(disconnect.Connection);
+                                    channel.IsConnected = false;
                                 }
                             }
                             else


### PR DESCRIPTION
Fixes reconnect test failing randomly (consistently with https://github.com/space-wizards/space-station-14/pull/2728) on the content repo. Allegedly.
Required for https://github.com/space-wizards/space-station-14/pull/2728