### PR TITLE
Remove NetId requirement for local event subscriptions

### DIFF
--- a/Robust.Shared/GameObjects/ComponentManager.cs
+++ b/Robust.Shared/GameObjects/ComponentManager.cs
@@ -156,9 +156,9 @@ namespace Robust.Shared.GameObjects
 
                 // mark the component as dirty for networking
                 component.Dirty();
-
-                ComponentAdded?.Invoke(this, new AddedComponentEventArgs(component, uid));
             }
+
+            ComponentAdded?.Invoke(this, new AddedComponentEventArgs(component, uid));
 
             _componentDependencyManager.OnComponentAdd(entity.Uid, component);
 


### PR DESCRIPTION
Moves AddedComponentEventArgs so that EntitySystem.SubscribeLocalEvent works with components without NetIds.