### PR TITLE
Don't update appearance while applying states

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
@@ -2,18 +2,25 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.IoC;
-using Robust.Shared.Reflection;
 using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.GameObjects;
 
 public abstract class SharedAppearanceSystem : EntitySystem
 {
+    [Dependency] private readonly IGameTiming _timing = default!;
+
     public virtual void MarkDirty(AppearanceComponent component) {}
 
     public void SetData(EntityUid uid, Enum key, object value, AppearanceComponent? component = null)
     {
+        // If appearance data is changing due to server state application, the server's comp state is getting applied
+        // anyways, so we can skip this.
+        if (_timing.ApplyingState)
+            return; 
+
         if (!Resolve(uid, ref component, false))
             return;
 


### PR DESCRIPTION
Skips appearance component data setting during state application. This also avoids issues where the client will effectively corrupt the received server appearance state if the server & client ever disagree about what the appearance data should be (e.g., see space-wizards/space-station-14/issues/11051)