### PR TITLE
Suppress invalid map saving warnings

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -967,7 +967,10 @@ public sealed class MapLoaderSystem : EntitySystem
         var prototypeCompCache = new Dictionary<string, Dictionary<string, MappingDataNode>>();
 
         var emptyMetaNode = _serManager.WriteValueAs<MappingDataNode>(typeof(MetaDataComponent), new MetaDataComponent(), alwaysWrite: true, context: _context);
+
+        _context.CurrentWritingComponent = _factory.GetComponentName(typeof(TransformComponent));
         var emptyXformNode = _serManager.WriteValueAs<MappingDataNode>(typeof(TransformComponent), new TransformComponent(), alwaysWrite: true, context: _context);
+        _context.CurrentWritingComponent = null;
 
         foreach (var (saveId, entityUid) in uidEntityMap.OrderBy( e=> e.Key))
         {
@@ -991,9 +994,11 @@ public sealed class MapLoaderSystem : EntitySystem
 
                     foreach (var (compType, comp) in prototype.Components)
                     {
+                        _context.CurrentWritingComponent = compType;
                         cache.Add(compType, _serManager.WriteValueAs<MappingDataNode>(comp.Component.GetType(), comp.Component, alwaysWrite: true, context: _context));
                     }
 
+                    _context.CurrentWritingComponent = null;
                     cache.TryAdd("MetaData", emptyMetaNode);
                     cache.TryAdd("Transform", emptyXformNode);
                 }

--- a/Robust.Shared/Map/MapSerializationContext.cs
+++ b/Robust.Shared/Map/MapSerializationContext.cs
@@ -94,10 +94,10 @@ internal sealed class MapSerializationContext : ISerializationContext, IEntityLo
     {
         if (!_entityUidMap.TryGetValue(value, out var entityUidMapped))
         {
-            // Terrible hack to mute this warning on the grids themselves when serializing blueprints.
-            if (CurrentWritingComponent != "Transform")
+            // Terrible hack to mute this error on the grids themselves when serializing blueprints.
+            if (value.IsValid() || CurrentWritingComponent != "Transform")
             {
-                Logger.WarningS("map", "Cannot write entity UID '{0}'.", value);
+                Logger.ErrorS("map", "Encountered an invalid entityUid '{0}' while serializing a map.", value);
             }
 
             return new ValueDataNode("invalid");


### PR DESCRIPTION
Suppresses some erroneous map saving warnings, and makes those warnings an error, as it indicates something has gone wrong while saving the map.