### PR TITLE
Default lag

### DIFF
--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -211,7 +211,7 @@ namespace Robust.Shared
         /// Add fake extra delay to all outgoing UDP network packets, in seconds.
         /// </summary>
         /// <seealso cref="NetFakeLagRand"/>
-        public static readonly CVarDef<float> NetFakeLagMin = CVarDef.Create("net.fakelagmin", 0f, CVar.CHEAT);
+        public static readonly CVarDef<float> NetFakeLagMin = CVarDef.Create("net.fakelagmin", 0.15f, CVar.CHEAT);
 
         /// <summary>
         /// Add fake extra random delay to all outgoing UDP network packets, in seconds.


### PR DESCRIPTION
As agreed in the 2022/05/14 maintainer meeting

![image](https://user-images.githubusercontent.com/31366439/171184575-0142e7c0-0b69-4b66-a13c-f72f0ba05340.png)


Might need to be 0.075 instead?