### PR TITLE
Port TestPoint from Box2D

### DIFF
--- a/Robust.Shared/Physics/Collision/Collision.cs
+++ b/Robust.Shared/Physics/Collision/Collision.cs
@@ -31,7 +31,7 @@ using Robust.Shared.Utility;
 
 namespace Robust.Shared.Physics.Collision
 {
-    internal interface ICollisionManager
+    internal interface IManifoldManager
     {
         bool TestOverlap(IPhysShape shapeA, int indexA, IPhysShape shapeB, int indexB, in Transform xfA,
             in Transform xfB);
@@ -64,7 +64,7 @@ namespace Robust.Shared.Physics.Collision
     /// <summary>
     ///     Handles several collision features: Generating contact manifolds, testing shape overlap,
     /// </summary>
-    internal class CollisionManager : ICollisionManager
+    internal sealed class CollisionManager : IManifoldManager
     {
         [Dependency] private readonly IConfigurationManager _configManager = default!;
 
@@ -82,7 +82,7 @@ namespace Robust.Shared.Physics.Collision
         /// <param name="xfA">The transform for the first shape.</param>
         /// <param name="xfB">The transform for the seconds shape.</param>
         /// <returns></returns>
-        bool ICollisionManager.TestOverlap(IPhysShape shapeA, int indexA, IPhysShape shapeB, int indexB,
+        bool IManifoldManager.TestOverlap(IPhysShape shapeA, int indexA, IPhysShape shapeB, int indexB,
             in Transform xfA, in Transform xfB)
         {
             // TODO: Make this a struct.

--- a/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
+++ b/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
@@ -42,7 +42,7 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
 {
     public class Contact : IEquatable<Contact>
     {
-        [Dependency] private readonly ICollisionManager _collisionManager = default!;
+        [Dependency] private readonly IManifoldManager _manifoldManager = default!;
 #if DEBUG
         private SharedDebugPhysicsSystem _debugPhysics = default!;
 #endif
@@ -299,7 +299,7 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
             {
                 IPhysShape shapeA = FixtureA.Shape;
                 IPhysShape shapeB = FixtureB.Shape;
-                touching = _collisionManager.TestOverlap(shapeA, ChildIndexA, shapeB, ChildIndexB, bodyATransform, bodyBTransform);
+                touching = _manifoldManager.TestOverlap(shapeA, ChildIndexA, shapeB, ChildIndexB, bodyATransform, bodyBTransform);
 
                 // Sensors don't generate manifolds.
                 Manifold.PointCount = 0;
@@ -381,16 +381,16 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
             {
                 // TODO: Need a unit test for these.
                 case ContactType.Polygon:
-                    _collisionManager.CollidePolygons(ref manifold, (PolygonShape) FixtureA!.Shape, transformA, (PolygonShape) FixtureB!.Shape, transformB);
+                    _manifoldManager.CollidePolygons(ref manifold, (PolygonShape) FixtureA!.Shape, transformA, (PolygonShape) FixtureB!.Shape, transformB);
                     break;
                 case ContactType.PolygonAndCircle:
-                    _collisionManager.CollidePolygonAndCircle(ref manifold, (PolygonShape) FixtureA!.Shape, transformA, (PhysShapeCircle) FixtureB!.Shape, transformB);
+                    _manifoldManager.CollidePolygonAndCircle(ref manifold, (PolygonShape) FixtureA!.Shape, transformA, (PhysShapeCircle) FixtureB!.Shape, transformB);
                     break;
                 case ContactType.EdgeAndCircle:
-                    _collisionManager.CollideEdgeAndCircle(ref manifold, (EdgeShape) FixtureA!.Shape, transformA, (PhysShapeCircle) FixtureB!.Shape, transformB);
+                    _manifoldManager.CollideEdgeAndCircle(ref manifold, (EdgeShape) FixtureA!.Shape, transformA, (PhysShapeCircle) FixtureB!.Shape, transformB);
                     break;
                 case ContactType.EdgeAndPolygon:
-                    _collisionManager.CollideEdgeAndPolygon(ref manifold, (EdgeShape) FixtureA!.Shape, transformA, (PolygonShape) FixtureB!.Shape, transformB);
+                    _manifoldManager.CollideEdgeAndPolygon(ref manifold, (EdgeShape) FixtureA!.Shape, transformA, (PolygonShape) FixtureB!.Shape, transformB);
                     break;
                 case ContactType.ChainAndCircle:
                     throw new NotImplementedException();
@@ -407,18 +407,18 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
                     Collision.CollisionManager.CollideEdgeAndPolygon(ref manifold, _edge, ref transformA, (PolygonShape)FixtureB.Shape, ref transformB);
                     */
                 case ContactType.Circle:
-                    _collisionManager.CollideCircles(ref manifold, (PhysShapeCircle) FixtureA!.Shape, in transformA, (PhysShapeCircle) FixtureB!.Shape, in transformB);
+                    _manifoldManager.CollideCircles(ref manifold, (PhysShapeCircle) FixtureA!.Shape, in transformA, (PhysShapeCircle) FixtureB!.Shape, in transformB);
                     break;
                 // Custom ones
                 // This is kind of shitcodey and originally I just had the poly version but if we get an AABB -> whatever version directly you'll get good optimisations over a cast.
                 case ContactType.Aabb:
-                    _collisionManager.CollideAabbs(ref manifold, (PhysShapeAabb) FixtureA!.Shape, transformA, (PhysShapeAabb) FixtureB!.Shape, transformB);
+                    _manifoldManager.CollideAabbs(ref manifold, (PhysShapeAabb) FixtureA!.Shape, transformA, (PhysShapeAabb) FixtureB!.Shape, transformB);
                     break;
                 case ContactType.AabbAndCircle:
-                    _collisionManager.CollideAabbAndCircle(ref manifold, (PhysShapeAabb) FixtureA!.Shape, transformA, (PhysShapeCircle) FixtureB!.Shape, transformB);
+                    _manifoldManager.CollideAabbAndCircle(ref manifold, (PhysShapeAabb) FixtureA!.Shape, transformA, (PhysShapeCircle) FixtureB!.Shape, transformB);
                     break;
                 case ContactType.AabbAndPolygon:
-                    _collisionManager.CollideAabbAndPolygon(ref manifold, (PhysShapeAabb) FixtureA!.Shape, transformA, (PolygonShape) FixtureB!.Shape, transformB);
+                    _manifoldManager.CollideAabbAndPolygon(ref manifold, (PhysShapeAabb) FixtureA!.Shape, transformA, (PolygonShape) FixtureB!.Shape, transformB);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException($"Collision between {FixtureA!.Shape.GetType()} and {FixtureB!.Shape.GetType()} not supported");

--- a/Robust.Shared/Physics/ShapeManager.cs
+++ b/Robust.Shared/Physics/ShapeManager.cs
@@ -1,0 +1,47 @@
+using System;
+using Robust.Shared.Maths;
+using Robust.Shared.Physics.Collision.Shapes;
+
+namespace Robust.Shared.Physics
+{
+    public interface IShapeManager
+    {
+        /// <summary>
+        /// Returns whether a particular point intersects the specified shape.
+        /// </summary>
+        bool TestPoint(IPhysShape shape, Transform xform, Vector2 worldPoint);
+    }
+
+    public class ShapeManager : IShapeManager
+    {
+        /// <inheritdoc />
+        public bool TestPoint(IPhysShape shape, Transform xform, Vector2 worldPoint)
+        {
+            switch (shape)
+            {
+                case EdgeShape:
+                    return false;
+                case PhysShapeAabb aabb:
+                    // TODO: When we get actual AABBs it will be a stupid ez check,
+                    var polygon = (PolygonShape) aabb;
+                    return TestPoint(polygon, xform, worldPoint);
+                case PhysShapeCircle circle:
+                    var center = xform.Position + Transform.Mul(xform.Quaternion2D, circle.Position);
+                    var distance = worldPoint - center;
+                    return Vector2.Dot(distance, distance) <= circle.Radius * circle.Radius;
+                case PolygonShape poly:
+                    var pLocal = Transform.MulT(xform.Quaternion2D, worldPoint - xform.Position);
+
+                    for (var i = 0; i < poly.Vertices.Count; i++)
+                    {
+                        var dot = Vector2.Dot(poly.Normals[i], pLocal - poly.Vertices[i]);
+                        if (dot > 0f) return false;
+                    }
+
+                    return true;
+                default:
+                    throw new ArgumentOutOfRangeException($"No implemented TestPoint for {shape.GetType()}");
+            }
+        }
+    }
+}

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -17,7 +17,6 @@ namespace Robust.Shared.Physics
     public abstract class SharedBroadphaseSystem : EntitySystem
     {
         [Dependency] private readonly IMapManager _mapManager = default!;
-        [Dependency] private readonly SharedPhysicsSystem _physicsSystem = default!;
 
         private const int MinimumBroadphaseCapacity = 256;
 

--- a/Robust.Shared/SharedIoC.cs
+++ b/Robust.Shared/SharedIoC.cs
@@ -46,9 +46,10 @@ namespace Robust.Shared
             IoCManager.Register<IRobustMappedStringSerializer, RobustMappedStringSerializer>();
             IoCManager.Register<IComponentDependencyManager, ComponentDependencyManager>();
             IoCManager.Register<ISandboxHelper, SandboxHelper>();
-            IoCManager.Register<ICollisionManager, CollisionManager>();
+            IoCManager.Register<IManifoldManager, CollisionManager>();
             IoCManager.Register<IIslandManager, IslandManager>();
             IoCManager.Register<IVerticesSimplifier, RamerDouglasPeuckerSimplifier>();
+            IoCManager.Register<IShapeManager, ShapeManager>();
         }
     }
 }

--- a/Robust.UnitTesting/Server/RobustServerSimulation.cs
+++ b/Robust.UnitTesting/Server/RobustServerSimulation.cs
@@ -203,7 +203,7 @@ namespace Robust.UnitTesting.Server
             container.Register<IComponentDependencyManager, ComponentDependencyManager>();
             container.Register<IEntitySystemManager, EntitySystemManager>();
             container.Register<IIslandManager, IslandManager>();
-            container.Register<ICollisionManager, CollisionManager>();
+            container.Register<IManifoldManager, CollisionManager>();
             container.Register<IMapManagerInternal, MapManager>();
             container.RegisterInstance<IPauseManager>(new Mock<IPauseManager>().Object); // TODO: get timing working similar to RobustIntegrationTest
             container.Register<IPhysicsManager, PhysicsManager>();

--- a/Robust.UnitTesting/Shared/Physics/ManifoldManager_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/ManifoldManager_Test.cs
@@ -8,10 +8,10 @@ using Robust.Shared.Physics.Collision.Shapes;
 namespace Robust.UnitTesting.Shared.Physics
 {
     [TestFixture]
-    [TestOf(typeof(ICollisionManager))]
-    public class CollisionManager_Test : RobustUnitTest
+    [TestOf(typeof(IManifoldManager))]
+    public class ManifoldManager_Test : RobustUnitTest
     {
-        private ICollisionManager _collisionManager = default!;
+        private IManifoldManager _manifoldManager = default!;
 
         private PhysShapeCircle _circleA = default!;
         private PhysShapeCircle _circleB = default!;
@@ -22,7 +22,7 @@ namespace Robust.UnitTesting.Shared.Physics
         [OneTimeSetUp]
         public void Setup()
         {
-            _collisionManager = IoCManager.Resolve<ICollisionManager>();
+            _manifoldManager = IoCManager.Resolve<IManifoldManager>();
             _circleA = new PhysShapeCircle {Radius = 0.5f};
             _circleB = new PhysShapeCircle {Radius = 0.5f};
             _polyA = new PolygonShape();
@@ -38,15 +38,15 @@ namespace Robust.UnitTesting.Shared.Physics
             var transformB = new Transform(Vector2.One, 0f);
 
             // No overlap
-            Assert.That(_collisionManager.TestOverlap(_circleA, 0, _circleB, 0, transformA, transformB), Is.EqualTo(false));
+            Assert.That(_manifoldManager.TestOverlap(_circleA, 0, _circleB, 0, transformA, transformB), Is.EqualTo(false));
 
             // Overlap directly
             transformA = new Transform(transformB.Position, 0f);
-            Assert.That(_collisionManager.TestOverlap(_circleA, 0, _circleB, 0, transformA, transformB), Is.EqualTo(true));
+            Assert.That(_manifoldManager.TestOverlap(_circleA, 0, _circleB, 0, transformA, transformB), Is.EqualTo(true));
 
             // Overlap on edge
             transformA.Position = transformB.Position + new Vector2(0.5f, 0.0f);
-            Assert.That(_collisionManager.TestOverlap(_circleA, 0, _circleB, 0, transformA, transformB), Is.EqualTo(true));
+            Assert.That(_manifoldManager.TestOverlap(_circleA, 0, _circleB, 0, transformA, transformB), Is.EqualTo(true));
         }
 
         [Test]
@@ -56,18 +56,18 @@ namespace Robust.UnitTesting.Shared.Physics
             var transformB = new Transform(Vector2.One, 0f);
 
             // No overlap
-            Assert.That(_collisionManager.TestOverlap(_polyA, 0, _polyB, 0, transformA, transformB), Is.EqualTo(false));
+            Assert.That(_manifoldManager.TestOverlap(_polyA, 0, _polyB, 0, transformA, transformB), Is.EqualTo(false));
 
             // Overlap directly
             transformA = new Transform(transformB.Position, 0f);
-            Assert.That(_collisionManager.TestOverlap(_polyA, 0, _polyB, 0, transformA, transformB), Is.EqualTo(true));
+            Assert.That(_manifoldManager.TestOverlap(_polyA, 0, _polyB, 0, transformA, transformB), Is.EqualTo(true));
 
             // Overlap on edge
             transformA.Position = transformB.Position + new Vector2(0.5f, 0.0f);
-            Assert.That(_collisionManager.TestOverlap(_polyA, 0, _polyB, 0, transformA, transformB), Is.EqualTo(true));
+            Assert.That(_manifoldManager.TestOverlap(_polyA, 0, _polyB, 0, transformA, transformB), Is.EqualTo(true));
 
             transformA.Quaternion2D = transformA.Quaternion2D.Set(45f);
-            Assert.That(_collisionManager.TestOverlap(_polyA, 0, _polyB, 0, transformA, transformB), Is.EqualTo(true));
+            Assert.That(_manifoldManager.TestOverlap(_polyA, 0, _polyB, 0, transformA, transformB), Is.EqualTo(true));
         }
 
         [Test]
@@ -92,7 +92,7 @@ namespace Robust.UnitTesting.Shared.Physics
                     new() {LocalPoint = new Vector2(0.5f, 0.5f), Id = new ContactID {Key = 65794}}
                 }
             };
-            _collisionManager.CollidePolygons(ref manifold, _polyA, transformA, _polyB, transformB);
+            _manifoldManager.CollidePolygons(ref manifold, _polyA, transformA, _polyB, transformB);
 
             for (var i = 0; i < manifold.Points.Length; i++)
             {

--- a/Robust.UnitTesting/Shared/Physics/Quaternion_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Quaternion_Test.cs
@@ -1,7 +1,0 @@
-namespace Robust.UnitTesting.Shared.Physics
-{
-    public class Quaternion_Test
-    {
-        
-    }
-}

--- a/Robust.UnitTesting/Shared/Physics/ShapeManager_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/ShapeManager_Test.cs
@@ -1,0 +1,69 @@
+using System;
+using NUnit.Framework;
+using Robust.Shared.Maths;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Collision.Shapes;
+
+namespace Robust.UnitTesting.Shared.Physics
+{
+    [TestFixture]
+    [TestOf(typeof(IShapeManager))]
+    public class ShapeManager_Test : RobustUnitTest
+    {
+        private IShapeManager _shapeManager = default!;
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            _shapeManager = new ShapeManager();
+        }
+
+        [Test]
+        public void TestCirclePoint()
+        {
+            var circle = new PhysShapeCircle() {Radius = 0.5f};
+            var transform = new Transform(0f);
+            var posA = Vector2.One;
+            var posB = Vector2.Zero;
+            var posC = new Vector2(0.1f, 0.3f);
+
+            Assert.That(_shapeManager.TestPoint(circle, transform, posA), Is.EqualTo(false));
+            Assert.That(_shapeManager.TestPoint(circle, transform, posB), Is.EqualTo(true));
+            Assert.That(_shapeManager.TestPoint(circle, transform, posC), Is.EqualTo(true));
+        }
+
+        [Test]
+        public void TestEdgePoint()
+        {
+            // Edges never collide with a point because they're a damn line
+            var edge = new EdgeShape(Vector2.Zero, Vector2.One);
+            var transform = new Transform(0f);
+            var posA = Vector2.One;
+            var posB = Vector2.Zero;
+            var posC = new Vector2(0.1f, 0.3f);
+
+            Assert.That(_shapeManager.TestPoint(edge, transform, posA), Is.EqualTo(false));
+            Assert.That(_shapeManager.TestPoint(edge, transform, posB), Is.EqualTo(false));
+            Assert.That(_shapeManager.TestPoint(edge, transform, posC), Is.EqualTo(false));
+        }
+
+        [Test]
+        public void TestPolyPoint()
+        {
+            var poly = new PolygonShape();
+            poly.SetAsBox(0.5f, 0.5f);
+            var transform = new Transform(0f);
+            var posA = Vector2.One;
+            var posB = Vector2.Zero;
+            var posC = new Vector2(0.6f, 0.0f);
+
+            Assert.That(_shapeManager.TestPoint(poly, transform, posA), Is.EqualTo(false));
+            Assert.That(_shapeManager.TestPoint(poly, transform, posB), Is.EqualTo(true));
+            Assert.That(_shapeManager.TestPoint(poly, transform, posC), Is.EqualTo(false));
+
+            // Rotations
+            transform.Quaternion2D = new Quaternion2D(MathF.PI / 4);
+            Assert.That(_shapeManager.TestPoint(poly, transform, posC), Is.EqualTo(true));
+        }
+    }
+}

--- a/Robust.UnitTesting/Shared/Physics/Stack_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Stack_Test.cs
@@ -49,7 +49,6 @@ namespace Robust.UnitTesting.Shared.Physics
             var entityManager = server.ResolveDependency<IEntityManager>();
             var mapManager = server.ResolveDependency<IMapManager>();
             var entitySystemManager = server.ResolveDependency<IEntitySystemManager>();
-            var physicsSystem = entitySystemManager.GetEntitySystem<SharedPhysicsSystem>();
             var broadphaseSystem = entitySystemManager.GetEntitySystem<SharedBroadphaseSystem>();
             MapId mapId;
 


### PR DESCRIPTION
Rather than having the methods on the shapes themselves (whenever we eventually get them as structs) I just put them on a shapemanager instead as it seemed cleaner?

Nothing currently uses this as EntityLookup and SharedBroadphaseSystem need their queries cleaned up a bit which will be a separate PR.

I also lumped in my change to ICollisionManager to call it IManifoldManager to better reflect its purpose as I was too lazy to split it out (and ICollisionManager will be an actual interface intended to be used by content).