### PR TITLE
Cache Sprite AABBs

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/ISpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/ISpriteComponent.cs
@@ -25,6 +25,8 @@ namespace Robust.Client.GameObjects
         [Animatable]
         Vector2 Scale { get; set; }
 
+        Box2 Bounds { get; }
+
         /// <summary>
         ///     A rotation applied to all layers.
         /// </summary>

--- a/Robust.Client/GameObjects/Components/Renderable/ISpriteLayer.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/ISpriteLayer.cs
@@ -35,6 +35,6 @@ namespace Robust.Client.GameObjects
         ///     Calculate layer bounding box in sprite local-space coordinates.
         /// </summary>
         /// <returns>Bounding box in sprite local-space coordinates.</returns>
-        Box2 CalculateBoundingBox(Angle worldAngle);
+        Box2 CalculateBoundingBox();
     }
 }

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -601,7 +601,7 @@ namespace Robust.Client.GameObjects
         private void RebuildBounds()
         {
             _bounds = new Box2();
-            foreach (var layer in Layers)
+            foreach (var layer in Layers.Where(layer => layer.Visible))
             {
                 _bounds = _bounds.Union(layer.CalculateBoundingBox());
             }
@@ -1128,7 +1128,6 @@ namespace Robust.Client.GameObjects
             }
 
             Layers[layer].SetVisible(visible);
-            RebuildBounds();
         }
 
         public void LayerSetVisible(object layerKey, bool visible)
@@ -1872,6 +1871,7 @@ namespace Robust.Client.GameObjects
                 Visible = value;
 
                 _parent.QueueUpdateIsInert();
+                _parent.RebuildBounds();
             }
 
             public void SetRsi(RSI? rsi)

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1974,7 +1974,7 @@ namespace Robust.Client.GameObjects
                 // we can take the quick path of just making a box the size of the texture.
                 if (_parent.NoRotation && _rotation != 0)
                 {
-                    return Box2.CenteredAround(Offset, textureSize);
+                    return Box2.CenteredAround(Offset, textureSize).Scale(_scale);
                 }
 
                 var rsiState = GetActualState();

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -815,6 +815,8 @@ namespace Robust.Client.GameObjects
                 default:
                     throw new NotImplementedException();
             }
+
+            RebuildBounds();
         }
 
         public void LayerSetSprite(object layerKey, SpriteSpecifier specifier)
@@ -840,6 +842,7 @@ namespace Robust.Client.GameObjects
 
             var theLayer = Layers[layer];
             theLayer.SetTexture(texture);
+            RebuildBounds();
         }
 
         public void LayerSetTexture(object layerKey, Texture texture)
@@ -905,6 +908,7 @@ namespace Robust.Client.GameObjects
 
             var theLayer = Layers[layer];
             theLayer.SetState(stateId);
+            RebuildBounds();
         }
 
         public void LayerSetState(object layerKey, RSI.StateId stateId)
@@ -952,6 +956,8 @@ namespace Robust.Client.GameObjects
                     theLayer.Texture = null;
                 }
             }
+
+            RebuildBounds();
         }
 
         public void LayerSetState(object layerKey, RSI.StateId stateId, RSI rsi)
@@ -1009,6 +1015,7 @@ namespace Robust.Client.GameObjects
 
             var theLayer = Layers[layer];
             theLayer.SetRsi(rsi);
+            RebuildBounds();
         }
 
         public void LayerSetRSI(object layerKey, RSI rsi)
@@ -1066,6 +1073,7 @@ namespace Robust.Client.GameObjects
 
             var theLayer = Layers[layer];
             theLayer.Scale = scale;
+            RebuildBounds();
         }
 
         public void LayerSetScale(object layerKey, Vector2 scale)
@@ -1092,6 +1100,7 @@ namespace Robust.Client.GameObjects
 
             var theLayer = Layers[layer];
             theLayer.Rotation = rotation;
+            RebuildBounds();
         }
 
         public void LayerSetRotation(object layerKey, Angle rotation)
@@ -1116,6 +1125,7 @@ namespace Robust.Client.GameObjects
             }
 
             Layers[layer].SetVisible(visible);
+            RebuildBounds();
         }
 
         public void LayerSetVisible(object layerKey, bool visible)
@@ -1141,6 +1151,8 @@ namespace Robust.Client.GameObjects
 
             var theLayer = Layers[layer];
             theLayer.Color = color;
+
+            RebuildBounds();
         }
 
         public void LayerSetColor(object layerKey, Color color)
@@ -1166,6 +1178,8 @@ namespace Robust.Client.GameObjects
 
             var theLayer = Layers[layer];
             theLayer.DirOffset = offset;
+
+            RebuildBounds();
         }
 
         public void LayerSetDirOffset(object layerKey, DirectionOffset offset)
@@ -1217,6 +1231,8 @@ namespace Robust.Client.GameObjects
             }
 
             Layers[layer].SetAutoAnimated(autoAnimated);
+
+            RebuildBounds();
         }
 
         public void LayerSetAutoAnimated(object layerKey, bool autoAnimated)
@@ -1242,6 +1258,8 @@ namespace Robust.Client.GameObjects
             }
 
             Layers[layer].Offset = layerOffset;
+
+            RebuildBounds();
         }
 
         public void LayerSetOffset(object layerKey, Vector2 layerOffset)

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1959,6 +1959,13 @@ namespace Robust.Client.GameObjects
 
                     var box = Box2.CenteredAround(Offset, textureSize);
 
+                    var rsiState = GetActualState();
+
+                    if (rsiState is {Directions: RSI.State.DirectionType.Dir8})
+                    {
+                        box = box.Union(Box2.CenteredAround(Offset, (textureSize.Y, textureSize.X)).Union(Box2.CenteredAround(Offset, Vector2.One * (textureSize.X + textureSize.Y) / MathF.Sqrt(2))));
+                    }
+
                     return _scale == Vector2.One ? box : box.Scale(_scale);
                 }
 

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -730,6 +730,8 @@ namespace Robust.Client.GameObjects
 
             // If neither state: nor texture: were provided we assume that they want a blank invisible layer.
             layer.Visible = anyTextureAttempted && layerDatum.Visible;
+
+            RebuildBounds();
         }
 
         public void LayerSetData(object layerKey, PrototypeLayerData data)
@@ -1967,6 +1969,13 @@ namespace Robust.Client.GameObjects
             public Box2 CalculateBoundingBox()
             {
                 var textureSize = PixelSize / EyeManager.PixelsPerMeter;
+
+                // If the parent has locked rotation and we don't have any rotation,
+                // we can take the quick path of just making a box the size of the texture.
+                if (_parent.NoRotation && _rotation != 0)
+                {
+                    return Box2.CenteredAround(Offset, textureSize);
+                }
 
                 var rsiState = GetActualState();
 


### PR DESCRIPTION
Fixes #2615.

Essentially, this adds a `Box2 Bounds` field to `SpriteComponent` that is automatically updated when sprite layers are added, modified or removed. This will take some pressure off the CPU by not having to re-calculate bounding boxes for all sprites every frame.

~~I also removed some related code that calculated sprite RSI directions, since that didn't seem to be affecting the actual render whatsoever.~~ It was used to calculate the bounds for 8-directional sprites. For those cases, the possible bounding boxes for these sprites are unioned into one larger bounding box.