### PR TITLE
NoLocalRotation fixes

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -723,7 +723,10 @@ public sealed class MapLoaderSystem : EntitySystem
             {
                 // Don't want to trigger events
                 xform._localPosition = data.Options.TransformMatrix.Transform(xform.LocalPosition);
-                xform._localRotation += data.Options.Rotation;
+                if (!xform.NoLocalRotation)
+                    xform._localRotation += data.Options.Rotation;
+
+                DebugTools.Assert(!xform.NoLocalRotation || xform.LocalRotation == 0);
             }
 
             StartupEntity(entity, metaQuery.GetComponent(entity), data);

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -186,6 +186,9 @@ namespace Robust.Shared.GameObjects
             }
             set
             {
+                if (NoLocalRotation)
+                    return;
+
                 var current = WorldRotation;
                 var diff = value - current;
                 LocalRotation += diff;

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -406,8 +406,10 @@ public abstract partial class SharedTransformSystem
         xform.MatricesDirty = true;
         xform._localPosition = value.Position;
 
-        if (rotation != null)
+        if (rotation != null && !xform.NoLocalRotation)
             xform._localRotation = rotation.Value;
+
+        DebugTools.Assert(!xform.NoLocalRotation || xform.LocalRotation == 0);
 
         // Perform parent change logic
         if (value.EntityId != xform._parent)
@@ -460,8 +462,10 @@ public abstract partial class SharedTransformSystem
             if (xform.Initialized)
             {
                 // preserve world rotation
-                if (rotation == null && oldParent != null && newParent != null)
+                if (rotation == null && oldParent != null && newParent != null && !xform.NoLocalRotation)
                     xform._localRotation += GetWorldRotation(oldParent, xformQuery) - GetWorldRotation(newParent, xformQuery);
+
+                DebugTools.Assert(!xform.NoLocalRotation || xform.LocalRotation == 0);
 
                 var entParentChangedMessage = new EntParentChangedMessage(xform.Owner, oldParent?.Owner, oldMapId, xform);
                 RaiseLocalEvent(xform.Owner, ref entParentChangedMessage, true);
@@ -946,6 +950,8 @@ public abstract partial class SharedTransformSystem
 
         if (!xform.NoLocalRotation)
             xform._localRotation = rot;
+
+        DebugTools.Assert(!xform.NoLocalRotation || xform.LocalRotation == 0);
 
         Dirty(xform);
         xform.MatricesDirty = true;

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -295,6 +295,8 @@ public abstract partial class SharedTransformSystem
 
         var ev = new TransformStartupEvent(xform);
         RaiseLocalEvent(uid, ref ev, true);
+
+        DebugTools.Assert(!xform.NoLocalRotation || xform.LocalRotation == 0);
     }
 
     #endregion


### PR DESCRIPTION
Fixes some instances where NoLocalRotation is ignored and an entity is given non-zero local rotation.