### PR TITLE
Style box texture scaling

### DIFF
--- a/Robust.Client/Graphics/Drawing/StyleBoxTexture.cs
+++ b/Robust.Client/Graphics/Drawing/StyleBoxTexture.cs
@@ -5,7 +5,13 @@ using Robust.Shared.Utility;
 namespace Robust.Client.Graphics
 {
     /// <summary>
-    ///     Style box based on a 9-patch texture.
+    ///     Style box based on a 9-patch texture. An image is
+    ///     divided into up to nine regions by splitting the
+    ///     image along each `PatchMargin.` The corner pieces
+    ///     will be drawn once, at their original size, while
+    ///     the `Mode` controls the (up to five) central pieces
+    ///     which can be either stretched or tiled to fill up
+    ///     the space the box is being drawn in.
     /// </summary>
     public sealed class StyleBoxTexture : StyleBox
     {
@@ -45,6 +51,7 @@ namespace Robust.Client.Graphics
 
         private float _patchMarginLeft;
 
+        // Distance of the left patch margin from the image. In texture space.
         public float PatchMarginLeft
         {
             get => _patchMarginLeft;
@@ -61,6 +68,7 @@ namespace Robust.Client.Graphics
 
         private float _patchMarginRight;
 
+        // Distance of the right patch margin from the image. In texture space.
         public float PatchMarginRight
         {
             get => _patchMarginRight;
@@ -77,6 +85,7 @@ namespace Robust.Client.Graphics
 
         private float _patchMarginTop;
 
+        // Distance of the top patch margin from the image. In texture space.
         public float PatchMarginTop
         {
             get => _patchMarginTop;
@@ -93,6 +102,7 @@ namespace Robust.Client.Graphics
 
         private float _patchMarginBottom;
 
+        // Distance of the bottom patch margin from the image. In texture space.
         public float PatchMarginBottom
         {
             get => _patchMarginBottom;


### PR DESCRIPTION
Adds an ability to scale a texture drawn by a StyleBoxTexture. I'm using this to get a couple of effects:

1. Scaling UIs while keeping texture sizes to a minimum
2. Scaling UIs so I can do things like line up a texture with text

As a bonus, also added some comments to StyleBoxTexture.

![2022-12-30_14-51](https://user-images.githubusercontent.com/1676295/210083156-c470e594-3709-4e18-b329-3ab586127095.png)
