### PR TITLE
Add tab "completion" for the server-side C# console

### DIFF
--- a/Robust.Client/Console/Completions.cs
+++ b/Robust.Client/Console/Completions.cs
@@ -37,10 +37,15 @@ namespace Robust.Client.Console
             ContentsContainer.AddChild(_suggestPanel);
         }
 
+        private bool _firstopen = true;
         public void OpenAt(Vector2 position, Vector2 size)
         {
-            SetSize = size;
-            LayoutContainer.SetPosition(this, position);
+            if (_firstopen)
+            {
+                SetSize = size;
+                LayoutContainer.SetPosition(this, position);
+                _firstopen = false;
+            }
             Open();
         }
 

--- a/Robust.Client/Console/Completions.cs
+++ b/Robust.Client/Console/Completions.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Immutable;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared.Input;
+using Robust.Shared.Maths;
+using Robust.Shared.Network.Messages;
+using Robust.Shared.Utility;
+using Robust.Shared.Scripting;
+using static Robust.Client.UserInterface.Controls.BoxContainer;
+using static Robust.Shared.Network.Messages.MsgScriptCompletionResponse;
+
+namespace Robust.Client.Console
+{
+    public class Completions : SS14Window
+    {
+        private HistoryLineEdit _textBar;
+        private ScrollContainer _suggestPanel = new()
+        {
+            HScrollEnabled = false,
+        };
+
+        private BoxContainer _suggestBox = new()
+        {
+            Orientation = LayoutOrientation.Vertical,
+            HorizontalAlignment = HAlignment.Left,
+        };
+
+        public Completions(HistoryLineEdit textBar) : base()
+        {
+            Title = "Suggestions";
+            MouseFilter = MouseFilterMode.Pass;
+
+            _textBar = textBar;
+            _suggestPanel.AddChild(_suggestBox);
+            ContentsContainer.AddChild(_suggestPanel);
+        }
+
+        public void OpenAt(Vector2 position, Vector2 size)
+        {
+            SetSize = size;
+            LayoutContainer.SetPosition(this, position);
+            Open();
+        }
+
+        private ImmutableArray<LiteResult> _results;
+
+        public void Update()
+        {
+            _suggestBox.RemoveAllChildren();
+            foreach (var res in _results)
+            {
+                var label = new Entry(res);
+
+                label.OnKeyBindDown += ev =>
+                {
+                    if (ev.Function == EngineKeyFunctions.UIClick)
+                        _textBar.InsertAtCursor(label.Result.Properties["InsertionText"]);
+                };
+
+                _suggestBox.AddChild(label);
+            }
+        }
+
+        public void TextChanged() => Close();
+
+        public void SetSuggestions(MsgScriptCompletionResponse response)
+        {
+            _results = response.Results;
+            Update();
+        }
+
+        // Label and ghetto button.
+        public class Entry : RichTextLabel
+        {
+            public readonly LiteResult Result;
+
+            public Entry(LiteResult result)
+            {
+                MouseFilter = MouseFilterMode.Stop;
+                Result = result;
+                var compl = new FormattedMessage();
+                var dim = Color.FromHsl((0f, 0f, 0.8f, 1f));
+
+                // warning: ew ahead
+                string basen = "default";
+                if (Result.Tags.Contains("Interface"))
+                    basen = "interface name";
+                else if (Result.Tags.Contains("Class"))
+                    basen = "class name";
+                else if (Result.Tags.Contains("Struct"))
+                    basen = "struct name";
+                else if (Result.Tags.Contains("Keyword"))
+                    basen = "keyword";
+                else if (Result.Tags.Contains("Namespace"))
+                    basen = "namespace name";
+                else if (Result.Tags.Contains("Method"))
+                    basen = "method name";
+                else if (Result.Tags.Contains("Property"))
+                    basen = "property name";
+                else if (Result.Tags.Contains("Field"))
+                    basen = "field name";
+
+                Color basec = ScriptInstanceShared.ColorScheme[basen];
+                compl.PushColor(basec * dim);
+                compl.AddText(Result.DisplayTextPrefix);
+                compl.PushColor(basec);
+                compl.AddText(Result.DisplayText);
+                compl.PushColor(basec * dim);
+                compl.AddText(Result.DisplayTextSuffix);
+                compl.AddText(" [" + String.Join(", ", Result.Tags) + "]");
+                if (Result.InlineDescription.Length != 0)
+                {
+                    compl.PushNewline();
+                    compl.AddText(": ");
+                    compl.PushColor(Color.LightSlateGray);
+                    compl.AddText(Result.InlineDescription);
+                }
+                SetMessage(compl);
+            }
+        }
+    }
+}

--- a/Robust.Client/Console/ScriptClient.ScriptConsoleServer.cs
+++ b/Robust.Client/Console/ScriptClient.ScriptConsoleServer.cs
@@ -46,6 +46,16 @@ namespace Robust.Client.Console
 
             }
 
+            protected override void Complete()
+            {
+                var msg = _client._netManager.CreateNetMessage<MsgScriptCompletion>();
+                msg.ScriptSession = _session;
+                msg.Code = InputBar.Text;
+                msg.Cursor = InputBar.CursorPosition;
+
+                _client._netManager.ClientSendMessage(msg);
+            }
+
             public override void Close()
             {
                 base.Close();
@@ -94,6 +104,12 @@ namespace Robust.Client.Console
                 OutputPanel.AddMessage(response.Response);
 
                 OutputPanel.AddText(">");
+            }
+
+            public void ReceiveCompletionResponse(MsgScriptCompletionResponse response)
+            {
+                Suggestions.SetSuggestions(response);
+                Suggestions.OpenAt((Position.X + Size.X, Position.Y), (Size.X / 2, Size.Y));
             }
         }
     }

--- a/Robust.Client/Console/ScriptClient.cs
+++ b/Robust.Client/Console/ScriptClient.cs
@@ -20,6 +20,8 @@ namespace Robust.Client.Console
             _netManager.RegisterNetMessage<MsgScriptStop>();
             _netManager.RegisterNetMessage<MsgScriptEval>();
             _netManager.RegisterNetMessage<MsgScriptStart>();
+            _netManager.RegisterNetMessage<MsgScriptCompletion>();
+            _netManager.RegisterNetMessage<MsgScriptCompletionResponse>(ReceiveScriptCompletionResponse);
             _netManager.RegisterNetMessage<MsgScriptResponse>(ReceiveScriptResponse);
             _netManager.RegisterNetMessage<MsgScriptStartAck>(ReceiveScriptStartAckResponse);
         }
@@ -42,6 +44,16 @@ namespace Robust.Client.Console
             }
 
             console.ReceiveResponse(message);
+        }
+
+        private void ReceiveScriptCompletionResponse(MsgScriptCompletionResponse message)
+        {
+            if (!_activeConsoles.TryGetValue(message.ScriptSession, out var console))
+            {
+                return;
+            }
+
+            console.ReceiveCompletionResponse(message);
         }
 
         public bool CanScript => _conGroupController.CanScript();

--- a/Robust.Client/Console/ScriptConsoleClient.cs
+++ b/Robust.Client/Console/ScriptConsoleClient.cs
@@ -53,6 +53,9 @@ namespace Robust.Client.Console
             OutputPanel.AddText(">");
         }
 
+        // No-op for now.
+        protected override void Complete() { }
+
         protected override async void Run()
         {
             var code = InputBar.Text;

--- a/Robust.Client/Input/EngineContexts.cs
+++ b/Robust.Client/Input/EngineContexts.cs
@@ -60,6 +60,7 @@ namespace Robust.Client.Input
             common.AddFunction(EngineKeyFunctions.TextReleaseFocus);
             common.AddFunction(EngineKeyFunctions.TextScrollToBottom);
             common.AddFunction(EngineKeyFunctions.TextDelete);
+            common.AddFunction(EngineKeyFunctions.TextTabComplete);
 
             var editor = contexts.New("editor", common);
             editor.AddFunction(EngineKeyFunctions.EditorLinePlace);

--- a/Robust.Client/UserInterface/Controls/LineEdit.cs
+++ b/Robust.Client/UserInterface/Controls/LineEdit.cs
@@ -48,6 +48,7 @@ namespace Robust.Client.UserInterface.Controls
         public event Action<LineEditEventArgs>? OnTextEntered;
         public event Action<LineEditEventArgs>? OnFocusEnter;
         public event Action<LineEditEventArgs>? OnFocusExit;
+        public event Action<LineEditEventArgs>? OnTabComplete;
 
         /// <summary>
         ///     Determines whether the LineEdit text gets changed by the input text.
@@ -522,6 +523,15 @@ namespace Robust.Client.UserInterface.Controls
                     ReleaseKeyboardFocus();
                     args.Handle();
                     return;
+                }
+                else if (args.Function == EngineKeyFunctions.TextTabComplete)
+                {
+                    if (Editable)
+                    {
+                        OnTabComplete?.Invoke(new LineEditEventArgs(this, _text));
+                    }
+
+                    args.Handle();
                 }
             }
             else

--- a/Robust.Client/UserInterface/CustomControls/ScriptConsole.cs
+++ b/Robust.Client/UserInterface/CustomControls/ScriptConsole.cs
@@ -1,6 +1,7 @@
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Maths;
+using Robust.Client.Console;
 using static Robust.Client.UserInterface.Controls.BoxContainer;
 
 namespace Robust.Client.UserInterface.CustomControls
@@ -10,6 +11,7 @@ namespace Robust.Client.UserInterface.CustomControls
         protected OutputPanel OutputPanel { get; }
         protected HistoryLineEdit InputBar { get; }
         protected Button RunButton { get; }
+        protected Completions Suggestions { get; }
 
         protected ScriptConsole()
         {
@@ -47,10 +49,15 @@ namespace Robust.Client.UserInterface.CustomControls
                 }
             });
 
+            Suggestions = new Completions(InputBar);
+            InputBar.OnTabComplete += _ => Complete();
+            InputBar.OnTextChanged += _ => Suggestions.TextChanged();
             InputBar.OnTextEntered += _ => Run();
             RunButton.OnPressed += _ => Run();
             MinSize = (550, 300);
         }
+
+        protected abstract void Complete();
 
         protected abstract void Run();
 

--- a/Robust.Server/Scripting/ScriptHost.cs
+++ b/Robust.Server/Scripting/ScriptHost.cs
@@ -1,12 +1,16 @@
+using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.CSharp.Scripting.Hosting;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.CodeAnalysis.Text;
 using Robust.Server.Console;
@@ -39,6 +43,8 @@ namespace Robust.Server.Scripting
             _netManager.RegisterNetMessage<MsgScriptStop>(ReceiveScriptEnd);
             _netManager.RegisterNetMessage<MsgScriptEval>(ReceiveScriptEval);
             _netManager.RegisterNetMessage<MsgScriptStart>(ReceiveScriptStart);
+            _netManager.RegisterNetMessage<MsgScriptCompletion>(ReceiveScriptCompletion);
+            _netManager.RegisterNetMessage<MsgScriptCompletionResponse>();
             _netManager.RegisterNetMessage<MsgScriptResponse>();
             _netManager.RegisterNetMessage<MsgScriptStartAck>();
 
@@ -234,6 +240,68 @@ namespace Robust.Server.Scripting
             }
 
             replyMessage.Response = msg;
+            _netManager.ServerSendMessage(replyMessage, message.MsgChannel);
+        }
+
+        private async void ReceiveScriptCompletion(MsgScriptCompletion message)
+        {
+            if (!_playerManager.TryGetSessionByChannel(message.MsgChannel, out var session))
+                return;
+
+            if (!_conGroupController.CanScript(session))
+            {
+                Logger.WarningS("script", "Client {0} tried to access Scripting without permissions.", session);
+                return;
+            }
+
+            if (!_instances.TryGetValue(session, out var instances) ||
+                !instances.TryGetValue(message.ScriptSession, out var instance))
+                    return;
+
+            var replyMessage = _netManager.CreateNetMessage<MsgScriptCompletionResponse>();
+            replyMessage.ScriptSession = message.ScriptSession;
+
+            // Everything below here cribbed from
+            // https://www.strathweb.com/2018/12/using-roslyn-c-completion-service-programmatically/
+            var workspace = new AdhocWorkspace(MefHostServices.Create(MefHostServices.DefaultAssemblies));
+
+            var scriptProject = workspace.AddProject(ProjectInfo.Create(
+                    ProjectId.CreateNewId(),
+                    VersionStamp.Create(),
+                    "Script", "Script",
+                    LanguageNames.CSharp,
+                    isSubmission: true
+                )
+                .WithMetadataReferences(
+                        _reflectionManager.Assemblies.Select(a => MetadataReference.CreateFromFile(a.Location))
+                )
+                .WithCompilationOptions(new CSharpCompilationOptions(
+                    OutputKind.DynamicallyLinkedLibrary,
+                    usings: ScriptInstanceShared.DefaultImports
+            )));
+
+            var document = workspace.AddDocument(DocumentInfo.Create(
+                DocumentId.CreateNewId(scriptProject.Id),
+                "Script",
+                sourceCodeKind: SourceCodeKind.Script,
+                loader: TextLoader.From(TextAndVersion.Create(SourceText.From(message.Code), VersionStamp.Create()))
+            ));
+
+            var results = await CompletionService
+                .GetService(document)
+                .GetCompletionsAsync(document, message.Cursor);
+
+            if (results is not null)
+            {
+                var ires = ImmutableArray.CreateBuilder<MsgScriptCompletionResponse.LiteResult>();
+                foreach  (var r in results.Items)
+                    ires.Add((MsgScriptCompletionResponse.LiteResult) r);
+
+                replyMessage.Results = ires.ToImmutable();
+            }
+            else
+                replyMessage.Results = ImmutableArray<MsgScriptCompletionResponse.LiteResult>.Empty;
+
             _netManager.ServerSendMessage(replyMessage, message.MsgChannel);
         }
 

--- a/Robust.Server/Scripting/ScriptHost.cs
+++ b/Robust.Server/Scripting/ScriptHost.cs
@@ -23,6 +23,7 @@ using Robust.Shared.Network.Messages;
 using Robust.Shared.Reflection;
 using Robust.Shared.Scripting;
 using Robust.Shared.Utility;
+using static Robust.Shared.Network.Messages.MsgScriptCompletionResponse;
 
 #nullable enable
 
@@ -293,14 +294,21 @@ namespace Robust.Server.Scripting
 
             if (results is not null)
             {
-                var ires = ImmutableArray.CreateBuilder<MsgScriptCompletionResponse.LiteResult>();
+                var ires = ImmutableArray.CreateBuilder<LiteResult>();
                 foreach  (var r in results.Items)
-                    ires.Add((MsgScriptCompletionResponse.LiteResult) r);
+                    ires.Add(new LiteResult(
+                                displayText: r.DisplayText,
+                                displayTextPrefix: r.DisplayTextPrefix,
+                                displayTextSuffix: r.DisplayTextSuffix,
+                                inlineDescription: r.InlineDescription,
+                                tags: r.Tags,
+                                properties: r.Properties
+                    ));
 
                 replyMessage.Results = ires.ToImmutable();
             }
             else
-                replyMessage.Results = ImmutableArray<MsgScriptCompletionResponse.LiteResult>.Empty;
+                replyMessage.Results = ImmutableArray<LiteResult>.Empty;
 
             _netManager.ServerSendMessage(replyMessage, message.MsgChannel);
         }

--- a/Robust.Shared.Scripting/ScriptInstanceShared.cs
+++ b/Robust.Shared.Scripting/ScriptInstanceShared.cs
@@ -28,7 +28,7 @@ namespace Robust.Shared.Scripting
         private static readonly Func<Script, bool> _hasReturnValue;
         private static readonly Func<Diagnostic, IReadOnlyList<object?>?> _getDiagnosticArguments;
 
-        private static readonly string[] _defaultImports =
+        public static readonly string[] DefaultImports =
         {
             "System",
             "System.Linq",
@@ -101,6 +101,24 @@ namespace Robust.Shared.Scripting
             return _getDiagnosticArguments(diag);
         }
 
+        public static readonly Dictionary<string, Color> ColorScheme = new()
+        {
+            {ClassificationTypeNames.ClassName, Color.FromHex("#4EC9B0")},
+            {ClassificationTypeNames.Comment, Color.FromHex("#57A64A")},
+            {ClassificationTypeNames.EnumName, Color.FromHex("#B8D7A3")},
+            {ClassificationTypeNames.FieldName, Color.FromHex("#C86E11")},
+            {ClassificationTypeNames.InterfaceName, Color.FromHex("#B8D7A3")},
+            {ClassificationTypeNames.Keyword, Color.FromHex("#569CD6")},
+            {ClassificationTypeNames.MethodName, Color.FromHex("#11A3C8")},
+            {ClassificationTypeNames.NamespaceName, Color.FromHex("#C8A611")},
+            {ClassificationTypeNames.NumericLiteral, Color.FromHex("#b5cea8")},
+            {ClassificationTypeNames.PropertyName, Color.FromHex("#11C89D")},
+            {ClassificationTypeNames.StaticSymbol, Color.FromHex("#4EC9B0")},
+            {ClassificationTypeNames.StringLiteral, Color.FromHex("#D69D85")},
+            {ClassificationTypeNames.StructName, Color.FromHex("#4EC9B0")},
+            {"default", Color.FromHex("#D4D4D4")},
+        };
+
         public static void AddWithSyntaxHighlighting(Script script, FormattedMessage msg, string code,
             Workspace workspace)
         {
@@ -126,19 +144,8 @@ namespace Robust.Shared.Scripting
                 // TODO: there are probably issues with multiple classifications overlapping the same text here.
                 // Too lazy to fix.
                 var src = code[span.TextSpan.Start..span.TextSpan.End];
-                var color = span.ClassificationType switch
-                {
-                    ClassificationTypeNames.Comment => Color.FromHex("#57A64A"),
-                    ClassificationTypeNames.NumericLiteral => Color.FromHex("#b5cea8"),
-                    ClassificationTypeNames.StringLiteral => Color.FromHex("#D69D85"),
-                    ClassificationTypeNames.Keyword => Color.FromHex("#569CD6"),
-                    ClassificationTypeNames.StaticSymbol => Color.FromHex("#4EC9B0"),
-                    ClassificationTypeNames.ClassName => Color.FromHex("#4EC9B0"),
-                    ClassificationTypeNames.StructName => Color.FromHex("#4EC9B0"),
-                    ClassificationTypeNames.InterfaceName => Color.FromHex("#B8D7A3"),
-                    ClassificationTypeNames.EnumName => Color.FromHex("#B8D7A3"),
-                    _ => Color.FromHex("#D4D4D4")
-                };
+                if (!ColorScheme.TryGetValue(span.ClassificationType, out var color))
+                        color = ColorScheme["default"];
 
                 msg.PushColor(color);
                 msg.AddText(src);
@@ -218,7 +225,7 @@ namespace Robust.Shared.Scripting
         public static ScriptOptions GetScriptOptions(IReflectionManager reflectionManager)
         {
             return ScriptOptions.Default
-                .AddImports(_defaultImports)
+                .AddImports(DefaultImports)
                 .AddReferences(GetDefaultReferences(reflectionManager));
         }
 

--- a/Robust.Shared/Input/KeyFunctions.cs
+++ b/Robust.Shared/Input/KeyFunctions.cs
@@ -69,6 +69,7 @@ namespace Robust.Shared.Input
         public static readonly BoundKeyFunction TextReleaseFocus = "TextReleaseFocus";
         public static readonly BoundKeyFunction TextScrollToBottom = "TextScrollToBottom";
         public static readonly BoundKeyFunction TextDelete = "TextDelete";
+        public static readonly BoundKeyFunction TextTabComplete = "TextTabComplete";
     }
 
     [Serializable, NetSerializable]

--- a/Robust.Shared/Network/Messages/MsgScriptCompletion.cs
+++ b/Robust.Shared/Network/Messages/MsgScriptCompletion.cs
@@ -1,0 +1,29 @@
+using Lidgren.Network;
+
+#nullable disable
+
+namespace Robust.Shared.Network.Messages
+{
+    public class MsgScriptCompletion : NetMessage
+    {
+        public override MsgGroups MsgGroup => MsgGroups.Command;
+
+        public int ScriptSession { get; set; }
+        public int Cursor { get; set; }
+        public string Code { get; set; }
+
+        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        {
+            ScriptSession = buffer.ReadInt32();
+            Cursor = buffer.ReadInt32();
+            Code = buffer.ReadString();
+        }
+
+        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        {
+            buffer.Write(ScriptSession);
+            buffer.Write(Cursor);
+            buffer.Write(Code);
+        }
+    }
+}

--- a/Robust.Shared/Network/Messages/MsgScriptCompletionResponse.cs
+++ b/Robust.Shared/Network/Messages/MsgScriptCompletionResponse.cs
@@ -1,0 +1,120 @@
+using System.Collections.Immutable;
+using System.IO;
+using Lidgren.Network;
+using Microsoft.CodeAnalysis.Completion;
+using Robust.Shared.IoC;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Network.Messages
+{
+    public class MsgScriptCompletionResponse : NetMessage
+    {
+        public override MsgGroups MsgGroup => MsgGroups.Command;
+
+        public int ScriptSession { get; set; }
+        public ImmutableArray<LiteResult> Results;
+
+        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        {
+            ScriptSession = buffer.ReadInt32()!;
+
+            var n = buffer.ReadInt32()!;
+            var cli = ImmutableArray.CreateBuilder<LiteResult>();
+            for (var i = 0; i < n; i++)
+            {
+                var lr = new LiteResult(buffer);
+                cli.Add(lr);
+            }
+            Results = cli.ToImmutable();
+        }
+
+        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        {
+            buffer.Write(ScriptSession);
+
+            buffer.Write(Results.Length);
+            foreach (var res in Results)
+                res.WriteToBuffer(buffer);
+        }
+
+        public class LiteResult {
+            public string DisplayText;
+            public string DisplayTextPrefix;
+            public string DisplayTextSuffix;
+
+            public string InlineDescription;
+
+            public ImmutableArray<string> Tags;
+            public ImmutableDictionary<string, string> Properties;
+
+            private LiteResult(
+                string displayText,
+                string displayTextPrefix,
+                string displayTextSuffix,
+                string inlineDescription,
+                ImmutableArray<string> tags,
+                ImmutableDictionary<string, string> properties
+            )
+            {
+                DisplayText = displayText;
+                DisplayTextPrefix = displayTextPrefix;
+                DisplayTextSuffix = displayTextSuffix;
+                InlineDescription = inlineDescription;
+
+                Tags = tags;
+                Properties = properties;
+            }
+
+            public LiteResult(NetIncomingMessage buffer)
+            {
+                DisplayText = buffer.ReadString()!;
+                DisplayTextPrefix = buffer.ReadString()!;
+                DisplayTextSuffix = buffer.ReadString()!;
+                InlineDescription = buffer.ReadString()!;
+
+                var n = buffer.ReadInt32()!;
+                var iab = ImmutableArray.CreateBuilder<string>();
+                for (var i = 0; i < n; i++)
+                    iab.Add(buffer.ReadString()!);
+
+                Tags = iab.ToImmutable()!;
+
+                n = buffer.ReadInt32()!;
+                var idb = ImmutableDictionary.CreateBuilder<string, string>();
+                for (var i = 0; i < n; i++)
+                    idb.Add(buffer.ReadString()!, buffer.ReadString()!);
+
+                Properties = idb.ToImmutable();
+            }
+
+            public void WriteToBuffer(NetOutgoingMessage buffer)
+            {
+                buffer.Write(DisplayText);
+                buffer.Write(DisplayTextPrefix);
+                buffer.Write(DisplayTextSuffix);
+                buffer.Write(InlineDescription);
+
+                buffer.Write(Tags.Length);
+                foreach (var e in Tags)
+                    buffer.Write(e);
+
+                buffer.Write(Properties.Count);
+                foreach (var e in Properties)
+                {
+                    buffer.Write(e.Key);
+                    buffer.Write(e.Value);
+                }
+            }
+
+            public static explicit operator LiteResult(CompletionItem ci) => new(
+                displayText: ci.DisplayText,
+                displayTextPrefix: ci.DisplayTextPrefix,
+                displayTextSuffix: ci.DisplayTextSuffix,
+                inlineDescription: ci.InlineDescription,
+                tags: ci.Tags,
+                properties: ci.Properties
+            );
+        }
+    }
+}

--- a/Robust.Shared/Network/Messages/MsgScriptCompletionResponse.cs
+++ b/Robust.Shared/Network/Messages/MsgScriptCompletionResponse.cs
@@ -1,10 +1,5 @@
 using System.Collections.Immutable;
-using System.IO;
 using Lidgren.Network;
-using Microsoft.CodeAnalysis.Completion;
-using Robust.Shared.IoC;
-using Robust.Shared.Serialization;
-using Robust.Shared.Utility;
 
 namespace Robust.Shared.Network.Messages
 {
@@ -48,7 +43,7 @@ namespace Robust.Shared.Network.Messages
             public ImmutableArray<string> Tags;
             public ImmutableDictionary<string, string> Properties;
 
-            private LiteResult(
+            public LiteResult(
                 string displayText,
                 string displayTextPrefix,
                 string displayTextSuffix,
@@ -106,15 +101,6 @@ namespace Robust.Shared.Network.Messages
                     buffer.Write(e.Value);
                 }
             }
-
-            public static explicit operator LiteResult(CompletionItem ci) => new(
-                displayText: ci.DisplayText,
-                displayTextPrefix: ci.DisplayTextPrefix,
-                displayTextSuffix: ci.DisplayTextSuffix,
-                inlineDescription: ci.InlineDescription,
-                tags: ci.Tags,
-                properties: ci.Properties
-            );
         }
     }
 }

--- a/Robust.Shared/Robust.Shared.csproj
+++ b/Robust.Shared/Robust.Shared.csproj
@@ -19,9 +19,6 @@
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="YamlDotNet" Version="9.1.4" />
     <PackageReference Include="System.Management" Version="5.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="3.8.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.8.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Lidgren.Network\Lidgren.Network.csproj" />

--- a/Robust.Shared/Robust.Shared.csproj
+++ b/Robust.Shared/Robust.Shared.csproj
@@ -19,6 +19,9 @@
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="YamlDotNet" Version="9.1.4" />
     <PackageReference Include="System.Management" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="3.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Lidgren.Network\Lidgren.Network.csproj" />


### PR DESCRIPTION
![Screenshot from 2021-10-29 08-48-21](https://user-images.githubusercontent.com/602406/139439172-2873463d-6210-46ca-9e6b-79c166d71665.png)

Note that it's not *exactly* like normal completion, as it suggests everything the current token _could be_.
i.e. `Robust.<Tab>` and `Robust.Ser<Tab>` will both produce `Shared` and `Server`. I assume that normal editors take the raw suggestion lists and filter them to things that only have some common subset with the current token, but this does not. That being said, it's unlikely that it would be difficult to add if so desired.

You can click on the entries to insert them at the cursor position. The above caveat still applies.

The functionality has not yet been ported to the client-side C# console.