### PR TITLE
Fix broadphase desync

### DIFF
--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -71,7 +71,7 @@ namespace Robust.Shared.GameObjects
 
             SubscribeLocalEvent<EntityLookupComponent, ComponentAdd>(OnLookupAdd);
             SubscribeLocalEvent<EntityLookupComponent, ComponentShutdown>(OnLookupShutdown);
-            SubscribeLocalEvent<GridInitializeEvent>(OnGridInit);
+            SubscribeLocalEvent<GridAddEvent>(OnGridAdd);
 
             EntityManager.EntityInitialized += OnEntityInit;
             SubscribeLocalEvent<MapChangedEvent>(OnMapCreated);
@@ -147,7 +147,7 @@ namespace Robust.Shared.GameObjects
             component.Tree.Clear();
         }
 
-        private void OnGridInit(GridInitializeEvent ev)
+        private void OnGridAdd(GridAddEvent ev)
         {
             EntityManager.EnsureComponent<EntityLookupComponent>(ev.EntityUid);
         }

--- a/Robust.Shared/Map/MapManager.MapCollection.cs
+++ b/Robust.Shared/Map/MapManager.MapCollection.cs
@@ -174,7 +174,8 @@ internal partial class MapManager
         // Yeah this sucks but I just want to save maps for now, deal.
         if (raiseEvent)
         {
-            OnMapCreatedGridTree(new MapEventArgs(mapId));
+            var args = new MapEventArgs(mapId);
+            OnMapCreatedGridTree(args);
             var ev = new MapChangedEvent(mapId, true);
             EntityManager.EventBus.RaiseLocalEvent(newMapEntity, ev, true);
         }

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -67,7 +67,7 @@ namespace Robust.Shared.Physics
             UpdatesAfter.Add(typeof(SharedTransformSystem));
 
             SubscribeLocalEvent<BroadphaseComponent, ComponentAdd>(OnBroadphaseAdd);
-            SubscribeLocalEvent<GridInitializeEvent>(OnGridAdd);
+            SubscribeLocalEvent<GridAddEvent>(OnGridAdd);
 
             SubscribeLocalEvent<CollisionChangeEvent>(OnPhysicsUpdate);
 
@@ -867,8 +867,9 @@ namespace Robust.Shared.Physics
             _moveBuffer.Remove(e.Map);
         }
 
-        private void OnGridAdd(GridInitializeEvent ev)
+        private void OnGridAdd(GridAddEvent ev)
         {
+            // Must be done before initialization as that's when broadphase data starts getting set.
             EnsureComp<BroadphaseComponent>(ev.EntityUid);
         }
 


### PR DESCRIPTION
So this is another fun MAPLOADER ONE.

The issue is because GridInitialize is being used for the broadphase there's ordering bugs where the grid is being initialized AFTER all these bodies are being added to the (map's) broadphase. The workaround for now is to just do it in Add instead (until maploader properly goes top-down).

Fixes https://github.com/space-wizards/RobustToolbox/issues/3077