### PR TITLE
QueueUpdateIsInert fixes

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
@@ -82,7 +82,7 @@ namespace Robust.Client.GameObjects
 
             SubscribeLocalEvent<SpriteComponent, EntParentChangedMessage>(SpriteParentChanged);
             SubscribeLocalEvent<SpriteComponent, ComponentRemove>(RemoveSprite);
-            SubscribeLocalEvent<SpriteComponent, SpriteUpdateEvent>(HandleSpriteUpdate);
+            SubscribeLocalEvent<SpriteComponent, UpdateSpriteTreeEvent>(HandleSpriteUpdate);
 
             SubscribeLocalEvent<PointLightComponent, EntParentChangedMessage>(LightParentChanged);
             SubscribeLocalEvent<PointLightComponent, PointLightRadiusChangedEvent>(PointLightRadiusChanged);
@@ -107,10 +107,9 @@ namespace Robust.Client.GameObjects
             QueueLightUpdate(component);
         }
 
-        private void HandleSpriteUpdate(EntityUid uid, SpriteComponent component, SpriteUpdateEvent args)
+        private void HandleSpriteUpdate(EntityUid uid, SpriteComponent component, UpdateSpriteTreeEvent args)
         {
-            if (component.TreeUpdateQueued) return;
-            QueueSpriteUpdate(component);
+            _spriteQueue.Add(component);
         }
 
         private void AnythingMoved(ref MoveEvent args)


### PR DESCRIPTION
- Fixes errors introduced in #3217, where adding, removing, and changing visibility of layers didn't trigger a SpriteUpdateInertEvent.
- Splits SpriteUpdateEvent from SpriteUpdateInertEvent
- Renames SpriteUpdateEvent to UpdateSpriteTreeEvent