### PR TITLE
Make RaisePredictiveEvent check IsPredictionEnabled

### DIFF
--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -71,7 +71,7 @@ namespace Robust.Client.GameObjects
                 return base.ToPrettyString(uid);
         }
 
-        public void RaisePredictiveEvent<T>(T msg) where T : EntityEventArgs
+        public override void RaisePredictiveEvent<T>(T msg)
         {
             var localPlayer = _playerManager.LocalPlayer;
             DebugTools.AssertNotNull(localPlayer);

--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -82,6 +82,8 @@ namespace Robust.Client.GameObjects
             if (!_stateMan.IsPredictionEnabled)
                 return;
 
+            DebugTools.Assert(_gameTiming.InPrediction && _gameTiming.IsFirstTimePredicted);
+
             var eventArgs = new EntitySessionEventArgs(localPlayer!.Session);
             EventBus.RaiseEvent(EventSource.Local, msg);
             EventBus.RaiseEvent(EventSource.Local, new EntitySessionMessage<T>(eventArgs, msg));

--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Prometheus;
+using Robust.Client.GameStates;
 using Robust.Client.Player;
 using Robust.Client.Timing;
 using Robust.Shared.GameObjects;
@@ -19,6 +20,7 @@ namespace Robust.Client.GameObjects
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly IClientNetManager _networkManager = default!;
         [Dependency] private readonly IClientGameTiming _gameTiming = default!;
+        [Dependency] private readonly IClientGameStateManager _stateMan = default!;
 
         protected override int NextEntityUid { get; set; } = EntityUid.ClientUid + 1;
 
@@ -67,6 +69,22 @@ namespace Robust.Client.GameObjects
                 return base.ToPrettyString(uid) with { Session = _playerManager.LocalPlayer.Session };
             else
                 return base.ToPrettyString(uid);
+        }
+
+        public void RaisePredictiveEvent<T>(T msg) where T : EntityEventArgs
+        {
+            var localPlayer = _playerManager.LocalPlayer;
+            DebugTools.AssertNotNull(localPlayer);
+
+            var sequence = _stateMan.SystemMessageDispatched(msg);
+            EntityNetManager?.SendSystemNetworkMessage(msg, sequence);
+
+            if (!_stateMan.IsPredictionEnabled)
+                return;
+
+            var eventArgs = new EntitySessionEventArgs(localPlayer!.Session);
+            EventBus.RaiseEvent(EventSource.Local, msg);
+            EventBus.RaiseEvent(EventSource.Local, new EntitySessionMessage<T>(eventArgs, msg));
         }
 
         #region IEntityNetworkManager impl

--- a/Robust.Client/GameObjects/EntityManagerExt.cs
+++ b/Robust.Client/GameObjects/EntityManagerExt.cs
@@ -1,8 +1,4 @@
-using Robust.Client.GameStates;
-using Robust.Client.Player;
 using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Utility;
 
 namespace Robust.Client.GameObjects
 {
@@ -11,16 +7,7 @@ namespace Robust.Client.GameObjects
         public static void RaisePredictiveEvent<T>(this IEntityManager entityManager, T msg)
             where T : EntityEventArgs
         {
-            var localPlayer = IoCManager.Resolve<IPlayerManager>().LocalPlayer;
-            DebugTools.AssertNotNull(localPlayer);
-
-            var sequence = IoCManager.Resolve<IClientGameStateManager>().SystemMessageDispatched(msg);
-            entityManager.EntityNetManager?.SendSystemNetworkMessage(msg, sequence);
-
-            var eventArgs = new EntitySessionEventArgs(localPlayer!.Session);
-
-            entityManager.EventBus.RaiseEvent(EventSource.Local, msg);
-            entityManager.EventBus.RaiseEvent(EventSource.Local, new EntitySessionMessage<T>(eventArgs, msg));
+            ((IClientEntityManager)entityManager).RaisePredictiveEvent(msg);
         }
     }
 }

--- a/Robust.Client/GameObjects/IClientEntityManager.cs
+++ b/Robust.Client/GameObjects/IClientEntityManager.cs
@@ -4,9 +4,5 @@ namespace Robust.Client.GameObjects
 {
     public interface IClientEntityManager : IEntityManager, IEntityNetworkManager
     {
-        /// <summary>
-        ///     Sends a networked message to the server, while also repeatedly raising it locally for every time this tick gets re-predicted.
-        /// </summary>
-        void RaisePredictiveEvent<T>(T msg) where T : EntityEventArgs;
     }
 }

--- a/Robust.Client/GameObjects/IClientEntityManager.cs
+++ b/Robust.Client/GameObjects/IClientEntityManager.cs
@@ -4,6 +4,9 @@ namespace Robust.Client.GameObjects
 {
     public interface IClientEntityManager : IEntityManager, IEntityNetworkManager
     {
-
+        /// <summary>
+        ///     Sends a networked message to the server, while also repeatedly raising it locally for every time this tick gets re-predicted.
+        /// </summary>
+        void RaisePredictiveEvent<T>(T msg) where T : EntityEventArgs;
     }
 }

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -563,9 +563,16 @@ namespace Robust.Shared.GameObjects
             return new EntityStringRepresentation(uid, metadata.EntityDeleted, metadata.EntityName, metadata.EntityPrototype?.ID);
         }
 
-#endregion Entity Management
+        #endregion Entity Management
 
-/// <summary>
+        public virtual void RaisePredictiveEvent<T>(T msg) where T : EntityEventArgs
+        {
+            // Part of shared the EntityManager so that systems can have convenient proxy methods, but the
+            // server should never be calling this.
+            DebugTools.Assert("Why are you raising predictive events on the server?");
+        }
+
+        /// <summary>
         ///     Factory for generating a new EntityUid for an entity currently being created.
         /// </summary>
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -678,4 +678,17 @@ public partial class EntitySystem
     }
 
     #endregion
+
+    #region Networked Events
+
+    /// <summary>
+    ///     Sends a networked message to the server, while also repeatedly raising it locally for every time this tick gets re-predicted.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected void RaisePredictiveEvent<T>(T msg) where T : EntityEventArgs
+    {
+        EntityManager.RaisePredictiveEvent(msg);
+    }
+
+    #endregion
 }

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -128,5 +128,10 @@ namespace Robust.Shared.GameObjects
         EntityStringRepresentation ToPrettyString(EntityUid uid);
 
         #endregion Entity Management
+
+        /// <summary>
+        ///     Sends a networked message to the server, while also repeatedly raising it locally for every time this tick gets re-predicted.
+        /// </summary>
+        void RaisePredictiveEvent<T>(T msg) where T : EntityEventArgs;
     }
 }


### PR DESCRIPTION
Makes `RaisePredictiveEvent()` check if prediction is enabled before raising the event locally.

Now also fixes #3254