### PR TITLE
Warn on startup if bad glibc version is detected.

### DIFF
--- a/Robust.Client/GameController/GameController.Standalone.cs
+++ b/Robust.Client/GameController/GameController.Standalone.cs
@@ -32,6 +32,8 @@ namespace Robust.Client
                 throw new InvalidOperationException("Cannot start twice!");
             }
 
+            GlibcBug.Check();
+
             _hasStarted = true;
 
             if (CommandLineArgs.TryParse(args, out var parsed))

--- a/Robust.Server/Program.cs
+++ b/Robust.Server/Program.cs
@@ -10,6 +10,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Asynchronous;
 using Robust.Shared.Reflection;
+using Robust.Shared.Utility;
 
 namespace Robust.Server
 {
@@ -30,6 +31,8 @@ namespace Robust.Server
             {
                 throw new InvalidOperationException("Cannot start twice!");
             }
+
+            GlibcBug.Check();
 
             _hasStarted = true;
 

--- a/Robust.Shared/Utility/GlibcBug.cs
+++ b/Robust.Shared/Utility/GlibcBug.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Runtime.InteropServices;
+using C = System.Console;
+
+namespace Robust.Shared.Utility;
+
+internal static unsafe class GlibcBug
+{
+    /// <summary>
+    /// Check for the glibc 2.35 DSO bug and log a warning if necessary.
+    /// </summary>
+    public static void Check()
+    {
+        if (!OperatingSystem.IsLinux())
+            return;
+
+        try
+        {
+            var versionString = Marshal.PtrToStringUTF8((IntPtr) gnu_get_libc_version());
+            var version = Version.Parse(versionString!);
+            var badVersion = new Version(2, 35);
+            if (version >= badVersion)
+            {
+                C.ForegroundColor = ConsoleColor.Yellow;
+                C.WriteLine($"!!!WARNING!!!: glibc {badVersion} or higher detected (you have {version}).");
+                C.WriteLine("If anything misbehaves (weird native crashes, library load failures), try setting GLIBC_TUNABLES=glibc.rtld.dynamic_sort=1 as environment variable.");
+                C.WriteLine("This is a severe glibc bug introduced in glibc 2.35. See https://github.com/space-wizards/RobustToolbox/issues/2563 for details");
+                C.ResetColor();
+            }
+        }
+        catch
+        {
+            // Couldn't figure out glibc version, whatever.
+            // Hell maybe you're not even using glibc.
+        }
+    }
+
+    [DllImport("libc.so.6")]
+    private static extern byte* gnu_get_libc_version();
+}


### PR DESCRIPTION
Yay.

See #2563. I've had enough Linux devs running into this trying to run the game that I feel this is important enough to mention.