### PR TITLE
Abstract VisualizerSystem

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
@@ -100,9 +100,9 @@ namespace Robust.Client.GameObjects
     }
 
     /// <summary>
-    /// Raised whenever the appearance data for an entity changes.
+    ///     Raised whenever the appearance data for an entity changes.
     /// </summary>
-    public sealed class AppearanceChangeEvent : EntityEventArgs
+    public struct AppearanceChangeEvent
     {
         public AppearanceComponent Component = default!;
         public IReadOnlyDictionary<object, object> AppearanceData = default!;

--- a/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
@@ -102,6 +102,7 @@ namespace Robust.Client.GameObjects
     /// <summary>
     ///     Raised whenever the appearance data for an entity changes.
     /// </summary>
+    [ByRefEvent]
     public struct AppearanceChangeEvent
     {
         public AppearanceComponent Component = default!;

--- a/Robust.Client/GameObjects/EntitySystems/VisualizerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/VisualizerSystem.cs
@@ -17,6 +17,6 @@ public abstract class VisualizerSystem<T> : EntitySystem
         SubscribeLocalEvent<T, AppearanceChangeEvent>(OnAppearanceChange);
     }
 
-    protected abstract void OnComponentInit(EntityUid uid, T component, ComponentInit args);
-    protected abstract void OnAppearanceChange(EntityUid uid, T component, ref AppearanceChangeEvent args);
+    protected virtual void OnComponentInit(EntityUid uid, T component, ComponentInit args) {}
+    protected virtual void OnAppearanceChange(EntityUid uid, T component, ref AppearanceChangeEvent args) {}
 }

--- a/Robust.Client/GameObjects/EntitySystems/VisualizerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/VisualizerSystem.cs
@@ -13,10 +13,8 @@ public abstract class VisualizerSystem<T> : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<T, ComponentInit>(OnComponentInit);
         SubscribeLocalEvent<T, AppearanceChangeEvent>(OnAppearanceChange);
     }
 
-    protected virtual void OnComponentInit(EntityUid uid, T component, ComponentInit args) {}
     protected virtual void OnAppearanceChange(EntityUid uid, T component, ref AppearanceChangeEvent args) {}
 }

--- a/Robust.Client/GameObjects/EntitySystems/VisualizerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/VisualizerSystem.cs
@@ -1,0 +1,22 @@
+﻿using Robust.Shared.GameObjects;
+
+namespace Robust.Client.GameObjects;
+
+/// <summary>
+///     An abstract entity system inheritor for systems that deal with
+///     appearance data, replacing <see cref="AppearanceVisualizer"/>.
+/// </summary>
+public abstract class VisualizerSystem<T> : EntitySystem
+    where T: Component
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<T, ComponentInit>(OnComponentInit);
+        SubscribeLocalEvent<T, AppearanceChangeEvent>(OnAppearanceChange);
+    }
+
+    protected abstract void OnComponentInit(EntityUid uid, T component, ComponentInit args);
+    protected abstract void OnAppearanceChange(EntityUid uid, T component, AppearanceChangeEvent args);
+}

--- a/Robust.Client/GameObjects/EntitySystems/VisualizerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/VisualizerSystem.cs
@@ -18,5 +18,5 @@ public abstract class VisualizerSystem<T> : EntitySystem
     }
 
     protected abstract void OnComponentInit(EntityUid uid, T component, ComponentInit args);
-    protected abstract void OnAppearanceChange(EntityUid uid, T component, AppearanceChangeEvent args);
+    protected abstract void OnAppearanceChange(EntityUid uid, T component, ref AppearanceChangeEvent args);
 }


### PR DESCRIPTION
This introduces an abstract EntitySystem inheritor in the same vein as `VirtualController` or `GameRuleSystem` in SS14.

It just abstracts away having to create the event subscriptions for ComponentInit and OnChangeData, which is nice.

This also makes `AppearanceChangeEvent` ref struct, so it requires space-wizards/space-station-14#6571.