### PR TITLE
Hopefully fix container occlusion bug?

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
@@ -6,6 +6,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
+using Robust.Shared.Map;
 using Robust.Shared.Serialization;
 using static Robust.Shared.Containers.ContainerManagerComponent;
 
@@ -139,9 +140,7 @@ namespace Robust.Client.GameObjects
                     // from the container. It would then subsequently be parented to the container without ever being
                     // re-inserted, leading to the client seeing what should be hidden entities attached to
                     // containers/players.
-                    // 
-                    // For any non-map entity, the parent of the transform should be valid. And maps can't be in containers.
-                    if (!Transform(entity).ParentUid.IsValid())
+                    if (!Transform(entity).MapID == MapId.Nullspace)
                     {
                         AddExpectedEntity(entity, container);
                         continue;

--- a/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
@@ -140,7 +140,7 @@ namespace Robust.Client.GameObjects
                     // from the container. It would then subsequently be parented to the container without ever being
                     // re-inserted, leading to the client seeing what should be hidden entities attached to
                     // containers/players.
-                    if (!Transform(entity).MapID == MapId.Nullspace)
+                    if (Transform(entity).MapID == MapId.Nullspace)
                     {
                         AddExpectedEntity(entity, container);
                         continue;

--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -126,7 +126,7 @@ namespace Robust.Shared.Containers
         #endregion
 
         // Eject entities from their parent container if the parent change is done by the transform only.
-        private void HandleParentChanged(ref EntParentChangedMessage message)
+        protected virtual void HandleParentChanged(ref EntParentChangedMessage message)
         {
             var oldParentEntity = message.OldParent;
 


### PR DESCRIPTION
So currently containers will occasionally just reveal their contents. I've often seen this happen for things like crates, but apparently it can also impact things like clothing and holoparasites (see space-wizards/space-station-14/issues/5964).

After having managed to reproduce it locally, the issue is that the client believes these entities are not actually contained in the container, leading to the sprite container-occlusion not being enabled, though these entities are still anchored to the containing-entity. AFAICT the reason the client believes they are not contained is because the client briefly resets the entity transforms to null-space when resetting predicted entities, leading to them being ejected from the container. AFAICT the process that leads to the bug is:
- Container moves out of player's PVS
- All entities outside of the PVS are sent to null-space
- It re-enter PVS
- IF the container and stored-entity's transform states are not sent simultaneously, then:
- contained entities are inserted into container
- Entity transforms are set & dirtied
- Predicted entities are reset, and all inserted entities w/o transform states are reset to null space.
- Entity sent to null space are removed from the container
- Entity transform state arrives, and they get anchored to the container.

This PR makes it so that when handling container states, any entity that should be inserted but that is currently in null space will instead be added to the list of expected entities. It then also updated the on-parent-changed subscription such that whenever an expected entity is parented to a container after coming from null-space, it will be inserted.

Reproducing the bug locally involves some randomness, so not 100% sure but this appears to fix the problem for crates. And hopefully the crate issue was the same as the holo-parasite and clothing one.

