### PR TITLE
Add more tolerance for if player sessions are connected to dead entities

### DIFF
--- a/Robust.Server/Player/PlayerSession.cs
+++ b/Robust.Server/Player/PlayerSession.cs
@@ -133,6 +133,17 @@ namespace Robust.Server.Player
             if (AttachedEntity == null)
                 return;
 
+#if EXCEPTION_TOLERANCE
+            if (AttachedEntity.Deleted)
+            {
+                Logger.Warning($"Player \"{this}\" was attached to an entity that was deleted. THIS SHOULD NEVER HAPPEN, BUT DOES.");
+                // We can't contact ActorSystem because trying to fire an entity event would crash.
+                // Work around it.
+                SetAttachedEntity(null);
+                return;
+            }
+#endif
+
             var detachPlayer = new DetachPlayerEvent();
             AttachedEntity.EntityManager.EventBus.RaiseLocalEvent(AttachedEntity.Uid, detachPlayer, false);
 

--- a/Robust.Server/Player/PlayerSession.cs
+++ b/Robust.Server/Player/PlayerSession.cs
@@ -139,7 +139,7 @@ namespace Robust.Server.Player
                 Logger.Warning($"Player \"{this}\" was attached to an entity that was deleted. THIS SHOULD NEVER HAPPEN, BUT DOES.");
                 // We can't contact ActorSystem because trying to fire an entity event would crash.
                 // Work around it.
-                SetAttachedEntity(null);
+                ((IPlayerSession) this).SetAttachedEntity(null);
                 return;
             }
 #endif


### PR DESCRIPTION
One may hope this stops the servers getting stuck throwing exceptions on round restart and never actually restarting the round.
This can be caused by various sorts of Bad Stuff (tm).