### PR TITLE
required changes for content benchmarks

### DIFF
--- a/Robust.Shared/ProgramShared.cs
+++ b/Robust.Shared/ProgramShared.cs
@@ -9,6 +9,8 @@ namespace Robust.Shared;
 
 internal static class ProgramShared
 {
+    public static string PathOffset = "";
+
     public static void RunExecCommands(IConsoleHost consoleHost, IReadOnlyList<string>? commands)
     {
         if (commands == null)
@@ -23,12 +25,12 @@ internal static class ProgramShared
 #if !FULL_RELEASE
     private static string FindContentRootDir(bool contentStart)
     {
-        return contentStart ? "../../" : "../../../";
+        return PathOffset + (contentStart ? "../../" : "../../../");
     }
 
     private static string FindEngineRootDir(bool contentStart)
     {
-        return contentStart ? "../../RobustToolbox/" : "../../";
+        return PathOffset + (contentStart ? "../../RobustToolbox/" : "../../");
     }
 #endif
 

--- a/Robust.UnitTesting/RobustIntegrationTest.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.cs
@@ -250,6 +250,8 @@ namespace Robust.UnitTesting
             private bool _isAlive = true;
             private Exception? _unhandledException;
 
+            public IDependencyCollection InstanceDependencyCollection => DependencyCollection;
+
             public virtual IntegrationOptions? Options { get; internal set; }
 
             /// <summary>


### PR DESCRIPTION
the pathoffset is needed due to benchmarkdotnet nesting its working directory in like 5 different layers. there probably is a more elegant solution, but this was hastily shitcoded.