### PR TITLE
Better ToPrettyString with EntityStringRepresentation

### DIFF
--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -87,6 +87,13 @@ namespace Robust.Server.GameObjects
             return entity;
         }
 
+        public override EntityStringRepresentation ToPrettyString(EntityUid uid)
+        {
+            TryGetComponent(uid, out ActorComponent? actor);
+
+            return base.ToPrettyString(uid) with { Session = actor?.PlayerSession };
+        }
+
         #region IEntityNetworkManager impl
 
         public override IEntityNetworkManager EntityNetManager => this;

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -473,15 +473,15 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public virtual string ToPrettyString(EntityUid uid)
+        public virtual EntityStringRepresentation ToPrettyString(EntityUid uid)
         {
             // We want to retrieve the MetaData component even if it is deleted.
             if (!_entTraitDict[typeof(MetaDataComponent)].TryGetValue(uid, out var component))
-                return $"{uid}D";
+                return new EntityStringRepresentation(uid, true);
 
-            var metaData = (MetaDataComponent) component;
+            var metadata = (MetaDataComponent) component;
 
-            return $"{metaData.EntityName} ({uid}, {metaData.EntityPrototype?.ID}){(metaData.EntityDeleted ? "D" : "")}";
+            return new EntityStringRepresentation(uid, metadata.EntityDeleted, metadata.EntityName, metadata.EntityPrototype?.ID);
         }
 
 #endregion Entity Management

--- a/Robust.Shared/GameObjects/EntityStringRepresentation.cs
+++ b/Robust.Shared/GameObjects/EntityStringRepresentation.cs
@@ -2,6 +2,19 @@ using Robust.Shared.Players;
 
 namespace Robust.Shared.GameObjects;
 
+/// <summary>
+///     A type that represents an entity, and allows you to get a string containing human-readable information about it.
+///     This type converts implicitly to string, for convenience purposes.
+/// </summary>
+/// <remarks>
+///     This can be used to pretty-print information about entities and also to log various information regarding an
+///     entity, if you're using string interpolation handlers.
+/// </remarks>
+/// <param name="Uid">The unique identifier of the entity.</param>
+/// <param name="Deleted">Whether the entity has been deleted or not. Also true if the entity does not exist.</param>
+/// <param name="Name">The name of the entity.</param>
+/// <param name="Prototype">The prototype identifier of the entity, if any.</param>
+/// <param name="Session">The session attached to the entity, if any.</param>
 public readonly record struct EntityStringRepresentation
     (EntityUid Uid, bool Deleted, string? Name = null, string? Prototype = null, ICommonSession? Session = null)
 {

--- a/Robust.Shared/GameObjects/EntityStringRepresentation.cs
+++ b/Robust.Shared/GameObjects/EntityStringRepresentation.cs
@@ -1,0 +1,18 @@
+using Robust.Shared.Players;
+
+namespace Robust.Shared.GameObjects;
+
+public readonly record struct EntityStringRepresentation
+    (EntityUid Uid, bool Deleted, string? Name = null, string? Prototype = null, ICommonSession? Session = null)
+{
+    public override string ToString()
+    {
+        if (Deleted && Name == null)
+            return $"{Uid}D";
+
+        return $"{Name} ({Uid}{(Prototype != null ? $", {Prototype}" : "")}{(Session != null ? $", {Session.Name}" : "")}){(Deleted ? "D" : "")}";
+    }
+
+    public static implicit operator EntityUid(EntityStringRepresentation rep) => rep.Uid;
+    public static implicit operator string(EntityStringRepresentation rep) => rep.ToString();
+}

--- a/Robust.Shared/GameObjects/EntityStringRepresentation.cs
+++ b/Robust.Shared/GameObjects/EntityStringRepresentation.cs
@@ -25,7 +25,6 @@ public readonly record struct EntityStringRepresentation
 
         return $"{Name} ({Uid}{(Prototype != null ? $", {Prototype}" : "")}{(Session != null ? $", {Session.Name}" : "")}){(Deleted ? "D" : "")}";
     }
-
-    public static implicit operator EntityUid(EntityStringRepresentation rep) => rep.Uid;
+    
     public static implicit operator string(EntityStringRepresentation rep) => rep.ToString();
 }

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -126,7 +126,7 @@ namespace Robust.Shared.GameObjects
         bool EntityExists(EntityUid uid);
 
         /// <summary>
-        /// Returns a string with various information regarding an entity.
+        /// Returns a string representation of an entity with various information regarding it.
         /// </summary>
         EntityStringRepresentation ToPrettyString(EntityUid uid);
 

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -128,7 +128,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         /// Returns a string with various information regarding an entity.
         /// </summary>
-        string ToPrettyString(EntityUid uid);
+        EntityStringRepresentation ToPrettyString(EntityUid uid);
 
         #endregion Entity Management
     }


### PR DESCRIPTION
Basically, instead of returning a plain string, we return a `readonly struct record` that contains a bunch of needed info for SS14 admin logging purposes. This type implicitly converts to `string` and `EntityUid` for convenience.