### PR TITLE
Remove some redundant physics calls

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/PhysicsSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/PhysicsSystem.cs
@@ -19,7 +19,6 @@ namespace Robust.Server.GameObjects
         public override void Initialize()
         {
             base.Initialize();
-            SubscribeLocalEvent<GridInitializeEvent>(HandleGridInit);
             LoadMetricCVar();
             _configurationManager.OnValueChanged(CVars.MetricsEnabled, _ => LoadMetricCVar());
         }
@@ -27,16 +26,6 @@ namespace Robust.Server.GameObjects
         private void LoadMetricCVar()
         {
             MetricsEnabled = _configurationManager.GetCVar(CVars.MetricsEnabled);
-        }
-
-        private void HandleGridInit(GridInitializeEvent ev)
-        {
-            var guid = ev.EntityUid;
-
-            if (!EntityManager.EntityExists(guid)) return;
-            var collideComp = guid.EnsureComponent<PhysicsComponent>();
-            collideComp.CanCollide = true;
-            collideComp.BodyType = BodyType.Static;
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
@@ -64,7 +64,7 @@ namespace Robust.Shared.Physics.Systems
             _sawmill = Logger.GetSawmill("physics");
             _sawmill.Level = LogLevel.Info;
 
-            SubscribeLocalEvent<GridInitializeEvent>(HandleGridInit);
+            SubscribeLocalEvent<GridAddEvent>(OnGridAdd);
             SubscribeLocalEvent<PhysicsWakeEvent>(OnWake);
             SubscribeLocalEvent<PhysicsSleepEvent>(OnSleep);
             SubscribeLocalEvent<CollisionChangeEvent>(OnCollisionChange);
@@ -85,7 +85,7 @@ namespace Robust.Shared.Physics.Systems
 
         private void OnPhysicsRemove(EntityUid uid, PhysicsComponent component, ComponentRemove args)
         {
-            SetCanCollide(component, false);
+            SetCanCollide(component, false, false);
             DebugTools.Assert(!component.Awake);
         }
 
@@ -243,13 +243,16 @@ namespace Robust.Shared.Physics.Systems
             }
         }
 
-        private void HandleGridInit(GridInitializeEvent ev)
+        private void OnGridAdd(GridAddEvent ev)
         {
-            if (!EntityManager.EntityExists(ev.EntityUid)) return;
-            // Yes this ordering matters
-            var collideComp = EntityManager.EnsureComponent<PhysicsComponent>(ev.EntityUid);
-            SetBodyType(collideComp, BodyType.Static);
-            EntityManager.EnsureComponent<FixturesComponent>(ev.EntityUid);
+            var guid = ev.EntityUid;
+
+            if (!EntityManager.EntityExists(guid) || HasComp<PhysicsComponent>(guid))
+                return;
+
+            var body = AddComp<PhysicsComponent>(guid);
+            SetCanCollide(body, true);
+            SetBodyType(body, BodyType.Static);
         }
 
         public override void Shutdown()


### PR DESCRIPTION
- The grid physics was duplicated.
- No point dirtying the entity getting deleted.

Doesn't seem to explode any loading ingame so hopefully tests are correct.