### PR TITLE
Fix map loading once and for all.

### DIFF
--- a/Robust.Server/Console/Commands/MapCommands.cs
+++ b/Robust.Server/Console/Commands/MapCommands.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -120,11 +121,13 @@ namespace Robust.Server.Console.Commands
         {
             if (args.Length != 2 && args.Length != 3 && args.Length != 5 && args.Length != 6)
             {
+                shell.WriteError("Must have either 2, 3, 5, or 6 arguments.");
                 return;
             }
 
             if (!int.TryParse(args[0], out var intMapId))
             {
+                shell.WriteError($"{args[0]} is not a valid integer.");
                 return;
             }
 
@@ -147,22 +150,39 @@ namespace Robust.Server.Console.Commands
             var loadOptions = new MapLoadOptions();
             if (args.Length > 2)
             {
-                loadOptions.StoreMapUids = bool.Parse(args[2]);
+                if (!Boolean.TryParse(args[2], out var storeUids))
+                {
+                    shell.WriteError($"{args[2]} is not a valid boolean..");
+                    return;
+                }
+
+                loadOptions.StoreMapUids = storeUids;
             }
 
             if (args.Length >= 5)
             {
                 if (!int.TryParse(args[3], out var x))
+                {
+                    shell.WriteError($"{args[3]} is not a valid integer.");
                     return;
+                }
+
                 if (!int.TryParse(args[4], out var y))
+                {
+                    shell.WriteError($"{args[4]} is not a valid integer.");
                     return;
+                }
+
                 loadOptions.Offset = new Vector2(x, y);
             }
 
             if (args.Length == 6)
             {
                 if (!float.TryParse(args[5], out var rotation))
+                {
+                    shell.WriteError($"{args[5]} is not a valid integer.");
                     return;
+                }
 
                 loadOptions.Rotation = new Angle(rotation);
             }
@@ -212,11 +232,16 @@ namespace Robust.Server.Console.Commands
 
         public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            if (args.Length != 1 && args.Length != 3 && args.Length != 4)
-                return;
+            if (args.Length != 2 && args.Length != 4 && args.Length != 5)
+            {
+                shell.WriteError($"Must have either 2, 4, or 5 arguments.");
+            }
 
             if (!int.TryParse(args[0], out var intMapId))
+            {
+                shell.WriteError($"{args[0]} is not a valid integer.");
                 return;
+            }
 
             var mapId = new MapId(intMapId);
 
@@ -238,17 +263,27 @@ namespace Robust.Server.Console.Commands
 
             if (args.Length >= 3)
             {
-                if (!int.TryParse(args[1], out var x))
+                if (!int.TryParse(args[2], out var x))
+                {
+                    shell.WriteError($"{args[2]} is not a valid integer.");
                     return;
-                if (!int.TryParse(args[2], out var y))
+                }
+
+                if (!int.TryParse(args[3], out var y))
+                {
+                    shell.WriteError($"{args[3]} is not a valid integer.");
                     return;
+                }
                 loadOptions.Offset = new Vector2(x, y);
             }
 
             if (args.Length == 4)
             {
-                if (!float.TryParse(args[3], out var rotation))
+                if (!float.TryParse(args[4], out var rotation))
+                {
+                    shell.WriteError($"{args[4]} is not a valid integer.");
                     return;
+                }
 
                 loadOptions.Rotation = new Angle(rotation);
             }

--- a/Robust.Server/Console/Commands/MapCommands.cs
+++ b/Robust.Server/Console/Commands/MapCommands.cs
@@ -114,11 +114,11 @@ namespace Robust.Server.Console.Commands
     {
         public string Command => "loadbp";
         public string Description => "Loads a blueprint from disk into the game.";
-        public string Help => "loadbp <MapID> <Path> [storeUids]";
+        public string Help => "loadbp <MapID> <Path> [storeUids] [x y] [rotation]";
 
         public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            if (args.Length < 2)
+            if (args.Length != 2 && args.Length != 3 && args.Length != 5 && args.Length != 6)
             {
                 return;
             }
@@ -148,6 +148,23 @@ namespace Robust.Server.Console.Commands
             if (args.Length > 2)
             {
                 loadOptions.StoreMapUids = bool.Parse(args[2]);
+            }
+
+            if (args.Length >= 5)
+            {
+                if (!int.TryParse(args[3], out var x))
+                    return;
+                if (!int.TryParse(args[4], out var y))
+                    return;
+                loadOptions.Offset = new Vector2(x, y);
+            }
+
+            if (args.Length == 6)
+            {
+                if (!float.TryParse(args[5], out var rotation))
+                    return;
+
+                loadOptions.Rotation = new Angle(rotation);
             }
 
             var mapLoader = IoCManager.Resolve<IMapLoader>();
@@ -191,11 +208,11 @@ namespace Robust.Server.Console.Commands
     {
         public string Command => "loadmap";
         public string Description => "Loads a map from disk into the game.";
-        public string Help => "loadmap <MapID> <Path>";
+        public string Help => "loadmap <MapID> <Path> [x y] [rotation]";
 
         public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            if (args.Length < 1)
+            if (args.Length != 1 && args.Length != 3 && args.Length != 4)
                 return;
 
             if (!int.TryParse(args[0], out var intMapId))
@@ -217,7 +234,26 @@ namespace Robust.Server.Console.Commands
                 return;
             }
 
-            IoCManager.Resolve<IMapLoader>().LoadMap(mapId, args[1]);
+            var loadOptions = new MapLoadOptions();
+
+            if (args.Length >= 3)
+            {
+                if (!int.TryParse(args[1], out var x))
+                    return;
+                if (!int.TryParse(args[2], out var y))
+                    return;
+                loadOptions.Offset = new Vector2(x, y);
+            }
+
+            if (args.Length == 4)
+            {
+                if (!float.TryParse(args[3], out var rotation))
+                    return;
+
+                loadOptions.Rotation = new Angle(rotation);
+            }
+
+            IoCManager.Resolve<IMapLoader>().LoadMap(mapId, args[1], loadOptions);
 
             if (mapManager.MapExists(mapId))
                 shell.WriteLine($"Map {mapId} has been loaded from {args[1]}.");

--- a/Robust.Server/Maps/IMapLoader.cs
+++ b/Robust.Server/Maps/IMapLoader.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using YamlDotNet.RepresentationModel;
 
@@ -6,12 +8,12 @@ namespace Robust.Server.Maps
 {
     public interface IMapLoader
     {
-        IMapGrid? LoadBlueprint(MapId mapId, string path);
-        IMapGrid? LoadBlueprint(MapId mapId, string path, MapLoadOptions options);
+        (IReadOnlyList<EntityUid>, GridId?) LoadBlueprint(MapId mapId, string path);
+        (IReadOnlyList<EntityUid>, GridId?) LoadBlueprint(MapId mapId, string path, MapLoadOptions options);
         void SaveBlueprint(GridId gridId, string yamlPath);
 
-        void LoadMap(MapId mapId, string path);
-        void LoadMap(MapId mapId, string path, MapLoadOptions options);
+        (IReadOnlyList<EntityUid>, IReadOnlyList<GridId>) LoadMap(MapId mapId, string path);
+        (IReadOnlyList<EntityUid>, IReadOnlyList<GridId>) LoadMap(MapId mapId, string path, MapLoadOptions options);
         void SaveMap(MapId mapId, string yamlPath);
 
         event Action<YamlStream, string> LoadedMapData;

--- a/Robust.Server/Maps/IMapLoader.cs
+++ b/Robust.Server/Maps/IMapLoader.cs
@@ -8,12 +8,12 @@ namespace Robust.Server.Maps
 {
     public interface IMapLoader
     {
-        (IReadOnlyList<EntityUid>, GridId?) LoadBlueprint(MapId mapId, string path);
-        (IReadOnlyList<EntityUid>, GridId?) LoadBlueprint(MapId mapId, string path, MapLoadOptions options);
+        (IReadOnlyList<EntityUid> entities, GridId? gridId) LoadBlueprint(MapId mapId, string path);
+        (IReadOnlyList<EntityUid> entities, GridId? gridId) LoadBlueprint(MapId mapId, string path, MapLoadOptions options);
         void SaveBlueprint(GridId gridId, string yamlPath);
 
-        (IReadOnlyList<EntityUid>, IReadOnlyList<GridId>) LoadMap(MapId mapId, string path);
-        (IReadOnlyList<EntityUid>, IReadOnlyList<GridId>) LoadMap(MapId mapId, string path, MapLoadOptions options);
+        (IReadOnlyList<EntityUid> entities, IReadOnlyList<GridId> gridIds) LoadMap(MapId mapId, string path);
+        (IReadOnlyList<EntityUid> entities, IReadOnlyList<GridId> gridIds) LoadMap(MapId mapId, string path, MapLoadOptions options);
         void SaveMap(MapId mapId, string yamlPath);
 
         event Action<YamlStream, string> LoadedMapData;

--- a/Robust.Server/Maps/MapLoadOptions.cs
+++ b/Robust.Server/Maps/MapLoadOptions.cs
@@ -1,5 +1,9 @@
-﻿namespace Robust.Server.Maps
+﻿using JetBrains.Annotations;
+using Robust.Shared.Maths;
+
+namespace Robust.Server.Maps
 {
+    [PublicAPI]
     public sealed class MapLoadOptions
     {
         /// <summary>
@@ -7,5 +11,38 @@
         ///     to maintain consistency upon subsequent savings.
         /// </summary>
         public bool StoreMapUids { get; set; }
+
+        /// <summary>
+        ///     Offset to apply to the loaded objects.
+        /// </summary>
+        public Vector2 Offset
+        {
+            get => _offset;
+            set
+            {
+                TransformMatrix = Matrix3.CreateTransform(value, Rotation);
+                _offset = value;
+            }
+        }
+
+        private Vector2 _offset = Vector2.Zero;
+
+        /// <summary>
+        ///     Rotation to apply to the loaded objects as a collective, around 0, 0.
+        /// </summary>
+        /// <remarks>Setting this overrides <</remarks>
+        public Angle Rotation
+        {
+            get => _rotation;
+            set
+            {
+                TransformMatrix = Matrix3.CreateTransform(Offset, value);
+                _rotation = value;
+            }
+        }
+
+        private Angle _rotation = Angle.Zero;
+
+        public Matrix3 TransformMatrix { get; set; } = Matrix3.Identity;
     }
 }

--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -70,7 +70,7 @@ namespace Robust.Server.Maps
         }
 
         /// <inheritdoc />
-        public (IReadOnlyList<EntityUid>, GridId?) LoadBlueprint(MapId mapId, string path)
+        public (IReadOnlyList<EntityUid> entities, GridId? gridId) LoadBlueprint(MapId mapId, string path)
         {
             return LoadBlueprint(mapId, path, DefaultLoadOptions);
         }
@@ -80,7 +80,7 @@ namespace Robust.Server.Maps
             return new ResourcePath(path).ToRootedPath();
         }
 
-        public (IReadOnlyList<EntityUid>, GridId?) LoadBlueprint(MapId mapId, string path, MapLoadOptions options)
+        public (IReadOnlyList<EntityUid> entities, GridId? gridId) LoadBlueprint(MapId mapId, string path, MapLoadOptions options)
         {
             var resPath = Rooted(path);
 
@@ -163,7 +163,7 @@ namespace Robust.Server.Maps
             Logger.InfoS("map", "Save completed!");
         }
 
-        public (IReadOnlyList<EntityUid>, IReadOnlyList<GridId>) LoadMap(MapId mapId, string path)
+        public (IReadOnlyList<EntityUid> entities, IReadOnlyList<GridId> gridIds) LoadMap(MapId mapId, string path)
         {
             return LoadMap(mapId, path, DefaultLoadOptions);
         }
@@ -195,7 +195,7 @@ namespace Robust.Server.Maps
             return true;
         }
 
-        public (IReadOnlyList<EntityUid>, IReadOnlyList<GridId>) LoadMap(MapId mapId, string path, MapLoadOptions options)
+        public (IReadOnlyList<EntityUid> entities, IReadOnlyList<GridId> gridIds) LoadMap(MapId mapId, string path, MapLoadOptions options)
         {
             var resPath = Rooted(path);
 

--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -241,6 +241,7 @@ namespace Robust.Server.Maps
             private readonly Dictionary<GridId, int> GridIDMap = new();
             public readonly List<MapGrid> Grids = new();
             private readonly List<GridId> _readGridIndices = new();
+            private EntityQuery<TransformComponent>? _xformQuery = null;
 
             private readonly Dictionary<EntityUid, int> EntityUidMap = new();
             private readonly Dictionary<int, EntityUid> UidEntityMap = new();
@@ -354,6 +355,8 @@ namespace Robust.Server.Maps
                 // Grid entities were NOT created inside ReadGridSection().
                 // We have to fix the created grids up with the grid entities deserialized from the map.
                 FixMapEntities();
+
+                _xformQuery = _serverEntityManager.GetEntityQuery<TransformComponent>();
 
                 // We have to attach grids to the target map here.
                 // If we don't, initialization & startup can fail for some entities.
@@ -581,7 +584,7 @@ namespace Robust.Server.Maps
 
                 foreach (var grid in Grids)
                 {
-                    var transform = _serverEntityManager.GetComponent<TransformComponent>(grid.GridEntityId);
+                    var transform = _xformQuery!.Value.GetComponent(grid.GridEntityId);
                     if (transform.Parent != null)
                         continue;
 
@@ -728,7 +731,7 @@ namespace Robust.Server.Maps
 
                 foreach (var entity in Entities)
                 {
-                    if (!_serverEntityManager.TryGetComponent<TransformComponent>(entity, out var transform) ||
+                    if (!_xformQuery!.Value.TryGetComponent(entity, out var transform) ||
                         transform.ParentUid != map) continue;
 
                     var off = _loadOptions.TransformMatrix.Transform(transform.Coordinates.Position);

--- a/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
+++ b/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
@@ -102,11 +102,12 @@ entities:
             entMan.EnsureComponent<BroadphaseComponent>(mapUid);
 
             var mapLoad = IoCManager.Resolve<IMapLoader>();
-            var grid = mapLoad.LoadBlueprint(mapId, "/TestMap.yml");
+            var grid = mapLoad.LoadBlueprint(mapId, "/TestMap.yml").Item2;
 
             Assert.That(grid, NUnit.Framework.Is.Not.Null);
 
-            var entity = entMan.GetComponent<TransformComponent>(grid!.GridEntityId).Children.Single().Owner;
+            var geid = map.GetGridEuid(grid!.Value);
+            var entity = entMan.GetComponent<TransformComponent>(geid).Children.Single().Owner;
             var c = entMan.GetComponent<MapDeserializeTestComponent>(entity);
 
             Assert.That(c.Bar, Is.EqualTo(2));

--- a/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
+++ b/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
@@ -102,7 +102,7 @@ entities:
             entMan.EnsureComponent<BroadphaseComponent>(mapUid);
 
             var mapLoad = IoCManager.Resolve<IMapLoader>();
-            var grid = mapLoad.LoadBlueprint(mapId, "/TestMap.yml").Item2;
+            var grid = mapLoad.LoadBlueprint(mapId, "/TestMap.yml").gridId;
 
             Assert.That(grid, NUnit.Framework.Is.Not.Null);
 


### PR DESCRIPTION
Map loading now accounts for rotation and translation, and returns what entities and grids were loaded in as part of it's API.
`loadbp` and `loadmap` now allow you to load at a specific position with a given rotation.
Depends on https://github.com/space-wizards/space-station-14/pull/7501

This change requires a major version bump due to changing the maploading API in a non-backwards compatible way.