### PR TITLE
Fix github action test output spam

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,6 +28,6 @@ jobs:
     - name: Build
       run: dotnet build --no-restore /p:WarningsAsErrors=nullable
     - name: Test Engine
-      run: dotnet test --no-build Robust.UnitTesting/Robust.UnitTesting.csproj -v n
+      run: dotnet test --no-build Robust.UnitTesting/Robust.UnitTesting.csproj -- NUnit.ConsoleOut=0
  
 


### PR DESCRIPTION
Noticed how the github action tests are outputting thousands of extra lines? This fixes that.
https://docs.nunit.org/articles/vs-test-adapter/Tips-And-Tricks.html#consoleout
> In earlier versions you had to use -v n, but that is no longer required. In order to silence it in dotnet test you have to do:
>
> dotnet test -- NUnit.ConsoleOut=0

It says the option "-v n" is no longer required. It appears more like it just doesn't work at all though. I replaced it with the newer recommended one, and the github tests appear to be back to having sane output.