### PR TITLE
Joint changes

### DIFF
--- a/Robust.Client/Physics/JointSystem.cs
+++ b/Robust.Client/Physics/JointSystem.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
+using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Dynamics.Joints;
 
@@ -18,50 +19,63 @@ namespace Robust.Client.Physics
         {
             if (args.Current is not JointComponent.JointComponentState jointState) return;
 
-            var changed = new List<string>();
-
-            foreach (var (existing, _) in component.Joints)
+            // Initial state gets applied before the entity (& entity's transform) have been initialized.
+            // So just let joint init code handle that.
+            if (!component.Initialized)
             {
-                if (!jointState.Joints.ContainsKey(existing))
+                component.Joints.Clear();
+                foreach (var (id, state) in jointState.Joints)
                 {
-                    changed.Add(existing);
+                    component.Joints[id] = state.GetJoint();
                 }
+                return;
             }
 
-            foreach (var removed in changed)
+            var removed = new List<Joint>();
+            foreach (var (existing, j) in component.Joints)
             {
-                RemoveJoint(component.Joints[removed]);
+                if (!jointState.Joints.ContainsKey(existing))
+                    removed.Add(j);
+            }
+
+            foreach (var j in removed)
+            {
+                RemoveJoint(j);
             }
 
             foreach (var (id, state) in jointState.Joints)
             {
-                Joint joint;
-
-                if (!component.Joints.ContainsKey(id))
+                if (component.Joints.TryGetValue(id, out var joint))
                 {
-                    // Add new joint (if possible).
-                    // Need to wait for BOTH joint components to come in first before we can add it. Yay dependencies!
-                    if (!EntityManager.HasComponent<JointComponent>(state.UidA) ||
-                        !EntityManager.HasComponent<JointComponent>(state.UidB)) continue;
-
-                    joint = state.GetJoint();
-                    AddJoint(joint);
+                    joint.ApplyState(state);
                     continue;
                 }
 
-                joint = state.GetJoint();
-                var existing = component.Joints[id];
+                var other = state.UidA == uid ? state.UidB : state.UidA;
 
-                if (!existing.Equals(joint))
+
+                // Add new joint (if possible).
+                // Need to wait for BOTH joint components to come in first before we can add it. Yay dependencies!
+                if (!EntityManager.HasComponent<JointComponent>(other))
+                    continue;
+
+                // TODO: if (other entity is outside of PVS range) continue;
+                // for now, half-assed check until something like PR #3000 gets merged.
+                if (Transform(other).MapID == MapId.Nullspace)
+                    continue;
+
+                // oh jolly what good fun: the joint component state can get handled prior to the transform component state.
+                // so if our current transform is on another map, this would throw an error.
+                // so lets just... assume the server state isn't messed up, and defer the joint processing.
+                // alternatively:
+                // TODO: component state handling ordering.
+                if (Transform(uid).MapID == MapId.Nullspace)
                 {
-                    existing.ApplyState(state);
-                    component.Dirty();
+                    AddedJoints.Add(state.GetJoint());
+                    continue;
                 }
-            }
 
-            if (changed.Count > 0)
-            {
-                component.Dirty();
+                AddJoint(state.GetJoint());
             }
         }
     }

--- a/Robust.Shared/Physics/Dynamics/Joints/FrictionJoint.cs
+++ b/Robust.Shared/Physics/Dynamics/Joints/FrictionJoint.cs
@@ -51,18 +51,7 @@ namespace Robust.Shared.Physics.Dynamics.Joints
 
         public override Joint GetJoint()
         {
-            var entityManager = IoCManager.Resolve<IEntityManager>();
-            var bodyA = entityManager.GetComponent<PhysicsComponent>(UidA);
-            var bodyB = entityManager.GetComponent<PhysicsComponent>(UidB);
-
-            var joint = new FrictionJoint(bodyA, bodyB)
-            {
-                MaxForce = MaxForce,
-                MaxTorque = MaxTorque,
-                LocalAnchorA = LocalAnchorA,
-                LocalAnchorB = LocalAnchorB,
-            };
-            return joint;
+            return new FrictionJoint(this);
         }
     }
 
@@ -121,8 +110,8 @@ namespace Robust.Shared.Physics.Dynamics.Joints
         {
             if (useWorldCoordinates)
             {
-                LocalAnchorA = BodyA.GetLocalPoint(anchor);
-                LocalAnchorB = BodyB.GetLocalPoint(anchor);
+                LocalAnchorA = bodyA.GetLocalPoint(anchor);
+                LocalAnchorB = bodyB.GetLocalPoint(anchor);
             }
             else
             {
@@ -136,14 +125,20 @@ namespace Robust.Shared.Physics.Dynamics.Joints
         {
             if (useWorldCoordinates)
             {
-                LocalAnchorA = BodyA.GetLocalPoint(Vector2.Zero);
-                LocalAnchorB = BodyB.GetLocalPoint(Vector2.Zero);
+                LocalAnchorA = bodyA.GetLocalPoint(Vector2.Zero);
+                LocalAnchorB = bodyB.GetLocalPoint(Vector2.Zero);
             }
             else
             {
                 LocalAnchorA = Vector2.Zero;
                 LocalAnchorB = Vector2.Zero;
             }
+        }
+
+        internal FrictionJoint(FrictionJointState state) : base(state)
+        {
+            MaxForce = state.MaxForce;
+            MaxTorque = state.MaxTorque;
         }
 
         public override JointState GetState()
@@ -173,16 +168,16 @@ namespace Robust.Shared.Physics.Dynamics.Joints
             return invDt * _angularImpulse;
         }
 
-        internal override void InitVelocityConstraints(SolverData data)
+        internal override void InitVelocityConstraints(SolverData data, PhysicsComponent bodyA, PhysicsComponent bodyB)
         {
-            _indexA = BodyA.IslandIndex[data.IslandIndex];
-            _indexB = BodyB.IslandIndex[data.IslandIndex];
-            _localCenterA = BodyA.LocalCenter;
-            _localCenterB = BodyB.LocalCenter;
-            _invMassA = BodyA.InvMass;
-            _invMassB = BodyB.InvMass;
-            _invIA = BodyA.InvI;
-            _invIB = BodyB.InvI;
+            _indexA = bodyA.IslandIndex[data.IslandIndex];
+            _indexB = bodyB.IslandIndex[data.IslandIndex];
+            _localCenterA = bodyA.LocalCenter;
+            _localCenterB = bodyB.LocalCenter;
+            _invMassA = bodyA.InvMass;
+            _invMassB = bodyB.InvMass;
+            _invIA = bodyA.InvI;
+            _invIB = bodyB.InvI;
 
             float aA = data.Angles[_indexA];
             Vector2 vA = data.LinearVelocities[_indexA];
@@ -225,7 +220,7 @@ namespace Robust.Shared.Physics.Dynamics.Joints
             }
 
             // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-            if (IoCManager.Resolve<IConfigurationManager>().GetCVar(CVars.WarmStarting))
+            if (data.WarmStarting)
             {
                 // Scale impulses to support a variable time step.
                 _linearImpulse *= data.DtRatio;

--- a/Robust.Shared/Physics/Dynamics/Joints/Joint.cs
+++ b/Robust.Shared/Physics/Dynamics/Joints/Joint.cs
@@ -115,20 +115,8 @@ namespace Robust.Shared.Physics.Dynamics.Joints
         /// <value>The type of the joint.</value>
         public abstract JointType JointType { get; }
 
-        /// <summary>
-        ///     Get the first body attached to this joint.
-        /// </summary>
-        public PhysicsComponent BodyA =>
-            IoCManager.Resolve<IEntityManager>().GetComponent<PhysicsComponent>(BodyAUid);
-
         [DataField("bodyA")]
         public EntityUid BodyAUid { get; init; }
-
-        /// <summary>
-        ///     Get the second body attached to this joint.
-        /// </summary>
-        public PhysicsComponent BodyB =>
-            IoCManager.Resolve<IEntityManager>().GetComponent<PhysicsComponent>(BodyBUid);
 
         [DataField("bodyB")]
         public EntityUid BodyBUid { get; init; }
@@ -183,7 +171,7 @@ namespace Robust.Shared.Physics.Dynamics.Joints
         }
 
         [DataField("collideConnected")]
-        private bool _collideConnected = true;
+        protected bool _collideConnected = true;
 
         /// <summary>
         ///     The Breakpoint simply indicates the maximum Value the JointError can be before it breaks.
@@ -210,10 +198,16 @@ namespace Robust.Shared.Physics.Dynamics.Joints
         // serializer.DataField(this, x => x.BodyA, "bodyA", EntityUid.Invalid);
         // serializer.DataField(this, x => x.BodyB, "bodyB", Ent);
 
-        protected void Dirty()
+        protected void Dirty(IEntityManager? entMan = null)
         {
-            BodyA.Dirty();
-            BodyB.Dirty();
+            // TODO: move dirty & setter functions to a system.
+            IoCManager.Resolve(ref entMan);
+
+            if (entMan.TryGetComponent(BodyAUid, out PhysicsComponent? physics))
+                entMan.Dirty(physics);
+
+            if (entMan.TryGetComponent(BodyBUid, out physics))
+                entMan.Dirty(physics);
         }
 
         protected Joint() {}
@@ -225,6 +219,18 @@ namespace Robust.Shared.Physics.Dynamics.Joints
 
             //Can't connect a joint to the same body twice.
             Debug.Assert(BodyAUid != BodyBUid);
+        }
+
+        protected Joint(JointState state)
+        {
+            ID = state.ID;
+            BodyAUid = state.UidA;
+            BodyBUid = state.UidB;
+            _enabled = state.Enabled;
+            _collideConnected = state.CollideConnected;
+            _localAnchorA = state.LocalAnchorA;
+            _localAnchorB = state.LocalAnchorB;
+            _breakpoint = state.Breakpoint;
         }
 
         /// <summary>
@@ -266,7 +272,7 @@ namespace Robust.Shared.Physics.Dynamics.Joints
         /// <param name="invDt">The inverse delta time.</param>
         public abstract float GetReactionTorque(float invDt);
 
-        internal abstract void InitVelocityConstraints(SolverData data);
+        internal abstract void InitVelocityConstraints(SolverData data, PhysicsComponent bodyA, PhysicsComponent bodyB);
 
         internal float Validate(float invDt)
         {

--- a/Robust.Shared/Physics/Dynamics/Joints/MouseJoint.cs
+++ b/Robust.Shared/Physics/Dynamics/Joints/MouseJoint.cs
@@ -39,20 +39,7 @@ internal sealed class MouseJointState : JointState
 
     public override Joint GetJoint()
     {
-        var joint = new MouseJoint(UidA, UidB, LocalAnchorA, LocalAnchorB)
-        {
-            ID = ID,
-            Breakpoint = Breakpoint,
-            CollideConnected = CollideConnected,
-            Enabled = Enabled,
-            Damping = Damping,
-            Stiffness = Stiffness,
-            MaxForce = MaxForce,
-            LocalAnchorA = LocalAnchorA,
-            LocalAnchorB = LocalAnchorB
-        };
-
-        return joint;
+        return new MouseJoint(this);
     }
 }
 
@@ -146,6 +133,13 @@ public sealed class MouseJoint : Joint, IEquatable<MouseJoint>
         LocalAnchorB = localAnchorB;
     }
 
+    internal MouseJoint(MouseJointState state) : base(state)
+    {
+        Damping = state.Damping;
+        Stiffness = state.Stiffness;
+        MaxForce = state.MaxForce;
+    }
+
     public override JointState GetState()
     {
         var mouseState = new MouseJointState
@@ -174,10 +168,8 @@ public sealed class MouseJoint : Joint, IEquatable<MouseJoint>
     private int _indexB;
     private Vector2 _localCenterB;
 
-    internal override void InitVelocityConstraints(SolverData data)
+    internal override void InitVelocityConstraints(SolverData data, PhysicsComponent bodyA, PhysicsComponent bodyB)
     {
-        var bodyB = BodyB;
-
         _indexB = bodyB.IslandIndex[data.IslandIndex];
         _localCenterB = bodyB.LocalCenter;
         _invMassB = bodyB.InvMass;

--- a/Robust.Shared/Physics/Dynamics/Joints/PrismaticJoint.cs
+++ b/Robust.Shared/Physics/Dynamics/Joints/PrismaticJoint.cs
@@ -104,25 +104,7 @@ namespace Robust.Shared.Physics.Dynamics.Joints
 
         public override Joint GetJoint()
         {
-            var joint = new PrismaticJoint(UidA, UidB)
-            {
-                ID = ID,
-                Breakpoint = Breakpoint,
-                CollideConnected = CollideConnected,
-                Enabled = Enabled,
-                LocalAxisA = LocalAxisA,
-                ReferenceAngle = ReferenceAngle,
-                EnableLimit = EnableLimit,
-                LowerTranslation = LowerTranslation,
-                UpperTranslation = UpperTranslation,
-                EnableMotor = EnableMotor,
-                MaxMotorForce = MaxMotorForce,
-                MotorSpeed = MotorSpeed,
-                LocalAnchorA = LocalAnchorA,
-                LocalAnchorB = LocalAnchorB
-            };
-
-            return joint;
+            return new PrismaticJoint(this);
         }
 
     }
@@ -237,6 +219,18 @@ namespace Robust.Shared.Physics.Dynamics.Joints
             ReferenceAngle = (float) (xformB.WorldRotation - xformA.WorldRotation);
         }
 
+        internal PrismaticJoint(PrismaticJointState state) : base(state)
+        {
+            LocalAxisA = state.LocalAxisA;
+            ReferenceAngle = state.ReferenceAngle;
+            EnableLimit = state.EnableLimit;
+            LowerTranslation = state.LowerTranslation;
+            UpperTranslation = state.UpperTranslation;
+            EnableMotor = state.EnableMotor;
+            MaxMotorForce = state.MaxMotorForce;
+            MotorSpeed = state.MotorSpeed;
+        }
+
         public override JointType JointType => JointType.Prismatic;
 
         public override JointState GetState()
@@ -261,18 +255,18 @@ namespace Robust.Shared.Physics.Dynamics.Joints
             return invDt * _impulse.Y;
         }
 
-        internal override void InitVelocityConstraints(SolverData data)
+        internal override void InitVelocityConstraints(SolverData data, PhysicsComponent bodyA, PhysicsComponent bodyB)
         {
-            _indexA = BodyA.IslandIndex[data.IslandIndex];
-	        _indexB = BodyB.IslandIndex[data.IslandIndex];
-	        _localCenterA = BodyA.LocalCenter;
-	        _localCenterB = BodyB.LocalCenter;
-	        _invMassA = BodyA.InvMass;
-	        _invMassB = BodyB.InvMass;
-	        _invIA = BodyA.InvI;
-	        _invIB = BodyB.InvI;
+            _indexA = bodyA.IslandIndex[data.IslandIndex];
+            _indexB = bodyB.IslandIndex[data.IslandIndex];
+            _localCenterA = bodyA.LocalCenter;
+            _localCenterB = bodyB.LocalCenter;
+            _invMassA = bodyA.InvMass;
+            _invMassB = bodyB.InvMass;
+            _invIA = bodyA.InvI;
+            _invIB = bodyB.InvI;
 
-	        var cA = data.Positions[_indexA];
+            var cA = data.Positions[_indexA];
 	        float aA = data.Angles[_indexA];
 	        var vA = data.Positions[_indexA];
 	        float wA = data.Angles[_indexA];

--- a/Robust.Shared/Physics/Dynamics/Joints/RevoluteJoint.cs
+++ b/Robust.Shared/Physics/Dynamics/Joints/RevoluteJoint.cs
@@ -42,24 +42,7 @@ namespace Robust.Shared.Physics.Dynamics.Joints
 
         public override Joint GetJoint()
         {
-            var joint = new RevoluteJoint(UidA, UidB)
-            {
-                ID = ID,
-                Breakpoint = Breakpoint,
-                CollideConnected = CollideConnected,
-                Enabled = Enabled,
-                EnableLimit = EnableLimit,
-                EnableMotor = EnableMotor,
-                ReferenceAngle = ReferenceAngle,
-                LowerAngle = LowerAngle,
-                UpperAngle = UpperAngle,
-                MotorSpeed = MotorSpeed,
-                MaxMotorTorque = MaxMotorTorque,
-                LocalAnchorA = LocalAnchorA,
-                LocalAnchorB = LocalAnchorB
-            };
-
-            return joint;
+            return new RevoluteJoint(this);
         }
     }
 
@@ -136,6 +119,17 @@ namespace Robust.Shared.Physics.Dynamics.Joints
 
         public RevoluteJoint(EntityUid bodyAUid, EntityUid bodyBUid) : base(bodyAUid, bodyBUid) {}
 
+        internal RevoluteJoint(RevoluteJointState state) : base(state)
+        {
+            EnableLimit = state.EnableLimit;
+            EnableMotor = state.EnableMotor;
+            ReferenceAngle = state.ReferenceAngle;
+            LowerAngle = state.LowerAngle;
+            UpperAngle = state.UpperAngle;
+            MotorSpeed = state.MotorSpeed;
+            MaxMotorTorque = state.MaxMotorTorque;
+        }
+
         public override JointType JointType => JointType.Revolute;
 
         public override JointState GetState()
@@ -171,18 +165,18 @@ namespace Robust.Shared.Physics.Dynamics.Joints
             return invDt * (_motorImpulse + _lowerImpulse - _upperImpulse);
         }
 
-        internal override void InitVelocityConstraints(SolverData data)
+        internal override void InitVelocityConstraints(SolverData data, PhysicsComponent bodyA, PhysicsComponent bodyB)
         {
-            _indexA = BodyA.IslandIndex[data.IslandIndex];
-	        _indexB = BodyB.IslandIndex[data.IslandIndex];
-            _localCenterA = BodyA.LocalCenter;
-            _localCenterB = BodyB.LocalCenter;
-	        _invMassA = BodyA.InvMass;
-	        _invMassB = BodyB.InvMass;
-	        _invIA = BodyA.InvI;
-	        _invIB = BodyB.InvI;
+            _indexA = bodyA.IslandIndex[data.IslandIndex];
+            _indexB = bodyB.IslandIndex[data.IslandIndex];
+            _localCenterA = bodyA.LocalCenter;
+            _localCenterB = bodyB.LocalCenter;
+            _invMassA = bodyA.InvMass;
+            _invMassB = bodyB.InvMass;
+            _invIA = bodyA.InvI;
+            _invIB = bodyB.InvI;
 
-	        float aA = data.Angles[_indexA];
+            float aA = data.Angles[_indexA];
 	        var vA = data.LinearVelocities[_indexA];
 	        float wA = data.AngularVelocities[_indexA];
 

--- a/Robust.Shared/Physics/Dynamics/Joints/WeldJoint.cs
+++ b/Robust.Shared/Physics/Dynamics/Joints/WeldJoint.cs
@@ -16,20 +16,7 @@ namespace Robust.Shared.Physics.Dynamics.Joints
 
         public override Joint GetJoint()
         {
-            var joint = new WeldJoint(UidA, UidB)
-            {
-                ID = ID,
-                Breakpoint = Breakpoint,
-                CollideConnected = CollideConnected,
-                Enabled = Enabled,
-                LocalAnchorA = LocalAnchorA,
-                LocalAnchorB = LocalAnchorB,
-                Stiffness = Stiffness,
-                Damping = Damping,
-                Bias = Bias,
-            };
-
-            return joint;
+            return new WeldJoint(this);
         }
     }
 
@@ -83,6 +70,13 @@ namespace Robust.Shared.Physics.Dynamics.Joints
 
         public WeldJoint(EntityUid bodyAUid, EntityUid bodyBUid) : base(bodyAUid, bodyBUid) {}
 
+        internal WeldJoint(WeldJointState state) : base(state)
+        {
+            Stiffness = state.Stiffness;
+            Damping = state.Damping;
+            Bias = state.Bias;
+        }
+
         public override JointType JointType => JointType.Weld;
         public override JointState GetState()
         {
@@ -103,19 +97,19 @@ namespace Robust.Shared.Physics.Dynamics.Joints
             return invDt * _impulse.Z;
         }
 
-        internal override void InitVelocityConstraints(SolverData data)
+        internal override void InitVelocityConstraints(SolverData data, PhysicsComponent bodyA, PhysicsComponent bodyB)
         {
-            _indexA = BodyA.IslandIndex[data.IslandIndex];
-	        _indexB = BodyB.IslandIndex[data.IslandIndex];
-            _localCenterA = BodyA.LocalCenter;
-	        _localCenterB = BodyB.LocalCenter;
-	        _invMassA = BodyA.InvMass;
-	        _invMassB = BodyB.InvMass;
-	        _invIA = BodyA.InvI;
-	        _invIB = BodyB.InvI;
+            _indexA = bodyA.IslandIndex[data.IslandIndex];
+            _indexB = bodyB.IslandIndex[data.IslandIndex];
+            _localCenterA = bodyA.LocalCenter;
+            _localCenterB = bodyB.LocalCenter;
+            _invMassA = bodyA.InvMass;
+            _invMassB = bodyB.InvMass;
+            _invIA = bodyA.InvI;
+            _invIB = bodyB.InvI;
 
-	        float aA = data.Angles[_indexA];
-	        var vA = data.LinearVelocities[_indexA];
+            float aA = data.Angles[_indexA];
+            var vA = data.LinearVelocities[_indexA];
 	        float wA = data.AngularVelocities[_indexA];
 
 	        float aB = data.Angles[_indexB];

--- a/Robust.Shared/Physics/Dynamics/PhysicsIsland.cs
+++ b/Robust.Shared/Physics/Dynamics/PhysicsIsland.cs
@@ -166,7 +166,7 @@ stored in a single array since multiple arrays lead to multiple misses.
 
         public PhysicsComponent[] Bodies = Array.Empty<PhysicsComponent>();
         private Contact[] _contacts = Array.Empty<Contact>();
-        private Joint[] _joints = Array.Empty<Joint>();
+        private (Joint Joint, PhysicsComponent BodyA, PhysicsComponent BodyB)[] _joints = Array.Empty<(Joint Joint, PhysicsComponent BodyA, PhysicsComponent BodyB)>();
 
         private List<(Joint Joint, float ErrorSquared)> _brokenJoints = new();
 
@@ -251,9 +251,12 @@ stored in a single array since multiple arrays lead to multiple misses.
                 Add(contact);
             }
 
+            var query = _entityManager.GetEntityQuery<PhysicsComponent>();
             foreach (var joint in joints)
             {
-                Add(joint);
+                var bodyA = query.GetComponent(joint.BodyAUid);
+                var bodyB = query.GetComponent(joint.BodyBUid);
+                Add((joint, bodyA, bodyB));
             }
         }
 
@@ -268,7 +271,7 @@ stored in a single array since multiple arrays lead to multiple misses.
             _contacts[ContactCount++] = contact;
         }
 
-        public void Add(Joint joint)
+        public void Add((Joint Joint, PhysicsComponent BodyA, PhysicsComponent BodyB) joint)
         {
             _joints[JointCount++] = joint;
         }
@@ -391,9 +394,9 @@ stored in a single array since multiple arrays lead to multiple misses.
 
             for (var i = 0; i < JointCount; i++)
             {
-                var joint = _joints[i];
+                var (joint, bodyA, bodyB) = _joints[i];
                 if (!joint.Enabled) continue;
-                joint.InitVelocityConstraints(SolverData);
+                joint.InitVelocityConstraints(SolverData, bodyA, bodyB);
             }
 
             // Velocity solver
@@ -401,7 +404,7 @@ stored in a single array since multiple arrays lead to multiple misses.
             {
                 for (var j = 0; j < JointCount; ++j)
                 {
-                    Joint joint = _joints[j];
+                    Joint joint = _joints[j].Joint;
 
                     if (!joint.Enabled)
                         continue;
@@ -462,7 +465,7 @@ stored in a single array since multiple arrays lead to multiple misses.
 
                 for (int j = 0; j < JointCount; ++j)
                 {
-                    var joint = _joints[j];
+                    var joint = _joints[j].Joint;
 
                     if (!joint.Enabled)
                         continue;

--- a/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
+++ b/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
@@ -300,7 +300,9 @@ namespace Robust.Shared.Physics.Dynamics
                     {
                         if (joint.IslandFlag) continue;
 
-                        var other = joint.BodyA == body ? joint.BodyB : joint.BodyA;
+                        var other = joint.BodyAUid == body.Owner
+                            ? _entityManager.GetComponent<PhysicsComponent>(joint.BodyBUid)
+                            : _entityManager.GetComponent<PhysicsComponent>(joint.BodyAUid);
 
                         // Don't simulate joints connected to inactive bodies.
                         if (!other.CanCollide) continue;

--- a/Robust.Shared/Physics/JointComponent.cs
+++ b/Robust.Shared/Physics/JointComponent.cs
@@ -18,8 +18,7 @@ namespace Robust.Shared.Physics
         [ViewVariables]
         public int JointCount => Joints.Count;
 
-        [ViewVariables]
-        public IEnumerable<Joint> GetJoints => Joints.Values;
+        public IReadOnlyDictionary<string, Joint> GetJoints => Joints;
 
         [DataField("joints")]
         internal Dictionary<string, Joint> Joints = new();

--- a/Robust.Shared/Physics/SharedJointSystem.cs
+++ b/Robust.Shared/Physics/SharedJointSystem.cs
@@ -135,10 +135,10 @@ namespace Robust.Shared.Physics
             var aUid = joint.BodyAUid;
             var bUid = joint.BodyBUid;
 
-            DebugTools.Assert(Transform(aUid).MapID == Transform(bUid).MapID, "Attempted to initialize cross-map joint");
-
             if (!TryComp<PhysicsComponent>(aUid, out var bodyA) ||
                 !TryComp<PhysicsComponent>(bUid, out var bodyB)) return;
+
+            DebugTools.Assert(Transform(aUid).MapID == Transform(bUid).MapID, "Attempted to initialize cross-map joint");
 
             var jointComponentA = EnsureComp<JointComponent>(bodyA.Owner);
             var jointComponentB = EnsureComp<JointComponent>(bodyB.Owner);


### PR DESCRIPTION
There are currently some issues with how the JointComponent state handling works. If some entity starts pulling something and they then leave & re-enter PVS, or the client just disconnects and reconnects, then state application will error and can cause pulling mispredicts. This PR partially fixes it, but there is still some jank where it currently needs to defer joint adding when the transform state has not yet been applied.

- Joint state handling can now deal with with uninitialized components & unapplied states
- `JointState.GetJoint()` now constructs a joint using only the state, without trying to fetch components of other entities (which might not exist yet).
- Removed the `Joint`'s PhysicsComponent getter function.
  - Now InitVelocityConstraints() requires the components to be passed in.
  - `PhysicsIland`s now store a `List<(Joint, PhysicsComponent, PhysicsComponent)>` rather than just a joint list
  - No more calling ` IoCManager.Resolve<IEntityManager>().GetComponent<PhysicsComponent>();` 8 or more times per joint in each physics step.


Content has similar issues with state handling, because the pulling state handling modified the joint state, but that should get fixed by space-wizards/space-station-14/pull/9952. That PR is also required because it removes some references to the removed getter functions.


