### PR TITLE
SnapGridComponent Removal

### DIFF
--- a/Robust.Client/Console/Commands/Debug.cs
+++ b/Robust.Client/Console/Commands/Debug.cs
@@ -311,12 +311,12 @@ namespace Robust.Client.Console.Commands
             if (mapMan.GridExists(new GridId(int.Parse(gridId, CultureInfo.InvariantCulture))))
             {
                 foreach (var entity in
-                    mapMan.GetGrid(new GridId(int.Parse(gridId, CultureInfo.InvariantCulture))).GetSnapGridCell(
+                    mapMan.GetGrid(new GridId(int.Parse(gridId, CultureInfo.InvariantCulture))).GetAnchoredEntities(
                         new Vector2i(
                             int.Parse(indices.Split(',')[0], CultureInfo.InvariantCulture),
                             int.Parse(indices.Split(',')[1], CultureInfo.InvariantCulture))))
                 {
-                    shell.WriteLine(entity.Owner.Uid.ToString());
+                    shell.WriteLine(entity.ToString());
                 }
             }
             else

--- a/Robust.Client/Console/Commands/Debug.cs
+++ b/Robust.Client/Console/Commands/Debug.cs
@@ -280,12 +280,12 @@ namespace Robust.Client.Console.Commands
     internal class SnapGridGetCell : IConsoleCommand
     {
         public string Command => "sggcell";
-        public string Help => "sggcell <gridID> <vector2i> [offset]\nThat vector2i param is in the form x<int>,y<int>.";
+        public string Help => "sggcell <gridID> <vector2i>\nThat vector2i param is in the form x<int>,y<int>.";
         public string Description => "Lists entities on a snap grid cell.";
 
         public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            if (args.Length != 2 && args.Length != 3)
+            if (args.Length != 2)
             {
                 shell.WriteLine(Help);
                 return;
@@ -293,7 +293,6 @@ namespace Robust.Client.Console.Commands
 
             string gridId = args[0];
             string indices = args[1];
-            string offset = args.Length == 3 ? args[2] : "Center";
 
             if (!int.TryParse(args[0], out var id))
             {
@@ -307,17 +306,6 @@ namespace Robust.Client.Console.Commands
                 return;
             }
 
-            SnapGridOffset selectedOffset;
-            if (Enum.IsDefined(typeof(SnapGridOffset), offset))
-            {
-                    selectedOffset = (SnapGridOffset)Enum.Parse(typeof(SnapGridOffset), offset);
-            }
-            else
-            {
-                shell.WriteError("given offset type is not defined");
-                return;
-            }
-
             var mapMan = IoCManager.Resolve<IMapManager>();
 
             if (mapMan.GridExists(new GridId(int.Parse(gridId, CultureInfo.InvariantCulture))))
@@ -326,8 +314,7 @@ namespace Robust.Client.Console.Commands
                     mapMan.GetGrid(new GridId(int.Parse(gridId, CultureInfo.InvariantCulture))).GetSnapGridCell(
                         new Vector2i(
                             int.Parse(indices.Split(',')[0], CultureInfo.InvariantCulture),
-                            int.Parse(indices.Split(',')[1], CultureInfo.InvariantCulture)),
-                        selectedOffset))
+                            int.Parse(indices.Split(',')[1], CultureInfo.InvariantCulture))))
                 {
                     shell.WriteLine(entity.Owner.Uid.ToString());
                 }

--- a/Robust.Client/GameObjects/Components/Light/ClientOccluderComponent.cs
+++ b/Robust.Client/GameObjects/Components/Light/ClientOccluderComponent.cs
@@ -77,7 +77,7 @@ namespace Robust.Client.GameObjects
             {
                 var grid = _mapManager.GetGrid(Owner.Transform.GridID);
                 var position = Owner.Transform.Coordinates;
-                foreach (var neighbor in MapGrid.GetInDir(grid, position, dir))
+                foreach (var neighbor in grid.GetInDir(position, dir))
                 {
                     if (neighbor.TryGetComponent(out ClientOccluderComponent? comp) && comp.Enabled)
                     {

--- a/Robust.Client/GameObjects/Components/Light/ClientOccluderComponent.cs
+++ b/Robust.Client/GameObjects/Components/Light/ClientOccluderComponent.cs
@@ -32,26 +32,24 @@ namespace Robust.Client.GameObjects
             if (Owner.TryGetComponent(out SnapGridComponent? snap))
             {
                 SnapGrid = snap;
-                SnapGrid.OnPositionChanged += SnapGridOnPositionChanged;
 
                 SnapGridOnPositionChanged();
             }
         }
 
-        private void SnapGridOnPositionChanged()
+        public void SnapGridOnPositionChanged()
         {
             SendDirty();
+
+            if(SnapGrid is null)
+                return;
+
             _lastPosition = (Owner.Transform.GridID, SnapGrid!.Position);
         }
 
         protected override void Shutdown()
         {
             base.Shutdown();
-
-            if (SnapGrid != null)
-            {
-                SnapGrid.OnPositionChanged -= SnapGridOnPositionChanged;
-            }
 
             SendDirty();
         }

--- a/Robust.Client/GameObjects/Components/Light/ClientOccluderComponent.cs
+++ b/Robust.Client/GameObjects/Components/Light/ClientOccluderComponent.cs
@@ -76,7 +76,7 @@ namespace Robust.Client.GameObjects
 
             void CheckDir(Direction dir, OccluderDir oclDir)
             {
-                foreach (var neighbor in SnapGrid.GetInDir(dir))
+                foreach (var neighbor in SnapGridComponent.GetInDir(SnapGrid, dir))
                 {
                     if (neighbor.TryGetComponent(out ClientOccluderComponent? comp) && comp.Enabled)
                     {

--- a/Robust.Client/GameObjects/Components/Light/ClientOccluderComponent.cs
+++ b/Robust.Client/GameObjects/Components/Light/ClientOccluderComponent.cs
@@ -61,7 +61,7 @@ namespace Robust.Client.GameObjects
             if (SnapGrid != null)
             {
                 Owner.EntityManager.EventBus.RaiseEvent(EventSource.Local,
-                    new OccluderDirtyEvent(Owner, _lastPosition, SnapGrid.Offset));
+                    new OccluderDirtyEvent(Owner, _lastPosition));
             }
         }
 

--- a/Robust.Client/GameObjects/Components/Light/ClientOccluderComponent.cs
+++ b/Robust.Client/GameObjects/Components/Light/ClientOccluderComponent.cs
@@ -45,7 +45,7 @@ namespace Robust.Client.GameObjects
                 return;
 
             var grid = _mapManager.GetGrid(Owner.Transform.GridID);
-            _lastPosition = (Owner.Transform.GridID, grid.SnapGridCellFor(Owner.Transform.Coordinates));
+            _lastPosition = (Owner.Transform.GridID, grid.TileIndicesFor(Owner.Transform.Coordinates));
         }
 
         protected override void Shutdown()
@@ -79,7 +79,7 @@ namespace Robust.Client.GameObjects
                 var position = Owner.Transform.Coordinates;
                 foreach (var neighbor in grid.GetInDir(position, dir))
                 {
-                    if (neighbor.TryGetComponent(out ClientOccluderComponent? comp) && comp.Enabled)
+                    if (Owner.EntityManager.ComponentManager.TryGetComponent(neighbor, out ClientOccluderComponent? comp) && comp.Enabled)
                     {
                         Occluding |= oclDir;
                         break;

--- a/Robust.Client/GameObjects/Components/Light/ClientOccluderComponent.cs
+++ b/Robust.Client/GameObjects/Components/Light/ClientOccluderComponent.cs
@@ -31,7 +31,7 @@ namespace Robust.Client.GameObjects
         {
             base.Startup();
 
-            if (Owner.HasComponent<SnapGridComponent>())
+            if (Owner.Transform.Anchored)
             {
                 SnapGridOnPositionChanged();
             }
@@ -41,7 +41,7 @@ namespace Robust.Client.GameObjects
         {
             SendDirty();
 
-            if(!Owner.HasComponent<SnapGridComponent>())
+            if(!Owner.Transform.Anchored)
                 return;
 
             var grid = _mapManager.GetGrid(Owner.Transform.GridID);
@@ -57,7 +57,7 @@ namespace Robust.Client.GameObjects
 
         private void SendDirty()
         {
-            if (Owner.HasComponent<SnapGridComponent>())
+            if (Owner.Transform.Anchored)
             {
                 Owner.EntityManager.EventBus.RaiseEvent(EventSource.Local,
                     new OccluderDirtyEvent(Owner, _lastPosition));

--- a/Robust.Client/GameObjects/Components/Light/ClientOccluderComponent.cs
+++ b/Robust.Client/GameObjects/Components/Light/ClientOccluderComponent.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
@@ -67,14 +68,16 @@ namespace Robust.Client.GameObjects
         {
             Occluding = OccluderDir.None;
 
-            if (Deleted || !Owner.TryGetComponent<SnapGridComponent>(out var snapGrid))
+            if (Deleted || !Owner.Transform.Anchored)
             {
                 return;
             }
 
             void CheckDir(Direction dir, OccluderDir oclDir)
             {
-                foreach (var neighbor in MapGrid.GetInDir(snapGrid, dir))
+                var grid = _mapManager.GetGrid(Owner.Transform.GridID);
+                var position = Owner.Transform.Coordinates;
+                foreach (var neighbor in MapGrid.GetInDir(grid, position, dir))
                 {
                     if (neighbor.TryGetComponent(out ClientOccluderComponent? comp) && comp.Enabled)
                     {

--- a/Robust.Client/GameObjects/EntitySystems/ClientOccluderSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ClientOccluderSystem.cs
@@ -79,10 +79,10 @@ namespace Robust.Client.GameObjects
             {
                 var pos = ev.LastPosition.Value.pos;
 
-                AddValidEntities(grid.GetSnapGridCell(pos + new Vector2i(1, 0), ev.Offset));
-                AddValidEntities(grid.GetSnapGridCell(pos + new Vector2i(-1, 0), ev.Offset));
-                AddValidEntities(grid.GetSnapGridCell(pos + new Vector2i(0, 1), ev.Offset));
-                AddValidEntities(grid.GetSnapGridCell(pos + new Vector2i(0, -1), ev.Offset));
+                AddValidEntities(grid.GetSnapGridCell(pos + new Vector2i(1, 0)));
+                AddValidEntities(grid.GetSnapGridCell(pos + new Vector2i(-1, 0)));
+                AddValidEntities(grid.GetSnapGridCell(pos + new Vector2i(0, 1)));
+                AddValidEntities(grid.GetSnapGridCell(pos + new Vector2i(0, -1)));
             }
         }
 
@@ -108,15 +108,13 @@ namespace Robust.Client.GameObjects
     /// </summary>
     internal sealed class OccluderDirtyEvent : EntityEventArgs
     {
-        public OccluderDirtyEvent(IEntity sender, (GridId grid, Vector2i pos)? lastPosition, SnapGridOffset offset)
+        public OccluderDirtyEvent(IEntity sender, (GridId grid, Vector2i pos)? lastPosition)
         {
             LastPosition = lastPosition;
-            Offset = offset;
             Sender = sender;
         }
 
         public (GridId grid, Vector2i pos)? LastPosition { get; }
-        public SnapGridOffset Offset { get; }
         public IEntity Sender { get; }
     }
 }

--- a/Robust.Client/GameObjects/EntitySystems/ClientOccluderSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ClientOccluderSystem.cs
@@ -83,13 +83,14 @@ namespace Robust.Client.GameObjects
                 sender.TryGetComponent(out ClientOccluderComponent? iconSmooth)
                 && iconSmooth.Running)
             {
-                var snapGrid = sender.GetComponent<SnapGridComponent>();
+                var grid1 = _mapManager.GetGrid(sender.Transform.GridID);
+                var coords = sender.Transform.Coordinates;
 
                 _dirtyEntities.Enqueue(sender);
-                AddValidEntities(MapGrid.GetInDir(snapGrid, Direction.North));
-                AddValidEntities(MapGrid.GetInDir(snapGrid, Direction.South));
-                AddValidEntities(MapGrid.GetInDir(snapGrid, Direction.East));
-                AddValidEntities(MapGrid.GetInDir(snapGrid, Direction.West));
+                AddValidEntities(MapGrid.GetInDir(grid1, coords, Direction.North));
+                AddValidEntities(MapGrid.GetInDir(grid1, coords, Direction.South));
+                AddValidEntities(MapGrid.GetInDir(grid1, coords, Direction.East));
+                AddValidEntities(MapGrid.GetInDir(grid1, coords, Direction.West));
             }
 
             // Entity is no longer valid, update around the last position it was at.

--- a/Robust.Client/GameObjects/EntitySystems/ClientOccluderSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ClientOccluderSystem.cs
@@ -87,10 +87,10 @@ namespace Robust.Client.GameObjects
                 var coords = sender.Transform.Coordinates;
 
                 _dirtyEntities.Enqueue(sender);
-                AddValidEntities(MapGrid.GetInDir(grid1, coords, Direction.North));
-                AddValidEntities(MapGrid.GetInDir(grid1, coords, Direction.South));
-                AddValidEntities(MapGrid.GetInDir(grid1, coords, Direction.East));
-                AddValidEntities(MapGrid.GetInDir(grid1, coords, Direction.West));
+                AddValidEntities(grid1.GetInDir(coords, Direction.North));
+                AddValidEntities(grid1.GetInDir(coords, Direction.South));
+                AddValidEntities(grid1.GetInDir(coords, Direction.East));
+                AddValidEntities(grid1.GetInDir(coords, Direction.West));
             }
 
             // Entity is no longer valid, update around the last position it was at.

--- a/Robust.Client/GameObjects/EntitySystems/ClientOccluderSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ClientOccluderSystem.cs
@@ -24,6 +24,7 @@ namespace Robust.Client.GameObjects
 
         private uint _updateGeneration;
 
+        /// <inheritdoc />
         public override void Initialize()
         {
             base.Initialize();
@@ -32,6 +33,18 @@ namespace Robust.Client.GameObjects
             UpdatesAfter.Add(typeof(PhysicsSystem));
 
             SubscribeLocalEvent<OccluderDirtyEvent>(HandleDirtyEvent);
+
+            SubscribeLocalEvent<ClientOccluderComponent, SnapGridPositionChangedEvent>(HandleSnapGridMove);
+        }
+
+        /// <inheritdoc />
+        public override void Shutdown()
+        {
+            UnsubscribeLocalEvent<OccluderDirtyEvent>();
+
+            UnsubscribeLocalEvent<ClientOccluderComponent, SnapGridPositionChangedEvent>(HandleSnapGridMove);
+
+            base.Shutdown();
         }
 
         public override void FrameUpdate(float frameTime)
@@ -56,6 +69,11 @@ namespace Robust.Client.GameObjects
                     occluder.UpdateGeneration = _updateGeneration;
                 }
             }
+        }
+
+        private static void HandleSnapGridMove(EntityUid uid, ClientOccluderComponent component, SnapGridPositionChangedEvent args)
+        {
+            component.SnapGridOnPositionChanged();
         }
 
         private void HandleDirtyEvent(OccluderDirtyEvent ev)

--- a/Robust.Client/GameObjects/EntitySystems/ClientOccluderSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ClientOccluderSystem.cs
@@ -86,10 +86,10 @@ namespace Robust.Client.GameObjects
                 var snapGrid = sender.GetComponent<SnapGridComponent>();
 
                 _dirtyEntities.Enqueue(sender);
-                AddValidEntities(SnapGridComponent.GetInDir(snapGrid, Direction.North));
-                AddValidEntities(SnapGridComponent.GetInDir(snapGrid, Direction.South));
-                AddValidEntities(SnapGridComponent.GetInDir(snapGrid, Direction.East));
-                AddValidEntities(SnapGridComponent.GetInDir(snapGrid, Direction.West));
+                AddValidEntities(MapGrid.GetInDir(snapGrid, Direction.North));
+                AddValidEntities(MapGrid.GetInDir(snapGrid, Direction.South));
+                AddValidEntities(MapGrid.GetInDir(snapGrid, Direction.East));
+                AddValidEntities(MapGrid.GetInDir(snapGrid, Direction.West));
             }
 
             // Entity is no longer valid, update around the last position it was at.

--- a/Robust.Client/GameObjects/EntitySystems/ClientOccluderSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ClientOccluderSystem.cs
@@ -68,10 +68,10 @@ namespace Robust.Client.GameObjects
                 var snapGrid = sender.GetComponent<SnapGridComponent>();
 
                 _dirtyEntities.Enqueue(sender);
-                AddValidEntities(snapGrid.GetInDir(Direction.North));
-                AddValidEntities(snapGrid.GetInDir(Direction.South));
-                AddValidEntities(snapGrid.GetInDir(Direction.East));
-                AddValidEntities(snapGrid.GetInDir(Direction.West));
+                AddValidEntities(SnapGridComponent.GetInDir(snapGrid, Direction.North));
+                AddValidEntities(SnapGridComponent.GetInDir(snapGrid, Direction.South));
+                AddValidEntities(SnapGridComponent.GetInDir(snapGrid, Direction.East));
+                AddValidEntities(SnapGridComponent.GetInDir(snapGrid, Direction.West));
             }
 
             // Entity is no longer valid, update around the last position it was at.

--- a/Robust.Client/Map/ClientMapManager.cs
+++ b/Robust.Client/Map/ClientMapManager.cs
@@ -56,8 +56,7 @@ namespace Robust.Client.Map
                         continue;
                     }
 
-                    CreateGrid(gridData![gridId].Coordinates.MapId, gridId, creationDatum.ChunkSize,
-                        creationDatum.SnapSize);
+                    CreateGrid(gridData![gridId].Coordinates.MapId, gridId, creationDatum.ChunkSize);
                 }
             }
 

--- a/Robust.Client/Placement/Modes/AlignSnapgridBorder.cs
+++ b/Robust.Client/Placement/Modes/AlignSnapgridBorder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Robust.Client.Graphics;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
@@ -62,7 +62,7 @@ namespace Robust.Client.Placement.Modes
             var gridId = MouseCoords.GetGridId(pManager.EntityManager);
             if (gridId.IsValid())
             {
-                snapSize = pManager.MapManager.GetGrid(gridId).SnapSize; //Find snap size for the grid.
+                snapSize = pManager.MapManager.GetGrid(gridId).TileSize; //Find snap size for the grid.
                 onGrid = true;
             }
             else

--- a/Robust.Client/Placement/Modes/AlignSnapgridCenter.cs
+++ b/Robust.Client/Placement/Modes/AlignSnapgridCenter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Robust.Client.Graphics;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
@@ -52,7 +52,7 @@ namespace Robust.Client.Placement.Modes
             snapSize = 1f;
             if (gridId.IsValid())
             {
-                snapSize = pManager.MapManager.GetGrid(gridId).SnapSize; //Find snap size for the grid.
+                snapSize = pManager.MapManager.GetGrid(gridId).TileSize; //Find snap size for the grid.
                 onGrid = true;
             }
             else

--- a/Robust.Server/GameStates/EntityViewCulling.cs
+++ b/Robust.Server/GameStates/EntityViewCulling.cs
@@ -193,13 +193,14 @@ namespace Robust.Server.GameStates
                 if (!_entMan.EntityExists(entityUid))
                     continue;
 
+                var xform = _compMan.GetComponent<ITransformComponent>(entityUid);
+
                 // Anchored entities don't ever leave
-                if (_compMan.HasComponent<SnapGridComponent>(entityUid))
+                if (xform.Anchored)
                     continue;
 
                 // PVS leave message
                 //TODO: Remove NaN as the signal to leave PVS
-                var xform = _compMan.GetComponent<ITransformComponent>(entityUid);
                 var oldState = (TransformComponent.TransformComponentState) xform.GetComponentState(session);
 
                 entityStates.Add(new EntityState(entityUid,
@@ -232,7 +233,8 @@ namespace Robust.Server.GameStates
                     // PVS enter message
 
                     // skip sending anchored entities (walls)
-                    if (_compMan.HasComponent<SnapGridComponent>(entityUid) && _entMan.GetEntity(entityUid).LastModifiedTick <= lastMapUpdate)
+                    var xform = _compMan.GetComponent<ITransformComponent>(entityUid);
+                    if (xform.Anchored && _entMan.GetEntity(entityUid).LastModifiedTick <= lastMapUpdate)
                         continue;
 
                     // don't assume the client knows anything about us

--- a/Robust.Server/Map/ServerMapManager.cs
+++ b/Robust.Server/Map/ServerMapManager.cs
@@ -73,7 +73,7 @@ namespace Robust.Server.Map
             var mapCreations = _mapCreationTick.Where(kv => kv.Value >= fromTick && kv.Key != MapId.Nullspace)
                 .Select(kv => kv.Key).ToArray();
             var gridCreations = _grids.Values.Where(g => g.CreatedTick >= fromTick && g.ParentMapId != MapId.Nullspace).ToDictionary(g => g.Index,
-                grid => new GameStateMapData.GridCreationDatum(grid.ChunkSize, grid.SnapSize));
+                grid => new GameStateMapData.GridCreationDatum(grid.ChunkSize));
 
             // no point sending empty collections
             if (gridDatums.Count        == 0)  gridDatums        = default;

--- a/Robust.Server/Maps/YamlGridSerializer.cs
+++ b/Robust.Server/Maps/YamlGridSerializer.cs
@@ -25,7 +25,6 @@ namespace Robust.Server.Maps
 
             info.Add("chunksize", grid.ChunkSize.ToString(CultureInfo.InvariantCulture));
             info.Add("tilesize", grid.TileSize.ToString(CultureInfo.InvariantCulture));
-            info.Add("snapsize", grid.SnapSize.ToString(CultureInfo.InvariantCulture));
 
             var chunks = grid.GetMapChunks();
             foreach (var chunk in chunks)

--- a/Robust.Shared/GameObjects/Components/ITransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/ITransformComponent.cs
@@ -125,6 +125,11 @@ namespace Robust.Shared.GameObjects
         IEnumerable<ITransformComponent> Children { get; }
         int ChildCount { get; }
         IEnumerable<EntityUid> ChildEntityUids { get; }
+
+        /// <summary>
+        /// Is this transform anchored to a grid tile?
+        /// </summary>
+        bool Anchored { get; }
         Matrix3 GetLocalMatrix();
         Matrix3 GetLocalMatrixInv();
         void DetachParentToNull();

--- a/Robust.Shared/GameObjects/Components/ITransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/ITransformComponent.cs
@@ -129,7 +129,8 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         /// Is this transform anchored to a grid tile?
         /// </summary>
-        bool Anchored { get; }
+        bool Anchored { get; set; }
+
         Matrix3 GetLocalMatrix();
         Matrix3 GetLocalMatrixInv();
         void DetachParentToNull();

--- a/Robust.Shared/GameObjects/Components/Transform/SnapGridComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/SnapGridComponent.cs
@@ -20,27 +20,8 @@ namespace Robust.Shared.GameObjects
         private bool IsSet;
         [Dependency] private readonly IMapManager _mapManager = default!;
 
-        [Obsolete]
-        public event Action? OnPositionChanged;
-
         private GridId _lastGrid;
         public Vector2i Position { get; private set; }
-
-        /// <inheritdoc />
-        public override void Initialize()
-        {
-            base.Initialize();
-
-            UpdatePosition(this);
-        }
-
-        /// <inheritdoc />
-        protected override void Shutdown()
-        {
-            base.Shutdown();
-
-            CompShutdown(this);
-        }
 
         public static void CompShutdown(SnapGridComponent snapComp)
         {
@@ -183,7 +164,6 @@ namespace Robust.Shared.GameObjects
 
             if (oldPos != snapComp.Position)
             {
-                snapComp.OnPositionChanged?.Invoke();
                 snapComp.Owner.EntityManager.EventBus.RaiseLocalEvent(snapComp.Owner.Uid,
                     new SnapGridPositionChangedEvent(snapComp.Position, oldPos, snapComp._lastGrid, oldGrid));
             }

--- a/Robust.Shared/GameObjects/Components/Transform/SnapGridComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/SnapGridComponent.cs
@@ -11,13 +11,13 @@ namespace Robust.Shared.GameObjects
     {
         public sealed override string Name => "SnapGrid";
 
-        internal bool IsSet;
-        internal IMapManager _mapManager => IoCManager.Resolve<IMapManager>();
+        private IMapManager _mapManager => IoCManager.Resolve<IMapManager>();
 
+        internal bool IsSet;
         internal GridId _lastGrid;
         internal Vector2i Position => GetTilePosition(_mapManager, Owner.Transform);
 
-        public static Vector2i GetTilePosition(IMapManager mapManager, ITransformComponent transform)
+        private static Vector2i GetTilePosition(IMapManager mapManager, ITransformComponent transform)
         {
             var grid = mapManager.GetGrid(transform.GridID);
             return grid.SnapGridCellFor(transform.Coordinates);

--- a/Robust.Shared/GameObjects/Components/Transform/SnapGridComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/SnapGridComponent.cs
@@ -1,31 +1,24 @@
-using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 
 namespace Robust.Shared.GameObjects
 {
     /// <summary>
-    ///     Makes it possible to look this entity up with the snap grid.
+    /// Makes it possible to look this entity up with the snap grid.
     /// </summary>
-    public class SnapGridComponent : Component, IComponentDebug
+    internal class SnapGridComponent : Component
     {
+        /// <inheritdoc />
         public sealed override string Name => "SnapGrid";
 
-        private IMapManager _mapManager => IoCManager.Resolve<IMapManager>();
+        /// <summary>
+        /// GridId the last time this component was moved.
+        /// </summary>
+        internal GridId LastGrid = GridId.Invalid;
 
-        internal bool IsSet;
-        internal GridId _lastGrid;
-        internal Vector2i Position => GetTilePosition(_mapManager, Owner.Transform);
-
-        private static Vector2i GetTilePosition(IMapManager mapManager, ITransformComponent transform)
-        {
-            var grid = mapManager.GetGrid(transform.GridID);
-            return grid.SnapGridCellFor(transform.Coordinates);
-        }
-
-        public string GetDebugString()
-        {
-            return $"pos: {GetTilePosition(_mapManager, Owner.Transform)}";
-        }
+        /// <summary>
+        /// TileIndices the last time this component was moved.
+        /// </summary>
+        internal Vector2i LastTileIndices;
     }
 }

--- a/Robust.Shared/GameObjects/Components/Transform/SnapGridComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/SnapGridComponent.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.Contracts;
-using System.Linq;
 using Robust.Shared.IoC;
-using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 
@@ -14,179 +9,23 @@ namespace Robust.Shared.GameObjects
     /// </summary>
     public class SnapGridComponent : Component, IComponentDebug
     {
-        private const string LogCategory = "go.comp.snapgrid";
         public sealed override string Name => "SnapGrid";
 
-        private bool IsSet;
-        [Dependency] private readonly IMapManager _mapManager = default!;
+        internal bool IsSet;
+        internal IMapManager _mapManager => IoCManager.Resolve<IMapManager>();
 
-        private GridId _lastGrid;
-        public Vector2i Position { get; private set; }
+        internal GridId _lastGrid;
+        internal Vector2i Position => GetTilePosition(_mapManager, Owner.Transform);
 
-        public static void CompShutdown(SnapGridComponent snapComp)
+        public static Vector2i GetTilePosition(IMapManager mapManager, ITransformComponent transform)
         {
-            if (!snapComp.IsSet)
-                return;
-
-            if (snapComp._mapManager.TryGetGrid(snapComp._lastGrid, out var grid))
-            {
-                grid.RemoveFromSnapGridCell(snapComp.Position, snapComp);
-                return;
-            }
-
-            snapComp.IsSet = false;
-        }
-
-        /// <summary>
-        ///     Returns an enumerable over all the entities which are one tile over in a certain direction.
-        /// </summary>
-        public static IEnumerable<IEntity> GetInDir(SnapGridComponent snapComp, Direction dir)
-        {
-            if (!snapComp._mapManager.TryGetGrid(snapComp.Owner.Transform.GridID, out var grid))
-                return Enumerable.Empty<IEntity>();
-            var pos = SnapGridPosAt(snapComp.Position, dir);
-
-            return grid.GetSnapGridCell(pos).Select(s => s.Owner);
-        }
-
-        [Pure]
-        public static IEnumerable<IEntity> GetOffset(SnapGridComponent snapComp, Vector2i offset)
-        {
-            if (!snapComp._mapManager.TryGetGrid(snapComp.Owner.Transform.GridID, out var grid))
-                return Enumerable.Empty<IEntity>();
-            var pos = snapComp.Position + offset;
-
-            return grid.GetSnapGridCell(pos).Select(s => s.Owner);
-        }
-
-        public static IEnumerable<IEntity> GetLocal(SnapGridComponent snapComp)
-        {
-            if (!snapComp._mapManager.TryGetGrid(snapComp.Owner.Transform.GridID, out var grid))
-                return Enumerable.Empty<IEntity>();
-
-            return grid.GetSnapGridCell(snapComp.Position).Select(s => s.Owner);
+            var grid = mapManager.GetGrid(transform.GridID);
+            return grid.SnapGridCellFor(transform.Coordinates);
         }
 
         public string GetDebugString()
         {
-            return $"pos: {Position}";
-        }
-
-        public static EntityCoordinates DirectionToGrid(SnapGridComponent snapComp, Direction direction)
-        {
-            if (!snapComp._mapManager.TryGetGrid(snapComp.Owner.Transform.GridID, out var grid))
-                return snapComp.Owner.Transform.Coordinates.Offset(direction.ToVec());
-
-            var coords = grid.GridTileToLocal(SnapGridPosAt(snapComp.Position, direction));
-
-            return coords;
-        }
-
-        private static Vector2i SnapGridPosAt(Vector2i position, Direction dir, int dist = 1)
-        {
-            switch (dir)
-            {
-                case Direction.East:
-                    return position + new Vector2i(dist, 0);
-                case Direction.SouthEast:
-                    return position + new Vector2i(dist, -dist);
-                case Direction.South:
-                    return position + new Vector2i(0, -dist);
-                case Direction.SouthWest:
-                    return position + new Vector2i(-dist, -dist);
-                case Direction.West:
-                    return position + new Vector2i(-dist, 0);
-                case Direction.NorthWest:
-                    return position + new Vector2i(-dist, dist);
-                case Direction.North:
-                    return position + new Vector2i(0, dist);
-                case Direction.NorthEast:
-                    return position + new Vector2i(dist, dist);
-                default:
-                    throw new NotImplementedException();
-            }
-        }
-
-        public static IEnumerable<SnapGridComponent> GetCardinalNeighborCells(SnapGridComponent snapComp)
-        {
-            if (!snapComp._mapManager.TryGetGrid(snapComp.Owner.Transform.GridID, out var grid))
-                yield break;
-
-            foreach (var cell in grid.GetSnapGridCell(snapComp.Position))
-                yield return cell;
-            foreach (var cell in grid.GetSnapGridCell(snapComp.Position + new Vector2i(0, 1)))
-                yield return cell;
-            foreach (var cell in grid.GetSnapGridCell(snapComp.Position + new Vector2i(0, -1)))
-                yield return cell;
-            foreach (var cell in grid.GetSnapGridCell(snapComp.Position + new Vector2i(1, 0)))
-                yield return cell;
-            foreach (var cell in grid.GetSnapGridCell(snapComp.Position + new Vector2i(-1, 0)))
-                yield return cell;
-        }
-
-        public static IEnumerable<SnapGridComponent> GetCellsInSquareArea(SnapGridComponent snapComp, int n = 1)
-        {
-            if (!snapComp._mapManager.TryGetGrid(snapComp.Owner.Transform.GridID, out var grid))
-                yield break;
-
-            for (var y = -n; y <= n; ++y)
-            for (var x = -n; x <= n; ++x)
-                foreach (var cell in grid.GetSnapGridCell(snapComp.Position + new Vector2i(x, y)))
-                    yield return cell;
-        }
-
-        internal static void UpdatePosition(SnapGridComponent snapComp)
-        {
-            if (snapComp.IsSet)
-            {
-                if (!snapComp._mapManager.TryGetGrid(snapComp._lastGrid, out var lastGrid))
-                {
-                    Logger.WarningS(LogCategory, "Entity {0} snapgrid didn't find grid {1}. Race condition?", snapComp.Owner.Uid, snapComp.Owner.Transform.GridID);
-                    return;
-                }
-
-                lastGrid.RemoveFromSnapGridCell(snapComp.Position, snapComp);
-            }
-
-            if (!snapComp._mapManager.TryGetGrid(snapComp.Owner.Transform.GridID, out var grid))
-            {
-                // Either a race condition, or we're not on any grids.
-                return;
-            }
-
-            snapComp.IsSet = true;
-
-            var oldPos = snapComp.Position;
-            snapComp.Position = grid.SnapGridCellFor(snapComp.Owner.Transform.Coordinates);
-            var oldGrid = snapComp._lastGrid;
-            snapComp._lastGrid = snapComp.Owner.Transform.GridID;
-            grid.AddToSnapGridCell(snapComp.Position, snapComp);
-
-            if (oldPos != snapComp.Position)
-            {
-                snapComp.Owner.EntityManager.EventBus.RaiseLocalEvent(snapComp.Owner.Uid,
-                    new SnapGridPositionChangedEvent(snapComp.Position, oldPos, snapComp._lastGrid, oldGrid));
-            }
-        }
-    }
-
-    public class SnapGridPositionChangedEvent : EntityEventArgs
-    {
-        public GridId OldGrid { get; }
-        public GridId NewGrid { get; }
-
-        public bool SameGrid => OldGrid == NewGrid;
-
-        public Vector2i OldPosition { get; }
-        public Vector2i Position { get; }
-
-        public SnapGridPositionChangedEvent(Vector2i position, Vector2i oldPosition, GridId newGrid, GridId oldGrid)
-        {
-            Position = position;
-            OldPosition = oldPosition;
-
-            NewGrid = newGrid;
-            OldGrid = oldGrid;
+            return $"pos: {GetTilePosition(_mapManager, Owner.Transform)}";
         }
     }
 }

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -321,6 +321,10 @@ namespace Robust.Shared.GameObjects
             }
         }
 
+        /// <inheritdoc />
+        [ViewVariables]
+        public bool Anchored => Owner.EntityManager.ComponentManager.HasComponent<SnapGridComponent>(Owner.Uid);
+
         [ViewVariables]
         public IEnumerable<ITransformComponent> Children =>
             _children.Select(u => Owner.EntityManager.GetEntity(u).Transform);

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -323,7 +323,18 @@ namespace Robust.Shared.GameObjects
 
         /// <inheritdoc />
         [ViewVariables]
-        public bool Anchored => Owner.EntityManager.ComponentManager.HasComponent<SnapGridComponent>(Owner.Uid);
+        public bool Anchored
+        {
+            get => Owner.HasComponent<SnapGridComponent>();
+            set
+            {
+                if(value && !Owner.HasComponent<SnapGridComponent>())
+                    Owner.AddComponent<SnapGridComponent>();
+
+                else if(!value && Owner.HasComponent<SnapGridComponent>())
+                    Owner.RemoveComponent<SnapGridComponent>();
+            }
+        }
 
         [ViewVariables]
         public IEnumerable<ITransformComponent> Children =>

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -114,7 +114,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public bool IsValid()
         {
-            return !Deleted;
+            return EntityManager.EntityExists(Uid);
         }
 
         /// <summary>
@@ -235,7 +235,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public bool HasComponent<T>()
         {
-            return EntityManager.ComponentManager.HasComponent(Uid, typeof(T));
+            return EntityManager.ComponentManager.HasComponent<T>(Uid);
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -297,7 +297,13 @@ namespace Robust.Shared.GameObjects
 
         public bool EntityExists(EntityUid uid)
         {
-            return TryGetEntity(uid, out var _);
+            if (!TryGetEntity(uid, out var ent))
+                return false;
+
+            if (ent.Deleted)
+                return false;
+
+            return true;
         }
 
         /// <summary>
@@ -349,8 +355,13 @@ namespace Robust.Shared.GameObjects
 
             var entity = new Entity(this, uid.Value);
 
+
             // we want this called before adding components
             EntityAdded?.Invoke(this, entity.Uid);
+
+            // We do this after the event, so if the event throws we have not committed 
+            Entities[entity.Uid] = entity;
+            AllEntities.Add(entity);
 
             // allocate the required MetaDataComponent
             _componentManager.AddComponent<MetaDataComponent>(entity);
@@ -358,8 +369,6 @@ namespace Robust.Shared.GameObjects
             // allocate the required TransformComponent
             _componentManager.AddComponent<TransformComponent>(entity);
 
-            Entities[entity.Uid] = entity;
-            AllEntities.Add(entity);
 
             return entity;
         }

--- a/Robust.Shared/GameObjects/Systems/SnapGridSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SnapGridSystem.cs
@@ -16,7 +16,7 @@ namespace Robust.Shared.GameObjects
         {
             base.Initialize();
 
-            SubscribeLocalEvent<SnapGridComponent, ComponentInit>(HandleComponentInit);
+            SubscribeLocalEvent<SnapGridComponent, ComponentStartup>(HandleComponentStartup);
             SubscribeLocalEvent<SnapGridComponent, ComponentShutdown>(HandleComponentShutdown);
             SubscribeLocalEvent<SnapGridComponent, MoveEvent>(HandleMoveEvent);
         }
@@ -26,12 +26,12 @@ namespace Robust.Shared.GameObjects
         {
             base.Shutdown();
 
-            UnsubscribeLocalEvent<SnapGridComponent, ComponentInit>(HandleComponentInit);
+            UnsubscribeLocalEvent<SnapGridComponent, ComponentStartup>(HandleComponentStartup);
             UnsubscribeLocalEvent<SnapGridComponent, ComponentShutdown>(HandleComponentShutdown);
             UnsubscribeLocalEvent<SnapGridComponent, MoveEvent>(HandleMoveEvent);
         }
 
-        private void HandleComponentInit(EntityUid uid, SnapGridComponent component, ComponentInit args)
+        private void HandleComponentStartup(EntityUid uid, SnapGridComponent component, ComponentStartup args)
         {
             var transform = ComponentManager.GetComponent<ITransformComponent>(uid);
             UpdatePosition(uid, transform, component);

--- a/Robust.Shared/GameObjects/Systems/SnapGridSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SnapGridSystem.cs
@@ -9,19 +9,33 @@ namespace Robust.Shared.GameObjects
         {
             base.Initialize();
 
-            SubscribeLocalEvent<SnapGridComponent, MoveEvent>(OnMoveEvent);
+            SubscribeLocalEvent<SnapGridComponent, ComponentInit>(HandleComponentInit);
+            SubscribeLocalEvent<SnapGridComponent, ComponentShutdown>(HandleComponentShutdown);
+            SubscribeLocalEvent<SnapGridComponent, MoveEvent>(HandleMoveEvent);
         }
-
+        
         public override void Shutdown()
         {
             base.Shutdown();
 
-            UnsubscribeLocalEvent<SnapGridComponent, MoveEvent>(OnMoveEvent);
+            UnsubscribeLocalEvent<SnapGridComponent, ComponentInit>(HandleComponentInit);
+            UnsubscribeLocalEvent<SnapGridComponent, ComponentShutdown>(HandleComponentShutdown);
+            UnsubscribeLocalEvent<SnapGridComponent, MoveEvent>(HandleMoveEvent);
         }
 
-        private void OnMoveEvent(EntityUid uid, SnapGridComponent snapGrid, MoveEvent args)
+        private void HandleComponentInit(EntityUid uid, SnapGridComponent component, ComponentInit args)
         {
-            snapGrid.UpdatePosition();
+            SnapGridComponent.UpdatePosition(component);
+        }
+
+        private void HandleComponentShutdown(EntityUid uid, SnapGridComponent component, ComponentShutdown args)
+        {
+            SnapGridComponent.CompShutdown(component);
+        }
+
+        private void HandleMoveEvent(EntityUid uid, SnapGridComponent snapGrid, MoveEvent args)
+        {
+            SnapGridComponent.UpdatePosition(snapGrid);
         }
     }
 }

--- a/Robust.Shared/GameObjects/Systems/SnapGridSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SnapGridSystem.cs
@@ -13,7 +13,7 @@ namespace Robust.Shared.GameObjects
             SubscribeLocalEvent<SnapGridComponent, ComponentShutdown>(HandleComponentShutdown);
             SubscribeLocalEvent<SnapGridComponent, MoveEvent>(HandleMoveEvent);
         }
-        
+
         public override void Shutdown()
         {
             base.Shutdown();

--- a/Robust.Shared/GameObjects/Systems/SnapGridSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SnapGridSystem.cs
@@ -1,10 +1,17 @@
 using JetBrains.Annotations;
+using Robust.Shared.IoC;
+using Robust.Shared.Log;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
 
 namespace Robust.Shared.GameObjects
 {
     [UsedImplicitly]
     public class SnapGridSystem : EntitySystem
     {
+        [Dependency] private readonly IMapManager _mapManager = default!;
+
+        /// <inheritdoc />
         public override void Initialize()
         {
             base.Initialize();
@@ -14,6 +21,7 @@ namespace Robust.Shared.GameObjects
             SubscribeLocalEvent<SnapGridComponent, MoveEvent>(HandleMoveEvent);
         }
 
+        /// <inheritdoc />
         public override void Shutdown()
         {
             base.Shutdown();
@@ -25,17 +33,82 @@ namespace Robust.Shared.GameObjects
 
         private void HandleComponentInit(EntityUid uid, SnapGridComponent component, ComponentInit args)
         {
-            SnapGridComponent.UpdatePosition(component);
+            UpdatePosition(component);
         }
 
         private void HandleComponentShutdown(EntityUid uid, SnapGridComponent component, ComponentShutdown args)
         {
-            SnapGridComponent.CompShutdown(component);
+            if (!component.IsSet)
+                return;
+
+            var transform = ComponentManager.GetComponent<ITransformComponent>(uid);
+
+            if (_mapManager.TryGetGrid(component._lastGrid, out var grid))
+            {
+                grid.RemoveFromSnapGridCell(grid.SnapGridCellFor(transform.Coordinates), component);
+                return;
+            }
+
+            component.IsSet = false;
         }
 
         private void HandleMoveEvent(EntityUid uid, SnapGridComponent snapGrid, MoveEvent args)
         {
-            SnapGridComponent.UpdatePosition(snapGrid);
+            UpdatePosition(snapGrid);
+        }
+
+        //TODO: The event is broken
+        private void UpdatePosition(SnapGridComponent snapComp)
+        {
+            if (snapComp.IsSet)
+            {
+                if (!_mapManager.TryGetGrid(snapComp._lastGrid, out var lastGrid))
+                {
+                    Logger.WarningS("go.comp.snapgrid", "Entity {0} snapgrid didn't find grid {1}. Race condition?", snapComp.Owner.Uid, snapComp.Owner.Transform.GridID);
+                    return;
+                }
+
+                lastGrid.RemoveFromSnapGridCell(snapComp.Position, snapComp);
+            }
+
+            if (!_mapManager.TryGetGrid(snapComp.Owner.Transform.GridID, out var grid))
+            {
+                // Either a race condition, or we're not on any grids.
+                return;
+            }
+
+            snapComp.IsSet = true;
+
+            var oldPos = snapComp.Position;
+            var oldGrid = snapComp._lastGrid;
+            snapComp._lastGrid = snapComp.Owner.Transform.GridID;
+            grid.AddToSnapGridCell(snapComp.Position, snapComp);
+
+            if (oldPos != snapComp.Position)
+            {
+                snapComp.Owner.EntityManager.EventBus.RaiseLocalEvent(snapComp.Owner.Uid,
+                    new SnapGridPositionChangedEvent(snapComp.Position, oldPos, snapComp._lastGrid, oldGrid));
+            }
+        }
+    }
+
+    public class SnapGridPositionChangedEvent : EntityEventArgs
+    {
+        public GridId OldGrid { get; }
+        public GridId NewGrid { get; }
+
+        public bool SameGrid => OldGrid == NewGrid;
+
+        public Vector2i OldPosition { get; }
+        public Vector2i Position { get; }
+
+        public SnapGridPositionChangedEvent(Vector2i position, Vector2i oldPosition, GridId newGrid, GridId oldGrid)
+        {
+            Position = position;
+            OldPosition = oldPosition;
+
+            NewGrid = newGrid;
+            OldGrid = oldGrid;
         }
     }
 }

--- a/Robust.Shared/GameObjects/Systems/SnapGridSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SnapGridSystem.cs
@@ -7,7 +7,7 @@ using Robust.Shared.Maths;
 namespace Robust.Shared.GameObjects
 {
     [UsedImplicitly]
-    public class SnapGridSystem : EntitySystem
+    internal class SnapGridSystem : EntitySystem
     {
         [Dependency] private readonly IMapManager _mapManager = default!;
 

--- a/Robust.Shared/GameStates/GameStateMapData.cs
+++ b/Robust.Shared/GameStates/GameStateMapData.cs
@@ -29,12 +29,10 @@ namespace Robust.Shared.GameStates
         public struct GridCreationDatum
         {
             public readonly ushort ChunkSize;
-            public readonly float SnapSize;
 
-            public GridCreationDatum(ushort chunkSize, float snapSize)
+            public GridCreationDatum(ushort chunkSize)
             {
                 ChunkSize = chunkSize;
-                SnapSize = snapSize;
             }
         }
 

--- a/Robust.Shared/Map/IMapChunk.cs
+++ b/Robust.Shared/Map/IMapChunk.cs
@@ -76,10 +76,10 @@ namespace Robust.Shared.Map
         /// <returns>The indices relative to the grid origin.</returns>
         Vector2i ChunkTileToGridTile(Vector2i chunkTile);
 
-        IEnumerable<SnapGridComponent> GetSnapGridCell(ushort xCell, ushort yCell);
+        IEnumerable<EntityUid> GetSnapGridCell(ushort xCell, ushort yCell);
 
-        void AddToSnapGridCell(ushort xCell, ushort yCell, SnapGridComponent snap);
-        void RemoveFromSnapGridCell(ushort xCell, ushort yCell, SnapGridComponent snap);
+        void AddToSnapGridCell(ushort xCell, ushort yCell, EntityUid euid);
+        void RemoveFromSnapGridCell(ushort xCell, ushort yCell, EntityUid euid);
 
         Box2i CalcLocalBounds();
 

--- a/Robust.Shared/Map/IMapChunk.cs
+++ b/Robust.Shared/Map/IMapChunk.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Maths;
 
@@ -76,10 +76,10 @@ namespace Robust.Shared.Map
         /// <returns>The indices relative to the grid origin.</returns>
         Vector2i ChunkTileToGridTile(Vector2i chunkTile);
 
-        IEnumerable<SnapGridComponent> GetSnapGridCell(ushort xCell, ushort yCell, SnapGridOffset offset);
+        IEnumerable<SnapGridComponent> GetSnapGridCell(ushort xCell, ushort yCell);
 
-        void AddToSnapGridCell(ushort xCell, ushort yCell, SnapGridOffset offset, SnapGridComponent snap);
-        void RemoveFromSnapGridCell(ushort xCell, ushort yCell, SnapGridOffset offset, SnapGridComponent snap);
+        void AddToSnapGridCell(ushort xCell, ushort yCell, SnapGridComponent snap);
+        void RemoveFromSnapGridCell(ushort xCell, ushort yCell, SnapGridComponent snap);
 
         Box2i CalcLocalBounds();
 

--- a/Robust.Shared/Map/IMapChunk.cs
+++ b/Robust.Shared/Map/IMapChunk.cs
@@ -7,7 +7,7 @@ namespace Robust.Shared.Map
     /// <summary>
     ///     A square section of a <see cref="IMapGrid"/>.
     /// </summary>
-    public interface IMapChunk : IEnumerable<TileRef>
+    internal interface IMapChunk : IEnumerable<TileRef>
     {
         /// <summary>
         ///     The number of tiles per side of the square chunk.

--- a/Robust.Shared/Map/IMapGrid.cs
+++ b/Robust.Shared/Map/IMapGrid.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
@@ -115,17 +115,17 @@ namespace Robust.Shared.Map
 
         #region SnapGridAccess
 
-        IEnumerable<SnapGridComponent> GetSnapGridCell(EntityCoordinates coords, SnapGridOffset offset);
-        IEnumerable<SnapGridComponent> GetSnapGridCell(Vector2i pos, SnapGridOffset offset);
+        IEnumerable<SnapGridComponent> GetSnapGridCell(EntityCoordinates coords);
+        IEnumerable<SnapGridComponent> GetSnapGridCell(Vector2i pos);
 
-        Vector2i SnapGridCellFor(EntityCoordinates coords, SnapGridOffset offset);
-        Vector2i SnapGridCellFor(MapCoordinates worldPos, SnapGridOffset offset);
-        Vector2i SnapGridCellFor(Vector2 localPos, SnapGridOffset offset);
+        Vector2i SnapGridCellFor(EntityCoordinates coords);
+        Vector2i SnapGridCellFor(MapCoordinates worldPos);
+        Vector2i SnapGridCellFor(Vector2 localPos);
 
-        void AddToSnapGridCell(Vector2i pos, SnapGridOffset offset, SnapGridComponent snap);
-        void AddToSnapGridCell(EntityCoordinates coords, SnapGridOffset offset, SnapGridComponent snap);
-        void RemoveFromSnapGridCell(Vector2i pos, SnapGridOffset offset, SnapGridComponent snap);
-        void RemoveFromSnapGridCell(EntityCoordinates coords, SnapGridOffset offset, SnapGridComponent snap);
+        void AddToSnapGridCell(Vector2i pos, SnapGridComponent snap);
+        void AddToSnapGridCell(EntityCoordinates coords, SnapGridComponent snap);
+        void RemoveFromSnapGridCell(Vector2i pos, SnapGridComponent snap);
+        void RemoveFromSnapGridCell(EntityCoordinates coords, SnapGridComponent snap);
 
         #endregion SnapGridAccess
 

--- a/Robust.Shared/Map/IMapGrid.cs
+++ b/Robust.Shared/Map/IMapGrid.cs
@@ -103,27 +103,27 @@ namespace Robust.Shared.Map
 
         #region SnapGridAccess
 
-        IEnumerable<SnapGridComponent> GetSnapGridCell(EntityCoordinates coords);
-        IEnumerable<SnapGridComponent> GetSnapGridCell(Vector2i pos);
+        IEnumerable<EntityUid> GetAnchoredEntities(EntityCoordinates coords);
+        IEnumerable<EntityUid> GetAnchoredEntities(Vector2i pos);
 
-        Vector2i SnapGridCellFor(EntityCoordinates coords) => CoordinatesToTile(coords);
-        Vector2i SnapGridCellFor(MapCoordinates worldPos) => CoordinatesToTile(MapToGrid(worldPos));
-        Vector2i SnapGridCellFor(Vector2 worldPos) => WorldToTile(worldPos);
+        Vector2i TileIndicesFor(EntityCoordinates coords) => CoordinatesToTile(coords);
+        Vector2i TileIndicesFor(MapCoordinates worldPos) => CoordinatesToTile(MapToGrid(worldPos));
+        Vector2i TileIndicesFor(Vector2 worldPos) => WorldToTile(worldPos);
 
-        void AddToSnapGridCell(Vector2i pos, SnapGridComponent snap);
-        void AddToSnapGridCell(EntityCoordinates coords, SnapGridComponent snap);
-        void RemoveFromSnapGridCell(Vector2i pos, SnapGridComponent snap);
-        void RemoveFromSnapGridCell(EntityCoordinates coords, SnapGridComponent snap);
+        void AddToSnapGridCell(Vector2i pos, EntityUid euid);
+        void AddToSnapGridCell(EntityCoordinates coords, EntityUid euid);
+        void RemoveFromSnapGridCell(Vector2i pos, EntityUid euid);
+        void RemoveFromSnapGridCell(EntityCoordinates coords, EntityUid euid);
 
         /// <summary>
         ///     Returns an enumerable over all the entities which are one tile over in a certain direction.
         /// </summary>
-        IEnumerable<IEntity> GetInDir(EntityCoordinates position, Direction dir);
-        IEnumerable<IEntity> GetOffset(EntityCoordinates coords, Vector2i offset);
-        IEnumerable<IEntity> GetLocal(EntityCoordinates coords);
+        IEnumerable<EntityUid> GetInDir(EntityCoordinates position, Direction dir);
+        IEnumerable<EntityUid> GetOffset(EntityCoordinates coords, Vector2i offset);
+        IEnumerable<EntityUid> GetLocal(EntityCoordinates coords);
         EntityCoordinates DirectionToGrid(EntityCoordinates coords, Direction direction);
-        IEnumerable<SnapGridComponent> GetCardinalNeighborCells(EntityCoordinates coords);
-        IEnumerable<SnapGridComponent> GetCellsInSquareArea(EntityCoordinates coords, int n);
+        IEnumerable<EntityUid> GetCardinalNeighborCells(EntityCoordinates coords);
+        IEnumerable<EntityUid> GetCellsInSquareArea(EntityCoordinates coords, int n);
 
         #endregion SnapGridAccess
 

--- a/Robust.Shared/Map/IMapGrid.cs
+++ b/Robust.Shared/Map/IMapGrid.cs
@@ -17,6 +17,9 @@ namespace Robust.Shared.Map
         /// </summary>
         MapId ParentMapId { get; set; }
 
+        /// <summary>
+        /// The entity this grid is represented by in the ECS system.
+        /// </summary>
         EntityUid GridEntityId { get; }
 
         /// <summary>
@@ -40,11 +43,6 @@ namespace Robust.Shared.Map
         ushort ChunkSize { get; }
 
         /// <summary>
-        ///     The distance between the snap grid, between each center snap and between each offset snap grid location
-        /// </summary>
-        float SnapSize { get; }
-
-        /// <summary>
         ///     The origin of the grid in world coordinates. Make sure to set this!
         /// </summary>
         Vector2 WorldPosition { get; set; }
@@ -53,16 +51,6 @@ namespace Robust.Shared.Map
         ///     Whether or not this grid has gravity
         /// </summary>
         bool HasGravity { get; set; }
-
-        /// <summary>
-        ///     Is this located at a position on the center grid of snap positions, accepts local coordinates
-        /// </summary>
-        bool OnSnapCenter(Vector2 position);
-
-        /// <summary>
-        ///     Is this located at a position on the border grid of snap positions, accepts local coordinates
-        /// </summary>
-        bool OnSnapBorder(Vector2 position);
 
         #region TileAccess
 

--- a/Robust.Shared/Map/IMapGrid.cs
+++ b/Robust.Shared/Map/IMapGrid.cs
@@ -106,9 +106,9 @@ namespace Robust.Shared.Map
         IEnumerable<SnapGridComponent> GetSnapGridCell(EntityCoordinates coords);
         IEnumerable<SnapGridComponent> GetSnapGridCell(Vector2i pos);
 
-        Vector2i SnapGridCellFor(EntityCoordinates coords);
-        Vector2i SnapGridCellFor(MapCoordinates worldPos);
-        Vector2i SnapGridCellFor(Vector2 localPos);
+        Vector2i SnapGridCellFor(EntityCoordinates coords) => CoordinatesToTile(coords);
+        Vector2i SnapGridCellFor(MapCoordinates worldPos) => CoordinatesToTile(MapToGrid(worldPos));
+        Vector2i SnapGridCellFor(Vector2 worldPos) => WorldToTile(worldPos);
 
         void AddToSnapGridCell(Vector2i pos, SnapGridComponent snap);
         void AddToSnapGridCell(EntityCoordinates coords, SnapGridComponent snap);

--- a/Robust.Shared/Map/IMapGrid.cs
+++ b/Robust.Shared/Map/IMapGrid.cs
@@ -127,6 +127,16 @@ namespace Robust.Shared.Map
         void RemoveFromSnapGridCell(Vector2i pos, SnapGridComponent snap);
         void RemoveFromSnapGridCell(EntityCoordinates coords, SnapGridComponent snap);
 
+        /// <summary>
+        ///     Returns an enumerable over all the entities which are one tile over in a certain direction.
+        /// </summary>
+        IEnumerable<IEntity> GetInDir(EntityCoordinates position, Direction dir);
+        IEnumerable<IEntity> GetOffset(EntityCoordinates coords, Vector2i offset);
+        IEnumerable<IEntity> GetLocal(EntityCoordinates coords);
+        EntityCoordinates DirectionToGrid(EntityCoordinates coords, Direction direction);
+        IEnumerable<SnapGridComponent> GetCardinalNeighborCells(EntityCoordinates coords);
+        IEnumerable<SnapGridComponent> GetCellsInSquareArea(EntityCoordinates coords, int n);
+
         #endregion SnapGridAccess
 
         #region Transforms

--- a/Robust.Shared/Map/IMapManager.cs
+++ b/Robust.Shared/Map/IMapManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.GameObjects;
@@ -80,7 +80,7 @@ namespace Robust.Shared.Map
 
         void DeleteMap(MapId mapID);
 
-        IMapGrid CreateGrid(MapId currentMapID, GridId? gridID = null, ushort chunkSize = 16, float snapSize = 1);
+        IMapGrid CreateGrid(MapId currentMapID, GridId? gridID = null, ushort chunkSize = 16);
         IMapGrid GetGrid(GridId gridID);
         bool TryGetGrid(GridId gridId, [NotNullWhen(true)] out IMapGrid? grid);
         bool GridExists(GridId gridID);

--- a/Robust.Shared/Map/IMapManagerInternal.cs
+++ b/Robust.Shared/Map/IMapManagerInternal.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Timing;
 
 namespace Robust.Shared.Map
@@ -16,6 +16,6 @@ namespace Robust.Shared.Map
         /// <param name="oldTile">The old tile that got replaced.</param>
         void RaiseOnTileChanged(TileRef tileRef, Tile oldTile);
 
-        IMapGridInternal CreateGridNoEntity(MapId currentMapID, GridId? gridID = null, ushort chunkSize = 16, float snapSize = 1);
+        IMapGridInternal CreateGridNoEntity(MapId currentMapID, GridId? gridID = null, ushort chunkSize = 16);
     }
 }

--- a/Robust.Shared/Map/MapChunk.cs
+++ b/Robust.Shared/Map/MapChunk.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using Robust.Shared.GameObjects;
@@ -10,6 +10,11 @@ namespace Robust.Shared.Map
     /// <inheritdoc />
     internal class MapChunk : IMapChunkInternal
     {
+        /// <summary>
+        /// New SnapGrid cells are allocated with this capacity.
+        /// </summary>
+        private const int SnapCellStartingCapacity = 1;
+
         private readonly IMapGridInternal _grid;
         private readonly Vector2i _gridIndices;
 
@@ -174,7 +179,7 @@ namespace Robust.Shared.Map
         }
 
         /// <inheritdoc />
-        public IEnumerable<SnapGridComponent> GetSnapGridCell(ushort xCell, ushort yCell, SnapGridOffset offset)
+        public IEnumerable<SnapGridComponent> GetSnapGridCell(ushort xCell, ushort yCell)
         {
             if (xCell >= ChunkSize)
                 throw new ArgumentOutOfRangeException(nameof(xCell), "Tile indices out of bounds.");
@@ -183,7 +188,7 @@ namespace Robust.Shared.Map
                 throw new ArgumentOutOfRangeException(nameof(yCell), "Tile indices out of bounds.");
 
             var cell = _snapGrid[xCell, yCell];
-            var list = offset == SnapGridOffset.Center ? cell.Center : cell.Edge;
+            var list = cell.Center;
 
             if (list == null)
             {
@@ -194,7 +199,7 @@ namespace Robust.Shared.Map
         }
 
         /// <inheritdoc />
-        public void AddToSnapGridCell(ushort xCell, ushort yCell, SnapGridOffset offset, SnapGridComponent snap)
+        public void AddToSnapGridCell(ushort xCell, ushort yCell, SnapGridComponent snap)
         {
             if (xCell >= ChunkSize)
                 throw new ArgumentOutOfRangeException(nameof(xCell), "Tile indices out of bounds.");
@@ -203,26 +208,12 @@ namespace Robust.Shared.Map
                 throw new ArgumentOutOfRangeException(nameof(yCell), "Tile indices out of bounds.");
 
             ref var cell = ref _snapGrid[xCell, yCell];
-            if (offset == SnapGridOffset.Center)
-            {
-                if (cell.Center == null)
-                {
-                    cell.Center = new List<SnapGridComponent>(1);
-                }
-                cell.Center.Add(snap);
-            }
-            else
-            {
-                if (cell.Edge == null)
-                {
-                    cell.Edge = new List<SnapGridComponent>(1);
-                }
-                cell.Edge.Add(snap);
-            }
+            cell.Center ??= new List<SnapGridComponent>(SnapCellStartingCapacity);
+            cell.Center.Add(snap);
         }
 
         /// <inheritdoc />
-        public void RemoveFromSnapGridCell(ushort xCell, ushort yCell, SnapGridOffset offset, SnapGridComponent snap)
+        public void RemoveFromSnapGridCell(ushort xCell, ushort yCell, SnapGridComponent snap)
         {
             if (xCell >= ChunkSize)
                 throw new ArgumentOutOfRangeException(nameof(xCell), "Tile indices out of bounds.");
@@ -231,14 +222,7 @@ namespace Robust.Shared.Map
                 throw new ArgumentOutOfRangeException(nameof(yCell), "Tile indices out of bounds.");
 
             ref var cell = ref _snapGrid[xCell, yCell];
-            if (offset == SnapGridOffset.Center)
-            {
-                cell.Center?.Remove(snap);
-            }
-            else
-            {
-                cell.Edge?.Remove(snap);
-            }
+            cell.Center?.Remove(snap);
         }
 
         public bool SuppressCollisionRegeneration { get; set; }
@@ -258,7 +242,7 @@ namespace Robust.Shared.Map
 
         public Box2 CalcWorldBounds()
         {
-            var worldPos = _grid.WorldPosition + (Vector2i)Indices * _grid.TileSize * ChunkSize;
+            var worldPos = _grid.WorldPosition + Indices * _grid.TileSize * ChunkSize;
             var localBounds = CalcLocalBounds();
             var ts = _grid.TileSize;
 
@@ -291,8 +275,7 @@ namespace Robust.Shared.Map
 
         private struct SnapGridCell
         {
-            public List<SnapGridComponent> Center;
-            public List<SnapGridComponent> Edge;
+            public List<SnapGridComponent>? Center;
         }
     }
 }

--- a/Robust.Shared/Map/MapChunk.cs
+++ b/Robust.Shared/Map/MapChunk.cs
@@ -179,7 +179,7 @@ namespace Robust.Shared.Map
         }
 
         /// <inheritdoc />
-        public IEnumerable<SnapGridComponent> GetSnapGridCell(ushort xCell, ushort yCell)
+        public IEnumerable<EntityUid> GetSnapGridCell(ushort xCell, ushort yCell)
         {
             if (xCell >= ChunkSize)
                 throw new ArgumentOutOfRangeException(nameof(xCell), "Tile indices out of bounds.");
@@ -192,14 +192,14 @@ namespace Robust.Shared.Map
 
             if (list == null)
             {
-                return Array.Empty<SnapGridComponent>();
+                return Array.Empty<EntityUid>();
             }
 
             return list;
         }
 
         /// <inheritdoc />
-        public void AddToSnapGridCell(ushort xCell, ushort yCell, SnapGridComponent snap)
+        public void AddToSnapGridCell(ushort xCell, ushort yCell, EntityUid euid)
         {
             if (xCell >= ChunkSize)
                 throw new ArgumentOutOfRangeException(nameof(xCell), "Tile indices out of bounds.");
@@ -208,12 +208,12 @@ namespace Robust.Shared.Map
                 throw new ArgumentOutOfRangeException(nameof(yCell), "Tile indices out of bounds.");
 
             ref var cell = ref _snapGrid[xCell, yCell];
-            cell.Center ??= new List<SnapGridComponent>(SnapCellStartingCapacity);
-            cell.Center.Add(snap);
+            cell.Center ??= new List<EntityUid>(SnapCellStartingCapacity);
+            cell.Center.Add(euid);
         }
 
         /// <inheritdoc />
-        public void RemoveFromSnapGridCell(ushort xCell, ushort yCell, SnapGridComponent snap)
+        public void RemoveFromSnapGridCell(ushort xCell, ushort yCell, EntityUid euid)
         {
             if (xCell >= ChunkSize)
                 throw new ArgumentOutOfRangeException(nameof(xCell), "Tile indices out of bounds.");
@@ -222,7 +222,7 @@ namespace Robust.Shared.Map
                 throw new ArgumentOutOfRangeException(nameof(yCell), "Tile indices out of bounds.");
 
             ref var cell = ref _snapGrid[xCell, yCell];
-            cell.Center?.Remove(snap);
+            cell.Center?.Remove(euid);
         }
 
         public bool SuppressCollisionRegeneration { get; set; }
@@ -275,7 +275,7 @@ namespace Robust.Shared.Map
 
         private struct SnapGridCell
         {
-            public List<SnapGridComponent>? Center;
+            public List<EntityUid>? Center;
         }
     }
 }

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Maths;
@@ -553,45 +552,26 @@ namespace Robust.Shared.Map
         /// <summary>
         ///     Returns an enumerable over all the entities which are one tile over in a certain direction.
         /// </summary>
-        public static IEnumerable<IEntity> GetInDir(SnapGridComponent snapComp, Direction dir)
+        public static IEnumerable<IEntity> GetInDir(IMapGrid grid, EntityCoordinates position, Direction dir)
         {
-            var transform = snapComp.Owner.Transform;
-            if (!snapComp._mapManager.TryGetGrid(transform.GridID, out var grid))
-                return Enumerable.Empty<IEntity>();
-
-            var pos = SnapGridPosAt(grid.SnapGridCellFor(transform.Coordinates), dir);
-
+            var pos = SnapGridPosAt(grid.SnapGridCellFor(position), dir);
             return grid.GetSnapGridCell(pos).Select(s => s.Owner);
         }
 
-        [Pure]
-        public static IEnumerable<IEntity> GetOffset(SnapGridComponent snapComp, Vector2i offset)
+        public static IEnumerable<IEntity> GetOffset(IMapGrid grid, EntityCoordinates coords, Vector2i offset)
         {
-            var transform = snapComp.Owner.Transform;
-            if (!snapComp._mapManager.TryGetGrid(transform.GridID, out var grid))
-                return Enumerable.Empty<IEntity>();
-
-            var pos = grid.SnapGridCellFor(transform.Coordinates) + offset;
-
+            var pos = grid.SnapGridCellFor(coords) + offset;
             return grid.GetSnapGridCell(pos).Select(s => s.Owner);
         }
 
-        public static IEnumerable<IEntity> GetLocal(SnapGridComponent snapComp)
+        public static IEnumerable<IEntity> GetLocal(IMapGrid grid, EntityCoordinates coords)
         {
-            var transform = snapComp.Owner.Transform;
-            if (!snapComp._mapManager.TryGetGrid(transform.GridID, out var grid))
-                return Enumerable.Empty<IEntity>();
-
-            return grid.GetSnapGridCell(grid.SnapGridCellFor(transform.Coordinates)).Select(s => s.Owner);
+            return grid.GetSnapGridCell(grid.SnapGridCellFor(coords)).Select(s => s.Owner);
         }
 
-        public static EntityCoordinates DirectionToGrid(SnapGridComponent snapComp, Direction direction)
+        public static EntityCoordinates DirectionToGrid(IMapGrid grid, EntityCoordinates coords, Direction direction)
         {
-            var transform = snapComp.Owner.Transform;
-            if (!snapComp._mapManager.TryGetGrid(transform.GridID, out var grid))
-                return transform.Coordinates.Offset(direction.ToVec());
-
-            return grid.GridTileToLocal(SnapGridPosAt(grid.SnapGridCellFor(transform.Coordinates), direction));
+            return grid.GridTileToLocal(SnapGridPosAt(grid.SnapGridCellFor(coords), direction));
         }
 
         private static Vector2i SnapGridPosAt(Vector2i position, Direction dir, int dist = 1)
@@ -619,13 +599,9 @@ namespace Robust.Shared.Map
             }
         }
 
-        public static IEnumerable<SnapGridComponent> GetCardinalNeighborCells(SnapGridComponent snapComp)
+        public static IEnumerable<SnapGridComponent> GetCardinalNeighborCells(IMapGrid grid, EntityCoordinates coords)
         {
-            var transform = snapComp.Owner.Transform;
-            if (!snapComp._mapManager.TryGetGrid(transform.GridID, out var grid))
-                yield break;
-
-            var position = grid.SnapGridCellFor(transform.Coordinates);
+            var position = grid.SnapGridCellFor(coords);
             foreach (var cell in grid.GetSnapGridCell(position))
                 yield return cell;
             foreach (var cell in grid.GetSnapGridCell(position + new Vector2i(0, 1)))
@@ -638,13 +614,9 @@ namespace Robust.Shared.Map
                 yield return cell;
         }
 
-        public static IEnumerable<SnapGridComponent> GetCellsInSquareArea(SnapGridComponent snapComp, int n = 1)
+        public static IEnumerable<SnapGridComponent> GetCellsInSquareArea(IMapGrid grid, EntityCoordinates coords, int n)
         {
-            var transform = snapComp.Owner.Transform;
-            if (!snapComp._mapManager.TryGetGrid(transform.GridID, out var grid))
-                yield break;
-
-            var position = grid.SnapGridCellFor(transform.Coordinates);
+            var position = grid.SnapGridCellFor(coords);
 
             for (var y = -n; y <= n; ++y)
             for (var x = -n; x <= n; ++x)

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -333,20 +333,20 @@ namespace Robust.Shared.Map
         #region SnapGridAccess
 
         /// <inheritdoc />
-        public IEnumerable<SnapGridComponent> GetSnapGridCell(EntityCoordinates coords)
+        public IEnumerable<EntityUid> GetAnchoredEntities(EntityCoordinates coords)
         {
-            return GetSnapGridCell(SnapGridCellFor(coords));
+            return GetAnchoredEntities(TileIndicesFor(coords));
         }
 
         /// <inheritdoc />
-        public IEnumerable<SnapGridComponent> GetSnapGridCell(Vector2i pos)
+        public IEnumerable<EntityUid> GetAnchoredEntities(Vector2i pos)
         {
             var (chunk, chunkTile) = ChunkAndOffsetForTile(pos);
             return chunk.GetSnapGridCell((ushort)chunkTile.X, (ushort)chunkTile.Y);
         }
 
         /// <inheritdoc />
-        public Vector2i SnapGridCellFor(EntityCoordinates coords)
+        public Vector2i TileIndicesFor(EntityCoordinates coords)
         {
             DebugTools.Assert(ParentMapId == coords.GetMapId(_entityManager));
 
@@ -355,7 +355,7 @@ namespace Robust.Shared.Map
         }
 
         /// <inheritdoc />
-        public Vector2i SnapGridCellFor(MapCoordinates worldPos)
+        public Vector2i TileIndicesFor(MapCoordinates worldPos)
         {
             DebugTools.Assert(ParentMapId == worldPos.MapId);
 
@@ -363,7 +363,7 @@ namespace Robust.Shared.Map
             return SnapGridLocalCellFor(localPos);
         }
 
-        public Vector2i SnapGridLocalCellFor(Vector2 localPos)
+        private Vector2i SnapGridLocalCellFor(Vector2 localPos)
         {
             var x = (int)Math.Floor(localPos.X / TileSize);
             var y = (int)Math.Floor(localPos.Y / TileSize);
@@ -371,29 +371,29 @@ namespace Robust.Shared.Map
         }
 
         /// <inheritdoc />
-        public void AddToSnapGridCell(Vector2i pos, SnapGridComponent snap)
+        public void AddToSnapGridCell(Vector2i pos, EntityUid euid)
         {
             var (chunk, chunkTile) = ChunkAndOffsetForTile(pos);
-            chunk.AddToSnapGridCell((ushort)chunkTile.X, (ushort)chunkTile.Y, snap);
+            chunk.AddToSnapGridCell((ushort)chunkTile.X, (ushort)chunkTile.Y, euid);
         }
 
         /// <inheritdoc />
-        public void AddToSnapGridCell(EntityCoordinates coords, SnapGridComponent snap)
+        public void AddToSnapGridCell(EntityCoordinates coords, EntityUid euid)
         {
-            AddToSnapGridCell(SnapGridCellFor(coords), snap);
+            AddToSnapGridCell(TileIndicesFor(coords), euid);
         }
 
         /// <inheritdoc />
-        public void RemoveFromSnapGridCell(Vector2i pos, SnapGridComponent snap)
+        public void RemoveFromSnapGridCell(Vector2i pos, EntityUid euid)
         {
             var (chunk, chunkTile) = ChunkAndOffsetForTile(pos);
-            chunk.RemoveFromSnapGridCell((ushort)chunkTile.X, (ushort)chunkTile.Y, snap);
+            chunk.RemoveFromSnapGridCell((ushort)chunkTile.X, (ushort) chunkTile.Y, euid);
         }
 
         /// <inheritdoc />
-        public void RemoveFromSnapGridCell(EntityCoordinates coords, SnapGridComponent snap)
+        public void RemoveFromSnapGridCell(EntityCoordinates coords, EntityUid euid)
         {
-            RemoveFromSnapGridCell(SnapGridCellFor(coords), snap);
+            RemoveFromSnapGridCell(TileIndicesFor(coords), euid);
         }
 
         private (IMapChunk, Vector2i) ChunkAndOffsetForTile(Vector2i pos)
@@ -430,56 +430,56 @@ namespace Robust.Shared.Map
         }
 
         /// <inheritdoc />
-        public IEnumerable<IEntity> GetInDir(EntityCoordinates position, Direction dir)
+        public IEnumerable<EntityUid> GetInDir(EntityCoordinates position, Direction dir)
         {
-            var pos = SnapGridPosAt(SnapGridCellFor(position), dir);
-            return GetSnapGridCell(pos).Select(s => s.Owner);
+            var pos = SnapGridPosAt(TileIndicesFor(position), dir);
+            return GetAnchoredEntities(pos);
         }
 
         /// <inheritdoc />
-        public IEnumerable<IEntity> GetOffset(EntityCoordinates coords, Vector2i offset)
+        public IEnumerable<EntityUid> GetOffset(EntityCoordinates coords, Vector2i offset)
         {
-            var pos = SnapGridCellFor(coords) + offset;
-            return GetSnapGridCell(pos).Select(s => s.Owner);
+            var pos = TileIndicesFor(coords) + offset;
+            return GetAnchoredEntities(pos);
         }
 
         /// <inheritdoc />
-        public IEnumerable<IEntity> GetLocal(EntityCoordinates coords)
+        public IEnumerable<EntityUid> GetLocal(EntityCoordinates coords)
         {
-            return GetSnapGridCell(SnapGridCellFor(coords)).Select(s => s.Owner);
+            return GetAnchoredEntities(TileIndicesFor(coords));
         }
 
         /// <inheritdoc />
         public EntityCoordinates DirectionToGrid(EntityCoordinates coords, Direction direction)
         {
-            return GridTileToLocal(SnapGridPosAt(SnapGridCellFor(coords), direction));
+            return GridTileToLocal(SnapGridPosAt(TileIndicesFor(coords), direction));
         }
 
         /// <inheritdoc />
-        public IEnumerable<SnapGridComponent> GetCardinalNeighborCells(EntityCoordinates coords)
+        public IEnumerable<EntityUid> GetCardinalNeighborCells(EntityCoordinates coords)
         {
-            var position = SnapGridCellFor(coords);
-            foreach (var cell in GetSnapGridCell(position))
+            var position = TileIndicesFor(coords);
+            foreach (var cell in GetAnchoredEntities(position))
                 yield return cell;
-            foreach (var cell in GetSnapGridCell(position + new Vector2i(0, 1)))
+            foreach (var cell in GetAnchoredEntities(position + new Vector2i(0, 1)))
                 yield return cell;
-            foreach (var cell in GetSnapGridCell(position + new Vector2i(0, -1)))
+            foreach (var cell in GetAnchoredEntities(position + new Vector2i(0, -1)))
                 yield return cell;
-            foreach (var cell in GetSnapGridCell(position + new Vector2i(1, 0)))
+            foreach (var cell in GetAnchoredEntities(position + new Vector2i(1, 0)))
                 yield return cell;
-            foreach (var cell in GetSnapGridCell(position + new Vector2i(-1, 0)))
+            foreach (var cell in GetAnchoredEntities(position + new Vector2i(-1, 0)))
                 yield return cell;
         }
 
         /// <inheritdoc />
-        public IEnumerable<SnapGridComponent> GetCellsInSquareArea(EntityCoordinates coords, int n)
+        public IEnumerable<EntityUid> GetCellsInSquareArea(EntityCoordinates coords, int n)
         {
-            var position = SnapGridCellFor(coords);
+            var position = TileIndicesFor(coords);
 
             for (var y = -n; y <= n; ++y)
                 for (var x = -n; x <= n; ++x)
                 {
-                    foreach (var cell in GetSnapGridCell(position + new Vector2i(x, y)))
+                    foreach (var cell in GetAnchoredEntities(position + new Vector2i(x, y)))
                     {
                         yield return cell;
                     }

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Maths;
@@ -62,6 +62,7 @@ namespace Robust.Shared.Map
         ///     Initializes a new instance of the <see cref="MapGrid"/> class.
         /// </summary>
         /// <param name="mapManager">Reference to the <see cref="MapManager"/> that will manage this grid.</param>
+        /// <param name="entityManager"></param>
         /// <param name="gridIndex">Index identifier of this grid.</param>
         /// <param name="chunkSize">The dimension of this square chunk.</param>
         /// <param name="snapSize">Distance in world units between the lines on the conceptual snap grid.</param>
@@ -349,72 +350,68 @@ namespace Robust.Shared.Map
         #region SnapGridAccess
 
         /// <inheritdoc />
-        public IEnumerable<SnapGridComponent> GetSnapGridCell(EntityCoordinates coords, SnapGridOffset offset)
+        public IEnumerable<SnapGridComponent> GetSnapGridCell(EntityCoordinates coords)
         {
-            return GetSnapGridCell(SnapGridCellFor(coords, offset), offset);
+            return GetSnapGridCell(SnapGridCellFor(coords));
         }
 
         /// <inheritdoc />
-        public IEnumerable<SnapGridComponent> GetSnapGridCell(Vector2i pos, SnapGridOffset offset)
+        public IEnumerable<SnapGridComponent> GetSnapGridCell(Vector2i pos)
         {
             var (chunk, chunkTile) = ChunkAndOffsetForTile(pos);
-            return chunk.GetSnapGridCell((ushort)chunkTile.X, (ushort)chunkTile.Y, offset);
+            return chunk.GetSnapGridCell((ushort)chunkTile.X, (ushort)chunkTile.Y);
         }
 
         /// <inheritdoc />
-        public Vector2i SnapGridCellFor(EntityCoordinates coords, SnapGridOffset offset)
+        public Vector2i SnapGridCellFor(EntityCoordinates coords)
         {
             DebugTools.Assert(ParentMapId == coords.GetMapId(_entityManager));
 
             var local = WorldToLocal(coords.ToMapPos(_entityManager));
-            return SnapGridCellFor(local, offset);
+            return SnapGridCellFor(local);
         }
 
         /// <inheritdoc />
-        public Vector2i SnapGridCellFor(MapCoordinates worldPos, SnapGridOffset offset)
+        public Vector2i SnapGridCellFor(MapCoordinates worldPos)
         {
             DebugTools.Assert(ParentMapId == worldPos.MapId);
 
             var localPos = WorldToLocal(worldPos.Position);
-            return SnapGridCellFor(localPos, offset);
+            return SnapGridCellFor(localPos);
         }
 
         /// <inheritdoc />
-        public Vector2i SnapGridCellFor(Vector2 localPos, SnapGridOffset offset)
+        public Vector2i SnapGridCellFor(Vector2 localPos)
         {
-            if (offset == SnapGridOffset.Edge)
-            {
-                localPos += new Vector2(TileSize / 2f, TileSize / 2f);
-            }
             var x = (int)Math.Floor(localPos.X / TileSize);
             var y = (int)Math.Floor(localPos.Y / TileSize);
             return new Vector2i(x, y);
         }
 
         /// <inheritdoc />
-        public void AddToSnapGridCell(Vector2i pos, SnapGridOffset offset, SnapGridComponent snap)
+        public void AddToSnapGridCell(Vector2i pos, SnapGridComponent snap)
         {
             var (chunk, chunkTile) = ChunkAndOffsetForTile(pos);
-            chunk.AddToSnapGridCell((ushort)chunkTile.X, (ushort)chunkTile.Y, offset, snap);
+            chunk.AddToSnapGridCell((ushort)chunkTile.X, (ushort)chunkTile.Y, snap);
         }
 
         /// <inheritdoc />
-        public void AddToSnapGridCell(EntityCoordinates coords, SnapGridOffset offset, SnapGridComponent snap)
+        public void AddToSnapGridCell(EntityCoordinates coords, SnapGridComponent snap)
         {
-            AddToSnapGridCell(SnapGridCellFor(coords, offset), offset, snap);
+            AddToSnapGridCell(SnapGridCellFor(coords), snap);
         }
 
         /// <inheritdoc />
-        public void RemoveFromSnapGridCell(Vector2i pos, SnapGridOffset offset, SnapGridComponent snap)
+        public void RemoveFromSnapGridCell(Vector2i pos, SnapGridComponent snap)
         {
             var (chunk, chunkTile) = ChunkAndOffsetForTile(pos);
-            chunk.RemoveFromSnapGridCell((ushort)chunkTile.X, (ushort)chunkTile.Y, offset, snap);
+            chunk.RemoveFromSnapGridCell((ushort)chunkTile.X, (ushort)chunkTile.Y, snap);
         }
 
         /// <inheritdoc />
-        public void RemoveFromSnapGridCell(EntityCoordinates coords, SnapGridOffset offset, SnapGridComponent snap)
+        public void RemoveFromSnapGridCell(EntityCoordinates coords, SnapGridComponent snap)
         {
-            RemoveFromSnapGridCell(SnapGridCellFor(coords, offset), offset, snap);
+            RemoveFromSnapGridCell(SnapGridCellFor(coords), snap);
         }
 
         private (IMapChunk, Vector2i) ChunkAndOffsetForTile(Vector2i pos)

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -68,14 +68,12 @@ namespace Robust.Shared.Map
         /// <param name="chunkSize">The dimension of this square chunk.</param>
         /// <param name="snapSize">Distance in world units between the lines on the conceptual snap grid.</param>
         /// <param name="parentMapId">Parent map identifier.</param>
-        internal MapGrid(IMapManagerInternal mapManager, IEntityManager entityManager, GridId gridIndex, ushort chunkSize, float snapSize,
-            MapId parentMapId)
+        internal MapGrid(IMapManagerInternal mapManager, IEntityManager entityManager, GridId gridIndex, ushort chunkSize, MapId parentMapId)
         {
             _mapManager = mapManager;
             _entityManager = entityManager;
             Index = gridIndex;
             ChunkSize = chunkSize;
-            SnapSize = snapSize;
             ParentMapId = parentMapId;
             LastModifiedTick = CreatedTick = _mapManager.GameTiming.CurTick;
             HasGravity = false;
@@ -102,10 +100,6 @@ namespace Robust.Shared.Map
         /// <inheritdoc />
         [ViewVariables]
         public ushort ChunkSize { get; }
-
-        /// <inheritdoc />
-        [ViewVariables]
-        public float SnapSize { get; }
 
         /// <inheritdoc />
         [ViewVariables]
@@ -173,18 +167,6 @@ namespace Robust.Shared.Map
         public void NotifyChunkCollisionRegenerated()
         {
             UpdateAABB();
-        }
-
-        /// <inheritdoc />
-        public bool OnSnapCenter(Vector2 position)
-        {
-            return (MathHelper.CloseTo(position.X % SnapSize, 0) && MathHelper.CloseTo(position.Y % SnapSize, 0));
-        }
-
-        /// <inheritdoc />
-        public bool OnSnapBorder(Vector2 position)
-        {
-            return (MathHelper.CloseTo(position.X % SnapSize, SnapSize / 2) && MathHelper.CloseTo(position.Y % SnapSize, SnapSize / 2));
         }
 
         #region TileAccess

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -351,7 +351,7 @@ namespace Robust.Shared.Map
             DebugTools.Assert(ParentMapId == coords.GetMapId(_entityManager));
 
             var local = WorldToLocal(coords.ToMapPos(_entityManager));
-            return SnapGridCellFor(local);
+            return SnapGridLocalCellFor(local);
         }
 
         /// <inheritdoc />
@@ -360,11 +360,10 @@ namespace Robust.Shared.Map
             DebugTools.Assert(ParentMapId == worldPos.MapId);
 
             var localPos = WorldToLocal(worldPos.Position);
-            return SnapGridCellFor(localPos);
+            return SnapGridLocalCellFor(localPos);
         }
 
-        /// <inheritdoc />
-        public Vector2i SnapGridCellFor(Vector2 localPos)
+        public Vector2i SnapGridLocalCellFor(Vector2 localPos)
         {
             var x = (int)Math.Floor(localPos.X / TileSize);
             var y = (int)Math.Floor(localPos.Y / TileSize);
@@ -530,6 +529,8 @@ namespace Robust.Shared.Map
         /// </summary>
         public Vector2i CoordinatesToTile(EntityCoordinates coords)
         {
+            DebugTools.Assert(ParentMapId == coords.GetMapId(_entityManager));
+
             var local = WorldToLocal(coords.ToMapPos(_entityManager));
             var x = (int)Math.Floor(local.X / TileSize);
             var y = (int)Math.Floor(local.Y / TileSize);

--- a/Robust.Shared/Map/MapManager.cs
+++ b/Robust.Shared/Map/MapManager.cs
@@ -398,13 +398,12 @@ namespace Robust.Shared.Map
             return _grids.Values;
         }
 
-        public IMapGrid CreateGrid(MapId currentMapID, GridId? gridID = null, ushort chunkSize = 16, float snapSize = 1)
+        public IMapGrid CreateGrid(MapId currentMapID, GridId? gridID = null, ushort chunkSize = 16)
         {
-            return CreateGridImpl(currentMapID, gridID, chunkSize, snapSize, true);
+            return CreateGridImpl(currentMapID, gridID, chunkSize, true);
         }
 
-        private IMapGridInternal CreateGridImpl(MapId currentMapID, GridId? gridID, ushort chunkSize, float snapSize,
-            bool createEntity)
+        private IMapGridInternal CreateGridImpl(MapId currentMapID, GridId? gridID, ushort chunkSize, bool createEntity)
         {
 #if DEBUG
             DebugTools.Assert(_dbgGuardRunning);
@@ -432,7 +431,7 @@ namespace Robust.Shared.Map
                 HighestGridID = actualID;
             }
 
-            var grid = new MapGrid(this, _entityManager, actualID, chunkSize, snapSize, currentMapID);
+            var grid = new MapGrid(this, _entityManager, actualID, chunkSize, currentMapID);
             _grids.Add(actualID, grid);
             Logger.InfoS("map", $"Creating new grid {actualID}");
 
@@ -481,10 +480,9 @@ namespace Robust.Shared.Map
             return grid;
         }
 
-        public IMapGridInternal CreateGridNoEntity(MapId currentMapID, GridId? gridID = null, ushort chunkSize = 16,
-            float snapSize = 1)
+        public IMapGridInternal CreateGridNoEntity(MapId currentMapID, GridId? gridID = null, ushort chunkSize = 16)
         {
-            return CreateGridImpl(currentMapID, gridID, chunkSize, snapSize, false);
+            return CreateGridImpl(currentMapID, gridID, chunkSize, false);
         }
 
         public IMapGrid GetGrid(GridId gridID)

--- a/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.UnitTesting.Server;
+
+namespace Robust.UnitTesting.Shared.GameObjects.Systems
+{
+    [TestFixture, Parallelizable]
+    public class AnchoredSystemTests
+    {
+        private class Subscriber : IEntityEventSubscriber { }
+
+        private static ISimulation SimulationFactory()
+        {
+            var sim = RobustServerSimulation
+                .NewSimulation()
+                .InitializeInstance();
+
+            // Adds the map with id 1, and spawns entity 1 as the map entity.
+            sim.AddMap(1);
+
+            return sim;
+        }
+
+        /// <summary>
+        /// When an entity is anchored to a grid tile, it's world position is unchanged.
+        /// </summary>
+        [Test]
+        public void Anchored_WorldPosition_Unchanged()
+        {
+            var sim = SimulationFactory();
+            var entMan = sim.Resolve<IEntityManager>();
+
+            var subscriber = new Subscriber();
+            int calledCount = 0;
+            entMan.EventBus.SubscribeEvent<MoveEvent>(EventSource.Local, subscriber, MoveEventHandler);
+            var ent1 = entMan.SpawnEntity(null, new MapCoordinates(Vector2.Zero, new MapId(1)));
+
+            throw new NotImplementedException();
+
+            Assert.That(calledCount, Is.EqualTo(0));
+            void MoveEventHandler(MoveEvent ev)
+            {
+                Assert.Fail("MoveEvent raised when anchoring entity.");
+                calledCount++;
+            }
+        }
+
+        // Anchored entities have their world position locked where it is, their rotation locked and rounded to one of the 4 cardinal directions,
+        // and their parent changed to the grid they are anchored to. None of these 3 properties can be changed while anchored. Trying to write to these
+        // properties will silently fail.
+
+        // Because of these restrictions, they will never raise move or parent events while anchored.
+
+        // Anchored entities are registered as a tile entity to the grid tile they are above to when the flag is set. They are not moved when
+        // anchored. Content is free to place and orient the entity where it wants before anchoring.
+
+        // Entities cannot be anchored to space tiles. If a tile is changed to a space tile, all ents anchored to that tile are unanchored.
+
+        // An anchored entity is defined as an entity with the ITransformComponent.Anchored flag set. PhysicsComponent.Anchored is obsolete,
+        // And PhysicsComponent.BodyType is not able to be changed by content. PhysicsComponent.BodyType is synchronized with ITransformComponent.Anchored
+        // through anchored messages. SnapGridComponent is obsolete.
+
+        // Trying to anchor an entity to a space tile is a no-op.
+
+        // Adding an anchored entity to a container un-anchors it.
+
+        // Adding and removing a physics component should poll ITransformComponent.Anchored for the correct body type. Ents without a physics component can be anchored.
+    }
+}

--- a/Robust.UnitTesting/Shared/GameObjects/Systems/TransformSystemTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/Systems/TransformSystemTests.cs
@@ -1,0 +1,51 @@
+using NUnit.Framework;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.UnitTesting.Server;
+
+namespace Robust.UnitTesting.Shared.GameObjects.Systems
+{
+    [TestFixture, Parallelizable]
+    class TransformSystemTests
+    {
+        private static ISimulation SimulationFactory()
+        {
+            var sim = RobustServerSimulation
+                .NewSimulation()
+                .InitializeInstance();
+
+            // Adds the map with id 1, and spawns entity 1 as the map entity.
+            sim.AddMap(1);
+
+            return sim;
+        }
+
+        /// <summary>
+        /// When the local position of the transform changes, a MoveEvent is raised.
+        /// </summary>
+        [Test]
+        public void OnMove_LocalPosChanged_RaiseMoveEvent()
+        {
+            var sim = SimulationFactory();
+            var entMan = sim.Resolve<IEntityManager>();
+
+            var subscriber = new Subscriber();
+            int calledCount = 0;
+            entMan.EventBus.SubscribeEvent<MoveEvent>(EventSource.Local, subscriber, MoveEventHandler);
+            var ent1 = entMan.SpawnEntity(null, new MapCoordinates(Vector2.Zero, new MapId(1)));
+
+            ent1.Transform.LocalPosition = Vector2.One;
+
+            Assert.That(calledCount, Is.EqualTo(1));
+            void MoveEventHandler(MoveEvent ev)
+            {
+                calledCount++;
+                Assert.That(ev.OldPosition, Is.EqualTo(new EntityCoordinates(new EntityUid(1), Vector2.Zero)));
+                Assert.That(ev.NewPosition, Is.EqualTo(new EntityCoordinates(new EntityUid(1), Vector2.One)));
+            }
+        }
+
+        private class Subscriber : IEntityEventSubscriber { }
+    }
+}

--- a/Robust.UnitTesting/Shared/Map/MapChunk_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/MapChunk_Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Moq;
@@ -282,112 +282,6 @@ namespace Robust.UnitTesting.Shared.Map
             var result = chunk.ToString();
 
             Assert.That(result, Is.EqualTo("Chunk (7, 9)"));
-        }
-
-        [Test]
-        public void GetEmptySnapGrid()
-        {
-            var chunk = MapChunkFactory(7, 9);
-
-            Assert.That(chunk.GetSnapGridCell(0,0).ToList().Count, Is.EqualTo(0));
-            Assert.That(chunk.GetSnapGridCell(0, 0).ToList().Count, Is.EqualTo(0));
-        }
-
-        [Test]
-        public void GetSnapGridThrowsOutOfRange()
-        {
-            var chunk = MapChunkFactory(7, 9);
-
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.GetSnapGridCell(8,0).ToList()));
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.GetSnapGridCell(0, 8).ToList()));
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.GetSnapGridCell(8,0).ToList()));
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.GetSnapGridCell(0, 8).ToList()));
-        }
-
-        [Test]
-        public void AddSnapGridCellCenter()
-        {
-            var chunk = MapChunkFactory(7, 9);
-
-            var snapGridComponent = new SnapGridComponent();
-            chunk.AddToSnapGridCell(3, 5, snapGridComponent);
-            chunk.AddToSnapGridCell(3, 5, new SnapGridComponent());
-            chunk.AddToSnapGridCell(3, 6, new SnapGridComponent());
-
-            var result = chunk.GetSnapGridCell(3, 5).ToList();
-
-            Assert.That(result.Count, Is.EqualTo(1));
-            Assert.That(result[0], Is.EqualTo(snapGridComponent));
-        }
-
-        [Test]
-        public void AddSnapGridCellEdge()
-        {
-            var chunk = MapChunkFactory(7, 9);
-
-            var snapGridComponent = new SnapGridComponent();
-            chunk.AddToSnapGridCell(3, 5, snapGridComponent);
-            chunk.AddToSnapGridCell(3, 5, new SnapGridComponent());
-            chunk.AddToSnapGridCell(3, 6, new SnapGridComponent());
-
-            var result = chunk.GetSnapGridCell(3, 5).ToList();
-
-            Assert.That(result.Count, Is.EqualTo(1));
-            Assert.That(result[0], Is.EqualTo(snapGridComponent));
-        }
-
-        [Test]
-        public void AddSnapGridThrowsOutOfRange()
-        {
-            var chunk = MapChunkFactory(7, 9);
-
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.AddToSnapGridCell(8, 0, new SnapGridComponent())));
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.AddToSnapGridCell(0, 8, new SnapGridComponent())));
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.AddToSnapGridCell(8, 0, new SnapGridComponent())));
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.AddToSnapGridCell(0, 8, new SnapGridComponent())));
-        }
-
-        [Test]
-        public void RemoveSnapGridCellCenter()
-        {
-            var chunk = MapChunkFactory(7, 9);
-
-            var snapGridComponent = new SnapGridComponent();
-            chunk.AddToSnapGridCell(3, 5, snapGridComponent);
-            chunk.AddToSnapGridCell(3, 5, new SnapGridComponent());
-            chunk.AddToSnapGridCell(3, 6, new SnapGridComponent());
-
-            chunk.RemoveFromSnapGridCell(3, 5, snapGridComponent);
-
-            var result = chunk.GetSnapGridCell(3, 5).ToList();
-            Assert.That(result.Count, Is.EqualTo(0));
-        }
-
-        [Test]
-        public void RemoveSnapGridCellEdge()
-        {
-            var chunk = MapChunkFactory(7, 9);
-
-            var snapGridComponent = new SnapGridComponent();
-            chunk.AddToSnapGridCell(3, 5, snapGridComponent);
-            chunk.AddToSnapGridCell(3, 5, new SnapGridComponent());
-            chunk.AddToSnapGridCell(3, 6, new SnapGridComponent());
-
-            chunk.RemoveFromSnapGridCell(3, 5, snapGridComponent);
-
-            var result = chunk.GetSnapGridCell(3, 5).ToList();
-            Assert.That(result.Count, Is.EqualTo(0));
-        }
-
-        [Test]
-        public void RemoveSnapGridThrowsOutOfRange()
-        {
-            var chunk = MapChunkFactory(7, 9);
-
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.RemoveFromSnapGridCell(8, 0, new SnapGridComponent())));
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.RemoveFromSnapGridCell(0, 8, new SnapGridComponent())));
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.RemoveFromSnapGridCell(8, 0, new SnapGridComponent())));
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.RemoveFromSnapGridCell(0, 8, new SnapGridComponent())));
         }
 
         [Test]

--- a/Robust.UnitTesting/Shared/Map/MapChunk_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/MapChunk_Tests.cs
@@ -289,8 +289,8 @@ namespace Robust.UnitTesting.Shared.Map
         {
             var chunk = MapChunkFactory(7, 9);
 
-            Assert.That(chunk.GetSnapGridCell(0,0, SnapGridOffset.Center).ToList().Count, Is.EqualTo(0));
-            Assert.That(chunk.GetSnapGridCell(0, 0, SnapGridOffset.Edge).ToList().Count, Is.EqualTo(0));
+            Assert.That(chunk.GetSnapGridCell(0,0).ToList().Count, Is.EqualTo(0));
+            Assert.That(chunk.GetSnapGridCell(0, 0).ToList().Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -298,10 +298,10 @@ namespace Robust.UnitTesting.Shared.Map
         {
             var chunk = MapChunkFactory(7, 9);
 
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.GetSnapGridCell(8,0, SnapGridOffset.Center).ToList()));
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.GetSnapGridCell(0, 8, SnapGridOffset.Center).ToList()));
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.GetSnapGridCell(8,0,SnapGridOffset.Edge).ToList()));
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.GetSnapGridCell(0, 8, SnapGridOffset.Edge).ToList()));
+            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.GetSnapGridCell(8,0).ToList()));
+            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.GetSnapGridCell(0, 8).ToList()));
+            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.GetSnapGridCell(8,0).ToList()));
+            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.GetSnapGridCell(0, 8).ToList()));
         }
 
         [Test]
@@ -310,11 +310,11 @@ namespace Robust.UnitTesting.Shared.Map
             var chunk = MapChunkFactory(7, 9);
 
             var snapGridComponent = new SnapGridComponent();
-            chunk.AddToSnapGridCell(3, 5, SnapGridOffset.Center, snapGridComponent);
-            chunk.AddToSnapGridCell(3, 5, SnapGridOffset.Edge, new SnapGridComponent());
-            chunk.AddToSnapGridCell(3, 6, SnapGridOffset.Center, new SnapGridComponent());
+            chunk.AddToSnapGridCell(3, 5, snapGridComponent);
+            chunk.AddToSnapGridCell(3, 5, new SnapGridComponent());
+            chunk.AddToSnapGridCell(3, 6, new SnapGridComponent());
 
-            var result = chunk.GetSnapGridCell(3, 5, SnapGridOffset.Center).ToList();
+            var result = chunk.GetSnapGridCell(3, 5).ToList();
 
             Assert.That(result.Count, Is.EqualTo(1));
             Assert.That(result[0], Is.EqualTo(snapGridComponent));
@@ -326,11 +326,11 @@ namespace Robust.UnitTesting.Shared.Map
             var chunk = MapChunkFactory(7, 9);
 
             var snapGridComponent = new SnapGridComponent();
-            chunk.AddToSnapGridCell(3, 5, SnapGridOffset.Edge, snapGridComponent);
-            chunk.AddToSnapGridCell(3, 5, SnapGridOffset.Center, new SnapGridComponent());
-            chunk.AddToSnapGridCell(3, 6, SnapGridOffset.Edge, new SnapGridComponent());
+            chunk.AddToSnapGridCell(3, 5, snapGridComponent);
+            chunk.AddToSnapGridCell(3, 5, new SnapGridComponent());
+            chunk.AddToSnapGridCell(3, 6, new SnapGridComponent());
 
-            var result = chunk.GetSnapGridCell(3, 5, SnapGridOffset.Edge).ToList();
+            var result = chunk.GetSnapGridCell(3, 5).ToList();
 
             Assert.That(result.Count, Is.EqualTo(1));
             Assert.That(result[0], Is.EqualTo(snapGridComponent));
@@ -341,10 +341,10 @@ namespace Robust.UnitTesting.Shared.Map
         {
             var chunk = MapChunkFactory(7, 9);
 
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.AddToSnapGridCell(8, 0, SnapGridOffset.Center, new SnapGridComponent())));
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.AddToSnapGridCell(0, 8, SnapGridOffset.Center, new SnapGridComponent())));
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.AddToSnapGridCell(8, 0, SnapGridOffset.Edge, new SnapGridComponent())));
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.AddToSnapGridCell(0, 8, SnapGridOffset.Edge, new SnapGridComponent())));
+            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.AddToSnapGridCell(8, 0, new SnapGridComponent())));
+            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.AddToSnapGridCell(0, 8, new SnapGridComponent())));
+            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.AddToSnapGridCell(8, 0, new SnapGridComponent())));
+            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.AddToSnapGridCell(0, 8, new SnapGridComponent())));
         }
 
         [Test]
@@ -353,13 +353,13 @@ namespace Robust.UnitTesting.Shared.Map
             var chunk = MapChunkFactory(7, 9);
 
             var snapGridComponent = new SnapGridComponent();
-            chunk.AddToSnapGridCell(3, 5, SnapGridOffset.Center, snapGridComponent);
-            chunk.AddToSnapGridCell(3, 5, SnapGridOffset.Edge, new SnapGridComponent());
-            chunk.AddToSnapGridCell(3, 6, SnapGridOffset.Center, new SnapGridComponent());
+            chunk.AddToSnapGridCell(3, 5, snapGridComponent);
+            chunk.AddToSnapGridCell(3, 5, new SnapGridComponent());
+            chunk.AddToSnapGridCell(3, 6, new SnapGridComponent());
 
-            chunk.RemoveFromSnapGridCell(3, 5, SnapGridOffset.Center, snapGridComponent);
+            chunk.RemoveFromSnapGridCell(3, 5, snapGridComponent);
 
-            var result = chunk.GetSnapGridCell(3, 5, SnapGridOffset.Center).ToList();
+            var result = chunk.GetSnapGridCell(3, 5).ToList();
             Assert.That(result.Count, Is.EqualTo(0));
         }
 
@@ -369,13 +369,13 @@ namespace Robust.UnitTesting.Shared.Map
             var chunk = MapChunkFactory(7, 9);
 
             var snapGridComponent = new SnapGridComponent();
-            chunk.AddToSnapGridCell(3, 5, SnapGridOffset.Edge, snapGridComponent);
-            chunk.AddToSnapGridCell(3, 5, SnapGridOffset.Center, new SnapGridComponent());
-            chunk.AddToSnapGridCell(3, 6, SnapGridOffset.Edge, new SnapGridComponent());
+            chunk.AddToSnapGridCell(3, 5, snapGridComponent);
+            chunk.AddToSnapGridCell(3, 5, new SnapGridComponent());
+            chunk.AddToSnapGridCell(3, 6, new SnapGridComponent());
 
-            chunk.RemoveFromSnapGridCell(3, 5, SnapGridOffset.Edge, snapGridComponent);
+            chunk.RemoveFromSnapGridCell(3, 5, snapGridComponent);
 
-            var result = chunk.GetSnapGridCell(3, 5, SnapGridOffset.Edge).ToList();
+            var result = chunk.GetSnapGridCell(3, 5).ToList();
             Assert.That(result.Count, Is.EqualTo(0));
         }
 
@@ -384,10 +384,10 @@ namespace Robust.UnitTesting.Shared.Map
         {
             var chunk = MapChunkFactory(7, 9);
 
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.RemoveFromSnapGridCell(8, 0, SnapGridOffset.Center, new SnapGridComponent())));
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.RemoveFromSnapGridCell(0, 8, SnapGridOffset.Center, new SnapGridComponent())));
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.RemoveFromSnapGridCell(8, 0, SnapGridOffset.Edge, new SnapGridComponent())));
-            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.RemoveFromSnapGridCell(0, 8, SnapGridOffset.Edge, new SnapGridComponent())));
+            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.RemoveFromSnapGridCell(8, 0, new SnapGridComponent())));
+            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.RemoveFromSnapGridCell(0, 8, new SnapGridComponent())));
+            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.RemoveFromSnapGridCell(8, 0, new SnapGridComponent())));
+            Assert.Throws<ArgumentOutOfRangeException>((() => chunk.RemoveFromSnapGridCell(0, 8, new SnapGridComponent())));
         }
 
         [Test]

--- a/Robust.UnitTesting/Shared/Map/MapGrid_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/MapGrid_Tests.cs
@@ -170,7 +170,7 @@ namespace Robust.UnitTesting.Shared.Map
             if(mapMan.GridExists(id))
                 mapMan.DeleteGrid(id);
 
-            var newGrid = mapMan.CreateGrid(mapId, id, 8, 1);
+            var newGrid = mapMan.CreateGrid(mapId, id, 8);
             newGrid.WorldPosition = new Vector2(3, 5);
 
             return (IMapGridInternal)newGrid;


### PR DESCRIPTION
* Removes all references to `SnapGridComponent` outside of `TransformComponent` and `SnapGridSystem`. Various functionality has been moved to `TransformComponent` and/or `IMapGrid`.
* Brings remaining SnapGrid ECS code up to 2021 standards.

This is in preparation for SnapGrid rework in https://github.com/space-wizards/RobustToolbox/issues/1719. The SnapGrid implementation code is not optimal, because it is about to be completely reworked.

Requires https://github.com/space-wizards/space-station-14/pull/3884.