### PR TITLE
fix pvs parent change

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -872,7 +872,7 @@ namespace Robust.Shared.GameObjects
         public readonly Angle NewRotation;
         public readonly TransformComponent Component;
 
-        public bool ParentChanged => NewPosition.EntityId == OldPosition.EntityId;
+        public bool ParentChanged => NewPosition.EntityId != OldPosition.EntityId;
 
         /// <summary>
         ///     If true, this event was generated during component state handling. This means it can be ignored in some instances.

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 using Robust.Shared.GameStates;
@@ -830,11 +831,15 @@ public abstract partial class SharedTransformSystem
             RaiseLocalEvent(xform.Owner, ref anchorStateChangedEvent, true);
         }
 
+        // TODO replace this with just setting the xform's entity coordinates.
+
         oldConcrete ??= xformQuery.GetComponent(oldParent);
         oldConcrete._children.Remove(xform.Owner);
 
-        xform._parent = EntityUid.Invalid;
+        var oldPos = xform.Coordinates;
+        var oldRot = xform.LocalRotation;
         var oldMap = xform.MapID;
+        xform._parent = EntityUid.Invalid;
 
         // aaaaaaaaaaaaaaaa
         ChangeMapId(xform, MapId.Nullspace, xformQuery, metaQuery);
@@ -844,6 +849,9 @@ public abstract partial class SharedTransformSystem
 
         var entParentChangedMessage = new EntParentChangedMessage(xform.Owner, oldParent, oldMap, xform);
         RaiseLocalEvent(xform.Owner, ref entParentChangedMessage, true);
+
+        var ev = new MoveEvent(xform.Owner, oldPos, default, oldRot, default, xform, _gameTiming.ApplyingState);
+        RaiseLocalEvent(xform.Owner, ref ev, true);
         Dirty(xform);
     }
     #endregion


### PR DESCRIPTION
PVS uses `ParentChanged`, which had a bug. PR also ensures that move events get raised on detach.