### PR TITLE
Raise an attempt-event when receiving client BUI messages.

### DIFF
--- a/Robust.Server/GameObjects/Components/UserInterface/ServerUserInterfaceComponent.cs
+++ b/Robust.Server/GameObjects/Components/UserInterface/ServerUserInterfaceComponent.cs
@@ -7,9 +7,9 @@ using Robust.Server.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
-using Robust.Shared.Log;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
+using static Robust.Shared.GameObjects.SharedUserInterfaceComponent;
 
 namespace Robust.Server.GameObjects
 {
@@ -39,7 +39,7 @@ namespace Robust.Server.GameObjects
 
             foreach (var prototypeData in _interfaceData)
             {
-                _interfaces[prototypeData.UiKey] = new BoundUserInterface(prototypeData.UiKey, this);
+                _interfaces[prototypeData.UiKey] = new BoundUserInterface(prototypeData, this);
             }
         }
 
@@ -71,18 +71,6 @@ namespace Robust.Server.GameObjects
             EntitySystem.Get<UserInterfaceSystem>()
                 .SendTo(session, new BoundUIWrapMessage(Owner, message, uiKey));
         }
-
-        internal void ReceiveMessage(IPlayerSession session, BoundUIWrapMessage msg)
-        {
-            if (!_interfaces.TryGetValue(msg.UiKey, out var @interface))
-            {
-                Logger.DebugS("go.comp.ui", "Got BoundInterfaceMessageWrapMessage for unknown UI key: {0}",
-                    msg.UiKey);
-                return;
-            }
-
-            @interface.ReceiveMessage(msg.Message, session);
-        }
     }
 
     /// <summary>
@@ -97,6 +85,7 @@ namespace Robust.Server.GameObjects
         public ServerUserInterfaceComponent Owner { get; }
         private readonly HashSet<IPlayerSession> _subscribedSessions = new();
         private BoundUserInterfaceState? _lastState;
+        public bool RequireInputValidation;
 
         private bool _stateDirty;
 
@@ -111,9 +100,10 @@ namespace Robust.Server.GameObjects
         public event Action<ServerBoundUserInterfaceMessage>? OnReceiveMessage;
         public event Action<IPlayerSession>? OnClosed;
 
-        public BoundUserInterface(object uiKey, ServerUserInterfaceComponent owner)
+        public BoundUserInterface(PrototypeData data, ServerUserInterfaceComponent owner)
         {
-            UiKey = uiKey;
+            RequireInputValidation = data.RequireInputValidation;
+            UiKey = data.UiKey;
             Owner = owner;
         }
 
@@ -243,7 +233,7 @@ namespace Robust.Server.GameObjects
             return true;
         }
 
-        private void CloseShared(IPlayerSession session)
+        public void CloseShared(IPlayerSession session)
         {
             var owner = Owner.Owner;
             IoCManager.Resolve<IEntityManager>().EventBus.RaiseLocalEvent(owner, new BoundUIClosedEvent(UiKey, owner, session));
@@ -319,26 +309,9 @@ namespace Robust.Server.GameObjects
             Owner.SendToSession(session, message, UiKey);
         }
 
-        internal void ReceiveMessage(BoundUserInterfaceMessage wrappedMessage, IPlayerSession session)
+        internal void ReceiveMessage(ServerBoundUserInterfaceMessage message)
         {
-            if (!_subscribedSessions.Contains(session))
-            {
-                Logger.DebugS("go.comp.ui", "Got message from session not subscribed to us.");
-                return;
-            }
-
-            switch (wrappedMessage)
-            {
-                case CloseBoundInterfaceMessage _:
-                    CloseShared(session);
-
-                    break;
-
-                default:
-                    var serverMsg = new ServerBoundUserInterfaceMessage(wrappedMessage, session);
-                    OnReceiveMessage?.Invoke(serverMsg);
-                    break;
-            }
+            OnReceiveMessage?.Invoke(message);
         }
 
         private void AssertContains(IPlayerSession session)

--- a/Robust.Server/GameObjects/EntitySystems/UserInterfaceSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/UserInterfaceSystem.cs
@@ -6,6 +6,7 @@ using JetBrains.Annotations;
 using Robust.Server.Player;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Log;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 using Robust.Shared.ViewVariables;
 
@@ -45,12 +46,44 @@ namespace Robust.Server.GameObjects
             RaiseNetworkEvent(msg, session.ConnectedClient);
         }
 
+        /// <summary>
+        ///     Validates the received message, and then pass it onto systems/components
+        /// </summary>
         private void OnMessageReceived(BoundUIWrapMessage msg, EntitySessionEventArgs args)
         {
             var uid = msg.Entity;
-            if (!EntityManager.TryGetComponent<ServerUserInterfaceComponent>(uid, out var uiComp))
+            if (!TryComp(uid, out ServerUserInterfaceComponent? uiComp) || args.SenderSession is not IPlayerSession session)
                 return;
 
+            if (!uiComp.TryGetBoundUserInterface(msg.UiKey, out var ui))
+            {
+                Logger.DebugS("go.comp.ui", "Got BoundInterfaceMessageWrapMessage for unknown UI key: {0}", msg.UiKey);
+                return;
+            }
+
+            if (!ui.SessionHasOpen(session))
+            {
+                Logger.DebugS("go.comp.ui", $"UI {msg.UiKey} got BoundInterfaceMessageWrapMessage from a client who was not subscribed: {session}", msg.UiKey);
+                return;
+            }
+
+            // if they want to close the UI, we can go home early.
+            if (msg.Message is CloseBoundInterfaceMessage)
+            {
+                ui.CloseShared(session);
+                return;
+            }
+
+            // verify that the user is allowed to press buttons on this UI:
+            if (ui.RequireInputValidation)
+            {
+                var attempt = new BoundUserInterfaceMessageAttempt(args.SenderSession, uid, msg.UiKey);
+                RaiseLocalEvent(attempt);
+                if (attempt.Cancelled)
+                    return;
+            }
+
+            // get the wrapped message and populate it with the sender & UI key information.
             var message = msg.Message;
             message.Session = args.SenderSession;
             message.Entity = uid;
@@ -59,7 +92,10 @@ namespace Robust.Server.GameObjects
             // Raise as object so the correct type is used.
             RaiseLocalEvent(uid, (object)message);
 
-            uiComp.ReceiveMessage((IPlayerSession) args.SenderSession, msg);
+            // Once we have populated our message's wrapped message, we will wrap it up into a message that can be sent
+            // to old component-code.
+            var WrappedUnwrappedMessageMessageMessage = new ServerBoundUserInterfaceMessage(message, session);
+            ui.ReceiveMessage(WrappedUnwrappedMessageMessageMessage);
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/Components/UserInterface/SharedUserInterfaceComponent.cs
+++ b/Robust.Shared/GameObjects/Components/UserInterface/SharedUserInterfaceComponent.cs
@@ -24,6 +24,17 @@ namespace Robust.Shared.GameObjects
             [DataField("type", readOnly: true, required: true)]
             public string ClientType { get; set; } = default!;
 
+            // TODO BUI move to content?
+            // I've tried to keep the name general, but really this is a bool for: can ghosts/stunned/dead people press buttons on this UI?
+            /// <summary>
+            ///     Determines whether the server should verify that a client is capable of performing generic UI interactions when receiving UI messages.
+            /// </summary>
+            /// <remarks>
+            ///     Avoids requiring each system to individually validate client inputs. However, perhaps some BUIs are supposed to be bypass accessibility checks
+            /// </remarks>
+            [DataField("requireInputValidation")]
+            public bool RequireInputValidation = true;
+
             void ISerializationHooks.AfterDeserialization()
             {
                 var reflectionManager = IoCManager.Resolve<IReflectionManager>();
@@ -36,6 +47,24 @@ namespace Robust.Shared.GameObjects
 
                 UiKey = _uiKeyRaw;
             }
+        }
+    }
+
+    /// <summary>
+    ///     Raised whenever the server receives a BUI message from a client relating to a UI that requires input
+    ///     validation.
+    /// </summary>
+    public class BoundUserInterfaceMessageAttempt : CancellableEntityEventArgs
+    {
+        public readonly ICommonSession Sender;
+        public readonly EntityUid Target;
+        public readonly object UiKey;
+
+        public BoundUserInterfaceMessageAttempt(ICommonSession sender, EntityUid target, object uiKey)
+        {
+            Sender = sender;
+            Target = target;
+            UiKey = uiKey;
         }
     }
 


### PR DESCRIPTION
A general problem in SS14 is that most BUI don't check action blockers when receiving UI messages from the client. For example currently a dead person next to the nuke can enter the code and arm it (assuming they had the UI open before dying). Instead of expecting every system to individually check action blockers, it makes sense to check them before passing messages along to systems/components.

This PR adds an attempt-event so that the interaction system can do that, along with an opt-out data-field in case someone does actually need a ghost/dead interactable UI. It uses an attempt event instead of directly checking action blockers because those are all SS14/content features.

As to why it should check individual messages rather than just closing the UI when players die / can no longer interact: because IMO ghosts/spectators should be able to observe consoles, PDAs, etc, but obviously shouldn't be able to modify them.

Currently this does lead to some jank, where ghosts can edit text/spin boxes which might give the illusion of allowing input, but it doesn't have any actual effect. Ideally those GUI elements would all be disabled by the client by checking the same attempt-event when opening the UI.