### PR TITLE
Ordered EventBus optimizations

### DIFF
--- a/Resources/Locale/en-US/commands.ftl
+++ b/Resources/Locale/en-US/commands.ftl
@@ -87,3 +87,10 @@ cmd-exec-help = Usage: exec <fileName>
     Each line in the file is executed as a single command, unless it starts with a #
 
 cmd-exec-arg-filename = <fileName>
+
+## 'dump_net_comps' command
+cmd-dump_net_comps-desc = Prints the table of networked components.
+cmd-dump_net_comps-help = Usage: dump_net-comps
+
+cmd-dump_net_comps-error-writeable = Registration still writeable, network ids have not been generated.
+cmd-dump_net_comps-header = Networked Component Registrations:

--- a/Robust.Client/GameObjects/ClientComponentFactory.cs
+++ b/Robust.Client/GameObjects/ClientComponentFactory.cs
@@ -1,4 +1,3 @@
-using Robust.Shared.Console;
 using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -8,8 +7,8 @@ namespace Robust.Client.GameObjects
 {
     internal sealed class ClientComponentFactory : ComponentFactory
     {
-        public ClientComponentFactory(IDynamicTypeFactoryInternal typeFactory, IReflectionManager reflectionManager, IConsoleHost conHost)
-            : base(typeFactory, reflectionManager, conHost)
+        public ClientComponentFactory(IDynamicTypeFactoryInternal typeFactory, IReflectionManager reflectionManager)
+            : base(typeFactory, reflectionManager)
         {
             // Required for the engine to work
             RegisterIgnore("KeyBindingInput");

--- a/Robust.Server/GameObjects/ServerComponentFactory.cs
+++ b/Robust.Server/GameObjects/ServerComponentFactory.cs
@@ -1,4 +1,3 @@
-using Robust.Shared.Console;
 using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -8,8 +7,8 @@ namespace Robust.Server.GameObjects
 {
     internal sealed class ServerComponentFactory : ComponentFactory
     {
-        public ServerComponentFactory(IDynamicTypeFactoryInternal typeFactory, IReflectionManager reflectionManager, IConsoleHost conHost)
-            : base(typeFactory, reflectionManager, conHost)
+        public ServerComponentFactory(IDynamicTypeFactoryInternal typeFactory, IReflectionManager reflectionManager)
+            : base(typeFactory, reflectionManager)
         {
             RegisterIgnore("Input");
             RegisterIgnore("AnimationPlayer");

--- a/Robust.Shared/Console/Commands/DumpNetComponentsCommand.cs
+++ b/Robust.Shared/Console/Commands/DumpNetComponentsCommand.cs
@@ -1,0 +1,31 @@
+﻿using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Localization;
+
+namespace Robust.Shared.Console.Commands;
+
+internal sealed class DumpNetComponentsCommand : IConsoleCommand
+{
+    public string Command => "dump_net_comps";
+    public string Description => Loc.GetString("cmd-dump_net_comps-desc");
+    public string Help => Loc.GetString("cmd-dump_net_comps-help");
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var mgr = IoCManager.Resolve<IComponentFactory>();
+
+        if (mgr.NetworkedComponents is not { } comps)
+        {
+            shell.WriteError(Loc.GetString("cmd-dump_net_comps-error-writeable"));
+            return;
+        }
+
+        shell.WriteLine(Loc.GetString("cmd-dump_net_comps-header"));
+
+        for (var netId = 0; netId < comps.Count; netId++)
+        {
+            var registration = comps[netId];
+            shell.WriteLine($"  [{netId,4}] {registration.Name,-16} {registration.Type.Name}");
+        }
+    }
+}

--- a/Robust.Shared/GameObjects/ComponentFactory.cs
+++ b/Robust.Shared/GameObjects/ComponentFactory.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.Serialization;
-using JetBrains.Annotations;
-using Robust.Shared.Console;
 using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
@@ -67,28 +65,10 @@ namespace Robust.Shared.GameObjects
 
         private IEnumerable<ComponentRegistration> AllRegistrations => types.Values;
 
-        public ComponentFactory(IDynamicTypeFactoryInternal typeFactory, IReflectionManager reflectionManager, IConsoleHost conHost)
+        public ComponentFactory(IDynamicTypeFactoryInternal typeFactory, IReflectionManager reflectionManager)
         {
-
             _typeFactory = typeFactory;
             _reflectionManager = reflectionManager;
-
-            conHost.RegisterCommand("dump_net_comps", "Prints the table of networked components.", "dump_net_comps", (shell, argStr, args) =>
-            {
-                if (_networkedComponents is null)
-                {
-                    shell.WriteError("Registration still writeable, network ids have not been generated.");
-                    return;
-                }
-
-                shell.WriteLine("Networked Component Registrations:");
-
-                for (int netId = 0; netId < _networkedComponents.Count; netId++)
-                {
-                    var registration = _networkedComponents[netId];
-                    shell.WriteLine($"  [{netId,4}] {registration.Name,-16} {registration.Type.Name}");
-                }
-            });
         }
 
         private void Register(Type type, bool overwrite = false)

--- a/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs
@@ -163,7 +163,7 @@ namespace Robust.Shared.GameObjects
             if (eventHandler == null)
                 throw new ArgumentNullException(nameof(eventHandler));
 
-            var order = new OrderingData(orderType, before, after);
+            var order = new OrderingData(orderType, before ?? Array.Empty<Type>(), after ?? Array.Empty<Type>());
 
             SubscribeEventCommon<T>(source, subscriber,
                 (ref Unit ev) => eventHandler(Unsafe.As<Unit, T>(ref ev)), eventHandler, order, false);
@@ -183,7 +183,7 @@ namespace Robust.Shared.GameObjects
             EntityEventRefHandler<T> eventHandler,
             Type orderType, Type[]? before = null, Type[]? after = null) where T : notnull
         {
-            var order = new OrderingData(orderType, before, after);
+            var order = new OrderingData(orderType, before ?? Array.Empty<Type>(), after ?? Array.Empty<Type>());
 
             SubscribeEventCommon<T>(source, subscriber, (ref Unit ev) =>
             {

--- a/Robust.Shared/GameObjects/EntityEventBus.Common.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Common.cs
@@ -57,7 +57,7 @@ internal sealed partial class EntityEventBus : IEventBus
         if (data == null)
             return;
 
-        if (data.Before != null || data.After != null)
+        if (data.Before.Length > 0 || data.After.Length > 0)
         {
             subs.IsOrdered = true;
             subs.OrderingUpToDate = false;

--- a/Robust.Shared/GameObjects/EntityEventBus.Common.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Common.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using JetBrains.Annotations;
+using Robust.Shared.Collections;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.GameObjects;
+
+internal sealed partial class EntityEventBus : IEventBus
+{
+    private readonly Dictionary<Type, EventSubscriptions> _eventSubscriptions = new();
+
+    private readonly Dictionary<IEntityEventSubscriber, Dictionary<Type, Registration>> _inverseEventSubscriptions
+        = new();
+
+    private readonly Queue<(EventSource source, object args)> _eventQueue = new();
+
+    private IEntityManager _entMan;
+    private IComponentFactory _comFac;
+
+    // eUid -> EventType -> { CompType1, ... CompTypeN }
+    private Dictionary<EntityUid, Dictionary<Type, HashSet<CompIdx>>> _entEventTables = new();
+
+    // CompType -> EventType -> Handler
+    private Dictionary<Type, DirectedRegistration>?[] _entSubscriptions =
+        Array.Empty<Dictionary<Type, DirectedRegistration>?>();
+
+    // EventType -> { CompType1, ... CompType N }
+    private Dictionary<Type, HashSet<CompIdx>> _entSubscriptionsInv = new();
+
+    // prevents shitcode, get your subscriptions figured out before you start spawning entities
+    private bool _subscriptionLock;
+
+    public bool IgnoreUnregisteredComponents;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowByRefMisMatch() =>
+        throw new InvalidOperationException("Mismatching by-ref ness on event!");
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ref Unit ExtractUnitRef(ref object obj, Type objType)
+    {
+        // If it's a boxed value type we have to do some trickery to return the INTERIOR reference,
+        // not the reference to the boxed object.
+        // Otherwise the unit points to the reference to the reference type.
+        return ref objType.IsValueType
+            ? ref Unsafe.As<object, UnitBox>(ref obj).Value
+            : ref Unsafe.As<object, Unit>(ref obj);
+    }
+
+    private void RegisterCommon(Type eventType, OrderingData? data, out EventSubscriptions subs)
+    {
+        subs = _eventSubscriptions.GetOrNew(eventType);
+
+        if (data == null)
+            return;
+
+        if (data.Before != null || data.After != null)
+        {
+            subs.IsOrdered = true;
+            subs.OrderingUpToDate = false;
+        }
+    }
+
+    private sealed class Registration : OrderedRegistration, IEquatable<Registration>
+    {
+        public readonly object EqualityToken;
+        public readonly RefEventHandler Handler;
+        public readonly EventSource Mask;
+        public readonly bool ReferenceEvent;
+
+        public Registration(
+            EventSource mask,
+            RefEventHandler handler,
+            object equalityToken,
+            OrderingData? ordering,
+            bool referenceEvent) : base(ordering)
+        {
+            Mask = mask;
+            Handler = handler;
+            EqualityToken = equalityToken;
+            ReferenceEvent = referenceEvent;
+        }
+
+        public bool Equals(Registration? other)
+        {
+            return other != null && Mask == other.Mask && Equals(EqualityToken, other.EqualityToken);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is Registration other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((int)Mask * 397) ^ EqualityToken.GetHashCode();
+            }
+        }
+    }
+
+    private sealed class EventSubscriptions
+    {
+        public bool IsOrdered;
+        public bool OrderingUpToDate;
+        public ValueList<Registration> Registrations;
+    }
+
+    // This is not a real type. Whenever you see a "ref Unit" it means it's a ref to *some* kind of other type.
+
+    // It should always be cast to/from with Unsafe.As<,>
+
+    private readonly struct Unit
+    {
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private sealed class UnitBox
+    {
+        [UsedImplicitly] public Unit Value;
+    }
+}

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -97,8 +97,8 @@ namespace Robust.Shared.GameObjects
             _comFac = entMan.ComponentFactory;
 
             // Dynamic handling of components is only for RobustUnitTest compatibility spaghetti.
-            _comFac.ComponentAdded += ETComFacOnComponentAdded;
-            _comFac.ComponentReferenceAdded += ETComFacOnComponentReferenceAdded;
+            _comFac.ComponentAdded += ComFacOnComponentAdded;
+            _comFac.ComponentReferenceAdded += ComFacOnComponentReferenceAdded;
 
             InitEntSubscriptionsArray();
         }
@@ -170,7 +170,7 @@ namespace Robust.Shared.GameObjects
 
         private void RaiseLocalEventCore(EntityUid uid, ref Unit unitRef, Type type, bool broadcast, bool byRef)
         {
-            if (!_eventSubscriptions.TryGetValue(type, out var subs))
+            if (!_eventData.TryGetValue(type, out var subs))
                 return;
 
             if (subs.IsOrdered)
@@ -270,12 +270,12 @@ namespace Robust.Shared.GameObjects
             EntUnsubscribe(CompIdx.Index<TComp>(), typeof(TEvent));
         }
 
-        private void ETComFacOnComponentReferenceAdded(ComponentRegistration arg1, CompIdx arg2)
+        private void ComFacOnComponentReferenceAdded(ComponentRegistration arg1, CompIdx arg2)
         {
             CompIdx.RefArray(ref _entSubscriptions, arg2) ??= new Dictionary<Type, DirectedRegistration>();
         }
 
-        private void ETComFacOnComponentAdded(ComponentRegistration obj)
+        private void ComFacOnComponentAdded(ComponentRegistration obj)
         {
             CompIdx.RefArray(ref _entSubscriptions, obj.Idx) ??= new Dictionary<Type, DirectedRegistration>();
         }
@@ -533,8 +533,8 @@ namespace Robust.Shared.GameObjects
 
         public void Dispose()
         {
-            _comFac.ComponentAdded -= ETComFacOnComponentAdded;
-            _comFac.ComponentReferenceAdded -= ETComFacOnComponentReferenceAdded;
+            _comFac.ComponentAdded -= ComFacOnComponentAdded;
+            _comFac.ComponentReferenceAdded -= ComFacOnComponentReferenceAdded;
 
             // punishment for use-after-free
             _entMan = null!;

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -214,7 +214,7 @@ namespace Robust.Shared.GameObjects
             void EventHandler(EntityUid uid, IComponent comp, ref TEvent args)
                 => handler(uid, (TComp)comp, args);
 
-            var orderData = new OrderingData(orderType, before, after);
+            var orderData = new OrderingData(orderType, before ?? Array.Empty<Type>(), after ?? Array.Empty<Type>());
 
             EntSubscribe<TEvent>(
                 CompIdx.Index<TComp>(),
@@ -249,7 +249,7 @@ namespace Robust.Shared.GameObjects
             void EventHandler(EntityUid uid, IComponent comp, ref TEvent args)
                 => handler(uid, (TComp)comp, ref args);
 
-            var orderData = new OrderingData(orderType, before, after);
+            var orderData = new OrderingData(orderType, before ?? Array.Empty<Type>(), after ?? Array.Empty<Type>());
 
             EntSubscribe<TEvent>(
                 CompIdx.Index<TComp>(),

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -82,9 +82,6 @@ namespace Robust.Shared.GameObjects
 
     internal partial class EntityEventBus : IDisposable
     {
-        private const string ValueDispatchError = "Tried to dispatch a value event to a by-reference subscription.";
-        private const string RefDispatchError = "Tried to dispatch a ref event to a by-value subscription.";
-
         private delegate void DirectedEventHandler(EntityUid uid, IComponent comp, ref Unit args);
 
         private delegate void DirectedEventHandler<TEvent>(EntityUid uid, IComponent comp, ref TEvent args)

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -80,15 +80,15 @@ namespace Robust.Shared.GameObjects
         public void OnlyCallOnRobustUnitTestISwearToGodPleaseSomebodyKillThisNightmare();
     }
 
-    internal partial class EntityEventBus : IDirectedEventBus, IEventBus, IDisposable
+    internal partial class EntityEventBus : IDisposable
     {
+        private const string ValueDispatchError = "Tried to dispatch a value event to a by-reference subscription.";
+        private const string RefDispatchError = "Tried to dispatch a ref event to a by-value subscription.";
+
         private delegate void DirectedEventHandler(EntityUid uid, IComponent comp, ref Unit args);
 
         private delegate void DirectedEventHandler<TEvent>(EntityUid uid, IComponent comp, ref TEvent args)
             where TEvent : notnull;
-
-        private IEntityManager _entMan;
-        private EventTables _eventTables;
 
         /// <summary>
         /// Constructs a new instance of <see cref="EntityEventBus"/>.
@@ -97,7 +97,27 @@ namespace Robust.Shared.GameObjects
         public EntityEventBus(IEntityManager entMan)
         {
             _entMan = entMan;
-            _eventTables = new EventTables(_entMan);
+            _comFac = entMan.ComponentFactory;
+
+            _entMan.EntityAdded += ETOnEntityAdded;
+            _entMan.EntityDeleted += ETOnEntityDeleted;
+
+            _entMan.ComponentAdded += ETOnComponentAdded;
+            _entMan.ComponentRemoved += ETOnComponentRemoved;
+
+            // Dynamic handling of components is only for RobustUnitTest compatibility spaghetti.
+            _comFac.ComponentAdded += ETComFacOnComponentAdded;
+            _comFac.ComponentReferenceAdded += ETComFacOnComponentReferenceAdded;
+
+            InitEntSubscriptionsArray();
+        }
+
+        private void InitEntSubscriptionsArray()
+        {
+            foreach (var refType in _comFac.GetAllRefTypes())
+            {
+                CompIdx.AssignArray(ref _entSubscriptions, refType, new Dictionary<Type, DirectedRegistration>());
+            }
         }
 
         /// <inheritdoc />
@@ -105,7 +125,7 @@ namespace Robust.Shared.GameObjects
         {
             ref var unitRef = ref Unsafe.As<TEvent, Unit>(ref args);
 
-            _eventTables.DispatchComponent<TEvent>(component.Owner, component, ref unitRef, false);
+            DispatchComponent<TEvent>(component.Owner, component, ref unitRef, false);
         }
 
         /// <inheritdoc />
@@ -113,12 +133,12 @@ namespace Robust.Shared.GameObjects
         {
             ref var unitRef = ref Unsafe.As<TEvent, Unit>(ref args);
 
-            _eventTables.DispatchComponent<TEvent>(component.Owner, component, ref unitRef, true);
+            DispatchComponent<TEvent>(component.Owner, component, ref unitRef, true);
         }
 
         public void OnlyCallOnRobustUnitTestISwearToGodPleaseSomebodyKillThisNightmare()
         {
-            _eventTables.IgnoreUnregisteredComponents = true;
+            IgnoreUnregisteredComponents = true;
         }
 
         /// <inheritdoc />
@@ -159,17 +179,20 @@ namespace Robust.Shared.GameObjects
 
         private void RaiseLocalEventCore(EntityUid uid, ref Unit unitRef, Type type, bool broadcast, bool byRef)
         {
-            if (_orderedEvents.Contains(type))
+            if (!_eventSubscriptions.TryGetValue(type, out var subs))
+                return;
+
+            if (subs.IsOrdered)
             {
-                RaiseLocalOrdered(uid, type, ref unitRef, broadcast, byRef);
+                RaiseLocalOrdered(uid, type, subs, ref unitRef, broadcast, byRef);
                 return;
             }
 
-            _eventTables.Dispatch(uid, type, ref unitRef, byRef);
+            EntDispatch(uid, type, ref unitRef, byRef);
 
             // we also broadcast it so the call site does not have to.
             if (broadcast)
-                ProcessSingleEvent(EventSource.Local, ref unitRef, type, byRef);
+                ProcessSingleEventCore(EventSource.Local, ref unitRef, subs, byRef);
         }
 
         /// <inheritdoc />
@@ -180,7 +203,7 @@ namespace Robust.Shared.GameObjects
             void EventHandler(EntityUid uid, IComponent comp, ref TEvent args)
                 => handler(uid, (TComp)comp, args);
 
-            _eventTables.Subscribe<TEvent>(
+            EntSubscribe<TEvent>(
                 CompIdx.Index<TComp>(),
                 typeof(TComp),
                 typeof(TEvent),
@@ -202,14 +225,15 @@ namespace Robust.Shared.GameObjects
 
             var orderData = new OrderingData(orderType, before, after);
 
-            _eventTables.Subscribe<TEvent>(
+            EntSubscribe<TEvent>(
                 CompIdx.Index<TComp>(),
                 typeof(TComp),
                 typeof(TEvent),
                 EventHandler,
                 orderData,
                 false);
-            HandleOrderRegistration(typeof(TEvent), orderData);
+
+            RegisterCommon(typeof(TEvent), orderData, out _);
         }
 
         public void SubscribeLocalEvent<TComp, TEvent>(ComponentEventRefHandler<TComp, TEvent> handler)
@@ -218,7 +242,7 @@ namespace Robust.Shared.GameObjects
             void EventHandler(EntityUid uid, IComponent comp, ref TEvent args)
                 => handler(uid, (TComp)comp, ref args);
 
-            _eventTables.Subscribe<TEvent>(
+            EntSubscribe<TEvent>(
                 CompIdx.Index<TComp>(),
                 typeof(TComp),
                 typeof(TEvent),
@@ -236,7 +260,7 @@ namespace Robust.Shared.GameObjects
 
             var orderData = new OrderingData(orderType, before, after);
 
-            _eventTables.Subscribe<TEvent>(
+            EntSubscribe<TEvent>(
                 CompIdx.Index<TComp>(),
                 typeof(TComp),
                 typeof(TEvent),
@@ -244,7 +268,7 @@ namespace Robust.Shared.GameObjects
                 orderData,
                 true);
 
-            HandleOrderRegistration(typeof(TEvent), orderData);
+            RegisterCommon(typeof(TEvent), orderData, out _);
         }
 
         /// <inheritdoc />
@@ -252,440 +276,395 @@ namespace Robust.Shared.GameObjects
             where TComp : IComponent
             where TEvent : notnull
         {
-            _eventTables.Unsubscribe(CompIdx.Index<TComp>(), typeof(TEvent));
+            EntUnsubscribe(CompIdx.Index<TComp>(), typeof(TEvent));
         }
 
-        private sealed class EventTables : IDisposable
+        private void ETComFacOnComponentReferenceAdded(ComponentRegistration arg1, CompIdx arg2)
         {
-            private const string ValueDispatchError = "Tried to dispatch a value event to a by-reference subscription.";
-            private const string RefDispatchError = "Tried to dispatch a ref event to a by-value subscription.";
+            CompIdx.RefArray(ref _entSubscriptions, arg2) ??= new Dictionary<Type, DirectedRegistration>();
+        }
 
-            private IEntityManager _entMan;
-            private IComponentFactory _comFac;
+        private void ETComFacOnComponentAdded(ComponentRegistration obj)
+        {
+            CompIdx.RefArray(ref _entSubscriptions, obj.Idx) ??= new Dictionary<Type, DirectedRegistration>();
+        }
 
-            // eUid -> EventType -> { CompType1, ... CompTypeN }
-            private Dictionary<EntityUid, Dictionary<Type, HashSet<CompIdx>>> _eventTables;
+        private void ETOnEntityAdded(EntityUid e)
+        {
+            EntAddEntity(e);
+        }
 
-            // CompType -> EventType -> Handler
-            private Dictionary<Type, DirectedRegistration>?[] _subscriptions;
+        private void ETOnEntityDeleted(EntityUid e)
+        {
+            EntRemoveEntity(e);
+        }
 
-            // prevents shitcode, get your subscriptions figured out before you start spawning entities
-            private bool _subscriptionLock;
+        private void ETOnComponentAdded(AddedComponentEventArgs e)
+        {
+            _subscriptionLock = true;
 
-            public EventTables(IEntityManager entMan)
+            EntAddComponent(e.BaseArgs.Owner, CompIdx.Index(e.BaseArgs.Component.GetType()));
+        }
+
+        private void ETOnComponentRemoved(RemovedComponentEventArgs e)
+        {
+            EntRemoveComponent(e.BaseArgs.Owner, CompIdx.Index(e.BaseArgs.Component.GetType()));
+        }
+
+        private void EntAddSubscription(
+            CompIdx compType,
+            Type compTypeObj,
+            Type eventType,
+            DirectedRegistration registration)
+        {
+            if (_subscriptionLock)
+                throw new InvalidOperationException("Subscription locked.");
+
+            var referenceEvent = eventType.HasCustomAttribute<ByRefEventAttribute>();
+
+            if (referenceEvent != registration.ReferenceEvent)
+                throw new InvalidOperationException(
+                    $"Attempted to subscribe by-ref and by-value to the same directed event! comp={compTypeObj.Name}, event={eventType.Name} eventIsByRef={referenceEvent} subscriptionIsByRef={registration.ReferenceEvent}");
+
+            if (compType.Value >= _entSubscriptions.Length || _entSubscriptions[compType.Value] is not { } compSubs)
             {
-                _entMan = entMan;
-                _comFac = entMan.ComponentFactory;
-
-                _entMan.EntityAdded += OnEntityAdded;
-                _entMan.EntityDeleted += OnEntityDeleted;
-
-                _entMan.ComponentAdded += OnComponentAdded;
-                _entMan.ComponentRemoved += OnComponentRemoved;
-
-                // Dynamic handling of components is only for RobustUnitTest compatibility spaghetti.
-                _comFac.ComponentAdded += ComFacOnComponentAdded;
-                _comFac.ComponentReferenceAdded += ComFacOnComponentReferenceAdded;
-
-                _eventTables = new();
-                _subscriptions = Array.Empty<Dictionary<Type, DirectedRegistration>>();
-                _subscriptionLock = false;
-
-                InitSubscriptionsArray();
-            }
-
-            public bool IgnoreUnregisteredComponents;
-
-            private void InitSubscriptionsArray()
-            {
-                foreach (var refType in _comFac.GetAllRefTypes())
-                {
-                    CompIdx.AssignArray(ref _subscriptions, refType, new Dictionary<Type, DirectedRegistration>());
-                }
-            }
-
-            private void ComFacOnComponentReferenceAdded(ComponentRegistration arg1, CompIdx arg2)
-            {
-                CompIdx.RefArray(ref _subscriptions, arg2) ??= new Dictionary<Type, DirectedRegistration>();
-            }
-
-            private void ComFacOnComponentAdded(ComponentRegistration obj)
-            {
-                CompIdx.RefArray(ref _subscriptions, obj.Idx) ??= new Dictionary<Type, DirectedRegistration>();
-            }
-
-            private void OnEntityAdded(EntityUid e)
-            {
-                AddEntity(e);
-            }
-
-            private void OnEntityDeleted(EntityUid e)
-            {
-                RemoveEntity(e);
-            }
-
-            private void OnComponentAdded(AddedComponentEventArgs e)
-            {
-                _subscriptionLock = true;
-
-                AddComponent(e.BaseArgs.Owner, CompIdx.Index(e.BaseArgs.Component.GetType()));
-            }
-
-            private void OnComponentRemoved(RemovedComponentEventArgs e)
-            {
-                RemoveComponent(e.BaseArgs.Owner, CompIdx.Index(e.BaseArgs.Component.GetType()));
-            }
-
-            private void AddSubscription(CompIdx compType, Type compTypeObj, Type eventType, DirectedRegistration registration)
-            {
-                if (_subscriptionLock)
-                    throw new InvalidOperationException("Subscription locked.");
-
-                var referenceEvent = eventType.HasCustomAttribute<ByRefEventAttribute>();
-
-                if (referenceEvent != registration.ReferenceEvent)
-                    throw new InvalidOperationException(
-                        $"Attempted to subscribe by-ref and by-value to the same directed event! comp={compTypeObj.Name}, event={eventType.Name} eventIsByRef={referenceEvent} subscriptionIsByRef={registration.ReferenceEvent}");
-
-                if (compType.Value >= _subscriptions.Length || _subscriptions[compType.Value] is not { } compSubs)
-                {
-                    if (IgnoreUnregisteredComponents)
-                        return;
-
-                    throw new InvalidOperationException($"Component is not a valid reference type: {compTypeObj.Name}");
-                }
-
-                if (compSubs.ContainsKey(eventType))
-                    throw new InvalidOperationException(
-                        $"Duplicate Subscriptions for comp={compTypeObj}, event={eventType.Name}");
-
-                compSubs.Add(eventType, registration);
-            }
-
-            public void Subscribe<TEvent>(
-                CompIdx compType,
-                Type compTypeObj,
-                Type eventType,
-                DirectedEventHandler<TEvent> handler,
-                OrderingData? order, bool byReference)
-                where TEvent : notnull
-            {
-                AddSubscription(compType, compTypeObj, eventType, new DirectedRegistration(handler, order,
-                    (EntityUid uid, IComponent comp, ref Unit ev) =>
-                    {
-                        ref var tev = ref Unsafe.As<Unit, TEvent>(ref ev);
-                        handler(uid, comp, ref tev);
-                    }, byReference));
-            }
-
-            public void Unsubscribe(CompIdx compType, Type eventType)
-            {
-                if (_subscriptionLock)
-                    throw new InvalidOperationException("Subscription locked.");
-
-                if (compType.Value >= _subscriptions.Length || _subscriptions[compType.Value] is not { } compSubs)
-                {
-                    if (IgnoreUnregisteredComponents)
-                        return;
-
-                    throw new InvalidOperationException("Trying to unsubscribe from unregistered component!");
-                }
-
-                compSubs.Remove(eventType);
-            }
-
-            private void AddEntity(EntityUid euid)
-            {
-                // odds are at least 1 component will subscribe to an event on the entity, so just
-                // preallocate the table now. Dispatch does not need to check this later.
-                _eventTables.Add(euid, new Dictionary<Type, HashSet<CompIdx>>());
-            }
-
-            private void RemoveEntity(EntityUid euid)
-            {
-                _eventTables.Remove(euid);
-            }
-
-            private void AddComponent(EntityUid euid, CompIdx compType)
-            {
-                var eventTable = _eventTables[euid];
-
-                var enumerator = GetReferences(compType);
-                while (enumerator.MoveNext(out var type))
-                {
-                    var compSubs = _subscriptions[type.Value]!;
-
-                    foreach (var kvSub in compSubs)
-                    {
-                        if (!eventTable.TryGetValue(kvSub.Key, out var subscribedComps))
-                        {
-                            subscribedComps = new HashSet<CompIdx>();
-                            eventTable.Add(kvSub.Key, subscribedComps);
-                        }
-
-                        subscribedComps.Add(type);
-                    }
-                }
-            }
-
-            private void RemoveComponent(EntityUid euid, CompIdx compType)
-            {
-                var eventTable = _eventTables[euid];
-
-                var enumerator = GetReferences(compType);
-                while (enumerator.MoveNext(out var type))
-                {
-                    var compSubs = _subscriptions[type.Value]!;
-
-                    foreach (var kvSub in compSubs)
-                    {
-                        if (!eventTable.TryGetValue(kvSub.Key, out var subscribedComps))
-                            return;
-
-                        subscribedComps.Remove(type);
-                    }
-                }
-            }
-
-            public void Dispatch(EntityUid euid, Type eventType, ref Unit args, bool dispatchByReference)
-            {
-                if (!TryGetSubscriptions(eventType, euid, out var enumerator))
+                if (IgnoreUnregisteredComponents)
                     return;
 
-                while (enumerator.MoveNext(out var tuple))
-                {
-                    var (component, reg) = tuple.Value;
-                    if (reg.ReferenceEvent != dispatchByReference)
-                        ThrowByRefMisMatch();
-
-                    reg.Handler(euid, component, ref args);
-                }
+                throw new InvalidOperationException($"Component is not a valid reference type: {compTypeObj.Name}");
             }
 
-            public void CollectOrdered(
-                EntityUid euid,
-                Type eventType,
-                List<(RefEventHandler, OrderingData?)> found,
-                bool byRef)
-            {
-                var eventTable = _eventTables[euid];
+            if (compSubs.ContainsKey(eventType))
+                throw new InvalidOperationException(
+                    $"Duplicate Subscriptions for comp={compTypeObj}, event={eventType.Name}");
 
-                if (!eventTable.TryGetValue(eventType, out var subscribedComps))
+            compSubs.Add(eventType, registration);
+
+            var invSubs = _entSubscriptionsInv.GetOrNew(eventType);
+            invSubs.Add(compType);
+        }
+
+        private void EntSubscribe<TEvent>(
+            CompIdx compType,
+            Type compTypeObj,
+            Type eventType,
+            DirectedEventHandler<TEvent> handler,
+            OrderingData? order, bool byReference)
+            where TEvent : notnull
+        {
+            EntAddSubscription(compType, compTypeObj, eventType, new DirectedRegistration(handler, order,
+                (EntityUid uid, IComponent comp, ref Unit ev) =>
+                {
+                    ref var tev = ref Unsafe.As<Unit, TEvent>(ref ev);
+                    handler(uid, comp, ref tev);
+                }, byReference));
+        }
+
+        private void EntUnsubscribe(CompIdx compType, Type eventType)
+        {
+            if (_subscriptionLock)
+                throw new InvalidOperationException("Subscription locked.");
+
+            if (compType.Value >= _entSubscriptions.Length || _entSubscriptions[compType.Value] is not { } compSubs)
+            {
+                if (IgnoreUnregisteredComponents)
                     return;
 
-                foreach (var compType in subscribedComps)
-                {
-                    var compSubs = _subscriptions[compType.Value]!;
-
-                    if (!compSubs.TryGetValue(eventType, out var reg))
-                        return;
-
-                    if (reg.ReferenceEvent != byRef)
-                        ThrowByRefMisMatch();
-
-                    var component = _entMan.GetComponent(euid, compType);
-
-                    found.Add(((ref Unit ev) => reg.Handler(euid, component, ref ev), reg.Ordering));
-                }
+                throw new InvalidOperationException("Trying to unsubscribe from unregistered component!");
             }
 
-            public void DispatchComponent<TEvent>(EntityUid euid, IComponent component, ref Unit args, bool dispatchByReference)
-                where TEvent : notnull
+            var removed = compSubs.Remove(eventType);
+            if (removed)
+                _entSubscriptionsInv[eventType].Remove(compType);
+        }
+
+        private void EntAddEntity(EntityUid euid)
+        {
+            // odds are at least 1 component will subscribe to an event on the entity, so just
+            // preallocate the table now. Dispatch does not need to check this later.
+            _entEventTables.Add(euid, new Dictionary<Type, HashSet<CompIdx>>());
+        }
+
+        private void EntRemoveEntity(EntityUid euid)
+        {
+            _entEventTables.Remove(euid);
+        }
+
+        private void EntAddComponent(EntityUid euid, CompIdx compType)
+        {
+            var eventTable = _entEventTables[euid];
+
+            var enumerator = EntGetReferences(compType);
+            while (enumerator.MoveNext(out var type))
             {
-                var enumerator = GetReferences(CompIdx.Index(component.GetType()));
-                while (enumerator.MoveNext(out var type))
+                var compSubs = _entSubscriptions[type.Value]!;
+
+                foreach (var kvSub in compSubs)
                 {
-                    var compSubs = _subscriptions[type.Value]!;
-
-                    if (!compSubs.TryGetValue(typeof(TEvent), out var reg))
-                        continue;
-
-                    if (reg.ReferenceEvent != dispatchByReference)
-                        ThrowByRefMisMatch();
-
-                    reg.Handler(euid, component, ref args);
-                }
-            }
-
-            public void ClearEntities()
-            {
-                _eventTables = new();
-                _subscriptionLock = false;
-            }
-
-            public void Clear()
-            {
-                ClearEntities();
-
-                foreach (var sub in _subscriptions)
-                {
-                    sub?.Clear();
-                }
-            }
-
-            public void Dispose()
-            {
-                _entMan.EntityAdded -= OnEntityAdded;
-                _entMan.EntityDeleted -= OnEntityDeleted;
-
-                _entMan.ComponentAdded -= OnComponentAdded;
-                _entMan.ComponentRemoved -= OnComponentRemoved;
-
-                _comFac.ComponentAdded -= ComFacOnComponentAdded;
-                _comFac.ComponentReferenceAdded -= ComFacOnComponentReferenceAdded;
-
-                // punishment for use-after-free
-                _entMan = null!;
-                _eventTables = null!;
-                _subscriptions = null!;
-            }
-
-            /// <summary>
-            ///     Enumerates the type's component references, returning the type itself last.
-            /// </summary>
-            private ReferencesEnumerator GetReferences(CompIdx type)
-            {
-                return new(type, _comFac.GetRegistration(type).References);
-            }
-
-            /// <summary>
-            ///     Enumerates all subscriptions for an event on a specific entity, returning the component instances and registrations.
-            /// </summary>
-            private bool TryGetSubscriptions(Type eventType, EntityUid euid, [NotNullWhen(true)] out SubscriptionsEnumerator enumerator)
-            {
-                if (!_eventTables.TryGetValue(euid, out var eventTable))
-                {
-                    enumerator = default!;
-                    return false;
-                }
-
-                // No subscriptions to this event type, return null.
-                if (!eventTable.TryGetValue(eventType, out var subscribedComps))
-                {
-                    enumerator = default;
-                    return false;
-                }
-
-                enumerator = new(eventType, subscribedComps.GetEnumerator(), _subscriptions, euid, _entMan);
-                return true;
-            }
-
-            private struct ReferencesEnumerator
-            {
-                private readonly CompIdx _baseType;
-                private readonly ValueList<CompIdx> _list;
-                private readonly int _totalLength;
-                private int _idx;
-
-                public ReferencesEnumerator(CompIdx baseType, ValueList<CompIdx> list)
-                {
-                    _baseType = baseType;
-                    _list = list;
-                    _totalLength = list.Count;
-                    _idx = 0;
-                }
-
-                public bool MoveNext([NotNullWhen(true)] out CompIdx type)
-                {
-                    if (_idx >= _totalLength)
+                    if (!eventTable.TryGetValue(kvSub.Key, out var subscribedComps))
                     {
-                        if (_idx++ == _totalLength)
-                        {
-                            type = _baseType;
-                            return true;
-                        }
-
-                        type = default;
-                        return false;
+                        subscribedComps = new HashSet<CompIdx>();
+                        eventTable.Add(kvSub.Key, subscribedComps);
                     }
 
-                    type = _list[_idx++];
-                    if (type == _baseType)
-                        return MoveNext(out type);
-
-                    return true;
-                }
-            }
-
-            private struct SubscriptionsEnumerator : IDisposable
-            {
-                private readonly Type _eventType;
-                private HashSet<CompIdx>.Enumerator _enumerator;
-                private readonly Dictionary<Type, DirectedRegistration>?[] _subscriptions;
-                private readonly EntityUid _uid;
-                private readonly IEntityManager _entityManager;
-
-                public SubscriptionsEnumerator(
-                    Type eventType,
-                    HashSet<CompIdx>.Enumerator enumerator,
-                    Dictionary<Type, DirectedRegistration>?[] subscriptions,
-                    EntityUid uid,
-                    IEntityManager entityManager)
-                {
-                    _eventType = eventType;
-                    _enumerator = enumerator;
-                    _subscriptions = subscriptions;
-                    _entityManager = entityManager;
-                    _uid = uid;
-                }
-
-                public bool MoveNext(
-                    [NotNullWhen(true)] out (IComponent Component, DirectedRegistration Registration)? tuple)
-                {
-                    // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-                    if (!_enumerator.MoveNext())
-                    {
-                        tuple = null;
-                        return false;
-                    }
-
-                    var compType = _enumerator.Current;
-                    var compSubs = _subscriptions[compType.Value]!;
-
-                    if (!compSubs.TryGetValue(_eventType, out var registration))
-                    {
-                        tuple = null;
-                        return false;
-                    }
-
-                    tuple = (_entityManager.GetComponent(_uid, compType), registration);
-                    return true;
-                }
-
-                public void Dispose()
-                {
-                    _enumerator.Dispose();
+                    subscribedComps.Add(type);
                 }
             }
         }
 
-        /// <inheritdoc />
+        private void EntRemoveComponent(EntityUid euid, CompIdx compType)
+        {
+            var eventTable = _entEventTables[euid];
+
+            var enumerator = EntGetReferences(compType);
+            while (enumerator.MoveNext(out var type))
+            {
+                var compSubs = _entSubscriptions[type.Value]!;
+
+                foreach (var kvSub in compSubs)
+                {
+                    if (!eventTable.TryGetValue(kvSub.Key, out var subscribedComps))
+                        return;
+
+                    subscribedComps.Remove(type);
+                }
+            }
+        }
+
+        private void EntDispatch(EntityUid euid, Type eventType, ref Unit args, bool dispatchByReference)
+        {
+            if (!EntTryGetSubscriptions(eventType, euid, out var enumerator))
+                return;
+
+            while (enumerator.MoveNext(out var tuple))
+            {
+                var (component, reg) = tuple.Value;
+                if (reg.ReferenceEvent != dispatchByReference)
+                    ThrowByRefMisMatch();
+
+                reg.Handler(euid, component, ref args);
+            }
+        }
+
+        private void EntCollectOrdered(
+            EntityUid euid,
+            Type eventType,
+            ref ValueList<OrderedEventDispatch> found,
+            bool byRef)
+        {
+            var eventTable = _entEventTables[euid];
+
+            if (!eventTable.TryGetValue(eventType, out var subscribedComps))
+                return;
+
+            foreach (var compType in subscribedComps)
+            {
+                var compSubs = _entSubscriptions[compType.Value]!;
+
+                if (!compSubs.TryGetValue(eventType, out var reg))
+                    return;
+
+                if (reg.ReferenceEvent != byRef)
+                    ThrowByRefMisMatch();
+
+                var component = _entMan.GetComponent(euid, compType);
+
+                found.Add(new OrderedEventDispatch((ref Unit ev) => reg.Handler(euid, component, ref ev), reg.Order));
+            }
+        }
+
+        private void DispatchComponent<TEvent>(EntityUid euid, IComponent component, ref Unit args,
+            bool dispatchByReference)
+            where TEvent : notnull
+        {
+            var enumerator = EntGetReferences(CompIdx.Index(component.GetType()));
+            while (enumerator.MoveNext(out var type))
+            {
+                var compSubs = _entSubscriptions[type.Value]!;
+
+                if (!compSubs.TryGetValue(typeof(TEvent), out var reg))
+                    continue;
+
+                if (reg.ReferenceEvent != dispatchByReference)
+                    ThrowByRefMisMatch();
+
+                reg.Handler(euid, component, ref args);
+            }
+        }
+
+        /// <summary>
+        ///     Enumerates the type's component references, returning the type itself last.
+        /// </summary>
+        private ReferencesEnumerator EntGetReferences(CompIdx type)
+        {
+            return new(type, _comFac.GetRegistration(type).References);
+        }
+
+        /// <summary>
+        ///     Enumerates all subscriptions for an event on a specific entity, returning the component instances and registrations.
+        /// </summary>
+        private bool EntTryGetSubscriptions(Type eventType, EntityUid euid, out SubscriptionsEnumerator enumerator)
+        {
+            if (!_entEventTables.TryGetValue(euid, out var eventTable))
+            {
+                enumerator = default!;
+                return false;
+            }
+
+            // No subscriptions to this event type, return null.
+            if (!eventTable.TryGetValue(eventType, out var subscribedComps))
+            {
+                enumerator = default;
+                return false;
+            }
+
+            enumerator = new(eventType, subscribedComps.GetEnumerator(), _entSubscriptions, euid, _entMan);
+            return true;
+        }
+
+        private void EntClear()
+        {
+            _entEventTables = new();
+            _subscriptionLock = false;
+        }
+
         public void ClearEventTables()
         {
-            _eventTables.Clear();
+            EntClear();
+
+            foreach (var sub in _entSubscriptions)
+            {
+                sub?.Clear();
+            }
         }
 
         public void Dispose()
         {
-            _eventTables.Dispose();
-            _eventTables = null!;
+            _entMan.EntityAdded -= ETOnEntityAdded;
+            _entMan.EntityDeleted -= ETOnEntityDeleted;
+
+            _entMan.ComponentAdded -= ETOnComponentAdded;
+            _entMan.ComponentRemoved -= ETOnComponentRemoved;
+
+            _comFac.ComponentAdded -= ETComFacOnComponentAdded;
+            _comFac.ComponentReferenceAdded -= ETComFacOnComponentReferenceAdded;
+
+            // punishment for use-after-free
             _entMan = null!;
+            _comFac = null!;
+            _entEventTables = null!;
+            _entSubscriptions = null!;
+            _entSubscriptionsInv = null!;
         }
 
-        private readonly struct DirectedRegistration
+        private struct ReferencesEnumerator
+        {
+            private readonly CompIdx _baseType;
+            private readonly ValueList<CompIdx> _list;
+            private readonly int _totalLength;
+            private int _idx;
+
+            public ReferencesEnumerator(CompIdx baseType, ValueList<CompIdx> list)
+            {
+                _baseType = baseType;
+                _list = list;
+                _totalLength = list.Count;
+                _idx = 0;
+            }
+
+            public bool MoveNext(out CompIdx type)
+            {
+                if (_idx >= _totalLength)
+                {
+                    if (_idx++ == _totalLength)
+                    {
+                        type = _baseType;
+                        return true;
+                    }
+
+                    type = default;
+                    return false;
+                }
+
+                type = _list[_idx++];
+                if (type == _baseType)
+                    return MoveNext(out type);
+
+                return true;
+            }
+        }
+
+        private struct SubscriptionsEnumerator : IDisposable
+        {
+            private readonly Type _eventType;
+            private HashSet<CompIdx>.Enumerator _enumerator;
+            private readonly Dictionary<Type, DirectedRegistration>?[] _subscriptions;
+            private readonly EntityUid _uid;
+            private readonly IEntityManager _entityManager;
+
+            public SubscriptionsEnumerator(
+                Type eventType,
+                HashSet<CompIdx>.Enumerator enumerator,
+                Dictionary<Type, DirectedRegistration>?[] subscriptions,
+                EntityUid uid,
+                IEntityManager entityManager)
+            {
+                _eventType = eventType;
+                _enumerator = enumerator;
+                _subscriptions = subscriptions;
+                _entityManager = entityManager;
+                _uid = uid;
+            }
+
+            public bool MoveNext(
+                [NotNullWhen(true)] out (IComponent Component, DirectedRegistration Registration)? tuple)
+            {
+                // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+                if (!_enumerator.MoveNext())
+                {
+                    tuple = null;
+                    return false;
+                }
+
+                var compType = _enumerator.Current;
+                var compSubs = _subscriptions[compType.Value]!;
+
+                if (!compSubs.TryGetValue(_eventType, out var registration))
+                {
+                    tuple = null;
+                    return false;
+                }
+
+                tuple = (_entityManager.GetComponent(_uid, compType), registration);
+                return true;
+            }
+
+            public void Dispose()
+            {
+                _enumerator.Dispose();
+            }
+        }
+
+        private sealed class DirectedRegistration : OrderedRegistration
         {
             public readonly Delegate Original;
-            public readonly OrderingData? Ordering;
             public readonly DirectedEventHandler Handler;
             public readonly bool ReferenceEvent;
 
-            public DirectedRegistration(Delegate original, OrderingData? ordering, DirectedEventHandler handler,
-                bool referenceEvent)
+            public DirectedRegistration(
+                Delegate original,
+                OrderingData? ordering,
+                DirectedEventHandler handler,
+                bool referenceEvent) : base(ordering)
             {
                 Original = original;
-                Ordering = ordering;
                 Handler = handler;
                 ReferenceEvent = referenceEvent;
+            }
+
+            public void SetOrder(int order)
+            {
+                Order = order;
             }
         }
     }

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -99,12 +99,6 @@ namespace Robust.Shared.GameObjects
             _entMan = entMan;
             _comFac = entMan.ComponentFactory;
 
-            _entMan.EntityAdded += ETOnEntityAdded;
-            _entMan.EntityDeleted += ETOnEntityDeleted;
-
-            _entMan.ComponentAdded += ETOnComponentAdded;
-            _entMan.ComponentRemoved += ETOnComponentRemoved;
-
             // Dynamic handling of components is only for RobustUnitTest compatibility spaghetti.
             _comFac.ComponentAdded += ETComFacOnComponentAdded;
             _comFac.ComponentReferenceAdded += ETComFacOnComponentReferenceAdded;
@@ -289,24 +283,24 @@ namespace Robust.Shared.GameObjects
             CompIdx.RefArray(ref _entSubscriptions, obj.Idx) ??= new Dictionary<Type, DirectedRegistration>();
         }
 
-        private void ETOnEntityAdded(EntityUid e)
+        public void OnEntityAdded(EntityUid e)
         {
             EntAddEntity(e);
         }
 
-        private void ETOnEntityDeleted(EntityUid e)
+        public void OnEntityDeleted(EntityUid e)
         {
             EntRemoveEntity(e);
         }
 
-        private void ETOnComponentAdded(AddedComponentEventArgs e)
+        public void OnComponentAdded(AddedComponentEventArgs e)
         {
             _subscriptionLock = true;
 
             EntAddComponent(e.BaseArgs.Owner, CompIdx.Index(e.BaseArgs.Component.GetType()));
         }
 
-        private void ETOnComponentRemoved(RemovedComponentEventArgs e)
+        public void OnComponentRemoved(RemovedComponentEventArgs e)
         {
             EntRemoveComponent(e.BaseArgs.Owner, CompIdx.Index(e.BaseArgs.Component.GetType()));
         }
@@ -342,6 +336,8 @@ namespace Robust.Shared.GameObjects
 
             var invSubs = _entSubscriptionsInv.GetOrNew(eventType);
             invSubs.Add(compType);
+
+            RegisterCommon(eventType, registration.Ordering, out _);
         }
 
         private void EntSubscribe<TEvent>(
@@ -540,12 +536,6 @@ namespace Robust.Shared.GameObjects
 
         public void Dispose()
         {
-            _entMan.EntityAdded -= ETOnEntityAdded;
-            _entMan.EntityDeleted -= ETOnEntityDeleted;
-
-            _entMan.ComponentAdded -= ETOnComponentAdded;
-            _entMan.ComponentRemoved -= ETOnComponentRemoved;
-
             _comFac.ComponentAdded -= ETComFacOnComponentAdded;
             _comFac.ComponentReferenceAdded -= ETComFacOnComponentReferenceAdded;
 

--- a/Robust.Shared/GameObjects/EntityEventBus.Ordering.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Ordering.cs
@@ -119,5 +119,26 @@ namespace Robust.Shared.GameObjects
                 Ordering = ordering;
             }
         }
+
+        /// <summary>
+        /// Ensure all ordered events are sorted out and verified.
+        /// </summary>
+        /// <remarks>
+        /// Internal sorting for ordered events is normally deferred until raised
+        /// (since broadcast event subscriptions can be edited at any time).
+        ///
+        /// Calling this gets all the sorting done ahead of time,
+        /// and makes sure that there are no problems with cycles and such.
+        /// </remarks>
+        public void CalcOrdering()
+        {
+            foreach (var (type, sub) in _eventSubscriptions)
+            {
+                if (sub.IsOrdered && !sub.OrderingUpToDate)
+                {
+                    UpdateOrderSeq(type, sub);
+                }
+            }
+        }
     }
 }

--- a/Robust.Shared/GameObjects/EntityEventBus.Ordering.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Ordering.cs
@@ -49,7 +49,7 @@ namespace Robust.Shared.GameObjects
         {
             found.Sort(OrderedEventDispatchComparer.Instance);
 
-            foreach (var (handler, orderData) in found)
+            foreach (var (handler, _) in found)
             {
                 handler(ref eventArgs);
             }

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -293,7 +293,9 @@ namespace Robust.Shared.GameObjects
                 Dirty(component);
             }
 
-            ComponentAdded?.Invoke(new AddedComponentEventArgs(new ComponentEventArgs(component, uid)));
+            var eventArgs = new AddedComponentEventArgs(new ComponentEventArgs(component, uid));
+            ComponentAdded?.Invoke(eventArgs);
+            _eventBus.OnComponentAdded(eventArgs);
 
             component.LifeAddToEntity(this);
 
@@ -425,7 +427,11 @@ namespace Robust.Shared.GameObjects
 
             if (component.LifeStage != ComponentLifeStage.PreAdd)
                 component.LifeRemoveFromEntity(this);
-            ComponentRemoved?.Invoke(new RemovedComponentEventArgs(new ComponentEventArgs(component, uid)));
+
+            var eventArgs = new RemovedComponentEventArgs(new ComponentEventArgs(component, uid));
+            ComponentRemoved?.Invoke(eventArgs);
+            _eventBus.OnComponentRemoved(eventArgs);
+
 #if EXCEPTION_TOLERANCE
             }
             catch (Exception e)
@@ -459,7 +465,10 @@ namespace Robust.Shared.GameObjects
                 if (component.LifeStage != ComponentLifeStage.PreAdd)
                     component.LifeRemoveFromEntity(this); // Sets delete
 
-                ComponentRemoved?.Invoke(new RemovedComponentEventArgs(new ComponentEventArgs(component, uid)));
+                var eventArgs = new RemovedComponentEventArgs(new ComponentEventArgs(component, uid));
+                ComponentRemoved?.Invoke(eventArgs);
+                _eventBus.OnComponentRemoved(eventArgs);
+
             }
 #if EXCEPTION_TOLERANCE
             }

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -324,6 +324,7 @@ namespace Robust.Shared.GameObjects
 
             metadata.EntityLifeStage = EntityLifeStage.Deleted;
             EntityDeleted?.Invoke(uid);
+            _eventBus.OnEntityDeleted(uid);
             EventBus.RaiseEvent(EventSource.Local, new EntityDeletedMessage(uid));
             Entities.Remove(uid);
         }
@@ -407,6 +408,7 @@ namespace Robust.Shared.GameObjects
 
             // we want this called before adding components
             EntityAdded?.Invoke(uid);
+            _eventBus.OnEntityAdded(uid);
 
             metadata = new MetaDataComponent { Owner = uid };
 

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -94,6 +94,7 @@ namespace Robust.Shared.GameObjects
             // TODO: Probably better to call this on its own given it's so infrequent.
             _entitySystemManager.Initialize();
             Started = true;
+            _eventBus.CalcOrdering();
         }
 
         public virtual void Shutdown()

--- a/Robust.Shared/GameObjects/EntitySystem.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.cs
@@ -98,12 +98,6 @@ namespace Robust.Shared.GameObjects
             }
         }
 
-        protected Task<T> AwaitNetworkEvent<T>(CancellationToken cancellationToken)
-            where T : EntityEventArgs
-        {
-            return EntityManager.EventBus.AwaitEvent<T>(EventSource.Network, cancellationToken);
-        }
-
         protected void RaiseLocalEvent<TEvent>(EntityUid uid, TEvent args, bool broadcast = true)
             where TEvent : notnull
         {

--- a/Robust.Shared/Physics/Dynamics/ContactManager.cs
+++ b/Robust.Shared/Physics/Dynamics/ContactManager.cs
@@ -261,11 +261,13 @@ namespace Robust.Shared.Physics.Dynamics
 
             // Connect to body A
             DebugTools.Assert(!fixtureA.Contacts.ContainsKey(fixtureB));
+            DebugTools.Assert(bodyA.PhysicsMap != null);
             fixtureA.Contacts.Add(fixtureB, contact);
             contact.BodyANode = bodyA.Contacts.AddLast(contact);
 
             // Connect to body B
             DebugTools.Assert(!fixtureB.Contacts.ContainsKey(fixtureA));
+            DebugTools.Assert(bodyB.PhysicsMap != null);
             fixtureB.Contacts.Add(fixtureA, contact);
             contact.BodyBNode = bodyB.Contacts.AddLast(contact);
         }

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -330,6 +330,8 @@ namespace Robust.Shared.Physics
             EntityQuery<TransformComponent> xformQuery,
             EntityQuery<BroadphaseComponent> broadphaseQuery)
         {
+            DebugTools.Assert(proxy.Fixture.Body.CanCollide);
+
             var proxyBody = proxy.Fixture.Body;
 
             // Broadphase can't intersect with entities on itself so skip.
@@ -354,6 +356,7 @@ namespace Robust.Shared.Physics
 
             foreach (var other in broadphaseComp.Tree.QueryAabb(_queryBuffer, aabb))
             {
+                DebugTools.Assert(other.Fixture.Body.CanCollide);
                 // Logger.DebugS("physics", $"Checking {proxy.Fixture.Body.Owner} against {other.Fixture.Body.Owner} at {aabb}");
 
                 // Do fast checks first and slower checks after (in ContactManager).
@@ -634,6 +637,8 @@ namespace Robust.Shared.Physics
             if(mapId == MapId.Nullspace)
                 return;
 
+            DebugTools.Assert(proxy.Fixture.Body.CanCollide);
+
             _moveBuffer[mapId][proxy] = aabb;
         }
 
@@ -716,6 +721,7 @@ namespace Robust.Shared.Physics
             {
                 var bounds = fixture.Shape.ComputeAABB(transform, i);
                 var proxy = new FixtureProxy(bounds, fixture, i);
+                DebugTools.Assert(fixture.Body.CanCollide);
                 proxy.ProxyId = broadphase.Tree.AddProxy(ref proxy);
                 fixture.Proxies[i] = proxy;
 

--- a/Robust.Shared/Utility/CollectionExtensions.cs
+++ b/Robust.Shared/Utility/CollectionExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.InteropServices;
 using JetBrains.Annotations;
 
 namespace Robust.Shared.Utility
@@ -183,6 +184,17 @@ namespace Robust.Shared.Utility
             }
 
             return value;
+        }
+
+        public static TValue GetOrNew<TKey, TValue>(this Dictionary<TKey, TValue> dict, TKey key)
+            where TValue : new()
+            where TKey : notnull
+        {
+            ref var entry = ref CollectionsMarshal.GetValueRefOrAddDefault(dict, key, out var exists);
+            if (!exists)
+                entry = new TValue();
+
+            return entry!;
         }
 
         // More efficient than LINQ.

--- a/Robust.Shared/Utility/HashCodeHelpers.cs
+++ b/Robust.Shared/Utility/HashCodeHelpers.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace Robust.Shared.Utility;
+
+/// <summary>
+/// Utility functions for working with <see cref="HashCode"/>.
+/// </summary>
+public static class HashCodeHelpers
+{
+    /// <summary>
+    /// Add the contents of an array to a <see cref="HashCode"/>.
+    /// </summary>
+    public static void AddArray<T>(ref this HashCode hc, T[]? array)
+    {
+        if (array == null)
+        {
+            hc.Add(0);
+            return;
+        }
+
+        hc.Add(array.Length);
+
+        foreach (var item in array)
+        {
+            hc.Add(item);
+        }
+    }
+}

--- a/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.ComponentEvent.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.ComponentEvent.cs
@@ -1,13 +1,10 @@
-using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using Moq;
 using NUnit.Framework;
 using Robust.Shared.GameObjects;
-using Robust.Shared.Map;
-using Robust.Shared.Prototypes;
-using Robust.UnitTesting.Server;
+using Robust.Shared.IoC;
+using Robust.Shared.Reflection;
+using Robust.UnitTesting.Shared.Reflection;
 
 namespace Robust.UnitTesting.Shared.GameObjects
 {
@@ -16,22 +13,16 @@ namespace Robust.UnitTesting.Shared.GameObjects
         [Test]
         public void SubscribeCompEvent()
         {
+            var compFactory = new ComponentFactory(new DynamicTypeFactory(), new ReflectionManagerTest());
+
             // Arrange
             var entUid = new EntityUid(7);
             var compInstance = new MetaDataComponent();
 
-            var compRegistration = new ComponentRegistration(
-                "MetaData",
-                typeof(MetaDataComponent),
-                CompIdx.Index<MetaDataComponent>());
-
             var entManMock = new Mock<IEntityManager>();
 
-            var compFacMock = new Mock<IComponentFactory>();
-
-            compFacMock.Setup(m => m.GetRegistration(CompIdx.Index<MetaDataComponent>())).Returns(compRegistration);
-            compFacMock.Setup(m => m.GetAllRefTypes()).Returns(new[] { CompIdx.Index<MetaDataComponent>() });
-            entManMock.Setup(m => m.ComponentFactory).Returns(compFacMock.Object);
+            compFactory.RegisterClass<MetaDataComponent>();
+            entManMock.Setup(m => m.ComponentFactory).Returns(compFactory);
 
             IComponent? outIComponent = compInstance;
             entManMock.Setup(m => m.TryGetComponent(entUid, typeof(MetaDataComponent), out outIComponent))
@@ -51,8 +42,8 @@ namespace Robust.UnitTesting.Shared.GameObjects
             bus.SubscribeLocalEvent<MetaDataComponent, TestEvent>(HandleTestEvent);
 
             // add a component to the system
-            entManMock.Raise(m => m.EntityAdded += null,  entUid);
-            entManMock.Raise(m => m.ComponentAdded += null, new AddedComponentEventArgs(new ComponentEventArgs(compInstance, entUid)));
+            bus.OnEntityAdded(entUid);
+            bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(compInstance, entUid)));
 
             // Raise
             var evntArgs = new TestEvent(5);
@@ -106,8 +97,8 @@ namespace Robust.UnitTesting.Shared.GameObjects
             bus.UnsubscribeLocalEvent<MetaDataComponent, TestEvent>();
 
             // add a component to the system
-            entManMock.Raise(m => m.EntityAdded += null, entUid);
-            entManMock.Raise(m => m.ComponentAdded += null, new AddedComponentEventArgs(new ComponentEventArgs(compInstance, entUid)));
+            bus.OnEntityAdded(entUid);
+            bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(compInstance, entUid)));
 
             // Raise
             var evntArgs = new TestEvent(5);
@@ -235,10 +226,10 @@ namespace Robust.UnitTesting.Shared.GameObjects
             bus.SubscribeLocalEvent<OrderCComponent, TestEvent>(HandlerC, typeof(OrderCComponent));
 
             // add a component to the system
-            entManMock.Raise(m => m.EntityAdded += null, entUid);
-            entManMock.Raise(m => m.ComponentAdded += null, new AddedComponentEventArgs(new ComponentEventArgs(instA, entUid)));
-            entManMock.Raise(m => m.ComponentAdded += null, new AddedComponentEventArgs(new ComponentEventArgs(instB, entUid)));
-            entManMock.Raise(m => m.ComponentAdded += null, new AddedComponentEventArgs(new ComponentEventArgs(instC, entUid)));
+            bus.OnEntityAdded(entUid);
+            bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(instA, entUid)));
+            bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(instB, entUid)));
+            bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(instC, entUid)));
 
             // Raise
             var evntArgs = new TestEvent(5);

--- a/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.OrderedEvents.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.OrderedEvents.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.UnitTesting.Server;
+
+namespace Robust.UnitTesting.Shared.GameObjects;
+
+public sealed partial class EntityEventBusTests
+{
+    // Explanation of what bug this is testing:
+    // Because event ordering is keyed on system type, we have a problem.
+    // If you register to a directed event like FooEvent twice for different components,
+    // you now have different subscriptions with the same key.
+    //
+    // To trigger this, at least one subscription to this event (possibly another system entirely)
+    // needs to demand some ordering calculation to happen.
+
+    [Test]
+    public void TestDifferentComponentsOrderedSameKeySub()
+    {
+        var simulation = RobustServerSimulation
+            .NewSimulation()
+            .RegisterEntitySystems(factory =>
+            {
+                factory.LoadExtraSystemType<DifferentComponentsSameKeySubSystem>();
+                factory.LoadExtraSystemType<DifferentComponentsSameKeySubSystem2>();
+            })
+            .RegisterComponents(factory => factory.RegisterClass<FooComponent>())
+            .InitializeInstance();
+
+        var map = new MapId(1);
+        simulation.AddMap(map);
+
+        var entity = simulation.SpawnEntity(null, new MapCoordinates(0, 0, map));
+        simulation.Resolve<IEntityManager>().AddComponent<FooComponent>(entity);
+
+        var foo = new FooEvent();
+        simulation.Resolve<IEntityManager>().EventBus.RaiseLocalEvent(entity, foo);
+
+        Assert.That(foo.EventOrder, Is.EquivalentTo(new[]{"Foo", "Transform", "Metadata"}).Or.EquivalentTo(new[]{"Foo", "Metadata", "Transform"}));
+    }
+
+    private sealed class DifferentComponentsSameKeySubSystem : EntitySystem
+    {
+        public override void Initialize()
+        {
+            SubscribeLocalEvent<TransformComponent, FooEvent>((_, _, e) => { e.EventOrder.Add("Transform"); });
+            SubscribeLocalEvent<MetaDataComponent, FooEvent>((_, _, e) => { e.EventOrder.Add("Metadata"); });
+        }
+    }
+
+    private sealed class DifferentComponentsSameKeySubSystem2 : EntitySystem
+    {
+        public override void Initialize()
+        {
+            SubscribeLocalEvent<FooComponent, FooEvent>(
+                (_, _, e) => e.EventOrder.Add("Foo"),
+                before: new[] {typeof(DifferentComponentsSameKeySubSystem)});
+        }
+    }
+
+
+    private sealed class FooComponent : Component
+    {
+
+    }
+
+    private sealed class FooEvent
+    {
+        public List<string> EventOrder = new();
+    }
+}

--- a/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.SystemEvent.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.SystemEvent.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
 using Robust.Shared.GameObjects;
@@ -411,49 +410,6 @@ namespace Robust.UnitTesting.Shared.GameObjects
 
             // Assert
             Assert.That(delCallCount, Is.EqualTo(1));
-        }
-
-        [Test]
-        public async Task AwaitEvent()
-        {
-            // Arrange
-            var bus = BusFactory();
-            var args = new TestEventArgs();
-
-            // Act
-            var task = bus.AwaitEvent<TestEventArgs>(EventSource.Local);
-            bus.RaiseEvent(EventSource.Local, args);
-            var result = await task;
-
-            // Assert
-            Assert.That(result, Is.EqualTo(args));
-        }
-
-        [Test]
-        public void AwaitEvent_SourceNone_ArgOutOfRange()
-        {
-            // Arrange
-            var bus = BusFactory();
-
-            // Act
-            void Code() => bus.AwaitEvent<TestEventArgs>(EventSource.None);
-
-            // Assert
-            Assert.Throws<ArgumentOutOfRangeException>(Code);
-        }
-
-        [Test]
-        public void AwaitEvent_DoubleTask_InvalidException()
-        {
-            // Arrange
-            var bus = BusFactory();
-            bus.AwaitEvent<TestEventArgs>(EventSource.Local);
-
-            // Act
-            void Code() => bus.AwaitEvent<TestEventArgs>(EventSource.Local);
-
-            // Assert
-            Assert.Throws<InvalidOperationException>(Code);
         }
 
         [Test]


### PR DESCRIPTION
Broadcast events now have no perf overhead from being ordered, directed events still have significant overhead but not that bad anymore.

Removed event awaiting from EventBus since nothing used it, it has practical problems in actual use, and it added a significant amount of complexity to the internals. If we want something like this, it should be implemented outside.