### PR TITLE
Fix pvs bugs

### DIFF
--- a/Robust.Client/GameStates/GameStateProcessor.cs
+++ b/Robust.Client/GameStates/GameStateProcessor.cs
@@ -193,6 +193,8 @@ namespace Robust.Client.GameStates
                     {
                         var old = compData[change.NetID];
 
+                        DebugTools.Assert(old is IComponentDeltaState oldDelta && oldDelta.FullState, "last state is not a full state");
+
                         if (cloneDelta)
                         {
                             compState = delta.CreateNewFullState(old);
@@ -202,7 +204,7 @@ namespace Robust.Client.GameStates
                             delta.ApplyToFullState(old);
                             compState = old;
                         }
-                        DebugTools.Assert(compState is IComponentDeltaState newState && newState.FullState);
+                        DebugTools.Assert(compState is IComponentDeltaState newState && newState.FullState, "newly constructed state is not a full state");
                     }
 
                     compData[change.NetID] = compState;

--- a/Robust.Server/GameStates/PVSSystem.Dirty.cs
+++ b/Robust.Server/GameStates/PVSSystem.Dirty.cs
@@ -17,13 +17,13 @@ namespace Robust.Server.GameStates
         /// <summary>
         /// if it's a new entity we need to GetEntityState from tick 0.
         /// </summary>
-        private HashSet<EntityUid>[] _addEntities = new HashSet<EntityUid>[TickBuffer];
-        private HashSet<EntityUid>[] _dirtyEntities = new HashSet<EntityUid>[TickBuffer];
+        private HashSet<EntityUid>[] _addEntities = new HashSet<EntityUid>[DirtyBufferSize];
+        private HashSet<EntityUid>[] _dirtyEntities = new HashSet<EntityUid>[DirtyBufferSize];
         private int _currentIndex = 1;
 
         private void InitializeDirty()
         {
-            for (var i = 0; i < TickBuffer; i++)
+            for (var i = 0; i < DirtyBufferSize; i++)
             {
                 _addEntities[i] = new HashSet<EntityUid>(32);
                 _dirtyEntities[i] = new HashSet<EntityUid>(32);
@@ -40,7 +40,7 @@ namespace Robust.Server.GameStates
 
         private void OnEntityAdd(EntityUid e)
         {
-            DebugTools.Assert(_currentIndex == _gameTiming.CurTick.Value % TickBuffer ||
+            DebugTools.Assert(_currentIndex == _gameTiming.CurTick.Value % DirtyBufferSize ||
                 _gameTiming.GetType().Name == "IGameTimingProxy");// Look I have NFI how best to excuse this assert if the game timing isn't real (a Mock<IGameTiming>). 
             _addEntities[_currentIndex].Add(e);
         }
@@ -54,14 +54,14 @@ namespace Robust.Server.GameStates
         private bool TryGetTick(GameTick tick, [NotNullWhen(true)] out HashSet<EntityUid>? addEntities, [NotNullWhen(true)] out HashSet<EntityUid>? dirtyEntities)
         {
             var currentTick = _gameTiming.CurTick;
-            if (currentTick.Value - tick.Value >= TickBuffer)
+            if (currentTick.Value - tick.Value >= DirtyBufferSize)
             {
                 addEntities = null;
                 dirtyEntities = null;
                 return false;
             }
 
-            var index = tick.Value % TickBuffer;
+            var index = tick.Value % DirtyBufferSize;
             addEntities = _addEntities[index];
             dirtyEntities = _dirtyEntities[index];
             return true;

--- a/Robust.Server/GameStates/PVSSystem.Dirty.cs
+++ b/Robust.Server/GameStates/PVSSystem.Dirty.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using Robust.Server.Player;
-using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Timing;
@@ -16,18 +14,16 @@ namespace Robust.Server.GameStates
     {
         [Dependency] private readonly IGameTiming _gameTiming = default!;
 
-        private const int DirtyBufferSize = 4;
-
         /// <summary>
         /// if it's a new entity we need to GetEntityState from tick 0.
         /// </summary>
-        private HashSet<EntityUid>[] _addEntities = new HashSet<EntityUid>[DirtyBufferSize];
-        private HashSet<EntityUid>[] _dirtyEntities = new HashSet<EntityUid>[DirtyBufferSize];
+        private HashSet<EntityUid>[] _addEntities = new HashSet<EntityUid>[TickBuffer];
+        private HashSet<EntityUid>[] _dirtyEntities = new HashSet<EntityUid>[TickBuffer];
         private int _currentIndex = 1;
 
         private void InitializeDirty()
         {
-            for (var i = 0; i < DirtyBufferSize; i++)
+            for (var i = 0; i < TickBuffer; i++)
             {
                 _addEntities[i] = new HashSet<EntityUid>(32);
                 _dirtyEntities[i] = new HashSet<EntityUid>(32);
@@ -44,7 +40,7 @@ namespace Robust.Server.GameStates
 
         private void OnEntityAdd(EntityUid e)
         {
-            DebugTools.Assert(_currentIndex == _gameTiming.CurTick.Value % DirtyBufferSize ||
+            DebugTools.Assert(_currentIndex == _gameTiming.CurTick.Value % TickBuffer ||
                 _gameTiming.GetType().Name == "IGameTimingProxy");// Look I have NFI how best to excuse this assert if the game timing isn't real (a Mock<IGameTiming>). 
             _addEntities[_currentIndex].Add(e);
         }
@@ -58,14 +54,14 @@ namespace Robust.Server.GameStates
         private bool TryGetTick(GameTick tick, [NotNullWhen(true)] out HashSet<EntityUid>? addEntities, [NotNullWhen(true)] out HashSet<EntityUid>? dirtyEntities)
         {
             var currentTick = _gameTiming.CurTick;
-            if (currentTick.Value - tick.Value >= DirtyBufferSize)
+            if (currentTick.Value - tick.Value >= TickBuffer)
             {
                 addEntities = null;
                 dirtyEntities = null;
                 return false;
             }
 
-            var index = tick.Value % DirtyBufferSize;
+            var index = tick.Value % TickBuffer;
             if (index > _dirtyEntities.Length - 1)
             {
                 addEntities = null;

--- a/Robust.Server/GameStates/PVSSystem.Dirty.cs
+++ b/Robust.Server/GameStates/PVSSystem.Dirty.cs
@@ -62,13 +62,6 @@ namespace Robust.Server.GameStates
             }
 
             var index = tick.Value % TickBuffer;
-            if (index > _dirtyEntities.Length - 1)
-            {
-                addEntities = null;
-                dirtyEntities = null;
-                return false;
-            }
-
             addEntities = _addEntities[index];
             dirtyEntities = _dirtyEntities[index];
             return true;

--- a/Robust.Server/GameStates/PVSSystem.Dirty.cs
+++ b/Robust.Server/GameStates/PVSSystem.Dirty.cs
@@ -51,7 +51,7 @@ namespace Robust.Server.GameStates
                 _dirtyEntities[_currentIndex].Add(uid);
         }
 
-        private bool TryGetTick(GameTick tick, [NotNullWhen(true)] out HashSet<EntityUid>? addEntities, [NotNullWhen(true)] out HashSet<EntityUid>? dirtyEntities)
+        private bool TryGetDirtyEntities(GameTick tick, [NotNullWhen(true)] out HashSet<EntityUid>? addEntities, [NotNullWhen(true)] out HashSet<EntityUid>? dirtyEntities)
         {
             var currentTick = _gameTiming.CurTick;
             if (currentTick.Value - tick.Value >= DirtyBufferSize)

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -1072,7 +1072,7 @@ internal sealed partial class PVSSystem : EntitySystem
             var metaQuery = EntityManager.GetEntityQuery<MetaDataComponent>();
             for (var i = fromTick.Value + 1; i <= toTick.Value; i++)
             {
-                if (!TryGetTick(new GameTick(i), out var add, out var dirty))
+                if (!TryGetDirtyEntities(new GameTick(i), out var add, out var dirty))
                 {
                     // This should be unreachable if `enumerateAll` is false.
                     throw new Exception($"Failed to get tick dirty data. tick: {i}, from: {fromTick}, to {toTick}, buffer: {DirtyBufferSize}");

--- a/Robust.Shared/Console/Commands/MapCommands.cs
+++ b/Robust.Shared/Console/Commands/MapCommands.cs
@@ -133,6 +133,9 @@ internal sealed class ListMapsCommand : LocalizedCommands
 
     public override string Command => "lsmap";
 
+    // PVS prevents the player from knowing about all maps.
+    public override bool RequireServerOrSingleplayer => true;
+
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
         var msg = new StringBuilder();
@@ -156,6 +159,10 @@ internal sealed class ListGridsCommand : LocalizedCommands
     [Dependency] private readonly IMapManager _map = default!;
 
     public override string Command => "lsgrid";
+
+    // PVS prevents the player from knowing about all maps.
+    public override bool RequireServerOrSingleplayer => true;
+
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
         var msg = new StringBuilder();


### PR DESCRIPTION
- Fixes paused entities not being properly sent when pvs is disabled (replace `EntityQueryEnumerator` -> `AllEntityQueryEnumerator`)
- Fixes an off-by-one error that was causing redundant data to be sent while PVS was disabled.
- Combines `DirtyBufferSize` and `TickBuffer` into a single const. These basically performed the same role, one for when PVS is enabled, and another for when PVS is disabled, and I can't think of any situation where you would want these to be different.
- Fixes `lsmap` and `lsgrid` commands not listing all entities because of PVS.