### PR TITLE
Marked PlayerSession find methods on PlayerManager Obsolete

### DIFF
--- a/Robust.Server/Console/Commands/PlayerCommands.cs
+++ b/Robust.Server/Console/Commands/PlayerCommands.cs
@@ -158,7 +158,7 @@ namespace Robust.Server.Console.Commands
 
             var sb = new StringBuilder();
 
-            var players = IoCManager.Resolve<IPlayerManager>().GetAllPlayers();
+            var players = IoCManager.Resolve<IPlayerManager>().ServerSessions;
             sb.AppendLine($"{"Player Name",20} {"Status",12} {"Playing Time",14} {"Ping",9} {"IP EndPoint",20}");
             sb.AppendLine("-------------------------------------------------------------------------------");
 
@@ -188,7 +188,7 @@ namespace Robust.Server.Console.Commands
             if (args.Length < 1)
             {
                 var player = shell.Player as IPlayerSession;
-                var toKickPlayer = player ?? players.GetAllPlayers().FirstOrDefault();
+                var toKickPlayer = player ?? players.ServerSessions.FirstOrDefault();
                 if (toKickPlayer == null)
                 {
                     shell.WriteLine("You need to provide a player to kick.");

--- a/Robust.Server/GameObjects/EntitySystems/EffectSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/EffectSystem.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Linq;
 using Robust.Server.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
@@ -19,7 +20,7 @@ namespace Robust.Server.GameObjects
         /// <summary>
         /// Priority queue sorted by how soon the effect will die, we remove messages from the front of the queue during update until caught up
         /// </summary>
-        private readonly PriorityQueue<EffectSystemMessage> _CurrentEffects = new(new EffectMessageComparer());
+        private readonly PriorityQueue<EffectSystemMessage> _currentEffects = new(new EffectMessageComparer());
 
         /// <summary>
         ///     Creates a particle effect and sends it to clients.
@@ -28,11 +29,11 @@ namespace Robust.Server.GameObjects
         /// <param name="excludedSession">Session to be excluded for prediction</param>
         public void CreateParticle(EffectSystemMessage effect, IPlayerSession? excludedSession = null)
         {
-            _CurrentEffects.Add(effect);
+            _currentEffects.Add(effect);
 
             //For now we will use this which sends to ALL clients
             //TODO: Client bubbling
-            foreach (var player in _playerManager.GetAllPlayers())
+            foreach (var player in _playerManager.ServerSessions)
             {
                 if (player.Status != SessionStatus.InGame || player == excludedSession)
                     continue;
@@ -44,9 +45,9 @@ namespace Robust.Server.GameObjects
         public override void Update(float frameTime)
         {
             //Take elements from front of priority queue until they are old
-            while (_CurrentEffects.Count != 0 && _CurrentEffects.Peek().DeathTime < _timing.CurTime)
+            while (_currentEffects.Count != 0 && _currentEffects.Peek().DeathTime < _timing.CurTime)
             {
-                _CurrentEffects.Take();
+                _currentEffects.Take();
             }
         }
 

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -16,7 +16,6 @@ using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Network;
 using Robust.Shared.Network.Messages;
-using Robust.Shared.Players;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -124,7 +123,7 @@ namespace Robust.Server.GameStates
                 _entityManager.CullDeletionHistory(GameTick.MaxValue);
                 _pvs.CullDeletionHistory(GameTick.MaxValue);
                 _mapManager.CullDeletionHistory(GameTick.MaxValue);
-                _pvs.Cleanup(_playerManager.GetAllPlayers());
+                _pvs.Cleanup(_playerManager.ServerSessions);
                 return;
             }
 
@@ -185,7 +184,7 @@ namespace Robust.Server.GameStates
                 _networkManager.ServerSendMessage(stateUpdateMessage, channel);
             }
 
-            Parallel.ForEach(_playerManager.GetAllPlayers(), session =>
+            Parallel.ForEach(_playerManager.ServerSessions, session =>
             {
                 try
                 {
@@ -197,7 +196,7 @@ namespace Robust.Server.GameStates
                 }
             });
 
-            _pvs.Cleanup(_playerManager.GetAllPlayers());
+            _pvs.Cleanup(_playerManager.ServerSessions);
             var oldestAck = new GameTick(oldestAckValue);
 
             // keep the deletion history buffers clean

--- a/Robust.Server/Player/IPlayerManager.cs
+++ b/Robust.Server/Player/IPlayerManager.cs
@@ -18,6 +18,11 @@ namespace Robust.Server.Player
         BoundKeyMap KeyMap { get; }
 
         /// <summary>
+        /// Same as the common sessions, but the server version.
+        /// </summary>
+        IEnumerable<IPlayerSession> ServerSessions { get; }
+
+        /// <summary>
         ///     Raised when the <see cref="SessionStatus" /> of a <see cref="IPlayerSession" /> is changed.
         /// </summary>
         event EventHandler<SessionStatusEventArgs> PlayerStatusChanged;
@@ -65,10 +70,16 @@ namespace Robust.Server.Player
 
         IEnumerable<IPlayerData> GetAllPlayerData();
 
+
+        [Obsolete]
         void DetachAll();
+        [Obsolete("Use player Filter or Inline me!")]
         List<IPlayerSession> GetPlayersInRange(MapCoordinates worldPos, int range);
+        [Obsolete("Use player Filter or Inline me!")]
         List<IPlayerSession> GetPlayersInRange(EntityCoordinates worldPos, int range);
+        [Obsolete("Use player Filter or Inline me!")]
         List<IPlayerSession> GetPlayersBy(Func<IPlayerSession, bool> predicate);
+        [Obsolete("Use player Filter or Inline me!")]
         List<IPlayerSession> GetAllPlayers();
         List<PlayerState>? GetPlayerStates(GameTick fromTick);
     }

--- a/Robust.Server/Player/PlayerSession.cs
+++ b/Robust.Server/Player/PlayerSession.cs
@@ -47,8 +47,6 @@ namespace Robust.Server.Player
 
         private SessionStatus _status = SessionStatus.Connecting;
 
-        /// <inheritdoc />
-
         [ViewVariables]
         internal string Name { get; set; }
 
@@ -99,7 +97,6 @@ namespace Robust.Server.Player
         /// <inheritdoc />
         public DateTime ConnectedTime { get; private set; }
 
-        /// <inheritdoc />
         [ViewVariables(VVAccess.ReadWrite)]
         public int VisibilityMask { get; set; } = 1;
 

--- a/Robust.UnitTesting/Shared/EngineIntegrationTest_Test.cs
+++ b/Robust.UnitTesting/Shared/EngineIntegrationTest_Test.cs
@@ -1,9 +1,10 @@
+using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using Robust.Server.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.IoC;
 using Robust.Shared.Network;
-using IPlayerManager = Robust.Server.Player.IPlayerManager;
 
 namespace Robust.UnitTesting.Shared
 {
@@ -56,7 +57,7 @@ namespace Robust.UnitTesting.Shared
                 Assert.That(playerManager.PlayerCount, Is.EqualTo(1));
 
                 // Get the only player...
-                var player = playerManager.GetAllPlayers()[0];
+                var player = playerManager.Sessions.Single();
 
                 Assert.That(player.Status, Is.EqualTo(SessionStatus.Connected));
                 Assert.That(player.ConnectedClient.IsConnected, Is.True);

--- a/Robust.UnitTesting/Shared/GameObjects/ContainerTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/ContainerTests.cs
@@ -58,7 +58,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
 
                 // Setup PVS
                 entity.AddComponent<Robust.Server.GameObjects.EyeComponent>();
-                var player = playerMan.GetAllPlayers().First();
+                var player = playerMan.ServerSessions.First();
                 player.AttachToEntity(entity);
                 player.JoinGame();
             });
@@ -185,7 +185,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
 
                 // Setup PVS
                 entity.AddComponent<Robust.Server.GameObjects.EyeComponent>();
-                var player = playerMan.GetAllPlayers().First();
+                var player = playerMan.ServerSessions.First();
                 player.AttachToEntity(entity);
                 player.JoinGame();
             });


### PR DESCRIPTION
Added IPlayerManager.ServerSessions to get the active session in the server type, instead of the shared type.
Marked old player session finding methods obsolete, use the Player Filter now.