### PR TITLE
Fix IMapGrid WorldToLocal + LocalToWorld

### DIFF
--- a/Robust.Shared/Map/IMapGrid.cs
+++ b/Robust.Shared/Map/IMapGrid.cs
@@ -47,10 +47,9 @@ namespace Robust.Shared.Map
         /// </summary>
         Vector2 WorldPosition { get; set; }
 
-        /// <summary>
-        ///     The rotation of the grid relative to the world.
-        /// </summary>
-        Angle WorldRotation { get; set; }
+        Matrix3 WorldMatrix { get; }
+
+        Matrix3 InvWorldMatrix { get; }
 
         #region TileAccess
 

--- a/Robust.Shared/Map/IMapGrid.cs
+++ b/Robust.Shared/Map/IMapGrid.cs
@@ -47,6 +47,11 @@ namespace Robust.Shared.Map
         /// </summary>
         Vector2 WorldPosition { get; set; }
 
+        /// <summary>
+        ///     The rotation of the grid relative to the world.
+        /// </summary>
+        Angle WorldRotation { get; set; }
+
         #region TileAccess
 
         /// <summary>

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -112,6 +112,24 @@ namespace Robust.Shared.Map
             }
         }
 
+        /// <inheritdoc />
+        [ViewVariables]
+        public Angle WorldRotation
+        {
+            get
+            {
+                //TODO: Make grids real parents of entities.
+                if(GridEntityId.IsValid())
+                    return _mapManager.EntityManager.GetEntity(GridEntityId).Transform.WorldRotation;
+                return Angle.Zero;
+            }
+            set
+            {
+                _mapManager.EntityManager.GetEntity(GridEntityId).Transform.WorldRotation = value;
+                LastModifiedTick = _mapManager.GameTiming.CurTick;
+            }
+        }
+
         /// <summary>
         /// Expands the AABB for this grid when a new tile is added. If the tile is already inside the existing AABB,
         /// nothing happens. If it is outside, the AABB is expanded to fit the new tile.
@@ -489,7 +507,10 @@ namespace Robust.Shared.Map
         /// <inheritdoc />
         public Vector2 WorldToLocal(Vector2 posWorld)
         {
-            return posWorld - WorldPosition;
+            var worldPos = WorldPosition;
+            var worldRot = WorldRotation;
+            var relativePos = new Angle(-worldRot.Theta).RotateVec(posWorld - worldPos);
+            return relativePos + worldPos;
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -530,7 +530,11 @@ namespace Robust.Shared.Map
         /// <inheritdoc />
         public Vector2 LocalToWorld(Vector2 posLocal)
         {
-            return posLocal + WorldPosition;
+            var worldPos = WorldPosition;
+            var worldRot = WorldRotation;
+            // Rotate the point about our origin
+            var relativePos = new Angle(worldRot.Theta).RotateVec(posLocal);
+            return relativePos + worldPos;
         }
 
         public Vector2i WorldToTile(Vector2 posWorld)

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -114,19 +114,29 @@ namespace Robust.Shared.Map
 
         /// <inheritdoc />
         [ViewVariables]
-        public Angle WorldRotation
+        public Matrix3 WorldMatrix
         {
             get
             {
                 //TODO: Make grids real parents of entities.
                 if(GridEntityId.IsValid())
-                    return _mapManager.EntityManager.GetEntity(GridEntityId).Transform.WorldRotation;
-                return Angle.Zero;
+                    return _mapManager.EntityManager.GetEntity(GridEntityId).Transform.WorldMatrix;
+
+                return Matrix3.Identity;
             }
-            set
+        }
+
+        /// <inheritdoc />
+        [ViewVariables]
+        public Matrix3 InvWorldMatrix
+        {
+            get
             {
-                _mapManager.EntityManager.GetEntity(GridEntityId).Transform.WorldRotation = value;
-                LastModifiedTick = _mapManager.GameTiming.CurTick;
+                //TODO: Make grids real parents of entities.
+                if(GridEntityId.IsValid())
+                    return _mapManager.EntityManager.GetEntity(GridEntityId).Transform.InvWorldMatrix;
+
+                return Matrix3.Identity;
             }
         }
 
@@ -507,10 +517,7 @@ namespace Robust.Shared.Map
         /// <inheritdoc />
         public Vector2 WorldToLocal(Vector2 posWorld)
         {
-            var worldPos = WorldPosition;
-            var worldRot = WorldRotation;
-            var relativePos = new Angle(-worldRot.Theta).RotateVec(posWorld - worldPos);
-            return relativePos + worldPos;
+            return InvWorldMatrix.Transform(posWorld);
         }
 
         /// <inheritdoc />
@@ -530,11 +537,7 @@ namespace Robust.Shared.Map
         /// <inheritdoc />
         public Vector2 LocalToWorld(Vector2 posLocal)
         {
-            var worldPos = WorldPosition;
-            var worldRot = WorldRotation;
-            // Rotate the point about our origin
-            var relativePos = new Angle(worldRot.Theta).RotateVec(posLocal);
-            return relativePos + worldPos;
+            return WorldMatrix.Transform(posLocal);
         }
 
         public Vector2i WorldToTile(Vector2 posWorld)

--- a/Robust.UnitTesting/Shared/Map/GridRotation_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/GridRotation_Tests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+
+namespace Robust.UnitTesting.Shared.Map
+{
+    [TestFixture]
+    public class GridRotation_Tests : RobustIntegrationTest
+    {
+        // Because integration tests are ten billion percent easier we'll just do all the rotation tests here.
+        // These are mainly looking out for situations where the grid is rotated 90 / 180 degrees and we
+        // need rotate poinst about the grid's origin which is a /very/ common source of bugs.
+
+        [Test]
+        public async Task Test()
+        {
+            var server = StartServer();
+
+            await server.WaitIdleAsync();
+
+            var entMan = server.ResolveDependency<IEntityManager>();
+            var mapMan = server.ResolveDependency<IMapManager>();
+
+            await server.WaitAssertion(() =>
+            {
+                var mapId = mapMan.CreateMap();
+                var grid = mapMan.CreateGrid(mapId);
+                var gridEnt = entMan.GetEntity(grid.GridEntityId);
+                var coordinates = new EntityCoordinates(gridEnt.Uid, new Vector2(10, 0));
+
+                // if no rotation and 0,0 position should just be the same coordinate.
+                Assert.That(gridEnt.Transform.WorldRotation, Is.EqualTo(Angle.Zero));
+                Assert.That(grid.WorldToLocal(coordinates.Position), Is.EqualTo(coordinates.Position));
+
+                // Rotate 180 degrees should show -10, 0 for the position in map-terms and 10, 0 for the position in entity terms (i.e. no change).
+                gridEnt.Transform.WorldRotation += new Angle(MathF.PI);
+                Assert.That(gridEnt.Transform.WorldRotation, Is.EqualTo(new Angle(MathF.PI)));
+                // Check the map coordinate rotates correctly
+                Assert.That(grid.WorldToLocal(new Vector2(10, 0)).EqualsApprox(new Vector2(-10, 0)));
+                Assert.That(grid.LocalToWorld(coordinates.Position).EqualsApprox(new Vector2(-10, 0)));
+
+                // Now we'll do the same for 180 degrees.
+                gridEnt.Transform.WorldRotation += MathF.PI / 2f;
+                // If grid facing down then worldpos of 10, 0 gets rotated 90 degrees CCW and hence should be 0, 10
+                Assert.That(grid.WorldToLocal(new Vector2(10, 0)).EqualsApprox(new Vector2(0, 10)));
+                // If grid facing down then local 10,0 pos should just return 0, -10 given it's aligned with the rotation.
+                Assert.That(grid.LocalToWorld(coordinates.Position).EqualsApprox(new Vector2(0, -10)));
+            });
+        }
+    }
+}

--- a/Robust.UnitTesting/Shared/Map/GridRotation_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/GridRotation_Tests.cs
@@ -12,7 +12,7 @@ namespace Robust.UnitTesting.Shared.Map
     {
         // Because integration tests are ten billion percent easier we'll just do all the rotation tests here.
         // These are mainly looking out for situations where the grid is rotated 90 / 180 degrees and we
-        // need rotate poinst about the grid's origin which is a /very/ common source of bugs.
+        // need to rotate points about the grid's origin which is a /very/ common source of bugs.
 
         [Test]
         public async Task Test()


### PR DESCRIPTION
I noticed this from the F3 menu on my rotated grids branch as it was the reason context menus don't work on rotated grids (amongst other things). I talked to Vera and we agreed that a -10,0 EntityCoordinate should remain -10,0 even if the grid is flipped 180 degrees.

Hence we need to account for the grid's rotation when returning WorldToLocal + LocalToWorld points.