### PR TITLE
Don't wake destroyed contact bodies if they can't collide

### DIFF
--- a/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
+++ b/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
@@ -429,8 +429,14 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
         {
             if (Manifold.PointCount > 0 && FixtureA?.Hard == true && FixtureB?.Hard == true)
             {
-                FixtureA.Body.Awake = true;
-                FixtureB.Body.Awake = true;
+                var bodyA = FixtureA.Body;
+                var bodyB = FixtureB.Body;
+
+                if (bodyA.CanCollide)
+                    FixtureA.Body.Awake = true;
+
+                if (bodyB.CanCollide)
+                    FixtureB.Body.Awake = true;
             }
 
             Reset(null, 0, null, 0);

--- a/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
+++ b/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
@@ -133,6 +133,7 @@ namespace Robust.Shared.Physics.Dynamics
             Bodies.Remove(body);
             AwakeBodies.Remove(body);
             body.DestroyContacts();
+            body.PhysicsMap = null;
         }
 
         public void RemoveSleepBody(PhysicsComponent body)


### PR DESCRIPTION
e.g. if they're getting yeeted to nullspace or inserted into a container.

Should fix the new perf problem.