### PR TITLE
Hopefully fix container issues?

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Robust.Client.Player;
 using Robust.Shared.Collections;
@@ -10,6 +11,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
 using static Robust.Shared.Containers.ContainerManagerComponent;
 
 namespace Robust.Client.GameObjects
@@ -35,10 +37,8 @@ namespace Robust.Client.GameObjects
 
         private void HandleEntityInitialized(EntityInitializedMessage ev)
         {
-            if (!ExpectedEntities.TryGetValue(ev.Entity, out var container))
+            if (!RemoveExpectedEntity(ev.Entity, out var container))
                 return;
-
-            RemoveExpectedEntity(ev.Entity);
 
             if (container.Deleted)
                 return;
@@ -115,7 +115,7 @@ namespace Robust.Client.GameObjects
 
                 foreach (var entityUid in removedExpected)
                 {
-                    RemoveExpectedEntity(entityUid);
+                    RemoveExpectedEntity(entityUid, out _);
                 }
 
                 // Add new entities.
@@ -140,8 +140,11 @@ namespace Robust.Client.GameObjects
                         continue;
                     }
 
-                    if (!container.ContainedEntities.Contains(entity))
-                        container.Insert(entity);
+                    if (container.Contains(entity))
+                        continue;
+
+                    RemoveExpectedEntity(entity, out _);
+                    container.Insert(entity);
                 }
             }
         }
@@ -159,7 +162,7 @@ namespace Robust.Client.GameObjects
             if (message.OldParent != null && message.OldParent.Value.IsValid())
                 return;
 
-            if (!ExpectedEntities.TryGetValue(message.Entity, out var container))
+            if (!RemoveExpectedEntity(message.Entity, out var container))
                 return;
 
             if (xform.ParentUid != container.Owner)
@@ -168,8 +171,6 @@ namespace Robust.Client.GameObjects
                 // Ah well, the sever should send a new container state that updates expected entities so just ignore it for now.
                 return;
             }
-
-            RemoveExpectedEntity(message.Entity);
 
             if (container.Deleted)
                 return;
@@ -190,20 +191,33 @@ namespace Robust.Client.GameObjects
 
         public void AddExpectedEntity(EntityUid uid, IContainer container)
         {
-            if (ExpectedEntities.ContainsKey(uid))
-                return;
+            DebugTools.Assert(!TryComp(uid, out MetaDataComponent? meta) ||
+                (meta.Flags & ( MetaDataFlags.Detached | MetaDataFlags.InContainer) ) == MetaDataFlags.Detached,
+                $"Adding entity {ToPrettyString(uid)} to list of expected entities for container {container.ID} in {ToPrettyString(container.Owner)}, despite it already being in a container.");
 
-            ExpectedEntities.Add(uid, container);
+            if (!ExpectedEntities.TryAdd(uid, container))
+            {
+                DebugTools.Assert(ExpectedEntities[uid] == container,
+                    $"Expecting entity {ToPrettyString(uid)} to be present in two containers. New: {container.ID} in {ToPrettyString(container.Owner)}. Old: {ExpectedEntities[uid].ID} in {ToPrettyString(ExpectedEntities[uid].Owner)}");
+                DebugTools.Assert(ExpectedEntities[uid].ExpectedEntities.Contains(uid),
+                    $"Entity {ToPrettyString(uid)} is expected, but not expected in the given container? Container: {ExpectedEntities[uid].ID} in {ToPrettyString(ExpectedEntities[uid].Owner)}");
+                return;
+            }
+
+            DebugTools.Assert(!container.ExpectedEntities.Contains(uid),
+                $"Contained entity {ToPrettyString(uid)} was not yet expected by the system, but was already expected by the container: {container.ID} in {ToPrettyString(container.Owner)}");
             container.ExpectedEntities.Add(uid);
         }
 
-        public void RemoveExpectedEntity(EntityUid uid)
+        public bool RemoveExpectedEntity(EntityUid uid, [NotNullWhen(true)] out IContainer? container)
         {
-            if (!ExpectedEntities.TryGetValue(uid, out var container))
-                return;
+            if (!ExpectedEntities.Remove(uid, out container))
+                return false;
 
-            ExpectedEntities.Remove(uid);
+            DebugTools.Assert(container.ExpectedEntities.Contains(uid),
+                $"While removing expected contained entity {ToPrettyString(uid)}, the entity was missing from the container expected set. Container: {container.ID} in {ToPrettyString(container.Owner)}");
             container.ExpectedEntities.Remove(uid);
+            return true;
         }
 
         public override void FrameUpdate(float frameTime)

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -739,7 +739,6 @@ namespace Robust.Client.GameStates
                     if ((meta.Flags & MetaDataFlags.Detached) != 0)
                         continue;
 
-                    meta.Flags |= MetaDataFlags.Detached;
                     meta.LastStateApplied = toTick;
 
                     var xform = xforms.GetComponent(ent);
@@ -750,12 +749,15 @@ namespace Robust.Client.GameStates
                         IContainer? container = null;
                         if ((meta.Flags & MetaDataFlags.InContainer) != 0 &&
                             metas.TryGetComponent(xform.ParentUid, out var containerMeta) &&
-                            (containerMeta.Flags & MetaDataFlags.Detached) == 0)
+                            (containerMeta.Flags & MetaDataFlags.Detached) == 0 &&
+                            containerSys.TryGetContainingContainer(xform.ParentUid, ent, out container, null, true))
                         {
-                            containerSys.TryGetContainingContainer(xform.ParentUid, ent, out container, null, true);
+                            container.ForceRemove(ent, _entities, meta);
                         }
 
+                        meta._flags |= MetaDataFlags.Detached;
                         xformSys.DetachParentToNull(xform, xforms, metas);
+                        DebugTools.Assert((meta.Flags & MetaDataFlags.InContainer) == 0);
 
                         if (container != null)
                             containerSys.AddExpectedEntity(ent, container);

--- a/Robust.Shared/Containers/BaseContainer.cs
+++ b/Robust.Shared/Containers/BaseContainer.cs
@@ -61,6 +61,7 @@ namespace Robust.Shared.Containers
             DebugTools.Assert(transform == null || transform.Owner == toinsert);
             DebugTools.Assert(ownerTransform == null || ownerTransform.Owner == Owner);
             DebugTools.Assert(meta == null || meta.Owner == toinsert);
+            DebugTools.Assert(!ExpectedEntities.Contains(toinsert));
             IoCManager.Resolve(ref entMan);
 
             //Verify we can insert into this container

--- a/Robust.Shared/Containers/Container.cs
+++ b/Robust.Shared/Containers/Container.cs
@@ -4,6 +4,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Containers
 {
@@ -38,6 +39,8 @@ namespace Robust.Shared.Containers
         /// <inheritdoc />
         protected override void InternalInsert(EntityUid toinsert, EntityUid oldParent, IEntityManager entMan)
         {
+            // Why TF is this even a list??????
+            DebugTools.Assert(!_containerList.Contains(toinsert));
             _containerList.Add(toinsert);
             base.InternalInsert(toinsert, oldParent, entMan);
         }

--- a/Robust.Shared/Containers/ContainerManagerComponent.cs
+++ b/Robust.Shared/Containers/ContainerManagerComponent.cs
@@ -144,7 +144,11 @@ namespace Robust.Shared.Containers
         {
             foreach (var container in Containers.Values)
             {
-                if (container.Contains(entity)) container.ForceRemove(entity);
+                if (container.Contains(entity))
+                {
+                    container.ForceRemove(entity);
+                    return;
+                }
             }
         }
 

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -7,6 +7,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 
 namespace Robust.Shared.GameObjects
@@ -140,7 +141,18 @@ namespace Robust.Shared.GameObjects
         public EntityLifeStage EntityLifeStage { get; internal set; }
 
         [ViewVariables]
-        public MetaDataFlags Flags { get; internal set; }
+        public MetaDataFlags Flags
+        {
+            get => _flags;
+            internal set
+            {
+                // In container and detached to null are mutually exclusive flags.
+                DebugTools.Assert((value & (MetaDataFlags.InContainer | MetaDataFlags.Detached)) != (MetaDataFlags.InContainer | MetaDataFlags.Detached));
+                _flags = value;
+            }
+        }
+
+        internal MetaDataFlags _flags;
 
         /// <summary>
         ///     The sum of our visibility layer and our parent's visibility layers.


### PR DESCRIPTION
I've managed to somewhat reliably reproduce the current container bug, and AFAICT this seems to fix it? At least it hasn't reoccurred despite repeatedly attempting to trigger it.

Aside from the fix, this PR also adds a bunch of `DebugTools.Asserts()` and changes some of the code a bit to ensure that an entity can never be both inside of a container and detached to null-space simultaneously.

Without space-wizards/space-station-14/pull/10783, these asserts fail for SS14.