### PR TITLE
Make directional sprite matrices static

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -2023,14 +2023,26 @@ namespace Robust.Client.GameObjects
             /// </summary>
             public void GetLayerDrawMatrix(RSIDirection dir, out Matrix3 layerDrawMatrix)
             {
-                if (_parent.NoRotation)
+                if (_parent.NoRotation || dir == RSIDirection.South)
                     layerDrawMatrix = LocalMatrix;
                 else
                 {
-                    var rsiDirectionMatrix = Matrix3.CreateTransform(Vector2.Zero, -dir.Convert().ToAngle());
-                    Matrix3.Multiply(ref rsiDirectionMatrix, ref LocalMatrix, out layerDrawMatrix);
+                    Matrix3.Multiply(ref _rsiDirectionMatrices[(int)dir], ref LocalMatrix, out layerDrawMatrix);
                 }
             }
+
+            private static Matrix3[] _rsiDirectionMatrices = new Matrix3[]
+            {
+                // array order chosen such that this array can be indexed by casing an RSI direction to an int
+                Matrix3.Identity, // should probably just avoid matrix multiplication altogether if the direction is south.
+                Matrix3.CreateRotation(-Direction.North.ToAngle()),
+                Matrix3.CreateRotation(-Direction.East.ToAngle()),
+                Matrix3.CreateRotation(-Direction.West.ToAngle()),
+                Matrix3.CreateRotation(-Direction.SouthEast.ToAngle()),
+                Matrix3.CreateRotation(-Direction.SouthWest.ToAngle()),
+                Matrix3.CreateRotation(-Direction.NorthEast.ToAngle()),
+                Matrix3.CreateRotation(-Direction.NorthWest.ToAngle())
+            };
 
             internal void Render(DrawingHandleWorld drawingHandle, ref Matrix3 spriteMatrix, Angle angle, Direction? overrideDirection)
             {

--- a/Robust.Client/Graphics/RSI/RSI.State.cs
+++ b/Robust.Client/Graphics/RSI/RSI.State.cs
@@ -152,9 +152,12 @@ namespace Robust.Client.Graphics
             /// <summary>
             ///     Specifies a direction in an RSI state.
             /// </summary>
+            /// <remarks>
+            ///     Value of the enum here matches the index used to store it in the icons array. If this ever changes, then
+            ///     <see cref="GameObjects.SpriteComponent.Layer._rsiDirectionMatrices"/> also needs to be updated.
+            /// </remarks>
             public enum Direction : byte
             {
-                // Value of the enum here matches the index used to store it in the icons array.
                 South = 0,
                 North = 1,
                 East = 2,


### PR DESCRIPTION
Fixing some of my shit code. Currently it is creating a new rotation matrix whenever layers are being rendered, rather than just using static matrices.