### PR TITLE
Don't sleep initialised items

### DIFF
--- a/Robust.Shared/GameObjects/Systems/CollisionWakeSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/CollisionWakeSystem.cs
@@ -77,11 +77,6 @@ namespace Robust.Shared.GameObjects
             UpdateCanCollide(uid, component, xform: args.Transform);
         }
 
-        internal void OnPhysicsInit(EntityUid uid, CollisionWakeComponent component)
-        {
-            UpdateCanCollide(uid, component, checkTerminating: false, dirty: false);
-        }
-
         private void OnJointRemove(EntityUid uid, CollisionWakeComponent component, JointRemovedEvent args)
         {
             UpdateCanCollide(uid, component, (PhysicsComponent) args.OurBody);

--- a/Robust.Shared/GameObjects/Systems/CollisionWakeSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/CollisionWakeSystem.cs
@@ -71,6 +71,9 @@ namespace Robust.Shared.GameObjects
 
         private void OnParentChange(EntityUid uid, CollisionWakeComponent component, ref EntParentChangedMessage args)
         {
+            if (component.LifeStage < ComponentLifeStage.Initialized)
+                return;
+
             UpdateCanCollide(uid, component, xform: args.Transform);
         }
 

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
@@ -14,7 +14,6 @@ namespace Robust.Shared.Physics.Systems;
 
 public partial class SharedPhysicsSystem
 {
-    [Dependency] private readonly CollisionWakeSystem _collisionWakeSystem = default!;
     [Dependency] private readonly FixtureSystem _fixtureSystem = default!;
     [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
 
@@ -29,12 +28,7 @@ public partial class SharedPhysicsSystem
 
         if (component._canCollide && xform.MapID != MapId.Nullspace)
         {
-            var physicsMap = EntityManager.GetComponent<SharedPhysicsMapComponent>(MapManager.GetMapEntityId(xform.MapID));
-
-            if (component.BodyType != BodyType.Static &&
-                (physicsMap.Gravity != Vector2.Zero ||
-                 !component.LinearVelocity.Equals(Vector2.Zero) ||
-                 !component.AngularVelocity.Equals(0f)))
+            if (component.BodyType != BodyType.Static)
             {
                 component.Awake = true;
             }
@@ -53,10 +47,6 @@ public partial class SharedPhysicsSystem
 
     private void OnPhysicsInitialized(EntityUid uid)
     {
-        if (EntityManager.TryGetComponent(uid, out CollisionWakeComponent? wakeComp))
-        {
-            _collisionWakeSystem.OnPhysicsInit(uid, wakeComp);
-        }
         _fixtureSystem.OnPhysicsInit(uid);
     }
 


### PR DESCRIPTION
It means some stuff spawns stuff into walls on content. As nice as it is to avoid waking these bodies it's kinda necessary.