### PR TITLE
SharedAppearanceSystem.TryGetData() generics support and small VisualizerSystem tweak

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/GenericVisualizerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/GenericVisualizerSystem.cs
@@ -19,16 +19,15 @@ public sealed class GenericVisualizerSystem : VisualizerSystem<GenericVisualizer
 
         foreach (var (appearanceKey, layerDict) in component.Visuals)
         {
-            if (!_appearanceSys.TryGetData(uid, appearanceKey, out var appearanceValue, args.Component))
+            if (!_appearanceSys.TryGetData<string?>(uid, appearanceKey, out var appearanceValue, args.Component))
                 continue;
 
-            var valueString = appearanceValue.ToString();
-            if (string.IsNullOrEmpty(valueString))
+            if (string.IsNullOrEmpty(appearanceValue))
                 continue;
 
             foreach (var (layerKeyRaw, layerDataDict) in layerDict)
             {
-                if (!layerDataDict.TryGetValue(valueString, out var layerData))
+                if (!layerDataDict.TryGetValue(appearanceValue, out var layerData))
                     continue;
 
                 object layerKey = _refMan.TryParseEnumReference(layerKeyRaw, out var @enum)

--- a/Robust.Client/GameObjects/EntitySystems/VisualizerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/VisualizerSystem.cs
@@ -10,7 +10,8 @@ namespace Robust.Client.GameObjects;
 public abstract class VisualizerSystem<T> : EntitySystem
     where T: Component
 {
-    [Dependency] protected readonly AppearanceSystem AppearanceSystem = default!; 
+    [Dependency] protected readonly AppearanceSystem AppearanceSystem = default!;
+    [Dependency] protected readonly AnimationPlayerSystem AnimationSystem = default!;
 
     public override void Initialize()
     {

--- a/Robust.Shared/GameObjects/Components/Appearance/AppearanceComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Appearance/AppearanceComponent.cs
@@ -30,6 +30,7 @@ public abstract class AppearanceComponent : Component
         _sysMan.GetEntitySystem<SharedAppearanceSystem>().SetData(Owner, key, value, this);
     }
 
+    [Obsolete("Use SharedAppearanceSystem instead")]
     public bool TryGetData<T>(Enum key, [NotNullWhen(true)] out T data)
     {
         if (AppearanceData.TryGetValue(key, out var dat) && dat is T)

--- a/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
@@ -40,7 +40,7 @@ public abstract class SharedAppearanceSystem : EntitySystem
         // anyways, so we can skip this.
         if (_timing.ApplyingState
             && component.NetSyncEnabled) // TODO consider removing this and avoiding the component resolve altogether.
-            return; 
+            return;
 
         if (component.AppearanceData.TryGetValue(key, out var existing) && existing.Equals(value))
             return;
@@ -52,15 +52,18 @@ public abstract class SharedAppearanceSystem : EntitySystem
         MarkDirty(component);
     }
 
-    public bool TryGetData(EntityUid uid, Enum key, [MaybeNullWhen(false)] out object value, AppearanceComponent? component = null)
+    public bool TryGetData<T>(EntityUid uid, Enum key, [NotNullWhen(true)] out T value, AppearanceComponent? component = null)
     {
-        if (!Resolve(uid, ref component))
+        if (Resolve(uid, ref component) &&
+            component.AppearanceData.TryGetValue(key, out var objValue) &&
+            objValue is T)
         {
-            value = null;
-            return false;
+            value = (T)objValue;
+            return true;
         }
 
-        return component.AppearanceData.TryGetValue(key, out value);
+        value = default!;
+        return false;
     }
 }
 


### PR DESCRIPTION
Requires https://github.com/space-wizards/space-station-14/pull/13053
Requires https://github.com/space-wizards/space-station-14/pull/13094
- Obsoletes `AppearanceComponent.TryGetData`
- Makes  `SharedAppearanceSystem.TryGetData` support generics
- Adds `AnimationPlayerSystem` as dependency to `VisualizerSystem` since most visualizers use animations