### PR TITLE
Cache TransformComponent in trees

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteBoundsOverlay.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteBoundsOverlay.cs
@@ -82,9 +82,9 @@ namespace Robust.Client.GameObjects
             {
                 var localAABB = _entityManager.GetComponent<TransformComponent>(comp.Owner).InvWorldMatrix.TransformBox(viewport);
 
-                foreach (var sprite in comp.SpriteTree.QueryAabb(localAABB))
+                foreach (var (sprite, xform) in comp.SpriteTree.QueryAabb(localAABB))
                 {
-                    var (worldPos, worldRot) = _entityManager.GetComponent<TransformComponent>(sprite.Owner).GetWorldPositionRotation();
+                    var (worldPos, worldRot) = xform.GetWorldPositionRotation();
                     var bounds = sprite.CalculateRotatedBoundingBox(worldPos, worldRot);
 
                     // Get scaled down bounds used to indicate the "south" of a sprite.

--- a/Robust.Client/GameObjects/Components/RenderingTreeComponent.cs
+++ b/Robust.Client/GameObjects/Components/RenderingTreeComponent.cs
@@ -6,7 +6,7 @@ namespace Robust.Client.GameObjects
     [RegisterComponent]
     public sealed class RenderingTreeComponent : Component
     {
-        internal DynamicTree<SpriteComponent> SpriteTree { get; set; } = default!;
-        internal DynamicTree<PointLightComponent> LightTree { get; set; } = default!;
+        internal DynamicTree<ComponentTreeEntry<SpriteComponent>> SpriteTree { get; set; } = default!;
+        internal DynamicTree<ComponentTreeEntry<PointLightComponent>> LightTree { get; set; } = default!;
     }
 }

--- a/Robust.Client/GameObjects/EntitySystems/DebugLightTreeSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/DebugLightTreeSystem.cs
@@ -70,9 +70,9 @@ namespace Robust.Client.GameObjects
 
                 foreach (var tree in _tree.GetRenderTrees(map, viewport))
                 {
-                    foreach (var light in tree.LightTree)
+                    foreach (var (light, xform) in tree.LightTree)
                     {
-                        var aabb = _lookup.GetWorldAABB(light.Owner);
+                        var aabb = _lookup.GetWorldAABB(light.Owner, xform);
                         if (!aabb.Intersects(worldBounds)) continue;
 
                         args.WorldHandle.DrawRect(aabb, Color.Green.WithAlpha(0.1f));

--- a/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Robust.Client.Physics;
@@ -18,6 +19,8 @@ namespace Robust.Client.GameObjects
     [UsedImplicitly]
     public sealed class RenderingTreeSystem : EntitySystem
     {
+        [Dependency] private readonly TransformSystem _xformSystem = default!;
+
         internal const string LoggerSawmill = "rendertree";
 
         // Nullspace is not indexed. Keep that in mind.
@@ -94,8 +97,8 @@ namespace Robust.Client.GameObjects
 
         private void OnTreeInit(EntityUid uid, RenderingTreeComponent component, ComponentInit args)
         {
-            component.LightTree = new DynamicTree<PointLightComponent>(LightAabbFunc);
-            component.SpriteTree = new DynamicTree<SpriteComponent>(SpriteAabbFunc);
+            component.LightTree = new(LightAabbFunc);
+            component.SpriteTree = new(SpriteAabbFunc);
         }
 
         private void HandleLightUpdate(EntityUid uid, PointLightComponent component, PointLightUpdateEvent args)
@@ -169,7 +172,7 @@ namespace Robust.Client.GameObjects
         {
             if (component.RenderTree == null) return;
 
-            component.RenderTree.SpriteTree.Remove(component);
+            component.RenderTree.SpriteTree.Remove(new() { Component = component });
             component.RenderTree = null;
         }
 
@@ -198,7 +201,7 @@ namespace Robust.Client.GameObjects
         {
             if (component.RenderTree == null) return;
 
-            component.RenderTree.LightTree.Remove(component);
+            component.RenderTree.LightTree.Remove(new() { Component = component });
             component.RenderTree = null;
         }
 
@@ -215,12 +218,12 @@ namespace Robust.Client.GameObjects
         {
             foreach (var sprite in component.SpriteTree)
             {
-                sprite.RenderTree = null;
+                sprite.Component.RenderTree = null;
             }
 
             foreach (var light in component.LightTree)
             {
-                light.RenderTree = null;
+                light.Component.RenderTree = null;
             }
 
             component.SpriteTree.Clear();
@@ -242,12 +245,11 @@ namespace Robust.Client.GameObjects
             EntityManager.EnsureComponent<RenderingTreeComponent>(_mapManager.GetGrid(ev.GridId).GridEntityId);
         }
 
-        private RenderingTreeComponent? GetRenderTree(EntityUid entity, EntityQuery<TransformComponent> xforms)
+        private RenderingTreeComponent? GetRenderTree(EntityUid entity, TransformComponent xform, EntityQuery<TransformComponent> xforms)
         {
             var lookups = EntityManager.GetEntityQuery<RenderingTreeComponent>();
 
             if (!EntityManager.EntityExists(entity) ||
-                !xforms.TryGetComponent(entity, out var xform) ||
                 xform.MapID == MapId.Nullspace ||
                 lookups.HasComponent(entity)) return null;
 
@@ -282,11 +284,11 @@ namespace Robust.Client.GameObjects
                     continue;
                 }
 
-                var oldMapTree = sprite.RenderTree;
-                var newMapTree = GetRenderTree(sprite.Owner, xforms);
-                // TODO: Temp PVS guard
                 var xform = xforms.GetComponent(sprite.Owner);
-                var (worldPos, worldRot) = xform.GetWorldPositionRotation();
+                var oldMapTree = sprite.RenderTree;
+                var newMapTree = GetRenderTree(sprite.Owner, xform, xforms);
+                // TODO: Temp PVS guard
+                var (worldPos, worldRot) = _xformSystem.GetWorldPositionRotation(xform, xforms);
 
                 if (float.IsNaN(worldPos.X) || float.IsNaN(worldPos.Y))
                 {
@@ -294,17 +296,17 @@ namespace Robust.Client.GameObjects
                     continue;
                 }
 
-                var aabb = SpriteAabbFunc(sprite, worldPos, worldRot, xforms);
+                var aabb = SpriteAabbFunc(sprite, xform, worldPos, worldRot, xforms);
 
                 // If we're on a new map then clear the old one.
                 if (oldMapTree != newMapTree)
                 {
                     ClearSprite(sprite);
-                    newMapTree?.SpriteTree.Add(sprite, aabb);
+                    newMapTree?.SpriteTree.Add((sprite,xform) , aabb);
                 }
                 else
                 {
-                    newMapTree?.SpriteTree.Update(sprite, aabb);
+                    newMapTree?.SpriteTree.Update((sprite, xform), aabb);
                 }
 
                 sprite.RenderTree = newMapTree;
@@ -320,10 +322,11 @@ namespace Robust.Client.GameObjects
                     continue;
                 }
 
+                var xform = xforms.GetComponent(light.Owner);
                 var oldMapTree = light.RenderTree;
-                var newMapTree = GetRenderTree(light.Owner, xforms);
+                var newMapTree = GetRenderTree(light.Owner, xform, xforms);
                 // TODO: Temp PVS guard
-                var worldPos = xforms.GetComponent(light.Owner).WorldPosition;
+                var worldPos = _xformSystem.GetWorldPosition(xform, xforms);
 
                 if (float.IsNaN(worldPos.X) || float.IsNaN(worldPos.Y))
                 {
@@ -337,18 +340,17 @@ namespace Robust.Client.GameObjects
                 {
                     Logger.WarningS(LoggerSawmill, $"Light radius for {light.Owner} set above max radius of {MaxLightRadius}. This may lead to pop-in.");
                 }
-
-                var aabb = LightAabbFunc(light, worldPos, xforms);
+                var aabb = LightAabbFunc(light, xform, worldPos, xforms);
 
                 // If we're on a new map then clear the old one.
                 if (oldMapTree != newMapTree)
                 {
                     ClearLight(light);
-                    newMapTree?.LightTree.Add(light, aabb);
+                    newMapTree?.LightTree.Add((light, xform), aabb);
                 }
                 else
                 {
-                    newMapTree?.LightTree.Update(light, aabb);
+                    newMapTree?.LightTree.Update((light, xform), aabb);
                 }
 
                 light.RenderTree = newMapTree;
@@ -358,39 +360,38 @@ namespace Robust.Client.GameObjects
             _lightQueue.Clear();
         }
 
-        private Box2 SpriteAabbFunc(in SpriteComponent value)
+        private Box2 SpriteAabbFunc(in ComponentTreeEntry<SpriteComponent> entry)
         {
             var xforms = EntityManager.GetEntityQuery<TransformComponent>();
-            var xform = xforms.GetComponent(value.Owner);
-            var (worldPos, worldRot) = xform.GetWorldPositionRotation();
 
-            return SpriteAabbFunc(value, worldPos, worldRot, xforms);
+            var (worldPos, worldRot) = _xformSystem.GetWorldPositionRotation(entry.Transform, xforms);
+
+            return SpriteAabbFunc(entry.Component, entry.Transform, worldPos, worldRot, xforms);
         }
 
-        private Box2 LightAabbFunc(in PointLightComponent value)
+        private Box2 LightAabbFunc(in ComponentTreeEntry<PointLightComponent> entry)
         {
             var xforms = EntityManager.GetEntityQuery<TransformComponent>();
+            var worldPos = _xformSystem.GetWorldPosition(entry.Transform, xforms);
+            var tree = GetRenderTree(entry.Uid, entry.Transform, xforms);
+            var boxSize = entry.Component.Radius * 2;
 
-            var worldPos = xforms.GetComponent(value.Owner).WorldPosition;
-            var tree = GetRenderTree(value.Owner, xforms);
-            var boxSize = value.Radius * 2;
-
-            var localPos = tree == null ? worldPos : xforms.GetComponent(tree.Owner).InvWorldMatrix.Transform(worldPos);
+            var localPos = tree == null ? worldPos : _xformSystem.GetInvWorldMatrix(tree.Owner, xforms).Transform(worldPos);
             return Box2.CenteredAround(localPos, (boxSize, boxSize));
         }
 
-        private Box2 SpriteAabbFunc(SpriteComponent value, Vector2 worldPos, Angle worldRot, EntityQuery<TransformComponent> xforms)
+        private Box2 SpriteAabbFunc(SpriteComponent value, TransformComponent xform, Vector2 worldPos, Angle worldRot, EntityQuery<TransformComponent> xforms)
         {
             var bounds = value.CalculateRotatedBoundingBox(worldPos, worldRot);
-            var tree = GetRenderTree(value.Owner, xforms);
+            var tree = GetRenderTree(value.Owner, xform, xforms);
 
-            return tree == null ? bounds.CalcBoundingBox() : xforms.GetComponent(tree.Owner).InvWorldMatrix.TransformBox(bounds);
+            return tree == null ? bounds.CalcBoundingBox() : _xformSystem.GetInvWorldMatrix(tree.Owner, xforms).TransformBox(bounds);
         }
 
-        private Box2 LightAabbFunc(PointLightComponent value, Vector2 worldPos, EntityQuery<TransformComponent> xforms)
+        private Box2 LightAabbFunc(PointLightComponent value, TransformComponent xform, Vector2 worldPos, EntityQuery<TransformComponent> xforms)
         {
             // Lights are circles so don't need entity's rotation
-            var tree = GetRenderTree(value.Owner, xforms);
+            var tree = GetRenderTree(value.Owner, xform, xforms);
             var boxSize = value.Radius * 2;
 
             var localPos = tree == null ? worldPos : xforms.GetComponent(tree.Owner).InvWorldMatrix.Transform(worldPos);

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
@@ -1,9 +1,10 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Robust.Client.Graphics;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
+using Robust.Shared.Physics;
 
 namespace Robust.Client.GameObjects
 {
@@ -66,15 +67,15 @@ namespace Robust.Client.GameObjects
             {
                 var bounds = xforms.GetComponent(comp.Owner).InvWorldMatrix.TransformBox(pvsBounds);
 
-                comp.SpriteTree.QueryAabb(ref frameTime, (ref float state, in SpriteComponent value) =>
+                comp.SpriteTree.QueryAabb(ref frameTime, (ref float state, in ComponentTreeEntry<SpriteComponent> value) =>
                 {
-                    if (value.IsInert)
+                    if (value.Component.IsInert)
                     {
                         return true;
                     }
 
-                    if (!_manualUpdate.Contains(value))
-                        value.FrameUpdate(state);
+                    if (!_manualUpdate.Contains(value.Component))
+                        value.Component.FrameUpdate(state);
                     return true;
                 }, bounds, true);
             }

--- a/Robust.Shared/GameObjects/Components/Light/OccluderTreeComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Light/OccluderTreeComponent.cs
@@ -7,6 +7,6 @@ namespace Robust.Shared.GameObjects
     /// </summary>
     public sealed class OccluderTreeComponent : Component
     {
-        internal DynamicTree<OccluderComponent> Tree { get; set; } = default!;
+        internal DynamicTree<ComponentTreeEntry<OccluderComponent>> Tree { get; set; } = default!;
     }
 }

--- a/Robust.Shared/GameObjects/Systems/OccluderSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/OccluderSystem.cs
@@ -120,7 +120,7 @@ namespace Robust.Shared.GameObjects
                 switch (occluderUpdate)
                 {
                     case OccluderAddEvent:
-                        if (component.Tree != null) break;
+                        if (component.Tree != null || component.Deleted) break;
                         tree = GetOccluderTree(component);
                         if (tree == null) break;
                         component.Tree = tree;
@@ -131,6 +131,7 @@ namespace Robust.Shared.GameObjects
                         });
                         break;
                     case OccluderUpdateEvent:
+                        if (component.Deleted) break;
                         var oldTree = component.Tree;
                         tree = GetOccluderTree(component);
                         var entry = new ComponentTreeEntry<OccluderComponent>()

--- a/Robust.Shared/GameObjects/Systems/OccluderSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/OccluderSystem.cs
@@ -66,7 +66,7 @@ namespace Robust.Shared.GameObjects
         {
             var capacity = (int) Math.Min(256, Math.Ceiling(EntityManager.GetComponent<TransformComponent>(component.Owner).ChildCount / TreeGrowthRate) * TreeGrowthRate);
 
-            component.Tree = new DynamicTree<OccluderComponent>(ExtractAabbFunc, capacity: capacity);
+            component.Tree = new(ExtractAabbFunc, capacity: capacity);
         }
 
         private void HandleGridInit(GridInitializeEvent ev)
@@ -111,6 +111,7 @@ namespace Robust.Shared.GameObjects
 
         private void UpdateTrees()
         {
+            var query = GetEntityQuery<TransformComponent>();
             while (_updates.TryDequeue(out var occluderUpdate))
             {
                 OccluderTreeComponent? tree;
@@ -123,25 +124,34 @@ namespace Robust.Shared.GameObjects
                         tree = GetOccluderTree(component);
                         if (tree == null) break;
                         component.Tree = tree;
-                        tree.Tree.Add(component);
+                        tree.Tree.Add(new()
+                        {
+                            Component = component,
+                            Transform = query.GetComponent(component.Owner)
+                        });
                         break;
                     case OccluderUpdateEvent:
                         var oldTree = component.Tree;
                         tree = GetOccluderTree(component);
+                        var entry = new ComponentTreeEntry<OccluderComponent>()
+                        {
+                            Component = component,
+                            Transform = query.GetComponent(component.Owner)
+                        };
                         if (oldTree != tree)
                         {
-                            oldTree?.Tree.Remove(component);
-                            tree?.Tree.Add(component);
+                            oldTree?.Tree.Remove(entry);
+                            tree?.Tree.Add(entry);
                             component.Tree = tree;
                             break;
                         }
 
-                        tree?.Tree.Update(component);
+                        tree?.Tree.Update(entry);
 
                         break;
                     case OccluderRemoveEvent:
                         tree = component.Tree;
-                        tree?.Tree.Remove(component);
+                        tree?.Tree.Remove(new() { Component = component });
                         break;
                     default:
                         throw new ArgumentOutOfRangeException($"No implemented occluder update for {occluderUpdate.GetType()}");
@@ -166,9 +176,9 @@ namespace Robust.Shared.GameObjects
             _mapManager.GetMapEntityId(e.Map).EnsureComponent<OccluderTreeComponent>();
         }
 
-        private Box2 ExtractAabbFunc(in OccluderComponent o)
+        private Box2 ExtractAabbFunc(in ComponentTreeEntry<OccluderComponent> entry)
         {
-            return o.BoundingBox.Translated(EntityManager.GetComponent<TransformComponent>(o.Owner).LocalPosition);
+            return entry.Component.BoundingBox.Translated(entry.Transform.LocalPosition);
         }
 
         public IEnumerable<RayCastResults> IntersectRayWithPredicate(MapId mapId, in Ray ray, float maxLength,
@@ -194,25 +204,25 @@ namespace Robust.Shared.GameObjects
             foreach (var comp in GetOccluderTrees(mapId, worldBox))
             {
                 var transform = xforms.GetComponent(comp.Owner);
-                var (_, treeRot, matrix) = transform.GetWorldPositionRotationInvMatrix();
+                var (_, treeRot, matrix) = transform.GetWorldPositionRotationInvMatrix(xforms);
 
                 var relativeAngle = new Angle(-treeRot.Theta).RotateVec(ray.Direction);
 
                 var treeRay = new Ray(matrix.Transform(ray.Position), relativeAngle);
 
                 comp.Tree.QueryRay(ref list,
-                    (ref List<RayCastResults> listState, in OccluderComponent value, in Vector2 point, float distFromOrigin) =>
+                    (ref List<RayCastResults> listState, in ComponentTreeEntry<OccluderComponent> value, in Vector2 point, float distFromOrigin) =>
                     {
                         if (distFromOrigin > maxLength)
                             return true;
 
-                        if (!value.Enabled)
+                        if (!value.Component.Enabled)
                             return true;
 
-                        if (predicate.Invoke(value.Owner, state))
+                        if (predicate.Invoke(value.Uid, state))
                             return true;
 
-                        var result = new RayCastResults(distFromOrigin, point, value.Owner);
+                        var result = new RayCastResults(distFromOrigin, point, value.Uid);
                         listState.Add(result);
                         return !returnOnFirstHit;
                     }, treeRay);

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -503,6 +503,12 @@ public abstract partial class SharedTransformSystem
         return component.WorldPosition;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public (Vector2 WorldPosition, Angle WorldRotation) GetWorldPositionRotation(TransformComponent component, EntityQuery<TransformComponent> xformQuery)
+    {
+        return component.GetWorldPositionRotation(xformQuery);
+    }
+
     public void SetWorldPosition(EntityUid uid, Vector2 worldPos)
     {
         var xform = Transform(uid);

--- a/Robust.Shared/Physics/ComponentTreeEntry.cs
+++ b/Robust.Shared/Physics/ComponentTreeEntry.cs
@@ -1,0 +1,42 @@
+using Robust.Shared.GameObjects;
+using System;
+
+namespace Robust.Shared.Physics;
+
+/// <summary>
+///     This is a data struct for use with a <see cref="DynamicTree"/>. This stores both some generic component and the
+///     entity's transform component. This is being used in place of a simple tuple so that the IEquatable can be
+///     overriden, such that we can remove entries without needing to fetch the transform component of a possible
+///     deleted entity.
+/// </summary>
+public readonly struct ComponentTreeEntry<T> : IEquatable<ComponentTreeEntry<T>>, IComparable<ComponentTreeEntry<T>> where T : Component
+{
+    public T Component { get; init; }
+    public TransformComponent Transform { get; init; }
+    public EntityUid Uid => Component.Owner;
+
+    public int CompareTo(ComponentTreeEntry<T> other)
+    {
+        return Uid.CompareTo(other.Uid);
+    }
+
+    public bool Equals(ComponentTreeEntry<T> other)
+    {
+        return Uid.Equals(other.Uid);
+    }
+
+    public readonly void Deconstruct(out T component, out TransformComponent xform)
+    {
+        component = Component;
+        xform = Transform;
+    }
+
+    public static implicit operator ComponentTreeEntry<T>((T, TransformComponent) tuple)
+    {
+        return new ComponentTreeEntry<T>()
+        {
+            Component = tuple.Item1,
+            Transform = tuple.Item2
+        };
+    }
+}


### PR DESCRIPTION
Whenever iterating over the sprite, point light, or occluder dynamic trees, this always involves also fetching the transform component.  So this PR updates those trees so that they also store the transform component. Currently this change should make rendering sliiightly faster.