### PR TITLE
Fix PreventCollideEvent

### DIFF
--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
@@ -1294,6 +1294,11 @@ namespace Robust.Shared.GameObjects
 
             if (preventCollideMessage.Cancelled) return false;
 
+            preventCollideMessage = new PreventCollideEvent(other, this);
+            Owner.EntityManager.EventBus.RaiseLocalEvent(other.Owner.Uid, preventCollideMessage);
+
+            if (preventCollideMessage.Cancelled) return false;
+
 #pragma warning disable 618
             foreach (var comp in Owner.GetAllComponents<ICollideSpecial>())
             {


### PR DESCRIPTION
With directed bus it's better to raise it both ways for a collision.