### PR TITLE
Shrink tile bounds slightly

### DIFF
--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -882,7 +882,9 @@ public sealed partial class EntityLookupSystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Box2 GetLocalBounds(Vector2i gridIndices, ushort tileSize)
     {
-        return new Box2(gridIndices * tileSize, (gridIndices + 1) * tileSize);
+        var gridPos = (Vector2)gridIndices;
+        // To avoid marginal overlap from other tiles
+        return new Box2(gridPos * tileSize + 0.05f, (gridPos + 1) * tileSize - 0.05f);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Problem was I was getting overlap on other tiles due to the poly skin. Box2d 3.0 is looking at removing it but for now I just want 1 tile.