### PR TITLE
defer field DI for RegisterInstance

### DIFF
--- a/Robust.Shared/IoC/IDependencyCollection.cs
+++ b/Robust.Shared/IoC/IDependencyCollection.cs
@@ -93,15 +93,21 @@ namespace Robust.Shared.IoC
         ///     Registers an interface to an existing instance of an implementation,
         ///     making it accessible to <see cref="IDependencyCollection.Resolve{T}"/>.
         ///     Unlike <see cref="IDependencyCollection.Register{TInterface, TImplementation}"/>,
-        ///     <see cref="IDependencyCollection.BuildGraph"/> does not need to be called after registering an instance.
+        ///     <see cref="IDependencyCollection.BuildGraph"/> does not need to be called after registering an instance
+        ///     if deferredInject is false.
         /// </summary>
         /// <typeparam name="TInterface">The type that will be resolvable.</typeparam>
         /// <param name="implementation">The existing instance to use as the implementation.</param>
         /// <param name="overwrite">
-        /// If true, do not throw an <see cref="InvalidOperationException"/> if an interface is already registered,
-        /// replace the current implementation instead.
+        ///     If true, do not throw an <see cref="InvalidOperationException"/> if an interface is already registered,
+        ///     replace the current implementation instead.
         /// </param>
-        void RegisterInstance<TInterface>(object implementation, bool overwrite = false);
+        /// <param name="deferInject">
+        ///     Defer field injection until <see cref="IDependencyCollection.BuildGraph"/> is called.
+        ///     If this is false, dependencies will be immediately injected. If the registered type requires dependencies
+        ///     that don't exist yet because you have not called BuildGraph, set this to true.
+        /// </param>
+        void RegisterInstance<TInterface>(object implementation, bool overwrite = false, bool deferInject = false);
 
         /// <summary>
         ///     Registers an interface to an existing instance of an implementation,
@@ -112,10 +118,15 @@ namespace Robust.Shared.IoC
         /// <param name="type">The type that will be resolvable.</param>
         /// <param name="implementation">The existing instance to use as the implementation.</param>
         /// <param name="overwrite">
-        /// If true, do not throw an <see cref="InvalidOperationException"/> if an interface is already registered,
-        /// replace the current implementation instead.
+        ///     If true, do not throw an <see cref="InvalidOperationException"/> if an interface is already registered,
+        ///     replace the current implementation instead.
         /// </param>
-        void RegisterInstance(Type type, object implementation, bool overwrite = false);
+        /// <param name="deferInject">
+        ///     Defer field injection until <see cref="IDependencyCollection.BuildGraph"/> is called.
+        ///     If this is false, dependencies will be immediately injected. If the registered type requires dependencies
+        ///     that don't exist yet because you have not called BuildGraph, set this to true.
+        /// </param>
+        void RegisterInstance(Type type, object implementation, bool overwrite = false, bool deferInject = false);
 
         /// <summary>
         /// Clear all services and types.

--- a/Robust.Shared/IoC/IoCManager.cs
+++ b/Robust.Shared/IoC/IoCManager.cs
@@ -151,19 +151,25 @@ namespace Robust.Shared.IoC
         ///     Registers an interface to an existing instance of an implementation,
         ///     making it accessible to <see cref="IDependencyCollection.Resolve{T}"/>.
         ///     Unlike <see cref="IDependencyCollection.Register{TInterface, TImplementation}"/>,
-        ///     <see cref="IDependencyCollection.BuildGraph"/> does not need to be called after registering an instance.
+        ///     <see cref="IDependencyCollection.BuildGraph"/> does not need to be called after registering an instance
+        ///     if deferredInject is false.
         /// </summary>
         /// <typeparam name="TInterface">The type that will be resolvable.</typeparam>
         /// <param name="implementation">The existing instance to use as the implementation.</param>
         /// <param name="overwrite">
-        /// If true, do not throw an <see cref="InvalidOperationException"/> if an interface is already registered,
-        /// replace the current implementation instead.
+        ///     If true, do not throw an <see cref="InvalidOperationException"/> if an interface is already registered,
+        ///     replace the current implementation instead.
         /// </param>
-        public static void RegisterInstance<TInterface>(object implementation, bool overwrite = false)
+        /// <param name="deferInject">
+        ///     Defer field injection until <see cref="IDependencyCollection.BuildGraph"/> is called.
+        ///     If this is false, dependencies will be immediately injected. If the registered type requires dependencies
+        ///     that don't exist yet because you have not called BuildGraph, set this to true.
+        /// </param>
+        public static void RegisterInstance<TInterface>(object implementation, bool overwrite = false, bool deferInject = false)
         {
             DebugTools.Assert(_container.IsValueCreated, NoContextAssert);
 
-            _container.Value!.RegisterInstance<TInterface>(implementation, overwrite);
+            _container.Value!.RegisterInstance<TInterface>(implementation, overwrite, deferInject);
         }
 
         /// <summary>


### PR DESCRIPTION
Added an option to defer field DI for RegisteredInstances until BuildGraph is called. This lets you register instances that contain dependency fields that are not instantiated yet.