### PR TITLE
Fixes SpriteComponent.AddLayer for specific RSI definition

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -564,7 +564,7 @@ namespace Robust.Client.GameObjects
                 Logger.ErrorS(LogCategory, "Unable to load RSI '{0}'. Trace:\n{1}", rsiPath, Environment.StackTrace);
             }
 
-            return AddLayer(stateId, res?.RSI);
+            return AddLayer(stateId, res?.RSI, newIndex);
         }
 
         public int AddLayerState(string stateId, ResourcePath rsiPath, int? newIndex = null)


### PR DESCRIPTION
SpriteComponent.AddLayer(RSI.StateId, ResourcePath, int (index)) failed to properly index the sprite when called with a new index. This should fix that