### PR TITLE
Reset last modified tick

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -366,6 +366,7 @@ namespace Robust.Client.GameStates
 
             var countReset = 0;
             var system = _entitySystemManager.GetEntitySystem<ClientDirtySystem>();
+            var query = _entityManager.GetEntityQuery<MetaDataComponent>();
 
             foreach (var entity in system.GetDirtyEntities(curTick))
             {
@@ -398,7 +399,9 @@ namespace Robust.Client.GameStates
                     var handleState = new ComponentHandleState(compState, null);
                     _entities.EventBus.RaiseComponentEvent(comp, ref handleState);
                     comp.HandleComponentState(compState, null);
+                    comp.LastModifiedTick = curTick;
                 }
+                query.GetComponent(entity).EntityLastModifiedTick = curTick;
             }
 
             system.Reset();

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -1074,7 +1074,7 @@ namespace Robust.Shared.GameObjects
 
         public bool MoveNext() => _dictEnum.MoveNext();
 
-        public (ushort netId, IComponent component) Current
+        public (ushort netId, Component component) Current
         {
             get
             {


### PR DESCRIPTION
Currently a component and the entity-metadata's last modified tick don't get reset when resetting predicted entities. 
Before #2826 this didn't really cause issues, other than occasionally unnecessarily resetting an entity that hadn't been modified. 