### PR TITLE
Expose IContentRoot to content.

### DIFF
--- a/Robust.Client/ResourceManagement/ResourceCache.LoaderApi.cs
+++ b/Robust.Client/ResourceManagement/ResourceCache.LoaderApi.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Robust.LoaderApi;
+using Robust.Shared.ContentPack;
 using Robust.Shared.Utility;
 
 namespace Robust.Client.ResourceManagement

--- a/Robust.Shared/ContentPack/IContentRoot.cs
+++ b/Robust.Shared/ContentPack/IContentRoot.cs
@@ -5,39 +5,36 @@ using Robust.Shared.Utility;
 
 namespace Robust.Shared.ContentPack
 {
-    internal partial class ResourceManager
+    /// <summary>
+    ///     Common interface for mounting various things in the VFS.
+    /// </summary>
+    public interface IContentRoot
     {
         /// <summary>
-        ///     Common interface for mounting various things in the VFS.
+        ///     Initializes the content root.
+        ///     Throws an exception if the content root failed to mount.
         /// </summary>
-        protected interface IContentRoot
-        {
-            /// <summary>
-            ///     Initializes the content root.
-            ///     Throws an exception if the content root failed to mount.
-            /// </summary>
-            void Mount();
+        void Mount();
 
-            /// <summary>
-            ///     Gets a file from the content root using the relative path.
-            /// </summary>
-            /// <param name="relPath">Relative path from the root directory.</param>
-            /// <param name="stream"></param>
-            /// <returns>A stream of the file loaded into memory.</returns>
-            bool TryGetFile(ResourcePath relPath, [NotNullWhen(true)] out Stream? stream);
+        /// <summary>
+        ///     Gets a file from the content root using the relative path.
+        /// </summary>
+        /// <param name="relPath">Relative path from the root directory.</param>
+        /// <param name="stream"></param>
+        /// <returns>A stream of the file loaded into memory.</returns>
+        bool TryGetFile(ResourcePath relPath, [NotNullWhen(true)] out Stream? stream);
 
-            /// <summary>
-            ///     Recursively finds all files in a directory and all sub directories.
-            /// </summary>
-            /// <param name="path">Directory to search inside of.</param>
-            /// <returns>Enumeration of all relative file paths of the files found.</returns>
-            IEnumerable<ResourcePath> FindFiles(ResourcePath path);
+        /// <summary>
+        ///     Recursively finds all files in a directory and all sub directories.
+        /// </summary>
+        /// <param name="path">Directory to search inside of.</param>
+        /// <returns>Enumeration of all relative file paths of the files found.</returns>
+        IEnumerable<ResourcePath> FindFiles(ResourcePath path);
 
-            /// <summary>
-            ///     Recursively returns relative paths to resource files.
-            /// </summary>
-            /// <returns>Enumeration of all relative file paths.</returns>
-            IEnumerable<string> GetRelativeFilePaths();
-        }
+        /// <summary>
+        ///     Recursively returns relative paths to resource files.
+        /// </summary>
+        /// <returns>Enumeration of all relative file paths.</returns>
+        IEnumerable<string> GetRelativeFilePaths();
     }
 }

--- a/Robust.Shared/ContentPack/IResourceManager.cs
+++ b/Robust.Shared/ContentPack/IResourceManager.cs
@@ -19,6 +19,13 @@ namespace Robust.Shared.ContentPack
         IWritableDirProvider UserData { get; }
 
         /// <summary>
+        ///     Provides a way to mount a <see cref="IContentRoot"/> implementation to the VFS.
+        /// </summary>
+        /// <param name="prefix"></param>
+        /// <param name="loader"></param>
+        void AddRoot(ResourcePath prefix, IContentRoot loader);
+
+        /// <summary>
         ///     Read a file from the mounted content roots.
         /// </summary>
         /// <param name="path">The path to the file in the VFS. Must be rooted.</param>

--- a/Robust.Shared/ContentPack/ResourceManager.cs
+++ b/Robust.Shared/ContentPack/ResourceManager.cs
@@ -93,7 +93,7 @@ namespace Robust.Shared.ContentPack
             AddRoot(prefix, loader);
         }
 
-        protected void AddRoot(ResourcePath prefix, IContentRoot loader)
+        public void AddRoot(ResourcePath prefix, IContentRoot loader)
         {
             loader.Mount();
             _contentRootsLock.EnterWriteLock();


### PR DESCRIPTION
Don't merge without a review from @PJB3005, just in case.

Exposes the `IContentRoot` interface and `IResourceManager.AddRoot(ResourcePath prefix, IContentRoot loader)` methods to content, allowing it to implement and mount an arbitrary VFS. This should allow things such as admin resource loading, on SS14.

Note: this does NOT expose any of the engine internal `IContentRoot` inheritors, such as `DirLoader` or `PackLoader` for security concerns.