### PR TITLE
ProcGen Terrain Grids

### DIFF
--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -948,7 +948,10 @@ internal sealed partial class PVSSystem : EntitySystem
     }
 
     // Read Safe
-    private (Vector2 worldPos, float range, MapId mapId) CalcViewBounds(in EntityUid euid, EntityQuery<TransformComponent> transformQuery)
+    /// <summary>
+    /// Calculates the PVS world view bounds of an entity.
+    /// </summary>
+    internal (Vector2 worldPos, float range, MapId mapId) CalcViewBounds(in EntityUid euid, EntityQuery<TransformComponent> transformQuery)
     {
         var xform = transformQuery.GetComponent(euid);
         return (xform.WorldPosition, _viewSize / 2f, xform.MapID);

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -16,6 +16,7 @@ using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
+using Robust.Shared.Maths;
 using Robust.Shared.Network;
 using Robust.Shared.Network.Messages;
 using Robust.Shared.Timing;
@@ -209,7 +210,9 @@ namespace Robust.Server.GameStates
                         playerChunks[sessionIndex], metadataQuery, transformQuery, viewerEntities[sessionIndex])
                     : _pvs.GetAllEntityStates(session, lastAck, _gameTiming.CurTick);
                 var playerStates = _playerManager.GetPlayerStates(lastAck);
-                var mapData = _mapManager.GetStateData(lastAck);
+
+                var viewBounds = session.AttachedEntity is not null ? _pvs.CalcViewBounds(session.AttachedEntity.Value, transformQuery) : default;
+                var mapData = _mapManager.GetStateData(lastAck, (Box2.UnitCentered.Scale(viewBounds.range).Translated(viewBounds.worldPos), viewBounds.mapId));
 
                 // lastAck varies with each client based on lag and such, we can't just make 1 global state and send it to everyone
                 var lastInputCommand = inputSystem.GetLastInputCommand(session);

--- a/Robust.Shared/GameObjects/Components/Map/MapGridComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Map/MapGridComponent.cs
@@ -27,7 +27,7 @@ namespace Robust.Shared.GameObjects
     /// <inheritdoc cref="IMapGridComponent"/>
     [ComponentReference(typeof(IMapGridComponent))]
     [NetworkedComponent]
-    internal sealed class MapGridComponent : Component, IMapGridComponent
+    public sealed class MapGridComponent : Component, IMapGridComponent
     {
         [Dependency] private readonly IMapManagerInternal _mapManager = default!;
         [Dependency] private readonly IEntityManager _entMan = default!;
@@ -137,7 +137,7 @@ namespace Robust.Shared.GameObjects
             _chunkSize = state.ChunkSize;
         }
 
-        public MapGrid AllocMapGrid(ushort chunkSize, ushort tileSize)
+        internal MapGrid AllocMapGrid(ushort chunkSize, ushort tileSize)
         {
             DebugTools.Assert(LifeStage == ComponentLifeStage.Added);
 
@@ -151,7 +151,7 @@ namespace Robust.Shared.GameObjects
             return grid;
         }
 
-        public static void ApplyMapGridState(NetworkedMapManager networkedMapManager, IMapGridComponent gridComp, GameStateMapData.ChunkDatum[] chunkUpdates)
+        internal static void ApplyMapGridState(NetworkedMapManager networkedMapManager, IMapGridComponent gridComp, GameStateMapData.ChunkDatum[] chunkUpdates)
         {
             var grid = (MapGrid)gridComp.Grid;
             networkedMapManager.SuppressOnTileChanged = true;

--- a/Robust.Shared/Map/IMapGrid.cs
+++ b/Robust.Shared/Map/IMapGrid.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Maths;
@@ -60,6 +61,13 @@ namespace Robust.Shared.Map
         Matrix3 WorldMatrix { get; }
 
         Matrix3 InvWorldMatrix { get; }
+
+        /// <summary>
+        /// Generates a new chunk any time an unallocated chunk is accessed. Set this to true if you want to generate chunks
+        /// as they come into a client's view (procedural terrain gen). Keep this as false if you only want to generate a new chunk when it is
+        /// explicitly written to (manually constructing tiles on a ship).
+        /// </summary>
+        bool GenerateChunkOnView { get; set; }
 
         #region TileAccess
 

--- a/Robust.Shared/Map/IMapGridInternal.cs
+++ b/Robust.Shared/Map/IMapGridInternal.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.Maths;
 
 namespace Robust.Shared.Map
@@ -31,6 +32,14 @@ namespace Robust.Shared.Map
         /// <param name="chunkIndices">The indices of the chunk in this grid.</param>
         /// <returns>The existing or new chunk.</returns>
         MapChunk GetChunk(Vector2i chunkIndices);
+
+        /// <summary>
+        ///     Returns the chunk at the given indices.
+        /// </summary>
+        /// <param name="chunkIndices">The indices of the chunk in this grid.</param>
+        /// <param name="chunk">The existing chunk.</param>
+        /// <returns></returns>
+        bool TryGetChunk(Vector2i chunkIndices, [MaybeNullWhen(false)] out MapChunk chunk);
 
         /// <summary>
         /// Returns whether a chunk exists with the specified indices.

--- a/Robust.Shared/Map/IMapManagerInternal.cs
+++ b/Robust.Shared/Map/IMapManagerInternal.cs
@@ -51,5 +51,6 @@ namespace Robust.Shared.Map
         void TrueDeleteMap(MapId mapId);
         GridId GenerateGridId(GridId? forcedGridId);
         void OnGridAllocated(MapGridComponent gridComponent, MapGrid mapGrid);
+        void GenerateChunk(MapGrid grid, MapChunk newChunk);
     }
 }

--- a/Robust.Shared/Map/MapId.cs
+++ b/Robust.Shared/Map/MapId.cs
@@ -53,5 +53,17 @@ namespace Robust.Shared.Map
         {
             return Value.ToString();
         }
+
+        public static bool TryParse(string str, out MapId mapId)
+        {
+            if (int.TryParse(str, out var val))
+            {
+                mapId = new MapId(val);
+                return true;
+            }
+
+            mapId = default;
+            return false;
+        }
     }
 }

--- a/Robust.Shared/Map/MapManager.GridCollection.cs
+++ b/Robust.Shared/Map/MapManager.GridCollection.cs
@@ -137,6 +137,11 @@ internal partial class MapManager
         return CreateGrid(currentMapId, forcedGridId, chunkSize, default);
     }
 
+    public void GenerateChunk(MapGrid grid, MapChunk newChunk)
+    {
+        EntityManager.EventBus.RaiseLocalEvent(grid.GridEntityId, new ChunkGenerateEvent(grid, newChunk.Indices));
+    }
+
     public IMapGrid GetGrid(GridId gridId)
     {
         DebugTools.Assert(gridId != GridId.Invalid);


### PR DESCRIPTION
This allows content to mark a grid to generate chunks when viewed by a player.
The grid raises an ECS event that can be handled by content, where any sort of planet terrain generation can happen.