### PR TITLE
Adds some OpenDream things to the sandbox whitelist

### DIFF
--- a/Robust.Shared/ContentPack/Sandbox.yml
+++ b/Robust.Shared/ContentPack/Sandbox.yml
@@ -292,6 +292,8 @@ Types:
     ImmutableSortedSet`1: { All: True }
     ImmutableSortedStack: { All: True }
     ImmutableSortedStack`1: { All: True }
+  System.Collections.Specialized:
+    NameValueCollection: { All: True }
   System.Collections:
     IEnumerable: { All: True }
     IEnumerator: { All: True }
@@ -665,6 +667,15 @@ Types:
     CancellationToken: { All: True }
     CancellationTokenSource: { All: True }
     Interlocked: { All: True }
+  System.Web:
+    HttpUtility:
+      Methods:
+        - "System.Collections.Specialized.NameValueCollection ParseQueryString(string, System.Text.Encoding)"
+        - "System.Collections.Specialized.NameValueCollection ParseQueryString(string)"
+        - "string UrlDecode(string, System.Text.Encoding)"
+        - "string UrlDecode(string)"
+        - "string UrlEncode(string, System.Text.Encoding)"
+        - "string UrlEncode(string)"
   System:
     IServiceProvider: { All: True }
     Action: { All: True }

--- a/Robust.Shared/ContentPack/Sandbox.yml
+++ b/Robust.Shared/ContentPack/Sandbox.yml
@@ -396,6 +396,7 @@ Types:
     IOrderedEnumerable`1: { All: True }
   System.Net:
     DnsEndPoint: { }
+    HttpStatusCode: { } # Enum
   System.Numerics:
     BitOperations: { All: True }
   System.Reflection:


### PR DESCRIPTION
NameValueCollection, HttpStatusCode, UrlEncode(), UrlDecode(), and ParseQueryString()