### PR TITLE
Change PVS parent-change handing

### DIFF
--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -312,6 +312,10 @@ internal sealed partial class PVSSystem : EntitySystem
 
     private void OnEntityMove(ref MoveEvent ev)
     {
+        // GriddUid is only set after init.
+        if (ev.Component.LifeStage < ComponentLifeStage.Initialized && ev.Component.GridUid == null)
+            _transform.SetGridId(ev.Component, ev.Component.FindGridEntityId(GetEntityQuery<TransformComponent>()));
+
         // since elements are cached grid-/map-relative, we dont need to update a given grids/maps children
         if (ev.Component.GridUid == ev.Sender || !ev.Component.ParentUid.IsValid())
             return;

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Security.Cryptography;
-using System.Text;
 using Microsoft.Extensions.ObjectPool;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
@@ -20,6 +13,11 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Players;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace Robust.Server.GameStates;
 
@@ -28,7 +26,6 @@ internal sealed partial class PVSSystem : EntitySystem
     [Shared.IoC.Dependency] private readonly IMapManagerInternal _mapManager = default!;
     [Shared.IoC.Dependency] private readonly IPlayerManager _playerManager = default!;
     [Shared.IoC.Dependency] private readonly IConfigurationManager _configManager = default!;
-    [Shared.IoC.Dependency] private readonly IServerEntityManager _serverEntManager = default!;
     [Shared.IoC.Dependency] private readonly SharedTransformSystem _transform = default!;
     [Shared.IoC.Dependency] private readonly INetConfigurationManager _netConfigManager = default!;
     [Shared.IoC.Dependency] private readonly IServerGameStateManager _serverGameStateManager = default!;
@@ -352,6 +349,9 @@ internal sealed partial class PVSSystem : EntitySystem
         {
             coordinates = _transform.GetMoverCoordinates(xform, xformQuery);
         }
+
+        // since elements are cached grid-/map-relative, we dont need to update a given grids/maps children
+        DebugTools.Assert(!_mapManager.IsGrid(uid) && !_mapManager.IsMap(uid));
 
         _entityPvsCollection.UpdateIndex(uid, coordinates);
 

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.ObjectPool;
 using Robust.Server.GameObjects;
@@ -119,7 +121,6 @@ internal sealed partial class PVSSystem : EntitySystem
 
         _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
         SubscribeLocalEvent<MoveEvent>(OnEntityMove);
-        SubscribeLocalEvent<EntParentChangedMessage>(OnParentChange);
         SubscribeLocalEvent<TransformComponent, TransformStartupEvent>(OnTransformStartup);
         EntityManager.EntityDeleted += OnEntityDeleted;
 
@@ -132,24 +133,14 @@ internal sealed partial class PVSSystem : EntitySystem
         InitializeDirty();
     }
 
-    private void OnParentChange(ref EntParentChangedMessage ev)
-    {
-        if (ev.Transform.GridUid == ev.Entity || _mapManager.IsMap(ev.Entity)) return;
-
-        // If parent changes then the RobustTree for that chunk will no longer be valid and we need to force it as dirty.
-        // Should still be at its old location as moveevent is called after.
-        var coordinates = _transform.GetMoverCoordinates(ev.Transform);
-        var index = _entityPvsCollection.GetChunkIndex(coordinates);
-        _entityPvsCollection.MarkDirty(index);
-    }
-
     /// <summary>
-    ///     Marks an entity's current chunk as drity.
+    ///     Marks an entity's current chunk as dirty.
     /// </summary>
     internal void MarkDirty(EntityUid uid)
     {
-        var xform = Transform(uid);
-        var coordinates = _transform.GetMoverCoordinates(xform);
+        var query = GetEntityQuery<TransformComponent>();
+        var xform = query.GetComponent(uid);
+        var coordinates = _transform.GetMoverCoordinates(xform, query);
         _entityPvsCollection.MarkDirty(_entityPvsCollection.GetChunkIndex(coordinates));
     }
 
@@ -324,16 +315,34 @@ internal sealed partial class PVSSystem : EntitySystem
 
     private void OnEntityMove(ref MoveEvent ev)
     {
+        // since elements are cached grid-/map-relative, we dont need to update a given grids/maps children
+        if (ev.Component.GridUid == ev.Sender || !ev.Component.ParentUid.IsValid())
+            return;
+
         var xformQuery = GetEntityQuery<TransformComponent>();
-        var coordinates = _transform.GetMoverCoordinates(ev.Component);
+
+        if (ev.ParentChanged)
+        {
+            // If parent changes then the RobustTree for that chunk will no longer be valid and we need to force it as dirty.
+            var oldCoordinates = _transform.GetMoverCoordinates(ev.OldPosition, xformQuery);
+            var oldIndex = _entityPvsCollection.GetChunkIndex(oldCoordinates);
+            _entityPvsCollection.MarkDirty(oldIndex);
+        }
+
+        var coordinates = _transform.GetMoverCoordinates(ev.Component, xformQuery);
         UpdateEntityRecursive(ev.Sender, ev.Component, coordinates, xformQuery, false);
     }
 
     private void OnTransformStartup(EntityUid uid, TransformComponent component, ref TransformStartupEvent args)
     {
         // use Startup because GridId is not set during the eventbus init yet!
+
+        // since elements are cached grid-/map-relative, we dont need to update a given grids/maps children
+        if (component.GridUid == uid || _mapManager.IsMap(uid))
+            return;
+
         var xformQuery = GetEntityQuery<TransformComponent>();
-        var coordinates = _transform.GetMoverCoordinates(component);
+        var coordinates = _transform.GetMoverCoordinates(component, xformQuery);
         UpdateEntityRecursive(uid, component, coordinates, xformQuery, false);
     }
 
@@ -341,13 +350,10 @@ internal sealed partial class PVSSystem : EntitySystem
     {
         if (mover && !xform.LocalPosition.Equals(Vector2.Zero))
         {
-            coordinates = _transform.GetMoverCoordinates(xform);
+            coordinates = _transform.GetMoverCoordinates(xform, xformQuery);
         }
 
         _entityPvsCollection.UpdateIndex(uid, coordinates);
-
-        // since elements are cached grid-/map-relative, we dont need to update a given grids/maps children
-        if(_mapManager.IsGrid(uid) || _mapManager.IsMap(uid)) return;
 
         var children = xform.ChildEnumerator;
 

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -537,14 +537,18 @@ namespace Robust.Shared.GameObjects
                 return null;
             }
 
-            if (_entMan.TryGetComponent(Owner, out IMapGridComponent? gridComponent))
+            if (_entMan.HasComponent<IMapGridComponent>(Owner))
             {
                 return Owner;
             }
 
             if (_parent.IsValid())
             {
-                return xformQuery.GetComponent(_parent).GridUid;
+                var parentXform = xformQuery.GetComponent(_parent);
+                if (parentXform.GridUid != null || parentXform.LifeStage >= ComponentLifeStage.Initialized)
+                    return parentXform.GridUid;
+                else
+                    return parentXform.FindGridEntityId(xformQuery);
             }
 
             return _mapManager.TryFindGridAt(MapID, WorldPosition, out var mapgrid) ? mapgrid.GridEntityId : null;
@@ -861,6 +865,8 @@ namespace Robust.Shared.GameObjects
         public readonly Angle OldRotation;
         public readonly Angle NewRotation;
         public readonly TransformComponent Component;
+
+        public bool ParentChanged => NewPosition.EntityId == OldPosition.EntityId;
 
         /// <summary>
         ///     If true, this event was generated during component state handling. This means it can be ignored in some instances.

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -230,8 +230,8 @@ public abstract partial class SharedTransformSystem
             parentXform._children.Add(uid);
         }
 
-
-        SetGridId(component, component.FindGridEntityId(xformQuery));
+        if (component.GridUid == null)
+            SetGridId(component, component.FindGridEntityId(xformQuery));
         component.MatricesDirty = true;
     }
 
@@ -265,7 +265,6 @@ public abstract partial class SharedTransformSystem
     public void SetGridId(TransformComponent xform, EntityUid? gridId, EntityQuery<TransformComponent>? xformQuery = null)
     {
         if (xform._gridUid == gridId) return;
-
 
         DebugTools.Assert(gridId == null || HasComp<MapGridComponent>(gridId));
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -132,8 +132,10 @@ namespace Robust.Shared.GameObjects
             if (xform.LifeStage < ComponentLifeStage.Initialized && xform.GridUid == null)
                 SetGridId(xform, xform.FindGridEntityId(xformQuery));
 
+            DebugTools.Assert(xform.ParentUid.IsValid());
+
             // Is the entity directly parented to the grid?
-            if (xform.GridUid == xform.ParentUid || _mapManager.IsMap(xform.ParentUid))
+            if (xform.GridUid == xform.ParentUid)
                 return xform.Coordinates;
 
             // Is the entity directly parented to the map?
@@ -145,7 +147,7 @@ namespace Robust.Shared.GameObjects
             var worldPos = GetWorldPosition(xform, xformQuery);
 
             return xform.GridUid == null
-                ? new EntityCoordinates(mapId ?? default, worldPos)
+                ? new EntityCoordinates(mapId ?? xform.ParentUid, worldPos)
                 : new EntityCoordinates(xform.GridUid.Value, xformQuery.GetComponent(xform.GridUid.Value).InvLocalMatrix.Transform(worldPos));
         }
 
@@ -156,13 +158,14 @@ namespace Robust.Shared.GameObjects
         {
             var parentUid = coordinates.EntityId;
             var parentXform = xformQuery.GetComponent(parentUid);
+            DebugTools.Assert(parentUid.IsValid());
 
             // GriddUid is only set after init.
             if (parentXform.LifeStage < ComponentLifeStage.Initialized && parentXform.GridUid == null)
                 SetGridId(parentXform, parentXform.FindGridEntityId(xformQuery));
 
             // Is the entity directly parented to the grid?
-            if (parentXform.GridUid == parentUid || _mapManager.IsMap(parentUid))
+            if (parentXform.GridUid == parentUid)
                 return coordinates;
 
             // Is the entity directly parented to the map?
@@ -174,7 +177,7 @@ namespace Robust.Shared.GameObjects
             var worldPos = GetWorldMatrix(parentXform, xformQuery).Transform(coordinates.Position);
 
             return parentXform.GridUid == null
-                ? new EntityCoordinates(mapId ?? default, worldPos)
+                ? new EntityCoordinates(mapId ?? parentUid, worldPos)
                 : new EntityCoordinates(parentXform.GridUid.Value, xformQuery.GetComponent(parentXform.GridUid.Value).InvLocalMatrix.Transform(worldPos));
         }
 
@@ -187,8 +190,10 @@ namespace Robust.Shared.GameObjects
             if (xform.LifeStage < ComponentLifeStage.Initialized && xform.GridUid == null)
                 SetGridId(xform, xform.FindGridEntityId(xformQuery));
 
+            DebugTools.Assert(xform.ParentUid.IsValid());
+
             // Is the entity directly parented to the grid?
-            if (xform.GridUid == xform.ParentUid || _mapManager.IsMap(xform.ParentUid))
+            if (xform.GridUid == xform.ParentUid)
                 return (xform.Coordinates, GetWorldRotation(xform, xformQuery));
 
             // Is the entity directly parented to the map?
@@ -199,7 +204,7 @@ namespace Robust.Shared.GameObjects
             var (pos, worldRot) = GetWorldPositionRotation(xform, xformQuery);
 
             var coords = xform.GridUid == null
-                ? new EntityCoordinates(mapId ?? default, pos)
+                ? new EntityCoordinates(mapId ?? xform.ParentUid, pos)
                 : new EntityCoordinates(xform.GridUid.Value, xformQuery.GetComponent(xform.GridUid.Value).InvLocalMatrix.Transform(pos));
 
             return (coords, worldRot);

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -1,12 +1,15 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
+using System.Reflection.Metadata.Ecma335;
 using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.GameObjects
 {
@@ -123,64 +126,83 @@ namespace Robust.Shared.GameObjects
             }
         }
 
-        public EntityCoordinates GetMoverCoordinates(TransformComponent xform)
+        public EntityCoordinates GetMoverCoordinates(TransformComponent xform, EntityQuery<TransformComponent> xformQuery)
         {
-            // If they're parented directly to the map or grid then just return the coordinates.
-            if (!_mapManager.TryGetGrid(xform.GridUid, out var grid))
-            {
-                var mapUid = _mapManager.GetMapEntityId(xform.MapID);
-                var coordinates = xform.Coordinates;
+            // GriddUid is only set after init.
+            if (xform.LifeStage < ComponentLifeStage.Initialized && xform.GridUid == null)
+                SetGridId(xform, xform.FindGridEntityId(xformQuery));
 
-                // Parented directly to the map.
-                if (xform.ParentUid == mapUid)
-                    return coordinates;
-
-                return new EntityCoordinates(mapUid, coordinates.ToMapPos(EntityManager));
-            }
-
-            // Parented directly to the grid
-            if (grid.GridEntityId == xform.ParentUid)
+            // Is the entity directly parented to the grid?
+            if (xform.GridUid == xform.ParentUid || _mapManager.IsMap(xform.ParentUid))
                 return xform.Coordinates;
 
-            // Parented to grid so convert their pos back to the grid.
-            var gridPos = Transform(grid.GridEntityId).InvWorldMatrix.Transform(xform.WorldPosition);
-            return new EntityCoordinates(grid.GridEntityId, gridPos);
+            // Is the entity directly parented to the map?
+            var mapId = xform.MapUid;
+            if (mapId == xform.ParentUid)
+                return xform.Coordinates;
+
+            // Not parented to grid so convert their pos back to the grid.
+            var worldPos = GetWorldPosition(xform, xformQuery);
+
+            return xform.GridUid == null
+                ? new EntityCoordinates(mapId ?? default, worldPos)
+                : new EntityCoordinates(xform.GridUid.Value, xformQuery.GetComponent(xform.GridUid.Value).InvLocalMatrix.Transform(worldPos));
         }
 
+        /// <summary>
+        ///     Variant of <see cref="GetMoverCoordinates"/> that uses a entity coordinates, rather than an entity's transform.
+        /// </summary>
         public EntityCoordinates GetMoverCoordinates(EntityCoordinates coordinates, EntityQuery<TransformComponent> xformQuery)
         {
-            // GridID isn't ready during EntityInit so YAY
-            IMapGrid? grid = null;
-            var ent = coordinates.EntityId;
+            var parentUid = coordinates.EntityId;
+            var parentXform = xformQuery.GetComponent(parentUid);
 
-            while (ent.IsValid())
-            {
-                if (_mapManager.TryGetGrid(ent, out grid))
-                    break;
+            // GriddUid is only set after init.
+            if (parentXform.LifeStage < ComponentLifeStage.Initialized && parentXform.GridUid == null)
+                SetGridId(parentXform, parentXform.FindGridEntityId(xformQuery));
 
-                ent = xformQuery.GetComponent(ent).ParentUid;
-            }
-
-            // If they're parented directly to the map or grid then just return the coordinates.
-            if (grid == null)
-            {
-                var mapPos = coordinates.ToMap(EntityManager);
-                var mapUid = _mapManager.GetMapEntityId(mapPos.MapId);
-
-                // Parented directly to the map.
-                if (coordinates.EntityId == mapUid)
-                    return coordinates;
-
-                return new EntityCoordinates(mapUid, mapPos.Position);
-            }
-
-            // Parented directly to the grid
-            if (grid.GridEntityId == coordinates.EntityId)
+            // Is the entity directly parented to the grid?
+            if (parentXform.GridUid == parentUid || _mapManager.IsMap(parentUid))
                 return coordinates;
 
-            // Parented to grid so convert their pos back to the grid.
-            var gridPos = Transform(grid.GridEntityId).InvWorldMatrix.Transform(coordinates.ToMapPos(EntityManager));
-            return new EntityCoordinates(grid.GridEntityId, gridPos);
+            // Is the entity directly parented to the map?
+            var mapId = parentXform.MapUid;
+            if (mapId == parentUid)
+                return coordinates;
+
+            // Not parented to grid so convert their pos back to the grid.
+            var worldPos = GetWorldMatrix(parentXform, xformQuery).Transform(coordinates.Position);
+
+            return parentXform.GridUid == null
+                ? new EntityCoordinates(mapId ?? default, worldPos)
+                : new EntityCoordinates(parentXform.GridUid.Value, xformQuery.GetComponent(parentXform.GridUid.Value).InvLocalMatrix.Transform(worldPos));
+        }
+
+        /// <summary>
+        ///     Variant of <see cref="GetMoverCoordinates()"/> that also returns the entity's world rotation
+        /// </summary>
+        public (EntityCoordinates Coords, Angle worldRot) GetMoverCoordinateRotation(TransformComponent xform, EntityQuery<TransformComponent> xformQuery)
+        {
+            // GriddUid is only set after init.
+            if (xform.LifeStage < ComponentLifeStage.Initialized && xform.GridUid == null)
+                SetGridId(xform, xform.FindGridEntityId(xformQuery));
+
+            // Is the entity directly parented to the grid?
+            if (xform.GridUid == xform.ParentUid || _mapManager.IsMap(xform.ParentUid))
+                return (xform.Coordinates, GetWorldRotation(xform, xformQuery));
+
+            // Is the entity directly parented to the map?
+            var mapId = xform.MapUid;
+            if (mapId == xform.ParentUid)
+                return (xform.Coordinates, GetWorldRotation(xform, xformQuery));
+
+            var (pos, worldRot) = GetWorldPositionRotation(xform, xformQuery);
+
+            var coords = xform.GridUid == null
+                ? new EntityCoordinates(mapId ?? default, pos)
+                : new EntityCoordinates(xform.GridUid.Value, xformQuery.GetComponent(xform.GridUid.Value).InvLocalMatrix.Transform(pos));
+
+            return (coords, worldRot);
         }
 
         /// <summary>

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection.Metadata.Ecma335;
+using System.Security.Cryptography;
 using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
@@ -132,8 +133,6 @@ namespace Robust.Shared.GameObjects
             if (xform.LifeStage < ComponentLifeStage.Initialized && xform.GridUid == null)
                 SetGridId(xform, xform.FindGridEntityId(xformQuery));
 
-            DebugTools.Assert(xform.ParentUid.IsValid());
-
             // Is the entity directly parented to the grid?
             if (xform.GridUid == xform.ParentUid)
                 return xform.Coordinates;
@@ -142,6 +141,8 @@ namespace Robust.Shared.GameObjects
             var mapId = xform.MapUid;
             if (mapId == xform.ParentUid)
                 return xform.Coordinates;
+
+            DebugTools.Assert(!_mapManager.IsGrid(xform.Owner) && !_mapManager.IsMap(xform.Owner));
 
             // Not parented to grid so convert their pos back to the grid.
             var worldPos = GetWorldPosition(xform, xformQuery);
@@ -158,7 +159,6 @@ namespace Robust.Shared.GameObjects
         {
             var parentUid = coordinates.EntityId;
             var parentXform = xformQuery.GetComponent(parentUid);
-            DebugTools.Assert(parentUid.IsValid());
 
             // GriddUid is only set after init.
             if (parentXform.LifeStage < ComponentLifeStage.Initialized && parentXform.GridUid == null)
@@ -172,6 +172,8 @@ namespace Robust.Shared.GameObjects
             var mapId = parentXform.MapUid;
             if (mapId == parentUid)
                 return coordinates;
+
+            DebugTools.Assert(!_mapManager.IsGrid(parentUid) && !_mapManager.IsMap(parentUid));
 
             // Not parented to grid so convert their pos back to the grid.
             var worldPos = GetWorldMatrix(parentXform, xformQuery).Transform(coordinates.Position);
@@ -190,8 +192,6 @@ namespace Robust.Shared.GameObjects
             if (xform.LifeStage < ComponentLifeStage.Initialized && xform.GridUid == null)
                 SetGridId(xform, xform.FindGridEntityId(xformQuery));
 
-            DebugTools.Assert(xform.ParentUid.IsValid());
-
             // Is the entity directly parented to the grid?
             if (xform.GridUid == xform.ParentUid)
                 return (xform.Coordinates, GetWorldRotation(xform, xformQuery));
@@ -200,6 +200,8 @@ namespace Robust.Shared.GameObjects
             var mapId = xform.MapUid;
             if (mapId == xform.ParentUid)
                 return (xform.Coordinates, GetWorldRotation(xform, xformQuery));
+
+            DebugTools.Assert(!_mapManager.IsGrid(xform.Owner) && !_mapManager.IsMap(xform.Owner));
 
             var (pos, worldRot) = GetWorldPositionRotation(xform, xformQuery);
 

--- a/Robust.UnitTesting/Shared/GameObjects/Systems/TransformSystemTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/Systems/TransformSystemTests.cs
@@ -70,8 +70,10 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             child1Xform.AttachParent(xform);
             child2Xform.AttachParent(xform);
 
-            var mover1 = xformSystem.GetMoverCoordinates(child1Xform);
-            var mover2 = xformSystem.GetMoverCoordinates(child2Xform);
+            var query = entManager.GetEntityQuery<TransformComponent>();
+
+            var mover1 = xformSystem.GetMoverCoordinates(child1Xform, query);
+            var mover2 = xformSystem.GetMoverCoordinates(child2Xform, query);
 
             Assert.That(mover1.Position, Is.EqualTo(Vector2.One));
             Assert.That(mover2.Position, Is.EqualTo(new Vector2(10f, 10f)));
@@ -80,7 +82,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             var child3Xform = entManager.GetComponent<TransformComponent>(child3);
             child3Xform.AttachParent(child2Xform);
 
-            Assert.That(xformSystem.GetMoverCoordinates(child3Xform).Position, Is.EqualTo(Vector2.One));
+            Assert.That(xformSystem.GetMoverCoordinates(child3Xform, query).Position, Is.EqualTo(Vector2.One));
         }
 
         /// <summary>


### PR DESCRIPTION
Removes `EntParentChangedMessage` handler from PVS system in favour of using only `MoveEvent`. Also significantly modifies `GetMoverCoordinates()` including addding new new functions that simultaneously gets the world rotation.