### PR TITLE
Use spans for chunk mesh

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics;
 using OpenToolkit.Graphics.OpenGL4;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -85,50 +86,43 @@ namespace Robust.Client.Graphics.Clyde
                 datum = _initChunkBuffers(grid, chunk);
             }
 
-            var vertexPool = ArrayPool<Vertex2D>.Shared;
-            var indexPool = ArrayPool<ushort>.Shared;
+            var sw = new Stopwatch();
+            sw.Start();
+            Span<ushort> indexBuffer = stackalloc ushort[_indicesPerChunk(chunk)];
+            Span<Vertex2D> vertexBuffer = stackalloc Vertex2D[_verticesPerChunk(chunk)];
 
-            var vertexBuffer = vertexPool.Rent(_verticesPerChunk(chunk));
-            var indexBuffer = indexPool.Rent(_indicesPerChunk(chunk));
-
-            try
+            var i = 0;
+            foreach (var tile in chunk)
             {
-                var i = 0;
-                foreach (var tile in chunk)
+                var regionMaybe = _tileDefinitionManager.TileAtlasRegion(tile.Tile);
+                if (regionMaybe == null)
                 {
-                    var regionMaybe = _tileDefinitionManager.TileAtlasRegion(tile.Tile);
-                    if (regionMaybe == null)
-                    {
-                        continue;
-                    }
-
-                    var region = regionMaybe.Value;
-
-                    var vIdx = i * 4;
-                    vertexBuffer[vIdx + 0] = new Vertex2D(tile.X, tile.Y, region.Left, region.Bottom);
-                    vertexBuffer[vIdx + 1] = new Vertex2D(tile.X + 1, tile.Y, region.Right, region.Bottom);
-                    vertexBuffer[vIdx + 2] = new Vertex2D(tile.X + 1, tile.Y + 1, region.Right, region.Top);
-                    vertexBuffer[vIdx + 3] = new Vertex2D(tile.X, tile.Y + 1, region.Left, region.Top);
-                    var nIdx = i * GetQuadBatchIndexCount();
-                    var tIdx = (ushort) (i * 4);
-                    QuadBatchIndexWrite(indexBuffer, ref nIdx, tIdx);
-                    i += 1;
+                    continue;
                 }
 
-                GL.BindVertexArray(datum.VAO);
-                CheckGlError();
-                datum.EBO.Use();
-                datum.VBO.Use();
-                datum.EBO.Reallocate(new Span<ushort>(indexBuffer, 0, i * GetQuadBatchIndexCount()));
-                datum.VBO.Reallocate(new Span<Vertex2D>(vertexBuffer, 0, i * 4));
-                datum.Dirty = false;
-                datum.TileCount = i;
+                var region = regionMaybe.Value;
+
+                var vIdx = i * 4;
+                vertexBuffer[vIdx + 0] = new Vertex2D(tile.X, tile.Y, region.Left, region.Bottom);
+                vertexBuffer[vIdx + 1] = new Vertex2D(tile.X + 1, tile.Y, region.Right, region.Bottom);
+                vertexBuffer[vIdx + 2] = new Vertex2D(tile.X + 1, tile.Y + 1, region.Right, region.Top);
+                vertexBuffer[vIdx + 3] = new Vertex2D(tile.X, tile.Y + 1, region.Left, region.Top);
+                var nIdx = i * GetQuadBatchIndexCount();
+                var tIdx = (ushort) (i * 4);
+                QuadBatchIndexWrite(indexBuffer, ref nIdx, tIdx);
+                i += 1;
             }
-            finally
-            {
-                vertexPool.Return(vertexBuffer);
-                indexPool.Return(indexBuffer);
-            }
+
+            GL.BindVertexArray(datum.VAO);
+            CheckGlError();
+            datum.EBO.Use();
+            datum.VBO.Use();
+            datum.EBO.Reallocate(indexBuffer[..(i * GetQuadBatchIndexCount())]);
+            datum.VBO.Reallocate(vertexBuffer[..(i * 4)]);
+            datum.Dirty = false;
+            datum.TileCount = i;
+
+            Logger.Debug(sw.Elapsed.ToString());
         }
 
         private MapChunkData _initChunkBuffers(IMapGrid grid, IMapChunk chunk)

--- a/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
@@ -86,8 +86,6 @@ namespace Robust.Client.Graphics.Clyde
                 datum = _initChunkBuffers(grid, chunk);
             }
 
-            var sw = new Stopwatch();
-            sw.Start();
             Span<ushort> indexBuffer = stackalloc ushort[_indicesPerChunk(chunk)];
             Span<Vertex2D> vertexBuffer = stackalloc Vertex2D[_verticesPerChunk(chunk)];
 
@@ -121,8 +119,6 @@ namespace Robust.Client.Graphics.Clyde
             datum.VBO.Reallocate(vertexBuffer[..(i * 4)]);
             datum.Dirty = false;
             datum.TileCount = i;
-
-            Logger.Debug(sw.Elapsed.ToString());
         }
 
         private MapChunkData _initChunkBuffers(IMapGrid grid, IMapChunk chunk)


### PR DESCRIPTION
Using a stopwatch it was mainly an increase for the first mesh and the rest were more-or-less the same when I re-ran it a bunch (me lazy). try-catch was also removed given all it did was return the buffers.

Pool:
![image](https://user-images.githubusercontent.com/31366439/136809252-b6a6c81a-d8fd-4b89-9ad1-42528142e8f8.png)

Spans:
![image](https://user-images.githubusercontent.com/31366439/136809212-750a8ab5-4c44-4d14-a2f9-73b1cddaf80a.png)
