### PR TITLE
PVS Bugfixes 1: The Debuggening

### DIFF
--- a/Robust.Server/GameStates/IServerGameStateManager.cs
+++ b/Robust.Server/GameStates/IServerGameStateManager.cs
@@ -1,4 +1,4 @@
-﻿namespace Robust.Server.GameStates
+namespace Robust.Server.GameStates
 {
     /// <summary>
     /// Engine service that provides creating and dispatching of game states.
@@ -15,7 +15,7 @@
         /// </summary>
         void SendGameStateUpdate();
 
-        bool PvsEnabled { get; }
-        float PvsRange { get; }
+        bool PvsEnabled { get; set; }
+        float PvsRange { get; set; }
     }
 }

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -40,8 +40,17 @@ namespace Robust.Server.GameStates
 
         private ISawmill _logger = default!;
 
-        public bool PvsEnabled => _configurationManager.GetCVar(CVars.NetPVS);
-        public float PvsRange => _configurationManager.GetCVar(CVars.NetMaxUpdateRange);
+        public bool PvsEnabled
+        {
+            get => _configurationManager.GetCVar(CVars.NetPVS);
+            set => _configurationManager.SetCVar(CVars.NetPVS, value);
+        }
+
+        public float PvsRange
+        {
+            get => _configurationManager.GetCVar(CVars.NetMaxUpdateRange);
+            set => _configurationManager.SetCVar(CVars.NetMaxUpdateRange, value);
+        }
 
         public void PostInject()
         {

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -10,6 +10,7 @@ using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
+using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Network.Messages;
@@ -37,11 +38,14 @@ namespace Robust.Server.GameStates
         [Dependency] private readonly IServerEntityNetworkManager _entityNetworkManager = default!;
         [Dependency] private readonly IConfigurationManager _configurationManager = default!;
 
+        private ISawmill _logger = default!;
+
         public bool PvsEnabled => _configurationManager.GetCVar(CVars.NetPVS);
         public float PvsRange => _configurationManager.GetCVar(CVars.NetMaxUpdateRange);
 
         public void PostInject()
         {
+            _logger = Logger.GetSawmill("PVS");
             _entityView = new EntityViewCulling(_entityManager, _mapManager);
         }
 
@@ -185,9 +189,24 @@ namespace Robust.Server.GameStates
                 return (stateUpdateMessage, channel);
             }
 
+            (MsgState, INetChannel?) SafeGenerateMail(IPlayerSession session)
+            {
+                try
+                {
+                    return GenerateMail(session);
+                }
+                catch (Exception e) // Catch EVERY exception
+                {
+                    _logger.Log(LogLevel.Error, e, string.Empty);
+                }
+
+                return (new MsgState(session.ConnectedClient), null);
+            }
+
             var mailBag = _playerManager.GetAllPlayers()
+                .Where(s => s.Status == SessionStatus.InGame)
                 .AsParallel()
-                .Where(s=>s.Status == SessionStatus.InGame).Select(GenerateMail);
+                .Select(SafeGenerateMail);
             
             foreach (var (msg, chan) in mailBag)
             {

--- a/Robust.Shared/Map/MapManager.cs
+++ b/Robust.Shared/Map/MapManager.cs
@@ -145,9 +145,13 @@ namespace Robust.Shared.Map
             if (_mapEntities.TryGetValue(MapId.Nullspace, out var entId))
             {
                 if (_entityManager.TryGetEntity(entId, out var entity))
+                {
+                    Logger.InfoS("map", $"Deleting map entity {entId}");
                     entity.Delete();
+                }
 
-                _mapEntities.Remove(MapId.Nullspace);
+                if(_mapEntities.Remove(MapId.Nullspace));
+                    Logger.InfoS("map", "Removing nullspace map entity.");
             }
 
 #if DEBUG
@@ -220,6 +224,7 @@ namespace Robust.Shared.Map
                 return;
 
             _mapDeletionHistory.Add((_gameTiming.CurTick, mapID));
+            Logger.InfoS("map", $"Deleting map {mapID}");
         }
 
         public MapId CreateMap(MapId? mapID = null)
@@ -424,6 +429,8 @@ namespace Robust.Shared.Map
                 actualID = new GridId(HighestGridID.Value + 1);
             }
 
+            DebugTools.Assert(actualID != GridId.Invalid);
+
             if (GridExists(actualID))
             {
                 throw new InvalidOperationException($"A grid with ID {actualID} already exists");
@@ -436,7 +443,7 @@ namespace Robust.Shared.Map
 
             var grid = new MapGrid(this, _entityManager, actualID, chunkSize, snapSize, currentMapID);
             _grids.Add(actualID, grid);
-            Logger.DebugS("map", $"Creating new grid {actualID}");
+            Logger.InfoS("map", $"Creating new grid {actualID}");
 
             if (actualID != GridId.Invalid && createEntity) // nullspace default grid is not bound to an entity
             {
@@ -473,6 +480,10 @@ namespace Robust.Shared.Map
                     newEnt.InitializeComponents();
                     newEnt.StartAllComponents();
                 }
+            }
+            else
+            {
+                Logger.DebugS("map", $"Skipping entity binding for gridId {actualID}");
             }
 
             OnGridCreated?.Invoke(actualID);


### PR DESCRIPTION
* Wrapped the parallel GetMail function in a try/catch. At least now we will get exception logspam instead of the server crashing.
* Added a hack to the ViewCulling leave message that skips ents that don't exist. Not 100% sure about the root cause of this, but it is causing the server to crash at roundstart.
* Map/Grid ents always inside view of the client, even with client detached from entity. Current MapManager requires this.
* More info logging about adding/removing maps/grids.

Resolves https://github.com/space-wizards/RobustToolbox/issues/1664