### PR TITLE
Add get-matrix functions to IViewportControl

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -398,7 +398,7 @@ namespace Robust.Client.Graphics.Clyde
             var xformSys = _entityManager.EntitySysManager.GetEntitySystem<TransformSystem>();
 
             // matrix equivalent for Viewport.WorldToLocal()
-            var worldToLocal = view.WorldToLocalMatrix;
+            var worldToLocal = view.GetWorldToLocalMatrix();
 
             foreach (var comp in _entitySystemManager.GetEntitySystem<RenderingTreeSystem>().GetRenderTrees(map, worldBounds))
             {

--- a/Robust.Client/Graphics/Clyde/Clyde.Viewport.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Viewport.cs
@@ -157,17 +157,15 @@ namespace Robust.Client.Graphics.Clyde
                 return newPoint;
             }
 
-            public Matrix3 WorldToLocalMatrix
+            public Matrix3 GetWorldToLocalMatrix()
             {
-                get {
-                    if (Eye == null)
-                        return default;
+                if (Eye == null)
+                    return Matrix3.Identity;
 
-                    Eye.GetViewMatrix(out var viewMatrix, RenderScale * (EyeManager.PixelsPerMeter, -EyeManager.PixelsPerMeter));
-                    viewMatrix.R0C2 += Size.X / 2f;
-                    viewMatrix.R1C2 += Size.Y / 2f;
-                    return viewMatrix;
-                }
+                Eye.GetViewMatrix(out var viewMatrix, RenderScale * (EyeManager.PixelsPerMeter, -EyeManager.PixelsPerMeter));
+                viewMatrix.R0C2 += Size.X / 2f;
+                viewMatrix.R1C2 += Size.Y / 2f;
+                return viewMatrix;
             }
 
             public void RenderScreenOverlaysBelow(

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -580,7 +580,7 @@ namespace Robust.Client.Graphics.Clyde
                 return default;
             }
 
-            public Matrix3 WorldToLocalMatrix => default;
+            public Matrix3 GetWorldToLocalMatrix() => default;
 
             public Vector2 WorldToLocal(Vector2 point)
             {

--- a/Robust.Client/Graphics/IClydeViewport.cs
+++ b/Robust.Client/Graphics/IClydeViewport.cs
@@ -46,7 +46,7 @@ namespace Robust.Client.Graphics
         /// <summary>
         ///     Matrix equivalent of <see cref="LocalToWorld(Vector2)"/>.
         /// </summary>
-        Matrix3 WorldToLocalMatrix { get; }
+        Matrix3 GetWorldToLocalMatrix();
 
         /// <summary>
         ///     Converts a point in world-space to the viewport's screen coordinates.

--- a/Robust.Client/UserInterface/CustomControls/IViewportControl.cs
+++ b/Robust.Client/UserInterface/CustomControls/IViewportControl.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Client.Graphics;
+using Robust.Client.Graphics;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 
@@ -30,5 +30,18 @@ namespace Robust.Client.UserInterface.CustomControls
         ///     The coordinates, in ABSOLUTE SCREEN PIXEL COORDINATES. NOT CONTROL-RELATIVE COORDINATES.
         /// </returns>
         Vector2 WorldToScreen(Vector2 map);
+
+        /// <summary>
+        ///     Returns a matrix that can be used to perform the <see cref="WorldToScreen(Vector2)"/> transformations.
+        /// </summary>
+        /// <remarks>
+        ///     This is generally just be a combination of <see cref="IClydeViewport.GetWorldToLocalMatrix"/> and <see cref="GetLocalToScreenMatrix"/>
+        /// </remarks>
+        Matrix3 GetWorldToScreenMatrix();
+
+        /// <summary>
+        ///     Returns a matrix that can be used to transform from view-port local to screen coordinates.
+        /// </summary>
+        Matrix3 GetLocalToScreenMatrix();
     }
 }

--- a/Robust.Client/UserInterface/CustomControls/ViewportContainer.cs
+++ b/Robust.Client/UserInterface/CustomControls/ViewportContainer.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Client.Graphics;
+using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Shared.Maths;
 using Robust.Shared.IoC;
@@ -133,6 +133,19 @@ namespace Robust.Client.UserInterface.CustomControls
         public Vector2 WorldToScreen(Vector2 point)
         {
             return WorldToLocalPixel(point) + GlobalPixelPosition;
+        }
+
+        public Matrix3 GetWorldToScreenMatrix()
+        {
+            if (Viewport == null)
+                return Matrix3.Identity;
+
+            return Viewport.GetWorldToLocalMatrix() * GetLocalToScreenMatrix();
+        }
+
+        public Matrix3 GetLocalToScreenMatrix()
+        {
+            return Matrix3.CreateTransform(GlobalPixelPosition, 0, Vector2.One / _viewportResolution);
         }
     }
 }


### PR DESCRIPTION
Adds some get-matrix functions to `IViewportControl`, and makes the `IClydeViewport` matrix getter an explicit function.

This mainly helps speed up drawing some screen-space overlays, which can just use the matrix instead of repeatedly calling `WorldToScreen()`

Requires space-wizards/space-station-14/pull/11388