### PR TITLE
Client entity deletion error tolerance

### DIFF
--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -31,6 +31,17 @@ namespace Robust.Client.GameObjects
 
             base.Initialize();
         }
+        public override void Shutdown()
+        {
+            using var _ = _gameTiming.StartStateApplicationArea();
+            base.Shutdown();
+        }
+
+        public override void Cleanup()
+        {
+            using var _ = _gameTiming.StartStateApplicationArea();
+            base.Cleanup();
+        }
 
         EntityUid IClientEntityManagerInternal.CreateEntity(string? prototypeName, EntityUid uid)
         {

--- a/Robust.Client/GameStates/ClientDirtySystem.cs
+++ b/Robust.Client/GameStates/ClientDirtySystem.cs
@@ -20,7 +20,7 @@ internal sealed class ClientDirtySystem : EntitySystem
     // could pool the ushort sets, but predicted component changes are rare... soo...
     internal readonly Dictionary<EntityUid, HashSet<ushort>> RemovedComponents = new();
 
-    internal readonly Queue<EntityUid> DirtyEntities = new(256);
+    internal readonly HashSet<EntityUid> DirtyEntities = new(256);
 
     public override void Initialize()
     {
@@ -74,6 +74,6 @@ internal sealed class ClientDirtySystem : EntitySystem
     private void OnEntityDirty(EntityUid e)
     {
         if (_timing.InPrediction && !e.IsClientSide())
-            DirtyEntities.Enqueue(e);
+            DirtyEntities.Add(e);
     }
 }

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -449,7 +449,7 @@ namespace Robust.Client.GameStates
             // This is terrible, and I hate it.
             _entitySystemManager.GetEntitySystem<SharedGridTraversalSystem>().QueuedEvents.Clear();
 
-            foreach (var entity in system.DirtyEntities)
+            while (system.DirtyEntities.TryDequeue(out var entity))
             {
                 // Check log level first to avoid the string alloc.
                 if (_sawmill.Level <= LogLevel.Debug)
@@ -463,7 +463,11 @@ namespace Robust.Client.GameStates
 
                 countReset += 1;
 
-                foreach (var (netId, comp) in _entityManager.GetNetComponents(entity))
+                var netComps = _entityManager.GetNetComponentsOrNull(entity);
+                if (netComps == null)
+                    return;
+
+                foreach (var (netId, comp) in netComps.Value)
                 {
                     DebugTools.AssertNotNull(netId);
                     if (!comp.NetSyncEnabled)

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -951,6 +951,14 @@ namespace Robust.Shared.GameObjects
             return new NetComponentEnumerable(_netComponents[uid]);
         }
 
+        /// <inheritdoc />
+        public NetComponentEnumerable? GetNetComponentsOrNull(EntityUid uid)
+        {
+            return _netComponents.TryGetValue(uid, out var data)
+                    ? new NetComponentEnumerable(data)
+                    : null;
+        }
+
         #region Join Functions
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -113,7 +113,7 @@ namespace Robust.Shared.GameObjects
             Started = false;
         }
 
-        public void Cleanup()
+        public virtual void Cleanup()
         {
             _componentFactory.ComponentAdded -= OnComponentAdded;
             _componentFactory.ComponentReferenceAdded -= OnComponentReferenceAdded;

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -345,8 +345,8 @@ namespace Robust.Shared.GameObjects
 
             try
             {
-                var ev = new EntityTerminatingEvent();
-                EventBus.RaiseLocalEvent(uid, ref ev);
+                var ev = new EntityTerminatingEvent(uid);
+                EventBus.RaiseLocalEvent(uid, ref ev, true);
             }
             catch (Exception e)
             {

--- a/Robust.Shared/GameObjects/EntitySystemMessages/EntityTerminatingEvent.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/EntityTerminatingEvent.cs
@@ -6,5 +6,11 @@ namespace Robust.Shared.GameObjects
     [ByRefEvent]
     public readonly struct EntityTerminatingEvent
     {
+        public readonly EntityUid Entity;
+
+        public EntityTerminatingEvent(EntityUid entity)
+        {
+            Entity = entity;
+        }
     }
 }

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -359,6 +359,14 @@ namespace Robust.Shared.GameObjects
         NetComponentEnumerable GetNetComponents(EntityUid uid);
 
         /// <summary>
+        ///     Returns ALL networked components on an entity, including deleted ones. Returns null if the entity does
+        ///     not exist.
+        /// </summary>
+        /// <param name="uid">Entity UID to look on.</param>
+        /// <returns>All components that have a network ID.</returns>
+        public NetComponentEnumerable? GetNetComponentsOrNull(EntityUid uid);
+
+        /// <summary>
         ///     Gets a component state.
         /// </summary>
         /// <param name="eventBus">A reference to the event bus instance.</param>


### PR DESCRIPTION
Adds bad entity deletion error logs and stops the client from spamming errors while trying to reset predicted entities.