### PR TITLE
Fix GetEntitiesIntersecting bug

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -37,6 +37,7 @@ namespace Robust.Shared.GameObjects
         ///     Maybe this should be moved to its own component eventually, but at least currently comps are not structs
         ///     and this data is required whenever any entity moves, so this will just save a component lookup.
         /// </remarks>
+        [ViewVariables]
         internal BroadphaseData? Broadphase;
 
         internal bool MatricesDirty = false;

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -116,7 +116,7 @@ public sealed partial class EntityLookupSystem
                     return true;
                 }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
         }
-        
+
         if ((flags & LookupFlags.Sundries) != 0x0)
         {
             lookup.SundriesTree.QueryAabb(ref intersecting,
@@ -662,28 +662,28 @@ public sealed partial class EntityLookupSystem
     public HashSet<EntityUid> GetEntitiesIntersecting(BroadphaseComponent lookup, Box2 aabb, LookupFlags flags = DefaultFlags)
     {
         var intersecting = new HashSet<EntityUid>();
-        var state = (lookup.SundriesTree._b2Tree, intersecting);
 
         if ((flags & LookupFlags.Dynamic) != 0x0)
         {
-            lookup.DynamicTree.QueryAabb(ref state,
-                static (ref (B2DynamicTree<EntityUid> _b2Tree, HashSet<EntityUid> intersecting) tuple, in FixtureProxy value) =>
+            lookup.DynamicTree.QueryAabb(ref intersecting,
+                static (ref HashSet<EntityUid> intersecting, in FixtureProxy value) =>
                 {
-                    tuple.intersecting.Add(value.Fixture.Body.Owner);
+                    intersecting.Add(value.Fixture.Body.Owner);
                     return true;
                 }, aabb, (flags & LookupFlags.Approximate) != 0x0);
         }
 
         if ((flags & (LookupFlags.Static | LookupFlags.Anchored)) != 0x0)
         {
-            lookup.StaticTree.QueryAabb(ref state,
-                static (ref (B2DynamicTree<EntityUid> _b2Tree, HashSet<EntityUid> intersecting) tuple, in FixtureProxy value) =>
+            lookup.StaticTree.QueryAabb(ref intersecting,
+                static (ref HashSet<EntityUid> intersecting, in FixtureProxy value) =>
                 {
-                    tuple.intersecting.Add(value.Fixture.Body.Owner);
+                    intersecting.Add(value.Fixture.Body.Owner);
                     return true;
                 }, aabb, (flags & LookupFlags.Approximate) != 0x0);
         }
 
+        var state = (lookup.StaticSundriesTree._b2Tree, intersecting);
         if ((flags & LookupFlags.StaticSundries) == LookupFlags.StaticSundries)
         {
             lookup.StaticSundriesTree._b2Tree.Query(ref state, static (ref (B2DynamicTree<EntityUid> _b2Tree, HashSet<EntityUid> intersecting) tuple, DynamicTree.Proxy proxy) =>
@@ -693,6 +693,7 @@ public sealed partial class EntityLookupSystem
             }, aabb);
         }
 
+        state = (lookup.SundriesTree._b2Tree, intersecting);
         if ((flags & LookupFlags.Sundries) != 0x0)
         {
             lookup.SundriesTree._b2Tree.Query(ref state, static (ref (B2DynamicTree<EntityUid> _b2Tree, HashSet<EntityUid> intersecting) tuple, DynamicTree.Proxy proxy) =>

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -94,15 +94,14 @@ namespace Robust.Shared.GameObjects
                 if (!xformQuery.TryGetComponent(entity, out var xform) || xform.ParentUid != gridId)
                     continue;
 
+                if (!aabb.Contains(xform.LocalPosition))
+                    continue;
+
                 // If a tile is being removed due to an explosion or somesuch, some entities are likely being deleted.
                 // Avoid unnecessary entity updates.
                 if (EntityManager.IsQueuedForDeletion(entity))
-                {
                     DetachParentToNull(xform, xformQuery, metaQuery, gridXform);
-                    continue;
-                }
-
-                if (aabb.Contains(xform.LocalPosition))
+                else
                     SetParent(xform, mapTransform.Owner, parentXform: mapTransform);
             }
         }


### PR DESCRIPTION
Fixes an issue where the StaticSundriesTree query was given a state with the `SundriesTree._b2Tree`. Was causing entities to not properly unanchor themselves when spaced