### PR TITLE
EntityQuery funnies

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -717,6 +717,7 @@ namespace Robust.Shared.GameObjects
 
         public EntQueryEnumerator<T> EntityQueryEnumerator<T>(bool includePaused = false) where T : Component
         {
+            // Unless you have a profile showing a speed need for the funny struct enumerator just using the IEnumerable is easier.
             var comps = _entTraitDict[ComponentTypeCache<T>.Type];
             var meta = _entTraitDict[ComponentTypeCache<MetaDataComponent>.Type];
             var enumerator = new EntQueryEnumerator<T>(includePaused, comps.GetEnumerator(), meta);

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -660,13 +660,13 @@ namespace Robust.Shared.GameObjects
         #region Join Functions
 
         // Funny struct enumerator equivalent to EntityQuery<T>
-        public struct EntityQueryEnumerator<T> : IDisposable where T : Component
+        public struct EntQueryEnumerator<T> : IDisposable where T : Component
         {
             private readonly bool _includePaused;
             private Dictionary<EntityUid, Component>.Enumerator _comps;
             private Dictionary<EntityUid, Component> _metaData;
 
-            public EntityQueryEnumerator(bool includePaused, Dictionary<EntityUid, Component>.Enumerator comps, Dictionary<EntityUid, Component> metaData)
+            public EntQueryEnumerator(bool includePaused, Dictionary<EntityUid, Component>.Enumerator comps, Dictionary<EntityUid, Component> metaData)
             {
                 _includePaused = includePaused;
                 _comps = comps;
@@ -715,11 +715,11 @@ namespace Robust.Shared.GameObjects
             }
         }
 
-        public EntityQueryEnumerator<T> EntityQueryEnumeration<T>(bool includePaused = false) where T : Component
+        public EntQueryEnumerator<T> EntityQueryEnumerator<T>(bool includePaused = false) where T : Component
         {
             var comps = _entTraitDict[ComponentTypeCache<T>.Type];
             var meta = _entTraitDict[ComponentTypeCache<MetaDataComponent>.Type];
-            var enumerator = new EntityQueryEnumerator<T>(includePaused, comps.GetEnumerator(), meta);
+            var enumerator = new EntQueryEnumerator<T>(includePaused, comps.GetEnumerator(), meta);
             return enumerator;
         }
 

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -279,7 +279,7 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         /// <typeparam name="T">A trait or type of a component to retrieve.</typeparam>
         /// <returns>All components that have the specified type.</returns>
-        EntityManager.EntityQueryEnumerator<T> EntityQueryEnumeration<T>(bool includePaused = false) where T : Component;
+        EntityManager.EntQueryEnumerator<T> EntityQueryEnumerator<T>(bool includePaused = false) where T : Component;
 
         /// <summary>
         ///     Returns ALL component instances of a specified type.

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -279,7 +279,14 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         /// <typeparam name="T">A trait or type of a component to retrieve.</typeparam>
         /// <returns>All components that have the specified type.</returns>
-        IEnumerable<T> EntityQuery<T>(bool includePaused = false);
+        EntityManager.EntityQueryEnumerator<T> EntityQueryEnumeration<T>(bool includePaused = false) where T : Component;
+
+        /// <summary>
+        ///     Returns ALL component instances of a specified type.
+        /// </summary>
+        /// <typeparam name="T">A trait or type of a component to retrieve.</typeparam>
+        /// <returns>All components that have the specified type.</returns>
+        IEnumerable<T> EntityQuery<T>(bool includePaused = false) where T: IComponent;
 
         /// <summary>
         /// Returns the relevant components from all entities that contain the two required components.

--- a/Robust.Shared/Map/MapManager.cs
+++ b/Robust.Shared/Map/MapManager.cs
@@ -248,7 +248,7 @@ namespace Robust.Shared.Map
 
             if (actualID != MapId.Nullspace) // nullspace isn't bound to an entity
             {
-                var mapComps = _entityManager.EntityQuery<IMapComponent>(true);
+                var mapComps = _entityManager.EntityQuery<MapComponent>(true);
 
                 IMapComponent? result = null;
                 foreach (var mapComp in mapComps)
@@ -431,7 +431,7 @@ namespace Robust.Shared.Map
             {
                 // the entity may already exist from map deserialization
                 IMapGridComponent? result = null;
-                foreach (var comp in _entityManager.EntityQuery<IMapGridComponent>(true))
+                foreach (var comp in _entityManager.EntityQuery<MapGridComponent>(true))
                 {
                     if (comp.GridIndex != actualID)
                         continue;


### PR DESCRIPTION
Struct enumerator though its speed is slightly worse than the IEnumerable and needs profiling on the allocs.

The real benefit is the 20x speedup due to not doing the IEntityManager resolve in the background when checking if an entity is paused.

Will need a content update for the generic constraint on EntityQuery<T> to align with the others.