### PR TITLE
Update ImageSharp and fix incompatibilities

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.cs
@@ -14,9 +14,10 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
-using Robust.Shared.Maths;
 using Robust.Shared.Profiling;
 using Robust.Shared.Timing;
+using SixLabors.ImageSharp;
+using Color = Robust.Shared.Maths.Color;
 using DependencyAttribute = Robust.Shared.IoC.DependencyAttribute;
 
 namespace Robust.Client.Graphics.Clyde
@@ -75,6 +76,7 @@ namespace Robust.Client.Graphics.Clyde
         {
             _currentBoundRenderTarget = default!;
             _currentRenderTarget = default!;
+            Configuration.Default.PreferContiguousImageBuffers = true;
         }
 
         public bool InitializePreWindowing()

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -37,6 +37,8 @@ namespace Robust.Client.Graphics.Clyde
 
         public ClydeHeadless()
         {
+            Configuration.Default.PreferContiguousImageBuffers = true;
+
             var mainRt = new DummyRenderWindow(this);
             var window = new DummyWindow(mainRt) {Id = new WindowId(1)};
 

--- a/Robust.Client/Robust.Client.csproj
+++ b/Robust.Client/Robust.Client.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.2" />
     <PackageReference Include="nfluidsynth" Version="0.3.1" />
     <PackageReference Include="NVorbis" Version="0.10.1" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
     <PackageReference Include="OpenToolkit.Graphics" Version="4.0.0-pre9.1" />
     <PackageReference Include="OpenToolkit.OpenAL" Version="4.0.0-pre9.1" />
     <PackageReference Include="SpaceWizards.SharpFont" Version="1.0.1" />

--- a/Robust.Client/Utility/ImageSharpExt.cs
+++ b/Robust.Client/Utility/ImageSharpExt.cs
@@ -66,12 +66,12 @@ namespace Robust.Client.Utility
         /// <exception cref="ArgumentException">Thrown if the image is not a single contiguous buffer.</exception>
         public static Span<T> GetPixelSpan<T>(this Image<T> image) where T : unmanaged, IPixel<T>
         {
-            if (!image.TryGetSinglePixelSpan(out var span))
+            if (!image.DangerousTryGetSinglePixelMemory(out var memory))
             {
                 throw new ArgumentException("Image is not backed by a single buffer, cannot fetch span.");
             }
 
-            return span;
+            return memory.Span;
         }
     }
 }


### PR DESCRIPTION
I updated ImageSharp to the latest version. This is required for changes to the map renderer. Esp. for exporting to lossless webp.

The only breaking change I could find is that `TryGetSinglePixelSpan` is now `DangerousTryGetSinglePixelMemory` which returns a memory object that contains the span and that `PreferContiguousImageBuffers` needed to be set to true.

I started up the game, ran tests and ran the map renderer and everything works fine.