### PR TITLE
Clyde can now render multiple viewports with different maps.

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
@@ -19,18 +19,17 @@ namespace Robust.Client.Graphics.Clyde
         private int _verticesPerChunk(IMapChunk chunk) => chunk.ChunkSize * chunk.ChunkSize * 4;
         private int _indicesPerChunk(IMapChunk chunk) => chunk.ChunkSize * chunk.ChunkSize * GetQuadBatchIndexCount();
 
-        private void _drawGrids(Box2 worldBounds)
+        private void _drawGrids(Viewport viewport, Box2 worldBounds, IEye eye)
         {
-            var mapId = _eyeManager.CurrentMap;
+            var mapId = eye.Position.MapId;
             if (!_mapManager.MapExists(mapId))
             {
-                // fall back to the default eye's map
-                _eyeManager.ClearCurrentEye();
-                mapId = _eyeManager.CurrentMap;
+                // fall back to nullspace map
+                mapId = MapId.Nullspace;
             }
 
             SetTexture(TextureUnit.Texture0, _tileDefinitionManager.TileTextureAtlas);
-            SetTexture(TextureUnit.Texture1, _lightingReady ? _currentViewport!.LightRenderTarget.Texture : _stockTextureWhite);
+            SetTexture(TextureUnit.Texture1, _lightingReady ? viewport.LightRenderTarget.Texture : _stockTextureWhite);
 
             var (gridProgram, _) = ActivateShaderInstance(_defaultShader.Handle);
             SetupGlobalUniformsImmediate(gridProgram, (ClydeTexture) _tileDefinitionManager.TileTextureAtlas);

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -201,9 +201,10 @@ namespace Robust.Client.Graphics.Clyde
         }
 
 
-        private void DrawEntities(Viewport viewport, Box2 worldBounds)
+        private void DrawEntities(Viewport viewport, Box2 worldBounds, IEye eye)
         {
-            if (_eyeManager.CurrentMap == MapId.Nullspace || !_mapManager.HasMapEntity(_eyeManager.CurrentMap))
+            var mapId = eye.Position.MapId;
+            if (mapId == MapId.Nullspace || !_mapManager.HasMapEntity(mapId))
             {
                 return;
             }
@@ -217,7 +218,7 @@ namespace Robust.Client.Graphics.Clyde
             // TODO: Make this check more accurate.
             var widerBounds = worldBounds.Enlarged(5);
 
-            ProcessSpriteEntities(_eyeManager.CurrentMap, widerBounds, _drawingSpriteList);
+            ProcessSpriteEntities(mapId, widerBounds, _drawingSpriteList);
 
             var worldOverlays = new List<Overlay>();
 
@@ -467,13 +468,13 @@ namespace Robust.Client.Graphics.Clyde
 
                     using (DebugGroup("Grids"))
                     {
-                        _drawGrids(worldBounds);
+                        _drawGrids(viewport, worldBounds, eye);
                     }
 
                     // We will also render worldspace overlays here so we can do them under / above entities as necessary
                     using (DebugGroup("Entities"))
                     {
-                        DrawEntities(viewport, worldBounds);
+                        DrawEntities(viewport, worldBounds, eye);
                     }
 
                     RenderOverlays(viewport, OverlaySpace.WorldSpaceBelowFOV, worldBounds);

--- a/Robust.Server/GameStates/EntityViewCulling.cs
+++ b/Robust.Server/GameStates/EntityViewCulling.cs
@@ -281,7 +281,6 @@ namespace Robust.Server.GameStates
                     visMask = eyeComp.VisibilityMask;
 
                 //Always include the map entity of the eye
-                //TODO: Add Map entity here
                 visibleEnts.Add(_mapManager.GetMapEntityId(eyeComp.Owner.Transform.MapID));
 
                 //Always include viewable ent itself

--- a/Robust.Server/GameStates/EntityViewCulling.cs
+++ b/Robust.Server/GameStates/EntityViewCulling.cs
@@ -280,8 +280,9 @@ namespace Robust.Server.GameStates
                 if (_compMan.TryGetComponent<EyeComponent>(eyeEuid, out var eyeComp))
                     visMask = eyeComp.VisibilityMask;
 
-                //Always include the map entity of the eye
-                visibleEnts.Add(_mapManager.GetMapEntityId(eyeComp.Owner.Transform.MapID));
+                //Always include the map entity of the eye, if it exists.
+                if(_mapManager.MapExists(mapId))
+                    visibleEnts.Add(_mapManager.GetMapEntityId(mapId));
 
                 //Always include viewable ent itself
                 visibleEnts.Add(eyeEuid);

--- a/Robust.Server/GameStates/EntityViewCulling.cs
+++ b/Robust.Server/GameStates/EntityViewCulling.cs
@@ -282,6 +282,7 @@ namespace Robust.Server.GameStates
 
                 //Always include the map entity of the eye
                 //TODO: Add Map entity here
+                visibleEnts.Add(_mapManager.GetMapEntityId(eyeComp.Owner.Transform.MapID));
 
                 //Always include viewable ent itself
                 visibleEnts.Add(eyeEuid);


### PR DESCRIPTION
It defaulted to using the main (current) eye's map, instead of passing the actual eye being rendered around.