### PR TITLE
Add xform comp ref to parent change message

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -365,7 +365,7 @@ namespace Robust.Shared.GameObjects
                     // Cache new GridID before raising the event.
                     GridID = GetGridIndex(xformQuery);
 
-                    var entParentChangedMessage = new EntParentChangedMessage(Owner, oldParent?.Owner, oldMapId);
+                    var entParentChangedMessage = new EntParentChangedMessage(Owner, oldParent?.Owner, oldMapId, this);
                     _entMan.EventBus.RaiseLocalEvent(Owner, ref entParentChangedMessage);
                 }
 
@@ -734,8 +734,9 @@ namespace Robust.Shared.GameObjects
             oldConcrete._children.Remove(uid);
 
             _parent = EntityUid.Invalid;
-            var entParentChangedMessage = new EntParentChangedMessage(Owner, oldParent, MapID);
+            var entParentChangedMessage = new EntParentChangedMessage(Owner, oldParent, MapID, this);
             MapID = MapId.Nullspace;
+            GridID = GridId.Invalid;
             _entMan.EventBus.RaiseLocalEvent(Owner, ref entParentChangedMessage);
 
             // Does it even make sense to call these since this is called purely from OnRemove right now?

--- a/Robust.Shared/GameObjects/EntitySystemMessages/EntParentChangedMessage.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/EntParentChangedMessage.cs
@@ -28,16 +28,17 @@ namespace Robust.Shared.GameObjects
         /// </remarks>
         public MapId OldMapId { get; }
 
+        public TransformComponent Transform { get; }
+
         /// <summary>
         ///     Creates a new instance of <see cref="EntParentChangedMessage"/>.
         /// </summary>
-        /// <param name="entity"></param>
-        /// <param name="oldParent"></param>
-        public EntParentChangedMessage(EntityUid entity, EntityUid? oldParent, MapId oldMapId)
+        public EntParentChangedMessage(EntityUid entity, EntityUid? oldParent, MapId oldMapId, TransformComponent xform)
         {
             Entity = entity;
             OldParent = oldParent;
             OldMapId = oldMapId;
+            Transform = xform;
         }
     }
 }


### PR DESCRIPTION
Most engine stuff subscribing to this will want transformcomponent.
Also updated GridID upon detaching to null as I noticed it wasn't when debugging.