### PR TITLE
More broadphase fixes

### DIFF
--- a/Robust.Shared/Containers/BaseContainer.cs
+++ b/Robust.Shared/Containers/BaseContainer.cs
@@ -261,7 +261,6 @@ namespace Robust.Shared.Containers
 
             // Unset flag (before parent change events are raised).
             meta.Flags &= ~MetaDataFlags.InContainer;
-
             // Implementation specific remove logic
             InternalRemove(toRemove, entMan);
 

--- a/Robust.Shared/Containers/Container.cs
+++ b/Robust.Shared/Containers/Container.cs
@@ -69,7 +69,7 @@ namespace Robust.Shared.Containers
                 if (!isClient)
                     entMan.DeleteEntity(entity);
                 else if (entMan.EntityExists(entity))
-                    Remove(entity, entMan, reparent: false, addToBroadphase: true, force: true);
+                    Remove(entity, entMan, reparent: false, force: true);
             }
         }
     }

--- a/Robust.Shared/Containers/ContainerManagerComponent.cs
+++ b/Robust.Shared/Containers/ContainerManagerComponent.cs
@@ -138,7 +138,6 @@ namespace Robust.Shared.Containers
             TransformComponent? xform = null,
             MetaDataComponent? meta = null,
             bool reparent = true,
-            bool addToBroadphase = true,
             bool force = false,
             EntityCoordinates? destination = null,
             Angle? localRotation = null)
@@ -146,7 +145,7 @@ namespace Robust.Shared.Containers
             foreach (var containers in Containers.Values)
             {
                 if (containers.Contains(toremove))
-                    return containers.Remove(toremove, _entMan, xform, meta, reparent, addToBroadphase, force, destination, localRotation);
+                    return containers.Remove(toremove, _entMan, xform, meta, reparent, force, destination, localRotation);
             }
 
             return true; // If we don't contain the entity, it will always be removed

--- a/Robust.Shared/Containers/ContainerSlot.cs
+++ b/Robust.Shared/Containers/ContainerSlot.cs
@@ -107,7 +107,7 @@ namespace Robust.Shared.Containers
             if (!isClient)
                 entMan.DeleteEntity(entity);
             else if (entMan.EntityExists(entity))
-                Remove(entity, entMan, reparent: false, addToBroadphase: true, force: true);
+                Remove(entity, entMan, reparent: false, force: true);
         }
     }
 }

--- a/Robust.Shared/Containers/IContainer.cs
+++ b/Robust.Shared/Containers/IContainer.cs
@@ -112,8 +112,6 @@ namespace Robust.Shared.Containers
         /// </summary>
         /// <param name="reparent">If false, this operation will not rigger a move or parent change event. Ignored if
         /// destination is not null</param>
-        /// <param name="addToBroadphase">If false, this entity will not get re-added to broadphases after removal
-        /// Useful if the entity is about to move or be re-inserted into another container.</param>
         /// <param name="force">If true, this will not perform can-remove checks.</param>
         /// <param name="destination">Where to place the entity after removing. Avoids unnecessary broadphase updates.
         /// If not specified, and reparent option is true, then the entity will either be inserted into a parent
@@ -125,7 +123,6 @@ namespace Robust.Shared.Containers
             TransformComponent? xform = null,
             MetaDataComponent? meta = null,
             bool reparent = true,
-            bool addToBroadphase = true,
             bool force = false,
             EntityCoordinates? destination = null,
             Angle? localRotation = null);

--- a/Robust.Shared/Containers/IContainerManager.cs
+++ b/Robust.Shared/Containers/IContainerManager.cs
@@ -28,8 +28,6 @@ namespace Robust.Shared.Containers
         /// </summary>
         /// <param name="reparent">If false, this operation will not rigger a move or parent change event. Ignored if
         /// destination is not null</param>
-        /// <param name="addToBroadphase">If false, this entity will not get re-added to broadphases after removal
-        /// Useful if the entity is about to move or be re-inserted into another container.</param>
         /// <param name="force">If true, this will not perform can-remove checks.</param>
         /// <param name="destination">Where to place the entity after removing. Avoids unnecessary broadphase updates.
         /// If not specified, and reparent option is true, then the entity will either be inserted into a parent
@@ -39,7 +37,6 @@ namespace Robust.Shared.Containers
             TransformComponent? xform = null,
             MetaDataComponent? meta = null,
             bool reparent = true,
-            bool addToBroadphase = true,
             bool force = false,
             EntityCoordinates? destination = null,
             Angle? localRotation = null);

--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -13,11 +13,9 @@ namespace Robust.Shared.Containers
 {
     public abstract partial class SharedContainerSystem : EntitySystem
     {
-        [Dependency] private readonly SharedTransformSystem _xforms = default!;
         [Dependency] private readonly SharedPhysicsSystem _physics = default!;
         [Dependency] private readonly SharedJointSystem _joint = default!;
         [Dependency] private readonly EntityLookupSystem _lookup = default!;
-        [Dependency] private readonly INetManager _netMan = default!;
 
         /// <inheritdoc />
         public override void Initialize()
@@ -116,7 +114,6 @@ namespace Robust.Shared.Containers
             TransformComponent? containedXform = null,
             MetaDataComponent? containedMeta = null,
             bool reparent = true,
-            bool addToBroadphase = true,
             bool force = false,
             EntityCoordinates? destination = null,
             Angle? localRotation = null)
@@ -124,7 +121,7 @@ namespace Robust.Shared.Containers
             if (!Resolve(uid, ref containerManager) || !Resolve(toremove, ref containedMeta, ref containedXform))
                 return;
 
-            containerManager.Remove(toremove, containedXform, containedMeta, reparent, addToBroadphase, force, destination, localRotation);
+            containerManager.Remove(toremove, containedXform, containedMeta, reparent, force, destination, localRotation);
         }
 
         public ContainerManagerComponent.AllContainersEnumerable GetAllContainers(EntityUid uid, ContainerManagerComponent? containerManager = null)
@@ -377,7 +374,7 @@ namespace Robust.Shared.Containers
             foreach (var entity in container.ContainedEntities.ToArray())
             {
                 if (query.TryGetComponent(entity, out var xform))
-                    container.Remove(entity, entMan, xform, null, attachToGridOrMap, true, force, moveTo);
+                    container.Remove(entity, entMan, xform, null, attachToGridOrMap, force, moveTo);
             }
         }
 

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -844,8 +844,9 @@ namespace Robust.Shared.GameObjects
     ///     Data used to store information about the broad-phase that any given entity is currently on.
     /// </summary>
     /// <remarks>
-    ///     A null value means that this entity is simply not on a broadphase (e.g., in null-space or in a container. An
-    ///     invalid entity indicates that an entity has intentionally been removed from broadphases.
+    ///     A null value means that this entity is simply not on a broadphase (e.g., in null-space or in a container).
+    ///     An invalid entity UID indicates that this entity has intentionally been removed from broadphases and should
+    ///     not automatically be re-added by movement events..
     /// </remarks>
     internal record struct BroadphaseData(EntityUid Uid, bool CanCollide, bool Static)
     {

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -843,8 +843,16 @@ namespace Robust.Shared.GameObjects
     /// <summary>
     ///     Data used to store information about the broad-phase that any given entity is currently on.
     /// </summary>
+    /// <remarks>
+    ///     A null value means that this entity is simply not on a broadphase (e.g., in null-space or in a container. An
+    ///     invalid entity indicates that an entity has intentionally been removed from broadphases.
+    /// </remarks>
     internal record struct BroadphaseData(EntityUid Uid, bool CanCollide, bool Static)
     {
+        public bool IsValid() => Uid.IsValid();
+        public bool Valid => IsValid();
+        public readonly static BroadphaseData Invalid = default;
+
         // TODO include MapId if ever grids are allowed to enter null-space (leave PVS).
     }
 }

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -964,6 +964,7 @@ public abstract partial class SharedTransformSystem
 
         // Before making any changes to physics or transforms, remove from the current broadphase
         _lookup.RemoveFromEntityTree(xform.Owner, xform, xformQuery);
+        xform.Broadphase = BroadphaseData.Invalid;
 
         // Stop any active lerps
         xform._nextPosition = null;

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -964,7 +964,6 @@ public abstract partial class SharedTransformSystem
 
         // Before making any changes to physics or transforms, remove from the current broadphase
         _lookup.RemoveFromEntityTree(xform.Owner, xform, xformQuery);
-        xform.Broadphase = BroadphaseData.Invalid;
 
         // Stop any active lerps
         xform._nextPosition = null;

--- a/Robust.UnitTesting/Server/GameObjects/Components/Container_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/Components/Container_Test.cs
@@ -336,7 +336,7 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
                     if (!isClient)
                         entMan.DeleteEntity(entity);
                     else if (entMan.EntityExists(entity))
-                        Remove(entity, entMan, reparent: false, addToBroadphase: true, force: true);
+                        Remove(entity, entMan, reparent: false, force: true);
                 }
             }
 


### PR DESCRIPTION
There is currently a bug where if an an that is parented to an entity inside of a container, but not in a container itself, gets reparented to some other entity, then it won't get added back to the broadphase.

This originally happened because broadphases were not updating during reparenting if the old broadphase was set to null. This was mainly done to avoid redundant broadphase updates. I've now changed this so that there is an explicit invalid broadphase. 

Now reparenting will always attempt to find a new broadphase unless that has been explicitly disabled by setting the broadphase to an invalid value.

Fixes space-wizards/space-station-14/issues/12342