### PR TITLE
Add session info for client-side ToPrettyString()

### DIFF
--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -61,6 +61,14 @@ namespace Robust.Client.GameObjects
                 base.Dirty(component);
         }
 
+        public override EntityStringRepresentation ToPrettyString(EntityUid uid)
+        {
+            if (_playerManager.LocalPlayer?.ControlledEntity == uid)
+                return base.ToPrettyString(uid) with { Session = _playerManager.LocalPlayer.Session };
+            else
+                return base.ToPrettyString(uid);
+        }
+
         #region IEntityNetworkManager impl
 
         public override IEntityNetworkManager EntityNetManager => this;


### PR DESCRIPTION
Allows you to infer whether or not a given entity was being controlled by the local player when reading client-side logs/errors. 