### PR TITLE
Fix deserialized grid networking

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedGridFixtureSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridFixtureSystem.cs
@@ -100,37 +100,6 @@ namespace Robust.Shared.GameObjects
             CheckSplit(gridEuid, mapChunks, removedChunks);
         }
 
-        internal void RegenerateCollision(EntityUid gridEuid, MapChunk chunk, List<Box2i> rectangles)
-        {
-            if (!_enabled) return;
-
-            if (chunk.FilledTiles == 0)
-            {
-                CheckSplit(gridEuid, chunk, rectangles);
-                return;
-            }
-
-            if (!EntityManager.TryGetComponent(gridEuid, out PhysicsComponent? physicsComponent))
-            {
-                Sawmill.Error($"Trying to regenerate collision for {gridEuid} that doesn't have {nameof(physicsComponent)}");
-                return;
-            }
-
-            if (!EntityManager.TryGetComponent(gridEuid, out FixturesComponent? fixturesComponent))
-            {
-                Sawmill.Error($"Trying to regenerate collision for {gridEuid} that doesn't have {nameof(fixturesComponent)}");
-                return;
-            }
-
-            if (UpdateFixture(chunk, rectangles, physicsComponent, fixturesComponent))
-            {
-                _fixtures.FixtureUpdate(fixturesComponent, physicsComponent);
-                EntityManager.EventBus.RaiseLocalEvent(gridEuid,new GridFixtureChangeEvent {NewFixtures = chunk.Fixtures}, true);
-
-                CheckSplit(gridEuid, chunk, rectangles);
-            }
-        }
-
         internal virtual void CheckSplit(EntityUid gridEuid, Dictionary<MapChunk, List<Box2i>> mapChunks,
             List<MapChunk> removedChunks) {}
 

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -53,6 +53,16 @@ public abstract partial class SharedMapSystem
                 _transform.SetParent(xform, MapManager.GetMapEntityIdOrThrow(mapId), xformQuery);
         }
 
+        // Force networkedmapmanager to send it due to non-ECS legacy code.
+        var curTick = _timing.CurTick;
+
+        foreach (var chunk in component.Chunks.Values)
+        {
+            chunk.LastTileModifiedTick = curTick;
+        }
+
+        component.LastTileModifiedTick = curTick;
+
         // Just in case.
         _transform.SetGridId(xform, uid, xformQuery);
 

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
@@ -6,12 +6,14 @@ using System.Collections.Generic;
 using Robust.Shared.GameStates;
 using Robust.Shared.Map.Components;
 using System.Linq;
+using Robust.Shared.Timing;
 
 namespace Robust.Shared.GameObjects
 {
     [UsedImplicitly]
     public abstract partial class SharedMapSystem : EntitySystem
     {
+        [Dependency] private readonly IGameTiming _timing = default!;
         [Dependency] protected readonly IMapManager MapManager = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
 


### PR DESCRIPTION
If they're not dirtied via other means then networkedmapmanager doesn't send it, hence we'll just force grids to always be dirty and get sent on initialise, at least for now.