### PR TITLE
Add the concurrent collections and BitConverter to the allow list.

### DIFF
--- a/Robust.Shared/ContentPack/Sandbox.yml
+++ b/Robust.Shared/ContentPack/Sandbox.yml
@@ -296,6 +296,11 @@ Types:
     ImmutableSortedStack`1: { All: True }
   System.Collections.Specialized:
     NameValueCollection: { All: True }
+  System.Collections.Concurrent:
+    ConcurrentBag`1: { All: True }
+    ConcurrentDictionary`2: { All: True }
+    ConcurrentQueue`1: { All: True }
+    ConcurrentStack`1: { All: True }
   System.Collections:
     IEnumerable: { All: True }
     IEnumerator: { All: True }
@@ -823,9 +828,7 @@ Types:
     Attribute: { All: True }
     AttributeTargets: { }
     AttributeUsageAttribute: { All: True }
-    BitConverter:
-      Methods:
-      - "uint ToUInt32(System.ReadOnlySpan`1<byte>)"
+    BitConverter: { All: True } # None of these APIs can do anything more complex than make funny looking NaNs and hex strings.
     Base64FormattingOptions: { } # Enum
     Boolean: { All: True }
     Byte: { All: True }


### PR DESCRIPTION
Nothing special about any of these, needed for RobustSand.