### PR TITLE
Benchmarks for EntityManager

### DIFF
--- a/Robust.Benchmarks/EntityManager/AddRemoveComponentBenchmark.cs
+++ b/Robust.Benchmarks/EntityManager/AddRemoveComponentBenchmark.cs
@@ -1,0 +1,54 @@
+using BenchmarkDotNet.Attributes;
+using JetBrains.Annotations;
+using Robust.Shared.Analyzers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.UnitTesting.Server;
+
+namespace Robust.Benchmarks.EntityManager;
+
+[Virtual]
+public class AddRemoveComponentBenchmark
+{
+    private ISimulation _simulation = default!;
+    private IEntityManager _entityManager = default!;
+
+    [UsedImplicitly]
+    [Params(1, 10, 100, 1000)]
+    public int N;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _simulation = RobustServerSimulation
+            .NewSimulation()
+            .RegisterComponents(f => f.RegisterClass<A>())
+            .InitializeInstance();
+
+        _entityManager = _simulation.Resolve<IEntityManager>();
+
+        var coords = new MapCoordinates(0, 0, new MapId(1));
+        _simulation.AddMap(coords.MapId);
+
+        for (var i = 0; i < N; i++)
+        {
+            _entityManager.SpawnEntity(null, coords);
+        }
+    }
+
+    [Benchmark]
+    public void AddRemoveComponent()
+    {
+        for (var i = 2; i <= N+1; i++)
+        {
+            var uid = new EntityUid(i);
+            _entityManager.AddComponent<A>(uid);
+            _entityManager.RemoveComponent<A>(uid);
+        }
+    }
+
+    [ComponentProtoName("A")]
+    public sealed class A : Component
+    {
+    }
+}

--- a/Robust.Benchmarks/EntityManager/GetComponentBenchmark.cs
+++ b/Robust.Benchmarks/EntityManager/GetComponentBenchmark.cs
@@ -1,0 +1,61 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using JetBrains.Annotations;
+using Robust.Shared.Analyzers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.UnitTesting.Server;
+
+namespace Robust.Benchmarks.EntityManager;
+
+[Virtual]
+public class GetComponentBenchmark
+{
+    private ISimulation _simulation = default!;
+    private IEntityManager _entityManager = default!;
+
+    [UsedImplicitly]
+    [Params(1, 10, 100, 1000)]
+    public int N;
+
+    public A[] Comps = default!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _simulation = RobustServerSimulation
+            .NewSimulation()
+            .RegisterComponents(f => f.RegisterClass<A>())
+            .InitializeInstance();
+
+        _entityManager = _simulation.Resolve<IEntityManager>();
+
+        Comps = new A[N+2];
+
+        var coords = new MapCoordinates(0, 0, new MapId(1));
+        _simulation.AddMap(coords.MapId);
+
+        for (var i = 0; i < N; i++)
+        {
+            var uid = _entityManager.SpawnEntity(null, coords);
+            _entityManager.AddComponent<A>(uid);
+        }
+    }
+
+    [Benchmark]
+    public A[] GetComponent()
+    {
+        for (var i = 2; i <= N+1; i++)
+        {
+            Comps[i] = _entityManager.GetComponent<A>(new EntityUid(i));
+        }
+
+        // Return something so the JIT doesn't optimize out all the GetComponent calls.
+        return Comps;
+    }
+
+    [ComponentProtoName("A")]
+    public sealed class A : Component
+    {
+    }
+}

--- a/Robust.Benchmarks/EntityManager/SpawnDeleteEntityBenchmark.cs
+++ b/Robust.Benchmarks/EntityManager/SpawnDeleteEntityBenchmark.cs
@@ -1,0 +1,62 @@
+using BenchmarkDotNet.Attributes;
+using JetBrains.Annotations;
+using Robust.Shared.Analyzers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.UnitTesting.Server;
+
+namespace Robust.Benchmarks.EntityManager;
+
+[Virtual]
+public class SpawnDeleteEntityBenchmark
+{
+    private ISimulation _simulation = default!;
+    private IEntityManager _entityManager = default!;
+
+    private MapCoordinates _mapCoords = MapCoordinates.Nullspace;
+    private EntityCoordinates _entCoords = EntityCoordinates.Invalid;
+
+    [UsedImplicitly]
+    [Params(1, 10, 100, 1000)]
+    public int N;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _simulation = RobustServerSimulation
+            .NewSimulation()
+            .RegisterComponents(f => f.RegisterClass<A>())
+            .InitializeInstance();
+
+        _entityManager = _simulation.Resolve<IEntityManager>();
+
+        _mapCoords = new MapCoordinates(0, 0, new MapId(1));
+        var uid = _simulation.AddMap(_mapCoords.MapId);
+        _entCoords = new EntityCoordinates(uid, 0, 0);
+    }
+
+    [Benchmark(Baseline = true)]
+    public void SpawnDeleteEntityMapCoords()
+    {
+        for (var i = 0; i < N; i++)
+        {
+            var uid = _entityManager.SpawnEntity(null, _mapCoords);
+            _entityManager.DeleteEntity(uid);
+        }
+    }
+
+    [Benchmark]
+    public void SpawnDeleteEntityEntCoords()
+    {
+        for (var i = 0; i < N; i++)
+        {
+            var uid = _entityManager.SpawnEntity(null, _entCoords);
+            _entityManager.DeleteEntity(uid);
+        }
+    }
+
+    [ComponentProtoName("A")]
+    public sealed class A : Component
+    {
+    }
+}

--- a/Robust.Benchmarks/Robust.Benchmarks.csproj
+++ b/Robust.Benchmarks/Robust.Benchmarks.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
       <ProjectReference Include="..\Robust.Server\Robust.Server.csproj" />
       <ProjectReference Include="..\Robust.Shared\Robust.Shared.csproj" />
+      <ProjectReference Include="..\Robust.UnitTesting\Robust.UnitTesting.csproj" />
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />

--- a/Robust.UnitTesting/AssemblyInfo.cs
+++ b/Robust.UnitTesting/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+// So it can use RobustServerSimulation.
+[assembly: InternalsVisibleTo("Robust.Benchmarks")]


### PR DESCRIPTION
Useful to measure any performance improvements made to `EntityManager`.

- AddRemoveComponentBenchmark
    - This benchmark adds a component to an entity, then immediately removes it.
- SpawnDeleteEntityBenchmark
    - This benchmark spawns an "empty" entity, then immediately deletes it. Tests both `SpawnEntity` overloads.
- GetComponentBenchmark
    - This benchmark gets a component on an entity.

We benchmark add/remove and spawn/delete together because otherwise it'd require `[IterationSetup]` or `[IterationCleanup]` which can mess up the results for microbenchmarks like these.

Do note that these use `RobustServerSimulation`, because in my opinion it's the simplest way to set up a working robust server "instance".