### PR TITLE
Shared/ContentPack: Work around a possible bug in PEReader (and/or ILVerify)

### DIFF
--- a/Robust.Shared/ContentPack/AssemblyTypeChecker.cs
+++ b/Robust.Shared/ContentPack/AssemblyTypeChecker.cs
@@ -809,7 +809,9 @@ namespace Robust.Shared.ContentPack
                         continue;
                     }
 
-                    return new PEReader(File.OpenRead(path));
+                    return new PEReader(File.OpenRead(path),
+                        OperatingSystem.IsLinux() ? PEStreamOptions.PrefetchEntireImage : PEStreamOptions.Default
+                    );
                 }
 
                 var extraStream = _parent.ExtraRobustLoader?.Invoke(dllName);
@@ -823,7 +825,9 @@ namespace Robust.Shared.ContentPack
                     try
                     {
                         var path = resLoadPath / dllName;
-                        return new PEReader(_parent._res.ContentFileRead(path));
+                        return new PEReader(_parent._res.ContentFileRead(path),
+                            OperatingSystem.IsLinux() ? PEStreamOptions.PrefetchEntireImage : PEStreamOptions.Default
+                        );
                     }
                     catch (FileNotFoundException)
                     {


### PR DESCRIPTION
`PEReader` (or `ILVerify`) was doing some weird `mmap`ing shit on Linux that caused evil heisenbuggy race condition exceptions during content pack verification. Apparently setting `PEStreamOptions.PrefetchEntireImage` may skip that step. If it isn't actually fixing the issue, at least it slows loading down enough to avoid the race condition.

Disclosure: Since there's no known way to deterministically reproduce the issue, I don't actually know if this fix really works. Consequently, if it does work, I have no clue why.

<details><summary>Spoiler:</summary>
The last attempt at fixing this worked perfectly until I started writing up the PR comment, so maybe this is a good way to repro?
<br/><br/>

**Update:** No luck with reproducing it, maybe the fix actually works?
</details>

If this doesn't work, I'm gating the `Parallel` IL verification parts behind `#if !LINUX` and writing sequential versions. If we get to that point, only the Lord will know if that will work either.