### PR TITLE
Sprite direction bias

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Client.Utility;
+using Robust.Shared;
 using Robust.Shared.Animations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -37,16 +38,9 @@ namespace Robust.Client.GameObjects
         [Dependency] private readonly IEyeManager eyeManager = default!;
 
         /// <summary>
-        ///     This biases diagonally oriented 4-directional sprites to avoid flickering between directions. A positive
-        ///     value biases towards facing N/S, while a negative value will bias towards E/W.
+        ///     See <see cref="CVars.RenderSpriteDirectionBias"/>.
         /// </summary>
-        /// <remarks>
-        ///     The bias needs to be large enough to prevent sprites on rotating grids from flickering, but should be
-        ///     small enough that it is generally unnoticeable. Currently it is somewhat large to combat issues with
-        ///     eye-lerping & grid rotations. 
-        /// </remarks>
-        public const double DirectionBias = 0.05;
-        // TODO make this a cvar?
+        public static double DirectionBias = -0.05;
 
         [DataField("visible")]
         private bool _visible = true;

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Robust.Client.Graphics;
+using Robust.Shared;
+using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
@@ -15,6 +18,7 @@ namespace Robust.Client.GameObjects
     public sealed partial class SpriteSystem : EntitySystem
     {
         [Dependency] private readonly IEyeManager _eyeManager = default!;
+        [Dependency] private readonly IConfigurationManager _cfg = default!;
         [Dependency] private readonly RenderingTreeSystem _treeSystem = default!;
 
         private readonly Queue<SpriteComponent> _inertUpdateQueue = new();
@@ -26,12 +30,19 @@ namespace Robust.Client.GameObjects
 
             _proto.PrototypesReloaded += OnPrototypesReloaded;
             SubscribeLocalEvent<SpriteUpdateInertEvent>(QueueUpdateInert);
+            _cfg.OnValueChanged(CVars.RenderSpriteDirectionBias, OnBiasChanged, true);
         }
 
         public override void Shutdown()
         {
             base.Shutdown();
             _proto.PrototypesReloaded -= OnPrototypesReloaded;
+            _cfg.UnsubValueChanged(CVars.RenderSpriteDirectionBias, OnBiasChanged);
+        }
+
+        private void OnBiasChanged(double value)
+        {
+            SpriteComponent.DirectionBias = value;
         }
 
         private void QueueUpdateInert(SpriteUpdateInertEvent ev)

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -640,6 +640,22 @@ namespace Robust.Shared
             CVarDef.Create("auth.server", AuthManager.DefaultAuthServer, CVar.SERVERONLY);
 
         /*
+         * RENDERING
+         */
+
+        /// <summary>
+        ///     This biases the RSI-direction used to draw diagonally oriented 4-directional sprites to avoid flickering between directions. A positive
+        ///     value biases towards facing N/S, while a negative value will bias towards E/W.
+        /// </summary>
+        /// <remarks>
+        ///     The bias needs to be large enough to prevent sprites on rotating grids from flickering, but should be
+        ///     small enough that it is generally unnoticeable. Currently it is somewhat large to combat issues with
+        ///     eye-lerping & grid rotations. 
+        /// </remarks>
+        public static readonly CVarDef<double> RenderSpriteDirectionBias =
+            CVarDef.Create("render.sprite_direction_bias", -0.05, CVar.ARCHIVE | CVar.CLIENTONLY);
+
+        /*
          * DISPLAY
          */
 


### PR DESCRIPTION
Currently players moving ( & thus rotated) diagonally can have sprites that flicker between RSI directions. For example, the flickering is visible in this [video that was linked on discord](https://www.youtube.com/watch?v=TNbK4WG1nDI&t=90s).

This PR tries to fix that by slightly adjusting the angle -> direction calculation to slightly prefer facing north & south.