### PR TITLE
DetachParentToNull tweaks

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -710,8 +710,11 @@ namespace Robust.Shared.GameObjects
         public void DetachParentToNull()
         {
             var oldParent = _parent;
-            if (!oldParent.IsValid())
+
+            // Could be parented to something in nullspace.
+            if (!oldParent.IsValid() || MapID == MapId.Nullspace)
             {
+                DebugTools.Assert(!Anchored);
                 return;
             }
 
@@ -734,9 +737,11 @@ namespace Robust.Shared.GameObjects
             oldConcrete._children.Remove(uid);
 
             _parent = EntityUid.Invalid;
-            var entParentChangedMessage = new EntParentChangedMessage(Owner, oldParent, MapID, this);
+            var oldMap = MapID;
             MapID = MapId.Nullspace;
             GridID = GridId.Invalid;
+
+            var entParentChangedMessage = new EntParentChangedMessage(Owner, oldParent, oldMap, this);
             _entMan.EventBus.RaiseLocalEvent(Owner, ref entParentChangedMessage);
 
             // Does it even make sense to call these since this is called purely from OnRemove right now?

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -711,8 +711,8 @@ namespace Robust.Shared.GameObjects
         {
             var oldParent = _parent;
 
-            // Could be parented to something in nullspace.
-            if (!oldParent.IsValid() || MapID == MapId.Nullspace)
+            // Even though they may already be in nullspace we may want to deparent them anyway
+            if (!oldParent.IsValid())
             {
                 DebugTools.Assert(!Anchored);
                 return;


### PR DESCRIPTION
The other parent change message already has the mapid and gridid updated when issuing the event.

We'll also guard the event by checking if they're already in nullspace.