### PR TITLE
Add overload to IntersectRayWithPredicate.

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.Queries.cs
@@ -178,25 +178,9 @@ namespace Robust.Shared.GameObjects
         /// <param name="predicate">A predicate to check whether to ignore an entity or not. If it returns true, it will be ignored.</param>
         /// <param name="returnOnFirstHit">If true, will only include the first hit entity in results. Otherwise, returns all of them.</param>
         /// <returns>A result object describing the hit, if any.</returns>
-        [Obsolete("Use any other overload for IntersectRayWithPredicate.")]
+        // TODO: Make the parameter order here consistent with the other overload.
         public IEnumerable<RayCastResults> IntersectRayWithPredicate(MapId mapId, CollisionRay ray,
-            float maxLength = 50F,
-            Func<EntityUid, bool>? predicate = null, bool returnOnFirstHit = true)
-        {
-            return IntersectRayWithPredicate(mapId, ray, predicate, maxLength, returnOnFirstHit);
-        }
-
-        /// <summary>
-        ///     Casts a ray in the world, returning the first entity it hits (or all entities it hits, if so specified)
-        /// </summary>
-        /// <param name="mapId"></param>
-        /// <param name="ray">Ray to cast in the world.</param>
-        /// <param name="maxLength">Maximum length of the ray in meters.</param>
-        /// <param name="predicate">A predicate to check whether to ignore an entity or not. If it returns true, it will be ignored.</param>
-        /// <param name="returnOnFirstHit">If true, will only include the first hit entity in results. Otherwise, returns all of them.</param>
-        /// <returns>A result object describing the hit, if any.</returns>
-        public IEnumerable<RayCastResults> IntersectRayWithPredicate(MapId mapId, CollisionRay ray,
-            Func<EntityUid, bool>? predicate = null, float maxLength = 50F, bool returnOnFirstHit = true)
+            float maxLength = 50F, Func<EntityUid, bool>? predicate = null, bool returnOnFirstHit = true)
         {
             // No, rider. This is better than a local function!
             // ReSharper disable once ConvertToLocalFunction

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.Queries.cs
@@ -202,7 +202,7 @@ namespace Robust.Shared.GameObjects
             // ReSharper disable once ConvertToLocalFunction
             var wrapper =
                 (EntityUid uid, Func<EntityUid, bool>? wrapped)
-                    => wrapped == null || wrapped(uid);
+                    => wrapped != null && wrapped(uid);
 
             return IntersectRayWithPredicate(mapId, ray, predicate, wrapper, maxLength, returnOnFirstHit);
         }
@@ -247,7 +247,7 @@ namespace Robust.Shared.GameObjects
                     if ((proxy.Fixture.CollisionLayer & ray.CollisionMask) == 0x0)
                         return true;
 
-                    if (predicate?.Invoke(proxy.Fixture.Body.Owner, state) == true)
+                    if (predicate.Invoke(proxy.Fixture.Body.Owner, state) == true)
                         return true;
 
                     // TODO: Shape raycast here
@@ -287,7 +287,13 @@ namespace Robust.Shared.GameObjects
         /// <param name="returnOnFirstHit">If false, will return a list of everything it hits, otherwise will just return a list of the first entity hit</param>
         /// <returns>An enumerable of either the first entity hit or everything hit</returns>
         public IEnumerable<RayCastResults> IntersectRay(MapId mapId, CollisionRay ray, float maxLength = 50, EntityUid? ignoredEnt = null, bool returnOnFirstHit = true)
-            => IntersectRayWithPredicate(mapId, ray, maxLength, entity => entity == ignoredEnt, returnOnFirstHit);
+        {
+            // ReSharper disable once ConvertToLocalFunction
+            var wrapper = (EntityUid uid, EntityUid? ignored)
+                => uid == ignored;
+
+            return IntersectRayWithPredicate(mapId, ray, ignoredEnt, wrapper, maxLength, returnOnFirstHit);
+        }
 
         /// <summary>
         ///     Casts a ray in the world and returns the distance the ray traveled while colliding with entities


### PR DESCRIPTION
Will help address some performance issues regarding heap allocs and variable capture.