### PR TITLE
Fixes ViewVariables sprite rotation bug

### DIFF
--- a/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceEntity.cs
+++ b/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceEntity.cs
@@ -116,7 +116,7 @@ namespace Robust.Client.ViewVariables.Instances
                     };
                     top.HorizontalExpand = true;
                     hBox.AddChild(top);
-                    hBox.AddChild(new SpriteView {Sprite = sprite});
+                    hBox.AddChild(new SpriteView {Sprite = sprite, OverrideDirection = Direction.South});
                     vBoxContainer.AddChild(hBox);
                 }
                 else


### PR DESCRIPTION
View Variables displays the sprite of the item you're VVing, but that sprite was rotated based on the station's rotation relative to the world rotation. This PR fixes that issue.