### PR TITLE
Fix non-map or grid coordinate returns for most cases

### DIFF
--- a/Robust.Shared/Map/CoordinatesExtensions.cs
+++ b/Robust.Shared/Map/CoordinatesExtensions.cs
@@ -28,20 +28,23 @@ namespace Robust.Shared.Map
             return new EntityCoordinates(grid.GridEntityId, (vector.X * tile, vector.Y * tile));
         }
 
-        public static EntityCoordinates AlignWithClosestGridTile(this EntityCoordinates coordinates, float searchBoxSize = 1.5f, IEntityManager? entityManager = null, IMapManager? mapManager = null)
+        public static EntityCoordinates AlignWithClosestGridTile(this EntityCoordinates coords, float searchBoxSize = 1.5f, IEntityManager? entityManager = null, IMapManager? mapManager = null)
         {
-            var coords = coordinates;
             IoCManager.Resolve(ref entityManager, ref mapManager);
 
             var gridId = coords.GetGridUid(entityManager);
 
-            if (!mapManager.GridExists(gridId))
+            if (mapManager.TryGetGrid(gridId, out var mapGrid))
+            {
+                return mapGrid.GridTileToLocal(mapGrid.CoordinatesToTile(coords));
+            }
+            else
             {
                 var mapCoords = coords.ToMap(entityManager);
 
-                if (mapManager.TryFindGridAt(mapCoords, out var mapGrid))
+                if (mapManager.TryFindGridAt(mapCoords, out mapGrid))
                 {
-                    return new EntityCoordinates(mapGrid.GridEntityId, mapGrid.WorldToLocal(mapCoords.Position));
+                    return mapGrid.GridTileToLocal(mapGrid.CoordinatesToTile(coords));
                 }
 
                 // create a box around the cursor


### PR DESCRIPTION
This fixes rods placing new grids when on a grid. This was because the function returned the unmodified coordinates if it had a valid grid uid.

Needs a bit of testing since this changed the functionality of the method.