### PR TITLE
Replaces ContainsEntity() with metadata flag check

### DIFF
--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -541,7 +541,7 @@ namespace Robust.Shared.GameObjects
             var metaQuery = GetEntityQuery<MetaDataComponent>();
             var contQuery = GetEntityQuery<ContainerManagerComponent>();
             var aabb = GetAABBNoContainer(xform.Owner, coordinates.Position, _transform.GetWorldRotation(xform, xformQuery) - lookupRotation);
-            AddToEntityTree(lookup, xform, aabb, xformQuery, lookupRotation, recursive);
+            AddToEntityTree(lookup, xform, aabb, xformQuery, metaQuery, contQuery, lookupRotation, recursive);
         }
 
         private void AddToEntityTree(


### PR DESCRIPTION
Replaces a `ContainerManagerComponent.ContainsEntity()` check with a metadata-flag check. If an entity has a container, it probably stores more than one entity and/or has more than one container, so checking the metadata comp should be faster than doing a List.Contains() foreach entity.

Also adds metadata & ContainerManagerComponent queries.