### PR TITLE
Change serialization copying with serializers to use expression trees

### DIFF
--- a/Robust.Benchmarks/Program.cs
+++ b/Robust.Benchmarks/Program.cs
@@ -4,6 +4,8 @@ namespace Robust.Benchmarks
 {
     internal class Program
     {
+        // --allCategories=ctg1,ctg2
+        // --anyCategories=ctg1,ctg2
         public static void Main(string[] args)
         {
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/Robust.Benchmarks/Serialization/BenchmarkIntSerializer.cs
+++ b/Robust.Benchmarks/Serialization/BenchmarkIntSerializer.cs
@@ -1,0 +1,40 @@
+﻿using System.Globalization;
+using Robust.Shared.IoC;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Manager.Result;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+
+namespace Robust.Benchmarks.Serialization
+{
+    public class BenchmarkIntSerializer : ITypeSerializer<int, ValueDataNode>
+    {
+        public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
+            IDependencyCollection dependencies, ISerializationContext? context = null)
+        {
+            return int.TryParse(node.Value, out _)
+                ? new ValidatedValueNode(node)
+                : new ErrorNode(node, $"Failed parsing int value: {node.Value}");
+        }
+
+        public DeserializationResult Read(ISerializationManager serializationManager, ValueDataNode node,
+            IDependencyCollection dependencies, bool skipHook, ISerializationContext? context = null)
+        {
+            return new DeserializedValue<int>(int.Parse(node.Value, CultureInfo.InvariantCulture));
+        }
+
+        public DataNode Write(ISerializationManager serializationManager, int value, bool alwaysWrite = false,
+            ISerializationContext? context = null)
+        {
+            return new ValueDataNode(value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        public int Copy(ISerializationManager serializationManager, int source, int target, bool skipHook,
+            ISerializationContext? context = null)
+        {
+            return source;
+        }
+    }
+}

--- a/Robust.Benchmarks/Serialization/Copy/SerializationCopyBenchmark.cs
+++ b/Robust.Benchmarks/Serialization/Copy/SerializationCopyBenchmark.cs
@@ -12,6 +12,7 @@ using YamlDotNet.RepresentationModel;
 
 namespace Robust.Benchmarks.Serialization.Copy
 {
+    [MemoryDiagnoser]
     public class SerializationCopyBenchmark : SerializationBenchmark
     {
         public SerializationCopyBenchmark()
@@ -119,7 +120,7 @@ namespace Robust.Benchmarks.Serialization.Copy
 
         [Benchmark]
         [BenchmarkCategory("flag")]
-        public object? CreateCopyFlagZero()
+        public object? CopyFlagZero()
         {
             return SerializationManager.CopyWithTypeSerializer(
                 typeof(FlagSerializer<BenchmarkFlags>),
@@ -129,12 +130,22 @@ namespace Robust.Benchmarks.Serialization.Copy
 
         [Benchmark]
         [BenchmarkCategory("flag")]
-        public object? CreateCopyFlagThirtyOne()
+        public object? CopyFlagThirtyOne()
         {
             return SerializationManager.CopyWithTypeSerializer(
                 typeof(FlagSerializer<BenchmarkFlags>),
                 (int) FlagThirtyOne,
                 (int) FlagThirtyOne);
+        }
+
+        [Benchmark]
+        [BenchmarkCategory("customTypeSerializer")]
+        public object? CopyIntegerCustomSerializer()
+        {
+            return SerializationManager.CopyWithTypeSerializer(
+                typeof(BenchmarkIntSerializer),
+                Integer,
+                Integer);
         }
     }
 }

--- a/Robust.Benchmarks/Serialization/Definitions/DataDefinitionWithString.cs
+++ b/Robust.Benchmarks/Serialization/Definitions/DataDefinitionWithString.cs
@@ -5,7 +5,7 @@ namespace Robust.Benchmarks.Serialization.Definitions
     [DataDefinition]
     public class DataDefinitionWithString
     {
-        [field: DataField("string")]
+        [DataField("string")]
         public string StringField { get; init; } = default!;
     }
 }

--- a/Robust.Benchmarks/Serialization/Initialize/SerializationInitializeBenchmark.cs
+++ b/Robust.Benchmarks/Serialization/Initialize/SerializationInitializeBenchmark.cs
@@ -3,6 +3,7 @@ using Robust.Shared.Serialization.Manager;
 
 namespace Robust.Benchmarks.Serialization.Initialize
 {
+    [MemoryDiagnoser]
     public class SerializationInitializeBenchmark : SerializationBenchmark
     {
         [IterationCleanup]

--- a/Robust.Benchmarks/Serialization/Read/SerializationReadBenchmark.cs
+++ b/Robust.Benchmarks/Serialization/Read/SerializationReadBenchmark.cs
@@ -11,6 +11,7 @@ using YamlDotNet.RepresentationModel;
 
 namespace Robust.Benchmarks.Serialization.Read
 {
+    [MemoryDiagnoser]
     public class SerializationReadBenchmark : SerializationBenchmark
     {
         public SerializationReadBenchmark()
@@ -80,6 +81,16 @@ namespace Robust.Benchmarks.Serialization.Read
                 typeof(int),
                 typeof(FlagSerializer<BenchmarkFlags>),
                 FlagThirtyOne);
+        }
+
+        [Benchmark]
+        [BenchmarkCategory("customTypeSerializer")]
+        public DeserializationResult ReadIntegerCustomSerializer()
+        {
+            return SerializationManager.ReadWithTypeSerializer(
+                typeof(int),
+                typeof(BenchmarkIntSerializer),
+                IntNode);
         }
     }
 }

--- a/Robust.Benchmarks/Serialization/Write/SerializationWriteBenchmark.cs
+++ b/Robust.Benchmarks/Serialization/Write/SerializationWriteBenchmark.cs
@@ -12,6 +12,7 @@ using YamlDotNet.RepresentationModel;
 
 namespace Robust.Benchmarks.Serialization.Write
 {
+    [MemoryDiagnoser]
     public class SerializationWriteBenchmark : SerializationBenchmark
     {
         public SerializationWriteBenchmark()
@@ -118,6 +119,16 @@ namespace Robust.Benchmarks.Serialization.Write
                 typeof(int),
                 typeof(FlagSerializer<BenchmarkFlags>),
                 FlagThirtyOne);
+        }
+
+        [Benchmark]
+        [BenchmarkCategory("customTypeSerializer")]
+        public DataNode WriteIntegerCustomSerializer()
+        {
+            return SerializationManager.WriteWithTypeSerializer(
+                typeof(int),
+                typeof(BenchmarkIntSerializer),
+                Integer);
         }
     }
 }

--- a/Robust.Shared/Serialization/Manager/ISerializationManager.cs
+++ b/Robust.Shared/Serialization/Manager/ISerializationManager.cs
@@ -216,6 +216,7 @@ namespace Robust.Shared.Serialization.Manager
         [MustUseReturnValue]
         T? Copy<T>(T? source, T? target, ISerializationContext? context = null, bool skipHook = false);
 
+        [MustUseReturnValue]
         object? CopyWithTypeSerializer(Type typeSerializer, object? source, object? target,
             ISerializationContext? context = null, bool skipHook = false);
 

--- a/Robust.Shared/Serialization/Manager/SerializationManager.CustomSerializers.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.CustomSerializers.cs
@@ -1,15 +1,72 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using Robust.Shared.Serialization.Manager.Result;
 using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Serialization.Manager
 {
     public partial class SerializationManager
     {
+        private delegate object CopySerializerDelegate(
+            object source,
+            ref object target,
+            bool skipHook,
+            ISerializationContext? context = null);
+
         private readonly Dictionary<Type, object> _customTypeSerializers = new();
+
+        private readonly ConcurrentDictionary<(Type common, Type source, Type target, Type serializer), CopySerializerDelegate>
+            _copySerializerDelegates = new();
+
+        private CopySerializerDelegate GetOrCreateCopySerializerDelegate(Type common, Type source, Type target, Type serializer)
+        {
+            return _copySerializerDelegates.GetOrAdd((common, source, target, serializer), (_, tuple) =>
+            {
+                var instanceParam = Expression.Constant(this);
+                var sourceParam = Expression.Parameter(typeof(object), "source");
+                var targetParam = Expression.Parameter(typeof(object).MakeByRefType(), "target");
+                var skipHookParam = Expression.Parameter(typeof(bool), "skipHook");
+                var contextParam = Expression.Parameter(typeof(ISerializationContext), "context");
+
+                var targetCastVariable = Expression.Variable(tuple.target, "targetCastVariable");
+
+                var returnLabel = Expression.Label(typeof(object));
+                var returnExpression = Expression.Label(returnLabel, targetParam);
+
+                var call = Expression.Call(
+                    instanceParam,
+                    nameof(CopyWithSerializer),
+                    new[] {tuple.common, tuple.source, tuple.target, tuple.serializer},
+                    Expression.Convert(sourceParam, tuple.source),
+                    targetCastVariable,
+                    skipHookParam,
+                    contextParam);
+
+                var block = Expression.Block(
+                    new[] {targetCastVariable},
+                    Expression.Assign(
+                        targetCastVariable,
+                        Expression.Convert(targetParam, tuple.target)),
+                    Expression.Assign(targetCastVariable, call),
+                    Expression.Assign(
+                        targetParam,
+                        Expression.Convert(targetCastVariable, typeof(object))),
+                    Expression.Return(returnLabel, targetParam),
+                    returnExpression);
+
+                return Expression.Lambda<CopySerializerDelegate>(
+                    block,
+                    sourceParam,
+                    targetParam,
+                    skipHookParam,
+                    contextParam).Compile();
+            }, (common, source, target, serializer));
+        }
 
         private DeserializationResult ReadWithSerializer<T, TNode, TSerializer>(
             TNode node,
@@ -34,9 +91,19 @@ namespace Robust.Shared.Serialization.Manager
             return serializer.Write(this, value, alwaysWrite, context);
         }
 
+        private object CopyWithSerializerRaw(Type serializer, object source, ref object target, bool skipHook, ISerializationContext? context = null)
+        {
+            var sourceType = source.GetType();
+            var targetType = target.GetType();
+            var commonType = TypeHelpers.SelectCommonType(sourceType, targetType) ??
+                             throw new ArgumentException($"No common type found between {sourceType} and {targetType}");
+
+            return GetOrCreateCopySerializerDelegate(commonType, sourceType, targetType, serializer)(source, ref target, skipHook, context);
+        }
+
         private TCommon CopyWithSerializer<TCommon, TSource, TTarget, TSerializer>(
             TSource source,
-            TTarget target,
+            ref TTarget target,
             bool skipHook,
             ISerializationContext? context = null)
             where TSource : TCommon

--- a/Robust.Shared/Serialization/Manager/SerializationManager.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.cs
@@ -653,19 +653,13 @@ namespace Robust.Shared.Serialization.Manager
             return copy == null ? default : (T?) copy;
         }
 
+        [MustUseReturnValue]
         public object? CopyWithTypeSerializer(Type typeSerializer, object? source, object? target,
             ISerializationContext? context = null, bool skipHook = false)
         {
             if (source == null || target == null) return source;
-            var commonType = TypeHelpers.SelectCommonType(source.GetType(), target.GetType());
-            if (commonType == null)
-            {
-                throw new InvalidOperationException($"Could not find common type in {nameof(CopyWithTypeSerializer)}!");
-            }
 
-            var method = typeof(SerializationManager).GetRuntimeMethods().First(m => m.Name == nameof(CopyWithSerializer))!
-                .MakeGenericMethod(commonType, source.GetType(), target.GetType(), typeSerializer);
-            return method.Invoke(this, new object?[] {source, target, skipHook, context});
+            return CopyWithSerializerRaw(typeSerializer, source, ref target, skipHook, context);
         }
 
         private object? CreateCopyInternal(Type type, object? source, ISerializationContext? context = null, bool skipHook = false)

--- a/Robust.UnitTesting/Shared/Serialization/TypeSerializers/ListSerializerTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/TypeSerializers/ListSerializerTest.cs
@@ -32,5 +32,30 @@ namespace Robust.UnitTesting.Shared.Serialization.TypeSerializers
 
             Assert.That(deserializedList, Is.EqualTo(list));
         }
+
+        [Test]
+        public void CustomCopyTest()
+        {
+            var source = new List<string> {"A", "E"};
+            var target = new List<string>();
+
+            Assert.IsNotEmpty(source);
+            Assert.IsEmpty(target);
+
+            var copy = (List<string>?) Serialization.CopyWithTypeSerializer(typeof(ListSerializers<string>), source, target);
+
+            Assert.NotNull(copy);
+
+            Assert.IsNotEmpty(copy!);
+            Assert.IsNotEmpty(target);
+
+            Assert.That(copy, Is.EqualTo(target));
+
+            Assert.That(copy, Does.Contain("A"));
+            Assert.That(copy, Does.Contain("E"));
+
+            Assert.That(target, Does.Contain("A"));
+            Assert.That(target, Does.Contain("E"));
+        }
     }
 }

--- a/Robust.UnitTesting/Shared/Serialization/TypeSerializers/ListSerializerTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/TypeSerializers/ListSerializerTest.cs
@@ -51,6 +51,9 @@ namespace Robust.UnitTesting.Shared.Serialization.TypeSerializers
 
             Assert.That(copy, Is.EqualTo(target));
 
+            Assert.That(copy!.Count, Is.EqualTo(2));
+            Assert.That(target.Count, Is.EqualTo(2));
+
             Assert.That(copy, Does.Contain("A"));
             Assert.That(copy, Does.Contain("E"));
 


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-4790K CPU 4.00GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.201
  [Host]     : .NET Core 5.0.4 (CoreCLR 5.0.421.11614, CoreFX 5.0.421.11614), X64 RyuJIT
  DefaultJob : .NET Core 5.0.4 (CoreCLR 5.0.421.11614, CoreFX 5.0.421.11614), X64 RyuJIT
```

|                      Method |     Mean |     Error |    StdDev |   Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------------- |---------:|----------:|----------:|---------:|-------:|------:|------:|----------:|
| OldCopyIntegerCustomSerializer | 4351 ns | 113.8 ns | 330.3 ns | 4241 ns | 0.5569 |     - |     - |   2334 B |
| NewCopyIntegerCustomSerializer | 171.2 ns | 3.36 ns | 3.86 ns  |     - |  0.0324 |     - |     - |     136 B |

