### PR TITLE
Dubious entity deletion prediction

### DIFF
--- a/Robust.Client/GameObjects/IClientEntityManagerInternal.cs
+++ b/Robust.Client/GameObjects/IClientEntityManagerInternal.cs
@@ -11,5 +11,10 @@ namespace Robust.Client.GameObjects
         void InitializeEntity(EntityUid entity);
 
         void StartEntity(EntityUid entity);
+
+        /// <summary>
+        ///     Actually delete server-side entities, rather than just moving them to null-space.
+        /// </summary>
+        void ActuallyDeleteEntity(EntityUid entityUid);
     }
 }

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -357,7 +357,8 @@ namespace Robust.Client.GameStates
                     continue;
                 }
 
-                // TODO: handle component deletions/creations.
+                // TODO: handle component creations. Deletions currently being handled by just detaching to null. If
+                // there was a mispredict, the transform comp reset should undo the pseudo deletion.
                 foreach (var (netId, comp) in _entityManager.GetNetComponents(entity))
                 {
                     DebugTools.AssertNotNull(netId);
@@ -487,7 +488,7 @@ namespace Robust.Client.GameStates
             foreach (var id in deletions)
             {
                 // Logger.Debug($"[{IGameTiming.TickStampStatic}] DELETE {id}");
-                _entities.DeleteEntity(id);
+                _entities.ActuallyDeleteEntity(id);
             }
 
 #if EXCEPTION_TOLERANCE

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -258,6 +258,12 @@ namespace Robust.Shared.GameObjects
         /// <param name="e">Entity to remove</param>
         public virtual void DeleteEntity(EntityUid e)
         {
+            // Client handles deletion prediciton / fake deletion here instead of calling:
+            DeleteEntityInternal(e);
+        }
+
+        protected void DeleteEntityInternal(EntityUid e)
+        {
             // Networking blindly spams entities at this function, they can already be
             // deleted from being a child of a previously deleted entity
             // TODO: Why does networking need to send deletes for child entities?
@@ -346,11 +352,11 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         /// Disposes all entities and clears all lists.
         /// </summary>
-        public void FlushEntities()
+        public virtual void FlushEntities()
         {
             foreach (var e in GetEntities())
             {
-                DeleteEntity(e);
+                DeleteEntityInternal(e);
             }
         }
 
@@ -421,7 +427,7 @@ namespace Robust.Shared.GameObjects
             {
                 // Exception during entity loading.
                 // Need to delete the entity to avoid corrupt state causing crashes later.
-                DeleteEntity(entity);
+                DeleteEntityInternal(entity);
                 throw new EntityCreationException($"Exception inside CreateEntity with prototype {prototypeName}", e);
             }
         }
@@ -444,7 +450,7 @@ namespace Robust.Shared.GameObjects
             }
             catch (Exception e)
             {
-                DeleteEntity(entity);
+                DeleteEntityInternal(entity);
                 throw new EntityCreationException("Exception inside InitializeAndStartEntity", e);
             }
         }


### PR DESCRIPTION
So I came up with this while trying to get item-stack prediction to work. Basically, instead of deleting server side entities, this just sending them to null space works well enough in most situations. If they actually get deleted by the server, they get deleted as normal. If there was a mispredict the transform-reset **should** fix it,

This PR makes it so that the client overrides the entity manager deletion. There is a separate function function that **actually** deletes the entity. The way I've done this is questionable and maybe very stupid. E.g.:
- This "deletion" doesn't trigger any of the normal component shutdown stuff, it doesn't even mark the entity as deleted (until normal / "real" deletion happens)
- The dubious way I've implemented it might mean people accidentally call the wrong function from client-side code, resulting in an entity not actually being deleted when it should be
- The client currently only **properly** deletes an entity when either when receiving a list of deletions from the server, or when calling `FlushEntities()`. I might've missed something.

So yeah not sure about this. It is also not strictly required. E.g., to get stack-prediction working I could just make the client-side stack system detach-to-null rather than calling `Delete()`. At least then it's a deliberate action that shouldn't lead to unintended side effects when `Delete()` is used elsewhere. 