### PR TITLE
Lets forces act on kinematic controllers.

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
@@ -667,7 +667,7 @@ public abstract partial class SharedPhysicsSystem
             var angularVelocity = body.AngularVelocity;
 
             // if the body cannot move, nothing to do here
-            if (body.BodyType == BodyType.Dynamic)
+            if (((int)body.BodyType & (int)(BodyType.Dynamic | BodyType.KinematicController)) != 0)
             {
                 if (body.IgnoreGravity)
                     linearVelocity += body.Force * data.FrameTime * body.InvMass;


### PR DESCRIPTION
Physics bodies with the kinematic controller bodytype allow forces, torques, and impulses to be applied similar to dynamic physics bodies. However, when the physics system runs it only applies forces to dynamic physics bodies, kinematic controllers are skipped. This results in some inconsistencies where applying an impulse to a kinematic controller works just fine since the change to the entities momentum is applied immediately but applying a force over time fails to have any effect at all.

This resolves the above inconsistency by allowing forces to apply to physics bodies.