### PR TITLE
Fix hotreload

### DIFF
--- a/Robust.Analyzers/AccessAnalyzer.cs
+++ b/Robust.Analyzers/AccessAnalyzer.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
-using Robust.Shared.Analyzers;
+using Robust.Shared.Analyzers.Implementation;
 
 namespace Robust.Analyzers
 {

--- a/Robust.Shared/Analyzers/AccessAttribute.cs
+++ b/Robust.Shared/Analyzers/AccessAttribute.cs
@@ -1,6 +1,10 @@
 using System;
 
+#if NETSTANDARD2_0
+namespace Robust.Shared.Analyzers.Implementation;
+#else
 namespace Robust.Shared.Analyzers;
+#endif
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct
                 | AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Constructor)]

--- a/Robust.Shared/Analyzers/AccessPermissions.cs
+++ b/Robust.Shared/Analyzers/AccessPermissions.cs
@@ -1,6 +1,10 @@
 using System;
 
+#if NETSTANDARD2_0
+namespace Robust.Shared.Analyzers.Implementation;
+#else
 namespace Robust.Shared.Analyzers;
+#endif
 
 [Flags]
 public enum AccessPermissions : byte


### PR DESCRIPTION
Puts AccessPermissions, and AccessAttribute under a different namespace when compiled on Robust.Analysers. This prevents hot reload from getting confused because the same classes appear in two different dlls. Hot reload is still buggy with rider, but it works some of the time after this change. I have better luck using hot reload with run, rather then debug.