### PR TITLE
Optimise physics broadphase cache

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -361,6 +361,7 @@ namespace Robust.Shared.GameObjects
                 comp.ProcessQueue();
             }
 
+            _broadphaseSystem.Cleanup();
             _physicsManager.ClearTransforms();
         }
 

--- a/Robust.Shared/Physics/Dynamics/PhysicsIsland.cs
+++ b/Robust.Shared/Physics/Dynamics/PhysicsIsland.cs
@@ -540,9 +540,11 @@ stored in a single array since multiple arrays lead to multiple misses.
                     body.LinearVelocity = linVelocity;
                 }
 
-                if (!float.IsNaN(_angularVelocities[i]))
+                var angVelocity = _angularVelocities[i];
+
+                if (!float.IsNaN(angVelocity))
                 {
-                    body.AngularVelocity = _angularVelocities[i];
+                    body.AngularVelocity = angVelocity;
                 }
             }
         }

--- a/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
+++ b/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
@@ -360,7 +360,7 @@ namespace Robust.Shared.Physics.Dynamics
                         other.Island = true;
                     }
 
-                    if (!body.Owner.TryGetComponent(out JointComponent? jointComponent)) continue;
+                    if (!Owner.EntityManager.TryGetComponent(body.OwnerUid, out JointComponent? jointComponent)) continue;
 
                     foreach (var (_, joint) in jointComponent.Joints)
                     {

--- a/Robust.Shared/Physics/SharedJointSystem.cs
+++ b/Robust.Shared/Physics/SharedJointSystem.cs
@@ -44,8 +44,6 @@ namespace Robust.Shared.Physics
 
     public abstract class SharedJointSystem : EntitySystem
     {
-        [Dependency] private readonly IConfigurationManager _configManager = default!;
-
         // To avoid issues with component states we'll queue up all dirty joints and check it every tick to see if
         // we can delete the component.
         private HashSet<JointComponent> _dirtyJoints = new();


### PR DESCRIPTION
Roughly 10% gains on packed by not having to iterate every fixture to get the WorldAABB as LocalBounds is already stored.