### PR TITLE
UserInterfaceSystem: fail gracefully if the ClientUserInterfaceComponent goes away

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/UserInterfaceSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/UserInterfaceSystem.cs
@@ -29,7 +29,8 @@ namespace Robust.Client.GameObjects
         private void MessageReceived(BoundUIWrapMessage ev)
         {
             var uid = ev.Entity;
-            var cmp = EntityManager.GetComponent<ClientUserInterfaceComponent>(uid);
+            if (!EntityManager.TryGetComponent<ClientUserInterfaceComponent>(uid, out var cmp))
+                return;
 
             var message = ev.Message;
             // This should probably not happen at this point, but better make extra sure!


### PR DESCRIPTION
The chem dispenser may die, but now the client lives on.