### PR TITLE
Fix NextMultipleOf for int/long

### DIFF
--- a/Robust.Shared.Maths/MathHelper.cs
+++ b/Robust.Shared.Maths/MathHelper.cs
@@ -172,7 +172,7 @@ namespace Robust.Shared.Maths
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long NextMultipleOf(long value, long of)
         {
-            return ((value - 1) | (of - 1)) + 1;
+            return ((value + of - 1) / of) * of;
         }
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace Robust.Shared.Maths
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int NextMultipleOf(int value, int of)
         {
-            return ((value - 1) | (of - 1)) + 1;
+            return ((value + of - 1) / of) * of;
         }
 
         #endregion


### PR DESCRIPTION
NextMultipleOf for int, and long gave incorrect values when "of" was not a power of 2. This makes it inconsistent with the other overloads, and might lead to bugs in the future. I don't see any code using this in a hot path, and the new version is also very fast.
