### PR TITLE
Fix point light add/remove

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/PointLightSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/PointLightSystem.cs
@@ -8,6 +8,7 @@ namespace Robust.Client.GameObjects
     public sealed class PointLightSystem : SharedPointLightSystem
     {
         [Dependency] private readonly IResourceCache _resourceCache = default!;
+        [Dependency] private readonly RenderingTreeSystem _renderingTreeSystem = default!;
 
         public override void Initialize()
         {
@@ -19,16 +20,14 @@ namespace Robust.Client.GameObjects
         private void HandleInit(EntityUid uid, PointLightComponent component, ComponentInit args)
         {
             UpdateMask(component);
+            RaiseLocalEvent(uid, new PointLightUpdateEvent());
         }
 
         private void HandleRemove(EntityUid uid, PointLightComponent component, ComponentRemove args)
         {
-            var map = EntityManager.GetComponent<TransformComponent>(uid).MapID;
-            // TODO: Just make this update the tree directly and not allocate
-            if (map != MapId.Nullspace)
+            if (Transform(uid).MapID != MapId.Nullspace)
             {
-                EntityManager.EventBus.RaiseEvent(EventSource.Local,
-                    new RenderTreeRemoveLightEvent(component, map));
+                _renderingTreeSystem.ClearLight(component);
             }
         }
 

--- a/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
@@ -84,7 +84,6 @@ namespace Robust.Client.GameObjects
             SubscribeLocalEvent<PointLightComponent, EntMapIdChangedMessage>(LightMapChanged);
             SubscribeLocalEvent<PointLightComponent, EntParentChangedMessage>(LightParentChanged);
             SubscribeLocalEvent<PointLightComponent, PointLightRadiusChangedEvent>(PointLightRadiusChanged);
-            SubscribeLocalEvent<PointLightComponent, RenderTreeRemoveLightEvent>(RemoveLight);
             SubscribeLocalEvent<PointLightComponent, PointLightUpdateEvent>(HandleLightUpdate);
 
             SubscribeLocalEvent<RenderingTreeComponent, ComponentInit>(OnTreeInit);
@@ -194,12 +193,7 @@ namespace Robust.Client.GameObjects
             QueueLightUpdate(component);
         }
 
-        private void RemoveLight(EntityUid uid, PointLightComponent component, RenderTreeRemoveLightEvent args)
-        {
-            ClearLight(component);
-        }
-
-        private void ClearLight(PointLightComponent component)
+        public void ClearLight(PointLightComponent component)
         {
             if (component.RenderTree == null) return;
 
@@ -437,17 +431,5 @@ namespace Robust.Client.GameObjects
             }
             return Box2.CenteredAround(localPos, (boxSize, boxSize));
         }
-    }
-
-    internal class RenderTreeRemoveLightEvent : EntityEventArgs
-    {
-        public RenderTreeRemoveLightEvent(PointLightComponent light, MapId map)
-        {
-            Light = light;
-            Map = map;
-        }
-
-        public PointLightComponent Light { get; }
-        public MapId Map { get; }
     }
 }


### PR DESCRIPTION
Using VV to add point lights to entities currently behaves oddly. The light doesn't appear automatically because the a rendering update is never queued on component init, and the removal isn't handled properly because it currently raises a broadcast event, while the event subscription is for a directed event.

This just gets rid of the method-event altogether and removes queues an update on init. 