### PR TITLE
ByRefEvent attribute for events.

### DIFF
--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -628,6 +628,7 @@ internal partial class PVSSystem : EntitySystem
     }
 }
 
+[ByRefEvent]
 public readonly struct ExpandPvsEvent
 {
     public readonly IPlayerSession Session;

--- a/Robust.Shared/GameObjects/ByRefEventAttribute.cs
+++ b/Robust.Shared/GameObjects/ByRefEventAttribute.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Robust.Shared.GameObjects;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+public class ByRefEventAttribute : Attribute
+{
+}

--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsInitializedEvent.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsInitializedEvent.cs
@@ -1,5 +1,6 @@
 namespace Robust.Shared.GameObjects
 {
+    [ByRefEvent]
     public readonly struct PhysicsInitializedEvent
     {
         public readonly EntityUid Uid;

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -1070,6 +1070,7 @@ namespace Robust.Shared.GameObjects
     ///     Raised whenever an entity moves.
     ///     There is no guarantee it will be raised if they move in worldspace, only when moved relative to their parent.
     /// </summary>
+    [ByRefEvent]
     public readonly struct MoveEvent
     {
         public MoveEvent(EntityUid sender, EntityCoordinates oldPos, EntityCoordinates newPos, TransformComponent component, Box2? worldAABB = null)
@@ -1095,6 +1096,7 @@ namespace Robust.Shared.GameObjects
     /// <summary>
     ///     Raised whenever this entity rotates in relation to their parent.
     /// </summary>
+    [ByRefEvent]
     public readonly struct RotateEvent
     {
         public RotateEvent(EntityUid sender, Angle oldRotation, Angle newRotation, Box2? worldAABB = null)
@@ -1118,6 +1120,7 @@ namespace Robust.Shared.GameObjects
     /// <summary>
     /// Raised when the Anchor state of the transform is changed.
     /// </summary>
+    [ByRefEvent]
     public readonly struct AnchorStateChangedEvent
     {
         public readonly EntityUid Entity;

--- a/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs
@@ -129,7 +129,6 @@ namespace Robust.Shared.GameObjects
 
         private delegate void RefEventHandler(ref Unit ev);
 
-        private readonly Dictionary<Type, bool> _refEvents = new();
         private readonly Dictionary<Type, List<Registration>> _eventSubscriptions = new();
 
         private readonly Dictionary<IEntityEventSubscriber, Dictionary<Type, Registration>> _inverseEventSubscriptions
@@ -244,15 +243,11 @@ namespace Robust.Shared.GameObjects
 
             var eventType = typeof(T);
 
-            if (!_refEvents.TryGetValue(eventType, out var eventReference))
-            {
-                _refEvents.Add(eventType, byRef);
-                eventReference = byRef;
-            }
+            var eventReference = eventType.HasCustomAttribute<ByRefEventAttribute>();
 
             if (eventReference != byRef)
                 throw new InvalidOperationException(
-                    $"Attempted to subscribe by-ref and by-value to the same broadcast event! event={eventType}");
+                    $"Attempted to subscribe by-ref and by-value to the same broadcast event! event={eventType} eventIsByRef={eventReference} subscriptionIsByRef={byRef}");
 
             var subscriptionTuple = new Registration(source, handler, equalityToken, order, byRef);
 

--- a/Robust.Shared/GameObjects/EntitySystemMessages/EntParentChangedMessage.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/EntParentChangedMessage.cs
@@ -3,6 +3,7 @@
     /// <summary>
     ///     Raised when an entity parent is changed.
     /// </summary>
+    [ByRefEvent]
     public class EntParentChangedMessage : EntityEventArgs
     {
         /// <summary>

--- a/Robust.Shared/GameObjects/EntitySystemMessages/EntityDirtyEvent.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/EntityDirtyEvent.cs
@@ -1,5 +1,6 @@
 namespace Robust.Shared.GameObjects
 {
+    [ByRefEvent]
     public struct EntityDirtyEvent
     {
         public EntityUid Uid;

--- a/Robust.Shared/GameStates/ComponentStateEvents.cs
+++ b/Robust.Shared/GameStates/ComponentStateEvents.cs
@@ -3,6 +3,7 @@ using Robust.Shared.Players;
 
 namespace Robust.Shared.GameStates
 {
+    [ByRefEvent]
     public readonly struct ComponentHandleState
     {
         public ComponentState? Current { get; }
@@ -18,6 +19,7 @@ namespace Robust.Shared.GameStates
     /// <summary>
     ///     Component event for getting the component state for a specific player.
     /// </summary>
+    [ByRefEvent]
     public struct ComponentGetState
     {
         /// <summary>

--- a/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.RefDirectedEvents.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.RefDirectedEvents.cs
@@ -180,6 +180,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             public override string Name => "DummyTwo";
         }
 
+        [ByRefEvent]
         private struct TestStructEvent
         {
             public int TestNumber;


### PR DESCRIPTION
Fixes #2266
Requires you to mark by-ref events with an attribute to use them as such.
Really just for convenience, so you can tell if an event is by-ref or not just by looking at its declaration.
Opens the possibility for a roslyn analyzer that checks by-ref vs by-value subscriptions in the future.