### PR TITLE
Miscellaneous fixes for thrusters

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -213,6 +213,7 @@ namespace Robust.Client.GameObjects
 
                     layer.Color = layerDatum.Color;
                     layer.Rotation = layerDatum.Rotation;
+                    layer._offset = layerDatum.Offset;
                     // If neither state: nor texture: were provided we assume that they want a blank invisible layer.
                     layer.Visible = anyTextureAttempted && layerDatum.Visible;
                     layer.Scale = layerDatum.Scale;
@@ -1259,7 +1260,7 @@ namespace Robust.Client.GameObjects
             if (worldRotation.Theta < 0)
                 worldRotation = new Angle(worldRotation.Theta + Math.Tau);
 
-            var localMatrix = GetLocalMatrix();
+            var spriteMatrix = GetLocalMatrix();
 
             foreach (var layer in Layers)
             {
@@ -1270,9 +1271,10 @@ namespace Robust.Client.GameObjects
 
                 var numDirs = GetLayerDirectionCount(layer);
                 var layerRotation = worldRotation + layer.Rotation;
+                var layerPosition = worldPosition + layerRotation.RotateVec(layer._offset);
 
-                CalcModelMatrix(numDirs, eyeRotation, layerRotation, worldPosition, out var modelMatrix);
-                Matrix3.Multiply(ref localMatrix, ref modelMatrix, out var transformMatrix);
+                CalcModelMatrix(numDirs, eyeRotation, layerRotation, layerPosition, out var modelMatrix);
+                Matrix3.Multiply(ref spriteMatrix, ref modelMatrix, out var transformMatrix);
                 drawingHandle.SetTransform(in transformMatrix);
 
                 RenderLayer(drawingHandle, layer, eyeRotation, layerRotation, overrideDirection);
@@ -1290,7 +1292,7 @@ namespace Robust.Client.GameObjects
 
             var layerColor = color * layer.Color;
 
-            var position = -(Vector2)texture.Size / (2f * EyeManager.PixelsPerMeter) + layer.Offset;
+            var position = -(Vector2)texture.Size / (2f * EyeManager.PixelsPerMeter);
             var textureSize = texture.Size / (float)EyeManager.PixelsPerMeter;
             var quad = Box2.FromDimensions(position, textureSize);
 
@@ -1723,7 +1725,7 @@ namespace Robust.Client.GameObjects
                 }
             }
 
-            private Vector2 _offset;
+            internal Vector2 _offset;
 
             [ViewVariables]
             public DirectionOffset DirOffset { get; set; }

--- a/Robust.Shared.Maths/Direction.cs
+++ b/Robust.Shared.Maths/Direction.cs
@@ -2,7 +2,6 @@
 
 namespace Robust.Shared.Maths
 {
-    [Flags]
     public enum Direction : sbyte
     {
         Invalid = -1,
@@ -14,6 +13,21 @@ namespace Robust.Shared.Maths
         NorthWest = 5,
         West = 6,
         SouthWest = 7,
+    }
+
+    [Flags]
+    public enum DirectionFlag : sbyte
+    {
+        None = 0,
+        South = 1 << 0,
+        East = 1 << 1,
+        North = 1 << 2,
+        West = 1 << 3,
+
+        SouthEast = South | East,
+        NorthEast = North | East,
+        NorthWest = North | West,
+        SouthWest = South | West,
     }
 
     /// <summary>
@@ -94,7 +108,7 @@ namespace Robust.Shared.Maths
             new (-1, 0),
             new Vector2(-1, -1).Normalized
         };
-        
+
         private static readonly Vector2i[] IntDirectionVectors = {
             new (0, -1),
             new (1, -1),
@@ -105,7 +119,7 @@ namespace Robust.Shared.Maths
             new (-1, 0),
             new (-1, -1)
         };
-        
+
         /// <summary>
         /// Converts a Direction to a normalized Direction vector.
         /// </summary>

--- a/Robust.Shared.Maths/Direction.cs
+++ b/Robust.Shared.Maths/Direction.cs
@@ -37,6 +37,56 @@ namespace Robust.Shared.Maths
     {
         private const double Segment = 2 * Math.PI / 8.0; // Cut the circle into 8 pieces
 
+        public static Direction AsDir(this DirectionFlag directionFlag)
+        {
+            switch (directionFlag)
+            {
+                case DirectionFlag.South:
+                    return Direction.South;
+                case DirectionFlag.SouthEast:
+                    return Direction.SouthEast;
+                case DirectionFlag.East:
+                    return Direction.East;
+                case DirectionFlag.NorthEast:
+                    return Direction.NorthEast;
+                case DirectionFlag.North:
+                    return Direction.North;
+                case DirectionFlag.NorthWest:
+                    return Direction.NorthWest;
+                case DirectionFlag.West:
+                    return Direction.West;
+                case DirectionFlag.SouthWest:
+                    return Direction.SouthWest;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public static DirectionFlag AsFlag(this Direction direction)
+        {
+            switch (direction)
+            {
+                case Direction.South:
+                    return DirectionFlag.South;
+                case Direction.SouthEast:
+                    return DirectionFlag.SouthEast;
+                case Direction.East:
+                    return DirectionFlag.East;
+                case Direction.NorthEast:
+                    return DirectionFlag.NorthEast;
+                case Direction.North:
+                    return DirectionFlag.North;
+                case Direction.NorthWest:
+                    return DirectionFlag.NorthWest;
+                case Direction.West:
+                    return DirectionFlag.West;
+                case Direction.SouthWest:
+                    return DirectionFlag.SouthWest;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
         /// <summary>
         /// Converts a direction vector to the closest Direction enum.
         /// </summary>

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -480,7 +480,7 @@ namespace Robust.Shared
         /// Performance impact if additional broadphases are being checked.
         /// </summary>
         public static readonly CVarDef<float> BroadphaseExpand =
-            CVarDef.Create("physics.broadphase_Expand", 2f);
+            CVarDef.Create("physics.broadphase_Expand", 2f, CVar.ARCHIVE | CVar.REPLICATED);
 
         // Grid fixtures
         /// <summary>

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -480,7 +480,7 @@ namespace Robust.Shared
         /// Performance impact if additional broadphases are being checked.
         /// </summary>
         public static readonly CVarDef<float> BroadphaseExpand =
-            CVarDef.Create("physics.broadphase_Expand", 2f, CVar.ARCHIVE | CVar.REPLICATED);
+            CVarDef.Create("physics.broadphase_expand", 2f, CVar.ARCHIVE | CVar.REPLICATED);
 
         // Grid fixtures
         /// <summary>

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -475,6 +475,13 @@ namespace Robust.Shared
          * PHYSICS
          */
 
+        /// <summary>
+        /// How much to expand broadphase checking for. This is useful for cross-grid collisions.
+        /// Performance impact if additional broadphases are being checked.
+        /// </summary>
+        public static readonly CVarDef<float> BroadphaseExpand =
+            CVarDef.Create("physics.broadphase_Expand", 2f);
+
         // Grid fixtures
         /// <summary>
         /// I'ma be real with you: the only reason this exists is to get tests working.

--- a/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
@@ -72,6 +72,8 @@ namespace Robust.Shared.GameObjects
             public Vector2 Scale = Vector2.One;
             [DataField("rotation")]
             public Angle Rotation = Angle.Zero;
+            [DataField("offset")]
+            public Vector2 Offset = Vector2.Zero;
             [DataField("visible")]
             public bool Visible = true;
             [DataField("color")]

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -866,6 +866,8 @@ namespace Robust.Shared.Physics
             base.Shutdown();
             var configManager = IoCManager.Resolve<IConfigurationManager>();
             configManager.UnsubValueChanged(CVars.BroadphaseExpand, SetBroadphaseExpand);
+            _mapManager.MapCreated -= OnMapCreated;
+            _mapManager.MapDestroyed -= OnMapDestroyed;
         }
 
         private void HandleGridInit(GridInitializeEvent ev)


### PR DESCRIPTION
Most important one is the sprite layer offset fix.

Note that this kinda breaks the spawn entity menu for anything that actually uses it so not sure on the best bandaid (I mean ideally it'd have a dedicated icon); could just not draw layers that have offsets or something?

Known issue: InteractionOutline (only on anything that uses layer offset), because of course, but I have NFI how to fix.