### PR TITLE
Try fix cvar toml type parsing

### DIFF
--- a/Robust.Shared/Configuration/ConfigurationManager.cs
+++ b/Robust.Shared/Configuration/ConfigurationManager.cs
@@ -299,6 +299,20 @@ namespace Robust.Shared.Configuration
                 if (cVar.Registered)
                     Logger.ErrorS("cfg", $"The variable '{name}' has already been registered.");
 
+                if (!type.IsEnum && cVar.Value != null && !type.IsAssignableFrom(cVar.Value.GetType()))
+                {
+                    try
+                    {
+                        // try convert thing like int to float.
+                        cVar.Value = Convert.ChangeType(cVar.Value, type);
+                    }
+                    catch
+                    {
+                        Logger.Error($"TOML parsed cvar does not match registered cvar type. Name: {name}. Code Type: {type.Name}. Toml type: {cVar.Value.GetType().Name}");
+                        return;
+                    }
+                }
+
                 cVar.DefaultValue = defaultValue;
                 cVar.Flags = flags;
                 cVar.Registered = true;


### PR DESCRIPTION
This tries to fix #3680. Cvar loading/registering & cvar def types in general are a bit of a mess & I'm not at all sure if this is the best way to do this, but it seem to fix the issue. 

It would be nice if there were just some kind of generic "can be cast from" but that doesn't exist AFAIK.