### PR TITLE
Drop SQLitePCL dependency

### DIFF
--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" PrivateAssets="All" />
     <PackageReference Include="SpaceWizards.HttpListener" Version="0.1.0" />
     <!--  -->
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.7" />
     <PackageReference Include="prometheus-net" Version="4.1.1" />
     <PackageReference Include="Serilog.Sinks.Loki" Version="4.0.0-beta3" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />


### PR DESCRIPTION
Nothing in Robust.Server actually uses Sqlite, so drop this unused dependency. Any RobustToolbox users will need to add this back if they actually use Sqlite.