### PR TITLE
Make entitylookup grid-relative

### DIFF
--- a/Robust.Client/BaseClient.cs
+++ b/Robust.Client/BaseClient.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Net;
 using Robust.Client.Debugging;
 using Robust.Client.GameObjects;

--- a/Robust.Client/GameObjects/Components/RenderingTreeComponent.cs
+++ b/Robust.Client/GameObjects/Components/RenderingTreeComponent.cs
@@ -15,29 +15,43 @@ namespace Robust.Client.GameObjects
         private static Box2 SpriteAabbFunc(in SpriteComponent value)
         {
             var worldPos = value.Owner.Transform.WorldPosition;
-            return new Box2(worldPos, worldPos);
+            var tree = RenderingTreeSystem.GetRenderTree(value.Owner);
+
+            var pos = worldPos - tree?.Owner.Transform.WorldPosition ?? Vector2.Zero;
+
+            return new Box2(pos, pos);
         }
 
         private static Box2 LightAabbFunc(in PointLightComponent value)
         {
             var worldPos = value.Owner.Transform.WorldPosition;
-
+            var tree = RenderingTreeSystem.GetRenderTree(value.Owner);
             var boxSize = value.Radius * 2;
-            return Box2.CenteredAround(worldPos, (boxSize, boxSize));
+
+            var pos = worldPos - tree?.Owner.Transform.WorldPosition ?? Vector2.Zero;
+
+            return Box2.CenteredAround(pos, (boxSize, boxSize));
         }
 
         internal static Box2 SpriteAabbFunc(SpriteComponent value, Vector2? worldPos = null)
         {
             worldPos ??= value.Owner.Transform.WorldPosition;
+            var tree = RenderingTreeSystem.GetRenderTree(value.Owner);
 
-            return new Box2(worldPos.Value, worldPos.Value);
+            var pos = worldPos - tree?.Owner.Transform.WorldPosition ?? Vector2.Zero;
+
+            return new Box2(pos, pos);
         }
 
         internal static Box2 LightAabbFunc(PointLightComponent value, Vector2? worldPos = null)
         {
             worldPos ??= value.Owner.Transform.WorldPosition;
+            var tree = RenderingTreeSystem.GetRenderTree(value.Owner);
             var boxSize = value.Radius * 2;
-            return Box2.CenteredAround(worldPos.Value, (boxSize, boxSize));
+
+            var pos = worldPos - tree?.Owner.Transform.WorldPosition ?? Vector2.Zero;
+
+            return Box2.CenteredAround(pos, (boxSize, boxSize));
         }
     }
 }

--- a/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
@@ -41,22 +41,12 @@ namespace Robust.Client.GameObjects
         {
             if (mapId == MapId.Nullspace) yield break;
 
-            var enclosed = false;
-
             foreach (var grid in _mapManager.FindGridsIntersecting(mapId, worldAABB))
             {
                 yield return EntityManager.GetEntity(grid.GridEntityId).GetComponent<RenderingTreeComponent>();
-
-                // if we're enclosed then we know no other grids relevant + don't need the map's rendertree
-                if (grid.WorldBounds.Encloses(in worldAABB))
-                {
-                    enclosed = true;
-                    break;
-                }
             }
 
-            if (!enclosed)
-                yield return _mapManager.GetMapEntity(mapId).GetComponent<RenderingTreeComponent>();
+            yield return _mapManager.GetMapEntity(mapId).GetComponent<RenderingTreeComponent>();
         }
 
         internal IEnumerable<DynamicTree<SpriteComponent>> GetSpriteTrees(MapId mapId, Box2 worldAABB)
@@ -259,9 +249,8 @@ namespace Robust.Client.GameObjects
             EntityManager.GetEntity(_mapManager.GetGrid(gridId).GridEntityId).EnsureComponent<RenderingTreeComponent>();
         }
 
-        private RenderingTreeComponent? GetRenderTree(IEntity entity)
+        internal static RenderingTreeComponent? GetRenderTree(IEntity entity)
         {
-
             if (entity.Transform.MapID == MapId.Nullspace ||
                 entity.HasComponent<RenderingTreeComponent>()) return null;
 
@@ -302,8 +291,7 @@ namespace Robust.Client.GameObjects
                     continue;
                 }
 
-                var treePos = newMapTree?.Owner.Transform.WorldPosition ?? Vector2.Zero;
-                var aabb = RenderingTreeComponent.SpriteAabbFunc(sprite, worldPos).Translated(-treePos);
+                var aabb = RenderingTreeComponent.SpriteAabbFunc(sprite, worldPos);
 
                 // If we're on a new map then clear the old one.
                 if (oldMapTree != newMapTree)
@@ -348,7 +336,7 @@ namespace Robust.Client.GameObjects
                 }
 
                 var treePos = newMapTree?.Owner.Transform.WorldPosition ?? Vector2.Zero;
-                var aabb = RenderingTreeComponent.LightAabbFunc(light, worldPos).Translated(-treePos);
+                var aabb = RenderingTreeComponent.LightAabbFunc(light, worldPos);
 
                 // If we're on a new map then clear the old one.
                 if (oldMapTree != newMapTree)

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -227,6 +227,17 @@ namespace Robust.Shared
             CVarDef.Create("light.max_radius", 20.0f, CVar.CLIENTONLY);
 
         /*
+         * Lookup
+         */
+
+        /// <summary>
+        /// Like MaxLightRadius this is how far we enlarge lookups to find intersecting components.
+        /// This should be set to your maximum entity size.
+        /// </summary>
+        public static readonly CVarDef<float> LookupEnlargementRange =
+            CVarDef.Create("lookup.enlargement_range", 10.0f, CVar.ARCHIVE | CVar.REPLICATED | CVar.CHEAT);
+
+        /*
          * LOKI
          */
 

--- a/Robust.Shared/GameObjects/Components/EntityLookupComponent.cs
+++ b/Robust.Shared/GameObjects/Components/EntityLookupComponent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.Physics;
+
+namespace Robust.Shared.GameObjects
+{
+    [RegisterComponent]
+    public sealed class EntityLookupComponent : Component
+    {
+        public override string Name => "EntityLookup";
+
+        internal DynamicTree<IEntity> Tree = default!;
+    }
+}

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -400,7 +400,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public void ClearEventTables()
         {
-            _eventTables.ClearEntities();
+            _eventTables.Clear();
         }
 
         public void Dispose()

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.cs
@@ -185,6 +185,8 @@ namespace Robust.Shared.GameObjects
 
         private void HandleMapCreated(object? sender, MapEventArgs eventArgs)
         {
+            if (eventArgs.Map == MapId.Nullspace) return;
+
             _mapManager.GetMapEntity(eventArgs.Map).EnsureComponent<EntityLookupComponent>();
         }
 

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.cs
@@ -145,9 +145,6 @@ namespace Robust.Shared.GameObjects
             _handledThisTick.Clear();
             _parentChangeQueue.Clear();
 
-            _entityManager.EventBus.UnsubscribeEvents(this);
-            _entityManager.EventBus.UnsubscribeLocalEvent<EntityLookupComponent, ComponentInit>();
-            _entityManager.EventBus.UnsubscribeLocalEvent<EntityLookupComponent, ComponentShutdown>();
             _entityManager.EntityDeleted -= HandleEntityDeleted;
             _entityManager.EntityStarted -= HandleEntityStarted;
             _mapManager.MapCreated -= HandleMapCreated;

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.cs
@@ -134,6 +134,26 @@ namespace Robust.Shared.GameObjects
             Started = true;
         }
 
+        public void Shutdown()
+        {
+            // If we haven't even started up, there's nothing to clean up then.
+            if (!Started)
+                return;
+
+            _moveQueue.Clear();
+            _rotateQueue.Clear();
+            _handledThisTick.Clear();
+            _parentChangeQueue.Clear();
+
+            _entityManager.EventBus.UnsubscribeEvents(this);
+            _entityManager.EventBus.UnsubscribeLocalEvent<EntityLookupComponent, ComponentInit>();
+            _entityManager.EventBus.UnsubscribeLocalEvent<EntityLookupComponent, ComponentShutdown>();
+            _entityManager.EntityDeleted -= HandleEntityDeleted;
+            _entityManager.EntityStarted -= HandleEntityStarted;
+            _mapManager.MapCreated -= HandleMapCreated;
+            Started = false;
+        }
+
         private void HandleLookupShutdown(EntityUid uid, EntityLookupComponent component, ComponentShutdown args)
         {
             component.Tree.Clear();
@@ -153,24 +173,6 @@ namespace Robust.Shared.GameObjects
                 capacity: capacity,
                 growthFunc: x => x == GrowthRate ? GrowthRate * 8 : x + GrowthRate
             );
-        }
-
-        public void Shutdown()
-        {
-            // If we haven't even started up, there's nothing to clean up then.
-            if (!Started)
-                return;
-
-            _moveQueue.Clear();
-            _rotateQueue.Clear();
-            _handledThisTick.Clear();
-            _parentChangeQueue.Clear();
-
-            _entityManager.EventBus.UnsubscribeEvents(this);
-            _entityManager.EntityDeleted -= HandleEntityDeleted;
-            _entityManager.EntityStarted -= HandleEntityStarted;
-            _mapManager.MapCreated -= HandleMapCreated;
-            Started = false;
         }
 
         private void HandleEntityDeleted(object? sender, EntityUid uid)

--- a/Robust.UnitTesting/Client/GameObjects/Components/TransformComponentTests.cs
+++ b/Robust.UnitTesting/Client/GameObjects/Components/TransformComponentTests.cs
@@ -26,6 +26,7 @@ namespace Robust.UnitTesting.Client.GameObjects.Components
                 .RegisterComponents(factory =>
                 {
                     factory.RegisterClass<ContainerManagerComponent>();
+                    factory.RegisterClass<EntityLookupComponent>();
                 })
                 .InitializeInstance();
 

--- a/Robust.UnitTesting/Client/GameObjects/Components/TransformComponentTests.cs
+++ b/Robust.UnitTesting/Client/GameObjects/Components/TransformComponentTests.cs
@@ -26,7 +26,6 @@ namespace Robust.UnitTesting.Client.GameObjects.Components
                 .RegisterComponents(factory =>
                 {
                     factory.RegisterClass<ContainerManagerComponent>();
-                    factory.RegisterClass<EntityLookupComponent>();
                 })
                 .InitializeInstance();
 

--- a/Robust.UnitTesting/RobustUnitTest.cs
+++ b/Robust.UnitTesting/RobustUnitTest.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -86,9 +86,15 @@ namespace Robust.UnitTesting
 
             // Required components for the engine to work
             var compFactory = IoCManager.Resolve<IComponentFactory>();
+
             if (!compFactory.AllRegisteredTypes.Contains(typeof(MetaDataComponent)))
             {
                 compFactory.RegisterClass<MetaDataComponent>();
+            }
+
+            if (!compFactory.AllRegisteredTypes.Contains(typeof(EntityLookupComponent)))
+            {
+                compFactory.RegisterClass<EntityLookupComponent>();
             }
 
             if(entMan.EventBus == null)

--- a/Robust.UnitTesting/Server/RobustServerSimulation.cs
+++ b/Robust.UnitTesting/Server/RobustServerSimulation.cs
@@ -192,9 +192,9 @@ namespace Robust.UnitTesting.Server
             //Tier 2: Simulation
             container.Register<IEntityManager, EntityManager>();
             container.Register<IMapManager, MapManager>();
-            container.Register<IEntityLookup, EntityLookup>();
             container.Register<ISerializationManager, SerializationManager>();
             container.Register<IComponentManager, ComponentManager>();
+            container.Register<IEntityLookup, EntityLookup>();
             container.Register<IPrototypeManager, PrototypeManager>();
             container.Register<IComponentFactory, ComponentFactory>();
             container.Register<IComponentDependencyManager, ComponentDependencyManager>();
@@ -223,6 +223,7 @@ namespace Robust.UnitTesting.Server
             compFactory.RegisterClass<MapComponent>();
             compFactory.RegisterClass<MapGridComponent>();
             compFactory.RegisterClass<PhysicsComponent>();
+            compFactory.RegisterClass<EntityLookupComponent>();
 
             _regDelegate?.Invoke(compFactory);
 


### PR DESCRIPTION
As the scope of https://github.com/space-wizards/RobustToolbox/pull/1848 is now a cruise missile and includes shuttles this is the last blocker to having grids move performantly that I was stalling until I was ready.

Client perf has dropped marginally but we can look at fixing it when entity anchoring is stable.