### PR TITLE
ECS detach to null

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
@@ -149,7 +149,7 @@ namespace Robust.Client.GameObjects
         {
             base.OnParentChanged(ref message);
 
-            var xform = Transform(message.Entity);
+            var xform = message.Transform;
 
             if (xform.MapID != MapId.Nullspace)
                 _updateQueue.Add(message.Entity);

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -1180,6 +1180,17 @@ namespace Robust.Shared.GameObjects
             throw new KeyNotFoundException($"Entity {uid} does not have a component of type {typeof(TComp1)}");
         }
 
+        public bool TryGetComponent([NotNullWhen(true)] EntityUid? uid, [NotNullWhen(true)] out TComp1? component)
+        {
+            if (uid == null)
+            {
+                component = default;
+                return false;
+            }
+            else
+                return TryGetComponent(uid.Value, out component);
+        }
+
         public bool TryGetComponent(EntityUid uid, [NotNullWhen(true)] out TComp1? component)
         {
             if (_traitDict.TryGetValue(uid, out var comp) && !comp.Deleted)

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -272,6 +272,10 @@ namespace Robust.Shared.GameObjects
         /// <param name="e">Entity to remove</param>
         public virtual void DeleteEntity(EntityUid e)
         {
+            // Some UIs get dispose after entity-manager has shut down and already deleted all entities.
+            if (!Started)
+                return;
+
             var metaQuery = GetEntityQuery<MetaDataComponent>();
             var xformQuery = GetEntityQuery<TransformComponent>();
             var xformSys = EntitySysManager.GetEntitySystem<SharedTransformSystem>();

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -272,10 +272,14 @@ namespace Robust.Shared.GameObjects
         /// <param name="e">Entity to remove</param>
         public virtual void DeleteEntity(EntityUid e)
         {
+            var metaQuery = GetEntityQuery<MetaDataComponent>();
+            var xformQuery = GetEntityQuery<TransformComponent>();
+            var xformSys = EntitySysManager.GetEntitySystem<SharedTransformSystem>();
+
             // Networking blindly spams entities at this function, they can already be
             // deleted from being a child of a previously deleted entity
             // TODO: Why does networking need to send deletes for child entities?
-            if (!_entTraitArray[CompIdx.ArrayIndex<MetaDataComponent>()].TryGetValue(e, out var comp)
+            if (!metaQuery.TryGetComponent(e, out var comp)
                 || comp is not MetaDataComponent meta || meta.EntityDeleted)
                 return;
 
@@ -285,29 +289,28 @@ namespace Robust.Shared.GameObjects
 #else
                 return;
 #endif
-
-            RecursiveDeleteEntity(e);
+            RecursiveDeleteEntity(meta, metaQuery, xformQuery, xformSys);
         }
 
-        private void RecursiveDeleteEntity(EntityUid uid)
+        private void RecursiveDeleteEntity(MetaDataComponent metadata, EntityQuery<MetaDataComponent> metaQuery, EntityQuery<TransformComponent> xformQuery, SharedTransformSystem xformSys)
         {
-            if (!TryGetComponent(uid, out MetaDataComponent? metadata) || metadata.EntityDeleted)
-                return; //TODO: Why was this still a child if it was already deleted?
-
-            var transform = GetComponent<TransformComponent>(uid);
+            var transform = xformQuery.GetComponent(metadata.Owner);
             metadata.EntityLifeStage = EntityLifeStage.Terminating;
-            var ev = new EntityTerminatingEvent(uid);
-            EventBus.RaiseLocalEvent(uid, ref ev, false);
+            var ev = new EntityTerminatingEvent(metadata.Owner);
+            EventBus.RaiseLocalEvent(metadata.Owner, ref ev, false);
 
             // DeleteEntity modifies our _children collection, we must cache the collection to iterate properly
             foreach (var child in transform._children.ToArray())
             {
+                if (!metaQuery.TryGetComponent(child, out var childMeta) || childMeta.EntityDeleted)
+                    continue; //TODO: Why was this still a child if it was already deleted?
+
                 // Recursion Alert
-                RecursiveDeleteEntity(child);
+                RecursiveDeleteEntity(childMeta, metaQuery, xformQuery, xformSys);
             }
 
             // Shut down all components.
-            foreach (var component in InSafeOrder(_entCompIndex[uid]))
+            foreach (var component in InSafeOrder(_entCompIndex[metadata.Owner]))
             {
                 if(component.Running)
                     component.LifeShutdown(this);
@@ -317,17 +320,17 @@ namespace Robust.Shared.GameObjects
             if (transform.ParentUid != EntityUid.Invalid)
             {
                 // Detach from my parent, if any
-                transform.DetachParentToNull();
+                xformSys.DetachParentToNull(transform, xformQuery, metaQuery);
             }
 
             // Dispose all my components, in a safe order so transform is available
-            DisposeComponents(uid);
+            DisposeComponents(metadata.Owner);
 
             metadata.EntityLifeStage = EntityLifeStage.Deleted;
-            EntityDeleted?.Invoke(uid);
-            _eventBus.OnEntityDeleted(uid);
-            EventBus.RaiseEvent(EventSource.Local, new EntityDeletedMessage(uid));
-            Entities.Remove(uid);
+            EntityDeleted?.Invoke(metadata.Owner);
+            _eventBus.OnEntityDeleted(metadata.Owner);
+            EventBus.RaiseEvent(EventSource.Local, new EntityDeletedMessage(metadata.Owner));
+            Entities.Remove(metadata.Owner);
         }
 
         public void QueueDeleteEntity(EntityUid uid)

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -120,7 +120,9 @@ namespace Robust.Shared.GameObjects
             {
                 RemoveFromEntityTree(args.Entity);
             }
-            else if (EntityManager.TryGetComponent(args.Entity, out MetaDataComponent? meta) && meta.EntityLifeStage < EntityLifeStage.Terminating)
+            else if (!args.Detaching &&
+                TryComp(args.Entity, out MetaDataComponent? meta) &&
+                meta.EntityLifeStage < EntityLifeStage.Terminating)
             {
                 var xformQuery = GetEntityQuery<TransformComponent>();
                 var xform = xformQuery.GetComponent(args.Entity);
@@ -276,7 +278,7 @@ namespace Robust.Shared.GameObjects
                 _mapManager.IsMap(args.Entity)) return;
 
             var xformQuery = GetEntityQuery<TransformComponent>();
-            var xform = xformQuery.GetComponent(args.Entity);
+            var xform = args.Transform;
             EntityLookupComponent? oldLookup = null;
 
             if (args.OldParent != null)

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -135,8 +135,10 @@ namespace Robust.Shared.GameObjects
         {
             var meta = MetaData(uid);
 
-            if (meta.EntityLifeStage < EntityLifeStage.Initialized || !TryComp(uid, out TransformComponent? xform))
+            if (meta.EntityLifeStage < EntityLifeStage.Initialized)
                 return;
+
+            var xform = args.Transform;
 
             // TODO: need to suss out this particular bit + containers + body.Broadphase.
             _broadphase.UpdateBroadphase(body, xform: xform);

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -367,8 +367,7 @@ public abstract partial class SharedTransformSystem
             {
                 if (!newParentId.IsValid())
                 {
-                    component.DetachParentToNull();
-                    return;
+                    DetachParentToNull(component);
                 }
                 else
                 {
@@ -676,4 +675,74 @@ public abstract partial class SharedTransformSystem
 
         return xform.MapID;
     }
+
+    #region State Handling
+    private void ChangeMapId(TransformComponent xform, MapId newMapId, EntityQuery<TransformComponent> xformQuery, EntityQuery<MetaDataComponent> metaQuery)
+    {
+        if (newMapId == xform.MapID)
+            return;
+
+        //Set Paused state
+        var mapPaused = _mapManager.IsMapPaused(newMapId);
+        var meta = metaQuery.GetComponent(xform.Owner);
+        _metaSys.SetEntityPaused(xform.Owner, mapPaused, meta);
+
+        xform.MapID = newMapId;
+        xform.UpdateChildMapIdsRecursive(xform.MapID, mapPaused, xformQuery, metaQuery, _metaSys);
+    }
+
+    public void DetachParentToNull(TransformComponent xform)
+    {
+        if (xform._parent.IsValid())
+            DetachParentToNull(xform, GetEntityQuery<TransformComponent>(), GetEntityQuery<MetaDataComponent>());
+        else
+            DebugTools.Assert(!xform.Anchored);
+    }
+
+    public void DetachParentToNull(TransformComponent xform, EntityQuery<TransformComponent> xformQuery, EntityQuery<MetaDataComponent> metaQuery)
+    {
+        var oldParent = xform._parent;
+
+        // Even though they may already be in nullspace we may want to deparent them anyway
+        if (!oldParent.IsValid())
+        {
+            DebugTools.Assert(!xform.Anchored);
+            return;
+        }
+
+        // Stop any active lerps
+        xform._nextPosition = null;
+        xform._nextRotation = null;
+        xform.LerpParent = EntityUid.Invalid;
+
+        if (xform.Anchored && metaQuery.TryGetComponent(xform.GridUid, out var meta) && meta.EntityLifeStage <= EntityLifeStage.MapInitialized)
+        {
+            var grid = Comp<IMapGridComponent>(xform.GridUid.Value);
+            var tileIndices = grid.Grid.TileIndicesFor(xform.Coordinates);
+            grid.Grid.RemoveFromSnapGridCell(tileIndices, xform.Owner);
+
+            // intentionally not updating physics body type to non-static, there is no need to add it to the current map.
+
+            xform._anchored = false;
+            var anchorStateChangedEvent = new AnchorStateChangedEvent(xform, true);
+            RaiseLocalEvent(xform.Owner, ref anchorStateChangedEvent, true);
+        }
+
+        var oldConcrete = xformQuery.GetComponent(oldParent);
+        oldConcrete._children.Remove(xform.Owner);
+
+        xform._parent = EntityUid.Invalid;
+        var oldMap = xform.MapID;
+
+        // aaaaaaaaaaaaaaaa
+        ChangeMapId(xform, MapId.Nullspace, xformQuery, metaQuery);
+
+        if (xform.GridUid != null)
+            SetGridId(xform, null, xformQuery);
+
+        var entParentChangedMessage = new EntParentChangedMessage(xform.Owner, oldParent, oldMap, xform);
+        RaiseLocalEvent(xform.Owner, ref entParentChangedMessage, true);
+        Dirty(xform);
+    }
+    #endregion
 }

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -14,6 +14,7 @@ namespace Robust.Shared.GameObjects
     {
         [Dependency] private readonly IMapManager _mapManager = default!;
         [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
+        [Dependency] private readonly MetaDataSystem _metaSys = default!;
 
         // Needed on release no remove.
         // ReSharper disable once NotAccessedField.Local

--- a/Robust.Shared/Map/MapManager.GridTrees.cs
+++ b/Robust.Shared/Map/MapManager.GridTrees.cs
@@ -151,7 +151,7 @@ internal partial class MapManager
             : EntityManager.GetComponent<TransformComponent>(args.OldParent.Value).MapID;
 
         // Make sure we cleanup old map for moved grid stuff.
-        var mapId = EntityManager.GetComponent<TransformComponent>(uid).MapID;
+        var mapId = args.Transform.MapID;
 
         // y'all need jesus
         if (oldMapId == mapId) return;


### PR DESCRIPTION
Moves the `TransformComponent.DetachParentToNull()` over to the system. Should slightly speed up both entity deletion for servers/explosions and client-side PVS detatching. 