### PR TITLE
Make recursive delete detach parents before children

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -338,6 +338,18 @@ namespace Robust.Shared.GameObjects
                     DebugTools.Assert(newParent != this,
                         $"Can't parent a {nameof(TransformComponent)} to itself.");
 
+                    if (newParent.LifeStage > ComponentLifeStage.Running ||
+                        _entMan.GetComponent<MetaDataComponent>(newParent.Owner).EntityLifeStage > EntityLifeStage.MapInitialized)
+                    {
+                        var msg = $"Attempted to re-parent to a terminating object. Entity: {_entMan.ToPrettyString(Owner)}, new parent: {_entMan.ToPrettyString(value.EntityId)}";
+#if EXCEPTION_TOLERANCE
+                        Logger.Error(msg);
+                        _entMan.DeleteEntity(Owner);
+#else
+                        throw new InvalidOperationException(msg);
+#endif
+                    }
+
                     // That's already our parent, don't bother attaching again.
 
                     var oldParent = _parent.IsValid() ? xformQuery.GetComponent(_parent) : null;

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -598,6 +598,9 @@ namespace Robust.Shared.GameObjects
             }
             else
             {
+                if (!_mapManager.IsMap(Owner))
+                    Logger.Warning($"Detached a non-map entity ({_entMan.ToPrettyString(Owner)}) to null-space. Unless this entity is being deleted, this should not happen.");
+
                 DetachParentToNull();
                 return;
             }

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -304,6 +304,11 @@ namespace Robust.Shared.GameObjects
             var ev = new EntityTerminatingEvent(metadata.Owner);
             EventBus.RaiseLocalEvent(metadata.Owner, ref ev, false);
 
+            // Detach the base entity to null before iterating over children
+            // This also ensures that the entity-lookup updates don't have to be re-run for every child (which recurses up the transform hierarchy).
+            if (transform.ParentUid != EntityUid.Invalid)
+                xformSys.DetachParentToNull(transform, xformQuery, metaQuery);
+
             // DeleteEntity modifies our _children collection, we must cache the collection to iterate properly
             foreach (var child in transform._children.ToArray())
             {
@@ -319,13 +324,6 @@ namespace Robust.Shared.GameObjects
             {
                 if(component.Running)
                     component.LifeShutdown(this);
-            }
-
-            // map does not have a parent node, everything else needs to be detached
-            if (transform.ParentUid != EntityUid.Invalid)
-            {
-                // Detach from my parent, if any
-                xformSys.DetachParentToNull(transform, xformQuery, metaQuery);
             }
 
             // Dispose all my components, in a safe order so transform is available

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -73,8 +73,6 @@ namespace Robust.Shared.GameObjects
             SubscribeLocalEvent<EntityLookupComponent, ComponentShutdown>(OnLookupShutdown);
             SubscribeLocalEvent<GridInitializeEvent>(OnGridInit);
 
-            SubscribeLocalEvent<EntityTerminatingEvent>(OnTerminate);
-
             EntityManager.EntityInitialized += OnEntityInit;
             SubscribeLocalEvent<MapChangedEvent>(OnMapCreated);
         }
@@ -198,12 +196,6 @@ namespace Robust.Shared.GameObjects
         #endregion
 
         #region Entity events
-
-        private void OnTerminate(ref EntityTerminatingEvent args)
-        {
-            RemoveFromEntityTree(args.Owner, false);
-        }
-
         private void OnEntityInit(EntityUid uid)
         {
             if (_container.IsEntityInContainer(uid)) return;

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.Velocities.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.Velocities.cs
@@ -1,5 +1,7 @@
 using Robust.Shared.IoC;
+using Robust.Shared.Map;
 using Robust.Shared.Maths;
+using Robust.Shared.Physics;
 using Robust.Shared.Timing;
 
 namespace Robust.Shared.GameObjects;
@@ -147,6 +149,9 @@ public abstract partial class SharedPhysicsSystem
             return;
 
         if (physics.LifeStage != ComponentLifeStage.Running)
+            return;
+
+        if (physics.BodyType == BodyType.Static || xform.MapID == MapId.Nullspace || !physics._canCollide)
             return;
 
         // When transferring bodies, we will preserve map angular and linear velocities. For this purpose, we simply

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -221,6 +221,8 @@ namespace Robust.Shared.GameObjects
                 newMap?.AddAwakeBody(body);
                 DebugTools.Assert(body.Awake);
             }
+            else
+                DebugTools.Assert(oldMap?.AwakeBodies.Contains(body) != true);
 
             if (fixturesQuery.TryGetComponent(uid, out var fixtures) && body._canCollide)
             {

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -183,7 +183,9 @@ namespace Robust.Shared.GameObjects
 
             _broadphase.TryGetMoveBuffer(oldMapId, out var oldMoveBuffer);
 
-            RecursiveMapUpdate(xform, body, newMapId, null, newMap, oldMap, oldMoveBuffer, bodyQuery, xformQuery, fixturesQuery, jointQuery, broadQuery);
+            var newBroadphase = _broadphase.GetBroadphase(xform, broadQuery, xformQuery);
+
+            RecursiveMapUpdate(xform, body, newMapId, newBroadphase, newMap, oldMap, oldMoveBuffer, bodyQuery, xformQuery, fixturesQuery, jointQuery, broadQuery);
         }
 
         /// <summary>

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -139,6 +139,10 @@ namespace Robust.Shared.GameObjects
 
             var xform = args.Transform;
 
+            // Is this entity getting recursively detached after it's parent was already detached to null?
+            if (args.OldMapId == MapId.Nullspace && xform.MapID == MapId.Nullspace)
+                return;
+
             if ((meta.Flags & MetaDataFlags.InContainer) != 0)
             {
                 // Here we intentionally dont dirty the physics comp. Client-side state handling will apply these same
@@ -151,10 +155,10 @@ namespace Robust.Shared.GameObjects
             }
 
             // TODO: need to suss out this particular bit + containers + body.Broadphase.
-            _broadphase.UpdateBroadphase(body, xform: xform);
+            _broadphase.UpdateBroadphase(body, args.OldMapId, xform: xform);
 
             // Handle map change
-            var mapId = _transform.GetMapId(args.Entity);
+            var mapId = args.Transform.MapID;
 
             if (args.OldMapId != mapId)
                 HandleMapChange(body, xform, args.OldMapId, mapId);

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -223,7 +223,6 @@ public abstract partial class SharedTransformSystem
 #endif
             }
 
-
             parentXform._children.Add(uid);
         }
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -667,15 +667,6 @@ public abstract partial class SharedTransformSystem
 
     #endregion
 
-    public MapId GetMapId(EntityUid? uid, TransformComponent? xform = null)
-    {
-        if (uid == null ||
-            !uid.Value.IsValid() ||
-            !Resolve(uid.Value, ref xform, false)) return MapId.Nullspace;
-
-        return xform.MapID;
-    }
-
     #region State Handling
     private void ChangeMapId(TransformComponent xform, MapId newMapId, EntityQuery<TransformComponent> xformQuery, EntityQuery<MetaDataComponent> metaQuery)
     {

--- a/Robust.Shared/Map/MapManager.GridTrees.cs
+++ b/Robust.Shared/Map/MapManager.GridTrees.cs
@@ -143,24 +143,23 @@ internal partial class MapManager
         var lifestage = EntityManager.GetComponent<MetaDataComponent>(uid).EntityLifeStage;
 
         // oh boy
-        // Want gridinit / gridremoval to handle this hence specialcase those situations.
-        if (lifestage is < EntityLifeStage.Initialized or >= EntityLifeStage.Terminating) return;
-
-        var oldMapId = args.OldParent == null
-            ? MapId.Nullspace
-            : EntityManager.GetComponent<TransformComponent>(args.OldParent.Value).MapID;
+        // Want gridinit to handle this hence specialcase those situations.
+        if (lifestage < EntityLifeStage.Initialized) return;
 
         // Make sure we cleanup old map for moved grid stuff.
         var mapId = args.Transform.MapID;
 
         // y'all need jesus
-        if (oldMapId == mapId) return;
+        if (args.OldMapId == mapId) return;
 
-        if (aGrid.MapProxy != DynamicTree.Proxy.Free && _movedGrids.TryGetValue(oldMapId, out var oldMovedGrids))
+        if (aGrid.MapProxy != DynamicTree.Proxy.Free && _movedGrids.TryGetValue(args.OldMapId, out var oldMovedGrids))
         {
             oldMovedGrids.Remove(component.Grid);
-            RemoveGrid(aGrid, oldMapId);
+            RemoveGrid(aGrid, args.OldMapId);
         }
+
+        if (args.Transform.MapID == MapId.Nullspace)
+            return;
 
         if (_movedGrids.TryGetValue(mapId, out var newMovedGrids))
         {

--- a/Robust.Shared/Map/MapManager.GridTrees.cs
+++ b/Robust.Shared/Map/MapManager.GridTrees.cs
@@ -158,9 +158,6 @@ internal partial class MapManager
             RemoveGrid(aGrid, args.OldMapId);
         }
 
-        if (args.Transform.MapID == MapId.Nullspace)
-            return;
-
         if (_movedGrids.TryGetValue(mapId, out var newMovedGrids))
         {
             newMovedGrids.Add(component.Grid);

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -440,8 +440,6 @@ namespace Robust.Shared.Physics
 
                 if (oldBroadphase == newBroadphase) return;
 
-                DebugTools.Assert(oldMapId != MapId.Nullspace);
-
                 DestroyProxies(body, manager, oldMapId);
 
                 // Shouldn't need to null-check as this already checks for nullspace so should be okay...?

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -397,7 +397,8 @@ namespace Robust.Shared.Physics
         internal void UpdateBroadphase(PhysicsComponent body, MapId oldMapId, FixturesComponent? manager = null, TransformComponent? xform = null)
         {
             if (!Resolve(body.Owner, ref manager, ref xform) ||
-                _mapManager.IsGrid(body.Owner)) return;
+                _mapManager.IsGrid(body.Owner) && xform.MapID != MapId.Nullspace)
+                return;
 
             var bodyQuery = GetEntityQuery<PhysicsComponent>();
             var fixturesQuery = GetEntityQuery<FixturesComponent>();
@@ -439,7 +440,7 @@ namespace Robust.Shared.Physics
 
                 if (oldBroadphase == newBroadphase) return;
 
-                DebugTools.Assert(oldMapId != null);
+                DebugTools.Assert(oldMapId != MapId.Nullspace);
 
                 DestroyProxies(body, manager, oldMapId);
 

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -397,9 +397,9 @@ namespace Robust.Shared.Physics
         /// <summary>
         /// If our broadphase has changed then remove us from our old one and add to our new one.
         /// </summary>
-        internal void UpdateBroadphase(PhysicsComponent body, MapId oldMapId, TransformComponent? xform = null)
+        internal void UpdateBroadphase(EntityUid uid, MapId oldMapId, TransformComponent? xform = null)
         {
-            if (!Resolve(body.Owner, ref xform))
+            if (!Resolve(uid, ref xform))
                 return;
 
             var bodyQuery = GetEntityQuery<PhysicsComponent>();

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -892,7 +892,7 @@ namespace Robust.Shared.Physics
             return GetBroadphase(xform, broadQuery, xformQuery);
         }
 
-        private BroadphaseComponent? GetBroadphase(TransformComponent xform, EntityQuery<BroadphaseComponent> broadQuery, EntityQuery<TransformComponent> xformQuery)
+        public BroadphaseComponent? GetBroadphase(TransformComponent xform, EntityQuery<BroadphaseComponent> broadQuery, EntityQuery<TransformComponent> xformQuery)
         {
             if (xform.MapID == MapId.Nullspace) return null;
 

--- a/Robust.Shared/Physics/SharedJointSystem.cs
+++ b/Robust.Shared/Physics/SharedJointSystem.cs
@@ -381,6 +381,11 @@ namespace Robust.Shared.Physics
             _dirtyJoints.Add(joint);
         }
 
+        public void ClearJoints(JointComponent joint)
+        {
+            _dirtyJoints.Add(joint);
+        }
+
         public void RemoveJoint(Joint joint)
         {
             var bodyAUid = joint.BodyAUid;


### PR DESCRIPTION
Previously recursive delete would:
- Raise a terminate event
- Recursively delete children
- Shutdown components
- Detach to null
- Dispose components
- Delete the entity

This PR changes the ordering so that entities get detached to null after raising the termination event, but before iterating through children.

The main motivator for this was that termination would cause the entity lookup system to recurse up the transform hierarchy to find a parent with a look-up component, and it would do this for every deleted entity, rather than just directly recursively removing the parent.

But this is also a pretty significant change that might cause unexpected issues when deleting something like a grid or map. AFAICT  thing still seem to work fine, round restart works, etc. 

Requires https://github.com/space-wizards/space-station-14/pull/9316

Also ran into several issues related to #2591.
I've added extra logging, and when something tries to parent to a terminating entity it should now try to delete that entity directly if exception tolerance is enabled. So I guess:
Fixes #2591 (really, whatever system was responsible for a re-parent-on-delete should just be more careful in the first place).