### PR TITLE
Minor xform optimisations

### DIFF
--- a/Robust.Shared/GameObjects/Components/Map/MapGridComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Map/MapGridComponent.cs
@@ -20,7 +20,6 @@ namespace Robust.Shared.GameObjects
 
         bool AnchorEntity(TransformComponent transform);
         void UnanchorEntity(TransformComponent transform);
-        void AnchoredEntityDirty(TransformComponent transform);
     }
 
     /// <inheritdoc cref="IMapGridComponent"/>
@@ -107,16 +106,6 @@ namespace Robust.Shared.GameObjects
             {
                 physicsComponent.BodyType = BodyType.Dynamic;
             }
-        }
-
-        /// <inheritdoc />
-        public void AnchoredEntityDirty(TransformComponent transform)
-        {
-            if (!transform.Anchored)
-                return;
-
-            var grid = (IMapGridInternal) _mapManager.GetGrid(transform.GridID);
-            grid.AnchoredEntDirty(grid.TileIndicesFor(transform.Coordinates));
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Prometheus;
-using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
@@ -262,7 +261,7 @@ namespace Robust.Shared.GameObjects
 
             var transform = GetComponent<TransformComponent>(uid);
             var metadata = GetComponent<MetaDataComponent>(uid);
-            GetComponent<MetaDataComponent>(uid).EntityLifeStage = EntityLifeStage.Terminating;
+            metadata.EntityLifeStage = EntityLifeStage.Terminating;
             EventBus.RaiseLocalEvent(uid, new EntityTerminatingEvent(), false);
 
             // DeleteEntity modifies our _children collection, we must cache the collection to iterate properly

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -4,6 +4,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.GameObjects
 {
@@ -25,10 +26,16 @@ namespace Robust.Shared.GameObjects
         {
             if (!component.Anchored ||
                 !component.ParentUid.IsValid() ||
-                EntityManager.GetComponent<MetaDataComponent>(uid).EntityLifeStage < EntityLifeStage.Initialized)
+                MetaData(uid).EntityLifeStage < EntityLifeStage.Initialized)
                 return;
 
-            EntityManager.GetComponent<IMapGridComponent>(component.ParentUid).AnchoredEntityDirty(component);
+            // Anchor dirty
+            // May not even need this in future depending what happens with chunk anchoring (paulVS plz).
+            var gridComp = EntityManager.GetComponent<IMapGridComponent>(component.ParentUid);
+
+            var grid = (IMapGridInternal) gridComp.Grid;
+            DebugTools.Assert(component.GridID == gridComp.GridIndex);
+            grid.AnchoredEntDirty(grid.TileIndicesFor(component.Coordinates));
         }
 
         public override void Shutdown()


### PR DESCRIPTION
- Saves a GetGrid on dirty anchored entities
- Avoids an unnecessary GetComponent on deleting entities