### PR TITLE
Revert "fix prototypemanager ignoring yaml files with the .yaml ending"

### DIFF
--- a/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
@@ -24,7 +24,7 @@ public partial class PrototypeManager
     {
         _hasEverBeenReloaded = true;
         var streams = Resources.ContentFindFiles(path)
-            .Where(filePath => filePath.Extension is "yml" or "yaml" && !filePath.Filename.StartsWith("."))
+            .Where(filePath => filePath.Extension == "yml" && !filePath.Filename.StartsWith("."))
             .ToArray();
 
         // Shuffle to avoid input data patterns causing uneven thread workloads.

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
@@ -84,7 +84,7 @@ public partial class PrototypeManager
     public Dictionary<string, HashSet<ErrorNode>> ValidateDirectory(ResourcePath path)
     {
         var streams = Resources.ContentFindFiles(path).ToList().AsParallel()
-            .Where(filePath => filePath.Extension is "yml" or "yaml" && !filePath.Filename.StartsWith("."));
+            .Where(filePath => filePath.Extension == "yml" && !filePath.Filename.StartsWith("."));
 
         var dict = new Dictionary<string, HashSet<ErrorNode>>();
         foreach (var resourcePath in streams)


### PR DESCRIPTION
This reverts commit 58c79b2c7bfe2cc54ceca3dcf81cf0754fcf7998.

Issues with this commit:
1. only updates *one* "yml" to also support "yaml". A cursory glance over the code for the string "yml" quickly shows 10+ cases that have been missed by the commit, in both prototype loading, prototype validation, tests, GitHub workflow configurations, texture loading, and probably something else I missed.
2. I mentioned on both Discord and GitHub this is not a good idea (as shown above). We should have a warning if .yaml is spotted anywhere, not allow loading it.