### PR TITLE
Moves fixture check in physics

### DIFF
--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
@@ -762,7 +762,7 @@ namespace Robust.Shared.GameObjects
                 localCenter += data.Center * data.Mass;
                 _inertia += data.I;
             }
-
+			// Update this after re-calculating mass as content may want to use the sum of fixture masses instead.
             if (((int) _bodyType & (int) (BodyType.Kinematic | BodyType.Static)) != 0)
             {
                 return;

--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
@@ -746,11 +746,6 @@ namespace Robust.Shared.GameObjects
             InvI = 0.0f;
             _localCenter = Vector2.Zero;
 
-            if (((int) _bodyType & (int) (BodyType.Kinematic | BodyType.Static)) != 0)
-            {
-                return;
-            }
-
             // Temporary until ECS don't @ me.
             fixtures ??= IoCManager.Resolve<IEntityManager>().GetComponent<FixturesComponent>(Owner);
             var localCenter = Vector2.Zero;
@@ -766,6 +761,11 @@ namespace Robust.Shared.GameObjects
                 _mass += data.Mass;
                 localCenter += data.Center * data.Mass;
                 _inertia += data.I;
+            }
+
+            if (((int) _bodyType & (int) (BodyType.Kinematic | BodyType.Static)) != 0)
+            {
+                return;
             }
 
             if (_mass > 0.0f)

--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
@@ -749,7 +749,6 @@ namespace Robust.Shared.GameObjects
             // Temporary until ECS don't @ me.
             fixtures ??= IoCManager.Resolve<IEntityManager>().GetComponent<FixturesComponent>(Owner);
             var localCenter = Vector2.Zero;
-            var shapeManager = _sysMan.GetEntitySystem<FixtureSystem>();
 
             foreach (var (_, fixture) in fixtures.Fixtures)
             {
@@ -762,7 +761,8 @@ namespace Robust.Shared.GameObjects
                 localCenter += data.Center * data.Mass;
                 _inertia += data.I;
             }
-			// Update this after re-calculating mass as content may want to use the sum of fixture masses instead.
+
+            // Update this after re-calculating mass as content may want to use the sum of fixture masses instead.
             if (((int) _bodyType & (int) (BodyType.Kinematic | BodyType.Static)) != 0)
             {
                 return;


### PR DESCRIPTION
client side PR that needs this: https://github.com/space-wizards/space-station-14/pull/8584

Reorders the fixture check so that it fixes an infinite temperature bug if a player was set to anchored.