### PR TITLE
'fix' transform coordinates assert

### DIFF
--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -614,7 +614,7 @@ internal sealed partial class PVSSystem : EntitySystem
             if (chunkLocation is MapChunkLocation)
                 DebugTools.Assert(xform.GridUid == null || xform.GridUid == uid);
             else if (chunkLocation is GridChunkLocation)
-                DebugTools.Assert(xform.GridUid != null && xform.ParentUid != xform.MapUid);
+                DebugTools.Assert(xform.GridUid != null);
 #endif
         }
 

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -614,7 +614,7 @@ internal sealed partial class PVSSystem : EntitySystem
             if (chunkLocation is MapChunkLocation)
                 DebugTools.Assert(xform.GridUid == null || xform.GridUid == uid);
             else if (chunkLocation is GridChunkLocation)
-                DebugTools.Assert(xform.GridUid != null);
+                DebugTools.Assert(xform.ParentUid != xform.MapUid || xform.GridUid == xform.MapUid);
 #endif
         }
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -512,11 +512,6 @@ public abstract partial class SharedTransformSystem
         if (!xform.Initialized)
             return;
 
-#if DEBUG
-        // If an entity is parented to the map, its grid uid should be null (unless it is itself a grid)
-        if (xform.ParentUid == xform.MapUid)
-            DebugTools.Assert(xform.GridUid == null || xform.GridUid == uid);
-#endif
         var newPosition = xform._parent.IsValid() ? new EntityCoordinates(xform._parent, xform._localPosition) : default;
         var moveEvent = new MoveEvent(uid, oldPosition, newPosition, oldRotation, xform._localRotation, xform, _gameTiming.ApplyingState);
         RaiseLocalEvent(uid, ref moveEvent, true);

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -513,6 +513,11 @@ public abstract partial class SharedTransformSystem
             return;
 
         var newPosition = xform._parent.IsValid() ? new EntityCoordinates(xform._parent, xform._localPosition) : default;
+#if DEBUG
+        // If an entity is parented to the map, its grid uid should be null (unless it is itself a grid or we have a map-grid)
+        if (xform.ParentUid == xform.MapUid)
+            DebugTools.Assert(xform.GridUid == null || xform.GridUid == uid || xform.GridUid == xform.MapUid);
+#endif
         var moveEvent = new MoveEvent(uid, oldPosition, newPosition, oldRotation, xform._localRotation, xform, _gameTiming.ApplyingState);
         RaiseLocalEvent(uid, ref moveEvent, true);
     }


### PR DESCRIPTION
Planetmaps function by adding gridcomponent to them hence can be both maps and grids at the same time.

Easiest way to repro is to spawn the salvate expedition console and pick a destruction mission.