### PR TITLE
Add event for entity placement

### DIFF
--- a/Robust.Server/Placement/PlacementManager.cs
+++ b/Robust.Server/Placement/PlacementManager.cs
@@ -122,6 +122,7 @@ namespace Robust.Server.Placement
                 var created = _entityManager.SpawnEntity(entityTemplateName, coordinates);
 
                 _entityManager.GetComponent<TransformComponent>(created).LocalRotation = dirRcv.ToAngle();
+                _entityManager.EventBus.RaiseLocalEvent(created, new EntityPlacedEvent(created, session));
             }
             else
             {
@@ -346,6 +347,22 @@ namespace Robust.Server.Placement
             }
 
             return null;
+        }
+    }
+
+    /// <summary>
+    ///     Event raised when an entity has been successfully placed down.
+    /// </summary>
+    public sealed class EntityPlacedEvent : EntityEventArgs
+    {
+        public EntityUid Placed;
+
+        public IPlayerSession PlacedBy;
+
+        public EntityPlacedEvent(EntityUid placed, IPlayerSession placedBy)
+        {
+            Placed = placed;
+            PlacedBy = placedBy;
         }
     }
 }


### PR DESCRIPTION
Raises an event on entity placement, containing the freshly placed entity and the session responsible for placing the entity. This is used in https://github.com/space-wizards/space-station-14/pull/10206 to automatically attach entities to the ghost role groups.