### PR TITLE
Fix FOV shader to allow for s p i n

### DIFF
--- a/Resources/Shaders/Internal/fov.swsl
+++ b/Resources/Shaders/Internal/fov.swsl
@@ -4,30 +4,27 @@ preset raw;
 
 const highp float g_MinVariance = 0.0;
 
-varying highp vec2 worldPosition;
+// World-space position offset from centre to pixel.
+varying highp vec2 worldSpaceDiff;
 
-// Center of the FOV, in world coordinates.
-uniform highp vec2 center;
+// Inverted transformation matrix from clip coordinates to difference coordinates.
+uniform highp mat3 clipToDiff;
 
 void vertex()
 {
-    highp vec3 transformed = modelMatrix * vec3(VERTEX, 1.0);
-    worldPosition = transformed.xy;
-    transformed = projectionMatrix * viewMatrix * transformed;
-
-    VERTEX = transformed.xy;
+    // Convert quad-space (0.0 to 1.0) to clip-space (-1.0 to 1.0)
+    VERTEX = (VERTEX.xy - 0.5) * 2.0;
+    worldSpaceDiff = (clipToDiff * vec3(VERTEX, 1.0)).xy;
 }
 
 void fragment()
 {
-    highp vec2 diff = worldPosition - center;
+    highp float ourDist = length(worldSpaceDiff);
 
-    highp float ourDist = length(diff);
-
-    highp float occlDist = occludeDepth(diff, TEXTURE, 0.75).r;
+    highp float occlDist = occludeDepth(worldSpaceDiff, TEXTURE, 0.75).r;
 
     // *Very* simple biased shadow check for FOV.
-    if (!doesOcclude(diff, TEXTURE, 0.75, -0.75/32.0))
+    if (!doesOcclude(worldSpaceDiff, TEXTURE, 0.75, -0.75/32.0))
     {
         discard;
     }

--- a/Robust.Shared.Maths/Matrix3.cs
+++ b/Robust.Shared.Maths/Matrix3.cs
@@ -337,6 +337,28 @@ namespace Robust.Shared.Maths
             R2C2 = matrix.Row2.Z;
         }
 
+        /// <summary>
+        /// Constructs a new instance from 3 vectors to quickly synthesize affine transforms.
+        /// </summary>
+        /// <param name="x">A Vector2 for the first, conventionally X basis, vector.</param>
+        /// <param name="y">A Vector2 for the second, conventionally Y basis, vector.</param>
+        /// <param name="origin">A Vector2 for the third, conventionally origin vector.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Matrix3(ref Vector2 x, ref Vector2 y, ref Vector2 origin)
+        {
+            R0C0 = x.X;
+            R0C1 = y.X;
+            R0C2 = origin.X;
+
+            R1C0 = x.Y;
+            R1C1 = y.Y;
+            R1C2 = origin.Y;
+
+            R2C0 = 0;
+            R2C1 = 0;
+            R2C2 = 1;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Matrix3 CreateTranslation(float x, float y)
         {


### PR DESCRIPTION
Theoretically this could've done what BlurOntoWalls does and messed with the projection and view matrices... but it's a rectangle that covers the whole screen. There's no need to calculate matrices for that part.
There is however a need to calculate inverse matrices to get back to world coordinates again, and that is done here through synthesizing the matrix via LocalToWorld for lack of better options.