### PR TITLE
Significantly reduce debug allocations

### DIFF
--- a/Robust.Shared/GameObjects/Component.cs
+++ b/Robust.Shared/GameObjects/Component.cs
@@ -50,7 +50,7 @@ namespace Robust.Shared.GameObjects
 #if DEBUG
             if (LifeStage != ComponentLifeStage.Added)
             {
-                DebugTools.Assert(false, $"Component {this.GetType().Name} did not call base {nameof(OnAdd)} in derived method.");
+                DebugTools.Assert($"Component {this.GetType().Name} did not call base {nameof(OnAdd)} in derived method.");
             }
 #endif
         }
@@ -69,7 +69,7 @@ namespace Robust.Shared.GameObjects
 #if DEBUG
             if (LifeStage != ComponentLifeStage.Initialized)
             {
-                DebugTools.Assert(false, $"Component {this.GetType().Name} did not call base {nameof(Initialize)} in derived method.");
+                DebugTools.Assert($"Component {this.GetType().Name} did not call base {nameof(Initialize)} in derived method.");
             }
 #endif
         }
@@ -88,7 +88,7 @@ namespace Robust.Shared.GameObjects
 #if DEBUG
             if (LifeStage != ComponentLifeStage.Running)
             {
-                DebugTools.Assert(false, $"Component {this.GetType().Name} did not call base {nameof(Startup)} in derived method.");
+                DebugTools.Assert($"Component {this.GetType().Name} did not call base {nameof(Startup)} in derived method.");
             }
 #endif
         }
@@ -111,7 +111,7 @@ namespace Robust.Shared.GameObjects
 #if DEBUG
             if (LifeStage != ComponentLifeStage.Stopped)
             {
-                DebugTools.Assert(false, $"Component {this.GetType().Name} did not call base {nameof(Shutdown)} in derived method.");
+                DebugTools.Assert($"Component {this.GetType().Name} did not call base {nameof(Shutdown)} in derived method.");
             }
 #endif
         }
@@ -131,7 +131,7 @@ namespace Robust.Shared.GameObjects
 #if DEBUG
             if (LifeStage != ComponentLifeStage.Deleted)
             {
-                DebugTools.Assert(false, $"Component {this.GetType().Name} did not call base {nameof(OnRemove)} in derived method.");
+                DebugTools.Assert($"Component {this.GetType().Name} did not call base {nameof(OnRemove)} in derived method.");
             }
 #endif
         }

--- a/Robust.Shared/GameObjects/Component.cs
+++ b/Robust.Shared/GameObjects/Component.cs
@@ -47,7 +47,12 @@ namespace Robust.Shared.GameObjects
             LifeStage = ComponentLifeStage.Adding;
             OnAdd();
 
-            DebugTools.Assert(LifeStage == ComponentLifeStage.Added, $"Component {this.GetType().Name} did not call base {nameof(OnAdd)} in derived method.");
+#if DEBUG
+            if (LifeStage != ComponentLifeStage.Added)
+            {
+                DebugTools.Assert(false, $"Component {this.GetType().Name} did not call base {nameof(OnAdd)} in derived method.");
+            }
+#endif
         }
 
         /// <summary>
@@ -61,7 +66,12 @@ namespace Robust.Shared.GameObjects
             LifeStage = ComponentLifeStage.Initializing;
             Initialize();
 
-            DebugTools.Assert(LifeStage == ComponentLifeStage.Initialized, $"Component {this.GetType().Name} did not call base {nameof(Initialize)} in derived method.");
+#if DEBUG
+            if (LifeStage != ComponentLifeStage.Initialized)
+            {
+                DebugTools.Assert(false, $"Component {this.GetType().Name} did not call base {nameof(Initialize)} in derived method.");
+            }
+#endif
         }
 
         /// <summary>
@@ -75,7 +85,12 @@ namespace Robust.Shared.GameObjects
             LifeStage = ComponentLifeStage.Starting;
             Startup();
 
-            DebugTools.Assert(LifeStage == ComponentLifeStage.Running, $"Component {this.GetType().Name} did not call base {nameof(Startup)} in derived method.");
+#if DEBUG
+            if (LifeStage != ComponentLifeStage.Running)
+            {
+                DebugTools.Assert(false, $"Component {this.GetType().Name} did not call base {nameof(Startup)} in derived method.");
+            }
+#endif
         }
 
         /// <summary>
@@ -93,7 +108,12 @@ namespace Robust.Shared.GameObjects
             LifeStage = ComponentLifeStage.Stopping;
             Shutdown();
 
-            DebugTools.Assert(LifeStage == ComponentLifeStage.Stopped, $"Component {this.GetType().Name} did not call base {nameof(Shutdown)} in derived method.");
+#if DEBUG
+            if (LifeStage != ComponentLifeStage.Stopped)
+            {
+                DebugTools.Assert(false, $"Component {this.GetType().Name} did not call base {nameof(Shutdown)} in derived method.");
+            }
+#endif
         }
 
         /// <summary>
@@ -108,7 +128,12 @@ namespace Robust.Shared.GameObjects
             LifeStage = ComponentLifeStage.Removing;
             OnRemove();
 
-            DebugTools.Assert(LifeStage == ComponentLifeStage.Deleted, $"Component {this.GetType().Name} did not call base {nameof(OnRemove)} in derived method.");
+#if DEBUG
+            if (LifeStage != ComponentLifeStage.Deleted)
+            {
+                DebugTools.Assert(false, $"Component {this.GetType().Name} did not call base {nameof(OnRemove)} in derived method.");
+            }
+#endif
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -149,7 +149,10 @@ namespace Robust.Shared.GameObjects
             // Second integrity check in case of.
             foreach (var t in EntityManager.ComponentManager.GetComponents(Uid))
             {
-                DebugTools.Assert(t.Initialized, $"Component {t.Name} was not initialized at the end of {nameof(InitializeComponents)}.");
+                if (!t.Initialized)
+                {
+                    DebugTools.Assert(false, $"Component {t.Name} was not initialized at the end of {nameof(InitializeComponents)}.");
+                }
             }
 
 #endif

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -151,7 +151,7 @@ namespace Robust.Shared.GameObjects
             {
                 if (!t.Initialized)
                 {
-                    DebugTools.Assert(false, $"Component {t.Name} was not initialized at the end of {nameof(InitializeComponents)}.");
+                    DebugTools.Assert($"Component {t.Name} was not initialized at the end of {nameof(InitializeComponents)}.");
                 }
             }
 


### PR DESCRIPTION
I know it's only debug but it's number 1 on entity spawning

![image](https://user-images.githubusercontent.com/31366439/132190499-148d9ac9-ce5c-44e8-8eea-34a38a2eb718.png)
