### PR TITLE
More physics ECS

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.Fixtures.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.Fixtures.cs
@@ -1,0 +1,105 @@
+using Robust.Shared.IoC;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Dynamics;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.GameObjects;
+
+public abstract partial class SharedPhysicsSystem
+{
+    [Dependency] private readonly FixtureSystem _fixtures = default!;
+
+    #region Collision Masks & Layers
+
+    public void AddCollisionMask(FixturesComponent component, Fixture fixture, int mask)
+    {
+        if ((fixture.CollisionMask & mask) == mask) return;
+
+        DebugTools.Assert(component.Fixtures.ContainsKey(fixture.ID));
+        fixture._collisionMask |= mask;
+
+        if (TryComp<PhysicsComponent>(component.Owner, out var body))
+        {
+            _fixtures.FixtureUpdate(component, body);
+        }
+
+        _broadphaseSystem.Refilter(fixture);
+    }
+
+    public void SetCollisionMask(FixturesComponent component, Fixture fixture, int mask)
+    {
+        if (fixture.CollisionMask == mask) return;
+
+        DebugTools.Assert(component.Fixtures.ContainsKey(fixture.ID));
+        fixture._collisionMask = mask;
+
+        if (TryComp<PhysicsComponent>(component.Owner, out var body))
+        {
+            _fixtures.FixtureUpdate(component, body);
+        }
+
+        _broadphaseSystem.Refilter(fixture);
+    }
+
+    public void RemoveCollisionMask(FixturesComponent component, Fixture fixture, int mask)
+    {
+        if ((fixture.CollisionMask & mask) == 0x0) return;
+
+        DebugTools.Assert(component.Fixtures.ContainsKey(fixture.ID));
+        fixture._collisionMask &= ~mask;
+
+        if (TryComp<PhysicsComponent>(component.Owner, out var body))
+        {
+            _fixtures.FixtureUpdate(component, body);
+        }
+
+        _broadphaseSystem.Refilter(fixture);
+    }
+
+    public void AddCollisionLayer(FixturesComponent component, Fixture fixture, int layer)
+    {
+        if ((fixture.CollisionLayer & layer) == layer) return;
+
+        DebugTools.Assert(component.Fixtures.ContainsKey(fixture.ID));
+        fixture._collisionLayer |= layer;
+
+        if (TryComp<PhysicsComponent>(component.Owner, out var body))
+        {
+            _fixtures.FixtureUpdate(component, body);
+        }
+
+        _broadphaseSystem.Refilter(fixture);
+    }
+
+    public void SetCollisionLayer(FixturesComponent component, Fixture fixture, int layer)
+    {
+        if (fixture.CollisionLayer == layer) return;
+
+        DebugTools.Assert(component.Fixtures.ContainsKey(fixture.ID));
+        fixture._collisionLayer = layer;
+
+        if (TryComp<PhysicsComponent>(component.Owner, out var body))
+        {
+            _fixtures.FixtureUpdate(component, body);
+        }
+
+        _broadphaseSystem.Refilter(fixture);
+    }
+
+    public void RemoveCollisionLayer(FixturesComponent component, Fixture fixture, int layer)
+    {
+        if ((fixture.CollisionLayer & layer) == 0x0) return;
+
+        DebugTools.Assert(component.Fixtures.ContainsKey(fixture.ID));
+        fixture._collisionLayer &= ~layer;
+
+        if (TryComp<PhysicsComponent>(component.Owner, out var body))
+        {
+            _fixtures.FixtureUpdate(component, body);
+        }
+
+        _broadphaseSystem.Refilter(fixture);
+    }
+
+    #endregion
+}

--- a/Robust.Shared/Physics/Dynamics/Fixture.cs
+++ b/Robust.Shared/Physics/Dynamics/Fixture.cs
@@ -190,7 +190,7 @@ namespace Robust.Shared.Physics.Dynamics
         }
 
         [DataField("layer", customTypeSerializer: typeof(FlagSerializer<CollisionLayer>))]
-        private int _collisionLayer;
+        internal int _collisionLayer;
 
         /// <summary>
         ///  Bitmask of the layers this component collides with.
@@ -211,7 +211,7 @@ namespace Robust.Shared.Physics.Dynamics
         }
 
         [DataField("mask", customTypeSerializer: typeof(FlagSerializer<CollisionMask>))]
-        private int _collisionMask;
+        internal int _collisionMask;
 
         public float Area
         {

--- a/Robust.Shared/Physics/FixtureSystem.cs
+++ b/Robust.Shared/Physics/FixtureSystem.cs
@@ -375,9 +375,7 @@ namespace Robust.Shared.Physics
         public void FixtureUpdate(FixturesComponent component, PhysicsComponent? body = null)
         {
             if (!Resolve(component.Owner, ref body))
-            {
                 return;
-            }
 
             var mask = 0;
             var layer = 0;
@@ -396,7 +394,7 @@ namespace Robust.Shared.Physics
             body.CollisionMask = mask;
             body.CollisionLayer = layer;
             body.Hard = hard;
-            component.Dirty();
+            Dirty(component);
         }
 
         [Serializable, NetSerializable]

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -402,23 +402,18 @@ namespace Robust.Shared.Physics
         public void Refilter(Fixture fixture)
         {
             // TODO: Call this method whenever collisionmask / collisionlayer changes
-            if (fixture.Body == null) return;
+            // TODO: This should never becalled when body is null.
+            DebugTools.Assert(fixture.Body != null);
+            if (fixture.Body == null)
+            {
+                return;
+            }
 
             var body = fixture.Body;
 
-            var node = body.Contacts.First;
-
-            while (node != null)
+            foreach (var (_, contact) in fixture.Contacts)
             {
-                var contact = node.Value;
-                node = node.Next;
-                var fixtureA = contact.FixtureA;
-                var fixtureB = contact.FixtureB;
-
-                if (fixtureA == fixture || fixtureB == fixture)
-                {
-                    contact.FilterFlag = true;
-                }
+                contact.FilterFlag = true;
             }
 
             var broadphase = body.Broadphase;
@@ -426,7 +421,7 @@ namespace Robust.Shared.Physics
             // If nullspace or whatever ignore it.
             if (broadphase == null) return;
 
-            TouchProxies(EntityManager.GetComponent<TransformComponent>(fixture.Body.Owner).MapID, broadphase, fixture);
+            TouchProxies(Transform(fixture.Body.Owner).MapID, broadphase, fixture);
         }
 
         private void TouchProxies(MapId mapId, BroadphaseComponent broadphase, Fixture fixture)


### PR DESCRIPTION
1. Collision mask / layer settable via physics system (saves a few resolves and I have an atmos PR that wants it)
2. Refilter just iterates the fixture's contacts, instead of all of the body's contacts, because as of a recent PR they are also stored there (there was a box2d issue up for this and I implemented because it's huge savings for a body with many contacts)