### PR TITLE
Auto Command Localization

### DIFF
--- a/Robust.Shared/Console/ConsoleCommand.cs
+++ b/Robust.Shared/Console/ConsoleCommand.cs
@@ -1,0 +1,23 @@
+using Robust.Shared.IoC;
+using Robust.Shared.Localization;
+
+namespace Robust.Shared.Console
+{
+    public abstract class ConsoleCommand : IConsoleCommand
+    {
+        [Dependency]
+        private readonly ILocalizationManager _loc = default!;
+
+        /// <inheritdoc />
+        public abstract string Command { get; }
+
+        /// <inheritdoc />
+        public string Description => _loc.GetCommandData(Command).Desc;
+
+        /// <inheritdoc />
+        public string Help => _loc.GetCommandData(Command).Help;
+
+        /// <inheritdoc />
+        public abstract void Execute( IConsoleShell shell, string argStr, string[] args );
+    }
+}

--- a/Robust.Shared/Localization/CommandLocData.cs
+++ b/Robust.Shared/Localization/CommandLocData.cs
@@ -1,0 +1,10 @@
+namespace Robust.Shared.Localization
+{
+    /// <summary>
+    ///     Contains localization data for console commands.
+    /// </summary>
+    public record CommandLocData(
+        string Desc,
+        string Help
+    );
+}

--- a/Robust.Shared/Localization/ILocalizationManager.cs
+++ b/Robust.Shared/Localization/ILocalizationManager.cs
@@ -83,6 +83,12 @@ namespace Robust.Shared.Localization
         ///     Gets localization data for an entity prototype.
         /// </summary>
         EntityLocData GetEntityData(string prototypeId);
+
+        /// <summary>
+        ///     Gets localization data for a console command.
+        /// </summary>
+        /// <param name="command">The command to get localization for, as a string.</param>
+        CommandLocData GetCommandData(string command);
     }
 
     internal interface ILocalizationManagerInternal : ILocalizationManager

--- a/Robust.Shared/Localization/LocalizationManager.cs
+++ b/Robust.Shared/Localization/LocalizationManager.cs
@@ -261,5 +261,46 @@ namespace Robust.Shared.Localization
                 _logSawmill.Warning("Error extracting `{locId}`\n{e1}", locId, err);
             }
         }
+
+        public CommandLocData GetCommandData(string command)
+        {
+            var locId = $"cmd-{command}";
+
+            string? desc = null;
+            string? help = null;
+
+            // get message from Fluent
+            if (TryGetMessage(locId, out var bundle, out var message))
+            {
+                // loop through attributes to find help attribute
+                foreach (var (attrId, pattern) in message.Attributes)
+                {
+                    var attrib = attrId.ToString();
+                    if (attrib.Equals("help"))
+                    {
+                        // get string from attribute pattern
+                        help = bundle.FormatPattern(pattern, null, out var errors);
+                        WriteWarningForErrs(errors, locId);
+
+                        break;
+                    } else
+                    {
+                        continue;
+                    }
+                }
+
+                if (message.Value != null)
+                {
+                    // get string from pattern
+                    desc = bundle.FormatPattern(message.Value, null, out var errors);
+                    WriteWarningForErrs(errors, locId);
+                }
+            }
+
+            return new CommandLocData(
+                desc ?? "",
+                help ?? ""
+            );
+        }
     }
 }


### PR DESCRIPTION
To begin satisfying space-wizards/space-station-14#5543, these changes allow for command localization to be automatically recognized if the correct keys are defined in the locale. This takes some heavy inspiration from how it was implemented for EntityPrototypes:

Additions:
+ New abstract `ConsoleCommand` class, extends interface and overrides the `Description` and `Help` members.
  - Commands should inherit this new class to use the automatic localization
+ `CommandLocData` record to house the localization data.

Modifications:
+ Helper method `GetCommandData()`, which fetches the fluent message from the locale and returns it for the abstract.
  - This was also added to the interface.

I see that the `LocalizationManager` has been split between 3 partials, (main, Entity, and Fluent functions), but I didn't see a reason to add an entire separate partial just for one method, let me know if this is unwanted.

I also just used the `[Dependency]` attribute to resolve the loc manager in the abstract, and didn't include a PostInject or anything like that, but I figured it was fine. Let me know if this is also problematic.

Eventually I would think about changing over the reflection manager for console commands to look for the abstract rather than the interface, but for backwards compatibility I've left it unchanged for now. I'm working on a content-side to this PR that implements the new class and adds localization for all commands.

Thoughts?

Edit: meant to include that the message keys it looks for are of the format `cmd-<command>`, so for defining localization for the `changelog` command, it would be `cmd-changelog` with the value being the description, then the attribute `.help` being the help localization.