### PR TITLE
Sync current time

### DIFF
--- a/Robust.Client/GameStates/GameStateProcessor.cs
+++ b/Robust.Client/GameStates/GameStateProcessor.cs
@@ -123,7 +123,13 @@ namespace Robust.Client.GameStates
             }
 
             if (applyNextState && !curState!.Extrapolated)
+            {
                 LastProcessedRealState = curState.ToSequence;
+
+                // Keep the client and the server current-time calculation in sync 
+                if (curState.ToTime != null)
+                    _timing.CachedCurTimeInfo = (curState.ToTime.Value, curState.ToSequence);
+            }
 
             if (!_waitingForFull)
             {
@@ -204,6 +210,9 @@ namespace Robust.Client.GameStates
                     Logger.DebugS("net", $"Resync CurTick to: {_lastFullState.ToSequence}");
 
                 var curTick = _timing.CurTick = _lastFullState.ToSequence;
+
+                if (_lastFullState.ToTime != null)
+                    _timing.CachedCurTimeInfo = (_lastFullState.ToTime.Value, _lastFullState.ToSequence);
 
                 if (Interpolation)
                 {

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -171,6 +171,7 @@ namespace Robust.Server.GameStates
             const int BatchSize = 2;
             var batches = (int) MathF.Ceiling((float) players.Length / BatchSize);
 
+            var curTime = _gameTiming.CurTime;
             Parallel.For(0, batches, i =>
             {
                 var start = i * BatchSize;
@@ -180,7 +181,7 @@ namespace Robust.Server.GameStates
                 {
                     try
                     {
-                        SendStateUpdate(j);
+                        SendStateUpdate(j, curTime);
                     }
                     catch (Exception e) // Catch EVERY exception
                     {
@@ -189,7 +190,7 @@ namespace Robust.Server.GameStates
                 }
             });
 
-            void SendStateUpdate(int sessionIndex)
+            void SendStateUpdate(int sessionIndex, TimeSpan curTime)
             {
                 var session = players[sessionIndex];
 
@@ -214,7 +215,7 @@ namespace Robust.Server.GameStates
                 // lastAck varies with each client based on lag and such, we can't just make 1 global state and send it to everyone
                 var lastInputCommand = inputSystem.GetLastInputCommand(session);
                 var lastSystemMessage = _entityNetworkManager.GetLastMessageSequence(session);
-                var state = new GameState(lastAck, _gameTiming.CurTick, Math.Max(lastInputCommand, lastSystemMessage), entStates, playerStates, deletions, mapData);
+                var state = new GameState(lastAck, _gameTiming.CurTick, Math.Max(lastInputCommand, lastSystemMessage), entStates, playerStates, deletions, mapData, curTime);
 
                 InterlockedHelper.Min(ref oldestAckValue, lastAck.Value);
 

--- a/Robust.Shared/GameStates/GameState.cs
+++ b/Robust.Shared/GameStates/GameState.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization;
 using System;
 using System.Diagnostics;
@@ -27,10 +27,11 @@ namespace Robust.Shared.GameStates
         /// <summary>
         /// Constructor!
         /// </summary>
-        public GameState(GameTick fromSequence, GameTick toSequence, uint lastInput, NetListAsArray<EntityState> entities, NetListAsArray<PlayerState> players, NetListAsArray<EntityUid> deletions, GameStateMapData? mapData)
+        public GameState(GameTick fromSequence, GameTick toSequence, uint lastInput, NetListAsArray<EntityState> entities, NetListAsArray<PlayerState> players, NetListAsArray<EntityUid> deletions, GameStateMapData? mapData, TimeSpan? toTime = null)
         {
             FromSequence = fromSequence;
             ToSequence = toSequence;
+            ToTime = toTime;
             LastProcessedInput = lastInput;
             EntityStates = entities;
             PlayerStates = players;
@@ -40,6 +41,15 @@ namespace Robust.Shared.GameStates
 
         public readonly GameTick FromSequence;
         public readonly GameTick ToSequence;
+
+        /// <summary>
+        ///     The current time corresponding to tick <see cref="ToSequence"/>.
+        /// </summary>
+        /// <remarks>
+        ///     If tick-rate is constant, this could just be inferred from the current tick. But with dynamic tick
+        ///     timing, and in the event of tick time cvar updates being dropped, this just ensures they stay in sync.
+        /// </remarks>
+        public readonly TimeSpan? ToTime;
 
         public readonly uint LastProcessedInput;
 

--- a/Robust.Shared/Timing/GameTiming.cs
+++ b/Robust.Shared/Timing/GameTiming.cs
@@ -48,7 +48,7 @@ namespace Robust.Shared.Timing
         //
         // Notice that it starts from GameTick 1  - the "first tick" has no impact
         // on timing
-        private (TimeSpan, GameTick) _cachedCurTimeInfo = (TimeSpan.Zero, GameTick.First);
+        public (TimeSpan, GameTick) CachedCurTimeInfo { get; set; } = (TimeSpan.Zero, GameTick.First);
 
         /// <summary>
         ///     The current synchronized uptime of the simulation. Use this for in-game timing. This can be rewound for
@@ -59,7 +59,7 @@ namespace Robust.Shared.Timing
             get
             {
                 // last tickrate change epoch
-                var (time, lastTimeTick) = _cachedCurTimeInfo;
+                var (time, lastTimeTick) = CachedCurTimeInfo;
 
                 // add our current time to it.
                 // the server never rewinds time, and the client never rewinds time outside of prediction.
@@ -207,7 +207,7 @@ namespace Robust.Shared.Timing
         // Call this whenever you change the TickRate.
         private void CacheCurTime()
         {
-            var (cachedTime, lastTimeTick) = _cachedCurTimeInfo;
+            var (cachedTime, lastTimeTick) = CachedCurTimeInfo;
 
             TimeSpan newTime;
 
@@ -217,7 +217,7 @@ namespace Robust.Shared.Timing
               newTime = cachedTime - (TickPeriod * (lastTimeTick.Value - CurTick.Value));
 
             DebugTools.Assert(TimeSpan.Zero <= newTime);
-            _cachedCurTimeInfo = (newTime, CurTick);
+            CachedCurTimeInfo = (newTime, CurTick);
         }
 
         /// <summary>
@@ -225,7 +225,7 @@ namespace Robust.Shared.Timing
         /// </summary>
         public void ResetSimTime()
         {
-            _cachedCurTimeInfo = (TimeSpan.Zero, GameTick.First);;
+            CachedCurTimeInfo = (TimeSpan.Zero, GameTick.First);
             CurTick = GameTick.First;
             TickRemainder = TimeSpan.Zero;
             Paused = true;

--- a/Robust.Shared/Timing/IGameTiming.cs
+++ b/Robust.Shared/Timing/IGameTiming.cs
@@ -25,6 +25,8 @@ namespace Robust.Shared.Timing
         /// </summary>
         TimeSpan CurTime { get; }
 
+        (TimeSpan, GameTick) CachedCurTimeInfo { get; set; }
+
         /// <summary>
         ///     The current real uptime of the simulation. Use this for UI and out of game timing.
         /// </summary>


### PR DESCRIPTION
Currently the server and a client's `IGameTiming.CurTime` can differ. The current time is inferred from the current tick, tick-rate, and some reference point (a cached time & tick). Whenever the server cvar gets updated, the cached time & tick get updated, but otherwise it just starts at (1st tick = 0 seconds). This causes problems if a player joins a game after the tick-timing has been adjusted, because they just use that initial reference point, effectively assuming that the server has been running at that tick rate the whole time, and thus evaluating the wrong current-time. 

To reproduce the use-delay, do-after, lobby-timer and some other general client-side prediction bugs encountered during the stress test, just start a server with a client and let it run for a bit. Then raise the tick rate and connect a new client, which will then encounter those bugs.

This PR is a pretty straightforward fix that just includes the current time in the game state that the server sends out. I don't fully understand all the client-side code, with all the extrapolation / interpolation & other stuff so someone should definitely check that I haven't missed something obvious.