### PR TITLE
Make map loader more robust

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -404,7 +404,8 @@ public sealed class MapLoaderSystem : EntitySystem
             }
             catch (UnknownPrototypeException e)
             {
-                Logger.ErrorS("loader", "Ignoring unknown prototype " + type.ToString());
+                if (type != null)
+                    Logger.ErrorS("loader", "Ignoring unknown prototype " + type.ToString());
             }
         }
 

--- a/Robust.Server/Maps/GridSerializer.cs
+++ b/Robust.Server/Maps/GridSerializer.cs
@@ -74,7 +74,17 @@ internal sealed class MapChunkSerializer : ITypeSerializer<MapChunk, MappingData
                 var variant = reader.ReadByte();
 
                 var defName = tileMap[id];
-                id = tileDefinitionManager[defName].TileId;
+                try
+                {
+                    // ITileDefinitionManager doesn't have a public Contains() method, so
+                    // we have to do it this way.
+                    id = tileDefinitionManager[defName].TileId;
+                }
+                catch (KeyNotFoundException e)
+                {
+                    string ReplacementTile = "Plating";
+                    id = tileDefinitionManager[ReplacementTile].TileId;
+                }
 
                 var tile = new Tile(id, flags, variant);
                 chunk.SetTile(x, y, tile);


### PR DESCRIPTION
## What
RobustToolbox's map loader is unrobust and cowardly bails out (usually with a massive backtrace in the console) when somebody tries to load old maps.

This PR makes RobustToolbox more robust by trying harder to load maps with missing prototypes and tiles (old maps). Drop entities with missing prototypes and replace missing tiles with Plating so that these maps at least load.

## Why
![image](https://user-images.githubusercontent.com/3229565/222613473-9be4ae21-925e-4b20-be38-372058fa01db.png)

Obviously, mappers still have to go find and replace the missing things, but this is infinitely better than giving up and starting a new version of Moose based on screenshots of the original, which is what mappers currently do.

## Results
This PR allows the current version of SS14 to load the original Moose, which was made a Long Time Ago:

![image](https://user-images.githubusercontent.com/3229565/222613293-9f28d322-8e2d-4d99-907d-c24bc7929838.png)

Notice that because somebody thought it was a good idea to rename all of the tiles (including space tiles), the backup Plating tile is loaded along chunkbb boundaries.

I wrote a vimscript to CamelCase the tilemap strings, which results in most of the correct tiles loading:

![image](https://user-images.githubusercontent.com/3229565/222613728-12e33a46-db7b-4458-adec-c4fa6a10bf54.png)

Due to personal safety reasons I am not submitting this vimscript at this time.