### PR TITLE
Fix bad reference

### DIFF
--- a/Robust.Client.WebView/Cef/WebViewManagerCef.Control.cs
+++ b/Robust.Client.WebView/Cef/WebViewManagerCef.Control.cs
@@ -360,27 +360,6 @@ namespace Robust.Client.WebView.Cef
                 return modifiers;
             }
 
-            public void TextEntered(GUITextEventArgs args)
-            {
-                if (_data == null)
-                    return;
-
-                var host = _data.Browser.GetHost();
-
-                Span<char> buf = stackalloc char[2];
-                var written = args.AsRune.EncodeToUtf16(buf);
-
-                for (var i = 0; i < written; i++)
-                {
-                    host.SendKeyEvent(new CefKeyEvent
-                    {
-                        EventType = CefKeyEventType.Char,
-                        WindowsKeyCode = buf[i],
-                        Character = buf[i],
-                        UnmodifiedCharacter = buf[i]
-                    });
-                }
-            }
 
             public void Resized()
             {

--- a/Robust.Client.WebView/Headless/WebViewManagerHeadless.cs
+++ b/Robust.Client.WebView/Headless/WebViewManagerHeadless.cs
@@ -106,6 +106,9 @@ namespace Robust.Client.WebView.Headless
                 return false;
             }
 
+            public void TextEntered(GUITextEnteredEventArgs args)
+            {
+            }
 
             public void Resized()
             {
@@ -120,6 +123,14 @@ namespace Robust.Client.WebView.Headless
             }
 
             public void RemoveBeforeBrowseHandler(Action<IBeforeBrowseContext> handler)
+            {
+            }
+
+            public void FocusEntered()
+            {
+            }
+
+            public void FocusExited()
             {
             }
         }

--- a/Robust.Client.WebView/Headless/WebViewManagerHeadless.cs
+++ b/Robust.Client.WebView/Headless/WebViewManagerHeadless.cs
@@ -106,9 +106,6 @@ namespace Robust.Client.WebView.Headless
                 return false;
             }
 
-            public void TextEntered(GUITextEventArgs args)
-            {
-            }
 
             public void Resized()
             {

--- a/Robust.Client.WebView/IWebViewControlImpl.cs
+++ b/Robust.Client.WebView/IWebViewControlImpl.cs
@@ -15,9 +15,12 @@ namespace Robust.Client.WebView
         void MouseExited();
         void MouseWheel(GUIMouseWheelEventArgs args);
         bool RawKeyEvent(in GuiRawKeyEvent guiRawEvent);
+        void TextEntered(GUITextEnteredEventArgs args);
         void Resized();
         void Draw(DrawingHandleScreen handle);
         void AddBeforeBrowseHandler(Action<IBeforeBrowseContext> handler);
         void RemoveBeforeBrowseHandler(Action<IBeforeBrowseContext> handler);
+        void FocusEntered();
+        void FocusExited();
     }
 }

--- a/Robust.Client.WebView/IWebViewControlImpl.cs
+++ b/Robust.Client.WebView/IWebViewControlImpl.cs
@@ -15,7 +15,6 @@ namespace Robust.Client.WebView
         void MouseExited();
         void MouseWheel(GUIMouseWheelEventArgs args);
         bool RawKeyEvent(in GuiRawKeyEvent guiRawEvent);
-        void TextEntered(GUITextEventArgs args);
         void Resized();
         void Draw(DrawingHandleScreen handle);
         void AddBeforeBrowseHandler(Action<IBeforeBrowseContext> handler);

--- a/Robust.Client.WebView/WebViewControl.cs
+++ b/Robust.Client.WebView/WebViewControl.cs
@@ -1,7 +1,6 @@
 using System;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
-using Robust.Client.WebView.Cef;
 using Robust.Shared.IoC;
 using Robust.Shared.ViewVariables;
 
@@ -76,6 +75,26 @@ namespace Robust.Client.WebView
             return _controlImpl.RawKeyEvent(guiRawEvent);
         }
 
+        protected internal override void TextEntered(GUITextEnteredEventArgs args)
+        {
+            base.TextEntered(args);
+
+            _controlImpl.TextEntered(args);
+        }
+
+        protected internal override void KeyboardFocusEntered()
+        {
+            base.KeyboardFocusEntered();
+
+            _controlImpl.FocusEntered();
+        }
+
+        protected internal override void KeyboardFocusExited()
+        {
+            base.KeyboardFocusExited();
+
+            _controlImpl.FocusExited();
+        }
 
         protected override void Resized()
         {

--- a/Robust.Client.WebView/WebViewControl.cs
+++ b/Robust.Client.WebView/WebViewControl.cs
@@ -76,12 +76,6 @@ namespace Robust.Client.WebView
             return _controlImpl.RawKeyEvent(guiRawEvent);
         }
 
-        protected internal override void TextEntered(GUITextEventArgs args)
-        {
-            base.TextEntered(args);
-
-            _controlImpl.TextEntered(args);
-        }
 
         protected override void Resized()
         {


### PR DESCRIPTION
Deletes references to `GUITextEventArgs` which was causing a compile fail for OpenDream due to a missing reference.

This is probably not the right way to fix this, so feel free to fix it properly instead.