### PR TITLE
Revert "Shrink tile bounds slightly (#3831)"

### DIFF
--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -882,9 +882,7 @@ public sealed partial class EntityLookupSystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Box2 GetLocalBounds(Vector2i gridIndices, ushort tileSize)
     {
-        var gridPos = (Vector2)gridIndices;
-        // To avoid marginal overlap from other tiles
-        return new Box2(gridPos * tileSize + 0.05f, (gridPos + 1) * tileSize - 0.05f);
+        return new Box2(gridIndices * tileSize, (gridIndices + 1) * tileSize);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
This reverts commit 9b43862.

This was causing power test failures which sounds cursed af.

It didn't cause too many issues with dungeon generation and I'd rather have working tests.