### PR TITLE
Remove Dirty(comp) on component init.

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -536,7 +536,7 @@ namespace Robust.Client.GameStates
                 }
 
                 var meta = query.GetComponent(entity);
-                DebugTools.Assert(meta.LastModifiedTick > _timing.LastRealTick || meta.LastModifiedTick == GameTick.Zero);
+                DebugTools.Assert(meta.EntityLastModifiedTick > _timing.LastRealTick);
                 meta.EntityLastModifiedTick = _timing.LastRealTick;
             }
 

--- a/Robust.Shared/GameObjects/Component.cs
+++ b/Robust.Shared/GameObjects/Component.cs
@@ -65,6 +65,8 @@ namespace Robust.Shared.GameObjects
 
             LifeStage = ComponentLifeStage.Adding;
             CreationTick = entManager.CurrentTick;
+            // networked components are assumed to be dirty when added to entities. See also: ClearTicks()
+            LastModifiedTick = entManager.CurrentTick;
             entManager.EventBus.RaiseComponentEvent(this, type, CompAddInstance);
             LifeStage = ComponentLifeStage.Added;
         }

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -337,6 +337,9 @@ namespace Robust.Shared.GameObjects
             if (!metadata.EntityInitialized && !metadata.EntityInitializing)
                 return;
 
+            if (component.Networked)
+                Dirty(uid, metadata);
+
             component.LifeInitialize(this, reg.Idx);
 
             if (metadata.EntityInitialized)

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -338,7 +338,7 @@ namespace Robust.Shared.GameObjects
                 return;
 
             if (component.Networked)
-                Dirty(uid, metadata);
+                DirtyEntity(uid, metadata);
 
             component.LifeInitialize(this, reg.Idx);
 

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -117,10 +117,6 @@ namespace Robust.Shared.GameObjects
             DebugTools.Assert(metadata.EntityLifeStage == EntityLifeStage.PreInit);
             metadata.EntityLifeStage = EntityLifeStage.Initializing;
 
-            // ensure that modified networked components get sent when PVS is disabled:
-            metadata.EntityLastModifiedTick = _gameTiming.CurTick;
-            EntityDirtied?.Invoke(uid);
-
             // Initialize() can modify the collection of components. Copy them.
             FixedArray32<Component?> compsFixed = default;
 


### PR DESCRIPTION
This mainly just removes a `Dirty(component)` call inside of `AddComponentInternal()`, which should slightly speed up entity spawning by avoiding fetching the meta-data component for each networked component that an entity has,