### PR TITLE
Optimise grid traversal for pop-in

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/TransformSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/TransformSystem.cs
@@ -52,7 +52,8 @@ namespace Robust.Client.GameObjects
 
                 // Only lerp if parent didn't change.
                 // E.g. entering lockers would do it.
-                if (transform.LerpParent == transform.ParentUid)
+                if (transform.LerpParent == transform.ParentUid &&
+                    transform.ParentUid.IsValid())
                 {
                     if (transform.LerpDestination != null)
                     {

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -357,12 +357,12 @@ namespace Robust.Shared.GameObjects
                     var oldMapId = MapID;
                     ChangeMapId(newParent.MapID, xformQuery);
 
+                    // Cache new GridID before raising the event.
+                    GridID = GetGridIndex(xformQuery);
+
                     // preserve world rotation
                     if (LifeStage == ComponentLifeStage.Running)
                         LocalRotation += (oldParent?.WorldRotation ?? Angle.Zero) - newParent.WorldRotation;
-
-                    // Cache new GridID before raising the event.
-                    GridID = GetGridIndex(xformQuery);
 
                     var entParentChangedMessage = new EntParentChangedMessage(Owner, oldParent?.Owner, oldMapId, this);
                     _entMan.EventBus.RaiseLocalEvent(Owner, ref entParentChangedMessage);
@@ -626,6 +626,11 @@ namespace Robust.Shared.GameObjects
                 DebugTools.Assert(!Anchored);
                 return;
             }
+
+            // Stop any active lerps
+            _nextPosition = null;
+            _nextRotation = null;
+            LerpParent = EntityUid.Invalid;
 
             // TODO: When ECSing this can just pass it into the anchor setter
             if (Anchored && _mapManager.TryGetGrid(GridID, out var grid))

--- a/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
@@ -12,7 +12,6 @@ namespace Robust.Shared.GameObjects
     internal sealed class SharedGridTraversalSystem : EntitySystem
     {
         [Dependency] private readonly IMapManagerInternal _mapManager = default!;
-        [Dependency] private readonly SharedContainerSystem _container = default!;
 
         private Stack<MoveEvent> _queuedEvents = new();
         private HashSet<EntityUid> _handledThisTick = new();
@@ -38,11 +37,11 @@ namespace Robust.Shared.GameObjects
 
         private void ProcessChanges()
         {
-            var maps = EntityManager.GetEntityQuery<MapComponent>();
-            var grids = EntityManager.GetEntityQuery<MapGridComponent>();
+            var maps = GetEntityQuery<MapComponent>();
+            var grids = GetEntityQuery<MapGridComponent>();
             var bodies = GetEntityQuery<PhysicsComponent>();
-            var xforms = EntityManager.GetEntityQuery<TransformComponent>();
-            var metas = EntityManager.GetEntityQuery<MetaDataComponent>();
+            var xforms = GetEntityQuery<TransformComponent>();
+            var metas = GetEntityQuery<MetaDataComponent>();
 
             while (_queuedEvents.TryPop(out var moveEvent))
             {
@@ -64,23 +63,24 @@ namespace Robust.Shared.GameObjects
         {
             var entity = moveEvent.Sender;
 
-            if (!metas.TryGetComponent(entity, out MetaDataComponent? meta) ||
+            if (!metas.TryGetComponent(entity, out var meta) ||
                 meta.EntityDeleted ||
                 (meta.Flags & MetaDataFlags.InContainer) == MetaDataFlags.InContainer ||
                 maps.HasComponent(entity) ||
-                grids.HasComponent(entity))
+                grids.HasComponent(entity) ||
+                !xforms.TryGetComponent(entity, out var xform) ||
+                // If the entity is anchored then we know for sure it's on the grid and not traversing
+                xform.Anchored)
             {
                 return;
             }
 
-            var xform = xforms.GetComponent(entity);
-            DebugTools.Assert(!float.IsNaN(moveEvent.NewPosition.X) && !float.IsNaN(moveEvent.NewPosition.Y));
+            // DebugTools.Assert(!float.IsNaN(moveEvent.NewPosition.X) && !float.IsNaN(moveEvent.NewPosition.Y));
 
             // We only do grid-traversal parent changes if the entity is currently parented to a map or a grid.
             var parentIsMap = xform.GridID == GridId.Invalid && maps.HasComponent(xform.ParentUid);
             if (!parentIsMap && !grids.HasComponent(xform.ParentUid))
                 return;
-
             var mapPos = moveEvent.NewPosition.ToMapPos(EntityManager);
             _gridBuffer.Clear();
 
@@ -91,7 +91,8 @@ namespace Robust.Shared.GameObjects
                 if (grid.Index != xform.GridID)
                 {
                     xform.AttachParent(grid.GridEntityId);
-                    RaiseLocalEvent(entity, new ChangedGridEvent(entity, xform.GridID, grid.Index));
+                    var ev = new ChangedGridEvent(entity, xform.GridID, grid.Index);
+                    RaiseLocalEvent(entity, ref ev);
                 }
             }
             else
@@ -102,17 +103,19 @@ namespace Robust.Shared.GameObjects
                 if (oldGridId != GridId.Invalid)
                 {
                     xform.AttachParent(_mapManager.GetMapEntityIdOrThrow(xform.MapID));
-                    RaiseLocalEvent(entity, new ChangedGridEvent(entity, oldGridId, GridId.Invalid));
+                    var ev = new ChangedGridEvent(entity, oldGridId, GridId.Invalid);
+                    RaiseLocalEvent(entity, ref ev);
                 }
             }
         }
     }
 
-    public sealed class ChangedGridEvent : EntityEventArgs
+    [ByRefEvent]
+    public readonly struct ChangedGridEvent
     {
-        public EntityUid Entity;
-        public GridId OldGrid;
-        public GridId NewGrid;
+        public readonly EntityUid Entity;
+        public readonly GridId OldGrid;
+        public readonly GridId NewGrid;
 
         public ChangedGridEvent(EntityUid entity, GridId oldGrid, GridId newGrid)
         {

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -343,11 +343,15 @@ public abstract partial class SharedTransformSystem
         {
             var newParentId = newState.ParentID;
             var rebuildMatrices = false;
+
+            // Update to new parent.
+            // if the new one isn't valid (e.g. PVS) then we'll just return early after yeeting them to nullspace.
             if (component.ParentUid != newParentId)
             {
                 if (!newParentId.IsValid())
                 {
                     component.DetachParentToNull();
+                    return;
                 }
                 else
                 {

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -16,6 +16,7 @@ namespace Robust.Shared.GameObjects
         [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
 
         // Needed on release no remove.
+        // ReSharper disable once NotAccessedField.Local
         private ISawmill _logger = default!;
 
         private readonly Queue<MoveEvent> _gridMoves = new();


### PR DESCRIPTION
This was like 1/6 of the frame spikes from PVS pop-in. The main benefit is just checking if the entity is anchored for grid traversal and the secondary was earlying-out handling component state if it's sent to nullspace.

Unfortunately I don't think it's feasible to remove the MoveEvent entirely (unless we just don't issue one on parent change) because entities coming back into parent range get it/