### PR TITLE
Fix collisionwake on spawn

### DIFF
--- a/Robust.Shared/GameObjects/Systems/CollisionWakeSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/CollisionWakeSystem.cs
@@ -9,8 +9,8 @@ namespace Robust.Shared.GameObjects
         public override void Initialize()
         {
             base.Initialize();
-            SubscribeLocalEvent<CollisionWakeComponent, EntityInitializedMessage>(HandleInitialize);
-            SubscribeLocalEvent<CollisionWakeComponent, ComponentRemove>(HandleRemove);
+            SubscribeLocalEvent<CollisionWakeComponent, PhysicsInitializedEvent>(OnInit);
+            SubscribeLocalEvent<CollisionWakeComponent, ComponentRemove>(OnRemove);
 
             SubscribeLocalEvent<CollisionWakeComponent, ComponentGetState>(OnGetState);
             SubscribeLocalEvent<CollisionWakeComponent, ComponentHandleState>(OnHandleState);
@@ -18,10 +18,10 @@ namespace Robust.Shared.GameObjects
             SubscribeLocalEvent<CollisionWakeComponent, PhysicsWakeEvent>(OnWake);
             SubscribeLocalEvent<CollisionWakeComponent, PhysicsSleepEvent>(OnSleep);
 
-            SubscribeLocalEvent<CollisionWakeComponent, JointAddedEvent>(HandleJointAdd);
-            SubscribeLocalEvent<CollisionWakeComponent, JointRemovedEvent>(HandleJointRemove);
+            SubscribeLocalEvent<CollisionWakeComponent, JointAddedEvent>(OnJointAdd);
+            SubscribeLocalEvent<CollisionWakeComponent, JointRemovedEvent>(OnJointRemove);
 
-            SubscribeLocalEvent<CollisionWakeComponent, EntParentChangedMessage>(HandleParentChange);
+            SubscribeLocalEvent<CollisionWakeComponent, EntParentChangedMessage>(OnParentChange);
         }
 
         public void SetEnabled(EntityUid uid, bool enabled, CollisionWakeComponent? component = null)
@@ -55,7 +55,7 @@ namespace Robust.Shared.GameObjects
             args.State = new CollisionWakeComponent.CollisionWakeState(component.Enabled);
         }
 
-        private void HandleRemove(EntityUid uid, CollisionWakeComponent component, ComponentRemove args)
+        private void OnRemove(EntityUid uid, CollisionWakeComponent component, ComponentRemove args)
         {
             if (component.Enabled
                 && !Terminating(uid)
@@ -65,22 +65,22 @@ namespace Robust.Shared.GameObjects
             }
         }
 
-        private void HandleParentChange(EntityUid uid, CollisionWakeComponent component, ref EntParentChangedMessage args)
+        private void OnParentChange(EntityUid uid, CollisionWakeComponent component, ref EntParentChangedMessage args)
         {
             UpdateCanCollide(uid, component, xform: args.Transform);
         }
 
-        private void HandleInitialize(EntityUid uid, CollisionWakeComponent component, EntityInitializedMessage args)
+        private void OnInit(EntityUid uid, CollisionWakeComponent component, ref PhysicsInitializedEvent args)
         {
             UpdateCanCollide(uid, component, checkTerminating: false);
         }
 
-        private void HandleJointRemove(EntityUid uid, CollisionWakeComponent component, JointRemovedEvent args)
+        private void OnJointRemove(EntityUid uid, CollisionWakeComponent component, JointRemovedEvent args)
         {
             UpdateCanCollide(uid, component, args.OurBody);
         }
 
-        private void HandleJointAdd(EntityUid uid, CollisionWakeComponent component, JointAddedEvent args)
+        private void OnJointAdd(EntityUid uid, CollisionWakeComponent component, JointAddedEvent args)
         {
             // Bypass UpdateCanCollide() as joint count will always be bigger than 0:
             if (component.Enabled)


### PR DESCRIPTION
Stuff that was immediately slept wasn't checked correctly. Thought I had a test for it but it tests everything else so that's been fixed.