### PR TITLE
Fix deleting empty containers on the client deleting their previous contents

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
@@ -59,6 +59,7 @@ namespace Robust.Client.GameObjects
             {
                 if (!cast.ContainerSet.Any(data => data.Id == id))
                 {
+                    container.EmptyContainer(true);
                     container.Shutdown();
                     toDelete ??= new List<string>();
                     toDelete.Add(id);


### PR DESCRIPTION
Fixes https://github.com/space-wizards/space-station-14/issues/4609

This does make the event for emptying the container fire on the client even when it shouldn't, though the entities are later deleted when applying the game state if they should have been.

@ShadowCommander @PJB3005 @Acruid 