### PR TITLE
Mark C# events on MapManager as Obsolete

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/GridRenderingSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/GridRenderingSystem.cs
@@ -1,0 +1,19 @@
+using Robust.Client.Graphics;
+using Robust.Shared.GameObjects;
+
+namespace Robust.Client.GameObjects;
+
+internal class GridRenderingSystem : EntitySystem
+{
+    private readonly IClydeInternal _clyde;
+
+    public GridRenderingSystem(IClydeInternal clyde)
+    {
+        _clyde = clyde;
+    }
+
+    public override void Initialize()
+    {
+        _clyde.RegisterGridEcsEvents();
+    }
+}

--- a/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
@@ -71,7 +71,8 @@ namespace Robust.Client.GameObjects
             UpdatesAfter.Add(typeof(PhysicsSystem));
 
             _mapManager.MapCreated += MapManagerOnMapCreated;
-            _mapManager.OnGridCreated += MapManagerOnGridCreated;
+
+            SubscribeLocalEvent<GridInitializeEvent>(MapManagerOnGridCreated);
 
             // Due to how recursion works, this must be done.
             SubscribeLocalEvent<MoveEvent>(AnythingMoved);
@@ -224,7 +225,6 @@ namespace Robust.Client.GameObjects
         {
             base.Shutdown();
             _mapManager.MapCreated -= MapManagerOnMapCreated;
-            _mapManager.OnGridCreated -= MapManagerOnGridCreated;
         }
 
         private void OnTreeRemove(EntityUid uid, RenderingTreeComponent component, ComponentRemove args)
@@ -253,9 +253,9 @@ namespace Robust.Client.GameObjects
             EntityManager.EnsureComponent<RenderingTreeComponent>(_mapManager.GetMapEntityId(e.Map));
         }
 
-        private void MapManagerOnGridCreated(MapId mapId, GridId gridId)
+        private void MapManagerOnGridCreated(GridInitializeEvent ev)
         {
-            EntityManager.EnsureComponent<RenderingTreeComponent>(_mapManager.GetGrid(gridId).GridEntityId);
+            EntityManager.EnsureComponent<RenderingTreeComponent>(_mapManager.GetGrid(ev.GridId).GridEntityId);
         }
 
         private RenderingTreeComponent? GetRenderTree(EntityUid entity, EntityQuery<TransformComponent> xforms)

--- a/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
@@ -70,7 +70,7 @@ namespace Robust.Client.GameObjects
             UpdatesAfter.Add(typeof(TransformSystem));
             UpdatesAfter.Add(typeof(PhysicsSystem));
 
-            _mapManager.MapCreated += MapManagerOnMapCreated;
+            SubscribeLocalEvent<MapChangedEvent>(MapManagerOnMapCreated);
 
             SubscribeLocalEvent<GridInitializeEvent>(MapManagerOnGridCreated);
 
@@ -221,12 +221,6 @@ namespace Robust.Client.GameObjects
         }
         #endregion
 
-        public override void Shutdown()
-        {
-            base.Shutdown();
-            _mapManager.MapCreated -= MapManagerOnMapCreated;
-        }
-
         private void OnTreeRemove(EntityUid uid, RenderingTreeComponent component, ComponentRemove args)
         {
             foreach (var sprite in component.SpriteTree)
@@ -243,9 +237,9 @@ namespace Robust.Client.GameObjects
             component.LightTree.Clear();
         }
 
-        private void MapManagerOnMapCreated(object? sender, MapEventArgs e)
+        private void MapManagerOnMapCreated(MapChangedEvent e)
         {
-            if (e.Map == MapId.Nullspace)
+            if (e.Destroyed || e.Map == MapId.Nullspace)
             {
                 return;
             }

--- a/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
@@ -186,7 +186,7 @@ namespace Robust.Client.Graphics.Clyde
             // Don't need to set it if we don't have an entry since lack of an entry is treated as dirty.
         }
 
-        private void _updateOnGridModified(object? sender, GridChangedEventArgs args)
+        private void _updateOnGridModified(GridModifiedEvent args)
         {
             foreach (var (pos, _) in args.Modified)
             {
@@ -196,21 +196,23 @@ namespace Robust.Client.Graphics.Clyde
             }
         }
 
-        private void _updateTileMapOnUpdate(object? sender, TileChangedEventArgs args)
+        private void _updateTileMapOnUpdate(TileChangedEvent args)
         {
             var grid = _mapManager.GetGrid(args.NewTile.GridIndex);
             var chunk = grid.GridTileToChunkIndices(new Vector2i(args.NewTile.X, args.NewTile.Y));
             _setChunkDirty(grid, chunk);
         }
 
-        private void _updateOnGridCreated(MapId mapId, GridId gridId)
+        private void _updateOnGridCreated(GridStartupEvent ev)
         {
+            var gridId = ev.GridId;
             Logger.DebugS("grid", $"Adding {gridId} to grid renderer");
             _mapChunkData.Add(gridId, new Dictionary<Vector2i, MapChunkData>());
         }
 
-        private void _updateOnGridRemoved(MapId mapId, GridId gridId)
+        private void _updateOnGridRemoved(GridRemovalEvent ev)
         {
+            var gridId = ev.GridId;
             Logger.DebugS("grid", $"Removing {gridId} from grid renderer");
 
             var data = _mapChunkData[gridId];

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -76,6 +76,11 @@ namespace Robust.Client.Graphics.Clyde
             return null;
         }
 
+        public void RegisterGridEcsEvents()
+        {
+            // Nada.
+        }
+
         public void SetWindowTitle(string title)
         {
             // Nada.

--- a/Robust.Client/Graphics/IClydeInternal.cs
+++ b/Robust.Client/Graphics/IClydeInternal.cs
@@ -61,5 +61,7 @@ namespace Robust.Client.Graphics
 
         /// <returns>Null if not running on X11.</returns>
         uint? GetX11WindowId();
+
+        void RegisterGridEcsEvents();
     }
 }

--- a/Robust.Client/Physics/PhysicsSystem.cs
+++ b/Robust.Client/Physics/PhysicsSystem.cs
@@ -37,7 +37,7 @@ namespace Robust.Client.Physics
             SimulateWorld((float) diff.TotalSeconds, true);
         }
 
-        protected override void HandleMapCreated(object? sender, MapEventArgs eventArgs)
+        protected override void HandleMapCreated(MapChangedEvent eventArgs)
         {
             if (eventArgs.Map == MapId.Nullspace) return;
             var mapUid = MapManager.GetMapEntityId(eventArgs.Map);

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -22,7 +22,7 @@ using Robust.Shared.Utility;
 
 namespace Robust.Client.Placement
 {
-    public sealed partial class PlacementManager : IPlacementManager, IDisposable
+    public sealed partial class PlacementManager : IPlacementManager, IDisposable, IEntityEventSubscriber
     {
         [Dependency] private readonly IClientNetManager NetworkManager = default!;
         [Dependency] public readonly IPlayerManager PlayerManager = default!;
@@ -185,7 +185,7 @@ namespace Robust.Client.Placement
                 _modeDictionary.Add(type.Name, type);
             }
 
-            MapManager.TileChanged += HandleTileChanged;
+            EntityManager.EventBus.SubscribeEvent<TileChangedEvent>(EventSource.Local, this, HandleTileChanged);
 
             _drawOverlay = new PlacementOverlay(this);
             _overlayManager.AddOverlay(_drawOverlay);
@@ -328,7 +328,7 @@ namespace Robust.Client.Placement
             }
         }
 
-        private void HandleTileChanged(object? sender, TileChangedEventArgs args)
+        private void HandleTileChanged(TileChangedEvent args)
         {
             var coords = MapManager.GetGrid(args.NewTile.GridIndex).GridTileToLocal(args.NewTile.GridIndices);
             _pendingTileChanges.RemoveAll(c => c.Item1 == coords);

--- a/Robust.Server/GameObjects/EntitySystems/PhysicsSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/PhysicsSystem.cs
@@ -1,4 +1,4 @@
-﻿using JetBrains.Annotations;
+using JetBrains.Annotations;
 using Robust.Server.Physics;
 using Robust.Shared;
 using Robust.Shared.Configuration;
@@ -37,7 +37,7 @@ namespace Robust.Server.GameObjects
             collideComp.BodyType = BodyType.Static;
         }
 
-        protected override void HandleMapCreated(object? sender, MapEventArgs eventArgs)
+        protected override void HandleMapCreated(MapChangedEvent eventArgs)
         {
             if (eventArgs.Map == MapId.Nullspace) return;
             var mapUid = MapManager.GetMapEntityIdOrThrow(eventArgs.Map);

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -97,8 +97,14 @@ internal sealed partial class PVSSystem : EntitySystem
         base.Initialize();
 
         _entityPvsCollection = RegisterPVSCollection<EntityUid>();
-        _mapManager.MapCreated += OnMapCreated;
-        _mapManager.MapDestroyed += OnMapDestroyed;
+
+        SubscribeLocalEvent<MapChangedEvent>(ev =>
+        {
+            if (ev.Created)
+                OnMapCreated(ev);
+            else
+                OnMapDestroyed(ev);
+        });
 
         SubscribeLocalEvent<GridInitializeEvent>(OnGridCreated);
         SubscribeLocalEvent<GridRemovalEvent>(OnGridRemoved);
@@ -126,8 +132,6 @@ internal sealed partial class PVSSystem : EntitySystem
         base.Shutdown();
 
         UnregisterPVSCollection(_entityPvsCollection);
-        _mapManager.MapCreated -= OnMapCreated;
-        _mapManager.MapDestroyed -= OnMapDestroyed;
         _playerManager.PlayerStatusChanged -= OnPlayerStatusChanged;
         EntityManager.EntityDeleted -= OnEntityDeleted;
 
@@ -285,7 +289,7 @@ internal sealed partial class PVSSystem : EntitySystem
         _entityPvsCollection.UpdateIndex(euid);
     }
 
-    private void OnMapDestroyed(object? sender, MapEventArgs e)
+    private void OnMapDestroyed(MapChangedEvent e)
     {
         foreach (var pvsCollection in _pvsCollections)
         {
@@ -293,7 +297,7 @@ internal sealed partial class PVSSystem : EntitySystem
         }
     }
 
-    private void OnMapCreated(object? sender, MapEventArgs e)
+    private void OnMapCreated(MapChangedEvent e)
     {
         foreach (var pvsCollection in _pvsCollections)
         {

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -99,8 +99,10 @@ internal sealed partial class PVSSystem : EntitySystem
         _entityPvsCollection = RegisterPVSCollection<EntityUid>();
         _mapManager.MapCreated += OnMapCreated;
         _mapManager.MapDestroyed += OnMapDestroyed;
-        _mapManager.OnGridCreated += OnGridCreated;
-        _mapManager.OnGridRemoved += OnGridRemoved;
+
+        SubscribeLocalEvent<GridInitializeEvent>(OnGridCreated);
+        SubscribeLocalEvent<GridRemovalEvent>(OnGridRemoved);
+
         _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
         SubscribeLocalEvent<MoveEvent>(OnEntityMove);
         SubscribeLocalEvent<TransformComponent, ComponentStartup>(OnTransformStartup);
@@ -126,8 +128,6 @@ internal sealed partial class PVSSystem : EntitySystem
         UnregisterPVSCollection(_entityPvsCollection);
         _mapManager.MapCreated -= OnMapCreated;
         _mapManager.MapDestroyed -= OnMapDestroyed;
-        _mapManager.OnGridCreated -= OnGridCreated;
-        _mapManager.OnGridRemoved -= OnGridRemoved;
         _playerManager.PlayerStatusChanged -= OnPlayerStatusChanged;
         EntityManager.EntityDeleted -= OnEntityDeleted;
 
@@ -265,16 +265,17 @@ internal sealed partial class PVSSystem : EntitySystem
         }
     }
 
-    private void OnGridRemoved(MapId mapId, GridId gridId)
+    private void OnGridRemoved(GridRemovalEvent ev)
     {
         foreach (var pvsCollection in _pvsCollections)
         {
-            pvsCollection.RemoveGrid(gridId);
+            pvsCollection.RemoveGrid(ev.GridId);
         }
     }
 
-    private void OnGridCreated(MapId mapId, GridId gridId)
+    private void OnGridCreated(GridInitializeEvent ev)
     {
+        var gridId = ev.GridId;
         foreach (var pvsCollection in _pvsCollections)
         {
             pvsCollection.AddGrid(gridId);

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -59,14 +59,13 @@ namespace Robust.Shared.GameObjects
             SubscribeLocalEvent<EntityTerminatingEvent>(OnTerminate);
 
             EntityManager.EntityInitialized += OnEntityInit;
-            _mapManager.MapCreated += OnMapCreated;
+            SubscribeLocalEvent<MapChangedEvent>(OnMapCreated);
         }
 
         public override void Shutdown()
         {
             base.Shutdown();
             EntityManager.EntityInitialized -= OnEntityInit;
-            _mapManager.MapCreated -= OnMapCreated;
         }
 
         private void OnAnchored(ref AnchorStateChangedEvent args)
@@ -129,8 +128,11 @@ namespace Robust.Shared.GameObjects
             );
         }
 
-        private void OnMapCreated(object? sender, MapEventArgs eventArgs)
+        private void OnMapCreated(MapChangedEvent eventArgs)
         {
+            if(eventArgs.Destroyed)
+                return;
+
             if (eventArgs.Map == MapId.Nullspace) return;
 
             EntityManager.EnsureComponent<EntityLookupComponent>(_mapManager.GetMapEntityId(eventArgs.Map));

--- a/Robust.Shared/GameObjects/Systems/OccluderSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/OccluderSystem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Robust.Shared.IoC;
@@ -21,8 +21,12 @@ namespace Robust.Shared.GameObjects
             base.Initialize();
 
             UpdatesOutsidePrediction = true;
-
-            _mapManager.MapCreated += OnMapCreated;
+            
+            SubscribeLocalEvent<MapChangedEvent>(ev =>
+            {
+                if (ev.Created)
+                    OnMapCreated(ev);
+            });
 
             SubscribeLocalEvent<GridInitializeEvent>(HandleGridInit);
             SubscribeLocalEvent<OccluderTreeComponent, ComponentInit>(HandleOccluderTreeInit);
@@ -92,7 +96,6 @@ namespace Robust.Shared.GameObjects
         public override void Shutdown()
         {
             base.Shutdown();
-            _mapManager.MapCreated -= OnMapCreated;
             _updates.Clear();
         }
 
@@ -156,7 +159,7 @@ namespace Robust.Shared.GameObjects
             _updates.Enqueue(new OccluderUpdateEvent(component));
         }
 
-        private void OnMapCreated(object? sender, MapEventArgs e)
+        private void OnMapCreated(MapChangedEvent e)
         {
             if (e.Map == MapId.Nullspace) return;
 

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
+using Robust.Shared.Maths;
 
 namespace Robust.Shared.GameObjects
 {
@@ -94,6 +96,56 @@ namespace Robust.Shared.GameObjects
         public GridAddEvent(EntityUid uid)
         {
             EntityUid = uid;
+        }
+    }
+
+    /// <summary>
+    ///     Arguments for when a single tile on a grid is changed locally or remotely.
+    /// </summary>
+    public sealed class TileChangedEvent : EntityEventArgs
+    {
+        /// <summary>
+        ///     Creates a new instance of this class.
+        /// </summary>
+        public TileChangedEvent(TileRef newTile, Tile oldTile)
+        {
+            NewTile = newTile;
+            OldTile = oldTile;
+        }
+
+        /// <summary>
+        ///     New tile that replaced the old one.
+        /// </summary>
+        public TileRef NewTile { get; }
+
+        /// <summary>
+        ///     Old tile that was replaced.
+        /// </summary>
+        public Tile OldTile { get; }
+    }
+
+    /// <summary>
+    ///     Arguments for when a one or more tiles on a grid are modified at once.
+    /// </summary>
+    public sealed class GridModifiedEvent : EntityEventArgs
+    {
+        /// <summary>
+        ///     Grid being changed.
+        /// </summary>
+        public IMapGrid Grid { get; }
+
+        /// <summary>
+        /// Set of tiles that were modified.
+        /// </summary>
+        public IReadOnlyCollection<(Vector2i position, Tile tile)> Modified { get; }
+
+        /// <summary>
+        ///     Creates a new instance of this class.
+        /// </summary>
+        public GridModifiedEvent(IMapGrid grid, IReadOnlyCollection<(Vector2i position, Tile tile)> modified)
+        {
+            Grid = grid;
+            Modified = modified;
         }
     }
 }

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -53,7 +53,11 @@ namespace Robust.Shared.GameObjects
         public override void Initialize()
         {
             base.Initialize();
-            MapManager.MapCreated += HandleMapCreated;
+            SubscribeLocalEvent<MapChangedEvent>(ev =>
+            {
+                if (ev.Created)
+                    HandleMapCreated(ev);
+            });
 
             SubscribeLocalEvent<GridInitializeEvent>(HandleGridInit);
             SubscribeLocalEvent<CollisionChangeMessage>(HandlePhysicsUpdateMessage);
@@ -196,13 +200,11 @@ namespace Robust.Shared.GameObjects
         {
             base.Shutdown();
 
-            MapManager.MapCreated -= HandleMapCreated;
-
             var configManager = IoCManager.Resolve<IConfigurationManager>();
             configManager.UnsubValueChanged(CVars.AutoClearForces, OnAutoClearChange);
         }
 
-        protected abstract void HandleMapCreated(object? sender, MapEventArgs eventArgs);
+        protected abstract void HandleMapCreated(MapChangedEvent eventArgs);
 
         private void HandleMapChange(EntMapIdChangedMessage message)
         {

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -21,16 +21,10 @@ namespace Robust.Shared.GameObjects
 
             UpdatesOutsidePrediction = true;
 
-            _mapManager.TileChanged += MapManagerOnTileChanged;
+            SubscribeLocalEvent<TileChangedEvent>(MapManagerOnTileChanged);
         }
 
-        public override void Shutdown()
-        {
-            _mapManager.TileChanged -= MapManagerOnTileChanged;
-            base.Shutdown();
-        }
-
-        private void MapManagerOnTileChanged(object? sender, TileChangedEventArgs e)
+        private void MapManagerOnTileChanged(TileChangedEvent e)
         {
             if(e.NewTile.Tile != Tile.Empty)
                 return;

--- a/Robust.Shared/Map/IMapManager.cs
+++ b/Robust.Shared/Map/IMapManager.cs
@@ -153,15 +153,19 @@ namespace Robust.Shared.Map
         /// <summary>
         ///     A tile is being modified.
         /// </summary>
+        [Obsolete("Subscribe to TileChangedEvent on the event bus.")]
         event EventHandler<TileChangedEventArgs> TileChanged;
 
+        [Obsolete("Subscribe to GridStartupEvent on the event bus.")]
         event GridEventHandler OnGridCreated;
 
+        [Obsolete("Subscribe to GridRemovalEvent on the event bus.")]
         event GridEventHandler OnGridRemoved;
 
         /// <summary>
         ///     A Grid was modified.
         /// </summary>
+        [Obsolete("Subscribe to GridModifiedEvent on the event bus.")]
         event EventHandler<GridChangedEventArgs> GridChanged;
 
         /// <summary>

--- a/Robust.Shared/Map/IMapManager.cs
+++ b/Robust.Shared/Map/IMapManager.cs
@@ -171,11 +171,13 @@ namespace Robust.Shared.Map
         /// <summary>
         ///     A new map has been created.
         /// </summary>
+        [Obsolete("Subscribe to MapChangedEvent on the event bus, and check if Created is true.")]
         event EventHandler<MapEventArgs> MapCreated;
 
         /// <summary>
         ///     An existing map has been destroyed.
         /// </summary>
+        [Obsolete("Subscribe to MapChangedEvent on the event bus, and check if Destroyed is true.")]
         event EventHandler<MapEventArgs> MapDestroyed;
 
         bool HasMapEntity(MapId mapId);

--- a/Robust.Shared/Map/MapManager.GridCollection.cs
+++ b/Robust.Shared/Map/MapManager.GridCollection.cs
@@ -322,6 +322,8 @@ internal partial class MapManager
             return;
 
         TileChanged?.Invoke(this, new TileChangedEventArgs(tileRef, oldTile));
+        var euid = GetGridEuid(tileRef.GridIndex);
+        EntityManager.EventBus.RaiseLocalEvent(euid, new TileChangedEvent(tileRef, oldTile));
     }
 
     protected IMapGrid CreateGrid(MapId currentMapId, GridId gridId, ushort chunkSize, EntityUid euid)
@@ -339,6 +341,8 @@ internal partial class MapManager
     protected void InvokeGridChanged(object? sender, GridChangedEventArgs ev)
     {
         GridChanged?.Invoke(sender, ev);
+        var args = new GridModifiedEvent(ev.Grid, ev.Modified);
+        EntityManager.EventBus.RaiseLocalEvent(ev.Grid.GridEntityId, args);
     }
 
     private IMapGridInternal CreateGridImpl(MapId currentMapId, GridId? gridId, ushort chunkSize, bool createEntity,

--- a/Robust.Shared/Map/NetworkedMapManager.cs
+++ b/Robust.Shared/Map/NetworkedMapManager.cs
@@ -222,6 +222,7 @@ internal sealed class NetworkedMapManager : MapManager, INetworkedMapManager
                         if (compChange.State is not MapComponentState mapCompState || mapCompState.MapId != mapId)
                             continue;
 
+                        DebugTools.Assert(compChange.Created, $"new map {mapId} is in CreatedMaps, but compState isn't marked as created.");
                         mapEuid = entityState.Uid;
                         goto BreakMapEntSearch;
                     }
@@ -255,6 +256,7 @@ internal sealed class NetworkedMapManager : MapManager, INetworkedMapManager
                         if (compState.State is not MapGridComponentState gridCompState || gridCompState.GridIndex != gridId)
                             continue;
 
+                        DebugTools.Assert(compState.Created, $"new grid {gridId} is in CreatedGrids, but compState isn't marked as created.");
                         gridEuid = entityState.Uid;
                         goto BreakGridEntSearch;
                     }

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -68,8 +68,14 @@ namespace Robust.Shared.Physics
 
             var configManager = IoCManager.Resolve<IConfigurationManager>();
             configManager.OnValueChanged(CVars.BroadphaseExpand, SetBroadphaseExpand, true);
-            _mapManager.MapCreated += OnMapCreated;
-            _mapManager.MapDestroyed += OnMapDestroyed;
+
+            SubscribeLocalEvent<MapChangedEvent>(ev =>
+            {
+                if (ev.Created)
+                    OnMapCreated(ev);
+                else
+                    OnMapDestroyed(ev);
+            });
         }
 
         private void SetBroadphaseExpand(float value) => _broadphaseExpand = value;
@@ -671,13 +677,11 @@ namespace Robust.Shared.Physics
             base.Shutdown();
             var configManager = IoCManager.Resolve<IConfigurationManager>();
             configManager.UnsubValueChanged(CVars.BroadphaseExpand, SetBroadphaseExpand);
-            _mapManager.MapCreated -= OnMapCreated;
-            _mapManager.MapDestroyed -= OnMapDestroyed;
         }
 
         #region Broadphase management
 
-        private void OnMapCreated(object? sender, MapEventArgs e)
+        private void OnMapCreated(MapChangedEvent e)
         {
             if (e.Map == MapId.Nullspace) return;
 
@@ -685,7 +689,7 @@ namespace Robust.Shared.Physics
             _moveBuffer[e.Map] = new Dictionary<FixtureProxy, Box2>(64);
         }
 
-        private void OnMapDestroyed(object? sender, MapEventArgs e)
+        private void OnMapDestroyed(MapChangedEvent e)
         {
             _moveBuffer.Remove(e.Map);
         }


### PR DESCRIPTION
Marks the C# events on MapManager as Obsolete, and adds the missing equivalent ECS events.