### PR TITLE
Store username in player data

### DIFF
--- a/Robust.Server/Player/IPlayerData.cs
+++ b/Robust.Server/Player/IPlayerData.cs
@@ -17,5 +17,7 @@ namespace Robust.Server.Player
         ///     Go wild.
         /// </summary>
         object? ContentDataUncast { get; set; }
+
+        string UserName { get; }
     }
 }

--- a/Robust.Server/Player/PlayerData.cs
+++ b/Robust.Server/Player/PlayerData.cs
@@ -5,13 +5,17 @@ namespace Robust.Server.Player
 {
     sealed class PlayerData : IPlayerData
     {
-        public PlayerData(NetUserId userId)
+        public PlayerData(NetUserId userId, string userName)
         {
             UserId = userId;
+            UserName = userName;
         }
 
         [ViewVariables]
         public NetUserId UserId { get; }
+
+        [ViewVariables]
+        public string UserName { get; }
 
         [ViewVariables]
         public object? ContentDataUncast { get; set; }

--- a/Robust.Server/Player/PlayerManager.cs
+++ b/Robust.Server/Player/PlayerManager.cs
@@ -383,7 +383,7 @@ namespace Robust.Server.Player
         {
             if (!_playerData.TryGetValue(args.Channel.UserId, out var data))
             {
-                data = new PlayerData(args.Channel.UserId);
+                data = new PlayerData(args.Channel.UserId, args.Channel.UserName);
                 _playerData.Add(args.Channel.UserId, data);
             }
 


### PR DESCRIPTION
Allows the username to be retrieved after a player has disconnected. Useful for some admin stuff.

This assumes that each net id has a single username, which I think is correct?