### PR TITLE
Fix broadphase for rotation events

### DIFF
--- a/Robust.Shared/Physics/Dynamics/Fixture.cs
+++ b/Robust.Shared/Physics/Dynamics/Fixture.cs
@@ -56,6 +56,7 @@ namespace Robust.Shared.Physics.Dynamics
         [DataField("id")]
         public string ID { get; set; } = string.Empty;
 
+        [ViewVariables]
         [field: NonSerialized]
         public FixtureProxy[] Proxies { get; set; } = Array.Empty<FixtureProxy>();
 

--- a/Robust.Shared/Physics/Dynamics/FixtureProxy.cs
+++ b/Robust.Shared/Physics/Dynamics/FixtureProxy.cs
@@ -21,6 +21,7 @@
 */
 
 using Robust.Shared.Maths;
+using Robust.Shared.ViewVariables;
 
 namespace Robust.Shared.Physics.Dynamics
 {
@@ -29,8 +30,10 @@ namespace Robust.Shared.Physics.Dynamics
         /// <summary>
         ///     Grid-based AABB of this proxy.
         /// </summary>
+        [ViewVariables]
         public Box2 AABB;
 
+        [ViewVariables]
         public int ChildIndex;
 
         /// <summary>
@@ -41,6 +44,7 @@ namespace Robust.Shared.Physics.Dynamics
         /// <summary>
         ///     ID of this proxy in the broadphase dynamictree.
         /// </summary>
+        [ViewVariables]
         public DynamicTree.Proxy ProxyId = DynamicTree.Proxy.Free;
 
         public FixtureProxy(Box2 aabb, Fixture fixture, int childIndex)

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -482,9 +482,11 @@ namespace Robust.Shared.Physics
         {
             if (!component.CanCollide) return;
 
-            var worldPos = EntityManager.GetComponent<TransformComponent>(uid).WorldPosition;
+            var xform = EntityManager.GetComponent<TransformComponent>(uid);
+            var (worldPos, worldRot) = xform.GetWorldPositionRotation();
+            DebugTools.Assert(xform.LocalRotation.Equals(args.NewRotation));
 
-            SynchronizeFixtures(component, worldPos, (float) args.NewRotation.Theta);
+            SynchronizeFixtures(component, worldPos, (float) worldRot.Theta);
         }
 
         private void SynchronizeFixtures(PhysicsComponent body, Vector2 worldPos, float worldRot, FixturesComponent? manager = null)


### PR DESCRIPTION
The event provides the localrotation which was being used for the broadphase.