### PR TITLE
ConsoleHost no longer depends on INetManager

### DIFF
--- a/Robust.Client/Console/IClientConsoleHost.cs
+++ b/Robust.Client/Console/IClientConsoleHost.cs
@@ -16,7 +16,6 @@ namespace Robust.Client.Console
         /// </summary>
         void Reset();
 
-        event EventHandler<AddStringArgs> AddString;
         event EventHandler<AddFormattedMessageArgs> AddFormatted;
 
         void AddFormattedLine(FormattedMessage message);

--- a/Robust.Shared/Console/ConsoleHost.cs
+++ b/Robust.Shared/Console/ConsoleHost.cs
@@ -46,7 +46,7 @@ namespace Robust.Shared.Console
         /// <inheritdoc />
         public IReadOnlyDictionary<string, IConsoleCommand> RegisteredCommands => AvailableCommands;
 
-        protected ConsoleHost()
+        public ConsoleHost()
         {
             LocalShell = new ConsoleShell(this, null);
         }

--- a/Robust.Shared/Console/IConsoleHost.cs
+++ b/Robust.Shared/Console/IConsoleHost.cs
@@ -39,6 +39,7 @@ namespace Robust.Shared.Console
         IReadOnlyDictionary<string, IConsoleCommand> RegisteredCommands { get; }
 
 
+        event EventHandler<AddStringArgs> AddString;
         event EventHandler ClearText;
 
         /// <summary>


### PR DESCRIPTION
- I decided against removing `IsServer` and `IsClient` since they're still used by `IPauseManager`