### PR TITLE
Add support for saving missing prototype components

### DIFF
--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -1153,6 +1153,7 @@ internal sealed partial class PVSSystem : EntitySystem
                 netComps!.Add(netId);
         }
 
+        DebugTools.Assert(meta.EntityLastModifiedTick >= meta.LastComponentRemoved);
         var entState = new EntityState(entityUid, changed, meta.EntityLastModifiedTick, netComps);
 
         return entState;

--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -1079,7 +1079,7 @@ namespace Robust.Server.Maps
                         mapping.Add("components", components);
                     }
 
-                    if (prototype == null)
+                    if (md.EntityPrototype == null)
                     {
                         // No prototype - we are done.
                         entities.Add(mapping);
@@ -1088,7 +1088,7 @@ namespace Robust.Server.Maps
 
                     // an entity may have less components than the original prototype, so we need to check if any are missing.
                     var missingComponents = new SequenceDataNode();
-                    foreach (var compName in prototype.Components.Keys)
+                    foreach (var compName in md.EntityPrototype.Components.Keys)
                     {
                         missingComponents.Add(new ValueDataNode(compName));
                     }

--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -1088,9 +1088,14 @@ namespace Robust.Server.Maps
 
                     // an entity may have less components than the original prototype, so we need to check if any are missing.
                     var missingComponents = new SequenceDataNode();
-                    foreach (var compName in md.EntityPrototype.Components.Keys)
+                    foreach (var (name, comp) in md.EntityPrototype.Components)
                     {
-                        missingComponents.Add(new ValueDataNode(compName));
+                        // try comp instead of has-comp as it checks whether the component is supposed to have been
+                        // deleted.
+                        if (_serverEntityManager.TryGetComponent(entityUid, comp.GetType(), out _))
+                            continue;
+
+                        missingComponents.Add(new ValueDataNode(name));
                     }
 
                     if (missingComponents.Count != 0)

--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -1083,7 +1083,7 @@ namespace Robust.Server.Maps
                     {
                         // No prototype - we are done.
                         entities.Add(mapping);
-                        return;
+                        continue;
                     }
 
                     // an entity may have less components than the original prototype, so we need to check if any are missing.

--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -1092,7 +1092,7 @@ namespace Robust.Server.Maps
                     {
                         // try comp instead of has-comp as it checks whether the component is supposed to have been
                         // deleted.
-                        if (_serverEntityManager.TryGetComponent(entityUid, comp.GetType(), out _))
+                        if (_serverEntityManager.TryGetComponent(entityUid, comp.Component.GetType(), out _))
                             continue;
 
                         missingComponents.Add(new ValueDataNode(name));

--- a/Robust.Server/Maps/MapLoader.cs
+++ b/Robust.Server/Maps/MapLoader.cs
@@ -1079,7 +1079,7 @@ namespace Robust.Server.Maps
                         mapping.Add("components", components);
                     }
 
-                    if (cache == null)
+                    if (prototype == null)
                     {
                         // No prototype - we are done.
                         entities.Add(mapping);
@@ -1088,16 +1088,8 @@ namespace Robust.Server.Maps
 
                     // an entity may have less components than the original prototype, so we need to check if any are missing.
                     var missingComponents = new SequenceDataNode();
-
-                    foreach (var compName in cache.Keys)
+                    foreach (var compName in prototype.Components.Keys)
                     {
-                        var reg = compFactory.GetRegistration(compName);
-
-                        // try comp instead of has-comp as it checks whether the component is supposed to have been
-                        // deleted.
-                        if (_serverEntityManager.TryGetComponent(entityUid, reg.Idx, out _))
-                            continue;
-
                         missingComponents.Add(new ValueDataNode(compName));
                     }
 

--- a/Robust.Shared/GameObjects/EntityState.cs
+++ b/Robust.Shared/GameObjects/EntityState.cs
@@ -13,7 +13,7 @@ namespace Robust.Shared.GameObjects
 
         public NetListAsArray<ComponentChange> ComponentChanges { get; }
 
-        public bool Empty => ComponentChanges.Value is null or { Count: 0 };
+        public bool Empty => (ComponentChanges.Value is null or { Count: 0 }) && NetComponents == null;
 
         public readonly GameTick EntityLastModified;
 

--- a/Robust.Shared/GameObjects/IEntityLoadContext.cs
+++ b/Robust.Shared/GameObjects/IEntityLoadContext.cs
@@ -22,5 +22,10 @@ namespace Robust.Shared.GameObjects
         ///     (and then deserialized with <see cref="GetComponentData"/>)
         /// </summary>
         IEnumerable<string> GetExtraComponentTypes();
+
+        /// <summary>
+        ///     Checks whether a given component should be added to an entity. Used to prevent certain prototype components from being added while spawning an entity.
+        /// </summary>
+        bool ShouldSkipComponent(string compName);
     }
 }

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -262,6 +262,9 @@ namespace Robust.Shared.Prototypes
             {
                 foreach (var (name, entry) in prototype.Components)
                 {
+                    if (context != null && context.ShouldSkipComponent(name))
+                        continue;
+
                     var fullData = entry.Mapping;
 
                     if (context != null)


### PR DESCRIPTION
Fixes #2824

This just makes the entity serialization write a list of components that are present on a prototype but absent from an entity. Map loading will then use this to skip adding specific components to an entity. 

This also fixes some networking issues where component removal wasn't always being synced with clients.