### PR TITLE
Avoid touching physicscomp when removed from container

### DIFF
--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -753,7 +753,8 @@ namespace Robust.Shared.Physics
 
         private void HandleContainerInsert(EntInsertedIntoContainerMessage ev)
         {
-            if ((!EntityManager.EntityExists(ev.Entity) ? EntityLifeStage.Deleted : EntityManager.GetComponent<MetaDataComponent>(ev.Entity).EntityLifeStage) >= EntityLifeStage.Deleted || !EntityManager.TryGetComponent(ev.Entity, out PhysicsComponent? physicsComponent)) return;
+            if (!EntityManager.TryGetComponent(ev.Entity, out PhysicsComponent? physicsComponent) ||
+                physicsComponent.LifeStage > ComponentLifeStage.Running) return;
 
             physicsComponent.CanCollide = false;
             physicsComponent.Awake = false;
@@ -761,7 +762,8 @@ namespace Robust.Shared.Physics
 
         private void HandleContainerRemove(EntRemovedFromContainerMessage ev)
         {
-            if (Deleted(ev.Entity) || !EntityManager.TryGetComponent(ev.Entity, out PhysicsComponent? physicsComponent)) return;
+            if (!EntityManager.TryGetComponent(ev.Entity, out PhysicsComponent? physicsComponent) ||
+                physicsComponent.LifeStage > ComponentLifeStage.Running) return;
 
             physicsComponent.CanCollide = true;
             physicsComponent.Awake = true;


### PR DESCRIPTION
This only checked entity-level deletion before but checking running is more appropriate so we don't touch the component when being deleted.