### PR TITLE
Fix nested container insert bug

### DIFF
--- a/Robust.Shared/Containers/IContainer.cs
+++ b/Robust.Shared/Containers/IContainer.cs
@@ -109,8 +109,9 @@ namespace Robust.Shared.Containers
         /// </summary>
         /// <param name="toremove">The entity to attempt to remove.</param>
         /// <param name="entMan"></param>
+        /// <param name="reparent">If true, will attempt to re-parent the entity to the container's parent, or the grid/map. If false, will not update the transform.</param>
         /// <returns>True if the entity was removed, false otherwise.</returns>
-        bool Remove(EntityUid toremove, IEntityManager? entMan = null, TransformComponent? xform = null, MetaDataComponent? meta = null);
+        bool Remove(EntityUid toremove, IEntityManager? entMan = null, TransformComponent? xform = null, MetaDataComponent? meta = null, bool reparent = true);
 
         /// <summary>
         /// Forcefully removes an entity from the container. Normally you would want to use <see cref="Remove" />,


### PR DESCRIPTION
Currently inserting an entity into a new container, when that entity is already stored inside of a container that is itself inside another another container can cause the "is-in-container" metadata flag to be improperly set to false. e.g., in ss14 moving an item from an equipped backpack to a player's hands results in the flag being set to false.

The reason for this is that before inserting the entity & setting the flag, the storage system will remove the entity from the old container, which makes sense. But this ends up calling `xform.AttachParentToContainerOrGrid()`. If the container was nested, this then tries to reinsert the entity into another container. The result is that a re-parenting after the flag has been set will then unset the flag.

This PR fixes this by just making the reparenting on container removal optional and adding a debug assert.

