### PR TITLE
Allow tight grid fits

### DIFF
--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Configuration;
 using Robust.Shared.Log;
 using Robust.Shared.Network;
+using Robust.Shared.Physics;
 
 namespace Robust.Shared
 {
@@ -506,6 +507,12 @@ namespace Robust.Shared
         /// </summary>
         public static readonly CVarDef<bool> GenerateGridFixtures =
             CVarDef.Create("physics.grid_fixtures", true, CVar.REPLICATED);
+
+        /// <summary>
+        /// How much to enlarge grids when determining their fixture bounds.
+        /// </summary>
+        public static readonly CVarDef<float> GridFixtureEnlargement =
+            CVarDef.Create("physics.grid_fixture_enlargement", -PhysicsConstants.PolygonRadius, CVar.ARCHIVE | CVar.REPLICATED);
 
         // - Contacts
         public static readonly CVarDef<int> ContactMultithreadThreshold =

--- a/Robust.Shared/GameObjects/Systems/SharedGridFixtureSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridFixtureSystem.cs
@@ -81,7 +81,7 @@ namespace Robust.Shared.GameObjects
 
             foreach (var rectangle in rectangles)
             {
-                var bounds = rectangle.Translated(origin);
+                var bounds = ((Box2) rectangle.Translated(origin)).Enlarged(-PhysicsConstants.PolygonRadius);
                 var poly = new PolygonShape();
 
                 vertices[0] = bounds.BottomLeft;

--- a/Robust.Shared/GameObjects/Systems/SharedGridFixtureSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridFixtureSystem.cs
@@ -20,20 +20,32 @@ namespace Robust.Shared.GameObjects
 
         private bool _enabled;
 
+        private float _fixtureEnlargement;
+
         public override void Initialize()
         {
             base.Initialize();
             UpdatesBefore.Add(typeof(SharedBroadphaseSystem));
-            IoCManager.Resolve<IConfigurationManager>().OnValueChanged(CVars.GenerateGridFixtures, SetEnabled, true);
+
+            var configManager = IoCManager.Resolve<IConfigurationManager>();
+
+            configManager.OnValueChanged(CVars.GenerateGridFixtures, SetEnabled, true);
+            configManager.OnValueChanged(CVars.GridFixtureEnlargement, SetEnlargement, true);
         }
 
         public override void Shutdown()
         {
             base.Shutdown();
-            IoCManager.Resolve<IConfigurationManager>().UnsubValueChanged(CVars.GenerateGridFixtures, SetEnabled);
+
+            var configManager = IoCManager.Resolve<IConfigurationManager>();
+
+            configManager.UnsubValueChanged(CVars.GenerateGridFixtures, SetEnabled);
+            configManager.UnsubValueChanged(CVars.GridFixtureEnlargement, SetEnlargement);
         }
 
         private void SetEnabled(bool value) => _enabled = value;
+
+        private void SetEnlargement(float value) => _fixtureEnlargement = value;
 
         internal void ProcessGrid(IMapGridInternal gridInternal)
         {
@@ -81,7 +93,7 @@ namespace Robust.Shared.GameObjects
 
             foreach (var rectangle in rectangles)
             {
-                var bounds = ((Box2) rectangle.Translated(origin)).Enlarged(-PhysicsConstants.PolygonRadius);
+                var bounds = ((Box2) rectangle.Translated(origin)).Enlarged(_fixtureEnlargement);
                 var poly = new PolygonShape();
 
                 vertices[0] = bounds.BottomLeft;

--- a/Robust.Shared/Map/MapManager.cs
+++ b/Robust.Shared/Map/MapManager.cs
@@ -553,6 +553,9 @@ namespace Robust.Shared.Map
                 var matrix = gridEnt.Transform.InvWorldMatrix;
                 var localPos = matrix.Transform(worldPos);
 
+                // NOTE:
+                // If you change this to use fixtures instead (i.e. if you want half-tiles) then you need to make sure
+                // you account for the fact that fixtures are shrunk slightly!
                 var tile = new Vector2i((int) Math.Floor(localPos.X), (int) Math.Floor(localPos.Y));
                 var chunkIndices = mapGrid.GridTileToChunkIndices(tile);
 
@@ -614,6 +617,7 @@ namespace Robust.Shared.Map
                             {
                                 for (var i = 0; i < fixture.Shape.ChildCount; i++)
                                 {
+                                    // TODO: Need to use collisionmanager for overlapsies
                                     if (!fixture.Shape.ComputeAABB(transform, i).Intersects(worldAABB)) continue;
 
                                     intersects = true;


### PR DESCRIPTION
I tried using up to 3/4 of the poly radius for the shrinking but that still made it nigh impossible to move. This allows the movement to be smooth and games can override it to whatever they want.

This does lead to visible bound seams *but* it shouldn't matter outside of grid collisions. When we get half-tiles TryFindGridAt will need updating but we can cross that bridge when we get to it.

Next map save will also update these.

![image](https://user-images.githubusercontent.com/31366439/144696329-50afabf6-4382-475b-8c41-df50de3cc68e.png)
