### PR TITLE
Lookup fixes

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/DebugEntityLookupSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/DebugEntityLookupSystem.cs
@@ -92,6 +92,12 @@ public sealed class EntityLookupOverlay : Overlay
                 return true;
             }, lookupAABB);
 
+            lookup.StaticSundriesTree.QueryAabb(ref ents, static (ref List<EntityUid> state, in EntityUid value) =>
+            {
+                state.Add(value);
+                return true;
+            }, lookupAABB);
+
             lookup.SundriesTree.QueryAabb(ref ents, static (ref List<EntityUid> state, in EntityUid value) =>
             {
                 state.Add(value);

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -53,6 +53,16 @@ public sealed partial class EntityLookupSystem
                 }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
         }
 
+        if ((flags & LookupFlags.Sundries & (LookupFlags.Static | LookupFlags.Anchored)) != 0x0)
+        {
+            lookup.StaticSundriesTree.QueryAabb(ref intersecting,
+                static (ref HashSet<EntityUid> state, in EntityUid value) =>
+                {
+                    state.Add(value);
+                    return true;
+                }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+        }
+
         if ((flags & LookupFlags.Sundries) != 0x0)
         {
             lookup.SundriesTree.QueryAabb(ref intersecting,
@@ -97,6 +107,16 @@ public sealed partial class EntityLookupSystem
             }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
         }
 
+        if ((flags & LookupFlags.Sundries & (LookupFlags.Static | LookupFlags.Anchored)) != 0x0)
+        {
+            lookup.StaticSundriesTree.QueryAabb(ref intersecting,
+                static (ref HashSet<EntityUid> state, in EntityUid value) =>
+                {
+                    state.Add(value);
+                    return true;
+                }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+        }
+        
         if ((flags & LookupFlags.Sundries) != 0x0)
         {
             lookup.SundriesTree.QueryAabb(ref intersecting,
@@ -131,11 +151,23 @@ public sealed partial class EntityLookupSystem
             }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
         }
 
-        if ((flags & LookupFlags.Dynamic) != 0x0)
+        if ((flags & (LookupFlags.Static | LookupFlags.Anchored)) != 0x0)
         {
             lookup.StaticTree.QueryAabb(ref state, (ref (EntityUid? ignored, bool found) tuple, in FixtureProxy value) =>
             {
                 if (tuple.ignored == value.Fixture.Body.Owner)
+                    return true;
+
+                tuple.found = true;
+                return false;
+            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+        }
+
+        if ((flags & LookupFlags.Sundries & (LookupFlags.Static | LookupFlags.Anchored)) != 0x0)
+        {
+            lookup.StaticSundriesTree.QueryAabb(ref state, static (ref (EntityUid? ignored, bool found) tuple, in EntityUid value) =>
+            {
+                if (tuple.ignored == value)
                     return true;
 
                 tuple.found = true;
@@ -189,6 +221,18 @@ public sealed partial class EntityLookupSystem
             lookup.StaticTree.QueryAabb(ref state, (ref (EntityUid? ignored, bool found) tuple, in FixtureProxy value) =>
             {
                 if (tuple.ignored == value.Fixture.Body.Owner)
+                    return true;
+
+                tuple.found = true;
+                return false;
+            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+        }
+
+        if ((flags & LookupFlags.Sundries & (LookupFlags.Static | LookupFlags.Anchored)) != 0x0)
+        {
+            lookup.StaticSundriesTree.QueryAabb(ref state, static (ref (EntityUid? ignored, bool found) tuple, in EntityUid value) =>
+            {
+                if (tuple.ignored == value)
                     return true;
 
                 tuple.found = true;
@@ -580,6 +624,15 @@ public sealed partial class EntityLookupSystem
                 }, aabb, (flags & LookupFlags.Approximate) != 0x0);
             }
 
+            if ((flags & LookupFlags.Sundries & (LookupFlags.Static | LookupFlags.Anchored)) != 0x0)
+            {
+                lookup.StaticSundriesTree.QueryAabb(ref intersecting, static (ref HashSet<EntityUid> intersecting, in EntityUid value) =>
+                {
+                    intersecting.Add(value);
+                    return true;
+                }, aabb, (flags & LookupFlags.Approximate) != 0x0);
+            }
+
             if ((flags & LookupFlags.Sundries) != 0x0)
             {
                 lookup.SundriesTree.QueryAabb(ref intersecting, static (ref HashSet<EntityUid> intersecting, in EntityUid value) =>
@@ -627,6 +680,15 @@ public sealed partial class EntityLookupSystem
                     tuple.intersecting.Add(value.Fixture.Body.Owner);
                     return true;
                 }, aabb, (flags & LookupFlags.Approximate) != 0x0);
+        }
+
+        if ((flags & LookupFlags.Sundries & (LookupFlags.Static | LookupFlags.Anchored)) != 0x0)
+        {
+            lookup.StaticSundriesTree._b2Tree.Query(ref state, static (ref (B2DynamicTree<EntityUid> _b2Tree, HashSet<EntityUid> intersecting) tuple, DynamicTree.Proxy proxy) =>
+            {
+                tuple.intersecting.Add(tuple._b2Tree.GetUserData(proxy));
+                return true;
+            }, aabb);
         }
 
         if ((flags & LookupFlags.Sundries) != 0x0)
@@ -706,6 +768,15 @@ public sealed partial class EntityLookupSystem
             }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
         }
 
+        if ((flags & LookupFlags.Sundries & (LookupFlags.Static | LookupFlags.Anchored)) != 0x0)
+        {
+            component.StaticSundriesTree.QueryAabb(ref intersecting, static (ref HashSet<EntityUid> intersecting, in EntityUid value) =>
+            {
+                intersecting.Add(value);
+                return true;
+            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+        }
+
         if ((flags & LookupFlags.Sundries) != 0x0)
         {
             component.SundriesTree.QueryAabb(ref intersecting, static (ref HashSet<EntityUid> intersecting, in EntityUid value) =>
@@ -738,6 +809,15 @@ public sealed partial class EntityLookupSystem
             component.StaticTree.QueryAabb(ref intersecting, static (ref HashSet<EntityUid> intersecting, in FixtureProxy value) =>
             {
                 intersecting.Add(value.Fixture.Body.Owner);
+                return true;
+            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+        }
+
+        if ((flags & LookupFlags.Sundries & (LookupFlags.Static | LookupFlags.Anchored)) != 0x0)
+        {
+            component.StaticSundriesTree.QueryAabb(ref intersecting, static (ref HashSet<EntityUid> intersecting, in EntityUid value) =>
+            {
+                intersecting.Add(value);
                 return true;
             }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
         }

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.ComponentQueries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.ComponentQueries.cs
@@ -50,6 +50,18 @@ public sealed partial class EntityLookupSystem
             }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
         }
 
+        if ((flags & LookupFlags.Sundries & (LookupFlags.Static | LookupFlags.Anchored)) != 0x0)
+        {
+            lookup.StaticSundriesTree.QueryAabb(ref state, static (ref (HashSet<T> intersecting, EntityQuery<T> query) tuple, in EntityUid value) =>
+            {
+                if (!tuple.query.TryGetComponent(value, out var comp))
+                    return true;
+
+                tuple.intersecting.Add(comp);
+                return true;
+            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+        }
+
         if ((flags & LookupFlags.Sundries) != 0x0)
         {
             lookup.SundriesTree.QueryAabb(ref state, static (ref (HashSet<T> intersecting, EntityQuery<T> query) tuple, in EntityUid value) =>

--- a/Robust.Shared/Physics/BroadphaseComponent.cs
+++ b/Robust.Shared/Physics/BroadphaseComponent.cs
@@ -19,8 +19,13 @@ namespace Robust.Shared.Physics
         public IBroadPhase StaticTree = default!;
 
         /// <summary>
-        /// Stores all entities not in another tree.
+        /// Stores all other non-static entities not in another tree.
         /// </summary>
         public DynamicTree<EntityUid> SundriesTree = default!;
+
+        /// <summary>
+        /// Stores all other static entities not in another tree.
+        /// </summary>
+        public DynamicTree<EntityUid> StaticSundriesTree = default!;
     }
 }

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
@@ -47,7 +47,7 @@ public partial class SharedPhysicsSystem
         var xform = Transform(uid);
 
 
-        if (component.CanCollide && (_containerSystem.IsEntityInContainer(uid) || xform.MapID == MapId.Nullspace))
+        if (component.CanCollide && (_containerSystem.IsEntityOrParentInContainer(uid) || xform.MapID == MapId.Nullspace))
         {
             SetCanCollide(component, false, false);
         }


### PR DESCRIPTION
- Body type and collision changed handling wasn't checking if entities were in containers, causing all contained entities to be added to the sundries tree
- Some is-in-container checks should have been is-ent-or-parent-in-container.
- One `StaticTree` query used the wrong bitflag check.
- collision-less anchored entities were added to the sundries tree, instead of the static tree
  - This is incompatible with old behaviour where excluding anchored entities would  uuhhh well exclude all anchored entities, leading to issues with storage lockers eating pipes
  - Adding collisionless entities to the static tree made physics cry, so This PR adds a StaticSundries tree instead.
  - There might be a better way of fixing this eventually, but I dunno enough and at least this fixes the issue for now.

This does NOTfix #3387, so there are more issues somewhere.