### PR TITLE
Add PVS/entity-state debug commands

### DIFF
--- a/Resources/Locale/en-US/client-state-commands.ftl
+++ b/Resources/Locale/en-US/client-state-commands.ftl
@@ -8,3 +8,6 @@ cmd-reset-all-ents-desc = Resets all entities to the most recently received serv
 
 cmd-detach-ent-help = Usage: detachent <Entity UID>
 cmd-detach-ent-desc = Detach an entity to null-space, as if it had left PVS range.
+
+cmd-local-delete-help = Usage: localdelete <Entity UID>
+cmd-local-delete-desc = Deletes an entity. Unlike the normal delete command, this is CLIENT-SIDE. Unless the entity is a client-side entity, this will likely cause errors.

--- a/Resources/Locale/en-US/client-state-commands.ftl
+++ b/Resources/Locale/en-US/client-state-commands.ftl
@@ -1,0 +1,10 @@
+﻿# Loc strings for various entity state & client-side PVS related commands
+
+cmd-reset-ent-help = Usage: resetent <Entity UID>
+cmd-reset-ent-desc = Reset an entity to the most recently received server state. This will also reset entities that have been detached to null-space. 
+
+cmd-reset-all-ents-help = Usage: resetallents
+cmd-reset-all-ents-desc = Resets all entities to the most recently received server state. This only impacts entities that have not been detached to null-space. 
+
+cmd-detach-ent-help = Usage: detachent <Entity UID>
+cmd-detach-ent-desc = Detach an entity to null-space, as if it had left PVS range.

--- a/Resources/Locale/en-US/client-state-commands.ftl
+++ b/Resources/Locale/en-US/client-state-commands.ftl
@@ -11,3 +11,6 @@ cmd-detach-ent-desc = Detach an entity to null-space, as if it had left PVS rang
 
 cmd-local-delete-help = Usage: localdelete <Entity UID>
 cmd-local-delete-desc = Deletes an entity. Unlike the normal delete command, this is CLIENT-SIDE. Unless the entity is a client-side entity, this will likely cause errors.
+
+cmd-full-state-reset-help = Usage: fullstatereset
+cmd-full-state-reset-desc = Discards any entity state information and requests a full-state from the server.

--- a/Resources/Locale/en-US/commands.ftl
+++ b/Resources/Locale/en-US/commands.ftl
@@ -1,10 +1,14 @@
 ﻿### Localization for engine console commands
 
-## generic
+## generic command errors
+
+cmd-invalid-arg-number-error = Invalid number of arguments.
 
 cmd-parse-failure-integer = {$arg} is not a valid integer.
 cmd-parse-failure-float = {$arg} is not a valid float.
 cmd-parse-failure-bool = {$arg} is not a valid bool.
+cmd-parse-failure-uid = {$arg} is not a valid entity UID.
+cmd-parse-failure-entity-exist = UID {$arg} does not correspond to an existing entity.
 
 
 ## 'help' command

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -129,6 +129,9 @@ namespace Robust.Client.GameStates
             // disable on release, to avoid making it trivial to make walls/occluders disappear.
             _conHost.RegisterCommand("detachent", Loc.GetString("cmd-detach-ent-desc"), Loc.GetString("cmd-detach-ent-help"), DetachEntCommand);
             _conHost.RegisterCommand("localdelete", Loc.GetString("cmd-local-delete-desc"), Loc.GetString("cmd-local-delete-help"), LocalDeleteEntCommand);
+
+            // Disabled on full release, because I am too lazy to implement rate limiting.
+            _conHost.RegisterCommand("fullstatereset", Loc.GetString("cmd-full-state-reset-desc"), Loc.GetString("cmd-full-state-reset-help"), (_,_,_) => RequestFullState());
 #endif
 
             var metaId = _compFactory.GetRegistration(typeof(MetaDataComponent)).NetID;

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -128,6 +128,7 @@ namespace Robust.Client.GameStates
 #if !FULL_RELEASE
             // disable on release, to avoid making it trivial to make walls/occluders disappear.
             _conHost.RegisterCommand("detachent", Loc.GetString("cmd-detach-ent-desc"), Loc.GetString("cmd-detach-ent-help"), DetachEntCommand);
+            _conHost.RegisterCommand("localdelete", Loc.GetString("cmd-local-delete-desc"), Loc.GetString("cmd-local-delete-help"), LocalDeleteEntCommand);
 #endif
 
             var metaId = _compFactory.GetRegistration(typeof(MetaDataComponent)).NetID;
@@ -984,6 +985,24 @@ namespace Robust.Client.GameStates
                 if (container != null)
                     containerSys.AddExpectedEntity(uid, container);
             }
+        }
+
+        /// <summary>
+        ///     Deletes an entity. Unlike the normal delete command, this is CLIENT-SIDE.
+        /// </summary>
+        /// <remarks>
+        ///     Unless the entity is a client-side entity, this will likely cause errors.
+        /// </remarks>
+        private void LocalDeleteEntCommand(IConsoleShell shell, string argStr, string[] args)
+        {
+            if (!TryParseUid(shell, args, out var uid, out var meta))
+                return;
+
+            _entities.DeleteEntity(uid);
+
+            // If this is not a client-side entity, it also needs to be removed from the full-server state dictionary to
+            // avoid errors.
+            _processor._lastStateFullRep.Remove(uid);
         }
 
         /// <summary>

--- a/Robust.Client/GameStates/GameStateProcessor.cs
+++ b/Robust.Client/GameStates/GameStateProcessor.cs
@@ -39,7 +39,7 @@ namespace Robust.Client.GameStates
         /// <summary>
         /// This dictionary stores the full most recently received server state of any entity. This is used whenever predicted entities get reset.
         /// </summary>
-        private readonly Dictionary<EntityUid, Dictionary<ushort, ComponentState>> _lastStateFullRep
+        internal readonly Dictionary<EntityUid, Dictionary<ushort, ComponentState>> _lastStateFullRep
             = new();
 
         /// <inheritdoc />


### PR DESCRIPTION
Adds client-side commands to detach an entity (simulate leaving PVS range), reset an entity to the most recent server state, and to reset all entities (that are not currently detached).

Makes it easier to debug client-side state handling issues, without having to actively move the controlled player in and out of PVS range.