### PR TITLE
Remove PhysicsMap ref from physics comp

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -131,10 +131,9 @@ namespace Robust.Shared.GameObjects
             var meta = MetaData(uid);
 
             if (meta.EntityLifeStage < EntityLifeStage.Initialized || !TryComp(uid, out TransformComponent? xform))
-            {
                 return;
-            }
 
+            // TODO: need to suss out this particular bit + containers + body.Broadphase.
             if (body._canCollide)
                 _broadphase.UpdateBroadphase(body, xform: xform);
 

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -187,13 +187,12 @@ namespace Robust.Shared.GameObjects
             var bodyQuery = GetEntityQuery<PhysicsComponent>();
             var metaQuery = GetEntityQuery<MetaDataComponent>();
 
-            RecursiveMapUpdate(xform, oldMap, map, xformQuery, bodyQuery, metaQuery);
+            RecursiveMapUpdate(xform, oldMapId, xformQuery, bodyQuery, metaQuery);
         }
 
         private void RecursiveMapUpdate(
             TransformComponent xform,
-            SharedPhysicsMapComponent? oldMap,
-            SharedPhysicsMapComponent? map,
+            MapId oldMap,
             EntityQuery<TransformComponent> xformQuery,
             EntityQuery<PhysicsComponent> bodyQuery,
             EntityQuery<MetaDataComponent> metaQuery)
@@ -206,8 +205,9 @@ namespace Robust.Shared.GameObjects
                     !xformQuery.TryGetComponent(child.Value, out var childXform) ||
                     metaQuery.GetComponent(child.Value).EntityLifeStage == EntityLifeStage.Deleted) continue;
 
+                DestroyContacts(childBody, oldMap);
                 _joints.ClearJoints(childBody);
-                RecursiveMapUpdate(childXform, oldMap, map, xformQuery, bodyQuery, metaQuery);
+                RecursiveMapUpdate(childXform, oldMap, xformQuery, bodyQuery, metaQuery);
             }
         }
 

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -9,7 +9,6 @@ using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Dynamics;
-using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using DependencyAttribute = Robust.Shared.IoC.DependencyAttribute;
 
@@ -50,7 +49,6 @@ namespace Robust.Shared.GameObjects
         public Action<Fixture, Fixture, float, Vector2>? KinematicControllerCollision;
 
         public bool MetricsEnabled { get; protected set; }
-        private readonly Stopwatch _stopwatch = new();
 
         private ISawmill _sawmill = default!;
 
@@ -103,7 +101,6 @@ namespace Robust.Shared.GameObjects
         {
             IoCManager.InjectDependencies(component);
             component.BroadphaseSystem = _broadphase;
-            component._physics = this;
             component.ContactManager = new();
             component.ContactManager.Initialize();
             component.ContactManager.MapId = component.MapId;

--- a/Robust.Shared/Physics/Dynamics/ContactManager.cs
+++ b/Robust.Shared/Physics/Dynamics/ContactManager.cs
@@ -261,13 +261,11 @@ namespace Robust.Shared.Physics.Dynamics
 
             // Connect to body A
             DebugTools.Assert(!fixtureA.Contacts.ContainsKey(fixtureB));
-            DebugTools.Assert(bodyA.PhysicsMap != null);
             fixtureA.Contacts.Add(fixtureB, contact);
             contact.BodyANode = bodyA.Contacts.AddLast(contact);
 
             // Connect to body B
             DebugTools.Assert(!fixtureB.Contacts.ContainsKey(fixtureA));
-            DebugTools.Assert(bodyB.PhysicsMap != null);
             fixtureB.Contacts.Add(fixtureA, contact);
             contact.BodyBNode = bodyB.Contacts.AddLast(contact);
         }

--- a/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
+++ b/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
@@ -215,9 +215,7 @@ namespace Robust.Shared.Physics.Dynamics
             }
 
             // Build and simulated islands from awake bodies.
-            // Ideally you don't need a stack size for all bodies but we'll TODO: optimise it later.
             _bodyStack.EnsureCapacity(AwakeBodies.Count);
-
             _islandSet.EnsureCapacity(AwakeBodies.Count);
             _awakeBodyList.AddRange(AwakeBodies);
 

--- a/Robust.Shared/Physics/IPhysBody.cs
+++ b/Robust.Shared/Physics/IPhysBody.cs
@@ -50,11 +50,6 @@ namespace Robust.Shared.Physics
         int CollisionMask { get; }
 
         /// <summary>
-        ///     Removes all of the currently active contacts for this body.
-        /// </summary>
-        void DestroyContacts();
-
-        /// <summary>
         /// The type of the body, which determines how collisions effect this object.
         /// </summary>
         BodyType BodyType { get; set; }

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -475,16 +475,7 @@ namespace Robust.Shared.Physics
 
         public void RegenerateContacts(PhysicsComponent body)
         {
-            // TODO: PhysicsMap actually needs to be made nullable (or needs a re-design to not be on the body).
-            // Eventually it'll be a component on the map so nullspace won't have one anyway and we need to handle that scenario.
-            // Technically it is nullable coz of networking (previously it got away with being able to ignore it
-            // but anchoring can touch BodyType in HandleComponentState so we need to handle this here).
-            if (body.PhysicsMap != null)
-            {
-                body.DestroyContacts();
-            }
-
-            DebugTools.Assert(body.Contacts.Count == 0);
+            Get<SharedPhysicsSystem>().DestroyContacts(body);
 
             var broadphase = body.Broadphase;
 


### PR DESCRIPTION
More trouble than it was worth bookkeeping and this should be 2% more stable than master.

The only reason PhysicsMap even stored bodies was in case gravity changed which we can just iterate over anyway. I also changed a bunch of stuff so CanCollide is attempted to be set to true before Awake juuusssttt in case.

I also made it so the container check in CanCollide is updated to check if any of its parents is in a container as well.