### PR TITLE
Tile rotation

### DIFF
--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -733,7 +733,8 @@ namespace Robust.Client.Placement
                     var grid = MapManager.GetGrid(gridId);
 
                     // no point changing the tile to the same thing.
-                    if (grid.GetTileRef(coordinates).Tile.TypeId == CurrentPermission.TileType)
+                    var t = grid.GetTileRef(coordinates).Tile;
+                    if (t.TypeId == CurrentPermission.TileType && t.Flags == Tile.DirectionToTileFlag(Direction))
                         return;
                 }
 

--- a/Robust.Server/Placement/PlacementManager.cs
+++ b/Robust.Server/Placement/PlacementManager.cs
@@ -125,11 +125,11 @@ namespace Robust.Server.Placement
             }
             else
             {
-                PlaceNewTile(tileType, coordinates);
+                PlaceNewTile(tileType, coordinates, Tile.DirectionToTileFlag(dirRcv));
             }
         }
 
-        private void PlaceNewTile(ushort tileType, EntityCoordinates coordinates)
+        private void PlaceNewTile(ushort tileType, EntityCoordinates coordinates, TileRenderFlag tileRenderFlag)
         {
             var mapCoordinates = coordinates.ToMap(_entityManager);
 
@@ -145,14 +145,14 @@ namespace Robust.Server.Placement
             {
                 if (!_mapManager.TryGetGrid(gridCoordinate.EntityId, out var grid)) return;
 
-                grid.SetTile(gridCoordinate, new Tile(tileType));
+                grid.SetTile(gridCoordinate, new Tile(tileType, tileRenderFlag));
             }
             else if (tileType != 0) // create a new grid
             {
                 var newGrid = _mapManager.CreateGrid(mapCoordinates.MapId);
                 newGrid.WorldPosition = mapCoordinates.Position + (newGrid.TileSize / 2f); // assume bottom left tile origin
                 var tilePos = newGrid.WorldToTile(mapCoordinates.Position);
-                newGrid.SetTile(tilePos, new Tile(tileType));
+                newGrid.SetTile(tilePos, new Tile(tileType, tileRenderFlag));
             }
         }
 

--- a/Robust.Shared/Map/Tile.cs
+++ b/Robust.Shared/Map/Tile.cs
@@ -143,8 +143,6 @@ public readonly struct Tile : IEquatable<Tile>, ISpanFormattable
     /// </summary>
     public static TileRenderFlag DirectionToTileFlag(Direction dir)
     {
-        // TODO Support Mirroring somehow
-
         return dir switch
         {
             Direction.East => TileRenderFlag.Rotate90,
@@ -161,17 +159,14 @@ public readonly struct Tile : IEquatable<Tile>, ISpanFormattable
 [Flags]
 public enum TileRenderFlag : byte
 {
-    // First two bits determine rotation
-    // Third bit determines whether to mirror along the x coordinate (before rotating).
-
+    // First two bits determine rotation. Third bit determines whether to mirror along the x coordinate (before
+    // rotating).
     Identity = 0,
-    Rotate90 = 1,
+    Rotate270 = 1,
     Rotate180 = 2,
-    Rotate270 = 3,
+    Rotate90 = 3,
     FlipX = 4,
-    FlipXRotate90 = 5,
+    FlipXRotate270 = 5,
     FlipXRotate180 = 6,
-    FlipXRotate270 = 7,
-
-    // Maybe use remaining bits for animation frame offset?
+    FlipXRotate90 = 7,
 }

--- a/Robust.Shared/Map/Tile.cs
+++ b/Robust.Shared/Map/Tile.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using JetBrains.Annotations;
+using Robust.Shared.Maths;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.Map;
@@ -136,9 +137,41 @@ public readonly struct Tile : IEquatable<Tile>, ISpanFormattable
             return (TypeId.GetHashCode() * 397) ^ Flags.GetHashCode() ^ Variant.GetHashCode();
         }
     }
+
+    /// <summary>
+    ///     Convert Direction to rotational render flag.
+    /// </summary>
+    public static TileRenderFlag DirectionToTileFlag(Direction dir)
+    {
+        // TODO Support Mirroring somehow
+
+        return dir switch
+        {
+            Direction.East => TileRenderFlag.Rotate90,
+            Direction.North => TileRenderFlag.Rotate180,
+            Direction.West => TileRenderFlag.Rotate270,
+            _ => TileRenderFlag.Identity,
+        };
+    }
 }
 
+/// <summary>
+///     Flags used to modify how a given tile gets rendered. Currently just used for rotation & mirroring.
+/// </summary>
+[Flags]
 public enum TileRenderFlag : byte
 {
+    // First two bits determine rotation
+    // Third bit determines whether to mirror along the x coordinate (before rotating).
 
+    Identity = 0,
+    Rotate90 = 1,
+    Rotate180 = 2,
+    Rotate270 = 3,
+    FlipX = 4,
+    FlipXRotate90 = 5,
+    FlipXRotate180 = 6,
+    FlipXRotate270 = 7,
+
+    // Maybe use remaining bits for animation frame offset?
 }


### PR DESCRIPTION
Allows `TileRenderFlags` to change tile rotation & mirroring, and makes placement manager set render flags based on the current placement rotation.

https://user-images.githubusercontent.com/60421075/173976962-83c8313a-63f7-4ed4-af4f-fd5604a091e4.mp4


