### PR TITLE
Fixes key combinations blocking single keys.

### DIFF
--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -199,8 +199,6 @@ namespace Robust.Client.Input
 
             _keysPressed[(int) args.Key] = true;
 
-            PackedKeyCombo matchedCombo = default;
-
             var bindsDown = new List<KeyBinding>();
             var hasCanFocus = false;
 
@@ -215,18 +213,10 @@ namespace Robust.Client.Input
                 {
                     // this statement *should* always be true first
                     // Keep triggering keybinds of the same PackedKeyCombo until Handled or no bindings left
-                    if ((matchedCombo == default || binding.PackedKeyCombo == matchedCombo) &&
-                        PackedContainsKey(binding.PackedKeyCombo, args.Key))
+                    if (PackedContainsKey(binding.PackedKeyCombo, args.Key))
                     {
-                        matchedCombo = binding.PackedKeyCombo;
-
                         bindsDown.Add(binding);
                         hasCanFocus |= binding.CanFocus;
-                    }
-                    else if (PackedIsSubPattern(matchedCombo, binding.PackedKeyCombo))
-                    {
-                        // kill any lower level matches
-                        UpBind(binding);
                     }
                 }
             }
@@ -378,8 +368,8 @@ namespace Robust.Client.Input
         {
             for (var i = 0; i < 32; i += 8)
             {
-                var key = (Key) (subPackedCombo.Packed >> i);
-                if (!PackedContainsKey(packedCombo, key))
+                var key = (Key)((subPackedCombo.Packed >> i) & 0b_1111_1111);
+                if (key != Key.Unknown && !PackedContainsKey(packedCombo, key))
                 {
                     return false;
                 }


### PR DESCRIPTION
Fixes space-wizards/space-station-14#2782

This changes the InputManager so that, when a key combination is pressed, the manager adds its subcombinations bindings to the list of binds to be triggered. For example, when you press Ctrl+A, the input manager adds TextSelectAll and MoveLeft to the list, instead of just TextSelectAll. So, if TextSelectAll doesn't get handled, MoveLeft is then triggered.
Also, I fixed the PackedIsSubPattern method but I noticed it isn't useful now. Anyways, I left it there.
I'm fairly new to C# so maybe this isn't the right way to fix the issue idk.