### PR TITLE
Fix potential SetTile crash when it unanchors entities

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -42,6 +42,8 @@ namespace Robust.Shared.GameObjects
 
             foreach (var ent in anchoredEnts.ToList()) // changing anchored modifies this set
             {
+                if (!EntityManager.EntityExists(ent)) continue;
+
                 ComponentManager.GetComponent<TransformComponent>(ent).Anchored = false;
             }
         }


### PR DESCRIPTION
Was happening infrequently with singularity