### PR TITLE
Add archetype iteration and has component benchmarks

### DIFF
--- a/Robust.Benchmarks/EntityManager/ArchetypeComponentAccessBenchmark.cs
+++ b/Robust.Benchmarks/EntityManager/ArchetypeComponentAccessBenchmark.cs
@@ -246,10 +246,15 @@ public class ArchetypeComponentAccessBenchmark
         }
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void IteratorSingle(Type1 t1)
+    {
+    }
+
     [Benchmark]
     public void IterateDelegateSingleComponentArchetype()
     {
-        _archetype.IterateSingleDelegate<Type1>(static _ => {});
+        _archetype.IterateSingleDelegate<Type1>(static t1 => IteratorSingle(t1));
     }
 
     [Benchmark]
@@ -272,16 +277,20 @@ public class ArchetypeComponentAccessBenchmark
         }
     }
 
-    [Benchmark]
-    public void IterateTenComponentsArchetype()
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void IteratorTen(ref Type1 t1, ref Type2 t2, ref Type3 t3, ref Type4 t4, ref Type5 t5, ref Type6 t6,
+        ref Type7 t7, ref Type8 t8, ref Type9 t9, ref Type10 t10)
     {
-        _archetype.IterateSingleDelegate<Type1>(static _ => {});
     }
 
     [Benchmark]
     public void IterateDelegateTenComponentsArchetype()
     {
-        _archetype.IterateDelegate(static (ref Type1 _, ref Type2 _, ref Type3 _, ref Type4 _, ref Type5 _, ref Type6 _, ref Type7 _, ref Type8 _, ref Type9 _, ref Type10 _) => {});
+        _archetype.IterateDelegate(
+            static (ref Type1 t1, ref Type2 t2, ref Type3 t3, ref Type4 t4, ref Type5 t5, ref Type6 t6, ref Type7 t7,
+                    ref Type8 t8, ref Type9 t9, ref Type10 t10) =>
+                IteratorTen(ref t1, ref t2, ref t3, ref t4, ref t5, ref t6, ref t7, ref t8, ref t9, ref t10)
+        );
     }
 
     // Just a bunch of types to pad the size of the arrays and such.

--- a/Robust.Benchmarks/EntityManager/ArchetypeComponentAccessBenchmark.cs
+++ b/Robust.Benchmarks/EntityManager/ArchetypeComponentAccessBenchmark.cs
@@ -231,7 +231,7 @@ public class ArchetypeComponentAccessBenchmark
     [Benchmark]
     public void IterateSingleComponentDictionary()
     {
-        foreach (var value in _componentDictionary[typeof(Type1)].Values.Cast<Type1>())
+        foreach (Type1 value in _componentDictionary[typeof(Type1)].Values)
         {
             _consumer.Consume(value);
         }
@@ -263,16 +263,16 @@ public class ArchetypeComponentAccessBenchmark
         for (var i = 0; i < N; i++)
         {
             _consumer.Consume((
-                _componentDictionary[typeof(Type1)][i],
-                _componentDictionary[typeof(Type2)][i],
-                _componentDictionary[typeof(Type3)][i],
-                _componentDictionary[typeof(Type4)][i],
-                _componentDictionary[typeof(Type5)][i],
-                _componentDictionary[typeof(Type6)][i],
-                _componentDictionary[typeof(Type7)][i],
-                _componentDictionary[typeof(Type8)][i],
-                _componentDictionary[typeof(Type9)][i],
-                _componentDictionary[typeof(Type10)][i]
+                (Type1) _componentDictionary[typeof(Type1)][i],
+                (Type2) _componentDictionary[typeof(Type2)][i],
+                (Type3) _componentDictionary[typeof(Type3)][i],
+                (Type4) _componentDictionary[typeof(Type4)][i],
+                (Type5) _componentDictionary[typeof(Type5)][i],
+                (Type6) _componentDictionary[typeof(Type6)][i],
+                (Type7) _componentDictionary[typeof(Type7)][i],
+                (Type8) _componentDictionary[typeof(Type8)][i],
+                (Type9) _componentDictionary[typeof(Type9)][i],
+                (Type10) _componentDictionary[typeof(Type10)][i]
             ));
         }
     }

--- a/Robust.Benchmarks/EntityManager/ArchetypeComponentAccessBenchmark.cs
+++ b/Robust.Benchmarks/EntityManager/ArchetypeComponentAccessBenchmark.cs
@@ -293,8 +293,6 @@ public class ArchetypeComponentAccessBenchmark
         );
     }
 
-    // Just a bunch of types to pad the size of the arrays and such.
-
     // @formatter:off
     // ReSharper disable UnusedType.Local
     public struct Type1{}

--- a/Robust.Benchmarks/EntityManager/ArchetypeComponentAccessBenchmark.cs
+++ b/Robust.Benchmarks/EntityManager/ArchetypeComponentAccessBenchmark.cs
@@ -11,6 +11,7 @@ namespace Robust.Benchmarks.EntityManager;
 public class ArchetypeComponentAccessBenchmark
 {
     private const int N = 10000;
+    private const int Entity = 1584;
 
     private Dictionary<Type, Dictionary<int, object>> _componentDictionary = default!;
     private Archetype<Type1, Type2, Type3, Type4, Type5, Type6, Type7, Type8, Type9, Type10> _archetype = default!;
@@ -61,51 +62,51 @@ public class ArchetypeComponentAccessBenchmark
     }
 
     [Benchmark]
-    public Type1 GetSingleComponentsDictionary()
+    public Type1 GetSingleComponentDictionary()
     {
-        return (Type1) _componentDictionary[typeof(Type1)][1584];
+        return (Type1) _componentDictionary[typeof(Type1)][Entity];
     }
 
     [Benchmark]
-    public Type1 GetSingleComponentsArchetypeCast()
+    public Type1 GetSingleComponentArchetypeCast()
     {
-        return _archetype.GetComponentCast<Type1>(1584);
+        return _archetype.GetComponentCast<Type1>(Entity);
     }
 
     [Benchmark]
-    public Type1 GetSingleComponentsArchetypeCastHandle()
+    public Type1 GetSingleComponentArchetypeCastHandle()
     {
         // Handle is the same as the id
-        return _archetype.GetComponentCastHandle<Type1>(1584);
+        return _archetype.GetComponentCastHandle<Type1>(Entity);
     }
 
     [Benchmark]
-    public Type1 GetSingleComponentsArchetypeUnsafe()
+    public Type1 GetSingleComponentArchetypeUnsafe()
     {
-        return _archetype.GetComponentUnsafe<Type1>(1584);
+        return _archetype.GetComponentUnsafe<Type1>(Entity);
     }
 
     [Benchmark]
-    public Type1 GetSingleComponentsArchetypeUnsafeHandle()
+    public Type1 GetSingleComponentArchetypeUnsafeHandle()
     {
         // Handle is the same as the id
-        return _archetype.GetComponentUnsafeHandle<Type1>(1584);
+        return _archetype.GetComponentUnsafeHandle<Type1>(Entity);
     }
 
     [Benchmark]
     public (Type1, Type2, Type3, Type4, Type5, Type6, Type7, Type8, Type9, Type10) GetTenComponentsDictionary()
     {
         return (
-            (Type1) _componentDictionary[typeof(Type1)][1584],
-            (Type2) _componentDictionary[typeof(Type2)][1584],
-            (Type3) _componentDictionary[typeof(Type3)][1584],
-            (Type4) _componentDictionary[typeof(Type4)][1584],
-            (Type5) _componentDictionary[typeof(Type5)][1584],
-            (Type6) _componentDictionary[typeof(Type6)][1584],
-            (Type7) _componentDictionary[typeof(Type7)][1584],
-            (Type8) _componentDictionary[typeof(Type8)][1584],
-            (Type9) _componentDictionary[typeof(Type9)][1584],
-            (Type10) _componentDictionary[typeof(Type10)][1584]
+            (Type1) _componentDictionary[typeof(Type1)][Entity],
+            (Type2) _componentDictionary[typeof(Type2)][Entity],
+            (Type3) _componentDictionary[typeof(Type3)][Entity],
+            (Type4) _componentDictionary[typeof(Type4)][Entity],
+            (Type5) _componentDictionary[typeof(Type5)][Entity],
+            (Type6) _componentDictionary[typeof(Type6)][Entity],
+            (Type7) _componentDictionary[typeof(Type7)][Entity],
+            (Type8) _componentDictionary[typeof(Type8)][Entity],
+            (Type9) _componentDictionary[typeof(Type9)][Entity],
+            (Type10) _componentDictionary[typeof(Type10)][Entity]
         );
     }
 
@@ -113,16 +114,16 @@ public class ArchetypeComponentAccessBenchmark
     public (Type1, Type2, Type3, Type4, Type5, Type6, Type7, Type8, Type9, Type10) GetTenComponentsArchetypeCast()
     {
         return (
-            _archetype.GetComponentCast<Type1>(1584),
-            _archetype.GetComponentCast<Type2>(1584),
-            _archetype.GetComponentCast<Type3>(1584),
-            _archetype.GetComponentCast<Type4>(1584),
-            _archetype.GetComponentCast<Type5>(1584),
-            _archetype.GetComponentCast<Type6>(1584),
-            _archetype.GetComponentCast<Type7>(1584),
-            _archetype.GetComponentCast<Type8>(1584),
-            _archetype.GetComponentCast<Type9>(1584),
-            _archetype.GetComponentCast<Type10>(1584)
+            _archetype.GetComponentCast<Type1>(Entity),
+            _archetype.GetComponentCast<Type2>(Entity),
+            _archetype.GetComponentCast<Type3>(Entity),
+            _archetype.GetComponentCast<Type4>(Entity),
+            _archetype.GetComponentCast<Type5>(Entity),
+            _archetype.GetComponentCast<Type6>(Entity),
+            _archetype.GetComponentCast<Type7>(Entity),
+            _archetype.GetComponentCast<Type8>(Entity),
+            _archetype.GetComponentCast<Type9>(Entity),
+            _archetype.GetComponentCast<Type10>(Entity)
         );
     }
 
@@ -131,16 +132,16 @@ public class ArchetypeComponentAccessBenchmark
     {
         // Handle is the same as the id
         return (
-            _archetype.GetComponentCastHandle<Type1>(1584),
-            _archetype.GetComponentCastHandle<Type2>(1584),
-            _archetype.GetComponentCastHandle<Type3>(1584),
-            _archetype.GetComponentCastHandle<Type4>(1584),
-            _archetype.GetComponentCastHandle<Type5>(1584),
-            _archetype.GetComponentCastHandle<Type6>(1584),
-            _archetype.GetComponentCastHandle<Type7>(1584),
-            _archetype.GetComponentCastHandle<Type8>(1584),
-            _archetype.GetComponentCastHandle<Type9>(1584),
-            _archetype.GetComponentCastHandle<Type10>(1584)
+            _archetype.GetComponentCastHandle<Type1>(Entity),
+            _archetype.GetComponentCastHandle<Type2>(Entity),
+            _archetype.GetComponentCastHandle<Type3>(Entity),
+            _archetype.GetComponentCastHandle<Type4>(Entity),
+            _archetype.GetComponentCastHandle<Type5>(Entity),
+            _archetype.GetComponentCastHandle<Type6>(Entity),
+            _archetype.GetComponentCastHandle<Type7>(Entity),
+            _archetype.GetComponentCastHandle<Type8>(Entity),
+            _archetype.GetComponentCastHandle<Type9>(Entity),
+            _archetype.GetComponentCastHandle<Type10>(Entity)
         );
     }
 
@@ -148,16 +149,16 @@ public class ArchetypeComponentAccessBenchmark
     public (Type1, Type2, Type3, Type4, Type5, Type6, Type7, Type8, Type9, Type10) GetTenComponentsArchetypeUnsafe()
     {
         return (
-            _archetype.GetComponentUnsafe<Type1>(1584),
-            _archetype.GetComponentUnsafe<Type2>(1584),
-            _archetype.GetComponentUnsafe<Type3>(1584),
-            _archetype.GetComponentUnsafe<Type4>(1584),
-            _archetype.GetComponentUnsafe<Type5>(1584),
-            _archetype.GetComponentUnsafe<Type6>(1584),
-            _archetype.GetComponentUnsafe<Type7>(1584),
-            _archetype.GetComponentUnsafe<Type8>(1584),
-            _archetype.GetComponentUnsafe<Type9>(1584),
-            _archetype.GetComponentUnsafe<Type10>(1584)
+            _archetype.GetComponentUnsafe<Type1>(Entity),
+            _archetype.GetComponentUnsafe<Type2>(Entity),
+            _archetype.GetComponentUnsafe<Type3>(Entity),
+            _archetype.GetComponentUnsafe<Type4>(Entity),
+            _archetype.GetComponentUnsafe<Type5>(Entity),
+            _archetype.GetComponentUnsafe<Type6>(Entity),
+            _archetype.GetComponentUnsafe<Type7>(Entity),
+            _archetype.GetComponentUnsafe<Type8>(Entity),
+            _archetype.GetComponentUnsafe<Type9>(Entity),
+            _archetype.GetComponentUnsafe<Type10>(Entity)
         );
     }
 
@@ -166,17 +167,59 @@ public class ArchetypeComponentAccessBenchmark
     {
         // Handle is the same as the id
         return (
-            _archetype.GetComponentUnsafeHandle<Type1>(1584),
-            _archetype.GetComponentUnsafeHandle<Type2>(1584),
-            _archetype.GetComponentUnsafeHandle<Type3>(1584),
-            _archetype.GetComponentUnsafeHandle<Type4>(1584),
-            _archetype.GetComponentUnsafeHandle<Type5>(1584),
-            _archetype.GetComponentUnsafeHandle<Type6>(1584),
-            _archetype.GetComponentUnsafeHandle<Type7>(1584),
-            _archetype.GetComponentUnsafeHandle<Type8>(1584),
-            _archetype.GetComponentUnsafeHandle<Type9>(1584),
-            _archetype.GetComponentUnsafeHandle<Type10>(1584)
+            _archetype.GetComponentUnsafeHandle<Type1>(Entity),
+            _archetype.GetComponentUnsafeHandle<Type2>(Entity),
+            _archetype.GetComponentUnsafeHandle<Type3>(Entity),
+            _archetype.GetComponentUnsafeHandle<Type4>(Entity),
+            _archetype.GetComponentUnsafeHandle<Type5>(Entity),
+            _archetype.GetComponentUnsafeHandle<Type6>(Entity),
+            _archetype.GetComponentUnsafeHandle<Type7>(Entity),
+            _archetype.GetComponentUnsafeHandle<Type8>(Entity),
+            _archetype.GetComponentUnsafeHandle<Type9>(Entity),
+            _archetype.GetComponentUnsafeHandle<Type10>(Entity)
         );
+    }
+
+    [Benchmark]
+    public bool HasSingleComponentDictionary()
+    {
+        return _componentDictionary[typeof(Type1)].ContainsKey(Entity);
+    }
+
+    [Benchmark]
+    public bool HasSingleComponentArchetype()
+    {
+        return _archetype.HasComponent<Type1>();
+    }
+
+    [Benchmark]
+    public bool HasTenComponentsDictionary()
+    {
+        return _componentDictionary[typeof(Type1)].ContainsKey(Entity) &&
+               _componentDictionary[typeof(Type2)].ContainsKey(Entity) &&
+               _componentDictionary[typeof(Type3)].ContainsKey(Entity) &&
+               _componentDictionary[typeof(Type4)].ContainsKey(Entity) &&
+               _componentDictionary[typeof(Type5)].ContainsKey(Entity) &&
+               _componentDictionary[typeof(Type6)].ContainsKey(Entity) &&
+               _componentDictionary[typeof(Type7)].ContainsKey(Entity) &&
+               _componentDictionary[typeof(Type8)].ContainsKey(Entity) &&
+               _componentDictionary[typeof(Type9)].ContainsKey(Entity) &&
+               _componentDictionary[typeof(Type10)].ContainsKey(Entity);
+    }
+
+    [Benchmark]
+    public bool HasTenComponentsArchetype()
+    {
+        return _archetype.HasComponent<Type1>() &&
+               _archetype.HasComponent<Type2>() &&
+               _archetype.HasComponent<Type3>() &&
+               _archetype.HasComponent<Type4>() &&
+               _archetype.HasComponent<Type5>() &&
+               _archetype.HasComponent<Type6>() &&
+               _archetype.HasComponent<Type7>() &&
+               _archetype.HasComponent<Type8>() &&
+               _archetype.HasComponent<Type9>() &&
+               _archetype.HasComponent<Type10>();
     }
 
     // Just a bunch of types to pad the size of the arrays and such.
@@ -271,8 +314,9 @@ public class ArchetypeComponentAccessBenchmark
             }
         }
 
-        public T GetComponentCast<T>(int entity, T val = default) where T : struct
+        public T GetComponentCast<T>(int entity) where T : struct
         {
+            Unsafe.SkipInit(out T val);
             var id = _ids[entity];
 
             return val switch
@@ -291,8 +335,9 @@ public class ArchetypeComponentAccessBenchmark
             };
         }
 
-        public T GetComponentCastHandle<T>(int handle, T val = default) where T : struct
+        public T GetComponentCastHandle<T>(int handle) where T : struct
         {
+            Unsafe.SkipInit(out T val);
             return val switch
             {
                 T1 => (T) (object) _t1Comps[handle]!,
@@ -309,8 +354,9 @@ public class ArchetypeComponentAccessBenchmark
             };
         }
 
-        public ref T GetComponentUnsafe<T>(int entity, T val = default) where T : struct
+        public ref T GetComponentUnsafe<T>(int entity) where T : struct
         {
+            Unsafe.SkipInit(out T val);
             var id = _ids[entity];
 
             switch (val)
@@ -340,8 +386,9 @@ public class ArchetypeComponentAccessBenchmark
             }
         }
 
-        public ref T GetComponentUnsafeHandle<T>(int handle, T val = default) where T : struct
+        public ref T GetComponentUnsafeHandle<T>(int handle) where T : struct
         {
+            Unsafe.SkipInit(out T val);
             switch (val)
             {
                 case T1:
@@ -367,6 +414,25 @@ public class ArchetypeComponentAccessBenchmark
                 default:
                     throw new ArgumentException($"Unknown type: {typeof(T)}");
             }
+        }
+
+        public bool HasComponent<T>()
+        {
+            Unsafe.SkipInit(out T val);
+            return val switch
+            {
+                T1 => true,
+                T2 => true,
+                T3 => true,
+                T4 => true,
+                T5 => true,
+                T6 => true,
+                T7 => true,
+                T8 => true,
+                T9 => true,
+                T10 => true,
+                _ => false,
+            };
         }
     }
 }


### PR DESCRIPTION
flecs now lives in robust.benchmarks

```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19045
AMD Ryzen 7 5800H with Radeon Graphics, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=7.0.101
  [Host]     : .NET Core 7.0.1 (CoreCLR 7.0.122.56804, CoreFX 7.0.122.56804), X64 RyuJIT
  DefaultJob : .NET Core 7.0.1 (CoreCLR 7.0.122.56804, CoreFX 7.0.122.56804), X64 RyuJIT
```

**In nanoseconds:**
|                                  Method |        Mean |     Error |     StdDev |      Median | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------------------------- |------------:|----------:|-----------:|------------:|------:|------:|------:|----------:|
|            GetSingleComponentDictionary |  16.8070 ns | 0.3537 ns |  0.3785 ns |  16.7737 ns |     - |     - |     - |         - |
|         GetSingleComponentArchetypeCast |   5.2794 ns | 0.1273 ns |  0.1190 ns |   5.2794 ns |     - |     - |     - |         - |
|   GetSingleComponentArchetypeCastHandle |   0.5332 ns | 0.0360 ns |  0.0354 ns |   0.5208 ns |     - |     - |     - |         - |
|       GetSingleComponentArchetypeUnsafe |   6.0309 ns | 0.1478 ns |  0.1702 ns |   5.9749 ns |     - |     - |     - |         - |
| GetSingleComponentArchetypeUnsafeHandle |   0.2497 ns | 0.0316 ns |  0.0570 ns |   0.2348 ns |     - |     - |     - |         - |
|              GetTenComponentsDictionary | 177.8261 ns | 3.5162 ns |  3.2890 ns | 177.7054 ns |     - |     - |     - |         - |
|           GetTenComponentsArchetypeCast | 134.6561 ns | 8.7672 ns | 25.8503 ns | 146.6265 ns |     - |     - |     - |         - |
|     GetTenComponentsArchetypeCastHandle |  24.6382 ns | 0.3686 ns |  0.3786 ns |  24.5764 ns |     - |     - |     - |         - |
|         GetTenComponentsArchetypeUnsafe |  66.4676 ns | 1.1681 ns |  1.0926 ns |  66.2135 ns |     - |     - |     - |         - |
|   GetTenComponentsArchetypeUnsafeHandle |  24.4127 ns | 0.4762 ns |  0.4455 ns |  24.3499 ns |     - |     - |     - |         - |
|            HasSingleComponentDictionary |  16.7066 ns | 0.3342 ns |  0.3126 ns |  16.7032 ns |     - |     - |     - |         - |
|             HasSingleComponentArchetype |   0.3037 ns | 0.0353 ns |  0.0377 ns |   0.2895 ns |     - |     - |     - |         - |
|              HasTenComponentsDictionary | 163.7121 ns | 2.4006 ns |  2.2455 ns | 163.8074 ns |     - |     - |     - |         - |
|               HasTenComponentsArchetype |   9.9055 ns | 0.0993 ns |  0.0830 ns |   9.8788 ns |     - |     - |     - |         - |

---

**In microseconds:**
|                                  Method |        Mean |      Error |     StdDev |      Median | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------------------------- |------------:|-----------:|-----------:|------------:|------:|------:|------:|----------:|
|        IterateSingleComponentDictionary |   131.00 us |   2.600 us |   4.199 us |   131.32 us |     - |     - |     - |      96 B |
|     IterateCastSingleComponentArchetype |    48.62 us |   0.958 us |   1.868 us |    48.96 us |     - |     - |     - |      32 B |
| IterateDelegateSingleComponentArchetype |    18.66 us |   0.347 us |   0.805 us |    18.36 us |     - |     - |     - |         - |
|          IterateTenComponentsDictionary | 2,150.50 us | 102.283 us | 293.469 us | 2,041.03 us |     - |     - |     - |       1 B |
|   IterateDelegateTenComponentsArchetype |    50.45 us |   0.926 us |   0.821 us |    50.39 us |     - |     - |     - |         - |