### PR TITLE
Fix issue with Fluents ??? for empty suffix.

### DIFF
--- a/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
+++ b/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
@@ -318,8 +318,7 @@ namespace Robust.Client.UserInterface.CustomControls
             button.ActualButton.OnToggled += OnItemButtonToggled;
             var entityLabelText = string.IsNullOrEmpty(prototype.Name) ? prototype.ID : prototype.Name;
 
-            // "{???}" value happens when Fluent can't find a value in .ftl files for EditorSuffix variable.
-            if (!string.IsNullOrWhiteSpace(prototype.EditorSuffix) && !"{???}".Equals(prototype.EditorSuffix))
+            if (!string.IsNullOrWhiteSpace(prototype.EditorSuffix))
             {
                 entityLabelText += $" [{prototype.EditorSuffix}]";
             }

--- a/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
+++ b/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.cs
@@ -318,7 +318,8 @@ namespace Robust.Client.UserInterface.CustomControls
             button.ActualButton.OnToggled += OnItemButtonToggled;
             var entityLabelText = string.IsNullOrEmpty(prototype.Name) ? prototype.ID : prototype.Name;
 
-            if (!string.IsNullOrWhiteSpace(prototype.EditorSuffix))
+            // "{???}" value happens when Fluent can't find a value in .ftl files for EditorSuffix variable.
+            if (!string.IsNullOrWhiteSpace(prototype.EditorSuffix) && !"{???}".Equals(prototype.EditorSuffix))
             {
                 entityLabelText += $" [{prototype.EditorSuffix}]";
             }

--- a/Robust.Shared/Localization/LocalizationManager.Entity.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Entity.cs
@@ -94,14 +94,16 @@ namespace Robust.Shared.Localization
 
                         var allErrors = new List<FluentError>();
                         if (desc == null
-                            && bundle.TryGetMsg(locId, "desc", null, out var err1, out desc))
+                            && !bundle.TryGetMsg(locId, "desc", null, out var err1, out desc))
                         {
+                            desc = null;
                             allErrors.AddRange(err1);
                         }
 
                         if (suffix == null
-                            && bundle.TryGetMsg(locId, "suffix", null, out var err, out suffix))
+                            && !bundle.TryGetMsg(locId, "suffix", null, out var err, out suffix))
                         {
+                            suffix = null;
                             allErrors.AddRange(err);
                         }
 


### PR DESCRIPTION
## About the PR
This fix addresses [issue 10438](https://github.com/space-wizards/space-station-14/issues/10438) from SS14 repo.

Previously there was no Fluent support for entities in the issue. So the engine used only what .yml files gave it. With .ftl files added it seems like Fluent defaults empty values for optional fields to `{???}` instead of `null` or just whitespace like with pure .yml.

Due to the value being neither `null` nor whitespace the check fails and weird `[{???}]` appears next to the names of entities in the Entity spawn panel for all Fluent-capable entities.

As mentioned in the issue by Morb0, one way to fix this is to add optional empty .suffix fields to .ftl descriptions for all entities. Obviously if this field is optional it should remain optional, so parsing changes are needed. That's what this fix is for.