### PR TITLE
RemoveComponentDeferred changes

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -475,20 +475,12 @@ namespace Robust.Shared.GameObjects
 
             if (component.Running)
                 component.LifeShutdown(this);
-
-            if (component.LifeStage != ComponentLifeStage.PreAdd)
-                component.LifeRemoveFromEntity(this);
-
-            var eventArgs = new RemovedComponentEventArgs(new ComponentEventArgs(component, uid));
-            ComponentRemoved?.Invoke(eventArgs);
-            _eventBus.OnComponentRemoved(eventArgs);
-
 #if EXCEPTION_TOLERANCE
             }
             catch (Exception e)
             {
                 _runtimeLog.LogException(e,
-                    $"RemoveComponentDeferred, owner={component.Owner}, type={component.GetType()}");
+                    $"RemoveComponentDeferred, owner={ToPrettyString(component.Owner)}, type={component.GetType()}");
             }
 #endif
         }
@@ -529,7 +521,7 @@ namespace Robust.Shared.GameObjects
             catch (Exception e)
             {
                 _runtimeLog.LogException(e,
-                    $"RemoveComponentImmediate, owner={component.Owner}, type={component.GetType()}");
+                    $"RemoveComponentImmediate, owner={ToPrettyString(component.Owner)}, type={component.GetType()}");
             }
 #endif
 
@@ -541,6 +533,37 @@ namespace Robust.Shared.GameObjects
         {
             foreach (var component in InSafeOrder(_deleteSet))
             {
+                if (component.Deleted)
+                    continue;
+
+#if EXCEPTION_TOLERANCE
+            try
+            {
+#endif
+                // The component may have been restarted sometime after removal was deferred.
+                if (component.Running)
+                {
+                    // TODO add options to cancel deferred deletion?
+                    Logger.Warning($"Found a running component while culling deferred deletions, owner={ToPrettyString(component.Owner)}, type={component.GetType()}");
+                    component.LifeShutdown(this);
+                }
+
+                if (component.LifeStage != ComponentLifeStage.PreAdd)
+                    component.LifeRemoveFromEntity(this);
+
+                var eventArgs = new RemovedComponentEventArgs(new ComponentEventArgs(component, component.Owner));
+                ComponentRemoved?.Invoke(eventArgs);
+                _eventBus.OnComponentRemoved(eventArgs);
+
+#if EXCEPTION_TOLERANCE
+            }
+            catch (Exception e)
+            {
+                _runtimeLog.LogException(e,
+                    $"CullRemovedComponents, owner={ToPrettyString(component.Owner)}, type={component.GetType()}");
+            }
+#endif
+
                 DeleteComponent(component);
             }
 

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -99,7 +99,7 @@ namespace Robust.Shared.GameObjects
         void RemoveComponent(EntityUid uid, IComponent component);
 
         /// <summary>
-        ///     Removes the specified component at a later time.
+        ///     Immediately shuts down a component, but defers the removal and deletion until the end of the tick.
         ///     Without needing to have the component itself.
         /// </summary>
         /// <typeparam name="T">The component reference type to remove.</typeparam>
@@ -107,7 +107,7 @@ namespace Robust.Shared.GameObjects
         bool RemoveComponentDeferred<T>(EntityUid uid);
 
         /// <summary>
-        ///     Removes the specified component with a specified type at a later time.
+        ///     Immediately shuts down a component, but defers the removal and deletion until the end of the tick.
         /// </summary>
         /// <param name="uid">Entity UID to modify.</param>
         /// <param name="type">A trait or component type to check for.</param>
@@ -115,7 +115,7 @@ namespace Robust.Shared.GameObjects
         bool RemoveComponentDeferred(EntityUid uid, Type type);
 
         /// <summary>
-        ///     Removes the component with a specified network ID at a later time.
+        ///     Immediately shuts down a component, but defers the removal and deletion until the end of the tick.
         /// </summary>
         /// <param name="uid">Entity UID to modify.</param>
         /// <param name="netID">Network ID of the component to remove.</param>
@@ -123,7 +123,7 @@ namespace Robust.Shared.GameObjects
         bool RemoveComponentDeferred(EntityUid uid, ushort netID);
 
         /// <summary>
-        ///     Removes the specified component at a later time.
+        ///     Immediately shuts down a component, but defers the removal and deletion until the end of the tick.
         ///     Throws if the given component does not belong to the entity.
         /// </summary>
         /// <param name="uid">Entity UID to modify.</param>
@@ -131,7 +131,7 @@ namespace Robust.Shared.GameObjects
         void RemoveComponentDeferred(EntityUid uid, IComponent component);
 
         /// <summary>
-        ///     Removes the specified component at a later time.
+        ///     Immediately shuts down a component, but defers the removal and deletion until the end of the tick.
         ///     Throws if the given component does not belong to the entity.
         /// </summary>
         /// <param name="uid">Entity UID to modify.</param>

--- a/Robust.UnitTesting/RobustIntegrationTest.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.cs
@@ -611,7 +611,10 @@ namespace Robust.UnitTesting
                     LoadContentResources = false,
                 };
 
-                // Autoregister components if options are null or we're NOT starting from content.
+                // Autoregister components if options are null or we're NOT starting from content, as in that case
+                // components will get auto-registered later. But either way, we will still invoke
+                // BeforeRegisterComponents here.
+                Options?.BeforeRegisterComponents?.Invoke();
                 if (!Options?.ContentStart ?? true)
                 {
                     var componentFactory = IoCManager.Resolve<IComponentFactory>();
@@ -767,7 +770,10 @@ namespace Robust.UnitTesting
                     LoadConfigAndUserData = false,
                 };
 
-                // Autoregister components if options are null or we're NOT starting from content.
+                // Autoregister components if options are null or we're NOT starting from content, as in that case
+                // components will get auto-registered later. But either way, we will still invoke
+                // BeforeRegisterComponents here.
+                Options?.BeforeRegisterComponents?.Invoke();
                 if (!Options?.ContentStart ?? true)
                 {
                     var componentFactory = IoCManager.Resolve<IComponentFactory>();
@@ -950,6 +956,7 @@ namespace Robust.UnitTesting
         public abstract class IntegrationOptions
         {
             public Action? InitIoC { get; set; }
+            public Action? BeforeRegisterComponents { get; set; }
             public Action? BeforeStart { get; set; }
             public Assembly[]? ContentAssemblies { get; set; }
             public string? ExtraPrototypes { get; set; }

--- a/Robust.UnitTesting/Shared/GameObjects/DeferredEntityDeletionTest.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/DeferredEntityDeletionTest.cs
@@ -1,0 +1,132 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Utility;
+
+namespace Robust.UnitTesting.Shared.GameObjects;
+
+public sealed partial class DeferredEntityDeletionTest : RobustIntegrationTest
+{
+    // This test ensures that deferred deletion can be used while handling events without issue, and that deleting an
+    // entity after deferring component removal doesn't cause any issues.
+
+    [Test]
+    public async Task TestDeferredEntityDeletion()
+    {
+        var options = new ServerIntegrationOptions();
+        options.Pool = false;
+        options.BeforeRegisterComponents += () =>
+        {
+            var fact = IoCManager.Resolve<IComponentFactory>();
+            fact.RegisterClass<DeferredDeletionTestComponent>();
+            fact.RegisterClass<OtherDeferredDeletionTestComponent>();
+        };
+        options.BeforeStart += () =>
+        {
+            var sysMan = IoCManager.Resolve<IEntitySystemManager>();
+            sysMan.LoadExtraSystemType<DeferredDeletionTestSystem>();
+            sysMan.LoadExtraSystemType<OtherDeferredDeletionTestSystem>();
+        };
+
+        var server = StartServer(options);
+        await server.WaitIdleAsync();
+
+        EntityUid uid1 = default, uid2 = default, uid3 = default;
+        DeferredDeletionTestComponent comp1 = default!, comp2 = default!, comp3 = default!;
+        IEntityManager entMan = default!;
+        
+        await server.WaitAssertion(() =>
+        {
+            var mapMan = IoCManager.Resolve<IMapManager>();
+            entMan = IoCManager.Resolve<IEntityManager>();
+            var sys = entMan.EntitySysManager.GetEntitySystem<DeferredDeletionTestSystem>();
+
+            uid1 = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            uid2 = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            uid3 = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+
+            comp1 = entMan.AddComponent<DeferredDeletionTestComponent>(uid1);
+            comp2 = entMan.AddComponent<DeferredDeletionTestComponent>(uid2);
+            comp3 =entMan.AddComponent<DeferredDeletionTestComponent>(uid3);
+
+            entMan.AddComponent<OtherDeferredDeletionTestComponent>(uid1);
+            entMan.AddComponent<OtherDeferredDeletionTestComponent>(uid2);
+            entMan.AddComponent<OtherDeferredDeletionTestComponent>(uid3);
+        });
+
+        await server.WaitRunTicks(1);
+
+        // first: test that deferring deletion while handling events doesn't cause issues
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(comp1.Running);
+            var ev = new DeferredDeletionTestEvent();
+            entMan.EventBus.RaiseLocalEvent(uid1, ev);
+            Assert.That(comp1.LifeStage == ComponentLifeStage.Stopped);
+        });
+
+        await server.WaitRunTicks(1);
+        Assert.That(comp1.LifeStage == ComponentLifeStage.Deleted);
+
+        // next check that entity deletion doesn't cause issues:
+        await server.WaitAssertion(() =>
+        {
+            var ev = new DeferredDeletionTestEvent();
+            entMan.EventBus.RaiseLocalEvent(uid2, ev);
+            entMan.EventBus.RaiseLocalEvent(uid3, ev);
+            entMan.DeleteEntity(uid2);
+            entMan.QueueDeleteEntity(uid3);
+            Assert.That(entMan.Deleted(uid2));
+            Assert.That(!entMan.Deleted(uid3));
+            Assert.That(comp2.LifeStage == ComponentLifeStage.Deleted);
+            Assert.That(comp3.LifeStage == ComponentLifeStage.Stopped);
+        });
+        
+        await server.WaitRunTicks(1);
+        Assert.That(comp3.LifeStage == ComponentLifeStage.Deleted);
+        Assert.That(entMan.Deleted(uid3));
+        await server.WaitIdleAsync();
+    }
+
+    private sealed class DeferredDeletionTestSystem : EntitySystem
+    {
+        public override void Initialize()
+        {
+            SubscribeLocalEvent<DeferredDeletionTestComponent, DeferredDeletionTestEvent>(OnTestEvent);
+        }
+
+        private void OnTestEvent(EntityUid uid, DeferredDeletionTestComponent component, DeferredDeletionTestEvent args)
+        {
+            // remove both this component, and some other component that this entity has that also subscribes to this event.
+            RemCompDeferred<DeferredDeletionTestComponent>(uid);
+            RemCompDeferred<OtherDeferredDeletionTestComponent>(uid);
+        }
+    }
+
+    private sealed class OtherDeferredDeletionTestSystem : EntitySystem
+    {
+        public override void Initialize() => SubscribeLocalEvent<OtherDeferredDeletionTestComponent, DeferredDeletionTestEvent>(OnTestEvent);
+
+        private void OnTestEvent(EntityUid uid, OtherDeferredDeletionTestComponent component, DeferredDeletionTestEvent args)
+        {
+            // remove both this component, and some other component that this entity has that also subscribes to this event.
+            RemCompDeferred<DeferredDeletionTestComponent>(uid);
+            RemCompDeferred<OtherDeferredDeletionTestComponent>(uid);
+        }
+    }
+
+    [RegisterComponent]
+    private sealed class DeferredDeletionTestComponent : Component
+    {
+    }
+
+    private sealed class OtherDeferredDeletionTestComponent : Component
+    {
+    }
+
+    private sealed class DeferredDeletionTestEvent
+    {
+    }
+}


### PR DESCRIPTION
Currently `RemoveComponentDeferred()` doesn't actually defer component removal, it just defers a part of the component deletion. This PR changes this so that the removal is deferred. AFAIK nothing in content/ss14 depends on the existing behaviour working like it does, and it currently causes issues (e.g., this will fix #3243).

This PR also adds a test for using deferred removal in event subscriptions, which errors on current master. In order to use `ServerIntegrationInstance`, this also slightly tweaks that so that engine tests can load extra component classes. But I'm still not familiar with tests, so maybe there is a much better way of doing this. Or should I just be using `RobustServerSimulation`? @wrexbe  