### PR TITLE
Fix y-sorting

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/ISpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/ISpriteComponent.cs
@@ -228,6 +228,6 @@ namespace Robust.Client.GameObjects
         /// <summary>
         ///     Calculate sprite bounding box in world-space coordinates.
         /// </summary>
-        Box2 CalculateBoundingBox();
+        Box2 CalculateBoundingBox(Vector2 worldPos);
     }
 }

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteBoundsOverlay.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteBoundsOverlay.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using Robust.Client.Graphics;
+using Robust.Client.Graphics.Clyde;
+using Robust.Shared.Console;
+using Robust.Shared.Enums;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Maths;
+using Robust.Shared.Utility;
+
+namespace Robust.Client.GameObjects
+{
+    public sealed class ShowSpriteBBCommand : IConsoleCommand
+    {
+        public string Command => "showspritebb";
+        public string Description => "Toggle whether sprite bounds are shown";
+        public string Help => $"{Command}";
+        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        {
+            EntitySystem.Get<SpriteBoundsSystem>().Enabled ^= true;
+        }
+    }
+
+    public sealed class SpriteBoundsSystem : EntitySystem
+    {
+        private SpriteBoundsOverlay? _overlay;
+
+        public bool Enabled
+        {
+            get => _enabled;
+            set
+            {
+                if (_enabled == value) return;
+
+                _enabled = value;
+
+                if (_enabled)
+                {
+                    DebugTools.AssertNull(_overlay);
+                    var overlayManager = IoCManager.Resolve<IOverlayManager>();
+                    _overlay = new SpriteBoundsOverlay(EntitySystem.Get<RenderingTreeSystem>(), IoCManager.Resolve<IEyeManager>());
+                    overlayManager.AddOverlay(_overlay);
+                }
+                else
+                {
+                    if (_overlay == null) return;
+                    var overlayManager = IoCManager.Resolve<IOverlayManager>();
+                    overlayManager.RemoveOverlay(_overlay);
+                    _overlay = null;
+                }
+            }
+        }
+
+        private bool _enabled;
+    }
+
+    public class SpriteBoundsOverlay : Overlay
+    {
+        public override OverlaySpace Space => OverlaySpace.WorldSpace;
+
+        private readonly IEyeManager _eyeManager = default!;
+        private RenderingTreeSystem _renderTree;
+
+        public SpriteBoundsOverlay(RenderingTreeSystem renderTree, IEyeManager eyeManager)
+        {
+            _renderTree = renderTree;
+            _eyeManager = eyeManager;
+        }
+
+        protected internal override void Draw(in OverlayDrawArgs args)
+        {
+            var handle = args.WorldHandle;
+            var currentMap = _eyeManager.CurrentMap;
+            var viewport = _eyeManager.GetWorldViewport();
+
+            foreach (var comp in _renderTree.GetRenderTrees(currentMap, viewport))
+            {
+                var localAABB = viewport.Translated(-comp.Owner.Transform.WorldPosition);
+
+                foreach (var sprite in comp.SpriteTree.QueryAabb(localAABB))
+                {
+                    var worldPos = sprite.Owner.Transform.WorldPosition;
+                    var bounds = sprite.CalculateBoundingBox(worldPos);
+                    handle.DrawRect(bounds, Color.Red.WithAlpha(0.2f));
+                    handle.DrawRect(bounds.Scale(0.2f).Translated(-new Vector2(0f, bounds.Extents.Y)), Color.Blue.WithAlpha(0.5f));
+                }
+            }
+        }
+    }
+}

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -2003,7 +2003,6 @@ namespace Robust.Client.GameObjects
             /// <inheritdoc/>
             public Box2 CalculateBoundingBox()
             {
-                // TODO: Event if the RSI size ever updates
                 // TODO: scale & rotation for layers is currently unimplemented.
                 return Box2.CenteredAround(Offset, PixelSize / EyeManager.PixelsPerMeter);
             }

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1512,6 +1512,11 @@ namespace Robust.Client.GameObjects
 
         private void QueueUpdateIsInert()
         {
+            // Look this was an easy way to get bounds checks for layer updates.
+            // If you really want it optimal you'll need to comb through all 2k lines of spritecomponent.
+            if (Owner?.EntityManager?.EventBus != null)
+                UpdateBounds();
+
             if (_inertUpdateQueued)
                 return;
 
@@ -1659,13 +1664,7 @@ namespace Robust.Client.GameObjects
 
         internal void UpdateBounds()
         {
-            var bounds = CalculateBoundingBox(Owner.Transform.WorldPosition);
-            Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, new SpriteBoundsUpdateEvent {Bounds = bounds});
-        }
-
-        public sealed class SpriteBoundsUpdateEvent : EntityEventArgs
-        {
-            public Box2 Bounds { get; init; }
+            Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, new SpriteUpdateEvent());
         }
 
         /// <summary>

--- a/Robust.Client/GameObjects/Components/RenderingTreeComponent.cs
+++ b/Robust.Client/GameObjects/Components/RenderingTreeComponent.cs
@@ -15,11 +15,12 @@ namespace Robust.Client.GameObjects
         private static Box2 SpriteAabbFunc(in SpriteComponent value)
         {
             var worldPos = value.Owner.Transform.WorldPosition;
+            var bounds = value.CalculateBoundingBox(worldPos);
             var tree = RenderingTreeSystem.GetRenderTree(value.Owner);
 
-            var pos = worldPos - tree?.Owner.Transform.WorldPosition ?? Vector2.Zero;
+            var offset = -tree?.Owner.Transform.WorldPosition ?? Vector2.Zero;
 
-            return new Box2(pos, pos);
+            return bounds.Translated(offset);
         }
 
         private static Box2 LightAabbFunc(in PointLightComponent value)
@@ -36,11 +37,12 @@ namespace Robust.Client.GameObjects
         internal static Box2 SpriteAabbFunc(SpriteComponent value, Vector2? worldPos = null)
         {
             worldPos ??= value.Owner.Transform.WorldPosition;
+            var bounds = value.CalculateBoundingBox(worldPos.Value);
             var tree = RenderingTreeSystem.GetRenderTree(value.Owner);
 
-            var pos = worldPos - tree?.Owner.Transform.WorldPosition ?? Vector2.Zero;
+            var offset = -tree?.Owner.Transform.WorldPosition ?? Vector2.Zero;
 
-            return new Box2(pos, pos);
+            return bounds.Translated(offset);
         }
 
         internal static Box2 LightAabbFunc(PointLightComponent value, Vector2? worldPos = null)

--- a/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
@@ -267,6 +267,11 @@ namespace Robust.Client.GameObjects
             return null;
         }
 
+        private bool IsVisible(SpriteComponent component)
+        {
+            return component.Visible && !component.ContainerOccluded;
+        }
+
         public override void FrameUpdate(float frameTime)
         {
             _checkedChildren.Clear();
@@ -274,7 +279,7 @@ namespace Robust.Client.GameObjects
             foreach (var sprite in _spriteQueue)
             {
                 sprite.TreeUpdateQueued = false;
-                if (!sprite.Visible || sprite.ContainerOccluded)
+                if (!IsVisible(sprite))
                 {
                     ClearSprite(sprite);
                     continue;

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -213,12 +213,7 @@ namespace Robust.Client.Graphics.Clyde
 
             var screenSize = viewport.Size;
 
-            // So we could calculate the correct size of the entities based on the contents of their sprite...
-            // Or we can just assume that no entity is larger than 10x10 and get a stupid easy check.
-            // TODO: Make this check more accurate.
-            var widerBounds = worldBounds.Enlarged(5);
-
-            ProcessSpriteEntities(mapId, widerBounds, _drawingSpriteList);
+            ProcessSpriteEntities(mapId, worldBounds, _drawingSpriteList);
 
             var worldOverlays = new List<Overlay>();
 
@@ -280,7 +275,7 @@ namespace Robust.Client.Graphics.Clyde
                 if (entry.sprite.PostShader != null)
                 {
                     // calculate world bounding box
-                    var spriteBB = entry.sprite.CalculateBoundingBox();
+                    var spriteBB = entry.sprite.CalculateBoundingBox(entry.worldMatrix.Transform(Vector2.Zero));
                     var spriteLB = spriteBB.BottomLeft;
                     var spriteRT = spriteBB.TopRight;
 
@@ -386,10 +381,12 @@ namespace Robust.Client.Graphics.Clyde
                     entry.worldRot = transform.WorldRotation;
                     entry.matrix = transform.WorldMatrix;
                     var worldPos = entry.matrix.Transform(transform.LocalPosition);
-                    entry.yWorldPos = worldPos.Y;
+                    // TODO: RETRIEVE IT FROM THE QUERY?
+                    var bounds = value.CalculateBoundingBox(worldPos);
+                    entry.yWorldPos = worldPos.Y - bounds.Extents.Y / 2f;
                     return true;
 
-                }), bounds, true);
+                }), bounds);
             }
         }
 

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -385,7 +385,7 @@ namespace Robust.Client.Graphics.Clyde
                     entry.worldRot = transform.WorldRotation;
                     entry.matrix = transform.WorldMatrix;
                     var worldPos = new Vector2(entry.matrix.R0C2, entry.matrix.R1C2);
-                    // TODO: RETRIEVE IT FROM THE QUERY?
+                    // Didn't use the bounds from the query as that has to be re-calculated (and is probably more expensive than this).
                     var bounds = value.CalculateBoundingBox(worldPos);
                     entry.yWorldPos = worldPos.Y - bounds.Extents.Y;
                     return true;

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -375,7 +375,7 @@ namespace Robust.Client.Graphics.Clyde
 
                 comp.SpriteTree.QueryAabb(ref list, (
                     ref RefList<(SpriteComponent sprite, Matrix3 matrix, Angle worldRot, float yWorldPos)> state,
-                    in SpriteComponent value, in Box2 aabb) =>
+                    in SpriteComponent value) =>
                 {
                     var entity = value.Owner;
                     var transform = entity.Transform;
@@ -385,7 +385,9 @@ namespace Robust.Client.Graphics.Clyde
                     entry.worldRot = transform.WorldRotation;
                     entry.matrix = transform.WorldMatrix;
                     var worldPos = new Vector2(entry.matrix.R0C2, entry.matrix.R1C2);
-                    entry.yWorldPos = worldPos.Y - aabb.Extents.Y;
+                    // TODO: RETRIEVE IT FROM THE QUERY?
+                    var bounds = value.CalculateBoundingBox(worldPos);
+                    entry.yWorldPos = worldPos.Y - bounds.Extents.Y;
                     return true;
 
                 }, bounds);

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -375,7 +375,7 @@ namespace Robust.Client.Graphics.Clyde
 
                 comp.SpriteTree.QueryAabb(ref list, (
                     ref RefList<(SpriteComponent sprite, Matrix3 matrix, Angle worldRot, float yWorldPos)> state,
-                    in SpriteComponent value) =>
+                    in SpriteComponent value, in Box2 aabb) =>
                 {
                     var entity = value.Owner;
                     var transform = entity.Transform;
@@ -385,9 +385,7 @@ namespace Robust.Client.Graphics.Clyde
                     entry.worldRot = transform.WorldRotation;
                     entry.matrix = transform.WorldMatrix;
                     var worldPos = new Vector2(entry.matrix.R0C2, entry.matrix.R1C2);
-                    // TODO: RETRIEVE IT FROM THE QUERY?
-                    var bounds = value.CalculateBoundingBox(worldPos);
-                    entry.yWorldPos = worldPos.Y - bounds.Extents.Y;
+                    entry.yWorldPos = worldPos.Y - aabb.Extents.Y;
                     return true;
 
                 }, bounds);

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -10,10 +10,6 @@ using Robust.Shared.Utility;
 using OpenToolkit.Graphics.OpenGL4;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.Enums;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Log;
-using Robust.Shared.Timing;
 
 namespace Robust.Client.Graphics.Clyde
 {

--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -7,6 +7,7 @@ using OpenToolkit.Graphics.OpenGL4;
 using Robust.Client.GameObjects;
 using Robust.Client.Utility;
 using Robust.Shared;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Maths;
 using Robust.Shared.Utility;
 using Color = Robust.Shared.Maths.Color;
@@ -1078,7 +1079,7 @@ namespace Robust.Client.Graphics.Clyde
                 var a = _drawList[x].Item1;
                 var b = _drawList[y].Item1;
 
-                var cmp = (a.DrawDepth).CompareTo(b.DrawDepth);
+                var cmp = a.DrawDepth.CompareTo(b.DrawDepth);
                 if (cmp != 0)
                 {
                     return cmp;
@@ -1091,7 +1092,7 @@ namespace Robust.Client.Graphics.Clyde
                     return cmp;
                 }
 
-                cmp = _drawList[x].Item4.CompareTo(_drawList[y].Item4);
+                cmp = _drawList[y].Item4.CompareTo(_drawList[x].Item4);
 
                 if (cmp != 0)
                 {

--- a/Robust.Shared/Physics/DynamicTree.cs
+++ b/Robust.Shared/Physics/DynamicTree.cs
@@ -62,7 +62,6 @@ namespace Robust.Shared.Physics
 
         public delegate bool QueryCallbackDelegate(in T value);
         public delegate bool QueryCallbackDelegate<TState>(ref TState state, in T value);
-        public delegate bool QueryAABBCallbackDelegate<TState>(ref TState state, in T value, in Box2 valueAABB);
 
         public delegate bool RayQueryCallbackDelegate(in T value, in Vector2 point, float distFromOrigin);
         public delegate bool RayQueryCallbackDelegate<TState>(ref TState state, in T value, in Vector2 point, float distFromOrigin);
@@ -223,18 +222,6 @@ namespace Robust.Shared.Physics
             state = tuple.state;
         }
 
-        /// <summary>
-        /// Query the tree and also retrieve the precise AABB of the values (which are local to the tree).
-        /// You may wish to use <see cref="QueryAabb(Robust.Shared.Physics.DynamicTree{T}.QueryCallbackDelegate,Robust.Shared.Maths.Box2,bool)"/> instead.
-        /// </summary>
-        public void QueryAabb<TState>(ref TState state, QueryAABBCallbackDelegate<TState> callback, Box2 aabb)
-        {
-            // Doesn't take in approx as we need to get the entry's AABB back out which re-calculates it anyway.
-            var tuple = (state, _b2Tree, callback, aabb, _extractAabb);
-            _b2Tree.Query(ref tuple, DelegateCache<TState>.ValueAabbQueryState, aabb);
-            state = tuple.state;
-        }
-
         public IEnumerable<T> QueryAabb(Box2 aabb, bool approx = false)
         {
             var list = new List<T>();
@@ -314,19 +301,6 @@ namespace Robust.Shared.Physics
             return tuple.callback(ref tuple.state, item);
         }
 
-        private static bool ValueAabbQueryStateCallback<TState>(ref (TState state, B2DynamicTree<T> tree, QueryAABBCallbackDelegate<TState> callback, Box2 aabb, ExtractAabbDelegate extract) tuple, Proxy proxy)
-        {
-            var item = tuple.tree.GetUserData(proxy)!;
-            var precise = tuple.extract(item);
-
-            if (!precise.Intersects(tuple.aabb))
-            {
-                return true;
-            }
-
-            return tuple.callback(ref tuple.state, item, precise);
-        }
-
         private static bool RayQueryStateCallback<TState>(ref (TState state, RayQueryCallbackDelegate<TState> callback, B2DynamicTree<T> tree, ExtractAabbDelegate? extract, Ray srcRay) tuple, Proxy proxy, in Vector2 hitPos, float distance)
         {
             var item = tuple.tree.GetUserData(proxy)!;
@@ -389,10 +363,6 @@ namespace Robust.Shared.Physics
             public static readonly
                 B2DynamicTree<T>.QueryCallback<(TState state, B2DynamicTree<T> tree, QueryCallbackDelegate<TState> callback, Box2 aabb, bool approx, ExtractAabbDelegate extract)> AabbQueryState =
                     AabbQueryStateCallback;
-
-            public static readonly
-                B2DynamicTree<T>.QueryCallback<(TState state, B2DynamicTree<T> tree, QueryAABBCallbackDelegate<TState> callback, Box2 aabb, ExtractAabbDelegate extract)> ValueAabbQueryState =
-                    ValueAabbQueryStateCallback;
 
             public static readonly
                 B2DynamicTree<T>.RayQueryCallback<(TState state, RayQueryCallbackDelegate<TState> callback,


### PR DESCRIPTION
Offsets the worldPos by the extent on the y-axis for sorting. This also has the benefit of querying less sprite entities as the rendertree stores "correct" bounds (at least, without accounting for grid rotation yet) and we don't need to enlarge the viewport by 5 tiles.