### PR TITLE
Prevent disembowelling on tile removal.

### DIFF
--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -104,7 +104,7 @@ public sealed partial class EntityLookup
             angle = wAng;
         }
 
-        var center = worldMatrix.Value.Transform((Vector2)tileRef.GridIndices * grid.TileSize + 0.5f);
+        var center = worldMatrix.Value.Transform((Vector2) tileRef.GridIndices + 0.5f) * grid.TileSize;
         var translatedBox = Box2.CenteredAround(center, (grid.TileSize, grid.TileSize));
 
         return new Box2Rotated(translatedBox, -angle.Value, center);

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -81,13 +81,13 @@ public sealed partial class EntityLookup
     #endregion
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private Box2 GetLocalBounds(Vector2i gridIndices, ushort tileSize)
+    public Box2 GetLocalBounds(Vector2i gridIndices, ushort tileSize)
     {
         return new Box2(gridIndices * tileSize, (gridIndices + 1) * tileSize);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private Box2 GetLocalBounds(TileRef tileRef, ushort tileSize)
+    public Box2 GetLocalBounds(TileRef tileRef, ushort tileSize)
     {
         return GetLocalBounds(tileRef.GridIndices, tileSize);
     }
@@ -104,8 +104,9 @@ public sealed partial class EntityLookup
             angle = wAng;
         }
 
-        var center = worldMatrix.Value.Transform((Vector2) tileRef.GridIndices + 0.5f);
+        var center = worldMatrix.Value.Transform((Vector2)tileRef.GridIndices * grid.TileSize + 0.5f);
+        var translatedBox = Box2.CenteredAround(center, (grid.TileSize, grid.TileSize));
 
-        return new Box2Rotated(Box2.UnitCentered.Translated(center), -angle.Value, center);
+        return new Box2Rotated(translatedBox, -angle.Value, center);
     }
 }

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.cs
@@ -85,6 +85,12 @@ namespace Robust.Shared.GameObjects
         void RemoveFromEntityTrees(EntityUid entity);
 
         Box2 GetWorldAabbFromEntity(in EntityUid ent);
+
+        Box2 GetLocalBounds(TileRef tileRef, ushort tileSize);
+
+        Box2 GetLocalBounds(Vector2i gridIndices, ushort tileSize);
+
+        Box2Rotated GetWorldBounds(TileRef tileRef, Matrix3? worldMatrix = null, Angle? angle = null);
     }
 
     [UsedImplicitly]

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -67,7 +67,7 @@ namespace Robust.Shared.GameObjects
             var grid = _mapManager.GetGrid(gridId);
             var gridUid = grid.GridEntityId;
             var mapTransform = Transform(_mapManager.GetMapEntityId(grid.ParentMapId));
-            var aabb = new Box2(tileIndices * grid.TileSize, (tileIndices + 1) * grid.TileSize);
+            var aabb = _entityLookup.GetLocalBounds(tileIndices, grid.TileSize);
 
             foreach (var entity in _entityLookup.GetEntitiesIntersecting(gridId, tileIndices).ToList())
             {

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -67,35 +67,13 @@ namespace Robust.Shared.GameObjects
             var grid = _mapManager.GetGrid(gridId);
             var gridUid = grid.GridEntityId;
             var mapTransform = Transform(_mapManager.GetMapEntityId(grid.ParentMapId));
-
-            // Given that we need to check if the entity's CENTER is on the tile, and not just whether it intersects,
-            // and as we need to obtain the entity's transform anyway, we will use the lookup with a callback rather
-            // than the generic GetEntitiesIntersecting().
-
             var aabb = new Box2(tileIndices * grid.TileSize, (tileIndices + 1) * grid.TileSize);
-            var lookup = Comp<EntityLookupComponent>(gridUid);
-            HashSet<TransformComponent> results = new();
 
-            _entityLookup.FastEntitiesIntersecting(lookup, ref aabb, (uid) =>
+            foreach (var entity in _entityLookup.GetEntitiesIntersecting(gridId, tileIndices).ToList())
             {
-                if (Deleted(uid))
-                    return;
-
-                var transform = Transform(uid);
+                var transform = Transform(entity);
                 if (transform.ParentUid == gridUid && aabb.Contains(transform.LocalPosition))
-                    results.Add(transform); // cannot de-parent directly, else modified-while-enumerating error.
-            });
-
-            foreach (var transform in results)
-            {
-                transform.AttachParent(mapTransform);
-            }
-
-            // Next handle anchored entities
-            foreach (var ent in grid.GetAnchoredEntities(tileIndices).ToList())
-            {
-                if (!Deleted(ent))
-                    Transform(ent).AttachParent(mapTransform);
+                    transform.AttachParent(mapTransform);
             }
         }
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -58,15 +58,22 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         ///     De-parents and unanchors all entities on a grid-tile.
         /// </summary>
+        /// <remarks>
+        ///     Used when a tile on a grid is removed (becomes space). Only de-parents entities if they are actually
+        ///     parented to that grid. No more disemboweling mobs. 
+        /// </remarks>
         private void DeparentAllEntsOnTile(GridId gridId, Vector2i tileIndices)
         {
-            var mapId = _mapManager.GetGrid(gridId).ParentMapId;
-            var mapTransform = Transform(_mapManager.GetMapEntityId(mapId));
+            var grid = _mapManager.GetGrid(gridId);
+            var gridUid = grid.GridEntityId;
+            var mapTransform = Transform(_mapManager.GetMapEntityId(grid.ParentMapId));
          
             foreach (var uid in _entityLookup.GetEntitiesIntersecting(gridId, tileIndices).ToList())
             {
-                // Attach parent will automatically set anchored=false;
-                Transform(uid).AttachParent(mapTransform);
+                // AttachParent() will automatically set anchored=false;
+                var transform = Transform(uid);
+                if (transform.ParentUid == gridUid)
+                    transform.AttachParent(mapTransform);
             }
         }
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -68,9 +68,9 @@ namespace Robust.Shared.GameObjects
             var gridUid = grid.GridEntityId;
             var mapTransform = Transform(_mapManager.GetMapEntityId(grid.ParentMapId));
 
-            // given that we need to check if the entity's CENTER is on the tile (not jut intersect), and as we need to
-            // obtain the entity's transform anyway, we will use the lookup with a callback rather than the generic
-            // GetEntitiesIntersecting().
+            // Given that we need to check if the entity's CENTER is on the tile, and not just whether it intersects,
+            // and as we need to obtain the entity's transform anyway, we will use the lookup with a callback rather
+            // than the generic GetEntitiesIntersecting().
 
             var aabb = new Box2(tileIndices * grid.TileSize, (tileIndices + 1) * grid.TileSize);
             var lookup = Comp<EntityLookupComponent>(gridUid);


### PR DESCRIPTION
Slight oversight.

Now also checks if the entity center is on the tile.