### PR TITLE
Remove Map & Grid Entity Pivoting

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -394,7 +394,7 @@ namespace Robust.Client.GameStates
         private List<EntityUid> ApplyGameState(GameState curState, GameState? nextState)
         {
             _config.TickProcessMessages();
-            _mapManager.ApplyGameStatePre(curState.MapData);
+            _mapManager.ApplyGameStatePre(curState.MapData, curState.EntityStates);
             var createdEntities = ApplyEntityStates(curState.EntityStates, curState.EntityDeletions,
                 nextState?.EntityStates);
             _players.ApplyPlayerStates(curState.PlayerStates);

--- a/Robust.Client/Map/IClientMapManager.cs
+++ b/Robust.Client/Map/IClientMapManager.cs
@@ -1,3 +1,4 @@
+using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 using Robust.Shared.Map;
 
@@ -7,7 +8,7 @@ namespace Robust.Client.Map
     {
         // Two methods here, so that new grids etc can be made BEFORE entities get states applied,
         // but old ones can be deleted after.
-        void ApplyGameStatePre(GameStateMapData? data);
+        void ApplyGameStatePre(GameStateMapData? data, EntityState[]? entityStates);
         void ApplyGameStatePost(GameStateMapData? data);
     }
 }

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -142,6 +142,11 @@ namespace Robust.Shared.GameObjects
 
         #region Entity Management
 
+        public IEntity CreateEntityUninitialized(string? prototypeName, EntityUid? euid)
+        {
+            return CreateEntity(prototypeName, euid);
+        }
+
         /// <inheritdoc />
         public virtual IEntity CreateEntityUninitialized(string? prototypeName)
         {

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -37,6 +37,8 @@ namespace Robust.Shared.GameObjects
         event EventHandler<EntityUid>? EntityStarted;
         event EventHandler<EntityUid>? EntityDeleted;
 
+        IEntity CreateEntityUninitialized(string? prototypeName, EntityUid? euid);
+
         IEntity CreateEntityUninitialized(string? prototypeName);
 
         IEntity CreateEntityUninitialized(string? prototypeName, EntityCoordinates coordinates);


### PR DESCRIPTION
Removes the map and grid entity pivot hack from clientside map networking. Now the maps and grids are linked to their shared entities when created clientside.

Because client entity states are applied in arbitrary order instead of scene graph preorder, accessing any parent properties like GridId, MapId, and ParentUid from inside component HandleState is still unsafe in the pre-init stage.