### PR TITLE
Refactor NextWordPosition to EndWordPosition

### DIFF
--- a/Robust.Client/UserInterface/Controls/LineEdit.cs
+++ b/Robust.Client/UserInterface/Controls/LineEdit.cs
@@ -479,7 +479,7 @@ namespace Robust.Client.UserInterface.Controls
                 }
                 else if (args.Function == EngineKeyFunctions.TextCursorWordRight)
                 {
-                    _selectionStart = _cursorPosition = TextEditShared.NextWordPosition(_text, _cursorPosition);
+                    _selectionStart = _cursorPosition = TextEditShared.EndWordPosition(_text, _cursorPosition);
 
                     args.Handle();
                 }
@@ -513,7 +513,7 @@ namespace Robust.Client.UserInterface.Controls
                 }
                 else if (args.Function == EngineKeyFunctions.TextCursorSelectWordRight)
                 {
-                    _cursorPosition = TextEditShared.NextWordPosition(_text, _cursorPosition);
+                    _cursorPosition = TextEditShared.EndWordPosition(_text, _cursorPosition);
 
                     args.Handle();
                 }

--- a/Robust.Client/UserInterface/Controls/TextEdit.cs
+++ b/Robust.Client/UserInterface/Controls/TextEdit.cs
@@ -545,7 +545,7 @@ public sealed class TextEdit : Control
             case MoveType.RightWord:
             {
                 var runes = Rope.EnumerateRunes(TextRope, _cursorPosition.Index);
-                var pos = _cursorPosition.Index + TextEditShared.NextWordPosition(runes.GetEnumerator());
+                var pos = _cursorPosition.Index + TextEditShared.EndWordPosition(runes.GetEnumerator());
 
                 return new CursorPos(pos, LineBreakBias.Bottom);
             }

--- a/Robust.Client/UserInterface/Controls/TextEditShared.cs
+++ b/Robust.Client/UserInterface/Controls/TextEditShared.cs
@@ -17,27 +17,29 @@ internal static class TextEditShared
     // Functions for calculating next positions when doing word-bound cursor movement (ctrl+left/right).
     //
 
-    internal static int NextWordPosition(string str, int cursor)
+    internal static int EndWordPosition(string str, int cursor)
     {
-        return cursor + NextWordPosition(new StringEnumerateHelpers.SubstringRuneEnumerator(str, cursor));
+        return cursor + EndWordPosition(new StringEnumerateHelpers.SubstringRuneEnumerator(str, cursor));
     }
 
-    internal static int NextWordPosition<T>(T runes) where T : IEnumerator<Rune>
+    internal static int EndWordPosition<T>(T runes) where T : IEnumerator<Rune>
     {
         if (!runes.MoveNext())
             return 0;
 
-        var charClass = GetCharClass(runes.Current);
-
         var i = 0;
+        if (!IterForward(CharClass.Whitespace))
+            return i;
 
+        var charClass = GetCharClass(runes.Current);
         IterForward(charClass);
-        IterForward(CharClass.Whitespace);
 
         return i;
 
-        void IterForward(CharClass cClass)
+        bool IterForward(CharClass cClass)
         {
+            var hasNext = true;
+
             do
             {
                 var rune = runes.Current;
@@ -46,7 +48,11 @@ internal static class TextEditShared
                     break;
 
                 i += rune.Utf16SequenceLength;
-            } while (runes.MoveNext());
+
+                hasNext = runes.MoveNext();
+            } while (hasNext);
+
+            return hasNext;
         }
     }
 

--- a/Robust.UnitTesting/Client/UserInterface/Controls/LineEditTest.cs
+++ b/Robust.UnitTesting/Client/UserInterface/Controls/LineEditTest.cs
@@ -139,14 +139,14 @@ namespace Robust.UnitTesting.Client.UserInterface.Controls
 
         [Test]
         // RIGHT
-        [TestCase("Foo Bar Baz", false, 0, ExpectedResult = 4)]
+        [TestCase("Foo Bar Baz", false, 0, ExpectedResult = 3)]
         [TestCase("Foo Bar Baz", false, 8, ExpectedResult = 11)]
         [TestCase("Foo[Bar[Baz", false, 0, ExpectedResult = 3)]
         [TestCase("Foo[Bar[Baz", false, 3, ExpectedResult = 4)]
         [TestCase("Foo^Bar^Baz", false, 0, ExpectedResult = 3)]
         [TestCase("Foo^Bar^Baz", false, 3, ExpectedResult = 5)]
         [TestCase("Foo^^^Bar^Baz", false, 3, ExpectedResult = 9)]
-        [TestCase("^^^ ^^^", false, 0, ExpectedResult = 7)]
+        [TestCase("^^^ ^^^", false, 0, ExpectedResult = 6)]
         [TestCase("^^^ ^^^", false, 7, ExpectedResult = 13)]
         // LEFT
         [TestCase("Foo Bar Baz", true, 4, ExpectedResult = 0)]

--- a/Robust.UnitTesting/Client/UserInterface/Controls/TextEditSharedTest.cs
+++ b/Robust.UnitTesting/Client/UserInterface/Controls/TextEditSharedTest.cs
@@ -41,28 +41,28 @@ internal sealed class TextEditSharedTest
     [Test]
     // @formatter:off
     [TestCase("foo bar baz",   11, ExpectedResult = 11)]
-    [TestCase("foo bar baz",   0,  ExpectedResult = 4 )]
-    [TestCase("foo bar baz",   1,  ExpectedResult = 4 )]
-    [TestCase("foo bar baz",   3,  ExpectedResult = 4 )]
-    [TestCase("foo bar baz",   4,  ExpectedResult = 8 )]
-    [TestCase("foo bar baz",   5,  ExpectedResult = 8 )]
-    [TestCase("Foo Bar Baz",   0,  ExpectedResult = 4 )]
+    [TestCase("foo bar baz",   0,  ExpectedResult = 3 )]
+    [TestCase("foo bar baz",   1,  ExpectedResult = 3 )]
+    [TestCase("foo bar baz",   3,  ExpectedResult = 7 )]
+    [TestCase("foo bar baz",   4,  ExpectedResult = 7 )]
+    [TestCase("foo bar baz",   5,  ExpectedResult = 7 )]
+    [TestCase("Foo Bar Baz",   0,  ExpectedResult = 3 )]
     [TestCase("Foo Bar Baz",   8,  ExpectedResult = 11)]
-    [TestCase("foo +bar baz",  0,  ExpectedResult = 4 )]
+    [TestCase("foo +bar baz",  0,  ExpectedResult = 3 )]
     [TestCase("foo +bar baz",  4,  ExpectedResult = 5 )]
     [TestCase("Foo[Bar[Baz",   0,  ExpectedResult = 3 )]
     [TestCase("Foo[Bar[Baz",   3,  ExpectedResult = 4 )]
     [TestCase("Foo^Bar^Baz",   0,  ExpectedResult = 3 )]
     [TestCase("Foo^Bar^Baz",   3,  ExpectedResult = 5 )]
     [TestCase("Foo^^^Bar^Baz", 3,  ExpectedResult = 9 )]
-    [TestCase("^^^ ^^^",       0,  ExpectedResult = 7 )]
+    [TestCase("^^^ ^^^",       0,  ExpectedResult = 6 )]
     [TestCase("^^^ ^^^",       7,  ExpectedResult = 13)]
     // @formatter:on
-    public int TestNextWordPosition(string str, int cursor)
+    public int TestEndWordPosition(string str, int cursor)
     {
         // For my sanity.
         str = str.Replace("^", "👏");
 
-        return TextEditShared.NextWordPosition(str, cursor);
+        return TextEditShared.EndWordPosition(str, cursor);
     }
 }


### PR DESCRIPTION
Instead of finding the start of the next word, it now finds the end of the current word. The new behaviour is consistent with any application I know of/have tried, and is less weird (before, moving a word left would not add the whitespace between the current and previous word, while moving a word right would add the whitespace in between the current and next word).