### PR TITLE
Stop double AnchorStateChangedEvent

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -393,7 +393,7 @@ public abstract partial class SharedTransformSystem
             {
                 var iGrid = Comp<MapGridComponent>(_mapManager.GetGridEuid(component.GridID));
                 AnchorEntity(component, iGrid);
-                component.SetAnchored(true);
+                DebugTools.Assert(component.Anchored);
             }
             else
             {


### PR DESCRIPTION
Currently transform component state handling raises two `AnchorStateChangedEvent` when setting something to anchored.