### PR TITLE
Hotfix generic visualizers

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/GenericVisualizerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/GenericVisualizerSystem.cs
@@ -1,3 +1,4 @@
+using System;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Reflection;
@@ -19,9 +20,10 @@ public sealed class GenericVisualizerSystem : VisualizerSystem<GenericVisualizer
 
         foreach (var (appearanceKey, layerDict) in component.Visuals)
         {
-            if (!_appearanceSys.TryGetData<string?>(uid, appearanceKey, out var appearanceValue, args.Component))
+            if (!_appearanceSys.TryGetData<Enum>(uid, appearanceKey, out var appearanceEnum, args.Component))
                 continue;
 
+            var appearanceValue = appearanceEnum.ToString();
             if (string.IsNullOrEmpty(appearanceValue))
                 continue;
 

--- a/Robust.Client/GameObjects/EntitySystems/GenericVisualizerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/GenericVisualizerSystem.cs
@@ -20,10 +20,10 @@ public sealed class GenericVisualizerSystem : VisualizerSystem<GenericVisualizer
 
         foreach (var (appearanceKey, layerDict) in component.Visuals)
         {
-            if (!_appearanceSys.TryGetData<Enum>(uid, appearanceKey, out var appearanceEnum, args.Component))
+            if (!_appearanceSys.TryGetData(uid, appearanceKey, out object? obj, args.Component))
                 continue;
 
-            var appearanceValue = appearanceEnum.ToString();
+            var appearanceValue = obj.ToString();
             if (string.IsNullOrEmpty(appearanceValue))
                 continue;
 

--- a/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
@@ -65,6 +65,17 @@ public abstract class SharedAppearanceSystem : EntitySystem
         value = default!;
         return false;
     }
+
+    public bool TryGetData(EntityUid uid, Enum key, [NotNullWhen(true)] out object? value, AppearanceComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+        {
+            value = null;
+            return false;
+        }
+
+        return component.AppearanceData.TryGetValue(key, out value);
+    }
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
The issue is that the data is stored with an Enum as a key and not the string so this will always fail. The old behaviour converted it to a string after the fact but the generic in this case checks for the type which will always fail.