### PR TITLE
RobustUnitTest tweaks

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -82,6 +82,7 @@ namespace Robust.Shared.GameObjects
             if (Started)
                 throw new InvalidOperationException("Startup() called multiple times");
 
+            // TODO: Probably better to call this on its own given it's so infrequent.
             EntitySystemManager.Initialize();
             Started = true;
         }
@@ -276,7 +277,7 @@ namespace Robust.Shared.GameObjects
 
         private void RecursiveDeleteEntity(EntityUid uid)
         {
-            if (!TryGetComponent(uid, out MetaDataComponent metadata) || metadata.EntityDeleted) 
+            if (!TryGetComponent(uid, out MetaDataComponent metadata) || metadata.EntityDeleted)
                 return; //TODO: Why was this still a child if it was already deleted?
 
             var transform = GetComponent<TransformComponent>(uid);

--- a/Robust.Shared/GameObjects/EntitySystemManager.cs
+++ b/Robust.Shared/GameObjects/EntitySystemManager.cs
@@ -105,14 +105,29 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public void Initialize()
+        public void Initialize(bool discover = true)
         {
+            // Tempted to make this an assert
+            // However, EntityManager calls this directly so we'd need to remove that and manually call it.
+            if (_initialized) return;
+
             var excludedTypes = new HashSet<Type>();
 
             _systemDependencyCollection = new(IoCManager.Instance!);
             var subTypes = new Dictionary<Type, Type>();
             _systemTypes.Clear();
-            foreach (var type in _reflectionManager.GetAllChildren<IEntitySystem>().Concat(_extraLoadedTypes))
+            IEnumerable<Type> systems;
+
+            if (discover)
+            {
+                systems = _reflectionManager.GetAllChildren<IEntitySystem>().Concat(_extraLoadedTypes);
+            }
+            else
+            {
+                systems = _extraLoadedTypes;
+            }
+
+            foreach (var type in systems)
             {
                 Logger.DebugS("go.sys", "Initializing entity system {0}", type);
 
@@ -251,6 +266,7 @@ namespace Robust.Shared.GameObjects
 
         public void Clear()
         {
+            _extraLoadedTypes.Clear();
             _systemTypes.Clear();
             _updateOrder = Array.Empty<UpdateReg>();
             _frameUpdateOrder = Array.Empty<IEntitySystem>();

--- a/Robust.Shared/GameObjects/IEntitySystemManager.cs
+++ b/Robust.Shared/GameObjects/IEntitySystemManager.cs
@@ -89,8 +89,9 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         /// Initialize, discover systems and initialize them through <see cref="IEntitySystem.Initialize"/>.
         /// </summary>
+        /// <param name="discover">Whether we should automatically find systems or have they been supplied already.</param>
         /// <seealso cref="IEntitySystem.Initialize"/>
-        void Initialize();
+        void Initialize(bool discover = true);
 
         /// <summary>
         /// Clean up, shut down all systems through <see cref="IEntitySystem.Shutdown"/> and remove them.

--- a/Robust.UnitTesting/RobustUnitTest.cs
+++ b/Robust.UnitTesting/RobustUnitTest.cs
@@ -3,16 +3,19 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
+using Robust.Server.Containers;
 using Robust.Server.GameObjects;
 using Robust.Server.Physics;
 using Robust.Shared;
 using Robust.Shared.Configuration;
+using Robust.Shared.Containers;
 using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Dynamics;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Reflection;
 using Robust.Shared.Utility;
 using GridFixtureSystem = Robust.Client.GameObjects.GridFixtureSystem;
@@ -73,21 +76,22 @@ namespace Robust.UnitTesting
 
             configurationManager.LoadCVarsFromAssembly(typeof(RobustUnitTest).Assembly);
 
-            // Required systems
             var systems = IoCManager.Resolve<IEntitySystemManager>();
-            systems.Initialize();
+            // Required systems
+            systems.LoadExtraSystemType<ContainerSystem>();
+            systems.LoadExtraSystemType<TransformSystem>();
 
             var entMan = IoCManager.Resolve<IEntityManager>();
-
-            if(entMan.EventBus == null)
-            {
-                entMan.Initialize();
-                entMan.Startup();
-            }
-
-            IoCManager.Resolve<IEntityLookup>().Startup();
             var mapMan = IoCManager.Resolve<IMapManager>();
+
+            // So by default EntityManager does its own EntitySystemManager initialize during Startup.
+            // We want to bypass this and load our own systems hence we will manually initialize it here.
+            entMan.Initialize();
             mapMan.Initialize();
+            systems.Initialize();
+
+            // TODO: Make this a system and it should be covered off by the above.
+            IoCManager.Resolve<IEntityLookup>().Startup();
 
             IoCManager.Resolve<IReflectionManager>().LoadAssemblies(assemblies);
 
@@ -123,11 +127,7 @@ namespace Robust.UnitTesting
                 compFactory.RegisterClass<FixturesComponent>();
             }
 
-            if(entMan.EventBus == null)
-            {
-                entMan.Startup();
-            }
-
+            entMan.Startup();
             mapMan.Startup();
         }
 

--- a/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
@@ -39,6 +39,7 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
   - type: Transform
   - type: Map
     index: 123
+  # Due to the map getting initialised last this seemed easiest to fix the test while removing the mocks.
   - type: EntityLookup
 ";
 

--- a/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
@@ -39,6 +39,7 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
   - type: Transform
   - type: Map
     index: 123
+  - type: EntityLookup
 ";
 
         private MapId MapA;
@@ -47,18 +48,6 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
         private IMapGrid GridB = default!;
 
         private static readonly EntityCoordinates InitialPos = new(new EntityUid(1), (0, 0));
-
-        protected override void OverrideIoC()
-        {
-            base.OverrideIoC();
-            var mock = new Mock<IEntitySystemManager>();
-            var broady = new BroadPhaseSystem();
-            var physics = new PhysicsSystem();
-            mock.Setup(m => m.GetEntitySystem<SharedBroadphaseSystem>()).Returns(broady);
-            mock.Setup(m => m.GetEntitySystem<SharedPhysicsSystem>()).Returns(physics);
-
-            IoCManager.RegisterInstance<IEntitySystemManager>(mock.Object, true);
-        }
 
         [OneTimeSetUp]
         public void Setup()

--- a/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
+++ b/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
@@ -3,6 +3,7 @@ using Moq;
 using NUnit.Framework;
 using Robust.Server.Containers;
 using Robust.Server.GameObjects;
+using Robust.Server.GameStates;
 using Robust.Server.Maps;
 using Robust.Server.Physics;
 using Robust.Shared.Containers;
@@ -60,39 +61,16 @@ entities:
 
 ";
 
-        protected override void OverrideIoC()
-        {
-            base.OverrideIoC();
-            //var mockFormat = new Mock<ICustomFormatManager>();
-            var mock = new Mock<IEntitySystemManager>();
-            var broady = new BroadPhaseSystem();
-            var physics = new PhysicsSystem();
-            var gridFixtures = new GridFixtureSystem();
-            var fixtures = new FixtureSystem();
-            var con = new ContainerSystem();
-
-            // MOCKS WHY
-            mock.Setup(m => m.GetEntitySystem<SharedBroadphaseSystem>()).Returns(broady);
-            mock.Setup(m => m.GetEntitySystem<SharedPhysicsSystem>()).Returns(physics);
-            mock.Setup(m => m.GetEntitySystem<GridFixtureSystem>()).Returns(gridFixtures);
-            mock.Setup(m => m.GetEntitySystem<SharedContainerSystem>()).Returns(con);
-            mock.Setup(m => m.GetEntitySystem<FixtureSystem>()).Returns(fixtures);
-
-            IoCManager.RegisterInstance<IEntitySystemManager>(mock.Object, true);
-            //IoCManager.RegisterInstance<ICustomFormatManager>(mockFormat.Object, true);
-
-            // Mocking moment...
-            IoCManager.BuildGraph();
-            IoCManager.RegisterInstance<SharedBroadphaseSystem>(broady);
-            IoCManager.InjectDependencies(fixtures);
-        }
-
-
         [OneTimeSetUp]
         public void Setup()
         {
+            var syssy = IoCManager.Resolve<IEntitySystemManager>();
+            syssy.Clear();
+            syssy.Initialize();
+
             var compFactory = IoCManager.Resolve<IComponentFactory>();
             compFactory.RegisterClass<MapDeserializeTestComponent>();
+            compFactory.RegisterClass<VisibilityComponent>();
             compFactory.GenerateNetIds();
             IoCManager.Resolve<ISerializationManager>().Initialize();
 

--- a/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
+++ b/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
@@ -64,6 +64,7 @@ entities:
         [OneTimeSetUp]
         public void Setup()
         {
+            // For some reason RobustUnitTest doesn't discover PVSSystem but this does here so ?
             var syssy = IoCManager.Resolve<IEntitySystemManager>();
             syssy.Clear();
             syssy.Initialize();

--- a/Robust.UnitTesting/Shared/GameObjects/EntitySystemManager_Tests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntitySystemManager_Tests.cs
@@ -51,7 +51,14 @@ namespace Robust.UnitTesting.Shared.GameObjects
         [OneTimeSetUp]
         public void Setup()
         {
-            IoCManager.Resolve<IEntitySystemManager>().Initialize();
+            var syssy = IoCManager.Resolve<IEntitySystemManager>();
+            syssy.Clear();
+            syssy.LoadExtraSystemType<ESystemA>();
+            syssy.LoadExtraSystemType<ESystemB>();
+            syssy.LoadExtraSystemType<ESystemC>();
+            syssy.LoadExtraSystemType<ESystemDepA>();
+            syssy.LoadExtraSystemType<ESystemDepB>();
+            syssy.Initialize(false);
         }
 
         [Test]

--- a/Robust.UnitTesting/Shared/Map/EntityCoordinates_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/EntityCoordinates_Tests.cs
@@ -25,18 +25,6 @@ namespace Robust.UnitTesting.Shared.Map
   components:
   - type: Transform";
 
-        protected override void OverrideIoC()
-        {
-            base.OverrideIoC();
-            var mock = new Mock<IEntitySystemManager>();
-            var broady = new BroadPhaseSystem();
-            var physics = new PhysicsSystem();
-            mock.Setup(m => m.GetEntitySystem<SharedBroadphaseSystem>()).Returns(broady);
-            mock.Setup(m => m.GetEntitySystem<SharedPhysicsSystem>()).Returns(physics);
-
-            IoCManager.RegisterInstance<IEntitySystemManager>(mock.Object, true);
-        }
-
         [OneTimeSetUp]
         public void Setup()
         {


### PR DESCRIPTION
- EntitySystemManager can now be set now to automatically do reflection (VERY useful for unit tests)
- EntitySystemManager clearing works (it never cleared extra loaded types on its own which is also useful)
- Removed some mocks that weren't necessary (just leads to more maintenance CBT)
- EntityManager + MapManager initialisation order now matches the game's order

This should fix most of the CBT I had with making mapmanager a system / fixing up entitylookup.