### PR TITLE
Lookup & dynamic tree changes

### DIFF
--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
@@ -256,10 +256,12 @@ namespace Robust.Shared.GameObjects
         {
             var bounds = new Box2(transform.Position, transform.Position);
 
+            // TODO cache this to speed up entity lookups & tree updating
             foreach (var fixture in _entMan.GetComponent<FixturesComponent>(Owner).Fixtures.Values)
             {
                 for (var i = 0; i < fixture.Shape.ChildCount; i++)
                 {
+                    // TODO don't transform each fixture, just transform the final AABB
                     var boundy = fixture.Shape.ComputeAABB(transform, i);
                     bounds = bounds.Union(boundy);
                 }

--- a/Robust.Shared/GameObjects/Components/EntityLookupComponent.cs
+++ b/Robust.Shared/GameObjects/Components/EntityLookupComponent.cs
@@ -5,6 +5,6 @@ namespace Robust.Shared.GameObjects
     [RegisterComponent]
     public sealed class EntityLookupComponent : Component
     {
-        internal DynamicTree<EntityUid> Tree = default!;
+        public DynamicTree<EntityUid> Tree = default!;
     }
 }

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -63,7 +63,7 @@ public sealed partial class EntityLookupSystem
         var lookup = lookupQuery.GetComponent(lookupUid);
         var localAABB = xformQuery.GetComponent(lookupUid).InvWorldMatrix.TransformBox(worldAABB);
 
-        foreach (var uid in lookup.Tree.QueryAabb(localAABB))
+        foreach (var uid in lookup.Tree.QueryAabb(localAABB, (flags & LookupFlags.Approximate) != 0x0))
         {
             if (uid == ignored) continue;
             return true;
@@ -613,14 +613,14 @@ public sealed partial class EntityLookupSystem
         var xformQuery = GetEntityQuery<TransformComponent>();
         var localAABB = xformQuery.GetComponent(component.Owner).InvWorldMatrix.TransformBox(worldAABB);
 
-        foreach (var uid in component.Tree.QueryAabb(localAABB))
+        foreach (var uid in component.Tree.QueryAabb(localAABB, (flags & LookupFlags.Approximate) != 0x0))
         {
             intersecting.Add(uid);
         }
 
-        if ((flags & LookupFlags.Anchored) != 0x0 && _mapManager.IsGrid(component.Owner))
+        if ((flags & LookupFlags.Anchored) != 0x0 && _mapManager.TryGetGrid(component.Owner, out var grid))
         {
-            foreach (var uid in _mapManager.GetGrid(component.Owner).GetLocalAnchoredEntities(localAABB))
+            foreach (var uid in grid.GetLocalAnchoredEntities(localAABB))
             {
                 intersecting.Add(uid);
             }
@@ -635,14 +635,14 @@ public sealed partial class EntityLookupSystem
     {
         var intersecting = new HashSet<EntityUid>();
 
-        foreach (var uid in component.Tree.QueryAabb(localAABB))
+        foreach (var uid in component.Tree.QueryAabb(localAABB, (flags & LookupFlags.Approximate) != 0x0))
         {
             intersecting.Add(uid);
         }
 
-        if ((flags & LookupFlags.Anchored) != 0x0 && _mapManager.IsGrid(component.Owner))
+        if ((flags & LookupFlags.Anchored) != 0x0 && _mapManager.TryGetGrid(component.Owner, out var grid))
         {
-            foreach (var uid in _mapManager.GetGrid(component.Owner).GetLocalAnchoredEntities(localAABB))
+            foreach (var uid in grid.GetLocalAnchoredEntities(localAABB))
             {
                 intersecting.Add(uid);
             }

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -168,7 +168,7 @@ namespace Robust.Shared.GameObjects
             }
 
             component.Tree = new DynamicTree<EntityUid>(
-                GetTreeAABB,
+                (in EntityUid e) => GetTreeAABB(e, component.Owner),
                 capacity: capacity,
                 growthFunc: x => x == GrowthRate ? GrowthRate * 8 : x * 2
             );
@@ -184,17 +184,15 @@ namespace Robust.Shared.GameObjects
             EntityManager.EnsureComponent<EntityLookupComponent>(_mapManager.GetMapEntityId(eventArgs.Map));
         }
 
-        private Box2 GetTreeAABB(in EntityUid entity)
+        private Box2 GetTreeAABB(EntityUid entity, EntityUid tree)
         {
-            // TODO: Should feed in AABB to lookup so it's not enlarged unnecessarily
-            var aabb = GetWorldAABB(entity);
             var xformQuery = GetEntityQuery<TransformComponent>();
-            var tree = GetLookup(entity, xformQuery);
+            var xform = xformQuery.GetComponent(entity);
 
-            if (tree == null)
-                return aabb;
+            if (xform.ParentUid == tree)
+                return GetAABBNoContainer(entity, xform.LocalPosition, xform.LocalRotation);
 
-            return xformQuery.GetComponent(tree.Owner).InvWorldMatrix.TransformBox(aabb);
+            return xformQuery.GetComponent(tree).InvWorldMatrix.TransformBox(GetWorldAABB(entity, xform));
         }
 
         #endregion
@@ -457,20 +455,15 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         private Box2 GetAABBNoContainer(EntityUid uid, Vector2 position, Angle angle)
         {
-            // DebugTools.Assert(!_container.IsEntityInContainer(uid, xform));
-            Box2 localAABB;
-            var transform = new Transform(position, angle);
-
             if (TryComp<ILookupWorldBox2Component>(uid, out var worldLookup))
             {
-                localAABB = worldLookup.GetAABB(transform);
+                var transform = new Transform(position, angle);
+                return worldLookup.GetAABB(transform);
             }
             else
             {
-                localAABB = new Box2Rotated(new Box2(transform.Position, transform.Position), transform.Quaternion2D.Angle, transform.Position).CalcBoundingBox();
+                return new Box2(position, position);
             }
-
-            return localAABB;
         }
 
         public Box2 GetWorldAABB(EntityUid uid, TransformComponent? xform = null)


### PR DESCRIPTION
- Some methods in `EntityLookup.Queries.cs` were not respecting the approximate lookup flag
  - Also replaced some IsGrid & GetGrid with TryGetGrid
- Modified `EntityLookupSystem.GetAAbb()`
  - Uses local AABB & skips `TryGetOuterContainer` if the tree is the entity's parent.
  - Passes the lookup/tree entity uid to avoid a `TryGetLookup()` to get the reference to the tree that currently already trying to calculate the aabb.
    - But now uses a lambda function delegate. Not sure if there's a nicer way of doing this without just making it a function in the component. 
- Changed `EntityLookupComponent.Tree` from internal to public.
  - I don't think it causes any issues and allows people to directly do custom queries if they need to. 