### PR TITLE
Add helper function in entity prototype

### DIFF
--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -164,10 +164,15 @@ namespace Robust.Shared.Prototypes
             _loc = IoCManager.Resolve<ILocalizationManager>();
         }
 
-        public bool TryGetComponent<T>([NotNullWhen(true)] out T? component) where T : IComponent
+        public bool TryGetComponent<T>([NotNullWhen(true)] out T? component, IComponentFactory? factory = null) where T : IComponent
         {
-            var compName = IoCManager.Resolve<IComponentFactory>().GetComponentName(typeof(T));
-            return TryGetComponent<T>(compName, out component);
+            if (factory == null)
+            {
+                factory = IoCManager.Resolve<IComponentFactory>();
+            }
+
+            var compName = factory.GetComponentName(typeof(T));
+            return TryGetComponent(compName, out component);
         }
 
         public bool TryGetComponent<T>(string name, [NotNullWhen(true)] out T? component) where T : IComponent

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -164,6 +164,12 @@ namespace Robust.Shared.Prototypes
             _loc = IoCManager.Resolve<ILocalizationManager>();
         }
 
+        public bool TryGetComponent<T>([NotNullWhen(true)] out T? component) where T : IComponent
+        {
+            var compName = IoCManager.Resolve<IComponentFactory>().GetComponentName(typeof(T));
+            return TryGetComponent<T>(compName, out component);
+        }
+
         public bool TryGetComponent<T>(string name, [NotNullWhen(true)] out T? component) where T : IComponent
         {
             if (!Components.TryGetValue(name, out var componentUnCast))


### PR DESCRIPTION
Add new `TryGetComponent` overload to get component from `EntityPrototype` without component name parameter. It will be resolved automatically from `IComponentFactory.GetComponentName()`.