### PR TITLE
Add proxy methods to SharedContainerSystem.

### DIFF
--- a/Robust.Shared/Containers/ContainerManagerComponent.cs
+++ b/Robust.Shared/Containers/ContainerManagerComponent.cs
@@ -18,7 +18,7 @@ namespace Robust.Shared.Containers
     /// Holds data about a set of entity containers on this entity.
     /// </summary>
     [ComponentReference(typeof(IContainerManager))]
-    [NetworkedComponent()]
+    [NetworkedComponent]
     public class ContainerManagerComponent : Component, IContainerManager
     {
         [Dependency] private readonly IDynamicTypeFactoryInternal _dynFactory = default!;
@@ -256,9 +256,9 @@ namespace Robust.Shared.Containers
 
         public readonly struct AllContainersEnumerable : IEnumerable<IContainer>
         {
-            private readonly ContainerManagerComponent _manager;
+            private readonly ContainerManagerComponent? _manager;
 
-            public AllContainersEnumerable(ContainerManagerComponent manager)
+            public AllContainersEnumerable(ContainerManagerComponent? manager)
             {
                 _manager = manager;
             }
@@ -283,9 +283,9 @@ namespace Robust.Shared.Containers
         {
             private Dictionary<string, IContainer>.ValueCollection.Enumerator _enumerator;
 
-            public AllContainersEnumerator(ContainerManagerComponent manager)
+            public AllContainersEnumerator(ContainerManagerComponent? manager)
             {
-                _enumerator = manager.Containers.Values.GetEnumerator();
+                _enumerator = manager?.Containers.Values.GetEnumerator() ?? new();
                 Current = default;
             }
 

--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.GameObjects;
 
 namespace Robust.Shared.Containers
@@ -13,6 +14,117 @@ namespace Robust.Shared.Containers
 
             SubscribeLocalEvent<EntParentChangedMessage>(HandleParentChanged);
         }
+
+        // TODO: Make ContainerManagerComponent ECS and make these proxy methods the real deal.
+
+        #region Proxy Methods
+
+        public T MakeContainer<T>(EntityUid uid, string id, ContainerManagerComponent? containerManager = null)
+            where T : IContainer
+        {
+            if (!Resolve(uid, ref containerManager))
+                // TODO: I am a Sad Vera. Merge ComponentManager and EntityManager so we don't have to do this. Pretty please?
+                // ps. The to-do above is in effect for this whole file.
+                containerManager = ComponentManager.AddComponent<ContainerManagerComponent>(EntityManager.GetEntity(uid));
+
+            return containerManager.MakeContainer<T>(id);
+        }
+
+        public T EnsureContainer<T>(EntityUid uid, string id, ContainerManagerComponent? containerManager = null)
+            where T : IContainer
+        {
+            if (!Resolve(uid, ref containerManager))
+                containerManager = ComponentManager.AddComponent<ContainerManagerComponent>(EntityManager.GetEntity(uid));
+
+            if (TryGetContainer(uid, id, out var container, containerManager))
+                return (T)container;
+
+            return MakeContainer<T>(uid, id, containerManager);
+        }
+
+        public IContainer GetContainer(EntityUid uid, string id, ContainerManagerComponent? containerManager = null)
+        {
+            if (!Resolve(uid, ref containerManager))
+                throw new ArgumentException("Entity does not have a ContainerManagerComponent!", nameof(uid));
+
+            return containerManager.GetContainer(id);
+        }
+
+        public bool HasContainer(EntityUid uid, string id, ContainerManagerComponent? containerManager)
+        {
+            if (!Resolve(uid, ref containerManager))
+                return false;
+
+            return containerManager.HasContainer(id);
+        }
+
+        public bool TryGetContainer(EntityUid uid, string id, [NotNullWhen(true)] out IContainer? container, ContainerManagerComponent? containerManager = null)
+        {
+            if (Resolve(uid, ref containerManager))
+                return containerManager.TryGetContainer(id, out container);
+
+            container = null;
+            return false;
+        }
+
+        public bool TryGetContainingContainer(EntityUid uid, EntityUid containedUid, [NotNullWhen(true)] out IContainer? container, ContainerManagerComponent? containerManager = null)
+        {
+            if (Resolve(uid, ref containerManager) && EntityManager.TryGetEntity(containedUid, out var containedEntity))
+                return containerManager.TryGetContainer(containedEntity, out container);
+
+            container = null;
+            return false;
+        }
+
+        public bool ContainsEntity(EntityUid uid, EntityUid containedUid, ContainerManagerComponent? containerManager = null)
+        {
+            if (!Resolve(uid, ref containerManager) || !EntityManager.TryGetEntity(containedUid, out var containedEntity))
+                return false;
+
+            return containerManager.ContainsEntity(containedEntity);
+        }
+
+        public void RemoveEntity(EntityUid uid, EntityUid containedUid, bool force = false, ContainerManagerComponent? containerManager = null)
+        {
+            if (!Resolve(uid, ref containerManager) || !EntityManager.TryGetEntity(containedUid, out var containedEntity))
+                return;
+
+            if (force)
+                containerManager.ForceRemove(containedEntity);
+            else
+                containerManager.Remove(containedEntity);
+        }
+
+        public ContainerManagerComponent.AllContainersEnumerable GetAllContainers(EntityUid uid, ContainerManagerComponent? containerManager = null)
+        {
+            if (!Resolve(uid, ref containerManager))
+                return new ContainerManagerComponent.AllContainersEnumerable();
+
+            return containerManager.GetAllContainers();
+        }
+
+        #endregion
+
+        #region Container Helpers
+
+        public bool TryGetContainingContainer(EntityUid uid, [NotNullWhen(true)] out IContainer? container, ITransformComponent? transform = null)
+        {
+            container = null;
+            if (!Resolve(uid, ref transform))
+                return false;
+
+            if (!transform.ParentUid.IsValid())
+                return false;
+
+            return TryGetContainingContainer(transform.ParentUid, uid, out container);
+        }
+
+        public bool IsEntityInContainer(EntityUid uid, ITransformComponent? transform = null)
+        {
+            return TryGetContainingContainer(uid, out _, transform);
+        }
+
+        #endregion
 
         // Eject entities from their parent container if the parent change is done by the transform only.
         private static void HandleParentChanged(ref EntParentChangedMessage message)


### PR DESCRIPTION
These methods basically just call the `ContainerManagerComponent` methods.
In the future, however, when `ContainerManager` is ECS'd, these methods will contain the actual logic.

This is good for ~~bitcoin~~ the codebase because it allows us to start working with containers from an ECS standpoint, without having to call any logic on components (even if deep down, these are only proxy methods that redirect you to E/C methods...)
Now we can *slowly* move things to use these proxies. When everything uses them, we can then ECS containers easily. Win-win.