### PR TITLE
Fix pre init map loads on postinit maps

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -524,7 +524,6 @@ public sealed class MapLoaderSystem : EntitySystem
                 }
 
                 Del(oldRootUid);
-                data.MapIsPostInit = _mapManager.IsMapInitialized(data.TargetMap);
             }
             else
             {


### PR DESCRIPTION
Don't overwrite the MapIsPostInit using the existing map's value.