### PR TITLE
Add system to turn entites into error-signs

### DIFF
--- a/Resources/Locale/en-US/errors.ftl
+++ b/Resources/Locale/en-US/errors.ftl
@@ -1,0 +1,1 @@
+error-system-entity-description = This entity encountered an error. No, this isn't just a source reference. Please check your console and report the error to someone.

--- a/Robust.Client/GameObjects/EntitySystems/ClientErrorSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ClientErrorSystem.cs
@@ -1,0 +1,37 @@
+using System;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Localization;
+
+namespace Robust.Client.GameObjects;
+
+/// <summary>
+///     Basic system for visually communicating client-side errors to players, so that they hopefully get reported
+///     instead of just being unread error logs somewhere in the console.
+/// </summary>
+public sealed class ClientErrorSystem : EntitySystem
+{
+    /// <summary>
+    ///     Raises an error event and optionally modifies the entity's sprite and description to indicate to players
+    ///     that something has gone wrong.
+    /// </summary>
+    public void EntityError(EntityUid uid, Exception e, bool updateEntity)
+    {
+        RaiseLocalEvent(uid, new EntityErrorEvent(uid, e), true);
+
+        if (!updateEntity || !TryComp(uid, out MetaDataComponent? meta))
+            return;
+
+        meta.NetSyncEnabled = false;
+        meta.EntityName = $"ERROR - {ToPrettyString(uid)}";
+        meta.EntityDescription = Loc.GetString("error-system-entity-description");
+
+        if (!TryComp(uid, out SpriteComponent? sprite))
+            return;
+
+        sprite.NetSyncEnabled = false;
+        var index = sprite.AddLayer("error", "/Textures/error.rsi");
+        sprite.LayerSetShader(index, "unshaded");
+    }
+}
+
+public sealed record EntityErrorEvent(EntityUid Entity, Exception Exception);

--- a/Robust.Client/GameObjects/EntitySystems/ClientErrorSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ClientErrorSystem.cs
@@ -14,7 +14,7 @@ public sealed class ClientErrorSystem : EntitySystem
     ///     Raises an error event and optionally modifies the entity's sprite and description to indicate to players
     ///     that something has gone wrong.
     /// </summary>
-    public void EntityError(EntityUid uid, Exception e, bool updateEntity)
+    public void NotifyEntityError(EntityUid uid, Exception e, bool updateEntity)
     {
         RaiseLocalEvent(uid, new EntityErrorEvent(uid, e), true);
 

--- a/Robust.Client/GameObjects/EntitySystems/ClientErrorSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ClientErrorSystem.cs
@@ -12,10 +12,12 @@ public sealed class ClientErrorSystem : EntitySystem
 {
     /// <summary>
     ///     Raises an error event and optionally modifies the entity's sprite and description to indicate to players
-    ///     that something has gone wrong.
+    ///     that something has gone wrong. Note that if this modifies the entity, then the player has to reconnect in
+    ///     order to properly reset the entity. So this should only be used for relatively significant errors.
     /// </summary>
-    public void NotifyEntityError(EntityUid uid, Exception e, bool updateEntity)
+    public void NotifyEntityError(EntityUid uid, Exception e, bool updateEntity = false)
     {
+        // SubnauticaSystem when?
         RaiseLocalEvent(uid, new EntityErrorEvent(uid, e), true);
 
         if (!updateEntity || !TryComp(uid, out MetaDataComponent? meta))

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -957,11 +957,16 @@ namespace Robust.Client.GameStates
                 }
                 catch (Exception e)
                 {
-#if EXCEPTION_TOLERANCE
-                        _sawmill.Error($"Failed to apply comp state: entity={comp.Owner}, comp={comp.GetType()}");
-                        _runtimeLog.LogException(e, $"{nameof(ClientGameStateManager)}.{nameof(HandleEntityState)}");
-#else
                     _sawmill.Error($"Failed to apply comp state: entity={comp.Owner}, comp={comp.GetType()}");
+
+                    // There may be client-side state application errors. Sometimes these are relatively unnoticeable in
+                    // release mode, and they obviously don't show up in sever logs. So we will update the client's
+                    // sprite in the hopes that they actually open the console and report bugs for once.
+                    _entitySystemManager.GetEntitySystem<ClientErrorSystem>().NotifyEntityError(comp.Owner, e, true);
+
+#if EXCEPTION_TOLERANCE
+                    _runtimeLog.LogException(e, $"{nameof(ClientGameStateManager)}.{nameof(HandleEntityState)}");
+#else
                     throw;
 #endif
                 }


### PR DESCRIPTION
This adds a client-side system that provides a function to update an entity's sprite, name, and raise an event to indicate that some error has occurred.

The main use of this is to try combat niche/rare client-side errors that simply don't get reported because they might not have a clearly noticeable impact on the game (and most people won't casually check the console for errors). I dunno if this is the best way to go about it, there might be better ways of trying track them.

Also, maybe this should just be an event defined in engine, with content event handlers?