### PR TITLE
Fix mapload positions

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -647,7 +647,6 @@ public sealed class MapLoaderSystem : EntitySystem
     private void StartupEntities(MapData data)
     {
         _stopwatch.Restart();
-        DebugTools.Assert(data.Entities.Count == data.Entities.Count);
         var metaQuery = GetEntityQuery<MetaDataComponent>();
         var rootEntity = data.Entities[0];
         var mapQuery = GetEntityQuery<MapComponent>();
@@ -667,21 +666,15 @@ public sealed class MapLoaderSystem : EntitySystem
             }
         }
 
-        var isRoot = true;
-
         for (var i = 1; i < data.Entities.Count; i++)
         {
             var entity = data.Entities[i];
 
-            if (isRoot && xformQuery.TryGetComponent(entity, out var xform) && IsRoot(xform, mapQuery))
+            if (xformQuery.TryGetComponent(entity, out var xform) && IsRoot(xform, mapQuery))
             {
                 // Don't want to trigger events
                 xform._localPosition = data.Options.TransformMatrix.Transform(xform.LocalPosition);
                 xform._localRotation += data.Options.Rotation;
-            }
-            else
-            {
-                isRoot = false;
             }
 
             StartupEntity(entity, metaQuery.GetComponent(entity), data);

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -40,7 +40,7 @@ namespace Robust.Shared.GameObjects
         [ViewVariables]
         internal BroadphaseData? Broadphase;
 
-        internal bool MatricesDirty = false;
+        internal bool MatricesDirty = true;
         private Matrix3 _localMatrix = Matrix3.Identity;
         private Matrix3 _invLocalMatrix = Matrix3.Identity;
 


### PR DESCRIPTION
GetWorldPosition() was relying on the local transform matrices being correct, which they aren't for uninitialized entities. This just fixes that by changing the default value of `MatricesDirty`.

Also fixes some other map loader offset issues that currently implicitly assume entities are sorted/ordered.

