### PR TITLE
Add command to profile entity spawning

### DIFF
--- a/Robust.Client/Console/Commands/ProfileEntitySpawningCommand.cs
+++ b/Robust.Client/Console/Commands/ProfileEntitySpawningCommand.cs
@@ -4,6 +4,7 @@ using Robust.Shared.Console;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
+using Robust.Shared.Timing;
 
 namespace Robust.Client.Console.Commands;
 
@@ -39,6 +40,9 @@ public sealed class ProfileEntitySpawningCommand : IConsoleCommand
                 return;
         }
 
+        var stopwatch = new Stopwatch();
+        stopwatch.Start();
+
         MeasureProfiler.StartCollectingData();
 
         for (var i = 0; i < amount; i++)
@@ -47,7 +51,8 @@ public sealed class ProfileEntitySpawningCommand : IConsoleCommand
         }
 
         MeasureProfiler.SaveData();
-        shell.WriteLine($"Client: Profiled spawning {amount} entities");
+
+        shell.WriteLine($"Client: Profiled spawning {amount} entities in {stopwatch.Elapsed.TotalMilliseconds:N3} ms");
     }
 }
 #endif

--- a/Robust.Client/Console/Commands/ProfileEntitySpawningCommand.cs
+++ b/Robust.Client/Console/Commands/ProfileEntitySpawningCommand.cs
@@ -1,0 +1,53 @@
+﻿#if !FULL_RELEASE
+using JetBrains.Profiler.Api;
+using Robust.Shared.Console;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+
+namespace Robust.Client.Console.Commands;
+
+public sealed class ProfileEntitySpawningCommand : IConsoleCommand
+{
+    [Dependency] private readonly IEntityManager _entities = default!;
+
+    public string Command => "profileEntitySpawning";
+    public string Description => "Profiles entity spawning with n entities";
+    public string Help => $"Usage: {Command} | {Command} <amount> <prototype>";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var amount = 1000;
+        string? prototype = null;
+
+        switch (args.Length)
+        {
+            case 0:
+                break;
+            case 2:
+                if (!int.TryParse(args[0], out amount))
+                {
+                    shell.WriteError($"First argument is not an integer: {args[0]}");
+                    return;
+                }
+
+                prototype = args[1];
+
+                break;
+            default:
+                shell.WriteError(Help);
+                return;
+        }
+
+        MeasureProfiler.StartCollectingData();
+
+        for (var i = 0; i < amount; i++)
+        {
+            _entities.SpawnEntity(prototype, MapCoordinates.Nullspace);
+        }
+
+        MeasureProfiler.SaveData();
+        shell.WriteLine($"Client: Profiled spawning {amount} entities");
+    }
+}
+#endif

--- a/Robust.Client/Robust.Client.csproj
+++ b/Robust.Client/Robust.Client.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="SpaceWizards.SharpFont" Version="1.0.1" />
     <PackageReference Include="Robust.Natives" Version="0.1.1" />
     <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.20348-rc2" />
+    <PackageReference Condition="'$(FullRelease)' != 'True'" Include="JetBrains.Profiler.Api" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(EnableClientScripting)' == 'True'">
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.1" />

--- a/Robust.Server/Console/Commands/ProfileEntitySpawningCommand.cs
+++ b/Robust.Server/Console/Commands/ProfileEntitySpawningCommand.cs
@@ -1,0 +1,53 @@
+﻿#if !FULL_RELEASE
+using JetBrains.Profiler.Api;
+using Robust.Shared.Console;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+
+namespace Robust.Server.Console.Commands;
+
+public sealed class ProfileEntitySpawningCommand : IConsoleCommand
+{
+    [Dependency] private readonly IEntityManager _entities = default!;
+
+    public string Command => "profileEntitySpawning";
+    public string Description => "Profiles entity spawning with n entities";
+    public string Help => $"Usage: {Command} | {Command} <amount>";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var amount = 1000;
+        string? prototype = null;
+
+        switch (args.Length)
+        {
+            case 0:
+                break;
+            case 2:
+                if (!int.TryParse(args[0], out amount))
+                {
+                    shell.WriteError($"First argument is not an integer: {args[0]}");
+                    return;
+                }
+
+                prototype = args[1];
+
+                break;
+            default:
+                shell.WriteError(Help);
+                return;
+        }
+
+        MeasureProfiler.StartCollectingData();
+
+        for (var i = 0; i < amount; i++)
+        {
+            _entities.SpawnEntity(prototype, MapCoordinates.Nullspace);
+        }
+
+        MeasureProfiler.SaveData();
+        shell.WriteLine($"Server: Profiled spawning {amount} entities");
+    }
+}
+#endif

--- a/Robust.Server/Console/Commands/ProfileEntitySpawningCommand.cs
+++ b/Robust.Server/Console/Commands/ProfileEntitySpawningCommand.cs
@@ -4,6 +4,7 @@ using Robust.Shared.Console;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
+using Robust.Shared.Timing;
 
 namespace Robust.Server.Console.Commands;
 
@@ -39,6 +40,9 @@ public sealed class ProfileEntitySpawningCommand : IConsoleCommand
                 return;
         }
 
+        var stopwatch = new Stopwatch();
+        stopwatch.Start();
+
         MeasureProfiler.StartCollectingData();
 
         for (var i = 0; i < amount; i++)
@@ -47,7 +51,8 @@ public sealed class ProfileEntitySpawningCommand : IConsoleCommand
         }
 
         MeasureProfiler.SaveData();
-        shell.WriteLine($"Server: Profiled spawning {amount} entities");
+
+        shell.WriteLine($"Server: Profiled spawning {amount} entities in {stopwatch.Elapsed.TotalMilliseconds:N3} ms");
     }
 }
 #endif

--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Serilog.Sinks.Loki" Version="4.0.0-beta3" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />
     <PackageReference Include="prometheus-net.DotNetRuntime" Version="4.2.2" />
+    <PackageReference Condition="'$(FullRelease)' != 'True'" Include="JetBrains.Profiler.Api" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Lidgren.Network\Lidgren.Network.csproj" />


### PR DESCRIPTION
We finally do have the technology.

To use:
- **On Visual Studio:** good luck look into `ReSharper | Profile | Run Application Performance Profiling`
- **On Rider:** create a new profiling configuration
![image](https://user-images.githubusercontent.com/10968691/197686904-3c213695-1348-4190-90d6-cf424582412b.png)
- Make sure to mark "Control profiling with API" 
![image](https://user-images.githubusercontent.com/10968691/197686804-34149174-71ed-478b-8eb5-3c7c3d03bda3.png)
- Run client and/or server with that configuration (in the case of the client disable sandboxing and uncomment the block of code that calls MeasureProfiler
- Run the command, examples:
  - profileEntitySpawning 
  - sudo profileEntitySpawning 
  - profileEntitySpawning 500
  - profileEntitySpawning 1000 MobHuman