### PR TITLE
Don't raise rotation event before parent change

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -338,6 +338,7 @@ namespace Robust.Shared.GameObjects
                 }
 
                 var oldPosition = Coordinates;
+                var oldRotation = LocalRotation;
                 _localPosition = value.Position;
                 var changedParent = false;
 
@@ -379,7 +380,10 @@ namespace Robust.Shared.GameObjects
 
                     // preserve world rotation
                     if (LifeStage == ComponentLifeStage.Running)
-                        LocalRotation += (oldParent?.WorldRotation ?? Angle.Zero) - newParent.WorldRotation;
+                    {
+                        oldRotation = _localRotation;
+                        _localRotation += (oldParent?.WorldRotation ?? Angle.Zero) - newParent.WorldRotation;
+                    }
 
                     var entParentChangedMessage = new EntParentChangedMessage(Owner, oldParent?.Owner, oldMapId, this);
                     _entMan.EventBus.RaiseLocalEvent(Owner, ref entParentChangedMessage, true);
@@ -398,9 +402,9 @@ namespace Robust.Shared.GameObjects
                     //TODO: This is a hack, look into WHY we can't call GridPosition before the comp is Running
                     if (Running)
                     {
-                        if (!oldPosition.Equals(Coordinates))
+                        if (!oldPosition.Equals(Coordinates) || !oldRotation.Equals(_localRotation))
                         {
-                            var moveEvent = new MoveEvent(Owner, oldPosition, Coordinates, _localRotation, _localRotation, this, _gameTiming.ApplyingState);
+                            var moveEvent = new MoveEvent(Owner, oldPosition, Coordinates, oldRotation, _localRotation, this, _gameTiming.ApplyingState);
                             _entMan.EventBus.RaiseLocalEvent(Owner, ref moveEvent, true);
                         }
                     }
@@ -408,6 +412,7 @@ namespace Robust.Shared.GameObjects
                 else
                 {
                     _oldCoords ??= oldPosition;
+                    _oldLocalRotation ??= oldRotation;
                 }
             }
         }

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -423,24 +423,23 @@ namespace Robust.Shared.GameObjects
 
         private void OnMove(ref MoveEvent args)
         {
-            UpdatePosition(args.Sender, args.Component);
-        }
-
-        private void UpdatePosition(EntityUid uid, TransformComponent xform)
-        {
             // Even if the entity is contained it may have children that aren't so we still need to update.
-            if (!CanMoveUpdate(uid)) return;
+            if (!CanMoveUpdate(args.Sender)) return;
 
             var broadQuery = GetEntityQuery<BroadphaseComponent>();
             var xformQuery = GetEntityQuery<TransformComponent>();
-            var lookup = GetBroadphase(uid, xform, broadQuery, xformQuery);
 
-            if (lookup == null) return;
+            // TODO: For now we'll just let parent change handle this.
+            var oldLookup = GetBroadphase(args.OldPosition.EntityId, broadQuery, xformQuery);
+            var newLookup = GetBroadphase(args.NewPosition.EntityId, broadQuery, xformQuery);
 
+            if (newLookup == null || oldLookup != newLookup) return;
+
+            var xform = args.Component;
             var coordinates = _transform.GetMoverCoordinates(xform.Coordinates, xformQuery);
-            var lookupRotation = _transform.GetWorldRotation(lookup.Owner, xformQuery);
-            var aabb = GetAABB(uid, coordinates.Position, _transform.GetWorldRotation(xform) - lookupRotation, xform, xformQuery);
-            AddToEntityTree(lookup, xform, aabb, xformQuery, lookupRotation);
+            var lookupRotation = _transform.GetWorldRotation(newLookup.Owner, xformQuery);
+            var aabb = GetAABB(args.Sender, coordinates.Position, _transform.GetWorldRotation(xform) - lookupRotation, xform, xformQuery);
+            AddToEntityTree(newLookup, xform, aabb, xformQuery, lookupRotation);
         }
 
         private bool CanMoveUpdate(EntityUid uid)

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -424,22 +424,20 @@ namespace Robust.Shared.GameObjects
         private void OnMove(ref MoveEvent args)
         {
             // Even if the entity is contained it may have children that aren't so we still need to update.
-            if (!CanMoveUpdate(args.Sender)) return;
+            if (!CanMoveUpdate(args.Sender))
+                return;
 
             var broadQuery = GetEntityQuery<BroadphaseComponent>();
             var xformQuery = GetEntityQuery<TransformComponent>();
+            var lookup = GetBroadphase(args.Sender, args.Component, broadQuery, xformQuery);
 
-            // TODO: For now we'll just let parent change handle this.
-            var oldLookup = GetBroadphase(args.OldPosition.EntityId, broadQuery, xformQuery);
-            var newLookup = GetBroadphase(args.NewPosition.EntityId, broadQuery, xformQuery);
-
-            if (newLookup == null || oldLookup != newLookup) return;
+            if (lookup == null) return;
 
             var xform = args.Component;
             var coordinates = _transform.GetMoverCoordinates(xform.Coordinates, xformQuery);
-            var lookupRotation = _transform.GetWorldRotation(newLookup.Owner, xformQuery);
+            var lookupRotation = _transform.GetWorldRotation(lookup.Owner, xformQuery);
             var aabb = GetAABB(args.Sender, coordinates.Position, _transform.GetWorldRotation(xform) - lookupRotation, xform, xformQuery);
-            AddToEntityTree(newLookup, xform, aabb, xformQuery, lookupRotation);
+            AddToEntityTree(lookup, xform, aabb, xformQuery, lookupRotation);
         }
 
         private bool CanMoveUpdate(EntityUid uid)


### PR DESCRIPTION
Saves us a MoveEvent per parent change + fixes lookup.