### PR TITLE
abstract prototype id validation

### DIFF
--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -136,7 +136,7 @@ namespace Robust.Shared.Prototypes
         /// The prototype we inherit from.
         /// </summary>
         [ViewVariables]
-        [ParentDataFieldAttribute(typeof(PrototypeIdSerializer<EntityPrototype>))]
+        [ParentDataFieldAttribute(typeof(AbstractPrototypeIdSerializer<EntityPrototype>))]
         public string? Parent { get; private set; }
 
         [ViewVariables]

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/Dictionary/PrototypeIdDictionarySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/Dictionary/PrototypeIdDictionarySerializer.cs
@@ -12,15 +12,23 @@ using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary
 {
-    // [TypeSerializer]
-    public sealed class PrototypeIdDictionarySerializer<TValue, TPrototype> :
+
+    public sealed class AbstractPrototypeIdDictionarySerializer<TValue, TPrototype> : PrototypeIdDictionarySerializer<TValue,
+            TPrototype> where TPrototype : class, IPrototype
+    {
+        protected override PrototypeIdSerializer<TPrototype> PrototypeSerializer =>
+            new AbstractPrototypeIdSerializer<TPrototype>();
+    }
+
+    [Virtual]
+    public class PrototypeIdDictionarySerializer<TValue, TPrototype> :
         ITypeSerializer<Dictionary<string, TValue>, MappingDataNode>,
         ITypeSerializer<SortedDictionary<string, TValue>, MappingDataNode>,
         ITypeSerializer<IReadOnlyDictionary<string, TValue>, MappingDataNode>
         where TPrototype : class, IPrototype
     {
         private readonly DictionarySerializer<string, TValue> _dictionarySerializer = new();
-        private readonly PrototypeIdSerializer<TPrototype> _prototypeSerializer = new();
+        protected virtual PrototypeIdSerializer<TPrototype> PrototypeSerializer => new();
 
         private ValidationNode Validate(ISerializationManager serializationManager, MappingDataNode node, IDependencyCollection dependencies, ISerializationContext? context)
         {
@@ -34,7 +42,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
                     continue;
                 }
 
-                mapping.Add(_prototypeSerializer.Validate(serializationManager, value, dependencies, context), serializationManager.ValidateNode(typeof(TValue), val, context));
+                mapping.Add(PrototypeSerializer.Validate(serializationManager, value, dependencies, context), serializationManager.ValidateNode(typeof(TValue), val, context));
             }
 
             return new ValidatedMappingNode(mapping);

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/List/PrototypeIdListSerializer.ImmutableList.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/List/PrototypeIdListSerializer.ImmutableList.cs
@@ -12,7 +12,7 @@ using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List
 {
-    public sealed partial class PrototypeIdListSerializer<T> :
+    public partial class PrototypeIdListSerializer<T> :
         ITypeSerializer<ImmutableList<string>, SequenceDataNode>
         where T : class, IPrototype
     {
@@ -33,7 +33,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
 
             foreach (var dataNode in node.Sequence)
             {
-                builder.Add(_prototypeSerializer.Read(
+                builder.Add(PrototypeSerializer.Read(
                     serializationManager,
                     (ValueDataNode) dataNode,
                     dependencies,

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/List/PrototypeIdListSerializer.ReadOnlyCollection.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/List/PrototypeIdListSerializer.ReadOnlyCollection.cs
@@ -11,7 +11,7 @@ using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List
 {
-    public sealed partial class PrototypeIdListSerializer<T> :
+    public partial class PrototypeIdListSerializer<T> :
         ITypeSerializer<IReadOnlyCollection<string>, SequenceDataNode>
         where T : class, IPrototype
     {
@@ -38,7 +38,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
 
             foreach (var dataNode in node.Sequence)
             {
-                list.Add(_prototypeSerializer.Read(
+                list.Add(PrototypeSerializer.Read(
                     serializationManager,
                     (ValueDataNode) dataNode,
                     dependencies,

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/List/PrototypeIdListSerializer.ReadOnlyList.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/List/PrototypeIdListSerializer.ReadOnlyList.cs
@@ -12,7 +12,7 @@ using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List
 {
-    public sealed partial class PrototypeIdListSerializer<T> : ITypeSerializer<IReadOnlyList<string>, SequenceDataNode>
+    public partial class PrototypeIdListSerializer<T> : ITypeSerializer<IReadOnlyList<string>, SequenceDataNode>
         where T : class, IPrototype
     {
         DataNode ITypeWriter<IReadOnlyList<string>>.Write(
@@ -49,7 +49,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
 
             foreach (var dataNode in node.Sequence)
             {
-                list.Add(_prototypeSerializer.Read(
+                list.Add(PrototypeSerializer.Read(
                     serializationManager,
                     (ValueDataNode) dataNode,
                     dependencies,
@@ -76,7 +76,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
                     continue;
                 }
 
-                list.Add(_prototypeSerializer.Validate(serializationManager, value, dependencies, context));
+                list.Add(PrototypeSerializer.Validate(serializationManager, value, dependencies, context));
             }
 
             return new ValidatedSequenceNode(list);

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/List/PrototypeIdListSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/List/PrototypeIdListSerializer.cs
@@ -10,9 +10,15 @@ using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List
 {
-    public sealed partial class PrototypeIdListSerializer<T> : ITypeSerializer<List<string>, SequenceDataNode> where T : class, IPrototype
+    public sealed class AbstractPrototypeIdListSerializer<T> : PrototypeIdListSerializer<T> where T : class, IPrototype
     {
-        private readonly PrototypeIdSerializer<T> _prototypeSerializer = new();
+        protected override PrototypeIdSerializer<T> PrototypeSerializer => new AbstractPrototypeIdSerializer<T>();
+    }
+
+    [Virtual]
+    public partial class PrototypeIdListSerializer<T> : ITypeSerializer<List<string>, SequenceDataNode> where T : class, IPrototype
+    {
+        protected virtual PrototypeIdSerializer<T> PrototypeSerializer => new();
 
         private ValidationNode ValidateInternal(
             ISerializationManager serializationManager,
@@ -30,7 +36,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
                     continue;
                 }
 
-                list.Add(_prototypeSerializer.Validate(serializationManager, value, dependencies, context));
+                list.Add(PrototypeSerializer.Validate(serializationManager, value, dependencies, context));
             }
 
             return new ValidatedSequenceNode(list);
@@ -46,7 +52,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
 
             foreach (var str in value)
             {
-                list.Add(_prototypeSerializer.Write(serializationManager, str, alwaysWrite, context));
+                list.Add(PrototypeSerializer.Write(serializationManager, str, alwaysWrite, context));
             }
 
             return new SequenceDataNode(list);
@@ -71,7 +77,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
 
             foreach (var dataNode in node.Sequence)
             {
-                list.Add(_prototypeSerializer.Read(
+                list.Add(PrototypeSerializer.Read(
                     serializationManager,
                     (ValueDataNode) dataNode,
                     dependencies,

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/PrototypeIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/PrototypeIdSerializer.cs
@@ -8,12 +8,25 @@ using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype
 {
-    public sealed class PrototypeIdSerializer<TPrototype> : ITypeSerializer<string, ValueDataNode> where TPrototype : class, IPrototype
+    public sealed class AbstractPrototypeIdSerializer<TPrototype> : PrototypeIdSerializer<TPrototype>
+        where TPrototype : class, IPrototype
     {
-        public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
+        public override ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
             return dependencies.Resolve<IPrototypeManager>().HasMapping<TPrototype>(node.Value)
+                ? new ValidatedValueNode(node)
+                : new ErrorNode(node, $"PrototypeID {node.Value} for type {typeof(TPrototype)} not found");
+        }
+    }
+
+    [Virtual]
+    public class PrototypeIdSerializer<TPrototype> : ITypeSerializer<string, ValueDataNode> where TPrototype : class, IPrototype
+    {
+        public virtual ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
+            IDependencyCollection dependencies, ISerializationContext? context = null)
+        {
+            return dependencies.Resolve<IPrototypeManager>().HasIndex<TPrototype>(node.Value)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, $"PrototypeID {node.Value} for type {typeof(TPrototype)} not found");
         }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/Set/PrototypeIdHashSetSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/Set/PrototypeIdHashSetSerializer.cs
@@ -10,9 +10,17 @@ using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Set
 {
-    public sealed class PrototypeIdHashSetSerializer<TPrototype> : ITypeSerializer<HashSet<string>, SequenceDataNode> where TPrototype : class, IPrototype
+    public sealed class AbstractPrototypeIdHashSetSerializer<TPrototype> : PrototypeIdHashSetSerializer<TPrototype>
+        where TPrototype : class, IPrototype
     {
-        private readonly PrototypeIdSerializer<TPrototype> _prototypeSerializer = new();
+        protected override PrototypeIdSerializer<TPrototype> PrototypeSerializer =>
+            new AbstractPrototypeIdSerializer<TPrototype>();
+    }
+
+    [Virtual]
+    public class PrototypeIdHashSetSerializer<TPrototype> : ITypeSerializer<HashSet<string>, SequenceDataNode> where TPrototype : class, IPrototype
+    {
+        protected virtual PrototypeIdSerializer<TPrototype> PrototypeSerializer => new();
 
         public ValidationNode Validate(ISerializationManager serializationManager, SequenceDataNode node, IDependencyCollection dependencies, ISerializationContext? context = null)
         {
@@ -26,7 +34,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
                     continue;
                 }
 
-                list.Add(_prototypeSerializer.Validate(serializationManager, value, dependencies, context));
+                list.Add(PrototypeSerializer.Validate(serializationManager, value, dependencies, context));
             }
 
             return new ValidatedSequenceNode(list);
@@ -40,7 +48,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
 
             foreach (var dataNode in node.Sequence)
             {
-                set.Add(_prototypeSerializer.Read(
+                set.Add(PrototypeSerializer.Read(
                     serializationManager,
                     (ValueDataNode) dataNode,
                     dependencies,
@@ -57,7 +65,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
 
             foreach (var str in value)
             {
-                list.Add(_prototypeSerializer.Write(serializationManager, str, alwaysWrite, context));
+                list.Add(PrototypeSerializer.Write(serializationManager, str, alwaysWrite, context));
             }
 
             return new SequenceDataNode(list);


### PR DESCRIPTION
requires https://github.com/space-wizards/space-station-14/pull/7519

Announcement for whoever merges it:
```
Starting now, if you want to your validation of prototype ids to include abstracts (you dont want this is 99% of cases), you should use the AbstractPrototypeIdSerializer-Variants else YamlLinter will complain.
```