### PR TITLE
Move LastModifiedTick out of Entity and into MetaDataComponent.

### DIFF
--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -350,9 +350,9 @@ namespace Robust.Server.GameStates
 
                     chunk.FastGetAllAnchoredEnts(uid =>
                     {
-                        var ent = _entMan.GetEntity(uid);
+                        var ent = _entMan.GetComponent<MetaDataComponent>(uid);
 
-                        if (ent.LastModifiedTick < lastSeenChunk)
+                        if (ent.EntityLastModifiedTick < lastSeenChunk)
                             return;
 
                         var newState = ServerGameStateManager.GetEntityState(_entMan, session, uid, lastSeenChunk);
@@ -508,7 +508,7 @@ namespace Robust.Server.GameStates
                     //Still Visible
 
                     // Nothing new to send
-                    if (EntityManager.GetEntity(entityUid).LastModifiedTick < fromTick)
+                    if (EntityManager.GetComponent<MetaDataComponent>(entityUid).EntityLastModifiedTick < fromTick)
                         continue;
 
                     // only send new changes

--- a/Robust.Shared/GameObjects/Component.cs
+++ b/Robust.Shared/GameObjects/Component.cs
@@ -233,7 +233,7 @@ namespace Robust.Shared.GameObjects
         {
             // Deserialization will cause this to be true.
             // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-            if(Owner is null)
+            if(Owner is null || LifeStage >= ComponentLifeStage.Removing)
                 return;
 
             var entManager = Owner.EntityManager;

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Players;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Timing;
 using Robust.Shared.ViewVariables;
 
 namespace Robust.Shared.GameObjects
@@ -58,6 +59,10 @@ namespace Robust.Shared.GameObjects
 
         /// <inheritdoc />
         public override string Name => "MetaData";
+
+        // Every entity starts at tick 1, because they are conceptually created in the time between 0->1
+        [ViewVariables]
+        public GameTick EntityLastModifiedTick { get; internal set; } = new(1);
 
         /// <summary>
         ///     The in-game name of this entity.

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -29,15 +29,7 @@ namespace Robust.Shared.GameObjects
         public EntityLifeStage LifeStage { get => MetaData.EntityLifeStage; internal set => MetaData.EntityLifeStage = value; }
 
         [ViewVariables]
-        GameTick IEntity.LastModifiedTick
-        {
-            get => _metaData?.EntityLastModifiedTick ?? GameTick.First;
-            set
-            {
-                if(_metaData != null)
-                    _metaData.EntityLastModifiedTick = value;
-            }
-        }
+        GameTick IEntity.LastModifiedTick { get => MetaData.EntityLastModifiedTick; set => MetaData.EntityLastModifiedTick = value; }
 
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -28,6 +28,18 @@ namespace Robust.Shared.GameObjects
 
         public EntityLifeStage LifeStage { get => MetaData.EntityLifeStage; internal set => MetaData.EntityLifeStage = value; }
 
+        [ViewVariables]
+        GameTick IEntity.LastModifiedTick
+        {
+            get => _metaData?.EntityLastModifiedTick ?? GameTick.First;
+            set
+            {
+                if(_metaData != null)
+                    _metaData.EntityLastModifiedTick = value;
+            }
+        }
+
+
         /// <inheritdoc />
         [ViewVariables]
         public EntityPrototype? Prototype
@@ -43,11 +55,6 @@ namespace Robust.Shared.GameObjects
             get => MetaData.EntityDescription;
             set => MetaData.EntityDescription = value;
         }
-
-        /// <inheritdoc />
-        [ViewVariables]
-        // Every entity starts at tick 1, because they are conceptually created in the time between 0->1
-        GameTick IEntity.LastModifiedTick { get; set; } = new(1);
 
         /// <inheritdoc />
         [ViewVariables(VVAccess.ReadWrite)]

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -355,11 +355,6 @@ namespace Robust.Shared.GameObjects
 
             var entityUid = component.Owner.Uid;
 
-            foreach (var refType in reg.References)
-            {
-                _entTraitDict[refType].Remove(entityUid);
-            }
-
             // ReSharper disable once InvertIf
             if (reg.NetID != null)
             {
@@ -370,6 +365,11 @@ namespace Robust.Shared.GameObjects
                     netSet.Remove(reg.NetID.Value);
 
                 DirtyEntity(entityUid);
+            }
+
+            foreach (var refType in reg.References)
+            {
+                _entTraitDict[refType].Remove(entityUid);
             }
 
             _entCompIndex.Remove(entityUid, component);

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -235,11 +235,16 @@ namespace Robust.Shared.GameObjects
         public void DirtyEntity(EntityUid uid)
         {
             var currentTick = CurrentTick;
-            var entity = GetEntity(uid);
 
-            if (entity.LastModifiedTick == currentTick) return;
+            // We want to retrieve MetaDataComponent even if its Deleted flag is set.
+            if (!_entTraitDict[typeof(MetaDataComponent)].TryGetValue(uid, out var component))
+                throw new KeyNotFoundException($"Entity {uid} does not exist, cannot dirty it.");
 
-            entity.LastModifiedTick = currentTick;
+            var metadata = (MetaDataComponent)component;
+
+            if (metadata.EntityLastModifiedTick == currentTick) return;
+
+            metadata.EntityLastModifiedTick = currentTick;
 
             var dirtyEvent = new EntityDirtyEvent {Uid = uid};
             EventBus.RaiseLocalEvent(uid, ref dirtyEvent);


### PR DESCRIPTION
Small notes:
- Components don't call Dirty if they're being removed or are deleted.
- DirtyEntity manually gets the `MetaDataComponent` from `_entTraitDict` so it can get it even when the deleted flag is set.
- Networked components are now removed from the `_netComponents` collection *before* being removed from `_entTraitDict` and such.