### PR TITLE
Got Inserted Event for containers

### DIFF
--- a/Robust.Shared/Containers/BaseContainer.cs
+++ b/Robust.Shared/Containers/BaseContainer.cs
@@ -127,6 +127,9 @@ namespace Robust.Shared.Containers
             transform.LocalPosition = Vector2.Zero;
             transform.LocalRotation = Angle.Zero;
 
+            var gotInsertedEvent = new GotInsertedEvent(toinsert, this);
+            entMan.EventBus.RaiseLocalEvent(toinsert, gotInsertedEvent, true);
+
             DebugTools.Assert(!physicsQuery.TryGetComponent(toinsert, out var phys) || !phys.Awake);
             return true;
         }

--- a/Robust.Shared/Containers/BaseContainer.cs
+++ b/Robust.Shared/Containers/BaseContainer.cs
@@ -115,9 +115,6 @@ namespace Robust.Shared.Containers
             transform.AttachParent(ownerTransform);
             InternalInsert(toinsert, oldParent, entMan);
 
-            var gotInsertedEvent = new EntGotInsertedIntoContainerMessage(toinsert, this);
-            entMan.EventBus.RaiseLocalEvent(toinsert, gotInsertedEvent, true);
-
             // the transform.AttachParent() could previously result in the flag being unset, so check that this hasn't happened.
             DebugTools.Assert((meta.Flags & MetaDataFlags.InContainer) != 0);
 
@@ -278,6 +275,8 @@ namespace Robust.Shared.Containers
         {
             DebugTools.Assert(!Deleted);
             entMan.EventBus.RaiseLocalEvent(Owner, new EntInsertedIntoContainerMessage(toinsert, oldParent, this), true);
+            var gotInsertedEvent = new EntGotInsertedIntoContainerMessage(toinsert, this);
+            entMan.EventBus.RaiseLocalEvent(toinsert, gotInsertedEvent, true);
             Manager.Dirty(entMan);
         }
 

--- a/Robust.Shared/Containers/BaseContainer.cs
+++ b/Robust.Shared/Containers/BaseContainer.cs
@@ -115,6 +115,9 @@ namespace Robust.Shared.Containers
             transform.AttachParent(ownerTransform);
             InternalInsert(toinsert, oldParent, entMan);
 
+            var gotInsertedEvent = new EntGotInsertedIntoContainerMessage(toinsert, this);
+            entMan.EventBus.RaiseLocalEvent(toinsert, gotInsertedEvent, true);
+
             // the transform.AttachParent() could previously result in the flag being unset, so check that this hasn't happened.
             DebugTools.Assert((meta.Flags & MetaDataFlags.InContainer) != 0);
 
@@ -126,9 +129,6 @@ namespace Robust.Shared.Containers
             // calling code can save the local position before calling this function, and apply it afterwords.
             transform.LocalPosition = Vector2.Zero;
             transform.LocalRotation = Angle.Zero;
-
-            var gotInsertedEvent = new GotInsertedEvent(toinsert, this);
-            entMan.EventBus.RaiseLocalEvent(toinsert, gotInsertedEvent, true);
 
             DebugTools.Assert(!physicsQuery.TryGetComponent(toinsert, out var phys) || !phys.Awake);
             return true;

--- a/Robust.Shared/Containers/Events/EntGotInsertedIntoContainerMessage.cs
+++ b/Robust.Shared/Containers/Events/EntGotInsertedIntoContainerMessage.cs
@@ -7,7 +7,7 @@ namespace Robust.Shared.Containers;
 /// Directed at the entity that was inserted successfully.
 /// </summary>
 [PublicAPI]
-public sealed class GotInsertedEvent : ContainerModifiedMessage
+public sealed class EntGotInsertedIntoContainerMessage : ContainerModifiedMessage
 {
-    public GotInsertedEvent(EntityUid entity, IContainer container) : base(entity, container) { }
+    public EntGotInsertedIntoContainerMessage(EntityUid entity, IContainer container) : base(entity, container) { }
 }

--- a/Robust.Shared/Containers/Events/GotInsertedEvent.cs
+++ b/Robust.Shared/Containers/Events/GotInsertedEvent.cs
@@ -1,0 +1,13 @@
+﻿using JetBrains.Annotations;
+using Robust.Shared.GameObjects;
+
+namespace Robust.Shared.Containers;
+
+/// <summary>
+/// Directed at the entity that was inserted successfully.
+/// </summary>
+[PublicAPI]
+public sealed class GotInsertedEvent : ContainerModifiedMessage
+{
+    public GotInsertedEvent(EntityUid entity, IContainer container) : base(entity, container) { }
+}


### PR DESCRIPTION
This event is raised on the entity that got inserted. It's good for entities that need to run code when they're inserted, but not on an attempt or on the owner of the container.

Needed for https://github.com/space-wizards/space-station-14/pull/11770