### PR TITLE
Misc PVS error logging / debugging changes

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -294,10 +294,10 @@ namespace Robust.Client.GameStates
                     createdEntities = ApplyGameState(curState, nextState);
 #if EXCEPTION_TOLERANCE
                     }
-                    catch (MissingMetadataException)
+                    catch (MissingMetadataException e)
                     {
                         // Something has gone wrong. Probably a missing meta-data component. Perhaps a full server state will fix it.
-                        RequestFullState();
+                        RequestFullState(e.Uid);
                         throw;
                     }
 #endif
@@ -366,10 +366,10 @@ namespace Robust.Client.GameStates
             }
         }
 
-        public void RequestFullState()
+        public void RequestFullState(EntityUid? missingEntity = null)
         {
             Logger.Info("Requesting full server state");
-            _network.ClientSendMessage(new MsgStateRequestFull() { Tick = _timing.LastRealTick });
+            _network.ClientSendMessage(new MsgStateRequestFull() { Tick = _timing.LastRealTick , MissingEntity = missingEntity ?? EntityUid.Invalid });
             _processor.RequestFullState();
         }
 
@@ -1080,9 +1080,12 @@ namespace Robust.Client.GameStates
 
     public sealed class MissingMetadataException : Exception
     {
+        public readonly EntityUid Uid;
+
         public MissingMetadataException(EntityUid uid)
             : base($"Server state is missing the metadata component for a new entity: {uid}.")
         {
+            Uid = uid;
         }
     }
 }

--- a/Robust.Client/GameStates/IClientGameStateManager.cs
+++ b/Robust.Client/GameStates/IClientGameStateManager.cs
@@ -79,7 +79,7 @@ namespace Robust.Client.GameStates
         /// <summary>
         ///     Requests a full state from the server. This should override even implicit entity data.
         /// </summary>
-        public void RequestFullState();
+        public void RequestFullState(EntityUid? missingEntity = null);
 
         uint SystemMessageDispatched<T>(T message) where T : EntityEventArgs;
     }

--- a/Robust.Server/GameStates/IServerGameStateManager.cs
+++ b/Robust.Server/GameStates/IServerGameStateManager.cs
@@ -1,4 +1,5 @@
 using System;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Players;
 using Robust.Shared.Timing;
 
@@ -23,6 +24,6 @@ namespace Robust.Server.GameStates
 
         Action<ICommonSession, GameTick, GameTick>? ClientAck { get; set; }
 
-        Action<ICommonSession, GameTick, GameTick>? ClientRequestFull { get; set; }
+        Action<ICommonSession, GameTick, GameTick, EntityUid?>? ClientRequestFull { get; set; }
     }
 }

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -200,7 +200,7 @@ internal sealed partial class PVSSystem : EntitySystem
         }
 
         // return last acked to pool, but only if it is not still in the OverflowDictionary.
-        if (sessionData.LastAcked != null && _gameTiming.CurTick.Value - lastAcked.Value > TickBuffer)
+        if (sessionData.LastAcked != null && !sessionData.SentEntities.ContainsKey(lastAcked))
             _visSetPool.Return(sessionData.LastAcked);
 
         sessionData.LastAcked = null;
@@ -234,7 +234,7 @@ internal sealed partial class PVSSystem : EntitySystem
     private void ProcessAckedTick(SessionPVSData sessionData, Dictionary<EntityUid, PVSEntityVisiblity> ackedData, GameTick tick, GameTick lastAckedTick)
     {
         // return last acked to pool, but only if it is not still in the OverflowDictionary.
-        if (sessionData.LastAcked != null && _gameTiming.CurTick.Value - lastAckedTick.Value > TickBuffer)
+        if (sessionData.LastAcked != null && !sessionData.SentEntities.ContainsKey(lastAckedTick))
             _visSetPool.Return(sessionData.LastAcked);
 
         sessionData.LastAcked = ackedData;

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -915,6 +915,14 @@ internal sealed partial class PVSSystem : EntitySystem
 
     private void AddToSendSet(in EntityUid uid, MetaDataComponent metaDataComponent, Dictionary<EntityUid, PVSEntityVisiblity> toSend, GameTick fromTick, bool entered)
     {
+        // This check shouldn't be required, but temporarily adding it to try debug PVS errors.
+        if (metaDataComponent.EntityLifeStage >= EntityLifeStage.Terminating)
+        {
+            var rep = new EntityStringRepresentation(uid, metaDataComponent.EntityDeleted, metaDataComponent.EntityName, metaDataComponent.EntityPrototype?.ID);
+            _sawmill.Error($"Attempted to add a deleted entity to PVS send set: {rep}");
+            return;
+        }
+
         if (entered)
         {
             toSend.Add(uid, PVSEntityVisiblity.Entered);

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -688,8 +688,10 @@ internal sealed partial class PVSSystem : EntitySystem
         var lastAcked = sessionData.LastAcked;
         var lastSeen = sessionData.LastSeenAt;
         var visibleEnts = _visSetPool.Get();
-        DebugTools.Assert(visibleEnts.Count == 0);
 
+        if (visibleEnts.Count != 0)
+            throw new Exception("Encountered non-empty object inside of _visSetPool. Was the same object returned to the pool more than once?");
+        
         var deletions = _entityPvsCollection.GetDeletedIndices(fromTick);
 
         foreach (var i in chunkIndices)

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -53,7 +53,7 @@ namespace Robust.Server.GameStates
         public ushort TransformNetId { get; set; }
 
         public Action<ICommonSession, GameTick, GameTick>? ClientAck { get; set; }
-        public Action<ICommonSession, GameTick, GameTick>? ClientRequestFull { get; set; }
+        public Action<ICommonSession, GameTick, GameTick, EntityUid?>? ClientRequestFull { get; set; }
 
         public void PostInject()
         {
@@ -138,7 +138,8 @@ namespace Robust.Server.GameStates
                 !_ackedStates.TryGetValue(msg.MsgChannel.ConnectionId, out var lastAcked))
                 return;
 
-            ClientRequestFull?.Invoke(session, msg.Tick, lastAcked);
+            EntityUid? ent = msg.MissingEntity.IsValid() ? msg.MissingEntity : null;
+            ClientRequestFull?.Invoke(session, msg.Tick, lastAcked, ent);
 
             // Update acked tick so that OnClientAck doesn't get invoked by any late acks.
             _ackedStates[msg.MsgChannel.ConnectionId] = _gameTiming.CurTick;

--- a/Robust.Shared/Network/Messages/MsgStateRequestFull.cs
+++ b/Robust.Shared/Network/Messages/MsgStateRequestFull.cs
@@ -1,4 +1,5 @@
 using Lidgren.Network;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Timing;
 
 #nullable disable
@@ -11,14 +12,18 @@ public sealed class MsgStateRequestFull : NetMessage
 
     public GameTick Tick;
 
+    public EntityUid MissingEntity;
+
     public override void ReadFromBuffer(NetIncomingMessage buffer)
     {
         Tick = buffer.ReadGameTick();
+        MissingEntity = buffer.ReadEntityUid();
     }
 
     public override void WriteToBuffer(NetOutgoingMessage buffer)
     {
         buffer.Write(Tick);
+        buffer.Write(MissingEntity);
     }
 
     public override NetDeliveryMethod DeliveryMethod => NetDeliveryMethod.ReliableUnordered;


### PR DESCRIPTION
- If a client requests a full game state due to receiving an entity without metadata, the UID is now included in the request so that it can be printed in server-side logs.
- Maaaybe fixes one of the PVS errors added in #3000 ?
- Adds a sanity check to `AddToSendSet()` that ensures deleted entities aren't somehow staying in the tree.