### PR TITLE
Avoid unnecessary EntMapIdChangedMessages

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -583,7 +583,11 @@ namespace Robust.Shared.GameObjects.Components.Transform
 
         internal void ChangeMapId(MapId newMapId)
         {
+            if (newMapId == MapID)
+                return;
+
             var oldMapId = MapID;
+
             MapID = newMapId;
             MapIdChanged(oldMapId);
             UpdateChildMapIdsRecursive(MapID, Owner.EntityManager.ComponentManager);


### PR DESCRIPTION
This is called for every AttachParent so this can save on container insertion / removals