### PR TITLE
Add function to directly perform lookups using an `EntityLookupComponent`

### DIFF
--- a/Robust.Shared/GameObjects/Systems/EntityLookup.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.cs
@@ -398,7 +398,6 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public void FastEntitiesIntersecting(EntityLookupComponent lookup, ref Box2 localAABB, EntityQueryCallback callback)
         {
             lookup.Tree._b2Tree.FastQuery(ref localAABB, (ref IEntity data) => callback(data));

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.cs
@@ -54,6 +54,8 @@ namespace Robust.Shared.GameObjects
         IEnumerable<IEntity> GetEntitiesIntersecting(MapId mapId, Vector2 position, LookupFlags flags = LookupFlags.IncludeAnchored);
 
         void FastEntitiesIntersecting(in MapId mapId, ref Box2 worldAABB, EntityQueryCallback callback, LookupFlags flags = LookupFlags.IncludeAnchored);
+        
+        void FastEntitiesIntersecting(EntityLookupComponent lookup, ref Box2 localAABB, EntityQueryCallback callback);
 
         IEnumerable<IEntity> GetEntitiesInRange(EntityCoordinates position, float range, LookupFlags flags = LookupFlags.IncludeAnchored);
 
@@ -393,6 +395,13 @@ namespace Robust.Shared.GameObjects
                     }
                 }
             }
+        }
+
+        /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        public void FastEntitiesIntersecting(EntityLookupComponent lookup, ref Box2 localAABB, EntityQueryCallback callback)
+        {
+            lookup.Tree._b2Tree.FastQuery(ref localAABB, (ref IEntity data) => callback(data));
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
This adds a variant of `EntityLookup.FastEntitiesIntersecting` that directly uses a given `EntityLookupComponent` instead of calling `GetLookupsIntersecting()`. Useful if you need to do a large number of lookups on a known grid w/o having to do the whole grid-intersections calculation in `GetLookupsIntersecting` for each tile.

Alternatively, if `EntityLookupComponent.Tree` were public instead of internal I could just query that directly, but I assume setting that to internal was intentional to stop content monkeys like myself from somehow messing up the tree by directly modifying it.

Opening this PR as it would be nice to have for a content PR that I'll open a draft of sometime today or tomorrow. Otherwise, I don't really know if there is actually a need for this, especially if QueurySystem or whatever comes along.