### PR TITLE
Multi-shader rendering

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
@@ -191,6 +191,13 @@ namespace Robust.Client.Graphics.Clyde
                 _clyde.DrawUseShader(clydeShader?.Handle ?? _clyde._defaultShader.Handle);
             }
 
+            public void UseShaders(ShaderInstance[] shaders)
+            {
+
+                var clydeShaders = Array.ConvertAll(shaders, item => ((ClydeShaderInstance)item).Handle);
+                _clyde.DrawUseShaders(clydeShaders);
+            }
+
             public void Viewport(Box2i viewport)
             {
                 _clyde.DrawViewport(viewport);
@@ -255,7 +262,10 @@ namespace Robust.Client.Graphics.Clyde
                 {
                     _renderHandle.UseShader(shader);
                 }
-
+                public override void UseShaders(ShaderInstance[] shaders)
+                {
+                    _renderHandle.UseShaders(shaders);
+                }
                 public override void DrawPrimitives(DrawPrimitiveTopology primitiveTopology, Texture texture,
                     ReadOnlySpan<DrawVertexUV2DColor> vertices)
                 {
@@ -324,6 +334,10 @@ namespace Robust.Client.Graphics.Clyde
                 public override void UseShader(ShaderInstance? shader)
                 {
                     _renderHandle.UseShader(shader);
+                }
+                public override void UseShaders(ShaderInstance[] shaders)
+                {
+                    _renderHandle.UseShaders(shaders);
                 }
 
                 public override void DrawCircle(Vector2 position, float radius, Color color, bool filled = true)

--- a/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
@@ -130,7 +130,7 @@ namespace Robust.Client.Graphics.Clyde
 
             _defaultShader = (ClydeShaderInstance) InstanceShader(defaultLoadedShader);
 
-            _queuedShader = _defaultShader.Handle;
+            _queuedShaders = new ClydeHandle[]{_defaultShader.Handle};
         }
 
         private string ReadEmbeddedShader(string fileName)

--- a/Robust.Client/Graphics/Drawing/DrawingHandleBase.cs
+++ b/Robust.Client/Graphics/Drawing/DrawingHandleBase.cs
@@ -47,6 +47,7 @@ namespace Robust.Client.Graphics
         public abstract void SetTransform(in Matrix3 matrix);
 
         public abstract void UseShader(ShaderInstance? shader);
+        public abstract void UseShaders(ShaderInstance[] shaders);
 
         // ---- DrawPrimitives: Vector2 API ----
 


### PR DESCRIPTION
Adds a path for rendering with multiple shaders at once, without requiring ping-pong use of `RenderInRenderTarget()`

Note: I fucked up
```
[StructLayout(LayoutKind.Explicit)]
private struct RenderCommand
```
because I don't entirely understand its purpose or how to fix it, so someone may want to check that out before merging.