### PR TITLE
Draw effects below FOV

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/EffectSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/EffectSystem.cs
@@ -323,7 +323,7 @@ namespace Robust.Client.GameObjects
         {
             private readonly IPlayerManager _playerManager;
 
-            public override OverlaySpace Space => OverlaySpace.WorldSpace;
+            public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowFOV;
 
             private readonly ShaderInstance _unshadedShader;
             private readonly EffectSystem _owner;


### PR DESCRIPTION
Feels like this should be content-controlled, but idk an easy way to do that

This has been a perennial problem with SS14 effects, you can see people hit shit through walls which is really annoying.