### PR TITLE
Fix CopyWithTypeSerializer not copying when null

### DIFF
--- a/Robust.Shared/Serialization/Manager/SerializationManager.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.cs
@@ -586,7 +586,7 @@ namespace Robust.Shared.Serialization.Manager
         public object? CopyWithTypeSerializer(Type typeSerializer, object? source, object? target,
             ISerializationContext? context = null, bool skipHook = false)
         {
-            if (source == null || target == null) return null;
+            if (source == null || target == null) return source;
             var commonType = TypeHelpers.SelectCommonType(source.GetType(), target.GetType());
             if (commonType == null)
             {


### PR DESCRIPTION
Changed `CopyWithTypeSerializer` to match with `CopyToTarget`
https://github.com/space-wizards/RobustToolbox/blob/cedfa0ee2f6d41efd07657c747de5de7ef61a2c1/Robust.Shared/Serialization/Manager/SerializationManager.cs#L473-L476

https://discord.com/channels/310555209753690112/770682801607278632/823457120544227378