### PR TITLE
Don't generate physics contacts for non-predicted bodies

### DIFF
--- a/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
+++ b/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
@@ -370,7 +370,7 @@ namespace Robust.Shared.Physics.Dynamics
             // Box2D does this at the end of a step and also here when there's a fixture update.
             // Given external stuff can move bodies we'll just do this here.
             // Unfortunately this NEEDS to be predicted to make pushing remotely fucking good.
-            BroadphaseSystem.FindNewContacts(MapId);
+            BroadphaseSystem.FindNewContacts(MapId, prediction);
 
             var invDt = frameTime > 0.0f ? 1.0f / frameTime : 0.0f;
             var dtRatio = _invDt0 * frameTime;

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -151,7 +151,7 @@ namespace Robust.Shared.Physics
         /// <summary>
         /// Check the AABB for each moved broadphase fixture and add any colliding entities to the movebuffer in case.
         /// </summary>
-        private void FindGridContacts(MapId mapId)
+        private void FindGridContacts(MapId mapId, bool prediction)
         {
             // This is so that if we're on a broadphase that's moving (e.g. a grid) we need to make sure anything
             // we move over is getting checked for collisions, and putting it on the movebuffer is the easiest way to do so.
@@ -164,7 +164,7 @@ namespace Robust.Shared.Physics
             {
                 var fixture = proxy.Fixture;
 
-                if (!_broadphases.Contains(fixture.Body.Owner.Uid)) continue;
+                if (!_broadphases.Contains(fixture.Body.Owner.Uid) || prediction && !fixture.Body.Predict) continue;
 
                 var broadphase = fixture.Body.Broadphase!;
                 var offset = _offsets[broadphase];
@@ -195,7 +195,7 @@ namespace Robust.Shared.Physics
         /// <summary>
         /// Go through every single created, moved, or touched proxy on the map and try to find any new contacts that should be created.
         /// </summary>
-        internal void FindNewContacts(MapId mapId)
+        internal void FindNewContacts(MapId mapId, bool prediction)
         {
             var moveBuffer = _moveBuffer[mapId];
 
@@ -219,7 +219,7 @@ namespace Robust.Shared.Physics
             }
 
             // Find any entities being driven over that might need to be considered
-            FindGridContacts(mapId);
+            FindGridContacts(mapId, prediction);
 
             // There is some mariana trench levels of bullshit going on.
             // We essentially need to re-create Box2D's FindNewContacts but in a way that allows us to check every
@@ -234,6 +234,8 @@ namespace Robust.Shared.Physics
             // TODO: Could store fixtures by broadphase for more perf?
             foreach (var (proxy, worldAABB) in moveBuffer)
             {
+                if (prediction && !proxy.Fixture.Body.Predict) continue;
+
                 // Get every broadphase we may be intersecting.
                 foreach (var (broadphase, offset) in _offsets)
                 {


### PR DESCRIPTION
These are all just handled on the server anyway so it's a significant waste of performance on the client for busy scenes.