### PR TITLE
Fixes Omnisharp failing to analyze the client by default.

### DIFF
--- a/MSBuild/XamlIL.targets
+++ b/MSBuild/XamlIL.targets
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- Avoid MSBuild adding a None entry for XAML files because they'd show up TWICE in the project view. -->
     <DefaultItemExcludes>**/*.xaml</DefaultItemExcludes>
-    <RobustUseExternalMSBuild>false</RobustUseExternalMSBuild>
+    <RobustUseExternalMSBuild>true</RobustUseExternalMSBuild>
     <_RobustUseExternalMSBuild>$(RobustUseExternalMSBuild)</_RobustUseExternalMSBuild>
     <_RobustUseExternalMSBuild Condition="'$(_RobustForceInternalMSBuild)' == 'true'">false</_RobustUseExternalMSBuild>
   </PropertyGroup>


### PR DESCRIPTION
Sets `RobustUseExternalMSBuild` to true in `XamlIL.targets`.

Afaik it was originally turned off because of "compile times and error reporting" since XamlIL isn't actively developed so recompiling it every time its a waste, but i haven't seen any concrete statistics supporting this and building locally with it enabled i didn't notice any differences. 

Even if there were measured benefits i still think this should be opt-in instead of opt-out because it makes Omnisharp fail to analyze the client which is a huge blunder since vscode and most free IDEs depend on it, so having the default result in failure is a big issue.

Probably solves the issue with the xaml-injector complaining that some dll was locked by a process thing reported by Paul.
 
# Extra info
Omnisharp died on the client with the following errors when `RobustUseExternalMSBuild` is set to false.
```
[info]: OmniSharp.MSBuild.ProjectManager
        Loading project: /home/maharba/Save/3-Programas/Git/Desarrollo/SS14/space-station-14/Content.Client/Content.Client.csproj
[fail]: OmniSharp.MSBuild.ProjectLoader
        The "CompileRobustXamlTask" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with <UsingTask> in the project file, or in the *.tasks files located in the "/usr/share/dotnet/sdk/6.0.101" directory.
[warn]: OmniSharp.MSBuild.ProjectManager
        Failed to load project file '/home/maharba/Save/3-Programas/Git/Desarrollo/SS14/space-station-14/Content.Client/Content.Client.csproj'.
/home/maharba/Save/3-Programas/Git/Desarrollo/SS14/space-station-14/Content.Client/Content.Client.csproj
/home/maharba/Save/3-Programas/Git/Desarrollo/SS14/space-station-14/RobustToolbox/MSBuild/XamlIL.targets(47,5): Error: The "CompileRobustXamlTask" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with <UsingTask> in the project file, or in the *.tasks files located in the "/usr/share/dotnet/sdk/6.0.101" directory.
```
```
[info]: OmniSharp.MSBuild.ProjectManager
        Loading project: /home/maharba/Save/3-Programas/Git/Desarrollo/SS14/space-station-14/RobustToolbox/Robust.Client/Robust.Client.csproj
[fail]: OmniSharp.MSBuild.ProjectLoader
        The "CompileRobustXamlTask" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with <UsingTask> in the project file, or in the *.tasks files located in the "/usr/share/dotnet/sdk/6.0.101" directory.
[warn]: OmniSharp.MSBuild.ProjectManager
        Failed to load project file '/home/maharba/Save/3-Programas/Git/Desarrollo/SS14/space-station-14/RobustToolbox/Robust.Client/Robust.Client.csproj'.
/home/maharba/Save/3-Programas/Git/Desarrollo/SS14/space-station-14/RobustToolbox/Robust.Client/Robust.Client.csproj
/home/maharba/Save/3-Programas/Git/Desarrollo/SS14/space-station-14/RobustToolbox/MSBuild/XamlIL.targets(47,5): Error: The "CompileRobustXamlTask" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with <UsingTask> in the project file, or in the *.tasks files located in the "/usr/share/dotnet/sdk/6.0.101" directory.
```

Do not merge without PJB:tm: approval