### PR TITLE
Make mapload errors more obvious

### DIFF
--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -850,8 +850,6 @@ namespace Robust.Server.Maps
 
                 if (failure)
                 {
-                    Logger.Fatal($"Cleaning up failed map load for {TargetMap}");
-
                     for (var i = 0; i < Entities.Count; i++)
                     {
                         _serverEntityManager.DeleteEntity(Entities[i]);
@@ -861,7 +859,7 @@ namespace Robust.Server.Maps
                     _entitiesToDeserialize.Clear();
 
                     throw new InvalidOperationException(
-                        $"Failed to load map due to deleted entities, see log for info");
+                        $"Failed to load map {TargetMap} due to deleted entities, see log for info");
                 }
             }
 

--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -855,10 +855,10 @@ namespace Robust.Server.Maps
                     for (var i = 0; i < Entities.Count; i++)
                     {
                         _serverEntityManager.DeleteEntity(Entities[i]);
-                        Entities.RemoveSwap(i);
-                        _entitiesToDeserialize.RemoveSwap(i);
-                        i--;
                     }
+
+                    Entities.Clear();
+                    _entitiesToDeserialize.Clear();
 
                     throw new InvalidOperationException(
                         $"Failed to load map due to deleted entities, see log for info");

--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -850,7 +850,7 @@ namespace Robust.Server.Maps
 
                 if (failure)
                 {
-                    Logger.Warning($"Cleaning up failed map load");
+                    Logger.Fatal($"Cleaning up failed map load for {TargetMap}");
 
                     for (var i = 0; i < Entities.Count; i++)
                     {


### PR DESCRIPTION
So people don't read the irrelevant exceptions.

This is what the console looks like now:
![image](https://user-images.githubusercontent.com/31366439/186807024-df57439d-c2e1-4443-b3ef-86d40734c966.png)
