### PR TITLE
Don't do any splitting when disabled

### DIFF
--- a/Robust.Server/Physics/GridFixtureSystem.cs
+++ b/Robust.Server/Physics/GridFixtureSystem.cs
@@ -28,6 +28,7 @@ namespace Robust.Server.Physics
         [Dependency] private readonly SharedTransformSystem _xformSystem = default!;
 
         private ISawmill _logger = default!;
+        // TODO: This should really be on a component sloth.
         private readonly Dictionary<EntityUid, Dictionary<Vector2i, ChunkNodeGroup>> _nodes = new();
 
         /// <summary>
@@ -55,10 +56,46 @@ namespace Robust.Server.Physics
             // It makes mapping painful
             configManager.OverrideDefault(CVars.GridSplitting, false);
 #endif
-            configManager.OnValueChanged(CVars.GridSplitting, SetSplitAllowed, true);
+            // Don't invoke immediately as maploader will handle this.
+            configManager.OnValueChanged(CVars.GridSplitting, SetSplitAllowed);
         }
 
-        private void SetSplitAllowed(bool value) => SplitAllowed = value;
+        private void SetSplitAllowed(bool value)
+        {
+            if (SplitAllowed.Equals(value)) return;
+            SplitAllowed = value;
+
+            if (SplitAllowed)
+            {
+                foreach (var grid in _mapManager.GetAllGrids())
+                {
+                    EnsureGrid(grid.GridEntityId);
+                    GenerateSplitNodes((IMapGridInternal) grid);
+                }
+
+                foreach (var (uid, _) in _nodes)
+                {
+                    SendNodeDebug(uid);
+                }
+            }
+            else
+            {
+                foreach (var (uid, _) in _nodes)
+                {
+                    var msg = new ChunkSplitDebugMessage
+                    {
+                        Grid = uid,
+                    };
+
+                    foreach (var session in _subscribedSessions)
+                    {
+                        RaiseNetworkEvent(msg, session.ConnectedClient);
+                    }
+                }
+
+                _nodes.Clear();
+            }
+        }
 
         public override void Shutdown()
         {
@@ -73,7 +110,7 @@ namespace Robust.Server.Physics
         /// </summary>
         internal void EnsureGrid(EntityUid uid)
         {
-            if (!_nodes.ContainsKey(uid))
+            if (SplitAllowed && !_nodes.ContainsKey(uid))
                 _nodes[uid] = new Dictionary<Vector2i, ChunkNodeGroup>();
         }
 
@@ -170,6 +207,8 @@ namespace Robust.Server.Physics
         /// </summary>
         internal void CheckSplits(EntityUid uid)
         {
+            if (!SplitAllowed) return;
+
             var nodes = _nodes[uid];
             var dirtyNodes = new HashSet<ChunkSplitNode>(nodes.Count);
 
@@ -367,6 +406,8 @@ namespace Robust.Server.Physics
 
         private void GenerateSplitNodes(IMapGridInternal grid)
         {
+            if (!SplitAllowed) return;
+
             foreach (var (_, chunk) in grid.GetMapChunks())
             {
                 var group = CreateNodes(grid.GridEntityId, grid, chunk);
@@ -509,6 +550,8 @@ namespace Robust.Server.Physics
         /// </summary>
         internal override void CheckSplit(EntityUid gridEuid, MapChunk chunk, List<Box2i> rectangles)
         {
+            if (!SplitAllowed) return;
+
             HashSet<ChunkSplitNode> nodes;
 
             if (chunk.FilledTiles == 0)
@@ -528,6 +571,8 @@ namespace Robust.Server.Physics
         /// </summary>
         internal override void CheckSplit(EntityUid gridEuid, Dictionary<MapChunk, List<Box2i>> mapChunks, List<MapChunk> removedChunks)
         {
+            if (!SplitAllowed) return;
+
             var nodes = new HashSet<ChunkSplitNode>();
 
             foreach (var chunk in removedChunks)


### PR DESCRIPTION
Previously it just avoided splitting but still did calcs, now it also won't store data or generate it (OD spams SetTile on init so this gets spammed).