### PR TITLE
Add capability to queue entity spawn for end of current update cycle

### DIFF
--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -67,6 +67,24 @@ namespace Robust.Shared.GameObjects
         void InitializeAndStartEntity(EntityUid entity, MapId? mapId = null);
 
         /// <summary>
+        /// Spawns an initialized entity at the default location, using the given prototype. Used in cases where adding an
+        /// entity immediately might cause an issue with an EntityQuery.
+        /// </summary>
+        /// <param name="protoName">The prototype to clone. If this is null, the entity won't have a prototype.</param>
+        /// <param name="coordinates"></param>
+        /// <returns>Newly created entity.</returns>
+        void QueueSpawnEntity(string? protoName, EntityCoordinates coordinates);
+
+        /// <summary>
+        /// Spawns an entity at a specific position. Used in cases where adding an entity immediately might cause an issue
+        /// with an EntityQuery.
+        /// </summary>
+        /// <param name="protoName"></param>
+        /// <param name="coordinates"></param>
+        /// <returns></returns>
+        void QueueSpawnEntity(string? protoName, MapCoordinates coordinates);
+
+        /// <summary>
         /// Spawns an initialized entity at the default location, using the given prototype.
         /// </summary>
         /// <param name="protoName">The prototype to clone. If this is null, the entity won't have a prototype.</param>


### PR DESCRIPTION
### **What?**
Adds a new method to entity manager that allows a request to spawn an entity rather than doing it immediately.

### **Why?**
This makes it possible to queue up a request to spawn entities while some system is in the middle of an `EntityQuery`. Otherwise, you might create an entity that modifies the `EntityQuery` while it's being iterated through, which is an exception.

It doesn't happen normally but you can reproduce the issue as follows:
1. Spawn Urist
2. Replace all of Urist's "Blood" with "BuzzochloricBees"
3. Attack Urist with a slashing weapon
4. During the Bloodstream system's update call it will query all entities with a bloodstream
5. Urist's bloodstream component will spill some bee/blood out, which spawns a new bee
6. The bee is an entity with a Bloodstream, so the collection has been modified while being iterated, which throws

### **How?**
This commit adds a `QueueSpawnEntity` method to `IEntityManager `which takes the same arguments as `SpawnEntity` but does not immediately return anything. Instead the `EntityManager` will wait until the end of the current update cycle to spawn the entities, similar to how deleting works. You can pass the coords for the entity's spawn location as MapCoords or EntityCoords and it will convert them. This doesn't match what `SpawnEntity` does exactly but it looks better to me. I might be wrong though.

I don't really know the codebase that well so I didn't want to make any changes to existing behavior. I think improvements could be made to the entity spawning system that would completely avoid the need for this sort of change, but I'm not confident enough to try them.