### PR TITLE
Fix lifestage for loading initialized map

### DIFF
--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -68,10 +68,6 @@ namespace Robust.Server.Maps
             stream.Save(new YamlMappingFix(new Emitter(writer)), false);
         }
 
-        /*
-         * TODO: LoadBlueprint and Loadmap should be almost identical methods but right now it's copypaste spaghet everywhere
-         */
-
         /// <inheritdoc />
         public IMapGrid? LoadBlueprint(MapId mapId, string path)
         {


### PR DESCRIPTION
These weren't getting marked as MapInitialized.

I also deduplicated most of loadbp and loadmap as ideally they function identically with loadbp throwing if more than 1 grid is on the requested map file.