### PR TITLE
RaiseLocalEvent non-generic overload that checks for GetType()

### DIFF
--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -12,7 +12,7 @@ namespace Robust.Shared.GameObjects
         void RaiseLocalEvent<TEvent>(EntityUid uid, TEvent args, bool broadcast = true)
             where TEvent:EntityEventArgs;
 
-        public void RaiseLocalEvent(EntityUid uid, EntityEventArgs args, bool broadcast = true);
+        void RaiseLocalEvent(EntityUid uid, EntityEventArgs args, bool broadcast = true);
 
         void SubscribeLocalEvent<TComp, TEvent>(ComponentEventHandler<TComp, TEvent> handler)
             where TComp : IComponent

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -12,6 +12,8 @@ namespace Robust.Shared.GameObjects
         void RaiseLocalEvent<TEvent>(EntityUid uid, TEvent args, bool broadcast = true)
             where TEvent:EntityEventArgs;
 
+        public void RaiseLocalEvent(EntityUid uid, EntityEventArgs args, bool broadcast = true);
+
         void SubscribeLocalEvent<TComp, TEvent>(ComponentEventHandler<TComp, TEvent> handler)
             where TComp : IComponent
             where TEvent : EntityEventArgs;
@@ -76,6 +78,24 @@ namespace Robust.Shared.GameObjects
             }
 
             _eventTables.Dispatch(uid, typeof(TEvent), args);
+
+            // we also broadcast it so the call site does not have to.
+            if(broadcast)
+                RaiseEvent(EventSource.Local, args);
+        }
+
+        /// <inheritdoc />
+        public void RaiseLocalEvent(EntityUid uid, EntityEventArgs args, bool broadcast = true)
+        {
+            var type = args.GetType();
+
+            if (_orderedEvents.Contains(type))
+            {
+                RaiseLocalOrdered(uid, args, broadcast);
+                return;
+            }
+
+            _eventTables.Dispatch(uid, type, args);
 
             // we also broadcast it so the call site does not have to.
             if(broadcast)

--- a/Robust.Shared/GameObjects/EntitySystem.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.cs
@@ -93,6 +93,11 @@ namespace Robust.Shared.GameObjects
             EntityManager.EventBus.RaiseLocalEvent(uid, args, broadcast);
         }
 
+        protected void RaiseLocalEvent(EntityUid uid, EntityEventArgs args, bool broadcast = true)
+        {
+            EntityManager.EventBus.RaiseLocalEvent(uid, args, broadcast);
+        }
+
         #endregion
 
         #region Static Helpers


### PR DESCRIPTION
Needed for stuff like do after, which stores any arbitrary event to be raised directed to an entity at a later time, without the use of generics. 