### PR TITLE
Allow startup to continue if prototype watching fails

### DIFF
--- a/Robust.Client/Prototypes/ClientPrototypeManager.cs
+++ b/Robust.Client/Prototypes/ClientPrototypeManager.cs
@@ -119,7 +119,14 @@ namespace Robust.Client.Prototypes
                     });
                 };
 
-                watcher.EnableRaisingEvents = true;
+                try
+                {
+                    watcher.EnableRaisingEvents = true;
+                }
+                catch (IOException ex)
+                {
+                    Logger.Error($"Watching resources in path {path} threw an exception:\n{ex}");
+                }
                 _watchers.Add(watcher);
             }
 #endif

--- a/Robust.Client/Prototypes/ClientPrototypeManager.cs
+++ b/Robust.Client/Prototypes/ClientPrototypeManager.cs
@@ -122,12 +122,12 @@ namespace Robust.Client.Prototypes
                 try
                 {
                     watcher.EnableRaisingEvents = true;
+                    _watchers.Add(watcher);
                 }
                 catch (IOException ex)
                 {
                     Logger.Error($"Watching resources in path {path} threw an exception:\n{ex}");
                 }
-                _watchers.Add(watcher);
             }
 #endif
         }


### PR DESCRIPTION
Example:
```
[ERRO] root: Watching resources in path /d/archives/projects/ss14/space-station-14/Resources/Prototypes threw an exception:
System.IO.IOException: The configured user limit (128) on the number of inotify instances has been reached, or the per-process limit on the number of open file descriptors has been reached.
   at System.IO.FileSystemWatcher.StartRaisingEvents()
   at System.IO.FileSystemWatcher.StartRaisingEventsIfNotDisposed()
   at System.IO.FileSystemWatcher.set_EnableRaisingEvents(Boolean value)
   at Robust.Client.Prototypes.ClientPrototypeManager.WatchResources() in /d/archives/projects/ss14/space-station-14/RobustToolbox/Robust.Client/Prototypes/ClientPrototypeManager.cs:line 124
```