### PR TITLE
Fix rotated grid collision

### DIFF
--- a/Robust.Shared/Physics/Dynamics/ContactManager.cs
+++ b/Robust.Shared/Physics/Dynamics/ContactManager.cs
@@ -360,8 +360,8 @@ namespace Robust.Shared.Physics.Dynamics
                         // These should really be destroyed before map changes.
                         DebugTools.Assert(broadphaseA.Owner.Transform.MapID == broadphaseB.Owner.Transform.MapID);
 
-                        var proxyAWorldAABB = proxyA.AABB.Translated(broadphaseA.Owner.Transform.WorldPosition);
-                        var proxyBWorldAABB = proxyB.AABB.Translated(broadphaseB.Owner.Transform.WorldPosition);
+                        var proxyAWorldAABB = broadphaseA.Owner.Transform.WorldMatrix.TransformBox(proxyA.AABB);
+                        var proxyBWorldAABB = broadphaseB.Owner.Transform.WorldMatrix.TransformBox(proxyB.AABB);
                         overlap = proxyAWorldAABB.Intersects(proxyBWorldAABB);
                     }
                 }

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -258,9 +258,7 @@ namespace Robust.Shared.Physics
                     }
                     else
                     {
-                        aabb = proxy.AABB
-                            .Translated(_offsets[proxyBroad!])
-                            .Translated(-offset);
+                        aabb = broadphase.Owner.Transform.InvWorldMatrix.TransformBox(worldAABB);
                     }
 
                     foreach (var other in broadphase.Tree.QueryAabb(_queryBuffer, aabb))
@@ -944,7 +942,7 @@ namespace Robust.Shared.Physics
             foreach (var broadphase in GetBroadphases(mapId, collider))
             {
                 // TODO: Is rotation a problem here?
-                var gridCollider = collider.Translated(-broadphase.Owner.Transform.WorldPosition);
+                var gridCollider = broadphase.Owner.Transform.InvWorldMatrix.TransformBox(collider);
 
                 broadphase.Tree.QueryAabb(ref state, (ref (Box2 collider, MapId map, bool found) state, in FixtureProxy proxy) =>
                 {
@@ -1007,7 +1005,7 @@ namespace Robust.Shared.Physics
 
             foreach (var broadphase in GetBroadphases(mapId, worldAABB))
             {
-                var gridAABB = worldAABB.Translated(-broadphase.Owner.Transform.WorldPosition);
+                var gridAABB = broadphase.Owner.Transform.InvWorldMatrix.TransformBox(worldAABB);
 
                 foreach (var proxy in broadphase.Tree.QueryAabb(gridAABB, false))
                 {


### PR DESCRIPTION
Fixes https://github.com/space-wizards/RobustToolbox/issues/2096

Should probably cache the matrices in collide but I'll do it later.