### PR TITLE
Fix two angle lerping bugs

### DIFF
--- a/Robust.Client/Animations/AnimationTrackProperty.cs
+++ b/Robust.Client/Animations/AnimationTrackProperty.cs
@@ -101,7 +101,7 @@ namespace Robust.Client.Animations
                 case double d:
                     return MathHelper.Lerp(d, (double) b, t);
                 case Angle angle:
-                    return (Angle) MathHelper.Lerp(angle, (Angle) b, t);
+                    return Angle.Lerp(angle, (Angle) b, t);
                 case Color color:
                     return Color.InterpolateBetween(color, (Color) b, t);
                 case int i:

--- a/Robust.Client/GameObjects/EntitySystems/TransformSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/TransformSystem.cs
@@ -71,7 +71,7 @@ namespace Robust.Client.GameObjects
                     {
                         var lerpDest = transform.LerpAngle.Value;
                         var lerpSource = transform.LerpSourceAngle;
-                        if (lerpDest.Theta - lerpSource.Theta < MaxInterpolationAngle)
+                        if (Math.Abs(Angle.ShortestDistance(lerpDest, lerpSource)) < MaxInterpolationAngle)
                         {
                             transform.LocalRotation = Angle.Lerp(lerpSource, lerpDest, step);
                             // Setting LocalRotation clears LerpAngle so fix that.


### PR DESCRIPTION
- Animation tracks weren't using the fancy `Angle.Lerp` which takes `ShortestDistance` into account so it was wrapping around unnecessarily. Fixes a content bug with ghost orbit lerps
- Transform lerping was A) not using `ShortestDistance` and B) not accounting for negative angle changes