### PR TITLE
Deferred Input Context Switches (fixes spawn entities menu while moving)

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/InputSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/InputSystem.cs
@@ -152,6 +152,12 @@ namespace Robust.Client.GameObjects
 
             SetEntityContextActive(_inputManager, _playerManager.LocalPlayer.ControlledEntity);
         }
+
+        /// <inheritdoc />
+        public virtual void FrameUpdate(float frameTime) {
+            base.FrameUpdate(frameTime);
+            _inputManager.Contexts.RunDeferredContextSwitch();
+        }
     }
 
     /// <summary>

--- a/Robust.Client/GameObjects/EntitySystems/InputSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/InputSystem.cs
@@ -152,12 +152,6 @@ namespace Robust.Client.GameObjects
 
             SetEntityContextActive(_inputManager, _playerManager.LocalPlayer.ControlledEntity);
         }
-
-        /// <inheritdoc />
-        public virtual void FrameUpdate(float frameTime) {
-            base.FrameUpdate(frameTime);
-            _inputManager.Contexts.RunDeferredContextSwitch();
-        }
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes spawn entities menu crashing the debug client if you're moving while you select an entry, or any other case where an input event causes a context change.