### PR TITLE
Misc rendering changes

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteBoundsOverlay.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteBoundsOverlay.cs
@@ -75,8 +75,8 @@ namespace Robust.Client.GameObjects
         protected internal override void Draw(in OverlayDrawArgs args)
         {
             var handle = args.WorldHandle;
-            var currentMap = _eyeManager.CurrentMap;
-            var viewport = _eyeManager.GetWorldViewbounds();
+            var currentMap = args.MapId;
+            var viewport = args.WorldBounds;
 
             foreach (var comp in _renderTree.GetRenderTrees(currentMap, viewport))
             {

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -2069,10 +2069,8 @@ namespace Robust.Client.GameObjects
                     drawingHandle.UseShader(Shader);
 
                 var layerColor = _parent.color * Color;
-
-                var position = -(Vector2)texture.Size / (2f * EyeManager.PixelsPerMeter);
                 var textureSize = texture.Size / (float)EyeManager.PixelsPerMeter;
-                var quad = Box2.FromDimensions(position, textureSize);
+                var quad = Box2.FromDimensions(textureSize/-2, textureSize);
 
                 drawingHandle.DrawTextureRectRegion(texture, quad, layerColor);
 

--- a/Robust.Client/GameObjects/EntitySystems/DebugLightTreeSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/DebugLightTreeSystem.cs
@@ -65,15 +65,12 @@ namespace Robust.Client.GameObjects
                 var map = _eyeManager.CurrentMap;
                 if (map == MapId.Nullspace) return;
 
-                var viewport = _eyeManager.GetWorldViewbounds();
-                var worldBounds = viewport.CalcBoundingBox();
-
-                foreach (var tree in _tree.GetRenderTrees(map, viewport))
+                foreach (var tree in _tree.GetRenderTrees(map, args.WorldBounds))
                 {
                     foreach (var (light, xform) in tree.LightTree)
                     {
                         var aabb = _lookup.GetWorldAABB(light.Owner, xform);
-                        if (!aabb.Intersects(worldBounds)) continue;
+                        if (!aabb.Intersects(args.WorldAABB)) continue;
 
                         args.WorldHandle.DrawRect(aabb, Color.Green.WithAlpha(0.1f));
                     }

--- a/Robust.Client/GameStates/NetInterpOverlay.cs
+++ b/Robust.Client/GameStates/NetInterpOverlay.cs
@@ -31,7 +31,7 @@ namespace Robust.Client.GameStates
             var handle = args.DrawingHandle;
             handle.UseShader(_shader);
             var worldHandle = (DrawingHandleWorld) handle;
-            var viewport = _eyeManager.GetWorldViewport();
+            var viewport = args.WorldAABB;
             foreach (var boundingBox in _entityManager.EntityQuery<IPhysBody>(true))
             {
                 // all entities have a TransformComponent

--- a/Robust.Client/Graphics/Clyde/Clyde.Viewport.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Viewport.cs
@@ -157,6 +157,19 @@ namespace Robust.Client.Graphics.Clyde
                 return newPoint;
             }
 
+            public Matrix3 WorldToLocalMatrix
+            {
+                get {
+                    if (Eye == null)
+                        return default;
+
+                    Eye.GetViewMatrix(out var viewMatrix, RenderScale * (EyeManager.PixelsPerMeter, -EyeManager.PixelsPerMeter));
+                    viewMatrix.R0C2 += Size.X / 2f;
+                    viewMatrix.R1C2 += Size.Y / 2f;
+                    return viewMatrix;
+                }
+            }
+
             public void RenderScreenOverlaysBelow(
                 DrawingHandleScreen handle,
                 IViewportControl control,

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -578,6 +578,8 @@ namespace Robust.Client.Graphics.Clyde
                 return default;
             }
 
+            public Matrix3 WorldToLocalMatrix => default;
+
             public Vector2 WorldToLocal(Vector2 point)
             {
                 return default;

--- a/Robust.Client/Graphics/ClydeHandle.cs
+++ b/Robust.Client/Graphics/ClydeHandle.cs
@@ -9,7 +9,7 @@ namespace Robust.Client.Graphics
             Value = value;
         }
 
-        public long Value { get; }
+        public readonly long Value;
 
         public static explicit operator ClydeHandle(long x)
         {
@@ -38,12 +38,12 @@ namespace Robust.Client.Graphics
 
         public static bool operator ==(ClydeHandle left, ClydeHandle right)
         {
-            return left.Equals(right);
+            return left.Value == right.Value;
         }
 
         public static bool operator !=(ClydeHandle left, ClydeHandle right)
         {
-            return !left.Equals(right);
+            return left.Value != right.Value;
         }
 
         public override string ToString()

--- a/Robust.Client/Graphics/IClydeViewport.cs
+++ b/Robust.Client/Graphics/IClydeViewport.cs
@@ -44,6 +44,11 @@ namespace Robust.Client.Graphics
         MapCoordinates LocalToWorld(Vector2 point);
 
         /// <summary>
+        ///     Matrix equivalent of <see cref="LocalToWorld(Vector2)"/>.
+        /// </summary>
+        Matrix3 WorldToLocalMatrix { get; }
+
+        /// <summary>
         ///     Converts a point in world-space to the viewport's screen coordinates.
         /// </summary>
         Vector2 WorldToLocal(Vector2 point);


### PR DESCRIPTION
- Make overlays use OverlayDrawArgs bounds
- Stop Clyde calculating World bounds twice (once for bounds, once for aabbs).
- Add WorldToLocalMatrix to ClydeViewport
  - Make `ProcessSpriteEntities` use this instead.
- Ever so slightly speed up ClydeHandle equality.
  - Very minor, but this gets called very frequently,
  - Then again maybe it was just a debug / profiling artefact that isn't even present during release?