### PR TITLE
Fix pvs chunk update bug

### DIFF
--- a/Robust.Server/GameStates/PVSCollection.cs
+++ b/Robust.Server/GameStates/PVSCollection.cs
@@ -441,6 +441,8 @@ public sealed class PVSCollection<TIndex> : IPVSCollection where TIndex : ICompa
             oldGrid.ChunkIndices == chunkIndices &&
             oldGrid.GridId == gridId)
         {
+            _locationChangeBuffer.Remove(index);
+
             if (forceDirty)
                 _dirtyChunks.Add(oldGrid);
             return;
@@ -467,6 +469,8 @@ public sealed class PVSCollection<TIndex> : IPVSCollection where TIndex : ICompa
             oldMap.ChunkIndices == chunkIndices &&
             oldMap.MapId == mapId)
         {
+            _locationChangeBuffer.Remove(index);
+
             if (forceDirty)
                 _dirtyChunks.Add(oldMap);
             return;

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -609,6 +609,13 @@ internal sealed partial class PVSSystem : EntitySystem
         foreach (var uid in chunk)
         {
             AddToChunkSetRecursively(in uid, visMask, tree, chunkSet, transform, metadata);
+#if DEBUG
+            var xform = transform.GetComponent(uid);
+            if (chunkLocation is MapChunkLocation)
+                DebugTools.Assert(xform.GridUid == null || xform.GridUid == uid);
+            else if (chunkLocation is GridChunkLocation)
+                DebugTools.Assert(xform.GridUid != null && xform.ParentUid != xform.MapUid);
+#endif
         }
 
         if (tree.RootNodes.Count == 0)

--- a/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
@@ -84,16 +84,18 @@ internal sealed class SharedGridTraversalSystem : EntitySystem
         var parentIsMap = xform.GridUid == null && maps.HasComponent(xform.ParentUid);
         if (!parentIsMap && !grids.HasComponent(xform.ParentUid))
             return;
-        var mapPos = moveEvent.NewPosition.ToMapPos(EntityManager);
+        var mapPos = moveEvent.NewPosition.ToMapPos(EntityManager, _transform);
 
         // Change parent if necessary
         if (_mapManager.TryFindGridAt(xform.MapID, mapPos, out var grid))
         {
+            var gridUid = grid.Owner;
+
             // Some minor duplication here with AttachParent but only happens when going on/off grid so not a big deal ATM.
-            if (grid.Owner != xform.GridUid)
+            if (gridUid != xform.GridUid)
             {
-                _transform.SetParent(entity, xform, grid.Owner);
-                var ev = new ChangedGridEvent(entity, xform.GridUid, grid.Owner);
+                _transform.SetParent(entity, xform, gridUid, xforms);
+                var ev = new ChangedGridEvent(entity, xform.GridUid, gridUid);
                 RaiseLocalEvent(entity, ref ev, true);
             }
         }

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -512,6 +512,11 @@ public abstract partial class SharedTransformSystem
         if (!xform.Initialized)
             return;
 
+#if DEBUG
+        // If an entity is parented to the map, its grid uid should be null (unless it is itself a grid)
+        if (xform.ParentUid == xform.MapUid)
+            DebugTools.Assert(xform.GridUid == null || xform.GridUid == uid);
+#endif
         var newPosition = xform._parent.IsValid() ? new EntityCoordinates(xform._parent, xform._localPosition) : default;
         var moveEvent = new MoveEvent(uid, oldPosition, newPosition, oldRotation, xform._localRotation, xform, _gameTiming.ApplyingState);
         RaiseLocalEvent(uid, ref moveEvent, true);

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -98,7 +98,7 @@ namespace Robust.Shared.GameObjects
                 if (EntityManager.IsQueuedForDeletion(entity))
                     DetachParentToNull(entity, xform, xformQuery, metaQuery, gridXform);
                 else
-                    SetParent(entity, xform, mapTransform.Owner, parentXform: mapTransform);
+                    SetParent(entity, xform, gridXform.MapUid.Value, xformQuery, mapTransform);
             }
         }
 

--- a/Robust.UnitTesting/Server/GameStates/PvsSystemTests.cs
+++ b/Robust.UnitTesting/Server/GameStates/PvsSystemTests.cs
@@ -1,0 +1,125 @@
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Robust.Server.Player;
+using Robust.Shared;
+using Robust.Shared.Configuration;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Network;
+using cIPlayerManager = Robust.Client.Player.IPlayerManager;
+using sIPlayerManager = Robust.Server.Player.IPlayerManager;
+
+namespace Robust.UnitTesting.Server.GameStates;
+
+public sealed class PvsSystemTests : RobustIntegrationTest
+{
+    /// <summary>
+    /// Checks that there are no issues when an entity changes PVS chunk location multiple times in a single tick.
+    /// </summary>
+    [Test]
+    public async Task TestMultipleIndexChange()
+    {
+        var server = StartServer();
+        var client = StartClient();
+
+        await Task.WhenAll(client.WaitIdleAsync(), server.WaitIdleAsync());
+
+        var mapMan = server.ResolveDependency<IMapManager>();
+        var sEntMan = server.ResolveDependency<IEntityManager>();
+        var netMan = client.ResolveDependency<IClientNetManager>();
+        var confMan = server.ResolveDependency<IConfigurationManager>();
+        var cPlayerMan = client.ResolveDependency<cIPlayerManager>();
+        var sPlayerMan = server.ResolveDependency<sIPlayerManager>();
+        var xforms = sEntMan.System<SharedTransformSystem>();
+
+        Assert.DoesNotThrow(() => client.SetConnectTarget(server));
+        client.Post(() => netMan.ClientConnect(null!, 0, null!));
+        server.Post(() => confMan.SetCVar(CVars.NetPVS, true));
+
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        // Set up map and grid
+        EntityUid grid = default;
+        EntityUid map = default;
+        await server.WaitPost(() =>
+        {
+            var mapId = mapMan.CreateMap();
+            map = mapMan.GetMapEntityId(mapId);
+            var gridComp = mapMan.CreateGrid(mapId);
+            gridComp.SetTile(Vector2i.Zero, new Tile(1));
+            grid = gridComp.Owner;
+        });
+
+        // Spawn player entity on grid 1
+        EntityUid player = default;
+        EntityUid other = default;
+        TransformComponent otherXform = default!;
+        var gridCoords = new EntityCoordinates(grid, (0.5f, 0.5f));
+        var mapCoords = new EntityCoordinates(map, (2, 2));
+        await server.WaitPost(() =>
+        {
+            player = sEntMan.SpawnEntity("", gridCoords);
+            other = sEntMan.SpawnEntity("", gridCoords);
+            otherXform = sEntMan.GetComponent<TransformComponent>(other);
+
+            // Ensure map PVS chunk is not empty
+            sEntMan.SpawnEntity("", mapCoords);
+
+            // Attach player.
+            var session = (IPlayerSession) sPlayerMan.Sessions.First();
+            session.AttachToEntity(player);
+            session.JoinGame();
+        });
+
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        // Check player got properly attached
+        await client.WaitPost(() =>
+        {
+            var ent = cPlayerMan.LocalPlayer?.ControlledEntity;
+            Assert.That(ent, Is.EqualTo(player));
+        });
+
+        // Move the player off-grid and back onto the grid in the same tick
+        xforms.SetCoordinates(other, otherXform, mapCoords);
+        xforms.SetCoordinates(other, otherXform, gridCoords);
+
+        // Run for a few ticks. The test just checks that no PVS asserts/errors happen.
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        // Repeat but in the opposite direction ( map -> grid -> map )
+        // first move to map and wait a bit.
+        xforms.SetCoordinates(other, otherXform, mapCoords);
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        // Move to and off grid in the same tick
+        xforms.SetCoordinates(other, otherXform, gridCoords);
+        xforms.SetCoordinates(other, otherXform, mapCoords);
+
+        // wait for errors.
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+    }
+}
+

--- a/Robust.UnitTesting/Shared/Physics/BroadphaseNetworkingTest.cs
+++ b/Robust.UnitTesting/Shared/Physics/BroadphaseNetworkingTest.cs
@@ -92,7 +92,7 @@ public sealed class BroadphaseNetworkingTest : RobustIntegrationTest
             session.JoinGame();
         });
 
-        for (int i = 0; i < 100; i++)
+        for (int i = 0; i < 10; i++)
         {
             await server.WaitRunTicks(1);
             await client.WaitRunTicks(1);


### PR DESCRIPTION
Fixes a situations where PVS could add a single entity to both grid & map chunks. This then caused some debug asserts to fail with the message "Root node count is 2 instead of 1." 