### PR TITLE
SIMD physics position integration.

### DIFF
--- a/Robust.Shared/Physics/Dynamics/PhysicsIsland.cs
+++ b/Robust.Shared/Physics/Dynamics/PhysicsIsland.cs
@@ -490,16 +490,15 @@ stored in a single array since multiple arrays lead to multiple misses.
             {
                 var linearVelocity = velocities[i];
                 var velSqr = linearVelocity.LengthSquared;
+
                 if (velSqr > vLimSqr)
                 {
                     linearVelocity *= vLimit / MathF.Sqrt(velSqr);
+                    // TODO: is this actually required?
                     velocities[i] = linearVelocity;
                 }
 
-                velocities[i] += linearVelocity * frameTime;
-
-                // TODO: is this actually required?
-                velocities[i] = linearVelocity;
+                positions[i] += linearVelocity * frameTime;
             }
         }
 
@@ -523,7 +522,7 @@ stored in a single array since multiple arrays lead to multiple misses.
                     var v = Sse.LoadVector128(vPtr + i);
                     var x = Sse.LoadVector128(xPtr + i);
                     v = Sse.Max(Sse.Min(v, maxV), minV);
-                    Sse.Store(xPtr + i, Fma.MultiplyAdd(x, time, x));
+                    Sse.Store(xPtr + i, Fma.MultiplyAdd(v, time, x));
 
                     // TODO: is this actually required?
                     Sse.Store(vPtr + i, v);

--- a/Robust.Shared/Physics/IslandManager.cs
+++ b/Robust.Shared/Physics/IslandManager.cs
@@ -124,12 +124,12 @@ namespace Robust.Shared.Physics
 
             void UpdateMaxLinearVelocity()
             {
-                _islandCfg.MaxLinearVelocity = _maxLinearVelocityRaw / _tickRate;
+                _islandCfg.MaxTranslationPerTick = _maxLinearVelocityRaw / _tickRate;
             }
 
             void UpdateMaxAngularVelocity()
             {
-                _islandCfg.MaxAngularVelocity = (MathF.PI * 2 * _maxAngularVelocityRaw) / _tickRate;
+                _islandCfg.MaxRotationPerTick = (MathF.PI * 2 * _maxAngularVelocityRaw) / _tickRate;
             }
 
             void CfgVar<T>(CVarDef<T> cVar, Action<T> callback) where T : notnull


### PR DESCRIPTION
Draft because this assumes FMA is supported.

This makes the position integration use SIMD. Performance wise, this should be compared with #3553 (which tries to avoid unnecessary clamping, whereas this will do it for all velocities). 

~~I don't actually know how to best benchmark this, so: Help me @metalgearsloth, you're my only hope.~~
Using 5 tumbler test beds, the overall improvement seems insignificant because most of the time is spent in solving constraints & finding contacts. Probably still worth adding though?

This does implicitly change the velocity limit cvar so that it goes from limiting the magnitude of the velocity, to limiting the magnitude of individual components. 

The same treatment could easily be given to the velocity damping if bodies are sorted by body type.