### PR TITLE
Adds a WCvar to override the CEF user-agent

### DIFF
--- a/Robust.Client.WebView/Cef/WebViewManagerCef.cs
+++ b/Robust.Client.WebView/Cef/WebViewManagerCef.cs
@@ -69,6 +69,12 @@ namespace Robust.Client.WebView.Cef
                 CachePath = cachePath,
             };
 
+            var userAgentOverride = _cfg.GetCVar(WCVars.UserAgentOverride);
+            if (!string.IsNullOrEmpty(userAgentOverride))
+            {
+                settings.UserAgent = userAgentOverride;
+            }
+
             Logger.Info($"CEF Version: {CefRuntime.ChromeVersion}");
 
             _app = new RobustCefApp();

--- a/Robust.Client.WebView/WCVars.cs
+++ b/Robust.Client.WebView/WCVars.cs
@@ -14,4 +14,10 @@ public static class WCVars
     /// </summary>
     public static readonly CVarDef<bool> WebResProtocol =
         CVarDef.Create("web.res_protocol", true, CVar.CLIENTONLY);
+
+    /// <summary>
+    /// Overrides the default CEF user-agent when set to a non-empty string.
+    /// </summary>
+    public static readonly CVarDef<string> UserAgentOverride =
+        CVarDef.Create("web.user_agent", "", CVar.CLIENTONLY);
 }


### PR DESCRIPTION
OpenDream needs this to trick older implementations of TGUI into thinking it's Internet Explorer.

Here's a random OD window that I used to test setting it to `opendream useragent test`:

![image](https://user-images.githubusercontent.com/5714543/211686549-edfcb731-1c8f-4c67-907c-ce124f5f045c.png)
