### PR TITLE
Fix tooltips being incorrect for a frame

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Fix tooltip panels being incorrectly sized for their first frame.
 
 ### Other
 

--- a/Robust.Client/UserInterface/Control.cs
+++ b/Robust.Client/UserInterface/Control.cs
@@ -184,7 +184,7 @@ namespace Robust.Client.UserInterface
 
                 _propagateVisibilityChanged(value);
                 // TODO: unhardcode this.
-                // Many containers ignore children if they're invisible, so that's why we're replicating that ehre.
+                // Many containers ignore children if they're invisible, so that's why we're replicating that here.
                 Parent?.InvalidateMeasure();
                 InvalidateMeasure();
             }

--- a/Robust.Client/UserInterface/CustomControls/Tooltip.cs
+++ b/Robust.Client/UserInterface/CustomControls/Tooltip.cs
@@ -14,7 +14,15 @@ namespace Robust.Client.UserInterface.CustomControls
 
         public Tooltip()
         {
-            AddChild(_label = new Label());
+            var vbox = new BoxContainer()
+            {
+                Orientation = BoxContainer.LayoutOrientation.Vertical,
+                RectClipContent = true,
+            };
+
+            AddChild(vbox);
+
+            vbox.AddChild(_label = new Label());
         }
     }
 }

--- a/Robust.Client/UserInterface/UserInterfaceManager.Input.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Input.cs
@@ -36,8 +36,7 @@ internal partial class UserInterfaceManager
 
     // set to null when not counting down
     private float? _tooltipDelay;
-    private Tooltip _tooltip = default!;
-    private bool showingTooltip;
+    private bool _showingTooltip;
     private Control? _suppliedTooltip;
     private const float TooltipDelay = 1;
 
@@ -290,8 +289,8 @@ internal partial class UserInterfaceManager
 
     private void _clearTooltip()
     {
-        if (!showingTooltip) return;
-        _tooltip.Visible = false;
+        if (!_showingTooltip) return;
+
         if (_suppliedTooltip != null)
         {
             PopupRoot.RemoveChild(_suppliedTooltip);
@@ -300,7 +299,7 @@ internal partial class UserInterfaceManager
 
         CurrentlyHovered?.PerformHideTooltip();
         _resetTooltipTimer();
-        showingTooltip = false;
+        _showingTooltip = false;
     }
 
     public void CursorChanged(Control control)
@@ -497,8 +496,8 @@ internal partial class UserInterfaceManager
 
     private void _showTooltip()
     {
-        if (showingTooltip) return;
-        showingTooltip = true;
+        if (_showingTooltip) return;
+        _showingTooltip = true;
         var hovered = CurrentlyHovered;
         if (hovered == null)
         {
@@ -509,20 +508,24 @@ internal partial class UserInterfaceManager
         if (hovered.TooltipSupplier != null)
         {
             _suppliedTooltip = hovered.TooltipSupplier.Invoke(hovered);
-            if (_suppliedTooltip != null)
-            {
-                PopupRoot.AddChild(_suppliedTooltip);
-                Tooltips.PositionTooltip(_suppliedTooltip);
-            }
         }
         else if (!String.IsNullOrWhiteSpace(hovered.ToolTip))
         {
             // show simple tooltip if there is one
-            _tooltip.Visible = true;
-            _tooltip.Text = hovered.ToolTip;
-            Tooltips.PositionTooltip(_tooltip);
+            var tooltip = new Tooltip()
+            {
+                Text = hovered.ToolTip
+            };
+
+            _suppliedTooltip = tooltip;
+        }
+        else
+        {
+            return;
         }
 
+        PopupRoot.AddChild(_suppliedTooltip!);
+        Tooltips.PositionTooltip(_suppliedTooltip!);
         hovered.PerformShowTooltip();
     }
 

--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -170,10 +170,6 @@ namespace Robust.Client.UserInterface
                 MouseFilter = Control.MouseFilterMode.Ignore
             };
             RootControl.AddChild(PopupRoot);
-
-            _tooltip = new Tooltip();
-            PopupRoot.AddChild(_tooltip);
-            _tooltip.Visible = false;
         }
 
         public void InitializeTesting()
@@ -269,7 +265,7 @@ namespace Robust.Client.UserInterface
 
             // count down tooltip delay if we're not showing one yet and
             // are hovering the mouse over a control without moving it
-            if (_tooltipDelay != null && !showingTooltip)
+            if (_tooltipDelay != null && !_showingTooltip)
             {
                 _tooltipTimer += args.DeltaSeconds;
                 if (_tooltipTimer >= _tooltipDelay)


### PR DESCRIPTION
It just works. The actual fix(?) is using a boxcontainer as the child; creating the tooltip as needed seemed more consistent than leaving one around?

https://user-images.githubusercontent.com/31366439/210931713-508dbdd8-7491-4677-8e0f-a9d7cec8b371.mp4