### PR TITLE
Alternative  `SpriteComponent.CopyFrom()` fix

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -304,11 +304,8 @@ namespace Robust.Client.GameObjects
 
         void ISerializationHooks.AfterDeserialization()
         {
-            // Please somebody burn this to the ground
-            // Fix prototype reload trying to update tree on deserialization dummy instances.
-            if (!Owner.IsValid())
-                return;
-
+            // Please somebody burn this to the ground. There is so much spaghetti.
+            
             IoCManager.InjectDependencies(this);
 
             {
@@ -1404,7 +1401,7 @@ namespace Robust.Client.GameObjects
 
         private void QueueUpdateRenderTree()
         {
-            if (TreeUpdateQueued || entities?.EventBus == null)
+            if (TreeUpdateQueued || !Owner.IsValid())
                 return;
 
             // TODO whenever sprite comp gets ECS'd , just make this a direct method call.
@@ -1414,7 +1411,7 @@ namespace Robust.Client.GameObjects
 
         private void QueueUpdateIsInert()
         {
-            if (_inertUpdateQueued || entities?.EventBus == null)
+            if (_inertUpdateQueued || !Owner.IsValid())
                 return;
 
             // TODO whenever sprite comp gets ECS'd , just make this a direct method call.


### PR DESCRIPTION
#3704 was murdered by networked sprite components and a pile of initialization spaghetti.