### PR TITLE
Put Control FrameUpdate() before style & layout.

### DIFF
--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -245,6 +245,19 @@ namespace Robust.Client.UserInterface
 
         public void FrameUpdate(FrameEventArgs args)
         {
+            using (_prof.Group("Update"))
+            {
+                foreach (var root in _roots)
+                {
+                    using (_prof.Group("Root"))
+                    {
+                        var totalUpdated = root.DoFrameUpdateRecursive(args);
+
+                        _prof.WriteValue("Total", ProfData.Int32(totalUpdated));
+                    }
+                }
+            }
+
             // Process queued style & layout updates.
             using (_prof.Group("Style"))
             {
@@ -295,19 +308,6 @@ namespace Robust.Client.UserInterface
                 }
 
                 _prof.WriteValue("Total", ProfData.Int32(total));
-            }
-
-            using (_prof.Group("Update"))
-            {
-                foreach (var root in _roots)
-                {
-                    using (_prof.Group("Root"))
-                    {
-                        var totalUpdated = root.DoFrameUpdateRecursive(args);
-
-                        _prof.WriteValue("Total", ProfData.Int32(totalUpdated));
-                    }
-                }
             }
 
             // count down tooltip delay if we're not showing one yet and


### PR DESCRIPTION
Seems like the saner option.

Requires https://github.com/space-wizards/space-station-14/pull/8472 to be merged to avoid everything exploding.