### PR TITLE
add CanInsertIfEmpty()

### DIFF
--- a/Robust.Shared/Containers/ContainerSlot.cs
+++ b/Robust.Shared/Containers/ContainerSlot.cs
@@ -53,18 +53,18 @@ namespace Robust.Shared.Containers
         /// <inheritdoc />
         public override bool CanInsert(EntityUid toinsert, IEntityManager? entMan = null)
         {
-            if (ContainedEntity != null)
-                return false;
-            return base.CanInsert(toinsert, entMan);
+            return (ContainedEntity == null) && CanInsertIfEmpty(toinsert, entMan);
         }
 
         /// <summary>
-        ///     Performs the same check as <see cref="CanInsert"/> without requiring that the slot has to be empty.
+        /// Checks if the entity can be inserted into this container, assuming that the container slot is empty.
         /// </summary>
         /// <remarks>
-        ///     Useful if you need to know whether an item could be inserted into a slot, without having to actually
-        ///     eject the currently contained entity first.
+        /// Useful if you need to know whether an item could be inserted into a slot, without having to actually eject
+        /// the currently contained entity first.
         /// </remarks>
+        /// <param name="toinsert">The entity to attempt to insert.</param>
+        /// <returns>True if the entity could be inserted into an empty slot, false otherwise.</returns>
         public bool CanInsertIfEmpty(EntityUid toinsert, IEntityManager? entMan = null)
         {
             return base.CanInsert(toinsert, entMan);

--- a/Robust.Shared/Containers/ContainerSlot.cs
+++ b/Robust.Shared/Containers/ContainerSlot.cs
@@ -58,6 +58,18 @@ namespace Robust.Shared.Containers
             return base.CanInsert(toinsert, entMan);
         }
 
+        /// <summary>
+        ///     Performs the same check as <see cref="CanInsert"/> without requiring that the slot has to be empty.
+        /// </summary>
+        /// <remarks>
+        ///     Useful if you need to know whether an item could be inserted into a slot, without having to actually
+        ///     eject the currently contained entity first.
+        /// </remarks>
+        public bool CanInsertIfEmpty(EntityUid toinsert, IEntityManager? entMan = null)
+        {
+            return base.CanInsert(toinsert, entMan);
+        }
+
         /// <inheritdoc />
         public override bool Contains(EntityUid contained)
         {


### PR DESCRIPTION
This adds a function to `ContainerSlot` that allows you to check whether an item could be inserted into a container slot if it were empty.

Currently, you need to actually empty the slot before `CanInsert()` provides useful information, which is annoying if you want know whether you could swap out an item.