### PR TITLE
Adds args.Handle(); into UI code for scrolling

### DIFF
--- a/Robust.Client/UserInterface/Controls/ItemList.cs
+++ b/Robust.Client/UserInterface/Controls/ItemList.cs
@@ -473,6 +473,8 @@ namespace Robust.Client.UserInterface.Controls
 
             _scrollBar.ValueTarget -= _getScrollSpeed() * args.Delta.Y;
             _isAtBottom = _scrollBar.IsAtEnd;
+
+            args.Handle();
         }
 
         [Pure]

--- a/Robust.Client/UserInterface/Controls/ScrollContainer.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollContainer.cs
@@ -204,6 +204,8 @@ namespace Robust.Client.UserInterface.Controls
             {
                 _hScrollBar.ValueTarget += args.Delta.X * 50;
             }
+
+            args.Handle();
         }
 
         protected override void ChildAdded(Control newChild)


### PR DESCRIPTION
Adds args.Handle(); under ItemList.cs and ScrollContainer.cs, which fixes same problems with both scrollsbars scrolling at the same time.