### PR TITLE
Show player rotation in debug overlay

### DIFF
--- a/Robust.Client/UserInterface/CustomControls/DebugCoordsPanel.cs
+++ b/Robust.Client/UserInterface/CustomControls/DebugCoordsPanel.cs
@@ -104,13 +104,16 @@ Mouse Pos:
                 var playerCoordinates = entityTransform.Coordinates;
                 var playerRotation = entityTransform.WorldRotation;
 
+                Angle gridRotation = _mapManager.TryGetGrid(entityTransform.GridID, out var grid) ? grid.WorldRotation : Angle.Zero;
+
                 stringBuilder.AppendFormat(@"    Screen: {0}
     {1}
     {2}
     Rotation: {3:F2}°
     EntId: {4}
-    GridID: {5}", playerScreen, playerWorldOffset, playerCoordinates, playerRotation.Degrees, entityTransform.Owner,
-                    entityTransform.GridID);
+    GridID: {5}
+    Grid Rotation: {6:F2}°", playerScreen, playerWorldOffset, playerCoordinates, playerRotation.Degrees, entityTransform.Owner,
+                    entityTransform.GridID, gridRotation.Degrees);
             }
 
             if (controlHovered != null)

--- a/Robust.Client/UserInterface/CustomControls/DebugCoordsPanel.cs
+++ b/Robust.Client/UserInterface/CustomControls/DebugCoordsPanel.cs
@@ -102,12 +102,14 @@ Mouse Pos:
                 var playerScreen = _eyeManager.WorldToScreen(playerWorldOffset.Position);
 
                 var playerCoordinates = entityTransform.Coordinates;
+                var playerRotation = entityTransform.WorldRotation;
 
                 stringBuilder.AppendFormat(@"    Screen: {0}
     {1}
     {2}
-    EntId: {3}
-    GridID: {4}", playerScreen, playerWorldOffset, playerCoordinates, entityTransform.Owner,
+    Rotation: {3:F2}°
+    EntId: {4}
+    GridID: {5}", playerScreen, playerWorldOffset, playerCoordinates, playerRotation.Degrees, entityTransform.Owner,
                     entityTransform.GridID);
             }
 


### PR DESCRIPTION
Fixes https://github.com/space-wizards/space-station-14/issues/6329

The world rotation of the player is now shown in the debug overlay so that players can report issues with rotation more easily.