### PR TITLE
Somewhat improve sprite processing

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/ISpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/ISpriteComponent.cs
@@ -222,6 +222,6 @@ namespace Robust.Client.GameObjects
         /// <summary>
         ///     Calculate the rotated sprite bounding box in world-space coordinates.
         /// </summary>
-        Box2Rotated CalculateRotatedBoundingBox(Vector2 worldPosition, Angle worldRotation, IEye? eye = null);
+        Box2Rotated CalculateRotatedBoundingBox(Vector2 worldPosition, Angle worldRotation, Angle eye);
     }
 }

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteBoundsOverlay.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteBoundsOverlay.cs
@@ -84,7 +84,7 @@ namespace Robust.Client.GameObjects
                 foreach (var (sprite, xform) in comp.SpriteTree.QueryAabb(localAABB))
                 {
                     var (worldPos, worldRot) = xform.GetWorldPositionRotation();
-                    var bounds = sprite.CalculateRotatedBoundingBox(worldPos, worldRot);
+                    var bounds = sprite.CalculateRotatedBoundingBox(worldPos, worldRot, _eyeManager.CurrentEye.Rotation);
 
                     // Get scaled down bounds used to indicate the "south" of a sprite.
                     var localBound = bounds.Box;

--- a/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Robust.Client.Graphics;
 using Robust.Client.Physics;
 using Robust.Shared;
 using Robust.Shared.Configuration;
@@ -20,6 +21,7 @@ namespace Robust.Client.GameObjects
     public sealed class RenderingTreeSystem : EntitySystem
     {
         [Dependency] private readonly TransformSystem _xformSystem = default!;
+        [Dependency] private readonly IEyeManager _eyeManager = default!;
 
         internal const string LoggerSawmill = "rendertree";
 
@@ -372,7 +374,7 @@ namespace Robust.Client.GameObjects
 
         private Box2 SpriteAabbFunc(SpriteComponent value, TransformComponent xform, Vector2 worldPos, Angle worldRot, EntityQuery<TransformComponent> xforms)
         {
-            var bounds = value.CalculateRotatedBoundingBox(worldPos, worldRot);
+            var bounds = value.CalculateRotatedBoundingBox(worldPos, worldRot, _eyeManager.CurrentEye.Rotation);
             var tree = GetRenderTree(value.Owner, xform, xforms);
 
             return tree == null ? bounds.CalcBoundingBox() : _xformSystem.GetInvWorldMatrix(tree.Owner, xforms).TransformBox(bounds);

--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -1008,45 +1008,6 @@ namespace Robust.Client.Graphics.Clyde
             PointList,
         }
 
-        private sealed class SpriteDrawingOrderComparer : IComparer<int>
-        {
-            private readonly RefList<(SpriteComponent, Vector2, Angle, Box2)> _drawList;
-
-            public SpriteDrawingOrderComparer(RefList<(SpriteComponent, Vector2, Angle, Box2)> drawList)
-            {
-                _drawList = drawList;
-            }
-
-            public int Compare(int x, int y)
-            {
-                var a = _drawList[x];
-                var b = _drawList[y];
-
-                var cmp = a.Item1.DrawDepth.CompareTo(b.Item1.DrawDepth);
-                if (cmp != 0)
-                {
-                    return cmp;
-                }
-
-                cmp = a.Item1.RenderOrder.CompareTo(b.Item1.RenderOrder);
-
-                if (cmp != 0)
-                {
-                    return cmp;
-                }
-
-                // compare the top of the sprite's BB for y-sorting. Because screen coordinates are flipped, the "top" of the BB is actually the "bottom".
-                cmp = a.Item4.Top.CompareTo(b.Item4.Top);
-
-                if (cmp != 0)
-                {
-                    return cmp;
-                }
-
-                return a.Item1.Owner.CompareTo(b.Item1.Owner);
-            }
-        }
-
         private readonly struct FullStoredRendererState
         {
             public readonly Matrix3 ProjMatrix;

--- a/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
@@ -55,7 +55,7 @@ internal partial class Clyde
         };
 
         // We need to batch the actual tree query, or alternatively we need just get the list of sprites and then
-        // prallelize the rotation & bounding box calculations.
+        // parallelize the rotation & bounding box calculations.
         var index = 0;
         var added = 0;
         var opts = new ParallelOptions { MaxDegreeOfParallelism = _parMan.ParallelProcessCount };
@@ -119,7 +119,7 @@ internal partial class Clyde
             DebugTools.Assert(data.Sprite.Visible);
 
             // To help explain the remainder of this function, it should be functionally equivalent to the following
-            // tree lines of code, but has been expanded & simplified to speed up the calculation:
+            // three lines of code, but has been expanded & simplified to speed up the calculation:
             // 
             // (data.WorldPos, data.WorldRot) = batch.Sys.GetWorldPositionRotation(data.Xform, batch.Query);
             // var spriteWorldBB = data.Sprite.CalculateRotatedBoundingBox(data.WorldPos, data.WorldRot, batch.ViewRotation);

--- a/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
@@ -1,0 +1,271 @@
+using Robust.Client.GameObjects;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Physics;
+using Robust.Shared.Threading;
+using Robust.Shared.Utility;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using System.Threading.Tasks;
+
+namespace Robust.Client.Graphics.Clyde;
+
+// this partial class contains code specific to querying, processing & sorting sprites.
+internal partial class Clyde
+{
+    [Shared.IoC.Dependency] private readonly IParallelManager _parMan = default!;
+    private readonly RefList<SpriteData> _drawingSpriteList = new();
+    private const int _spriteProcessingBatchSize = 25;
+
+    private void GetSprites(MapId map, Viewport view, IEye eye, Box2Rotated worldBounds, out int[] indexList)
+    {
+        ProcessSpriteEntities(map, view, eye, worldBounds, _drawingSpriteList);
+
+        // We use a separate list for indexing sprites so that the sort is faster.
+        indexList = ArrayPool<int>.Shared.Rent(_drawingSpriteList.Count);
+
+        // populate index list
+        for (var i = 0; i < _drawingSpriteList.Count; i++)
+            indexList[i] = i;
+
+        // sort index list
+        // TODO better sorting? parallel merge sort?
+        Array.Sort(indexList, 0, _drawingSpriteList.Count, new SpriteDrawingOrderComparer(_drawingSpriteList));
+    }
+
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProcessSpriteEntities(MapId map, Viewport view, IEye eye, Box2Rotated worldBounds, RefList<SpriteData> list)
+    {
+        var query = _entityManager.GetEntityQuery<TransformComponent>();
+        var viewScale = eye.Scale * view.RenderScale * (EyeManager.PixelsPerMeter, -EyeManager.PixelsPerMeter);
+        var treeData = new BatchData()
+        {
+            Sys = _entityManager.EntitySysManager.GetEntitySystem<TransformSystem>(),
+            Query = query,
+            ViewRotation = eye.Rotation,
+            ViewScale = viewScale,
+            PreScaleViewOffset = view.Size / 2f / viewScale,
+            ViewPosition = eye.Position.Position + eye.Offset
+        };
+
+        // We need to batch the actual tree query, or alternatively we need just get the list of sprites and then
+        // prallelize the rotation & bounding box calculations.
+        var index = 0;
+        var added = 0;
+        var opts = new ParallelOptions { MaxDegreeOfParallelism = _parMan.ParallelProcessCount };
+        foreach (var comp in _entitySystemManager.GetEntitySystem<RenderingTreeSystem>().GetRenderTrees(map, worldBounds))
+        {
+            var treeOwner = comp.Owner;
+            var treeXform = query.GetComponent(comp.Owner);
+            var bounds = treeXform.InvWorldMatrix.TransformBox(worldBounds);
+            DebugTools.Assert(treeXform.MapUid == treeXform.ParentUid || !treeXform.ParentUid.IsValid());
+
+            treeData = treeData with
+            {
+                TreeOwner = treeOwner,
+                TreePos = treeXform.LocalPosition,
+                TreeRot = treeXform.LocalRotation,
+                Sin = MathF.Sin((float)treeXform.LocalRotation),
+                Cos = MathF.Cos((float)treeXform.LocalRotation),
+            };
+
+            comp.SpriteTree.QueryAabb(ref list,
+                static (ref RefList<SpriteData> state, in ComponentTreeEntry<SpriteComponent> value) =>
+                {
+                    ref var entry = ref state.AllocAdd();
+                    entry.Sprite = value.Component;
+                    entry.Xform = value.Transform;
+                    return true;
+                }, bounds, true);
+
+            // Get bounding boxes & world positions
+            added = list.Count - index;
+            var batches = added/_spriteProcessingBatchSize;
+                
+            // TODO also do sorting here & use a merge sort later on for y-sorting?
+            if (batches > 1)
+                Parallel.For(0, batches, opts, (i) => ProcessSprites(list, index + i * _spriteProcessingBatchSize, _spriteProcessingBatchSize, treeData));
+            else
+                batches = 0;
+
+            var remainder = added - _spriteProcessingBatchSize * batches;
+            if (remainder > 0)
+                ProcessSprites(list, index + batches * _spriteProcessingBatchSize, remainder, treeData);
+
+            index += batches * _spriteProcessingBatchSize + remainder;
+        }
+    }
+
+    /// <summary>
+    ///     This function computes a sprites world position, rotation, and screen-space bounding box. The position &
+    ///     rotation are required in general, but the bounding box is only really needed for y-sorting & if the
+    ///     sprite has a post processing shader.
+    /// </summary>
+    private void ProcessSprites(
+        RefList<SpriteData> list,
+        int startIndex,
+        int count,
+        in BatchData batch)
+    {
+        for (int i = startIndex; i < startIndex + count; i++)
+        {
+            ref var data = ref list[i];
+            DebugTools.Assert(data.Sprite.Visible);
+
+            // To help explain the remainder of this function, it should be functionally equivalent to the following
+            // tree lines of code, but has been expanded & simplified to speed up the calculation:
+            // 
+            // (data.WorldPos, data.WorldRot) = batch.Sys.GetWorldPositionRotation(data.Xform, batch.Query);
+            // var spriteWorldBB = data.Sprite.CalculateRotatedBoundingBox(data.WorldPos, data.WorldRot, batch.ViewRotation);
+            // data.SpriteScreenBB = Viewport.GetWorldToLocalMatrix().TransformBox(spriteWorldBB);
+
+            var (pos, rot) = batch.Sys.GetParentRelativePositionRotation(data.Xform, batch.TreeOwner, batch.Query);
+            pos = new Vector2(
+                batch.TreePos.X + batch.Cos * pos.X - batch.Sin * pos.Y,
+                batch.TreePos.Y + batch.Sin * pos.X + batch.Cos * pos.Y);
+
+            rot += batch.TreeRot;
+            data.WorldRot = rot;
+            data.WorldPos = pos;
+
+            var finalRotation = (float) (data.Sprite.NoRotation
+                ? data.Sprite.Rotation
+                : data.Sprite.Rotation + rot + batch.ViewRotation);
+
+            // false for 99.9% of sprites
+            if (data.Sprite.Offset != Vector2.Zero)
+            {
+                pos += data.Sprite.NoRotation
+                    ? (-batch.ViewRotation).RotateVec(data.Sprite.Offset)
+                    : rot.RotateVec(data.Sprite.Offset);
+            }
+
+            pos = batch.ViewRotation.RotateVec(pos - batch.ViewPosition);
+
+            // special casing angle = n*pi/2 to avoid box rotation & bounding calculations doesn't seem to give significant speedups.
+            data.SpriteScreenBB = TransformCenteredBoxSse(
+                data.Sprite.Bounds,
+                finalRotation,
+                pos + batch.PreScaleViewOffset,
+                batch.ViewScale);
+        }
+    }
+
+    /// <summary>
+    /// This is effectively a specialized variant of <see cref="Box2Rotated.CalcBoundingBox()"/>. It assumes that
+    /// the initial box is centered at the origin, and automatically applies an offset and scale while computing the
+    /// bounds.
+    /// </summary> 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe Box2 TransformCenteredBoxSse(in Box2 box, float angle, in Vector2 offset, in Vector2 scale)
+    {
+        // This function is for sprites, which flip the y axis, so here we flip the definition of t and b relative to the normal function.
+        DebugTools.Assert(scale.Y < 0);
+        DebugTools.Assert(box.Center.EqualsApprox(Vector2.Zero));
+
+        if (!Sse.IsSupported || !NumericsHelpers.Enabled)
+        {
+            var bound = new Box2Rotated(box, angle, Vector2.Zero).CalcBoundingBoxSlow();
+            return new Box2(
+                (bound.Left + offset.X) * scale.X,
+                (bound.Top + offset.Y) * scale.Y,
+                (bound.Right + offset.X) * scale.X,
+                (bound.Bottom + offset.Y) * scale.Y);
+        }
+
+        Vector128<float> boxVec;
+        Vector128<float> offsetVec;
+        Vector128<float> scaleVec;
+        fixed (float* lPtr = &box.Left, offsetPtr = &offset.X, scalePtr = &scale.X)
+        {
+            boxVec = Sse.LoadVector128(lPtr);
+            offsetVec = Sse.LoadVector128(offsetPtr); // upper undefined
+            scaleVec = Sse.LoadVector128(scalePtr); // upper undefined
+        }
+
+        offsetVec = Sse.MoveLowToHigh(offsetVec, offsetVec);
+        scaleVec = Sse.MoveLowToHigh(scaleVec, scaleVec);
+
+        var originX = Vector128.Create(offset.X);
+        var originY = Vector128.Create(offset.Y);
+        var sinVec = Vector128.Create(MathF.Sin(angle));
+        var cosVec = Vector128.Create(MathF.Cos(angle));
+        var allX = Sse.Shuffle(boxVec, boxVec, 0b10_10_00_00);
+        var allY = Sse.Shuffle(boxVec, boxVec, 0b01_11_11_01);
+        var modX = Sse.Subtract(Sse.Multiply(allX, cosVec), Sse.Multiply(allY, sinVec));
+        var modY = Sse.Add(Sse.Multiply(allX, sinVec), Sse.Multiply(allY, cosVec));
+
+        var lrlr = SimdHelpers.MinMaxHorizontalSse(modX);
+        var btbt = SimdHelpers.MaxMinHorizontalSse(modY);
+        var lbrt = Sse.UnpackLow(lrlr, btbt);
+
+        // offset and scale box.
+        lbrt = Sse.Add(lbrt, offsetVec);
+        lbrt = Sse.Multiply(lbrt, scaleVec);
+
+        return Unsafe.As<Vector128<float>, Box2>(ref lbrt);
+    }
+
+    private struct SpriteData
+    {
+        public SpriteComponent Sprite;
+        public TransformComponent Xform;
+        public Vector2 WorldPos;
+        public Angle WorldRot;
+        public Box2 SpriteScreenBB;
+    }
+
+    private readonly struct BatchData
+    {
+        public TransformSystem Sys { get; init; }
+        public EntityQuery<TransformComponent> Query { get; init; }
+        public Angle ViewRotation { get; init; }
+        public Vector2 ViewScale { get; init; }
+        public Vector2 PreScaleViewOffset { get; init; }
+        public Vector2 ViewPosition { get; init; }
+        public EntityUid TreeOwner { get; init; }
+        public Vector2 TreePos { get; init; }
+        public Angle TreeRot { get; init; }
+        public float Sin { get; init; }
+        public float Cos { get;  init; }
+    }
+
+    private sealed class SpriteDrawingOrderComparer : IComparer<int>
+    {
+        private readonly RefList<SpriteData> _drawList;
+
+        public SpriteDrawingOrderComparer(RefList<SpriteData> drawList)
+        {
+            _drawList = drawList;
+        }
+
+        public int Compare(int x, int y)
+        {
+            var a = _drawList[x];
+            var b = _drawList[y];
+
+            var cmp = a.Sprite.DrawDepth.CompareTo(b.Sprite.DrawDepth);
+            if (cmp != 0)
+                return cmp;
+
+            cmp = a.Sprite.RenderOrder.CompareTo(b.Sprite.RenderOrder);
+
+            if (cmp != 0)
+                return cmp;
+
+            // compare the top of the sprite's BB for y-sorting. Because screen coordinates are flipped, the "top" of the BB is actually the "bottom".
+            cmp = a.SpriteScreenBB.Top.CompareTo(b.SpriteScreenBB.Top);
+
+            if (cmp != 0)
+                return cmp;
+
+            return a.Sprite.Owner.CompareTo(b.Sprite.Owner);
+        }
+    }
+}

--- a/Robust.Shared.Maths/Angle.cs
+++ b/Robust.Shared.Maths/Angle.cs
@@ -104,13 +104,12 @@ namespace Robust.Shared.Maths
             // No calculation necessery when theta is zero
             if (Theta == 0) return vec;
 
-            var (x, y) = vec;
-            var cos = Math.Cos(Theta);
-            var sin = Math.Sin(Theta);
-            var dx = cos * x - sin * y;
-            var dy = sin * x + cos * y;
+            var cos = MathF.Cos((float)Theta);
+            var sin = MathF.Sin((float)Theta);
+            var dx = cos * vec.X - sin * vec.Y;
+            var dy = sin * vec.X + cos * vec.Y;
 
-            return new Vector2((float)dx, (float)dy);
+            return new Vector2(dx, dy);
         }
 
         public bool EqualsApprox(Angle other, double tolerance)

--- a/Robust.Shared.Maths/Box2.cs
+++ b/Robust.Shared.Maths/Box2.cs
@@ -424,5 +424,12 @@ namespace Robust.Shared.Maths
                    && MathHelper.CloseToPercent(Right, other.Right, tolerance)
                    && MathHelper.CloseToPercent(Top, other.Top, tolerance);
         }
+        public bool EqualsApproxAbs(Box2 other, double tolerance)
+        {
+            return MathHelper.CloseTo(Left, other.Left, tolerance)
+                   && MathHelper.CloseTo(Bottom, other.Bottom, tolerance)
+                   && MathHelper.CloseTo(Right, other.Right, tolerance)
+                   && MathHelper.CloseTo(Top, other.Top, tolerance);
+        }
     }
 }

--- a/Robust.Shared.Maths/Box2.cs
+++ b/Robust.Shared.Maths/Box2.cs
@@ -424,12 +424,5 @@ namespace Robust.Shared.Maths
                    && MathHelper.CloseToPercent(Right, other.Right, tolerance)
                    && MathHelper.CloseToPercent(Top, other.Top, tolerance);
         }
-        public bool EqualsApproxAbs(Box2 other, double tolerance)
-        {
-            return MathHelper.CloseTo(Left, other.Left, tolerance)
-                   && MathHelper.CloseTo(Bottom, other.Bottom, tolerance)
-                   && MathHelper.CloseTo(Right, other.Right, tolerance)
-                   && MathHelper.CloseTo(Top, other.Top, tolerance);
-        }
     }
 }

--- a/Robust.Shared.Maths/Box2Rotated.cs
+++ b/Robust.Shared.Maths/Box2Rotated.cs
@@ -95,15 +95,10 @@ namespace Robust.Shared.Maths
             allX = Sse.Add(modX, originX);
             allY = Sse.Add(modY, originY);
 
-            var l = SimdHelpers.MinHorizontalSse(allX);
-            var b = SimdHelpers.MinHorizontalSse(allY);
-            var r = SimdHelpers.MaxHorizontalSse(allX);
-            var t = SimdHelpers.MaxHorizontalSse(allY);
-
-            var lb = Sse.UnpackLow(l, b);
-            var rt = Sse.UnpackLow(r, t);
-
-            var lbrt = Sse.Shuffle(lb, rt, 0b11_10_01_00);
+            // lrlr = vector containing [left right left right]
+            var lrlr = SimdHelpers.MinMaxHorizontalSse(allX);
+            var btbt = SimdHelpers.MinMaxHorizontalSse(allY);
+            var lbrt = Sse.UnpackLow(lrlr, btbt);
 
             return Unsafe.As<Vector128<float>, Box2>(ref lbrt);
         }

--- a/Robust.Shared.Maths/Box2Rotated.cs
+++ b/Robust.Shared.Maths/Box2Rotated.cs
@@ -89,13 +89,14 @@ namespace Robust.Shared.Maths
                 var btbt = SimdHelpers.MinMaxHorizontalSse(allY);
                 lbrt = Sse.UnpackLow(lrlr, btbt);
             }
-
-            var l = SimdHelpers.MinHorizontal128(allX);
-            var b = SimdHelpers.MinHorizontal128(allY);
-            var r = SimdHelpers.MaxHorizontal128(allX);
-            var t = SimdHelpers.MaxHorizontal128(allY);
-
-            var lbrt = SimdHelpers.MergeRows128(l, b, r, t);
+            else
+            {
+                var l = SimdHelpers.MinHorizontal128(allX);
+                var b = SimdHelpers.MinHorizontal128(allY);
+                var r = SimdHelpers.MaxHorizontal128(allX);
+                var t = SimdHelpers.MaxHorizontal128(allY);
+                lbrt = SimdHelpers.MergeRows128(l, b, r, t);
+            }
 
             return Unsafe.As<Vector128<float>, Box2>(ref lbrt);
         }

--- a/Robust.Shared.Maths/SimdHelpers.cs
+++ b/Robust.Shared.Maths/SimdHelpers.cs
@@ -37,7 +37,6 @@ namespace Robust.Shared.Maths
             return Sse.Shuffle(tmp, tmp, 0b00_11_00_11);
         }
 
-
         /// <returns>The min value is broadcast to the whole vector.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector128<float> MinHorizontal128(Vector128<float> v)

--- a/Robust.Shared.Maths/SimdHelpers.cs
+++ b/Robust.Shared.Maths/SimdHelpers.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Intrinsics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 
 namespace Robust.Shared.Maths
@@ -8,6 +9,35 @@ namespace Robust.Shared.Maths
     /// </summary>
     internal static class SimdHelpers
     {
+        /// <returns>A vector with the horizontal minimum and maximum values arranged as { min max min max} .</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<float> MinMaxHorizontalSse(Vector128<float> input)
+        {
+            var tmp = Sse.Shuffle(input, input, 0b00_01_10_11);
+            var min = Sse.Min(tmp, input);
+            var max = Sse.Max(tmp, input);
+            tmp = Sse.Shuffle(min, max, 0b01_00_00_01);
+            min = Sse.Min(tmp, min);
+            max = Sse.Max(tmp, max);
+            tmp = Sse.MoveScalar(max, min);
+            return Sse.Shuffle(tmp, tmp, 0b11_00_11_00);
+        }
+
+        /// <returns>A vector with the horizontal minimum and maximum values arranged as { max min max min} .</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<float> MaxMinHorizontalSse(Vector128<float> input)
+        {
+            var tmp = Sse.Shuffle(input, input, 0b00_01_10_11);
+            var min = Sse.Min(tmp, input);
+            var max = Sse.Max(tmp, input);
+            tmp = Sse.Shuffle(min, max, 0b01_00_00_01);
+            min = Sse.Min(tmp, min);
+            max = Sse.Max(tmp, max);
+            tmp = Sse.MoveScalar(max, min);
+            return Sse.Shuffle(tmp, tmp, 0b00_11_00_11);
+        }
+
+
         /// <returns>The min value is broadcast to the whole vector.</returns>
         public static Vector128<float> MinHorizontalSse(Vector128<float> v)
         {

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -764,7 +764,6 @@ public abstract partial class SharedTransformSystem
         return (pos, rot);
     }
 
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void SetWorldPosition(EntityUid uid, Vector2 worldPos)
     {

--- a/Robust.UnitTesting/Shared/Maths/Box2Rotated_Test.cs
+++ b/Robust.UnitTesting/Shared/Maths/Box2Rotated_Test.cs
@@ -63,6 +63,9 @@ namespace Robust.UnitTesting.Shared.Maths
 
             var rotated = new Box2Rotated(baseBox, rotation, origin);
             Assert.That(rotated.CalcBoundingBoxSlow(), Is.Approximately(expected));
+
+            if (Sse.IsSupported)
+                Assert.That(rotated.CalcBoundingBoxSse(), Is.Approximately(expected));
         }
 
         [Test]


### PR DESCRIPTION
This PR improves the pre-rendering sprite processing (getting world position, rotation, and bounding boxes). It also moves most of the processing & sorting logic into a separate partial class. AFAICT this is generally not a bottleneck in most situations, but can becomes problematic if there are many sprites on screen (e.g., when zooming out). 

I just tested this using a basic test map with ~15k sprites on screen with random positions. On master release mode I get about 67fps, with a running average of 4.9ms spent inside `ProcessSpriteEntities()`. With these changes, I get ~90fps with 0.67ms spent processing sprites. About half of the speedup just comes from faster transform & bounding box calculations (4.9ms -> 2.5ms), the rest comes from parallelising (2.5ms -> 0.62ms, though it actually increases to ~3.3ms if only using a single thread).

When it comes to SS14 gameplay, when moving around box station (400-500 sprites on screen), my desktop & laptop framerate doesn't actually change all that much. But maybe this will help potato computers?