### PR TITLE
Remove Entity Transform/MetaData Component Cache

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
@@ -247,7 +247,7 @@ namespace Robust.Client.GameObjects
 
         internal static RenderingTreeComponent? GetRenderTree(IEntity entity)
         {
-            if (entity.Transform.MapID == MapId.Nullspace ||
+            if (entity.Deleted || entity.Transform.MapID == MapId.Nullspace ||
                 entity.HasComponent<RenderingTreeComponent>()) return null;
 
             var parent = entity.Transform.Parent?.Owner;
@@ -265,7 +265,7 @@ namespace Robust.Client.GameObjects
 
         private bool IsVisible(SpriteComponent component)
         {
-            return component.Visible && !component.ContainerOccluded;
+            return component.Visible && !component.ContainerOccluded && !component.Deleted;
         }
 
         public override void FrameUpdate(float frameTime)
@@ -312,7 +312,7 @@ namespace Robust.Client.GameObjects
             {
                 light.TreeUpdateQueued = false;
 
-                if (!light.Enabled || light.ContainerOccluded)
+                if (light.Deleted || !light.Enabled || light.ContainerOccluded)
                 {
                     ClearLight(light);
                     continue;

--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -77,7 +77,7 @@ namespace Robust.Shared.GameObjects
         public bool Deleted => LifeStage >= EntityLifeStage.Deleted;
 
         [ViewVariables]
-        public bool Paused { get => MetaData.EntityPaused; set => MetaData.EntityPaused = value; }
+        public bool Paused { get => Deleted || MetaData.EntityPaused; set => MetaData.EntityPaused = value; }
 
         /// <inheritdoc />
         [ViewVariables]

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -306,15 +306,15 @@ namespace Robust.Shared.GameObjects
                 RecursiveDeleteEntity(childTransform.Owner);
             }
 
-            // Dispose all my components, in a safe order so transform is available
-            DisposeComponents(entity.Uid);
-
             // map does not have a parent node, everything else needs to be detached
             if (transform.ParentUid != EntityUid.Invalid)
             {
                 // Detach from my parent, if any
                 transform.DetachParentToNull();
             }
+
+            // Dispose all my components, in a safe order so transform is available
+            DisposeComponents(entity.Uid);
 
             metadata.EntityLifeStage = EntityLifeStage.Deleted;
             EntityDeleted?.Invoke(this, entity.Uid);
@@ -343,7 +343,7 @@ namespace Robust.Shared.GameObjects
 
         public bool EntityExists(EntityUid uid)
         {
-            return TryGetEntity(uid, out _);
+            return _entTraitDict[typeof(MetaDataComponent)].ContainsKey(uid);
         }
 
         /// <summary>
@@ -402,7 +402,6 @@ namespace Robust.Shared.GameObjects
 
             // Create the MetaDataComponent and set it directly on the Entity to avoid a stack overflow in DEBUG.
             var metadata = new MetaDataComponent() { Owner = entity };
-            entity.MetaData = metadata;
 
             // add the required MetaDataComponent directly.
             AddComponentInternal(uid.Value, metadata);

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -293,10 +293,10 @@ namespace Robust.Shared.GameObjects
             if(entity.Deleted) //TODO: Why was this still a child if it was already deleted?
                 return;
 
+            var uid = entity.Uid;
             var transform = entity.Transform;
             var metadata = entity.MetaData;
             entity.LifeStage = EntityLifeStage.Terminating;
-
             EventBus.RaiseLocalEvent(entity.Uid, new EntityTerminatingEvent(), false);
 
             // DeleteEntity modifies our _children collection, we must cache the collection to iterate properly
@@ -304,6 +304,13 @@ namespace Robust.Shared.GameObjects
             {
                 // Recursion Alert
                 RecursiveDeleteEntity(childTransform.Owner);
+            }
+
+            // Shut down all components.
+            foreach (var component in InSafeOrder(_entCompIndex[uid]))
+            {
+                if(component.Running)
+                    component.LifeShutdown();
             }
 
             // map does not have a parent node, everything else needs to be detached

--- a/Robust.Shared/GameObjects/Systems/OccluderSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/OccluderSystem.cs
@@ -72,7 +72,7 @@ namespace Robust.Shared.GameObjects
         {
             var entity = component.Owner;
 
-            if (entity.Transform.MapID == MapId.Nullspace) return null;
+            if (entity.Deleted || entity.Transform.MapID == MapId.Nullspace) return null;
 
             var parent = entity.Transform.Parent?.Owner;
 

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -719,6 +719,9 @@ namespace Robust.Shared.Physics
 
         private void AddToMoveBuffer(MapId mapId, FixtureProxy proxy, Box2 aabb)
         {
+            if(mapId == MapId.Nullspace)
+                return;
+
             _moveBuffer[mapId][proxy] = aabb;
         }
 

--- a/Robust.UnitTesting/Server/GameObjects/Components/Container_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/Components/Container_Test.cs
@@ -153,7 +153,7 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
             Assert.That(entityItem.Transform.Parent!.Owner, Is.EqualTo(entityOne));
 
             entityOne.Delete();
-            Assert.That(entityTwo.Transform.Deleted, Is.True);
+            Assert.That(entityTwo.Deleted, Is.True);
         }
 
         [Test]

--- a/Robust.UnitTesting/Shared/Map/EntityCoordinates_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/EntityCoordinates_Tests.cs
@@ -254,14 +254,11 @@ namespace Robust.UnitTesting.Shared.Map
             mapEnt.Delete();
 
             // These shouldn't be valid anymore.
-            Assert.That(newEnt.Transform.Coordinates.IsValid(entityManager), Is.False);
-            Assert.That(gridEnt.Transform.Coordinates.IsValid(entityManager), Is.False);
+            Assert.That(newEnt.Deleted, Is.True);
+            Assert.That(gridEnt.Deleted, Is.True);
 
-            Assert.That(newEnt.Transform.Coordinates.TryGetEntity(entityManager, out newEntParent), Is.EqualTo(false));
-            Assert.That(newEntParent, Is.Null);
-
-            Assert.That(gridEnt.Transform.Coordinates.TryGetEntity(entityManager, out gridEntParent), Is.EqualTo(false));
-            Assert.That(gridEntParent, Is.Null);
+            Assert.That(newEntParent!.Deleted, Is.True);
+            Assert.That(gridEntParent!.Deleted, Is.True);
         }
 
         [Test]


### PR DESCRIPTION
Removes transform/metadata caching on Entity, disposes components after calling event so systems can properly access comps to cleanup.

This fixes a problem that prevented https://github.com/space-wizards/RobustToolbox/pull/2295 from being complete.