### PR TITLE
Make benchmark debuggable

### DIFF
--- a/Robust.Benchmarks/Program.cs
+++ b/Robust.Benchmarks/Program.cs
@@ -1,4 +1,6 @@
-﻿using BenchmarkDotNet.Running;
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Running;
+using System;
 
 namespace Robust.Benchmarks
 {
@@ -8,7 +10,14 @@ namespace Robust.Benchmarks
         // --anyCategories=ctg1,ctg2
         public static void Main(string[] args)
         {
+#if DEBUG
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine("\nWARNING: YOU ARE RUNNING A DEBUG BUILD, USE A RELEASE BUILD FOR AN ACCURATE BENCHMARK");
+            Console.WriteLine("THE DEBUG BUILD IS ONLY GOOD FOR FIXING A CRASHING BENCHMARK\n");
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, new DebugInProcessConfig());
+#else
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+#endif
         }
     }
 }


### PR DESCRIPTION
Changes:

When compiled under debug:
1. Runs the tests in-process, so the debugger works with exceptions
2. Add a warning, that if you want a real benchmark, you need to use a release build.