### PR TITLE
Make ResourcePath() public

### DIFF
--- a/Robust.Shared/Utility/ResourcePath.cs
+++ b/Robust.Shared/Utility/ResourcePath.cs
@@ -1,4 +1,4 @@
-﻿// Because System.IO.Path sucks.
+// Because System.IO.Path sucks.
 
 using System;
 using System.Collections.Generic;
@@ -50,9 +50,13 @@ namespace Robust.Shared.Utility
         public string Separator { get; }
 
         /// <summary>
-        /// This exists for serv3.
+        /// This exists for serv3. Equivalent to ResourcePath("");
         /// </summary>
-        private ResourcePath() : this("") {}
+        public ResourcePath()
+        {
+            Separator = "/";
+            Segments = new string[] { "." };
+        }
 
         /// <summary>
         ///     Create a new path from a string, splitting it by the separator provided.


### PR DESCRIPTION
Alternatively:
- Serv3 could switch to using `Activator.CreateInstance(type, nonPublic: true)`?
- Or just allow type serializers to copy into null (effectively forcing them to specify their own constructor & avoiding similar errors in the future)?

On that note: #3127 takes the other approach. So I guess if that's preferable, close this pr.
