### PR TITLE
Don't dirty appearance if state is identical

### DIFF
--- a/Robust.Client/GameObjects/Components/Appearance/AppearanceComponent.cs
+++ b/Robust.Client/GameObjects/Components/Appearance/AppearanceComponent.cs
@@ -84,6 +84,23 @@ namespace Robust.Client.GameObjects
             if (curState is not AppearanceComponentState actualState)
                 return;
 
+            var stateDiff = data.Count != actualState.Data.Count;
+
+            if (!stateDiff)
+            {
+                foreach (var (key, value) in data)
+                {
+                    if (!actualState.Data.TryGetValue(key, out var stateValue) ||
+                        !value.Equals(stateValue))
+                    {
+                        stateDiff = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!stateDiff) return;
+
             data = actualState.Data;
             MarkDirty();
         }


### PR DESCRIPTION
Avoids unnecessary visualizer calls and bugs from duplicate animations or the likes.

Also I playtested this on an old commit with the duplicate animation bug and it was fixed.