### PR TITLE
Fix load grid errors

### DIFF
--- a/Robust.Client/Player/LocalPlayer.cs
+++ b/Robust.Client/Player/LocalPlayer.cs
@@ -97,7 +97,8 @@ namespace Robust.Client.Player
                 entMan.EventBus.RaiseLocalEvent(previous.Value, new PlayerDetachedEvent(previous.Value), true);
             }
 
-            ControlledEntity = default;
+            ControlledEntity = null;
+            InternalSession.AttachedEntity = null;
 
             if (previous != null)
             {

--- a/Robust.Server/Console/Commands/MapCommands.cs
+++ b/Robust.Server/Console/Commands/MapCommands.cs
@@ -104,7 +104,7 @@ namespace Robust.Server.Console.Commands
                 return;
             }
 
-            IoCManager.Resolve<IMapLoader>().SaveGridBlueprint(gridId, args[1]);
+            IoCManager.Resolve<IMapLoader>().SaveGrid(gridId, args[1]);
             shell.WriteLine("Save successful. Look in the user data directory.");
         }
 
@@ -200,7 +200,7 @@ namespace Robust.Server.Console.Commands
             }
 
             var mapLoader = IoCManager.Resolve<IMapLoader>();
-            mapLoader.LoadGridBlueprint(mapId, args[1], loadOptions);
+            mapLoader.LoadGrid(mapId, args[1], loadOptions);
         }
 
         public CompletionResult GetCompletion(IConsoleShell shell, string[] args)

--- a/Robust.Server/Console/Commands/MapCommands.cs
+++ b/Robust.Server/Console/Commands/MapCommands.cs
@@ -75,11 +75,11 @@ namespace Robust.Server.Console.Commands
         }
     }
 
-    public sealed class SaveBp : IConsoleCommand
+    public sealed class SaveGridCommand : IConsoleCommand
     {
-        public string Command => "savebp";
+        public string Command => "savegrid";
         public string Description => "Serializes a grid to disk.";
-        public string Help => "savebp <gridID> <Path>";
+        public string Help => "savegrid <gridID> <Path>";
 
         public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
@@ -104,7 +104,7 @@ namespace Robust.Server.Console.Commands
                 return;
             }
 
-            IoCManager.Resolve<IMapLoader>().SaveBlueprint(gridId, args[1]);
+            IoCManager.Resolve<IMapLoader>().SaveGridBlueprint(gridId, args[1]);
             shell.WriteLine("Save successful. Look in the user data directory.");
         }
 
@@ -123,11 +123,11 @@ namespace Robust.Server.Console.Commands
         }
     }
 
-    public sealed class LoadBp : IConsoleCommand
+    public sealed class LoadGridCommand : IConsoleCommand
     {
-        public string Command => "loadbp";
-        public string Description => "Loads a blueprint from disk into the game.";
-        public string Help => "loadbp <MapID> <Path> [x y] [rotation] [storeUids]";
+        public string Command => "loadgrid";
+        public string Description => "Loads a grid from a file into an existing map.";
+        public string Help => "loadgrid <MapID> <Path> [x y] [rotation] [storeUids]";
 
         public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
@@ -162,15 +162,15 @@ namespace Robust.Server.Console.Commands
             var loadOptions = new MapLoadOptions();
             if (args.Length >= 4)
             {
-                if (!int.TryParse(args[2], out var x))
+                if (!float.TryParse(args[2], out var x))
                 {
-                    shell.WriteError($"{args[2]} is not a valid integer.");
+                    shell.WriteError($"{args[2]} is not a valid float.");
                     return;
                 }
 
-                if (!int.TryParse(args[3], out var y))
+                if (!float.TryParse(args[3], out var y))
                 {
-                    shell.WriteError($"{args[3]} is not a valid integer.");
+                    shell.WriteError($"{args[3]} is not a valid float.");
                     return;
                 }
 
@@ -181,7 +181,7 @@ namespace Robust.Server.Console.Commands
             {
                 if (!float.TryParse(args[4], out var rotation))
                 {
-                    shell.WriteError($"{args[4]} is not a valid integer.");
+                    shell.WriteError($"{args[4]} is not a valid float.");
                     return;
                 }
 
@@ -192,7 +192,7 @@ namespace Robust.Server.Console.Commands
             {
                 if (!bool.TryParse(args[5], out var storeUids))
                 {
-                    shell.WriteError($"{args[5]} is not a valid boolean..");
+                    shell.WriteError($"{args[5]} is not a valid boolean.");
                     return;
                 }
 
@@ -200,7 +200,7 @@ namespace Robust.Server.Console.Commands
             }
 
             var mapLoader = IoCManager.Resolve<IMapLoader>();
-            mapLoader.LoadBlueprint(mapId, args[1], loadOptions);
+            mapLoader.LoadGridBlueprint(mapId, args[1], loadOptions);
         }
 
         public CompletionResult GetCompletion(IConsoleShell shell, string[] args)

--- a/Robust.Server/Maps/IMapLoader.cs
+++ b/Robust.Server/Maps/IMapLoader.cs
@@ -8,9 +8,9 @@ namespace Robust.Server.Maps
 {
     public interface IMapLoader
     {
-        (IReadOnlyList<EntityUid> entities, EntityUid? gridId) LoadBlueprint(MapId mapId, string path);
-        (IReadOnlyList<EntityUid> entities, EntityUid? gridId) LoadGridBlueprint(MapId mapId, string path, MapLoadOptions options);
-        void SaveGridBlueprint(EntityUid gridId, string yamlPath);
+        (IReadOnlyList<EntityUid> entities, EntityUid? gridId) LoadGrid(MapId mapId, string path);
+        (IReadOnlyList<EntityUid> entities, EntityUid? gridId) LoadGrid(MapId mapId, string path, MapLoadOptions options);
+        void SaveGrid(EntityUid gridId, string yamlPath);
 
         (IReadOnlyList<EntityUid> entities, IReadOnlyList<EntityUid> gridIds) LoadMap(MapId mapId, string path);
         (IReadOnlyList<EntityUid> entities, IReadOnlyList<EntityUid> gridIds) LoadMap(MapId mapId, string path, MapLoadOptions options);

--- a/Robust.Server/Maps/IMapLoader.cs
+++ b/Robust.Server/Maps/IMapLoader.cs
@@ -9,8 +9,8 @@ namespace Robust.Server.Maps
     public interface IMapLoader
     {
         (IReadOnlyList<EntityUid> entities, EntityUid? gridId) LoadBlueprint(MapId mapId, string path);
-        (IReadOnlyList<EntityUid> entities, EntityUid? gridId) LoadBlueprint(MapId mapId, string path, MapLoadOptions options);
-        void SaveBlueprint(EntityUid gridId, string yamlPath);
+        (IReadOnlyList<EntityUid> entities, EntityUid? gridId) LoadGridBlueprint(MapId mapId, string path, MapLoadOptions options);
+        void SaveGridBlueprint(EntityUid gridId, string yamlPath);
 
         (IReadOnlyList<EntityUid> entities, IReadOnlyList<EntityUid> gridIds) LoadMap(MapId mapId, string path);
         (IReadOnlyList<EntityUid> entities, IReadOnlyList<EntityUid> gridIds) LoadMap(MapId mapId, string path, MapLoadOptions options);

--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -84,7 +84,9 @@ namespace Robust.Server.Maps
         public (IReadOnlyList<EntityUid> entities, EntityUid? gridId) LoadGridBlueprint(MapId mapId, string path, MapLoadOptions options)
         {
             DebugTools.Assert(_mapManager.MapExists(mapId));
-            options.LoadMap = false;
+
+            var oldLoadMapOpt = options.LoadMap; // lets not mutate the default options
+            options.LoadMap = false; 
 
             var resPath = Rooted(path);
 
@@ -113,6 +115,7 @@ namespace Robust.Server.Maps
                 entities = context.Entities;
 
                 PostDeserialize(mapId, context);
+                options.LoadMap = oldLoadMapOpt;
             }
 
             return (entities, grid?.GridEntityId);

--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -51,7 +51,7 @@ namespace Robust.Server.Maps
         public event Action<YamlStream, string>? LoadedMapData;
 
         /// <inheritdoc />
-        public void SaveGridBlueprint(EntityUid gridId, string yamlPath)
+        public void SaveGrid(EntityUid gridId, string yamlPath)
         {
             var grid = _mapManager.GetGrid(gridId);
 
@@ -71,9 +71,9 @@ namespace Robust.Server.Maps
         }
 
         /// <inheritdoc />
-        public (IReadOnlyList<EntityUid> entities, EntityUid? gridId) LoadBlueprint(MapId mapId, string path)
+        public (IReadOnlyList<EntityUid> entities, EntityUid? gridId) LoadGrid(MapId mapId, string path)
         {
-            return LoadGridBlueprint(mapId, path, DefaultLoadOptions);
+            return LoadGrid(mapId, path, DefaultLoadOptions);
         }
 
         private ResourcePath Rooted(string path)
@@ -81,7 +81,7 @@ namespace Robust.Server.Maps
             return new ResourcePath(path).ToRootedPath();
         }
 
-        public (IReadOnlyList<EntityUid> entities, EntityUid? gridId) LoadGridBlueprint(MapId mapId, string path, MapLoadOptions options)
+        public (IReadOnlyList<EntityUid> entities, EntityUid? gridId) LoadGrid(MapId mapId, string path, MapLoadOptions options)
         {
             DebugTools.Assert(_mapManager.MapExists(mapId));
 

--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -225,9 +225,6 @@ namespace Robust.Server.Maps
 
                 LoadedMapData?.Invoke(data.Stream, resPath.ToString());
 
-                if (_mapManager.MapExists(mapId))
-                    _mapManager.DeleteMap(mapId);
-
                 var context = new MapContext(_mapManager, _tileDefinitionManager, _serverEntityManager,
                     _prototypeManager, _serializationManager, _componentFactory, data.RootNode.ToDataNodeCast<MappingDataNode>(), mapId, options);
                 context.Deserialize();

--- a/Robust.Shared/GameObjects/Components/Map/MapGridComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Map/MapGridComponent.cs
@@ -73,7 +73,8 @@ namespace Robust.Shared.GameObjects
 
         protected override void OnRemove()
         {
-            _mapManager.TrueGridDelete((MapGrid)_mapGrid!);
+            if (_mapGrid != null)
+                _mapManager.TrueGridDelete((MapGrid)_mapGrid);
 
             base.OnRemove();
         }

--- a/Robust.Shared/Map/MapManager.MapCollection.cs
+++ b/Robust.Shared/Map/MapManager.MapCollection.cs
@@ -120,8 +120,11 @@ internal partial class MapManager
         {
             if (kvEntity.Value == newMapEntity)
             {
+                if (mapId == kvEntity.Key)
+                    return;
+
                 throw new InvalidOperationException(
-                    $"Entity {newMapEntity} is already the root node of map {kvEntity.Key}.");
+                    $"Entity {newMapEntity} is already the root node of another map {kvEntity.Key}.");
             }
         }
 

--- a/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
+++ b/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
@@ -99,7 +99,7 @@ entities:
             entMan.EnsureComponent<BroadphaseComponent>(mapUid);
 
             var mapLoad = IoCManager.Resolve<IMapLoader>();
-            var geid = mapLoad.LoadBlueprint(mapId, "/TestMap.yml").gridId;
+            var geid = mapLoad.LoadGrid(mapId, "/TestMap.yml").gridId;
 
             Assert.That(geid, NUnit.Framework.Is.Not.Null);
 


### PR DESCRIPTION
- Renames load/savebp commands to load/savegrid (fixes #3179)
- Using loadgrid to load map file now outputs a descriptive error and should no longer unintentionally delete maps (fixes #3177)
  - ~~There will still be errors, but in release mode, the game still seems to function & rounds can re-start after a bad grid load.~~
  - Correction: after #3160 & the LoadMap = false option, it doesn't even error anymore.
- This PR also updates the client-side session's attached entity to null when the player is detached from an entity
  - Makes it clearer in logs that the player has been detached & the old entity has been deleted, rather than the somewhat confusing "\<OldPlayerUid\> does not have XYZ component" errors. AFAIK this doesn't cause any issues.

Requires space-wizards/space-station-14/pull/10817, for the command permissions and because the `LoadBlueprint` -> `LoadGrid` renaming.