### PR TITLE
Make PauseTime a DataField

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,8 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* `MetaDataComponent.PauseTime` is now a yaml data-field
+* The client-side `(un)pausemap` command is now disabled while connected to a server.
 
 ### Other
 

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -8,6 +8,7 @@ using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 using System;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Robust.Shared.GameObjects
 {
@@ -66,7 +67,8 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         /// When this entity was paused, if applicable
         /// </summary>
-        internal TimeSpan? PauseTime;
+        [DataField("pauseTime", customTypeSerializer:typeof(TimeOffsetSerializer))]
+        public TimeSpan? PauseTime { get; internal set; }
 
         // Every entity starts at tick 1, because they are conceptually created in the time between 0->1
         [ViewVariables]

--- a/Robust.Shared/Map/MapManager.Pause.cs
+++ b/Robust.Shared/Map/MapManager.Pause.cs
@@ -176,7 +176,8 @@ namespace Robust.Shared.Map
                     }
 
                     SetMapPaused(mapId, true);
-                });
+                },
+                requireServerOrSingleplayer: true);
 
             _conhost.RegisterCommand("querymappaused",
                 "Check whether a map is paused or not.",
@@ -214,7 +215,8 @@ namespace Robust.Shared.Map
                     }
 
                     SetMapPaused(mapId, false);
-                });
+                },
+                requireServerOrSingleplayer: true);
         }
     }
 }


### PR DESCRIPTION
Also blocks the client from trying to use the client-side version of the pause/unpause commands while connected to a server.