### PR TITLE
Revert "Don't defer dirty matrices"

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -166,11 +166,11 @@ namespace Robust.Shared.GameObjects
 
                 var oldRotation = _localRotation;
                 _localRotation = value;
-                MatricesDirty = true;
                 _entMan.Dirty(this);
 
                 if (!DeferUpdates)
                 {
+                    MatricesDirty = true;
                     if (!Initialized)
                         return;
 
@@ -354,11 +354,11 @@ namespace Robust.Shared.GameObjects
 
                 var oldGridPos = Coordinates;
                 _localPosition = value;
-                MatricesDirty = true;
                 _entMan.Dirty(this);
 
                 if (!DeferUpdates)
                 {
+                    MatricesDirty = true;
                     if (!Initialized)
                         return;
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -889,11 +889,11 @@ public abstract partial class SharedTransformSystem
         if (!xform.NoLocalRotation)
             xform._localRotation = rot;
 
-        xform.MatricesDirty = true;
         Dirty(xform);
 
         if (!xform.DeferUpdates)
         {
+            xform.MatricesDirty = true;
             if (!xform.Initialized)
                 return;
 


### PR DESCRIPTION
Apparently required for physics on moving grids?
Reverts space-wizards/RobustToolbox#3586