### PR TITLE
validates generic args of typeserializers

### DIFF
--- a/Robust.Shared/Serialization/Manager/SerializationManager.TypeSerializers.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.TypeSerializers.cs
@@ -60,14 +60,34 @@ namespace Robust.Shared.Serialization.Manager
 
             if (type.IsGenericTypeDefinition)
             {
+                var genArgs = type.GetGenericArguments();
+
+                void GenericArgumentsCheck(Type genericInterface)
+                {
+                    var targetType = genericInterface.GetGenericArguments()[0];
+                    var readTypeArgs = targetType.GetGenericArguments();
+                    if(genArgs.Length != readTypeArgs.Length)
+                        throw new InvalidOperationException(
+                            $"Generic Argcount mismatch! (Target={targetType}, Interface={genericInterface}, Type={type})");
+
+                    for (int i = 0; i < genArgs.Length; i++)
+                    {
+                        if (genArgs[i] != readTypeArgs[i])
+                            throw new InvalidOperationException(
+                                $"Generic Parameter {i} mismatch! (Target={targetType}, Interface={genericInterface}, Type={type})");
+                    }
+                }
+
                 foreach (var writerInterface in writerInterfaces)
                 {
+                    GenericArgumentsCheck(writerInterface);
                     if (!_genericWriterTypes.TryAdd(writerInterface.GetGenericArguments()[0], type))
                         Logger.ErrorS(LogCategory, $"Tried registering generic writer for type {writerInterface.GetGenericArguments()[0]} twice");
                 }
 
                 foreach (var readerInterface in readerInterfaces)
                 {
+                    GenericArgumentsCheck(readerInterface);
                     var genericArguments = readerInterface.GetGenericArguments();
                     var readType = genericArguments[0];
                     var nodeType = genericArguments[1];
@@ -78,18 +98,21 @@ namespace Robust.Shared.Serialization.Manager
 
                 foreach (var copierInterface in copierInterfaces)
                 {
+                    GenericArgumentsCheck(copierInterface);
                     if (!_genericCopierTypes.TryAdd(copierInterface.GetGenericArguments()[0], type))
                         Logger.ErrorS(LogCategory, $"Tried registering generic copier for type {copierInterface.GetGenericArguments()[0]} twice");
                 }
 
                 foreach (var validatorInterface in validatorInterfaces)
                 {
+                    GenericArgumentsCheck(validatorInterface);
                     if (!_genericValidatorTypes.TryAdd((validatorInterface.GetGenericArguments()[0], validatorInterface.GetGenericArguments()[1]), type))
                         Logger.ErrorS(LogCategory, $"Tried registering generic reader for type {validatorInterface.GetGenericArguments()[0]} and node {validatorInterface.GetGenericArguments()[1]} twice");
                 }
 
                 foreach (var inheritanceHandlerInterface in inheritanceHandlerInterfaces)
                 {
+                    GenericArgumentsCheck(inheritanceHandlerInterface);
                     if (!_genericInheritanceHandlerTypes.TryAdd((inheritanceHandlerInterface.GetGenericArguments()[0], inheritanceHandlerInterface.GetGenericArguments()[1]), type))
                         Logger.ErrorS(LogCategory, $"Tried registering generic reader for type {inheritanceHandlerInterface.GetGenericArguments()[0]} and node {inheritanceHandlerInterface.GetGenericArguments()[1]} twice");
                 }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/CustomHashSetSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/CustomHashSetSerializer.cs
@@ -14,7 +14,6 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
 /// <summary>
 ///     This is a variation of the <see cref="HashSetSerializer{T}"/> that uses a custom type serializer to read the values.
 /// </summary>
-[TypeSerializer]
 public sealed class CustomHashSetSerializer<T, TCustomSerializer>
     : ITypeSerializer<HashSet<T>, SequenceDataNode>
     where TCustomSerializer : ITypeSerializer<T, ValueDataNode>


### PR DESCRIPTION
fixes #3039 

Enforces Argcount mismatch:
```csharp
[TypeSerializer]
public sealed class CustomHashSetSerializer<T, TCustomSerializer> : ITypeSerializer<HashSet<T>, SequenceDataNode>
```
```
System.InvalidOperationException: Generic Argcount mismatch! (Target=System.Collections.Generic.HashSet`1[T], Interface=Robust.Shared.Serialization.TypeSerializers.Interfaces.ITypeWriter`1[System.Collections.Generic.HashSet`1
[T]], Type=Robust.Shared.Serialization.TypeSerializers.Implementations.Generic.CustomHashSetSerializer`2[T,TCustomSerializer])
```

As well as invalid implementations (generic param switchup) (this is how the generic typeserializer instantiation logic works, it copies over the generic params in order from the target type of the ITypeSerializer)
```csharp
[TypeSerializer]
public sealed class ValueTupleSerializer<T2, T1> : ITypeSerializer<ValueTuple<T1, T2>, MappingDataNode>
```
```
System.InvalidOperationException: Generic Parameter 0 mismatch! (Target=System.ValueTuple`2[T1,T2], Interface=Robust.Shared.Serialization.TypeSerializers.Interfaces.ITypeWriter`1[System.ValueTuple`2[T1,T2]], Type=Robust.Share
d.Serialization.TypeSerializers.Implementations.Generic.ValueTupleSerializer`2[T2,T1])
```