### PR TITLE
Fix bug where config files could be corrupted

### DIFF
--- a/Robust.Shared/Configuration/ConfigurationManager.cs
+++ b/Robust.Shared/Configuration/ConfigurationManager.cs
@@ -260,7 +260,7 @@ namespace Robust.Shared.Configuration
                 var memoryStream = new MemoryStream();
                 SaveToTomlStream(memoryStream, cvars);
                 memoryStream.Position = 0;
-                using var file = File.OpenWrite(_configFile);
+                using var file = File.Open(_configFile, FileMode.Create, FileAccess.Write);
                 memoryStream.CopyTo(file);
                 Logger.InfoS("cfg", $"config saved to '{_configFile}'.");
             }

--- a/Robust.Shared/Configuration/ConfigurationManager.cs
+++ b/Robust.Shared/Configuration/ConfigurationManager.cs
@@ -260,7 +260,7 @@ namespace Robust.Shared.Configuration
                 var memoryStream = new MemoryStream();
                 SaveToTomlStream(memoryStream, cvars);
                 memoryStream.Position = 0;
-                using var file = File.Open(_configFile, FileMode.Create, FileAccess.Write);
+                using var file = File.Create(_configFile);
                 memoryStream.CopyTo(file);
                 Logger.InfoS("cfg", $"config saved to '{_configFile}'.");
             }


### PR DESCRIPTION
Code was previously using a File.OpenWrite, which as documented, in the API, does not truncate the file if it already exists; when a user restored some options to their defaults, this would cause the new config file to be shorter, and, depending on how lucky/unlucky they get, could result in some options being incorrectly set or (more likely) total failure to parse the config file the next time the application is launched (and the bug will repeat.)