### PR TITLE
Fix rendertexture for rotated eyes

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1285,13 +1285,13 @@ namespace Robust.Client.GameObjects
                 Matrix3.Multiply(ref localMatrix, ref modelMatrix, out var transformMatrix);
                 drawingHandle.SetTransform(in transformMatrix);
 
-                RenderLayer(drawingHandle, layer, worldRotation, overrideDirection);
+                RenderLayer(drawingHandle, layer, eyeRotation, worldRotation, overrideDirection);
             }
         }
 
-        private void RenderLayer(DrawingHandleWorld drawingHandle, Layer layer, Angle worldRotation, Direction? overrideDirection)
+        private void RenderLayer(DrawingHandleWorld drawingHandle, Layer layer, Angle eyeRotation, Angle worldRotation, Direction? overrideDirection)
         {
-            var texture = GetRenderTexture(layer, worldRotation, overrideDirection);
+            var texture = GetRenderTexture(layer, worldRotation + eyeRotation, overrideDirection);
 
             if (layer.Shader != null)
             {

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1261,7 +1261,7 @@ namespace Robust.Client.GameObjects
             }
             else
             {
-                angle = CalcRectWorldAngle(worldRotation, numDirs);
+                angle = CalcRectWorldAngle(worldRotation + eyeRotation, numDirs) - eyeRotation;
             }
 
             var sWorldRotation = angle;


### PR DESCRIPTION
Now when grid's rotating all the sprites should use the correct texture and be rotated correctly.