### PR TITLE
Fix FOV wall shadowing not working properly due to broken fov-lighting

### DIFF
--- a/Resources/Shaders/Internal/fov-lighting.swsl
+++ b/Resources/Shaders/Internal/fov-lighting.swsl
@@ -2,29 +2,15 @@ preset raw;
 
 #include "/Shaders/Internal/shadow_cast_shared.swsl"
 
+#include "/Shaders/Internal/fov_shared.swsl"
+
 const highp float g_MinVariance = 0.0;
-
-varying highp vec2 worldPosition;
-
-// Center of the FOV, in world coordinates.
-uniform highp vec2 center;
-
-void vertex()
-{
-    highp vec3 transformed = modelMatrix * vec3(VERTEX, 1.0);
-    worldPosition = transformed.xy;
-    transformed = projectionMatrix * viewMatrix * transformed;
-
-    VERTEX = transformed.xy;
-}
 
 void fragment()
 {
-    highp vec2 diff = worldPosition - center;
+    highp float ourDist = length(worldSpaceDiff);
 
-    highp float ourDist = length(diff);
-
-    highp vec2 occlDist = occludeDepth(diff, TEXTURE, 0.25);
+    highp vec2 occlDist = occludeDepth(worldSpaceDiff, TEXTURE, 0.25);
 
     highp float occlusion = ChebyshevUpperBound(occlDist, ourDist);
 

--- a/Resources/Shaders/Internal/fov.swsl
+++ b/Resources/Shaders/Internal/fov.swsl
@@ -2,20 +2,9 @@ preset raw;
 
 #include "/Shaders/Internal/shadow_cast_shared.swsl"
 
+#include "/Shaders/Internal/fov_shared.swsl"
+
 const highp float g_MinVariance = 0.0;
-
-// World-space position offset from centre to pixel.
-varying highp vec2 worldSpaceDiff;
-
-// Inverted transformation matrix from clip coordinates to difference coordinates.
-uniform highp mat3 clipToDiff;
-
-void vertex()
-{
-    // Convert quad-space (0.0 to 1.0) to clip-space (-1.0 to 1.0)
-    VERTEX = (VERTEX.xy - 0.5) * 2.0;
-    worldSpaceDiff = (clipToDiff * vec3(VERTEX, 1.0)).xy;
-}
 
 void fragment()
 {

--- a/Resources/Shaders/Internal/fov_shared.swsl
+++ b/Resources/Shaders/Internal/fov_shared.swsl
@@ -1,0 +1,16 @@
+// Shared between fov-lighting.swsl and fov.swsl, which both use the Clyde quad,
+//  manually transformed into clip-space to cover the entire viewport
+
+// World-space position offset from centre to pixel.
+varying highp vec2 worldSpaceDiff;
+
+// Inverted transformation matrix from clip coordinates to difference coordinates.
+uniform highp mat3 clipToDiff;
+
+void vertex()
+{
+    // Convert quad-space (0.0 to 1.0) to clip-space (-1.0 to 1.0)
+    VERTEX = (VERTEX.xy - 0.5) * 2.0;
+    worldSpaceDiff = (clipToDiff * vec3(VERTEX, 1.0)).xy;
+}
+


### PR DESCRIPTION
um, whoops?
Bug was caused during the occlusion updates b/c I forgot about `fov-lighting.swsl` being a separate shader
