### PR TITLE
BUI range check changes

### DIFF
--- a/Robust.Server/GameObjects/Components/UserInterface/ServerUserInterfaceComponent.cs
+++ b/Robust.Server/GameObjects/Components/UserInterface/ServerUserInterfaceComponent.cs
@@ -81,6 +81,8 @@ namespace Robust.Server.GameObjects
     {
         private bool _isActive;
 
+        public float InteractionRangeSqrd;
+
         public object UiKey { get; }
         public ServerUserInterfaceComponent Owner { get; }
         private readonly HashSet<IPlayerSession> _subscribedSessions = new();
@@ -105,6 +107,7 @@ namespace Robust.Server.GameObjects
             RequireInputValidation = data.RequireInputValidation;
             UiKey = data.UiKey;
             Owner = owner;
+            InteractionRangeSqrd = data.InteractionRange * MathF.Abs(data.InteractionRange);
         }
 
         /// <summary>

--- a/Robust.Server/Placement/PlacementManager.cs
+++ b/Robust.Server/Placement/PlacementManager.cs
@@ -79,7 +79,7 @@ namespace Robust.Server.Placement
             var dirRcv = msg.DirRcv;
 
             var session = _playerManager.GetSessionByChannel(msg.MsgChannel);
-            var plyEntity = session.AttachedEntityTransform;
+            var plyEntity = _entityManager.GetComponentOrNull<TransformComponent>(session.AttachedEntity);
 
             // Don't have an entity, don't get to place.
             if (plyEntity == null)

--- a/Robust.Shared/GameObjects/Components/UserInterface/SharedUserInterfaceComponent.cs
+++ b/Robust.Shared/GameObjects/Components/UserInterface/SharedUserInterfaceComponent.cs
@@ -22,6 +22,12 @@ namespace Robust.Shared.GameObjects
             [DataField("type", readOnly: true, required: true)]
             public string ClientType { get; set; } = default!;
 
+            /// <summary>
+            ///     Maximum range before a BUI auto-closes. A non-positive number means there is no limit.
+            /// </summary>
+            [DataField("range")]
+            public float InteractionRange = 2f;
+
             // TODO BUI move to content?
             // I've tried to keep the name general, but really this is a bool for: can ghosts/stunned/dead people press buttons on this UI?
             /// <summary>


### PR DESCRIPTION
- Uses transform queries
- Allows the max range to be set by each BUI
- No longer uses `ICommonSession.AttachedEntityTransform` (hidden `IoCManager.Resolve<IEntityManager>()`).
  - Also removes a use in placement manager. 