### PR TITLE
Add a CVar to disable texture preloading for tests

### DIFF
--- a/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
+++ b/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
@@ -3,6 +3,8 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Robust.Client.Graphics;
+using Robust.Shared;
+using Robust.Shared.Configuration;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 
@@ -12,10 +14,17 @@ namespace Robust.Client.ResourceManagement
     {
         [Dependency] private readonly IClyde _clyde = default!;
         [Dependency] private readonly ILogManager _logManager = default!;
+        [Dependency] private readonly IConfigurationManager _configurationManager = default!;
 
         public void PreloadTextures()
         {
             var sawmill = _logManager.GetSawmill("res.preload");
+
+            if (!_configurationManager.GetCVar(CVars.TexturePreloadingEnabled))
+            {
+                sawmill.Debug($"Skipping texture preloading due to CVar value.");
+                return;
+            }
 
             PreloadTextures(sawmill);
             PreloadRsis(sawmill);

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -400,5 +400,8 @@ namespace Robust.Shared
 
         public static readonly CVarDef<bool> ResCheckPathCasing =
             CVarDef.Create("res.checkpathcasing", false);
+
+        public static readonly CVarDef<bool> TexturePreloadingEnabled =
+            CVarDef.Create("res.texturepreloadingenabled", true, CVar.CLIENTONLY);
     }
 }


### PR DESCRIPTION
Required for https://github.com/space-wizards/space-station-14/pull/3625

Profile of an empty test that starts the client:
![rider64_LxWiiH6GKa](https://user-images.githubusercontent.com/10968691/110956652-2155f780-834b-11eb-9f14-fe9bb2a8431d.png)
