### PR TITLE
Add missing types to type conversion

### DIFF
--- a/Robust.Shared/Localization/LocalizationManager.Functions.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Functions.cs
@@ -259,7 +259,16 @@ namespace Robust.Shared.Localization
                 DateTime dateTime => new FluentLocWrapperType(new LocValueDateTime(dateTime)),
                 bool or Enum => (FluentString)obj.ToString()!.ToLowerInvariant(),
                 string str => (FluentString)str,
+                byte num => (FluentNumber)num,
+                sbyte num => (FluentNumber)num,
+                short num => (FluentNumber)num,
+                ushort num => (FluentNumber)num,
+                int num => (FluentNumber)num,
+                uint num => (FluentNumber)num,
+                long num => (FluentNumber)num,
+                ulong num => (FluentNumber)num,
                 double dbl => (FluentNumber)dbl,
+                float dbl => (FluentNumber)dbl,
                 _ => (FluentString)obj.ToString()!,
             };
         }

--- a/Robust.UnitTesting/Shared/Localization/LocalizationTests.cs
+++ b/Robust.UnitTesting/Shared/Localization/LocalizationTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
 using NUnit.Framework;
 using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
@@ -105,6 +107,12 @@ enum-match = { $enum ->
     *[bar] B
 }
 
+num-selector = { $num ->
+    [0] A
+    [1] B
+    *[2] C
+}
+
 ent-GenderTestEntityNoComp = Gender Test Entity
   .gender = male
   .otherAttrib = sausages
@@ -174,6 +182,48 @@ test-message-custom-attrib = { ATTRIB($entity, ""otherAttrib"") }
             });
         }
 
+        static IEnumerable<object[]> NumericTestSource()
+        {
+            const byte b1 = 0, b2 = 1, b3 = 5;
+            const sbyte sb1 = 0, sb2 = 1, sb3 = 5;
+            const short sh1 = 0, sh2 = 1, sh3 = 5;
+            const ushort ush1 = 0, ush2 = 1, ush3 = 5;
+            const int i1 = 0, i2 = 1, i3 = 5;
+            const uint ui1 = 0, ui2 = 1, ui3 = 5;
+            const long lng1 = 0, lng2 = 1, lng3 = 5;
+            const ulong ulng1 = 0, ulng2 = 1, ulng3 = 5;
+            const float f1 = 0, f2 = 1, f3 = 5;
+            const double d1 = 0, d2 = 1, d3 = 5;
+            
+            yield return new object[] { b1, b2, b3 };
+            yield return new object[] { sb1, sb2, sb3 };
+            yield return new object[] { sh1, sh2, sh3 };
+            yield return new object[] { ush1, ush2, ush3 };
+            yield return new object[] { i1, i2, i3 };
+            yield return new object[] { ui1, ui2, ui3 };
+            yield return new object[] { lng1, lng2, lng3 };
+            yield return new object[] { ulng1, ulng2, ulng3 };
+            yield return new object[] { f1, f2, f3 };
+            yield return new object[] { d1, d2, d3 };
+        }
+
+
+        [Test]
+        [TestCaseSource(nameof(NumericTestSource))]
+        public void TestNumbers(object o1, object o2, object o3)
+        {
+            // Small test to check numbers are being properly converted
+            var loc   = IoCManager.Resolve<ILocalizationManager>();
+            var func  = new Func<object, string>(x1 => loc.GetString("num-selector", ("num", x1)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(func(o1), Is.EqualTo("A"));
+                Assert.That(func(o2), Is.EqualTo("B"));
+                Assert.That(func(o3), Is.EqualTo("C"));
+            });
+        }
+
+        
         [Test]
         [TestCase("PropsInPrototype")]
         [TestCase("PropsInLoc")]


### PR DESCRIPTION
Problem:
![Image of code using Robust.Shared.Localization;
Loc.GetString("comp-gas-tank-examine", ("pressure", 1000.0))](https://cdn.discordapp.com/attachments/770682801607278632/853905575809515560/unknown.png)

Solution:
Right now Linguini doesn't understand that an int passed to it and defaults to `ToString()` impl. This PR adds those missing values and tests for that behavior.