### PR TITLE
Fixes pvs culling & make budgets more granular

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -429,8 +429,6 @@ namespace Robust.Client.GameStates
             var toApply = new Dictionary<EntityUid, (EntityState?, EntityState?)>();
             var toInitialize = new List<EntityUid>();
             var created = new List<EntityUid>();
-            var toHide = new List<EntityUid>();
-            var toShow = new List<EntityUid>();
 
             foreach (var es in curEntStates)
             {
@@ -440,9 +438,6 @@ namespace Robust.Client.GameStates
                 {
                     // Logger.Debug($"[{IGameTiming.TickStampStatic}] MOD {es.Uid}");
                     toApply.Add(uid, (es, null));
-                    if(_hiddenEntities.ContainsKey(uid))
-                        toShow.Add(uid);
-                    uid = es.Uid;
                 }
                 else //Unknown entities
                 {
@@ -456,10 +451,7 @@ namespace Robust.Client.GameStates
                     toApply.Add(newEntity, (es, null));
                     toInitialize.Add(newEntity);
                     created.Add(newEntity);
-                    uid = newEntity;
                 }
-                if(es.Hide)
-                    toHide.Add(uid);
             }
 
             foreach (var es in nextEntStates)
@@ -541,21 +533,6 @@ namespace Robust.Client.GameStates
                 _entityManager.DeleteEntity(entity);
             }
 #endif
-
-            foreach (var entityUid in toHide)
-            {
-                if(_entityManager.HasComponent<MapGridComponent>(entityUid)) continue;
-
-                var xform = _entityManager.GetComponent<TransformComponent>(entityUid);
-                _hiddenEntities.Add(entityUid, xform.MapID);
-                xform.ChangeMapId(MapId.Nullspace);
-            }
-
-            foreach (var entityUid in toShow)
-            {
-                _entityManager.GetComponent<TransformComponent>(entityUid).ChangeMapId(_hiddenEntities[entityUid]);
-                _hiddenEntities.Remove(entityUid);
-            }
 
             return created;
         }

--- a/Robust.Server/BaseServer.cs
+++ b/Robust.Server/BaseServer.cs
@@ -342,6 +342,12 @@ namespace Robust.Server
             IoCManager.Resolve<IEntityLookup>().Startup();
             _stateManager.Initialize();
 
+            var reg = _entityManager.ComponentFactory.GetRegistration<TransformComponent>();
+            if (!reg.NetID.HasValue)
+                throw new InvalidOperationException("TransformComponent does not have a NetId.");
+
+            _stateManager.TransformNetId = reg.NetID.Value;
+
             _scriptHost.Initialize();
 
             _modLoader.BroadcastRunLevel(ModRunLevel.PostInit);

--- a/Robust.Server/GameStates/IServerGameStateManager.cs
+++ b/Robust.Server/GameStates/IServerGameStateManager.cs
@@ -14,5 +14,7 @@ namespace Robust.Server.GameStates
         /// Create and dispatch game states to all connected sessions.
         /// </summary>
         void SendGameStateUpdate();
+
+        ushort TransformNetId { get; set; }
     }
 }

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -23,6 +23,7 @@ internal partial class PVSSystem : EntitySystem
     [Shared.IoC.Dependency] private readonly IMapManager _mapManager = default!;
     [Shared.IoC.Dependency] private readonly IPlayerManager _playerManager = default!;
     [Shared.IoC.Dependency] private readonly IConfigurationManager _configManager = default!;
+    [Shared.IoC.Dependency] private readonly IServerGameStateManager _stateManager = default!;
 
     public const float ChunkSize = 8;
 
@@ -30,11 +31,6 @@ internal partial class PVSSystem : EntitySystem
     /// Maximum number of pooled objects
     /// </summary>
     private const int MaxVisPoolSize = 1024;
-
-    /// <summary>
-    /// Starting number of entities that are in view
-    /// </summary>
-    private const int ViewSetCapacity = 256;
 
     /// <summary>
     /// Is view culling enabled, or will we send the whole map?
@@ -47,6 +43,11 @@ internal partial class PVSSystem : EntitySystem
     private int _newEntityBudget;
 
     /// <summary>
+    /// How many entered entities can be sent per tick.
+    /// </summary>
+    private int _entityBudget;
+
+    /// <summary>
     /// Size of the side of the view bounds square.
     /// </summary>
     private float _viewSize;
@@ -55,6 +56,7 @@ internal partial class PVSSystem : EntitySystem
     /// All <see cref="Robust.Shared.GameObjects.EntityUid"/>s a <see cref="ICommonSession"/> saw last iteration.
     /// </summary>
     private readonly Dictionary<ICommonSession, Dictionary<EntityUid, PVSEntityVisiblity>> _playerVisibleSets = new();
+    private readonly Dictionary<ICommonSession, HashSet<EntityUid>> _playerSeenSets = new();
 
     private PVSCollection<EntityUid> _entityPvsCollection = default!;
     public PVSCollection<EntityUid> EntityPVSCollection => _entityPvsCollection;
@@ -83,9 +85,15 @@ internal partial class PVSSystem : EntitySystem
 
         _configManager.OnValueChanged(CVars.NetPVS, SetPvs, true);
         _configManager.OnValueChanged(CVars.NetMaxUpdateRange, OnViewsizeChanged, true);
+        _configManager.OnValueChanged(CVars.NetPVSNewEntityBudget, OnNewEntityBudgetChanged, true);
         _configManager.OnValueChanged(CVars.NetPVSEntityBudget, OnEntityBudgetChanged, true);
 
         InitializeDirty();
+    }
+
+    private void OnEntityBudgetChanged(int obj)
+    {
+        _entityBudget = obj;
     }
 
     public override void Shutdown()
@@ -117,7 +125,7 @@ internal partial class PVSSystem : EntitySystem
         _cullingEnabled = value;
     }
 
-    private void OnEntityBudgetChanged(int obj)
+    private void OnNewEntityBudgetChanged(int obj)
     {
         _newEntityBudget = obj;
     }
@@ -193,6 +201,7 @@ internal partial class PVSSystem : EntitySystem
         if (e.NewStatus == SessionStatus.InGame)
         {
             _playerVisibleSets.Add(e.Session, _visSetPool.Get());
+            _playerSeenSets.Add(e.Session, new HashSet<EntityUid>());
             foreach (var pvsCollection in _pvsCollections)
             {
                 pvsCollection.AddPlayer(e.Session);
@@ -202,6 +211,7 @@ internal partial class PVSSystem : EntitySystem
         {
             _visSetPool.Return(_playerVisibleSets[e.Session]);
             _playerVisibleSets.Remove(e.Session);
+            _playerSeenSets.Remove(e.Session);
             foreach (var pvsCollection in _pvsCollections)
             {
                 pvsCollection.RemovePlayer(e.Session);
@@ -250,12 +260,12 @@ internal partial class PVSSystem : EntitySystem
 
     #endregion
 
-    //todo make this actually use toTick in non-all-sending
     public (List<EntityState>? updates, List<EntityUid>? deletions) CalculateEntityStates(ICommonSession session,
         GameTick fromTick, GameTick toTick)
     {
         DebugTools.Assert(session.Status == SessionStatus.InGame);
         var newEntitiesSent = 0;
+        var entitiesSent = 0;
 
         var deletions = _entityPvsCollection.GetDeletedIndices(fromTick);
         if (!_cullingEnabled)
@@ -266,23 +276,25 @@ internal partial class PVSSystem : EntitySystem
 
         var playerVisibleSet = _playerVisibleSets[session];
         var visibleEnts = _visSetPool.Get();
+        var seenSet = _playerSeenSets[session];
+
         visibleEnts.Clear();
 
         foreach (var entityUid in _entityPvsCollection.GlobalOverrides)
         {
-            TryAddToVisibleEnts(entityUid, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent);
+            TryAddToVisibleEnts(entityUid, seenSet, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, ref entitiesSent);
         }
 
         foreach (var entityUid in _entityPvsCollection.GetElementsForSession(session))
         {
-            TryAddToVisibleEnts(entityUid, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent);
+            TryAddToVisibleEnts(entityUid, seenSet, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, ref entitiesSent);
         }
 
         var expandEvent = new ExpandPvsEvent((IPlayerSession) session, new List<EntityUid>());
         RaiseLocalEvent(ref expandEvent);
         foreach (var entityUid in expandEvent.Entities)
         {
-            TryAddToVisibleEnts(entityUid, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent);
+            TryAddToVisibleEnts(entityUid, seenSet, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, ref entitiesSent);
         }
 
         var viewers = GetSessionViewers(session);
@@ -296,7 +308,7 @@ internal partial class PVSSystem : EntitySystem
                 visMask = eyeComp.VisibilityMask;
 
             //todo at some point just register the viewerentities as localoverrides
-            TryAddToVisibleEnts(eyeEuid, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, visMask);
+            TryAddToVisibleEnts(eyeEuid, seenSet, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, ref entitiesSent, visMask);
 
             var mapChunkEnumerator = new ChunkIndicesEnumerator(viewBox, ChunkSize);
 
@@ -306,7 +318,7 @@ internal partial class PVSSystem : EntitySystem
                 {
                     foreach (var index in chunk)
                     {
-                        TryAddToVisibleEnts(index, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, visMask);
+                        TryAddToVisibleEnts(index, seenSet, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, ref entitiesSent, visMask);
                     }
                 }
             }
@@ -323,7 +335,7 @@ internal partial class PVSSystem : EntitySystem
                     {
                         foreach (var index in chunk)
                         {
-                            TryAddToVisibleEnts(index, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, visMask);
+                            TryAddToVisibleEnts(index, seenSet, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, ref entitiesSent, visMask);
                         }
                     }
                 }
@@ -360,8 +372,10 @@ internal partial class PVSSystem : EntitySystem
             if (!EntityManager.EntityExists(entityUid))
                 continue;
 
-            //create a state indicating it should be hidden
-            entityStates.Add(new EntityState(entityUid, new NetListAsArray<ComponentChange>(), true));
+            entityStates.Add(new EntityState(entityUid, new NetListAsArray<ComponentChange>(new []
+            {
+                ComponentChange.Changed(_stateManager.TransformNetId, new TransformComponent.TransformComponentState(Vector2.Zero, Angle.Zero, EntityUid.Invalid, false, false)),
+            }), true));
         }
 
         _playerVisibleSets[session] = visibleEnts;
@@ -373,7 +387,7 @@ internal partial class PVSSystem : EntitySystem
     }
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-    private bool TryAddToVisibleEnts(EntityUid uid, Dictionary<EntityUid, PVSEntityVisiblity> previousVisibleEnts, Dictionary<EntityUid, PVSEntityVisiblity> toSend, GameTick fromTick, ref int newEntitiesSent, uint? visMask = null, bool dontSkip = false, bool trustParent = false)
+    private bool TryAddToVisibleEnts(EntityUid uid, HashSet<EntityUid> seenSet, Dictionary<EntityUid, PVSEntityVisiblity> previousVisibleEnts, Dictionary<EntityUid, PVSEntityVisiblity> toSend, GameTick fromTick, ref int newEntitiesSent, ref int totalEnteredEntities, uint? visMask = null, bool dontSkip = false, bool trustParent = false)
     {
         //are we valid yet?
         //sometimes uids gets added without being valid YET (looking at you mapmanager) (mapcreate & gridcreated fire before the uids becomes valid)
@@ -396,22 +410,32 @@ internal partial class PVSSystem : EntitySystem
         if (!trustParent && //do we have it on good authority the parent exists?
             parent.IsValid() && //is it not a worldentity?
             !toSend.ContainsKey(parent) && //was the parent not yet added to toSend?
-            !TryAddToVisibleEnts(parent, previousVisibleEnts, toSend, fromTick, ref newEntitiesSent, visMask)) //did we just fail to add the parent?
+            !TryAddToVisibleEnts(parent, seenSet, previousVisibleEnts, toSend, fromTick, ref newEntitiesSent, ref totalEnteredEntities, visMask)) //did we just fail to add the parent?
             return false; //we failed? suppose we dont get added either
 
         //did we already get added through the parent call?
         if (toSend.ContainsKey(uid)) return true;
 
-        //did the previous tick see us?
-        var @new = !previousVisibleEnts.Remove(uid);
+        //are we new?
+        var @new = !seenSet.Contains(uid);
+        var entered = @new | !previousVisibleEnts.Remove(uid);
+
+        if (entered)
+        {
+            if (!dontSkip && totalEnteredEntities >= _entityBudget)
+                return false;
+
+            totalEnteredEntities++;
+        }
 
         if (@new)
         {
             //we just entered pvs, do we still have enough budget to send us?
-            if(!dontSkip && newEntitiesSent > _newEntityBudget)
+            if(!dontSkip && newEntitiesSent >= _newEntityBudget)
                 return false;
 
             newEntitiesSent++;
+            seenSet.Add(uid);
         }
 
         //we *need* to send out contained entities too as part of the intial state
@@ -421,13 +445,19 @@ internal partial class PVSSystem : EntitySystem
             {
                 foreach (var containedEntity in container.ContainedEntities)
                 {
-                    TryAddToVisibleEnts(containedEntity, previousVisibleEnts, toSend, fromTick, ref newEntitiesSent, null,
+                    TryAddToVisibleEnts(containedEntity, seenSet, previousVisibleEnts, toSend, fromTick, ref newEntitiesSent, ref totalEnteredEntities, null,
                         true, true);
                 }
             }
         }
 
-        if (!@new && packet.MetaDataComponent.EntityLastModifiedTick < fromTick)
+        if (entered)
+        {
+            toSend.Add(uid, PVSEntityVisiblity.Entered);
+            return true;
+        }
+
+        if (packet.MetaDataComponent.EntityLastModifiedTick < fromTick)
         {
             //entity has been sent before and hasnt been updated since
             toSend.Add(uid, PVSEntityVisiblity.StayedUnchanged);
@@ -435,7 +465,7 @@ internal partial class PVSSystem : EntitySystem
         }
 
         //add us
-        toSend.Add(uid, @new ? PVSEntityVisiblity.Entered : PVSEntityVisiblity.StayedChanged);
+        toSend.Add(uid, PVSEntityVisiblity.StayedChanged);
         return true;
     }
 

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -42,6 +42,8 @@ namespace Robust.Server.GameStates
 
         private ISawmill _logger = default!;
 
+        public ushort TransformNetId { get; set; }
+
         public void PostInject()
         {
             _logger = Logger.GetSawmill("PVS");

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -86,8 +86,11 @@ namespace Robust.Shared
         public static readonly CVarDef<float> NetMaxUpdateRange =
             CVarDef.Create("net.maxupdaterange", 12.5f, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
 
+        public static readonly CVarDef<int> NetPVSNewEntityBudget =
+            CVarDef.Create("net.pvs_new_budget", 20, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
+
         public static readonly CVarDef<int> NetPVSEntityBudget =
-            CVarDef.Create("net.pvsbudget", 100, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
+            CVarDef.Create("net.pvs_budget", 50, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
 
         public static readonly CVarDef<bool> NetLogLateMsg =
             CVarDef.Create("net.log_late_msg", true);

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -902,6 +902,7 @@ namespace Robust.Shared.GameObjects
                 _prevRotation = newState.Rotation;
 
                 Anchored = newState.Anchored;
+                _noLocalRotation = newState.NoLocalRotation;
 
                 // This is not possible, because client entities don't exist on the server, so the parent HAS to be a shared entity.
                 // If this assert fails, the code above that sets the parent is broken.

--- a/Robust.Shared/GameObjects/EntityState.cs
+++ b/Robust.Shared/GameObjects/EntityState.cs
@@ -12,12 +12,10 @@ namespace Robust.Shared.GameObjects
         public NetListAsArray<ComponentChange> ComponentChanges { get; }
 
         public bool Empty => ComponentChanges.Value is null or { Count: 0 };
-        public bool Hide;
 
         public EntityState(EntityUid uid, NetListAsArray<ComponentChange> changedComponents, bool hide = false)
         {
             Uid = uid;
-            Hide = hide;
             ComponentChanges = changedComponents;
         }
     }


### PR DESCRIPTION
split the entitybudget up into a total streaming budget (entities entering pvs), as well as a new entity budget (entities never before seen by client -> will need to be allocated)

also refactors pvs culling to just send a transformcompstate sending the entitiy to nullspace. this should fix the bugs people saw of stuff disappearing.