### PR TITLE
Make occluder use try get map

### DIFF
--- a/Robust.Client/GameObjects/Components/Light/ClientOccluderComponent.cs
+++ b/Robust.Client/GameObjects/Components/Light/ClientOccluderComponent.cs
@@ -40,13 +40,14 @@ namespace Robust.Client.GameObjects
 
         public void AnchorStateChanged()
         {
-            SendDirty();
+            var xform = _entityManager.GetComponent<TransformComponent>(Owner);
+            SendDirty(xform);
 
-            if(!_entityManager.GetComponent<TransformComponent>(Owner).Anchored)
+            if(!xform.Anchored)
                 return;
 
-            var grid = _mapManager.GetGrid(_entityManager.GetComponent<TransformComponent>(Owner).GridID);
-            _lastPosition = (_entityManager.GetComponent<TransformComponent>(Owner).GridID, grid.TileIndicesFor(_entityManager.GetComponent<TransformComponent>(Owner).Coordinates));
+            var grid = _mapManager.GetGrid(xform.GridID);
+            _lastPosition = (xform.GridID, grid.TileIndicesFor(xform.Coordinates));
         }
 
         protected override void Shutdown()
@@ -56,9 +57,10 @@ namespace Robust.Client.GameObjects
             SendDirty();
         }
 
-        private void SendDirty()
+        private void SendDirty(TransformComponent? xform = null)
         {
-            if (_entityManager.GetComponent<TransformComponent>(Owner).Anchored)
+            xform ??= _entityManager.GetComponent<TransformComponent>(Owner);
+            if (xform.Anchored)
             {
                 _entityManager.EventBus.RaiseEvent(EventSource.Local,
                     new OccluderDirtyEvent(Owner, _lastPosition));

--- a/Robust.Client/GameObjects/EntitySystems/ClientOccluderSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ClientOccluderSystem.cs
@@ -74,8 +74,11 @@ namespace Robust.Client.GameObjects
                 EntityManager.TryGetComponent(sender, out ClientOccluderComponent? iconSmooth)
                 && iconSmooth.Initialized)
             {
-                var grid1 = _mapManager.GetGrid(EntityManager.GetComponent<TransformComponent>(sender).GridID);
-                var coords = EntityManager.GetComponent<TransformComponent>(sender).Coordinates;
+                var xform = EntityManager.GetComponent<TransformComponent>(sender);
+                if (!_mapManager.TryGetGrid(xform.GridID, out var grid1))
+                    return;
+
+                var coords = xform.Coordinates;
 
                 _dirtyEntities.Enqueue(sender);
                 AddValidEntities(grid1.GetInDir(coords, Direction.North));


### PR DESCRIPTION
Seems to make `DummyIconTest` fail if other components set occlusion on init. Required for space-wizards/space-station-14/pull/6506. Also reduces transform component try-gets a bit.