### PR TITLE
Add QueueDel logs

### DIFF
--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -7,6 +7,7 @@ using Robust.Client.Player;
 using Robust.Client.Timing;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Log;
 using Robust.Shared.Network;
 using Robust.Shared.Network.Messages;
 using Robust.Shared.Utility;
@@ -61,6 +62,18 @@ namespace Robust.Client.GameObjects
             //  Client only dirties during prediction
             if (_gameTiming.InPrediction)
                 base.DirtyEntity(uid, meta);
+        }
+
+        public override void QueueDeleteEntity(EntityUid uid)
+        {
+            if (!_gameTiming.InPrediction || uid.IsClientSide())
+            {
+                base.QueueDeleteEntity(uid);
+                return;
+            }
+
+            // Client-side entity deletion is not supported and will cause errors.
+            Logger.Error($"Predicting the queued deletion of a networked entity: {ToPrettyString(uid)}. Trace: {Environment.StackTrace}");
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -455,7 +455,7 @@ namespace Robust.Shared.GameObjects
             Entities.Remove(uid);
         }
 
-        public void QueueDeleteEntity(EntityUid uid)
+        public virtual void QueueDeleteEntity(EntityUid uid)
         {
             if(QueuedDeletionsSet.Add(uid))
                 QueuedDeletions.Enqueue(uid);


### PR DESCRIPTION
HandVirtualItem is getting QueueDeld on client so want to try to track down what's doing it.

```
[ERRO] root: Predicting the deletion of a networked entity: VIRTUAL ITEM YOU SHOULD NOT SEE THIS (178335, HandVirtualItem). Trace:    at System.Environment.get_StackTrace()
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass6_0`1.<SubscribeEvent>b__0(Unit& ev) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs:line 191
   at Robust.Shared.GameObjects.EntityEventBus.ProcessSingleEventCore(EventSource source, Unit& unitRef, EventData subs, Boolean byRef) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs:line 324
   at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEvent[TEvent](EntityUid uid, TEvent& args, Boolean broadcast) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 197
   at Robust.Shared.GameObjects.EntityManager.RecursiveFlagEntityTermination(EntityUid uid, MetaDataComponent metadata, EntityQuery`1 metaQuery, EntityQuery`1 xformQuery) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 351
   at Robust.Shared.GameObjects.EntityManager.DeleteEntity(EntityUid e) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 333
   at Robust.Shared.GameObjects.EntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 150
   at Robust.Client.GameObjects.ClientEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/GameObjects/ClientEntityManager.cs:line 125
   at Robust.Client.GameStates.ClientGameStateManager.ApplyGameState() in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/GameStates/ClientGameStateManager.cs:line 207
   at Robust.Client.GameController.Tick(FrameEventArgs frameEventArgs) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/GameController/GameController.cs:line 538
   at Robust.Shared.Timing.GameLoop.Run() in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 218
   at Robust.Client.GameController.ContinueStartupAndLoop(DisplayMode mode) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/GameController/GameController.Standalone.cs:line 133
   at Robust.Client.GameController.GameThreadMain(DisplayMode mode) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/GameController/GameController.Standalone.cs:line 118
   at Robust.Client.GameController.<>c__DisplayClass92_0.<Run>b__0() in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/GameController/GameController.Standalone.cs:line 85
   at System.Threading.Thread.StartCallback()
```