### PR TITLE
Make Visible a Shared Property for sprites

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -36,7 +36,7 @@ namespace Robust.Client.GameObjects
         private bool _visible = true;
 
         [ViewVariables(VVAccess.ReadWrite)]
-        public bool Visible
+        public override bool Visible
         {
             get => _visible;
             set => _visible = value;

--- a/Robust.Server/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Server/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -54,17 +54,19 @@ namespace Robust.Server.GameObjects
             get => _drawDepth;
             set
             {
+                if (_drawDepth == value) return;
                 _drawDepth = value;
                 Dirty();
             }
         }
 
         [ViewVariables(VVAccess.ReadWrite)]
-        public bool Visible
+        public override bool Visible
         {
             get => _visible;
             set
             {
+                if (_visible == value) return;
                 _visible = value;
                 Dirty();
             }

--- a/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
@@ -7,10 +7,12 @@ using Robust.Shared.Utility;
 
 namespace Robust.Shared.GameObjects
 {
-    public class SharedSpriteComponent : Component
+    public abstract class SharedSpriteComponent : Component
     {
         public override string Name => "Sprite";
         public override uint? NetID => NetIDs.SPRITE;
+
+        public abstract bool Visible { get; set; }
 
         /// <summary>
         ///     The resource path from which all texture paths are relative to.


### PR DESCRIPTION
Looking at moving SubFloorSystem to shared for content and being able to use Visible on SharedSprite is easier (should probably have all the properties on shared?)