### PR TITLE
Directed event improvements

### DIFF
--- a/Robust.Shared/GameObjects/ComponentManager.cs
+++ b/Robust.Shared/GameObjects/ComponentManager.cs
@@ -21,6 +21,8 @@ namespace Robust.Shared.GameObjects
         [Dependency] private readonly IRuntimeLog _runtimeLog = default!;
 #endif
 
+        public IComponentFactory ComponentFactory => _componentFactory;
+
         private const int TypeCapacity = 32;
         private const int ComponentCollectionCapacity = 1024;
         private const int EntityCapacity = 1024;

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -99,6 +99,7 @@ namespace Robust.Shared.GameObjects
         private class EventTables : IDisposable
         {
             private IEntityManager _entMan;
+            private IComponentFactory _comFac;
 
             // eUid -> EventType -> { CompType1, ... CompTypeN }
             private Dictionary<EntityUid, Dictionary<Type, HashSet<Type>>> _eventTables;
@@ -112,6 +113,7 @@ namespace Robust.Shared.GameObjects
             public EventTables(IEntityManager entMan)
             {
                 _entMan = entMan;
+                _comFac = entMan.ComponentManager.ComponentFactory;
 
                 _entMan.EntityAdded += OnEntityAdded;
                 _entMan.EntityDeleted += OnEntityDeleted;
@@ -266,7 +268,6 @@ namespace Robust.Shared.GameObjects
                 }
             }
 
-
             public void ClearEntities()
             {
                 _eventTables = new();
@@ -295,7 +296,7 @@ namespace Robust.Shared.GameObjects
 
             private IEnumerable<Type> GetReferences(Type type)
             {
-                return _entMan.ComponentManager.ComponentFactory.GetRegistration(type).References;
+                return _comFac.GetRegistration(type).References;
             }
         }
 

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -259,10 +259,10 @@ namespace Robust.Shared.GameObjects
                 foreach (var type in GetReferences(component.GetType()))
                 {
                     if (!_subscriptions.TryGetValue(type, out var compSubs))
-                        return;
+                        continue;
 
                     if (!compSubs.TryGetValue(eventType, out var handler))
-                        return;
+                        continue;
 
                     handler(euid, component, args);
                 }

--- a/Robust.Shared/GameObjects/IComponentManager.cs
+++ b/Robust.Shared/GameObjects/IComponentManager.cs
@@ -252,5 +252,7 @@ namespace Robust.Shared.GameObjects
         ///     Culls all components from the collection that are marked as deleted. This needs to be called often.
         /// </summary>
         void CullRemovedComponents();
+
+        IComponentFactory ComponentFactory { get; }
     }
 }

--- a/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.ComponentEvent.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.ComponentEvent.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using Moq;
 using NUnit.Framework;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
 
 namespace Robust.UnitTesting.Shared.GameObjects
 {
@@ -14,10 +17,17 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var entUid = new EntityUid(7);
             var compInstance = new MetaDataComponent();
 
+            var compRegistration = new Mock<IComponentRegistration>();
+
             var entManMock = new Mock<IEntityManager>();
-            
+
 
             var compManMock = new Mock<IComponentManager>();
+            var compFacMock = new Mock<IComponentFactory>();
+
+            compRegistration.Setup(m => m.References).Returns(new List<Type> {typeof(MetaDataComponent)});
+            compFacMock.Setup(m => m.GetRegistration(typeof(MetaDataComponent))).Returns(compRegistration.Object);
+            compManMock.Setup(m => m.ComponentFactory).Returns(compFacMock.Object);
 
             IComponent? outIComponent = compInstance;
             compManMock.Setup(m => m.TryGetComponent(entUid, typeof(MetaDataComponent), out outIComponent))
@@ -25,6 +35,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
 
             compManMock.Setup(m => m.GetComponent(entUid, typeof(MetaDataComponent)))
                 .Returns(compInstance);
+
 
             entManMock.Setup(m => m.ComponentManager).Returns(compManMock.Object);
             var bus = new EntityEventBus(entManMock.Object);
@@ -62,8 +73,14 @@ namespace Robust.UnitTesting.Shared.GameObjects
 
             var entManMock = new Mock<IEntityManager>();
 
+            var compRegistration = new Mock<IComponentRegistration>();
 
             var compManMock = new Mock<IComponentManager>();
+            var compFacMock = new Mock<IComponentFactory>();
+
+            compRegistration.Setup(m => m.References).Returns(new List<Type> {typeof(MetaDataComponent)});
+            compFacMock.Setup(m => m.GetRegistration(typeof(MetaDataComponent))).Returns(compRegistration.Object);
+            compManMock.Setup(m => m.ComponentFactory).Returns(compFacMock.Object);
 
             IComponent? outIComponent = compInstance;
             compManMock.Setup(m => m.TryGetComponent(entUid, typeof(MetaDataComponent), out outIComponent))
@@ -96,7 +113,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             }
 
         }
-        
+
         [Test]
         public void SubscribeCompLifeEvent()
         {
@@ -108,9 +125,15 @@ namespace Robust.UnitTesting.Shared.GameObjects
             compInstance.Owner = mockEnt.Object;
 
             var entManMock = new Mock<IEntityManager>();
-            
+
+            var compRegistration = new Mock<IComponentRegistration>();
 
             var compManMock = new Mock<IComponentManager>();
+            var compFacMock = new Mock<IComponentFactory>();
+
+            compRegistration.Setup(m => m.References).Returns(new List<Type> {typeof(MetaDataComponent)});
+            compFacMock.Setup(m => m.GetRegistration(typeof(MetaDataComponent))).Returns(compRegistration.Object);
+            compManMock.Setup(m => m.ComponentFactory).Returns(compFacMock.Object);
 
             IComponent? outIComponent = compInstance;
             compManMock.Setup(m => m.TryGetComponent(entUid, typeof(MetaDataComponent), out outIComponent))


### PR DESCRIPTION
~~- Subscriptions for <TComp, TEvent> pairs can be duplicated~~ Bad idea.
- Component references are taken into account and added/removed from entity event tables.
- Component references are taken into account when dispatching component events.

**Do NOT merge without @Acruid's explicit review and approval**

Fixes #1730