### PR TITLE
Make VV auto-dirty components

### DIFF
--- a/Robust.Server/ViewVariables/ServerViewVariablesManager.cs
+++ b/Robust.Server/ViewVariables/ServerViewVariablesManager.cs
@@ -228,7 +228,7 @@ namespace Robust.Server.ViewVariables
 
             var sessionId = _nextSessionId++;
             var session = new ViewVariablesSession(message.MsgChannel.UserId, theObject, sessionId, this,
-                _robustSerializer);
+                _robustSerializer, _entityManager);
 
             _sessions.Add(sessionId, session);
 

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -297,7 +297,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="type">A trait or component type to check for.</param>
         /// <param name="component">Component of the specified type (if exists).</param>
         /// <returns>If the component existed in the entity.</returns>
-        bool TryGetComponent([NotNullWhen(true)] EntityUid uid, CompIdx type, [NotNullWhen(true)] out IComponent? component);
+        bool TryGetComponent(EntityUid uid, CompIdx type, [NotNullWhen(true)] out IComponent? component);
 
         /// <summary>
         ///     Returns the component of a specific type.

--- a/Robust.Shared/ViewVariables/ViewVariablesManager.TypeHandlers.cs
+++ b/Robust.Shared/ViewVariables/ViewVariablesManager.TypeHandlers.cs
@@ -34,7 +34,7 @@ internal abstract partial class ViewVariablesManager
             || !_entMan.TryGetComponent(uid, registration.Idx, out var component))
             return null;
 
-        return new ViewVariablesComponentPath(component, uid);
+        return new ViewVariablesComponentPath((Component) component, uid);
     }
 
     private IEnumerable<string> EntityComponentList(EntityUid uid)


### PR DESCRIPTION
VV now tries to automatically dirty relevant components when setting values., mainly to get rid of the boilerplate for simple VV-writable networked fields. When using the VV GUI with a component window open, it will automatically dirty the component that the window belongs to. Note that this means it will not automatically work when editing data nested in some other object. VV paths should try to automatically dirty the nearest component in the path and should work fine with nested objects. E.g., this should dirty the eye component but not the transform:
```
vvwrite /player/localhost@ElectroSR/AttachedEntity/Transform/Owner/Eye/Zoom 2,2
```
Similarly, this will dirty the fixture component even though this wouldn't work with the GUI because we are modifying the shape object instead of directly modifying a component. Note that this example requires actually making the radius field vv-writable first.
```
vvwrite /player/localhost@ElectroSR/AttachedEntity/Fixtures/Fixtures[fixture_1]/Shape/Radius 0.8
```
