### PR TITLE
Add trace to mid-deletion reparenting error logs.

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -45,11 +45,11 @@ namespace Robust.Shared.GameObjects
                 return;
 
             if (LifeStage(ev.Entity) >= EntityLifeStage.Terminating)
-                _logger.Error($"Entity {ToPrettyString(ev.Entity)} is getting attached to a new parent while terminating. New parent: {ToPrettyString(ev.Transform.ParentUid)}");
+                _logger.Error($"Entity {ToPrettyString(ev.Entity)} is getting attached to a new parent while terminating. New parent: {ToPrettyString(ev.Transform.ParentUid)}. Trace: {Environment.StackTrace}");
 
 
             if (LifeStage(ev.Transform.ParentUid) >= EntityLifeStage.Terminating)
-                _logger.Error($"Entity {ToPrettyString(ev.Entity)} is attaching itself to a terminating entity {ToPrettyString(ev.Transform.ParentUid)}.");
+                _logger.Error($"Entity {ToPrettyString(ev.Entity)} is attaching itself to a terminating entity {ToPrettyString(ev.Transform.ParentUid)}. Trace: {Environment.StackTrace}");
         }
 
         private void MapManagerOnTileChanged(TileChangedEvent e)


### PR DESCRIPTION
These are still happening, and these always seem to include food trash entities.