### PR TITLE
haha what if i just quickly fix pvs

### DIFF
--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -130,9 +130,10 @@ namespace Robust.Server.GameStates
 
             //todo paul oh my god make this less shit
             EntityQuery<MetaDataComponent> metadataQuery = default!;
+            EntityQuery<TransformComponent> transformQuery = default!;
             HashSet<int>[] playerChunks = default!;
             EntityUid[][] viewerEntities = default!;
-            Dictionary<EntityUid, MetaDataComponent>?[] chunkCache = default!;
+            (Dictionary<EntityUid, MetaDataComponent> metadata, List<EntityUid> order)?[] chunkCache = default!;
 
             if (_pvs.CullingEnabled)
             {
@@ -141,8 +142,9 @@ namespace Robust.Server.GameStates
                 const int ChunkBatchSize = 2;
                 var chunksCount = chunks.Count;
                 var chunkBatches = (int) MathF.Ceiling((float) chunksCount / ChunkBatchSize);
-                chunkCache = new Dictionary<EntityUid, MetaDataComponent>?[chunks.Count];
-                var transformQuery = _entityManager.GetEntityQuery<TransformComponent>();
+                chunkCache =
+                    new (Dictionary<EntityUid, MetaDataComponent> metadata, List<EntityUid> order)?[chunksCount];
+                transformQuery = _entityManager.GetEntityQuery<TransformComponent>();
                 metadataQuery = _entityManager.GetEntityQuery<MetaDataComponent>();
                 Parallel.For(0, chunkBatches, i =>
                 {
@@ -195,7 +197,7 @@ namespace Robust.Server.GameStates
 
                 var (entStates, deletions) = _pvs.CullingEnabled
                     ? _pvs.CalculateEntityStates(session, lastAck, _gameTiming.CurTick, chunkCache,
-                        playerChunks[sessionIndex], metadataQuery, viewerEntities[sessionIndex])
+                        playerChunks[sessionIndex], metadataQuery, transformQuery, viewerEntities[sessionIndex])
                     : _pvs.GetAllEntityStates(session, lastAck, _gameTiming.CurTick);
                 var playerStates = _playerManager.GetPlayerStates(lastAck);
                 var mapData = _mapManager.GetStateData(lastAck);


### PR DESCRIPTION
so this has a few changes i wanna make you aware about, incase you want to object

firstly, i added a list to the chunkcache since i rely on insertionorder of the chunkcache to send entities in order, but i cant rely on the dict to not fuck it up. ordereddictionary is explicitly said to be shite at insertion, so here i got making my own.

additionally, i changed local & globaloverrides, as well as viewerentities to manually recursively add their parents. now this uses getcomp calls, which is slow. therefore, i moved the adding of chunks to a given playerstate infront of the iteration of the overrides & viewers, meaning if they were already included in the chunks (they are 99% of the time), they will be skipped and an expensive getcomp call can get avoided.
this however means that the budget will be even less enforced, since now the max (worstcase) entities sent per tick will be budget+overridecount, where before it was simply overridecount.

anyways, pls merge before the americans start playing so that we can actually check if its fixed now.