### PR TITLE
Replace Logger.Error with IRuntimeLog

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -368,7 +368,7 @@ namespace Robust.Client.GameStates
 
         public void RequestFullState(EntityUid? missingEntity = null)
         {
-            Logger.Info("Requesting full server state");
+            _sawmill.Info("Requesting full server state");
             _network.ClientSendMessage(new MsgStateRequestFull() { Tick = _timing.LastRealTick , MissingEntity = missingEntity ?? EntityUid.Invalid });
             _processor.RequestFullState();
         }
@@ -837,7 +837,8 @@ namespace Robust.Client.GameStates
                     }
                     catch (Exception e)
                     {
-                        Logger.ErrorS("state", $"Server entity threw in Init: ent={_entityManager.ToPrettyString(entity)}\n{e}");
+                        _sawmill.Error($"Server entity threw in Init: ent={_entityManager.ToPrettyString(entity)}");
+                        _runtimeLog.LogException(e, $"{nameof(ClientGameStateManager)}.{nameof(InitializeAndStart)}");
                         brokenEnts.Add(entity);
                         toCreate.Remove(entity);
                     }
@@ -858,7 +859,8 @@ namespace Robust.Client.GameStates
                     }
                     catch (Exception e)
                     {
-                        Logger.ErrorS("state", $"Server entity threw in Start: ent={_entityManager.ToPrettyString(entity)}\n{e}");
+                        _sawmill.Error($"Server entity threw in Start: ent={_entityManager.ToPrettyString(entity)}");
+                        _runtimeLog.LogException(e, $"{nameof(ClientGameStateManager)}.{nameof(InitializeAndStart)}");
                         brokenEnts.Add(entity);
                         toCreate.Remove(entity);
                     }
@@ -956,10 +958,10 @@ namespace Robust.Client.GameStates
                 catch (Exception e)
                 {
 #if EXCEPTION_TOLERANCE
-                _runtimeLog.LogException(new ComponentStateApplyException(
-                        $"Failed to apply comp state: entity={comp.Owner}, comp={comp.GetType()}", e), "Component state apply");
+                        _sawmill.Error($"Failed to apply comp state: entity={comp.Owner}, comp={comp.GetType()}");
+                        _runtimeLog.LogException(e, $"{nameof(ClientGameStateManager)}.{nameof(HandleEntityState)}");
 #else
-                    Logger.Error($"Failed to apply comp state: entity={comp.Owner}, comp={comp.GetType()}");
+                    _sawmill.Error($"Failed to apply comp state: entity={comp.Owner}, comp={comp.GetType()}");
                     throw;
 #endif
                 }

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -295,7 +295,7 @@ namespace Robust.Server.GameObjects
 #if EXCEPTION_TOLERANCE
             catch (Exception e)
             {
-                _runtimeLog.LogException(e, $"{nameof(DispatchEntityNetworkMessage)} {message.Type}");
+                _runtimeLog.LogException(e, $"{nameof(DispatchEntityNetworkMessage)}({message.Type})");
             }
 #endif
         }

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -6,6 +6,9 @@ using Robust.Server.Player;
 using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.Enums;
+#if EXCEPTION_TOLERANCE
+using Robust.Shared.Exceptions;
+#endif
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
@@ -31,6 +34,9 @@ namespace Robust.Server.GameObjects
         [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+#if EXCEPTION_TOLERANCE
+        [Dependency] private readonly IRuntimeLog _runtimeLog = default!;
+#endif
 
         protected override int NextEntityUid { get; set; } = (int) EntityUid.FirstUid;
 
@@ -289,7 +295,7 @@ namespace Robust.Server.GameObjects
 #if EXCEPTION_TOLERANCE
             catch (Exception e)
             {
-                Logger.ErrorS("net.ent", $"Caught exception while dispatching {message.Type}: {e}");
+                _runtimeLog.LogException(e, $"{nameof(DispatchEntityNetworkMessage)} {message.Type}");
             }
 #endif
         }

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -498,7 +498,7 @@ namespace Robust.Shared.GameObjects
             }
             catch (Exception e)
             {
-                Logger.Error($"Error while queuing deferred component removal. Entity={ToPrettyString(component.Owner)}, type={component.GetType()}");
+                Logger.Error($"Caught exception while queuing deferred component removal. Entity={ToPrettyString(component.Owner)}, type={component.GetType()}");
                 _runtimeLog.LogException(e, nameof(RemoveComponentDeferred));
             }
 #endif
@@ -539,7 +539,7 @@ namespace Robust.Shared.GameObjects
             }
             catch (Exception e)
             {
-                Logger.Error($"Error while processing immediate component removal. Entity={ToPrettyString(component.Owner)}, type={component.GetType()}");
+                Logger.Error($"Caught exception during immediate component removal. Entity={ToPrettyString(component.Owner)}, type={component.GetType()}");
                 _runtimeLog.LogException(e, nameof(RemoveComponentImmediate));
             }
 #endif
@@ -578,7 +578,7 @@ namespace Robust.Shared.GameObjects
             }
             catch (Exception e)
             {
-                Logger.Error($"Error while processing deferred component removal. Entity={ToPrettyString(component.Owner)}, type={component.GetType()}");
+                Logger.Error($"Caught exception  while processing deferred component removal. Entity={ToPrettyString(component.Owner)}, type={component.GetType()}");
                 _runtimeLog.LogException(e, nameof(CullRemovedComponents));
             }
 #endif

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -498,8 +498,8 @@ namespace Robust.Shared.GameObjects
             }
             catch (Exception e)
             {
-                _runtimeLog.LogException(e,
-                    $"RemoveComponentDeferred, owner={ToPrettyString(component.Owner)}, type={component.GetType()}");
+                Logger.Error($"Error while queuing deferred component removal. Entity={ToPrettyString(component.Owner)}, type={component.GetType()}");
+                _runtimeLog.LogException(e, nameof(RemoveComponentDeferred));
             }
 #endif
         }
@@ -539,8 +539,8 @@ namespace Robust.Shared.GameObjects
             }
             catch (Exception e)
             {
-                _runtimeLog.LogException(e,
-                    $"RemoveComponentImmediate, owner={ToPrettyString(component.Owner)}, type={component.GetType()}");
+                Logger.Error($"Error while processing immediate component removal. Entity={ToPrettyString(component.Owner)}, type={component.GetType()}");
+                _runtimeLog.LogException(e, nameof(RemoveComponentImmediate));
             }
 #endif
 
@@ -578,8 +578,8 @@ namespace Robust.Shared.GameObjects
             }
             catch (Exception e)
             {
-                _runtimeLog.LogException(e,
-                    $"CullRemovedComponents, owner={ToPrettyString(component.Owner)}, type={component.GetType()}");
+                Logger.Error($"Error while processing deferred component removal. Entity={ToPrettyString(component.Owner)}, type={component.GetType()}");
+                _runtimeLog.LogException(e, nameof(CullRemovedComponents));
             }
 #endif
 


### PR DESCRIPTION
Replaces some `Logger.Error()` calls in try-catch blocks with `IRuntimeLog.LogException()`.
Also moves some data that was included in the "catcher" argument into a separate error log.