### PR TITLE
Tiles Name->Id DisplayName->Name

### DIFF
--- a/Robust.Client/UserInterface/CustomControls/TileSpawnWindow.cs
+++ b/Robust.Client/UserInterface/CustomControls/TileSpawnWindow.cs
@@ -106,11 +106,11 @@ namespace Robust.Client.UserInterface.CustomControls
             if (!string.IsNullOrEmpty(searchStr))
             {
                 tileDefs = tileDefs.Where(s =>
-                    s.DisplayName.IndexOf(searchStr, StringComparison.InvariantCultureIgnoreCase) >= 0 ||
-                    s.Name.IndexOf(searchStr, StringComparison.OrdinalIgnoreCase) >= 0);
+                    s.Name.IndexOf(searchStr, StringComparison.InvariantCultureIgnoreCase) >= 0 ||
+                    s.ID.IndexOf(searchStr, StringComparison.OrdinalIgnoreCase) >= 0);
             }
 
-            tileDefs = tileDefs.OrderBy(d => d.DisplayName);
+            tileDefs = tileDefs.OrderBy(d => d.Name);
 
             _shownItems.Clear();
             _shownItems.AddRange(tileDefs);
@@ -122,7 +122,7 @@ namespace Robust.Client.UserInterface.CustomControls
                 {
                     texture = _resourceCache.GetResource<TextureResource>(new ResourcePath(entry.Path) / $"{entry.SpriteName}.png");
                 }
-                TileList.AddItem(entry.DisplayName, texture);
+                TileList.AddItem(entry.Name, texture);
             }
         }
 

--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -691,7 +691,7 @@ namespace Robust.Server.Maps
                 RootNode.Add("tilemap", tileMap);
                 foreach (var tileDefinition in _tileDefinitionManager)
                 {
-                    tileMap.Add(tileDefinition.TileId.ToString(CultureInfo.InvariantCulture), tileDefinition.Name);
+                    tileMap.Add(tileDefinition.TileId.ToString(CultureInfo.InvariantCulture), tileDefinition.ID);
                 }
             }
 

--- a/Robust.Shared/Map/ITileDefinition.cs
+++ b/Robust.Shared/Map/ITileDefinition.cs
@@ -13,12 +13,12 @@
         /// <summary>
         ///     The name of the definition. This is user facing.
         /// </summary>
-        string DisplayName { get; }
+        string Name { get; }
 
         /// <summary>
         ///     Internal name of the definition.
         /// </summary>
-        string Name { get; }
+        string ID { get; }
 
         /// <summary>
         ///     The name of the sprite to draw.

--- a/Robust.Shared/Map/TileDefinitionManager.cs
+++ b/Robust.Shared/Map/TileDefinitionManager.cs
@@ -25,7 +25,7 @@ namespace Robust.Shared.Map
 
         public virtual void Register(ITileDefinition tileDef)
         {
-            var name = tileDef.Name;
+            var name = tileDef.ID;
             if (_tileNames.ContainsKey(name))
             {
                 throw new ArgumentException("Another tile definition with the same name has already been registered.", nameof(tileDef));


### PR DESCRIPTION
For this:
#5188
Fixed this:

> Tiles prototype use name as their ID and display_name as their name. This is very confusing and not in line with how the rest of the codebase handles this, so changing name to id and display_name to name is necessary.

Part of: https://github.com/space-wizards/space-station-14/pull/5991