### PR TITLE
Reflection Commands POC

### DIFF
--- a/Robust.Server/BaseServer.cs
+++ b/Robust.Server/BaseServer.cs
@@ -19,6 +19,7 @@ using Robust.Server.ViewVariables;
 using Robust.Shared;
 using Robust.Shared.Asynchronous;
 using Robust.Shared.Configuration;
+using Robust.Shared.Console.ReflectionCommands;
 using Robust.Shared.ContentPack;
 using Robust.Shared.Enums;
 using Robust.Shared.Exceptions;
@@ -338,6 +339,8 @@ namespace Robust.Server
 
             IoCManager.Resolve<IDebugDrawingManager>().Initialize();
             IoCManager.Resolve<ISerializationManager>().Initialize();
+
+            IoCManager.Resolve<CommandManager>().Initialize();
 
             // because of 'reasons' this has to be called after the last assembly is loaded
             // otherwise the prototypes will be cleared

--- a/Robust.Server/ServerIoC.cs
+++ b/Robust.Server/ServerIoC.cs
@@ -15,6 +15,7 @@ using Robust.Server.ServerStatus;
 using Robust.Server.ViewVariables;
 using Robust.Shared;
 using Robust.Shared.Console;
+using Robust.Shared.Console.ReflectionCommands;
 using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -75,6 +76,7 @@ namespace Robust.Server
             IoCManager.Register<IPhysicsManager, PhysicsManager>();
             IoCManager.Register<IBqlQueryManager, BqlQueryManager>();
             IoCManager.Register<HubManager, HubManager>();
+            IoCManager.Register<CommandManager>();
         }
     }
 }

--- a/Robust.Shared/Console/ReflectionCommands/CommandManager.cs
+++ b/Robust.Shared/Console/ReflectionCommands/CommandManager.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Maths;
+using Robust.Shared.Reflection;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Console.ReflectionCommands;
+
+public sealed class CommandManager
+{
+    [Dependency] private readonly ISerializationManager _serializationManager = default!;
+    [Dependency] private readonly IReflectionManager _reflectionManager = default!;
+
+    delegate void Command(IConsoleShell shell, string[] args);
+
+    private readonly Dictionary<string, Command> _commands = new();
+
+    [RegisterCommand("test")]
+    public void Test(IConsoleShell shell, EntityUid uid, Color color, ResourcePath path)
+    {
+        shell.WriteLine($"{uid} | {color} | {path}");
+    }
+
+    [RegisterCommand("test_static")]
+    public static void TestStatic(IConsoleShell shell, EntityUid uid, Color color, ResourcePath path)
+    {
+        shell.WriteLine($"{uid} | {color} | {path}");
+    }
+
+    public void Initialize()
+    {
+        RegisterCommand(typeof(CommandManager).GetMethod("Test")!, instance:this);
+        RegisterCommand(typeof(CommandManager).GetMethod("TestStatic")!);
+
+        var shell = new ConsoleShell(IoCManager.Resolve<IConsoleHost>(), null);
+        ExecuteCommand(shell, "test 1 red path");
+        ExecuteCommand(shell, "test_static 1 red path");
+    }
+
+    public void RegisterCommand(MethodInfo info, RegisterCommandAttribute? attribute = null, object? instance = null)
+    {
+        if (attribute == null && !info.TryGetCustomAttribute(out attribute))
+        {
+            throw new InvalidOperationException(
+                $"{nameof(MethodInfo)} is not annotated with {nameof(RegisterCommandAttribute)}.");
+        }
+
+        if (_commands.ContainsKey(attribute.Command))
+            throw new InvalidOperationException($"Command {attribute.Command} has been defined twice.");
+
+        var parameters = info.GetParameters();
+        if (parameters.Length == 0 || parameters[0].ParameterType != typeof(IConsoleShell))
+            throw new InvalidOperationException($"The first parameter should be typed as {nameof(IConsoleShell)}.");
+
+        var serv3Const = Expression.Constant(_serializationManager);
+
+        var shellParam = Expression.Parameter(typeof(IConsoleShell), "shell");
+        var argsParam = Expression.Parameter(typeof(string[]), "args");
+
+        var args = new Expression[parameters.Length];
+        args[0] = shellParam;
+        var valueDataNodeCtor = typeof(ValueDataNode).GetConstructor(new[] { typeof(string) })!;
+        var nullConst = Expression.Default(typeof(ISerializationContext));
+        var falseConst = Expression.Constant(false);
+
+        for (int i = 1; i < args.Length; i++)
+        {
+            var readMethod = typeof(ISerializationManager).GetMethods().First(x => x.ContainsGenericParameters && x.Name == "Read").MakeGenericMethod(parameters[i].ParameterType);
+            args[i] = Expression.Call(serv3Const, readMethod,
+                Expression.New(valueDataNodeCtor, Expression.ArrayIndex(argsParam, Expression.Constant(i))), nullConst, falseConst, Expression.Default(parameters[i].ParameterType));
+        }
+
+        var call = instance == null ? Expression.Call(info, args) : Expression.Call(Expression.Constant(instance), info, args);
+
+        var tree = Expression.Condition(Expression.Equal(Expression.ArrayLength(argsParam), Expression.Constant(args.Length)),
+            call,
+            Expression.Throw(Expression.New(typeof(InvalidOperationException))));
+
+        _commands.Add(attribute.Command, Expression.Lambda<Command>(tree, new[] { shellParam, argsParam }).Compile());
+    }
+
+    public void ExecuteCommand(IConsoleShell shell, string command)
+    {
+        var args = new List<string>();
+        CommandParsing.ParseArguments(command, args);
+
+        var cmdName = args[0];
+        if (!_commands.TryGetValue(cmdName, out var commandDelegate))
+            throw new InvalidOperationException($"Command {cmdName} not found.");
+
+        commandDelegate(shell, args.ToArray());
+    }
+}

--- a/Robust.Shared/Console/ReflectionCommands/RegisterCommandAttribute.cs
+++ b/Robust.Shared/Console/ReflectionCommands/RegisterCommandAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Robust.Shared.Console.ReflectionCommands;
+
+public sealed class RegisterCommandAttribute : Attribute
+{
+    public readonly string Command;
+
+    public RegisterCommandAttribute(string command)
+    {
+        Command = command;
+    }
+}

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/EntityUidSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/EntityUidSerializer.cs
@@ -1,0 +1,41 @@
+﻿using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+
+namespace Robust.Shared.Serialization.TypeSerializers.Implementations;
+
+[TypeSerializer]
+public sealed class EntityUidSerializer : ITypeSerializer<EntityUid, ValueDataNode>
+{
+    private IntSerializer _intSerializer = new();
+
+    public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
+        IDependencyCollection dependencies, ISerializationContext? context = null)
+    {
+        return _intSerializer.Validate(serializationManager, node, dependencies, context);
+    }
+
+    public EntityUid Read(ISerializationManager serializationManager, ValueDataNode node, IDependencyCollection dependencies,
+        bool skipHook, ISerializationContext? context = null, EntityUid value = default)
+    {
+        return new EntityUid(_intSerializer.Read(serializationManager, node, dependencies, skipHook, context));
+    }
+
+    public DataNode Write(ISerializationManager serializationManager, EntityUid value, bool alwaysWrite = false,
+        ISerializationContext? context = null)
+    {
+        return _intSerializer.Write(serializationManager, value.GetHashCode(), alwaysWrite, context);
+    }
+
+    public EntityUid Copy(ISerializationManager serializationManager, EntityUid source, EntityUid target, bool skipHook,
+        ISerializationContext? context = null)
+    {
+        return source;
+    }
+}


### PR DESCRIPTION
PoC of an idea of mine i recently mentioned about how we could making defining commands easier.
Uses Serv3 to try to read the type from a valuedatanode created using the arg value.

Usage:
```csharp
[RegisterCommand("test")]
public void Test(IConsoleShell shell, EntityUid uid, Color color, ResourcePath path)
{
    shell.WriteLine($"{uid} | {color} | {path}");
}

[RegisterCommand("test_static")]
public static void TestStatic(IConsoleShell shell, EntityUid uid, Color color, ResourcePath path)
{
    shell.WriteLine($"{uid} | {color} | {path}");
}
```

This can also be used to easily autogenerate help text. for example:
- for arg explanations, function params can be annotated OR xmldocs could be used(? dunno how much we can access xmldocs at runtime)
- for helptext in general, xmldoc (see previous point) or another param on the registercommandattribute could be used

TODO
- log errors if read fails and dont just throw
- integrate into current console system