### PR TITLE
Fix cross-grid/map container inserts

### DIFF
--- a/Robust.Shared/Containers/BaseContainer.cs
+++ b/Robust.Shared/Containers/BaseContainer.cs
@@ -78,8 +78,9 @@ namespace Robust.Shared.Containers
             meta.Flags |= MetaDataFlags.InContainer;
 
             ownerTransform ??= entMan.GetComponent<TransformComponent>(Owner);
+            var oldParent = transform.ParentUid;
             transform.AttachParent(ownerTransform);
-            InternalInsert(toinsert, entMan);
+            InternalInsert(toinsert, oldParent, entMan);
 
             // This is an edge case where the parent grid is the container being inserted into, so AttachParent would not unanchor.
             if (transform.Anchored)
@@ -200,10 +201,10 @@ namespace Robust.Shared.Containers
         /// </summary>
         /// <param name="toinsert"></param>
         /// <param name="entMan"></param>
-        protected virtual void InternalInsert(EntityUid toinsert, IEntityManager entMan)
+        protected virtual void InternalInsert(EntityUid toinsert, EntityUid oldParent, IEntityManager entMan)
         {
             DebugTools.Assert(!Deleted);
-            entMan.EventBus.RaiseLocalEvent(Owner, new EntInsertedIntoContainerMessage(toinsert, this), true);
+            entMan.EventBus.RaiseLocalEvent(Owner, new EntInsertedIntoContainerMessage(toinsert, oldParent, this), true);
             Manager.Dirty(entMan);
         }
 

--- a/Robust.Shared/Containers/Container.cs
+++ b/Robust.Shared/Containers/Container.cs
@@ -36,10 +36,10 @@ namespace Robust.Shared.Containers
         public override string ContainerType => ClassName;
 
         /// <inheritdoc />
-        protected override void InternalInsert(EntityUid toinsert, IEntityManager entMan)
+        protected override void InternalInsert(EntityUid toinsert, EntityUid oldParent, IEntityManager entMan)
         {
             _containerList.Add(toinsert);
-            base.InternalInsert(toinsert, entMan);
+            base.InternalInsert(toinsert, oldParent, entMan);
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/Containers/ContainerSlot.cs
+++ b/Robust.Shared/Containers/ContainerSlot.cs
@@ -79,10 +79,10 @@ namespace Robust.Shared.Containers
         }
 
         /// <inheritdoc />
-        protected override void InternalInsert(EntityUid toinsert, IEntityManager entMan)
+        protected override void InternalInsert(EntityUid toinsert, EntityUid oldParent, IEntityManager entMan)
         {
             ContainedEntity = toinsert;
-            base.InternalInsert(toinsert, entMan);
+            base.InternalInsert(toinsert, oldParent, entMan);
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/Containers/Events/EntInsertedIntoContainerMessage.cs
+++ b/Robust.Shared/Containers/Events/EntInsertedIntoContainerMessage.cs
@@ -4,11 +4,16 @@ using Robust.Shared.GameObjects;
 namespace Robust.Shared.Containers
 {
     /// <summary>
-    /// Raised when an entity is inserted into a container.
+    /// Raised when an entity is inserted into a container. This is raised AFTER the entity has been re-parented. I.e., the current parent is the container.
     /// </summary>
     [PublicAPI]
     public sealed class EntInsertedIntoContainerMessage : ContainerModifiedMessage
     {
-        public EntInsertedIntoContainerMessage(EntityUid entity, IContainer container) : base(entity, container) { }
+        public readonly EntityUid OldParent;
+
+        public EntInsertedIntoContainerMessage(EntityUid entity, EntityUid oldParent, IContainer container) : base(entity, container)
+        {
+            OldParent = oldParent;
+        }
     }
 }

--- a/Robust.Shared/Containers/Events/EntRemovedFromContainerMessage.cs
+++ b/Robust.Shared/Containers/Events/EntRemovedFromContainerMessage.cs
@@ -4,7 +4,7 @@ using Robust.Shared.GameObjects;
 namespace Robust.Shared.Containers
 {
     /// <summary>
-    /// Raised when an entity is removed from a container. Directed at the container.
+    /// Raised when an entity is removed from a container. Directed at the container. This gets called BEFORE the entity gets re-parented. I.e., the current parent is the container.
     /// </summary>
     [PublicAPI]
     public sealed class EntRemovedFromContainerMessage : ContainerModifiedMessage
@@ -13,7 +13,7 @@ namespace Robust.Shared.Containers
     }
 
     /// <summary>
-    /// Raised when an entity is removed from a container. Directed at the entity.
+    /// Raised when an entity is removed from a container. Directed at the entity. This gets called BEFORE the entity gets re-parented. I.e., the current parent is the container.
     /// </summary>
     [PublicAPI]
     public sealed class EntGotRemovedFromContainerMessage : ContainerModifiedMessage

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -272,9 +272,22 @@ namespace Robust.Shared.GameObjects
         {
             var meta = MetaData(args.Entity);
 
-            // Parent change gets raised after container insert so we'll just drop it and let OnContainerInsert handle.
+            // If our parent is changing due to a container-insert, we let the container insert event handle that. Note
+            // that the in-container flag gets set BEFORE insert parent change, and gets unset before the container
+            // removal parent-change. So if it is set here, this must mean we are getting inserted.
+            //
+            // However, this means that this method will still get run in full on container removal. Additionally,
+            // because not all container removals are guaranteed to result in a parent change, container removal events
+            // also need to add the entity to a tree. So this generally results in:
+            // add-to-tree -> remove-from-tree -> add-to-tree.
+            // Though usually, `oldLookup == newLookup` for the last step. Its still shit though.
+            //
+            // TODO IMPROVE CONTAINER REMOVAL HANDLING
+
+            if (_container.IsEntityInContainer(args.Entity, meta))
+                return;
+
             if (meta.EntityLifeStage < EntityLifeStage.Initialized ||
-                _container.IsEntityInContainer(args.Entity, meta) ||
                 _mapManager.IsGrid(args.Entity) ||
                 _mapManager.IsMap(args.Entity)) return;
 
@@ -300,7 +313,6 @@ namespace Robust.Shared.GameObjects
 
         private void OnContainerRemove(EntRemovedFromContainerMessage ev)
         {
-            // This gets handled before parent change so that should just early out from lookups matching.
             var xformQuery = GetEntityQuery<TransformComponent>();
             var xform = xformQuery.GetComponent(ev.Entity);
             var lookup = GetLookup(ev.Entity, xform, xformQuery);
@@ -313,10 +325,13 @@ namespace Robust.Shared.GameObjects
         private void OnContainerInsert(EntInsertedIntoContainerMessage ev)
         {
             var xformQuery = GetEntityQuery<TransformComponent>();
-            var xform = xformQuery.GetComponent(ev.Entity);
-            var lookup = GetLookup(ev.Entity, xform, xformQuery);
 
-            RemoveFromEntityTree(lookup, xform, xformQuery);
+            if (ev.OldParent == EntityUid.Invalid || !xformQuery.TryGetComponent(ev.OldParent, out var oldXform))
+                return;
+
+            var lookup = GetLookup(ev.OldParent, oldXform, xformQuery);
+
+            RemoveFromEntityTree(lookup, xformQuery.GetComponent(ev.Entity), xformQuery);
         }
 
         private void AddToEntityTree(

--- a/Robust.UnitTesting/Server/GameObjects/Components/Container_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/Components/Container_Test.cs
@@ -304,10 +304,10 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
             public override List<EntityUid> ExpectedEntities => _expectedEntities;
 
             /// <inheritdoc />
-            protected override void InternalInsert(EntityUid toinsert, IEntityManager entMan)
+            protected override void InternalInsert(EntityUid toinsert, EntityUid oldParent, IEntityManager entMan)
             {
                 _containerList.Add(toinsert);
-                base.InternalInsert(toinsert, entMan);
+                base.InternalInsert(toinsert, oldParent, entMan);
             }
 
             /// <inheritdoc />


### PR DESCRIPTION
Container insert events were removing an entity from the lookup tree corresponding to the current-transform/parent, rather than the one it was in prior to insertion.