### PR TITLE
Fix metadata dupes on maps

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -914,6 +914,8 @@ public sealed class MapLoaderSystem : EntitySystem
         var entities = new SequenceDataNode();
         rootNode.Add("entities", entities);
 
+        // As metadata isn't on components we'll special-case it.
+        var metadataName = _factory.GetComponentName(typeof(MetaDataComponent));
         var prototypeCompCache = new Dictionary<string, Dictionary<string, MappingDataNode>>();
 
         foreach (var (saveId, entityUid) in uidEntityMap.OrderBy( e=> e.Key))
@@ -940,6 +942,8 @@ public sealed class MapLoaderSystem : EntitySystem
                     {
                         cache.Add(compType, _serManager.WriteValueAs<MappingDataNode>(comp.Component.GetType(), comp.Component));
                     }
+
+                    cache.GetOrNew(metadataName);
                 }
             }
 


### PR DESCRIPTION
Fixes https://github.com/space-wizards/RobustToolbox/issues/3504

Issue seems to be that because the component isn't on the prototype the cache assumes it's always new and always writes it. Transform is probably okay if we support transform-less entities in the future then it needs to stay as is.

Also SessionSpecific is written on a lot of these but not sure if necessary.