### PR TITLE
Significantly optimise server when PVS disabled

### DIFF
--- a/Robust.Server/GameStates/IServerGameStateManager.cs
+++ b/Robust.Server/GameStates/IServerGameStateManager.cs
@@ -15,7 +15,6 @@ namespace Robust.Server.GameStates
         /// </summary>
         void SendGameStateUpdate();
 
-        bool PvsEnabled { get; set; }
         float PvsRange { get; set; }
         void SetTransformNetId(ushort netId);
     }

--- a/Robust.Server/GameStates/PVSSystem.Dirty.cs
+++ b/Robust.Server/GameStates/PVSSystem.Dirty.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Robust.Server.Player;
+using Robust.Shared.Enums;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Log;
+using Robust.Shared.Timing;
+
+namespace Robust.Server.GameStates
+{
+    /// <summary>
+    /// Caching for dirty bodies
+    /// </summary>
+    internal partial class PVSSystem
+    {
+        private const int DirtyBufferSize = 4;
+
+        /// <summary>
+        /// if it's a new entity we need to GetEntityState from tick 0.
+        /// </summary>
+        private HashSet<EntityUid>[] _addEntities = new HashSet<EntityUid>[DirtyBufferSize];
+        private HashSet<EntityUid>[] _dirtyEntities = new HashSet<EntityUid>[DirtyBufferSize];
+        private int _currentIndex = 0;
+
+        private void InitializeDirty()
+        {
+            for (var i = 0; i < DirtyBufferSize; i++)
+            {
+                _addEntities[i] = new HashSet<EntityUid>(32);
+                _dirtyEntities[i] = new HashSet<EntityUid>(32);
+            }
+        }
+
+        private void OnEntityInit(object? sender, EntityUid e)
+        {
+            _addEntities[_currentIndex].Add(e);
+        }
+
+        private void OnDirty(ref EntityDirtyEvent ev)
+        {
+            if (_addEntities[_currentIndex].Contains(ev.Uid) ||
+                EntityManager.GetComponent<MetaDataComponent>(ev.Uid).EntityLifeStage < EntityLifeStage.Initialized) return;
+
+            _dirtyEntities[_currentIndex].Add(ev.Uid);
+        }
+
+        private void CleanupDirty(IEnumerable<IPlayerSession> sessions)
+        {
+            _currentIndex = (_currentIndex + 1) % DirtyBufferSize;
+            _addEntities[_currentIndex].Clear();
+            _dirtyEntities[_currentIndex].Clear();
+
+            if (!CullingEnabled)
+            {
+                foreach (var player in sessions)
+                {
+                    if (player.Status != SessionStatus.InGame)
+                    {
+                        _oldPlayers.Remove(player);
+                    }
+                    else
+                    {
+                        _oldPlayers.Add(player);
+                    }
+                }
+            }
+        }
+
+        private bool TryGetTick(GameTick tick, [NotNullWhen(true)] out HashSet<EntityUid>? addEntities, [NotNullWhen(true)] out HashSet<EntityUid>? dirtyEntities)
+        {
+            var currentTick = _gameTiming.CurTick;
+            if (currentTick.Value - tick.Value >= DirtyBufferSize)
+            {
+                addEntities = null;
+                dirtyEntities = null;
+                return false;
+            }
+
+            var index = tick.Value % DirtyBufferSize;
+            if (index > _dirtyEntities.Length - 1)
+            {
+                addEntities = null;
+                dirtyEntities = null;
+                return false;
+            }
+
+            addEntities = _addEntities[index];
+            dirtyEntities = _dirtyEntities[index];
+            return true;
+        }
+    }
+}

--- a/Robust.Server/GameStates/PVSSystem.Dirty.cs
+++ b/Robust.Server/GameStates/PVSSystem.Dirty.cs
@@ -3,7 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using Robust.Server.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
-using Robust.Shared.Log;
 using Robust.Shared.Timing;
 
 namespace Robust.Server.GameStates
@@ -20,7 +19,7 @@ namespace Robust.Server.GameStates
         /// </summary>
         private HashSet<EntityUid>[] _addEntities = new HashSet<EntityUid>[DirtyBufferSize];
         private HashSet<EntityUid>[] _dirtyEntities = new HashSet<EntityUid>[DirtyBufferSize];
-        private int _currentIndex = 0;
+        private int _currentIndex = 1;
 
         private void InitializeDirty()
         {
@@ -31,7 +30,7 @@ namespace Robust.Server.GameStates
             }
         }
 
-        private void OnEntityInit(object? sender, EntityUid e)
+        private void OnEntityAdd(object? sender, EntityUid e)
         {
             _addEntities[_currentIndex].Add(e);
         }

--- a/Robust.Server/GameStates/PVSSystem.Dirty.cs
+++ b/Robust.Server/GameStates/PVSSystem.Dirty.cs
@@ -4,6 +4,7 @@ using Robust.Server.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Robust.Server.GameStates
 {
@@ -32,6 +33,7 @@ namespace Robust.Server.GameStates
 
         private void OnEntityAdd(object? sender, EntityUid e)
         {
+            DebugTools.Assert(_currentIndex == _gameTiming.CurTick.Value % DirtyBufferSize);
             _addEntities[_currentIndex].Add(e);
         }
 
@@ -45,7 +47,8 @@ namespace Robust.Server.GameStates
 
         private void CleanupDirty(IEnumerable<IPlayerSession> sessions)
         {
-            _currentIndex = (_currentIndex + 1) % DirtyBufferSize;
+            // Just in case we desync somehow
+            _currentIndex = ((int) _gameTiming.CurTick.Value + 1) % DirtyBufferSize;
             _addEntities[_currentIndex].Clear();
             _dirtyEntities[_currentIndex].Clear();
 

--- a/Robust.Server/GameStates/PVSSystem.States.cs
+++ b/Robust.Server/GameStates/PVSSystem.States.cs
@@ -65,7 +65,7 @@ namespace Robust.Server.GameStates
         /// <summary>
         ///     Gets all entity states that have been modified after and including the provided tick.
         /// </summary>
-        private List<EntityState>? GetAllEntityStates(ICommonSession player, GameTick fromTick)
+        private List<EntityState>? GetAllEntityStates(ICommonSession player, GameTick fromTick, GameTick toTick)
         {
             List<EntityState> stateEntities;
 

--- a/Robust.Server/GameStates/PVSSystem.States.cs
+++ b/Robust.Server/GameStates/PVSSystem.States.cs
@@ -1,0 +1,120 @@
+using System.Collections.Generic;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Players;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Robust.Server.GameStates
+{
+    internal partial class PVSSystem
+    {
+        /// <summary>
+        /// Keep around a cache of players who don't need every entity state dumped on them where culling disabled.
+        /// </summary>
+        private HashSet<ICommonSession> _oldPlayers = new();
+
+        /// <summary>
+        /// Generates a network entity state for the given entity.
+        /// </summary>
+        /// <param name="player">The player to generate this state for.</param>
+        /// <param name="entityUid">Uid of the entity to generate the state from.</param>
+        /// <param name="fromTick">Only provide delta changes from this tick.</param>
+        /// <returns>New entity State for the given entity.</returns>
+        private EntityState GetEntityState(ICommonSession player, EntityUid entityUid, GameTick fromTick)
+        {
+            var bus = _entMan.EventBus;
+            var changed = new List<ComponentChange>();
+
+            foreach (var (netId, component) in _entMan.GetNetComponents(entityUid))
+            {
+                DebugTools.Assert(component.Initialized);
+
+                // NOTE: When LastModifiedTick or CreationTick are 0 it means that the relevant data is
+                // "not different from entity creation".
+                // i.e. when the client spawns the entity and loads the entity prototype,
+                // the data it deserializes from the prototype SHOULD be equal
+                // to what the component state / ComponentChange would send.
+                // As such, we can avoid sending this data in this case since the client "already has it".
+
+                DebugTools.Assert(component.LastModifiedTick >= component.CreationTick);
+
+                if (component.CreationTick != GameTick.Zero && component.CreationTick >= fromTick && !component.Deleted)
+                {
+                    ComponentState? state = null;
+                    if (component.NetSyncEnabled && component.LastModifiedTick != GameTick.Zero && component.LastModifiedTick >= fromTick)
+                        state = _entMan.GetComponentState(bus, component, player);
+
+                    // Can't be null since it's returned by GetNetComponents
+                    // ReSharper disable once PossibleInvalidOperationException
+                    changed.Add(ComponentChange.Added(netId, state));
+                }
+                else if (component.NetSyncEnabled && component.LastModifiedTick != GameTick.Zero && component.LastModifiedTick >= fromTick)
+                {
+                    changed.Add(ComponentChange.Changed(netId, _entMan.GetComponentState(bus, component, player)));
+                }
+            }
+
+            foreach (var netId in _entMan.GetDeletedComponents(entityUid, fromTick))
+            {
+                changed.Add(ComponentChange.Removed(netId));
+            }
+
+            return new EntityState(entityUid, changed.ToArray());
+        }
+
+        /// <summary>
+        ///     Gets all entity states that have been modified after and including the provided tick.
+        /// </summary>
+        private List<EntityState>? GetAllEntityStates(ICommonSession player, GameTick fromTick)
+        {
+            List<EntityState> stateEntities;
+
+            if (_oldPlayers.Contains(player) && TryGetTick(fromTick, out var add, out var dirty))
+            {
+                stateEntities = new List<EntityState>(add.Count + dirty.Count);
+
+                foreach (var uid in add)
+                {
+                    if (!_entMan.TryGetEntity(uid, out var entity) || entity.Deleted) continue;
+
+                    DebugTools.Assert(entity.Initialized);
+
+                    if (entity.LastModifiedTick >= fromTick)
+                        stateEntities.Add(GetEntityState(player, entity.Uid, GameTick.Zero));
+                }
+
+                foreach (var uid in dirty)
+                {
+                    DebugTools.Assert(!add.Contains(uid));
+
+                    if (!_entMan.TryGetEntity(uid, out var entity) || entity.Deleted) continue;
+
+                    DebugTools.Assert(entity.Initialized);
+
+                    if (entity.LastModifiedTick >= fromTick)
+                        stateEntities.Add(GetEntityState(player, entity.Uid, fromTick));
+                }
+
+                return stateEntities.Count == 0 ? default : stateEntities;
+            }
+
+            stateEntities = new List<EntityState>(EntityManager.EntityCount);
+
+            foreach (var entity in _entMan.GetEntities())
+            {
+                if (entity.Deleted)
+                {
+                    continue;
+                }
+
+                DebugTools.Assert(entity.Initialized);
+
+                if (entity.LastModifiedTick >= fromTick)
+                    stateEntities.Add(GetEntityState(player, entity.Uid, fromTick));
+            }
+
+            // no point sending an empty collection
+            return stateEntities.Count == 0 ? default : stateEntities;
+        }
+    }
+}

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -112,6 +112,7 @@ namespace Robust.Server.GameStates
         {
             base.Initialize();
             EntityManager.EntityDeleted += OnEntityDelete;
+            EntityManager.EntityAdded += OnEntityAdd;
             _playerManager.PlayerStatusChanged += OnPlayerStatusChange;
             _mapManager.OnGridRemoved += OnGridRemoved;
 
@@ -121,7 +122,6 @@ namespace Robust.Server.GameStates
             _configManager.OnValueChanged(CVars.StreamedTileRange, SetStreamRange, true);
             _configManager.OnValueChanged(CVars.NetPVS, SetPvs, true);
 
-            EntityManager.EntityInitialized += OnEntityInit;
             SubscribeLocalEvent<EntityDirtyEvent>(OnDirty);
 
             InitializeDirty();
@@ -151,6 +151,7 @@ namespace Robust.Server.GameStates
         {
             base.Shutdown();
             EntityManager.EntityDeleted -= OnEntityDelete;
+            EntityManager.EntityAdded -= OnEntityAdd;
             _playerManager.PlayerStatusChanged -= OnPlayerStatusChange;
             _mapManager.OnGridRemoved -= OnGridRemoved;
             _configManager.UnsubValueChanged(CVars.StreamedTileRange, SetStreamRange);
@@ -242,7 +243,7 @@ namespace Robust.Server.GameStates
             List<EntityUid>? deletions;
             if (!CullingEnabled)
             {
-                var allStates = GetAllEntityStates(session, fromTick);
+                var allStates = GetAllEntityStates(session, fromTick, toTick);
                 deletions = GetDeletedEntities(fromTick);
                 _playerLastFullMap.AddOrUpdate(session, toTick, (_, _) => toTick);
                 return (allStates, deletions);

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Composition;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.ObjectPool;
 using Robust.Server.GameObjects;
@@ -18,7 +17,7 @@ using Robust.Shared.Utility;
 
 namespace Robust.Server.GameStates
 {
-    internal sealed class PVSSystem : EntitySystem
+    internal sealed partial class PVSSystem : EntitySystem
     {
         private const int ViewSetCapacity = 256; // starting number of entities that are in view
         private const int PlayerSetSize = 64; // Starting number of players
@@ -120,11 +119,32 @@ namespace Robust.Server.GameStates
             // plus invalidate any chunks currently being streamed as well.
             StreamingTilesPerTick = (int) (_configManager.GetCVar(CVars.StreamedTilesPerSecond) / _gameTiming.TickRate);
             _configManager.OnValueChanged(CVars.StreamedTileRange, SetStreamRange, true);
+            _configManager.OnValueChanged(CVars.NetPVS, SetPvs, true);
+
+            EntityManager.EntityInitialized += OnEntityInit;
+            SubscribeLocalEvent<EntityDirtyEvent>(OnDirty);
+
+            InitializeDirty();
+        }
+
+        public void Cleanup(IEnumerable<IPlayerSession> sessions)
+        {
+            CleanupDirty(sessions);
         }
 
         private void SetStreamRange(float value)
         {
             StreamRange = value;
+        }
+
+        private void SetPvs(bool value)
+        {
+            CullingEnabled = value;
+
+            if (CullingEnabled)
+            {
+                _oldPlayers.Clear();
+            }
         }
 
         public override void Shutdown()
@@ -134,6 +154,7 @@ namespace Robust.Server.GameStates
             _playerManager.PlayerStatusChanged -= OnPlayerStatusChange;
             _mapManager.OnGridRemoved -= OnGridRemoved;
             _configManager.UnsubValueChanged(CVars.StreamedTileRange, SetStreamRange);
+            _configManager.UnsubValueChanged(CVars.NetPVS, SetPvs);
         }
 
         private void OnGridRemoved(MapId mapid, GridId gridid)
@@ -181,6 +202,7 @@ namespace Robust.Server.GameStates
             _playerChunks.Remove(session);
             _playerLastFullMap.Remove(session, out _);
             _streamingChunks.Remove(session);
+            _oldPlayers.Remove(session);
         }
 
         #endregion
@@ -220,7 +242,7 @@ namespace Robust.Server.GameStates
             List<EntityUid>? deletions;
             if (!CullingEnabled)
             {
-                var allStates = ServerGameStateManager.GetAllEntityStates(_entMan, session, fromTick);
+                var allStates = GetAllEntityStates(session, fromTick);
                 deletions = GetDeletedEntities(fromTick);
                 _playerLastFullMap.AddOrUpdate(session, toTick, (_, _) => toTick);
                 return (allStates, deletions);
@@ -355,7 +377,7 @@ namespace Robust.Server.GameStates
                         if (ent.LastModifiedTick < lastSeenChunk)
                             return;
 
-                        var newState = ServerGameStateManager.GetEntityState(_entMan, session, uid, lastSeenChunk);
+                        var newState = GetEntityState(session, uid, lastSeenChunk);
                         entityStates.Add(newState);
                     });
 
@@ -390,7 +412,7 @@ namespace Robust.Server.GameStates
 
                         foreach (var anchoredEnt in chunk.GetSnapGridCell(x, y))
                         {
-                            var newState = ServerGameStateManager.GetEntityState(_entMan, session, anchoredEnt, GameTick.Zero);
+                            var newState = GetEntityState(session, anchoredEnt, GameTick.Zero);
                             entityStates.Add(newState);
                         }
                     }
@@ -512,7 +534,7 @@ namespace Robust.Server.GameStates
                         continue;
 
                     // only send new changes
-                    var newState = ServerGameStateManager.GetEntityState(_entMan, session, entityUid, fromTick);
+                    var newState = GetEntityState(session, entityUid, fromTick);
 
                     if (!newState.Empty)
                         entityStates.Add(newState);
@@ -522,7 +544,7 @@ namespace Robust.Server.GameStates
                     // PVS enter message
 
                     // don't assume the client knows anything about us
-                    var newState = ServerGameStateManager.GetEntityState(_entMan, session, entityUid, GameTick.Zero);
+                    var newState = GetEntityState(session, entityUid, GameTick.Zero);
                     entityStates.Add(newState);
                 }
             }

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -133,7 +133,6 @@ namespace Robust.Server.GameStates
 
             var mainThread = Thread.CurrentThread;
             var parentDeps = IoCManager.Instance!;
-            var players = _playerManager.GetAllPlayers().Where(o => o.Status == SessionStatus.InGame).ToList();
 
             void SendStateUpdate(IPlayerSession session)
             {
@@ -185,7 +184,7 @@ namespace Robust.Server.GameStates
                 _networkManager.ServerSendMessage(stateUpdateMessage, channel);
             }
 
-            Parallel.ForEach(players, session =>
+            Parallel.ForEach(_playerManager.GetAllPlayers(), session =>
             {
                 try
                 {
@@ -197,7 +196,7 @@ namespace Robust.Server.GameStates
                 }
             });
 
-            _pvs.Cleanup(players);
+            _pvs.Cleanup(_playerManager.GetAllPlayers());
             var oldestAck = new GameTick(oldestAckValue);
 
             // keep the deletion history buffers clean

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -124,6 +124,7 @@ namespace Robust.Server.GameStates
                 _entityManager.CullDeletionHistory(GameTick.MaxValue);
                 _pvs.CullDeletionHistory(GameTick.MaxValue);
                 _mapManager.CullDeletionHistory(GameTick.MaxValue);
+                _pvs.Cleanup(_playerManager.GetAllPlayers());
                 return;
             }
 

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -41,12 +42,6 @@ namespace Robust.Server.GameStates
         [Dependency] private readonly IConfigurationManager _configurationManager = default!;
 
         private ISawmill _logger = default!;
-
-        public bool PvsEnabled
-        {
-            get => _configurationManager.GetCVar(CVars.NetPVS);
-            set => _configurationManager.SetCVar(CVars.NetPVS, value);
-        }
 
         public float PvsRange
         {
@@ -122,7 +117,6 @@ namespace Robust.Server.GameStates
             DebugTools.Assert(_networkManager.IsServer);
 
             _pvs.ViewSize = PvsRange * 2;
-            _pvs.CullingEnabled = PvsEnabled;
 
             if (!_networkManager.IsConnected)
             {
@@ -139,6 +133,7 @@ namespace Robust.Server.GameStates
 
             var mainThread = Thread.CurrentThread;
             var parentDeps = IoCManager.Instance!;
+            var players = _playerManager.GetAllPlayers().Where(o => o.Status == SessionStatus.InGame).ToList();
 
             void SendStateUpdate(IPlayerSession session)
             {
@@ -190,7 +185,7 @@ namespace Robust.Server.GameStates
                 _networkManager.ServerSendMessage(stateUpdateMessage, channel);
             }
 
-            Parallel.ForEach(_playerManager.GetAllPlayers(), session =>
+            Parallel.ForEach(players, session =>
             {
                 try
                 {
@@ -202,6 +197,7 @@ namespace Robust.Server.GameStates
                 }
             });
 
+            _pvs.Cleanup(players);
             var oldestAck = new GameTick(oldestAckValue);
 
             // keep the deletion history buffers clean
@@ -212,79 +208,6 @@ namespace Robust.Server.GameStates
                 _pvs.CullDeletionHistory(oldestAck);
                 _mapManager.CullDeletionHistory(oldestAck);
             }
-        }
-
-        /// <summary>
-        /// Generates a network entity state for the given entity.
-        /// </summary>
-        /// <param name="entMan">EntityManager that contains the entity.</param>
-        /// <param name="player">The player to generate this state for.</param>
-        /// <param name="entityUid">Uid of the entity to generate the state from.</param>
-        /// <param name="fromTick">Only provide delta changes from this tick.</param>
-        /// <returns>New entity State for the given entity.</returns>
-        internal static EntityState GetEntityState(IServerEntityManager entMan, ICommonSession player, EntityUid entityUid, GameTick fromTick)
-        {
-            var bus = entMan.EventBus;
-            var changed = new List<ComponentChange>();
-
-            foreach (var (netId, component) in entMan.GetNetComponents(entityUid))
-            {
-                DebugTools.Assert(component.Initialized);
-
-                // NOTE: When LastModifiedTick or CreationTick are 0 it means that the relevant data is
-                // "not different from entity creation".
-                // i.e. when the client spawns the entity and loads the entity prototype,
-                // the data it deserializes from the prototype SHOULD be equal
-                // to what the component state / ComponentChange would send.
-                // As such, we can avoid sending this data in this case since the client "already has it".
-
-                DebugTools.Assert(component.LastModifiedTick >= component.CreationTick);
-
-                if (component.CreationTick != GameTick.Zero && component.CreationTick >= fromTick && !component.Deleted)
-                {
-                    ComponentState? state = null;
-                    if (component.NetSyncEnabled && component.LastModifiedTick != GameTick.Zero && component.LastModifiedTick >= fromTick)
-                        state = entMan.GetComponentState(bus, component, player);
-
-                    // Can't be null since it's returned by GetNetComponents
-                    // ReSharper disable once PossibleInvalidOperationException
-                    changed.Add(ComponentChange.Added(netId, state));
-                }
-                else if (component.NetSyncEnabled && component.LastModifiedTick != GameTick.Zero && component.LastModifiedTick >= fromTick)
-                {
-                    changed.Add(ComponentChange.Changed(netId, entMan.GetComponentState(bus, component, player)));
-                }
-            }
-
-            foreach (var netId in entMan.GetDeletedComponents(entityUid, fromTick))
-            {
-                changed.Add(ComponentChange.Removed(netId));
-            }
-
-            return new EntityState(entityUid, changed.ToArray());
-        }
-
-        /// <summary>
-        ///     Gets all entity states that have been modified after and including the provided tick.
-        /// </summary>
-        internal static List<EntityState>? GetAllEntityStates(IServerEntityManager entityMan, ICommonSession player, GameTick fromTick)
-        {
-            var stateEntities = new List<EntityState>();
-            foreach (var entity in entityMan.GetEntities())
-            {
-                if (entity.Deleted)
-                {
-                    continue;
-                }
-
-                DebugTools.Assert(entity.Initialized);
-
-                if (entity.LastModifiedTick >= fromTick)
-                    stateEntities.Add(GetEntityState(entityMan, player, entity.Uid, fromTick));
-            }
-
-            // no point sending an empty collection
-            return stateEntities.Count == 0 ? default : stateEntities;
         }
     }
 }

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -222,6 +222,9 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <inheritdoc />
+        public int EntityCount => Entities.Count;
+
+        /// <inheritdoc />
         public IEnumerable<IEntity> GetEntities() => Entities.Values;
 
         public IEnumerable<EntityUid> GetEntityUids() => Entities.Keys;

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -81,6 +81,11 @@ namespace Robust.Shared.GameObjects
         bool TryGetEntity(EntityUid uid, [NotNullWhen(true)] out IEntity? entity);
 
         /// <summary>
+        /// How many entities are currently active.
+        /// </summary>
+        int EntityCount { get; }
+
+        /// <summary>
         /// Returns all entities
         /// </summary>
         /// <returns></returns>
@@ -91,7 +96,7 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         /// <returns></returns>
         IEnumerable<EntityUid> GetEntityUids();
-        
+
         public void DirtyEntity(EntityUid uid);
 
         public void QueueDeleteEntity(IEntity entity);


### PR DESCRIPTION
It's significantly faster than with culling enabled now (I got up to 10x faster with an "idle" server and 40 dummy clients).

tl;dr is that we keep a ringbuffer of dirty entities and (after the first time the client has everything dumped on them) use that to determine what to send them that tick instead of iterating every entity. The multi-threading overhead probably overshadows it now.

The dirty ringbuffer will probably also be useful for future PVS work hence why I didn't disable it when culling is enabled.

I also moved some more ServerGameStateManager stuff to PVS and added some partials for it to make it actually digestable.

Resolves https://github.com/space-wizards/RobustToolbox/issues/2195