### PR TITLE
make /tpto use AttachToGridOrMap()

### DIFF
--- a/Robust.Server/Console/Commands/PlayerCommands.cs
+++ b/Robust.Server/Console/Commands/PlayerCommands.cs
@@ -107,6 +107,7 @@ namespace Robust.Server.Console.Commands
                 }
 
                 playerTransform.Coordinates = targetCoords;
+                playerTransform.AttachToGridOrMap();
             }
             else
             {
@@ -119,6 +120,7 @@ namespace Robust.Server.Console.Commands
                         return;
 
                     victimTransform.Coordinates = targetCoords;
+                    victimTransform.AttachToGridOrMap();
                 }
             }
         }


### PR DESCRIPTION
Avoids issues when the target location is in some container or parented to something else.