### PR TITLE
Entity localization refactoring

### DIFF
--- a/Robust.Shared/Enums/Gender.cs
+++ b/Robust.Shared/Enums/Gender.cs
@@ -1,11 +1,30 @@
 
 namespace Robust.Shared.Enums
 {
+    /// <summary>
+    ///     Represents a grammatical gender of an object.
+    /// </summary>
     public enum Gender : byte
     {
+        /// <summary>
+        ///     Object has no gender and a gender probably makes no sense. Think inanimate objects. It/it.
+        /// </summary>
+        Neuter = 0,
+
+        /// <summary>
+        ///     Object is something you would consider as *capable of having a gender*, but *doesn't*.
+        ///     Think people without (visible/unambiguous) gender. They/them.
+        /// </summary>
         Epicene,
+
+        /// <summary>
+        ///     Female gender. She/her
+        /// </summary>
         Female,
+
+        /// <summary>
+        ///     Male gender. He/his
+        /// </summary>
         Male,
-        Neuter,
     }
 }

--- a/Robust.Shared/GameObjects/Components/Localization/GrammarComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Localization/GrammarComponent.cs
@@ -1,9 +1,14 @@
+using System;
+using System.Collections.Generic;
 using Robust.Shared.Enums;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.ViewVariables;
 
 namespace Robust.Shared.GameObjects.Components.Localization
 {
+    /// <summary>
+    ///     Overrides grammar attributes specified in prototypes or localization files.
+    /// </summary>
     [RegisterComponent]
     public class GrammarComponent : Component
     {
@@ -11,15 +16,33 @@ namespace Robust.Shared.GameObjects.Components.Localization
         public override uint? NetID => NetIDs.GRAMMAR;
 
         [ViewVariables]
-        [DataField("localizationId")]
-        public string LocalizationId = "";
+        [DataField("attributes")]
+        public Dictionary<string, string> Attributes { get; } = new();
 
         [ViewVariables]
-        [DataField("gender")]
-        public Gender? Gender = null;
+        public Gender? Gender
+        {
+            get => Attributes.TryGetValue("gender", out var g) ? Enum.Parse<Gender>(g, true) : null;
+            set
+            {
+                if (value.HasValue)
+                    Attributes["gender"] = value.Value.ToString();
+                else
+                    Attributes.Remove("gender");
+            }
+        }
 
         [ViewVariables]
-        [DataField("proper")]
-        public bool? ProperNoun = null;
+        public bool? ProperNoun
+        {
+            get => Attributes.TryGetValue("proper", out var g) ? bool.Parse(g) : null;
+            set
+            {
+                if (value.HasValue)
+                    Attributes["proper"] = value.Value.ToString();
+                else
+                    Attributes.Remove("proper");
+            }
+        }
     }
 }

--- a/Robust.Shared/Localization/EntityLocData.cs
+++ b/Robust.Shared/Localization/EntityLocData.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Immutable;
+
+namespace Robust.Shared.Localization
+{
+    /// <summary>
+    ///     Contains based localized entity prototype data.
+    /// </summary>
+    /// <param name="Name">The localized name of the entity prototype.</param>
+    /// <param name="Desc">The localized description of the entity prototype.</param>
+    /// <param name="Suffix">Editor-visible suffix of this entity prototype.</param>
+    /// <param name="Attributes">Any extra attributes that can be used for localization, such as gender, proper, ...</param>
+    public record EntityLocData(
+        string Name,
+        string Desc,
+        string? Suffix,
+        ImmutableDictionary<string, string> Attributes);
+}

--- a/Robust.Shared/Localization/ILocalizationManager.cs
+++ b/Robust.Shared/Localization/ILocalizationManager.cs
@@ -94,6 +94,11 @@ namespace Robust.Shared.Localization
         [Obsolete]
         [StringFormatMethod("text")]
         string GetString(string text, params object[] args);
+
+        /// <summary>
+        ///     Gets localization data for an entity prototype.
+        /// </summary>
+        EntityLocData GetEntityData(string prototypeId);
     }
 
     internal interface ILocalizationManagerInternal : ILocalizationManager

--- a/Robust.Shared/Localization/LocalizationManager.Entity.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Entity.cs
@@ -1,0 +1,137 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects.Components.Localization;
+using Robust.Shared.Prototypes;
+
+namespace Robust.Shared.Localization
+{
+    internal sealed partial class LocalizationManager
+    {
+        private readonly Dictionary<string, EntityLocData> _entityCache = new();
+
+        private void FlushEntityCache()
+        {
+            _logSawmill.Debug("Flushing entity localization cache.");
+            _entityCache.Clear();
+        }
+
+        private bool TryGetEntityLocAttrib(IEntity entity, string attribute, [NotNullWhen(true)] out string? value)
+        {
+            if (entity.TryGetComponent<GrammarComponent>(out var grammar) &&
+                grammar.Attributes.TryGetValue(attribute, out value))
+            {
+                return true;
+            }
+
+            if (entity.Prototype == null)
+            {
+                value = null;
+                return false;
+            }
+
+            var data = GetEntityData(entity.Prototype.ID);
+            return data.Attributes.TryGetValue(attribute, out value);
+        }
+
+        // Flush caches conservatively on prototype/localization changes.
+        private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)
+        {
+            if (!args.ByType.TryGetValue(typeof(EntityPrototype), out var changeSet))
+                return;
+
+            FlushEntityCache();
+        }
+
+        private EntityLocData CalcEntityLoc(string prototypeId)
+        {
+            string? name = null;
+            string? desc = null;
+            string? suffix = null;
+            Dictionary<string, string>? attribs = null;
+
+            while (true)
+            {
+                var prototype = _prototype.Index<EntityPrototype>(prototypeId);
+                var locId = prototype.CustomLocalizationID ?? $"ent-{prototypeId}";
+
+                if (TryGetMessage(locId, out var ctx, out var msg))
+                {
+                    // Localization override exists.
+                    var mAttribs = msg.Attributes;
+
+                    if (name == null && msg.Value != null)
+                    {
+                        // Only set name if the value isn't empty.
+                        // So that you can override *only* a desc/suffix.
+                        name = ctx.Format(msg.Value);
+                    }
+
+                    if (mAttribs != null && mAttribs.Count != 0)
+                    {
+                        if (desc == null && mAttribs.TryGetValue("desc", out var mDesc))
+                        {
+                            desc = ctx.Format(mDesc);
+                        }
+
+                        if (suffix == null && mAttribs.TryGetValue("suffix", out var mSuffix))
+                        {
+                            suffix = ctx.Format(mSuffix);
+                        }
+
+                        foreach (var (attrib, value) in msg.Attributes)
+                        {
+                            if (attrib is "desc" or "suffix")
+                                continue;
+
+                            attribs ??= new Dictionary<string, string>();
+                            if (!attribs.ContainsKey(attrib))
+                            {
+                                attribs[attrib] = ctx.Format(value);
+                            }
+                        }
+                    }
+                }
+
+                name ??= prototype.SetName;
+                desc ??= prototype.SetDesc;
+                suffix ??= prototype.SetSuffix;
+
+                if (prototype.LocProperties.Count != 0)
+                {
+                    foreach (var (attrib, value) in prototype.LocProperties)
+                    {
+                        attribs ??= new Dictionary<string, string>();
+                        if (!attribs.ContainsKey(attrib))
+                        {
+                            attribs[attrib] = value;
+                        }
+                    }
+                }
+
+                if (prototype.Parent == null)
+                    break;
+
+                prototypeId = prototype.Parent;
+            }
+
+            return new EntityLocData(
+                name ?? "",
+                desc ?? "",
+                suffix,
+                attribs?.ToImmutableDictionary() ?? ImmutableDictionary<string, string>.Empty);
+        }
+
+        public EntityLocData GetEntityData(string prototypeId)
+        {
+            if (!_entityCache.TryGetValue(prototypeId, out var data))
+            {
+                data = CalcEntityLoc(prototypeId);
+                _entityCache.Add(prototypeId, data);
+            }
+
+            return data;
+        }
+    }
+}

--- a/Robust.Shared/Localization/LocalizationManager.Functions.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Functions.cs
@@ -1,0 +1,130 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using Fluent.Net;
+using Robust.Shared.Enums;
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects.Components.Localization;
+
+namespace Robust.Shared.Localization
+{
+    internal sealed partial class LocalizationManager
+    {
+        private void AddBuiltinFunctions(MessageContext context)
+        {
+            // Grammatical gender
+            AddCtxFunction(context, "GENDER", FuncGender);
+
+            // Proper nouns
+            AddCtxFunction(context, "PROPER", FuncProper);
+
+            // Misc Attribs
+            AddCtxFunction(context, "ATTRIB", args => FuncAttrib(context, args));
+
+            AddCtxFunction(context, "THE", FuncThe);
+        }
+
+        private ILocValue FuncThe(LocArgs args)
+        {
+            return new LocValueString(GetString("zzzz-the", ("ent", args.Args[0])));
+        }
+
+        private ILocValue FuncGender(LocArgs args)
+        {
+            if (args.Args.Count < 1) return new LocValueString(nameof(Gender.Neuter));
+
+            ILocValue entity0 = args.Args[0];
+            if (entity0.Value != null)
+            {
+                IEntity entity = (IEntity) entity0.Value;
+
+                if (entity.TryGetComponent<GrammarComponent>(out var grammar) && grammar.Gender.HasValue)
+                {
+                    return new LocValueString(grammar.Gender.Value.ToString().ToLowerInvariant());
+                }
+
+                if (TryGetEntityLocAttrib(entity, "gender", out var gender))
+                {
+                    return new LocValueString(gender);
+                }
+            }
+
+            return new LocValueString(nameof(Gender.Neuter));
+        }
+
+        private ILocValue FuncAttrib(MessageContext context, LocArgs args)
+        {
+            if (args.Args.Count < 2) return new LocValueString("other");
+
+            ILocValue entity0 = args.Args[0];
+            if (entity0.Value != null)
+            {
+                IEntity entity = (IEntity) entity0.Value;
+                ILocValue attrib0 = args.Args[1];
+                if (TryGetEntityLocAttrib(entity, attrib0.Format(new LocContext(context)), out var attrib))
+                {
+                    return new LocValueString(attrib);
+                }
+            }
+
+            return new LocValueString("other");
+        }
+
+        private ILocValue FuncProper(LocArgs args)
+        {
+            if (args.Args.Count < 1) return new LocValueString("false");
+
+            ILocValue entity0 = args.Args[0];
+            if (entity0.Value != null)
+            {
+                IEntity entity = (IEntity) entity0.Value;
+
+                if (entity.TryGetComponent<GrammarComponent>(out var grammar) && grammar.ProperNoun.HasValue)
+                {
+                    return new LocValueString(grammar.ProperNoun.Value.ToString().ToLowerInvariant());
+                }
+
+                if (TryGetEntityLocAttrib(entity, "proper", out var proper))
+                {
+                    return new LocValueString(proper);
+                }
+            }
+
+            return new LocValueString("false");
+        }
+
+        private void AddCtxFunction(MessageContext ctx, string name, LocFunction function)
+        {
+            ctx.Functions.Add(name, (args, options) => CallFunction(function, args, options));
+        }
+
+        public void AddFunction(CultureInfo culture, string name, LocFunction function)
+        {
+            var context = _contexts[culture];
+
+            context.Functions.Add(name, (args, options) => CallFunction(function, args, options));
+        }
+
+        private FluentType CallFunction(
+            LocFunction function,
+            IList<object> fluentArgs, IDictionary<string, object> fluentOptions)
+        {
+            var args = new ILocValue[fluentArgs.Count];
+            for (var i = 0; i < args.Length; i++)
+            {
+                args[i] = ValFromFluent(fluentArgs[i]);
+            }
+
+            var options = new Dictionary<string, ILocValue>(fluentOptions.Count);
+            foreach (var (k, v) in fluentOptions)
+            {
+                options.Add(k, ValFromFluent(v));
+            }
+
+            var argStruct = new LocArgs(args, options);
+
+            var ret = function(argStruct);
+
+            return ValToFluent(ret);
+        }
+    }
+}

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -18,8 +18,9 @@ namespace Robust.Shared.Prototypes
     [Prototype("entity", -1)]
     public class EntityPrototype : IPrototype, IInheritingPrototype
     {
+        private readonly ILocalizationManager _loc = IoCManager.Resolve<ILocalizationManager>();
+
         private static readonly Dictionary<string, string> LocPropertiesDefault = new();
-        private static ILocalizationManager Loc => IoCManager.Resolve<ILocalizationManager>();
 
         // LOCALIZATION NOTE:
         // Localization-related properties in here are manually localized in LocalizationManager.
@@ -65,20 +66,20 @@ namespace Robust.Shared.Prototypes
         /// The "in game name" of the object. What is displayed to most players.
         /// </summary>
         [ViewVariables]
-        public string Name => Loc.GetEntityData(ID).Name;
+        public string Name => _loc.GetEntityData(ID).Name;
 
         /// <summary>
         /// The description of the object that shows upon using examine
         /// </summary>
         [ViewVariables]
-        public string Description => Loc.GetEntityData(ID).Desc;
+        public string Description => _loc.GetEntityData(ID).Desc;
 
         /// <summary>
         ///     Optional suffix to display in development menus like the entity spawn panel,
         ///     to provide additional info without ruining the Name property itself.
         /// </summary>
         [ViewVariables]
-        public string? EditorSuffix => Loc.GetEntityData(ID).Suffix;
+        public string? EditorSuffix => _loc.GetEntityData(ID).Suffix;
 
         /// <summary>
         /// Fluent messageId used to lookup the entity's name and localization attributes.

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
@@ -10,7 +8,6 @@ using Robust.Shared.Log;
 using Robust.Shared.Maths;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 
 namespace Robust.Shared.Prototypes
@@ -21,6 +18,19 @@ namespace Robust.Shared.Prototypes
     [Prototype("entity", -1)]
     public class EntityPrototype : IPrototype, IInheritingPrototype
     {
+        private static readonly Dictionary<string, string> LocPropertiesDefault = new();
+        private static ILocalizationManager Loc => IoCManager.Resolve<ILocalizationManager>();
+
+        // LOCALIZATION NOTE:
+        // Localization-related properties in here are manually localized in LocalizationManager.
+        // As such, they should NOT be inherited to avoid confusing the system.
+
+        private const int DEFAULT_RANGE = 200;
+
+        [NeverPushInheritance]
+        [DataField("loc")]
+        private Dictionary<string, string>? _locPropertiesSet;
+
         /// <summary>
         /// The "in code name" of the object. Must be unique.
         /// </summary>
@@ -29,68 +39,55 @@ namespace Robust.Shared.Prototypes
         public string ID { get; private set; } = default!;
 
         /// <summary>
-        /// The "in game name" of the object. What is displayed to most players.
+        ///     The name set on this level of the prototype. This does NOT handle localization or inheritance.
+        ///     You probably want <see cref="Name"/> instead.
         /// </summary>
-        [ViewVariables, CanBeNull]
+        /// <seealso cref="Name"/>
+        [ViewVariables]
+        [NeverPushInheritance]
         [DataField("name")]
-        public string Name {
-            get => _name;
-            private set
-            {
-                _nameModified = true;
-                _name = Loc.GetString(value);
-            }
-        }
+        public string? SetName { get; private set; }
 
-        private string _name = "";
+        [ViewVariables]
+        [NeverPushInheritance]
+        [DataField("description")]
+        public string? SetDesc { get; private set; }
 
-        private bool _nameModified;
+        [ViewVariables]
+        [NeverPushInheritance]
+        [DataField("suffix")]
+        public string? SetSuffix { get; private set; }
 
-        [DataField("localizationId")]
-        string? _localizationId;
+        [ViewVariables]
+        public IReadOnlyDictionary<string, string> LocProperties => _locPropertiesSet ?? LocPropertiesDefault;
 
         /// <summary>
-        /// Fluent messageId used to lookup the entity's name and localization attributes.
+        /// The "in game name" of the object. What is displayed to most players.
         /// </summary>
-        [ViewVariables, CanBeNull]
-        public string? LocalizationID
-        {
-            get => _localizationId ??= $"ent-{CaseConversion.PascalToKebab(ID)}";
-            private set => _localizationId = value;
-        }
+        [ViewVariables]
+        public string Name => Loc.GetEntityData(ID).Name;
+
+        /// <summary>
+        /// The description of the object that shows upon using examine
+        /// </summary>
+        [ViewVariables]
+        public string Description => Loc.GetEntityData(ID).Desc;
 
         /// <summary>
         ///     Optional suffix to display in development menus like the entity spawn panel,
         ///     to provide additional info without ruining the Name property itself.
         /// </summary>
         [ViewVariables]
-        [DataField("suffix")]
-        public string? EditorSuffix
-        {
-            get => _editorSuffix;
-            private set => _editorSuffix = value != null ? Loc.GetString(value) : null;
-        }
-
-        private string? _editorSuffix;
+        public string? EditorSuffix => Loc.GetEntityData(ID).Suffix;
 
         /// <summary>
-        /// The description of the object that shows upon using examine
+        /// Fluent messageId used to lookup the entity's name and localization attributes.
         /// </summary>
         [ViewVariables]
-        [DataField("description")]
-        public string Description
-        {
-            get => _description;
-            private set
-            {
-                _descriptionModified = true;
-                _description = Loc.GetString(value);
-            }
+        [DataField("localizationId")]
+        [NeverPushInheritance]
+        public string? CustomLocalizationID { get; private set; }
 
-        }
-        private string _description = "";
-
-        private bool _descriptionModified;
 
         /// <summary>
         ///     If true, this object should not show up in the entity spawn panel.
@@ -100,8 +97,7 @@ namespace Robust.Shared.Prototypes
         [DataField("abstract")]
         public bool Abstract { get; private set; }
 
-        [DataField("placement")]
-        private EntityPlacementProperties PlacementProperties = new();
+        [DataField("placement")] private EntityPlacementProperties PlacementProperties = new();
 
         /// <summary>
         /// The different mounting points on walls. (If any).
@@ -121,22 +117,11 @@ namespace Robust.Shared.Prototypes
         [ViewVariables]
         public int PlacementRange => PlacementProperties.PlacementRange;
 
-        private const int DEFAULT_RANGE = 200;
-
-        /// <summary>
-        /// Set to hold snapping categories that this object has applied to it such as pipe/wire/wallmount
-        /// </summary>
-        private HashSet<string> _snapFlags => PlacementProperties.SnapFlags;
-
-        private bool _snapOverriden => PlacementProperties.SnapOverriden;
-
         /// <summary>
         /// Offset that is added to the position when placing. (if any). Client only.
         /// </summary>
         [ViewVariables]
         public Vector2i PlacementOffset => PlacementProperties.PlacementOffset;
-
-        private bool _placementOverriden => PlacementProperties.PlacementOverriden;
 
         /// <summary>
         /// True if this entity will be saved by the map loader.
@@ -153,28 +138,11 @@ namespace Robust.Shared.Prototypes
         public string? Parent { get; private set; }
 
         /// <summary>
-        /// A list of children inheriting from this prototype.
-        /// </summary>
-        [ViewVariables]
-        public List<EntityPrototype> Children { get; private set; } = new();
-
-        public bool IsRoot => Parent == null;
-
-        /// <summary>
         /// A dictionary mapping the component type list to the YAML mapping containing their settings.
         /// </summary>
         [DataField("components")]
         [AlwaysPushInheritance]
         public ComponentRegistry Components { get; } = new();
-
-        private readonly HashSet<Type> ReferenceTypes = new();
-
-        string? CurrentDeserializingComponent;
-
-        readonly Dictionary<string, Dictionary<(string, Type), object?>> FieldCache =
-            new();
-
-        readonly Dictionary<string, object?> DataCache = new();
 
         public EntityPrototype()
         {
@@ -202,7 +170,8 @@ namespace Robust.Shared.Prototypes
         {
             if (ID != entity.Prototype?.ID)
             {
-                Logger.Error($"Reloaded prototype used to update entity did not match entity's existing prototype: Expected '{ID}', got '{entity.Prototype?.ID}'");
+                Logger.Error(
+                    $"Reloaded prototype used to update entity did not match entity's existing prototype: Expected '{ID}', got '{entity.Prototype?.ID}'");
                 return;
             }
 
@@ -238,11 +207,11 @@ namespace Robust.Shared.Prototypes
             var componentDependencyManager = IoCManager.Resolve<IComponentDependencyManager>();
 
             // Add new components
-            foreach (var (name, type) in newPrototypeComponents.Where(t => !ignoredComponents.Contains(t.name)).Except(oldPrototypeComponents))
+            foreach (var (name, type) in newPrototypeComponents.Where(t => !ignoredComponents.Contains(t.name))
+                .Except(oldPrototypeComponents))
             {
                 var data = Components[name];
                 var component = (Component) factory.GetComponent(name);
-                CurrentDeserializingComponent = name;
                 component.Owner = entity;
                 componentDependencyManager.OnComponentAdd(entity.Uid, component);
                 entity.AddComponent(component);
@@ -252,7 +221,8 @@ namespace Robust.Shared.Prototypes
             entity.MetaData.EntityPrototype = this;
         }
 
-        internal static void LoadEntity(EntityPrototype? prototype, Entity entity, IComponentFactory factory, IEntityLoadContext? context) //yeah officer this method right here
+        internal static void LoadEntity(EntityPrototype? prototype, Entity entity, IComponentFactory factory,
+            IEntityLoadContext? context) //yeah officer this method right here
         {
             /*YamlObjectSerializer.Context? defaultContext = null;
             if (context == null)
@@ -293,7 +263,8 @@ namespace Robust.Shared.Prototypes
             }
         }
 
-        private static void EnsureCompExistsAndDeserialize(Entity entity, IComponentFactory factory, string compName, IComponent data, ISerializationContext? context)
+        private static void EnsureCompExistsAndDeserialize(Entity entity, IComponentFactory factory, string compName,
+            IComponent data, ISerializationContext? context)
         {
             var compType = factory.GetRegistration(compName).Type;
 
@@ -358,7 +329,7 @@ namespace Robust.Shared.Prototypes
             [DataField("nodes")] public List<int>? MountingPoints;
 
             [DataField("range")] public int PlacementRange = DEFAULT_RANGE;
-            private HashSet<string> _snapFlags = new ();
+            private HashSet<string> _snapFlags = new();
 
             [DataField("snap")]
             public HashSet<string> SnapFlags

--- a/Robust.UnitTesting/Shared/Localization/LocalizationTests.cs
+++ b/Robust.UnitTesting/Shared/Localization/LocalizationTests.cs
@@ -33,19 +33,60 @@ namespace Robust.UnitTesting.Shared.Localization
         }
 
         private const string YAMLCode = @"
+# Values specified in prototype
+- type: entity
+  id: PropsInPrototype
+  name: A
+  description: B
+  suffix: C
+  loc:
+    gender: male
+    proper: true
+
+# Values specified in fluent
+- type: entity
+  id: PropsInLoc
+
+# Values specified in YAML but overriden by fluent.
+- type: entity
+  id: PropsInLocOverriding
+  name: XA
+  description: XB
+  suffix: XC
+  loc:
+    gender: female
+    proper: false
+
+# Values specified in fluent at PARENT and replaced by child YAML.
+- type: entity
+  id: TestInheritOverridingParent
 
 - type: entity
-  id: SpecifiedInProto
-  localizationId: 'not-auto-kebab'
+  id: TestInheritOverridingChild
+  parent: TestInheritOverridingParent
+  name: A
+  description: B
+  suffix: C
+  loc:
+    gender: male
+    proper: true
 
+# Attribures stored in grammar component
 - type: entity
-  id: SpecifiedInComponent
+  id: PropsInGrammar
+  name: A
+  description: B
+  suffix: C
+  loc:
+    gender: female
+    proper: false
+
   components:
-    - type: Grammar
-      localizationId: 'from-component'
+  - type: Grammar
+    attributes:
+      gender: male
+      proper: true
 
-- type: entity
-  id: SpecifiedAuto
 
 - type: entity
   id: GenderTestEntityNoComp
@@ -54,30 +95,53 @@ namespace Robust.UnitTesting.Shared.Localization
   id: GenderTestEntityWithComp
   components:
   - type: Grammar
-    gender: Female
+    attributes:
+      gender: Female
 ";
 
         private const string FluentCode = @"
-
 enum-match = { $enum ->
     [foo] A
     *[bar] B
 }
 
-ent-gender-test-entity-no-comp = Gender Test Entity
+ent-GenderTestEntityNoComp = Gender Test Entity
   .gender = male
   .otherAttrib = sausages
 
-ent-gender-test-entity-with-comp = Gender Test Entity 2
+ent-GenderTestEntityWithComp = Gender Test Entity 2
+
+ent-PropsInLoc = A
+  .desc = B
+  .suffix = C
+  .gender = male
+  .proper = true
+
+ent-PropsInLocOverriding = A
+  .desc = B
+  .suffix = C
+  .gender = male
+  .proper = true
+
+ent-TestInheritOverridingParent = XA
+  .desc = XB
+  .suffix = XC
+  .gender = female
+  .proper = false
+
 
 test-message-gender = { GENDER($entity) ->
   [male] male
   [female] female
-  *[other] BAD
+  *[neuter] BAD
+}
+
+test-message-proper = { PROPER($entity) ->
+  [true] true
+  *[false] false
 }
 
 test-message-custom-attrib = { ATTRIB($entity, ""otherAttrib"") }
-
 ";
 
         [Test]
@@ -88,26 +152,6 @@ test-message-custom-attrib = { ATTRIB($entity, ""otherAttrib"") }
             Assert.That(loc.GetString("enum-match", ("enum", TestEnum.Foo)), Is.EqualTo("A"));
             Assert.That(loc.GetString("enum-match", ("enum", TestEnum.Bar)), Is.EqualTo("B"));
             Assert.That(loc.GetString("enum-match", ("enum", TestEnum.Baz)), Is.EqualTo("B"));
-        }
-
-        [Test]
-        public void TestLocalizationID()
-        {
-            var entMan               = IoCManager.Resolve<IEntityManager>();
-            var specifiedInProto     = entMan.CreateEntityUninitialized("SpecifiedInProto");
-            var specifiedInComponent = entMan.CreateEntityUninitialized("SpecifiedInComponent");
-            var specifiedAuto        = entMan.CreateEntityUninitialized("SpecifiedAuto");
-
-            System.Console.WriteLine(specifiedInProto.Prototype?.LocalizationID);
-            System.Console.WriteLine(specifiedInComponent.GetComponent<GrammarComponent>().LocalizationId);
-            System.Console.WriteLine(specifiedAuto.Prototype?.LocalizationID);
-
-            Assert.Multiple(() =>
-            {
-                Assert.That(specifiedInProto.Prototype?.LocalizationID, Is.EqualTo("not-auto-kebab"));
-                Assert.That(specifiedInComponent.GetComponent<GrammarComponent>().LocalizationId, Is.EqualTo("from-component"));
-                Assert.That(specifiedAuto.Prototype?.LocalizationID, Is.EqualTo("ent-specified-auto"));
-            });
         }
 
         [Test]
@@ -128,6 +172,26 @@ test-message-custom-attrib = { ATTRIB($entity, ""otherAttrib"") }
                 Assert.That(genderFromGrammar, Is.EqualTo("female"));
                 Assert.That(customAttrib, Is.EqualTo("sausages"));
             });
+        }
+
+        [Test]
+        [TestCase("PropsInPrototype")]
+        [TestCase("PropsInLoc")]
+        [TestCase("PropsInLocOverriding")]
+        [TestCase("PropsInGrammar")]
+        [TestCase("TestInheritOverridingChild")]
+        public void TestLocData(string prototype)
+        {
+            var loc = IoCManager.Resolve<ILocalizationManager>();
+            var entMan = IoCManager.Resolve<IEntityManager>();
+            var ent = entMan.CreateEntityUninitialized(prototype);
+
+            Assert.That(ent.Name, Is.EqualTo("A"));
+            Assert.That(ent.Description, Is.EqualTo("B"));
+            Assert.That(ent.Prototype!.EditorSuffix, Is.EqualTo("C"));
+
+            Assert.That(loc.GetString("test-message-gender", ("entity", ent)), Is.EqualTo("male"));
+            Assert.That(loc.GetString("test-message-proper", ("entity", ent)), Is.EqualTo("true"));
         }
 
         private enum TestEnum


### PR DESCRIPTION
Entity name (and other props) resolution is moved into localization manager and done later. This allows for hot reloading and not spaghettifying serv3 to make it work.

Putting names in YAML is now fair game. Localization names override YAML names if found. Same goes for all other properties.

Localization attributes like gender/properness can be specified on the prototype with the new `loc:` key. Same overriding rules apply with Fluent.