### PR TITLE
Log error for invalid coordinate conversions

### DIFF
--- a/Robust.Client/Graphics/ClientEye/EyeManager.cs
+++ b/Robust.Client/Graphics/ClientEye/EyeManager.cs
@@ -135,7 +135,7 @@ namespace Robust.Client.Graphics
         {
             if (CurrentEye.Position.MapId != point.MapId)
             {
-                Logger.Error($"Attempted to convert map coordinates ({point}) to screen coordinates with an eye on another map (${CurrentEye.Position.MapId})");
+                Logger.Error($"Attempted to convert map coordinates ({point}) to screen coordinates with an eye on another map ({CurrentEye.Position.MapId})");
                 return new(default, WindowId.Invalid);
             }
 

--- a/Robust.Client/Graphics/ClientEye/EyeManager.cs
+++ b/Robust.Client/Graphics/ClientEye/EyeManager.cs
@@ -2,6 +2,7 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 
@@ -132,6 +133,12 @@ namespace Robust.Client.Graphics
 
         public ScreenCoordinates MapToScreen(MapCoordinates point)
         {
+            if (CurrentEye.Position.MapId != point.MapId)
+            {
+                Logger.Error($"Attempted to convert map coordinates ({point}) to screen coordinates with an eye on another map (${CurrentEye.Position.MapId})");
+                return new(default, WindowId.Invalid);
+            }
+
             return new(WorldToScreen(point.Position), MainViewport.Window?.Id ?? default);
         }
 


### PR DESCRIPTION
Related to space-wizards/space-station-14/issues/7749. Should help avoid situations where the discovery of a map-screen coordinate conversion bug depends on the station being located at 0,0.