### PR TITLE
Stop updating entity tree on pre-delete un-anchor event

### DIFF
--- a/Robust.Shared/GameObjects/Systems/EntityLookup.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.cs
@@ -177,7 +177,7 @@ namespace Robust.Shared.GameObjects
                 var xform = _entityManager.GetComponent<TransformComponent>(@event.Entity);
                 UpdateEntityTree(@event.Entity, xform);
             }
-            // the entity is terminating. We can ignore this un-anchor event, it will be removed by the tree via OnEntityDeleted.
+            // else -> the entity is terminating. We can ignore this un-anchor event, as this entity will be removed by the tree via OnEntityDeleted.
         }
 
         private void OnLookupShutdown(EntityUid uid, EntityLookupComponent component, ComponentShutdown args)

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.cs
@@ -172,11 +172,12 @@ namespace Robust.Shared.GameObjects
             {
                 RemoveFromEntityTrees(@event.Entity);
             }
-            else
+            else if (_entityManager.TryGetComponent(@event.Entity, out MetaDataComponent? meta) && meta.EntityLifeStage < EntityLifeStage.Terminating)
             {
                 var xform = _entityManager.GetComponent<TransformComponent>(@event.Entity);
                 UpdateEntityTree(@event.Entity, xform);
             }
+            // the entity is terminating. We can ignore this un-anchor event, it will be removed by the tree via OnEntityDeleted.
         }
 
         private void OnLookupShutdown(EntityUid uid, EntityLookupComponent component, ComponentShutdown args)


### PR DESCRIPTION
Currently when an anchored entity is deleted, it will first un-anchor itself and be added to the entity lookup tree. then, when `EntityManager.EntityDeleted` gets invoked, it gets removed from that tree. This just stops the entity from being added to the tree in the first place.

Though on a more general note: how vital is the unanchoring / detach-to-null before an entity is deleted?
Time is still wasted on other components, for example the `CollideOnAnchorComponent` needlessly updates the physics collision. AFAIK any entity that would care about un-anchor events should also have the required logic present in their shutdown-logic. Should the unanchor event even be raised on shutdown?