### PR TITLE
Introduce BQLv2, part 1

### DIFF
--- a/Robust.Server/Bql/BqlQueryManager.Parsers.cs
+++ b/Robust.Server/Bql/BqlQueryManager.Parsers.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Pidgin;
+using Robust.Shared.GameObjects;
+using static Pidgin.Parser;
+
+namespace Robust.Server.Bql
+{
+    public partial class BqlQueryManager
+    {
+        static Parser<char, T> Tok<T>(Parser<char, T> p) =>
+            Try(p).Before(SkipWhitespaces);
+
+        private static Parser<char, string> Word => Tok(
+            from chars in OneOf(LetterOrDigit, Char('_')).ManyString()
+            select chars
+        );
+
+        private static Parser<char, object> Objectify<T>(Parser<char, T> inp)
+        {
+            return Parser.Map(x => (object) x!, inp);
+        }
+
+        private struct SubstitutionData
+        {
+            public string Name;
+
+            public SubstitutionData(string name)
+            {
+                Name = name;
+            }
+        }
+
+        private static Parser<char, SubstitutionData> Substitution =>
+            Try(Char('$').Then(Tok(
+                from chars in OneOf(Uppercase, Char('_')).ManyString()
+                select chars
+            ))).MapWithInput((x, _) => new SubstitutionData(x.ToString()));
+
+        private static Parser<char, int> Integer =>
+            Try(Tok(Int(10)));
+
+        private static Parser<char, object> SubstitutableInteger =>
+            Objectify(Integer).Or(Objectify(Try(Substitution)));
+
+        private static Parser<char, double> Float =>
+            Try(Tok(Real));
+
+        private static Parser<char, object> SubstitutableFloat =>
+            Objectify(Float).Or(Objectify(Try(Substitution)));
+
+        private static Parser<char, double> Percentage =>
+            Try(Tok(Real).Before(Char('%')));
+
+        private static Parser<char, object> SubstitutablePercentage =>
+            Objectify(Percentage).Or(Objectify(Try(Substitution)));
+
+        private static Parser<char, EntityUid> EntityId =>
+            Try(Parser.Map(x => new EntityUid(x), Tok(Int(10))));
+
+        private static Parser<char, object> SubstitutableEntityId =>
+            Objectify(EntityId).Or(Objectify(Try(Substitution)));
+
+        private static Parser<char, Type> Component =>
+            Try(Parser.Map(t => _componentFactory.GetRegistration(t).Type, Word));
+
+        private static Parser<char, object> SubstitutableComponent =>
+            Objectify(Component).Or(Objectify(Try(Substitution)));
+
+        private static Parser<char, string> String =>
+            Try(Word); //TODO: Actually parse a string input.
+
+        private static Parser<char, object> SubstitutableString =>
+            Objectify(String).Or(Objectify(Try(Substitution)));
+
+        // thing to make sure it all compiles.
+        [UsedImplicitly]
+        private static Parser<char, object> TypeSystemCheck =>
+            OneOf(new[]
+            {
+                Objectify(Integer),
+                Objectify(Percentage),
+                Objectify(EntityId),
+                Objectify(Component),
+                Objectify(Float),
+                Objectify(String)
+            });
+
+        private Parser<char, BqlQuerySelectorParsed> BqlQueryParser(string token)
+        {
+            var inst = _queriesByToken[token];
+
+            if (inst.Arguments.Length == 0)
+                return new Pidgin.Parser.String;
+
+            List<Parser<char, object>> argsParsers = new();
+
+            foreach (var (arg, idx) in inst.Arguments.Select((x, i) => (x, i)))
+            {
+                List<Parser<char, object>> choices = new();
+                if ((arg & QuerySelectorArgument.String) == QuerySelectorArgument.String)
+                {
+                    choices.Add(SubstitutableString);
+                }
+                if ((arg & QuerySelectorArgument.Component) == QuerySelectorArgument.Component)
+                {
+                    choices.Add(SubstitutableComponent);
+                }
+                if ((arg & QuerySelectorArgument.EntityId) == QuerySelectorArgument.EntityId)
+                {
+                    choices.Add(SubstitutableEntityId);
+                }
+                if ((arg & QuerySelectorArgument.Integer) == QuerySelectorArgument.Integer)
+                {
+                    choices.Add(SubstitutableInteger);
+                }
+                if ((arg & QuerySelectorArgument.Percentage) == QuerySelectorArgument.Percentage)
+                {
+                    choices.Add(SubstitutablePercentage);
+                }
+                if ((arg & QuerySelectorArgument.Float) == QuerySelectorArgument.Float)
+                {
+                    choices.Add(SubstitutableFloat);
+                }
+                argsParsers.Add(OneOf(choices).Labelled("argument "+idx));
+            }
+
+            Parser<char, List<object>>? finalParser = argsParsers[0].Map(x => new List<object> { x });
+
+            foreach (var parser in )
+            {
+
+            }
+        }
+    }
+}

--- a/Robust.Server/Bql/BqlQueryManager.Parsers.cs
+++ b/Robust.Server/Bql/BqlQueryManager.Parsers.cs
@@ -155,17 +155,14 @@ namespace Robust.Server.Bql
                 _parsers.Add(inst.GetType(), BuildBqlQueryParser(inst));
             }
 
-            _allQuerySelectors = OneOf(_instances.Select(x => Parser.Map((a, b) => (a, b),
-                Try(String("not").Before(Char(' '))).Optional(),
-                Try(String(x.Token).Before(Char(' ')))))).Then(tok =>
-                _parsers[_queriesByToken[tok.b].GetType()].Map(a =>
-                {
-                    a.Inverted = tok.a.HasValue;
-                    return a;
-                })
-            );
-
-
+            _allQuerySelectors = Parser.Map((a,b) => (a,b), Try(String("not").Before(Char(' '))).Optional(), OneOf(_instances.Select(x =>
+                Try(String(x.Token).Before(Char(' '))))).Then(tok =>
+                _parsers[_queriesByToken[tok].GetType()])
+            ).Map(pair =>
+            {
+                pair.b.Inverted = pair.a.HasValue;
+                return pair.b;
+            });
         }
     }
 }

--- a/Robust.Server/Bql/BqlQueryManager.SimpleExecutor.cs
+++ b/Robust.Server/Bql/BqlQueryManager.SimpleExecutor.cs
@@ -9,7 +9,7 @@ namespace Robust.Server.Bql
 {
     public partial class BqlQueryManager
     {
-        public (IEnumerable<IEntity>, string) SimpleParseAndExecute(string query)
+        public (IEnumerable<EntityUid>, string) SimpleParseAndExecute(string query)
         {
             var parsed = _simpleQuery.Parse(query);
             if (parsed.Success)
@@ -18,15 +18,15 @@ namespace Robust.Server.Bql
                 var selectors = parsed.Value.Item1.ToArray();
                 if (selectors.Length == 0)
                 {
-                    return (entityManager.GetEntities(), parsed.Value.Item2);
+                    return (entityManager.GetEntityUids(), parsed.Value.Item2);
                 }
 
                 var entities = _queriesByToken[selectors[0].Token]
-                    .DoInitialSelection(selectors[0].Arguments, selectors[0].Inverted);
+                    .DoInitialSelection(selectors[0].Arguments, selectors[0].Inverted, entityManager);
 
                 foreach (var sel in selectors[1..])
                 {
-                    entities = _queriesByToken[sel.Token].DoSelection(entities, sel.Arguments, sel.Inverted);
+                    entities = _queriesByToken[sel.Token].DoSelection(entities, sel.Arguments, sel.Inverted, entityManager);
                 }
 
                 return (entities, parsed.Value.Item2);

--- a/Robust.Server/Bql/BqlQueryManager.SimpleExecutor.cs
+++ b/Robust.Server/Bql/BqlQueryManager.SimpleExecutor.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Pidgin;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+
+namespace Robust.Server.Bql
+{
+    public partial class BqlQueryManager
+    {
+        public (IEnumerable<IEntity>, string) SimpleParseAndExecute(string query)
+        {
+            var parsed = _simpleQuery.Parse(query);
+            if (parsed.Success)
+            {
+                var entityManager = IoCManager.Resolve<IEntityManager>();
+                var selectors = parsed.Value.Item1.ToArray();
+                if (selectors.Length == 0)
+                {
+                    return (entityManager.GetEntities(), parsed.Value.Item2);
+                }
+
+                var entities = _queriesByToken[selectors[0].Token]
+                    .DoInitialSelection(selectors[0].Arguments, selectors[0].Inverted);
+
+                foreach (var sel in selectors[1..])
+                {
+                    entities = _queriesByToken[sel.Token].DoSelection(entities, sel.Arguments, sel.Inverted);
+                }
+
+                return (entities, parsed.Value.Item2);
+            }
+            else
+            {
+                throw new Exception(parsed.Error!.RenderErrorMessage());
+            }
+        }
+    }
+}

--- a/Robust.Server/Bql/BqlQueryManager.SimpleExecutor.cs
+++ b/Robust.Server/Bql/BqlQueryManager.SimpleExecutor.cs
@@ -11,7 +11,7 @@ namespace Robust.Server.Bql
     {
         public (IEnumerable<EntityUid>, string) SimpleParseAndExecute(string query)
         {
-            var parsed = _simpleQuery.Parse(query);
+            var parsed = SimpleQuery.Parse(query);
             if (parsed.Success)
             {
                 var entityManager = IoCManager.Resolve<IEntityManager>();

--- a/Robust.Server/Bql/BqlQueryManager.cs
+++ b/Robust.Server/Bql/BqlQueryManager.cs
@@ -24,7 +24,7 @@ namespace Robust.Server.Bql
         }
 
         /// <summary>
-        /// Automatically registers all quer
+        /// Automatically registers all query selectors with the parser/executor.
         /// </summary>
         public void DoAutoRegistrations()
         {

--- a/Robust.Server/Bql/BqlQueryManager.cs
+++ b/Robust.Server/Bql/BqlQueryManager.cs
@@ -8,7 +8,7 @@ using Robust.Shared.Utility;
 
 namespace Robust.Server.Bql
 {
-    public partial class BqlQueryManager
+    public partial class BqlQueryManager : IBqlQueryManager
     {
         private static IReflectionManager _reflectionManager = default!;
         private static IComponentFactory _componentFactory = default!;
@@ -16,7 +16,6 @@ namespace Robust.Server.Bql
         private readonly List<BqlQuerySelector> _instances = new();
         private readonly Dictionary<string, BqlQuerySelector> _queriesByToken = new();
         private readonly Dictionary<Type, BqlQuerySelector> _queriesByType = new();
-
 
         public BqlQueryManager()
         {
@@ -48,11 +47,6 @@ namespace Robust.Server.Bql
             _instances.Add(inst);
             _queriesByToken.Add(inst.Token, inst);
             _queriesByType.Add(bqlQuerySelector, inst);
-        }
-
-        public void DoParserSetup()
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/Robust.Server/Bql/BqlQueryManager.cs
+++ b/Robust.Server/Bql/BqlQueryManager.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Reflection;
+using Robust.Shared.Utility;
+
+namespace Robust.Server.Bql
+{
+    public partial class BqlQueryManager
+    {
+        private static IReflectionManager _reflectionManager = default!;
+        private static IComponentFactory _componentFactory = default!;
+
+        private readonly List<BqlQuerySelector> _instances = new();
+        private readonly Dictionary<string, BqlQuerySelector> _queriesByToken = new();
+        private readonly Dictionary<Type, BqlQuerySelector> _queriesByType = new();
+
+
+        public BqlQueryManager()
+        {
+            _reflectionManager = IoCManager.Resolve<IReflectionManager>();
+            _componentFactory = IoCManager.Resolve<IComponentFactory>();
+        }
+
+        /// <summary>
+        /// Automatically registers all quer
+        /// </summary>
+        public void DoAutoRegistrations()
+        {
+            foreach (var type in _reflectionManager.FindTypesWithAttribute<RegisterBqlQuerySelectorAttribute>())
+            {
+                RegisterClass(type);
+            }
+
+            DoParserSetup();
+        }
+
+        /// <summary>
+        /// Internally registers the given <see cref="BqlQuerySelector"/>.
+        /// </summary>
+        /// <param name="bqlQuerySelector">The selector to register</param>
+        private void RegisterClass(Type bqlQuerySelector)
+        {
+            DebugTools.Assert(bqlQuerySelector.BaseType == typeof(BqlQuerySelector));
+            var inst = (BqlQuerySelector)Activator.CreateInstance(bqlQuerySelector)!;
+            _instances.Add(inst);
+            _queriesByToken.Add(inst.Token, inst);
+            _queriesByType.Add(bqlQuerySelector, inst);
+        }
+
+        public void DoParserSetup()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Robust.Server/Bql/BqlQueryManager.cs
+++ b/Robust.Server/Bql/BqlQueryManager.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Reflection;
@@ -10,12 +9,11 @@ namespace Robust.Server.Bql
 {
     public partial class BqlQueryManager : IBqlQueryManager
     {
-        private static IReflectionManager _reflectionManager = default!;
-        private static IComponentFactory _componentFactory = default!;
+        private readonly IReflectionManager _reflectionManager;
+        private readonly IComponentFactory _componentFactory;
 
         private readonly List<BqlQuerySelector> _instances = new();
         private readonly Dictionary<string, BqlQuerySelector> _queriesByToken = new();
-        private readonly Dictionary<Type, BqlQuerySelector> _queriesByType = new();
 
         public BqlQueryManager()
         {
@@ -46,7 +44,6 @@ namespace Robust.Server.Bql
             var inst = (BqlQuerySelector)Activator.CreateInstance(bqlQuerySelector)!;
             _instances.Add(inst);
             _queriesByToken.Add(inst.Token, inst);
-            _queriesByType.Add(bqlQuerySelector, inst);
         }
     }
 }

--- a/Robust.Server/Bql/BqlQuerySelector.Builtin.cs
+++ b/Robust.Server/Bql/BqlQuerySelector.Builtin.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 
 namespace Robust.Server.Bql
 {
@@ -17,6 +18,17 @@ namespace Robust.Server.Bql
         {
             var comp = (Type) arguments[0];
             return input.Where(x => x.HasComponent(comp) ^ isInverted);
+        }
+
+        public override IEnumerable<IEntity> DoInitialSelection(IReadOnlyList<object> arguments, bool isInverted)
+        {
+            if (isInverted)
+            {
+                return base.DoInitialSelection(arguments, isInverted);
+            }
+
+            return IoCManager.Resolve<IEntityManager>().GetAllComponents((Type) arguments[0])
+                .Select(x => x.Owner);
         }
     }
 

--- a/Robust.Server/Bql/BqlQuerySelector.Builtin.cs
+++ b/Robust.Server/Bql/BqlQuerySelector.Builtin.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Log;
 
 namespace Robust.Server.Bql
 {
@@ -56,7 +57,7 @@ namespace Robust.Server.Bql
         public override IEnumerable<IEntity> DoSelection(IEnumerable<IEntity> input, IReadOnlyList<object> arguments, bool isInverted)
         {
             var uid = (EntityUid) arguments[0];
-            return input.Where(e => e.Transform.ParentUid == uid ^ isInverted);
+            return input.Where(e => (e.Transform.ParentUid == uid) ^ isInverted);
         }
     }
 
@@ -75,7 +76,7 @@ namespace Robust.Server.Bql
                 var cur = e;
                 while (cur.Transform.Parent is not null)
                 {
-                    if (cur.Transform.ParentUid == uid ^ isInverted)
+                    if ((cur.Transform.ParentUid == uid) ^ isInverted)
                         return true;
                     cur = cur.Transform.Parent.Owner;
                 }
@@ -94,8 +95,9 @@ namespace Robust.Server.Bql
 
         public override IEnumerable<IEntity> DoSelection(IEnumerable<IEntity> input, IReadOnlyList<object> arguments, bool isInverted)
         {
+            Logger.Debug((string) arguments[0]);
             var name = (string) arguments[0];
-            return input.Where(e => e.Prototype?.Name == name ^ isInverted);
+            return input.Where(e => (e.Prototype?.Name == name) ^ isInverted);
         }
     }
 
@@ -111,10 +113,10 @@ namespace Robust.Server.Bql
             var name = (string) arguments[0];
             return input.Where(e =>
             {
-                if (e.Prototype?.Name == name ^ isInverted)
+                if ((e.Prototype?.Name == name) ^ isInverted)
                     return true;
 
-                return e.Prototype?.Parent == name ^ isInverted; // Damn, can't actually do recursive check here.
+                return (e.Prototype?.Parent == name) ^ isInverted; // Damn, can't actually do recursive check here.
             });
         }
     }

--- a/Robust.Server/Bql/BqlQuerySelector.Builtin.cs
+++ b/Robust.Server/Bql/BqlQuerySelector.Builtin.cs
@@ -319,7 +319,7 @@ namespace Robust.Server.Bql
     {
         public override string Token => "anchored";
 
-        public override QuerySelectorArgument[] Arguments => new [] { QuerySelectorArgument.Integer };
+        public override QuerySelectorArgument[] Arguments => Array.Empty<QuerySelectorArgument>();
 
         public override IEnumerable<EntityUid> DoSelection(IEnumerable<EntityUid> input, IReadOnlyList<object> arguments, bool isInverted, IEntityManager entityManager)
         {

--- a/Robust.Server/Bql/BqlQuerySelector.Builtin.cs
+++ b/Robust.Server/Bql/BqlQuerySelector.Builtin.cs
@@ -97,7 +97,7 @@ namespace Robust.Server.Bql
         {
             Logger.Debug((string) arguments[0]);
             var name = (string) arguments[0];
-            return input.Where(e => (e.Prototype?.Name == name) ^ isInverted);
+            return input.Where(e => (e.Prototype?.ID == name) ^ isInverted);
         }
     }
 
@@ -113,7 +113,7 @@ namespace Robust.Server.Bql
             var name = (string) arguments[0];
             return input.Where(e =>
             {
-                if ((e.Prototype?.Name == name) ^ isInverted)
+                if ((e.Prototype?.ID == name) ^ isInverted)
                     return true;
 
                 return (e.Prototype?.Parent == name) ^ isInverted; // Damn, can't actually do recursive check here.

--- a/Robust.Server/Bql/BqlQuerySelector.Builtin.cs
+++ b/Robust.Server/Bql/BqlQuerySelector.Builtin.cs
@@ -157,7 +157,7 @@ namespace Robust.Server.Bql
 
         public override IEnumerable<EntityUid> DoInitialSelection(IReadOnlyList<object> arguments, bool isInverted, IEntityManager entityManager)
         {
-            return base.DoSelection(entityManager.EntityQuery<ITransformComponent>().Select(x => x.OwnerUid), arguments,
+            return DoSelection(entityManager.EntityQuery<ITransformComponent>().Select(x => x.OwnerUid), arguments,
                 isInverted, entityManager);
         }
     }

--- a/Robust.Server/Bql/BqlQuerySelector.Builtin.cs
+++ b/Robust.Server/Bql/BqlQuerySelector.Builtin.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Robust.Shared.GameObjects;
+
+namespace Robust.Server.Bql
+{
+    [RegisterBqlQuerySelector]
+    public class WithQuerySelector : BqlQuerySelector
+    {
+        public override string Token => "with";
+
+        public override QuerySelectorArgument[] Arguments => new []{ QuerySelectorArgument.Component };
+
+        public override IEnumerable<IEntity> DoSelection(IEnumerable<IEntity> input, IReadOnlyList<object> arguments, bool isInverted)
+        {
+            var comp = (Type) arguments[0];
+            return input.Where(x => x.HasComponent(comp) ^ isInverted);
+        }
+    }
+
+    [RegisterBqlQuerySelector]
+    public class NamedQuerySelector : BqlQuerySelector
+    {
+        public override string Token => "named";
+
+        public override QuerySelectorArgument[] Arguments => new []{ QuerySelectorArgument.String };
+
+        public override IEnumerable<IEntity> DoSelection(IEnumerable<IEntity> input, IReadOnlyList<object> arguments, bool isInverted)
+        {
+            var r = new Regex("^" + (string) arguments[0] + "$");
+            return input.Where(e => r.IsMatch(e.Name) ^ isInverted);
+        }
+    }
+
+    [RegisterBqlQuerySelector]
+    public class ParentedToQuerySelector : BqlQuerySelector
+    {
+        public override string Token => "parentedto";
+
+        public override QuerySelectorArgument[] Arguments => new []{ QuerySelectorArgument.EntityId };
+
+        public override IEnumerable<IEntity> DoSelection(IEnumerable<IEntity> input, IReadOnlyList<object> arguments, bool isInverted)
+        {
+            var uid = (EntityUid) arguments[0];
+            return input.Where(e => e.Transform.ParentUid == uid ^ isInverted);
+        }
+    }
+
+    [RegisterBqlQuerySelector]
+    public class RecursiveParentedToQuerySelector : BqlQuerySelector
+    {
+        public override string Token => "rparentedto";
+
+        public override QuerySelectorArgument[] Arguments => new []{ QuerySelectorArgument.EntityId };
+
+        public override IEnumerable<IEntity> DoSelection(IEnumerable<IEntity> input, IReadOnlyList<object> arguments, bool isInverted)
+        {
+            var uid = (EntityUid) arguments[0];
+            return input.Where(e =>
+            {
+                var cur = e;
+                while (cur.Transform.Parent is not null)
+                {
+                    if (cur.Transform.ParentUid == uid ^ isInverted)
+                        return true;
+                    cur = cur.Transform.Parent.Owner;
+                }
+
+                return false;
+            });
+        }
+    }
+
+    [RegisterBqlQuerySelector]
+    public class PrototypedQuerySelector : BqlQuerySelector
+    {
+        public override string Token => "prototyped";
+
+        public override QuerySelectorArgument[] Arguments => new []{ QuerySelectorArgument.String };
+
+        public override IEnumerable<IEntity> DoSelection(IEnumerable<IEntity> input, IReadOnlyList<object> arguments, bool isInverted)
+        {
+            var name = (string) arguments[0];
+            return input.Where(e => e.Prototype?.Name == name ^ isInverted);
+        }
+    }
+
+    [RegisterBqlQuerySelector]
+    public class RecursivePrototypedQuerySelector : BqlQuerySelector
+    {
+        public override string Token => "rprototyped";
+
+        public override QuerySelectorArgument[] Arguments => new []{ QuerySelectorArgument.String };
+
+        public override IEnumerable<IEntity> DoSelection(IEnumerable<IEntity> input, IReadOnlyList<object> arguments, bool isInverted)
+        {
+            var name = (string) arguments[0];
+            return input.Where(e =>
+            {
+                if (e.Prototype?.Name == name ^ isInverted)
+                    return true;
+
+                return e.Prototype?.Parent == name ^ isInverted; // Damn, can't actually do recursive check here.
+            });
+        }
+    }
+
+    [RegisterBqlQuerySelector]
+    public class SelectQuerySelector : BqlQuerySelector
+    {
+        public override string Token => "select";
+
+        public override QuerySelectorArgument[] Arguments => new []{ QuerySelectorArgument.Integer | QuerySelectorArgument.Percentage };
+
+        public override IEnumerable<IEntity> DoSelection(IEnumerable<IEntity> input, IReadOnlyList<object> arguments, bool isInverted)
+        {
+            if (arguments[0] is int)
+            {
+                return input.OrderBy(a => Guid.NewGuid()).Take((int) arguments[0]);
+            }
+
+            var enumerable = input.OrderBy(a => Guid.NewGuid()).ToArray();
+            var amount = (int)Math.Floor(enumerable.Length * (double)arguments[0]);
+            return enumerable.Take(amount);
+        }
+    }
+}

--- a/Robust.Server/Bql/BqlQuerySelector.cs
+++ b/Robust.Server/Bql/BqlQuerySelector.cs
@@ -32,6 +32,16 @@ namespace Robust.Server.Bql
         /// </summary>
         public virtual QuerySelectorArgument[] Arguments => throw new NotImplementedException();
 
+        /// <summary>
+        /// Performs a transform over it's input entity list, whether that be filtering (selecting) or expanding the
+        /// input on some criteria like what entities are nearby.
+        /// </summary>
+        /// <param name="input">Input entity list.</param>
+        /// <param name="arguments">Parsed selector arguments.</param>
+        /// <param name="isInverted">Whether the query is inverted.</param>
+        /// <param name="entityManager">The entity manager.</param>
+        /// <returns>New list of entities</returns>
+        /// <exception cref="NotImplementedException">someone is a moron if this happens.</exception>
         public virtual IEnumerable<EntityUid> DoSelection(IEnumerable<EntityUid> input, IReadOnlyList<object> arguments, bool isInverted, IEntityManager entityManager)
         {
             throw new NotImplementedException();

--- a/Robust.Server/Bql/BqlQuerySelector.cs
+++ b/Robust.Server/Bql/BqlQuerySelector.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Robust.Shared.GameObjects;
+
+namespace Robust.Server.Bql
+{
+    [Flags]
+    [PublicAPI]
+    public enum QuerySelectorArgument
+    {
+        Integer    = 0b00000001,
+        Float      = 0b00000010,
+        String     = 0b00000100,
+        Percentage = 0b00001000,
+        Component  = 0b00010000,
+        SubQuery   = 0b00100000,
+        EntityId   = 0b01000000,
+    }
+
+    [PublicAPI]
+    public abstract class BqlQuerySelector
+    {
+        /// <summary>
+        /// The token name for the given QuerySelector, for example `when`.
+        /// </summary>
+        public virtual string Token => throw new NotImplementedException();
+
+        /// <summary>
+        /// Arguments for the given QuerySelector, presented as "what arguments are permitted in what spot".
+        /// </summary>
+        public virtual QuerySelectorArgument[] Arguments => throw new NotImplementedException();
+
+        public virtual IEnumerable<IEntity> DoSelection(IEnumerable<IEntity> input, IReadOnlyList<object> arguments, bool isInverted)
+        {
+            throw new NotImplementedException();
+        }
+
+        [UsedImplicitly]
+        protected BqlQuerySelector() {}
+    }
+}

--- a/Robust.Server/Bql/BqlQuerySelector.cs
+++ b/Robust.Server/Bql/BqlQuerySelector.cs
@@ -32,17 +32,10 @@ namespace Robust.Server.Bql
         /// </summary>
         public virtual QuerySelectorArgument[] Arguments => throw new NotImplementedException();
 
-        /// <summary>
-        /// Selects entities from the input to pass on, functioning as a sort of filter. Can also add NEW entities as
-        /// well, for behaviors like "getting every entity near the inputs"
-        /// </summary>
-        /// <param name="input"></param>
-        /// <param name="arguments"></param>
-        /// <param name="isInverted"></param>
-        /// <param name="entityManager"></param>
-        /// <returns></returns>
-        public abstract IEnumerable<EntityUid> DoSelection(IEnumerable<EntityUid> input,
-            IReadOnlyList<object> arguments, bool isInverted, IEntityManager entityManager);
+        public virtual IEnumerable<EntityUid> DoSelection(IEnumerable<EntityUid> input, IReadOnlyList<object> arguments, bool isInverted, IEntityManager entityManager)
+        {
+            throw new NotImplementedException();
+        }
 
         /// <summary>
         /// Performs selection as the first selector in the query. Allows for optimizing when you can be more efficient

--- a/Robust.Server/Bql/BqlQuerySelector.cs
+++ b/Robust.Server/Bql/BqlQuerySelector.cs
@@ -32,7 +32,7 @@ namespace Robust.Server.Bql
         /// </summary>
         public virtual QuerySelectorArgument[] Arguments => throw new NotImplementedException();
 
-        public virtual IEnumerable<IEntity> DoSelection(IEnumerable<IEntity> input, IReadOnlyList<object> arguments, bool isInverted)
+        public virtual IEnumerable<EntityUid> DoSelection(IEnumerable<EntityUid> input, IReadOnlyList<object> arguments, bool isInverted, IEntityManager entityManager)
         {
             throw new NotImplementedException();
         }
@@ -43,11 +43,11 @@ namespace Robust.Server.Bql
         /// </summary>
         /// <param name="arguments"></param>
         /// <param name="isInverted"></param>
+        /// <param name="entityManager"></param>
         /// <returns></returns>
-        public virtual IEnumerable<IEntity> DoInitialSelection(IReadOnlyList<object> arguments, bool isInverted)
+        public virtual IEnumerable<EntityUid> DoInitialSelection(IReadOnlyList<object> arguments, bool isInverted, IEntityManager entityManager)
         {
-            var entityManager = IoCManager.Resolve<IEntityManager>();
-            return DoSelection(entityManager.GetEntities(), arguments, isInverted);
+            return DoSelection(entityManager.GetEntityUids(), arguments, isInverted, entityManager);
         }
 
         [UsedImplicitly]

--- a/Robust.Server/Bql/BqlQuerySelector.cs
+++ b/Robust.Server/Bql/BqlQuerySelector.cs
@@ -42,10 +42,8 @@ namespace Robust.Server.Bql
         /// <param name="entityManager">The entity manager.</param>
         /// <returns>New list of entities</returns>
         /// <exception cref="NotImplementedException">someone is a moron if this happens.</exception>
-        public virtual IEnumerable<EntityUid> DoSelection(IEnumerable<EntityUid> input, IReadOnlyList<object> arguments, bool isInverted, IEntityManager entityManager)
-        {
-            throw new NotImplementedException();
-        }
+        public abstract IEnumerable<EntityUid> DoSelection(IEnumerable<EntityUid> input,
+            IReadOnlyList<object> arguments, bool isInverted, IEntityManager entityManager);
 
         /// <summary>
         /// Performs selection as the first selector in the query. Allows for optimizing when you can be more efficient

--- a/Robust.Server/Bql/BqlQuerySelector.cs
+++ b/Robust.Server/Bql/BqlQuerySelector.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 
 namespace Robust.Server.Bql
 {
@@ -14,7 +15,7 @@ namespace Robust.Server.Bql
         String     = 0b00000100,
         Percentage = 0b00001000,
         Component  = 0b00010000,
-        SubQuery   = 0b00100000,
+        //SubQuery   = 0b00100000,
         EntityId   = 0b01000000,
     }
 
@@ -34,6 +35,19 @@ namespace Robust.Server.Bql
         public virtual IEnumerable<IEntity> DoSelection(IEnumerable<IEntity> input, IReadOnlyList<object> arguments, bool isInverted)
         {
             throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Performs selection as the first selector in the query. Allows for optimizing when you can be more efficient
+        /// than just querying every entity.
+        /// </summary>
+        /// <param name="arguments"></param>
+        /// <param name="isInverted"></param>
+        /// <returns></returns>
+        public virtual IEnumerable<IEntity> DoInitialSelection(IReadOnlyList<object> arguments, bool isInverted)
+        {
+            var entityManager = IoCManager.Resolve<IEntityManager>();
+            return DoSelection(entityManager.GetEntities(), arguments, isInverted);
         }
 
         [UsedImplicitly]

--- a/Robust.Server/Bql/BqlQuerySelector.cs
+++ b/Robust.Server/Bql/BqlQuerySelector.cs
@@ -32,10 +32,17 @@ namespace Robust.Server.Bql
         /// </summary>
         public virtual QuerySelectorArgument[] Arguments => throw new NotImplementedException();
 
-        public virtual IEnumerable<EntityUid> DoSelection(IEnumerable<EntityUid> input, IReadOnlyList<object> arguments, bool isInverted, IEntityManager entityManager)
-        {
-            throw new NotImplementedException();
-        }
+        /// <summary>
+        /// Selects entities from the input to pass on, functioning as a sort of filter. Can also add NEW entities as
+        /// well, for behaviors like "getting every entity near the inputs"
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="arguments"></param>
+        /// <param name="isInverted"></param>
+        /// <param name="entityManager"></param>
+        /// <returns></returns>
+        public abstract IEnumerable<EntityUid> DoSelection(IEnumerable<EntityUid> input,
+            IReadOnlyList<object> arguments, bool isInverted, IEntityManager entityManager);
 
         /// <summary>
         /// Performs selection as the first selector in the query. Allows for optimizing when you can be more efficient

--- a/Robust.Server/Bql/BqlQuerySelectorParsed.cs
+++ b/Robust.Server/Bql/BqlQuerySelectorParsed.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Robust.Server.Bql
@@ -6,5 +7,13 @@ namespace Robust.Server.Bql
     {
         public List<object> Arguments;
         public string Token;
+        public bool Inverted;
+
+        public BqlQuerySelectorParsed(List<object> arguments, string token, bool inverted)
+        {
+            Arguments = arguments;
+            Token = token;
+            Inverted = inverted;
+        }
     }
 }

--- a/Robust.Server/Bql/BqlQuerySelectorParsed.cs
+++ b/Robust.Server/Bql/BqlQuerySelectorParsed.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Robust.Server.Bql
+{
+    public struct BqlQuerySelectorParsed
+    {
+        public List<object> Arguments;
+        public string Token;
+    }
+}

--- a/Robust.Server/Bql/ForAllCommand.cs
+++ b/Robust.Server/Bql/ForAllCommand.cs
@@ -1,0 +1,72 @@
+using System.Globalization;
+using System.Linq;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+
+namespace Robust.Server.Bql
+{
+    public class ForAllCommand : IConsoleCommand
+    {
+        public string Command => "forall";
+        public string Description => "Runs a command over all entities with a given component";
+        public string Help => "Usage: forall <bql query> do <command...>";
+
+        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        {
+            if (args.Length < 2)
+            {
+                shell.WriteLine(Help);
+                return;
+            }
+
+            var queryManager = IoCManager.Resolve<IBqlQueryManager>();
+            var (entities, rest) = queryManager.SimpleParseAndExecute(argStr[6..]);
+
+            foreach (var ent in entities.ToList())
+            {
+                var cmds = SubstituteEntityDetails(shell, ent, rest).Split(";");
+                foreach (var cmd in cmds)
+                {
+                    shell.ExecuteCommand(cmd);
+                }
+            }
+        }
+
+        // This will be refactored out soon.
+        private static string SubstituteEntityDetails(IConsoleShell shell, IEntity ent, string ruleString)
+        {
+            // gross, is there a better way to do this?
+            ruleString = ruleString.Replace("$ID", ent.Uid.ToString());
+            ruleString = ruleString.Replace("$WX",
+                ent.Transform.WorldPosition.X.ToString(CultureInfo.InvariantCulture));
+            ruleString = ruleString.Replace("$WY",
+                ent.Transform.WorldPosition.Y.ToString(CultureInfo.InvariantCulture));
+            ruleString = ruleString.Replace("$LX",
+                ent.Transform.LocalPosition.X.ToString(CultureInfo.InvariantCulture));
+            ruleString = ruleString.Replace("$LY",
+                ent.Transform.LocalPosition.Y.ToString(CultureInfo.InvariantCulture));
+            ruleString = ruleString.Replace("$NAME", ent.Name);
+
+            if (shell.Player is IPlayerSession player)
+            {
+                if (player.AttachedEntity != null)
+                {
+                    var p = player.AttachedEntity;
+                    ruleString = ruleString.Replace("$PID", ent.Uid.ToString());
+                    ruleString = ruleString.Replace("$PWX",
+                        p.Transform.WorldPosition.X.ToString(CultureInfo.InvariantCulture));
+                    ruleString = ruleString.Replace("$PWY",
+                        p.Transform.WorldPosition.Y.ToString(CultureInfo.InvariantCulture));
+                    ruleString = ruleString.Replace("$PLX",
+                        p.Transform.LocalPosition.X.ToString(CultureInfo.InvariantCulture));
+                    ruleString = ruleString.Replace("$PLY",
+                        p.Transform.LocalPosition.Y.ToString(CultureInfo.InvariantCulture));
+                }
+            }
+
+            return ruleString;
+        }
+    }
+}

--- a/Robust.Server/Bql/ForAllCommand.cs
+++ b/Robust.Server/Bql/ForAllCommand.cs
@@ -22,11 +22,12 @@ namespace Robust.Server.Bql
             }
 
             var queryManager = IoCManager.Resolve<IBqlQueryManager>();
+            var entityManager = IoCManager.Resolve<IEntityManager>();
             var (entities, rest) = queryManager.SimpleParseAndExecute(argStr[6..]);
 
             foreach (var ent in entities.ToList())
             {
-                var cmds = SubstituteEntityDetails(shell, ent, rest).Split(";");
+                var cmds = SubstituteEntityDetails(shell, entityManager.GetEntity(ent), rest).Split(";");
                 foreach (var cmd in cmds)
                 {
                     shell.ExecuteCommand(cmd);

--- a/Robust.Server/Bql/IBqlQueryManager.cs
+++ b/Robust.Server/Bql/IBqlQueryManager.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using Robust.Shared.GameObjects;
+
+namespace Robust.Server.Bql
+{
+    public interface IBqlQueryManager
+    {
+        public (IEnumerable<IEntity>, string) SimpleParseAndExecute(string query);
+        void DoAutoRegistrations();
+    }
+}

--- a/Robust.Server/Bql/IBqlQueryManager.cs
+++ b/Robust.Server/Bql/IBqlQueryManager.cs
@@ -5,7 +5,7 @@ namespace Robust.Server.Bql
 {
     public interface IBqlQueryManager
     {
-        public (IEnumerable<IEntity>, string) SimpleParseAndExecute(string query);
+        public (IEnumerable<EntityUid>, string) SimpleParseAndExecute(string query);
         void DoAutoRegistrations();
     }
 }

--- a/Robust.Server/Bql/RegisterBqlQuerySelectorAttribute.cs
+++ b/Robust.Server/Bql/RegisterBqlQuerySelectorAttribute.cs
@@ -1,0 +1,14 @@
+using System;
+using JetBrains.Annotations;
+
+namespace Robust.Server.Bql
+{
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    [BaseTypeRequired(typeof(BqlQuerySelector))]
+    [MeansImplicitUse]
+    [PublicAPI]
+    public class RegisterBqlQuerySelectorAttribute : Attribute
+    {
+
+    }
+}

--- a/Robust.Server/ServerIoC.cs
+++ b/Robust.Server/ServerIoC.cs
@@ -1,3 +1,4 @@
+using Robust.Server.Bql;
 using Robust.Server.Console;
 using Robust.Server.DataMetrics;
 using Robust.Server.Debugging;
@@ -73,6 +74,7 @@ namespace Robust.Server
             IoCManager.Register<IMetricsManager, MetricsManager>();
             IoCManager.Register<IAuthManager, AuthManager>();
             IoCManager.Register<IPhysicsManager, PhysicsManager>();
+            IoCManager.Register<IBqlQueryManager, BqlQueryManager>();
         }
     }
 }

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -224,6 +224,8 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public IEnumerable<IEntity> GetEntities() => Entities.Values;
 
+        public IEnumerable<EntityUid> GetEntityUids() => Entities.Keys;
+
         /// <summary>
         /// Shuts-down and removes given Entity. This is also broadcast to all clients.
         /// </summary>

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -86,6 +86,12 @@ namespace Robust.Shared.GameObjects
         /// <returns></returns>
         IEnumerable<IEntity> GetEntities();
 
+        /// <summary>
+        /// Returns all entities by uid
+        /// </summary>
+        /// <returns></returns>
+        IEnumerable<EntityUid> GetEntityUids();
+
         public void QueueDeleteEntity(IEntity entity);
 
         public void QueueDeleteEntity(EntityUid uid);


### PR DESCRIPTION
This achieves rough feature parity with the original BQL. Must be merged simultaneously with it's corresponding content PR!
Part 2 (and beyond) will clean up the nasty hack that is how `forall` itself works and make BQL properly reusable. Substitutions are in but do not function
Docs TBD, happy to explain what's implemented, but i've got little time so part 2 may be a while.