### PR TITLE
Add try-catch to window rendering

### DIFF
--- a/Robust.Client/UserInterface/UserInterfaceManager.Layout.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Layout.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared.Log;
 using Robust.Shared.Maths;
 using Robust.Shared.Profiling;
 
@@ -124,7 +126,9 @@ internal sealed partial class UserInterfaceManager
                 DoRender(_windowsToRoot[_clyde.MainWindow.Id]);
             }
 
-            void DoRender(WindowRoot root)
+        void DoRender(WindowRoot root)
+        {
+            try
             {
                 var total = 0;
                 _render(renderHandle, ref total, root, Vector2i.Zero, Color.White, null);
@@ -134,7 +138,13 @@ internal sealed partial class UserInterfaceManager
 
                 _prof.WriteValue("Controls rendered", ProfData.Int32(total));
             }
+            catch (Exception e)
+            {
+                Logger.Error($"Caught exception while trying to draw a UI element: {root}");
+                _runtime.LogException(e, nameof(UserInterfaceManager));
+            }
         }
+    }
 
         public void QueueStyleUpdate(Control control)
         {

--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -10,6 +10,7 @@ using Robust.Client.UserInterface.CustomControls;
 using Robust.Client.UserInterface.CustomControls.DebugMonitorControls;
 using Robust.Shared;
 using Robust.Shared.Configuration;
+using Robust.Shared.Exceptions;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Input;
 using Robust.Shared.Input.Binding;
@@ -47,6 +48,7 @@ namespace Robust.Client.UserInterface
         [Dependency] private readonly IReflectionManager _reflectionManager = default!;
         [Dependency] private readonly IEntitySystemManager _systemManager = default!;
         [Dependency] private readonly ILogManager _logManager = default!;
+        [Dependency] private readonly IRuntimeLog _runtime = default!;
 
         [ViewVariables] public InterfaceTheme ThemeDefaults { get; private set; } = default!;
         [ViewVariables]


### PR DESCRIPTION
Tries to prevent things like broken markup in some content window from just killing the frame update.