### PR TITLE
Avoid unnecessary TransformComponent cast in PVS

### DIFF
--- a/Robust.Server/GameStates/EntityViewCulling.cs
+++ b/Robust.Server/GameStates/EntityViewCulling.cs
@@ -430,7 +430,7 @@ namespace Robust.Server.GameStates
 
             // This is slow but entities being parented to anchored ones is hopefully rare so shouldn't be hit too much.
             var mapGrid = (IMapGridInternal) _mapManager.GetGrid(xform.GridID);
-            var local = mapGrid.MapToGrid(xform.MapPosition);
+            var local = xform.Coordinates;
             var chunk = mapGrid.GetChunk(mapGrid.LocalToChunkIndices(local));
 
             if (!includedChunks.TryGetValue(xform.GridID, out var chunks))

--- a/Robust.Shared/Map/IMapGrid.cs
+++ b/Robust.Shared/Map/IMapGrid.cs
@@ -220,7 +220,7 @@ namespace Robust.Shared.Map
         Vector2i GridTileToChunkIndices(Vector2i gridTile);
 
         /// <summary>
-        /// Transforms local grid coordinates to chunk indices.
+        /// Transforms EntityCoordinates to chunk indices relative to grid origin.
         /// </summary>
         Vector2i LocalToChunkIndices(EntityCoordinates gridPos);
 

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -656,9 +656,7 @@ namespace Robust.Shared.Map
             return new Vector2i(x, y);
         }
 
-        /// <summary>
-        ///     Transforms entity coordinates to tile indices relative to grid origin.
-        /// </summary>
+        /// <inheritdoc />
         public Vector2i CoordinatesToTile(EntityCoordinates coords)
         {
             DebugTools.Assert(ParentMapId == coords.GetMapId(_entityManager));
@@ -674,9 +672,7 @@ namespace Robust.Shared.Map
             return new Vector2i(x, y);
         }
 
-        /// <summary>
-        ///     Transforms global world coordinates to chunk indices relative to grid origin.
-        /// </summary>
+        /// <inheritdoc />
         public Vector2i LocalToChunkIndices(EntityCoordinates gridPos)
         {
             Vector2 local;


### PR DESCRIPTION
I profiled for a minute running in release with 20 clients:
master:
![image](https://user-images.githubusercontent.com/31366439/132213469-0c4b80d4-632e-4d7e-9995-96fa2d2d6e57.png)
PR:
![image](https://user-images.githubusercontent.com/31366439/132213621-efb1d263-d629-47b0-abbb-9267a5d3d460.png)

Although it doesn't use the transform property but this supports removing IEntity better + avoids all of the unnecessary casts when going up transforms (which I imagine happens very frequently).