### PR TITLE
ECS collision wake

### DIFF
--- a/Robust.Shared/GameObjects/Components/CollisionWakeComponent.cs
+++ b/Robust.Shared/GameObjects/Components/CollisionWakeComponent.cs
@@ -3,7 +3,6 @@ using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.ViewVariables;
 
 namespace Robust.Shared.GameObjects
 {
@@ -11,43 +10,11 @@ namespace Robust.Shared.GameObjects
     ///     An optimisation component for stuff that should be set as collidable when it's awake and non-collidable when asleep.
     /// </summary>
     [NetworkedComponent()]
+    [Friend(typeof(CollisionWakeSystem))]
     public sealed class CollisionWakeComponent : Component
     {
-        [Dependency] private readonly IEntityManager _entMan = default!;
-
         [DataField("enabled")]
-        private bool _enabled = true;
-
-        [ViewVariables(VVAccess.ReadWrite)]
-        public bool Enabled
-        {
-            get => _enabled;
-            set
-            {
-                if (value == _enabled) return;
-
-                _enabled = value;
-                Dirty();
-                RaiseStateChange();
-            }
-        }
-
-        internal void RaiseStateChange()
-        {
-            _entMan.EventBus.RaiseLocalEvent(Owner, new CollisionWakeStateMessage(), false);
-        }
-
-        public override ComponentState GetComponentState()
-        {
-            return new CollisionWakeState(Enabled);
-        }
-
-        public override void HandleComponentState(ComponentState? curState, ComponentState? nextState)
-        {
-            if (curState is not CollisionWakeState state) return;
-
-            Enabled = state.Enabled;
-        }
+        public bool Enabled = true;
 
         [Serializable, NetSerializable]
         public sealed class CollisionWakeState : ComponentState

--- a/Robust.Shared/GameObjects/Systems/CollisionWakeSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/CollisionWakeSystem.cs
@@ -42,7 +42,12 @@ namespace Robust.Shared.GameObjects
         private void OnHandleState(EntityUid uid, CollisionWakeComponent component, ref ComponentHandleState args)
         {
             if (args.Current is CollisionWakeComponent.CollisionWakeState state)
-                SetEnabled(uid, state.Enabled, component);
+                component.Enabled = state.Enabled;
+
+            // Note, this explicitly does not update PhysicsComponent.CanCollide. The physics component should perform
+            // its own state-handling logic. Additionally, if we wanted to set it you would have to ensure that things
+            // like the join-component and physics component have already handled their states, otherwise CanCollide may
+            // be set incorrectly and leave the client with a bad state.
         }
 
         private void OnGetState(EntityUid uid, CollisionWakeComponent component, ref ComponentGetState args)

--- a/Robust.Shared/GameObjects/Systems/CollisionWakeSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/CollisionWakeSystem.cs
@@ -1,3 +1,4 @@
+using Robust.Shared.GameStates;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
 
@@ -11,9 +12,11 @@ namespace Robust.Shared.GameObjects
             SubscribeLocalEvent<CollisionWakeComponent, EntityInitializedMessage>(HandleInitialize);
             SubscribeLocalEvent<CollisionWakeComponent, ComponentRemove>(HandleRemove);
 
+            SubscribeLocalEvent<CollisionWakeComponent, ComponentGetState>(OnGetState);
+            SubscribeLocalEvent<CollisionWakeComponent, ComponentHandleState>(OnHandleState);
+
             SubscribeLocalEvent<CollisionWakeComponent, PhysicsWakeMessage>(HandleWake);
             SubscribeLocalEvent<CollisionWakeComponent, PhysicsSleepMessage>(HandleSleep);
-            SubscribeLocalEvent<CollisionWakeComponent, CollisionWakeStateMessage>(HandleCollisionWakeState);
 
             SubscribeLocalEvent<CollisionWakeComponent, JointAddedEvent>(HandleJointAdd);
             SubscribeLocalEvent<CollisionWakeComponent, JointRemovedEvent>(HandleJointRemove);
@@ -21,73 +24,89 @@ namespace Robust.Shared.GameObjects
             SubscribeLocalEvent<CollisionWakeComponent, EntParentChangedMessage>(HandleParentChange);
         }
 
+        public void SetEnabled(EntityUid uid, bool enabled, CollisionWakeComponent? component = null)
+        {
+            if (!Resolve(uid, ref component) || component.Enabled == enabled)
+                return;
+
+            component.Enabled = enabled;
+
+            if (component.Enabled)
+                UpdateCanCollide(uid, component);
+            else if (TryComp(uid, out PhysicsComponent? physics))
+                physics.CanCollide = true;
+
+            Dirty(component);
+        }
+
+        private void OnHandleState(EntityUid uid, CollisionWakeComponent component, ref ComponentHandleState args)
+        {
+            if (args.Current is CollisionWakeComponent.CollisionWakeState state)
+                SetEnabled(uid, state.Enabled, component);
+        }
+
+        private void OnGetState(EntityUid uid, CollisionWakeComponent component, ref ComponentGetState args)
+        {
+            args.State = new CollisionWakeComponent.CollisionWakeState(component.Enabled);
+        }
+
         private void HandleRemove(EntityUid uid, CollisionWakeComponent component, ComponentRemove args)
         {
-            if (!Terminating(uid) && TryComp(uid, out PhysicsComponent? physics))
+            if (component.Enabled
+                && !Terminating(uid)
+                && TryComp(uid, out PhysicsComponent? physics))
             {
                 physics.CanCollide = true;
             }
         }
 
-        private bool CanRaiseEvent(EntityUid uid)
-        {
-            var meta = MetaData(uid);
-
-            if (meta.EntityLifeStage >= EntityLifeStage.Terminating) return false;
-            return true;
-        }
-
         private void HandleParentChange(EntityUid uid, CollisionWakeComponent component, ref EntParentChangedMessage args)
         {
-            if (!CanRaiseEvent(uid)) return;
-
-            component.RaiseStateChange();
+            UpdateCanCollide(uid, component);
         }
 
         private void HandleInitialize(EntityUid uid, CollisionWakeComponent component, EntityInitializedMessage args)
         {
-            component.RaiseStateChange();
+            UpdateCanCollide(uid, component, checkTerminating: false);
         }
 
         private void HandleJointRemove(EntityUid uid, CollisionWakeComponent component, JointRemovedEvent args)
         {
-            if (!CanRaiseEvent(uid)) return;
-
-            component.RaiseStateChange();
+            UpdateCanCollide(uid, component, args.OurBody);
         }
 
         private void HandleJointAdd(EntityUid uid, CollisionWakeComponent component, JointAddedEvent args)
         {
-            component.RaiseStateChange();
+            // Bypass UpdateCanCollide() as joint count will always be bigger than 0:
+            if (component.Enabled)
+                args.OurBody.CanCollide = true;
         }
 
         private void HandleWake(EntityUid uid, CollisionWakeComponent component, PhysicsWakeMessage args)
         {
-            component.RaiseStateChange();
+            UpdateCanCollide(uid, component, args.Body, false);
         }
 
         private void HandleSleep(EntityUid uid, CollisionWakeComponent component, PhysicsSleepMessage args)
         {
-            if (!CanRaiseEvent(uid)) return;
-
-            component.RaiseStateChange();
+            UpdateCanCollide(uid, component, args.Body);
         }
 
-        private void HandleCollisionWakeState(EntityUid uid, CollisionWakeComponent component, CollisionWakeStateMessage args)
+        private void UpdateCanCollide(EntityUid uid, CollisionWakeComponent component, IPhysBody? body = null, bool checkTerminating = true)
         {
-            // If you really wanted you could optimise for each use case above and save some calls but
-            // these are called pretty infrequently so I'm fine with this for now.
+            if (!component.Enabled)
+                return;
 
-            // If we just got put into a container don't want to mess with our collision state.
-            if (!EntityManager.TryGetComponent<PhysicsComponent>(uid, out var body)) return;
+            if (checkTerminating && Terminating(uid))
+                return;
+
+            if (!Resolve(uid, ref body, false))
+                return;
 
             // If we're attached to the map we'll also just never disable collision due to how grid movement works.
-            body.CanCollide = !component.Enabled ||
-                              body.Awake ||
-                              (EntityManager.TryGetComponent(uid, out JointComponent? jointComponent) && jointComponent.JointCount > 0) ||
-                              EntityManager.GetComponent<TransformComponent>(uid).GridID == GridId.Invalid;
+            body.CanCollide = body.Awake ||
+                              (TryComp(uid, out JointComponent? jointComponent) && jointComponent.JointCount > 0) ||
+                              Transform(uid).GridID == GridId.Invalid;
         }
     }
-
-    public sealed class CollisionWakeStateMessage : EntityEventArgs { }
 }


### PR DESCRIPTION
Moves logic out of the collision wake component. It was mostly already ECSed, but for whatever reason all the system methods were getting the component to raise a method event to call a function in the system.

This PR does slightly change functionality. Previously the component would continue to set `CanCollide` even when the component was disabled. Now it only sets can collide when the component is first disabled, but not afterwards. It also no longer updates `CanCollide` when handling the component state.

Requires space-wizards/space-station-14/pull/7330