### PR TITLE
Fixes component deletion/removal not being synced with clients.

### DIFF
--- a/Robust.Server/GameObjects/IServerEntityNetworkManager.cs
+++ b/Robust.Server/GameObjects/IServerEntityNetworkManager.cs
@@ -1,10 +1,14 @@
+using System.Collections.Generic;
 using Robust.Server.Player;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Timing;
 
 namespace Robust.Server.GameObjects
 {
     public interface IServerEntityNetworkManager : IEntityNetworkManager
     {
         uint GetLastMessageSequence(IPlayerSession session);
+        List<ushort> GetDeletedComponents(EntityUid uid, GameTick fromTick);
+        void CullDeletionHistory(GameTick oldestAck);
     }
 }

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -102,12 +102,18 @@ namespace Robust.Server.GameObjects
         private readonly Dictionary<IPlayerSession, uint> _lastProcessedSequencesCmd =
             new();
 
+        private readonly Dictionary<EntityUid, List<(GameTick tick, ushort netId)>> _componentDeletionHistory = new();
+
         private bool _logLateMsgs;
 
         /// <inheritdoc />
         public void SetupNetworking()
         {
             _networkManager.RegisterNetMessage<MsgEntity>(HandleEntityNetworkMessage);
+
+            // For syncing component deletions.
+            EntityDeleted += OnEntityRemoved;
+            ComponentRemoved += OnComponentRemoved;
 
             _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
 
@@ -133,6 +139,65 @@ namespace Robust.Server.GameObjects
         public uint GetLastMessageSequence(IPlayerSession session)
         {
             return _lastProcessedSequencesCmd[session];
+        }
+
+        private void OnEntityRemoved(object? sender, EntityUid e)
+        {
+            if (_componentDeletionHistory.ContainsKey(e))
+                _componentDeletionHistory.Remove(e);
+        }
+
+        private void OnComponentRemoved(object? sender, ComponentEventArgs e)
+        {
+            var reg = ComponentFactory.GetRegistration(e.Component.GetType());
+
+            // We only keep track of networked components being removed.
+            if (reg.NetID is not {} netId)
+                return;
+
+            var uid = e.OwnerUid;
+
+            if (!_componentDeletionHistory.TryGetValue(uid, out var list))
+            {
+                list = new List<(GameTick tick, ushort netId)>();
+                _componentDeletionHistory[uid] = list;
+            }
+
+            list.Add((_gameTiming.CurTick, netId));
+        }
+
+        public List<ushort> GetDeletedComponents(EntityUid uid, GameTick fromTick)
+        {
+            // TODO: Maybe make this a struct enumerator? Right now it's a list for consistency...
+            var list = new List<ushort>();
+
+            if (!_componentDeletionHistory.TryGetValue(uid, out var history))
+                return list;
+
+            foreach (var (tick, id) in history)
+            {
+                if (tick >= fromTick) list.Add(id);
+            }
+
+            return list;
+        }
+
+        public void CullDeletionHistory(GameTick oldestAck)
+        {
+            var remQueue = new RemQueue<EntityUid>();
+
+            foreach (var (uid, list) in _componentDeletionHistory)
+            {
+                list.RemoveAll(hist => hist.tick < oldestAck);
+
+                if(list.Count == 0)
+                    remQueue.Add(uid);
+            }
+
+            foreach (var uid in remQueue)
+            {
+                _componentDeletionHistory.Remove(uid);
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixes networked components deletions not being synced to clients. Before, game state code assumed that `GetNetComponents` would return deleted components, which is no longer the case. This is also a step towards removing deferred component deletion. 

I made `GetDeletedComponents` return a `List<short>` for consistency with `EntityViewCulling`'s `GetDeletedEntities`, which returns a `List<EntityUid>`. I can code a struct enumerator instead if needed, though.

Please review @PJB3005 