### PR TITLE
More BUI changes

### DIFF
--- a/Robust.Client/GameObjects/Components/UserInterface/ClientUserInterfaceComponent.cs
+++ b/Robust.Client/GameObjects/Components/UserInterface/ClientUserInterfaceComponent.cs
@@ -96,15 +96,16 @@ namespace Robust.Client.GameObjects
     /// </summary>
     public abstract class BoundUserInterface : IDisposable
     {
-        public readonly ClientUserInterfaceComponent Owner;
+        protected ClientUserInterfaceComponent Owner { get; }
+
         public readonly Enum UiKey;
 
         /// <summary>
         ///     The last received state object sent from the server.
         /// </summary>
-        public BoundUserInterfaceState? State { get; private set; }
+        protected BoundUserInterfaceState? State { get; private set; }
 
-        public BoundUserInterface(ClientUserInterfaceComponent owner, Enum uiKey)
+        protected BoundUserInterface(ClientUserInterfaceComponent owner, Enum uiKey)
         {
             Owner = owner;
             UiKey = uiKey;

--- a/Robust.Client/GameObjects/Components/UserInterface/ClientUserInterfaceComponent.cs
+++ b/Robust.Client/GameObjects/Components/UserInterface/ClientUserInterfaceComponent.cs
@@ -5,13 +5,12 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Reflection;
 using Robust.Shared.Serialization;
-using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.ViewVariables;
 
 namespace Robust.Client.GameObjects
 {
     [ComponentReference(typeof(SharedUserInterfaceComponent))]
-    public sealed class ClientUserInterfaceComponent : SharedUserInterfaceComponent, ISerializationHooks
+    public sealed class ClientUserInterfaceComponent : SharedUserInterfaceComponent
     {
         [Dependency] private readonly IReflectionManager _reflectionManager = default!;
         [Dependency] private readonly IDynamicTypeFactory _dynamicTypeFactory = default!;
@@ -19,26 +18,13 @@ namespace Robust.Client.GameObjects
         [Dependency] private readonly IEntityManager _entityManager = default!;
         [Dependency] private readonly IEntityNetworkManager _netMan = default!;
 
-        private readonly Dictionary<object, BoundUserInterface> _openInterfaces =
+        internal readonly Dictionary<Enum, BoundUserInterface> _openInterfaces =
             new();
 
-        private readonly Dictionary<object, PrototypeData> _interfaces = new();
-
-        [DataField("interfaces", readOnly: true)]
-        private List<PrototypeData> _interfaceData = new();
+        internal readonly Dictionary<Enum, PrototypeData> _interfaces = new();
 
         [ViewVariables]
         public IEnumerable<BoundUserInterface> Interfaces => _openInterfaces.Values;
-
-        void ISerializationHooks.AfterDeserialization()
-        {
-            _interfaces.Clear();
-
-            foreach (var data in _interfaceData)
-            {
-                _interfaces[data.UiKey] = data;
-            }
-        }
 
         internal void MessageReceived(BoundUIWrapMessage msg)
         {
@@ -73,7 +59,7 @@ namespace Robust.Client.GameObjects
             // TODO: This type should be cached, but I'm too lazy.
             var type = _reflectionManager.LooseGetType(data.ClientType);
             var boundInterface =
-                (BoundUserInterface) _dynamicTypeFactory.CreateInstance(type, new[] {this, wrapped.UiKey});
+                (BoundUserInterface) _dynamicTypeFactory.CreateInstance(type, new object[] {this, wrapped.UiKey});
             boundInterface.Open();
             _openInterfaces[wrapped.UiKey] = boundInterface;
 
@@ -82,7 +68,7 @@ namespace Robust.Client.GameObjects
                 _entityManager.EventBus.RaiseLocalEvent(Owner, new BoundUIOpenedEvent(wrapped.UiKey, Owner, playerSession), true);
         }
 
-        internal void Close(object uiKey, bool remoteCall)
+        internal void Close(Enum uiKey, bool remoteCall)
         {
             if (!_openInterfaces.TryGetValue(uiKey, out var boundUserInterface))
             {
@@ -99,7 +85,7 @@ namespace Robust.Client.GameObjects
                 _entityManager.EventBus.RaiseLocalEvent(Owner, new BoundUIClosedEvent(uiKey, Owner, playerSession), true);
         }
 
-        internal void SendMessage(BoundUserInterfaceMessage message, object uiKey)
+        internal void SendMessage(BoundUserInterfaceMessage message, Enum uiKey)
         {
             _netMan.SendSystemNetworkMessage(new BoundUIWrapMessage(Owner, message, uiKey));
         }
@@ -110,15 +96,15 @@ namespace Robust.Client.GameObjects
     /// </summary>
     public abstract class BoundUserInterface : IDisposable
     {
-        protected ClientUserInterfaceComponent Owner { get; }
-        protected object UiKey { get; }
+        public readonly ClientUserInterfaceComponent Owner;
+        public readonly Enum UiKey;
 
         /// <summary>
         ///     The last received state object sent from the server.
         /// </summary>
-        protected BoundUserInterfaceState? State { get; private set; }
+        public BoundUserInterfaceState? State { get; private set; }
 
-        protected BoundUserInterface(ClientUserInterfaceComponent owner, object uiKey)
+        public BoundUserInterface(ClientUserInterfaceComponent owner, Enum uiKey)
         {
             Owner = owner;
             UiKey = uiKey;
@@ -149,7 +135,7 @@ namespace Robust.Client.GameObjects
         /// <summary>
         ///     Invoked to close the UI.
         /// </summary>
-        protected void Close()
+        public void Close()
         {
             Owner.Close(UiKey, false);
         }
@@ -157,7 +143,7 @@ namespace Robust.Client.GameObjects
         /// <summary>
         ///     Sends a message to the server-side UI.
         /// </summary>
-        protected void SendMessage(BoundUserInterfaceMessage message)
+        public void SendMessage(BoundUserInterfaceMessage message)
         {
             Owner.SendMessage(message, UiKey);
         }

--- a/Robust.Client/GameObjects/EntitySystems/UserInterfaceSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/UserInterfaceSystem.cs
@@ -1,4 +1,4 @@
-﻿using JetBrains.Annotations;
+using JetBrains.Annotations;
 using Robust.Client.Player;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -16,8 +16,16 @@ namespace Robust.Client.GameObjects
 
             SubscribeNetworkEvent<BoundUIWrapMessage>(MessageReceived);
             SubscribeLocalEvent<ClientUserInterfaceComponent, ComponentShutdown>(OnUserInterfaceShutdown);
+            SubscribeLocalEvent<ClientUserInterfaceComponent, ComponentInit>(OnAdd);
         }
 
+        private void OnAdd(EntityUid uid, ClientUserInterfaceComponent component, ComponentInit args)
+        {
+            foreach (var data in component._interfaceData)
+            {
+                component._interfaces.Add(data.UiKey, data);
+            }
+        }
         private void OnUserInterfaceShutdown(EntityUid uid, ClientUserInterfaceComponent component, ComponentShutdown args)
         {
             foreach (var bui in component.Interfaces)

--- a/Robust.Server/GameObjects/EntitySystems/UserInterfaceSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/UserInterfaceSystem.cs
@@ -198,7 +198,7 @@ namespace Robust.Server.GameObjects
         }
 
         #region Get BUI
-        public bool HasUi(EntityUid uid, object uiKey, ServerUserInterfaceComponent? ui = null)
+        public bool HasUi(EntityUid uid, Enum uiKey, ServerUserInterfaceComponent? ui = null)
         {
             if (!Resolve(uid, ref ui))
                 return false;
@@ -206,7 +206,7 @@ namespace Robust.Server.GameObjects
             return ui._interfaces.ContainsKey(uiKey);
         }
 
-        public BoundUserInterface GetUi(EntityUid uid, object uiKey, ServerUserInterfaceComponent? ui = null)
+        public BoundUserInterface GetUi(EntityUid uid, Enum uiKey, ServerUserInterfaceComponent? ui = null)
         {
             if (!Resolve(uid, ref ui))
                 throw new InvalidOperationException($"Cannot get {typeof(BoundUserInterface)} from an entity without {typeof(ServerUserInterfaceComponent)}!");
@@ -214,14 +214,14 @@ namespace Robust.Server.GameObjects
             return ui._interfaces[uiKey];
         }
 
-        public BoundUserInterface? GetUiOrNull(EntityUid uid, object uiKey, ServerUserInterfaceComponent? ui = null)
+        public BoundUserInterface? GetUiOrNull(EntityUid uid, Enum uiKey, ServerUserInterfaceComponent? ui = null)
         {
             return TryGetUi(uid, uiKey, out var bui, ui)
                 ? bui
                 : null;
         }
 
-        public bool TryGetUi(EntityUid uid, object uiKey, [NotNullWhen(true)] out BoundUserInterface? bui, ServerUserInterfaceComponent? ui = null)
+        public bool TryGetUi(EntityUid uid, Enum uiKey, [NotNullWhen(true)] out BoundUserInterface? bui, ServerUserInterfaceComponent? ui = null)
         {
             bui = null;
 
@@ -229,7 +229,7 @@ namespace Robust.Server.GameObjects
         }
         #endregion
 
-        public bool IsUiOpen(EntityUid uid, object uiKey, ServerUserInterfaceComponent? ui = null)
+        public bool IsUiOpen(EntityUid uid, Enum uiKey, ServerUserInterfaceComponent? ui = null)
         {
             if (!TryGetUi(uid, uiKey, out var bui, ui))
                 return false;
@@ -237,7 +237,7 @@ namespace Robust.Server.GameObjects
             return bui.SubscribedSessions.Count > 0;
         }
 
-        public bool SessionHasOpenUi(EntityUid uid, object uiKey, IPlayerSession session, ServerUserInterfaceComponent? ui = null)
+        public bool SessionHasOpenUi(EntityUid uid, Enum uiKey, IPlayerSession session, ServerUserInterfaceComponent? ui = null)
         {
             if (!TryGetUi(uid, uiKey, out var bui, ui))
                 return false;
@@ -259,7 +259,7 @@ namespace Robust.Server.GameObjects
         ///     Set to null for sending it to every subscribed player session.
         /// </param>
         public bool TrySetUiState(EntityUid uid,
-            object uiKey,
+            Enum uiKey,
             BoundUserInterfaceState state,
             IPlayerSession? session = null,
             ServerUserInterfaceComponent? ui = null,
@@ -305,7 +305,7 @@ namespace Robust.Server.GameObjects
         /// <summary>
         ///     Switches between closed and open for a specific client.
         /// </summary>
-        public bool TryToggleUi(EntityUid uid, object uiKey, IPlayerSession session, ServerUserInterfaceComponent? ui = null)
+        public bool TryToggleUi(EntityUid uid, Enum uiKey, IPlayerSession session, ServerUserInterfaceComponent? ui = null)
         {
             if (!TryGetUi(uid, uiKey, out var bui, ui))
                 return false;
@@ -327,7 +327,7 @@ namespace Robust.Server.GameObjects
 
         #region Open
 
-        public bool TryOpen(EntityUid uid, object uiKey, IPlayerSession session, ServerUserInterfaceComponent? ui = null)
+        public bool TryOpen(EntityUid uid, Enum uiKey, IPlayerSession session, ServerUserInterfaceComponent? ui = null)
         {
             if (!TryGetUi(uid, uiKey, out var bui, ui))
                 return false;
@@ -362,7 +362,7 @@ namespace Robust.Server.GameObjects
         #endregion
 
         #region Close
-        public bool TryClose(EntityUid uid, object uiKey, IPlayerSession session, ServerUserInterfaceComponent? ui = null)
+        public bool TryClose(EntityUid uid, Enum uiKey, IPlayerSession session, ServerUserInterfaceComponent? ui = null)
         {
             if (!TryGetUi(uid, uiKey, out var bui, ui))
                 return false;
@@ -392,7 +392,6 @@ namespace Robust.Server.GameObjects
             if (_openInterfaces.TryGetValue(session, out var buis))
                 buis.Remove(bui);
 
-            bui.InvokeOnClosed(session);
             RaiseLocalEvent(owner, new BoundUIClosedEvent(bui.UiKey, owner, session));
 
             if (bui._subscribedSessions.Count == 0)
@@ -418,7 +417,7 @@ namespace Robust.Server.GameObjects
         /// <summary>
         ///     Closes this specific interface for any clients that have it open.
         /// </summary>
-        public bool TryCloseAll(EntityUid uid, object uiKey, ServerUserInterfaceComponent? ui = null)
+        public bool TryCloseAll(EntityUid uid, Enum uiKey, ServerUserInterfaceComponent? ui = null)
         {
             if (!TryGetUi(uid, uiKey, out var bui, ui))
                 return false;
@@ -443,7 +442,7 @@ namespace Robust.Server.GameObjects
         /// <summary>
         ///     Send a BUI message to all connected player sessions.
         /// </summary>
-        public bool TrySendUiMessage(EntityUid uid, object uiKey, BoundUserInterfaceMessage message, ServerUserInterfaceComponent? ui = null)
+        public bool TrySendUiMessage(EntityUid uid, Enum uiKey, BoundUserInterfaceMessage message, ServerUserInterfaceComponent? ui = null)
         {
             if (!TryGetUi(uid, uiKey, out var bui, ui))
                 return false;
@@ -467,7 +466,7 @@ namespace Robust.Server.GameObjects
         /// <summary>
         ///     Send a BUI message to a specific player session.
         /// </summary>
-        public bool TrySendUiMessage(EntityUid uid, object uiKey, BoundUserInterfaceMessage message, IPlayerSession session, ServerUserInterfaceComponent? ui = null)
+        public bool TrySendUiMessage(EntityUid uid, Enum uiKey, BoundUserInterfaceMessage message, IPlayerSession session, ServerUserInterfaceComponent? ui = null)
         {
             if (!TryGetUi(uid, uiKey, out var bui, ui))
                 return false;

--- a/Robust.Server/GameObjects/EntitySystems/UserInterfaceSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/UserInterfaceSystem.cs
@@ -30,7 +30,16 @@ namespace Robust.Server.GameObjects
 
             SubscribeNetworkEvent<BoundUIWrapMessage>(OnMessageReceived);
             SubscribeLocalEvent<ServerUserInterfaceComponent, ComponentShutdown>(OnUserInterfaceShutdown);
+            SubscribeLocalEvent<ServerUserInterfaceComponent, ComponentInit>(OnAdd);
             _playerMan.PlayerStatusChanged += OnPlayerStatusChanged;
+        }
+
+        private void OnAdd(EntityUid uid, ServerUserInterfaceComponent component, ComponentInit args)
+        {
+            foreach (var data in component._interfaceData)
+            {
+                component._interfaces.Add(data.UiKey, new(data, component));
+            }
         }
 
         public override void Shutdown()

--- a/Robust.Shared/GameObjects/Components/UserInterface/SharedUserInterfaceComponent.cs
+++ b/Robust.Shared/GameObjects/Components/UserInterface/SharedUserInterfaceComponent.cs
@@ -11,7 +11,7 @@ namespace Robust.Shared.GameObjects
     public abstract class SharedUserInterfaceComponent : Component
     {
         [DataField("interfaces")]
-        protected List<PrototypeData> _interfaceData = new();
+        internal List<PrototypeData> _interfaceData = new();
 
         [DataDefinition]
         public sealed class PrototypeData

--- a/Robust.Shared/GameObjects/Components/UserInterface/SharedUserInterfaceComponent.cs
+++ b/Robust.Shared/GameObjects/Components/UserInterface/SharedUserInterfaceComponent.cs
@@ -1,8 +1,7 @@
 using System;
+using System.Collections.Generic;
 using Robust.Shared.GameStates;
-using Robust.Shared.IoC;
 using Robust.Shared.Players;
-using Robust.Shared.Reflection;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
 
@@ -11,13 +10,14 @@ namespace Robust.Shared.GameObjects
     [NetworkedComponent]
     public abstract class SharedUserInterfaceComponent : Component
     {
-        [DataDefinition]
-        public sealed class PrototypeData : ISerializationHooks
-        {
-            public object UiKey { get; set; } = default!;
+        [DataField("interfaces")]
+        protected List<PrototypeData> _interfaceData = new();
 
+        [DataDefinition]
+        public sealed class PrototypeData
+        {
             [DataField("key", readOnly: true, required: true)]
-            private string _uiKeyRaw = default!;
+            public Enum UiKey { get; set; } = default!;
 
             [DataField("type", readOnly: true, required: true)]
             public string ClientType { get; set; } = default!;
@@ -38,19 +38,6 @@ namespace Robust.Shared.GameObjects
             /// </remarks>
             [DataField("requireInputValidation")]
             public bool RequireInputValidation = true;
-
-            void ISerializationHooks.AfterDeserialization()
-            {
-                var reflectionManager = IoCManager.Resolve<IReflectionManager>();
-
-                if (reflectionManager.TryParseEnumReference(_uiKeyRaw, out var @enum))
-                {
-                    UiKey = @enum;
-                    return;
-                }
-
-                UiKey = _uiKeyRaw;
-            }
         }
     }
 
@@ -62,9 +49,9 @@ namespace Robust.Shared.GameObjects
     {
         public readonly ICommonSession Sender;
         public readonly EntityUid Target;
-        public readonly object UiKey;
+        public readonly Enum UiKey;
 
-        public BoundUserInterfaceMessageAttempt(ICommonSession sender, EntityUid target, object uiKey)
+        public BoundUserInterfaceMessageAttempt(ICommonSession sender, EntityUid target, Enum uiKey)
         {
             Sender = sender;
             Target = target;
@@ -85,7 +72,7 @@ namespace Robust.Shared.GameObjects
         ///     The UI of this message.
         ///     Only set when the message is raised as a directed event.
         /// </summary>
-        public object UiKey { get; set; } = default!;
+        public Enum UiKey { get; set; } = default!;
 
         /// <summary>
         ///     The Entity receiving the message.
@@ -126,9 +113,9 @@ namespace Robust.Shared.GameObjects
     {
         public readonly EntityUid Entity;
         public readonly BoundUserInterfaceMessage Message;
-        public readonly object UiKey;
+        public readonly Enum UiKey;
 
-        public BoundUIWrapMessage(EntityUid entity, BoundUserInterfaceMessage message, object uiKey)
+        public BoundUIWrapMessage(EntityUid entity, BoundUserInterfaceMessage message, Enum uiKey)
         {
             Message = message;
             UiKey = uiKey;
@@ -143,7 +130,7 @@ namespace Robust.Shared.GameObjects
 
     public sealed class BoundUIOpenedEvent : BoundUserInterfaceMessage
     {
-        public BoundUIOpenedEvent(object uiKey, EntityUid uid, ICommonSession session)
+        public BoundUIOpenedEvent(Enum uiKey, EntityUid uid, ICommonSession session)
         {
             UiKey = uiKey;
             Entity = uid;
@@ -153,7 +140,7 @@ namespace Robust.Shared.GameObjects
 
     public sealed class BoundUIClosedEvent : BoundUserInterfaceMessage
     {
-        public BoundUIClosedEvent(object uiKey, EntityUid uid, ICommonSession session)
+        public BoundUIClosedEvent(Enum uiKey, EntityUid uid, ICommonSession session)
         {
             UiKey = uiKey;
             Entity = uid;

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/EnumSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/EnumSerializer.cs
@@ -1,0 +1,49 @@
+using System;
+using Robust.Shared.IoC;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+
+namespace Robust.Shared.Serialization.TypeSerializers.Implementations;
+
+/// <summary>
+///     Attempts to resolve a string into an enum. If it fails, it simply reads the string. Useful for both both sprite
+///     layer and appearance data keys, which both simultaneously support enums and strings. 
+/// </summary>
+[TypeSerializer]
+public sealed class EnumSerializer : ITypeSerializer<Enum, ValueDataNode>
+{
+    public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
+        IDependencyCollection dependencies, ISerializationContext? context = null)
+    {
+        if (serializationManager.ReflectionManager.TryParseEnumReference(node.Value, out var _, false))
+            return new ValidatedValueNode(node);
+
+        return new ErrorNode(node, $"Failed to parse enum {node.Value}");
+    }
+
+    public Enum Read(ISerializationManager serializationManager, ValueDataNode node,
+        IDependencyCollection dependencies, bool skipHook, ISerializationContext? context = null, Enum? value = null)
+    {
+        if (serializationManager.ReflectionManager.TryParseEnumReference(node.Value, out var @enum))
+            return @enum;
+
+        throw new ArgumentException($"Failed to parse enum {node.Value}");
+    }
+
+    public DataNode Write(ISerializationManager serializationManager, Enum value, bool alwaysWrite = false,
+        ISerializationContext? context = null)
+    {
+        return new ValueDataNode(serializationManager.ReflectionManager.GetEnumReference(value));
+    }
+
+    public Enum Copy(ISerializationManager serializationManager, Enum source, Enum target, bool skipHook,
+        ISerializationContext? context = null)
+    {
+        return source;
+    }
+}
+


### PR DESCRIPTION
This is basically a continuation of #3102, but this time the changes require a content PR

- Removes the `OnClosed` action
- Replace object BUI keys with Enums.
- Remove ISerializationHooks in favor of an EnumSerializer (the same one also added in #3086)
- Removes more component functions in favour of just reading from the component's dictionary.

Requires space-wizards/space-station-14/pull/10308
