### PR TITLE
Store grids in a DynamicTree

### DIFF
--- a/Robust.Client/GameController/GameController.cs
+++ b/Robust.Client/GameController/GameController.cs
@@ -134,8 +134,8 @@ namespace Robust.Client
             _prototypeManager.Initialize();
             _prototypeManager.LoadDirectory(Options.PrototypeDirectory);
             _prototypeManager.Resync();
-            _mapManager.Initialize();
             _entityManager.Initialize();
+            _mapManager.Initialize();
             _gameStateManager.Initialize();
             _placementManager.Initialize();
             _viewVariablesManager.Initialize();

--- a/Robust.Client/GameObjects/EntitySystems/GridChunkBoundsDebugSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/GridChunkBoundsDebugSystem.cs
@@ -1,4 +1,3 @@
-using System;
 using Robust.Client.Graphics;
 using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
@@ -13,6 +12,10 @@ namespace Robust.Client.GameObjects
 {
     public class GridChunkBoundsDebugSystem : EntitySystem
     {
+        [Dependency] private readonly IEyeManager _eyeManager = default!;
+        [Dependency] private readonly IMapManager _mapManager = default!;
+        [Dependency] private readonly IOverlayManager _overlayManager = default!;
+
         private GridChunkBoundsOverlay? _overlay;
 
         public bool Enabled
@@ -29,14 +32,14 @@ namespace Robust.Client.GameObjects
                     DebugTools.Assert(_overlay == null);
                     _overlay = new GridChunkBoundsOverlay(
                         EntityManager,
-                        IoCManager.Resolve<IEyeManager>(),
-                        IoCManager.Resolve<IMapManager>());
+                        _eyeManager,
+                        _mapManager);
 
-                    IoCManager.Resolve<IOverlayManager>().AddOverlay(_overlay);
+                    _overlayManager.AddOverlay(_overlay);
                 }
                 else
                 {
-                    IoCManager.Resolve<IOverlayManager>().RemoveOverlay(_overlay!);
+                    _overlayManager.RemoveOverlay(_overlay!);
                     _overlay = null;
                 }
             }
@@ -63,7 +66,7 @@ namespace Robust.Client.GameObjects
         protected internal override void Draw(in OverlayDrawArgs args)
         {
             var currentMap = _eyeManager.CurrentMap;
-            var viewport = _eyeManager.GetWorldViewport();
+            var viewport = args.WorldBounds;
             var worldHandle = args.WorldHandle;
 
             foreach (var grid in _mapManager.FindGridsIntersecting(currentMap, viewport))

--- a/Robust.Client/Map/ClientMapManager.cs
+++ b/Robust.Client/Map/ClientMapManager.cs
@@ -108,6 +108,7 @@ namespace Robust.Client.Map
                         throw new NotImplementedException("Moving grids between maps is not yet implemented");
                     }
 
+                    // I love mapmanager!!!
                     grid.WorldPosition = gridDatum.Coordinates.Position;
                     grid.WorldRotation = gridDatum.Angle;
 

--- a/Robust.Client/Map/ClientMapManager.cs
+++ b/Robust.Client/Map/ClientMapManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
+using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
@@ -108,6 +109,7 @@ namespace Robust.Client.Map
                     }
 
                     grid.WorldPosition = gridDatum.Coordinates.Position;
+                    grid.WorldRotation = gridDatum.Angle;
 
                     var modified = new List<(Vector2i position, Tile tile)>();
                     foreach (var chunkData in gridDatum.ChunkData)

--- a/Robust.Server/Map/ServerMapManager.cs
+++ b/Robust.Server/Map/ServerMapManager.cs
@@ -109,7 +109,8 @@ namespace Robust.Server.Map
                 var gridDatum = new GameStateMapData.GridDatum(
                         chunkData.ToArray(),
                         deletedChunkData.ToArray(),
-                        new MapCoordinates(grid.WorldPosition, grid.ParentMapId));
+                        new MapCoordinates(grid.WorldPosition, grid.ParentMapId),
+                        grid.WorldRotation);
 
                 gridDatums.Add(grid.Index, gridDatum);
             }

--- a/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
@@ -61,8 +61,10 @@ namespace Robust.Shared.GameObjects
 
             if (_container.IsEntityInContainer(entity, transform)) return;
 
+            var mapPos = moveEvent.NewPosition.ToMapPos(EntityManager);
+
             // Change parent if necessary
-            if (_mapManager.TryFindGridAt(transform.MapID, moveEvent.NewPosition.ToMapPos(EntityManager), out var grid) &&
+            if (_mapManager.TryFindGridAt(transform.MapID, mapPos, out var grid) &&
                 // TODO: Do we even need this?
                 EntityManager.EntityExists(grid.GridEntityId) &&
                 grid.GridEntityId != entity)

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
@@ -21,7 +21,8 @@ namespace Robust.Shared.GameObjects
 
         private void OnGridAdd(EntityUid uid, MapGridComponent component, ComponentAdd args)
         {
-            var msg = new GridAddEvent(uid, component.GridIndex);
+            // GridID is not set yet so we don't include it.
+            var msg = new GridAddEvent(uid);
             EntityManager.EventBus.RaiseLocalEvent(uid, msg);
         }
 
@@ -89,12 +90,10 @@ namespace Robust.Shared.GameObjects
     public sealed class GridAddEvent : EntityEventArgs
     {
         public EntityUid EntityUid { get; }
-        public GridId GridId { get; }
 
-        public GridAddEvent(EntityUid uid, GridId gridId)
+        public GridAddEvent(EntityUid uid)
         {
             EntityUid = uid;
-            GridId = gridId;
         }
     }
 }

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -326,9 +326,6 @@ namespace Robust.Shared.GameObjects
             var updateBeforeSolve = new PhysicsUpdateBeforeSolveEvent(prediction, deltaTime);
             RaiseLocalEvent(ref updateBeforeSolve);
 
-            // As controllers may update rotations / positions on their own we can't re-use the cache for finding new contacts
-            _broadphaseSystem.EnsureBroadphaseTransforms();
-
             foreach (var comp in EntityManager.EntityQuery<SharedPhysicsMapComponent>(true))
             {
                 comp.Step(deltaTime, prediction);

--- a/Robust.Shared/GameStates/GameStateMapData.cs
+++ b/Robust.Shared/GameStates/GameStateMapData.cs
@@ -40,14 +40,16 @@ namespace Robust.Shared.GameStates
         public struct GridDatum
         {
             public readonly MapCoordinates Coordinates;
+            public readonly Angle Angle;
             public readonly ChunkDatum[] ChunkData;
             public readonly DeletedChunkDatum[] DeletedChunkData;
 
-            public GridDatum(ChunkDatum[] chunkData, DeletedChunkDatum[] deletedChunkData, MapCoordinates coordinates)
+            public GridDatum(ChunkDatum[] chunkData, DeletedChunkDatum[] deletedChunkData, MapCoordinates coordinates, Angle angle)
             {
                 ChunkData = chunkData;
                 DeletedChunkData = deletedChunkData;
                 Coordinates = coordinates;
+                Angle = angle;
             }
         }
 

--- a/Robust.Shared/Map/CoordinatesExtensions.cs
+++ b/Robust.Shared/Map/CoordinatesExtensions.cs
@@ -8,7 +8,7 @@ namespace Robust.Shared.Map
     {
         public static EntityCoordinates ToEntityCoordinates(this Vector2i vector, GridId gridId, IMapManager? mapManager = null)
         {
-            mapManager ??= IoCManager.Resolve<IMapManager>();
+            IoCManager.Resolve(ref mapManager);
 
             var grid = mapManager.GetGrid(gridId);
             var tile = grid.TileSize;

--- a/Robust.Shared/Map/IMapManager.cs
+++ b/Robust.Shared/Map/IMapManager.cs
@@ -25,6 +25,16 @@ namespace Robust.Shared.Map
         bool SuppressOnTileChanged { get; set; }
 
         /// <summary>
+        /// Get the set of grids that have moved on this map in this tick.
+        /// </summary>
+        HashSet<IMapGrid> GetMovedGrids(MapId mapId);
+
+        /// <summary>
+        /// Clear the set of grids that have moved on this map in this tick.
+        /// </summary>
+        void ClearMovedGrids(MapId mapId);
+
+        /// <summary>
         ///     Starts up the map system.
         /// </summary>
         void Initialize();

--- a/Robust.Shared/Map/IMapManagerInternal.cs
+++ b/Robust.Shared/Map/IMapManagerInternal.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Timing;
 

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Maths;
+using Robust.Shared.Physics;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
@@ -35,6 +36,11 @@ namespace Robust.Shared.Map
 
         [ViewVariables]
         public EntityUid GridEntityId { get; internal set; }
+
+        /// <summary>
+        /// Map DynamicTree proxy to lookup for grid intersection.
+        /// </summary>
+        internal DynamicTree.Proxy MapProxy = DynamicTree.Proxy.Free;
 
         /// <summary>
         ///     Grid chunks than make up this grid.

--- a/Robust.Shared/Map/MapManager.GridTrees.cs
+++ b/Robust.Shared/Map/MapManager.GridTrees.cs
@@ -1,0 +1,131 @@
+using System.Collections.Generic;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Maths;
+using Robust.Shared.Physics;
+
+namespace Robust.Shared.Map;
+
+internal partial class MapManager
+{
+    // TODO: Move IMapManager stuff to the system
+    private Dictionary<MapId, B2DynamicTree<MapGrid>> _gridTrees = new();
+    private Dictionary<MapId, HashSet<IMapGrid>> _movedGrids = new();
+
+    // Gets the grids that have moved this tick until broadphase has run.
+    public HashSet<IMapGrid> GetMovedGrids(MapId mapId)
+    {
+        return _movedGrids[mapId];
+    }
+
+    public void ClearMovedGrids(MapId mapId)
+    {
+        _movedGrids[mapId].Clear();
+    }
+
+    private void StartupGridTrees()
+    {
+        MapCreated += OnMapCreatedGridTree;
+        MapDestroyed += OnMapDestroyedGridTree;
+
+        _entityManager.EventBus.SubscribeEvent<GridInitializeEvent>(EventSource.Local, this, OnGridInit);
+        _entityManager.EventBus.SubscribeEvent<GridRemovalEvent>(EventSource.Local, this, OnGridRemove);
+        _entityManager.EventBus.SubscribeLocalEvent<MapGridComponent, MoveEvent>(OnGridMove);
+        _entityManager.EventBus.SubscribeLocalEvent<MapGridComponent, EntMapIdChangedMessage>(OnGridMapChange);
+        _entityManager.EventBus.SubscribeLocalEvent<MapGridComponent, GridFixtureChangeEvent>(OnGridBoundsChange);
+    }
+
+    private void ShutdownGridTrees()
+    {
+        MapCreated -= OnMapCreatedGridTree;
+        MapDestroyed -= OnMapDestroyedGridTree;
+
+        _entityManager.EventBus.UnsubscribeEvent<GridInitializeEvent>(EventSource.Local, this);
+        _entityManager.EventBus.UnsubscribeEvent<GridRemovalEvent>(EventSource.Local, this);
+        _entityManager.EventBus.UnsubscribeLocalEvent<MapGridComponent, MoveEvent>();
+        _entityManager.EventBus.UnsubscribeLocalEvent<MapGridComponent, EntMapIdChangedMessage>();
+        _entityManager.EventBus.UnsubscribeLocalEvent<MapGridComponent, GridFixtureChangeEvent>();
+    }
+
+    private void OnMapCreatedGridTree(object? sender, MapEventArgs e)
+    {
+        if (e.Map == MapId.Nullspace) return;
+
+        _gridTrees.Add(e.Map, new B2DynamicTree<MapGrid>());
+        _movedGrids.Add(e.Map, new HashSet<IMapGrid>());
+    }
+
+    private void OnMapDestroyedGridTree(object? sender, MapEventArgs e)
+    {
+        if (e.Map == MapId.Nullspace) return;
+
+        _gridTrees.Remove(e.Map);
+        _movedGrids.Remove(e.Map);
+    }
+
+    private Box2 GetWorldAABB(MapGrid grid)
+    {
+        var xform = EntityManager.GetComponent<TransformComponent>(grid.GridEntityId);
+
+        var (worldPos, worldRot) = xform.GetWorldPositionRotation();
+
+        return new Box2Rotated(grid.LocalBounds.Translated(worldPos), worldRot, worldPos).CalcBoundingBox();
+    }
+
+    private void OnGridInit(GridInitializeEvent args)
+    {
+        var grid = (MapGrid) GetGrid(args.GridId);
+        var xform = EntityManager.GetComponent<TransformComponent>(args.EntityUid);
+        var mapId = xform.MapID;
+
+        var aabb = GetWorldAABB(grid);
+        var proxy = _gridTrees[mapId].CreateProxy(in aabb, grid);
+
+        grid.MapProxy = proxy;
+
+        _movedGrids[mapId].Add(grid);
+    }
+
+    private void OnGridRemove(GridRemovalEvent args)
+    {
+        var grid = (MapGrid) GetGrid(args.GridId);
+        var xform = EntityManager.GetComponent<TransformComponent>(args.EntityUid);
+
+        _gridTrees[xform.MapID].DestroyProxy(grid.MapProxy);
+    }
+
+    private void OnGridMove(EntityUid uid, MapGridComponent component, ref MoveEvent args)
+    {
+        var xform = EntityManager.GetComponent<TransformComponent>(uid);
+        var grid = (MapGrid) component.Grid;
+        var aabb = GetWorldAABB(grid);
+        _gridTrees[xform.MapID].MoveProxy(grid.MapProxy, in aabb, Vector2.Zero);
+    }
+
+    private void OnGridMapChange(EntityUid uid, MapGridComponent component, EntMapIdChangedMessage args)
+    {
+        // Make sure we cleanup old map for moved grid stuff.
+        var mapId = EntityManager.GetComponent<TransformComponent>(uid).MapID;
+
+        if (_movedGrids.TryGetValue(args.OldMapId, out var oldMovedGrids))
+        {
+            oldMovedGrids.Remove(component.Grid);
+        }
+
+        if (_movedGrids.TryGetValue(mapId, out var newMovedGrids))
+        {
+            newMovedGrids.Add(component.Grid);
+        }
+    }
+
+    private void OnGridBoundsChange(EntityUid uid, MapGridComponent component, GridFixtureChangeEvent args)
+    {
+        // Just MapLoader things.
+        if (EntityManager.GetComponent<MetaDataComponent>(uid).EntityLifeStage < EntityLifeStage.Initialized) return;
+
+        var xform = EntityManager.GetComponent<TransformComponent>(uid);
+        var grid = (MapGrid) component.Grid;
+        var aabb = GetWorldAABB(grid);
+        _gridTrees[xform.MapID].MoveProxy(grid.MapProxy, in aabb, Vector2.Zero);
+    }
+}

--- a/Robust.Shared/Map/MapManager.GridTrees.cs
+++ b/Robust.Shared/Map/MapManager.GridTrees.cs
@@ -3,6 +3,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Map;
 
@@ -98,17 +99,28 @@ internal partial class MapManager
 
     private void OnGridMove(EntityUid uid, MapGridComponent component, ref MoveEvent args)
     {
+        // Just maploader things
+        var lifestage = EntityManager.GetComponent<MetaDataComponent>(uid).EntityLifeStage;
+
+        if (lifestage < EntityLifeStage.Initialized) return;
+
         var xform = EntityManager.GetComponent<TransformComponent>(uid);
         var grid = (MapGrid) component.Grid;
         var aabb = GetWorldAABB(grid);
+        DebugTools.Assert(grid.MapProxy != DynamicTree.Proxy.Free);
         _gridTrees[xform.MapID].MoveProxy(grid.MapProxy, in aabb, Vector2.Zero);
     }
 
     private void OnGridRotate(EntityUid uid, MapGridComponent component, ref RotateEvent args)
     {
+        var lifestage = EntityManager.GetComponent<MetaDataComponent>(uid).EntityLifeStage;
+
+        if (lifestage < EntityLifeStage.Initialized) return;
+
         var xform = EntityManager.GetComponent<TransformComponent>(uid);
         var grid = (MapGrid) component.Grid;
         var aabb = GetWorldAABB(grid);
+        DebugTools.Assert(grid.MapProxy != DynamicTree.Proxy.Free);
         _gridTrees[xform.MapID].MoveProxy(grid.MapProxy, in aabb, Vector2.Zero);
     }
 

--- a/Robust.Shared/Map/MapManager.GridTrees.cs
+++ b/Robust.Shared/Map/MapManager.GridTrees.cs
@@ -99,14 +99,13 @@ internal partial class MapManager
 
     private void OnGridRotate(EntityUid uid, MapGridComponent component, ref RotateEvent args)
     {
-        var lifestage = EntityManager.GetComponent<MetaDataComponent>(uid).EntityLifeStage;
+        var grid = (MapGrid) component.Grid;
 
-        if (lifestage < EntityLifeStage.Initialized) return;
+        // Just maploader / test things
+        if (grid.MapProxy == DynamicTree.Proxy.Free) return;
 
         var xform = EntityManager.GetComponent<TransformComponent>(uid);
-        var grid = (MapGrid) component.Grid;
         var aabb = GetWorldAABB(grid);
-        DebugTools.Assert(grid.MapProxy != DynamicTree.Proxy.Free);
         _gridTrees[xform.MapID].MoveProxy(grid.MapProxy, in aabb, Vector2.Zero);
     }
 

--- a/Robust.Shared/Map/MapManager.GridTrees.cs
+++ b/Robust.Shared/Map/MapManager.GridTrees.cs
@@ -94,20 +94,20 @@ internal partial class MapManager
         var grid = (MapGrid) GetGrid(args.GridId);
         var xform = EntityManager.GetComponent<TransformComponent>(args.EntityUid);
 
+        if (xform.MapID == MapId.Nullspace) return;
+
         _gridTrees[xform.MapID].DestroyProxy(grid.MapProxy);
     }
 
     private void OnGridMove(EntityUid uid, MapGridComponent component, ref MoveEvent args)
     {
-        // Just maploader things
-        var lifestage = EntityManager.GetComponent<MetaDataComponent>(uid).EntityLifeStage;
+        var grid = (MapGrid) component.Grid;
 
-        if (lifestage < EntityLifeStage.Initialized) return;
+        // Just maploader / test things
+        if (grid.MapProxy == DynamicTree.Proxy.Free) return;
 
         var xform = EntityManager.GetComponent<TransformComponent>(uid);
-        var grid = (MapGrid) component.Grid;
         var aabb = GetWorldAABB(grid);
-        DebugTools.Assert(grid.MapProxy != DynamicTree.Proxy.Free);
         _gridTrees[xform.MapID].MoveProxy(grid.MapProxy, in aabb, Vector2.Zero);
     }
 

--- a/Robust.Shared/Map/MapManager.GridTrees.cs
+++ b/Robust.Shared/Map/MapManager.GridTrees.cs
@@ -24,11 +24,8 @@ internal partial class MapManager
         _movedGrids[mapId].Clear();
     }
 
-    private void StartupGridTrees()
+    private void InitializeGridTrees()
     {
-        MapCreated += OnMapCreatedGridTree;
-        MapDestroyed += OnMapDestroyedGridTree;
-
         _entityManager.EventBus.SubscribeEvent<GridInitializeEvent>(EventSource.Local, this, OnGridInit);
         _entityManager.EventBus.SubscribeEvent<GridRemovalEvent>(EventSource.Local, this, OnGridRemove);
         _entityManager.EventBus.SubscribeLocalEvent<MapGridComponent, MoveEvent>(OnGridMove);
@@ -37,20 +34,7 @@ internal partial class MapManager
         _entityManager.EventBus.SubscribeLocalEvent<MapGridComponent, GridFixtureChangeEvent>(OnGridBoundsChange);
     }
 
-    private void ShutdownGridTrees()
-    {
-        MapCreated -= OnMapCreatedGridTree;
-        MapDestroyed -= OnMapDestroyedGridTree;
-
-        _entityManager.EventBus.UnsubscribeEvent<GridInitializeEvent>(EventSource.Local, this);
-        _entityManager.EventBus.UnsubscribeEvent<GridRemovalEvent>(EventSource.Local, this);
-        _entityManager.EventBus.UnsubscribeLocalEvent<MapGridComponent, MoveEvent>();
-        _entityManager.EventBus.UnsubscribeLocalEvent<MapGridComponent, RotateEvent>();
-        _entityManager.EventBus.UnsubscribeLocalEvent<MapGridComponent, EntMapIdChangedMessage>();
-        _entityManager.EventBus.UnsubscribeLocalEvent<MapGridComponent, GridFixtureChangeEvent>();
-    }
-
-    private void OnMapCreatedGridTree(object? sender, MapEventArgs e)
+    private void OnMapCreatedGridTree(MapEventArgs e)
     {
         if (e.Map == MapId.Nullspace) return;
 
@@ -58,7 +42,7 @@ internal partial class MapManager
         _movedGrids.Add(e.Map, new HashSet<IMapGrid>());
     }
 
-    private void OnMapDestroyedGridTree(object? sender, MapEventArgs e)
+    private void OnMapDestroyedGridTree(MapEventArgs e)
     {
         if (e.Map == MapId.Nullspace) return;
 

--- a/Robust.Shared/Map/MapManager.GridTrees.cs
+++ b/Robust.Shared/Map/MapManager.GridTrees.cs
@@ -65,6 +65,8 @@ internal partial class MapManager
         var xform = EntityManager.GetComponent<TransformComponent>(args.EntityUid);
         var mapId = xform.MapID;
 
+        if (mapId == MapId.Nullspace) return;
+
         var aabb = GetWorldAABB(grid);
         var proxy = _gridTrees[mapId].CreateProxy(in aabb, grid);
 

--- a/Robust.Shared/Map/MapManager.GridTrees.cs
+++ b/Robust.Shared/Map/MapManager.GridTrees.cs
@@ -31,6 +31,7 @@ internal partial class MapManager
         _entityManager.EventBus.SubscribeEvent<GridInitializeEvent>(EventSource.Local, this, OnGridInit);
         _entityManager.EventBus.SubscribeEvent<GridRemovalEvent>(EventSource.Local, this, OnGridRemove);
         _entityManager.EventBus.SubscribeLocalEvent<MapGridComponent, MoveEvent>(OnGridMove);
+        _entityManager.EventBus.SubscribeLocalEvent<MapGridComponent, RotateEvent>(OnGridRotate);
         _entityManager.EventBus.SubscribeLocalEvent<MapGridComponent, EntMapIdChangedMessage>(OnGridMapChange);
         _entityManager.EventBus.SubscribeLocalEvent<MapGridComponent, GridFixtureChangeEvent>(OnGridBoundsChange);
     }
@@ -43,6 +44,7 @@ internal partial class MapManager
         _entityManager.EventBus.UnsubscribeEvent<GridInitializeEvent>(EventSource.Local, this);
         _entityManager.EventBus.UnsubscribeEvent<GridRemovalEvent>(EventSource.Local, this);
         _entityManager.EventBus.UnsubscribeLocalEvent<MapGridComponent, MoveEvent>();
+        _entityManager.EventBus.UnsubscribeLocalEvent<MapGridComponent, RotateEvent>();
         _entityManager.EventBus.UnsubscribeLocalEvent<MapGridComponent, EntMapIdChangedMessage>();
         _entityManager.EventBus.UnsubscribeLocalEvent<MapGridComponent, GridFixtureChangeEvent>();
     }
@@ -95,6 +97,14 @@ internal partial class MapManager
     }
 
     private void OnGridMove(EntityUid uid, MapGridComponent component, ref MoveEvent args)
+    {
+        var xform = EntityManager.GetComponent<TransformComponent>(uid);
+        var grid = (MapGrid) component.Grid;
+        var aabb = GetWorldAABB(grid);
+        _gridTrees[xform.MapID].MoveProxy(grid.MapProxy, in aabb, Vector2.Zero);
+    }
+
+    private void OnGridRotate(EntityUid uid, MapGridComponent component, ref RotateEvent args)
     {
         var xform = EntityManager.GetComponent<TransformComponent>(uid);
         var grid = (MapGrid) component.Grid;

--- a/Robust.Shared/Map/MapManager.Queries.cs
+++ b/Robust.Shared/Map/MapManager.Queries.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Maths;
+using Robust.Shared.Physics;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Map;
+
+internal partial class MapManager
+{
+    public IEnumerable<IMapGrid> FindGridsIntersecting(MapId mapId, Box2Rotated bounds, bool approx = false)
+    {
+        var aabb = bounds.CalcBoundingBox();
+        // TODO: We can do slower GJK checks to check if 2 bounds actually intersect, but WYCI.
+        return FindGridsIntersecting(mapId, aabb, approx);
+    }
+
+    /// <summary>
+    /// Returns the grids intersecting this AABB.
+    /// </summary>
+    /// <param name="mapId">The relevant MapID</param>
+    /// <param name="aabb">The AABB to intersect</param>
+    /// <param name="approx">Set to false if you wish to accurately get the grid bounds per-tile.</param>
+    public IEnumerable<IMapGrid> FindGridsIntersecting(MapId mapId, Box2 aabb, bool approx = false)
+    {
+        if (!_gridTrees.TryGetValue(mapId, out var gridTree)) return Enumerable.Empty<IMapGrid>();
+
+        var grids = new List<MapGrid>();
+
+        gridTree.FastQuery(ref aabb, (ref MapGrid data) =>
+        {
+            grids.Add(data);
+        });
+
+        if (!approx)
+        {
+            for (var i = grids.Count - 1; i >= 0; i--)
+            {
+                var grid = grids[i];
+
+                var xformComp = EntityManager.GetComponent<TransformComponent>(grid.GridEntityId);
+                var (worldPos, worldRot, invMatrix) = xformComp.GetWorldPositionRotationInvMatrix();
+                var localAABB = invMatrix.TransformBox(aabb);
+
+                var intersects = false;
+
+                if (EntityManager.HasComponent<PhysicsComponent>(grid.GridEntityId))
+                {
+                    grid.GetLocalMapChunks(localAABB, out var enumerator);
+
+                    var transform = new Transform(worldPos, worldRot);
+
+                    while (!intersects && enumerator.MoveNext(out var chunk))
+                    {
+                        foreach (var fixture in chunk.Fixtures)
+                        {
+                            for (var j = 0; j < fixture.Shape.ChildCount; j++)
+                            {
+                                if (!fixture.Shape.ComputeAABB(transform, j).Intersects(aabb)) continue;
+
+                                intersects = true;
+                                break;
+                            }
+
+                            if (intersects) break;
+                        }
+                    }
+                }
+
+                if (intersects || grid.ChunkCount == 0 && aabb.Contains(worldPos)) continue;
+
+                grids.RemoveSwap(i);
+            }
+        }
+
+        return grids;
+    }
+
+    /// <summary>
+    /// Attempts to find the map grid under the map location.
+    /// </summary>
+    public bool TryFindGridAt(MapId mapId, Vector2 worldPos, [NotNullWhen(true)] out IMapGrid? grid)
+    {
+        // Need to enlarge the AABB by at least the grid shrinkage size.
+        var aabb = new Box2(worldPos - 0.5f, worldPos + 0.5f);
+        var grids = FindGridsIntersecting(mapId, aabb, true);
+
+        foreach (var gridInter in grids)
+        {
+            var mapGrid = (MapGrid) gridInter;
+
+            // Turn the worldPos into a localPos and work out the relevant chunk we need to check
+            // This is much faster than iterating over every chunk individually.
+            // (though now we need some extra calcs up front).
+
+            // Doesn't use WorldBounds because it's just an AABB.
+            var matrix = EntityManager.GetComponent<TransformComponent>(mapGrid.GridEntityId).InvWorldMatrix;
+            var localPos = matrix.Transform(worldPos);
+
+            // NOTE:
+            // If you change this to use fixtures instead (i.e. if you want half-tiles) then you need to make sure
+            // you account for the fact that fixtures are shrunk slightly!
+            var tile = new Vector2i((int) Math.Floor(localPos.X), (int) Math.Floor(localPos.Y));
+            var chunkIndices = mapGrid.GridTileToChunkIndices(tile);
+
+            if (!mapGrid.HasChunk(chunkIndices)) continue;
+
+            var chunk = mapGrid.GetChunk(chunkIndices);
+            var chunkTile = chunk.GetTileRef(chunk.GridTileToChunkTile(tile));
+
+            if (chunkTile.Tile.IsEmpty) continue;
+            grid = mapGrid;
+            return true;
+        }
+
+        grid = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to find the map grid under the map location.
+    /// </summary>
+    public bool TryFindGridAt(MapCoordinates mapCoordinates, [NotNullWhen(true)] out IMapGrid? grid)
+    {
+        return TryFindGridAt(mapCoordinates.MapId, mapCoordinates.Position, out grid);
+    }
+}

--- a/Robust.Shared/Map/MapManager.cs
+++ b/Robust.Shared/Map/MapManager.cs
@@ -65,6 +65,8 @@ namespace Robust.Shared.Map
         /// <inheritdoc />
         public void Initialize()
         {
+            InitializeGridTrees();
+
 #if DEBUG
             DebugTools.Assert(!_dbgGuardInit);
             DebugTools.Assert(!_dbgGuardRunning);
@@ -75,8 +77,6 @@ namespace Robust.Shared.Map
         /// <inheritdoc />
         public void Startup()
         {
-            StartupGridTrees();
-
 #if DEBUG
             DebugTools.Assert(_dbgGuardInit);
             _dbgGuardRunning = true;
@@ -146,8 +146,6 @@ namespace Robust.Shared.Map
                     Logger.InfoS("map", "Removing nullspace map entity.");
             }
 
-            ShutdownGridTrees();
-
 #if DEBUG
             DebugTools.Assert(_grids.Count == 0);
             DebugTools.Assert(!GridExists(GridId.Invalid));
@@ -201,7 +199,9 @@ namespace Robust.Shared.Map
 
             if (mapID != MapId.Nullspace)
             {
-                MapDestroyed?.Invoke(this, new MapEventArgs(mapID));
+                var args = new MapEventArgs(mapID);
+                OnMapDestroyedGridTree(args);
+                MapDestroyed?.Invoke(this, args);
                 _maps.Remove(mapID);
                 _mapCreationTick.Remove(mapID);
             }
@@ -282,7 +282,9 @@ namespace Robust.Shared.Map
                 }
             }
 
-            MapCreated?.Invoke(this, new MapEventArgs(actualID));
+            var args = new MapEventArgs(actualID);
+            OnMapCreatedGridTree(args);
+            MapCreated?.Invoke(this, args);
 
             return actualID;
         }

--- a/Robust.Shared/Physics/FixtureSystem.cs
+++ b/Robust.Shared/Physics/FixtureSystem.cs
@@ -112,7 +112,6 @@ namespace Robust.Shared.Physics
             {
                 var (worldPos, worldRot) = xform.GetWorldPositionRotation();
 
-                _broadphaseSystem.UpdateBroadphaseCache(body.Broadphase);
                 _broadphaseSystem.CreateProxies(fixture, worldPos, worldRot);
             }
 

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -194,6 +194,8 @@ namespace Robust.Shared.Physics
                 }
 
                 // Get every broadphase we may be intersecting.
+                // TODO: Fuck LINQ
+                // Also TODO: Don't put grids on movebuffer so you get peak shuttle driving performance.
                 var broadphases = _mapManager.FindGridsIntersecting(mapId, worldAABB.Enlarged(_broadphaseExpand)).Select(o => o.GridEntityId).ToList();
                 broadphases.Add(_mapManager.GetMapEntityIdOrThrow(mapId));
 

--- a/Robust.UnitTesting/Shared/Map/MapGrid_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/MapGrid_Tests.cs
@@ -164,8 +164,6 @@ namespace Robust.UnitTesting.Shared.Map
 
         private static IMapGridInternal MapGridFactory(GridId id)
         {
-            var entMan = (ServerEntityManager)IoCManager.Resolve<IEntityManager>();
-
             var mapId = new MapId(5);
             var mapMan = IoCManager.Resolve<IMapManager>();
 


### PR DESCRIPTION
Removes the nasty O(n) check from FindGridsIntersecting which is much better for large grid counts.

I wasted a lot of time trying to debug issues until I realised ClientMapManager never applied the grid's rotation.

TODO:

- [x] Anchoring test for rotated grid (I think this already gets caughhhttt?)
- [x] Move grids off of the map's broadphase