### PR TITLE
Add `string HttpUtility.JavaScriptStringEncode(string)` to the sandbox

### DIFF
--- a/Robust.Shared/ContentPack/Sandbox.yml
+++ b/Robust.Shared/ContentPack/Sandbox.yml
@@ -708,6 +708,7 @@ Types:
       Methods:
         - "System.Collections.Specialized.NameValueCollection ParseQueryString(string, System.Text.Encoding)"
         - "System.Collections.Specialized.NameValueCollection ParseQueryString(string)"
+        - "string JavaScriptStringEncode(string)"
         - "string UrlDecode(string, System.Text.Encoding)"
         - "string UrlDecode(string)"
         - "string UrlEncode(string, System.Text.Encoding)"


### PR DESCRIPTION
I need this to properly escape a string being inserted into JavaScript code at runtime in OpenDream.