### PR TITLE
Don't set global audio every tick

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
@@ -148,8 +148,6 @@ public sealed class AudioSystem : SharedAudioSystem
                 && stream.TrackingEntity == null
                 && stream.TrackingFallbackCoordinates == null);
 
-            // Does this really have to be set every frame???
-            stream.Source.SetVolume(stream.Volume);
             return;
         }
 


### PR DESCRIPTION
Audio cleanup sometime in the next millenium.

Weather sets volume directly and this was resetting it. Ideally you wouldn't be able to set the source and audio stream volume independently.