### PR TITLE
Hotfix assembly paths

### DIFF
--- a/Robust.Client/GameControllerOptions.cs
+++ b/Robust.Client/GameControllerOptions.cs
@@ -51,12 +51,12 @@ namespace Robust.Client
         /// <summary>
         ///     Directory to load all assemblies from.
         /// </summary>
-        public ResPath AssemblyDirectory { get; init; } = new(@"/Assemblies/");
+        public ResPath AssemblyDirectory { get; init; } = new(@"/Assemblies");
 
         /// <summary>
         ///     Directory to load all prototypes from.
         /// </summary>
-        public ResPath PrototypeDirectory { get; init; } = new(@"/Prototypes/");
+        public ResPath PrototypeDirectory { get; init; } = new(@"/Prototypes");
 
         /// <summary>
         /// Directory resource path containing window icons to load.

--- a/Robust.Server/ServerOptions.cs
+++ b/Robust.Server/ServerOptions.cs
@@ -29,12 +29,12 @@ namespace Robust.Server
         /// <summary>
         ///     Directory to load all assemblies from.
         /// </summary>
-        public ResPath AssemblyDirectory { get; init; } = new(@"/Assemblies/");
+        public ResPath AssemblyDirectory { get; init; } = new(@"/Assemblies");
 
         /// <summary>
         ///     Directory to load all prototypes from.
         /// </summary>
-        public ResPath PrototypeDirectory { get; init; } = new(@"/Prototypes/");
+        public ResPath PrototypeDirectory { get; init; } = new(@"/Prototypes");
 
         /// <summary>
         ///     Whether to disable mounting the "Resources/" folder on FULL_RELEASE.


### PR DESCRIPTION
Checked that sandbox is still being run but this was causing double // when adding the path.