### PR TITLE
Add null check to VV string parsing

### DIFF
--- a/Robust.Client/ViewVariables/Editors/VVPropEditorString.cs
+++ b/Robust.Client/ViewVariables/Editors/VVPropEditorString.cs
@@ -9,7 +9,7 @@ namespace Robust.Client.ViewVariables.Editors
         {
             var lineEdit = new LineEdit
             {
-                Text = (string) value!,
+                Text = (string) (value ?? ""),
                 Editable = !ReadOnly,
                 HorizontalExpand = true,
             };


### PR DESCRIPTION
Null check for VV string, since Text is non-nullable.

This fixes a bug where VVing a Fixture without an `_id` caused it to stop parsing VV.

![](https://user-images.githubusercontent.com/10494922/164969444-5a31288d-49f2-4210-a6cc-f487d6db40a6.png)

