### PR TITLE
Fix awake-physics map change bug

### DIFF
--- a/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/GameObjects/Components/Collidable/PhysicsComponent.Physics.cs
@@ -140,7 +140,7 @@ namespace Robust.Shared.GameObjects
 
         private bool _awake = false;
 
-        private void SetAwake(bool value, bool updateSleepTime = true)
+        public void SetAwake(bool value, bool updateSleepTime = true)
         {
             if (_awake == value)
                 return;

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.Components.cs
@@ -27,7 +27,6 @@ public partial class SharedPhysicsSystem
 
         if (component._canCollide && xform.MapID != MapId.Nullspace)
         {
-            bool awake;
             var physicsMap = EntityManager.GetComponent<SharedPhysicsMapComponent>(MapManager.GetMapEntityId(xform.MapID));
 
             if (component.BodyType != BodyType.Static &&

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.Components.cs
@@ -28,7 +28,6 @@ public partial class SharedPhysicsSystem
         if (component._canCollide && xform.MapID != MapId.Nullspace)
         {
             bool awake;
-            component._awake = false;
             var physicsMap = EntityManager.GetComponent<SharedPhysicsMapComponent>(MapManager.GetMapEntityId(xform.MapID));
 
             if (component.BodyType != BodyType.Static &&
@@ -36,19 +35,8 @@ public partial class SharedPhysicsSystem
                  !component.LinearVelocity.Equals(Vector2.Zero) ||
                  !component.AngularVelocity.Equals(0f)))
             {
-                awake = true;
-            }
-            else
-            {
-                awake = false;
-            }
-
-            if (awake)
                 component.Awake = true;
-        }
-        else
-        {
-            component._awake = false;
+            }
         }
 
         // Gets added to broadphase via fixturessystem

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -146,25 +146,32 @@ namespace Robust.Shared.GameObjects
             if (args.OldMapId == MapId.Nullspace && xform.MapID == MapId.Nullspace)
                 return;
 
-            if (TryComp(uid, out PhysicsComponent? body) && (meta.Flags & MetaDataFlags.InContainer) != 0)
-            {
-                // Here we intentionally dont dirty the physics comp. Client-side state handling will apply these same
-                // changes. This also ensures that the server doesn't have to send the physics comp state to every
-                // player for any entity inside of a container during init.
-                SetLinearVelocity(body, Vector2.Zero, false);
-                SetAngularVelocity(body, 0, false);
-                SetCanCollide(body, false, false);
-                _joints.ClearJoints(body);
-            }
+            var body = CompOrNull<PhysicsComponent>(uid);
 
             // Handle map changes
             if (args.OldMapId != xform.MapID)
             {
                 // This will also handle broadphase updating & joint clearing.
                 HandleMapChange(xform, body, args.OldMapId, xform.MapID);
-                return;
             }
 
+            if (body != null && (meta.Flags & MetaDataFlags.InContainer) != 0)
+            {
+                // Here we intentionally dont dirty the physics comp. Client-side state handling will apply these same
+                // changes. This also ensures that the server doesn't have to send the physics comp state to every
+                // player for any entity inside of a container during init.
+                SetLinearVelocity(body, Vector2.Zero, false);
+                SetAngularVelocity(body, 0, false);
+
+                // This needs to get called AFTER handle map change Otherwise this will set awake to false, but will
+                // fail to remove the body from the "current map" (which should really be the old map).
+                SetCanCollide(body, false, false);
+                _joints.ClearJoints(body);
+            }
+
+            if (args.OldMapId != xform.MapID)
+                return;
+            
             _broadphase.UpdateBroadphase(uid, args.OldMapId, xform: xform);
 
             if (body != null)
@@ -216,12 +223,6 @@ namespace Robust.Shared.GameObjects
             // This entity may not have a body, but some of its children might:
             if (body != null)
             {
-                // TODO: Could potentially migrate these but would need more thinking
-                if (oldMap != null)
-                    DestroyContacts(body, oldMap);
-
-                DebugTools.Assert(body.Contacts.Count == 0);
-
                 if (body.Awake)
                 {
                     oldMap?.RemoveSleepBody(body);
@@ -230,6 +231,11 @@ namespace Robust.Shared.GameObjects
                 }
                 else
                     DebugTools.Assert(oldMap?.AwakeBodies.Contains(body) != true);
+
+                // TODO: Could potentially migrate these but would need more thinking
+                if (oldMap != null)
+                    DestroyContacts(body, oldMap); // This can modify body.Awake
+                DebugTools.Assert(body.Contacts.Count == 0);
 
                 if (fixturesQuery.TryGetComponent(uid, out var fixtures) && body._canCollide)
                 {

--- a/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
+++ b/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
@@ -137,6 +137,7 @@ namespace Robust.Shared.Physics.Dynamics
                 return;
             }
 
+            DebugTools.Assert(body.Awake);
             AwakeBodies.Add(body);
         }
 
@@ -262,7 +263,7 @@ namespace Robust.Shared.Physics.Dynamics
                     if (body.BodyType == BodyType.Static) continue;
 
                     // As static bodies can never be awake (unlike Farseer) we'll set this after the check.
-                    body.ForceAwake();
+                    body.SetAwake(true, updateSleepTime: false);
 
                     var node = body.Contacts.First;
 


### PR DESCRIPTION
If an entity gets inserted into a container on another map, this can result in it not being removed from the original map's list of awake bodies. The container check was setting awake to false before the map change logic was getting run.

This PR fixes that and also makes some other misc changes:
- The Awake setter now just calls `SetAwake()` directly. Some of the checks from the setter were moved into `SetAwake()`
- ForceAwake is now just an optional bool for SetAwake