### PR TITLE
Prevent dirty-on-init

### DIFF
--- a/Robust.Shared/Containers/BaseContainer.cs
+++ b/Robust.Shared/Containers/BaseContainer.cs
@@ -60,6 +60,7 @@ namespace Robust.Shared.Containers
             DebugTools.Assert(!Deleted);
             DebugTools.Assert(transform == null || transform.Owner == toinsert);
             DebugTools.Assert(ownerTransform == null || ownerTransform.Owner == Owner);
+            DebugTools.Assert(meta == null || meta.Owner == toinsert);
             IoCManager.Resolve(ref entMan);
 
             //Verify we can insert into this container
@@ -72,10 +73,13 @@ namespace Robust.Shared.Containers
             if (toinsert.TryGetContainerMan(out var containerManager, entMan) && !containerManager.Remove(toinsert))
                 return false; // Can't remove from existing container, can't insert.
 
-            // Attach to parent first so we can check IsInContainer more easily.
+            // Update metadata first, so that parent change events can check IsInContainer.
+            meta ??= entMan.GetComponent<MetaDataComponent>(toinsert);
+            meta.Flags |= MetaDataFlags.InContainer;
+
             ownerTransform ??= entMan.GetComponent<TransformComponent>(Owner);
             transform.AttachParent(ownerTransform);
-            InternalInsert(toinsert, entMan, meta);
+            InternalInsert(toinsert, entMan);
 
             // This is an edge case where the parent grid is the container being inserted into, so AttachParent would not unanchor.
             if (transform.Anchored)
@@ -196,13 +200,9 @@ namespace Robust.Shared.Containers
         /// </summary>
         /// <param name="toinsert"></param>
         /// <param name="entMan"></param>
-        protected virtual void InternalInsert(EntityUid toinsert, IEntityManager entMan, MetaDataComponent? meta = null)
+        protected virtual void InternalInsert(EntityUid toinsert, IEntityManager entMan)
         {
             DebugTools.Assert(!Deleted);
-            DebugTools.Assert(meta == null || meta.Owner == toinsert);
-
-            meta ??= entMan.GetComponent<MetaDataComponent>(toinsert);
-            meta.Flags |= MetaDataFlags.InContainer;
             entMan.EventBus.RaiseLocalEvent(Owner, new EntInsertedIntoContainerMessage(toinsert, this), true);
             Manager.Dirty(entMan);
         }
@@ -223,6 +223,7 @@ namespace Robust.Shared.Containers
             meta ??= entMan.GetComponent<MetaDataComponent>(toremove);
             meta.Flags &= ~MetaDataFlags.InContainer;
             entMan.EventBus.RaiseLocalEvent(Owner, new EntRemovedFromContainerMessage(toremove, this), true);
+            entMan.EventBus.RaiseLocalEvent(toremove, new EntGotRemovedFromContainerMessage(toremove, this), false);
             Manager.Dirty(entMan);
         }
     }

--- a/Robust.Shared/Containers/Container.cs
+++ b/Robust.Shared/Containers/Container.cs
@@ -36,10 +36,10 @@ namespace Robust.Shared.Containers
         public override string ContainerType => ClassName;
 
         /// <inheritdoc />
-        protected override void InternalInsert(EntityUid toinsert, IEntityManager entMan, MetaDataComponent? meta = null)
+        protected override void InternalInsert(EntityUid toinsert, IEntityManager entMan)
         {
             _containerList.Add(toinsert);
-            base.InternalInsert(toinsert, entMan, meta);
+            base.InternalInsert(toinsert, entMan);
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/Containers/ContainerSlot.cs
+++ b/Robust.Shared/Containers/ContainerSlot.cs
@@ -79,10 +79,10 @@ namespace Robust.Shared.Containers
         }
 
         /// <inheritdoc />
-        protected override void InternalInsert(EntityUid toinsert, IEntityManager entMan, MetaDataComponent? meta = null)
+        protected override void InternalInsert(EntityUid toinsert, IEntityManager entMan)
         {
             ContainedEntity = toinsert;
-            base.InternalInsert(toinsert, entMan, meta);
+            base.InternalInsert(toinsert, entMan);
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/Containers/Events/EntRemovedFromContainerMessage.cs
+++ b/Robust.Shared/Containers/Events/EntRemovedFromContainerMessage.cs
@@ -4,11 +4,20 @@ using Robust.Shared.GameObjects;
 namespace Robust.Shared.Containers
 {
     /// <summary>
-    /// Raised when an entity is removed from a container.
+    /// Raised when an entity is removed from a container. Directed at the container.
     /// </summary>
     [PublicAPI]
     public sealed class EntRemovedFromContainerMessage : ContainerModifiedMessage
     {
         public EntRemovedFromContainerMessage(EntityUid entity, IContainer container) : base(entity, container) { }
+    }
+
+    /// <summary>
+    /// Raised when an entity is removed from a container. Directed at the entity.
+    /// </summary>
+    [PublicAPI]
+    public sealed class EntGotRemovedFromContainerMessage : ContainerModifiedMessage
+    {
+        public EntGotRemovedFromContainerMessage(EntityUid entity, IContainer container) : base(entity, container) { }
     }
 }

--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
@@ -611,7 +611,7 @@ namespace Robust.Shared.GameObjects
             }
         }
 
-        private float _angularVelocity;
+        internal float _angularVelocity;
 
         /// <summary>
         ///     Current momentum of the entity in kilogram meters per second

--- a/Robust.Shared/GameObjects/Systems/CollisionWakeSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/CollisionWakeSystem.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.GameStates;
+using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
 
@@ -6,6 +7,8 @@ namespace Robust.Shared.GameObjects
 {
     public sealed class CollisionWakeSystem : EntitySystem
     {
+        [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -71,12 +74,12 @@ namespace Robust.Shared.GameObjects
 
         internal void OnPhysicsInit(EntityUid uid, CollisionWakeComponent component)
         {
-            UpdateCanCollide(uid, component, checkTerminating: false);
+            UpdateCanCollide(uid, component, checkTerminating: false, dirty: false);
         }
 
         private void OnJointRemove(EntityUid uid, CollisionWakeComponent component, JointRemovedEvent args)
         {
-            UpdateCanCollide(uid, component, args.OurBody);
+            UpdateCanCollide(uid, component, (PhysicsComponent) args.OurBody);
         }
 
         private void OnJointAdd(EntityUid uid, CollisionWakeComponent component, JointAddedEvent args)
@@ -99,9 +102,10 @@ namespace Robust.Shared.GameObjects
         private void UpdateCanCollide(
             EntityUid uid,
             CollisionWakeComponent component,
-            IPhysBody? body = null,
+            PhysicsComponent? body = null,
             TransformComponent? xform = null,
-            bool checkTerminating = true)
+            bool checkTerminating = true,
+            bool dirty = true)
         {
             if (!component.Enabled)
                 return;
@@ -115,9 +119,11 @@ namespace Robust.Shared.GameObjects
                 return;
 
             // If we're attached to the map we'll also just never disable collision due to how grid movement works.
-            body.CanCollide = body.Awake ||
+            var canCollide = body.Awake ||
                               (TryComp(uid, out JointComponent? jointComponent) && jointComponent.JointCount > 0) ||
                               xform.GridUid == null;
+
+            _physics.SetCanCollide(body, canCollide, dirty);
         }
     }
 }

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.Components.cs
@@ -1,4 +1,5 @@
 using System;
+using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
@@ -13,9 +14,16 @@ public partial class SharedPhysicsSystem
 {
     [Dependency] private readonly CollisionWakeSystem _collisionWakeSystem = default!;
     [Dependency] private readonly FixtureSystem _fixtureSystem = default!;
+    [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
+
     private void OnPhysicsInit(EntityUid uid, PhysicsComponent component, ComponentInit args)
     {
         var xform = Transform(uid);
+
+        if (component.CanCollide && _containerSystem.IsEntityInContainer(uid))
+        {
+            SetCanCollide(component, false, false);
+        }
 
         if (component._canCollide && xform.MapID != MapId.Nullspace)
         {
@@ -49,8 +57,8 @@ public partial class SharedPhysicsSystem
         // Issue the event for stuff that needs it.
         if (component._canCollide)
         {
-            component._canCollide = false;
-            component.CanCollide = true;
+            var ev = new CollisionChangeEvent(component, true);
+            RaiseLocalEvent(ref ev);
         }
     }
 
@@ -100,7 +108,7 @@ public partial class SharedPhysicsSystem
     /// </summary>
     /// <param name="body"></param>
     /// <param name="velocity"></param>
-    public void SetLinearVelocity(PhysicsComponent body, Vector2 velocity)
+    public void SetLinearVelocity(PhysicsComponent body, Vector2 velocity, bool dirty = true)
     {
         if (body.BodyType == BodyType.Static) return;
 
@@ -112,7 +120,49 @@ public partial class SharedPhysicsSystem
             return;
 
         body._linearVelocity = velocity;
-        Dirty(body);
+
+        if (dirty)
+            Dirty(body);
+    }
+
+    public void SetAngularVelocity(PhysicsComponent body, float value, bool dirty = true)
+    {
+        if (body.BodyType == BodyType.Static)
+            return;
+
+        if (value * value > 0.0f)
+            body.Awake = true;
+
+        // CloseToPercent tolerance needs to be small enough such that an angular velocity just above
+        // sleep-tolerance can damp down to sleeping.
+
+        if (MathHelper.CloseToPercent(body._angularVelocity, value, 0.00001f))
+            return;
+
+        body._angularVelocity = value;
+
+        if (dirty)
+            Dirty(body);
+    }
+
+    public void SetCanCollide(PhysicsComponent body, bool value, bool dirty = true)
+    {
+        if (body._canCollide == value)
+            return;
+
+        // If we're recursively in a container then never set this.
+        if (value && _containerSystem.IsEntityOrParentInContainer(body.Owner))
+            return;
+
+        if (!value)
+            body.Awake = false;
+
+        body._canCollide = value;
+        var ev = new CollisionChangeEvent(body, value);
+        RaiseLocalEvent(ref ev);
+
+        if (dirty)
+            Dirty(body);
     }
 
     public Box2 GetWorldAABB(PhysicsComponent body, TransformComponent xform, EntityQuery<TransformComponent> xforms, EntityQuery<FixturesComponent> fixtures)

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -70,8 +70,7 @@ namespace Robust.Shared.GameObjects
             SubscribeLocalEvent<PhysicsWakeEvent>(OnWake);
             SubscribeLocalEvent<PhysicsSleepEvent>(OnSleep);
             SubscribeLocalEvent<CollisionChangeEvent>(OnCollisionChange);
-            SubscribeLocalEvent<EntInsertedIntoContainerMessage>(HandleContainerInserted);
-            SubscribeLocalEvent<EntRemovedFromContainerMessage>(HandleContainerRemoved);
+            SubscribeLocalEvent<PhysicsComponent, EntGotRemovedFromContainerMessage>(HandleContainerRemoved);
             SubscribeLocalEvent<PhysicsComponent, EntParentChangedMessage>(OnParentChange);
             SubscribeLocalEvent<SharedPhysicsMapComponent, ComponentInit>(HandlePhysicsMapInit);
             SubscribeLocalEvent<SharedPhysicsMapComponent, ComponentRemove>(HandlePhysicsMapRemove);
@@ -139,6 +138,17 @@ namespace Robust.Shared.GameObjects
                 return;
 
             var xform = args.Transform;
+
+            if ((meta.Flags & MetaDataFlags.InContainer) != 0)
+            {
+                // Here we intentionally dont dirty the physics comp. Client-side state handling will apply these same
+                // changes. This also ensures that the server doesn't have to send the physics comp state to every
+                // player for any entity inside of a container during init.
+                SetLinearVelocity(body, Vector2.Zero, false);
+                SetAngularVelocity(body, 0, false);
+                _joints.ClearJoints(body);
+                SetCanCollide(body, false, false);
+            }
 
             // TODO: need to suss out this particular bit + containers + body.Broadphase.
             _broadphase.UpdateBroadphase(body, xform: xform);
@@ -263,23 +273,12 @@ namespace Robust.Shared.GameObjects
             EntityManager.GetComponent<SharedPhysicsMapComponent>(tempQualifier).RemoveSleepBody(@event.Body);
         }
 
-        private void HandleContainerInserted(EntInsertedIntoContainerMessage message)
-        {
-            if (!EntityManager.TryGetComponent(message.Entity, out PhysicsComponent? physicsComponent)) return;
-
-            physicsComponent.LinearVelocity = Vector2.Zero;
-            physicsComponent.AngularVelocity = 0.0f;
-            _joints.ClearJoints(physicsComponent);
-            physicsComponent.CanCollide = false;
-        }
-
-        private void HandleContainerRemoved(EntRemovedFromContainerMessage message)
+        private void HandleContainerRemoved(EntityUid uid, PhysicsComponent physics, EntGotRemovedFromContainerMessage message)
         {
             // If entity being deleted then the parent change will already be handled elsewhere and we don't want to re-add it to the map.
-            if (!EntityManager.TryGetComponent(message.Entity, out PhysicsComponent? physicsComponent) ||
-                MetaData(message.Entity).EntityLifeStage >= EntityLifeStage.Terminating) return;
+            if (MetaData(uid).EntityLifeStage >= EntityLifeStage.Terminating) return;
 
-            physicsComponent.WakeBody();
+            SetCanCollide(physics, true, false);
         }
 
         /// <summary>

--- a/Robust.Shared/Physics/FixtureSystem.cs
+++ b/Robust.Shared/Physics/FixtureSystem.cs
@@ -251,7 +251,7 @@ namespace Robust.Shared.Physics
                 }
 
                 // Make sure all the right stuff is set on the body
-                FixtureUpdate(component);
+                FixtureUpdate(component, body, false);
 
                 if (body.CanCollide)
                 {
@@ -416,7 +416,7 @@ namespace Robust.Shared.Physics
         /// <summary>
         /// Updates all of the cached physics information on the body derived from fixtures.
         /// </summary>
-        public void FixtureUpdate(FixturesComponent component, PhysicsComponent? body = null)
+        public void FixtureUpdate(FixturesComponent component, PhysicsComponent? body = null, bool dirty = true)
         {
             if (!Resolve(component.Owner, ref body))
                 return;
@@ -438,7 +438,8 @@ namespace Robust.Shared.Physics
             body.CollisionMask = mask;
             body.CollisionLayer = layer;
             body.Hard = hard;
-            Dirty(component);
+            if (dirty)
+                Dirty(component);
         }
 
         [Serializable, NetSerializable]

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -65,8 +65,6 @@ namespace Robust.Shared.Physics
             SubscribeLocalEvent<BroadphaseComponent, ComponentAdd>(OnBroadphaseAdd);
             SubscribeLocalEvent<GridAddEvent>(OnGridAdd);
 
-            SubscribeLocalEvent<EntInsertedIntoContainerMessage>(HandleContainerInsert);
-            SubscribeLocalEvent<EntRemovedFromContainerMessage>(HandleContainerRemove);
             SubscribeLocalEvent<CollisionChangeEvent>(OnPhysicsUpdate);
 
             SubscribeLocalEvent<PhysicsComponent, MoveEvent>(OnMove);
@@ -802,24 +800,6 @@ namespace Robust.Shared.Physics
             }
 
             fixture.ProxyCount = 0;
-        }
-
-        private void HandleContainerInsert(EntInsertedIntoContainerMessage ev)
-        {
-            if (!EntityManager.TryGetComponent(ev.Entity, out PhysicsComponent? physicsComponent) ||
-                physicsComponent.LifeStage > ComponentLifeStage.Running) return;
-
-            physicsComponent.CanCollide = false;
-            physicsComponent.Awake = false;
-        }
-
-        private void HandleContainerRemove(EntRemovedFromContainerMessage ev)
-        {
-            if (!EntityManager.TryGetComponent(ev.Entity, out PhysicsComponent? physicsComponent) ||
-                physicsComponent.LifeStage > ComponentLifeStage.Running) return;
-
-            physicsComponent.CanCollide = true;
-            physicsComponent.Awake = true;
         }
 
         public override void Shutdown()

--- a/Robust.UnitTesting/Server/GameObjects/Components/Container_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/Components/Container_Test.cs
@@ -304,10 +304,10 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
             public override List<EntityUid> ExpectedEntities => _expectedEntities;
 
             /// <inheritdoc />
-            protected override void InternalInsert(EntityUid toinsert, IEntityManager entMan, MetaDataComponent? meta = null)
+            protected override void InternalInsert(EntityUid toinsert, IEntityManager entMan)
             {
                 _containerList.Add(toinsert);
-                base.InternalInsert(toinsert, entMan, meta);
+                base.InternalInsert(toinsert, entMan);
             }
 
             /// <inheritdoc />


### PR DESCRIPTION
This PR makes various changes to avoid unnecessarily dirtying components during initialization.

Several components, most notably physics & fixtures, are being consistently dirtied during initialization. This means that for something like a wall, the server has to initially send the meta-data, xform, physics and fixture states to every player, instead of only the xform & meta-data.

This also changes the order in which container-insertion metadata updating occurs. Now the in-container meta-data flag gets set BEFORE the parent changes. AFAIK this shouldn't break anything, and based on a comment is apparently how it should have been done in the first place. 