### PR TITLE
Add exception for infinite loop in Balance()

### DIFF
--- a/Robust.Shared/Physics/B2DynamicTree.cs
+++ b/Robust.Shared/Physics/B2DynamicTree.cs
@@ -583,10 +583,8 @@ namespace Robust.Shared.Physics
                 indexNode.Height = Math.Max(child1Node.Height, child2Node.Height) + 1;
                 indexNode.Aabb = child1Node.Aabb.Union(child2Node.Aabb);
 
-#if DEBUG
                 if (index == indexNode.Parent)
                     throw new Exception($"Infinite loop in B2DynamicTree.Balance(). Trace: {Environment.StackTrace}");
-#endif
 
                 index = indexNode.Parent;
             }

--- a/Robust.Shared/Physics/B2DynamicTree.cs
+++ b/Robust.Shared/Physics/B2DynamicTree.cs
@@ -583,6 +583,11 @@ namespace Robust.Shared.Physics
                 indexNode.Height = Math.Max(child1Node.Height, child2Node.Height) + 1;
                 indexNode.Aabb = child1Node.Aabb.Union(child2Node.Aabb);
 
+#if DEBUG
+                if (index == indexNode.Parent)
+                    throw new Exception($"Infinite loop in B2DynamicTree.Balance(). Trace: {Environment.StackTrace}");
+#endif
+
                 index = indexNode.Parent;
             }
 


### PR DESCRIPTION
Dunno enough about how the dynamic tree works to know if there's any reason you'd ever have `index == indexNode.Parent` but it seems to work fine with this assert?

Related to #3395, but this obviously doesn't fix the issue.