### PR TITLE
Sends the AttachedEntity of the PlayerState

### DIFF
--- a/Robust.Server/Player/PlayerManager.cs
+++ b/Robust.Server/Player/PlayerManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -8,6 +8,7 @@ using Prometheus;
 using Robust.Server.Interfaces;
 using Robust.Server.Interfaces.Player;
 using Robust.Shared.Enums;
+using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 using Robust.Shared.Input;
 using Robust.Shared.Interfaces.GameObjects;
@@ -378,6 +379,7 @@ namespace Robust.Server.Player
             }
 
             PlayerCountMetric.Set(PlayerCount);
+            Dirty();
         }
 
         private void OnPlayerStatusChanged(IPlayerSession session, SessionStatus oldStatus, SessionStatus newStatus)
@@ -449,7 +451,8 @@ namespace Robust.Server.Player
                     UserId = client.UserId,
                     Name = client.Name,
                     Status = client.Status,
-                    Ping = client.ConnectedClient.Ping
+                    Ping = client.ConnectedClient.Ping,
+                    ControlledEntity = client.AttachedEntityUid
                 };
                 list.Add(info);
             }

--- a/Robust.Shared/Network/Messages/MsgPlayerList.cs
+++ b/Robust.Shared/Network/Messages/MsgPlayerList.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Lidgren.Network;
 using Robust.Shared.Enums;
+using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.Players;
@@ -31,7 +32,8 @@ namespace Robust.Shared.Network.Messages
                     UserId = new NetUserId(buffer.ReadGuid()),
                     Name = buffer.ReadString(),
                     Status = (SessionStatus)buffer.ReadByte(),
-                    Ping = buffer.ReadInt16()
+                    Ping = buffer.ReadInt16(),
+                    ControlledEntity = buffer.ReadEntityUid_()
                 };
                 Plyrs.Add(plyNfo);
             }
@@ -45,8 +47,9 @@ namespace Robust.Shared.Network.Messages
             {
                 buffer.Write(ply.UserId.UserId);
                 buffer.Write(ply.Name);
-                buffer.Write((byte) ply.Status);
+                buffer.Write((byte)ply.Status);
                 buffer.Write(ply.Ping);
+                buffer.Write(ply.ControlledEntity);
             }
         }
     }

--- a/Robust.Shared/Network/NetMessageExt.cs
+++ b/Robust.Shared/Network/NetMessageExt.cs
@@ -43,6 +43,16 @@ namespace Robust.Shared.Network
             return new(message.ReadInt32());
         }
 
+        public static EntityUid? ReadEntityUid_(this NetIncomingMessage message)
+        {
+            var uid = message.ReadInt32();
+            return uid > 0 ? new(uid) : null;
+        }
+        public static void Write(this NetOutgoingMessage message, EntityUid? entityUid)
+        {
+            message.Write(entityUid == null ? 0 : (int)entityUid);
+        }
+
         public static void Write(this NetOutgoingMessage message, EntityUid entityUid)
         {
             message.Write((int)entityUid);


### PR DESCRIPTION
This should fix the lack of names in the admin menu Player tab and the admin teleport function. Related to [#2438](https://github.com/space-wizards/space-station-14/issues/2438)