### PR TITLE
Use preset matrices for 90 degree angles

### DIFF
--- a/Robust.Shared.Maths/Matrix3.cs
+++ b/Robust.Shared.Maths/Matrix3.cs
@@ -467,7 +467,14 @@ namespace Robust.Shared.Maths
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Matrix3 CreateTransform(in Vector2 position, in Angle angle)
         {
-            return CreateTransform(position.X, position.Y, (float)angle.Theta);
+            // Rounding moment
+            return angle.Theta switch
+            {
+                -Math.PI / 2 => new Matrix3(0f, 1f, position.X, -1f, 0f, position.Y, 0f, 0f, 1f),
+                Math.PI / 2 => new Matrix3(0f, -1f, position.X, 1f, 0f, position.Y, 0f, 0f, 1f),
+                Math.PI => new Matrix3(-1f, 0f, position.X, 0f, -1f, position.Y, 0f, 0f, 1f),
+                _ => CreateTransform(position.X, position.Y, (float) angle.Theta)
+            };
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
I was getting rounding issues doing matrix transforms for tiles but angles are already doubles. I tried using the double versions of Math internally but still had issues.