### PR TITLE
Implement deleting a full word at a time

### DIFF
--- a/Robust.Client/Input/EngineContexts.cs
+++ b/Robust.Client/Input/EngineContexts.cs
@@ -56,6 +56,9 @@ namespace Robust.Client.Input
             common.AddFunction(EngineKeyFunctions.TextCursorSelectEnd);
 
             common.AddFunction(EngineKeyFunctions.TextBackspace);
+            common.AddFunction(EngineKeyFunctions.TextDelete);
+            common.AddFunction(EngineKeyFunctions.TextWordBackspace);
+            common.AddFunction(EngineKeyFunctions.TextWordDelete);
             common.AddFunction(EngineKeyFunctions.TextNewline);
             common.AddFunction(EngineKeyFunctions.TextSubmit);
             common.AddFunction(EngineKeyFunctions.TextCopy);
@@ -66,7 +69,6 @@ namespace Robust.Client.Input
             common.AddFunction(EngineKeyFunctions.TextHistoryNext);
             common.AddFunction(EngineKeyFunctions.TextReleaseFocus);
             common.AddFunction(EngineKeyFunctions.TextScrollToBottom);
-            common.AddFunction(EngineKeyFunctions.TextDelete);
             common.AddFunction(EngineKeyFunctions.TextTabComplete);
             common.AddFunction(EngineKeyFunctions.TextCompleteNext);
             common.AddFunction(EngineKeyFunctions.TextCompletePrev);

--- a/Robust.Client/UserInterface/Controls/LineEdit.cs
+++ b/Robust.Client/UserInterface/Controls/LineEdit.cs
@@ -358,7 +358,7 @@ namespace Robust.Client.UserInterface.Controls
             _imeData = null;
         }
 
-        public event Action<LineEditBackspaceEventArgs>? OnBackspace;
+        public event Action<LineEditTextRemovedEventArgs>? OnTextRemoved;
 
         protected internal override void KeyBindDown(GUIBoundKeyEventArgs args)
         {
@@ -405,7 +405,7 @@ namespace Robust.Client.UserInterface.Controls
                             _selectionStart = _cursorPosition;
                             OnTextChanged?.Invoke(new LineEditEventArgs(this, _text));
                             _updatePseudoClass();
-                            OnBackspace?.Invoke(new LineEditBackspaceEventArgs(oldText, _text, cursor, selectStart));
+                            OnTextRemoved?.Invoke(new LineEditTextRemovedEventArgs(oldText, _text, cursor, selectStart));
                         }
                     }
 
@@ -436,6 +436,71 @@ namespace Robust.Client.UserInterface.Controls
                             _selectionStart = _cursorPosition;
                             OnTextChanged?.Invoke(new LineEditEventArgs(this, _text));
                             _updatePseudoClass();
+                            OnTextRemoved?.Invoke(new LineEditTextRemovedEventArgs(_text, _text, _cursorPosition, _selectionStart));
+                        }
+                    }
+
+                    args.Handle();
+                }
+                else if (args.Function == EngineKeyFunctions.TextWordBackspace)
+                {
+                    if (Editable)
+                    {
+                        var changed = false;
+
+                        // If there is a selection, we just delete the selection. Otherwise we delete the previous word
+                        if (_selectionStart != _cursorPosition)
+                        {
+                            _text = _text.Remove(SelectionLower, SelectionLength);
+                            _cursorPosition = SelectionLower;
+                            changed = true;
+                        }
+                        else if (_cursorPosition != 0)
+                        {
+                            int remAmt = _cursorPosition - TextEditShared.PrevWordPosition(_text, _cursorPosition);
+
+                            _text = _text.Remove(_cursorPosition - remAmt, remAmt);
+                            _cursorPosition -= remAmt;
+                            changed = true;
+                        }
+
+                        if (changed)
+                        {
+                            _selectionStart = _cursorPosition;
+                            OnTextChanged?.Invoke(new LineEditEventArgs(this, _text));
+                            _updatePseudoClass();
+                            OnTextRemoved?.Invoke(new LineEditTextRemovedEventArgs(_text, _text, _cursorPosition, _selectionStart));
+                        }
+                    }
+
+                    args.Handle();
+                }
+                else if (args.Function == EngineKeyFunctions.TextWordDelete)
+                {
+                    if (Editable)
+                    {
+                        var changed = false;
+
+                        // If there is a selection, we just delete the selection. Otherwise we delete the next word
+                        if (_selectionStart != _cursorPosition)
+                        {
+                            _text = _text.Remove(SelectionLower, SelectionLength);
+                            _cursorPosition = SelectionLower;
+                            changed = true;
+                        }
+                        else if (_cursorPosition < _text.Length)
+                        {
+                            int nextWord = TextEditShared.EndWordPosition(_text, _cursorPosition);
+                            _text = _text.Remove(_cursorPosition, nextWord - _cursorPosition);
+                            changed = true;
+                        }
+
+                        if (changed)
+                        {
+                            _selectionStart = _cursorPosition;
+                            OnTextChanged?.Invoke(new LineEditEventArgs(this, _text));
+                            _updatePseudoClass();
+                            OnTextRemoved?.Invoke(new LineEditTextRemovedEventArgs(_text, _text, _cursorPosition, _selectionStart));
                         }
                     }
 
@@ -479,7 +544,7 @@ namespace Robust.Client.UserInterface.Controls
                 }
                 else if (args.Function == EngineKeyFunctions.TextCursorWordRight)
                 {
-                    _selectionStart = _cursorPosition = TextEditShared.NextWordPosition(_text, _cursorPosition);
+                    _selectionStart = _cursorPosition = TextEditShared.EndWordPosition(_text, _cursorPosition);
 
                     args.Handle();
                 }
@@ -513,7 +578,7 @@ namespace Robust.Client.UserInterface.Controls
                 }
                 else if (args.Function == EngineKeyFunctions.TextCursorSelectWordRight)
                 {
-                    _cursorPosition = TextEditShared.NextWordPosition(_text, _cursorPosition);
+                    _cursorPosition = TextEditShared.EndWordPosition(_text, _cursorPosition);
 
                     args.Handle();
                 }
@@ -829,14 +894,14 @@ namespace Robust.Client.UserInterface.Controls
             }
         }
 
-        public sealed class LineEditBackspaceEventArgs : EventArgs
+        public sealed class LineEditTextRemovedEventArgs : EventArgs
         {
             public string OldText { get; }
             public string NewText { get; }
             public int OldCursorPosition { get; }
             public int OldSelectionStart { get; }
 
-            public LineEditBackspaceEventArgs(
+            public LineEditTextRemovedEventArgs(
                 string oldText,
                 string newText,
                 int oldCursorPosition,

--- a/Robust.Client/UserInterface/Controls/TextEdit.cs
+++ b/Robust.Client/UserInterface/Controls/TextEdit.cs
@@ -357,6 +357,65 @@ public sealed class TextEdit : Control
                 args.Handle();
             }
         }
+        else if (args.Function == EngineKeyFunctions.TextWordBackspace)
+        {
+            if (Editable)
+            {
+                var changed = false;
+
+                // If there is a selection, we just delete the selection. Otherwise we delete the previous word
+                if (_selectionStart != _cursorPosition)
+                {
+                    TextRope = Rope.Delete(TextRope, SelectionLower.Index, SelectionLength);
+                    _cursorPosition = SelectionLower;
+                    changed = true;
+                }
+                else if (_cursorPosition.Index < TextLength)
+                {
+                    var runes = Rope.EnumerateRunesReverse(TextRope, _cursorPosition.Index);
+                    int remAmt = -TextEditShared.PrevWordPosition(runes.GetEnumerator());
+
+                    TextRope = Rope.Delete(TextRope, _cursorPosition.Index - remAmt, remAmt);
+                    _cursorPosition.Index -= remAmt;
+                    changed = true;
+                }
+
+                if (changed)
+                    _selectionStart = _cursorPosition;
+
+                InvalidateHorizontalCursorPos();
+                args.Handle();
+            }
+        }
+        else if (args.Function == EngineKeyFunctions.TextWordDelete)
+        {
+            if (Editable)
+            {
+                var changed = false;
+
+                // If there is a selection, we just delete the selection. Otherwise we delete the next word
+                if (_selectionStart != _cursorPosition)
+                {
+                    TextRope = Rope.Delete(TextRope, SelectionLower.Index, SelectionLength);
+                    _cursorPosition = SelectionLower;
+                    changed = true;
+                }
+                else if (_cursorPosition.Index < TextLength)
+                {
+                    var runes = Rope.EnumerateRunes(TextRope, _cursorPosition.Index);
+                    int endWord = _cursorPosition.Index + TextEditShared.EndWordPosition(runes.GetEnumerator());
+
+                    TextRope = Rope.Delete(TextRope, _cursorPosition.Index, endWord - _cursorPosition.Index);
+                    changed = true;
+                }
+
+                if (changed)
+                    _selectionStart = _cursorPosition;
+
+                InvalidateHorizontalCursorPos();
+                args.Handle();
+            }
+        }
         else if (args.Function == EngineKeyFunctions.TextNewline)
         {
             InsertAtCursor("\n");
@@ -545,7 +604,7 @@ public sealed class TextEdit : Control
             case MoveType.RightWord:
             {
                 var runes = Rope.EnumerateRunes(TextRope, _cursorPosition.Index);
-                var pos = _cursorPosition.Index + TextEditShared.NextWordPosition(runes.GetEnumerator());
+                var pos = _cursorPosition.Index + TextEditShared.EndWordPosition(runes.GetEnumerator());
 
                 return new CursorPos(pos, LineBreakBias.Bottom);
             }

--- a/Robust.Client/UserInterface/Controls/TextEditShared.cs
+++ b/Robust.Client/UserInterface/Controls/TextEditShared.cs
@@ -17,27 +17,29 @@ internal static class TextEditShared
     // Functions for calculating next positions when doing word-bound cursor movement (ctrl+left/right).
     //
 
-    internal static int NextWordPosition(string str, int cursor)
+    internal static int EndWordPosition(string str, int cursor)
     {
-        return cursor + NextWordPosition(new StringEnumerateHelpers.SubstringRuneEnumerator(str, cursor));
+        return cursor + EndWordPosition(new StringEnumerateHelpers.SubstringRuneEnumerator(str, cursor));
     }
 
-    internal static int NextWordPosition<T>(T runes) where T : IEnumerator<Rune>
+    internal static int EndWordPosition<T>(T runes) where T : IEnumerator<Rune>
     {
         if (!runes.MoveNext())
             return 0;
 
-        var charClass = GetCharClass(runes.Current);
-
         var i = 0;
+        if (!IterForward(CharClass.Whitespace))
+            return i;
 
+        var charClass = GetCharClass(runes.Current);
         IterForward(charClass);
-        IterForward(CharClass.Whitespace);
 
         return i;
 
-        void IterForward(CharClass cClass)
+        bool IterForward(CharClass cClass)
         {
+            var hasNext = true;
+
             do
             {
                 var rune = runes.Current;
@@ -46,7 +48,11 @@ internal static class TextEditShared
                     break;
 
                 i += rune.Utf16SequenceLength;
-            } while (runes.MoveNext());
+
+                hasNext = runes.MoveNext();
+            } while (hasNext);
+
+            return hasNext;
         }
     }
 

--- a/Robust.Client/UserInterface/CustomControls/DebugConsole.xaml.Completions.cs
+++ b/Robust.Client/UserInterface/CustomControls/DebugConsole.xaml.Completions.cs
@@ -43,7 +43,7 @@ public sealed partial class DebugConsole
     {
         CommandBar.OnTextTyped += CommandBarOnOnTextTyped;
         CommandBar.OnFocusExit += CommandBarOnOnFocusExit;
-        CommandBar.OnBackspace += CommandBarOnOnBackspace;
+        CommandBar.OnTextRemoved += CommandBarOnTextRemoved;
     }
 
     private void CommandBarOnOnFocusExit(LineEdit.LineEditEventArgs obj)
@@ -56,7 +56,7 @@ public sealed partial class DebugConsole
         TypeUpdateCompletions(true);
     }
 
-    private void CommandBarOnOnBackspace(LineEdit.LineEditBackspaceEventArgs eventArgs)
+    private void CommandBarOnTextRemoved(LineEdit.LineEditTextRemovedEventArgs eventArgs)
     {
         if (eventArgs.OldCursorPosition == 0 || eventArgs.OldSelectionStart != eventArgs.OldCursorPosition)
         {

--- a/Robust.Shared/Input/KeyFunctions.cs
+++ b/Robust.Shared/Input/KeyFunctions.cs
@@ -65,6 +65,9 @@ namespace Robust.Shared.Input
         public static readonly BoundKeyFunction TextCursorSelectEnd = "TextCursorSelectEnd";
 
         public static readonly BoundKeyFunction TextBackspace = "TextBackspace";
+        public static readonly BoundKeyFunction TextDelete = "TextDelete";
+        public static readonly BoundKeyFunction TextWordBackspace = "TextWordBackspace";
+        public static readonly BoundKeyFunction TextWordDelete = "TextWordDelete";
         public static readonly BoundKeyFunction TextNewline = "TextNewline";
         public static readonly BoundKeyFunction TextSubmit = "TextSubmit";
         public static readonly BoundKeyFunction TextSelectAll = "TextSelectAll";
@@ -75,7 +78,6 @@ namespace Robust.Shared.Input
         public static readonly BoundKeyFunction TextHistoryNext = "TextHistoryNext";
         public static readonly BoundKeyFunction TextReleaseFocus = "TextReleaseFocus";
         public static readonly BoundKeyFunction TextScrollToBottom = "TextScrollToBottom";
-        public static readonly BoundKeyFunction TextDelete = "TextDelete";
         public static readonly BoundKeyFunction TextTabComplete = "TextTabComplete";
         public static readonly BoundKeyFunction TextCompleteNext = "TextCompleteNext";
         public static readonly BoundKeyFunction TextCompletePrev = "TextCompletePrev";

--- a/Robust.UnitTesting/Client/UserInterface/Controls/LineEditTest.cs
+++ b/Robust.UnitTesting/Client/UserInterface/Controls/LineEditTest.cs
@@ -139,14 +139,14 @@ namespace Robust.UnitTesting.Client.UserInterface.Controls
 
         [Test]
         // RIGHT
-        [TestCase("Foo Bar Baz", false, 0, ExpectedResult = 4)]
+        [TestCase("Foo Bar Baz", false, 0, ExpectedResult = 3)]
         [TestCase("Foo Bar Baz", false, 8, ExpectedResult = 11)]
         [TestCase("Foo[Bar[Baz", false, 0, ExpectedResult = 3)]
         [TestCase("Foo[Bar[Baz", false, 3, ExpectedResult = 4)]
         [TestCase("Foo^Bar^Baz", false, 0, ExpectedResult = 3)]
         [TestCase("Foo^Bar^Baz", false, 3, ExpectedResult = 5)]
         [TestCase("Foo^^^Bar^Baz", false, 3, ExpectedResult = 9)]
-        [TestCase("^^^ ^^^", false, 0, ExpectedResult = 7)]
+        [TestCase("^^^ ^^^", false, 0, ExpectedResult = 6)]
         [TestCase("^^^ ^^^", false, 7, ExpectedResult = 13)]
         // LEFT
         [TestCase("Foo Bar Baz", true, 4, ExpectedResult = 0)]

--- a/Robust.UnitTesting/Client/UserInterface/Controls/TextEditSharedTest.cs
+++ b/Robust.UnitTesting/Client/UserInterface/Controls/TextEditSharedTest.cs
@@ -41,28 +41,28 @@ internal sealed class TextEditSharedTest
     [Test]
     // @formatter:off
     [TestCase("foo bar baz",   11, ExpectedResult = 11)]
-    [TestCase("foo bar baz",   0,  ExpectedResult = 4 )]
-    [TestCase("foo bar baz",   1,  ExpectedResult = 4 )]
-    [TestCase("foo bar baz",   3,  ExpectedResult = 4 )]
-    [TestCase("foo bar baz",   4,  ExpectedResult = 8 )]
-    [TestCase("foo bar baz",   5,  ExpectedResult = 8 )]
-    [TestCase("Foo Bar Baz",   0,  ExpectedResult = 4 )]
+    [TestCase("foo bar baz",   0,  ExpectedResult = 3 )]
+    [TestCase("foo bar baz",   1,  ExpectedResult = 3 )]
+    [TestCase("foo bar baz",   3,  ExpectedResult = 7 )]
+    [TestCase("foo bar baz",   4,  ExpectedResult = 7 )]
+    [TestCase("foo bar baz",   5,  ExpectedResult = 7 )]
+    [TestCase("Foo Bar Baz",   0,  ExpectedResult = 3 )]
     [TestCase("Foo Bar Baz",   8,  ExpectedResult = 11)]
-    [TestCase("foo +bar baz",  0,  ExpectedResult = 4 )]
+    [TestCase("foo +bar baz",  0,  ExpectedResult = 3 )]
     [TestCase("foo +bar baz",  4,  ExpectedResult = 5 )]
     [TestCase("Foo[Bar[Baz",   0,  ExpectedResult = 3 )]
     [TestCase("Foo[Bar[Baz",   3,  ExpectedResult = 4 )]
     [TestCase("Foo^Bar^Baz",   0,  ExpectedResult = 3 )]
     [TestCase("Foo^Bar^Baz",   3,  ExpectedResult = 5 )]
     [TestCase("Foo^^^Bar^Baz", 3,  ExpectedResult = 9 )]
-    [TestCase("^^^ ^^^",       0,  ExpectedResult = 7 )]
+    [TestCase("^^^ ^^^",       0,  ExpectedResult = 6 )]
     [TestCase("^^^ ^^^",       7,  ExpectedResult = 13)]
     // @formatter:on
-    public int TestNextWordPosition(string str, int cursor)
+    public int TestEndWordPosition(string str, int cursor)
     {
         // For my sanity.
         str = str.Replace("^", "👏");
 
-        return TextEditShared.NextWordPosition(str, cursor);
+        return TextEditShared.EndWordPosition(str, cursor);
     }
 }


### PR DESCRIPTION
Requires #3724. Makes it possible to remove a word at a time, just like Ctrl+Backspace and Ctrl+Delete do in almost all programs.