### PR TITLE
Add IWritableDirProvider.OpenSubdirectory()

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-* Added `IWritableDirProvider.OpenDirectory()`, which returns a new `IWritableDirProvider` pointing to some subdirectory.
+* Added `IWritableDirProvider.OpenSubdirectory()`, which returns a new `IWritableDirProvider` with the root set to some subdirectory.
 
 ### Bugfixes
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Added `IWritableDirProvider.OpenDirectory()`, which returns a new `IWritableDirProvider` pointing to some subdirectory.
 
 ### Bugfixes
 

--- a/Robust.Shared/ContentPack/IWritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/IWritableDirProvider.cs
@@ -89,7 +89,7 @@ namespace Robust.Shared.ContentPack
         /// Returns a new <see cref="IWritableDirProvider"/> that points to a subdirectory.
         /// </summary>
         /// <param name="path">Path of directory to open.</param>
-        IWritableDirProvider OpenDirectory(ResourcePath path);
+        IWritableDirProvider OpenSubdirectory(ResourcePath path);
 
         /// <summary>
         /// Attempts to rename a file.

--- a/Robust.Shared/ContentPack/IWritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/IWritableDirProvider.cs
@@ -86,6 +86,12 @@ namespace Robust.Shared.ContentPack
         }
 
         /// <summary>
+        /// Returns a new <see cref="IWritableDirProvider"/> that points to a subdirectory.
+        /// </summary>
+        /// <param name="path">Path of directory to open.</param>
+        IWritableDirProvider OpenDirectory(ResourcePath path);
+
+        /// <summary>
         /// Attempts to rename a file.
         /// </summary>
         /// <param name="oldPath">Path of the file to rename.</param>

--- a/Robust.Shared/ContentPack/VirtualWritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/VirtualWritableDirProvider.cs
@@ -248,7 +248,7 @@ namespace Robust.Shared.ContentPack
             throw new InvalidOperationException("Unreachable.");
         }
 
-        public IWritableDirProvider OpenDirectory(ResourcePath path)
+        public IWritableDirProvider OpenSubdirectory(ResourcePath path)
         {
             if (!TryGetNodeAt(path, out var node) || node is not DirectoryNode dirNode)
                 throw new FileNotFoundException();

--- a/Robust.Shared/ContentPack/VirtualWritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/VirtualWritableDirProvider.cs
@@ -14,7 +14,17 @@ namespace Robust.Shared.ContentPack
     public sealed class VirtualWritableDirProvider : IWritableDirProvider
     {
         // Just a simple tree. No need to over complicate this.
-        private readonly DirectoryNode _rootDirectoryNode = new();
+        private readonly DirectoryNode _rootDirectoryNode;
+
+        public VirtualWritableDirProvider()
+        {
+            _rootDirectoryNode = new();
+        }
+
+        private VirtualWritableDirProvider(DirectoryNode node)
+        {
+            _rootDirectoryNode = node;
+        }
 
         /// <inheritdoc />
         public string? RootDir => null;
@@ -236,6 +246,14 @@ namespace Robust.Shared.ContentPack
             }
 
             throw new InvalidOperationException("Unreachable.");
+        }
+
+        public IWritableDirProvider OpenDirectory(ResourcePath path)
+        {
+            if (!TryGetNodeAt(path, out var node) || node is not DirectoryNode dirNode)
+                throw new FileNotFoundException();
+
+            return new VirtualWritableDirProvider(dirNode);
         }
 
         private interface INode

--- a/Robust.Shared/ContentPack/WritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/WritableDirProvider.cs
@@ -104,7 +104,7 @@ namespace Robust.Shared.ContentPack
             return File.Open(fullPath, fileMode, access, share);
         }
 
-        public IWritableDirProvider OpenDirectory(ResourcePath path)
+        public IWritableDirProvider OpenSubdirectory(ResourcePath path)
         {
             if (!IsDir(path))
                 throw new FileNotFoundException();

--- a/Robust.Shared/ContentPack/WritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/WritableDirProvider.cs
@@ -104,6 +104,15 @@ namespace Robust.Shared.ContentPack
             return File.Open(fullPath, fileMode, access, share);
         }
 
+        public IWritableDirProvider OpenDirectory(ResourcePath path)
+        {
+            if (!IsDir(path))
+                throw new FileNotFoundException();
+
+            var dirInfo = new DirectoryInfo(GetFullPath(path));
+            return new WritableDirProvider(dirInfo);
+        }
+
         /// <inheritdoc />
         public void Rename(ResourcePath oldPath, ResourcePath newPath)
         {


### PR DESCRIPTION
Adds a new function to `IWritableDirProvider` that returns an `IWritableDirProvider` which points to some subdirectory. AFAIK this is safe, `GetFullPath()` should ensure that the path really is a sub-folder of an already read-writeable directory.