### PR TITLE
Change serialization reading with serializers to use expression trees

### DIFF
--- a/Robust.Shared/Serialization/Manager/ISerializationManager.cs
+++ b/Robust.Shared/Serialization/Manager/ISerializationManager.cs
@@ -137,7 +137,7 @@ namespace Robust.Shared.Serialization.Manager
         /// <returns>The deserialized object, or null.</returns>
         T? ReadValue<T>(DataNode node, ISerializationContext? context = null, bool skipHook = false);
 
-        DeserializationResult ReadWithTypeSerializer(Type type, Type typeSerializer, DataNode node,
+        DeserializationResult ReadWithTypeSerializer(Type value, Type serializer, DataNode node,
             ISerializationContext? context = null, bool skipHook = false);
 
         #endregion

--- a/Robust.Shared/Serialization/Manager/SerializationManager.CustomSerializers.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.CustomSerializers.cs
@@ -33,9 +33,9 @@ namespace Robust.Shared.Serialization.Manager
 
         private ReadSerializerDelegate GetOrCreateReadSerializerDelegate(Type value, Type node, Type serializer)
         {
-            return _readSerializerDelegates.GetOrAdd((value, node, serializer), (_, tuple) =>
+            return _readSerializerDelegates.GetOrAdd((value, node, serializer), static (tuple, instance) =>
             {
-                var instanceParam = Expression.Constant(this);
+                var instanceParam = Expression.Constant(instance);
                 var nodeParam = Expression.Parameter(typeof(DataNode), "node");
                 var contextParam = Expression.Parameter(typeof(ISerializationContext), "context");
                 var skipHookParam = Expression.Parameter(typeof(bool), "skipHook");
@@ -63,7 +63,7 @@ namespace Robust.Shared.Serialization.Manager
                     nodeParam,
                     contextParam,
                     skipHookParam).Compile();
-            }, (value, node, serializer));
+            }, this);
         }
 
         private CopySerializerDelegate GetOrCreateCopySerializerDelegate(Type common, Type source, Type target, Type serializer)

--- a/Robust.Shared/Serialization/Manager/SerializationManager.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.cs
@@ -461,12 +461,10 @@ namespace Robust.Shared.Serialization.Manager
             return ReadValueCast<T>(typeof(T), node, context, skipHook);
         }
 
-        public DeserializationResult ReadWithTypeSerializer(Type type, Type typeSerializer, DataNode node, ISerializationContext? context = null,
+        public DeserializationResult ReadWithTypeSerializer(Type value, Type serializer, DataNode node, ISerializationContext? context = null,
             bool skipHook = false)
         {
-            var method = typeof(SerializationManager).GetRuntimeMethods().First(m => m.Name == nameof(ReadWithSerializer))!
-                .MakeGenericMethod(type, node.GetType(), typeSerializer);
-            return (DeserializationResult) method.Invoke(this, new object?[] {node, context, skipHook})!;
+            return ReadWithSerializerRaw(value, node, serializer, context, skipHook);
         }
 
         public DataNode WriteValue<T>(T value, bool alwaysWrite = false,

--- a/Robust.UnitTesting/Shared/Serialization/TypeSerializers/ListSerializerTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/TypeSerializers/ListSerializerTest.cs
@@ -34,6 +34,21 @@ namespace Robust.UnitTesting.Shared.Serialization.TypeSerializers
         }
 
         [Test]
+        public void CustomReadTest()
+        {
+            var node = new SequenceDataNode("A", "E");
+
+            var result = Serialization.ReadWithTypeSerializer(typeof(List<string>), typeof(ListSerializers<string>), node);
+            var list = (List<string>?) result.RawValue;
+
+            Assert.NotNull(list);
+            Assert.IsNotEmpty(list!);
+            Assert.That(list, Has.Count.EqualTo(2));
+            Assert.That(list, Does.Contain("A"));
+            Assert.That(list, Does.Contain("E"));
+        }
+
+        [Test]
         public void CustomCopyTest()
         {
             var source = new List<string> {"A", "E"};


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-4790K CPU 4.00GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.201
  [Host]     : .NET Core 5.0.4 (CoreCLR 5.0.421.11614, CoreFX 5.0.421.11614), X64 RyuJIT
  DefaultJob : .NET Core 5.0.4 (CoreCLR 5.0.421.11614, CoreFX 5.0.421.11614), X64 RyuJIT
```
|                         Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
| OldReadIntegerCustomSerializer |  3186 ns |   77.5 ns |  218.5 ns | 0.4578 |     - |     - |    1880 B |
| NewReadIntegerCustomSerializer | 152.3 ns |   3.00 ns |   5.84 ns | 0.0210 |     - |     - |      88 B |
