### PR TITLE
Fix deferred component remove error

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -546,15 +546,15 @@ namespace Robust.Shared.GameObjects
             var entityUid = component.Owner;
 
             // ReSharper disable once InvertIf
-            if (reg.NetID != null)
+            if (reg.NetID != null && _netComponents.TryGetValue(entityUid, out var netSet))
             {
-                var netSet = _netComponents[entityUid];
                 if (netSet.Count == 1)
                     _netComponents.Remove(entityUid);
                 else
                     netSet.Remove(reg.NetID.Value);
 
-                Dirty(entityUid);
+                if (component.NetSyncEnabled)
+                    Dirty(entityUid);
             }
 
             foreach (var refType in reg.References)


### PR DESCRIPTION
This error was getting spammed in grafana. AFAICT it was probably due to a deferred component removal for an entity that had since been deleted?

```
Caught exception in GameLoop Tick
System.Collections.Generic.KeyNotFoundException: The given key '21024' was not present in the dictionary.
   at Robust.Shared.GameObjects.EntityManager.DeleteComponent(Component component) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Components.cs:line 544
   at Robust.Shared.GameObjects.EntityManager.CullRemovedComponents() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Components.cs:line 540
   at Robust.Shared.GameObjects.EntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 158
   at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 147
   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/BaseServer.cs:line 684
   at Robust.Shared.Timing.GameLoop.Run() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 213
 Catcher="GameLoop Tick" Sawmill=runtime
```