### PR TITLE
Broadphase update deferral

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -28,6 +28,7 @@ using Robust.Shared.Network.Messages;
 using Robust.Shared.Profiling;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+using TerraFX.Interop.DirectX;
 
 namespace Robust.Client.GameStates
 {
@@ -327,6 +328,15 @@ namespace Robust.Client.GameStates
                 // Failed to process even a single tick. Chances are the tick buffer is empty, either because of
                 // networking issues or because the server is dead. This will functionally freeze the client-side simulation.
                 return;
+            }
+
+            // Update entity trees.
+            using (_prof.Group("Update entity trees"))
+            {
+                var counts = _entitySystemManager.GetEntitySystem<EntityLookupSystem>().ProcessDeferredUpdates();
+                _prof.WriteValue("Updates", ProfData.Int32(counts.Updates)); // update position in the same tree
+                _prof.WriteValue("Changes", ProfData.Int32(counts.Changes)); // remove from one tree, add to another)
+                _prof.WriteValue("Removals", ProfData.Int32(counts.Removals));
             }
 
             // remove old pending inputs

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -28,7 +28,6 @@ using Robust.Shared.Network.Messages;
 using Robust.Shared.Profiling;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
-using TerraFX.Interop.DirectX;
 
 namespace Robust.Client.GameStates
 {

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.Deferred.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.Deferred.cs
@@ -1,0 +1,176 @@
+using Robust.Shared.Containers;
+using Robust.Shared.Log;
+using Robust.Shared.Map;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Dynamics;
+using System;
+using System.Collections.Generic;
+
+namespace Robust.Shared.GameObjects;
+
+public sealed partial class EntityLookupSystem : EntitySystem
+{
+    // This logic could just be client-side but I CBF creating client/sever variants. The server should never run this code anyways.
+
+    private readonly HashSet<EntityUid> _deferredBroadChanges = new(); // update broadphase (e.g., grid to map)
+    private readonly HashSet<EntityUid> _deferredRemoval = new(); // remove from a broadphase
+    private readonly HashSet<EntityUid> _deferredUpdates = new(); // Update position or collision state
+
+    public (int Updates, int Changes, int Removals) ProcessDeferredUpdates()
+    {
+        _deferredRemoval.ExceptWith(_deferredBroadChanges);
+        _deferredUpdates.ExceptWith(_deferredBroadChanges);
+        _deferredUpdates.ExceptWith(_deferredRemoval);
+
+        var xformQuery = GetEntityQuery<TransformComponent>();
+        var metaQuery = GetEntityQuery<MetaDataComponent>();
+        var contQuery = GetEntityQuery<ContainerManagerComponent>();
+        var physicsQuery = GetEntityQuery<PhysicsComponent>();
+        var fixturesQuery = GetEntityQuery<FixturesComponent>();
+        var broadQuery = GetEntityQuery<BroadphaseComponent>();
+
+        // Blech
+        // what if an entity moves map, changes body, then moves back?
+        // too many edge cases.
+
+        var updates = _deferredUpdates.Count;
+        var changes = _deferredBroadChanges.Count;
+        var removals = _deferredRemoval.Count;
+        try
+        {
+            foreach (var uid in _deferredBroadChanges)
+            {
+                if (!xformQuery.TryGetComponent(uid, out var xform))
+                    continue;
+
+                BroadphaseComponent? oldBroadphase = null;
+                if (xform.Broadphase != null)
+                    broadQuery.TryGetComponent(xform.Broadphase.Value.Uid, out oldBroadphase);
+
+                // TODO separate change-tree from change-broadphase
+                // i.e., if just changing can-collide, we can avoid this call altogether.
+                TryFindBroadphase(xform, broadQuery, xformQuery, out var newBroadphase);
+
+                if (oldBroadphase != null && oldBroadphase != newBroadphase)
+                {
+                    if ()
+                    {
+                        // broadphase[hase unchanged, but tree may have changed
+                        _deferredUpdates.Add(uid);
+                        continue;
+                    }
+
+                    var oldBroadphaseXform = xformQuery.GetComponent(oldBroadphase.Owner);
+                    if (oldBroadphaseXform.MapID != MapId.Nullspace)
+                    {
+                        if (!TryComp(oldBroadphaseXform.MapUid, out SharedPhysicsMapComponent? oldPhysMap))
+                        {
+                            throw new InvalidOperationException(
+                                $"Oldd broadphase's map is missing a physics map comp. Broadphase: {ToPrettyString(oldBroadphase.Owner)}");
+                        }
+
+                        RemoveFromEntityTree(oldBroadphase.Owner, oldBroadphase, oldBroadphaseXform, oldPhysMap, uid, xform, xformQuery, physicsQuery, fixturesQuery);
+                    }
+                }
+
+                if (newBroadphase == null)
+                    continue;
+
+                var newBroadphaseXform = xformQuery.GetComponent(newBroadphase.Owner);
+                if (!TryComp(newBroadphaseXform.MapUid, out SharedPhysicsMapComponent? physMap))
+                {
+                    throw new InvalidOperationException(
+                        $"Broadphase's map is missing a physics map comp. Broadphase: {ToPrettyString(newBroadphase.Owner)}");
+                }
+
+                AddToEntityTree(
+                    newBroadphase.Owner,
+                    newBroadphase,
+                    newBroadphaseXform,
+                    physMap,
+                    uid,
+                    xform,
+                    xformQuery,
+                    metaQuery,
+                    contQuery,
+                    physicsQuery,
+                    fixturesQuery);
+            }
+
+            foreach (var uid in _deferredUpdates)
+            {
+                if (!xformQuery.TryGetComponent(uid, out var xform)
+                    || xform.Broadphase == null
+                    || !broadQuery.TryGetComponent(xform.Broadphase.Value.Uid, out var broadphase))
+                    continue;
+
+                var canCollide = physicsQuery.TryGetComponent(uid, out var body) && body.CanCollide;
+                var staticBody = body?.BodyType == BodyType.Static;
+                var treeChanged = (xform.Broadphase.Value.CanCollide == canCollide) && (xform.Broadphase.Value.Static == staticBody);
+
+                a
+
+                var broadphaseXform = xformQuery.GetComponent(broadphase.Owner);
+
+                if (broadphaseXform.MapID != MapId.Nullspace)
+                    continue;
+
+                if (!TryComp(broadphaseXform.MapUid, out SharedPhysicsMapComponent? physMap))
+                {
+                    throw new InvalidOperationException(
+                        $"Broadphase's map is missing a physics map comp. Broadphase: {ToPrettyString(broadphase.Owner)}");
+                }
+
+                // TODO ensure children are removed from _deferredUpdates?
+                AddToEntityTree(
+                    broadphase.Owner,
+                    broadphase,
+                    broadphaseXform,
+                    physMap,
+                    uid,
+                    xform,
+                    xformQuery,
+                    metaQuery,
+                    contQuery,
+                    physicsQuery,
+                    fixturesQuery);
+            }
+
+            foreach (var uid in _deferredRemoval)
+            {
+                if (!xformQuery.TryGetComponent(uid, out var xform)
+                    || xform.Broadphase == null
+                    || !broadQuery.TryGetComponent(xform.Broadphase.Value.Uid, out var broadphase))
+                    continue;
+
+                var broadphaseXform = xformQuery.GetComponent(broadphase.Owner);
+                if (broadphaseXform.MapID != MapId.Nullspace)
+                    continue;
+
+                if (!TryComp(broadphaseXform.MapUid, out SharedPhysicsMapComponent? physMap))
+                {
+                    throw new InvalidOperationException(
+                        $"Broadphase's map is missing a physics map comp. Broadphase: {ToPrettyString(broadphase.Owner)}");
+                }
+
+                RemoveFromEntityTree(broadphase.Owner, broadphase, broadphaseXform, physMap, uid, xform, xformQuery, physicsQuery, fixturesQuery);
+            }
+        }
+        catch (Exception e)
+        {
+            _deferredBroadChanges.Clear();
+            _deferredUpdates.Clear();
+            _deferredRemoval.Clear();
+            Logger.Error($"Caught Exception while processing deferred lookup updates. Exception: {e}. Stack Trace: {Environment.StackTrace}");
+#if !EXCEPTION_TOLERANCE
+            throw;
+#endif
+        }
+
+        _deferredBroadChanges.Clear();
+        _deferredUpdates.Clear();
+        _deferredRemoval.Clear();
+        return (updates, changes, removals);
+    }
+}


### PR DESCRIPTION
WIP

Tries to defer broadphase updates while applying server states. Should help significantly with stutter induced by entities coming into PVS range by avoid wasted broadphase insertions/removals. Currently the combination of moving, physics body type, physics collision, and container insertion can mean that an entity might be unnecessarily added & removed from broadphases 3+ times.