### PR TITLE
Fix _enableAllKeybinds buttons breaking due to Use

### DIFF
--- a/Robust.Client/UserInterface/Controls/BaseButton.cs
+++ b/Robust.Client/UserInterface/Controls/BaseButton.cs
@@ -199,7 +199,7 @@ namespace Robust.Client.UserInterface.Controls
         {
             base.KeyBindDown(args);
 
-            if (Disabled || (!_enableAllKeybinds && args.Function != EngineKeyFunctions.UIClick))
+            if (Disabled || args.Function == EngineKeyFunctions.Use || (!_enableAllKeybinds && args.Function != EngineKeyFunctions.UIClick))
             {
                 return;
             }
@@ -242,7 +242,7 @@ namespace Robust.Client.UserInterface.Controls
         {
             base.KeyBindUp(args);
 
-            if (Disabled || (!_enableAllKeybinds && args.Function != EngineKeyFunctions.UIClick))
+            if (Disabled || args.Function == EngineKeyFunctions.Use || (!_enableAllKeybinds && args.Function != EngineKeyFunctions.UIClick))
             {
                 return;
             }


### PR DESCRIPTION
Provides a fix for _enableAllKeybinds breaking buttons due to Use deselecting the button before UIClick can trigger it.