### PR TITLE
Hotfix recursive physics contacts

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -146,7 +146,10 @@ namespace Robust.Shared.GameObjects
 
         private void HandleMapChange(PhysicsComponent body, TransformComponent xform, MapId oldMapId, MapId mapId)
         {
-            DestroyContacts(body, oldMapId);
+            // TODO: Could potentially migrate these but would need more thinking
+            // For now just recursively destroy them
+            RecursiveDestroyContacts(body, oldMapId);
+
             _joints.ClearJoints(body);
 
             // So if the map is being deleted it detaches all of its bodies to null soooo we have this fun check.


### PR DESCRIPTION
Needed for evac shuttle to not crash. Kinda deals with https://github.com/space-wizards/RobustToolbox/issues/2963 but not ideal for large grid movement.

Ideally we'd preserve contacts across maps if it's a grid moving but for now we just destroy them.