### PR TITLE
Revert "Replace `ResourcePath` with `ResPath` (#3926)"

### DIFF
--- a/Robust.Benchmarks/Serialization/Copy/SerializationCopyBenchmark.cs
+++ b/Robust.Benchmarks/Serialization/Copy/SerializationCopyBenchmark.cs
@@ -108,7 +108,9 @@ namespace Robust.Benchmarks.Serialization.Copy
             copy.Potency = Seed.Potency;
             copy.Ligneous = Seed.Ligneous;
 
-            copy.PlantRsi = new ResPath(Seed.PlantRsi.ToString());
+            copy.PlantRsi = Seed.PlantRsi == null
+                ? null!
+                : new ResourcePath(Seed.PlantRsi.ToString(), Seed.PlantRsi.Separator);
             copy.PlantIconState = Seed.PlantIconState;
             copy.Bioluminescent = Seed.Bioluminescent;
             copy.BioluminescentColor = Seed.BioluminescentColor;

--- a/Robust.Benchmarks/Serialization/Definitions/SeedDataDefinition.cs
+++ b/Robust.Benchmarks/Serialization/Definitions/SeedDataDefinition.cs
@@ -87,7 +87,7 @@ namespace Robust.Benchmarks.Serialization.Definitions
         #endregion
 
         #region Cosmetics
-        [DataField("plantRsi", required: true)] public ResPath PlantRsi { get; set; } = default!;
+        [DataField("plantRsi", required: true)] public ResourcePath PlantRsi { get; set; } = default!;
         [DataField("plantIconState")] public string PlantIconState { get; set; } = "produce";
         [DataField("bioluminescent")] public bool Bioluminescent { get; set; }
         [DataField("bioluminescentColor")] public Color BioluminescentColor { get; set; } = Color.White;

--- a/Robust.Benchmarks/Utility/ResourcePathBench.cs
+++ b/Robust.Benchmarks/Utility/ResourcePathBench.cs
@@ -31,6 +31,17 @@ public class ResourcePathBench
         }
         return res;
     }
+    
+    [Benchmark]
+    public ResourcePath? CreateResourcePath()
 
+    {
+        ResourcePath? res = null;
+        for (var i = 0; i < N; i++)
+        {
+            res = new ResourcePath(_path);
+        }
+        return res;
+    }
 }
 #pragma warning restore CS0612

--- a/Robust.Client.WebView/Cef/WebViewManagerCef.cs
+++ b/Robust.Client.WebView/Cef/WebViewManagerCef.cs
@@ -60,7 +60,7 @@ namespace Robust.Client.WebView.Cef
 
             var cachePath = "";
             if (_resourceManager.UserData is WritableDirProvider userData)
-                cachePath = userData.GetFullPath(new ResPath("/cef_cache"));
+                cachePath = userData.GetFullPath(new ResourcePath("/cef_cache"));
 
             var settings = new CefSettings()
             {
@@ -171,10 +171,10 @@ namespace Robust.Client.WebView.Cef
 
                 _sawmill.Debug($"HANDLING: {request.Url}");
 
-                var resPath = new ResPath(uri.AbsolutePath);
-                if (_resourceManager.TryContentFileRead(resPath, out var stream))
+                var resourcePath = new ResourcePath(uri.AbsolutePath);
+                if (_resourceManager.TryContentFileRead(resourcePath, out var stream))
                 {
-                    if (!_parent.TryGetResourceMimeType(resPath.Extension, out var mime))
+                    if (!_parent.TryGetResourceMimeType(resourcePath.Extension, out var mime))
                         mime = "application/octet-stream";
 
                     return new RequestResultStream(stream, mime, HttpStatusCode.OK).MakeHandler();

--- a/Robust.Client/Audio/Midi/MidiManager.cs
+++ b/Robust.Client/Audio/Midi/MidiManager.cs
@@ -103,7 +103,7 @@ internal sealed partial class MidiManager : IMidiManager
 
     private const string ContentCustomSoundfontDirectory = "/Audio/MidiCustom/";
 
-    private static ResPath CustomSoundfontDirectory = new("/soundfonts/");
+    private static ResourcePath CustomSoundfontDirectory = new ResourcePath("/soundfonts/");
 
     private readonly ResourceLoaderCallbacks _soundfontLoaderCallbacks;
 
@@ -476,7 +476,7 @@ internal sealed partial class MidiManager : IMidiManager
 
             Stream? stream;
             var resourceCache = _parent._resourceManager;
-            var resourcePath = new ResPath(filename);
+            var resourcePath = new ResourcePath(filename);
 
             if (resourcePath.IsRooted)
             {

--- a/Robust.Client/Console/Commands/Debug.cs
+++ b/Robust.Client/Console/Commands/Debug.cs
@@ -468,7 +468,7 @@ namespace Robust.Client.Console.Commands
 
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            using var writer = _res.UserData.OpenWriteText(new ResPath("/guidump.txt"));
+            using var writer = _res.UserData.OpenWriteText(new ResourcePath("/guidump.txt"));
 
             foreach (var root in _ui.AllRoots)
             {
@@ -674,7 +674,7 @@ namespace Robust.Client.Console.Commands
                         ? StringComparer.Ordinal
                         : StringComparer.OrdinalIgnoreCase;
 
-                    var reversePathResolution = new ConcurrentDictionary<string, HashSet<ResPath>>(stringComparer);
+                    var reversePathResolution = new ConcurrentDictionary<string, HashSet<ResourcePath>>(stringComparer);
 
                     var taskManager = _taskManager;
 
@@ -688,7 +688,7 @@ namespace Robust.Client.Console.Commands
                             throw new NotImplementedException();
                         }
 
-                        reversePathResolution.GetOrAdd(fullPath, _ => new HashSet<ResPath>()).Add(path);
+                        reversePathResolution.GetOrAdd(fullPath, _ => new HashSet<ResourcePath>()).Add(path);
 
                         var dir = Path.GetDirectoryName(fullPath)!;
                         var fileName = Path.GetFileName(fullPath);
@@ -702,7 +702,7 @@ namespace Robust.Client.Console.Commands
                                 throw new NotImplementedException();
                             }
 
-                            reversePathResolution.GetOrAdd(incFullPath, _ => new HashSet<ResPath>()).Add(path);
+                            reversePathResolution.GetOrAdd(incFullPath, _ => new HashSet<ResourcePath>()).Add(path);
 
                             var incDir = Path.GetDirectoryName(incFullPath)!;
                             var incFileName = Path.GetFileName(incFullPath);

--- a/Robust.Client/GameController/GameController.cs
+++ b/Robust.Client/GameController/GameController.cs
@@ -157,7 +157,7 @@ namespace Robust.Client
             ProgramShared.FinishCheckBadFileExtensions(checkBadExtensions);
 
             _prototypeManager.Initialize();
-            _prototypeManager.LoadDirectory(new("/EnginePrototypes/"));
+            _prototypeManager.LoadDirectory(new ResourcePath("/EnginePrototypes/"));
             _prototypeManager.LoadDirectory(Options.PrototypeDirectory);
             _prototypeManager.ResolveResults();
             _userInterfaceManager.Initialize();
@@ -387,7 +387,7 @@ namespace Robust.Client
                 {
                     foreach (var (api, prefix) in mounts)
                     {
-                        _resourceCache.MountLoaderApi(api, "", new(prefix));
+                        _resourceCache.MountLoaderApi(api, "", new ResourcePath(prefix));
                     }
                 }
 

--- a/Robust.Client/GameControllerOptions.cs
+++ b/Robust.Client/GameControllerOptions.cs
@@ -51,22 +51,22 @@ namespace Robust.Client
         /// <summary>
         ///     Directory to load all assemblies from.
         /// </summary>
-        public ResPath AssemblyDirectory { get; init; } = new(@"/Assemblies");
+        public ResourcePath AssemblyDirectory { get; init; } = new(@"/Assemblies/");
 
         /// <summary>
         ///     Directory to load all prototypes from.
         /// </summary>
-        public ResPath PrototypeDirectory { get; init; } = new(@"/Prototypes");
+        public ResourcePath PrototypeDirectory { get; init; } = new(@"/Prototypes/");
 
         /// <summary>
         /// Directory resource path containing window icons to load.
         /// </summary>
-        public ResPath? WindowIconSet { get; init; }
+        public ResourcePath? WindowIconSet { get; init; }
 
         /// <summary>
         /// Resource path for splash image to show when the game starts up.
         /// </summary>
-        public ResPath? SplashLogo { get; init; }
+        public ResourcePath? SplashLogo { get; init; }
 
         /// <summary>
         ///     Whether to disable mounting the "Resources/" folder on FULL_RELEASE.

--- a/Robust.Client/GameObjects/Components/Icon/IconComponent.cs
+++ b/Robust.Client/GameObjects/Components/Icon/IconComponent.cs
@@ -18,7 +18,7 @@ namespace Robust.Client.GameObjects
         public IDirectionalTextureProvider? Icon { get; private set; }
 
         [DataField("sprite")]
-        private ResPath rsi;
+        private ResourcePath? rsi;
         [DataField("state")]
         private string? stateID;
 

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -505,10 +505,10 @@ namespace Robust.Client.GameObjects
 
         public int AddLayer(string texturePath, int? newIndex = null)
         {
-            return AddLayer(new ResPath(texturePath), newIndex);
+            return AddLayer(new ResourcePath(texturePath), newIndex);
         }
 
-        public int AddLayer(ResPath texturePath, int? newIndex = null)
+        public int AddLayer(ResourcePath texturePath, int? newIndex = null)
         {
             if (!resourceCache.TryGetResource<TextureResource>(TextureRoot / texturePath, out var texture))
             {
@@ -555,7 +555,7 @@ namespace Robust.Client.GameObjects
 
         public int AddLayer(RSI.StateId stateId, string rsiPath, int? newIndex = null)
         {
-            return AddLayer(stateId, new ResPath(rsiPath), newIndex);
+            return AddLayer(stateId, new ResourcePath(rsiPath), newIndex);
         }
 
         public int AddLayerState(string stateId, string rsiPath, int? newIndex = null)
@@ -563,7 +563,7 @@ namespace Robust.Client.GameObjects
             return AddLayer(new RSI.StateId(stateId), rsiPath, newIndex);
         }
 
-        public int AddLayer(RSI.StateId stateId, ResPath rsiPath, int? newIndex = null)
+        public int AddLayer(RSI.StateId stateId, ResourcePath rsiPath, int? newIndex = null)
         {
             if (!resourceCache.TryGetResource<RSIResource>(TextureRoot / rsiPath, out var res))
             {
@@ -573,7 +573,7 @@ namespace Robust.Client.GameObjects
             return AddLayer(stateId, res?.RSI, newIndex);
         }
 
-        public int AddLayerState(string stateId, ResPath rsiPath, int? newIndex = null)
+        public int AddLayerState(string stateId, ResourcePath rsiPath, int? newIndex = null)
         {
             return AddLayer(new RSI.StateId(stateId), rsiPath, newIndex);
         }
@@ -899,15 +899,15 @@ namespace Robust.Client.GameObjects
 
         public void LayerSetTexture(int layer, string texturePath)
         {
-            LayerSetTexture(layer, new ResPath(texturePath));
+            LayerSetTexture(layer, new ResourcePath(texturePath));
         }
 
         public void LayerSetTexture(object layerKey, string texturePath)
         {
-            LayerSetTexture(layerKey, new ResPath(texturePath));
+            LayerSetTexture(layerKey, new ResourcePath(texturePath));
         }
 
-        public void LayerSetTexture(int layer, ResPath texturePath)
+        public void LayerSetTexture(int layer, ResourcePath texturePath)
         {
             if (!resourceCache.TryGetResource<TextureResource>(TextureRoot / texturePath, out var texture))
             {
@@ -925,7 +925,7 @@ namespace Robust.Client.GameObjects
             LayerSetTexture(layer, texture?.Texture);
         }
 
-        public void LayerSetTexture(object layerKey, ResPath texturePath)
+        public void LayerSetTexture(object layerKey, ResourcePath texturePath)
         {
             if (!LayerMapTryGet(layerKey, out var layer, true))
                 return;
@@ -991,15 +991,15 @@ namespace Robust.Client.GameObjects
 
         public void LayerSetState(int layer, RSI.StateId stateId, string rsiPath)
         {
-            LayerSetState(layer, stateId, new ResPath(rsiPath));
+            LayerSetState(layer, stateId, new ResourcePath(rsiPath));
         }
 
         public void LayerSetState(object layerKey, RSI.StateId stateId, string rsiPath)
         {
-            LayerSetState(layerKey, stateId, new ResPath(rsiPath));
+            LayerSetState(layerKey, stateId, new ResourcePath(rsiPath));
         }
 
-        public void LayerSetState(int layer, RSI.StateId stateId, ResPath rsiPath)
+        public void LayerSetState(int layer, RSI.StateId stateId, ResourcePath rsiPath)
         {
             if (!resourceCache.TryGetResource<RSIResource>(TextureRoot / rsiPath, out var res))
             {
@@ -1009,7 +1009,7 @@ namespace Robust.Client.GameObjects
             LayerSetState(layer, stateId, res?.RSI);
         }
 
-        public void LayerSetState(object layerKey, RSI.StateId stateId, ResPath rsiPath)
+        public void LayerSetState(object layerKey, RSI.StateId stateId, ResourcePath rsiPath)
         {
             if (!LayerMapTryGet(layerKey, out var layer, true))
                 return;
@@ -1035,15 +1035,15 @@ namespace Robust.Client.GameObjects
 
         public void LayerSetRSI(int layer, string rsiPath)
         {
-            LayerSetRSI(layer, new ResPath(rsiPath));
+            LayerSetRSI(layer, new ResourcePath(rsiPath));
         }
 
         public void LayerSetRSI(object layerKey, string rsiPath)
         {
-            LayerSetRSI(layerKey, new ResPath(rsiPath));
+            LayerSetRSI(layerKey, new ResourcePath(rsiPath));
         }
 
-        public void LayerSetRSI(int layer, ResPath rsiPath)
+        public void LayerSetRSI(int layer, ResourcePath rsiPath)
         {
             if (!resourceCache.TryGetResource<RSIResource>(TextureRoot / rsiPath, out var res))
             {
@@ -1053,7 +1053,7 @@ namespace Robust.Client.GameObjects
             LayerSetRSI(layer, res?.RSI);
         }
 
-        public void LayerSetRSI(object layerKey, ResPath rsiPath)
+        public void LayerSetRSI(object layerKey, ResourcePath rsiPath)
         {
             if (!LayerMapTryGet(layerKey, out var layer, true))
                 return;
@@ -1678,7 +1678,7 @@ namespace Robust.Client.GameObjects
                     Shader = ShaderPrototype,
                     State = State.Name,
                     Visible = Visible,
-                    RsiPath = RSI?.Path.CanonPath,
+                    RsiPath = RSI?.Path?.ToString(),
                     //todo TexturePath = Textur
                     //todo MapKeys
                 };
@@ -1797,7 +1797,7 @@ namespace Robust.Client.GameObjects
                     }
                     else
                     {
-                        Logger.ErrorS(LogCategory, "State '{0}' does not exist in set RSI ({1}). Trace:\n{2}", State, rsi?.Path.CanonPath ?? "null",
+                        Logger.ErrorS(LogCategory, "State '{0}' does not exist in set RSI ({1}). Trace:\n{2}", State, rsi?.Path?.ToString() ?? "null",
                             Environment.StackTrace);
                         Texture = null;
                     }

--- a/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
@@ -290,7 +290,7 @@ public sealed class AudioSystem : SharedAudioSystem
     #region Play AudioStream
     private bool TryGetAudio(string filename, [NotNullWhen(true)] out AudioResource? audio)
     {
-        if (_resourceCache.TryGetResource<AudioResource>(new ResPath(filename), out audio))
+        if (_resourceCache.TryGetResource<AudioResource>(new ResourcePath(filename), out audio))
             return true;
 
         _sawmill.Error($"Server tried to play audio file {filename} which does not exist.");
@@ -524,7 +524,7 @@ public sealed class AudioSystem : SharedAudioSystem
     /// <inheritdoc />
     public override IPlayingAudioStream? Play(string filename, Filter playerFilter, EntityUid entity, bool recordReplay, AudioParams? audioParams = null)
     {
-        if (_resourceCache.TryGetResource<AudioResource>(new ResPath(filename), out var audio))
+        if (_resourceCache.TryGetResource<AudioResource>(new ResourcePath(filename), out var audio))
         {
             return Play(audio, entity, null, audioParams);
         }
@@ -555,7 +555,7 @@ public sealed class AudioSystem : SharedAudioSystem
     /// <inheritdoc />
     public override IPlayingAudioStream? PlayEntity(string filename, ICommonSession recipient, EntityUid uid, AudioParams? audioParams = null)
     {
-        if (_resourceCache.TryGetResource<AudioResource>(new ResPath(filename), out var audio))
+        if (_resourceCache.TryGetResource<AudioResource>(new ResourcePath(filename), out var audio))
         {
             return Play(audio, uid, null, audioParams);
         }
@@ -565,7 +565,7 @@ public sealed class AudioSystem : SharedAudioSystem
     /// <inheritdoc />
     public override IPlayingAudioStream? PlayEntity(string filename, EntityUid recipient, EntityUid uid, AudioParams? audioParams = null)
     {
-        if (_resourceCache.TryGetResource<AudioResource>(new ResPath(filename), out var audio))
+        if (_resourceCache.TryGetResource<AudioResource>(new ResourcePath(filename), out var audio))
         {
             return Play(audio, uid, null, audioParams);
         }

--- a/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
@@ -33,7 +33,7 @@ namespace Robust.Client.Graphics.Clyde
         private Renderer _chosenRenderer;
 #pragma warning restore 414
 
-        private ResPath _windowIconPath;
+        private ResourcePath? _windowIconPath;
         private Thread? _windowingThread;
         private bool _vSync;
         private WindowMode _windowMode;
@@ -96,7 +96,7 @@ namespace Robust.Client.Graphics.Clyde
 
             var iconPath = _cfg.GetCVar(CVars.DisplayWindowIconSet);
             if (!string.IsNullOrWhiteSpace(iconPath))
-                _windowIconPath = new ResPath(iconPath);
+                _windowIconPath = new ResourcePath(iconPath);
 
             _windowingThread = Thread.CurrentThread;
 

--- a/Robust.Client/Graphics/RSI/RSI.cs
+++ b/Robust.Client/Graphics/RSI/RSI.cs
@@ -27,7 +27,7 @@ namespace Robust.Client.Graphics
         ///     The original path of this RSI or null.
         /// </summary>
         [ViewVariables]
-        public ResPath Path { get; }
+        public ResourcePath? Path { get; }
 
         public State this[StateId key] => States[key];
 
@@ -46,7 +46,7 @@ namespace Robust.Client.Graphics
             return States.TryGetValue(stateId, out state);
         }
 
-        public RSI(Vector2i size, ResPath path = default, int capacity = 0)
+        public RSI(Vector2i size, ResourcePath? path = null, int capacity = 0)
         {
             Size = size;
             Path = path;

--- a/Robust.Client/Graphics/Shaders/ParsedShader.cs
+++ b/Robust.Client/Graphics/Shaders/ParsedShader.cs
@@ -10,7 +10,7 @@ namespace Robust.Client.Graphics
         public ParsedShader(IReadOnlyDictionary<string, ShaderUniformDefinition> uniforms,
             IReadOnlyDictionary<string, ShaderVaryingDefinition> varyings,
             IReadOnlyDictionary<string, ShaderConstantDefinition> constants, IList<ShaderFunctionDefinition> functions,
-            ShaderLightMode lightMode, ShaderBlendMode blendMode, ShaderPreset preset, ICollection<ResPath> includes)
+            ShaderLightMode lightMode, ShaderBlendMode blendMode, ShaderPreset preset, ICollection<ResourcePath> includes)
         {
             Uniforms = uniforms;
             Varyings = varyings;
@@ -29,7 +29,7 @@ namespace Robust.Client.Graphics
         public ShaderLightMode LightMode { get; }
         public ShaderBlendMode BlendMode { get; }
         public ShaderPreset Preset { get; }
-        public ICollection<ResPath> Includes { get; }
+        public ICollection<ResourcePath> Includes { get; }
 
     }
 

--- a/Robust.Client/Graphics/Shaders/ShaderParser.Tokenizer.cs
+++ b/Robust.Client/Graphics/Shaders/ShaderParser.Tokenizer.cs
@@ -156,7 +156,7 @@ namespace Robust.Client.Graphics
             _currentParser.Take(); // Quote.
 
             var pathString = new string(pathParsing.ToArray());
-            var path = new ResPath(pathString);
+            var path = new ResourcePath(pathString);
             _includes.AddLast(path);
             using var stream = _resManager.ContentFileRead(path);
             using var reader = new StreamReader(stream, EncodingHelpers.UTF8);

--- a/Robust.Client/Graphics/Shaders/ShaderParser.cs
+++ b/Robust.Client/Graphics/Shaders/ShaderParser.cs
@@ -19,7 +19,7 @@ namespace Robust.Client.Graphics
         private readonly List<ShaderConstantDefinition> _constantsParsing = new();
         private readonly List<ShaderVaryingDefinition> _varyingsParsing = new();
         private readonly List<ShaderFunctionDefinition> _functionsParsing = new();
-        private readonly LinkedList<ResPath> _includes = new();
+        private readonly LinkedList<ResourcePath> _includes = new();
 
         public static ParsedShader Parse(TextReader reader, IResourceManager resManager)
         {

--- a/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
+++ b/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
@@ -102,7 +102,7 @@ namespace Robust.Client.Graphics
         }
 
         [DataField("kind", readOnly: true, required: true)] private string _rawKind = default!;
-        [DataField("path", readOnly: true)] private ResPath path;
+        [DataField("path", readOnly: true)] private ResourcePath? path;
         [DataField("params", readOnly: true)] private Dictionary<string, string>? paramMapping;
         [DataField("light_mode", readOnly: true)] private string? rawMode;
         [DataField("blend_mode", readOnly: true)] private string? rawBlendMode;

--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -113,7 +113,7 @@ namespace Robust.Client.Input
 
             Contexts.ContextChanged += OnContextChanged;
 
-            var path = new ResPath(KeybindsPath);
+            var path = new ResourcePath(KeybindsPath);
             if (_resourceMan.UserData.Exists(path))
             {
                 LoadKeyFile(path, true);
@@ -154,7 +154,7 @@ namespace Robust.Client.Input
             mapping.Add("binds", _serialization.WriteValue(modifiedBindings, notNullableOverride: true));
             mapping.Add("leaveEmpty", _serialization.WriteValue(leaveEmpty, notNullableOverride: true));
 
-            var path = new ResPath(KeybindsPath);
+            var path = new ResourcePath(KeybindsPath);
             using var writer = _resourceMan.UserData.OpenWriteText(path);
             var stream = new YamlStream {new(mapping.ToYaml())};
             stream.Save(new YamlMappingFix(new Emitter(writer)), false);
@@ -474,7 +474,7 @@ namespace Robust.Client.Input
             return true;
         }
 
-        private void LoadKeyFile(ResPath file, bool userData)
+        private void LoadKeyFile(ResourcePath file, bool userData)
         {
             TextReader reader;
             if (userData)

--- a/Robust.Client/Map/ClydeTileDefinitionManager.cs
+++ b/Robust.Client/Map/ClydeTileDefinitionManager.cs
@@ -101,7 +101,7 @@ namespace Robust.Client.Map
             {
                 Image<Rgba32> image;
                 // Already know it's not null above
-                var path = def.Sprite!.Value;
+                var path = def.Sprite!;
 
                 using (var stream = _resourceCache.ContentFileRead(path))
                 {

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -721,7 +721,7 @@ namespace Robust.Client.Placement
             }
             else
             {
-                sc.AddLayer(new ResPath("/Textures/UserInterface/tilebuildoverlay.png"));
+                sc.AddLayer(new ResourcePath("/Textures/UserInterface/tilebuildoverlay.png"));
             }
             sc.NoRotation = noRot;
 
@@ -735,7 +735,7 @@ namespace Robust.Client.Placement
         private void PreparePlacementTile()
         {
             var sc = SetupPlacementOverlayEntity();
-            sc.AddLayer(new ResPath("/Textures/UserInterface/tilebuildoverlay.png"));
+            sc.AddLayer(new ResourcePath("/Textures/UserInterface/tilebuildoverlay.png"));
 
             IsActive = true;
         }

--- a/Robust.Client/Placement/PlacementMode.cs
+++ b/Robust.Client/Placement/PlacementMode.cs
@@ -196,12 +196,12 @@ namespace Robust.Client.Placement
 
         public TextureResource GetSprite(string key)
         {
-            return pManager.ResourceCache.GetResource<TextureResource>(new ResPath("/Textures/") / key);
+            return pManager.ResourceCache.GetResource<TextureResource>(new ResourcePath("/Textures/") / key);
         }
 
         public bool TryGetSprite(string key, [NotNullWhen(true)] out TextureResource? sprite)
         {
-            return pManager.ResourceCache.TryGetResource(new ResPath(@"/Textures/") / key, out sprite);
+            return pManager.ResourceCache.TryGetResource(new ResourcePath(@"/Textures/") / key, out sprite);
         }
 
         /// <summary>

--- a/Robust.Client/Prototypes/ClientPrototypeManager.cs
+++ b/Robust.Client/Prototypes/ClientPrototypeManager.cs
@@ -29,7 +29,7 @@ namespace Robust.Client.Prototypes
         private readonly List<FileSystemWatcher> _watchers = new();
         private readonly TimeSpan _reloadDelay = TimeSpan.FromMilliseconds(10);
         private CancellationTokenSource _reloadToken = new();
-        private readonly HashSet<ResPath> _reloadQueue = new();
+        private readonly HashSet<ResourcePath> _reloadQueue = new();
 
         public override void Initialize()
         {
@@ -111,7 +111,7 @@ namespace Robust.Client.Prototypes
 
                     TaskManager.RunOnMainThread(() =>
                     {
-                        var file = new ResPath(args.FullPath);
+                        var file = new ResourcePath(args.FullPath);
 
                         foreach (var root in Resources.GetContentRoots())
                         {
@@ -120,7 +120,7 @@ namespace Robust.Client.Prototypes
                                 continue;
                             }
 
-                            _reloadQueue.Add(relative.Value);
+                            _reloadQueue.Add(relative);
                         }
                     });
                 };

--- a/Robust.Client/ResourceManagement/BaseResource.cs
+++ b/Robust.Client/ResourceManagement/BaseResource.cs
@@ -12,7 +12,7 @@ namespace Robust.Client.ResourceManagement
         /// <summary>
         ///     Fallback resource path if this one does not exist.
         /// </summary>
-        public virtual ResPath Fallback => default;
+        public virtual ResourcePath? Fallback => null;
 
         /// <summary>
         ///     Disposes this resource.
@@ -26,9 +26,9 @@ namespace Robust.Client.ResourceManagement
         /// </summary>
         /// <param name="cache">ResourceCache this resource is being loaded into.</param>
         /// <param name="path">Path of the resource requested on the VFS.</param>
-        public abstract void Load(IResourceCache cache, ResPath path);
+        public abstract void Load(IResourceCache cache, ResourcePath path);
 
-        public virtual void Reload(IResourceCache cache, ResPath path, CancellationToken ct = default)
+        public virtual void Reload(IResourceCache cache, ResourcePath path, CancellationToken ct = default)
         {
 
         }

--- a/Robust.Client/ResourceManagement/IResourceCache.cs
+++ b/Robust.Client/ResourceManagement/IResourceCache.cs
@@ -11,31 +11,31 @@ namespace Robust.Client.ResourceManagement
         T GetResource<T>(string path, bool useFallback = true)
             where T : BaseResource, new();
 
-        T GetResource<T>(ResPath path, bool useFallback = true)
+        T GetResource<T>(ResourcePath path, bool useFallback = true)
             where T : BaseResource, new();
 
         bool TryGetResource<T>(string path, [NotNullWhen(true)] out T? resource)
             where T : BaseResource, new();
 
-        bool TryGetResource<T>(ResPath path, [NotNullWhen(true)] out T? resource)
+        bool TryGetResource<T>(ResourcePath path, [NotNullWhen(true)] out T? resource)
             where T : BaseResource, new();
 
         void ReloadResource<T>(string path)
             where T : BaseResource, new();
 
-        void ReloadResource<T>(ResPath path)
+        void ReloadResource<T>(ResourcePath path)
             where T : BaseResource, new();
 
         void CacheResource<T>(string path, T resource)
             where T : BaseResource, new();
 
-        void CacheResource<T>(ResPath path, T resource)
+        void CacheResource<T>(ResourcePath path, T resource)
             where T : BaseResource, new();
 
         T GetFallback<T>()
             where T : BaseResource, new();
 
-        IEnumerable<KeyValuePair<ResPath, T>> GetAllResources<T>() where T : BaseResource, new();
+        IEnumerable<KeyValuePair<ResourcePath, T>> GetAllResources<T>() where T : BaseResource, new();
 
         // Resource load callbacks so content can hook stuff like click maps.
         event Action<TextureLoadedEventArgs> OnRawTextureLoaded;

--- a/Robust.Client/ResourceManagement/IResourceCacheInternal.cs
+++ b/Robust.Client/ResourceManagement/IResourceCacheInternal.cs
@@ -9,7 +9,7 @@ namespace Robust.Client.ResourceManagement
         void TextureLoaded(TextureLoadedEventArgs eventArgs);
         void RsiLoaded(RsiLoadedEventArgs eventArgs);
 
-        void MountLoaderApi(IFileApi api, string apiPrefix, ResPath? prefix=null);
+        void MountLoaderApi(IFileApi api, string apiPrefix, ResourcePath? prefix=null);
         void PreloadTextures();
     }
 }

--- a/Robust.Client/ResourceManagement/ResourceCache.LoaderApi.cs
+++ b/Robust.Client/ResourceManagement/ResourceCache.LoaderApi.cs
@@ -24,7 +24,7 @@ namespace Robust.Client.ResourceManagement
             {
             }
 
-            public bool TryGetFile(ResPath relPath, [NotNullWhen(true)] out Stream? stream)
+            public bool TryGetFile(ResourcePath relPath, [NotNullWhen(true)] out Stream? stream)
             {
                 if (_api.TryOpen($"{_prefix}{relPath}", out stream))
                 {
@@ -35,14 +35,14 @@ namespace Robust.Client.ResourceManagement
                 return false;
             }
 
-            public IEnumerable<ResPath> FindFiles(ResPath path)
+            public IEnumerable<ResourcePath> FindFiles(ResourcePath path)
             {
                 foreach (var relPath in _api.AllFiles)
                 {
                     if (!relPath.StartsWith(_prefix))
                         continue;
 
-                    var resP = new ResPath(relPath[_prefix.Length..]);
+                    var resP = new ResourcePath(relPath[_prefix.Length..]);
                     if (resP.TryRelativeTo(path, out _))
                     {
                         yield return resP;

--- a/Robust.Client/ResourceManagement/ResourceCache.cs
+++ b/Robust.Client/ResourceManagement/ResourceCache.cs
@@ -12,17 +12,17 @@ namespace Robust.Client.ResourceManagement
 {
     internal sealed partial class ResourceCache : ResourceManager, IResourceCacheInternal, IDisposable
     {
-        private readonly Dictionary<Type, Dictionary<ResPath, BaseResource>> CachedResources =
+        private readonly Dictionary<Type, Dictionary<ResourcePath, BaseResource>> CachedResources =
             new();
 
         private readonly Dictionary<Type, BaseResource> _fallbacks = new();
 
         public T GetResource<T>(string path, bool useFallback = true) where T : BaseResource, new()
         {
-            return GetResource<T>(new ResPath(path), useFallback);
+            return GetResource<T>(new ResourcePath(path), useFallback);
         }
 
-        public T GetResource<T>(ResPath path, bool useFallback = true) where T : BaseResource, new()
+        public T GetResource<T>(ResourcePath path, bool useFallback = true) where T : BaseResource, new()
         {
             var cache = GetTypeDict<T>();
             if (cache.TryGetValue(path, out var cached))
@@ -56,10 +56,10 @@ namespace Robust.Client.ResourceManagement
 
         public bool TryGetResource<T>(string path, [NotNullWhen(true)] out T? resource) where T : BaseResource, new()
         {
-            return TryGetResource(new ResPath(path), out resource);
+            return TryGetResource(new ResourcePath(path), out resource);
         }
 
-        public bool TryGetResource<T>(ResPath path, [NotNullWhen(true)] out T? resource) where T : BaseResource, new()
+        public bool TryGetResource<T>(ResourcePath path, [NotNullWhen(true)] out T? resource) where T : BaseResource, new()
         {
             var cache = GetTypeDict<T>();
             if (cache.TryGetValue(path, out var cached))
@@ -85,10 +85,10 @@ namespace Robust.Client.ResourceManagement
 
         public void ReloadResource<T>(string path) where T : BaseResource, new()
         {
-            ReloadResource<T>(new ResPath(path));
+            ReloadResource<T>(new ResourcePath(path));
         }
 
-        public void ReloadResource<T>(ResPath path) where T : BaseResource, new()
+        public void ReloadResource<T>(ResourcePath path) where T : BaseResource, new()
         {
             var cache = GetTypeDict<T>();
 
@@ -110,20 +110,20 @@ namespace Robust.Client.ResourceManagement
 
         public bool HasResource<T>(string path) where T : BaseResource, new()
         {
-            return HasResource<T>(new ResPath(path));
+            return HasResource<T>(new ResourcePath(path));
         }
 
-        public bool HasResource<T>(ResPath path) where T : BaseResource, new()
+        public bool HasResource<T>(ResourcePath path) where T : BaseResource, new()
         {
             return TryGetResource<T>(path, out var _);
         }
 
         public void CacheResource<T>(string path, T resource) where T : BaseResource, new()
         {
-            CacheResource(new ResPath(path), resource);
+            CacheResource(new ResourcePath(path), resource);
         }
 
-        public void CacheResource<T>(ResPath path, T resource) where T : BaseResource, new()
+        public void CacheResource<T>(ResourcePath path, T resource) where T : BaseResource, new()
         {
             GetTypeDict<T>()[path] = resource;
         }
@@ -146,9 +146,9 @@ namespace Robust.Client.ResourceManagement
             return (T) fallback;
         }
 
-        public IEnumerable<KeyValuePair<ResPath, T>> GetAllResources<T>() where T : BaseResource, new()
+        public IEnumerable<KeyValuePair<ResourcePath, T>> GetAllResources<T>() where T : BaseResource, new()
         {
-            return GetTypeDict<T>().Select(p => new KeyValuePair<ResPath, T>(p.Key, (T) p.Value));
+            return GetTypeDict<T>().Select(p => new KeyValuePair<ResourcePath, T>(p.Key, (T) p.Value));
         }
 
         public event Action<TextureLoadedEventArgs>? OnRawTextureLoaded;
@@ -190,11 +190,11 @@ namespace Robust.Client.ResourceManagement
         #endregion IDisposable Members
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private Dictionary<ResPath, BaseResource> GetTypeDict<T>()
+        private Dictionary<ResourcePath, BaseResource> GetTypeDict<T>()
         {
             if (!CachedResources.TryGetValue(typeof(T), out var ret))
             {
-                ret = new Dictionary<ResPath, BaseResource>();
+                ret = new Dictionary<ResourcePath, BaseResource>();
                 CachedResources.Add(typeof(T), ret);
             }
 
@@ -211,11 +211,11 @@ namespace Robust.Client.ResourceManagement
             OnRsiLoaded?.Invoke(eventArgs);
         }
 
-        public void MountLoaderApi(IFileApi api, string apiPrefix, ResPath? prefix=null)
+        public void MountLoaderApi(IFileApi api, string apiPrefix, ResourcePath? prefix=null)
         {
-            prefix ??= ResPath.Root;
+            prefix ??= ResourcePath.Root;
             var root = new LoaderApiLoader(api, apiPrefix);
-            AddRoot(prefix.Value, root);
+            AddRoot(prefix, root);
         }
     }
 }

--- a/Robust.Client/ResourceManagement/ResourceTypes/AudioResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/AudioResource.cs
@@ -11,7 +11,7 @@ namespace Robust.Client.ResourceManagement
     {
         public AudioStream AudioStream { get; private set; } = default!;
 
-        public override void Load(IResourceCache cache, ResPath path)
+        public override void Load(IResourceCache cache, ResourcePath path)
         {
             if (!cache.ContentFileExists(path))
             {

--- a/Robust.Client/ResourceManagement/ResourceTypes/FontResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/FontResource.cs
@@ -9,7 +9,7 @@ namespace Robust.Client.ResourceManagement
     {
         internal IFontFaceHandle FontFaceHandle { get; private set; } = default!;
 
-        public override void Load(IResourceCache cache, ResPath path)
+        public override void Load(IResourceCache cache, ResourcePath path)
         {
             if (!cache.TryContentFileRead(path, out var stream))
             {

--- a/Robust.Client/ResourceManagement/ResourceTypes/RSIResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/RSIResource.cs
@@ -18,7 +18,7 @@ namespace Robust.Client.ResourceManagement
     /// </summary>
     public sealed class RSIResource : BaseResource
     {
-        public override ResPath Fallback => new("/Textures/error.rsi");
+        public override ResourcePath? Fallback => new("/Textures/error.rsi");
 
         public RSI RSI { get; private set; } = default!;
 
@@ -32,7 +32,7 @@ namespace Robust.Client.ResourceManagement
         /// </summary>
         public const uint MAXIMUM_RSI_VERSION = RsiLoading.MAXIMUM_RSI_VERSION;
 
-        public override void Load(IResourceCache cache, ResPath path)
+        public override void Load(IResourceCache cache, ResourcePath path)
         {
             var clyde = IoCManager.Resolve<IClyde>();
 
@@ -373,7 +373,7 @@ namespace Robust.Client.ResourceManagement
         internal sealed class LoadStepData
         {
             public bool Bad;
-            public ResPath Path = default!;
+            public ResourcePath Path = default!;
             public Image<Rgba32> AtlasSheet = default!;
             public int DimX;
             public StateReg[] AtlasList = default!;

--- a/Robust.Client/ResourceManagement/ResourceTypes/ShaderSourceResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/ShaderSourceResource.cs
@@ -15,7 +15,7 @@ namespace Robust.Client.ResourceManagement
         internal ClydeHandle ClydeHandle { get; private set; }
         internal ParsedShader ParsedShader { get; private set; } = default!;
 
-        public override void Load(IResourceCache cache, ResPath path)
+        public override void Load(IResourceCache cache, ResourcePath path)
         {
             using (var stream = cache.ContentFileRead(path))
             using (var reader = new StreamReader(stream, EncodingHelpers.UTF8))
@@ -27,7 +27,7 @@ namespace Robust.Client.ResourceManagement
             ClydeHandle = clyde.LoadShader(ParsedShader, path.ToString());
         }
 
-        public override void Reload(IResourceCache cache, ResPath path, CancellationToken ct = default)
+        public override void Reload(IResourceCache cache, ResourcePath path, CancellationToken ct = default)
         {
             ct = ct != default ? ct : new CancellationTokenSource(30000).Token;
 

--- a/Robust.Client/ResourceManagement/ResourceTypes/TextureResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/TextureResource.cs
@@ -14,11 +14,11 @@ namespace Robust.Client.ResourceManagement
     public sealed class TextureResource : BaseResource
     {
         private OwnedTexture _texture = default!;
-        public override ResPath Fallback => new("/Textures/noSprite.png");
+        public override ResourcePath Fallback => new("/Textures/noSprite.png");
 
         public Texture Texture => _texture;
 
-        public override void Load(IResourceCache cache, ResPath path)
+        public override void Load(IResourceCache cache, ResourcePath path)
         {
             var clyde = IoCManager.Resolve<IClyde>();
 
@@ -64,7 +64,7 @@ namespace Robust.Client.ResourceManagement
             data.Image.Dispose();
         }
 
-        private static TextureLoadParameters? TryLoadTextureParameters(IResourceCache cache, ResPath path)
+        private static TextureLoadParameters? TryLoadTextureParameters(IResourceCache cache, ResourcePath path)
         {
             var metaPath = path.WithName(path.Filename + ".yml");
             if (cache.TryContentFileRead(metaPath, out var stream))
@@ -91,7 +91,7 @@ namespace Robust.Client.ResourceManagement
             return null;
         }
 
-        public override void Reload(IResourceCache cache, ResPath path, CancellationToken ct = default)
+        public override void Reload(IResourceCache cache, ResourcePath path, CancellationToken ct = default)
         {
             var clyde = IoCManager.Resolve<IClyde>();
 
@@ -116,7 +116,7 @@ namespace Robust.Client.ResourceManagement
 
         internal sealed class LoadStepData
         {
-            public ResPath Path = default!;
+            public ResourcePath Path = default!;
             public Image<Rgba32> Image = default!;
             public TextureLoadParameters LoadParameters;
             public OwnedTexture Texture = default!;

--- a/Robust.Client/ResourceManagement/RsiLoadedEventArgs.cs
+++ b/Robust.Client/ResourceManagement/RsiLoadedEventArgs.cs
@@ -8,7 +8,7 @@ namespace Robust.Client.ResourceManagement
 {
     public readonly struct RsiLoadedEventArgs
     {
-        internal RsiLoadedEventArgs(ResPath path, RSIResource resource, Image atlas, Dictionary<RSI.StateId, Vector2i[][]> atlasOffsets)
+        internal RsiLoadedEventArgs(ResourcePath path, RSIResource resource, Image atlas, Dictionary<RSI.StateId, Vector2i[][]> atlasOffsets)
         {
             Path = path;
             Resource = resource;
@@ -16,7 +16,7 @@ namespace Robust.Client.ResourceManagement
             AtlasOffsets = atlasOffsets;
         }
 
-        public ResPath Path { get; }
+        public ResourcePath Path { get; }
         public RSIResource Resource { get; }
         public Image Atlas { get; }
         public Dictionary<RSI.StateId, Vector2i[][]> AtlasOffsets { get; }

--- a/Robust.Client/ResourceManagement/TextureLoadedEventArgs.cs
+++ b/Robust.Client/ResourceManagement/TextureLoadedEventArgs.cs
@@ -5,14 +5,14 @@ namespace Robust.Client.ResourceManagement
 {
     public readonly struct TextureLoadedEventArgs
     {
-        internal TextureLoadedEventArgs(ResPath path, Image image, TextureResource resource)
+        internal TextureLoadedEventArgs(ResourcePath path, Image image, TextureResource resource)
         {
             Path = path;
             Image = image;
             Resource = resource;
         }
 
-        public ResPath Path { get; }
+        public ResourcePath Path { get; }
         public Image Image { get; }
         public TextureResource Resource { get; }
     }

--- a/Robust.Client/UserInterface/CustomControls/DebugConsole.xaml.cs
+++ b/Robust.Client/UserInterface/CustomControls/DebugConsole.xaml.cs
@@ -45,7 +45,7 @@ namespace Robust.Client.UserInterface.CustomControls
         [Dependency] private readonly IResourceManager _resourceManager = default!;
         [Dependency] private readonly IConfigurationManager _cfg = default!;
 
-        private static readonly ResPath HistoryPath = new("/debug_console_history.json");
+        private static readonly ResourcePath HistoryPath = new("/debug_console_history.json");
 
         private readonly ConcurrentQueue<FormattedMessage> _messageQueue = new();
 

--- a/Robust.Client/UserInterface/RichText/FontPrototype.cs
+++ b/Robust.Client/UserInterface/RichText/FontPrototype.cs
@@ -11,5 +11,5 @@ public sealed class FontPrototype : IPrototype
     public string ID { get; } = default!;
 
     [DataField("path", required: true)]
-    public ResPath Path { get; } = default!;
+    public ResourcePath Path { get; } = default!;
 }

--- a/Robust.Client/UserInterface/Themes/UiTheme.cs
+++ b/Robust.Client/UserInterface/Themes/UiTheme.cs
@@ -23,11 +23,11 @@ public sealed class UITheme : IPrototype
     public string ID { get; } = default!;
 
     [DataField("path")]
-    private ResPath _path;
+    private ResourcePath? _path;
 
     [DataField("colors", readOnly: true)]
     public Dictionary<string, Color>? Colors { get; }
-    public ResPath Path => _path == default ? new ResPath(DefaultPath+"/"+ID) : _path;
+    public ResourcePath Path => _path == null ? new ResourcePath(DefaultPath+"/"+ID) : _path;
 
     private void ValidateFilePath(IResourceCache resourceCache)
     {
@@ -41,7 +41,7 @@ public sealed class UITheme : IPrototype
     }
     public Texture ResolveTexture(IResourceCache cache, string texturePath)
     {
-        return cache.TryGetResource<TextureResource>( new ResPath($"{Path}/{texturePath}.png"), out var texture) ? texture :
+        return cache.TryGetResource<TextureResource>( new ResourcePath($"{Path}/{texturePath}.png"), out var texture) ? texture :
             cache.GetResource<TextureResource>($"{DefaultPath}/{DefaultName}/{texturePath}.png");
     }
 

--- a/Robust.Server/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Server/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -192,7 +192,7 @@ namespace Robust.Server.GameObjects
             return Layers.Count - 1;
         }
 
-        public int AddLayerWithTexture(ResPath texture)
+        public int AddLayerWithTexture(ResourcePath texture)
         {
             return AddLayerWithTexture(texture.ToString());
         }
@@ -216,7 +216,7 @@ namespace Robust.Server.GameObjects
             return Layers.Count - 1;
         }
 
-        public int AddLayerWithState(string stateId, ResPath rsiPath)
+        public int AddLayerWithState(string stateId, ResourcePath rsiPath)
         {
             return AddLayerWithState(stateId, rsiPath.ToString());
         }
@@ -296,7 +296,7 @@ namespace Robust.Server.GameObjects
             Dirty();
         }
 
-        public void LayerSetTexture(int layer, ResPath texturePath)
+        public void LayerSetTexture(int layer, ResourcePath texturePath)
         {
             LayerSetTexture(layer, texturePath.ToString());
         }
@@ -335,7 +335,7 @@ namespace Robust.Server.GameObjects
             Dirty();
         }
 
-        public void LayerSetState(int layer, string stateId, ResPath rsiPath)
+        public void LayerSetState(int layer, string stateId, ResourcePath rsiPath)
         {
             LayerSetState(layer, stateId, rsiPath.ToString());
         }
@@ -355,7 +355,7 @@ namespace Robust.Server.GameObjects
             Dirty();
         }
 
-        public void LayerSetRSI(int layer, ResPath rsiPath)
+        public void LayerSetRSI(int layer, ResourcePath rsiPath)
         {
             LayerSetRSI(layer, rsiPath.ToString());
         }

--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -129,7 +129,7 @@ public sealed class MapLoaderSystem : EntitySystem
     {
         options ??= DefaultLoadOptions;
 
-        var resPath = new ResPath(path).ToRootedPath();
+        var resPath = new ResourcePath(path).ToRootedPath();
 
         if (!TryGetReader(resPath, out var reader))
         {
@@ -199,7 +199,7 @@ public sealed class MapLoaderSystem : EntitySystem
 
         var document = new YamlDocument(GetSaveData(uid).ToYaml());
 
-        var resPath = new ResPath(ymlPath).ToRootedPath();
+        var resPath = new ResourcePath(ymlPath).ToRootedPath();
         _resourceManager.UserData.CreateDir(resPath.Directory);
 
         using var writer = _resourceManager.UserData.OpenWriteText(resPath);
@@ -226,7 +226,7 @@ public sealed class MapLoaderSystem : EntitySystem
 
     #region Loading
 
-    private bool TryGetReader(ResPath resPath, [NotNullWhen(true)] out TextReader? reader)
+    private bool TryGetReader(ResourcePath resPath, [NotNullWhen(true)] out TextReader? reader)
     {
         // try user
         if (!_resourceManager.UserData.Exists(resPath))

--- a/Robust.Server/Replays/ReplayRecordingManager.cs
+++ b/Robust.Server/Replays/ReplayRecordingManager.cs
@@ -42,7 +42,7 @@ internal sealed class ReplayRecordingManager : IInternalReplayRecordingManager
     private int _maxUncompressedSize;
     private int _tickBatchSize;
     private bool _enabled;
-    private ResPath _path;
+    private ResourcePath? _path;
     public bool Recording => _curStream != null;
     private int _index = 0;
     private MemoryStream? _curStream;
@@ -106,7 +106,7 @@ internal sealed class ReplayRecordingManager : IInternalReplayRecordingManager
             return false;
 
         var path = directory ?? _netConf.GetCVar(CVars.ReplayDirectory);
-        _path = new ResPath(path).ToRootedPath();
+        _path = new ResourcePath(path).ToRootedPath();
         if (_resourceManager.UserData.Exists(_path))
         {
             if (overwrite)

--- a/Robust.Server/Serialization/ServerSpriteSpecifierSerializer.cs
+++ b/Robust.Server/Serialization/ServerSpriteSpecifierSerializer.cs
@@ -33,7 +33,7 @@ public sealed class ServerSpriteSpecifierSerializer : SpriteSpecifierSerializer
             return new ErrorNode(node, "Sprite specifier has missing/invalid state node");
         }
 
-        var path = serializationManager.ValidateNode<ResPath>(
+        var path = serializationManager.ValidateNode<ResourcePath>(
             new ValueDataNode($"{SharedSpriteComponent.TextureRoot / valuePathNode.Value}"), context);
 
         if (path is ErrorNode) return path;
@@ -43,7 +43,7 @@ public sealed class ServerSpriteSpecifierSerializer : SpriteSpecifierSerializer
         // the state exists. So lets just check if the state .png exists, without properly validating the RSI's
         // meta.json
 
-        var statePath = serializationManager.ValidateNode<ResPath>(
+        var statePath = serializationManager.ValidateNode<ResourcePath>(
             new ValueDataNode($"{SharedSpriteComponent.TextureRoot / valuePathNode.Value / valueStateNode.Value}.png"),
             context);
 

--- a/Robust.Server/ServerOptions.cs
+++ b/Robust.Server/ServerOptions.cs
@@ -29,12 +29,12 @@ namespace Robust.Server
         /// <summary>
         ///     Directory to load all assemblies from.
         /// </summary>
-        public ResPath AssemblyDirectory { get; init; } = new(@"/Assemblies");
+        public ResourcePath AssemblyDirectory { get; init; } = new(@"/Assemblies/");
 
         /// <summary>
         ///     Directory to load all prototypes from.
         /// </summary>
-        public ResPath PrototypeDirectory { get; init; } = new(@"/Prototypes");
+        public ResourcePath PrototypeDirectory { get; init; } = new(@"/Prototypes/");
 
         /// <summary>
         ///     Whether to disable mounting the "Resources/" folder on FULL_RELEASE.

--- a/Robust.Shared/Audio/SoundCollectionPrototype.cs
+++ b/Robust.Shared/Audio/SoundCollectionPrototype.cs
@@ -14,5 +14,5 @@ public sealed class SoundCollectionPrototype : IPrototype
     public string ID { get; } = default!;
 
     [DataField("files")]
-    public List<ResPath> PickFiles { get; } = new();
+    public List<ResourcePath> PickFiles { get; } = new();
 }

--- a/Robust.Shared/Audio/SoundSpecifier.cs
+++ b/Robust.Shared/Audio/SoundSpecifier.cs
@@ -27,19 +27,19 @@ public sealed class SoundPathSpecifier : SoundSpecifier
 {
     public const string Node = "path";
 
-    [DataField(Node, customTypeSerializer: typeof(ResPathSerializer), required: true)]
-    public ResPath Path { get; }
+    [DataField(Node, customTypeSerializer: typeof(ResourcePathSerializer), required: true)]
+    public ResourcePath? Path { get; }
 
     [UsedImplicitly]
     public SoundPathSpecifier()
     {
     }
 
-    public SoundPathSpecifier(string path, AudioParams? @params = null) : this(new ResPath(path), @params)
+    public SoundPathSpecifier(string path, AudioParams? @params = null) : this(new ResourcePath(path), @params)
     {
     }
 
-    public SoundPathSpecifier(ResPath path, AudioParams? @params = null)
+    public SoundPathSpecifier(ResourcePath path, AudioParams? @params = null)
     {
         Path = path;
         if (@params.HasValue)

--- a/Robust.Shared/Audio/SoundSpecifierTypeSerializer.cs
+++ b/Robust.Shared/Audio/SoundSpecifierTypeSerializer.cs
@@ -60,7 +60,7 @@ public sealed class SoundSpecifierTypeSerializer :
     public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
         IDependencyCollection dependencies, ISerializationContext? context = null)
     {
-        if (serializationManager.ValidateNode<ResPath>(node, context) is not ErrorNode)
+        if (serializationManager.ValidateNode<ResourcePath>(node, context) is not ErrorNode)
             return new ValidatedValueNode(node);
 
         return new ErrorNode(node, "SoundSpecifier value is not a valid resource path!");

--- a/Robust.Shared/Console/Commands/ExecCommand.cs
+++ b/Robust.Shared/Console/Commands/ExecCommand.cs
@@ -24,7 +24,7 @@ namespace Robust.Shared.Console.Commands
                 return;
             }
 
-            var path = new ResPath(args[0]).ToRootedPath();
+            var path = new ResourcePath(args[0]).ToRootedPath();
             if (!_resources.UserData.Exists(path))
             {
                 shell.WriteError("File does not exist.");

--- a/Robust.Shared/Console/CompletionHelper.cs
+++ b/Robust.Shared/Console/CompletionHelper.cs
@@ -31,12 +31,10 @@ public static class CompletionHelper
         if (!curPath.StartsWith("/"))
             curPath = "/";
 
-        var resPath = new ResPath(curPath);
+        var resPath = new ResourcePath(curPath);
 
-        if (!curPath.EndsWith("/")){
-            resPath /= "..";
-            resPath = resPath.Clean();
-        }
+        if (!curPath.EndsWith("/"))
+            resPath = (resPath / "..").Clean();
 
         var options = res.ContentGetDirectoryEntries(resPath)
             .OrderBy(c => c)
@@ -59,16 +57,13 @@ public static class CompletionHelper
         if (curPath == "")
             curPath = "/";
 
-        var resPath = new ResPath(curPath);
+        var resPath = new ResourcePath(curPath);
 
         if (!resPath.IsRooted)
             return Enumerable.Empty<CompletionOption>();
 
         if (!curPath.EndsWith("/"))
-        {
-            resPath /= "..";
-            resPath = resPath.Clean();
-        }
+            resPath = (resPath / "..").Clean();
 
         var entries = provider.DirectoryEntries(resPath);
 

--- a/Robust.Shared/ContentPack/AssemblyTypeChecker.cs
+++ b/Robust.Shared/ContentPack/AssemblyTypeChecker.cs
@@ -89,7 +89,7 @@ namespace Robust.Shared.ContentPack
             return new Resolver(
                 this,
                 loadDirs.ToArray(),
-                new[] {new ResPath("/Assemblies/")}
+                new[] {new ResourcePath("/Assemblies/")}
             );
         }
 
@@ -861,9 +861,9 @@ namespace Robust.Shared.ContentPack
             private readonly ConcurrentDictionary<string, PEReader?> _dictionary = new();
             private readonly AssemblyTypeChecker _parent;
             private readonly string[] _diskLoadPaths;
-            private readonly ResPath[] _resLoadPaths;
+            private readonly ResourcePath[] _resLoadPaths;
 
-            public Resolver(AssemblyTypeChecker parent, string[] diskLoadPaths, ResPath[] resLoadPaths)
+            public Resolver(AssemblyTypeChecker parent, string[] diskLoadPaths, ResourcePath[] resLoadPaths)
             {
                 _parent = parent;
                 _diskLoadPaths = diskLoadPaths;

--- a/Robust.Shared/ContentPack/DirLoader.cs
+++ b/Robust.Shared/ContentPack/DirLoader.cs
@@ -43,7 +43,7 @@ namespace Robust.Shared.ContentPack
             }
 
             /// <inheritdoc />
-            public bool TryGetFile(ResPath relPath, [NotNullWhen(true)] out Stream? stream)
+            public bool TryGetFile(ResourcePath relPath, [NotNullWhen(true)] out Stream? stream)
             {
                 var path = GetPath(relPath);
                 if (!File.Exists(path))
@@ -58,13 +58,13 @@ namespace Robust.Shared.ContentPack
                 return true;
             }
 
-            internal string GetPath(ResPath relPath)
+            internal string GetPath(ResourcePath relPath)
             {
                 return Path.GetFullPath(Path.Combine(_directory.FullName, relPath.ToRelativeSystemPath()));
             }
 
             /// <inheritdoc />
-            public IEnumerable<ResPath> FindFiles(ResPath path)
+            public IEnumerable<ResourcePath> FindFiles(ResourcePath path)
             {
                 var fullPath = GetPath(path);
                 if (!Directory.Exists(fullPath))
@@ -78,11 +78,11 @@ namespace Robust.Shared.ContentPack
                 foreach (var filePath in paths)
                 {
                     var relPath = filePath.Substring(_directory.FullName.Length);
-                    yield return ResPath.FromRelativeSystemPath(relPath);
+                    yield return ResourcePath.FromRelativeSystemPath(relPath);
                 }
             }
 
-            public IEnumerable<string> GetEntries(ResPath path)
+            public IEnumerable<string> GetEntries(ResourcePath path)
             {
                 var fullPath = GetPath(path);
                 if (!Directory.Exists(fullPath))
@@ -100,7 +100,7 @@ namespace Robust.Shared.ContentPack
             }
 
             [Conditional("DEBUG")]
-            private void CheckPathCasing(ResPath path)
+            private void CheckPathCasing(ResourcePath path)
             {
                 if (!_checkCasing)
                     return;
@@ -108,10 +108,10 @@ namespace Robust.Shared.ContentPack
                 // Run this inside the thread pool due to overhead.
                 Task.Run(() =>
                 {
-                    var prevPath = GetPath(ResPath.Root);
-                    var diskPath = ResPath.Root;
+                    var prevPath = GetPath(ResourcePath.Root);
+                    var diskPath = ResourcePath.Root;
                     var mismatch = false;
-                    foreach (var segment in path.CanonPath.Split('/'))
+                    foreach (var segment in path.EnumerateSegments())
                     {
                         var prevDir = new DirectoryInfo(prevPath);
                         var found = false;
@@ -166,7 +166,7 @@ namespace Robust.Shared.ContentPack
 
                     var filePath = file.FullName;
                     var relPath = filePath.Substring(_directory.FullName.Length);
-                    yield return ResPath.FromRelativeSystemPath(relPath).ToRootedPath().ToString();
+                    yield return ResourcePath.FromRelativeSystemPath(relPath).ToRootedPath().ToString();
                 }
 
                 foreach (var subDir in dir.EnumerateDirectories())

--- a/Robust.Shared/ContentPack/IContentRoot.cs
+++ b/Robust.Shared/ContentPack/IContentRoot.cs
@@ -23,14 +23,14 @@ namespace Robust.Shared.ContentPack
         /// <param name="relPath">Relative path from the root directory.</param>
         /// <param name="stream"></param>
         /// <returns>A stream of the file loaded into memory.</returns>
-        bool TryGetFile(ResPath relPath, [NotNullWhen(true)] out Stream? stream);
+        bool TryGetFile(ResourcePath relPath, [NotNullWhen(true)] out Stream? stream);
 
         /// <summary>
         ///     Recursively finds all files in a directory and all sub directories.
         /// </summary>
         /// <param name="path">Directory to search inside of.</param>
         /// <returns>Enumeration of all relative file paths of the files found.</returns>
-        IEnumerable<ResPath> FindFiles(ResPath path);
+        IEnumerable<ResourcePath> FindFiles(ResourcePath path);
 
         /// <summary>
         ///     Recursively returns relative paths to resource files.
@@ -38,15 +38,14 @@ namespace Robust.Shared.ContentPack
         /// <returns>Enumeration of all relative file paths.</returns>
         IEnumerable<string> GetRelativeFilePaths();
 
-        IEnumerable<string> GetEntries(ResPath path)
+        IEnumerable<string> GetEntries(ResourcePath path)
         {
-            var countDirs = path == ResPath.Self ? 0 : path.CanonPath.Split('/').Count();
+            var countDirs = path == ResourcePath.Self ? 0 : path.EnumerateSegments().Count();
 
             var options = FindFiles(path).Select(c =>
             {
-                var segment = path.CanonPath.Split('/');
-                var segCount = segment.Count();
-                var newPath = segment.Skip(countDirs).First();
+                var segCount = c.EnumerateSegments().Count();
+                var newPath = c.EnumerateSegments().Skip(countDirs).First();
                 if (segCount > countDirs + 1)
                     newPath += "/";
 

--- a/Robust.Shared/ContentPack/IModLoader.cs
+++ b/Robust.Shared/ContentPack/IModLoader.cs
@@ -37,7 +37,7 @@ namespace Robust.Shared.ContentPack
         /// <param name="mountPath">The directory in which to look for assemblies.</param>
         /// <param name="filterPrefix">The prefix files need to have to be considered. e.g. <c>Content.</c></param>
         /// <returns>True if all modules loaded successfully. False if there were load errors.</returns>
-        bool TryLoadModulesFrom(ResPath mountPath, string filterPrefix);
+        bool TryLoadModulesFrom(ResourcePath mountPath, string filterPrefix);
 
         /// <summary>
         ///     Loads an assembly into the current AppDomain.

--- a/Robust.Shared/ContentPack/IResourceManager.cs
+++ b/Robust.Shared/ContentPack/IResourceManager.cs
@@ -23,7 +23,7 @@ namespace Robust.Shared.ContentPack
         /// </summary>
         /// <param name="prefix"></param>
         /// <param name="loader"></param>
-        void AddRoot(ResPath prefix, IContentRoot loader);
+        void AddRoot(ResourcePath prefix, IContentRoot loader);
 
         /// <summary>
         ///     Read a file from the mounted content roots.
@@ -34,7 +34,7 @@ namespace Robust.Shared.ContentPack
         /// <exception cref="ArgumentException">Thrown if <paramref name="path"/> is not rooted.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="path"/> is null.</exception>
         /// <seealso cref="ResourceManagerExt.ContentFileReadOrNull"/>
-        Stream ContentFileRead(ResPath path);
+        Stream ContentFileRead(ResourcePath path);
 
         /// <summary>
         ///     Read a file from the mounted content roots.
@@ -53,7 +53,7 @@ namespace Robust.Shared.ContentPack
         /// <returns>True if the file exists, false otherwise.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="path"/> is not rooted.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="path"/> is null.</exception>
-        bool ContentFileExists(ResPath path);
+        bool ContentFileExists(ResourcePath path);
 
         /// <summary>
         ///     Check if a file exists in any of the mounted content roots.
@@ -73,7 +73,7 @@ namespace Robust.Shared.ContentPack
         /// <exception cref="ArgumentException">Thrown if <paramref name="path"/> is not rooted.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="path"/> is null.</exception>
         /// <seealso cref="ResourceManagerExt.ContentFileReadOrNull"/>
-        bool TryContentFileRead(ResPath? path, [NotNullWhen(true)] out Stream? fileStream);
+        bool TryContentFileRead(ResourcePath path, [NotNullWhen(true)] out Stream? fileStream);
 
         /// <summary>
         ///     Try to read a file from the mounted content roots.
@@ -95,9 +95,9 @@ namespace Robust.Shared.ContentPack
         /// <returns>Enumeration of all absolute file paths of the files found.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="path"/> is not rooted.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="path"/> is null.</exception>
-        IEnumerable<ResPath> ContentFindFiles(ResPath? path);
+        IEnumerable<ResourcePath> ContentFindFiles(ResourcePath path);
 
-        IEnumerable<ResPath> ContentFindRelativeFiles(ResPath path)
+        IEnumerable<ResourcePath> ContentFindRelativeFiles(ResourcePath path)
         {
             foreach (var absPath in ContentFindFiles(path))
             {
@@ -107,7 +107,7 @@ namespace Robust.Shared.ContentPack
                     throw new InvalidOperationException("This is unreachable");
                 }
 
-                yield return rel.Value;
+                yield return rel;
             }
         }
 
@@ -121,7 +121,7 @@ namespace Robust.Shared.ContentPack
         /// <returns>Enumeration of all absolute file paths of the files found.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="path"/> is not rooted.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="path"/> is null.</exception>
-        IEnumerable<ResPath> ContentFindFiles(string path);
+        IEnumerable<ResourcePath> ContentFindFiles(string path);
 
         /// <summary>
         /// Gets entries in a content directory.
@@ -133,13 +133,13 @@ namespace Robust.Shared.ContentPack
         /// </remarks>
         /// <param name="path"></param>
         /// <returns>A sequence of entry names. If the entry name ends in a slash, it's a directory.</returns>
-        IEnumerable<string> ContentGetDirectoryEntries(ResPath path);
+        IEnumerable<string> ContentGetDirectoryEntries(ResourcePath path);
 
         /// <summary>
         ///     Returns a list of paths to all top-level content directories
         /// </summary>
         /// <returns></returns>
-        IEnumerable<ResPath> GetContentRoots();
+        IEnumerable<ResourcePath> GetContentRoots();
 
         /// <summary>
         ///     Read a file from the mounted content paths to a string.
@@ -147,14 +147,14 @@ namespace Robust.Shared.ContentPack
         /// <param name="path">Path of the file to read.</param>
         string ContentFileReadAllText(string path)
         {
-            return ContentFileReadAllText(new ResPath(path));
+            return ContentFileReadAllText(new ResourcePath(path));
         }
 
         /// <summary>
         ///     Read a file from the mounted content paths to a string.
         /// </summary>
         /// <param name="path">Path of the file to read.</param>
-        string ContentFileReadAllText(ResPath path)
+        string ContentFileReadAllText(ResourcePath path)
         {
             return ContentFileReadAllText(path, EncodingHelpers.UTF8);
         }
@@ -164,7 +164,7 @@ namespace Robust.Shared.ContentPack
         /// </summary>
         /// <param name="path">Path of the file to read.</param>
         /// <param name="encoding">Text encoding to use when reading.</param>
-        string ContentFileReadAllText(ResPath path, Encoding encoding)
+        string ContentFileReadAllText(ResourcePath path, Encoding encoding)
         {
             using var stream = ContentFileRead(path);
             using var reader = new StreamReader(stream, encoding);
@@ -172,7 +172,7 @@ namespace Robust.Shared.ContentPack
             return reader.ReadToEnd();
         }
 
-        public YamlStream ContentFileReadYaml(ResPath path)
+        public YamlStream ContentFileReadYaml(ResourcePath path)
         {
             using var reader = ContentFileReadText(path);
 
@@ -182,12 +182,12 @@ namespace Robust.Shared.ContentPack
             return yamlStream;
         }
 
-        public StreamReader ContentFileReadText(ResPath path)
+        public StreamReader ContentFileReadText(ResourcePath path)
         {
             return ContentFileReadText(path, EncodingHelpers.UTF8);
         }
 
-        public StreamReader ContentFileReadText(ResPath path, Encoding encoding)
+        public StreamReader ContentFileReadText(ResourcePath path, Encoding encoding)
         {
             var stream = ContentFileRead(path);
             return new StreamReader(stream, encoding);

--- a/Robust.Shared/ContentPack/IResourceManagerInternal.cs
+++ b/Robust.Shared/ContentPack/IResourceManagerInternal.cs
@@ -21,7 +21,7 @@ namespace Robust.Shared.ContentPack
         /// </summary>
         /// <param name="stream">The stream to mount.</param>
         /// <param name="path">The path that the file will be mounted at.</param>
-        void MountStreamAt(MemoryStream stream, ResPath path);
+        void MountStreamAt(MemoryStream stream, ResourcePath path);
 
         /// <summary>
         ///     Loads the default content pack from the configuration file into the VFS.
@@ -37,9 +37,9 @@ namespace Robust.Shared.ContentPack
         /// <exception cref="FileNotFoundException">Thrown if <paramref name="pack"/> does not exist on disk.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="prefix"/> is not rooted.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="pack"/> is null.</exception>
-        void MountContentPack(string pack, ResPath? prefix = null);
+        void MountContentPack(string pack, ResourcePath? prefix = null);
 
-        void MountContentPack(Stream zipStream, ResPath? prefix = null);
+        void MountContentPack(Stream zipStream, ResourcePath? prefix = null);
 
         /// <summary>
         ///     Adds a directory to search inside of to the VFS. The directory is relative to
@@ -50,7 +50,7 @@ namespace Robust.Shared.ContentPack
         /// <exception cref="DirectoryNotFoundException">Thrown if <paramref name="path"/> does not exist on disk.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="prefix"/> passed is not rooted.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="path"/> is null.</exception>
-        void MountContentDirectory(string path, ResPath? prefix = null);
+        void MountContentDirectory(string path, ResourcePath? prefix = null);
 
         /// <summary>
         ///     Attempts to get an on-disk path absolute file path for the specified resource path.
@@ -64,6 +64,6 @@ namespace Robust.Shared.ContentPack
         ///     This can be used for optimizations such as assembly loading, where an on-disk path is better.
         /// </para>
         /// </remarks>
-        bool TryGetDiskFilePath(ResPath path, [NotNullWhen(true)] out string? diskPath);
+        bool TryGetDiskFilePath(ResourcePath path, [NotNullWhen(true)] out string? diskPath);
     }
 }

--- a/Robust.Shared/ContentPack/IWritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/IWritableDirProvider.cs
@@ -21,21 +21,21 @@ namespace Robust.Shared.ContentPack
         /// Creates a directory. If the directory exists, does nothing.
         /// </summary>
         /// <param name="path">Path of directory to create.</param>
-        void CreateDir(ResPath path);
+        void CreateDir(ResourcePath path);
 
         /// <summary>
         /// Deletes a file or directory. If the file or directory
         /// does not exist, does nothing.
         /// </summary>
         /// <param name="path">Path of object to delete.</param>
-        void Delete(ResPath path);
+        void Delete(ResourcePath path);
 
         /// <summary>
         /// Tests if a file or directory exists.
         /// </summary>
         /// <param name="path">Path to test.</param>
         /// <returns>If the object exists.</returns>
-        bool Exists(ResPath path);
+        bool Exists(ResourcePath path);
 
         /// <summary>
         /// Finds all files and directories that match the expression. This will include empty directories.
@@ -43,17 +43,17 @@ namespace Robust.Shared.ContentPack
         /// <param name="pattern"></param>
         /// <param name="recursive"></param>
         /// <returns>A tuple that contains collections of files, directories that matched the expression.</returns>
-        (IEnumerable<ResPath> files, IEnumerable<ResPath> directories) Find(string pattern,
+        (IEnumerable<ResourcePath> files, IEnumerable<ResourcePath> directories) Find(string pattern,
             bool recursive = true);
 
-        IEnumerable<string> DirectoryEntries(ResPath path);
+        IEnumerable<string> DirectoryEntries(ResourcePath path);
 
         /// <summary>
         /// Tests if a path is a directory.
         /// </summary>
         /// <param name="path">Path to test.</param>
         /// <returns>True if it is a directory, false if it is a file.</returns>
-        bool IsDir(ResPath path);
+        bool IsDir(ResourcePath path);
 
         /// <summary>
         /// Attempts to open a file.
@@ -66,7 +66,7 @@ namespace Robust.Shared.ContentPack
         /// <exception cref="FileNotFoundException">
         ///     Thrown if the file does not exist.
         /// </exception>
-        Stream Open(ResPath path, FileMode fileMode, FileAccess access, FileShare share);
+        Stream Open(ResourcePath path, FileMode fileMode, FileAccess access, FileShare share);
 
         /// <summary>
         /// Attempts to open a file.
@@ -77,7 +77,7 @@ namespace Robust.Shared.ContentPack
         /// <exception cref="FileNotFoundException">
         ///     Thrown if the file does not exist.
         /// </exception>
-        Stream Open(ResPath path, FileMode fileMode)
+        Stream Open(ResourcePath path, FileMode fileMode)
         {
             return Open(path,
                 fileMode,
@@ -89,7 +89,7 @@ namespace Robust.Shared.ContentPack
         /// Returns a new <see cref="IWritableDirProvider"/> that points to a subdirectory.
         /// </summary>
         /// <param name="path">Path of directory to open.</param>
-        IWritableDirProvider OpenSubdirectory(ResPath path);
+        IWritableDirProvider OpenSubdirectory(ResourcePath path);
 
         /// <summary>
         /// Attempts to rename a file.
@@ -97,6 +97,6 @@ namespace Robust.Shared.ContentPack
         /// <param name="oldPath">Path of the file to rename.</param>
         /// <param name="newPath">New name of the file.</param>
         /// <returns></returns>
-        void Rename(ResPath oldPath, ResPath newPath);
+        void Rename(ResourcePath oldPath, ResourcePath newPath);
     }
 }

--- a/Robust.Shared/ContentPack/MemoryContentRoot.cs
+++ b/Robust.Shared/ContentPack/MemoryContentRoot.cs
@@ -12,7 +12,7 @@ namespace Robust.Shared.ContentPack;
 /// </summary>
 public sealed class MemoryContentRoot : IContentRoot, IDisposable
 {
-    private readonly Dictionary<ResPath, byte[]> _files = new();
+    private readonly Dictionary<ResourcePath, byte[]> _files = new();
 
     private readonly ReaderWriterLockSlim _lock = new();
 
@@ -21,7 +21,7 @@ public sealed class MemoryContentRoot : IContentRoot, IDisposable
     /// </summary>
     /// <param name="relPath">The relative path of the file.</param>
     /// <param name="data">The data byte array to store in the content root. Stored as is, without being copied or cloned.</param>
-    public void AddOrUpdateFile(ResPath relPath, byte[] data)
+    public void AddOrUpdateFile(ResourcePath relPath, byte[] data)
     {
         // Just in case, we ensure it's a clean relative path.
         relPath = relPath.Clean().ToRelativePath();
@@ -42,7 +42,7 @@ public sealed class MemoryContentRoot : IContentRoot, IDisposable
     /// </summary>
     /// <param name="relPath">The relative path to the file.</param>
     /// <returns></returns>
-    public bool RemoveFile(ResPath relPath)
+    public bool RemoveFile(ResourcePath relPath)
     {
         _lock.EnterWriteLock();
         try
@@ -56,7 +56,7 @@ public sealed class MemoryContentRoot : IContentRoot, IDisposable
     }
 
     /// <inheritdoc />
-    public bool TryGetFile(ResPath relPath, [NotNullWhen(true)] out Stream? stream)
+    public bool TryGetFile(ResourcePath relPath, [NotNullWhen(true)] out Stream? stream)
     {
         _lock.EnterReadLock();
         try
@@ -78,7 +78,7 @@ public sealed class MemoryContentRoot : IContentRoot, IDisposable
     }
 
     /// <inheritdoc />
-    public IEnumerable<ResPath> FindFiles(ResPath path)
+    public IEnumerable<ResourcePath> FindFiles(ResourcePath path)
     {
         _lock.EnterReadLock();
         try
@@ -116,7 +116,7 @@ public sealed class MemoryContentRoot : IContentRoot, IDisposable
     ///     Enumerates all files and their resource paths on this content root.
     /// </summary>
     /// <remarks>Do not modify or keep around the returned byte array, it's meant to be read-only.</remarks>
-    public IEnumerable<(ResPath relPath, byte[] data)> GetAllFiles()
+    public IEnumerable<(ResourcePath relPath, byte[] data)> GetAllFiles()
     {
         _lock.EnterReadLock();
         try

--- a/Robust.Shared/ContentPack/ModLoader.cs
+++ b/Robust.Shared/ContentPack/ModLoader.cs
@@ -74,11 +74,11 @@ namespace Robust.Shared.ContentPack
             _engineModuleDirectories.Add(dir);
         }
 
-        public bool TryLoadModulesFrom(ResPath mountPath, string filterPrefix)
+        public bool TryLoadModulesFrom(ResourcePath mountPath, string filterPrefix)
         {
             var sw = Stopwatch.StartNew();
             Logger.DebugS("res.mod", "LOADING modules");
-            var files = new Dictionary<string, (ResPath Path, string[] references)>();
+            var files = new Dictionary<string, (ResourcePath Path, string[] references)>();
 
             // Find all modules we want to load.
             foreach (var filePath in _res.ContentFindRelativeFiles(mountPath)
@@ -246,7 +246,7 @@ namespace Robust.Shared.ContentPack
 
         public bool TryLoadAssembly(string assemblyName)
         {
-            var dllPath = new ResPath($@"/Assemblies/{assemblyName}.dll");
+            var dllPath = new ResourcePath($@"/Assemblies/{assemblyName}.dll");
             // To prevent breaking debugging on Rider, try to load from disk if possible.
             if (_res.TryGetDiskFilePath(dllPath, out var path))
             {
@@ -270,7 +270,7 @@ namespace Robust.Shared.ContentPack
                     Logger.DebugS("srv", $"Loading {assemblyName} DLL");
 
                     // see if debug info is present
-                    if (_res.TryContentFileRead(new ResPath($@"/Assemblies/{assemblyName}.pdb"),
+                    if (_res.TryContentFileRead(new ResourcePath($@"/Assemblies/{assemblyName}.pdb"),
                         out var gamePdb))
                     {
                         using (gamePdb)

--- a/Robust.Shared/ContentPack/PackLoader.cs
+++ b/Robust.Shared/ContentPack/PackLoader.cs
@@ -51,7 +51,7 @@ namespace Robust.Shared.ContentPack
             }
 
             /// <inheritdoc />
-            public bool TryGetFile(ResPath relPath, [NotNullWhen(true)] out Stream? stream)
+            public bool TryGetFile(ResourcePath relPath, [NotNullWhen(true)] out Stream? stream)
             {
                 var entry = _zip.GetEntry(relPath.ToString());
 
@@ -76,7 +76,7 @@ namespace Robust.Shared.ContentPack
             }
 
             /// <inheritdoc />
-            public IEnumerable<ResPath> FindFiles(ResPath path)
+            public IEnumerable<ResourcePath> FindFiles(ResourcePath path)
             {
                 var rootPath = path + "/";
                 foreach (var entry in _zip.Entries)
@@ -89,7 +89,7 @@ namespace Robust.Shared.ContentPack
 
                     if (entry.FullName.StartsWith(rootPath))
                     {
-                        yield return new ResPath(entry.FullName).ToRelativePath();
+                        yield return new ResourcePath(entry.FullName).ToRelativePath();
                     }
                 }
             }
@@ -104,7 +104,7 @@ namespace Robust.Shared.ContentPack
                         continue;
                     }
 
-                    yield return new ResPath(entry.FullName).ToRootedPath().ToString();
+                    yield return new ResourcePath(entry.FullName).ToRootedPath().ToString();
                 }
             }
         }

--- a/Robust.Shared/ContentPack/ResourceManager.SingleStreamLoader.cs
+++ b/Robust.Shared/ContentPack/ResourceManager.SingleStreamLoader.cs
@@ -10,9 +10,9 @@ namespace Robust.Shared.ContentPack
         private sealed class SingleStreamLoader : IContentRoot
         {
             private readonly MemoryStream _stream;
-            private readonly ResPath _resourcePath;
+            private readonly ResourcePath _resourcePath;
 
-            public SingleStreamLoader(MemoryStream stream, ResPath resourcePath)
+            public SingleStreamLoader(MemoryStream stream, ResourcePath resourcePath)
             {
                 _stream = stream;
                 _resourcePath = resourcePath;
@@ -23,7 +23,7 @@ namespace Robust.Shared.ContentPack
                 // Nothing to do here I'm pretty sure.
             }
 
-            public bool TryGetFile(ResPath relPath, [NotNullWhen(true)] out Stream? stream)
+            public bool TryGetFile(ResourcePath relPath, [NotNullWhen(true)] out Stream? stream)
             {
                 if (relPath == _resourcePath)
                 {
@@ -40,7 +40,7 @@ namespace Robust.Shared.ContentPack
                 return false;
             }
 
-            public IEnumerable<ResPath> FindFiles(ResPath path)
+            public IEnumerable<ResourcePath> FindFiles(ResourcePath path)
             {
                 if (_resourcePath.TryRelativeTo(path, out var relative))
                 {

--- a/Robust.Shared/ContentPack/ResourceManagerExt.cs
+++ b/Robust.Shared/ContentPack/ResourceManagerExt.cs
@@ -14,9 +14,9 @@ namespace Robust.Shared.ContentPack
         /// <returns>The memory stream of the file, or null if the file does not exist.</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="path"/> is not rooted.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="path"/> is null.</exception>
-        /// <seealso cref="IResourceManager.ContentFileRead(ResPath)"/>
-        /// <seealso cref="IResourceManager.TryContentFileRead(ResPath, out Stream)"/>
-        public static Stream? ContentFileReadOrNull(this IResourceManager res, ResPath path)
+        /// <seealso cref="IResourceManager.ContentFileRead(ResourcePath)"/>
+        /// <seealso cref="IResourceManager.TryContentFileRead(ResourcePath, out Stream)"/>
+        public static Stream? ContentFileReadOrNull(this IResourceManager res, ResourcePath path)
         {
             if (res.TryContentFileRead(path, out var stream))
             {

--- a/Robust.Shared/ContentPack/VirtualWritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/VirtualWritableDirProvider.cs
@@ -29,7 +29,7 @@ namespace Robust.Shared.ContentPack
         /// <inheritdoc />
         public string? RootDir => null;
 
-        public void CreateDir(ResPath path)
+        public void CreateDir(ResourcePath path)
         {
             if (!path.IsRooted)
             {
@@ -39,7 +39,6 @@ namespace Robust.Shared.ContentPack
             path = path.Clean();
 
             var directory = _rootDirectoryNode;
-
             foreach (var segment in path.EnumerateSegments())
             {
                 if (directory.Children.TryGetValue(segment, out var child))
@@ -59,7 +58,7 @@ namespace Robust.Shared.ContentPack
             }
         }
 
-        public void Delete(ResPath path)
+        public void Delete(ResourcePath path)
         {
             if (!path.IsRooted)
             {
@@ -78,18 +77,18 @@ namespace Robust.Shared.ContentPack
             directory.Children.Remove(path.Filename);
         }
 
-        public bool Exists(ResPath path)
+        public bool Exists(ResourcePath path)
         {
             return TryGetNodeAt(path, out _);
         }
 
-        public (IEnumerable<ResPath> files, IEnumerable<ResPath> directories) Find(string pattern,
+        public (IEnumerable<ResourcePath> files, IEnumerable<ResourcePath> directories) Find(string pattern,
             bool recursive = true)
         {
             throw new NotImplementedException();
         }
 
-        public IEnumerable<string> DirectoryEntries(ResPath path)
+        public IEnumerable<string> DirectoryEntries(ResourcePath path)
         {
             if (!TryGetNodeAt(path, out var dir) || dir is not DirectoryNode dirNode)
                 throw new ArgumentException("Path is not a valid directory node.");
@@ -97,17 +96,19 @@ namespace Robust.Shared.ContentPack
             return dirNode.Children.Keys;
         }
 
-        public bool IsDir(ResPath path)
+        public bool IsDir(ResourcePath path)
         {
             return TryGetNodeAt(path, out var node) && node is DirectoryNode;
         }
 
-        public Stream Open(ResPath path, FileMode fileMode, FileAccess access, FileShare share)
+        public Stream Open(ResourcePath path, FileMode fileMode, FileAccess access, FileShare share)
         {
             if (!path.IsRooted)
             {
                 throw new ArgumentException("Path must be rooted", nameof(path));
             }
+
+            path = path.Clean();
 
             var parentPath = path.Directory;
             if (!TryGetNodeAt(parentPath, out var parent) || !(parent is DirectoryNode parentDir))
@@ -204,12 +205,12 @@ namespace Robust.Shared.ContentPack
             }
         }
 
-        public void Rename(ResPath oldPath, ResPath newPath)
+        public void Rename(ResourcePath oldPath, ResourcePath newPath)
         {
             throw new NotImplementedException();
         }
 
-        private bool TryGetNodeAt(ResPath path, [NotNullWhen(true)] out INode? node)
+        private bool TryGetNodeAt(ResourcePath path, [NotNullWhen(true)] out INode? node)
         {
             if (!path.IsRooted)
             {
@@ -218,14 +219,14 @@ namespace Robust.Shared.ContentPack
 
             path = path.Clean();
 
-            if (path == ResPath.Root)
+            if (path == ResourcePath.Root)
             {
                 node = _rootDirectoryNode;
                 return true;
             }
 
             var directory = _rootDirectoryNode;
-            var segments = path.EnumerateSegments();
+            var segments = path.EnumerateSegments().ToArray();
             for (var i = 0; i < segments.Length; i++)
             {
                 var segment = segments[i];
@@ -247,7 +248,7 @@ namespace Robust.Shared.ContentPack
             throw new InvalidOperationException("Unreachable.");
         }
 
-        public IWritableDirProvider OpenSubdirectory(ResPath path)
+        public IWritableDirProvider OpenSubdirectory(ResourcePath path)
         {
             if (!TryGetNodeAt(path, out var node) || node is not DirectoryNode dirNode)
                 throw new FileNotFoundException();

--- a/Robust.Shared/ContentPack/WritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/WritableDirProvider.cs
@@ -26,14 +26,14 @@ namespace Robust.Shared.ContentPack
         #region File Access
 
         /// <inheritdoc />
-        public void CreateDir(ResPath path)
+        public void CreateDir(ResourcePath path)
         {
             var fullPath = GetFullPath(path);
             Directory.CreateDirectory(fullPath);
         }
 
         /// <inheritdoc />
-        public void Delete(ResPath path)
+        public void Delete(ResourcePath path)
         {
             var fullPath = GetFullPath(path);
             if (Directory.Exists(fullPath))
@@ -47,14 +47,14 @@ namespace Robust.Shared.ContentPack
         }
 
         /// <inheritdoc />
-        public bool Exists(ResPath path)
+        public bool Exists(ResourcePath path)
         {
             var fullPath = GetFullPath(path);
             return Directory.Exists(fullPath) || File.Exists(fullPath);
         }
 
         /// <inheritdoc />
-        public (IEnumerable<ResPath> files, IEnumerable<ResPath> directories) Find(string pattern, bool recursive = true)
+        public (IEnumerable<ResourcePath> files, IEnumerable<ResourcePath> directories) Find(string pattern, bool recursive = true)
         {
             var rootLen = RootDir.Length - 1;
             var option = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
@@ -62,23 +62,23 @@ namespace Robust.Shared.ContentPack
             var files = Directory.GetFiles(RootDir, pattern, option);
             var dirs = Directory.GetDirectories(RootDir, pattern, option);
 
-            var resFiles = new List<ResPath>(files.Length);
-            var resDirs = new List<ResPath>(dirs.Length);
+            var resFiles = new List<ResourcePath>(files.Length);
+            var resDirs = new List<ResourcePath>(dirs.Length);
 
             foreach (var file in files)
             {
-                resFiles.Add(new ResPath(file.Substring(rootLen)));
+                resFiles.Add(new ResourcePath(file.Substring(rootLen), ResourcePath.SYSTEM_SEPARATOR).ChangeSeparator("/"));
             }
 
             foreach (var dir in dirs)
             {
-                resDirs.Add(new ResPath(dir.Substring(rootLen)));
+                resDirs.Add(new ResourcePath(dir.Substring(rootLen), ResourcePath.SYSTEM_SEPARATOR).ChangeSeparator("/"));
             }
 
             return (resFiles, resDirs);
         }
 
-        public IEnumerable<string> DirectoryEntries(ResPath path)
+        public IEnumerable<string> DirectoryEntries(ResourcePath path)
         {
             var fullPath = GetFullPath(path);
 
@@ -92,19 +92,19 @@ namespace Robust.Shared.ContentPack
         }
 
         /// <inheritdoc />
-        public bool IsDir(ResPath path)
+        public bool IsDir(ResourcePath path)
         {
             return Directory.Exists(GetFullPath(path));
         }
 
         /// <inheritdoc />
-        public Stream Open(ResPath path, FileMode fileMode, FileAccess access, FileShare share)
+        public Stream Open(ResourcePath path, FileMode fileMode, FileAccess access, FileShare share)
         {
             var fullPath = GetFullPath(path);
             return File.Open(fullPath, fileMode, access, share);
         }
 
-        public IWritableDirProvider OpenSubdirectory(ResPath path)
+        public IWritableDirProvider OpenSubdirectory(ResourcePath path)
         {
             if (!IsDir(path))
                 throw new FileNotFoundException();
@@ -114,7 +114,7 @@ namespace Robust.Shared.ContentPack
         }
 
         /// <inheritdoc />
-        public void Rename(ResPath oldPath, ResPath newPath)
+        public void Rename(ResourcePath oldPath, ResourcePath newPath)
         {
             var fullOldPath = GetFullPath(oldPath);
             var fullNewPath = GetFullPath(newPath);
@@ -123,21 +123,19 @@ namespace Robust.Shared.ContentPack
 
         #endregion
 
-        public string GetFullPath(ResPath path)
+        public string GetFullPath(ResourcePath path)
         {
             if (!path.IsRooted)
             {
                 throw new ArgumentException("Path must be rooted.");
             }
 
-            path = path.Clean();
-
             return GetFullPath(RootDir, path);
         }
 
-        private static string GetFullPath(string root, ResPath path)
+        private static string GetFullPath(string root, ResourcePath path)
         {
-            var relPath = path.ToRelativeSystemPath();
+            var relPath = path.Clean().ToRelativeSystemPath();
             if (relPath.Contains("\\..") || relPath.Contains("/.."))
             {
                 // Hard cap on any exploit smuggling a .. in there.

--- a/Robust.Shared/ContentPack/WritableDirProviderExt.cs
+++ b/Robust.Shared/ContentPack/WritableDirProviderExt.cs
@@ -18,7 +18,7 @@ namespace Robust.Shared.ContentPack
         /// <exception cref="FileNotFoundException">
         ///     Thrown if the file does not exist.
         /// </exception>
-        public static Stream OpenRead(this IWritableDirProvider provider, ResPath path)
+        public static Stream OpenRead(this IWritableDirProvider provider, ResourcePath path)
         {
             return provider.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
         }
@@ -32,7 +32,7 @@ namespace Robust.Shared.ContentPack
         /// <exception cref="FileNotFoundException">
         ///     Thrown if the file does not exist.
         /// </exception>
-        public static StreamReader OpenText(this IWritableDirProvider provider, ResPath path)
+        public static StreamReader OpenText(this IWritableDirProvider provider, ResourcePath path)
         {
             var stream = OpenRead(provider, path);
             return new StreamReader(stream, EncodingHelpers.UTF8);
@@ -44,7 +44,7 @@ namespace Robust.Shared.ContentPack
         /// <param name="provider">The writable directory provider</param>
         /// <param name="path">The path of the file to open.</param>
         /// <returns>A valid file stream.</returns>
-        public static Stream OpenWrite(this IWritableDirProvider provider, ResPath path)
+        public static Stream OpenWrite(this IWritableDirProvider provider, ResourcePath path)
         {
             return provider.Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
         }
@@ -55,7 +55,7 @@ namespace Robust.Shared.ContentPack
         /// <param name="provider">The writable directory provider</param>
         /// <param name="path">The path of the file to open.</param>
         /// <returns>A valid file stream writer.</returns>
-        public static StreamWriter OpenWriteText(this IWritableDirProvider provider, ResPath path)
+        public static StreamWriter OpenWriteText(this IWritableDirProvider provider, ResourcePath path)
         {
             var stream = OpenWrite(provider, path);
             return new StreamWriter(stream, EncodingHelpers.UTF8);
@@ -68,7 +68,7 @@ namespace Robust.Shared.ContentPack
         /// <param name="provider">The writable directory provider</param>
         /// <param name="path">Path of file to append to.</param>
         /// <param name="content">String to append.</param>
-        public static void AppendAllText(this IWritableDirProvider provider, ResPath path, ReadOnlySpan<char> content)
+        public static void AppendAllText(this IWritableDirProvider provider, ResourcePath path, ReadOnlySpan<char> content)
         {
             using var stream = provider.Open(path, FileMode.Append, FileAccess.Write, FileShare.Read);
             using var writer = new StreamWriter(stream, EncodingHelpers.UTF8);
@@ -82,7 +82,7 @@ namespace Robust.Shared.ContentPack
         /// <param name="provider"></param>
         /// <param name="path">File to read.</param>
         /// <returns>String of the file contents</returns>
-        public static string ReadAllText(this IWritableDirProvider provider, ResPath path)
+        public static string ReadAllText(this IWritableDirProvider provider, ResourcePath path)
         {
             using var reader = provider.OpenText(path);
 
@@ -96,7 +96,7 @@ namespace Robust.Shared.ContentPack
         /// <param name="path">The path to read the contents from.</param>
         /// <param name="text">The content read from the path, or null if the path did not exist.</param>
         /// <returns>true if path was successfully read; otherwise, false.</returns>
-        public static bool TryReadAllText(this IWritableDirProvider provider, ResPath path, [NotNullWhen(true)] out string? text)
+        public static bool TryReadAllText(this IWritableDirProvider provider, ResourcePath path, [NotNullWhen(true)] out string? text)
         {
             try
             {
@@ -116,7 +116,7 @@ namespace Robust.Shared.ContentPack
         /// <param name="provider">The writable directory to look for the path in.</param>
         /// <param name="path">The path to read the contents from.</param>
         /// <returns>The contents of the path as a byte array.</returns>
-        public static byte[] ReadAllBytes(this IWritableDirProvider provider, ResPath path)
+        public static byte[] ReadAllBytes(this IWritableDirProvider provider, ResourcePath path)
         {
             using var stream = provider.OpenRead(path);
             using var memoryStream = new MemoryStream((int) stream.Length);
@@ -131,7 +131,7 @@ namespace Robust.Shared.ContentPack
         /// <param name="provider">The writable directory provider</param>
         /// <param name="path">Path of the file to write to.</param>
         /// <param name="content">String contents of the file.</param>
-        public static void WriteAllText(this IWritableDirProvider provider, ResPath path, ReadOnlySpan<char> content)
+        public static void WriteAllText(this IWritableDirProvider provider, ResourcePath path, ReadOnlySpan<char> content)
         {
             using var writer = provider.OpenWriteText(path);
 
@@ -145,7 +145,7 @@ namespace Robust.Shared.ContentPack
         /// <param name="provider">The writable directory provider</param>
         /// <param name="path">Path of the file to write to.</param>
         /// <param name="content">Bytes to write to the file.</param>
-        public static void WriteAllBytes(this IWritableDirProvider provider, ResPath path, ReadOnlySpan<byte> content)
+        public static void WriteAllBytes(this IWritableDirProvider provider, ResourcePath path, ReadOnlySpan<byte> content)
         {
             using var stream = provider.OpenWrite(path);
 

--- a/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Renderable/SharedSpriteComponent.cs
@@ -16,7 +16,8 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         ///     The resource path from which all texture paths are relative to.
         /// </summary>
-        public static readonly ResPath TextureRoot = new("/Textures");
+        public static readonly ResourcePath TextureRoot = new("/Textures");
+        public static readonly ResPath TextureRootResPath = new("/Textures");
 
         [Serializable, NetSerializable]
         protected sealed class SpriteComponentState : ComponentState

--- a/Robust.Shared/Localization/LocalizationManager.cs
+++ b/Robust.Shared/Localization/LocalizationManager.cs
@@ -240,7 +240,7 @@ namespace Robust.Shared.Localization
             // Load data from .ftl files.
             // Data is loaded from /Locale/<language-code>/*
 
-            var root = new ResPath($"/Locale/{culture.Name}/");
+            var root = new ResourcePath($"/Locale/{culture.Name}/");
 
             var files = resourceManager.ContentFindFiles(root)
                 .Where(c => c.Filename.EndsWith(".ftl", StringComparison.InvariantCultureIgnoreCase))
@@ -264,7 +264,7 @@ namespace Robust.Shared.Localization
             }
         }
 
-        private void WriteWarningForErrs(ResPath path, List<ParseError> errs, ReadOnlyMemory<char> resource)
+        private void WriteWarningForErrs(ResourcePath path, List<ParseError> errs, ReadOnlyMemory<char> resource)
         {
             foreach (var err in errs)
             {

--- a/Robust.Shared/Map/ITileDefinition.cs
+++ b/Robust.Shared/Map/ITileDefinition.cs
@@ -27,12 +27,12 @@ namespace Robust.Shared.Map
         /// <summary>
         ///     The path of the sprite to draw.
         /// </summary>
-        ResPath? Sprite { get; }
+        ResourcePath? Sprite { get; }
 
         /// <summary>
         /// Possible sprites to use if we're neighboring another tile.
         /// </summary>
-        Dictionary<Direction, ResPath> EdgeSprites { get; }
+        Dictionary<Direction, ResourcePath> EdgeSprites { get; }
 
         /// <summary>
         ///     Physics objects that are interacting on this tile are slowed down by this float.

--- a/Robust.Shared/Network/Messages/MsgReloadPrototypes.cs
+++ b/Robust.Shared/Network/Messages/MsgReloadPrototypes.cs
@@ -8,16 +8,16 @@ namespace Robust.Shared.Network.Messages
     {
         public override MsgGroups MsgGroup => MsgGroups.Command;
 
-        public ResPath[] Paths = default!;
+        public ResourcePath[] Paths = default!;
 
         public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             var count = buffer.ReadInt32();
-            Paths = new ResPath[count];
+            Paths = new ResourcePath[count];
 
             for (var i = 0; i < count; i++)
             {
-                Paths[i] = new ResPath(buffer.ReadString());
+                Paths[i] = new ResourcePath(buffer.ReadString());
             }
         }
 

--- a/Robust.Shared/ProgramShared.cs
+++ b/Robust.Shared/ProgramShared.cs
@@ -45,7 +45,7 @@ internal static class ProgramShared
         sawmill.Debug($"OS: {RuntimeInformation.OSDescription} {RuntimeInformation.OSArchitecture}");
     }
 
-    internal static void DoMounts(IResourceManagerInternal res, MountOptions? options, string contentBuildDir, ResPath assembliesPath, bool loadContentResources = true,
+    internal static void DoMounts(IResourceManagerInternal res, MountOptions? options, string contentBuildDir, ResourcePath assembliesPath, bool loadContentResources = true,
         bool loader = false, bool contentStart = false)
     {
 #if FULL_RELEASE

--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -196,9 +196,9 @@ public interface IPrototypeManager
     /// <summary>
     /// Load prototypes from files in a directory, recursively.
     /// </summary>
-    void LoadDirectory(ResPath path, bool overwrite = false, Dictionary<Type, HashSet<string>>? changed = null);
+    void LoadDirectory(ResourcePath path, bool overwrite = false, Dictionary<Type, HashSet<string>>? changed = null);
 
-    Dictionary<string, HashSet<ErrorNode>> ValidateDirectory(ResPath path);
+    Dictionary<string, HashSet<ErrorNode>> ValidateDirectory(ResourcePath path);
 
     void LoadFromStream(TextReader stream, bool overwrite = false, Dictionary<Type, HashSet<string>>? changed = null);
 

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
@@ -19,7 +19,7 @@ public partial class PrototypeManager
     public event Action<DataNodeDocument>? LoadedData;
 
     /// <inheritdoc />
-    public void LoadDirectory(ResPath path, bool overwrite = false,
+    public void LoadDirectory(ResourcePath path, bool overwrite = false,
         Dictionary<Type, HashSet<string>>? changed = null)
     {
         _hasEverBeenReloaded = true;
@@ -33,7 +33,7 @@ public partial class PrototypeManager
         var sawmill = _logManager.GetSawmill("eng");
 
         var results = streams.AsParallel()
-            .Select<ResPath, (ResPath, IEnumerable<ExtractedMappingData>)>(file =>
+            .Select<ResourcePath, (ResourcePath, IEnumerable<ExtractedMappingData>)>(file =>
             {
                 try
                 {
@@ -81,7 +81,7 @@ public partial class PrototypeManager
         }
     }
 
-    public Dictionary<string, HashSet<ErrorNode>> ValidateDirectory(ResPath path)
+    public Dictionary<string, HashSet<ErrorNode>> ValidateDirectory(ResourcePath path)
     {
         var streams = Resources.ContentFindFiles(path).ToList().AsParallel()
             .Where(filePath => filePath.Extension == "yml" && !filePath.Filename.StartsWith("."));
@@ -130,7 +130,7 @@ public partial class PrototypeManager
         return dict;
     }
 
-    private StreamReader? ReadFile(ResPath file, bool @throw = true)
+    private StreamReader? ReadFile(ResourcePath file, bool @throw = true)
     {
         var retries = 0;
 
@@ -161,7 +161,7 @@ public partial class PrototypeManager
         }
     }
 
-    public void LoadFile(ResPath file, bool overwrite = false, Dictionary<Type, HashSet<string>>? changed = null)
+    public void LoadFile(ResourcePath file, bool overwrite = false, Dictionary<Type, HashSet<string>>? changed = null)
     {
         try
         {

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -192,7 +192,7 @@ namespace Robust.Shared.Prototypes
             return _kindPriorities[b].CompareTo(_kindPriorities[a]);
         }
 
-        protected void ReloadPrototypes(IEnumerable<ResPath> filePaths)
+        protected void ReloadPrototypes(IEnumerable<ResourcePath> filePaths)
         {
 #if TOOLS
             var changed = new Dictionary<Type, HashSet<string>>();

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/ResPathSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/ResPathSerializer.cs
@@ -28,7 +28,7 @@ public sealed class ResPathSerializer : ITypeSerializer<ResPath, ValueDataNode>,
 
         if (!path.CanonPath.Split('/').First().Equals("Textures", StringComparison.InvariantCultureIgnoreCase))
         {
-            path = SharedSpriteComponent.TextureRoot / path;
+            path = SharedSpriteComponent.TextureRootResPath / path;
         }
 
         path = path.ToRootedPath();
@@ -44,7 +44,7 @@ public sealed class ResPathSerializer : ITypeSerializer<ResPath, ValueDataNode>,
             if (node.Value.EndsWith(ResPath.SeparatorStr)
                 // Once Resource path is purged this will be
                 //  resourceManager.ContentGetDirectoryEntries(path).Any()
-                && resourceManager.ContentGetDirectoryEntries(new ResPath(path.CanonPath)).Any())
+                && resourceManager.ContentGetDirectoryEntries(new ResourcePath(path.CanonPath)).Any())
             {
                 return new ValidatedValueNode(node);
             }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/ResourcePathSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/ResourcePathSerializer.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Linq;
+using JetBrains.Annotations;
+using Robust.Shared.ContentPack;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Serialization.TypeSerializers.Implementations
+{
+    [TypeSerializer]
+    public sealed class ResourcePathSerializer : ITypeSerializer<ResourcePath, ValueDataNode>, ITypeCopyCreator<ResourcePath>
+    {
+        public ResourcePath Read(ISerializationManager serializationManager, ValueDataNode node,
+            IDependencyCollection dependencies,
+            SerializationHookContext hookCtx,
+            ISerializationContext? context = null,
+            ISerializationManager.InstantiationDelegate<ResourcePath>? instanceProvider = null)
+        {
+            return new ResourcePath(node.Value);
+        }
+
+        public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
+            IDependencyCollection dependencies,
+            ISerializationContext? context = null)
+        {
+            var path = new ResourcePath(node.Value);
+
+            if (path.Extension.Equals("rsi"))
+            {
+                path /= "meta.json";
+            }
+
+            if (!path.EnumerateSegments().First().Equals("Textures", StringComparison.InvariantCultureIgnoreCase))
+            {
+                path = SharedSpriteComponent.TextureRoot / path;
+            }
+
+            path = path.ToRootedPath();
+
+
+            try
+            {
+                var resourceManager = dependencies.Resolve<IResourceManager>();
+                if(resourceManager.ContentFileExists(path))
+                {
+                    return new ValidatedValueNode(node);
+                }
+
+                if (node.Value.EndsWith(path.Separator) && resourceManager.ContentGetDirectoryEntries(path).Any())
+                {
+                    return new ValidatedValueNode(node);
+                }
+
+                return new ErrorNode(node, $"File not found. ({path})");
+            }
+            catch (Exception e)
+            {
+                return new ErrorNode(node, $"Failed parsing filepath. ({path}) ({e.Message})");
+            }
+        }
+
+        public DataNode Write(ISerializationManager serializationManager, ResourcePath value,
+            IDependencyCollection dependencies,
+            bool alwaysWrite = false,
+            ISerializationContext? context = null)
+        {
+            return new ValueDataNode(value.ToString());
+        }
+
+        [MustUseReturnValue]
+        public ResourcePath CreateCopy(ISerializationManager serializationManager, ResourcePath source,
+            SerializationHookContext hookCtx,
+            ISerializationContext? context = null)
+        {
+            return new(source.ToString());
+        }
+    }
+}

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/SpriteSpecifierSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/SpriteSpecifierSerializer.cs
@@ -31,7 +31,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             SerializationHookContext hookCtx, ISerializationContext? context,
             ISerializationManager.InstantiationDelegate<Texture>? instanceProvider)
         {
-            var path = serializationManager.Read<ResPath>(node, hookCtx, context);
+            var path = serializationManager.Read<ResourcePath>(node, hookCtx, context, notNullableOverride: true);
             return new Texture(path);
         }
 
@@ -69,7 +69,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
                 throw new InvalidMappingException("Expected state-node as a valuenode");
             }
 
-            var path = serializationManager.Read<ResPath>(pathNode, hookCtx, context);
+            var path = serializationManager.Read<ResourcePath>(pathNode, hookCtx, context, notNullableOverride: true);
             return new Rsi(path, valueDataNode.Value);
         }
 
@@ -108,7 +108,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             IDependencyCollection dependencies,
             ISerializationContext? context)
         {
-            return serializationManager.ValidateNode<ResPath>(new ValueDataNode($"{SharedSpriteComponent.TextureRoot / node.Value}"), context);
+            return serializationManager.ValidateNode<ResourcePath>(new ValueDataNode($"{SharedSpriteComponent.TextureRoot / node.Value}"), context);
         }
 
         ValidationNode ITypeValidator<SpriteSpecifier, MappingDataNode>.Validate(
@@ -145,7 +145,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             IDependencyCollection dependencies, bool alwaysWrite = false,
             ISerializationContext? context = null)
         {
-            return serializationManager.WriteValue(value.TexturePath, alwaysWrite, context);
+            return serializationManager.WriteValue(value.TexturePath, alwaysWrite, context, notNullableOverride: true);
         }
 
         public DataNode Write(ISerializationManager serializationManager, EntityPrototype value,
@@ -162,7 +162,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             ISerializationContext? context = null)
         {
             var mapping = new MappingDataNode();
-            mapping.Add("sprite", serializationManager.WriteValue(value.RsiPath));
+            mapping.Add("sprite", serializationManager.WriteValue(value.RsiPath, notNullableOverride: true));
             mapping.Add("state", new ValueDataNode(value.RsiState));
             return mapping;
         }

--- a/Robust.Shared/Utility/ResourcePath.cs
+++ b/Robust.Shared/Utility/ResourcePath.cs
@@ -1,0 +1,722 @@
+﻿// Because System.IO.Path sucks.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using JetBrains.Annotations;
+using Robust.Shared.Serialization;
+
+namespace Robust.Shared.Utility
+{
+    /// <summary>
+    ///     Provides object-oriented path manipulation for resource paths.
+    ///     ResourcePaths are immutable.
+    /// </summary>
+    [PublicAPI, Serializable, NetSerializable]
+    [Obsolete(@$"Use {nameof(ResPath)} instead")]
+    public sealed class ResourcePath : IEquatable<ResourcePath>
+    {
+        /// <summary>
+        ///     The separator for the file system of the system we are compiling to.
+        ///     Backslash on Windows, forward slash on sane systems.
+        /// </summary>
+#if WINDOWS
+        public const string SYSTEM_SEPARATOR = "\\";
+#else
+        public const string SYSTEM_SEPARATOR = "/";
+#endif
+
+        /// <summary>
+        ///     "." as a static. Separator used is <c>/</c>.
+        /// </summary>
+        public static readonly ResourcePath Self = new(".");
+
+        /// <summary>
+        ///     "/" (root) as a static. Separator used is <c>/</c>.
+        /// </summary>
+        public static readonly ResourcePath Root = new("/");
+
+        /// <summary>
+        ///     List of the segments of the path.
+        ///     This is pretty much a split of the input string path by separator,
+        ///     except for the root, which is represented as the separator in position #0.
+        /// </summary>
+        private readonly string[] Segments;
+
+        /// <summary>
+        ///     The separator between "segments"/"directories" for this path.
+        /// </summary>
+        public string Separator { get; }
+
+        /// <summary>
+        /// This exists for serv3.
+        /// </summary>
+        private ResourcePath() : this("") {}
+
+        /// <summary>
+        ///     Create a new path from a string, splitting it by the separator provided.
+        /// </summary>
+        /// <param name="path">The string path to turn into a resource path.</param>
+        /// <param name="separator">The separator for the resource path.</param>
+        /// <exception cref="ArgumentException">Thrown if you try to use "." as separator.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if either argument is null.</exception>
+        public ResourcePath(string path, string separator = "/")
+        {
+            ValidateSeparate(separator);
+
+            Separator = separator;
+
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            if (path == "")
+            {
+                Segments = new string[] {"."};
+                return;
+            }
+
+            var splitSegments = path.Split(separator);
+            var segments = new List<string>(splitSegments.Length);
+
+            var i = 0;
+            if (splitSegments[0] == "")
+            {
+                i = 1;
+                segments.Add(separator);
+            }
+
+            for (; i < splitSegments.Length; i++)
+            {
+                var segment = splitSegments[i];
+                if (segment == "" || (segment == "." && segments.Count != 0))
+                {
+                    continue;
+                }
+
+                if (i == 1 && segments[0] == ".")
+                {
+                    segments[0] = segment;
+                }
+                else
+                {
+                    segments.Add(segment);
+                }
+            }
+
+            Segments = ListToArray(segments);
+        }
+
+        private ResourcePath(string[] segments, string separator)
+        {
+            Segments = segments;
+            Separator = separator;
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+            var i = 0;
+            if (IsRooted)
+            {
+                i = 1;
+                builder.Append(Separator);
+            }
+
+            for (; i < Segments.Length; i++)
+            {
+                builder.Append(Segments[i]);
+                if (i + 1 < Segments.Length)
+                {
+                    builder.Append(Separator);
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     Returns true if the path is rooted (starts with the separator).
+        /// </summary>
+        /// <seealso cref="IsRelative" />
+        /// <seealso cref="ToRootedPath"/>
+        public bool IsRooted => Segments[0] == Separator;
+
+        /// <summary>
+        ///     Returns true if the path is not rooted.
+        /// </summary>
+        /// <seealso cref="IsRooted" />
+        /// <seealso cref="ToRelativePath"/>
+        public bool IsRelative => !IsRooted;
+
+        /// <summary>
+        ///     Returns true if the path is equal to "."
+        /// </summary>
+        public bool IsSelf => Segments.Length == 1 && Segments[0] == ".";
+
+        /// <summary>
+        ///     Returns the file extension of file path, if any.
+        ///     Returns "" if there is no file extension.
+        ///     The extension returned does NOT include a period.
+        /// </summary>
+        public string Extension
+        {
+            get
+            {
+                var filename = Filename;
+                if (string.IsNullOrWhiteSpace(filename))
+                {
+                    return "";
+                }
+
+                var index = filename.LastIndexOf('.');
+                if (index == 0 || index == -1 || index == filename.Length - 1)
+                {
+                    // The path is a dotfile (like .bashrc),
+                    // or there's no period at all,
+                    // or the period is at the very end.
+                    // Non of these cases are truly an extension.
+                    return "";
+                }
+
+                return filename.Substring(index + 1);
+            }
+        }
+
+        /// <summary>
+        ///     Returns the file name.
+        /// </summary>
+        public string Filename
+        {
+            get
+            {
+                if (Segments.Length == 1 && IsRooted)
+                {
+                    return "";
+                }
+
+                return Segments[Segments.Length - 1];
+            }
+        }
+
+        /// <summary>
+        ///     Returns the file name, without extension.
+        /// </summary>
+        public string FilenameWithoutExtension
+        {
+            get
+            {
+                var filename = Filename;
+                if (string.IsNullOrWhiteSpace(filename))
+                {
+                    return filename;
+                }
+
+                var index = filename.LastIndexOf('.');
+                if (index == 0 || index == -1 || index == filename.Length - 1)
+                {
+                    return filename;
+                }
+
+                return filename.Substring(0, index);
+            }
+        }
+
+        /// <summary>
+        ///     Returns the directory that this file resides in.
+        /// </summary>
+        public ResourcePath Directory
+        {
+            get
+            {
+                if (IsSelf) return this;
+
+                var fileName = Filename;
+                if (!string.IsNullOrWhiteSpace(fileName))
+                {
+                    var path = ToString();
+                    var dir = path.Remove(path.Length - fileName.Length);
+                    return new ResourcePath(dir);
+                }
+
+                return this;
+            }
+        }
+
+        /// <summary>
+        ///     Returns a new instance with a different separator set.
+        /// </summary>
+        /// <param name="newSeparator">The new separator to use.</param>
+        /// <exception cref="ArgumentException">Thrown if the new separator is invalid.</exception>
+        public ResourcePath ChangeSeparator(string newSeparator)
+        {
+            ValidateSeparate(newSeparator);
+
+            // Convert the segments into a string path, then re-parse it.
+            // Solves the edge case of the segments containing the new separator.
+            ResourcePath path;
+            if (IsRooted)
+            {
+                var clone = (string[]) Segments.Clone();
+                clone[0] = newSeparator;
+                path = new ResourcePath(clone, newSeparator);
+            }
+            else
+            {
+                path = new ResourcePath(Segments, newSeparator);
+            }
+            return new ResourcePath(path.ToString(), newSeparator);
+        }
+
+        /// <summary>
+        ///     Joins two resource paths together, with separator in between.
+        ///     If the second path is absolute, the first path is completely ignored.
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown if the separators of the two paths do not match.</exception>
+        // "Why use / instead of +" you may think:
+        // * It's clever, although I got the idea from Python's pathlib.
+        // * It avoids confusing operator precedence causing you to join two strings,
+        //   because path + string + string != path + (string + string),
+        //   whereas path / (string / string) doesn't compile.
+        public static ResourcePath operator /(ResourcePath a, ResourcePath b)
+        {
+            if (a.Separator != b.Separator)
+            {
+                throw new ArgumentException("Both separators must be the same.");
+            }
+
+            if (b.IsRooted)
+            {
+                return b;
+            }
+
+            if (b.IsSelf)
+            {
+                return a;
+            }
+
+            string[] segments = new string[a.Segments.Length + b.Segments.Length];
+            a.Segments.CopyTo(segments, 0);
+            b.Segments.CopyTo(segments, a.Segments.Length);
+            return new ResourcePath(segments, a.Separator);
+        }
+
+        /// <summary>
+        ///     Adds a new segment to the path as string.
+        /// </summary>
+        public static ResourcePath operator /(ResourcePath path, string b)
+        {
+            return path / new ResourcePath(b, path.Separator);
+        }
+
+        /// <summary>
+        ///     "Cleans" the resource path, removing <c>..</c>.
+        /// </summary>
+        /// <remarks>
+        ///     If .. appears at the base of a path, it is left alone. If it appears at root level (like /..) it is removed entirely.
+        /// </remarks>
+        public ResourcePath Clean()
+        {
+            var segments = new List<string>();
+
+            foreach (var segment in Segments)
+            {
+                // If you have ".." cleaning that up doesn't remove that.
+                if (segment == ".." && segments.Count != 0)
+                {
+                    // Trying to do /.. results in /
+                    if (segments.Count == 1 && segments[0] == Separator)
+                    {
+                        continue;
+                    }
+
+                    var pos = segments.Count - 1;
+                    if (segments[pos] != "..")
+                    {
+                        segments.RemoveAt(pos);
+                        continue;
+                    }
+                }
+
+                segments.Add(segment);
+            }
+
+            if (segments.Count == 0)
+            {
+                return new ResourcePath(".", Separator);
+            }
+
+            return new ResourcePath(ListToArray(segments), Separator);
+        }
+
+        /// <summary>
+        ///     Check whether a path is clean, i.e. <see cref="Clean"/> would not modify it.
+        /// </summary>
+        /// <returns></returns>
+        public bool IsClean()
+        {
+            for (var i = 0; i < Segments.Length; i++)
+            {
+                if (Segments[i] == "..")
+                {
+                    if (IsRooted)
+                    {
+                        return false;
+                    }
+
+                    if (i > 0 && Segments[i - 1] != "..")
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        ///     Turns the path into a rooted path by prepending it with the separator.
+        ///     Does nothing if the path is already rooted.
+        /// </summary>
+        /// <seealso cref="IsRooted" />
+        /// <seealso cref="ToRelativePath" />
+        public ResourcePath ToRootedPath()
+        {
+            if (IsRooted)
+            {
+                return this;
+            }
+
+            var segments = new string[Segments.Length + 1];
+            Segments.CopyTo(segments, 1);
+            segments[0] = Separator;
+            return new ResourcePath(segments, Separator);
+        }
+
+        /// <summary>
+        ///     Turns the path into a relative path by removing the root separator, if any.
+        ///     Does nothing if the path is already relative.
+        /// </summary>
+        /// <seealso cref="IsRelative"/>
+        /// <seealso cref="ToRootedPath" />
+        public ResourcePath ToRelativePath()
+        {
+            if (IsRelative)
+            {
+                return this;
+            }
+
+            if (Segments.Length == 1)
+            {
+                // This path is literally just "/"
+                return new ResourcePath(".", Separator);
+            }
+
+            var segments = new string[Segments.Length - 1];
+            Array.Copy(Segments, 1, segments, 0, Segments.Length - 1);
+            return new ResourcePath(segments, Separator);
+        }
+
+        /// <summary>
+        ///     Turns the path into a relative path with system-specific separator.
+        ///     For usage in disk I/O.
+        /// </summary>
+        public string ToRelativeSystemPath()
+        {
+            return ChangeSeparator(SYSTEM_SEPARATOR).ToRelativePath().ToString();
+        }
+
+        /// <summary>
+        ///     Converts a relative disk path back into a resource path.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">Thrown if either argument is null.</exception>
+        public static ResourcePath FromRelativeSystemPath(string path, string newSeparator = "/")
+        {
+            // ReSharper disable once RedundantArgumentDefaultValue
+            return new ResourcePath(path, SYSTEM_SEPARATOR).ChangeSeparator(newSeparator);
+        }
+
+        /// <summary>
+        ///     Returns the path of how this instance is "relative" to <paramref name="basePath"/>,
+        ///     such that <c>basePath/result == this</c>.
+        /// </summary>
+        /// <example>
+        ///     <code>
+        ///     var path1 = new ResourcePath("/a/b/c");
+        ///     var path2 = new ResourcePath("/a");
+        ///     Console.WriteLine(path1.RelativeTo(path2)); // prints "b/c".
+        ///     </code>
+        /// </example>
+        /// <exception cref="ArgumentException">Thrown if we are not relative to the base path or the separators are not the same.</exception>
+        public ResourcePath RelativeTo(ResourcePath basePath)
+        {
+            if (TryRelativeTo(basePath, out var relative))
+            {
+                return relative;
+            }
+
+            throw new ArgumentException($"{this} does not start with {basePath}.");
+        }
+
+        /// <summary>
+        ///     Try pattern version of <see cref="RelativeTo(ResourcePath)"/>.
+        /// </summary>
+        /// <param name="basePath">The base path which we can be made relative to.</param>
+        /// <param name="relative">The path of how we are relative to <paramref name="basePath"/>, if at all.</param>
+        /// <returns>True if we are relative to <paramref name="basePath"/>, false otherwise.</returns>
+        /// <exception cref="ArgumentException">Thrown if the separators are not the same.</exception>
+        public bool TryRelativeTo(ResourcePath basePath, [NotNullWhen(true)] out ResourcePath? relative)
+        {
+            if (basePath.Separator != Separator)
+            {
+                throw new ArgumentException("Separators must be the same.", nameof(basePath));
+            }
+
+            if (Segments.Length < basePath.Segments.Length)
+            {
+                relative = null;
+                return false;
+            }
+
+            if (Segments.Length == basePath.Segments.Length)
+            {
+                if (this == basePath)
+                {
+                    relative = new ResourcePath(".", Separator);
+                    return true;
+                }
+                else
+                {
+                    relative = null;
+                    return false;
+                }
+            }
+
+            for (var i = 0; i < basePath.Segments.Length; i++)
+            {
+                if (Segments[i] != basePath.Segments[i])
+                {
+                    relative = null;
+                    return false;
+                }
+            }
+
+            var segments = new string[Segments.Length - basePath.Segments.Length];
+            Array.Copy(Segments, basePath.Segments.Length, segments, 0, segments.Length);
+            relative = new ResourcePath(segments, Separator);
+            return true;
+        }
+
+        /// <summary>
+        ///     Gets the common base of two paths.
+        /// </summary>
+        /// <example>
+        ///     <code>
+        ///     var path1 = new ResourcePath("/a/b/c");
+        ///     var path2 = new ResourcePath("/a/e/d");
+        ///     Console.WriteLine(path1.RelativeTo(path2)); // prints "/a".
+        ///     </code>
+        /// </example>
+        /// <param name="other">The other path.</param>
+        /// <exception cref="ArgumentException">Thrown if there is no common base between the two paths.</exception>
+        public ResourcePath CommonBase(ResourcePath other)
+        {
+            if (other.Separator != Separator)
+            {
+                throw new ArgumentException("Separators must match.");
+            }
+
+            var i = 0;
+            for (; i < Segments.Length && i < other.Segments.Length; i++)
+            {
+                if (Segments[i] != other.Segments[i])
+                {
+                    break;
+                }
+            }
+
+            if (i == 0)
+            {
+                throw new ArgumentException($"{this} and {other} have no common base.");
+            }
+
+            var segments = new string[i];
+            Array.Copy(Segments, segments, i);
+            return new ResourcePath(segments, Separator);
+        }
+
+        /// <summary>
+        ///     Return a copy of this resource path with the file name changed.
+        /// </summary>
+        /// <param name="name">
+        ///     The new file name.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        ///     Thrown if <paramref name="name"/> is null, empty,
+        ///     contains <see cref="Separator"/> or is equal to <c>.</c>
+        /// </exception>
+        public ResourcePath WithName(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("New file name cannot be null or empty.");
+            }
+
+            if (name.Contains(Separator))
+            {
+                throw new ArgumentException("New file name cannot contain the separator.");
+            }
+
+            if (name == ".")
+            {
+                throw new ArgumentException("New file name cannot be '.'");
+            }
+
+            var newSegments = (string[]) Segments.Clone();
+            newSegments[newSegments.Length - 1] = name;
+
+            return new ResourcePath(newSegments, Separator);
+        }
+
+        /// <summary>
+        ///     Return a copy of this resource path with the file extension changed.
+        /// </summary>
+        /// <param name="newExtension">
+        ///     The new file extension.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        ///     Thrown if <paramref name="newExtension"/> is null, empty,
+        ///     contains <see cref="Separator"/> or is equal to <c>.</c>
+        /// </exception>
+        public ResourcePath WithExtension(string newExtension)
+        {
+            if (string.IsNullOrEmpty(newExtension))
+            {
+                throw new ArgumentException("New file name cannot be null or empty.");
+            }
+
+            if (newExtension.Contains(Separator))
+            {
+                throw new ArgumentException("New file name cannot contain the separator.");
+            }
+
+            return WithName($"{FilenameWithoutExtension}.{newExtension}");
+        }
+
+        /// <summary>
+        ///     Enumerates the segments of this path.
+        /// </summary>
+        /// <remarks>
+        ///     Segments are returned from highest to deepest.
+        ///     For example <c>/a/b</c> will yield <c>a</c> then <c>b</c>.
+        ///     No special indication is given for rooted paths,
+        ///     so <c>/a/b</c> yields the same as <c>a/b</c>.
+        /// </remarks>
+        public IEnumerable<string> EnumerateSegments()
+        {
+            if (IsRooted)
+            {
+                // Skip '/' root.
+                return Segments.Skip(1);
+            }
+
+            return Segments;
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            var code = Separator.GetHashCode();
+            foreach (var segment in Segments)
+            {
+                unchecked
+                {
+                    code = code * 31 + segment.GetHashCode();
+                }
+            }
+
+            return code;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return obj is ResourcePath path && Equals(path);
+        }
+
+        /// <summary>
+        ///     Checks that we are equal with <paramref name="path"/>.
+        ///     This method does NOT clean the paths beforehand, so paths that point to the same location may fail if they are not cleaned beforehand.
+        ///     Paths are never equal if they do not have the same separator.
+        /// </summary>
+        /// <param name="other">The path to check equality with.</param>
+        /// <returns>True if the paths are equal, false otherwise.</returns>
+        public bool Equals(ResourcePath? other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (other.Separator != Separator || Segments.Length != other.Segments.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < Segments.Length; i++)
+            {
+                if (Segments[i] != other.Segments[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public static bool operator ==(ResourcePath? a, ResourcePath? b)
+        {
+            if ((object?) a == null)
+            {
+                return (object?) b == null;
+            }
+
+            return a.Equals(b);
+        }
+
+        public static bool operator !=(ResourcePath? a, ResourcePath? b)
+        {
+            return !(a == b);
+        }
+
+        // While profiling I found that List<T>.ToArray() is just incredibly slow. No idea why honestly.
+        private static string[] ListToArray(List<string> list)
+        {
+            var array = new string[list.Count];
+
+            for (var i = 0; i < list.Count; i++)
+            {
+                array[i] = list[i];
+            }
+
+            return array;
+        }
+
+        private static void ValidateSeparate(string separator)
+        {
+            if (string.IsNullOrWhiteSpace(separator))
+            {
+                throw new ArgumentException("Separator may not be null or whitespace.");
+            }
+
+            if (separator == "." || separator == "..")
+            {
+                throw new ArgumentException("Separator may not be . or ..");
+            }
+        }
+    }
+}

--- a/Robust.Shared/Utility/SpriteSpecifier.cs
+++ b/Robust.Shared/Utility/SpriteSpecifier.cs
@@ -6,8 +6,8 @@ namespace Robust.Shared.Utility
 {
     // >tfw you're not using Rust and you don't have easy sum types.
     // pub enum SpriteSpecifier {
-    //      Rsi { path: ResPath, state: String, },
-    //      Texture(ResPath),
+    //      Rsi { path: ResourcePath, state: String, },
+    //      Texture(ResourcePath),
     // }
     /// <summary>
     ///     Is a reference to EITHER an RSI + RSI State, OR a bare texture path.
@@ -15,7 +15,7 @@ namespace Robust.Shared.Utility
     [Serializable, NetSerializable]
     public abstract class SpriteSpecifier
     {
-        public static readonly SpriteSpecifier Invalid = new Texture(ResPath.Self);
+        public static readonly SpriteSpecifier Invalid = new Texture(new ResourcePath("."));
 
         public static SpriteSpecifier FromYaml(YamlNode node)
         {
@@ -33,7 +33,7 @@ namespace Robust.Shared.Utility
         [Serializable, NetSerializable]
         public sealed class Rsi : SpriteSpecifier
         {
-            public ResPath RsiPath { get; internal set; }
+            public ResourcePath RsiPath { get; internal set; }
             public string RsiState { get; internal set; }
 
             // For serialization
@@ -43,7 +43,7 @@ namespace Robust.Shared.Utility
                 RsiState = default!;
             }
 
-            public Rsi(ResPath rsiPath, string rsiState)
+            public Rsi(ResourcePath rsiPath, string rsiState)
             {
                 RsiPath = rsiPath;
                 RsiState = rsiState;
@@ -63,7 +63,7 @@ namespace Robust.Shared.Utility
         [Serializable, NetSerializable]
         public sealed class Texture : SpriteSpecifier
         {
-            public ResPath TexturePath { get; internal set; }
+            public ResourcePath TexturePath { get; internal set; }
 
             // For serialization
             private Texture()
@@ -71,7 +71,7 @@ namespace Robust.Shared.Utility
                 TexturePath = default!;
             }
 
-            public Texture(ResPath texturePath)
+            public Texture(ResourcePath texturePath)
             {
                 TexturePath = texturePath;
             }

--- a/Robust.Shared/Utility/YamlHelpers.cs
+++ b/Robust.Shared/Utility/YamlHelpers.cs
@@ -165,7 +165,7 @@ namespace Robust.Shared.Utility
         }
 
         [Pure]
-        public static ResPath AsResourcePath(this YamlNode node)
+        public static ResourcePath AsResourcePath(this YamlNode node)
         {
             return new(node.ToString());
         }

--- a/Robust.UnitTesting/Helpers.cs
+++ b/Robust.UnitTesting/Helpers.cs
@@ -18,7 +18,7 @@ namespace Robust.UnitTesting
             var stream = new MemoryStream();
             stream.Write(Encoding.UTF8.GetBytes(content));
             stream.Position = 0;
-            resourceManager.MountStreamAt(stream, new (path));
+            resourceManager.MountStreamAt(stream, new ResourcePath(path));
         }
     }
 }

--- a/Robust.UnitTesting/RobustUnitTest.cs
+++ b/Robust.UnitTesting/RobustUnitTest.cs
@@ -215,7 +215,7 @@ namespace Robust.UnitTesting
 
             var modLoader = deps.Resolve<TestingModLoader>();
             modLoader.Assemblies = contentAssemblies;
-            modLoader.TryLoadModulesFrom(ResPath.Root, "");
+            modLoader.TryLoadModulesFrom(ResourcePath.Root, "");
 
             entMan.Startup();
             mapMan.Startup();

--- a/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
+++ b/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
@@ -79,8 +79,8 @@ entities:
             var protoMan = IoCManager.Resolve<IPrototypeManager>();
             protoMan.RegisterKind(typeof(EntityPrototype));
 
-            protoMan.LoadDirectory(new ("/EnginePrototypes"));
-            protoMan.LoadDirectory(new ("/Prototypes"));
+            protoMan.LoadDirectory(new ResourcePath("/EnginePrototypes"));
+            protoMan.LoadDirectory(new ResourcePath("/Prototypes"));
             protoMan.ResolveResults();
         }
 

--- a/Robust.UnitTesting/Shared/ContentPack/ResourceManagerTest.cs
+++ b/Robust.UnitTesting/Shared/ContentPack/ResourceManagerTest.cs
@@ -67,7 +67,7 @@ namespace Robust.UnitTesting.Shared.ContentPack
 
             var stream = new MemoryStream(Data);
             var resourceManager = IoCManager.Resolve<IResourceManagerInternal>();
-            resourceManager.MountStreamAt(stream, new ("/a/b/c.dat"));
+            resourceManager.MountStreamAt(stream, new ResourcePath("/a/b/c.dat"));
         }
 
         [Test]
@@ -83,13 +83,13 @@ namespace Robust.UnitTesting.Shared.ContentPack
         [Test]
         public void TestInvalidPaths([ValueSource(nameof(InvalidPaths))] string path)
         {
-            Assert.That(ResourceManager.IsPathValid(new (path)), Is.False);
+            Assert.That(ResourceManager.IsPathValid(new ResourcePath(path)), Is.False);
         }
 
         [Test]
         public void TestInvalidPathsLowerCase([ValueSource(nameof(InvalidPaths))] string path)
         {
-            Assert.That(ResourceManager.IsPathValid(new (path.ToLowerInvariant())), Is.False);
+            Assert.That(ResourceManager.IsPathValid(new ResourcePath(path.ToLowerInvariant())), Is.False);
         }
 
         [Test]
@@ -112,8 +112,8 @@ namespace Robust.UnitTesting.Shared.ContentPack
 
             Assert.That(found, Is.EquivalentTo(new[]
             {
-                new ResPath("/bar/a.txt"),
-                new ResPath("/bar/b.txt"),
+                new ResourcePath("/bar/a.txt"),
+                new ResourcePath("/bar/b.txt"),
             }));
         }
 

--- a/Robust.UnitTesting/Shared/Localization/LocalizationTests.cs
+++ b/Robust.UnitTesting/Shared/Localization/LocalizationTests.cs
@@ -32,7 +32,7 @@ namespace Robust.UnitTesting.Shared.Localization
             var protoMan = IoCManager.Resolve<IPrototypeManager>();
 
             protoMan.RegisterKind(typeof(EntityPrototype));
-            protoMan.LoadDirectory(new ResPath("/EnginePrototypes"));
+            protoMan.LoadDirectory(new ResourcePath("/EnginePrototypes"));
             protoMan.ResolveResults();
 
             var loc = IoCManager.Resolve<ILocalizationManager>();

--- a/Robust.UnitTesting/Shared/Resources/WritableDirProviderTest.cs
+++ b/Robust.UnitTesting/Shared/Resources/WritableDirProviderTest.cs
@@ -39,7 +39,7 @@ namespace Robust.UnitTesting.Shared.Resources
             File.WriteAllText(Path.Combine(_testDirPath, "dummy"), "foobar");
 
             // No, ../ does not work to read stuff in the parent dir.
-            Assert.That(() => _dirProvider.ReadAllText(new ResPath("/../dummy")),
+            Assert.That(() => _dirProvider.ReadAllText(new ResourcePath("/../dummy")),
                 Throws.InstanceOf<FileNotFoundException>());
         }
 
@@ -47,7 +47,7 @@ namespace Robust.UnitTesting.Shared.Resources
         public void TestNotRooted()
         {
             // Path must be rooted.
-            Assert.That(() => _dirProvider.OpenRead(new ResPath("foo.bar")),
+            Assert.That(() => _dirProvider.OpenRead(new ResourcePath("foo.bar")),
                 Throws.InstanceOf<ArgumentException>());
         }
 
@@ -56,10 +56,10 @@ namespace Robust.UnitTesting.Shared.Resources
         {
             File.WriteAllText(Path.Combine(_testDirPath, "dummy"), "foobar");
 
-            _dirProvider.WriteAllText(new ResPath("/dummy"), "pranked");
+            _dirProvider.WriteAllText(new ResourcePath("/dummy"), "pranked");
 
             // ../ should get clamped to /.
-            Assert.That(_dirProvider.ReadAllText(new ResPath("/../dummy")), Is.EqualTo("pranked"));
+            Assert.That(_dirProvider.ReadAllText(new ResourcePath("/../dummy")), Is.EqualTo("pranked"));
         }
     }
 }

--- a/Robust.UnitTesting/Shared/Utility/ResPathTest.cs
+++ b/Robust.UnitTesting/Shared/Utility/ResPathTest.cs
@@ -22,7 +22,7 @@ public sealed class ResPathTest
     public string ExtensionTest(string input)
     {
         var resPathExt = new ResPath(input).Extension;
-        var resourceExt = new ResPath(input).Extension;
+        var resourceExt = new ResourcePath(input).Extension;
         Assert.That(resPathExt, Is.EqualTo(resourceExt),
             message: "Found discrepancy between ResPath and ResourcePath Extension");
         return resPathExt;
@@ -42,6 +42,9 @@ public sealed class ResPathTest
     public string FilenameTest(string input)
     {
         var resPathFilename = new ResPath(input).Filename;
+        var resourceFilename = new ResourcePath(input).Filename;
+        Assert.That(resPathFilename, Is.EqualTo(resourceFilename),
+            message: "Found discrepancy between ResPath and ResourcePath Extension");
         return resPathFilename;
     }
 
@@ -58,7 +61,10 @@ public sealed class ResPathTest
     public string FilenameWithoutExtension(string input)
     {
         var resPathFileNoExt = new ResPath(input).FilenameWithoutExtension;
-        return resPathFileNoExt;
+        var resourceFileNoExt = new ResourcePath(input).FilenameWithoutExtension;
+        Assert.That(resPathFileNoExt, Is.EqualTo(resourceFileNoExt),
+            message: "Found discrepancy between ResPath and ResourcePath FilenameWithoutExtension methods");
+        return resourceFileNoExt;
     }
 
     [Test]
@@ -68,10 +74,12 @@ public sealed class ResPathTest
     [TestCase(@"/foo/bar/", ExpectedResult = @"/foo")]
     [TestCase(@"/foo/bar/x", ExpectedResult = @"/foo/bar")]
     [TestCase(@"/foo/bar.txt", ExpectedResult = @"/foo")]
-    [TestCase(@"/bar.txt", ExpectedResult = @"/")]
     public string DirectoryTest(string path)
     {
         var resPathDirectory = new ResPath(path).Directory.ToString();
+        var resourceDirectory = new ResourcePath(path).Directory.ToString();
+        Assert.That(resPathDirectory, Is.EqualTo(resourceDirectory),
+            message: "Found discrepancy between ResPath and ResourcePath Directory methods");
         return resPathDirectory;
     }
 
@@ -97,8 +105,6 @@ public sealed class ResPathTest
     [TestCase("/a/b", "z", ExpectedResult = "/a/b/z")]
     [TestCase("/a/b", "/z", ExpectedResult = "/z")]
     [TestCase("/a/b", ".", ExpectedResult = "/a/b")]
-    [TestCase("/", "/a", ExpectedResult = "/a")]
-    [TestCase("/", "a", ExpectedResult = "/a")]
     public string CombineTest(string left, string right)
     {
         var pathDivRes = new ResPath(left) / new ResPath(right);
@@ -128,7 +134,6 @@ public sealed class ResPathTest
     [TestCase("/a/b/c", "/", ExpectedResult = "a/b/c")]
     [TestCase("/a", "/a", ExpectedResult = ".")]
     [TestCase("a/b", "a", ExpectedResult = "b")]
-    [TestCase("/bar/", "/", ExpectedResult = "bar")]
     [TestCase("/Textures/Weapons/laser.png", "/Textures/", ExpectedResult = "Weapons/laser.png")]
     public string RelativeToTest(string source, string baseDir)
     {

--- a/Robust.UnitTesting/TestingModLoader.cs
+++ b/Robust.UnitTesting/TestingModLoader.cs
@@ -10,7 +10,7 @@ namespace Robust.UnitTesting
     {
         public Assembly[] Assemblies { get; set; } = Array.Empty<Assembly>();
 
-        public bool TryLoadModulesFrom(ResPath mountPath, string filterPrefix)
+        public bool TryLoadModulesFrom(ResourcePath mountPath, string filterPrefix)
         {
             foreach (var assembly in Assemblies)
             {


### PR DESCRIPTION
This reverts commit d6a3e1e286ee510e8f2fb4f447a7e48a66d19984.

# Conflicts:
#	Robust.Client/GameControllerOptions.cs
#	Robust.Server/ServerOptions.cs