### PR TITLE
Add error tolerance to physics map

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -355,6 +355,7 @@ namespace Robust.Shared.GameObjects
 
                     // offset position from world to parent
                     _parent = value.EntityId;
+                    var oldMapId = MapID;
                     ChangeMapId(newParent.MapID, xformQuery);
 
                     // preserve world rotation
@@ -364,7 +365,7 @@ namespace Robust.Shared.GameObjects
                     // Cache new GridID before raising the event.
                     GridID = GetGridIndex(xformQuery);
 
-                    var entParentChangedMessage = new EntParentChangedMessage(Owner, oldParent?.Owner);
+                    var entParentChangedMessage = new EntParentChangedMessage(Owner, oldParent?.Owner, oldMapId);
                     _entMan.EventBus.RaiseLocalEvent(Owner, ref entParentChangedMessage);
                 }
 
@@ -733,8 +734,8 @@ namespace Robust.Shared.GameObjects
             oldConcrete._children.Remove(uid);
 
             _parent = EntityUid.Invalid;
+            var entParentChangedMessage = new EntParentChangedMessage(Owner, oldParent, MapID);
             MapID = MapId.Nullspace;
-            var entParentChangedMessage = new EntParentChangedMessage(Owner, oldParent);
             _entMan.EventBus.RaiseLocalEvent(Owner, ref entParentChangedMessage);
 
             // Does it even make sense to call these since this is called purely from OnRemove right now?

--- a/Robust.Shared/GameObjects/EntitySystemMessages/EntParentChangedMessage.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/EntParentChangedMessage.cs
@@ -19,11 +19,12 @@ namespace Robust.Shared.GameObjects
         public EntityUid? OldParent { get; }
 
         /// <summary>
-        ///     Old map Id.
+        ///     The map Id that the entity was on before its parent changed.
         /// </summary>
         /// <remarks>
-        ///     If the old parent has been detached to null, this will differ from the old-parent's map ID. Also avoids
-        ///     having to fetch the old parent's transform component.
+        ///     If the old parent was detached to null without manually updating the map ID of its children, then this
+        ///     is required as we cannot simply use the old parent's map ID. Also avoids having to fetch the old
+        ///     parent's transform component.
         /// </remarks>
         public MapId OldMapId { get; }
 

--- a/Robust.Shared/GameObjects/EntitySystemMessages/EntParentChangedMessage.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/EntParentChangedMessage.cs
@@ -1,4 +1,6 @@
-﻿namespace Robust.Shared.GameObjects
+using Robust.Shared.Map;
+
+namespace Robust.Shared.GameObjects
 {
     /// <summary>
     ///     Raised when an entity parent is changed.
@@ -17,14 +19,24 @@
         public EntityUid? OldParent { get; }
 
         /// <summary>
+        ///     Old map Id.
+        /// </summary>
+        /// <remarks>
+        ///     If the old parent has been detached to null, this will differ from the old-parent's map ID. Also avoids
+        ///     having to fetch the old parent's transform component.
+        /// </remarks>
+        public MapId OldMapId { get; }
+
+        /// <summary>
         ///     Creates a new instance of <see cref="EntParentChangedMessage"/>.
         /// </summary>
         /// <param name="entity"></param>
         /// <param name="oldParent"></param>
-        public EntParentChangedMessage(EntityUid entity, EntityUid? oldParent)
+        public EntParentChangedMessage(EntityUid entity, EntityUid? oldParent, MapId oldMapId)
         {
             Entity = entity;
             OldParent = oldParent;
+            OldMapId = oldMapId;
         }
     }
 }

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -125,15 +125,12 @@ namespace Robust.Shared.GameObjects
                 _broadphase.UpdateBroadphase(body, xform: xform);
 
             // Handle map change
-            var oldMapId = _transform.GetMapId(args.OldParent);
             var mapId = _transform.GetMapId(args.Entity);
 
-            if (oldMapId != mapId)
-            {
-                HandleMapChange(body, xform, oldMapId, mapId);
-            }
+            if (args.OldMapId != mapId)
+                HandleMapChange(body, xform, args.OldMapId, mapId);
 
-            if (!_container.IsEntityInContainer(uid, meta))
+            if (mapId != MapId.Nullspace && !_container.IsEntityInContainer(uid, meta))
                 HandleParentChangeVelocity(uid, body, ref args, xform);
         }
 
@@ -162,10 +159,10 @@ namespace Robust.Shared.GameObjects
                 map.AddBody(body);
             }
 
-            if (_mapManager.IsGrid(body.Owner) ||
-                _mapManager.IsMap(body.Owner) ||
-                xform.ChildCount == 0 ||
-                (oldMap == null && map == null)) return;
+            if (xform.ChildCount == 0 ||
+                (oldMap == null && map == null) ||
+                _mapManager.IsGrid(body.Owner) ||
+                _mapManager.IsMap(body.Owner)) return;
 
             var xformQuery = GetEntityQuery<TransformComponent>();
             var bodyQuery = GetEntityQuery<PhysicsComponent>();

--- a/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
+++ b/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
@@ -302,6 +302,14 @@ namespace Robust.Shared.Physics.Dynamics
             {
                 // TODO: When this gets ECSd add a helper and remove
 
+                if (seed.Deleted)
+                {
+                    // This should never happen. Yet it does.
+                    Logger.Error($"Deleted physics component in awake bodies set. Owner Uid: {seed.Owner}. Physics map: {_entityManager.ToPrettyString(Owner)}");
+                    RemoveBody(seed);
+                    continue;
+                }
+
                 // I tried not running prediction for non-contacted entities but unfortunately it looked like shit
                 // when contact broke so if you want to try that then GOOD LUCK.
                 if (seed.Island ||


### PR DESCRIPTION
This PR prevents PhysicsMapComponent from entering an infinite loop of errors when a deleted entity gets added to the list of awake entities.

It also adds some code to make sure that if ever a parent of an entity is detached to null before the child is, that the child will still properly remove itself from the physics map. Basically removes code that was relying on the old-parent's MapId to determine an entity's old-map ID. Even after these changes, a deleted entity will sometimes still appear in a client's awake bodies list. Still not sure what causes that, but at least it won't enter an error loop.