### PR TITLE
Make Eye use Matrix3.CreateTransform

### DIFF
--- a/Robust.Client/Graphics/ClientEye/Eye.cs
+++ b/Robust.Client/Graphics/ClientEye/Eye.cs
@@ -78,8 +78,8 @@ namespace Robust.Client.Graphics
         public void GetViewMatrixInv(out Matrix3 viewMatrixInv, Vector2 renderScale)
         {
             viewMatrixInv = Matrix3.CreateTransform(
-                _coords.Position.X,
-                _coords.Position.Y,
+                _coords.Position.X + Offset.X,
+                _coords.Position.Y + Offset.Y,
                 (float)-Rotation.Theta,
                 1 / (_scale.X * renderScale.X),
                 1 / (_scale.Y * renderScale.Y));

--- a/Robust.Client/Graphics/ClientEye/Eye.cs
+++ b/Robust.Client/Graphics/ClientEye/Eye.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Map;
+using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.ViewVariables;
 
@@ -56,27 +56,33 @@ namespace Robust.Client.Graphics
         /// <inheritdoc />
         public void GetViewMatrix(out Matrix3 viewMatrix, Vector2 renderScale)
         {
-            var scaleMat = Matrix3.CreateScale(_scale.X * renderScale.X, _scale.Y * renderScale.Y);
-            var rotMat = Matrix3.CreateRotation(_rotation);
-            var transMat = Matrix3.CreateTranslation(-_coords.Position - Offset);
-
-            viewMatrix = transMat * rotMat * scaleMat;
+            viewMatrix = Matrix3.CreateInverseTransform(
+                _coords.Position.X + Offset.X,
+                _coords.Position.Y + Offset.Y,
+                (float)-Rotation.Theta,
+                1 / (_scale.X * renderScale.X),
+                1 / (_scale.Y * renderScale.Y));
         }
 
         public void GetViewMatrixNoOffset(out Matrix3 viewMatrix, Vector2 renderScale)
         {
-            var scaleMat = Matrix3.CreateScale(_scale.X * renderScale.X, _scale.Y * renderScale.Y);
-            var rotMat = Matrix3.CreateRotation(_rotation);
-            var transMat = Matrix3.CreateTranslation(-_coords.Position);
-
-            viewMatrix = transMat * rotMat * scaleMat;
+            viewMatrix = Matrix3.CreateInverseTransform(
+                _coords.Position.X,
+                _coords.Position.Y,
+                (float)-Rotation.Theta,
+                1 / (_scale.X * renderScale.X),
+                1 / (_scale.Y * renderScale.Y));
         }
 
         /// <inheritdoc />
         public void GetViewMatrixInv(out Matrix3 viewMatrixInv, Vector2 renderScale)
         {
-            GetViewMatrix(out var viewMatrix, renderScale);
-            viewMatrixInv = Matrix3.Invert(viewMatrix);
+            viewMatrixInv = Matrix3.CreateTransform(
+                _coords.Position.X,
+                _coords.Position.Y,
+                (float)-Rotation.Theta,
+                1 / (_scale.X * renderScale.X),
+                1 / (_scale.Y * renderScale.Y));
         }
     }
 }

--- a/Robust.Shared.Maths/Matrix3.cs
+++ b/Robust.Shared.Maths/Matrix3.cs
@@ -367,8 +367,8 @@ namespace Robust.Shared.Maths
             var result = Identity;
 
             /* column major
-             0 0 x
-             0 0 y
+             1 0 x
+             0 1 y
              0 0 1
             */
             result.R0C2 = x;
@@ -434,7 +434,8 @@ namespace Robust.Shared.Maths
         {
             // returns a matrix that is equivalent to returning CreateScale(scale) * CreateRotation(angle) * CreateTranslation(posX, posY)
 
-            var (sin, cos) = MathF.SinCos(angle);
+            var sin = MathF.Sin(angle);
+            var cos = MathF.Cos(angle);
 
             return new Matrix3
             {
@@ -453,7 +454,8 @@ namespace Robust.Shared.Maths
         {
             // returns a matrix that is equivalent to returning CreateTranslation(-posX, -posY) * CreateRotation(-angle) * CreateScale(1/scaleX, 1/scaleY)
 
-            var (sin, cos) = MathF.SinCos(angle);
+            var sin = MathF.Sin(angle);
+            var cos = MathF.Cos(angle);
 
             return new Matrix3
             {


### PR DESCRIPTION
Avoids unnecessary matrix multiplication and inversion.

Also removes `MathF.SinCos` from those functions, because it is apparently slower than getting sin and cos separately.