### PR TITLE
Fix Entity spawning on top of Grids without being attached to the Grid.

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -215,7 +215,7 @@ namespace Robust.Shared.GameObjects
                 throw new ArgumentException($"Attempted to spawn entity on an invalid map. Coordinates: {coordinates}");
 
             EntityCoordinates coords;
-            if (transform.Anchored && _mapManager.TryFindGridAt(coordinates, out var grid))
+            if (_mapManager.TryFindGridAt(coordinates, out var grid))
             {
                 coords = new(grid.GridEntityId, grid.WorldToLocal(coordinates.Position));
                 _xforms.SetCoordinates(transform, coords, unanchor: false);

--- a/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
@@ -165,7 +165,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored = true;
 
             Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).ParentUid, Is.EqualTo(grid.GridEntityId));
-            Assert.That(calledCount, Is.EqualTo(1));
+            Assert.That(calledCount, Is.EqualTo(0));
             void ParentChangedHandler(ref EntParentChangedMessage ev)
             {
                 Assert.That(ev.Entity, Is.EqualTo(ent1));
@@ -514,7 +514,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             // Act
             IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored = false;
 
-            Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).ParentUid, Is.EqualTo(mapMan.GetMapEntityId(TestMapId)));
+            Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).ParentUid, Is.EqualTo(gridId)));
             Assert.That(calledCount, Is.EqualTo(0));
             void ParentChangedHandler(ref EntParentChangedMessage ev)
             {

--- a/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
@@ -514,7 +514,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             // Act
             IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).Anchored = false;
 
-            Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).ParentUid, Is.EqualTo(gridId)));
+            Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(ent1).ParentUid, Is.EqualTo(gridId));
             Assert.That(calledCount, Is.EqualTo(0));
             void ParentChangedHandler(ref EntParentChangedMessage ev)
             {


### PR DESCRIPTION
https://github.com/space-wizards/RobustToolbox/blob/c2de89044166f3b2c5a2a1a7c9772b835b2855be/Robust.Shared/GameObjects/EntityManager.cs#L218

After combing through how Entities come into existence, I concluded that `transform.Anchored` should never be true at this stage of an entity's life, and having played for some minutes with a debug logger to alert me of any entities spawning in with Anchored set to true, I saw no debug messages.

I believe removing this subcondition will allow entities to properly attach themselves to grids again when spawning via MapCoordinates. It seems everything worked fine when spawning via EntityCoordinates, but this path of MapCoordinates was the common root to many bugs in Space Station 14.

This should fix several bugs on Space Station 14, including but not limited to:

- Glass shards and ammunition being deleted on spawn due to lacking a grid and possessing the SpaceGarbageComponent. https://github.com/space-wizards/space-station-14/issues/12544 and https://github.com/space-wizards/space-station-14/issues/12593
- Pointer point arrows drifting off into space instead of locking onto the grid.
- Guns not shooting properly within fast-moving grids such as the emergency shuttle in FTL mode. Related but does not entirely fix the issue mentioned in https://github.com/space-wizards/space-station-14/issues/12852 because you can aim outside the shuttle and it will still fire in an odd angle, but you can aim within the shuttle grid, and it'll fire straight now.
- Butchered items sometimes drifting off.
- Anything that spawns in with MapCoordinates failing to attach to the grid. (SpawnEntitiesBehavior)

Hopefully this is a better solution than my first attempt in the Space Station 14 repository. https://github.com/space-wizards/space-station-14/pull/12882 If this behavior of entities not attaching to grids when spawned in via MapCoordinates is expected, then I can only assume the way to fix these bugs would be to switch to EntityCoordinates for every call that uses MapCoordinates which should also expect the spawned entity to attach to the local grid.

I have adjusted two of the tests to be congruent with the new behavior, but I wonder if they are superfluous now, given how things work with this change. For example, I'm unaware of any situation in which being unanchored causes an entity to lose its parent. I need some advice on that one.

Ultimately, this fix relies upon deciding what is the expected behavior for spawning an entity with MapCoordinates: should those entities not be attached to any grid even if they spawn on top of one, or should they behave more in line with the EntityCoordinates spawning method? Having played Space Station 14 for a few months now, I can say confidently that bullets and pointers used to be attached to the grids they were on, and there was none of this null-grid drift before October or so.

However, if this patch is merged, it could fix a lot of issues, maybe even things I haven't found yet. 

Pinging @metalgearsloth because I think he'd have a good idea based on his previous comments about whether this is the better, non-hacky solution to the problems listed.

Pinging @Mervill because I know he had an interest in solving this too.

Pinging @ElectroJr because he was the last to touch this line and could maybe offer some wisdom about how this is supposed to work.