### PR TITLE
Fix InteractionOutline for rotated eyes

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/ISpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/ISpriteComponent.cs
@@ -219,6 +219,6 @@ namespace Robust.Client.GameObjects
         /// <summary>
         ///     Calculate sprite bounding box in world-space coordinates.
         /// </summary>
-        Box2 CalculateBoundingBox(Vector2 worldPos);
+        Box2 CalculateBoundingBox(Matrix3 worldMatrix);
     }
 }

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteBoundsOverlay.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteBoundsOverlay.cs
@@ -84,8 +84,8 @@ namespace Robust.Client.GameObjects
 
                 foreach (var sprite in comp.SpriteTree.QueryAabb(localAABB))
                 {
-                    var worldPos = _entityManager.GetComponent<TransformComponent>(sprite.Owner).WorldPosition;
-                    var bounds = sprite.CalculateBoundingBox(worldPos);
+                    var worldMatrix = _entityManager.GetComponent<TransformComponent>(sprite.Owner).WorldMatrix;
+                    var bounds = sprite.CalculateBoundingBox(worldMatrix);
                     handle.DrawRect(bounds, Color.Red.WithAlpha(0.2f));
                     handle.DrawRect(bounds.Scale(0.2f).Translated(-new Vector2(0f, bounds.Extents.Y)), Color.Blue.WithAlpha(0.5f));
                 }

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1622,8 +1622,11 @@ namespace Robust.Client.GameObjects
         }
 
         /// <inheritdoc/>
-        public Box2 CalculateBoundingBox(Vector2 worldPos)
+        public Box2 CalculateBoundingBox(Matrix3 worldMatrix)
         {
+            // Given if the thing is upside down the offset is inverse we need to do a matrix transform
+            var worldPos = new Vector2(worldMatrix.R0C2, worldMatrix.R1C2);
+
             // fast check for empty sprites
             if (Layers.Count == 0)
                 return new Box2(worldPos, worldPos);
@@ -1649,7 +1652,8 @@ namespace Robust.Client.GameObjects
                 new Box2Rotated(spriteBox, Rotation).CalcBoundingBox() : spriteBox;
 
             // move it all to world transform system (with sprite offset)
-            var worldBB = spriteBB.Translated(Offset + worldPos);
+            var worldBB = spriteBB.Translated(worldMatrix.Transform(Offset));
+
             return worldBB;
         }
 

--- a/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
@@ -292,7 +292,7 @@ namespace Robust.Client.GameObjects
                 var newMapTree = GetRenderTree(sprite.Owner);
                 // TODO: Temp PVS guard
                 var xform = EntityManager.GetComponent<TransformComponent>(sprite.Owner);
-                var (worldPos, worldRot) = xform.GetWorldPositionRotation();
+                var (worldPos, worldRot, worldMatrix) = xform.GetWorldPositionRotationMatrix();
 
                 if (float.IsNaN(worldPos.X) || float.IsNaN(worldPos.Y))
                 {
@@ -300,7 +300,7 @@ namespace Robust.Client.GameObjects
                     continue;
                 }
 
-                var aabb = SpriteAabbFunc(sprite, worldPos, worldRot);
+                var aabb = SpriteAabbFunc(sprite, worldPos, worldRot, worldMatrix);
 
                 // If we're on a new map then clear the old one.
                 if (oldMapTree != newMapTree)
@@ -367,8 +367,8 @@ namespace Robust.Client.GameObjects
         private Box2 SpriteAabbFunc(in SpriteComponent value)
         {
             var xform = EntityManager.GetComponent<TransformComponent>(value.Owner);
-            var (worldPos, worldRot) = xform.GetWorldPositionRotation();
-            var bounds = new Box2Rotated(value.CalculateBoundingBox(worldPos), worldRot, worldPos);
+            var (worldPos, worldRot, worldMatrix) = xform.GetWorldPositionRotationMatrix();
+            var bounds = new Box2Rotated(value.CalculateBoundingBox(worldMatrix), worldRot, worldPos);
             var tree = GetRenderTree(value.Owner);
 
             if (tree == null)
@@ -400,9 +400,9 @@ namespace Robust.Client.GameObjects
             return Box2.CenteredAround(localPos, (boxSize, boxSize));
         }
 
-        private Box2 SpriteAabbFunc(SpriteComponent value, Vector2 worldPos, Angle worldRot)
+        private Box2 SpriteAabbFunc(SpriteComponent value, Vector2 worldPos, Angle worldRot, Matrix3 worldMatrix)
         {
-            var bounds = new Box2Rotated(value.CalculateBoundingBox(worldPos), worldRot, worldPos);
+            var bounds = new Box2Rotated(value.CalculateBoundingBox(worldMatrix), worldRot, worldPos);
             var tree = GetRenderTree(value.Owner);
 
             if (tree == null)

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -284,7 +284,7 @@ namespace Robust.Client.Graphics.Clyde
                 if (entry.sprite.PostShader != null)
                 {
                     // calculate world bounding box
-                    var spriteBB = entry.sprite.CalculateBoundingBox(worldPosition);
+                    var spriteBB = entry.sprite.CalculateBoundingBox(matrix);
                     var spriteLB = spriteBB.BottomLeft;
                     var spriteRT = spriteBB.TopRight;
 
@@ -389,7 +389,7 @@ namespace Robust.Client.Graphics.Clyde
                     entry.matrix = transform.WorldMatrix;
                     var eyePos = eyeMatrix.Transform(new Vector2(entry.matrix.R0C2, entry.matrix.R1C2));
                     // Didn't use the bounds from the query as that has to be re-calculated (and is probably more expensive than this).
-                    var bounds = value.CalculateBoundingBox(eyePos);
+                    var bounds = value.CalculateBoundingBox(eyeMatrix);
                     entry.yWorldPos = eyePos.Y - bounds.Extents.Y;
                     return true;
 


### PR DESCRIPTION
Bounds transform moment.

On master the offset is just applied to worldpos so falls over when the grid rotates, so we just do a transform on it using the entity's world matrix and get the correct rotated offset.

master:
![image](https://user-images.githubusercontent.com/31366439/151708067-5058e722-448e-411c-9923-5ab36026eb25.png)

fixed:
![image](https://user-images.githubusercontent.com/31366439/151707824-c7cb56f8-b84d-43fb-ad2d-851097ac406f.png)

Fixes the other half of https://github.com/space-wizards/RobustToolbox/issues/2431 also https://github.com/space-wizards/space-station-14/issues/5455