### PR TITLE
Adds GridUid field to TileRef.

### DIFF
--- a/Robust.Client/Placement/PlacementMode.cs
+++ b/Robust.Client/Placement/PlacementMode.cs
@@ -171,8 +171,9 @@ namespace Robust.Client.Placement
         public TileRef GetTileRef(EntityCoordinates coordinates)
         {
             var gridId = coordinates.GetGridId(pManager.EntityManager);
+            var gridUid = coordinates.GetGridUid(pManager.EntityManager);
             return gridId.IsValid() ? pManager.MapManager.GetGrid(gridId).GetTileRef(MouseCoords)
-                : new TileRef(gridId,
+                : new TileRef(gridId, gridUid.GetValueOrDefault(),
                     MouseCoords.ToVector2i(pManager.EntityManager, pManager.MapManager), Tile.Empty);
         }
 

--- a/Robust.Client/UserInterface/CustomControls/DebugCoordsPanel.cs
+++ b/Robust.Client/UserInterface/CustomControls/DebugCoordsPanel.cs
@@ -73,7 +73,7 @@ namespace Robust.Client.UserInterface.CustomControls
             {
                 mouseGridPos = new EntityCoordinates(_mapManager.GetMapEntityId(mouseWorldMap.MapId),
                     mouseWorldMap.Position);
-                tile = new TileRef(GridId.Invalid,
+                tile = new TileRef(GridId.Invalid, EntityUid.Invalid,
                     mouseGridPos.ToVector2i(_entityManager, _mapManager), Tile.Empty);
             }
 

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -198,7 +198,7 @@ namespace Robust.Shared.Map
             if (!_chunks.TryGetValue(chunkIndices, out var output))
             {
                 // Chunk doesn't exist, return a tileRef to an empty (space) tile.
-                return new TileRef(Index, tileCoordinates.X, tileCoordinates.Y, default);
+                return new TileRef(Index, GridEntityId, tileCoordinates.X, tileCoordinates.Y, default);
             }
 
             var chunkTileIndices = output.GridTileToChunkTile(tileCoordinates);
@@ -221,7 +221,7 @@ namespace Robust.Shared.Map
                 throw new ArgumentOutOfRangeException(nameof(yIndex), "Tile indices out of bounds.");
 
             var indices = mapChunk.ChunkTileToGridTile(new Vector2i(xIndex, yIndex));
-            return new TileRef(Index, indices, mapChunk.GetTile(xIndex, yIndex));
+            return new TileRef(Index, GridEntityId, indices, mapChunk.GetTile(xIndex, yIndex));
         }
 
         /// <inheritdoc />
@@ -240,7 +240,7 @@ namespace Robust.Shared.Map
                             continue;
 
                         var (gridX, gridY) = new Vector2i(x, y) + chunk.Indices * ChunkSize;
-                        yield return new TileRef(Index, gridX, gridY, tile);
+                        yield return new TileRef(Index, GridEntityId, gridX, gridY, tile);
                     }
                 }
             }
@@ -249,7 +249,7 @@ namespace Robust.Shared.Map
         /// <inheritdoc />
         public GridTileEnumerator GetAllTilesEnumerator(bool ignoreEmpty = true)
         {
-            return new GridTileEnumerator(Index, _chunks.GetEnumerator(), ChunkSize, ignoreEmpty);
+            return new GridTileEnumerator(Index, GridEntityId, _chunks.GetEnumerator(), ChunkSize, ignoreEmpty);
         }
 
         /// <inheritdoc />
@@ -338,7 +338,7 @@ namespace Robust.Shared.Map
                     }
                     else if (!ignoreEmpty)
                     {
-                        var tile = new TileRef(Index, x, y, new Tile());
+                        var tile = new TileRef(Index, GridEntityId, x, y, new Tile());
 
                         if (predicate == null || predicate(tile))
                             yield return tile;
@@ -1028,7 +1028,7 @@ namespace Robust.Shared.Map
             // ParentMapId is not able to be accessed on unbound grids, so we can't even call this function for unbound grids.
             if(!_mapManager.SuppressOnTileChanged)
             {
-                var newTileRef = new TileRef(Index, gridTile, newTile);
+                var newTileRef = new TileRef(Index, GridEntityId, gridTile, newTile);
                 _mapManager.RaiseOnTileChanged(newTileRef, oldTile);
             }
 
@@ -1053,14 +1053,16 @@ namespace Robust.Shared.Map
     public struct GridTileEnumerator
     {
         private GridId _gridId;
+        private EntityUid _gridUid;
         private Dictionary<Vector2i, MapChunk>.Enumerator _chunkEnumerator;
         private readonly ushort _chunkSize;
         private int _index;
         private bool _ignoreEmpty;
 
-        internal GridTileEnumerator(GridId gridId, Dictionary<Vector2i, MapChunk>.Enumerator chunkEnumerator, ushort chunkSize, bool ignoreEmpty)
+        internal GridTileEnumerator(GridId gridId, EntityUid gridUid, Dictionary<Vector2i, MapChunk>.Enumerator chunkEnumerator, ushort chunkSize, bool ignoreEmpty)
         {
             _gridId = gridId;
+            _gridUid = gridUid;
             _chunkEnumerator = chunkEnumerator;
             _chunkSize = chunkSize;
             _index = _chunkSize * _chunkSize;
@@ -1094,7 +1096,7 @@ namespace Robust.Shared.Map
 
             var gridX = x + chunkOrigin.X * _chunkSize;
             var gridY = y + chunkOrigin.Y * _chunkSize;
-            tileRef = new TileRef(_gridId, gridX, gridY, tile);
+            tileRef = new TileRef(_gridId, _gridUid, gridX, gridY, tile);
             return true;
         }
     }

--- a/Robust.Shared/Map/TileRef.cs
+++ b/Robust.Shared/Map/TileRef.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using JetBrains.Annotations;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Maths;
 
 namespace Robust.Shared.Map
@@ -10,12 +11,17 @@ namespace Robust.Shared.Map
     [PublicAPI]
     public readonly struct TileRef : IEquatable<TileRef>
     {
-        public static TileRef Zero => new(GridId.Invalid, Vector2i.Zero, Tile.Empty);
+        public static TileRef Zero => new(GridId.Invalid, EntityUid.Invalid, Vector2i.Zero, Tile.Empty);
 
         /// <summary>
         ///     Identifier of the <see cref="MapGrid"/> this Tile belongs to.
         /// </summary>
         public readonly GridId GridIndex;
+
+        /// <summary>
+        ///     Grid Entity this Tile belongs to.
+        /// </summary>
+        public readonly EntityUid GridUid;
 
         /// <summary>
         ///     Positional indices of this tile on the grid.
@@ -31,21 +37,24 @@ namespace Robust.Shared.Map
         ///     Constructs a new instance of TileRef.
         /// </summary>
         /// <param name="gridId">Identifier of the grid this tile belongs to.</param>
+        /// <param name="gridUid">Identifier of the grid entity this tile belongs to.</param>
         /// <param name="xIndex">Positional X index of this tile on the grid.</param>
         /// <param name="yIndex">Positional Y index of this tile on the grid.</param>
         /// <param name="tile">Actual data of this tile.</param>
-        internal TileRef(GridId gridId, int xIndex, int yIndex, Tile tile)
-            : this(gridId, new Vector2i(xIndex, yIndex), tile) { }
+        internal TileRef(GridId gridId, EntityUid gridUid, int xIndex, int yIndex, Tile tile)
+            : this(gridId, gridUid, new Vector2i(xIndex, yIndex), tile) { }
 
         /// <summary>
         ///     Constructs a new instance of TileRef.
         /// </summary>
         /// <param name="gridId">Identifier of the grid this tile belongs to.</param>
+        /// <param name="gridUid">Identifier of the grid entity this tile belongs to.</param>
         /// <param name="gridIndices">Positional indices of this tile on the grid.</param>
         /// <param name="tile">Actual data of this tile.</param>
-        internal TileRef(GridId gridId, Vector2i gridIndices, Tile tile)
+        internal TileRef(GridId gridId, EntityUid gridUid, Vector2i gridIndices, Tile tile)
         {
             GridIndex = gridId;
+            GridUid = gridUid;
             GridIndices = gridIndices;
             Tile = tile;
         }

--- a/Robust.UnitTesting/Shared/Map/MapGrid_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/MapGrid_Tests.cs
@@ -38,7 +38,7 @@ namespace Robust.UnitTesting.Shared.Map
 
             Assert.That(grid.ChunkCount, Is.EqualTo(1));
             Assert.That(grid.GetMapChunks().Keys.ToList()[0], Is.EqualTo(new Vector2i(-2, -1)));
-            Assert.That(result, Is.EqualTo(new TileRef(grid.Index, new Vector2i(-9,-1), new Tile(1, (TileRenderFlag)1, 1))));
+            Assert.That(result, Is.EqualTo(new TileRef(grid.Index, grid.GridEntityId, new Vector2i(-9,-1), new Tile(1, (TileRenderFlag)1, 1))));
         }
 
         /// <summary>
@@ -151,7 +151,7 @@ namespace Robust.UnitTesting.Shared.Map
             Assert.That(foundTile, Is.True);
             Assert.That(grid.ChunkCount, Is.EqualTo(1));
             Assert.That(grid.GetMapChunks().Keys.ToList()[0], Is.EqualTo(new Vector2i(-2, -1)));
-            Assert.That(tileRef, Is.EqualTo(new TileRef(grid.Index, new Vector2i(-9, -1), new Tile(1, (TileRenderFlag)1, 1))));
+            Assert.That(tileRef, Is.EqualTo(new TileRef(grid.Index, grid.GridEntityId, new Vector2i(-9, -1), new Tile(1, (TileRenderFlag)1, 1))));
         }
 
         [Test]


### PR DESCRIPTION
Eventually we're removing `GridId`, so might as well add actual grid `EntityUid`s around, for convenience.