### PR TITLE
Fix grid splitting

### DIFF
--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -463,8 +463,12 @@ namespace Robust.Server.Maps
             private void ApplyGridFixtures()
             {
                 var entManager = _serverEntityManager;
-                var gridFixtures = EntitySystem.Get<GridFixtureSystem>();
-                var fixtureSystem = EntitySystem.Get<FixtureSystem>();
+                var sysManager = _serverEntityManager.EntitySysManager;
+                var gridFixtures = sysManager.GetEntitySystem<GridFixtureSystem>();
+                var fixtureSystem = sysManager.GetEntitySystem<FixtureSystem>();
+                // Disable splitting temporarily while maploading occurs.
+                var splitEnabled = gridFixtures.SplitAllowed;
+                gridFixtures.SplitAllowed = false;
 
                 foreach (var grid in Grids)
                 {
@@ -473,7 +477,7 @@ namespace Robust.Server.Maps
                     var fixtures = entManager.EnsureComponent<FixturesComponent>(grid.GridEntityId);
                     // Regenerate grid collision.
                     gridFixtures.EnsureGrid(grid.GridEntityId);
-                    gridFixtures.ProcessGrid(gridInternal);
+                    gridFixtures.ProcessGrid(grid);
                     // Avoid duplicating the deserialization in FixtureSystem.
                     fixtures.SerializedFixtures.Clear();
 
@@ -510,6 +514,8 @@ namespace Robust.Server.Maps
 
                     fixtureSystem.FixtureUpdate(fixtures, body);
                 }
+
+                gridFixtures.SplitAllowed = splitEnabled;
             }
 
             private void ReadGridSection()

--- a/Robust.Server/Physics/GridFixtureSystem.cs
+++ b/Robust.Server/Physics/GridFixtureSystem.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Robust.Server.Console;
 using Robust.Server.Player;
 using Robust.Shared;
+using Robust.Shared.Collections;
 using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -39,7 +40,7 @@ namespace Robust.Server.Physics
         /// </summary>
         private bool _isSplitting;
 
-        private bool _splitAllowed = true;
+        internal bool SplitAllowed = true;
 
         public override void Initialize()
         {
@@ -53,7 +54,7 @@ namespace Robust.Server.Physics
             configManager.OnValueChanged(CVars.GridSplitting, SetSplitAllowed, true);
         }
 
-        private void SetSplitAllowed(bool value) => _splitAllowed = value;
+        private void SetSplitAllowed(bool value) => SplitAllowed = value;
 
         public override void Shutdown()
         {
@@ -184,7 +185,7 @@ namespace Robust.Server.Physics
         /// </summary>
         private void CheckSplits(EntityUid uid, HashSet<ChunkSplitNode> dirtyNodes)
         {
-            if (_isSplitting || !_splitAllowed) return;
+            if (_isSplitting || !SplitAllowed) return;
 
             _isSplitting = true;
             _logger.Debug($"Started split check for {ToPrettyString(uid)}");
@@ -272,6 +273,7 @@ namespace Robust.Server.Physics
                     }
 
                     splitGrid.SetTiles(tileData);
+                    DebugTools.Assert(_mapManager.IsGrid(splitGrid.GridEntityId), "A split grid had no tiles?");
 
                     // Set tiles on new grid + update anchored entities
                     foreach (var node in group)
@@ -318,7 +320,7 @@ namespace Robust.Server.Physics
                         _nodes[mapGrid.GridEntityId][node.Group.Chunk.Indices].Nodes.Remove(node);
                     }
 
-                    var eevee = new PostGridSplitEvent(mapGrid.Index, splitGrid.Index);
+                    var eevee = new PostGridSplitEvent(mapGrid.GridEntityId, splitGrid.GridEntityId);
                     RaiseLocalEvent(uid, ref eevee);
 
                     for (var j = 0; j < tileData.Count; j++)
@@ -498,24 +500,96 @@ namespace Robust.Server.Physics
             return group;
         }
 
-        internal override void GenerateSplitNode(EntityUid gridEuid, MapChunk chunk, bool checkSplit = true)
+        /// <summary>
+        /// Checks for grid split with 1 chunk updated.
+        /// </summary>
+        internal override void CheckSplit(EntityUid gridEuid, MapChunk chunk, List<Box2i> rectangles)
         {
-            if (_isSplitting) return;
+            HashSet<ChunkSplitNode> nodes;
 
-            var grid = (IMapGridInternal) _mapManager.GetGrid(gridEuid);
+            if (chunk.FilledTiles == 0)
+            {
+                nodes = RemoveSplitNode(gridEuid, chunk);
+            }
+            else
+            {
+                nodes = GenerateSplitNode(gridEuid, chunk);
+            }
+
+            CheckSplits(gridEuid, nodes);
+        }
+
+        /// <summary>
+        /// Checks for grid split with many chunks updated.
+        /// </summary>
+        internal override void CheckSplit(EntityUid gridEuid, Dictionary<MapChunk, List<Box2i>> mapChunks, List<MapChunk> removedChunks)
+        {
+            var nodes = new HashSet<ChunkSplitNode>();
+
+            foreach (var chunk in removedChunks)
+            {
+                nodes.UnionWith(RemoveSplitNode(gridEuid, chunk));
+            }
+
+            foreach (var (chunk, _) in mapChunks)
+            {
+                nodes.UnionWith(GenerateSplitNode(gridEuid, chunk));
+            }
+
+            var toRemove = new ValueList<ChunkSplitNode>();
+
+            // Some of the neighbour nodes may have been added that were since deleted during the above enumeration
+            // e.g. if NodeA and NodeB both had their counts set to 0 and are neighbours then either might add
+            // the other to dirtynodes.
+            foreach (var node in nodes)
+            {
+                if (node.Indices.Count > 0) continue;
+                toRemove.Add(node);
+            }
+
+            foreach (var node in toRemove)
+            {
+                nodes.Remove(node);
+            }
+
+            CheckSplits(gridEuid, nodes);
+        }
+
+        /// <summary>
+        /// Removes this chunk from nodes and dirties its neighbours.
+        /// </summary>
+        private HashSet<ChunkSplitNode> RemoveSplitNode(EntityUid gridEuid, MapChunk chunk)
+        {
             var dirtyNodes = new HashSet<ChunkSplitNode>();
 
+            if (_isSplitting) return new HashSet<ChunkSplitNode>();
+
             Cleanup(gridEuid, chunk, dirtyNodes);
+            DebugTools.Assert(dirtyNodes.All(o => o.Group.Chunk != chunk));
+            return dirtyNodes;
+        }
+
+        /// <summary>
+        /// Re-adds this chunk to nodes and dirties its neighbours and itself.
+        /// </summary>
+        private HashSet<ChunkSplitNode> GenerateSplitNode(EntityUid gridEuid, MapChunk chunk)
+        {
+            var dirtyNodes = RemoveSplitNode(gridEuid, chunk);
+
+            if (_isSplitting) return dirtyNodes;
+
+            DebugTools.Assert(chunk.FilledTiles > 0);
+
+            var grid = (IMapGridInternal) _mapManager.GetGrid(gridEuid);
             var group = CreateNodes(gridEuid, grid, chunk);
-            _nodes[grid.GridEntityId][chunk.Indices] = group;
+            _nodes[gridEuid][chunk.Indices] = group;
 
             foreach (var chunkNode in group.Nodes)
             {
                 dirtyNodes.Add(chunkNode);
             }
 
-            if (checkSplit)
-                CheckSplits(gridEuid, dirtyNodes);
+            return dirtyNodes;
         }
 
         /// <summary>
@@ -562,13 +636,13 @@ namespace Robust.Server.Physics
             _nodes[gridEuid].Remove(chunk.Indices);
         }
 
-        private sealed class ChunkNodeGroup
+        internal sealed class ChunkNodeGroup
         {
             internal MapChunk Chunk = default!;
             public HashSet<ChunkSplitNode> Nodes = new();
         }
 
-        private sealed class ChunkSplitNode
+        internal sealed class ChunkSplitNode
         {
             public ChunkNodeGroup Group = default!;
             public HashSet<Vector2i> Indices { get; set; } = new();
@@ -643,14 +717,14 @@ public readonly struct PostGridSplitEvent
     /// <summary>
     ///     The grid it was part of previously.
     /// </summary>
-    public readonly GridId OldGrid;
+    public readonly EntityUid OldGrid;
 
     /// <summary>
     ///     The grid that has been split.
     /// </summary>
-    public readonly GridId Grid;
+    public readonly EntityUid Grid;
 
-    public PostGridSplitEvent(GridId oldGrid, GridId grid)
+    public PostGridSplitEvent(EntityUid oldGrid, EntityUid grid)
     {
         OldGrid = oldGrid;
         Grid = grid;

--- a/Robust.Shared/GameObjects/Systems/SharedGridFixtureSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridFixtureSystem.cs
@@ -59,11 +59,14 @@ namespace Robust.Shared.GameObjects
             // Just in case there's any deleted we'll ToArray
             foreach (var (_, chunk) in gridInternal.GetMapChunks().ToArray())
             {
-                gridInternal.RegenerateCollision(chunk, false);
+                gridInternal.RegenerateCollision(chunk);
             }
         }
 
-        internal void RegenerateCollision(EntityUid gridEuid, Dictionary<MapChunk, List<Box2i>> mapChunks, bool checkSplit = true)
+        internal void RegenerateCollision(
+            EntityUid gridEuid,
+            Dictionary<MapChunk, List<Box2i>> mapChunks,
+            List<MapChunk> removedChunks)
         {
             if (!_enabled) return;
 
@@ -90,17 +93,18 @@ namespace Robust.Shared.GameObjects
             _fixtures.FixtureUpdate(fixturesComponent, physicsComponent);
             EntityManager.EventBus.RaiseLocalEvent(gridEuid,new GridFixtureChangeEvent {NewFixtures = fixtures});
 
-            foreach (var (chunk, _) in mapChunks)
-            {
-                GenerateSplitNode(gridEuid, chunk, checkSplit);
-            }
+            CheckSplit(gridEuid, mapChunks, removedChunks);
         }
 
-        internal void RegenerateCollision(EntityUid gridEuid, MapChunk chunk, List<Box2i> rectangles, bool checkSplit = true)
+        internal void RegenerateCollision(EntityUid gridEuid, MapChunk chunk, List<Box2i> rectangles)
         {
             if (!_enabled) return;
 
-            DebugTools.Assert(chunk.FilledTiles > 0);
+            if (chunk.FilledTiles == 0)
+            {
+                CheckSplit(gridEuid, chunk, rectangles);
+                return;
+            }
 
             if (!EntityManager.TryGetComponent(gridEuid, out PhysicsComponent? physicsComponent))
             {
@@ -118,9 +122,15 @@ namespace Robust.Shared.GameObjects
             {
                 _fixtures.FixtureUpdate(fixturesComponent, physicsComponent);
                 EntityManager.EventBus.RaiseLocalEvent(gridEuid,new GridFixtureChangeEvent {NewFixtures = chunk.Fixtures});
-                GenerateSplitNode(gridEuid, chunk, checkSplit);
+
+                CheckSplit(gridEuid, chunk, rectangles);
             }
         }
+
+        internal virtual void CheckSplit(EntityUid gridEuid, Dictionary<MapChunk, List<Box2i>> mapChunks,
+            List<MapChunk> removedChunks) {}
+
+        internal virtual void CheckSplit(EntityUid gridEuid, MapChunk chunk, List<Box2i> rectangles) {}
 
         private bool UpdateFixture(MapChunk chunk, List<Box2i> rectangles, PhysicsComponent physicsComponent, FixturesComponent fixturesComponent)
         {
@@ -214,8 +224,6 @@ namespace Robust.Shared.GameObjects
 
             return updated;
         }
-
-        internal virtual void GenerateSplitNode(EntityUid gridEuid, MapChunk chunk, bool checkSplit = true) {}
     }
 
     public sealed class GridFixtureChangeEvent : EntityEventArgs

--- a/Robust.Shared/Map/IMapGridInternal.cs
+++ b/Robust.Shared/Map/IMapGridInternal.cs
@@ -64,7 +64,7 @@ namespace Robust.Shared.Map
         /// <summary>
         /// Regenerates the chunk local bounds of this chunk.
         /// </summary>
-        void RegenerateCollision(MapChunk mapChunk, bool checkSplit = true);
+        void RegenerateCollision(MapChunk mapChunk);
 
         /// <summary>
         /// Calculate the world space AABB for this chunk.


### PR DESCRIPTION
Removed chunks weren't being culled correctly for node splitting. This fixes that and batches multiple chunk updates better as well.

- I removed the checkSplit bool everywhere as it only matters for maploading and I just had that disable splitting globally temporarily.
- For bulk chunk updates all the dirty nodes are added together, then any not relevant are culled, then the split is check (previously this was done chunk-by-chunk which could lead to issues).