### PR TITLE
Adds an option to control rendering strategies on a layer basis for sprites

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1340,7 +1340,7 @@ namespace Robust.Client.GameObjects
                             layer.Render(drawingHandle, ref transformSprite, angle, overrideDirection);
                             break;
                         default:
-                            Logger.Error($"Tried to render a layer with unknown rendering stragegy : {layer.RenderingStrategy}");
+                            Logger.Error($"Tried to render a layer with unknown rendering stragegy: {layer.RenderingStrategy}");
                             break;
                     }
                 }

--- a/Robust.Shared/GameObjects/Components/Renderable/SpriteLayerData.cs
+++ b/Robust.Shared/GameObjects/Components/Renderable/SpriteLayerData.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Robust.Shared.GameObjects;
 

--- a/Robust.Shared/GameObjects/Components/Renderable/SpriteLayerData.cs
+++ b/Robust.Shared/GameObjects/Components/Renderable/SpriteLayerData.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Robust.Shared.GameObjects;
 
@@ -26,4 +28,14 @@ public sealed class PrototypeLayerData
     [DataField("visible")] public bool? Visible;
     [DataField("color")] public Color? Color;
     [DataField("map")] public HashSet<string>? MapKeys;
+    [DataField("renderingStrategy")] public LayerRenderingStrategy? RenderingStrategy;
+}
+
+[Serializable, NetSerializable]
+public enum LayerRenderingStrategy
+{
+    Default,
+    SnapToCardinals,
+    NoRotation,
+    UseSpriteStrategy
 }


### PR DESCRIPTION
**Context**
While trying to make freezers/heaters rotatable again in the SS14 codebase, we've encountered a case where some layers needed to have differents rendering strategies (the machine body shouldn't rotate and always faces south while the pipes connectors can rotate freely or snap to cardinals).
See https://github.com/space-wizards/space-station-14/pull/14225#issuecomment-1440991771 and https://github.com/space-wizards/space-station-14/pull/14225#issuecomment-1442670391

The current "fix" is to put the whole sprite on No Rotation and duplicates all icons (for all states) so they exist for the four directions. That's obviously far from ideal.

**In this PR**
What i propose here is to add attributes to both the sprite component and the layer object that would allows layer-based rendering differentiation :

* the sprite's `GranularLayersRendering` is set to `false` by default, so every existing sprites will work as usual with the minimal overhead of checking a bool
* if `GranularLayersRendering` is set to `true` (only possible in the prototype), then, when the sprite renders, it computes the three matrices related to the default/norotation/snapcardinal strategies and apply them on a per-layer basis, using the layer's `LayerRenderingStrategy` (here again set in the prototype) to select which one to apply.

Unfortunately, the yaml data type for `LayerRenderingStrategy` is a string, because it proved a real pain to make it an enumeration.