### PR TITLE
Make transform delete entity if parent invalid

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -764,11 +764,10 @@ namespace Robust.Shared.GameObjects
                         {
                             if (!Owner.EntityManager.TryGetEntity(newParentId, out var newParent))
                             {
-                                var msg = $"Unable to find new parent {newParentId}! Deleting {Owner}";
 #if !EXCEPTION_TOLERANCE
-                                throw new InvalidOperationException(msg);
+                                throw new InvalidOperationException($"Unable to find new parent {newParentId}! This probably means the server never sent it.");
 #else
-                                Logger.ErrorS("transform", msg);
+                                Logger.ErrorS("transform", $"Unable to find new parent {newParentId}! Deleting {Owner}");
 #endif
                                 Owner.QueueDelete();
                                 return;

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -769,8 +769,8 @@ namespace Robust.Shared.GameObjects
 #else
                                 Logger.ErrorS("transform", $"Unable to find new parent {newParentId}! Deleting {Owner}");
                                 Owner.QueueDelete();
-#endif
                                 return;
+#endif
                             }
 
                             AttachParent(newParent.Transform);

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -768,8 +768,8 @@ namespace Robust.Shared.GameObjects
                                 throw new InvalidOperationException($"Unable to find new parent {newParentId}! This probably means the server never sent it.");
 #else
                                 Logger.ErrorS("transform", $"Unable to find new parent {newParentId}! Deleting {Owner}");
-#endif
                                 Owner.QueueDelete();
+#endif
                                 return;
                             }
 

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Robust.Shared.Animations;
 using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
+using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Players;
@@ -761,7 +762,13 @@ namespace Robust.Shared.GameObjects
                         }
                         else
                         {
-                            var newParent = Owner.EntityManager.GetEntity(newParentId);
+                            if (!Owner.EntityManager.TryGetEntity(newParentId, out var newParent))
+                            {
+                                Logger.ErrorS("transform", $"Unable to find new parent {newParentId}! Deleting {Owner}");
+                                Owner.QueueDelete();
+                                return;
+                            }
+
                             AttachParent(newParent.Transform);
                         }
                     }

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -765,6 +765,7 @@ namespace Robust.Shared.GameObjects
                             if (!Owner.EntityManager.TryGetEntity(newParentId, out var newParent))
                             {
                                 Logger.ErrorS("transform", $"Unable to find new parent {newParentId}! Deleting {Owner}");
+                                DebugTools.Assert(false);
                                 Owner.QueueDelete();
                                 return;
                             }

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -764,8 +764,12 @@ namespace Robust.Shared.GameObjects
                         {
                             if (!Owner.EntityManager.TryGetEntity(newParentId, out var newParent))
                             {
-                                Logger.ErrorS("transform", $"Unable to find new parent {newParentId}! Deleting {Owner}");
-                                DebugTools.Assert(false);
+                                var msg = $"Unable to find new parent {newParentId}! Deleting {Owner}";
+#if !EXCEPTION_TOLERANCE
+                                throw new InvalidOperationException(msg);
+#else
+                                Logger.ErrorS("transform", msg);
+#endif
                                 Owner.QueueDelete();
                                 return;
                             }


### PR DESCRIPTION
These days this pretty much only happens if PVS didn't send the parent (and we know of a circumstance in which it doesn't where the new parent for the NaN state has never been seen). Right now this just floods the log with errors every tick and hammers client performance so this hopefully handle those situations well enough that the game is playable.

I playtested the 2 situations I knew about that cause the PVS issue: Admin picking up item and using the cursed locker.