### PR TITLE
Adds ReflectRaiseEvent attribute, add SetValue method to IReflectionManager

### DIFF
--- a/Robust.Client/ViewVariables/IViewVariablesManager.cs
+++ b/Robust.Client/ViewVariables/IViewVariablesManager.cs
@@ -1,3 +1,4 @@
+using Robust.Shared.GameObjects;
 using Robust.Shared.ViewVariables;
 
 namespace Robust.Client.ViewVariables
@@ -8,7 +9,8 @@ namespace Robust.Client.ViewVariables
         ///     Open a VV window for a locally existing object.
         /// </summary>
         /// <param name="obj">The object to VV.</param>
-        void OpenVV(object obj);
+        /// <param name="uid">Pass an entityUid to raise directed events when changing members that support this</param>
+        void OpenVV(object obj, EntityUid? uid = null);
 
         /// <summary>
         ///     Open a VV window for a remotely existing object.

--- a/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceEntity.cs
+++ b/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceEntity.cs
@@ -13,6 +13,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Log;
 using Robust.Shared.Maths;
+using Robust.Shared.Reflection;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
@@ -61,7 +62,7 @@ namespace Robust.Client.ViewVariables.Instances
 
         private bool _serverLoaded;
 
-        public ViewVariablesInstanceEntity(IViewVariablesManagerInternal vvm, IEntityManager entityManager, IRobustSerializer robustSerializer) : base(vvm, robustSerializer)
+        public ViewVariablesInstanceEntity(IViewVariablesManagerInternal vvm, IEntityManager entityManager, IRobustSerializer robustSerializer, IReflectionManager reflectionManager) : base(vvm, robustSerializer,  reflectionManager)
         {
             _entityManager = entityManager;
         }
@@ -123,7 +124,7 @@ namespace Robust.Client.ViewVariables.Instances
             _tabs.SetTabTitle(TabClientVars, "Client Variables");
 
             var first = true;
-            foreach (var group in LocalPropertyList(obj, ViewVariablesManager, _robustSerializer))
+            foreach (var group in LocalPropertyList(obj, _entity.Uid, ViewVariablesManager, _robustSerializer, ReflectionManager))
             {
                 ViewVariablesTraitMembers.CreateMemberGroupHeader(
                     ref first,
@@ -185,7 +186,7 @@ namespace Robust.Client.ViewVariables.Instances
                     StyleClasses = { SS14Window.StyleClassWindowCloseButton },
                     HorizontalAlignment = HAlignment.Right
                 };
-                button.OnPressed += _ => ViewVariablesManager.OpenVV(component);
+                button.OnPressed += _ => ViewVariablesManager.OpenVV(component, _entity.Uid);
                 removeButton.OnPressed += _ => RemoveClientComponent(component);
                 button.AddChild(removeButton);
                 _clientComponents.AddChild(button);

--- a/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceObject.cs
+++ b/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceObject.cs
@@ -4,7 +4,9 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Client.ViewVariables.Traits;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Input;
+using Robust.Shared.Reflection;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
 using Robust.Shared.Utility;
@@ -24,9 +26,14 @@ namespace Robust.Client.ViewVariables.Instances
 
         public ViewVariablesRemoteSession? Session { get; private set; }
         public object? Object { get; private set; }
+        public EntityUid? Uid { get; private set; }
 
-        public ViewVariablesInstanceObject(IViewVariablesManagerInternal vvm, IRobustSerializer robustSerializer)
-            : base(vvm, robustSerializer) { }
+        public ViewVariablesInstanceObject(EntityUid? uid, IViewVariablesManagerInternal vvm,
+            IRobustSerializer robustSerializer, IReflectionManager reflectionManager)
+            : base(vvm, robustSerializer, reflectionManager)
+        {
+            Uid = uid;
+        }
 
         public override void Initialize(SS14Window window, object obj)
         {

--- a/Robust.Client/ViewVariables/Traits/ViewVariablesTraitMembers.cs
+++ b/Robust.Client/ViewVariables/Traits/ViewVariablesTraitMembers.cs
@@ -35,8 +35,8 @@ namespace Robust.Client.ViewVariables.Traits
             if (Instance.Object != null)
             {
                 var first = true;
-                foreach (var group in ViewVariablesInstance.LocalPropertyList(Instance.Object,
-                    Instance.ViewVariablesManager, _robustSerializer))
+                foreach (var group in ViewVariablesInstance.LocalPropertyList(Instance.Object, Instance.Uid,
+                    Instance.ViewVariablesManager, _robustSerializer, Instance.ReflectionManager))
                 {
                     CreateMemberGroupHeader(
                         ref first,

--- a/Robust.Server/ViewVariables/IViewVariablesSession.cs
+++ b/Robust.Server/ViewVariables/IViewVariablesSession.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Robust.Shared.Network;
+using Robust.Shared.Reflection;
 using Robust.Shared.Serialization;
 
 namespace Robust.Server.ViewVariables
@@ -8,6 +9,7 @@ namespace Robust.Server.ViewVariables
     {
         IViewVariablesHost Host { get; }
         IRobustSerializer RobustSerializer { get; }
+        IReflectionManager ReflectionManager { get; }
         NetUserId PlayerUser { get; }
         object Object { get; }
         uint SessionId { get; }

--- a/Robust.Server/ViewVariables/Traits/ViewVariablesTraitEntity.cs
+++ b/Robust.Server/ViewVariables/Traits/ViewVariablesTraitEntity.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 

--- a/Robust.Server/ViewVariables/ViewVariablesHost.cs
+++ b/Robust.Server/ViewVariables/ViewVariablesHost.cs
@@ -117,6 +117,9 @@ namespace Robust.Server.ViewVariables
 
             object theObject;
 
+            // Uid for component selectors.
+            EntityUid? uid = null;
+
             switch (message.Selector)
             {
                 case ViewVariablesComponentSelector componentSelector:
@@ -129,6 +132,7 @@ namespace Robust.Server.ViewVariables
                     }
 
                     theObject = component;
+                    uid = componentSelector.Entity;
                     break;
                 case ViewVariablesEntitySelector entitySelector:
                 {
@@ -197,8 +201,8 @@ namespace Robust.Server.ViewVariables
             }
 
             var sessionId = _nextSessionId++;
-            var session = new ViewVariablesesSession(message.MsgChannel.UserId, theObject, sessionId, this,
-                _robustSerializer);
+            var session = new ViewVariablesesSession(message.MsgChannel.UserId, theObject, sessionId, uid, this,
+                _robustSerializer, _reflectionManager);
 
             _sessions.Add(sessionId, session);
 

--- a/Robust.Server/ViewVariables/ViewVariablesTrait.cs
+++ b/Robust.Server/ViewVariables/ViewVariablesTrait.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Robust.Server.ViewVariables.Traits;
+using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Network.Messages;
 using Robust.Shared.Prototypes;
@@ -76,8 +77,9 @@ namespace Robust.Server.ViewVariables
         /// <param name="value">
         ///     The new value of the object.
         /// </param>
+        /// <param name="uid">Entity Uid for raising directed events when needed.</param>
         /// <returns>True if this trait can and did modify the property, false otherwise.</returns>
-        public virtual bool TryModifyProperty(object[] property, object value)
+        public virtual bool TryModifyProperty(object[] property, object value, EntityUid? uid)
         {
             return false;
         }

--- a/Robust.Shared/ContentPack/IModLoader.cs
+++ b/Robust.Shared/ContentPack/IModLoader.cs
@@ -30,6 +30,11 @@ namespace Robust.Shared.ContentPack
     internal interface IModLoaderInternal : IModLoader
     {
         /// <summary>
+        ///     Whether sandboxing is currently enabled.
+        /// </summary>
+        bool SandboxingEnabled { get; }
+
+        /// <summary>
         ///     Loads all content assemblies from the specified resource directory and filename prefix.
         /// </summary>
         /// <param name="mountPath">The directory in which to look for assemblies.</param>

--- a/Robust.Shared/ContentPack/ModLoader.cs
+++ b/Robust.Shared/ContentPack/ModLoader.cs
@@ -34,7 +34,9 @@ namespace Robust.Shared.ContentPack
         private static int _modLoaderId;
 
         private bool _useLoadContext = true;
-        private bool _sandboxingEnabled;
+
+        /// <inheritdoc />
+        public bool SandboxingEnabled { get; private set; }
 
         public ModLoader()
         {
@@ -56,7 +58,7 @@ namespace Robust.Shared.ContentPack
 
         public void SetEnableSandboxing(bool sandboxing)
         {
-            _sandboxingEnabled = sandboxing;
+            SandboxingEnabled = sandboxing;
             Logger.DebugS("res", "{0} sandboxing", sandboxing ? "ENABLING" : "DISABLING");
         }
 
@@ -86,7 +88,7 @@ namespace Robust.Shared.ContentPack
                 }
             }
 
-            if (_sandboxingEnabled)
+            if (SandboxingEnabled)
             {
                 var checkerSw = Stopwatch.StartNew();
 
@@ -304,7 +306,7 @@ namespace Robust.Shared.ContentPack
 
                     // Do not allow sideloading when sandboxing is enabled.
                     // Side loaded assemblies would not be checked for sandboxing currently, so we can't have that.
-                    if (!_sandboxingEnabled)
+                    if (!SandboxingEnabled)
                     {
                         foreach (var assembly in _sideModules)
                         {
@@ -370,8 +372,8 @@ namespace Robust.Shared.ContentPack
         {
             return new(_res, Logger.GetSawmill("res.typecheck"))
             {
-                VerifyIL = _sandboxingEnabled,
-                DisableTypeCheck = !_sandboxingEnabled,
+                VerifyIL = SandboxingEnabled,
+                DisableTypeCheck = !SandboxingEnabled,
                 ExtraRobustLoader = VerifierExtraLoadHandler
             };
         }

--- a/Robust.Shared/IoC/DynamicTypeFactory.cs
+++ b/Robust.Shared/IoC/DynamicTypeFactory.cs
@@ -28,7 +28,7 @@ namespace Robust.Shared.IoC
         /// <param name="type">Type of object to instantiate.</param>
         /// <param name="args">The arguments to be passed to the constructor.</param>
         /// <returns>Newly created object.</returns>
-        object CreateInstance(Type type, object[] args);
+        object CreateInstance(Type type, object?[] args);
 
         /// <summary>
         ///     Constructs a new instance of the given type with Dependencies resolved.
@@ -54,7 +54,7 @@ namespace Robust.Shared.IoC
         /// <param name="type">Type of object to instantiate.</param>
         /// <param name="args">The arguments to be passed to the constructor.</param>
         /// <returns>Newly created object.</returns>
-        object CreateInstanceUnchecked(Type type, object[] args);
+        object CreateInstanceUnchecked(Type type, object?[] args);
 
         /// <summary>
         ///     Constructs a new instance of the given type with Dependencies resolved.
@@ -117,7 +117,7 @@ namespace Robust.Shared.IoC
         /// <param name="args">The arguments to pass to the constructor.</param>
         /// <typeparam name="T">The type that the instance will be cast to.</typeparam>
         /// <returns>Newly created object, cast to <typeparamref name="T"/>.</returns>
-        internal static T CreateInstanceUnchecked<T>(this IDynamicTypeFactoryInternal dynamicTypeFactory, Type type, object[] args)
+        internal static T CreateInstanceUnchecked<T>(this IDynamicTypeFactoryInternal dynamicTypeFactory, Type type, object?[] args)
         {
             DebugTools.Assert(typeof(T).IsAssignableFrom(type), "type must be subtype of T");
             return (T) dynamicTypeFactory.CreateInstanceUnchecked(type, args);
@@ -143,7 +143,7 @@ namespace Robust.Shared.IoC
             return CreateInstanceUnchecked(type);
         }
 
-        public object CreateInstance(Type type, object[] args)
+        public object CreateInstance(Type type, object?[] args)
         {
             if (!_modLoader.IsContentTypeAccessAllowed(type))
             {
@@ -175,7 +175,7 @@ namespace Robust.Shared.IoC
             return instance;
         }
 
-        public object CreateInstanceUnchecked(Type type, object[] args)
+        public object CreateInstanceUnchecked(Type type, object?[] args)
         {
             if (type == null)
                 throw new ArgumentNullException(nameof(type));

--- a/Robust.Shared/Reflection/IReflectionManager.cs
+++ b/Robust.Shared/Reflection/IReflectionManager.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 
 namespace Robust.Shared.Reflection
 {
@@ -111,5 +113,16 @@ namespace Robust.Shared.Reflection
         bool TryParseEnumReference(string reference, [NotNullWhen(true)] out Enum? @enum);
 
         Type? YamlTypeTagLookup(Type baseType, string typeName);
+
+        /// <summary>
+        ///     Changes a member's value in an object instance.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="member"></param>
+        /// <param name="value"></param>
+        /// <param name="uid"></param>
+        /// <param name="broadcast"></param>
+        void SetValue(object obj, string member, object? value, EntityUid uid = default);
+        internal void SetValueInternal(object obj, string member, object? value, EntityUid uid = default);
     }
 }

--- a/Robust.Shared/Reflection/ReflectRaiseEventAttribute.cs
+++ b/Robust.Shared/Reflection/ReflectRaiseEventAttribute.cs
@@ -1,0 +1,19 @@
+using System;
+using JetBrains.Annotations;
+
+namespace Robust.Shared.Reflection
+{
+    [MeansImplicitUse]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class ReflectRaiseEventAttribute : Attribute
+    {
+        public readonly Type EventType;
+        public readonly bool Broadcast;
+
+        public ReflectRaiseEventAttribute(Type eventType, bool broadcast = false)
+        {
+            EventType = eventType;
+            Broadcast = broadcast;
+        }
+    }
+}

--- a/Robust.UnitTesting/TestingModLoader.cs
+++ b/Robust.UnitTesting/TestingModLoader.cs
@@ -10,6 +10,9 @@ namespace Robust.UnitTesting
     {
         public Assembly[] Assemblies { get; set; } = Array.Empty<Assembly>();
 
+        // No sandboxing in here.
+        public bool SandboxingEnabled => false;
+
         public bool TryLoadModulesFrom(ResourcePath mountPath, string filterPrefix)
         {
             foreach (var assembly in Assemblies)


### PR DESCRIPTION
When you set members (fields and properties only) through ReflectionManager, it will check if they have the ReflectRaiseEvent attribute and if so raise an event. If you pass the entity uid, the event will be raised directed. If the attribute on your member has `broadcast` set to true, it will raise the event broadcast regardless of uid.
When an event is raised, the actual data in the member isn't modified, as we assume the event does so.
This makes VV able to raise events when it changes properties and fields that require it.

*VV seriously needs a rewrite, I swear...*

TODO:
- Change Animations to use this
- Tests