### PR TITLE
Add Friend classes to C# with the help of Analyzers and Attributes.

### DIFF
--- a/Robust.Analyzers/FriendAnalyzer.cs
+++ b/Robust.Analyzers/FriendAnalyzer.cs
@@ -1,0 +1,108 @@
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Robust.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class FriendAnalyzer : DiagnosticAnalyzer
+    {
+        const string FriendAttribute = "Robust.Shared.Analyzers.FriendAttribute";
+
+        public const string DiagnosticId = "RA0002";
+
+        private const string Title = "Tried to access friend-only member";
+        private const string MessageFormat = "Tried to access member \"{0}\" in class \"{1}\" which can only be accessed by friend classes";
+        private const string Description = "Make sure to specify the accessing class in the friends attribute.";
+        private const string Category = "Usage";
+
+        [SuppressMessage("ReSharper", "RS2008")]
+        private static readonly DiagnosticDescriptor Rule = new (DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, true, Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(CheckFriendship, SyntaxKind.SimpleMemberAccessExpression);
+        }
+
+        private void CheckFriendship(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is not MemberAccessExpressionSyntax memberAccess)
+                return;
+
+            // We only do something if our parent is one of a few types.
+            switch (context.Node.Parent)
+            {
+                // If we're being assigned...
+                case AssignmentExpressionSyntax assignParent:
+                {
+                    if (assignParent.Left != memberAccess)
+                        return;
+                    break;
+                }
+
+                // If we're being invoked...
+                case InvocationExpressionSyntax:
+                    break;
+
+                // Otherwise, do nothing.
+                default:
+                    return;
+            }
+
+            // Get the friend attribute, if it can't be found do nothing...
+            if (context.Compilation.GetTypeByMetadataName(FriendAttribute) is not {} friendAttr)
+                return;
+
+            // Get the type that is containing this expression, or, the class where this is happening.
+            if (context.ContainingSymbol?.ContainingType is not { } containingType)
+                return;
+
+            // We check all of our children and get only the identifiers.
+            foreach (var identifier in memberAccess.ChildNodes().Select(node => node as IdentifierNameSyntax))
+            {
+                if (identifier == null) continue;
+
+                // Get the type info of the identifier, so we can check the attributes...
+                if (context.SemanticModel.GetTypeInfo(identifier).ConvertedType is not { } type)
+                    continue;
+
+                // Same-type access is always fine.
+                if (SymbolEqualityComparer.Default.Equals(type, containingType))
+                    continue;
+
+                // Finally, get all attributes of the type, to check if we have any friend classes.
+                foreach (var attribute in type.GetAttributes())
+                {
+                    // If the attribute isn't the friend attribute, continue.
+                    if (!SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, friendAttr))
+                        continue;
+
+                    // Check all types allowed in the friend attribute. (We assume there's only one constructor arg.)
+                    foreach (var constant in attribute.ConstructorArguments[0].Values)
+                    {
+                        // Check if the value is a type...
+                        if (constant.Value is not INamedTypeSymbol t)
+                            continue;
+
+                        // If we find that the containing class is specified in the attribute, return! All is good.
+                        if (SymbolEqualityComparer.Default.Equals(containingType, t))
+                            return;
+                    }
+
+                    // Not in a friend class! Report an error.
+                    context.ReportDiagnostic(
+                        Diagnostic.Create(Rule, context.Node.GetLocation(),
+                            $"{context.Node.ToString().Split('.')[^1]}", $"{type.Name}"));
+                }
+            }
+        }
+    }
+}

--- a/Robust.Analyzers/FriendAnalyzer.cs
+++ b/Robust.Analyzers/FriendAnalyzer.cs
@@ -100,7 +100,7 @@ namespace Robust.Analyzers
                     // Not in a friend class! Report an error.
                     context.ReportDiagnostic(
                         Diagnostic.Create(Rule, context.Node.GetLocation(),
-                            $"{context.Node.ToString().Split('.')[^1]}", $"{type.Name}"));
+                            $"{context.Node.ToString().Split('.').LastOrDefault()}", $"{type.Name}"));
                 }
             }
         }

--- a/Robust.Analyzers/FriendAnalyzer.cs
+++ b/Robust.Analyzers/FriendAnalyzer.cs
@@ -57,9 +57,8 @@ namespace Robust.Analyzers
                     return;
             }
 
-            // Get the friend attribute, if it can't be found do nothing...
-            if (context.Compilation.GetTypeByMetadataName(FriendAttribute) is not {} friendAttr)
-                return;
+            // Get the friend attribute
+            var friendAttr = context.Compilation.GetTypeByMetadataName(FriendAttribute);
 
             // Get the type that is containing this expression, or, the class where this is happening.
             if (context.ContainingSymbol?.ContainingType is not { } containingType)

--- a/Robust.Analyzers/Robust.Analyzers.csproj
+++ b/Robust.Analyzers/Robust.Analyzers.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Robust.Analyzers/Robust.Analyzers.csproj
+++ b/Robust.Analyzers/Robust.Analyzers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>9</LangVersion>
   </PropertyGroup>
 

--- a/Robust.Shared/Analyzers/FriendAttribute.cs
+++ b/Robust.Shared/Analyzers/FriendAttribute.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Robust.Shared.Analyzers
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct)]
+    public class FriendAttribute : Attribute
+    {
+        public readonly Type[] Friends;
+
+        public FriendAttribute(params Type[] friends)
+        {
+            Friends = friends;
+        }
+    }
+}


### PR DESCRIPTION
So basically, because of ECS every member in components is public and anything can write/invoke them even if they shouldn't, yes? The solution we came up with was to code better comments/xmldocs, and review things properly.

But of course, the dumb coder will still write to/invoke them directly instead of going through the intended entity system... The drunk maintainer will absolutely miss these awful crimes against humanity, and the codebase will burn and suffer as a result. All because there's no encapsulation. Smh.

Because of these awful predictions about the future, I decided to sacrifice myself and learn roslyn analyzers with the goal of avoiding that timeline and save the project from the shitcoders: 
I implemented "friend classes" in C#.

The way this works is very simple. You add a `[Friend(typeof(MyFriend), typeof(MyBestFriend))]` attribute to your component, and now only those two classes will be able to write/invoke members in it. Any class can *read*, but only friends can write/invoke.
This also works with inheritance: If your base class is friends with Foo, and the inheriting class is friends with Bar, the inheriting class is friends with Foo as well, but the base class is not friends with Bar. In short, this should probably force you to think about your relationships between components/things using components..

Shoutouts to Y for giving me the motivation required for coding this.