### PR TITLE
Fix grid chunk double subscription

### DIFF
--- a/Robust.Client/Console/Commands/Debug.cs
+++ b/Robust.Client/Console/Commands/Debug.cs
@@ -625,7 +625,7 @@ namespace Robust.Client.Console.Commands
             }
 
             var chunkIndex = grid.LocalToChunkIndices(grid.MapToGrid(mousePos));
-            var chunk = grid.GetChunk(chunkIndex);
+            var chunk = grid.GetOrAddChunk(chunkIndex);
 
             shell.WriteLine($"worldBounds: {grid.CalcWorldAABB(chunk)} localBounds: {chunk.CachedBounds}");
         }

--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -622,7 +622,7 @@ public sealed class MapLoaderSystem : EntitySystem
             foreach (var chunkNode in yamlGridChunks.Cast<MappingDataNode>())
             {
                 var (chunkOffsetX, chunkOffsetY) = _serManager.Read<Vector2i>(chunkNode["ind"]);
-                var chunk = grid.GetChunk(chunkOffsetX, chunkOffsetY);
+                var chunk = grid.GetOrAddChunk(chunkOffsetX, chunkOffsetY);
                 _serManager.Read(chunkNode, _context, value: chunk);
             }
         }

--- a/Robust.Shared/GameObjects/IComponent.cs
+++ b/Robust.Shared/GameObjects/IComponent.cs
@@ -40,7 +40,7 @@ namespace Robust.Shared.GameObjects
         EntityUid Owner { get; }
 
         /// <summary>
-        /// Component has been properly initialized.
+        /// Component has been (or is currently being) initialized.
         /// </summary>
         bool Initialized { get; }
 

--- a/Robust.Shared/Map/Components/MapGridComponent.cs
+++ b/Robust.Shared/Map/Components/MapGridComponent.cs
@@ -447,7 +447,7 @@ namespace Robust.Shared.Map.Components
             var newChunk = new MapChunk(chunkIndices.X, chunkIndices.Y, ChunkSize);
             newChunk.LastTileModifiedTick = _mapManager.GameTiming.CurTick;
 
-            if (LifeStage > ComponentLifeStage.Initializing)
+            if (Initialized)
                 newChunk.TileModified += OnTileModified;
 
             return Chunks[chunkIndices] = newChunk;

--- a/Robust.Shared/Map/Components/MapGridComponent.cs
+++ b/Robust.Shared/Map/Components/MapGridComponent.cs
@@ -447,7 +447,7 @@ namespace Robust.Shared.Map.Components
             var newChunk = new MapChunk(chunkIndices.X, chunkIndices.Y, ChunkSize);
             newChunk.LastTileModifiedTick = _mapManager.GameTiming.CurTick;
 
-            if (Initialized)
+            if (LifeStage > ComponentLifeStage.Initializing)
                 newChunk.TileModified += OnTileModified;
 
             return Chunks[chunkIndices] = newChunk;

--- a/Robust.Shared/Map/MapChunk.cs
+++ b/Robust.Shared/Map/MapChunk.cs
@@ -155,6 +155,10 @@ namespace Robust.Shared.Map
             _tiles[xIndex, yIndex] = tile;
 
             var tileIndices = new Vector2i(xIndex, yIndex);
+
+            // God I hate C# events sometimes.
+            DebugTools.Assert(TileModified == null || TileModified.GetInvocationList().Length <= 1);
+
             TileModified?.Invoke(this, tileIndices, tile, oldTile, shapeChanged);
         }
 

--- a/Robust.Shared/Map/MapManager.Queries.cs
+++ b/Robust.Shared/Map/MapManager.Queries.cs
@@ -185,7 +185,7 @@ internal partial class MapManager
 
             if (!iGrid.HasChunk(chunkIndices)) return true;
 
-            var chunk = iGrid.GetChunk(chunkIndices);
+            var chunk = iGrid.GetOrAddChunk(chunkIndices);
             Vector2i indices = chunk.GridTileToChunkTile(tile);
             var chunkTile = chunk.GetTile((ushort)indices.X, (ushort)indices.Y);
 


### PR DESCRIPTION
Prevents `GetChunk()` from subscribing to the `TileModified` event if the component has not yet been initialized. Also renames `GetChunk` to `GetOrAddChunk`