### PR TITLE
Add component registration lookup with case insensitive names

### DIFF
--- a/Robust.Shared/Interfaces/GameObjects/IComponentFactory.cs
+++ b/Robust.Shared/Interfaces/GameObjects/IComponentFactory.cs
@@ -54,12 +54,13 @@ namespace Robust.Shared.Interfaces.GameObjects
         /// </summary>
         IEnumerable<Type> AllRegisteredTypes { get; }
 
-            /// <summary>
+        /// <summary>
         /// Get whether a component is available right now.
         /// </summary>
         /// <param name="componentName">The name of the component to check.</param>
+        /// <param name="ignoreCase">Whether or not to ignore casing on <see cref="componentName"/></param>
         /// <returns>The availability of the component.</returns>
-        ComponentAvailability GetComponentAvailability(string componentName);
+        ComponentAvailability GetComponentAvailability(string componentName, bool ignoreCase = false);
 
         /// <summary>
         /// Registers a prototype to be available for spawning.
@@ -109,11 +110,12 @@ namespace Robust.Shared.Interfaces.GameObjects
         /// Gets a new component instantiated of the specified <see cref="IComponent.Name"/>.
         /// </summary>
         /// <param name="componentName">name of component to make</param>
+        /// <param name="ignoreCase">Whether or not to ignore casing on <see cref="componentName"/></param>
         /// <returns>A Component</returns>
         /// <exception cref="UnknownComponentException">
         ///     Thrown if no component exists with the given name <see cref="componentName"/>.
         /// </exception>
-        IComponent GetComponent(string componentName);
+        IComponent GetComponent(string componentName, bool ignoreCase = false);
 
         /// <summary>
         /// Gets a new component instantiated of the specified network ID.
@@ -129,10 +131,11 @@ namespace Robust.Shared.Interfaces.GameObjects
         ///     Gets the registration belonging to a component, throwing an exception if it does not exist.
         /// </summary>
         /// <param name="componentName">The name of the component.</param>
+        /// <param name="ignoreCase">Whether or not to ignore casing on <see cref="componentName"/></param>
         /// <exception cref="UnknownComponentException">
         ///     Thrown if no component exists with the given name <see cref="componentName"/>.
         /// </exception>
-        IComponentRegistration GetRegistration(string componentName);
+        IComponentRegistration GetRegistration(string componentName, bool ignoreCase = false);
 
         /// <summary>
         ///     Gets the registration belonging to a component, throwing an exception if it does not exist.
@@ -179,8 +182,9 @@ namespace Robust.Shared.Interfaces.GameObjects
         /// </summary>
         /// <param name="componentName">The name of the component.</param>
         /// <param name="registration">The registration if found, null otherwise.</param>
+        /// <param name="ignoreCase">Whether or not to ignore casing on <see cref="componentName"/></param>
         /// <returns>true it found, false otherwise.</returns>
-        bool TryGetRegistration(string componentName, [NotNullWhen(true)] out IComponentRegistration? registration);
+        bool TryGetRegistration(string componentName, [NotNullWhen(true)] out IComponentRegistration? registration, bool ignoreCase = true);
 
         /// <summary>
         ///     Tries to get the registration belonging to a component.

--- a/Robust.Shared/Interfaces/GameObjects/IComponentFactory.cs
+++ b/Robust.Shared/Interfaces/GameObjects/IComponentFactory.cs
@@ -184,7 +184,7 @@ namespace Robust.Shared.Interfaces.GameObjects
         /// <param name="registration">The registration if found, null otherwise.</param>
         /// <param name="ignoreCase">Whether or not to ignore casing on <see cref="componentName"/></param>
         /// <returns>true it found, false otherwise.</returns>
-        bool TryGetRegistration(string componentName, [NotNullWhen(true)] out IComponentRegistration? registration, bool ignoreCase = true);
+        bool TryGetRegistration(string componentName, [NotNullWhen(true)] out IComponentRegistration? registration, bool ignoreCase = false);
 
         /// <summary>
         ///     Tries to get the registration belonging to a component.

--- a/Robust.UnitTesting/Shared/GameObjects/ComponentFactory_Tests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/ComponentFactory_Tests.cs
@@ -1,0 +1,118 @@
+﻿using NUnit.Framework;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Reflection;
+
+// ReSharper disable AccessToStaticMemberViaDerivedType
+
+namespace Robust.UnitTesting.Shared.GameObjects
+{
+    [TestFixture]
+    [TestOf(typeof(ComponentFactory))]
+    public class ComponentFactory_Tests : RobustUnitTest
+    {
+        private const string TestComponentName = "A";
+        private const string LowercaseTestComponentName = "a";
+        private const string NonexistentComponentName = "B";
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            IoCManager.Resolve<IComponentFactory>().Register<TestComponent>();
+        }
+
+        [Test]
+        public void GetComponentAvailabilityTest()
+        {
+            var componentFactory = IoCManager.Resolve<IComponentFactory>();
+
+            // Should not exist
+            Assert.That(componentFactory.GetComponentAvailability(NonexistentComponentName), Is.EqualTo(ComponentAvailability.Unknown));
+            Assert.That(componentFactory.GetComponentAvailability(NonexistentComponentName, true), Is.EqualTo(ComponentAvailability.Unknown));
+
+            // Normal casing, do not ignore case, should exist
+            Assert.That(componentFactory.GetComponentAvailability(TestComponentName), Is.EqualTo(ComponentAvailability.Available));
+
+            // Normal casing, ignore case, should exist
+            Assert.That(componentFactory.GetComponentAvailability(TestComponentName, true), Is.EqualTo(ComponentAvailability.Available));
+
+            // Lower casing, do not ignore case, should not exist
+            Assert.That(componentFactory.GetComponentAvailability(LowercaseTestComponentName), Is.EqualTo(ComponentAvailability.Unknown));
+
+            // Lower casing, ignore case, should exist
+            Assert.That(componentFactory.GetComponentAvailability(LowercaseTestComponentName, true), Is.EqualTo(ComponentAvailability.Available));
+        }
+
+        [Test]
+        public void GetComponentTest()
+        {
+            var componentFactory = IoCManager.Resolve<IComponentFactory>();
+
+            // Should not exist
+            Assert.Throws<UnknownComponentException>(() => componentFactory.GetComponent(NonexistentComponentName));
+            Assert.Throws<UnknownComponentException>(() => componentFactory.GetComponent(NonexistentComponentName, true));
+
+            // Normal casing, do not ignore case, should exist
+            Assert.IsInstanceOf<TestComponent>(componentFactory.GetComponent(TestComponentName));
+
+            // Normal casing, ignore case, should exist
+            Assert.IsInstanceOf<TestComponent>(componentFactory.GetComponent(TestComponentName, true));
+
+            // Lower casing, do not ignore case, should not exist
+            Assert.Throws<UnknownComponentException>(() => componentFactory.GetComponent(LowercaseTestComponentName));
+
+            // Lower casing, ignore case, should exist
+            Assert.IsInstanceOf<TestComponent>(componentFactory.GetComponent(LowercaseTestComponentName, true));
+        }
+
+        [Test]
+        public void GetRegistrationTest()
+        {
+            var componentFactory = IoCManager.Resolve<IComponentFactory>();
+
+            // Should not exist
+            Assert.Throws<UnknownComponentException>(() => componentFactory.GetRegistration(NonexistentComponentName));
+            Assert.Throws<UnknownComponentException>(() => componentFactory.GetRegistration(NonexistentComponentName, true));
+
+            // Normal casing, do not ignore case, should exist
+            Assert.DoesNotThrow(() => componentFactory.GetRegistration(TestComponentName));
+
+            // Normal casing, ignore case, should exist
+            Assert.DoesNotThrow(() => componentFactory.GetRegistration(TestComponentName, true));
+
+            // Lower casing, do not ignore case, should not exist
+            Assert.Throws<UnknownComponentException>(() => componentFactory.GetRegistration(LowercaseTestComponentName));
+
+            // Lower casing, ignore case, should exist
+            Assert.DoesNotThrow(() => componentFactory.GetRegistration(LowercaseTestComponentName, true));
+        }
+
+        [Test]
+        public void TryGetRegistrationTest()
+        {
+            var componentFactory = IoCManager.Resolve<IComponentFactory>();
+
+            // Should not exist
+            Assert.False(componentFactory.TryGetRegistration(NonexistentComponentName, out _));
+            Assert.False(componentFactory.TryGetRegistration(NonexistentComponentName, out _, true));
+
+            // Normal casing, do not ignore case, should exist
+            Assert.True(componentFactory.TryGetRegistration(TestComponentName, out _));
+
+            // Normal casing, ignore case, should exist
+            Assert.True(componentFactory.TryGetRegistration(TestComponentName, out _, true));
+
+            // Lower casing, do not ignore case, should not exist
+            Assert.False(componentFactory.TryGetRegistration(LowercaseTestComponentName, out _));
+
+            // Lower casing, ignore case, should exist
+            Assert.True(componentFactory.TryGetRegistration(LowercaseTestComponentName, out _, true));
+        }
+
+        private class TestComponent : Component
+        {
+            public override string Name => TestComponentName;
+        }
+    }
+}


### PR DESCRIPTION
Adds an ignoreCase argument to the relevant methods and a lower case to normal case component name mapping to allow case insensitive lookups.
Needed to make content commands a bit easier to use, because getting "transform component does not exist" gets annoying after a while.