### PR TITLE
Two small bugfixes

### DIFF
--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -91,10 +91,7 @@ namespace Robust.Client.GameObjects
             var sequence = _stateMan.SystemMessageDispatched(msg);
             EntityNetManager?.SendSystemNetworkMessage(msg, sequence);
 
-            if (!_stateMan.IsPredictionEnabled)
-                return;
-
-            DebugTools.Assert(_gameTiming.InPrediction && _gameTiming.IsFirstTimePredicted || _client.RunLevel != ClientRunLevel.Connected);
+            DebugTools.Assert(!_stateMan.IsPredictionEnabled || _gameTiming.InPrediction && _gameTiming.IsFirstTimePredicted || _client.RunLevel != ClientRunLevel.Connected);
 
             var eventArgs = new EntitySessionEventArgs(localPlayer!.Session);
             EventBus.RaiseEvent(EventSource.Local, msg);

--- a/Robust.Shared/GameObjects/Systems/SharedAudioSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedAudioSystem.cs
@@ -177,7 +177,7 @@ public abstract class SharedAudioSystem : EntitySystem
     /// <param name="audioParams">Audio parameters to apply when playing the sound. Defaults to using the sound specifier's parameters</param>
     public IPlayingAudioStream? PlayPvs(SoundSpecifier? sound, EntityUid uid, AudioParams? audioParams = null)
     {
-        return sound == null ? null : PlayPvs(GetSound(sound), uid, audioParams);
+        return sound == null ? null : PlayPvs(GetSound(sound), uid, audioParams ?? sound.Params);
     }
 
     /// <summary>


### PR DESCRIPTION
- Fixes `PlayPvs` not taking audio options from the sound specifier
- Allows `RaisePredictiveEvent` to be used even when prediction is disabled (in which case it is just equivalent to raise local + raise networked)