### PR TITLE
Speed up map init, and unpause map on init

### DIFF
--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -37,9 +37,9 @@ namespace Robust.Client.GameObjects
             return base.CreateEntity(prototypeName, uid);
         }
 
-        void IClientEntityManagerInternal.InitializeEntity(EntityUid entity)
+        void IClientEntityManagerInternal.InitializeEntity(EntityUid entity, MetaDataComponent? meta = null)
         {
-            base.InitializeEntity(entity);
+            base.InitializeEntity(entity, meta);
         }
 
         void IClientEntityManagerInternal.StartEntity(EntityUid entity)

--- a/Robust.Client/GameObjects/IClientEntityManagerInternal.cs
+++ b/Robust.Client/GameObjects/IClientEntityManagerInternal.cs
@@ -8,7 +8,7 @@ namespace Robust.Client.GameObjects
 
         EntityUid CreateEntity(string? prototypeName, EntityUid uid = default);
 
-        void InitializeEntity(EntityUid entity);
+        void InitializeEntity(EntityUid entity, MetaDataComponent? meta = null);
 
         void StartEntity(EntityUid entity);
     }

--- a/Robust.Server/GameObjects/IServerEntityManagerInternal.cs
+++ b/Robust.Server/GameObjects/IServerEntityManagerInternal.cs
@@ -11,7 +11,7 @@ namespace Robust.Server.GameObjects
 
         void FinishEntityLoad(EntityUid entity, IEntityLoadContext? context = null);
 
-        void FinishEntityInitialization(EntityUid entity);
+        void FinishEntityInitialization(EntityUid entity, MetaDataComponent? meta = null);
 
         void FinishEntityStartup(EntityUid entity);
     }

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -52,9 +52,9 @@ namespace Robust.Server.GameObjects
             LoadEntity(entity, context);
         }
 
-        void IServerEntityManagerInternal.FinishEntityInitialization(EntityUid entity)
+        void IServerEntityManagerInternal.FinishEntityInitialization(EntityUid entity, MetaDataComponent? meta = null)
         {
-            InitializeEntity(entity);
+            InitializeEntity(entity, meta);
         }
 
         void IServerEntityManagerInternal.FinishEntityStartup(EntityUid entity)

--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -128,13 +128,20 @@ namespace Robust.Server.Maps
             }
             else if (_mapManager.IsMapInitialized(mapId))
             {
-
                 foreach (var entity in context.Entities)
                 {
                     var meta = query.GetComponent(entity);
                     _serverEntityManager.RunMapInit(entity, meta);
                     if (isPaused)
                         meta.EntityPaused = true;
+                }
+            }
+            else if (isPaused)
+            {
+                foreach (var entity in context.Entities)
+                {
+                    var meta = query.GetComponent(entity);
+                    meta.EntityPaused = true;
                 }
             }
         }

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -122,9 +122,9 @@ namespace Robust.Shared.GameObjects
 
         #region Component Management
 
-        public void InitializeComponents(EntityUid uid)
+        public void InitializeComponents(EntityUid uid, MetaDataComponent? metadata = null)
         {
-            var metadata = GetComponent<MetaDataComponent>(uid);
+            metadata ??= GetComponent<MetaDataComponent>(uid);
             DebugTools.Assert(metadata.EntityLifeStage == EntityLifeStage.PreInit);
             metadata.EntityLifeStage = EntityLifeStage.Initializing;
 

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -7,6 +7,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.GameObjects
 {
@@ -28,6 +29,8 @@ namespace Robust.Shared.GameObjects
 
         /// <inheritdoc />
         public GameTick CurrentTick => _gameTiming.CurTick;
+
+        public static readonly MapInitEvent MapInitEventInstance = new();
 
         IComponentFactory IEntityManager.ComponentFactory => ComponentFactory;
 
@@ -438,12 +441,13 @@ namespace Robust.Shared.GameObjects
         {
             try
             {
-                InitializeEntity(entity);
+                var meta = GetComponent<MetaDataComponent>(entity);
+                InitializeEntity(entity, meta);
                 StartEntity(entity);
 
                 // If the map we're initializing the entity on is initialized, run map init on it.
                 if (_mapManager.IsMapInitialized(mapId))
-                    entity.RunMapInit();
+                    RunMapInit(entity, meta);
             }
             catch (Exception e)
             {
@@ -452,9 +456,9 @@ namespace Robust.Shared.GameObjects
             }
         }
 
-        protected void InitializeEntity(EntityUid entity)
+        protected void InitializeEntity(EntityUid entity, MetaDataComponent? meta = null)
         {
-            InitializeComponents(entity);
+            InitializeComponents(entity, meta);
             EntityInitialized?.Invoke(this, entity);
         }
 
@@ -462,6 +466,17 @@ namespace Robust.Shared.GameObjects
         {
             StartComponents(entity);
             EntityStarted?.Invoke(this, entity);
+        }
+
+        public void RunMapInit(EntityUid entity, MetaDataComponent meta)
+        {            
+            if (meta.EntityLifeStage == EntityLifeStage.MapInitialized)
+                return; // Already map initialized, do nothing.
+
+            DebugTools.Assert(meta.EntityLifeStage == EntityLifeStage.Initialized, $"Expected entity {ToPrettyString(entity)} to be initialized, was {meta.EntityLifeStage}");
+            meta.EntityLifeStage = EntityLifeStage.MapInitialized;
+
+            EventBus.RaiseLocalEvent(entity, MapInitEventInstance, false);
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -26,7 +26,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         ///     Calls Initialize() on all registered components of the entity.
         /// </summary>
-        void InitializeComponents(EntityUid uid);
+        void InitializeComponents(EntityUid uid, MetaDataComponent? meta = null);
 
         /// <summary>
         ///     Calls Startup() on all registered components of the entity.

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -120,6 +120,8 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         bool Deleted([NotNullWhen(false)] EntityUid? uid);
 
+        void RunMapInit(EntityUid entity, MetaDataComponent meta);
+
         /// <summary>
         /// Returns a string representation of an entity with various information regarding it.
         /// </summary>

--- a/Robust.Shared/GameObjects/IMapInit.cs
+++ b/Robust.Shared/GameObjects/IMapInit.cs
@@ -1,6 +1,3 @@
-using Robust.Shared.IoC;
-using Robust.Shared.Utility;
-
 namespace Robust.Shared.GameObjects
 {
     /// <summary>
@@ -8,25 +5,5 @@ namespace Robust.Shared.GameObjects
     /// </summary>
     public sealed class MapInitEvent : EntityEventArgs
     {
-    }
-
-    public static class MapInitExt
-    {
-        private static readonly MapInitEvent MapInit = new MapInitEvent();
-
-        public static void RunMapInit(this EntityUid entity, IEntityManager? entMan = null)
-        {
-            // Temporary until a bit more ECS
-            IoCManager.Resolve(ref entMan);
-            var meta = entMan.GetComponent<MetaDataComponent>(entity);
-
-            if (meta.EntityLifeStage == EntityLifeStage.MapInitialized)
-                return; // Already map initialized, do nothing.
-
-            DebugTools.Assert(meta.EntityLifeStage == EntityLifeStage.Initialized, $"Expected entity {entMan.ToPrettyString(entity)} to be initialized, was {meta.EntityLifeStage}");
-            meta.EntityLifeStage = EntityLifeStage.MapInitialized;
-
-            entMan.EventBus.RaiseLocalEvent(entity, MapInit, false);
-        }
     }
 }

--- a/Robust.Shared/Map/MapManager.Pause.cs
+++ b/Robust.Shared/Map/MapManager.Pause.cs
@@ -159,16 +159,6 @@ namespace Robust.Shared.Map
             return mapComp.MapPreInit;
         }
 
-        private void ClearMapPreInit(MapId mapId)
-        {
-            if(mapId == MapId.Nullspace)
-                return;
-
-            var mapEuid = GetMapEntityId(mapId);
-            var mapComp = EntityManager.GetComponent<IMapComponent>(mapEuid);
-            mapComp.MapPreInit = false;
-        }
-
         /// <inheritdoc />
         public bool IsMapPaused(MapId mapId)
         {

--- a/Robust.Shared/Map/MapManager.Pause.cs
+++ b/Robust.Shared/Map/MapManager.Pause.cs
@@ -54,16 +54,18 @@ namespace Robust.Shared.Map
             if (IsMapInitialized(mapId))
                 throw new ArgumentException("That map is already initialized.");
 
-            ClearMapPreInit(mapId);
-
             var mapEnt = GetMapEntityId(mapId);
+            var mapComp = EntityManager.GetComponent<IMapComponent>(mapEnt);
             var xformQuery = EntityManager.GetEntityQuery<TransformComponent>();
             var metaQuery = EntityManager.GetEntityQuery<MetaDataComponent>();
+
+            mapComp.MapPreInit = false;
+            mapComp.MapPaused = false;
 
             RecursiveDoMapInit(mapEnt, in xformQuery, in metaQuery);
         }
 
-        private static void RecursiveDoMapInit(EntityUid entity,
+        private void RecursiveDoMapInit(EntityUid entity,
             in EntityQuery<TransformComponent> xformQuery,
             in EntityQuery<MetaDataComponent> metaQuery)
         {
@@ -72,7 +74,7 @@ namespace Robust.Shared.Map
             if(!metaQuery.TryGetComponent(entity, out var meta))
                 return;
 
-            entity.RunMapInit();
+            EntityManager.RunMapInit(entity, meta);
             meta.EntityPaused = false;
 
             foreach (var child in xformQuery.GetComponent(entity)._children.ToArray())


### PR DESCRIPTION
Currently the `mapinit` command un-pauses all entities, but not the map itself. This updates `MapManager.DoMapInitialize()` so that it also un-pauses the map.

This PR also removes the `RunMapInit` EntityUid extension, in favour of adding a method to EntityManager. This also fixes a problem where `MapManager.DoMapInitialize()` would do an IEntityManager resolve for every entity on the map.

It also changes some init/startup function so that they either use a metadata query or accept a metadata component as an input.