### PR TITLE
Move MoveBuffer to the physicsmapcomponent

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -192,7 +192,12 @@ namespace Robust.Shared.GameObjects
             TryComp(MapManager.GetMapEntityId(oldMapId), out SharedPhysicsMapComponent? oldMap);
             TryComp(MapManager.GetMapEntityId(newMapId), out SharedPhysicsMapComponent? newMap);
 
-            _broadphase.TryGetMoveBuffer(oldMapId, out var oldMoveBuffer);
+            Dictionary<FixtureProxy, Box2>? oldMoveBuffer = null;
+
+            if (oldMap != null)
+            {
+                oldMoveBuffer = oldMap.MoveBuffer;
+            }
 
             var newBroadphase = _broadphase.GetBroadphase(xform, broadQuery, xformQuery);
 

--- a/Robust.Shared/Physics/BroadphaseComponent.cs
+++ b/Robust.Shared/Physics/BroadphaseComponent.cs
@@ -2,6 +2,9 @@ using Robust.Shared.GameObjects;
 
 namespace Robust.Shared.Physics
 {
+    /// <summary>
+    /// Stores the broadphase structore for the relevant grid / map.
+    /// </summary>
     [RegisterComponent]
     public sealed class BroadphaseComponent : Component
     {

--- a/Robust.Shared/Physics/BroadphaseComponent.cs
+++ b/Robust.Shared/Physics/BroadphaseComponent.cs
@@ -3,7 +3,7 @@ using Robust.Shared.GameObjects;
 namespace Robust.Shared.Physics
 {
     /// <summary>
-    /// Stores the broadphase structore for the relevant grid / map.
+    /// Stores the broadphase structure for the relevant grid / map.
     /// </summary>
     [RegisterComponent]
     public sealed class BroadphaseComponent : Component

--- a/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
+++ b/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
@@ -45,6 +45,11 @@ namespace Robust.Shared.Physics.Dynamics
         public bool AutoClearForces;
 
         /// <summary>
+        /// Keep a buffer of everything that moved in a tick. This will be used to check for physics contacts.
+        /// </summary>
+        public readonly Dictionary<FixtureProxy, Box2> MoveBuffer = new();
+
+        /// <summary>
         ///     Change the global gravity vector.
         /// </summary>
         public Vector2 Gravity
@@ -158,7 +163,7 @@ namespace Robust.Shared.Physics.Dynamics
             // Box2D does this at the end of a step and also here when there's a fixture update.
             // Given external stuff can move bodies we'll just do this here.
             // Unfortunately this NEEDS to be predicted to make pushing remotely fucking good.
-            BroadphaseSystem.FindNewContacts(MapId);
+            BroadphaseSystem.FindNewContacts(this, MapId);
 
             var invDt = frameTime > 0.0f ? 1.0f / frameTime : 0.0f;
             var dtRatio = _invDt0 * frameTime;

--- a/Robust.Shared/Physics/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/SharedBroadphaseSystem.cs
@@ -235,6 +235,7 @@ namespace Robust.Shared.Physics
                 // (nothing in SS14 does this yet).
 
                 var transform = bodyQuery.GetComponent(grid.GridEntityId).GetTransform(xform);
+                gridsPool.Clear();
 
                 foreach (var colliding in _mapManager.FindGridsIntersecting(mapId, aabb, gridsPool, xformQuery, bodyQuery, true))
                 {


### PR DESCRIPTION
Baby steps in ECSifying physics fully.

Should also avoid the movebuffer crashes whenever something goes awry with a map.