### PR TITLE
Fix map loader entity dirtying

### DIFF
--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -465,11 +465,8 @@ namespace Robust.Server.Maps
                                 // Though it's still in the prototype itself so creation doesn't need to be sent.
                                 castComp.ClearCreationTick();
                             }
-                            else
-                            {
-                                // New component that the prototype normally does not have, need to sync full data.
-                                continue;
-                            }
+
+                            continue;
                         }
 
                         // This component is not modified by the map file,


### PR DESCRIPTION
Currently map loader is incorrectly marking some entities as unmodified relative to the entity prototype. This means that some data that is present in the map yaml never gets sent to clients.

This caused the mispredicts in space-wizards/space-station-14/issues/11731, but has nothing to do with the fixture / interaction issue.