### PR TITLE
Add prometheus-net.DotNetRuntime for more detailed runtime metrics like GC pause times.

### DIFF
--- a/Robust.Server/DataMetrics/MetricsManager.MetricsServer.cs
+++ b/Robust.Server/DataMetrics/MetricsManager.MetricsServer.cs
@@ -1,0 +1,156 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ManagedHttpListener;
+using Prometheus;
+using Robust.Shared.Log;
+
+namespace Robust.Server.DataMetrics;
+
+internal sealed partial class MetricsManager
+{
+    // prometheus-net's MetricServer uses HttpListener by default.
+    // Use our ManagedHttpListener instead because it's less problematic.
+
+    private sealed class ManagedHttpListenerMetricsServer : MetricHandler
+    {
+        private readonly ISawmill _sawmill;
+        private readonly HttpListener _listener;
+
+        public ManagedHttpListenerMetricsServer(ISawmill sawmill, string host, int port, string url = "metrics/",
+            CollectorRegistry? registry = null) : base(registry)
+        {
+            _sawmill = sawmill;
+            _listener = new HttpListener();
+            _listener.Prefixes.Add($"http://{host}:{port}/{url}");
+        }
+
+        protected override Task StartServer(CancellationToken cancel)
+        {
+            _listener.Start();
+
+            return Task.Run(() => ListenerThread(cancel), CancellationToken.None);
+        }
+
+        private async Task ListenerThread(CancellationToken cancel)
+        {
+            try
+            {
+                while (!cancel.IsCancellationRequested)
+                {
+                    var getContextTask = _listener.GetContextAsync();
+                    var ctx = await getContextTask.WaitAsync(cancel);
+
+                    // Task.Run this so it gets run on another thread pool thread.
+                    _ = Task.Run(async () =>
+                    {
+                        var resp = ctx.Response;
+                        try
+                        {
+                            // prometheus-net is a terrible library and have to do all this insanity,
+                            // just to handle the ScrapeFailedException correctly.
+                            // Ridiculous.
+                            await _registry.CollectAndExportAsTextAsync(new WriteWrapStream(() =>
+                            {
+                                resp.ContentType = "text/plain; version=0.0.4; charset=utf-8";
+                                resp.StatusCode = 200;
+
+                                return resp.OutputStream;
+                            }), cancel);
+                        }
+                        catch (ScrapeFailedException e)
+                        {
+                            resp.StatusCode = 503;
+                            if (!string.IsNullOrWhiteSpace(e.Message))
+                            {
+                                await using var sw = new StreamWriter(resp.OutputStream);
+                                await sw.WriteAsync(e.Message);
+                            }
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            // Nada.
+                        }
+                        catch (Exception e)
+                        {
+                            _sawmill.Log(LogLevel.Error, e, "Exception in metrics listener");
+
+                            resp.StatusCode = 500;
+                        }
+                        finally
+                        {
+                            resp.Close();
+                        }
+                    }, CancellationToken.None);
+                }
+            }
+            finally
+            {
+                _listener.Stop();
+                _listener.Close();
+            }
+        }
+
+        private sealed class WriteWrapStream : Stream
+        {
+            private Stream? _stream;
+            private readonly Func<Stream> _streamFunc;
+
+            public WriteWrapStream(Func<Stream> streamFunc)
+            {
+                _streamFunc = streamFunc;
+            }
+
+            public override void Flush()
+            {
+                GetStream().Flush();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+            public override void SetLength(long value) => throw new NotSupportedException();
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                GetStream().Write(buffer, offset, count);
+            }
+
+            public override void Write(ReadOnlySpan<byte> buffer)
+            {
+                GetStream().Write(buffer);
+            }
+
+            public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer,
+                CancellationToken cancellationToken = new CancellationToken())
+            {
+                return GetStream().WriteAsync(buffer, cancellationToken);
+            }
+
+            public override void WriteByte(byte value)
+            {
+                GetStream().WriteByte(value);
+            }
+
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                return GetStream().WriteAsync(buffer, offset, count, cancellationToken);
+            }
+
+            public override bool CanRead => false;
+            public override bool CanSeek => false;
+            public override bool CanWrite => true;
+            public override long Length => throw new NotSupportedException();
+
+            public override long Position
+            {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
+
+            private Stream GetStream() => _stream ??= _streamFunc();
+        }
+    }
+}

--- a/Robust.Server/DataMetrics/MetricsManager.cs
+++ b/Robust.Server/DataMetrics/MetricsManager.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
 using Prometheus;
+using Prometheus.DotNetRuntime;
+using Prometheus.DotNetRuntime.Metrics.Producers;
 using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects;
@@ -13,22 +17,39 @@ namespace Robust.Server.DataMetrics
 {
     internal sealed class MetricsManager : IMetricsManager, IDisposable
     {
-        [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+        [Dependency] private readonly IConfigurationManager _cfg = default!;
         [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
 
         private bool _initialized;
 
         private MetricServer? _metricServer;
+        private IDisposable? _runtimeCollector;
 
         public void Initialize()
         {
             _initialized = true;
 
-            _configurationManager.OnValueChanged(CVars.MetricsEnabled, _ => Reload());
-            _configurationManager.OnValueChanged(CVars.MetricsHost, _ => Reload());
-            _configurationManager.OnValueChanged(CVars.MetricsPort, _ => Reload());
+            ValueChanged(CVars.MetricsEnabled);
+            ValueChanged(CVars.MetricsHost);
+            ValueChanged(CVars.MetricsPort);
+            ValueChanged(CVars.MetricsRuntime);
+            ValueChanged(CVars.MetricsRuntimeGc);
+            ValueChanged(CVars.MetricsRuntimeGcHistogram);
+            ValueChanged(CVars.MetricsRuntimeContention);
+            ValueChanged(CVars.MetricsRuntimeContentionSampleRate);
+            ValueChanged(CVars.MetricsRuntimeThreadPool);
+            ValueChanged(CVars.MetricsRuntimeThreadPoolQueueHistogram);
+            ValueChanged(CVars.MetricsRuntimeJit);
+            ValueChanged(CVars.MetricsRuntimeJitSampleRate);
+            ValueChanged(CVars.MetricsRuntimeException);
+            ValueChanged(CVars.MetricsRuntimeSocket);
 
             Reload();
+
+            void ValueChanged<T>(CVarDef<T> cVar) where T : notnull
+            {
+                _cfg.OnValueChanged(cVar, _ => Reload());
+            }
         }
 
         private async Task Stop()
@@ -41,6 +62,8 @@ namespace Robust.Server.DataMetrics
             Logger.InfoS("metrics", "Shutting down metrics.");
             await _metricServer.StopAsync();
             _metricServer = null;
+            _runtimeCollector?.Dispose();
+            _runtimeCollector = null;
         }
 
         async void IDisposable.Dispose()
@@ -59,7 +82,7 @@ namespace Robust.Server.DataMetrics
 
             await Stop();
 
-            var enabled = _configurationManager.GetCVar(CVars.MetricsEnabled);
+            var enabled = _cfg.GetCVar(CVars.MetricsEnabled);
             _entitySystemManager.MetricsEnabled = enabled;
 
             if (!enabled)
@@ -67,12 +90,79 @@ namespace Robust.Server.DataMetrics
                 return;
             }
 
-            var host = _configurationManager.GetCVar(CVars.MetricsHost);
-            var port = _configurationManager.GetCVar(CVars.MetricsPort);
+            var host = _cfg.GetCVar(CVars.MetricsHost);
+            var port = _cfg.GetCVar(CVars.MetricsPort);
 
             Logger.InfoS("metrics", "Prometheus metrics enabled, host: {1} port: {0}", port, host);
             _metricServer = new MetricServer(host, port);
             _metricServer.Start();
+
+            if (_cfg.GetCVar(CVars.MetricsRuntime))
+            {
+                Logger.DebugS("metrics", "Enabling runtime metrics");
+                _runtimeCollector = BuildRuntimeStats().StartCollecting();
+            }
+        }
+
+        private DotNetRuntimeStatsBuilder.Builder BuildRuntimeStats()
+        {
+            var builder = DotNetRuntimeStatsBuilder.Customize();
+
+            if (CapLevel(CVars.MetricsRuntimeGc) is { } gc)
+            {
+                var buckets = Buckets(CVars.MetricsRuntimeGcHistogram);
+                builder.WithGcStats(gc, buckets);
+            }
+
+            if (CapLevel(CVars.MetricsRuntimeContention) is { } contention)
+            {
+                var rate = _cfg.GetCVar(CVars.MetricsRuntimeContentionSampleRate);
+                builder.WithContentionStats(contention, (SampleEvery)rate);
+            }
+
+            if (CapLevel(CVars.MetricsRuntimeThreadPool) is { } threadPool)
+            {
+                builder.WithThreadPoolStats(threadPool, new ThreadPoolMetricsProducer.Options
+                {
+                    QueueLengthHistogramBuckets = Buckets(CVars.MetricsRuntimeThreadPoolQueueHistogram)
+                });
+            }
+
+            if (CapLevel(CVars.MetricsRuntimeJit) is { } jit)
+            {
+                var rate = _cfg.GetCVar(CVars.MetricsRuntimeJitSampleRate);
+                builder.WithJitStats(jit, (SampleEvery) rate);
+            }
+
+            if (CapLevel(CVars.MetricsRuntimeException) is { } exception)
+            {
+                builder.WithExceptionStats(exception);
+            }
+
+            if (CapLevel(CVars.MetricsRuntimeSocket) is { })
+            {
+                builder.WithSocketStats();
+            }
+
+            CaptureLevel? CapLevel(CVarDef<string> cvar)
+            {
+                var val = _cfg.GetCVar(cvar);
+                if (val != "")
+                    return Enum.Parse<CaptureLevel>(val);
+
+                return null;
+            }
+
+            // 🪣
+            double[] Buckets(CVarDef<string> cvar)
+            {
+                return _cfg.GetCVar(cvar)
+                    .Split()
+                    .Select(x => double.Parse(x, CultureInfo.InvariantCulture) / 1000)
+                    .ToArray();
+            }
+
+            return builder;
         }
     }
 

--- a/Robust.Server/DataMetrics/MetricsManager.cs
+++ b/Robust.Server/DataMetrics/MetricsManager.cs
@@ -13,161 +13,160 @@ using Robust.Shared.Log;
 
 #nullable enable
 
-namespace Robust.Server.DataMetrics
+namespace Robust.Server.DataMetrics;
+
+internal sealed class MetricsManager : IMetricsManager, IDisposable
 {
-    internal sealed class MetricsManager : IMetricsManager, IDisposable
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
+
+    private bool _initialized;
+
+    private MetricServer? _metricServer;
+    private IDisposable? _runtimeCollector;
+
+    public void Initialize()
     {
-        [Dependency] private readonly IConfigurationManager _cfg = default!;
-        [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
+        _initialized = true;
 
-        private bool _initialized;
+        ValueChanged(CVars.MetricsEnabled);
+        ValueChanged(CVars.MetricsHost);
+        ValueChanged(CVars.MetricsPort);
+        ValueChanged(CVars.MetricsRuntime);
+        ValueChanged(CVars.MetricsRuntimeGc);
+        ValueChanged(CVars.MetricsRuntimeGcHistogram);
+        ValueChanged(CVars.MetricsRuntimeContention);
+        ValueChanged(CVars.MetricsRuntimeContentionSampleRate);
+        ValueChanged(CVars.MetricsRuntimeThreadPool);
+        ValueChanged(CVars.MetricsRuntimeThreadPoolQueueHistogram);
+        ValueChanged(CVars.MetricsRuntimeJit);
+        ValueChanged(CVars.MetricsRuntimeJitSampleRate);
+        ValueChanged(CVars.MetricsRuntimeException);
+        ValueChanged(CVars.MetricsRuntimeSocket);
 
-        private MetricServer? _metricServer;
-        private IDisposable? _runtimeCollector;
+        Reload();
 
-        public void Initialize()
+        void ValueChanged<T>(CVarDef<T> cVar) where T : notnull
         {
-            _initialized = true;
-
-            ValueChanged(CVars.MetricsEnabled);
-            ValueChanged(CVars.MetricsHost);
-            ValueChanged(CVars.MetricsPort);
-            ValueChanged(CVars.MetricsRuntime);
-            ValueChanged(CVars.MetricsRuntimeGc);
-            ValueChanged(CVars.MetricsRuntimeGcHistogram);
-            ValueChanged(CVars.MetricsRuntimeContention);
-            ValueChanged(CVars.MetricsRuntimeContentionSampleRate);
-            ValueChanged(CVars.MetricsRuntimeThreadPool);
-            ValueChanged(CVars.MetricsRuntimeThreadPoolQueueHistogram);
-            ValueChanged(CVars.MetricsRuntimeJit);
-            ValueChanged(CVars.MetricsRuntimeJitSampleRate);
-            ValueChanged(CVars.MetricsRuntimeException);
-            ValueChanged(CVars.MetricsRuntimeSocket);
-
-            Reload();
-
-            void ValueChanged<T>(CVarDef<T> cVar) where T : notnull
-            {
-                _cfg.OnValueChanged(cVar, _ => Reload());
-            }
-        }
-
-        private async Task Stop()
-        {
-            if (_metricServer == null)
-            {
-                return;
-            }
-
-            Logger.InfoS("metrics", "Shutting down metrics.");
-            await _metricServer.StopAsync();
-            _metricServer = null;
-            _runtimeCollector?.Dispose();
-            _runtimeCollector = null;
-        }
-
-        async void IDisposable.Dispose()
-        {
-            await Stop();
-
-            _initialized = false;
-        }
-
-        private async void Reload()
-        {
-            if (!_initialized)
-            {
-                return;
-            }
-
-            await Stop();
-
-            var enabled = _cfg.GetCVar(CVars.MetricsEnabled);
-            _entitySystemManager.MetricsEnabled = enabled;
-
-            if (!enabled)
-            {
-                return;
-            }
-
-            var host = _cfg.GetCVar(CVars.MetricsHost);
-            var port = _cfg.GetCVar(CVars.MetricsPort);
-
-            Logger.InfoS("metrics", "Prometheus metrics enabled, host: {1} port: {0}", port, host);
-            _metricServer = new MetricServer(host, port);
-            _metricServer.Start();
-
-            if (_cfg.GetCVar(CVars.MetricsRuntime))
-            {
-                Logger.DebugS("metrics", "Enabling runtime metrics");
-                _runtimeCollector = BuildRuntimeStats().StartCollecting();
-            }
-        }
-
-        private DotNetRuntimeStatsBuilder.Builder BuildRuntimeStats()
-        {
-            var builder = DotNetRuntimeStatsBuilder.Customize();
-
-            if (CapLevel(CVars.MetricsRuntimeGc) is { } gc)
-            {
-                var buckets = Buckets(CVars.MetricsRuntimeGcHistogram);
-                builder.WithGcStats(gc, buckets);
-            }
-
-            if (CapLevel(CVars.MetricsRuntimeContention) is { } contention)
-            {
-                var rate = _cfg.GetCVar(CVars.MetricsRuntimeContentionSampleRate);
-                builder.WithContentionStats(contention, (SampleEvery)rate);
-            }
-
-            if (CapLevel(CVars.MetricsRuntimeThreadPool) is { } threadPool)
-            {
-                builder.WithThreadPoolStats(threadPool, new ThreadPoolMetricsProducer.Options
-                {
-                    QueueLengthHistogramBuckets = Buckets(CVars.MetricsRuntimeThreadPoolQueueHistogram)
-                });
-            }
-
-            if (CapLevel(CVars.MetricsRuntimeJit) is { } jit)
-            {
-                var rate = _cfg.GetCVar(CVars.MetricsRuntimeJitSampleRate);
-                builder.WithJitStats(jit, (SampleEvery) rate);
-            }
-
-            if (CapLevel(CVars.MetricsRuntimeException) is { } exception)
-            {
-                builder.WithExceptionStats(exception);
-            }
-
-            if (CapLevel(CVars.MetricsRuntimeSocket) is { })
-            {
-                builder.WithSocketStats();
-            }
-
-            CaptureLevel? CapLevel(CVarDef<string> cvar)
-            {
-                var val = _cfg.GetCVar(cvar);
-                if (val != "")
-                    return Enum.Parse<CaptureLevel>(val);
-
-                return null;
-            }
-
-            // 🪣
-            double[] Buckets(CVarDef<string> cvar)
-            {
-                return _cfg.GetCVar(cvar)
-                    .Split()
-                    .Select(x => double.Parse(x, CultureInfo.InvariantCulture) / 1000)
-                    .ToArray();
-            }
-
-            return builder;
+            _cfg.OnValueChanged(cVar, _ => Reload());
         }
     }
 
-    internal interface IMetricsManager
+    private async Task Stop()
     {
-        void Initialize();
+        if (_metricServer == null)
+        {
+            return;
+        }
+
+        Logger.InfoS("metrics", "Shutting down metrics.");
+        await _metricServer.StopAsync();
+        _metricServer = null;
+        _runtimeCollector?.Dispose();
+        _runtimeCollector = null;
     }
+
+    async void IDisposable.Dispose()
+    {
+        await Stop();
+
+        _initialized = false;
+    }
+
+    private async void Reload()
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        await Stop();
+
+        var enabled = _cfg.GetCVar(CVars.MetricsEnabled);
+        _entitySystemManager.MetricsEnabled = enabled;
+
+        if (!enabled)
+        {
+            return;
+        }
+
+        var host = _cfg.GetCVar(CVars.MetricsHost);
+        var port = _cfg.GetCVar(CVars.MetricsPort);
+
+        Logger.InfoS("metrics", "Prometheus metrics enabled, host: {1} port: {0}", port, host);
+        _metricServer = new MetricServer(host, port);
+        _metricServer.Start();
+
+        if (_cfg.GetCVar(CVars.MetricsRuntime))
+        {
+            Logger.DebugS("metrics", "Enabling runtime metrics");
+            _runtimeCollector = BuildRuntimeStats().StartCollecting();
+        }
+    }
+
+    private DotNetRuntimeStatsBuilder.Builder BuildRuntimeStats()
+    {
+        var builder = DotNetRuntimeStatsBuilder.Customize();
+
+        if (CapLevel(CVars.MetricsRuntimeGc) is { } gc)
+        {
+            var buckets = Buckets(CVars.MetricsRuntimeGcHistogram);
+            builder.WithGcStats(gc, buckets);
+        }
+
+        if (CapLevel(CVars.MetricsRuntimeContention) is { } contention)
+        {
+            var rate = _cfg.GetCVar(CVars.MetricsRuntimeContentionSampleRate);
+            builder.WithContentionStats(contention, (SampleEvery)rate);
+        }
+
+        if (CapLevel(CVars.MetricsRuntimeThreadPool) is { } threadPool)
+        {
+            builder.WithThreadPoolStats(threadPool, new ThreadPoolMetricsProducer.Options
+            {
+                QueueLengthHistogramBuckets = Buckets(CVars.MetricsRuntimeThreadPoolQueueHistogram)
+            });
+        }
+
+        if (CapLevel(CVars.MetricsRuntimeJit) is { } jit)
+        {
+            var rate = _cfg.GetCVar(CVars.MetricsRuntimeJitSampleRate);
+            builder.WithJitStats(jit, (SampleEvery) rate);
+        }
+
+        if (CapLevel(CVars.MetricsRuntimeException) is { } exception)
+        {
+            builder.WithExceptionStats(exception);
+        }
+
+        if (CapLevel(CVars.MetricsRuntimeSocket) is { })
+        {
+            builder.WithSocketStats();
+        }
+
+        CaptureLevel? CapLevel(CVarDef<string> cvar)
+        {
+            var val = _cfg.GetCVar(cvar);
+            if (val != "")
+                return Enum.Parse<CaptureLevel>(val);
+
+            return null;
+        }
+
+        // 🪣
+        double[] Buckets(CVarDef<string> cvar)
+        {
+            return _cfg.GetCVar(cvar)
+                .Split()
+                .Select(x => double.Parse(x, CultureInfo.InvariantCulture) / 1000)
+                .ToArray();
+        }
+
+        return builder;
+    }
+}
+
+internal interface IMetricsManager
+{
+    void Initialize();
 }

--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="prometheus-net" Version="4.1.1" />
     <PackageReference Include="Serilog.Sinks.Loki" Version="4.0.0-beta3" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="5.0.0" />
+    <PackageReference Include="prometheus-net.DotNetRuntime" Version="4.2.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Lidgren.Network\Lidgren.Network.csproj" />

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -323,7 +323,7 @@ namespace Robust.Shared
         /// Histogram buckets for thread pool queue length.
         /// </summary>
         public static readonly CVarDef<string> MetricsRuntimeThreadPoolQueueHistogram =
-            CVarDef.Create("metrics.runtime_thread_pool_queue_histogram", "0,10,25,50,100", CVar.SERVERONLY);
+            CVarDef.Create("metrics.runtime_thread_pool_queue_histogram", "0,10,30,60,120,180", CVar.SERVERONLY);
 
         /// <summary>
         /// Mode for runtime JIT metrics. Empty to disable.

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -267,6 +267,100 @@ namespace Robust.Shared
         public static readonly CVarDef<int> MetricsPort =
             CVarDef.Create("metrics.port", 44880, CVar.SERVERONLY);
 
+        /// <summary>
+        /// Enable detailed runtime metrics. Empty to disable.
+        /// </summary>
+        /// <remarks>
+        /// Runtime metrics are provided by https://github.com/djluck/prometheus-net.DotNetRuntime.
+        /// Granularity of metrics can be further configured with related CVars.
+        /// </remarks>
+        public static readonly CVarDef<bool> MetricsRuntime =
+            CVarDef.Create("metrics.runtime", true, CVar.SERVERONLY);
+
+        /// <summary>
+        /// Mode for runtime GC metrics. Empty to disable.
+        /// </summary>
+        /// <remarks>
+        /// See the documentation for prometheus-net.DotNetRuntime for values and their metrics:
+        /// https://github.com/djluck/prometheus-net.DotNetRuntime/blob/master/docs/metrics-exposed-5.0.md
+        /// </remarks>
+        public static readonly CVarDef<string> MetricsRuntimeGc =
+            CVarDef.Create("metrics.runtime_gc", "Counters", CVar.SERVERONLY);
+
+        /// <summary>
+        /// Histogram buckets for GC and pause times. Comma-separated list of floats, in milliseconds.
+        /// </summary>
+        public static readonly CVarDef<string> MetricsRuntimeGcHistogram =
+            CVarDef.Create("metrics.runtime_gc_histogram", "0.5,1.0,2.0,4.0,6.0,10.0,15.0,20.0", CVar.SERVERONLY);
+
+        /// <summary>
+        /// Mode for runtime lock contention metrics. Empty to disable.
+        /// </summary>
+        /// <remarks>
+        /// See the documentation for prometheus-net.DotNetRuntime for values and their metrics:
+        /// https://github.com/djluck/prometheus-net.DotNetRuntime/blob/master/docs/metrics-exposed-5.0.md
+        /// </remarks>
+        public static readonly CVarDef<string> MetricsRuntimeContention =
+            CVarDef.Create("metrics.runtime_contention", "Counters", CVar.SERVERONLY);
+
+        /// <summary>
+        /// Sample lock contention every N events. Higher numbers increase accuracy but also memory use.
+        /// </summary>
+        public static readonly CVarDef<int> MetricsRuntimeContentionSampleRate =
+            CVarDef.Create("metrics.runtime_contention_sample_rate", 50, CVar.SERVERONLY);
+
+        /// <summary>
+        /// Mode for runtime thread pool metrics. Empty to disable.
+        /// </summary>
+        /// <remarks>
+        /// See the documentation for prometheus-net.DotNetRuntime for values and their metrics:
+        /// https://github.com/djluck/prometheus-net.DotNetRuntime/blob/master/docs/metrics-exposed-5.0.md
+        /// </remarks>
+        public static readonly CVarDef<string> MetricsRuntimeThreadPool =
+            CVarDef.Create("metrics.runtime_thread_pool", "Counters", CVar.SERVERONLY);
+
+        /// <summary>
+        /// Histogram buckets for thread pool queue length.
+        /// </summary>
+        public static readonly CVarDef<string> MetricsRuntimeThreadPoolQueueHistogram =
+            CVarDef.Create("metrics.runtime_thread_pool_queue_histogram", "0,10,25,50,100", CVar.SERVERONLY);
+
+        /// <summary>
+        /// Mode for runtime JIT metrics. Empty to disable.
+        /// </summary>
+        /// <remarks>
+        /// See the documentation for prometheus-net.DotNetRuntime for values and their metrics:
+        /// https://github.com/djluck/prometheus-net.DotNetRuntime/blob/master/docs/metrics-exposed-5.0.md
+        /// </remarks>
+        public static readonly CVarDef<string> MetricsRuntimeJit =
+            CVarDef.Create("metrics.runtime_jit", "Counters", CVar.SERVERONLY);
+
+        /// <summary>
+        /// Sample JIT every N events. Higher numbers increase accuracy but also memory use.
+        /// </summary>
+        public static readonly CVarDef<int> MetricsRuntimeJitSampleRate =
+            CVarDef.Create("metrics.runtime_jit_sample_rate", 10, CVar.SERVERONLY);
+
+        /// <summary>
+        /// Mode for runtime exception metrics. Empty to disable.
+        /// </summary>
+        /// <remarks>
+        /// See the documentation for prometheus-net.DotNetRuntime for values and their metrics:
+        /// https://github.com/djluck/prometheus-net.DotNetRuntime/blob/master/docs/metrics-exposed-5.0.md
+        /// </remarks>
+        public static readonly CVarDef<string> MetricsRuntimeException =
+            CVarDef.Create("metrics.runtime_exception", "Counters", CVar.SERVERONLY);
+
+        /// <summary>
+        /// Mode for runtime TCP socket metrics. Empty to disable.
+        /// </summary>
+        /// <remarks>
+        /// See the documentation for prometheus-net.DotNetRuntime for values and their metrics:
+        /// https://github.com/djluck/prometheus-net.DotNetRuntime/blob/master/docs/metrics-exposed-5.0.md
+        /// </remarks>
+        public static readonly CVarDef<string> MetricsRuntimeSocket =
+            CVarDef.Create("metrics.runtime_socket", "Counters", CVar.SERVERONLY);
+
         /*
          * STATUS
          */


### PR DESCRIPTION
Also made the metrics server support gzip which should reduce data usage a lot.