### PR TITLE
Fix max_connections category in config

### DIFF
--- a/Robust.Server/server_config.toml
+++ b/Robust.Server/server_config.toml
@@ -12,6 +12,7 @@ enabled = false
 tickrate = 60
 port = 1212
 bindto = "::,0.0.0.0"
+max_connections = 256
 # Automatic port forwarding!
 # Disabled by default because you may not want to do this.
 # upnp = true
@@ -33,7 +34,6 @@ enabled = true
 [game]
 hostname = "MyServer"
 # map = "Saltern"
-max_connections = 256
 welcomemsg = "Welcome to the server!"
 
 [console]


### PR DESCRIPTION
The new CVar has the prefix `net`, not `game`.

Here is the signature
```cs
        public static readonly CVarDef<int> NetMaxConnections =
            CVarDef.Create("net.max_connections", 256, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
```

I haven't tested it, but I think it's unnecessary, the error is obvious.

https://github.com/space-wizards/RobustToolbox/pull/3552