### PR TITLE
Viewport improvements.

### DIFF
--- a/Robust.Client/Graphics/ClientEye/EyeManager.cs
+++ b/Robust.Client/Graphics/ClientEye/EyeManager.cs
@@ -1,5 +1,6 @@
 ﻿using Robust.Client.Interfaces.Graphics;
 using Robust.Client.Interfaces.Graphics.ClientEye;
+using Robust.Client.Interfaces.UserInterface;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
@@ -21,6 +22,7 @@ namespace Robust.Client.Graphics.ClientEye
 
         [Dependency] private readonly IClyde _displayManager = default!;
         [Dependency] private readonly IEntityManager _entityManager = default!;
+        [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
 
         // We default to this when we get set to a null eye.
         private readonly FixedEye _defaultEye = new();
@@ -63,16 +65,7 @@ namespace Robust.Client.Graphics.ClientEye
         /// <inheritdoc />
         public Vector2 WorldToScreen(Vector2 point)
         {
-            var newPoint = point;
-
-            CurrentEye.GetViewMatrix(out var viewMatrix);
-            newPoint = viewMatrix * newPoint;
-
-            // (inlined version of UiProjMatrix)
-            newPoint *= new Vector2(1, -1) * PixelsPerMeter;
-            newPoint += _displayManager.ScreenSize / 2f;
-
-            return newPoint;
+            return _uiManager.MainViewport.WorldToScreen(point);
         }
 
         /// <inheritdoc />
@@ -117,17 +110,7 @@ namespace Robust.Client.Graphics.ClientEye
         /// <inheritdoc />
         public MapCoordinates ScreenToMap(Vector2 point)
         {
-            var newPoint = point;
-
-            // (inlined version of UiProjMatrix^-1)
-            newPoint -= _displayManager.ScreenSize / 2f;
-            newPoint *= new Vector2(1, -1) / PixelsPerMeter;
-
-            // view matrix
-            CurrentEye.GetViewMatrixInv(out var viewMatrixInv);
-            newPoint = viewMatrixInv * newPoint;
-
-            return new MapCoordinates(newPoint, CurrentMap);
+            return _uiManager.MainViewport.ScreenToMap(point);
         }
     }
 }

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -187,7 +187,7 @@ namespace Robust.Client.Graphics.Clyde
                     // which is necessary for light application,
                     // but it's ACTUALLY drawing into the center of the render target.
                     var spritePos = entry.sprite.Owner.Transform.WorldPosition;
-                    var screenPos = _eyeManager.WorldToScreen(spritePos);
+                    var screenPos = viewport.WorldToScreen(spritePos);
                     var (roundedX, roundedY) = roundedPos = (Vector2i) screenPos;
                     var flippedPos = new Vector2i(roundedX, screenSize.Y - roundedY);
                     flippedPos -= EntityPostRenderTarget.Size / 2;

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -187,7 +187,7 @@ namespace Robust.Client.Graphics.Clyde
                     // which is necessary for light application,
                     // but it's ACTUALLY drawing into the center of the render target.
                     var spritePos = entry.sprite.Owner.Transform.WorldPosition;
-                    var screenPos = viewport.WorldToScreen(spritePos);
+                    var screenPos = viewport.WorldToLocal(spritePos);
                     var (roundedX, roundedY) = roundedPos = (Vector2i) screenPos;
                     var flippedPos = new Vector2i(roundedX, screenSize.Y - roundedY);
                     flippedPos -= EntityPostRenderTarget.Size / 2;

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -73,6 +73,12 @@ namespace Robust.Client.Graphics.Clyde
 
             RenderOverlays(OverlaySpace.ScreenSpaceBelowWorld);
 
+            foreach (var weak in _viewports.Values)
+            {
+                if(weak.TryGetTarget(out var viewport))
+                    RenderViewport(viewport);
+            }
+
             TakeScreenshot(ScreenshotType.BeforeUI);
 
             RenderOverlays(OverlaySpace.ScreenSpace);
@@ -276,7 +282,7 @@ namespace Robust.Client.Graphics.Clyde
 
         private void RenderViewport(Viewport viewport)
         {
-            if (viewport.Eye == null)
+            if (viewport.Eye == null || viewport.Eye.Position.MapId == MapId.Nullspace)
             {
                 return;
             }
@@ -310,7 +316,7 @@ namespace Robust.Client.Graphics.Clyde
 
                 // Calculate world-space AABB for camera, to cull off-screen things.
                 var worldBounds = Box2.CenteredAround(eye.Position.Position,
-                    _framebufferSize / (float) EyeManager.PixelsPerMeter * eye.Zoom);
+                    viewport.Size / (float) EyeManager.PixelsPerMeter * eye.Zoom);
 
                 if (_eyeManager.CurrentMap != MapId.Nullspace)
                 {

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -73,17 +73,6 @@ namespace Robust.Client.Graphics.Clyde
 
             RenderOverlays(OverlaySpace.ScreenSpaceBelowWorld);
 
-            _mainViewport.Eye = _eyeManager.CurrentEye;
-            RenderViewport(_mainViewport);
-
-            {
-                var handle = _renderHandle.DrawingHandleScreen;
-                var tex = _mainViewport.RenderTarget.Texture;
-
-                handle.DrawTexture(tex, (0, 0));
-                FlushRenderQueue();
-            }
-
             TakeScreenshot(ScreenshotType.BeforeUI);
 
             RenderOverlays(OverlaySpace.ScreenSpace);

--- a/Robust.Client/Graphics/Clyde/Clyde.Viewport.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Viewport.cs
@@ -115,7 +115,7 @@ namespace Robust.Client.Graphics.Clyde
                 _clyde.RenderViewport(this);
             }
 
-            public Vector2 WorldToScreen(Vector2 point)
+            public Vector2 WorldToLocal(Vector2 point)
             {
                 if (Eye == null)
                     return (0, 0);

--- a/Robust.Client/Graphics/Clyde/Clyde.Viewport.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Viewport.cs
@@ -115,6 +115,24 @@ namespace Robust.Client.Graphics.Clyde
                 _clyde.RenderViewport(this);
             }
 
+            public Vector2 WorldToScreen(Vector2 point)
+            {
+                if (Eye == null)
+                    return (0, 0);
+
+                var eye = (IEye) Eye;
+                var newPoint = point;
+
+                eye.GetViewMatrix(out var viewMatrix);
+                newPoint = viewMatrix * newPoint;
+
+                // (inlined version of UiProjMatrix)
+                newPoint *= new Vector2(1, -1) * EyeManager.PixelsPerMeter;
+                newPoint += Size / 2f;
+
+                return newPoint;
+            }
+
             public void Dispose()
             {
                 RenderTarget.Dispose();

--- a/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
@@ -511,11 +511,6 @@ namespace Robust.Client.Graphics.Clyde
 
                 GL.Viewport(0, 0, fbW, fbH);
                 CheckGlError();
-                if (fbW != 0 && fbH != 0)
-                {
-                    _mainViewport.Dispose();
-                    CreateMainViewport();
-                }
 
                 OnWindowResized?.Invoke(new WindowResizedEventArgs(oldSize, _framebufferSize));
             }

--- a/Robust.Client/Graphics/Clyde/Clyde.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.cs
@@ -56,8 +56,6 @@ namespace Robust.Client.Graphics.Clyde
         private GLBuffer QuadVBO = default!;
         private GLHandle QuadVAO;
 
-        private Viewport _mainViewport = default!;
-
         private bool _drawingSplash = true;
 
         private GLShaderProgram? _currentProgram;
@@ -322,19 +320,6 @@ namespace Robust.Client.Graphics.Clyde
             EntityPostRenderTarget = CreateRenderTarget(Vector2i.One * 8 * EyeManager.PixelsPerMeter,
                 new RenderTargetFormatParameters(RenderTargetColorFormat.Rgba8Srgb, true),
                 name: nameof(EntityPostRenderTarget));
-
-            CreateMainViewport();
-        }
-
-        private void CreateMainViewport()
-        {
-            var (w, h) = _framebufferSize;
-
-            // Ensure viewport size is always even to avoid artifacts.
-            if (w % 2 == 1) w += 1;
-            if (h % 2 == 1) h += 1;
-
-            _mainViewport = CreateViewport((w, h), nameof(_mainViewport));
         }
 
         [Conditional("DEBUG")]

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -458,6 +458,11 @@ namespace Robust.Client.Graphics.Clyde
             public void Render()
             {
             }
+
+            public Vector2 WorldToLocal(Vector2 point)
+            {
+                return point;
+            }
         }
     }
 }

--- a/Robust.Client/Interfaces/Graphics/IClydeViewport.cs
+++ b/Robust.Client/Interfaces/Graphics/IClydeViewport.cs
@@ -21,5 +21,6 @@ namespace Robust.Client.Interfaces.Graphics
         ///     Render the state of the world in this viewport, updating the texture inside the render target.
         /// </summary>
         void Render();
+        Vector2 WorldToLocal(Vector2 point);
     }
 }

--- a/Robust.Client/Interfaces/UserInterface/IUserInterfaceManager.cs
+++ b/Robust.Client/Interfaces/UserInterface/IUserInterfaceManager.cs
@@ -3,6 +3,7 @@ using Robust.Client.Input;
 using Robust.Client.Interfaces.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared;
 using Robust.Shared.Input;
 using Robust.Shared.Map;
@@ -36,6 +37,8 @@ namespace Robust.Client.Interfaces.UserInterface
         /// happens. When focus is lost on a control, it always fires Control.ControlFocusExited.
         /// </summary>
         Control? ControlFocused { get; }
+
+        ViewportContainer MainViewport { get; }
 
         LayoutContainer StateRoot { get; }
 

--- a/Robust.Client/UserInterface/CustomControls/MainViewportContainer.cs
+++ b/Robust.Client/UserInterface/CustomControls/MainViewportContainer.cs
@@ -3,6 +3,7 @@ using Robust.Shared.Utility;
 ﻿using Robust.Client.Graphics.Drawing;
 using Robust.Client.Interfaces.Graphics;
 using Robust.Client.Interfaces.Graphics.ClientEye;
+using Robust.Shared.Timing;
 
 namespace Robust.Client.UserInterface.CustomControls
 {
@@ -14,15 +15,17 @@ namespace Robust.Client.UserInterface.CustomControls
     {
         private readonly IEyeManager _eyeManager;
 
-        public MainViewportContainer(IEyeManager eyeManager) : base()
+        public MainViewportContainer(IEyeManager eyeManager)
         {
             _eyeManager = eyeManager;
         }
 
-        protected internal override void Draw(DrawingHandleScreen handle)
+        protected override void Update(FrameEventArgs args)
         {
-            Viewport.Eye = _eyeManager.CurrentEye;
-            base.Draw(handle);
+            base.Update(args);
+
+            if(Viewport != null)
+                Viewport.Eye = _eyeManager.CurrentEye;
         }
     }
 }

--- a/Robust.Client/UserInterface/CustomControls/MainViewportContainer.cs
+++ b/Robust.Client/UserInterface/CustomControls/MainViewportContainer.cs
@@ -14,7 +14,7 @@ namespace Robust.Client.UserInterface.CustomControls
     {
         private readonly IEyeManager _eyeManager;
 
-        public MainViewportContainer(IEyeManager eyeManager) : base(true)
+        public MainViewportContainer(IEyeManager eyeManager) : base()
         {
             _eyeManager = eyeManager;
         }

--- a/Robust.Client/UserInterface/CustomControls/MainViewportContainer.cs
+++ b/Robust.Client/UserInterface/CustomControls/MainViewportContainer.cs
@@ -1,0 +1,28 @@
+﻿using Robust.Shared.Maths;
+using Robust.Shared.Utility;
+﻿using Robust.Client.Graphics.Drawing;
+using Robust.Client.Interfaces.Graphics;
+using Robust.Client.Interfaces.Graphics.ClientEye;
+
+namespace Robust.Client.UserInterface.CustomControls
+{
+    /// <summary>
+    ///     A viewport container shows a viewport.
+    ///     This one is particularly gnarly because it has the code for the main viewport stuff.
+    /// </summary>
+    public class MainViewportContainer : ViewportContainer
+    {
+        private readonly IEyeManager _eyeManager;
+
+        public MainViewportContainer(IEyeManager eyeManager) : base(true)
+        {
+            _eyeManager = eyeManager;
+        }
+
+        protected internal override void Draw(DrawingHandleScreen handle)
+        {
+            Viewport.Eye = _eyeManager.CurrentEye;
+            base.Draw(handle);
+        }
+    }
+}

--- a/Robust.Client/UserInterface/CustomControls/ViewportContainer.cs
+++ b/Robust.Client/UserInterface/CustomControls/ViewportContainer.cs
@@ -16,7 +16,7 @@ namespace Robust.Client.UserInterface.CustomControls
         private readonly IClyde _displayManager;
         public IClydeViewport Viewport = default!;
 
-        private Vector2 _viewportResolution = (1.0f, 1.0f);
+        private Vector2 _viewportResolution = (1f, 1f);
 
         /// <summary>
         ///     This controls the render target size, *as a fraction of the control size.*
@@ -41,7 +41,7 @@ namespace Robust.Client.UserInterface.CustomControls
         protected internal override void Draw(DrawingHandleScreen handle)
         {
             base.Draw(handle);
-            Viewport.Render();
+
             if (Viewport == null)
             {
                 handle.DrawRect(UIBox2.FromDimensions((0, 0), Size * UserInterfaceManager.UIScale), Color.Red);

--- a/Robust.Client/UserInterface/CustomControls/ViewportContainer.cs
+++ b/Robust.Client/UserInterface/CustomControls/ViewportContainer.cs
@@ -14,7 +14,7 @@ namespace Robust.Client.UserInterface.CustomControls
     public class ViewportContainer : Control
     {
         private readonly IClyde _displayManager;
-        public IClydeViewport Viewport = default!;
+        public IClydeViewport? Viewport;
 
         private Vector2 _viewportResolution = (1f, 1f);
 
@@ -52,7 +52,7 @@ namespace Robust.Client.UserInterface.CustomControls
             }
         }
 
-        protected override void Resized()
+        protected sealed override void Resized()
         {
             Viewport?.Dispose();
             Viewport = _displayManager.CreateViewport(Vector2i.ComponentMax((1, 1), (Vector2i) (PixelSize * _viewportResolution)), "ViewportContainerViewport");
@@ -64,13 +64,13 @@ namespace Robust.Client.UserInterface.CustomControls
 
         public MapCoordinates LocalPixelToMap(Vector2 point)
         {
-            if (Viewport.Eye == null)
+            if (Viewport?.Eye == null)
                 return MapCoordinates.Nullspace;
 
-            var eye = (IEye) Viewport.Eye;
+            var eye = Viewport.Eye;
             var newPoint = point;
 
-            // prescaler
+            // pre-scaler
             newPoint *= _viewportResolution;
 
             // (inlined version of UiProjMatrix^-1)
@@ -86,9 +86,12 @@ namespace Robust.Client.UserInterface.CustomControls
 
         public Vector2 WorldToLocalPixel(Vector2 point)
         {
+            if (Viewport?.Eye == null)
+                return Vector2.Zero;
+
             var newPoint = Viewport.WorldToLocal(point);
 
-            // prescaler
+            // pre-scaler
             newPoint /= _viewportResolution;
 
             return newPoint;

--- a/Robust.Client/UserInterface/CustomControls/ViewportContainer.cs
+++ b/Robust.Client/UserInterface/CustomControls/ViewportContainer.cs
@@ -1,6 +1,5 @@
 ﻿using Robust.Shared.Maths;
-using Robust.Shared.Utility;
-﻿using Robust.Client.Graphics.Drawing;
+using Robust.Client.Graphics.Drawing;
 using Robust.Client.Graphics.ClientEye;
 using Robust.Client.Interfaces.Graphics;
 using Robust.Client.Interfaces.Graphics.ClientEye;
@@ -87,18 +86,7 @@ namespace Robust.Client.UserInterface.CustomControls
 
         public Vector2 WorldToLocalPixel(Vector2 point)
         {
-            if (Viewport.Eye == null)
-                return (0, 0);
-
-            var eye = Viewport.Eye;
-            var newPoint = point;
-
-            eye.GetViewMatrix(out var viewMatrix);
-            newPoint = viewMatrix * newPoint;
-
-            // (inlined version of UiProjMatrix)
-            newPoint *= new Vector2(1, -1) * EyeManager.PixelsPerMeter;
-            newPoint += Viewport.Size / 2f;
+            var newPoint = Viewport.WorldToLocal(point);
 
             // prescaler
             newPoint /= _viewportResolution;

--- a/Robust.Client/UserInterface/CustomControls/ViewportContainer.cs
+++ b/Robust.Client/UserInterface/CustomControls/ViewportContainer.cs
@@ -1,0 +1,56 @@
+﻿using Robust.Shared.Maths;
+using Robust.Shared.Utility;
+﻿using Robust.Client.Graphics.Drawing;
+using Robust.Client.Interfaces.Graphics;
+using Robust.Shared.IoC;
+using Robust.Shared.Maths;
+
+namespace Robust.Client.UserInterface.CustomControls
+{
+    /// <summary>
+    ///     A viewport container shows a viewport.
+    /// </summary>
+    public class ViewportContainer : Control
+    {
+        private readonly IClyde _displayManager;
+        public IClydeViewport? Viewport;
+        public readonly bool OwnsViewport;
+
+        public ViewportContainer(bool owns)
+        {
+            _displayManager = IoCManager.Resolve<IClyde>();
+            OwnsViewport = owns;
+            if (owns)
+            {
+                Viewport = _displayManager.CreateViewport((1, 1), "ViewportContainerOwnedViewport");
+            }
+        }
+
+        protected internal override void Draw(DrawingHandleScreen handle)
+        {
+            base.Draw(handle);
+            if (OwnsViewport)
+            {
+                Viewport.Render();
+            }
+            if (Viewport == null)
+            {
+                handle.DrawRect(UIBox2.FromDimensions((0, 0), Size * UserInterfaceManager.UIScale), Color.Red);
+            }
+            else
+            {
+                handle.DrawTextureRect(Viewport.RenderTarget.Texture, UIBox2.FromDimensions((0, 0), PixelSize));
+            }
+        }
+
+        protected override void Resized()
+        {
+            if (OwnsViewport)
+            {
+                Viewport?.Dispose();
+                Viewport = _displayManager.CreateViewport(Vector2i.ComponentMax((1, 1), PixelSize), "ViewportContainerOwnedViewport");
+            }
+        }
+
+    }
+}

--- a/Robust.Client/UserInterface/CustomControls/ViewportContainer.cs
+++ b/Robust.Client/UserInterface/CustomControls/ViewportContainer.cs
@@ -90,7 +90,7 @@ namespace Robust.Client.UserInterface.CustomControls
             if (Viewport.Eye == null)
                 return (0, 0);
 
-            var eye = (IEye) Viewport.Eye;
+            var eye = Viewport.Eye;
             var newPoint = point;
 
             eye.GetViewMatrix(out var viewMatrix);

--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -59,6 +59,7 @@ namespace Robust.Client.UserInterface
 
         public Control? ControlFocused { get; private set; }
 
+        public ViewportContainer MainViewport { get; private set; } = default!;
         public LayoutContainer StateRoot { get; private set; } = default!;
         public PopupContainer ModalRoot { get; private set; } = default!;
         public Control? CurrentlyHovered { get; private set; } = default!;
@@ -129,6 +130,13 @@ namespace Robust.Client.UserInterface
             };
             RootControl.Size = _displayManager.ScreenSize / UIScale;
             _displayManager.OnWindowResized += args => _updateRootSize();
+
+            MainViewport = new MainViewportContainer(_eyeManager)
+            {
+                Name = "MainViewport",
+                MouseFilter = Control.MouseFilterMode.Ignore
+            };
+            RootControl.AddChild(MainViewport);
 
             StateRoot = new LayoutContainer
             {


### PR DESCRIPTION
@20kdc coded most of this.

- Adds ViewportContainer control.
- ViewportContainer can set viewport resolution.
This means you could set the viewport resolution to half, and double the eye's zoom for **FREE** performance gains!
- Main viewport is now contained within a control.
Content can access this control and reparent it as needed, therefore allowing things like this: ![image](https://user-images.githubusercontent.com/6766154/105366962-368e8f80-5c00-11eb-816c-2115cd07b52c.png) _BYOND layout, anyone?_