### PR TITLE
Adds new keybind property: AllowSubCombs

### DIFF
--- a/Robust.Client/Interfaces/Input/IKeyBinding.cs
+++ b/Robust.Client/Interfaces/Input/IKeyBinding.cs
@@ -16,6 +16,7 @@ namespace Robust.Client.Interfaces.Input
 
         bool CanFocus { get; }
         bool CanRepeat { get; }
+        bool AllowSubCombs { get; }
         int Priority { get; }
 
         /// <summary>

--- a/Robust.Client/Interfaces/Input/KeyBindingRegistration.cs
+++ b/Robust.Client/Interfaces/Input/KeyBindingRegistration.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Client.Input;
+using Robust.Client.Input;
 using Robust.Shared.Input;
 using Robust.Shared.Interfaces.Serialization;
 using Robust.Shared.Serialization;
@@ -16,6 +16,7 @@ namespace Robust.Client.Interfaces.Input
         public int Priority;
         public bool CanFocus;
         public bool CanRepeat;
+        public bool AllowSubCombs;
 
         public void ExposeData(ObjectSerializer serializer)
         {
@@ -28,6 +29,7 @@ namespace Robust.Client.Interfaces.Input
             serializer.DataField(ref Priority, "priority", 0);
             serializer.DataField(ref CanFocus, "canFocus", false);
             serializer.DataField(ref CanRepeat, "canRepeat", false);
+            serializer.DataField(ref AllowSubCombs, "allowSubCombs", false);
         }
     }
 }


### PR DESCRIPTION
This new keybind property makes a keybind, bound to a key combination, trigger any subcombination of it. For example, TextSelectAll is bound to Ctrl+A, if you add "allowSubCombs = true" to it, then, when the combination gets pressed, the input manager will add any bind bound with A (In this case MoveLeft) to the trigger list, so, if TextSelectAll doesn't get handled then MoveLeft will get triggered. This fixes space-wizards/space-station-14#2782 and similar issues, for example, pressing Ctrl+C when you are not writing in the chat doesn't open the character menu.