### PR TITLE
Make OffsetRsiDir() and GetDir() public

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1547,7 +1547,7 @@ namespace Robust.Client.GameObjects
             return rsi["error"];
         }
 
-        private static RSI.State.Direction OffsetRsiDir(RSI.State.Direction dir, DirectionOffset offset)
+        public static RSI.State.Direction OffsetRsiDir(RSI.State.Direction dir, DirectionOffset offset)
         {
             // There is probably a better way to do this.
             // Eh.

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1526,51 +1526,6 @@ namespace Robust.Client.GameObjects
             return rsi["error"];
         }
 
-        public static RSI.State.Direction OffsetRsiDir(RSI.State.Direction dir, DirectionOffset offset)
-        {
-            // There is probably a better way to do this.
-            // Eh.
-            switch (offset)
-            {
-                case DirectionOffset.None:
-                    return dir;
-                case DirectionOffset.Clockwise:
-                    return dir switch
-                    {
-                        RSI.State.Direction.North => RSI.State.Direction.East,
-                        RSI.State.Direction.East => RSI.State.Direction.South,
-                        RSI.State.Direction.South => RSI.State.Direction.West,
-                        RSI.State.Direction.West => RSI.State.Direction.North,
-                        _ => throw new NotImplementedException()
-                    };
-                case DirectionOffset.CounterClockwise:
-                    return dir switch
-                    {
-                        RSI.State.Direction.North => RSI.State.Direction.West,
-                        RSI.State.Direction.East => RSI.State.Direction.North,
-                        RSI.State.Direction.South => RSI.State.Direction.East,
-                        RSI.State.Direction.West => RSI.State.Direction.South,
-                        _ => throw new NotImplementedException()
-                    };
-                case DirectionOffset.Flip:
-                    switch (dir)
-                    {
-                        case RSI.State.Direction.North:
-                            return RSI.State.Direction.South;
-                        case RSI.State.Direction.East:
-                            return RSI.State.Direction.West;
-                        case RSI.State.Direction.South:
-                            return RSI.State.Direction.North;
-                        case RSI.State.Direction.West:
-                            return RSI.State.Direction.East;
-                        default:
-                            throw new NotImplementedException();
-                    }
-                default:
-                    throw new NotImplementedException();
-            }
-        }
-
         public string GetDebugString()
         {
             var builder = new StringBuilder();
@@ -1821,7 +1776,7 @@ namespace Robust.Client.GameObjects
                         dir = worldRotation.ToRsiDirection(state.Directions);
                     }
 
-                    return OffsetRsiDir(dir, DirOffset);
+                    return dir.OffsetRsiDir(DirOffset);
                 }
             }
 

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1474,30 +1474,6 @@ namespace Robust.Client.GameObjects
             }
         }
 
-        private RSI.State.Direction GetDir(RSI.State.DirectionType rsiDirectionType, Angle worldRotation)
-        {
-            var dir = rsiDirectionType switch
-            {
-                RSI.State.DirectionType.Dir1 => Direction.South,
-                RSI.State.DirectionType.Dir4 => worldRotation.GetCardinalDir(),
-                RSI.State.DirectionType.Dir8 => worldRotation.GetDir(),
-                _ => throw new ArgumentException($"Unknown RSI DirectionType: {rsiDirectionType}.", nameof(rsiDirectionType))
-            };
-
-            return dir switch
-            {
-                Direction.North => RSI.State.Direction.North,
-                Direction.South => RSI.State.Direction.South,
-                Direction.East => RSI.State.Direction.East,
-                Direction.West => RSI.State.Direction.West,
-                Direction.SouthEast => RSI.State.Direction.SouthEast,
-                Direction.SouthWest => RSI.State.Direction.SouthWest,
-                Direction.NorthEast => RSI.State.Direction.NorthEast,
-                Direction.NorthWest => RSI.State.Direction.NorthWest,
-                _ => throw new ArgumentOutOfRangeException(nameof(dir), dir, null)
-            };
-        }
-
         private void QueueUpdateIsInert()
         {
             // Look this was an easy way to get bounds checks for layer updates.
@@ -1598,7 +1574,7 @@ namespace Robust.Client.GameObjects
             builder.AppendFormat(
                 "vis/depth/scl/rot/ofs/col/norot/override/dir: {0}/{1}/{2}/{3}/{4}/{5}/{6}/{8}/{7}\n",
                 Visible, DrawDepth, Scale, Rotation, Offset,
-                Color, NoRotation, GetDir(RSI.State.DirectionType.Dir8, entities.GetComponent<TransformComponent>(Owner).WorldRotation),
+                Color, NoRotation, entities.GetComponent<TransformComponent>(Owner).WorldRotation.ToRsiDirection(RSI.State.DirectionType.Dir8),
                 DirectionOverride
             );
 
@@ -1839,7 +1815,7 @@ namespace Robust.Client.GameObjects
                     }
                     else
                     {
-                        dir = _parent.GetDir(state.Directions, worldRotation);
+                        dir = worldRotation.ToRsiDirection(state.Directions);
                     }
 
                     return OffsetRsiDir(dir, DirOffset);

--- a/Robust.Client/Utility/DirExt.cs
+++ b/Robust.Client/Utility/DirExt.cs
@@ -115,8 +115,7 @@ namespace Robust.Client.Utility
             return type switch
             {
                 RSI.State.DirectionType.Dir1 => RSIDirection.South,
-                RSI.State.DirectionType.Dir4 => angle.GetCardinalDir().Convert(type),
-                RSI.State.DirectionType.Dir8 => angle.GetDir().Convert(type),
+                RSI.State.DirectionType.Dir4 or RSI.State.DirectionType.Dir8 => angle.GetDir().Convert(type),
                 _ => throw new ArgumentOutOfRangeException($"Unknown rsi direction type: {type}.", nameof(type))
             };
         }

--- a/Robust.Client/Utility/DirExt.cs
+++ b/Robust.Client/Utility/DirExt.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Robust.Client.Graphics;
 using Robust.Shared.Maths;
+using static Robust.Client.GameObjects.SpriteComponent;
 using RSIDirection = Robust.Client.Graphics.RSI.State.Direction;
 
 namespace Robust.Client.Utility
@@ -118,6 +119,54 @@ namespace Robust.Client.Utility
                 RSI.State.DirectionType.Dir4 or RSI.State.DirectionType.Dir8 => angle.GetDir().Convert(type),
                 _ => throw new ArgumentOutOfRangeException($"Unknown rsi direction type: {type}.", nameof(type))
             };
+        }
+
+        public static RSIDirection OffsetRsiDir(this RSIDirection dir, DirectionOffset offset)
+        {
+            // There is probably a better way to do this.
+            // Eh.
+            //
+            // Maybe convert RSI direction to a direction and use the much more elegant solution in `TurnCw()` functions?
+            // but that conversion would probably be slower than this, even though its a mess to read.
+            switch (offset)
+            {
+                case DirectionOffset.None:
+                    return dir;
+                case DirectionOffset.Clockwise:
+                    return dir switch
+                    {
+                        RSIDirection.North => RSIDirection.East,
+                        RSIDirection.East => RSIDirection.South,
+                        RSIDirection.South => RSIDirection.West,
+                        RSIDirection.West => RSIDirection.North,
+                        _ => throw new NotImplementedException()
+                    };
+                case DirectionOffset.CounterClockwise:
+                    return dir switch
+                    {
+                        RSIDirection.North => RSIDirection.West,
+                        RSIDirection.East => RSIDirection.North,
+                        RSIDirection.South => RSIDirection.East,
+                        RSIDirection.West => RSIDirection.South,
+                        _ => throw new NotImplementedException()
+                    };
+                case DirectionOffset.Flip:
+                    switch (dir)
+                    {
+                        case RSIDirection.North:
+                            return RSIDirection.South;
+                        case RSIDirection.East:
+                            return RSIDirection.West;
+                        case RSIDirection.South:
+                            return RSIDirection.North;
+                        case RSIDirection.West:
+                            return RSIDirection.East;
+                        default:
+                            throw new NotImplementedException();
+                    }
+                default:
+                    throw new NotImplementedException();
+            }
         }
     }
 }

--- a/Robust.Client/Utility/DirExt.cs
+++ b/Robust.Client/Utility/DirExt.cs
@@ -109,5 +109,16 @@ namespace Robust.Client.Utility
         {
             return (Direction)(((int)dir + 1) % 8);
         }
+
+        public static RSIDirection ToRsiDirection(this Angle angle, RSI.State.DirectionType type)
+        {
+            return type switch
+            {
+                RSI.State.DirectionType.Dir1 => RSIDirection.South,
+                RSI.State.DirectionType.Dir4 => angle.GetCardinalDir().Convert(type),
+                RSI.State.DirectionType.Dir8 => angle.GetDir().Convert(type),
+                _ => throw new ArgumentOutOfRangeException($"Unknown rsi direction type: {type}.", nameof(type))
+            };
+        }
     }
 }


### PR DESCRIPTION
Makes `SpriteComponent`'s `OffsetRsiDir()` public and moves `GetDir()` function into direction extensions.

Nice to have for space-wizards/space-station-14#6221