### PR TITLE
Add generic visualizer system

### DIFF
--- a/Robust.Client/GameObjects/Components/Appearance/GenericVisualizerComponent.cs
+++ b/Robust.Client/GameObjects/Components/Appearance/GenericVisualizerComponent.cs
@@ -20,6 +20,6 @@ public sealed class GenericVisualizerComponent : Component
     ///
     ///     In most instances, each of these dictionaries will probably only have a single entry.
     /// </summary>
-    [DataField("data", required:true)]
-    public Dictionary<string, Dictionary<string, Dictionary<string, PrototypeLayerData>>> Data = default!;
+    [DataField("visuals", required:true)]
+    public Dictionary<string, Dictionary<string, Dictionary<string, PrototypeLayerData>>> Visuals = default!;
 }

--- a/Robust.Client/GameObjects/Components/Appearance/GenericVisualizerComponent.cs
+++ b/Robust.Client/GameObjects/Components/Appearance/GenericVisualizerComponent.cs
@@ -1,0 +1,25 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.Serialization.Manager.Attributes;
+using System;
+using System.Collections.Generic;
+using static Robust.Shared.GameObjects.SharedSpriteComponent;
+
+namespace Robust.Client.GameObjects;
+
+/// <summary>
+///     This component can be used to apply generic changes to an entity's sprite component as a result of appearance
+///     data changes.
+/// </summary>
+[RegisterComponent]
+[Friend(typeof(GenericVisualizerSystem))]
+public sealed class GenericVisualizerComponent : Component
+{
+    /// <summary>
+    ///     This is a nested dictionary that maps appearance data keys -> sprite layer keys -> appearance data values -> layer data.
+    ///     While somewhat convoluted, this enables the sprite layer data to be completely modified using only yaml.
+    ///
+    ///     In most instances, each of these dictionaries will probably only have a single entry.
+    /// </summary>
+    [DataField("data", required:true)]
+    public Dictionary<string, Dictionary<string, Dictionary<string, PrototypeLayerData>>> Data = default!;
+}

--- a/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
@@ -121,7 +121,7 @@ namespace Robust.Client.GameObjects
             };
 
             // Give it AppearanceData so we can still keep the friend attribute on the component.
-            EntityManager.EventBus.RaiseLocalEvent(uid, ref ev);
+            EntityManager.EventBus.RaiseLocalEvent(uid, ref ev, false);
 
             // Eventually visualizers would be nuked and we'd just make them components instead.
             foreach (var visualizer in appearanceComponent.Visualizers)

--- a/Robust.Client/GameObjects/EntitySystems/GenericVisualizerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/GenericVisualizerSystem.cs
@@ -1,0 +1,43 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Reflection;
+
+namespace Robust.Client.GameObjects;
+
+/// <summary>
+///     A generic visualizer system that modifies sprite layer data.
+/// </summary>
+public sealed class GenericVisualizerSystem : VisualizerSystem<GenericVisualizerComponent>
+{
+    [Dependency] private readonly IReflectionManager _refMan = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearanceSys = default!;
+
+    protected override void OnAppearanceChange(EntityUid uid, GenericVisualizerComponent component, ref AppearanceChangeEvent args)
+    {
+        if (args.Sprite == null)
+            return;
+
+        foreach (var (appearanceKey, layerDict) in component.Data)
+        {
+            if (!_appearanceSys.TryGetData(uid, appearanceKey, out var appearanceValue, args.Component))
+                continue;
+
+            var valueString = appearanceValue.ToString();
+            if (valueString == null)
+                continue;
+
+            foreach (var (layerKeyRaw, layerDataDict) in layerDict)
+            {
+                if (!layerDataDict.TryGetValue(valueString, out var layerData))
+                    continue;
+
+                object layerKey = _refMan.TryParseEnumReference(layerKeyRaw, out var @enum)
+                    ? @enum
+                    : layerKeyRaw;
+
+                var layerIndex = args.Sprite.LayerMapReserveBlank(layerKey);
+                args.Sprite.LayerSetData(layerIndex, layerData);
+            }
+        }
+    }
+}

--- a/Robust.Client/GameObjects/EntitySystems/GenericVisualizerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/GenericVisualizerSystem.cs
@@ -17,7 +17,7 @@ public sealed class GenericVisualizerSystem : VisualizerSystem<GenericVisualizer
         if (args.Sprite == null)
             return;
 
-        foreach (var (appearanceKey, layerDict) in component.Data)
+        foreach (var (appearanceKey, layerDict) in component.Visuals)
         {
             if (!_appearanceSys.TryGetData(uid, appearanceKey, out var appearanceValue, args.Component))
                 continue;

--- a/Robust.Server/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Server/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -15,8 +15,6 @@ namespace Robust.Server.GameObjects
     [ComponentReference(typeof(SharedSpriteComponent))]
     public sealed class SpriteComponent : SharedSpriteComponent, ISerializationHooks
     {
-        const string LayerSerializationCache = "spritelayersrv";
-
         [ViewVariables]
         [DataField("layers", priority: 2, readOnly: true)]
         private List<PrototypeLayerData> Layers = new();
@@ -145,7 +143,7 @@ namespace Robust.Server.GameObjects
             {
                 if (state != null || texture != null)
                 {
-                    var layerZeroData = SharedSpriteComponent.PrototypeLayerData.New();
+                    var layerZeroData = new PrototypeLayerData();
                     if (!string.IsNullOrWhiteSpace(state))
                     {
                         layerZeroData.State = state;
@@ -166,7 +164,7 @@ namespace Robust.Server.GameObjects
 
         public int AddLayerWithSprite(SpriteSpecifier specifier)
         {
-            var layer = PrototypeLayerData.New();
+            var layer = new PrototypeLayerData();
             switch (specifier)
             {
                 case SpriteSpecifier.Texture tex:
@@ -187,7 +185,7 @@ namespace Robust.Server.GameObjects
 
         public int AddLayerWithTexture(string texture)
         {
-            var layer = PrototypeLayerData.New();
+            var layer = new PrototypeLayerData();
             layer.TexturePath = texture;
             Layers.Add(layer);
             Dirty();
@@ -201,7 +199,7 @@ namespace Robust.Server.GameObjects
 
         public int AddLayerWithState(string stateId)
         {
-            var layer = PrototypeLayerData.New();
+            var layer = new PrototypeLayerData();
             layer.State = stateId;
             Layers.Add(layer);
             Dirty();
@@ -210,7 +208,7 @@ namespace Robust.Server.GameObjects
 
         public int AddLayerWithState(string stateId, string rsiPath)
         {
-            var layer = PrototypeLayerData.New();
+            var layer = new PrototypeLayerData();
             layer.State = stateId;
             layer.RsiPath = rsiPath;
             Layers.Add(layer);

--- a/Robust.Server/GameObjects/ServerComponentFactory.cs
+++ b/Robust.Server/GameObjects/ServerComponentFactory.cs
@@ -13,6 +13,7 @@ namespace Robust.Server.GameObjects
         {
             RegisterIgnore("Input");
             RegisterIgnore("AnimationPlayer");
+            RegisterIgnore("GenericVisualizer");
 
             RegisterClass<MetaDataComponent>();
             RegisterClass<TransformComponent>();

--- a/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
@@ -67,27 +67,17 @@ namespace Robust.Shared.GameObjects
             [DataField("state")]
             public string? State;
             [DataField("scale")]
-            public Vector2 Scale = Vector2.One;
+            public Vector2? Scale;
             [DataField("rotation")]
-            public Angle Rotation = Angle.Zero;
+            public Angle? Rotation;
             [DataField("offset")]
-            public Vector2 Offset = Vector2.Zero;
+            public Vector2? Offset;
             [DataField("visible")]
-            public bool Visible = true;
+            public bool? Visible;
             [DataField("color")]
-            public Color Color = Color.White;
+            public Color? Color;
             [DataField("map")]
             public HashSet<string>? MapKeys;
-
-            public static PrototypeLayerData New()
-            {
-                return new()
-                {
-                    Scale = Vector2.One,
-                    Color = Color.White,
-                    Visible = true,
-                };
-            }
         }
     }
 }

--- a/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
@@ -78,6 +78,10 @@ namespace Robust.Shared.GameObjects
             public Color? Color;
             [DataField("map")]
             public HashSet<string>? MapKeys;
+
+            // TODO delete this.
+            // requires content PR and I cbf the current PR to a content one.
+            public static PrototypeLayerData New() => new();
         }
     }
 }

--- a/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
@@ -1,12 +1,76 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.IoC;
+using Robust.Shared.Reflection;
 using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.GameObjects;
 
 public abstract class SharedAppearanceSystem : EntitySystem
 {
+    [Dependency] private readonly IReflectionManager _refMan = default!;
+
     public virtual void MarkDirty(AppearanceComponent component) {}
+
+    #region SetData
+    public void SetData(EntityUid uid, string key, object value, AppearanceComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+
+        if (_refMan.TryParseEnumReference(key, out var @enum))
+            SetDataPrivate(component, @enum, value);
+        else
+            SetDataPrivate(component, key, value);
+    }
+
+    public void SetData(EntityUid uid, Enum key, object value, AppearanceComponent? component = null)
+    {
+        if (Resolve(uid, ref component))
+            SetDataPrivate(component, key, value);
+    }
+
+    private void SetDataPrivate(AppearanceComponent component, object key, object value)
+    {
+        if (component.AppearanceData.TryGetValue(key, out var existing) && existing.Equals(value))
+            return;
+
+        DebugTools.Assert(value.GetType().IsValueType || value is ICloneable, "Appearance data values must be cloneable.");
+
+        component.AppearanceData[key] = value;
+        Dirty(component);
+        MarkDirty(component);
+    }
+    #endregion
+
+    #region TryGetData
+    public bool TryGetData(EntityUid uid, string key, [MaybeNullWhen(false)] out object value, AppearanceComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+        {
+            value = null;
+            return false;
+        }
+
+        if (_refMan.TryParseEnumReference(key, out var @enum))
+            return component.AppearanceData.TryGetValue(@enum, out value);
+        else
+            return component.AppearanceData.TryGetValue(key, out value);
+    }
+
+    public bool TryGetData(EntityUid uid, Enum key, [MaybeNullWhen(false)] out object value, AppearanceComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+        {
+            value = null;
+            return false;
+        }
+
+        return component.AppearanceData.TryGetValue(key, out value);
+    }
+    #endregion
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
Currently SS14 has a generic enum visualizer, which allows someone to use yaml to map some appearance component data onto a sprite layer state. However there is no way to specify other sprite layer data (e.g., shader, scale, etc). Also, given that this is generally useful and not at all ss14 specific, this functionality should probably be in engine.

So this PR adds a generic visualizer system to the engine, which extends the generic enum visualizer so that it can be used to fully specify the sprite layer data. It also uses string keys, instead of enums. This adds support for things like the `PowerDeviceVisuals.Powered` appearance data, which is a bool. 

For example. the yaml for the PAI visualizer used to look like this:
```yaml
- type: Appearance
  visuals:
  - type: GenericEnumVisualizer
    key: enum.PAIVisuals.Status
    layer: 1
    states:
      enum.PAIStatus.Off: pai-off-overlay
      enum.PAIStatus.Searching: pai-searching-overlay
      enum.PAIStatus.On: pai-on-overlay
```
Now it looks like:
```yaml
  - type: GenericVisualizer
    visuals:
      enum.PAIVisuals.Status:
        unshaded-layer:
          Off: { state: pai-off-overlay }
          Searching: { state: pai-searching-overlay }
          On: { state: pai-on-overlay }
```

This didn't and still doesn't have any yaml linter checking. Given that the keys & values for the various dictionaries & maps can be either strings, enums, or generic objects, I don't really think there is any reasonable way of linting that without adding restrictions on the types.

This PR also:
- Adds `SetData()` and `TryGetData()` functions to the appearance system, which should be used instead of the component-functions. 
- Makes some changes to sprite component, so that more `PrototypeLayerData` fields are nullable.