### PR TITLE
Add vertices simplifier

### DIFF
--- a/Robust.Shared/Physics/RamerDouglasPeuckerSimplifier.cs
+++ b/Robust.Shared/Physics/RamerDouglasPeuckerSimplifier.cs
@@ -1,0 +1,109 @@
+/* Original source Farseer Physics Engine:
+ * Copyright (c) 2014 Ian Qvist, http://farseerphysics.codeplex.com
+ * Microsoft Permissive License (Ms-PL) v1.1
+ */
+
+using System;
+using System.Collections.Generic;
+using Robust.Shared.Maths;
+
+namespace Robust.Shared.Physics
+{
+    /// <summary>
+    /// Takes in a list of vertices and removes any that are redundant (within tolerance).
+    /// </summary>
+    public interface IVerticesSimplifier
+    {
+        List<Vector2> Simplify(List<Vector2> vertices, float tolerance);
+    }
+
+    /// <inheritdoc />
+    public class RamerDouglasPeuckerSimplifier : IVerticesSimplifier
+    {
+        /// <summary>
+        /// Ramer-Douglas-Peucker polygon simplification algorithm. This is the general recursive version that does not use the
+        /// speed-up technique by using the Melkman convex hull.
+        ///
+        /// If you pass in 0, it will remove all collinear points.
+        /// </summary>
+        /// <returns>The simplified polygon</returns>
+        public List<Vector2> Simplify(List<Vector2> vertices, float distanceTolerance)
+        {
+            if (vertices.Count <= 3)
+                return vertices;
+
+            Span<bool> usePoint = stackalloc bool[vertices.Count];
+
+            for (var i = 0; i < vertices.Count; i++)
+                usePoint[i] = true;
+
+            SimplifySection(vertices, 0, vertices.Count - 1, usePoint, distanceTolerance);
+
+            var simplified = new List<Vector2>(vertices.Count);
+
+            for (var i = 0; i < vertices.Count; i++)
+            {
+                if (usePoint[i])
+                    simplified.Add(vertices[i]);
+            }
+
+            return simplified;
+        }
+
+        private static void SimplifySection(List<Vector2> vertices, int i, int j, Span<bool> usePoint, float distanceTolerance)
+        {
+            if (i + 1 == j)
+                return;
+
+            var a = vertices[i];
+            var b = vertices[j];
+
+            double maxDistance = -1.0;
+            int maxIndex = i;
+            for (int k = i + 1; k < j; k++)
+            {
+                Vector2 point = vertices[k];
+
+                double distance = DistanceBetweenPointAndLineSegment(in point, in a, in b);
+
+                if (distance > maxDistance)
+                {
+                    maxDistance = distance;
+                    maxIndex = k;
+                }
+            }
+
+            if (maxDistance <= distanceTolerance)
+            {
+                for (int k = i + 1; k < j; k++)
+                {
+                    usePoint[k] = false;
+                }
+            }
+            else
+            {
+                SimplifySection(vertices, i, maxIndex, usePoint, distanceTolerance);
+                SimplifySection(vertices, maxIndex, j, usePoint, distanceTolerance);
+            }
+        }
+
+        public static float DistanceBetweenPointAndLineSegment(in Vector2 point, in Vector2 start, in Vector2 end)
+        {
+            if (start == end)
+                return (point - start).Length;
+
+            var v = end - start;
+            var w = point - start;
+
+            var c1 = Vector2.Dot(w, v);
+            if (c1 <= 0) return (point - start).Length;
+
+            var c2 = Vector2.Dot(v, v);
+            if (c2 <= c1) return (point - end).Length;
+
+            var b = c1 / c2;
+            var pointOnLine = start + v * b;
+            return (point - pointOnLine).Length;
+        }
+    }
+}

--- a/Robust.Shared/SharedIoC.cs
+++ b/Robust.Shared/SharedIoC.cs
@@ -48,6 +48,7 @@ namespace Robust.Shared
             IoCManager.Register<ISandboxHelper, SandboxHelper>();
             IoCManager.Register<ICollisionManager, CollisionManager>();
             IoCManager.Register<IIslandManager, IslandManager>();
+            IoCManager.Register<IVerticesSimplifier, RamerDouglasPeuckerSimplifier>();
         }
     }
 }

--- a/Robust.UnitTesting/Shared/Physics/VerticesSimplifier_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/VerticesSimplifier_Test.cs
@@ -10,6 +10,61 @@ namespace Robust.UnitTesting.Shared.Physics
     public class VerticesSimplifier_Test : RobustUnitTest
     {
         /*
+         * Collinear tests
+         */
+        [Test]
+        public void TestCollinearLine()
+        {
+            var simplifier = new CollinearSimplifier();
+
+            var line = new List<Vector2>
+            {
+                new(0.0f, 0f),
+                new(0.5f, 0f),
+                new(1.0f, 0f),
+                new(1.5f, 0f),
+                new(2.0f, 0f),
+            };
+
+            Assert.That(simplifier.Simplify(line, 0.01f).Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void TestCollinearBox()
+        {
+            // Box should still simplify to a box.
+            var simplifier = new CollinearSimplifier();
+
+            var line = new List<Vector2>
+            {
+                new(0.0f, 0f),
+                new(0.0f, 1.0f),
+                new(1.0f, 1.0f),
+                new(1.0f, 0f),
+            };
+
+            Assert.That(simplifier.Simplify(line, 0.01f).Count, Is.EqualTo(4));
+        }
+
+        [Test]
+        public void TestCollinearSquiggle()
+        {
+            var simplifier = new CollinearSimplifier();
+
+            var line = new List<Vector2>
+            {
+                new(0.0f, 0f),
+                new(0.5f, 0.05f),
+                new(1.0f, 0f),
+                new(1.5f, -0.05f),
+                new(2.0f, 0f),
+            };
+
+            Assert.That(simplifier.Simplify(line, 0.1f).Count, Is.EqualTo(2));
+        }
+
+
+        /*
          * Douglas Peucker tests
          */
         [Test]

--- a/Robust.UnitTesting/Shared/Physics/VerticesSimplifier_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/VerticesSimplifier_Test.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Robust.Shared.Maths;
+using Robust.Shared.Physics;
+
+namespace Robust.UnitTesting.Shared.Physics
+{
+    [TestFixture, Parallelizable]
+    [TestOf(typeof(IVerticesSimplifier))]
+    public class VerticesSimplifier_Test : RobustUnitTest
+    {
+        /*
+         * Douglas Peucker tests
+         */
+        [Test]
+        public void TestDouglasPeuckerLine()
+        {
+            var simplifier = new RamerDouglasPeuckerSimplifier();
+
+            var line = new List<Vector2>
+            {
+                new(0.0f, 0f),
+                new(0.5f, 0f),
+                new(1.0f, 0f),
+                new(1.5f, 0f),
+                new(2.0f, 0f),
+            };
+
+            Assert.That(simplifier.Simplify(line, 0.01f).Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void TestDouglasPeuckerBox()
+        {
+            // Box should still simplify to a box.
+            var simplifier = new RamerDouglasPeuckerSimplifier();
+
+            var line = new List<Vector2>
+            {
+                new(0.0f, 0f),
+                new(0.0f, 1.0f),
+                new(1.0f, 1.0f),
+                new(1.0f, 0f),
+            };
+
+            Assert.That(simplifier.Simplify(line, 0.01f).Count, Is.EqualTo(4));
+        }
+
+        [Test]
+        public void TestDouglasPeuckerSquiggle()
+        {
+            var simplifier = new RamerDouglasPeuckerSimplifier();
+
+            var line = new List<Vector2>
+            {
+                new(0.0f, 0f),
+                new(0.5f, 0.05f),
+                new(1.0f, 0f),
+                new(1.5f, -0.05f),
+                new(2.0f, 0f),
+            };
+
+            Assert.That(simplifier.Simplify(line, 0.1f).Count, Is.EqualTo(2));
+        }
+    }
+}


### PR DESCRIPTION
This takes in a set of vector2s and simplifies it (within tolerance). I only ported the RamerDouglasPeucker one from farseer as it was the only that was recursive.

(Farseer's license is already in the repo).

Intend to use it eventually for accurate grid bounds.

Source at https://github.com/Zumorica/FarseerPhysicsEngine/blob/master/FarseerPhysics/Common/PolygonManipulation/SimplifyTools.cs