### PR TITLE
Allow `PrototypeLayerData` to clear shaders

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -751,9 +751,14 @@ namespace Robust.Client.GameObjects
                 }
             }
 
-            if (!string.IsNullOrWhiteSpace(layerDatum.Shader))
+            if (layerDatum.Shader != null)
             {
-                if (prototypes.TryIndex<ShaderPrototype>(layerDatum.Shader, out var prototype))
+                if (layerDatum.Shader == string.Empty)
+                {
+                    layer.ShaderPrototype = null;
+                    layer.Shader = null;
+                }
+                else if (prototypes.TryIndex<ShaderPrototype>(layerDatum.Shader, out var prototype))
                 {
                     layer.ShaderPrototype = layerDatum.Shader;
                     layer.Shader = prototype.Instance();

--- a/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
@@ -58,7 +58,14 @@ namespace Robust.Shared.GameObjects
         [DataDefinition]
         public sealed class PrototypeLayerData
         {
+            /// <summary>
+            /// The shader prototype to use for this layer.
+            /// </summary>
+            /// <remarks>
+            /// Null implies no shader is specified. An empty string will clear the current shader.
+            /// </remarks>
             [DataField("shader")] public string? Shader;
+
             [DataField("texture")] public string? TexturePath;
             [DataField("sprite")] public string? RsiPath;
             [DataField("state")] public string? State;


### PR DESCRIPTION
Should allow things like generic visualizers to remove shaders from a layer.
Supersedes #3720