### PR TITLE
Extra-graceful entity deletions.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -15,7 +15,7 @@ Template for new versions:
 
 ### Bugfixes
 
-*None yet*
+* Made entity deletion more resilient against exceptions. Should fix several bugs.
 
 ### Other
 
@@ -102,7 +102,7 @@ Template for new versions:
 
 * The ordering of component removals and shutdowns during entity deltion has changed (see #3355).
 * Improved Box2Serializer
-* Removed uses IEnumerables from EntityLookupSystem. 
+* Removed uses IEnumerables from EntityLookupSystem.
 * Optimized client entity spawning by 15%.
 * Modified how the rendering tree handles entity movement.
 * Improved grid enumeration allocs.

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -980,7 +980,7 @@ internal sealed partial class PVSSystem : EntitySystem
         if (metaDataComponent.EntityLifeStage >= EntityLifeStage.Terminating)
         {
             var rep = new EntityStringRepresentation(uid, metaDataComponent.EntityDeleted, metaDataComponent.EntityName, metaDataComponent.EntityPrototype?.ID);
-            _sawmill.Error($"Attempted to add a deleted entity to PVS send set: {rep}");
+            _sawmill.Error($"Attempted to add a deleted entity to PVS send set: '{rep}'. Trace:\n{Environment.StackTrace}");
             return;
         }
 

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -459,7 +459,14 @@ namespace Robust.Shared.GameObjects
         {
             foreach (var comp in InSafeOrder(_entCompIndex[uid]))
             {
-                RemoveComponentImmediate(comp, uid, true);
+                try
+                {
+                    RemoveComponentImmediate(comp, uid, true);
+                }
+                catch (Exception e)
+                {
+                    Logger.Error($"Caught exception while trying to remove component from entity '{ToPrettyString(uid)}'");
+                }
             }
 
             // DisposeComponents means the entity is getting deleted.
@@ -507,7 +514,8 @@ namespace Robust.Shared.GameObjects
 
         private void RemoveComponentImmediate(Component component, EntityUid uid, bool terminating)
         {
-            if (component == null) throw new ArgumentNullException(nameof(component));
+            if (component == null)
+                throw new ArgumentNullException(nameof(component));
 
             if (component.Owner != uid)
                 throw new InvalidOperationException("Component is not owned by entity.");

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -338,8 +338,6 @@ namespace Robust.Shared.GameObjects
             try
             {
                 var ev = new EntityTerminatingEvent();
-                // TODO: consider making this a meta-data flag?
-                // veeeery few entities make use of this event.
                 EventBus.RaiseLocalEvent(uid, ref ev);
             }
             catch (Exception e)

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -318,7 +318,7 @@ namespace Robust.Shared.GameObjects
 #if !EXCEPTION_TOLERANCE
                 throw new InvalidOperationException(msg);
 #else
-                Logger.Error($"{msg}. Stack: {Environment.StackTrace}");
+                Logger.Error($"{msg}. Trace: {Environment.StackTrace}");
 #endif
             }
 
@@ -331,16 +331,27 @@ namespace Robust.Shared.GameObjects
 
         private void RecursiveFlagEntityTermination(MetaDataComponent metadata, EntityQuery<MetaDataComponent> metaQuery, EntityQuery<TransformComponent> xformQuery, SharedTransformSystem xformSys)
         {
-            var transform = xformQuery.GetComponent(metadata.Owner);
+            var uid = metadata.Owner;
+            var transform = xformQuery.GetComponent(uid);
             metadata.EntityLifeStage = EntityLifeStage.Terminating;
-            var ev = new EntityTerminatingEvent();
-            EventBus.RaiseLocalEvent(metadata.Owner, ref ev);
+
+            try
+            {
+                var ev = new EntityTerminatingEvent();
+                // TODO: consider making this a meta-data flag?
+                // veeeery few entities make use of this event.
+                EventBus.RaiseLocalEvent(uid, ref ev);
+            }
+            catch (Exception e)
+            {
+                Logger.Error($"Caught exception while raising event {nameof(EntityTerminatingEvent)} on entity {ToPrettyString(uid, metadata)}\n{e}");
+            }
 
             foreach (var child in transform._children)
             {
                 if (!metaQuery.TryGetComponent(child, out var childMeta) || childMeta.EntityDeleted)
                 {
-                    Logger.Error($"A deleted entity was still the transform child of another entity. Parent: {ToPrettyString(metadata.Owner)}.");
+                    Logger.Error($"A deleted entity was still the transform child of another entity. Parent: {ToPrettyString(uid, metadata)}.");
                     transform._children.Remove(child);
                     continue;
                 }
@@ -351,29 +362,85 @@ namespace Robust.Shared.GameObjects
 
         private void RecursiveDeleteEntity(MetaDataComponent metadata, EntityQuery<MetaDataComponent> metaQuery, EntityQuery<TransformComponent> xformQuery, SharedTransformSystem xformSys)
         {
-            var transform = xformQuery.GetComponent(metadata.Owner);
+            // Note about this method: #if EXCEPTION_TOLERANCE is not used here because we're gonna it in the future...
+
+            var uid = metadata.Owner;
+            var transform = xformQuery.GetComponent(uid);
 
             // Detach the base entity to null before iterating over children
             // This also ensures that the entity-lookup updates don't have to be re-run for every child (which recurses up the transform hierarchy).
             if (transform.ParentUid != EntityUid.Invalid)
-                xformSys.DetachParentToNull(transform, xformQuery, metaQuery);
+            {
+                try
+                {
+                    xformSys.DetachParentToNull(transform, xformQuery, metaQuery);
+                }
+                catch (Exception e)
+                {
+                    Logger.Error($"Caught exception while trying to detach parent of entity '{ToPrettyString(uid, metadata)}' to null.\n{e}");
+                }
+            }
 
             foreach (var child in transform._children)
             {
-                RecursiveDeleteEntity(metaQuery.GetComponent(child), metaQuery, xformQuery, xformSys);
+                try
+                {
+                    RecursiveDeleteEntity(metaQuery.GetComponent(child), metaQuery, xformQuery, xformSys);
+                }
+                catch(Exception e)
+                {
+                    Logger.Error($"Caught exception while trying to recursively delete child entity '{ToPrettyString(child)}' of '{ToPrettyString(uid, metadata)}'\n{e}");
+                }
             }
 
             if (transform._children.Count != 0)
-                Logger.Error($"Failed to delete all children of entity: {ToPrettyString(metadata.Owner)}");
+                Logger.Error($"Failed to delete all children of entity: {ToPrettyString(uid)}");
+
+            // Shut down all components.
+            foreach (var component in InSafeOrder(_entCompIndex[uid]))
+            {
+                if (component.Running)
+                {
+                    try
+                    {
+                        component.LifeShutdown(this);
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Error($"Caught exception while trying to call shutdown on component of entity '{ToPrettyString(uid, metadata)}'\n{e}");
+                    }
+                }
+            }
 
             // Dispose all my components, in a safe order so transform is available
-            DisposeComponents(metadata.Owner);
-
+            DisposeComponents(uid);
             metadata.EntityLifeStage = EntityLifeStage.Deleted;
-            EntityDeleted?.Invoke(metadata.Owner);
-            _eventBus.OnEntityDeleted(metadata.Owner);
-            EventBus.RaiseEvent(EventSource.Local, new EntityDeletedMessage(metadata.Owner));
-            Entities.Remove(metadata.Owner);
+
+            try
+            {
+                EntityDeleted?.Invoke(uid);
+            }
+            catch (Exception e)
+            {
+                Logger.Error($"Caught exception while invoking event {nameof(EntityDeleted)} on '{ToPrettyString(uid, metadata)}'\n{e}");
+            }
+
+            _eventBus.OnEntityDeleted(uid);
+
+            // Another try-catch, so quickly after the other one?!
+            // Yes. Both of these are try-catch blocks for *events*, which take our precious execution flow away from
+            // us and into whatever spooky code subscribed to this. We don't want an exception in user code suddenly
+            // fucking up entity deletion and leaving us with a frankesteintity, now do we?
+            try
+            {
+                EventBus.RaiseEvent(EventSource.Local, new EntityDeletedMessage(uid));
+            }
+            catch (Exception e)
+            {
+                Logger.Error($"Caught exception while raising {nameof(EntityDeletedMessage)} on '{ToPrettyString(uid, metadata)}'\n{e}");
+            }
+
+            Entities.Remove(uid);
         }
 
         public void QueueDeleteEntity(EntityUid uid)
@@ -556,6 +623,11 @@ namespace Robust.Shared.GameObjects
 
             var metadata = (MetaDataComponent) component;
 
+            return ToPrettyString(uid, metadata);
+        }
+
+        private EntityStringRepresentation ToPrettyString(EntityUid uid, MetaDataComponent metadata)
+        {
             return new EntityStringRepresentation(uid, metadata.EntityDeleted, metadata.EntityName, metadata.EntityPrototype?.ID);
         }
 


### PR DESCRIPTION
AKA add a try-catch block around anything that may throw.
This includes any sort of event invocation, since we can't be entirely sure that the subscribers to those events won't throw.
Will *hopefully* fix https://github.com/space-wizards/space-station-14/issues/12262.

Basically, the exceptions caused by #3402 were being thrown during entity deletion, inside a component shutdown...
EntityManager didn't handle this gracefully enough, and execution would stop before PVS could be notified that the entity had been deleted through an event. The entity, meanwhile, would end up in a "zombie" state.

Now, EntityManager will gracefully handle exceptions on the "unsafe" parts and correctly delete the entity internally even if an error occurs somewhere.