### PR TITLE
Force get PVS parents for viewers

### DIFF
--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -477,8 +477,7 @@ internal sealed partial class PVSSystem : EntitySystem
 
         foreach (var viewerEntity in viewerEntities)
         {
-            var xform = xformQuery.GetComponent(viewerEntity);
-            var parent = xform.ParentUid;
+            var parent = viewerEntity;
 
             while (parent.IsValid())
             {
@@ -488,9 +487,6 @@ internal sealed partial class PVSSystem : EntitySystem
                 var parentXform = xformQuery.GetComponent(parent);
                 parent = parentXform.ParentUid;
             }
-
-            TryAddToVisibleEnts(in viewerEntity, seenSet, playerVisibleSet, visibleEnts, fromTick, ref newEntitiesSent,
-                ref entitiesSent, mQuery, dontSkip: true);
         }
 
         foreach (var i in chunkIndices)

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -130,6 +130,7 @@ namespace Robust.Server.GameStates
 
             //todo paul oh my god make this less shit
             EntityQuery<MetaDataComponent> metadataQuery = default!;
+            EntityQuery<TransformComponent> transformQuery = default!;
             HashSet<int>[] playerChunks = default!;
             EntityUid[][] viewerEntities = default!;
             Dictionary<EntityUid, MetaDataComponent>?[] chunkCache = default!;
@@ -142,7 +143,7 @@ namespace Robust.Server.GameStates
                 var chunksCount = chunks.Count;
                 var chunkBatches = (int) MathF.Ceiling((float) chunksCount / ChunkBatchSize);
                 chunkCache = new Dictionary<EntityUid, MetaDataComponent>?[chunks.Count];
-                var transformQuery = _entityManager.GetEntityQuery<TransformComponent>();
+                transformQuery = _entityManager.GetEntityQuery<TransformComponent>();
                 metadataQuery = _entityManager.GetEntityQuery<MetaDataComponent>();
                 Parallel.For(0, chunkBatches, i =>
                 {
@@ -195,7 +196,7 @@ namespace Robust.Server.GameStates
 
                 var (entStates, deletions) = _pvs.CullingEnabled
                     ? _pvs.CalculateEntityStates(session, lastAck, _gameTiming.CurTick, chunkCache,
-                        playerChunks[sessionIndex], metadataQuery, viewerEntities[sessionIndex])
+                        playerChunks[sessionIndex], metadataQuery, transformQuery, viewerEntities[sessionIndex])
                     : _pvs.GetAllEntityStates(session, lastAck, _gameTiming.CurTick);
                 var playerStates = _playerManager.GetPlayerStates(lastAck);
                 var mapData = _mapManager.GetStateData(lastAck);


### PR DESCRIPTION
So replicating this on master is CBT (vv'ing your parent to something across the station is unreliable) but AFAICT when you go over-budget there's no guarantee the viewer parents are sent which is bad.

Don't merge without @PaulRitter approval