### PR TITLE
Optimise GetMapChunks

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
@@ -51,17 +51,9 @@ namespace Robust.Client.Graphics.Clyde
 
                 var transform = compMan.GetComponent<ITransformComponent>(grid.GridEntityId);
                 gridProgram.SetUniform(UniIModelMatrix, transform.WorldMatrix);
-                var worldPos = transform.WorldPosition;
-                var worldRot = transform.WorldRotation;
 
-                foreach (var (_, chunk) in grid.GetMapChunks())
+                foreach (var chunk in grid.GetMapChunks(worldBounds))
                 {
-                    // Calc world bounds for chunk.
-                    if (!chunk.CalcWorldAABB(worldPos, worldRot).Intersects(in worldBounds))
-                    {
-                        continue;
-                    }
-
                     if (_isChunkDirty(grid, chunk))
                     {
                         _updateChunkMesh(grid, chunk);

--- a/Robust.Shared/Map/IMapGridInternal.cs
+++ b/Robust.Shared/Map/IMapGridInternal.cs
@@ -48,5 +48,10 @@ namespace Robust.Shared.Map
         /// </summary>
         /// <returns>All chunks in the grid.</returns>
         IReadOnlyDictionary<Vector2i, IMapChunkInternal> GetMapChunks();
+
+        /// <summary>
+        ///     Returns all the <see cref="IMapChunkInternal"/> intersecting the worldAABB.
+        /// </summary>
+        IEnumerable<IMapChunkInternal> GetMapChunks(Box2 worldAABB);
     }
 }

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -379,6 +379,27 @@ namespace Robust.Shared.Map
             return _chunks;
         }
 
+        public IEnumerable<IMapChunkInternal> GetMapChunks(Box2 worldAABB)
+        {
+            var worldPos = WorldPosition;
+            var localArea = new Box2Rotated(worldAABB.Translated(-worldPos), -WorldRotation).CalcBoundingBox();
+
+            var chunkLB = new Vector2i((int)Math.Floor(localArea.Left / ChunkSize), (int)Math.Floor(localArea.Bottom / ChunkSize));
+            var chunkRT = new Vector2i((int)Math.Floor(localArea.Right / ChunkSize), (int)Math.Floor(localArea.Top / ChunkSize));
+
+            for (var x = chunkLB.X; x <= chunkRT.X; x++)
+            {
+                for (var y = chunkLB.Y; y <= chunkRT.Y; y++)
+                {
+                    var gridChunk = new Vector2i(x, y);
+
+                    if (!_chunks.TryGetValue(gridChunk, out var chunk)) continue;
+
+                    yield return chunk;
+                }
+            }
+        }
+
         #endregion ChunkAccess
 
         #region SnapGridAccess


### PR DESCRIPTION
Don't need to check every chunk's bounds when you can just do dictionary lookups. Should be an okay bonus for PVS and grid rendering on larger grids. Didn't make tests yet because all of the existing ones are mocked and painful to change.