### PR TITLE
Fix deserializing null structs

### DIFF
--- a/Robust.Shared/Serialization/Manager/SerializationManager.Reading.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.Reading.cs
@@ -127,24 +127,21 @@ namespace Robust.Shared.Serialization.Manager
                     var instantiator = instance.GetOrCreateInstantiator(value) ?? throw new NullReferenceException($"No instantiator could be made for type {value}");
                     var instantiatorConst = Expression.Constant(instantiator);
 
-                    if (value.IsValueType)
+                    call = value.IsValueType switch
                     {
-                        call = Expression.Call(
+                        true when nullable => call = Expression.Call(
                             instanceConst,
                             nameof(ReadSelfSerializeNullableStruct),
-                            new[] { value },
+                            new[] {value},
                             Expression.Convert(nodeParam, typeof(ValueDataNode)),
-                            instantiatorConst);
-                    }
-                    else
-                    {
-                        call = Expression.Call(
+                            instantiatorConst),
+                        _ => call = Expression.Call(
                             instanceConst,
                             nameof(ReadSelfSerialize),
                             new[] { value },
                             Expression.Convert(nodeParam, typeof(ValueDataNode)),
-                            instantiatorConst);
-                    }
+                            instantiatorConst)
+                    };
                 }
                 else if (instance.TryGetTypeReader(value, nodeType, out var reader))
                 {

--- a/Robust.UnitTesting/Shared/Serialization/TypeSerializers/ColorSerializerTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/TypeSerializers/ColorSerializerTest.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using Robust.Shared.Maths;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Markdown.Value;
@@ -39,6 +40,41 @@ namespace Robust.UnitTesting.Shared.Serialization.TypeSerializers
             var color = new Color(r, g, b, a);
 
             Assert.That(deserializedColor.ToString(), Is.EqualTo(color.ToString()));
+        }
+
+        [Test]
+        public void DeserializeNullableNullTest()
+        {
+            var node = new ValueDataNode("null");
+            var color = Serialization.ReadValue<Color?>(node);
+
+            Assert.That(color, Is.Null);
+        }
+
+        [Test]
+        public void DeserializeNullableNotNullTest()
+        {
+            var node = new ValueDataNode("#FFFFFFFF");
+            var color = Serialization.ReadValue<Color?>(node);
+
+            Assert.That(color, Is.Not.Null);
+            Assert.That(color, Is.EqualTo(Color.White));
+        }
+
+        [Test]
+        public void DeserializeNullTest()
+        {
+            var node = new ValueDataNode("null");
+            Assert.That(() => Serialization.ReadValue<Color>(node), Throws.Exception);
+        }
+
+        [Test]
+        public void DeserializeNotNullTest()
+        {
+            var node = new ValueDataNode("#FFFFFFFF");
+            var color = Serialization.ReadValue<Color>(node);
+
+            Assert.That(color, Is.EqualTo(Color.White));
         }
     }
 }


### PR DESCRIPTION
Previously deserializing a node with value "null" into a nullable struct would return the default value of the underlying struct instead of null.