### PR TITLE
Fix PVS debug assert

### DIFF
--- a/Robust.Server/GameStates/PVSCollection.cs
+++ b/Robust.Server/GameStates/PVSCollection.cs
@@ -144,6 +144,15 @@ public sealed class PVSCollection<TIndex> : IPVSCollection where TIndex : ICompa
             _deletionHistory.Add((tick, index));
         }
 
+        foreach (var index in _changedIndices)
+        {
+            var oldLoc = RemoveIndexInternal(index);
+            if(oldLoc is GridChunkLocation or MapChunkLocation)
+                _dirtyChunks.Add((IChunkIndexLocation) oldLoc);
+
+            AddIndexInternal(index, _locationChangeBuffer[index], _dirtyChunks);
+        }
+
         // remove empty chunk-subsets
         foreach (var chunkLocation in _dirtyChunks)
         {
@@ -162,15 +171,6 @@ public sealed class PVSCollection<TIndex> : IPVSCollection where TIndex : ICompa
                         mapChunks.Remove(mapChunkLocation.ChunkIndices);
                     break;
             }
-        }
-
-        foreach (var index in _changedIndices)
-        {
-            var oldLoc = RemoveIndexInternal(index);
-            if(oldLoc is GridChunkLocation or MapChunkLocation)
-                _dirtyChunks.Add((IChunkIndexLocation) oldLoc);
-
-            AddIndexInternal(index, _locationChangeBuffer[index], _dirtyChunks);
         }
 
         _changedIndices.Clear();

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -489,8 +489,6 @@ internal sealed partial class PVSSystem : EntitySystem
 
         _mapIndices.Clear();
         _gridIndices.Clear();
-        var xformQuery = GetEntityQuery<TransformComponent>();
-        var physicsQuery = GetEntityQuery<PhysicsComponent>();
 
         for (int i = 0; i < sessions.Length; i++)
         {
@@ -559,14 +557,14 @@ internal sealed partial class PVSSystem : EntitySystem
                             List<(uint, IChunkIndexLocation)> _chunkList) tuple) =>
                     {
                         {
-                            var localPos = tuple.transformQuery.GetComponent(((Component) mapGrid).Owner).InvWorldMatrix.Transform(tuple.viewPos);
+                            var localPos = tuple.transformQuery.GetComponent(mapGrid.Owner).InvWorldMatrix.Transform(tuple.viewPos);
 
                             var gridChunkEnumerator =
                                 new ChunkIndicesEnumerator(localPos, tuple.range, ChunkSize);
 
                             while (gridChunkEnumerator.MoveNext(out var gridChunkIndices))
                             {
-                                var chunkLocation = new GridChunkLocation(((Component) mapGrid).Owner, gridChunkIndices.Value);
+                                var chunkLocation = new GridChunkLocation(mapGrid.Owner, gridChunkIndices.Value);
                                 var entry = (tuple.visMask, chunkLocation);
 
                                 if (tuple.gridDict.TryGetValue(chunkLocation, out var indexOf))


### PR DESCRIPTION
So afaict:

- empty chunks hang around and get returned for chunkcache
- these have no nodes at all (hence no root nodes) so the assert trips
- Dirty chunks need to hang around for some of the pvs caching.
- Changed indices adds to dirtychunks so theoretically by moving the iterator that prunes old chunks to after that it should make sure they get caught before we calculate entity states in this tick?

I couldn't repro the issue by going into space anymore at least.