### PR TITLE
Call OnConnect method for player session

### DIFF
--- a/Robust.Server/Player/PlayerManager.cs
+++ b/Robust.Server/Player/PlayerManager.cs
@@ -459,7 +459,7 @@ namespace Robust.Server.Player
             // This is done before the packet is built, so that the client
             // can see themselves Connected.
             var session = GetSessionByChannel(channel);
-            session.Status = SessionStatus.Connected;
+            session.OnConnect();
 
             var list = new List<PlayerState>();
             foreach (var client in players)


### PR DESCRIPTION
This method exists but is not used anywhere, although it initializes `ConnectedTime` parameter.
A side effect is that the method calls `UpdatePlayerState`, but there's nothing wrong with that, is there?
Tested these changes locally and there were no problems.

https://github.com/space-wizards/RobustToolbox/blob/5fed38fecde5a640bc95a450bc5b81ad8218311f/Robust.Server/Player/PlayerSession.cs#L162-L167