### PR TITLE
Split dynamic and static broadphases

### DIFF
--- a/Robust.Shared/Physics/BroadphaseComponent.cs
+++ b/Robust.Shared/Physics/BroadphaseComponent.cs
@@ -8,6 +8,14 @@ namespace Robust.Shared.Physics
     [RegisterComponent]
     public sealed class BroadphaseComponent : Component
     {
-        internal IBroadPhase Tree = default!;
+        /// <summary>
+        /// Stores all non-static bodies.
+        /// </summary>
+        internal IBroadPhase DynamicTree = default!;
+
+        /// <summary>
+        /// Stores all static bodies.
+        /// </summary>
+        internal IBroadPhase StaticTree = default!;
     }
 }

--- a/Robust.Shared/Physics/Components/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/Physics/Components/PhysicsComponent.Physics.cs
@@ -58,35 +58,6 @@ namespace Robust.Shared.Physics.Components
         internal BroadphaseComponent? Broadphase { get; set; }
 
         /// <summary>
-        /// Debugging VV
-        /// </summary>
-        [ViewVariables]
-        private Box2? _broadphaseAABB
-        {
-            get
-            {
-                Box2? aabb = null;
-
-                if (Broadphase == null)
-                {
-                    return aabb;
-                }
-
-                var tree = Broadphase.Tree;
-
-                foreach (var (_, fixture) in IoCManager.Resolve<IEntityManager>().GetComponent<FixturesComponent>(Owner).Fixtures)
-                {
-                    foreach (var proxy in fixture.Proxies)
-                    {
-                        aabb = aabb?.Union(tree.GetProxy(proxy.ProxyId)!.AABB) ?? tree.GetProxy(proxy.ProxyId)!.AABB;
-                    }
-                }
-
-                return aabb;
-            }
-        }
-
-        /// <summary>
         ///     Store the body's index within the island so we can lookup its data.
         ///     Key is Island's ID and value is our index.
         /// </summary>

--- a/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
@@ -516,8 +516,8 @@ namespace Robust.Shared.Physics.Systems
             if (broadphase == null)
                 return;
 
-            var oldTree = GetBroadphase(component, broadphase, args.Old);
-            var newTree = GetBroadphase(component, broadphase, component.BodyType);
+            var oldTree = GetBroadphaseTree(component, broadphase, args.Old);
+            var newTree = GetBroadphaseTree(component, broadphase, component.BodyType);
 
             if (oldTree.Equals(newTree))
                 return;
@@ -526,7 +526,7 @@ namespace Robust.Shared.Physics.Systems
             AddProxies(component, newTree);
         }
 
-        private IBroadPhase GetBroadphase(PhysicsComponent body, BroadphaseComponent broadphaseComponent, BodyType bodyType)
+        private IBroadPhase GetBroadphaseTree(PhysicsComponent body, BroadphaseComponent broadphaseComponent, BodyType bodyType)
         {
             return body.BodyType == BodyType.Static ? broadphaseComponent.StaticTree : broadphaseComponent.DynamicTree;
         }
@@ -731,8 +731,7 @@ namespace Robust.Shared.Physics.Systems
             var relativePos1 = new Transform(
                 broadphaseInvMatrix.Transform(transform1.Position),
                 transform1.Quaternion2D.Angle - broadphaseWorldRot);
-            var bodyType = fixture.Body.BodyType;
-            var tree = (bodyType & BodyType.Static) != 0 ? broadphase.StaticTree : broadphase.DynamicTree;
+            var tree = GetBroadphaseTree(fixture.Body, broadphase, fixture.Body.BodyType);
 
             for (var i = 0; i < proxyCount; i++)
             {
@@ -831,8 +830,7 @@ namespace Robust.Shared.Physics.Systems
 
             var transform = new Transform(localPos, worldRot - broadphaseWorldRotation);
             var mapId = broadphaseXform.MapID;
-            var bodyType = fixture.Body.BodyType;
-            var tree = (bodyType & BodyType.Static) != 0 ? broadphase.StaticTree : broadphase.DynamicTree;
+            var tree = GetBroadphaseTree(fixture.Body, broadphase, fixture.Body.BodyType);
 
             for (var i = 0; i < proxyCount; i++)
             {
@@ -865,8 +863,7 @@ namespace Robust.Shared.Physics.Systems
             var proxyCount = fixture.ProxyCount;
             TryComp<SharedPhysicsMapComponent>(_mapManager.GetMapEntityId(map), out var physicsMap);
             var moveBuffer = physicsMap?.MoveBuffer;
-            var bodyType = fixture.Body.BodyType;
-            var tree = (bodyType & BodyType.Static) != 0 ? broadphase.StaticTree : broadphase.DynamicTree;
+            var tree = GetBroadphaseTree(fixture.Body, broadphase, fixture.Body.BodyType);
 
             for (var i = 0; i < proxyCount; i++)
             {

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs
@@ -25,6 +25,7 @@ namespace Robust.Shared.Physics.Systems
         /// <param name="bodyA"></param>
         /// <param name="bodyB"></param>
         /// <returns> 0 -> 1.0f based on WorldAABB overlap</returns>
+        [Obsolete]
         public float IntersectionPercent(PhysicsComponent bodyA, PhysicsComponent bodyB)
         {
             // TODO: Use actual shapes and not just the AABB?
@@ -47,7 +48,20 @@ namespace Robust.Shared.Physics.Systems
             {
                 var gridCollider = EntityManager.GetComponent<TransformComponent>(broadphase.Owner).InvWorldMatrix.TransformBox(collider);
 
-                broadphase.Tree.QueryAabb(ref state, (ref (Box2 collider, MapId map, bool found) state, in FixtureProxy proxy) =>
+                broadphase.StaticTree.QueryAabb(ref state, (ref (Box2 collider, MapId map, bool found) state, in FixtureProxy proxy) =>
+                {
+                    if (proxy.Fixture.CollisionLayer == 0x0)
+                        return true;
+
+                    if (proxy.AABB.Intersects(gridCollider))
+                    {
+                        state.found = true;
+                        return false;
+                    }
+                    return true;
+                }, gridCollider, approximate);
+
+                broadphase.DynamicTree.QueryAabb(ref state, (ref (Box2 collider, MapId map, bool found) state, in FixtureProxy proxy) =>
                 {
                     if (proxy.Fixture.CollisionLayer == 0x0)
                         return true;
@@ -64,6 +78,7 @@ namespace Robust.Shared.Physics.Systems
             return state.found;
         }
 
+        [Obsolete("Use EntityLookup")]
         public IEnumerable<PhysicsComponent> GetCollidingEntities(PhysicsComponent body, bool approximate = true)
         {
             var broadphase = body.Broadphase;
@@ -80,7 +95,19 @@ namespace Robust.Shared.Physics.Systems
             {
                 foreach (var proxy in fixture.Proxies)
                 {
-                    broadphase.Tree.QueryAabb(ref state,
+                    broadphase.StaticTree.QueryAabb(ref state,
+                        (ref (PhysicsComponent body, List<PhysicsComponent> entities) state,
+                            in FixtureProxy other) =>
+                        {
+                            if (other.Fixture.Body.Deleted || other.Fixture.Body == body) return true;
+                            if ((proxy.Fixture.CollisionMask & other.Fixture.CollisionLayer) == 0x0) return true;
+                            if (!ShouldCollide(body, other.Fixture.Body)) return true;
+
+                            state.entities.Add(other.Fixture.Body);
+                            return true;
+                        }, proxy.AABB, approximate);
+
+                    broadphase.DynamicTree.QueryAabb(ref state,
                         (ref (PhysicsComponent body, List<PhysicsComponent> entities) state,
                             in FixtureProxy other) =>
                         {
@@ -120,7 +147,18 @@ namespace Robust.Shared.Physics.Systems
             {
                 foreach (var proxy in fixture.Proxies)
                 {
-                    body.Broadphase.Tree.QueryAabb(ref state,
+                    body.Broadphase.StaticTree.QueryAabb(ref state,
+                        (ref (PhysicsComponent body, HashSet<EntityUid> entities) state,
+                            in FixtureProxy other) =>
+                        {
+                            if (other.Fixture.Body.Deleted || other.Fixture.Body == body) return true;
+                            if ((collisionMask & other.Fixture.CollisionLayer) == 0x0) return true;
+
+                            state.entities.Add(other.Fixture.Body.Owner);
+                            return true;
+                        }, proxy.AABB, approximate);
+
+                    body.Broadphase.DynamicTree.QueryAabb(ref state,
                         (ref (PhysicsComponent body, HashSet<EntityUid> entities) state,
                             in FixtureProxy other) =>
                         {
@@ -149,7 +187,12 @@ namespace Robust.Shared.Physics.Systems
             {
                 var gridAABB = EntityManager.GetComponent<TransformComponent>(broadphase.Owner).InvWorldMatrix.TransformBox(worldAABB);
 
-                foreach (var proxy in broadphase.Tree.QueryAabb(gridAABB, false))
+                foreach (var proxy in broadphase.StaticTree.QueryAabb(gridAABB, false))
+                {
+                    bodies.Add(proxy.Fixture.Body);
+                }
+
+                foreach (var proxy in broadphase.DynamicTree.QueryAabb(gridAABB, false))
                 {
                     bodies.Add(proxy.Fixture.Body);
                 }
@@ -171,7 +214,12 @@ namespace Robust.Shared.Physics.Systems
             {
                 var gridAABB = EntityManager.GetComponent<TransformComponent>(broadphase.Owner).InvWorldMatrix.TransformBox(worldBounds);
 
-                foreach (var proxy in broadphase.Tree.QueryAabb(gridAABB, false))
+                foreach (var proxy in broadphase.StaticTree.QueryAabb(gridAABB, false))
+                {
+                    bodies.Add(proxy.Fixture.Body);
+                }
+
+                foreach (var proxy in broadphase.DynamicTree.QueryAabb(gridAABB, false))
                 {
                     bodies.Add(proxy.Fixture.Body);
                 }
@@ -274,7 +322,33 @@ namespace Robust.Shared.Physics.Systems
 
                 var gridRay = new CollisionRay(position, direction, ray.CollisionMask);
 
-                broadphase.Tree.QueryRay((in FixtureProxy proxy, in Vector2 point, float distFromOrigin) =>
+                broadphase.StaticTree.QueryRay((in FixtureProxy proxy, in Vector2 point, float distFromOrigin) =>
+                {
+                    if (returnOnFirstHit && results.Count > 0)
+                        return true;
+
+                    if (distFromOrigin > maxLength)
+                        return true;
+
+                    if ((proxy.Fixture.CollisionLayer & ray.CollisionMask) == 0x0)
+                        return true;
+
+                    if (!proxy.Fixture.Body.Hard)
+                        return true;
+
+                    if (predicate.Invoke(proxy.Fixture.Body.Owner, state) == true)
+                        return true;
+
+                    // TODO: Shape raycast here
+
+                    // Need to convert it back to world-space.
+                    var result = new RayCastResults(distFromOrigin, matrix.Transform(point), proxy.Fixture.Body.Owner);
+                    results.Add(result);
+                    _sharedDebugRaySystem.ReceiveLocalRayFromAnyThread(new DebugRayData(ray, maxLength, result));
+                    return true;
+                }, gridRay);
+
+                broadphase.DynamicTree.QueryRay((in FixtureProxy proxy, in Vector2 point, float distFromOrigin) =>
                 {
                     if (returnOnFirstHit && results.Count > 0)
                         return true;
@@ -353,7 +427,26 @@ namespace Robust.Shared.Physics.Systems
 
                 var gridRay = new CollisionRay(position, direction, ray.CollisionMask);
 
-                broadphase.Tree.QueryRay((in FixtureProxy proxy, in Vector2 point, float distFromOrigin) =>
+                broadphase.StaticTree.QueryRay((in FixtureProxy proxy, in Vector2 point, float distFromOrigin) =>
+                {
+                    if (distFromOrigin > maxLength || proxy.Fixture.Body.Owner == ignoredEnt)
+                        return true;
+
+                    if (!proxy.Fixture.Hard)
+                        return true;
+
+                    if ((proxy.Fixture.CollisionLayer & ray.CollisionMask) == 0x0)
+                        return true;
+
+                    if (new Ray(point + gridRay.Direction * proxy.AABB.Size.Length * 2, -gridRay.Direction).Intersects(
+                            proxy.AABB, out _, out var exitPoint))
+                    {
+                        penetration += (point - exitPoint).Length;
+                    }
+                    return true;
+                }, gridRay);
+
+                broadphase.DynamicTree.QueryRay((in FixtureProxy proxy, in Vector2 point, float distFromOrigin) =>
                 {
                     if (distFromOrigin > maxLength || proxy.Fixture.Body.Owner == ignoredEnt)
                         return true;

--- a/Robust.UnitTesting/Shared/Physics/Broadphase_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Broadphase_Test.cs
@@ -36,13 +36,13 @@ public sealed class Broadphase_Test
         var mapBroadphase2 = entManager.GetComponent<BroadphaseComponent>(mapManager.GetMapEntityId(mapId2));
         entManager.TickUpdate(0.016f, false);
 #pragma warning disable NUnit2046
-        Assert.That(mapBroadphase1.Tree.Count, Is.EqualTo(0));
+        Assert.That(mapBroadphase1.DynamicTree.Count, Is.EqualTo(0));
 #pragma warning restore NUnit2046
 
         xform.Coordinates = new EntityCoordinates(mapManager.GetMapEntityId(mapId2), Vector2.Zero);
         entManager.TickUpdate(0.016f, false);
 #pragma warning disable NUnit2046
-        Assert.That(mapBroadphase2.Tree.Count, Is.EqualTo(0));
+        Assert.That(mapBroadphase2.DynamicTree.Count, Is.EqualTo(0));
 #pragma warning restore NUnit2046
     }
 


### PR DESCRIPTION
Should make movement significantly faster because static rarely updates and the graph is much larger. Most physics engines do this though some also split by collision mask (which I think might be unreasonable in our case given we have so many, idk).

Eventually I want to make it so the entitylookup tree is just for anything without collision so that will drop the number of ents stored in data structures by <the entire entity count> but that one is much more painful.