### PR TITLE
Client Networked event subscriptions can now take in EntitySessionEventArgs

### DIFF
--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -232,6 +232,7 @@ namespace Robust.Server.GameObjects
                     var msg = message.SystemMessage;
                     var sessionType = typeof(EntitySessionMessage<>).MakeGenericType(msg.GetType());
                     var sessionMsg = Activator.CreateInstance(sessionType, new EntitySessionEventArgs(player), msg)!;
+                    ReceivedSystemMessage?.Invoke(this, msg);
                     ReceivedSystemMessage?.Invoke(this, sessionMsg);
                     return;
             }


### PR DESCRIPTION
Server can also now handle network messages without EntitySessionEventArgs, although this is of course discouraged.

Before, it just didn't work at all if you tried, but it didn't error out or anything. The event args will have the local player's session.
This is good for shared code where the server and client handle network messages the same way, I guess.

@DrSmugleaf this one's for you bb