### PR TITLE
Slight movement PVS performance improvement

### DIFF
--- a/Robust.Server/GameStates/PVSCollection.cs
+++ b/Robust.Server/GameStates/PVSCollection.cs
@@ -54,7 +54,7 @@ public sealed class PVSCollection<TIndex> : IPVSCollection where TIndex : ICompa
     [Shared.IoC.Dependency] private readonly IEntityManager _entityManager = default!;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Vector2i GetChunkIndices(Vector2 coordinates)
+    public static Vector2i GetChunkIndices(Vector2 coordinates)
     {
         return (coordinates / PVSSystem.ChunkSize).Floored();
     }
@@ -127,7 +127,7 @@ public sealed class PVSCollection<TIndex> : IPVSCollection where TIndex : ICompa
     {
         _changedIndices.EnsureCapacity(_locationChangeBuffer.Count);
 
-        foreach (var (key, loc) in _locationChangeBuffer)
+        foreach (var key in _locationChangeBuffer.Keys)
         {
             _changedIndices.Add(key);
         }

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -918,7 +918,6 @@ internal sealed partial class PVSSystem : EntitySystem
         // to follow a far away entity, the player's own entity is still being sent, but we need to ensure that we also
         // send the new parents, which may otherwise be delayed because of the PVS budget..
 
-
         // TODO PERFORMANCE.
         // ProcessEntry() unnecessarily checks lastSent.ContainsKey() and maybe lastSeen.Contains(). Given that at this
         // point the budgets are just ignored, this should just bypass those checks. But then again 99% of the time this


### PR DESCRIPTION
Mainly replaces the entity coordinate based `UpdateIndex()` with a grid or map specific one, given that we already know from calling `GetMoverCoordinates()` that the coordinates are relative to either a grid or a map.