### PR TITLE
Add logs to grid splitting

### DIFF
--- a/Robust.Client/Physics/GridFixtureSystem.cs
+++ b/Robust.Client/Physics/GridFixtureSystem.cs
@@ -4,6 +4,7 @@ using Robust.Client.Graphics;
 using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Utility;
@@ -19,6 +20,7 @@ namespace Robust.Client.Physics
             {
                 if (_enableDebug == value) return;
 
+                Sawmill.Info($"Set grid fixture debug to {value}");
                 _enableDebug = value;
                 var overlayManager = IoCManager.Resolve<IOverlayManager>();
 
@@ -35,6 +37,8 @@ namespace Robust.Client.Physics
                 }
             }
         }
+
+        private ISawmill Sawmill = default!;
 
         private bool _enableDebug = false;
         private readonly Dictionary<EntityUid, Dictionary<Vector2i, List<List<Vector2i>>>> _nodes = new();
@@ -55,6 +59,7 @@ namespace Robust.Client.Physics
 
         private void OnDebugMessage(ChunkSplitDebugMessage ev)
         {
+            Sawmill.Info($"Received grid fixture debug data");
             if (!_enableDebug) return;
 
             _nodes[ev.Grid] = ev.Nodes;

--- a/Robust.Client/Physics/GridSplitVisualsCommand.cs
+++ b/Robust.Client/Physics/GridSplitVisualsCommand.cs
@@ -13,6 +13,6 @@ public sealed class GridSplitVisualCommand : IConsoleCommand
     {
         var system = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<GridFixtureSystem>();
         system.EnableDebug ^= true;
-        shell.WriteLine($"Toggled gridsplit node visuals");
+        shell.WriteLine($"Toggled gridsplit node visuals to {system.EnableDebug}");
     }
 }

--- a/Robust.Server/Physics/GridFixtureSystem.cs
+++ b/Robust.Server/Physics/GridFixtureSystem.cs
@@ -190,7 +190,6 @@ namespace Robust.Server.Physics
             var splitFrontier = new Queue<ChunkSplitNode>(4);
             var grids = new List<HashSet<ChunkSplitNode>>(1);
 
-            // TODO: At this point detect splits.
             while (dirtyNodes.Count > 0)
             {
                 var originEnumerator = dirtyNodes.GetEnumerator();
@@ -234,10 +233,11 @@ namespace Robust.Server.Physics
 
                 var xformQuery = GetEntityQuery<TransformComponent>();
                 var bodyQuery = GetEntityQuery<PhysicsComponent>();
+                var gridQuery = GetEntityQuery<MapGridComponent>();
                 var oldGridXform = xformQuery.GetComponent(mapGrid.GridEntityId);
                 var (gridPos, gridRot) = oldGridXform.GetWorldPositionRotation(xformQuery);
                 var mapBody = bodyQuery.GetComponent(mapGrid.GridEntityId);
-                var oldGridComp = Comp<MapGridComponent>(mapGrid.GridEntityId);
+                var oldGridComp = gridQuery.GetComponent(mapGrid.GridEntityId);
                 var newGrids = new GridId[grids.Count - 1];
 
                 for (var i = 0; i < grids.Count - 1; i++)
@@ -254,7 +254,7 @@ namespace Robust.Server.Physics
                     splitBody.LinearVelocity = mapBody.LinearVelocity;
                     splitBody.AngularVelocity = mapBody.AngularVelocity;
 
-                    var gridComp = Comp<MapGridComponent>(splitGrid.GridEntityId);
+                    var gridComp = gridQuery.GetComponent(splitGrid.GridEntityId);
                     var tileData = new List<(Vector2i GridIndices, Tile Tile)>(group.Sum(o => o.Indices.Count));
 
                     // Gather all tiles up front and set once to minimise fixture change events


### PR DESCRIPTION
Somehow it turns off entirely indefinitely and all I can think is _isSplitting gets stuck on during a split