### PR TITLE
Add fallback culture for localization

### DIFF
--- a/Robust.Shared/Localization/LocalizationManager.cs
+++ b/Robust.Shared/Localization/LocalizationManager.cs
@@ -33,6 +33,7 @@ namespace Robust.Shared.Localization
         private readonly Dictionary<CultureInfo, FluentBundle> _contexts = new();
 
         private CultureInfo? _defaultCulture;
+        private CultureInfo? _fallbackCulture;
 
         void IPostInjectInit.PostInject()
         {
@@ -115,20 +116,23 @@ namespace Robust.Shared.Localization
             string messageId,
             [NotNullWhen(true)] out FluentBundle? bundle)
         {
-            if (_defaultCulture == null)
+            foreach (var culture in new[] { _defaultCulture, _fallbackCulture })
             {
-                bundle = null;
-                return false;
+                if (culture != null && _contexts.TryGetValue(culture, out bundle))
+                {
+                    if (messageId.Contains('.'))
+                    {
+                        var split = messageId.Split('.');
+                        if (bundle.HasMessage(split[0]))
+                            return true;
+                    }
+                    if (bundle.HasMessage(messageId))
+                        return true;
+                }
             }
 
-            bundle = _contexts[_defaultCulture];
-            if (messageId.Contains('.'))
-            {
-                var split = messageId.Split('.');
-                return bundle.HasMessage(split[0]);
-            }
-
-            return bundle.HasMessage(messageId);
+            bundle = null;
+            return false;
         }
 
         private bool TryGetMessage(
@@ -136,15 +140,18 @@ namespace Robust.Shared.Localization
             [NotNullWhen(true)] out FluentBundle? bundle,
             [NotNullWhen(true)] out AstMessage? message)
         {
-            if (_defaultCulture == null)
+            foreach (var culture in new[] { _defaultCulture, _fallbackCulture })
             {
-                bundle = null;
-                message = null;
-                return false;
+                if (culture != null && _contexts.TryGetValue(culture, out bundle))
+                {
+                    if (bundle.TryGetAstMessage(messageId, out message))
+                        return true;
+                }
             }
 
-            bundle = _contexts[_defaultCulture];
-            return bundle.TryGetAstMessage(messageId, out message);
+            bundle = null;
+            message = null;
+            return false;
         }
 
         public void ReloadLocalizations()
@@ -192,6 +199,16 @@ namespace Robust.Shared.Localization
 
             _loadData(_res, culture, bundle);
             DefaultCulture ??= culture;
+        }
+
+        public void SetFallbackCluture(CultureInfo culture)
+        {
+            if (!_contexts.ContainsKey(culture))
+            {
+                throw new ArgumentException("That culture is not loaded.", nameof(culture));
+            }
+
+            _fallbackCulture = culture;
         }
 
         public void AddLoadedToStringSerializer(IRobustMappedStringSerializer serializer)


### PR DESCRIPTION
Allow to set fallback culture in localization.
API looks like:
```c#
public void Initialize()
{
    var culture = new CultureInfo("ru-RU");
    var fallbackCulture = new CultureInfo("en-US");

    _loc.LoadCulture(culture);
    _loc.LoadCulture(fallbackCulture);
    
    _loc.SetFallbackCluture(fallbackCulture);
    // ...
}
```

Was tested in game:
![image](https://user-images.githubusercontent.com/14136326/217903738-6f9bbe00-6617-460f-8340-8ce278645e48.png)
![image](https://user-images.githubusercontent.com/14136326/217903752-5299d038-487e-4eef-a70b-4d2b827b9864.png)
