### PR TITLE
Improves PlacementManager (construction/etc.) handling of parent world rotation

### DIFF
--- a/Robust.Client/Placement/PlacementMode.cs
+++ b/Robust.Client/Placement/PlacementMode.cs
@@ -114,13 +114,19 @@ namespace Robust.Client.Placement
             var size = TexturesToDraw[0].Size;
             foreach (var coordinate in locationcollection)
             {
+                if (!coordinate.IsValid(pManager.EntityManager))
+                    return; // Just some paranoia just in case
+                var entity = coordinate.GetEntity(pManager.EntityManager);
                 var worldPos = coordinate.ToMapPos(pManager.EntityManager);
-                var pos = worldPos - (size/(float)EyeManager.PixelsPerMeter) / 2f;
+                var worldRot = entity.Transform.WorldRotation;
+                // Need to calculate a Box2Rotated to properly apply WorldRotation
+                var posBase = Box2.UnitCentered.Scale(size / (float) EyeManager.PixelsPerMeter).Translated(worldPos);
+                var pos = new Box2Rotated(posBase, worldRot, worldPos);
                 var color = IsValidPosition(coordinate) ? ValidPlaceColor : InvalidPlaceColor;
 
                 foreach (var texture in TexturesToDraw)
                 {
-                    handle.DrawTexture(texture, pos, color);
+                    handle.DrawTextureRect(texture, in pos, color);
                 }
             }
         }


### PR DESCRIPTION
Note: This *does not* fully handle every possible rotation situation.

In practice, the specific thing that breaks is noRot sprites in space while the eye has been rotated (standing on rotated grid), but those were already broken in one way or another as far as I can tell.

This still fixes the rotation of the common cases, which are:
+ tile placement indicators
+ any noRot sprite on the same grid as you

It doesn't fix the rotation of rotatable sprites with no sprite directions (read: rotated item sprites), but it shouldn't introduce a bug with it either.

The hypothetical ideal of course would be that more data would be provided to the placement overlay renderer to handle all of this, but in practice this is more than enough right now, and it's a basis for further work.