### PR TITLE
UserInterfaceManager tweaks

### DIFF
--- a/Robust.Client/UserInterface/IUserInterfaceManager.Screens.cs
+++ b/Robust.Client/UserInterface/IUserInterfaceManager.Screens.cs
@@ -11,4 +11,6 @@ public partial interface IUserInterfaceManager
     public void UnloadScreen();
     public T? GetActiveUIWidgetOrNull<T>() where T : UIWidget, new();
     public T GetActiveUIWidget<T>() where T : UIWidget, new();
+
+    public event Action<(UIScreen? Old, UIScreen? New)>? OnScreenChanged;
 }

--- a/Robust.Client/UserInterface/UserInterfaceManager.UIScreens.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.UIScreens.cs
@@ -14,12 +14,19 @@ internal partial class UserInterfaceManager
         get => _activeScreen;
         private set
         {
-            if (_activeScreen == value) return;
-            _activeScreen?.OnRemoved();
+            if (_activeScreen == value)
+                return;
+
+            var old = _activeScreen;
+            old?.OnRemoved();
             _activeScreen = value;
             _activeScreen?.OnAdded();
+
+            OnScreenChanged?.Invoke((old, _activeScreen));
         }
     }
+
+    public event Action<(UIScreen? Old, UIScreen? New)>? OnScreenChanged;
 
     [ViewVariables] public Control ScreenRoot { get; private set; } = default!;
 


### PR DESCRIPTION
This PR adds a new `OnScreenChanged` event that gets invoked when `IUserInterfaceManager.ActiveScreen` changes. This PR also changes the `IOnStateEntered` interface logic so that you can support to a base state. I.e., so that you can use `IOnStateEntered<GameplayStateBase>` instead of needing to explicitly add every inheritor of `GameplayStateBase`.