### PR TITLE
Fix FormattedMessage#IsEmpty

### DIFF
--- a/Robust.Shared/Utility/FormattedMessage.cs
+++ b/Robust.Shared/Utility/FormattedMessage.cs
@@ -24,7 +24,7 @@ public sealed partial class FormattedMessage
     /// <summary>
     /// true if the formatted message doesn't contain any nodes
     /// </summary>
-    public bool IsEmpty => _nodes.Count > 0;
+    public bool IsEmpty => _nodes.Count == 0;
 
     private readonly List<MarkupNode> _nodes;
 


### PR DESCRIPTION
![minor spelling mistake](https://media.tenor.com/7pXIzb8f2rUAAAAd/minor-spelling-mistake.gif)