### PR TITLE
Add "midipanic" command.

### DIFF
--- a/Resources/Locale/en-US/midi-commands.ftl
+++ b/Resources/Locale/en-US/midi-commands.ftl
@@ -1,0 +1,1 @@
+midi-panic-command-description = Turns off every note for every active MIDI renderer.

--- a/Robust.Client/Audio/Midi/Commands/MidiPanicCommand.cs
+++ b/Robust.Client/Audio/Midi/Commands/MidiPanicCommand.cs
@@ -1,0 +1,22 @@
+using Robust.Shared.Console;
+using Robust.Shared.IoC;
+using Robust.Shared.Localization;
+
+namespace Robust.Client.Audio.Midi.Commands;
+
+public sealed class MidiPanicCommand : IConsoleCommand
+{
+    [Dependency] private readonly IMidiManager _midiManager = default!;
+
+    public string Command => "midipanic";
+    public string Description => Loc.GetString("midi-panic-command-description");
+    public string Help => $"{Command}";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        foreach (var renderer in _midiManager.Renderers)
+        {
+            renderer.StopAllNotes();
+        }
+    }
+}

--- a/Robust.Client/Audio/Midi/IMidiManager.cs
+++ b/Robust.Client/Audio/Midi/IMidiManager.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NFluidsynth;
 using Robust.Shared.Audio.Midi;
 
@@ -5,6 +6,11 @@ namespace Robust.Client.Audio.Midi;
 
 public interface IMidiManager
 {
+    /// <summary>
+    ///     A read-only list of all existing MIDI Renderers.
+    /// </summary>
+    IReadOnlyList<IMidiRenderer> Renderers { get; }
+
     /// <summary>
     ///     If true, MIDI support is available.
     /// </summary>

--- a/Robust.Client/Audio/Midi/MidiManager.cs
+++ b/Robust.Client/Audio/Midi/MidiManager.cs
@@ -33,6 +33,18 @@ internal sealed partial class MidiManager : IMidiManager
 
     private SharedPhysicsSystem _broadPhaseSystem = default!;
 
+    public IReadOnlyList<IMidiRenderer> Renderers
+    {
+        get
+        {
+            lock (_renderers)
+            {
+                // Perform a copy. Sadly, we can't return a reference to the original list due to threading concerns.
+                return _renderers.ToArray();
+            }
+        }
+    }
+
     [ViewVariables]
     public bool IsAvailable
     {

--- a/Robust.Client/Audio/Midi/MidiRenderer.cs
+++ b/Robust.Client/Audio/Midi/MidiRenderer.cs
@@ -138,7 +138,11 @@ internal sealed class MidiRenderer : IMidiRenderer
     public uint SequencerTick => !Disposed ? _sequencer?.Tick ?? 0 : 0;
 
     [ViewVariables(VVAccess.ReadWrite)]
-    public double SequencerTimeScale => !Disposed ? _sequencer?.TimeScale ?? 0 : 0;
+    public double SequencerTimeScale
+    {
+        get => !Disposed ? _sequencer?.TimeScale ?? 0 : 0;
+        set => _sequencer.TimeScale = value;
+    }
 
     [ViewVariables(VVAccess.ReadWrite)]
     public bool Mono { get; set; }


### PR DESCRIPTION
This command sends a "turn off all notes" event to all active MIDI renderers.
Useful in case there's a MIDI renderer with stuck notes driving you crazy.