### PR TITLE
Don't serialize grid fixtures

### DIFF
--- a/Robust.Shared/Physics/FixturesComponent.cs
+++ b/Robust.Shared/Physics/FixturesComponent.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Robust.Shared.Analyzers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
+using Robust.Shared.IoC;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
@@ -40,6 +41,10 @@ namespace Robust.Shared.Physics
         {
             // Can't assert the count is 0 because it's possible it gets re-serialized before init!
             if (SerializedFixtures.Count > 0) return;
+
+            // At some stage we'll serialize non-default grids (gridfixturesystem does support it)
+            // but for now just for smaller map file + reading speed we'll just globally cull them.
+            if (IoCManager.Resolve<IEntityManager>().HasComponent<MapGridComponent>(Owner)) return;
 
             foreach (var (_, fixture) in Fixtures)
             {


### PR DESCRIPTION
Thought about it a bit. Ideally long-term custom ones would be serialized but I'd need to make a bunch of changes to gridfixturesystem to support determining whether they are custom.

For now:

Pros:
- Faster yml reading for map loads
- Faster map writing
- 5% reduced map line count (for saltern)

Cons:
- Any custom data around restitution etc set via vv isn't getting serialized.
- Serialization may or may not be faster overall? (Resolve IEntityManager for every body vs having to serialize >100 fixtures).