### PR TITLE
Add support for entity system timed updates

### DIFF
--- a/Robust.Shared/GameObjects/EntitySystem.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.cs
@@ -26,6 +26,10 @@ namespace Robust.Shared.GameObjects
         protected internal List<Type> UpdatesAfter { get; } = new();
         protected internal List<Type> UpdatesBefore { get; } = new();
 
+        public virtual float TimedInterval { get; set; }
+
+        public float AccumulatedFrametime { get; set; }
+
         IEnumerable<Type> IEntitySystem.UpdatesAfter => UpdatesAfter;
         IEnumerable<Type> IEntitySystem.UpdatesBefore => UpdatesBefore;
 
@@ -42,6 +46,9 @@ namespace Robust.Shared.GameObjects
 
         /// <inheritdoc />
         public virtual void FrameUpdate(float frameTime) { }
+
+        /// <inheritdoc />
+        public virtual void TimedUpdate() { }
 
         /// <inheritdoc />
         public virtual void Shutdown()

--- a/Robust.Shared/GameObjects/EntitySystemManager.cs
+++ b/Robust.Shared/GameObjects/EntitySystemManager.cs
@@ -230,6 +230,17 @@ namespace Robust.Shared.GameObjects
                 {
 #endif
                     updReg.System.Update(frameTime);
+
+                    if (updReg.System.TimedInterval > 0)
+                    {
+                        updReg.System.AccumulatedFrametime += frameTime;
+                        if (updReg.System.AccumulatedFrametime > updReg.System.TimedInterval)
+                        {
+                            updReg.System.TimedUpdate();
+                            updReg.System.AccumulatedFrametime = 0.0f;
+                        }
+                    }
+
 #if EXCEPTION_TOLERANCE
                 }
                 catch (Exception e)

--- a/Robust.Shared/GameObjects/IEntitySystem.cs
+++ b/Robust.Shared/GameObjects/IEntitySystem.cs
@@ -17,6 +17,16 @@ namespace Robust.Shared.GameObjects
         IEnumerable<Type> UpdatesBefore { get; }
 
         /// <summary>
+        ///     How often should TimedUpdate() be called, in seconds.
+        /// </summary>
+        float TimedInterval { get; set; }
+
+        /// <summary>
+        ///     How much time has passed since the last TimedUpdate() call.
+        /// </summary>
+        float AccumulatedFrametime { get; set; }
+
+        /// <summary>
         ///     Called once when the system is created to initialize its state.
         /// </summary>
         void Initialize();
@@ -32,5 +42,10 @@ namespace Robust.Shared.GameObjects
         /// <param name="frameTime">Delta time since Update() was last called.</param>
         void Update(float frameTime);
         void FrameUpdate(float frameTime);
+
+        /// <summary>
+        ///     Called once every <see cref="TimedInterval"/> seconds.
+        /// </summary>
+        void TimedUpdate();
     }
 }

--- a/Robust.Shared/GameObjects/IEntitySystem.cs
+++ b/Robust.Shared/GameObjects/IEntitySystem.cs
@@ -17,12 +17,12 @@ namespace Robust.Shared.GameObjects
         IEnumerable<Type> UpdatesBefore { get; }
 
         /// <summary>
-        ///     How often should TimedUpdate() be called, in seconds.
+        ///     How often should <see cref="TimedUpdate"/>be called, in seconds.
         /// </summary>
         float TimedInterval { get; set; }
 
         /// <summary>
-        ///     How much time has passed since the last TimedUpdate() call.
+        ///     How much time has passed since the last <see cref="TimedUpdate"/> call.
         /// </summary>
         float AccumulatedFrametime { get; set; }
 

--- a/Robust.UnitTesting/Shared/GameObjects/EntitySystemManagerOrderTest.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntitySystemManagerOrderTest.cs
@@ -26,6 +26,10 @@ namespace Robust.UnitTesting.Shared.GameObjects
             public Counter? Counter;
             public int LastUpdate;
 
+            public virtual float TimedInterval { get; set; } = 0.0f;
+
+            public float AccumulatedFrametime { get; set; } = 0.0f;
+
             public virtual IEnumerable<Type> UpdatesAfter => Enumerable.Empty<Type>();
             public virtual IEnumerable<Type> UpdatesBefore => Enumerable.Empty<Type>();
             public void Initialize() { }
@@ -36,6 +40,8 @@ namespace Robust.UnitTesting.Shared.GameObjects
                 LastUpdate = Counter!.X++;
             }
             public void FrameUpdate(float frameTime) { }
+
+            public void TimedUpdate() { }
         }
 
         // Expected update order is is A -> D -> C -> B

--- a/Robust.UnitTesting/Shared/GameObjects/EntitySystemManager_Tests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntitySystemManager_Tests.cs
@@ -14,12 +14,16 @@ namespace Robust.UnitTesting.Shared.GameObjects
 
         public abstract class ESystemBase : IEntitySystem
         {
+            public virtual float TimedInterval { get; set; }
+            public float AccumulatedFrametime { get; set; }
+
             public virtual IEnumerable<Type> UpdatesAfter => Enumerable.Empty<Type>();
             public virtual IEnumerable<Type> UpdatesBefore => Enumerable.Empty<Type>();
             public void Initialize() { }
             public void Shutdown() { }
             public void Update(float frameTime) { }
             public void FrameUpdate(float frameTime) { }
+            public void TimedUpdate() { }
         }
         public class ESystemA : ESystemBase { }
         public class ESystemC : ESystemA { }


### PR DESCRIPTION
This is to avoid the whole `_accumulatedFrametime += frameTime` boilerplate that content does a lot everywhere. Introduces a new virtual method, TimedUpdate so you can still do stuff every tick and timed in the same entity system. Should still respect ordering. EntitySystems that don't override `TimedInterval` shouldn't ever call it and only incurs a single if check.

note: unsure if this is really the best way to do it or if this bloats entitysystems too heavily