### PR TITLE
Implements blend modes

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -243,6 +243,8 @@ namespace Robust.Client.Graphics.Clyde
 
             program.SetUniformMaybe(UniITexturePixelSize, Vector2.One / loadedTexture.Size);
 
+            SetBlendFunc(loaded.BlendMode);
+
             var primitiveType = MapPrimitiveType(command.PrimitiveType);
             if (command.Indexed)
             {
@@ -255,6 +257,9 @@ namespace Robust.Client.Graphics.Clyde
                 GL.DrawArrays(primitiveType, command.StartIndex, command.Count);
                 CheckGlError();
             }
+
+            ResetBlendFunc();
+            GL.BlendEquation(BlendEquationMode.FuncAdd);
 
             _debugStats.LastGLDrawCalls += 1;
         }
@@ -867,6 +872,23 @@ namespace Robust.Client.Graphics.Clyde
             _queuedShader = _defaultShader.Handle;
 
             GL.Viewport(0, 0, _mainWindow!.FramebufferSize.X, _mainWindow!.FramebufferSize.Y);
+        }
+
+        private void SetBlendFunc(ShaderBlendMode blend)
+        {
+            switch (blend)
+                {
+                    case ShaderBlendMode.Add:
+                        GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.DstAlpha);
+                        break;
+                    case ShaderBlendMode.Subtract:
+                        GL.BlendFuncSeparate(BlendingFactorSrc.SrcAlpha, BlendingFactorDest.DstAlpha, BlendingFactorSrc.Zero, BlendingFactorDest.DstAlpha);
+                        GL.BlendEquation(BlendEquationMode.FuncReverseSubtract);
+                        break;
+                    case ShaderBlendMode.Multiply:
+                        GL.BlendFunc(BlendingFactor.DstColor, BlendingFactor.OneMinusSrcAlpha);
+                        break;
+                }
         }
 
         private void ResetBlendFunc()

--- a/Robust.Client/Graphics/Shaders/ShaderParser.cs
+++ b/Robust.Client/Graphics/Shaders/ShaderParser.cs
@@ -90,7 +90,7 @@ namespace Robust.Client.Graphics
                 }
                 else if (word.Word == "blend_mode")
                 {
-                    if (lightMode != null)
+                    if (blendMode != null)
                     {
                         throw new ShaderParseException("Already specified 'blend_mode' before!");
                     }


### PR DESCRIPTION
Title! This morning, we were wanting to whip up a half-serious shitpost (notably, making blood multiplicative, similar to what's currently present on Citadel Main), but we noticed that both RT and SS14 lack blend modes. We thought blend modes simply weren't present at all until it was pointed out to us that the vars are already there at the engine level, just unused! Needless to say, we were a little disappointed to see that they were unimplemented.

So this PR implements blend modes, which we imagine would be coincidentally useful for the current wizardry going on over at OpenDream. A strong alternative to this PR would be to instead allow shader prototypes to manually define args for `BlendFuncSeparate()` and `BlendEquation()`, which would be far more flexible, at the cost of making it extremely trivial to completely break the rendering (as a bad `BlendFunc()` can cause the screen to black out, produce full-screen flashing lights, and other artifacts.)

This PR implements all blend modes for which values exist. We've made no attempt to implement the `Mix` or `None` modes, as we have no idea what the differentiation between the two is supposed to be in theory (same situation as Byond's `BLEND_DEFAULT` vs `BLEND_OVERLAY`, we assume?).  For the implementation, we've modeled the blend modes after the equivalents available within DX9 (a rendering API we're far more familiar with), which coincidentally are the same blending methods used for Byond's blend modes.

Since pictures speak louder than words, here's an image showing all of the blend modes:
![image](https://user-images.githubusercontent.com/6356337/215243226-a56790e7-0be2-4f2d-a99a-d754544ada4d.png)
(Shader properties from top left to bottom right: Unlit, multiplicative+unlit, lit, additive+unlit, subtractive+unlit)

As a bonus, this PR also makes a one-line fix to allow shader prototypes to both be unlit *and* have a blending mode defined! ooaaa

Closes #3739 