### PR TITLE
Save & load command loc strings & completion

### DIFF
--- a/Resources/Locale/en-US/commands.ftl
+++ b/Resources/Locale/en-US/commands.ftl
@@ -1,5 +1,12 @@
 ﻿### Localization for engine console commands
 
+## generic
+
+cmd-parse-failure-integer = {$arg} is not a valid integer.
+cmd-parse-failure-float = {$arg} is not a valid float.
+cmd-parse-failure-bool = {$arg} is not a valid bool.
+
+
 ## 'help' command
 cmd-help-desc = Display general help or help text for a specific command
 cmd-help-help = Usage: help [command name]
@@ -114,3 +121,26 @@ cmd-monitor-invalid-name = Invalid monitor name
 cmd-monitor-arg-count = Missing monitor argument
 cmd-monitor-minus-all-hint = Hides all monitors
 cmd-monitor-plus-all-hint = Shows all monitors
+
+
+## Mapping commands
+
+cmd-savemap-desc = Serializes a map to disk. Will not save a post-init map unless forced.
+cmd-savemap-help = savemap <MapID> <Path> [force]
+cmd-savemap-not-exist = Target map does not exist.
+cmd-savemap-init-warning = Attempted to save a post-init map without forcing the save.
+cmd-savemap-attempt = Attempting to save map {$mapId} to {$path}.
+cmd-hint-savemap-id = <MapID>
+cmd-hint-savemap-path = <Path>
+cmd-hint-savemap-force = [bool]
+
+cmd-loadmap-desc = Loads a map from disk into the game.
+cmd-loadmap-help = loadmap <MapID> <Path> [x] [y] [rotation] [consistentUids]
+cmd-loadmap-nullspace = You cannot load into map 0.
+cmd-loadmap-exists = Map {$mapId} already exists.
+cmd-loadmap-success = Map {$mapId} has been loaded from {$path}.
+cmd-loadmap-error = An error occurred while loading map from {$path}.
+cmd-hint-loadmap-x-position = [x-position]
+cmd-hint-loadmap-y-position = [y-position]
+cmd-hint-loadmap-rotation = [rotation]
+cmd-hint-loadmap-uids = [float]

--- a/Robust.Shared/ContentPack/WritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/WritableDirProvider.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Robust.Shared.Log;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.ContentPack
@@ -80,6 +81,9 @@ namespace Robust.Shared.ContentPack
         public IEnumerable<string> DirectoryEntries(ResourcePath path)
         {
             var fullPath = GetFullPath(path);
+
+            if (!Directory.Exists(fullPath))
+                yield break;
 
             foreach (var entry in Directory.EnumerateFileSystemEntries(fullPath))
             {


### PR DESCRIPTION
Adds localization and completions to the load & save map commands. Also stops an exception from being thrown when using invalid filepaths for completions.