### PR TITLE
Remove nullspace logic from CreateEntityUninitialized

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -197,21 +197,16 @@ namespace Robust.Shared.GameObjects
             var newEntity = CreateEntity(prototypeName);
             var transform = GetComponent<TransformComponent>(newEntity);
 
-            var mapEnt = _mapManager.GetMapEntityId(coordinates.MapId);
-            TryGetComponent(mapEnt, out TransformComponent? mapXform);
-
-            // If the entity is being spawned in null-space, we will parent the entity to the null-map, IF it exists.
-            // For whatever reason, tests create and expect null-space to have a map entity, and it does on the client, but it
-            // intentionally doesn't on the server??
-            if (coordinates.MapId == MapId.Nullspace &&
-                mapXform == null)
+            if (coordinates.MapId == MapId.Nullspace)
             {
+                DebugTools.Assert(_mapManager.GetMapEntityId(coordinates.MapId) == EntityUid.Invalid);
                 transform._parent = EntityUid.Invalid;
                 transform.Anchored = false;
                 return newEntity;
             }
 
-            if (mapXform == null)
+            var mapEnt = _mapManager.GetMapEntityId(coordinates.MapId);
+            if (!TryGetComponent(mapEnt, out TransformComponent? mapXform))
                 throw new ArgumentException($"Attempted to spawn entity on an invalid map. Coordinates: {coordinates}");
 
             EntityCoordinates coords;

--- a/Robust.Shared/Map/MapManager.MapCollection.cs
+++ b/Robust.Shared/Map/MapManager.MapCollection.cs
@@ -257,6 +257,7 @@ internal partial class MapManager
 
             if (result != null)
             {
+                DebugTools.Assert(mapId != null);
                 _mapEntities.Add(actualId, result.Owner);
                 Logger.DebugS("map", $"Rebinding map {actualId} to entity {result.Owner}");
             }


### PR DESCRIPTION
Nullspace maps should no longer be getting created by anything.