### PR TITLE
Allows YML parsing of shaders with `mat4` or `mat3` default values

### DIFF
--- a/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
+++ b/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
@@ -230,8 +230,12 @@ namespace Robust.Client.Graphics
                     {
                         return node.AsVector4();
                     }
+                case ShaderDataType.Mat3:
+                    return node.AsMatrix3();
+                case ShaderDataType.Mat4:
+                    return node.AsMatrix4();
                 default:
-                    throw new NotSupportedException("Unsupported uniform type.");
+                    throw new NotSupportedException($"Unsupported uniform type '{dataType}'.");
             }
         }
 
@@ -268,6 +272,12 @@ namespace Robust.Client.Graphics
                         instance.SetParameter(key, i);
                         break;
                     case bool i:
+                        instance.SetParameter(key, i);
+                        break;
+                    case Matrix3 i:
+                        instance.SetParameter(key, i);
+                        break;
+                    case Matrix4 i:
                         instance.SetParameter(key, i);
                         break;
                 }

--- a/Robust.Shared/Utility/YamlHelpers.cs
+++ b/Robust.Shared/Utility/YamlHelpers.cs
@@ -104,6 +104,44 @@ namespace Robust.Shared.Utility
         }
 
         [Pure]
+        public static Matrix3 AsMatrix3(this YamlNode node)
+        {
+            string raw = AsString(node);
+            string[] args = raw.Split(',');
+            if (args.Length != 12)
+            {
+               throw new ArgumentException(string.Format("Could not parse {0}: '{1}'", nameof(Matrix3), raw));
+            }
+            float[] parsedArgs = new float[12];
+            for(var i = 0; i < 12; i += 1) {
+                parsedArgs[i] = float.Parse(args[i],CultureInfo.InvariantCulture);
+            }
+            return new Matrix3(parsedArgs);
+        }
+
+        [Pure]
+        public static Matrix4 AsMatrix4(this YamlNode node)
+        {
+            string raw = AsString(node);
+            string[] args = raw.Split(',');
+            if (args.Length != 16)
+            {
+               throw new ArgumentException(string.Format("Could not parse {0}: '{1}'", nameof(Matrix4), raw));
+            }
+            Vector4[] vectorBlocks = new Vector4[4];
+            for(var i = 0; i < 16; i += 4) {
+                vectorBlocks.Append(new Vector4(
+                    float.Parse(args[0 + i], CultureInfo.InvariantCulture),
+                    float.Parse(args[1 + i], CultureInfo.InvariantCulture),
+                    float.Parse(args[2 + i], CultureInfo.InvariantCulture),
+                    float.Parse(args[3 + i], CultureInfo.InvariantCulture)
+                ));
+            }
+
+            return new Matrix4(vectorBlocks[0],vectorBlocks[1],vectorBlocks[2],vectorBlocks[3]);
+        }
+
+        [Pure]
         public static T AsEnum<T>(this YamlNode node)
         {
             return (T) Enum.Parse(typeof(T), node.AsString(), true);


### PR DESCRIPTION
Previously there was no easy way of passing matrices onto shaders, with the current setup.
Now, matrices can be defined for the shader in the same way that vectors can, as a series of numbers parsed as floats.

This is required for OpenDream, specifically so that this can work: https://github.com/OpenDreamProject/OpenDream/pull/1062