### PR TITLE
Better sprite errors

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/ISpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/ISpriteComponent.cs
@@ -111,7 +111,7 @@ namespace Robust.Client.GameObjects
         /// <exception cref="ArgumentNullException">
         ///     Thrown if <paramref name="key"/> is null.
         /// </exception>
-        bool LayerMapTryGet(object key, out int layer);
+        bool LayerMapTryGet(object key, out int layer, bool logError = false);
 
         /// <summary>
         ///     Create a new blank layer and add it to the layer map,

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -673,10 +673,8 @@ namespace Robust.Client.GameObjects
         /// </summary>
         public void LayerSetData(int index, PrototypeLayerData layerDatum)
         {
-            if (!LayerExists(layer))
+            if (!TryGetLayer(index, out var layer))
                 return;
-
-            var layer = Layers[index];
 
             if (!string.IsNullOrWhiteSpace(layerDatum.RsiPath))
             {


### PR DESCRIPTION
Includes information about the relevant entity in some of the more common sprite errors.
Also condenses a bunch of the error logging code into just two functions. 