### PR TITLE
Fix CVars overridden by program arguments not replicating to the client

### DIFF
--- a/Robust.Shared/Configuration/ConfigurationManager.cs
+++ b/Robust.Shared/Configuration/ConfigurationManager.cs
@@ -357,7 +357,7 @@ namespace Robust.Shared.Configuration
         {
             if (_configVars.TryGetValue(name, out var cVar) && cVar.Registered)
                 //TODO: Make flags work, required non-derpy net system.
-                return (T) (cVar.OverrideValueParsed ?? cVar.Value ?? cVar.DefaultValue)!;
+                return (T) (GetConfigVarValue(cVar))!;
 
             throw new InvalidConfigurationException($"Trying to get unregistered variable '{name}'");
         }
@@ -376,6 +376,11 @@ namespace Robust.Shared.Configuration
 
             // If it's null it's a string, since the rest is primitives which aren't null.
             return cVar.Value?.GetType() ?? typeof(string);
+        }
+
+        protected static object GetConfigVarValue(ConfigVar cVar)
+        {
+            return cVar.OverrideValueParsed ?? cVar.Value ?? cVar.DefaultValue;
         }
 
         public void OverrideConVars(IEnumerable<(string key, string value)> cVars)

--- a/Robust.Shared/Configuration/NetConfigurationManager.cs
+++ b/Robust.Shared/Configuration/NetConfigurationManager.cs
@@ -330,7 +330,7 @@ namespace Robust.Shared.Configuration
                 if (_netManager.IsClient && (cVar.Flags & CVar.SERVER) != 0)
                     continue;
 
-                nwVars.Add((cVar.Name, cVar.Value ?? cVar.DefaultValue));
+                nwVars.Add((cVar.Name, GetConfigVarValue(cVar)));
 
                 Logger.DebugS("cfg", $"name={cVar.Name}, val={(cVar.Value ?? cVar.DefaultValue)}");
             }


### PR DESCRIPTION
This fixes CVars set in the program arguments not being correctly replicated to the client.

`--cvar net.tickrate=20` would replicate the `DefaultValue` to the client when it connected instead of the `OverrideValueParsed`.