### PR TITLE
Add BroadphaseNetworkingTest

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -744,13 +744,13 @@ namespace Robust.Shared.GameObjects
     /// <remarks>
     ///     A null value means that this entity is simply not on a broadphase (e.g., in null-space or in a container).
     ///     An invalid entity UID indicates that this entity has intentionally been removed from broadphases and should
-    ///     not automatically be re-added by movement events..
+    ///     not automatically be re-added by movement events.
     /// </remarks>
-    internal record struct BroadphaseData(EntityUid Uid, EntityUid MapUid, bool CanCollide, bool Static)
+    internal record struct BroadphaseData(EntityUid Uid, EntityUid PhysicsMap, bool CanCollide, bool Static)
     {
         public bool IsValid() => Uid.IsValid();
         public bool Valid => IsValid();
-        public readonly static BroadphaseData Invalid = default;
+        public static readonly BroadphaseData Invalid = default;
 
         // TODO include MapId if ever grids are allowed to enter null-space (leave PVS).
     }

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -129,9 +129,9 @@ namespace Robust.Shared.GameObjects
                 if (childXform.Broadphase.Value.CanCollide && fixtureQuery.TryGetComponent(child.Value, out var fixtures))
                 {
                     if (map == null)
-                        physicsMapQuery.TryGetComponent(childXform.Broadphase.Value.MapUid, out map);
+                        physicsMapQuery.TryGetComponent(childXform.Broadphase.Value.PhysicsMap, out map);
 
-                    DebugTools.Assert(map == null || childXform.Broadphase.Value.MapUid == map.Owner);
+                    DebugTools.Assert(map == null || childXform.Broadphase.Value.PhysicsMap == map.Owner);
                     var tree = childXform.Broadphase.Value.Static ? component.StaticTree : component.DynamicTree;
                     foreach (var fixture in fixtures.Fixtures.Values)
                     {
@@ -272,7 +272,7 @@ namespace Robust.Shared.GameObjects
             var fixtures = Comp<FixturesComponent>(uid);
             if (old.CanCollide)
             {
-                TryComp(old.MapUid, out PhysicsMapComponent? physicsMap);
+                TryComp(old.PhysicsMap, out PhysicsMapComponent? physicsMap);
                 RemoveBroadTree(broadphase, fixtures, old.Static, physicsMap);
             }
             else
@@ -478,8 +478,8 @@ namespace Robust.Shared.GameObjects
             if (xform.Broadphase == null || !xform.Broadphase.Value.CanCollide)
                 return;
 
-            DebugTools.Assert(_netMan.IsClient || !xform.Broadphase.Value.MapUid.IsValid() || xform.Broadphase.Value.MapUid == oldMap);
-            xform.Broadphase = xform.Broadphase.Value with { MapUid = newMap };
+            DebugTools.Assert(_netMan.IsClient || !xform.Broadphase.Value.PhysicsMap.IsValid() || xform.Broadphase.Value.PhysicsMap == oldMap);
+            xform.Broadphase = xform.Broadphase.Value with { PhysicsMap = newMap };
 
             if (!fixturesQuery.TryGetComponent(uid, out var fixtures))
                 return;
@@ -522,7 +522,7 @@ namespace Robust.Shared.GameObjects
                 if (!xform.Broadphase.Value.IsValid())
                     return; // Entity is intentionally not on a broadphase (deferred updating?).
 
-                TryComp(xform.Broadphase.Value.MapUid, out oldPhysMap);
+                TryComp(xform.Broadphase.Value.PhysicsMap, out oldPhysMap);
 
                 if (!broadQuery.TryGetComponent(xform.Broadphase.Value.Uid, out oldBroadphase))
                 {
@@ -743,7 +743,7 @@ namespace Robust.Shared.GameObjects
             var fixturesQuery = GetEntityQuery<FixturesComponent>();
 
             PhysicsMapComponent? physMap = null;
-            if (xform.Broadphase!.Value.MapUid is { Valid: true } map && !TryComp(map, out physMap))
+            if (xform.Broadphase!.Value.PhysicsMap is { Valid: true } map && !TryComp(map, out physMap))
             {
                 throw new InvalidOperationException(
                     $"Broadphase's map is missing a physics map comp. Broadphase: {ToPrettyString(broadphase.Owner)}");
@@ -781,15 +781,15 @@ namespace Robust.Shared.GameObjects
                 broadUid = old.Uid;
             }
 
-            if (old.MapUid.IsValid() && physicsMap?.Owner != old.MapUid)
+            if (old.PhysicsMap.IsValid() && physicsMap?.Owner != old.PhysicsMap)
             {
-                if (!TryComp(old.MapUid, out physicsMap))
+                if (!TryComp(old.PhysicsMap, out physicsMap))
                     Logger.Error($"Entity {ToPrettyString(uid)} has missing physics map?");
             }
 
             if (old.CanCollide)
             {
-                DebugTools.Assert(old.MapUid == (physicsMap?.Owner ?? default));
+                DebugTools.Assert(old.PhysicsMap == (physicsMap?.Owner ?? default));
                 RemoveBroadTree(broadphase, fixturesQuery.GetComponent(uid), old.Static, physicsMap);
             }
             else if (old.Static)

--- a/Robust.UnitTesting/Shared/Physics/BroadphaseNetworkingTest.cs
+++ b/Robust.UnitTesting/Shared/Physics/BroadphaseNetworkingTest.cs
@@ -1,0 +1,154 @@
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Robust.Server.Player;
+using Robust.Shared;
+using Robust.Shared.Configuration;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Network;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Collision.Shapes;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Dynamics;
+using Robust.Shared.Physics.Systems;
+using cIPlayerManager = Robust.Client.Player.IPlayerManager;
+using sIPlayerManager = Robust.Server.Player.IPlayerManager;
+
+// ReSharper disable AccessToStaticMemberViaDerivedType
+
+namespace Robust.UnitTesting.Shared.Physics;
+
+public sealed class BroadphaseNetworkingTest : RobustIntegrationTest
+{
+    /// <summary>
+    /// Check that the transform/broadphase is properly networked when a player moves to a newly spawned map/grid.
+    /// </summary>
+    /// <remarks>
+    /// See PR #3919 or issue #3924
+    /// </remarks>
+    [Test]
+    public async Task TestBroadphaseNetworking()
+    {
+        var server = StartServer();
+        var client = StartClient();
+
+        await Task.WhenAll(client.WaitIdleAsync(), server.WaitIdleAsync());
+
+        var mapMan = server.ResolveDependency<IMapManager>();
+        var sEntMan = server.ResolveDependency<IEntityManager>();
+        var cEntMan = client.ResolveDependency<IEntityManager>();
+        var netMan = client.ResolveDependency<IClientNetManager>();
+        var confMan = server.ResolveDependency<IConfigurationManager>();
+        var cPlayerMan = client.ResolveDependency<cIPlayerManager>();
+        var sPlayerMan = server.ResolveDependency<sIPlayerManager>();
+        var fixturesSystem = sEntMan.EntitySysManager.GetEntitySystem<FixtureSystem>();
+        var physicsSystem = sEntMan.EntitySysManager.GetEntitySystem<SharedPhysicsSystem>();
+
+        Assert.DoesNotThrow(() => client.SetConnectTarget(server));
+        client.Post(() => netMan.ClientConnect(null!, 0, null!));
+        server.Post(() => confMan.SetCVar(CVars.NetPVS, true));
+
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        // Set up maps 1 & grid 1
+        EntityUid grid1 = default;
+        EntityUid map1 = default;
+        await server.WaitPost(() =>
+        {
+            var mapId = mapMan.CreateMap();
+            map1 = mapMan.GetMapEntityId(mapId);
+            var gridComp = mapMan.CreateGrid(mapId);
+            gridComp.SetTile(Vector2i.Zero, new Tile(1));
+            grid1 = gridComp.Owner;
+        });
+
+        // Spawn player entity on grid 1
+        EntityUid player = default;
+        await server.WaitPost(() =>
+        {
+            var coords = new EntityCoordinates(grid1, (0.5f, 0.5f));
+            player = sEntMan.SpawnEntity("", coords);
+
+            // Enable physics
+            var physics = sEntMan.AddComponent<PhysicsComponent>(player);
+            var xform = sEntMan.GetComponent<TransformComponent>(player);
+            var shape = new PolygonShape();
+            shape.SetAsBox(0.5f, 0.5f);
+            var fixture = new Fixture(shape, 0, 0, true);
+            fixturesSystem.CreateFixture(player, fixture, body: physics, xform: xform);
+            physicsSystem.SetCanCollide(player, true, body: physics);
+            physicsSystem.SetBodyType(player, BodyType.Dynamic);
+            Assert.That(physics.CanCollide);
+
+            // Attach player.
+            var session = (IPlayerSession) sPlayerMan.Sessions.First();
+            session.AttachToEntity(player);
+            session.JoinGame();
+        });
+
+        for (int i = 0; i < 100; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        // Check player got properly attached
+        await client.WaitPost(() =>
+        {
+            var ent = cPlayerMan.LocalPlayer?.ControlledEntity;
+            Assert.That(ent, Is.EqualTo(player));
+        });
+
+        var sPlayerXform = sEntMan.GetComponent<TransformComponent>(player);
+        var cPlayerXform = cEntMan.GetComponent<TransformComponent>(player);
+
+        // Client initially has correct transform data.
+        var broadphase = new BroadphaseData(grid1, map1, true, false);
+        Assert.That(cPlayerXform.GridUid, Is.EqualTo(grid1));
+        Assert.That(sPlayerXform.GridUid, Is.EqualTo(grid1));
+        Assert.That(cPlayerXform.MapUid, Is.EqualTo(map1));
+        Assert.That(sPlayerXform.MapUid, Is.EqualTo(map1));
+        Assert.That(cPlayerXform.Broadphase, Is.EqualTo(broadphase));
+        Assert.That(sPlayerXform.Broadphase, Is.EqualTo(broadphase));
+
+        // Set up maps 2 & grid 2 and move the player there (in the same tick).
+        EntityUid grid2 = default;
+        EntityUid map2 = default;
+        await server.WaitPost(() =>
+        {
+            // Create grid
+            var mapId = mapMan.CreateMap();
+            map2 = mapMan.GetMapEntityId(mapId);
+            var gridComp = mapMan.CreateGrid(mapId);
+            gridComp.SetTile(Vector2i.Zero, new Tile(1));
+            grid2 = gridComp.Owner;
+
+            // Move player
+            var coords = new EntityCoordinates(grid2, Vector2.Zero);
+            sEntMan.System<SharedTransformSystem>().SetCoordinates(player, coords);
+
+        });
+
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        // Player & server xforms should match.
+        broadphase = new BroadphaseData(grid2, map2, true, false);
+        Assert.That(cPlayerXform.GridUid, Is.EqualTo(grid2));
+        Assert.That(sPlayerXform.GridUid, Is.EqualTo(grid2));
+        Assert.That(cPlayerXform.MapUid, Is.EqualTo(map2));
+        Assert.That(sPlayerXform.MapUid, Is.EqualTo(map2));
+        Assert.That(cPlayerXform.Broadphase, Is.EqualTo(broadphase));
+        Assert.That(sPlayerXform.Broadphase, Is.EqualTo(broadphase));
+    }
+}
+


### PR DESCRIPTION
Adds a new test, which would have failed before #3919 was merged.

Also renames the broadphase `MapUid` field to `PhysicsMap` to make it somewhat clearer that this field is related to physics and won't be set to anything for sundries.