### PR TITLE
"Fix" another client connection crash

### DIFF
--- a/Robust.Shared/Network/NetManager.ClientConnect.cs
+++ b/Robust.Shared/Network/NetManager.ClientConnect.cs
@@ -115,6 +115,7 @@ namespace Robust.Shared.Network
                 return;
             }
 
+            DebugTools.Assert(ChannelCount > 0 && winningPeer.Channels.Count > 0);
             ClientConnectState = ClientConnectionState.Connected;
             Logger.DebugS("net", "Handshake completed, connection established.");
         }
@@ -176,7 +177,7 @@ namespace Robust.Shared.Network
                 if (keyBytes.Length != CryptoBox.PublicKeyBytes)
                 {
                     connection.Disconnect("Invalid public key length");
-                    return;
+                    throw new Exception("Invalid public key length");
                 }
 
                 // Data is [shared]+[verify]

--- a/Robust.Shared/Network/NetManager.ClientConnect.cs
+++ b/Robust.Shared/Network/NetManager.ClientConnect.cs
@@ -176,8 +176,9 @@ namespace Robust.Shared.Network
 
                 if (keyBytes.Length != CryptoBox.PublicKeyBytes)
                 {
-                    connection.Disconnect("Invalid public key length");
-                    throw new Exception("Invalid public key length");
+                    var msg = $"Invalid public key length. Expected {CryptoBox.PublicKeyBytes}, but was {keyBytes.Length}.";
+                    connection.Disconnect(msg);
+                    throw new Exception(msg);
                 }
 
                 // Data is [shared]+[verify]


### PR DESCRIPTION
Again, this doesn't actually fix the underlying networking issue, this just makes the client handle it. Instead of crashing, it now just reports that there was an error and you can just hit the connect button again