### PR TITLE
Add stack trace to transform log.

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -1187,7 +1187,7 @@ public abstract partial class SharedTransformSystem
         else
         {
             if (!_mapManager.IsMap(uid))
-                Logger.Warning($"Failed to attach entity to map or grid. Entity: ({ToPrettyString(uid)}).");
+                _logger.Warning($"Failed to attach entity to map or grid. Entity: ({ToPrettyString(uid)}). Trace: {Environment.StackTrace}");
 
             DetachParentToNull(uid, xform);
             return;


### PR DESCRIPTION
Happens consistently to body parts during tests but I don't know why.