### PR TITLE
Don't error on missing entity suffixes

### DIFF
--- a/Robust.Shared/Localization/LocalizationManager.Entity.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Entity.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
@@ -104,7 +104,6 @@ namespace Robust.Shared.Localization
                             && !bundle.TryGetMsg(locId, "suffix", null, out var err, out suffix))
                         {
                             suffix = null;
-                            allErrors.AddRange(err);
                         }
 
                         WriteWarningForErrs(allErrors, locId);


### PR DESCRIPTION
Currently opening the spawn menu spams suffix related errors. Not all entites have a suffix in the spawn menu.

![logs](https://media.discordapp.net/attachments/790656972801572905/1008081073512648704/unknown.png)

