### PR TITLE
Add nullable overrides for the the Deleted() & Exists() proxy methods.

### DIFF
--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -19,6 +19,13 @@ public partial class EntitySystem
         return EntityManager.EntityExists(uid);
     }
 
+    /// <inheritdoc cref="IEntityManager.EntityExists" />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool Exists([NotNullWhen(true)] EntityUid? uid)
+    {
+        return EntityManager.EntityExists(uid);
+    }
+
     /// <summary>
     ///     Retrieves whether the entity is initializing. Throws if the entity does not exist.
     /// </summary>
@@ -56,6 +63,15 @@ public partial class EntitySystem
             return true;
 
         return metaData.EntityDeleted;
+    }
+
+    /// <summary>
+    ///     Retrieves whether the entity is deleted or is nonexistent.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool Deleted([NotNullWhen(false)] EntityUid? uid)
+    {
+        return !uid.HasValue || Deleted(uid.Value);
     }
 
     /// <inheritdoc cref="MetaDataComponent.EntityLifeStage" />

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -20,7 +20,7 @@ public partial class EntitySystem
     }
 
     /// <inheritdoc cref="IEntityManager.EntityExists" />
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public bool Exists([NotNullWhen(true)] EntityUid? uid)
     {
         return EntityManager.EntityExists(uid);
@@ -68,7 +68,7 @@ public partial class EntitySystem
     /// <summary>
     ///     Retrieves whether the entity is deleted or is nonexistent.
     /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public bool Deleted([NotNullWhen(false)] EntityUid? uid)
     {
         return !uid.HasValue || Deleted(uid.Value);


### PR DESCRIPTION
The `EntityManager.Deleted()` & `EntityExists()` functions have overrides that take nullable uids with `NotNullWhen` attributes for the input. This just adds similar overrides for the new proxy methods.