### PR TITLE
Remove redundant client-side error

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -1122,8 +1122,11 @@ namespace Robust.Client.GameStates
             if (!uid.IsClientSide() && _entities.TryGetComponent(uid, out TransformComponent? xform))
                 _recursiveRemoveState(xform, _entities.GetEntityQuery<TransformComponent>());
 
-            _entities.DeleteEntity(uid);
-
+            // Set ApplyingState to true to avoid logging errors about predicting the deletion of networked entities.
+            using (_timing.StartStateApplicationArea())
+            {
+                _entities.DeleteEntity(uid);
+            }
         }
 
         /// <summary>

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -734,7 +734,7 @@ internal sealed partial class PVSSystem : EntitySystem
         var entStateCount = 0;
 
         var stack = _stackPool.Get();
-        // TODO reorder chunks to prioritize those that are closest to the viewer? Helps make pop0in less visible.
+        // TODO reorder chunks to prioritize those that are closest to the viewer? Helps make pop-in less visible.
         foreach (var i in chunkIndices)
         {
             var cache = chunkCache[i];
@@ -827,7 +827,7 @@ internal sealed partial class PVSSystem : EntitySystem
 #if !FULL_RELEASE
                 // This happens relatively frequently for the current TickBuffer value, and doesn't really provide any
                 // useful info when not debugging/testing locally. Hence disabled on FULL_RELEASE.
-                _sawmill.Warning($"Client {session} exceeded tick buffer.");
+                _sawmill.Debug($"Client {session} exceeded tick buffer.");
 #endif
             }
             else if (oldEntry.Value.Value != lastAcked)

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -423,7 +423,7 @@ public abstract partial class SharedTransformSystem
 
             if (value.EntityId.IsValid())
             {
-                if (!xformQuery.Resolve(value.EntityId, ref newParent))
+                if (!xformQuery.Resolve(value.EntityId, ref newParent, false))
                 {
                     QueueDel(xform.Owner);
                     throw new InvalidOperationException($"Attempted to parent entity {ToPrettyString(xform.Owner)} to non-existent entity {value.EntityId}");


### PR DESCRIPTION
Removes/prevent a redundant client-side error that make debugging things like #3413 slightly more annoying.

Also downgrades a pvs debug message from warning to debug, seeing as people keep getting confused and asking if its significant.
