### PR TITLE
Ignore missing components on the client

### DIFF
--- a/Robust.Client/Console/ClientConsoleHost.cs
+++ b/Robust.Client/Console/ClientConsoleHost.cs
@@ -53,6 +53,8 @@ namespace Robust.Client.Console
 
         private bool _requestedCommands;
 
+        public ClientConsoleHost() : base(isServer: false) {}
+
         /// <inheritdoc />
         public void Initialize()
         {

--- a/Robust.Server/Console/ServerConsoleHost.cs
+++ b/Robust.Server/Console/ServerConsoleHost.cs
@@ -20,6 +20,8 @@ namespace Robust.Server.Console
         [Dependency] private readonly IPlayerManager _players = default!;
         [Dependency] private readonly ISystemConsoleManager _systemConsole = default!;
 
+        public ServerConsoleHost() : base(isServer: true) {}
+
         public override event ConAnyCommandCallback? AnyCommandExecuted;
 
         /// <inheritdoc />

--- a/Robust.Shared/Console/ConsoleHost.cs
+++ b/Robust.Shared/Console/ConsoleHost.cs
@@ -30,7 +30,7 @@ namespace Robust.Shared.Console
         private readonly CommandBuffer _commandBuffer = new CommandBuffer();
 
         /// <inheritdoc />
-        public bool IsServer => NetManager.IsServer;
+        public bool IsServer { get; }
 
         /// <inheritdoc />
         public IConsoleShell LocalShell { get; }
@@ -40,8 +40,9 @@ namespace Robust.Shared.Console
 
         public abstract event ConAnyCommandCallback? AnyCommandExecuted;
 
-        protected ConsoleHost()
+        protected ConsoleHost(bool isServer)
         {
+            IsServer = isServer;
             LocalShell = new ConsoleShell(this, null);
         }
 

--- a/Robust.Shared/GameObjects/ComponentFactory.cs
+++ b/Robust.Shared/GameObjects/ComponentFactory.cs
@@ -67,6 +67,8 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         private readonly HashSet<string> IgnoredComponentNames = new();
 
+        private bool _isClient;
+
         /// <inheritdoc />
         public event Action<IComponentRegistration>? ComponentAdded;
 
@@ -86,8 +88,10 @@ namespace Robust.Shared.GameObjects
 
         public ComponentFactory(IDynamicTypeFactoryInternal typeFactory, IReflectionManager reflectionManager, IConsoleHost conHost)
         {
+
             _typeFactory = typeFactory;
             _reflectionManager = reflectionManager;
+            _isClient = conHost.IsClient;
 
             conHost.RegisterCommand("dump_net_comps", "Prints the table of networked components.", "dump_net_comps", (shell, argStr, args) =>
             {
@@ -266,7 +270,7 @@ namespace Robust.Shared.GameObjects
                 return ComponentAvailability.Available;
             }
 
-            if (IgnoredComponentNames.Contains(componentName))
+            if (_isClient || IgnoredComponentNames.Contains(componentName))
             {
                 return ComponentAvailability.Ignore;
             }

--- a/Robust.Shared/GameObjects/ComponentFactory.cs
+++ b/Robust.Shared/GameObjects/ComponentFactory.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -16,6 +16,7 @@ namespace Robust.Shared.GameObjects
     [Virtual]
     internal class ComponentFactory : IComponentFactory
     {
+        private bool _ignoreMissingComponents;
         private readonly IDynamicTypeFactoryInternal _typeFactory;
         private readonly IReflectionManager _reflectionManager;
 
@@ -67,8 +68,6 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         private readonly HashSet<string> IgnoredComponentNames = new();
 
-        private bool _isClient;
-
         /// <inheritdoc />
         public event Action<IComponentRegistration>? ComponentAdded;
 
@@ -91,7 +90,6 @@ namespace Robust.Shared.GameObjects
 
             _typeFactory = typeFactory;
             _reflectionManager = reflectionManager;
-            _isClient = conHost.IsClient;
 
             conHost.RegisterCommand("dump_net_comps", "Prints the table of networked components.", "dump_net_comps", (shell, argStr, args) =>
             {
@@ -225,6 +223,11 @@ namespace Robust.Shared.GameObjects
             ComponentReferenceAdded?.Invoke((registration, @interface));
         }
 
+        public void IgnoreMissingComponents()
+        {
+            _ignoreMissingComponents = true;
+        }
+
         public void RegisterIgnore(string name, bool overwrite = false)
         {
             if (IgnoredComponentNames.Contains(name))
@@ -270,7 +273,7 @@ namespace Robust.Shared.GameObjects
                 return ComponentAvailability.Available;
             }
 
-            if (_isClient || IgnoredComponentNames.Contains(componentName))
+            if (_ignoreMissingComponents || IgnoredComponentNames.Contains(componentName))
             {
                 return ComponentAvailability.Ignore;
             }

--- a/Robust.Shared/GameObjects/IComponentFactory.cs
+++ b/Robust.Shared/GameObjects/IComponentFactory.cs
@@ -91,6 +91,11 @@ namespace Robust.Shared.GameObjects
         void RegisterIgnore(string name, bool overwrite = false);
 
         /// <summary>
+        /// Disabled throwing on missing components that have not been ignored
+        /// </summary>
+        void IgnoreMissingComponents();
+
+        /// <summary>
         /// Gets a new component instantiated of the specified type.
         /// </summary>
         /// <param name="componentType">type of component to make</param>


### PR DESCRIPTION
Made it so client doesn't care if the component isn't registered.

Content half: https://github.com/space-wizards/space-station-14/pull/8308