### PR TITLE
No events on stopping components

### DIFF
--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -389,6 +389,8 @@ namespace Robust.Shared.GameObjects
                     var (component, reg) = tuple.Value;
                     if (reg.ReferenceEvent != dispatchByReference)
                         ThrowByRefMisMatch();
+                    
+                    if (component.LifeStage >= ComponentLifeStage.Stopping) continue;
 
                     reg.Handler(euid, component, ref args);
                 }


### PR DESCRIPTION
This change prevents a system from receiving an event for a component if its life cycle is stopping, or later. The lifecycle events seem to go through the bus on a different path, so they are unaffected by this change.  