### PR TITLE
Don't allow velocity to be set where an obj can't collide

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.Components.cs
@@ -8,7 +8,8 @@ public partial class SharedPhysicsSystem
 {
     public void SetLinearVelocity(PhysicsComponent body, Vector2 velocity)
     {
-        if (body.BodyType == BodyType.Static) return;
+        if (body.BodyType == BodyType.Static ||
+            !body.CanCollide) return;
 
         if (Vector2.Dot(velocity, velocity) > 0.0f)
             body.Awake = true;


### PR DESCRIPTION
Mover code was doing this client-side. Really CanCollide should be renamed to Enabled like it is on box2d I think.