### PR TITLE
Entity Lifetime Levels

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -2085,6 +2085,7 @@ namespace Robust.Client.GameObjects
             public IEntityManager EntityManager { get; } = null!;
             public string Name { get; set; } = string.Empty;
             public EntityUid Uid { get; } = EntityUid.Invalid;
+            EntityLifeStage IEntity.LifeStage { get => _lifeStage; set => _lifeStage = value; }
             public bool Initialized { get; } = false;
             public bool Initializing { get; } = false;
             public bool Deleted { get; } = true;
@@ -2101,6 +2102,7 @@ namespace Robust.Client.GameObjects
             public IMetaDataComponent MetaData { get; } = null!;
 
             private Dictionary<Type, IComponent> _components = new();
+            private EntityLifeStage _lifeStage;
 
             public T AddComponent<T>() where T : Component, new()
             {
@@ -2189,11 +2191,7 @@ namespace Robust.Client.GameObjects
             {
                 return null;
             }
-
-            public void Shutdown()
-            {
-            }
-
+            
             public void Delete()
             {
             }

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -75,7 +75,7 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public bool Initialized => EntityLifeStage.Initialized <= LifeStage && LifeStage <= EntityLifeStage.Terminating;
+        public bool Initialized => LifeStage >= EntityLifeStage.Initialized;
 
         /// <inheritdoc />
         public bool Initializing => LifeStage == EntityLifeStage.Initializing;

--- a/Robust.Shared/GameObjects/EntityLifeState.cs
+++ b/Robust.Shared/GameObjects/EntityLifeState.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Robust.Shared.GameObjects
 {
     public enum EntityLifeStage
@@ -12,7 +6,15 @@ namespace Robust.Shared.GameObjects
         /// The entity has just been created, and needs to be initialized.
         /// </summary>
         PreInit = 0,
+
+        /// <summary>
+        /// The entity is currently being initialized.
+        /// </summary>
         Initializing,
+
+        /// <summary>
+        /// The entity has been initialized.
+        /// </summary>
         Initialized,
 
         /// <summary>

--- a/Robust.Shared/GameObjects/EntityLifeState.cs
+++ b/Robust.Shared/GameObjects/EntityLifeState.cs
@@ -18,6 +18,11 @@ namespace Robust.Shared.GameObjects
         Initialized,
 
         /// <summary>
+        /// The map this entity is on has been initialized, so this entity has been as well.
+        /// </summary>
+        MapInitialized,
+
+        /// <summary>
         /// The entity is currently removing all of it's components and is about to be deleted.
         /// </summary>
         Terminating,

--- a/Robust.Shared/GameObjects/EntityLifeState.cs
+++ b/Robust.Shared/GameObjects/EntityLifeState.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Robust.Shared.GameObjects
+{
+    public enum EntityLifeStage
+    {
+        /// <summary>
+        /// The entity has just been created, and needs to be initialized.
+        /// </summary>
+        PreInit = 0,
+        Initializing,
+        Initialized,
+
+        /// <summary>
+        /// The entity is currently removing all of it's components and is about to be deleted.
+        /// </summary>
+        Terminating,
+
+        /// <summary>
+        /// The entity has been deleted.
+        /// </summary>
+        Deleted,
+    }
+}

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -233,6 +233,13 @@ namespace Robust.Shared.GameObjects
             if (e.Deleted)
                 return;
 
+            if (e.LifeStage >= EntityLifeStage.Terminating)
+#if !EXCEPTION_TOLERANCE
+                throw new InvalidOperationException("Called Delete on an entity already being deleted.");
+#else
+                return;
+#endif
+
             RecursiveDeleteEntity(e);
         }
 
@@ -242,6 +249,7 @@ namespace Robust.Shared.GameObjects
                 return;
             
             var transform = entity.Transform;
+            entity.LifeStage = EntityLifeStage.Terminating;
 
             // DeleteEntity modifies our _children collection, we must cache the collection to iterate properly
             foreach (var childTransform in transform.Children.ToArray())
@@ -260,7 +268,7 @@ namespace Robust.Shared.GameObjects
                 transform.DetachParentToNull();
             }
 
-            entity.Shutdown();
+            entity.LifeStage = EntityLifeStage.Deleted;
             EntityDeleted?.Invoke(this, entity.Uid);
         }
         

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -247,9 +247,11 @@ namespace Robust.Shared.GameObjects
         {
             if(entity.Deleted) //TODO: Why was this still a child if it was already deleted?
                 return;
-            
+
             var transform = entity.Transform;
             entity.LifeStage = EntityLifeStage.Terminating;
+
+            EventBus.RaiseLocalEvent(entity.Uid, new EntityTerminatingEvent(), false);
 
             // DeleteEntity modifies our _children collection, we must cache the collection to iterate properly
             foreach (var childTransform in transform.Children.ToArray())
@@ -716,6 +718,11 @@ namespace Robust.Shared.GameObjects
         }
 
     }
+
+    /// <summary>
+    /// The children of this entity are about to be deleted.
+    /// </summary>
+    public class EntityTerminatingEvent : EntityEventArgs { }
 
     public enum EntityMessageType : byte
     {

--- a/Robust.Shared/GameObjects/IEntity.cs
+++ b/Robust.Shared/GameObjects/IEntity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.Network;
@@ -30,6 +30,12 @@ namespace Robust.Shared.GameObjects
         ///     and correspond to counterparts across the network.
         /// </summary>
         EntityUid Uid { get; }
+
+        /// <summary>
+        ///     The current lifetime stage of this entity. You can use this to check
+        ///     if the entity is initialized or being deleted.
+        /// </summary>
+        EntityLifeStage LifeStage { get; internal set; }
 
         /// <summary>
         ///     Whether this entity has fully initialized.
@@ -182,13 +188,6 @@ namespace Robust.Shared.GameObjects
         /// <param name="netId">The component net ID to attempt to fetch.</param>
         /// <returns>The component, if it was found. Null otherwise.</returns>
         IComponent? GetComponentOrNull(uint netId);
-
-        /// <summary>
-        ///     Used by the entity manager to delete the entity.
-        ///     Do not call directly. If you want to delete entities,
-        ///     see <see cref="Delete" />.
-        /// </summary>
-        void Shutdown();
 
         /// <summary>
         ///     Deletes this entity.

--- a/Robust.Shared/GameObjects/IMapInit.cs
+++ b/Robust.Shared/GameObjects/IMapInit.cs
@@ -1,3 +1,5 @@
+using Robust.Shared.Utility;
+
 namespace Robust.Shared.GameObjects
 {
     /// <summary>
@@ -14,6 +16,9 @@ namespace Robust.Shared.GameObjects
     {
         public static void RunMapInit(this IEntity entity)
         {
+            DebugTools.Assert(entity.LifeStage == EntityLifeStage.Initialized);
+            entity.LifeStage = EntityLifeStage.MapInitialized;
+
             foreach (var init in entity.GetAllComponents<IMapInit>())
             {
                 init.MapInit();

--- a/Robust.Shared/Map/MapManager.cs
+++ b/Robust.Shared/Map/MapManager.cs
@@ -577,7 +577,7 @@ namespace Robust.Shared.Map
 
             var grid = _grids[gridID];
 
-            if (_entityManager.TryGetEntity(grid.GridEntityId, out var gridEnt))
+            if (_entityManager.TryGetEntity(grid.GridEntityId, out var gridEnt) && gridEnt.LifeStage <= EntityLifeStage.Initialized)
                 gridEnt.Delete();
 
             grid.Dispose();


### PR DESCRIPTION
Added an entity lifetime level property. You can use this to check if an entity is in the process of being initialized or deleted. This replaces a few boolean fields in Entity that were not actually mutually exclusive.
Added exception when recursively deleting an entity.