### PR TITLE
Graphics/Clyde: add option to submit GLSL `#defines` for shaders

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
@@ -52,11 +52,11 @@ namespace Robust.Client.Graphics.Clyde
             public StencilParameters Stencil = StencilParameters.Default;
         }
 
-        public ClydeHandle LoadShader(ParsedShader shader, string? name = null)
+        public ClydeHandle LoadShader(ParsedShader shader, string? name = null, Dictionary<string,string>? defines = null)
         {
             var (vertBody, fragBody) = GetShaderCode(shader);
 
-            var program = _compileProgram(vertBody, fragBody, BaseShaderAttribLocations, name);
+            var program = _compileProgram(vertBody, fragBody, BaseShaderAttribLocations, name, defines: defines);
 
             if (_hasGLUniformBuffers)
             {
@@ -141,7 +141,7 @@ namespace Robust.Client.Graphics.Clyde
         }
 
         private GLShaderProgram _compileProgram(string vertexSource, string fragmentSource,
-            (string, uint)[] attribLocations, string? name = null, bool includeLib=true)
+            (string, uint)[] attribLocations, string? name = null, bool includeLib=true, Dictionary<string,string>? defines=null)
         {
             GLShader? vertexShader = null;
             GLShader? fragmentShader = null;
@@ -184,6 +184,14 @@ namespace Robust.Client.Graphics.Clyde
             if (_hasGLUniformBuffers)
             {
                 versionHeader += "#define HAS_UNIFORM_BUFFERS\n";
+            }
+
+            if (defines is not null)
+            {
+                foreach (var k in defines.Keys)
+                {
+                    versionHeader += $"#define {k} {defines[k]}\n";
+                }
             }
 
             var lib = includeLib ? _shaderLibrary : "";

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -221,7 +221,7 @@ namespace Robust.Client.Graphics.Clyde
             return window;
         }
 
-        public ClydeHandle LoadShader(ParsedShader shader, string? name = null)
+        public ClydeHandle LoadShader(ParsedShader shader, string? name = null, Dictionary<string,string>? defines = null)
         {
             return default;
         }

--- a/Robust.Client/Graphics/IClydeInternal.cs
+++ b/Robust.Client/Graphics/IClydeInternal.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Robust.Client.Input;
 using Robust.Client.UserInterface;
 using Robust.Shared.Map;
@@ -31,7 +32,7 @@ namespace Robust.Client.Graphics
         event Action<WindowRequestClosedEventArgs> CloseWindow;
         event Action<WindowDestroyedEventArgs> DestroyWindow;
 
-        ClydeHandle LoadShader(ParsedShader shader, string? name = null);
+        ClydeHandle LoadShader(ParsedShader shader, string? name = null, Dictionary<string,string>? defines = null);
 
         void ReloadShader(ClydeHandle handle, ParsedShader newShader);
 


### PR DESCRIPTION
Still does what it says on the tin. Does absolutely nothing to prevent malformed `#define`s, so probably some room for improvement there. There *may* be a more clean option provided by the OpenGL library, but I didn't bother looking.