### PR TITLE
Adjust InRange entity lookups

### DIFF
--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -579,7 +579,25 @@ public sealed partial class EntityLookupSystem
 
         // TODO: Actual circles
         var worldAABB = new Box2(worldPos - range, worldPos + range);
-        return GetEntitiesIntersecting(mapId, worldAABB, flags);
+        var entities =  GetEntitiesIntersecting(mapId, worldAABB, flags);
+        var xformQuery = GetEntityQuery<TransformComponent>();
+        var toRemove = new ValueList<EntityUid>();
+
+        foreach (var uid in entities)
+        {
+            if (xformQuery.TryGetComponent(uid, out var xform) &&
+                (_transform.GetWorldPosition(xform, xformQuery) - worldPos).Length > range)
+            {
+                toRemove.Add(uid);
+            }
+        }
+
+        foreach (var comp in toRemove)
+        {
+            entities.Remove(comp);
+        }
+
+        return entities;
     }
 
     #endregion


### PR DESCRIPTION
Use worldpos to check the centre. Not as good as physics shape checks but that is pending larger changes to stuff like raycasts to actually use proper physics shapes.