### PR TITLE
Make unknown component errors more helpful

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -566,7 +566,9 @@ namespace Robust.Shared.GameObjects
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool HasComponent<T>(EntityUid uid)
         {
-            return _entTraitArray[CompIdx.ArrayIndex<T>()].TryGetValue(uid, out var comp) && !comp.Deleted;
+            var dict = _entTraitArray[CompIdx.ArrayIndex<T>()];
+            DebugTools.Assert(dict != null, $"Unknown component: {typeof(T).Name}");
+            return dict!.TryGetValue(uid, out var comp) && !comp.Deleted;
         }
 
         /// <inheritdoc />
@@ -647,7 +649,8 @@ namespace Robust.Shared.GameObjects
         public T GetComponent<T>(EntityUid uid)
         {
             var dict = _entTraitArray[CompIdx.ArrayIndex<T>()];
-            if (dict.TryGetValue(uid, out var comp))
+            DebugTools.Assert(dict != null, $"Unknown component: {typeof(T).Name}");
+            if (dict!.TryGetValue(uid, out var comp))
             {
                 if (!comp.Deleted)
                 {
@@ -697,7 +700,8 @@ namespace Robust.Shared.GameObjects
         public bool TryGetComponent<T>(EntityUid uid, [NotNullWhen(true)] out T? component)
         {
             var dict = _entTraitArray[CompIdx.ArrayIndex<T>()];
-            if (dict.TryGetValue(uid, out var comp))
+            DebugTools.Assert(dict != null, $"Unknown component: {typeof(T).Name}");
+            if (dict!.TryGetValue(uid, out var comp))
             {
                 if (!comp.Deleted)
                 {
@@ -826,7 +830,9 @@ namespace Robust.Shared.GameObjects
 
         public EntityQuery<TComp1> GetEntityQuery<TComp1>() where TComp1 : Component
         {
-            return new EntityQuery<TComp1>(_entTraitArray[CompIdx.ArrayIndex<TComp1>()]);
+            var comps = _entTraitArray[CompIdx.ArrayIndex<TComp1>()];
+            DebugTools.Assert(comps != null, $"Unknown component: {typeof(TComp1).Name}");
+            return new EntityQuery<TComp1>(comps!);
         }
 
         /// <inheritdoc />
@@ -884,10 +890,11 @@ namespace Robust.Shared.GameObjects
         public IEnumerable<T> EntityQuery<T>(bool includePaused = false) where T : IComponent
         {
             var comps = _entTraitArray[CompIdx.ArrayIndex<T>()];
+            DebugTools.Assert(comps != null, $"Unknown component: {typeof(T).Name}");
 
             if (includePaused)
             {
-                foreach (var t1Comp in comps.Values)
+                foreach (var t1Comp in comps!.Values)
                 {
                     if (t1Comp.Deleted) continue;
 
@@ -898,7 +905,7 @@ namespace Robust.Shared.GameObjects
             {
                 var metaComps = _entTraitArray[CompIdx.ArrayIndex<MetaDataComponent>()];
 
-                foreach (var t1Comp in comps.Values)
+                foreach (var t1Comp in comps!.Values)
                 {
                     if (t1Comp.Deleted || !metaComps.TryGetValue(t1Comp.Owner, out var metaComp)) continue;
 


### PR DESCRIPTION
Currently users trying to check for or get an invalid component just encounter a null reference exception, which has caused confusion on several occasions. This just adds some asserts to hopefully make the actual error clearer.