### PR TITLE
Set blend function for shaders with `ShaderBlendMode.None`

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -888,6 +888,9 @@ namespace Robust.Client.Graphics.Clyde
                     case ShaderBlendMode.Multiply:
                         GL.BlendFunc(BlendingFactor.DstColor, BlendingFactor.OneMinusSrcAlpha);
                         break;
+                    case ShaderBlendMode.None:
+                        GL.BlendFunc(BlendingFactor.One, BlendingFactor.Zero);
+                        break;
                 }
         }
 


### PR DESCRIPTION
This makes it so that shaders with `blend_mode none;` will actually not do any blending, rather than using the default of `ShaderBlendMode.Mix`.