### PR TITLE
Automatic simple component state networking

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -434,7 +434,7 @@ namespace Robust.Client.GameStates
                 {
                     var state = _entityManager.GetComponentState(bus, component);
 
-                    if(state.GetType() == typeof(ComponentState))
+                    if(state == null)
                         continue;
 
                     compData.Add(netId, state);

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -921,7 +921,7 @@ internal sealed partial class PVSSystem : EntitySystem
             else
             {
                 DebugTools.Assert(changeState);
-                changed.Add(ComponentChange.Changed(netId, EntityManager.GetComponentState(bus, component)));
+                changed.Add(ComponentChange.Changed(netId, EntityManager.GetComponentState(bus, component) ?? new ComponentState()));
             }
         }
 

--- a/Robust.Shared/GameObjects/Component.cs
+++ b/Robust.Shared/GameObjects/Component.cs
@@ -204,7 +204,7 @@ namespace Robust.Shared.GameObjects
             IoCManager.Resolve(ref entManager);
             entManager.Dirty(this);
         }
-        
+
         /// <inheritdoc />
         public virtual ComponentState? GetComponentState()
         {

--- a/Robust.Shared/GameObjects/Component.cs
+++ b/Robust.Shared/GameObjects/Component.cs
@@ -204,9 +204,7 @@ namespace Robust.Shared.GameObjects
             IoCManager.Resolve(ref entManager);
             entManager.Dirty(this);
         }
-
-        private static readonly ComponentState DefaultComponentState = new();
-
+        
         /// <inheritdoc />
         public virtual ComponentState? GetComponentState()
         {

--- a/Robust.Shared/GameObjects/Component.cs
+++ b/Robust.Shared/GameObjects/Component.cs
@@ -208,13 +208,13 @@ namespace Robust.Shared.GameObjects
         private static readonly ComponentState DefaultComponentState = new();
 
         /// <inheritdoc />
-        public virtual ComponentState GetComponentState()
+        public virtual ComponentState? GetComponentState()
         {
             DebugTools.Assert(
                 Attribute.GetCustomAttribute(GetType(), typeof(NetworkedComponentAttribute)) != null,
                 $"Calling base {nameof(GetComponentState)} without being networked.");
 
-            return DefaultComponentState;
+            return null;
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -1154,10 +1154,12 @@ namespace Robust.Shared.GameObjects
             {
                 // If there's a field in the component with the same name as the state,
                 // set the state to the components field.
-                if (compFields.FirstOrDefault(f => f.Name == field.Name) is { } applicable)
-                {
-                    field.SetValue(state, applicable.GetValue(comp));
-                }
+                if (compFields.FirstOrDefault(f => f.Name == field.Name) is not { } applicable)
+                    continue;
+
+                DebugTools.Assert(applicable.FieldType == field.FieldType,
+                    $"Field {field.Name} on {comp.Name} had matching field for auto-generating on {stateType.Name}, but their types differ! {field.FieldType.Name} vs {applicable.FieldType.Name}");
+                field.SetValue(state, applicable.GetValue(comp));
             }
 
             return (ComponentState) state;

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -1149,6 +1149,7 @@ namespace Robust.Shared.GameObjects
         private static ComponentState AutoGenerateState(IComponent comp, Type compType, Type stateType)
         {
             var compFields = compType.GetFields();
+
             var state = Activator.CreateInstance(stateType)!;
             foreach (var field in stateType.GetFields())
             {
@@ -1161,6 +1162,9 @@ namespace Robust.Shared.GameObjects
                     $"Field {field.Name} on {comp.Name} had matching field for auto-generating on {stateType.Name}, but their types differ! {field.FieldType.Name} vs {applicable.FieldType.Name}");
                 field.SetValue(state, applicable.GetValue(comp));
             }
+
+            DebugTools.Assert(typeof(ComponentState).IsAssignableFrom(stateType),
+                $"State type {stateType} is not an inheritor of {nameof(ComponentState)}!");
 
             return (ComponentState) state;
         }

--- a/Robust.Shared/GameObjects/IComponent.cs
+++ b/Robust.Shared/GameObjects/IComponent.cs
@@ -73,7 +73,7 @@ namespace Robust.Shared.GameObjects
         ///     Get the component's state for replicating on the client.
         /// </summary>
         /// <returns>ComponentState object</returns>
-        ComponentState GetComponentState();
+        ComponentState? GetComponentState();
 
         /// <summary>
         ///     Handles an incoming component state from the server.

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -348,7 +348,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="component">Component to generate the state for.</param>
         /// <returns>The component state of the component.</returns>
         ///
-        ComponentState GetComponentState(IEventBus eventBus, IComponent component);
+        ComponentState? GetComponentState(IEventBus eventBus, IComponent component);
 
         /// <summary>
         ///     Checks if a certain player should get a component state.

--- a/Robust.Shared/GameStates/NetworkedComponentAttribute.cs
+++ b/Robust.Shared/GameStates/NetworkedComponentAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using Robust.Shared.GameObjects;
 
 namespace Robust.Shared.GameStates
 {
@@ -6,5 +7,17 @@ namespace Robust.Shared.GameStates
     /// This attribute marks a component as networked, so that it is replicated to clients.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
-    public sealed class NetworkedComponentAttribute : Attribute { }
+    public sealed class NetworkedComponentAttribute : Attribute
+    {
+        /// <summary>
+        ///     Optionally defines which type to use for automatic component state creation, if <see cref="ComponentGetState"/>
+        ///     is not handled. Must be an inheritor of <see cref="ComponentState"/>.
+        /// </summary>
+        public Type? ComponentStateType;
+
+        public NetworkedComponentAttribute(Type? componentStateType=null)
+        {
+            ComponentStateType = componentStateType;
+        }
+    }
 }

--- a/Robust.UnitTesting/Server/GameObjects/Components/Container_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/Components/Container_Test.cs
@@ -278,7 +278,7 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
             container.Insert(childEnt);
 
             var containerMan = IoCManager.Resolve<IEntityManager>().GetComponent<IContainerManager>(entity);
-            var state = (ContainerManagerComponent.ContainerManagerComponentState)containerMan.GetComponentState();
+            var state = (ContainerManagerComponent.ContainerManagerComponentState)containerMan.GetComponentState()!;
 
             Assert.That(state.ContainerSet.Count, Is.EqualTo(1));
             Assert.That(state.ContainerSet[0].Id, Is.EqualTo("dummy"));


### PR DESCRIPTION
## Why

In content a common pattern emerges, where you have some very simple component state, and the get/handling process entirely just involves getting/setting the fields on the state (which have the same name as the component's fields) as-is, like so:

```csharp
    private void OnComponentGetState(EntityUid uid, IdCardComponent component, ref ComponentGetState args)
    {
        args.State = new IdCardComponentState(component.FullName, component.JobTitle);
    }

    private void OnComponentHandleState(EntityUid uid, IdCardComponent component, ref ComponentHandleState args)
    {
        if (args.Current is IdCardComponentState state)
        {
            component.FullName = state.FullName;
            component.JobTitle = state.JobTitle;
        }
    }
```

This feels terrible and makes it a pain to network basic components, and can also be a little confusing to explain why this is needed at all. All in all should be able to see why reducing the boilerplate here is good

## How

`NetworkedComponentAttribute` optionally takes in a type which inherits from `ComponentState`:
```csharp
[NetworkedComponent(typeof(IdCardComponentState))]
```

The data you want to auto-network is defined on the component state type, and must have the same name as the fields on the component:

```csharp
        // Component fields
		...
        [DataField("fullName")]
        [Access(typeof(SharedIdCardSystem), typeof(SharedPDASystem), typeof(SharedAgentIdCardSystem),
            Other = AccessPermissions.ReadWrite)] // FIXME Friends
        public string? FullName;

        [DataField("jobTitle")]
        public string? JobTitle;
		...

		// Component state fields
		...
		public string? FullName;
        public string? JobTitle;
		...
```

For get-state:
- First, attempt to get the state through a component event & override
- If fail, check if a state type is specified on the attribute and autogenerate
- Create an instance of the new state, then go over all the fields on the state type, match them to fields on the component, & fill them in on the state

For handle-state:
- Attempt to auto-handle state first for easy setting of values
- Check for the specified state type, go over all the fields on it, match to component fields, then fill in fields on the component
- Then, handle state through the component event & override

## Caveats / Misc

- This only works with fields, not properties. Shouldn't be an issue as components should be data-only anyway.
- Component states that want this now require a parameterless ctor. It's possible (and would be nice) to circumvent this and just call the normal ctor instead of `Activator.CreateInstance` (like EFcore can https://docs.microsoft.com/en-us/ef/core/modeling/constructors) but I'll figure it out later I'm lazy.
- There is probably a very minor perf hit, in that handlestate now needs to get the networked attribute regardless of if the auto handling is done at all (getstate can early out 99% of the time). But this is so negligible that its almost certainly fine.
- This will require documentation and a #codebase-changes post since it's perhaps unintuitive. I'm willing to write both of these obviously
- `GetComponentState` was made to return a nullable state instead of an empty component state, and a check in gamestate manager was changed which used to just check for it being the base type which was ugly.