### PR TITLE
Decrease error tolerance for angular velocity updates

### DIFF
--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
@@ -658,7 +658,10 @@ namespace Robust.Shared.GameObjects
                 if (value * value > 0.0f)
                     Awake = true;
 
-                if (MathHelper.CloseToPercent(_angularVelocity, value, 0.0001f))
+                // CloseToPercent tolerance needs to be small enough such that an angular velocity just above
+                // sleep-tolerance can damp down to sleeping.
+
+                if (MathHelper.CloseToPercent(_angularVelocity, value, 0.00001f))
                     return;
 
                 _angularVelocity = value;


### PR DESCRIPTION
The current tolerance prevents physics bodies from going to sleep. The current default angular sleep tolerance is ~0.005. At 60TPS an entity with angular velocity 0.01 and damping of 0.2 would have its velocity decrease to ~0.0099666, which is a small enough change that the current tolerances for the `CloseToPercent()` check passes and the value doesn't get updated. 

There will still be problems for entities with low innate drag coefficients, but this will fix the problem for most entities flung out into space.