### PR TITLE
TeleportTo upgrades

### DIFF
--- a/Robust.Server/Console/Commands/PlayerCommands.cs
+++ b/Robust.Server/Console/Commands/PlayerCommands.cs
@@ -69,7 +69,7 @@ namespace Robust.Server.Console.Commands
         }
     }
 
-    public class TeleportToPlayerCommand : IConsoleCommand
+    public class TeleportToCommand : IConsoleCommand
     {
         public string Command => "tpto";
         public string Description => "Teleports the current player or the specified players/entities to the location of last player/entity specified.";


### PR DESCRIPTION
Cleaned up duplicate code in the TeleportTo command.
Add teleporting to EntityUids in addition to usernames.
Renamed TeleportToPlayerCommand to TeleportToCommand.
