### PR TITLE
Fix space in dotnet breaking windows builds

### DIFF
--- a/MSBuild/XamlIL.targets
+++ b/MSBuild/XamlIL.targets
@@ -58,6 +58,6 @@
     </PropertyGroup>
     <Exec
       Condition="'$(_RobustUseExternalMSBuild)' == 'true'"
-      Command="$(DOTNET_HOST_PATH) msbuild /nodereuse:false $(MSBuildProjectFile) /t:CompileRobustXaml /p:_RobustForceInternalMSBuild=true /p:Configuration=$(Configuration) /p:RuntimeIdentifier=$(RuntimeIdentifier) /p:TargetFramework=$(TargetFramework) /p:BuildProjectReferences=false"/>
+      Command="&quot;$(DOTNET_HOST_PATH)&quot; msbuild /nodereuse:false $(MSBuildProjectFile) /t:CompileRobustXaml /p:_RobustForceInternalMSBuild=true /p:Configuration=$(Configuration) /p:RuntimeIdentifier=$(RuntimeIdentifier) /p:TargetFramework=$(TargetFramework) /p:BuildProjectReferences=false"/>
   </Target>
 </Project>


### PR DESCRIPTION
Who would win?
Thirty developers
-OR-
One sneaky ` ` boi?

On windows default path to dotnet are `C:\Program Files\...`. Without quoting the
the command if it contains a space, it's going to think the command is `C:\Program`.