### PR TITLE
Fix inverse vec2 allocations

### DIFF
--- a/Robust.Shared/Physics/Dynamics/Contacts/ContactVelocityConstraint.cs
+++ b/Robust.Shared/Physics/Dynamics/Contacts/ContactVelocityConstraint.cs
@@ -43,9 +43,9 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
 
         public Vector2 Normal;
 
-        public Vector2[] NormalMass;
+        public System.Numerics.Vector4 NormalMass;
 
-        public Vector2[] K;
+        public System.Numerics.Vector4 K;
 
         public float InvMassA;
 

--- a/Robust.Shared/Physics/Dynamics/Joints/FrictionJoint.cs
+++ b/Robust.Shared/Physics/Dynamics/Joints/FrictionJoint.cs
@@ -212,7 +212,7 @@ namespace Robust.Shared.Physics.Dynamics.Joints
             K[1].X = K[0].Y;
             K[1].Y = mA + mB + iA * _rA.X * _rA.X + iB * _rB.X * _rB.X;
 
-            _linearMass = Vector2Helpers.Inverse(K);
+            Vector4Helpers.Inverse(K);
 
             _angularMass = iA + iB;
             if (_angularMass > 0.0f)

--- a/Robust.Shared/Physics/Transform.cs
+++ b/Robust.Shared/Physics/Transform.cs
@@ -124,6 +124,11 @@ namespace Robust.Shared.Physics
             return new(quaternion2D.C * vector.X - quaternion2D.S * vector.Y, quaternion2D.S * vector.X + quaternion2D.C * vector.Y);
         }
 
+        public static Vector2 Mul(System.Numerics.Vector4 A, Vector2 v)
+        {
+            return new Vector2(A.X * v.X + A.Y * v.Y, A.Z * v.X + A.W * v.Y);
+        }
+
         public static Vector2 Mul(in Vector2[] A, in Vector2 v)
         {
             // A needing to be a 2 x 2 matrix

--- a/Robust.Shared/Physics/Vector4Helpers.cs
+++ b/Robust.Shared/Physics/Vector4Helpers.cs
@@ -26,29 +26,21 @@ using Robust.Shared.Utility;
 
 namespace Robust.Shared.Physics
 {
-    internal static class Vector2Helpers
+    internal static class Vector4Helpers
     {
-        public static Vector2[] Inverse(this Vector2[] matrix)
+        public static System.Numerics.Vector4 Inverse(System.Numerics.Vector4 matrix)
         {
-            DebugTools.Assert(matrix.Length == 2);
-            float a = matrix[0].X, b = matrix[1].X, c = matrix[0].Y, d = matrix[1].Y;
+            float a = matrix.X, b = matrix.Z, c = matrix.Y, d = matrix.W;
             float det = a * d - b * c;
             if (det != 0.0f)
             {
                 det = 1.0f / det;
             }
 
-            Vector2[] result = new Vector2[2];
-            result[0].X = det * d;
-            result[0].Y = -det * c;
-
-            result[1].X = -det * b;
-            result[1].Y = det * a;
-
-            return result;
+            return new System.Numerics.Vector4(det * d, -det * c, -det * b, det * a);
         }
 
-        public static Vector2[] Inverse(Span<Vector2> matrix)
+        public static void Inverse(Span<Vector2> matrix)
         {
             DebugTools.Assert(matrix.Length == 2);
             float a = matrix[0].X, b = matrix[1].X, c = matrix[0].Y, d = matrix[1].Y;
@@ -58,14 +50,11 @@ namespace Robust.Shared.Physics
                 det = 1.0f / det;
             }
 
-            Vector2[] result = new Vector2[2];
-            result[0].X = det * d;
-            result[0].Y = -det * c;
+            matrix[0].X = det * d;
+            matrix[0].Y = -det * c;
 
-            result[1].X = -det * b;
-            result[1].Y = det * a;
-
-            return result;
+            matrix[1].X = -det * b;
+            matrix[1].Y = det * a;
         }
     }
 }


### PR DESCRIPTION
It's just a 2x2 matrix so we can just use a vec4.

Profiled in debug but still, Vec4 is gonna be better than an array on release.

![image](https://user-images.githubusercontent.com/31366439/196012929-07066416-343d-4c84-8683-4130da658533.png)
