### PR TITLE
Optimize client entity spawning by 15%

### DIFF
--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -475,7 +475,7 @@ namespace Robust.Shared.GameObjects
             table.ComponentLists = newArray;
         }
 
-        private static void InitEventTableFreeList(EventTableListEntry[] entries, int end, int start)
+        private static void InitEventTableFreeList(Span<EventTableListEntry> entries, int end, int start)
         {
             var lastFree = -1;
             for (var i = end - 1; i >= start; i--)


### PR DESCRIPTION
For 500 MobHumans spawned in a loop with SpawnEntity: 1540 > 1345 ms