### PR TITLE
Fix RegisteredCommand() & replay bugs

### DIFF
--- a/Robust.Client/Console/ClientConsoleHost.cs
+++ b/Robust.Client/Console/ClientConsoleHost.cs
@@ -92,7 +92,7 @@ namespace Robust.Client.Console
             UpdateAvailableCommands();
         }
 
-        private void UpdateAvailableCommands()
+        protected override void UpdateAvailableCommands()
         {
             _availableCommands.Clear();
 

--- a/Robust.Server/Replays/ReplayRecordingManager.cs
+++ b/Robust.Server/Replays/ReplayRecordingManager.cs
@@ -125,8 +125,8 @@ internal sealed class ReplayRecordingManager : IInternalReplayRecordingManager
         _curStream = new(_tickBatchSize * 2);
         _index = 0;
         _firstTick = true;
-        WriteInitialMetadata();
         _recordingStart = (_timing.CurTick, _timing.CurTime);
+        WriteInitialMetadata();
         if (duration != null)
             _recordingEnd = _timing.CurTime + duration.Value;
 
@@ -250,10 +250,10 @@ internal sealed class ReplayRecordingManager : IInternalReplayRecordingManager
 
             // Time data
             var timeBase = _timing.TimeBase;
-            _yamlMetadata["startTick"] = new ValueDataNode(_timing.CurTick.Value.ToString());
+            _yamlMetadata["startTick"] = new ValueDataNode(_recordingStart.Tick.Value.ToString());
             _yamlMetadata["timeBaseTick"] = new ValueDataNode(timeBase.Item2.Value.ToString());
             _yamlMetadata["timeBaseTimespan"] = new ValueDataNode(timeBase.Item1.Ticks.ToString());
-            _yamlMetadata["recordingStartTime"] = new ValueDataNode(_recordingStart.ToString());
+            _yamlMetadata["recordingStartTime"] = new ValueDataNode(_recordingStart.Time.ToString());
 
             OnRecordingStarted?.Invoke((_yamlMetadata, extraData));
 

--- a/Robust.Shared/Console/ConsoleHost.cs
+++ b/Robust.Shared/Console/ConsoleHost.cs
@@ -68,6 +68,10 @@ namespace Robust.Shared.Console
             }
         }
 
+        protected virtual void UpdateAvailableCommands()
+        {
+        }
+
         #region RegisterCommand
         public void RegisterCommand(
             string command,
@@ -81,6 +85,7 @@ namespace Robust.Shared.Console
 
             var newCmd = new RegisteredCommand(command, description, help, callback, requireServerOrSingleplayer);
             RegisteredCommands.Add(command, newCmd);
+            UpdateAvailableCommands();
         }
 
         public void RegisterCommand(
@@ -96,6 +101,7 @@ namespace Robust.Shared.Console
 
             var newCmd = new RegisteredCommand(command, description, help, callback, completionCallback, requireServerOrSingleplayer);
             RegisteredCommands.Add(command, newCmd);
+            UpdateAvailableCommands();
         }
 
         public void RegisterCommand(
@@ -111,6 +117,7 @@ namespace Robust.Shared.Console
 
             var newCmd = new RegisteredCommand(command, description, help, callback, completionCallback, requireServerOrSingleplayer);
             RegisteredCommands.Add(command, newCmd);
+            UpdateAvailableCommands();
         }
 
         public void RegisterCommand(string command, ConCommandCallback callback,
@@ -155,6 +162,7 @@ namespace Robust.Shared.Console
                     "You cannot unregister commands that have been registered automatically.");
 
             RegisteredCommands.Remove(command);
+            UpdateAvailableCommands();
         }
 
         //TODO: Pull up


### PR DESCRIPTION
Fixes a bug added in #3694 where RegisteredCommand() would not properly register client-side commands without a state change. Also fixes serialization of replay recording start times.