### PR TITLE
Correct removal of PVS state for players without inGame status

### DIFF
--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -403,7 +403,7 @@ internal sealed partial class PVSSystem : EntitySystem
             return;
         }
 
-        if (e.NewStatus != SessionStatus.Disconnected)
+        if (e.NewStatus != SessionStatus.Disconnected || e.OldStatus != SessionStatus.InGame)
             return;
 
         foreach (var pvsCollection in _pvsCollections)

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -403,7 +403,10 @@ internal sealed partial class PVSSystem : EntitySystem
             return;
         }
 
-        if (e.NewStatus != SessionStatus.Disconnected || e.OldStatus != SessionStatus.InGame)
+        if (e.NewStatus != SessionStatus.Disconnected)
+            return;
+
+        if (!_playerVisibleSets.Remove(e.Session, out var data))
             return;
 
         foreach (var pvsCollection in _pvsCollections)
@@ -411,9 +414,6 @@ internal sealed partial class PVSSystem : EntitySystem
             if (!pvsCollection.RemovePlayer(e.Session))
                 _sawmill.Error($"Attempted to remove player from pvsCollection, but they were already removed? Session:{e.Session}");
         }
-
-        if (!_playerVisibleSets.Remove(e.Session, out var data))
-            return;
 
         if (data.Overflow != null)
             _visSetPool.Return(data.Overflow.Value.SentEnts);


### PR DESCRIPTION
The state for PVS is created only if the player's status went to `InGame`, but is deleted without checking whether the player was really in `InGame` state.
This fixes the problem when the user disconnect while in `Connected` state.
Checked in game and error from 412 line gone.