### PR TITLE
Fix serv warnings

### DIFF
--- a/Robust.Shared/Physics/Collision/Shapes/EdgeShape.cs
+++ b/Robust.Shared/Physics/Collision/Shapes/EdgeShape.cs
@@ -30,7 +30,6 @@ using Robust.Shared.Serialization.Manager.Attributes;
 namespace Robust.Shared.Physics.Collision.Shapes
 {
     [Serializable, NetSerializable]
-    [DataDefinition]
     public sealed class EdgeShape : IPhysShape
     {
         internal Vector2 Centroid { get; set; } = Vector2.Zero;

--- a/Robust.Shared/Physics/Dynamics/Joints/DistanceJoint.cs
+++ b/Robust.Shared/Physics/Dynamics/Joints/DistanceJoint.cs
@@ -57,7 +57,6 @@ namespace Robust.Shared.Physics.Dynamics.Joints
     /// this as a massless, rigid rod.
     /// </summary>
     [Serializable, NetSerializable]
-    [DataDefinition]
     public sealed class DistanceJoint : Joint, IEquatable<DistanceJoint>
     {
         // Sloth note:

--- a/Robust.Shared/Physics/Dynamics/Joints/FrictionJoint.cs
+++ b/Robust.Shared/Physics/Dynamics/Joints/FrictionJoint.cs
@@ -48,7 +48,6 @@ namespace Robust.Shared.Physics.Dynamics.Joints
     /// It provides 2D translational friction and angular friction.
     /// </summary>
     [Serializable, NetSerializable]
-    [DataDefinition]
     public sealed class FrictionJoint : Joint, IEquatable<FrictionJoint>
     {
         // Solver shared

--- a/Robust.Shared/Physics/Dynamics/Joints/Joint.cs
+++ b/Robust.Shared/Physics/Dynamics/Joints/Joint.cs
@@ -57,7 +57,6 @@ namespace Robust.Shared.Physics.Dynamics.Joints
     }
 
     [Serializable, NetSerializable]
-    [DataDefinition]
     public abstract class Joint : IEquatable<Joint>
     {
         /// <summary>


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

These were caused by DataDefinition being on classes that have no datafields nor a parameterless ctor, so there was no reason to keep them as data definitions
