### PR TITLE
Fix outline when eye is rotated

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -292,6 +292,9 @@ namespace Robust.Client.Graphics.Clyde
                     // scale can be passed with PostShader as variable in future
                     var postShadeScale = 1.25f;
                     var screenSpriteSize = (Vector2i) ((screenRT - screenLB) * postShadeScale).Rounded();
+
+                    // Rotate the vector by the eye angle, otherwise the bounding box will be incorrect
+                    screenSpriteSize = (Vector2i) eye.Rotation.RotateVec(screenSpriteSize).Rounded();
                     screenSpriteSize.Y = -screenSpriteSize.Y;
 
                     // I'm not 100% sure why it works, but without it post-shader

--- a/Robust.Shared.Maths/Angle.cs
+++ b/Robust.Shared.Maths/Angle.cs
@@ -103,6 +103,9 @@ namespace Robust.Shared.Maths
         [Pure]
         public Vector2 RotateVec(in Vector2 vec)
         {
+            // No calculation necessery when theta is zero
+            if (Theta == 0) return vec;
+
             var (x, y) = vec;
             var cos = Math.Cos(Theta);
             var sin = Math.Sin(Theta);


### PR DESCRIPTION
The PostShader bounding box calculation does not account for eye rotation, and thus clips the sprite. This change essentially rotates the calculated bounding box by the eye rotation, making it correct again.