### PR TITLE
Fix crash caused by passing uninitialized structure to ZSTD_inBuffer

### DIFF
--- a/Robust.Shared/Utility/ZStd.cs
+++ b/Robust.Shared/Utility/ZStd.cs
@@ -386,7 +386,7 @@ internal sealed class ZStdCompressStream : Stream
             outBuf.pos = (nuint)_bufferPos;
             outBuf.dst = outPtr;
 
-            ZSTD_inBuffer inBuf;
+            ZSTD_inBuffer inBuf = default;
 
             while (true)
             {


### PR DESCRIPTION
NOTE: The bug here caused crashes on Release, but not Debug.