### PR TITLE
Fix PVS bug

### DIFF
--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -1133,10 +1133,10 @@ internal sealed partial class PVSSystem : EntitySystem
                 continue;
             }
 
-            if (component.SendOnlyToOwner && player != null && player.AttachedEntity != component.Owner)
+            if (component.SendOnlyToOwner && player != null && player.AttachedEntity != entityUid)
                 continue;
 
-            if (component.LastModifiedTick <= fromTick && fromTick != GameTick.Zero)
+            if (component.LastModifiedTick <= fromTick)
             {
                 if (sendCompList && (!component.SessionSpecific || player == null || EntityManager.CanGetComponentState(bus, component, player)))
                     netComps!.Add(netId);
@@ -1175,7 +1175,7 @@ internal sealed partial class PVSSystem : EntitySystem
             if (!component.NetSyncEnabled)
                 continue;
 
-            if (component.SendOnlyToOwner && player.AttachedEntity != component.Owner)
+            if (component.SendOnlyToOwner && player.AttachedEntity != entityUid)
                 continue;
 
             if (component.SessionSpecific && !EntityManager.CanGetComponentState(bus, component, player))


### PR DESCRIPTION
Fixes #3779 #3509 made PVS unnecessarily send some component states, which in turn revealed some broken sprite prototypes which should've had netsync disabled. This PR just makes PVS not send that data, 

This doesn't actually fix related dubious sprite networking, cause that's planned to be removed anyways. Nor does it fix the bad prototypes (which are in content anyways)