### PR TITLE
Run appearancevisualizers on dummy entities again

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -2074,6 +2074,11 @@ namespace Robust.Client.GameObjects
             var dummy = entityManager.SpawnEntity(prototype.ID, MapCoordinates.Nullspace);
             var spriteComponent = entityManager.EnsureComponent<SpriteComponent>(dummy);
 
+            if (entityManager.TryGetComponent(dummy, out ClientAppearanceComponent? appearanceComponent))
+            {
+                EntitySystem.Get<AppearanceSystem>().OnChangeData(appearanceComponent);
+            }
+
             var anyTexture = false;
             foreach (var layer in spriteComponent.AllLayers)
             {

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -2073,11 +2073,7 @@ namespace Robust.Client.GameObjects
             var entityManager = IoCManager.Resolve<IEntityManager>();
             var dummy = entityManager.SpawnEntity(prototype.ID, MapCoordinates.Nullspace);
             var spriteComponent = entityManager.EnsureComponent<SpriteComponent>(dummy);
-
-            if (entityManager.TryGetComponent(dummy, out ClientAppearanceComponent? appearanceComponent))
-            {
-                EntitySystem.Get<AppearanceSystem>().OnChangeData(appearanceComponent);
-            }
+            EntitySystem.Get<AppearanceSystem>().OnChangeData(dummy);
 
             var anyTexture = false;
             foreach (var layer in spriteComponent.AllLayers)

--- a/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
@@ -21,13 +21,15 @@ namespace Robust.Client.GameObjects
                 if (appearance.Deleted)
                     return;
 
-                OnChangeData(appearance);
+                OnChangeData(appearance.Owner, appearance);
                 appearance.UnmarkDirty();
             }
         }
 
-        public void OnChangeData(ClientAppearanceComponent appearanceComponent)
+        public void OnChangeData(EntityUid uid, ClientAppearanceComponent? appearanceComponent = null)
         {
+            if (!Resolve(uid, ref appearanceComponent, false)) return;
+
             foreach (var visualizer in appearanceComponent.Visualizers)
             {
                 visualizer.OnChangeData(appearanceComponent);

--- a/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
@@ -21,12 +21,16 @@ namespace Robust.Client.GameObjects
                 if (appearance.Deleted)
                     return;
 
-                foreach (var visualizer in appearance.Visualizers)
-                {
-                    visualizer.OnChangeData(appearance);
-                }
-
+                OnChangeData(appearance);
                 appearance.UnmarkDirty();
+            }
+        }
+
+        public void OnChangeData(ClientAppearanceComponent appearanceComponent)
+        {
+            foreach (var visualizer in appearanceComponent.Visualizers)
+            {
+                visualizer.OnChangeData(appearanceComponent);
             }
         }
     }


### PR DESCRIPTION
The issue is that appearancesystem defers this until frameupdate but we're spawning the entity and immediately deleting it.