### PR TITLE
More broadphase fixes

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
@@ -181,20 +181,11 @@ namespace Robust.Shared.Physics.Systems
             var bodyQuery = GetEntityQuery<PhysicsComponent>();
             var xformQuery = GetEntityQuery<TransformComponent>();
             var jointQuery = GetEntityQuery<JointComponent>();
-            var fixturesQuery = GetEntityQuery<FixturesComponent>();
-            var broadQuery = GetEntityQuery<BroadphaseComponent>();
 
             TryComp(MapManager.GetMapEntityId(oldMapId), out SharedPhysicsMapComponent? oldMap);
             TryComp(MapManager.GetMapEntityId(newMapId), out SharedPhysicsMapComponent? newMap);
 
-            Dictionary<FixtureProxy, Box2>? oldMoveBuffer = null;
-
-            if (oldMap != null)
-            {
-                oldMoveBuffer = oldMap.MoveBuffer;
-            }
-
-            RecursiveMapUpdate(xform, body, newMapId, newMap, oldMap, oldMoveBuffer, bodyQuery, xformQuery, fixturesQuery, jointQuery, broadQuery);
+            RecursiveMapUpdate(xform, body, newMap, oldMap, bodyQuery, xformQuery, jointQuery);
         }
 
         /// <summary>
@@ -203,18 +194,13 @@ namespace Robust.Shared.Physics.Systems
         private void RecursiveMapUpdate(
             TransformComponent xform,
             PhysicsComponent? body,
-            MapId newMapId,
             SharedPhysicsMapComponent? newMap,
             SharedPhysicsMapComponent? oldMap,
-            Dictionary<FixtureProxy, Box2>? oldMoveBuffer,
             EntityQuery<PhysicsComponent> bodyQuery,
             EntityQuery<TransformComponent> xformQuery,
-            EntityQuery<FixturesComponent> fixturesQuery,
-            EntityQuery<JointComponent> jointQuery,
-            EntityQuery<BroadphaseComponent> broadQuery)
+            EntityQuery<JointComponent> jointQuery)
         {
             var uid = xform.Owner;
-
             DebugTools.Assert(!Deleted(uid));
 
             // This entity may not have a body, but some of its children might:
@@ -244,9 +230,8 @@ namespace Robust.Shared.Physics.Systems
                 if (xformQuery.TryGetComponent(child, out var childXform))
                 {
                     bodyQuery.TryGetComponent(child, out var childBody);
-                    RecursiveMapUpdate(childXform, childBody, newMapId, newMap, oldMap, oldMoveBuffer, bodyQuery, xformQuery, fixturesQuery, jointQuery, broadQuery);
+                    RecursiveMapUpdate(childXform, childBody, newMap, oldMap, bodyQuery, xformQuery, jointQuery);
                 }
-
             }
         }
 

--- a/Robust.UnitTesting/Shared/Physics/Broadphase_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Broadphase_Test.cs
@@ -1,5 +1,7 @@
 using System.Linq;
 using NUnit.Framework;
+using Robust.Client.UserInterface.CustomControls;
+using Robust.Server.GameStates;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
@@ -9,6 +11,7 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Systems;
 using Robust.UnitTesting.Server;
+using SharpFont.PostScript;
 
 namespace Robust.UnitTesting.Shared.Physics;
 
@@ -81,6 +84,7 @@ public sealed class Broadphase_Test
         var fixture = new Fixture(physics, shape);
         fixturesSystem.CreateFixture(physics, fixture);
         physicsSystem.SetCanCollide(physics, true);
+        Assert.That(physics.CanCollide);
 
         // Now that we're collidable should be correctly on the grid's tree.
         Assert.That(fixture.ProxyCount, Is.EqualTo(1));
@@ -174,6 +178,139 @@ public sealed class Broadphase_Test
     }
 
     /// <summary>
+    /// Check that broadphases properly recursively update when entities move between maps and grids. The broadphase
+    /// updating handles grids separately from other entities, this is intended to be an exhaustive check that the
+    /// broadphase always gets updated. E.g., this previously failed when a grid moved from one map to another
+    /// </summary>
+    [Test]
+    public void EntMapChangeRecursiveUpdate()
+    {
+        var sim = RobustServerSimulation.NewSimulation().InitializeInstance();
+        var entManager = sim.Resolve<IEntityManager>();
+        var mapManager = sim.Resolve<IMapManager>();
+        var lookup = sim.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
+        var xforms = sim.Resolve<IEntitySystemManager>().GetEntitySystem<SharedTransformSystem>();
+        var physSystem = sim.Resolve<IEntitySystemManager>().GetEntitySystem<SharedPhysicsSystem>();
+        var fixtures = sim.Resolve<IEntitySystemManager>().GetEntitySystem<FixtureSystem>();
+
+        // setup maps
+        var mapAId = mapManager.CreateMap();
+        var mapA = mapManager.GetMapEntityId(mapAId);
+        var mapBId = mapManager.CreateMap();
+        var mapB = mapManager.GetMapEntityId(mapBId);
+
+        // setup grids
+        var gridAComp = mapManager.CreateGrid(mapAId);
+        var gridBComp = mapManager.CreateGrid(mapBId);
+        var gridCComp = mapManager.CreateGrid(mapAId);
+        var gridA = gridAComp.Owner;
+        var gridB = gridBComp.Owner;
+        var gridC = gridCComp.Owner;
+        xforms.SetLocalPosition(gridC, (10, 10));
+        gridAComp.SetTile(Vector2i.Zero, new Tile(1));
+        gridBComp.SetTile(Vector2i.Zero, new Tile(1));
+        gridCComp.SetTile(Vector2i.Zero, new Tile(1));
+
+        // set up test entities
+        var parent = entManager.SpawnEntity(null, new EntityCoordinates(mapA, (200,200)));
+        var parentXform = entManager.GetComponent<TransformComponent>(parent);
+        var child = entManager.SpawnEntity(null, new EntityCoordinates(parent, Vector2.Zero));
+        var childXform = entManager.GetComponent<TransformComponent>(child);
+        var childBody = entManager.AddComponent<PhysicsComponent>(child);
+        var childFixtures = entManager.GetComponent<FixturesComponent>(child);
+
+        // enable collision for the child
+        var shape = new PolygonShape();
+        shape.SetAsBox(0.5f, 0.5f);
+        var fixture = new Fixture(childBody, shape);
+        fixtures.CreateFixture(childBody, fixture);
+        physSystem.SetCanCollide(childBody, true);
+        Assert.That(childBody.CanCollide);
+
+        // Initially on mapA
+        var AssertMap = (EntityUid map, EntityUid otherMap) =>
+        {
+            var broadphase = entManager.GetComponent<BroadphaseComponent>(map);
+            var physMap = entManager.GetComponent<SharedPhysicsMapComponent>(map);
+            Assert.That(parentXform.ParentUid == map);
+            Assert.That(parentXform.MapUid == map);
+            Assert.That(childXform.MapUid == map);
+            Assert.That(lookup.FindBroadphase(parent), Is.EqualTo(broadphase));
+            Assert.That(lookup.FindBroadphase(child), Is.EqualTo(broadphase));
+            Assert.That(parentXform.Broadphase == new BroadphaseData(map, default, false, false));
+            Assert.That(childXform.Broadphase == new BroadphaseData(map, map, true, true));
+            Assert.That(physMap.MoveBuffer.ContainsKey(childFixtures.Fixtures.First().Value.Proxies.First()));
+            var otherPhysMap = entManager.GetComponent<SharedPhysicsMapComponent>(otherMap);
+            Assert.That(otherPhysMap.MoveBuffer.Count == 0);
+        };
+        AssertMap(mapA, mapB);
+
+        // we are now going to test several broadphase updates where we relocate the parent entity such that it moves:
+        // - map to map with a map change
+        // - map to grid with a map change
+        // - grid to grid with a map change
+        // - grid to map with a map change
+        // - map to grid without a map change
+        // - grid to grid without a map change
+        // - grid to map without a map change
+
+        // Move to map B (map to map with a map change) 
+        xforms.SetCoordinates(parent, new EntityCoordinates(mapB, (200, 200)));
+        AssertMap(mapB, mapA);
+
+        // Move to gridA on mapA (map to grid with a map change)
+        xforms.SetCoordinates(parent, new EntityCoordinates(gridA, default));
+        var AssertGrid = (EntityUid grid, EntityUid map, EntityUid otherMap) =>
+        {
+            var broadphase = entManager.GetComponent<BroadphaseComponent>(grid);
+            var physMap = entManager.GetComponent<SharedPhysicsMapComponent>(map);
+            var gridXform = entManager.GetComponent<TransformComponent>(grid);
+            Assert.That(gridXform.ParentUid == map);
+            Assert.That(gridXform.MapUid == map);
+            Assert.That(parentXform.ParentUid == grid);
+            Assert.That(parentXform.MapUid == map);
+            Assert.That(childXform.MapUid == map);
+            Assert.That(lookup.FindBroadphase(parent), Is.EqualTo(broadphase));
+            Assert.That(lookup.FindBroadphase(child), Is.EqualTo(broadphase));
+            Assert.That(parentXform.Broadphase == new BroadphaseData(grid, default, false, false));
+            Assert.That(childXform.Broadphase == new BroadphaseData(grid, map, true, true));
+            Assert.That(physMap.MoveBuffer.ContainsKey(childFixtures.Fixtures.First().Value.Proxies.First()));
+            var otherPhysMap = entManager.GetComponent<SharedPhysicsMapComponent>(otherMap);
+            Assert.That(otherPhysMap.MoveBuffer.Count == 0);
+        };
+        AssertGrid(gridA, mapA, mapB);
+
+        // Move to gridB on mapB (grid to grid with a map change)
+        xforms.SetCoordinates(parent, new EntityCoordinates(gridB, default));
+        AssertGrid(gridB, mapB, mapA);
+
+        // move to mapA (grid to map with a map change)
+        xforms.SetCoordinates(parent, new EntityCoordinates(mapA, (200, 200)));
+        AssertMap(mapA, mapB);
+
+        // move to gridA on mapA (map to grid without a map change)
+        xforms.SetCoordinates(parent, new EntityCoordinates(gridA, default));
+        AssertGrid(gridA, mapA, mapB);
+
+        // move to gridC on mapA (grid to grid without a map change)
+        xforms.SetCoordinates(parent, new EntityCoordinates(gridC, default));
+        AssertGrid(gridC, mapA, mapB);
+
+        // move to gridC on mapA (grid to map without a map change)
+        xforms.SetCoordinates(parent, new EntityCoordinates(mapA, (200, 200)));
+        AssertMap(mapA, mapB);
+
+        // Finally, we check if the broadphase updates if the whole grid moves, instead of just the entity
+        // first, move it to a grid:
+        xforms.SetCoordinates(parent, new EntityCoordinates(gridC, default));
+        AssertGrid(gridC, mapA, mapB);
+
+        // then move the grid to a new map:
+        xforms.SetCoordinates(gridC, new EntityCoordinates(mapB, (200,200)));
+        AssertGrid(gridC, mapB, mapA);
+    }
+
+    /// <summary>
     /// If an entity's broadphase is changed to nullspace are its children updated.
     /// </summary>
     [Test]
@@ -184,6 +321,7 @@ public sealed class Broadphase_Test
         var xformSystem = sim.Resolve<IEntitySystemManager>().GetEntitySystem<SharedTransformSystem>();
         var physSystem = sim.Resolve<IEntitySystemManager>().GetEntitySystem<SharedPhysicsSystem>();
         var lookup = sim.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
+        var fixtures = sim.Resolve<IEntitySystemManager>().GetEntitySystem<FixtureSystem>();
         var mapManager = sim.Resolve<IMapManager>();
 
         var mapId = mapManager.CreateMap();
@@ -199,6 +337,13 @@ public sealed class Broadphase_Test
         var child1 = entManager.SpawnEntity(null, new EntityCoordinates(parent, Vector2.Zero));
         var child1Xform = entManager.GetComponent<TransformComponent>(child1);
         var child1Body = entManager.AddComponent<PhysicsComponent>(child1);
+
+        var shape = new PolygonShape();
+        shape.SetAsBox(0.5f, 0.5f);
+        var fixture = new Fixture(child1Body, shape);
+        fixtures.CreateFixture(child1Body, fixture);
+        physSystem.SetCanCollide(child1Body, true);
+        Assert.That(child1Body.CanCollide);
 
         // Have a non-collidable child and check it doesn't get added too.
         var child2 = entManager.SpawnEntity(null, new EntityCoordinates(child1, Vector2.Zero));


### PR DESCRIPTION
Currently if a grid moves from one map to another the children's cached broadphase data is not updated and neither of the map move buffers get updated. This currently causes some asserts to fail when loading in grids/maps into existing maps, or when deleting maps.

This PR fixes that by adding a recursive `OnGridChangedMap()` function to the lookup system.
This PR also adds a new test which currently fails on master (specifically the last set of asserts).