### PR TITLE
Remove NetMessage deprecated boilerplate entirely

### DIFF
--- a/Robust.Shared/Network/INetManager.cs
+++ b/Robust.Shared/Network/INetManager.cs
@@ -116,23 +116,6 @@ namespace Robust.Shared.Network
         /// </summary>
         event EventHandler<NetDisconnectedArgs> Disconnect;
 
-        #region StringTable
-
-        /// <summary>
-        ///     Registers a NetMessage to be sent or received.
-        /// </summary>
-        /// <typeparam name="T">Type to register.</typeparam>
-        /// <param name="name">String ID of the message.</param>
-        /// <param name="rxCallback">Callback function to process the received message.</param>
-        /// <param name="accept">
-        /// The side of the network this message is accepted on.
-        /// If we are not on the side specified, the receive callback will not be registered even if provided.
-        /// </param>
-        [Obsolete("Use the method without a name argument instead")]
-        void RegisterNetMessage<T>(string name, ProcessMessage<T>? rxCallback = null,
-            NetMessageAccept accept = NetMessageAccept.Both)
-            where T : NetMessage;
-
         /// <summary>
         ///     Registers a NetMessage to be sent or received.
         /// </summary>
@@ -156,8 +139,5 @@ namespace Robust.Shared.Network
         /// <typeparam name="T">Type of NetMessage to send.</typeparam>
         /// <returns>Instance of the NetMessage.</returns>
         T CreateNetMessage<T>() where T : NetMessage;
-
-        #endregion StringTable
-
     }
 }

--- a/Robust.Shared/Network/Messages/MsgPlayerListReq.cs
+++ b/Robust.Shared/Network/Messages/MsgPlayerListReq.cs
@@ -1,7 +1,5 @@
 ﻿using Lidgren.Network;
 
-#nullable disable
-
 namespace Robust.Shared.Network.Messages
 {
     public class MsgPlayerListReq : NetMessage

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -902,10 +902,11 @@ namespace Robust.Shared.Network
         #region NetMessages
 
         /// <inheritdoc />
-        public void RegisterNetMessage<T>(string name, ProcessMessage<T>? rxCallback = null,
+        public void RegisterNetMessage<T>(ProcessMessage<T>? rxCallback = null,
             NetMessageAccept accept = NetMessageAccept.Both)
-            where T : NetMessage
+            where T : NetMessage, new()
         {
+            var name = new T().MsgName;
             var id = _strings.AddString(name);
 
             _messages.Add(name, typeof(T));
@@ -926,14 +927,6 @@ namespace Robust.Shared.Network
             // But it means the caching logic isn't behind a TryGetValue in CreateNetMessage<T>,
             // so it no thread safety crap.
             CacheBlankFunction(typeof(T));
-        }
-
-        /// <inheritdoc />
-        public void RegisterNetMessage<T>(ProcessMessage<T>? rxCallback = null,
-            NetMessageAccept accept = NetMessageAccept.Both)
-            where T : NetMessage, new()
-        {
-            RegisterNetMessage(new T().MsgName, rxCallback, accept);
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/Network/NetMessage.cs
+++ b/Robust.Shared/Network/NetMessage.cs
@@ -66,18 +66,6 @@ namespace Robust.Shared.Network
         /// </summary>
         public int MsgSize { get; set; }
 
-        /// <summary>
-        /// Constructs an instance of the NetMessage.
-        /// </summary>
-        /// <param name="name">String identifier of the message type.</param>
-        /// <param name="group">The group this message type belongs to.</param>
-        [Obsolete("Use NetMessageAttribute and no constructor instead")]
-        protected NetMessage(string name, MsgGroups group)
-        {
-            MsgName = name;
-            MsgGroup = group;
-        }
-
         protected NetMessage()
         {
             MsgName = GetType().Name;

--- a/Robust.Shared/Serialization/RobustMappedStringSerializer.cs
+++ b/Robust.Shared/Serialization/RobustMappedStringSerializer.cs
@@ -214,9 +214,9 @@ namespace Robust.Shared.Serialization
         /// <seealso cref="OnClientCompleteHandshake"/>
         private void NetworkInitialize()
         {
-            _net.RegisterNetMessage<MsgMapStrServerHandshake>(nameof(MsgMapStrServerHandshake), HandleServerHandshake, NetMessageAccept.Client);
-            _net.RegisterNetMessage<MsgMapStrClientHandshake>(nameof(MsgMapStrClientHandshake), HandleClientHandshake, NetMessageAccept.Server);
-            _net.RegisterNetMessage<MsgMapStrStrings>(nameof(MsgMapStrStrings), HandleStringsMessage, NetMessageAccept.Client);
+            _net.RegisterNetMessage<MsgMapStrServerHandshake>(HandleServerHandshake, NetMessageAccept.Client);
+            _net.RegisterNetMessage<MsgMapStrClientHandshake>(HandleClientHandshake, NetMessageAccept.Server);
+            _net.RegisterNetMessage<MsgMapStrStrings>(HandleStringsMessage, NetMessageAccept.Client);
 
             _net.Disconnect += NetOnDisconnect;
         }

--- a/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
@@ -272,19 +272,14 @@ namespace Robust.UnitTesting
             public event EventHandler<NetChannelArgs>? Connected;
             public event EventHandler<NetDisconnectedArgs>? Disconnect;
 
-            public void RegisterNetMessage<T>(string name, ProcessMessage<T>? rxCallback = null,
-                NetMessageAccept accept = NetMessageAccept.Both) where T : NetMessage
+            public void RegisterNetMessage<T>(ProcessMessage<T>? rxCallback = null, NetMessageAccept accept = NetMessageAccept.Both) where T : NetMessage, new()
             {
+                var name = new T().MsgName;
                 var thisSide = IsServer ? NetMessageAccept.Server : NetMessageAccept.Client;
 
                 _registeredMessages.Add(typeof(T));
                 if (rxCallback != null && (accept & thisSide) != 0)
                     _callbacks.Add(typeof(T), msg => rxCallback((T) msg));
-            }
-
-            public void RegisterNetMessage<T>(ProcessMessage<T>? rxCallback = null, NetMessageAccept accept = NetMessageAccept.Both) where T : NetMessage, new()
-            {
-                RegisterNetMessage(new T().MsgName, rxCallback, accept);
             }
 
             public T CreateNetMessage<T>() where T : NetMessage


### PR DESCRIPTION
Removes all boilerplate/obsoleted uses of netmessage constructors/nameof stuff deprecated in #1770

Requires space-wizards/space-station-14#4196