### PR TITLE
Prevent PVS error spam and add more debugging asserts

### DIFF
--- a/Robust.Server/GameStates/PVSCollection.cs
+++ b/Robust.Server/GameStates/PVSCollection.cs
@@ -18,10 +18,17 @@ public interface IPVSCollection
     /// Processes all previous additions, removals and updates of indices.
     /// </summary>
     public void Process();
+
+    /// <summary>
+    ///     Adds a player session to the collection. Returns false if the player was already present.
+    /// </summary>
     public bool AddPlayer(ICommonSession session);
     public void AddGrid(GridId gridId);
     public void AddMap(MapId mapId);
 
+    /// <summary>
+    ///     Removes a player session from the collection. Returns false if the player was not present in the collection.
+    /// </summary>
     public bool RemovePlayer(ICommonSession session);
 
     public void RemoveGrid(GridId gridId);

--- a/Robust.Server/GameStates/PVSCollection.cs
+++ b/Robust.Server/GameStates/PVSCollection.cs
@@ -18,11 +18,11 @@ public interface IPVSCollection
     /// Processes all previous additions, removals and updates of indices.
     /// </summary>
     public void Process();
-    public void AddPlayer(ICommonSession session);
+    public bool AddPlayer(ICommonSession session);
     public void AddGrid(GridId gridId);
     public void AddMap(MapId mapId);
 
-    public void RemovePlayer(ICommonSession session);
+    public bool RemovePlayer(ICommonSession session);
 
     public void RemoveGrid(GridId gridId);
 
@@ -249,10 +249,9 @@ public sealed class PVSCollection<TIndex> : IPVSCollection where TIndex : ICompa
     #region Init Functions
 
     /// <inheritdoc />
-    public void AddPlayer(ICommonSession session)
+    public bool AddPlayer(ICommonSession session)
     {
-        _localOverrides[session] = new();
-        _lastSeen[session] = new();
+        return _localOverrides.TryAdd(session, new()) & _lastSeen.TryAdd(session, new());
     }
 
     /// <inheritdoc />
@@ -266,14 +265,17 @@ public sealed class PVSCollection<TIndex> : IPVSCollection where TIndex : ICompa
     #region ShutdownFunctions
 
     /// <inheritdoc />
-    public void RemovePlayer(ICommonSession session)
+    public bool RemovePlayer(ICommonSession session)
     {
-        foreach (var index in _localOverrides[session])
+        if (_localOverrides.Remove(session, out var indices))
         {
-            _indexLocations.Remove(index);
+            foreach (var index in indices)
+            {
+                _indexLocations.Remove(index);
+            }
         }
-        _localOverrides.Remove(session);
-        _lastSeen.Remove(session);
+
+        return _lastSeen.Remove(session) && indices != null;
     }
 
     /// <inheritdoc />

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -364,10 +364,13 @@ internal sealed partial class PVSSystem : EntitySystem
     {
         if (e.NewStatus == SessionStatus.InGame)
         {
-            _playerVisibleSets.Add(e.Session, new());
+            if (!_playerVisibleSets.TryAdd(e.Session, new()))
+                _sawmill.Error($"Attempted to add player to _playerVisibleSets, but they were already present? Session:{e.Session}");
+
             foreach (var pvsCollection in _pvsCollections)
             {
-                pvsCollection.AddPlayer(e.Session);
+                if (!pvsCollection.AddPlayer(e.Session))
+                    _sawmill.Error($"Attempted to add player to pvsCollection, but they were already present? Session:{e.Session}");
             }
             return;
         }
@@ -377,7 +380,8 @@ internal sealed partial class PVSSystem : EntitySystem
 
         foreach (var pvsCollection in _pvsCollections)
         {
-            pvsCollection.RemovePlayer(e.Session);
+            if (!pvsCollection.RemovePlayer(e.Session))
+                _sawmill.Error($"Attempted to remove player from pvsCollection, but they were already removed? Session:{e.Session}");
         }
 
         if (!_playerVisibleSets.Remove(e.Session, out var data))

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -361,7 +361,8 @@ namespace Robust.Shared.GameObjects
                 RecursiveDeleteEntity(metaQuery.GetComponent(child), metaQuery, xformQuery, xformSys);
             }
 
-            DebugTools.Assert(transform._children.Count == 0, $"Failed to delete all children of entity: {ToPrettyString(metadata.Owner)}");
+            if (transform._children.Count != 0)
+                Logger.Error($"Failed to delete all children of entity: {ToPrettyString(metadata.Owner)}"));
 
             // Shut down all components.
             foreach (var component in InSafeOrder(_entCompIndex[metadata.Owner]))

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -349,7 +349,6 @@ namespace Robust.Shared.GameObjects
 
         private void RecursiveDeleteEntity(MetaDataComponent metadata, EntityQuery<MetaDataComponent> metaQuery, EntityQuery<TransformComponent> xformQuery, SharedTransformSystem xformSys)
         {
-
             var transform = xformQuery.GetComponent(metadata.Owner);
 
             // Detach the base entity to null before iterating over children

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -349,6 +349,7 @@ namespace Robust.Shared.GameObjects
 
         private void RecursiveDeleteEntity(MetaDataComponent metadata, EntityQuery<MetaDataComponent> metaQuery, EntityQuery<TransformComponent> xformQuery, SharedTransformSystem xformSys)
         {
+
             var transform = xformQuery.GetComponent(metadata.Owner);
 
             // Detach the base entity to null before iterating over children
@@ -362,7 +363,7 @@ namespace Robust.Shared.GameObjects
             }
 
             if (transform._children.Count != 0)
-                Logger.Error($"Failed to delete all children of entity: {ToPrettyString(metadata.Owner)}"));
+                Logger.Error($"Failed to delete all children of entity: {ToPrettyString(metadata.Owner)}");
 
             // Shut down all components.
             foreach (var component in InSafeOrder(_entCompIndex[metadata.Owner]))

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -35,6 +35,21 @@ namespace Robust.Shared.GameObjects
             SubscribeLocalEvent<TransformComponent, ComponentStartup>(OnCompStartup);
             SubscribeLocalEvent<TransformComponent, ComponentGetState>(OnGetState);
             SubscribeLocalEvent<TransformComponent, ComponentHandleState>(OnHandleState);
+            SubscribeLocalEvent<EntParentChangedMessage>(OnParentChange);
+        }
+
+        private void OnParentChange(ref EntParentChangedMessage ev)
+        {
+            // TODO: when PVS errors on live servers get fixed, wrap this whole subscription in an #if DEBUG block to speed up parent changes & entity deletion.
+            if (ev.Transform.ParentUid == EntityUid.Invalid)
+                return;
+
+            if (LifeStage(ev.Entity) >= EntityLifeStage.Terminating)
+                _logger.Error($"Entity {ToPrettyString(ev.Entity)} is getting attached to a new parent while terminating. New parent: {ToPrettyString(ev.Transform.ParentUid)}");
+
+
+            if (LifeStage(ev.Transform.ParentUid) >= EntityLifeStage.Terminating)
+                _logger.Error($"Entity {ToPrettyString(ev.Entity)} is attaching itself to a terminating entity {ToPrettyString(ev.Transform.ParentUid)}.");
         }
 
         private void MapManagerOnTileChanged(TileChangedEvent e)


### PR DESCRIPTION
Currently an error while handling player disconnects will result in pvs spamming errors while generating mail. This PR changes the `AddPlayer` & `RemovePlayer` functions so that they return bools rather than throwing exceptions, so that this just logs an error.

The original exception that caused the error spam on grafana was seemingly due to a player disconnecting twice? or disconecting without having fully connected?
```
Caught exception in OnDisconnected handler:
System.Collections.Generic.KeyNotFoundException: The given key 'Ponch' was not present in the dictionary.
   at Robust.Server.GameStates.PVSCollection`1.RemovePlayer(ICommonSession session) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PVSCollection.cs:line 271
   at Robust.Server.GameStates.PVSSystem.OnPlayerStatusChanged(Object sender, SessionStatusEventArgs e) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PVSSystem.cs:line 400
   at Robust.Server.Player.PlayerManager.EndSession(Object sender, NetChannelArgs args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/Player/PlayerManager.cs:line 448
   at Robust.Shared.Network.NetManager.HandleDisconnect(NetPeerData peer, NetConnection connection, String reason) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/Network/NetManager.cs:line 790
 Sawmill=net
```

This PR also adds some more deletion related checks/asserts, because there is still some bug related to PVS & entity deletion and I have NFI what causes it. 