### PR TITLE
Network View Bubble

### DIFF
--- a/Robust.Client/GameStates/NetEntityOverlay.cs
+++ b/Robust.Client/GameStates/NetEntityOverlay.cs
@@ -225,7 +225,7 @@ namespace Robust.Client.GameStates
             {
                 if (args.Length != 1)
                 {
-                    shell.WriteError("Invalid argument amount. Expected 2 arguments.");
+                    shell.WriteError("Invalid argument amount. Expected 1 arguments.");
                     return;
                 }
 

--- a/Robust.Client/GameStates/NetEntityOverlay.cs
+++ b/Robust.Client/GameStates/NetEntityOverlay.cs
@@ -97,9 +97,9 @@ namespace Robust.Client.GameStates
             }
 
             bool pvsEnabled = _configurationManager.GetCVar<bool>("net.pvs");
-            float pvsSize = _configurationManager.GetCVar<float>("net.maxupdaterange");
+            float pvsRange = _configurationManager.GetCVar<float>("net.maxupdaterange");
             var pvsCenter = _eyeManager.CurrentEye.Position;
-            Box2 pvsBox = Box2.CenteredAround(pvsCenter.Position, new Vector2(pvsSize, pvsSize));
+            Box2 pvsBox = Box2.CenteredAround(pvsCenter.Position, new Vector2(pvsRange*2, pvsRange*2));
 
             int timeout = _gameTiming.TickRate * 3;
             for (int i = 0; i < _netEnts.Count; i++)

--- a/Robust.Client/GameStates/NetEntityOverlay.cs
+++ b/Robust.Client/GameStates/NetEntityOverlay.cs
@@ -10,6 +10,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Maths;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Robust.Client.GameStates
 {
@@ -167,9 +168,16 @@ namespace Robust.Client.GameStates
             {
                 var netEnt = _netEnts[i];
 
+                if (!_entityManager.TryGetEntity(netEnt.Id, out var ent))
+                {
+                    _netEnts.RemoveSwap(i);
+                    i--;
+                    continue;
+                }
+
                 var xPos = 100;
                 var yPos = 10 + _lineHeight * i;
-                var name = $"({netEnt.Id}) {_entityManager.GetEntity(netEnt.Id).Prototype?.ID}";
+                var name = $"({netEnt.Id}) {ent.Prototype?.ID}";
                 var color = CalcTextColor(ref netEnt);
                 DrawString(screenHandle, _font, new Vector2(xPos + (TrafficHistorySize + 4), yPos), name, color);
                 DrawTrafficBox(screenHandle, ref netEnt, xPos, yPos);

--- a/Robust.Client/GameStates/NetGraphOverlay.cs
+++ b/Robust.Client/GameStates/NetGraphOverlay.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Shared.Enums;
 using Robust.Shared.Console;
+using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Maths;
 using Robust.Shared.Network;
@@ -36,6 +38,10 @@ namespace Robust.Client.GameStates
 
         private readonly List<(GameTick Tick, int Payload, int lag, int interp)> _history = new(HistorySize+10);
 
+        private int _totalHistoryPayload; // sum of all data point sizes in bytes
+
+        public EntityUid WatchEntId { get; set; }
+
         public NetGraphOverlay()
         {
             IoCManager.InjectDependencies(this);
@@ -60,7 +66,73 @@ namespace Robust.Client.GameStates
             // calc interp info
             var interpBuff = _gameStateManager.CurrentBufferSize - _gameStateManager.MinBufferSize;
 
+            _totalHistoryPayload += sz;
             _history.Add((toSeq, sz, lag, interpBuff));
+
+            // not watching an ent
+            if(!WatchEntId.IsValid() || WatchEntId.IsClientSide())
+                return;
+
+            string? entStateString = null;
+            string? entDelString = null;
+            var conShell = IoCManager.Resolve<IConsoleHost>().LocalShell;
+
+            var entStates = args.AppliedState.EntityStates;
+            if (entStates is not null)
+            {
+                var sb = new StringBuilder();
+                foreach (var entState in entStates)
+                {
+                    if (entState.Uid == WatchEntId)
+                    {
+                        if(entState.ComponentChanges is not null)
+                        {
+                            sb.Append($"\n  Changes:");
+                            foreach (var compChange in entState.ComponentChanges)
+                            {
+                                var del = compChange.Deleted ? 'D' : 'C';
+                                sb.Append($"\n    [{del}]{compChange.NetID}:{compChange.ComponentName}");
+                            }
+                        }
+
+                        if (entState.ComponentStates is not null)
+                        {
+                            sb.Append($"\n  States:");
+                            foreach (var compState in entState.ComponentStates)
+                            {
+                                sb.Append($"\n    {compState.NetID}:{compState.GetType().Name}");
+                            }
+                        }
+                    }
+                }
+                entStateString = sb.ToString();
+            }
+
+            var entDeletes = args.AppliedState.EntityDeletions;
+            if (entDeletes is not null)
+            {
+                var sb = new StringBuilder();
+                foreach (var entDelete in entDeletes)
+                {
+                    if (entDelete == WatchEntId)
+                    {
+                        entDelString = "\n  Deleted";
+                    }
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(entStateString) || !string.IsNullOrWhiteSpace(entDelString))
+            {
+                var fullString = $"watchEnt: from={args.AppliedState.FromSequence}, to={args.AppliedState.ToSequence}, eid={WatchEntId}";
+                if (!string.IsNullOrWhiteSpace(entStateString))
+                    fullString += entStateString;
+
+                if (!string.IsNullOrWhiteSpace(entDelString))
+                    fullString += entDelString;
+
+                conShell.WriteLine(fullString + "\n");
+            }
+
         }
 
         /// <inheritdoc />
@@ -69,10 +141,16 @@ namespace Robust.Client.GameStates
             base.FrameUpdate(args);
 
             var over = _history.Count - HistorySize;
-            if (over > 0)
+            if (over <= 0)
+                return;
+
+            for (int i = 0; i < over; i++)
             {
-                _history.RemoveRange(0, over);
+                var point = _history[i];
+                _totalHistoryPayload -= point.Payload;
             }
+
+            _history.RemoveRange(0, over);
         }
 
         protected override void Draw(DrawingHandleBase handle, OverlaySpace currentSpace)
@@ -82,6 +160,7 @@ namespace Robust.Client.GameStates
             var leftMargin = 300;
             var width = HistorySize;
             var height = 500;
+            var drawSizeThreshold = Math.Min(_totalHistoryPayload / HistorySize, 300);
 
             // bottom payload line
             handle.DrawLine(new Vector2(leftMargin, height), new Vector2(leftMargin + width, height), Color.DarkGray.WithAlpha(0.8f));
@@ -100,6 +179,12 @@ namespace Robust.Client.GameStates
                 var xOff = leftMargin + i;
                 var yoff = height - state.Payload / BytesPerPixel;
                 handle.DrawLine(new Vector2(xOff, height), new Vector2(xOff, yoff), Color.LightGreen.WithAlpha(0.8f));
+
+                // Draw size if above average
+                if (drawSizeThreshold * 1.5 < state.Payload)
+                {
+                    DrawString((DrawingHandleScreen) handle, _font, new Vector2(xOff, yoff - _font.GetLineHeight(1)), state.Payload.ToString());
+                }
 
                 // second tick marks
                 if (state.Tick.Value % _gameTiming.TickRate == 0)
@@ -124,6 +209,10 @@ namespace Robust.Client.GameStates
 
                 handle.DrawLine(new Vector2(xOff, height + LowerGraphOffset), new Vector2(xOff, height + LowerGraphOffset + state.interp * 6), interpColor.WithAlpha(0.8f));
             }
+
+            // average payload line
+            var avgyoff = height - drawSizeThreshold / BytesPerPixel;
+            handle.DrawLine(new Vector2(leftMargin, avgyoff), new Vector2(leftMargin + width, avgyoff), Color.DarkGray.WithAlpha(0.8f));
 
             // top payload warning line
             var warnYoff = height - _warningPayloadSize / BytesPerPixel;
@@ -194,6 +283,37 @@ namespace Robust.Client.GameStates
                 {
                     overlayMan.RemoveOverlay(typeof(NetGraphOverlay));
                     shell.WriteLine("Disabled network overlay.");
+                }
+            }
+        }
+
+        private class NetWatchEntCommand : IConsoleCommand
+        {
+            public string Command => "net_watchent";
+            public string Help => "net_watchent <0|EntityUid>";
+            public string Description => "Dumps all network updates for an EntityId to the console.";
+
+            public void Execute(IConsoleShell shell, string argStr, string[] args)
+            {
+                if (args.Length != 1)
+                {
+                    shell.WriteError("Invalid argument amount. Expected 1 argument.");
+                    return;
+                }
+
+                if (!EntityUid.TryParse(args[0], out var eValue))
+                {
+                    shell.WriteError("Invalid argument: Needs to be 0 or an entityId.");
+                    return;
+                }
+                
+                var overlayMan = IoCManager.Resolve<IOverlayManager>();
+                
+                if (overlayMan.HasOverlay(typeof(NetGraphOverlay)))
+                {
+                    var netOverlay = overlayMan.GetOverlay<NetGraphOverlay>();
+
+                    netOverlay.WatchEntId = eValue;
                 }
             }
         }

--- a/Robust.Client/Graphics/Overlays/OverlayManager.cs
+++ b/Robust.Client/Graphics/Overlays/OverlayManager.cs
@@ -87,11 +87,11 @@ namespace Robust.Client.Graphics
         public bool HasOverlay(Type overlayClass) {
             if (!overlayClass.IsSubclassOf(typeof(Overlay)))
                 Logger.Error("HasOverlay was called with arg: " + overlayClass.ToString() + ", which is not a subclass of Overlay!");
-            return _overlays.Remove(overlayClass);
+            return _overlays.ContainsKey(overlayClass);
         }
 
         public bool HasOverlay<T>() where T : Overlay  {
-            return _overlays.Remove(typeof(T));
+            return _overlays.ContainsKey(typeof(T));
         }
 
     }

--- a/Robust.Server/GameObjects/IServerEntityManager.cs
+++ b/Robust.Server/GameObjects/IServerEntityManager.cs
@@ -1,51 +1,9 @@
-﻿using System.Collections.Generic;
-using Robust.Server.Player;
 using Robust.Shared.GameObjects;
-using Robust.Shared.Players;
-using Robust.Shared.Timing;
 
 namespace Robust.Server.GameObjects
 {
-    public interface IServerEntityManager : IEntityManager
-    {
-        /// <summary>
-        ///     Gets all entity states that have been modified after and including the provided tick.
-        /// </summary>
-        List<EntityState>? GetEntityStates(ICommonSession player, GameTick fromTick);
-
-        /// <summary>
-        ///     Gets all entity states within an AABB that have been modified after and including the provided tick.
-        /// </summary>
-        List<EntityState>? UpdatePlayerSeenEntityStates(GameTick fromTick, IPlayerSession player, float range);
-
-        // Keep track of deleted entities so we can sync deletions with the client.
-        /// <summary>
-        ///     Gets a list of all entity UIDs that were deleted between <paramref name="fromTick" /> and now.
-        /// </summary>
-        List<EntityUid>? GetDeletedEntities(GameTick fromTick);
-
-        /// <summary>
-        ///     Remove deletion history.
-        /// </summary>
-        /// <param name="toTick">The last tick to delete the history for. Inclusive.</param>
-        void CullDeletionHistory(GameTick toTick);
-
-        /// <summary>
-        ///     Removes entity state persistence information from the entity manager for a player.
-        /// </summary>
-        /// <param name="player"></param>
-        void DropPlayerState(IPlayerSession player);
-
-        float MaxUpdateRange { get; }
-
-        /// <summary>
-        /// Generates a network entity state for the given entity.
-        /// </summary>
-        /// <param name="compMan">ComponentManager that contains the components for the entity.</param>
-        /// <param name="entityUid">Uid of the entity to generate the state from.</param>
-        /// <param name="fromTick">Only provide delta changes from this tick.</param>
-        /// <param name="player">The player to generate this state for.</param>
-        /// <returns>New entity State for the given entity.</returns>
-        EntityState GetEntityState(EntityUid entityUid, GameTick fromTick, ICommonSession player);
-    }
+    /// <summary>
+    /// Server side version of the <see cref="IEntityManager"/>.
+    /// </summary>
+    public interface IServerEntityManager : IEntityManager { }
 }

--- a/Robust.Server/GameObjects/IServerEntityManager.cs
+++ b/Robust.Server/GameObjects/IServerEntityManager.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Robust.Server.Player;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Players;
 using Robust.Shared.Timing;
 
 namespace Robust.Server.GameObjects
@@ -10,7 +11,7 @@ namespace Robust.Server.GameObjects
         /// <summary>
         ///     Gets all entity states that have been modified after and including the provided tick.
         /// </summary>
-        List<EntityState>? GetEntityStates(GameTick fromTick, IPlayerSession player);
+        List<EntityState>? GetEntityStates(ICommonSession player, GameTick fromTick);
 
         /// <summary>
         ///     Gets all entity states within an AABB that have been modified after and including the provided tick.
@@ -37,5 +38,14 @@ namespace Robust.Server.GameObjects
 
         float MaxUpdateRange { get; }
 
+        /// <summary>
+        /// Generates a network entity state for the given entity.
+        /// </summary>
+        /// <param name="compMan">ComponentManager that contains the components for the entity.</param>
+        /// <param name="entityUid">Uid of the entity to generate the state from.</param>
+        /// <param name="fromTick">Only provide delta changes from this tick.</param>
+        /// <param name="player">The player to generate this state for.</param>
+        /// <returns>New entity State for the given entity.</returns>
+        EntityState GetEntityState(EntityUid entityUid, GameTick fromTick, ICommonSession player);
     }
 }

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -1,53 +1,28 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
+using JetBrains.Annotations;
 using Prometheus;
-using Robust.Server.Player;
-using Robust.Shared;
-using Robust.Shared.Configuration;
-using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 using Robust.Shared.Map;
-using Robust.Shared.Maths;
-using Robust.Shared.Physics;
-using Robust.Shared.Players;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
-using Robust.Shared.Utility;
-using static Robust.Shared.GameObjects.TransformComponent;
 
 namespace Robust.Server.GameObjects
 {
     /// <summary>
     /// Manager for entities -- controls things like template loading and instantiation
     /// </summary>
+    [UsedImplicitly] // DI Container
     public sealed class ServerEntityManager : EntityManager, IServerEntityManagerInternal
     {
         private static readonly Gauge EntitiesCount = Metrics.CreateGauge(
             "robust_entities_count",
             "Amount of alive entities.");
 
-        #region IEntityManager Members
-
-        [Shared.IoC.Dependency] private readonly IMapManager _mapManager = default!;
-        [Shared.IoC.Dependency] private readonly IPauseManager _pauseManager = default!;
-        [Shared.IoC.Dependency] private readonly IConfigurationManager _configurationManager = default!;
-
-        private float? _maxUpdateRangeCache;
-
-        public float MaxUpdateRange => _maxUpdateRangeCache
-            ??= _configurationManager.GetCVar(CVars.NetMaxUpdateRange);
+        [Dependency] private readonly IMapManager _mapManager = default!;
+        [Dependency] private readonly IPauseManager _pauseManager = default!;
 
         private int _nextServerEntityUid = (int) EntityUid.FirstUid;
-
-        private readonly List<(GameTick tick, EntityUid uid)> _deletionHistory = new();
-
-        public override void Update()
-        {
-            base.Update();
-            _maxUpdateRangeCache = null;
-        }
 
         /// <inheritdoc />
         public override IEntity CreateEntityUninitialized(string? prototypeName)
@@ -78,33 +53,6 @@ namespace Robust.Server.GameObjects
             return newEntity;
         }
 
-        private Entity CreateEntityServer(string? prototypeName)
-        {
-            var entity = CreateEntity(prototypeName);
-
-            if (prototypeName != null)
-            {
-                var prototype = PrototypeManager.Index<EntityPrototype>(prototypeName);
-
-                // At this point in time, all data configure on the entity *should* be purely from the prototype.
-                // As such, we can reset the modified ticks to Zero,
-                // which indicates "not different from client's own deserialization".
-                // So the initial data for the component or even the creation doesn't have to be sent over the wire.
-                foreach (var component in ComponentManager.GetNetComponents(entity.Uid))
-                {
-                    // Make sure to ONLY get components that are defined in the prototype.
-                    // Others could be instantiated directly by AddComponent (e.g. ContainerManager).
-                    // And those aren't guaranteed to exist on the client, so don't clear them.
-                    if (prototype.Components.ContainsKey(component.Name))
-                    {
-                        ((Component) component).ClearTicks();
-                    }
-                }
-            }
-
-            return entity;
-        }
-
         /// <inheritdoc />
         public override IEntity SpawnEntity(string? protoName, EntityCoordinates coordinates)
         {
@@ -115,10 +63,7 @@ namespace Robust.Server.GameObjects
 
             InitializeAndStartEntity((Entity) entity);
 
-            if (_pauseManager.IsMapInitialized(coordinates.GetMapId(this)))
-            {
-                entity.RunMapInit();
-            }
+            if (_pauseManager.IsMapInitialized(coordinates.GetMapId(this))) entity.RunMapInit();
 
             return entity;
         }
@@ -132,722 +77,24 @@ namespace Robust.Server.GameObjects
         }
 
         /// <inheritdoc />
-        public List<EntityState>? GetEntityStates(ICommonSession player, GameTick fromTick)
+        public override void Startup()
         {
-            var stateEntities = new List<EntityState>();
-            foreach (var entity in AllEntities)
-            {
-                if (entity.Deleted)
-                {
-                    continue;
-                }
-
-                DebugTools.Assert(entity.Initialized);
-
-                if (entity.LastModifiedTick <= fromTick)
-                    continue;
-
-                stateEntities.Add(GetEntityState(entity.Uid, fromTick, player));
-            }
-
-            // no point sending an empty collection
-            return stateEntities.Count == 0 ? default : stateEntities;
+            base.Startup();
+            EntitySystemManager.Initialize();
+            Started = true;
         }
-
-        private readonly Dictionary<IPlayerSession, SortedSet<EntityUid>> _seenMovers
-            = new();
-
-        // Is thread safe.
-
-        private SortedSet<EntityUid> GetSeenMoversUnlocked(IPlayerSession player)
-        {
-            if (!_seenMovers.TryGetValue(player, out var movers))
-            {
-                movers = new SortedSet<EntityUid>();
-                _seenMovers.Add(player, movers);
-            }
-
-            return movers;
-        }
-
-        private void AddToSeenMovers(IPlayerSession player, EntityUid entityUid)
-        {
-            var movers = GetSeenMoversUnlocked(player);
-
-            movers.Add(entityUid);
-        }
-
-        private readonly Dictionary<IPlayerSession, Dictionary<EntityUid, GameTick>> _playerLastSeen
-            = new();
-
-        private static readonly Vector2 Vector2NaN = new(float.NaN, float.NaN);
-
-        private Dictionary<EntityUid, GameTick> GetLastSeen(IPlayerSession player)
-        {
-            lock (_playerLastSeen)
-            {
-                if (!_playerLastSeen.TryGetValue(player, out var lastSeen))
-                {
-                    lastSeen = new Dictionary<EntityUid, GameTick>();
-                    _playerLastSeen.Add(player, lastSeen);
-                }
-
-                return lastSeen;
-            }
-        }
-
-        private static GameTick GetLastSeenTick(Dictionary<EntityUid, GameTick> lastSeen, EntityUid uid)
-        {
-            if (!lastSeen.TryGetValue(uid, out var tick))
-            {
-                tick = GameTick.First;
-            }
-
-            return tick;
-        }
-
-        private static GameTick UpdateLastSeenTick(Dictionary<EntityUid, GameTick> lastSeen, EntityUid uid, GameTick newTick)
-        {
-            if (!lastSeen.TryGetValue(uid, out var oldTick))
-            {
-                oldTick = GameTick.First;
-            }
-
-            lastSeen[uid] = newTick;
-
-            return oldTick;
-        }
-
-        private static IEnumerable<EntityUid> GetLastSeenAfter(Dictionary<EntityUid, GameTick> lastSeen, GameTick fromTick)
-        {
-            foreach (var (uid, tick) in lastSeen)
-            {
-                if (tick > fromTick)
-                {
-                    yield return uid;
-                }
-            }
-        }
-
-        private IEnumerable<EntityUid> GetLastSeenOn(Dictionary<EntityUid, GameTick> lastSeen, GameTick fromTick)
-        {
-            foreach (var (uid, tick) in lastSeen)
-            {
-                if (tick == fromTick)
-                {
-                    yield return uid;
-                }
-            }
-        }
-
-        private static void SetLastSeenTick(Dictionary<EntityUid, GameTick> lastSeen, EntityUid uid, GameTick tick)
-        {
-            lastSeen[uid] = tick;
-        }
-
-        private static void ClearLastSeenTick(Dictionary<EntityUid, GameTick> lastSeen, EntityUid uid)
-        {
-            lastSeen.Remove(uid);
-        }
-
-        public void DropPlayerState(IPlayerSession player)
-        {
-            lock (_playerLastSeen)
-            {
-                _playerLastSeen.Remove(player);
-            }
-        }
-
-        private static void IncludeRelatives(IEnumerable<IEntity> children, HashSet<IEntity> set)
-        {
-            foreach (var child in children)
-            {
-                var ent = child!;
-
-                while (ent != null && !ent.Deleted)
-                {
-                    if (set.Add(ent))
-                    {
-                        AddContainedRecursive(ent, set);
-
-                        ent = ent.Transform.Parent?.Owner!;
-                    }
-                    else
-                    {
-                        // Already processed this entity once.
-                        break;
-                    }
-                }
-            }
-        }
-
-        private static void AddContainedRecursive(IEntity ent, HashSet<IEntity> set)
-        {
-            if (!ent.TryGetComponent(out ContainerManagerComponent? contMgr))
-            {
-                return;
-            }
-
-            foreach (var container in contMgr.GetAllContainers())
-            {
-                // Manual for loop to cut out allocations.
-                // ReSharper disable once ForCanBeConvertedToForeach
-                for (var i = 0; i < container.ContainedEntities.Count; i++)
-                {
-                    var contEnt = container.ContainedEntities[i];
-                    set.Add(contEnt);
-                    AddContainedRecursive(contEnt, set);
-                }
-            }
-        }
-
-        private class PlayerSeenEntityStatesResources
-        {
-            public readonly HashSet<EntityUid> IncludedEnts = new();
-
-            public readonly List<EntityState> EntityStates = new();
-
-            public readonly HashSet<EntityUid> NeededEnts = new();
-
-            public readonly HashSet<IEntity> Relatives = new();
-        }
-
-        private readonly ThreadLocal<PlayerSeenEntityStatesResources> _playerSeenEntityStatesResources
-            = new(() => new PlayerSeenEntityStatesResources());
 
         /// <inheritdoc />
-        public List<EntityState>? UpdatePlayerSeenEntityStates(GameTick fromTick, IPlayerSession player, float range)
+        public override void TickUpdate(float frameTime, Histogram? histogram)
         {
-            const float MinimumMotionForMovers = 1 / 128f;
+            base.TickUpdate(frameTime, histogram);
 
-            var playerEnt = player.AttachedEntity;
-            if (playerEnt == null)
-            {
-                // super-observer?
-                return GetEntityStates(player, fromTick);
-            }
-
-            var playerUid = playerEnt.Uid;
-
-            var transform = playerEnt.Transform;
-            var position = transform.WorldPosition;
-            var mapId = transform.MapID;
-            var viewbox = new Box2(position, position).Enlarged(MaxUpdateRange);
-
-            SortedSet<EntityUid> ret;
-            lock (_seenMovers)
-            {
-                ret = GetSeenMoversUnlocked(player);
-            }
-
-            var seenMovers = ret;
-            var lSeen = GetLastSeen(player);
-
-            var pseStateRes = _playerSeenEntityStatesResources.Value!;
-            var checkedEnts = pseStateRes.IncludedEnts;
-            var entityStates = pseStateRes.EntityStates;
-            var neededEnts = pseStateRes.NeededEnts;
-            var relatives = pseStateRes.Relatives;
-            checkedEnts.Clear();
-            entityStates.Clear();
-            neededEnts.Clear();
-            relatives.Clear();
-
-            foreach (var uid in seenMovers.ToList())
-            {
-                if (!TryGetEntity(uid, out var entity) || entity.Deleted)
-                {
-                    seenMovers.Remove(uid);
-                    continue;
-                }
-
-                if (entity.TryGetComponent(out IPhysBody? body))
-                {
-                    if (body.LinearVelocity.EqualsApprox(Vector2.Zero, MinimumMotionForMovers))
-                    {
-                        if (AnyParentInSet(uid, seenMovers))
-                        {
-                            // parent is moving
-                            continue;
-                        }
-
-                        if (MathF.Abs(body.AngularVelocity) > 0)
-                        {
-                            if (entity.TryGetComponent(out TransformComponent? txf) && txf.ChildCount > 0)
-                            {
-                                // has children spinning
-                                continue;
-                            }
-                        }
-
-                        seenMovers.Remove(uid);
-                    }
-                }
-
-                var state = GetEntityState(uid, fromTick, player);
-
-                if (checkedEnts.Add(uid))
-                {
-                    entityStates.Add(state);
-
-                    // mover did not change
-                    if (state.ComponentStates != null)
-                    {
-                        // mover can be seen
-                        if (!viewbox.Intersects(GetWorldAabbFromEntity(entity)))
-                        {
-                            // mover changed and can't be seen
-                            var idx = Array.FindIndex(state.ComponentStates,
-                                x => x is TransformComponentState);
-
-                            if (idx != -1)
-                            {
-                                // mover changed positional data and can't be seen
-                                var oldState =
-                                    (TransformComponentState) state.ComponentStates[idx];
-                                var newState = new TransformComponentState(Vector2NaN,
-                                    oldState.Rotation, oldState.ParentID, oldState.NoLocalRotation);
-                                state.ComponentStates[idx] = newState;
-                                seenMovers.Remove(uid);
-                                ClearLastSeenTick(lSeen, uid);
-
-                                checkedEnts.Add(uid);
-
-                                var needed = oldState.ParentID;
-                                if (!needed.IsValid() || checkedEnts.Contains(needed))
-                                {
-                                    // either no parent attached or parent already included
-                                    continue;
-                                }
-
-                                if (GetLastSeenTick(lSeen, needed) == GameTick.Zero)
-                                {
-                                    neededEnts.Add(needed);
-                                }
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    // mover already added?
-                    if (!viewbox.Intersects(GetWorldAabbFromEntity(entity)))
-                    {
-                        // mover can't be seen
-                        var oldState =
-                            (TransformComponentState) entity.Transform.GetComponentState(player);
-                        entityStates.Add(new EntityState(uid,
-                            new ComponentChanged[]
-                            {
-                                new(false, NetIDs.TRANSFORM, "Transform")
-                            },
-                            new ComponentState[]
-                            {
-                                new TransformComponentState(Vector2NaN, oldState.Rotation,
-                                    oldState.ParentID, oldState.NoLocalRotation)
-                            }));
-
-                        seenMovers.Remove(uid);
-                        ClearLastSeenTick(lSeen, uid);
-                        checkedEnts.Add(uid);
-
-                        var needed = oldState.ParentID;
-                        if (!needed.IsValid() || checkedEnts.Contains(needed))
-                        {
-                            // either no parent attached or parent already included
-                            continue;
-                        }
-
-                        if (GetLastSeenTick(lSeen, needed) == GameTick.Zero)
-                        {
-                            neededEnts.Add(needed);
-                        }
-                    }
-                }
-            }
-
-            var currentTick = CurrentTick;
-
-            // scan pvs box and include children and parents recursively
-            IncludeRelatives(GetEntitiesInRange(mapId, position, range, true), relatives);
-
-            if (player.AttachedEntity is null || !player.AttachedEntity.TryGetComponent<EyeComponent>(out var eyeComp))
-                eyeComp = null;
-
-            // Exclude any entities that are currently invisible to the player.
-            ExcludeInvisible(relatives, eyeComp?.VisibilityMask ?? 0);
-
-            // Always send updates for all grid and map entities.
-            // If we don't, the client-side game state manager WILL blow up.
-            // TODO: Make map manager netcode aware of PVS to avoid the need for this workaround.
-            IncludeMapCriticalEntities(relatives);
-
-            foreach (var entity in relatives)
-            {
-                DebugTools.Assert(entity.Initialized && !entity.Deleted);
-
-                var lastChange = entity.LastModifiedTick;
-
-                var uid = entity.Uid;
-
-                var lastSeen = UpdateLastSeenTick(lSeen, uid, currentTick);
-
-                DebugTools.Assert(lastSeen != currentTick);
-
-                /*
-                if (uid != playerUid && entity.Prototype == playerEnt.Prototype && lastSeen < fromTick)
-                {
-                    Logger.DebugS("pvs", $"Player {playerUid} is seeing player {uid}.");
-                }
-                */
-
-                if (checkedEnts.Contains(uid))
-                {
-                    // already have it
-                    continue;
-                }
-
-                if (lastChange <= lastSeen)
-                {
-                    // hasn't changed since last seen
-                    continue;
-                }
-
-                // should this be lastSeen or fromTick?
-                var entityState = GetEntityState(uid, lastSeen, player);
-
-                checkedEnts.Add(uid);
-
-                if (entityState.ComponentStates == null)
-                {
-                    // no changes
-                    continue;
-                }
-
-                entityStates.Add(entityState);
-
-                if (uid == playerUid)
-                {
-                    continue;
-                }
-
-                if (!entity.TryGetComponent(out IPhysBody? body))
-                {
-                    // can't be a mover w/o physics
-                    continue;
-                }
-
-                if (!body.LinearVelocity.EqualsApprox(Vector2.Zero, MinimumMotionForMovers))
-                {
-                    // has motion
-                    seenMovers.Add(uid);
-                }
-                else
-                {
-                    // not moving
-                    seenMovers.Remove(uid);
-                }
-            }
-
-            var priorTick = new GameTick(fromTick.Value - 1);
-            foreach (var uid in GetLastSeenOn(lSeen, priorTick))
-            {
-                if (checkedEnts.Contains(uid))
-                {
-                    continue;
-                }
-
-                if (uid == playerUid)
-                {
-                    continue;
-                }
-
-                if (!TryGetEntity(uid, out var entity) || entity.Deleted)
-                {
-                    // TODO: remove from states list being sent?
-                    continue;
-                }
-
-                if (viewbox.Intersects(GetWorldAabbFromEntity(entity)))
-                {
-                    // can be seen
-                    continue;
-                }
-
-                var state = GetEntityState(uid, fromTick, player);
-
-                if (state.ComponentStates == null)
-                {
-                    // nothing changed
-                    continue;
-                }
-
-                checkedEnts.Add(uid);
-                entityStates.Add(state);
-
-                seenMovers.Remove(uid);
-                ClearLastSeenTick(lSeen, uid);
-
-                var idx = Array.FindIndex(state.ComponentStates, x => x is TransformComponentState);
-
-                if (idx == -1)
-                {
-                    // no transform changes
-                    continue;
-                }
-
-                var oldState = (TransformComponentState) state.ComponentStates[idx];
-                var newState =
-                    new TransformComponentState(Vector2NaN, oldState.Rotation, oldState.ParentID, oldState.NoLocalRotation);
-                state.ComponentStates[idx] = newState;
-
-
-                var needed = oldState.ParentID;
-                if (!needed.IsValid() || checkedEnts.Contains(needed))
-                {
-                    // don't need to include parent or already included
-                    continue;
-                }
-
-                if (GetLastSeenTick(lSeen, needed) == GameTick.First)
-                {
-                    neededEnts.Add(needed);
-                }
-            }
-
-            do
-            {
-                var moreNeededEnts = new HashSet<EntityUid>();
-
-                foreach (var uid in moreNeededEnts)
-                {
-                    if (checkedEnts.Contains(uid))
-                    {
-                        continue;
-                    }
-
-                    var entity = GetEntity(uid);
-                    var state = GetEntityState(uid, fromTick, player);
-
-                    if (state.ComponentStates == null || viewbox.Intersects(GetWorldAabbFromEntity(entity)))
-                    {
-                        // no states or should already be seen
-                        continue;
-                    }
-
-
-                    checkedEnts.Add(uid);
-                    entityStates.Add(state);
-
-                    var idx = Array.FindIndex(state.ComponentStates,
-                        x => x is TransformComponentState);
-
-                    if (idx == -1)
-                    {
-                        // no transform state
-                        continue;
-                    }
-
-                    var oldState = (TransformComponentState) state.ComponentStates[idx];
-                    var newState =
-                        new TransformComponentState(Vector2NaN, oldState.Rotation,
-                            oldState.ParentID, oldState.NoLocalRotation);
-                    state.ComponentStates[idx] = newState;
-                    seenMovers.Remove(uid);
-
-                    ClearLastSeenTick(lSeen, uid);
-                    var needed = oldState.ParentID;
-
-                    if (!needed.IsValid() || checkedEnts.Contains(needed))
-                    {
-                        // done here
-                        continue;
-                    }
-
-                    // check if further needed
-                    if (!checkedEnts.Contains(uid) && GetLastSeenTick(lSeen, needed) == GameTick.Zero)
-                    {
-                        moreNeededEnts.Add(needed);
-                    }
-                }
-
-                neededEnts = moreNeededEnts;
-            } while (neededEnts.Count > 0);
-
-            // help the client out
-            entityStates.Sort((a, b) => a.Uid.CompareTo(b.Uid));
-
-#if DEBUG_NULL_ENTITY_STATES
-            foreach ( var state in entityStates ) {
-                if (state.ComponentStates == null)
-                {
-                    throw new NotImplementedException("Shouldn't send null states.");
-                }
-            }
-#endif
-
-            // no point sending an empty collection
-            return entityStates.Count == 0 ? default : entityStates;
+            EntitiesCount.Set(AllEntities.Count);
         }
-
-        public override void DeleteEntity(IEntity e)
-        {
-            base.DeleteEntity(e);
-            EventBus.RaiseEvent(EventSource.Local, new EntityDeletedMessage(e));
-            _deletionHistory.Add((CurrentTick, e.Uid));
-        }
-
-        public List<EntityUid>? GetDeletedEntities(GameTick fromTick)
-        {
-            var list = new List<EntityUid>();
-            foreach (var (tick, id) in _deletionHistory)
-            {
-                if (tick >= fromTick)
-                {
-                    list.Add(id);
-                }
-            }
-
-            // no point sending an empty collection
-            return list.Count == 0 ? default : list;
-        }
-
-        public void CullDeletionHistory(GameTick toTick)
-        {
-            _deletionHistory.RemoveAll(hist => hist.tick <= toTick);
-        }
-
-        public override bool UpdateEntityTree(IEntity entity, Box2? worldAABB = null)
-        {
-            var currentTick = CurrentTick;
-            var updated = base.UpdateEntityTree(entity, worldAABB);
-
-            if (entity.Deleted
-                || !entity.Initialized
-                || !Entities.ContainsKey(entity.Uid))
-            {
-                return updated;
-            }
-
-            DebugTools.Assert(entity.Transform.Initialized);
-
-            // note: updated can be false even if something moved a bit
-            worldAABB ??= GetWorldAabbFromEntity(entity);
-
-            foreach (var (player, lastSeen) in _playerLastSeen)
-            {
-                var playerEnt = player.AttachedEntity;
-                if (playerEnt == null)
-                {
-                    // player has no entity, gaf?
-                    continue;
-                }
-
-                var playerUid = playerEnt.Uid;
-
-                var entityUid = entity.Uid;
-
-                if (entityUid == playerUid)
-                {
-                    continue;
-                }
-
-                if (!lastSeen.TryGetValue(playerUid, out var playerTick))
-                {
-                    // player can't "see" itself, gaf?
-                    continue;
-                }
-
-                var playerPos = playerEnt.Transform.WorldPosition;
-
-                var viewbox = new Box2(playerPos, playerPos).Enlarged(MaxUpdateRange);
-
-                if (!lastSeen.TryGetValue(entityUid, out var tick))
-                {
-                    // never saw it other than first tick or was cleared
-                    if (!AnyParentMoving(player, entityUid))
-                    {
-                        continue;
-                    }
-                }
-
-                if (tick >= currentTick)
-                {
-                    // currently seeing it
-                    continue;
-                }
-                // saw it previously
-
-                // player can't see it now
-                if (!viewbox.Intersects(worldAABB.Value))
-                {
-                    var addToMovers = false;
-                    if (entity.Transform.LastModifiedTick >= currentTick)
-                    {
-                        addToMovers = true;
-                    }
-                    else if (entity.TryGetComponent(out IPhysBody? physics)
-                             && physics.LastModifiedTick >= currentTick)
-                    {
-                        addToMovers = true;
-                    }
-
-                    if (addToMovers)
-                    {
-                        AddToSeenMovers(player, entityUid);
-                    }
-                }
-            }
-
-            return updated;
-        }
-
-        private bool AnyParentMoving(IPlayerSession player, EntityUid entityUid)
-        {
-            var seenMovers = GetSeenMoversUnlocked(player);
-            if (seenMovers == null)
-            {
-                return false;
-            }
-
-            return AnyParentInSet(entityUid, seenMovers);
-        }
-
-        private bool AnyParentInSet(EntityUid entityUid, SortedSet<EntityUid> set)
-        {
-            for (;;)
-            {
-                if (!TryGetEntity(entityUid, out var ent))
-                {
-                    return false;
-                }
-
-                var txf = ent.Transform;
-
-                entityUid = txf.ParentUid;
-
-                if (entityUid == EntityUid.Invalid)
-                {
-                    return false;
-                }
-
-                if (set.Contains(entityUid))
-                {
-                    return true;
-                }
-            }
-        }
-
-        #endregion IEntityManager Members
 
         IEntity IServerEntityManagerInternal.AllocEntity(string? prototypeName, EntityUid? uid)
         {
             return AllocEntity(prototypeName, uid);
-        }
-
-        protected override EntityUid GenerateEntityUid()
-        {
-            return new(_nextServerEntityUid++);
         }
 
         void IServerEntityManagerInternal.FinishEntityLoad(IEntity entity, IEntityLoadContext? context)
@@ -866,95 +113,33 @@ namespace Robust.Server.GameObjects
         }
 
         /// <inheritdoc />
-        public override void Startup()
+        protected override EntityUid GenerateEntityUid()
         {
-            base.Startup();
-            EntitySystemManager.Initialize();
-            Started = true;
+            return new(_nextServerEntityUid++);
         }
 
-        /// <summary>
-        /// Generates a network entity state for the given entity.
-        /// </summary>
-        /// <param name="compMan">ComponentManager that contains the components for the entity.</param>
-        /// <param name="entityUid">Uid of the entity to generate the state from.</param>
-        /// <param name="fromTick">Only provide delta changes from this tick.</param>
-        /// <param name="player">The player to generate this state for.</param>
-        /// <returns>New entity State for the given entity.</returns>
-        public EntityState GetEntityState(EntityUid entityUid, GameTick fromTick, ICommonSession player)
+        private Entity CreateEntityServer(string? prototypeName)
         {
-            IComponentManager compMan = ComponentManager;
-            var compStates = new List<ComponentState>();
-            var changed = new List<ComponentChanged>();
+            var entity = CreateEntity(prototypeName);
 
-            foreach (var comp in compMan.GetNetComponents(entityUid))
+            if (prototypeName != null)
             {
-                DebugTools.Assert(comp.Initialized);
+                var prototype = PrototypeManager.Index<EntityPrototype>(prototypeName);
 
-                // NOTE: When LastModifiedTick or CreationTick are 0 it means that the relevant data is
-                // "not different from entity creation".
-                // i.e. when the client spawns the entity and loads the entity prototype,
-                // the data it deserializes from the prototype SHOULD be equal
-                // to what the component state / ComponentChanged would send.
-                // As such, we can avoid sending this data in this case since the client "already has it".
-
-                if (comp.NetSyncEnabled && comp.LastModifiedTick != GameTick.Zero && comp.LastModifiedTick >= fromTick)
-                    compStates.Add(comp.GetComponentState(player));
-
-                if (comp.CreationTick != GameTick.Zero && comp.CreationTick >= fromTick && !comp.Deleted)
+                // At this point in time, all data configure on the entity *should* be purely from the prototype.
+                // As such, we can reset the modified ticks to Zero,
+                // which indicates "not different from client's own deserialization".
+                // So the initial data for the component or even the creation doesn't have to be sent over the wire.
+                foreach (var component in ComponentManager.GetNetComponents(entity.Uid))
                 {
-                    // Can't be null since it's returned by GetNetComponents
-                    // ReSharper disable once PossibleInvalidOperationException
-                    changed.Add(ComponentChanged.Added(comp.NetID!.Value, comp.Name));
-                }
-                else if (comp.Deleted && comp.LastModifiedTick >= fromTick)
-                {
-                    // Can't be null since it's returned by GetNetComponents
-                    // ReSharper disable once PossibleInvalidOperationException
-                    changed.Add(ComponentChanged.Removed(comp.NetID!.Value));
+                    // Make sure to ONLY get components that are defined in the prototype.
+                    // Others could be instantiated directly by AddComponent (e.g. ContainerManager).
+                    // And those aren't guaranteed to exist on the client, so don't clear them.
+                    if (prototype.Components.ContainsKey(component.Name)) ((Component) component).ClearTicks();
                 }
             }
 
-            return new EntityState(entityUid, changed.ToArray(), compStates.ToArray());
-        }
-
-        private void IncludeMapCriticalEntities(HashSet<IEntity> set)
-        {
-            foreach (var mapId in _mapManager.GetAllMapIds())
-            {
-                if (_mapManager.HasMapEntity(mapId))
-                {
-                    set.Add(_mapManager.GetMapEntity(mapId));
-                }
-            }
-
-            foreach (var grid in _mapManager.GetAllGrids())
-            {
-                if (grid.GridEntityId != EntityUid.Invalid)
-                {
-                    set.Add(GetEntity(grid.GridEntityId));
-                }
-            }
-        }
-
-        private static void ExcludeInvisible(HashSet<IEntity> set, uint visibilityMask)
-        {
-            set.RemoveWhere(e =>
-            {
-                if (!e.TryGetComponent(out VisibilityComponent? visibility))
-                {
-                    return false;
-                }
-
-                return (visibilityMask & visibility.Layer) == 0;
-            });
-        }
-
-        public override void TickUpdate(float frameTime, Histogram? histogram)
-        {
-            base.TickUpdate(frameTime, histogram);
-
-            EntitiesCount.Set(AllEntities.Count);
+            return entity;
         }
     }
 }

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -319,7 +319,7 @@ namespace Robust.Server.GameObjects
         public List<EntityState>? UpdatePlayerSeenEntityStates(GameTick fromTick, IPlayerSession player, float range)
         {
             const float MinimumMotionForMovers = 1 / 128f;
-            
+
             var playerEnt = player.AttachedEntity;
             if (playerEnt == null)
             {
@@ -475,7 +475,7 @@ namespace Robust.Server.GameObjects
                 eyeComp = null;
 
             // Exclude any entities that are currently invisible to the player.
-            ExcludeInvisible(relatives, (int)(eyeComp?.VisibilityMask ?? 0));
+            ExcludeInvisible(relatives, eyeComp?.VisibilityMask ?? 0);
 
             // Always send updates for all grid and map entities.
             // If we don't, the client-side game state manager WILL blow up.
@@ -937,7 +937,7 @@ namespace Robust.Server.GameObjects
             }
         }
 
-        private static void ExcludeInvisible(HashSet<IEntity> set, int visibilityMask)
+        private static void ExcludeInvisible(HashSet<IEntity> set, uint visibilityMask)
         {
             set.RemoveWhere(e =>
             {

--- a/Robust.Server/GameStates/EntityViewCulling.cs
+++ b/Robust.Server/GameStates/EntityViewCulling.cs
@@ -1,0 +1,240 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.ObjectPool;
+using Robust.Server.GameObjects;
+using Robust.Shared.Enums;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Players;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Robust.Server.GameStates
+{
+    internal class EntityViewCulling
+    {
+        private const int ViewSetSize = 128; // starting number of entities that are in view
+        private const int PlayerSetSize = 64; // Starting size of the number of players
+        private const int MaxVisPoolSize = 256; // Maximum number of pooled objects, this should always be at least the max number of players
+
+        private readonly IServerEntityManager _entMan;
+        private readonly IMapManager _mapManager;
+
+        private readonly Dictionary<ICommonSession, HashSet<EntityUid>> _playerVisibleSets = new(PlayerSetSize);
+
+        private readonly List<(GameTick tick, EntityUid uid)> _deletionHistory = new();
+
+        private readonly ObjectPool<HashSet<EntityUid>> _visSetPool
+            = new DefaultObjectPool<HashSet<EntityUid>>(new DefaultPooledObjectPolicy<HashSet<EntityUid>>(), MaxVisPoolSize);
+
+        /// <summary>
+        /// Size of the side of the view bounds square.
+        /// </summary>
+        public float ViewSize { get; set; }
+
+        /// <summary>
+        /// Is view culling enabled, or will we send the whole map?
+        /// </summary>
+        public bool CullingEnabled { get; set; }
+
+        public EntityViewCulling(IServerEntityManager entMan, IMapManager mapManager)
+        {
+            _entMan = entMan;
+            _mapManager = mapManager;
+        }
+
+        // Not thread safe
+        public void EntityDeleted(EntityUid e)
+        {
+            // Not aware of prediction
+            _deletionHistory.Add((_entMan.CurrentTick, e));
+        }
+
+        // Not thread safe
+        public void CullDeletionHistory(GameTick oldestAck)
+        {
+            _deletionHistory.RemoveAll(hist => hist.tick < oldestAck);
+        }
+
+        private List<EntityUid>? GetDeletedEntities(GameTick fromTick)
+        {
+            var list = new List<EntityUid>();
+            foreach (var (tick, id) in _deletionHistory)
+            {
+                if (tick >= fromTick)
+                {
+                    list.Add(id);
+                }
+            }
+
+            // no point sending an empty collection
+            return list.Count == 0 ? default : list;
+        }
+
+        // Not thread safe
+        public void AddPlayer(ICommonSession session)
+        {
+            _playerVisibleSets.Add(session, new HashSet<EntityUid>(ViewSetSize));
+        }
+
+        // Not thread safe
+        public void RemovePlayer(ICommonSession session)
+        {
+            _playerVisibleSets.Remove(session);
+        }
+
+        // thread safe
+        public bool IsPointVisible(ICommonSession session, in MapCoordinates position)
+        {
+            //TODO: This needs to support multiple bubbles per client
+
+            var bounds = CalcViewBounds(session);
+
+            if (bounds is null)
+                return false;
+
+            var (viewBox, mapId) = bounds.Value;
+
+            if (!CullingEnabled && mapId == position.MapId)
+                return true;
+            
+            return mapId == position.MapId && viewBox.Contains(position.Position);
+        }
+
+        // thread safe
+        public (List<EntityState>? updates, List<EntityUid>? deletions) CalculateEntityStates(ICommonSession session, GameTick fromTick)
+        {
+            DebugTools.Assert(session.Status == SessionStatus.InGame);
+
+            //TODO: Stop sending all sim entities to every player first tick
+            List<EntityUid>? deletions;
+            if (!CullingEnabled || fromTick == GameTick.Zero)
+            {
+                var allStates = _entMan.GetEntityStates(session, fromTick);
+                deletions = GetDeletedEntities(fromTick);
+                return (allStates, deletions);
+            }
+
+            var currentSet = CalcCurrentViewSet(session, fromTick);
+
+            // If they don't have a usable eye, nothing to send, and map remove will deal with ent removal
+            if (currentSet is null)
+                return (null, null);
+
+            var previousSet = _playerVisibleSets[session];
+
+            //TODO: Set theory to calc enter/exit events
+
+            // pretty big allocations :(
+            List<EntityState> entityStates = new(currentSet.Count);
+            foreach (var entityUid in currentSet)
+            {
+                var newState = _entMan.GetEntityState(entityUid, fromTick, session);
+
+                if(!newState.Empty)
+                    entityStates.Add(newState);
+            }
+
+            // pivot out vis sets
+            _playerVisibleSets[session] = currentSet;
+            previousSet.Clear();
+            _visSetPool.Return(previousSet);
+
+            deletions = GetDeletedEntities(fromTick);
+
+            return (entityStates, deletions);
+        }
+
+        private HashSet<EntityUid>? CalcCurrentViewSet(ICommonSession session, GameTick fromTick)
+        {
+            var bounds = CalcViewBounds(session);
+
+            if (bounds is null)
+                return null;
+            
+            var (viewBox, mapId) = bounds.Value;
+
+            // assume there are no deleted ents in here, cull them first in ent/comp manager
+            var potentialVisibleEnts = _entMan.GetEntitiesIntersecting(mapId, viewBox);
+            var visibleEnts = _visSetPool.Get();
+            //TODO: Move visibility to EyeComponent
+
+            foreach (var potentialEnt in potentialVisibleEnts)
+            {
+                //TODO: Add Parents
+                //TODO: Container culling
+                //TODO: per-eye VisibilityComponent cull
+
+                //TODO: If parent is already in the set, it has already been checked
+                visibleEnts.Add(potentialEnt.Uid);
+            }
+
+            // TODO: Need eye-based technology
+            //Always include client AttachedEnt
+            var eyeEnt = session.AttachedEntityUid!; // already verified in CalcBounds
+            visibleEnts.Add(eyeEnt.Value);
+
+            //Ensure map Critical ents are included
+            IncludeMapCriticalEntities(visibleEnts);
+
+            return visibleEnts;
+        }
+
+        // thread safe
+        private (Box2 view, MapId mapId)? CalcViewBounds(ICommonSession playerSession)
+        {
+            //TODO: This needs to support multiple bubbles per client
+
+            var clientEnt = playerSession.AttachedEntityUid;
+
+            if (clientEnt is null)
+                return null;
+
+            var xform = _entMan.ComponentManager.GetComponent<ITransformComponent>(clientEnt.Value);
+
+            if (!CullingEnabled)
+                return (new Box2(), xform.MapID);
+
+            var view = Box2.UnitCentered.Scale(ViewSize).Translated(xform.WorldPosition);
+            var map = xform.MapID;
+
+            return (view, map);
+        }
+
+        // Read safe
+        private void IncludeMapCriticalEntities(ISet<EntityUid> set)
+        {
+            foreach (var mapId in _mapManager.GetAllMapIds())
+            {
+                if (_mapManager.HasMapEntity(mapId))
+                {
+                    set.Add(_mapManager.GetMapEntityId(mapId));
+                }
+            }
+
+            foreach (var grid in _mapManager.GetAllGrids())
+            {
+                if (grid.GridEntityId != EntityUid.Invalid)
+                {
+                    set.Add(grid.GridEntityId);
+                }
+            }
+        }
+
+        // Read Safe
+        private static void ExcludeInvisible(HashSet<IEntity> set, int visibilityMask)
+        {
+            set.RemoveWhere(e =>
+            {
+                if (!e.TryGetComponent(out VisibilityComponent? visibility))
+                {
+                    return false;
+                }
+
+                return (visibilityMask & visibility.Layer) == 0;
+            });
+        }
+    }
+}

--- a/Robust.Server/GameStates/IServerGameStateManager.cs
+++ b/Robust.Server/GameStates/IServerGameStateManager.cs
@@ -1,18 +1,21 @@
 ﻿namespace Robust.Server.GameStates
 {
     /// <summary>
-    ///     Engine service that provides creating and dispatching of game states.
+    /// Engine service that provides creating and dispatching of game states.
     /// </summary>
     public interface IServerGameStateManager
     {
         /// <summary>
-        ///     One time initialization of the service.
+        /// One time initialization of the service.
         /// </summary>
         void Initialize();
 
         /// <summary>
-        ///     Create and dispatch game states to all connected sessions.
+        /// Create and dispatch game states to all connected sessions.
         /// </summary>
         void SendGameStateUpdate();
+
+        bool PvsEnabled { get; }
+        float PvsRange { get; }
     }
 }

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -123,8 +123,7 @@ namespace Robust.Server.GameStates
 
             _entityManager.Update();
 
-            //TODO: Make these cvars
-            _entityView.ViewSize = PvsRange;
+            _entityView.ViewSize = PvsRange * 2;
             _entityView.CullingEnabled = PvsEnabled;
 
             if (!_networkManager.IsConnected)

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -206,7 +206,7 @@ namespace Robust.Server.GameStates
             }
 
             var mailBag = _playerManager.GetAllPlayers()
-                .Where(s=>s.Status == SessionStatus.InGame).Select(GenerateMail).ToList();
+                .Where(s=>s.Status == SessionStatus.InGame).Select(GenerateMail);
             
             foreach (var (msg, chan) in mailBag)
             {

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
 using Robust.Shared;
@@ -19,11 +20,13 @@ using Robust.Shared.Utility;
 namespace Robust.Server.GameStates
 {
     /// <inheritdoc />
-    public class ServerGameStateManager : IServerGameStateManager
+    public class ServerGameStateManager : IServerGameStateManager, IPostInjectInit
     {
         // Mapping of net UID of clients -> last known acked state.
         private readonly Dictionary<long, GameTick> _ackedStates = new();
         private GameTick _lastOldestAck = GameTick.Zero;
+
+        private EntityViewCulling _entityView = null!;
 
         [Dependency] private readonly IServerEntityManager _entityManager = default!;
         [Dependency] private readonly IGameTiming _gameTiming = default!;
@@ -35,6 +38,12 @@ namespace Robust.Server.GameStates
         [Dependency] private readonly IConfigurationManager _configurationManager = default!;
 
         public bool PvsEnabled => _configurationManager.GetCVar(CVars.NetPVS);
+        public float PvsRange => _configurationManager.GetCVar(CVars.NetMaxUpdateRange);
+
+        public void PostInject()
+        {
+            _entityView = new EntityViewCulling(_entityManager, _mapManager);
+        }
 
         /// <inheritdoc />
         public void Initialize()
@@ -44,6 +53,27 @@ namespace Robust.Server.GameStates
 
             _networkManager.Connected += HandleClientConnected;
             _networkManager.Disconnect += HandleClientDisconnect;
+
+            _playerManager.PlayerStatusChanged += HandlePlayerStatusChanged;
+
+            _entityManager.EntityDeleted += HandleEntityDeleted;
+        }
+
+        private void HandleEntityDeleted(object? sender, EntityUid e)
+        {
+            _entityView.EntityDeleted(e);
+        }
+
+        private void HandlePlayerStatusChanged(object? sender, SessionStatusEventArgs e)
+        {
+            if (e.NewStatus == SessionStatus.InGame)
+            {
+                _entityView.AddPlayer(e.Session);
+            }
+            else if(e.OldStatus == SessionStatus.InGame)
+            {
+                _entityView.RemovePlayer(e.Session);
+            }
         }
 
         private void HandleClientConnected(object? sender, NetChannelArgs e)
@@ -100,10 +130,17 @@ namespace Robust.Server.GameStates
 
             _entityManager.Update();
 
+            //TODO: Make these cvars
+            _entityView.ViewSize = PvsRange;
+            _entityView.CullingEnabled = PvsEnabled;
+
             if (!_networkManager.IsConnected)
             {
                 // Prevent deletions piling up if we have no clients.
+#if OLD_PVS
                 _entityManager.CullDeletionHistory(GameTick.MaxValue);
+#endif
+                _entityView.CullDeletionHistory(GameTick.MaxValue);
                 _mapManager.CullDeletionHistory(GameTick.MaxValue);
                 return;
             }
@@ -112,16 +149,14 @@ namespace Robust.Server.GameStates
 
             var oldestAck = GameTick.MaxValue;
 
-            var oldDeps = IoCManager.Resolve<IDependencyCollection>();
-
-            var deps = new DependencyCollection();
-            deps.RegisterInstance<ILogManager>(new ProxyLogManager(IoCManager.Resolve<ILogManager>()));
-            deps.BuildGraph();
-
+            var mainThread = Thread.CurrentThread;
             (MsgState, INetChannel) GenerateMail(IPlayerSession session)
             {
-                IoCManager.InitThread(deps, true);
+                // KILL IT WITH FIRE
+                if(mainThread != Thread.CurrentThread)
+                    IoCManager.InitThread(new DependencyCollection(), true);
 
+                // people not in the game don't get states
                 if (session.Status != SessionStatus.InGame)
                 {
                     return default;
@@ -133,13 +168,17 @@ namespace Robust.Server.GameStates
                 {
                     DebugTools.Assert("Why does this channel not have an entry?");
                 }
-
+#if OLD_PVS
                 var entStates = lastAck == GameTick.Zero || !PvsEnabled
                     ? _entityManager.GetEntityStates(lastAck, session)
                     : _entityManager.UpdatePlayerSeenEntityStates(lastAck, session, _entityManager.MaxUpdateRange);
-                var playerStates = _playerManager.GetPlayerStates(lastAck);
                 var deletions = _entityManager.GetDeletedEntities(lastAck);
+#else
+                var (entStates, deletions) = _entityView.CalculateEntityStates(session, lastAck);
+#endif
+                var playerStates = _playerManager.GetPlayerStates(lastAck);
                 var mapData = _mapManager.GetStateData(lastAck);
+
 
                 // lastAck varies with each client based on lag and such, we can't just make 1 global state and send it to everyone
                 var lastInputCommand = inputSystem.GetLastInputCommand(session);
@@ -167,15 +206,8 @@ namespace Robust.Server.GameStates
             }
 
             var mailBag = _playerManager.GetAllPlayers()
-                .AsParallel().Select(GenerateMail).ToList();
-
-            // TODO: oh god oh fuck kill it with fire.
-            // PLINQ *seems* to be scheduling to the main thread partially (I guess that makes sense?)
-            // Which causes that IoC "hack" up there to override IoC in the main thread, nuking the game.
-            // At least, that's our running theory. I reproduced it once locally and can't reproduce it again.
-            // Throwing shit at the wall to hope it fixes it.
-            IoCManager.InitThread(oldDeps, true);
-
+                .Where(s=>s.Status == SessionStatus.InGame).Select(GenerateMail).ToList();
+            
             foreach (var (msg, chan) in mailBag)
             {
                 // see session.Status != SessionStatus.InGame above
@@ -187,7 +219,10 @@ namespace Robust.Server.GameStates
             if (oldestAck > _lastOldestAck)
             {
                 _lastOldestAck = oldestAck;
+#if OLD_PVS
                 _entityManager.CullDeletionHistory(oldestAck);
+#endif
+                _entityView.CullDeletionHistory(oldestAck);
                 _mapManager.CullDeletionHistory(oldestAck);
             }
         }

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -121,8 +121,6 @@ namespace Robust.Server.GameStates
         {
             DebugTools.Assert(_networkManager.IsServer);
 
-            _entityManager.Update();
-
             _entityView.ViewSize = PvsRange * 2;
             _entityView.CullingEnabled = PvsEnabled;
 
@@ -188,6 +186,7 @@ namespace Robust.Server.GameStates
             }
 
             var mailBag = _playerManager.GetAllPlayers()
+                .AsParallel()
                 .Where(s=>s.Status == SessionStatus.InGame).Select(GenerateMail);
             
             foreach (var (msg, chan) in mailBag)

--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2020.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.3" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.4" />
     <PackageReference Include="prometheus-net" Version="4.1.1" />
     <PackageReference Include="Serilog.Sinks.Loki" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="5.0.0" />

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -735,11 +735,6 @@ namespace Robust.Shared.GameObjects
         }
 
 #endregion
-
-        public virtual void Update()
-        {
-        }
-
     }
 
     public enum EntityMessageType : byte

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -280,6 +280,7 @@ namespace Robust.Shared.GameObjects
 
             entity.LifeStage = EntityLifeStage.Deleted;
             EntityDeleted?.Invoke(this, entity.Uid);
+            EventBus.RaiseEvent(EventSource.Local, new EntityDeletedMessage(entity));
         }
         
         public void DeleteEntity(EntityUid uid)
@@ -459,6 +460,9 @@ namespace Robust.Shared.GameObjects
             }
         }
 
+        /// <summary>
+        /// Factory for generating a new EntityUid for an entity currently being created.
+        /// </summary>
         protected abstract EntityUid GenerateEntityUid();
 
 #region Spatial Queries
@@ -737,11 +741,6 @@ namespace Robust.Shared.GameObjects
         }
 
     }
-
-    /// <summary>
-    /// The children of this entity are about to be deleted.
-    /// </summary>
-    public class EntityTerminatingEvent : EntityEventArgs { }
 
     public enum EntityMessageType : byte
     {

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -480,8 +480,9 @@ namespace Robust.Shared.GameObjects
             return found;
         }
 
+        /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public void FastEntitiesIntersecting(MapId mapId, ref Box2 position, EntityQueryCallback callback)
+        public void FastEntitiesIntersecting(in MapId mapId, ref Box2 position, EntityQueryCallback callback)
         {
             if (mapId == MapId.Nullspace)
                 return;

--- a/Robust.Shared/GameObjects/EntityState.cs
+++ b/Robust.Shared/GameObjects/EntityState.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Serialization;
+using Robust.Shared.Serialization;
 using System;
 
 namespace Robust.Shared.GameObjects
@@ -9,6 +9,8 @@ namespace Robust.Shared.GameObjects
         public EntityUid Uid { get; }
         public ComponentChanged[]? ComponentChanges { get; }
         public ComponentState[]? ComponentStates { get; }
+
+        public bool Empty => ComponentChanges is null && ComponentStates is null;
 
         public EntityState(EntityUid uid, ComponentChanged[]? changedComponents, ComponentState[]? componentStates)
         {

--- a/Robust.Shared/GameObjects/EntitySystemMessages/EntityDeletedMessage.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/EntityDeletedMessage.cs
@@ -1,6 +1,4 @@
-using Robust.Shared.GameObjects;
-
-namespace Robust.Server.GameObjects
+namespace Robust.Shared.GameObjects
 {
     public sealed class EntityDeletedMessage : EntityEventArgs
     {

--- a/Robust.Shared/GameObjects/EntitySystemMessages/EntityTerminatingEvent.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/EntityTerminatingEvent.cs
@@ -1,0 +1,7 @@
+namespace Robust.Shared.GameObjects
+{
+    /// <summary>
+    /// The children of this entity are about to be deleted.
+    /// </summary>
+    public class EntityTerminatingEvent : EntityEventArgs { }
+}

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -218,7 +218,5 @@ namespace Robust.Shared.GameObjects
         bool RemoveFromEntityTree(IEntity entity, MapId mapId);
 
         #endregion
-
-        void Update();
     }
 }

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -126,6 +126,8 @@ namespace Robust.Shared.GameObjects
         /// <param name="box"></param>
         /// <param name="approximate">If true, will not recalculate precise entity AABBs, resulting in a perf increase. </param>
         bool AnyEntitiesIntersecting(MapId mapId, Box2 box, bool approximate = false);
+        
+        void FastEntitiesIntersecting(MapId mapId, ref Box2 position, EntityQueryCallback callback);
 
         /// <summary>
         /// Gets entities with a bounding box that intersects this box
@@ -218,6 +220,5 @@ namespace Robust.Shared.GameObjects
         #endregion
 
         void Update();
-
     }
 }

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -127,7 +127,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="approximate">If true, will not recalculate precise entity AABBs, resulting in a perf increase. </param>
         bool AnyEntitiesIntersecting(MapId mapId, Box2 box, bool approximate = false);
         
-        void FastEntitiesIntersecting(MapId mapId, ref Box2 position, EntityQueryCallback callback);
+        void FastEntitiesIntersecting(in MapId mapId, ref Box2 position, EntityQueryCallback callback);
 
         /// <summary>
         /// Gets entities with a bounding box that intersects this box

--- a/Robust.Shared/Map/MapId.cs
+++ b/Robust.Shared/Map/MapId.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using Robust.Shared.Serialization;
 
 namespace Robust.Shared.Map
 {
     [Serializable, NetSerializable]
-    public struct MapId : IEquatable<MapId>
+    public readonly struct MapId : IEquatable<MapId>
     {
         public static readonly MapId Nullspace = new(0);
 

--- a/Robust.Shared/Physics/DynamicTree.cs
+++ b/Robust.Shared/Physics/DynamicTree.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Initially based on Box2D by Erin Catto, license follows;
  *
  * Copyright (c) 2009 Erin Catto http://www.box2d.org
@@ -72,7 +72,7 @@ namespace Robust.Shared.Physics
 
         // avoids "Collection was modified; enumeration operation may not execute."
         private Dictionary<T, Proxy> _nodeLookup;
-        private readonly B2DynamicTree<T> _b2Tree;
+        public readonly B2DynamicTree<T> _b2Tree;
 
         public DynamicTree(ExtractAabbDelegate extractAabbFunc, IEqualityComparer<T>? comparer = null, float aabbExtendSize = 1f / 32, int capacity = 256, Func<int, int>? growthFunc = null)
         {

--- a/Robust.UnitTesting/Shared/Map/MapGrid_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/MapGrid_Tests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Moq;
 using NUnit.Framework;
 using Robust.Server.GameObjects;
@@ -8,7 +8,6 @@ using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics.Broadphase;
-using Robust.Shared.Timing;
 using MapGrid = Robust.Shared.Map.MapGrid;
 
 namespace Robust.UnitTesting.Shared.Map
@@ -159,7 +158,6 @@ namespace Robust.UnitTesting.Shared.Map
         private static IMapGridInternal MapGridFactory(GridId id)
         {
             var entMan = (ServerEntityManager)IoCManager.Resolve<IEntityManager>();
-            entMan.CullDeletionHistory(GameTick.MaxValue);
 
             var mapId = new MapId(5);
             var mapMan = IoCManager.Resolve<IMapManager>();


### PR DESCRIPTION
Remake of the entire network bubble system.

> just simply cull entities outside of a view box, really, how hard could that be? *queue screams of the damned*

- [x] basic entity culling
- [x] mover support
- [x] allow per-client entity visibility (Resolves https://github.com/space-wizards/RobustToolbox/issues/1255)
- [ ] obscure container contents (per-entity vis) (https://github.com/space-wizards/RobustToolbox/issues/1432)
- [x] multiple viewports (Resolves https://github.com/space-wizards/RobustToolbox/issues/1257)
- [ ] needs to handle large AABBs, like lights (https://github.com/space-wizards/RobustToolbox/issues/1198)
- [ ] client PVS entity cache using mapids (https://github.com/space-wizards/RobustToolbox/issues/1592)
- [ ] no NANs (https://github.com/space-wizards/RobustToolbox/issues/1210)

Network usage is currently higher, ~10KB/s up from ~3KB/s while moving.

*30TPS server with 1 Client running around the station for 60 seconds.*
*Napkin Math: 2.8s/60s = 4.6% of cpu time, US-WEST has 24 cores, ~5x24 players for 25% total time in Grafana*
![image](https://user-images.githubusercontent.com/1685952/112908870-3057dc00-90a5-11eb-9557-cfe22267f02f.png)


Misc Changes:
* Moved visibility mask from client session to eye.
* Network debug tool improvements.