### PR TITLE
Maybe fix a placement manager crash

### DIFF
--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -492,7 +492,7 @@ namespace Robust.Client.Placement
         {
             // Try to get current map.
             var map = MapId.Nullspace;
-            if (PlayerManager.LocalPlayer!.ControlledEntity is {Valid: true} ent)
+            if (PlayerManager.LocalPlayer?.ControlledEntity is {Valid: true} ent)
             {
                 map = EntityManager.GetComponent<TransformComponent>(ent).MapID;
             }


### PR DESCRIPTION
[Reported on discord.](https://discord.com/channels/310555209753690112/790656972801572905/988393336245194762)
```
[ERRO] runtime: Caught exception in "GameLoop Update"
System.NullReferenceException: Object reference not set to an instance of an object.
   at Robust.Client.Placement.PlacementManager.CurrentMousePosition(ScreenCoordinates& coordinates) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/Placement/PlacementManager.cs:line 507
   at Robust.Client.Placement.PlacementManager.FrameUpdate(FrameEventArgs e) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/Placement/PlacementManager.cs:line 562
   at Robust.Client.GameController.Update(FrameEventArgs frameEventArgs) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/GameController/GameController.cs:line 533
   at Robust.Shared.Timing.GameLoop.Run() in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 263
```