### PR TITLE
Flexible object pool for ZStd compression contexts rather than the array one

### DIFF
--- a/Robust.Shared/Threading/ParallelManager.cs
+++ b/Robust.Shared/Threading/ParallelManager.cs
@@ -53,37 +53,3 @@ internal sealed class ParallelManager : IParallelManagerInternal
     }
 }
 
-public static class ParallelManagerExt
-{
-    public delegate void ParallelResourceAction<T>(int i, ref T resource);
-
-    public static void ParallelForWithResources<T>(
-        this IParallelManager manager,
-        int fromInclusive,
-        int toExclusive,
-        T[] resources,
-        ParallelResourceAction<T> action)
-    {
-        var parallelCount = manager.ParallelProcessCount;
-
-        DebugTools.Assert(
-            resources.Length >= parallelCount,
-            "Resources buffer is too small to fit maximum thread count.");
-
-        var threadIndex = -1;
-
-        Parallel.For(
-            fromInclusive, toExclusive,
-            new ParallelOptions { MaxDegreeOfParallelism = parallelCount },
-            () => Interlocked.Increment(ref threadIndex),
-            (i, _, localThreadIdx) =>
-            {
-                ref var resource = ref resources[localThreadIdx];
-
-                action(i, ref resource);
-
-                return localThreadIdx;
-            },
-            _ => { });
-    }
-}


### PR DESCRIPTION
I theorize, but do not guarantee, that this will solve the ParallelManager problems.
Caveat emptor... er, maintainer.
