### PR TITLE
Fix adding mapgrid to a map

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -298,16 +298,6 @@ public abstract partial class SharedMapSystem
     {
         var xformQuery = GetEntityQuery<TransformComponent>();
         var xform = xformQuery.GetComponent(uid);
-        var mapId = xform.MapID;
-
-        if (MapManager.HasMapEntity(mapId))
-        {
-            var mapUid = MapManager.GetMapEntityIdOrThrow(mapId);
-
-            // Mapgrid moment
-            if (mapUid != uid)
-                _transform.SetParent(uid, xform, MapManager.GetMapEntityIdOrThrow(mapId), xformQuery);
-        }
 
         // Force networkedmapmanager to send it due to non-ECS legacy code.
         var curTick = _timing.CurTick;
@@ -320,8 +310,23 @@ public abstract partial class SharedMapSystem
 
         component.LastTileModifiedTick = curTick;
 
-        // Just in case.
-        _transform.SetGridId(xform, uid, xformQuery);
+        var mapId = xform.MapID;
+
+        if (MapManager.HasMapEntity(mapId))
+        {
+            var mapUid = MapManager.GetMapEntityIdOrThrow(mapId);
+
+            // Mapgrid moment
+            if (mapUid != uid)
+                _transform.SetParent(uid, xform, MapManager.GetMapEntityIdOrThrow(mapId), xformQuery);
+
+            _transform.SetGridIdNoRecursive(xform, uid);
+        }
+        else
+        {
+            // Just in case.
+            _transform.SetGridId(xform, uid, xformQuery);
+        }
 
         var msg = new GridInitializeEvent(uid);
         RaiseLocalEvent(uid, msg, true);

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -322,6 +322,19 @@ public abstract partial class SharedTransformSystem
     #region GridId
 
     /// <summary>
+    /// Sets the <see cref="GridId"/> for the transformcomponent without updating its children. Does not Dirty it.
+    /// </summary>
+    internal void SetGridIdNoRecursive(TransformComponent xform, EntityUid? gridUid)
+    {
+        if (xform._gridUid == gridUid)
+            return;
+
+        DebugTools.Assert(gridUid == null || HasComp<MapGridComponent>(gridUid));
+
+        xform._gridUid = gridUid;
+    }
+
+    /// <summary>
     /// Sets the <see cref="GridId"/> for the transformcomponent. Does not Dirty it.
     /// </summary>
     public void SetGridId(TransformComponent xform, EntityUid? gridId, EntityQuery<TransformComponent>? xformQuery = null)

--- a/Robust.UnitTesting/Shared/Map/MapGridMap_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/MapGridMap_Tests.cs
@@ -28,4 +28,27 @@ public sealed class MapGridMap_Tests
         entManager.AddComponent<MapGridComponent>(mapManager.GetMapEntityId(mapId));
         Assert.That(mapManager.FindGridsIntersecting(mapId, Box2.UnitCentered).Count() == 1);
     }
+
+    /// <summary>
+    /// Asserts that adding <see cref="MapGridComponent"/> to an existing map with a grid on it doesn't explode.
+    /// </summary>
+    [Test]
+    public void AddGridCompToMap()
+    {
+        var sim = RobustServerSimulation.NewSimulation().InitializeInstance();
+
+        var entManager = sim.Resolve<IEntityManager>();
+        var mapManager = sim.Resolve<IMapManager>();
+
+        var mapId = mapManager.CreateMap();
+        var gridId = mapManager.CreateGrid(mapId);
+
+        Assert.DoesNotThrow(() =>
+        {
+            entManager.AddComponent<MapGridComponent>(mapManager.GetMapEntityId(mapId));
+            entManager.TickUpdate(0.016f, false);
+        });
+
+        mapManager.DeleteMap(mapId);
+    }
 }


### PR DESCRIPTION
If there's no grids on it it's fine but if there are grids it tries to erroneously update their gridid to itself.