### PR TITLE
attribute/analyser to restrict attributeusage to members of types that have basetype X

### DIFF
--- a/Robust.Analyzers/Diagnostics.cs
+++ b/Robust.Analyzers/Diagnostics.cs
@@ -8,6 +8,8 @@ public static class Diagnostics
     public const string IdSerializable = "RA0001";
     public const string IdFriend = "RA0002";
     public const string IdExplicitVirtual = "RA0003";
+    public const string MemberRequiresBaseType = "RA0004";
+
 
     public static SuppressionDescriptor MeansImplicitAssignment =>
         new SuppressionDescriptor("RADC1000", "CS0649", "Marked as implicitly assigned.");

--- a/Robust.Analyzers/FriendAnalyzer.cs
+++ b/Robust.Analyzers/FriendAnalyzer.cs
@@ -93,7 +93,7 @@ namespace Robust.Analyzers
                             continue;
 
                         // If we find that the containing class is specified in the attribute, return! All is good.
-                        if (InheritsFromOrEquals(containingType, t))
+                        if (Utils.InheritsFromOrEquals(containingType, t))
                             return;
                     }
 
@@ -102,27 +102,6 @@ namespace Robust.Analyzers
                         Diagnostic.Create(Rule, context.Node.GetLocation(),
                             $"{context.Node.ToString().Split('.').LastOrDefault()}", $"{type.Name}"));
                 }
-            }
-        }
-
-        private bool InheritsFromOrEquals(INamedTypeSymbol type, INamedTypeSymbol baseType)
-        {
-            foreach (var otherType in GetBaseTypesAndThis(type))
-            {
-                if (SymbolEqualityComparer.Default.Equals(otherType, baseType))
-                    return true;
-            }
-
-            return false;
-        }
-
-        private IEnumerable<INamedTypeSymbol> GetBaseTypesAndThis(INamedTypeSymbol namedType)
-        {
-            var current = namedType;
-            while (current != null)
-            {
-                yield return current;
-                current = current.BaseType;
             }
         }
     }

--- a/Robust.Analyzers/FriendAnalyzer.cs
+++ b/Robust.Analyzers/FriendAnalyzer.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;

--- a/Robust.Analyzers/MemberRequiresBaseTypeAnalyzer.cs
+++ b/Robust.Analyzers/MemberRequiresBaseTypeAnalyzer.cs
@@ -67,7 +67,6 @@ public class MemberRequiresBaseTypeAnalyzer : DiagnosticAnalyzer
                         matchedType |= Utils.InheritsFromOrEquals(obj.Symbol.ContainingType, t);
                     }
 
-                    Debugger.Launch();
                     if (!matchedType)
                     {
                         obj.ReportDiagnostic(Diagnostic.Create(Rule, obj.Symbol.Locations.First(), string.Join(",", allowedTypes)));

--- a/Robust.Analyzers/MemberRequiresBaseTypeAnalyzer.cs
+++ b/Robust.Analyzers/MemberRequiresBaseTypeAnalyzer.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Robust.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class MemberRequiresBaseTypeAnalyzer : DiagnosticAnalyzer
+{
+    private const string AnalyzerAttribute = "Robust.Shared.Analyzers.MemberRequiresBaseTypeAttribute";
+
+    [SuppressMessage("ReSharper", "RS2008")]
+    private static readonly DiagnosticDescriptor Rule = new (
+        Diagnostics.MemberRequiresBaseType,
+        "Required basetype missing",
+        "You can only use this attribute for members of types which are subtypes of \"{0}\"",
+        "Usage",
+        DiagnosticSeverity.Error,
+        true,
+        "Make sure to specify the accessing class in the friends attribute.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(CheckBaseType, SymbolKind.Field);
+        context.RegisterSymbolAction(CheckBaseType, SymbolKind.Property);
+        context.RegisterSymbolAction(CheckBaseType, SymbolKind.Method);
+        context.RegisterSymbolAction(CheckBaseType, SymbolKind.Event);
+    }
+
+    private void CheckBaseType(SymbolAnalysisContext obj)
+    {
+        if(obj.Symbol.ContainingType == null) return;
+
+        var analyzerAttribute = obj.Compilation.GetTypeByMetadataName(AnalyzerAttribute);
+
+        INamedTypeSymbol requiredBaseType = null;
+        foreach (var attribute in obj.Symbol.GetAttributes())
+        {
+            if(attribute.AttributeClass == null) continue;
+
+            foreach (var attributeAttribute in attribute.AttributeClass.GetAttributes())
+            {
+                if (SymbolEqualityComparer.Default.Equals(analyzerAttribute, attributeAttribute.AttributeClass))
+                {
+                    requiredBaseType = (INamedTypeSymbol) attributeAttribute.ConstructorArguments[0].Value;
+                }
+            }
+        }
+
+        if(requiredBaseType == null) return;
+
+        if (!Utils.InheritsFromOrEquals(obj.Symbol.ContainingType, requiredBaseType))
+        {
+            obj.ReportDiagnostic(Diagnostic.Create(Rule, obj.Symbol.Locations.First(), requiredBaseType.Name));
+        }
+    }
+}
+

--- a/Robust.Analyzers/MemberRequiresBaseTypeAnalyzer.cs
+++ b/Robust.Analyzers/MemberRequiresBaseTypeAnalyzer.cs
@@ -21,7 +21,7 @@ public class MemberRequiresBaseTypeAnalyzer : DiagnosticAnalyzer
         "Usage",
         DiagnosticSeverity.Error,
         true,
-        "Make sure to specify the accessing class in the friends attribute.");
+        "Make sure to inherit the correct basetype.");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/Robust.Analyzers/Utils.cs
+++ b/Robust.Analyzers/Utils.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace Robust.Analyzers;
+
+public static class Utils
+{
+   public static bool InheritsFromOrEquals(INamedTypeSymbol type, INamedTypeSymbol baseType)
+    {
+        foreach (var otherType in GetBaseTypesAndThis(type))
+        {
+            if (SymbolEqualityComparer.Default.Equals(otherType, baseType))
+                return true;
+        }
+
+        return false;
+    }
+
+    public static IEnumerable<INamedTypeSymbol> GetBaseTypesAndThis(INamedTypeSymbol namedType)
+    {
+        var current = namedType;
+        while (current != null)
+        {
+            yield return current;
+            current = current.BaseType;
+        }
+    }
+}

--- a/Robust.Shared/Analyzers/MemberRequiresBaseTypeAttribute.cs
+++ b/Robust.Shared/Analyzers/MemberRequiresBaseTypeAttribute.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using JetBrains.Annotations;
+
+namespace Robust.Shared.Analyzers;
+
+[AttributeUsage(AttributeTargets.Class)]
+[BaseTypeRequired(typeof(Attribute))]
+public sealed class MemberRequiresBaseTypeAttribute : Attribute
+{
+    public readonly Type[] Friends;
+
+    public MemberRequiresBaseTypeAttribute(params Type[] friends)
+    {
+        Friends = friends;
+    }
+
+}


### PR DESCRIPTION
what it says on the tin

doesnt work for unknown reasons rn, no time to look into it further atm

Example:
```csharp
[MemberRequiresBaseType(typeof(BaseType))]
public class AnalyzerTestAttribute : Attribute { }

public abstract class BaseType {}

public sealed class ChildType : BaseType
{
    [AnalyzerTest] //valid usage
    public int AnalyzerTest;
}

public sealed class NonChildType
{
    [AnalyzerTest] //invalid usage, produces error
    public int Test;
}
```