### PR TITLE
Fix buckling

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
@@ -46,7 +46,7 @@ namespace Robust.Shared.GameObjects
                     grid.GridEntityId != entity.Uid)
                 {
                     // Also this may deparent if 2 entities are parented but not using containers so fix that
-                    if (grid.GridEntityId != transform.ParentUid)
+                    if (grid.Index != transform.GridID)
                     {
                         transform.AttachParent(EntityManager.GetEntity(grid.GridEntityId));
                     }


### PR DESCRIPTION
Change the check to use the recursive grid id check instead of only parent entity id.