### PR TITLE
Fix stuck lathes properly.

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -330,24 +330,29 @@ namespace Robust.Shared.GameObjects
 
             var entityUid = component.Owner.Uid;
 
-            foreach (var refType in reg.References)
+            // If another component of the same type was added, then we can't actually remove this properly.
+            // To test this case, have a component that gets removed, and then is EnsureComponent'd.
+            // If this is broken, the removal of the old component will get rid of the new component.
+            if (_entCompIndex.Remove(entityUid, component))
             {
-                _entTraitDict[refType].Remove(entityUid);
+                foreach (var refType in reg.References)
+                {
+                    _entTraitDict[refType].Remove(entityUid);
+                }
+
+                // ReSharper disable once InvertIf
+                if (reg.NetID != null)
+                {
+                    var netSet = _netComponents[entityUid];
+                    if (netSet.Count == 1)
+                        _netComponents.Remove(entityUid);
+                    else
+                        netSet.Remove(reg.NetID.Value);
+
+                    component.Owner.Dirty();
+                }
             }
 
-            // ReSharper disable once InvertIf
-            if (reg.NetID != null)
-            {
-                var netSet = _netComponents[entityUid];
-                if (netSet.Count == 1)
-                    _netComponents.Remove(entityUid);
-                else
-                    netSet.Remove(reg.NetID.Value);
-
-                component.Owner.Dirty();
-            }
-
-            _entCompIndex.Remove(entityUid, component);
             ComponentDeleted?.Invoke(this, new DeletedComponentEventArgs(component, entityUid));
         }
 


### PR DESCRIPTION
**Big warning: This PR needs severe testing. It messes around with the component registry. Feel free to close it and put in a PR that does something else, but I would not recommend simply disabling TimerComponent auto-removal as that leaves the engine open to future problems of this kind.**

Ought to fix https://github.com/space-wizards/space-station-14/issues/4518

# An explaination

So, you may know that autolathes and protolathes on SS14 get stuck right now.
What's happening?

Well, here's how a lathe works in relation to the relevant systems:
![image](https://user-images.githubusercontent.com/22304167/135766101-7ed13508-01b3-43e1-952d-eb8e6f31be06.png)

And here's what actually happens when a lathe freezes:
![image](https://user-images.githubusercontent.com/22304167/135766029-c7ea3ec8-aa79-46e9-93b9-b6d9cdf661eb.png)

In further detail, when the old TimerComponent is finally removed from the deferred parts of the component dictionaries, it is not actually checked that the targetted parts of the component dictionaries refer to the old TimerComponent.

This PR performs that check and avoids doing any "anonymous" component actions in that event, on the basis that a replacement component exists.
