### PR TITLE
Misc physics/shutdown related optimizations

### DIFF
--- a/Robust.Shared/GameObjects/Components/CollisionWakeComponent.cs
+++ b/Robust.Shared/GameObjects/Components/CollisionWakeComponent.cs
@@ -1,9 +1,6 @@
 using System;
-using System.Linq;
 using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
-using Robust.Shared.Physics;
-using Robust.Shared.Players;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.ViewVariables;
@@ -38,17 +35,6 @@ namespace Robust.Shared.GameObjects
         internal void RaiseStateChange()
         {
             _entMan.EventBus.RaiseLocalEvent(Owner, new CollisionWakeStateMessage(), false);
-        }
-
-        protected override void OnRemove()
-        {
-            base.OnRemove();
-            if (_entMan.TryGetComponent(Owner, out IPhysBody? body)
-                && _entMan.TryGetComponent<MetaDataComponent>(Owner, out var metaData)
-                && metaData.EntityLifeStage < EntityLifeStage.Terminating)
-            {
-                body.CanCollide = true;
-            }
         }
 
         public override ComponentState GetComponentState()

--- a/Robust.Shared/GameObjects/Systems/CollisionWakeSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/CollisionWakeSystem.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
 
@@ -11,6 +9,7 @@ namespace Robust.Shared.GameObjects
         {
             base.Initialize();
             SubscribeLocalEvent<CollisionWakeComponent, EntityInitializedMessage>(HandleInitialize);
+            SubscribeLocalEvent<CollisionWakeComponent, ComponentRemove>(HandleRemove);
 
             SubscribeLocalEvent<CollisionWakeComponent, PhysicsWakeMessage>(HandleWake);
             SubscribeLocalEvent<CollisionWakeComponent, PhysicsSleepMessage>(HandleSleep);
@@ -20,6 +19,14 @@ namespace Robust.Shared.GameObjects
             SubscribeLocalEvent<CollisionWakeComponent, JointRemovedEvent>(HandleJointRemove);
 
             SubscribeLocalEvent<CollisionWakeComponent, EntParentChangedMessage>(HandleParentChange);
+        }
+
+        private void HandleRemove(EntityUid uid, CollisionWakeComponent component, ComponentRemove args)
+        {
+            if (!Terminating(uid) && TryComp(uid, out PhysicsComponent? physics))
+            {
+                physics.CanCollide = true;
+            }
         }
 
         private bool CanRaiseEvent(EntityUid uid)

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -101,9 +101,12 @@ namespace Robust.Shared.GameObjects
 
         private void HandleParentChange(EntityUid uid, PhysicsComponent body, ref EntParentChangedMessage args)
         {
-            if (LifeStage(uid) != EntityLifeStage.MapInitialized || !TryComp(uid, out TransformComponent? xform))
+            if (LifeStage(uid) is < EntityLifeStage.Initialized or > EntityLifeStage.MapInitialized
+                || !TryComp(uid, out TransformComponent? xform))
+            {
                 return;
-
+            }
+                
             if (body.CanCollide)
                 _broadphase.UpdateBroadphase(body, xform: xform);
             

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+using System;
 using Prometheus;
 using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
@@ -8,14 +6,9 @@ using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
-using Robust.Shared.Physics.Controllers;
 using Robust.Shared.Physics.Dynamics;
-using Robust.Shared.Physics.Dynamics.Joints;
-using Robust.Shared.Reflection;
 using Robust.Shared.Timing;
-using Robust.Shared.Utility;
 using DependencyAttribute = Robust.Shared.IoC.DependencyAttribute;
-using Logger = Robust.Shared.Log.Logger;
 
 namespace Robust.Shared.GameObjects
 {
@@ -46,6 +39,8 @@ namespace Robust.Shared.GameObjects
                 Buckets = Histogram.ExponentialBuckets(0.000_001, 1.5, 25)
             });
 
+        [Dependency] private readonly SharedBroadphaseSystem _broadphase = default!;
+        [Dependency] private readonly SharedContainerSystem _container = default!;
         [Dependency] private readonly SharedJointSystem _joints = default!;
         [Dependency] protected readonly IMapManager MapManager = default!;
         [Dependency] private readonly IPhysicsManager _physicsManager = default!;
@@ -67,7 +62,7 @@ namespace Robust.Shared.GameObjects
             SubscribeLocalEvent<EntMapIdChangedMessage>(HandleMapChange);
             SubscribeLocalEvent<EntInsertedIntoContainerMessage>(HandleContainerInserted);
             SubscribeLocalEvent<EntRemovedFromContainerMessage>(HandleContainerRemoved);
-            SubscribeLocalEvent<EntParentChangedMessage>(HandleParentChange);
+            SubscribeLocalEvent<PhysicsComponent, EntParentChangedMessage>(HandleParentChange);
             SubscribeLocalEvent<SharedPhysicsMapComponent, ComponentInit>(HandlePhysicsMapInit);
             SubscribeLocalEvent<SharedPhysicsMapComponent, ComponentRemove>(HandlePhysicsMapRemove);
             SubscribeLocalEvent<PhysicsComponent, ComponentInit>(OnPhysicsInit);
@@ -104,18 +99,26 @@ namespace Robust.Shared.GameObjects
             component.ContactManager.Shutdown();
         }
 
-        private void HandleParentChange(ref EntParentChangedMessage args)
+        private void HandleParentChange(EntityUid uid, PhysicsComponent body, ref EntParentChangedMessage args)
         {
-            var entity = args.Entity;
+            if (LifeStage(uid) != EntityLifeStage.MapInitialized)
+                return;
 
-            if (!TryInitialized(entity, out var initialized) || !initialized.Value ||
-                !EntityManager.TryGetComponent(entity, out PhysicsComponent? body) ||
-                entity.IsInContainer()) return;
+            var xform = Transform(uid);
 
+            if (body.CanCollide)
+                _broadphase.UpdateBroadphase(body, xform: xform);
+            
+            if (!xform.ParentUid.IsValid() || !_container.IsEntityInContainer(uid, xform))
+                HandleParentChangeVelocity(uid, body, ref args, xform);
+        }
+
+        private void HandleParentChangeVelocity(EntityUid uid, PhysicsComponent body, ref EntParentChangedMessage args, TransformComponent xform)
+        {
             var angularVelocityDiff = 0f;
             var linearVelocityDiff = Vector2.Zero;
 
-            var (worldPos, worldRot) = Transform(entity).GetWorldPositionRotation();
+            var (worldPos, worldRot) = xform.GetWorldPositionRotation();
             var R = Matrix3.CreateRotation(worldRot);
             R.Transpose(out var nRT);
             nRT.Multiply(-1f);
@@ -151,7 +154,7 @@ namespace Robust.Shared.GameObjects
                 angularVelocityDiff += (nRT * w * R).R1C0;
             }
 
-            var newParent = EntityManager.GetComponent<TransformComponent>(entity).ParentUid;
+            var newParent = xform.ParentUid;
 
             if (newParent != EntityUid.Invalid && EntityManager.TryGetComponent(newParent, out PhysicsComponent? newBody))
             {

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -101,10 +101,8 @@ namespace Robust.Shared.GameObjects
 
         private void HandleParentChange(EntityUid uid, PhysicsComponent body, ref EntParentChangedMessage args)
         {
-            if (LifeStage(uid) != EntityLifeStage.MapInitialized)
+            if (LifeStage(uid) != EntityLifeStage.MapInitialized || !TryComp(uid, out TransformComponent? xform))
                 return;
-
-            var xform = Transform(uid);
 
             if (body.CanCollide)
                 _broadphase.UpdateBroadphase(body, xform: xform);
@@ -123,7 +121,7 @@ namespace Robust.Shared.GameObjects
             R.Transpose(out var nRT);
             nRT.Multiply(-1f);
 
-            if (args.OldParent is {} oldParent && EntityManager.TryGetComponent(oldParent, out PhysicsComponent? oldBody))
+            if (args.OldParent is {Valid: true} oldParent && EntityManager.TryGetComponent(oldParent, out PhysicsComponent? oldBody))
             {
                 var (linear, angular) = oldBody.MapVelocities;
 

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -295,7 +295,7 @@ namespace Robust.Shared.Physics
         /// If our broadphase has changed then remove us from our old one and add to our new one.
         /// </summary>
         /// <param name="body"></param>
-        public void UpdateBroadphase(PhysicsComponent body, FixturesComponent? manager = null, TransformComponent? xform = null)
+        internal void UpdateBroadphase(PhysicsComponent body, FixturesComponent? manager = null, TransformComponent? xform = null)
         {
             if (!Resolve(body.Owner, ref manager, ref xform)) return;
 

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -64,9 +64,6 @@ namespace Robust.Shared.Physics
             SubscribeLocalEvent<EntRemovedFromContainerMessage>(HandleContainerRemove);
             SubscribeLocalEvent<CollisionChangeMessage>(OnPhysicsUpdate);
 
-            // Shouldn't need to listen to mapchanges as parent changes should handle it...
-            SubscribeLocalEvent<PhysicsComponent, EntParentChangedMessage>(OnParentChange);
-
             SubscribeLocalEvent<PhysicsComponent, MoveEvent>(OnMove);
             SubscribeLocalEvent<PhysicsComponent, RotateEvent>(OnRotate);
 
@@ -294,22 +291,11 @@ namespace Robust.Shared.Physics
             _broadInvMatrices.Clear();
         }
 
-        private void OnParentChange(EntityUid uid, PhysicsComponent component, ref EntParentChangedMessage args)
-        {
-            if (!component.CanCollide) return;
-
-            var lifestage = EntityManager.GetComponent<MetaDataComponent>(uid).EntityLifeStage;
-
-            if (lifestage is < EntityLifeStage.Initialized or > EntityLifeStage.MapInitialized) return;
-
-            UpdateBroadphase(component);
-        }
-
         /// <summary>
         /// If our broadphase has changed then remove us from our old one and add to our new one.
         /// </summary>
         /// <param name="body"></param>
-        private void UpdateBroadphase(PhysicsComponent body, FixturesComponent? manager = null, TransformComponent? xform = null)
+        public void UpdateBroadphase(PhysicsComponent body, FixturesComponent? manager = null, TransformComponent? xform = null)
         {
             if (!Resolve(body.Owner, ref manager, ref xform)) return;
 


### PR DESCRIPTION
- Move `CollisionWakeComponent` shutdown to system and only run it if entity is not terminating.
- Move `PhysicsComponent`'s `EntParentChangedMessage` subscription into SharedPhysicsSystem 
  - Previously in `SharedBroadPhaseSystem`, but this subscription is also required for another function (duplicate subscription issues).
  - New subscription calls `SharedBroadPhaseSystem.UpdateBroadphase()` & the old `HandleParentChange` (now called `HandleParentChangeVelocity`
  - Less transform resolves, and avoids updating entity velocity when its being detached to null during deletion.