### PR TITLE
VV invoke/paths rejig

### DIFF
--- a/Robust.Client/ViewVariables/ClientViewVariablesManager.Domains.cs
+++ b/Robust.Client/ViewVariables/ClientViewVariablesManager.Domains.cs
@@ -19,7 +19,7 @@ internal sealed partial class ClientViewVariablesManager
             : null, segments);
     }
 
-    private IEnumerable<string>? ListGuiHoverPaths(string[] segments)
+    private IEnumerable<string>? ListGuiHoverPaths(string[] segments, VVListPathOptions options)
     {
         return null;
     }

--- a/Robust.Client/ViewVariables/ViewVariablesCommand.cs
+++ b/Robust.Client/ViewVariables/ViewVariablesCommand.cs
@@ -16,6 +16,7 @@ namespace Robust.Client.ViewVariables
         [Dependency] private readonly IEntityManager _entities = default!;
 
         public override string Command => "vv";
+        protected override VVAccess RequiredAccess => VVAccess.ReadOnly;
 
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {

--- a/Robust.Server/ViewVariables/ServerViewVariablesManager.Domains.cs
+++ b/Robust.Server/ViewVariables/ServerViewVariablesManager.Domains.cs
@@ -47,7 +47,7 @@ internal sealed partial class ServerViewVariablesManager
         return EmptyResolve;
     }
 
-    private IEnumerable<string>? ListPlayerPaths(string[] segments)
+    private IEnumerable<string>? ListPlayerPaths(string[] segments, VVListPathOptions options)
     {
         if (segments.Length > 1)
             return null;

--- a/Robust.Server/ViewVariables/ServerViewVariablesManager.cs
+++ b/Robust.Server/ViewVariables/ServerViewVariablesManager.cs
@@ -212,7 +212,7 @@ namespace Robust.Server.ViewVariables
                 }
                 case ViewVariablesPathSelector paSelector:
                 {
-                    if (ResolvePath(paSelector.Path)?.Get() is not {} obj)
+                    if (!TryReadPath(paSelector.Path, out var res, out _) || res is not {} obj)
                     {
                         Deny(ViewVariablesResponseCode.NoObject);
                         return;

--- a/Robust.Server/ViewVariables/Traits/ViewVariablesTraitMembers.cs
+++ b/Robust.Server/ViewVariables/Traits/ViewVariablesTraitMembers.cs
@@ -41,7 +41,7 @@ namespace Robust.Server.ViewVariables.Traits
 
                     members.Add((new MemberData
                     {
-                        Editable = access == VVAccess.ReadWrite,
+                        Editable = (access & VVAccess.ReadWrite) == VVAccess.ReadWrite,
                         Name = property.Name,
                         Type = property.PropertyType.AssemblyQualifiedName,
                         TypePretty = PrettyPrint.PrintUserFacingTypeShort(property.PropertyType, 2),
@@ -60,7 +60,7 @@ namespace Robust.Server.ViewVariables.Traits
 
                     members.Add((new MemberData
                     {
-                        Editable = access == VVAccess.ReadWrite,
+                        Editable = (access & VVAccess.ReadWrite) == VVAccess.ReadWrite,
                         Name = field.Name,
                         Type = field.FieldType.AssemblyQualifiedName,
                         TypePretty = PrettyPrint.PrintUserFacingTypeShort(field.FieldType, 2),

--- a/Robust.Shared/Utility/TypeHelpers.cs
+++ b/Robust.Shared/Utility/TypeHelpers.cs
@@ -12,20 +12,31 @@ namespace Robust.Shared.Utility
         /// <summary>
         ///     Returns absolutely all fields, privates, readonlies, and ones from parents.
         /// </summary>
-        public static IEnumerable<FieldInfo> GetAllFields(this Type t)
+        public static IEnumerable<FieldInfo> GetAllFields(this Type t,
+            BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public)
         {
             // We need to fetch the entire class hierarchy and SelectMany(),
             // Because BindingFlags.FlattenHierarchy doesn't read privates,
             // Even when you pass BindingFlags.NonPublic.
+            flags |= BindingFlags.DeclaredOnly;
             foreach (var p in GetClassHierarchy(t))
             {
-                foreach (var field in p.GetFields(
-                    BindingFlags.NonPublic |
-                    BindingFlags.Instance |
-                    BindingFlags.DeclaredOnly |
-                    BindingFlags.Public))
+                foreach (var field in p.GetFields(flags))
                 {
                     yield return field;
+                }
+            }
+        }
+
+        public static IEnumerable<MemberInfo> GetAllMembers(this Type t,
+            BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public)
+        {
+            flags |= BindingFlags.DeclaredOnly;
+            foreach (var p in GetClassHierarchy(t))
+            {
+                foreach (var member in p.GetMembers(flags))
+                {
+                    yield return member;
                 }
             }
         }

--- a/Robust.Shared/ViewVariables/Commands/ViewVariablesWriteCommand.cs
+++ b/Robust.Shared/ViewVariables/Commands/ViewVariablesWriteCommand.cs
@@ -5,8 +5,9 @@ namespace Robust.Shared.ViewVariables.Commands;
 public sealed class ViewVariablesWriteCommand : ViewVariablesBaseCommand
 {
     public override string Command => "vvwrite";
+    protected override VVAccess RequiredAccess => VVAccess.Write;
 
-    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    public async override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
         if (args.Length != 2)
         {
@@ -21,7 +22,12 @@ public sealed class ViewVariablesWriteCommand : ViewVariablesBaseCommand
         {
             if (!path.StartsWith("/c"))
             {
-                _vvm.WriteRemotePath(path, value);
+                var res = await _vvm.WriteRemotePath(path, value);
+                if (res.Item2 == ViewVariablesResponseCode.Ok)
+                    shell.WriteLine(res.Item1 ?? "null");
+                else
+                    shell.WriteError($"Failed to write. Error code: {res.Item2}. Error: {res.Item1}");
+
                 return;
             }
 
@@ -29,6 +35,10 @@ public sealed class ViewVariablesWriteCommand : ViewVariablesBaseCommand
             path = path[2..];
         }
 
-        _vvm.WritePath(path, value);
+        if (_vvm.TryWritePath(path, value, out var error))
+            shell.WriteLine("Successfully written.");
+        else
+            shell.WriteError($"Failed to write. Error: {error}");
+
     }
 }

--- a/Robust.Shared/ViewVariables/IViewVariablesManager.cs
+++ b/Robust.Shared/ViewVariables/IViewVariablesManager.cs
@@ -51,15 +51,15 @@ public interface IViewVariablesManager
 
     /// <param name="path">The path to be resolved.</param>
     /// <returns>An object representing the path, or null if the path couldn't be resolved.</returns>
-    ViewVariablesPath? ResolvePath(string path);
-    object? ReadPath(string path);
-    string? ReadPathSerialized(string path);
-    void WritePath(string path, string value);
-    object? InvokePath(string path, string arguments);
+    bool TryResolvePath(string path, out ViewVariablesPath? result, out string? error);
+    bool TryReadPath(string path, out object? result, out string? error);
+    bool TryReadPathSerialized(string path, out string? result, out string? error);
+    bool TryWritePath(string path, string value, out string? error);
+    bool TryInvokePath(string path, string arguments, out object? result, out string? error);
     IEnumerable<string> ListPath(string path, VVListPathOptions options);
 
-    Task<string?> ReadRemotePath(string path, ICommonSession? session = null);
-    Task WriteRemotePath(string path, string value, ICommonSession? session = null);
-    Task<string?> InvokeRemotePath(string path, string arguments, ICommonSession? session = null);
+    Task<(string?, ViewVariablesResponseCode)> ReadRemotePath(string path, ICommonSession? session = null);
+    Task<(string?, ViewVariablesResponseCode)> WriteRemotePath(string path, string value, ICommonSession? session = null);
+    Task<(string?, ViewVariablesResponseCode)> InvokeRemotePath(string path, string arguments, ICommonSession? session = null);
     Task<IEnumerable<string>> ListRemotePath(string path, VVListPathOptions options, ICommonSession? session = null);
 }

--- a/Robust.Shared/ViewVariables/ViewVariablesAttribute.cs
+++ b/Robust.Shared/ViewVariables/ViewVariablesAttribute.cs
@@ -1,14 +1,20 @@
 using System;
 using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.ViewVariables
 {
     /// <summary>
     ///     Attribute to make a property or field accessible to VV.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method)]
-    public sealed class ViewVariablesAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    [Virtual]
+    public class ViewVariablesAttribute : Attribute
     {
+        /// <summary>
+        ///     These access permissions control whether a field or property is readonly or writable. Methods are always
+        ///     invokable.
+        /// </summary>
         public readonly VVAccess Access = VVAccess.ReadOnly;
 
         public ViewVariablesAttribute()
@@ -22,17 +28,25 @@ namespace Robust.Shared.ViewVariables
         }
     }
 
-    [Serializable, NetSerializable]
+    /// <summary>
+    ///     Attribute to make a method invokable via VV.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class VVInvokableAttribute : ViewVariablesAttribute
+    {
+        public VVInvokableAttribute() : base(VVAccess.Execute)
+        {
+        }
+    }
+
+    [Flags, Serializable, NetSerializable]
     public enum VVAccess : byte
     {
-        /// <summary>
-        ///     This property can only be read, not written.
-        /// </summary>
-        ReadOnly = 0,
+        ReadOnly =  1 << 0,
+        Write =     1 << 1,
+        Execute =   1 << 2,
 
-        /// <summary>
-        ///     This property is read and writable.
-        /// </summary>
-        ReadWrite = 1,
+        ReadWrite = ReadOnly | Write,
+        All = ReadWrite | Execute
     }
 }

--- a/Robust.Shared/ViewVariables/ViewVariablesManager.Domains.cs
+++ b/Robust.Shared/ViewVariables/ViewVariablesManager.Domains.cs
@@ -11,7 +11,7 @@ using Robust.Shared.Serialization.Manager.Attributes;
 namespace Robust.Shared.ViewVariables;
 
 public delegate (ViewVariablesPath? path, string[] segments) DomainResolveObject(string path);
-public delegate IEnumerable<string>? DomainListPaths(string[] segments);
+public delegate IEnumerable<string>? DomainListPaths(string[] segments, VVListPathOptions options);
 
 internal abstract partial class ViewVariablesManager
 {
@@ -62,7 +62,7 @@ internal abstract partial class ViewVariablesManager
             : EmptyResolve;
     }
 
-    private IEnumerable<string>? ListIoCPaths(string[] segments)
+    private IEnumerable<string>? ListIoCPaths(string[] segments, VVListPathOptions options)
     {
         if (segments.Length > 1 || IoCManager.Instance is not {} deps)
             return null;
@@ -96,7 +96,7 @@ internal abstract partial class ViewVariablesManager
         return (new ViewVariablesInstancePath(uid), segments[1..]);
     }
 
-    private IEnumerable<string>? ListEntityPaths(string[] segments)
+    private IEnumerable<string>? ListEntityPaths(string[] segments, VVListPathOptions options)
     {
         if (segments.Length > 1)
             return null;
@@ -136,7 +136,7 @@ internal abstract partial class ViewVariablesManager
             : EmptyResolve;
     }
 
-    private IEnumerable<string>? ListEntitySystemPaths(string[] segments)
+    private IEnumerable<string>? ListEntitySystemPaths(string[] segments, VVListPathOptions options)
     {
         if (segments.Length > 1)
             return null;
@@ -177,7 +177,7 @@ internal abstract partial class ViewVariablesManager
         return (new ViewVariablesInstancePath(prototype), segments[2..]);
     }
 
-    private IEnumerable<string>? ListPrototypePaths(string[] segments)
+    private IEnumerable<string>? ListPrototypePaths(string[] segments, VVListPathOptions options)
     {
         switch (segments.Length)
         {
@@ -223,7 +223,7 @@ internal abstract partial class ViewVariablesManager
         return (new ViewVariablesInstancePath(obj), segments[1..]);
     }
 
-    private IEnumerable<string>? ListStoredObjectPaths(string[] segments)
+    private IEnumerable<string>? ListStoredObjectPaths(string[] segments, VVListPathOptions options)
     {
         if (segments.Length > 1)
             return null;
@@ -246,7 +246,7 @@ internal abstract partial class ViewVariablesManager
         return (new ViewVariablesInstancePath(new VvTest()), segments);
     }
 
-    private IEnumerable<string>? ListVvTestObjectPaths(string[] segments)
+    private IEnumerable<string>? ListVvTestObjectPaths(string[] segments, VVListPathOptions options)
     {
         return null;
     }

--- a/Robust.Shared/ViewVariables/ViewVariablesManager.TypeHandlers.cs
+++ b/Robust.Shared/ViewVariables/ViewVariablesManager.TypeHandlers.cs
@@ -37,7 +37,7 @@ internal abstract partial class ViewVariablesManager
         return new ViewVariablesComponentPath(component, uid);
     }
 
-    private IEnumerable<string> EntityComponentList(EntityUid uid)
+    private IEnumerable<string> EntityComponentList(EntityUid uid, VVListPathOptions options)
     {
         return _entMan.GetComponents(uid)
             .Select(component => _compFact.GetComponentName(component.GetType()));

--- a/Robust.Shared/ViewVariables/ViewVariablesResponseCode.cs
+++ b/Robust.Shared/ViewVariables/ViewVariablesResponseCode.cs
@@ -21,4 +21,9 @@ public enum ViewVariablesResponseCode : ushort
     ///     Object pointing to by the selector does not exist.
     /// </summary>
     NoObject = 404,
+
+    /// <summary>
+    ///     Failed to parse arguments.
+    /// </summary>
+    ParseFailure = 405,
 }

--- a/Robust.Shared/ViewVariables/ViewVariablesSerializationContext.cs
+++ b/Robust.Shared/ViewVariables/ViewVariablesSerializationContext.cs
@@ -1,0 +1,47 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+
+namespace Robust.Shared.ViewVariables;
+
+internal sealed class ViewVariablesSerializationContext : ISerializationContext, ITypeSerializer<EntityUid, ValueDataNode>
+{
+    public SerializationManager.SerializerProvider SerializerProvider { get; } = new();
+
+    public ViewVariablesSerializationContext()
+    {
+        SerializerProvider.RegisterSerializer(this);
+    }
+
+    ValidationNode ITypeValidator<EntityUid, ValueDataNode>.Validate(ISerializationManager serializationManager,
+        ValueDataNode node, IDependencyCollection dependencies, ISerializationContext? context)
+    {
+        return new ValidatedValueNode(node);
+    }
+
+    public DataNode Write(ISerializationManager serializationManager, EntityUid value,
+        IDependencyCollection dependencies, bool alwaysWrite = false,
+        ISerializationContext? context = null)
+    {
+        return new ValueDataNode(value.ToString());
+    }
+
+    EntityUid ITypeReader<EntityUid, ValueDataNode>.Read(ISerializationManager serializationManager,
+        ValueDataNode node,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context, ISerializationManager.InstantiationDelegate<EntityUid>? _)
+    {
+        if (node.Value == "invalid")
+        {
+            return EntityUid.Invalid;
+        }
+
+        return EntityUid.Parse(node.Value);
+    }
+}


### PR DESCRIPTION
There were a few things that bothered me with the new VV paths/commands and this PR tries to fix them, though I'm, not at all sure that I'm taking the best approach for each one.

Requires space-wizards/space-station-14/pull/13792

## Better filtering when listing paths

Currently vv-read/write/invoke console completion will return forbidden/invalid paths. I.e., vvinvoke will returns paths regardless of whether they are actually invokable. This PR fixes this by:
- Splitting `VVAccess` into read, write, and execute flags
- Making the invoke/read/write commands use the appropriate flags for `VVListPathOptions.MinimumAccess` (previously was always just `VVAccess.ReadOnly`)
- The reflection based paths just check the VV attributes's access to see if they satisfy `VVListPathOptions.MinimumAccess` 
- The `VVListPathOptions` are now also passed onto custom domain/type handlers so they can use that information however they like to restrict the returned paths.

In order to ensure that methods with a vv attribute are always executable (otherwise what is the point?) I decided to make the `ViewVariablesAttribute` no longer be applicable to methods, and there is now a separate `VVInvokableAttribute` that inherits from `ViewVariablesAttribute` but can only be applied to methods and has no access customization.

## inherited private members

Apparently `Type.GetMembers()` fails to return private members from an object's base class, which means that VV paths currently can't access any private methods defined in things like shared systems. This just makes the get-member functions use the same solution already used in old vv code (see `TypeHelper.GetAllFields()`).

## Error messages / feedback

Quite often if you execute an invalid vv command (e.g. failing to parse arguments for a vvinvoke) the command just returns "null" without any indication that something went wrong. This PR tries to fix that by:

- Making remote functions like `InvokeRemotePath()` return the `ViewVariablesResponseCode`.
- If the response code is not "Ok", the returned string is either null or some informative error message. 
- Replaced several `DoThing(path)` type functions with `bool TryDoThing(path, out result, out string? error)`
  - Maybe its better to just make this use exceptions & try-catches instead of having `out string?`s everywhere.
- The console commands print any errors returned by the vv functions. 

## EntityUid parsing

I CBF using `/entity/123` whenever I want to pass in an entity to a function, so I added a VV yaml serialization context. So now you can use either `123` or the old `/entity/123`.

## TODO
Other things that should probably be done:
- vvinvoke console completions should show a summary of argument & return types.
- On a related note: vvinvoke needs to be better at dealing with methods with the same name but different signatures.
- I guess the new errors should probably be localized?