### PR TITLE
Change ComponentGetState args

### DIFF
--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -1153,7 +1153,7 @@ internal sealed partial class PVSSystem : EntitySystem
             if (component.SessionSpecific && !EntityManager.CanGetComponentState(bus, component, player))
                 continue;
 
-            var state = EntityManager.GetComponentState(bus, component, component.SessionSpecific ? player : null);
+            var state = EntityManager.GetComponentState(bus, component, player);
             changed.Add(new ComponentChange(netId, state, component.LastModifiedTick));
 
             if (sendCompList)
@@ -1187,7 +1187,7 @@ internal sealed partial class PVSSystem : EntitySystem
             if (component.SessionSpecific && !EntityManager.CanGetComponentState(bus, component, player))
                 continue;
 
-            changed.Add(new ComponentChange(netId, EntityManager.GetComponentState(bus, component, component.SessionSpecific ? player : null), component.LastModifiedTick));
+            changed.Add(new ComponentChange(netId, EntityManager.GetComponentState(bus, component, player), component.LastModifiedTick));
             netComps.Add(netId);
         }
 

--- a/Robust.Shared/GameStates/ComponentStateEvents.cs
+++ b/Robust.Shared/GameStates/ComponentStateEvents.cs
@@ -28,7 +28,7 @@ namespace Robust.Shared.GameStates
         public ComponentState? State { get; set; }
 
         /// <summary>
-        ///     Input parameter. The player the state is being sent to.
+        ///     The player the state is being sent to. Null implies the state is for a replay or some spectator entity.
         /// </summary>
         public readonly ICommonSession? Player;
 


### PR DESCRIPTION
Changes the session argument of the ComponentGetState event, so that the session is always included when sending the state to normal players.