### PR TITLE
Add SetAndDirtyIfChanged extension method

### DIFF
--- a/Robust.Shared/GameObjects/ComponentExt.cs
+++ b/Robust.Shared/GameObjects/ComponentExt.cs
@@ -95,7 +95,7 @@ namespace Robust.Shared.GameObjects
             return entity.AddComponent<T>();
         }
 
-        public static TValue SetAndDirtyIfChanged<TComp, TValue>(
+        public static TComp SetAndDirtyIfChanged<TComp, TValue>(
             this TComp comp,
             ref TValue backingField,
             TValue value)
@@ -103,13 +103,13 @@ namespace Robust.Shared.GameObjects
         {
             if (EqualityComparer<TValue>.Default.Equals(backingField, value))
             {
-                return value;
+                return comp;
             }
 
             backingField = value;
             comp.Dirty();
 
-            return value;
+            return comp;
         }
     }
 }

--- a/Robust.Shared/GameObjects/ComponentExt.cs
+++ b/Robust.Shared/GameObjects/ComponentExt.cs
@@ -95,11 +95,10 @@ namespace Robust.Shared.GameObjects
             return entity.AddComponent<T>();
         }
 
-        public static TComp SetAndDirtyIfChanged<TComp, TValue>(
-            this TComp comp,
+        public static IComponent SetAndDirtyIfChanged<TValue>(
+            this IComponent comp,
             ref TValue backingField,
             TValue value)
-            where TComp : IComponent
         {
             if (EqualityComparer<TValue>.Default.Equals(backingField, value))
             {

--- a/Robust.Shared/GameObjects/ComponentExt.cs
+++ b/Robust.Shared/GameObjects/ComponentExt.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Robust.Shared.Log;
 
@@ -92,6 +93,23 @@ namespace Robust.Shared.GameObjects
             Logger.Warning(warning);
 
             return entity.AddComponent<T>();
+        }
+
+        public static TValue SetAndDirtyIfChanged<TComp, TValue>(
+            this TComp comp,
+            ref TValue backingField,
+            TValue value)
+            where TComp : IComponent
+        {
+            if (EqualityComparer<TValue>.Default.Equals(backingField, value))
+            {
+                return value;
+            }
+
+            backingField = value;
+            comp.Dirty();
+
+            return value;
         }
     }
 }


### PR DESCRIPTION
In the interest of replacing this
![](https://cdn.discordapp.com/attachments/560845886263918612/851800371466076160/rider64_kIUf3gPJ8Q.png)

With this 
![](https://cdn.discordapp.com/attachments/560845886263918612/851800380144091156/unknown.png)


It works like [RaiseAndSetIfChanged in ReactiveUI](https://www.reactiveui.net/api/reactiveui/ireactiveobjectextensions/554ad0a8) but it returns the component instead of the value being set for method chaining.