### PR TITLE
Make `ShortestDistance` not reduce angle

### DIFF
--- a/Robust.Shared.Maths/Angle.cs
+++ b/Robust.Shared.Maths/Angle.cs
@@ -235,9 +235,12 @@ namespace Robust.Shared.Maths
         /// <summary>
         ///     Returns the shortest distance between two angles.
         /// </summary>
+        /// <remarks>
+        ///     This does not reduce either angle. It is up to the caller to reduce the input angles.
+        /// </remarks>
         public static Angle ShortestDistance(in Angle a, in Angle b)
         {
-            var delta = (b - a) % Math.Tau;
+            var delta = b - a;
             return 2 * delta % Math.Tau - delta;
         }
 


### PR DESCRIPTION
This was causing an issue with emergency lights on content, because they were trying to lerp from 0 to 1080 (the same angle). Now it's the job of the caller to reduce the angles they input