### PR TITLE
Include stack trace in deletion errors

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -313,7 +313,7 @@ namespace Robust.Shared.GameObjects
 #if !EXCEPTION_TOLERANCE
                 throw new InvalidOperationException(msg);
 #else
-                Logger.Error(msg);
+                Logger.Error($"{msg}. Stack: {Environment.StackTrace}");
 #endif
             }
 


### PR DESCRIPTION
These errors appear every now and then on grafana, but they are not very useful without knowing what is triggering the deletion.