### PR TITLE
Allow for out-of-source-tree builds

### DIFF
--- a/Avalonia.Base/Avalonia.Base.csproj
+++ b/Avalonia.Base/Avalonia.Base.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <Import Project="..\MSBuild\Robust.Common.props" />
 </Project>

--- a/Avalonia.Base/Avalonia.Base.csproj
+++ b/Avalonia.Base/Avalonia.Base.csproj
@@ -1,3 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\MSBuild\Robust.Engine.props" />
+  <Import Project="..\MSBuild\Robust.Common.props" />
 </Project>

--- a/MSBuild/Robust.Common.props
+++ b/MSBuild/Robust.Common.props
@@ -1,4 +1,4 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup Condition="'$(BuildPrefix)'==''">
     <RobustBuildPrefix>..\bin</RobustBuildPrefix>
     <ContentBuildPrefix>..\bin</ContentBuildPrefix>

--- a/MSBuild/Robust.Common.props
+++ b/MSBuild/Robust.Common.props
@@ -1,0 +1,10 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+  <PropertyGroup Condition="'$(BuildPrefix)'==''">
+    <RobustBuildPrefix>..\bin</RobustBuildPrefix>
+    <ContentBuildPrefix>..\bin</ContentBuildPrefix>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(BuildPrefix)'!=''">
+    <RobustBuildPrefix>$(BuildPrefix)\Content\RobustToolbox\bin</RobustBuildPrefix>
+    <ContentBuildPrefix>$(BuildPrefix)\Content\bin</ContentBuildPrefix>
+  </PropertyGroup>
+</Project>

--- a/MSBuild/Robust.OutOfSourceTree.targets
+++ b/MSBuild/Robust.OutOfSourceTree.targets
@@ -1,0 +1,29 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+  <Target
+    Name="OutOfSourceTreeResources"
+    Condition="'$(BuildPrefix)'!=''"
+    AfterTargets="AfterCompile"
+    Outputs="$(RobustBuildPrefix)\..\Resources;$(RobustBuildPrefix)\..\Schemas;$(ContentBuildPrefix)\..\Resources">
+    <ItemGroup>
+      <!--MSB3025 Copy task won't accept directory as input to symlink-->
+      <RobustResourcesPath Include="$(MSBuildThisFileDirectory)..\Resources\**\*"/>
+      <RobustSchemasPath Include="$(MSBuildThisFileDirectory)..\Schemas\**\*"/>
+      <ContentResourcesPath Include="$(MSBuildThisFileDirectory)..\..\Resources\**\*"/>
+    </ItemGroup>
+    <PropertyGroup Condition="'$(UseSymbolicLinksIfPossible)'==''">
+      <UseSymbolicLinksIfPossible>true</UseSymbolicLinksIfPossible>
+    </PropertyGroup>
+    <Copy
+      SourceFiles="@(RobustResourcesPath)"
+      DestinationFiles="@(RobustResourcesPath->'$(RobustBuildPrefix)\..\Resources\%(RecursiveDir)%(Filename)%(Extension)')"
+      UseSymbolicLinksIfPossible="$(UseSymbolicLinksIfPossible)"/>
+    <Copy
+      SourceFiles="@(RobustSchemasPath)"
+      DestinationFiles="@(RobustSchemasPath->'$(RobustBuildPrefix)\..\Schemas\%(RecursiveDir)%(Filename)%(Extension)')"
+      UseSymbolicLinksIfPossible="$(UseSymbolicLinksIfPossible)"/>
+    <Copy
+      SourceFiles="@(ContentResourcesPath)"
+      DestinationFiles="@(ContentResourcesPath->'$(ContentBuildPrefix)\..\Resources\%(RecursiveDir)%(Filename)%(Extension)')"
+      UseSymbolicLinksIfPossible="$(UseSymbolicLinksIfPossible)"/>
+  </Target>
+</Project>

--- a/MSBuild/Robust.OutOfSourceTree.targets
+++ b/MSBuild/Robust.OutOfSourceTree.targets
@@ -1,4 +1,4 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <Target
     Name="OutOfSourceTreeResources"
     Condition="'$(BuildPrefix)'!=''"

--- a/MSBuild/XamlIL.targets
+++ b/MSBuild/XamlIL.targets
@@ -27,9 +27,13 @@
   </PropertyGroup>
 
   <UsingTask
-    Condition="'$(_RobustUseExternalMSBuild)' != 'true' And $(DesignTimeBuild) != true"
+    Condition="'$(_RobustUseExternalMSBuild)' != 'true' And $(DesignTimeBuild) != true And $(BuildPrefix) == ''"
     TaskName="CompileRobustXamlTask"
     AssemblyFile="$(MSBuildThisFileDirectory)\..\Robust.Client.Injectors\bin\$(RobustInjectorsConfiguration)\netstandard2.0\Robust.Client.Injectors.dll"/>
+  <UsingTask
+    Condition="'$(_RobustUseExternalMSBuild)' != 'true' And $(DesignTimeBuild) != true And $(BuildPrefix) != ''"
+    TaskName="CompileRobustXamlTask"
+    AssemblyFile="$(BuildPrefix)\Robust.Client.Injectors\bin\$(Configuration)\netstandard2.0\Robust.Client.Injectors.dll"/>
   <Target
     Name="CompileRobustXaml"
     Condition="Exists('@(IntermediateAssembly)')"

--- a/OpenToolkit.GraphicsLibraryFramework/OpenToolkit.GraphicsLibraryFramework.csproj
+++ b/OpenToolkit.GraphicsLibraryFramework/OpenToolkit.GraphicsLibraryFramework.csproj
@@ -1,4 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\MSBuild\Robust.Common.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>9.0</LangVersion>

--- a/OpenToolkit.GraphicsLibraryFramework/OpenToolkit.GraphicsLibraryFramework.csproj
+++ b/OpenToolkit.GraphicsLibraryFramework/OpenToolkit.GraphicsLibraryFramework.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\MSBuild\Robust.Common.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Robust.Analyzers.Tests/Robust.Analyzers.Tests.csproj
+++ b/Robust.Analyzers.Tests/Robust.Analyzers.Tests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\MSBuild\Robust.Properties.targets" />
+  <Import Project="..\MSBuild\Robust.Common.props" />
   <Import Project="..\MSBuild\Robust.Engine.props" />
   
   <PropertyGroup>

--- a/Robust.Analyzers/Robust.Analyzers.csproj
+++ b/Robust.Analyzers/Robust.Analyzers.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\MSBuild\Robust.Common.props" />
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/Robust.Benchmarks/Robust.Benchmarks.csproj
+++ b/Robust.Benchmarks/Robust.Benchmarks.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\MSBuild\Robust.Common.props" />
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <PropertyGroup>
       <IsPackable>false</IsPackable>
       <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-      <OutputPath>../bin/Benchmarks</OutputPath>
+      <OutputPath>$(RobustBuildPrefix)\Benchmarks</OutputPath>
       <OutputType>Exe</OutputType>
       <NoWarn>RA0003</NoWarn>
   </PropertyGroup>

--- a/Robust.Client.Injectors/Robust.Client.Injectors.csproj
+++ b/Robust.Client.Injectors/Robust.Client.Injectors.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+    <Import Project="..\MSBuild\Robust.Common.props" />
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>

--- a/Robust.Client.NameGenerator/Robust.Client.NameGenerator.csproj
+++ b/Robust.Client.NameGenerator/Robust.Client.NameGenerator.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\MSBuild\Robust.Common.props" />
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>

--- a/Robust.Client.WebView/Robust.Client.WebView.csproj
+++ b/Robust.Client.WebView/Robust.Client.WebView.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\MSBuild\Robust.Common.props" />
   <Import Project="..\MSBuild\Robust.Engine.props" />
 
   <PropertyGroup>

--- a/Robust.Client/Robust.Client.csproj
+++ b/Robust.Client/Robust.Client.csproj
@@ -1,4 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\MSBuild\Robust.Common.props" />
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <PropertyGroup>
     <IsPackable>false</IsPackable>
@@ -6,7 +7,7 @@
     <OutputType>WinExe</OutputType>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <NoWarn>NU1701</NoWarn>
-    <OutputPath>../bin/Client</OutputPath>
+    <OutputPath>$(RobustBuildPrefix)\Client</OutputPath>
     <RobustILLink>true</RobustILLink>
   </PropertyGroup>
   <ItemGroup>

--- a/Robust.Client/Robust.Client.csproj
+++ b/Robust.Client/Robust.Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\MSBuild\Robust.Common.props" />
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <PropertyGroup>

--- a/Robust.Generators.UnitTesting/Robust.Generators.UnitTesting.csproj
+++ b/Robust.Generators.UnitTesting/Robust.Generators.UnitTesting.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\MSBuild\Robust.Common.props" />
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>

--- a/Robust.Generators/Robust.Generators.csproj
+++ b/Robust.Generators/Robust.Generators.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\MSBuild\Robust.Common.props" />
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>

--- a/Robust.Packaging/Robust.Packaging.csproj
+++ b/Robust.Packaging/Robust.Packaging.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\MSBuild\Robust.Common.props" />
   <Import Project="..\MSBuild\Robust.Engine.props" />
 
   <PropertyGroup>

--- a/Robust.Physics/Robust.Physics.csproj
+++ b/Robust.Physics/Robust.Physics.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\MSBuild\Robust.Common.props" />
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <PropertyGroup>
 

--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\MSBuild\Robust.Common.props" />
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <PropertyGroup>

--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -1,10 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\MSBuild\Robust.Common.props" />
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <OutputPath>../bin/Server</OutputPath>
+    <OutputPath>$(RobustBuildPrefix)\Server</OutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <!-- Try to fix sporadic errors against Robust.Packaging, apparently?? -->

--- a/Robust.Shared.CompNetworkGenerator/Robust.Shared.CompNetworkGenerator.csproj
+++ b/Robust.Shared.CompNetworkGenerator/Robust.Shared.CompNetworkGenerator.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\MSBuild\Robust.Common.props" />
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/Robust.Shared.Maths/Robust.Shared.Maths.csproj
+++ b/Robust.Shared.Maths/Robust.Shared.Maths.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\MSBuild\Robust.Common.props" />
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <PropertyGroup>

--- a/Robust.Shared.Maths/Robust.Shared.Maths.csproj
+++ b/Robust.Shared.Maths/Robust.Shared.Maths.csproj
@@ -1,4 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\MSBuild\Robust.Common.props" />
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <PropertyGroup>
     <IsPackable>false</IsPackable>

--- a/Robust.Shared.Scripting/Robust.Shared.Scripting.csproj
+++ b/Robust.Shared.Scripting/Robust.Shared.Scripting.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\MSBuild\Robust.Common.props" />
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath>$(RobustBuildPrefix)\Shared.Maths</OutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/Robust.Shared/Robust.Shared.csproj
+++ b/Robust.Shared/Robust.Shared.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\MSBuild\Robust.Common.props" />
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <PropertyGroup>
     <IsPackable>false</IsPackable>
@@ -51,4 +52,5 @@
 
   <Import Project="..\MSBuild\Robust.Properties.targets" />
   <Import Project="..\MSBuild\Robust.CompNetworkGenerator.targets" />
+  <Import Project="..\MSBuild\Robust.OutOfSourceTree.targets" />
 </Project>

--- a/Robust.UnitTesting/Robust.UnitTesting.csproj
+++ b/Robust.UnitTesting/Robust.UnitTesting.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\MSBuild\Robust.Common.props" />
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <PropertyGroup>

--- a/Robust.UnitTesting/Robust.UnitTesting.csproj
+++ b/Robust.UnitTesting/Robust.UnitTesting.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\MSBuild\Robust.Common.props" />
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <OutputPath>../bin/UnitTesting</OutputPath>
+    <OutputPath>$(RobustBuildPrefix)\UnitTesting</OutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
~Allows build without errors with respect to #3403 but I need to think about it more before I consider this to be a fix.~

~Contingent on [XamlX#1](https://github.com/space-wizards/XamlX/pull/1). **Edit:** This PR build fails without it, that PR copies XamlX and Mono.Cecil assemblies.~

~Changed from AfterCompile to AfterBuild as I suppose copy task for ProjectReferences hadn't run yet. Seems fine. Would prefer links instead of copies to save space.~

~`$(OutDir)` setting in Directory.Build.props appears to override all `$(OutputPath)` settings which I see are used to curate stuff in `bin/stuff/` in both content and robusttoolbox. So that's a consideration, if any other tooling I may use requires that curated structure?~

**EDIT:** Initial proposal had problems. See new comment for new proposal.