### PR TITLE
Fix FileDialogManager not doing DLL mapping properly in sandbox, and FileDialogManager hard crash on multiple dialogs

### DIFF
--- a/OpenToolkit.GraphicsLibraryFramework/GLFWNative.cs
+++ b/OpenToolkit.GraphicsLibraryFramework/GLFWNative.cs
@@ -17,6 +17,7 @@ namespace OpenToolkit.GraphicsLibraryFramework
             // On net472, we rely on Mono's DllMap for this. See the .dll.config file.
             NativeLibrary.SetDllImportResolver(typeof(GLFWNative).Assembly, (name, assembly, path) =>
             {
+                // Please keep in sync with what Robust.Shared/DllMapHelper.cs does.
                 if (name != "glfw3.dll")
                 {
                     return IntPtr.Zero;

--- a/Robust.Client/UserInterface/FileDialogManager.cs
+++ b/Robust.Client/UserInterface/FileDialogManager.cs
@@ -179,7 +179,17 @@ namespace Robust.Client.UserInterface
             return tcs.Task;
 #else
             // Luckily, GTK Linux and COM Windows are both happily threaded. Yay!
-            return Task.Run(action);
+            // * Actual attempts to have multiple file dialogs up at the same time, and the resulting crashes,
+            // have shown that at least for GTK+ (Linux), just because it can handle being on any thread doesn't mean it handle being on two at the same time.
+            // Testing system was Ubuntu 20.04.
+            // COM on Windows might handle this, but honestly, who exactly wants to risk it?
+            // In particular this could very well be an swnfd issue.
+            return Task.Run(() =>
+            {
+                lock (this) {
+                    return action();
+                }
+            });
 #endif
         }
 


### PR DESCRIPTION
+ Apparently DllMapManager is not as commonly used as the name would suggest. In the end I copied the behaviour from GLFWNative to fix it, since GLFWNative has a "known good" DLL mapper
+ Apparently one of: (swnfd, GTK+) does not like when multiple dialogs are opened, all on different threads
