### PR TITLE
Fix missing Attribute suffix from some serialization attributes

### DIFF
--- a/Robust.Shared/Serialization/Manager/Attributes/DataDefinitionAttribute.cs
+++ b/Robust.Shared/Serialization/Manager/Attributes/DataDefinitionAttribute.cs
@@ -6,7 +6,7 @@ namespace Robust.Shared.Serialization.Manager.Attributes
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
     [MeansDataDefinition]
     [MeansImplicitUse]
-    public class DataDefinition : Attribute
+    public class DataDefinitionAttribute : Attribute
     {
     }
 }

--- a/Robust.Shared/Serialization/Manager/Attributes/MeansDataDefinitionAttribute.cs
+++ b/Robust.Shared/Serialization/Manager/Attributes/MeansDataDefinitionAttribute.cs
@@ -5,7 +5,7 @@ namespace Robust.Shared.Serialization.Manager.Attributes
 {
     [BaseTypeRequired(typeof(Attribute))]
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]
-    public class MeansDataDefinition : Attribute
+    public class MeansDataDefinitionAttribute : Attribute
     {
     }
 }

--- a/Robust.Shared/Serialization/Manager/Definition/DataDefinition.Delegates.cs
+++ b/Robust.Shared/Serialization/Manager/Definition/DataDefinition.Delegates.cs
@@ -1,7 +1,7 @@
 ﻿using Robust.Shared.Serialization.Manager.Result;
 using Robust.Shared.Serialization.Markdown.Mapping;
 
-namespace Robust.Shared.Serialization.Manager.DataDefinition
+namespace Robust.Shared.Serialization.Manager.Definition
 {
     public partial class DataDefinition
     {

--- a/Robust.Shared/Serialization/Manager/Definition/DataDefinition.Emitters.cs
+++ b/Robust.Shared/Serialization/Manager/Definition/DataDefinition.Emitters.cs
@@ -8,7 +8,7 @@ using Robust.Shared.Serialization.Manager.Result;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Utility;
 
-namespace Robust.Shared.Serialization.Manager.DataDefinition
+namespace Robust.Shared.Serialization.Manager.Definition
 {
     public partial class DataDefinition
     {

--- a/Robust.Shared/Serialization/Manager/Definition/DataDefinition.cs
+++ b/Robust.Shared/Serialization/Manager/Definition/DataDefinition.cs
@@ -11,7 +11,7 @@ using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Utility;
 
-namespace Robust.Shared.Serialization.Manager.DataDefinition
+namespace Robust.Shared.Serialization.Manager.Definition
 {
     public partial class DataDefinition
     {

--- a/Robust.Shared/Serialization/Manager/Definition/FieldDefinition.cs
+++ b/Robust.Shared/Serialization/Manager/Definition/FieldDefinition.cs
@@ -2,7 +2,7 @@
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Utility;
 
-namespace Robust.Shared.Serialization.Manager.DataDefinition
+namespace Robust.Shared.Serialization.Manager.Definition
 {
     public class FieldDefinition
     {

--- a/Robust.Shared/Serialization/Manager/Definition/InheritanceBehavior.cs
+++ b/Robust.Shared/Serialization/Manager/Definition/InheritanceBehavior.cs
@@ -1,4 +1,4 @@
-﻿namespace Robust.Shared.Serialization.Manager.DataDefinition
+﻿namespace Robust.Shared.Serialization.Manager.Definition
 {
     public enum InheritanceBehavior : byte
     {

--- a/Robust.Shared/Serialization/Manager/Result/DeserializedFieldEntry.cs
+++ b/Robust.Shared/Serialization/Manager/Result/DeserializedFieldEntry.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Serialization.Manager.DataDefinition;
+﻿using Robust.Shared.Serialization.Manager.Definition;
 
 namespace Robust.Shared.Serialization.Manager.Result
 {

--- a/Robust.Shared/Serialization/Manager/SerializationManager.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.cs
@@ -66,7 +66,7 @@ namespace Robust.Shared.Serialization.Manager
                 }
             }
 
-            foreach (var meansAttr in _reflectionManager.FindTypesWithAttribute<MeansDataDefinition>())
+            foreach (var meansAttr in _reflectionManager.FindTypesWithAttribute<MeansDataDefinitionAttribute>())
             {
                 foreach (var type in _reflectionManager.FindTypesWithAttribute(meansAttr))
                 {

--- a/Robust.Shared/Serialization/Manager/SerializationManager.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.cs
@@ -10,6 +10,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Reflection;
 using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Serialization.Manager.Definition;
 using Robust.Shared.Serialization.Manager.Result;
 using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Mapping;
@@ -30,7 +31,7 @@ namespace Robust.Shared.Serialization.Manager
         private bool _initializing;
         private bool _initialized;
 
-        private readonly Dictionary<Type, DataDefinition.DataDefinition> _dataDefinitions = new();
+        private readonly Dictionary<Type, DataDefinition> _dataDefinitions = new();
         private readonly HashSet<Type> _copyByRefRegistrations = new();
 
         public IDependencyCollection DependencyCollection { get; private set; } = default!;
@@ -89,7 +90,7 @@ namespace Robust.Shared.Serialization.Manager
                     continue;
                 }
 
-                _dataDefinitions.Add(type, new DataDefinition.DataDefinition(type));
+                _dataDefinitions.Add(type, new DataDefinition(type));
             }
 
             var error = new StringBuilder();
@@ -273,14 +274,14 @@ namespace Robust.Shared.Serialization.Manager
             return res;
         }
 
-        internal DataDefinition.DataDefinition? GetDataDefinition(Type type)
+        internal DataDefinition? GetDataDefinition(Type type)
         {
             if (_dataDefinitions.TryGetValue(type, out var dataDefinition)) return dataDefinition;
 
             return null;
         }
 
-        internal bool TryGetDataDefinition(Type type, [NotNullWhen(true)] out DataDefinition.DataDefinition? dataDefinition)
+        internal bool TryGetDataDefinition(Type type, [NotNullWhen(true)] out DataDefinition? dataDefinition)
         {
             dataDefinition = GetDataDefinition(type);
             return dataDefinition != null;

--- a/Robust.UnitTesting/Server/RobustServerSimulation.cs
+++ b/Robust.UnitTesting/Server/RobustServerSimulation.cs
@@ -1,6 +1,5 @@
 using JetBrains.Annotations;
 using Moq;
-using Robust.Server.GameObjects;
 using Robust.Shared.Asynchronous;
 using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
@@ -10,7 +9,6 @@ using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
-using Robust.Shared.Network;
 using Robust.Shared.Physics;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Reflection;
@@ -150,14 +148,14 @@ namespace Robust.UnitTesting.Server
 
             var reflectionManager = new Mock<IReflectionManager>();
             reflectionManager
-                .Setup(x => x.FindTypesWithAttribute<MeansDataDefinition>())
+                .Setup(x => x.FindTypesWithAttribute<MeansDataDefinitionAttribute>())
                 .Returns(() => new[]
                 {
-                    typeof(DataDefinition)
+                    typeof(DataDefinitionAttribute)
                 });
 
             reflectionManager
-                .Setup(x => x.FindTypesWithAttribute(typeof(DataDefinition)))
+                .Setup(x => x.FindTypesWithAttribute(typeof(DataDefinitionAttribute)))
                 .Returns(() => new[]
                 {
                     typeof(EntityPrototype),

--- a/Robust.UnitTesting/Shared/Serialization/InheritanceSerializationTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/InheritanceSerializationTest.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Attributes;
-using DataDefinition = Robust.Shared.Serialization.Manager.DataDefinition.DataDefinition;
+using Robust.Shared.Serialization.Manager.Definition;
 
 namespace Robust.UnitTesting.Shared.Serialization
 {
@@ -54,7 +54,7 @@ namespace Robust.UnitTesting.Shared.Serialization
 
             var serializationManager = IoCManager.Resolve<ISerializationManager>();
             serializationManager.Initialize();
-            
+
             var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
 
             prototypeManager.LoadString(Prototypes);

--- a/Robust.UnitTesting/Shared/Serialization/PropertyAndFieldDefinitionTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/PropertyAndFieldDefinitionTest.cs
@@ -2,7 +2,7 @@
 using NUnit.Framework;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.Serialization.Manager.DataDefinition;
+using Robust.Shared.Serialization.Manager.Definition;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Utility;


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/identifier-names

Also fixes the namespace and type name for DataDefinition being the same.