### PR TITLE
Fix PanelContainer ArrangeOverride()

### DIFF
--- a/Robust.Client/UserInterface/Controls/PanelContainer.cs
+++ b/Robust.Client/UserInterface/Controls/PanelContainer.cs
@@ -34,13 +34,24 @@ namespace Robust.Client.UserInterface.Controls
 
         protected override Vector2 ArrangeOverride(Vector2 finalSize)
         {
-            var pixelSize = finalSize * UIScale;
-            var ourSize = UIBox2.FromDimensions(Vector2.Zero, pixelSize);
-            var contentBox = _getStyleBox()?.GetContentBox(ourSize) ?? ourSize;
+            var style = _getStyleBox();
+
+            UIBox2 contentBox;
+            if (style == null)
+            {
+                contentBox = UIBox2.FromDimensions(Vector2.Zero, finalSize);
+            }
+            else
+            {
+                var scale = UIScale;
+                var pixelBox = UIBox2.FromDimensions(Vector2.Zero, finalSize * scale);
+                var contentPixelBox = style.GetContentBox(pixelBox);
+                contentBox = new UIBox2(contentPixelBox.TopLeft/scale, contentPixelBox.BottomRight/scale);
+            }
 
             foreach (var child in Children)
             {
-                child.ArrangePixel((UIBox2i) contentBox);
+                child.Arrange(contentBox);
             }
 
             return finalSize;


### PR DESCRIPTION
Currently the PanelContainer's `MeasureOverride()` treat style box margins/padding as physical pixels (i.e., not scaled by `UiScale`), while the `ArrangeOverride()` effectively treats them as virtual pixels. This PR changes the arrange method so that it also treats them like physical pixels, which fixes some UI layout bugs (e.g., scroll bar visibility in context menu pop-ups).