### PR TITLE
Unwrap ParsedMain

### DIFF
--- a/Robust.Server/Program.cs
+++ b/Robust.Server/Program.cs
@@ -40,15 +40,7 @@ namespace Robust.Server
 
             ThreadPool.SetMinThreads(Environment.ProcessorCount * 2, Environment.ProcessorCount);
 
-            // this sets up TaskScheduler.Current for new tasks to be scheduled off the main thread
-            // the LongRunning option causes it to not be scheduled on the thread pool, so it's just a plain thread with a task context
-            new TaskFactory(
-                    CancellationToken.None,
-                    TaskCreationOptions.LongRunning,
-                    TaskContinuationOptions.None,
-                    RobustTaskScheduler.Instance
-                ).StartNew(() => ParsedMain(parsed, contentStart, options))
-                .GetAwaiter().GetResult();
+            ParsedMain(parsed, contentStart, options);
         }
 
         private static void ParsedMain(CommandLineArgs args, bool contentStart, ServerOptions options)


### PR DESCRIPTION
What the previous code does:
1. Creates a new thread, and makes the main thread do nothing forever, waiting on the new thread.
2. Messes up exception stack traces

What it does now:
1. Uses the main thread to run the code, instead of making a new thread to do it. So the main thread isn't wasted.
2. Lets the debugger find the correct place when an exception happens.