### PR TITLE
Expose total fixtures mass on physics

### DIFF
--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
@@ -335,11 +335,17 @@ namespace Robust.Shared.GameObjects
         [ViewVariables]
         public int CollisionMask { get; internal set; }
 
+        /// <summary>
+        ///     The current total mass of the entities fixtures in kilograms. Ignores the body type.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadOnly)]
+        public float FixturesMass => _mass;
+
         // I made Mass read-only just because overwriting it doesn't touch inertia.
         /// <summary>
-        ///     Current mass of the entity in kilograms.
+        ///     Current mass of the entity in kilograms. This may be 0 depending on the body type.
         /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
+        [ViewVariables(VVAccess.ReadOnly)]
         public float Mass => (BodyType & (BodyType.Dynamic | BodyType.KinematicController)) != 0 ? _mass : 0.0f;
 
         private float _mass;

--- a/Robust.Shared/Physics/IPhysBody.cs
+++ b/Robust.Shared/Physics/IPhysBody.cs
@@ -89,6 +89,12 @@ namespace Robust.Shared.Physics
         float InvMass { get; }
 
         /// <summary>
+        /// Mass of the entities fixtures in kilograms
+        /// Ignores body type
+        /// </summary>
+        float FixturesMass { get; }
+
+        /// <summary>
         /// Mass of the entity in kilograms
         /// Set this via fixtures.
         /// </summary>


### PR DESCRIPTION
Exposes the total fixtures mass, so the Heat Capacity calculation can work when the body type changes in content.