### PR TITLE
Use correct native GLFW library name on FreeBSD

### DIFF
--- a/OpenToolkit.GraphicsLibraryFramework/GLFWNative.cs
+++ b/OpenToolkit.GraphicsLibraryFramework/GLFWNative.cs
@@ -25,7 +25,7 @@ namespace OpenToolkit.GraphicsLibraryFramework
                 }
 
                 string rName = null;
-                if (OperatingSystem.IsLinux()) rName = "libglfw.so.3";
+                if (OperatingSystem.IsLinux() || OperatingSystem.IsFreeBSD()) rName = "libglfw.so.3";
                 else if (OperatingSystem.IsMacOS()) rName = "libglfw.3.dylib";
 
                 if ((rName != null) && NativeLibrary.TryLoad(rName, assembly, path, out var handle))


### PR DESCRIPTION
This change is actually already upstream, thanks to @PJB3005 :
https://github.com/opentk/opentk/blob/4.0.0-pre9.1/src/OpenToolkit.Windowing.GraphicsLibraryFramework/OpenToolkit.Windowing.GLFW.dll.config

However, because RobustToolbox carries around its own fork of GraphicsLibraryFramework, we need to make this change locally.

By the way, that does in fact work on FreeBSD.