### PR TITLE
Expose GetLocalTilesIntersecting methods

### DIFF
--- a/Robust.Shared/Map/IMapGrid.cs
+++ b/Robust.Shared/Map/IMapGrid.cs
@@ -117,6 +117,10 @@ namespace Robust.Shared.Map
         /// <param name="tiles"></param>
         void SetTiles(List<(Vector2i GridIndices, Tile Tile)> tiles);
 
+        IEnumerable<TileRef> GetLocalTilesIntersecting(Box2Rotated localArea, bool ignoreEmpty = true, Predicate<TileRef>? predicate = null);
+
+        IEnumerable<TileRef> GetLocalTilesIntersecting(Box2 localArea, bool ignoreEmpty = true, Predicate<TileRef>? predicate = null);
+
         IEnumerable<TileRef> GetTilesIntersecting(Box2Rotated worldArea, bool ignoreEmpty = true, Predicate<TileRef>? predicate = null);
 
         /// <summary>

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -300,6 +300,12 @@ namespace Robust.Shared.Map
             RegenerateCollision(chunks);
         }
 
+        public IEnumerable<TileRef> GetLocalTilesIntersecting(Box2Rotated localArea, bool ignoreEmpty = true, Predicate<TileRef>? predicate = null)
+        {
+            var localAABB = localArea.CalcBoundingBox();
+            return GetLocalTilesIntersecting(localAABB, ignoreEmpty, predicate);
+        }
+
         /// <inheritdoc />
         public IEnumerable<TileRef> GetTilesIntersecting(Box2Rotated worldArea, bool ignoreEmpty = true,
             Predicate<TileRef>? predicate = null)
@@ -325,12 +331,13 @@ namespace Robust.Shared.Map
             }
         }
 
-        private IEnumerable<TileRef> GetLocalTilesIntersecting(Box2 localArea, bool ignoreEmpty, Predicate<TileRef>? predicate)
+        public IEnumerable<TileRef> GetLocalTilesIntersecting(Box2 localArea, bool ignoreEmpty, Predicate<TileRef>? predicate)
         {
             // TODO: Should move the intersecting calls onto mapmanager system and then allow people to pass in xform / xformquery
             // that way we can avoid the GetComp here.
             var gridTileLb = new Vector2i((int)Math.Floor(localArea.Left), (int)Math.Floor(localArea.Bottom));
-            var gridTileRt = new Vector2i((int)Math.Floor(localArea.Right), (int)Math.Floor(localArea.Top));
+            // If we have 20.1 we want to include that tile but if we have 20 then we don't.
+            var gridTileRt = new Vector2i((int)Math.Floor(localArea.Right - float.Epsilon), (int)Math.Floor(localArea.Top - float.Epsilon));
 
             for (var x = gridTileLb.X; x <= gridTileRt.X; x++)
             {

--- a/Robust.Shared/Map/MapGrid.cs
+++ b/Robust.Shared/Map/MapGrid.cs
@@ -337,11 +337,11 @@ namespace Robust.Shared.Map
             // that way we can avoid the GetComp here.
             var gridTileLb = new Vector2i((int)Math.Floor(localArea.Left), (int)Math.Floor(localArea.Bottom));
             // If we have 20.1 we want to include that tile but if we have 20 then we don't.
-            var gridTileRt = new Vector2i((int)Math.Floor(localArea.Right - float.Epsilon), (int)Math.Floor(localArea.Top - float.Epsilon));
+            var gridTileRt = new Vector2i((int)Math.Ceiling(localArea.Right), (int)Math.Ceiling(localArea.Top));
 
-            for (var x = gridTileLb.X; x <= gridTileRt.X; x++)
+            for (var x = gridTileLb.X; x < gridTileRt.X; x++)
             {
-                for (var y = gridTileLb.Y; y <= gridTileRt.Y; y++)
+                for (var y = gridTileLb.Y; y < gridTileRt.Y; y++)
                 {
                     var gridChunk = GridTileToChunkIndices(new Vector2i(x, y));
 


### PR DESCRIPTION
Also made GetTilesIntersecting round down if it's on the very left-most edge of a tile rather than round up, i.e. 20.1 goes to 21, 20 goes to 20. Previously 20 would essentially be treated as 21.