### PR TITLE
Remove ambiguity in sprite specifier

### DIFF
--- a/Robust.Shared/Serialization/Manager/Definition/DataDefinition.Emitters.cs
+++ b/Robust.Shared/Serialization/Manager/Definition/DataDefinition.Emitters.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -79,7 +79,7 @@ namespace Robust.Shared.Serialization.Manager.Definition
             return PopulateDelegate;
         }
 
-        private SerializeDelegateSignature EmitSerializeDelegate()
+        private SerializeDelegateSignature EmitSerializeDelegate(IDependencyCollection collection)
         {
             MappingDataNode SerializeDelegate(
                 object obj,
@@ -100,7 +100,7 @@ namespace Robust.Shared.Serialization.Manager.Definition
                     }
 
                     if (fieldDefinition.Attribute.ServerOnly &&
-                        !IoCManager.Resolve<INetManager>().IsServer)
+                        !collection.Resolve<INetManager>().IsServer)
                     {
                         continue;
                     }

--- a/Robust.Shared/Serialization/Manager/Definition/DataDefinition.cs
+++ b/Robust.Shared/Serialization/Manager/Definition/DataDefinition.cs
@@ -57,7 +57,7 @@ namespace Robust.Shared.Serialization.Manager.Definition
             DefaultValues = fieldDefs.Select(f => f.DefaultValue).ToArray();
 
             _populate = EmitPopulateDelegate(collection);
-            _serialize = EmitSerializeDelegate();
+            _serialize = EmitSerializeDelegate(collection);
             _copy = EmitCopyDelegate();
 
             var fieldAccessors = new AccessField<object, object?>[BaseFieldDefinitions.Length];

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/ResourcePathSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/ResourcePathSerializer.cs
@@ -45,7 +45,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
 
             try
             {
-                return IoCManager.Resolve<IResourceManager>().ContentFileExists(path)
+                return dependencies.Resolve<IResourceManager>().ContentFileExists(path)
                     ? new ValidatedValueNode(node)
                     : new ErrorNode(node, $"File not found. ({path})");
             }


### PR DESCRIPTION
Currently it is ambiguous whether a sprite specifier defined in yaml using just a single string is meant to be an entity prototype or a texture path.

Currently this is resolved by doing a `IoCManager.Resolve<Prototypes.IPrototypeManager>().HasIndex()`, and if it fails, it assumes that the string is a resource path for a texture. This significantly slows down entity loading / spawning for some entities.

So this PR makes entity prototype sprite specifiers use a `MappingDataNode` instead. So now:
- `ValueDataNode` implies a texture path
- `MappingDataNode` with an "entity" key implies an entity prototype
- Any other `MappingDataNode` implies an RSI

This will require a content PR to update mapping actions. Otherwise, AFAIK entity prototype sprite specs aren't really used in any yaml prototypes or maps?