### PR TITLE
Provide a generic way to expose tags on the status endpoint

### DIFF
--- a/Robust.Server/ServerStatus/StatusHost.Handlers.cs
+++ b/Robust.Server/ServerStatus/StatusHost.Handlers.cs
@@ -48,10 +48,10 @@ namespace Robust.Server.ServerStatus
             var tagsCache = _serverTagsCache;
             if (tagsCache != null)
             {
-                var tags = new JsonObject();
+                var tags = new JsonArray();
                 foreach (var tag in tagsCache)
                 {
-                    tags[tag] = true;
+                    tags.Add(tag);
                 }
                 jObject["tags"] = tags;
             }

--- a/Robust.Server/ServerStatus/StatusHost.Handlers.cs
+++ b/Robust.Server/ServerStatus/StatusHost.Handlers.cs
@@ -39,10 +39,22 @@ namespace Robust.Server.ServerStatus
             var jObject = new JsonObject
             {
                 // We need to send at LEAST name and player count to have the launcher work with us.
+                // Tags is optional technically but will be necessary practically for future organization.
                 // Content can override these if it wants (e.g. stealthmins).
                 ["name"] = _serverNameCache,
                 ["players"] = _playerManager.PlayerCount
             };
+
+            var tagsCache = _serverTagsCache;
+            if (tagsCache != null)
+            {
+                var tags = new JsonObject();
+                foreach (var tag in tagsCache)
+                {
+                    tags[tag] = true;
+                }
+                jObject["tags"] = tags;
+            }
 
             OnStatusRequest?.Invoke(jObject);
 

--- a/Robust.Server/ServerStatus/StatusHost.cs
+++ b/Robust.Server/ServerStatus/StatusHost.cs
@@ -42,6 +42,7 @@ namespace Robust.Server.ServerStatus
         private ISawmill _aczSawmill = default!;
 
         private string? _serverNameCache;
+        private string[]? _serverTagsCache;
 
         public async Task ProcessRequestAsync(HttpListenerContext context)
         {
@@ -99,9 +100,20 @@ namespace Robust.Server.ServerStatus
             _aczSawmill = Logger.GetSawmill($"{Sawmill}.acz");
             RegisterCVars();
 
-            // Cache this in a field to avoid thread safety shenanigans.
+            // Cache these in fields to avoid thread safety shenanigans.
             // Writes/reads of references are atomic in C# so no further synchronization necessary.
             _cfg.OnValueChanged(CVars.GameHostName, n => _serverNameCache = n, true);
+            _cfg.OnValueChanged(CVars.HubTags, t =>
+                {
+                    var tags = t.Split(",", StringSplitOptions.RemoveEmptyEntries);
+                    for (var i = 0; i < tags.Length; i++)
+                    {
+                        tags[i] = tags[i].Trim();
+                    }
+                    _serverTagsCache = tags;
+                },
+                true
+            );
 
             if (!_cfg.GetCVar(CVars.StatusEnabled))
             {

--- a/Robust.Server/server_config.toml
+++ b/Robust.Server/server_config.toml
@@ -45,7 +45,11 @@ loginlocal = true
 
 [hub]
 # Set to true to show this server on the public server list
+# Before enabling this, read: https://docs.spacestation14.io/hosts/hub-rules
 advertise = false
+# Comma-separated list of tags, useful for categorizing your server.
+# See https://docs.spacestation14.io/hosts/hub-rules for more details on this when it becomes relevant.
+tags = ""
 # URL of your server. Fill this in if you have a domain name,
 # want to use HTTPS (with a reverse proxy), or other advanced scenarios.
 # Must be in the form of an ss14:// or ss14s:// URI pointing to the status API.

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1076,6 +1076,12 @@ namespace Robust.Shared
             CVarDef.Create("hub.advertise", false, CVar.SERVERONLY);
 
         /// <summary>
+        /// Comma-separated list of tags to advertise via the status server (and therefore, to the hub).
+        /// </summary>
+        public static readonly CVarDef<string> HubTags =
+            CVarDef.Create("hub.tags", "", CVar.ARCHIVE | CVar.SERVERONLY);
+
+        /// <summary>
         /// URL of the master hub server to advertise to.
         /// </summary>
         public static readonly CVarDef<string> HubMasterUrl =


### PR DESCRIPTION
This is so that there's a way to get things such as language information and content severity information to Launcher at some later date.

There is no use-case as of this moment, I don't have a Launcher PR using this.

Basically this gets the preparatory work over with so that if anyone wants to add such features to Launcher, they don't have to get an engine PR in place to actually write them.
