### PR TITLE
Use invariant culture in serialization

### DIFF
--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Box2Serializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Box2Serializer.cs
@@ -45,10 +45,10 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
                 return new ErrorNode(node, "Invalid amount of args for Box2.");
             }
 
-            return float.TryParse(args[0], out _) &&
-                   float.TryParse(args[1], out _) &&
-                   float.TryParse(args[2], out _) &&
-                   float.TryParse(args[3], out _)
+            return float.TryParse(args[0], NumberStyles.Any, CultureInfo.InvariantCulture, out _) &&
+                   float.TryParse(args[1], NumberStyles.Any, CultureInfo.InvariantCulture, out _) &&
+                   float.TryParse(args[2], NumberStyles.Any, CultureInfo.InvariantCulture, out _) &&
+                   float.TryParse(args[3], NumberStyles.Any, CultureInfo.InvariantCulture, out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, "Failed parsing values of Box2.");
         }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Box2Serializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Box2Serializer.cs
@@ -8,6 +8,7 @@ using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations
 {
@@ -26,10 +27,10 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
                 throw new InvalidMappingException($"Could not parse {nameof(Box2)}: '{node.Value}'");
             }
 
-            var l = float.Parse(args[0], CultureInfo.InvariantCulture);
-            var b = float.Parse(args[1], CultureInfo.InvariantCulture);
-            var r = float.Parse(args[2], CultureInfo.InvariantCulture);
-            var t = float.Parse(args[3], CultureInfo.InvariantCulture);
+            var l = Parse.Float(args[0]);
+            var b = Parse.Float(args[1]);
+            var r = Parse.Float(args[2]);
+            var t = Parse.Float(args[3]);
 
             return new Box2(l, b, r, t);
         }
@@ -45,10 +46,10 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
                 return new ErrorNode(node, "Invalid amount of args for Box2.");
             }
 
-            return float.TryParse(args[0], NumberStyles.Any, CultureInfo.InvariantCulture, out _) &&
-                   float.TryParse(args[1], NumberStyles.Any, CultureInfo.InvariantCulture, out _) &&
-                   float.TryParse(args[2], NumberStyles.Any, CultureInfo.InvariantCulture, out _) &&
-                   float.TryParse(args[3], NumberStyles.Any, CultureInfo.InvariantCulture, out _)
+            return Parse.TryFloat(args[0], out _) &&
+                   Parse.TryFloat(args[1], out _) &&
+                   Parse.TryFloat(args[2], out _) &&
+                   Parse.TryFloat(args[3], out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, "Failed parsing values of Box2.");
         }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/MapIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/MapIdSerializer.cs
@@ -8,6 +8,7 @@ using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations
 {
@@ -19,7 +20,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             bool skipHook,
             ISerializationContext? context = null, MapId value = default)
         {
-            var val = int.Parse(node.Value, CultureInfo.InvariantCulture);
+            var val = Parse.Int32(node.Value);
             return new MapId(val);
         }
 
@@ -27,7 +28,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             IDependencyCollection dependencies,
             ISerializationContext? context = null)
         {
-            return int.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
+            return Parse.TryInt32(node.Value, out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, "Failed parsing MapId");
         }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/MapIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/MapIdSerializer.cs
@@ -27,7 +27,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             IDependencyCollection dependencies,
             ISerializationContext? context = null)
         {
-            return int.TryParse(node.Value, out _)
+            return int.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, "Failed parsing MapId");
         }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/DecimalSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/DecimalSerializer.cs
@@ -15,7 +15,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
-            return decimal.TryParse(node.Value, out _)
+            return decimal.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, $"Failed parsing decimal value: {node.Value}");
         }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/DecimalSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/DecimalSerializer.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
 {
@@ -15,7 +16,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
-            return decimal.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
+            return Parse.TryDecimal(node.Value, out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, $"Failed parsing decimal value: {node.Value}");
         }
@@ -23,7 +24,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public decimal Read(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, bool skipHook, ISerializationContext? context = null, decimal value = default)
         {
-            return decimal.Parse(node.Value, CultureInfo.InvariantCulture);
+            return Parse.Decimal(node.Value);
         }
 
         public DataNode Write(ISerializationManager serializationManager, decimal value,

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/DoubleSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/DoubleSerializer.cs
@@ -15,7 +15,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
-            return double.TryParse(node.Value, out _)
+            return double.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, $"Failed parsing double value: {node.Value}");
         }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/DoubleSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/DoubleSerializer.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
 {
@@ -15,7 +16,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
-            return double.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
+            return Parse.TryDouble(node.Value, NumberStyles.Any, out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, $"Failed parsing double value: {node.Value}");
         }
@@ -23,7 +24,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public double Read(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, bool skipHook, ISerializationContext? context = null, double value = default)
         {
-            return double.Parse(node.Value, CultureInfo.InvariantCulture);
+            return Parse.Double(node.Value);
         }
 
         public DataNode Write(ISerializationManager serializationManager, double value,

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/IntSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/IntSerializer.cs
@@ -15,7 +15,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
-            return int.TryParse(node.Value, out _)
+            return int.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, $"Failed parsing int value: {node.Value}");
         }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/IntSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/IntSerializer.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
 {
@@ -15,7 +16,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
-            return int.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
+            return Parse.TryInt32(node.Value, out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, $"Failed parsing int value: {node.Value}");
         }
@@ -23,7 +24,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public int Read(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, bool skipHook, ISerializationContext? context = null, int value = default)
         {
-            return int.Parse(node.Value, CultureInfo.InvariantCulture);
+            return Parse.Int32(node.Value);
         }
 
         public DataNode Write(ISerializationManager serializationManager, int value, IDependencyCollection dependencies,

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/LongSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/LongSerializer.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
 {
@@ -15,7 +16,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
-            return long.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
+            return Parse.TryInt64(node.Value, out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, $"Failed parsing long value: {node.Value}");
         }
@@ -23,7 +24,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public long Read(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, bool skipHook, ISerializationContext? context = null, long value = default)
         {
-            return long.Parse(node.Value, CultureInfo.InvariantCulture);
+            return Parse.Int64(node.Value);
         }
 
         public DataNode Write(ISerializationManager serializationManager, long value,

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/LongSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/LongSerializer.cs
@@ -15,7 +15,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
-            return long.TryParse(node.Value, out _)
+            return long.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, $"Failed parsing long value: {node.Value}");
         }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/ShortSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/ShortSerializer.cs
@@ -15,7 +15,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
-            return short.TryParse(node.Value, out _)
+            return short.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, $"Failed parsing short value: {node.Value}");
         }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/ShortSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/ShortSerializer.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
 {
@@ -15,7 +16,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
-            return short.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
+            return Parse.TryInt16(node.Value, out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, $"Failed parsing short value: {node.Value}");
         }
@@ -23,7 +24,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public short Read(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, bool skipHook, ISerializationContext? context = null, short value = default)
         {
-            return short.Parse(node.Value, CultureInfo.InvariantCulture);
+            return Parse.Int16(node.Value);
         }
 
         public DataNode Write(ISerializationManager serializationManager, short value,

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/UIntSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/UIntSerializer.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
 {
@@ -15,7 +16,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
-            return uint.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
+            return Parse.TryUInt32(node.Value, out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, $"Failed parsing unsigned int value: {node.Value}");
         }
@@ -23,7 +24,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public uint Read(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, bool skipHook, ISerializationContext? context = null, uint value = default)
         {
-            return uint.Parse(node.Value, CultureInfo.InvariantCulture);
+            return Parse.UInt32(node.Value);
         }
 
         public DataNode Write(ISerializationManager serializationManager, uint value,

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/UIntSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/UIntSerializer.cs
@@ -15,7 +15,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
-            return uint.TryParse(node.Value, out _)
+            return uint.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, $"Failed parsing unsigned int value: {node.Value}");
         }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/ULongSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/ULongSerializer.cs
@@ -15,7 +15,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
-            return ulong.TryParse(node.Value, out _)
+            return ulong.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, $"Failed parsing unsigned long value: {node.Value}");
         }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/ULongSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/ULongSerializer.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
 {
@@ -15,7 +16,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
-            return ulong.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
+            return Parse.TryUInt64(node.Value, out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, $"Failed parsing unsigned long value: {node.Value}");
         }
@@ -23,7 +24,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public ulong Read(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, bool skipHook, ISerializationContext? context = null, ulong value = default)
         {
-            return ulong.Parse(node.ToString(), CultureInfo.InvariantCulture);
+            return Parse.UInt64(node.ToString());
         }
 
         public DataNode Write(ISerializationManager serializationManager, ulong value,

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/UShortSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/UShortSerializer.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
 {
@@ -15,7 +16,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
-            return ushort.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
+            return Parse.TryUInt16(node.Value, out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, $"Failed parsing unsigned short value: {node.Value}");
         }
@@ -23,7 +24,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public ushort Read(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, bool skipHook, ISerializationContext? context = null, ushort value = default)
         {
-            return ushort.Parse(node.Value, CultureInfo.InvariantCulture);
+            return Parse.UInt16(node.Value);
         }
 
         public DataNode Write(ISerializationManager serializationManager, ushort value,

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/UShortSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/UShortSerializer.cs
@@ -15,7 +15,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive
         public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
-            return ushort.TryParse(node.Value, out _)
+            return ushort.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, $"Failed parsing unsigned short value: {node.Value}");
         }

--- a/Robust.Shared/Utility/Parse.cs
+++ b/Robust.Shared/Utility/Parse.cs
@@ -98,7 +98,7 @@ public static class Parse
         return long.Parse(text, style, CultureInfo.InvariantCulture);
     }
 
-    // ULONG64
+    // UINT64
 
     public static bool TryUInt64(ReadOnlySpan<char> text, out ulong result)
     {

--- a/Robust.Shared/Utility/Parse.cs
+++ b/Robust.Shared/Utility/Parse.cs
@@ -13,6 +13,40 @@ namespace Robust.Shared.Utility;
 /// for the privilege of having code that isn't gonna break for French people.</remarks>
 public static class Parse
 {
+    // INT16
+
+    public static bool TryInt16(ReadOnlySpan<char> text, out short result)
+    {
+        return TryInt16(text, NumberStyles.Integer, out result);
+    }
+
+    public static bool TryInt16(ReadOnlySpan<char> text, NumberStyles style, out short result)
+    {
+        return short.TryParse(text, style, CultureInfo.InvariantCulture, out result);
+    }
+
+    public static short Int16(ReadOnlySpan<char> text, NumberStyles style = NumberStyles.Integer)
+    {
+        return short.Parse(text, style, CultureInfo.InvariantCulture);
+    }
+
+    // UINT16
+
+    public static bool TryUInt16(ReadOnlySpan<char> text, out ushort result)
+    {
+        return TryUInt16(text, NumberStyles.Integer, out result);
+    }
+
+    public static bool TryUInt16(ReadOnlySpan<char> text, NumberStyles style, out ushort result)
+    {
+        return ushort.TryParse(text, style, CultureInfo.InvariantCulture, out result);
+    }
+
+    public static ushort UInt16(ReadOnlySpan<char> text, NumberStyles style = NumberStyles.Integer)
+    {
+        return ushort.Parse(text, style, CultureInfo.InvariantCulture);
+    }
+
     // INT32
 
     public static bool TryInt32(ReadOnlySpan<char> text, out int result)
@@ -28,6 +62,23 @@ public static class Parse
     public static int Int32(ReadOnlySpan<char> text, NumberStyles style = NumberStyles.Integer)
     {
         return int.Parse(text, style, CultureInfo.InvariantCulture);
+    }
+
+    // UINT32
+
+    public static bool TryUInt32(ReadOnlySpan<char> text, out uint result)
+    {
+        return TryUInt32(text, NumberStyles.Integer, out result);
+    }
+
+    public static bool TryUInt32(ReadOnlySpan<char> text, NumberStyles style, out uint result)
+    {
+        return uint.TryParse(text, style, CultureInfo.InvariantCulture, out result);
+    }
+
+    public static uint UInt32(ReadOnlySpan<char> text, NumberStyles style = NumberStyles.Integer)
+    {
+        return uint.Parse(text, style, CultureInfo.InvariantCulture);
     }
 
     // INT64
@@ -46,6 +97,24 @@ public static class Parse
     {
         return long.Parse(text, style, CultureInfo.InvariantCulture);
     }
+
+    // ULONG64
+
+    public static bool TryUInt64(ReadOnlySpan<char> text, out ulong result)
+    {
+        return TryUInt64(text, NumberStyles.Integer, out result);
+    }
+
+    public static bool TryUInt64(ReadOnlySpan<char> text, NumberStyles style, out ulong result)
+    {
+        return ulong.TryParse(text, style, CultureInfo.InvariantCulture, out result);
+    }
+
+    public static ulong UInt64(ReadOnlySpan<char> text, NumberStyles style = NumberStyles.Integer)
+    {
+        return ulong.Parse(text, style, CultureInfo.InvariantCulture);
+    }
+
 
     // FLOAT
 
@@ -79,5 +148,22 @@ public static class Parse
     public static double Double(ReadOnlySpan<char> text, NumberStyles style = NumberStyles.Float)
     {
         return double.Parse(text, style, CultureInfo.InvariantCulture);
+    }
+
+    // DECIMAL
+
+    public static bool TryDecimal(ReadOnlySpan<char> text, out decimal result)
+    {
+        return TryDecimal(text, NumberStyles.Float, out result);
+    }
+
+    public static bool TryDecimal(ReadOnlySpan<char> text, NumberStyles style, out decimal result)
+    {
+        return decimal.TryParse(text, style, CultureInfo.InvariantCulture, out result);
+    }
+
+    public static decimal Decimal(ReadOnlySpan<char> text, NumberStyles style = NumberStyles.Float)
+    {
+        return decimal.Parse(text, style, CultureInfo.InvariantCulture);
     }
 }


### PR DESCRIPTION
Fixes serialization when using locales with comma separated floats