### PR TITLE
Remove RotateEvent

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/TransformSystem.Component.cs
+++ b/Robust.Client/GameObjects/EntitySystems/TransformSystem.Component.cs
@@ -29,4 +29,15 @@ public sealed partial class TransformSystem
         base.SetLocalRotation(xform, angle);
         ActivateLerp(xform);
     }
+
+    public override void SetLocalPositionRotation(TransformComponent xform, Vector2 pos, Angle rot)
+    {
+        xform._prevPosition = xform._localPosition;
+        xform._nextPosition = pos;
+        xform._prevRotation = xform._localRotation;
+        xform._nextRotation = rot;
+        xform.LerpParent = xform.ParentUid;
+        base.SetLocalPositionRotation(xform, pos, rot);
+        ActivateLerp(xform);
+    }
 }

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -42,8 +42,8 @@ namespace Robust.Shared.GameObjects
         internal Angle _prevRotation;
 
         // Cache changes so we can distribute them after physics is done (better cache)
-        private EntityCoordinates? _oldCoords;
-        private Angle? _oldLocalRotation;
+        internal EntityCoordinates? _oldCoords;
+        internal Angle? _oldLocalRotation;
 
         /// <summary>
         ///     While updating did we actually defer anything?
@@ -133,8 +133,8 @@ namespace Robust.Shared.GameObjects
                 if (!DeferUpdates)
                 {
                     RebuildMatrices();
-                    var rotateEvent = new RotateEvent(Owner, oldRotation, _localRotation, this);
-                    _entMan.EventBus.RaiseLocalEvent(Owner, ref rotateEvent, true);
+                    var moveEvent = new MoveEvent(Owner, Coordinates, Coordinates, oldRotation, _localRotation, this, _gameTiming.ApplyingState);
+                    _entMan.EventBus.RaiseLocalEvent(Owner, ref moveEvent, true);
                 }
                 else
                 {
@@ -385,7 +385,7 @@ namespace Robust.Shared.GameObjects
                     {
                         if (!oldPosition.Equals(Coordinates))
                         {
-                            var moveEvent = new MoveEvent(Owner, oldPosition, Coordinates, this, _gameTiming.ApplyingState);
+                            var moveEvent = new MoveEvent(Owner, oldPosition, Coordinates, _localRotation, _localRotation, this, _gameTiming.ApplyingState);
                             _entMan.EventBus.RaiseLocalEvent(Owner, ref moveEvent, true);
                         }
                     }
@@ -428,7 +428,7 @@ namespace Robust.Shared.GameObjects
                 if (!DeferUpdates)
                 {
                     RebuildMatrices();
-                    var moveEvent = new MoveEvent(Owner, oldGridPos, Coordinates, this, _gameTiming.ApplyingState);
+                    var moveEvent = new MoveEvent(Owner, oldGridPos, Coordinates, _localRotation, _localRotation, this, _gameTiming.ApplyingState);
                     _entMan.EventBus.RaiseLocalEvent(Owner, ref moveEvent, true);
                 }
                 else
@@ -537,7 +537,7 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <summary>
-        ///     Run MoveEvent, RotateEvent, and UpdateEntityTree updates.
+        ///     Raise deferred MoveEvents and rebuild matrices.
         /// </summary>
         public void RunDeferred()
         {
@@ -550,19 +550,10 @@ namespace Robust.Shared.GameObjects
 
             RebuildMatrices();
 
-            if (_oldCoords != null)
-            {
-                var moveEvent = new MoveEvent(Owner, _oldCoords.Value, Coordinates, this, _gameTiming.ApplyingState);
-                _entMan.EventBus.RaiseLocalEvent(Owner, ref moveEvent, true);
-                _oldCoords = null;
-            }
-
-            if (_oldLocalRotation != null)
-            {
-                var rotateEvent = new RotateEvent(Owner, _oldLocalRotation.Value, _localRotation, this);
-                _entMan.EventBus.RaiseLocalEvent(Owner, ref rotateEvent, true);
-                _oldLocalRotation = null;
-            }
+            var moveEvent = new MoveEvent(Owner, _oldCoords ?? Coordinates, Coordinates, _oldLocalRotation ?? _localRotation, _localRotation, this, _gameTiming.ApplyingState);
+            _entMan.EventBus.RaiseLocalEvent(Owner, ref moveEvent, true);
+            _oldCoords = null;
+            _oldLocalRotation = null;
         }
 
         /// <summary>
@@ -803,6 +794,8 @@ namespace Robust.Shared.GameObjects
 
         internal void RebuildMatrices()
         {
+            // TODO maybe just add a matrix dirty bool, and rebuild only when needed? I.e., if a lone entity is just
+            // drifting through space, do things even usually need to access both the local & inverse-local matrices??
             var pos = _localPosition;
 
             if (!_parent.IsValid()) // Root Node
@@ -833,17 +826,18 @@ namespace Robust.Shared.GameObjects
     }
 
     /// <summary>
-    ///     Raised whenever an entity moves.
-    ///     There is no guarantee it will be raised if they move in worldspace, only when moved relative to their parent.
+    ///     Raised whenever an entity translates or rotates relative to their parent.
     /// </summary>
     [ByRefEvent]
     public readonly struct MoveEvent
     {
-        public MoveEvent(EntityUid sender, EntityCoordinates oldPos, EntityCoordinates newPos, TransformComponent component, bool stateHandling)
+        public MoveEvent(EntityUid sender, EntityCoordinates oldPos, EntityCoordinates newPos, Angle oldRotation, Angle newRotation, TransformComponent component, bool stateHandling)
         {
             Sender = sender;
             OldPosition = oldPos;
             NewPosition = newPos;
+            OldRotation = oldRotation;
+            NewRotation = newRotation;
             Component = component;
             FromStateHandling = stateHandling;
         }
@@ -851,32 +845,14 @@ namespace Robust.Shared.GameObjects
         public readonly EntityUid Sender;
         public readonly EntityCoordinates OldPosition;
         public readonly EntityCoordinates NewPosition;
+        public readonly Angle OldRotation;
+        public readonly Angle NewRotation;
         public readonly TransformComponent Component;
 
         /// <summary>
         ///     If true, this event was generated during component state handling. This means it can be ignored in some instances.
         /// </summary>
         public readonly bool FromStateHandling;
-    }
-
-    /// <summary>
-    ///     Raised whenever this entity rotates in relation to their parent.
-    /// </summary>
-    [ByRefEvent]
-    public readonly struct RotateEvent
-    {
-        public RotateEvent(EntityUid sender, Angle oldRotation, Angle newRotation, TransformComponent xform)
-        {
-            Sender = sender;
-            OldRotation = oldRotation;
-            NewRotation = newRotation;
-            Component = xform;
-        }
-
-        public readonly EntityUid Sender;
-        public readonly Angle OldRotation;
-        public readonly Angle NewRotation;
-        public readonly TransformComponent Component;
     }
 
     public struct TransformChildrenEnumerator : IDisposable

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -63,7 +63,6 @@ namespace Robust.Shared.GameObjects
             configManager.OnValueChanged(CVars.LookupEnlargementRange, value => _lookupEnlargementRange = value, true);
 
             SubscribeLocalEvent<MoveEvent>(OnMove);
-            SubscribeLocalEvent<RotateEvent>(OnRotate);
             SubscribeLocalEvent<EntParentChangedMessage>(OnParentChange);
             SubscribeLocalEvent<AnchorStateChangedEvent>(OnAnchored);
             SubscribeLocalEvent<EntInsertedIntoContainerMessage>(OnContainerInsert);
@@ -236,11 +235,6 @@ namespace Robust.Shared.GameObjects
         }
 
         private void OnMove(ref MoveEvent args)
-        {
-            UpdatePosition(args.Sender, args.Component);
-        }
-
-        private void OnRotate(ref RotateEvent args)
         {
             UpdatePosition(args.Sender, args.Component);
         }

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -45,6 +45,8 @@ public abstract partial class SharedTransformSystem
         var movEevee = new MoveEvent(xform.Owner,
             new EntityCoordinates(oldGrid.Owner, xform._localPosition),
             new EntityCoordinates(newGrid.Owner, xform._localPosition),
+            xform.LocalRotation,
+            xform.LocalRotation,
             xform,
             _gameTiming.ApplyingState);
         RaiseLocalEvent(xform.Owner, ref movEevee, true);
@@ -430,18 +432,14 @@ public abstract partial class SharedTransformSystem
                 rebuildMatrices = true;
             }
 
-            if (component.LocalRotation != newState.Rotation)
-            {
-                component._localRotation = newState.Rotation;
-                rebuildMatrices = true;
-            }
-
-            if (!component.LocalPosition.EqualsApprox(newState.LocalPosition))
+            if (!component.LocalPosition.EqualsApprox(newState.LocalPosition) || !component.LocalRotation.EqualsApprox(newState.Rotation))
             {
                 var oldPos = component.Coordinates;
                 component._localPosition = newState.LocalPosition;
+                var oldRot = component.LocalRotation;
+                component._localRotation = newState.Rotation;
 
-                var ev = new MoveEvent(uid, oldPos, component.Coordinates, component, _gameTiming.ApplyingState);
+                var ev = new MoveEvent(uid, oldPos, component.Coordinates, oldRot, component.LocalRotation, component, _gameTiming.ApplyingState);
                 DeferMoveEvent(ref ev);
 
                 rebuildMatrices = true;
@@ -591,15 +589,7 @@ public abstract partial class SharedTransformSystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void SetWorldPosition(TransformComponent component, Vector2 worldPos)
     {
-        if (!component._parent.IsValid())
-        {
-            DebugTools.Assert("Parent is invalid while attempting to set WorldPosition - did you try to move root node?");
-            return;
-        }
-
-        // world coords to parent coords
-        var newPos = component.Parent!.InvWorldMatrix.Transform(worldPos);
-        SetLocalPosition(component, newPos);
+        SetWorldPosition(component, worldPos, GetEntityQuery<TransformComponent>());
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -610,6 +600,8 @@ public abstract partial class SharedTransformSystem
             DebugTools.Assert("Parent is invalid while attempting to set WorldPosition - did you try to move root node?");
             return;
         }
+
+        // TODO look at SetWorldPositionRotation and how it sets world position. I ASSUME that is faster than matrix products + transform, but not actually sure.
 
         // world coords to parent coords
         var newPos = GetInvWorldMatrix(component._parent, xformQuery).Transform(worldPos);
@@ -676,6 +668,81 @@ public abstract partial class SharedTransformSystem
         var current = GetWorldRotation(component, xformQuery);
         var diff = angle - current;
         SetLocalRotation(component, component.LocalRotation + diff);
+    }
+
+    #endregion
+
+    #region Set Position+Rotation
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetWorldPositionRotation(EntityUid uid, Vector2 worldPos, Angle worldRot, EntityQuery<TransformComponent> xformQuery)
+    {
+        var component = xformQuery.GetComponent(uid);
+        SetWorldPositionRotation(component, worldPos, worldRot, xformQuery);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetWorldPositionRotation(TransformComponent component, Vector2 worldPos, Angle worldRot)
+    {
+        SetWorldPositionRotation(component, worldPos, worldRot, GetEntityQuery<TransformComponent>());
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetWorldPositionRotation(TransformComponent component, Vector2 worldPos, Angle worldRot, EntityQuery<TransformComponent> xformQuery)
+    {
+        if (!component._parent.IsValid())
+        {
+            DebugTools.Assert("Parent is invalid while attempting to set WorldPosition - did you try to move root node?");
+            return;
+        }
+
+        var (curWorldPos, curWorldRot) = GetWorldPositionRotation(component, xformQuery);
+
+        var negativeParentWorldRot = component.LocalRotation - curWorldRot;
+
+        var newLocalPos = component.LocalPosition + negativeParentWorldRot.RotateVec(worldPos - curWorldPos);
+        var newLocalRot = component.LocalRotation + worldRot - curWorldRot;
+
+        SetLocalPositionRotation(component, newLocalPos, newLocalRot);
+    }
+
+    /// <summary>
+    ///     Simultaneously set the position and rotation. This is better than setting individually, as it reduces the number of move events and matrix rebuilding operations.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public virtual void SetLocalPositionRotation(TransformComponent xform, Vector2 pos, Angle rot)
+    {
+        if (!xform._parent.IsValid())
+        {
+            DebugTools.Assert("Parent is invalid while attempting to set WorldPosition - did you try to move root node?");
+            return;
+        }
+
+        if (xform._localPosition.EqualsApprox(pos) && xform.LocalRotation.EqualsApprox(rot))
+            return;
+
+        var oldPosition = xform.Coordinates;
+        var oldRotation = xform.LocalRotation;
+
+        if (!xform.Anchored)
+            xform._localPosition = pos;
+
+        if (!xform.NoLocalRotation)
+            xform.LocalRotation = rot;
+
+        Dirty(xform);
+
+        if (!xform.DeferUpdates)
+        {
+            xform.RebuildMatrices();
+            var moveEvent = new MoveEvent(xform.Owner, oldPosition, xform.Coordinates, oldRotation, rot, xform, _gameTiming.ApplyingState);
+            RaiseLocalEvent(xform.Owner, ref moveEvent, true);
+        }
+        else
+        {
+            xform._oldCoords ??= oldPosition;
+            xform._oldLocalRotation ??= oldRotation;
+        }
     }
 
     #endregion

--- a/Robust.Shared/Physics/Dynamics/PhysicsIsland.cs
+++ b/Robust.Shared/Physics/Dynamics/PhysicsIsland.cs
@@ -522,10 +522,9 @@ stored in a single array since multiple arrays lead to multiple misses.
                     bodyPos -= Transform.Mul(q, body.LocalCenter);
                     var transform = xforms.GetComponent(body.Owner);
 
-                    // Defer MoveEvent / RotateEvent until the end of the physics step so cache can be better.
+                    // Defer MoveEvent until the end of the physics step so cache can be better.
                     transform.DeferUpdates = true;
-                    _transform.SetWorldPosition(transform, bodyPos, xforms);
-                    _transform.SetWorldRotation(transform, angle, xforms);
+                    _transform.SetWorldPositionRotation(transform, bodyPos, angle, xforms);
                     transform.DeferUpdates = false;
 
                     // Unfortunately we can't cache the position and angle here because if our parent's position

--- a/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
@@ -54,7 +54,6 @@ namespace Robust.Shared.Physics.Systems
             SubscribeLocalEvent<CollisionChangeEvent>(OnPhysicsUpdate);
 
             SubscribeLocalEvent<PhysicsComponent, MoveEvent>(OnMove);
-            SubscribeLocalEvent<PhysicsComponent, RotateEvent>(OnRotate);
 
             var configManager = IoCManager.Resolve<IConfigurationManager>();
             configManager.OnValueChanged(CVars.BroadphaseExpand, SetBroadphaseExpand, true);
@@ -580,34 +579,17 @@ namespace Robust.Shared.Physics.Systems
 
         private void OnMove(EntityUid uid, PhysicsComponent component, ref MoveEvent args)
         {
-            if (!component.CanCollide ||
-                !TryComp<FixturesComponent>(uid, out var manager) ||
-                _mapManager.IsGrid(uid)) return;
-
-            var worldRot = Transform(uid).WorldRotation;
-
-            SynchronizeFixtures(component, args.NewPosition.ToMapPos(EntityManager), (float) worldRot.Theta, manager);
-        }
-
-        private void OnRotate(EntityUid uid, PhysicsComponent component, ref RotateEvent args)
-        {
-            if (!component.CanCollide ||
-                _mapManager.IsGrid(uid)) return;
-
-            var xform = Transform(uid);
-            var (worldPos, worldRot) = xform.GetWorldPositionRotation();
-            DebugTools.Assert(xform.LocalRotation.Equals(args.NewRotation));
-
-            SynchronizeFixtures(component, worldPos, (float) worldRot.Theta);
-        }
-
-        private void SynchronizeFixtures(PhysicsComponent body, Vector2 worldPos, float worldRot, FixturesComponent? manager = null)
-        {
-            if (!Resolve(body.Owner, ref manager))
-            {
+            if (!component.CanCollide
+                || args.Component.GridUid == uid
+                || !TryComp(uid, out FixturesComponent? manager))
                 return;
-            }
 
+            var (worldPos, worldRot) = _xformSys.GetWorldPositionRotation(args.Component, GetEntityQuery<TransformComponent>());
+            SynchronizeFixtures(component, worldPos, (float)worldRot, manager);
+        }
+
+        private void SynchronizeFixtures(PhysicsComponent body, Vector2 worldPos, float worldRot, FixturesComponent manager)
+        {
             // Logger.DebugS("physics", $"Synchronizing fixtures for {body.Owner}");
             // Don't cache this as controllers may change it freely before we run physics!
             var xf = new Transform(worldPos, worldRot);


### PR DESCRIPTION
Fixes #3204. 

This merges RotateEvent into MoveEvent. Unlike the suggestion in #3204 the move event wasn't renamed. IMO rotation is just a type of movement, and the name is still descriptive. So unless someone ever needs to add a translation-only event it can just stay as is. The main reason for this change is to avoid doubling up on fixture synchronization and entity lookup updates for moving & rotating entities. 

This PR also adds some transform system functions to set both world rotation & position simultaneously.

Requires space-wizards/space-station-14/pull/11448