### PR TITLE
Make TransformComponent._localMatrix public

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -30,8 +30,30 @@ namespace Robust.Shared.GameObjects
         [DataField("anchored")]
         internal bool _anchored;
 
+        internal bool MatricesDirty = false;
         private Matrix3 _localMatrix = Matrix3.Identity;
         private Matrix3 _invLocalMatrix = Matrix3.Identity;
+
+        // these should just be system methods, but existing component functions like InvWorldMatrix still rely on
+        // getting these so those have to be fully ECS-ed first.
+        public Matrix3 LocalMatrix
+        {
+            get
+            {
+                if (MatricesDirty)
+                    RebuildMatrices();
+                return _localMatrix;
+            }
+        }
+        public Matrix3 InvLocalMatrix
+        {
+            get
+            {
+                if (MatricesDirty)
+                    RebuildMatrices();
+                return _invLocalMatrix;
+            }
+        }
 
         // used for lerping
 
@@ -124,7 +146,7 @@ namespace Robust.Shared.GameObjects
 
                 if (!DeferUpdates)
                 {
-                    RebuildMatrices();
+                    MatricesDirty = true;
                     var moveEvent = new MoveEvent(Owner, Coordinates, Coordinates, oldRotation, _localRotation, this, _gameTiming.ApplyingState);
                     _entMan.EventBus.RaiseLocalEvent(Owner, ref moveEvent, true);
                 }
@@ -211,12 +233,12 @@ namespace Robust.Shared.GameObjects
             {
                 var xformQuery = _entMan.GetEntityQuery<TransformComponent>();
                 var parent = _parent;
-                var myMatrix = _localMatrix;
+                var myMatrix = LocalMatrix;
 
                 while (parent.IsValid())
                 {
                     var parentXform = xformQuery.GetComponent(parent);
-                    var parentMatrix = parentXform._localMatrix;
+                    var parentMatrix = parentXform.LocalMatrix;
                     parent = parentXform.ParentUid;
 
                     Matrix3.Multiply(in myMatrix, in parentMatrix, out var result);
@@ -236,12 +258,12 @@ namespace Robust.Shared.GameObjects
             {
                 var xformQuery = _entMan.GetEntityQuery<TransformComponent>();
                 var parent = _parent;
-                var myMatrix = _invLocalMatrix;
+                var myMatrix = InvLocalMatrix;
 
                 while (parent.IsValid())
                 {
                     var parentXform = xformQuery.GetComponent(parent);
-                    var parentMatrix = parentXform._invLocalMatrix;
+                    var parentMatrix = parentXform.InvLocalMatrix;
                     parent = parentXform.ParentUid;
 
                     Matrix3.Multiply(in parentMatrix, in myMatrix, out var result);
@@ -366,7 +388,7 @@ namespace Robust.Shared.GameObjects
                 //  in regards to when to rebuild matrices.
                 // This may not in fact be the right thing.
                 if (changedParent || !DeferUpdates)
-                    RebuildMatrices();
+                    MatricesDirty = true;
 
                 Dirty(_entMan);
 
@@ -419,7 +441,7 @@ namespace Robust.Shared.GameObjects
 
                 if (!DeferUpdates)
                 {
-                    RebuildMatrices();
+                    MatricesDirty = true;
                     var moveEvent = new MoveEvent(Owner, oldGridPos, Coordinates, _localRotation, _localRotation, this, _gameTiming.ApplyingState);
                     _entMan.EventBus.RaiseLocalEvent(Owner, ref moveEvent, true);
                 }
@@ -540,7 +562,7 @@ namespace Robust.Shared.GameObjects
                 return;
             }
 
-            RebuildMatrices();
+            MatricesDirty = true;
 
             var moveEvent = new MoveEvent(Owner, _oldCoords ?? Coordinates, Coordinates, _oldLocalRotation ?? _localRotation, _localRotation, this, _gameTiming.ApplyingState);
             _entMan.EventBus.RaiseLocalEvent(Owner, ref moveEvent, true);
@@ -698,14 +720,14 @@ namespace Robust.Shared.GameObjects
         {
             var parent = _parent;
             var worldRot = _localRotation;
-            var worldMatrix = _localMatrix;
+            var worldMatrix = LocalMatrix;
 
             // By doing these all at once we can elide multiple IsValid + GetComponent calls
             while (parent.IsValid())
             {
                 var xform = xforms.GetComponent(parent);
                 worldRot += xform.LocalRotation;
-                var parentMatrix = xform._localMatrix;
+                var parentMatrix = xform.LocalMatrix;
                 Matrix3.Multiply(in worldMatrix, in parentMatrix, out var result);
                 worldMatrix = result;
                 parent = xform.ParentUid;
@@ -759,8 +781,8 @@ namespace Robust.Shared.GameObjects
         {
             var parent = _parent;
             var worldRot = _localRotation;
-            var invMatrix = _invLocalMatrix;
-            var worldMatrix = _localMatrix;
+            var invMatrix = InvLocalMatrix;
+            var worldMatrix = LocalMatrix;
 
             // By doing these all at once we can elide multiple IsValid + GetComponent calls
             while (parent.IsValid())
@@ -768,11 +790,11 @@ namespace Robust.Shared.GameObjects
                 var xform = xformQuery.GetComponent(parent);
                 worldRot += xform.LocalRotation;
 
-                var parentMatrix = xform._localMatrix;
+                var parentMatrix = xform.LocalMatrix;
                 Matrix3.Multiply(in worldMatrix, in parentMatrix, out var result);
                 worldMatrix = result;
 
-                var parentInvMatrix = xform._invLocalMatrix;
+                var parentInvMatrix = xform.InvLocalMatrix;
                 Matrix3.Multiply(in parentInvMatrix, in invMatrix, out var invResult);
                 invMatrix = invResult;
 
@@ -784,19 +806,18 @@ namespace Robust.Shared.GameObjects
             return (worldPosition, worldRot, worldMatrix, invMatrix);
         }
 
-        internal void RebuildMatrices()
+        private void RebuildMatrices()
         {
-            // TODO maybe just add a matrix dirty bool, and rebuild only when needed? I.e., if a lone entity is just
-            // drifting through space, do things even usually need to access both the local & inverse-local matrices??
-            var pos = _localPosition;
+            MatricesDirty = false;
 
             if (!_parent.IsValid()) // Root Node
-                pos = Vector2.Zero;
+            {
+                _localMatrix = Matrix3.Identity;
+                _invLocalMatrix = Matrix3.Identity;
+            }
 
-            var rot = (float)_localRotation.Theta;
-
-            _localMatrix = Matrix3.CreateTransform(pos.X, pos.Y, rot);
-            _invLocalMatrix = Matrix3.CreateInverseTransform(pos.X, pos.Y, rot);
+            _localMatrix = Matrix3.CreateTransform(_localPosition, _localRotation);
+            _invLocalMatrix = Matrix3.CreateInverseTransform(_localPosition, _localRotation);
         }
 
         public string GetDebugString()

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -232,7 +232,7 @@ public abstract partial class SharedTransformSystem
 
 
         SetGridId(component, component.FindGridEntityId(xformQuery));
-        component.RebuildMatrices();
+        component.MatricesDirty = true;
     }
 
     private void OnCompStartup(EntityUid uid, TransformComponent component, ComponentStartup args)
@@ -473,7 +473,7 @@ public abstract partial class SharedTransformSystem
 
             if (rebuildMatrices)
             {
-                component.RebuildMatrices();
+                component.MatricesDirty = true;
             }
 
             Dirty(component);
@@ -734,7 +734,7 @@ public abstract partial class SharedTransformSystem
 
         if (!xform.DeferUpdates)
         {
-            xform.RebuildMatrices();
+            xform.MatricesDirty = true;
             var moveEvent = new MoveEvent(xform.Owner, oldPosition, xform.Coordinates, oldRotation, rot, xform, _gameTiming.ApplyingState);
             RaiseLocalEvent(xform.Owner, ref moveEvent, true);
         }


### PR DESCRIPTION
Makes the transform component's local matrices public. Also makes `RebuildMatrices()` lazy. It now defers updating the matrices until they are actually required.