### PR TITLE
Adds help method to C# scripting.

### DIFF
--- a/Robust.Client/Console/ScriptConsoleClient.cs
+++ b/Robust.Client/Console/ScriptConsoleClient.cs
@@ -210,7 +210,7 @@ namespace Robust.Client.Console
                 vvm.OpenVV(a);
             }
 
-            protected override void writesyntax(object toString)
+            protected override void WriteSyntax(object toString)
             {
                 var code = toString.ToString();
 

--- a/Robust.Client/Console/ScriptConsoleClient.cs
+++ b/Robust.Client/Console/ScriptConsoleClient.cs
@@ -210,7 +210,7 @@ namespace Robust.Client.Console
                 vvm.OpenVV(a);
             }
 
-            public override void writesyntax(object toString)
+            protected override void writesyntax(object toString)
             {
                 var code = toString.ToString();
 

--- a/Robust.Client/Console/ScriptConsoleClient.cs
+++ b/Robust.Client/Console/ScriptConsoleClient.cs
@@ -210,6 +210,23 @@ namespace Robust.Client.Console
                 vvm.OpenVV(a);
             }
 
+            public override void writesyntax(object toString)
+            {
+                var code = toString.ToString();
+
+                if (code == null)
+                    return;
+
+                var options = ScriptInstanceShared.GetScriptOptions(_owner._reflectionManager).AddReferences(typeof(Image).Assembly);
+                var script = CSharpScript.Create(code, options, typeof(ScriptGlobals));
+                script.Compile();
+
+                var syntax = new FormattedMessage();
+                ScriptInstanceShared.AddWithSyntaxHighlighting(script, syntax, code, _owner._highlightWorkspace);
+
+                _owner.OutputPanel.AddMessage(syntax);
+            }
+
             public override void write(object toString)
             {
                 _owner.OutputPanel.AddText(toString?.ToString() ?? "");

--- a/Robust.Client/Console/WatchWindow.cs
+++ b/Robust.Client/Console/WatchWindow.cs
@@ -155,6 +155,11 @@ namespace Robust.Client.Console
                 IoCManager.InjectDependencies(this);
             }
 
+            public override void writesyntax(object toString)
+            {
+                // No-op: nothing to write to.
+            }
+
             public override void write(object toString)
             {
                 // No-op: nothing to write to.

--- a/Robust.Client/Console/WatchWindow.cs
+++ b/Robust.Client/Console/WatchWindow.cs
@@ -155,7 +155,7 @@ namespace Robust.Client.Console
                 IoCManager.InjectDependencies(this);
             }
 
-            public override void writesyntax(object toString)
+            protected override void writesyntax(object toString)
             {
                 // No-op: nothing to write to.
             }

--- a/Robust.Client/Console/WatchWindow.cs
+++ b/Robust.Client/Console/WatchWindow.cs
@@ -155,7 +155,7 @@ namespace Robust.Client.Console
                 IoCManager.InjectDependencies(this);
             }
 
-            protected override void writesyntax(object toString)
+            protected override void WriteSyntax(object toString)
             {
                 // No-op: nothing to write to.
             }

--- a/Robust.Server/Scripting/ScriptHost.cs
+++ b/Robust.Server/Scripting/ScriptHost.cs
@@ -358,7 +358,7 @@ namespace Robust.Server.Scripting
                 IoCManager.InjectDependencies(this);
             }
 
-            public override void writesyntax(object toString)
+            protected override void writesyntax(object toString)
             {
                 if (_scriptInstance.RunningScript && toString?.ToString() is {} code)
                 {

--- a/Robust.Server/Scripting/ScriptHost.cs
+++ b/Robust.Server/Scripting/ScriptHost.cs
@@ -358,7 +358,7 @@ namespace Robust.Server.Scripting
                 IoCManager.InjectDependencies(this);
             }
 
-            protected override void writesyntax(object toString)
+            protected override void WriteSyntax(object toString)
             {
                 if (_scriptInstance.RunningScript && toString?.ToString() is {} code)
                 {

--- a/Robust.Shared.Scripting/ScriptGlobalsShared.cs
+++ b/Robust.Shared.Scripting/ScriptGlobalsShared.cs
@@ -123,18 +123,17 @@ namespace Robust.Shared.Scripting
                             continue;
 
                         builder.Append(method.PrintMethodSignature());
-                        builder.AppendLine(";");
                         break;
 
                     case MemberTypes.Property:
                         builder.Append(((PropertyInfo)member).PrintPropertySignature());
-                        builder.AppendLine(";");
                         break;
 
                     default:
                         continue;
                 }
 
+                builder.AppendLine(";");
                 builder.AppendLine();
             }
 

--- a/Robust.Shared.Scripting/ScriptGlobalsShared.cs
+++ b/Robust.Shared.Scripting/ScriptGlobalsShared.cs
@@ -1,11 +1,15 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Reflection;
+using System.Text;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Scripting
 {
@@ -103,6 +107,42 @@ namespace Robust.Shared.Scripting
             return m!.Invoke(target, args);
         }
 
+        public void help()
+        {
+            var builder = new StringBuilder();
+
+            foreach (var member in GetType().GetMembers(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public))
+            {
+                switch (member.MemberType)
+                {
+                    case MemberTypes.Method:
+                        var method = (MethodInfo) member;
+
+                        // Let's not print constructors, property methods, etc.
+                        if (method.IsSpecialName)
+                            continue;
+
+                        builder.Append(method.PrintMethodSignature());
+                        builder.AppendLine(";");
+                        break;
+
+                    case MemberTypes.Property:
+                        builder.Append(((PropertyInfo)member).PrintPropertySignature());
+                        builder.AppendLine(";");
+                        break;
+
+                    default:
+                        continue;
+                }
+
+                builder.AppendLine();
+            }
+
+            // This is slow, so do it all at once.
+            writesyntax(builder.ToString());
+        }
+
+        public abstract void writesyntax(object toString);
         public abstract void write(object toString);
         public abstract void show(object obj);
     }

--- a/Robust.Shared.Scripting/ScriptGlobalsShared.cs
+++ b/Robust.Shared.Scripting/ScriptGlobalsShared.cs
@@ -141,7 +141,7 @@ namespace Robust.Shared.Scripting
             writesyntax(builder.ToString());
         }
 
-        public abstract void writesyntax(object toString);
+        protected abstract void writesyntax(object toString);
         public abstract void write(object toString);
         public abstract void show(object obj);
     }

--- a/Robust.Shared/Utility/FormattedMessage.cs
+++ b/Robust.Shared/Utility/FormattedMessage.cs
@@ -19,6 +19,8 @@ namespace Robust.Shared.Utility
         public TagList Tags => new(_tags);
         private readonly List<Tag> _tags;
 
+        public bool IsEmpty => _tags.Count == 0;
+
         public FormattedMessage()
         {
             _tags = new List<Tag>();


### PR DESCRIPTION
Because my memory sucks.

- Added `help` method to scripting, which returns all scripting global methods and properties with proper highlighting.
- Added `writesyntax` method to scripting. It allows you to write anything with C# syntax highlighting to the scripting output. Please note that this method compiles whatever you pass into it to a C# script to perform highlighting, making it fairly slow.
- Added various extension methods to pretty-print `MethodInfo`, `PropertyInfo`, `ParameterInfo` and `Type` with their proper C# signatures.
- Added `IsEmpty` property to `FormattedMessage`.  
- Changed `ScriptInstance`'s `OutputBuffer` to a `FormattedMessage`, for color output purposes.

![Peek 24-12-2021 14-51](https://user-images.githubusercontent.com/6766154/147358543-3e7f0220-157b-4005-b7af-4710ed74095a.gif)
![Peek 24-12-2021 14-27](https://user-images.githubusercontent.com/6766154/147358545-4622494d-9ad6-4ef7-909f-b348eabfd0ed.gif)

