### PR TITLE
Add osx-arm64 support

### DIFF
--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -26,7 +26,7 @@ jobs:
         dotnet-version: 6.0.100
 
     - name: Package client
-      run: Tools/package_client_build.py -p windows mac linux
+      run: Tools/package_client_build.py -p windows mac-intel mac-apple-silicon linux
 
     - name: Shuffle files around
       run: |

--- a/Robust.Client/Audio/Midi/MidiManager.cs
+++ b/Robust.Client/Audio/Midi/MidiManager.cs
@@ -103,6 +103,12 @@ internal sealed partial class MidiManager : IMidiManager
 
     private const string ContentCustomSoundfontDirectory = "/Audio/MidiCustom/";
 
+    // explicitly look for version 2 where possible, or the fluidsynth module will just pick up anything called 'libfluidsynth'
+    // and we're incompatible with v3.
+    private const string DefaultLibrary = "fluidsynth";
+    private const string LinuxLibrary =  "libfluidsynth.2.so";
+    private const string OsxLibrary = "libfluidsynth.2.dylib";
+
     private const float MaxDistanceForOcclusion = 1000;
 
     private static ResourcePath CustomSoundfontDirectory = new ResourcePath("/soundfonts/");
@@ -148,6 +154,8 @@ internal sealed partial class MidiManager : IMidiManager
             _resourceManager.UserData.Rename(CustomSoundfontDirectory, CustomSoundfontDirectory.WithName(CustomSoundfontDirectory.Filename + ".old"));
             _resourceManager.UserData.CreateDir(CustomSoundfontDirectory);
         }
+
+        DllMapHelper.RegisterExplicitMap(typeof(NFluidsynth.Logger).Assembly, DefaultLibrary, LinuxLibrary, OsxLibrary);
 
         try
         {

--- a/Robust.Client/Robust.Client.csproj
+++ b/Robust.Client/Robust.Client.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="OpenToolkit.Graphics" Version="4.0.0-pre9.1" />
     <PackageReference Include="OpenTK.OpenAL" Version="4.7.5" />
     <PackageReference Include="SpaceWizards.SharpFont" Version="1.0.1" />
-    <PackageReference Include="Robust.Natives" Version="0.1.1" />
+    <PackageReference Include="Robust.Natives" Version="0.1.2" />
     <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.20348-rc2" />
   </ItemGroup>
   <ItemGroup Condition="'$(EnableClientScripting)' == 'True'">

--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -20,6 +20,8 @@
     <PackageReference Include="Serilog.Sinks.Loki" Version="4.0.0-beta3" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />
     <PackageReference Include="prometheus-net.DotNetRuntime" Version="4.2.2" />
+    <PackageReference Include="Robust.Natives.Zstd" Version="0.1.0" />
+    <PackageReference Include="Robust.Natives.Libsodium" Version="0.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Lidgren.Network\Lidgren.Network.csproj" />

--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="Serilog.Sinks.Loki" Version="4.0.0-beta3" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />
     <PackageReference Include="prometheus-net.DotNetRuntime" Version="4.2.2" />
-    <PackageReference Include="Robust.Natives.Zstd" Version="0.1.0" />
-    <PackageReference Include="Robust.Natives.Libsodium" Version="0.1.0" />
+    <PackageReference Condition="'$(TargetOS)' == 'MacOS' and '$(ProcessorArchitecture)' == 'arm64'"
+        Include="Robust.Natives.Zstd" Version="0.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Lidgren.Network\Lidgren.Network.csproj" />

--- a/Robust.Shared/Robust.Shared.csproj
+++ b/Robust.Shared/Robust.Shared.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="Linguini.Bundle" Version="0.1.3" />
     <PackageReference Include="SharpZstd.Interop" Version="1.5.2-beta2" />
-    <PackageReference Include="SpaceWizards.Sodium" Version="0.2.0" />
+    <PackageReference Include="SpaceWizards.Sodium" Version="0.2.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
   </ItemGroup>
   <ItemGroup>

--- a/Tools/package_client_build.py
+++ b/Tools/package_client_build.py
@@ -164,17 +164,17 @@ def build_windows(skip_build: bool) -> None:
     # Cool we're done.
     client_zip.close()
 
-def build_macos(platform_name: str, skip_build: bool) -> None:
-    arch_directory_name = "osx-x64" if platform_name == PLATFORM_MACOS else "osx-arm64"
+def build_macos(publish_name: str, skip_build: bool) -> None:
+    arch_directory_name = "osx-x64" if publish_name == PLATFORM_MACOS else "osx-arm64"
 
-    print(Fore.GREEN + f"Building project for ${platform_name} (${arch_directory_name})..." + Style.RESET_ALL)
+    print(Fore.GREEN + f"Building project for {publish_name} ({arch_directory_name})..." + Style.RESET_ALL)
 
     if not skip_build:
         publish_client(arch_directory_name, "MacOS")
 
-    print(Fore.GREEN + f"Packaging ${platform_name} (${arch_directory_name}) client..." + Style.RESET_ALL)
+    print(Fore.GREEN + f"Packaging {publish_name} ({arch_directory_name}) client..." + Style.RESET_ALL)
     # Client has to go in an app bundle.
-    client_zip = zipfile.ZipFile(p("release", f"Robust.Client_${platform_name}.zip"), "a",
+    client_zip = zipfile.ZipFile(p("release", f"Robust.Client_{publish_name}.zip"), "a",
                                  compression=zipfile.ZIP_DEFLATED)
 
     contents = p("Space Station 14.app", "Contents", "Resources")


### PR DESCRIPTION
Adds osx-arm64 support. Still in testing stages and this is still very early. Draft for feedback.

In local tests this seems to all work, and I played a full game on Lizard and it worked almost perfectly the entire time and was pegged at 120 FPS... 

but some part of the map had a client-side entity that caused my screen to stop updating entirely. Though the game was still responsive, so I could walk away from the bugged area and everything would resume, it is pretty brutal. Traceback is below under Known Issues. I don't know more than that yet.

Still, things seem promising.

The number one open question of course is: is this a good idea at all, and now that I have it somewhat working, I can see arguments for both sides.


### Changes
- bump native dependencies for Robust.Client
- Robust.Server osx-arm64 now requires Zstd.
- explicitly set the library name of fluidsynth to have a `2` in it to be compatible with the dylib that is packed in the build deps, and to stop problems like https://github.com/space-wizards/RobustToolbox/issues/3376
- update package_client_build.py to add `mac-apple-silicon` 

#### Upstream requirements

- [ ] https://github.com/space-wizards/nativefiledialog/pull/2
- [ ] https://github.com/space-wizards/native-build/pull/4
- [ ] https://github.com/space-wizards/build-dependencies/pull/2
- [ ] https://github.com/space-wizards/SpaceWizards.Sodium/pull/1


### Known issues
- https://github.com/glfw/glfw/issues/1997
This has been happening a long time and also happens under Rosetta - e.g. https://github.com/space-wizards/space-station-14/issues/5186 - and the GLFW maintainers traced it back to bugs introduced by Apple. Doesn't seem like there is much we can do here. Some minor revisions of OSX remove the bug, but other ones seem to bring it back.
- Bugged client-side entity (light?), needs investigation.
```
[ERRO] runtime: Caught exception in "GameLoop Render"
System.Collections.Generic.KeyNotFoundException: Entity c2754 does not have a component of type Robust.Shared.GameObjects.TransformComponent
   at Robust.Client.Graphics.Clyde.Clyde.DrawLightsAndFov(Viewport viewport, Box2Rotated worldBounds, Box2 worldAABB, IEye eye) in .../Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs:line 436
   at Robust.Client.Graphics.Clyde.Clyde.<>c__DisplayClass204_0.<RenderViewport>b__0() in .../Robust.Client/Graphics/Clyde/Clyde.HLR.cs:line 574
   at Robust.Client.Graphics.Clyde.Clyde.RenderInRenderTarget(RenderTargetBase rt, Action a, Nullable`1 clearColor) in .../Robust.Client/Graphics/Clyde/Clyde.HLR.cs:line 446
   at Robust.Client.Graphics.Clyde.Clyde.RenderViewport(Viewport viewport) in .../Robust.Client/Graphics/Clyde/Clyde.HLR.cs:line 575
```
- changing the libsodium version might be a bad idea (https://github.com/jedisct1/libsodium/issues/1075) -- make a native runtime package instead.

### Questions
- Not actually sure if `$(ProcessArchitecture)` is doing what I want? It seems to work locally. Could just remove the conditional, it's not hurting anybody
- Seems like a really ugly place to set the fluidsynth library name but I can't figure out where would be better, suggestions welcome
- Does package_client_build.py do anything? Am I doing it right? I can't really tell.


