### PR TITLE
Expose RemoveComponentDeferred

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -330,6 +330,12 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <inheritdoc />
+        public void RemoveComponentDeferred(EntityUid owner, Component component)
+        {
+            RemoveComponentDeferred(component, owner, false);
+        }
+
+        /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool RemoveComponent(EntityUid uid, ushort netId)
         {
@@ -400,6 +406,9 @@ namespace Robust.Shared.GameObjects
         private void RemoveComponentDeferred(Component component, EntityUid uid, bool removeProtected)
         {
             if (component == null) throw new ArgumentNullException(nameof(component));
+
+            if (component.Owner != uid)
+                throw new InvalidOperationException("Component is not owned by entity.");
 
             if (component.Deleted) return;
 

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -527,6 +527,38 @@ public partial class EntitySystem
 
     #endregion
 
+    #region Component Remove Deferred
+
+    /// <inheritdoc cref="IEntityManager.RemoveComponentDeferred&lt;T&gt;(EntityUid)"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected bool RemCompDeferred<T>(EntityUid uid) where T : class, IComponent
+    {
+        return EntityManager.RemoveComponentDeferred<T>(uid);
+    }
+
+    /// <inheritdoc cref="IEntityManager.RemoveComponentDeferred(EntityUid, Type)"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected bool RemCompDeferred(EntityUid uid, Type type)
+    {
+        return EntityManager.RemoveComponentDeferred(uid, type);
+    }
+
+    /// <inheritdoc cref="IEntityManager.RemoveComponentDeferred(EntityUid, Component)"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected void RemCompDeferred(EntityUid uid, Component component)
+    {
+        EntityManager.RemoveComponentDeferred(uid, component);
+    }
+
+    /// <inheritdoc cref="IEntityManager.RemoveComponentDeferred(EntityUid, IComponent)"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected void RemCompDeferred(EntityUid uid, IComponent component)
+    {
+        EntityManager.RemoveComponentDeferred(uid, component);
+    }
+    #endregion
+
+
     #region Component Remove
 
     /// <inheritdoc cref="IEntityManager.RemoveComponent&lt;T&gt;(EntityUid)"/>

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -94,18 +94,44 @@ namespace Robust.Shared.GameObjects
         void RemoveComponent(EntityUid uid, IComponent component);
 
         /// <summary>
-        ///     Removes the specified component at a later time. Throws if the given component does not belong to the entity.
+        ///     Removes the specified component at a later time.
+        ///     Without needing to have the component itself.
+        /// </summary>
+        /// <typeparam name="T">The component reference type to remove.</typeparam>
+        /// <param name="uid">Entity UID to modify.</param>
+        bool RemoveComponentDeferred<T>(EntityUid uid);
+
+        /// <summary>
+        ///     Removes the specified component with a specified type at a later time.
+        /// </summary>
+        /// <param name="uid">Entity UID to modify.</param>
+        /// <param name="type">A trait or component type to check for.</param>
+        /// <returns>Returns false if the entity did not have the specified component.</returns>
+        bool RemoveComponentDeferred(EntityUid uid, Type type);
+
+        /// <summary>
+        ///     Removes the component with a specified network ID at a later time.
+        /// </summary>
+        /// <param name="uid">Entity UID to modify.</param>
+        /// <param name="netID">Network ID of the component to remove.</param>
+        /// <returns>Returns false if the entity did not have the specified component.</returns>
+        bool RemoveComponentDeferred(EntityUid uid, ushort netID);
+
+        /// <summary>
+        ///     Removes the specified component at a later time.
+        ///     Throws if the given component does not belong to the entity.
+        /// </summary>
+        /// <param name="uid">Entity UID to modify.</param>
+        /// <param name="component">Component to remove.</param>
+        void RemoveComponentDeferred(EntityUid uid, IComponent component);
+
+        /// <summary>
+        ///     Removes the specified component at a later time.
+        ///     Throws if the given component does not belong to the entity.
         /// </summary>
         /// <param name="uid">Entity UID to modify.</param>
         /// <param name="component">Component to remove.</param>
         void RemoveComponentDeferred(EntityUid uid, Component component);
-
-        /// <summary>
-        ///     Removes the specified component at a later time. Throws if the given component does not belong to the entity.
-        /// </summary>
-        /// <param name="uid">Entity UID to modify.</param>
-        /// <param name="component">Component to remove.</param>
-        void RemoveComponent(EntityUid uid, Component component);
 
         /// <summary>
         ///     Removes all components from an entity, except the required components.

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -94,7 +94,14 @@ namespace Robust.Shared.GameObjects
         void RemoveComponent(EntityUid uid, IComponent component);
 
         /// <summary>
-        ///     Removes the specified component. Throws if the given component does not belong to the entity.
+        ///     Removes the specified component at a later time. Throws if the given component does not belong to the entity.
+        /// </summary>
+        /// <param name="uid">Entity UID to modify.</param>
+        /// <param name="component">Component to remove.</param>
+        void RemoveComponentDeferred(EntityUid uid, Component component);
+
+        /// <summary>
+        ///     Removes the specified component at a later time. Throws if the given component does not belong to the entity.
         /// </summary>
         /// <param name="uid">Entity UID to modify.</param>
         /// <param name="component">Component to remove.</param>


### PR DESCRIPTION
There are at least 5 places in content that are rolling their own method of deferring component deletion, because you can't call RemoveComponent inside of an EntityQuery. The functionality to defer was already there, so I added a way to call it.