### PR TITLE
Fix nullspace spawning

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -664,6 +664,15 @@ namespace Robust.Shared.GameObjects
             Dirty(_entMan);
         }
 
+        public void AttachParent(EntityUid parent)
+        {
+            // If no parent change OR we're the root entity already.
+            if (_parent == parent) return;
+
+            // offset position from world to parent, and set
+            AttachParent(_entMan.GetComponent<TransformComponent>(parent));
+        }
+
         /// <summary>
         /// Sets another entity as the parent entity, maintaining world position.
         /// </summary>
@@ -723,12 +732,6 @@ namespace Robust.Shared.GameObjects
                     concrete.UpdateChildMapIdsRecursive(newMapId, mapPaused, xformQuery, metaQuery, system);
                 }
             }
-        }
-
-        public void AttachParent(EntityUid parent)
-        {
-            var transform = _entMan.GetComponent<TransformComponent>(parent);
-            AttachParent(transform);
         }
 
         /// <summary>

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -186,15 +186,13 @@ namespace Robust.Shared.GameObjects
         public virtual EntityUid CreateEntityUninitialized(string? prototypeName, MapCoordinates coordinates)
         {
             var newEntity = CreateEntity(prototypeName);
-            var transform = GetComponent<TransformComponent>(newEntity);
-            transform.AttachParent(_mapManager.GetMapEntityId(coordinates.MapId));
 
             // TODO: Look at this bullshit. Please code a way to force-move an entity regardless of anchoring.
-            // Soon Vera...
-            var oldAnchored = transform.Anchored;
-
-            if (oldAnchored)
+            if (coordinates.MapId != MapId.Nullspace)
             {
+                var transform = GetComponent<TransformComponent>(newEntity);
+                transform.AttachParent(_mapManager.GetMapEntityId(coordinates.MapId));
+                var oldAnchored = transform.Anchored;
                 transform.Anchored = false;
                 transform.WorldPosition = coordinates.Position;
                 transform.Anchored = oldAnchored;

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -190,10 +190,16 @@ namespace Robust.Shared.GameObjects
             transform.AttachParent(_mapManager.GetMapEntityId(coordinates.MapId));
 
             // TODO: Look at this bullshit. Please code a way to force-move an entity regardless of anchoring.
+            // Soon Vera...
             var oldAnchored = transform.Anchored;
-            transform.Anchored = false;
-            transform.WorldPosition = coordinates.Position;
-            transform.Anchored = oldAnchored;
+
+            if (oldAnchored)
+            {
+                transform.Anchored = false;
+                transform.WorldPosition = coordinates.Position;
+                transform.Anchored = oldAnchored;
+            }
+
             return newEntity;
         }
 
@@ -475,7 +481,7 @@ namespace Robust.Shared.GameObjects
         }
 
         public void RunMapInit(EntityUid entity, MetaDataComponent meta)
-        {            
+        {
             if (meta.EntityLifeStage == EntityLifeStage.MapInitialized)
                 return; // Already map initialized, do nothing.
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 using Robust.Shared.GameStates;
+using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -167,7 +167,7 @@ public abstract partial class SharedTransformSystem
             if (xform._mapIdInitialized)
                 return xform.MapID;
 
-            MapId value;
+            var value = MapId.Nullspace;
 
             if (xform.ParentUid.IsValid())
             {
@@ -175,15 +175,12 @@ public abstract partial class SharedTransformSystem
             }
             else
             {
-                // second level node, terminates recursion up the branch of the tree
+                // Entity is the Map so set the value to itself.
                 if (entMan.TryGetComponent(xform.Owner, out IMapComponent? mapComp))
                 {
                     value = mapComp.WorldMap;
                 }
-                else
-                {
-                    throw new InvalidOperationException("Transform node does not exist inside scene tree!");
-                }
+                // If that fails then entity was spawned in nullspace.
             }
 
             xform.MapID = value;

--- a/Robust.Shared/Map/MapManager.cs
+++ b/Robust.Shared/Map/MapManager.cs
@@ -52,10 +52,11 @@ internal partial class MapManager : IMapManagerInternal, IEntityEventSubscriber
 #endif
         Logger.DebugS("map", "Stopping...");
 
-        foreach (var mapComp in EntityManager.EntityQuery<IMapComponent>())
+        foreach (var entity in EntityManager.GetEntities())
         {
-            EntityManager.DeleteEntity(mapComp.Owner);
+            EntityManager.DeleteEntity(entity);
         }
+
         ShutdownGridTrees();
 
 #if DEBUG

--- a/Robust.Shared/Map/MapManager.cs
+++ b/Robust.Shared/Map/MapManager.cs
@@ -72,10 +72,11 @@ internal partial class MapManager : IMapManagerInternal, IEntityEventSubscriber
 
         // Don't just call Shutdown / Startup because we don't want to touch the subscriptions on gridtrees
         // Restart can be called any time during a game, whereas shutdown / startup are typically called upon connection.
-        foreach (var mapComp in EntityManager.EntityQuery<IMapComponent>())
+        foreach (var entity in EntityManager.GetEntities())
         {
-            EntityManager.DeleteEntity(mapComp.Owner);
+            EntityManager.DeleteEntity(entity);
         }
+
         EnsureNullspaceExistsAndClear();
     }
 

--- a/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Reflection;
 using Moq;
@@ -475,7 +476,7 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
         }
 
         [Test]
-        public void TestNullspaceSpawn()
+        public void TestMapNullspaceSpawn()
         {
             var ent = EntityManager.SpawnEntity(null, MapCoordinates.Nullspace);
             Assert.That(!EntityManager.Deleted(ent));

--- a/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/Components/Transform_Test.cs
@@ -474,6 +474,13 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
             Assert.That(node3Trans.WorldPosition, new ApproxEqualityConstraint(new Vector2(15, 15)));
         }
 
+        [Test]
+        public void TestNullspaceSpawn()
+        {
+            var ent = EntityManager.SpawnEntity(null, MapCoordinates.Nullspace);
+            Assert.That(!EntityManager.Deleted(ent));
+        }
+
         /*
          * There used to be a TestMapInitOrder test here. The problem is that the actual game will probably explode if
          * you start initialising children before parents and the test only worked because of specific setup being done

--- a/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
@@ -113,9 +113,9 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             entMan.EventBus.SubscribeEvent<EntParentChangedMessage>(EventSource.Local, subscriber, ParentChangedHandler);
 
             // Act
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored = true;
+            entMan.GetComponent<TransformComponent>(ent1).Anchored = true;
 
-            Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).ParentUid, Is.EqualTo(grid.GridEntityId));
+            Assert.That(entMan.GetComponent<TransformComponent>(ent1).ParentUid, Is.EqualTo(grid.GridEntityId));
             Assert.That(calledCount, Is.EqualTo(1));
             void ParentChangedHandler(ref EntParentChangedMessage ev)
             {
@@ -136,11 +136,11 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
 
             var grid = mapMan.GetGrid(TestGridId);
             var ent1 = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(7, 7), TestMapId));
-            var tileIndices = grid.TileIndicesFor(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Coordinates);
+            var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, Tile.Empty);
 
             // Act
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored = true;
+            entMan.GetComponent<TransformComponent>(ent1).Anchored = true;
 
             Assert.That(grid.GetAnchoredEntities(tileIndices).Count(), Is.EqualTo(0));
             Assert.That(grid.GetTileRef(tileIndices).Tile, Is.EqualTo(Tile.Empty));
@@ -159,17 +159,17 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
 
             var grid = mapMan.GetGrid(TestGridId);
             var ent1 = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(7, 7), TestMapId));
-            var tileIndices = grid.TileIndicesFor(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Coordinates);
+            var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
 
             // Act
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored = true;
+            entMan.GetComponent<TransformComponent>(ent1).Anchored = true;
 
             Assert.That(grid.GetAnchoredEntities(tileIndices).First(), Is.EqualTo(ent1));
             Assert.That(grid.GetTileRef(tileIndices).Tile, Is.Not.EqualTo(Tile.Empty));
-            Assert.That(IoCManager.Resolve<IEntityManager>().HasComponent<PhysicsComponent>(ent1), Is.False);
+            Assert.That(entMan.HasComponent<PhysicsComponent>(ent1), Is.False);
             var tempQualifier = grid.GridEntityId;
-            Assert.That(IoCManager.Resolve<IEntityManager>().HasComponent<PhysicsComponent>(tempQualifier), Is.True);
+            Assert.That(entMan.HasComponent<PhysicsComponent>(tempQualifier), Is.True);
         }
 
         /// <summary>
@@ -194,15 +194,15 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             var subscriber = new Subscriber();
             int calledCount = 0;
             var ent1 = entMan.SpawnEntity(null, coordinates); // this raises MoveEvent, subscribe after
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored = true; // Anchoring will change parent if needed, raising MoveEvent, subscribe after
+            entMan.GetComponent<TransformComponent>(ent1).Anchored = true; // Anchoring will change parent if needed, raising MoveEvent, subscribe after
             entMan.EventBus.SubscribeEvent<MoveEvent>(EventSource.Local, subscriber, MoveEventHandler);
 
             // Act
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).WorldPosition = new Vector2(99, 99);
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).LocalPosition = new Vector2(99, 99);
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Coordinates = new EntityCoordinates(grid.GridEntityId, 99, 99); // make sure not to change parent, that would un-anchor
+            entMan.GetComponent<TransformComponent>(ent1).WorldPosition = new Vector2(99, 99);
+            entMan.GetComponent<TransformComponent>(ent1).LocalPosition = new Vector2(99, 99);
+            entMan.GetComponent<TransformComponent>(ent1).Coordinates = new EntityCoordinates(grid.GridEntityId, 99, 99); // make sure not to change parent, that would un-anchor
 
-            Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).MapPosition, Is.EqualTo(coordinates));
+            Assert.That(entMan.GetComponent<TransformComponent>(ent1).MapPosition, Is.EqualTo(coordinates));
             Assert.That(calledCount, Is.EqualTo(0));
             void MoveEventHandler(ref MoveEvent ev)
             {
@@ -226,14 +226,14 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             var grid = mapMan.GetGrid(TestGridId);
 
             var ent1 = entMan.SpawnEntity(null, coordinates);
-            var tileIndices = grid.TileIndicesFor(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Coordinates);
+            var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored = true;
+            entMan.GetComponent<TransformComponent>(ent1).Anchored = true;
 
             // Act
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).ParentUid = mapMan.GetMapEntityId(TestMapId);
+            entMan.GetComponent<TransformComponent>(ent1).ParentUid = mapMan.GetMapEntityId(TestMapId);
 
-            Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored, Is.False);
+            Assert.That(entMan.GetComponent<TransformComponent>(ent1).Anchored, Is.False);
             Assert.That(grid.GetAnchoredEntities(tileIndices).Count(), Is.EqualTo(0));
             Assert.That(grid.GetTileRef(tileIndices).Tile, Is.EqualTo(new Tile(1)));
         }
@@ -252,12 +252,12 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
 
             var grid = mapMan.GetGrid(TestGridId);
             var ent1 = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(7, 7), TestMapId));
-            var tileIndices = grid.TileIndicesFor(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Coordinates);
+            var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored = true;
+            entMan.GetComponent<TransformComponent>(ent1).Anchored = true;
 
             // Act
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).ParentUid = grid.GridEntityId;
+            entMan.GetComponent<TransformComponent>(ent1).ParentUid = grid.GridEntityId;
 
             Assert.That(grid.GetAnchoredEntities(tileIndices).First(), Is.EqualTo(ent1));
             Assert.That(grid.GetTileRef(tileIndices).Tile, Is.Not.EqualTo(Tile.Empty));
@@ -275,15 +275,15 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
 
             var grid = mapMan.GetGrid(TestGridId);
             var ent1 = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(7, 7), TestMapId));
-            var tileIndices = grid.TileIndicesFor(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Coordinates);
+            var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
             grid.SetTile(new Vector2i(100, 100), new Tile(1)); // Prevents the grid from being deleted when the Act happens
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored = true;
+            entMan.GetComponent<TransformComponent>(ent1).Anchored = true;
 
             // Act
             grid.SetTile(tileIndices, Tile.Empty);
 
-            Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored, Is.False);
+            Assert.That(entMan.GetComponent<TransformComponent>(ent1).Anchored, Is.False);
             Assert.That(grid.GetAnchoredEntities(tileIndices).Count(), Is.EqualTo(0));
             Assert.That(grid.GetTileRef(tileIndices).Tile, Is.EqualTo(Tile.Empty));
         }
@@ -304,17 +304,17 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
 
             var grid = mapMan.GetGrid(TestGridId);
             var ent1 = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(7, 7), TestMapId));
-            var tileIndices = grid.TileIndicesFor(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Coordinates);
+            var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored = true;
+            entMan.GetComponent<TransformComponent>(ent1).Anchored = true;
 
             // Act
             // We purposefully use the grid as container so parent stays the same, reparent will unanchor
-            var containerMan = IoCManager.Resolve<IEntityManager>().AddComponent<ContainerManagerComponent>(grid.GridEntityId);
+            var containerMan = entMan.AddComponent<ContainerManagerComponent>(grid.GridEntityId);
             var container = containerMan.MakeContainer<Container>("TestContainer");
             container.Insert(ent1);
 
-            Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored, Is.False);
+            Assert.That(entMan.GetComponent<TransformComponent>(ent1).Anchored, Is.False);
             Assert.That(grid.GetAnchoredEntities(tileIndices).Count(), Is.EqualTo(0));
             Assert.That(grid.GetTileRef(tileIndices).Tile, Is.EqualTo(new Tile(1)));
             Assert.That(container.ContainedEntities.Count, Is.EqualTo(1));
@@ -332,13 +332,13 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
 
             var grid = mapMan.GetGrid(TestGridId);
             var ent1 = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(7, 7), TestMapId));
-            var tileIndices = grid.TileIndicesFor(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Coordinates);
+            var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored = true;
+            entMan.GetComponent<TransformComponent>(ent1).Anchored = true;
 
             // Act
             // assumed default body is Dynamic
-            var physComp = IoCManager.Resolve<IEntityManager>().AddComponent<PhysicsComponent>(ent1);
+            var physComp = entMan.AddComponent<PhysicsComponent>(ent1);
 
             Assert.That(physComp.BodyType, Is.EqualTo(BodyType.Static));
         }
@@ -360,11 +360,11 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             grid.SetTile(grid.TileIndicesFor(coordinates), new Tile(1));
 
             var ent1 = entMan.SpawnEntity(null, coordinates);
-            var physComp = IoCManager.Resolve<IEntityManager>().AddComponent<PhysicsComponent>(ent1);
+            var physComp = entMan.AddComponent<PhysicsComponent>(ent1);
             physComp.BodyType = BodyType.Dynamic;
 
             // Act
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored = true;
+            entMan.GetComponent<TransformComponent>(ent1).Anchored = true;
 
             Assert.That(physComp.BodyType, Is.EqualTo(BodyType.Static));
         }
@@ -381,13 +381,13 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
 
             var grid = mapMan.GetGrid(TestGridId);
             var ent1 = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(7, 7), TestMapId));
-            var tileIndices = grid.TileIndicesFor(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Coordinates);
+            var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
-            var physComp = IoCManager.Resolve<IEntityManager>().AddComponent<PhysicsComponent>(ent1);
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored = true;
+            var physComp = entMan.AddComponent<PhysicsComponent>(ent1);
+            entMan.GetComponent<TransformComponent>(ent1).Anchored = true;
 
             // Act
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored = false;
+            entMan.GetComponent<TransformComponent>(ent1).Anchored = false;
 
             Assert.That(physComp.BodyType, Is.EqualTo(BodyType.Dynamic));
         }
@@ -407,10 +407,10 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             // Act
             var ent1 = entMan.SpawnEntity("anchoredEnt", new MapCoordinates(new Vector2(7, 7), TestMapId));
 
-            var tileIndices = grid.TileIndicesFor(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Coordinates);
+            var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             Assert.That(grid.GetAnchoredEntities(tileIndices).Count(), Is.EqualTo(0));
             Assert.That(grid.GetTileRef(tileIndices).Tile, Is.EqualTo(Tile.Empty));
-            Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored, Is.False);
+            Assert.That(entMan.GetComponent<TransformComponent>(ent1).Anchored, Is.False);
         }
 
         /// <summary>
@@ -425,17 +425,17 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
 
             var grid = mapMan.GetGrid(TestGridId);
             var ent1 = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(7, 7), TestMapId));
-            var tileIndices = grid.TileIndicesFor(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Coordinates);
+            var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
 
-            var containerMan = IoCManager.Resolve<IEntityManager>().AddComponent<ContainerManagerComponent>(grid.GridEntityId);
+            var containerMan = entMan.AddComponent<ContainerManagerComponent>(grid.GridEntityId);
             var container = containerMan.MakeContainer<Container>("TestContainer");
             container.Insert(ent1);
 
             // Act
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored = true;
+            entMan.GetComponent<TransformComponent>(ent1).Anchored = true;
 
-            Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored, Is.False);
+            Assert.That(entMan.GetComponent<TransformComponent>(ent1).Anchored, Is.False);
             Assert.That(grid.GetAnchoredEntities(tileIndices).Count(), Is.EqualTo(0));
             Assert.That(grid.GetTileRef(tileIndices).Tile, Is.EqualTo(new Tile(1)));
             Assert.That(container.ContainedEntities.Count, Is.EqualTo(1));
@@ -463,9 +463,9 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             entMan.EventBus.SubscribeEvent<EntParentChangedMessage>(EventSource.Local, subscriber, ParentChangedHandler);
 
             // Act
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored = false;
+            entMan.GetComponent<TransformComponent>(ent1).Anchored = false;
 
-            Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).ParentUid, Is.EqualTo(mapMan.GetMapEntityId(TestMapId)));
+            Assert.That(entMan.GetComponent<TransformComponent>(ent1).ParentUid, Is.EqualTo(mapMan.GetMapEntityId(TestMapId)));
             Assert.That(calledCount, Is.EqualTo(0));
             void ParentChangedHandler(ref EntParentChangedMessage ev)
             {
@@ -491,9 +491,9 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             grid.SetTile(grid.TileIndicesFor(coordinates), new Tile(1));
             var ent1 = entMan.SpawnEntity("anchoredEnt", grid.MapToGrid(coordinates));
 
-            IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored = false;
+            entMan.GetComponent<TransformComponent>(ent1).Anchored = false;
 
-            Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).ParentUid, Is.EqualTo(grid.GridEntityId));
+            Assert.That(entMan.GetComponent<TransformComponent>(ent1).ParentUid, Is.EqualTo(grid.GridEntityId));
         }
     }
 }

--- a/Robust.UnitTesting/Shared/Map/MapManager_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/MapManager_Tests.cs
@@ -70,11 +70,12 @@ namespace Robust.UnitTesting.Shared.Map
             entMan.InitializeComponents(oldEntity);
 
             mapMan.Restart();
-
-            Assert.That(mapMan.MapExists(MapId.Nullspace), Is.True);
-            Assert.That(mapMan.GridExists(GridId.Invalid), Is.False);
-            Assert.That(entMan.Deleted(oldEntity), Is.True);
-
+            Assert.Multiple(() =>
+            {
+                Assert.That(mapMan.MapExists(MapId.Nullspace), Is.True);
+                Assert.That(mapMan.GridExists(GridId.Invalid), Is.False);
+                Assert.That(entMan.Deleted(oldEntity), Is.True);
+            });
         }
 
         /// <summary>

--- a/Robust.UnitTesting/Shared/Map/MapManager_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/MapManager_Tests.cs
@@ -66,8 +66,7 @@ namespace Robust.UnitTesting.Shared.Map
 
             mapMan.CreateNewMapEntity(MapId.Nullspace);
 
-            var oldEntity = entMan.CreateEntityUninitialized(null, MapCoordinates.Nullspace);
-            entMan.InitializeComponents(oldEntity);
+            var oldEntity = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
 
             mapMan.Restart();
             Assert.Multiple(() =>


### PR DESCRIPTION
Apparently this is intended. Invalid entitycoordinates still explodes.

Fixes https://github.com/space-wizards/RobustToolbox/issues/2789