### PR TITLE
Entity deletion changes

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -370,13 +370,6 @@ namespace Robust.Shared.GameObjects
             if (transform._children.Count != 0)
                 Logger.Error($"Failed to delete all children of entity: {ToPrettyString(metadata.Owner)}");
 
-            // Shut down all components.
-            foreach (var component in InSafeOrder(_entCompIndex[metadata.Owner]))
-            {
-                if(component.Running)
-                    component.LifeShutdown(this);
-            }
-
             // Dispose all my components, in a safe order so transform is available
             DisposeComponents(metadata.Owner);
 

--- a/Robust.Shared/Physics/Systems/FixtureSystem.cs
+++ b/Robust.Shared/Physics/Systems/FixtureSystem.cs
@@ -145,7 +145,7 @@ namespace Robust.Shared.Physics.Systems
         /// </summary>
         public Fixture? GetFixtureOrNull(PhysicsComponent body, string id, FixturesComponent? manager = null)
         {
-            if (!Resolve(body.Owner, ref manager))
+            if (!Resolve(body.Owner, ref manager, false))
             {
                 return null;
             }


### PR DESCRIPTION
This PR changes two things around.

Firstly for component removal it moves the `ComponentRemoved.Invoke()` and `_eventBus.OnComponentRemoved()` calls outside of the component `LifeShutdown()` and `LifeRemoveFromEntity()` try-catch statements. This is so that if something goes wrong with some system somewhere while handling component removal events, at least the component still gets removed from event bus subscription stuff.

Secondly, it removes the `LifeShutdown()` calls for each component prior to calling `DisposeComponents()`. This wasn't wrapped in a try-catch and could lead to deleted entities sticking around (e.g., #3017, #3231). Note that `DisposeComponents()` will also call LifeShutdown(), but this does slightly change the logic. It is now basically a single foreach loop that does shutdown, remove, and delete, whereas before it was one loop doing shutdown for all components, and then separately remove & delete all components. I don't think this change has any effect, but if there was some reason it was like this I guess I can just wrap the shutdown loop in try catch statements?
