### PR TITLE
Commits an unholy sin (PJB approved)

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1205,7 +1205,7 @@ namespace Robust.Client.GameObjects
         public IEnumerable<ISpriteLayer> AllLayers => Layers;
 
         // Lobby SpriteView rendering path
-        internal void Render(DrawingHandleWorld drawingHandle, Angle eyeRotation, Angle worldRotation, Direction? overrideDirection = null)
+        public void Render(DrawingHandleWorld drawingHandle, Angle eyeRotation, Angle worldRotation, Direction? overrideDirection = null)
         {
             RenderInternal(drawingHandle, eyeRotation, worldRotation, Vector2.Zero, overrideDirection);
         }
@@ -1251,7 +1251,7 @@ namespace Robust.Client.GameObjects
         public bool EnableDirectionOverride { get => _enableOverrideDirection; set => _enableOverrideDirection = value; }
 
         // Sprite rendering path
-        internal void Render(DrawingHandleWorld drawingHandle, Angle eyeRotation, in Angle worldRotation, in Vector2 worldPosition)
+        public void Render(DrawingHandleWorld drawingHandle, Angle eyeRotation, in Angle worldRotation, in Vector2 worldPosition)
         {
             Direction? overrideDir = null;
             if (_enableOverrideDirection)


### PR DESCRIPTION
This is necessary for the map editor in lieu of better options (NONE EXIST, SPRITE IS A FUCK, 410,757,864,530 DEAD GRAPHICS CODERS)

tl;dr there is literally no way to draw the hovering placement preview without this, and PlacementManager cheats and simply uses .Render() directly with it's special engine privileges.

In the future this should be nuked when someone fully refactors sprite rendering :)