### PR TITLE
Toggle button updates

### DIFF
--- a/Robust.Client/UserInterface/Controls/BaseButton.cs
+++ b/Robust.Client/UserInterface/Controls/BaseButton.cs
@@ -256,15 +256,16 @@ namespace Robust.Client.UserInterface.Controls
             if (Mode == ActionMode.Release && _attemptingPress > 0 && HasPoint((args.PointerLocation.Position - GlobalPixelPosition) / UIScale))
             {
                 // Can't un press a radio button directly.
-                if (Group == null || !Pressed)
+                // Only trigger toggle on UIClick. Do not un-press a toggle button if it's in a group.
+                if (args.Function != EngineKeyFunctions.UIClick || Group == null || !Pressed)
                 {
-                    if (ToggleMode)
+                    if (args.Function == EngineKeyFunctions.UIClick && ToggleMode && _attemptingPress == 1)
                     {
                         Pressed = !Pressed;
                     }
 
                     OnPressed?.Invoke(buttonEventArgs);
-                    if (ToggleMode && args.CanFocus)
+                    if (args.Function == EngineKeyFunctions.UIClick && ToggleMode)
                     {
                         OnToggled?.Invoke(new ButtonToggledEventArgs(Pressed, this, args));
                         UnsetOtherGroupButtons();
@@ -333,6 +334,13 @@ namespace Robust.Client.UserInterface.Controls
             {
                 DrawModeChanged();
             }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            Group = null;
         }
 
         public enum DrawModeEnum : byte

--- a/Robust.UnitTesting/Client/UserInterface/Controls/BaseButtonTest.cs
+++ b/Robust.UnitTesting/Client/UserInterface/Controls/BaseButtonTest.cs
@@ -1,0 +1,95 @@
+﻿using NUnit.Framework;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Input;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+
+namespace Robust.UnitTesting.Client.UserInterface.Controls;
+
+[TestFixture]
+public sealed class BaseButtonTest : RobustUnitTest
+{
+    public override UnitTestProject Project => UnitTestProject.Client;
+
+    private string UIRightClick = "UIRightClick";
+    private string OpenContextMenu = "OpenContextMenu";
+
+    private sealed class TestButton : BaseButton { }
+
+    [OneTimeSetUp]
+    public void Setup()
+    {
+        IoCManager.Resolve<IUserInterfaceManagerInternal>().InitializeTesting();
+    }
+
+    [Test]
+    public void TestToggleButtonToggle()
+    {
+        var button = new TestButton
+        {
+            ToggleMode = true
+        };
+        var toggled = false;
+
+        button.OnToggled += _ =>
+        {
+            toggled = true;
+        };
+
+        var click = new GUIBoundKeyEventArgs(EngineKeyFunctions.UIClick, BoundKeyState.Down, new ScreenCoordinates(), true, Vector2.Zero, Vector2.Zero);
+        button.KeyBindDown(click);
+        button.KeyBindUp(click);
+        Assert.That(button.Pressed, Is.EqualTo(true));
+        Assert.That(toggled, Is.EqualTo(true));
+
+        toggled = false;
+        button.KeyBindDown(click);
+        button.KeyBindUp(click);
+        Assert.That(button.Pressed, Is.EqualTo(false));
+        Assert.That(toggled, Is.EqualTo(true));
+    }
+
+    [Test]
+    public void TestToggleButtonAllKeybinds()
+    {
+        var button = new TestButton
+        {
+            EnableAllKeybinds = true,
+            ToggleMode = true
+        };
+
+        var uiRightClickPressed = false;
+        var openContextMenuPressed = false;
+        var toggled = false;
+        button.OnPressed += args =>
+        {
+            if (args.Event.Function == UIRightClick)
+                uiRightClickPressed = true;
+            else if (args.Event.Function == OpenContextMenu)
+                openContextMenuPressed = true;
+        };
+        button.OnToggled += _ =>
+        {
+            toggled = true;
+        };
+
+        var uiRightClick = new GUIBoundKeyEventArgs(UIRightClick, BoundKeyState.Down, new ScreenCoordinates(), true, Vector2.Zero, Vector2.Zero);
+        var openContextMenu = new GUIBoundKeyEventArgs(OpenContextMenu, BoundKeyState.Down, new ScreenCoordinates(), true, Vector2.Zero, Vector2.Zero);
+        button.KeyBindDown(uiRightClick);
+        button.KeyBindDown(openContextMenu);
+
+        Assert.That(button.Pressed, Is.EqualTo(false));
+        Assert.That(toggled, Is.EqualTo(false));
+        button.KeyBindUp(uiRightClick);
+        Assert.That(button.Pressed, Is.EqualTo(false));
+        Assert.That(toggled, Is.EqualTo(false));
+        button.KeyBindUp(openContextMenu);
+
+        Assert.That(uiRightClickPressed, Is.EqualTo(true));
+        Assert.That(openContextMenuPressed, Is.EqualTo(true));
+        Assert.That(button.Pressed, Is.EqualTo(false));
+        Assert.That(toggled, Is.EqualTo(false));
+    }
+}


### PR DESCRIPTION
Changes toggle buttons to only trigger on UI Click. This allows for other keybinds to be triggered on buttons in a group that are pressed.
Added tests for normal toggle button functionality and non-triggering on non-UIClick inputs.

Needed for player lists to be able to change groups and also allow OpenContextMenu(Right click) to not get blocked by the selected group button.