### PR TITLE
Fix placement of grid tiles on the edge of a grid

### DIFF
--- a/Robust.Shared/Map/CoordinatesExtensions.cs
+++ b/Robust.Shared/Map/CoordinatesExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Maths;
 
@@ -53,7 +53,7 @@ namespace Robust.Shared.Map
                 if (closest != null) // stick to existing grid
                 {
                     // round to nearest cardinal dir
-                    var normal = new Angle(coords.Position - intersect.Center).GetCardinalDir().ToVec();
+                    var normal = coords.Position - intersect.Center;
 
                     // round coords to center of tile
                     var tileIndices = closest.WorldToTile(intersect.Center);

--- a/Robust.Shared/Map/CoordinatesExtensions.cs
+++ b/Robust.Shared/Map/CoordinatesExtensions.cs
@@ -26,11 +26,13 @@ namespace Robust.Shared.Map
 
             if (!gridId.IsValid() || !mapManager.GridExists(gridId))
             {
+                var mapCoords = coords.ToMap(entityManager);
+
                 // create a box around the cursor
-                var gridSearchBox = Box2.UnitCentered.Scale(searchBoxSize).Translated(coords.Position);
+                var gridSearchBox = Box2.UnitCentered.Scale(searchBoxSize).Translated(mapCoords.Position);
 
                 // find grids in search box
-                var gridsInArea = mapManager.FindGridsIntersecting(coords.GetMapId(entityManager), gridSearchBox);
+                var gridsInArea = mapManager.FindGridsIntersecting(mapCoords.MapId, gridSearchBox);
 
                 // find closest grid intersecting our search box.
                 IMapGrid? closest = null;
@@ -40,7 +42,7 @@ namespace Robust.Shared.Map
                 {
                     // figure out closest intersect
                     var gridIntersect = gridSearchBox.Intersect(grid.WorldBounds);
-                    var gridDist = (gridIntersect.Center - coords.Position).LengthSquared;
+                    var gridDist = (gridIntersect.Center - mapCoords.Position).LengthSquared;
 
                     if (gridDist >= distance)
                         continue;
@@ -53,7 +55,7 @@ namespace Robust.Shared.Map
                 if (closest != null) // stick to existing grid
                 {
                     // round to nearest cardinal dir
-                    var normal = coords.Position - intersect.Center;
+                    var normal = mapCoords.Position - intersect.Center;
 
                     // round coords to center of tile
                     var tileIndices = closest.WorldToTile(intersect.Center);


### PR DESCRIPTION
At some point tile snapping when placing new tiles on the edge of the grid broke. Removing all of the conversions fixed it.

It snaps if the cursor is closer than around 2/3rds of a tile.