### PR TITLE
Ensures SplitContainer children have measured sizes when clamping split center

### DIFF
--- a/Robust.Client/UserInterface/Controls/SplitContainer.cs
+++ b/Robust.Client/UserInterface/Controls/SplitContainer.cs
@@ -191,8 +191,23 @@ namespace Robust.Client.UserInterface.Controls
                 var first = GetChild(0);
                 var second = GetChild(1);
 
-                firstMinSize ??= (Vertical ? first.DesiredSize.Y : first.DesiredSize.X);
-                secondMinSize ??= (Vertical ? second.DesiredSize.Y : second.DesiredSize.X);
+                var firstDesiredSize = firstMinSize ?? (Vertical ? first.DesiredSize.Y : first.DesiredSize.X);
+                var secondDesiredSize = secondMinSize ??  (Vertical ? second.DesiredSize.Y : second.DesiredSize.X);
+                var firstOrientedMinSize = Vertical ? first.MinSize.Y : first.MinSize.X;
+                var secondOrientedMinSize = Vertical ? second.MinSize.Y : second.MinSize.X;
+
+                if (firstOrientedMinSize > firstDesiredSize && firstOrientedMinSize != 0)
+                {
+                    first.Measure(controlSize);
+                }
+
+                if (secondOrientedMinSize > secondDesiredSize && secondOrientedMinSize != 0)
+                {
+                    second.Measure(controlSize);
+                }
+
+                firstMinSize = Vertical ? first.DesiredSize.Y : first.DesiredSize.X;
+                secondMinSize = Vertical ? second.DesiredSize.Y : second.DesiredSize.X;
                 var size = Vertical ? controlSize.Y : controlSize.X;
 
                 _splitStart = MathHelper.Clamp(_splitStart, firstMinSize.Value,


### PR DESCRIPTION
This caused a bug (https://github.com/space-wizards/space-station-14/issues/14454) whenever the split in a SplitContainer was moved in a full screen window, and then the window was sized down to a smaller size.