### PR TITLE
Fix sprite bug

### DIFF
--- a/Robust.Client/Utility/DirExt.cs
+++ b/Robust.Client/Utility/DirExt.cs
@@ -65,11 +65,8 @@ namespace Robust.Client.Utility
 
         public static RSIDirection Convert(this Direction dir, RSI.State.DirectionType type)
         {
-            // Round down to a four-way direction if appropriate
-            if (type != RSI.State.DirectionType.Dir8)
-            {
-                return dir.Convert(RSI.State.DirectionType.Dir8).RoundToCardinal();
-            }
+            if (type == RSI.State.DirectionType.Dir1)
+                return RSIDirection.South;
 
             switch (dir)
             {
@@ -84,21 +81,24 @@ namespace Robust.Client.Utility
 
                 case Direction.West:
                     return RSIDirection.West;
-
-                case Direction.SouthEast:
-                    return RSIDirection.SouthEast;
-
-                case Direction.SouthWest:
-                    return RSIDirection.SouthWest;
-
-                case Direction.NorthEast:
-                    return RSIDirection.NorthEast;
-
-                case Direction.NorthWest:
-                    return RSIDirection.NorthWest;
             }
 
-            throw new ArgumentException($"Unknown dir: {dir}.", nameof(dir));
+            var rsiDir = dir switch
+            {
+                Direction.SouthEast => RSIDirection.SouthEast,
+                Direction.SouthWest => RSIDirection.SouthWest,
+                Direction.NorthEast => RSIDirection.NorthEast,
+                Direction.NorthWest => RSIDirection.NorthWest,
+                _ => throw new ArgumentException($"Unknown dir: {dir}.", nameof(dir))
+            };
+
+            // Round down to a four-way direction if appropriate.
+            if (type == RSI.State.DirectionType.Dir4)
+            {
+                return RoundToCardinal(rsiDir);
+            }
+
+            return rsiDir;
         }
 
         public static Direction TurnCw(this Direction dir)

--- a/Robust.Client/Utility/DirExt.cs
+++ b/Robust.Client/Utility/DirExt.cs
@@ -116,7 +116,8 @@ namespace Robust.Client.Utility
             return type switch
             {
                 RSI.State.DirectionType.Dir1 => RSIDirection.South,
-                RSI.State.DirectionType.Dir4 or RSI.State.DirectionType.Dir8 => angle.GetDir().Convert(type),
+                RSI.State.DirectionType.Dir4 => angle.GetCardinalDir().Convert(type),
+                RSI.State.DirectionType.Dir8 => angle.GetDir().Convert(type),
                 _ => throw new ArgumentOutOfRangeException($"Unknown rsi direction type: {type}.", nameof(type))
             };
         }


### PR DESCRIPTION
#2434 added a sprite rotation bug where 4-directional sprites directions were not properly converted from angles because of how the dir -> RSIdir "rounding" worked, leading to odd sprites at ~45 degree angles.

This fixes it by reverting ba67af2. This also updates the `Convert()` function to avoid unnecessary calls to `RoundToCardinal`