### PR TITLE
Fix some test issues

### DIFF
--- a/Robust.UnitTesting/RobustIntegrationTest.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.cs
@@ -574,6 +574,7 @@ namespace Robust.UnitTesting
                     var server = Init();
                     GameLoop.Run();
                     server.FinishMainLoop();
+                    IoCManager.Clear();
                 }
                 catch (Exception e)
                 {

--- a/Robust.UnitTesting/TestLogHandler.cs
+++ b/Robust.UnitTesting/TestLogHandler.cs
@@ -8,7 +8,7 @@ using Serilog.Events;
 
 namespace Robust.UnitTesting
 {
-    public sealed class TestLogHandler : ILogHandler, IDisposable
+    public sealed class TestLogHandler : ILogHandler
     {
         private readonly string? _prefix;
         private readonly TextWriter _writer;
@@ -24,11 +24,6 @@ namespace Robust.UnitTesting
         }
 
         private LogLevel? FailureLevel { get; set; }
-
-        public void Dispose()
-        {
-            _writer.Dispose();
-        }
 
         public void Log(string sawmillName, LogEvent message)
         {


### PR DESCRIPTION
- Fix the IoC leaking between disposed servers, and new servers, by cleaning the IoC when the server is stopped.
- Don't dispose the TestContext.Out. (screws up other output calls)