### PR TITLE
Show current rotation in entity spawn window

### DIFF
--- a/Robust.Client/Placement/IPlacementManager.cs
+++ b/Robust.Client/Placement/IPlacementManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Robust.Shared.Enums;
+using Robust.Shared.Maths;
 using Robust.Shared.Timing;
 
 namespace Robust.Client.Placement
@@ -11,6 +12,16 @@ namespace Robust.Client.Placement
         bool Eraser { get; }
         PlacementMode? CurrentMode { get; set; }
         PlacementInformation? CurrentPermission { get; set; }
+
+        /// <summary>
+        /// The direction to spawn the entity in (presently exposed for EntitySpawnWindow UI)
+        /// </summary>
+        Direction Direction { get; set; }
+
+        /// <summary>
+        /// Gets called when Direction changed (presently for EntitySpawnWindow UI)
+        /// </summary>
+        event EventHandler DirectionChanged;
 
         /// <summary>
         /// Gets called when the PlacementManager changed its build/erase mode or when the hijacks changed

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -143,10 +143,21 @@ namespace Robust.Client.Placement
             set => _colliderAABB = value;
         }
 
-        /// <summary>
-        /// The directional to spawn the entity in
-        /// </summary>
-        public Direction Direction { get; set; } = Direction.South;
+        private Direction _direction = Direction.South;
+
+        /// <inheritdoc />
+        public Direction Direction
+        {
+            get => _direction;
+            set
+            {
+                _direction = value;
+                DirectionChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        /// <inheritdoc />
+        public event EventHandler? DirectionChanged;
 
         private PlacementOverlay _drawOverlay = default!;
         private bool _isActive;

--- a/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
+++ b/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
@@ -28,6 +28,7 @@ namespace Robust.Client.UserInterface.CustomControls
         private OptionButton OverrideMenu;
         private Button ClearButton;
         private Button EraseButton;
+        private Label RotationLabel;
 
         private EntitySpawnButton MeasureButton;
 
@@ -122,6 +123,7 @@ namespace Robust.Client.UserInterface.CustomControls
                             })
                         }
                     },
+                    (RotationLabel = new Label()),
                     new DoNotMeasure
                     {
                         Visible = false,
@@ -149,6 +151,8 @@ namespace Robust.Client.UserInterface.CustomControls
             BuildEntityList();
 
             this.placementManager.PlacementChanged += OnPlacementCanceled;
+            this.placementManager.DirectionChanged += OnDirectionChanged;
+            UpdateDirectionLabel();
             SearchBar.GrabKeyboardFocus();
         }
 
@@ -162,6 +166,7 @@ namespace Robust.Client.UserInterface.CustomControls
                 placementManager.Clear();
 
             placementManager.PlacementChanged -= OnPlacementCanceled;
+            placementManager.DirectionChanged -= OnDirectionChanged;
         }
 
         private void OnSearchBarTextChanged(LineEdit.LineEditEventArgs args)
@@ -510,6 +515,16 @@ namespace Robust.Client.UserInterface.CustomControls
 
             EraseButton.Pressed = false;
             OverrideMenu.Disabled = false;
+        }
+
+        private void OnDirectionChanged(object? sender, EventArgs e)
+        {
+            UpdateDirectionLabel();
+        }
+
+        private void UpdateDirectionLabel()
+        {
+            RotationLabel.Text = placementManager.Direction.ToString();
         }
 
         private class DoNotMeasure : Control


### PR DESCRIPTION
Image taken 10 seconds before wall rotation disaster:
![image](https://user-images.githubusercontent.com/22304167/137356899-a6edd8a8-01fa-405d-8b37-6441b5092299.png)

Is this added UI a bit bad? Yes, but it should prevent the "wait, is the placement rotated right" problems, somewhat.
I guess a better way would be making "unsafe to rotate" things unrotatable, but not sure how to do that.
