### PR TITLE
Aggressively sleep physics bodies

### DIFF
--- a/Robust.Client/Audio/Midi/MidiManager.cs
+++ b/Robust.Client/Audio/Midi/MidiManager.cs
@@ -94,7 +94,7 @@ namespace Robust.Client.Audio.Midi
             get => _volume;
             set
             {
-                if (MathHelper.CloseTo(_volume, value))
+                if (MathHelper.CloseToPercent(_volume, value))
                     return;
 
                 _cfgMan.SetCVar(CVars.MidiVolume, value);

--- a/Robust.Client/GameObjects/Components/Light/PointLightComponent.cs
+++ b/Robust.Client/GameObjects/Components/Light/PointLightComponent.cs
@@ -142,7 +142,7 @@ namespace Robust.Client.GameObjects
             get => _radius;
             set
             {
-                if (MathHelper.CloseTo(value, _radius)) return;
+                if (MathHelper.CloseToPercent(value, _radius)) return;
 
                 base.Radius = value;
                 Owner.EntityManager.EventBus.RaiseEvent(EventSource.Local, new PointLightRadiusChangedEvent(this));

--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -434,13 +434,13 @@ namespace Robust.Client.Graphics.Clyde
                     lightShader.SetUniformTextureMaybe(UniIMainTexture, TextureUnit.Texture0);
                 }
 
-                if (!MathHelper.CloseTo(lastRange, component.Radius))
+                if (!MathHelper.CloseToPercent(lastRange, component.Radius))
                 {
                     lastRange = component.Radius;
                     lightShader.SetUniformMaybe("lightRange", lastRange);
                 }
 
-                if (!MathHelper.CloseTo(lastPower, component.Energy))
+                if (!MathHelper.CloseToPercent(lastPower, component.Energy))
                 {
                     lastPower = component.Energy;
                     lightShader.SetUniformMaybe("lightPower", lastPower);
@@ -452,7 +452,7 @@ namespace Robust.Client.Graphics.Clyde
                     lightShader.SetUniformMaybe("lightColor", lastColor);
                 }
 
-                if (_enableSoftShadows && !MathHelper.CloseTo(lastSoftness, component.Softness))
+                if (_enableSoftShadows && !MathHelper.CloseToPercent(lastSoftness, component.Softness))
                 {
                     lastSoftness = component.Softness;
                     lightShader.SetUniformMaybe("lightSoftness", lastSoftness);

--- a/Robust.Client/UserInterface/Controls/ItemList.cs
+++ b/Robust.Client/UserInterface/Controls/ItemList.cs
@@ -475,7 +475,7 @@ namespace Robust.Client.UserInterface.Controls
         {
             base.MouseWheel(args);
 
-            if (MathHelper.CloseTo(0, args.Delta.Y))
+            if (MathHelper.CloseToPercent(0, args.Delta.Y))
             {
                 return;
             }

--- a/Robust.Client/UserInterface/Controls/OutputPanel.cs
+++ b/Robust.Client/UserInterface/Controls/OutputPanel.cs
@@ -149,7 +149,7 @@ namespace Robust.Client.UserInterface.Controls
         {
             base.MouseWheel(args);
 
-            if (MathHelper.CloseTo(0, args.Delta.Y))
+            if (MathHelper.CloseToPercent(0, args.Delta.Y))
             {
                 return;
             }

--- a/Robust.Client/UserInterface/Controls/Range.cs
+++ b/Robust.Client/UserInterface/Controls/Range.cs
@@ -94,7 +94,7 @@ namespace Robust.Client.UserInterface.Controls
         private void _ensureValueClamped()
         {
             var newValue = ClampValue(_value);
-            if (!MathHelper.CloseTo(newValue, _value))
+            if (!MathHelper.CloseToPercent(newValue, _value))
             {
                 _value = newValue;
                 OnValueChanged?.Invoke(this);

--- a/Robust.Client/UserInterface/Controls/ScrollBar.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollBar.cs
@@ -50,7 +50,7 @@ namespace Robust.Client.UserInterface.Controls
             get
             {
                 var offset = ValueTarget + Page;
-                return offset > MaxValue || MathHelper.CloseTo(offset, MaxValue);
+                return offset > MaxValue || MathHelper.CloseToPercent(offset, MaxValue);
             }
         }
 
@@ -64,7 +64,7 @@ namespace Robust.Client.UserInterface.Controls
         {
             base.FrameUpdate(args);
 
-            if (!VisibleInTree || MathHelper.CloseTo(Value, ValueTarget))
+            if (!VisibleInTree || MathHelper.CloseToPercent(Value, ValueTarget))
             {
                 Value = ValueTarget;
             }

--- a/Robust.Server/Console/Commands/TestbedCommand.cs
+++ b/Robust.Server/Console/Commands/TestbedCommand.cs
@@ -111,7 +111,7 @@ namespace Robust.Server.Console.Commands
             if (mapId == MapId.Nullspace) return;
             var pauseManager = IoCManager.Resolve<IPauseManager>();
             pauseManager.SetMapPaused(mapId, false);
-            IoCManager.Resolve<IMapManager>().GetMapEntity(mapId).GetComponent<SharedPhysicsMapComponent>().Gravity = new Vector2(0, -4.9f);
+            IoCManager.Resolve<IMapManager>().GetMapEntity(mapId).GetComponent<SharedPhysicsMapComponent>().Gravity = new Vector2(0, -9.8f);
 
             return;
         }

--- a/Robust.Shared.Maths/Angle.cs
+++ b/Robust.Shared.Maths/Angle.cs
@@ -133,9 +133,9 @@ namespace Robust.Shared.Maths
 
             // The second two expressions cover an edge case where one number is barely non-negative while the other number is negative.
             // In this case, the negative number will get FlipPositived to ~2pi and the comparison will give a false negative.
-            return MathHelper.CloseTo(aPositive, bPositive)
-                || MathHelper.CloseTo(aPositive + MathHelper.TwoPi, bPositive)
-                || MathHelper.CloseTo(aPositive, bPositive + MathHelper.TwoPi);
+            return MathHelper.CloseToPercent(aPositive, bPositive)
+                || MathHelper.CloseToPercent(aPositive + MathHelper.TwoPi, bPositive)
+                || MathHelper.CloseToPercent(aPositive, bPositive + MathHelper.TwoPi);
         }
 
         private static bool EqualsApprox(Angle a, Angle b, double tolerance)
@@ -149,9 +149,9 @@ namespace Robust.Shared.Maths
 
             // The second two expressions cover an edge case where one number is barely non-negative while the other number is negative.
             // In this case, the negative number will get FlipPositived to ~2pi and the comparison will give a false negative.
-            return MathHelper.CloseTo(aPositive, bPositive, tolerance)
-                || MathHelper.CloseTo(aPositive + MathHelper.TwoPi, bPositive, tolerance)
-                || MathHelper.CloseTo(aPositive, bPositive + MathHelper.TwoPi, tolerance);
+            return MathHelper.CloseToPercent(aPositive, bPositive, tolerance)
+                || MathHelper.CloseToPercent(aPositive + MathHelper.TwoPi, bPositive, tolerance)
+                || MathHelper.CloseToPercent(aPositive, bPositive + MathHelper.TwoPi, tolerance);
         }
 
         /// <summary>

--- a/Robust.Shared.Maths/Box2.cs
+++ b/Robust.Shared.Maths/Box2.cs
@@ -191,7 +191,7 @@ namespace Robust.Shared.Maths
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly bool IsEmpty()
         {
-            return MathHelper.CloseTo(Width, 0.0f) && MathHelper.CloseTo(Height, 0.0f);
+            return MathHelper.CloseToPercent(Width, 0.0f) && MathHelper.CloseToPercent(Height, 0.0f);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -298,10 +298,10 @@ namespace Robust.Shared.Maths
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(Box2 a, Box2 b)
         {
-            return MathHelper.CloseTo(a.Bottom, b.Bottom) &&
-                   MathHelper.CloseTo(a.Right, b.Right) &&
-                   MathHelper.CloseTo(a.Top, b.Top) &&
-                   MathHelper.CloseTo(a.Left, b.Left);
+            return MathHelper.CloseToPercent(a.Bottom, b.Bottom) &&
+                   MathHelper.CloseToPercent(a.Right, b.Right) &&
+                   MathHelper.CloseToPercent(a.Top, b.Top) &&
+                   MathHelper.CloseToPercent(a.Left, b.Left);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -365,18 +365,18 @@ namespace Robust.Shared.Maths
 
         public bool EqualsApprox(Box2 other)
         {
-            return MathHelper.CloseTo(Left, other.Left)
-                   && MathHelper.CloseTo(Bottom, other.Bottom)
-                   && MathHelper.CloseTo(Right, other.Right)
-                   && MathHelper.CloseTo(Top, other.Top);
+            return MathHelper.CloseToPercent(Left, other.Left)
+                   && MathHelper.CloseToPercent(Bottom, other.Bottom)
+                   && MathHelper.CloseToPercent(Right, other.Right)
+                   && MathHelper.CloseToPercent(Top, other.Top);
         }
 
         public bool EqualsApprox(Box2 other, double tolerance)
         {
-            return MathHelper.CloseTo(Left, other.Left, tolerance)
-                   && MathHelper.CloseTo(Bottom, other.Bottom, tolerance)
-                   && MathHelper.CloseTo(Right, other.Right, tolerance)
-                   && MathHelper.CloseTo(Top, other.Top, tolerance);
+            return MathHelper.CloseToPercent(Left, other.Left, tolerance)
+                   && MathHelper.CloseToPercent(Bottom, other.Bottom, tolerance)
+                   && MathHelper.CloseToPercent(Right, other.Right, tolerance)
+                   && MathHelper.CloseToPercent(Top, other.Top, tolerance);
         }
     }
 }

--- a/Robust.Shared.Maths/Circle.cs
+++ b/Robust.Shared.Maths/Circle.cs
@@ -69,7 +69,7 @@ namespace Robust.Shared.Maths
             var r2 = Radius * Radius;
 
             // Instead of d2 <= r2, use MathHelper.CloseTo to allow for some tolerance.
-            return (d2 < r2) || MathHelper.CloseTo(d2, r2);
+            return (d2 < r2) || MathHelper.CloseToPercent(d2, r2);
         }
 
         /// <inheritdoc />

--- a/Robust.Shared.Maths/Color.cs
+++ b/Robust.Shared.Maths/Color.cs
@@ -1015,10 +1015,10 @@ namespace Robust.Shared.Maths
         public readonly bool Equals(Color other)
         {
             return
-                MathHelper.CloseTo(R, other.R) &&
-                MathHelper.CloseTo(G, other.G) &&
-                MathHelper.CloseTo(B, other.B) &&
-                MathHelper.CloseTo(A, other.A);
+                MathHelper.CloseToPercent(R, other.R) &&
+                MathHelper.CloseToPercent(G, other.G) &&
+                MathHelper.CloseToPercent(B, other.B) &&
+                MathHelper.CloseToPercent(A, other.A);
         }
 
         [PublicAPI]

--- a/Robust.Shared.Maths/MathHelper.cs
+++ b/Robust.Shared.Maths/MathHelper.cs
@@ -500,53 +500,75 @@ namespace Robust.Shared.Maths
 
         #endregion Clamp
 
+        #region CloseToPercent
+
+        /// <summary>
+        /// Returns whether two floating point numbers are within <paramref name="percentage"/> of eachother
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool CloseToPercent(float a, float b, double percentage = .00001)
+        {
+            // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
+            double epsilon = Math.Max(Math.Max(Math.Abs(a), Math.Abs(b)) * percentage, percentage);
+            return Math.Abs(a - b) <= epsilon;
+        }
+
+        /// <summary>
+        /// Returns whether two floating point numbers are within <paramref name="percentage"/> of eachother
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool CloseToPercent(float a, double b, double percentage = .00001)
+        {
+            // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
+            double epsilon = Math.Max(Math.Max(Math.Abs(a), Math.Abs(b)) * percentage, percentage);
+            return Math.Abs(a - b) <= epsilon;
+        }
+
+        /// <summary>
+        /// Returns whether two floating point numbers are within <paramref name="percentage"/> of eachother
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool CloseToPercent(double a, float b, double percentage = .00001)
+        {
+            // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
+            double epsilon = Math.Max(Math.Max(Math.Abs(a), Math.Abs(b)) * percentage, percentage);
+            return Math.Abs(a - b) <= epsilon;
+        }
+
+        /// <summary>
+        /// Returns whether two floating point numbers are within <paramref name="percentage"/> of eachother
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool CloseToPercent(double a, double b, double percentage = .00001)
+        {
+            // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
+            double epsilon = Math.Max(Math.Max(Math.Abs(a), Math.Abs(b)) * percentage, percentage);
+            return Math.Abs(a - b) <= epsilon;
+        }
+
+        #endregion CloseToPercent
+
         #region CloseTo
 
         /// <summary>
         /// Returns whether two floating point numbers are within <paramref name="tolerance"/> of eachother
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool CloseTo(float a, float b, double tolerance = .00001)
+        public static bool CloseTo(float a, float b, float tolerance = .0000001f)
         {
-            // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
-            double epsilon = Math.Max(Math.Max(Math.Abs(a), Math.Abs(b)) * tolerance, tolerance);
-            return Math.Abs(a - b) <= epsilon;
+            return MathF.Abs(a - b) <= tolerance;
         }
 
         /// <summary>
         /// Returns whether two floating point numbers are within <paramref name="tolerance"/> of eachother
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool CloseTo(float a, double b, double tolerance = .00001)
+        public static bool CloseTo(double a, double b, double tolerance = .0000001)
         {
-            // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
-            double epsilon = Math.Max(Math.Max(Math.Abs(a), Math.Abs(b)) * tolerance, tolerance);
-            return Math.Abs(a - b) <= epsilon;
+            return Math.Abs(a - b) <= tolerance;
         }
 
-        /// <summary>
-        /// Returns whether two floating point numbers are within <paramref name="tolerance"/> of eachother
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool CloseTo(double a, float b, double tolerance = .00001)
-        {
-            // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
-            double epsilon = Math.Max(Math.Max(Math.Abs(a), Math.Abs(b)) * tolerance, tolerance);
-            return Math.Abs(a - b) <= epsilon;
-        }
-
-        /// <summary>
-        /// Returns whether two floating point numbers are within <paramref name="tolerance"/> of eachother
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool CloseTo(double a, double b, double tolerance = .00001)
-        {
-            // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
-            double epsilon = Math.Max(Math.Max(Math.Abs(a), Math.Abs(b)) * tolerance, tolerance);
-            return Math.Abs(a - b) <= epsilon;
-        }
-
-        #endregion CloseTo
+        #endregion
 
         #region Lerp
 

--- a/Robust.Shared.Maths/Matrix3.cs
+++ b/Robust.Shared.Maths/Matrix3.cs
@@ -811,7 +811,7 @@ namespace Robust.Shared.Maths
             //Credit: https://stackoverflow.com/a/18504573
 
             var d = Determinant;
-            if (MathHelper.CloseTo(d, 0))
+            if (MathHelper.CloseToPercent(d, 0))
                 throw new InvalidOperationException("Matrix is singular and cannot be inverted.");
 
             var m = this;

--- a/Robust.Shared.Maths/UIBox2.cs
+++ b/Robust.Shared.Maths/UIBox2.cs
@@ -78,7 +78,7 @@ namespace Robust.Shared.Maths
 
         public readonly bool IsEmpty()
         {
-            return MathHelper.CloseTo(Width, 0.0f) && MathHelper.CloseTo(Height, 0.0f);
+            return MathHelper.CloseToPercent(Width, 0.0f) && MathHelper.CloseToPercent(Height, 0.0f);
         }
 
         public readonly bool Encloses(UIBox2 inner)
@@ -159,10 +159,10 @@ namespace Robust.Shared.Maths
         /// </summary>
         public static bool operator ==(UIBox2 a, UIBox2 b)
         {
-            return MathHelper.CloseTo(a.Bottom, b.Bottom) &&
-                   MathHelper.CloseTo(a.Right, b.Right) &&
-                   MathHelper.CloseTo(a.Top, b.Top) &&
-                   MathHelper.CloseTo(a.Left, b.Left);
+            return MathHelper.CloseToPercent(a.Bottom, b.Bottom) &&
+                   MathHelper.CloseToPercent(a.Right, b.Right) &&
+                   MathHelper.CloseToPercent(a.Top, b.Top) &&
+                   MathHelper.CloseToPercent(a.Left, b.Left);
         }
 
         public static bool operator !=(UIBox2 a, UIBox2 b)

--- a/Robust.Shared.Maths/Vector2.cs
+++ b/Robust.Shared.Maths/Vector2.cs
@@ -404,5 +404,11 @@ namespace Robust.Shared.Maths
         {
             return MathHelper.CloseTo(X, other.X, tolerance) && MathHelper.CloseTo(Y, other.Y, tolerance);
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly bool EqualsApproxPercent(Vector2 other, double tolerance = 0.0001)
+        {
+            return MathHelper.CloseToPercent(X, other.X, tolerance) && MathHelper.CloseToPercent(Y, other.Y, tolerance);
+        }
     }
 }

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -473,7 +473,7 @@ namespace Robust.Shared
             CVarDef.Create("physics.angsleeptol", 2.0f / 180.0f * MathF.PI);
 
         public static readonly CVarDef<float> LinearSleepTolerance =
-            CVarDef.Create("physics.linsleeptol", 0.001f);
+            CVarDef.Create("physics.linsleeptol", 0.1f);
 
         public static readonly CVarDef<bool> SleepAllowed =
             CVarDef.Create("physics.sleepallowed", true);

--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
@@ -869,7 +869,7 @@ namespace Robust.Shared.GameObjects
         }
 
         [DataField("angularDamping")]
-        private float _angularDamping = 0.1f;
+        private float _angularDamping = 0.2f;
 
         /// <summary>
         /// Get the linear and angular velocities at the same time.

--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
@@ -272,7 +272,7 @@ namespace Robust.Shared.GameObjects
             {
                 DebugTools.Assert(!float.IsNaN(value));
 
-                if (MathHelper.CloseTo(value, _sleepTime))
+                if (MathHelper.CloseToPercent(value, _sleepTime))
                     return;
 
                 _sleepTime = value;
@@ -714,7 +714,7 @@ namespace Robust.Shared.GameObjects
 
                 if (_bodyType != BodyType.Dynamic) return;
 
-                if (MathHelper.CloseTo(_inertia, value)) return;
+                if (MathHelper.CloseToPercent(_inertia, value)) return;
 
                 if (value > 0.0f && !_fixedRotation)
                 {
@@ -813,7 +813,7 @@ namespace Robust.Shared.GameObjects
             get => _friction;
             set
             {
-                if (MathHelper.CloseTo(value, _friction))
+                if (MathHelper.CloseToPercent(value, _friction))
                     return;
 
                 _friction = value;
@@ -836,7 +836,7 @@ namespace Robust.Shared.GameObjects
             {
                 DebugTools.Assert(!float.IsNaN(value));
 
-                if (MathHelper.CloseTo(value, _linearDamping))
+                if (MathHelper.CloseToPercent(value, _linearDamping))
                     return;
 
                 _linearDamping = value;
@@ -845,7 +845,7 @@ namespace Robust.Shared.GameObjects
         }
 
         [DataField("linearDamping")]
-        private float _linearDamping = 0.02f;
+        private float _linearDamping = 0.2f;
 
         /// <summary>
         ///     This is a set amount that the body's angular velocity is reduced every tick.
@@ -860,7 +860,7 @@ namespace Robust.Shared.GameObjects
             {
                 DebugTools.Assert(!float.IsNaN(value));
 
-                if (MathHelper.CloseTo(value, _angularDamping))
+                if (MathHelper.CloseToPercent(value, _angularDamping))
                     return;
 
                 _angularDamping = value;
@@ -869,7 +869,7 @@ namespace Robust.Shared.GameObjects
         }
 
         [DataField("angularDamping")]
-        private float _angularDamping = 0.02f;
+        private float _angularDamping = 0.1f;
 
         /// <summary>
         /// Get the linear and angular velocities at the same time.
@@ -915,7 +915,7 @@ namespace Robust.Shared.GameObjects
                 if (Vector2.Dot(value, value) > 0.0f)
                     Awake = true;
 
-                if (_linVelocity.EqualsApprox(value))
+                if (_linVelocity.EqualsApprox(value, 0.0001f))
                     return;
 
                 _linVelocity = value;
@@ -970,7 +970,7 @@ namespace Robust.Shared.GameObjects
                 if (value * value > 0.0f)
                     Awake = true;
 
-                if (MathHelper.CloseTo(_angVelocity, value))
+                if (MathHelper.CloseToPercent(_angVelocity, value, 0.0001f))
                     return;
 
                 _angVelocity = value;

--- a/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
@@ -61,7 +61,7 @@ namespace Robust.Shared.GameObjects
             get => _radius;
             set
             {
-                if (MathHelper.CloseTo(_radius, value)) return;
+                if (MathHelper.CloseToPercent(_radius, value)) return;
                 _radius = MathF.Max(value, 0.01f); // setting radius to 0 causes exceptions, so just use a value close enough to zero that it's unnoticeable.
                 Dirty();
             }

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -109,7 +109,7 @@ namespace Robust.Shared.GameObjects
                 if(_noLocalRotation)
                     return;
 
-                if (_localRotation.EqualsApprox(value, 0.00001))
+                if (_localRotation.EqualsApprox(value, 0.0001f))
                     return;
 
                 var oldRotation = _localRotation;

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.cs
@@ -446,8 +446,8 @@ namespace Robust.Shared.GameObjects
             {
                 var transform = entity.Transform;
                 var entPos = transform.WorldPosition;
-                if (MathHelper.CloseTo(entPos.X, mapPosition.X)
-                    && MathHelper.CloseTo(entPos.Y, mapPosition.Y))
+                if (MathHelper.CloseToPercent(entPos.X, mapPosition.X)
+                    && MathHelper.CloseToPercent(entPos.Y, mapPosition.Y))
                 {
                     return true;
                 }

--- a/Robust.Shared/Physics/Collision/Manifold.cs
+++ b/Robust.Shared/Physics/Collision/Manifold.cs
@@ -254,16 +254,16 @@ namespace Robust.Shared.Physics.Collision
         {
             return Id == other.Id &&
                    LocalPoint.EqualsApprox(other.LocalPoint) &&
-                   MathHelper.CloseTo(NormalImpulse, other.NormalImpulse) &&
-                   MathHelper.CloseTo(TangentImpulse, other.TangentImpulse);
+                   MathHelper.CloseToPercent(NormalImpulse, other.NormalImpulse) &&
+                   MathHelper.CloseToPercent(TangentImpulse, other.TangentImpulse);
         }
 
         public bool EqualsApprox(ManifoldPoint other, double tolerance)
         {
             return Id == other.Id &&
                    LocalPoint.EqualsApprox(other.LocalPoint, tolerance) &&
-                   MathHelper.CloseTo(NormalImpulse, other.NormalImpulse, tolerance) &&
-                   MathHelper.CloseTo(TangentImpulse, other.TangentImpulse, tolerance);
+                   MathHelper.CloseToPercent(NormalImpulse, other.NormalImpulse, tolerance) &&
+                   MathHelper.CloseToPercent(TangentImpulse, other.TangentImpulse, tolerance);
         }
     }
 }

--- a/Robust.Shared/Physics/Collision/Shapes/EdgeShape.cs
+++ b/Robust.Shared/Physics/Collision/Shapes/EdgeShape.cs
@@ -74,7 +74,7 @@ namespace Robust.Shared.Physics.Collision.Shapes
             get => _radius;
             set
             {
-                if (MathHelper.CloseTo(_radius, value)) return;
+                if (MathHelper.CloseToPercent(_radius, value)) return;
                 _radius = value;
                 //ComputeProperties();
             }

--- a/Robust.Shared/Physics/Collision/Shapes/PhysShapeAabb.cs
+++ b/Robust.Shared/Physics/Collision/Shapes/PhysShapeAabb.cs
@@ -30,7 +30,7 @@ namespace Robust.Shared.Physics.Collision.Shapes
             get => _radius;
             set
             {
-                if (MathHelper.CloseTo(_radius, value)) return;
+                if (MathHelper.CloseToPercent(_radius, value)) return;
                 _radius = value;
                 OnDataChanged?.Invoke();
             }

--- a/Robust.Shared/Physics/Collision/Shapes/PhysShapeCircle.cs
+++ b/Robust.Shared/Physics/Collision/Shapes/PhysShapeCircle.cs
@@ -53,7 +53,7 @@ namespace Robust.Shared.Physics.Collision.Shapes
             get => _radius;
             set
             {
-                if (MathHelper.CloseTo(_radius, value)) return;
+                if (MathHelper.CloseToPercent(_radius, value)) return;
                 _radius = value;
                 OnDataChanged?.Invoke();
             }
@@ -86,7 +86,7 @@ namespace Robust.Shared.Physics.Collision.Shapes
         public bool Equals(IPhysShape? other)
         {
             if (other is not PhysShapeCircle otherCircle) return false;
-            return MathHelper.CloseTo(_radius, otherCircle._radius);
+            return MathHelper.CloseToPercent(_radius, otherCircle._radius);
         }
     }
 }

--- a/Robust.Shared/Physics/Collision/Shapes/PolygonShape.cs
+++ b/Robust.Shared/Physics/Collision/Shapes/PolygonShape.cs
@@ -64,7 +64,7 @@ namespace Robust.Shared.Physics.Collision.Shapes
             get => _radius;
             set
             {
-                if (MathHelper.CloseTo(_radius, value)) return;
+                if (MathHelper.CloseToPercent(_radius, value)) return;
                 _radius = value;
                 // TODO: Update
             }

--- a/Robust.Shared/Physics/Dynamics/Fixture.cs
+++ b/Robust.Shared/Physics/Dynamics/Fixture.cs
@@ -79,7 +79,7 @@ namespace Robust.Shared.Physics.Dynamics
             get => _friction;
             set
             {
-                if (MathHelper.CloseTo(value, _friction)) return;
+                if (MathHelper.CloseToPercent(value, _friction)) return;
 
                 _friction = value;
                 Body.FixtureChanged(this);
@@ -99,7 +99,7 @@ namespace Robust.Shared.Physics.Dynamics
             get => _restitution;
             set
             {
-                if (MathHelper.CloseTo(value, _restitution)) return;
+                if (MathHelper.CloseToPercent(value, _restitution)) return;
 
                 _restitution = value;
                 Body.FixtureChanged(this);
@@ -151,7 +151,7 @@ namespace Robust.Shared.Physics.Dynamics
             get => _mass;
             set
             {
-                if (MathHelper.CloseTo(value, _mass)) return;
+                if (MathHelper.CloseToPercent(value, _mass)) return;
 
                 _mass = MathF.Max(0f, value);
                 ComputeProperties();

--- a/Robust.Shared/Physics/Dynamics/Joints/DistanceJoint.cs
+++ b/Robust.Shared/Physics/Dynamics/Joints/DistanceJoint.cs
@@ -191,7 +191,7 @@ namespace Robust.Shared.Physics.Dynamics.Joints
             get => _length;
             set
             {
-                if (MathHelper.CloseTo(value, _length)) return;
+                if (MathHelper.CloseToPercent(value, _length)) return;
 
                 _impulse = 0.0f;
                 _length = MathF.Max(IoCManager.Resolve<IConfigurationManager>().GetCVar(CVars.LinearSlop), _length);
@@ -210,7 +210,7 @@ namespace Robust.Shared.Physics.Dynamics.Joints
             get => _maxLength;
             set
             {
-                if (MathHelper.CloseTo(value, _maxLength)) return;
+                if (MathHelper.CloseToPercent(value, _maxLength)) return;
 
                 _upperImpulse = 0.0f;
                 _maxLength = MathF.Max(value, _minLength);
@@ -229,7 +229,7 @@ namespace Robust.Shared.Physics.Dynamics.Joints
             get => _minLength;
             set
             {
-                if (MathHelper.CloseTo(value, _minLength)) return;
+                if (MathHelper.CloseToPercent(value, _minLength)) return;
 
                 _lowerImpulse = 0.0f;
                 _minLength = Math.Clamp(_minLength, IoCManager.Resolve<IConfigurationManager>().GetCVar(CVars.LinearSlop), MaxLength);
@@ -245,7 +245,7 @@ namespace Robust.Shared.Physics.Dynamics.Joints
             get => _stiffness;
             set
             {
-                if (MathHelper.CloseTo(_stiffness, value)) return;
+                if (MathHelper.CloseToPercent(_stiffness, value)) return;
 
                 _stiffness = value;
                 Dirty();
@@ -260,7 +260,7 @@ namespace Robust.Shared.Physics.Dynamics.Joints
             get => _damping;
             set
             {
-                if (MathHelper.CloseTo(_damping, value)) return;
+                if (MathHelper.CloseToPercent(_damping, value)) return;
 
                 _damping = value;
                 Dirty();
@@ -544,7 +544,7 @@ namespace Robust.Shared.Physics.Dynamics.Joints
             float length = u.Length;
             u = u.Normalized;
             float C;
-            if (MathHelper.CloseTo(_minLength, _maxLength))
+            if (MathHelper.CloseToPercent(_minLength, _maxLength))
             {
                 C = length - _minLength;
             }
@@ -583,11 +583,11 @@ namespace Robust.Shared.Physics.Dynamics.Joints
             if (ReferenceEquals(this, other)) return true;
             return LocalAnchorA.EqualsApprox(other.LocalAnchorA) &&
                    LocalAnchorB.EqualsApprox(other.LocalAnchorB) &&
-                   MathHelper.CloseTo(Length, other.Length) &&
-                   MathHelper.CloseTo(Stiffness, other.Stiffness) &&
-                   MathHelper.CloseTo(Damping, other.Damping) &&
-                   MathHelper.CloseTo(MaxLength, other.MaxLength) &&
-                   MathHelper.CloseTo(MinLength, other.MinLength);
+                   MathHelper.CloseToPercent(Length, other.Length) &&
+                   MathHelper.CloseToPercent(Stiffness, other.Stiffness) &&
+                   MathHelper.CloseToPercent(Damping, other.Damping) &&
+                   MathHelper.CloseToPercent(MaxLength, other.MaxLength) &&
+                   MathHelper.CloseToPercent(MinLength, other.MinLength);
         }
     }
 }

--- a/Robust.Shared/Physics/Dynamics/Joints/FrictionJoint.cs
+++ b/Robust.Shared/Physics/Dynamics/Joints/FrictionJoint.cs
@@ -299,8 +299,8 @@ namespace Robust.Shared.Physics.Dynamics.Joints
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return base.Equals(other) &&
-                   MathHelper.CloseTo(MaxForce, other.MaxForce) &&
-                   MathHelper.CloseTo(MaxTorque, other.MaxTorque) &&
+                   MathHelper.CloseToPercent(MaxForce, other.MaxForce) &&
+                   MathHelper.CloseToPercent(MaxTorque, other.MaxTorque) &&
                    LocalAnchorA.EqualsApprox(other.LocalAnchorA) &&
                    LocalAnchorB.EqualsApprox(other.LocalAnchorB);
         }

--- a/Robust.Shared/Physics/Dynamics/Joints/Joint.cs
+++ b/Robust.Shared/Physics/Dynamics/Joints/Joint.cs
@@ -158,7 +158,7 @@ namespace Robust.Shared.Physics.Dynamics.Joints
             get => _breakpoint;
             set
             {
-                if (MathHelper.CloseTo(_breakpoint, value)) return;
+                if (MathHelper.CloseToPercent(_breakpoint, value)) return;
                 _breakpoint = value;
                 _breakpointSquared = _breakpoint * _breakpoint;
                 Dirty();
@@ -243,7 +243,7 @@ namespace Robust.Shared.Physics.Dynamics.Joints
                    BodyAUid.Equals(other.BodyAUid) &&
                    BodyBUid.Equals(other.BodyBUid) &&
                    CollideConnected == other.CollideConnected &&
-                   MathHelper.CloseTo(_breakpoint, other._breakpoint);
+                   MathHelper.CloseToPercent(_breakpoint, other._breakpoint);
         }
 
         public sealed class JointBreakMessage : EntityEventArgs

--- a/Robust.Shared/Physics/GiftWrap.cs
+++ b/Robust.Shared/Physics/GiftWrap.cs
@@ -53,7 +53,7 @@ namespace Robust.Shared.Physics
             for (int i = 1; i < vertices.Length; ++i)
             {
                 float x = vertices[i].X;
-                if (x > x0 || (MathHelper.CloseTo(x, x0) && vertices[i].Y < vertices[i0].Y))
+                if (x > x0 || (MathHelper.CloseToPercent(x, x0) && vertices[i].Y < vertices[i0].Y))
                 {
                     i0 = i;
                     x0 = x;

--- a/Robust.Shared/Physics/Ray.cs
+++ b/Robust.Shared/Physics/Ray.cs
@@ -30,7 +30,7 @@ namespace Robust.Shared.Physics
             Position = position;
             Direction = direction;
 
-            DebugTools.Assert(MathHelper.CloseTo(Direction.LengthSquared, 1));
+            DebugTools.Assert(MathHelper.CloseToPercent(Direction.LengthSquared, 1));
 
         }
 

--- a/Robust.UnitTesting/ApproxEqualityConstraint.cs
+++ b/Robust.UnitTesting/ApproxEqualityConstraint.cs
@@ -22,20 +22,20 @@ namespace Robust.UnitTesting
                 {
                     if (Tolerance != null)
                     {
-                        return new ConstraintResult(this, actual, MathHelper.CloseTo(f1, f2, Tolerance.Value));
+                        return new ConstraintResult(this, actual, MathHelper.CloseToPercent(f1, f2, Tolerance.Value));
                     }
 
-                    return new ConstraintResult(this, actual, MathHelper.CloseTo(f1, f2));
+                    return new ConstraintResult(this, actual, MathHelper.CloseToPercent(f1, f2));
                 }
 
                 if (Expected is double d1 && actual is float d2)
                 {
                     if (Tolerance != null)
                     {
-                        return new ConstraintResult(this, actual, MathHelper.CloseTo(d1, d2, Tolerance.Value));
+                        return new ConstraintResult(this, actual, MathHelper.CloseToPercent(d1, d2, Tolerance.Value));
                     }
 
-                    return new ConstraintResult(this, actual, MathHelper.CloseTo(d1, d2));
+                    return new ConstraintResult(this, actual, MathHelper.CloseToPercent(d1, d2));
                 }
 
                 return new ConstraintResult(this, actual, false);

--- a/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
@@ -218,8 +218,8 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
             var result = childTrans.WorldPosition;
             Assert.Multiple(() =>
             {
-                Assert.That(MathHelper.CloseTo(result.X, 0));
-                Assert.That(MathHelper.CloseTo(result.Y, 2));
+                Assert.That(MathHelper.CloseToPercent(result.X, 0));
+                Assert.That(MathHelper.CloseToPercent(result.Y, 2));
             });
         }
 
@@ -245,8 +245,8 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
             var result = childTrans.WorldPosition;
             Assert.Multiple(() =>
             {
-                Assert.That(MathHelper.CloseTo(result.X, 1));
-                Assert.That(MathHelper.CloseTo(result.Y, 2));
+                Assert.That(MathHelper.CloseToPercent(result.X, 1));
+                Assert.That(MathHelper.CloseToPercent(result.Y, 2));
             });
         }
 
@@ -327,8 +327,8 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
             // Assert
             Assert.Multiple(() =>
             {
-                Assert.That(MathHelper.CloseTo(oldWpos.X, newWpos.Y), $"{oldWpos.X} should be {newWpos.Y}");
-                Assert.That(MathHelper.CloseTo(oldWpos.Y, newWpos.Y), newWpos.ToString);
+                Assert.That(MathHelper.CloseToPercent(oldWpos.X, newWpos.Y), $"{oldWpos.X} should be {newWpos.Y}");
+                Assert.That(MathHelper.CloseToPercent(oldWpos.Y, newWpos.Y), newWpos.ToString);
             });
         }
 
@@ -374,8 +374,8 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
 
             Assert.Multiple(() =>
             {
-                Assert.That(MathHelper.CloseTo(oldWpos.X, newWpos.Y));
-                Assert.That(MathHelper.CloseTo(oldWpos.Y, newWpos.Y));
+                Assert.That(MathHelper.CloseToPercent(oldWpos.X, newWpos.Y));
+                Assert.That(MathHelper.CloseToPercent(oldWpos.Y, newWpos.Y));
             });
         }
 

--- a/Robust.UnitTesting/Shared/Map/GridFixtures_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/GridFixtures_Tests.cs
@@ -39,7 +39,7 @@ namespace Robust.UnitTesting.Shared.Map
                 // Also should only be a single tile.
                 var bounds = gridBody.Fixtures[0].Shape.ComputeAABB(new Transform(Vector2.Zero, (float) Angle.Zero.Theta), 0);
                 // Poly probably has Box2D's radius added to it so won't be a unit square
-                Assert.That(MathHelper.CloseTo(Box2.Area(bounds), 1.0f, 0.1f));
+                Assert.That(MathHelper.CloseToPercent(Box2.Area(bounds), 1.0f, 0.1f));
 
                 // Now do 2 tiles (same chunk)
                 grid.SetTile(Vector2i.One, new Tile(1));
@@ -48,7 +48,7 @@ namespace Robust.UnitTesting.Shared.Map
                 bounds = gridBody.Fixtures[0].Shape.ComputeAABB(new Transform(Vector2.Zero, (float) Angle.Zero.Theta), 0);
 
                 // Even if we add a new tile old fixture should stay the same if they don't connect.
-                Assert.That(MathHelper.CloseTo(Box2.Area(bounds), 1.0f, 0.1f));
+                Assert.That(MathHelper.CloseToPercent(Box2.Area(bounds), 1.0f, 0.1f));
 
                 // If we add a new chunk should be 3 now
                 grid.SetTile(new Vector2i(-1, -1), new Tile(1));

--- a/Robust.UnitTesting/Shared/Map/GridRotation_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/GridRotation_Tests.cs
@@ -41,15 +41,15 @@ namespace Robust.UnitTesting.Shared.Map
                 gridEnt.Transform.WorldRotation += new Angle(MathF.PI);
                 Assert.That(gridEnt.Transform.WorldRotation, Is.EqualTo(new Angle(MathF.PI)));
                 // Check the map coordinate rotates correctly
-                Assert.That(grid.WorldToLocal(new Vector2(10, 0)).EqualsApprox(new Vector2(-10, 0)));
-                Assert.That(grid.LocalToWorld(coordinates.Position).EqualsApprox(new Vector2(-10, 0)));
+                Assert.That(grid.WorldToLocal(new Vector2(10, 0)).EqualsApprox(new Vector2(-10, 0), 0.01f));
+                Assert.That(grid.LocalToWorld(coordinates.Position).EqualsApprox(new Vector2(-10, 0), 0.01f));
 
                 // Now we'll do the same for 180 degrees.
                 gridEnt.Transform.WorldRotation += MathF.PI / 2f;
                 // If grid facing down then worldpos of 10, 0 gets rotated 90 degrees CCW and hence should be 0, 10
-                Assert.That(grid.WorldToLocal(new Vector2(10, 0)).EqualsApprox(new Vector2(0, 10)));
+                Assert.That(grid.WorldToLocal(new Vector2(10, 0)).EqualsApprox(new Vector2(0, 10), 0.01f));
                 // If grid facing down then local 10,0 pos should just return 0, -10 given it's aligned with the rotation.
-                Assert.That(grid.LocalToWorld(coordinates.Position).EqualsApprox(new Vector2(0, -10)));
+                Assert.That(grid.LocalToWorld(coordinates.Position).EqualsApprox(new Vector2(0, -10), 0.01f));
             });
         }
 

--- a/Robust.UnitTesting/Shared/Maths/Angle_Test.cs
+++ b/Robust.UnitTesting/Shared/Maths/Angle_Test.cs
@@ -142,7 +142,7 @@ namespace Robust.UnitTesting.Shared.Maths
 
             var result = angle.RotateVec(vec);
 
-            Assert.That(result, new ApproxEqualityConstraint(new Vector2(0.183013f, 0.683013f)));
+            Assert.That(result, new ApproxEqualityConstraint(new Vector2(0.183013f, 0.683013f), 0.001));
         }
 
         [TestCase(0, 4, ExpectedResult = 0f)]

--- a/Robust.UnitTesting/Shared/Maths/Matrix3_Test.cs
+++ b/Robust.UnitTesting/Shared/Maths/Matrix3_Test.cs
@@ -48,8 +48,8 @@ namespace Robust.UnitTesting.Shared.Maths
             var control = testCase.Item1;
             var result = test.Xy;
 
-            Assert.That(MathHelper.CloseTo(control.X, result.X), Is.True, result.ToString);
-            Assert.That(MathHelper.CloseTo(control.Y, result.Y), Is.True, result.ToString);
+            Assert.That(MathHelper.CloseToPercent(control.X, result.X), Is.True, result.ToString);
+            Assert.That(MathHelper.CloseToPercent(control.Y, result.Y), Is.True, result.ToString);
         }
 
         [Test]
@@ -114,8 +114,8 @@ namespace Robust.UnitTesting.Shared.Maths
             var result = test.Xy;
 
             // Assert
-            Assert.That(MathHelper.CloseTo(result.X, 2), result.ToString);
-            Assert.That(MathHelper.CloseTo(result.Y, 2), result.ToString);
+            Assert.That(MathHelper.CloseToPercent(result.X, 2), result.ToString);
+            Assert.That(MathHelper.CloseToPercent(result.Y, 2), result.ToString);
         }
 
         [Test]
@@ -137,8 +137,8 @@ namespace Robust.UnitTesting.Shared.Maths
             Matrix3.Transform(in invMatrix, in localPoint, out var result);
 
             // Assert
-            Assert.That(MathHelper.CloseTo(startPoint.X, result.X), Is.True, result.ToString);
-            Assert.That(MathHelper.CloseTo(startPoint.Y, result.Y), Is.True, result.ToString);
+            Assert.That(MathHelper.CloseToPercent(startPoint.X, result.X), Is.True, result.ToString);
+            Assert.That(MathHelper.CloseToPercent(startPoint.Y, result.Y), Is.True, result.ToString);
         }
     }
 }

--- a/Robust.UnitTesting/Shared/Physics/ShapeAABB_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/ShapeAABB_Test.cs
@@ -53,7 +53,7 @@ namespace Robust.UnitTesting.Shared.Physics
         {
             var edge = new EdgeShape(Vector2.Zero, Vector2.One);
             var aabb = edge.ComputeAABB(_rotatedTransform, 0);
-            Assert.That(MathHelper.CloseTo(aabb.Width, 0.02f));
+            Assert.That(MathHelper.CloseToPercent(aabb.Width, 0.02f));
             Assert.That(aabb.EqualsApprox(new Box2(0.99f, 0.99f, 1.01f, 2.42f), 0.01f));
         }
 

--- a/Robust.UnitTesting/Shared/Physics/Stack_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Stack_Test.cs
@@ -216,6 +216,7 @@ namespace Robust.UnitTesting.Shared.Physics
                         var circle = entityManager.SpawnEntity(null,
                             new MapCoordinates(new Vector2(xs[j] + x, 0.55f + 2.1f * i), mapId)).AddComponent<PhysicsComponent>();
 
+                        circle.LinearDamping = 0.05f;
                         circle.BodyType = BodyType.Dynamic;
                         shape = new PhysShapeCircle {Radius = 0.5f};
 
@@ -245,7 +246,7 @@ namespace Robust.UnitTesting.Shared.Physics
 
             // Assert
 
-            await server.WaitRunTicks(150);
+            await server.WaitRunTicks(200);
 
             // Assert settled, none below 0, etc.
             await server.WaitAssertion(() =>
@@ -257,9 +258,11 @@ namespace Robust.UnitTesting.Shared.Physics
                         var body = bodies[j * columnCount + i];
                         var worldPos = body.Owner.Transform.WorldPosition;
 
+                        var expectedY = 0.5f + i;
+
                         // TODO: Multi-column support but I cbf right now
                         // Can't be more exact as some level of sinking is allowed.
-                        Assert.That(worldPos.EqualsApprox(new Vector2(0.0f, i + 0.5f), 0.1f), $"Expected y-value of {i + 0.5f} but found {worldPos.Y}");
+                        Assert.That(worldPos.EqualsApproxPercent(new Vector2(0.0f, expectedY), 0.1f), $"Expected y-value of {expectedY} but found {worldPos.Y}");
                     }
                 }
             });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31366439/135238716-10cc4fbf-bab0-4127-a261-08917c6d23fa.png)

Actual changes:
* CloseTo renamed to CloseToPercent so physics can do minute body changes
* Sleep tolerance threshold significantly increased
* Damping significantly increased (20%)

I was mainly concerned with how weightless items and shuttles performed, i.e. weightless items still look floaty but sleep as fast as possible. This is why I had to do a 5x multiplier when initially moving the shuttle on content to make sure it exceeded the sleep threshold from the initial impulse.