### PR TITLE
Remove duplicate PluralRules.Generator in RobustToolbox.sln

### DIFF
--- a/RobustToolbox.sln
+++ b/RobustToolbox.sln
@@ -57,8 +57,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Linguini.Shared", "Linguini
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Linguini.Syntax", "Linguini\Linguini.Syntax\Linguini.Syntax.csproj", "{A5EDDBF2-3FA0-4364-A953-A814A0CBBE53}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PluralRules.Generator", "Linguini\PluralRules.Generator\PluralRules.Generator.csproj", "{0641361F-37D7-40D8-A763-16896F67DC54}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PluralRules.Generator", "Linguini\PluralRules.Generator\PluralRules.Generator.csproj", "{479FD643-665B-4DE1-B68E-3AAAD8E7A967}"
 EndProject
 Global
@@ -245,14 +243,6 @@ Global
 		{A5EDDBF2-3FA0-4364-A953-A814A0CBBE53}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A5EDDBF2-3FA0-4364-A953-A814A0CBBE53}.Release|x64.ActiveCfg = Release|Any CPU
 		{A5EDDBF2-3FA0-4364-A953-A814A0CBBE53}.Release|x64.Build.0 = Release|Any CPU
-		{0641361F-37D7-40D8-A763-16896F67DC54}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0641361F-37D7-40D8-A763-16896F67DC54}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0641361F-37D7-40D8-A763-16896F67DC54}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{0641361F-37D7-40D8-A763-16896F67DC54}.Debug|x64.Build.0 = Debug|Any CPU
-		{0641361F-37D7-40D8-A763-16896F67DC54}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0641361F-37D7-40D8-A763-16896F67DC54}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0641361F-37D7-40D8-A763-16896F67DC54}.Release|x64.ActiveCfg = Release|Any CPU
-		{0641361F-37D7-40D8-A763-16896F67DC54}.Release|x64.Build.0 = Release|Any CPU
 		{479FD643-665B-4DE1-B68E-3AAAD8E7A967}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{479FD643-665B-4DE1-B68E-3AAAD8E7A967}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{479FD643-665B-4DE1-B68E-3AAAD8E7A967}.Debug|x64.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
I removed the duplicate project reference to PluralRules.Generator in RobustToolbox.sln