### PR TITLE
Revert "Fix stuck lathes properly. (#2091)"

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -343,29 +343,24 @@ namespace Robust.Shared.GameObjects
 
             var entityUid = component.Owner.Uid;
 
-            // If another component of the same type was added, then we can't actually remove this properly.
-            // To test this case, have a component that gets removed, and then is EnsureComponent'd.
-            // If this is broken, the removal of the old component will get rid of the new component.
-            if (_entCompIndex.Remove(entityUid, component))
+            foreach (var refType in reg.References)
             {
-                foreach (var refType in reg.References)
-                {
-                    _entTraitDict[refType].Remove(entityUid);
-                }
-
-                // ReSharper disable once InvertIf
-                if (reg.NetID != null)
-                {
-                    var netSet = _netComponents[entityUid];
-                    if (netSet.Count == 1)
-                        _netComponents.Remove(entityUid);
-                    else
-                        netSet.Remove(reg.NetID.Value);
-
-                    component.Owner.Dirty();
-                }
+                _entTraitDict[refType].Remove(entityUid);
             }
 
+            // ReSharper disable once InvertIf
+            if (reg.NetID != null)
+            {
+                var netSet = _netComponents[entityUid];
+                if (netSet.Count == 1)
+                    _netComponents.Remove(entityUid);
+                else
+                    netSet.Remove(reg.NetID.Value);
+
+                component.Owner.Dirty();
+            }
+
+            _entCompIndex.Remove(entityUid, component);
             ComponentDeleted?.Invoke(this, new DeletedComponentEventArgs(component, entityUid));
         }
 


### PR DESCRIPTION
This reverts commit a60993c60db828f76a953f6bb58620cfab3cf1c9 and therefore PR #2091 

Reasoning:
Try using The Nuclear Option at the indicated spot on a debug build and move about a bit as a ghost. It may take, like, 2 tries or something.

![image](https://user-images.githubusercontent.com/22304167/136305761-edf1cc47-dfde-4519-98f6-82689884572a.png)

Resulting client error:
```
[FATL] unhandled: System.InvalidOperationException: Tried to overwrite a protected component.
   at Robust.Shared.GameObjects.EntityManager.AddComponentInternal[T](EntityUid uid, T component, Boolean overwrite) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Components.cs:line 148
   at Robust.Shared.GameObjects.EntityManager.AllocEntity(Nullable`1 uid) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 372
   at Robust.Shared.GameObjects.EntityManager.AllocEntity(String prototypeName, Nullable`1 uid) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 336
   at Robust.Shared.GameObjects.EntityManager.CreateEntity(String prototypeName, Nullable`1 uid) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 389
   at Robust.Client.GameObjects.ClientEntityManager.Robust.Client.GameObjects.IClientEntityManagerInternal.CreateEntity(String prototypeName, Nullable`1 uid) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Client/GameObjects/ClientEntityManager.cs:line 38
   at Robust.Client.GameStates.ClientGameStateManager.ApplyEntityStates(EntityState[] curEntStates, IEnumerable`1 deletions, EntityState[] nextEntStates) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Client/GameStates/ClientGameStateManager.cs:line 451
   at Robust.Client.GameStates.ClientGameStateManager.ApplyGameState(GameState curState, GameState nextState) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Client/GameStates/ClientGameStateManager.cs:line 416
   at Robust.Client.GameStates.ClientGameStateManager.ApplyGameState() in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Client/GameStates/ClientGameStateManager.cs:line 233
   at Robust.Client.GameController.Tick(FrameEventArgs frameEventArgs) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Client/GameController/GameController.cs:line 382
   at Robust.Client.GameController.<StartupContinue>b__44_0(Object sender, FrameEventArgs args) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Client/GameController/GameController.cs:line 159
   at Robust.Shared.Timing.GameLoop.Run() in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 197
   at Robust.Client.GameController.ContinueStartupAndLoop(DisplayMode mode) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Client/GameController/GameController.Standalone.cs:line 129
   at Robust.Client.GameController.GameThreadMain(DisplayMode mode) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Client/GameController/GameController.Standalone.cs:line 114
   at Robust.Client.GameController.<>c__DisplayClass73_0.<Run>b__0() in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Client/GameController/GameController.Standalone.cs:line 81
   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.ThreadHelper.ThreadStart()
Unhandled exception. System.InvalidOperationException: Tried to overwrite a protected component.
   at Robust.Shared.GameObjects.EntityManager.AddComponentInternal[T](EntityUid uid, T component, Boolean overwrite) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Components.cs:line 148
   at Robust.Shared.GameObjects.EntityManager.AllocEntity(Nullable`1 uid) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 372
   at Robust.Shared.GameObjects.EntityManager.AllocEntity(String prototypeName, Nullable`1 uid) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 336
   at Robust.Shared.GameObjects.EntityManager.CreateEntity(String prototypeName, Nullable`1 uid) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 389
   at Robust.Client.GameObjects.ClientEntityManager.Robust.Client.GameObjects.IClientEntityManagerInternal.CreateEntity(String prototypeName, Nullable`1 uid) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Client/GameObjects/ClientEntityManager.cs:line 38
   at Robust.Client.GameStates.ClientGameStateManager.ApplyEntityStates(EntityState[] curEntStates, IEnumerable`1 deletions, EntityState[] nextEntStates) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Client/GameStates/ClientGameStateManager.cs:line 451
   at Robust.Client.GameStates.ClientGameStateManager.ApplyGameState(GameState curState, GameState nextState) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Client/GameStates/ClientGameStateManager.cs:line 416
   at Robust.Client.GameStates.ClientGameStateManager.ApplyGameState() in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Client/GameStates/ClientGameStateManager.cs:line 233
   at Robust.Client.GameController.Tick(FrameEventArgs frameEventArgs) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Client/GameController/GameController.cs:line 382
   at Robust.Client.GameController.<StartupContinue>b__44_0(Object sender, FrameEventArgs args) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Client/GameController/GameController.cs:line 159
   at Robust.Shared.Timing.GameLoop.Run() in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 197
   at Robust.Client.GameController.ContinueStartupAndLoop(DisplayMode mode) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Client/GameController/GameController.Standalone.cs:line 129
   at Robust.Client.GameController.GameThreadMain(DisplayMode mode) in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Client/GameController/GameController.Standalone.cs:line 114
   at Robust.Client.GameController.<>c__DisplayClass73_0.<Run>b__0() in /home/20kdc/Documents/External/space-station-14/RobustToolbox/Robust.Client/GameController/GameController.Standalone.cs:line 81
   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.ThreadHelper.ThreadStart()
Aborted (core dumped)
```

To be clear, I do *NOT* know what the issue with the PR is. The underlying issue it fixes still needs to be fixed, but... yeah, uh.