### PR TITLE
Maybe fix PVS bug

### DIFF
--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -187,10 +187,11 @@ internal sealed partial class PVSSystem : EntitySystem
             sessionData.Overflow = null;
         }
 
-        // return last acked to pool, but only if it is not still in the overflow dictionary.
+        // return last acked to pool, but only if it is not still in the OverflowDictionary.
         if (sessionData.LastAcked != null && _gameTiming.CurTick.Value - lastAcked.Value > TickBuffer)
             _visSetPool.Return(sessionData.LastAcked);
 
+        sessionData.LastAcked = null;
         sessionData.RequestedFull = true;
     }
 
@@ -220,7 +221,7 @@ internal sealed partial class PVSSystem : EntitySystem
 
     private void ProcessAckedTick(SessionPVSData sessionData, Dictionary<EntityUid, PVSEntityVisiblity> ackedData, GameTick tick, GameTick lastAckedTick)
     {
-        // return last acked to pool, but only if it is not still in the overflow dictionary.
+        // return last acked to pool, but only if it is not still in the OverflowDictionary.
         if (sessionData.LastAcked != null && _gameTiming.CurTick.Value - lastAckedTick.Value > TickBuffer)
             _visSetPool.Return(sessionData.LastAcked);
 
@@ -371,6 +372,7 @@ internal sealed partial class PVSSystem : EntitySystem
 
         if (data.Overflow != null)
             _visSetPool.Return(data.Overflow.Value.SentEnts);
+        data.Overflow = null;
 
         if (data.LastAcked != null)
             _visSetPool.Return(data.LastAcked);
@@ -380,6 +382,8 @@ internal sealed partial class PVSSystem : EntitySystem
             if (visSet != data.LastAcked)
                 _visSetPool.Return(visSet);
         }
+
+        data.LastAcked = null;
     }
 
     private void OnGridRemoved(GridRemovalEvent ev)


### PR DESCRIPTION
There were some PVS related exceptions on grafana, probably due to #3000. AFAICT they were probably caused by returning the same dictionary the ObjectPool more than once?


The errors in question:
```
Caught exception while generating mail.
System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
   at System.Collections.Generic.Dictionary`2.FindValue(TKey key)
   at Robust.Server.GameStates.PVSSystem.RecursivelyAddTreeNode(EntityUid& nodeIndex, RobustTree`1 tree, Dictionary`2 lastAcked, Dictionary`2 lastSent, Dictionary`2 toSend, GameTick fromTick, Int32& totalEnteredEntities, Dictionary`2 metaDataCache, Int32& enteredEntityBudget) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PVSSystem.cs:line 811
   at Robust.Server.GameStates.PVSSystem.RecursivelyAddTreeNode(EntityUid& nodeIndex, RobustTree`1 tree, Dictionary`2 lastAcked, Dictionary`2 lastSent, Dictionary`2 toSend, GameTick fromTick, Int32& totalEnteredEntities, Dictionary`2 metaDataCache, Int32& enteredEntityBudget) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PVSSystem.cs:line 828
   at Robust.Server.GameStates.PVSSystem.RecursivelyAddTreeNode(EntityUid& nodeIndex, RobustTree`1 tree, Dictionary`2 lastAcked, Dictionary`2 lastSent, Dictionary`2 toSend, GameTick fromTick, Int32& totalEnteredEntities, Dictionary`2 metaDataCache, Int32& enteredEntityBudget) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PVSSystem.cs:line 828
   at Robust.Server.GameStates.PVSSystem.RecursivelyAddTreeNode(EntityUid& nodeIndex, RobustTree`1 tree, Dictionary`2 lastAcked, Dictionary`2 lastSent, Dictionary`2 toSend, GameTick fromTick, Int32& totalEnteredEntities, Dictionary`2 metaDataCache, Int32& enteredEntityBudget) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PVSSystem.cs:line 828
   at Robust.Server.GameStates.PVSSystem.RecursivelyAddTreeNode(EntityUid& nodeIndex, RobustTree`1 tree, Dictionary`2 lastAcked, Dictionary`2 lastSent, Dictionary`2 toSend, GameTick fromTick, Int32& totalEnteredEntities, Dictionary`2 metaDataCache, Int32& enteredEntityBudget) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PVSSystem.cs:line 828
   at Robust.Server.GameStates.PVSSystem.CalculateEntityStates(IPlayerSession session, GameTick fromTick, GameTick toTick, Nullable`1[] chunkCache, HashSet`1 chunkIndices, EntityQuery`1 mQuery, EntityQuery`1 tQuery, EntityUid[] viewerEntities) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PVSSystem.cs:line 668
   at Robust.Server.GameStates.ServerGameStateManager.<>c__DisplayClass36_0.<SendGameStateUpdate>g__SendStateUpdate|4(Int32 sessionIndex, PvsThreadResources resources) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/ServerGameStateManager.cs:line 301
   at Robust.Server.GameStates.ServerGameStateManager.<>c__DisplayClass36_0.<SendGameStateUpdate>b__2(Int32 i, ParallelLoopState loop, PvsThreadResources resource) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/ServerGameStateManager.cs:line 241
 Sawmill=PVS

Caught exception while generating mail.
System.Collections.Generic.KeyNotFoundException: Entity 0 does not have a component of type Robust.Shared.GameObjects.MetaDataComponent
   at Robust.Shared.GameObjects.EntityQuery`1.GetComponent(EntityUid uid) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Components.cs:line 1197
   at Robust.Server.GameStates.PVSSystem.CalculateEntityStates(IPlayerSession session, GameTick fromTick, GameTick toTick, Nullable`1[] chunkCache, HashSet`1 chunkIndices, EntityQuery`1 mQuery, EntityQuery`1 tQuery, EntityUid[] viewerEntities) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PVSSystem.cs:line 668
   at Robust.Server.GameStates.ServerGameStateManager.<>c__DisplayClass36_0.<SendGameStateUpdate>g__SendStateUpdate|4(Int32 sessionIndex, PvsThreadResources resources) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/ServerGameStateManager.cs:line 301
   at Robust.Server.GameStates.ServerGameStateManager.<>c__DisplayClass36_0.<SendGameStateUpdate>b__2(Int32 i, ParallelLoopState loop, PvsThreadResources resource) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/ServerGameStateManager.cs:line 241
 Sawmill=PVS

Caught exception while generating mail.
System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
   at Robust.Server.GameStates.PVSSystem.ProcessLeavePVS(Dictionary`2 visibleEnts, Dictionary`2 lastSent) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PVSSystem.cs:line 781
   at Robust.Server.GameStates.PVSSystem.CalculateEntityStates(IPlayerSession session, GameTick fromTick, GameTick toTick, Nullable`1[] chunkCache, HashSet`1 chunkIndices, EntityQuery`1 mQuery, EntityQuery`1 tQuery, EntityUid[] viewerEntities) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PVSSystem.cs:line 668
   at Robust.Server.GameStates.ServerGameStateManager.<>c__DisplayClass36_0.<SendGameStateUpdate>g__SendStateUpdate|4(Int32 sessionIndex, PvsThreadResources resources) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/ServerGameStateManager.cs:line 301
   at Robust.Server.GameStates.ServerGameStateManager.<>c__DisplayClass36_0.<SendGameStateUpdate>b__2(Int32 i, ParallelLoopState loop, PvsThreadResources resource) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/ServerGameStateManager.cs:line 241
 Sawmill=PVS
```