### PR TITLE
Don't sleep items parented to map

### DIFF
--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
@@ -606,7 +606,8 @@ namespace Robust.Shared.GameObjects
             get => _canCollide;
             set
             {
-                if (_canCollide == value)
+                if (_canCollide == value ||
+                    value && Owner.IsInContainer())
                     return;
 
                 _canCollide = value;

--- a/Robust.Shared/GameObjects/Systems/CollisionWakeSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/CollisionWakeSystem.cs
@@ -58,8 +58,7 @@ namespace Robust.Shared.GameObjects
             // these are called pretty infrequently so I'm fine with this for now.
 
             // If we just got put into a container don't want to mess with our collision state.
-            if (!ComponentManager.TryGetComponent<PhysicsComponent>(uid, out var body) ||
-                component.Owner.IsInContainer()) return;
+            if (!ComponentManager.TryGetComponent<PhysicsComponent>(uid, out var body)) return;
 
             // If we're attached to the map we'll also just never disable collision due to how grid movement works.
             body.CanCollide = !component.Enabled || body.Awake || body.Joints.Any() || ComponentManager.GetComponent<TransformComponent>(uid).GridID == GridId.Invalid;

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -300,6 +300,12 @@ namespace Robust.Shared.Physics
                 {
                     if (other.Fixture.Body.Deleted) continue;
 
+                    // Because we may be colliding with something asleep (due to the way grid movement works) need
+                    // to make sure the contact doesn't fail.
+                    // This is because we generate a contact across 2 different broadphases where both bodies aren't
+                    // moving locally but are moving in world-terms.
+                    proxyA.Fixture.Body.WakeBody();
+                    other.Fixture.Body.WakeBody();
                     contactManager.AddPair(proxyA, other);
                 }
             }

--- a/Robust.UnitTesting/Shared/Physics/CollisionWake_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/CollisionWake_Test.cs
@@ -1,0 +1,82 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+
+namespace Robust.UnitTesting.Shared.Physics
+{
+    [TestFixture, TestOf(typeof(CollisionWakeSystem))]
+    public class CollisionWake_Test : RobustIntegrationTest
+    {
+        private const string Prototype = @"
+- type: entity
+  name: dummy
+  id: CollisionWakeTestItem
+  components:
+  - type: Transform
+  - type: Physics
+    bodyType: Dynamic
+  - type: CollisionWake
+";
+
+        /// <summary>
+        /// Test whether a CollisionWakeComponent correctly turns off collision on a grid and leaves it on off of a grid.
+        /// </summary>
+        [Test]
+        public async Task TestCollisionWakeGrid()
+        {
+            var options = new ServerIntegrationOptions {ExtraPrototypes = Prototype};
+            options.CVarOverrides["physics.timetosleep"] = "0.0";
+            var server = StartServer(options);
+            await server.WaitIdleAsync();
+
+            var compManager = server.ResolveDependency<IComponentManager>();
+            var entManager = server.ResolveDependency<IEntityManager>();
+            var mapManager = server.ResolveDependency<IMapManager>();
+
+            IMapGrid grid = default!;
+            MapId mapId = default!;
+            PhysicsComponent physics = default!;
+
+            await server.WaitPost(() =>
+            {
+                mapId = mapManager.CreateMap();
+                grid = mapManager.CreateGrid(mapId);
+
+                var entity = entManager.SpawnEntity("CollisionWakeTestItem", new MapCoordinates(Vector2.One, mapId));
+                physics = compManager.GetComponent<PhysicsComponent>(entity.Uid);
+            });
+
+            // Should still be collidable
+            await server.WaitRunTicks(1);
+
+            await server.WaitAssertion(() =>
+            {
+                Assert.That(physics.Awake, Is.EqualTo(false));
+                Assert.That(physics.CanCollide, Is.EqualTo(true));
+
+                physics.Owner.Transform.AttachParent(entManager.GetEntity(grid.GridEntityId));
+            });
+
+            await server.WaitRunTicks(1);
+
+            await server.WaitAssertion(() =>
+            {
+                Assert.That(physics.Awake, Is.EqualTo(false));
+                Assert.That(physics.CanCollide, Is.EqualTo(false));
+
+                physics.Owner.Transform.AttachParent(mapManager.GetMapEntity(mapId));
+            });
+
+            // Juussttt in case we'll re-parent it to the map and check its collision is back on.
+            await server.WaitRunTicks(1);
+
+            await server.WaitAssertion(() =>
+            {
+                Assert.That(physics.Awake, Is.EqualTo(false));
+                Assert.That(physics.CanCollide, Is.EqualTo(true));
+            });
+        }
+    }
+}


### PR DESCRIPTION
Allows us to drive over items in space cleanly with a grid. If this becomes a perf problem we can just delete low-prio entities.

Fixes https://github.com/space-wizards/RobustToolbox/issues/2028