### PR TITLE
Fix multi viewport sprite update

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -294,7 +294,7 @@ namespace Robust.Client.GameObjects
 
         [ViewVariables] private Dictionary<object, int> LayerMap = new();
         [ViewVariables] private bool _layerMapShared;
-        [ViewVariables] private List<Layer> Layers = new();
+        [ViewVariables] internal List<Layer> Layers = new();
 
         [ViewVariables(VVAccess.ReadWrite)] public uint RenderOrder { get; set; }
 
@@ -368,8 +368,8 @@ namespace Robust.Client.GameObjects
             UpdateLocalMatrix();
             drawDepth = other.drawDepth;
             _screenLock = other._screenLock;
-            _overrideDirection = other._overrideDirection;
-            _enableOverrideDirection = other._enableOverrideDirection;
+            DirectionOverride = other.DirectionOverride;
+            EnableDirectionOverride = other.EnableDirectionOverride;
             Layers = new List<Layer>(other.Layers.Count);
             foreach (var otherLayer in other.Layers)
             {
@@ -1244,36 +1244,18 @@ namespace Robust.Client.GameObjects
         private bool _snapCardinals = false;
 
         [DataField("overrideDir")]
-        private Direction _overrideDirection = Direction.East;
+        [ViewVariables(VVAccess.ReadWrite)]
+        public Direction DirectionOverride = Direction.East;
 
         [DataField("enableOverrideDir")]
-        private bool _enableOverrideDirection;
+        [ViewVariables(VVAccess.ReadWrite)]
+        public bool EnableDirectionOverride;
 
         /// <inheritdoc />
         [ViewVariables(VVAccess.ReadWrite)]
         public bool NoRotation { get => _screenLock; set => _screenLock = value; }
 
-        /// <inheritdoc />
-        [ViewVariables(VVAccess.ReadWrite)]
-        public Direction DirectionOverride { get => _overrideDirection; set => _overrideDirection = value; }
-
-        /// <inheritdoc />
-        [ViewVariables(VVAccess.ReadWrite)]
-        public bool EnableDirectionOverride { get => _enableOverrideDirection; set => _enableOverrideDirection = value; }
-
-        // Sprite rendering path
-        public void Render(DrawingHandleWorld drawingHandle, Angle eyeRotation, in Angle worldRotation, in Vector2 worldPosition)
-        {
-            Direction? overrideDir = null;
-            if (_enableOverrideDirection)
-            {
-                overrideDir = _overrideDirection;
-            }
-
-            RenderInternal(drawingHandle, eyeRotation, worldRotation, worldPosition, overrideDir);
-        }
-
-        private void RenderInternal(DrawingHandleWorld drawingHandle, Angle eyeRotation, Angle worldRotation, Vector2 worldPosition, Direction? overrideDirection)
+        internal void RenderInternal(DrawingHandleWorld drawingHandle, Angle eyeRotation, Angle worldRotation, Vector2 worldPosition, Direction? overrideDirection)
         {
             var angle = worldRotation + eyeRotation; // angle on-screen. Used to decide the direction of 4/8 directional RSIs
             var cardinal = Angle.Zero;
@@ -1318,51 +1300,6 @@ namespace Robust.Client.GameObjects
                 RSI.State.DirectionType.Dir8 => 8,
                 _ => throw new ArgumentOutOfRangeException()
             };
-        }
-
-        public void FrameUpdate(float delta)
-        {
-            foreach (var t in Layers)
-            {
-                var layer = t;
-                // Since StateId is a struct, we can't null-check it directly.
-                if (!layer.State.IsValid || !layer.Visible || !layer.AutoAnimated || layer.Blank)
-                {
-                    continue;
-                }
-
-                var rsi = layer.RSI ?? BaseRSI;
-                if (rsi == null || !rsi.TryGetState(layer.State, out var state))
-                {
-                    state = GetFallbackState(resourceCache);
-                }
-
-                if (!state.IsAnimated)
-                {
-                    continue;
-                }
-
-                layer.AnimationTime += delta;
-                layer.AnimationTimeLeft -= delta;
-                _advanceFrameAnimation(layer, state);
-            }
-        }
-
-        private static void _advanceFrameAnimation(Layer layer, RSI.State state)
-        {
-            var delayCount = state.DelayCount;
-            while (layer.AnimationTimeLeft < 0)
-            {
-                layer.AnimationFrame += 1;
-
-                if (layer.AnimationFrame >= delayCount)
-                {
-                    layer.AnimationFrame = 0;
-                    layer.AnimationTime = -layer.AnimationTimeLeft;
-                }
-
-                layer.AnimationTimeLeft += state.GetDelay(layer.AnimationFrame);
-            }
         }
 
         public override void HandleComponentState(ComponentState? curState, ComponentState? nextState)
@@ -1822,8 +1759,7 @@ namespace Robust.Client.GameObjects
                 }
 
                 AnimationTime = animationTime;
-                // After setting timing data correctly, run advance to get to the correct frame.
-                _advanceFrameAnimation(this, state);
+                AdvanceFrameAnimation(state);
             }
 
             public void SetAutoAnimated(bool value)
@@ -2087,6 +2023,23 @@ namespace Robust.Client.GameObjects
                     return Texture ?? _parent.resourceCache.GetFallback<TextureResource>().Texture;
 
                 return state.GetFrame(dir, AnimationFrame);
+            }
+
+            internal void AdvanceFrameAnimation(RSI.State state)
+            {
+                var delayCount = state.DelayCount;
+                while (AnimationTimeLeft < 0)
+                {
+                    AnimationFrame += 1;
+
+                    if (AnimationFrame >= delayCount)
+                    {
+                        AnimationFrame = 0;
+                        AnimationTime = -AnimationTimeLeft;
+                    }
+
+                    AnimationTimeLeft += state.GetDelay(AnimationFrame);
+                }
             }
         }
 

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Component.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Component.cs
@@ -5,23 +5,23 @@ namespace Robust.Client.GameObjects;
 public sealed partial class SpriteSystem
 {
     /// <summary>
-    /// Resets the sprite's animated layers to align with realtime.
+    /// Resets the sprite's animated layers to align with a given time (in seconds).
     /// </summary>
-    public void SetAutoAnimateSync(SpriteComponent sprite)
+    public void SetAutoAnimateSync(SpriteComponent sprite, double time)
     {
         foreach (var layer in sprite.AllLayers)
         {
-            if (!layer.AutoAnimated || layer is not SpriteComponent.Layer spriteLayer)
+            if (layer is not SpriteComponent.Layer spriteLayer)
                 continue;
 
-            SetAutoAnimateSync(sprite, spriteLayer);
+            SetAutoAnimateSync(sprite, spriteLayer, time);
         }
     }
 
     /// <summary>
-    /// Resets the layer's animation to align with realtime.
+    /// Resets the layer's animation to align with a given time (in seconds).
     /// </summary>
-    public void SetAutoAnimateSync(SpriteComponent sprite, SpriteComponent.Layer layer)
+    public void SetAutoAnimateSync(SpriteComponent sprite, SpriteComponent.Layer layer, double time)
     {
         if (!layer.AutoAnimated)
             return;
@@ -38,10 +38,7 @@ public sealed partial class SpriteSystem
             return;
         }
 
-        var animationDuration = state.GetDelays().Sum();
-        var curTime = _timing.RealTime;
-
-        layer.AnimationTimeLeft = (float) -(curTime.TotalSeconds % animationDuration);
+        layer.AnimationTimeLeft = (float) -(time % state.TotalDelay);
         layer.AnimationFrame = 0;
     }
 }

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
@@ -9,9 +9,11 @@ using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
+using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using static Robust.Client.GameObjects.SpriteComponent;
 
 namespace Robust.Client.GameObjects
 {
@@ -22,16 +24,24 @@ namespace Robust.Client.GameObjects
     public sealed partial class SpriteSystem : EntitySystem
     {
         [Dependency] private readonly IConfigurationManager _cfg = default!;
-        [Dependency] private readonly IEyeManager _eyeManager = default!;
         [Dependency] private readonly IGameTiming _timing = default!;
         [Dependency] private readonly IPrototypeManager _proto = default!;
         [Dependency] private readonly IResourceCache _resourceCache = default!;
-        [Dependency] private readonly SpriteTreeSystem _treeSystem = default!;
 
         private readonly Queue<SpriteComponent> _inertUpdateQueue = new();
-        private readonly HashSet<SpriteComponent> _manualUpdate = new();
 
-        private TimeSpan _syncTime;
+        /// <summary>
+        ///     Entities that require a sprite frame update.
+        /// </summary>
+        private readonly HashSet<EntityUid> _queuedFrameUpdate = new();
+
+        internal void Render(EntityUid uid, SpriteComponent sprite, DrawingHandleWorld drawingHandle, Angle eyeRotation, in Angle worldRotation, in Vector2 worldPosition)
+        {
+            if (!sprite.IsInert)
+                _queuedFrameUpdate.Add(uid);
+
+            sprite.RenderInternal(drawingHandle, eyeRotation, worldRotation, worldPosition, sprite.EnableDirectionOverride ? sprite.DirectionOverride : null);
+        }
 
         public override void Initialize()
         {
@@ -79,66 +89,61 @@ namespace Robust.Client.GameObjects
         /// <inheritdoc />
         public override void FrameUpdate(float frameTime)
         {
-            _syncTime += TimeSpan.FromSeconds(frameTime);
-
             while (_inertUpdateQueue.TryDequeue(out var sprite))
             {
                 sprite.DoUpdateIsInert();
             }
 
-            foreach (var sprite in _manualUpdate)
-            {
-                if (!sprite.Deleted && !sprite.IsInert)
-                    sprite.FrameUpdate(frameTime);
-            }
-
-            var pvsBounds = _eyeManager.GetWorldViewbounds();
-
-            var currentMap = _eyeManager.CurrentMap;
-            if (currentMap == MapId.Nullspace)
-            {
-                return;
-            }
-
+            var realtime = _timing.RealTime.TotalSeconds;
+            var spriteQuery = GetEntityQuery<SpriteComponent>();
             var syncQuery = GetEntityQuery<SyncSpriteComponent>();
-            var spriteState = (frameTime, _manualUpdate, syncQuery, this);
+            foreach (var uid in _queuedFrameUpdate)
+            {
+                if (!spriteQuery.TryGetComponent(uid, out var sprite))
+                    continue;
 
-            _treeSystem.QueryAabb( ref spriteState, static (ref (
-                    float frameTime,
-                    HashSet<SpriteComponent> _manualUpdate,
-                    EntityQuery<SyncSpriteComponent> syncQuery,
-                    SpriteSystem system) tuple,
-                in ComponentTreeEntry<SpriteComponent> value) =>
+                if (sprite.IsInert)
+                    continue;
+
+                var sync = syncQuery.HasComponent(uid);
+
+                foreach (var layer in sprite.Layers)
                 {
-                    if (value.Component.IsInert)
-                        return true;
+                    if (!layer.State.IsValid || !layer.Visible || !layer.AutoAnimated)
+                        continue;
 
-                    // So the reason this is here is because we only update animations inside of our viewport(s)
-                    // The problem with this is if something comes in pvs range but may not necessarily be in our viewport
-                    // then the animation doesn't update. This means the synced sprites can desync before we see them.
-                    // However, we can't just have all of our animations update in pvs range in case of situations
-                    // where pvs is off (and update every single sprite ever),
-                    // hence we just query for every sprite and ensure its timing is correct.
-                    if (tuple.syncQuery.HasComponent(value.Uid))
+                    var rsi = layer.RSI ?? sprite.BaseRSI;
+                    if (rsi == null || !rsi.TryGetState(layer.State, out var state))
+                        state = GetFallbackState();
+
+                    if (!state.IsAnimated)
+                        continue;
+
+                    if (sync)
                     {
-                        tuple.system.SetAutoAnimateSync(value.Component);
+                        layer.AnimationTime = (float)(realtime % state.TotalDelay);
+                        layer.AnimationTimeLeft = -layer.AnimationTime;
+                        layer.AnimationFrame = 0;
+                    }
+                    else
+                    {
+                        layer.AnimationTime += frameTime;
+                        layer.AnimationTimeLeft -= frameTime;
                     }
 
-                    if (!tuple._manualUpdate.Contains(value.Component))
-                        value.Component.FrameUpdate(tuple.frameTime);
+                    layer.AdvanceFrameAnimation(state);
+                }
+            }
 
-                    return true;
-                }, currentMap, pvsBounds, true);
-
-            _manualUpdate.Clear();
+            _queuedFrameUpdate.Clear();
         }
 
         /// <summary>
         ///     Force update of the sprite component next frame
         /// </summary>
-        public void ForceUpdate(SpriteComponent sprite)
+        public void ForceUpdate(EntityUid uid)
         {
-            _manualUpdate.Add(sprite);
+            _queuedFrameUpdate.Add(uid);
         }
     }
 

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -230,6 +230,7 @@ namespace Robust.Client.Graphics.Clyde
             RenderOverlays(viewport, OverlaySpace.WorldSpaceBelowEntities, worldAABB, worldBounds);
             var worldOverlays = GetOverlaysForSpace(OverlaySpace.WorldSpaceEntities);
 
+            var spriteSystem = _entityManager.System<SpriteSystem>();
             GetSprites(mapId, viewport, eye, worldBounds, out var indexList);
 
             var screenSize = viewport.Size;
@@ -326,7 +327,7 @@ namespace Robust.Client.Graphics.Clyde
                     }
                 }
 
-                entry.Sprite.Render(_renderHandle.DrawingHandleWorld, eye.Rotation, in entry.WorldRot, in entry.WorldPos);
+                spriteSystem.Render(entry.Uid, entry.Sprite, _renderHandle.DrawingHandleWorld, eye.Rotation, in entry.WorldRot, in entry.WorldPos);
 
                 if (entry.Sprite.PostShader != null && entityPostRenderTarget != null)
                 {

--- a/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
@@ -79,6 +79,7 @@ internal partial class Clyde
                 static (ref RefList<SpriteData> state, in ComponentTreeEntry<SpriteComponent> value) =>
                 {
                     ref var entry = ref state.AllocAdd();
+                    entry.Uid = value.Uid;
                     entry.Sprite = value.Component;
                     entry.Xform = value.Transform;
                     return true;
@@ -204,6 +205,7 @@ internal partial class Clyde
 
     private struct SpriteData
     {
+        public EntityUid Uid;
         public SpriteComponent Sprite;
         public TransformComponent Xform;
         public Vector2 WorldPos;

--- a/Robust.Client/Graphics/RSI/RSI.State.cs
+++ b/Robust.Client/Graphics/RSI/RSI.State.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Linq;
 using Robust.Client.Utility;
 using Robust.Shared.Maths;
 using Robust.Shared.Utility;
@@ -35,6 +36,7 @@ namespace Robust.Client.Graphics
                 StateId = stateId;
                 Directions = direction;
                 Delays = delays;
+                TotalDelay = delays.Sum();
                 Icons = icons;
 
                 foreach (var delay in delays)
@@ -115,6 +117,8 @@ namespace Robust.Client.Graphics
             {
                 return Delays;
             }
+
+            public float TotalDelay;
 
             Texture IDirectionalTextureProvider.Default => Frame0;
 

--- a/Robust.Client/Placement/PlacementMode.cs
+++ b/Robust.Client/Placement/PlacementMode.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Robust.Client.GameObjects;
@@ -110,6 +110,7 @@ namespace Robust.Client.Placement
             }
 
             var dirAng = pManager.Direction.ToAngle();
+            var spriteSys = pManager.EntityManager.System<SpriteSystem>();
             foreach (var coordinate in locationcollection)
             {
                 if (!coordinate.IsValid(pManager.EntityManager))
@@ -118,7 +119,7 @@ namespace Robust.Client.Placement
                 var worldRot = pManager.EntityManager.GetComponent<TransformComponent>(coordinate.EntityId).WorldRotation + dirAng;
 
                 sc.Color = IsValidPosition(coordinate) ? ValidPlaceColor : InvalidPlaceColor;
-                sc.Render(handle, pManager.EyeManager.CurrentEye.Rotation, worldRot, worldPos);
+                spriteSys.Render(sce.Value, sc, handle, pManager.EyeManager.CurrentEye.Rotation, worldRot, worldPos);
             }
         }
 

--- a/Robust.Client/UserInterface/Controls/SpriteView.cs
+++ b/Robust.Client/UserInterface/Controls/SpriteView.cs
@@ -55,10 +55,12 @@ namespace Robust.Client.UserInterface.Controls
                 return;
             }
 
-            _spriteSystem ??= IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SpriteSystem>();
-            _spriteSystem?.ForceUpdate(Sprite);
+            var uid = Sprite.Owner;
 
-            renderHandle.DrawEntity(Sprite.Owner, PixelSize / 2, Scale * UIScale, OverrideDirection);
+            _spriteSystem ??= IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SpriteSystem>();
+            _spriteSystem?.ForceUpdate(uid);
+
+            renderHandle.DrawEntity(uid, PixelSize / 2, Scale * UIScale, OverrideDirection);
         }
     }
 }


### PR DESCRIPTION
Currently only sprites visible in the main viewport or in `SpriteView` controls have their animation/frame updated. Entities in other viewports (e.g., SS14 cameras) just don't animate. This PR fixes that while also moving some frame update logic out of the component and into the system.