### PR TITLE
Tile aliases

### DIFF
--- a/Robust.Shared/Map/ITileDefinitionManager.cs
+++ b/Robust.Shared/Map/ITileDefinitionManager.cs
@@ -9,6 +9,7 @@ namespace Robust.Shared.Map
     {
         /// <summary>
         ///     Indexer to retrieve a tile definition by name.
+        ///     Note: In the presence of tile aliases, this[A].ID does not necessarily equal A.
         /// </summary>
         /// <param name="name">The name of the tile definition.</param>
         /// <returns>The named tile definition.</returns>
@@ -33,5 +34,15 @@ namespace Robust.Shared.Map
         /// </summary>
         /// <param name="tileDef">THe definition to register.</param>
         void Register(ITileDefinition tileDef);
+
+        /// <summary>
+        ///     Register a tile alias with this manager.
+        ///     The tile need not exist yet - the alias's creation will be deferred until it exists.
+        ///     Tile aliases do not have IDs of their own and do not show up in enumeration.
+        ///     Their main utility is for easier map migration.
+        /// </summary>
+        /// <param name="src">The source tile (i.e. name of the alias).</param>
+        /// <param name="dst">The destination tile (i.e. the actual concrete tile).</param>
+        void AssignAlias(string src, string dst);
     }
 }

--- a/Robust.Shared/Map/TileDefinitionManager.cs
+++ b/Robust.Shared/Map/TileDefinitionManager.cs
@@ -1,13 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using Robust.Shared.IoC;
+using Robust.Shared.Prototypes;
 
 namespace Robust.Shared.Map
 {
     [Virtual]
     internal class TileDefinitionManager : ITileDefinitionManager
     {
+        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         protected readonly List<ITileDefinition> TileDefs;
         private readonly Dictionary<string, ITileDefinition> _tileNames;
+        private readonly Dictionary<string, List<string>> _awaitingAliases;
         private readonly Dictionary<ITileDefinition, ushort> _tileIds;
 
         /// <summary>
@@ -18,10 +22,15 @@ namespace Robust.Shared.Map
             TileDefs = new List<ITileDefinition>();
             _tileNames = new Dictionary<string, ITileDefinition>();
             _tileIds = new Dictionary<ITileDefinition, ushort>();
+            _awaitingAliases = new();
         }
 
         public virtual void Initialize()
         {
+            foreach (var prototype in _prototypeManager.EnumeratePrototypes<TileAliasPrototype>())
+            {
+                AssignAlias(prototype.ID, prototype.Target);
+            }
         }
 
         public virtual void Register(ITileDefinition tileDef)
@@ -29,7 +38,7 @@ namespace Robust.Shared.Map
             var name = tileDef.ID;
             if (_tileNames.ContainsKey(name))
             {
-                throw new ArgumentException("Another tile definition with the same name has already been registered.", nameof(tileDef));
+                throw new ArgumentException("Another tile definition or alias with the same name has already been registered.", nameof(tileDef));
             }
 
             var id = checked((ushort) TileDefs.Count);
@@ -37,6 +46,45 @@ namespace Robust.Shared.Map
             TileDefs.Add(tileDef);
             _tileNames[name] = tileDef;
             _tileIds[tileDef] = id;
+
+            AliasingHandleDeferred(name);
+        }
+
+        private void AliasingHandleDeferred(string name)
+        {
+            // Aliases may have been held back due to tiles not being registered yet, handle this.
+            if (_awaitingAliases.ContainsKey(name))
+            {
+                var list = _awaitingAliases[name];
+                _awaitingAliases.Remove(name);
+                foreach (var alias in list)
+                {
+                    AssignAlias(alias, name);
+                }
+            }
+        }
+
+
+        public virtual void AssignAlias(string src, string dst)
+        {
+            if (_tileNames.ContainsKey(src))
+            {
+                throw new ArgumentException("Another tile definition or alias with the same name has already been registered.", nameof(src));
+            }
+
+            if (_tileNames.ContainsKey(dst))
+            {
+                // Simple enough, source to destination.
+                _tileNames[src] = _tileNames[dst];
+                AliasingHandleDeferred(src);
+            }
+            else
+            {
+                // Less simple - stash this alias for later so it appears when the target does.
+                if (!_awaitingAliases.ContainsKey(dst))
+                    _awaitingAliases[dst] = new();
+                _awaitingAliases[dst].Add(src);
+            }
         }
 
         public ITileDefinition this[string name] => _tileNames[name];

--- a/Robust.Shared/Prototypes/TileAliasPrototype.cs
+++ b/Robust.Shared/Prototypes/TileAliasPrototype.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Localization;
+using Robust.Shared.Log;
+using Robust.Shared.Maths;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Serialization.Markdown.Mapping;
+using Robust.Shared.Serialization.Markdown.Sequence;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Robust.Shared.ViewVariables;
+
+namespace Robust.Shared.Prototypes;
+
+/// <summary>
+/// Prototype that represents an alias from one tile ID to another.
+/// Tile alias prototypes, unlike tile prototypes, are implemented here, as they're really just fed to TileDefinitionManager.
+/// </summary>
+[Prototype("tileAlias", -1)]
+public sealed class TileAliasPrototype : IPrototype
+{
+    /// <summary>
+    /// The target tile ID to alias to.
+    /// </summary>
+    [ViewVariables]
+    [DataField("target")]
+    public string Target { get; private set; } = default!;
+
+    /// <summary>
+    /// The source tile ID (and the ID of this tile alias).
+    /// </summary>
+    [ViewVariables]
+    [IdDataFieldAttribute]
+    public string ID { get; private set; } = default!;
+}


### PR DESCRIPTION
Underplating problem looks annoying to handle, especially as newly saved maps will still contain `xx: underplating` lines until it's killed for good.

As such, an engine change is necessary to make killing these things less of a disaster.

Introducing: Tile aliases, the planks of tomorrow!

As there's no need for these things to be extensible, they're an engine-defined prototype.

To be clear, the main reason for these things is to ensure that the engine can *read* `xx: underplating` without it *writing* `xx: underplating`, so that underplating can actually be phased out.

An alternative method I considered was to allow tiles to be "opportunistically omitted" from saved tile maps, but this seemed too likely to introduce merge conflicts.
