### PR TITLE
Remove DeferredUpdates

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -80,15 +80,6 @@ namespace Robust.Shared.GameObjects
         [ViewVariables]
         public Angle PrevRotation { get; internal set; }
 
-        // Cache changes so we can distribute them after physics is done (better cache)
-        internal EntityCoordinates? _oldCoords;
-        internal Angle? _oldLocalRotation;
-
-        /// <summary>
-        ///     While updating did we actually defer anything?
-        /// </summary>
-        public bool UpdatesDeferred => _oldCoords != null || _oldLocalRotation != null;
-
         [ViewVariables(VVAccess.ReadWrite)]
         internal bool ActivelyLerping { get; set; }
 
@@ -116,11 +107,6 @@ namespace Robust.Shared.GameObjects
                 return id.IsValid() ? id : null;
             }
         }
-
-        /// <summary>
-        ///     Defer updates to the EntityTree and MoveEvent calls if toggled.
-        /// </summary>
-        public bool DeferUpdates { get; set; }
 
         /// <summary>
         ///     The EntityUid of the grid which this object is on, if any.
@@ -167,20 +153,13 @@ namespace Robust.Shared.GameObjects
                 var oldRotation = _localRotation;
                 _localRotation = value;
                 _entMan.Dirty(this);
+                MatricesDirty = true;
 
-                if (!DeferUpdates)
-                {
-                    MatricesDirty = true;
-                    if (!Initialized)
-                        return;
+                if (!Initialized)
+                    return;
 
-                    var moveEvent = new MoveEvent(Owner, Coordinates, Coordinates, oldRotation, _localRotation, this, _gameTiming.ApplyingState);
-                    _entMan.EventBus.RaiseLocalEvent(Owner, ref moveEvent, true);
-                }
-                else
-                {
-                    _oldLocalRotation ??= oldRotation;
-                }
+                var moveEvent = new MoveEvent(Owner, Coordinates, Coordinates, oldRotation, _localRotation, this, _gameTiming.ApplyingState);
+                _entMan.EventBus.RaiseLocalEvent(Owner, ref moveEvent, true);
             }
         }
 
@@ -355,20 +334,13 @@ namespace Robust.Shared.GameObjects
                 var oldGridPos = Coordinates;
                 _localPosition = value;
                 _entMan.Dirty(this);
+                MatricesDirty = true;
 
-                if (!DeferUpdates)
-                {
-                    MatricesDirty = true;
-                    if (!Initialized)
-                        return;
+                if (!Initialized)
+                    return;
 
-                    var moveEvent = new MoveEvent(Owner, oldGridPos, Coordinates, _localRotation, _localRotation, this, _gameTiming.ApplyingState);
-                    _entMan.EventBus.RaiseLocalEvent(Owner, ref moveEvent, true);
-                }
-                else
-                {
-                    _oldCoords ??= oldGridPos;
-                }
+                var moveEvent = new MoveEvent(Owner, oldGridPos, Coordinates, _localRotation, _localRotation, this, _gameTiming.ApplyingState);
+                _entMan.EventBus.RaiseLocalEvent(Owner, ref moveEvent, true);
             }
         }
 
@@ -450,26 +422,6 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <summary>
-        ///     Raise deferred MoveEvents and rebuild matrices.
-        /// </summary>
-        public void RunDeferred()
-        {
-            // if we resolved to (close enough) to the OG position then no update.
-            if ((_oldCoords == null || _oldCoords.Equals(Coordinates)) &&
-                (_oldLocalRotation == null || _oldLocalRotation.Equals(_localRotation)))
-            {
-                return;
-            }
-
-            MatricesDirty = true;
-
-            var moveEvent = new MoveEvent(Owner, _oldCoords ?? Coordinates, Coordinates, _oldLocalRotation ?? _localRotation, _localRotation, this, _gameTiming.ApplyingState);
-            _entMan.EventBus.RaiseLocalEvent(Owner, ref moveEvent, true);
-            _oldCoords = null;
-            _oldLocalRotation = null;
-        }
-
-        /// <summary>
         /// Detaches this entity from its parent.
         /// </summary>
         public void AttachToGridOrMap()
@@ -491,11 +443,10 @@ namespace Robust.Shared.GameObjects
             {
                 newMapEntity = mapGrid.Owner;
             }
-            else if (_mapManager.HasMapEntity(mapPos.MapId)
-                     && _mapManager.GetMapEntityIdOrThrow(mapPos.MapId) is var mapEnt
+            else if (_mapManager.GetMapEntityId(mapPos.MapId) is EntityUid { Valid: true } mapEnt
                      && !TerminatingOrDeleted(mapEnt))
             {
-                newMapEntity = _mapManager.GetMapEntityIdOrThrow(mapPos.MapId);
+                newMapEntity = mapEnt;
             }
             else
             {
@@ -512,13 +463,7 @@ namespace Robust.Shared.GameObjects
                 return;
             }
 
-            _entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().SetParent(this, newMapEntity);
-
-            // Technically we're not moving, just changing parent.
-            DeferUpdates = true;
-            WorldPosition = mapPos.Position;
-            DeferUpdates = false;
-
+            _entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().SetCoordinates(this, new(newMapEntity, mapPos.Position));
             _entMan.Dirty(this);
         }
 

--- a/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
+++ b/Robust.Shared/Physics/Dynamics/SharedPhysicsMapComponent.cs
@@ -95,10 +95,6 @@ namespace Robust.Shared.Physics.Dynamics
             }
         }
 
-        // TODO: Given physics bodies are a common thing to be listening for on moveevents it's probably beneficial to have 2 versions; one that includes the entity
-        // and one that includes the body
-        protected readonly HashSet<TransformComponent> DeferredUpdates = new();
-
         /// <summary>
         ///     All awake bodies on this map.
         /// </summary>
@@ -139,20 +135,6 @@ namespace Robust.Shared.Physics.Dynamics
         }
 
         #endregion
-
-        /// <summary>
-        ///     Go through all of the deferred MoveEvents and then run them
-        /// </summary>
-        public virtual void ProcessQueue()
-        {
-            // We'll store the WorldAABB on the MoveEvent given a lot of stuff ends up re-calculating it.
-            foreach (var xform in DeferredUpdates)
-            {
-                xform.RunDeferred();
-            }
-
-            DeferredUpdates.Clear();
-        }
     }
 
     [ByRefEvent]

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
@@ -326,15 +326,6 @@ namespace Robust.Shared.Physics.Systems
                 var updateAfterSolve = new PhysicsUpdateAfterSolveEvent(prediction, frameTime);
                 RaiseLocalEvent(ref updateAfterSolve);
 
-                // Go through and run all of the deferred events now
-                // Also compares the position pre physics and post physics to fix substep lerping issues
-                enumerator = AllEntityQuery<SharedPhysicsMapComponent>();
-
-                while (enumerator.MoveNext(out var comp))
-                {
-                    comp.ProcessQueue();
-                }
-
                 // On last substep (or main step where no substeps occured) we'll update all of the lerp data.
                 if (i == _substeps - 1)
                 {


### PR DESCRIPTION
Currently the only bits of code that use deferred movement logic include `AttachToGridOrMap()`, which uses it incorrectly, and some mover code in SS14 (hence this requires a content PR). Both of those uses only used it to supress move events, not to actually defer them. If there's actually a need for that , that should just become an argument for the setter functions.

Requires https://github.com/space-wizards/space-station-14/pull/13198