### PR TITLE
Move popup above modal in `RootControl`

### DIFF
--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -164,19 +164,19 @@ namespace Robust.Client.UserInterface
             };
             RootControl.AddChild(WindowRoot);
 
-            PopupRoot = new LayoutContainer
-            {
-                Name = "PopupRoot",
-                MouseFilter = Control.MouseFilterMode.Ignore
-            };
-            RootControl.AddChild(PopupRoot);
-
             ModalRoot = new PopupContainer
             {
                 Name = "ModalRoot",
                 MouseFilter = Control.MouseFilterMode.Ignore,
             };
             RootControl.AddChild(ModalRoot);
+
+            PopupRoot = new LayoutContainer
+            {
+                Name = "PopupRoot",
+                MouseFilter = Control.MouseFilterMode.Ignore
+            };
+            RootControl.AddChild(PopupRoot);
 
             _tooltip = new Tooltip();
             PopupRoot.AddChild(_tooltip);


### PR DESCRIPTION
This reverses the ordering of `PopupRoot` and `ModalRoot` in `RootControl`. Tooltips are a children of `PopupRoot`, so this ensures that hover-tooltips appear above other UI elements in ModalRoot, so that they can be used there. AFAIK this doesn't cause any issues? UI elements all seem to be behaving normally, but maybe this is stupid for some reason, I don't really know what all the implications of this are.

AFAIK this is currently only an issue for the context menu, where tooltips for disabled verbs appear below the menu.
So if this isn't the way to fix this, how should one handle tooltips for that?