### PR TITLE
Make AppearanceSystem public

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
@@ -6,7 +6,7 @@ using Robust.Shared.GameStates;
 namespace Robust.Client.GameObjects
 {
     [UsedImplicitly]
-    internal sealed class AppearanceSystem : SharedAppearanceSystem
+    public sealed class AppearanceSystem : SharedAppearanceSystem
     {
         private readonly Queue<ClientAppearanceComponent> _queuedUpdates = new();
 

--- a/Robust.Server/GameObjects/EntitySystems/AppearanceSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/AppearanceSystem.cs
@@ -3,7 +3,7 @@ using Robust.Shared.GameStates;
 
 namespace Robust.Server.GameObjects;
 
-internal sealed class AppearanceSystem : SharedAppearanceSystem
+public sealed class AppearanceSystem : SharedAppearanceSystem
 {
     public override void Initialize()
     {

--- a/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Serialization;
 
 namespace Robust.Shared.GameObjects;
 
-internal abstract class SharedAppearanceSystem : EntitySystem
+public abstract class SharedAppearanceSystem : EntitySystem
 {
     public virtual void MarkDirty(AppearanceComponent component) {}
 }


### PR DESCRIPTION
Is there any good reason for it to be internal? It would be useful in some instances to expose `MarkDirty()` for client-side systems