### PR TITLE
Fix some grid traversal misprediction

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/TransformSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/TransformSystem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Robust.Client.Physics;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Maths;
@@ -32,6 +33,8 @@ namespace Robust.Client.GameObjects
             base.Initialize();
 
             SubscribeLocalEvent<TransformStartLerpMessage>(TransformStartLerpHandler);
+
+            UpdatesBefore.Add(typeof(PhysicsSystem));
         }
 
         private void TransformStartLerpHandler(TransformStartLerpMessage ev)

--- a/Robust.Client/GameObjects/EntitySystems/TransformSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/TransformSystem.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
-using Robust.Client.Physics;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Maths;
@@ -33,8 +32,6 @@ namespace Robust.Client.GameObjects
             base.Initialize();
 
             SubscribeLocalEvent<TransformStartLerpMessage>(TransformStartLerpHandler);
-
-            UpdatesBefore.Add(typeof(PhysicsSystem));
         }
 
         private void TransformStartLerpHandler(TransformStartLerpMessage ev)

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -225,6 +225,9 @@ namespace Robust.Client.GameStates
                     using var _ = _timing.StartStateApplicationArea();
 
                     ResetPredictedEntities(_timing.CurTick);
+
+                    // This check shouldn't be necessary anymore, but I am paranoid.
+                    DebugTools.Assert(_entitySystemManager.GetEntitySystem<SharedGridTraversalSystem>().QueuedEvents.Count == 0);
                 }
 
                 using (_prof.Group("FullRep"))

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -226,8 +226,8 @@ namespace Robust.Client.GameStates
 
                     ResetPredictedEntities(_timing.CurTick);
 
-                    // This check shouldn't be necessary anymore, but I am paranoid.
-                    DebugTools.Assert(_entitySystemManager.GetEntitySystem<SharedGridTraversalSystem>().QueuedEvents.Count == 0);
+                    // I hate this..
+                    _entitySystemManager.GetEntitySystem<SharedGridTraversalSystem>().QueuedEvents.Clear();
                 }
 
                 using (_prof.Group("FullRep"))

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -43,6 +43,7 @@ namespace Robust.Shared.GameObjects
         [Dependency] private readonly SharedBroadphaseSystem _broadphase = default!;
         [Dependency] private readonly SharedJointSystem _joints = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
+        [Dependency] private readonly SharedGridTraversalSystem _traversal = default!;
         [Dependency] protected readonly IMapManager MapManager = default!;
         [Dependency] private readonly IPhysicsManager _physicsManager = default!;
 
@@ -291,6 +292,8 @@ namespace Robust.Shared.GameObjects
             {
                 comp.ProcessQueue();
             }
+
+            _traversal.ProcessMovement();
 
             _physicsManager.ClearTransforms();
         }

--- a/Robust.UnitTesting/Server/RobustServerSimulation.cs
+++ b/Robust.UnitTesting/Server/RobustServerSimulation.cs
@@ -253,6 +253,7 @@ namespace Robust.UnitTesting.Server
 
             // PhysicsComponent Requires this.
             entitySystemMan.LoadExtraSystemType<PhysicsSystem>();
+            entitySystemMan.LoadExtraSystemType<SharedGridTraversalSystem>();
             entitySystemMan.LoadExtraSystemType<ContainerSystem>();
             entitySystemMan.LoadExtraSystemType<JointSystem>();
             entitySystemMan.LoadExtraSystemType<MapSystem>();


### PR DESCRIPTION
Grid traversal would queue events and process them during a system update, but this could lead to movement events being raised during frame updates, prediction getting reset, and then that future-event being processed during the next tick.

This just moves the grid traversal processing to happen at the end of `PhysicsSystem.SimulateWorld()`. Apparently having traversal processed during a frame update used to cause issues at some point, but I haven't seen anything weird so far.

There is still a separate issue causing some grid traversal issues, this is only a partial fix.