### PR TITLE
Fix for Crash Caused by the Entity Spawn Menu

### DIFF
--- a/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
+++ b/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
@@ -239,7 +239,7 @@ namespace Robust.Client.UserInterface.CustomControls
 
             // Calculate index of first prototype to render based on current scroll.
             var height = MeasureButton.DesiredSize.Y + PrototypeListContainer.Separation;
-            var offset = -PrototypeList.Position.Y;
+            var offset = Math.Max(-PrototypeList.Position.Y, 0);
             var startIndex = (int) Math.Floor(offset / height);
             PrototypeList.ItemOffset = startIndex;
 


### PR DESCRIPTION
The entity spawn menu was having an index out of range error, caused by some funky math with the offset number. With this change, the startIndex will no longer point to out of range numbers like -3 and will be clamped at 0.