### PR TITLE
Fix grid fixture deserialization

### DIFF
--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -433,7 +433,10 @@ namespace Robust.Server.Maps
                     var mapUid = _mapManager.GetMapEntityIdOrThrow(grid.ParentMapId);
                     body.Broadphase = entManager.GetComponent<BroadphaseComponent>(mapUid);
                     var fixtures = entManager.EnsureComponent<FixturesComponent>(grid.GridEntityId);
+                    // Regenerate grid collision.
                     gridFixtures.ProcessGrid(gridInternal);
+                    // Avoid duplicating the deserialization in FixtureSystem.
+                    fixtures.SerializedFixtures.Clear();
 
                     // Need to go through and double-check we don't have any hanging-on fixtures that
                     // no longer apply (e.g. due to an update in GridFixtureSystem)


### PR DESCRIPTION
FixtureSystem was duplicating some of this work and causing duplicate fixtures.