### PR TITLE
Add a method to unregister "manual" commands from IConsoleHost.

### DIFF
--- a/Robust.Shared/Console/ConsoleHost.cs
+++ b/Robust.Shared/Console/ConsoleHost.cs
@@ -70,6 +70,18 @@ namespace Robust.Shared.Console
             AvailableCommands.Add(command, newCmd);
         }
 
+        /// <inheritdoc />
+        public void UnregisterCommand(string command)
+        {
+            if (!AvailableCommands.TryGetValue(command, out var cmd))
+                throw new KeyNotFoundException($"Command {command} is not registered.");
+
+            if (cmd is not RegisteredCommand)
+                throw new InvalidOperationException("You cannot unregister commands that have been registered automatically.");
+
+            AvailableCommands.Remove(command);
+        }
+
         //TODO: Pull up
         public abstract void ExecuteCommand(ICommonSession? session, string command);
 

--- a/Robust.Shared/Console/IConsoleHost.cs
+++ b/Robust.Shared/Console/IConsoleHost.cs
@@ -54,13 +54,20 @@ namespace Robust.Shared.Console
 
         /// <summary>
         /// Registers a console command into the console system. This is an alternative to
-        /// creating an <see cref="IConsoleCommand" /> class.
+        /// creating an <see cref="IConsoleCommand"/> class.
         /// </summary>
         /// <param name="command">A string as identifier for this command.</param>
         /// <param name="description">Short one sentence description of the command.</param>
         /// <param name="help">Command format string.</param>
         /// <param name="callback"></param>
         void RegisterCommand(string command, string description, string help, ConCommandCallback callback);
+
+        /// <summary>
+        /// Unregisters a console command that has been registered previously with <see cref="RegisterCommand"/>.
+        /// If the specified command was registered automatically or isn't registered at all, the method will throw.
+        /// </summary>
+        /// <param name="command">The string identifier for the command.</param>
+        void UnregisterCommand(string command);
 
         /// <summary>
         /// Returns the console shell for a given active session.


### PR DESCRIPTION
Required by https://github.com/space-wizards/space-station-14/pull/6025
This will allow us to register commands from entity systems and clean them up properly on shutdown.