### PR TITLE
Fix placement manager on rotated grid

### DIFF
--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -709,8 +709,7 @@ namespace Robust.Client.Placement
 
             // world x and y
             message.EntityCoordinates = coordinates;
-
-            message.DirRcv = Direction;
+            message.DirRcv = Direction.ToAngle();
 
             NetworkManager.ClientSendMessage(message);
         }

--- a/Robust.Client/Placement/PlacementMode.cs
+++ b/Robust.Client/Placement/PlacementMode.cs
@@ -94,6 +94,8 @@ namespace Robust.Client.Placement
             if (TexturesToDraw == null || TexturesToDraw.Count == 0)
                 return;
 
+            var eyeRotation = pManager.eyeManager.CurrentEye.Rotation;
+
             IEnumerable<EntityCoordinates> locationcollection;
             switch (pManager.PlacementType)
             {
@@ -115,14 +117,17 @@ namespace Robust.Client.Placement
             foreach (var coordinate in locationcollection)
             {
                 var worldPos = coordinate.ToMapPos(pManager.EntityManager);
-                var pos = worldPos - (size/(float)EyeManager.PixelsPerMeter) / 2f;
+                var pos = worldPos;
+                handle.SetTransform(pos, -eyeRotation + pManager.Direction.ToAngle());
                 var color = IsValidPosition(coordinate) ? ValidPlaceColor : InvalidPlaceColor;
 
                 foreach (var texture in TexturesToDraw)
                 {
-                    handle.DrawTexture(texture, pos, color);
+                    handle.DrawTexture(texture, -size / (float)EyeManager.PixelsPerMeter / 2f, color);
                 }
             }
+
+            handle.SetTransform(in Matrix3.Identity);
         }
 
         public IEnumerable<EntityCoordinates> SingleCoordinate()

--- a/Robust.Server/Placement/PlacementManager.cs
+++ b/Robust.Server/Placement/PlacementManager.cs
@@ -121,7 +121,7 @@ namespace Robust.Server.Placement
             {
                 var created = _entityManager.SpawnEntity(entityTemplateName, coordinates);
 
-                created.Transform.LocalRotation = dirRcv.ToAngle();
+                created.Transform.LocalRotation = dirRcv;
             }
             else
             {

--- a/Robust.Shared/Network/Messages/MsgPlacement.cs
+++ b/Robust.Shared/Network/Messages/MsgPlacement.cs
@@ -19,7 +19,7 @@ namespace Robust.Shared.Network.Messages
         public ushort TileType { get; set; }
         public string EntityTemplateName { get; set; }
         public EntityCoordinates EntityCoordinates { get; set; }
-        public Direction DirRcv { get; set; }
+        public Angle DirRcv { get; set; }
         public EntityUid EntityUid { get; set; }
 
         public int Range { get; set; }
@@ -40,7 +40,7 @@ namespace Robust.Shared.Network.Messages
                     else EntityTemplateName = buffer.ReadString();
 
                     EntityCoordinates = buffer.ReadEntityCoordinates();
-                    DirRcv = (Direction)buffer.ReadByte();
+                    DirRcv = buffer.ReadAngle();
                     break;
                 case PlacementManagerMessage.StartPlacement:
                     Range = buffer.ReadInt32();
@@ -74,7 +74,7 @@ namespace Robust.Shared.Network.Messages
                     else buffer.Write(EntityTemplateName);
 
                     buffer.Write(EntityCoordinates);
-                    buffer.Write((byte)DirRcv);
+                    buffer.Write(DirRcv);
                     break;
                 case PlacementManagerMessage.StartPlacement:
                     buffer.Write(Range);

--- a/Robust.Shared/Network/NetMessageExt.cs
+++ b/Robust.Shared/Network/NetMessageExt.cs
@@ -24,6 +24,17 @@ namespace Robust.Shared.Network
             message.Write(coordinates.Position);
         }
 
+        public static Angle ReadAngle(this NetIncomingMessage message)
+        {
+            var angle = new Angle(message.ReadDouble());
+            return angle;
+        }
+
+        public static void Write(this NetOutgoingMessage message, Angle angle)
+        {
+            message.Write(angle.Theta);
+        }
+
         public static Vector2 ReadVector2(this NetIncomingMessage message)
         {
             var x = message.ReadFloat();


### PR DESCRIPTION
Specifically the ghost entity should always match what gets placed and it should align with cursor properly.