### PR TITLE
Engine changes for more server-pushed lighting variables

### DIFF
--- a/Robust.Client/GameObjects/Components/Light/PointLightComponent.cs
+++ b/Robust.Client/GameObjects/Components/Light/PointLightComponent.cs
@@ -97,26 +97,6 @@ namespace Robust.Client.GameObjects
         public Texture? Mask { get; set; }
 
         [ViewVariables(VVAccess.ReadWrite)]
-        [Animatable]
-        public float Energy
-        {
-            get => _energy;
-            set => _energy = value;
-        }
-
-        /// <summary>
-        ///     Soft shadow strength multiplier.
-        ///     Has no effect if soft shadows are not enabled.
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        [Animatable]
-        public float Softness
-        {
-            get => _softness;
-            set => _softness = value;
-        }
-
-        [ViewVariables(VVAccess.ReadWrite)]
         public bool VisibleNested
         {
             get => _visibleNested;
@@ -134,10 +114,7 @@ namespace Robust.Client.GameObjects
         [DataField("autoRot")]
         private bool _maskAutoRotate;
         private Angle _rotation;
-        [DataField("energy")]
-        private float _energy = 1f;
-        [DataField("softness")]
-        private float _softness = 1f;
+
         [DataField("mask")]
         internal string? _maskPath;
 

--- a/Robust.Shared/GameObjects/Components/Light/PointLightComponentState.cs
+++ b/Robust.Shared/GameObjects/Components/Light/PointLightComponentState.cs
@@ -8,17 +8,23 @@ namespace Robust.Shared.GameObjects
     public sealed class PointLightComponentState : ComponentState
     {
         public readonly Color Color;
+
+        public readonly float Energy;
+
+        public readonly float Softness;
         public readonly bool Enabled;
 
         public readonly float Radius;
         public readonly Vector2 Offset;
 
-        public PointLightComponentState(bool enabled, Color color, float radius, Vector2 offset)
+        public PointLightComponentState(bool enabled, Color color, float radius, Vector2 offset, float energy, float softness)
         {
             Enabled = enabled;
             Color = color;
             Radius = radius;
             Offset = offset;
+            Energy = energy;
+            Softness = softness;
         }
     }
 }

--- a/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
@@ -90,7 +90,7 @@ namespace Robust.Shared.GameObjects
 
         [ViewVariables(VVAccess.ReadWrite)]
         [Animatable]
-        public virtual float Energy
+        public float Energy
         {
             get => _energy;
             set
@@ -107,7 +107,7 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [Animatable]
-        public virtual float Softness
+        public float Softness
         {
             get => _softness;
             set

--- a/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
@@ -1,4 +1,5 @@
 using System;
+using Robust.Shared.Animations;
 using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 using Robust.Shared.Maths;
@@ -32,6 +33,11 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         [DataField("offset")]
         protected Vector2 _offset = Vector2.Zero;
+
+        [DataField("energy")]
+        private float _energy = 1f;
+        [DataField("softness")]
+        private float _softness = 1f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         public virtual bool Enabled
@@ -78,6 +84,36 @@ namespace Robust.Shared.GameObjects
             {
                 if (_offset.EqualsApprox(value)) return;
                 _offset = value;
+                Dirty();
+            }
+        }
+
+        [ViewVariables(VVAccess.ReadWrite)]
+        [Animatable]
+        public virtual float Energy
+        {
+            get => _energy;
+            set
+            {
+                if (_energy.Equals(value)) return;
+                _energy = value;
+                Dirty();
+            }
+        }
+
+        /// <summary>
+        ///     Soft shadow strength multiplier.
+        ///     Has no effect if soft shadows are not enabled.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [Animatable]
+        public virtual float Softness
+        {
+            get => _softness;
+            set
+            {
+                if (_softness.Equals(value)) return;
+                _softness = value;
                 Dirty();
             }
         }

--- a/Robust.Shared/GameObjects/Systems/SharedPointLightSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPointLightSystem.cs
@@ -13,7 +13,7 @@ namespace Robust.Shared.GameObjects
 
         private void GetCompState(EntityUid uid, SharedPointLightComponent component, ref ComponentGetState args)
         {
-            args.State = new PointLightComponentState(component.Enabled, component.Color, component.Radius, component.Offset);
+            args.State = new PointLightComponentState(component.Enabled, component.Color, component.Radius, component.Offset, component.Energy, component.Softness);
         }
 
         private void HandleCompState(EntityUid uid, SharedPointLightComponent component, ref ComponentHandleState args)
@@ -23,6 +23,8 @@ namespace Robust.Shared.GameObjects
             component.Radius = newState.Radius;
             component.Offset = newState.Offset;
             component.Color = newState.Color;
+            component.Energy = newState.Energy;
+            component.Softness = newState.Softness;
         }
     }
 }


### PR DESCRIPTION
More of the variables on a client-side PointLight are now replicated from the server.
There's some controversy over whether this is the right way to do things, and even if it is I'm not sure I did it right as I just imitated existing structures in the code with limited understanding of their inner workings, but it seems to work in my testing.
This is necessary for bulbs inserted into PoweredLights to change more than just the colour, and have the values replicate to clients correctly, using the same logic already used for colour changes. An implementation of this is found in the corresponding content PR.