### PR TITLE
Don't use DeferMoveEvent if the position is NaN

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -734,7 +734,7 @@ namespace Robust.Shared.GameObjects
 
                 var newParentId = newState.ParentID;
                 var rebuildMatrices = false;
-                if (Parent?.Owner?.Uid != newParentId)
+                if (Parent?.Owner.Uid != newParentId)
                 {
                     if (newParentId != _parent)
                     {

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Robust.Shared.IoC;
+using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 
@@ -68,7 +69,13 @@ namespace Robust.Shared.GameObjects
                     if (ev.Sender.Deleted)
                         continue;
 
-                    RaiseLocalEvent(ev);
+                    // Hopefully we can remove this when PVS gets updated to not use NaNs
+                    if (!ev.NewPosition.IsValid(EntityManager))
+                    {
+                        continue;
+                    }
+
+                    RaiseLocalEvent(ev.Sender.Uid, ev);
                 }
             }
         }

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -125,8 +125,7 @@ namespace Robust.Shared.Physics
 
             while (_queuedMoves.TryDequeue(out var move))
             {
-                if (!_handledThisTick.Add(move.Sender.Uid) ||
-                    move.Sender.Deleted ||
+                if (move.Sender.Deleted ||
                     !move.Sender.TryGetComponent(out PhysicsComponent? body) ||
                     !body.CanCollide) continue;
 


### PR DESCRIPTION
The issue is that currently moving around means any non-anchored entities have their positions updated to / from NaN. As you can imagine this is a performance nightmare for anything subscribing to it, especially considering it leads to the broadphase getting desynced for physics when anchoring (currently) OR broadphase performance tanking the client due to contacts never stopping their overlap (at least without adding specific NaN handlers everywhere for this which is FUN).

Realistically we need one of the alternatives Acruid has laid out because I can't foresee a sane solution to keep the broadphase up to date without adding hacks for it.

Fixes: https://github.com/space-wizards/RobustToolbox/issues/1893

I'd suggest not merging without acruid / PJB's approval.

@Acruid 