### PR TITLE
Unpause the map when initialized

### DIFF
--- a/Robust.Shared/Map/MapManager.Pause.cs
+++ b/Robust.Shared/Map/MapManager.Pause.cs
@@ -54,7 +54,7 @@ namespace Robust.Shared.Map
             if (IsMapInitialized(mapId))
                 throw new ArgumentException("That map is already initialized.");
 
-            ClearMapPreInit(mapId);
+            ClearMapPreInitAndUnpauseMap(mapId);
 
             var mapEnt = GetMapEntityId(mapId);
             var xformQuery = EntityManager.GetEntityQuery<TransformComponent>();
@@ -157,7 +157,7 @@ namespace Robust.Shared.Map
             return mapComp.MapPreInit;
         }
 
-        private void ClearMapPreInit(MapId mapId)
+        private void ClearMapPreInitAndUnpauseMap(MapId mapId)
         {
             if(mapId == MapId.Nullspace)
                 return;
@@ -165,6 +165,7 @@ namespace Robust.Shared.Map
             var mapEuid = GetMapEntityId(mapId);
             var mapComp = EntityManager.GetComponent<IMapComponent>(mapEuid);
             mapComp.MapPreInit = false;
+            mapComp.MapPaused = false;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
When mapping commands were run in this order, the spawned player would be unable to move:
```
mapping 2 maps/whatever.yml
respawn
mapinit 2
tp 0 0 2
```
This was due to `mapping` setting MapComponent.MapPaused to true, but `mapinit` did not set MapPaused back to false. This PR rectifies the situation.