### PR TITLE
Adds utility "PrototypeFlags" collection.

### DIFF
--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/PrototypeFlagsTypeSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/PrototypeFlagsTypeSerializer.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Linq;
+using Robust.Shared.IoC;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Serialization.Manager.Result;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Sequence;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype
+{
+    [TypeSerializer]
+    public class PrototypeFlagsTypeSerializer<T> : ITypeSerializer<PrototypeFlags<T>, SequenceDataNode>
+        where T : class, IPrototype
+    {
+        public ValidationNode Validate(ISerializationManager serializationManager, SequenceDataNode node,
+            IDependencyCollection dependencies, ISerializationContext? context = null)
+        {
+            var list = new List<ValidationNode>();
+
+            foreach (var dataNode in node.Sequence)
+            {
+                if (dataNode is not ValueDataNode value)
+                {
+                    list.Add(new ErrorNode(dataNode, $"Cannot cast node {dataNode} to ValueDataNode."));
+                    continue;
+                }
+
+                list.Add(serializationManager.ValidateNodeWith<string, PrototypeIdSerializer<T>, ValueDataNode>(value, context));
+            }
+
+            return new ValidatedSequenceNode(list);
+        }
+
+        public DeserializationResult Read(ISerializationManager serializationManager, SequenceDataNode node,
+            IDependencyCollection dependencies, bool skipHook, ISerializationContext? context = null)
+        {
+            var flags = new List<string>(node.Sequence.Count);
+
+            foreach (var dataNode in node.Sequence)
+            {
+                if (dataNode is not ValueDataNode value)
+                    continue;
+
+                flags.Add(value.Value);
+            }
+
+            return new DeserializedValue<PrototypeFlags<T>>(new PrototypeFlags<T>(flags));
+        }
+
+        public DataNode Write(ISerializationManager serializationManager, PrototypeFlags<T> value, bool alwaysWrite = false,
+            ISerializationContext? context = null)
+        {
+            return new SequenceDataNode(value.ToArray());
+        }
+
+        public PrototypeFlags<T> Copy(ISerializationManager serializationManager, PrototypeFlags<T> source, PrototypeFlags<T> target,
+            bool skipHook, ISerializationContext? context = null)
+        {
+            return new PrototypeFlags<T>(source);
+        }
+    }
+}

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/PrototypeFlagsTypeSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/PrototypeFlagsTypeSerializer.cs
@@ -15,7 +15,8 @@ using Robust.Shared.Utility;
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype
 {
     [TypeSerializer]
-    public class PrototypeFlagsTypeSerializer<T> : ITypeSerializer<PrototypeFlags<T>, SequenceDataNode>
+    public class PrototypeFlagsTypeSerializer<T>
+        : ITypeSerializer<PrototypeFlags<T>, SequenceDataNode>, ITypeSerializer<PrototypeFlags<T>, ValueDataNode>
         where T : class, IPrototype
     {
         public ValidationNode Validate(ISerializationManager serializationManager, SequenceDataNode node,
@@ -63,6 +64,18 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
             bool skipHook, ISerializationContext? context = null)
         {
             return new PrototypeFlags<T>(source);
+        }
+
+        public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
+            IDependencyCollection dependencies, ISerializationContext? context = null)
+        {
+            return serializationManager.ValidateNodeWith<string, PrototypeIdSerializer<T>, ValueDataNode>(node, context);
+        }
+
+        public DeserializationResult Read(ISerializationManager serializationManager, ValueDataNode node,
+            IDependencyCollection dependencies, bool skipHook, ISerializationContext? context = null)
+        {
+            return new DeserializedValue<PrototypeFlags<T>>(new PrototypeFlags<T>(node.Value));
         }
     }
 }

--- a/Robust.Shared/Utility/PrototypeFlags.cs
+++ b/Robust.Shared/Utility/PrototypeFlags.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Robust.Shared.Prototypes;
+
+namespace Robust.Shared.Utility
+{
+    /// <summary>
+    ///     Data structure for storing prototype IDs, and ensuring that all stored IDs resolve to valid prototypes.
+    /// </summary>
+    /// <typeparam name="T">The prototype variant.</typeparam>
+    public sealed class PrototypeFlags<T> : IReadOnlyPrototypeFlags<T>
+        where T : class, IPrototype
+    {
+        private readonly HashSet<string> _flags;
+
+        #region Constructors
+
+        public PrototypeFlags()
+        {
+            _flags = new HashSet<string>();
+        }
+
+        public PrototypeFlags(params string[] flags)
+        {
+            _flags = new HashSet<string>(flags);
+        }
+
+        public PrototypeFlags(IEnumerable<string> flags)
+        {
+            _flags = new HashSet<string>(flags);
+        }
+
+        #endregion
+
+        #region API
+
+        public int Count => _flags.Count;
+
+        /// <summary>
+        ///     Adds a prototype flag, but only if it's valid.
+        /// </summary>
+        /// <param name="flag">The prototype identifier.</param>
+        /// <param name="prototypeManager">The prototype manager containing the prototype.</param>
+        /// <returns>Whether the flag was added or not.</returns>
+        public bool Add(string flag, IPrototypeManager prototypeManager)
+        {
+            return !prototypeManager.TryIndex<T>(flag, out _) && _flags.Add(flag);
+        }
+
+        /// <summary>
+        ///     Checks whether a specific flag is contained here or not.
+        /// </summary>
+        public bool Contains(string flag)
+        {
+            return _flags.Contains(flag);
+        }
+
+        /// <summary>
+        ///     Checks whether all specified flags are contained here or not.
+        /// </summary>
+        public bool ContainsAll(IEnumerable<string> flags)
+        {
+            foreach (var flag in flags)
+            {
+                if (!Contains(flag))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        ///     Checks whether all specified flags are contained here or not.
+        /// </summary>
+        public bool ContainsAll(params string[] flags)
+        {
+            return ContainsAll((IEnumerable<string>) flags);
+        }
+
+        /// <summary>
+        ///     Checks whether any of the specified flags are contained here or not.
+        /// </summary>
+        public bool ContainsAny(IEnumerable<string> flags)
+        {
+            foreach (var flag in flags)
+            {
+                if (Contains(flag))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///     Checks whether any of the specified flags are contained here or not.
+        /// </summary>
+        public bool ContainsAny(params string[] flags)
+        {
+            return ContainsAny((IEnumerable<string>) flags);
+        }
+
+        /// <summary>
+        ///     Removes a flag, if present.
+        /// </summary>
+        /// <param name="flag">The flag to be removed.</param>
+        /// <returns>Whether the prototype flag was successfully removed.</returns>
+        public bool Remove(string flag)
+        {
+            return _flags.Remove(flag);
+        }
+
+        /// <summary>
+        ///     Empties the collection of all prototype flags.
+        /// </summary>
+        public void Clear()
+        {
+            _flags.Clear();
+        }
+
+        #endregion
+
+        #region Enumeration
+
+        public IEnumerable<T> GetPrototypes(IPrototypeManager prototypeManager)
+        {
+            foreach (var prototype in _flags)
+            {
+                yield return prototypeManager.Index<T>(prototype);
+            }
+        }
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            return _flags.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        #endregion
+    }
+
+    public interface IReadOnlyPrototypeFlags<T> : IEnumerable<string>
+        where T : class, IPrototype
+    {
+        int Count { get; }
+
+        bool Contains(string flag);
+        bool ContainsAll(IEnumerable<string> flags);
+        bool ContainsAll(params string[] flags);
+        bool ContainsAny(IEnumerable<string> flags);
+        bool ContainsAny(params string[] flags);
+
+        /// <summary>
+        ///     Enumerates all prototype flags and returns their actual prototype instances.
+        /// </summary>
+        /// <param name="prototypeManager">The prototype manager where the prototypes are stored.</param>
+        /// <exception cref="InvalidOperationException">Thrown if prototypes in the <see cref="IPrototypeManager"/>
+        ///     haven't been loaded yet.
+        /// </exception>
+        /// <exception cref="UnknownPrototypeException">Thrown if any of the prototype flags in this class does not
+        ///     correspond to a valid, known prototype in the <see cref="IPrototypeManager"/>.
+        /// </exception>
+        /// <returns>The prototype instances for all prototype flags in this object.</returns>
+        IEnumerable<T> GetPrototypes(IPrototypeManager prototypeManager);
+    }
+}

--- a/Robust.Shared/Utility/PrototypeFlags.cs
+++ b/Robust.Shared/Utility/PrototypeFlags.cs
@@ -10,7 +10,6 @@ namespace Robust.Shared.Utility
     ///     Data structure for storing prototype IDs, and ensuring that all stored IDs resolve to valid prototypes.
     /// </summary>
     /// <typeparam name="T">The prototype variant.</typeparam>
-    [Serializable, NetSerializable]
     public sealed class PrototypeFlags<T> : IReadOnlyPrototypeFlags<T>
         where T : class, IPrototype
     {

--- a/Robust.Shared/Utility/PrototypeFlags.cs
+++ b/Robust.Shared/Utility/PrototypeFlags.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
 
 namespace Robust.Shared.Utility
 {
@@ -9,6 +10,7 @@ namespace Robust.Shared.Utility
     ///     Data structure for storing prototype IDs, and ensuring that all stored IDs resolve to valid prototypes.
     /// </summary>
     /// <typeparam name="T">The prototype variant.</typeparam>
+    [Serializable, NetSerializable]
     public sealed class PrototypeFlags<T> : IReadOnlyPrototypeFlags<T>
         where T : class, IPrototype
     {


### PR DESCRIPTION
This PR adds a new utility collection class, `PrototypeFlags`.
This collection acts as a set of unordered strings which resolve to prototypes.
This class can be (de)serialized as a sequence of strings, with full linter support.

This is useful for things such as `TagComponent` in SS14, or tool quality prototypes in the future.
I feel like this helper class should be in engine, as it's a fairly simple collection that's unlikely to see many changes.