### PR TITLE
Give container attempt events an optional reason output.

### DIFF
--- a/Robust.Shared/Containers/BaseContainer.cs
+++ b/Robust.Shared/Containers/BaseContainer.cs
@@ -86,9 +86,10 @@ namespace Robust.Shared.Containers
         }
 
         /// <inheritdoc />
-        public virtual bool CanInsert(EntityUid toinsert, IEntityManager? entMan = null)
+        public virtual bool CanInsert(EntityUid toinsert, out string? reason, IEntityManager? entMan = null)
         {
             DebugTools.Assert(!Deleted);
+            reason = null;
 
             // cannot insert into itself.
             if (Owner == toinsert)
@@ -111,15 +112,23 @@ namespace Robust.Shared.Containers
             var insertAttemptEvent = new ContainerIsInsertingAttemptEvent(this, toinsert);
             entMan.EventBus.RaiseLocalEvent(Owner, insertAttemptEvent);
             if (insertAttemptEvent.Cancelled)
+            {
+                reason = insertAttemptEvent.Reason;
                 return false;
+            }
 
             var gettingInsertedAttemptEvent = new ContainerGettingInsertedAttemptEvent(this, toinsert);
             entMan.EventBus.RaiseLocalEvent(toinsert, gettingInsertedAttemptEvent);
             if (gettingInsertedAttemptEvent.Cancelled)
+            {
+                reason = gettingInsertedAttemptEvent.Reason;
                 return false;
+            }
 
             return true;
         }
+
+        public bool CanInsert(EntityUid toinsert, IEntityManager? entMan = null) => CanInsert(toinsert, out _, entMan);
 
         /// <inheritdoc />
         public bool Remove(EntityUid toremove, IEntityManager? entMan = null)
@@ -150,9 +159,10 @@ namespace Robust.Shared.Containers
         }
 
         /// <inheritdoc />
-        public virtual bool CanRemove(EntityUid toremove, IEntityManager? entMan = null)
+        public virtual bool CanRemove(EntityUid toremove, out string? reason, IEntityManager? entMan = null)
         {
             DebugTools.Assert(!Deleted);
+            reason = null;
 
             if (!Contains(toremove))
                 return false;
@@ -163,15 +173,23 @@ namespace Robust.Shared.Containers
             var removeAttemptEvent = new ContainerIsRemovingAttemptEvent(this, toremove);
             entMan.EventBus.RaiseLocalEvent(Owner, removeAttemptEvent);
             if (removeAttemptEvent.Cancelled)
+            {
+                reason = removeAttemptEvent.Reason;
                 return false;
+            }
 
             var gettingRemovedAttemptEvent = new ContainerGettingRemovedAttemptEvent(this, toremove);
             entMan.EventBus.RaiseLocalEvent(toremove, gettingRemovedAttemptEvent);
             if (gettingRemovedAttemptEvent.Cancelled)
+            {
+                reason = gettingRemovedAttemptEvent.Reason;
                 return false;
+            }
 
             return true;
         }
+
+        public bool CanRemove(EntityUid toremove, IEntityManager? entMan = null) => CanRemove(toremove, out _, entMan);
 
         /// <inheritdoc />
         public abstract bool Contains(EntityUid contained);

--- a/Robust.Shared/Containers/ContainerSlot.cs
+++ b/Robust.Shared/Containers/ContainerSlot.cs
@@ -51,9 +51,10 @@ namespace Robust.Shared.Containers
         public override string ContainerType => ClassName;
 
         /// <inheritdoc />
-        public override bool CanInsert(EntityUid toinsert, IEntityManager? entMan = null)
+        public override bool CanInsert(EntityUid toinsert, out string? reason, IEntityManager? entMan = null)
         {
-            return (ContainedEntity == null) && CanInsertIfEmpty(toinsert, entMan);
+            reason = null;
+            return (ContainedEntity == null) && CanInsertIfEmpty(toinsert, out reason, entMan);
         }
 
         /// <summary>
@@ -65,10 +66,12 @@ namespace Robust.Shared.Containers
         /// </remarks>
         /// <param name="toinsert">The entity to attempt to insert.</param>
         /// <returns>True if the entity could be inserted into an empty slot, false otherwise.</returns>
-        public bool CanInsertIfEmpty(EntityUid toinsert, IEntityManager? entMan = null)
+        public bool CanInsertIfEmpty(EntityUid toinsert, out string? reason, IEntityManager? entMan = null)
         {
-            return base.CanInsert(toinsert, entMan);
+            return base.CanInsert(toinsert, out reason, entMan);
         }
+
+        public bool CanInsertIfEmpty(EntityUid toinsert, IEntityManager? entMan = null) => CanInsertIfEmpty(toinsert, out _, entMan);
 
         /// <inheritdoc />
         public override bool Contains(EntityUid contained)

--- a/Robust.Shared/Containers/Events/ContainerAttemptEvents.cs
+++ b/Robust.Shared/Containers/Events/ContainerAttemptEvents.cs
@@ -8,6 +8,7 @@ public class ContainerAttemptEventBase : CancellableEntityEventArgs
 {
     public readonly IContainer Container;
     public readonly EntityUid EntityUid;
+    public string? Reason;
 
     public ContainerAttemptEventBase(IContainer container, EntityUid entityUid)
     {

--- a/Robust.UnitTesting/Server/GameObjects/Components/Container_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/Components/Container_Test.cs
@@ -324,8 +324,9 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
                 }
             }
 
-            public override bool CanInsert(EntityUid toinsert, IEntityManager? entMan = null)
+            public override bool CanInsert(EntityUid toinsert, out string? reason, IEntityManager? entMan = null)
             {
+                reason = null;
                 IoCManager.Resolve(ref entMan);
                 return entMan.TryGetComponent(toinsert, out IContainerManager? _);
             }


### PR DESCRIPTION
Useful for giving feedback to players when they are attempting to insert an entity into some container.