### PR TITLE
Add benchmarks for serializing flags

### DIFF
--- a/Robust.Benchmarks/Serialization/Copy/SerializationCopyBenchmark.cs
+++ b/Robust.Benchmarks/Serialization/Copy/SerializationCopyBenchmark.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.Markdown.Sequence;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 using Robust.Shared.Utility;
 using YamlDotNet.RepresentationModel;
 
@@ -34,6 +35,10 @@ namespace Robust.Benchmarks.Serialization.Copy
         private DataDefinitionWithString DataDefinitionWithString { get; }
 
         private SeedDataDefinition Seed { get; }
+
+        private BenchmarkFlagsEnum FlagZero = BenchmarkFlagsEnum.Zero;
+
+        private BenchmarkFlagsEnum FlagThirtyOne = BenchmarkFlagsEnum.ThirtyOne;
 
         [Benchmark]
         public string? CreateCopyString()
@@ -110,6 +115,26 @@ namespace Robust.Benchmarks.Serialization.Copy
             copy.SplatPrototype = Seed.SplatPrototype;
 
             return copy;
+        }
+
+        [Benchmark]
+        [BenchmarkCategory("flag")]
+        public object? CreateCopyFlagZero()
+        {
+            return SerializationManager.CopyWithTypeSerializer(
+                typeof(FlagSerializer<BenchmarkFlags>),
+                (int) FlagZero,
+                (int) FlagZero);
+        }
+
+        [Benchmark]
+        [BenchmarkCategory("flag")]
+        public object? CreateCopyFlagThirtyOne()
+        {
+            return SerializationManager.CopyWithTypeSerializer(
+                typeof(FlagSerializer<BenchmarkFlags>),
+                (int) FlagThirtyOne,
+                (int) FlagThirtyOne);
         }
     }
 }

--- a/Robust.Benchmarks/Serialization/Definitions/BenchmarkFlags.cs
+++ b/Robust.Benchmarks/Serialization/Definitions/BenchmarkFlags.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Robust.Shared.Serialization;
+
+namespace Robust.Benchmarks.Serialization.Definitions
+{
+    public class BenchmarkFlags
+    {
+        public const int Zero = 1 << 0;
+        public const int ThirtyOne = 1 << 31;
+    }
+
+    [Flags]
+    [FlagsFor(typeof(BenchmarkFlags))]
+    public enum BenchmarkFlagsEnum
+    {
+        Zero = BenchmarkFlags.Zero,
+        ThirtyOne = BenchmarkFlags.ThirtyOne
+    }
+}

--- a/Robust.Benchmarks/Serialization/Read/SerializationReadBenchmark.cs
+++ b/Robust.Benchmarks/Serialization/Read/SerializationReadBenchmark.cs
@@ -1,10 +1,12 @@
 ﻿using System.IO;
 using BenchmarkDotNet.Attributes;
 using Robust.Benchmarks.Serialization.Definitions;
+using Robust.Shared.Serialization.Manager.Result;
 using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.Markdown.Sequence;
 using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 using YamlDotNet.RepresentationModel;
 
 namespace Robust.Benchmarks.Serialization.Read
@@ -32,6 +34,10 @@ namespace Robust.Benchmarks.Serialization.Read
 
         private MappingDataNode SeedNode { get; }
 
+        private ValueDataNode FlagZero { get; } = new("Zero");
+
+        private ValueDataNode FlagThirtyOne { get; } = new("ThirtyOne");
+
         [Benchmark]
         public string? ReadString()
         {
@@ -54,6 +60,26 @@ namespace Robust.Benchmarks.Serialization.Read
         public SeedDataDefinition? ReadSeedDataDefinition()
         {
             return SerializationManager.ReadValue<SeedDataDefinition>(SeedNode);
+        }
+
+        [Benchmark]
+        [BenchmarkCategory("flag")]
+        public DeserializationResult ReadFlagZero()
+        {
+            return SerializationManager.ReadWithTypeSerializer(
+                typeof(int),
+                typeof(FlagSerializer<BenchmarkFlags>),
+                FlagZero);
+        }
+
+        [Benchmark]
+        [BenchmarkCategory("flag")]
+        public DeserializationResult ReadThirtyOne()
+        {
+            return SerializationManager.ReadWithTypeSerializer(
+                typeof(int),
+                typeof(FlagSerializer<BenchmarkFlags>),
+                FlagThirtyOne);
         }
     }
 }

--- a/Robust.Benchmarks/Serialization/Write/SerializationWriteBenchmark.cs
+++ b/Robust.Benchmarks/Serialization/Write/SerializationWriteBenchmark.cs
@@ -7,6 +7,7 @@ using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.Markdown.Sequence;
 using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 using YamlDotNet.RepresentationModel;
 
 namespace Robust.Benchmarks.Serialization.Write
@@ -34,6 +35,10 @@ namespace Robust.Benchmarks.Serialization.Write
         private DataDefinitionWithString DataDefinitionWithString { get; }
 
         private SeedDataDefinition Seed { get; }
+
+        private BenchmarkFlagsEnum FlagZero = BenchmarkFlagsEnum.Zero;
+
+        private BenchmarkFlagsEnum FlagThirtyOne = BenchmarkFlagsEnum.ThirtyOne;
 
         [Benchmark]
         public DataNode WriteString()
@@ -93,6 +98,26 @@ namespace Robust.Benchmarks.Serialization.Write
             mapping.Add("chemicals", chemicals);
 
             return mapping;
+        }
+
+        [Benchmark]
+        [BenchmarkCategory("flag")]
+        public DataNode WriteFlagZero()
+        {
+            return SerializationManager.WriteWithTypeSerializer(
+                typeof(int),
+                typeof(FlagSerializer<BenchmarkFlags>),
+                FlagZero);
+        }
+
+        [Benchmark]
+        [BenchmarkCategory("flag")]
+        public DataNode WriteThirtyOne()
+        {
+            return SerializationManager.WriteWithTypeSerializer(
+                typeof(int),
+                typeof(FlagSerializer<BenchmarkFlags>),
+                FlagThirtyOne);
         }
     }
 }


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-4790K CPU 4.00GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.201
  [Host]     : .NET Core 5.0.4 (CoreCLR 5.0.421.11614, CoreFX 5.0.421.11614), X64 RyuJIT
  DefaultJob : .NET Core 5.0.4 (CoreCLR 5.0.421.11614, CoreFX 5.0.421.11614), X64 RyuJIT


```
|                  Method |     Mean |     Error |    StdDev |
|------------------------ |---------:|----------:|----------:|
|      CreateCopyFlagZero | 2.956 μs | 0.0753 μs | 0.2184 μs |
| CreateCopyFlagThirtyOne | 3.241 μs | 0.0754 μs | 0.2138 μs |
|  ReadFlagZero | 3.079 μs | 0.0693 μs | 0.1955 μs |
| ReadThirtyOne | 3.097 μs | 0.0985 μs | 0.2763 μs |
|  WriteFlagZero | 3.557 μs | 0.0683 μs | 0.0605 μs |
| WriteThirtyOne | 3.685 μs | 0.0639 μs | 0.1232 μs |

