### PR TITLE
Adjust center point on non 32px Sprites if SpriteOffset == false

### DIFF
--- a/Robust.Client/UserInterface/Controls/SpriteView.cs
+++ b/Robust.Client/UserInterface/Controls/SpriteView.cs
@@ -61,8 +61,13 @@ namespace Robust.Client.UserInterface.Controls
             }
 
             var uid = Sprite.Owner;
-            //Add the Sprite.Offset and if SpriteOffset = false, adjust the SpriteOffset center point if the sprite is > 32px.
-            var  offsetAdj = (SpriteOffset ? Sprite.Offset : new Vector2(0,(1.0f/(32*Sprite.Bounds.Height))*32));
+            var offsetAdj = Vector2.Zero;
+
+            //Set SpriteOffset, If the sprite is > 32px, adjust the SpriteOffset center point
+            if(Sprite.Bounds.Height > 1)
+            {
+                offsetAdj = (SpriteOffset ? Sprite.Offset : new Vector2(0,(1.0f/(32*Sprite.Bounds.Height))*32));
+            }
 
             _spriteSystem ??= IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SpriteSystem>();
             _spriteSystem?.ForceUpdate(uid);

--- a/Robust.Client/UserInterface/Controls/SpriteView.cs
+++ b/Robust.Client/UserInterface/Controls/SpriteView.cs
@@ -30,7 +30,7 @@ namespace Robust.Client.UserInterface.Controls
         /// <summary>
         /// Should the sprite's offset be applied to the control.
         /// </summary>
-        public bool SpriteOffset = true;
+        public bool SpriteOffset { get; set; } = true;
 
         /// <summary>
         ///     Overrides the direction used to render the sprite.

--- a/Robust.Client/UserInterface/Controls/SpriteView.cs
+++ b/Robust.Client/UserInterface/Controls/SpriteView.cs
@@ -61,11 +61,13 @@ namespace Robust.Client.UserInterface.Controls
             }
 
             var uid = Sprite.Owner;
+            //Add the Sprite.Offset and if SpriteOffset = false, adjust the SpriteOffset center point if the sprite is > 32px.
+            var  offsetAdj = (SpriteOffset ? Sprite.Offset : new Vector2(0,(1.0f/(32*Sprite.Bounds.Height))*32));
 
             _spriteSystem ??= IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SpriteSystem>();
             _spriteSystem?.ForceUpdate(uid);
 
-            renderHandle.DrawEntity(uid, PixelSize / 2 + PixelSize * (SpriteOffset ? Sprite.Offset : Vector2.Zero), Scale * UIScale, OverrideDirection);
+            renderHandle.DrawEntity(uid, PixelSize / 2 + PixelSize * offsetAdj, Scale * UIScale, OverrideDirection);
         }
     }
 }


### PR DESCRIPTION
This is to fix an issue with setting SpriteOffset to false on sprites that are larger than 32px.

If SpriteOffset is false in the draw entity it would just pass in a Vec2.zero, however this was never tested as SpriteOffset=false has not been used by any content. It doesn't work as expected and this is designed to fix that.

For 32px this will set to 0,1. if 64 will be 0,0.5, if 96 will be 0,0.33 etc... This was designed to not impact the larger sprite system. This will not impact any sprites unless explicitly you set there SpriteOffet to false (true by default) 