### PR TITLE
Sprite layer draw depths

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/ISpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/ISpriteComponent.cs
@@ -211,9 +211,9 @@ namespace Robust.Client.GameObjects
         /// </summary>
         RSI? LayerGetActualRSI(object layerKey);
 
-        ISpriteLayer this[int layer] { get; }
-        ISpriteLayer this[Index layer] { get; }
-        ISpriteLayer this[object layerKey] { get; }
+        SpriteComponent.Layer this[int layer] { get; }
+        SpriteComponent.Layer this[Index layer] { get; }
+        SpriteComponent.Layer this[object layerKey] { get; }
 
         IEnumerable<ISpriteLayer> AllLayers { get; }
 

--- a/Robust.Client/GameObjects/Components/Renderable/ISpriteLayer.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/ISpriteLayer.cs
@@ -1,8 +1,10 @@
-﻿using Robust.Client.Graphics;
+using Robust.Client.Graphics;
 using Robust.Shared.Maths;
+using System;
 
 namespace Robust.Client.GameObjects
 {
+    [Obsolete("Use SpriteComponent.Layer directly instead of this")]
     public interface ISpriteLayer
     {
         SpriteComponent.DirectionOffset DirOffset { get; set; }

--- a/Robust.Client/GameObjects/Components/Renderable/ISpriteLayer.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/ISpriteLayer.cs
@@ -36,5 +36,6 @@ namespace Robust.Client.GameObjects
         /// </summary>
         /// <returns>Bounding box in sprite local-space coordinates.</returns>
         Box2 CalculateBoundingBox();
+        int GetDirectionCount();
     }
 }

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1365,7 +1365,7 @@ namespace Robust.Client.GameObjects
         /// </summary>
         private bool HasDirectionalSorting => _comparer.HasDirectionalSorting;
 
-        private Dictionary<RSIDirection, Layer[]> _sortedLayers = new(1);
+        private Layer[]?[] _sortedLayers = new Layer[]?[8];
 
         /// <summary>
         ///     The number of directions that this sprite has. Depends entirely on the sprite's layers & their RSI states.
@@ -1405,14 +1405,16 @@ namespace Robust.Client.GameObjects
         {
             if (LayerOrderDirty)
                 SortLayers();
+            else
+                DebugTools.AssertNotNull(_sortedLayers[0]);
 
             if (!HasDirectionalSorting)
-                return _sortedLayers[RSIDirection.South];
+                return _sortedLayers[(int)RSIDirection.South]!;
 
             if (LayerDirections == RSI.State.DirectionType.Dir4)
                 dir = dir.RoundToCardinal();
 
-            return _sortedLayers[dir];
+            return _sortedLayers[(int)dir]!;
         }
 
         /// <summary>
@@ -1421,15 +1423,14 @@ namespace Robust.Client.GameObjects
         public void SortLayers()
         {
             int i = (int) RSIDirection.South;
-            RSIDirection dir;
-            _sortedLayers.Clear();
+            _sortedLayers = new Layer[]?[8];
             _comparer.HasDirectionalSorting = false;
             do
             {
                 _comparer.Direction = (RSIDirection)i;
                 var arr = Layers.ToArray();
                 Array.Sort(arr, _comparer);
-                _sortedLayers[_comparer.Direction] = arr;
+                _sortedLayers[i] = arr;
                 i++;
             }
             while (HasDirectionalSorting && (i < 4 || LayerDirections == RSI.State.DirectionType.Dir8) && i < 8);

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -590,7 +590,7 @@ namespace Robust.Client.GameObjects
         }
 
         /// <summary>
-        ///     Update <see cref="LayerDirections"/>
+        ///     This function calculates & sets <see cref="LayerDirections"/>
         /// </summary>
         private void UpdateLayerDirections()
         {
@@ -605,6 +605,8 @@ namespace Robust.Client.GameObjects
 
             if (_layerDirections != old && HasDirectionalSorting)
                 LayerOrderDirty = true;
+
+            _layerDirectionsDirty = false;
         }
 
         public void RemoveLayer(object layerKey)

--- a/Robust.Client/Graphics/RSI/RSI.State.cs
+++ b/Robust.Client/Graphics/RSI/RSI.State.cs
@@ -136,17 +136,17 @@ namespace Robust.Client.Graphics
                 /// <summary>
                 ///     A single direction, namely South.
                 /// </summary>
-                Dir1,
+                Dir1 = 1,
 
                 /// <summary>
                 ///     4 cardinal directions.
                 /// </summary>
-                Dir4,
+                Dir4 = 4,
 
                 /// <summary>
                 ///     4 cardinal + 4 diagonal directions.
                 /// </summary>
-                Dir8,
+                Dir8 = 8,
             }
 
             /// <summary>

--- a/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
@@ -78,10 +78,10 @@ namespace Robust.Shared.GameObjects
             public Color? Color;
             [DataField("map")]
             public HashSet<string>? MapKeys;
-
-            // TODO delete this.
-            // requires content PR and I cbf the current PR to a content one.
-            public static PrototypeLayerData New() => new();
+            [DataField("drawDepth")]
+            public int DrawDepth;
+            [DataField("renderOrder")]
+            public int RenderOrder;
         }
     }
 }


### PR DESCRIPTION
Revival of #2582.

This PR adds a draw depths to sprite layers, which determines the order in which they are drawn. It also adds RSI-direction based overrides, so that you could choose to have a layer behind another if an entity is facing a specific direction.
 The change is motivated by https://github.com/space-wizards/space-station-14/issues/4387 and https://github.com/space-wizards/space-station-14/issues/4563,

Previously layers would just get drawn in the order they were added to the sprite's layer list. Now it sorts them based on a draw depth & render order, similar to how entities/sprites get drawn. In order to avoid having to sort a list every time a sprite gets drawn, this caches sorted layer arrays, with one array per relevant direction. Overall this will probably be slightly slower than sprite rendering was before, but not by much.

Also makes some misc sprite/layer changes, like renaming `Layer.RSI` to `Layer.Rsi`, so that it is consistent with `ISpriteLayer.Rsi`

Requires space-wizards/space-station-14/pull/8989
