### PR TITLE
Optimise DetachParentToNull for grid deletion

### DIFF
--- a/Robust.Shared/GameObjects/Component.cs
+++ b/Robust.Shared/GameObjects/Component.cs
@@ -236,14 +236,14 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public void Dirty()
+        public void Dirty(IEntityManager? entManager = null)
         {
             // Deserialization will cause this to be true.
             // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-            if(Owner == EntityUid.Invalid || LifeStage >= ComponentLifeStage.Removing)
+            if (!Owner.IsValid() || LifeStage >= ComponentLifeStage.Removing)
                 return;
 
-            var entManager = IoCManager.Resolve<IEntityManager>();
+            IoCManager.Resolve(ref entManager);
             entManager.DirtyEntity(Owner);
             LastModifiedTick = entManager.CurrentTick;
         }

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -662,7 +662,7 @@ namespace Robust.Shared.GameObjects
             }
 
             // TODO: When ECSing this can just pass it into the anchor setter
-            if (_mapManager.TryGetGrid(GridID, out var grid))
+            if (Anchored && _mapManager.TryGetGrid(GridID, out var grid))
             {
                 if (_entMan.GetComponent<MetaDataComponent>(grid.GridEntityId).EntityLifeStage <=
                     EntityLifeStage.MapInitialized)
@@ -1059,7 +1059,7 @@ namespace Robust.Shared.GameObjects
         internal void SetAnchored(bool value)
         {
             _anchored = value;
-            Dirty();
+            Dirty(_entMan);
 
             var anchorStateChangedEvent = new AnchorStateChangedEvent(Owner, value);
             _entMan.EventBus.RaiseLocalEvent(Owner, ref anchorStateChangedEvent);

--- a/Robust.Shared/GameObjects/IComponent.cs
+++ b/Robust.Shared/GameObjects/IComponent.cs
@@ -62,7 +62,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         ///     Marks the component as dirty so that the network will re-sync it with clients.
         /// </summary>
-        void Dirty();
+        void Dirty(IEntityManager? entManager = null);
 
         /// <summary>
         ///     This is the tick the component was created.


### PR DESCRIPTION
This was almost a quarter of grid deletion time (in debug), which was a quarter of overall round restarts.

DetachParentToNull is only used in extenuating circumstances (e.g. nullspace) so shouldn't really have an impact on any normal codepaths.