### PR TITLE
Fix component removal / PVS bugs

### DIFF
--- a/Robust.Client/GameStates/ClientDirtySystem.cs
+++ b/Robust.Client/GameStates/ClientDirtySystem.cs
@@ -37,9 +37,8 @@ internal sealed class ClientDirtySystem : EntitySystem
 
     private void OnCompRemoved(RemovedComponentEventArgs args)
     {
-        // TODO if entity deletion ever gets predicted, enable this check. Currently it is redundant:
-        // if (args.Terminating)
-        //    return;
+        if (args.Terminating)
+            return;
 
         var comp = args.BaseArgs.Component;
         if (!_timing.InPrediction || comp.Owner.IsClientSide() || !comp.NetSyncEnabled)

--- a/Robust.Client/GameStates/ClientDirtySystem.cs
+++ b/Robust.Client/GameStates/ClientDirtySystem.cs
@@ -37,6 +37,10 @@ internal sealed class ClientDirtySystem : EntitySystem
 
     private void OnCompRemoved(RemovedComponentEventArgs args)
     {
+        // TODO if entity deletion ever gets predicted, enable this check. Currently it is redundant:
+        // if (args.Terminating)
+        //    return;
+
         var comp = args.BaseArgs.Component;
         if (!_timing.InPrediction || comp.Owner.IsClientSide() || !comp.NetSyncEnabled)
             return;
@@ -44,12 +48,6 @@ internal sealed class ClientDirtySystem : EntitySystem
         // Was this component added during prediction? If yes, then there is no need to re-add it when resetting.
         if (comp.CreationTick > _timing.LastRealTick)
             return;
-
-        // TODO if entity deletion ever gets predicted, then to speed this function up the component removal event
-        // should probably get an arg that specifies whether removal is occurring because of entity deletion. AKA: I
-        // don't want to have to fetch the meta-data component 10+ times for each entity that gets deleted. Currently
-        // server-induced deletions should get ignored, as _timing.InPrediction will be false while applying game
-        // states.
 
         var netId = _compFact.GetRegistration(comp).NetID;
         if (netId != null)

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -1127,10 +1127,7 @@ namespace Robust.Client.GameStates
             RemQueue<Component> toRemove = new();
             foreach (var (id, comp) in _entities.GetNetComponents(uid))
             {
-                if (!comp.NetSyncEnabled)
-                    continue;
-
-                if (!lastState.ContainsKey(id))
+                if (comp.NetSyncEnabled && !lastState.ContainsKey(id))
                     toRemove.Add(comp);
             }
 

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -883,12 +883,12 @@ namespace Robust.Client.GameStates
             var compStateWork = new Dictionary<ushort, (IComponent Component, ComponentState? curState, ComponentState? nextState)>(size);
 
             // First remove any deleted components
-            if (curState.NetComponents != null)
+            if (curState?.NetComponents != null)
             {
                 RemQueue<Component> toRemove = new();
                 foreach (var (id, comp) in _entities.GetNetComponents(uid))
                 {
-                    if (comp.NetSyncEnabled && !netCompIds.Contains(id))
+                    if (comp.NetSyncEnabled && !curState.NetComponents.Contains(id))
                         toRemove.Add(comp);
                 }
 

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -883,7 +883,7 @@ namespace Robust.Client.GameStates
             var compStateWork = new Dictionary<ushort, (IComponent Component, ComponentState? curState, ComponentState? nextState)>(size);
 
             // First remove any deleted components
-            if (curState?.NetComponents is { } netCompIds)
+            if (curState.NetComponents != null)
             {
                 RemQueue<Component> toRemove = new();
                 foreach (var (id, comp) in _entities.GetNetComponents(uid))

--- a/Robust.Client/GameStates/GameStateProcessor.cs
+++ b/Robust.Client/GameStates/GameStateProcessor.cs
@@ -169,17 +169,6 @@ namespace Robust.Client.GameStates
                 {
                     _lastStateFullRep.Remove(deletion);
                 }
-
-                foreach (var (uid, deletedComps) in state.ComponentDeletions)
-                {
-                    if (!_lastStateFullRep.TryGetValue(uid, out var compData))
-                        continue;
-
-                    foreach (var netId in deletedComps)
-                    {
-                        compData.Remove(netId);
-                    }
-                }
             }
 
             foreach (var entityState in state.EntityStates.Span)
@@ -188,6 +177,15 @@ namespace Robust.Client.GameStates
                 {
                     compData = new Dictionary<ushort, ComponentState>();
                     _lastStateFullRep.Add(entityState.Uid, compData);
+                }
+
+                if (entityState.NetComponents != null)
+                {
+                    foreach (var key in compData.Keys)
+                    {
+                        if (!entityState.NetComponents.Contains(key))
+                            compData.Remove(key);
+                    }
                 }
 
                 foreach (var change in entityState.ComponentChanges.Span)

--- a/Robust.Client/GameStates/GameStateProcessor.cs
+++ b/Robust.Client/GameStates/GameStateProcessor.cs
@@ -179,18 +179,18 @@ namespace Robust.Client.GameStates
                     _lastStateFullRep.Add(entityState.Uid, compData);
                 }
 
-                if (entityState.NetComponents != null)
-                {
-                    foreach (var key in compData.Keys)
-                    {
-                        if (!entityState.NetComponents.Contains(key))
-                            compData.Remove(key);
-                    }
-                }
-
                 foreach (var change in entityState.ComponentChanges.Span)
                 {
                     compData[change.NetID] = change.State;
+                }
+
+                if (entityState.NetComponents == null)
+                    continue;
+
+                foreach (var key in compData.Keys)
+                {
+                    if (!entityState.NetComponents.Contains(key))
+                        compData.Remove(key);
                 }
             }
         }

--- a/Robust.Client/GameStates/NetGraphOverlay.cs
+++ b/Robust.Client/GameStates/NetGraphOverlay.cs
@@ -80,6 +80,7 @@ namespace Robust.Client.GameStates
             string? entDelString = null;
             var conShell = IoCManager.Resolve<IConsoleHost>().LocalShell;
 
+            bool found = false;
             var entStates = args.AppliedState.EntityStates;
             if (entStates.HasContents)
             {
@@ -88,6 +89,8 @@ namespace Robust.Client.GameStates
                 {
                     if (entState.Uid != WatchEntId)
                         continue;
+
+                    found = true;
 
                     if (!entState.ComponentChanges.HasContents)
                     {
@@ -99,15 +102,25 @@ namespace Robust.Client.GameStates
                     foreach (var compChange in entState.ComponentChanges.Span)
                     {
                         var registration = _componentFactory.GetRegistration(compChange.NetID);
-                        var create = compChange.Created ? 'C' : '\0';
-                        var mod = !(compChange.Created || compChange.Created) ? 'M' : '\0';
-                        var del = compChange.Deleted ? 'D' : '\0';
-                        sb.Append($"\n    [{create}{mod}{del}]{compChange.NetID}:{registration.Name}");
+                        sb.Append($"\n    [{compChange.NetID}:{registration.Name}");
 
                         if (compChange.State is not null)
                             sb.Append($"\n      STATE:{compChange.State.GetType().Name}");
                     }
+
+                    break;
                 }
+
+                if (args.AppliedState.ComponentDeletions.TryGetValue(WatchEntId, out var deletions))
+                {
+                    sb.Append($"\n  Component Deletions:");
+                    foreach (var netId in deletions)
+                    {
+                        var registration = _componentFactory.GetRegistration(netId);
+                        sb.Append($"\n    [{netId}:{registration.Name}");
+                    }
+                }
+
                 entStateString = sb.ToString();
             }
 

--- a/Robust.Client/GameStates/NetGraphOverlay.cs
+++ b/Robust.Client/GameStates/NetGraphOverlay.cs
@@ -23,6 +23,7 @@ namespace Robust.Client.GameStates
         [Dependency] private readonly IClientNetManager _netManager = default!;
         [Dependency] private readonly IClientGameStateManager _gameStateManager = default!;
         [Dependency] private readonly IComponentFactory _componentFactory = default!;
+        [Dependency] private readonly IEntityManager _entMan = default!;
 
         private const int HistorySize = 60 * 3; // number of ticks to keep in history.
         private const int TargetPayloadBps = 56000 / 8; // Target Payload size in Bytes per second. A mind-numbing fifty-six thousand bits per second, who would ever need more?
@@ -80,7 +81,6 @@ namespace Robust.Client.GameStates
             string? entDelString = null;
             var conShell = IoCManager.Resolve<IConsoleHost>().LocalShell;
 
-            bool found = false;
             var entStates = args.AppliedState.EntityStates;
             if (entStates.HasContents)
             {
@@ -89,8 +89,6 @@ namespace Robust.Client.GameStates
                 {
                     if (entState.Uid != WatchEntId)
                         continue;
-
-                    found = true;
 
                     if (!entState.ComponentChanges.HasContents)
                     {
@@ -109,16 +107,6 @@ namespace Robust.Client.GameStates
                     }
 
                     break;
-                }
-
-                if (args.AppliedState.ComponentDeletions.TryGetValue(WatchEntId, out var deletions))
-                {
-                    sb.Append($"\n  Component Deletions:");
-                    foreach (var netId in deletions)
-                    {
-                        var registration = _componentFactory.GetRegistration(netId);
-                        sb.Append($"\n    [{netId}:{registration.Name}");
-                    }
                 }
 
                 entStateString = sb.ToString();

--- a/Robust.Client/GameStates/NetGraphOverlay.cs
+++ b/Robust.Client/GameStates/NetGraphOverlay.cs
@@ -106,9 +106,11 @@ namespace Robust.Client.GameStates
                             sb.Append($"\n      STATE:{compChange.State.GetType().Name}");
                     }
 
+                    // Note that component deletion is now implicit via the list of network comp ids. So it currently
+                    // doesn't get logged here.
+
                     break;
                 }
-
                 entStateString = sb.ToString();
             }
 

--- a/Robust.Server/GameObjects/EntitySystems/ServerMetaDataSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/ServerMetaDataSystem.cs
@@ -42,11 +42,7 @@ public sealed class ServerMetaDataSystem : MetaDataSystem
     private void OnComponentRemoved(RemovedComponentEventArgs obj)
     {
         var removed = obj.BaseArgs.Component;
-        if (!removed.NetSyncEnabled || (!removed.SessionSpecific && !removed.SendOnlyToOwner))
-            return;
-
-        var meta = MetaData(obj.BaseArgs.Owner);
-        if (meta.EntityLifeStage >= EntityLifeStage.Terminating)
+        if (obj.Terminating || !removed.NetSyncEnabled || (!removed.SessionSpecific && !removed.SendOnlyToOwner))
             return;
 
         foreach (var (_, comp) in EntityManager.GetNetComponents(obj.BaseArgs.Owner))
@@ -59,7 +55,7 @@ public sealed class ServerMetaDataSystem : MetaDataSystem
         }
 
         // remove the flag
-        meta.Flags &= ~MetaDataFlags.SessionSpecific;
+        MetaData(obj.BaseArgs.Owner).Flags &= ~MetaDataFlags.SessionSpecific;
     }
 
     /// <summary>

--- a/Robust.Server/GameObjects/IServerEntityNetworkManager.cs
+++ b/Robust.Server/GameObjects/IServerEntityNetworkManager.cs
@@ -8,7 +8,7 @@ namespace Robust.Server.GameObjects
     public interface IServerEntityNetworkManager : IEntityNetworkManager
     {
         uint GetLastMessageSequence(IPlayerSession session);
-        List<ushort> GetDeletedComponents(EntityUid uid, GameTick fromTick);
+        Dictionary<EntityUid, List<ushort>> GetDeletedComponents(GameTick fromTick);
         void CullDeletionHistory(GameTick oldestAck);
     }
 }

--- a/Robust.Server/GameObjects/IServerEntityNetworkManager.cs
+++ b/Robust.Server/GameObjects/IServerEntityNetworkManager.cs
@@ -8,7 +8,5 @@ namespace Robust.Server.GameObjects
     public interface IServerEntityNetworkManager : IEntityNetworkManager
     {
         uint GetLastMessageSequence(IPlayerSession session);
-        Dictionary<EntityUid, List<ushort>> GetDeletedComponents(GameTick fromTick);
-        void CullDeletionHistory(GameTick oldestAck);
     }
 }

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -112,8 +112,6 @@ namespace Robust.Server.GameObjects
         private readonly Dictionary<IPlayerSession, uint> _lastProcessedSequencesCmd =
             new();
 
-        private readonly Dictionary<EntityUid, Dictionary<ushort, GameTick>> _componentDeletionHistory = new();
-
         private bool _logLateMsgs;
 
         /// <inheritdoc />

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -122,15 +122,12 @@ namespace Robust.Server.GameObjects
             _networkManager.RegisterNetMessage<MsgEntity>(HandleEntityNetworkMessage);
 
             // For syncing component deletions.
-            EntityDeleted += OnEntityRemoved;
             ComponentRemoved += OnComponentRemoved;
-            ComponentAdded += OnComponentAdded;
 
             _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
 
             _configurationManager.OnValueChanged(CVars.NetLogLateMsg, b => _logLateMsgs = b, true);
         }
-
 
         /// <inheritdoc />
         public override void TickUpdate(float frameTime, bool noPredictions, Histogram? histogram)
@@ -153,85 +150,13 @@ namespace Robust.Server.GameObjects
             return _lastProcessedSequencesCmd[session];
         }
 
-        private void OnEntityRemoved(EntityUid e)
-        {
-            if (_componentDeletionHistory.ContainsKey(e))
-                _componentDeletionHistory.Remove(e);
-        }
-
         private void OnComponentRemoved(RemovedComponentEventArgs e)
         {
             if (e.Terminating || !e.BaseArgs.Component.NetSyncEnabled)
                 return;
 
-            var reg = ComponentFactory.GetRegistration(e.BaseArgs.Component.GetType());
-
-            // We only keep track of networked components being removed.
-            if (reg.NetID is not {} netId)
-                return;
-
-            var uid = e.BaseArgs.Owner;
-
-            if (!_componentDeletionHistory.TryGetValue(uid, out var dict))
-            {
-                dict = new();
-                _componentDeletionHistory[uid] = dict;
-            }
-
-            dict.Add(netId, _gameTiming.CurTick);
-        }
-
-        private void OnComponentAdded(AddedComponentEventArgs e)
-        {
-            // if a component was removed and then gets re-added before removal history gets culled, this ensures that we
-            // don't accidentally instruct clients to remove those components:
-
-            if (!e.BaseArgs.Component.NetSyncEnabled)
-                return;
-
-            if (!_componentDeletionHistory.TryGetValue(e.BaseArgs.Owner, out var history))
-                return;
-
-            var reg = ComponentFactory.GetRegistration(e.BaseArgs.Component.GetType());
-
-            if (reg.NetID != null)
-                history.Remove(reg.NetID.Value);
-        }
-
-        public Dictionary<EntityUid, List<ushort>> GetDeletedComponents(GameTick fromTick)
-        {
-            // TODO maybe it would just be better to just send the whole deletion history, instead of constructing this data for each client?
-
-            var result = new Dictionary<EntityUid, List<ushort>>(_componentDeletionHistory.Count);
-            foreach (var (uid, history) in _componentDeletionHistory)
-            {
-                var list = new List<ushort>(history.Count);
-
-                foreach (var (id, tick) in history)
-                {
-                    if (tick >= fromTick) list.Add(id);
-                }
-
-                result.Add(uid, list);
-            }
-
-            return result;
-        }
-
-        public void CullDeletionHistory(GameTick oldestAck)
-        {
-            foreach (var (uid, deletions) in _componentDeletionHistory)
-            {
-                foreach (var (netId, tick) in deletions)
-                {
-                    if (tick <= oldestAck)
-                        deletions.Remove(netId);
-                }
-
-                if (deletions.Count == 0)
-                    _componentDeletionHistory.Remove(uid);
-            }
-            
+            if (TryGetComponent(e.BaseArgs.Owner, out MetaDataComponent? meta))
+                meta.LastComponentRemoved = _gameTiming.CurTick;
         }
 
         /// <inheritdoc />

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -1079,7 +1079,15 @@ internal sealed partial class PVSSystem : EntitySystem
             changed.Add(new ComponentChange(netId, state, component.LastModifiedTick));
         }
 
-        return new EntityState(entityUid, changed, meta.EntityLastModifiedTick);
+        var entState = new EntityState(entityUid, changed, meta.EntityLastModifiedTick);
+
+        if (meta.LastComponentRemoved > fromTick)
+        {
+            // TODO: should this respect NetSyncEnabled, SendOnlyToOwner & CanGetComponentState?
+            entState.NetComponents = new(EntityManager.GetNetComponentIds(entityUid));
+        }
+
+        return entState;
     }
 
     /// <summary>
@@ -1104,7 +1112,12 @@ internal sealed partial class PVSSystem : EntitySystem
             changed.Add(new ComponentChange(netId, EntityManager.GetComponentState(bus, component, component.SessionSpecific ? player : null), component.LastModifiedTick));
         }
 
-        return new EntityState(entityUid, changed, meta.EntityLastModifiedTick);
+        var entState = new EntityState(entityUid, changed, meta.EntityLastModifiedTick);
+
+        // TODO: should this respect NetSyncEnabled, SendOnlyToOwner & CanGetComponentState?
+        entState.NetComponents = new(EntityManager.GetNetComponentIds(entityUid));
+
+        return entState;
     }
 
     private EntityUid[] GetSessionViewers(ICommonSession session)

--- a/Robust.Shared/GameObjects/ComponentEventArgs.cs
+++ b/Robust.Shared/GameObjects/ComponentEventArgs.cs
@@ -44,9 +44,12 @@ namespace Robust.Shared.GameObjects
     {
         public readonly ComponentEventArgs BaseArgs;
 
-        public RemovedComponentEventArgs(ComponentEventArgs baseArgs)
+        public readonly bool Terminating;
+
+        public RemovedComponentEventArgs(ComponentEventArgs baseArgs, bool terminating)
         {
             BaseArgs = baseArgs;
+            Terminating = terminating;
         }
     }
 
@@ -54,9 +57,12 @@ namespace Robust.Shared.GameObjects
     {
         public readonly ComponentEventArgs BaseArgs;
 
-        public DeletedComponentEventArgs(ComponentEventArgs baseArgs)
+        public readonly bool Terminating;
+
+        public DeletedComponentEventArgs(ComponentEventArgs baseArgs, bool terminating)
         {
             BaseArgs = baseArgs;
+            Terminating = terminating;
         }
     }
 }

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -68,6 +68,12 @@ namespace Robust.Shared.GameObjects
         public GameTick LastStateApplied { get; internal set; } = GameTick.Zero;
 
         /// <summary>
+        ///     This is the most recent tick at which some component was removed from this entity.
+        /// </summary>
+        [ViewVariables]
+        public GameTick LastComponentRemoved { get; internal set; } = GameTick.Zero;
+
+        /// <summary>
         ///     The in-game name of this entity.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -945,8 +945,6 @@ namespace Robust.Shared.GameObjects
             return new NetComponentEnumerable(_netComponents[uid]);
         }
 
-        public IReadOnlyCollection<ushort> GetNetComponentIds(EntityUid uid) => _netComponents[uid].Keys;
-
         #region Join Functions
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -945,6 +945,8 @@ namespace Robust.Shared.GameObjects
             return new NetComponentEnumerable(_netComponents[uid]);
         }
 
+        public IReadOnlyCollection<ushort> GetNetComponentIds(EntityUid uid) => _netComponents[uid].Keys;
+
         #region Join Functions
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/EntityState.cs
+++ b/Robust.Shared/GameObjects/EntityState.cs
@@ -2,6 +2,7 @@ using Robust.Shared.Serialization;
 using System;
 using NetSerializer;
 using Robust.Shared.Timing;
+using System.Collections.Generic;
 
 namespace Robust.Shared.GameObjects
 {
@@ -15,6 +16,12 @@ namespace Robust.Shared.GameObjects
         public bool Empty => ComponentChanges.Value is null or { Count: 0 };
 
         public readonly GameTick EntityLastModified;
+
+        /// <summary>
+        ///     Set of all networked component ids. Only sent to clients if a component has been removed sometime since the
+        ///     entity was last sent to a player.
+        /// </summary>
+        public HashSet<ushort>? NetComponents = null;
 
         public EntityState(EntityUid uid, NetListAsArray<ComponentChange> changedComponents, GameTick lastModified)
         {

--- a/Robust.Shared/GameObjects/EntityState.cs
+++ b/Robust.Shared/GameObjects/EntityState.cs
@@ -29,20 +29,9 @@ namespace Robust.Shared.GameObjects
     {
         // 15ish bytes to create a component (strings are big), 5 bytes to remove one
 
-        /// <summary>
-        ///     Was the component removed from the entity.
-        /// </summary>
-        public readonly bool Deleted;
-
-        /// <summary>
-        /// Was the component added to the entity.
-        /// </summary>
-        public readonly bool Created;
-
-        /// <summary>
         /// State data for the created/modified component, if any.
         /// </summary>
-        public readonly ComponentState? State;
+        public readonly ComponentState State;
 
         /// <summary>
         ///     The Network ID of the component to remove.
@@ -51,33 +40,16 @@ namespace Robust.Shared.GameObjects
 
         public readonly GameTick LastModifiedTick;
 
-        public ComponentChange(ushort netId, bool created, bool deleted, ComponentState? state, GameTick lastModifiedTick)
+        public ComponentChange(ushort netId, ComponentState state, GameTick lastModifiedTick)
         {
-            Deleted = deleted;
             State = state;
             NetID = netId;
-            Created = created;
             LastModifiedTick = lastModifiedTick;
         }
 
         public override string ToString()
         {
-            return $"{(Deleted ? "D" : "C")} {NetID} {State?.GetType().Name}";
-        }
-
-        public static ComponentChange Added(ushort netId, ComponentState? state, GameTick lastModifiedTick)
-        {
-            return new(netId, true, false, state, lastModifiedTick);
-        }
-
-        public static ComponentChange Changed(ushort netId, ComponentState state, GameTick lastModifiedTick)
-        {
-            return new(netId, false, false, state, lastModifiedTick);
-        }
-
-        public static ComponentChange Removed(ushort netId)
-        {
-            return new(netId, false, true, null, default);
+            return $"{NetID} {State?.GetType().Name}";
         }
     }
 }

--- a/Robust.Shared/GameObjects/EntityState.cs
+++ b/Robust.Shared/GameObjects/EntityState.cs
@@ -21,13 +21,14 @@ namespace Robust.Shared.GameObjects
         ///     Set of all networked component ids. Only sent to clients if a component has been removed sometime since the
         ///     entity was last sent to a player.
         /// </summary>
-        public HashSet<ushort>? NetComponents = null;
+        public HashSet<ushort>? NetComponents;
 
-        public EntityState(EntityUid uid, NetListAsArray<ComponentChange> changedComponents, GameTick lastModified)
+        public EntityState(EntityUid uid, NetListAsArray<ComponentChange> changedComponents, GameTick lastModified, HashSet<ushort>? netComps = null)
         {
             Uid = uid;
             ComponentChanges = changedComponents;
             EntityLastModified = lastModified;
+            NetComponents = netComps;
         }
     }
 

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -359,11 +359,6 @@ namespace Robust.Shared.GameObjects
         NetComponentEnumerable GetNetComponents(EntityUid uid);
 
         /// <summary>
-        ///     Returns ALL networked components Ids on an entity.
-        /// </summary>
-        IReadOnlyCollection<ushort> GetNetComponentIds(EntityUid uid);
-
-        /// <summary>
         ///     Gets a component state.
         /// </summary>
         /// <param name="eventBus">A reference to the event bus instance.</param>

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -359,6 +359,11 @@ namespace Robust.Shared.GameObjects
         NetComponentEnumerable GetNetComponents(EntityUid uid);
 
         /// <summary>
+        ///     Returns ALL networked components Ids on an entity.
+        /// </summary>
+        IReadOnlyCollection<ushort> GetNetComponentIds(EntityUid uid);
+
+        /// <summary>
         ///     Gets a component state.
         /// </summary>
         /// <param name="eventBus">A reference to the event bus instance.</param>

--- a/Robust.Shared/GameStates/GameState.cs
+++ b/Robust.Shared/GameStates/GameState.cs
@@ -28,7 +28,6 @@ namespace Robust.Shared.GameStates
             NetListAsArray<EntityState> entities,
             NetListAsArray<PlayerState> players,
             NetListAsArray<EntityUid> deletions,
-            Dictionary<EntityUid, List<ushort>> componentDeletions,
             GameStateMapData? mapData)
         {
             FromSequence = fromSequence;
@@ -37,7 +36,6 @@ namespace Robust.Shared.GameStates
             EntityStates = entities;
             PlayerStates = players;
             EntityDeletions = deletions;
-            ComponentDeletions = componentDeletions;
             MapData = mapData;
         }
 
@@ -49,7 +47,6 @@ namespace Robust.Shared.GameStates
         public readonly NetListAsArray<EntityState> EntityStates;
         public readonly NetListAsArray<PlayerState> PlayerStates;
         public readonly NetListAsArray<EntityUid> EntityDeletions;
-        public readonly Dictionary<EntityUid, List<ushort>> ComponentDeletions;
         public readonly GameStateMapData? MapData;
     }
 }

--- a/Robust.Shared/GameStates/GameState.cs
+++ b/Robust.Shared/GameStates/GameState.cs
@@ -1,9 +1,10 @@
-﻿using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization;
 using System;
 using System.Diagnostics;
 using NetSerializer;
 using Robust.Shared.Timing;
+using System.Collections.Generic;
 
 namespace Robust.Shared.GameStates
 {
@@ -20,7 +21,15 @@ namespace Robust.Shared.GameStates
         /// <summary>
         /// Constructor!
         /// </summary>
-        public GameState(GameTick fromSequence, GameTick toSequence, uint lastInput, NetListAsArray<EntityState> entities, NetListAsArray<PlayerState> players, NetListAsArray<EntityUid> deletions, GameStateMapData? mapData)
+        public GameState(
+            GameTick fromSequence,
+            GameTick toSequence,
+            uint lastInput,
+            NetListAsArray<EntityState> entities,
+            NetListAsArray<PlayerState> players,
+            NetListAsArray<EntityUid> deletions,
+            Dictionary<EntityUid, List<ushort>> componentDeletions,
+            GameStateMapData? mapData)
         {
             FromSequence = fromSequence;
             ToSequence = toSequence;
@@ -28,6 +37,7 @@ namespace Robust.Shared.GameStates
             EntityStates = entities;
             PlayerStates = players;
             EntityDeletions = deletions;
+            ComponentDeletions = componentDeletions;
             MapData = mapData;
         }
 
@@ -39,6 +49,7 @@ namespace Robust.Shared.GameStates
         public readonly NetListAsArray<EntityState> EntityStates;
         public readonly NetListAsArray<PlayerState> PlayerStates;
         public readonly NetListAsArray<EntityUid> EntityDeletions;
+        public readonly Dictionary<EntityUid, List<ushort>> ComponentDeletions;
         public readonly GameStateMapData? MapData;
     }
 }

--- a/Robust.Shared/Map/NetworkedMapManager.cs
+++ b/Robust.Shared/Map/NetworkedMapManager.cs
@@ -126,9 +126,6 @@ internal sealed class NetworkedMapManager : MapManager, INetworkedMapManager
             {
                 foreach (var compChange in entityState.ComponentChanges.Span)
                 {
-                    if (!compChange.Created)
-                        continue;
-
                     if (compChange.State is MapComponentState mapCompState)
                     {
                         var mapEuid = entityState.Uid;

--- a/Robust.UnitTesting/Shared/GameObjects/EntityState_Tests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityState_Tests.cs
@@ -62,7 +62,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
                     new EntityUid(512),
                     new []
                     {
-                        new ComponentChange(0, true, false, new MapGridComponentState(new GridId(0), 16), default)
+                        new ComponentChange(0, new MapGridComponentState(new GridId(0), 16), default)
                     }, default);
 
                 serializer.Serialize(stream, payload);


### PR DESCRIPTION
See space-wizards/space-station-14/issues/11360

The main issue was that the PVS system only sent component removal messages to entities within PVS range, but would cull component deletion history based on the oldest acknowledged tick, so clients would just never receive component removal messages if the removal happened out of view. 

This PR fixes this by just sending the client a list of all networked component ids whenever some components have been removed since the entity was last sent to the client. While this is somewhat inefficient, component removal is pretty rare relative to state changes so its probably not too bad. Other possible fixes I can think of would be to either stop culling component deletion history, or sending deletion data to all clients, regardless of PVS range (as is done for entity deletions). I dislike the latter approach, because it effectively leaks data about out of view entities (e.g., status effect removal data would get sent to all clients).

This PR also fixes two other issues:
- Entities that were entering PVS range on the same tick that components were being removed weren't removing those components.
- The `ResetEnt` command/function did not remove components that were not in the most recent server state.

This PR also adds a `Terminating` bool to `RemovedComponentEventArgs` and `DeletedComponentEventArgs`, which helps speed up entity deletion a bit. 