### PR TITLE
Add editor copy keybinding

### DIFF
--- a/Robust.Client/Input/EngineContexts.cs
+++ b/Robust.Client/Input/EngineContexts.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Input;
+using Robust.Shared.Input;
 
 namespace Robust.Client.Input
 {
@@ -63,6 +63,9 @@ namespace Robust.Client.Input
             common.AddFunction(EngineKeyFunctions.TextTabComplete);
             common.AddFunction(EngineKeyFunctions.TextCompleteNext);
             common.AddFunction(EngineKeyFunctions.TextCompletePrev);
+
+            // Not in the editor context, so that it can be used to initiate placement.
+            common.AddFunction(EngineKeyFunctions.EditorCopyObject);
 
             var editor = contexts.New("editor", common);
             editor.AddFunction(EngineKeyFunctions.EditorLinePlace);

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -292,7 +292,7 @@ namespace Robust.Client.Placement
                 && EntityManager.TryGetComponent(uid, out MetaDataComponent? comp)
                 && !comp.EntityDeleted)
             {
-                if (comp.EntityPrototype == null)
+                if (comp.EntityPrototype == null || comp.EntityPrototype.NoSpawn || comp.EntityPrototype.Abstract)
                     return false;
 
                 Eraser = false;

--- a/Robust.Shared/Input/KeyFunctions.cs
+++ b/Robust.Shared/Input/KeyFunctions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Robust.Shared.Serialization;
 
 namespace Robust.Shared.Input
@@ -36,6 +36,7 @@ namespace Robust.Shared.Input
         public static readonly BoundKeyFunction EditorPlaceObject = "EditorPlaceObject";
         public static readonly BoundKeyFunction EditorCancelPlace = "EditorCancelPlace";
         public static readonly BoundKeyFunction EditorRotateObject = "EditorRotateObject";
+        public static readonly BoundKeyFunction EditorCopyObject = "EditorCopyObject";
 
         // Buttons to navigate between UI controls.
         public static readonly BoundKeyFunction GuiTabNavigateNext = "GuiTabNavigateNext";


### PR DESCRIPTION
Adds a keybinding that starts placing the type of entity or tile that a user's mouse is hovering over.