### PR TITLE
Use approximate bounds for sprite rendering

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -386,7 +386,7 @@ namespace Robust.Client.Graphics.Clyde
                     entry.yWorldPos = worldPos.Y - bounds.Extents.Y;
                     return true;
 
-                }, bounds);
+                }, bounds, true);
             }
         }
 


### PR DESCRIPTION
Not using approx means it re-calculates the bounds which is expensive (given it needs to get the AABB back in world terms for hundreds of sprites).

Also this was 13% of debug perf.