### PR TITLE
Attach to parent before inserting into container

### DIFF
--- a/Robust.Shared/Containers/BaseContainer.cs
+++ b/Robust.Shared/Containers/BaseContainer.cs
@@ -68,8 +68,9 @@ namespace Robust.Shared.Containers
             if (toinsert.TryGetContainerMan(out var containerManager) && !containerManager.Remove(toinsert))
                 return false; // Can't remove from existing container, can't insert.
 
-            InternalInsert(toinsert);
+            // Attach to parent first so we can check IsInContainer more easily.
             transform.AttachParent(Owner.Transform);
+            InternalInsert(toinsert);
 
             // This is an edge case where the parent grid is the container being inserted into, so AttachParent would not unanchor.
             if (transform.Anchored)


### PR DESCRIPTION
tl;dr is that throwing on content needs to be able to have IsInContainer return the correct result when checking for it in EntInsertedIntoContainer