### PR TITLE
Fix entity map change crash

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -230,18 +230,25 @@ namespace Robust.Shared.GameObjects
                 return;
 
             _joints.ClearJoints(physicsComponent);
+
+            // So if the map is being deleted it detaches all of its bodies to null soooo we have this fun check.
+
             var oldMapId = message.OldMapId;
             if (oldMapId != MapId.Nullspace)
             {
-                EntityUid tempQualifier = MapManager.GetMapEntityId(oldMapId);
-                EntityManager.GetComponent<SharedPhysicsMapComponent>(tempQualifier).RemoveBody(physicsComponent);
+                var oldMapEnt = MapManager.GetMapEntityId(oldMapId);
+
+                if (MetaData(oldMapEnt).EntityLifeStage < EntityLifeStage.Terminating)
+                {
+                    EntityManager.GetComponent<SharedPhysicsMapComponent>(oldMapEnt).RemoveBody(physicsComponent);
+                }
             }
 
-            var newMapId = EntityManager.GetComponent<TransformComponent>(message.Entity).MapID;
+            var newMapId = Transform(message.Entity).MapID;
+
             if (newMapId != MapId.Nullspace)
             {
-                EntityUid tempQualifier = MapManager.GetMapEntityId(newMapId);
-                EntityManager.GetComponent<SharedPhysicsMapComponent>(tempQualifier).AddBody(physicsComponent);
+                EntityManager.GetComponent<SharedPhysicsMapComponent>(MapManager.GetMapEntityId(newMapId)).AddBody(physicsComponent);
             }
         }
 


### PR DESCRIPTION
All of the entities on the map have DetachParentToNull run which is !FUN!

Ideally they wouldn't (as this will also help make grid deletion MUCH faster) but for now we're worried about fixing the crash.

Edit: Should also note only way I could replicate is by closing the client window.