### PR TITLE
Faster box transform

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -941,7 +941,7 @@ namespace Robust.Client.Graphics.Clyde
                         var tl = worldTransform.Transform(box.TopLeft);
                         var tr = worldTransform.Transform(box.TopRight);
                         var br = worldTransform.Transform(box.BottomRight);
-                        var bl = worldTransform.Transform(box.BottomLeft);
+                        var bl = tl + br - tr;
 
                         // Faces.
                         var faceN = new Vector4(tl.X, tl.Y, tr.X, tr.Y);
@@ -983,7 +983,7 @@ namespace Robust.Client.Graphics.Clyde
                         var dTl = eyeTransform.Transform(tl);
                         var dTr = eyeTransform.Transform(tr);
                         var dBl = eyeTransform.Transform(bl);
-                        var dBr = eyeTransform.Transform(br);
+                        var dBr = dBl + dTr - dTl;
 
                         // Get which neighbors are occluding.
                         var no = (occluder.Occluding & OccluderDir.North) != 0;

--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -539,7 +539,7 @@ namespace Robust.Client.Graphics.Clyde
             bl = _currentMatrixModel.Transform(bl);
             br = _currentMatrixModel.Transform(br);
             tr = _currentMatrixModel.Transform(tr);
-            tl = _currentMatrixModel.Transform(tl);
+            tl = tr + bl - br;
 
             // TODO: split batch if necessary.
             var vIdx = BatchVertexIndex;

--- a/Robust.Shared.Maths/Box2Rotated.cs
+++ b/Robust.Shared.Maths/Box2Rotated.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
@@ -28,6 +28,9 @@ namespace Robust.Shared.Maths
         public readonly Vector2 TopLeft => Origin + Rotation.RotateVec(Box.TopLeft - Origin);
         public readonly Vector2 TopRight => Origin + Rotation.RotateVec(Box.TopRight - Origin);
         public readonly Vector2 BottomLeft => Origin + Rotation.RotateVec(Box.BottomLeft - Origin);
+        public readonly Vector2 Centre => Origin + Rotation.RotateVec((Box.BottomLeft + Box.TopRight)/2 - Origin);
+
+        public Matrix3 Transform => Matrix3.CreateTransform(Origin - Rotation.RotateVec(Origin), Rotation);
 
         public Box2Rotated(Vector2 bottomLeft, Vector2 topRight)
             : this(new Box2(bottomLeft, topRight))


### PR DESCRIPTION
- Replaces some vector2 transforms with vector addition
- Pilfers Sse code from `Box2Rotated.CalcBoundingBox()`
  - Seems to work, but I don't fully understand all the bit shuffling.
  - Also, NumericsHelpers checks for `Avx` & `AdvSimd`, but the pilfered code only supports Sse
  - From my limited understanding, `Avx` isn't required as the box only has 4 corners, and `AdvSimd` is for ARM? so its probably fine as is?

Before the changes, my idle client would spend ~3% of cpu time on box transforms inside `ProcessSpriteEntities()`, now its down to 1.5%.