### PR TITLE
Fix incorrect size of second window in split container

### DIFF
--- a/Robust.Client/UserInterface/Controls/SplitContainer.cs
+++ b/Robust.Client/UserInterface/Controls/SplitContainer.cs
@@ -291,7 +291,7 @@ namespace Robust.Client.UserInterface.Controls
                 else
                     size.X = availableSize.X - _splitStart - _splitWidth;
 
-                size = Vector2.ComponentMax(availableSize, Vector2.Zero);
+                size = Vector2.ComponentMax(size, Vector2.Zero);
                 second.Measure(size);
             }
             else

--- a/Robust.Client/UserInterface/Controls/SplitContainer.cs
+++ b/Robust.Client/UserInterface/Controls/SplitContainer.cs
@@ -291,7 +291,7 @@ namespace Robust.Client.UserInterface.Controls
                 else
                     size.X = availableSize.X - _splitStart - _splitWidth;
 
-                size = Vector2.ComponentMax(availableSize - _splitStart - _splitWidth, Vector2.Zero);
+                size = Vector2.ComponentMax(availableSize, Vector2.Zero);
                 second.Measure(size);
             }
             else


### PR DESCRIPTION
CL https://github.com/space-wizards/RobustToolbox/commit/45295d4b49ca16ba5ae8c06635051c257c3ec0e7 introduced a small bug where the second widget in a SplitContainer could have the wrong measure applied. This manifested in some strange-looking layouts of that widget's children:

![Peek 2023-01-10 23-02](https://user-images.githubusercontent.com/1676295/211680910-c89d887f-dd1e-4857-96fc-438a18422926.gif)

The additional size adjustment for the padding of the SplitContainer's second widget was being applied twice, and, in the second instance, was erroneously subtracting a scalar from a vector - really feels like that should be a domain error, but it looks like there's a bunch of code that relies on "Vector2.operator -(Vector2 a, float b)" (and operator+)