### PR TITLE
Prevent `CreateAudioSource()` from erroring/crashing in debug when hitting source limit

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
@@ -253,9 +253,15 @@ namespace Robust.Client.GameObjects
         /// </summary>
         /// <param name="stream">The audio stream to play.</param>
         /// <param name="audioParams"></param>
-        private IPlayingAudioStream Play(AudioStream stream, AudioParams? audioParams = null)
+        private IPlayingAudioStream? Play(AudioStream stream, AudioParams? audioParams = null)
         {
             var source = _clyde.CreateAudioSource(stream);
+
+            if (source == null)
+            {
+                return null;
+            }
+
             ApplyAudioParams(audioParams, source);
 
             source.SetGlobal();
@@ -303,6 +309,12 @@ namespace Robust.Client.GameObjects
             AudioParams? audioParams = null)
         {
             var source = _clyde.CreateAudioSource(stream);
+
+            if (source == null)
+            {
+                return null;
+            }
+
             if (!source.SetPosition(EntityManager.GetComponent<TransformComponent>(entity).WorldPosition))
             {
                 return Play(stream, fallbackCoordinates, fallbackCoordinates, audioParams);
@@ -356,6 +368,12 @@ namespace Robust.Client.GameObjects
             EntityCoordinates fallbackCoordinates, AudioParams? audioParams = null)
         {
             var source = _clyde.CreateAudioSource(stream);
+
+            if (source == null)
+            {
+                return null;
+            }
+
             if (!source.SetPosition(fallbackCoordinates.Position))
             {
                 source.Dispose();

--- a/Robust.Client/Graphics/Audio/ClydeAudio.cs
+++ b/Robust.Client/Graphics/Audio/ClydeAudio.cs
@@ -215,9 +215,16 @@ namespace Robust.Client.Graphics.Audio
             _openALSawmill.Info($"Set audio attenuation to {attToString.ToString()}");
         }
 
-        public IClydeAudioSource CreateAudioSource(AudioStream stream)
+        public IClydeAudioSource? CreateAudioSource(AudioStream stream)
         {
             var source = AL.GenSource();
+
+            if (!AL.IsSource(source))
+            {
+                _openALSawmill.Error("Failed to generate source. Too many simultaneous audio streams?");
+                return null;
+            }
+            
             // ReSharper disable once PossibleInvalidOperationException
             // TODO: This really shouldn't be indexing based on the ClydeHandle...
             AL.Source(source, ALSourcei.Buffer, _audioSampleBuffers[(int) stream.ClydeHandle!.Value.Value].BufferHandle);

--- a/Robust.Client/Graphics/Audio/ProxyClydeAudio.cs
+++ b/Robust.Client/Graphics/Audio/ProxyClydeAudio.cs
@@ -54,7 +54,7 @@ namespace Robust.Client.Graphics.Audio
             return ActualImplementation.LoadAudioRaw(samples, channels, sampleRate, name);
         }
 
-        public IClydeAudioSource CreateAudioSource(AudioStream stream)
+        public IClydeAudioSource? CreateAudioSource(AudioStream stream)
         {
             return ActualImplementation.CreateAudioSource(stream);
         }

--- a/Robust.Client/Graphics/IClydeAudio.cs
+++ b/Robust.Client/Graphics/IClydeAudio.cs
@@ -13,7 +13,7 @@ namespace Robust.Client.Graphics
 
         void SetMasterVolume(float newVolume);
 
-        IClydeAudioSource CreateAudioSource(AudioStream stream);
+        IClydeAudioSource? CreateAudioSource(AudioStream stream);
         IClydeBufferedAudioSource CreateBufferedAudioSource(int buffers, bool floatAudio=false);
     }
 }


### PR DESCRIPTION
See #2388.

This PR just makes `CreateAudioSource()` check if `AL.GenSource()` succeeded via `AL.IsSource()` before continuing. If it failed, it logs an error and returns null. This doesn't actually fix the fact that there is a limit, it just prevents the game from erroring in debug and should result in more informative / readable error logs.

