### PR TITLE
Small state/pvs cleanup.

### DIFF
--- a/Robust.Client/GameStates/NetEntityOverlay.cs
+++ b/Robust.Client/GameStates/NetEntityOverlay.cs
@@ -217,16 +217,5 @@ namespace Robust.Client.GameStates
                 }
             }
         }
-
-        private sealed class NetShowGraphCommand : LocalizedCommands
-        {
-            // Yeah commands should be localized, but I'm lazy and this is really just a debug command.
-            public override string Command => "net_refresh";
-
-            public override void Execute(IConsoleShell shell, string argStr, string[] args)
-            {
-                IoCManager.Resolve<IClientGameStateManager>().RequestFullState();
-            }
-        }
     }
 }

--- a/Robust.Client/Player/LocalPlayer.cs
+++ b/Robust.Client/Player/LocalPlayer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using Robust.Client.GameObjects;
 using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
@@ -65,10 +64,17 @@ namespace Robust.Client.Player
             // Detach and cleanup first
             DetachEntity();
 
+            var entMan = IoCManager.Resolve<IEntityManager>();
+
+            if (!entMan.EntityExists(entity))
+            {
+                Logger.Error($"Attempting to attach player to non-existent entity {entity}!");
+                return;
+            }
+
             ControlledEntity = entity;
             InternalSession.AttachedEntity = entity;
 
-            var entMan = IoCManager.Resolve<IEntityManager>();
 
             if (!entMan.TryGetComponent<EyeComponent?>(entity, out var eye))
             {

--- a/Robust.Server/GameStates/PVSSystem.Dirty.cs
+++ b/Robust.Server/GameStates/PVSSystem.Dirty.cs
@@ -55,14 +55,6 @@ namespace Robust.Server.GameStates
                 _dirtyEntities[_currentIndex].Add(uid);
         }
 
-        private void CleanupDirty(IEnumerable<IPlayerSession> sessions)
-        {
-            // Just in case we desync somehow
-            _currentIndex = ((int) _gameTiming.CurTick.Value + 1) % DirtyBufferSize;
-            _addEntities[_currentIndex].Clear();
-            _dirtyEntities[_currentIndex].Clear();
-        }
-
         private bool TryGetTick(GameTick tick, [NotNullWhen(true)] out HashSet<EntityUid>? addEntities, [NotNullWhen(true)] out HashSet<EntityUid>? dirtyEntities)
         {
             var currentTick = _gameTiming.CurTick;

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -245,6 +245,7 @@ internal sealed partial class PVSSystem : EntitySystem
 
     private void SetPvs(bool value)
     {
+        SeenAllEnts.Clear();
         CullingEnabled = value;
     }
 
@@ -256,23 +257,20 @@ internal sealed partial class PVSSystem : EntitySystem
         }
     }
 
-    public void Cleanup(IEnumerable<IPlayerSession> sessions)
+    public void CleanupDirty(IEnumerable<IPlayerSession> sessions)
     {
-        var playerSessions = sessions.ToArray();
-
         if (!CullingEnabled)
         {
-            foreach (var player in playerSessions)
+            SeenAllEnts.Clear();
+            foreach (var player in sessions)
             {
                 SeenAllEnts.Add(player);
             }
         }
-        else
-        {
-            SeenAllEnts.Clear();
-        }
 
-        CleanupDirty(playerSessions);
+        _currentIndex = ((int)_gameTiming.CurTick.Value + 1) % DirtyBufferSize;
+        _addEntities[_currentIndex].Clear();
+        _dirtyEntities[_currentIndex].Clear();
 
         foreach (var collection in _pvsCollections)
         {
@@ -1026,91 +1024,80 @@ internal sealed partial class PVSSystem : EntitySystem
     /// </summary>
     public (List<EntityState>?, List<EntityUid>?, List<EntityUid>?, GameTick fromTick) GetAllEntityStates(ICommonSession player, GameTick fromTick, GameTick toTick)
     {
-        var deletions = _entityPvsCollection.GetDeletedIndices(fromTick);
-        // no point sending an empty collection
-        if (deletions.Count == 0) deletions = default;
-
-        var stateEntities = new List<EntityState>();
+        List<EntityState>? stateEntities;
         var seenEnts = new HashSet<EntityUid>();
-        var slowPath = false;
-        var metadataQuery = EntityManager.GetEntityQuery<MetaDataComponent>();
+        var metaQuery = EntityManager.GetEntityQuery<MetaDataComponent>();
+        List<(HashSet<EntityUid>, HashSet<EntityUid>)>? tickData = null;
 
         if (!SeenAllEnts.Contains(player))
         {
             // Give them E V E R Y T H I N G
-            stateEntities = new List<EntityState>(EntityManager.EntityCount);
-
-            // This is the same as iterating every existing entity.
-            foreach (var md in EntityManager.EntityQuery<MetaDataComponent>(true))
-            {
-                DebugTools.Assert(md.EntityLifeStage >= EntityLifeStage.Initialized);
-                stateEntities.Add(GetEntityState(player, md.Owner, GameTick.Zero, md));
-            }
-
-            return (stateEntities.Count == 0 ? default : stateEntities, deletions, null, fromTick);
+            fromTick = GameTick.Zero;
         }
-
-        // Just get the relevant entities that have been dirtied
-        // This should be extremely fast.
-        if (!slowPath)
+        else
         {
+            tickData = new();
             for (var i = fromTick.Value; i <= toTick.Value; i++)
             {
-                // Fallback to dumping every entity on them.
                 var tick = new GameTick(i);
                 if (!TryGetTick(tick, out var add, out var dirty))
                 {
-                    slowPath = true;
+                    // Fall back to dumping every entity on them.
+                    tickData = null;
                     break;
                 }
 
+                tickData.Add((add, dirty));
+            }
+        }
+
+        if (tickData == null)
+        {
+            stateEntities = new List<EntityState>(EntityManager.EntityCount);
+            foreach (var md in EntityManager.EntityQuery<MetaDataComponent>(true))
+            {
+                DebugTools.Assert(md.EntityLifeStage >= EntityLifeStage.Initialized);
+                if (md.EntityLastModifiedTick > fromTick)
+                    stateEntities.Add(GetEntityState(player, md.Owner, fromTick, md));
+            }
+        }
+        else
+        {
+            stateEntities = new();
+            // Just get the relevant entities that have been dirtied
+            // This should be extremely fast.
+            foreach (var (add, dirty) in tickData)
+            {
                 foreach (var uid in add)
                 {
-                    if (!seenEnts.Add(uid)) continue;
-                    // This is essentially the same as IEntityManager.EntityExists, but returning MetaDataComponent.
-                    if (!metadataQuery.TryGetComponent(uid, out var md)) continue;
+                    if (!seenEnts.Add(uid) || !metaQuery.TryGetComponent(uid, out var md))
+                        continue;
 
                     DebugTools.Assert(md.EntityLifeStage >= EntityLifeStage.Initialized);
-
                     if (md.EntityLastModifiedTick > fromTick)
-                        stateEntities.Add(GetEntityState(player, uid, GameTick.Zero, md));
+                        stateEntities.Add(GetEntityState(player, uid, fromTick, md));
                 }
 
                 foreach (var uid in dirty)
                 {
                     DebugTools.Assert(!add.Contains(uid));
-
-                    if (!seenEnts.Add(uid)) continue;
-                    if (!metadataQuery.TryGetComponent(uid, out var md)) continue;
+                    if (!seenEnts.Add(uid) || !metaQuery.TryGetComponent(uid, out var md))
+                        continue;
 
                     DebugTools.Assert(md.EntityLifeStage >= EntityLifeStage.Initialized);
-
                     if (md.EntityLastModifiedTick > fromTick)
                         stateEntities.Add(GetEntityState(player, uid, fromTick, md));
                 }
             }
         }
 
-        if (!slowPath)
-        {
-            if (stateEntities.Count == 0) stateEntities = default;
+        List<EntityUid>? deletions = _entityPvsCollection.GetDeletedIndices(fromTick);
 
-            return (stateEntities, deletions, null, fromTick);
-        }
+        if (deletions.Count == 0)
+            deletions = null;
 
-        stateEntities = new List<EntityState>(EntityManager.EntityCount);
-
-        // This is the same as iterating every existing entity.
-        foreach (var md in EntityManager.EntityQuery<MetaDataComponent>(true))
-        {
-            DebugTools.Assert(md.EntityLifeStage >= EntityLifeStage.Initialized);
-
-            if (md.EntityLastModifiedTick >= fromTick)
-                stateEntities.Add(GetEntityState(player, md.Owner, fromTick, md));
-        }
-
-        // no point sending an empty collection
-        if (stateEntities.Count == 0) stateEntities = default;
+        if (stateEntities.Count == 0)
+            stateEntities = null;
 
         return (stateEntities, deletions, null, fromTick);
     }

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -168,7 +168,7 @@ namespace Robust.Server.GameStates
                 // Prevent deletions piling up if we have no clients.
                 _pvs.CullDeletionHistory(GameTick.MaxValue);
                 _mapManager.CullDeletionHistory(GameTick.MaxValue);
-                _pvs.Cleanup(_playerManager.ServerSessions);
+                _pvs.CleanupDirty(Enumerable.Empty<IPlayerSession>());
                 return;
             }
 
@@ -226,7 +226,7 @@ namespace Robust.Server.GameStates
             Parallel.For(
                 0, players.Length,
                 new ParallelOptions { MaxDegreeOfParallelism = _parallelMgr.ParallelProcessCount },
-                () => _threadResourcesPool.Get(),
+                _threadResourcesPool.Get,
                 (i, _, resource) =>
                 {
                     try
@@ -239,7 +239,7 @@ namespace Robust.Server.GameStates
                     }
                     return resource;
                 },
-                resource => _threadResourcesPool.Return(resource)
+                _threadResourcesPool.Return
             );
 
             void SendStateUpdate(int sessionIndex, PvsThreadResources resources)
@@ -302,7 +302,7 @@ namespace Robust.Server.GameStates
 
             if (_pvs.CullingEnabled)
                 _pvs.ReturnToPool(playerChunks);
-            _pvs.Cleanup(_playerManager.ServerSessions);
+            _pvs.CleanupDirty(_playerManager.ServerSessions);
             var oldestAck = new GameTick(oldestAckValue);
 
             // keep the deletion history buffers clean


### PR DESCRIPTION
This PR has some miscellaneous changes that I made while unsuccessfully attempting to fix the current test heisenbug.
- Removes `net_refresh` command (duplicate of `fullstatereset`)
- Added proper error log to AttachEntity(), so the heisenbug error is slightly clearer.
- Cleaned up `PVSSystem.GetAllEntityStates()` a bit
  - Fixed a possible bug if pvs is disabled & some packets get dropped while an entity is created.
  - Its still pretty shit and will probably perform terribly if PVS is ever disabled with a sizeable player count. 