### PR TITLE
Adds ServerOptions, improve GameControllerOptions, fix engine integration tests

### DIFF
--- a/Robust.Client/ContentStart.cs
+++ b/Robust.Client/ContentStart.cs
@@ -7,13 +7,13 @@ namespace Robust.Client
 #if FULL_RELEASE
             throw new System.InvalidOperationException("ContentStart.Start is not available on a full release.");
 #else
-            GameController.Start(args, true);
+            GameController.Start(args, new GameControllerOptions(), true);
 #endif
         }
 
         public static void StartLibrary(string[] args, GameControllerOptions options)
         {
-            GameController.Start(args, true, null, options);
+            GameController.Start(args, options, true, null);
         }
     }
 }

--- a/Robust.Client/GameController/GameController.Loader.cs
+++ b/Robust.Client/GameController/GameController.Loader.cs
@@ -11,7 +11,7 @@ namespace Robust.Client
         {
             public void Main(IMainArgs args)
             {
-                Start(args.Args, contentStart: false, args);
+                Start(args.Args, new GameControllerOptions(), contentStart: false, args);
             }
         }
     }

--- a/Robust.Client/GameController/GameController.Standalone.cs
+++ b/Robust.Client/GameController/GameController.Standalone.cs
@@ -22,10 +22,10 @@ namespace Robust.Client
 
         public static void Main(string[] args)
         {
-            Start(args);
+            Start(args, new GameControllerOptions());
         }
 
-        public static void Start(string[] args, bool contentStart = false, IMainArgs? loaderArgs=null, GameControllerOptions? options = null)
+        public static void Start(string[] args, GameControllerOptions options, bool contentStart = false, IMainArgs? loaderArgs=null)
         {
             if (_hasStarted)
             {
@@ -40,7 +40,7 @@ namespace Robust.Client
             }
         }
 
-        private static void ParsedMain(CommandLineArgs args, bool contentStart, IMainArgs? loaderArgs, GameControllerOptions? options)
+        private static void ParsedMain(CommandLineArgs args, bool contentStart, IMainArgs? loaderArgs, GameControllerOptions options)
         {
             IoCManager.InitThread();
 
@@ -51,15 +51,13 @@ namespace Robust.Client
             var gc = IoCManager.Resolve<GameController>();
             gc.SetCommandLineArgs(args);
             gc._loaderArgs = loaderArgs;
-            if(options != null)
-                gc.Options = options;
 
             // When the game is ran with the startup executable being content,
             // we have to disable the separate load context.
             // Otherwise the content assemblies will be loaded twice which causes *many* fun bugs.
             gc.ContentStart = contentStart;
 
-            gc.Run(mode);
+            gc.Run(mode, options);
         }
 
         public void OverrideMainLoop(IGameLoop gameLoop)
@@ -67,9 +65,9 @@ namespace Robust.Client
             _mainLoop = gameLoop;
         }
 
-        public void Run(DisplayMode mode, Func<ILogHandler>? logHandlerFactory = null)
+        public void Run(DisplayMode mode, GameControllerOptions options, Func<ILogHandler>? logHandlerFactory = null)
         {
-            if (!StartupSystemSplash(logHandlerFactory))
+            if (!StartupSystemSplash(options, logHandlerFactory))
             {
                 Logger.Fatal("Failed to start game controller!");
                 return;

--- a/Robust.Client/IGameControllerInternal.cs
+++ b/Robust.Client/IGameControllerInternal.cs
@@ -10,8 +10,7 @@ namespace Robust.Client
         GameControllerOptions Options { get; }
         bool ContentStart { get; set; }
         void SetCommandLineArgs(CommandLineArgs args);
-        bool LoadConfigAndUserData { get; set; }
-        void Run(GameController.DisplayMode mode, Func<ILogHandler>? logHandlerFactory = null);
+        void Run(GameController.DisplayMode mode, GameControllerOptions options, Func<ILogHandler>? logHandlerFactory = null);
         void KeyDown(KeyEventArgs keyEvent);
         void KeyUp(KeyEventArgs keyEvent);
         void TextEntered(TextEventArgs textEvent);

--- a/Robust.Server/ContentStart.cs
+++ b/Robust.Server/ContentStart.cs
@@ -7,13 +7,13 @@ namespace Robust.Server
 #if FULL_RELEASE
             throw new System.InvalidOperationException("ContentStart.Start is not available on a full release.");
 #else
-            Program.Start(args, true);
+            Program.Start(args, new ServerOptions(), true);
 #endif
         }
 
-        public static void StartLibrary(string[] args)
+        public static void StartLibrary(string[] args, ServerOptions options)
         {
-            Program.Start(args, true);
+            Program.Start(args, options, true);
         }
     }
 }

--- a/Robust.Server/IBaseServer.cs
+++ b/Robust.Server/IBaseServer.cs
@@ -23,7 +23,7 @@ namespace Robust.Server
         ///     Sets up the server, loads the game, gets ready for client connections.
         /// </summary>
         /// <returns></returns>
-        bool Start(Func<ILogHandler>? logHandler = null);
+        bool Start(ServerOptions options, Func<ILogHandler>? logHandler = null);
 
         /// <summary>
         ///     Hard restarts the server, shutting it down, kicking all players, and starting the server again.
@@ -44,11 +44,10 @@ namespace Robust.Server
 
     internal interface IBaseServerInternal : IBaseServer
     {
+        ServerOptions Options { get; }
         bool ContentStart { set; }
-        bool LoadConfigAndUserData { set; }
 
         void OverrideMainLoop(IGameLoop gameLoop);
-
         void SetCommandLineArgs(CommandLineArgs args);
     }
 }

--- a/Robust.Server/Program.cs
+++ b/Robust.Server/Program.cs
@@ -21,10 +21,10 @@ namespace Robust.Server
 
         internal static void Main(string[] args)
         {
-            Start(args);
+            Start(args, new ServerOptions());
         }
 
-        internal static void Start(string[] args, bool contentStart = false)
+        internal static void Start(string[] args, ServerOptions options, bool contentStart = false)
         {
             if (_hasStarted)
             {
@@ -47,11 +47,11 @@ namespace Robust.Server
                     TaskCreationOptions.LongRunning,
                     TaskContinuationOptions.None,
                     RobustTaskScheduler.Instance
-                ).StartNew(() => ParsedMain(parsed, contentStart))
+                ).StartNew(() => ParsedMain(parsed, contentStart, options))
                 .GetAwaiter().GetResult();
         }
 
-        private static void ParsedMain(CommandLineArgs args, bool contentStart)
+        private static void ParsedMain(CommandLineArgs args, bool contentStart, ServerOptions options)
         {
             Thread.CurrentThread.Name = "Main Thread";
             IoCManager.InitThread();
@@ -67,7 +67,7 @@ namespace Robust.Server
 
             Logger.Info("Server -> Starting");
 
-            if (server.Start())
+            if (server.Start(options))
             {
                 Logger.Fatal("Server -> Can not start server");
                 //Not like you'd see this, haha. Perhaps later for logging.

--- a/Robust.Server/ServerOptions.cs
+++ b/Robust.Server/ServerOptions.cs
@@ -1,36 +1,20 @@
 using Robust.Shared;
 using Robust.Shared.Utility;
 
-namespace Robust.Client
+namespace Robust.Server
 {
-    public class GameControllerOptions
+    public class ServerOptions
     {
         /// <summary>
         ///     Whether content sandboxing will be enabled & enforced.
         /// </summary>
-        public bool Sandboxing { get; init; } = true;
+        public bool Sandboxing { get; init; } = false;
 
         // TODO: Expose mounting methods to games using Robust as a library.
         /// <summary>
         ///     Lists of mount options to mount.
         /// </summary>
         public MountOptions MountOptions { get; init; } = new();
-
-        /// <summary>
-        ///     Name the userdata directory will have.
-        /// </summary>
-        public string UserDataDirectoryName { get; init; } = "Space Station 14";
-
-        /// <summary>
-        ///     Name of the configuration file in the user data directory.
-        /// </summary>
-        public string ConfigFileName { get; init; } = "client_config.toml";
-
-        // TODO: Define engine branding from json file in resources.
-        /// <summary>
-        ///     Default window title.
-        /// </summary>
-        public string DefaultWindowTitle { get; init; } = "Space Station 14";
 
         /// <summary>
         ///     Assemblies with this prefix will be loaded.
@@ -40,7 +24,7 @@ namespace Robust.Client
         /// <summary>
         ///     Name of the content build directory, for game pack mounting purposes.
         /// </summary>
-        public string ContentBuildDirectory { get; init; } = "Content.Client";
+        public string ContentBuildDirectory { get; init; } = "Content.Server";
 
         /// <summary>
         ///     Directory to load all assemblies from.
@@ -66,10 +50,5 @@ namespace Robust.Client
         ///     Whether to load config and user data.
         /// </summary>
         public bool LoadConfigAndUserData { get; init; } = true;
-
-        /// <summary>
-        ///     Whether to disable command line args server auto-connecting.
-        /// </summary>
-        public bool DisableCommandLineConnect { get; init; } = false;
     }
 }

--- a/Robust.Shared/ProgramShared.cs
+++ b/Robust.Shared/ProgramShared.cs
@@ -12,6 +12,11 @@ namespace Robust.Shared
         {
             return contentStart ? "../../" : "../../../";
         }
+
+        private static string FindEngineRootDir(bool contentStart)
+        {
+            return contentStart ? "../../RobustToolbox/" : "../../";
+        }
 #endif
 
         internal static void PrintRuntimeInfo(ISawmill sawmill)
@@ -20,17 +25,21 @@ namespace Robust.Shared
             sawmill.Debug($"OS: {RuntimeInformation.OSDescription} {RuntimeInformation.OSArchitecture}");
         }
 
-        internal static void DoMounts(IResourceManagerInternal res, MountOptions? options, string contentBuildDir,
+        internal static void DoMounts(IResourceManagerInternal res, MountOptions? options, string contentBuildDir, ResourcePath assembliesPath, bool loadContentResources = true,
             bool loader = false, bool contentStart = false)
         {
 #if FULL_RELEASE
             if (!loader)
                 res.MountContentDirectory(@"Resources/");
 #else
-            var contentRootDir = FindContentRootDir(contentStart);
-            res.MountContentDirectory($@"{contentRootDir}RobustToolbox/Resources/");
-            res.MountContentDirectory($@"{contentRootDir}bin/{contentBuildDir}/", new ResourcePath("/Assemblies/"));
-            res.MountContentDirectory($@"{contentRootDir}Resources/");
+            res.MountContentDirectory($@"{FindEngineRootDir(contentStart)}Resources/");
+
+            if (loadContentResources)
+            {
+                var contentRootDir = FindContentRootDir(contentStart);
+                res.MountContentDirectory($@"{contentRootDir}bin/{contentBuildDir}/", assembliesPath);
+                res.MountContentDirectory($@"{contentRootDir}Resources/");
+            }
 #endif
 
             if (options == null)

--- a/Robust.UnitTesting/GameControllerDummy.cs
+++ b/Robust.UnitTesting/GameControllerDummy.cs
@@ -33,7 +33,7 @@ namespace Robust.UnitTesting
 
         public string? ContentRootDir { get; set; }
 
-        public void Run(GameController.DisplayMode mode, Func<ILogHandler>? logHandlerFactory = null)
+        public void Run(GameController.DisplayMode mode, GameControllerOptions options, Func<ILogHandler>? logHandlerFactory = null)
         {
         }
 

--- a/Robust.UnitTesting/RobustIntegrationTest.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.cs
@@ -17,6 +17,7 @@ using Robust.Shared;
 using Robust.Shared.Asynchronous;
 using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
+using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Network;
@@ -700,7 +701,7 @@ namespace Robust.UnitTesting
         public abstract class IntegrationOptions
         {
             public Action? InitIoC { get; set; }
-            public Action? BeforeStart { get; set; }
+            public virtual Action? BeforeStart { get; set; } = () => { IoCManager.Resolve<IComponentFactory>().DoAutoRegistrations(); };
             public Assembly[]? ContentAssemblies { get; set; }
             public string? ExtraPrototypes { get; set; }
             public LogLevel? FailureLogLevel { get; set; } = LogLevel.Error;

--- a/Robust.UnitTesting/RobustIntegrationTest.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.cs
@@ -573,7 +573,17 @@ namespace Robust.UnitTesting
                     }
                 }
 
-                cfg.OverrideConVars(new[] {(CVars.NetPredictLagBias.Name, "0")});
+                cfg.OverrideConVars(new[]
+                {
+                    (CVars.NetPredictLagBias.Name, "0"),
+
+                    // Connecting to Discord is a massive waste of time.
+                    // Basically just makes the CI logs a mess.
+                    (CVars.DiscordEnabled.Name, "false"),
+
+                    // Avoid preloading textures.
+                    (CVars.TexturePreloadingEnabled.Name, "false"),
+                });
 
                 GameLoop = new IntegrationGameLoop(DependencyCollection.Resolve<IGameTiming>(),
                     _fromInstanceWriter, _toInstanceReader);

--- a/Robust.UnitTesting/RobustIntegrationTest.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.cs
@@ -426,7 +426,12 @@ namespace Robust.UnitTesting
                 var serverOptions = _options != null ? _options.Options : new ServerOptions()
                 {
                     LoadConfigAndUserData = false,
+                    LoadContentResources = false,
                 };
+
+                // Autoregister components if options are null or we're NOT starting from content.
+                if(!_options?.ContentStart ?? true)
+                    IoCManager.Resolve<IComponentFactory>().DoAutoRegistrations();
 
                 if (_options?.ContentAssemblies != null)
                 {
@@ -544,6 +549,10 @@ namespace Robust.UnitTesting
                     LoadContentResources = false,
                     LoadConfigAndUserData = false,
                 };
+
+                // Autoregister components if options are null or we're NOT starting from content.
+                if(!_options?.ContentStart ?? true)
+                    IoCManager.Resolve<IComponentFactory>().DoAutoRegistrations();
 
                 if (_options?.ContentAssemblies != null)
                 {
@@ -701,7 +710,7 @@ namespace Robust.UnitTesting
         public abstract class IntegrationOptions
         {
             public Action? InitIoC { get; set; }
-            public virtual Action? BeforeStart { get; set; } = () => { IoCManager.Resolve<IComponentFactory>().DoAutoRegistrations(); };
+            public Action? BeforeStart { get; set; }
             public Assembly[]? ContentAssemblies { get; set; }
             public string? ExtraPrototypes { get; set; }
             public LogLevel? FailureLogLevel { get; set; } = LogLevel.Error;

--- a/Robust.UnitTesting/RobustIntegrationTest.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.cs
@@ -422,7 +422,10 @@ namespace Robust.UnitTesting
 
                 var server = DependencyCollection.Resolve<BaseServer>();
 
-                server.LoadConfigAndUserData = false;
+                var serverOptions = _options != null ? _options.Options : new ServerOptions()
+                {
+                    LoadConfigAndUserData = false,
+                };
 
                 if (_options?.ContentAssemblies != null)
                 {
@@ -447,7 +450,7 @@ namespace Robust.UnitTesting
 
                 var failureLevel = _options == null ? LogLevel.Error : _options.FailureLogLevel;
                 server.ContentStart = _options?.ContentStart ?? false;
-                if (server.Start(() => new TestLogHandler("SERVER", failureLevel)))
+                if (server.Start(serverOptions, () => new TestLogHandler("SERVER", failureLevel)))
                 {
                     throw new Exception("Server failed to start.");
                 }
@@ -535,12 +538,16 @@ namespace Robust.UnitTesting
 
                 var client = DependencyCollection.Resolve<GameController>();
 
+                var clientOptions = _options != null ? _options.Options : new GameControllerOptions()
+                {
+                    LoadContentResources = false,
+                    LoadConfigAndUserData = false,
+                };
+
                 if (_options?.ContentAssemblies != null)
                 {
                     IoCManager.Resolve<TestingModLoader>().Assemblies = _options.ContentAssemblies;
                 }
-
-                client.LoadConfigAndUserData = false;
 
                 var cfg = IoCManager.Resolve<IConfigurationManagerInternal>();
 
@@ -563,8 +570,8 @@ namespace Robust.UnitTesting
 
                 var failureLevel = _options == null ? LogLevel.Error : _options.FailureLogLevel;
                 client.OverrideMainLoop(GameLoop);
-                client.ContentStart = true;
-                client.StartupSystemSplash(() => new TestLogHandler("CLIENT", failureLevel));
+                client.ContentStart = _options?.ContentStart ?? false;
+                client.StartupSystemSplash(clientOptions, () => new TestLogHandler("CLIENT", failureLevel));
                 client.StartupContinue(GameController.DisplayMode.Headless);
 
                 GameLoop.RunInit();
@@ -674,10 +681,20 @@ namespace Robust.UnitTesting
 
         public class ServerIntegrationOptions : IntegrationOptions
         {
+            public virtual ServerOptions Options { get; set; } = new()
+            {
+                LoadConfigAndUserData = false,
+                LoadContentResources = false,
+            };
         }
 
         public class ClientIntegrationOptions : IntegrationOptions
         {
+            public virtual GameControllerOptions Options { get; set; } = new()
+            {
+                LoadContentResources = false,
+                LoadConfigAndUserData = false,
+            };
         }
 
         public abstract class IntegrationOptions

--- a/Robust.UnitTesting/Shared/EngineIntegrationTest_Test.cs
+++ b/Robust.UnitTesting/Shared/EngineIntegrationTest_Test.cs
@@ -1,0 +1,75 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Robust.Shared.Enums;
+using Robust.Shared.IoC;
+using Robust.Shared.Network;
+using IPlayerManager = Robust.Server.Player.IPlayerManager;
+
+namespace Robust.UnitTesting.Shared
+{
+    [TestFixture]
+    public class EngineIntegrationTest_Test : RobustIntegrationTest
+    {
+        [Test]
+        public void ServerStartsCorrectlyTest()
+        {
+            ServerIntegrationInstance? server = null;
+            Assert.DoesNotThrow(() => server = StartServer());
+            Assert.That(server, Is.Not.Null);
+        }
+
+        [Test]
+        public void ClientStartsCorrectlyTest()
+        {
+            ClientIntegrationInstance? client = null;
+            Assert.DoesNotThrow(() => client = StartClient());
+            Assert.That(client, Is.Not.Null);
+        }
+
+        [Test]
+        public async Task ServerClientPairConnectCorrectlyTest()
+        {
+            var server = StartServer();
+            var client = StartClient();
+
+            Assert.That(server, Is.Not.Null);
+            Assert.That(client, Is.Not.Null);
+
+            await Task.WhenAll(client.WaitIdleAsync(), server.WaitIdleAsync());
+
+            // Connect client to the server...
+            Assert.DoesNotThrow(() => client.SetConnectTarget(server));
+            client.Post(() => IoCManager.Resolve<IClientNetManager>().ClientConnect(null!, 0, null!));
+
+            // Run 10 synced ticks...
+            for (int i = 0; i < 10; i++)
+            {
+                await server.WaitRunTicks(1);
+                await client.WaitRunTicks(1);
+            }
+
+            await server.WaitAssertion(() =>
+            {
+                var playerManager = IoCManager.Resolve<IPlayerManager>();
+
+                // There must be a player connected.
+                Assert.That(playerManager.PlayerCount, Is.EqualTo(1));
+
+                // Get the only player...
+                var player = playerManager.GetAllPlayers()[0];
+
+                Assert.That(player.Status, Is.EqualTo(SessionStatus.Connected));
+                Assert.That(player.ConnectedClient.IsConnected, Is.True);
+            });
+
+            await client.WaitAssertion(() =>
+            {
+                var netManager = IoCManager.Resolve<IClientNetManager>();
+
+                Assert.That(netManager.IsConnected, Is.True);
+                Assert.That(netManager.ServerChannel, Is.Not.Null);
+                Assert.That(netManager.ServerChannel!.IsConnected, Is.True);
+            });
+        }
+    }
+}


### PR DESCRIPTION
Required by https://github.com/space-wizards/space-station-14/pull/4248

- Adds the ServerOptions class, useful for games using robust as library, or for specifying different server options.
- Adds a few new options to GameControllerOptions.
- Fixes integration tests in the engine! Now they don't load the content resources anymore, and they make use of client/server options.

Yup, this PR is one of these:
**DO NOT MERGE WITHOUT @PJB3005's EXPLICIT REVIEW AND APPROVAL.**
This changes some very important things in how the server/client launch... Including the loader API for the client so.