### PR TITLE
Add option to make `ScrollContainer` return size.

### DIFF
--- a/Robust.Client/UserInterface/Controls/ScrollContainer.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollContainer.cs
@@ -20,6 +20,8 @@ namespace Robust.Client.UserInterface.Controls
         public int ScrollSpeedX { get; set; } = 50;
         public int ScrollSpeedY { get; set; } = 50;
 
+        public bool ReturnMeasure { get; set; } = false;
+
         public ScrollContainer()
         {
             MouseFilter = MouseFilterMode.Pass;
@@ -89,11 +91,9 @@ namespace Robust.Client.UserInterface.Controls
                 size = Vector2.ComponentMax(size, child.DesiredSize);
             }
 
-            // Unlike WPF/Avalonia we report ZERO here instead of available size.
-            // This is to fix a bunch of jank with e.g. BoxContainer.
-            // Tbh this might be a mistake.
-            // DockPanel when.
-            return Vector2.Zero;
+            // Unlike WPF/Avalonia we default to reporting ZERO here instead of available size. This is to fix a bunch
+            // of jank with e.g. BoxContainer.
+            return ReturnMeasure ? size : Vector2.Zero;
         }
 
         protected override Vector2 ArrangeOverride(Vector2 finalSize)

--- a/Robust.Client/UserInterface/Controls/ScrollContainer.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollContainer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.Contracts;
 using Robust.Shared.Maths;
 
@@ -93,7 +93,16 @@ namespace Robust.Client.UserInterface.Controls
 
             // Unlike WPF/Avalonia we default to reporting ZERO here instead of available size. This is to fix a bunch
             // of jank with e.g. BoxContainer.
-            return ReturnMeasure ? size : Vector2.Zero;
+            if (!ReturnMeasure)
+                return Vector2.Zero;
+
+            if (_vScrollEnabled)
+                size.X += _vScrollBar.DesiredSize.X;
+
+            if (_hScrollEnabled)
+                size.Y += _hScrollBar.DesiredSize.Y;
+
+            return size;
         }
 
         protected override Vector2 ArrangeOverride(Vector2 finalSize)


### PR DESCRIPTION
Currently a `ScrollContainer` always reports its desired size as zero. Apparently there's a reason for that but it causes issues when you want a control whose size is determined by the size of a `ScrollContainer`. This just adds a `bool` that toggles whether or not it reports its size as zero.

This feature would be nice to have for [space-wizards/space-station-14#4768](https://github.com/space-wizards/space-station-14/pull/4768), which currently just has some janky code to infer the actual desired size of the scroll container.