### PR TITLE
Fix `AudioParams` DataDefinition

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
@@ -441,9 +441,6 @@ namespace Robust.Client.GameObjects
         }
 
         /// <inheritdoc />
-        public int DefaultSoundRange => 25;
-
-        /// <inheritdoc />
         public int OcclusionCollisionMask { get; set; }
 
         /// <inheritdoc />

--- a/Robust.Server/GameObjects/EntitySystems/AudioSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/AudioSystem.cs
@@ -15,8 +15,6 @@ namespace Robust.Server.GameObjects
     {
         [Dependency] private readonly IEntityManager _entityManager = default!;
 
-        private const int AudioDistanceRange = 25;
-
         private uint _streamIndex;
 
         private class AudioSourceServer : IPlayingAudioStream
@@ -67,9 +65,6 @@ namespace Robust.Server.GameObjects
         }
 
         /// <inheritdoc />
-        public int DefaultSoundRange => AudioDistanceRange;
-
-        /// <inheritdoc />
         public int OcclusionCollisionMask { get; set; }
 
         /// <inheritdoc />
@@ -97,7 +92,7 @@ namespace Robust.Server.GameObjects
         public IPlayingAudioStream? Play(Filter playerFilter, string filename, EntityUid uid, AudioParams? audioParams = null)
         {
             //TODO: Calculate this from PAS
-            var range = audioParams is null || audioParams.Value.MaxDistance <= 0 ? AudioDistanceRange : audioParams.Value.MaxDistance;
+            var range = audioParams is null || audioParams.Value.MaxDistance <= 0 ? DefaultSoundRange : audioParams.Value.MaxDistance;
 
             if(!EntityManager.TryGetComponent<TransformComponent>(uid, out var transform))
                 return null;
@@ -129,7 +124,7 @@ namespace Robust.Server.GameObjects
         public IPlayingAudioStream Play(Filter playerFilter, string filename, EntityCoordinates coordinates, AudioParams? audioParams = null)
         {
             //TODO: Calculate this from PAS
-            var range = audioParams is null || audioParams.Value.MaxDistance <= 0 ? AudioDistanceRange : audioParams.Value.MaxDistance;
+            var range = audioParams is null || audioParams.Value.MaxDistance <= 0 ? DefaultSoundRange : audioParams.Value.MaxDistance;
 
             var id = CacheIdentifier();
 

--- a/Robust.Shared/Audio/AudioParams.cs
+++ b/Robust.Shared/Audio/AudioParams.cs
@@ -3,6 +3,7 @@ using System;
 using System.Diagnostics.Contracts;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.GameObjects;
 
 namespace Robust.Shared.Audio
 {
@@ -84,7 +85,7 @@ namespace Robust.Shared.Audio
         /// <summary>
         ///     The "default" audio configuration.
         /// </summary>
-        public static readonly AudioParams Default = new(0, 1, "Master", SoundSystem.DefaultSoundRange, 1, 1, false, 0f);
+        public static readonly AudioParams Default = new(0, 1, "Master", SharedAudioSystem.DefaultSoundRange, 1, 1, false, 0f);
 
         public AudioParams(
             float volume,
@@ -216,9 +217,15 @@ namespace Robust.Shared.Audio
 
         public void PopulateDefaultValues()
         {
-            PitchScale = 1f;
-            BusName = "Master";
-            MaxDistance = SoundSystem.DefaultSoundRange;
+            Attenuation = Default.Attenuation;
+            Volume = Default.Volume;
+            PitchScale = Default.PitchScale;
+            BusName = Default.BusName;
+            MaxDistance = Default.MaxDistance;
+            RolloffFactor = Default.RolloffFactor;
+            ReferenceDistance = Default.ReferenceDistance;
+            Loop = Default.Loop;
+            PlayOffsetSeconds = Default.PlayOffsetSeconds;
         }
     }
 }

--- a/Robust.Shared/Audio/IAudioSystem.cs
+++ b/Robust.Shared/Audio/IAudioSystem.cs
@@ -10,11 +10,6 @@ namespace Robust.Shared.Audio
     public interface IAudioSystem
     {
         /// <summary>
-        /// Default max range at which the sound can be heard.
-        /// </summary>
-        int DefaultSoundRange { get; }
-
-        /// <summary>
         /// Used in the PAS to designate the physics collision mask of occluders.
         /// </summary>
         int OcclusionCollisionMask { get; set; }

--- a/Robust.Shared/Audio/SoundSystem.cs
+++ b/Robust.Shared/Audio/SoundSystem.cs
@@ -11,11 +11,6 @@ namespace Robust.Shared.Audio
     public static class SoundSystem
     {
         /// <summary>
-        /// Default max range at which the sound can be heard.
-        /// </summary>
-        public static int DefaultSoundRange => GetAudio()?.DefaultSoundRange ?? 0;
-
-        /// <summary>
         /// Used in the PAS to designate the physics collision mask of occluders.
         /// </summary>
         public static int OcclusionCollisionMask

--- a/Robust.Shared/GameObjects/Systems/SharedAudioSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedAudioSystem.cs
@@ -7,6 +7,11 @@ namespace Robust.Shared.GameObjects
     {
         [Dependency] private readonly IMapManager _mapManager = default!;
 
+        /// <summary>
+        /// Default max range at which the sound can be heard.
+        /// </summary>
+        public const int DefaultSoundRange = 25;
+
         protected EntityCoordinates GetFallbackCoordinates(MapCoordinates mapCoordinates)
         {
             if (_mapManager.TryFindGridAt(mapCoordinates, out var mapGrid))


### PR DESCRIPTION
Currently `AudioParams` is a data definition, so that it can be defined in yaml, but AFAIK it can't actually be used at the moment. When you try to use them you get a null reference exception when trying to get the default MaxDistance. The default `AudioParams` MaxDistance calls a static function that runs:
```cs
var args = new QueryAudioSystem();
IoCManager.Resolve<IEntityManager>().EventBus.RaiseEvent(EventSource.Local, args);
``` 
In order to access a `public readonly int` that is defined separately in the client & server, and in the case of the server just points to a `private const int`??

This PR just replaces all this with a single `public const int` defined in `SharedAudioSystem`. I have no idea why this was set up the way that it was, if there's a reason for it then something else needs to be done to fix `AudioParams` data-definitions.

The PR also updates `AudioParams.PopulateDefaultValues()` to use the same values as the static `AudioParams.Default`.