### PR TITLE
Fix gamestate debug display

### DIFF
--- a/Robust.Shared/GameStates/GameState.cs
+++ b/Robust.Shared/GameStates/GameState.cs
@@ -1,4 +1,4 @@
-using Robust.Shared.GameObjects;
+﻿using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization;
 using System;
 using System.Diagnostics;
@@ -7,7 +7,7 @@ using Robust.Shared.Timing;
 
 namespace Robust.Shared.GameStates
 {
-    [DebuggerDisplay("GameState from={FromSequence} to={ToSequence} ext={Extrapolated}")]
+    [DebuggerDisplay("GameState from={FromSequence} to={ToSequence}")]
     [Serializable, NetSerializable]
     public sealed class GameState
     {


### PR DESCRIPTION
Fix IDE debug crash by removing Extrapolated from debug display, because it is not a variable on gamestate.