### PR TITLE
Revert ShortestDistance changes

### DIFF
--- a/Robust.Client/Animations/AnimationTrackProperty.cs
+++ b/Robust.Client/Animations/AnimationTrackProperty.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Robust.Shared.Animations;
 using Robust.Shared.Maths;
@@ -101,7 +101,7 @@ namespace Robust.Client.Animations
                 case double d:
                     return MathHelper.Lerp(d, (double) b, t);
                 case Angle angle:
-                    return Angle.Lerp(angle, (Angle) b, t);
+                    return Angle.Lerp(angle, (Angle) b, t, false);
                 case Color color:
                     return Color.InterpolateBetween(color, (Color) b, t);
                 case int i:

--- a/Robust.Shared.Maths/Angle.cs
+++ b/Robust.Shared.Maths/Angle.cs
@@ -225,22 +225,21 @@ namespace Robust.Shared.Maths
         }
 
         /// <summary>
-        ///     Similar to Lerp but makes sure the angle wraps around to 360 degrees.
+        ///     Similar to Lerp but, but defaults to making sure that lerping from 1 to 359 degrees doesn't wrap around
+        ///     the whole circle.
         /// </summary>
-        public static Angle Lerp(in Angle a, in Angle b, float factor)
+        public static Angle Lerp(in Angle a, in Angle b, float factor, bool reduce = true)
         {
-            return a + ShortestDistance(a, b) * factor;
+            return reduce ? a + ShortestDistance(a, b) * factor
+                : new(a.Theta + (a.Theta - b.Theta) * factor);
         }
 
         /// <summary>
         ///     Returns the shortest distance between two angles.
         /// </summary>
-        /// <remarks>
-        ///     This does not reduce either angle. It is up to the caller to reduce the input angles.
-        /// </remarks>
         public static Angle ShortestDistance(in Angle a, in Angle b)
         {
-            var delta = b - a;
+            var delta = (b - a) % Math.Tau;
             return 2 * delta % Math.Tau - delta;
         }
 


### PR DESCRIPTION
reverts #2869. IMO shortest distance doesn't really make sense without reducing the angle, and I think just about every time it or the angle lerp get used you'll want that behaviour.

Instead this PR adds an option to Angle.Lerp to not call shortest distance in the first place and makes animation tracks use that.

Fixes space-wizards/space-station-14/issues/8497