### PR TITLE
Make tile grid placement somewhat bearable

### DIFF
--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -55,6 +55,9 @@ namespace Robust.Client.Placement
         /// </summary>
         private bool _placenextframe;
 
+        // Massive hack to avoid creating a billion grids for now.
+        private bool _gridFrameBuffer;
+
         /// <summary>
         /// Allows various types of placement as singular, line, or grid placement where placement mode allows this type of placement
         /// </summary>
@@ -259,6 +262,7 @@ namespace Robust.Client.Placement
                         if (!CurrentPermission!.IsTile)
                             HandlePlacement();
 
+                        _gridFrameBuffer = false;
                         _placenextframe = false;
                         return true;
                     }))
@@ -394,6 +398,7 @@ namespace Robust.Client.Placement
                     DeactivateSpecialPlacement();
                     break;
                 case PlacementTypes.Grid:
+                    _gridFrameBuffer = true;
                     foreach (var coordinate in CurrentMode!.GridCoordinates())
                     {
                         RequestPlacement(coordinate);
@@ -570,8 +575,10 @@ namespace Robust.Client.Placement
             _pendingTileChanges.RemoveAll(c => c.Item2 < _time.RealTime);
 
             // continues tile placement but placement of entities only occurs on mouseUp
-            if (_placenextframe && CurrentPermission!.IsTile)
+            if (_placenextframe && CurrentPermission!.IsTile && !_gridFrameBuffer)
+            {
                 HandlePlacement();
+            }
         }
 
         private void ActivateLineMode()

--- a/Robust.Server/Physics/GridFixtureSystem.cs
+++ b/Robust.Server/Physics/GridFixtureSystem.cs
@@ -45,12 +45,16 @@ namespace Robust.Server.Physics
         public override void Initialize()
         {
             base.Initialize();
-            _logger = Shared.Log.Logger.GetSawmill("gsplit");
+            _logger = Logger.GetSawmill("gsplit");
             SubscribeLocalEvent<GridInitializeEvent>(OnGridInit);
             SubscribeLocalEvent<GridRemovalEvent>(OnGridRemoval);
             SubscribeNetworkEvent<RequestGridNodesMessage>(OnDebugRequest);
             SubscribeNetworkEvent<StopGridNodesMessage>(OnDebugStopRequest);
             var configManager = IoCManager.Resolve<IConfigurationManager>();
+#if !FULL_RELEASE
+            // It makes mapping painful
+            configManager.OverrideDefault(CVars.GridSplitting, false);
+#endif
             configManager.OnValueChanged(CVars.GridSplitting, SetSplitAllowed, true);
         }
 

--- a/Robust.Server/Placement/PlacementManager.cs
+++ b/Robust.Server/Placement/PlacementManager.cs
@@ -131,27 +131,21 @@ namespace Robust.Server.Placement
 
         private void PlaceNewTile(ushort tileType, EntityCoordinates coordinates)
         {
-            var mapCoordinates = coordinates.ToMap(_entityManager);
+            if (!coordinates.IsValid(_entityManager)) return;
 
-            if (mapCoordinates.MapId == MapId.Nullspace) return;
-
-            var gridCoordinate = coordinates.AlignWithClosestGridTile(entityManager: _entityManager, mapManager: _mapManager);
-
-            if (!gridCoordinate.IsValid(_entityManager)) return;
-
-            var closest = _mapManager.IsGrid(gridCoordinate.EntityId);
+            var closest = _mapManager.IsGrid(coordinates.EntityId);
 
             if (closest) // stick to existing grid
             {
-                if (!_mapManager.TryGetGrid(gridCoordinate.EntityId, out var grid)) return;
+                if (!_mapManager.TryGetGrid(coordinates.EntityId, out var grid)) return;
 
-                grid.SetTile(gridCoordinate, new Tile(tileType));
+                grid.SetTile(coordinates, new Tile(tileType));
             }
             else if (tileType != 0) // create a new grid
             {
-                var newGrid = _mapManager.CreateGrid(mapCoordinates.MapId);
-                newGrid.WorldPosition = mapCoordinates.Position + (newGrid.TileSize / 2f); // assume bottom left tile origin
-                var tilePos = newGrid.WorldToTile(mapCoordinates.Position);
+                var newGrid = _mapManager.CreateGrid(coordinates.GetMapId(_entityManager));
+                newGrid.WorldPosition = coordinates.Position + (newGrid.TileSize / 2f); // assume bottom left tile origin
+                var tilePos = newGrid.WorldToTile(coordinates.Position);
                 newGrid.SetTile(tilePos, new Tile(tileType));
             }
         }

--- a/Robust.Shared/Map/CoordinatesExtensions.cs
+++ b/Robust.Shared/Map/CoordinatesExtensions.cs
@@ -35,9 +35,14 @@ namespace Robust.Shared.Map
 
             var gridId = coords.GetGridUid(entityManager);
 
-            if (gridId != null || !mapManager.GridExists(gridId))
+            if (!mapManager.GridExists(gridId))
             {
                 var mapCoords = coords.ToMap(entityManager);
+
+                if (mapManager.TryFindGridAt(mapCoords, out var mapGrid))
+                {
+                    return new EntityCoordinates(mapGrid.GridEntityId, mapGrid.WorldToLocal(mapCoords.Position));
+                }
 
                 // create a box around the cursor
                 var gridSearchBox = Box2.UnitCentered.Scale(searchBoxSize).Translated(mapCoords.Position);

--- a/Robust.UnitTesting/Shared/Map/GridSplit_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/GridSplit_Tests.cs
@@ -1,5 +1,7 @@
 using System.Linq;
 using NUnit.Framework;
+using Robust.Shared;
+using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
@@ -10,10 +12,20 @@ namespace Robust.UnitTesting.Shared.Map;
 [TestFixture]
 public sealed class GridSplit_Tests
 {
+    private ISimulation GetSim()
+    {
+        var sim = RobustServerSimulation.NewSimulation().InitializeInstance();
+
+        var config = sim.Resolve<IConfigurationManager>();
+        config.SetCVar(CVars.GridSplitting, true);
+
+        return sim;
+    }
+
     [Test]
     public void SimpleSplit()
     {
-        var sim = RobustServerSimulation.NewSimulation().InitializeInstance();
+        var sim =GetSim();
         var mapManager = sim.Resolve<IMapManager>();
         var mapId = mapManager.CreateMap();
         var grid = mapManager.CreateGrid(mapId);
@@ -34,7 +46,7 @@ public sealed class GridSplit_Tests
     [Test]
     public void DonutSplit()
     {
-        var sim = RobustServerSimulation.NewSimulation().InitializeInstance();
+        var sim =GetSim();
         var mapManager = sim.Resolve<IMapManager>();
         var mapId = mapManager.CreateMap();
         var grid = mapManager.CreateGrid(mapId);
@@ -64,7 +76,7 @@ public sealed class GridSplit_Tests
     [Test]
     public void TriSplit()
     {
-        var sim = RobustServerSimulation.NewSimulation().InitializeInstance();
+        var sim =GetSim();
         var mapManager = sim.Resolve<IMapManager>();
         var mapId = mapManager.CreateMap();
         var grid = mapManager.CreateGrid(mapId);
@@ -90,7 +102,7 @@ public sealed class GridSplit_Tests
     [Test]
     public void ReparentSplit()
     {
-        var sim = RobustServerSimulation.NewSimulation().InitializeInstance();
+        var sim =GetSim();
         var entManager = sim.Resolve<IEntityManager>();
         var mapManager = sim.Resolve<IMapManager>();
         var mapId = mapManager.CreateMap();


### PR DESCRIPTION
These are bandaids because pmanager SUCKS.

1. AlignWithClosestGridTile will use TryFindGridAt as a first resort
2. Bulk tile placement won't create a billion grids due to a hack.