### PR TITLE
Matrix3x2 and Matrix SIMD

### DIFF
--- a/Robust.Benchmarks/NumericsHelpers/MatrixInversionBenchmark.cs
+++ b/Robust.Benchmarks/NumericsHelpers/MatrixInversionBenchmark.cs
@@ -1,0 +1,30 @@
+using BenchmarkDotNet.Attributes;
+using System.Numerics;
+using Robust.Shared.Analyzers;
+using Robust.Shared.Maths;
+
+namespace Robust.Benchmarks.NumericsHelpers
+{
+    [Virtual]
+    [DisassemblyDiagnoser(printSource: true, exportHtml:true)]
+    public class MatrixInversionBenchmark
+    {
+        public Matrix3 matrix = Matrix3.Identity;
+        public Matrix3x2 nmatrix = Matrix3x2.Identity;
+
+        [Benchmark(Baseline =true, Description = "Normal calculation")]
+        public Matrix3 BenchNoSimd()
+        {
+            // 3x3 will naturally be slower than 3x2 inversion, but this is still slow.
+            Matrix3.Invert(matrix, out var result);
+            return result;
+        }
+
+        [Benchmark(Description = "Equivalent using System.Numerics")]
+        public Matrix3x2 BenchNumerics()
+        {
+            Matrix3x2.Invert(nmatrix, out var result);
+            return result;
+        }
+    }
+}

--- a/Robust.Benchmarks/NumericsHelpers/MatrixMultiplicationBenchmark.cs
+++ b/Robust.Benchmarks/NumericsHelpers/MatrixMultiplicationBenchmark.cs
@@ -1,0 +1,57 @@
+using BenchmarkDotNet.Attributes;
+using System.Numerics;
+using Robust.Shared.Analyzers;
+using Robust.Shared.Maths;
+
+namespace Robust.Benchmarks.NumericsHelpers
+{
+    [Virtual]
+    [DisassemblyDiagnoser(printSource: true, exportHtml:true)]
+    public class MatrixMultiplicationBenchmark
+    {
+        public Matrix3 matrixA = Matrix3.Identity;
+        public Matrix3x2 nmatrixA = Matrix3x2.Identity;
+        public Matrix3 matrixB = Matrix3.Identity;
+        public Matrix3x2 nmatrixB = Matrix3x2.Identity;
+
+        [Benchmark(Baseline = true, Description = "No Simd")]
+        public Matrix3 BenchNoSimd()
+        {
+            Matrix3.Multiply3x2(in matrixA, in matrixB, out var result);
+            Matrix3.Multiply3x2(in result, in matrixA, out var result2);
+            Matrix3.Multiply3x2(in result2, in matrixB, out var result3);
+            return result3;
+        }
+
+        [Benchmark(Description = "Using Fma")]
+        public Matrix3 MultiplyFma()
+        {
+            Matrix3.MultiplyFma(in matrixA, in matrixB, out var result);
+            Matrix3.MultiplyFma(in result, in matrixA, out var result2);
+            Matrix3.MultiplyFma(in result2, in matrixB, out var result3);
+            return result3;
+        }
+
+        [Benchmark(Description = "Using Sse")]
+        public Matrix3 MultiplySse()
+        {
+            Matrix3.MultiplySse(in matrixA, in matrixB, out var result);
+            Matrix3.MultiplySse(in result, in matrixA, out var result2);
+            Matrix3.MultiplySse(in result2, in matrixB, out var result3);
+            return result3;
+        }
+
+        // for whatever reason this seems to be slower than the operator form?
+        [Benchmark(Description = "System.Numerics")]
+        public Matrix3x2 BenchNumerics()
+        {
+            return Matrix3x2.Multiply(Matrix3x2.Multiply(Matrix3x2.Multiply(nmatrixA, nmatrixB), nmatrixA), nmatrixB);
+        }
+
+        [Benchmark(Description = "System.Numerics (operator)")]
+        public Matrix3x2 BenchNumericsOperator()
+        {
+            return nmatrixA * nmatrixB * nmatrixA * nmatrixB;
+        }
+    }
+}

--- a/Robust.Benchmarks/NumericsHelpers/VectorTransformBenchmark.cs
+++ b/Robust.Benchmarks/NumericsHelpers/VectorTransformBenchmark.cs
@@ -1,0 +1,53 @@
+using BenchmarkDotNet.Attributes;
+using System.Numerics;
+using Robust.Shared.Analyzers;
+using Robust.Shared.Maths;
+using NVector2 = System.Numerics.Vector2;
+using Vector2 = Robust.Shared.Maths.Vector2;
+using System;
+
+namespace Robust.Benchmarks.NumericsHelpers
+{
+    [Virtual]
+    [DisassemblyDiagnoser(printSource: true, exportHtml:true)]
+    public class VectorTransformBenchmark
+    {
+        public Matrix3 matrix = Matrix3.CreateTransform((0.1f, 0.2f), 0.5f, (1f, 1.1f));
+        public Matrix3x2 nmatrix = Matrix3x2.CreateScale(1f, 1.1f)*Matrix3x2.CreateRotation(0.5f)* Matrix3x2.CreateTranslation(0.1f, 0.2f);
+
+        public Vector2 vector = Vector2.One;
+        public NVector2 nvector = NVector2.One;
+        
+        [Benchmark(Baseline =true, Description = "No SIMD")]
+        public Vector2 BenchNoSimd()
+        {
+            return Matrix3.TransformVec2NoSimd(in matrix, Matrix3.TransformVec2NoSimd(in matrix, Matrix3.TransformVec2NoSimd(in matrix, vector)));
+        }
+
+        [Benchmark(Description = "Using SSE")]
+        public Vector2 BenchSse()
+        {
+            return Matrix3.TransformVec2Sse(in matrix, Matrix3.TransformVec2Sse(in matrix, Matrix3.TransformVec2Sse(in matrix, vector)));
+        }
+
+        [Benchmark(Description = "Using SSE3")]
+        public Vector2 BenchSse3()
+        {
+            return Matrix3.TransformVec2Sse3(in matrix, Matrix3.TransformVec2Sse3(in matrix, Matrix3.TransformVec2Sse3(in matrix, vector)));
+        }
+
+        [Benchmark(Description = "Using FMA")]
+        public Vector2 BenchFma()
+        {
+            return Matrix3.TransformVec2Fma(in matrix, Matrix3.TransformVec2Fma(in matrix, Matrix3.TransformVec2Fma(in matrix, vector)));
+        }
+
+
+        [Benchmark(Description = "System.Numerics")]
+        public NVector2 BenchNumerics()
+        {
+            // even faster than the best I can get with simd
+            return NVector2.Transform(NVector2.Transform(NVector2.Transform(nvector, nmatrix), nmatrix), nmatrix);
+        }
+    }
+}

--- a/Robust.Benchmarks/Robust.Benchmarks.csproj
+++ b/Robust.Benchmarks/Robust.Benchmarks.csproj
@@ -6,6 +6,7 @@
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <OutputPath>../bin/Benchmarks</OutputPath>
         <OutputType>Exe</OutputType>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <NoWarn>RA0003</NoWarn>
     </PropertyGroup>
     <ItemGroup>

--- a/Robust.Client/Graphics/Clyde/GLObjects/Clyde.ShaderProgram.cs
+++ b/Robust.Client/Graphics/Clyde/GLObjects/Clyde.ShaderProgram.cs
@@ -259,14 +259,56 @@ namespace Robust.Client.Graphics.Clyde
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private unsafe void SetUniformDirect(int slot, in Matrix3 value, bool transpose=true)
             {
-                Matrix3 tmpTranspose = value;
+                GlMatrix3 tmpTranspose;
+
                 if (transpose)
                 {
-                    // transposition not supported on GLES2, & no access to _hasGLES
-                    tmpTranspose.Transpose();
+                    tmpTranspose = new()
+                    {
+                        R0C0 = value.R0C0,
+                        R1C0 = value.R1C0,
+                        R2C0 = value.R2C0,
+                        R0C1 = value.R0C1,
+                        R1C1 = value.R1C1,
+                        R2C1 = value.R2C1,
+                        R0C2 = value.R0C2,
+                        R1C2 = value.R1C2,
+                        R2C2 = value.R2C2,
+                    };
                 }
+                else
+                {
+                    tmpTranspose = new()
+                    {
+                        R0C0 = value.R0C0,
+                        R1C0 = value.R0C1,
+                        R2C0 = value.R0C2,
+                        R0C1 = value.R1C0,
+                        R1C1 = value.R1C1,
+                        R2C1 = value.R1C2,
+                        R0C2 = value.R2C0,
+                        R1C2 = value.R2C1,
+                        R2C2 = value.R2C2,
+                    };
+                }
+
                 GL.UniformMatrix3(slot, 1, false, (float*) &tmpTranspose);
                 _clyde.CheckGlError();
+            }
+
+            // GL currently uses matrix 3. This is just temporary to check if the game still works with the simd changes.
+            // If these changes are added, GL needs to be converted to use matrix3x2
+            private struct GlMatrix3
+            {
+                public float R0C0;
+                public float R1C0;
+                public float R2C0;
+                public float R0C1;
+                public float R1C1;
+                public float R2C1;
+                public float R0C2;
+                public float R1C2;
+                public float R2C2;
             }
 
             public void SetUniform(string uniformName, in Matrix4 matrix, bool transpose=true)

--- a/Robust.Shared.Maths/Box2Rotated.cs
+++ b/Robust.Shared.Maths/Box2Rotated.cs
@@ -65,7 +65,7 @@ namespace Robust.Shared.Maths
                 return CalcBoundingBoxSse();
             }
 
-            return CalcBoundingBoxSlow();
+            return CalcBoundingBoxNoSimd();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -95,21 +95,15 @@ namespace Robust.Shared.Maths
             allX = Sse.Add(modX, originX);
             allY = Sse.Add(modY, originY);
 
-            var l = SimdHelpers.MinHorizontalSse(allX);
-            var b = SimdHelpers.MinHorizontalSse(allY);
-            var r = SimdHelpers.MaxHorizontalSse(allX);
-            var t = SimdHelpers.MaxHorizontalSse(allY);
-
-            var lb = Sse.UnpackLow(l, b);
-            var rt = Sse.UnpackLow(r, t);
-
-            var lbrt = Sse.Shuffle(lb, rt, 0b11_10_01_00);
+            var lr = SimdHelpers.MinMaxHorizontalSse(allX);
+            var bt = SimdHelpers.MinMaxHorizontalSse(allY);
+            var lbrt = Sse.UnpackLow(lr, bt);
 
             return Unsafe.As<Vector128<float>, Box2>(ref lbrt);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe Box2 CalcBoundingBoxSlow()
+        internal readonly unsafe Box2 CalcBoundingBoxNoSimd()
         {
             Span<float> allX = stackalloc float[4];
             Span<float> allY = stackalloc float[4];

--- a/Robust.Shared.Maths/Matrix22.cs
+++ b/Robust.Shared.Maths/Matrix22.cs
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Runtime.CompilerServices;
+
 namespace Robust.Shared.Maths
 {
     public struct Matrix22
@@ -35,6 +37,7 @@ namespace Robust.Shared.Maths
 
         public Matrix22(float a11, float a12, float a21, float a22)
         {
+            Unsafe.SkipInit(out this);
             EX.X = a11; EX.Y = a21;
             EY.X = a12; EY.Y = a22;
         }

--- a/Robust.Shared.Maths/Matrix33.cs
+++ b/Robust.Shared.Maths/Matrix33.cs
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Runtime.CompilerServices;
+
 namespace Robust.Shared.Maths
 {
     public struct Matrix33
@@ -83,6 +85,7 @@ namespace Robust.Shared.Maths
             Vector2 x;
             x.X = det * (a22 * b.X - a12 * b.Y);
             x.Y = det * (a11 * b.Y - a21 * b.X);
+            Unsafe.SkipInit(out x);
             return x;
         }
 

--- a/Robust.Shared.Maths/SimdHelpers.cs
+++ b/Robust.Shared.Maths/SimdHelpers.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 
 namespace Robust.Shared.Maths
@@ -6,8 +6,21 @@ namespace Robust.Shared.Maths
     /// <summary>
     ///     Helper stuff for SIMD code.
     /// </summary>
-    internal static class SimdHelpers
+    public static class SimdHelpers
     {
+        /// <returns>A vector with the horizontal minimum and maximum values arranged as { min max max min} .</returns>
+        public static Vector128<float> MinMaxHorizontalSse(Vector128<float> v)
+        {
+            var b = Sse.Shuffle(v, v, 0b00_01_10_11);
+            var m = Sse.Min(b, v);
+            var M = Sse.Max(b, v);
+            var c = Sse.Shuffle(m, M, 0b01_00_00_01);
+            var mm = Sse.Min(c, m);
+            var MM = Sse.Max(c, M);
+            var d = Sse.MoveScalar(MM, mm);
+            return Sse.Shuffle(d, d, 0b00_11_11_00);
+        }
+
         /// <returns>The min value is broadcast to the whole vector.</returns>
         public static Vector128<float> MinHorizontalSse(Vector128<float> v)
         {

--- a/Robust.Shared.Maths/Vector2.cs
+++ b/Robust.Shared.Maths/Vector2.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Robust.Shared.Utility;
@@ -8,19 +8,26 @@ namespace Robust.Shared.Maths
     /// <summary>
     ///     Represents a float vector with two components (x, y).
     /// </summary>
-    [StructLayout(LayoutKind.Sequential)]
+    [StructLayout(LayoutKind.Explicit)]
     [Serializable]
     public struct Vector2 : IEquatable<Vector2>, IApproxEquatable<Vector2>, ISpanFormattable
     {
         /// <summary>
         ///     The X component of the vector.
         /// </summary>
+        [FieldOffset(sizeof(float) * 0)]
         public float X;
 
         /// <summary>
         ///     The Y component of the vector.
         /// </summary>
+        [FieldOffset(sizeof(float) * 1)]
         public float Y;
+
+        // Shhhhh don't question it.
+        [FieldOffset(sizeof(float) * 0)]
+        [NonSerialized]
+        public System.Numerics.Vector2 Translation;
 
         /// <summary>
         ///     A zero length vector.
@@ -57,6 +64,7 @@ namespace Robust.Shared.Maths
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Vector2(float x, float y)
         {
+            Unsafe.SkipInit(out this);
             X = x;
             Y = y;
         }

--- a/Robust.Shared/Physics/Dynamics/Joints/MouseJoint.cs
+++ b/Robust.Shared/Physics/Dynamics/Joints/MouseJoint.cs
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 using System;
+using System.Runtime.CompilerServices;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Maths;
@@ -216,6 +217,7 @@ public sealed class MouseJoint : Joint, IEquatable<MouseJoint>
         K.EX.Y = -_invIB * _rB.X * _rB.Y;
         K.EY.X = K.EX.Y;
         K.EY.Y = _invMassB + _invIB * _rB.X * _rB.X + _gamma;
+        Unsafe.SkipInit(out K);
 
         _mass = K.GetInverse();
 

--- a/Robust.Shared/Physics/Dynamics/Joints/PrismaticJoint.cs
+++ b/Robust.Shared/Physics/Dynamics/Joints/PrismaticJoint.cs
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 using System;
+using System.Runtime.CompilerServices;
 using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -451,7 +452,8 @@ namespace Robust.Shared.Physics.Dynamics.Joints
 		        Cdot.X = Vector2.Dot(_perp, vB - vA) + _s2 * wB - _s1 * wA;
 		        Cdot.Y = wB - wA;
 
-		        Vector2 df = _K.Solve(-Cdot);
+                Unsafe.SkipInit(out Cdot);
+                Vector2 df = _K.Solve(-Cdot);
 		        _impulse += df;
 
 		        Vector2 P = _perp * df.X;
@@ -568,7 +570,8 @@ namespace Robust.Shared.Physics.Dynamics.Joints
 		        Matrix22 K;
                 K = new Matrix22(k11, k12, k12, k22);
 
-		        Vector2 impulse1 = K.Solve(-C1);
+                Unsafe.SkipInit(out C1);
+                Vector2 impulse1 = K.Solve(-C1);
 		        impulse.X = impulse1.X;
 		        impulse.Y = impulse1.Y;
 		        impulse.Z = 0.0f;

--- a/Robust.Shared/Utility/DebugTools.cs
+++ b/Robust.Shared/Utility/DebugTools.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;

--- a/Robust.UnitTesting/Shared/Maths/Box2Rotated_Test.cs
+++ b/Robust.UnitTesting/Shared/Maths/Box2Rotated_Test.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.Intrinsics.X86;
 using NUnit.Framework;
@@ -62,7 +62,7 @@ namespace Robust.UnitTesting.Shared.Maths
             var (baseBox, origin, rotation, expected) = dat;
 
             var rotated = new Box2Rotated(baseBox, rotation, origin);
-            Assert.That(rotated.CalcBoundingBoxSlow(), Is.Approximately(expected));
+            Assert.That(rotated.CalcBoundingBoxNoSimd(), Is.Approximately(expected));
         }
 
         [Test]


### PR DESCRIPTION
Marked as a draft, because this isn't so much a PR as it is just me sharing my benchmark code and trying to make sense of the results. Also, disclaimer: All I know about SIMD & C# Unsafe code I've learnt in the last week, so there might be rookie mistakes.

There are two main benchmarks to look at, firstly `VectorTransformBenchmark` which applies a sequence of three matrix transforms to a vector, using existing (non-simd) code, some new simd functions, and an equivalent using `System.Numerics.` equivalents. On my machine, the result of that is:

<details>
<summary>Triple Vector Transform Results</summary>

```ini
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
AMD Ryzen 7 3800X, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=6.0.300
  [Host]     : .NET Core 6.0.5 (CoreCLR 6.0.522.21309, CoreFX 6.0.522.21309), X64 RyuJIT
  DefaultJob : .NET Core 6.0.5 (CoreCLR 6.0.522.21309, CoreFX 6.0.522.21309), X64 RyuJIT
```
|          Method |      Mean |     Error |    StdDev | Ratio | Code Size |
|---------------- |----------:|----------:|----------:|------:|----------:|
|       &#39;No SIMD&#39; | 25.816 ns | 0.0236 ns | 0.0209 ns |  1.00 |     290 B |
|     &#39;Using SSE&#39; |  8.831 ns | 0.0054 ns | 0.0048 ns |  0.34 |     355 B |
|    &#39;Using SSE3&#39; |  8.466 ns | 0.0065 ns | 0.0054 ns |  0.33 |     301 B |
|     &#39;Using FMA&#39; |  8.414 ns | 0.0138 ns | 0.0115 ns |  0.33 |     316 B |
| System.Numerics |  5.165 ns | 0.0042 ns | 0.0037 ns |  0.20 |     300 B |

 
</details>

If there is nothing heinously wrong with my benchmarking setup, that at least indicates that moving to using the `Numerics` structs would be best for performance, albeit only by a relatively small amount. The relative results are basically the same when just doing a single transform. Nothing I have tried has come close to the `Numerics` results, and the best benchmark results I can get involve require using `Numerics` within the robust stucts themselves in order to convert to and from from Vector128<float>. Before that I was using some possibly illegal/unsafe uses of `Unsafe.AsPointer`.

But then there is the other benchmar:k: `MatrixMultiplicationBenchmark`, which is just a sequence of three matrix multiplications again using "normal" code, SIMD code, and System.Numerics.

<details>
<summary>Triple Matrix Multiplication Results</summary>

|                       Method |     Mean |    Error |   StdDev | Ratio | Code Size |
|----------------------------- |---------:|---------:|---------:|------:|----------:|
|                    &#39;No Simd&#39; | 13.29 ns | 0.013 ns | 0.010 ns |  1.00 |     730 B |
|                  &#39;Using Fma&#39; | 10.95 ns | 0.007 ns | 0.006 ns |  0.82 |     566 B |
|                  &#39;Using Sse&#39; | 11.09 ns | 0.006 ns | 0.005 ns |  0.83 |     575 B |
|              System.Numerics | 38.40 ns | 0.008 ns | 0.008 ns |  2.89 |     644 B |
| &#39;System.Numerics (operator)&#39; | 31.50 ns | 0.022 ns | 0.020 ns |  2.37 |     449 B |

 
</details>

The SIMDified code only seems to do ~20% better, but the `System.Numerics` results are just garbage? This might have to do with the fact that AFAICT they have no in/out/readonly variants?  If only doing a single transform, the results aren't quite as heinous, but still just worse than existing code?

<details>
<summary>Single Matrix Multiplication Results</summary>

|                       Method |     Mean |     Error |    StdDev | Ratio | Code Size |
|----------------------------- |---------:|----------:|----------:|------:|----------:|
|                    &#39;No Simd&#39; | 7.582 ns | 0.0237 ns | 0.0198 ns |  1.00 |     266 B |
|                  &#39;Using Fma&#39; | 5.397 ns | 0.0052 ns | 0.0046 ns |  0.71 |     205 B |
|                  &#39;Using Sse&#39; | 5.510 ns | 0.0035 ns | 0.0032 ns |  0.73 |     208 B |
|              System.Numerics | 9.796 ns | 0.0310 ns | 0.0275 ns |  1.29 |     361 B |
| &#39;System.Numerics (operator)&#39; | 8.593 ns | 0.0044 ns | 0.0039 ns |  1.13 |     314 B |

</details>

So uhhh:
- Someone please check my benchmark code isn't hot garbage for some reason
- Are the results consistent across different CPUs (cpu info included in first set of results)? 
- Given matrix mult appears to be trash while vector transform is only slightly slower, Do we just keep using Robust math + SIMD for the sake of convenience?
  - This would still involve refactoring Robust Matirx3 -> Robust Matrix3x2. 