### PR TITLE
Make AudioSystem accept nullable SoundSpecifier

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
@@ -475,9 +475,9 @@ namespace Robust.Client.GameObjects
         }
 
         /// <inheritdoc />
-        public override IPlayingAudioStream? PlayPredicted(SoundSpecifier sound, EntityUid source, EntityUid? user, AudioParams? audioParams = null)
+        public override IPlayingAudioStream? PlayPredicted(SoundSpecifier? sound, EntityUid source, EntityUid? user, AudioParams? audioParams = null)
         {
-            if (_timing.IsFirstTimePredicted)
+            if (_timing.IsFirstTimePredicted || sound == null)
                 return Play(sound, Filter.Local(), source, audioParams);
             else
                 return null; // uhh Lets hope predicted audio never needs to somehow store the playing audio....

--- a/Robust.Server/GameObjects/EntitySystems/AudioSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/AudioSystem.cs
@@ -119,8 +119,11 @@ namespace Robust.Server.GameObjects
         }
 
         /// <inheritdoc />
-        public override IPlayingAudioStream? PlayPredicted(SoundSpecifier sound, EntityUid source, EntityUid? user, AudioParams? audioParams = null)
+        public override IPlayingAudioStream? PlayPredicted(SoundSpecifier? sound, EntityUid source, EntityUid? user, AudioParams? audioParams = null)
         {
+            if (sound == null)
+                return null;
+
             var filter = Filter.Pvs(source, entityManager: EntityManager).RemoveWhereAttachedEntity(e => e == user);
             return Play(sound, filter, source, audioParams);
         }

--- a/Robust.Shared/GameObjects/Systems/SharedAudioSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedAudioSystem.cs
@@ -50,8 +50,10 @@ namespace Robust.Shared.GameObjects
         /// <param name="audioParams">Audio parameters to apply when playing the sound.</param>
         public abstract IPlayingAudioStream? PlayGlobal(string filename, Filter playerFilter, AudioParams? audioParams = null);
 
-        public IPlayingAudioStream? PlayGlobal(SoundSpecifier sound, Filter playerFilter, AudioParams? audioParams = null)
-            => PlayGlobal(GetSound(sound), playerFilter, audioParams ?? sound.Params);
+        public IPlayingAudioStream? PlayGlobal(SoundSpecifier? sound, Filter playerFilter, AudioParams? audioParams = null)
+        {
+            return sound == null ? null : PlayGlobal(GetSound(sound), playerFilter, audioParams ?? sound.Params);
+        }
 
         /// <summary>
         /// Play an audio file following an entity.
@@ -69,8 +71,10 @@ namespace Robust.Shared.GameObjects
         /// <param name="playerFilter">The set of players that will hear the sound.</param>
         /// <param name="uid">The UID of the entity "emitting" the audio.</param>
         /// <param name="audioParams">Audio parameters to apply when playing the sound. Defaults to using the sound specifier's parameters</param>
-        public IPlayingAudioStream? Play(SoundSpecifier sound, Filter playerFilter, EntityUid uid, AudioParams? audioParams = null)
-            => Play(GetSound(sound), playerFilter, uid, audioParams ?? sound.Params);
+        public IPlayingAudioStream? Play(SoundSpecifier? sound, Filter playerFilter, EntityUid uid, AudioParams? audioParams = null)
+        {
+            return sound == null ? null : Play(GetSound(sound), playerFilter, uid, audioParams ?? sound.Params);
+        }
 
         /// <summary>
         /// Play an audio file following an entity for every entity in PVS range.
@@ -78,8 +82,10 @@ namespace Robust.Shared.GameObjects
         /// <param name="sound">The sound specifier that points the audio file(s) that should be played.</param>
         /// <param name="uid">The UID of the entity "emitting" the audio.</param>
         /// <param name="audioParams">Audio parameters to apply when playing the sound. Defaults to using the sound specifier's parameters</param>
-        public IPlayingAudioStream? PlayPvs(SoundSpecifier sound, EntityUid uid, AudioParams? audioParams = null)
-            => Play(sound, Filter.Pvs(uid, entityManager: EntityManager), uid, audioParams);
+        public IPlayingAudioStream? PlayPvs(SoundSpecifier? sound, EntityUid uid, AudioParams? audioParams = null)
+        {
+            return sound == null ? null : Play(sound, Filter.Pvs(uid, entityManager: EntityManager), uid, audioParams);
+        }
 
         /// <summary>
         /// Plays a predicted sound following an entity. The server will send the sound to every player in PVS range,
@@ -90,7 +96,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="source">The UID of the entity "emitting" the audio.</param>
         /// <param name="user">The UID of the user that initiated this sound. This is usually some player's controlled entity.</param>
         /// <param name="audioParams">Audio parameters to apply when playing the sound. Defaults to using the sound specifier's parameters</param>
-        public abstract IPlayingAudioStream? PlayPredicted(SoundSpecifier sound, EntityUid source, EntityUid? user, AudioParams? audioParams = null);
+        public abstract IPlayingAudioStream? PlayPredicted(SoundSpecifier? sound, EntityUid source, EntityUid? user, AudioParams? audioParams = null);
 
         /// <summary>
         /// Play an audio file at a static position.
@@ -109,8 +115,11 @@ namespace Robust.Shared.GameObjects
         /// <param name="playerFilter">The set of players that will hear the sound.</param>
         /// <param name="coordinates">The coordinates at which to play the audio.</param>
         /// <param name="audioParams">Audio parameters to apply when playing the sound.</param>
-        public IPlayingAudioStream? Play(SoundSpecifier sound, Filter playerFilter, EntityCoordinates coordinates,
-            AudioParams? audioParams = null) => Play(GetSound(sound), playerFilter, coordinates, audioParams ?? sound.Params);
+        public IPlayingAudioStream? Play(SoundSpecifier? sound, Filter playerFilter, EntityCoordinates coordinates,
+            AudioParams? audioParams = null)
+        {
+            return sound == null ? null : Play(GetSound(sound), playerFilter, coordinates, audioParams ?? sound.Params);
+        }
 
         protected EntityCoordinates GetFallbackCoordinates(MapCoordinates mapCoordinates)
         {


### PR DESCRIPTION
A lot of systems have optional/nullable sound effects, so you quite often see code like
```cs
if (component.Sound != null)
    _audioSys.PlayPvs(component.Sound, uid)
```

So for the sake of convenience, this pr makes it so that audio system can just directly take & check nullable sound specifiers