### PR TITLE
Invalid OutputPanel entries upon tree enter

### DIFF
--- a/Robust.Client/UserInterface/Controls/OutputPanel.cs
+++ b/Robust.Client/UserInterface/Controls/OutputPanel.cs
@@ -244,5 +244,14 @@ namespace Robust.Client.UserInterface.Controls
         {
             return font.GetLineHeight(scale) * 2;
         }
+
+        protected override void EnteredTree()
+        {
+            base.EnteredTree();
+            // Due to any number of reasons the entries may be invalidated if added when not visible in the tree.
+            // e.g. the control has not had its UI scale set and the messages were added, but the
+            // existing ones were valid when the UI scale was set.
+            _invalidateEntries();
+        }
     }
 }


### PR DESCRIPTION
Maybe fixes https://github.com/space-wizards/space-station-14/issues/14455 but need to confirm with tstalker.

At least in my case, the issue is that messages cache their width / height for drawing. This means that, for example upon reconnecting to the server it flushes all of its messages even when the OutputPanel's UIScale isn't set (i.e. it's still set to 1 but my cvars have it as 1.5). This means all of the text gets jumbled and draws over each other until it gets invalidated again (e.g. the output panel is resized). 

This may not be the only instance of the invalid dimensions being cached, but the easiest fix for this is to just always invalidate when the control enters the tree. Is it the best? Probably not, though not requiring this would require significantly more work in changing other areas of the codebase and I'm not the best at UI.