### PR TITLE
Change default value for outsidePrediction

### DIFF
--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -266,7 +266,7 @@ namespace Robust.Client.Placement
                         _gridFrameBuffer = false;
                         _placenextframe = false;
                         return true;
-                    }))
+                    }, true))
                 .Bind(EngineKeyFunctions.EditorRotateObject, InputCmdHandler.FromDelegate(
                     session =>
                     {
@@ -280,7 +280,7 @@ namespace Robust.Client.Placement
                         if (DeactivateSpecialPlacement())
                             return;
                         Clear();
-                    }))
+                    }, outsidePrediction: true))
                 .Register<PlacementManager>();
 
             var localPlayer = PlayerManager.LocalPlayer;

--- a/Robust.Shared/Input/Binding/InputCmdHandler.cs
+++ b/Robust.Shared/Input/Binding/InputCmdHandler.cs
@@ -27,7 +27,7 @@ namespace Robust.Shared.Input.Binding
         /// <param name="disabled">The delegate to be ran when this command is disabled.</param>
         /// <returns>The new input command.</returns>
         public static InputCmdHandler FromDelegate(StateInputCmdDelegate? enabled = null,
-            StateInputCmdDelegate? disabled = null, bool handle=true, bool outsidePrediction=false)
+            StateInputCmdDelegate? disabled = null, bool handle=true, bool outsidePrediction=true)
         {
             return new StateInputCmdHandler
             {


### PR DESCRIPTION
This changes the default value of `InputCmdHandler.FromDelegate()`'s `oustidePrediction` argument from false to true. Almost all  uses of this function should be using true, and it seems like this should just be the default (I only found one exception, space-wizards/space-station-14/pull/13088). The current default leads to some bugs where various key-bindings just don't function when prediction is disabled (e.g., the escape key doesn't open the menu).


A downside of this is that the default value for this option is now inconsistent for different handlers. An alternative fix would be to fix all the existing uses, but at that point I'd rather just make the argument non-optional so that it has to be explicitly specified to avoid bugs like this in the future.