### PR TITLE
Remove string allocs from client prediction

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -350,9 +350,9 @@ namespace Robust.Client.GameStates
                 }
 
                 // Check log level first to avoid the string alloc.
-                if (_sawmill.Level >= LogLevel.Debug)
+                if (_sawmill.Level <= LogLevel.Debug)
                 {
-                    _sawmill.Debug(CVars.NetPredict.Name, $"Entity {entity} was made dirty.");
+                    _sawmill.Debug($"Entity {entity} was made dirty.");
                 }
 
                 if (!_processor.TryGetLastServerStates(entity, out var last))

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -213,7 +213,7 @@ namespace Robust.Client.GameStates
                     break;
                 }
 
-                // _sawmill.Debug("net", $"{IGameTiming.TickStampStatic}: applying state from={curState.FromSequence} to={curState.ToSequence} ext={curState.Extrapolated}");
+                // Logger.DebugS("net", $"{IGameTiming.TickStampStatic}: applying state from={curState.FromSequence} to={curState.ToSequence} ext={curState.Extrapolated}");
 
                 // TODO: If Predicting gets disabled *while* the world state is dirty from a prediction,
                 // this won't run meaning it could potentially get stuck dirty.
@@ -350,7 +350,7 @@ namespace Robust.Client.GameStates
                 }
 
                 // Check log level first to avoid the string alloc.
-                if (_sawmill.Level <= LogLevel.Debug)
+                if (_sawmill.Level >= LogLevel.Debug)
                 {
                     _sawmill.Debug(CVars.NetPredict.Name, $"Entity {entity} was made dirty.");
                 }


### PR DESCRIPTION
dotnet 6 plz.

Before:
![image](https://user-images.githubusercontent.com/31366439/152079559-a75ea035-e914-41a4-b41d-9c7d111d2475.png)

After:
![image](https://user-images.githubusercontent.com/31366439/152079418-52c2cd23-43d4-4627-b491-2ed082d397cf.png)

(Overall allocs are different because the before is from another PR and I've already nuked most of the main offenders).