### PR TITLE
Adds config file support for Content.Client

### DIFF
--- a/Robust.Client/GameController/GameController.cs
+++ b/Robust.Client/GameController/GameController.cs
@@ -281,6 +281,22 @@ namespace Robust.Client
 
             if (Options.LoadConfigAndUserData)
             {
+                // Load content config
+                if (_resourceCache.TryGetDiskFilePath(new ResourcePath(Options.ContentConfigFileName),
+                        out var contentPath))
+                {
+                    _configurationManager.LoadFromFile(contentPath);
+                }
+                else
+                {
+                    var contentFile = Path.Combine(userDataDir, Options.ContentConfigFileName);
+                    if (File.Exists(contentFile))
+                    {
+                        _configurationManager.LoadFromFile(contentFile);
+                    }
+                }
+
+                // Load client config
                 var configFile = Path.Combine(userDataDir, Options.ConfigFileName);
                 if (File.Exists(configFile))
                 {
@@ -321,10 +337,6 @@ namespace Robust.Client
             ProgramShared.DoMounts(_resourceCache, mountOptions, Options.ContentBuildDirectory,
                 Options.AssemblyDirectory,
                 Options.LoadContentResources, _loaderArgs != null && !Options.ResourceMountDisabled, ContentStart);
-
-            // Load content config
-            if(_resourceCache.TryGetDiskFilePath(new ResourcePath(Options.ContentConfigFileName), out var contentPath))
-                _configurationManager.LoadFromFile(contentPath);
 
             if (_loaderArgs != null)
             {

--- a/Robust.Client/GameController/GameController.cs
+++ b/Robust.Client/GameController/GameController.cs
@@ -322,6 +322,10 @@ namespace Robust.Client
                 Options.AssemblyDirectory,
                 Options.LoadContentResources, _loaderArgs != null && !Options.ResourceMountDisabled, ContentStart);
 
+            // Load content config
+            if(_resourceCache.TryGetDiskFilePath(new ResourcePath(Options.ContentConfigFileName), out var contentPath))
+                _configurationManager.LoadFromFile(contentPath);
+
             if (_loaderArgs != null)
             {
                 _stringSerializer.EnableCaching = false;

--- a/Robust.Client/GameControllerOptions.cs
+++ b/Robust.Client/GameControllerOptions.cs
@@ -26,6 +26,11 @@ namespace Robust.Client
         /// </summary>
         public string ConfigFileName { get; init; } = "client_config.toml";
 
+        /// <summary>
+        ///     Name of the content configuration file in the content resources directory.
+        /// </summary>
+        public string ContentConfigFileName { get; init; } = "content_client.toml";
+
         // TODO: Define engine branding from json file in resources.
         /// <summary>
         ///     Default window title.


### PR DESCRIPTION
This is just lifted directly from an old commit on Acruid's fork.

Useful for OpenDream development so we don't have to tell people to pass any cvars as program arguments.