### PR TITLE
Fix destroyproxies crashing when getting transform

### DIFF
--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -775,7 +775,7 @@ namespace Robust.Shared.Physics
             }
 
             var proxyCount = fixture.ProxyCount;
-            var moveBuffer = _moveBuffer[_entityManager.GetComponent<TransformComponent>(broadphase.Owner).MapID];
+            var moveBuffer = _moveBuffer[fixture.Body.PhysicsMap!.MapId];
 
             for (var i = 0; i < proxyCount; i++)
             {


### PR DESCRIPTION
When a ghost was on top of something, and it gets deleted, this was crashing,  because the transform was already gone. This seems to work better for getting the map id (it's not crashing), but I don't know enough about the system to know if this alternative way of getting it is ok.