### PR TITLE
Optimise client 5% with this one trick

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -337,10 +337,12 @@ namespace Robust.Client.GameStates
 
         private void ResetPredictedEntities(GameTick curTick)
         {
-            foreach (var entity in _entities.GetEntities())
+            foreach (var meta in _entityManager.EntityQuery<MetaDataComponent>(true))
             {
+                var entity = meta.Owner;
+
                 // TODO: 99% there's an off-by-one here.
-                if (entity.IsClientSide() || _entityManager.GetComponent<MetaDataComponent>(entity).EntityLastModifiedTick < curTick)
+                if (entity.IsClientSide() || meta.EntityLastModifiedTick < curTick)
                 {
                     continue;
                 }


### PR DESCRIPTION
Beyond this you either need:
Funny struct enumerator, or
Cache the modified entities (probably more ideal at higher entity counts)