### PR TITLE
Fix bug where ScrollContainer could cause layout engine to loop forever.

### DIFF
--- a/Robust.Client/UserInterface/Control.Layout.cs
+++ b/Robust.Client/UserInterface/Control.Layout.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Map;
@@ -529,7 +529,7 @@ namespace Robust.Client.UserInterface
         /// <returns>The actual measured desired size of the control.</returns>
         protected virtual Vector2 MeasureCore(Vector2 availableSize)
         {
-            if (!Visible)
+            if (!(Visible || ReservesSpace))
                 return default;
 
             if (_stylingDirty)
@@ -621,7 +621,7 @@ namespace Robust.Client.UserInterface
         /// </summary>
         protected virtual void ArrangeCore(UIBox2 finalRect)
         {
-            if (!Visible)
+            if (!(Visible || ReservesSpace))
                 return;
 
             var withoutMargins = _margin.Deflate(finalRect);

--- a/Robust.Client/UserInterface/Control.cs
+++ b/Robust.Client/UserInterface/Control.cs
@@ -28,6 +28,9 @@ namespace Robust.Client.UserInterface
         private readonly List<Control> _orderedChildren = new();
 
         private bool _visible = true;
+        // Determines if this control requires space, even when
+        // it's visibility has been set to false
+        private bool _reservesSpace = true;
 
         // _marginSetSize is the size calculated by the margins,
         // but it's different from _size if min size is higher.
@@ -170,7 +173,7 @@ namespace Robust.Client.UserInterface
         /// <seealso cref="VisibleInTree"/>
         [ViewVariables(VVAccess.ReadWrite)]
         [Animatable]
-        public virtual bool Visible
+        public bool Visible
         {
             get => _visible;
             set
@@ -206,6 +209,33 @@ namespace Robust.Client.UserInterface
                 }
             }
         }
+
+        /// <summary>
+        ///     Whether or not this control and its children require
+        ///     space to be reserved, even when not visible.
+        /// </summary>
+        /// <seealso cref="ReservesSpace"/>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [Animatable]
+        public virtual bool ReservesSpace
+        {
+            get => _reservesSpace;
+            set
+            {
+                if (_reservesSpace == value)
+                {
+                    return;
+                }
+
+                _reservesSpace = value;
+
+                // TODO: unhardcode this.
+                // Many containers ignore children if they're invisible, so that's why we're replicating that here.
+                Parent?.InvalidateMeasure();
+                InvalidateMeasure();
+            }
+        }
+
 
         /// <summary>
         ///     Whether or not this control is an (possibly indirect) child of

--- a/Robust.Client/UserInterface/Control.cs
+++ b/Robust.Client/UserInterface/Control.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -170,7 +170,7 @@ namespace Robust.Client.UserInterface
         /// <seealso cref="VisibleInTree"/>
         [ViewVariables(VVAccess.ReadWrite)]
         [Animatable]
-        public bool Visible
+        public virtual bool Visible
         {
             get => _visible;
             set

--- a/Robust.Client/UserInterface/Control.cs
+++ b/Robust.Client/UserInterface/Control.cs
@@ -217,7 +217,7 @@ namespace Robust.Client.UserInterface
         /// <seealso cref="ReservesSpace"/>
         [ViewVariables(VVAccess.ReadWrite)]
         [Animatable]
-        public virtual bool ReservesSpace
+        public bool ReservesSpace
         {
             get => _reservesSpace;
             set

--- a/Robust.Client/UserInterface/Control.cs
+++ b/Robust.Client/UserInterface/Control.cs
@@ -30,7 +30,7 @@ namespace Robust.Client.UserInterface
         private bool _visible = true;
         // Determines if this control requires space, even when
         // it's visibility has been set to false
-        private bool _reservesSpace = true;
+        private bool _reservesSpace = false;
 
         // _marginSetSize is the size calculated by the margins,
         // but it's different from _size if min size is higher.

--- a/Robust.Client/UserInterface/Controls/ScrollBar.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollBar.cs
@@ -18,12 +18,6 @@ namespace Robust.Client.UserInterface.Controls
         private (Vector2 pos, float value)? _grabData;
         private float _valueTarget;
 
-        /// <summary>
-        /// Whether we need to draw the scroll bars or not.
-        /// See <see cref="Visible" />.
-        /// </summary>
-        protected bool _shouldDraw = true;
-
         public float ValueTarget
         {
             get => _valueTarget;
@@ -86,11 +80,8 @@ namespace Robust.Client.UserInterface.Controls
 
         protected internal override void Draw(DrawingHandleScreen handle)
         {
-            if (_shouldDraw)
-            {
-                var styleBox = _getGrabberStyleBox();
-                styleBox?.Draw(handle, _getGrabberBox());
-            }
+            var styleBox = _getGrabberStyleBox();
+            styleBox?.Draw(handle, _getGrabberBox());
         }
 
         protected internal override void MouseExited()

--- a/Robust.Client/UserInterface/Controls/ScrollBar.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollBar.cs
@@ -48,6 +48,7 @@ namespace Robust.Client.UserInterface.Controls
         protected ScrollBar(OrientationMode orientation)
         {
             MouseFilter = MouseFilterMode.Pass;
+            ReservesSpace = true;
 
             _orientation = orientation;
         }
@@ -81,17 +82,6 @@ namespace Robust.Client.UserInterface.Controls
                 Value = MathHelper.Lerp(Value, ValueTarget, Math.Min(args.DeltaSeconds * 15, 1));
                 _updating = false;
             }
-        }
-
-        // We override Visible here to always return true, so that the layout engine
-        // always reserves space for this control. This avoids a bug where the layout
-        // constantly toggles the visiblity of the scroll bar. Since we still want
-        // to control the visiblilty of the bar itself, we'll save that to another
-        // property.
-        public override bool Visible
-        {
-            get => true;
-            set => _shouldDraw = value;
         }
 
         protected internal override void Draw(DrawingHandleScreen handle)

--- a/Robust.Client/UserInterface/Controls/ScrollBar.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollBar.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Robust.Client.Graphics;
 using Robust.Shared.Input;
 using Robust.Shared.Maths;
@@ -17,6 +17,12 @@ namespace Robust.Client.UserInterface.Controls
         private bool _isHovered;
         private (Vector2 pos, float value)? _grabData;
         private float _valueTarget;
+
+        /// <summary>
+        /// Whether we need to draw the scroll bars or not.
+        /// See <see cref="Visible" />.
+        /// </summary>
+        protected bool _shouldDraw = true;
 
         public float ValueTarget
         {
@@ -77,11 +83,24 @@ namespace Robust.Client.UserInterface.Controls
             }
         }
 
+        // We override Visible here to always return true, so that the layout engine
+        // always reserves space for this control. This avoids a bug where the layout
+        // constantly toggles the visiblity of the scroll bar. Since we still want
+        // to control the visiblilty of the bar itself, we'll save that to another
+        // property.
+        public override bool Visible
+        {
+            get => true;
+            set => _shouldDraw = value;
+        }
+
         protected internal override void Draw(DrawingHandleScreen handle)
         {
-            var styleBox = _getGrabberStyleBox();
-
-            styleBox?.Draw(handle, _getGrabberBox());
+            if (_shouldDraw)
+            {
+                var styleBox = _getGrabberStyleBox();
+                styleBox?.Draw(handle, _getGrabberBox());
+            }
         }
 
         protected internal override void MouseExited()


### PR DESCRIPTION
Copy-pasting repro from https://github.com/space-wizards/space-station-14/issues/13641

> To repro (there's a slighly simpler way to repro it, I'm sure):
> 1. Write a paper with the contents "11111 11111i 11111ii 11111iii 11111iiii 11111iiiii 11111iiiiii 11111iiiiiii 11111iiiiiiii 11111iiiiiiiii 11111iiiiiiiiii 11111iiiiiiiiiii 11111iiiiiiiiiiii 11111iiiiiiiiiiiii 11111iiiiiiiiiiiiii 11111iiiiiiiiiiiiiii 11111iiiiiiiiiiiiiiii 11111iiiiiiiiiiiiiiiii"
> 2. Resize the paper so the entered text just fills up the the whole page
    Hang forever

What's happening is that the ScrollContainer and RichTextLabel don't get on. The ScrollContainer decides it needs to enable the scrollbar, which causes an InvalidateMeasure(), then, on next layout, the RichTextLabel decides it needs to add a line break to account for the slightly more narrow space. Then, on next layout, the scroll bar isn't necessary anymore, which causes an InvalidateMeasure() and....

ScrollContainer _attempts_ to account for the size of the scroll bars, but when they are `Visible==false`, their `DesiredSize` is 0. This adds the ability for ScrollBars to be Visible for the purposes of layout, but won't draw themselves if not necessary. Longer-term, this feels like it would be a nice to break Visibility out into `Invisible` `Invisible-but-takes-up-space` and `Visible`.

I tested this on a bunch of the other UIs which use ScrollContainer, and they seem to be behaving correctly.