### PR TITLE
Make RemoveComp not error on missing component

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -325,35 +325,50 @@ namespace Robust.Shared.GameObjects
 
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void RemoveComponent<T>(EntityUid uid)
+        public bool RemoveComponent<T>(EntityUid uid)
         {
-            RemoveComponent(uid, typeof(T));
+            return RemoveComponent(uid, typeof(T));
         }
 
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void RemoveComponent(EntityUid uid, Type type)
+        public bool RemoveComponent(EntityUid uid, Type type)
         {
-            RemoveComponentImmediate((Component)GetComponent(uid, type), uid, false);
+            if (!TryGetComponent(uid, type, out var comp))
+                return false;
+
+            RemoveComponentImmediate((Component)comp, uid, false);
+            return true;
         }
 
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void RemoveComponent(EntityUid uid, ushort netId)
+        public bool RemoveComponent(EntityUid uid, ushort netId)
         {
-            RemoveComponentImmediate((Component)GetComponent(uid, netId), uid, false);
+            if (!TryGetComponent(uid, netId, out var comp))
+                return false;
+
+            RemoveComponentImmediate((Component)comp, uid, false);
+            return true;
         }
 
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void RemoveComponent(EntityUid uid, IComponent component)
         {
+            RemoveComponent(uid, (Component)component);
+        }
+
+        /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void RemoveComponent(EntityUid uid, Component component)
+        {
             if (component == null) throw new ArgumentNullException(nameof(component));
 
             if (component.Owner != uid)
                 throw new InvalidOperationException("Component is not owned by entity.");
 
-            RemoveComponentImmediate((Component)component, uid, false);
+            RemoveComponentImmediate(component, uid, false);
         }
 
         private static IEnumerable<Component> InSafeOrder(IEnumerable<Component> comps, bool forCreation = false)

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -519,11 +519,31 @@ public partial class EntitySystem
 
     /// <inheritdoc cref="IEntityManager.RemoveComponent&lt;T&gt;(EntityUid)"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected void RemComp<T>(EntityUid uid) where T : class, IComponent
+    protected bool RemComp<T>(EntityUid uid) where T : class, IComponent
     {
-        EntityManager.RemoveComponent<T>(uid);
+        return EntityManager.RemoveComponent<T>(uid);
     }
 
+    /// <inheritdoc cref="IEntityManager.RemoveComponent(EntityUid, Type)"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected bool RemComp(EntityUid uid, Type type)
+    {
+        return EntityManager.RemoveComponent(uid, type);
+    }
+
+    /// <inheritdoc cref="IEntityManager.RemoveComponent(EntityUid, Component)"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected void RemComp(EntityUid uid, Component component)
+    {
+        EntityManager.RemoveComponent(uid, component);
+    }
+
+    /// <inheritdoc cref="IEntityManager.RemoveComponent(EntityUid, IComponent)"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected void RemComp(EntityUid uid, IComponent component)
+    {
+        EntityManager.RemoveComponent(uid, component);
+    }
     #endregion
 
     #region Entity Delete

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -68,28 +68,37 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         /// <typeparam name="T">The component reference type to remove.</typeparam>
         /// <param name="uid">Entity UID to modify.</param>
-        void RemoveComponent<T>(EntityUid uid);
+        bool RemoveComponent<T>(EntityUid uid);
 
         /// <summary>
         ///     Removes the component with a specified type.
         /// </summary>
         /// <param name="uid">Entity UID to modify.</param>
         /// <param name="type">A trait or component type to check for.</param>
-        void RemoveComponent(EntityUid uid, Type type);
+        /// <returns>Returns false if the entity did not have the specified component.</returns>
+        bool RemoveComponent(EntityUid uid, Type type);
 
         /// <summary>
         ///     Removes the component with a specified network ID.
         /// </summary>
         /// <param name="uid">Entity UID to modify.</param>
         /// <param name="netID">Network ID of the component to remove.</param>
-        void RemoveComponent(EntityUid uid, ushort netID);
+        /// <returns>Returns false if the entity did not have the specified component.</returns>
+        bool RemoveComponent(EntityUid uid, ushort netID);
 
         /// <summary>
-        ///     Removes the specified component.
+        ///     Removes the specified component. Throws if the given component does not belong to the entity.
         /// </summary>
         /// <param name="uid">Entity UID to modify.</param>
         /// <param name="component">Component to remove.</param>
         void RemoveComponent(EntityUid uid, IComponent component);
+
+        /// <summary>
+        ///     Removes the specified component. Throws if the given component does not belong to the entity.
+        /// </summary>
+        /// <param name="uid">Entity UID to modify.</param>
+        /// <param name="component">Component to remove.</param>
+        void RemoveComponent(EntityUid uid, Component component);
 
         /// <summary>
         ///     Removes all components from an entity, except the required components.


### PR DESCRIPTION
https://discord.com/channels/310555209753690112/770682801607278632/960780462798823454

- Makes some of the remove component functions return a bool instead of just erroring.
  - The variants that have a component passed in still just throw.
- Adds a proxy method for the function that takes the component as an input (to avoid unnecessary try-get-comp calls)
- Adds function variants that directly take a `Component`, instead of `IComponent` variants, to avoid unnecessarily casting to `IComponent` before just casting back down to to `Component`.
  - I have no idea if this actually matters for performance.