### PR TITLE
Optimise GetBroadphases

### DIFF
--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
@@ -945,26 +946,6 @@ namespace Robust.Shared.Physics
                 if (chunkEnumerator.MoveNext(out _))
                 {
                     yield return broadphase;
-                }
-            }
-        }
-
-                var transform = physicsComponent.GetTransform();
-                var found = false;
-
-                // TODO: Need CollisionManager for accurate checks
-                foreach (var fixture in physicsComponent.Fixtures)
-                {
-                    for (var i = 0; i < fixture.Shape.ChildCount; i++)
-                    {
-                        if (!fixture.Shape.ComputeAABB(transform, i).Intersects(aabb)) continue;
-                        yield return broadphase;
-                        found = true;
-                        break;
-                    }
-
-                    if (found)
-                        break;
                 }
             }
         }


### PR DESCRIPTION
Only used in the public APIs; mainly just avoids getting every fixture in a grid which is wasteful and will only consider it to a chunk level.