### PR TITLE
Don't allocate a list per physics contact

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
@@ -197,8 +197,8 @@ namespace Robust.Shared.Physics.Systems
                     if (proxyA.Fixture.Hard && other.Fixture.Hard &&
                         (gridMoveBuffer.ContainsKey(proxyA) || gridMoveBuffer.ContainsKey(other)))
                     {
-                        proxyABody.WakeBody();
-                        otherBody.WakeBody();
+                        _physicsSystem.WakeBody(proxyABody);
+                        _physicsSystem.WakeBody(otherBody);
                     }
 
                     contactManager.AddPair(proxyA, other);
@@ -324,35 +324,35 @@ namespace Robust.Shared.Physics.Systems
             }
 
             var broadphaseComp = broadphaseQuery.GetComponent(broadphase);
+            var proxyPairs = pairBuffer.GetOrNew(proxy);
+            var state = (proxyPairs, pairBuffer, proxy);
 
-            foreach (var other in broadphaseComp.Tree.QueryAabb(aabb))
+            broadphaseComp.Tree.QueryAabb(ref state, static (
+                ref (HashSet<FixtureProxy> proxyPairs, Dictionary<FixtureProxy, HashSet<FixtureProxy>> pairBuffer, FixtureProxy proxy) tuple,
+                in FixtureProxy other) =>
             {
                 DebugTools.Assert(other.Fixture.Body.CanCollide);
                 // Logger.DebugS("physics", $"Checking {proxy.Fixture.Body.Owner} against {other.Fixture.Body.Owner} at {aabb}");
 
-                // Do fast checks first and slower checks after (in ContactManager).
-                if (proxy == other ||
-                    proxy.Fixture.Body == other.Fixture.Body ||
-                    !ContactManager.ShouldCollide(proxy.Fixture, other.Fixture)) continue;
+                if (tuple.proxy == other ||
+                    !ContactManager.ShouldCollide(tuple.proxy.Fixture, other.Fixture) ||
+                    tuple.proxy.Fixture.Body == other.Fixture.Body)
+                {
+                    return true;
+                }
 
                 // Don't add duplicates.
                 // Look it disgusts me but we can't do it Box2D's way because we're getting pairs
                 // with different broadphases so can't use Proxy sorting to skip duplicates.
-                // TODO: This needs to be better
-                if (pairBuffer.TryGetValue(other, out var existing) &&
-                    existing.Contains(proxy))
+                if (tuple.proxyPairs.Contains(other) ||
+                    tuple.pairBuffer.TryGetValue(other, out var otherPairs) && otherPairs.Contains(tuple.proxy))
                 {
-                    continue;
+                    return true;
                 }
 
-                if (!pairBuffer.TryGetValue(proxy, out var proxyExisting))
-                {
-                    proxyExisting = new HashSet<FixtureProxy>();
-                    pairBuffer[proxy] = proxyExisting;
-                }
-
-                proxyExisting.Add(other);
-            }
+                tuple.proxyPairs.Add(other);
+                return true;
+            }, aabb, true);
         }
 
         /// <summary>


### PR DESCRIPTION
Forgot to get around to this. no.2 on server allocs on tumbler testbed.