### PR TITLE
Add fluent function for indefinite article

### DIFF
--- a/Robust.Shared/Localization/LocalizationManager.Functions.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Functions.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
 using Linguini.Bundle;
 using Linguini.Bundle.Types;
 using Linguini.Shared.Types.Bundle;
@@ -35,6 +37,7 @@ namespace Robust.Shared.Localization
             // Misc
             AddCtxFunction(bundle, "ATTRIB", args => FuncAttrib(bundle, args));
             AddCtxFunction(bundle, "CAPITALIZE", FuncCapitalize);
+            AddCtxFunction(bundle, "INDEFINITE", FuncIndefinite);
         }
 
         /// <summary>
@@ -54,6 +57,92 @@ namespace Robust.Shared.Localization
             if (!String.IsNullOrEmpty(input))
                 return new LocValueString(input[0].ToString().ToUpper() + input.Substring(1));
             else return new LocValueString("");
+        }
+
+        private static string[] IndefExceptions = { "euler", "heir", "honest" };
+        private static char[] IndefCharList = { 'a', 'e', 'd', 'h', 'i', 'l', 'm', 'n', 'o', 'r', 's', 'x' };
+        private static string[] IndefRegexes = { "^e[uw]", "^onc?e\b", "^uni([^nmd]|mo)", "^u[bcfhjkqrst][aeiou]" };
+        private static char[] IndefVowels = { 'a', 'e', 'i', 'o', 'u' };
+
+        private ILocValue FuncIndefinite(LocArgs args)
+        {
+            ILocValue val = args.Args[0];
+            if (val.Value == null)
+                return new LocValueString("an");
+
+            string? word;
+            string? input;
+            if (val.Value is EntityUid entity)
+            {
+                if (TryGetEntityLocAttrib(entity, "indefinite", out var indef))
+                    return new LocValueString(indef);
+
+                input = _entMan.GetComponent<MetaDataComponent>(entity).EntityName;
+            }
+            else
+            {
+                input = val.Format(new LocContext());
+            }
+
+            if (String.IsNullOrEmpty(input))
+                return new LocValueString("");
+
+            var a = new LocValueString("a");
+            var an = new LocValueString("an");
+
+            var m = Regex.Match(input, @"\w+");
+            if (m.Success)
+            {
+                word = m.Groups[0].Value;
+            }
+            else
+            {
+                return an;
+            }
+
+            var wordi = word.ToLower();
+            if (IndefExceptions.Any(anword => wordi.StartsWith(anword)))
+            {
+                return an;
+            }
+
+            if (wordi.StartsWith("hour") && !wordi.StartsWith("houri"))
+                return an;
+
+            if (wordi.Length == 1)
+            {
+                return wordi.IndexOfAny(IndefCharList) == 0 ? an : a;
+            }
+
+            if (Regex.Match(word,
+                    "(?!FJO|[HLMNS]Y.|RY[EO]|SQU|(F[LR]?|[HL]|MN?|N|RH?|S[CHKLMNPTVW]?|X(YL)?)[AEIOU])[FHLMNRSX][A-Z]")
+                .Success)
+            {
+                return an;
+            }
+
+            foreach (var regex in IndefRegexes)
+            {
+                if (Regex.IsMatch(wordi, regex))
+                    return a;
+            }
+
+            if (Regex.IsMatch(word, "^U[NK][AIEO]"))
+            {
+                return a;
+            }
+
+            if (word == word.ToUpper())
+            {
+                return wordi.IndexOfAny(IndefCharList) == 0 ? an : a;
+            }
+
+            if (wordi.IndexOfAny(IndefVowels) == 0)
+            {
+                return an;
+            }
+
+            return Regex.IsMatch(wordi, "^y(b[lor]|cl[ea]|fere|gg|p[ios]|rou|tt)") ? an : a;
         }
 
         /// <summary>

--- a/Robust.Shared/Localization/LocalizationManager.Functions.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Functions.cs
@@ -59,10 +59,25 @@ namespace Robust.Shared.Localization
             else return new LocValueString("");
         }
 
-        private static string[] IndefExceptions = { "euler", "heir", "honest" };
-        private static char[] IndefCharList = { 'a', 'e', 'd', 'h', 'i', 'l', 'm', 'n', 'o', 'r', 's', 'x' };
-        private static string[] IndefRegexes = { "^e[uw]", "^onc?e\b", "^uni([^nmd]|mo)", "^u[bcfhjkqrst][aeiou]" };
-        private static char[] IndefVowels = { 'a', 'e', 'i', 'o', 'u' };
+        private static readonly string[] IndefExceptions = { "euler", "heir", "honest" };
+        private static readonly char[] IndefCharList = { 'a', 'e', 'd', 'h', 'i', 'l', 'm', 'n', 'o', 'r', 's', 'x' };
+        private static readonly Regex[] IndefRegexes =
+        {
+            new ("^e[uw]"),
+            new ("^onc?e\b"),
+            new ("^uni([^nmd]|mo)"),
+            new ("^u[bcfhjkqrst][aeiou]")
+        };
+
+        private static readonly Regex IndefRegexFjo =
+            new("(?!FJO|[HLMNS]Y.|RY[EO]|SQU|(F[LR]?|[HL]|MN?|N|RH?|S[CHKLMNPTVW]?|X(YL)?)[AEIOU])[FHLMNRSX][A-Z]");
+
+        private static readonly Regex IndefRegexU = new("^U[NK][AIEO]");
+
+        private static readonly Regex IndefRegexY =
+            new("^y(b[lor]|cl[ea]|fere|gg|p[ios]|rou|tt)");
+
+        private static readonly char[] IndefVowels = { 'a', 'e', 'i', 'o', 'u' };
 
         private ILocValue FuncIndefinite(LocArgs args)
         {
@@ -114,8 +129,7 @@ namespace Robust.Shared.Localization
                 return wordi.IndexOfAny(IndefCharList) == 0 ? an : a;
             }
 
-            if (Regex.Match(word,
-                    "(?!FJO|[HLMNS]Y.|RY[EO]|SQU|(F[LR]?|[HL]|MN?|N|RH?|S[CHKLMNPTVW]?|X(YL)?)[AEIOU])[FHLMNRSX][A-Z]")
+            if (IndefRegexFjo.Match(word)
                 .Success)
             {
                 return an;
@@ -123,11 +137,11 @@ namespace Robust.Shared.Localization
 
             foreach (var regex in IndefRegexes)
             {
-                if (Regex.IsMatch(wordi, regex))
+                if (regex.IsMatch(wordi))
                     return a;
             }
 
-            if (Regex.IsMatch(word, "^U[NK][AIEO]"))
+            if (IndefRegexU.IsMatch(word))
             {
                 return a;
             }
@@ -142,7 +156,7 @@ namespace Robust.Shared.Localization
                 return an;
             }
 
-            return Regex.IsMatch(wordi, "^y(b[lor]|cl[ea]|fere|gg|p[ios]|rou|tt)") ? an : a;
+            return IndefRegexY.IsMatch(wordi) ? an : a;
         }
 
         /// <summary>


### PR DESCRIPTION
Mostly stolen from here: https://stackoverflow.com/a/8044744

Works on either string or entity loc values. For entity just takes it from metadata name

Proof it works:

![image](https://user-images.githubusercontent.com/19853115/167524800-5670dfa5-3c05-4ac3-9c17-445597900e17.png)

![image](https://user-images.githubusercontent.com/19853115/167524839-16bdc283-717a-4c67-a186-52e32b507b39.png)

(these two are just tested, not actually implementing that)
![image](https://user-images.githubusercontent.com/19853115/167524809-823cf866-8c45-4540-9dad-3bcc639f5f78.png)

![image](https://user-images.githubusercontent.com/19853115/167524814-9357bdb4-d41e-41bc-8334-a760b078be4f.png)

