### PR TITLE
Undo all angle lerp changes

### DIFF
--- a/Robust.Client/Animations/AnimationTrackProperty.cs
+++ b/Robust.Client/Animations/AnimationTrackProperty.cs
@@ -101,7 +101,7 @@ namespace Robust.Client.Animations
                 case double d:
                     return MathHelper.Lerp(d, (double) b, t);
                 case Angle angle:
-                    return Angle.Lerp(angle, (Angle) b, t, false);
+                    return Angle.Lerp(angle, (Angle) b, t);
                 case Color color:
                     return Color.InterpolateBetween(color, (Color) b, t);
                 case int i:

--- a/Robust.Shared.Maths/Angle.cs
+++ b/Robust.Shared.Maths/Angle.cs
@@ -228,10 +228,9 @@ namespace Robust.Shared.Maths
         ///     Similar to Lerp but, but defaults to making sure that lerping from 1 to 359 degrees doesn't wrap around
         ///     the whole circle.
         /// </summary>
-        public static Angle Lerp(in Angle a, in Angle b, float factor, bool reduce = true)
+        public static Angle Lerp(in Angle a, in Angle b, float factor)
         {
-            return reduce ? a + ShortestDistance(a, b) * factor
-                : new(a.Theta + (a.Theta - b.Theta) * factor);
+            return a + ShortestDistance(a, b) * factor;
         }
 
         /// <summary>


### PR DESCRIPTION
Reverts to before #2869 and #2881.
#2881 also broke some animations. Best solution is probably to just fix the emergency light animation directly (see space-wizards/space-station-14/pull/8531).