### PR TITLE
Layer draw depths / sorting

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/ISpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/ISpriteComponent.cs
@@ -176,7 +176,10 @@ namespace Robust.Client.GameObjects
         void LayerSetRSI(object layerKey, string rsiPath);
         void LayerSetRSI(int layer, ResourcePath rsiPath);
         void LayerSetRSI(object layerKey, ResourcePath rsiPath);
-
+        void LayerSetOffset(int layer, Vector2 offet);
+        void LayerSetOffset(object layerKey, Vector2 offet);
+        void LayerSetDrawDepthOverride(int layer, Dictionary<RSI.State.Direction, int>? depthOverride);
+        void LayerSetDrawDepthOverride(object layerKey, Dictionary<RSI.State.Direction, int>? depthOverride);
         void LayerSetScale(int layer, Vector2 scale);
         void LayerSetScale(object layerKey, Vector2 scale);
         void LayerSetRotation(int layer, Angle rotation);

--- a/Robust.Client/GameObjects/Components/Renderable/ISpriteLayer.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/ISpriteLayer.cs
@@ -15,6 +15,9 @@ namespace Robust.Client.GameObjects
 
         Angle Rotation { get; set; }
         Vector2 Scale { get; set; }
+        Vector2 Offset { get; set; }
+
+        int DrawDepth { get; set; }
 
         bool Visible { get; set; }
         Color Color { get; set; }

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1375,7 +1375,7 @@ namespace Robust.Client.GameObjects
             var angle = worldRotation + eyeRotation; // angle on-screen. Used to decide the direction of 4/8 directional RSIs
 
             // Sort layers by draw depth. This can be dependent on the RSI direction, and so it isn't pre-sorted.
-            List<QueuedLayer> sortedLayers = new(Layers.Count);
+            List<LayerEntry> sortedLayers = new(Layers.Count);
             foreach (var layer in Layers)
             {
                 if (!layer.Visible)
@@ -1402,9 +1402,12 @@ namespace Robust.Client.GameObjects
             }
         }
 
-        internal readonly struct QueuedLayer
+        /// <summary>
+        ///     Struct used for sorting layers & caching the `layer.GetActualState()` result.
+        /// </summary>
+        internal readonly struct LayerEntry
         {
-            public QueuedLayer(int depth, Layer layer, RSI.State? rsiState, RSIDirection direction)
+            public LayerEntry(int depth, Layer layer, RSI.State? rsiState, RSIDirection direction)
             {
                 Depth = depth;
                 Layer = layer;

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1169,7 +1169,7 @@ namespace Robust.Client.GameObjects
         {
             if (Layers.Count <= layer)
             {
-                Logger.ErrorS(LogCategory, "Layer with index '{0}' does not exist, cannot set color! Trace:\n{1}",
+                Logger.ErrorS(LogCategory, "Layer with index '{0}' does not exist, cannot set depth overrides! Trace:\n{1}",
                     layer, Environment.StackTrace);
                 return;
             }
@@ -1182,7 +1182,7 @@ namespace Robust.Client.GameObjects
         {
             if (!LayerMapTryGet(layerKey, out var layer))
             {
-                Logger.ErrorS(LogCategory, "Layer with key '{0}' does not exist, cannot set color! Trace:\n{1}",
+                Logger.ErrorS(LogCategory, "Layer with key '{0}' does not exist, cannot set depth overrides! Trace:\n{1}",
                     layerKey, Environment.StackTrace);
                 return;
             }

--- a/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
@@ -78,6 +78,8 @@ namespace Robust.Shared.GameObjects
             public Color Color = Color.White;
             [DataField("map")]
             public HashSet<string>? MapKeys;
+            [DataField("drawDepth")]
+            public int DrawDepth;
 
             public static PrototypeLayerData New()
             {


### PR DESCRIPTION
This PR adds a draw depth to sprite layers, which determines the order in which they are drawn. It also adds RSI-direction based overrides, so that you could choose to have a layer behind another if an entity is facing east or west.

The change is motivated bv space-wizards/space-station-14/issues/4387 and space-wizards/space-station-14/issues/4563, but is also required to fix some bugs that were introduced by space-wizards/space-station-14/pull/6252

I'm not sure about how I did the sorting. Initially I just kept an up to date list of pre-sorted layer indices and iterated over those in `RenderInternal()`. However, after adding support for the directional draw depths, you can't sort the layers without knowing the angle entity's angle, so afaik the sorting has to be done inside of `RenderInternal()`. I just did the sorting by creating a temporary list and using `,Sort()`, but I feel like there might be a better way of doing that?