### PR TITLE
Dirty PVS chunk when visibility mask changes

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/ClientMetaDataSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ClientMetaDataSystem.cs
@@ -1,0 +1,8 @@
+using Robust.Shared.GameObjects;
+
+namespace Robust.Client.GameObjects;
+
+public sealed class ClientMetaDataSystem : MetaDataSystem
+{
+    // Howdy.
+}

--- a/Robust.Server/GameObjects/EntitySystems/ServerMetaDataSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/ServerMetaDataSystem.cs
@@ -1,0 +1,19 @@
+using Robust.Server.GameStates;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+
+namespace Robust.Server.GameObjects;
+
+public sealed class ServerMetaDataSystem : MetaDataSystem
+{
+    [Dependency] private readonly PVSSystem _pvsSystem = default!;
+
+    public override void SetVisibilityMask(EntityUid uid, int value, MetaDataComponent? meta = null)
+    {
+        if (!Resolve(uid, ref meta) || meta.VisibilityMask == value)
+            return;
+
+        base.SetVisibilityMask(uid, value, meta);
+        _pvsSystem.MarkDirty(uid);
+    }
+}

--- a/Robust.Server/GameObjects/EntitySystems/VisibilitySystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/VisibilitySystem.cs
@@ -59,16 +59,8 @@ namespace Robust.Server.GameObjects
 
         public void RefreshVisibility(EntityUid uid, MetaDataComponent? metaDataComponent = null, VisibilityComponent? visibilityComponent = null)
         {
-            if (!Resolve(uid, ref metaDataComponent, false))
-            {
-                // This means it's deleting or some shit; I'd love to make it a GetComponent<T> in future.
-                return;
-            }
-
-            var visMask = 1;
-            GetVisibilityMask(uid, ref visMask, visibilityComponent);
-
-            _metaSys.SetVisibilityMask(uid, visMask, metaDataComponent);
+            if (Resolve(uid, ref metaDataComponent, false))
+                _metaSys.SetVisibilityMask(uid, GetVisibilityMask(uid, visibilityComponent), metaDataComponent);
         }
 
         public void RefreshVisibility(VisibilityComponent visibilityComponent)
@@ -76,16 +68,18 @@ namespace Robust.Server.GameObjects
             RefreshVisibility(visibilityComponent.Owner, null, visibilityComponent);
         }
 
-        private int GetVisibilityMask(EntityUid uid, ref int visMask, VisibilityComponent? visibilityComponent = null, TransformComponent? xform = null)
+        private int GetVisibilityMask(EntityUid uid, VisibilityComponent? visibilityComponent = null, TransformComponent? xform = null)
         {
+            int visMask;
             if (Resolve(uid, ref visibilityComponent, false))
-            {
-                visMask |= visibilityComponent.Layer;
-            }
+                visMask = visibilityComponent.Layer;
+            else
+                visMask = 1;
 
+            // Include parent vis masks
             if (Resolve(uid, ref xform) && xform.ParentUid.IsValid())
             {
-                GetVisibilityMask(xform.ParentUid, ref visMask);
+                visMask |= GetVisibilityMask(xform.ParentUid);
             }
 
             return visMask;

--- a/Robust.Server/GameObjects/EntitySystems/VisibilitySystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/VisibilitySystem.cs
@@ -70,17 +70,13 @@ namespace Robust.Server.GameObjects
 
         private int GetVisibilityMask(EntityUid uid, VisibilityComponent? visibilityComponent = null, TransformComponent? xform = null)
         {
-            int visMask;
+            int visMask = 1; // apparently some content expects everything to have the first bit/flag set to true.
             if (Resolve(uid, ref visibilityComponent, false))
-                visMask = visibilityComponent.Layer;
-            else
-                visMask = 1;
-
+                visMask |= visibilityComponent.Layer;
+            
             // Include parent vis masks
             if (Resolve(uid, ref xform) && xform.ParentUid.IsValid())
-            {
                 visMask |= GetVisibilityMask(xform.ParentUid);
-            }
 
             return visMask;
         }

--- a/Robust.Server/GameObjects/EntitySystems/VisibilitySystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/VisibilitySystem.cs
@@ -1,9 +1,12 @@
 using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 
 namespace Robust.Server.GameObjects
 {
     public sealed class VisibilitySystem : EntitySystem
     {
+        [Dependency] private readonly MetaDataSystem _metaSys = default!;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -63,12 +66,14 @@ namespace Robust.Server.GameObjects
             }
 
             var visMask = 1;
-            metaDataComponent.VisibilityMask = GetVisibilityMask(uid, ref visMask, visibilityComponent);
+            GetVisibilityMask(uid, ref visMask, visibilityComponent);
+
+            _metaSys.SetVisibilityMask(uid, visMask, metaDataComponent);
         }
 
         public void RefreshVisibility(VisibilityComponent visibilityComponent)
         {
-            RefreshVisibility(visibilityComponent.Owner);
+            RefreshVisibility(visibilityComponent.Owner, null, visibilityComponent);
         }
 
         private int GetVisibilityMask(EntityUid uid, ref int visMask, VisibilityComponent? visibilityComponent = null, TransformComponent? xform = null)

--- a/Robust.Server/GameStates/PVSSystem.Dirty.cs
+++ b/Robust.Server/GameStates/PVSSystem.Dirty.cs
@@ -44,7 +44,8 @@ namespace Robust.Server.GameStates
 
         private void OnEntityAdd(EntityUid e)
         {
-            DebugTools.Assert(_currentIndex == _gameTiming.CurTick.Value % DirtyBufferSize);
+            DebugTools.Assert(_currentIndex == _gameTiming.CurTick.Value % DirtyBufferSize ||
+                _gameTiming.GetType().Name == "IGameTimingProxy");// Look I have NFI how best to excuse this assert if the game timing isn't real (a Mock<IGameTiming>). 
             _addEntities[_currentIndex].Add(e);
         }
 

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -128,14 +128,23 @@ internal sealed partial class PVSSystem : EntitySystem
 
     private void OnParentChange(ref EntParentChangedMessage ev)
     {
-        if (_mapManager.IsGrid(ev.Entity) || _mapManager.IsMap(ev.Entity)) return;
+        if (ev.Transform.GridUid == ev.Entity || _mapManager.IsMap(ev.Entity)) return;
 
         // If parent changes then the RobustTree for that chunk will no longer be valid and we need to force it as dirty.
         // Should still be at its old location as moveevent is called after.
-        var xform = Transform(ev.Entity);
-        var coordinates = _transform.GetMoverCoordinates(xform);
+        var coordinates = _transform.GetMoverCoordinates(ev.Transform);
         var index = _entityPvsCollection.GetChunkIndex(coordinates);
         _entityPvsCollection.MarkDirty(index);
+    }
+
+    /// <summary>
+    ///     Marks an entity's current chunk as drity.
+    /// </summary>
+    internal void MarkDirty(EntityUid uid)
+    {
+        var xform = Transform(uid);
+        var coordinates = _transform.GetMoverCoordinates(xform);
+        _entityPvsCollection.MarkDirty(_entityPvsCollection.GetChunkIndex(coordinates));
     }
 
     public override void Shutdown()

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -138,10 +138,13 @@ namespace Robust.Shared.GameObjects
 
         /// <summary>
         ///     The sum of our visibility layer and our parent's visibility layers.
-        ///     Server-only.
         /// </summary>
+        /// <remarks>
+        ///     Every entity has a mask of 1, unless this is overridden via a VisibilityComponent. So unless every
+        ///     parent, including the map, has such a component, the 1-flag is almost certainly set.
+        /// </remarks>
         [Access(typeof(MetaDataSystem))]
-        public int VisibilityMask;
+        public int VisibilityMask = 1;
 
         [UsedImplicitly, ViewVariables(VVAccess.ReadWrite)]
         private int VVVisibilityMask

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -140,8 +140,7 @@ namespace Robust.Shared.GameObjects
         ///     The sum of our visibility layer and our parent's visibility layers.
         /// </summary>
         /// <remarks>
-        ///     Every entity has a mask of 1, unless this is overridden via a VisibilityComponent. So unless every
-        ///     parent, including the map, has such a component, the 1-flag is almost certainly set.
+        ///     Every entity will always have the first bit set to true.
         /// </remarks>
         [Access(typeof(MetaDataSystem))]
         public int VisibilityMask = 1;

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -1,4 +1,5 @@
 using System;
+using JetBrains.Annotations;
 using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 using Robust.Shared.Players;
@@ -139,8 +140,15 @@ namespace Robust.Shared.GameObjects
         ///     The sum of our visibility layer and our parent's visibility layers.
         ///     Server-only.
         /// </summary>
-        [ViewVariables]
-        public int VisibilityMask { get; internal set; }
+        [Access(typeof(MetaDataSystem))]
+        public int VisibilityMask;
+
+        [UsedImplicitly, ViewVariables(VVAccess.ReadWrite)]
+        private int VVVisibilityMask
+        {
+            get => VisibilityMask;
+            set => IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<MetaDataSystem>().SetVisibilityMask(Owner, value, this);
+        }
 
         [ViewVariables]
         public bool EntityPaused

--- a/Robust.Shared/GameObjects/Systems/MetaDataSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/MetaDataSystem.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Prototypes;
 
 namespace Robust.Shared.GameObjects;
 
-public sealed class MetaDataSystem : EntitySystem
+public abstract class MetaDataSystem : EntitySystem
 {
     [Dependency] private readonly IPrototypeManager _proto = default!;
 
@@ -65,6 +65,12 @@ public sealed class MetaDataSystem : EntitySystem
         EntityManager.EventBus.RaiseLocalEvent(component.Owner, ref ev, true);
 
         component.Flags &= ~ev.ToRemove;
+    }
+
+    public virtual void SetVisibilityMask(EntityUid uid, int value, MetaDataComponent? meta = null)
+    {
+        if (Resolve(uid, ref meta))
+            meta.VisibilityMask = value;
     }
 }
 

--- a/Robust.UnitTesting/RobustUnitTest.cs
+++ b/Robust.UnitTesting/RobustUnitTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
+using Robust.Client.GameObjects;
 using Robust.Server.Containers;
 using Robust.Server.GameObjects;
 using Robust.Server.GameStates;
@@ -77,11 +78,22 @@ namespace Robust.UnitTesting
 
             var systems = IoCManager.Resolve<IEntitySystemManager>();
             // Required systems
-            systems.LoadExtraSystemType<ContainerSystem>();
-            systems.LoadExtraSystemType<TransformSystem>();
             systems.LoadExtraSystemType<EntityLookupSystem>();
-            systems.LoadExtraSystemType<ServerMetaDataSystem>();
-            systems.LoadExtraSystemType<PVSSystem>();
+
+            // uhhh so maybe these are the wrong system for the client, but I CBF adding sprite system and all the rest,
+            // and it was like this when I found it.
+            systems.LoadExtraSystemType<Robust.Server.Containers.ContainerSystem>();
+            systems.LoadExtraSystemType<Robust.Server.GameObjects.TransformSystem>();
+
+            if (Project == UnitTestProject.Client)
+            {
+                systems.LoadExtraSystemType<ClientMetaDataSystem>();
+            }
+            else
+            {
+                systems.LoadExtraSystemType<ServerMetaDataSystem>();
+                systems.LoadExtraSystemType<PVSSystem>();
+            }
 
             var entMan = IoCManager.Resolve<IEntityManager>();
             var mapMan = IoCManager.Resolve<IMapManager>();

--- a/Robust.UnitTesting/RobustUnitTest.cs
+++ b/Robust.UnitTesting/RobustUnitTest.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using NUnit.Framework;
 using Robust.Server.Containers;
 using Robust.Server.GameObjects;
+using Robust.Server.GameStates;
 using Robust.Server.Physics;
 using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
@@ -80,6 +81,7 @@ namespace Robust.UnitTesting
             systems.LoadExtraSystemType<TransformSystem>();
             systems.LoadExtraSystemType<EntityLookupSystem>();
             systems.LoadExtraSystemType<ServerMetaDataSystem>();
+            systems.LoadExtraSystemType<PVSSystem>();
 
             var entMan = IoCManager.Resolve<IEntityManager>();
             var mapMan = IoCManager.Resolve<IMapManager>();

--- a/Robust.UnitTesting/RobustUnitTest.cs
+++ b/Robust.UnitTesting/RobustUnitTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -79,7 +79,7 @@ namespace Robust.UnitTesting
             systems.LoadExtraSystemType<ContainerSystem>();
             systems.LoadExtraSystemType<TransformSystem>();
             systems.LoadExtraSystemType<EntityLookupSystem>();
-            systems.LoadExtraSystemType<MetaDataSystem>();
+            systems.LoadExtraSystemType<ServerMetaDataSystem>();
 
             var entMan = IoCManager.Resolve<IEntityManager>();
             var mapMan = IoCManager.Resolve<IMapManager>();

--- a/Robust.UnitTesting/Server/RobustServerSimulation.cs
+++ b/Robust.UnitTesting/Server/RobustServerSimulation.cs
@@ -6,6 +6,7 @@ using Moq;
 using Robust.Server;
 using Robust.Server.Containers;
 using Robust.Server.GameObjects;
+using Robust.Server.GameStates;
 using Robust.Server.Physics;
 using Robust.Server.Reflection;
 using Robust.Shared;
@@ -266,6 +267,7 @@ namespace Robust.UnitTesting.Server
             entitySystemMan.LoadExtraSystemType<TransformSystem>();
             entitySystemMan.LoadExtraSystemType<EntityLookupSystem>();
             entitySystemMan.LoadExtraSystemType<ServerMetaDataSystem>();
+            entitySystemMan.LoadExtraSystemType<PVSSystem>();
 
             _systemDelegate?.Invoke(entitySystemMan);
 

--- a/Robust.UnitTesting/Server/RobustServerSimulation.cs
+++ b/Robust.UnitTesting/Server/RobustServerSimulation.cs
@@ -265,7 +265,7 @@ namespace Robust.UnitTesting.Server
             entitySystemMan.LoadExtraSystemType<GridFixtureSystem>();
             entitySystemMan.LoadExtraSystemType<TransformSystem>();
             entitySystemMan.LoadExtraSystemType<EntityLookupSystem>();
-            entitySystemMan.LoadExtraSystemType<MetaDataSystem>();
+            entitySystemMan.LoadExtraSystemType<ServerMetaDataSystem>();
 
             _systemDelegate?.Invoke(entitySystemMan);
 

--- a/Robust.UnitTesting/Server/RobustServerSimulation.cs
+++ b/Robust.UnitTesting/Server/RobustServerSimulation.cs
@@ -8,6 +8,7 @@ using Robust.Server.Containers;
 using Robust.Server.GameObjects;
 using Robust.Server.GameStates;
 using Robust.Server.Physics;
+using Robust.Server.Player;
 using Robust.Server.Reflection;
 using Robust.Shared;
 using Robust.Shared.Asynchronous;
@@ -214,6 +215,14 @@ namespace Robust.UnitTesting.Server
             container.Register<IPhysicsManager, PhysicsManager>();
             container.Register<INetManager, NetManager>();
             container.Register<IAuthManager, AuthManager>();
+
+            // I just wanted to load pvs system
+            container.Register<IServerEntityManager, ServerEntityManager>();
+            container.Register<INetConfigurationManager, NetConfigurationManager>();
+            container.Register<IServerNetManager, NetManager>();
+            // god help you if you actually need to test pvs functions
+            container.RegisterInstance<IPlayerManager>(new Mock<IPlayerManager>().Object);
+            container.RegisterInstance<IServerGameStateManager>(new Mock<IServerGameStateManager>().Object);
 
             _diFactory?.Invoke(container);
             container.BuildGraph();


### PR DESCRIPTION
- Adds an internal `MarkDirty(EntityUid)`  to pvs system
- Makes VisibilityMask a friend of the metadata system, as it should be set via a new function in that system.
- Makes that function dirty the pvs chunk.
  - Requires a server & client version of the meta-data system.
- Minor unrelated changes to PVS's `OnParentChange` (less component fetching/checking).

Required so that an entity that has its visibility mask changed gets added to / or removed from a client's view without needing to wait for entities to move around in the pvs chunk. 


Edit:
So adding PVS system as a dependency to MetadataSystem made unit tests dependency stuff unhappy. I fixed it, but maybe not how I should've done.