### PR TITLE
Reduce gamestate allocs

### DIFF
--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -127,7 +127,7 @@ namespace Robust.Server.GameStates
             // people not in the game don't get states
             var players = _playerManager.ServerSessions.Where(o => o.Status == SessionStatus.InGame).ToArray();
 
-            const int BatchSize = 4;
+            const int BatchSize = 2;
             var batches = (int) MathF.Ceiling((float) players.Length / BatchSize);
 
             Parallel.For(0, batches, i =>

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -328,7 +328,9 @@ namespace Robust.Shared.GameObjects
 
         internal static (int Batches, int BatchSize) GetBatch(int count, int minimumBatchSize)
         {
-            var batches = Math.Min((int) MathF.Floor((float) count / minimumBatchSize), Math.Max(1, Environment.ProcessorCount));
+            var batches = Math.Min(
+                (int) MathF.Ceiling((float) count / minimumBatchSize),
+                Math.Max(1, Environment.ProcessorCount));
             var batchSize = (int) MathF.Ceiling((float) count / batches);
 
             return (batches, batchSize);


### PR DESCRIPTION
Parallel.ForEach has no right allocating that much with no partitioner specified

Before:
![image](https://user-images.githubusercontent.com/31366439/151966296-391716a6-25b4-4830-a9e3-1cb5e66113e3.png)

After:
![image](https://user-images.githubusercontent.com/31366439/151966329-6e5082a5-f632-4280-bb44-20970d16ce98.png)
