### PR TITLE
Makes VirtualController an abstract class inheriting EntitySystem

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -57,14 +57,14 @@ namespace Robust.Shared.GameObjects
          * Given the kind of game SS14 is (our target game I guess) parallelising the islands will probably be the biggest benefit.
          */
 
-        private static readonly Histogram _tickUsageControllerBeforeSolveHistogram = Metrics.CreateHistogram("robust_entity_physics_controller_before_solve",
+        public static readonly Histogram TickUsageControllerBeforeSolveHistogram = Metrics.CreateHistogram("robust_entity_physics_controller_before_solve",
             "Amount of time spent running a controller's UpdateBeforeSolve", new HistogramConfiguration
             {
                 LabelNames = new[] {"controller"},
                 Buckets = Histogram.ExponentialBuckets(0.000_001, 1.5, 25)
             });
 
-        private static readonly Histogram _tickUsageControllerAfterSolveHistogram = Metrics.CreateHistogram("robust_entity_physics_controller_after_solve",
+        public static readonly Histogram TickUsageControllerAfterSolveHistogram = Metrics.CreateHistogram("robust_entity_physics_controller_after_solve",
             "Amount of time spent running a controller's UpdateAfterSolve", new HistogramConfiguration
             {
                 LabelNames = new[] {"controller"},
@@ -75,12 +75,9 @@ namespace Robust.Shared.GameObjects
         [Dependency] protected readonly IMapManager MapManager = default!;
         [Dependency] private readonly IPhysicsManager _physicsManager = default!;
 
-        internal IEnumerable<VirtualController> Controllers => _controllers.Values;
-        private readonly Dictionary<Type, VirtualController> _controllers = new();
-
         public Action<Fixture, Fixture, float, Vector2>? KinematicControllerCollision;
 
-        public bool MetricsEnabled;
+        public bool MetricsEnabled { get; protected set; }
         private readonly Stopwatch _stopwatch = new();
 
         public override void Initialize()
@@ -99,9 +96,6 @@ namespace Robust.Shared.GameObjects
             SubscribeLocalEvent<SharedPhysicsMapComponent, ComponentInit>(HandlePhysicsMapInit);
             SubscribeLocalEvent<SharedPhysicsMapComponent, ComponentRemove>(HandlePhysicsMapRemove);
             SubscribeLocalEvent<PhysicsComponent, ComponentInit>(OnPhysicsInit);
-
-            BuildControllers();
-            Logger.DebugS("physics", $"Found {_controllers.Count} physics controllers.");
 
             IoCManager.Resolve<IIslandManager>().Initialize();
 
@@ -133,11 +127,6 @@ namespace Robust.Shared.GameObjects
         {
             component.ContactManager.KinematicControllerCollision -= KinematicControllerCollision;
             component.ContactManager.Shutdown();
-        }
-
-        public T GetController<T>() where T : VirtualController
-        {
-            return (T) _controllers[typeof(T)];
         }
 
         private void HandleParentChange(ref EntParentChangedMessage args)
@@ -223,50 +212,9 @@ namespace Robust.Shared.GameObjects
             EntityManager.EnsureComponent<FixturesComponent>(ev.EntityUid);
         }
 
-        private void BuildControllers()
-        {
-            var reflectionManager = IoCManager.Resolve<IReflectionManager>();
-            var typeFactory = IoCManager.Resolve<IDynamicTypeFactory>();
-            var instantiated = new List<VirtualController>();
-
-            foreach (var type in reflectionManager.GetAllChildren(typeof(VirtualController)))
-            {
-                if (type.IsAbstract)
-                    continue;
-
-                instantiated.Add(typeFactory.CreateInstance<VirtualController>(type));
-            }
-
-            var nodes = TopologicalSort.FromBeforeAfter(
-                instantiated,
-                c => c.GetType(),
-                c => c,
-                c => c.UpdatesBefore,
-                c => c.UpdatesAfter);
-
-            var controllers = TopologicalSort.Sort(nodes).ToList();
-
-            foreach (var controller in controllers)
-            {
-                _controllers[controller.GetType()] = controller;
-            }
-
-            foreach (var (_, controller) in _controllers)
-            {
-                controller.BeforeMonitor = _tickUsageControllerBeforeSolveHistogram.WithLabels(controller.GetType().Name);
-                controller.AfterMonitor = _tickUsageControllerAfterSolveHistogram.WithLabels(controller.GetType().Name);
-                controller.Initialize();
-            }
-        }
-
         public override void Shutdown()
         {
             base.Shutdown();
-
-            foreach (var (_, controller) in _controllers)
-            {
-                controller.Shutdown();
-            }
 
             MapManager.MapCreated -= HandleMapCreated;
 
@@ -375,18 +323,8 @@ namespace Robust.Shared.GameObjects
         /// <param name="prediction">Should only predicted entities be considered in this simulation step?</param>
         protected void SimulateWorld(float deltaTime, bool prediction)
         {
-            foreach (var (_, controller) in _controllers)
-            {
-                if (MetricsEnabled)
-                {
-                    _stopwatch.Restart();
-                }
-                controller.UpdateBeforeSolve(prediction, deltaTime);
-                if (MetricsEnabled)
-                {
-                    controller.BeforeMonitor.Observe(_stopwatch.Elapsed.TotalSeconds);
-                }
-            }
+            var updateBeforeSolve = new PhysicsUpdateBeforeSolveEvent(prediction, deltaTime);
+            RaiseLocalEvent(ref updateBeforeSolve);
 
             // As controllers may update rotations / positions on their own we can't re-use the cache for finding new contacts
             _broadphaseSystem.EnsureBroadphaseTransforms();
@@ -396,20 +334,8 @@ namespace Robust.Shared.GameObjects
                 comp.Step(deltaTime, prediction);
             }
 
-            foreach (var (_, controller) in _controllers)
-            {
-                if (MetricsEnabled)
-                {
-                    _stopwatch.Restart();
-                }
-
-                controller.UpdateAfterSolve(prediction, deltaTime);
-
-                if (MetricsEnabled)
-                {
-                    controller.AfterMonitor.Observe(_stopwatch.Elapsed.TotalSeconds);
-                }
-            }
+            var updateAfterSolve = new PhysicsUpdateAfterSolveEvent(prediction, deltaTime);
+            RaiseLocalEvent(ref updateAfterSolve);
 
             // Go through and run all of the deferred events now
             foreach (var comp in EntityManager.EntityQuery<SharedPhysicsMapComponent>(true))
@@ -427,6 +353,32 @@ namespace Robust.Shared.GameObjects
             var batchSize = (int) MathF.Ceiling((float) count / batches);
 
             return (batches, batchSize);
+        }
+    }
+
+    [ByRefEvent]
+    public readonly struct PhysicsUpdateAfterSolveEvent
+    {
+        public readonly bool Prediction;
+        public readonly float DeltaTime;
+
+        public PhysicsUpdateAfterSolveEvent(bool prediction, float deltaTime)
+        {
+            Prediction = prediction;
+            DeltaTime = deltaTime;
+        }
+    }
+
+    [ByRefEvent]
+    public readonly struct PhysicsUpdateBeforeSolveEvent
+    {
+        public readonly bool Prediction;
+        public readonly float DeltaTime;
+
+        public PhysicsUpdateBeforeSolveEvent(bool prediction, float deltaTime)
+        {
+            Prediction = prediction;
+            DeltaTime = deltaTime;
         }
     }
 }

--- a/Robust.Shared/Physics/Controllers/VirtualController.cs
+++ b/Robust.Shared/Physics/Controllers/VirtualController.cs
@@ -5,27 +5,72 @@ using Prometheus;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Physics.Dynamics;
+using Robust.Shared.Timing;
 
 namespace Robust.Shared.Physics.Controllers
 {
     [MeansImplicitUse]
-    public abstract class VirtualController
+    public abstract class VirtualController : EntitySystem
     {
-        [Dependency] protected readonly IEntityManager EntityManager = default!;
+        [Dependency] protected readonly SharedPhysicsSystem PhysicsSystem = default!;
+
+        private static readonly Stopwatch Stopwatch = new();
 
         public Histogram.Child BeforeMonitor = default!;
         public Histogram.Child AfterMonitor = default!;
 
-        public virtual List<Type> UpdatesBefore => new();
+        #region Boilerplate
 
-        public virtual List<Type> UpdatesAfter => new();
-
-        public virtual void Initialize()
+        public override void Initialize()
         {
-            IoCManager.InjectDependencies(this);
+            base.Initialize();
+
+            BeforeMonitor = SharedPhysicsSystem.TickUsageControllerBeforeSolveHistogram.WithLabels(GetType().Name);
+            AfterMonitor = SharedPhysicsSystem.TickUsageControllerAfterSolveHistogram.WithLabels(GetType().Name);
+
+            var updatesBefore = UpdatesBefore.ToArray();
+            var updatesAfter = UpdatesAfter.ToArray();
+
+            SubscribeLocalEvent<PhysicsUpdateBeforeSolveEvent>(OnBeforeSolve, updatesBefore, updatesAfter);
+            SubscribeLocalEvent<PhysicsUpdateAfterSolveEvent>(OnAfterSolve, updatesBefore, updatesAfter);
+
+            SubscribeLocalEvent<PhysicsUpdateBeforeMapSolveEvent>(OnBeforeMapSolve, updatesBefore, updatesAfter);
+            SubscribeLocalEvent<PhysicsUpdateAfterMapSolveEvent>(OnAfterMapSolve, updatesBefore, updatesAfter);
         }
 
-        public virtual void Shutdown() {}
+        private void OnBeforeSolve(ref PhysicsUpdateBeforeSolveEvent ev)
+        {
+            if(PhysicsSystem.MetricsEnabled)
+                Stopwatch.Restart();
+
+            UpdateBeforeSolve(ev.Prediction, ev.DeltaTime);
+
+            if(PhysicsSystem.MetricsEnabled)
+                BeforeMonitor.Observe(Stopwatch.Elapsed.TotalSeconds);
+        }
+
+        private void OnAfterSolve(ref PhysicsUpdateAfterSolveEvent ev)
+        {
+            if(PhysicsSystem.MetricsEnabled)
+                Stopwatch.Restart();
+
+            UpdateAfterSolve(ev.Prediction, ev.DeltaTime);
+
+            if(PhysicsSystem.MetricsEnabled)
+                AfterMonitor.Observe(Stopwatch.Elapsed.TotalSeconds);
+        }
+
+        private void OnBeforeMapSolve(ref PhysicsUpdateBeforeMapSolveEvent ev)
+        {
+            UpdateBeforeMapSolve(ev.Prediction, ev.MapComponent, ev.DeltaTime);
+        }
+
+        private void OnAfterMapSolve(ref PhysicsUpdateAfterMapSolveEvent ev)
+        {
+            UpdateAfterMapSolve(ev.Prediction, ev.MapComponent, ev.DeltaTime);
+        }
+
+        #endregion
 
         /// <summary>
         ///     Run before any map processing starts.

--- a/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
+++ b/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
@@ -229,10 +229,8 @@ namespace Robust.Shared.Physics.Dynamics
             var invDt = frameTime > 0.0f ? 1.0f / frameTime : 0.0f;
             var dtRatio = _invDt0 * frameTime;
 
-            foreach (var controller in PhysicsSystem.Controllers)
-            {
-                controller.UpdateBeforeMapSolve(prediction, this, frameTime);
-            }
+            var updateBeforeSolve = new PhysicsUpdateBeforeMapSolveEvent(prediction, this, frameTime);
+            _entityManager.EventBus.RaiseEvent(EventSource.Local, ref updateBeforeSolve);
 
             ContactManager.Collide();
             // Don't run collision behaviors during FrameUpdate?
@@ -247,10 +245,8 @@ namespace Robust.Shared.Physics.Dynamics
 
             // TODO: SolveTOI
 
-            foreach (var controller in PhysicsSystem.Controllers)
-            {
-                controller.UpdateAfterMapSolve(prediction, this, frameTime);
-            }
+            var updateAfterSolve = new PhysicsUpdateAfterMapSolveEvent(prediction, this, frameTime);
+            _entityManager.EventBus.RaiseEvent(EventSource.Local, ref updateAfterSolve);
 
             // Box2d recommends clearing (if you are) during fixed updates rather than variable if you are using it
             if (!prediction && AutoClearForces)
@@ -472,6 +468,36 @@ namespace Robust.Shared.Physics.Dynamics
                 body.Force = Vector2.Zero;
                 body.Torque = 0.0f;
             }
+        }
+    }
+
+    [ByRefEvent]
+    public readonly struct PhysicsUpdateBeforeMapSolveEvent
+    {
+        public readonly bool Prediction;
+        public readonly SharedPhysicsMapComponent MapComponent;
+        public readonly float DeltaTime;
+
+        public PhysicsUpdateBeforeMapSolveEvent(bool prediction, SharedPhysicsMapComponent mapComponent, float deltaTime)
+        {
+            Prediction = prediction;
+            MapComponent = mapComponent;
+            DeltaTime = deltaTime;
+        }
+    }
+
+    [ByRefEvent]
+    public readonly struct PhysicsUpdateAfterMapSolveEvent
+    {
+        public readonly bool Prediction;
+        public readonly SharedPhysicsMapComponent MapComponent;
+        public readonly float DeltaTime;
+
+        public PhysicsUpdateAfterMapSolveEvent(bool prediction, SharedPhysicsMapComponent mapComponent, float deltaTime)
+        {
+            Prediction = prediction;
+            MapComponent = mapComponent;
+            DeltaTime = deltaTime;
         }
     }
 }


### PR DESCRIPTION
- `VirtualController` is now an abstract class that inherits `EntitySystem`, with some code to reduce boilerplate on inheritors.
- Uses by-ref `readonly struct` events for `UpdateBeforeSolve`, `UpdateAfterSolve`, `UpdateBeforeMapSolve` and `UpdateAfterMapSolve`
- Content barely needs changes! Hurray!

Required by https://github.com/space-wizards/space-station-14/pull/6161

cc @metalgearsloth 