### PR TITLE
Allow sprites to override container occlusion

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -211,6 +211,7 @@ namespace Robust.Client.GameObjects
         ///     Should this entity show up in containers regardless of whether the container can show contents?
         /// </summary>
         [DataField("overrideContainerOcclusion")]
+        [ViewVariables(VVAccess.ReadWrite)]
         public bool OverrideContainerOcclusion;
 
         [ViewVariables(VVAccess.ReadWrite)]

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -216,11 +216,10 @@ namespace Robust.Client.GameObjects
         [ViewVariables(VVAccess.ReadWrite)]
         public bool ContainerOccluded
         {
-            get => _containerOccluded;
+            get => _containerOccluded || OverrideContainerOcclusion;
             set
             {
                 if (_containerOccluded == value) return;
-                if (OverrideContainerOcclusion) return;
                 _containerOccluded = value;
                 entities.EventBus.RaiseLocalEvent(Owner, new SpriteUpdateEvent());
             }

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -207,6 +207,12 @@ namespace Robust.Client.GameObjects
         [DataField("state", readOnly: true)] private string? state;
         [DataField("texture", readOnly: true)] private string? texture;
 
+        /// <summary>
+        ///     Should this entity show up in containers regardless of whether the container can show contents?
+        /// </summary>
+        [DataField("overrideContainerOcclusion")]
+        public bool OverrideContainerOcclusion;
+
         [ViewVariables(VVAccess.ReadWrite)]
         public bool ContainerOccluded
         {
@@ -214,6 +220,7 @@ namespace Robust.Client.GameObjects
             set
             {
                 if (_containerOccluded == value) return;
+                if (OverrideContainerOcclusion) return;
                 _containerOccluded = value;
                 entities.EventBus.RaiseLocalEvent(Owner, new SpriteUpdateEvent());
             }

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -217,7 +217,7 @@ namespace Robust.Client.GameObjects
         [ViewVariables(VVAccess.ReadWrite)]
         public bool ContainerOccluded
         {
-            get => _containerOccluded || OverrideContainerOcclusion;
+            get => _containerOccluded && !OverrideContainerOcclusion;
             set
             {
                 if (_containerOccluded == value) return;


### PR DESCRIPTION
Needed for content to allow ghosts to not be occluded