### PR TITLE
Move CastShadows to SharedPointLightComponent

### DIFF
--- a/Robust.Client/GameObjects/Components/Light/PointLightComponent.cs
+++ b/Robust.Client/GameObjects/Components/Light/PointLightComponent.cs
@@ -103,12 +103,6 @@ namespace Robust.Client.GameObjects
             set => _visibleNested = value;
         }
 
-        /// <summary>
-        ///     Whether this pointlight should cast shadows
-        /// </summary>
-        [DataField("castShadows")]
-        public bool CastShadows = true;
-
         [DataField("nestedvisible")]
         private bool _visibleNested = true;
         [DataField("autoRot")]

--- a/Robust.Shared/GameObjects/Components/Light/PointLightComponentState.cs
+++ b/Robust.Shared/GameObjects/Components/Light/PointLightComponentState.cs
@@ -13,11 +13,12 @@ namespace Robust.Shared.GameObjects
 
         public readonly float Softness;
         public readonly bool Enabled;
+        public readonly bool CastShadows;
 
         public readonly float Radius;
         public readonly Vector2 Offset;
 
-        public PointLightComponentState(bool enabled, Color color, float radius, Vector2 offset, float energy, float softness)
+        public PointLightComponentState(bool enabled, Color color, float radius, Vector2 offset, float energy, float softness, bool castShadows)
         {
             Enabled = enabled;
             Color = color;
@@ -25,6 +26,7 @@ namespace Robust.Shared.GameObjects
             Offset = offset;
             Energy = energy;
             Softness = softness;
+            CastShadows = castShadows;
         }
     }
 }

--- a/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
@@ -37,6 +37,12 @@ namespace Robust.Shared.GameObjects
         [DataField("softness")]
         private float _softness = 1f;
 
+        /// <summary>
+        ///     Whether this pointlight should cast shadows
+        /// </summary>
+        [DataField("castShadows")]
+        public bool CastShadows = true;
+
         [ViewVariables(VVAccess.ReadWrite)]
         public virtual bool Enabled
         {

--- a/Robust.Shared/GameObjects/Systems/SharedPointLightSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPointLightSystem.cs
@@ -13,7 +13,7 @@ namespace Robust.Shared.GameObjects
 
         private void GetCompState(EntityUid uid, SharedPointLightComponent component, ref ComponentGetState args)
         {
-            args.State = new PointLightComponentState(component.Enabled, component.Color, component.Radius, component.Offset, component.Energy, component.Softness);
+            args.State = new PointLightComponentState(component.Enabled, component.Color, component.Radius, component.Offset, component.Energy, component.Softness, component.CastShadows);
         }
 
         private void HandleCompState(EntityUid uid, SharedPointLightComponent component, ref ComponentHandleState args)
@@ -25,6 +25,7 @@ namespace Robust.Shared.GameObjects
             component.Color = newState.Color;
             component.Energy = newState.Energy;
             component.Softness = newState.Softness;
+            component.CastShadows = newState.CastShadows;
         }
     }
 }


### PR DESCRIPTION
This change makes it possible for the server to set CastShadows to false. Shadow casting is a relatively expensive operation that can be skipped for some lights.