### PR TITLE
Makes client connection timeout a cvar

### DIFF
--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -98,6 +98,15 @@ namespace Robust.Shared
         public static readonly CVarDef<int> NetTickrate =
             CVarDef.Create("net.tickrate", 60, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
 
+        public static readonly CVarDef<float> ConnectionTimeout =
+            CVarDef.Create("net.connection_timeout", 25.0f, CVar.ARCHIVE | CVar.CLIENTONLY);
+
+        public static readonly CVarDef<float> ResendHandshakeInterval =
+            CVarDef.Create("net.handshake_interval", 3.0f, CVar.ARCHIVE | CVar.CLIENTONLY);
+            
+        public static readonly CVarDef<int> MaximumHandshakeAttempts =
+            CVarDef.Create("net.handshake_attempts", 5, CVar.ARCHIVE | CVar.CLIENTONLY);
+
         /**
          * SUS
          */

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -538,6 +538,12 @@ namespace Robust.Shared.Network
                 netConfig.SetMessageTypeEnabled(NetIncomingMessageType.ConnectionApproval, true);
                 netConfig.MaximumConnections = _config.GetCVar(CVars.GameMaxPlayers);
             }
+            else
+            {
+                netConfig.ConnectionTimeout = _config.GetCVar(CVars.ConnectionTimeout);
+                netConfig.ResendHandshakeInterval = _config.GetCVar(CVars.ResendHandshakeInterval);
+                netConfig.MaximumHandshakeAttempts = _config.GetCVar(CVars.MaximumHandshakeAttempts);
+            }
 
 
 #if DEBUG


### PR DESCRIPTION
See title. Useful for OpenDream as a bandaid for the connection issue. 

Cvar defaults match lidgren's default values.

Tested it and it seems to work.