### PR TITLE
Fix PVS crash

### DIFF
--- a/Robust.Server/GameStates/EntityViewCulling.cs
+++ b/Robust.Server/GameStates/EntityViewCulling.cs
@@ -460,6 +460,7 @@ namespace Robust.Server.GameStates
                 // PVS leave message
                 //TODO: Remove NaN as the signal to leave PVS
                 var oldState = (TransformComponent.TransformComponentState) xform.GetComponentState(session);
+                var mapEnt = _mapManager.GetMapEntityId(xform.MapID);
 
                 entityStates.Add(new EntityState(entityUid,
                     new[]
@@ -467,7 +468,7 @@ namespace Robust.Server.GameStates
                         ComponentChange.Changed(_transformNetId,
                             new TransformComponent.TransformComponentState(Vector2NaN,
                                 oldState.Rotation,
-                                oldState.ParentID,
+                                mapEnt,
                                 oldState.NoLocalRotation,
                                 oldState.Anchored)),
                     }));


### PR DESCRIPTION
Fixes https://github.com/space-wizards/RobustToolbox/issues/2135
Might fix https://github.com/space-wizards/space-station-14/issues/4995 but no stacktrace

The issue is that when the client gets sent a NaN state it assumes the client knows about the new parent, but because it never knows about an aghost this throws.

This will lead to additional re-parent events on the client but that's what you get for using NaN states Q.