### PR TITLE
Fix fixture init/state bug.

### DIFF
--- a/Robust.Shared/Physics/FixtureSystem.cs
+++ b/Robust.Shared/Physics/FixtureSystem.cs
@@ -293,6 +293,7 @@ namespace Robust.Shared.Physics
                 return;
             }
 
+            component.SerializedFixtures.Clear();
             var toAddFixtures = new ValueList<Fixture>();
             var toRemoveFixtures = new ValueList<Fixture>();
             var computeProperties = false;


### PR DESCRIPTION
Currently entities will receive fixtures from the server state, and then also add the prototype-fixtures during init, which causes bugs. See space-wizards/space-station-14/issues/10559