### PR TITLE
Fix Coordinates setter destroying local position during a parent change

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -115,7 +115,7 @@ namespace Robust.Shared.GameObjects
 
                 // Set _nextRotation to null to break any active lerps if this is a client side prediction.
                 _nextRotation = null;
-                SetRotation(value);
+                _localRotation = value;
                 Dirty();
 
                 if (!DeferUpdates)
@@ -258,17 +258,51 @@ namespace Robust.Shared.GameObjects
                 var valid = _parent.IsValid();
                 return new EntityCoordinates(valid ? _parent : Owner.Uid, valid ? LocalPosition : Vector2.Zero);
             }
+            // NOTE: This setter must be callable from before initialize (inheriting from AttachParent's note)
             set
             {
                 var oldPosition = Coordinates;
                 _localPosition = value.Position;
 
+                var changedParent = false;
+
                 if (value.EntityId != _parent)
                 {
-                    var newEntity = Owner.EntityManager.GetEntity(value.EntityId);
-                    AttachParent(newEntity);
+                    changedParent = true;
+                    var newParentEnt = Owner.EntityManager.GetEntity(value.EntityId);
+                    var newParent = newParentEnt.Transform;
+
+                    DebugTools.Assert(newParent != this,
+                        $"Can't parent a {nameof(ITransformComponent)} to itself.");
+
+                    // That's already our parent, don't bother attaching again.
+
+                    var oldParent = Parent;
+                    var oldConcrete = (TransformComponent?) oldParent;
+                    var uid = Owner.Uid;
+                    oldConcrete?._children.Remove(uid);
+                    var newConcrete = (TransformComponent) newParent;
+                    newConcrete._children.Add(uid);
+
+                    var oldParentOwner = oldParent?.Owner;
+                    var entMessage = new EntParentChangedMessage(Owner, oldParentOwner);
+                    var compMessage = new ParentChangedMessage(newParentEnt, oldParentOwner);
+
+                    // offset position from world to parent
+                    _parent = newParentEnt.Uid;
+                    ChangeMapId(newConcrete.MapID);
+
+                    Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, entMessage);
+                    Owner.SendMessage(this, compMessage);
+
+                    GridID = GetGridIndex();
                 }
 
+                // These conditions roughly emulate the effects of the code before I changed things,
+                //  in regards to when to rebuild matrices.
+                // This may not in fact be the right thing.
+                if (changedParent || !DeferUpdates)
+                    RebuildMatrices();
                 Dirty();
 
                 if (!DeferUpdates)
@@ -276,7 +310,6 @@ namespace Robust.Shared.GameObjects
                     //TODO: This is a hack, look into WHY we can't call GridPosition before the comp is Running
                     if (Running)
                     {
-                        RebuildMatrices();
                         Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, new MoveEvent(Owner, oldPosition, Coordinates));
                     }
                 }
@@ -304,7 +337,7 @@ namespace Robust.Shared.GameObjects
                 _nextPosition = null;
 
                 var oldGridPos = Coordinates;
-                SetPosition(value);
+                _localPosition = value;
                 Dirty();
 
                 if (!DeferUpdates)
@@ -556,49 +589,22 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <summary>
-        /// Sets another entity as the parent entity.
+        /// Sets another entity as the parent entity, maintaining world position.
         /// </summary>
         /// <param name="newParent"></param>
         public virtual void AttachParent(ITransformComponent newParent)
         {
             //NOTE: This function must be callable from before initialize
 
-            // nothing to attach to.
+            // don't attach to something we're already attached to
             if (ParentUid == newParent.Owner.Uid)
                 return;
 
             DebugTools.Assert(newParent != this,
                 $"Can't parent a {nameof(ITransformComponent)} to itself.");
 
-            // That's already our parent, don't bother attaching again.
-            var newParentEnt = newParent.Owner;
-            if (newParentEnt.Uid == _parent)
-            {
-                return;
-            }
-
-            var oldParent = Parent;
-            var oldConcrete = (TransformComponent?) oldParent;
-            var uid = Owner.Uid;
-            oldConcrete?._children.Remove(uid);
-            var newConcrete = (TransformComponent) newParent;
-            newConcrete._children.Add(uid);
-
-            var oldParentOwner = oldParent?.Owner;
-            var entMessage = new EntParentChangedMessage(Owner, oldParentOwner);
-            var compMessage = new ParentChangedMessage(newParentEnt, oldParentOwner);
-
-            // offset position from world to parent
-            SetPosition(newParent.InvWorldMatrix.Transform(WorldPosition));
-            _parent = newParentEnt.Uid;
-            ChangeMapId(newConcrete.MapID);
-
-            Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, entMessage);
-            Owner.SendMessage(this, compMessage);
-
-            RebuildMatrices();
-            Dirty();
-            GridID = GetGridIndex();
+            // offset position from world to parent, and set
+            Coordinates = new EntityCoordinates(newParent.Owner.Uid, newParent.InvWorldMatrix.Transform(WorldPosition));
         }
 
         internal void ChangeMapId(MapId newMapId)
@@ -713,14 +719,14 @@ namespace Robust.Shared.GameObjects
 
                 if (LocalRotation != newState.Rotation)
                 {
-                    SetRotation(newState.Rotation);
+                    _localRotation = newState.Rotation;
                     rebuildMatrices = true;
                 }
 
                 if (!_localPosition.EqualsApprox(newState.LocalPosition, 0.0001))
                 {
                     var oldPos = Coordinates;
-                    SetPosition(newState.LocalPosition);
+                    _localPosition = newState.LocalPosition;
 
                     var ev = new MoveEvent(Owner, oldPos, Coordinates);
                     EntitySystem.Get<SharedTransformSystem>().DeferMoveEvent(ev);
@@ -753,17 +759,6 @@ namespace Robust.Shared.GameObjects
                 _nextRotation = null;
                 LerpParent = EntityUid.Invalid;
             }
-        }
-
-        protected virtual void SetPosition(Vector2 position)
-        {
-            // DebugTools.Assert(!float.IsNaN(position.X) && !float.IsNaN(position.Y));
-            _localPosition = position;
-        }
-
-        protected virtual void SetRotation(Angle rotation)
-        {
-            _localRotation = rotation;
         }
 
         public Matrix3 GetLocalMatrix()


### PR DESCRIPTION
This fixes computer boards going missing.
To reproduce the involved bug, simply take a computer, and remove the board.
The board will go missing.
For best effect, do this near but not at 0,0 - the board will appear nearby, at a "doubled" position.
The summary is that setting coordinates via the coordinates setter never worked if a parent change was involved.
Since it makes more sense for Coordinates to be the "root of all position changes", I've done that. There is a less involved way to do this but it involves a version of AttachParent which doesn't change local position.