### PR TITLE
Infer default command names

### DIFF
--- a/Robust.Client/Audio/Midi/Commands/MidiPanicCommand.cs
+++ b/Robust.Client/Audio/Midi/Commands/MidiPanicCommand.cs
@@ -8,8 +8,6 @@ public sealed class MidiPanicCommand : LocalizedCommands
 {
     [Dependency] private readonly IMidiManager _midiManager = default!;
 
-    public override string Command => "midipanic";
-
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
         foreach (var renderer in _midiManager.Renderers)

--- a/Robust.Client/Console/Commands/ConfigurationCommands.cs
+++ b/Robust.Client/Console/Commands/ConfigurationCommands.cs
@@ -6,10 +6,8 @@ using Robust.Shared.IoC;
 namespace Robust.Client.Console.Commands
 {
     [UsedImplicitly]
-    public sealed class SaveConfig : LocalizedCommands
+    public sealed class SaveConfigCommand : LocalizedCommands
     {
-        public override string Command => "saveconfig";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             IoCManager.Resolve<IConfigurationManager>().SaveToFile();

--- a/Robust.Client/Console/Commands/ConsoleCommands.cs
+++ b/Robust.Client/Console/Commands/ConsoleCommands.cs
@@ -18,8 +18,6 @@ namespace Robust.Client.Console.Commands
 
     sealed class FillCommand : LocalizedCommands
     {
-        public override string Command => "fill";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             for (int x = 0; x < 50; x++)

--- a/Robust.Client/Console/Commands/Debug.cs
+++ b/Robust.Client/Console/Commands/Debug.cs
@@ -33,8 +33,6 @@ namespace Robust.Client.Console.Commands
 {
     internal sealed class DumpEntitiesCommand : LocalizedCommands
     {
-        public override string Command => "dumpentities";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var entityManager = IoCManager.Resolve<IEntityManager>();
@@ -49,9 +47,6 @@ namespace Robust.Client.Console.Commands
 
     internal sealed class GetComponentRegistrationCommand : LocalizedCommands
     {
-        public override string Command => "getcomponentregistration";
-
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             if (args.Length < 1)
@@ -211,8 +206,6 @@ namespace Robust.Client.Console.Commands
 
     internal sealed class DisconnectCommand : LocalizedCommands
     {
-        public override string Command => "disconnect";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             IoCManager.Resolve<IClientNetManager>().ClientDisconnect("Disconnect command used.");
@@ -431,8 +424,6 @@ namespace Robust.Client.Console.Commands
 
     internal sealed class GuiDumpCommand : LocalizedCommands
     {
-        public override string Command => "guidump";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var uiMgr = IoCManager.Resolve<IUserInterfaceManager>();
@@ -503,8 +494,6 @@ namespace Robust.Client.Console.Commands
 
     internal sealed class UITestCommand : LocalizedCommands
     {
-        public override string Command => "uitest";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var window = new DefaultWindow { MinSize = (500, 400) };
@@ -633,8 +622,6 @@ namespace Robust.Client.Console.Commands
 
     internal sealed class SetClipboardCommand : LocalizedCommands
     {
-        public override string Command => "setclipboard";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var mgr = IoCManager.Resolve<IClipboardManager>();
@@ -644,8 +631,6 @@ namespace Robust.Client.Console.Commands
 
     internal sealed class GetClipboardCommand : LocalizedCommands
     {
-        public override string Command => "getclipboard";
-
         public override async void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var mgr = IoCManager.Resolve<IClipboardManager>();
@@ -655,8 +640,6 @@ namespace Robust.Client.Console.Commands
 
     internal sealed class ToggleLight : LocalizedCommands
     {
-        public override string Command => "togglelight";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var mgr = IoCManager.Resolve<ILightManager>();
@@ -667,8 +650,6 @@ namespace Robust.Client.Console.Commands
 
     internal sealed class ToggleFOV : LocalizedCommands
     {
-        public override string Command => "togglefov";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var mgr = IoCManager.Resolve<IEyeManager>();
@@ -679,8 +660,6 @@ namespace Robust.Client.Console.Commands
 
     internal sealed class ToggleHardFOV : LocalizedCommands
     {
-        public override string Command => "togglehardfov";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var mgr = IoCManager.Resolve<ILightManager>();
@@ -691,8 +670,6 @@ namespace Robust.Client.Console.Commands
 
     internal sealed class ToggleShadows : LocalizedCommands
     {
-        public override string Command => "toggleshadows";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var mgr = IoCManager.Resolve<ILightManager>();
@@ -703,8 +680,6 @@ namespace Robust.Client.Console.Commands
 
     internal sealed class ToggleLightBuf : LocalizedCommands
     {
-        public override string Command => "togglelightbuf";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var mgr = IoCManager.Resolve<ILightManager>();
@@ -715,8 +690,6 @@ namespace Robust.Client.Console.Commands
 
     internal sealed class ChunkInfoCommand : LocalizedCommands
     {
-        public override string Command => "chunkinfo";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var mapMan = IoCManager.Resolve<IMapManager>();

--- a/Robust.Client/Console/Commands/MonitorCommands.cs
+++ b/Robust.Client/Console/Commands/MonitorCommands.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using JetBrains.Annotations;
 using Robust.Client.Graphics;
 using Robust.Shared.Console;
@@ -9,8 +9,6 @@ namespace Robust.Client.Console.Commands
     [UsedImplicitly]
     public sealed class LsMonitorCommand : LocalizedCommands
     {
-        public override string Command => "lsmonitor";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var clyde = IoCManager.Resolve<IClyde>();
@@ -26,8 +24,6 @@ namespace Robust.Client.Console.Commands
     [UsedImplicitly]
     public sealed class MonitorInfoCommand : LocalizedCommands
     {
-        public override string Command => "monitorinfo";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             if (args.Length < 1)
@@ -52,8 +48,6 @@ namespace Robust.Client.Console.Commands
     [UsedImplicitly]
     public sealed class SetMonitorCommand : LocalizedCommands
     {
-        public override string Command => "setmonitor";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var clyde = IoCManager.Resolve<IClyde>();

--- a/Robust.Client/Console/Commands/QuitCommand.cs
+++ b/Robust.Client/Console/Commands/QuitCommand.cs
@@ -6,8 +6,6 @@ namespace Robust.Client.Console.Commands
 {
     sealed class HardQuitCommand : LocalizedCommands
     {
-        public override string Command => "hardquit";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             Environment.Exit(0);
@@ -16,8 +14,6 @@ namespace Robust.Client.Console.Commands
 
     sealed class QuitCommand : LocalizedCommands
     {
-        public override string Command => "quit";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             IoCManager.Resolve<IGameController>().Shutdown("quit command used");

--- a/Robust.Client/Console/Commands/Scripting.cs
+++ b/Robust.Client/Console/Commands/Scripting.cs
@@ -16,8 +16,6 @@ namespace Robust.Client.Console.Commands
 
     internal sealed class WatchCommand : LocalizedCommands
     {
-        public override string Command => "watch";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             new WatchWindow().OpenCentered();

--- a/Robust.Client/Console/Commands/SendGarbageCommand.cs
+++ b/Robust.Client/Console/Commands/SendGarbageCommand.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Console;
+using Robust.Shared.Console;
 using Robust.Shared.IoC;
 using Robust.Shared.Network;
 
@@ -6,8 +6,6 @@ namespace Robust.Client.Console.Commands
 {
     internal sealed class SendGarbageCommand : LocalizedCommands
     {
-        public override string Command => "sendgarbage";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             // MsgStringTableEntries is registered as NetMessageAccept.Client so the server will immediately deny it.

--- a/Robust.Client/Console/Commands/SetInputContextCommand.cs
+++ b/Robust.Client/Console/Commands/SetInputContextCommand.cs
@@ -8,8 +8,6 @@ namespace Robust.Client.Console.Commands
     [UsedImplicitly]
     public sealed class SetInputContextCommand : LocalizedCommands
     {
-        public override string Command => "setinputcontext";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             if (args.Length != 1)

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteBoundsOverlay.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteBoundsOverlay.cs
@@ -12,8 +12,6 @@ namespace Robust.Client.GameObjects
 {
     public sealed class ShowSpriteBBCommand : LocalizedCommands
     {
-        public override string Command => "showspritebb";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             EntitySystem.Get<SpriteBoundsSystem>().Enabled ^= true;

--- a/Robust.Client/Graphics/Clyde/VramCommand.cs
+++ b/Robust.Client/Graphics/Clyde/VramCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using Robust.Shared.Console;
 using Robust.Shared.Utility;
@@ -13,8 +13,6 @@ namespace Robust.Client.Graphics.Clyde
 {
     public sealed class VramCommand : LocalizedCommands
     {
-        public override string Command => "vram";
-
         public override unsafe void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             if (!OperatingSystem.IsWindows())

--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -909,8 +909,6 @@ namespace Robust.Client.Input
     [UsedImplicitly]
     internal sealed class BindCommand : LocalizedCommands
     {
-        public override string Command => "bind";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             if (args.Length < 3)

--- a/Robust.Server/Bql/ForAllCommand.cs
+++ b/Robust.Server/Bql/ForAllCommand.cs
@@ -9,8 +9,6 @@ namespace Robust.Server.Bql
 {
     public sealed class ForAllCommand : LocalizedCommands
     {
-        public override string Command => "forall";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             if (args.Length < 2)

--- a/Robust.Server/Console/Commands/DeleteCommand.cs
+++ b/Robust.Server/Console/Commands/DeleteCommand.cs
@@ -7,8 +7,6 @@ namespace Robust.Server.Console.Commands
 {
     public sealed class DeleteCommand : LocalizedCommands
     {
-        public override string Command => "delete";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             if (args.Length != 1)

--- a/Robust.Server/Console/Commands/MapCommands.cs
+++ b/Robust.Server/Console/Commands/MapCommands.cs
@@ -15,8 +15,6 @@ namespace Robust.Server.Console.Commands
 {
     sealed class AddMapCommand : LocalizedCommands
     {
-        public override string Command => "addmap";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             if (args.Length < 1)
@@ -70,8 +68,6 @@ namespace Robust.Server.Console.Commands
 
     public sealed class SaveGridCommand : LocalizedCommands
     {
-        public override string Command => "savegrid";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             if (args.Length < 2)
@@ -116,8 +112,6 @@ namespace Robust.Server.Console.Commands
 
     public sealed class LoadGridCommand : LocalizedCommands
     {
-        public override string Command => "loadgrid";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             if (args.Length < 2 || args.Length == 3 || args.Length > 6)
@@ -200,8 +194,6 @@ namespace Robust.Server.Console.Commands
 
     public sealed class SaveMap : LocalizedCommands
     {
-        public override string Command => "savemap";
-
         public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
         {
             switch (args.Length)
@@ -260,8 +252,6 @@ namespace Robust.Server.Console.Commands
 
     public sealed class LoadMap : LocalizedCommands
     {
-        public override string Command => "loadmap";
-
         public static CompletionResult GetCompletionResult(IConsoleShell shell, string[] args)
         {
             switch (args.Length)
@@ -397,8 +387,6 @@ namespace Robust.Server.Console.Commands
 
     sealed class TpGridCommand : LocalizedCommands
     {
-        public override string Command => "tpgrid";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             if (args.Length < 3 || args.Length > 4)

--- a/Robust.Server/Console/Commands/PlayerCommands.cs
+++ b/Robust.Server/Console/Commands/PlayerCommands.cs
@@ -143,7 +143,6 @@ namespace Robust.Server.Console.Commands
 
     public sealed class ListPlayers : LocalizedCommands
     {
-        public override string Command => "listplayers";
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             // Player: number of people connected and their byond keys

--- a/Robust.Server/Console/Commands/ScaleCommand.cs
+++ b/Robust.Server/Console/Commands/ScaleCommand.cs
@@ -12,7 +12,6 @@ namespace Robust.Server.Console.Commands;
 
 public sealed class ScaleCommand : LocalizedCommands
 {
-    public override string Command => "scale";
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
         if (args.Length != 2)

--- a/Robust.Server/Console/Commands/SpawnCommand.cs
+++ b/Robust.Server/Console/Commands/SpawnCommand.cs
@@ -10,8 +10,6 @@ namespace Robust.Server.Console.Commands
 {
     public sealed class SpawnCommand : LocalizedCommands
     {
-        public override string Command => "spawn";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var player = shell.Player as IPlayerSession;

--- a/Robust.Server/Console/Commands/SpinCommand.cs
+++ b/Robust.Server/Console/Commands/SpinCommand.cs
@@ -8,8 +8,6 @@ namespace Robust.Server.Console.Commands;
 
 public sealed class SpinCommand : LocalizedCommands
 {
-    public override string Command => "spin";
-
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
         if (args.Length < 1)

--- a/Robust.Server/Console/Commands/SysCommands.cs
+++ b/Robust.Server/Console/Commands/SysCommands.cs
@@ -9,8 +9,6 @@ namespace Robust.Server.Console.Commands
 {
     sealed class RestartCommand : LocalizedCommands
     {
-        public override string Command => "restart";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             IoCManager.Resolve<IBaseServer>().Restart();
@@ -19,8 +17,6 @@ namespace Robust.Server.Console.Commands
 
     sealed class ShutdownCommand : LocalizedCommands
     {
-        public override string Command => "shutdown";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             IoCManager.Resolve<IBaseServer>().Shutdown(null);
@@ -29,8 +25,6 @@ namespace Robust.Server.Console.Commands
 
     public sealed class SaveConfig : LocalizedCommands
     {
-        public override string Command => "saveconfig";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             IoCManager.Resolve<IConfigurationManager>().SaveToFile();
@@ -62,8 +56,6 @@ namespace Robust.Server.Console.Commands
 
     sealed class ShowTimeCommand : LocalizedCommands
     {
-        public override string Command => "showtime";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var timing = IoCManager.Resolve<IGameTiming>();

--- a/Robust.Server/Console/Commands/TestbedCommand.cs
+++ b/Robust.Server/Console/Commands/TestbedCommand.cs
@@ -48,8 +48,6 @@ namespace Robust.Server.Console.Commands
     /// </summary>
     public sealed class TestbedCommand : LocalizedCommands
     {
-        public override string Command => "testbed";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             if (args.Length != 2)

--- a/Robust.Shared/Configuration/ConfigurationCommands.cs
+++ b/Robust.Shared/Configuration/ConfigurationCommands.cs
@@ -11,8 +11,6 @@ namespace Robust.Shared.Configuration
     [SuppressMessage("ReSharper", "StringLiteralTypo")]
     internal sealed class CVarCommand : LocalizedCommands
     {
-        public override string Command => "cvar";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             if (args.Length is < 1 or > 2)

--- a/Robust.Shared/Console/Commands/ExecCommand.cs
+++ b/Robust.Shared/Console/Commands/ExecCommand.cs
@@ -12,8 +12,6 @@ namespace Robust.Shared.Console.Commands
     {
         private static readonly Regex CommentRegex = new Regex(@"^\s*#");
 
-        public override string Command => "exec";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var res = IoCManager.Resolve<IResourceManager>();

--- a/Robust.Shared/Console/Commands/GcCommands.cs
+++ b/Robust.Shared/Console/Commands/GcCommands.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime;
 using Robust.Shared.Localization;
 using Robust.Shared.Utility;
@@ -7,8 +7,6 @@ namespace Robust.Shared.Console.Commands;
 
 internal sealed class GcCommand : LocalizedCommands
 {
-    public override string Command => "gc";
-
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
         if (args.Length == 0)
@@ -91,8 +89,6 @@ internal sealed class GcModeCommand : LocalizedCommands
 
 internal sealed class MemCommand : LocalizedCommands
 {
-    public override string Command => "mem";
-
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
         var info = GC.GetGCMemoryInfo();

--- a/Robust.Shared/Console/Commands/HelpCommand.cs
+++ b/Robust.Shared/Console/Commands/HelpCommand.cs
@@ -1,12 +1,10 @@
-﻿using System.Linq;
+using System.Linq;
 using Robust.Shared.Localization;
 
 namespace Robust.Shared.Console.Commands;
 
 internal sealed class HelpCommand : LocalizedCommands
 {
-    public override string Command => "help";
-
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
         switch (args.Length)

--- a/Robust.Shared/Console/Commands/ListCommand.cs
+++ b/Robust.Shared/Console/Commands/ListCommand.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Text;
 using Robust.Shared.Localization;
 
@@ -6,8 +6,6 @@ namespace Robust.Shared.Console.Commands;
 
 internal sealed class ListCommands : LocalizedCommands
 {
-    public override string Command => "list";
-
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
         var filter = "";

--- a/Robust.Shared/Console/Commands/LogCommands.cs
+++ b/Robust.Shared/Console/Commands/LogCommands.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
@@ -60,8 +60,6 @@ internal sealed class LogSetLevelCommand : LocalizedCommands
 
 internal sealed class TestLog : LocalizedCommands
 {
-    public override string Command => "testlog";
-
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
         if (args.Length != 3)

--- a/Robust.Shared/Console/LocalizedCommands.cs
+++ b/Robust.Shared/Console/LocalizedCommands.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
@@ -10,8 +10,16 @@ public abstract class LocalizedCommands : IConsoleCommand
     [Dependency] protected readonly ILocalizationManager LocalizationManager = default!;
 
     /// <inheritdoc />
-    public abstract string Command { get; }
-
+    public virtual string Command
+    {
+        get
+        {
+            var className = GetType().Name;
+            if (className.EndsWith("Command") && className.Length > 7)
+                className = className.Substring(0, className.Length - 7);
+            return className.ToLowerInvariant();
+        }
+    }
     /// <inheritdoc />
     public virtual string Description => LocalizationManager.TryGetString($"cmd-{Command}-desc", out var val) ? val : "";
 

--- a/Robust.Shared/Network/HWId.cs
+++ b/Robust.Shared/Network/HWId.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Security.Cryptography;
 using Microsoft.Win32;
 using Robust.Shared.Console;
@@ -35,8 +35,6 @@ namespace Robust.Shared.Network
 #if DEBUG
     internal sealed class HwidCommand : LocalizedCommands
     {
-        public override string Command => "hwid";
-
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             shell.WriteLine(Convert.ToBase64String(HWId.Calc(), Base64FormattingOptions.None));


### PR DESCRIPTION
Makes localized commands default to using a command string inferred from the class name . E.g. for something like the `DumpEntitiesCommand` class, you no longer need to specify `public override string Command => "dumpentities";`

This implicitly makes flatcase/mumblecase the standard convention, which it already appears to be (though there are some snake_case commands),