### PR TITLE
Fix PVS concurrent update exception

### DIFF
--- a/Robust.Server/GameStates/PVSSystem.Ack.cs
+++ b/Robust.Server/GameStates/PVSSystem.Ack.cs
@@ -23,7 +23,7 @@ internal sealed partial class PVSSystem
             return;
 
         sessionData.LastReceivedAck = ackedTick;
-        _pendingAcks.Add(session);
+        PendingAcks.Add(session);
     }
 
     /// <summary>
@@ -32,8 +32,8 @@ internal sealed partial class PVSSystem
     internal void ProcessQueuedAcks()
     {
         var opts = new ParallelOptions {MaxDegreeOfParallelism = _parallelManager.ParallelProcessCount};
-        Parallel.ForEach(_pendingAcks, opts, ProcessQueuedAck);
-        _pendingAcks.Clear();
+        Parallel.ForEach(PendingAcks, opts, ProcessQueuedAck);
+        PendingAcks.Clear();
     }
 
     /// <summary>

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -100,7 +100,7 @@ internal sealed partial class PVSSystem : EntitySystem
     private readonly Dictionary<uint, Dictionary<MapChunkLocation, int>> _mapIndices = new(4);
     private readonly Dictionary<uint, Dictionary<GridChunkLocation, int>> _gridIndices = new(4);
     private readonly List<(uint, IChunkIndexLocation)> _chunkList = new(64);
-    private readonly HashSet<ICommonSession> _pendingAcks = new();
+    internal readonly HashSet<ICommonSession> PendingAcks = new();
 
     private ISawmill _sawmill = default!;
 

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -357,7 +357,13 @@ namespace Robust.Server.GameStates
             // large that it (or part of it) consistently gets dropped. When we send reliably, we immediately update the
             // ack so that the next state will not also be huge.
             if (stateUpdateMessage.ShouldSendReliably())
-                ClientAck?.Invoke(session, _gameTiming.CurTick);
+            {
+                sessionData.LastReceivedAck = _gameTiming.CurTick;
+                lock (_pvs.PendingAcks)
+                {
+                    _pvs.PendingAcks.Add(session);
+                }
+            }
 
             // Send PVS detach / left-view messages separately and reliably. This is not resistant to packet loss, but
             // unlike game state it doesn't really matter. This also significantly reduces the size of game state


### PR DESCRIPTION
Fixes an error introduced in #3936 by removing a necessary `lock()`