### PR TITLE
Revert "Don't draw text contents over scrollbar for outputpanel"

### DIFF
--- a/Robust.Client/UserInterface/Controls/OutputPanel.cs
+++ b/Robust.Client/UserInterface/Controls/OutputPanel.cs
@@ -29,11 +29,6 @@ namespace Robust.Client.UserInterface.Controls
 
         public bool ScrollFollowing { get; set; } = true;
 
-        /// <summary>
-        /// Margin between the text and the scrollbar.
-        /// </summary>
-        public float ScrollMargin = 4f;
-
         public OutputPanel()
         {
             IoCManager.InjectDependencies(this);
@@ -43,7 +38,7 @@ namespace Robust.Client.UserInterface.Controls
             _scrollBar = new VScrollBar
             {
                 Name = "_v_scroll",
-                HorizontalAlignment = HAlignment.Right,
+                HorizontalAlignment = HAlignment.Right
             };
             AddChild(_scrollBar);
             _scrollBar.OnValueChanged += _ => _isAtBottom = _scrollBar.IsAtEnd;
@@ -235,8 +230,7 @@ namespace Robust.Client.UserInterface.Controls
         private UIBox2 _getContentBox()
         {
             var style = _getStyleBox();
-            var box = style?.GetContentBox(PixelSizeBox) ?? PixelSizeBox;
-            return new UIBox2(box.Left, box.Top, box.Right - _scrollBar.SizeBox.Width - Margin.Right - ScrollMargin, box.Bottom);
+            return style?.GetContentBox(PixelSizeBox) ?? PixelSizeBox;
         }
 
         protected internal override void UIScaleChanged()


### PR DESCRIPTION
Reverts space-wizards/RobustToolbox#3876

this is causing outputpanel rich text debug asserts for chat for some reason!!! i dont know why and sloth cant repro it