### PR TITLE
Fix static sleeping crash

### DIFF
--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Farseer Physics Engine:
 * Copyright (c) 2012 Ian Qvist
 *
@@ -109,12 +109,15 @@ namespace Robust.Shared.GameObjects
 
                 if (_bodyType == BodyType.Static)
                 {
+                    Awake = false;
                     _linVelocity = Vector2.Zero;
                     _angVelocity = 0.0f;
                     // SynchronizeFixtures(); TODO: When CCD
                 }
-
-                Awake = true;
+                else
+                {
+                    Awake = true;
+                }     
 
                 Force = Vector2.Zero;
                 Torque = 0.0f;
@@ -145,13 +148,6 @@ namespace Robust.Shared.GameObjects
             {
                 if (_awake == value)
                     return;
-
-                if (BodyType == BodyType.Static)
-                {
-                    // Check nothing slipped through
-                    DebugTools.Assert(!_awake);
-                    return;
-                }
 
                 _awake = value;
 

--- a/Robust.Shared/Physics/Dynamics/PhysicsMap.cs
+++ b/Robust.Shared/Physics/Dynamics/PhysicsMap.cs
@@ -220,7 +220,7 @@ namespace Robust.Shared.Physics.Dynamics
                 // Sloth note: So FPE doesn't seem to handle static bodies being woken gracefully as they never sleep
                 // (No static body's an island so can't increase their min sleep time).
                 // AFAIK not adding it to woken bodies shouldn't matter for anything tm...
-                if (!Bodies.Contains(body) || !body.Awake || body.BodyType == BodyType.Static) continue;
+                if (!body.Awake || body.BodyType == BodyType.Static || !Bodies.Contains(body)) continue;
                 AwakeBodies.Add(body);
             }
 


### PR DESCRIPTION
Removing the assert should be gucci given a body swapping types may or may not already be awake.

Also this is a change from Farseer where static bodies can be awake even though they can't propagate islands which is stupid so I just don't allow them to ever be awake.