### PR TITLE
Remove some resolves from filters

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/AudioSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/AudioSystem.cs
@@ -121,7 +121,7 @@ public sealed class AudioSystem : SharedAudioSystem
         if (sound == null)
             return null;
 
-        var filter = Filter.Pvs(source, entityManager: EntityManager).RemoveWhereAttachedEntity(e => e == user);
+        var filter = Filter.Pvs(source, entityManager: EntityManager, playerManager: PlayerManager, cfgManager: CfgManager).RemoveWhereAttachedEntity(e => e == user);
         return Play(sound, filter, source, audioParams);
     }
 }

--- a/Robust.Shared/GameObjects/Systems/SharedAudioSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedAudioSystem.cs
@@ -5,13 +5,17 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using System;
+using Robust.Shared.Configuration;
+using Robust.Shared.Players;
 
 namespace Robust.Shared.GameObjects;
 public abstract class SharedAudioSystem : EntitySystem
 {
     [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly IPrototypeManager _protoMan = default!;
+    [Dependency] protected readonly IConfigurationManager CfgManager = default!;
     [Dependency] protected readonly IRobustRandom RandMan = default!;
+    [Dependency] protected readonly ISharedPlayerManager PlayerManager = default!;
 
     /// <summary>
     /// Default max range at which the sound can be heard.

--- a/Robust.Shared/Player/Filter.cs
+++ b/Robust.Shared/Player/Filter.cs
@@ -40,11 +40,11 @@ namespace Robust.Shared.Player
         ///     Adds all players inside an entity's PVS.
         ///     The current PVS range will be multiplied by <see cref="rangeMultiplier"/>.
         /// </summary>
-        public Filter AddPlayersByPvs(EntityUid origin, float rangeMultiplier = 2f, IEntityManager? entityManager = null)
+        public Filter AddPlayersByPvs(EntityUid origin, float rangeMultiplier = 2f, IEntityManager? entityManager = null, ISharedPlayerManager? playerMan = null, IConfigurationManager? cfgMan = null)
         {
-            IoCManager.Resolve(ref entityManager);
+            IoCManager.Resolve(ref entityManager, ref playerMan, ref cfgMan);
             var transform = entityManager.GetComponent<TransformComponent>(origin);
-            return AddPlayersByPvs(transform.MapPosition, rangeMultiplier);
+            return AddPlayersByPvs(transform.MapPosition, rangeMultiplier, entityManager, playerMan, cfgMan);
         }
 
         /// <summary>
@@ -63,14 +63,14 @@ namespace Robust.Shared.Player
         public Filter AddPlayersByPvs(EntityCoordinates origin, float rangeMultiplier = 2f, IEntityManager? entityMan = null, ISharedPlayerManager? playerMan = null)
         {
             IoCManager.Resolve(ref entityMan, ref playerMan);
-            return AddPlayersByPvs(origin.ToMap(entityMan), rangeMultiplier, playerMan);
+            return AddPlayersByPvs(origin.ToMap(entityMan), rangeMultiplier, entityMan, playerMan);
         }
 
         /// <summary>
         ///     Adds all players inside an entity's PVS.
         ///     The current PVS range will be multiplied by <see cref="rangeMultiplier"/>.
         /// </summary>
-        public Filter AddPlayersByPvs(MapCoordinates origin, float rangeMultiplier = 2f, ISharedPlayerManager? playerMan = null, IConfigurationManager? cfgMan = null)
+        public Filter AddPlayersByPvs(MapCoordinates origin, float rangeMultiplier = 2f, IEntityManager? entManager = null, ISharedPlayerManager? playerMan = null, IConfigurationManager? cfgMan = null)
         {
             IoCManager.Resolve(ref playerMan, ref cfgMan);
 
@@ -80,7 +80,7 @@ namespace Robust.Shared.Player
 
             var pvsRange = cfgMan.GetCVar(CVars.NetMaxUpdateRange) * rangeMultiplier;
 
-            return AddInRange(origin, pvsRange, playerMan);
+            return AddInRange(origin, pvsRange, playerMan, entManager);
         }
 
         /// <summary>
@@ -165,7 +165,7 @@ namespace Robust.Shared.Player
         /// </summary>
         public Filter AddInRange(MapCoordinates position, float range, ISharedPlayerManager? playerMan = null, IEntityManager? entMan = null)
         {
-            IoCManager.Resolve(ref entMan);
+            IoCManager.Resolve(ref playerMan, ref entMan);
             var xformQuery = entMan.GetEntityQuery<TransformComponent>();
 
             return AddWhere(session =>
@@ -325,9 +325,9 @@ namespace Robust.Shared.Player
         /// <summary>
         ///     A filter with every player whose PVS overlaps this entity.
         /// </summary>
-        public static Filter Pvs(EntityUid origin, float rangeMultiplier = 2f, IEntityManager? entityManager = null)
+        public static Filter Pvs(EntityUid origin, float rangeMultiplier = 2f, IEntityManager? entityManager = null, ISharedPlayerManager? playerManager = null, IConfigurationManager? cfgManager = null)
         {
-            return Empty().AddPlayersByPvs(origin, rangeMultiplier, entityManager);
+            return Empty().AddPlayersByPvs(origin, rangeMultiplier, entityManager, playerManager, cfgManager);
         }
 
         /// <summary>


### PR DESCRIPTION
This took up 40ms of 400ms of mob movement on my profile. Ideally we'd kill filters but yeah...