### PR TITLE
Add additional container assert

### DIFF
--- a/Robust.Shared/Containers/BaseContainer.cs
+++ b/Robust.Shared/Containers/BaseContainer.cs
@@ -207,6 +207,7 @@ namespace Robust.Shared.Containers
             IoCManager.Resolve(ref entMan);
             DebugTools.Assert(entMan.EntityExists(toremove));
             DebugTools.Assert(xform == null || xform.Owner == toremove);
+            DebugTools.Assert(entMan.GetComponent<MetaDataComponent>(Owner).EntityLifeStage < EntityLifeStage.Terminating);
 
             if (!CanRemove(toremove, entMan)) return false;
             InternalRemove(toremove, entMan, meta);

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -334,7 +334,7 @@ namespace Robust.Shared.GameObjects
             var transform = xformQuery.GetComponent(metadata.Owner);
             metadata.EntityLifeStage = EntityLifeStage.Terminating;
             var ev = new EntityTerminatingEvent(metadata.Owner);
-            EventBus.RaiseLocalEvent(metadata.Owner, ref ev, false);
+            EventBus.RaiseLocalEvent(metadata.Owner, ref ev);
 
             foreach (var child in transform._children)
             {

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -334,9 +334,6 @@ namespace Robust.Shared.GameObjects
             var transform = xformQuery.GetComponent(metadata.Owner);
             metadata.EntityLifeStage = EntityLifeStage.Terminating;
             var ev = new EntityTerminatingEvent(metadata.Owner);
-
-            // TODO: consider making this a meta-data flag?
-            // veeeery few entities make use of this event.
             EventBus.RaiseLocalEvent(metadata.Owner, ref ev, false);
 
             foreach (var child in transform._children)

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -333,7 +333,7 @@ namespace Robust.Shared.GameObjects
         {
             var transform = xformQuery.GetComponent(metadata.Owner);
             metadata.EntityLifeStage = EntityLifeStage.Terminating;
-            var ev = new EntityTerminatingEvent(metadata.Owner);
+            var ev = new EntityTerminatingEvent();
             EventBus.RaiseLocalEvent(metadata.Owner, ref ev);
 
             foreach (var child in transform._children)

--- a/Robust.Shared/GameObjects/EntitySystemMessages/EntityTerminatingEvent.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/EntityTerminatingEvent.cs
@@ -4,13 +4,7 @@ namespace Robust.Shared.GameObjects
     /// The children of this entity are about to be deleted.
     /// </summary>
     [ByRefEvent]
-    public struct EntityTerminatingEvent
+    public readonly struct EntityTerminatingEvent
     {
-        public EntityUid Owner;
-
-        public EntityTerminatingEvent(EntityUid uid)
-        {
-            Owner = uid;
-        }
     }
 }


### PR DESCRIPTION
Disposal units and maybe some other entities currently fail this assert.

Also removed EntityUid from termination events, seeing as it isn't broadcasted anyways.