### PR TITLE
Improves the Filter API.

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/AudioSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/AudioSystem.cs
@@ -80,13 +80,9 @@ namespace Robust.Server.GameObjects
                 Identifier = id
             };
 
-            var players = (playerFilter as IFilter).Recipients;
-            foreach (var player in players)
-            {
-                RaiseNetworkEvent(msg, player.ConnectedClient);
-            }
+            RaiseNetworkEvent(msg, playerFilter);
 
-            return new AudioSourceServer(this, id, players);
+            return new AudioSourceServer(this, id, playerFilter.Recipients.ToArray());
         }
 
         /// <inheritdoc />
@@ -105,21 +101,17 @@ namespace Robust.Server.GameObjects
                 AudioParams = audioParams ?? AudioParams.Default,
                 Identifier = id,
             };
-            
-            IList<ICommonSession> players;
-            var recipients = (playerFilter as IFilter).Recipients;
 
+            // We clone the filter here as to not modify the original instance.
             if (range > 0.0f)
-                players = PasInRange(recipients, entity.Transform.MapPosition, range);
-            else
-                players = recipients;
+                playerFilter = playerFilter.Clone().AddInRange(entity.Transform.MapPosition, range);
 
-            foreach (var player in players)
+            foreach (var player in playerFilter.Recipients)
             {
                 RaiseNetworkEvent(msg, player.ConnectedClient);
             }
-            
-            return new AudioSourceServer(this, id, players);
+
+            return new AudioSourceServer(this, id, playerFilter.Recipients.ToArray());
         }
 
         /// <inheritdoc />
@@ -136,29 +128,17 @@ namespace Robust.Server.GameObjects
                 AudioParams = audioParams ?? AudioParams.Default,
                 Identifier = id
             };
-            
-            IList<ICommonSession> players;
-            var recipients = (playerFilter as IFilter).Recipients;
 
+            // We clone the filter here as to not modify the original instance.
             if (range > 0.0f)
-                players = PasInRange(recipients, coordinates.ToMap(EntityManager), range);
-            else
-                players = recipients;
+                playerFilter = playerFilter.Clone().AddInRange(coordinates.ToMap(EntityManager), range);
 
-            foreach (var player in players)
+            foreach (var player in playerFilter.Recipients)
             {
                 RaiseNetworkEvent(msg, player.ConnectedClient);
             }
-            
-            return new AudioSourceServer(this, id, players);
-        }
 
-        private static List<ICommonSession> PasInRange(IEnumerable<ICommonSession> players, MapCoordinates position, float range)
-        {
-            return players.Where(x =>
-                    x.AttachedEntity != null &&
-                    position.InRange(x.AttachedEntity.Transform.MapPosition, range))
-                .ToList();
+            return new AudioSourceServer(this, id, playerFilter.Recipients.ToArray());
         }
     }
 }

--- a/Robust.Server/GameObjects/EntitySystems/AudioSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/AudioSystem.cs
@@ -106,10 +106,7 @@ namespace Robust.Server.GameObjects
             if (range > 0.0f)
                 playerFilter = playerFilter.Clone().AddInRange(entity.Transform.MapPosition, range);
 
-            foreach (var player in playerFilter.Recipients)
-            {
-                RaiseNetworkEvent(msg, player.ConnectedClient);
-            }
+            RaiseNetworkEvent(msg, playerFilter);
 
             return new AudioSourceServer(this, id, playerFilter.Recipients.ToArray());
         }
@@ -133,10 +130,7 @@ namespace Robust.Server.GameObjects
             if (range > 0.0f)
                 playerFilter = playerFilter.Clone().AddInRange(coordinates.ToMap(EntityManager), range);
 
-            foreach (var player in playerFilter.Recipients)
-            {
-                RaiseNetworkEvent(msg, player.ConnectedClient);
-            }
+            RaiseNetworkEvent(msg, playerFilter);
 
             return new AudioSourceServer(this, id, playerFilter.Recipients.ToArray());
         }

--- a/Robust.Shared/GameObjects/EntitySystem.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Robust.Shared.IoC;
 using Robust.Shared.Network;
+using Robust.Shared.Player;
 using Robust.Shared.Reflection;
 
 namespace Robust.Shared.GameObjects
@@ -109,6 +110,14 @@ namespace Robust.Shared.GameObjects
         protected void RaiseNetworkEvent(EntityEventArgs message, INetChannel channel)
         {
             EntityManager.EntityNetManager?.SendSystemNetworkMessage(message, channel);
+        }
+
+        protected void RaiseNetworkEvent(EntityEventArgs message, Filter filter)
+        {
+            foreach (var session in filter.Recipients)
+            {
+                EntityManager.EntityNetManager?.SendSystemNetworkMessage(message, session.ConnectedClient);
+            }
         }
 
         protected Task<T> AwaitNetworkEvent<T>(CancellationToken cancellationToken)

--- a/Robust.Shared/Player/Filter.cs
+++ b/Robust.Shared/Player/Filter.cs
@@ -159,7 +159,6 @@ namespace Robust.Shared.Player
         public Filter RemoveWhere(Predicate<ICommonSession> predicate)
         {
             _recipients.RemoveWhere(predicate);
-
             return this;
         }
 

--- a/Robust.Shared/Player/Filter.cs
+++ b/Robust.Shared/Player/Filter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
@@ -11,46 +12,23 @@ using Robust.Shared.Utility;
 namespace Robust.Shared.Player
 {
     /// <summary>
-    /// A filter for recipients of a networked method call.
-    /// </summary>
-    public interface IFilter
-    {
-        /// <summary>
-        /// Should this networked call be properly predicted?
-        /// True: Check things like IsFirstTimePredicted().
-        /// False: JUST DO IT.
-        /// </summary>
-        bool CheckPrediction { get; }
-
-        /// <summary>
-        /// Should this network call be sent as reliable?
-        /// </summary>
-        bool SendReliable { get; }
-
-        /// <summary>
-        /// Networked sessions that should receive the event.
-        /// </summary>
-        IList<ICommonSession> Recipients { get; }
-    }
-
-    /// <summary>
-    /// Contains a set of recipients for a networked method call.
+    ///     Contains a set of recipients for a networked method call.
     /// </summary>
     [PublicAPI]
-    public class Filter : IFilter
+    public class Filter
     {
-        private bool _prediction = true;
         private List<ICommonSession> _recipients = new();
-        private bool _reliable;
 
         private Filter() { }
 
-        bool IFilter.CheckPrediction => _prediction;
-        bool IFilter.SendReliable => _reliable;
-        IList<ICommonSession> IFilter.Recipients => _recipients;
+        public bool CheckPrediction { get; private set; } = true;
+
+        public bool SendReliable { get; private set; }
+
+        public IEnumerable<ICommonSession> Recipients => _recipients;
 
         /// <summary>
-        /// Adds a single player to the filter.
+        ///     Adds a single player to the filter.
         /// </summary>
         public Filter AddPlayer(ICommonSession player)
         {
@@ -59,52 +37,52 @@ namespace Robust.Shared.Player
         }
 
         /// <summary>
-        /// Adds all players inside an entity's PVS.
+        ///     Adds all players inside an entity's PVS.
+        ///     The current PVS range will be multiplied by <see cref="rangeMultiplier"/>.
         /// </summary>
-        protected Filter AddPlayersByPvs(IEntity origin)
+        public Filter AddPlayersByPvs(IEntity origin, float rangeMultiplier = 2f)
         {
-            return AddPlayersByPvs(origin.Transform.MapPosition);
+            return AddPlayersByPvs(origin.Transform.MapPosition, rangeMultiplier);
         }
 
         /// <summary>
-        /// Adds all players inside an entity's PVS.
+        ///     Adds all players inside an entity's PVS.
+        ///     The current PVS range will be multiplied by <see cref="rangeMultiplier"/>.
         /// </summary>
-        protected Filter AddPlayersByPvs(ITransformComponent origin)
+        public Filter AddPlayersByPvs(ITransformComponent origin, float rangeMultiplier = 2f)
         {
-            return AddPlayersByPvs(origin.MapPosition);
+            return AddPlayersByPvs(origin.MapPosition, rangeMultiplier);
         }
 
         /// <summary>
-        /// Adds all players inside an entity's PVS.
+        ///     Adds all players inside an entity's PVS.
+        ///     The current PVS range will be multiplied by <see cref="rangeMultiplier"/>.
         /// </summary>
-        protected Filter AddPlayersByPvs(EntityCoordinates origin)
+        public Filter AddPlayersByPvs(EntityCoordinates origin, float rangeMultiplier = 2f)
         {
             var entityMan = IoCManager.Resolve<IEntityManager>();
-            return AddPlayersByPvs(origin.ToMap(entityMan));
+            return AddPlayersByPvs(origin.ToMap(entityMan), rangeMultiplier);
         }
 
         /// <summary>
-        /// Adds all players inside an entity's PVS.
+        ///     Adds all players inside an entity's PVS.
+        ///     The current PVS range will be multiplied by <see cref="rangeMultiplier"/>.
         /// </summary>
-        protected Filter AddPlayersByPvs(MapCoordinates origin)
+        public Filter AddPlayersByPvs(MapCoordinates origin, float rangeMultiplier = 2f)
         {
-            //TODO: Calculate this from the PVS system that does not exist.
-            var playerMan = IoCManager.Resolve<ISharedPlayerManager>();
+            var cfgMan = IoCManager.Resolve<IConfigurationManager>();
 
-            const int range = 25;
-            var players = playerMan.NetworkedSessions.Where(x =>
-                x.AttachedEntity != null && origin.InRange(x.AttachedEntity.Transform.MapPosition, range));
+            // If PVS is disabled, we simply return all players.
+            if (!cfgMan.GetCVar(CVars.NetPVS))
+                return AddAllPlayers();
 
-            foreach (var session in players)
-            {
-                AddPlayer(session);
-            }
+            var pvsRange = cfgMan.GetCVar(CVars.NetMaxUpdateRange) * rangeMultiplier;
 
-            return this;
+            return AddInRange(origin, pvsRange);
         }
 
         /// <summary>
-        /// Adds a set of players to the filter.
+        ///     Adds a set of players to the filter.
         /// </summary>
         public Filter AddPlayers(IEnumerable<ICommonSession> players)
         {
@@ -117,7 +95,7 @@ namespace Robust.Shared.Player
         }
 
         /// <summary>
-        /// Adds all players to the filter.
+        ///     Adds all players to the filter.
         /// </summary>
         public Filter AddAllPlayers()
         {
@@ -129,35 +107,7 @@ namespace Robust.Shared.Player
         }
 
         /// <summary>
-        /// Removes a single player from the filter.
-        /// </summary>
-        public Filter RemovePlayer(ICommonSession player)
-        {
-            _recipients.Remove(player);
-            return this;
-        }
-
-        /// <summary>
-        /// Removes all players from the filter that match a predicate.
-        /// </summary>
-        public Filter RemoveWhere(Predicate<ICommonSession> predicate)
-        {
-            for (int i = 0; i < _recipients.Count; i++)
-            {
-                var player = _recipients[i];
-
-                if (predicate(player))
-                {
-                    _recipients.RemoveSwap(i);
-                    i--;
-                }
-            }
-
-            return this;
-        }
-
-        /// <summary>
-        /// Adds all players that match a predicate.
+        ///     Adds all players that match a predicate.
         /// </summary>
         public Filter AddWhere(Predicate<ICommonSession> predicate)
         {
@@ -174,36 +124,107 @@ namespace Robust.Shared.Player
         }
 
         /// <summary>
-        /// Normally a filter will properly handle client side prediction. Calling this
-        /// function disables that, and the event will be spammed during every prediction
-        /// tick.
+        ///     Adds all players in range of a position.
+        /// </summary>
+        public Filter AddInRange(MapCoordinates position, float range)
+        {
+            return AddWhere(session =>
+                session.AttachedEntity != null &&
+                position.InRange(session.AttachedEntity.Transform.MapPosition, range));
+        }
+
+        /// <summary>
+        ///     Removes all players without the specified visibility flag.
+        /// </summary>
+        public Filter RemoveByVisibility(uint flag)
+        {
+            return RemoveWhere(session =>
+                session.AttachedEntity == null
+                || !session.AttachedEntity.TryGetComponent(out SharedEyeComponent? eye)
+                || (eye.VisibilityMask & flag) == 0);
+        }
+
+        /// <summary>
+        ///     Removes a single player from the filter.
+        /// </summary>
+        public Filter RemovePlayer(ICommonSession player)
+        {
+            _recipients.Remove(player);
+            return this;
+        }
+
+        /// <summary>
+        ///     Removes all players from the filter that match a predicate.
+        /// </summary>
+        public Filter RemoveWhere(Predicate<ICommonSession> predicate)
+        {
+            for (var i = 0; i < _recipients.Count; i++)
+            {
+                var player = _recipients[i];
+
+                if (!predicate(player))
+                    continue;
+
+                _recipients.RemoveSwap(i);
+                i--;
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        ///     Removes all players in range of a position.
+        /// </summary>
+        public Filter RemoveInRange(MapCoordinates position, float range)
+        {
+            return RemoveWhere(session =>
+                session.AttachedEntity != null &&
+                position.InRange(session.AttachedEntity.Transform.MapPosition, range));
+        }
+
+        /// <summary>
+        ///     Returns a new filter with the same parameters as this one.
+        /// </summary>
+        public Filter Clone()
+        {
+            return new()
+            {
+                _recipients = new List<ICommonSession>(_recipients),
+                SendReliable = SendReliable,
+                CheckPrediction = CheckPrediction,
+            };
+        }
+
+        /// <summary>
+        ///     Normally a filter will properly handle client side prediction. Calling this
+        ///     function disables that, and the event will be spammed during every prediction
+        ///     tick.
         /// </summary>
         public Filter Unpredicted()
         {
-            _prediction = false;
+            CheckPrediction = false;
             return this;
         }
 
         /// <summary>
-        /// Should it be guaranteed that recipients receive the message?
+        ///     Should it be guaranteed that recipients receive the message?
         /// </summary>
         public Filter SendReliably()
         {
-            _reliable = true;
+            SendReliable = true;
             return this;
         }
 
         /// <summary>
-        /// A new filter that is empty.
+        ///     A new filter that is empty.
         /// </summary>
-        /// <returns></returns>
         public static Filter Empty()
         {
             return new();
         }
 
         /// <summary>
-        /// A new filter with a single player in it.
+        ///     A new filter with a single player in it.
         /// </summary>
         public static Filter SinglePlayer(ICommonSession player)
         {
@@ -211,48 +232,47 @@ namespace Robust.Shared.Player
         }
 
         /// <summary>
-        /// A new filter with all players in it.
+        ///     A new filter with all players in it.
         /// </summary>
         public static Filter Broadcast()
         {
             return Empty().AddAllPlayers();
         }
 
-
         /// <summary>
-        /// A filter with every player who's PVS overlaps this entity.
+        ///     A filter with every player who's PVS overlaps this entity.
         /// </summary>
-        public static Filter Pvs(IEntity origin)
+        public static Filter Pvs(IEntity origin, float rangeMultiplier = 2f)
         {
-            return Empty().AddPlayersByPvs(origin);
+            return Empty().AddPlayersByPvs(origin, rangeMultiplier);
         }
 
         /// <summary>
-        /// A filter with every player who's PVS overlaps this point.
+        ///     A filter with every player who's PVS overlaps this point.
         /// </summary>
-        public static Filter Pvs(ITransformComponent origin)
+        public static Filter Pvs(ITransformComponent origin, float rangeMultiplier = 2f)
         {
-            return Empty().AddPlayersByPvs(origin);
+            return Empty().AddPlayersByPvs(origin, rangeMultiplier);
         }
 
         /// <summary>
-        /// A filter with every player who's PVS overlaps this point.
+        ///     A filter with every player who's PVS overlaps this point.
         /// </summary>
-        public static Filter Pvs(EntityCoordinates origin)
+        public static Filter Pvs(EntityCoordinates origin, float rangeMultiplier = 2f)
         {
-            return Empty().AddPlayersByPvs(origin);
+            return Empty().AddPlayersByPvs(origin, rangeMultiplier);
         }
 
         /// <summary>
-        /// A filter with every player who's PVS overlaps this point.
+        ///     A filter with every player who's PVS overlaps this point.
         /// </summary>
-        public static Filter Pvs(MapCoordinates origin)
+        public static Filter Pvs(MapCoordinates origin, float rangeMultiplier = 2f)
         {
-            return Empty().AddPlayersByPvs(origin);
+            return Empty().AddPlayersByPvs(origin, rangeMultiplier);
         }
 
         /// <summary>
-        /// A filter with only the local player.
+        ///     A filter with only the local player.
         /// </summary>
         public static Filter Local()
         {

--- a/Robust.Shared/Player/Filter.cs
+++ b/Robust.Shared/Player/Filter.cs
@@ -17,7 +17,7 @@ namespace Robust.Shared.Player
     [PublicAPI]
     public class Filter
     {
-        private List<ICommonSession> _recipients = new();
+        private HashSet<ICommonSession> _recipients = new();
 
         private Filter() { }
 
@@ -99,10 +99,10 @@ namespace Robust.Shared.Player
         /// </summary>
         public Filter AddAllPlayers()
         {
-            _recipients.Clear();
-
             var playerMan = IoCManager.Resolve<ISharedPlayerManager>();
-            _recipients.AddRange(playerMan.NetworkedSessions);
+
+            _recipients = new HashSet<ICommonSession>(playerMan.NetworkedSessions);
+
             return this;
         }
 
@@ -158,16 +158,7 @@ namespace Robust.Shared.Player
         /// </summary>
         public Filter RemoveWhere(Predicate<ICommonSession> predicate)
         {
-            for (var i = 0; i < _recipients.Count; i++)
-            {
-                var player = _recipients[i];
-
-                if (!predicate(player))
-                    continue;
-
-                _recipients.RemoveSwap(i);
-                i--;
-            }
+            _recipients.RemoveWhere(predicate);
 
             return this;
         }
@@ -189,7 +180,7 @@ namespace Robust.Shared.Player
         {
             return new()
             {
-                _recipients = new List<ICommonSession>(_recipients),
+                _recipients = new HashSet<ICommonSession>(_recipients),
                 SendReliable = SendReliable,
                 CheckPrediction = CheckPrediction,
             };


### PR DESCRIPTION
- Recipients is now of type `IEnumerable<ICommonSession>`.
    - This way, people need to use the Filter API to modify the recipients, instead of being allowed to modify the underlying collection directly.
- Underlying collection is now a HashSet.
    - We want no duplicates at all. This will ensure that while being quite performant.
- Removes `IFilter`.
    - Let's face it, everyone is gonna end up using `Filter` instead as it has a much more convenient API, and nothing else will EVER implement `IFilter`. For this reason, I've just gone ahead and removed it. Every method used `Filter` already, anyway.
- Adds EntitySystem `RaiseNetworkEvent` overload that takes in a `Filter`.
    - This deduplicates a lot of code that enumerated the recipients and raised a network event per each one.
- Made AddPlayersByPvs aware of `net.pvs` and `net.maxupdaterange`, has a range multiplier parameter.
    - Now it will simply add all players to the filter if PVS is disabled, and add all players in range if it's enabled.
    - The range multiplier parameter allows us to make the PVS filter a bit more permissive, and generally better. The range is doubled by default, as it was already before.
- Adds `AddInRange` method to filters.
    - This is useful for the AudioSystem, and the PVS methods use it, too!
- Adds `RemoveByVisibility` method to filters.
    - This will remove all recipients that don't have a visibility flag in their entity's EyeComponent from the filter.
    - (This will be VERY useful for Ghost Pointing, for example)
- Adds `Clone` method to filters.
    - This is useful in cases where methods take in a filter and want to modify it without modifying the original instance. (See AudioSystem)