### PR TITLE
fix GridTileToWorldPos

### DIFF
--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -765,7 +765,7 @@ namespace Robust.Shared.Map
             var locX = gridTile.X * TileSize + (TileSize / 2f);
             var locY = gridTile.Y * TileSize + (TileSize / 2f);
 
-            return new Vector2(locX, locY) + WorldPosition;
+            return WorldMatrix.Transform(new Vector2(locX, locY));
         }
 
         public MapCoordinates GridTileToWorld(Vector2i gridTile)


### PR DESCRIPTION
Turns out, grids don't only translate, they can also rotate.