### PR TITLE
Don't draw 0-mass non-hard fixtures as invalid

### DIFF
--- a/Robust.Client/Debugging/DebugPhysicsSystem.cs
+++ b/Robust.Client/Debugging/DebugPhysicsSystem.cs
@@ -209,8 +209,8 @@ namespace Robust.Client.Debugging
 
                     foreach (var fixture in _entityManager.GetComponent<FixturesComponent>(physBody.Owner).Fixtures.Values)
                     {
-                        // Invalid shape - Box2D doesn't check for IsSensor
-                        if (physBody.BodyType == BodyType.Dynamic && fixture.Mass == 0f)
+                        // Invalid shape - Box2D doesn't check for IsSensor but we will for sanity.
+                        if (physBody.BodyType == BodyType.Dynamic && fixture.Mass == 0f && fixture.Hard)
                         {
                             DrawShape(worldHandle, fixture, xform, Color.Red.WithAlpha(AlphaModifier));
                         }


### PR DESCRIPTION
Box2D does but this doesn't actually matter anywhere from memory.