### PR TITLE
Fix awake bodies in containers

### DIFF
--- a/Robust.Shared/Containers/IContainer.cs
+++ b/Robust.Shared/Containers/IContainer.cs
@@ -94,7 +94,12 @@ namespace Robust.Shared.Containers
         /// Thrown if this container is a child of the entity,
         /// which would cause infinite loops.
         /// </exception>
-        bool Insert(EntityUid toinsert, IEntityManager? entMan = null, TransformComponent? transform = null, TransformComponent? ownerTransform = null, MetaDataComponent? meta = null);
+        bool Insert(EntityUid toinsert,
+            IEntityManager? entMan = null,
+            TransformComponent? transform = null,
+            TransformComponent? ownerTransform = null,
+            MetaDataComponent? meta = null,
+            PhysicsComponent? physics = null);
 
         /// <summary>
         /// Checks if the entity can be removed from this container.

--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -155,20 +155,6 @@ namespace Robust.Shared.GameObjects
                 HandleMapChange(xform, body, args.OldMapId, xform.MapID);
             }
 
-            if (body != null && (meta.Flags & MetaDataFlags.InContainer) != 0)
-            {
-                // Here we intentionally dont dirty the physics comp. Client-side state handling will apply these same
-                // changes. This also ensures that the server doesn't have to send the physics comp state to every
-                // player for any entity inside of a container during init.
-                SetLinearVelocity(body, Vector2.Zero, false);
-                SetAngularVelocity(body, 0, false);
-
-                // This needs to get called AFTER handle map change Otherwise this will set awake to false, but will
-                // fail to remove the body from the "current map" (which should really be the old map).
-                SetCanCollide(body, false, false);
-                _joints.ClearJoints(body);
-            }
-
             if (args.OldMapId != xform.MapID)
                 return;
 


### PR DESCRIPTION
Good ol' container bugs.

Because physics system was only setting collision to false on container insertions via parent changes, you could sometimes get awake bodies in containers when transferring things between containers on the same entity (e.g. for ss14, hands & inventory transfers). The awake bodies could then get non-zero local positions while inside of containers. This is probably the cause of space-wizards/space-station-14/issues/11012

Now the container insert function directly updates the physics properties, while also recursively updating children (which it previously wasn't doing).