### PR TITLE
Modify light rendering cvars

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -36,6 +36,8 @@ END TEMPLATE-->
 ### Breaking changes
 
 * Undid `*.yaml` prototype loading change from previous version.
+* Several light related cvars have been renamed. E.g., "display.softshadows" is now "light.softshadows". 
+* The "display.lightmapdivider" integer cvar has been replaced with a float multiplier named "light.resolution_scale".
 
 ### New features
 
@@ -47,7 +49,7 @@ END TEMPLATE-->
 
 ### Other
 
-*None yet*
+* Added entity, occluder and shadow-casting light counts to the clyde debug panel.
 
 ### Internal
 

--- a/Robust.Client/Graphics/Clyde/Clyde.Debug.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Debug.cs
@@ -21,6 +21,9 @@ namespace Robust.Client.Graphics.Clyde
             public int LargestBatchVertices { get; set; }
             public int LargestBatchIndices { get; set; }
             public int TotalLights { get; set; }
+            public int ShadowLights { get; set; }
+            public int Occluders { get; set; }
+            public int Entities { get; set; }
 
             public void Reset()
             {
@@ -30,6 +33,9 @@ namespace Robust.Client.Graphics.Clyde
                 LargestBatchVertices = 0;
                 LargestBatchIndices = 0;
                 TotalLights = 0;
+                ShadowLights = 0;
+                Occluders = 0;
+                Entities = 0;
             }
         }
     }

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -112,6 +112,8 @@ namespace Robust.Client.Graphics.Clyde
                 _prof.WriteValue("Max Batch Verts", ProfData.Int32(_debugStats.LargestBatchVertices));
                 _prof.WriteValue("Max Batch Idxes", ProfData.Int32(_debugStats.LargestBatchIndices));
                 _prof.WriteValue("Lights", ProfData.Int32(_debugStats.TotalLights));
+                _prof.WriteValue("Shadow Lights", ProfData.Int32(_debugStats.ShadowLights));
+                _prof.WriteValue("Occluders", ProfData.Int32(_debugStats.Occluders));
             }
         }
 
@@ -367,6 +369,7 @@ namespace Robust.Client.Graphics.Clyde
             ArrayPool<int>.Shared.Return(indexList);
             entityPostRenderTarget?.DisposeDeferred();
 
+            _debugStats.Entities += _drawingSpriteList.Count;
             _drawingSpriteList.Clear();
             FlushRenderQueue();
         }

--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -16,6 +16,7 @@ using TKStencilOp = OpenToolkit.Graphics.OpenGL4.StencilOp;
 using Robust.Shared.Physics;
 using Robust.Client.ComponentTrees;
 using static Robust.Shared.GameObjects.OccluderComponent;
+using Robust.Shared.Utility;
 
 namespace Robust.Client.Graphics.Clyde
 {
@@ -32,11 +33,6 @@ namespace Robust.Client.Graphics.Clyde
         // Horizontal width, in pixels, of the shadow maps used to render FOV.
         // I figured this was more accuracy sensitive than lights so resolution is significantly higher.
         private const int FovMapSize = 2048;
-
-        // The maximum possible amount of lights in the light list.
-        // In the average case, the only cost of increasing this value is memory.
-        // If you are ever in a situation where this value needs to be increased, however, it will also implicitly cost some CPU time to sort the additional lights.
-        private const int LightsToRenderListSize = 2048;
 
         private ClydeShaderInstance _fovDebugShaderInstance = default!;
 
@@ -95,11 +91,12 @@ namespace Robust.Client.Graphics.Clyde
         private ClydeTexture FovTexture => _fovRenderTarget.Texture;
         private ClydeTexture ShadowTexture => _shadowRenderTarget.Texture;
 
-        private (PointLightComponent light, Vector2 pos, float distanceSquared)[] _lightsToRenderList =
-            new (PointLightComponent light, Vector2 pos, float distanceSquared)[LightsToRenderListSize];
+        private (PointLightComponent light, Vector2 pos, float distanceSquared)[] _lightsToRenderList = default!;
 
         private unsafe void InitLighting()
         {
+
+
             // Other...
             LoadLightingShaders();
 
@@ -173,7 +170,7 @@ namespace Robust.Client.Graphics.Clyde
 
             // Shadow FBO.
             _shadowRenderTargetCanInitializeSafely = true;
-            MaxLightsPerSceneChanged(_maxLightsPerScene);
+            MaxShadowcastingLightsChanged(_maxShadowcastingLights);
         }
 
         private void LoadLightingShaders()
@@ -502,8 +499,6 @@ namespace Robust.Client.Graphics.Clyde
                     (matrix.R0C2, matrix.R1C2) = lightPos;
 
                     _drawQuad(-offset, offset, matrix, lightShader);
-
-                    _debugStats.TotalLights += 1;
                 }
             }
 
@@ -513,7 +508,7 @@ namespace Robust.Client.Graphics.Clyde
 
             CheckGlError();
 
-            if (_cfg.GetCVar(CVars.DisplayBlurLight))
+            if (_cfg.GetCVar(CVars.LightBlur))
                 BlurLights(viewport, eye);
 
             using (_prof.Group("BlurOntoWalls"))
@@ -562,7 +557,7 @@ namespace Robust.Client.Graphics.Clyde
                     ref var count = ref state.count;
                     ref var shadowCount = ref state.shadowCastingCount;
 
-                    if (count >= LightsToRenderListSize)
+                    if (count >= state.clyde._maxLights)
                     {
                         // There are too many lights to fit in the static memory.
                         return false;
@@ -593,7 +588,7 @@ namespace Robust.Client.Graphics.Clyde
                 }, bounds);
             }
 
-            if (state.shadowCastingCount > _maxLightsPerScene)
+            if (state.shadowCastingCount > _maxShadowcastingLights)
             {
                 // There are too many lights casting shadows to fit in the scene.
                 // This check must occur before occluder expansion, or else bad things happen.
@@ -617,7 +612,7 @@ namespace Robust.Client.Graphics.Clyde
 
                 // Then effectively delete the furthest lights, by setting the end of the array to exclude N
                 // number of shadow casting lights (where N is the number above the max number per scene.)
-                state.count -= state.shadowCastingCount - _maxLightsPerScene;
+                state.count -= state.shadowCastingCount - _maxShadowcastingLights;
             }
 
             // When culling occluders later, we can't just remove any occluders outside the worldBounds.
@@ -632,6 +627,9 @@ namespace Robust.Client.Graphics.Clyde
                 var (_, lightPos, _) = _lightsToRenderList[i];
                 expandedBounds = expandedBounds.ExtendToContain(lightPos);
             }
+
+            _debugStats.TotalLights += state.count;
+            _debugStats.ShadowLights += Math.Min(state.shadowCastingCount, _maxShadowcastingLights);
 
             return (_lightsToRenderList, state.count, expandedBounds);
         }
@@ -664,7 +662,7 @@ namespace Robust.Client.Graphics.Clyde
 
             // Have to scale the blurring radius based on viewport size and camera zoom.
             const float refCameraHeight = 14;
-            var facBase = _cfg.GetCVar(CVars.DisplayBlurLightFactor);
+            var facBase = _cfg.GetCVar(CVars.LightBlurFactor);
             var cameraSize = eye.Zoom.Y * viewport.Size.Y * (1 / viewport.RenderScale.Y) / EyeManager.PixelsPerMeter;
             // 7e-3f is just a magic factor that makes it look ok.
             var factor = facBase * (refCameraHeight / cameraSize);
@@ -907,48 +905,49 @@ namespace Robust.Client.Graphics.Clyde
             // 3D geometry used during depth projection.
             // 2D mask geometry used to apply wall bleed.
 
-            // TODO: Yes this function throws and index exception if you reach maxOccluders.
-
-            const int maxOccluders = 2048;
-
             // 16 = 4 vertices * 4 directions
-            var arrayBuffer = ArrayPool<Vector4>.Shared.Rent(maxOccluders * 4 * 4);
+            var arrayBuffer = ArrayPool<Vector4>.Shared.Rent(_maxOccluders * 4 * 4);
             // multiplied by 2 (it's a vector2 of bytes)
-            var arrayVIBuffer = ArrayPool<byte>.Shared.Rent(maxOccluders * 2 * 4 * 4);
-            var indexBuffer = ArrayPool<ushort>.Shared.Rent(maxOccluders * GetQuadBatchIndexCount() * 4);
+            var arrayVIBuffer = ArrayPool<byte>.Shared.Rent(_maxOccluders * 2 * 4 * 4);
+            var indexBuffer = ArrayPool<ushort>.Shared.Rent(_maxOccluders * GetQuadBatchIndexCount() * 4);
 
-            var arrayMaskBuffer = ArrayPool<Vector2>.Shared.Rent(maxOccluders * 4);
-            var indexMaskBuffer = ArrayPool<ushort>.Shared.Rent(maxOccluders * GetQuadBatchIndexCount());
+            var arrayMaskBuffer = ArrayPool<Vector2>.Shared.Rent(_maxOccluders * 4);
+            var indexMaskBuffer = ArrayPool<ushort>.Shared.Rent(_maxOccluders * GetQuadBatchIndexCount());
+
+            // I love mysterious variable names, it keeps you on your toes.
+            var ai = 0;
+            var avi = 0;
+            var ami = 0;
+            var ii = 0;
+            var imi = 0;
+            var amiMax = _maxOccluders * 4;
+
+            var occluderSystem = _entitySystemManager.GetEntitySystem<OccluderSystem>();
+            var xformSystem = _entitySystemManager.GetEntitySystem<TransformSystem>();
+            var xforms = _entityManager.GetEntityQuery<TransformComponent>();
 
             try
             {
-                var occluderSystem = _entitySystemManager.GetEntitySystem<OccluderSystem>();
-                var xformSystem = _entitySystemManager.GetEntitySystem<TransformSystem>();
-
-                var ai = 0;
-                var avi = 0;
-                var ami = 0;
-                var ii = 0;
-                var imi = 0;
-
-                var xforms = _entityManager.GetEntityQuery<TransformComponent>();
-
                 foreach (var comp in occluderSystem.GetIntersectingTrees(map, expandedBounds))
                 {
+                    if (ami >= amiMax)
+                        break;
+
                     var treeBounds = xforms.GetComponent(comp.Owner).InvWorldMatrix.TransformBox(expandedBounds);
 
                     comp.Tree.QueryAabb((in ComponentTreeEntry<OccluderComponent> entry) =>
                     {
-                        var (sOccluder, transform) = entry;
-                        if (!sOccluder.Enabled)
+                        var (occluder, transform) = entry;
+                        if (!occluder.Enabled)
                         {
                             return true;
                         }
 
-                        var occluder = (OccluderComponent)sOccluder;
+                        if (ami >= amiMax)
+                            return false;
 
                         var worldTransform = xformSystem.GetWorldMatrix(transform, xforms);
-                        var box = sOccluder.BoundingBox;
+                        var box = occluder.BoundingBox;
 
                         var tl = worldTransform.Transform(box.TopLeft);
                         var tr = worldTransform.Transform(box.TopRight);
@@ -1114,6 +1113,8 @@ namespace Robust.Client.Graphics.Clyde
                 ArrayPool<Vector2>.Shared.Return(arrayMaskBuffer);
                 ArrayPool<ushort>.Shared.Return(indexMaskBuffer);
             }
+
+            _debugStats.Occluders += ami / 4;
         }
 
         private void RegenLightRts(Viewport viewport)
@@ -1167,27 +1168,28 @@ namespace Robust.Client.Graphics.Clyde
 
         private Vector2i GetLightMapSize(Vector2i screenSize, bool furtherDivide = false)
         {
-            var divider = (float)_lightmapDivider;
+            var scale = _lightResolutionScale;
             if (furtherDivide)
             {
-                divider *= 2;
+                scale /= 2;
             }
 
-            var w = (int)Math.Ceiling(screenSize.X / divider);
-            var h = (int)Math.Ceiling(screenSize.Y / divider);
+            var w = (int)Math.Ceiling(screenSize.X * scale);
+            var h = (int)Math.Ceiling(screenSize.Y * scale);
 
             return (w, h);
         }
 
-        private void LightmapDividerChanged(int newValue)
+        private void LightResolutionScaleChanged(float newValue)
         {
-            _lightmapDivider = newValue;
+            _lightResolutionScale = newValue;
             RegenAllLightRts();
         }
 
-        private void MaxLightsPerSceneChanged(int newValue)
+        private void MaxShadowcastingLightsChanged(int newValue)
         {
-            _maxLightsPerScene = newValue;
+            _maxShadowcastingLights = newValue;
+            DebugTools.Assert(_maxLights >= _maxShadowcastingLights);
 
             // This guard is in place because otherwise the shadow FBO is initialized before GL is initialized.
             if (!_shadowRenderTargetCanInitializeSafely)
@@ -1199,7 +1201,7 @@ namespace Robust.Client.Graphics.Clyde
             }
 
             // Shadow FBO.
-            _shadowRenderTarget = CreateRenderTarget((ShadowMapSize, _maxLightsPerScene),
+            _shadowRenderTarget = CreateRenderTarget((ShadowMapSize, _maxShadowcastingLights),
                 new RenderTargetFormatParameters(
                     _hasGLFloatFramebuffers ? RenderTargetColorFormat.RG32F : RenderTargetColorFormat.Rgba8, true),
                 new TextureSampleParameters { WrapMode = TextureWrapMode.Repeat, Filter = true },
@@ -1209,6 +1211,18 @@ namespace Robust.Client.Graphics.Clyde
         private void SoftShadowsChanged(bool newValue)
         {
             _enableSoftShadows = newValue;
+        }
+
+        private void MaxOccludersChanged(int value)
+        {
+            _maxOccluders = Math.Max(value, 1024);
+        }
+
+        private void MaxLightsChanged(int value)
+        {
+            _maxLights = value;
+            _lightsToRenderList = new (PointLightComponent, Vector2, float)[value];
+            DebugTools.Assert(_maxLights >= _maxShadowcastingLights);
         }
     }
 }

--- a/Robust.Client/Graphics/Clyde/Clyde.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.cs
@@ -64,8 +64,10 @@ namespace Robust.Client.Graphics.Clyde
 
         private GLShaderProgram? _currentProgram;
 
-        private int _lightmapDivider = 2;
-        private int _maxLightsPerScene = 128;
+        private float _lightResolutionScale = 0.5f;
+        private int _maxLights = 2048;
+        private int _maxOccluders = 2048;
+        private int _maxShadowcastingLights = 128;
         private bool _enableSoftShadows = true;
 
         private bool _checkGLErrors;
@@ -92,9 +94,11 @@ namespace Robust.Client.Graphics.Clyde
             _cfg.OnValueChanged(CVars.DisplayOGLCheckErrors, b => _checkGLErrors = b, true);
             _cfg.OnValueChanged(CVars.DisplayVSync, VSyncChanged, true);
             _cfg.OnValueChanged(CVars.DisplayWindowMode, WindowModeChanged, true);
-            _cfg.OnValueChanged(CVars.DisplayLightMapDivider, LightmapDividerChanged, true);
-            _cfg.OnValueChanged(CVars.DisplayMaxLightsPerScene, MaxLightsPerSceneChanged, true);
-            _cfg.OnValueChanged(CVars.DisplaySoftShadows, SoftShadowsChanged, true);
+            _cfg.OnValueChanged(CVars.LightResolutionScale, LightResolutionScaleChanged, true);
+            _cfg.OnValueChanged(CVars.MaxShadowcastingLights, MaxShadowcastingLightsChanged, true);
+            _cfg.OnValueChanged(CVars.LightSoftShadows, SoftShadowsChanged, true);
+            _cfg.OnValueChanged(CVars.MaxLightCount, MaxLightsChanged, true);
+            _cfg.OnValueChanged(CVars.MaxOccluderCount, MaxOccludersChanged, true);
             // I can't be bothered to tear down and set these threads up in a cvar change handler.
 
             // Windows and Linux can be trusted to not explode with threaded windowing,

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -557,6 +557,9 @@ namespace Robust.Client.Graphics.Clyde
             public int LastBatches => 0;
             public (int vertices, int indices) LargestBatchSize => (0, 0);
             public int TotalLights => 0;
+            public int ShadowLights => 0;
+            public int Occluders => 0;
+            public int Entities => 0;
         }
 
         private sealed class DummyDebugInfo : IClydeDebugInfo

--- a/Robust.Client/Graphics/IClydeDebugStats.cs
+++ b/Robust.Client/Graphics/IClydeDebugStats.cs
@@ -29,5 +29,20 @@ namespace Robust.Client.Graphics
         ///     The amount of lights that were rendered last frame.
         /// </summary>
         int TotalLights { get; }
+
+        /// <summary>
+        ///     Number of shadow-casting lights that were rendered last frame.
+        /// </summary>
+        int ShadowLights { get; }
+
+        /// <summary>
+        ///     Number of occluders that were rendered last frame.
+        /// </summary>
+        int Occluders { get; }
+
+        /// <summary>
+        ///     Number of entities that were rendered last frame.
+        /// </summary>
+        int Entities { get; }
     }
 }

--- a/Robust.Client/UserInterface/CustomControls/DebugMonitorControls/DebugClydePanel.cs
+++ b/Robust.Client/UserInterface/CustomControls/DebugMonitorControls/DebugClydePanel.cs
@@ -54,7 +54,7 @@ Version: {info.VersionString}");
 
             _textBuilder.Append($@"Draw Calls: Cly: {stats.LastClydeDrawCalls} GL: {stats.LastGLDrawCalls}
 Batches: {stats.LastBatches} Max size: ({stats.LargestBatchSize.vertices} vtx, {stats.LargestBatchSize.vertices} idx)
-Lights: {stats.TotalLights}");
+Lights: {stats.TotalLights}, Shadowcasting: {stats.ShadowLights}, Occluders: {stats.Occluders}, Entities: { stats.Entities}");
 
             _label.TextMemory = FormatHelpers.BuilderToMemory(_textBuilder, _textBuffer);
         }

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -630,7 +630,50 @@ namespace Robust.Shared
         /// outside of our viewport.
         /// </remarks>
         public static readonly CVarDef<float> MaxLightRadius =
-            CVarDef.Create("light.max_radius", 32.1f, CVar.CLIENTONLY);
+            CVarDef.Create("light.max_radius", 32.1f, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+        /// <summary>
+        /// Maximum number of lights that the client will draw.
+        /// </summary>
+        public static readonly CVarDef<int> MaxLightCount =
+            CVarDef.Create("light.max_light_count", 2048, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+        /// <summary>
+        /// Maximum number of occluders that the client will draw. Values below 1024 have no effect.
+        /// </summary>
+        public static readonly CVarDef<int> MaxOccluderCount =
+            CVarDef.Create("light.max_occluder_count", 2048, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+        /// <summary>
+        /// Scale used to modify the horizontal and vertical resolution of lighting framebuffers,
+        /// relative to the viewport framebuffer size.
+        /// </summary>
+        public static readonly CVarDef<float> LightResolutionScale =
+            CVarDef.Create("light.resolution_scale", 0.5f, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+        /// <summary>
+        /// Maximum amount of shadow-casting lights that can be rendered in a single viewport at once.
+        /// </summary>
+        public static readonly CVarDef<int> MaxShadowcastingLights =
+            CVarDef.Create("light.max_shadowcasting_lights", 128, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+        /// <summary>
+        /// Whether to give shadows a soft edge when rendering.
+        /// </summary>
+        public static readonly CVarDef<bool> LightSoftShadows =
+            CVarDef.Create("light.soft_shadows", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+        /// <summary>
+        /// Apply a gaussian blur to the final lighting framebuffer to smoothen it out a little.
+        /// </summary>
+        public static readonly CVarDef<bool> LightBlur=
+            CVarDef.Create("light.blur", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+        /// <summary>
+        /// Factor by which to blur the lighting framebuffer under <c>light.blur</c>.
+        /// </summary>
+        public static readonly CVarDef<float> LightBlurFactor =
+            CVarDef.Create("light.blur_factor", 0.001f, CVar.CLIENTONLY | CVar.ARCHIVE);
 
         /*
          * Lookup
@@ -745,37 +788,6 @@ namespace Robust.Shared
         /// </summary>
         public static readonly CVarDef<int> DisplayHeight =
             CVarDef.Create("display.height", 720, CVar.CLIENTONLY);
-
-        /// <summary>
-        /// Factor by which to divide the horizontal and vertical resolution of lighting framebuffers,
-        /// relative to the viewport framebuffer size.
-        /// </summary>
-        public static readonly CVarDef<int> DisplayLightMapDivider =
-            CVarDef.Create("display.lightmapdivider", 2, CVar.CLIENTONLY | CVar.ARCHIVE);
-
-        /// <summary>
-        /// Maximum amount of lights that can be rendered in a single viewport at once.
-        /// </summary>
-        public static readonly CVarDef<int> DisplayMaxLightsPerScene =
-            CVarDef.Create("display.maxlightsperscene", 128, CVar.CLIENTONLY | CVar.ARCHIVE);
-
-        /// <summary>
-        /// Whether to give shadows a soft edge when rendering.
-        /// </summary>
-        public static readonly CVarDef<bool> DisplaySoftShadows =
-            CVarDef.Create("display.softshadows", true, CVar.CLIENTONLY | CVar.ARCHIVE);
-
-        /// <summary>
-        /// Apply a gaussian blur to the final lighting framebuffer to smoothen it out a little.
-        /// </summary>
-        public static readonly CVarDef<bool> DisplayBlurLight =
-            CVarDef.Create("display.blur_light", true, CVar.CLIENTONLY | CVar.ARCHIVE);
-
-        /// <summary>
-        /// Factor by which to blur the lighting framebuffer under <c>display.blur_light</c>.
-        /// </summary>
-        public static readonly CVarDef<float> DisplayBlurLightFactor =
-            CVarDef.Create("display.blur_light_factor", 0.001f, CVar.CLIENTONLY | CVar.ARCHIVE);
 
         /// <summary>
         /// UI scale for all UI controls. If zero, this value is automatically calculated from the OS.


### PR DESCRIPTION
- Makes max lights & occluders cvars instead of `const`s
- Adds shadowcasting lights, occluders, & entity counts to the clyde debug panel.
- Makes the fov/occluder code not error when there are too many occluders
- Moves several cvars from the "display" to the "light" category (i.e., display.softshadows -> light.softshadows)
- Replaces the light resolution divisor integer cvar with a float multiplier.  

Some of the cvar renaming might mess with existing user configs, but I don't think there's really a way of avoiding it without some sort of basic toml config version / migration tools.

Requires a content PR to update cvar names (space-wizards/space-station-14/pull/14001)