### PR TITLE
Fix physics grid reparent crash

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -171,7 +171,7 @@ namespace Robust.Shared.GameObjects
 
             if (args.OldMapId != xform.MapID)
                 return;
-            
+
             _broadphase.UpdateBroadphase(uid, args.OldMapId, xform: xform);
 
             if (body != null)
@@ -237,7 +237,8 @@ namespace Robust.Shared.GameObjects
                     DestroyContacts(body, oldMap); // This can modify body.Awake
                 DebugTools.Assert(body.Contacts.Count == 0);
 
-                if (fixturesQuery.TryGetComponent(uid, out var fixtures) && body._canCollide)
+                // TODO: When we cull sharedphysicsmapcomponent we can probably remove this grid check.
+                if (!MapManager.IsGrid(uid.Value) && fixturesQuery.TryGetComponent(uid, out var fixtures) && body._canCollide)
                 {
                     // TODO If not deleting, update world position+rotation while iterating through children and pass into UpdateBodyBroadphase
                     _broadphase.UpdateBodyBroadphase(body, fixtures, xform, newBroadphase, xformQuery, oldMoveBuffer);

--- a/Robust.Shared/Physics/BroadPhase/DynamicTreeBroadPhase.cs
+++ b/Robust.Shared/Physics/BroadPhase/DynamicTreeBroadPhase.cs
@@ -22,6 +22,8 @@ namespace Robust.Shared.Physics.Broadphase
             return proxy.AABB;
         }
 
+        public int Count => _tree.NodeCount;
+
         public Box2 GetFatAabb(DynamicTree.Proxy proxy)
         {
             return _tree.GetFatAabb(proxy);

--- a/Robust.Shared/Physics/IBroadPhase.cs
+++ b/Robust.Shared/Physics/IBroadPhase.cs
@@ -7,6 +7,8 @@ namespace Robust.Shared.Physics {
 
     public interface IBroadPhase
     {
+        int Count { get; }
+
         Box2 GetFatAabb(DynamicTree.Proxy proxy);
 
         DynamicTree.Proxy AddProxy(ref FixtureProxy proxy);


### PR DESCRIPTION
Better solution would require the eventual SharedPhysicsMapComponent culling but this just fixes the debug assert in a slow way + adds a test to prevent it happening again.

Fixes https://github.com/space-wizards/RobustToolbox/issues/2989 as all of the physics re-parenting is tested (apart from awakebodies but that's going to get refactored eventually)