### PR TITLE
Optimise PVS recursion

### DIFF
--- a/Robust.Server/GameStates/PVSCollection.cs
+++ b/Robust.Server/GameStates/PVSCollection.cs
@@ -352,13 +352,13 @@ public sealed class PVSCollection<TIndex> : IPVSCollection where TIndex : ICompa
         var gridId = coordinates.GetGridId(_entityManager);
         if (gridId != GridId.Invalid)
         {
-            var gridIndices = GetChunkIndices(_mapManager.GetGrid(gridId).LocalToGrid(coordinates));
+            var gridIndices = GetChunkIndices(coordinates.Position);
             UpdateIndex(index, gridId, gridIndices, true); //skip overridecheck bc we already did it (saves some dict lookups)
             return;
         }
 
         var mapId = coordinates.GetMapId(_entityManager);
-        var mapIndices = GetChunkIndices(coordinates.ToMapPos(_entityManager));
+        var mapIndices = GetChunkIndices(coordinates.Position);
         UpdateIndex(index, mapId, mapIndices, true); //skip overridecheck bc we already did it (saves some dict lookups)
     }
 

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -182,18 +182,20 @@ internal sealed partial class PVSSystem : EntitySystem
 
     private void OnEntityMove(ref MoveEvent ev)
     {
+        var xformQuery = EntityManager.GetEntityQuery<TransformComponent>();
         var coordinates = _transform.GetMoverCoordinates(ev.Component);
-        UpdateEntityRecursive(ev.Sender, ev.Component, coordinates, false);
+        UpdateEntityRecursive(ev.Sender, ev.Component, coordinates, xformQuery, false);
     }
 
     private void OnTransformStartup(EntityUid uid, TransformComponent component, ComponentStartup args)
     {
         // use Startup because GridId is not set during the eventbus init yet!
+        var xformQuery = EntityManager.GetEntityQuery<TransformComponent>();
         var coordinates = _transform.GetMoverCoordinates(component);
-        UpdateEntityRecursive(uid, component, coordinates, false);
+        UpdateEntityRecursive(uid, component, coordinates, xformQuery, false);
     }
 
-    private void UpdateEntityRecursive(EntityUid uid, TransformComponent xform, EntityCoordinates coordinates, bool mover)
+    private void UpdateEntityRecursive(EntityUid uid, TransformComponent xform, EntityCoordinates coordinates, EntityQuery<TransformComponent> xformQuery, bool mover)
     {
         if (mover && !xform.LocalPosition.Equals(Vector2.Zero))
         {
@@ -209,7 +211,7 @@ internal sealed partial class PVSSystem : EntitySystem
 
         while (children.MoveNext(out var child))
         {
-            UpdateEntityRecursive(child.Value, Transform(child.Value), coordinates, true);
+            UpdateEntityRecursive(child.Value, xformQuery.GetComponent(child.Value), coordinates, xformQuery, true);
         }
     }
 

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -79,7 +79,7 @@ internal sealed partial class PVSSystem : EntitySystem
         _mapManager.OnGridRemoved += OnGridRemoved;
         _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
         SubscribeLocalEvent<MoveEvent>(OnEntityMove);
-        SubscribeLocalEvent<TransformComponent, ComponentInit>(OnTransformInit);
+        SubscribeLocalEvent<TransformComponent, ComponentStartup>(OnTransformStartup);
         EntityManager.EntityDeleted += OnEntityDeleted;
 
         _configManager.OnValueChanged(CVars.NetPVS, SetPvs, true);
@@ -170,30 +170,60 @@ internal sealed partial class PVSSystem : EntitySystem
 
     private void OnEntityMove(ref MoveEvent ev)
     {
-        UpdateEntityRecursive(ev.Sender, ev.Component);
+        var coordinates = GetMoverCoordinates(ev.Component);
+        UpdateEntityRecursive(ev.Sender, ev.Component, coordinates, false);
     }
 
-    private void OnTransformInit(EntityUid uid, TransformComponent component, ComponentInit args)
+    private void OnTransformStartup(EntityUid uid, TransformComponent component, ComponentStartup args)
     {
-        UpdateEntityRecursive(uid, component);
+        // use Startup because GridId is not set during the eventbus init yet!
+        var coordinates = GetMoverCoordinates(component);
+        UpdateEntityRecursive(uid, component, coordinates, false);
     }
 
-    private void UpdateEntityRecursive(EntityUid uid, TransformComponent? transformComponent = null)
+    private void UpdateEntityRecursive(EntityUid uid, TransformComponent xform, EntityCoordinates coordinates, bool mover)
     {
-        if(!Resolve(uid, ref transformComponent))
-            return;
+        // TODO: Need to vibe using EntityQuery<T> here for transforms / grid / map checks.
+        if (mover && !xform.LocalPosition.Equals(Vector2.Zero))
+        {
+            coordinates = GetMoverCoordinates(xform);
+        }
 
-        _entityPvsCollection.UpdateIndex(uid, transformComponent.Coordinates);
+        _entityPvsCollection.UpdateIndex(uid, coordinates);
 
         // since elements are cached grid-/map-relative, we dont need to update a given grids/maps children
         if(_mapManager.IsGrid(uid) || _mapManager.IsMap(uid)) return;
 
-        var children = transformComponent.ChildEnumerator;
+        var children = xform.ChildEnumerator;
 
         while (children.MoveNext(out var child))
         {
-            UpdateEntityRecursive(child.Value);
+            UpdateEntityRecursive(child.Value, Transform(child.Value), coordinates, true);
         }
+    }
+
+    public EntityCoordinates GetMoverCoordinates(TransformComponent xform)
+    {
+        // If they're parented directly to the map or grid then just return the coordinates.
+        if (!_mapManager.TryGetGrid(xform.GridID, out var grid))
+        {
+            var mapUid = _mapManager.GetMapEntityId(xform.MapID);
+            var coordinates = xform.Coordinates;
+
+            // Parented directly to the map.
+            if (xform.ParentUid == mapUid)
+                return coordinates;
+
+            return new EntityCoordinates(mapUid, coordinates.ToMapPos(EntityManager));
+        }
+
+        // Parented directly to the grid
+        if (grid.GridEntityId == xform.ParentUid)
+            return xform.Coordinates;
+
+        // Parented to grid so convert their pos back to the grid.
+        var gridPos = Transform(grid.GridEntityId).InvWorldMatrix.Transform(xform.WorldPosition);
+        return new EntityCoordinates(grid.GridEntityId, gridPos);
     }
 
     private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs e)

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -100,5 +100,29 @@ namespace Robust.Shared.GameObjects
                 }
             }
         }
+
+        public EntityCoordinates GetMoverCoordinates(TransformComponent xform)
+        {
+            // If they're parented directly to the map or grid then just return the coordinates.
+            if (!_mapManager.TryGetGrid(xform.GridID, out var grid))
+            {
+                var mapUid = _mapManager.GetMapEntityId(xform.MapID);
+                var coordinates = xform.Coordinates;
+
+                // Parented directly to the map.
+                if (xform.ParentUid == mapUid)
+                    return coordinates;
+
+                return new EntityCoordinates(mapUid, coordinates.ToMapPos(EntityManager));
+            }
+
+            // Parented directly to the grid
+            if (grid.GridEntityId == xform.ParentUid)
+                return xform.Coordinates;
+
+            // Parented to grid so convert their pos back to the grid.
+            var gridPos = Transform(grid.GridEntityId).InvWorldMatrix.Transform(xform.WorldPosition);
+            return new EntityCoordinates(grid.GridEntityId, gridPos);
+        }
     }
 }

--- a/Robust.UnitTesting/Shared/GameObjects/Systems/TransformSystemTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/Systems/TransformSystemTests.cs
@@ -47,6 +47,42 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             }
         }
 
+        /// <summary>
+        /// Checks that the MoverCoordinates between parent and children is correct.
+        /// </summary>
+        [Test]
+        public void MoverCoordinatesCorrect()
+        {
+            var sim = SimulationFactory();
+            var entManager = sim.Resolve<IEntityManager>();
+            var xformSystem = sim.Resolve<IEntitySystemManager>().GetEntitySystem<SharedTransformSystem>();
+            var mapId = new MapId(1);
+
+            var parent = entManager.SpawnEntity(null, new MapCoordinates(Vector2.One, mapId));
+            var xform = entManager.GetComponent<TransformComponent>(parent);
+            Assert.That(xform.LocalPosition, Is.EqualTo(Vector2.One));
+
+            var child1 = entManager.SpawnEntity(null, new MapCoordinates(Vector2.One, mapId));
+            var child2 = entManager.SpawnEntity(null, new MapCoordinates(new Vector2(10f, 10f), mapId));
+
+            var child1Xform = entManager.GetComponent<TransformComponent>(child1);
+            var child2Xform = entManager.GetComponent<TransformComponent>(child2);
+            child1Xform.AttachParent(xform);
+            child2Xform.AttachParent(xform);
+
+            var mover1 = xformSystem.GetMoverCoordinates(child1Xform);
+            var mover2 = xformSystem.GetMoverCoordinates(child2Xform);
+
+            Assert.That(mover1.Position, Is.EqualTo(Vector2.One));
+            Assert.That(mover2.Position, Is.EqualTo(new Vector2(10f, 10f)));
+
+            var child3 = entManager.SpawnEntity(null, new MapCoordinates(Vector2.One, mapId));
+            var child3Xform = entManager.GetComponent<TransformComponent>(child3);
+            child3Xform.AttachParent(child2Xform);
+
+            Assert.That(xformSystem.GetMoverCoordinates(child3Xform).Position, Is.EqualTo(Vector2.One));
+        }
+
         private sealed class Subscriber : IEntityEventSubscriber { }
     }
 }


### PR DESCRIPTION
Before:
![old_pvs](https://user-images.githubusercontent.com/31366439/153212370-5238121e-fb15-4272-af6d-acd4e5723034.JPG)

After:
![new_pvs](https://user-images.githubusercontent.com/31366439/153212359-9ee16671-21a2-4612-8d4a-f0b265991776.JPG)

40 pathfinding dummies with gear on over a minute.

Gonna go for the easy wins before I start trying to get the hard ones.

@PaulRitter 