### PR TITLE
Adds overloads for entity system methods with out parameters.

### DIFF
--- a/Robust.Shared/GameObjects/EntitySystem.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.cs
@@ -53,10 +53,11 @@ namespace Robust.Shared.GameObjects
             EntityManager.EventBus.RaiseEvent(EventSource.Local, message);
         }
 
-        protected void RaiseLocalEvent<T>(T message, out T outMessage) where T : notnull
+        protected bool RaiseLocalEvent<T>(T message, out T outMessage) where T : notnull
         {
             EntityManager.EventBus.RaiseEvent(EventSource.Local, message);
             outMessage = message;
+            return true;
         }
 
         protected void RaiseLocalEvent(object message)
@@ -64,10 +65,11 @@ namespace Robust.Shared.GameObjects
             EntityManager.EventBus.RaiseEvent(EventSource.Local, message);
         }
 
-        protected void RaiseLocalEvent(object message, out object outMessage)
+        protected bool RaiseLocalEvent(object message, out object outMessage)
         {
             EntityManager.EventBus.RaiseEvent(EventSource.Local, message);
             outMessage = message;
+            return true;
         }
 
         protected void QueueLocalEvent(EntityEventArgs message)
@@ -105,11 +107,12 @@ namespace Robust.Shared.GameObjects
             EntityManager.EventBus.RaiseLocalEvent(uid, args, broadcast);
         }
 
-        protected void RaiseLocalEvent<TEvent>(EntityUid uid, TEvent args, out TEvent outArgs, bool broadcast = true)
+        protected bool RaiseLocalEvent<TEvent>(EntityUid uid, TEvent args, out TEvent outArgs, bool broadcast = true)
             where TEvent : EntityEventArgs
         {
             EntityManager.EventBus.RaiseLocalEvent(uid, args, broadcast);
             outArgs = args;
+            return true;
         }
 
         #endregion

--- a/Robust.Shared/GameObjects/EntitySystem.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.cs
@@ -53,9 +53,21 @@ namespace Robust.Shared.GameObjects
             EntityManager.EventBus.RaiseEvent(EventSource.Local, message);
         }
 
+        protected void RaiseLocalEvent<T>(T message, out T outMessage) where T : notnull
+        {
+            EntityManager.EventBus.RaiseEvent(EventSource.Local, message);
+            outMessage = message;
+        }
+
         protected void RaiseLocalEvent(object message)
         {
             EntityManager.EventBus.RaiseEvent(EventSource.Local, message);
+        }
+
+        protected void RaiseLocalEvent(object message, out object outMessage)
+        {
+            EntityManager.EventBus.RaiseEvent(EventSource.Local, message);
+            outMessage = message;
         }
 
         protected void QueueLocalEvent(EntityEventArgs message)
@@ -91,6 +103,13 @@ namespace Robust.Shared.GameObjects
             where TEvent : EntityEventArgs
         {
             EntityManager.EventBus.RaiseLocalEvent(uid, args, broadcast);
+        }
+
+        protected void RaiseLocalEvent<TEvent>(EntityUid uid, TEvent args, out TEvent outArgs, bool broadcast = true)
+            where TEvent : EntityEventArgs
+        {
+            EntityManager.EventBus.RaiseLocalEvent(uid, args, broadcast);
+            outArgs = args;
         }
 
         #endregion

--- a/Robust.Shared/GameObjects/EntitySystem.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.cs
@@ -48,28 +48,16 @@ namespace Robust.Shared.GameObjects
 
         #region Event Proxy
 
-        protected void RaiseLocalEvent<T>(T message) where T : notnull
+        protected T RaiseLocalEvent<T>(T message) where T : notnull
         {
             EntityManager.EventBus.RaiseEvent(EventSource.Local, message);
+            return message;
         }
 
-        protected bool RaiseLocalEvent<T>(T message, out T outMessage) where T : notnull
+        protected object RaiseLocalEvent(object message)
         {
             EntityManager.EventBus.RaiseEvent(EventSource.Local, message);
-            outMessage = message;
-            return true;
-        }
-
-        protected void RaiseLocalEvent(object message)
-        {
-            EntityManager.EventBus.RaiseEvent(EventSource.Local, message);
-        }
-
-        protected bool RaiseLocalEvent(object message, out object outMessage)
-        {
-            EntityManager.EventBus.RaiseEvent(EventSource.Local, message);
-            outMessage = message;
-            return true;
+            return message;
         }
 
         protected void QueueLocalEvent(EntityEventArgs message)
@@ -101,18 +89,11 @@ namespace Robust.Shared.GameObjects
             return EntityManager.EventBus.AwaitEvent<T>(EventSource.Network, cancellationToken);
         }
 
-        protected void RaiseLocalEvent<TEvent>(EntityUid uid, TEvent args, bool broadcast = true)
+        protected TEvent RaiseLocalEvent<TEvent>(EntityUid uid, TEvent args, bool broadcast = true)
             where TEvent : EntityEventArgs
         {
             EntityManager.EventBus.RaiseLocalEvent(uid, args, broadcast);
-        }
-
-        protected bool RaiseLocalEvent<TEvent>(EntityUid uid, TEvent args, out TEvent outArgs, bool broadcast = true)
-            where TEvent : EntityEventArgs
-        {
-            EntityManager.EventBus.RaiseLocalEvent(uid, args, broadcast);
-            outArgs = args;
-            return true;
+            return args;
         }
 
         #endregion


### PR DESCRIPTION
Okay, I know this seems silly but bear with me here for a second.
This will (imo) improve QOL, as you can use `new WhateverEvent()` in the method calls to raise them, and have it as the return value to do funny pattern matching with.