### PR TITLE
Replace `EntityDirtyEvent` with C# event.

### DIFF
--- a/Robust.Server/GameStates/PVSSystem.Dirty.cs
+++ b/Robust.Server/GameStates/PVSSystem.Dirty.cs
@@ -39,6 +39,7 @@ namespace Robust.Server.GameStates
         private void ShutdownDirty()
         {
             EntityManager.EntityAdded -= OnEntityAdd;
+            EntityManager.EntityDirtied -= OnEntityDirty;
         }
 
         private void OnEntityAdd(object? sender, EntityUid e)

--- a/Robust.Server/GameStates/PVSSystem.Dirty.cs
+++ b/Robust.Server/GameStates/PVSSystem.Dirty.cs
@@ -33,7 +33,7 @@ namespace Robust.Server.GameStates
                 _dirtyEntities[i] = new HashSet<EntityUid>(32);
             }
             EntityManager.EntityAdded += OnEntityAdd;
-            SubscribeLocalEvent<EntityDirtyEvent>(OnDirty);
+            EntityManager.EntityDirtied += OnEntityDirty;
         }
 
         private void ShutdownDirty()
@@ -47,12 +47,10 @@ namespace Robust.Server.GameStates
             _addEntities[_currentIndex].Add(e);
         }
 
-        private void OnDirty(ref EntityDirtyEvent ev)
+        private void OnEntityDirty(object? sender, EntityUid uid)
         {
-            if (_addEntities[_currentIndex].Contains(ev.Uid) ||
-                EntityManager.GetComponent<MetaDataComponent>(ev.Uid).EntityLifeStage < EntityLifeStage.Initialized) return;
-
-            _dirtyEntities[_currentIndex].Add(ev.Uid);
+            if (!_addEntities[_currentIndex].Contains(uid))
+                _dirtyEntities[_currentIndex].Add(uid);
         }
 
         private void CleanupDirty(IEnumerable<IPlayerSession> sessions)

--- a/Robust.Shared/GameObjects/EntitySystemMessages/EntityDirtyEvent.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/EntityDirtyEvent.cs
@@ -1,8 +1,0 @@
-namespace Robust.Shared.GameObjects
-{
-    [ByRefEvent]
-    public struct EntityDirtyEvent
-    {
-        public EntityUid Uid;
-    }
-}

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -49,6 +49,7 @@ namespace Robust.Shared.GameObjects
         event EventHandler<EntityUid>? EntityInitialized;
         event EventHandler<EntityUid>? EntityStarted;
         event EventHandler<EntityUid>? EntityDeleted;
+        event EventHandler<EntityUid>? EntityDirtied; // only raised after initialization
 
         EntityUid CreateEntityUninitialized(string? prototypeName, EntityUid euid);
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -22,23 +22,6 @@ namespace Robust.Shared.GameObjects
             UpdatesOutsidePrediction = true;
 
             _mapManager.TileChanged += MapManagerOnTileChanged;
-            SubscribeLocalEvent<TransformComponent, EntityDirtyEvent>(OnTransformDirty);
-        }
-
-        private void OnTransformDirty(EntityUid uid, TransformComponent component, ref EntityDirtyEvent args)
-        {
-            if (!component.Anchored ||
-                !component.ParentUid.IsValid() ||
-                MetaData(uid).EntityLifeStage < EntityLifeStage.Initialized)
-                return;
-
-            // Anchor dirty
-            // May not even need this in future depending what happens with chunk anchoring (paulVS plz).
-            var gridComp = EntityManager.GetComponent<IMapGridComponent>(component.ParentUid);
-
-            var grid = (IMapGridInternal) gridComp.Grid;
-            DebugTools.Assert(component.GridID == gridComp.GridIndex);
-            grid.AnchoredEntDirty(grid.TileIndicesFor(component.Coordinates));
         }
 
         public override void Shutdown()

--- a/Robust.Shared/Map/IMapChunkInternal.cs
+++ b/Robust.Shared/Map/IMapChunkInternal.cs
@@ -18,10 +18,5 @@ namespace Robust.Shared.Map
         /// The last game simulation tick that a tile on this chunk was modified.
         /// </summary>
         GameTick LastTileModifiedTick { get; }
-
-        /// <summary>
-        /// The last game simulation tick that an anchored entity on this chunk was modified.
-        /// </summary>
-        GameTick LastAnchoredModifiedTick { get; set; }
     }
 }

--- a/Robust.Shared/Map/IMapGridInternal.cs
+++ b/Robust.Shared/Map/IMapGridInternal.cs
@@ -16,15 +16,7 @@ namespace Robust.Shared.Map
         /// </summary>
         int ChunkCount { get; }
 
-        GameTick LastAnchoredModifiedTick { get; }
-
         void NotifyTileChanged(in TileRef tileRef, in Tile oldTile);
-
-        /// <summary>
-        /// Notifies the grid that an anchored entity is dirty.
-        /// </summary>
-        /// <param name="pos">Position of the entity in local tile indices.</param>
-        void AnchoredEntDirty(Vector2i pos);
 
         void UpdateAABB();
 

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -376,8 +376,6 @@ namespace Robust.Shared.Map
         /// </summary>
         public int ChunkCount => _chunks.Count;
 
-        public GameTick LastAnchoredModifiedTick { get; private set; }
-
         /// <inheritdoc />
         public IMapChunkInternal GetChunk(int xIndex, int yIndex)
         {
@@ -571,7 +569,6 @@ namespace Robust.Shared.Map
                 return false;
 
             chunk.AddToSnapGridCell((ushort)chunkTile.X, (ushort)chunkTile.Y, euid);
-            LastAnchoredModifiedTick = _entityManager.CurrentTick;
             return true;
         }
 
@@ -586,7 +583,6 @@ namespace Robust.Shared.Map
         {
             var (chunk, chunkTile) = ChunkAndOffsetForTile(pos);
             chunk.RemoveFromSnapGridCell((ushort)chunkTile.X, (ushort) chunkTile.Y, euid);
-            LastAnchoredModifiedTick = _entityManager.CurrentTick;
         }
 
         /// <inheritdoc />
@@ -683,15 +679,6 @@ namespace Robust.Shared.Map
                         yield return cell;
                     }
                 }
-        }
-
-        /// <inheritdoc />
-        public void AnchoredEntDirty(Vector2i pos)
-        {
-            LastAnchoredModifiedTick = _entityManager.CurrentTick;
-
-            var chunk = GetChunk(GridTileToChunkIndices(pos));
-            chunk.LastAnchoredModifiedTick = LastAnchoredModifiedTick;
         }
 
         #endregion


### PR DESCRIPTION
Currently whenever any entity is dirtied, `EntityManager` will raise a "normal" `EntityDirtyEvent` via the event bus. This event is currently used by both PVS and the `TransformSystem`. However the transform system just uses it to set `LastAnchoredModifiedTick`, which is currently completely unused (an old PVS thing?). So currently it just results in wasting time on meta-data, transform and map-grid component fetching whenever an entity is dirtied.

So this PR just removes `LastAnchoredModifiedTick`. It also replaces `EntityDirtyEvent` with a C# event, which AFAIK should be faster, which matters for something as common as just dirtying an entity.

I also moved the PVS system's ` EntityLifeStage` check into `EntityManager`'s `Dirty()`, so that dirty events are only ever be raised if the entity has been initialized, but currently that makes no difference as only PVS actually uses this event, and doing so saves a meta-data resolve.

Also has an edit to `RecursiveDeleteEntity()` to avoid retrieving the metadata component twice.