### PR TITLE
Fixes Overwriting a Deleted Component

### DIFF
--- a/Robust.Shared/GameObjects/ComponentManager.cs
+++ b/Robust.Shared/GameObjects/ComponentManager.cs
@@ -93,17 +93,17 @@ namespace Robust.Shared.GameObjects
             // Check that there are no overlapping references.
             foreach (var type in reg.References)
             {
-                if (!TryGetComponent(uid, type, out var duplicate)) continue;
+                var dict = _entTraitDict[type];
+                if (!dict.TryGetValue(uid, out var duplicate))
+                    continue;
 
-                if (!overwrite)
+                if (!overwrite && !duplicate.Deleted)
                     throw new InvalidOperationException(
                         $"Component reference type {type} already occupied by {duplicate}");
 
                 // these two components are required on all entities and cannot be overwritten.
                 if (duplicate is ITransformComponent || duplicate is IMetaDataComponent)
-                {
                     throw new InvalidOperationException("Tried to overwrite a protected component.");
-                }
 
                 RemoveComponentImmediate((Component) duplicate);
             }
@@ -262,18 +262,20 @@ namespace Robust.Shared.GameObjects
         {
             if (component == null) throw new ArgumentNullException(nameof(component));
 
-            if (component.Deleted) return;
-
-            // these two components are required on all entities and cannot be removed.
-            if (component is ITransformComponent || component is IMetaDataComponent)
+            if (!component.Deleted)
             {
-                DebugTools.Assert("Tried to remove a protected component.");
-                return;
-            }
+                // these two components are required on all entities and cannot be removed.
+                if (component is ITransformComponent || component is IMetaDataComponent)
+                {
+                    DebugTools.Assert("Tried to remove a protected component.");
+                    return;
+                }
 
-            component.Running = false;
-            component.OnRemove();
-            ComponentRemoved?.Invoke(this, new RemovedComponentEventArgs(component));
+                component.Running = false;
+                component.OnRemove(); // Sets delete
+                ComponentRemoved?.Invoke(this, new RemovedComponentEventArgs(component));
+
+            }
 
             DeleteComponent(component);
         }

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -16,11 +16,11 @@ namespace Robust.Shared.GameObjects
         #region Members
 
         /// <inheritdoc />
-        public IEntityManager EntityManager { get; private set; } = default!;
+        public IEntityManager EntityManager { get; }
 
         /// <inheritdoc />
         [ViewVariables]
-        public EntityUid Uid { get; private set; }
+        public EntityUid Uid { get; }
 
         /// <inheritdoc />
         [ViewVariables]
@@ -106,47 +106,16 @@ namespace Robust.Shared.GameObjects
 
         #region Initialization
 
-        /// <summary>
-        ///     Sets fundamental managers after the entity has been created.
-        /// </summary>
-        /// <remarks>
-        ///     This is a separate method because C# makes constructors painful.
-        /// </remarks>
-        /// <exception cref="InvalidOperationException">
-        ///     Thrown if the method is called and the entity already has initialized managers.
-        /// </exception>
-        public void SetManagers(IEntityManager entityManager)
+        public Entity(IEntityManager entityManager, EntityUid uid)
         {
-            if (EntityManager != null)
-            {
-                throw new InvalidOperationException("Entity already has initialized managers.");
-            }
-
             EntityManager = entityManager;
+            Uid = uid;
         }
 
         /// <inheritdoc />
         public bool IsValid()
         {
             return !Deleted;
-        }
-
-        /// <summary>
-        ///     Initialize the entity's UID. This can only be called once.
-        /// </summary>
-        /// <param name="uid">The new UID.</param>
-        /// <exception cref="InvalidOperationException">
-        ///     Thrown if the method is called and the entity already has a UID.
-        /// </exception>
-        public void SetUid(EntityUid uid)
-        {
-            if (!uid.IsValid())
-                throw new ArgumentException("Uid is not valid.", nameof(uid));
-
-            if (Uid.IsValid())
-                throw new InvalidOperationException("Entity already has a UID.");
-
-            Uid = uid;
         }
 
         /// <summary>

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -279,10 +279,7 @@ namespace Robust.Shared.GameObjects
                 throw new InvalidOperationException($"UID already taken: {uid}");
             }
 
-            var entity = new Entity();
-
-            entity.SetManagers(this);
-            entity.SetUid(uid.Value);
+            var entity = new Entity(this, uid.Value);
 
             // allocate the required MetaDataComponent
             _componentManager.AddComponent<MetaDataComponent>(entity);

--- a/Robust.UnitTesting/Shared/GameObjects/ComponentManager_Tests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/ComponentManager_Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Moq;
@@ -52,6 +52,25 @@ namespace Robust.UnitTesting.Shared.GameObjects
             // Assert
             var result = manager.GetComponent<DummyComponent>(entity.Uid);
             Assert.That(result, Is.EqualTo(component));
+        }
+
+        [Test]
+        public void AddComponent_ExistingDeleted()
+        {
+            // Arrange
+            var manager = ManagerFactory(out var entityManager);
+            var entity = EntityFactory(entityManager);
+            var firstComp = new DummyComponent {Owner = entity};
+            manager.AddComponent(entity, firstComp);
+            manager.RemoveComponent<DummyComponent>(entity.Uid);
+            var secondComp = new DummyComponent { Owner = entity };
+            
+            // Act
+            manager.AddComponent(entity, secondComp);
+
+            // Assert
+            var result = manager.GetComponent<DummyComponent>(entity.Uid);
+            Assert.That(result, Is.EqualTo(secondComp));
         }
 
         [Test]

--- a/Robust.UnitTesting/Shared/Physics/CollisionManager_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/CollisionManager_Test.cs
@@ -1,7 +1,8 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Linq;
 using Moq;
 using NUnit.Framework;
+using Robust.Server.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
@@ -138,7 +139,7 @@ namespace Robust.UnitTesting.Shared.Physics
 
             var mock = new Mock<IPhysBody>();
             mock.Setup(foo => foo.WorldAABB).Returns(box);
-            mock.Setup(foo => foo.Entity).Returns(new Entity()); // requires IPhysBody not have null owner
+            mock.Setup(foo => foo.Entity).Returns(new Entity(new ServerEntityManager(), EntityUid.FirstUid)); // requires IPhysBody not have null owner
             mock.Setup(foo => foo.CanCollide).Returns(true);
             mock.Setup(foo => foo.CollisionLayer).Returns(1);
             mock.Setup(foo => foo.CollisionMask).Returns(1);
@@ -167,7 +168,7 @@ namespace Robust.UnitTesting.Shared.Physics
 
             var mock = new Mock<IPhysBody>();
             mock.Setup(foo => foo.WorldAABB).Returns(box);
-            mock.Setup(foo => foo.Entity).Returns(new Entity()); // requires IPhysBody not have null owner
+            mock.Setup(foo => foo.Entity).Returns(new Entity(new ServerEntityManager(), EntityUid.FirstUid)); // requires IPhysBody not have null owner
             mock.Setup(foo => foo.CanCollide).Returns(true);
             mock.Setup(foo => foo.CollisionLayer).Returns(1);
             mock.Setup(foo => foo.CollisionMask).Returns(1);
@@ -189,8 +190,8 @@ namespace Robust.UnitTesting.Shared.Physics
             var ray = new CollisionRay(Vector2.UnitY, Vector2.UnitX, 1);
             var manager = new PhysicsManager();
 
-            var e1 = new Entity();
-            var e2 = new Entity();
+            var e1 = new Entity(new ServerEntityManager(), EntityUid.FirstUid);
+            var e2 = new Entity(new ServerEntityManager(), EntityUid.FirstUid);
 
             var m1 = new Mock<IPhysBody>();
             m1.Setup(foo => foo.WorldAABB).Returns(b1);


### PR DESCRIPTION
Fixes bug with an exception being throw when trying to overwrite a deleted Component.
Entity now uses constructor injection instead of property injection.

Resolves https://github.com/space-wizards/RobustToolbox/issues/1580.