### PR TITLE
Add readonly to Box2Rotated methods

### DIFF
--- a/Robust.Shared.Maths/Box2.cs
+++ b/Robust.Shared.Maths/Box2.cs
@@ -302,14 +302,14 @@ namespace Robust.Shared.Maths
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override readonly bool Equals(object? obj)
+        public readonly override bool Equals(object? obj)
         {
             if (obj is null) return false;
             return obj is Box2 box2 && Equals(box2);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override readonly int GetHashCode()
+        public readonly override int GetHashCode()
         {
             unchecked
             {

--- a/Robust.Shared.Maths/Box2Rotated.cs
+++ b/Robust.Shared.Maths/Box2Rotated.cs
@@ -101,7 +101,7 @@ namespace Robust.Shared.Maths
             return Unsafe.As<Vector128<float>, Box2>(ref lbrt);
         }
 
-        public bool Contains(Vector2 worldPoint)
+        public readonly bool Contains(Vector2 worldPoint)
         {
             // Get the worldpoint in our frame of reference so we can do a faster AABB check.
             var localPoint = GetLocalPoint(worldPoint);
@@ -111,7 +111,7 @@ namespace Robust.Shared.Maths
         /// <summary>
         /// Convert a point in world-space coordinates to our local coordinates.
         /// </summary>
-        private Vector2 GetLocalPoint(Vector2 point)
+        private readonly Vector2 GetLocalPoint(Vector2 point)
         {
             return Origin + (-Rotation).RotateVec(point - Origin);
         }
@@ -125,14 +125,14 @@ namespace Robust.Shared.Maths
         }
 
         /// <inheritdoc />
-        public override readonly bool Equals(object? obj)
+        public readonly override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj)) return false;
             return obj is Box2Rotated other && Equals(other);
         }
 
         /// <inheritdoc />
-        public override readonly int GetHashCode()
+        public readonly override int GetHashCode()
         {
             unchecked
             {
@@ -161,7 +161,7 @@ namespace Robust.Shared.Maths
         /// <summary>
         ///     Returns a string representation of this type.
         /// </summary>
-        public override readonly string ToString()
+        public readonly override string ToString()
         {
             return $"{Box}, {Rotation}";
         }


### PR DESCRIPTION
Adds `readonly` to two Box2Rotated methods.

Also rearranges some modifiers to rider stops complaining about inconsistent modifiers declaration ordering.