### PR TITLE
Fix localizing color

### DIFF
--- a/Robust.Shared/Localization/LocalizationManager.Functions.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Functions.cs
@@ -11,6 +11,7 @@ using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameObjects.Components.Localization;
 using Robust.Shared.IoC;
+using Robust.Shared.Maths;
 
 namespace Robust.Shared.Localization
 {
@@ -362,6 +363,7 @@ namespace Robust.Shared.Localization
                 EntityUid entity => new FluentLocWrapperType(new LocValueEntity(entity)),
                 DateTime dateTime => new FluentLocWrapperType(new LocValueDateTime(dateTime)),
                 TimeSpan timeSpan => new FluentLocWrapperType(new LocValueTimeSpan(timeSpan)),
+                Color color => (FluentString)color.ToHex(),
                 bool or Enum => (FluentString)obj.ToString()!.ToLowerInvariant(),
                 string str => (FluentString)str,
                 byte num => (FluentNumber)num,


### PR DESCRIPTION
Noticed code like this crashing
```
_label.SetMarkup(Loc.GetString("crayon-drawing-label",
                ("color",_parent.Color),
                ("state",_parent.SelectedState),
                ("charges", _parent.Charges),
                ("capacity",_parent.Capacity)));
```
SetMarkup supports a hex string, so now color gets turned into a hex string