### PR TITLE
Fix obsolete warnings in tests

### DIFF
--- a/Robust.UnitTesting/Shared/GameObjects/ContainerTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/ContainerTests.cs
@@ -49,7 +49,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
                  var mapMan = IoCManager.Resolve<IMapManager>();
                  var entMan = IoCManager.Resolve<IEntityManager>();
                  var playerMan = IoCManager.Resolve<IPlayerManager>();
-                 var containerSys = EntitySystem.Get<SharedContainerSystem>();
+                 var containerSys = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SharedContainerSystem>();
 
                  mapId = mapMan.CreateMap();
                  mapPos = new MapCoordinates((0, 0), mapId);
@@ -74,7 +74,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
              await server.WaitAssertion(() =>
              {
                  var entMan = IoCManager.Resolve<IEntityManager>();
-                 var containerSys = EntitySystem.Get<SharedContainerSystem>();
+                 var containerSys = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SharedContainerSystem>();
 
                  itemUid = entMan.SpawnEntity(null, mapPos);
                  entMan.GetComponent<MetaDataComponent>(itemUid).EntityName = "Item";
@@ -171,7 +171,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
                  var mapMan = IoCManager.Resolve<IMapManager>();
                  var entMan = IoCManager.Resolve<IEntityManager>();
                  var playerMan = IoCManager.Resolve<IPlayerManager>();
-                 var containerSys = EntitySystem.Get<SharedContainerSystem>();
+                 var containerSys = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SharedContainerSystem>();
 
                  mapId = mapMan.CreateMap();
                  mapPos = new MapCoordinates((0, 0), mapId);
@@ -196,7 +196,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
              await server.WaitAssertion(() =>
              {
                  var entMan = IoCManager.Resolve<IEntityManager>();
-                 var containerSys = EntitySystem.Get<SharedContainerSystem>();
+                 var containerSys = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SharedContainerSystem>();
 
                  itemUid = entMan.SpawnEntity(null, mapPos);
                  entMan.GetComponent<MetaDataComponent>(itemUid).EntityName = "Item";
@@ -232,11 +232,13 @@ namespace Robust.UnitTesting.Shared.GameObjects
              await server.WaitAssertion(() =>
              {
                  var entMan = IoCManager.Resolve<IEntityManager>();
+                 var containerSystem = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SharedContainerSystem>();
 
                  // If possible it'd be best to only have the DeleteEntity, but right now
                  // the entity deleted event is not played on the client if the entity does not exist on the client.
                  if (entMan.EntityExists(itemUid)
-                     && itemUid.TryGetContainer(out var container))
+                     // && itemUid.TryGetContainer(out var container))
+                     && containerSystem.TryGetContainingContainer(itemUid, out var container))
                      container.ForceRemove(itemUid);
                  entMan.DeleteEntity(itemUid);
              });

--- a/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
@@ -7,6 +7,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
 using Robust.UnitTesting.Server;
 
 // ReSharper disable AccessToStaticMemberViaDerivedType
@@ -352,6 +353,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             var (sim, gridId) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
             var mapMan = sim.Resolve<IMapManager>();
+            var physSystem = sim.Resolve<IEntitySystemManager>().GetEntitySystem<SharedPhysicsSystem>();
 
             var coordinates = new MapCoordinates(new Vector2(7, 7), TestMapId);
 
@@ -361,7 +363,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
 
             var ent1 = entMan.SpawnEntity(null, coordinates);
             var physComp = IoCManager.Resolve<IEntityManager>().AddComponent<PhysicsComponent>(ent1);
-            physComp.BodyType = BodyType.Dynamic;
+            physSystem.SetBodyType(physComp, BodyType.Dynamic);
 
             // Act
             IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored = true;

--- a/Robust.UnitTesting/Shared/Map/GridCollision_Test.cs
+++ b/Robust.UnitTesting/Shared/Map/GridCollision_Test.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
 
 namespace Robust.UnitTesting.Shared.Map
 {
@@ -20,6 +21,7 @@ namespace Robust.UnitTesting.Shared.Map
 
             var mapManager = server.ResolveDependency<IMapManager>();
             var entManager = server.ResolveDependency<IEntityManager>();
+            var physSystem = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<SharedPhysicsSystem>();
 
             MapId mapId;
             IMapGrid? gridId1 = null;
@@ -40,8 +42,8 @@ namespace Robust.UnitTesting.Shared.Map
                 physics2 = entManager.GetComponent<PhysicsComponent>(gridEnt2.Value);
                 // Can't collide static bodies and grids (at time of this writing) start as static
                 // (given most other games would probably prefer them as static) hence we need to make them dynamic.
-                physics1.BodyType = BodyType.Dynamic;
-                physics2.BodyType = BodyType.Dynamic;
+                physSystem.SetBodyType(physics1, BodyType.Dynamic);
+                physSystem.SetBodyType(physics2, BodyType.Dynamic);
             });
 
             await server.WaitRunTicks(1);

--- a/Robust.UnitTesting/Shared/Map/GridFixtures_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/GridFixtures_Tests.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
 
 namespace Robust.UnitTesting.Shared.Map
 {
@@ -23,6 +24,7 @@ namespace Robust.UnitTesting.Shared.Map
 
             var entManager = server.ResolveDependency<IEntityManager>();
             var mapManager = server.ResolveDependency<IMapManager>();
+            var physSystem = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<SharedPhysicsSystem>();
 
             await server.WaitAssertion(() =>
             {
@@ -57,7 +59,7 @@ namespace Robust.UnitTesting.Shared.Map
                 grid.SetTile(new Vector2i(0, -1), new Tile(1));
                 Assert.That(manager.FixtureCount, Is.EqualTo(2));
 
-                gridBody.LinearVelocity = Vector2.One;
+                physSystem.SetLinearVelocity(gridBody, Vector2.One);
                 Assert.That(gridBody.LinearVelocity.Length, Is.EqualTo(0f));
             });
         }

--- a/Robust.UnitTesting/Shared/Physics/Broadphase_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Broadphase_Test.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
 using Robust.UnitTesting.Server;
 
 namespace Robust.UnitTesting.Shared.Physics;
@@ -54,6 +55,7 @@ public sealed class Broadphase_Test
         var sim = RobustServerSimulation.NewSimulation().InitializeInstance();
         var entManager = sim.Resolve<IEntityManager>();
         var mapManager = sim.Resolve<IMapManager>();
+        var physicsSystem = sim.Resolve<IEntitySystemManager>().GetEntitySystem<SharedPhysicsSystem>();
 
         var mapId = mapManager.CreateMap();
         var grid = mapManager.CreateGrid(mapId);
@@ -75,7 +77,7 @@ public sealed class Broadphase_Test
         var child2 = entManager.SpawnEntity(null, new EntityCoordinates(child1, Vector2.Zero));
         var child2Xform = entManager.GetComponent<TransformComponent>(child2);
         var child2Body = entManager.AddComponent<PhysicsComponent>(child2);
-        child2Body.CanCollide = false;
+        physicsSystem.SetCanCollide(child2Body, false);
         Assert.That(!child2Body.CanCollide);
         Assert.That(child2Body.Broadphase, Is.EqualTo(null));
 
@@ -101,6 +103,7 @@ public sealed class Broadphase_Test
         var sim = RobustServerSimulation.NewSimulation().InitializeInstance();
         var entManager = sim.Resolve<IEntityManager>();
         var xformSystem = sim.Resolve<IEntitySystemManager>().GetEntitySystem<SharedTransformSystem>();
+        var physSystem = sim.Resolve<IEntitySystemManager>().GetEntitySystem<SharedPhysicsSystem>();
         var mapManager = sim.Resolve<IMapManager>();
 
         var mapId = mapManager.CreateMap();
@@ -121,7 +124,7 @@ public sealed class Broadphase_Test
         var child2 = entManager.SpawnEntity(null, new EntityCoordinates(child1, Vector2.Zero));
         var child2Xform = entManager.GetComponent<TransformComponent>(child2);
         var child2Body = entManager.AddComponent<PhysicsComponent>(child2);
-        child2Body.CanCollide = false;
+        physSystem.SetCanCollide(child2Body, false);
         Assert.That(!child2Body.CanCollide);
 
         Assert.That(child1Xform.ParentUid, Is.EqualTo(parent));

--- a/Robust.UnitTesting/Shared/Physics/Fixtures_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Fixtures_Test.cs
@@ -27,7 +27,7 @@ public sealed class Fixtures_Test
 
         var ent = sim.SpawnEntity(null, new MapCoordinates(Vector2.Zero, map));
         var body = entManager.AddComponent<PhysicsComponent>(ent);
-        body.BodyType = BodyType.Dynamic;
+        physicsSystem.SetBodyType(body, BodyType.Dynamic);
         var fixture = new Fixture();
         fixturesSystem.CreateFixture(body, fixture);
 

--- a/Robust.UnitTesting/Shared/Physics/GridDeletion_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/GridDeletion_Test.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
 
 namespace Robust.UnitTesting.Shared.Physics;
 
@@ -24,6 +25,9 @@ public sealed class GridDeletion_Test : RobustIntegrationTest
 
         var entManager = server.ResolveDependency<IEntityManager>();
         var mapManager = server.ResolveDependency<IMapManager>();
+        var physSystem = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<SharedPhysicsSystem>();
+
+
         PhysicsComponent physics = default!;
         IMapGrid grid = default!;
         MapId mapId = default!;
@@ -34,8 +38,8 @@ public sealed class GridDeletion_Test : RobustIntegrationTest
             grid = mapManager.CreateGrid(mapId);
 
             physics = entManager.GetComponent<PhysicsComponent>(grid.GridEntityId);
-            physics.BodyType = BodyType.Dynamic;
-            physics.LinearVelocity = new Vector2(50f, 0f);
+            physSystem.SetBodyType(physics, BodyType.Dynamic);
+            physSystem.SetLinearVelocity(physics, new Vector2(50f, 0f));
             Assert.That(physics.LinearVelocity.Length, NUnit.Framework.Is.GreaterThan(0f));
         });
 

--- a/Robust.UnitTesting/Shared/Physics/GridMovement_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/GridMovement_Test.cs
@@ -26,6 +26,7 @@ public sealed class GridMovement_Test : RobustIntegrationTest
         var fixtureSystem = systems.GetEntitySystem<FixtureSystem>();
         var mapManager = server.ResolveDependency<IMapManager>();
         var entManager = server.ResolveDependency<IEntityManager>();
+        var physSystem = systems.GetEntitySystem<SharedPhysicsSystem>();
 
         await server.WaitAssertion(() =>
         {
@@ -39,21 +40,21 @@ public sealed class GridMovement_Test : RobustIntegrationTest
 
             var onGrid = entManager.SpawnEntity(null, new EntityCoordinates(grid.GridEntityId, 0.5f, 0.5f ));
             var onGridBody = entManager.AddComponent<PhysicsComponent>(onGrid);
-            onGridBody.BodyType = BodyType.Dynamic;
+            physSystem.SetBodyType(onGridBody, BodyType.Dynamic);
             var shapeA = new PolygonShape();
             shapeA.SetAsBox(0.5f, 0.5f);
             var fixtureA = fixtureSystem.CreateFixture(onGridBody, shapeA);
-            fixtureA.CollisionMask = 1;
+            physSystem.SetCollisionMask(fixtureA, 1);
             Assert.That(fixtureSystem.GetFixtureCount(onGrid), Is.EqualTo(1));
             Assert.That(entManager.GetComponent<TransformComponent>(onGrid).ParentUid, Is.EqualTo(grid.GridEntityId));
 
             var offGrid = entManager.SpawnEntity(null, new MapCoordinates(new Vector2(10f, 10f), mapId));
             var offGridBody = entManager.AddComponent<PhysicsComponent>(offGrid);
-            offGridBody.BodyType = BodyType.Dynamic;
+            physSystem.SetBodyType(offGridBody, BodyType.Dynamic);
             var shapeB = new PolygonShape();
             shapeB.SetAsBox(0.5f, 0.5f);
             var fixtureB = fixtureSystem.CreateFixture(offGridBody, shapeB);
-            fixtureB.CollisionLayer = 1;
+            physSystem.SetCollisionLayer(fixtureB, 1);
             Assert.That(fixtureSystem.GetFixtureCount(offGrid), Is.EqualTo(1));
             Assert.That(entManager.GetComponent<TransformComponent>(offGrid).ParentUid, Is.Not.EqualTo((grid.GridEntityId)));
 

--- a/Robust.UnitTesting/Shared/Physics/JointDeletion_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/JointDeletion_Test.cs
@@ -26,6 +26,7 @@ public sealed class JointDeletion_Test : RobustIntegrationTest
         var jointSystem = susManager.GetEntitySystem<SharedJointSystem>();
         var broadphase = susManager.GetEntitySystem<SharedBroadphaseSystem>();
         var fixSystem = susManager.GetEntitySystem<FixtureSystem>();
+        var physicsSystem = susManager.GetEntitySystem<SharedPhysicsSystem>();
 
         DistanceJoint joint = default!;
         EntityUid ent1;
@@ -44,10 +45,10 @@ public sealed class JointDeletion_Test : RobustIntegrationTest
             body2 = entManager.AddComponent<PhysicsComponent>(ent2);
             entManager.AddComponent<CollisionWakeComponent>(ent2);
 
-            body1.BodyType = BodyType.Dynamic;
-            body2.BodyType = BodyType.Dynamic;
-            body1.CanCollide = true;
-            body2.CanCollide = true;
+            physicsSystem.SetBodyType(body1, BodyType.Dynamic);
+            physicsSystem.SetBodyType(body2, BodyType.Dynamic);
+            physicsSystem.SetCanCollide(body1, true);
+            physicsSystem.SetCanCollide(body2, true);
             var shape = new PolygonShape();
             shape.SetAsBox(0.5f, 0.5f);
 
@@ -62,7 +63,7 @@ public sealed class JointDeletion_Test : RobustIntegrationTest
         await server.WaitAssertion(() =>
         {
             Assert.That(joint.Enabled);
-            body2.Awake = false;
+            physicsSystem.SetAwake(body2, false);
             Assert.That(!body2.Awake);
 
             entManager.DeleteEntity(ent2);

--- a/Robust.UnitTesting/Shared/Physics/Joints_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Joints_Test.cs
@@ -33,6 +33,7 @@ namespace Robust.UnitTesting.Shared.Physics
             var fixtureSystem = entManager.EntitySysManager.GetEntitySystem<FixtureSystem>();
             var jointSystem = entManager.EntitySysManager.GetEntitySystem<JointSystem>();
             var broadphaseSystem = entManager.EntitySysManager.GetEntitySystem<SharedBroadphaseSystem>();
+            var physicsSystem = server.Resolve<IEntitySystemManager>().GetEntitySystem<SharedPhysicsSystem>();
 
             var mapId = mapManager.CreateMap();
 
@@ -40,8 +41,8 @@ namespace Robust.UnitTesting.Shared.Physics
             var ent2 = entManager.SpawnEntity(null, new MapCoordinates(Vector2.Zero, mapId));
             var body1 = entManager.AddComponent<PhysicsComponent>(ent1);
             var body2 = entManager.AddComponent<PhysicsComponent>(ent2);
-            body1.BodyType = BodyType.Dynamic;
-            body2.BodyType = BodyType.Dynamic;
+            physicsSystem.SetBodyType(body1, BodyType.Dynamic);
+            physicsSystem.SetBodyType(body2, BodyType.Dynamic);
 
             fixtureSystem.TryCreateFixture(body1, new Fixture(new PhysShapeCircle()
             {

--- a/Robust.UnitTesting/Shared/Physics/MapVelocity_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/MapVelocity_Test.cs
@@ -40,7 +40,7 @@ namespace Robust.UnitTesting.Shared.Physics
                 var grid2 = mapManager.CreateGrid(mapId);
 
                 Assert.That(entityManager.TryGetComponent<PhysicsComponent>(grid.GridEntityId, out var gridPhysics));
-                gridPhysics!.BodyType = BodyType.Dynamic;
+                physicsSys.SetBodyType(gridPhysics!, BodyType.Dynamic);
 
                 Vector2 offset = new(3, 4);
                 Vector2 expectedFinalVelocity = new Vector2(-4, 3) * 2 + Vector2.One;
@@ -51,7 +51,7 @@ namespace Robust.UnitTesting.Shared.Physics
                 xform!.AttachParent(grid.GridEntityId);
 
                 // Test Linear Velocities
-                gridPhysics.LinearVelocity = Vector2.One;
+                physicsSys.SetLinearVelocity(gridPhysics!, Vector2.One);
                 Assert.That(body!.LinearVelocity, Is.Approximately(Vector2.Zero, 1e-6));
                 Assert.That(body.AngularVelocity, Is.Approximately(0f, 1e-6));
 
@@ -64,7 +64,7 @@ namespace Robust.UnitTesting.Shared.Physics
                 Assert.That(velocities.Item2, Is.Approximately(angularVelocity, 1e-6));
 
                 // Add angular velocity
-                gridPhysics.AngularVelocity = 2;
+                physicsSys.SetAngularVelocity(gridPhysics!, 2);
                 Assert.That(body.LinearVelocity, Is.EqualTo(Vector2.Zero));
                 Assert.That(body.AngularVelocity, Is.EqualTo(0f));
 
@@ -105,7 +105,7 @@ namespace Robust.UnitTesting.Shared.Physics
                 var grid = mapManager.CreateGrid(mapId);
 
                 Assert.That(entityManager.TryGetComponent<PhysicsComponent>(grid.GridEntityId, out var gridPhysics));
-                gridPhysics!.BodyType = BodyType.Dynamic;
+                physicsSys.SetBodyType(gridPhysics!, BodyType.Dynamic);
 
                 Vector2 offset1 = new(2, 0);
                 var dummy1 = entityManager.SpawnEntity(DummyEntity, new EntityCoordinates(grid.GridEntityId, offset1));
@@ -122,8 +122,8 @@ namespace Robust.UnitTesting.Shared.Physics
 
                 Assert.That(xform2.WorldPosition, Is.Approximately(new Vector2(1, 0), 1e-6));
 
-                gridPhysics.LinearVelocity = new Vector2(1, 0);
-                gridPhysics.AngularVelocity = 1;
+                physicsSys.SetLinearVelocity(gridPhysics!, new Vector2(1, 0));
+                physicsSys.SetAngularVelocity(gridPhysics!, 1);
 
                 // check that dummy2 properly gets the velocities from its grand-parent
                 var linearVelocity = physicsSys.GetMapLinearVelocity(dummy2, body2);
@@ -136,8 +136,8 @@ namespace Robust.UnitTesting.Shared.Physics
 
                 // check that if we make move in the opposite direction, but spin in the same direction, then dummy2 is
                 // (for this moment in time) stationary, but still rotating.
-                body1!.LinearVelocity = -gridPhysics.LinearVelocity;
-                body1.AngularVelocity = gridPhysics.AngularVelocity;
+                physicsSys.SetLinearVelocity(body1!, -gridPhysics!.LinearVelocity);
+                physicsSys.SetAngularVelocity(body1!, gridPhysics.AngularVelocity);
                 linearVelocity = physicsSys.GetMapLinearVelocity(dummy2, body2);
                 angularVelocity = physicsSys.GetMapAngularVelocity(dummy2, body2);
                 velocities = physicsSys.GetMapVelocities(dummy2, body2);

--- a/Robust.UnitTesting/Shared/Physics/PhysicsComponent_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/PhysicsComponent_Test.cs
@@ -26,6 +26,8 @@ namespace Robust.UnitTesting.Shared.Physics
             var mapManager = server.ResolveDependency<IMapManager>();
             var fixtureSystem = server.ResolveDependency<IEntitySystemManager>()
                 .GetEntitySystem<FixtureSystem>();
+            var physicsSystem = server.ResolveDependency<IEntitySystemManager>()
+                .GetEntitySystem<SharedPhysicsSystem>();
 
             await server.WaitAssertion(() =>
             {
@@ -35,22 +37,22 @@ namespace Robust.UnitTesting.Shared.Physics
                 var poly = new PolygonShape();
                 poly.SetAsBox(0.5f, 0.5f);
                 var fixture = fixtureSystem.CreateFixture(box, poly);
-                fixture.Density = 1f;
-                box.FixedRotation = false;
-                box.BodyType = BodyType.Dynamic;
+                physicsSystem.SetDensity(fixture, 1f);
+                physicsSystem.SetFixedRotation(box, false);
+                physicsSystem.SetBodyType(box, BodyType.Dynamic);
                 Assert.That(box.InvI, Is.GreaterThan(0f));
 
                 // Check regular impulse works
-                box.ApplyLinearImpulse(new Vector2(0f, 1f));
+                physicsSystem.ApplyLinearImpulse(box, new Vector2(0f, 1f));
                 Assert.That(box.LinearVelocity.Length, Is.GreaterThan(0f));
 
                 // Reset the box
-                box.LinearVelocity = Vector2.Zero;
+                physicsSystem.SetLinearVelocity(box, Vector2.Zero);
                 Assert.That(box.LinearVelocity.Length, Is.EqualTo(0f));
                 Assert.That(box.AngularVelocity, Is.EqualTo(0f));
 
                 // Check the angular impulse is applied from the point
-                box.ApplyLinearImpulse(new Vector2(0f, 1f), new Vector2(0.5f, 0f));
+                physicsSystem.ApplyLinearImpulse(box, new Vector2(0f, 1f), new Vector2(0.5f, 0f));
                 Assert.That(box.LinearVelocity.Length, Is.GreaterThan(0f));
                 Assert.That(box.AngularVelocity, Is.Not.EqualTo(0f));
             });

--- a/Robust.UnitTesting/Shared/Physics/PhysicsMap_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/PhysicsMap_Test.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
+using Robust.Shared.Physics.Systems;
 using Robust.UnitTesting.Server;
 
 namespace Robust.UnitTesting.Shared.Physics;
@@ -22,6 +23,7 @@ public sealed class PhysicsMap_Test
         var sim = RobustServerSimulation.NewSimulation().InitializeInstance();
         var entManager = sim.Resolve<IEntityManager>();
         var mapManager = sim.Resolve<IMapManager>();
+        var physSystem = sim.Resolve<IEntitySystemManager>().GetEntitySystem<SharedPhysicsSystem>();
 
         var mapId = mapManager.CreateMap();
         var mapId2 = mapManager.CreateMap();
@@ -34,18 +36,19 @@ public sealed class PhysicsMap_Test
         var parent = entManager.SpawnEntity(null, new MapCoordinates(Vector2.Zero, mapId));
         var parentXform = entManager.GetComponent<TransformComponent>(parent);
         var parentBody = entManager.AddComponent<PhysicsComponent>(parent);
-        parentBody.BodyType = BodyType.Dynamic;
 
-        parentBody.SleepingAllowed = false;
-        parentBody.WakeBody();
+        physSystem.SetBodyType(parentBody, BodyType.Dynamic);
+        physSystem.SetSleepingAllowed(parentBody, false);
+
+        physSystem.WakeBody(parentBody);
         Assert.That(physicsMap.AwakeBodies, Does.Contain(parentBody));
 
         var child = entManager.SpawnEntity(null, new EntityCoordinates(parent, Vector2.Zero));
         var childBody = entManager.AddComponent<PhysicsComponent>(child);
-        childBody.BodyType = BodyType.Dynamic;
 
-        childBody.SleepingAllowed = false;
-        childBody.WakeBody();
+        physSystem.SetBodyType(childBody, BodyType.Dynamic);
+        physSystem.SetSleepingAllowed(childBody, false);
+        physSystem.WakeBody(childBody);
 
         Assert.That(physicsMap.AwakeBodies, Does.Contain(childBody));
 

--- a/Robust.UnitTesting/Shared/Physics/Stack_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Stack_Test.cs
@@ -52,6 +52,7 @@ namespace Robust.UnitTesting.Shared.Physics
             var mapManager = server.ResolveDependency<IMapManager>();
             var entitySystemManager = server.ResolveDependency<IEntitySystemManager>();
             var fixtureSystem = entitySystemManager.GetEntitySystem<FixtureSystem>();
+            var physSystem = entitySystemManager.GetEntitySystem<SharedPhysicsSystem>();
             MapId mapId;
 
             const int columnCount = 1;
@@ -70,22 +71,19 @@ namespace Robust.UnitTesting.Shared.Physics
                 var ground = entityManager.AddComponent<PhysicsComponent>(tempQualifier);
 
                 var horizontal = new EdgeShape(new Vector2(-40, 0), new Vector2(40, 0));
-                var horizontalFixture = new Fixture(ground, horizontal)
-                {
-                    CollisionLayer = 1,
-                    CollisionMask = 1,
-                    Hard = true
-                };
+                var horizontalFixture = new Fixture(ground, horizontal);
+                physSystem.SetCollisionLayer(horizontalFixture, 1);
+                physSystem.SetCollisionMask(horizontalFixture, 1);
+                physSystem.SetHard(horizontalFixture, true);
 
                 fixtureSystem.CreateFixture(ground, horizontalFixture);
 
                 var vertical = new EdgeShape(new Vector2(10, 0), new Vector2(10, 10));
-                var verticalFixture = new Fixture(ground, vertical)
-                {
-                    CollisionLayer = 1,
-                    CollisionMask = 1,
-                    Hard = true
-                };
+
+                var verticalFixture = new Fixture(ground, vertical);
+                physSystem.SetCollisionLayer(verticalFixture, 1);
+                physSystem.SetCollisionMask(verticalFixture, 1);
+                physSystem.SetHard(verticalFixture, true);
 
                 fixtureSystem.CreateFixture(ground, verticalFixture);
 
@@ -104,7 +102,7 @@ namespace Robust.UnitTesting.Shared.Physics
                             new MapCoordinates(new Vector2(xs[j] + x, 0.55f + 2.1f * i), mapId));
                         var box = entityManager.AddComponent<PhysicsComponent>(tempQualifier1);
 
-                        box.BodyType = BodyType.Dynamic;
+                        physSystem.SetBodyType(box, BodyType.Dynamic);
                         var poly = new PolygonShape(0.001f);
                         poly.SetVertices(new List<Vector2>()
                         {
@@ -114,12 +112,10 @@ namespace Robust.UnitTesting.Shared.Physics
                             new(-0.5f, -0.5f),
                         });
 
-                        var fixture = new Fixture(box, poly)
-                        {
-                            CollisionMask = 1,
-                            CollisionLayer = 1,
-                            Hard = true,
-                        };
+                        var fixture = new Fixture(box, poly);
+                        physSystem.SetCollisionLayer(fixture, 1);
+                        physSystem.SetCollisionMask(fixture, 1);
+                        physSystem.SetHard(fixture, true);
 
                         fixtureSystem.CreateFixture(box, fixture);
 
@@ -173,6 +169,7 @@ namespace Robust.UnitTesting.Shared.Physics
             var mapManager = server.ResolveDependency<IMapManager>();
             var entitySystemManager = server.ResolveDependency<IEntitySystemManager>();
             var fixtureSystem = entitySystemManager.GetEntitySystem<FixtureSystem>();
+            var physSystem = entitySystemManager.GetEntitySystem<SharedPhysicsSystem>();
             MapId mapId;
 
             var columnCount = 1;
@@ -190,22 +187,18 @@ namespace Robust.UnitTesting.Shared.Physics
                 var ground = entityManager.AddComponent<PhysicsComponent>(tempQualifier);
 
                 var horizontal = new EdgeShape(new Vector2(-40, 0), new Vector2(40, 0));
-                var horizontalFixture = new Fixture(ground, horizontal)
-                {
-                    CollisionLayer = 1,
-                    CollisionMask = 1,
-                    Hard = true
-                };
+                var horizontalFixture = new Fixture(ground, horizontal);
+                physSystem.SetCollisionLayer(horizontalFixture, 1);
+                physSystem.SetCollisionMask(horizontalFixture, 1);
+                physSystem.SetHard(horizontalFixture, true);
 
                 fixtureSystem.CreateFixture(ground, horizontalFixture);
 
                 var vertical = new EdgeShape(new Vector2(10, 0), new Vector2(10, 10));
-                var verticalFixture = new Fixture(ground, vertical)
-                {
-                    CollisionLayer = 1,
-                    CollisionMask = 1,
-                    Hard = true
-                };
+                var verticalFixture = new Fixture(ground, vertical);
+                physSystem.SetCollisionLayer(verticalFixture, 1);
+                physSystem.SetCollisionMask(verticalFixture, 1);
+                physSystem.SetHard(verticalFixture, true);
 
                 fixtureSystem.CreateFixture(ground, verticalFixture);
 
@@ -226,16 +219,14 @@ namespace Robust.UnitTesting.Shared.Physics
                             new MapCoordinates(new Vector2(xs[j] + x, 0.55f + 1.1f * i), mapId));
                         var circle = entityManager.AddComponent<PhysicsComponent>(tempQualifier1);
 
-                        circle.LinearDamping = 0.05f;
-                        circle.BodyType = BodyType.Dynamic;
+                        physSystem.SetLinearDamping(circle, 0.05f);
+                        physSystem.SetBodyType(circle, BodyType.Dynamic);
                         shape = new PhysShapeCircle {Radius = 0.5f};
 
-                        var fixture = new Fixture(circle, shape)
-                        {
-                            CollisionMask = 1,
-                            CollisionLayer = 1,
-                            Hard = true,
-                        };
+                        var fixture = new Fixture(circle, shape);
+                        physSystem.SetCollisionLayer(fixture, 1);
+                        physSystem.SetCollisionMask(fixture, 1);
+                        physSystem.SetHard(fixture, true);
 
                         fixtureSystem.CreateFixture(circle, fixture);
 


### PR DESCRIPTION
Just some minor refactor to avoid Obsolete method calls in methods.

Changes in the engine proper might cause backward compatibility issues. Don't want to do those without OD agreeing.