### PR TITLE
DynamicTypeFactory PreInject Dependencies

### DIFF
--- a/Robust.Shared/IoC/DynamicTypeFactory.cs
+++ b/Robust.Shared/IoC/DynamicTypeFactory.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using Robust.Shared.ContentPack;
 using Robust.Shared.Utility;
@@ -169,9 +170,10 @@ namespace Robust.Shared.IoC
         {
             if (type == null)
                 throw new ArgumentNullException(nameof(type));
-
-            var instance = Activator.CreateInstance(type)!;
+            
+            object instance = FormatterServices.GetUninitializedObject(type);
             _dependencies.InjectDependencies(instance);
+            instance.GetType().GetConstructor(Type.EmptyTypes)!.Invoke(instance, null);
             return instance;
         }
 
@@ -180,16 +182,18 @@ namespace Robust.Shared.IoC
             if (type == null)
                 throw new ArgumentNullException(nameof(type));
 
-            var instance = Activator.CreateInstance(type, args)!;
+            object instance = FormatterServices.GetUninitializedObject(type);
             _dependencies.InjectDependencies(instance);
+            instance.GetType().GetConstructors()[0]!.Invoke(instance, args); // hope you only have one
             return instance;
         }
 
         public T CreateInstanceUnchecked<T>() where T : new()
         {
-            var instance = new T();
+            object instance = FormatterServices.GetUninitializedObject(typeof(T));
             _dependencies.InjectDependencies(instance);
-            return instance;
+            instance.GetType().GetConstructor(Type.EmptyTypes)!.Invoke(instance, null);
+            return (T)instance;
         }
     }
 }

--- a/Robust.UnitTesting/Shared/IoC/DynamicTypeFactory_Test.cs
+++ b/Robust.UnitTesting/Shared/IoC/DynamicTypeFactory_Test.cs
@@ -1,0 +1,40 @@
+using Moq;
+using NUnit.Framework;
+using Robust.Shared.ContentPack;
+using Robust.Shared.IoC;
+
+namespace Robust.UnitTesting.Shared.IoC
+{
+    [TestFixture, Parallelizable, TestOf(typeof(DynamicTypeFactory))]
+    public class DynamicTypeFactoryTests
+    {
+        [Test]
+        public void InjectDepsBeforeConstructor()
+        {
+            var fakeLoader = new Mock<IModLoader>().Object;
+            var deps = new DependencyCollection();
+            deps.RegisterInstance<IModLoader>(fakeLoader);
+            deps.Register<IDynamicTypeFactoryInternal, DynamicTypeFactory>();
+            deps.BuildGraph();
+            var factory = deps.Resolve<IDynamicTypeFactoryInternal>();
+            
+            var manager = factory.CreateInstanceUnchecked<DummyManager>();
+
+            Assert.That(manager.Result, Is.EqualTo(fakeLoader));
+        }
+
+        private class DummyManager
+        {
+            // Note that we don't assign this field, because the static constructor will
+            // overwrite it when the constructor is called.
+            // Look into RuntimeHelpers.RunClassConstructor
+            [Dependency] private readonly IModLoader _modLoader;
+            public IModLoader Result { get; }
+            public DummyManager()
+            {
+                _modLoader ??= default!; // no ur nullable
+                Result = _modLoader;
+            }
+        }
+    }
+}


### PR DESCRIPTION
DynamicTypeFactory now injects the dependencies into the fields before the constructor is called.

There might be a better way of doing this with the IL codegen in the IoCManager to cache the constructor, but someone that knows how that works would have to change it. Maybe a new `IoCManager.CreateInstance()`?