### PR TITLE
Make Resolve<TComp> protected

### DIFF
--- a/Robust.Shared/GameObjects/EntitySystem.Resolve.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Resolve.cs
@@ -18,7 +18,7 @@ namespace Robust.Shared.GameObjects
         /// <typeparam name="TComp">The component type to resolve.</typeparam>
         /// <returns>True if the component is not null or was resolved correctly, false if the component couldn't be resolved.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-        public bool Resolve<TComp>(EntityUid uid, [NotNullWhen(true)] ref TComp? component, bool logMissing = true)
+        protected bool Resolve<TComp>(EntityUid uid, [NotNullWhen(true)] ref TComp? component, bool logMissing = true)
             where TComp : IComponent
         {
             DebugTools.Assert(component == null || uid == component.Owner, "Specified Entity is not the component's Owner!");
@@ -45,7 +45,7 @@ namespace Robust.Shared.GameObjects
         /// <typeparam name="TComp2">The component type to resolve.</typeparam>
         /// <returns>True if the components are not null or were resolved correctly, false if any of the component couldn't be resolved.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-        public bool Resolve<TComp1, TComp2>(EntityUid uid, [NotNullWhen(true)] ref TComp1? comp1, [NotNullWhen(true)] ref TComp2? comp2, bool logMissing = true)
+        protected bool Resolve<TComp1, TComp2>(EntityUid uid, [NotNullWhen(true)] ref TComp1? comp1, [NotNullWhen(true)] ref TComp2? comp2, bool logMissing = true)
             where TComp1 : IComponent
             where TComp2 : IComponent
         {
@@ -65,7 +65,7 @@ namespace Robust.Shared.GameObjects
         /// <typeparam name="TComp3">The component type to resolve.</typeparam>
         /// <returns>True if the components are not null or were resolved correctly, false if any of the component couldn't be resolved.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-        public bool Resolve<TComp1, TComp2, TComp3>(EntityUid uid, [NotNullWhen(true)] ref TComp1? comp1, [NotNullWhen(true)] ref TComp2? comp2, [NotNullWhen(true)] ref TComp3? comp3, bool logMissing = true)
+        protected bool Resolve<TComp1, TComp2, TComp3>(EntityUid uid, [NotNullWhen(true)] ref TComp1? comp1, [NotNullWhen(true)] ref TComp2? comp2, [NotNullWhen(true)] ref TComp3? comp3, bool logMissing = true)
             where TComp1 : IComponent
             where TComp2 : IComponent
             where TComp3 : IComponent
@@ -88,7 +88,7 @@ namespace Robust.Shared.GameObjects
         /// <typeparam name="TComp4">The component type to resolve.</typeparam>
         /// <returns>True if the components are not null or were resolved correctly, false if any of the component couldn't be resolved.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-        public bool Resolve<TComp1, TComp2, TComp3, TComp4>(EntityUid uid, [NotNullWhen(true)] ref TComp1? comp1, [NotNullWhen(true)] ref TComp2? comp2, [NotNullWhen(true)] ref TComp3? comp3, [NotNullWhen(true)] ref TComp4? comp4, bool logMissing = true)
+        protected bool Resolve<TComp1, TComp2, TComp3, TComp4>(EntityUid uid, [NotNullWhen(true)] ref TComp1? comp1, [NotNullWhen(true)] ref TComp2? comp2, [NotNullWhen(true)] ref TComp3? comp3, [NotNullWhen(true)] ref TComp4? comp4, bool logMissing = true)
             where TComp1 : IComponent
             where TComp2 : IComponent
             where TComp3 : IComponent


### PR DESCRIPTION
Same rationale as for all the other system helper methods.