### PR TITLE
Unbuckling Closes Inventory UI

### DIFF
--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -440,7 +440,12 @@ namespace Robust.Server.Maps
                 foreach (var grid in Grids)
                 {
                     var entity = _serverEntityManager.GetEntity(grid.GridEntityId);
+                    if (entity.Transform.Parent != null)
+                        continue;
+
+                    var mapOffset = entity.Transform.LocalPosition;
                     entity.Transform.AttachParent(mapEntity);
+                    entity.Transform.WorldPosition = mapOffset;
                 }
             }
 

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -553,6 +553,8 @@ namespace Robust.Shared.GameObjects
             var entMessage = new EntParentChangedMessage(Owner, oldParentOwner);
             var compMessage = new ParentChangedMessage(newParentEnt, oldParentOwner);
 
+            // offset position from world to parent
+            SetPosition(newParent.InvWorldMatrix.Transform(WorldPosition));
             _parent = newParentEnt.Uid;
 
             ChangeMapId(newConcrete.MapID);
@@ -560,8 +562,6 @@ namespace Robust.Shared.GameObjects
             Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, entMessage);
             Owner.SendMessage(this, compMessage);
 
-            // offset position from world to parent
-            SetPosition(newParent.InvWorldMatrix.Transform(_localPosition));
             RebuildMatrices();
             Dirty();
         }

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -542,6 +542,10 @@ namespace Robust.Shared.GameObjects
                 return;
             }
 
+
+            // offset position from world to parent
+            SetPosition(WorldPosition - newParent.WorldPosition);
+
             var oldParent = Parent;
             var oldConcrete = (TransformComponent?) oldParent;
             var uid = Owner.Uid;
@@ -560,8 +564,7 @@ namespace Robust.Shared.GameObjects
             Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, entMessage);
             Owner.SendMessage(this, compMessage);
 
-            // offset position from world to parent
-            SetPosition(newParent.InvWorldMatrix.Transform(_localPosition));
+            
             RebuildMatrices();
             Dirty();
         }

--- a/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
@@ -159,6 +159,40 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
         }
 
         /// <summary>
+        ///     Tests that a child entity does not move when attaching to a parent.
+        /// </summary>
+        [Test]
+        public void ParentDoubleAttachMoveTest()
+        {
+            // Arrange
+            var parent = EntityManager.SpawnEntity("dummy", InitialPos);
+            var childOne = EntityManager.SpawnEntity("dummy", InitialPos);
+            var childTwo = EntityManager.SpawnEntity("dummy", InitialPos);
+            var parentTrans = parent.Transform;
+            var childOneTrans = childOne.Transform;
+            var childTwoTrans = childTwo.Transform;
+            parentTrans.WorldPosition = new Vector2(1, 1);
+            childOneTrans.WorldPosition = new Vector2(2, 2);
+            childTwoTrans.WorldPosition = new Vector2(3, 3);
+
+            // Act
+            var oldWpos = childOneTrans.WorldPosition;
+            childOneTrans.AttachParent(parentTrans);
+            var newWpos = childOneTrans.WorldPosition;
+            Assert.That(oldWpos, Is.EqualTo(newWpos));
+
+            oldWpos = childTwoTrans.WorldPosition;
+            childTwoTrans.AttachParent(parentTrans);
+            newWpos = childTwoTrans.WorldPosition;
+            Assert.That(oldWpos, Is.EqualTo(newWpos));
+
+            oldWpos = childTwoTrans.WorldPosition;
+            childTwoTrans.AttachParent(childOneTrans);
+            newWpos = childTwoTrans.WorldPosition;
+            Assert.That(oldWpos, Is.EqualTo(newWpos));
+        }
+
+        /// <summary>
         ///     Tests that the entity orbits properly when the parent rotates.
         /// </summary>
         [Test]


### PR DESCRIPTION
What a fucking mudcrawl this was.
Fixes a line of code that caused parented objects to receive incorrect positions, causing, apparently, all sorts of icky stuff.
My brain is hot mush.