### PR TITLE
Fix exception on right arrow key at second to last character

### DIFF
--- a/Robust.Shared/Utility/TextRope.cs
+++ b/Robust.Shared/Utility/TextRope.cs
@@ -483,16 +483,10 @@ public static class Rope
     [Pure]
     public static long RuneShiftRight(long index, Node rope)
     {
-        index += 1;
+        if (char.IsHighSurrogate(Index(rope, index)))
+            return index + 2;
 
-        // Before you confuse yourself on "shouldn't this be high surrogate since shifting left checks low"
-        // (Because yes, I did myself too a week after writing it)
-        // char.IsLowSurrogate(_text[_cursorPosition]) means "is the cursor between a surrogate pair"
-        // because we ALREADY moved.
-        if (char.IsLowSurrogate(Index(rope, index)))
-            index += 1;
-
-        return index;
+        return index + 1;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #3718.

Before, the code would try to find the character at the index after the last character (to check whether its a low surrogate), which doesn't exist if we're not dealing with a surrogate pair. Now the code will just check if the last character is a high surrogate and only then add 2 to the index instead of 1.