### PR TITLE
Bandaid entity deletion entitylookup

### DIFF
--- a/Robust.Shared/GameObjects/Systems/EntityLookup.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.cs
@@ -669,9 +669,10 @@ namespace Robust.Shared.GameObjects
         {
             // TODO: Need to fix ordering issues and then we can just directly remove it from the tree
             // rather than this O(n) legacy garbage.
+            // Also we can't early returns because somehow it gets added to multiple trees!!!
             foreach (var lookup in _entityManager.EntityQuery<EntityLookupComponent>(true))
             {
-                if (lookup.Tree.Remove(entity)) return;
+                lookup.Tree.Remove(entity);
             }
         }
 


### PR DESCRIPTION
I still blame Q for the absolute state of EntityLookup don't @ me son

"Fixes https://github.com/space-wizards/space-station-14/issues/4787" and I use that term loosely because entitylookup needs a cleanup due to all the ordering bullshit going on.