### PR TITLE
Fix WorldSpace overlay drawing

### DIFF
--- a/Robust.Shared/Enums/OverlaySpaces.cs
+++ b/Robust.Shared/Enums/OverlaySpaces.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -7,7 +7,7 @@ namespace Robust.Shared.Enums {
     ///     Determines in which canvas layers an overlay gets drawn.
     /// </summary>
     [Flags]
-    public enum OverlaySpace {
+    public enum OverlaySpace : byte {
         /// <summary>
         ///     Used for matching bit flags.
         /// </summary>
@@ -29,18 +29,24 @@ namespace Robust.Shared.Enums {
         WorldSpaceBelowFOV = 1 << 3,
 
         /// <summary>
+        ///     This overlay will be along with entities, with the order depending on overlay's ZOrder and sprite's
+        ///     DrawDepth.
+        /// </summary>
+        WorldSpaceEntities = 1 << 4,
+
+        /// <summary>
         ///     This overlay will be drawn beneath entities, lighting, and FOV; above grids.
         /// </summary>
-        WorldSpaceBelowEntities = 1 << 4,
+        WorldSpaceBelowEntities = 1 << 5,
 
         /// <summary>
         ///     This overlay will be drawn in screen coordinates behind the world.
         /// </summary>
-        ScreenSpaceBelowWorld = 1 << 5,
+        ScreenSpaceBelowWorld = 1 << 6,
 
         /// <summary>
         ///     Overlay will be rendered below grids, entities, and everything else. In world space.
         /// </summary>
-        WorldSpaceBelowWorld = 1 << 6
+        WorldSpaceBelowWorld = 1 << 7
     }
 }


### PR DESCRIPTION
From the doc string, WorldSpace overlays are meant to be drawn above entities, but there is code that will drawn them at the same time as entities, sorted based on the overlay's ZIndex and the sprite's drawdepth.

However, these overlays get drawn again later on, and the actual sorting code was bugged and could draw the same overlay repeatedly So currently any world-space overlay with a ZIndex below could get drawn hundreds of times. Fortunately this wasn't actually impacting any overlays, as they all had either null or 100+ z-indices.

This PR fixes the sorting and creates a separate overlay space for overlays that want to get drawn at the same time as entities.