### PR TITLE
Enable Fluent logs for only .ftl files

### DIFF
--- a/Robust.Client/GameController/GameController.cs
+++ b/Robust.Client/GameController/GameController.cs
@@ -510,7 +510,7 @@ namespace Robust.Client
             logManager.GetSawmill("discord").Level = LogLevel.Warning;
             logManager.GetSawmill("net.predict").Level = LogLevel.Info;
             logManager.GetSawmill("szr").Level = LogLevel.Info;
-            logManager.GetSawmill("loc").Level = LogLevel.Error;
+            logManager.GetSawmill("loc").Level = LogLevel.Warning;
 
 #if DEBUG_ONLY_FCE_INFO
 #if DEBUG_ONLY_FCE_LOG

--- a/Robust.Shared/Localization/LocalizationManager.cs
+++ b/Robust.Shared/Localization/LocalizationManager.cs
@@ -47,7 +47,7 @@ namespace Robust.Shared.Localization
 
             if (!TryGetString(messageId, out var msg))
             {
-                _logSawmill.Warning("Unknown messageId ({culture}): {messageId}", _defaultCulture.Name, messageId);
+                _logSawmill.Debug("Unknown messageId ({culture}): {messageId}", _defaultCulture.Name, messageId);
                 msg = messageId;
             }
 
@@ -62,7 +62,7 @@ namespace Robust.Shared.Localization
 
             if (!TryGetString(messageId, out var msg, args0))
             {
-                _logSawmill.Warning("Unknown messageId ({culture}): {messageId}", _defaultCulture.Name, messageId);
+                _logSawmill.Debug("Unknown messageId ({culture}): {messageId}", _defaultCulture.Name, messageId);
                 msg = messageId;
             }
 


### PR DESCRIPTION
Due to overly restrictive log levels, `.ftl` parsing errors were silenced.

This commit will break `Content` because it was already broken.