### PR TITLE
Makes BoundUserInterfaces partially ECS.

### DIFF
--- a/Robust.Client/GameObjects/Components/UserInterface/ClientUserInterfaceComponent.cs
+++ b/Robust.Client/GameObjects/Components/UserInterface/ClientUserInterfaceComponent.cs
@@ -89,7 +89,7 @@ namespace Robust.Client.GameObjects
 
             var playerSession = IoCManager.Resolve<IPlayerManager>().LocalPlayer?.Session;
             if(playerSession != null)
-                Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, new BoundUIClosedEvent());
+                Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, new BoundUIClosedEvent(uiKey, Owner.Uid, playerSession));
         }
 
         internal void SendMessage(BoundUserInterfaceMessage message, object uiKey)

--- a/Robust.Client/GameObjects/Components/UserInterface/ClientUserInterfaceComponent.cs
+++ b/Robust.Client/GameObjects/Components/UserInterface/ClientUserInterfaceComponent.cs
@@ -89,7 +89,7 @@ namespace Robust.Client.GameObjects
 
             var playerSession = IoCManager.Resolve<IPlayerManager>().LocalPlayer?.Session;
             if(playerSession != null)
-                Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, new BoundUserInterfaceClosedEvent(Owner.Uid, uiKey, playerSession));
+                Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, new BoundUIClosedEvent());
         }
 
         internal void SendMessage(BoundUserInterfaceMessage message, object uiKey)

--- a/Robust.Client/GameObjects/Components/UserInterface/ClientUserInterfaceComponent.cs
+++ b/Robust.Client/GameObjects/Components/UserInterface/ClientUserInterfaceComponent.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Robust.Client.Player;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Reflection;
@@ -85,6 +86,10 @@ namespace Robust.Client.GameObjects
                 SendMessage(new CloseBoundInterfaceMessage(), uiKey);
             _openInterfaces.Remove(uiKey);
             boundUserInterface.Dispose();
+
+            var playerSession = IoCManager.Resolve<IPlayerManager>().LocalPlayer?.Session;
+            if(playerSession != null)
+                Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, new BoundUserInterfaceClosedEvent(Owner.Uid, uiKey, playerSession));
         }
 
         internal void SendMessage(BoundUserInterfaceMessage message, object uiKey)

--- a/Robust.Server/GameObjects/Components/UserInterface/ServerUserInterfaceComponent.cs
+++ b/Robust.Server/GameObjects/Components/UserInterface/ServerUserInterfaceComponent.cs
@@ -245,7 +245,7 @@ namespace Robust.Server.GameObjects
         private void CloseShared(IPlayerSession session)
         {
             var owner = Owner.Owner;
-            owner.EntityManager.EventBus.RaiseLocalEvent(owner.Uid, new BoundUIClosedEvent());
+            owner.EntityManager.EventBus.RaiseLocalEvent(owner.Uid, new BoundUIClosedEvent(UiKey, owner.Uid, session));
             OnClosed?.Invoke(session);
             _subscribedSessions.Remove(session);
             _playerStateOverrides.Remove(session);

--- a/Robust.Server/GameObjects/Components/UserInterface/ServerUserInterfaceComponent.cs
+++ b/Robust.Server/GameObjects/Components/UserInterface/ServerUserInterfaceComponent.cs
@@ -245,7 +245,7 @@ namespace Robust.Server.GameObjects
         private void CloseShared(IPlayerSession session)
         {
             var owner = Owner.Owner;
-            owner.EntityManager.EventBus.RaiseLocalEvent(owner.Uid, new BoundUserInterfaceClosedEvent(owner.Uid, UiKey, session));
+            owner.EntityManager.EventBus.RaiseLocalEvent(owner.Uid, new BoundUIClosedEvent());
             OnClosed?.Invoke(session);
             _subscribedSessions.Remove(session);
             _playerStateOverrides.Remove(session);

--- a/Robust.Shared/GameObjects/Components/UserInterface/SharedUserInterfaceComponent.cs
+++ b/Robust.Shared/GameObjects/Components/UserInterface/SharedUserInterfaceComponent.cs
@@ -110,5 +110,11 @@ namespace Robust.Shared.GameObjects
 
     public class BoundUIClosedEvent : BoundUserInterfaceMessage
     {
+        public BoundUIClosedEvent(object uiKey, EntityUid uid, ICommonSession session)
+        {
+            UiKey = uiKey;
+            Entity = uid;
+            Session = session;
+        }
     }
 }

--- a/Robust.Shared/GameObjects/Components/UserInterface/SharedUserInterfaceComponent.cs
+++ b/Robust.Shared/GameObjects/Components/UserInterface/SharedUserInterfaceComponent.cs
@@ -1,13 +1,14 @@
 using System;
 using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
+using Robust.Shared.Players;
 using Robust.Shared.Reflection;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
 
 namespace Robust.Shared.GameObjects
 {
-    [NetworkedComponent()]
+    [NetworkedComponent]
     public abstract class SharedUserInterfaceComponent : Component
     {
         public sealed override string Name => "UserInterface";
@@ -45,8 +46,25 @@ namespace Robust.Shared.GameObjects
 
 
     [NetSerializable, Serializable]
-    public class BoundUserInterfaceMessage
+    public class BoundUserInterfaceMessage : EntityEventArgs
     {
+        /// <summary>
+        ///     The UI of this message.
+        ///     Only set when the message is raised as a directed event.
+        /// </summary>
+        public object UiKey { get; set; } = default!;
+
+        /// <summary>
+        ///     The Entity receiving the message.
+        ///     Only set when the message is raised as a directed event.
+        /// </summary>
+        public EntityUid Entity { get; set; } = EntityUid.Invalid;
+
+        /// <summary>
+        ///     The session sending or receiving this message.
+        ///     Only set when the message is raised as a directed event.
+        /// </summary>
+        public ICommonSession Session { get; set; } = default!;
     }
 
     [NetSerializable, Serializable]
@@ -87,6 +105,20 @@ namespace Robust.Shared.GameObjects
         public override string ToString()
         {
             return $"{nameof(BoundUIWrapMessage)}: {Message}";
+        }
+    }
+
+    public class BoundUserInterfaceClosedEvent : EntityEventArgs
+    {
+        public readonly ICommonSession Session;
+        public readonly EntityUid Entity;
+        public readonly object UiKey;
+
+        public BoundUserInterfaceClosedEvent(EntityUid entity, object uiKey, ICommonSession session)
+        {
+            Entity = entity;
+            UiKey = uiKey;
+            Session = session;
         }
     }
 }

--- a/Robust.Shared/GameObjects/Components/UserInterface/SharedUserInterfaceComponent.cs
+++ b/Robust.Shared/GameObjects/Components/UserInterface/SharedUserInterfaceComponent.cs
@@ -108,17 +108,7 @@ namespace Robust.Shared.GameObjects
         }
     }
 
-    public class BoundUserInterfaceClosedEvent : EntityEventArgs
+    public class BoundUIClosedEvent : BoundUserInterfaceMessage
     {
-        public readonly ICommonSession Session;
-        public readonly EntityUid Entity;
-        public readonly object UiKey;
-
-        public BoundUserInterfaceClosedEvent(EntityUid entity, object uiKey, ICommonSession session)
-        {
-            Entity = entity;
-            UiKey = uiKey;
-            Session = session;
-        }
     }
 }

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -1,0 +1,7 @@
+namespace Robust.Shared.GameObjects
+{
+    public abstract class SharedUserInterfaceSystem : EntitySystem
+    {
+
+    }
+}


### PR DESCRIPTION
- All received BoundUserInterfaceMessages will be raised as directed events.
- Base BoundUserInterfaceMessage now has fields for the entity UID, UI key and relevant player session.
    - Please note that these are *only* set before raising the directed event, for ECS purposes.
- Made UserInterfaceSystem public, added a bunch of *proxy* methods to it.
    - These proxy methods call into the actual BoundUserInterface methods. In the future the logic will be moved into the systems though.
    - This means you can start using these methods to ECS your bound user interfaces!
- Added BoundUserInterfaceClosedEvent for when a bound user interface is closed. Yay, ECS!

I think this is done now. Please review and give me feedback on these changes!
For an example of the changes in this PR being used, refer to this content PR: https://github.com/space-wizards/space-station-14/pull/4608