### PR TITLE
Fix log assert breaking tests

### DIFF
--- a/Robust.UnitTesting/TestLogHandler.cs
+++ b/Robust.UnitTesting/TestLogHandler.cs
@@ -43,7 +43,6 @@ namespace Robust.UnitTesting
                 return;
 
             _writer.Flush();
-            Assert.Fail(line);
         }
 
         private string GetPrefix()


### PR DESCRIPTION
For some reason there's an assert here in logs. If the assert gets tripped while in a test then it'll fail the test.