### PR TITLE
Remove IEnumerable abuse from entitylookup

### DIFF
--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -499,9 +499,12 @@ public sealed partial class EntityLookupSystem
                 return true;
             }, aabb, (flags & LookupFlags.Approximate) != 0x0);
 
-            foreach (var ent in grid.GetAnchoredEntities(index))
+            if ((flags & LookupFlags.Anchored) != 0x0)
             {
-                intersecting.Add(ent);
+                foreach (var ent in grid.GetAnchoredEntities(index))
+                {
+                    intersecting.Add(ent);
+                }
             }
         }
 

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -33,11 +33,11 @@ public sealed partial class EntityLookupSystem
         var localAABB = invMatrix.TransformBox(worldAABB);
 
         lookup.Tree.QueryAabb(ref intersecting,
-            static (ref HashSet<EntityUid> intersecting, in EntityUid value) =>
-            {
-                intersecting.Add(value);
-                return true;
-            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+        static (ref HashSet<EntityUid> intersecting, in EntityUid value) =>
+        {
+            intersecting.Add(value);
+            return true;
+        }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
     }
 
     private void AddEntitiesIntersecting(
@@ -53,11 +53,11 @@ public sealed partial class EntityLookupSystem
         var localAABB = invMatrix.TransformBox(worldBounds);
 
         lookup.Tree.QueryAabb(ref intersecting,
-            static (ref HashSet<EntityUid> intersecting, in EntityUid value) =>
-            {
-                intersecting.Add(value);
-                return true;
-            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+        static (ref HashSet<EntityUid> intersecting, in EntityUid value) =>
+        {
+            intersecting.Add(value);
+            return true;
+        }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
     }
 
     private bool AnyEntitiesIntersecting(EntityUid lookupUid,
@@ -69,8 +69,7 @@ public sealed partial class EntityLookupSystem
     {
         var lookup = lookupQuery.GetComponent(lookupUid);
         var localAABB = xformQuery.GetComponent(lookupUid).InvWorldMatrix.TransformBox(worldAABB);
-        var found = false;
-        var state = (ignored, found);
+        var state = (ignored, found: false);
 
         lookup.Tree.QueryAabb(ref state, static (ref (EntityUid? ignored, bool found) tuple, in EntityUid value) =>
         {
@@ -109,8 +108,7 @@ public sealed partial class EntityLookupSystem
     {
         var lookup = lookupQuery.GetComponent(lookupUid);
         var localAABB = xformQuery.GetComponent(lookupUid).InvWorldMatrix.TransformBox(worldBounds);
-        var found = false;
-        var state = (ignored, found);
+        var state = (ignored, found: false);
 
         lookup.Tree.QueryAabb(ref state, static (ref (EntityUid? ignored, bool found) tuple, in EntityUid value) =>
         {
@@ -136,7 +134,7 @@ public sealed partial class EntityLookupSystem
             }
         }
 
-        return found;
+        return state.found;
     }
 
     private void RecursiveAdd(EntityUid uid, ValueList<EntityUid> toAdd, EntityQuery<TransformComponent> xformQuery)

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -1,7 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using Robust.Shared.Collections;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
@@ -29,12 +29,15 @@ public sealed partial class EntityLookupSystem
         EntityQuery<TransformComponent> xformQuery)
     {
         var lookup = lookupQuery.GetComponent(lookupUid);
-        var localAABB = xformQuery.GetComponent(lookupUid).InvWorldMatrix.TransformBox(worldAABB);
+        var invMatrix = _transform.GetInvWorldMatrix(lookupUid, xformQuery);
+        var localAABB = invMatrix.TransformBox(worldAABB);
 
-        foreach (var ent in lookup.Tree.QueryAabb(localAABB, (flags & LookupFlags.Approximate) != 0x0))
-        {
-            intersecting.Add(ent);
-        }
+        lookup.Tree.QueryAabb(ref intersecting,
+            static (ref HashSet<EntityUid> intersecting, in EntityUid value) =>
+            {
+                intersecting.Add(value);
+                return true;
+            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
     }
 
     private void AddEntitiesIntersecting(
@@ -46,12 +49,15 @@ public sealed partial class EntityLookupSystem
         EntityQuery<TransformComponent> xformQuery)
     {
         var lookup = lookupQuery.GetComponent(lookupUid);
-        var localAABB = xformQuery.GetComponent(lookupUid).InvWorldMatrix.TransformBox(worldBounds);
+        var invMatrix = _transform.GetInvWorldMatrix(lookupUid, xformQuery);
+        var localAABB = invMatrix.TransformBox(worldBounds);
 
-        foreach (var ent in lookup.Tree.QueryAabb(localAABB, (flags & LookupFlags.Approximate) != 0x0))
-        {
-            intersecting.Add(ent);
-        }
+        lookup.Tree.QueryAabb(ref intersecting,
+            static (ref HashSet<EntityUid> intersecting, in EntityUid value) =>
+            {
+                intersecting.Add(value);
+                return true;
+            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
     }
 
     private bool AnyEntitiesIntersecting(EntityUid lookupUid,
@@ -63,12 +69,20 @@ public sealed partial class EntityLookupSystem
     {
         var lookup = lookupQuery.GetComponent(lookupUid);
         var localAABB = xformQuery.GetComponent(lookupUid).InvWorldMatrix.TransformBox(worldAABB);
+        var found = false;
+        var state = (ignored, found);
 
-        foreach (var uid in lookup.Tree.QueryAabb(localAABB, (flags & LookupFlags.Approximate) != 0x0))
+        lookup.Tree.QueryAabb(ref state, static (ref (EntityUid? ignored, bool found) tuple, in EntityUid value) =>
         {
-            if (uid == ignored) continue;
+            if (tuple.ignored == value)
+                return true;
+
+            tuple.found = true;
+            return false;
+        }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+
+        if (state.found)
             return true;
-        }
 
         if (!_mapManager.TryGetGrid(lookupUid, out var grid)) return false;
 
@@ -96,14 +110,18 @@ public sealed partial class EntityLookupSystem
         var lookup = lookupQuery.GetComponent(lookupUid);
         var localAABB = xformQuery.GetComponent(lookupUid).InvWorldMatrix.TransformBox(worldBounds);
         var found = false;
+        var state = (ignored, found);
 
-        lookup.Tree._b2Tree.Query(ref found, static (ref bool state, DynamicTree.Proxy _) =>
+        lookup.Tree.QueryAabb(ref state, static (ref (EntityUid? ignored, bool found) tuple, in EntityUid value) =>
         {
-            state = true;
-            return false;
-        }, localAABB);
+            if (tuple.ignored == value)
+                return true;
 
-        if (found)
+            tuple.found = true;
+            return false;
+        }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+
+        if (state.found)
             return true;
 
         if (_mapManager.TryGetGrid(lookupUid, out var grid))
@@ -121,7 +139,7 @@ public sealed partial class EntityLookupSystem
         return found;
     }
 
-    private void RecursiveAdd(EntityUid uid, List<EntityUid> toAdd, EntityQuery<TransformComponent> xformQuery)
+    private void RecursiveAdd(EntityUid uid, ValueList<EntityUid> toAdd, EntityQuery<TransformComponent> xformQuery)
     {
         var childEnumerator = xformQuery.GetComponent(uid).ChildEnumerator;
 
@@ -134,10 +152,10 @@ public sealed partial class EntityLookupSystem
 
     private void AddContained(HashSet<EntityUid> intersecting, LookupFlags flags, EntityQuery<TransformComponent> xformQuery)
     {
-        if ((flags & LookupFlags.Contained) == 0x0) return;
+        if ((flags & LookupFlags.Contained) == 0x0 || intersecting.Count == 0) return;
 
         var conQuery = GetEntityQuery<ContainerManagerComponent>();
-        var toAdd = new List<EntityUid>();
+        var toAdd = new ValueList<EntityUid>();
 
         foreach (var uid in intersecting)
         {
@@ -477,17 +495,15 @@ public sealed partial class EntityLookupSystem
         {
             var aabb = GetLocalBounds(index, tileSize);
 
-            lookup.Tree._b2Tree.FastQuery(ref aabb, (ref EntityUid data) =>
+            lookup.Tree.QueryAabb(ref intersecting, static (ref HashSet<EntityUid> intersecting, in EntityUid value) =>
             {
-                intersecting.Add(data);
-            });
+                intersecting.Add(value);
+                return true;
+            }, aabb, (flags & LookupFlags.Approximate) != 0x0);
 
-            if ((flags & LookupFlags.Anchored) != 0x0)
+            foreach (var ent in grid.GetAnchoredEntities(index))
             {
-                foreach (var ent in grid.GetAnchoredEntities(index))
-                {
-                    intersecting.Add(ent);
-                }
+                intersecting.Add(ent);
             }
         }
 
@@ -508,10 +524,13 @@ public sealed partial class EntityLookupSystem
         var aabb = GetLocalBounds(gridIndices, tileSize);
         var intersecting = new HashSet<EntityUid>();
 
-        lookup.Tree._b2Tree.FastQuery(ref aabb, (ref EntityUid data) =>
+        var state = (lookup.Tree._b2Tree, intersecting);
+
+        lookup.Tree._b2Tree.Query(ref state, static (ref (B2DynamicTree<EntityUid> _b2Tree, HashSet<EntityUid> intersecting) tuple, DynamicTree.Proxy proxy) =>
         {
-            intersecting.Add(data);
-        });
+            tuple.intersecting.Add(tuple._b2Tree.GetUserData(proxy));
+            return true;
+        }, aabb);
 
         if ((flags & LookupFlags.Anchored) != 0x0)
         {
@@ -588,10 +607,11 @@ public sealed partial class EntityLookupSystem
         var xformQuery = GetEntityQuery<TransformComponent>();
         var localAABB = xformQuery.GetComponent(component.Owner).InvWorldMatrix.TransformBox(worldAABB);
 
-        foreach (var uid in component.Tree.QueryAabb(localAABB, (flags & LookupFlags.Approximate) != 0x0))
+        component.Tree.QueryAabb(ref intersecting, static (ref HashSet<EntityUid> intersecting, in EntityUid value) =>
         {
-            intersecting.Add(uid);
-        }
+            intersecting.Add(value);
+            return true;
+        }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
 
         if ((flags & LookupFlags.Anchored) != 0x0 && _mapManager.TryGetGrid(component.Owner, out var grid))
         {
@@ -606,14 +626,15 @@ public sealed partial class EntityLookupSystem
         return intersecting;
     }
 
-    public HashSet<EntityUid> GetLocalEntitiesIntersecting(EntityLookupComponent component, ref Box2 localAABB, LookupFlags flags = DefaultFlags)
+    public HashSet<EntityUid> GetLocalEntitiesIntersecting(EntityLookupComponent component, Box2 localAABB, LookupFlags flags = DefaultFlags)
     {
         var intersecting = new HashSet<EntityUid>();
 
-        foreach (var uid in component.Tree.QueryAabb(localAABB, (flags & LookupFlags.Approximate) != 0x0))
+        component.Tree.QueryAabb(ref intersecting, static (ref HashSet<EntityUid> intersecting, in EntityUid value) =>
         {
-            intersecting.Add(uid);
-        }
+            intersecting.Add(value);
+            return true;
+        }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
 
         if ((flags & LookupFlags.Anchored) != 0x0 && _mapManager.TryGetGrid(component.Owner, out var grid))
         {

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -16,6 +16,7 @@ namespace Robust.Shared.GameObjects
     public enum LookupFlags : byte
     {
         None = 0,
+
         /// <summary>
         /// Should we use the approximately intersecting entities or check tighter bounds.
         /// </summary>
@@ -31,8 +32,6 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         Contained = 1 << 2,
         // IncludeGrids = 1 << 2,
-        // IncludePhysics (whenever it gets split off)
-        // Include maps
     }
 
     public sealed partial class EntityLookupSystem : EntitySystem

--- a/Robust.UnitTesting/Shared/EntityLookup_Test.cs
+++ b/Robust.UnitTesting/Shared/EntityLookup_Test.cs
@@ -12,6 +12,25 @@ namespace Robust.UnitTesting.Shared
     [TestFixture, TestOf(typeof(EntityLookupSystem))]
     public sealed class EntityLookupTest
     {
+        [Test]
+        public void AnyIntersecting()
+        {
+            var sim = RobustServerSimulation.NewSimulation();
+            var server = sim.InitializeInstance();
+
+            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
+            var entManager = server.Resolve<IEntityManager>();
+            var mapManager = server.Resolve<IMapManager>();
+
+            var mapId = mapManager.CreateMap();
+
+            var theMapSpotBeingUsed = new Box2(Vector2.Zero, Vector2.One);
+
+            var dummy = entManager.SpawnEntity(null, new MapCoordinates(Vector2.Zero, mapId));
+            Assert.That(lookup.AnyEntitiesIntersecting(mapId, theMapSpotBeingUsed));
+            mapManager.DeleteMap(mapId);
+        }
+
         /// <summary>
         /// If we don't pass an anchor flag do we still return an anchored entity
         /// </summary>


### PR DESCRIPTION
static lambdas are gud. At the time I was more worried about getting a decent API over allocations.

Whenever we stop duplicating entities across data structures in the future we can kill the hashsets too which will be very based.