### PR TITLE
Fix construction ghost rotation on entities without directional sprites

### DIFF
--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -109,7 +109,7 @@ namespace Robust.Client.Placement
         /// </summary>
         public List<IDirectionalTextureProvider>? CurrentTextures {
             set {
-                PreparePlacementTexList(value, value != null, null);
+                PreparePlacementTexList(value, !Hijack?.CanRotate ?? value != null, null);
             }
         }
 
@@ -717,7 +717,7 @@ namespace Robust.Client.Placement
             }
             sc.NoRotation = noRot;
 
-            if (prototype?.TryGetComponent<SpriteComponent>("Sprite", out var spriteComp) == true)
+            if (prototype != null && prototype.TryGetComponent<SpriteComponent>("Sprite", out var spriteComp))
             {
                 sc.Scale = spriteComp.Scale;
             }


### PR DESCRIPTION
Small change to PreparePlacementTexList that makes rotation show on entities without directional sprites.

https://user-images.githubusercontent.com/10494922/187614282-43fecf6f-e1fa-4d8b-b6af-ed37ae976699.mp4

