### PR TITLE
Limit audio raycast length

### DIFF
--- a/Robust.Client/Audio/Midi/MidiManager.cs
+++ b/Robust.Client/Audio/Midi/MidiManager.cs
@@ -325,7 +325,7 @@ internal sealed partial class MidiManager : IMidiManager
                             pos.Position,
                             sourceRelative.Normalized,
                             OcclusionCollisionMask),
-                        sourceRelative.Length,
+                        sourceRelative.Length, // TODO: Limit this to a certain maximum
                         renderer.TrackingEntity);
                 }
 

--- a/Robust.Client/Audio/Midi/MidiManager.cs
+++ b/Robust.Client/Audio/Midi/MidiManager.cs
@@ -100,6 +100,8 @@ internal sealed partial class MidiManager : IMidiManager
 
     private const string FallbackSoundfont = "/Midi/fallback.sf2";
 
+    private const float MaxDistanceForOcclusion = 1000;
+
     private static ResourcePath CustomSoundfontDirectory = new ResourcePath("/soundfonts/");
 
     private readonly ResourceLoaderCallbacks _soundfontLoaderCallbacks = new();
@@ -325,7 +327,7 @@ internal sealed partial class MidiManager : IMidiManager
                             pos.Position,
                             sourceRelative.Normalized,
                             OcclusionCollisionMask),
-                        sourceRelative.Length, // TODO: Limit this to a certain maximum
+                        MathF.Min(sourceRelative.Length, MaxDistanceForOcclusion),
                         renderer.TrackingEntity);
                 }
 

--- a/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
@@ -156,7 +156,7 @@ namespace Robust.Client.GameObjects
                                         pos.Position,
                                         sourceRelative.Normalized,
                                         OcclusionCollisionMask),
-                                    sourceRelative.Length,
+                                    MathF.Min(sourceRelative.Length, stream.MaxDistance),
                                     stream.TrackingEntity);
                             }
 

--- a/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
@@ -144,75 +144,94 @@ namespace Robust.Client.GameObjects
                         {
                             stream.Source.SetVolume(-10000000);
                         }
-                        else
+                        else if (stream.Attenuation == Attenuation.NoAttenuation)
                         {
-                            var sourceRelative = ourPos - pos.Position;
-                            var occlusion = 0f;
-                            if (sourceRelative.Length > 0)
-                            {
-                                occlusion = _broadPhaseSystem.IntersectRayPenetration(
-                                    pos.MapId,
-                                    new CollisionRay(
-                                        pos.Position,
-                                        sourceRelative.Normalized,
-                                        OcclusionCollisionMask),
-                                    MathF.Min(sourceRelative.Length, stream.MaxDistance),
-                                    stream.TrackingEntity);
-                            }
-
-                            var distance = MathF.Max(stream.ReferenceDistance, MathF.Min(sourceRelative.Length, stream.MaxDistance));
-                            float gain;
-
-                            // Technically these are formulas for gain not decibels but EHHHHHHHH.
-                            switch (stream.Attenuation)
-                            {
-                                case Attenuation.Default:
-                                    gain = 1f;
-                                    break;
-                                // You thought I'd implement clamping per source? Hell no that's just for the overall OpenAL setting
-                                // I didn't even wanna implement this much for linear but figured it'd be cleaner.
-                                case Attenuation.InverseDistanceClamped:
-                                case Attenuation.InverseDistance:
-                                    gain = stream.ReferenceDistance /
-                                           (stream.ReferenceDistance + stream.RolloffFactor * (distance - stream.ReferenceDistance));
-
-                                    break;
-                                case Attenuation.LinearDistanceClamped:
-                                case Attenuation.LinearDistance:
-                                    gain = 1f - stream.RolloffFactor * (distance - stream.ReferenceDistance) /
-                                        (stream.MaxDistance - stream.ReferenceDistance);
-
-                                    break;
-                                case Attenuation.ExponentDistanceClamped:
-                                case Attenuation.ExponentDistance:
-                                    gain = MathF.Pow((distance / stream.ReferenceDistance),
-                                        (-stream.RolloffFactor));
-                                    break;
-                                default:
-                                    throw new ArgumentOutOfRangeException($"No implemented attenuation for {stream.Attenuation.ToString()}");
-                            }
-
-                            var volume = MathF.Pow(10, stream.Volume / 10);
-                            var actualGain = MathF.Max(0f, volume * gain);
-
-                            stream.Source.SetVolumeDirect(actualGain);
-                            stream.Source.SetOcclusion(occlusion);
-                        }
-
-                        SetAudioPos(stream, stream.Attenuation != Attenuation.NoAttenuation ? pos.Position : ourPos);
-
-                        void SetAudioPos(PlayingStream stream, Vector2 pos)
-                        {
-                            if (!stream.Source.SetPosition(pos))
+                            //TODO: OpenAL supports positional audio together with no attenuation, we should do too.
+                            if (!stream.Source.SetPosition(ourPos))
                             {
                                 Logger.Warning("Interrupting positional audio, can't set position.");
                                 stream.Source.StopPlaying();
                             }
                         }
-
-                        if (stream.TrackingEntity != default)
+                        else
                         {
-                            stream.Source.SetVelocity(stream.TrackingEntity.GlobalLinearVelocity());
+                            var sourceRelative = ourPos - pos.Position;
+                            // OpenAL uses MaxDistance to limit how much attenuation can *reduce* the gain,
+                            // and doesn't do any culling. We however cull based on MaxDistance, because
+                            // this is what all current code that uses MaxDistance expects and because
+                            // we don't need the OpenAL behaviour.
+                            if (sourceRelative.Length > stream.MaxDistance)
+                            {
+                                stream.Source.SetVolume(-10000000);
+                            }
+                            else
+                            {
+                                var occlusion = 0f;
+                                if (sourceRelative.Length > 0)
+                                {
+                                    occlusion = _broadPhaseSystem.IntersectRayPenetration(
+                                        pos.MapId,
+                                        new CollisionRay(
+                                            pos.Position,
+                                            sourceRelative.Normalized,
+                                            OcclusionCollisionMask),
+                                        sourceRelative.Length,
+                                        stream.TrackingEntity);
+                                }
+
+                                // OpenAL also limits the distance to <= AL_MAX_DISTANCE, but since we cull
+                                // sources that are further away than stream.MaxDistance, we don't do that.
+                                var distance = MathF.Max(stream.ReferenceDistance, sourceRelative.Length);
+                                float gain;
+
+                                // Technically these are formulas for gain not decibels but EHHHHHHHH.
+                                switch (stream.Attenuation)
+                                {
+                                    case Attenuation.Default:
+                                        gain = 1f;
+                                        break;
+                                    // You thought I'd implement clamping per source? Hell no that's just for the overall OpenAL setting
+                                    // I didn't even wanna implement this much for linear but figured it'd be cleaner.
+                                    case Attenuation.InverseDistanceClamped:
+                                    case Attenuation.InverseDistance:
+                                        gain = stream.ReferenceDistance /
+                                               (stream.ReferenceDistance + stream.RolloffFactor *
+                                                   (distance - stream.ReferenceDistance));
+
+                                        break;
+                                    case Attenuation.LinearDistanceClamped:
+                                    case Attenuation.LinearDistance:
+                                        gain = 1f - stream.RolloffFactor * (distance - stream.ReferenceDistance) /
+                                            (stream.MaxDistance - stream.ReferenceDistance);
+
+                                        break;
+                                    case Attenuation.ExponentDistanceClamped:
+                                    case Attenuation.ExponentDistance:
+                                        gain = MathF.Pow((distance / stream.ReferenceDistance),
+                                            (-stream.RolloffFactor));
+                                        break;
+                                    default:
+                                        throw new ArgumentOutOfRangeException(
+                                            $"No implemented attenuation for {stream.Attenuation.ToString()}");
+                                }
+
+                                var volume = MathF.Pow(10, stream.Volume / 10);
+                                var actualGain = MathF.Max(0f, volume * gain);
+
+                                stream.Source.SetVolumeDirect(actualGain);
+                                stream.Source.SetOcclusion(occlusion);
+
+                                if (!stream.Source.SetPosition(pos.Position))
+                                {
+                                    Logger.Warning("Interrupting positional audio, can't set position.");
+                                    stream.Source.StopPlaying();
+                                }
+
+                                if (stream.TrackingEntity != default)
+                                {
+                                    stream.Source.SetVelocity(stream.TrackingEntity.GlobalLinearVelocity());
+                                }
+                            }
                         }
                     }
                 }
@@ -266,6 +285,7 @@ namespace Robust.Client.GameObjects
 
             source.SetGlobal();
             source.StartPlaying();
+            // These defaults differ from AudioParams.Default
             var playing = new PlayingStream
             {
                 Source = source,


### PR DESCRIPTION
Fixes #2848

The latest commit also not only limits occlusion to MaxDistance, but completely culls based on MaxDistance.
This is not what OpenAL does, so our behaviour will differ from OpenAL there. What OpenAL does is limit the
reduction of volume caused by attenuation beyond MaxDistance. What this PR does is mute/cull sources beyond MaxDistance.

AFAICT all code that sets MaxDistance (grep for WithMaxDistance) currently assumed that MaxDistance limits the range a sound can be heard, which was not the case until this PR.