### PR TITLE
Add WorldBounds as an arg for overlays

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -98,7 +98,7 @@ namespace Robust.Client.Graphics.Clyde
             SwapAllBuffers();
         }
 
-        private void RenderOverlays(Viewport vp, OverlaySpace space, in Box2 worldBox)
+        private void RenderOverlays(Viewport vp, OverlaySpace space, in Box2 worldBox, in Box2Rotated worldBounds)
         {
             using (DebugGroup($"Overlays: {space}"))
             {
@@ -116,7 +116,7 @@ namespace Robust.Client.Graphics.Clyde
                         ClearFramebuffer(default);
                     }
 
-                    overlay.ClydeRender(_renderHandle, space, null, vp, new UIBox2i((0, 0), vp.Size), worldBox);
+                    overlay.ClydeRender(_renderHandle, space, null, vp, new UIBox2i((0, 0), vp.Size), worldBox, worldBounds);
                 }
 
                 FlushRenderQueue();
@@ -132,8 +132,9 @@ namespace Robust.Client.Graphics.Clyde
         {
             var list = GetOverlaysForSpace(space);
 
-            var worldBounds = CalcWorldAABB(vp);
-            var args = new OverlayDrawArgs(space, vpControl, vp, handle, bounds, worldBounds);
+            var worldAABB = CalcWorldAABB(vp);
+            var worldBounds = CalcWorldBounds(vp);
+            var args = new OverlayDrawArgs(space, vpControl, vp, handle, bounds, worldAABB, worldBounds);
 
             foreach (var overlay in list)
             {
@@ -211,7 +212,7 @@ namespace Robust.Client.Graphics.Clyde
                 return;
             }
 
-            RenderOverlays(viewport, OverlaySpace.WorldSpaceBelowEntities, worldAABB);
+            RenderOverlays(viewport, OverlaySpace.WorldSpaceBelowEntities, worldAABB, worldBounds);
 
             var screenSize = viewport.Size;
             eye.GetViewMatrix(out var eyeMatrix, eye.Scale);
@@ -264,7 +265,8 @@ namespace Robust.Client.Graphics.Clyde
                             null,
                             viewport,
                             new UIBox2i((0, 0), viewport.Size),
-                            worldAABB);
+                            worldAABB,
+                            worldBounds);
                         overlayIndex = j;
                         continue;
                     }
@@ -471,7 +473,7 @@ namespace Robust.Client.Graphics.Clyde
                         DrawLightsAndFov(viewport, worldBounds, worldAABB, eye);
                     }
 
-                    RenderOverlays(viewport, OverlaySpace.WorldSpaceBelowWorld, worldAABB);
+                    RenderOverlays(viewport, OverlaySpace.WorldSpaceBelowWorld, worldAABB, worldBounds);
 
                     using (DebugGroup("Grids"))
                     {
@@ -484,7 +486,7 @@ namespace Robust.Client.Graphics.Clyde
                         DrawEntities(viewport, worldBounds, worldAABB, eye);
                     }
 
-                    RenderOverlays(viewport, OverlaySpace.WorldSpaceBelowFOV, worldAABB);
+                    RenderOverlays(viewport, OverlaySpace.WorldSpaceBelowFOV, worldAABB, worldBounds);
 
                     if (_lightManager.Enabled && _lightManager.DrawHardFov && eye.DrawFov)
                     {
@@ -517,7 +519,7 @@ namespace Robust.Client.Graphics.Clyde
                         UIBox2.FromDimensions(Vector2.Zero, viewport.Size), new Color(1, 1, 1, 0.5f));
                 }
 
-                RenderOverlays(viewport, OverlaySpace.WorldSpace, worldAABB);
+                RenderOverlays(viewport, OverlaySpace.WorldSpace, worldAABB, worldBounds);
 
                 _currentViewport = oldVp;
             });
@@ -529,7 +531,8 @@ namespace Robust.Client.Graphics.Clyde
             if (eye == null)
                 return default;
 
-            return GetAABB(eye, viewport);
+            // Will be larger than the actual viewport due to rotation.
+            return CalcWorldBounds(viewport).CalcBoundingBox();
         }
 
         private static Box2 GetAABB(IEye eye, Viewport viewport)

--- a/Robust.Client/Graphics/Overlays/Overlay.cs
+++ b/Robust.Client/Graphics/Overlays/Overlay.cs
@@ -84,7 +84,8 @@ namespace Robust.Client.Graphics
             IViewportControl? vpControl,
             IClydeViewport vp,
             in UIBox2i screenBox,
-            in Box2 worldBox)
+            in Box2 worldBox,
+            in Box2Rotated worldBounds)
         {
             DrawingHandleBase handle;
             if (currentSpace == OverlaySpace.ScreenSpace || currentSpace == OverlaySpace.ScreenSpaceBelowWorld)
@@ -97,7 +98,7 @@ namespace Robust.Client.Graphics
                 handle = renderHandle.DrawingHandleWorld;
             }
 
-            var args = new OverlayDrawArgs(currentSpace, vpControl, vp, handle, screenBox, worldBox);
+            var args = new OverlayDrawArgs(currentSpace, vpControl, vp, handle, screenBox, worldBox, worldBounds);
 
             Draw(args);
         }

--- a/Robust.Client/Graphics/Overlays/OverlayDrawArgs.cs
+++ b/Robust.Client/Graphics/Overlays/OverlayDrawArgs.cs
@@ -41,7 +41,12 @@ namespace Robust.Client.Graphics
         /// <summary>
         ///     AABB enclosing the area visible in the viewport.
         /// </summary>
-        public readonly Box2 WorldBounds;
+        public readonly Box2 WorldAABB;
+
+        /// <summary>
+        ///     <see cref="Box2Rotated"/> of the area visible in the viewport.
+        /// </summary>
+        public readonly Box2Rotated WorldBounds;
 
         public DrawingHandleScreen ScreenHandle => (DrawingHandleScreen) DrawingHandle;
         public DrawingHandleWorld WorldHandle => (DrawingHandleWorld) DrawingHandle;
@@ -52,13 +57,15 @@ namespace Robust.Client.Graphics
             IClydeViewport viewport,
             DrawingHandleBase drawingHandle,
             in UIBox2i viewportBounds,
-            in Box2 worldBounds)
+            in Box2 worldAabb,
+            in Box2Rotated worldBounds)
         {
             Space = space;
             ViewportControl = viewportControl;
             Viewport = viewport;
             DrawingHandle = drawingHandle;
             ViewportBounds = viewportBounds;
+            WorldAABB = worldAabb;
             WorldBounds = worldBounds;
         }
     }


### PR DESCRIPTION
This is a Box2Rotated. I also made it so WorldAABB is the enlarged bounding box and not just the un-rotated one. This means you'll get overdraw but this also fixes parallax (if you zoom out far enough you can see it clipping).

Content PR: https://github.com/space-wizards/space-station-14/pull/5128