### PR TITLE
Fix crash on checking if grid 0 is paused

### DIFF
--- a/Robust.Shared/Timing/PauseManager.cs
+++ b/Robust.Shared/Timing/PauseManager.cs
@@ -92,6 +92,11 @@ namespace Robust.Shared.Timing
 
         public bool IsGridPaused(GridId gridId)
         {
+            if (!gridId.IsValid())
+            {
+                return false;
+            }
+
             if (_mapManager.TryGetGrid(gridId, out var grid))
             {
                 return IsGridPaused(grid);


### PR DESCRIPTION
AISteeringSystem in content uses this to know if steering should continue.
If the steerer is on grid 0 then an exception occurs since its not found.
It makes the most sense to me for grid 0 to never be paused, otherwise the check would have to be moved to AISteeringSystem's Update method.