### PR TITLE
Add by-ref event analyzer

### DIFF
--- a/Robust.Analyzers/ByRefEventAnalyzer.cs
+++ b/Robust.Analyzers/ByRefEventAnalyzer.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Robust.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ByRefEventAnalyzer : DiagnosticAnalyzer
+{
+    private const string ByRefAttribute = "Robust.Shared.GameObjects.ByRefEventAttribute";
+
+    private static readonly DiagnosticDescriptor ByRefRaisedByValueRule = new(
+        Diagnostics.IdByRefEventRaisedByValue,
+        "Invalid by-refness",
+        "Tried to raise a by-ref event '{0}' by value.",
+        "Usage",
+        DiagnosticSeverity.Error,
+        true,
+        "Make sure that by-ref events are raised with the ref keyword."
+    );
+
+    private ISymbol _subscribeLocalEventMethod = default!;
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(ByRefRaisedByValueRule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+        context.RegisterOperationAction(CheckByRefEvents, OperationKind.Invocation);
+    }
+
+    private void CheckByRefEvents(OperationAnalysisContext context)
+    {
+        if (context.Operation is not IInvocationOperation operation)
+            return;
+
+        operation.TargetMethod.Equals()
+    }
+}

--- a/Robust.Analyzers/ByRefEventAnalyzer.cs
+++ b/Robust.Analyzers/ByRefEventAnalyzer.cs
@@ -1,7 +1,10 @@
-﻿using System.Collections.Immutable;
+﻿#nullable enable
+using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
+using static Microsoft.CodeAnalysis.SymbolEqualityComparer;
 
 namespace Robust.Analyzers;
 
@@ -10,33 +13,194 @@ public sealed class ByRefEventAnalyzer : DiagnosticAnalyzer
 {
     private const string ByRefAttribute = "Robust.Shared.GameObjects.ByRefEventAttribute";
 
-    private static readonly DiagnosticDescriptor ByRefRaisedByValueRule = new(
+    private static readonly DiagnosticDescriptor ByRefEventSubscribedByValueRule = new(
+        Diagnostics.IdByRefEventSubscribedByValue,
+        "By-ref event subscribed to by value",
+        "Tried to subscribe to a by-ref event '{0}' by value.",
+        "Usage",
+        DiagnosticSeverity.Error,
+        true,
+        "Make sure that methods subscribing to a ref event have the ref keyword for the event argument."
+    );
+
+    private static readonly DiagnosticDescriptor ByValueEventSubscribedByRefRule = new(
+        Diagnostics.IdValueEventRaisedByRef,
+        "Value event subscribed to by-ref",
+        "Tried to subscribe to a value event '{0}' by-ref.",
+        "Usage",
+        DiagnosticSeverity.Error,
+        true,
+        "Make sure that methods subscribing to value events do not have the ref keyword for the event argument."
+    );
+
+    private static readonly DiagnosticDescriptor ByRefEventRaisedByValueRule = new(
         Diagnostics.IdByRefEventRaisedByValue,
-        "Invalid by-refness",
+        "By-ref event raised by value",
         "Tried to raise a by-ref event '{0}' by value.",
         "Usage",
         DiagnosticSeverity.Error,
         true,
-        "Make sure that by-ref events are raised with the ref keyword."
+        "Make sure to use the ref keyword when raising ref events."
     );
 
-    private ISymbol _subscribeLocalEventMethod = default!;
+    private static readonly DiagnosticDescriptor ByValueEventRaisedByRefRule = new(
+        Diagnostics.IdValueEventRaisedByRef,
+        "Value event raised by-ref",
+        "Tried to raise a value event '{0}' by-ref.",
+        "Usage",
+        DiagnosticSeverity.Error,
+        true,
+        "Make sure to not use the ref keyword when raising value events."
+    );
 
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-        ImmutableArray.Create(ByRefRaisedByValueRule);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+        ByRefEventSubscribedByValueRule,
+        ByValueEventSubscribedByRefRule,
+        ByRefEventRaisedByValueRule,
+        ByValueEventRaisedByRefRule
+    );
 
     public override void Initialize(AnalysisContext context)
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
         context.EnableConcurrentExecution();
-        context.RegisterOperationAction(CheckByRefEvents, OperationKind.Invocation);
+        context.RegisterOperationAction(CheckEventSubscription, OperationKind.Invocation);
+        context.RegisterOperationAction(CheckEventRaise, OperationKind.Invocation);
     }
 
-    private void CheckByRefEvents(OperationAnalysisContext context)
+    private void CheckEventSubscription(OperationAnalysisContext context)
     {
         if (context.Operation is not IInvocationOperation operation)
             return;
 
-        operation.TargetMethod.Equals()
+        var subscribeMethods = context.Compilation
+            .GetTypeByMetadataName("Robust.Shared.GameObjects.EntitySystem")?
+            .GetMembers()
+            .Where(m => m.Name.Contains("SubscribeLocalEvent"))
+            .Cast<IMethodSymbol>();
+
+        if (subscribeMethods == null)
+            return;
+
+        if (!subscribeMethods.Any(m => m.Equals(operation.TargetMethod.OriginalDefinition, Default)))
+            return;
+
+        var typeArguments = operation.TargetMethod.TypeArguments;
+        if (typeArguments.Length < 1 || typeArguments.Length > 2)
+            return;
+
+        if (operation.Arguments.First().Value is not IDelegateCreationOperation delegateCreation)
+            return;
+
+        if (delegateCreation.Target is not IMethodReferenceOperation methodReference)
+            return;
+
+        var eventParameter = methodReference.Method.Parameters.LastOrDefault();
+        if (eventParameter == null)
+            return;
+
+        ITypeSymbol eventArgument;
+        switch (typeArguments.Length)
+        {
+            case 1:
+                eventArgument = typeArguments[0];
+                break;
+            case 2:
+                eventArgument = typeArguments[1];
+                break;
+            default:
+                return;
+        }
+
+        var byRefAttribute = context.Compilation.GetTypeByMetadataName(ByRefAttribute);
+        if (byRefAttribute == null)
+            return;
+
+        var isByRefEventType = eventArgument
+            .GetAttributes()
+            .Any(attribute => attribute.AttributeClass?.Equals(byRefAttribute, Default) ?? false);
+        var parameterIsRef = eventParameter.RefKind == RefKind.Ref;
+
+        if (isByRefEventType != parameterIsRef)
+        {
+            var descriptor = isByRefEventType ? ByRefEventSubscribedByValueRule : ByValueEventSubscribedByRefRule;
+            var diagnostic = Diagnostic.Create(descriptor, operation.Syntax.GetLocation(), eventArgument);
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+
+    private void CheckEventRaise(OperationAnalysisContext context)
+    {
+        if (context.Operation is not IInvocationOperation operation)
+            return;
+
+        var raiseMethods = context.Compilation
+            .GetTypeByMetadataName("Robust.Shared.GameObjects.EntitySystem")?
+            .GetMembers()
+            .Where(m => m.Name.Contains("RaiseLocalEvent") && m.Kind == SymbolKind.Method)
+            .Cast<IMethodSymbol>();
+
+        var busRaiseMethods = context.Compilation
+            .GetTypeByMetadataName("Robust.Shared.GameObjects.EntityEventBus")?
+            .GetMembers()
+            .Where(m => m.Name.Contains("RaiseLocalEvent") && m.Kind == SymbolKind.Method)
+            .Cast<IMethodSymbol>();
+
+        if (raiseMethods == null)
+            return;
+
+        if (busRaiseMethods != null)
+            raiseMethods = raiseMethods.Concat(busRaiseMethods);
+
+        if (!raiseMethods.Any(m => m.Equals(operation.TargetMethod.OriginalDefinition, Default)))
+        {
+            // If you try to do this normally by concatenating like busRaiseMethods above
+            // the analyzer does not run without any errors
+            // I don't know man
+            const string directedBusMethod = "Robust.Shared.GameObjects.IDirectedEventBus.RaiseLocalEvent";
+            if (!operation.TargetMethod.ToString().StartsWith(directedBusMethod))
+                return;
+        }
+
+        var arguments = operation.Arguments;
+        IArgumentOperation eventArgument;
+        switch (arguments.Length)
+        {
+            case 1:
+                eventArgument = arguments[0];
+                break;
+            case 2:
+            case 3:
+                eventArgument = arguments[1];
+                break;
+            default:
+                return;
+        }
+
+        var eventParameter = eventArgument.Parameter;
+        // TODO have a way to check generic type parameters
+        if (eventParameter == null ||
+            eventParameter.Type.SpecialType == SpecialType.System_Object ||
+            eventParameter.Type.TypeKind == TypeKind.TypeParameter)
+        {
+            return;
+        }
+
+        var byRefAttribute = context.Compilation.GetTypeByMetadataName(ByRefAttribute);
+        if (byRefAttribute == null)
+            return;
+
+        var isByRefEventType = eventParameter.Type
+            .GetAttributes()
+            .Any(attribute => attribute.AttributeClass?.Equals(byRefAttribute, Default) ?? false);
+
+        var parameterIsRef = eventParameter.RefKind == RefKind.Ref;
+
+        if (isByRefEventType != parameterIsRef)
+        {
+            var descriptor = isByRefEventType ? ByRefEventRaisedByValueRule : ByValueEventRaisedByRefRule;
+            var diagnostic = Diagnostic.Create(descriptor, eventArgument.Syntax.GetLocation(), eventParameter.Type);
+            context.ReportDiagnostic(diagnostic);
+        }
     }
 }

--- a/Robust.Analyzers/Diagnostics.cs
+++ b/Robust.Analyzers/Diagnostics.cs
@@ -17,6 +17,8 @@ public static class Diagnostics
     public const string IdInvalidNotNullableFlagImplementation = "RA0010";
     public const string IdInvalidNotNullableFlagType = "RA0011";
     public const string IdNotNullableFlagValueType = "RA0012";
+    public const string IdByRefEventRaisedByValue = "RA0013";
+    public const string IdValueEventRaisedByRef = "RA0014";
 
     public static SuppressionDescriptor MeansImplicitAssignment =>
         new SuppressionDescriptor("RADC1000", "CS0649", "Marked as implicitly assigned.");

--- a/Robust.Analyzers/Diagnostics.cs
+++ b/Robust.Analyzers/Diagnostics.cs
@@ -17,8 +17,10 @@ public static class Diagnostics
     public const string IdInvalidNotNullableFlagImplementation = "RA0010";
     public const string IdInvalidNotNullableFlagType = "RA0011";
     public const string IdNotNullableFlagValueType = "RA0012";
-    public const string IdByRefEventRaisedByValue = "RA0013";
-    public const string IdValueEventRaisedByRef = "RA0014";
+    public const string IdByRefEventSubscribedByValue = "RA0013";
+    public const string IdValueEventSubscribedByRef = "RA0014";
+    public const string IdByRefEventRaisedByValue = "RA0015";
+    public const string IdValueEventRaisedByRef = "RA0016";
 
     public static SuppressionDescriptor MeansImplicitAssignment =>
         new SuppressionDescriptor("RADC1000", "CS0649", "Marked as implicitly assigned.");

--- a/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.RefBroadcastEvents.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.RefBroadcastEvents.cs
@@ -59,8 +59,10 @@ namespace Robust.UnitTesting.Shared.GameObjects
             public override void Initialize()
             {
                 // The below is not allowed, as you're subscribing by-ref and by-value to the same event...
+#pragma warning disable RA0013
                 SubscribeLocalEvent<TestStructEvent>(MyRefHandler);
                 SubscribeLocalEvent<TestStructEvent>(MyValueHandler);
+#pragma warning enable RA0013
             }
 
             private void MyValueHandler(TestStructEvent args) { }

--- a/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.RefDirectedEvents.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.RefDirectedEvents.cs
@@ -77,7 +77,9 @@ namespace Robust.UnitTesting.Shared.GameObjects
             {
                 // The below is not allowed, as you're subscribing by-ref and by-value to the same event...
                 SubscribeLocalEvent<DummyComponent, TestStructEvent>(MyRefHandler);
+#pragma warning disable RA0013
                 SubscribeLocalEvent<DummyTwoComponent, TestStructEvent>(MyValueHandler);
+#pragma warning enable RA0013
             }
 
             private void MyValueHandler(EntityUid uid, DummyTwoComponent component, TestStructEvent args) { }


### PR DESCRIPTION
No longer do I have to start up the game just to get yelled at by the event bus because I forgot a ref keyword or ByRefEvent attribute.

https://user-images.githubusercontent.com/10968691/220374469-934b9f04-d3a1-43ac-863f-cb390fcd9e89.mp4