### PR TITLE
Fix entity state exception tolerance

### DIFF
--- a/Robust.Client/GameStates/GameStateProcessor.cs
+++ b/Robust.Client/GameStates/GameStateProcessor.cs
@@ -215,7 +215,7 @@ namespace Robust.Client.GameStates
             }
 
             // we let the buffer fill up before starting to tick
-            if (_stateBuffer.Count >= TargetBufferSize && (!Interpolation || nextState != null))
+            if (_stateBuffer.Count >= TargetBufferSize)
             {
                 if (Logging)
                     Logger.DebugS("net", $"Resync CurTick to: {LastFullState.ToSequence}");

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -141,7 +141,7 @@ namespace Robust.Server.GameStates
             ClientRequestFull?.Invoke(session, msg.Tick, lastAcked);
 
             // Update acked tick so that OnClientAck doesn't get invoked by any late acks.
-            _ackedStates[msg.MsgChannel.ConnectionId] = msg.Tick;
+            _ackedStates[msg.MsgChannel.ConnectionId] = _gameTiming.CurTick;
         }
 
         private void HandleStateAck(MsgStateAck msg)


### PR DESCRIPTION
Fixes a bug that could cause state error/exception handling code to cause the client to hang.

Basically, if the client receives a new entity without a meta-data component, previously the client would just die,
#3000 added some error tolerance to this by making the client request a full game state, but currently this can sometimes cause the client to freeze when game states arrive out of order.