### PR TITLE
Fix scroll bars being visible when they shouldn't be.

### DIFF
--- a/Robust.Client/UserInterface/Controls/ScrollContainer.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollContainer.cs
@@ -150,7 +150,7 @@ namespace Robust.Client.UserInterface.Controls
                     sWidth -= vBarSize;
                 }
 
-                if (sWidth < cWidth && _hScrollEnabled)
+                if (sWidth < cWidth && _hScrollEnabled && !MathHelper.CloseTo(sWidth, cWidth, 1e-3))
                 {
                     _hScrollBar.Visible = _hScrollVisible = true;
                     _hScrollBar.Page = sWidth;
@@ -161,7 +161,7 @@ namespace Robust.Client.UserInterface.Controls
                     _hScrollBar.Visible = _hScrollVisible = false;
                 }
 
-                if (sHeight < cHeight && _vScrollEnabled)
+                if (sHeight < cHeight && _vScrollEnabled && !MathHelper.CloseTo(sHeight, cHeight, 1e-3))
                 {
                     _vScrollBar.Visible = _vScrollVisible = true;
                     _vScrollBar.Page = sHeight;


### PR DESCRIPTION
Currently scroll bars sometimes appear in scroll containers when they are exactly the desired size of their children due to floating point errors. This should fix that.

This also appears like it might resolve #3567 in the process? Adding logs it looks like the scroll container was fluctuating between showing and not showing the scroll bars? But I'm not 100% sure if this actually fully fixes that, or just stops it from happening for the specific case I was testing (which was showing a scroll bar when it shouldn't have been).