### PR TITLE
Adds a getter to AnimationHelper

### DIFF
--- a/Robust.Shared/Animations/AnimationHelper.cs
+++ b/Robust.Shared/Animations/AnimationHelper.cs
@@ -32,6 +32,34 @@ namespace Robust.Shared.Animations
             property.SetValue(target, value);
         }
 
+        /// <summary>
+        ///     Gets the value of a property marked with <see cref="AnimatableAttribute"/> from an object.
+        /// </summary>
+        /// <remarks>
+        ///     This does not use <see cref="IAnimationProperties"/>.
+        /// </remarks>
+        /// <param name="target">The object to get the property from.</param>
+        /// <param name="name">The name of the property to get.</param>
+        /// <returns>The current value of the property.</returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown if the property does not exist or does not have <see cref="AnimatableAttribute"/>.
+        /// </exception>
+        public static object? GetAnimatableProperty(object target, string name)
+        {
+            var property = target.GetType().GetProperty(name);
+            if (property == null)
+            {
+                throw new ArgumentException($"Animatable property with name '{name}' does not exist.");
+            }
+
+            if (!Attribute.IsDefined(property, typeof(AnimatableAttribute)))
+            {
+                throw new ArgumentException($"Animatable property with name '{name}' does not exist.");
+            }
+
+            return property.GetValue(target);
+        }
+
         public static void CallAnimatableMethod(object target, string name, object[] arguments)
         {
             var method = target.GetType().GetMethod(name);


### PR DESCRIPTION
This is a small change that adds a getter method on AnimationHelper, to get the value of an animatable property. I'm using it here: https://github.com/space-wizards/space-station-14/pull/11768 and I think it makes sense to have a getter since we already have a setter and an invoker in the same file.