### PR TITLE
Fix nullable yaml validation

### DIFF
--- a/Robust.Shared/Serialization/Manager/SerializationManager.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.cs
@@ -211,7 +211,17 @@ namespace Robust.Shared.Serialization.Manager
 
         public ValidationNode ValidateNode(Type type, DataNode node, ISerializationContext? context = null)
         {
-            var underlyingType = type.EnsureNotNullableType();
+            var underlyingType = Nullable.GetUnderlyingType(type);
+
+            if (underlyingType != null) // implies that type was nullable
+            {
+                if (node is ValueDataNode dataNode && dataNode.Value == "null")
+                    return new ValidatedValueNode(node);
+            }
+            else
+            {
+                underlyingType = type;
+            }
 
             if (underlyingType.IsArray)
             {


### PR DESCRIPTION
Currently the yaml linter will error on some "null" values.