### PR TITLE
Make Box2Serializer split on a span

### DIFF
--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Box2Serializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Box2Serializer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using JetBrains.Annotations;
 using Robust.Shared.IoC;
@@ -15,22 +16,31 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
     [TypeSerializer]
     public sealed class Box2Serializer : ITypeSerializer<Box2, ValueDataNode>
     {
+        private static void NextOrThrow(ref SpanSplitExtensions.Enumerator<char> enumerator, string value)
+        {
+            if (!enumerator.MoveNext())
+                throw new InvalidMappingException($"Could not parse {nameof(Box2)}: '{value}'");
+        }
+
         public Box2 Read(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies,
             bool skipHook,
             ISerializationContext? context = null, Box2 value = default)
         {
-            var args = node.Value.Split(',');
+            var nodeValue = node.Value;
+            var args = nodeValue.AsSpan().Split(',').GetEnumerator();
+            NextOrThrow(ref args, nodeValue);
 
-            if (args.Length != 4)
-            {
-                throw new InvalidMappingException($"Could not parse {nameof(Box2)}: '{node.Value}'");
-            }
+            var l = Parse.Float(args.Current);
+            NextOrThrow(ref args, nodeValue);
 
-            var l = Parse.Float(args[0]);
-            var b = Parse.Float(args[1]);
-            var r = Parse.Float(args[2]);
-            var t = Parse.Float(args[3]);
+            var b = Parse.Float(args.Current);
+            NextOrThrow(ref args, nodeValue);
+
+            var r = Parse.Float(args.Current);
+            NextOrThrow(ref args, nodeValue);
+
+            var t = Parse.Float(args.Current);
 
             return new Box2(l, b, r, t);
         }

--- a/Robust.Shared/Utility/SpanSplitExtensions.cs
+++ b/Robust.Shared/Utility/SpanSplitExtensions.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
+
+namespace Robust.Shared.Utility;
+
+// https://github.com/dotnet/runtime/issues/934
+// https://gist.github.com/LordJZ/92b7decebe52178a445a0b82f63e585a
+internal static class SpanSplitExtensions
+{
+    public ref struct Enumerable<T> where T : IEquatable<T>
+    {
+        public Enumerable(ReadOnlySpan<T> span, T separator)
+        {
+            Span = span;
+            Separator = separator;
+        }
+
+        private ReadOnlySpan<T> Span { get; }
+        private T Separator { get; }
+
+        public Enumerator<T> GetEnumerator() => new(Span, Separator);
+    }
+
+    internal ref struct Enumerator<T> where T : IEquatable<T>
+    {
+        internal Enumerator(ReadOnlySpan<T> span, T separator)
+        {
+            Span = span;
+            Separator = separator;
+            Current = default;
+
+            if (Span.IsEmpty)
+                TrailingEmptyItem = true;
+        }
+
+        private ReadOnlySpan<T> Span { get; set; }
+        private T Separator { get; }
+        private static int SeparatorLength => 1;
+
+        private ReadOnlySpan<T> TrailingEmptyItemSentinel => Unsafe.As<T[]>(nameof(TrailingEmptyItemSentinel)).AsSpan();
+
+        private bool TrailingEmptyItem
+        {
+            get => Span == TrailingEmptyItemSentinel;
+            set => Span = value ? TrailingEmptyItemSentinel : default;
+        }
+
+        public bool MoveNext()
+        {
+            if (TrailingEmptyItem)
+            {
+                TrailingEmptyItem = false;
+                Current = default;
+                return true;
+            }
+
+            if (Span.IsEmpty)
+            {
+                Span = Current = default;
+                return false;
+            }
+
+            var idx = Span.IndexOf(Separator);
+            if (idx < 0)
+            {
+                Current = Span;
+                Span = default;
+            }
+            else
+            {
+                Current = Span[..idx];
+                Span = Span[(idx + SeparatorLength)..];
+                if (Span.IsEmpty)
+                    TrailingEmptyItem = true;
+            }
+
+            return true;
+        }
+
+        public ReadOnlySpan<T> Current { get; private set; }
+    }
+
+    [Pure]
+    internal static Enumerable<T> Split<T>(this ReadOnlySpan<T> span, T separator) where T : IEquatable<T>
+    {
+        return new Enumerable<T>(span, separator);
+    }
+}


### PR DESCRIPTION
Saves ~60 ms out of a total of 1345 ms when spawning 500 MobHumans
From https://gist.github.com/LordJZ/92b7decebe52178a445a0b82f63e585a
See https://github.com/dotnet/runtime/issues/934

<!-- They did splitting on a span -->