### PR TITLE
Fix light pop-in

### DIFF
--- a/Robust.Client/Console/Commands/LightBBCommand.cs
+++ b/Robust.Client/Console/Commands/LightBBCommand.cs
@@ -1,0 +1,17 @@
+using Robust.Client.GameObjects;
+using Robust.Shared.Console;
+using Robust.Shared.GameObjects;
+
+namespace Robust.Client.Console.Commands
+{
+    internal sealed class LightDebugCommand : IConsoleCommand
+    {
+        public string Command => "lightbb";
+        public string Description => "Toggles whether to show light bounding boxes";
+        public string Help => $"{Command}";
+        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        {
+            EntitySystem.Get<DebugLightTreeSystem>().Enabled ^= true;
+        }
+    }
+}

--- a/Robust.Client/GameObjects/EntitySystems/DebugLightTreeSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/DebugLightTreeSystem.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+
+namespace Robust.Client.GameObjects
+{
+    internal sealed class DebugLightTreeSystem : EntitySystem
+    {
+        private DebugLightOverlay? _lightOverlay;
+
+        public bool Enabled
+        {
+            get => _enabled;
+            set
+            {
+                if (_enabled == value) return;
+
+                _enabled = value;
+                var overlayManager = IoCManager.Resolve<IOverlayManager>();
+
+                if (_enabled)
+                {
+                    _lightOverlay = new DebugLightOverlay(
+                        IoCManager.Resolve<IEntityLookup>(),
+                        IoCManager.Resolve<IEyeManager>(),
+                        IoCManager.Resolve<IMapManager>(),
+                        Get<RenderingTreeSystem>());
+
+                    overlayManager.AddOverlay(_lightOverlay);
+                }
+                else
+                {
+                    overlayManager.RemoveOverlay(_lightOverlay!);
+                    _lightOverlay = null;
+                }
+            }
+        }
+
+        private bool _enabled;
+
+        private sealed class DebugLightOverlay : Overlay
+        {
+            private IEntityLookup _lookup;
+            private IEyeManager _eyeManager;
+            private IMapManager _mapManager;
+
+            private RenderingTreeSystem _tree;
+
+            public override OverlaySpace Space => OverlaySpace.WorldSpace;
+
+            public DebugLightOverlay(IEntityLookup lookup, IEyeManager eyeManager, IMapManager mapManager, RenderingTreeSystem tree)
+            {
+                _lookup = lookup;
+                _eyeManager = eyeManager;
+                _mapManager = mapManager;
+                _tree = tree;
+            }
+
+            protected internal override void Draw(in OverlayDrawArgs args)
+            {
+                var map = _eyeManager.CurrentMap;
+                if (map == MapId.Nullspace) return;
+
+                var viewport = _eyeManager.GetWorldViewport();
+                var renderedLights = new HashSet<PointLightComponent>();
+
+                foreach (var gridId in _mapManager.FindGridIdsIntersecting(map, viewport, true))
+                {
+                    foreach (var light in _tree.GetLightTreeForMap(map, gridId))
+                    {
+                        if (renderedLights.Contains(light)) continue;
+
+                        renderedLights.Add(light);
+                        args.WorldHandle.DrawRect(_lookup.GetWorldAabbFromEntity(light.Owner), Color.Green.WithAlpha(0.1f));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
@@ -54,12 +54,10 @@ namespace Robust.Client.GameObjects
             SubscribeLocalEvent<MoveEvent>(AnythingMoved);
 
             SubscribeLocalEvent<SpriteComponent, EntMapIdChangedMessage>(SpriteMapChanged);
-            SubscribeLocalEvent<SpriteComponent, MoveEvent>(SpriteMoved);
             SubscribeLocalEvent<SpriteComponent, EntParentChangedMessage>(SpriteParentChanged);
             SubscribeLocalEvent<SpriteComponent, ComponentRemove>(RemoveSprite);
 
             SubscribeLocalEvent<PointLightComponent, EntMapIdChangedMessage>(LightMapChanged);
-            SubscribeLocalEvent<PointLightComponent, MoveEvent>(LightMoved);
             SubscribeLocalEvent<PointLightComponent, EntParentChangedMessage>(LightParentChanged);
             SubscribeLocalEvent<PointLightComponent, PointLightRadiusChangedEvent>(PointLightRadiusChanged);
             SubscribeLocalEvent<PointLightComponent, RenderTreeRemoveLightEvent>(RemoveLight);
@@ -92,11 +90,6 @@ namespace Robust.Client.GameObjects
 
         #region SpriteHandlers
         private void SpriteMapChanged(EntityUid uid, SpriteComponent component, EntMapIdChangedMessage args)
-        {
-            QueueSpriteUpdate(component);
-        }
-
-        private void SpriteMoved(EntityUid uid, SpriteComponent component, MoveEvent args)
         {
             QueueSpriteUpdate(component);
         }
@@ -152,11 +145,6 @@ namespace Robust.Client.GameObjects
 
         #region LightHandlers
         private void LightMapChanged(EntityUid uid, PointLightComponent component, EntMapIdChangedMessage args)
-        {
-            QueueLightUpdate(component);
-        }
-
-        private void LightMoved(EntityUid uid, PointLightComponent component, MoveEvent args)
         {
             QueueLightUpdate(component);
         }
@@ -301,7 +289,7 @@ namespace Robust.Client.GameObjects
                 if (mapId == MapId.Nullspace) continue;
 
                 var mapTree = _gridTrees[mapId];
-                var aabb = MapTrees.SpriteAabbFunc(sprite);
+                var aabb = SpriteAabbFunc(sprite);
                 var intersectingGrids = _mapManager.FindGridIdsIntersecting(mapId, aabb, true).ToList();
 
                 // Remove from old
@@ -344,7 +332,7 @@ namespace Robust.Client.GameObjects
                 if (mapId == MapId.Nullspace) continue;
 
                 var mapTree = _gridTrees[mapId];
-                var aabb = MapTrees.LightAabbFunc(light);
+                var aabb = LightAabbFunc(light);
                 var intersectingGrids = _mapManager.FindGridIdsIntersecting(mapId, aabb, true).ToList();
 
                 // Remove from old
@@ -385,21 +373,21 @@ namespace Robust.Client.GameObjects
                 SpriteTree = new DynamicTree<SpriteComponent>(SpriteAabbFunc);
                 LightTree = new DynamicTree<PointLightComponent>(LightAabbFunc);
             }
+        }
 
-            internal static Box2 SpriteAabbFunc(in SpriteComponent value)
-            {
-                var worldPos = value.Owner.Transform.WorldPosition;
+        internal static Box2 SpriteAabbFunc(in SpriteComponent value)
+        {
+            var worldPos = value.Owner.Transform.WorldPosition;
 
-                return new Box2(worldPos, worldPos);
-            }
+            return new Box2(worldPos, worldPos);
+        }
 
-            internal static Box2 LightAabbFunc(in PointLightComponent value)
-            {
-                var worldPos = value.Owner.Transform.WorldPosition;
+        internal static Box2 LightAabbFunc(in PointLightComponent value)
+        {
+            var worldPos = value.Owner.Transform.WorldPosition;
 
-                var boxSize = value.Radius * 2;
-                return Box2.CenteredAround(worldPos, (boxSize, boxSize));
-            }
+            var boxSize = value.Radius * 2;
+            return Box2.CenteredAround(worldPos, (boxSize, boxSize));
         }
     }
 

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿using System.Collections.Generic;
+using JetBrains.Annotations;
 using Robust.Client.Graphics;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -37,6 +38,8 @@ namespace Robust.Client.GameObjects
                 return;
             }
 
+            var doubledSprites = new HashSet<SpriteComponent>();
+
             foreach (var gridId in _mapManager.FindGridIdsIntersecting(currentMap, pvsBounds, true))
             {
                 var gridBounds = gridId == GridId.Invalid ? pvsBounds : pvsBounds.Translated(-_mapManager.GetGrid(gridId).WorldPosition);
@@ -48,6 +51,12 @@ namespace Robust.Client.GameObjects
                     if (value.IsInert)
                     {
                         return true;
+                    }
+
+                    if (value.IntersectingGrids.Count > 1)
+                    {
+                        if (doubledSprites.Contains(value)) return true;
+                        doubledSprites.Add(value);
                     }
 
                     value.FrameUpdate(state);

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -367,6 +367,7 @@ namespace Robust.Client.Graphics.Clyde
             RefList<(SpriteComponent sprite, Matrix3 matrix, Angle worldRot, float yWorldPos)> list)
         {
             var spriteSystem = _entitySystemManager.GetEntitySystem<RenderingTreeSystem>();
+            var doubledSprites = new HashSet<SpriteComponent>();
 
             foreach (var gridId in _mapManager.FindGridIdsIntersecting(map, worldBounds, true))
             {
@@ -391,6 +392,12 @@ namespace Robust.Client.Graphics.Clyde
                     if (value.ContainerOccluded || !value.Visible)
                     {
                         return true;
+                    }
+
+                    if (value.IntersectingGrids.Count > 1)
+                    {
+                        if (doubledSprites.Contains(value)) return true;
+                        doubledSprites.Add(value);
                     }
 
                     var entity = value.Owner;

--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Buffers;
 using OpenToolkit.Graphics.OpenGL4;
@@ -495,6 +495,7 @@ namespace Robust.Client.Graphics.Clyde
         {
             var renderingTreeSystem = _entitySystemManager.GetEntitySystem<RenderingTreeSystem>();
             var state = (this, worldBounds, count: 0);
+            var doubledLights = new HashSet<PointLightComponent>();
 
             foreach (var gridId in _mapManager.FindGridIdsIntersecting(map, worldBounds, true))
             {
@@ -525,6 +526,12 @@ namespace Robust.Client.Graphics.Clyde
                     if (!light.Enabled || light.ContainerOccluded)
                     {
                         return true;
+                    }
+
+                    if (light.IntersectingGrids.Count > 1)
+                    {
+                        if (doubledLights.Contains(light)) return true;
+                        doubledLights.Add(light);
                     }
 
                     var lightPos = transform.WorldMatrix.Transform(light.Offset);


### PR DESCRIPTION
D'oh.

Fixes https://github.com/space-wizards/RobustToolbox/issues/1754

Not sure if it's the best way to go about it but the problem is that lights / sprites that intersect 2 grids get drawn twice.

I also added a debug command to show every light in the viewport.