### PR TITLE
Make RobustServerSim public

### DIFF
--- a/Robust.UnitTesting/Server/RobustServerSimulation.cs
+++ b/Robust.UnitTesting/Server/RobustServerSimulation.cs
@@ -48,7 +48,7 @@ using Robust.Shared.Timing;
 namespace Robust.UnitTesting.Server
 {
     [PublicAPI]
-    internal interface ISimulationFactory
+    public interface ISimulationFactory
     {
         ISimulationFactory RegisterComponents(CompRegistrationDelegate factory);
         ISimulationFactory RegisterDependencies(DiContainerDelegate factory);
@@ -58,7 +58,7 @@ namespace Robust.UnitTesting.Server
     }
 
     [PublicAPI]
-    internal interface ISimulation
+    public interface ISimulation
     {
         IDependencyCollection Collection { get; }
 
@@ -76,15 +76,15 @@ namespace Robust.UnitTesting.Server
         EntityUid SpawnEntity(string? protoId, MapCoordinates coordinates);
     }
 
-    internal delegate void DiContainerDelegate(IDependencyCollection diContainer);
+    public delegate void DiContainerDelegate(IDependencyCollection diContainer);
 
-    internal delegate void CompRegistrationDelegate(IComponentFactory factory);
+    public delegate void CompRegistrationDelegate(IComponentFactory factory);
 
-    internal delegate void EntitySystemRegistrationDelegate(IEntitySystemManager systemMan);
+    public delegate void EntitySystemRegistrationDelegate(IEntitySystemManager systemMan);
 
-    internal delegate void PrototypeRegistrationDelegate(IPrototypeManager protoMan);
+    public delegate void PrototypeRegistrationDelegate(IPrototypeManager protoMan);
 
-    internal sealed class RobustServerSimulation : ISimulation, ISimulationFactory
+    public sealed class RobustServerSimulation : ISimulation, ISimulationFactory
     {
         private DiContainerDelegate? _diFactory;
         private CompRegistrationDelegate? _regDelegate;


### PR DESCRIPTION
Okay so a long time ago in a maintainer meeting I went on a rant.

The issue is we have the following ways to run tests:
- Actual unit test
- RobustUnitTest
- RobustServerSim
- RobustIntegrationTest
- ContentIntegrationTest

Ideally we would kill RobustUnitTest because RobustServerSim is the more recent, less poorly coded, and faster version that can also be re-used for benchmarks.

I checked it works okay on one of my engine PRs and it was significantly faster than the current poolmanager.

The other test frameworks need cleaning up (even ignoring how flakey integration tests are) but I think ideally most tests really only need something lightweight anyway and not the full game sim.

```
var sim = RobustServerSimulation.NewSimulation().InitializeInstance();
var protoManager = sim.Resolve<IPrototypeManager>();
protoManager.RegisterKind(typeof(DungeonRoomPrototype));
protoManager.RegisterKind(typeof(DungeonRoomPackPrototype));
protoManager.RegisterKind(typeof(DungeonPresetPrototype));
protoManager.LoadDirectory(new ResourcePath("/Resources/Procedural/"));

var sizes = new HashSet<Vector2i>();

foreach (var proto in protoManager.EnumeratePrototypes<DungeonRoomPrototype>())
{
    sizes.Add(proto.Size);
    sizes.Add(new Vector2i(proto.Size.Y, proto.Size.X));
}
```