### PR TITLE
Avoid resetting mass

### DIFF
--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
@@ -735,7 +735,6 @@ namespace Robust.Shared.GameObjects
 
         public void ResetMassData(FixturesComponent? fixtures = null)
         {
-            _mass = 0.0f;
             _invMass = 0.0f;
             _inertia = 0.0f;
             InvI = 0.0f;
@@ -746,10 +745,13 @@ namespace Robust.Shared.GameObjects
                 return;
             }
 
+            // We need the mass to not get reset, unless we plan on recalculating it
+            // So it can be used in temperature calculations
+            _mass = 0.0f;
+
             // Temporary until ECS don't @ me.
             fixtures ??= IoCManager.Resolve<IEntityManager>().GetComponent<FixturesComponent>(Owner);
             var localCenter = Vector2.Zero;
-            var shapeManager = _sysMan.GetEntitySystem<FixtureSystem>();
 
             foreach (var (_, fixture) in fixtures.Fixtures)
             {


### PR DESCRIPTION
Bug: When something gets anchored, it becomes static, and the cached mass gets set to 0, and if that thing has a temperature component, it starts getting very hot.

Hack: If something goes from Non-Static to Static, we don't set the mass to 0, so it keeps the mass from before it went static.
I don't see a way the non-zero value could be seen, except on FixturesMass where it's supposed to be exposed.