### PR TITLE
Improve PVS metrics & multithread ack processing.

### DIFF
--- a/Robust.Server/BaseServer.cs
+++ b/Robust.Server/BaseServer.cs
@@ -658,6 +658,7 @@ namespace Robust.Server
 
         private void Input(FrameEventArgs args)
         {
+            using var _ = TickUsage.WithLabels("Inputs").NewTimer();
             _systemConsole.UpdateInput();
 
             _network.ProcessPackets();

--- a/Robust.Server/GameStates/IServerGameStateManager.cs
+++ b/Robust.Server/GameStates/IServerGameStateManager.cs
@@ -22,8 +22,8 @@ namespace Robust.Server.GameStates
 
         ushort TransformNetId { get; set; }
 
-        Action<ICommonSession, GameTick, GameTick>? ClientAck { get; set; }
+        Action<ICommonSession, GameTick>? ClientAck { get; set; }
 
-        Action<ICommonSession, GameTick, GameTick, EntityUid?>? ClientRequestFull { get; set; }
+        Action<ICommonSession, GameTick, EntityUid?>? ClientRequestFull { get; set; }
     }
 }

--- a/Robust.Server/GameStates/PVSSystem.Ack.cs
+++ b/Robust.Server/GameStates/PVSSystem.Ack.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Players;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Robust.Server.GameStates;
+
+// This partial class contains code relating to acknowledging game states received by clients.
+internal sealed partial class PVSSystem
+{
+    /// <summary>
+    ///     Invoked when a client ack message is received. Queues up for processing in parallel prior to sending game
+    ///     state data.
+    /// </summary>
+    private void OnClientAck(ICommonSession session, GameTick ackedTick)
+    {
+        if (!PlayerData.TryGetValue(session, out var sessionData))
+            return;
+
+        if (ackedTick <= sessionData.LastReceivedAck)
+            return;
+
+        sessionData.LastReceivedAck = ackedTick;
+        _pendingAcks.Add(session);
+    }
+
+    /// <summary>
+    ///     Processes queued client acks in parallel
+    /// </summary>
+    internal void ProcessQueuedAcks()
+    {
+        var opts = new ParallelOptions {MaxDegreeOfParallelism = _parallelManager.ParallelProcessCount};
+        Parallel.ForEach(_pendingAcks, opts, ProcessQueuedAck);
+        _pendingAcks.Clear();
+    }
+
+    /// <summary>
+    ///     Process a given client's queued ack.
+    /// </summary>
+    private void ProcessQueuedAck(ICommonSession session)
+    {
+        if (!PlayerData.TryGetValue(session, out var sessionData))
+            return;
+
+        var ackedTick = sessionData.LastReceivedAck;
+        Dictionary<EntityUid, PVSEntityVisiblity>? ackedData;
+
+        if (sessionData.Overflow != null && sessionData.Overflow.Value.Tick <= ackedTick)
+        {
+            var (overflowTick, overflowEnts) = sessionData.Overflow.Value;
+            sessionData.Overflow = null;
+            ackedData = overflowEnts;
+
+            // Even though the acked tick might be newer, we have no guarantee that the client received the cached tick,
+            // so discard it unless they happen to be equal.
+            if (overflowTick != ackedTick)
+            {
+                _visSetPool.Return(overflowEnts);
+                DebugTools.Assert(!sessionData.SentEntities.Values.Contains(overflowEnts));
+                return;
+            }
+        }
+        else if (!sessionData.SentEntities.TryGetValue(ackedTick, out ackedData))
+            return;
+
+        // return last acked to pool, but only if it is not still in the OverflowDictionary.
+        if (sessionData.LastAcked != null && !sessionData.SentEntities.ContainsKey(sessionData.LastAcked.Value.Tick))
+        {
+            DebugTools.Assert(!sessionData.SentEntities.Values.Contains(sessionData.LastAcked.Value.Data));
+            _visSetPool.Return(sessionData.LastAcked.Value.Data);
+        }
+
+        sessionData.LastAcked = (ackedTick, ackedData);
+        foreach (var ent in ackedData.Keys)
+        {
+            sessionData.LastSeenAt[ent] = ackedTick;
+        }
+
+        // The client acked a tick. If they requested a full state, this ack happened some time after that, so we can safely set this to false
+        sessionData.RequestedFull = false;
+    }
+}

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -17,6 +17,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
 using Robust.Shared.Players;
+using Robust.Shared.Threading;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -30,6 +31,7 @@ internal sealed partial class PVSSystem : EntitySystem
     [Shared.IoC.Dependency] private readonly SharedTransformSystem _transform = default!;
     [Shared.IoC.Dependency] private readonly IServerNetConfigurationManager _netConfigManager = default!;
     [Shared.IoC.Dependency] private readonly IServerGameStateManager _serverGameStateManager = default!;
+    [Shared.IoC.Dependency] private readonly IParallelManager _parallelManager = default!;
 
     public const float ChunkSize = 8;
 
@@ -57,9 +59,9 @@ internal sealed partial class PVSSystem : EntitySystem
     /// If PVS disabled then we'll track if we've dumped all entities on the player.
     /// This way any future ticks can be orders of magnitude faster as we only send what changes.
     /// </summary>
-    public HashSet<ICommonSession> SeenAllEnts = new();
+    private HashSet<ICommonSession> _seenAllEnts = new();
 
-    private readonly Dictionary<ICommonSession, SessionPVSData> _playerVisibleSets = new();
+    internal readonly Dictionary<ICommonSession, SessionPVSData> PlayerData = new();
 
     private PVSCollection<EntityUid> _entityPvsCollection = default!;
     public PVSCollection<EntityUid> EntityPVSCollection => _entityPvsCollection;
@@ -98,6 +100,7 @@ internal sealed partial class PVSSystem : EntitySystem
     private readonly Dictionary<uint, Dictionary<MapChunkLocation, int>> _mapIndices = new(4);
     private readonly Dictionary<uint, Dictionary<GridChunkLocation, int>> _gridIndices = new(4);
     private readonly List<(uint, IChunkIndexLocation)> _chunkList = new(64);
+    private readonly HashSet<ICommonSession> _pendingAcks = new();
 
     private ISawmill _sawmill = default!;
 
@@ -134,17 +137,6 @@ internal sealed partial class PVSSystem : EntitySystem
         InitializeDirty();
     }
 
-    /// <summary>
-    ///     Marks an entity's current chunk as dirty.
-    /// </summary>
-    internal void MarkDirty(EntityUid uid)
-    {
-        var query = GetEntityQuery<TransformComponent>();
-        var xform = query.GetComponent(uid);
-        var coordinates = _transform.GetMoverCoordinates(xform, query);
-        _entityPvsCollection.MarkDirty(_entityPvsCollection.GetChunkIndex(coordinates));
-    }
-
     public override void Shutdown()
     {
         base.Shutdown();
@@ -163,10 +155,14 @@ internal sealed partial class PVSSystem : EntitySystem
     }
 
     // TODO rate limit this?
-    private void OnClientRequestFull(ICommonSession session, GameTick tick, GameTick lastAcked, EntityUid? missingEntity)
+    private void OnClientRequestFull(ICommonSession session, GameTick tick, EntityUid? missingEntity)
     {
-        if (!_playerVisibleSets.TryGetValue(session, out var sessionData))
+        if (!PlayerData.TryGetValue(session, out var sessionData))
             return;
+
+        // Update acked tick so that OnClientAck doesn't get invoked by any late acks.
+        var lastAcked = sessionData.LastReceivedAck;
+        sessionData.LastReceivedAck = _gameTiming.CurTick;
 
         var sb = new StringBuilder();
         sb.Append($"Client {session} requested full state on tick {tick}. Last Acked: {lastAcked}.");
@@ -190,51 +186,14 @@ internal sealed partial class PVSSystem : EntitySystem
         }
 
         // return last acked to pool, but only if it is not still in the OverflowDictionary.
-        if (sessionData.LastAcked != null && !sessionData.SentEntities.ContainsKey(lastAcked))
-            _visSetPool.Return(sessionData.LastAcked);
+        if (sessionData.LastAcked != null && !sessionData.SentEntities.ContainsKey(sessionData.LastAcked.Value.Tick))
+        {
+            DebugTools.Assert(sessionData.SentEntities.Values.Contains(sessionData.LastAcked.Value.Data));
+            _visSetPool.Return(sessionData.LastAcked.Value.Data);
+        }
 
         sessionData.LastAcked = null;
         sessionData.RequestedFull = true;
-    }
-
-    private void OnClientAck(ICommonSession session, GameTick ackedTick, GameTick lastAckedTick)
-    {
-        if (!_playerVisibleSets.TryGetValue(session, out var sessionData))
-            return;
-
-        if (sessionData.Overflow != null && sessionData.Overflow.Value.Tick < ackedTick)
-        {
-            var (overflowTick, overflowEnts) = sessionData.Overflow.Value;
-            sessionData.Overflow = null;
-            if (overflowTick == ackedTick)
-            {
-                ProcessAckedTick(sessionData, overflowEnts, ackedTick, lastAckedTick);
-                return;
-            }
-
-            // Even though the acked tick is newer, we have no guarantee that the client received the cached set, so
-            // we just discard it.
-            _visSetPool.Return(overflowEnts);
-        }
-
-        if (sessionData.SentEntities.TryGetValue(ackedTick, out var ackedData))
-            ProcessAckedTick(sessionData, ackedData, ackedTick, lastAckedTick);
-    }
-
-    private void ProcessAckedTick(SessionPVSData sessionData, Dictionary<EntityUid, PVSEntityVisiblity> ackedData, GameTick tick, GameTick lastAckedTick)
-    {
-        // return last acked to pool, but only if it is not still in the OverflowDictionary.
-        if (sessionData.LastAcked != null && !sessionData.SentEntities.ContainsKey(lastAckedTick))
-            _visSetPool.Return(sessionData.LastAcked);
-
-        sessionData.LastAcked = ackedData;
-        foreach (var ent in ackedData.Keys)
-        {
-            sessionData.LastSeenAt[ent] = tick;
-        }
-
-        // The client acked a tick. If they requested a full state, this ack happened some time after that, so we can safely set this to false
-        sessionData.RequestedFull = false;
     }
 
     private void OnViewsizeChanged(float obj)
@@ -244,7 +203,7 @@ internal sealed partial class PVSSystem : EntitySystem
 
     private void SetPvs(bool value)
     {
-        SeenAllEnts.Clear();
+        _seenAllEnts.Clear();
         CullingEnabled = value;
     }
 
@@ -253,27 +212,6 @@ internal sealed partial class PVSSystem : EntitySystem
         foreach (var collection in _pvsCollections)
         {
             collection.Process();
-        }
-    }
-
-    public void CleanupDirty(IEnumerable<IPlayerSession> sessions)
-    {
-        if (!CullingEnabled)
-        {
-            SeenAllEnts.Clear();
-            foreach (var player in sessions)
-            {
-                SeenAllEnts.Add(player);
-            }
-        }
-
-        _currentIndex = ((int)_gameTiming.CurTick.Value + 1) % DirtyBufferSize;
-        _addEntities[_currentIndex].Clear();
-        _dirtyEntities[_currentIndex].Clear();
-
-        foreach (var collection in _pvsCollections)
-        {
-            collection.ClearDirty();
         }
     }
 
@@ -304,7 +242,7 @@ internal sealed partial class PVSSystem : EntitySystem
 
         var previousTick = _gameTiming.CurTick - 1;
 
-        foreach (var sessionData in _playerVisibleSets.Values)
+        foreach (var sessionData in PlayerData.Values)
         {
             sessionData.LastSeenAt.Remove(e);
             if (sessionData.SentEntities.TryGetValue(previousTick, out var ents))
@@ -390,7 +328,7 @@ internal sealed partial class PVSSystem : EntitySystem
     {
         if (e.NewStatus == SessionStatus.InGame)
         {
-            if (!_playerVisibleSets.TryAdd(e.Session, new()))
+            if (!PlayerData.TryAdd(e.Session, new()))
                 _sawmill.Error($"Attempted to add player to _playerVisibleSets, but they were already present? Session:{e.Session}");
 
             foreach (var pvsCollection in _pvsCollections)
@@ -404,7 +342,7 @@ internal sealed partial class PVSSystem : EntitySystem
         if (e.NewStatus != SessionStatus.Disconnected)
             return;
 
-        if (!_playerVisibleSets.Remove(e.Session, out var data))
+        if (!PlayerData.Remove(e.Session, out var data))
             return;
 
         foreach (var pvsCollection in _pvsCollections)
@@ -417,12 +355,13 @@ internal sealed partial class PVSSystem : EntitySystem
             _visSetPool.Return(data.Overflow.Value.SentEnts);
         data.Overflow = null;
 
-        if (data.LastAcked != null)
-            _visSetPool.Return(data.LastAcked);
+        var acked = data.LastAcked?.Data;
+        if (acked != null)
+            _visSetPool.Return(acked);
 
         foreach (var visSet in data.SentEntities.Values)
         {
-            if (visSet != data.LastAcked)
+            if (visSet != acked)
                 _visSetPool.Return(visSet);
         }
 
@@ -734,20 +673,24 @@ internal sealed partial class PVSSystem : EntitySystem
         return true;
     }
 
-    public (List<EntityState>? updates, List<EntityUid>? deletions, List<EntityUid>? leftPvs, GameTick fromTick) CalculateEntityStates(IPlayerSession session,
-        GameTick fromTick, GameTick toTick,
-        (Dictionary<EntityUid, MetaDataComponent> metadata, RobustTree<EntityUid> tree)?[] chunkCache,
-        HashSet<int> chunkIndices, EntityQuery<MetaDataComponent> mQuery, EntityQuery<TransformComponent> tQuery,
-        EntityUid[] viewerEntities)
+    internal (List<EntityState>? updates, List<EntityUid>? deletions, List<EntityUid>? leftPvs, GameTick fromTick)
+        CalculateEntityStates(IPlayerSession session,
+            GameTick fromTick,
+            GameTick toTick,
+            EntityQuery<MetaDataComponent> mQuery,
+            EntityQuery<TransformComponent> tQuery,
+            (Dictionary<EntityUid, MetaDataComponent> metadata, RobustTree<EntityUid> tree)?[] chunks,
+            HashSet<int> visibleChunks,
+            EntityUid[] viewers)
     {
         DebugTools.Assert(session.Status == SessionStatus.InGame);
         var newEntityBudget = _netConfigManager.GetClientCVar(session.ConnectedClient, CVars.NetPVSEntityBudget);
         var enteredEntityBudget = _netConfigManager.GetClientCVar(session.ConnectedClient, CVars.NetPVSEntityEnterBudget);
         var newEntityCount = 0;
         var enteredEntityCount = 0;
-        var sessionData = _playerVisibleSets[session];
+        var sessionData = PlayerData[session];
         sessionData.SentEntities.TryGetValue(toTick - 1, out var lastSent);
-        var lastAcked = sessionData.LastAcked;
+        var lastAcked = sessionData.LastAcked?.Data;
         var lastSeen = sessionData.LastSeenAt;
         var visibleEnts = _visSetPool.Get();
 
@@ -760,9 +703,9 @@ internal sealed partial class PVSSystem : EntitySystem
 
         var stack = _stackPool.Get();
         // TODO reorder chunks to prioritize those that are closest to the viewer? Helps make pop-in less visible.
-        foreach (var i in chunkIndices)
+        foreach (var i in visibleChunks)
         {
-            var cache = chunkCache[i];
+            var cache = chunks[i];
             if(!cache.HasValue) continue;
 
 #if DEBUG
@@ -800,7 +743,7 @@ internal sealed partial class PVSSystem : EntitySystem
         }
         localEnumerator.Dispose();
 
-        foreach (var viewerEntity in viewerEntities)
+        foreach (var viewerEntity in viewers)
         {
             RecursivelyAddOverride(in viewerEntity, lastAcked, lastSent, visibleEnts, lastSeen, in mQuery, in tQuery, in fromTick,
                 ref newEntityCount, ref enteredEntityCount, ref entStateCount, in newEntityBudget, in enteredEntityBudget);
@@ -1048,7 +991,7 @@ internal sealed partial class PVSSystem : EntitySystem
     /// <summary>
     ///     Gets all entity states that have been modified after and including the provided tick.
     /// </summary>
-    public (List<EntityState>?, List<EntityUid>?, List<EntityUid>?, GameTick fromTick) GetAllEntityStates(ICommonSession? player, GameTick fromTick, GameTick toTick)
+    public (List<EntityState>?, List<EntityUid>?, GameTick fromTick) GetAllEntityStates(ICommonSession? player, GameTick fromTick, GameTick toTick)
     {
         List<EntityState>? stateEntities;
         var toSend = _uidSetPool.Get();
@@ -1059,7 +1002,7 @@ internal sealed partial class PVSSystem : EntitySystem
         {
             enumerateAll = fromTick == GameTick.Zero;
         }
-        else if (!SeenAllEnts.Contains(player))
+        else if (!_seenAllEnts.Contains(player))
         {
             enumerateAll = true;
             fromTick = GameTick.Zero;
@@ -1129,7 +1072,7 @@ internal sealed partial class PVSSystem : EntitySystem
         if (stateEntities.Count == 0)
             stateEntities = null;
 
-        return (stateEntities, deletions, null, fromTick);
+        return (stateEntities, deletions, fromTick);
     }
 
     /// <summary>
@@ -1289,9 +1232,9 @@ internal sealed partial class PVSSystem : EntitySystem
     }
 
     /// <summary>
-    ///     Session data class used to avoid having to lock session dictionaries.
+    ///     Class used to store per-session data in order to avoid having to lock dictionaries.
     /// </summary>
-    private sealed class SessionPVSData
+    internal sealed class SessionPVSData
     {
         /// <summary>
         /// All <see cref="EntityUid"/>s that this session saw during the last <see cref="DirtyBufferSize"/> ticks.
@@ -1301,7 +1244,7 @@ internal sealed partial class PVSSystem : EntitySystem
         /// <summary>
         ///     The most recently acked entities
         /// </summary>
-        public Dictionary<EntityUid, PVSEntityVisiblity>? LastAcked = new();
+        public (GameTick Tick, Dictionary<EntityUid, PVSEntityVisiblity> Data)? LastAcked;
 
         /// <summary>
         ///     Stores the last tick at which a given entity was acked by a player. Used to avoid re-sending the whole entity
@@ -1310,7 +1253,7 @@ internal sealed partial class PVSSystem : EntitySystem
         public readonly Dictionary<EntityUid, GameTick> LastSeenAt = new();
 
         /// <summary>
-        ///     <see cref="_sentData"/> overflow in case a player's last ack is more than <see cref="DirtyBufferSize"/> ticks behind the current tick.
+        ///     <see cref="SentEntities"/> overflow in case a player's last ack is more than <see cref="DirtyBufferSize"/> ticks behind the current tick.
         /// </summary>
         public (GameTick Tick, Dictionary<EntityUid, PVSEntityVisiblity> SentEnts)? Overflow;
 
@@ -1319,6 +1262,14 @@ internal sealed partial class PVSSystem : EntitySystem
         ///     all data, not just data that cannot be implicitly inferred from entity prototypes.
         /// </summary>
         public bool RequestedFull = false;
+
+        /// <summary>
+        ///     The tick of the most recently received client Ack. Will be used to update <see cref="LastAcked"/>
+        /// </summary>
+        /// <remarks>
+        ///     As the server delays processing acks, this might not currently be the same as <see cref="LastAcked"/>
+        /// </remarks>
+        public GameTick LastReceivedAck;
     }
 }
 

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -2,7 +2,6 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
@@ -22,6 +21,7 @@ using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using SharpZstd.Interop;
 using Microsoft.Extensions.ObjectPool;
+using Prometheus;
 using Robust.Shared.Players;
 using Robust.Server.Replays;
 using Robust.Shared.Map.Components;
@@ -33,7 +33,6 @@ namespace Robust.Server.GameStates
     public sealed class ServerGameStateManager : IServerGameStateManager, IPostInjectInit
     {
         // Mapping of net UID of clients -> last known acked state.
-        private readonly Dictionary<long, GameTick> _ackedStates = new();
         private GameTick _lastOldestAck = GameTick.Zero;
 
         private PVSSystem _pvs = default!;
@@ -49,14 +48,21 @@ namespace Robust.Server.GameStates
         [Dependency] private readonly IConfigurationManager _cfg = default!;
         [Dependency] private readonly IParallelManager _parallelMgr = default!;
 
+        private static readonly Histogram _usageHistogram = Metrics.CreateHistogram("robust_game_state_update_usage",
+            "Amount of time spent processing different parts of the game state update", new HistogramConfiguration
+            {
+                LabelNames = new[] {"area"},
+                Buckets = Histogram.ExponentialBuckets(0.000_001, 1.5, 25)
+            });
+
         private ISawmill _logger = default!;
 
         private DefaultObjectPool<PvsThreadResources> _threadResourcesPool = default!;
 
         public ushort TransformNetId { get; set; }
 
-        public Action<ICommonSession, GameTick, GameTick>? ClientAck { get; set; }
-        public Action<ICommonSession, GameTick, GameTick, EntityUid?>? ClientRequestFull { get; set; }
+        public Action<ICommonSession, GameTick>? ClientAck { get; set; }
+        public Action<ICommonSession, GameTick, EntityUid?>? ClientRequestFull { get; set; }
 
         public void PostInject()
         {
@@ -70,9 +76,6 @@ namespace Robust.Server.GameStates
             _networkManager.RegisterNetMessage<MsgStateLeavePvs>();
             _networkManager.RegisterNetMessage<MsgStateAck>(HandleStateAck);
             _networkManager.RegisterNetMessage<MsgStateRequestFull>(HandleFullStateRequest);
-
-            _networkManager.Connected += HandleClientConnected;
-            _networkManager.Disconnect += HandleClientDisconnect;
 
             _pvs = _entityManager.System<PVSSystem>();
 
@@ -125,42 +128,19 @@ namespace Robust.Server.GameStates
             }
         }
 
-        private void HandleClientConnected(object? sender, NetChannelArgs e)
-        {
-            _ackedStates[e.Channel.ConnectionId] = GameTick.Zero;
-        }
-
-        private void HandleClientDisconnect(object? sender, NetChannelArgs e)
-        {
-            _ackedStates.Remove(e.Channel.ConnectionId);
-        }
-
         private void HandleFullStateRequest(MsgStateRequestFull msg)
         {
-            if (!_playerManager.TryGetSessionById(msg.MsgChannel.UserId, out var session) ||
-                !_ackedStates.TryGetValue(msg.MsgChannel.ConnectionId, out var lastAcked))
+            if (!_playerManager.TryGetSessionById(msg.MsgChannel.UserId, out var session))
                 return;
 
             EntityUid? ent = msg.MissingEntity.IsValid() ? msg.MissingEntity : null;
-            ClientRequestFull?.Invoke(session, msg.Tick, lastAcked, ent);
-
-            // Update acked tick so that OnClientAck doesn't get invoked by any late acks.
-            _ackedStates[msg.MsgChannel.ConnectionId] = _gameTiming.CurTick;
+            ClientRequestFull?.Invoke(session, msg.Tick, ent);
         }
 
         private void HandleStateAck(MsgStateAck msg)
         {
             if (_playerManager.TryGetSessionById(msg.MsgChannel.UserId, out var session))
-                Ack(msg.MsgChannel.ConnectionId, msg.Sequence, session);
-        }
-
-        private void Ack(long uniqueIdentifier, GameTick stateAcked, IPlayerSession playerSession)
-        {
-            if (!_ackedStates.TryGetValue(uniqueIdentifier, out var lastAck) || stateAcked <= lastAck)
-                return;
-
-            ClientAck?.Invoke(playerSession, stateAcked, lastAck);
-            _ackedStates[uniqueIdentifier] = stateAcked;
+                ClientAck?.Invoke(session, msg.Sequence);
         }
 
         /// <inheritdoc />
@@ -175,38 +155,108 @@ namespace Robust.Server.GameStates
                 return;
             }
 
-            var inputSystem = _systemManager.GetEntitySystem<InputSystem>();
-
-            var oldestAckValue = GameTick.MaxValue.Value;
-
-            _pvs.ProcessCollections();
-
-            // people not in the game don't get states
             var players = _playerManager.ServerSessions.Where(o => o.Status == SessionStatus.InGame).ToArray();
 
-            //todo paul oh my god make this less shit
-            EntityQuery<MetaDataComponent> metadataQuery = default!;
-            EntityQuery<TransformComponent> transformQuery = default!;
-            HashSet<int>[] playerChunks = default!;
-            EntityUid[][] viewerEntities = default!;
-            (Dictionary<EntityUid, MetaDataComponent> metadata, RobustTree<EntityUid> tree)?[] chunkCache = default!;
+            // Update entity positions in PVS chunks/collections
+            // TODO disable processing if culling is disabled? Need to check if toggling PVS breaks anything.
+            // TODO parallelize?
+            using (_usageHistogram.WithLabels("Update Collections").NewTimer())
+            {
+                _pvs.ProcessCollections();
+            }
 
+            // Figure out what chunks players can see and cache some chunk data.
+            PvsData? pvsData = null;
             if (_pvs.CullingEnabled)
             {
-                List<(uint, IChunkIndexLocation)> chunks;
-                (chunks, playerChunks, viewerEntities) = _pvs.GetChunks(players);
-                const int ChunkBatchSize = 2;
-                var chunksCount = chunks.Count;
-                var chunkBatches = (int)MathF.Ceiling((float)chunksCount / ChunkBatchSize);
-                chunkCache =
-                    new (Dictionary<EntityUid, MetaDataComponent> metadata, RobustTree<EntityUid> tree)?[chunksCount];
+                using var _ = _usageHistogram.WithLabels("Get Chunks").NewTimer();
+                pvsData = GetPVSData(players);
+            }
 
-                // Update the reused trees sequentially to avoid having to lock the dictionary per chunk.
-                var reuse = ArrayPool<bool>.Shared.Rent(chunksCount);
+            // Update client acks, which is used to figure out what data needs to be sent to clients
+            using (_usageHistogram.WithLabels("Process Acks").NewTimer())
+            {
+                _pvs.ProcessQueuedAcks();
+            }
 
-                transformQuery = _entityManager.GetEntityQuery<TransformComponent>();
-                metadataQuery = _entityManager.GetEntityQuery<MetaDataComponent>();
-                Parallel.For(0, chunkBatches,
+            // Construct & send the game state to each player.
+            GameTick oldestAck;
+            using (_usageHistogram.WithLabels("Send States").NewTimer())
+            {
+                oldestAck = SendStates(players, pvsData);
+            }
+
+            if (pvsData != null)
+                _pvs.ReturnToPool(pvsData.Value.PlayerChunks);
+
+            using (_usageHistogram.WithLabels("Clean Dirty").NewTimer())
+            {
+                _pvs.CleanupDirty(_playerManager.ServerSessions);
+            }
+
+            // keep the deletion history buffers clean
+            if (oldestAck > _lastOldestAck)
+            {
+                using var _ = _usageHistogram.WithLabels("Cull History").NewTimer();
+                _lastOldestAck = oldestAck;
+                _pvs.CullDeletionHistory(oldestAck);
+                _mapManager.CullDeletionHistory(oldestAck);
+            }
+        }
+
+        private GameTick SendStates(IPlayerSession[] players, PvsData? pvsData)
+        {
+            var inputSystem = _systemManager.GetEntitySystem<InputSystem>();
+            var opts = new ParallelOptions {MaxDegreeOfParallelism = _parallelMgr.ParallelProcessCount};
+            var oldestAckValue = GameTick.MaxValue.Value;
+            var tQuery = _entityManager.GetEntityQuery<TransformComponent>();
+            var mQuery = _entityManager.GetEntityQuery<MetaDataComponent>();
+
+            // Replays process game states in parallel with players
+            var start = _replay.Recording ? -1 : 0;
+            Parallel.For(start, players.Length, opts, _threadResourcesPool.Get, SendPlayer, _threadResourcesPool.Return);
+
+            PvsThreadResources SendPlayer(int i, ParallelLoopState state, PvsThreadResources resource)
+            {
+                try
+                {
+                    if (i >= 0)
+                        SendStateUpdate(i, resource, inputSystem, players[i], pvsData, mQuery, tQuery, ref oldestAckValue);
+                    else
+                        _replay.SaveReplayData(resource);
+                }
+                catch (Exception e) // Catch EVERY exception
+                {
+                    _logger.Log(LogLevel.Error, e, "Caught exception while generating mail.");
+                }
+                return resource;
+            }
+
+            return new GameTick(oldestAckValue);
+        }
+
+        private struct PvsData
+        {
+            public HashSet<int>[] PlayerChunks;
+            public EntityUid[][] ViewerEntities;
+            public (Dictionary<EntityUid, MetaDataComponent> metadata, RobustTree<EntityUid> tree)?[] ChunkCache;
+        }
+
+        private PvsData? GetPVSData(IPlayerSession[] players)
+        {
+            var (chunks, playerChunks, viewerEntities) = _pvs.GetChunks(players);
+            const int ChunkBatchSize = 2;
+            var chunksCount = chunks.Count;
+            var chunkBatches = (int)MathF.Ceiling((float)chunksCount / ChunkBatchSize);
+            var chunkCache =
+                new (Dictionary<EntityUid, MetaDataComponent> metadata, RobustTree<EntityUid> tree)?[chunksCount];
+
+            // Update the reused trees sequentially to avoid having to lock the dictionary per chunk.
+            var reuse = ArrayPool<bool>.Shared.Rent(chunksCount);
+
+            var transformQuery = _entityManager.GetEntityQuery<TransformComponent>();
+            var metadataQuery = _entityManager.GetEntityQuery<MetaDataComponent>();
+            Parallel.For(0, chunkBatches,
                 new ParallelOptions { MaxDegreeOfParallelism = _parallelMgr.ParallelProcessCount },
                 i =>
                 {
@@ -235,104 +285,87 @@ namespace Robust.Server.GameStates
                     }
                 });
 
-                _pvs.RegisterNewPreviousChunkTrees(chunks, chunkCache, reuse);
-                ArrayPool<bool>.Shared.Return(reuse);
-            }
-
-            Parallel.For(
-                _replay.Recording ? -1 : 0, players.Length,
-                new ParallelOptions { MaxDegreeOfParallelism = _parallelMgr.ParallelProcessCount },
-                _threadResourcesPool.Get,
-                (i, _, resource) =>
-                {
-                    if (i == -1)
-                    {
-                        _replay.SaveReplayData(resource);
-                        return resource;
-                    }
-
-                    try
-                    {
-                        SendStateUpdate(i, resource);
-                    }
-                    catch (Exception e) // Catch EVERY exception
-                    {
-                        _logger.Log(LogLevel.Error, e, "Caught exception while generating mail.");
-                    }
-                    return resource;
-                },
-                _threadResourcesPool.Return
-            );
-
-            void SendStateUpdate(int sessionIndex, PvsThreadResources resources)
+            _pvs.RegisterNewPreviousChunkTrees(chunks, chunkCache, reuse);
+            ArrayPool<bool>.Shared.Return(reuse);
+            return new PvsData()
             {
-                var session = players[sessionIndex];
+                PlayerChunks = playerChunks,
+                ViewerEntities = viewerEntities,
+                ChunkCache = chunkCache,
+            };
+        }
 
-                var channel = session.ConnectedClient;
+        private void SendStateUpdate(int i,
+            PvsThreadResources resources,
+            InputSystem inputSystem,
+            IPlayerSession session,
+            PvsData? pvsData,
+            EntityQuery<MetaDataComponent> mQuery,
+            EntityQuery<TransformComponent> tQuery,
+            ref uint oldestAckValue)
+        {
+            var channel = session.ConnectedClient;
+            var sessionData = _pvs.PlayerData[session];
+            var lastAck = sessionData.LastReceivedAck;
+            List<EntityUid>? leftPvs = null;
+            List<EntityState>? entStates;
+            List<EntityUid>? deletions;
+            GameTick fromTick;
 
-                if (!_ackedStates.TryGetValue(channel.ConnectionId, out var lastAck))
-                {
-                    DebugTools.Assert("Why does this channel not have an entry?");
-                }
-
-                var (entStates, deletions, leftPvs, fromTick) = _pvs.CullingEnabled
-                    ? _pvs.CalculateEntityStates(session, lastAck, _gameTiming.CurTick, chunkCache,
-                        playerChunks[sessionIndex], metadataQuery, transformQuery, viewerEntities[sessionIndex])
-                    : _pvs.GetAllEntityStates(session, lastAck, _gameTiming.CurTick);
-                var playerStates = _playerManager.GetPlayerStates(lastAck);
-
-                // lastAck varies with each client based on lag and such, we can't just make 1 global state and send it to everyone
-                var lastInputCommand = inputSystem.GetLastInputCommand(session);
-                var lastSystemMessage = _entityNetworkManager.GetLastMessageSequence(session);
-
-                var state = new GameState(
-                    fromTick,
+            DebugTools.Assert(_pvs.CullingEnabled == (pvsData != null));
+            if (pvsData != null)
+            {
+                (entStates, deletions, leftPvs, fromTick) = _pvs.CalculateEntityStates(
+                    session,
+                    lastAck,
                     _gameTiming.CurTick,
-                    Math.Max(lastInputCommand, lastSystemMessage),
-                    entStates,
-                    playerStates,
-                    deletions);
-
-                InterlockedHelper.Min(ref oldestAckValue, lastAck.Value);
-
-                // actually send the state
-                var stateUpdateMessage = new MsgState();
-                stateUpdateMessage.State = state;
-                stateUpdateMessage.CompressionContext = resources.CompressionContext;
-
-                _networkManager.ServerSendMessage(stateUpdateMessage, channel);
-
-                // If the state is too big we let Lidgren send it reliably.
-                // This is to avoid a situation where a state is so large that it consistently gets dropped
-                // (or, well, part of it).
-                // When we send them reliably, we immediately update the ack so that the next state will not be huge.
-                if (stateUpdateMessage.ShouldSendReliably())
-                {
-                    // TODO: remove this lock by having a single state object per session that contains all per-session state needed.
-                    lock (_ackedStates)
-                    {
-                        Ack(channel.ConnectionId, _gameTiming.CurTick, session);
-                    }
-                }
-
-                // separately, we send PVS detach / left-view messages reliably. This is not resistant to packet loss,
-                // but unlike game state it doesn't really matter. This also significantly reduces the size of game
-                // state messages PVS chunks move out of view.
-                if (leftPvs != null && leftPvs.Count > 0)
-                    _networkManager.ServerSendMessage(new MsgStateLeavePvs() { Entities = leftPvs, Tick = _gameTiming.CurTick }, channel);
+                    mQuery,
+                    tQuery,
+                    pvsData.Value.ChunkCache,
+                    pvsData.Value.PlayerChunks[i],
+                    pvsData.Value.ViewerEntities[i]);
+            }
+            else
+            {
+                (entStates, deletions, fromTick) = _pvs.GetAllEntityStates(session, lastAck, _gameTiming.CurTick);
             }
 
-            if (_pvs.CullingEnabled)
-                _pvs.ReturnToPool(playerChunks);
-            _pvs.CleanupDirty(_playerManager.ServerSessions);
-            var oldestAck = new GameTick(oldestAckValue);
+            var playerStates = _playerManager.GetPlayerStates(lastAck);
 
-            // keep the deletion history buffers clean
-            if (oldestAck > _lastOldestAck)
+            // lastAck varies with each client based on lag and such, we can't just make 1 global state and send it to everyone
+            var lastInputCommand = inputSystem.GetLastInputCommand(session);
+            var lastSystemMessage = _entityNetworkManager.GetLastMessageSequence(session);
+
+            var state = new GameState(
+                fromTick,
+                _gameTiming.CurTick,
+                Math.Max(lastInputCommand, lastSystemMessage),
+                entStates,
+                playerStates,
+                deletions);
+
+            InterlockedHelper.Min(ref oldestAckValue, lastAck.Value);
+
+            // actually send the state
+            var stateUpdateMessage = new MsgState();
+            stateUpdateMessage.State = state;
+            stateUpdateMessage.CompressionContext = resources.CompressionContext;
+
+            _networkManager.ServerSendMessage(stateUpdateMessage, channel);
+
+            // If the state is too big we let Lidgren send it reliably. This is to avoid a situation where a state is so
+            // large that it (or part of it) consistently gets dropped. When we send reliably, we immediately update the
+            // ack so that the next state will not also be huge.
+            if (stateUpdateMessage.ShouldSendReliably())
+                ClientAck?.Invoke(session, _gameTiming.CurTick);
+
+            // Send PVS detach / left-view messages separately and reliably. This is not resistant to packet loss, but
+            // unlike game state it doesn't really matter. This also significantly reduces the size of game state
+            // messages as PVS chunks get moved out of view.
+            if (leftPvs != null && leftPvs.Count > 0)
             {
-                _lastOldestAck = oldestAck;
-                _pvs.CullDeletionHistory(oldestAck);
-                _mapManager.CullDeletionHistory(oldestAck);
+                var pvsMessage = new MsgStateLeavePvs {Entities = leftPvs, Tick = _gameTiming.CurTick};
+                _networkManager.ServerSendMessage(pvsMessage, channel);
             }
         }
     }

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -24,6 +24,7 @@ using SharpZstd.Interop;
 using Microsoft.Extensions.ObjectPool;
 using Robust.Shared.Players;
 using Robust.Server.Replays;
+using Robust.Shared.Map.Components;
 
 namespace Robust.Server.GameStates
 {
@@ -218,6 +219,19 @@ namespace Robust.Server.GameStates
                         reuse[j] = _pvs.TryCalculateChunk(chunkIndexLocation, visMask, transformQuery, metadataQuery,
                             out var chunk);
                         chunkCache[j] = chunk;
+
+#if DEBUG
+                        if (chunk == null)
+                            continue;
+
+                        // Each root nodes should simply be a map or a grid entity.
+                        DebugTools.Assert(chunk.Value.tree.RootNodes.Count == 1,
+                            $"Root node count is {chunk.Value.tree.RootNodes.Count} instead of 1.");
+                        var ent = chunk.Value.tree.RootNodes.FirstOrDefault();
+                        DebugTools.Assert(_entityManager.EntityExists(ent), $"Root node does not exist. Node {ent}.");
+                        DebugTools.Assert(_entityManager.HasComponent<MapComponent>(ent)
+                                          || _entityManager.HasComponent<MapGridComponent>(ent));
+#endif
                     }
                 });
 

--- a/Robust.Server/Replays/ReplayRecordingManager.cs
+++ b/Robust.Server/Replays/ReplayRecordingManager.cs
@@ -164,7 +164,7 @@ internal sealed class ReplayRecordingManager : IInternalReplayRecordingManager
             var lastAck = _firstTick ? GameTick.Zero : _timing.CurTick - 1;
             _firstTick = false;
 
-            var (entStates, deletions, _, __) = _pvs.GetAllEntityStates(null, lastAck, _timing.CurTick);
+            var (entStates, deletions, _) = _pvs.GetAllEntityStates(null, lastAck, _timing.CurTick);
             var playerStates = _playerMan.GetPlayerStates(lastAck);
             var state = new GameState(lastAck, _timing.CurTick, 0, entStates, playerStates, deletions);
 


### PR DESCRIPTION
- Adds a new area for the `TickUsage` histrogram for `BaseServer.Input()`. Previously this just wasn't being measured, and was hiding significant PVS tick time for processing game state acks. 
- PVS now queues up and processes game state acks in parallel.
- Added a new histogram for `ServerGameStateManager`, for collecting more detailed information about which parts of PVS take up time.
- Tried to clean up `SendGameStateUpdate()` a bit by moving local functions & chunks of code into separate functions, along with making use of the new histogram.
- Moved around various PVS & game-state functions, including by creating a new partial file for PVSSystem to handle client acks.

I've never actually added new grafana histograms or histogram areas/labels before. So I have no idea if it requires anything beyond what I've done here.

Fixes #3928
This PR includes #3935 for the sake of being able to test PVS with multiple clients.