### PR TITLE
Sync CurTime base.

### DIFF
--- a/Robust.Client/BaseClient.cs
+++ b/Robust.Client/BaseClient.cs
@@ -68,7 +68,11 @@ namespace Robust.Client
         private void SyncTimeBase(MsgSyncTimeBase message)
         {
             Logger.DebugS("client", $"Synchronized time base: {message.Tick}: {message.Time}");
-            _timeBase = (message.Time, message.Tick);
+
+            if (RunLevel >= ClientRunLevel.Connected)
+                _timing.TimeBase = (message.Time, message.Tick);
+            else
+                _timeBase = (message.Time, message.Tick);
         }
 
         private void TickRateChanged(int tickrate, in CVarChangeInfo info)

--- a/Robust.Server/BaseServer.cs
+++ b/Robust.Server/BaseServer.cs
@@ -545,6 +545,8 @@ namespace Robust.Server
                 Logger.InfoS("game", $"Tickrate changed to: {b} on tick {_time.CurTick}");
             });
 
+            var startOffset = TimeSpan.FromSeconds(_config.GetCVar(CVars.NetTimeStartOffset));
+            _time.TimeBase = (startOffset, GameTick.First);
             _time.TickRate = (byte) _config.GetCVar(CVars.NetTickrate);
 
             Logger.InfoS("srv", $"Name: {ServerName}");

--- a/Robust.Server/Player/PlayerManager.cs
+++ b/Robust.Server/Player/PlayerManager.cs
@@ -112,6 +112,7 @@ namespace Robust.Server.Player
 
             _network.RegisterNetMessage<MsgPlayerListReq>(HandlePlayerListReq);
             _network.RegisterNetMessage<MsgPlayerList>();
+            _network.RegisterNetMessage<MsgSyncTimeBase>();
 
             _network.Connecting += OnConnecting;
             _network.Connected += NewSession;
@@ -403,6 +404,11 @@ namespace Robust.Server.Player
             }
 
             PlayerCountMetric.Set(PlayerCount);
+
+            // Synchronize base time.
+            var msgTimeBase = new MsgSyncTimeBase();
+            (msgTimeBase.Time, msgTimeBase.Tick) = _timing.TimeBase;
+            _network.ServerSendMessage(msgTimeBase, args.Channel);
 
             IoCManager.Resolve<INetConfigurationManager>().SyncConnectingClient(args.Channel);
         }

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -157,6 +157,12 @@ namespace Robust.Shared
             CVarDef.Create("net.tickrate", 60, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
 
         /// <summary>
+        /// Offset CurTime at server start by this amount (in seconds).
+        /// </summary>
+        public static readonly CVarDef<int> NetTimeStartOffset =
+            CVarDef.Create("net.time_start_offset", 0, CVar.SERVERONLY);
+
+        /// <summary>
         /// How many seconds after the last message from the server before we consider it timed out.
         /// </summary>
         public static readonly CVarDef<float> ConnectionTimeout =

--- a/Robust.Shared/Collections/InvokeList.cs
+++ b/Robust.Shared/Collections/InvokeList.cs
@@ -1,0 +1,120 @@
+﻿using System;
+
+namespace Robust.Shared.Collections;
+
+/// <summary>
+/// Alternative to multi-cast delegates that has separate equality keys.
+/// </summary>
+/// <typeparam name="T">The type of delegate to store.</typeparam>
+/// <remarks>
+/// While this type is immutable (via copies), creating a copy (via add or remove) is not currently thread safe.
+/// This is in contrast to multi-cast delegate.
+/// </remarks>
+internal struct InvokeList<T>
+{
+    private Entry[]? _entries;
+
+    public int Count => _entries?.Length ?? 0;
+
+    /// <summary>
+    /// Add an entry to the current invoke list, mutating it.
+    /// </summary>
+    /// <param name="value">Actual value to store.</param>
+    /// <param name="equality">Equality comparison key.</param>
+    public void AddInPlace(T value, object equality)
+    {
+        this = Add(value, equality);
+    }
+
+    /// <summary>
+    /// Add an entry to the invoke list, returning a new instance. The original list is not modified.
+    /// </summary>
+    /// <param name="value">Actual value to store.</param>
+    /// <param name="equality">Equality comparison key.</param>
+    public readonly InvokeList<T> Add(T value, object equality)
+    {
+        if (_entries == null)
+        {
+            return new InvokeList<T>
+            {
+                _entries = new[]
+                {
+                    new Entry { Value = value, Equality = equality }
+                }
+            };
+        }
+
+        var arr = _entries;
+        Array.Resize(ref arr, arr.Length + 1);
+        arr[^1] = new Entry { Value = value, Equality = equality };
+
+        return new InvokeList<T>
+        {
+            _entries = arr
+        };
+    }
+
+    /// <summary>
+    /// Remove an entry from the current invoke list, mutating it.
+    /// </summary>
+    /// <param name="equality">Equality comparison key.</param>
+    public void RemoveInPlace(object equality)
+    {
+        this = Remove(equality);
+    }
+
+    /// <summary>
+    /// Remove an entry from the invoke list, returning a new instance. The original list is not modified.
+    /// </summary>
+    /// <param name="equality">Equality comparison key.</param>
+    public readonly InvokeList<T> Remove(object equality)
+    {
+        if (_entries == null)
+            return this;
+
+        // Find if we even have this key in the list.
+        var entryIdx = -1;
+        for (var i = 0; i < _entries.Length; i++)
+        {
+            var entry = _entries[i];
+            if (equality.Equals(entry))
+            {
+                entryIdx = i;
+                break;
+            }
+        }
+
+        // Entry not in the list, copy is identical.
+        if (entryIdx < 0)
+            return this;
+
+        // Would remove the last element from the array, new instance is empty.
+        if (_entries.Length == 1)
+            return default;
+
+        // Create new backing array and copy stuff into it.
+        var newEntries = new Entry[_entries.Length - 1];
+        for (var i = 0; i < entryIdx; i++)
+        {
+            newEntries[i] = _entries[i];
+        }
+
+        for (var i = entryIdx + 1; i < _entries.Length; i++)
+        {
+            newEntries[entryIdx - 1] = _entries[entryIdx];
+        }
+
+        return new InvokeList<T>
+        {
+            _entries = newEntries
+        };
+    }
+
+    public ReadOnlySpan<Entry> Entries => _entries;
+
+    public struct Entry
+    {
+        public T? Value;
+        public object? Equality;
+    }
+}

--- a/Robust.Shared/Configuration/IConfigurationManager.cs
+++ b/Robust.Shared/Configuration/IConfigurationManager.cs
@@ -1,8 +1,32 @@
 using System;
 using System.Collections.Generic;
+using Robust.Shared.Timing;
 
 namespace Robust.Shared.Configuration
 {
+    /// <summary>
+    /// Additional information about a CVar change.
+    /// </summary>
+    public readonly struct CVarChangeInfo
+    {
+        /// <summary>
+        /// The tick this CVar changed at.
+        /// </summary>
+        /// <remarks>
+        /// Nominally this should always be the current tick,
+        /// however due to poor network conditions it is possible for CVars to get applied late.
+        /// In this case, this is effectively "this is the tick it was SUPPOSED to have been applied at".
+        /// </remarks>
+        public readonly GameTick TickChanged;
+
+        internal CVarChangeInfo(GameTick tickChanged)
+        {
+            TickChanged = tickChanged;
+        }
+    }
+
+    public delegate void CVarChanged<in T>(T newValue, in CVarChangeInfo info);
+
     /// <summary>
     /// Stores and manages global configuration variables.
     /// </summary>
@@ -89,6 +113,9 @@ namespace Robust.Shared.Configuration
         /// <summary>
         /// Listen for an event for if the config value changes.
         /// </summary>
+        /// <remarks>
+        /// This is an O(n) operation.
+        /// </remarks>
         /// <param name="cVar">The CVar to listen for.</param>
         /// <param name="onValueChanged">The delegate to run when the value was changed.</param>
         /// <param name="invokeImmediately">
@@ -102,6 +129,9 @@ namespace Robust.Shared.Configuration
         /// <summary>
         /// Listen for an event for if the config value changes.
         /// </summary>
+        /// <remarks>
+        /// This is an O(n) operation.
+        /// </remarks>
         /// <param name="name">The name of the CVar to listen for.</param>
         /// <param name="onValueChanged">The delegate to run when the value was changed.</param>
         /// <param name="invokeImmediately">
@@ -115,6 +145,9 @@ namespace Robust.Shared.Configuration
         /// <summary>
         /// Unsubscribe an event previously registered with <see cref="OnValueChanged{T}(Robust.Shared.Configuration.CVarDef{T},System.Action{T},bool)"/>.
         /// </summary>
+        /// <remarks>
+        /// This is an O(n) operation.
+        /// </remarks>
         /// <param name="cVar">The CVar to unsubscribe from.</param>
         /// <param name="onValueChanged">The delegate to unsubscribe.</param>
         /// <typeparam name="T">The type of value contained in this CVar.</typeparam>
@@ -124,10 +157,69 @@ namespace Robust.Shared.Configuration
         /// <summary>
         /// Unsubscribe an event previously registered with <see cref="OnValueChanged{T}(string,System.Action{T},bool)"/>.
         /// </summary>
+        /// <remarks>
+        /// This is an O(n) operation.
+        /// </remarks>
         /// <param name="name">The name of the CVar to unsubscribe from.</param>
         /// <param name="onValueChanged">The delegate to unsubscribe.</param>
         /// <typeparam name="T">The type of value contained in this CVar.</typeparam>
         void UnsubValueChanged<T>(string name, Action<T> onValueChanged)
+            where T : notnull;
+
+        /// <summary>
+        /// Listen for an event for if the config value changes.
+        /// </summary>
+        /// <remarks>
+        /// This is an O(n) operation.
+        /// </remarks>
+        /// <param name="cVar">The CVar to listen for.</param>
+        /// <param name="onValueChanged">The delegate to run when the value was changed.</param>
+        /// <param name="invokeImmediately">
+        /// Whether to run the callback immediately in this method. Can help reduce boilerplate
+        /// </param>
+        /// <typeparam name="T">The type of value contained in this CVar.</typeparam>
+        /// <seealso cref="UnsubValueChanged{T}(Robust.Shared.Configuration.CVarDef{T},System.Action{T})"/>
+        void OnValueChanged<T>(CVarDef<T> cVar, CVarChanged<T> onValueChanged, bool invokeImmediately = false)
+            where T : notnull;
+
+        /// <summary>
+        /// Listen for an event for if the config value changes.
+        /// </summary>
+        /// <remarks>
+        /// This is an O(n) operation.
+        /// </remarks>
+        /// <param name="name">The name of the CVar to listen for.</param>
+        /// <param name="onValueChanged">The delegate to run when the value was changed.</param>
+        /// <param name="invokeImmediately">
+        /// Whether to run the callback immediately in this method. Can help reduce boilerplate
+        /// </param>
+        /// <typeparam name="T">The type of value contained in this CVar.</typeparam>
+        /// <seealso cref="UnsubValueChanged{T}(string,System.Action{T})"/>
+        void OnValueChanged<T>(string name, CVarChanged<T> onValueChanged, bool invokeImmediately = false)
+            where T : notnull;
+
+        /// <summary>
+        /// Unsubscribe an event previously registered with <see cref="OnValueChanged{T}(Robust.Shared.Configuration.CVarDef{T},System.Action{T},bool)"/>.
+        /// </summary>
+        /// <remarks>
+        /// This is an O(n) operation.
+        /// </remarks>
+        /// <param name="cVar">The CVar to unsubscribe from.</param>
+        /// <param name="onValueChanged">The delegate to unsubscribe.</param>
+        /// <typeparam name="T">The type of value contained in this CVar.</typeparam>
+        void UnsubValueChanged<T>(CVarDef<T> cVar, CVarChanged<T> onValueChanged)
+            where T : notnull;
+
+        /// <summary>
+        /// Unsubscribe an event previously registered with <see cref="OnValueChanged{T}(string,System.Action{T},bool)"/>.
+        /// </summary>
+        /// <remarks>
+        /// This is an O(n) operation.
+        /// </remarks>
+        /// <param name="name">The name of the CVar to unsubscribe from.</param>
+        /// <param name="onValueChanged">The delegate to unsubscribe.</param>
+        /// <typeparam name="T">The type of value contained in this CVar.</typeparam>
+        void UnsubValueChanged<T>(string name, CVarChanged<T> onValueChanged)
             where T : notnull;
     }
 }

--- a/Robust.Shared/Configuration/NetConfigurationManager.cs
+++ b/Robust.Shared/Configuration/NetConfigurationManager.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Network;
@@ -158,7 +157,7 @@ namespace Robust.Shared.Configuration
             if (toApply.Count == 0)
                 return;
 
-            toApply.Sort();
+            toApply.Sort((a, b) => a.Tick.CompareTo(b.Tick));
 
             foreach (var msg in toApply)
             {

--- a/Robust.Shared/Network/Messages/MsgSyncTimeBase.cs
+++ b/Robust.Shared/Network/Messages/MsgSyncTimeBase.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Lidgren.Network;
+using Robust.Shared.Timing;
+
+namespace Robust.Shared.Network.Messages;
+
+/// <summary>
+/// Sent server -> client to synchronize initial TimeBase on connection.
+/// Any further time synchronizations are done through the configuration system.
+/// </summary>
+internal sealed class MsgSyncTimeBase : NetMessage
+{
+    public override MsgGroups MsgGroup => MsgGroups.String;
+
+    public GameTick Tick;
+    public TimeSpan Time;
+
+    public override void ReadFromBuffer(NetIncomingMessage buffer)
+    {
+        Tick = buffer.ReadGameTick();
+        Time = buffer.ReadTimeSpan();
+    }
+
+    public override void WriteToBuffer(NetOutgoingMessage buffer)
+    {
+        buffer.Write(Tick);
+        buffer.Write(Time);
+    }
+}

--- a/Robust.Shared/Timing/GameTiming.cs
+++ b/Robust.Shared/Timing/GameTiming.cs
@@ -48,7 +48,7 @@ namespace Robust.Shared.Timing
         //
         // Notice that it starts from GameTick 1  - the "first tick" has no impact
         // on timing
-        private (TimeSpan, GameTick) _cachedCurTimeInfo = (TimeSpan.Zero, GameTick.First);
+        public (TimeSpan, GameTick) TimeBase { get; set; } = (TimeSpan.Zero, GameTick.First);
 
         /// <summary>
         ///     The current synchronized uptime of the simulation. Use this for in-game timing. This can be rewound for
@@ -59,7 +59,7 @@ namespace Robust.Shared.Timing
             get
             {
                 // last tickrate change epoch
-                var (time, lastTimeTick) = _cachedCurTimeInfo;
+                var (time, lastTimeTick) = TimeBase;
 
                 // add our current time to it.
                 // the server never rewinds time, and the client never rewinds time outside of prediction.
@@ -131,18 +131,7 @@ namespace Robust.Shared.Timing
         public byte TickRate
         {
             get => _tickRate;
-            set
-            {
-                // Check this, because TickRate is a divisor in the cache calculation
-                // The first time TickRate is set, no time will have passed anyways
-                if (_tickRate != 0)
-                    // Cache BEFORE updating the tick rate, because ticks up until
-                    // now have been on a different rate, so they count for a
-                    // different amount of time
-                    CacheCurTime();
-
-                _tickRate = value;
-            }
+            set => SetTickRateAt(value, CurTick);
         }
 
         /// <summary>
@@ -205,19 +194,19 @@ namespace Robust.Shared.Timing
 
         // Calculate and store the current time value, based on the current tick rate.
         // Call this whenever you change the TickRate.
-        private void CacheCurTime()
+        private void CacheCurTime(GameTick atTick)
         {
-            var (cachedTime, lastTimeTick) = _cachedCurTimeInfo;
+            var (cachedTime, lastTimeTick) = TimeBase;
 
             TimeSpan newTime;
 
-            if (CurTick.Value >= lastTimeTick.Value)
-              newTime = cachedTime + (TickPeriod * (CurTick.Value - lastTimeTick.Value));
+            if (atTick.Value >= lastTimeTick.Value)
+              newTime = cachedTime + (TickPeriod * (atTick.Value - lastTimeTick.Value));
             else
-              newTime = cachedTime - (TickPeriod * (lastTimeTick.Value - CurTick.Value));
+              newTime = cachedTime - (TickPeriod * (lastTimeTick.Value - atTick.Value));
 
             DebugTools.Assert(TimeSpan.Zero <= newTime);
-            _cachedCurTimeInfo = (newTime, CurTick);
+            TimeBase = (newTime, atTick);
         }
 
         /// <summary>
@@ -225,10 +214,28 @@ namespace Robust.Shared.Timing
         /// </summary>
         public void ResetSimTime()
         {
-            _cachedCurTimeInfo = (TimeSpan.Zero, GameTick.First);;
+            ResetSimTime((TimeSpan.Zero, GameTick.First));
+        }
+
+        public void ResetSimTime((TimeSpan, GameTick) timeBase)
+        {
+            TimeBase = timeBase;
             CurTick = GameTick.First;
             TickRemainder = TimeSpan.Zero;
             Paused = true;
+        }
+
+        public void SetTickRateAt(byte tickRate, GameTick atTick)
+        {
+            // Check this, because TickRate is a divisor in the cache calculation
+            // The first time TickRate is set, no time will have passed anyways
+            if (_tickRate != 0)
+                // Cache BEFORE updating the tick rate, because ticks up until
+                // now have been on a different rate, so they count for a
+                // different amount of time
+                CacheCurTime(atTick);
+
+            _tickRate = tickRate;
         }
 
         public virtual TimeSpan RealLocalToServer(TimeSpan local)

--- a/Robust.Shared/Timing/GameTiming.cs
+++ b/Robust.Shared/Timing/GameTiming.cs
@@ -67,7 +67,7 @@ namespace Robust.Shared.Timing
                 //DebugTools.Assert(CurTick >= lastTimeTick);
                 //TODO: turns out prediction leaves CurTick at the last predicted tick, and not at the last processed server tick
                 //so time gets rewound when processing events like TickRate.
-                time += TickPeriod * (CurTick.Value - lastTimeTick.Value);
+                time += TickPeriod.Mul(CurTick.Value - lastTimeTick.Value);
 
                 if (!InSimulation) // rendering can draw frames between ticks
                 {
@@ -198,12 +198,7 @@ namespace Robust.Shared.Timing
         {
             var (cachedTime, lastTimeTick) = TimeBase;
 
-            TimeSpan newTime;
-
-            if (atTick.Value >= lastTimeTick.Value)
-              newTime = cachedTime + (TickPeriod * (atTick.Value - lastTimeTick.Value));
-            else
-              newTime = cachedTime - (TickPeriod * (lastTimeTick.Value - atTick.Value));
+            var newTime = cachedTime + TickPeriod.Mul(atTick.Value - lastTimeTick.Value);
 
             DebugTools.Assert(TimeSpan.Zero <= newTime);
             TimeBase = (newTime, atTick);

--- a/Robust.Shared/Timing/IGameTiming.cs
+++ b/Robust.Shared/Timing/IGameTiming.cs
@@ -88,6 +88,11 @@ namespace Robust.Shared.Timing
         byte TickRate { get; set; }
 
         /// <summary>
+        /// The baseline time value that CurTime is calculated relatively to.
+        /// </summary>
+        (TimeSpan, GameTick) TimeBase { get; set; }
+
+        /// <summary>
         ///     The length of a tick at the current TickRate. 1/TickRate.
         /// </summary>
         TimeSpan TickPeriod { get; }
@@ -151,6 +156,9 @@ namespace Robust.Shared.Timing
         /// Resets the simulation time. This should be called on round restarts.
         /// </summary>
         void ResetSimTime();
+        void ResetSimTime((TimeSpan, GameTick) timeBase);
+
+        void SetTickRateAt( byte tickRate, GameTick atTick);
 
         TimeSpan RealLocalToServer(TimeSpan local);
         TimeSpan RealServerToLocal(TimeSpan server);

--- a/Robust.Shared/Utility/TimeSpanExt.cs
+++ b/Robust.Shared/Utility/TimeSpanExt.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Robust.Shared.Utility;
+
+/// <summary>
+/// Helper functions for <see cref="TimeSpan"/>
+/// </summary>
+public static class TimeSpanExt
+{
+    /// <summary>
+    /// Multiply a <see cref="TimeSpan"/> with an integer factor.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="TimeSpan"/> only has a multiplication operator for doubles,
+    /// so this is necessary to avoid round-tripping through floating point calculations.
+    /// </remarks>
+    public static TimeSpan Mul(this TimeSpan time, long factor)
+    {
+        return TimeSpan.FromTicks(time.Ticks * factor);
+    }
+}

--- a/Robust.UnitTesting/Shared/Configuration/ConfigurationManagerTest.cs
+++ b/Robust.UnitTesting/Shared/Configuration/ConfigurationManagerTest.cs
@@ -1,5 +1,7 @@
 ﻿using NUnit.Framework;
 using Robust.Shared.Configuration;
+using Robust.Shared.IoC;
+using Robust.Shared.Timing;
 
 namespace Robust.UnitTesting.Shared.Configuration
 {
@@ -11,7 +13,7 @@ namespace Robust.UnitTesting.Shared.Configuration
         [Test]
         public void TestSubscribeUnsubscribe()
         {
-            var mgr = new ConfigurationManager();
+            var mgr = MakeCfg();
 
             mgr.RegisterCVar("foo.bar", 5);
 
@@ -39,7 +41,7 @@ namespace Robust.UnitTesting.Shared.Configuration
         [Test]
         public void TestOverrideDefaultValue()
         {
-            var mgr = new ConfigurationManager();
+            var mgr = MakeCfg();
             mgr.RegisterCVar("foo.bar", 5);
 
             var value = 0;
@@ -62,6 +64,16 @@ namespace Robust.UnitTesting.Shared.Configuration
 
             Assert.That(value, Is.EqualTo(7));
             Assert.That(mgr.GetCVar<int>("foo.bar"), Is.EqualTo(7));
+        }
+
+        private ConfigurationManager MakeCfg()
+        {
+            var collection = new DependencyCollection();
+            collection.Register<ConfigurationManager, ConfigurationManager>();
+            collection.Register<IGameTiming, GameTiming>();
+            collection.BuildGraph();
+
+            return collection.Resolve<ConfigurationManager>();
         }
     }
 }

--- a/Robust.UnitTesting/Shared/GameObjects/EntitySystemManagerOrderTest.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntitySystemManagerOrderTest.cs
@@ -11,6 +11,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Profiling;
 using Robust.Shared.Reflection;
+using Robust.Shared.Timing;
 
 namespace Robust.UnitTesting.Shared.GameObjects
 {
@@ -70,6 +71,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var deps = new DependencyCollection();
             deps.Register<IRuntimeLog, RuntimeLog>();
             deps.Register<ILogManager, LogManager>();
+            deps.Register<IGameTiming, GameTiming>();
             deps.Register<IConfigurationManager, ConfigurationManager>();
             deps.Register<ProfManager, ProfManager>();
             deps.Register<IDynamicTypeFactory, DynamicTypeFactory>();


### PR DESCRIPTION
Synchronized on connect, and change of net.tickrate mid game correctly reports intended tick to client so it can make sure it's always synced.

Supersedes #2705