### PR TITLE
Fix disappearing grids

### DIFF
--- a/Robust.Shared/Map/MapManager.GridTrees.cs
+++ b/Robust.Shared/Map/MapManager.GridTrees.cs
@@ -24,14 +24,29 @@ internal partial class MapManager
         _movedGrids[mapId].Clear();
     }
 
-    private void InitializeGridTrees()
+    private void StartupGridTrees()
     {
+        // Needs to be done on mapmanager startup because the eventbus will clear on shutdown
+        // (and mapmanager initialize doesn't run upon connecting to a server every time).
         EntityManager.EventBus.SubscribeEvent<GridInitializeEvent>(EventSource.Local, this, OnGridInit);
         EntityManager.EventBus.SubscribeEvent<GridRemovalEvent>(EventSource.Local, this, OnGridRemove);
         EntityManager.EventBus.SubscribeLocalEvent<MapGridComponent, MoveEvent>(OnGridMove);
         EntityManager.EventBus.SubscribeLocalEvent<MapGridComponent, RotateEvent>(OnGridRotate);
         EntityManager.EventBus.SubscribeLocalEvent<MapGridComponent, EntMapIdChangedMessage>(OnGridMapChange);
         EntityManager.EventBus.SubscribeLocalEvent<MapGridComponent, GridFixtureChangeEvent>(OnGridBoundsChange);
+    }
+
+    private void ShutdownGridTrees()
+    {
+        EntityManager.EventBus.UnsubscribeEvent<GridInitializeEvent>(EventSource.Local, this);
+        EntityManager.EventBus.UnsubscribeEvent<GridRemovalEvent>(EventSource.Local, this);
+        EntityManager.EventBus.UnsubscribeLocalEvent<MapGridComponent, MoveEvent>();
+        EntityManager.EventBus.UnsubscribeLocalEvent<MapGridComponent, RotateEvent>();
+        EntityManager.EventBus.UnsubscribeLocalEvent<MapGridComponent, EntMapIdChangedMessage>();
+        EntityManager.EventBus.UnsubscribeLocalEvent<MapGridComponent, GridFixtureChangeEvent>();
+
+        DebugTools.Assert(_gridTrees.Count == 0);
+        DebugTools.Assert(_movedGrids.Count == 0);
     }
 
     private void OnMapCreatedGridTree(MapEventArgs e)

--- a/Robust.Shared/Map/MapManager.cs
+++ b/Robust.Shared/Map/MapManager.cs
@@ -67,6 +67,8 @@ internal partial class MapManager : IMapManagerInternal, IEntityEventSubscriber
     {
         Logger.DebugS("map", "Restarting...");
 
+        // Don't just call Shutdown / Startup because we don't want to touch the subscriptions on gridtrees
+        // Restart can be called any time during a game, whereas shutdown / startup are typically called upon connection.
         DeleteAllMaps();
         EnsureNullspaceExistsAndClear();
     }

--- a/Robust.Shared/Map/MapManager.cs
+++ b/Robust.Shared/Map/MapManager.cs
@@ -24,7 +24,6 @@ internal partial class MapManager : IMapManagerInternal, IEntityEventSubscriber
         DebugTools.Assert(!_dbgGuardRunning);
         _dbgGuardInit = true;
 #endif
-        InitializeGridTrees();
         InitializeMapPausing();
     }
 
@@ -38,6 +37,7 @@ internal partial class MapManager : IMapManagerInternal, IEntityEventSubscriber
 
         Logger.DebugS("map", "Starting...");
 
+        StartupGridTrees();
         EnsureNullspaceExistsAndClear();
 
         DebugTools.Assert(_grids.Count == 0);
@@ -53,6 +53,7 @@ internal partial class MapManager : IMapManagerInternal, IEntityEventSubscriber
         Logger.DebugS("map", "Stopping...");
 
         DeleteAllMaps();
+        ShutdownGridTrees();
 
 #if DEBUG
         DebugTools.Assert(_grids.Count == 0);
@@ -66,8 +67,8 @@ internal partial class MapManager : IMapManagerInternal, IEntityEventSubscriber
     {
         Logger.DebugS("map", "Restarting...");
 
-        Shutdown();
-        Startup();
+        DeleteAllMaps();
+        EnsureNullspaceExistsAndClear();
     }
 
 #if DEBUG


### PR DESCRIPTION
The issue is that mapmanager initialize is run once when starting the game but startup is run upon connecting to the server which has bit me a few times.

The problem is that all of the eventbus subscriptions get cleared upon the entitymanager shutting down but we never re-subscribe to it.

Should fix https://github.com/space-wizards/RobustToolbox/issues/2471

Electro gave me steps to replicate a form of the issue and this fixes that.