### PR TITLE
Make serialization work with backing fields automatically

### DIFF
--- a/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
+++ b/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
@@ -19,7 +19,7 @@ namespace Robust.Client.Graphics
         [Dependency] private readonly IResourceCache _resourceCache = default!;
 
         [ViewVariables]
-        [field: DataField("id", required: true)]
+        [DataField("id", required: true)]
         public string ID { get; } = default!;
 
         private ShaderKind Kind;

--- a/Robust.Shared/Containers/BaseContainer.cs
+++ b/Robust.Shared/Containers/BaseContainer.cs
@@ -32,7 +32,7 @@ namespace Robust.Shared.Containers
 
         /// <inheritdoc />
         [ViewVariables(VVAccess.ReadWrite)]
-        [field: DataField("occludes")]
+        [DataField("occludes")]
         public bool OccludesLight { get; set; } = true;
 
         /// <inheritdoc />
@@ -41,7 +41,7 @@ namespace Robust.Shared.Containers
 
         /// <inheritdoc />
         [ViewVariables(VVAccess.ReadWrite)]
-        [field: DataField("showEnts")]
+        [DataField("showEnts")]
         public bool ShowContents { get; set; }
 
         /// <summary>

--- a/Robust.Shared/GameObjects/Component.cs
+++ b/Robust.Shared/GameObjects/Component.cs
@@ -28,7 +28,7 @@ namespace Robust.Shared.GameObjects
 
         /// <inheritdoc />
         [ViewVariables]
-        [field: DataField("netsync")]
+        [DataField("netsync")]
         public bool NetSyncEnabled { get; set; } = true;
 
         /// <inheritdoc />

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -163,8 +163,8 @@ namespace Robust.Shared.Prototypes
         /// <summary>
         /// A dictionary mapping the component type list to the YAML mapping containing their settings.
         /// </summary>
-        [field: DataField("components")]
-        [field: AlwaysPushInheritance]
+        [DataField("components")]
+        [AlwaysPushInheritance]
         public ComponentRegistry Components { get; } = new();
 
         private readonly HashSet<Type> ReferenceTypes = new();

--- a/Robust.Shared/Serialization/Manager/Attributes/NeverPushInheritanceAttribute.cs
+++ b/Robust.Shared/Serialization/Manager/Attributes/NeverPushInheritanceAttribute.cs
@@ -4,7 +4,6 @@ namespace Robust.Shared.Serialization.Manager.Attributes
 {
     //todo paul find a way to constrain this to datafields only & make exclusive w/ alwayspush
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-
     public class NeverPushInheritanceAttribute : Attribute
     {
 

--- a/Robust.Shared/Serialization/Manager/SerializationDataDefinition.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationDataDefinition.cs
@@ -142,8 +142,7 @@ namespace Robust.Shared.Serialization.Manager
 
             _duplicates = fieldDefs
                 .Where(f =>
-                    fieldDefs
-                        .Count(df => df.Attribute.Tag == f.Attribute.Tag) > 1)
+                    fieldDefs.Count(df => df.Attribute.Tag == f.Attribute.Tag) > 1)
                 .Select(f => f.Attribute.Tag)
                 .Distinct()
                 .ToArray();

--- a/Robust.Shared/Serialization/Manager/SerializationDataDefinition.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationDataDefinition.cs
@@ -150,13 +150,13 @@ namespace Robust.Shared.Serialization.Manager
                 .Distinct()
                 .ToArray();
 
-            var fields = fieldDefs;
-            fields
+            var fields = fieldDefs
                 .Values
-                .ToList()
-                .Sort((a, b) => b.Attribute.Priority.CompareTo(a.Attribute.Priority));
+                .ToList();
 
-            _baseFieldDefinitions = fields.Values.ToArray();
+            fields.Sort((a, b) => b.Attribute.Priority.CompareTo(a.Attribute.Priority));
+
+            _baseFieldDefinitions = fields.ToArray();
             _defaultValues = fieldDefs.Values.Select(f => f.DefaultValue).ToArray();
 
             _deserializeDelegate = EmitDeserializationDelegate();

--- a/Robust.Shared/Serialization/Manager/SerializationDataDefinition.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationDataDefinition.cs
@@ -82,7 +82,7 @@ namespace Robust.Shared.Serialization.Manager
             Type = type;
             var dummyObj = Activator.CreateInstance(type)!;
 
-            var fieldDefs = new Dictionary<AbstractFieldInfo, FieldDefinition>();
+            var fieldDefs = new List<FieldDefinition>();
 
             foreach (var abstractFieldInfo in type.GetAllPropertiesAndFields())
             {
@@ -137,27 +137,23 @@ namespace Robust.Shared.Serialization.Manager
                     backingField,
                     inheritanceBehaviour);
 
-                fieldDefs.Add(abstractFieldInfo, fieldDefinition);
+                fieldDefs.Add(fieldDefinition);
             }
 
             _duplicates = fieldDefs
-                .Values
                 .Where(f =>
                     fieldDefs
-                        .Values
                         .Count(df => df.Attribute.Tag == f.Attribute.Tag) > 1)
                 .Select(f => f.Attribute.Tag)
                 .Distinct()
                 .ToArray();
 
-            var fields = fieldDefs
-                .Values
-                .ToList();
+            var fields = fieldDefs;
 
             fields.Sort((a, b) => b.Attribute.Priority.CompareTo(a.Attribute.Priority));
 
             _baseFieldDefinitions = fields.ToArray();
-            _defaultValues = fieldDefs.Values.Select(f => f.DefaultValue).ToArray();
+            _defaultValues = fieldDefs.Select(f => f.DefaultValue).ToArray();
 
             _deserializeDelegate = EmitDeserializationDelegate();
             _populateDelegate = EmitPopulateDelegate();

--- a/Robust.Shared/Serialization/Manager/SerializationManager.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.cs
@@ -247,14 +247,14 @@ namespace Robust.Shared.Serialization.Manager
             return res;
         }
 
-        private SerializationDataDefinition? GetDataDefinition(Type type)
+        internal SerializationDataDefinition? GetDataDefinition(Type type)
         {
             if (_dataDefinitions.TryGetValue(type, out var dataDefinition)) return dataDefinition;
 
             return null;
         }
 
-        private bool TryGetDataDefinition(Type type, [NotNullWhen(true)] out SerializationDataDefinition? dataDefinition)
+        internal bool TryGetDataDefinition(Type type, [NotNullWhen(true)] out SerializationDataDefinition? dataDefinition)
         {
             dataDefinition = GetDataDefinition(type);
             return dataDefinition != null;

--- a/Robust.UnitTesting/Shared/Serialization/PropertyAndFieldDefinitionTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/PropertyAndFieldDefinitionTest.cs
@@ -1,0 +1,124 @@
+﻿using NUnit.Framework;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Utility;
+using static Robust.Shared.Serialization.Manager.SerializationDataDefinition;
+
+// ReSharper disable UnassignedGetOnlyAutoProperty
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+// ReSharper disable AccessToStaticMemberViaDerivedType
+
+namespace Robust.UnitTesting.Shared.Serialization
+{
+    public class PropertyAndFieldDefinitionTest : SerializationTest
+    {
+        private const string GetOnlyPropertyName = "GetOnlyProperty";
+        private const string GetOnlyPropertyFieldTargetedName = "GetOnlyPropertyFieldTargeted";
+        private const string GetAndSetPropertyName = "GetAndSetProperty";
+        private const string FieldName = "Field";
+        private const string GetOnlyPropertyWithOtherAttributeFieldTargetedName =
+            "GetOnlyPropertyWithOtherAttributeFieldTargeted";
+        private const string GetOnlyPropertyFieldTargetedAndOtherAttributeName =
+            "GetOnlyPropertyFieldTargetedAndOtherAttribute";
+
+        [Test]
+        public void ParityTest()
+        {
+            var mapping = new MappingDataNode();
+            mapping.AddNode(GetOnlyPropertyName, new ValueDataNode("5"));
+            mapping.AddNode(GetOnlyPropertyFieldTargetedName, new ValueDataNode("10"));
+            mapping.AddNode(GetAndSetPropertyName, new ValueDataNode("15"));
+            mapping.AddNode(FieldName, new ValueDataNode("20"));
+            mapping.AddNode(GetOnlyPropertyWithOtherAttributeFieldTargetedName, new ValueDataNode("25"));
+            mapping.AddNode(GetOnlyPropertyFieldTargetedAndOtherAttributeName, new ValueDataNode("30"));
+
+            var definition = Serialization.ReadValue<PropertyAndFieldDefinitionTestDefinition>(mapping);
+
+            Assert.NotNull(definition);
+
+            // Set only property with backing field, property targeted
+            Assert.That(definition!.GetOnlyProperty, Is.EqualTo(5));
+
+            var backingField = definition.GetType().GetBackingField(GetOnlyPropertyName);
+            Assert.NotNull(backingField);
+
+            var backingFieldValue = backingField!.GetValue(definition);
+            Assert.That(backingFieldValue, Is.EqualTo(5));
+
+            // Set only property with backing field, field targeted
+            Assert.That(definition.GetOnlyPropertyFieldTargeted, Is.EqualTo(10));
+
+            // Get and set property with backing field, property targeted
+            Assert.That(definition.GetAndSetProperty, Is.EqualTo(15));
+
+            // Field
+            Assert.That(definition.Field, Is.EqualTo(20));
+
+            // Get only property with other attribute field targeted
+            Assert.That(definition.GetOnlyPropertyWithOtherAttributeFieldTargeted, Is.EqualTo(25));
+
+            var property = definition.GetType().GetProperty(GetOnlyPropertyWithOtherAttributeFieldTargetedName);
+            Assert.NotNull(property);
+
+            var propertyInfo = new SpecificPropertyInfo(property!);
+            Assert.NotNull(propertyInfo.GetCustomAttribute<DataFieldAttribute>());
+            Assert.NotNull(propertyInfo.GetCustomAttribute<AlwaysPushInheritanceAttribute>());
+
+            // We check for the property info properly finding field targeted attributes as
+            // well, otherwise we run the risk of the data field being targeted to the
+            // property but an additional attribute like AlwaysPushInheritance being targeted
+            // to the field, as was the case in EntityPrototype.
+            // And I don't want to debug that ever again.
+            Assert.NotNull(propertyInfo.DeclaringType);
+
+            var dataDefinition = ((SerializationManager) Serialization).GetDataDefinition(propertyInfo.DeclaringType!);
+            Assert.NotNull(dataDefinition);
+
+            var inheritanceBehaviour = dataDefinition!.GetInheritanceBehaviour(propertyInfo);
+            Assert.NotNull(inheritanceBehaviour);
+            Assert.That(inheritanceBehaviour!.Value, Is.EqualTo(InheritanceBehaviour.Always));
+
+            // Get only property with backing field and another attribute targeted to the property
+            Assert.That(definition.GetOnlyPropertyFieldTargetedAndOtherAttribute, Is.EqualTo(30));
+
+            property = definition.GetType().GetProperty(GetOnlyPropertyFieldTargetedAndOtherAttributeName);
+            Assert.NotNull(property);
+
+            propertyInfo = new SpecificPropertyInfo(property!);
+            Assert.NotNull(propertyInfo.GetCustomAttribute<DataFieldAttribute>());
+            Assert.NotNull(propertyInfo.GetCustomAttribute<NeverPushInheritanceAttribute>());
+
+            dataDefinition = ((SerializationManager) Serialization).GetDataDefinition(property.DeclaringType!);
+            Assert.NotNull(dataDefinition);
+            inheritanceBehaviour = dataDefinition!.GetInheritanceBehaviour(propertyInfo);
+            Assert.NotNull(inheritanceBehaviour);
+            Assert.That(inheritanceBehaviour!.Value, Is.EqualTo(InheritanceBehaviour.Never));
+        }
+
+        [DataDefinition]
+        public class PropertyAndFieldDefinitionTestDefinition
+        {
+            [DataField(GetOnlyPropertyName)]
+            public int GetOnlyProperty { get; }
+
+            [field: DataField(GetOnlyPropertyFieldTargetedName)]
+            public int GetOnlyPropertyFieldTargeted { get; }
+
+            [DataField(GetAndSetPropertyName)]
+            public int GetAndSetProperty { get; set; }
+
+            [DataField(FieldName)]
+            // ReSharper disable once UnassignedField.Global
+            public int Field;
+
+            [DataField(GetOnlyPropertyWithOtherAttributeFieldTargetedName)]
+            [field: AlwaysPushInheritance]
+            public int GetOnlyPropertyWithOtherAttributeFieldTargeted { get; }
+
+            [field: DataField(GetOnlyPropertyFieldTargetedAndOtherAttributeName)]
+            [NeverPushInheritance]
+            public int GetOnlyPropertyFieldTargetedAndOtherAttribute { get; }
+        }
+    }
+}

--- a/Robust.UnitTesting/Shared/Serialization/SerializationPriorityTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/SerializationPriorityTest.cs
@@ -36,8 +36,8 @@ namespace Robust.UnitTesting.Shared.Serialization
 
             Assert.That(component.Strings.Count, Is.EqualTo(3));
             Assert.That(component.First, Is.EqualTo("A"));
-            Assert.That(component.Second, Is.EqualTo("B"));
-            Assert.That(component.Third, Is.EqualTo("C"));
+            Assert.That(component.Second, Is.EqualTo("C"));
+            Assert.That(component.Third, Is.EqualTo("B"));
         }
     }
 
@@ -54,14 +54,14 @@ namespace Robust.UnitTesting.Shared.Serialization
             set => Strings.Add(value);
         }
 
-        [DataField("second", priority: 2)]
+        [DataField("second", priority: 1)]
         public string Second
         {
             get => Strings[1];
             set => Strings.Add(value);
         }
 
-        [DataField("third", priority: 1)]
+        [DataField("third", priority: 2)]
         public string Third
         {
             get => Strings[2];

--- a/Robust.UnitTesting/Shared/Serialization/SerializationTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/SerializationTest.cs
@@ -2,9 +2,9 @@
 using Robust.Shared.IoC;
 using Robust.Shared.Serialization.Manager;
 
-namespace Robust.UnitTesting.Shared.Serialization.TypeSerializers
+namespace Robust.UnitTesting.Shared.Serialization
 {
-    public abstract class TypeSerializerTest : RobustUnitTest
+    public abstract class SerializationTest : RobustUnitTest
     {
         protected ISerializationManager Serialization => IoCManager.Resolve<ISerializationManager>();
 

--- a/Robust.UnitTesting/Shared/Serialization/TypeSerializers/AngleSerializerTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/TypeSerializers/AngleSerializerTest.cs
@@ -10,7 +10,7 @@ namespace Robust.UnitTesting.Shared.Serialization.TypeSerializers
 {
     [TestFixture]
     [TestOf(typeof(AngleSerializer))]
-    public class AngleSerializerTest : TypeSerializerTest
+    public class AngleSerializerTest : SerializationTest
     {
         [Test]
         public void SerializationTest()

--- a/Robust.UnitTesting/Shared/Serialization/TypeSerializers/ArraySerializerTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/TypeSerializers/ArraySerializerTest.cs
@@ -9,7 +9,7 @@ namespace Robust.UnitTesting.Shared.Serialization.TypeSerializers
 {
     [TestFixture]
     [TestOf(typeof(ListSerializers<>))]
-    public class ArraySerializerTest : TypeSerializerTest
+    public class ArraySerializerTest : SerializationTest
     {
         [Test]
         public void SerializationTest()

--- a/Robust.UnitTesting/Shared/Serialization/TypeSerializers/Box2SerializerTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/TypeSerializers/Box2SerializerTest.cs
@@ -10,7 +10,7 @@ namespace Robust.UnitTesting.Shared.Serialization.TypeSerializers
 {
     [TestFixture]
     [TestOf(typeof(Box2Serializer))]
-    public class Box2SerializerTest : TypeSerializerTest
+    public class Box2SerializerTest : SerializationTest
     {
         [Test]
         public void SerializationTest()

--- a/Robust.UnitTesting/Shared/Serialization/TypeSerializers/ColorSerializerTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/TypeSerializers/ColorSerializerTest.cs
@@ -10,7 +10,7 @@ namespace Robust.UnitTesting.Shared.Serialization.TypeSerializers
 {
     [TestFixture]
     [TestOf(typeof(ColorSerializer))]
-    public class ColorSerializerTest : TypeSerializerTest
+    public class ColorSerializerTest : SerializationTest
     {
         [Test]
         public void SerializationTest()

--- a/Robust.UnitTesting/Shared/Serialization/TypeSerializers/ComponentRegistrySerializerTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/TypeSerializers/ComponentRegistrySerializerTest.cs
@@ -13,7 +13,7 @@ namespace Robust.UnitTesting.Shared.Serialization.TypeSerializers
 {
     [TestFixture]
     [TestOf(typeof(ComponentRegistrySerializer))]
-    public class ComponentRegistrySerializerTest : TypeSerializerTest
+    public class ComponentRegistrySerializerTest : SerializationTest
     {
         [OneTimeSetUp]
         public new void OneTimeSetup()

--- a/Robust.UnitTesting/Shared/Serialization/TypeSerializers/Custom/Prototype/PrototypeIdListSerializerTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/TypeSerializers/Custom/Prototype/PrototypeIdListSerializerTest.cs
@@ -17,7 +17,7 @@ namespace Robust.UnitTesting.Shared.Serialization.TypeSerializers.Custom.Prototy
 {
     [TestFixture]
     [TestOf(typeof(PrototypeIdListSerializer<>))]
-    public class PrototypeIdListSerializerTest : TypeSerializerTest
+    public class PrototypeIdListSerializerTest : SerializationTest
     {
         private static readonly string TestEntityId = $"{nameof(PrototypeIdListSerializerTest)}Dummy";
 
@@ -162,16 +162,16 @@ entitiesImmutableList:
     [DataDefinition]
     public class PrototypeIdListSerializerTestDataDefinition
     {
-        [field: DataField("entitiesList", customTypeSerializer: typeof(PrototypeIdListSerializer<EntityPrototype>))]
+        [DataField("entitiesList", customTypeSerializer: typeof(PrototypeIdListSerializer<EntityPrototype>))]
         public List<string> EntitiesList = new();
 
-        [field: DataField("entitiesReadOnlyList", customTypeSerializer: typeof(PrototypeIdListSerializer<EntityPrototype>))]
+        [DataField("entitiesReadOnlyList", customTypeSerializer: typeof(PrototypeIdListSerializer<EntityPrototype>))]
         public IReadOnlyList<string> EntitiesReadOnlyList = new List<string>();
 
-        [field: DataField("entitiesReadOnlyCollection", customTypeSerializer: typeof(PrototypeIdListSerializer<EntityPrototype>))]
+        [DataField("entitiesReadOnlyCollection", customTypeSerializer: typeof(PrototypeIdListSerializer<EntityPrototype>))]
         public IReadOnlyCollection<string> EntitiesReadOnlyCollection = new List<string>();
 
-        [field: DataField("entitiesImmutableList", customTypeSerializer: typeof(PrototypeIdListSerializer<EntityPrototype>))]
+        [DataField("entitiesImmutableList", customTypeSerializer: typeof(PrototypeIdListSerializer<EntityPrototype>))]
         public ImmutableList<string> EntitiesImmutableList = ImmutableList<string>.Empty;
     }
 }

--- a/Robust.UnitTesting/Shared/Serialization/TypeSerializers/DictionarySerializerTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/TypeSerializers/DictionarySerializerTest.cs
@@ -10,7 +10,7 @@ namespace Robust.UnitTesting.Shared.Serialization.TypeSerializers
 {
     [TestFixture]
     [TestOf(typeof(DictionarySerializer<,>))]
-    public class DictionarySerializerTest : TypeSerializerTest
+    public class DictionarySerializerTest : SerializationTest
     {
         [Test]
         public void SerializationTest()

--- a/Robust.UnitTesting/Shared/Serialization/TypeSerializers/HashSetSerializerTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/TypeSerializers/HashSetSerializerTest.cs
@@ -10,7 +10,7 @@ namespace Robust.UnitTesting.Shared.Serialization.TypeSerializers
 {
     [TestFixture]
     [TestOf(typeof(HashSetSerializer<>))]
-    public class HashSetSerializerTest : TypeSerializerTest
+    public class HashSetSerializerTest : SerializationTest
     {
         [Test]
         public void SerializationTest()

--- a/Robust.UnitTesting/Shared/Serialization/TypeSerializers/ListSerializerTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/TypeSerializers/ListSerializerTest.cs
@@ -10,7 +10,7 @@ namespace Robust.UnitTesting.Shared.Serialization.TypeSerializers
 {
     [TestFixture]
     [TestOf(typeof(ListSerializers<>))]
-    public class ListSerializerTest : TypeSerializerTest
+    public class ListSerializerTest : SerializationTest
     {
         [Test]
         public void SerializationTest()

--- a/Robust.UnitTesting/Shared/Serialization/TypeSerializers/RegexSerializerTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/TypeSerializers/RegexSerializerTest.cs
@@ -10,7 +10,7 @@ namespace Robust.UnitTesting.Shared.Serialization.TypeSerializers
 {
     [TestFixture]
     [TestOf(typeof(RegexSerializer))]
-    public class RegexSerializerTest : TypeSerializerTest
+    public class RegexSerializerTest : SerializationTest
     {
         [Test]
         public void SerializationTest()


### PR DESCRIPTION
This removes the need to write [field: DataField(...)] on get-only properties with a backing field, for which the only warning was a line in the serialization doc and an error after starting up the game.

The backing field is found by looking for a field with the name \<PropertyName\>k__BackingField and an attribute of CompilerGenerated, as far as I know these are an implementation detail but the same across C# and a bunch of other compilers. The method that finds the backing field is in TypeHelpers in case its implementation ever needs to be changed. The other way to do it would be to analyze the instructions of the method body and finding the Ldfld op code (second instruction) and going from there, but that is above my paygrade.