### PR TITLE
Prevent players from attaching to terminating entities

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/ActorSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/ActorSystem.cs
@@ -50,8 +50,8 @@ namespace Robust.Server.GameObjects
             // Null by default.
             forceKicked = null;
 
-            // Cannot attach to a deleted/nonexisting entity.
-            if (EntityManager.Deleted(uid))
+            // Cannot attach to a deleted, nonexisting or terminating entity.
+            if (!TryComp(uid, out MetaDataComponent? meta) || meta.EntityLifeStage > EntityLifeStage.MapInitialized)
             {
                 return false;
             }


### PR DESCRIPTION
Currently shutting down a server with aghosts / visiting-minds will trigger a DebugAssert about not adding components to terminating entities. This fixes that,