### PR TITLE
Allow EnsureComp to override deferred deletion

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -686,7 +686,13 @@ namespace Robust.Shared.GameObjects
         public T EnsureComponent<T>(EntityUid uid) where T : Component, new()
         {
             if (TryGetComponent<T>(uid, out var component))
-                return component;
+            {
+                // Check for deferred component removal.
+                if (component.LifeStage <= ComponentLifeStage.Running)
+                    return component;
+                else
+                    RemoveComponent(uid, component);
+            }
 
             return AddComponent<T>(uid);
         }
@@ -697,8 +703,14 @@ namespace Robust.Shared.GameObjects
         {
             if (TryGetComponent<T>(entity, out var comp))
             {
-                component = comp;
-                return true;
+                // Check for deferred component removal.
+                if (comp.LifeStage <= ComponentLifeStage.Running)
+                {
+                    component = comp;
+                    return true;
+                }
+                else
+                    RemoveComponent(entity, comp);
             }
 
             component = AddComponent<T>(entity);

--- a/Robust.UnitTesting/Shared/GameObjects/EntityManager_Components_Tests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityManager_Components_Tests.cs
@@ -186,6 +186,23 @@ namespace Robust.UnitTesting.Shared.GameObjects
         }
 
         [Test]
+        public void EnsureQueuedComponentDeletion()
+        {
+            var sim = SimulationFactory();
+            var entMan = sim.Resolve<IEntityManager>();
+            var entity = entMan.SpawnEntity(null, DefaultCoords);
+            var component = entMan.AddComponent<DummyComponent>(entity);
+
+            Assert.That(component.LifeStage, Is.LessThanOrEqualTo(ComponentLifeStage.Running));
+            entMan.RemoveComponentDeferred(entity, component);
+            Assert.That(component.LifeStage, Is.EqualTo(ComponentLifeStage.Stopped));
+
+            Assert.False(entMan.EnsureComponent<DummyComponent>(entity, out var comp2));
+            Assert.That(comp2.LifeStage, Is.LessThanOrEqualTo(ComponentLifeStage.Running));
+            Assert.That(component.LifeStage, Is.EqualTo(ComponentLifeStage.Deleted));
+        }
+
+        [Test]
         public void RemoveNetComponentTest()
         {
             // Arrange


### PR DESCRIPTION
This makes it so that if a component is queued for removal via RemCompDeferred, then ensure comp will immediately delete that component and add a new one. Fixes #3690