### PR TITLE
Async status host handlers to reduce ACZ stalling

### DIFF
--- a/Robust.Server/ServerStatus/IStatusHost.cs
+++ b/Robust.Server/ServerStatus/IStatusHost.cs
@@ -8,6 +8,7 @@ namespace Robust.Server.ServerStatus
         void Start();
 
         void AddHandler(StatusHostHandler handler);
+        void AddHandler(StatusHostHandlerAsync handler);
 
         /// <summary>
         ///     Invoked when a client queries a status request from the server.

--- a/Robust.Server/ServerStatus/StatusHost.Handlers.cs
+++ b/Robust.Server/ServerStatus/StatusHost.Handlers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using System.Net;
 using Newtonsoft.Json.Linq;
 using Robust.Shared;
@@ -50,7 +51,7 @@ namespace Robust.Server.ServerStatus
             return true;
         }
 
-        private bool HandleInfo(IStatusHandlerContext context)
+        private async Task<bool> HandleInfo(IStatusHandlerContext context)
         {
             if (!context.IsGetLike || context.Url!.AbsolutePath != "/info")
             {
@@ -63,7 +64,7 @@ namespace Robust.Server.ServerStatus
 
             if (string.IsNullOrEmpty(downloadUrl))
             {
-                buildInfo = PrepareACZBuildInfo();
+                buildInfo = await PrepareACZBuildInfo();
             }
             else
             {
@@ -105,12 +106,10 @@ namespace Robust.Server.ServerStatus
             return true;
         }
 
-        private JObject? PrepareACZBuildInfo()
+        private async Task<JObject?> PrepareACZBuildInfo()
         {
-            if (PrepareACZ() == null)
-            {
-                return null;
-            }
+            var acz = await PrepareACZ();
+            if (acz == null) return null;
 
             // Automatic - pass to ACZ
             // Unfortunately, we still can't divine engine version.
@@ -126,10 +125,10 @@ namespace Robust.Server.ServerStatus
             {
                 ["engine_version"] = engineVersion,
                 ["fork_id"] = fork,
-                ["version"] = _aczHash,
+                ["version"] = acz.Value.Hash,
                 // Don't supply a download URL - like supplying an empty self-address
                 ["download_url"] = "",
-                ["hash"] = _aczHash,
+                ["hash"] = acz.Value.Hash,
             };
         }
     }

--- a/Robust.Server/ServerStatus/StatusHostHandler.cs
+++ b/Robust.Server/ServerStatus/StatusHostHandler.cs
@@ -1,5 +1,9 @@
+using System.Threading.Tasks;
+
 namespace Robust.Server.ServerStatus
 {
     public delegate bool StatusHostHandler(
+        IStatusHandlerContext context);
+    public delegate Task<bool> StatusHostHandlerAsync(
         IStatusHandlerContext context);
 }


### PR DESCRIPTION
This addresses that PR comment about use of `Task.Run`/etc.
However it doesn't address the byte[] situation - I'm not sure of a good fix for now, and it may become semi-irrelevant if some sort of resource manifest system crops up later.