### PR TITLE
Some minor PVS optimizations

### DIFF
--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -492,9 +492,9 @@ internal partial class PVSSystem : EntitySystem
             foreach (var uid in add)
             {
                 if (!seenEnts.Add(uid)) continue;
-                if (!EntityManager.EntityExists(uid)) continue;
+                // This is essentially the same as IEntityManager.EntityExists, but returning MetaDataComponent.
+                if (!EntityManager.TryGetComponent(uid, out MetaDataComponent? md)) continue;
 
-                var md = EntityManager.GetComponent<MetaDataComponent>(uid);
                 var ls = md.EntityLifeStage;
                 if (ls >= EntityLifeStage.Deleted) continue;
 
@@ -509,9 +509,8 @@ internal partial class PVSSystem : EntitySystem
                 DebugTools.Assert(!add.Contains(uid));
 
                 if (!seenEnts.Add(uid)) continue;
-                if (!EntityManager.EntityExists(uid)) continue;
+                if (!EntityManager.TryGetComponent(uid, out MetaDataComponent? md)) continue;
 
-                var md = EntityManager.GetComponent<MetaDataComponent>(uid);
                 var ls = md.EntityLifeStage;
                 if (ls >= EntityLifeStage.Deleted) continue;
 
@@ -529,17 +528,16 @@ internal partial class PVSSystem : EntitySystem
 
         stateEntities = new List<EntityState>(EntityManager.EntityCount);
 
-        foreach (var entity in EntityManager.GetEntities())
+        // This is the same as iterating every existing entity.
+        foreach (var md in EntityManager.EntityQuery<MetaDataComponent>(true))
         {
-            if (!EntityManager.EntityExists(entity)) continue;
-            var md = EntityManager.GetComponent<MetaDataComponent>(entity);
             var ls = md.EntityLifeStage;
             if (ls >= EntityLifeStage.Deleted) continue;
 
             DebugTools.Assert(ls >= EntityLifeStage.Initialized);
 
             if (md.EntityLastModifiedTick >= fromTick)
-                stateEntities.Add(GetEntityState(player, entity, fromTick));
+                stateEntities.Add(GetEntityState(player, md.Owner, fromTick));
         }
 
         // no point sending an empty collection

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -494,11 +494,8 @@ internal partial class PVSSystem : EntitySystem
                 if (!seenEnts.Add(uid)) continue;
                 // This is essentially the same as IEntityManager.EntityExists, but returning MetaDataComponent.
                 if (!EntityManager.TryGetComponent(uid, out MetaDataComponent? md)) continue;
-
-                var ls = md.EntityLifeStage;
-                if (ls >= EntityLifeStage.Deleted) continue;
-
-                DebugTools.Assert(ls >= EntityLifeStage.Initialized);
+                
+                DebugTools.Assert(md.EntityLifeStage >= EntityLifeStage.Initialized);
 
                 if (md.EntityLastModifiedTick >= fromTick)
                     stateEntities.Add(GetEntityState(player, uid, GameTick.Zero));
@@ -511,10 +508,7 @@ internal partial class PVSSystem : EntitySystem
                 if (!seenEnts.Add(uid)) continue;
                 if (!EntityManager.TryGetComponent(uid, out MetaDataComponent? md)) continue;
 
-                var ls = md.EntityLifeStage;
-                if (ls >= EntityLifeStage.Deleted) continue;
-
-                DebugTools.Assert(ls >= EntityLifeStage.Initialized);
+                DebugTools.Assert(md.EntityLifeStage >= EntityLifeStage.Initialized);
 
                 if (md.EntityLastModifiedTick >= fromTick)
                     stateEntities.Add(GetEntityState(player, uid, fromTick));

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -531,10 +531,7 @@ internal partial class PVSSystem : EntitySystem
         // This is the same as iterating every existing entity.
         foreach (var md in EntityManager.EntityQuery<MetaDataComponent>(true))
         {
-            var ls = md.EntityLifeStage;
-            if (ls >= EntityLifeStage.Deleted) continue;
-
-            DebugTools.Assert(ls >= EntityLifeStage.Initialized);
+            DebugTools.Assert(md.EntityLifeStage >= EntityLifeStage.Initialized);
 
             if (md.EntityLastModifiedTick >= fromTick)
                 stateEntities.Add(GetEntityState(player, md.Owner, fromTick));


### PR DESCRIPTION
Reduces some redundant dictionary lookups.

`EntityExists` and `GetComponent<MetaDataComponent>` can be turned into a single `TryGetComponent<MetaDataComponent>` check
`GetEntities()` and `GetComponent<MetaDataComponent>` can be turned into an `EntityQuery<MetaDataComponent>()`