### PR TITLE
Deprecate CreateNetMessage<T>.

### DIFF
--- a/Robust.Client/Console/ClientConsoleHost.cs
+++ b/Robust.Client/Console/ClientConsoleHost.cs
@@ -134,7 +134,7 @@ namespace Robust.Client.Console
             if (!NetManager.IsConnected) // we don't care about session on client
                 return;
 
-            var msg = NetManager.CreateNetMessage<MsgConCmd>();
+            var msg = new MsgConCmd();
             msg.Text = command;
             NetManager.ClientSendMessage(msg);
         }
@@ -198,7 +198,7 @@ namespace Robust.Client.Console
             if (!NetManager.IsConnected)
                 return;
 
-            var msg = NetManager.CreateNetMessage<MsgConCmdReg>();
+            var msg = new MsgConCmdReg();
             NetManager.ClientSendMessage(msg);
 
             _requestedCommands = true;

--- a/Robust.Client/Console/Commands/SendGarbageCommand.cs
+++ b/Robust.Client/Console/Commands/SendGarbageCommand.cs
@@ -15,7 +15,7 @@ namespace Robust.Client.Console.Commands
             // MsgStringTableEntries is registered as NetMessageAccept.Client so the server will immediately deny it.
             // And kick us.
             var net = IoCManager.Resolve<IClientNetManager>();
-            var msg = net.CreateNetMessage<MsgStringTableEntries>();
+            var msg = new MsgStringTableEntries();
             msg.Entries = new MsgStringTableEntries.Entry[0];
             net.ClientSendMessage(msg);
         }

--- a/Robust.Client/Console/ScriptClient.ScriptConsoleServer.cs
+++ b/Robust.Client/Console/ScriptClient.ScriptConsoleServer.cs
@@ -35,7 +35,7 @@ namespace Robust.Client.Console
 
                 RunButton.Disabled = true;
 
-                var msg = _client._netManager.CreateNetMessage<MsgScriptEval>();
+                var msg = new MsgScriptEval();
                 msg.ScriptSession = _session;
                 msg.Code = _lastEnteredText = InputBar.Text;
 
@@ -48,7 +48,7 @@ namespace Robust.Client.Console
 
             protected override void Complete()
             {
-                var msg = _client._netManager.CreateNetMessage<MsgScriptCompletion>();
+                var msg = new MsgScriptCompletion();
                 msg.ScriptSession = _session;
                 msg.Code = InputBar.Text;
                 msg.Cursor = InputBar.CursorPosition;

--- a/Robust.Client/Console/ScriptClient.cs
+++ b/Robust.Client/Console/ScriptClient.cs
@@ -65,7 +65,7 @@ namespace Robust.Client.Console
                 throw new InvalidOperationException("We do not have scripting permission.");
             }
 
-            var msg = _netManager.CreateNetMessage<MsgScriptStart>();
+            var msg = new MsgScriptStart();
             msg.ScriptSession = _nextSessionId++;
             _netManager.ClientSendMessage(msg);
         }
@@ -74,7 +74,7 @@ namespace Robust.Client.Console
         {
             _activeConsoles.Remove(session);
 
-            var msg = _netManager.CreateNetMessage<MsgScriptStop>();
+            var msg = new MsgScriptStop();
             msg.ScriptSession = session;
             _netManager.ClientSendMessage(msg);
         }

--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -86,7 +86,7 @@ namespace Robust.Client.GameObjects
 
         public void SendSystemNetworkMessage(EntityEventArgs message, uint sequence)
         {
-            var msg = _networkManager.CreateNetMessage<MsgEntity>();
+            var msg = new MsgEntity();
             msg.Type = EntityMessageType.SystemMessage;
             msg.SystemMessage = message;
             msg.SourceTick = _gameTiming.CurTick;

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -409,7 +409,7 @@ namespace Robust.Client.GameStates
 
         private void AckGameState(GameTick sequence)
         {
-            var msg = _network.CreateNetMessage<MsgStateAck>();
+            var msg = new MsgStateAck();
             msg.Sequence = sequence;
             _network.ClientSendMessage(msg);
         }

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -418,7 +418,7 @@ namespace Robust.Client.Placement
             if (!IsActive || !Eraser) return;
             if (Hijack != null && Hijack.HijackDeletion(entity)) return;
 
-            var msg = NetworkManager.CreateNetMessage<MsgPlacement>();
+            var msg = new MsgPlacement();
             msg.PlaceType = PlacementManagerMessage.RequestEntRemove;
             msg.EntityUid = entity;
             NetworkManager.ClientSendMessage(msg);
@@ -426,7 +426,7 @@ namespace Robust.Client.Placement
 
         public void HandleRectDeletion(EntityCoordinates start, Box2 rect)
         {
-            var msg = NetworkManager.CreateNetMessage<MsgPlacement>();
+            var msg = new MsgPlacement();
             msg.PlaceType = PlacementManagerMessage.RequestRectRemove;
             msg.EntityCoordinates = new EntityCoordinates(StartPoint.EntityId, rect.BottomLeft);
             msg.RectSize = rect.Size;
@@ -748,7 +748,7 @@ namespace Robust.Client.Placement
                 _pendingTileChanges.Add(tuple);
             }
 
-            var message = NetworkManager.CreateNetMessage<MsgPlacement>();
+            var message = new MsgPlacement();
             message.PlaceType = PlacementManagerMessage.RequestPlacement;
 
             message.Align = CurrentMode.ModeName;

--- a/Robust.Client/Player/PlayerManager.cs
+++ b/Robust.Client/Player/PlayerManager.cs
@@ -89,7 +89,7 @@ namespace Robust.Client.Player
         {
             LocalPlayer = new LocalPlayer();
 
-            var msgList = _network.CreateNetMessage<MsgPlayerListReq>();
+            var msgList = new MsgPlayerListReq();
             // message is empty
             _network.ClientSendMessage(msgList);
         }

--- a/Robust.Client/Prototypes/ClientPrototypeManager.cs
+++ b/Robust.Client/Prototypes/ClientPrototypeManager.cs
@@ -57,7 +57,7 @@ namespace Robust.Client.Prototypes
 #if !FULL_RELEASE
             var sw = Stopwatch.StartNew();
 
-            var msg = _netManager.CreateNetMessage<MsgReloadPrototypes>();
+            var msg = new MsgReloadPrototypes();
             msg.Paths = _reloadQueue.ToArray();
             _netManager.ClientSendMessage(msg);
 

--- a/Robust.Client/ViewVariables/ViewVariablesManager.cs
+++ b/Robust.Client/ViewVariables/ViewVariablesManager.cs
@@ -277,7 +277,7 @@ namespace Robust.Client.ViewVariables
 
         public Task<ViewVariablesRemoteSession> RequestSession(ViewVariablesObjectSelector selector)
         {
-            var msg = _netManager.CreateNetMessage<MsgViewVariablesReqSession>();
+            var msg = new MsgViewVariablesReqSession();
             msg.Selector = selector;
             msg.RequestId = _nextReqId++;
             _netManager.ClientSendMessage(msg);
@@ -293,7 +293,7 @@ namespace Robust.Client.ViewVariables
                 throw new ArgumentException("Session is closed", nameof(session));
             }
 
-            var msg = _netManager.CreateNetMessage<MsgViewVariablesReqData>();
+            var msg = new MsgViewVariablesReqData();
             var reqId = msg.RequestId = _nextReqId++;
             msg.RequestMeta = meta;
             msg.SessionId = session.SessionId;
@@ -315,7 +315,7 @@ namespace Robust.Client.ViewVariables
                 throw new ArgumentException();
             }
 
-            var closeMsg = _netManager.CreateNetMessage<MsgViewVariablesCloseSession>();
+            var closeMsg = new MsgViewVariablesCloseSession();
             closeMsg.SessionId = session.SessionId;
             _netManager.ClientSendMessage(closeMsg);
         }
@@ -332,7 +332,7 @@ namespace Robust.Client.ViewVariables
                 throw new ArgumentException();
             }
 
-            var msg = _netManager.CreateNetMessage<MsgViewVariablesModifyRemote>();
+            var msg = new MsgViewVariablesModifyRemote();
             msg.SessionId = session.SessionId;
             msg.ReinterpretValue = reinterpretValue;
             msg.PropertyIndex = propertyIndex;

--- a/Robust.Server/Console/ServerConsoleHost.cs
+++ b/Robust.Server/Console/ServerConsoleHost.cs
@@ -33,7 +33,7 @@ namespace Robust.Server.Console
             if (!NetManager.IsConnected || session is null)
                 return;
 
-            var msg = NetManager.CreateNetMessage<MsgConCmd>();
+            var msg = new MsgConCmd();
             msg.Text = command;
             NetManager.ServerSendMessage(msg, ((IPlayerSession)session).ConnectedClient);
         }
@@ -121,7 +121,7 @@ namespace Robust.Server.Console
         private void HandleRegistrationRequest(INetChannel senderConnection)
         {
             var netMgr = IoCManager.Resolve<IServerNetManager>();
-            var message = netMgr.CreateNetMessage<MsgConCmdReg>();
+            var message = new MsgConCmdReg();
 
             var counter = 0;
             message.Commands = new MsgConCmdReg.Command[RegisteredCommands.Count];
@@ -154,7 +154,7 @@ namespace Robust.Server.Console
         {
             if (session != null)
             {
-                var replyMsg = NetManager.CreateNetMessage<MsgConCmdAck>();
+                var replyMsg = new MsgConCmdAck();
                 replyMsg.Error = error;
                 replyMsg.Text = text;
                 NetManager.ServerSendMessage(replyMsg, session.ConnectedClient);

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -206,7 +206,7 @@ namespace Robust.Server.GameObjects
         /// <inheritdoc />
         public void SendSystemNetworkMessage(EntityEventArgs message)
         {
-            var newMsg = _networkManager.CreateNetMessage<MsgEntity>();
+            var newMsg = new MsgEntity();
             newMsg.Type = EntityMessageType.SystemMessage;
             newMsg.SystemMessage = message;
             newMsg.SourceTick = _gameTiming.CurTick;
@@ -217,7 +217,7 @@ namespace Robust.Server.GameObjects
         /// <inheritdoc />
         public void SendSystemNetworkMessage(EntityEventArgs message, INetChannel targetConnection)
         {
-            var newMsg = _networkManager.CreateNetMessage<MsgEntity>();
+            var newMsg = new MsgEntity();
             newMsg.Type = EntityMessageType.SystemMessage;
             newMsg.SystemMessage = message;
             newMsg.SourceTick = _gameTiming.CurTick;

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -219,7 +219,7 @@ namespace Robust.Server.GameStates
                 InterlockedHelper.Min(ref oldestAckValue, lastAck.Value);
 
                 // actually send the state
-                var stateUpdateMessage = _networkManager.CreateNetMessage<MsgState>();
+                var stateUpdateMessage = new MsgState();
                 stateUpdateMessage.State = state;
 
                 // If the state is too big we let Lidgren send it reliably.

--- a/Robust.Server/Placement/PlacementManager.cs
+++ b/Robust.Server/Placement/PlacementManager.cs
@@ -230,7 +230,7 @@ namespace Robust.Server.Placement
             if (playerConnection == null)
                 return;
 
-            var message = _networkManager.CreateNetMessage<MsgPlacement>();
+            var message = new MsgPlacement();
             message.PlaceType = PlacementManagerMessage.StartPlacement;
             message.Range = range;
             message.IsTile = false;
@@ -251,7 +251,7 @@ namespace Robust.Server.Placement
             if (playerConnection == null)
                 return;
 
-            var message = _networkManager.CreateNetMessage<MsgPlacement>();
+            var message = new MsgPlacement();
             message.PlaceType = PlacementManagerMessage.StartPlacement;
             message.Range = range;
             message.IsTile = true;
@@ -272,7 +272,7 @@ namespace Robust.Server.Placement
             if (playerConnection == null)
                 return;
 
-            var message = _networkManager.CreateNetMessage<MsgPlacement>();
+            var message = new MsgPlacement();
             message.PlaceType = PlacementManagerMessage.CancelPlacement;
             _networkManager.ServerSendMessage(message, playerConnection);
         }

--- a/Robust.Server/Player/PlayerManager.cs
+++ b/Robust.Server/Player/PlayerManager.cs
@@ -445,7 +445,7 @@ namespace Robust.Server.Player
         {
             var channel = message.MsgChannel;
             var players = Sessions;
-            var netMsg = channel.CreateNetMessage<MsgPlayerList>();
+            var netMsg = new MsgPlayerList();
 
             // client session is complete, set their status accordingly.
             // This is done before the packet is built, so that the client

--- a/Robust.Server/Scripting/ScriptHost.cs
+++ b/Robust.Server/Scripting/ScriptHost.cs
@@ -75,7 +75,7 @@ namespace Robust.Server.Scripting
 
         private void ReceiveScriptStart(MsgScriptStart message)
         {
-            var reply = _netManager.CreateNetMessage<MsgScriptStartAck>();
+            var reply = new MsgScriptStartAck();
             reply.ScriptSession = message.ScriptSession;
             reply.WasAccepted = false;
             if (!_playerManager.TryGetSessionByChannel(message.MsgChannel, out var session))
@@ -128,7 +128,7 @@ namespace Robust.Server.Scripting
                 return;
             }
 
-            var replyMessage = _netManager.CreateNetMessage<MsgScriptResponse>();
+            var replyMessage = new MsgScriptResponse();
             replyMessage.ScriptSession = message.ScriptSession;
 
             var code = message.Code;
@@ -259,7 +259,7 @@ namespace Robust.Server.Scripting
                 !instances.TryGetValue(message.ScriptSession, out var instance))
                     return;
 
-            var replyMessage = _netManager.CreateNetMessage<MsgScriptCompletionResponse>();
+            var replyMessage = new MsgScriptCompletionResponse();
             replyMessage.ScriptSession = message.ScriptSession;
 
             // Everything below here cribbed from

--- a/Robust.Server/ViewVariables/ViewVariablesHost.cs
+++ b/Robust.Server/ViewVariables/ViewVariablesHost.cs
@@ -91,7 +91,7 @@ namespace Robust.Server.ViewVariables
 
             var blob = session.DataRequest(message.RequestMeta);
 
-            var dataMsg = _netManager.CreateNetMessage<MsgViewVariablesRemoteData>();
+            var dataMsg = new MsgViewVariablesRemoteData();
             dataMsg.RequestId = message.RequestId;
             dataMsg.Blob = blob;
             _netManager.ServerSendMessage(dataMsg, message.MsgChannel);
@@ -101,7 +101,7 @@ namespace Robust.Server.ViewVariables
         {
             void Deny(DenyReason reason)
             {
-                var denyMsg = _netManager.CreateNetMessage<MsgViewVariablesDenySession>();
+                var denyMsg = new MsgViewVariablesDenySession();
                 denyMsg.RequestId = message.RequestId;
                 denyMsg.Reason = reason;
                 _netManager.ServerSendMessage(denyMsg, message.MsgChannel);
@@ -217,7 +217,7 @@ namespace Robust.Server.ViewVariables
 
             _sessions.Add(sessionId, session);
 
-            var allowMsg = _netManager.CreateNetMessage<MsgViewVariablesOpenSession>();
+            var allowMsg = new MsgViewVariablesOpenSession();
             allowMsg.RequestId = message.RequestId;
             allowMsg.SessionId = session.SessionId;
             _netManager.ServerSendMessage(allowMsg, message.MsgChannel);
@@ -245,7 +245,7 @@ namespace Robust.Server.ViewVariables
                 return;
             }
 
-            var closeMsg = _netManager.CreateNetMessage<MsgViewVariablesCloseSession>();
+            var closeMsg = new MsgViewVariablesCloseSession();
             closeMsg.SessionId = session.SessionId;
             _netManager.ServerSendMessage(closeMsg, player.ConnectedClient);
         }

--- a/Robust.Shared/Configuration/NetConfigurationManager.cs
+++ b/Robust.Shared/Configuration/NetConfigurationManager.cs
@@ -276,7 +276,7 @@ namespace Robust.Shared.Configuration
             // replicate if needed
             if (_netManager.IsClient)
             {
-                var msg = _netManager.CreateNetMessage<MsgConVars>();
+                var msg = new MsgConVars();
                 msg.Tick = _timing.CurTick;
                 msg.NetworkedVars = new List<(string name, object value)>
                 {
@@ -286,7 +286,7 @@ namespace Robust.Shared.Configuration
             }
             else // Server
             {
-                var msg = _netManager.CreateNetMessage<MsgConVars>();
+                var msg = new MsgConVars();
                 msg.Tick = _timing.CurTick;
                 msg.NetworkedVars = new List<(string name, object value)>
                 {
@@ -304,7 +304,7 @@ namespace Robust.Shared.Configuration
 
             Logger.InfoS("cfg", $"{client}: Sending server info...");
 
-            var msg = _netManager.CreateNetMessage<MsgConVars>();
+            var msg = new MsgConVars();
             msg.Tick = _timing.CurTick;
             msg.NetworkedVars = GetReplicatedVars();
             _netManager.ServerSendMessage(msg, client);
@@ -318,7 +318,7 @@ namespace Robust.Shared.Configuration
 
             Logger.InfoS("cfg", "Sending client info...");
 
-            var msg = _netManager.CreateNetMessage<MsgConVars>();
+            var msg = new MsgConVars();
             msg.Tick = default;
             msg.NetworkedVars = GetReplicatedVars();
             _netManager.ClientSendMessage(msg);

--- a/Robust.Shared/Network/INetChannel.cs
+++ b/Robust.Shared/Network/INetChannel.cs
@@ -66,8 +66,9 @@ namespace Robust.Shared.Network
         /// </summary>
         /// <typeparam name="T">The derived NetMessage type to send.</typeparam>
         /// <returns>A new instance of the net message.</returns>
+        [Obsolete("Just new NetMessage directly")]
         T CreateNetMessage<T>()
-            where T : NetMessage;
+            where T : NetMessage, new();
 
         /// <summary>
         ///     Sends a NetMessage over this NetChannel.

--- a/Robust.Shared/Network/INetManager.cs
+++ b/Robust.Shared/Network/INetManager.cs
@@ -138,6 +138,7 @@ namespace Robust.Shared.Network
         /// </remarks>
         /// <typeparam name="T">Type of NetMessage to send.</typeparam>
         /// <returns>Instance of the NetMessage.</returns>
-        T CreateNetMessage<T>() where T : NetMessage;
+        [Obsolete("Just new NetMessage directly")]
+        T CreateNetMessage<T>() where T : NetMessage, new();
     }
 }

--- a/Robust.Shared/Network/NetManager.NetChannel.cs
+++ b/Robust.Shared/Network/NetManager.NetChannel.cs
@@ -67,7 +67,7 @@ namespace Robust.Shared.Network
 
             /// <inheritdoc />
             public T CreateNetMessage<T>()
-                where T : NetMessage
+                where T : NetMessage, new()
             {
                 return _manager.CreateNetMessage<T>();
             }

--- a/Robust.Shared/Network/StringTable.cs
+++ b/Robust.Shared/Network/StringTable.cs
@@ -236,7 +236,7 @@ namespace Robust.Shared.Network
             if (!_network.IsRunning)
                 return;
 
-            var message = _network.CreateNetMessage<MsgStringTableEntries>();
+            var message = new MsgStringTableEntries();
 
             message.Entries = new MsgStringTableEntries.Entry[1];
             message.Entries[0].Id = id;
@@ -254,7 +254,7 @@ namespace Robust.Shared.Network
             if (_network.IsClient)
                 return;
 
-            var message = _network.CreateNetMessage<MsgStringTableEntries>();
+            var message = new MsgStringTableEntries();
 
             var count = _strings.Count;
             message.Entries = new MsgStringTableEntries.Entry[count];

--- a/Robust.Shared/Serialization/RobustMappedStringSerializer.cs
+++ b/Robust.Shared/Serialization/RobustMappedStringSerializer.cs
@@ -154,7 +154,7 @@ namespace Robust.Shared.Serialization
 
             _incompleteHandshakes.Add(channel, new InProgressHandshake(tcs));
 
-            var message = _net.CreateNetMessage<MsgMapStrServerHandshake>();
+            var message = new MsgMapStrServerHandshake();
             message.Hash = _stringMapHash;
             _net.ServerSendMessage(message, channel);
 
@@ -354,7 +354,7 @@ namespace Robust.Shared.Serialization
 
             handshake.HasRequestedStrings = true;
 
-            var strings = _net.CreateNetMessage<MsgMapStrStrings>();
+            var strings = new MsgMapStrStrings();
             strings.Package = _mappedStringsPackage;
             LogSzr.Debug(
                 $"Sending {_mappedStringsPackage!.Length} bytes sized mapped strings package to {channel.UserName}.");
@@ -409,7 +409,7 @@ namespace Robust.Shared.Serialization
             if (fileName == null || !File.Exists(fileName))
             {
                 LogSzr.Debug($"No string cache for {hashStr}.");
-                var handshake = _net.CreateNetMessage<MsgMapStrClientHandshake>();
+                var handshake = new MsgMapStrClientHandshake();
                 LogSzr.Debug("Asking server to send mapped strings.");
                 handshake.NeedsStrings = true;
                 msgMapStr.MsgChannel.SendMessage(handshake);
@@ -438,7 +438,7 @@ namespace Robust.Shared.Serialization
         private void OnClientCompleteHandshake(INetManager net, INetChannel channel)
         {
             LogSzr.Debug("Letting server know we're good to go.");
-            var handshake = net.CreateNetMessage<MsgMapStrClientHandshake>();
+            var handshake = new MsgMapStrClientHandshake();
             handshake.NeedsStrings = false;
             channel.SendMessage(handshake);
 

--- a/Robust.UnitTesting/IntegrationMappedStringSerializer.cs
+++ b/Robust.UnitTesting/IntegrationMappedStringSerializer.cs
@@ -21,7 +21,7 @@ namespace Robust.UnitTesting
 
         public Task Handshake(INetChannel channel)
         {
-            var message = _net.CreateNetMessage<MsgMapStrServerHandshake>();
+            var message = new MsgMapStrServerHandshake();
             message.Hash = _hash;
             _net.ServerSendMessage(message, channel);
 

--- a/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
@@ -287,7 +287,7 @@ namespace Robust.UnitTesting
                     _callbacks.Add(typeof(T), msg => rxCallback((T) msg));
             }
 
-            public T CreateNetMessage<T>() where T : NetMessage
+            public T CreateNetMessage<T>() where T : NetMessage, new()
             {
                 var type = typeof(T);
 
@@ -429,7 +429,7 @@ namespace Robust.UnitTesting
                     RemoteUid = remoteUid;
                 }
 
-                public T CreateNetMessage<T>() where T : NetMessage
+                public T CreateNetMessage<T>() where T : NetMessage, new()
                 {
                     return _owner.CreateNetMessage<T>();
                 }


### PR DESCRIPTION
Technically a breaking change because I added the `new()` constraint but I don't think we care so.