### PR TITLE
Add can-see / visibility function to `ContainerHelpers`

### DIFF
--- a/Robust.Shared/Containers/ContainerHelpers.cs
+++ b/Robust.Shared/Containers/ContainerHelpers.cs
@@ -242,7 +242,7 @@ namespace Robust.Shared.Containers
             // Is the user contained in the other entity?
             if (userContainer?.Owner == other) return true;
 
-            // Does the user contains the other and can they see through themselves?
+            // Does the user contain the other and can they see through themselves?
             if (userSeeInsideSelf && otherContainer?.Owner == user) return true;
 
             // Next we check for see-through containers. This uses some recursion, but it should be fine unless people


### PR DESCRIPTION
This adds a new function (`IsInSameOrTransparentContainer`) to `ContainerHelpers`. This is effectively a variant of `IsInSameOrParentContainer` that is designed to check whether an entity can "see" another entity through any containers.

A function like this is/was used by [space-wizards/space-station-14#4768](https://github.com/space-wizards/space-station-14/pull/4768) to check whether entities should appear on the entity context menu and @mirrorcult recommended it just become a container helper function.