### PR TITLE
Add ImageSharp's `Image.Load<>()` to the sandbox

### DIFF
--- a/Robust.Shared/ContentPack/Sandbox.yml
+++ b/Robust.Shared/ContentPack/Sandbox.yml
@@ -200,6 +200,7 @@ Types:
       - "int get_Height()"
       - "int get_Width()"
       - "SixLabors.ImageSharp.Formats.PixelTypeInfo get_PixelType()"
+      - "SixLabors.ImageSharp.Image`1<!!0> Load<>(System.IO.Stream)"
       - "void Dispose()"
     Image`1:
       Methods:


### PR DESCRIPTION
OpenDream will need to use this method to load & use an image's pixel data for creating a click map before turning it into a Clyde texture.