### PR TITLE
Allow specifying that sprite layer offsets shouldn't rotate

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -211,6 +211,7 @@ namespace Robust.Client.GameObjects
                     layer.Color = layerDatum.Color;
                     layer.Rotation = layerDatum.Rotation;
                     layer._offset = layerDatum.Offset;
+                    layer.RotateOffset = layerDatum.RotateOffset;
                     // If neither state: nor texture: were provided we assume that they want a blank invisible layer.
                     layer.Visible = anyTextureAttempted && layerDatum.Visible;
                     layer.Scale = layerDatum.Scale;
@@ -1271,7 +1272,9 @@ namespace Robust.Client.GameObjects
 
                 var numDirs = GetLayerDirectionCount(layer);
                 var layerRotation = worldRotation + layer.Rotation;
-                var layerPosition = worldPosition + layerRotation.RotateVec(layer._offset + offset);
+                var layerPosition = worldPosition + (layer.RotateOffset
+                    ? layerRotation.RotateVec(layer._offset + offset)
+                    : layer._offset + offset);
 
                 CalcModelMatrix(numDirs, eyeRotation, layerRotation, layerPosition, out var modelMatrix);
                 Matrix3.Multiply(ref spriteMatrix, ref modelMatrix, out var transformMatrix);
@@ -1657,6 +1660,12 @@ namespace Robust.Client.GameObjects
             }
 
             internal Vector2 _offset;
+
+            /// <summary>
+            ///     Should this layer's offset change with layer rotation?
+            /// </summary>
+            [ViewVariables]
+            public bool RotateOffset = true;
 
             [ViewVariables]
             public DirectionOffset DirOffset { get; set; }

--- a/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
@@ -72,6 +72,8 @@ namespace Robust.Shared.GameObjects
             public Angle Rotation = Angle.Zero;
             [DataField("offset")]
             public Vector2 Offset = Vector2.Zero;
+            [DataField("rotateOffset")]
+            public bool RotateOffset = true;
             [DataField("visible")]
             public bool Visible = true;
             [DataField("color")]


### PR DESCRIPTION
This is useful for 'absolute' translations of a layer where you dont actually want it to change with rotation, like translating clothing sprites for SS14 (space-wizards/space-station-14#6644)