### PR TITLE
timedthingy v2

### DIFF
--- a/Robust.Shared/GameObjects/EntitySystem.Update.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Update.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Robust.Shared.GameObjects
+{
+    public abstract partial class EntitySystem
+    {
+        private Dictionary<Action, (float required, float accumulated)> _updateRegistrations = new();
+
+        /// <inheritdoc />
+        public IEnumerable<Action> GetDueUpdates(float frameTime)
+        {
+            foreach (var (method, (required, accumulated)) in _updateRegistrations)
+            {
+                var delta = accumulated + frameTime;
+                while (delta > required)
+                {
+                    delta -= required;
+                    yield return method;
+                }
+
+                _updateRegistrations[method] = (required, delta);
+            }
+        }
+
+        protected void RegisterUpdate(float requiredFrametime, Action method)
+        {
+            if (_updateRegistrations.ContainsKey(method))
+                throw new ArgumentException($"Method {method} has already been registered.");
+
+            _updateRegistrations[method] = (requiredFrametime, 0f);
+        }
+
+        protected void UnregisterUpdate(Action method)
+        {
+            if (!_updateRegistrations.Remove(method))
+                throw new ArgumentException($"Failed unregistering method {method}.");
+        }
+    }
+}

--- a/Robust.Shared/GameObjects/EntitySystemManager.cs
+++ b/Robust.Shared/GameObjects/EntitySystemManager.cs
@@ -230,6 +230,10 @@ namespace Robust.Shared.GameObjects
                 {
 #endif
                     updReg.System.Update(frameTime);
+                    foreach (var updateMethod in updReg.System.GetDueUpdates(frameTime))
+                    {
+                        updateMethod();
+                    }
 #if EXCEPTION_TOLERANCE
                 }
                 catch (Exception e)

--- a/Robust.Shared/GameObjects/IEntitySystem.cs
+++ b/Robust.Shared/GameObjects/IEntitySystem.cs
@@ -32,5 +32,12 @@ namespace Robust.Shared.GameObjects
         /// <param name="frameTime">Delta time since Update() was last called.</param>
         void Update(float frameTime);
         void FrameUpdate(float frameTime);
+
+        /// <summary>
+        /// Returns all methods for which the required frametime has been reached.
+        /// </summary>
+        /// <param name="frameTime">frametime since last call</param>
+        /// <returns></returns>
+        IEnumerable<Action> GetDueUpdates(float frameTime);
     }
 }


### PR DESCRIPTION
alternative version to #2125

update-functions can be registered using either
```csharp
void RegisterUpdate(float requiredFrametime, Action method)
```
or
```csharp
void RegisterUpdate(Func<float> requiredFrameTimeProvider, Action method)
```

The `Func<float>` variant is there to allow for dynamic required times, for example as can be seen in GasTileOverlay (required time is a cvar that might be changed). The update logic accounts for this, using a while loop to subtract from the accumulated frametime.