### PR TITLE
ITileDefinition now has a Path string that ClydeTileDefinitionManager uses to load textures from

### DIFF
--- a/Robust.Client/Map/ClydeTileDefinitionManager.cs
+++ b/Robust.Client/Map/ClydeTileDefinitionManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
@@ -17,7 +18,7 @@ namespace Robust.Client.Map
         [Dependency] private readonly IResourceCache _resourceCache = default!;
 
         private Texture? _tileTextureAtlas;
-        
+
         public Texture TileTextureAtlas => _tileTextureAtlas ?? Texture.Transparent;
 
         private readonly Dictionary<ushort, Box2> _tileRegions = new();
@@ -61,7 +62,7 @@ namespace Robust.Client.Map
                 var row = i / dimensionX;
 
                 Image<Rgba32> image;
-                using (var stream = _resourceCache.ContentFileRead($"/Textures/Constructible/Tiles/{def.SpriteName}.png"))
+                using (var stream = _resourceCache.ContentFileRead(Path.Join(def.Path, $"{def.SpriteName}.png")))
                 {
                     image = Image.Load<Rgba32>(stream);
                 }

--- a/Robust.Shared/Map/ITileDefinition.cs
+++ b/Robust.Shared/Map/ITileDefinition.cs
@@ -26,6 +26,11 @@
         string SpriteName { get; }
 
         /// <summary>
+        ///     Path to the folder where the tile sprite is contained.
+        /// </summary>
+        string Path { get; }
+
+        /// <summary>
         ///     Physics objects that are interacting on this tile are slowed down by this float.
         /// </summary>
         float Friction { get; }


### PR DESCRIPTION
It's not longer hardcoded to "/Textures/Constructible/Tiles/" for every single damn Robust game, yay!