### PR TITLE
Uninitialized component joint fix on the client

### DIFF
--- a/Robust.Client/Physics/JointSystem.cs
+++ b/Robust.Client/Physics/JointSystem.cs
@@ -16,6 +16,7 @@ namespace Robust.Client.Physics
 
         private void HandleComponentState(EntityUid uid, JointComponent component, ref ComponentHandleState args)
         {
+            if (!component.Initialized) return;
             if (args.Current is not JointComponent.JointComponentState jointState) return;
 
             var changed = new List<string>();


### PR DESCRIPTION
Avoids changing joints on an Uninitialized joint component on the client, which does not work.
Fixes "Tried to add joint to ineligible bodies" error messages on making, and restarting a map on the client in some cases.