### PR TITLE
Improves SpriteSystem.GetPrototypeIcon method significantly.

### DIFF
--- a/Robust.Client/GameObjects/Components/Icon/IconComponent.cs
+++ b/Robust.Client/GameObjects/Components/Icon/IconComponent.cs
@@ -1,3 +1,4 @@
+using System;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Client.Utility;
@@ -32,11 +33,13 @@ namespace Robust.Client.GameObjects
         public const string LogCategory = "go.comp.icon";
         const string SerializationCache = "icon";
 
+        [Obsolete("Use SpriteSystem instead.")]
         private static IRsiStateLike TextureForConfig(IconComponent compData, IResourceCache resourceCache)
         {
             return compData.Icon?.Default ?? resourceCache.GetFallback<TextureResource>().Texture;
         }
 
+        [Obsolete("Use SpriteSystem instead.")]
         public static IRsiStateLike? GetPrototypeIcon(EntityPrototype prototype, IResourceCache resourceCache)
         {
             if (!prototype.Components.TryGetValue("Icon", out var compData))

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1520,6 +1520,7 @@ namespace Robust.Client.GameObjects
             }
         }
 
+        [Obsolete("Use SpriteSystem instead.")]
         internal static RSI.State GetFallbackState(IResourceCache cache)
         {
             var rsi = cache.GetResource<RSIResource>("/Textures/error.rsi").RSI;

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Specifier.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Specifier.cs
@@ -16,14 +16,12 @@ public sealed partial class SpriteSystem
 {
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly IResourceCache _resourceCache = default!;
-
-    [Pure]
+    
     public Texture Frame0(SpriteSpecifier specifier)
     {
         return RsiStateLike(specifier).Default;
     }
 
-    [Pure]
     public IRsiStateLike RsiStateLike(SpriteSpecifier specifier)
     {
         switch (specifier)
@@ -48,7 +46,6 @@ public sealed partial class SpriteSystem
         }
     }
 
-    [Pure]
     public IRsiStateLike GetPrototypeIcon(EntityPrototype prototype, IResourceCache resourceCache)
     {
         var icon = IconComponent.GetPrototypeIcon(prototype, _resourceCache);

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
@@ -23,6 +23,7 @@ namespace Robust.Client.GameObjects
         {
             base.Initialize();
 
+            _proto.PrototypesReloaded += OnPrototypesReloaded;
             SubscribeLocalEvent<SpriteUpdateInertEvent>(QueueUpdateInert);
         }
 

--- a/Robust.Client/ResourceManagement/ResourceTypes/RSIResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/RSIResource.cs
@@ -22,6 +22,8 @@ namespace Robust.Client.ResourceManagement
     {
         private static readonly float[] OneArray = {1};
 
+        public override ResourcePath? Fallback => new("/Textures/error.rsi");
+
         private static readonly JsonSerializerOptions SerializerOptions =
             new JsonSerializerOptions(JsonSerializerDefaults.Web)
             {


### PR DESCRIPTION
No breaking changes, only a new overload and a buncha methods marked as obsolete. See commits for more info!