### PR TITLE
LoadFromDocument properly detects duplicate entities

### DIFF
--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -786,7 +786,7 @@ namespace Robust.Shared.Prototypes
                 if (!datanode.TryGet<ValueDataNode>(IdDataFieldAttribute.Name, out var idNode))
                     throw new PrototypeLoadException($"Prototype type {type} is missing an 'id' datafield.");
 
-                if (!overwrite && _prototypes[prototypeType].ContainsKey(idNode.Value))
+                if (!overwrite && _prototypeResults[prototypeType].ContainsKey(idNode.Value))
                 {
                     throw new PrototypeLoadException($"Duplicate ID: '{idNode.Value}'");
                 }


### PR DESCRIPTION
I circled back around to this and discovered that the fix is (probably?) easy.

Closes #3079

I tested this locally but I'm pushing the change via the web editor so I don't have to go to the trouble of setting up a Robust fork of my own.