### PR TITLE
Don't store contained entities on entitylookup

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/DebugEntityLookupSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/DebugEntityLookupSystem.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using Robust.Client.Graphics;
+using Robust.Shared.Console;
+using Robust.Shared.Containers;
+using Robust.Shared.Enums;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Utility;
+using Color = Robust.Shared.Maths.Color;
+
+namespace Robust.Client.GameObjects;
+
+public sealed class DebugEntityLookupCommand : IConsoleCommand
+{
+    public string Command => "togglelookup";
+    public string Description => "Shows / hides entitylookup bounds via an overlay";
+    public string Help => $"{Command}";
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        EntitySystem.Get<DebugEntityLookupSystem>().Enabled ^= true;
+    }
+}
+
+public sealed class DebugEntityLookupSystem : EntitySystem
+{
+    public bool Enabled
+    {
+        get => _enabled;
+        set
+        {
+            if (_enabled == value) return;
+
+            _enabled = value;
+
+            if (_enabled)
+            {
+                IoCManager.Resolve<IOverlayManager>().AddOverlay(
+                    new EntityLookupOverlay(
+                        EntityManager,
+                        Get<EntityLookupSystem>()));
+            }
+            else
+            {
+                IoCManager.Resolve<IOverlayManager>().RemoveOverlay<EntityLookupOverlay>();
+            }
+        }
+    }
+
+    private bool _enabled;
+}
+
+public sealed class EntityLookupOverlay : Overlay
+{
+    private IEntityManager _entityManager = default!;
+    private EntityLookupSystem _lookup = default!;
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+
+    public EntityLookupOverlay(IEntityManager entManager, EntityLookupSystem lookup)
+    {
+        _entityManager = entManager;
+        _lookup = lookup;
+    }
+
+    protected internal override void Draw(in OverlayDrawArgs args)
+    {
+        var worldHandle = args.WorldHandle;
+        var xformQuery = _entityManager.GetEntityQuery<TransformComponent>();
+
+        foreach (var lookup in _lookup.FindLookupsIntersecting(args.MapId, args.WorldBounds))
+        {
+            var lookupXform = xformQuery.GetComponent(lookup.Owner);
+
+            var (_, rotation, matrix, invMatrix) = lookupXform.GetWorldPositionRotationMatrixWithInv();
+
+            worldHandle.SetTransform(matrix);
+
+
+            var lookupAABB = invMatrix.TransformBox(args.WorldBounds);
+            var ents = new List<EntityUid>();
+
+            // Gonna allocate a lot but debug overlay sooo
+            lookup.Tree._b2Tree.FastQuery(ref lookupAABB, (ref EntityUid data) =>
+            {
+                ents.Add(data);
+            });
+
+            foreach (var ent in ents)
+            {
+                if (_entityManager.Deleted(ent)) continue;
+                var xform = xformQuery.GetComponent(ent);
+
+                //DebugTools.Assert(!ent.IsInContainer(_entityManager));
+
+                var lookupPos = invMatrix.Transform(xform.WorldPosition);
+                var lookupRot = xform.WorldRotation - rotation;
+
+                var aabb = _lookup.GetAABB(ent, lookupPos, lookupRot, xform, xformQuery);
+
+                worldHandle.DrawRect(aabb, Color.Blue.WithAlpha(0.2f));
+            }
+        }
+    }
+}

--- a/Robust.Client/GameObjects/EntitySystems/DebugEntityLookupSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/DebugEntityLookupSystem.cs
@@ -91,9 +91,10 @@ public sealed class EntityLookupOverlay : Overlay
                 var xform = xformQuery.GetComponent(ent);
 
                 //DebugTools.Assert(!ent.IsInContainer(_entityManager));
+                var (entPos, entRot) = xform.GetWorldPositionRotation();
 
-                var lookupPos = invMatrix.Transform(xform.WorldPosition);
-                var lookupRot = xform.WorldRotation - rotation;
+                var lookupPos = invMatrix.Transform(entPos);
+                var lookupRot = entRot - rotation;
 
                 var aabb = _lookup.GetAABB(ent, lookupPos, lookupRot, xform, xformQuery);
 

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -142,7 +142,7 @@ namespace Robust.Client.Graphics.Clyde
 
             var worldAABB = CalcWorldAABB(vp);
             var worldBounds = CalcWorldBounds(vp);
-            var args = new OverlayDrawArgs(space, vpControl, vp, handle, bounds, worldAABB, worldBounds);
+            var args = new OverlayDrawArgs(space, vpControl, vp, handle, bounds, vp.Eye!.Position.MapId, worldAABB, worldBounds);
 
             foreach (var overlay in list)
             {

--- a/Robust.Client/Graphics/Overlays/Overlay.cs
+++ b/Robust.Client/Graphics/Overlays/Overlay.cs
@@ -98,7 +98,7 @@ namespace Robust.Client.Graphics
                 handle = renderHandle.DrawingHandleWorld;
             }
 
-            var args = new OverlayDrawArgs(currentSpace, vpControl, vp, handle, screenBox, worldBox, worldBounds);
+            var args = new OverlayDrawArgs(currentSpace, vpControl, vp, handle, screenBox, vp.Eye!.Position.MapId, worldBox, worldBounds);
 
             Draw(args);
         }

--- a/Robust.Client/Graphics/Overlays/OverlayDrawArgs.cs
+++ b/Robust.Client/Graphics/Overlays/OverlayDrawArgs.cs
@@ -1,6 +1,7 @@
 ﻿using JetBrains.Annotations;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.Enums;
+using Robust.Shared.Map;
 using Robust.Shared.Maths;
 
 namespace Robust.Client.Graphics
@@ -39,6 +40,11 @@ namespace Robust.Client.Graphics
         public readonly UIBox2i ViewportBounds;
 
         /// <summary>
+        /// <see cref="MapId"/> of the viewport's eye.
+        /// </summary>
+        public readonly MapId MapId;
+
+        /// <summary>
         ///     AABB enclosing the area visible in the viewport.
         /// </summary>
         public readonly Box2 WorldAABB;
@@ -57,6 +63,7 @@ namespace Robust.Client.Graphics
             IClydeViewport viewport,
             DrawingHandleBase drawingHandle,
             in UIBox2i viewportBounds,
+            in MapId mapId,
             in Box2 worldAabb,
             in Box2Rotated worldBounds)
         {
@@ -65,6 +72,7 @@ namespace Robust.Client.Graphics
             Viewport = viewport;
             DrawingHandle = drawingHandle;
             ViewportBounds = viewportBounds;
+            MapId = mapId;
             WorldAABB = worldAabb;
             WorldBounds = worldBounds;
         }

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -80,6 +80,45 @@ public sealed partial class EntityLookupSystem
 
     #endregion
 
+    #region Lookups
+
+    /// <summary>
+    /// Gets the relevant <see cref="EntityLookupComponent"/> that intersects the specified area.
+    /// </summary>
+    public IEnumerable<EntityLookupComponent> FindLookupsIntersecting(MapId mapId, Box2 worldAABB)
+    {
+        if (mapId == MapId.Nullspace) yield break;
+
+        var lookupQuery = EntityManager.GetEntityQuery<EntityLookupComponent>();
+
+        yield return lookupQuery.GetComponent(_mapManager.GetMapEntityId(mapId));
+
+        foreach (var grid in _mapManager.FindGridsIntersecting(mapId, worldAABB))
+        {
+            yield return lookupQuery.GetComponent(grid.GridEntityId);
+        }
+    }
+
+    /// <summary>
+    /// Gets the relevant <see cref="EntityLookupComponent"/> that intersects the specified area.
+    /// </summary>
+    public IEnumerable<EntityLookupComponent> FindLookupsIntersecting(MapId mapId, Box2Rotated worldBounds)
+    {
+        if (mapId == MapId.Nullspace) yield break;
+
+        var lookupQuery = EntityManager.GetEntityQuery<EntityLookupComponent>();
+
+        yield return lookupQuery.GetComponent(_mapManager.GetMapEntityId(mapId));
+
+        // Copy-paste with above but the query may differ slightly internally.
+        foreach (var grid in _mapManager.FindGridsIntersecting(mapId, worldBounds))
+        {
+            yield return lookupQuery.GetComponent(grid.GridEntityId);
+        }
+    }
+
+    #endregion
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Box2 GetLocalBounds(Vector2i gridIndices, ushort tileSize)
     {

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -1,9 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using JetBrains.Annotations;
 using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
@@ -26,9 +21,9 @@ namespace Robust.Shared.GameObjects
 
     public sealed partial class EntityLookupSystem : EntitySystem
     {
-        [IoC.Dependency] private readonly IMapManager _mapManager = default!;
-        [IoC.Dependency] private readonly SharedContainerSystem _container = default!;
-        [IoC.Dependency] private readonly SharedTransformSystem _transform = default!;
+        [Dependency] private readonly IMapManager _mapManager = default!;
+        [Dependency] private readonly SharedContainerSystem _container = default!;
+        [Dependency] private readonly SharedTransformSystem _transform = default!;
 
         private const int GrowthRate = 256;
 
@@ -167,7 +162,8 @@ namespace Robust.Shared.GameObjects
             if (!xformQuery.TryGetComponent(uid, out var xform) ||
                 xform.Anchored ||
                 _mapManager.IsMap(uid) ||
-                _mapManager.IsGrid(uid)) return;
+                _mapManager.IsGrid(uid) ||
+                _container.IsEntityInContainer(uid, xform)) return;
 
             var lookup = GetLookup(uid, xform, xformQuery);
 
@@ -414,7 +410,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         /// Get the AABB of an entity with the supplied position and angle. Tries to consider if the entity is in a container.
         /// </summary>
-        private Box2 GetAABB(EntityUid uid, Vector2 position, Angle angle, TransformComponent xform, EntityQuery<TransformComponent> xformQuery)
+        internal Box2 GetAABB(EntityUid uid, Vector2 position, Angle angle, TransformComponent xform, EntityQuery<TransformComponent> xformQuery)
         {
             // If we're in a container then we just use the container's bounds.
             if (_container.TryGetOuterContainer(uid, xform, out var container, xformQuery))


### PR DESCRIPTION
The movement updates on SS14 are killer.

If any other games using Robust really needs it we can add a preprocessor or cvar or something.

~6-7x faster

Just need to update methods to account for this.