### PR TITLE
Allow entities to be spawned directly in null-space

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -191,6 +191,14 @@ namespace Robust.Shared.GameObjects
         {
             var newEntity = CreateEntity(prototypeName);
             var transform = GetComponent<TransformComponent>(newEntity);
+
+            if (coordinates.MapId == MapId.Nullspace)
+            {
+                transform._parent = EntityUid.Invalid;
+                transform.Anchored = false;
+                return newEntity;
+            }
+
             transform.AttachParent(_mapManager.GetMapEntityId(coordinates.MapId));
 
             // TODO: Look at this bullshit. Please code a way to force-move an entity regardless of anchoring.

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -192,14 +192,24 @@ namespace Robust.Shared.GameObjects
             var newEntity = CreateEntity(prototypeName);
             var transform = GetComponent<TransformComponent>(newEntity);
 
-            if (coordinates.MapId == MapId.Nullspace)
+            var mapEnt = _mapManager.GetMapEntityId(coordinates.MapId);
+            TryGetComponent(mapEnt, out TransformComponent? mapXform);
+
+            // If the entity is being spawned in null-space, we will parent the entity to the null-map, IF it exists.
+            // For whatever reason, tests create and expect null-space to have a map entity, and it does on the client, but it
+            // intentionally doesn't on the server??
+            if (coordinates.MapId == MapId.Nullspace &&
+                mapXform == null) 
             {
                 transform._parent = EntityUid.Invalid;
                 transform.Anchored = false;
                 return newEntity;
             }
 
-            transform.AttachParent(_mapManager.GetMapEntityId(coordinates.MapId));
+            if (mapXform == null)
+                throw new ArgumentException($"Attempted to spawn entity on an invalid map. Coordinates: {coordinates}");
+
+            transform.AttachParent(mapXform);
 
             // TODO: Look at this bullshit. Please code a way to force-move an entity regardless of anchoring.
             var oldAnchored = transform.Anchored;

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -188,7 +188,8 @@ public abstract partial class SharedTransformSystem
                 }
                 else
                 {
-                    throw new InvalidOperationException("Transform node does not exist inside scene tree!");
+                    // We allow entities to be spawned directly into null-space.
+                    value = MapId.Nullspace;
                 }
             }
 


### PR DESCRIPTION
AFAIK this causes no issues, and avoids people needing to spawn into some arbitrary map and then immediately detaching the entity, as is done in space-wizards/space-station-14/pull/10348.