### PR TITLE
Add extra helpers to Direction

### DIFF
--- a/Robust.Shared.Maths/Direction.cs
+++ b/Robust.Shared.Maths/Direction.cs
@@ -95,14 +95,41 @@ namespace Robust.Shared.Maths
             new Vector2(-1, 0),
             new Vector2(-1, -1).Normalized
         };
+        
+        private static readonly Vector2i[] IntDirectionVectors = new[]
+        {
+            new Vector2i(0, -1),
+            new Vector2i(1, -1),
+            new Vector2i(1, 0),
+            new Vector2i(1, 1),
+            new Vector2i(0, 1),
+            new Vector2i(-1, 1),
+            new Vector2i(-1, 0),
+            new Vector2i(-1, -1)
+        };
+        
         /// <summary>
         /// Converts a Direction to a normalized Direction vector.
         /// </summary>
         /// <param name="dir"></param>
-        /// <returns></returns>
+        /// <returns>a normalized 2D Vector</returns>
+        /// <exception cref="IndexOutOfRangeException">if invalid Direction is used</exception>
+        /// <seealso cref="Vector2"/>
         public static Vector2 ToVec(this Direction dir)
         {
             return directionVectors[(int) dir];
+        }
+
+        /// <summary>
+        /// Converts a Direction to a Vector2i. Useful for getting adjacent tiles.
+        /// </summary>
+        /// <param name="dir">Direction</param>
+        /// <returns>an 2D int Vector</returns>
+        /// <exception cref="IndexOutOfRangeException">if invalid Direction is used</exception>
+        /// <seealso cref="Vector2i"/>
+        public static Vector2i ToIntVec(this Direction dir)
+        {
+            return IntDirectionVectors[(int) dir];
         }
 
         /// <summary>

--- a/Robust.Shared.Maths/Direction.cs
+++ b/Robust.Shared.Maths/Direction.cs
@@ -131,6 +131,18 @@ namespace Robust.Shared.Maths
         }
 
         /// <summary>
+        ///     Offset 2D integer vector by a given direction.
+        ///     Convenience for adding <see cref="ToIntVec"/> to <see cref="Vector2i"/>
+        /// </summary>
+        /// <param name="vec">2D integer vector</param>
+        /// <param name="dir">Direction by which we offset</param>
+        /// <returns>a newly vector offset by the <param name="dir">dir</param> or exception if the direction is invalid</returns>
+        public static Vector2i Offset(this Vector2i vec, Direction dir)
+        {
+            return vec + dir.ToIntVec();
+        }
+
+        /// <summary>
         /// Converts a direction vector to an angle, where angle is -PI to +PI.
         /// </summary>
         /// <param name="vec">Vector to get the angle from.</param>

--- a/Robust.Shared.Maths/Direction.cs
+++ b/Robust.Shared.Maths/Direction.cs
@@ -84,28 +84,26 @@ namespace Robust.Shared.Maths
             return ang;
         }
 
-        private static Vector2[] directionVectors = new[]
-        {
-            new Vector2(0, -1),
+        private static readonly Vector2[] DirectionVectors = {
+            new (0, -1),
             new Vector2(1, -1).Normalized,
-            new Vector2(1, 0),
+            new (1, 0),
             new Vector2(1, 1).Normalized,
-            new Vector2(0, 1),
+            new (0, 1),
             new Vector2(-1, 1).Normalized,
-            new Vector2(-1, 0),
+            new (-1, 0),
             new Vector2(-1, -1).Normalized
         };
         
-        private static readonly Vector2i[] IntDirectionVectors = new[]
-        {
-            new Vector2i(0, -1),
-            new Vector2i(1, -1),
-            new Vector2i(1, 0),
-            new Vector2i(1, 1),
-            new Vector2i(0, 1),
-            new Vector2i(-1, 1),
-            new Vector2i(-1, 0),
-            new Vector2i(-1, -1)
+        private static readonly Vector2i[] IntDirectionVectors = {
+            new (0, -1),
+            new (1, -1),
+            new (1, 0),
+            new (1, 1),
+            new (0, 1),
+            new (-1, 1),
+            new (-1, 0),
+            new (-1, -1)
         };
         
         /// <summary>
@@ -117,7 +115,7 @@ namespace Robust.Shared.Maths
         /// <seealso cref="Vector2"/>
         public static Vector2 ToVec(this Direction dir)
         {
-            return directionVectors[(int) dir];
+            return DirectionVectors[(int) dir];
         }
 
         /// <summary>

--- a/Robust.UnitTesting/Shared/Maths/Direction_Test.cs
+++ b/Robust.UnitTesting/Shared/Maths/Direction_Test.cs
@@ -38,9 +38,12 @@ namespace Robust.UnitTesting.Shared.Maths
         public void TestDirectionToVec([ValueSource(nameof(sources))] (float, float, Direction, double) test)
         {
             var control = new Vector2(test.Item1, test.Item2).Normalized;
+            var controlInt = new Vector2i((int)test.Item1, (int)test.Item2);
             var val = test.Item3.ToVec();
+            var intVec = test.Item3.ToIntVec();
 
             Assert.That(val, Is.Approximately(control));
+            Assert.That(intVec, Is.Approximately(controlInt));
         }
 
         [Test]

--- a/Robust.UnitTesting/Shared/Maths/Direction_Test.cs
+++ b/Robust.UnitTesting/Shared/Maths/Direction_Test.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Robust.Shared.Maths;
 using NUnit.Framework;
 
@@ -7,70 +6,75 @@ namespace Robust.UnitTesting.Shared.Maths
 {
     [Parallelizable(ParallelScope.All | ParallelScope.Fixtures)]
     [TestFixture]
-    internal class Direction_Test
+    internal class DirectionTest
     {
         private const double Epsilon = 1.0e-8;
 
-        private static IEnumerable<(float x, float y, Direction dir, double angle)> sources => new(float, float, Direction, double)[]
+        private static IEnumerable<TestCaseData> Sources()
         {
-            (1, 0, Direction.East, Angle.FromDegrees(90)),
-            (1, 1, Direction.NorthEast, Angle.FromDegrees(135)),
-            (0, 1, Direction.North, Angle.FromDegrees(180)),
-            (-1, 1, Direction.NorthWest, Angle.FromDegrees(-135)),
-            (-1, 0, Direction.West, Angle.FromDegrees(-90)),
-            (-1, -1, Direction.SouthWest, Angle.FromDegrees(-45)),
-            (0, -1, Direction.South, 0),
-            (1, -1, Direction.SouthEast, Angle.FromDegrees(45))
-        };
+            yield return new TestCaseData(1, 0, Direction.East, Angle.FromDegrees(90));
+            yield return new TestCaseData(1, 1, Direction.NorthEast, Angle.FromDegrees(135));
+            yield return new TestCaseData(0, 1, Direction.North, Angle.FromDegrees(180));
+            yield return new TestCaseData(-1, 1, Direction.NorthWest, Angle.FromDegrees(-135));
+            yield return new TestCaseData(-1, 0, Direction.West, Angle.FromDegrees(-90));
+            yield return new TestCaseData(-1, -1, Direction.SouthWest, Angle.FromDegrees(-45));
+            yield return new TestCaseData(0, -1, Direction.South, Angle.FromDegrees(0));
+            yield return new TestCaseData(1, -1, Direction.SouthEast, Angle.FromDegrees(45));
+        }
 
         [Test]
-        [Sequential]
-        public void TestDirectionToAngle([ValueSource(nameof(sources))] (float, float, Direction, double) test)
+        [TestCaseSource(nameof(Sources))]
+        [Parallelizable]
+        public void TestDirectionToAngle(float x, float y, Direction dir, Angle angle)
         {
-            var control = test.Item4;
-            var val = test.Item3.ToAngle();
+            double control = angle;
+            var val = dir.ToAngle();
 
             Assert.That(val.Theta, Is.EqualTo(control).Within(Epsilon));
         }
 
         [Test]
-        [Sequential]
-        public void TestDirectionToVec([ValueSource(nameof(sources))] (float, float, Direction, double) test)
+        [TestCaseSource(nameof(Sources))]
+        [Parallelizable]
+        public void TestDirectionToVec(float x, float y, Direction dir, Angle _)
         {
-            var control = new Vector2(test.Item1, test.Item2).Normalized;
-            var controlInt = new Vector2i((int)test.Item1, (int)test.Item2);
-            var val = test.Item3.ToVec();
-            var intVec = test.Item3.ToIntVec();
+            var control = new Vector2(x, y).Normalized;
+            var controlInt = new Vector2i((int)x, (int)y);
+            var val = dir.ToVec();
+            var intVec = dir.ToIntVec();
 
             Assert.That(val, Is.Approximately(control));
-            Assert.That(intVec, Is.Approximately(controlInt));
+            Assert.That(intVec, Is.EqualTo(controlInt));
         }
 
         [Test]
-        [Sequential]
-        public void TestVecToAngle([ValueSource(nameof(sources))] (float, float, Direction, double) test)
+        [TestCaseSource(nameof(Sources))]
+        [Parallelizable]
+        public void TestVecToAngle(float x, float y, Direction dir, Angle angle)
         {
-            var target = new Vector2(test.Item1, test.Item2).Normalized;
+            var target = new Vector2(x, y).Normalized;
 
-            Assert.That(target.ToWorldAngle().Reduced(), Is.Approximately(new Angle(test.Item4)));
+            Assert.That(target.ToWorldAngle().Reduced(), Is.Approximately(new Angle(angle)));
         }
 
         [Test]
-        [Sequential]
-        public void TestVector2ToDirection([ValueSource(nameof(sources))] (float, float, Direction, double) test)
+        [TestCaseSource(nameof(Sources))]
+        [Parallelizable]
+        public void TestVector2ToDirection(float x, float y, Direction dir, Angle angle)
         {
-            var target = new Vector2(test.Item1, test.Item2).Normalized;
+            var target = new Vector2(x, y).Normalized;
 
-            Assert.That(target.GetDir(), Is.EqualTo(test.Item3));
+            Assert.That(target.GetDir(), Is.EqualTo(dir));
         }
 
         [Test]
-        [Sequential]
-        public void TestAngleToDirection([ValueSource(nameof(sources))] (float, float, Direction, double) test)
+        [TestCaseSource(nameof(Sources))]
+        [Parallelizable]
+        public void TestAngleToDirection(float x, float y, Direction dir, Angle angle)
         {
-            var target = new Angle(test.Item4);
+            var target = new Angle(angle);
 
-            Assert.That(target.GetDir(), Is.EqualTo(test.Item3));
+            Assert.That(target.GetDir(), Is.EqualTo(dir));
         }
 
     }

--- a/Robust.UnitTesting/Shared/Maths/Direction_Test.cs
+++ b/Robust.UnitTesting/Shared/Maths/Direction_Test.cs
@@ -46,6 +46,17 @@ namespace Robust.UnitTesting.Shared.Maths
             Assert.That(val, Is.Approximately(control));
             Assert.That(intVec, Is.EqualTo(controlInt));
         }
+        
+        [Test]
+        [Parallelizable]
+        public void TestDirectionOffset()
+        {
+            var v = new Vector2i(1, 1);
+            var expected = new Vector2i(2, 2);
+            var dir = Direction.NorthEast; 
+            
+            Assert.That(v.Offset(dir), Is.EqualTo(expected));
+        }
 
         [Test]
         [TestCaseSource(nameof(Sources))]


### PR DESCRIPTION
# Purpose of this commit

This commit adds Directional methods for getting `Vector2i` out of `Direction`. I need this for easier getting of neighbouring tiles  (all eight directions).

In addition, this adds some docxml and spruces up tests a bit.