### PR TITLE
Integration test logging improvements

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,11 +39,11 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* `IntegrationOptions` now allows changing the `ILogHandler` used by the integration test via `OverrideLogHandler`.
 
 ### Bugfixes
 
-*None yet*
+* Default integration test log output should more reliably capture `TestContext.Out` now.
 
 ### Other
 

--- a/Robust.UnitTesting/RobustIntegrationTest.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
@@ -245,6 +246,8 @@ namespace Robust.UnitTesting
             private protected readonly ChannelReader<object> _fromInstanceReader;
             private protected readonly ChannelWriter<object> _fromInstanceWriter;
 
+            private protected TextWriter _testOut;
+
             private int _currentTicksId = 1;
             private int _ackTicksId;
 
@@ -302,6 +305,7 @@ namespace Robust.UnitTesting
             private protected IntegrationInstance(IntegrationOptions? options)
             {
                 Options = options;
+                _testOut = TestContext.Out;
 
                 var toInstance = Channel.CreateUnbounded<object>(new UnboundedChannelOptions
                 {
@@ -659,7 +663,8 @@ namespace Robust.UnitTesting
                 });
 
                 server.ContentStart = Options?.ContentStart ?? false;
-                if (server.Start(serverOptions, () => new TestLogHandler(cfg, "SERVER")))
+                var logHandler = Options?.OverrideLogHandler ?? (() => new TestLogHandler(cfg, "SERVER", _testOut));
+                if (server.Start(serverOptions, logHandler))
                 {
                     throw new Exception("Server failed to start.");
                 }
@@ -840,7 +845,7 @@ namespace Robust.UnitTesting
                 client.ContentStart = Options?.ContentStart ?? false;
                 client.StartupSystemSplash(
                     clientOptions,
-                    () => new TestLogHandler(cfg, "CLIENT"),
+                    Options?.OverrideLogHandler ?? (() => new TestLogHandler(cfg, "CLIENT", _testOut)),
                     globalExceptionLog: false);
                 client.StartupContinue(GameController.DisplayMode.Headless);
 
@@ -986,6 +991,8 @@ namespace Robust.UnitTesting
             public Dictionary<string, string> CVarOverrides { get; } = new();
             public bool Asynchronous { get; set; } = true;
             public bool? Pool { get; set; }
+
+            public Func<ILogHandler>? OverrideLogHandler { get; set; }
         }
 
         /// <summary>

--- a/Robust.UnitTesting/TestLogHandler.cs
+++ b/Robust.UnitTesting/TestLogHandler.cs
@@ -14,12 +14,12 @@ namespace Robust.UnitTesting
         private readonly TextWriter _writer;
         private readonly Stopwatch _sw = Stopwatch.StartNew();
 
-        public TestLogHandler(IConfigurationManager cfg, string? prefix = null)
+        public TestLogHandler(IConfigurationManager cfg, string? prefix = null, TextWriter? testOutput = null)
         {
             cfg.OnValueChanged(RTCVars.FailureLogLevel, value => FailureLevel = value, true);
 
             _prefix = prefix;
-            _writer = TestContext.Out;
+            _writer = testOutput ?? TestContext.Out;
             _writer.WriteLine($"{GetPrefix()}Started {DateTime.Now:o}");
         }
 


### PR DESCRIPTION
Allow overriding the log handler that is created for integration instances. Cache TestContext.Out earlier to make sure it's attributed to the correct test.