### PR TITLE
PVS budget tweaks

### DIFF
--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -685,8 +685,10 @@ internal sealed partial class PVSSystem : EntitySystem
         EntityUid[] viewerEntities)
     {
         DebugTools.Assert(session.Status == SessionStatus.InGame);
-        var enteredEntityBudget = _netConfigManager.GetClientCVar(session.ConnectedClient, CVars.NetPVSEntityBudget);
-        var entitiesSent = 0;
+        var newEntityBudget = _netConfigManager.GetClientCVar(session.ConnectedClient, CVars.NetPVSEntityBudget);
+        var enteredEntityBudget = _netConfigManager.GetClientCVar(session.ConnectedClient, CVars.NetPVSEntityEnterBudget);
+        var newEntityCount = 0;
+        var enteredEntityCount = 0;
         var sessionData = _playerVisibleSets[session];
         sessionData.SentEntities.TryGetValue(toTick - 1, out var lastSent);
         var lastAcked = sessionData.LastAcked;
@@ -698,14 +700,21 @@ internal sealed partial class PVSSystem : EntitySystem
 
         var deletions = _entityPvsCollection.GetDeletedIndices(fromTick);
 
+        // Iterate over visible chunks and add entities.
+        // TODO reorder chunks and allow early termination?
+        // Previously this iteration terminated early whenever the PVS budget was full. However, if this iteration
+        // iterates over new chunks first, then this can lead to a situation where previously seen entities in currently
+        // still visible chunks are never added to visibleEnts, and therefore get treated as if they had left PVS.
+        // Currently this is fixed by just not exiting the iteration early, but it is probably better to just ensure
+        // that new chunks are always the last to be iterated over.
         foreach (var i in chunkIndices)
         {
             var cache = chunkCache[i];
             if(!cache.HasValue) continue;
             foreach (var rootNode in cache.Value.tree.RootNodes)
             {
-                RecursivelyAddTreeNode(in rootNode, cache.Value.tree, lastAcked, lastSent, visibleEnts, fromTick,
-                        ref entitiesSent, cache.Value.metadata, in enteredEntityBudget);
+                RecursivelyAddTreeNode(in rootNode, cache.Value.tree, lastAcked, lastSent, visibleEnts, lastSeen, cache.Value.metadata, fromTick,
+                        ref newEntityCount, ref enteredEntityCount,  in newEntityBudget, in enteredEntityBudget);
             }
         }
 
@@ -713,8 +722,8 @@ internal sealed partial class PVSSystem : EntitySystem
         while (globalEnumerator.MoveNext())
         {
             var uid = globalEnumerator.Current;
-            RecursivelyAddOverride(in uid, lastAcked, lastSent, visibleEnts, fromTick,
-                ref entitiesSent, mQuery, tQuery, in enteredEntityBudget);
+            RecursivelyAddOverride(in uid, lastAcked, lastSent, visibleEnts, lastSeen, mQuery, tQuery, fromTick,
+                ref newEntityCount, ref enteredEntityCount, in newEntityBudget, in enteredEntityBudget);
         }
         globalEnumerator.Dispose();
 
@@ -722,23 +731,23 @@ internal sealed partial class PVSSystem : EntitySystem
         while (localEnumerator.MoveNext())
         {
             var uid = localEnumerator.Current;
-            RecursivelyAddOverride(in uid, lastAcked, lastSent, visibleEnts, fromTick,
-                ref entitiesSent, mQuery, tQuery, in enteredEntityBudget);
+            RecursivelyAddOverride(in uid, lastAcked, lastSent, visibleEnts, lastSeen, mQuery, tQuery, fromTick,
+                ref newEntityCount, ref enteredEntityCount, in newEntityBudget, in enteredEntityBudget);
         }
         localEnumerator.Dispose();
 
         foreach (var viewerEntity in viewerEntities)
         {
-            RecursivelyAddOverride(in viewerEntity, lastAcked, lastSent, visibleEnts, fromTick,
-                ref entitiesSent, mQuery, tQuery, in enteredEntityBudget);
+            RecursivelyAddOverride(in viewerEntity, lastAcked, lastSent, visibleEnts, lastSeen, mQuery, tQuery, fromTick,
+                ref newEntityCount, ref enteredEntityCount, in newEntityBudget, in enteredEntityBudget);
         }
 
         var expandEvent = new ExpandPvsEvent(session, new List<EntityUid>());
         RaiseLocalEvent(ref expandEvent);
         foreach (var entityUid in expandEvent.Entities)
         {
-            RecursivelyAddOverride(in entityUid, lastAcked, lastSent, visibleEnts, fromTick,
-                ref entitiesSent, mQuery, tQuery, in enteredEntityBudget);
+            RecursivelyAddOverride(in entityUid, lastAcked, lastSent, visibleEnts, lastSeen, mQuery, tQuery, fromTick,
+                ref newEntityCount, ref enteredEntityCount, in newEntityBudget, in enteredEntityBudget);
         }
 
         var entityStates = new List<EntityState>();
@@ -819,14 +828,17 @@ internal sealed partial class PVSSystem : EntitySystem
     }
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-    private bool RecursivelyAddTreeNode(in EntityUid nodeIndex,
+    private void RecursivelyAddTreeNode(in EntityUid nodeIndex,
         RobustTree<EntityUid> tree,
         Dictionary<EntityUid, PVSEntityVisiblity>? lastAcked,
         Dictionary<EntityUid, PVSEntityVisiblity>? lastSent,
         Dictionary<EntityUid, PVSEntityVisiblity> toSend,
-        GameTick fromTick,
-        ref int totalEnteredEntities,
+        Dictionary<EntityUid, GameTick> lastSeen,
         Dictionary<EntityUid, MetaDataComponent> metaDataCache,
+        GameTick fromTick,
+        ref int newEntityCount,
+        ref int enteredEntityCount,
+        in int newEntityBudget,
         in int enteredEntityBudget)
     {
         //are we valid?
@@ -837,28 +849,22 @@ internal sealed partial class PVSSystem : EntitySystem
         // on different chunks (this is especially common with direct grid children)
         if (nodeIndex.IsValid() && !toSend.ContainsKey(nodeIndex))
         {
-            //are we new?
-            var (entered, budgetFull) = ProcessEntry(in nodeIndex, lastAcked, lastSent,
-                ref totalEnteredEntities, in enteredEntityBudget);
+            var (entered, shouldAdd) = ProcessEntry(in nodeIndex, lastAcked, lastSent, lastSeen,
+                ref newEntityCount, ref enteredEntityCount, newEntityBudget, enteredEntityBudget);
 
-            AddToSendSet(in nodeIndex, metaDataCache[nodeIndex], toSend, fromTick, entered);
-
-            if (budgetFull) return true;
+            if (shouldAdd)
+                AddToSendSet(in nodeIndex, metaDataCache[nodeIndex], toSend, fromTick, entered);
         }
 
         var node = tree[nodeIndex];
-        //our children are important regardless! iterate them!
-        if(node.Children != null)
-        {
-            foreach (var child in node.Children)
-            {
-                if (RecursivelyAddTreeNode(in child, tree, lastAcked, lastSent, toSend, fromTick,
-                    ref totalEnteredEntities, metaDataCache, in enteredEntityBudget))
-                    return true;
-            }
-        }
+        if (node.Children == null)
+            return;
 
-        return false;
+        foreach (var child in node.Children)
+        {
+            RecursivelyAddTreeNode(in child, tree, lastAcked, lastSent, toSend, lastSeen, metaDataCache, fromTick,
+                ref newEntityCount, ref enteredEntityCount, in newEntityBudget, in enteredEntityBudget);
+        }
     }
 
     public bool RecursivelyAddOverride(
@@ -866,10 +872,13 @@ internal sealed partial class PVSSystem : EntitySystem
         Dictionary<EntityUid, PVSEntityVisiblity>? lastAcked,
         Dictionary<EntityUid, PVSEntityVisiblity>? lastSent,
         Dictionary<EntityUid, PVSEntityVisiblity> toSend,
-        GameTick fromTick,
-        ref int totalEnteredEntities,
+        Dictionary<EntityUid, GameTick> lastSeen,
         EntityQuery<MetaDataComponent> metaQuery,
         EntityQuery<TransformComponent> transQuery,
+        GameTick fromTick,
+        ref int newEntityCount,
+        ref int enteredEntityCount,
+        in int newEntityBudget,
         in int enteredEntityBudget)
     {
         //are we valid?
@@ -880,28 +889,31 @@ internal sealed partial class PVSSystem : EntitySystem
         if (toSend.ContainsKey(uid)) return true;
 
         var parent = transQuery.GetComponent(uid).ParentUid;
-        if (parent.IsValid() && !RecursivelyAddOverride(in parent, lastAcked, lastSent, toSend, fromTick,
-                ref totalEnteredEntities, metaQuery, transQuery, in enteredEntityBudget))
+        if (parent.IsValid() && !RecursivelyAddOverride(in parent, lastAcked, lastSent, toSend, lastSeen, metaQuery, transQuery, fromTick,
+                ref newEntityCount, ref enteredEntityCount, in newEntityBudget, in enteredEntityBudget))
             return false;
 
-        var (entered, _) = ProcessEntry(in uid, lastAcked, lastSent,
-            ref totalEnteredEntities, in enteredEntityBudget);
+        var (entered, _) = ProcessEntry(in uid, lastAcked, lastSent, lastSeen, ref newEntityCount, ref enteredEntityCount, newEntityBudget, enteredEntityBudget);
 
         AddToSendSet(in uid, metaQuery.GetComponent(uid), toSend, fromTick, entered);
         return true;
     }
 
-    private (bool entering, bool budgetFull) ProcessEntry(in EntityUid uid,
+    private (bool Entered, bool ShouldAdd) ProcessEntry(in EntityUid uid,
         Dictionary<EntityUid, PVSEntityVisiblity>? lastAcked,
         Dictionary<EntityUid, PVSEntityVisiblity>? lastSent,
-        ref int totalEnteredEntities, in int enteredEntityBudget)
+        Dictionary<EntityUid, GameTick> lastSeen,
+        ref int newEntityCount,
+        ref int enteredEntityCount,
+        in int newEntityBudget,
+        in int enteredEntityBudget)
     {
         var enteredSinceLastSent = lastSent == null || !lastSent.ContainsKey(uid);
 
         var entered = enteredSinceLastSent || // OR, entered since last ack:
                         lastAcked == null || !lastAcked.ContainsKey(uid);
 
-        // If the entity is entering, but we already sent this entering entity, in the last message, we won't add it to
+        // If the entity is entering, but we already sent this entering entity in the last message, we won't add it to
         // the budget. Chances are the packet will arrive in a nice and orderly fashion, and the client will stick to
         // their requested budget. However this can cause issues if a packet gets dropped, because a player may create
         // 2x or more times the normal entity creation budget.
@@ -910,13 +922,15 @@ internal sealed partial class PVSSystem : EntitySystem
         // rate.
         if (enteredSinceLastSent)
         {
-            // TODO: should we separate this budget into "entered-but-seen" and "completely-new"?
-            // completely new entities are significantly more intensive for both server sending and client processing.
-            if (totalEnteredEntities++ >= enteredEntityBudget)
-                return (entered, true);
+            if (newEntityCount >= newEntityBudget || enteredEntityCount >= enteredEntityBudget)
+                return (entered, false);
+
+            enteredEntityCount++;
+            if (!lastSeen.ContainsKey(uid))
+                newEntityCount++;
         }
 
-        return (entered, false);
+        return (entered, true);
     }
 
     private void AddToSendSet(in EntityUid uid, MetaDataComponent metaDataComponent, Dictionary<EntityUid, PVSEntityVisiblity> toSend, GameTick fromTick, bool entered)

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -168,10 +168,20 @@ namespace Robust.Shared
             CVarDef.Create("net.maxupdaterange", 12.5f, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
 
         /// <summary>
-        /// The amount of entered entities that can be sent to a client in a single game state, under PVS.
+        /// This limits the number of new entities that can be sent to a client in a single game state. This exists to
+        /// avoid stuttering on the client when it has to spawn a bunch of entities in a single tick. If ever entity
+        /// spawning isn't hot garbage, this can be increased.
         /// </summary>
         public static readonly CVarDef<int> NetPVSEntityBudget =
             CVarDef.Create("net.pvs_budget", 50, CVar.ARCHIVE | CVar.REPLICATED);
+
+        /// <summary>
+        /// This limits the number of entities that can re-enter a client's view in a single game state. This exists to
+        /// avoid stuttering on the client when it has to update the transform of a bunch (700+) of entities in a single
+        /// tick. Ideally this would just be handled client-side somehow.
+        /// </summary>
+        public static readonly CVarDef<int> NetPVSEntityEnterBudget =
+            CVarDef.Create("net.pvs_enter_budget", 200, CVar.ARCHIVE | CVar.REPLICATED);
 
         /// <summary>
         /// The amount of pvs-exiting entities that a client will process in a single tick.


### PR DESCRIPTION
Currently PVS limits the number of entities that get sent to players if they have newly entered their view. This is mostly done to limit stuttering due to entity spawning. This PR separates that limit into a new-entity and entered-entity budget, which should help reduce pop-in a bit when moving around previously seen areas. PVS-entry still has a limit because even though it is much faster than entity spawning, it will still cause the client to stutter if it has to re-parent 1000+ entities in a single tick. 

This also fixes a bug where PVS would sometimes incorrectly detach entities when the budget gets overwhelmed. To cause the bug on current master, just set the entity budget to 1, tickrate to 30, and walk around. You will notice that the player's own clothes occasionally disappear for a bit, despite the fact that they are always in PVS range.