### PR TITLE
Make the server/client libraries

### DIFF
--- a/Robust.Client/Robust.Client.csproj
+++ b/Robust.Client/Robust.Client.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Library</OutputType>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>../bin/Client</OutputPath>
     <NoWarn>NU1701</NoWarn>

--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <OutputType>Exe</OutputType>
+    <OutputType>Library</OutputType>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>../bin/Server</OutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Was playing with robust pong, and noticed two exe files in my build output. Changing the robust client, and server to be a dll seems to have a very small file size improvement, and has a slight usability improvement if you want to run it from the folder. I'm not sure if they are exes because of something from the past, or there is some reason it needs to be an exe.