### PR TITLE
Fix OnParentChange bug

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPhysicsSystem.cs
@@ -134,13 +134,15 @@ namespace Robust.Shared.GameObjects
         {
             // We do not have a directed/body subscription, because the entity changing parents may not have a physics component, but one of its children might.
             var uid = args.Entity;
-
-            var meta = MetaData(uid);
-
-            if (meta.EntityLifeStage < EntityLifeStage.Initialized)
-                return;
-
             var xform = args.Transform;
+
+            // If this entity has yet to be initialized, then we can skip this as equivalent code will get run during
+            // init anyways. HOWEVER: it is possible that one of the children of this entity are already post-init, in
+            // which case they still need to handle map changes. This frequently happens when clients receives a server
+            // state where a known/old entity gets attached to a new, previously unknown, entity. The new entity will be
+            // uninitialized but have an initialized child.
+            if (xform.ChildCount == 0 && LifeStage(uid) < EntityLifeStage.Initialized)
+                return;
 
             // Is this entity getting recursively detached after it's parent was already detached to null?
             if (args.OldMapId == MapId.Nullspace && xform.MapID == MapId.Nullspace)


### PR DESCRIPTION
AFAIK the `(meta.EntityLifeStage < EntityLifeStage.Initialized` check is only there for the sake of performance. If it actually needs to be there for some other reason this might need to be fixed some other way.