### PR TITLE
Make MappingDataNode.Except() not recursive

### DIFF
--- a/Robust.Shared/Serialization/Markdown/DataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/DataNode.cs
@@ -20,12 +20,9 @@ namespace Robust.Shared.Serialization.Markdown
         public abstract DataNode Copy();
 
         /// <summary>
-        ///     Return a new DataNode that contains only data that is not present in some other data node. Will return
-        ///     null if ever bit of data in this node is also present in the other node.
+        ///     This function will return a data node that contains only the elements within this data node that do not
+        ///     have an equivalent entry in some other data node.
         /// </summary>
-        /// <remarks>
-        ///     This only performs equality comparisons on the data, it does not recursively call Except().
-        /// </remarks>
         public abstract DataNode? Except(DataNode node);
 
         public abstract DataNode PushInheritance(DataNode parent);
@@ -44,10 +41,6 @@ namespace Robust.Shared.Serialization.Markdown
 
         public abstract override T Copy();
 
-        /// <summary>
-        ///     This function will return a data node that contains only the elements within this data node that do not
-        ///     have an equivalent entry in some other data node.
-        /// </summary>
         public abstract T? Except(T node);
 
         public abstract T PushInheritance(T node);

--- a/Robust.Shared/Serialization/Markdown/DataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/DataNode.cs
@@ -19,19 +19,16 @@ namespace Robust.Shared.Serialization.Markdown
 
         public abstract DataNode Copy();
 
+        /// <summary>
+        ///     Return a new DataNode that contains only data that is not present in some other data node. Will return
+        ///     null if ever bit of data in this node is also present in the other node.
+        /// </summary>
+        /// <remarks>
+        ///     This only performs equality comparisons on the data, it does not recursively call Except().
+        /// </remarks>
         public abstract DataNode? Except(DataNode node);
 
         public abstract DataNode PushInheritance(DataNode parent);
-
-        public override bool Equals(object? obj)
-        {
-            if (obj is not DataNode other)
-                return false;
-
-            // mapping and sequences nodes are equal if removing duplicate entires leaves us with nothing. Value nodes
-            // override this and directly check equality.
-            return Except(other) == null;
-        }
 
         public T CopyCast<T>() where T : DataNode
         {

--- a/Robust.Shared/Serialization/Markdown/DataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/DataNode.cs
@@ -44,6 +44,10 @@ namespace Robust.Shared.Serialization.Markdown
 
         public abstract override T Copy();
 
+        /// <summary>
+        ///     This function will return a data node that contains only the elements within this data node that do not
+        ///     have an equivalent entry in some other data node.
+        /// </summary>
         public abstract T? Except(T node);
 
         public abstract T PushInheritance(T node);

--- a/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNode.cs
@@ -276,7 +276,8 @@ namespace Robust.Shared.Serialization.Markdown.Mapping
             if (_children.Count != other._children.Count)
                 return false;
 
-            // If removing identical entries leaves us with nothing, then the mappings are equal.
+            // Given that keys are unique and we do not care about the ordering, we know that if removing identical
+            // key-value pairs leaves us with an empty list then the mappings are equal.
             return Except(other) == null;
         }
 

--- a/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNode.cs
@@ -263,9 +263,7 @@ namespace Robust.Shared.Serialization.Markdown.Mapping
                 }
             }
 
-            if (mappingNode._children.Count == 0) return null;
-
-            return mappingNode;
+            return mappingNode._children.Count == 0 ? null : mappingNode;
         }
 
         public override bool Equals(object? obj)

--- a/Robust.Shared/Serialization/Markdown/Sequence/SequenceDataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/Sequence/SequenceDataNode.cs
@@ -168,8 +168,16 @@ namespace Robust.Shared.Serialization.Markdown.Sequence
             if (_nodes.Count != other._nodes.Count)
                 return false;
 
-            // If removing identical entries leaves us with nothing, then the mappings are equal.
-            return Except(other) == null;
+            // We cannot just use Except() to check equality, because the sequence [a, a, b] would be equivalent to
+            // [a, b ,b]. I.e., the number of entries matter. Similarly, for anyone serializing an ordered list, the
+            // order of entries matters.
+
+            for (int i = 0; i < _nodes.Count; i++)
+            {
+                if (!_nodes[i].Equals(other._nodes[i]))
+                    return false;
+            }
+            return true;
         }
 
         public override SequenceDataNode PushInheritance(SequenceDataNode node)

--- a/Robust.Shared/Serialization/Markdown/Sequence/SequenceDataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/Sequence/SequenceDataNode.cs
@@ -160,6 +160,18 @@ namespace Robust.Shared.Serialization.Markdown.Sequence
             return null;
         }
 
+        public override bool Equals(object? obj)
+        {
+            if (obj is not SequenceDataNode other)
+                return false;
+
+            if (_nodes.Count != other._nodes.Count)
+                return false;
+
+            // If removing identical entries leaves us with nothing, then the mappings are equal.
+            return Except(other) == null;
+        }
+
         public override SequenceDataNode PushInheritance(SequenceDataNode node)
         {
             var newNode = Copy();


### PR DESCRIPTION
Currently there is an issue with map saving. `MapLoader` uses the the `MappingDataNode.Except()` function to remove data that is already present in the entity prototype in order to reduce map sizes. However because this function recursively removes data, and because of how map loading works, this can lead to errors when saving & loading entities.

E.g. if you have some entity prototype with a component that has as some dictionary datafields:
```yaml
- type: MyComponent
  data:
    A: 1
  unchangedData: 
    B: 2
``` 
If some system adds an entry to the `data` dictionary, the dictionary SHOULD get saved to the map as something like:
```yaml
- type: MyComponent
  data:
    A: 1
    C: 3
``` 
But because of the recursive `Except()` it instead just saves it as:
```yaml
- type: MyComponent
  data:
    C: 2 
``` 
As the map loading stuff uses the `data` dictionary defined in the map to overwrite prototype-defined dictionary, if you then load that map you get a missing `A: 1` entry.

Because map saving is currently really only done pre-map init, this would only cause problems for systems that add or remove data from a non-empty dictionary/list during component add/init/startup. The only place I know of where this currently causes issues is for docking airlocks, where the docking system adds a fixture on init, resulting in the airlock getting saved with only that fixture, and not the default door fixture. This just wasn't noticed before because prior to #2610 those sequence mappings just weren't getting saved in the first place.

So this PR updates `Except()` to not be recursive while adding a separate `RecursiveExcept()` that keeps the old behaviour. AFAIK `Except()` was only really used in `MapLoader`, so AFAIK this shouldn't cause issues? But again I don't really know all the implications of messing with all this data node stuff.

This PR also fixes the equality override added in #2610, which just wasn't sufficient to ensure equality for sequences and mappings.