### PR TITLE
Disable kinematic controller collisions

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
@@ -13,8 +13,11 @@ public abstract partial class SharedPhysicsSystem
     /// <returns></returns>
     internal bool ShouldCollide(PhysicsComponent body, PhysicsComponent other)
     {
-        if ((body.BodyType & (BodyType.Kinematic | BodyType.Static)) != 0 &&
-            (other.BodyType & (BodyType.Kinematic | BodyType.Static)) != 0)
+        if (((body.BodyType & (BodyType.Kinematic | BodyType.Static)) != 0 &&
+            (other.BodyType & (BodyType.Kinematic | BodyType.Static)) != 0) ||
+            // Kinematic controllers can't collide.
+            (body.BodyType == BodyType.KinematicController &&
+             other.BodyType == BodyType.KinematicController))
         {
             return false;
         }


### PR DESCRIPTION
Fixes the high angular velocity bug from vehicles colliding with mobs for ? reasons.
Fixes https://github.com/space-wizards/space-station-14/issues/11693

Thanks to dogzero for reproing it for me as I forgor.