### PR TITLE
Physics solver tweaks

### DIFF
--- a/Robust.Shared/Physics/IslandManager.cs
+++ b/Robust.Shared/Physics/IslandManager.cs
@@ -124,12 +124,12 @@ namespace Robust.Shared.Physics
 
             void UpdateMaxLinearVelocity()
             {
-                _islandCfg.MaxLinearVelocity = _maxLinearVelocityRaw / _tickRate;
+                _islandCfg.MaxTranslationPerTick = _maxLinearVelocityRaw / _tickRate;
             }
 
             void UpdateMaxAngularVelocity()
             {
-                _islandCfg.MaxAngularVelocity = (MathF.PI * 2 * _maxAngularVelocityRaw) / _tickRate;
+                _islandCfg.MaxRotationPerTick = (MathF.PI * 2 * _maxAngularVelocityRaw) / _tickRate;
             }
 
             void CfgVar<T>(CVarDef<T> cVar, Action<T> callback) where T : notnull


### PR DESCRIPTION
- Renames _maxLinearVelocity & _maxAngularVelocity to _maxTranslation & _maxRotation
- Fixes max angular velocity not being properly applied
  - was previously checking if `rotation^2 > _maxRotation`
  - This would actually cause objects to start spinning FASTER while  `rotation^2 > _maxRotation > rotation`. 
  - Was probably responsible for some eternally rotating physics objects.
- Speeds up the main integration loop a bit
  - Moves some of the math outside of the loop
  -  Avoids updating the velocity arrays unless required.
  - Avoids (mostly) unnecessary square root