### PR TITLE
Pass IRobustSerializer to NetMessage

### DIFF
--- a/Robust.Shared/Network/Messages/Handshake/MsgEncryptionRequest.cs
+++ b/Robust.Shared/Network/Messages/Handshake/MsgEncryptionRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Lidgren.Network;
+using Robust.Shared.Serialization;
 
 #nullable disable
 
@@ -13,7 +14,7 @@ namespace Robust.Shared.Network.Messages.Handshake
         public byte[] VerifyToken;
         public byte[] PublicKey;
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             var tokenLength = buffer.ReadVariableInt32();
             VerifyToken = buffer.ReadBytes(tokenLength);
@@ -21,7 +22,7 @@ namespace Robust.Shared.Network.Messages.Handshake
             PublicKey = buffer.ReadBytes(keyLength);
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.WriteVariableInt32(VerifyToken.Length);
             buffer.Write(VerifyToken);

--- a/Robust.Shared/Network/Messages/Handshake/MsgEncryptionResponse.cs
+++ b/Robust.Shared/Network/Messages/Handshake/MsgEncryptionResponse.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Lidgren.Network;
+using Robust.Shared.Serialization;
 
 #nullable disable
 
@@ -14,14 +15,14 @@ namespace Robust.Shared.Network.Messages.Handshake
         public Guid UserId;
         public byte[] SealedData;
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             UserId = buffer.ReadGuid();
             var keyLength = buffer.ReadVariableInt32();
             SealedData = buffer.ReadBytes(keyLength);
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(UserId);
             buffer.WriteVariableInt32(SealedData.Length);

--- a/Robust.Shared/Network/Messages/Handshake/MsgLoginStart.cs
+++ b/Robust.Shared/Network/Messages/Handshake/MsgLoginStart.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Immutable;
 using Lidgren.Network;
+using Robust.Shared.Serialization;
 
 #nullable disable
 
@@ -20,7 +21,7 @@ namespace Robust.Shared.Network.Messages.Handshake
         public bool NeedPubKey;
         public bool Encrypt;
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             UserName = buffer.ReadString();
             var length = buffer.ReadByte();
@@ -30,7 +31,7 @@ namespace Robust.Shared.Network.Messages.Handshake
             Encrypt = buffer.ReadBoolean();
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(UserName);
             buffer.Write((byte) HWId.Length);

--- a/Robust.Shared/Network/Messages/Handshake/MsgLoginSuccess.cs
+++ b/Robust.Shared/Network/Messages/Handshake/MsgLoginSuccess.cs
@@ -1,4 +1,5 @@
 ﻿using Lidgren.Network;
+using Robust.Shared.Serialization;
 
 #nullable disable
 
@@ -14,7 +15,7 @@ namespace Robust.Shared.Network.Messages.Handshake
         public NetUserData UserData;
         public LoginType Type;
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             var name = buffer.ReadString();
             var id = buffer.ReadGuid();
@@ -26,7 +27,7 @@ namespace Robust.Shared.Network.Messages.Handshake
             Type = (LoginType) buffer.ReadByte();
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(UserData.UserName);
             buffer.Write(UserData.UserId);

--- a/Robust.Shared/Network/Messages/MsgConCmd.cs
+++ b/Robust.Shared/Network/Messages/MsgConCmd.cs
@@ -1,4 +1,5 @@
 ﻿using Lidgren.Network;
+using Robust.Shared.Serialization;
 
 #nullable disable
 
@@ -10,12 +11,12 @@ namespace Robust.Shared.Network.Messages
 
         public string Text { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             Text = buffer.ReadString();
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(Text);
         }

--- a/Robust.Shared/Network/Messages/MsgConCmdAck.cs
+++ b/Robust.Shared/Network/Messages/MsgConCmdAck.cs
@@ -1,4 +1,5 @@
 using Lidgren.Network;
+using Robust.Shared.Serialization;
 
 #nullable disable
 
@@ -11,12 +12,12 @@ namespace Robust.Shared.Network.Messages
         public string Text { get; set; }
         public bool Error { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             Text = buffer.ReadString();
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(Text);
         }

--- a/Robust.Shared/Network/Messages/MsgConCmdReg.cs
+++ b/Robust.Shared/Network/Messages/MsgConCmdReg.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using Lidgren.Network;
+using Robust.Shared.Serialization;
 
 #nullable disable
 
@@ -18,7 +19,7 @@ namespace Robust.Shared.Network.Messages
             public string Help { get; set; }
         }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             var cmdCount = buffer.ReadUInt16();
             Commands = new Command[cmdCount];
@@ -33,7 +34,7 @@ namespace Robust.Shared.Network.Messages
             }
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             if(Commands == null) // client leaves comands as null to request from server
                 Commands = new Command[0];

--- a/Robust.Shared/Network/Messages/MsgConCompletion.cs
+++ b/Robust.Shared/Network/Messages/MsgConCompletion.cs
@@ -1,4 +1,5 @@
 using Lidgren.Network;
+using Robust.Shared.Serialization;
 
 namespace Robust.Shared.Network.Messages;
 
@@ -11,7 +12,7 @@ public sealed class MsgConCompletion : NetMessage
     public int Seq { get; set; }
     public string[] Args { get; set; }
 
-    public override void ReadFromBuffer(NetIncomingMessage buffer)
+    public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
     {
         Seq = buffer.ReadInt32();
 
@@ -23,7 +24,7 @@ public sealed class MsgConCompletion : NetMessage
         }
     }
 
-    public override void WriteToBuffer(NetOutgoingMessage buffer)
+    public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
     {
         buffer.Write(Seq);
 

--- a/Robust.Shared/Network/Messages/MsgConCompletionResp.cs
+++ b/Robust.Shared/Network/Messages/MsgConCompletionResp.cs
@@ -1,5 +1,6 @@
 using Lidgren.Network;
 using Robust.Shared.Console;
+using Robust.Shared.Serialization;
 
 namespace Robust.Shared.Network.Messages;
 
@@ -12,7 +13,7 @@ public sealed class MsgConCompletionResp : NetMessage
     public int Seq { get; set; }
     public CompletionResult Result { get; set; }
 
-    public override void ReadFromBuffer(NetIncomingMessage buffer)
+    public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
     {
         Seq = buffer.ReadInt32();
 
@@ -35,7 +36,7 @@ public sealed class MsgConCompletionResp : NetMessage
         Result = new CompletionResult(options, hint == "" ? null : hint);
     }
 
-    public override void WriteToBuffer(NetOutgoingMessage buffer)
+    public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
     {
         buffer.Write(Seq);
 

--- a/Robust.Shared/Network/Messages/MsgConVars.cs
+++ b/Robust.Shared/Network/Messages/MsgConVars.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Lidgren.Network;
 using Robust.Shared.Log;
 using Robust.Shared.Maths;
+using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 
 namespace Robust.Shared.Network.Messages
@@ -20,7 +21,7 @@ namespace Robust.Shared.Network.Messages
         public List<(string name, object value)> NetworkedVars = null!;
 
         /// <inheritdoc />
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             if(buffer.LengthBytes > MaxMessageSize)
                 Logger.WarningS("net", $"{MsgChannel}: received a large {nameof(MsgConVars)}, {buffer.LengthBytes}B > {MaxMessageSize}B");
@@ -76,7 +77,7 @@ namespace Robust.Shared.Network.Messages
         }
 
         /// <inheritdoc />
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             if(NetworkedVars == null)
                 throw new InvalidOperationException($"{nameof(NetworkedVars)} collection is null.");

--- a/Robust.Shared/Network/Messages/MsgEntity.cs
+++ b/Robust.Shared/Network/Messages/MsgEntity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using Lidgren.Network;
 using Robust.Shared.GameObjects;
@@ -23,7 +23,7 @@ namespace Robust.Shared.Network.Messages
         public uint Sequence { get; set; }
         public GameTick SourceTick { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             Type = (EntityMessageType)buffer.ReadByte();
             SourceTick = buffer.ReadGameTick();
@@ -33,7 +33,6 @@ namespace Robust.Shared.Network.Messages
             {
                 case EntityMessageType.SystemMessage:
                 {
-                    var serializer = IoCManager.Resolve<IRobustSerializer>();
                     int length = buffer.ReadVariableInt32();
                     using var stream = buffer.ReadAlignedMemory(length);
                     SystemMessage = serializer.Deserialize<EntityEventArgs>(stream);
@@ -42,7 +41,7 @@ namespace Robust.Shared.Network.Messages
             }
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write((byte)Type);
             buffer.Write(SourceTick);
@@ -52,7 +51,6 @@ namespace Robust.Shared.Network.Messages
             {
                 case EntityMessageType.SystemMessage:
                 {
-                    var serializer = IoCManager.Resolve<IRobustSerializer>();
                     var stream = new MemoryStream();
 
                     serializer.Serialize(stream, SystemMessage);

--- a/Robust.Shared/Network/Messages/MsgMapStrClientHandshake.cs
+++ b/Robust.Shared/Network/Messages/MsgMapStrClientHandshake.cs
@@ -28,10 +28,10 @@ namespace Robust.Shared.Network.Messages
         /// </value>
         public bool NeedsStrings { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
             => NeedsStrings = buffer.ReadBoolean();
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
             => buffer.Write(NeedsStrings);
     }
 }

--- a/Robust.Shared/Network/Messages/MsgMapStrServerHandshake.cs
+++ b/Robust.Shared/Network/Messages/MsgMapStrServerHandshake.cs
@@ -22,7 +22,7 @@ namespace Robust.Shared.Network.Messages
         /// </value>
         public byte[]? Hash { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             var len = buffer.ReadVariableInt32();
             if (len > 64)
@@ -33,7 +33,7 @@ namespace Robust.Shared.Network.Messages
             buffer.ReadBytes(Hash = new byte[len]);
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             if (Hash == null)
             {

--- a/Robust.Shared/Network/Messages/MsgMapStrStrings.cs
+++ b/Robust.Shared/Network/Messages/MsgMapStrStrings.cs
@@ -22,13 +22,13 @@ namespace Robust.Shared.Network.Messages
         /// </value>
         public byte[]? Package { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             var size = buffer.ReadVariableInt32();
             buffer.ReadBytes(Package = new byte[size]);
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             if (Package == null)
             {

--- a/Robust.Shared/Network/Messages/MsgPlacement.cs
+++ b/Robust.Shared/Network/Messages/MsgPlacement.cs
@@ -4,6 +4,7 @@ using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
+using Robust.Shared.Serialization;
 
 #nullable disable
 
@@ -27,7 +28,7 @@ namespace Robust.Shared.Network.Messages
         public string AlignOption { get; set; }
         public Vector2 RectSize { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             PlaceType = (PlacementManagerMessage) buffer.ReadByte();
             switch (PlaceType)
@@ -61,7 +62,7 @@ namespace Robust.Shared.Network.Messages
             }
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write((byte)PlaceType);
             switch (PlaceType)

--- a/Robust.Shared/Network/Messages/MsgPlayerList.cs
+++ b/Robust.Shared/Network/Messages/MsgPlayerList.cs
@@ -2,6 +2,7 @@
 using Lidgren.Network;
 using Robust.Shared.Enums;
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
 
 #nullable disable
 
@@ -14,7 +15,7 @@ namespace Robust.Shared.Network.Messages
         public byte PlyCount { get; set; }
         public List<PlayerState> Plyrs { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             Plyrs = new List<PlayerState>();
             PlyCount = buffer.ReadByte();
@@ -31,7 +32,7 @@ namespace Robust.Shared.Network.Messages
             }
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(PlyCount);
 

--- a/Robust.Shared/Network/Messages/MsgPlayerListReq.cs
+++ b/Robust.Shared/Network/Messages/MsgPlayerListReq.cs
@@ -1,4 +1,5 @@
 ﻿using Lidgren.Network;
+using Robust.Shared.Serialization;
 
 namespace Robust.Shared.Network.Messages
 {
@@ -6,11 +7,11 @@ namespace Robust.Shared.Network.Messages
     {
         public override MsgGroups MsgGroup => MsgGroups.Core;
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
         }
     }

--- a/Robust.Shared/Network/Messages/MsgReloadPrototypes.cs
+++ b/Robust.Shared/Network/Messages/MsgReloadPrototypes.cs
@@ -1,4 +1,5 @@
 ﻿using Lidgren.Network;
+using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.Network.Messages
@@ -9,7 +10,7 @@ namespace Robust.Shared.Network.Messages
 
         public ResourcePath[] Paths = default!;
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             var count = buffer.ReadInt32();
             Paths = new ResourcePath[count];
@@ -20,7 +21,7 @@ namespace Robust.Shared.Network.Messages
             }
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(Paths.Length);
 

--- a/Robust.Shared/Network/Messages/MsgScriptCompletion.cs
+++ b/Robust.Shared/Network/Messages/MsgScriptCompletion.cs
@@ -1,4 +1,5 @@
 using Lidgren.Network;
+using Robust.Shared.Serialization;
 
 #nullable disable
 
@@ -12,14 +13,14 @@ namespace Robust.Shared.Network.Messages
         public int Cursor { get; set; }
         public string Code { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             ScriptSession = buffer.ReadInt32();
             Cursor = buffer.ReadInt32();
             Code = buffer.ReadString();
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(ScriptSession);
             buffer.Write(Cursor);

--- a/Robust.Shared/Network/Messages/MsgScriptCompletionResponse.cs
+++ b/Robust.Shared/Network/Messages/MsgScriptCompletionResponse.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using Lidgren.Network;
+using Robust.Shared.Serialization;
 
 namespace Robust.Shared.Network.Messages
 {
@@ -10,7 +11,7 @@ namespace Robust.Shared.Network.Messages
         public int ScriptSession { get; set; }
         public ImmutableArray<LiteResult> Results;
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             ScriptSession = buffer.ReadInt32()!;
 
@@ -24,7 +25,7 @@ namespace Robust.Shared.Network.Messages
             Results = cli.ToImmutable();
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(ScriptSession);
 

--- a/Robust.Shared/Network/Messages/MsgScriptEval.cs
+++ b/Robust.Shared/Network/Messages/MsgScriptEval.cs
@@ -1,4 +1,5 @@
 using Lidgren.Network;
+using Robust.Shared.Serialization;
 
 #nullable disable
 
@@ -11,13 +12,13 @@ namespace Robust.Shared.Network.Messages
         public int ScriptSession { get; set; }
         public string Code { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             ScriptSession = buffer.ReadInt32();
             Code = buffer.ReadString();
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(ScriptSession);
             buffer.Write(Code);

--- a/Robust.Shared/Network/Messages/MsgScriptResponse.cs
+++ b/Robust.Shared/Network/Messages/MsgScriptResponse.cs
@@ -19,15 +19,13 @@ namespace Robust.Shared.Network.Messages
         public FormattedMessage Echo;
         public FormattedMessage Response;
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             ScriptSession = buffer.ReadInt32();
             WasComplete = buffer.ReadBoolean();
 
             if (WasComplete)
             {
-                var serializer = IoCManager.Resolve<IRobustSerializer>();
-
                 buffer.ReadPadBits();
                 var length = buffer.ReadVariableInt32();
                 using var stream = buffer.ReadAlignedMemory(length);
@@ -36,7 +34,7 @@ namespace Robust.Shared.Network.Messages
             }
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(ScriptSession);
             buffer.Write(WasComplete);
@@ -44,7 +42,6 @@ namespace Robust.Shared.Network.Messages
             if (WasComplete)
             {
                 buffer.WritePadBits();
-                var serializer = IoCManager.Resolve<IRobustSerializer>();
 
                 var memoryStream = new MemoryStream();
                 serializer.SerializeDirect(memoryStream, Echo);

--- a/Robust.Shared/Network/Messages/MsgScriptStart.cs
+++ b/Robust.Shared/Network/Messages/MsgScriptStart.cs
@@ -1,4 +1,5 @@
 using Lidgren.Network;
+using Robust.Shared.Serialization;
 
 #nullable disable
 
@@ -10,12 +11,12 @@ namespace Robust.Shared.Network.Messages
 
         public int ScriptSession { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             ScriptSession = buffer.ReadInt32();
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(ScriptSession);
         }

--- a/Robust.Shared/Network/Messages/MsgScriptStartAck.cs
+++ b/Robust.Shared/Network/Messages/MsgScriptStartAck.cs
@@ -1,4 +1,5 @@
 using Lidgren.Network;
+using Robust.Shared.Serialization;
 
 #nullable disable
 
@@ -11,13 +12,13 @@ namespace Robust.Shared.Network.Messages
         public bool WasAccepted { get; set; }
         public int ScriptSession { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             WasAccepted = buffer.ReadBoolean();
             ScriptSession = buffer.ReadInt32();
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(WasAccepted);
             buffer.Write(ScriptSession);

--- a/Robust.Shared/Network/Messages/MsgScriptStop.cs
+++ b/Robust.Shared/Network/Messages/MsgScriptStop.cs
@@ -1,4 +1,5 @@
 using Lidgren.Network;
+using Robust.Shared.Serialization;
 
 #nullable disable
 
@@ -10,12 +11,12 @@ namespace Robust.Shared.Network.Messages
 
         public int ScriptSession { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             ScriptSession = buffer.ReadInt32();
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(ScriptSession);
         }

--- a/Robust.Shared/Network/Messages/MsgState.cs
+++ b/Robust.Shared/Network/Messages/MsgState.cs
@@ -29,7 +29,7 @@ namespace Robust.Shared.Network.Messages
 
         internal bool _hasWritten;
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             MsgSize = buffer.LengthBytes;
             var uncompressedLength = buffer.ReadVariableInt32();
@@ -53,16 +53,14 @@ namespace Robust.Shared.Network.Messages
                 finalStream = stream;
             }
 
-            var serializer = IoCManager.Resolve<IRobustSerializer>();
             serializer.DeserializeDirect(finalStream, out State);
             finalStream.Dispose();
 
             State.PayloadSize = uncompressedLength;
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
-            var serializer = IoCManager.Resolve<IRobustSerializer>();
             var stateStream = new MemoryStream();
             serializer.SerializeDirect(stateStream, State);
             buffer.WriteVariableInt32((int)stateStream.Length);

--- a/Robust.Shared/Network/Messages/MsgStateAck.cs
+++ b/Robust.Shared/Network/Messages/MsgStateAck.cs
@@ -1,4 +1,5 @@
 ﻿using Lidgren.Network;
+using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 
 #nullable disable
@@ -11,12 +12,12 @@ namespace Robust.Shared.Network.Messages
 
         public GameTick Sequence { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             Sequence = new GameTick(buffer.ReadUInt32());
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(Sequence.Value);
         }

--- a/Robust.Shared/Network/Messages/MsgStateLeavePvs.cs
+++ b/Robust.Shared/Network/Messages/MsgStateLeavePvs.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Lidgren.Network;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Log;
+using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 
 #nullable disable
@@ -21,7 +22,7 @@ public sealed class MsgStateLeavePvs : NetMessage
     public List<EntityUid> Entities;
     public GameTick Tick;
 
-    public override void ReadFromBuffer(NetIncomingMessage buffer)
+    public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
     {
         Tick = buffer.ReadGameTick();
         var length = buffer.ReadInt32();
@@ -33,7 +34,7 @@ public sealed class MsgStateLeavePvs : NetMessage
         }
     }
 
-    public override void WriteToBuffer(NetOutgoingMessage buffer)
+    public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
     {
         buffer.Write(Tick);
         buffer.Write(Entities.Count);

--- a/Robust.Shared/Network/Messages/MsgStateRequestFull.cs
+++ b/Robust.Shared/Network/Messages/MsgStateRequestFull.cs
@@ -1,5 +1,6 @@
 using Lidgren.Network;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 
 #nullable disable
@@ -14,13 +15,13 @@ public sealed class MsgStateRequestFull : NetMessage
 
     public EntityUid MissingEntity;
 
-    public override void ReadFromBuffer(NetIncomingMessage buffer)
+    public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
     {
         Tick = buffer.ReadGameTick();
         MissingEntity = buffer.ReadEntityUid();
     }
 
-    public override void WriteToBuffer(NetOutgoingMessage buffer)
+    public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
     {
         buffer.Write(Tick);
         buffer.Write(MissingEntity);

--- a/Robust.Shared/Network/Messages/MsgSyncTimeBase.cs
+++ b/Robust.Shared/Network/Messages/MsgSyncTimeBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Lidgren.Network;
+using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 
 namespace Robust.Shared.Network.Messages;
@@ -15,13 +16,13 @@ internal sealed class MsgSyncTimeBase : NetMessage
     public GameTick Tick;
     public TimeSpan Time;
 
-    public override void ReadFromBuffer(NetIncomingMessage buffer)
+    public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
     {
         Tick = buffer.ReadGameTick();
         Time = buffer.ReadTimeSpan();
     }
 
-    public override void WriteToBuffer(NetOutgoingMessage buffer)
+    public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
     {
         buffer.Write(Tick);
         buffer.Write(Time);

--- a/Robust.Shared/Network/Messages/MsgViewVariablesCloseSession.cs
+++ b/Robust.Shared/Network/Messages/MsgViewVariablesCloseSession.cs
@@ -1,4 +1,5 @@
 using Lidgren.Network;
+using Robust.Shared.Serialization;
 
 #nullable disable
 
@@ -16,12 +17,12 @@ namespace Robust.Shared.Network.Messages
         /// </summary>
         public uint SessionId { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             SessionId = buffer.ReadUInt32();
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(SessionId);
         }

--- a/Robust.Shared/Network/Messages/MsgViewVariablesDenySession.cs
+++ b/Robust.Shared/Network/Messages/MsgViewVariablesDenySession.cs
@@ -1,4 +1,5 @@
 using Lidgren.Network;
+using Robust.Shared.Serialization;
 
 #nullable disable
 
@@ -22,13 +23,13 @@ namespace Robust.Shared.Network.Messages
         /// </summary>
         public DenyReason Reason { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             RequestId = buffer.ReadUInt32();
             Reason = (DenyReason)buffer.ReadUInt16();
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(RequestId);
             buffer.Write((ushort)Reason);

--- a/Robust.Shared/Network/Messages/MsgViewVariablesModifyRemote.cs
+++ b/Robust.Shared/Network/Messages/MsgViewVariablesModifyRemote.cs
@@ -37,9 +37,8 @@ namespace Robust.Shared.Network.Messages
         /// </summary>
         public object Value { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
-            var serializer = IoCManager.Resolve<IRobustSerializer>();
             SessionId = buffer.ReadUInt32();
             {
                 var length = buffer.ReadInt32();
@@ -54,9 +53,8 @@ namespace Robust.Shared.Network.Messages
             ReinterpretValue = buffer.ReadBoolean();
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
-            var serializer = IoCManager.Resolve<IRobustSerializer>();
             buffer.Write(SessionId);
 
             var stream = new MemoryStream();

--- a/Robust.Shared/Network/Messages/MsgViewVariablesOpenSession.cs
+++ b/Robust.Shared/Network/Messages/MsgViewVariablesOpenSession.cs
@@ -1,4 +1,5 @@
 using Lidgren.Network;
+using Robust.Shared.Serialization;
 
 #nullable disable
 
@@ -22,13 +23,13 @@ namespace Robust.Shared.Network.Messages
         /// </summary>
         public uint SessionId { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             RequestId = buffer.ReadUInt32();
             SessionId = buffer.ReadUInt32();
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(RequestId);
             buffer.Write(SessionId);

--- a/Robust.Shared/Network/Messages/MsgViewVariablesRemoteData.cs
+++ b/Robust.Shared/Network/Messages/MsgViewVariablesRemoteData.cs
@@ -27,19 +27,17 @@ namespace Robust.Shared.Network.Messages
         /// </summary>
         public ViewVariablesBlob Blob { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             RequestId = buffer.ReadUInt32();
-            var serializer = IoCManager.Resolve<IRobustSerializer>();
             var length = buffer.ReadInt32();
             using var stream = buffer.ReadAlignedMemory(length);
             Blob = serializer.Deserialize<ViewVariablesBlob>(stream);
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(RequestId);
-            var serializer = IoCManager.Resolve<IRobustSerializer>();
 
             var stream = new MemoryStream();
             serializer.Serialize(stream, Blob);

--- a/Robust.Shared/Network/Messages/MsgViewVariablesReqData.cs
+++ b/Robust.Shared/Network/Messages/MsgViewVariablesReqData.cs
@@ -32,21 +32,19 @@ namespace Robust.Shared.Network.Messages
         /// </summary>
         public ViewVariablesRequest RequestMeta { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             RequestId = buffer.ReadUInt32();
             SessionId = buffer.ReadUInt32();
-            var serializer = IoCManager.Resolve<IRobustSerializer>();
             var length = buffer.ReadInt32();
             using var stream = buffer.ReadAlignedMemory(length);
             RequestMeta = serializer.Deserialize<ViewVariablesRequest>(stream);
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(RequestId);
             buffer.Write(SessionId);
-            var serializer = IoCManager.Resolve<IRobustSerializer>();
 
             var stream = new MemoryStream();
             serializer.Serialize(stream, RequestMeta);

--- a/Robust.Shared/Network/Messages/MsgViewVariablesReqSession.cs
+++ b/Robust.Shared/Network/Messages/MsgViewVariablesReqSession.cs
@@ -28,19 +28,17 @@ namespace Robust.Shared.Network.Messages
         /// </summary>
         public ViewVariablesObjectSelector Selector { get; set; }
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             RequestId = buffer.ReadUInt32();
-            var serializer = IoCManager.Resolve<IRobustSerializer>();
             var length = buffer.ReadInt32();
             using var stream = buffer.ReadAlignedMemory(length);
             Selector = serializer.Deserialize<ViewVariablesObjectSelector>(stream);
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(RequestId);
-            var serializer = IoCManager.Resolve<IRobustSerializer>();
 
             var stream = new MemoryStream();
             serializer.Serialize(stream, Selector);

--- a/Robust.Shared/Network/NetManager.ClientConnect.cs
+++ b/Robust.Shared/Network/NetManager.ClientConnect.cs
@@ -143,7 +143,7 @@ namespace Robust.Shared.Network
             };
 
             var outLoginMsg = peer.Peer.CreateMessage();
-            msgLogin.WriteToBuffer(outLoginMsg);
+            msgLogin.WriteToBuffer(outLoginMsg, _serializer);
             peer.Peer.SendMessage(outLoginMsg, connection, NetDeliveryMethod.ReliableOrdered);
 
             NetEncryption? encryption = null;
@@ -154,7 +154,7 @@ namespace Robust.Shared.Network
             {
                 // Need to authenticate, packet is MsgEncryptionRequest
                 var encRequest = new MsgEncryptionRequest();
-                encRequest.ReadFromBuffer(response);
+                encRequest.ReadFromBuffer(response, _serializer);
 
                 var sharedSecret = new byte[SharedKeyLength];
                 RandomNumberGenerator.Fill(sharedSecret);
@@ -205,7 +205,7 @@ namespace Robust.Shared.Network
                 };
 
                 var outEncRespMsg = peer.Peer.CreateMessage();
-                encryptionResponse.WriteToBuffer(outEncRespMsg);
+                encryptionResponse.WriteToBuffer(outEncRespMsg, _serializer);
                 peer.Peer.SendMessage(outEncRespMsg, connection, NetDeliveryMethod.ReliableOrdered);
 
                 // Expect login success here.
@@ -214,7 +214,7 @@ namespace Robust.Shared.Network
             }
 
             var msgSuc = new MsgLoginSuccess();
-            msgSuc.ReadFromBuffer(response);
+            msgSuc.ReadFromBuffer(response, _serializer);
 
             var channel = new NetChannel(this, connection, msgSuc.UserData with { HWId = hwId }, msgSuc.Type);
             _channels.Add(connection, channel);

--- a/Robust.Shared/Network/NetManager.ServerAuth.cs
+++ b/Robust.Shared/Network/NetManager.ServerAuth.cs
@@ -40,7 +40,7 @@ namespace Robust.Shared.Network
                 var incPacket = await AwaitData(connection);
 
                 var msgLogin = new MsgLoginStart();
-                msgLogin.ReadFromBuffer(incPacket);
+                msgLogin.ReadFromBuffer(incPacket, _serializer);
 
                 var ip = connection.RemoteEndPoint.Address;
                 var isLocal = IPAddress.IsLoopback(ip) && _config.GetCVar(CVars.AuthAllowLocal);
@@ -75,13 +75,13 @@ namespace Robust.Shared.Network
                     var outMsgEncReq = peer.Peer.CreateMessage();
                     outMsgEncReq.Write(false);
                     outMsgEncReq.WritePadBits();
-                    msgEncReq.WriteToBuffer(outMsgEncReq);
+                    msgEncReq.WriteToBuffer(outMsgEncReq, _serializer);
                     peer.Peer.SendMessage(outMsgEncReq, connection, NetDeliveryMethod.ReliableOrdered);
 
                     incPacket = await AwaitData(connection);
 
                     var msgEncResponse = new MsgEncryptionResponse();
-                    msgEncResponse.ReadFromBuffer(incPacket);
+                    msgEncResponse.ReadFromBuffer(incPacket, _serializer);
 
                     var encResp = new byte[verifyToken.Length + SharedKeyLength];
                     var ret = CryptoBox.SealOpen(
@@ -219,7 +219,7 @@ namespace Robust.Shared.Network
                     msg.WritePadBits();
                 }
 
-                msgResp.WriteToBuffer(msg);
+                msgResp.WriteToBuffer(msg, _serializer);
                 encryption?.Encrypt(msg);
                 peer.Peer.SendMessage(msg, connection, NetDeliveryMethod.ReliableOrdered);
 

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -882,7 +882,7 @@ namespace Robust.Shared.Network
 
             try
             {
-                instance.ReadFromBuffer(msg);
+                instance.ReadFromBuffer(msg, _serializer);
             }
             catch (InvalidCastException ice)
             {
@@ -967,7 +967,7 @@ namespace Robust.Shared.Network
                     $"[NET] No string in table with name {message.MsgName}. Was it registered?");
 
             packet.Write((byte) msgId);
-            message.WriteToBuffer(packet);
+            message.WriteToBuffer(packet, _serializer);
             return packet;
         }
 

--- a/Robust.Shared/Network/NetMessage.cs
+++ b/Robust.Shared/Network/NetMessage.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using Lidgren.Network;
+using Robust.Shared.Serialization;
 
 #nullable disable
 
@@ -75,13 +76,15 @@ namespace Robust.Shared.Network
         /// Deserializes the NetIncomingMessage into this NetMessage class.
         /// </summary>
         /// <param name="buffer">The buffer of the raw incoming packet.</param>
-        public abstract void ReadFromBuffer(NetIncomingMessage buffer);
+        /// <param name="serializer"></param>
+        public abstract void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer);
 
         /// <summary>
         /// Serializes this NetMessage into a new NetOutgoingMessage.
         /// </summary>
         /// <param name="buffer">The buffer of the new packet being serialized.</param>
-        public abstract void WriteToBuffer(NetOutgoingMessage buffer);
+        /// <param name="serializer"></param>
+        public abstract void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer);
 
         public virtual NetDeliveryMethod DeliveryMethod
         {

--- a/Robust.Shared/Network/StringTable.cs
+++ b/Robust.Shared/Network/StringTable.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Lidgren.Network;
 using Robust.Shared.Log;
+using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.Network
@@ -300,7 +301,7 @@ namespace Robust.Shared.Network
         }
 
         /// <inheritdoc />
-        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             var count = buffer.ReadUInt32();
             Entries = new Entry[count];
@@ -312,7 +313,7 @@ namespace Robust.Shared.Network
         }
 
         /// <inheritdoc />
-        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             if (Entries == null)
                 throw new InvalidOperationException("Entries is null!");


### PR DESCRIPTION
This adds an `IRobustSerializer` argument to  `NetMessage.ReadFromBuffer()` and `WriteToBuffer()`, and removes several IoCManager.Resolve() calls. 

A significant number of content & engine messages require `IRobustSerializer`, notably entity states & system event messages (inc player inputs), which results in at least 2 ioc-resolves per player per update.

Requires space-wizards/space-station-14/pull/11021