### PR TITLE
Merge ComponentManager into EntityManager.

### DIFF
--- a/Robust.Client/ClientIoC.cs
+++ b/Robust.Client/ClientIoC.cs
@@ -46,6 +46,7 @@ namespace Robust.Client
             IoCManager.Register<IMapManagerInternal, ClientMapManager>();
             IoCManager.Register<IClientMapManager, ClientMapManager>();
             IoCManager.Register<IEntityManager, ClientEntityManager>();
+            IoCManager.Register<IComponentManager, ClientEntityManager>();
             IoCManager.Register<IEntityLookup, EntityLookup>();
             IoCManager.Register<IReflectionManager, ClientReflectionManager>();
             IoCManager.Register<IConsoleHost, ClientConsoleHost>();

--- a/Robust.Server/ServerIoC.cs
+++ b/Robust.Server/ServerIoC.cs
@@ -49,6 +49,7 @@ namespace Robust.Server
             IoCManager.Register<IMapManagerInternal, ServerMapManager>();
             IoCManager.Register<IServerMapManager, ServerMapManager>();
             IoCManager.Register<IEntityManager, ServerEntityManager>();
+            IoCManager.Register<IComponentManager, ServerEntityManager>();
             IoCManager.Register<IEntityLookup, EntityLookup>();
             IoCManager.Register<IEntityNetworkManager, ServerEntityManager>();
             IoCManager.Register<IServerEntityNetworkManager, ServerEntityManager>();

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using Robust.Shared.Exceptions;
 using Robust.Shared.GameStates;
 using Robust.Shared.Physics;
 using Robust.Shared.Players;
@@ -13,7 +12,7 @@ using DependencyAttribute = Robust.Shared.IoC.DependencyAttribute;
 namespace Robust.Shared.GameObjects
 {
     /// <inheritdoc />
-    public class ComponentManager : IComponentManager
+    public partial class EntityManager : IComponentManager
     {
         [Dependency] private readonly IComponentFactory _componentFactory = default!;
         [Dependency] private readonly IComponentDependencyManager _componentDependencyManager = default!;
@@ -49,33 +48,31 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public event EventHandler<ComponentEventArgs>? ComponentDeleted;
 
-        private bool initialized;
-        public void Initialize()
+        public void InitializeComponents()
         {
-            if (initialized)
+            if (Initialized)
                 throw new InvalidOperationException("Already initialized.");
 
-            initialized = true;
+            Initialized = true;
 
             FillComponentDict();
             _componentFactory.ComponentAdded += OnComponentAdded;
             _componentFactory.ComponentReferenceAdded += OnComponentReferenceAdded;
         }
 
-        /// <inheritdoc />
-        public void Clear()
+        /// <summary>
+        ///     Instantly clears all components from the manager. This will NOT shut them down gracefully.
+        ///     Any entities relying on existing components will be broken.
+        /// </summary>
+        public void ClearComponents()
         {
+            _componentFactory.ComponentAdded -= OnComponentAdded;
+            _componentFactory.ComponentReferenceAdded -= OnComponentReferenceAdded;
             _netComponents.Clear();
             _entTraitDict.Clear();
             _entCompIndex.Clear();
             _deleteSet.Clear();
             FillComponentDict();
-        }
-
-        public void Dispose()
-        {
-            _componentFactory.ComponentAdded -= OnComponentAdded;
-            _componentFactory.ComponentReferenceAdded -= OnComponentReferenceAdded;
         }
 
         private void OnComponentAdded(IComponentRegistration obj)

--- a/Robust.Shared/GameObjects/IComponentManager.cs
+++ b/Robust.Shared/GameObjects/IComponentManager.cs
@@ -9,6 +9,7 @@ namespace Robust.Shared.GameObjects
     /// <summary>
     ///     Holds a collection of ECS components that are attached to entities.
     /// </summary>
+    [Obsolete("Use IEntityManager instead.")]
     [PublicAPI]
     public interface IComponentManager
     {

--- a/Robust.Shared/GameObjects/IComponentManager.cs
+++ b/Robust.Shared/GameObjects/IComponentManager.cs
@@ -10,7 +10,7 @@ namespace Robust.Shared.GameObjects
     ///     Holds a collection of ECS components that are attached to entities.
     /// </summary>
     [PublicAPI]
-    public interface IComponentManager : IDisposable
+    public interface IComponentManager
     {
         /// <summary>
         ///     A component was added to the manager.
@@ -27,12 +27,6 @@ namespace Robust.Shared.GameObjects
         ///     Usually you will want to subscribe to <see cref="ComponentRemoved"/>.
         /// </summary>
         event EventHandler<ComponentEventArgs>? ComponentDeleted;
-
-        /// <summary>
-        ///     Instantly clears all components from the manager. This will NOT shut them down gracefully.
-        ///     Any entities relying on existing components will be broken.
-        /// </summary>
-        void Clear();
 
         void Initialize();
 

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -7,7 +7,7 @@ using Robust.Shared.Timing;
 
 namespace Robust.Shared.GameObjects
 {
-    public interface IEntityManager
+    public interface IEntityManager : IComponentManager
     {
         /// <summary>
         ///     The current simulation tick being processed.

--- a/Robust.Shared/SharedIoC.cs
+++ b/Robust.Shared/SharedIoC.cs
@@ -23,7 +23,6 @@ namespace Robust.Shared
         public static void RegisterIoC()
         {
             IoCManager.Register<ISerializationManager, SerializationManager>();
-            IoCManager.Register<IComponentManager, ComponentManager>();
             IoCManager.Register<IConfigurationManager, NetConfigurationManager>();
             IoCManager.Register<INetConfigurationManager, NetConfigurationManager>();
             IoCManager.Register<IConfigurationManagerInternal, NetConfigurationManager>();

--- a/Robust.UnitTesting/Server/RobustServerSimulation.cs
+++ b/Robust.UnitTesting/Server/RobustServerSimulation.cs
@@ -198,9 +198,9 @@ namespace Robust.UnitTesting.Server
             //Tier 2: Simulation
             container.RegisterInstance<IConsoleHost>(new Mock<IConsoleHost>().Object); //Console is technically a frontend, we want to run headless
             container.Register<IEntityManager, EntityManager>();
+            container.Register<IComponentManager, EntityManager>();
             container.Register<IMapManager, MapManager>();
             container.Register<ISerializationManager, SerializationManager>();
-            container.Register<IComponentManager, ComponentManager>();
             container.Register<IEntityLookup, EntityLookup>();
             container.Register<IPrototypeManager, PrototypeManager>();
             container.Register<IComponentFactory, ComponentFactory>();

--- a/Robust.UnitTesting/Shared/GameObjects/ComponentManager_Tests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/ComponentManager_Tests.cs
@@ -8,7 +8,7 @@ using Robust.UnitTesting.Server;
 
 namespace Robust.UnitTesting.Shared.GameObjects
 {
-    [TestFixture, Parallelizable ,TestOf(typeof(ComponentManager))]
+    [TestFixture, Parallelizable ,TestOf(typeof(EntityManager))]
     public class ComponentManager_Tests
     {
         private static readonly EntityCoordinates DefaultCoords = new(new EntityUid(1), Vector2.Zero);
@@ -67,7 +67,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             manager.AddComponent(entity, firstComp);
             manager.RemoveComponent<DummyComponent>(entity.Uid);
             var secondComp = new DummyComponent { Owner = entity };
-            
+
             // Act
             manager.AddComponent(entity, secondComp);
 


### PR DESCRIPTION
Fixes #2063
Required by https://github.com/space-wizards/space-station-14/pull/4694

This PR doesn't break backwards compatibility at all.
However, `IEntityManager` now also implements `IComponentManager`.
`IComponentManager` is now effectively obsolete.

Please note: I have not made any significant changes to the code, any and all future improvements (see: `IEntity` responsability removal, `AddComponent<T>(EntityUid)` methods etc, will come in different PRs after this is merged.

The process for merging these has been the following:
1. Rename ComponentManager to EntityManager.
2. Make EntityManager a partial class.
3. Fix the fires.

SS14 goes ingame just fine, all tests pass... This seems good to go, honestly.