### PR TITLE
Change serialization writing with serializers to use expression trees

### DIFF
--- a/Robust.Shared/Serialization/Manager/ISerializationManager.cs
+++ b/Robust.Shared/Serialization/Manager/ISerializationManager.cs
@@ -174,7 +174,7 @@ namespace Robust.Shared.Serialization.Manager
         /// </returns>
         DataNode WriteValue(Type type, object? value, bool alwaysWrite = false, ISerializationContext? context = null);
 
-        DataNode WriteWithTypeSerializer(Type type, Type typeSerializer, object? value, bool alwaysWrite = false,
+        DataNode WriteWithTypeSerializer(Type type, Type serializer, object? value, bool alwaysWrite = false,
             ISerializationContext? context = null);
 
         #endregion

--- a/Robust.Shared/Serialization/Manager/SerializationManager.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.cs
@@ -540,15 +540,13 @@ namespace Robust.Shared.Serialization.Manager
             return mapping;
         }
 
-        public DataNode WriteWithTypeSerializer(Type type, Type typeSerializer, object? value, bool alwaysWrite = false,
+        public DataNode WriteWithTypeSerializer(Type type, Type serializer, object? value, bool alwaysWrite = false,
             ISerializationContext? context = null)
         {
             // TODO Serialization: just return null
             if (type.IsNullable() && value == null) return new MappingDataNode();
 
-            var method = typeof(SerializationManager).GetRuntimeMethods().First(m => m.Name == nameof(WriteWithSerializer))!
-                .MakeGenericMethod(type, typeSerializer);
-            return (DataNode) method.Invoke(this, new object?[] {value, context, alwaysWrite})!;
+            return WriteWithSerializerRaw(type, serializer, value!, context, alwaysWrite);
         }
 
         private object? CopyToTarget(object? source, object? target, ISerializationContext? context = null, bool skipHook = false)

--- a/Robust.UnitTesting/Shared/Serialization/TypeSerializers/ListSerializerTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/TypeSerializers/ListSerializerTest.cs
@@ -49,6 +49,18 @@ namespace Robust.UnitTesting.Shared.Serialization.TypeSerializers
         }
 
         [Test]
+        public void CustomWriteTest()
+        {
+            var list = new List<string> {"A", "E"};
+
+            var node = (SequenceDataNode) Serialization.WriteWithTypeSerializer(typeof(List<string>), typeof(ListSerializers<string>), list);
+
+            Assert.That(node.Sequence.Count, Is.EqualTo(2));
+            Assert.That(node.Cast<ValueDataNode>(0).Value, Is.EqualTo("A"));
+            Assert.That(node.Cast<ValueDataNode>(1).Value, Is.EqualTo("E"));
+        }
+
+        [Test]
         public void CustomCopyTest()
         {
             var source = new List<string> {"A", "E"};


### PR DESCRIPTION
The trilogy complete

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-4790K CPU 4.00GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.201
  [Host]     : .NET Core 5.0.4 (CoreCLR 5.0.421.11614, CoreFX 5.0.421.11614), X64 RyuJIT
  DefaultJob : .NET Core 5.0.4 (CoreCLR 5.0.421.11614, CoreFX 5.0.421.11614), X64 RyuJIT
```
|                          Method |     Mean |   Error |  StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------- |---------:|--------:|--------:|-------:|------:|------:|----------:|
| OldWriteIntegerCustomSerializer |  3166 ns | 60.9 ns |   77 ns | 0.5035 |     - |     - |    2060 B |
| NewWriteIntegerCustomSerializer | 124.3 ns | 1.24 ns | 1.16 ns | 0.0172 |     - |     - |      72 B |