### PR TITLE
Reduce ContainerHelper IoCManager resolves

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
@@ -59,7 +59,7 @@ namespace Robust.Client.GameObjects
             {
                 if (!cast.ContainerSet.Any(data => data.Id == id))
                 {
-                    container.EmptyContainer(true);
+                    container.EmptyContainer(true, EntityManager);
                     container.Shutdown();
                     toDelete ??= new List<string>();
                     toDelete.Add(id);

--- a/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
@@ -59,7 +59,7 @@ namespace Robust.Client.GameObjects
             {
                 if (!cast.ContainerSet.Any(data => data.Id == id))
                 {
-                    container.EmptyContainer(true, EntityManager);
+                    container.EmptyContainer(true, entMan: EntityManager);
                     container.Shutdown();
                     toDelete ??= new List<string>();
                     toDelete.Add(id);

--- a/Robust.Client/GameStates/NetInterpOverlay.cs
+++ b/Robust.Client/GameStates/NetInterpOverlay.cs
@@ -38,7 +38,7 @@ namespace Robust.Client.GameStates
                 var transform = _entityManager.GetComponent<TransformComponent>(boundingBox.Owner);
 
                 // if not on the same map, continue
-                if (transform.MapID != _eyeManager.CurrentMap || boundingBox.Owner.IsInContainer())
+                if (transform.MapID != _eyeManager.CurrentMap || boundingBox.Owner.IsInContainer(_entityManager))
                     continue;
 
                 // This entity isn't lerping, no need to draw debug info for it

--- a/Robust.Shared/Containers/BaseContainer.cs
+++ b/Robust.Shared/Containers/BaseContainer.cs
@@ -67,7 +67,7 @@ namespace Robust.Shared.Containers
             var transform = entMan.GetComponent<TransformComponent>(toinsert);
 
             // CanInsert already checks nullability of Parent (or container forgot to call base that does)
-            if (toinsert.TryGetContainerMan(out var containerManager) && !containerManager.Remove(toinsert))
+            if (toinsert.TryGetContainerMan(out var containerManager, entMan) && !containerManager.Remove(toinsert))
                 return false; // Can't remove from existing container, can't insert.
 
             // Attach to parent first so we can check IsInContainer more easily.
@@ -133,7 +133,7 @@ namespace Robust.Shared.Containers
             if (!CanRemove(toremove, entMan)) return false;
             InternalRemove(toremove, entMan);
 
-            entMan.GetComponent<TransformComponent>(toremove).AttachParentToContainerOrGrid();
+            entMan.GetComponent<TransformComponent>(toremove).AttachParentToContainerOrGrid(entMan);
             return true;
         }
 

--- a/Robust.Shared/Containers/ContainerHelpers.cs
+++ b/Robust.Shared/Containers/ContainerHelpers.cs
@@ -199,9 +199,7 @@ namespace Robust.Shared.Containers
             where T : IContainer
         {
             IoCManager.Resolve(ref entMan);
-            if (!entMan.TryGetComponent<IContainerManager?>(entity, out var containermanager))
-                containermanager = entMan.AddComponent<ContainerManagerComponent>(entity);
-
+            var containermanager = entMan.EnsureComponent<ContainerManagerComponent>(entity);
             return containermanager.MakeContainer<T>(containerId);
         }
 

--- a/Robust.Shared/Containers/ContainerHelpers.cs
+++ b/Robust.Shared/Containers/ContainerHelpers.cs
@@ -90,9 +90,9 @@ namespace Robust.Shared.Containers
                 wasInContainer = true;
 
                 if (!force)
-                    return container.Remove(entity);
+                    return container.Remove(entity, entMan);
 
-                container.ForceRemove(entity);
+                container.ForceRemove(entity, entMan);
                 return true;
             }
 
@@ -162,7 +162,7 @@ namespace Robust.Shared.Containers
         private static bool TryInsertIntoContainer(this TransformComponent transform, IContainer container, IEntityManager? entMan = null)
         {
             IoCManager.Resolve(ref entMan);
-            if (container.Insert(transform.Owner)) return true;
+            if (container.Insert(transform.Owner, entMan)) return true;
 
             if (entMan.GetComponent<TransformComponent>(container.Owner).Parent != null
                 && TryGetContainer(container.Owner, out var newContainer, entMan))

--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
@@ -346,7 +346,7 @@ namespace Robust.Shared.GameObjects
             set
             {
                 if (_canCollide == value ||
-                    value && Owner.IsInContainer())
+                    value && Owner.IsInContainer(_entMan))
                     return;
 
                 _canCollide = value;

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.cs
@@ -868,7 +868,7 @@ namespace Robust.Shared.GameObjects
             }
 
             // MOCKS WHY
-            if (ent.TryGetContainer(out var container))
+            if (ent.TryGetContainer(out var container, _entityManager))
             {
                 return GetWorldAABB(container.Owner);
             }


### PR DESCRIPTION
AFAICT currently a single `TryRemoveFromContainer` could result in 4+ `IoCManager.Resolve<IEntityManager>()` calls.