### PR TITLE
Add acruid's funny entity query

### DIFF
--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -278,12 +278,26 @@ internal partial class PVSSystem : EntitySystem
 
         visibleEnts.Clear();
 
+        var eyeQuery = EntityManager.GetEntityQuery<EyeComponent>();
+        var transformQuery = EntityManager.GetEntityQuery<TransformComponent>();
+        var metadataQuery = EntityManager.GetEntityQuery<MetaDataComponent>();
+
         var globalOverridesEnumerator = _entityPvsCollection.GlobalOverridesEnumerator;
         while(globalOverridesEnumerator.MoveNext())
         {
             var uid = globalOverridesEnumerator.Current;
             //todo paul reenable budgetcheck here once you fix mapmanager
-            TryAddToVisibleEnts(in uid, seenSet, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, ref entitiesSent, dontSkip: true);
+            TryAddToVisibleEnts(
+                in uid,
+                seenSet,
+                playerVisibleSet,
+                visibleEnts,
+                fromTick,
+                ref newEntitiesSent,
+                ref entitiesSent,
+                metadataQuery,
+                transformQuery,
+                dontSkip: true);
         }
         globalOverridesEnumerator.Dispose();
 
@@ -292,7 +306,7 @@ internal partial class PVSSystem : EntitySystem
         {
             var uid = localOverridesEnumerator.Current;
             //todo paul reenable budgetcheck here once you fix mapmanager
-            TryAddToVisibleEnts(in uid, seenSet, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, ref entitiesSent, dontSkip: true);
+            TryAddToVisibleEnts(in uid, seenSet, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, ref entitiesSent, metadataQuery, transformQuery, dontSkip: true);
         }
         localOverridesEnumerator.Dispose();
 
@@ -300,21 +314,21 @@ internal partial class PVSSystem : EntitySystem
         RaiseLocalEvent(ref expandEvent);
         foreach (var entityUid in expandEvent.Entities)
         {
-            TryAddToVisibleEnts(in entityUid, seenSet, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, ref entitiesSent);
+            TryAddToVisibleEnts(in entityUid, seenSet, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, ref entitiesSent, metadataQuery, transformQuery);
         }
 
         var viewers = GetSessionViewers(session);
 
         foreach (var eyeEuid in viewers)
         {
-            var (viewBox, mapId) = CalcViewBounds(in eyeEuid);
+            var (viewBox, mapId) = CalcViewBounds(in eyeEuid, transformQuery);
 
             uint visMask = EyeComponent.DefaultVisibilityMask;
-            if (EntityManager.TryGetComponent<EyeComponent>(eyeEuid, out var eyeComp))
+            if (eyeQuery.TryGetComponent(eyeEuid, out var eyeComp))
                 visMask = eyeComp.VisibilityMask;
 
             //todo at some point just register the viewerentities as localoverrides
-            TryAddToVisibleEnts(in eyeEuid, seenSet, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, ref entitiesSent, visMask, dontSkip: true);
+            TryAddToVisibleEnts(in eyeEuid, seenSet, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, ref entitiesSent, metadataQuery, transformQuery, visMask, dontSkip: true);
 
             var mapChunkEnumerator = new ChunkIndicesEnumerator(viewBox, ChunkSize);
 
@@ -324,7 +338,7 @@ internal partial class PVSSystem : EntitySystem
                 {
                     foreach (var index in chunk)
                     {
-                        TryAddToVisibleEnts(in index, seenSet, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, ref entitiesSent, visMask);
+                        TryAddToVisibleEnts(in index, seenSet, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, ref entitiesSent, metadataQuery, transformQuery, visMask);
                     }
                 }
             }
@@ -341,7 +355,7 @@ internal partial class PVSSystem : EntitySystem
                     {
                         foreach (var index in chunk)
                         {
-                            TryAddToVisibleEnts(in index, seenSet, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, ref entitiesSent, visMask);
+                            TryAddToVisibleEnts(in index, seenSet, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent, ref entitiesSent, metadataQuery, transformQuery, visMask);
                         }
                     }
                 }
@@ -393,7 +407,19 @@ internal partial class PVSSystem : EntitySystem
     }
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-    private bool TryAddToVisibleEnts(in EntityUid uid, HashSet<EntityUid> seenSet, Dictionary<EntityUid, PVSEntityVisiblity> previousVisibleEnts, Dictionary<EntityUid, PVSEntityVisiblity> toSend, GameTick fromTick, ref int newEntitiesSent, ref int totalEnteredEntities, uint? visMask = null, bool dontSkip = false, bool trustParent = false)
+    private bool TryAddToVisibleEnts(
+        in EntityUid uid,
+        HashSet<EntityUid> seenSet,
+        Dictionary<EntityUid, PVSEntityVisiblity> previousVisibleEnts,
+        Dictionary<EntityUid, PVSEntityVisiblity> toSend,
+        GameTick fromTick,
+        ref int newEntitiesSent,
+        ref int totalEnteredEntities,
+        FunnyEntityQuery<MetaDataComponent> metadataQuery,
+        FunnyEntityQuery<TransformComponent> transformQuery,
+        uint? visMask = null,
+        bool dontSkip = false,
+        bool trustParent = false)
     {
         //are we valid yet?
         //sometimes uids gets added without being valid YET (looking at you mapmanager) (mapcreate & gridcreated fire before the uids becomes valid)
@@ -402,7 +428,7 @@ internal partial class PVSSystem : EntitySystem
         //did we already get added?
         if (toSend.ContainsKey(uid)) return true;
 
-        var metadata = MetaData(uid);
+        var metadata = metadataQuery.GetComponent(uid);
 
         // if we are invisible, we are not going into the visSet, so don't worry about parents, and children are not going in
         if (visMask != null)
@@ -410,16 +436,16 @@ internal partial class PVSSystem : EntitySystem
             // TODO: Don't need to know about parents so no longer need to use bool for this method.
 
             // If the eye is missing ANY layer this entity or any of its parents belongs to, it is considered invisible.
-            if ((visMask & metadata.VisibilityMask) != metadata.VisibilityMask) 
+            if ((visMask & metadata.VisibilityMask) != metadata.VisibilityMask)
                 return false;
         }
 
-        var parent = Transform(uid).ParentUid;
+        var parent = transformQuery.GetComponent(uid).ParentUid;
 
         if (!trustParent && //do we have it on good authority the parent exists?
             parent.IsValid() && //is it not a worldentity?
             !toSend.ContainsKey(parent) && //was the parent not yet added to toSend?
-            !TryAddToVisibleEnts(in parent, seenSet, previousVisibleEnts, toSend, fromTick, ref newEntitiesSent, ref totalEnteredEntities, visMask)) //did we just fail to add the parent?
+            !TryAddToVisibleEnts(in parent, seenSet, previousVisibleEnts, toSend, fromTick, ref newEntitiesSent, ref totalEnteredEntities, metadataQuery, transformQuery, visMask)) //did we just fail to add the parent?
             return false; //we failed? suppose we dont get added either
 
         //did we already get added through the parent call?
@@ -475,6 +501,7 @@ internal partial class PVSSystem : EntitySystem
         stateEntities = new List<EntityState>();
         var seenEnts = new HashSet<EntityUid>();
         var slowPath = false;
+        var metadataQuery = EntityManager.GetEntityQuery<MetaDataComponent>();
 
         for (var i = fromTick.Value; i <= toTick.Value; i++)
         {
@@ -489,7 +516,7 @@ internal partial class PVSSystem : EntitySystem
             {
                 if (!seenEnts.Add(uid)) continue;
                 // This is essentially the same as IEntityManager.EntityExists, but returning MetaDataComponent.
-                if (!EntityManager.TryGetComponent(uid, out MetaDataComponent? md)) continue;
+                if (!metadataQuery.TryGetComponent(uid, out MetaDataComponent? md)) continue;
 
                 DebugTools.Assert(md.EntityLifeStage >= EntityLifeStage.Initialized);
 
@@ -502,7 +529,7 @@ internal partial class PVSSystem : EntitySystem
                 DebugTools.Assert(!add.Contains(uid));
 
                 if (!seenEnts.Add(uid)) continue;
-                if (!EntityManager.TryGetComponent(uid, out MetaDataComponent? md)) continue;
+                if (!metadataQuery.TryGetComponent(uid, out MetaDataComponent? md)) continue;
 
                 DebugTools.Assert(md.EntityLifeStage >= EntityLifeStage.Initialized);
 
@@ -607,9 +634,9 @@ internal partial class PVSSystem : EntitySystem
     }
 
     // Read Safe
-    private (Box2 view, MapId mapId) CalcViewBounds(in EntityUid euid)
+    private (Box2 view, MapId mapId) CalcViewBounds(in EntityUid euid, FunnyEntityQuery<TransformComponent> transformQuery)
     {
-        var xform = EntityManager.GetComponent<TransformComponent>(euid);
+        var xform = transformQuery.GetComponent(euid);
 
         var view = Box2.UnitCentered.Scale(_viewSize).Translated(xform.WorldPosition);
         var map = xform.MapID;

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -415,8 +415,8 @@ internal partial class PVSSystem : EntitySystem
         GameTick fromTick,
         ref int newEntitiesSent,
         ref int totalEnteredEntities,
-        FunnyEntityQuery<MetaDataComponent> metadataQuery,
-        FunnyEntityQuery<TransformComponent> transformQuery,
+        EntityQuery<MetaDataComponent> metadataQuery,
+        EntityQuery<TransformComponent> transformQuery,
         uint? visMask = null,
         bool dontSkip = false,
         bool trustParent = false)
@@ -634,7 +634,7 @@ internal partial class PVSSystem : EntitySystem
     }
 
     // Read Safe
-    private (Box2 view, MapId mapId) CalcViewBounds(in EntityUid euid, FunnyEntityQuery<TransformComponent> transformQuery)
+    private (Box2 view, MapId mapId) CalcViewBounds(in EntityUid euid, EntityQuery<TransformComponent> transformQuery)
     {
         var xform = transformQuery.GetComponent(euid);
 

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -453,11 +453,20 @@ namespace Robust.Shared.GameObjects
         }
 
         [ViewVariables]
-        public IEnumerable<TransformComponent> Children =>
-            _children.Select(u =>
+        public IEnumerable<TransformComponent> Children
+        {
+            get
             {
-                return _entMan.GetComponent<TransformComponent>(u);
-            });
+                if (_children.Count == 0) yield break;
+
+                var xforms = _entMan.GetEntityQuery<TransformComponent>();
+
+                foreach (var child in _children)
+                {
+                    yield return xforms.GetComponent(child);
+                }
+            }
+        }
 
         [ViewVariables] public IEnumerable<EntityUid> ChildEntities => _children;
 
@@ -724,9 +733,11 @@ namespace Robust.Shared.GameObjects
 
         private void UpdateChildMapIdsRecursive(MapId newMapId, IEntityManager entMan)
         {
+            var xforms = _entMan.GetEntityQuery<TransformComponent>();
+
             foreach (var child in _children)
             {
-                var concrete = entMan.GetComponent<TransformComponent>(child);
+                var concrete = xforms.GetComponent(child);
                 var old = concrete.MapID;
 
                 concrete.MapID = newMapId;
@@ -781,11 +792,12 @@ namespace Robust.Shared.GameObjects
             var parent = _parent;
             var worldRot = _localRotation;
             var worldMatrix = GetLocalMatrix();
+            var xforms = _entMan.GetEntityQuery<TransformComponent>();
 
             // By doing these all at once we can elide multiple IsValid + GetComponent calls
             while (parent.IsValid())
             {
-                var xform = _entMan.GetComponent<TransformComponent>(parent);
+                var xform = xforms.GetComponent(parent);
                 worldRot += xform.LocalRotation;
                 var parentMatrix = xform.GetLocalMatrix();
                 Matrix3.Multiply(ref worldMatrix, ref parentMatrix, out var result);
@@ -816,11 +828,12 @@ namespace Robust.Shared.GameObjects
             var worldRot = _localRotation;
             var invMatrix = GetLocalMatrixInv();
             var worldMatrix = GetLocalMatrix();
+            var xforms = _entMan.GetEntityQuery<TransformComponent>();
 
             // By doing these all at once we can elide multiple IsValid + GetComponent calls
             while (parent.IsValid())
             {
-                var xform = _entMan.GetComponent<TransformComponent>(parent);
+                var xform = xforms.GetComponent(parent);
                 worldRot += xform.LocalRotation;
 
                 var parentMatrix = xform.GetLocalMatrix();

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -669,6 +670,11 @@ namespace Robust.Shared.GameObjects
             return false;
         }
 
+        public FunnyEntityQuery<TComp1> GetEntityQuery<TComp1>() where TComp1 : Component
+        {
+            return new FunnyEntityQuery<TComp1>(_entTraitArray[ArrayIndexFor<TComp1>()]);
+        }
+
         /// <inheritdoc />
         public IEnumerable<IComponent> GetComponents(EntityUid uid)
         {
@@ -1040,6 +1046,36 @@ namespace Robust.Shared.GameObjects
                 var val = _dictEnum.Current;
                 return (val.Key, val.Value);
             }
+        }
+    }
+
+    public readonly struct FunnyEntityQuery<TComp1> where TComp1 : Component
+    {
+        private readonly Dictionary<EntityUid, Component> _traitDict;
+
+        public FunnyEntityQuery(Dictionary<EntityUid, Component> traitDict)
+        {
+            _traitDict = traitDict;
+        }
+
+        public TComp1 GetComponent(EntityUid uid)
+        {
+            if (_traitDict.TryGetValue(uid, out var comp) && !comp.Deleted)
+                return (TComp1) comp;
+
+            throw new KeyNotFoundException($"Entity {uid} does not have a component of type {typeof(TComp1)}");
+        }
+
+        public bool TryGetComponent(EntityUid uid, [NotNullWhen(true)] out TComp1? component)
+        {
+            if (_traitDict.TryGetValue(uid, out var comp) && !comp.Deleted)
+            {
+                component = (TComp1) comp;
+                return true;
+            }
+
+            component = default;
+            return false;
         }
     }
 }

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -670,9 +670,9 @@ namespace Robust.Shared.GameObjects
             return false;
         }
 
-        public FunnyEntityQuery<TComp1> GetEntityQuery<TComp1>() where TComp1 : Component
+        public EntityQuery<TComp1> GetEntityQuery<TComp1>() where TComp1 : Component
         {
-            return new FunnyEntityQuery<TComp1>(_entTraitArray[ArrayIndexFor<TComp1>()]);
+            return new EntityQuery<TComp1>(_entTraitArray[ArrayIndexFor<TComp1>()]);
         }
 
         /// <inheritdoc />
@@ -1049,11 +1049,11 @@ namespace Robust.Shared.GameObjects
         }
     }
 
-    public readonly struct FunnyEntityQuery<TComp1> where TComp1 : Component
+    public readonly struct EntityQuery<TComp1> where TComp1 : Component
     {
         private readonly Dictionary<EntityUid, Component> _traitDict;
 
-        public FunnyEntityQuery(Dictionary<EntityUid, Component> traitDict)
+        public EntityQuery(Dictionary<EntityUid, Component> traitDict)
         {
             _traitDict = traitDict;
         }

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -235,7 +235,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         /// Returns a cached struct enumerator with the specified component.
         /// </summary>
-        FunnyEntityQuery<TComp1> GetEntityQuery<TComp1>() where TComp1 : Component;
+        EntityQuery<TComp1> GetEntityQuery<TComp1>() where TComp1 : Component;
 
         /// <summary>
         ///     Returns ALL component type instances on an entity. A single component instance

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -233,6 +233,11 @@ namespace Robust.Shared.GameObjects
         bool TryGetComponent([NotNullWhen(true)] EntityUid? uid, ushort netId, [NotNullWhen(true)] out IComponent? component);
 
         /// <summary>
+        /// Returns a cached struct enumerator with the specified component.
+        /// </summary>
+        FunnyEntityQuery<TComp1> GetEntityQuery<TComp1>() where TComp1 : Component;
+
+        /// <summary>
         ///     Returns ALL component type instances on an entity. A single component instance
         ///     can have multiple component types.
         /// </summary>

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -107,7 +107,6 @@ namespace Robust.Shared.GameObjects
         {
             IoCManager.InjectDependencies(component);
             component.BroadphaseSystem = _broadphaseSystem;
-            component.PhysicsSystem = this;
             component.ContactManager = new();
             component.ContactManager.Initialize();
             component.ContactManager.MapId = component.MapId;

--- a/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
+++ b/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
@@ -40,7 +40,6 @@ namespace Robust.Shared.Physics.Dynamics
         [Dependency] private readonly IIslandManager _islandManager = default!;
 
         internal SharedBroadphaseSystem BroadphaseSystem = default!;
-        internal SharedPhysicsSystem PhysicsSystem = default!;
 
         public override string Name => "PhysicsMap";
 
@@ -292,6 +291,7 @@ namespace Robust.Shared.Physics.Dynamics
 
             _awakeBodyList.AddRange(AwakeBodies);
 
+            var jointQuery = _entityManager.GetEntityQuery<JointComponent>();
 
             // Build the relevant islands / graphs for all bodies.
             foreach (var seed in _awakeBodyList)
@@ -360,7 +360,7 @@ namespace Robust.Shared.Physics.Dynamics
                         other.Island = true;
                     }
 
-                    if (!_entityManager.TryGetComponent(body.Owner, out JointComponent? jointComponent)) continue;
+                    if (!jointQuery.TryGetComponent(body.Owner, out var jointComponent)) continue;
 
                     foreach (var (_, joint) in jointComponent.Joints)
                     {

--- a/Robust.Shared/Random/IRobustRandom.cs
+++ b/Robust.Shared/Random/IRobustRandom.cs
@@ -13,6 +13,7 @@ namespace Robust.Shared.Random
         int Next(int minValue, int maxValue);
         int Next(int maxValue);
         double NextDouble();
+        double NextDouble(double minValue, double maxValue) => NextDouble() * (maxValue - minValue) + minValue;
         void NextBytes(byte[] buffer);
 
         public Angle NextAngle() => NextFloat() * MathHelper.Pi * 2;


### PR DESCRIPTION
tl;dr You don't have to typecast back into the dictionary every time.

Resolves https://github.com/space-wizards/RobustToolbox/issues/2227

In my shitty PVS profiling with 20 clients it's roughly a third faster (TryGetValue is still like 40% of the time though) so it's not gonna let us hit 300 clients but it'll be a nice saving in multiple places in the engine once more stuff is converted. Should also help physics a little bit as I converted the helper methods to use it.

(On release, left is pr im just a dumby)
![image](https://user-images.githubusercontent.com/31366439/150281946-91d4bb9a-3dff-4f3e-840b-ad093cc78542.png)
