### PR TITLE
Some fixes for map init.

### DIFF
--- a/Robust.Shared/GameObjects/IMapInit.cs
+++ b/Robust.Shared/GameObjects/IMapInit.cs
@@ -29,7 +29,11 @@ namespace Robust.Shared.GameObjects
         {
             var entMan = IoCManager.Resolve<IEntityManager>();
             var meta = entMan.GetComponent<MetaDataComponent>(entity);
-            DebugTools.Assert(meta.EntityLifeStage == EntityLifeStage.Initialized);
+
+            if (meta.EntityLifeStage == EntityLifeStage.MapInitialized)
+                return; // Already map initialized, do nothing.
+
+            DebugTools.Assert(meta.EntityLifeStage == EntityLifeStage.Initialized, $"Expected entity {entMan.ToPrettyString(entity)} to be initialized, was {meta.EntityLifeStage}");
             meta.EntityLifeStage = EntityLifeStage.MapInitialized;
 
             entMan.EventBus.RaiseLocalEvent(entity, MapInit, false);

--- a/Robust.Shared/Timing/PauseManager.cs
+++ b/Robust.Shared/Timing/PauseManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Robust.Shared.Console;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -49,10 +50,13 @@ namespace Robust.Shared.Timing
 
             _unInitializedMaps.Remove(mapId);
 
-            foreach (var entity in IoCManager.Resolve<IEntityLookup>().GetEntitiesInMap(mapId))
+            foreach (var entity in IoCManager.Resolve<IEntityLookup>().GetEntitiesInMap(mapId).ToArray())
             {
                 entity.RunMapInit();
-                _entityManager.GetComponent<MetaDataComponent>(entity).EntityPaused = false;
+
+                // MapInit could have deleted this entity.
+                if(_entityManager.TryGetComponent(entity, out MetaDataComponent? meta))
+                    meta.EntityPaused = false;
             }
         }
 

--- a/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
+++ b/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
@@ -101,6 +101,7 @@ entities:
             protoMan.RegisterType(typeof(EntityPrototype));
 
             protoMan.LoadDirectory(new ResourcePath("/Prototypes"));
+            protoMan.Resync();
         }
 
         [Test]

--- a/Robust.UnitTesting/Shared/Serialization/InheritanceSerializationTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/InheritanceSerializationTest.cs
@@ -60,6 +60,7 @@ namespace Robust.UnitTesting.Shared.Serialization
 
             prototypeManager.RegisterType(typeof(EntityPrototype));
             prototypeManager.LoadString(Prototypes);
+            prototypeManager.Resync();
 
             var entityManager = IoCManager.Resolve<IEntityManager>();
 


### PR DESCRIPTION
This allows the content gameticker to create the default map uninitialized, then map initialize it just before the round starts.