### PR TITLE
Fix concurrent update error in SerializationManager._copyByRefRegistrations

### DIFF
--- a/Robust.Shared/Serialization/Manager/SerializationManager.Copying.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.Copying.cs
@@ -250,7 +250,7 @@ public sealed partial class SerializationManager
         return type.IsPrimitive ||
                type.IsEnum ||
                type == typeof(string) ||
-               _copyByRefRegistrations.Contains(type);
+               _copyByRefRegistrations.ContainsKey(type);
     }
 
     private bool CopyToInternal<TCommon>(

--- a/Robust.Shared/Serialization/Manager/SerializationManager.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.cs
@@ -28,7 +28,9 @@ namespace Robust.Shared.Serialization.Manager
         private bool _initialized;
 
         private readonly ConcurrentDictionary<Type, DataDefinition> _dataDefinitions = new();
-        private readonly HashSet<Type> _copyByRefRegistrations = new();
+
+        // Always has a dummy value of 0 for any types that should be copied by ref
+        private readonly ConcurrentDictionary<Type, byte> _copyByRefRegistrations = new();
 
         [field: IoC.Dependency]
         public IDependencyCollection DependencyCollection { get; } = default!;
@@ -169,7 +171,7 @@ namespace Robust.Shared.Serialization.Manager
                 throw new ArgumentException($"Invalid Types used for include fields:\n{invalidIncludes}");
             }
 
-            _copyByRefRegistrations.Add(typeof(Type));
+            _copyByRefRegistrations[typeof(Type)] = 0;
 
             _initialized = true;
             _initializing = false;
@@ -209,7 +211,7 @@ namespace Robust.Shared.Serialization.Manager
                     implicitDataRecord.Add(type);
 
                 if (type.IsDefined(typeof(CopyByRefAttribute)))
-                    _copyByRefRegistrations.Add(type);
+                    _copyByRefRegistrations[type] = 0;
             });
         }
 


### PR DESCRIPTION
serv4 just a week away

```
  Failed ToMap_MoveGrid(100,-500,-200,-300) [< 1 ms]
  Error Message:
   Robust.Shared.GameObjects.EntityCreationException : Exception inside CreateEntity with prototype dummy
  ----> System.InvalidOperationException : Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
  Stack Trace:
     at Robust.Shared.GameObjects.EntityManager.CreateEntity(String prototypeName, EntityUid uid) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 565
   at Robust.Server.GameObjects.ServerEntityManager.CreateEntity(String prototypeName, EntityUid uid) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 80
   at Robust.Shared.GameObjects.EntityManager.CreateEntityUninitialized(String prototypeName, EntityCoordinates coordinates) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 184
   at Robust.UnitTesting.Shared.Map.EntityCoordinates_Tests.ToMap_MoveGrid(Single x1, Single y1, Single x2, Single y2) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.UnitTesting/Shared/Map/EntityCoordinates_Tests.cs:line 273
   at InvokeStub_EntityCoordinates_Tests.ToMap_MoveGrid(Object, Object, IntPtr*)
   at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
--InvalidOperationException
   at System.Collections.Generic.HashSet`1.FindItemIndex(T item)
   at System.Collections.Generic.HashSet`1.Contains(T item)
   at Robust.Shared.Serialization.Manager.SerializationManager.ShouldReturnSource(Type type) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/Serialization/Manager/SerializationManager.Copying.cs:line 250
   at Robust.Shared.Serialization.Manager.SerializationManager.CopyToInternal[TCommon](TCommon source, TCommon& target, DataDefinition`1 definition, ISerializationManager serializationManager, SerializationHookContext hookCtx, ISerializationContext context) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/Serialization/Manager/SerializationManager.Copying.cs:line 272
   at lambda_method24719(Closure, IComponent, IComponent&, SerializationHookContext, ISerializationContext)
   at Robust.Shared.Serialization.Manager.SerializationManager.CopyTo[T](T source, T& target, SerializationHookContext hookCtx, ISerializationContext context, Boolean notNullableOverride) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/Serialization/Manager/SerializationManager.Copying.cs:line 414
   at Robust.Shared.Serialization.Manager.SerializationManager.CopyTo[T](T source, T& target, ISerializationContext context, Boolean skipHook, Boolean notNullableOverride) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/Serialization/Manager/SerializationManager.Copying.cs:line 391
   at Robust.Shared.Prototypes.EntityPrototype.EnsureCompExistsAndDeserialize(EntityUid entity, IComponentFactory factory, IEntityManager entityManager, ISerializationManager serManager, String compName, IComponent data, ISerializationContext context) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/Prototypes/EntityPrototype.cs:line 247
   at Robust.Shared.Prototypes.EntityPrototype.LoadEntity(EntityPrototype prototype, EntityUid entity, IComponentFactory factory, IEntityManager entityManager, ISerializationManager serManager, IEntityLoadContext context) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/Prototypes/EntityPrototype.cs:line 202
   at Robust.Shared.GameObjects.EntityManager.CreateEntity(String prototypeName, EntityUid uid) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 557
```