### PR TITLE
Audio position fixes

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
@@ -215,19 +215,7 @@ public sealed class AudioSystem : SharedAudioSystem
 
             if (stream.Source.IsGlobal)
             {
-                float actualGain;
-
-                if (stream.Gain != null)
-                {
-                    actualGain = stream.Gain.Value;
-                }
-                else
-                {
-                    var volume = MathF.Pow(10, stream.Volume / 10);
-                    actualGain = MathF.Max(0f, volume);
-                }
-
-                stream.Source.SetVolumeDirect(actualGain);
+                stream.Source.SetVolume(stream.Volume);
             }
             else if (pos.MapId != _eyeManager.CurrentMap)
                 stream.Source.SetVolumeDirect(0f);

--- a/Robust.Client/Graphics/Audio/ClydeAudio.AudioSources.cs
+++ b/Robust.Client/Graphics/Audio/ClydeAudio.AudioSources.cs
@@ -105,7 +105,7 @@ namespace Robust.Client.Graphics.Audio
                 _master._checkAlError();
             }
 
-            public void SetVolumeDirect(float scale)
+            public void SetVolumeDirect(float gain)
             {
                 _checkDisposed();
                 var priorOcclusion = 1f;
@@ -114,7 +114,7 @@ namespace Robust.Client.Graphics.Audio
                     AL.GetSource(SourceHandle, ALSourcef.Gain, out var priorGain);
                     priorOcclusion = priorGain / _gain;
                 }
-                _gain = scale;
+                _gain = gain;
                 AL.Source(SourceHandle, ALSourcef.Gain, _gain * priorOcclusion);
                 _master._checkAlError();
             }
@@ -373,7 +373,7 @@ namespace Robust.Client.Graphics.Audio
                 _master._checkAlError();
             }
 
-            public void SetVolumeDirect(float scale)
+            public void SetVolumeDirect(float gain)
             {
                 _checkDisposed();
                 var priorOcclusion = 1f;
@@ -382,7 +382,7 @@ namespace Robust.Client.Graphics.Audio
                     AL.GetSource(SourceHandle!.Value, ALSourcef.Gain, out var priorGain);
                     priorOcclusion = priorGain / _gain;
                 }
-                _gain = scale;
+                _gain = gain;
                 AL.Source(SourceHandle!.Value, ALSourcef.Gain, _gain * priorOcclusion);
                 _master._checkAlError();
             }

--- a/Robust.Client/Graphics/Audio/ClydeAudio.AudioSources.cs
+++ b/Robust.Client/Graphics/Audio/ClydeAudio.AudioSources.cs
@@ -84,6 +84,17 @@ namespace Robust.Client.Graphics.Audio
                 }
             }
 
+            public bool IsGlobal
+            {
+                get
+                {
+                    _checkDisposed();
+                    AL.GetSource(SourceHandle, ALSourceb.SourceRelative, out var value);
+                    _master._checkAlError();
+                    return value;
+                }
+            }
+
             public void SetGlobal()
             {
                 _checkDisposed();
@@ -444,6 +455,17 @@ namespace Robust.Client.Graphics.Audio
                 // ReSharper disable once PossibleInvalidOperationException
                 AL.Source(SourceHandle!.Value, ALSourcef.SecOffset, seconds);
                 _master._checkAlError();
+            }
+
+            public bool IsGlobal
+            {
+                get
+                {
+                    _checkDisposed();
+                    AL.GetSource(SourceHandle!.Value, ALSourceb.SourceRelative, out var value);
+                    _master._checkAlError();
+                    return value;
+                }
             }
 
             public bool SetPosition(Vector2 position)

--- a/Robust.Client/Graphics/Audio/DummyAudioSource.cs
+++ b/Robust.Client/Graphics/Audio/DummyAudioSource.cs
@@ -41,6 +41,8 @@ namespace Robust.Client.Graphics.Audio
             // Nada.
         }
 
+        public bool IsGlobal { get; }
+
         public bool SetPosition(Vector2 position)
         {
             return true;
@@ -61,7 +63,7 @@ namespace Robust.Client.Graphics.Audio
             // Nada.
         }
 
-        public void SetVolumeDirect(float scale)
+        public void SetVolumeDirect(float gain)
         {
             // Nada.
         }

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -289,6 +289,8 @@ namespace Robust.Client.Graphics.Clyde
                 // Nada.
             }
 
+            public bool IsGlobal { get; }
+
             public bool SetPosition(Vector2 position)
             {
                 return true;
@@ -309,7 +311,7 @@ namespace Robust.Client.Graphics.Clyde
                 // Nada.
             }
 
-            public void SetVolumeDirect(float scale)
+            public void SetVolumeDirect(float gain)
             {
                 // Nada.
             }

--- a/Robust.Client/Graphics/IClydeAudioSource.cs
+++ b/Robust.Client/Graphics/IClydeAudioSource.cs
@@ -12,13 +12,14 @@ namespace Robust.Client.Graphics
         bool IsPlaying { get; }
 
         bool IsLooping { get; set; }
+        bool IsGlobal { get; }
 
         [MustUseReturnValue]
         bool SetPosition(Vector2 position);
         void SetPitch(float pitch);
         void SetGlobal();
         void SetVolume(float decibels);
-        void SetVolumeDirect(float decibels);
+        void SetVolumeDirect(float gain);
         void SetMaxDistance(float maxDistance);
         void SetRolloffFactor(float rolloffFactor);
         void SetReferenceDistance(float refDistance);


### PR DESCRIPTION
- Positionless audio now properly sets its volume
- Use SetVolumeDirect(0) to stop audio instead of getting very close to 0 with SetVolume.
- IsGlobal query implemented.

Will do further cleanup of the stream stuff later.

![image](https://user-images.githubusercontent.com/31366439/200989089-3e26b3e2-a595-4c0e-8fc9-1a16cec31a4e.png)
