### PR TITLE
Make the UI System TryGet functions not log failed resolves

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/UserInterfaceSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/UserInterfaceSystem.cs
@@ -176,7 +176,7 @@ namespace Robust.Server.GameObjects
 
         public BoundUserInterface? GetUiOrNull(EntityUid uid, object uiKey, ServerUserInterfaceComponent? ui = null)
         {
-            return TryGetUi(uid, uiKey, out var bui)
+            return TryGetUi(uid, uiKey, out var bui, ui)
                 ? bui
                 : null;
         }
@@ -185,12 +185,12 @@ namespace Robust.Server.GameObjects
         {
             bui = null;
 
-            return Resolve(uid, ref ui) && ui.TryGetBoundUserInterface(uiKey, out bui);
+            return Resolve(uid, ref ui, false) && ui.TryGetBoundUserInterface(uiKey, out bui);
         }
 
         public bool IsUiOpen(EntityUid uid, object uiKey, ServerUserInterfaceComponent? ui = null)
         {
-            if (!Resolve(uid, ref ui))
+            if (!Resolve(uid, ref ui, false))
                 return false;
 
             if (!TryGetUi(uid, uiKey, out var bui, ui))
@@ -201,7 +201,7 @@ namespace Robust.Server.GameObjects
 
         public bool TrySetUiState(EntityUid uid, object uiKey, BoundUserInterfaceState state, IPlayerSession? session = null, ServerUserInterfaceComponent? ui = null)
         {
-            if (!Resolve(uid, ref ui))
+            if (!Resolve(uid, ref ui, false))
                 return false;
 
             if (!TryGetUi(uid, uiKey, out var bui, ui))


### PR DESCRIPTION
Currently the `TryGetUi` functions will log an error when the resolve fails. This causes miscellaneous tests (e.g. add & remove each component) to fail if systems use these functions.