### PR TITLE
Adds Write/Copy TypeSerializer methods for base SpriteSpecifier.

### DIFF
--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/SpriteSpecifierSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/SpriteSpecifierSerializer.cs
@@ -1,3 +1,4 @@
+using System;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Serialization.Manager;
@@ -18,8 +19,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
         ITypeSerializer<Texture, ValueDataNode>,
         ITypeSerializer<EntityPrototype, ValueDataNode>,
         ITypeSerializer<Rsi, MappingDataNode>,
-        ITypeReader<SpriteSpecifier, MappingDataNode>,
-        ITypeReader<SpriteSpecifier, ValueDataNode>
+        ITypeSerializer<SpriteSpecifier, MappingDataNode>,
+        ITypeSerializer<SpriteSpecifier, ValueDataNode>
     {
         DeserializationResult ITypeReader<Texture, ValueDataNode>.Read(ISerializationManager serializationManager,
             ValueDataNode node,
@@ -190,6 +191,42 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             ISerializationContext? context = null)
         {
             return new(source.RsiPath, source.RsiState);
+        }
+
+        public DataNode Write(ISerializationManager serializationManager, SpriteSpecifier value, bool alwaysWrite = false,
+            ISerializationContext? context = null)
+        {
+            return value switch
+            {
+                Rsi rsi
+                    => Write(serializationManager, rsi, alwaysWrite, context),
+
+                Texture texture
+                    => Write(serializationManager, texture, alwaysWrite, context),
+
+                EntityPrototype entityPrototype
+                    => Write(serializationManager, entityPrototype, alwaysWrite, context),
+
+                _ => throw new InvalidOperationException("Invalid SpriteSpecifier specified!")
+            };
+        }
+
+        public SpriteSpecifier Copy(ISerializationManager serializationManager, SpriteSpecifier source, SpriteSpecifier target,
+            bool skipHook, ISerializationContext? context = null)
+        {
+            return source switch
+            {
+                Rsi rsi
+                    => new Rsi(rsi.RsiPath, rsi.RsiState),
+
+                Texture texture
+                    => new Texture(texture.TexturePath),
+
+                EntityPrototype entityPrototype
+                    => new EntityPrototype(entityPrototype.EntityPrototypeId),
+
+                _ => throw new InvalidOperationException("Invalid SpriteSpecifier specified!")
+            };
         }
     }
 }


### PR DESCRIPTION
Allows us to serialize/copy the base `SpriteSpecifier` as its correct type.
@PaulRitter pls review