### PR TITLE
Fix crossgrid/parent joints

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -148,9 +148,9 @@ namespace Robust.Shared.GameObjects
                 SetLinearVelocity(body, Vector2.Zero, false);
                 SetAngularVelocity(body, 0, false);
                 SetCanCollide(body, false, false);
+                _joints.ClearJoints(body);
             }
 
-            _joints.ClearJoints(body);
             // TODO: need to suss out this particular bit + containers + body.Broadphase.
             _broadphase.UpdateBroadphase(body, xform: xform);
 
@@ -158,7 +158,10 @@ namespace Robust.Shared.GameObjects
             var mapId = _transform.GetMapId(args.Entity);
 
             if (args.OldMapId != mapId)
+            {
                 HandleMapChange(body, xform, args.OldMapId, mapId);
+                _joints.ClearJoints(body);
+            }
 
             if (body.BodyType != BodyType.Static && mapId != MapId.Nullspace && body._canCollide)
                 HandleParentChangeVelocity(uid, body, ref args, xform);

--- a/Robust.Shared/Physics/SharedJointSystem.cs
+++ b/Robust.Shared/Physics/SharedJointSystem.cs
@@ -376,8 +376,12 @@ namespace Robust.Shared.Physics
 
         public void ClearJoints(PhysicsComponent body)
         {
-            if (!TryComp<JointComponent>(body.Owner, out var joint)) return;
+            if (TryComp<JointComponent>(body.Owner, out var joint))
+                ClearJoints(joint);
+        }
 
+        public void ClearJoints(JointComponent joint)
+        {
             foreach (var a in joint.Joints.Values.ToArray())
             {
                 RemoveJoint(a);


### PR DESCRIPTION
Fixed a bug introduced in #3046 that cleared joints on any parent change, not just map changes. Caused some pulling weirdness when moving across grids.