### PR TITLE
Make `ContainerSystem.ContainsEntity()` not log missing components

### DIFF
--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -77,7 +77,7 @@ namespace Robust.Shared.Containers
 
         public bool ContainsEntity(EntityUid uid, EntityUid containedUid, ContainerManagerComponent? containerManager = null)
         {
-            if (!Resolve(uid, ref containerManager) || !EntityManager.EntityExists(containedUid))
+            if (!Resolve(uid, ref containerManager, false) || !EntityManager.EntityExists(containedUid))
                 return false;
 
             return containerManager.ContainsEntity(containedUid);


### PR DESCRIPTION
This just makes the `Resolve()` in `ContainsEntity()` not log an error when the "containing" entity has no container component.