### PR TITLE
Make typereader stabler

### DIFF
--- a/Robust.Shared/Serialization/Manager/SerializationManager.TypeReaders.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.TypeReaders.cs
@@ -33,12 +33,15 @@ namespace Robust.Shared.Serialization.Manager
             if (type.IsGenericType)
             {
                 var typeDef = type.GetGenericTypeDefinition();
+                var typeGenericArgs = type.GetGenericArguments();
 
                 Type? serializerTypeDef = null;
 
                 foreach (var (key, val) in _genericReaderTypes)
                 {
-                    if (typeDef.HasSameMetadataDefinitionAs(key.Type) && key.DataNodeType.IsAssignableFrom(node))
+                    if (typeDef.HasSameMetadataDefinitionAs(key.Type) &&
+                        key.DataNodeType.IsAssignableFrom(node) &&
+                        typeGenericArgs.Length == val.GetGenericArguments().Length)
                     {
                         serializerTypeDef = val;
                         break;
@@ -51,7 +54,7 @@ namespace Robust.Shared.Serialization.Manager
                     return false;
                 }
 
-                var serializerType = serializerTypeDef.MakeGenericType(type.GetGenericArguments());
+                var serializerType = serializerTypeDef.MakeGenericType(typeGenericArgs);
 
                 reader = RegisterSerializer(serializerType) ?? throw new NullReferenceException();
                 return true;


### PR DESCRIPTION
The problem seems to be that the dictionary has multiple things in it that matched, and since dictionaries don't promise the order, sometimes something is picked that doesn't work. Adding the generic argument check seems to prevent duplicate matches, so I think this resolves it.

Fixes https://github.com/space-wizards/RobustToolbox/issues/3039
