### PR TITLE
Allow int uniforms to specify precision

### DIFF
--- a/Robust.Client/Graphics/Shaders/ParsedShader.cs
+++ b/Robust.Client/Graphics/Shaders/ParsedShader.cs
@@ -201,6 +201,7 @@ namespace Robust.Client.Graphics
         {
             return
                 (type == ShaderDataType.Float) ||
+                (type == ShaderDataType.Int) ||
                 (type == ShaderDataType.Vec2) ||
                 (type == ShaderDataType.Vec3) ||
                 (type == ShaderDataType.Vec4) ||


### PR DESCRIPTION
I'm not really sure why, but using int uniforms without an explicit precision seems to cause issues in compatibility mode.