### PR TITLE
Map serialization postmapinit  bugfix

### DIFF
--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -855,7 +855,10 @@ namespace Robust.Server.Maps
                 meta.Add("name", "DemoStation");
                 meta.Add("author", "Space-Wizards");
 
-                var isPostInit = false;
+                //TODO: MapId is null when saveBP is used, another reason this jumbled mess needs to be rewritten
+                var isPostInit = MapId is not null && _mapManager.IsMapInitialized(MapId.Value);
+
+                //TODO: This is a workaround to make SaveBP function
                 foreach (var grid in Grids)
                 {
                     if (_mapManager.IsMapInitialized(grid.ParentMapId))

--- a/Robust.Shared/GameObjects/Components/Map/MapComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Map/MapComponent.cs
@@ -41,6 +41,7 @@ namespace Robust.Shared.GameObjects
             internal set => _mapIndex = value;
         }
 
+        [ViewVariables(VVAccess.ReadOnly)]
         internal bool MapPaused { get; set; } = false;
 
         /// <inheritdoc />
@@ -50,6 +51,7 @@ namespace Robust.Shared.GameObjects
             set => this.MapPaused = value;
         }
 
+        [ViewVariables(VVAccess.ReadOnly)]
         internal bool MapPreInit { get; set; } = false;
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixes a bug where maps saved that don't contain a grid fail to properly set the postmapinit value.
Makes MapComponent.MapPaused and MapComponent.MapPreInit visible in VV.
Adds a test demonstrating that containers still contain their entities on the server when a postinit map is loaded.

Related to https://github.com/space-wizards/RobustToolbox/issues/3119