### PR TITLE
Allow appearance to ignore PVS state

### DIFF
--- a/Robust.Client/GameObjects/Components/Appearance/ClientAppearanceComponent.cs
+++ b/Robust.Client/GameObjects/Components/Appearance/ClientAppearanceComponent.cs
@@ -16,4 +16,15 @@ public sealed class ClientAppearanceComponent : AppearanceComponent
     [ViewVariables]
     [DataField("visuals")]
     internal List<AppearanceVisualizer> Visualizers = new();
+
+    /// <summary>
+    ///     If true, then this entity's visuals will get updated in the next frame update regardless of whether or not
+    ///     this entity is currently inside of PVS range.
+    /// </summary>
+    /// <remarks>
+    ///     This defaults to true, because it is possible for an entity to both be initialized and detached to null
+    ///     during the same tick. This can happen because entity states & pvs-departure messages are sent & handled
+    ///     separately. However, we want to ensure that each entity has an initial appearance update.
+    /// </remarks>
+    internal bool UpdateDetached = true;
 }

--- a/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
@@ -79,18 +79,15 @@ namespace Robust.Client.GameObjects
             return newDict;
         }
 
-        public override void MarkDirty(AppearanceComponent component)
+        public override void MarkDirty(AppearanceComponent component, bool updateDetached = false)
         {
             if (component.AppearanceDirty)
                 return;
 
-            _queuedUpdates.Enqueue((ClientAppearanceComponent) component);
+            var clientComp = (ClientAppearanceComponent)component;
+            _queuedUpdates.Enqueue(clientComp);
             component.AppearanceDirty = true;
-        }
-
-        internal void UnmarkDirty(ClientAppearanceComponent component)
-        {
-            component.AppearanceDirty = false;
+            clientComp.UpdateDetached |= updateDetached;
         }
 
         public override void FrameUpdate(float frameTime)
@@ -102,11 +99,13 @@ namespace Robust.Client.GameObjects
                 if (appearance.Deleted)
                     continue;
 
-                UnmarkDirty(appearance);
+                appearance.AppearanceDirty = false;
 
                 // If the entity is no longer within the clients PVS, don't bother updating.
-                if ((metaQuery.GetComponent(appearance.Owner).Flags & MetaDataFlags.Detached) != 0)
+                if ((metaQuery.GetComponent(appearance.Owner).Flags & MetaDataFlags.Detached) != 0 && !appearance.UpdateDetached)
                     continue;
+
+                appearance.UpdateDetached = false;
 
                 // Sprite comp is allowed to be null, so that things like spriteless point-lights can use this system
                 spriteQuery.TryGetComponent(appearance.Owner, out var sprite);

--- a/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
@@ -81,13 +81,14 @@ namespace Robust.Client.GameObjects
 
         public override void MarkDirty(AppearanceComponent component, bool updateDetached = false)
         {
+            var clientComp = (ClientAppearanceComponent)component;
+            clientComp.UpdateDetached |= updateDetached;
+
             if (component.AppearanceDirty)
                 return;
 
-            var clientComp = (ClientAppearanceComponent)component;
             _queuedUpdates.Enqueue(clientComp);
             component.AppearanceDirty = true;
-            clientComp.UpdateDetached |= updateDetached;
         }
 
         public override void FrameUpdate(float frameTime)

--- a/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
@@ -12,7 +12,12 @@ public abstract class SharedAppearanceSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
 
-    public virtual void MarkDirty(AppearanceComponent component) {}
+    /// <summary>
+    ///     Mark an appearance component as dirty, so that the appearance will get updated in the next frame update.
+    /// </summary>
+    /// <param name="component"></param>
+    /// <param name="updateDetached">If true, the appearance will update even if the entity is currently outside of PVS range.</param>
+    public virtual void MarkDirty(AppearanceComponent component, bool updateDetached = false) {}
 
     public void SetData(EntityUid uid, Enum key, object value, AppearanceComponent? component = null)
     {


### PR DESCRIPTION
Currently the appearance system will not update the appearance of entities outside of PVS range. This avoids updating things like pipes & wires that get unanchored as they get detached.

However in some edge cases this can cause issues, so this adds a bool to the appearance component that will force an update regardless of the current pvs status.