### PR TITLE
Multi-thread physics contacts

### DIFF
--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -353,7 +353,7 @@ namespace Robust.Shared
 
         // - Contacts
         public static readonly CVarDef<int> ContactMultithreadThreshold =
-            CVarDef.Create("physics.contact_multithread_threshold", 16);
+            CVarDef.Create("physics.contact_multithread_threshold", 32);
 
         public static readonly CVarDef<int> ContactMinimumThreads =
             CVarDef.Create("physics.contact_minimum_threads", 2);

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -351,6 +351,13 @@ namespace Robust.Shared
          * PHYSICS
          */
 
+        // - Contacts
+        public static readonly CVarDef<int> ContactMultithreadThreshold =
+            CVarDef.Create("physics.contact_multithread_threshold", 16);
+
+        public static readonly CVarDef<int> ContactMinimumThreads =
+            CVarDef.Create("physics.contact_minimum_threads", 2);
+
         // - Sleep
         public static readonly CVarDef<float> AngularSleepTolerance =
             CVarDef.Create("physics.angsleeptol", 2.0f / 180.0f * MathF.PI);

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -366,10 +366,10 @@ namespace Robust.Shared.GameObjects
             _physicsManager.ClearTransforms();
         }
 
-        internal static (int Batches, int BatchSize) GetBatch(int count, int minimumThreads)
+        internal static (int Batches, int BatchSize) GetBatch(int count, int minimumBatchSize)
         {
             // Deduct 1 for networking thread I guess?
-            var batches = Math.Min((int) MathF.Floor((float) count / minimumThreads), Math.Max(1, Environment.ProcessorCount - 1));
+            var batches = Math.Min((int) MathF.Floor((float) count / minimumBatchSize), Math.Max(1, Environment.ProcessorCount - 1));
             var batchSize = (int) MathF.Ceiling((float) count / batches);
 
             return (batches, batchSize);

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -210,6 +210,7 @@ namespace Robust.Shared.GameObjects
             var map = _maps[eventArgs.Map];
             map.ContactManager.KinematicControllerCollision -= KinematicControllerCollision;
 
+            map.Shutdown();
             _maps.Remove(eventArgs.Map);
             Logger.DebugS("physics", $"Destroyed physics map for {eventArgs.Map}");
         }
@@ -355,6 +356,15 @@ namespace Robust.Shared.GameObjects
                 if (mapId == MapId.Nullspace) continue;
                 map.ProcessQueue();
             }
+        }
+
+        internal static (int Batches, int BatchSize) GetBatch(int count, int minimumThreads)
+        {
+            // Deduct 1 for networking thread I guess?
+            var batches = Math.Min((int) MathF.Floor((float) count / minimumThreads), Math.Max(1, Environment.ProcessorCount - 1));
+            var batchSize = (int) MathF.Ceiling((float) count / batches);
+
+            return (batches, batchSize);
         }
     }
 }

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -368,8 +368,7 @@ namespace Robust.Shared.GameObjects
 
         internal static (int Batches, int BatchSize) GetBatch(int count, int minimumBatchSize)
         {
-            // Deduct 1 for networking thread I guess?
-            var batches = Math.Min((int) MathF.Floor((float) count / minimumBatchSize), Math.Max(1, Environment.ProcessorCount - 1));
+            var batches = Math.Min((int) MathF.Floor((float) count / minimumBatchSize), Math.Max(1, Environment.ProcessorCount));
             var batchSize = (int) MathF.Ceiling((float) count / batches);
 
             return (batches, batchSize);

--- a/Robust.Shared/Physics/Collision/Collision.cs
+++ b/Robust.Shared/Physics/Collision/Collision.cs
@@ -364,6 +364,7 @@ namespace Robust.Shared.Physics.Collision
         private class EPCollider
         {
             private float _polygonRadius;
+            private float _angularSlop;
 
             private TempPolygon _polygonB;
 
@@ -379,6 +380,7 @@ namespace Robust.Shared.Physics.Collision
             internal EPCollider(IConfigurationManager configManager)
             {
                 _polygonRadius = configManager.GetCVar(CVars.PolygonRadius);
+                _angularSlop = configManager.GetCVar(CVars.AngularSlop);
                 _polygonB = new TempPolygon(configManager);
             }
 
@@ -639,7 +641,7 @@ namespace Robust.Shared.Physics.Collision
                     primaryAxis = edgeAxis;
                 }
 
-                ClipVertex[] ie = new ClipVertex[2];
+                Span<ClipVertex> ie = stackalloc ClipVertex[2];
                 ReferenceFace rf;
                 if (primaryAxis.Type == EPAxisType.EdgeA)
                 {
@@ -837,19 +839,17 @@ namespace Robust.Shared.Physics.Collision
                         return axis;
                     }
 
-                    var angularSlop = IoCManager.Resolve<IConfigurationManager>().GetCVar(CVars.LinearSlop);
-
                     // Adjacency
                     if (Vector2.Dot(n, perp) >= 0.0f)
                     {
-                        if (Vector2.Dot(n - _upperLimit, _normal) < -angularSlop)
+                        if (Vector2.Dot(n - _upperLimit, _normal) < -_angularSlop)
                         {
                             continue;
                         }
                     }
                     else
                     {
-                        if (Vector2.Dot(n - _lowerLimit, _normal) < -angularSlop)
+                        if (Vector2.Dot(n - _lowerLimit, _normal) < -_angularSlop)
                         {
                             continue;
                         }

--- a/Robust.Shared/Physics/Collision/Collision.cs
+++ b/Robust.Shared/Physics/Collision/Collision.cs
@@ -87,8 +87,6 @@ namespace Robust.Shared.Physics.Collision
          * should also profile just using FixedArray2 / FixedArray3
          */
 
-        private DistanceInput _input = new();
-
         /// <summary>
         /// Test overlap between the two shapes.
         /// </summary>
@@ -102,15 +100,16 @@ namespace Robust.Shared.Physics.Collision
         bool ICollisionManager.TestOverlap(IPhysShape shapeA, int indexA, IPhysShape shapeB, int indexB,
             in Transform xfA, in Transform xfB)
         {
-            _input.ProxyA.Set(shapeA, indexA);
-            _input.ProxyB.Set(shapeB, indexB);
-            _input.TransformA = xfA;
-            _input.TransformB = xfB;
-            _input.UseRadii = true;
+            // TODO: Make this a struct.
+            var input = new DistanceInput();
 
-            SimplexCache cache;
-            DistanceOutput output;
-            DistanceManager.ComputeDistance(out output, out cache, _input);
+            input.ProxyA.Set(shapeA, indexA);
+            input.ProxyB.Set(shapeB, indexB);
+            input.TransformA = xfA;
+            input.TransformB = xfB;
+            input.UseRadii = true;
+
+            DistanceManager.ComputeDistance(out var output, out _, input);
 
             return output.Distance < 10.0f * float.Epsilon;
         }

--- a/Robust.Shared/Physics/Dynamics/ContactManager.cs
+++ b/Robust.Shared/Physics/Dynamics/ContactManager.cs
@@ -450,7 +450,7 @@ namespace Robust.Shared.Physics.Dynamics
         {
             if (count > _contactMultithreadThreshold * _contactMinimumThreads)
             {
-                var (batches, batchSize) = SharedPhysicsSystem.GetBatch(count, _contactMinimumThreads);
+                var (batches, batchSize) = SharedPhysicsSystem.GetBatch(count, _contactMultithreadThreshold);
 
                 Parallel.For(0, batches, i =>
                 {

--- a/Robust.Shared/Physics/Dynamics/ContactManager.cs
+++ b/Robust.Shared/Physics/Dynamics/ContactManager.cs
@@ -60,8 +60,8 @@ namespace Robust.Shared.Physics.Dynamics
         /// </summary>
         internal event Action<Fixture, Fixture, float, Vector2>? KinematicControllerCollision;
 
-        private int _contactMultithreadThreshold = 16;
-        private int _contactMinimumThreads = 2;
+        private int _contactMultithreadThreshold;
+        private int _contactMinimumThreads;
 
         // TODO: Also need to clean the station up to not have 160 contacts on roundstart
 

--- a/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
+++ b/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
@@ -275,8 +275,8 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
             PhysicsComponent bodyB = FixtureB?.Body!;
             IPhysShape shapeA = FixtureA?.Shape!;
             IPhysShape shapeB = FixtureB?.Shape!;
-            var bodyATransform = physicsManager.GetTransform(bodyA);
-            var bodyBTransform = physicsManager.GetTransform(bodyB);
+            var bodyATransform = physicsManager.GetOrCreateTransform(bodyA);
+            var bodyBTransform = physicsManager.GetOrCreateTransform(bodyB);
 
             ContactSolver.InitializeManifold(ref Manifold, bodyATransform, bodyBTransform, shapeA.Radius, shapeB.Radius, out normal, points);
         }
@@ -286,7 +286,7 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
         /// Note: do not assume the fixture AABBs are overlapping or are valid.
         /// </summary>
         /// <returns>What current status of the contact is (e.g. start touching, end touching, etc.)</returns>
-        internal ContactStatus Update()
+        internal ContactStatus Update(IPhysicsManager physicsManager)
         {
             PhysicsComponent bodyA = FixtureA!.Body;
             PhysicsComponent bodyB = FixtureB!.Body;

--- a/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
+++ b/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
@@ -279,8 +279,8 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
             PhysicsComponent bodyB = FixtureB?.Body!;
             IPhysShape shapeA = FixtureA?.Shape!;
             IPhysShape shapeB = FixtureB?.Shape!;
-            var bodyATransform = physicsManager.GetOrCreateTransform(bodyA);
-            var bodyBTransform = physicsManager.GetOrCreateTransform(bodyB);
+            var bodyATransform = physicsManager.EnsureTransform(bodyA);
+            var bodyBTransform = physicsManager.EnsureTransform(bodyB);
 
             ContactSolver.InitializeManifold(ref Manifold, bodyATransform, bodyBTransform, shapeA.Radius, shapeB.Radius, out normal, points);
         }

--- a/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
+++ b/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
@@ -283,7 +283,8 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
         /// Update the contact manifold and touching status.
         /// Note: do not assume the fixture AABBs are overlapping or are valid.
         /// </summary>
-        internal void Update(List<Contact> startCollisions, List<Contact> endCollisions)
+        /// <returns>What current status of the contact is (e.g. start touching, end touching, etc.)</returns>
+        internal ContactStatus Update()
         {
             PhysicsComponent bodyA = FixtureA!.Body;
             PhysicsComponent bodyB = FixtureB!.Body;
@@ -318,7 +319,7 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
 
                 // Match old contact ids to new contact ids and copy the
                 // stored impulses to warm start the solver.
-                for (int i = 0; i < Manifold.PointCount; ++i)
+                for (var i = 0; i < Manifold.PointCount; ++i)
                 {
                     var mp2 = Manifold.Points[i];
                     mp2.NormalImpulse = 0.0f;
@@ -348,28 +349,31 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
             }
 
             IsTouching = touching;
+            var status = ContactStatus.NoContact;
 
             if (!wasTouching)
             {
                 if (touching)
                 {
-                    startCollisions.Add(this);
+                    status = ContactStatus.StartTouching;
                 }
             }
             else
             {
                 if (!touching)
                 {
-                    endCollisions.Add(this);
+                    status = ContactStatus.EndTouching;
                 }
             }
 
-            if (sensor)
-                return;
-
 #if DEBUG
-            _debugPhysics.HandlePreSolve(this, oldManifold);
+            if (!sensor)
+            {
+                _debugPhysics.HandlePreSolve(this, oldManifold);
+            }
 #endif
+
+            return status;
         }
 
         /// <summary>

--- a/Robust.Shared/Physics/Dynamics/PhysicsIsland.cs
+++ b/Robust.Shared/Physics/Dynamics/PhysicsIsland.cs
@@ -326,7 +326,7 @@ stored in a single array since multiple arrays lead to multiple misses.
                 var body = Bodies[i];
 
                 // Didn't use the old variable names because they're hard to read
-                var transform = _physicsManager.GetOrCreateTransform(body);
+                var transform = _physicsManager.EnsureTransform(body);
                 var position = transform.Position;
                 // DebugTools.Assert(!float.IsNaN(position.X) && !float.IsNaN(position.Y));
                 var angle = transform.Quaternion2D.Angle;

--- a/Robust.Shared/Physics/Dynamics/PhysicsIsland.cs
+++ b/Robust.Shared/Physics/Dynamics/PhysicsIsland.cs
@@ -326,7 +326,7 @@ stored in a single array since multiple arrays lead to multiple misses.
                 var body = Bodies[i];
 
                 // Didn't use the old variable names because they're hard to read
-                var transform = _physicsManager.GetTransform(body);
+                var transform = _physicsManager.GetOrCreateTransform(body);
                 var position = transform.Position;
                 // DebugTools.Assert(!float.IsNaN(position.X) && !float.IsNaN(position.Y));
                 var angle = transform.Quaternion2D.Angle;

--- a/Robust.Shared/Physics/Dynamics/PhysicsMap.cs
+++ b/Robust.Shared/Physics/Dynamics/PhysicsMap.cs
@@ -37,9 +37,7 @@ namespace Robust.Shared.Physics.Dynamics
 {
     public sealed class PhysicsMap
     {
-        [Dependency] private readonly IConfigurationManager _configManager = default!;
         [Dependency] private readonly IEntityManager _entityManager = default!;
-        [Dependency] private readonly IMapManager _mapManager = default!;
         [Dependency] private readonly IIslandManager _islandManager = default!;
 
         private SharedPhysicsSystem _physicsSystem = default!;
@@ -134,8 +132,21 @@ namespace Robust.Shared.Physics.Dynamics
             ContactManager.Initialize();
             ContactManager.MapId = MapId;
 
-            _autoClearForces = _configManager.GetCVar(CVars.AutoClearForces);
-            _configManager.OnValueChanged(CVars.AutoClearForces, value => _autoClearForces = value);
+            var configManager = IoCManager.Resolve<IConfigurationManager>();
+            configManager.OnValueChanged(CVars.AutoClearForces, OnAutoClearChange, true);
+        }
+
+        public void Shutdown()
+        {
+            ContactManager.Shutdown();
+
+            var configManager = IoCManager.Resolve<IConfigurationManager>();
+            configManager.UnsubValueChanged(CVars.AutoClearForces, OnAutoClearChange);
+        }
+
+        private void OnAutoClearChange(bool value)
+        {
+            _autoClearForces = value;
         }
 
         #region AddRemove

--- a/Robust.Shared/Physics/PhysicsManager.cs
+++ b/Robust.Shared/Physics/PhysicsManager.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Robust.Shared.GameObjects;
 
 namespace Robust.Shared.Physics
@@ -12,7 +12,7 @@ namespace Robust.Shared.Physics
 
         public bool CreateTransform(PhysicsComponent body);
 
-        public Transform GetOrCreateTransform(PhysicsComponent body);
+        public Transform EnsureTransform(PhysicsComponent body);
 
         /// <summary>
         /// Get a cached transform for physics use.
@@ -38,7 +38,7 @@ namespace Robust.Shared.Physics
             return true;
         }
 
-        public Transform GetOrCreateTransform(PhysicsComponent body)
+        public Transform EnsureTransform(PhysicsComponent body)
         {
             CreateTransform(body);
             return _transforms[body];

--- a/Robust.Shared/Physics/PhysicsManager.cs
+++ b/Robust.Shared/Physics/PhysicsManager.cs
@@ -10,8 +10,12 @@ namespace Robust.Shared.Physics
         /// </summary>
         void ClearTransforms();
 
+        public bool CreateTransform(PhysicsComponent body);
+
+        public Transform GetOrCreateTransform(PhysicsComponent body);
+
         /// <summary>
-        /// Get / create a cached transform for physics use.
+        /// Get a cached transform for physics use.
         /// </summary>
         public Transform GetTransform(PhysicsComponent body);
     }
@@ -26,18 +30,24 @@ namespace Robust.Shared.Physics
             _transforms.Clear();
         }
 
+        public bool CreateTransform(PhysicsComponent body)
+        {
+            if (_transforms.ContainsKey(body)) return false;
+
+            _transforms[body] = body.GetTransform();
+            return true;
+        }
+
+        public Transform GetOrCreateTransform(PhysicsComponent body)
+        {
+            CreateTransform(body);
+            return _transforms[body];
+        }
+
         /// <inheritdoc />
         public Transform GetTransform(PhysicsComponent body)
         {
-            if (_transforms.TryGetValue(body, out var transform))
-            {
-                return transform;
-            }
-
-            transform = body.GetTransform();
-            _transforms[body] = transform;
-
-            return transform;
+            return _transforms[body];
         }
     }
 }


### PR DESCRIPTION
I'd also recommend any reviewer suss out ICollisionManager but it should be thread-safe (assuming GetCvar is).

I also removed the start + end collision lists as I can just use the contact array now instead as the update returns a byte instead of updating the list directly.

I haven't done proper benchmarking but it was roughly a 2x speedup on the pyramid testbed (it drops my framerate from 300 to only 150 now and I profiled with DotTrace). With the transform caching PR + if we could SIMD the Transform.Mul / Transform.MulT methods Collide() would be BTFO.

Fixes https://github.com/space-wizards/RobustToolbox/pull/1897