### PR TITLE
Cleanup NativeLibrary.Load usages by replacing them with TryLoad

### DIFF
--- a/OpenToolkit.GraphicsLibraryFramework/GLFWNative.cs
+++ b/OpenToolkit.GraphicsLibraryFramework/GLFWNative.cs
@@ -26,7 +26,7 @@ namespace OpenToolkit.GraphicsLibraryFramework
 
                 string rName = null;
                 if (OperatingSystem.IsLinux()) rName = "libglfw.so.3";
-                if (OperatingSystem.IsMacOS()) rName = "libglfw.3.dylib";
+                else if (OperatingSystem.IsMacOS()) rName = "libglfw.3.dylib";
 
                 if ((rName != null) && NativeLibrary.TryLoad(rName, assembly, path, out var handle))
                     return handle;

--- a/OpenToolkit.GraphicsLibraryFramework/GLFWNative.cs
+++ b/OpenToolkit.GraphicsLibraryFramework/GLFWNative.cs
@@ -18,20 +18,18 @@ namespace OpenToolkit.GraphicsLibraryFramework
             NativeLibrary.SetDllImportResolver(typeof(GLFWNative).Assembly, (name, assembly, path) =>
             {
                 // Please keep in sync with what Robust.Shared/DllMapHelper.cs does.
+
                 if (name != "glfw3.dll")
                 {
                     return IntPtr.Zero;
                 }
 
-                if (OperatingSystem.IsLinux())
-                {
-                    return NativeLibrary.Load("libglfw.so.3", assembly, path);
-                }
+                string rName = null;
+                if (OperatingSystem.IsLinux()) rName = "libglfw.so.3";
+                if (OperatingSystem.IsMacOS()) rName = "libglfw.3.dylib";
 
-                if (OperatingSystem.IsMacOS())
-                {
-                    return NativeLibrary.Load("libglfw.3.dylib", assembly, path);
-                }
+                if ((rName != null) && NativeLibrary.TryLoad(rName, assembly, path, out var handle))
+                    return handle;
 
                 return IntPtr.Zero;
             });

--- a/Robust.Shared/DllMapHelper.cs
+++ b/Robust.Shared/DllMapHelper.cs
@@ -26,22 +26,18 @@ namespace Robust.Shared
             NativeLibrary.SetDllImportResolver(assembly, (name, assembly, path) =>
             {
                 // Please keep in sync with what GLFWNative does.
-                // This particular API is only really used by the MIDI instruments stuff in SS14 right now,
-                //  which means when it breaks people don't notice or report.
+                // This particular API isn't used by anything at all, but I really wish it was.
                 if (name != baseName)
                 {
                     return IntPtr.Zero;
                 }
 
-                if (OperatingSystem.IsLinux())
-                {
-                    return NativeLibrary.Load(linuxName, assembly, path);
-                }
+                string? rName = null;
+                if (OperatingSystem.IsLinux()) rName = linuxName;
+                if (OperatingSystem.IsMacOS()) rName = macName;
 
-                if (OperatingSystem.IsMacOS())
-                {
-                    return NativeLibrary.Load(macName, assembly, path);
-                }
+                if ((rName != null) && NativeLibrary.TryLoad(rName, assembly, path, out var handle))
+                    return handle;
 
                 return IntPtr.Zero;
             });


### PR DESCRIPTION
Summary is that NativeLibrary.Load can throw exceptions.
Feel free to close this PR if it seems too pointless.
