### PR TITLE
Destroy non-colliding contacts

### DIFF
--- a/Robust.Shared/Physics/Dynamics/ContactManager.cs
+++ b/Robust.Shared/Physics/Dynamics/ContactManager.cs
@@ -362,6 +362,7 @@ namespace Robust.Shared.Physics.Dynamics
                 if (!bodyA.CanCollide || !bodyB.CanCollide)
                 {
                     node = node.Next;
+                    Destroy(contact);
                     continue;
                 }
 


### PR DESCRIPTION
Box2d keeps these around but we use cancollide long-term so it's better to just clean up.