### PR TITLE
New ControlFocusExited hook on Control

### DIFF
--- a/Robust.Client/Interfaces/UserInterface/IUserInterfaceManager.cs
+++ b/Robust.Client/Interfaces/UserInterface/IUserInterfaceManager.cs
@@ -21,7 +21,21 @@ namespace Robust.Client.Interfaces.UserInterface
         /// </summary>
         Stylesheet? Stylesheet { get; set; }
 
+        /// <summary>
+        /// A control can have "keyboard focus" separate from ControlFocused, obtained when calling
+        /// Control.GrabKeyboardFocus. Corresponding events in Control are KeyboardFocusEntered/Exited
+        /// </summary>
         Control? KeyboardFocused { get; }
+
+        /// <summary>
+        /// A control gets "ControlFocused" when a mouse button (or any KeyBinding which has CanFocus = true) is
+        /// pressed down on the control. While it is focused, it will receive mouse hover events and the corresponding
+        /// keyup event if it still has focus when that occurs (it will NOT receive the keyup if focus has
+        /// been taken by another control). Focus is removed when a different control takes focus
+        /// (such as by pressing a different mouse button down over a different control) or when the keyup event
+        /// happens. When focus is lost on a control, it always fires Control.ControlFocusExited.
+        /// </summary>
+        Control? ControlFocused { get; }
 
         LayoutContainer StateRoot { get; }
 

--- a/Robust.Client/UserInterface/Control.cs
+++ b/Robust.Client/UserInterface/Control.cs
@@ -757,14 +757,32 @@ namespace Robust.Client.UserInterface
         /// <summary>
         ///     Called when this control receives keyboard focus.
         /// </summary>
-        protected internal virtual void FocusEntered()
+        protected internal virtual void KeyboardFocusEntered()
         {
         }
 
         /// <summary>
-        ///     Called when this control loses keyboard focus.
+        ///     Called when this control loses keyboard focus (corresponds to UserInterfaceManager.KeyboardFocused).
         /// </summary>
-        protected internal virtual void FocusExited()
+        protected internal virtual void KeyboardFocusExited()
+        {
+        }
+
+        /// <summary>
+        ///     Fired when a control loses control focus for any reason. See <see cref="IUserInterfaceManager.ControlFocused"/>.
+        /// </summary>
+        /// <remarks>
+        ///     Controls which have some sort of drag / drop behavior should usually implement this method (typically by cancelling the drag drop).
+        ///     Otherwise, if a user clicks down LMB over one control to initiate a drag, then clicks RMB down
+        ///     over a different control while still holding down LMB, the control being dragged will now lose focus
+        ///     and will no longer receive the keyup for the LMB, thus won't cancel the drag.
+        ///     This should also be considered for controls which have any special KeyBindUp behavior - consider
+        ///     what would happen if the control lost focus and never received the KeyBindUp.
+        ///
+        ///     There is no corresponding ControlFocusEntered - if a control wants to handle that situation they should simply
+        ///     handle KeyBindDown as that's the only way a control would gain focus.
+        /// </remarks>
+        protected internal virtual void ControlFocusExited()
         {
         }
 

--- a/Robust.Client/UserInterface/Controls/LineEdit.cs
+++ b/Robust.Client/UserInterface/Controls/LineEdit.cs
@@ -589,18 +589,18 @@ namespace Robust.Client.UserInterface.Controls
             return index;
         }
 
-        protected internal override void FocusEntered()
+        protected internal override void KeyboardFocusEntered()
         {
-            base.FocusEntered();
+            base.KeyboardFocusEntered();
 
             // Reset this so the cursor is always visible immediately after gaining focus..
             _resetCursorBlink();
             OnFocusEnter?.Invoke(new LineEditEventArgs(this, _text));
         }
 
-        protected internal override void FocusExited()
+        protected internal override void KeyboardFocusExited()
         {
-            base.FocusExited();
+            base.KeyboardFocusExited();
             OnFocusExit?.Invoke(new LineEditEventArgs(this, _text));
         }
 


### PR DESCRIPTION
Fixes #1449 , but not quite in the way the ticket suggests.

I initially tried an approach where you could have multiple controls with "focus" simultaneously. This would ensure that the control always received the eventual KeyBindUp when it got a KeyBindDown. Also all the currently focused controls would receive mouse hover events (which could be multiple controls).

I ended up not really liking this approach, not only was it complicated, but it also allowed for weird UI behavior like letting you drag / drop something with LMB while simultaneously right clicking other UI elements. I couldn't see a reason this capability would ever be necessary and it didn't feel like it was worth the complexity, though I did get it working (see https://github.com/chairbender/RobustToolbox/tree/1449-keybindup if interested).

Instead, I opted to simply add a hook to let controls know when they've lost focus, which can happen when, for example, you press LMB down on one control, then drag, then RMB down on a different control while still holding LMB down. Controls which care about this (generally controls which have some drag / drop logic or special keybindup logic) can implement that method. This fi

The downside of this approach is, if a dev isn't aware of this quirk and they only implement KeyBindUp but not ControlFocusExited, their drag/drop can become "stuck" (because the control will never get the KeyBindUp if it lost focus). My alternate approach did not have that downside - KeyBindUp was guaranteed to be fired so there was no need for this hook (but suffered all the other issues I mentioned above). Since it seems like there are only a few controls that would actually care about ControlFocusExited I don't think that's a big problem, and overall I think this approach is simpler and better and fits more naturally into our existing UI system's concept of "control focus", rather than complicating it by allowing multiple things to be "focused".

EDIT: see this follow up ticket where we can leverage this capability to fix other controls affected by this problem https://github.com/space-wizards/RobustToolbox/issues/1468 