### PR TITLE
Fix client crash on sprite layer state change

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -654,6 +654,8 @@ namespace Robust.Client.GameObjects
                     {
                         // Always use south because this layer will be cached in the serializer.
                         layer.AnimationTimeLeft = state.GetDelay(0);
+                        layer.AnimationTime = 0;
+                        layer.AnimationFrame = 0;
                     }
                     else
                     {


### PR DESCRIPTION
Fixes an issue where changing from an animated sprite layer state to another with less frames could cause a client crash to an out of bounds error when getting the frame.