### PR TITLE
Add build property to use system SQLite3

### DIFF
--- a/MSBuild/Robust.DefineConstants.targets
+++ b/MSBuild/Robust.DefineConstants.targets
@@ -26,4 +26,7 @@
   <PropertyGroup Condition="'$(EnableClientScripting)' == 'True'">
     <DefineConstants>$(DefineConstants);CLIENT_SCRIPTING</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(UseSystemSqlite)' == 'True'">
+    <DefineConstants>$(DefineConstants);USE_SYSTEM_SQLITE</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/MSBuild/Robust.Properties.targets
+++ b/MSBuild/Robust.Properties.targets
@@ -16,6 +16,11 @@
         <ActualOS>MacOS</ActualOS>
       </PropertyGroup>
     </When>
+    <When Condition="$([MSBuild]::IsOSPlatform('FreeBSD'))">
+      <PropertyGroup>
+        <ActualOS>FreeBSD</ActualOS>
+      </PropertyGroup>
+    </When>
     <Otherwise>
       <PropertyGroup>
         <ActualOS>Linux</ActualOS>
@@ -30,5 +35,6 @@
     <EnableClientScripting>True</EnableClientScripting>
     <!-- Client scripting is disabled on full release builds for security and size reasons. -->
     <EnableClientScripting Condition="'$(FullRelease)' == 'True'">False</EnableClientScripting>
+    <UseSystemSqlite Condition="'$(TargetOS)' == 'FreeBSD'">True</UseSystemSqlite>
   </PropertyGroup>
 </Project>

--- a/Robust.Client/Console/Commands/LauncherAuthCommand.cs
+++ b/Robust.Client/Console/Commands/LauncherAuthCommand.cs
@@ -22,6 +22,9 @@ namespace Robust.Client.Console.Commands
             var basePath = Path.GetDirectoryName(UserDataDir.GetUserDataDir())!;
             var dbPath = Path.Combine(basePath, "launcher", "settings.db");
 
+#if USE_SYSTEM_SQLITE
+            SQLitePCL.raw.SetProvider(new SQLitePCL.SQLite3Provider_sqlite3());
+#endif
             using var con = new SqliteConnection($"Data Source={dbPath};Mode=ReadOnly");
             con.Open();
             using var cmd = con.CreateCommand();

--- a/Robust.Client/Robust.Client.csproj
+++ b/Robust.Client/Robust.Client.csproj
@@ -14,7 +14,9 @@
   <ItemGroup>
     <PackageReference Include="DiscordRichPresence" Version="1.0.175" />
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="6.0.9" />
+    <PackageReference Include="SQLitePCLRaw.provider.sqlite3" Version="2.1.2" Condition="'$(UseSystemSqlite)' == 'True'" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.2" Condition="'$(UseSystemSqlite)' != 'True'" />
     <PackageReference Include="nfluidsynth" Version="0.3.1" />
     <PackageReference Include="NVorbis" Version="0.10.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />

--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -13,7 +13,9 @@
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" PrivateAssets="All" />
     <PackageReference Include="SpaceWizards.HttpListener" Version="0.1.0" />
     <!--  -->
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.7" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="6.0.9" />
+    <PackageReference Include="SQLitePCLRaw.provider.sqlite3" Version="2.1.2" Condition="'$(UseSystemSqlite)' == 'True'" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.2" Condition="'$(UseSystemSqlite)' != 'True'" />
     <PackageReference Include="prometheus-net" Version="4.1.1" />
     <PackageReference Include="Serilog.Sinks.Loki" Version="4.0.0-beta3" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />


### PR DESCRIPTION
SQLitePCLRaw.bundle_e_sqlite3 does not bundle native SQLite3 shared libraries for all .NET platforms. Add a build property that uses the system SQLite3 library PCL and enable it by default for FreeBSD.