### PR TITLE
RSI meta atlas

### DIFF
--- a/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
+++ b/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
@@ -1,12 +1,18 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using OpenToolkit.Graphics.OpenGL4;
 using Robust.Client.Graphics;
+using Robust.Client.Utility;
 using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
+using Robust.Shared.Maths;
+using Robust.Shared.Utility;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace Robust.Client.ResourceManagement
 {
@@ -130,20 +136,76 @@ namespace Robust.Client.ResourceManagement
                 }
             });
 
-            foreach (var data in rsiList)
+            // This combines individual RSI atlases into larger atlases to reduce draw batches. currently this is a VERY
+            // lazy bundling and is not at all compact, its basically an atlas of RSI atlases. Really what this should
+            // try to do is to have each RSI write directly to the atlas, rather than having each RSI write to its own
+            // sub-atlas first.
+            //
+            // Also if the max texture size is too small, such that there needs to be more than one atlas, then each
+            // atlas should somehow try to group things by draw-depth & frequency to minimize batches? But currently
+            // everything fits onto a single 8k x 8k image so as long as the computer can manage that, it should be
+            // fine.
+            //
+            // Also giant RSIs (boardgames, singularity, etc) should just get their own atlas or just shouldn't be RSIs
+            // TODO combine with (non-rsi) texture atlas?
+
+            Array.Sort(rsiList, (b, a) => b.AtlasSheet.Height.CompareTo(a.AtlasSheet.Height));
+            // Each RSI sub atlas has a different size.
+            // Even if we iterate through them once to estimate total area, I have NFI how to sanely estimate an optimal square-texture size.
+            // So fuck it, just default to letting it be as large as it needs to and crop it as needed?
+            var maxSize = Math.Min(GL.GetInteger(GetPName.MaxTextureSize), 16384);
+            var sheet = new Image<Rgba32>(maxSize, maxSize);
+
+            var deltaY = 0;
+            Vector2i offset = default;
+            int finalized = -1;
+            int atlasCount = 0;
+            for (int i = 0; i < rsiList.Length; i++)
             {
-                if (data.Bad)
+                var rsi = rsiList[i];
+                if (rsi.Bad)
                     continue;
 
-                try
+                DebugTools.Assert(rsi.AtlasSheet.Width < sheet.Width);
+                DebugTools.Assert(rsi.AtlasSheet.Height < sheet.Height);
+
+                if (offset.X + rsi.AtlasSheet.Width > sheet.Width)
                 {
-                    RSIResource.LoadTexture(_clyde, data);
+                    offset.X = 0;
+                    offset.Y += deltaY;
                 }
-                catch (Exception e)
+
+                if (offset.Y + rsi.AtlasSheet.Height > sheet.Height)
                 {
-                    sawmill.Error($"Exception while loading RSI {data.Path}:\n{e}");
-                    data.Bad = true;
+                    FinalizeMetaAtlas(i-1, sheet);
+                    sheet = new Image<Rgba32>(maxSize, maxSize);
+                    deltaY = 0;
+                    offset = default;
                 }
+
+                deltaY = Math.Max(deltaY, rsi.AtlasSheet.Height);
+                var box = new UIBox2i(0, 0, rsi.AtlasSheet.Width, rsi.AtlasSheet.Height);
+                rsi.AtlasSheet.Blit(box, sheet, offset);
+                rsi.AtlasOffset = offset;
+                offset.X += rsi.AtlasSheet.Width;
+            }
+
+            var height = offset.Y + deltaY;
+            var croppedSheet = new Image<Rgba32>(maxSize, height);
+            sheet.Blit(new UIBox2i(0, 0, maxSize, height), croppedSheet, default);
+            FinalizeMetaAtlas(rsiList.Length - 1, croppedSheet);
+
+            void FinalizeMetaAtlas(int toIndex, Image<Rgba32> sheet)
+            {
+                var atlas = _clyde.LoadTextureFromImage(sheet);
+                for (int i = finalized + 1; i <= toIndex; i++)
+                {
+                    var rsi = rsiList[i];
+                    rsi.AtlasTexture = atlas;
+                }
+
+                finalized = toIndex;
+                atlasCount++;
             }
 
             Parallel.ForEach(rsiList, data =>
@@ -186,8 +248,9 @@ namespace Robust.Client.ResourceManagement
             }
 
             sawmill.Debug(
-                "Preloaded {CountLoaded} RSIs ({CountErrored} errored) in {LoadTime}",
+                "Preloaded {CountLoaded} RSIs into {CountAtlas} Atlas(es?) ({CountErrored} errored) in {LoadTime}",
                 rsiList.Length,
+                atlasCount,
                 errors,
                 sw.Elapsed);
 

--- a/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
+++ b/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
@@ -145,15 +145,16 @@ namespace Robust.Client.ResourceManagement
             // atlas should somehow try to group things by draw-depth & frequency to minimize batches? But currently
             // everything fits onto a single 8k x 8k image so as long as the computer can manage that, it should be
             // fine.
-            //
-            // Also giant RSIs (boardgames, singularity, etc) should just get their own atlas or just shouldn't be RSIs
+            
+            // TODO allow RSIs to opt out (useful for very big & rare RSIs)
             // TODO combine with (non-rsi) texture atlas?
 
             Array.Sort(rsiList, (b, a) => b.AtlasSheet.Height.CompareTo(a.AtlasSheet.Height));
+
             // Each RSI sub atlas has a different size.
             // Even if we iterate through them once to estimate total area, I have NFI how to sanely estimate an optimal square-texture size.
             // So fuck it, just default to letting it be as large as it needs to and crop it as needed?
-            var maxSize = Math.Min(GL.GetInteger(GetPName.MaxTextureSize), 16384);
+            var maxSize = Math.Min(GL.GetInteger(GetPName.MaxTextureSize), _configurationManager.GetCVar(CVars.ResRSIAtlasSize));
             var sheet = new Image<Rgba32>(maxSize, maxSize);
 
             var deltaY = 0;

--- a/Robust.Client/ResourceManagement/ResourceTypes/RSIResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/RSIResource.cs
@@ -39,20 +39,14 @@ namespace Robust.Client.ResourceManagement
             var loadStepData = new LoadStepData {Path = path};
             LoadPreTexture(cache, loadStepData);
 
-            // Load atlas.
-            LoadTexture(clyde, loadStepData);
+            loadStepData.AtlasTexture = clyde.LoadTextureFromImage(
+                loadStepData.AtlasSheet,
+                loadStepData.Path.ToString());
 
             LoadPostTexture(loadStepData);
             LoadFinish(cache, loadStepData);
 
             loadStepData.AtlasSheet.Dispose();
-        }
-
-        internal static void LoadTexture(IClyde clyde, LoadStepData loadStepData)
-        {
-            loadStepData.AtlasTexture = clyde.LoadTextureFromImage(
-                loadStepData.AtlasSheet,
-                loadStepData.Path.ToString());
         }
 
         internal static void LoadPreTexture(IResourceCache cache, LoadStepData data)
@@ -210,7 +204,7 @@ namespace Robust.Client.ResourceManagement
                         var sheetPos = (sheetColumn * frameSize.X, sheetRow * frameSize.Y);
 
                         dirOffsets[j] = sheetPos;
-                        dirOutput[j] = new AtlasTexture(texture, UIBox2.FromDimensions(sheetPos, frameSize));
+                        dirOutput[j] = new AtlasTexture(texture, UIBox2.FromDimensions(data.AtlasOffset + sheetPos, frameSize));
                     }
                 }
 
@@ -386,6 +380,7 @@ namespace Robust.Client.ResourceManagement
             public Vector2i FrameSize;
             public Dictionary<RSI.StateId, Vector2i[][]> CallbackOffsets = default!;
             public Texture AtlasTexture = default!;
+            public Vector2i AtlasOffset;
             public RSI Rsi = default!;
         }
 

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1196,6 +1196,13 @@ namespace Robust.Shared
         public static readonly CVarDef<bool> ResTexturePreloadingEnabled =
             CVarDef.Create("res.texturepreloadingenabled", true, CVar.CLIENTONLY);
 
+        /// <summary>
+        /// Upper limit on the size of the RSI atlas texture. A lower limit might waste less vram, but start to defeat
+        /// the purpose of using an atlas if it gets too small.
+        /// </summary>
+        public static readonly CVarDef<int> ResRSIAtlasSize =
+            CVarDef.Create("res.rsi_atlas_size", 8192, CVar.CLIENTONLY);
+
         // TODO: Currently unimplemented.
         /// <summary>
         /// Cache texture preload data to speed things up even further.


### PR DESCRIPTION
This PR combines individual RSI atlases into one or more large combined atlases. It does this by just writing each RSI to some larger atlas left to right, top to bottom, with each row just being the height of the largest RSI atlas in that row. This can lead to gaps / bad packing, but seems to work well enough. Might hurt start-up times, but improves with rendering.

I don't know what typical max texture sizes are, but 8kx8k currently fits all of content. If it turns out that most users can only support 2k*2k (requires ~ 14 atlases), then maybe the way rsis are grouped into atlases needs to be more intelligent, to ensure that entities that are very common and have the same draw-depth are in the same atlas.

Needs testing on potato computers before merging. I did test it on my laptop, which has no dedicated GPU and it still got a significant improvement, but even that apparently still supports 8k textures.
