### PR TITLE
Fix physics joint disconnect spam

### DIFF
--- a/Robust.Shared/Physics/Dynamics/PhysicsMap.cs
+++ b/Robust.Shared/Physics/Dynamics/PhysicsMap.cs
@@ -342,6 +342,8 @@ namespace Robust.Shared.Physics.Dynamics
             {
                 bool collideConnected = joint.CollideConnected;
 
+                // TODO: See above how much I hate joints rn
+                if (!Joints.Contains(joint)) continue;
                 // Remove from the world list.
                 Joints.Remove(joint);
 


### PR DESCRIPTION
Turns out this method is used in Farseer (and the similar one in Aether2D) only when you're purging all joints so we'll just add a check to it. I'd really like to improve joints but right now it's low prio compared to performance (this was just a low-hanging fruit optimisation for client).