### PR TITLE
Minor grid traversal optimisation

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
@@ -12,23 +12,33 @@ namespace Robust.Shared.GameObjects
     {
         [Dependency] private readonly IMapManager _mapManager = default!;
 
-        private Queue<MoveEvent> _queuedEvents = new();
+        private Stack<MoveEvent> _queuedEvents = new();
+        private HashSet<EntityUid> _handledThisTick = new();
 
         public override void Initialize()
         {
             base.Initialize();
-            SubscribeLocalEvent<MoveEvent>(ev => _queuedEvents.Enqueue(ev));
+            SubscribeLocalEvent<MoveEvent>(ev => _queuedEvents.Push(ev));
         }
 
         public override void Update(float frameTime)
         {
             base.Update(frameTime);
 
-            // Need to queue because otherwise calling HandleMove during FrameUpdate will lead to prediction isues.
-            while (_queuedEvents.TryDequeue(out var moveEvent))
+            // Need to queue because otherwise calling HandleMove during FrameUpdate will lead to prediction issues.
+            // TODO: Need to check if that's even still relevant since transform lerping fix?
+            ProcessChanges();
+        }
+
+        private void ProcessChanges()
+        {
+            while (_queuedEvents.TryPop(out var moveEvent))
             {
+                if (!_handledThisTick.Add(moveEvent.Sender.Uid)) continue;
                 HandleMove(moveEvent);
             }
+
+            _handledThisTick.Clear();
         }
 
         private void HandleMove(MoveEvent moveEvent)
@@ -60,8 +70,8 @@ namespace Robust.Shared.GameObjects
                 // Some minor duplication here with AttachParent but only happens when going on/off grid so not a big deal ATM.
                 if (grid.Index != transform.GridID)
                 {
-                    transform.AttachParent(EntityManager.GetEntity(grid.GridEntityId));
-                    RaiseLocalEvent(entity.Uid, new ChangedGridMessage(entity, transform.GridID, grid.Index));
+                    transform.AttachParent(gridEnt);
+                    RaiseLocalEvent(entity.Uid, new ChangedGridEvent(entity, transform.GridID, grid.Index));
                 }
             }
             else
@@ -72,19 +82,19 @@ namespace Robust.Shared.GameObjects
                 if (oldGridId != GridId.Invalid)
                 {
                     transform.AttachParent(_mapManager.GetMapEntity(transform.MapID));
-                    RaiseLocalEvent(entity.Uid, new ChangedGridMessage(entity, oldGridId, GridId.Invalid));
+                    RaiseLocalEvent(entity.Uid, new ChangedGridEvent(entity, oldGridId, GridId.Invalid));
                 }
             }
         }
     }
 
-    public sealed class ChangedGridMessage : EntityEventArgs
+    public sealed class ChangedGridEvent : EntityEventArgs
     {
         public IEntity Entity;
         public GridId OldGrid;
         public GridId NewGrid;
 
-        public ChangedGridMessage(IEntity entity, GridId oldGrid, GridId newGrid)
+        public ChangedGridEvent(IEntity entity, GridId oldGrid, GridId newGrid)
         {
             Entity = entity;
             OldGrid = oldGrid;


### PR DESCRIPTION
Avoids running duplicate events, mainly for client, but also avoids the additional GetEntity call as well.