### PR TITLE
Improve Discord Rich Presence

### DIFF
--- a/Robust.Client/BaseClient.cs
+++ b/Robust.Client/BaseClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Net;
 using Robust.Client.Configuration;
 using Robust.Client.Debugging;
@@ -63,7 +64,14 @@ namespace Robust.Client
             _configManager.OnValueChanged(CVars.NetTickrate, TickRateChanged, invokeImmediately: true);
 
             _playMan.Initialize();
+            _playMan.PlayerListUpdated += OnPlayerListUpdated;
             Reset();
+        }
+
+        private void OnPlayerListUpdated(object? sender, EventArgs e)
+        {
+            var serverPlayers = _playMan.PlayerCount;
+            _discord.Update(GameInfo!.ServerName, _net.ServerChannel!.UserName, GameInfo.ServerMaxPlayers.ToString(), serverPlayers.ToString());
         }
 
         private void SyncTimeBase(MsgSyncTimeBase message)
@@ -165,11 +173,9 @@ namespace Robust.Client
             var maxPlayers = _configManager.GetCVar<int>("game.maxplayers");
             info.ServerMaxPlayers = maxPlayers;
 
-            var ServerPlayers = _playMan.PlayerCount;
-
             var userName = _net.ServerChannel!.UserName;
             var userId = _net.ServerChannel.UserId;
-            _discord.Update(info.ServerName, userName, info.ServerMaxPlayers.ToString(), ServerPlayers.ToString());
+
             // start up player management
             _playMan.Startup();
 
@@ -177,6 +183,10 @@ namespace Robust.Client
             _playMan.LocalPlayer.Name = userName;
 
             _playMan.LocalPlayer.StatusChanged += OnLocalStatusChanged;
+
+            var serverPlayers = _playMan.PlayerCount;
+            _discord.Update(info.ServerName, userName, info.ServerMaxPlayers.ToString(), serverPlayers.ToString());
+
         }
 
         /// <summary>

--- a/Robust.Client/BaseClient.cs
+++ b/Robust.Client/BaseClient.cs
@@ -165,9 +165,11 @@ namespace Robust.Client
             var maxPlayers = _configManager.GetCVar<int>("game.maxplayers");
             info.ServerMaxPlayers = maxPlayers;
 
+            var ServerPlayers = _playMan.PlayerCount;
+
             var userName = _net.ServerChannel!.UserName;
             var userId = _net.ServerChannel.UserId;
-            _discord.Update(info.ServerName, userName, info.ServerMaxPlayers.ToString());
+            _discord.Update(info.ServerName, userName, info.ServerMaxPlayers.ToString(), ServerPlayers.ToString());
             // start up player management
             _playMan.Startup();
 

--- a/Robust.Client/Utility/DiscordRichPresence.cs
+++ b/Robust.Client/Utility/DiscordRichPresence.cs
@@ -3,6 +3,7 @@ using DiscordRPC.Logging;
 using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.IoC;
+using Robust.Shared.Localization;
 using Robust.Shared.Log;
 using LogLevel = DiscordRPC.Logging.LogLevel;
 
@@ -10,15 +11,7 @@ namespace Robust.Client.Utility
 {
     internal sealed class DiscordRichPresence : IDiscordRichPresence
     {
-        private static readonly RichPresence _defaultPresence = new()
-        {
-            State = "In Main Menu",
-            Assets = new Assets
-            {
-                LargeImageKey = "logo",
-                LargeImageText = "I think coolsville SUCKS"
-            }
-        };
+        private static RichPresence _defaultPresence = new() {};
 
         private RichPresence? _activePresence;
 
@@ -26,11 +19,21 @@ namespace Robust.Client.Utility
 
         [Dependency] private readonly IConfigurationManager _configurationManager = default!;
         [Dependency] private readonly ILogManager _logManager = default!;
+        [Dependency] private readonly ILocalizationManager _loc = default!;
 
         private bool _initialized;
 
         public void Initialize()
         {
+            _defaultPresence = new()
+            {
+                State = _loc.GetString("discord-rpc-in-main-menu"),
+                Assets = new Assets
+                {
+                    LargeImageKey = "logo",
+                    LargeImageText = "I think coolsville SUCKS"
+                }
+            };
             _configurationManager.OnValueChanged(CVars.DiscordEnabled, newValue =>
             {
                 if (!_initialized)
@@ -50,7 +53,7 @@ namespace Robust.Client.Utility
                     _stop();
                 }
             });
-            
+
             if (_configurationManager.GetCVar(CVars.DiscordEnabled))
             {
                 _start();
@@ -90,16 +93,16 @@ namespace Robust.Client.Utility
             _client = null;
         }
 
-        public void Update(string serverName, string username, string maxUser, string Users)
+        public void Update(string serverName, string username, string maxUsers, string users)
         {
             _activePresence = new RichPresence
             {
-                Details = $"On Server: {serverName}",
-                State = $"Players: {Users}/{maxUser}",
+                Details = _loc.GetString("discord-rpc-on-server", ("servername", serverName)),
+                State = _loc.GetString("discord-rpc-players", ("players", users), ("maxplayers", maxUsers)),
                 Assets = new Assets
                 {
                     LargeImageKey = "devstation",
-                    LargeImageText = $"Character: {username}",
+                    LargeImageText = _loc.GetString("discord-rpc-character", ("username", username)),
                     SmallImageKey = "logo"
                 }
             };

--- a/Robust.Client/Utility/DiscordRichPresence.cs
+++ b/Robust.Client/Utility/DiscordRichPresence.cs
@@ -1,4 +1,4 @@
-﻿using DiscordRPC;
+using DiscordRPC;
 using DiscordRPC.Logging;
 using Robust.Shared;
 using Robust.Shared.Configuration;
@@ -12,13 +12,11 @@ namespace Robust.Client.Utility
     {
         private static readonly RichPresence _defaultPresence = new()
         {
-            Details = "In Main Menu",
             State = "In Main Menu",
             Assets = new Assets
             {
-                LargeImageKey = "devstation",
-                LargeImageText = "I think coolsville SUCKS",
-                SmallImageKey = "logo"
+                LargeImageKey = "logo",
+                LargeImageText = "I think coolsville SUCKS"
             }
         };
 
@@ -92,12 +90,12 @@ namespace Robust.Client.Utility
             _client = null;
         }
 
-        public void Update(string serverName, string username, string maxUser)
+        public void Update(string serverName, string username, string maxUser, string Users)
         {
             _activePresence = new RichPresence
             {
                 Details = $"On Server: {serverName}",
-                State = $"Max players: {maxUser}",
+                State = $"Players: {Users}/{maxUser}",
                 Assets = new Assets
                 {
                     LargeImageKey = "devstation",

--- a/Robust.Client/Utility/IDiscordRichPresence.cs
+++ b/Robust.Client/Utility/IDiscordRichPresence.cs
@@ -1,11 +1,11 @@
-﻿using System;
+using System;
 
 namespace Robust.Client.Utility
 {
     public interface IDiscordRichPresence: IDisposable
     {
         void Initialize();
-        void Update(string serverName, string username, string maxUser);
+        void Update(string serverName, string username, string maxUser, string Users);
         void ClearPresence();
     }
 }


### PR DESCRIPTION
**This PR is necessary - space-wizards/space-station-14#14350**

### What does it change?
- Removes the second "In Main Menu" string
- Adds player counter instead of only max players (now it looks like **Players: 2/10**)
- You can now change the text shown in Rich Presence without changing the engine (Localization support)
- Makes the logo primary image when in lobby
- Makes Discord RPC automatically update when a player joins the server
### Media
![image](https://user-images.githubusercontent.com/46868845/220157741-e215bd30-0320-470c-ac21-97f919f1a94b.png)
![image](https://user-images.githubusercontent.com/46868845/220157749-c871053d-5b24-46de-ab96-17d1f9a52acd.png)