### PR TITLE
Shared/GameObjects: Apply grid's rotational velocity when leaving

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using Robust.Shared.Utility;
+using Robust.Shared.Maths;
 using Robust.Shared.Containers;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
@@ -61,29 +63,50 @@ namespace Robust.Shared.GameObjects
             }
 
             var mapPos = moveEvent.NewPosition.ToMapPos(EntityManager);
+            (IEntity newParent, GridId newGrid)? dat = default;
 
             // Change parent if necessary
             if (_mapManager.TryFindGridAt(transform.MapID, mapPos, out var grid) &&
                 EntityManager.TryGetEntity(grid.GridEntityId, out var gridEnt) &&
                 grid.GridEntityId != entity.Uid)
             {
-                // Some minor duplication here with AttachParent but only happens when going on/off grid so not a big deal ATM.
-                if (grid.Index != transform.GridID)
-                {
-                    transform.AttachParent(gridEnt);
-                    RaiseLocalEvent(entity.Uid, new ChangedGridEvent(entity, transform.GridID, grid.Index));
-                }
+                if (transform.GridID != grid.Index)
+                    dat = (newParent: gridEnt, newGrid: grid.Index);
             }
             else
             {
-                var oldGridId = transform.GridID;
-
                 // Attach them to map / they are on an invalid grid
-                if (oldGridId != GridId.Invalid)
+                if (transform.GridID != GridId.Invalid)
+                    dat = (newParent: _mapManager.GetMapEntity(transform.MapID), newGrid: GridId.Invalid);
+            }
+
+            if (dat.HasValue)
+            {
+                var _dat = dat.Value;
+                // Apply the angular velocity of the grid to the object leaving the grid, as linear velocity
+                if (entity.TryGetComponent<PhysicsComponent>(out var ePhysComp) &&
+                        _mapManager.TryGetGrid(transform.GridID, out var oGridMap) &&
+                        EntityManager.TryGetEntity(oGridMap.GridEntityId, out var oGrid) &&
+                        oGrid.TryGetComponent<PhysicsComponent>(out var gPhysComp))
                 {
-                    transform.AttachParent(_mapManager.GetMapEntity(transform.MapID));
-                    RaiseLocalEvent(entity.Uid, new ChangedGridEvent(entity, oldGridId, GridId.Invalid));
+                    // Our rotation system is backwards, so we invert the angular velocity.
+                    var o = -gPhysComp.MapAngularVelocity;
+
+                    // Get the vector between the grid and the entity leaving
+                    var r = oGrid.Transform.WorldPosition - transform.WorldPosition;
+
+                    // Get the tangent of r by rotating it π/2 rad (90°)
+                    var v = new Angle(MathHelper.PiOver2).RotateVec(r);
+
+                    // Scale the new vector by the angular velocity
+                    v *= o;
+
+                    // Smack it on to the entity
+                    ePhysComp.LinearVelocity += v;
                 }
+
+                transform.AttachParent(_dat.newParent);
+                RaiseLocalEvent(entity.Uid, new ChangedGridEvent(entity, transform.GridID, _dat.newGrid));
             }
         }
     }


### PR DESCRIPTION
Caveat: Does not work for controlled mobs.

Many thanks to @ElectroJr and @Tomeno for correcting my atrocious math
...repeatedly.