### PR TITLE
Adds deflate compression to MsgState.

### DIFF
--- a/Robust.Shared/Network/Messages/MsgState.cs
+++ b/Robust.Shared/Network/Messages/MsgState.cs
@@ -63,7 +63,6 @@ namespace Robust.Shared.Network.Messages
             var serializer = IoCManager.Resolve<IRobustSerializer>();
             MemoryStream finalStream;
             var stateStream = new MemoryStream();
-            DebugTools.Assert(stateStream.Length <= Int32.MaxValue);
             serializer.SerializeDirect(stateStream, State);
             buffer.WriteVariableInt32((int) stateStream.Length);
 

--- a/Robust.Shared/Network/Messages/MsgState.cs
+++ b/Robust.Shared/Network/Messages/MsgState.cs
@@ -40,9 +40,10 @@ namespace Robust.Shared.Network.Messages
             {
                 var stream = buffer.ReadAlignedMemory(compressedLength);
                 using var decompressStream = new DeflateStream(stream, CompressionMode.Decompress);
-                var decompressedStream = new MemoryStream(decompressStream.CopyToArray(), false);
+                var decompressedStream = new MemoryStream(uncompressedLength);
+                decompressStream.CopyTo(decompressedStream, uncompressedLength);
+                decompressedStream.Position = 0;
                 finalStream = decompressedStream;
-                DebugTools.Assert(decompressedStream.Length == uncompressedLength);
             }
             // State is uncompressed.
             else
@@ -69,7 +70,7 @@ namespace Robust.Shared.Network.Messages
             // We compress the state.
             if (stateStream.Length > CompressionThreshold)
             {
-                stateStream.Seek(0, SeekOrigin.Begin);
+                stateStream.Position = 0;
                 var compressedStream = new MemoryStream();
                 using (var deflateStream = new DeflateStream(compressedStream, CompressionMode.Compress, true))
                 {


### PR DESCRIPTION
Related #889
GameStates above a certain size threshold (256 bytes right now) will be compressed using the deflate algorithm.
I've tested this extensively, and it seems to produce very good results. Here is an example:
![image](https://user-images.githubusercontent.com/6766154/130834439-389bff9e-daaa-4238-8a4a-02e868fb24a3.png)
Initial gamestate being compressed from 1.38 MB down to 73.22 KB

Paging @PJB3005 for review 