### PR TITLE
Arbitrary occluder rotation

### DIFF
--- a/Robust.Client/GameObjects/Components/Light/ClientOccluderComponent.cs
+++ b/Robust.Client/GameObjects/Components/Light/ClientOccluderComponent.cs
@@ -74,10 +74,10 @@ namespace Robust.Client.GameObjects
                 return;
             }
 
+            var grid = _mapManager.GetGrid(Owner.Transform.GridID);
+            var position = Owner.Transform.Coordinates;
             void CheckDir(Direction dir, OccluderDir oclDir)
             {
-                var grid = _mapManager.GetGrid(Owner.Transform.GridID);
-                var position = Owner.Transform.Coordinates;
                 foreach (var neighbor in grid.GetInDir(position, dir))
                 {
                     if (Owner.EntityManager.TryGetComponent(neighbor, out ClientOccluderComponent? comp) && comp.Enabled)
@@ -88,10 +88,20 @@ namespace Robust.Client.GameObjects
                 }
             }
 
-            CheckDir(Direction.North, OccluderDir.North);
-            CheckDir(Direction.East, OccluderDir.East);
-            CheckDir(Direction.South, OccluderDir.South);
-            CheckDir(Direction.West, OccluderDir.West);
+            var angle = Owner.Transform.LocalRotation;
+            var dirRolling = angle.GetCardinalDir();
+            // dirRolling starts at effective south
+
+            CheckDir(dirRolling, OccluderDir.South);
+            dirRolling = dirRolling.GetClockwise90Degrees();
+
+            CheckDir(dirRolling, OccluderDir.West);
+            dirRolling = dirRolling.GetClockwise90Degrees();
+
+            CheckDir(dirRolling, OccluderDir.North);
+            dirRolling = dirRolling.GetClockwise90Degrees();
+
+            CheckDir(dirRolling, OccluderDir.East);
         }
 
         [Flags]

--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -943,7 +943,7 @@ namespace Robust.Client.Graphics.Clyde
                         {
                             // get normal
                             var alongNormal = b - a;
-                            var normal = new Vector2(-alongNormal.Y, alongNormal.X).Normalized;
+                            var normal = alongNormal.Rotated90DegreesAnticlockwiseWorld.Normalized;
                             // determine which side of the plane the face is on
                             // the plane is at the origin of this coordinate system, which is also the eye
                             // the normal of the plane is that of the face

--- a/Robust.Shared.Maths/Direction.cs
+++ b/Robust.Shared.Maths/Direction.cs
@@ -69,6 +69,22 @@ namespace Robust.Shared.Maths
             };
         }
 
+        public static Direction GetClockwise90Degrees(this Direction direction)
+        {
+            return direction switch
+            {
+                Direction.East => Direction.South,
+                Direction.West => Direction.North,
+                Direction.North => Direction.East,
+                Direction.South => Direction.West,
+                Direction.NorthEast => Direction.SouthEast,
+                Direction.SouthWest => Direction.NorthWest,
+                Direction.NorthWest => Direction.NorthEast,
+                Direction.SouthEast => Direction.SouthWest,
+                _ => throw new ArgumentOutOfRangeException(nameof(direction))
+            };
+        }
+
         /// <summary>
         /// Converts a direction to an angle, where angle is -PI to +PI.
         /// </summary>

--- a/Robust.Shared.Maths/Vector2.cs
+++ b/Robust.Shared.Maths/Vector2.cs
@@ -92,6 +92,32 @@ namespace Robust.Shared.Maths
             }
         }
 
+        /// <summary>
+        ///     Returns a new, rotated 90 degrees clockwise (in world Y-up orientation), vector.
+        /// </summary>
+        /// <returns></returns>
+        public readonly Vector2 Rotated90DegreesClockwiseWorld
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return new Vector2(Y, -X);
+            }
+        }
+
+        /// <summary>
+        ///     Returns a new, rotated 90 degrees anticlockwise (in world Y-up orientation), vector.
+        /// </summary>
+        /// <returns></returns>
+        public readonly Vector2 Rotated90DegreesAnticlockwiseWorld
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return new Vector2(-Y, X);
+            }
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly Vector2 Rounded()
         {


### PR DESCRIPTION
Stuff the PR does as of now:

+ Occluders may be locally rotated without visual glitching, `fixoccluders` is now only necessary because inconsistency is bad.

Things To Discuss:

+ Arbitrary polygonal occluder meshes?
+ If so, how far to push the API for such?
+ Face elimination in vertex shader?
