### PR TITLE
Fixes sprite scale not being taken into account.

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -992,8 +992,7 @@ namespace Robust.Client.GameObjects
             Matrix3.Multiply(ref mRotation, ref mOffset, out var transform);
 
             // Only apply scale if needed.
-            if(!MathHelper.CloseTo(Scale.Length, 1f))
-                transform.Multiply(Matrix3.CreateScale(Scale));
+            if(!MathHelper.CloseTo(Scale.Length, 1f)) transform.Multiply(Matrix3.CreateScale(Scale));
             
             transform.Multiply(worldTransform);
 

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -991,6 +991,10 @@ namespace Robust.Client.GameObjects
             var mRotation = Matrix3.CreateRotation(angle);
             Matrix3.Multiply(ref mRotation, ref mOffset, out var transform);
 
+            // Only apply scale if needed.
+            if(!MathHelper.CloseTo(Scale.Length, 1f))
+                transform.Multiply(Matrix3.CreateScale(Scale));
+            
             transform.Multiply(worldTransform);
 
             RenderInternal(drawingHandle, worldRotation, overrideDirection, transform);

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -992,8 +992,7 @@ namespace Robust.Client.GameObjects
             Matrix3.Multiply(ref mRotation, ref mOffset, out var transform);
 
             // Only apply scale if needed.
-            if(!Scale.EqualsApprox(Vector2.One))
-                transform.Multiply(Matrix3.CreateScale(Scale));
+            if(!Scale.EqualsApprox(Vector2.One)) transform.Multiply(Matrix3.CreateScale(Scale));
 
             transform.Multiply(worldTransform);
 

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -992,8 +992,9 @@ namespace Robust.Client.GameObjects
             Matrix3.Multiply(ref mRotation, ref mOffset, out var transform);
 
             // Only apply scale if needed.
-            if(!MathHelper.CloseTo(Scale.Length, 1f)) transform.Multiply(Matrix3.CreateScale(Scale));
-            
+            if(!Scale.EqualsApprox(Vector2.One))
+                transform.Multiply(Matrix3.CreateScale(Scale));
+
             transform.Multiply(worldTransform);
 
             RenderInternal(drawingHandle, worldRotation, overrideDirection, transform);


### PR DESCRIPTION
Only applies scale if length of scale vector not close or equal to 1.
Requesting review from PJB just in case.