### PR TITLE
Fix sprite bb calculation

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1969,7 +1969,7 @@ namespace Robust.Client.GameObjects
             /// <inheritdoc/>
             public Box2 CalculateBoundingBox()
             {
-                var textureSize = PixelSize / EyeManager.PixelsPerMeter;
+                var textureSize = (Vector2) PixelSize / EyeManager.PixelsPerMeter;
 
                 // If the parent has locked rotation and we don't have any rotation,
                 // we can take the quick path of just making a box the size of the texture.


### PR DESCRIPTION
Turns out not all RSI/texture sizes are integer multiples of 32. 