### PR TITLE
Sprite offset rendering fix

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1257,7 +1257,10 @@ namespace Robust.Client.GameObjects
             if (worldRotation.Theta < 0)
                 worldRotation = new Angle(worldRotation.Theta + Math.Tau);
 
-            var spriteMatrix = GetLocalMatrix();
+            // sprite matrix, WITHOUT offset.
+            // offset is applied after sprite numDirs snapping/rotation correction
+            // --> apply at same time as layer offset
+            var spriteMatrix = Matrix3.CreateTransform(Vector2.Zero, rotation, scale);
 
             foreach (var layer in Layers)
             {
@@ -1268,7 +1271,7 @@ namespace Robust.Client.GameObjects
 
                 var numDirs = GetLayerDirectionCount(layer);
                 var layerRotation = worldRotation + layer.Rotation;
-                var layerPosition = worldPosition + layerRotation.RotateVec(layer._offset);
+                var layerPosition = worldPosition + layerRotation.RotateVec(layer._offset + offset);
 
                 CalcModelMatrix(numDirs, eyeRotation, layerRotation, layerPosition, out var modelMatrix);
                 Matrix3.Multiply(ref spriteMatrix, ref modelMatrix, out var transformMatrix);


### PR DESCRIPTION
Fixes the second issue mentioned in #2431

This does mess up content's air alarms, because these were using bad offsets to render in the correct locations.
So space-wizards/space-station-14/pull/6216 should be merged around the same time.