### PR TITLE
NetSyncEnabled & animation changes

### DIFF
--- a/Robust.Client/Animations/AnimationTrackComponentProperty.cs
+++ b/Robust.Client/Animations/AnimationTrackComponentProperty.cs
@@ -25,6 +25,7 @@ namespace Robust.Client.Animations
 
             if (!entManager.TryGetComponent(entity, ComponentType, out var component))
             {
+                // This gets checked when the animation is first played, but the component may also be removed while the animation plays
                 Logger.Error($"Couldn't find component {ComponentType} on {entManager.ToPrettyString(entity)} for animation playback!");
                 return;
             }

--- a/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
@@ -100,7 +100,7 @@ namespace Robust.Client.GameObjects
                     return;
                 }
 
-                if (component.Owner.IsClientSide() || !component.NetSyncEnabled)
+                if (component.Owner.IsClientSide() || !animatedComp.NetSyncEnabled)
                     continue;
 
                 var reg = _compFact.GetRegistration(animatedComp);

--- a/Robust.Shared/GameObjects/Component.cs
+++ b/Robust.Shared/GameObjects/Component.cs
@@ -23,8 +23,7 @@ namespace Robust.Shared.GameObjects
 
         /// <inheritdoc />
         [DataField("netsync")]
-        public bool NetSyncEnabled { get; } = true;
-        //readonly. If you want to make it writable, you need to add the component to the entity's net-components
+        public bool NetSyncEnabled { get; set;  } = true;
 
         /// <inheritdoc />
         [ViewVariables]

--- a/Robust.Shared/GameObjects/IComponent.cs
+++ b/Robust.Shared/GameObjects/IComponent.cs
@@ -32,7 +32,7 @@ namespace Robust.Shared.GameObjects
         ///     This flag has no effect if <see cref="NetworkedComponentAttribute" /> is not defined on the component.
         ///     This is enabled by default.
         /// </summary>
-        bool NetSyncEnabled { get; }
+        bool NetSyncEnabled { get; set; }
 
         /// <summary>
         ///     Entity that this component is attached to.


### PR DESCRIPTION
Makes NetSyncEnabled no longer readonly. It was accidentally changed to readonly #3000 (was required for an earlier version, but wasn't changed back). Also adds several animation related debug checks, to ensure that a networked component isn't getting animated.