### PR TITLE
GridId Removal API Changes

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -95,6 +95,7 @@ namespace Robust.Shared.GameObjects
 
         // TODO: Cache this.
         public EntityUid? GridUid => _mapManager.TryGetGrid(_gridId, out var mapGrid) ? mapGrid.GridEntityId : null;
+        public EntityUid GridEntityId => _mapManager.TryGetGrid(_gridId, out var mapGrid) ? mapGrid.GridEntityId : EntityUid.Invalid;
 
         /// <summary>
         ///     Disables or enables to ability to locally rotate the entity. When set it removes any local rotation.

--- a/Robust.Shared/Map/EntityCoordinates.cs
+++ b/Robust.Shared/Map/EntityCoordinates.cs
@@ -226,6 +226,17 @@ namespace Robust.Shared.Map
         }
 
         /// <summary>
+        ///     Returns the Grid EntityUid these coordinates are on.
+        ///     If none of the ancestors are a grid, returns null instead.
+        /// </summary>
+        /// <param name="entityManager"></param>
+        /// <returns>Grid EntityUid this entity is on or null</returns>
+        public EntityUid GetGridEntityId(IEntityManager entityManager)
+        {
+            return !IsValid(entityManager) ? EntityUid.Invalid : entityManager.GetComponent<TransformComponent>(EntityId).GridEntityId;
+        }
+
+        /// <summary>
         ///     Returns the Map Id these coordinates are on.
         ///     If the relative entity is not valid, returns <see cref="MapId.Nullspace"/> instead.
         /// </summary>

--- a/Robust.Shared/Map/IMapManager.cs
+++ b/Robust.Shared/Map/IMapManager.cs
@@ -92,6 +92,7 @@ namespace Robust.Shared.Map
 
         IMapGrid CreateGrid(MapId currentMapId, GridId? gridId = null, ushort chunkSize = 16);
         IMapGrid GetGrid(GridId gridId);
+        IMapGrid GetGrid(EntityUid gridId);
         bool TryGetGrid(GridId gridId, [NotNullWhen(true)] out IMapGrid? grid);
         bool GridExists(GridId gridId);
         IEnumerable<IMapGrid> GetAllMapGrids(MapId mapId);

--- a/Robust.Shared/Map/MapManager.GridCollection.cs
+++ b/Robust.Shared/Map/MapManager.GridCollection.cs
@@ -145,6 +145,13 @@ internal partial class MapManager
         return GetGridComp(euid).Grid;
     }
 
+    public IMapGrid GetGrid(EntityUid gridId)
+    {
+        DebugTools.Assert(gridId.IsValid());
+        
+        return GetGridComp(gridId).Grid;
+    }
+
     public bool IsGrid(EntityUid uid)
     {
         return EntityManager.HasComponent<IMapGridComponent>(uid);

--- a/Robust.Shared/Map/MapManager.Pause.cs
+++ b/Robust.Shared/Map/MapManager.Pause.cs
@@ -188,6 +188,17 @@ namespace Robust.Shared.Map
             return true;
         }
 
+        public bool IsGridPaused(EntityUid gridId)
+        {
+            if (TryGetGrid(gridId, out var grid))
+            {
+                return IsGridPaused(grid);
+            }
+
+            Logger.ErrorS("map", $"Tried to check if unknown grid {gridId} was paused.");
+            return true;
+        }
+
         /// <inheritdoc />
         public bool IsMapInitialized(MapId mapId)
         {

--- a/Robust.Shared/Timing/IPauseManager.cs
+++ b/Robust.Shared/Timing/IPauseManager.cs
@@ -1,5 +1,6 @@
 using System;
 using JetBrains.Annotations;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 
 namespace Robust.Shared.Timing
@@ -27,6 +28,9 @@ namespace Robust.Shared.Timing
 
         [Pure]
         bool IsGridPaused(GridId gridId);
+        
+        [Pure]
+        bool IsGridPaused(EntityUid gridId);
 
         [Pure]
         bool IsMapInitialized(MapId mapId);


### PR DESCRIPTION
Backwards compatible API additions to support removing `GridId` from content.