### PR TITLE
Make map loading log errors on invalid UIDs

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -381,14 +381,7 @@ public sealed class MapLoaderSystem : EntitySystem
                 type = typeNode.Value;
             }
 
-            // TODO Fix this. If the entities are ever defined out of order, and if one of them does not have a
-            // "uid" node, then defaulting to Entities.Count will error.
-            var uid = data.Entities.Count;
-
-            if (entityDef.TryGet<ValueDataNode>("uid", out var uidNode))
-            {
-                uid = uidNode.AsInt();
-            }
+            var uid = entityDef.Get<ValueDataNode>("uid").AsInt();
 
             var entity = _serverEntityManager.AllocEntity(type);
             data.Entities.Add(entity);

--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -886,7 +886,7 @@ public sealed class MapLoaderSystem : EntitySystem
 
         RecursivePopulate(uid, entities, uidEntityMap, withoutUid, metaCompQuery, transformCompQuery, saveCompQuery);
 
-        var uidCounter = 0;
+        var uidCounter = 1;
         foreach (var entity in withoutUid)
         {
             while (uidEntityMap.ContainsKey(uidCounter))

--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -440,7 +440,10 @@ public sealed class MapLoaderSystem : EntitySystem
                             compType,
                             new[] { protData.Mapping }, datanode, _context);
                 }
+
+                _context.CurrentComponent = value;
                 _context.CurrentReadingEntityComponents[value] = (IComponent) _serManager.Read(compType, datanode, _context)!;
+                _context.CurrentComponent = null;
             }
         }
 
@@ -958,9 +961,9 @@ public sealed class MapLoaderSystem : EntitySystem
 
         var emptyMetaNode = _serManager.WriteValueAs<MappingDataNode>(typeof(MetaDataComponent), new MetaDataComponent(), alwaysWrite: true, context: _context);
 
-        _context.CurrentWritingComponent = _factory.GetComponentName(typeof(TransformComponent));
+        _context.CurrentComponent = _factory.GetComponentName(typeof(TransformComponent));
         var emptyXformNode = _serManager.WriteValueAs<MappingDataNode>(typeof(TransformComponent), new TransformComponent(), alwaysWrite: true, context: _context);
-        _context.CurrentWritingComponent = null;
+        _context.CurrentComponent = null;
 
         foreach (var (saveId, entityUid) in uidEntityMap.OrderBy( e=> e.Key))
         {
@@ -984,11 +987,11 @@ public sealed class MapLoaderSystem : EntitySystem
 
                     foreach (var (compType, comp) in prototype.Components)
                     {
-                        _context.CurrentWritingComponent = compType;
+                        _context.CurrentComponent = compType;
                         cache.Add(compType, _serManager.WriteValueAs<MappingDataNode>(comp.Component.GetType(), comp.Component, alwaysWrite: true, context: _context));
                     }
 
-                    _context.CurrentWritingComponent = null;
+                    _context.CurrentComponent = null;
                     cache.TryAdd("MetaData", emptyMetaNode);
                     cache.TryAdd("Transform", emptyXformNode);
                 }
@@ -1010,7 +1013,7 @@ public sealed class MapLoaderSystem : EntitySystem
 
                 var compType = component.GetType();
                 var compName = _factory.GetComponentName(compType);
-                _context.CurrentWritingComponent = compName;
+                _context.CurrentComponent = compName;
                 MappingDataNode? compMapping;
                 MappingDataNode? protMapping = null;
                 if (cache != null && cache.TryGetValue(compName, out protMapping))

--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -811,6 +811,10 @@ public sealed class MapLoaderSystem : EntitySystem
         var uidEntityMap = new Dictionary<int, EntityUid>();
         var entities = new List<EntityUid>();
 
+        var rootXform = _serverEntityManager.GetComponent<TransformComponent>(uid);
+        if (rootXform.ParentUid.IsValid())
+            uidEntityMap.Add(0, rootXform.ParentUid);
+
         _stopwatch.Restart();
         PopulateEntityList(uid, entities, uidEntityMap, entityUidMap);
         WriteTileMapSection(data, entities);

--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -368,7 +368,7 @@ public sealed class MapLoaderSystem : EntitySystem
         var entities = data.RootMappingNode.Get<SequenceDataNode>("entities");
         var mapUid = _mapManager.GetMapEntityId(data.TargetMap);
         var pauseTime = mapUid.IsValid() ? _meta.GetPauseTime(mapUid) : TimeSpan.Zero;
-        _context.Set(data.UidEntityMap, new Dictionary<EntityUid, int>(), pauseTime);
+        _context.Set(data.UidEntityMap, new Dictionary<EntityUid, int>(), pauseTime, null);
         data.Entities.EnsureCapacity(entities.Count);
         data.UidEntityMap.EnsureCapacity(entities.Count);
         data.EntitiesToDeserialize.EnsureCapacity(entities.Count);
@@ -804,17 +804,15 @@ public sealed class MapLoaderSystem : EntitySystem
         var uidEntityMap = new Dictionary<int, EntityUid>();
         var entities = new List<EntityUid>();
 
-        var rootXform = _serverEntityManager.GetComponent<TransformComponent>(uid);
-        if (rootXform.ParentUid.IsValid())
-            uidEntityMap.Add(0, rootXform.ParentUid);
-
         _stopwatch.Restart();
         PopulateEntityList(uid, entities, uidEntityMap, entityUidMap);
         WriteTileMapSection(data, entities);
 
         _logLoader.Debug($"Populated entity list in {_stopwatch.Elapsed}");
         var pauseTime = _meta.GetPauseTime(uid);
-        _context.Set(uidEntityMap, entityUidMap, pauseTime);
+
+        var rootXform = _serverEntityManager.GetComponent<TransformComponent>(uid);
+        _context.Set(uidEntityMap, entityUidMap, pauseTime, rootXform.ParentUid);
 
         _stopwatch.Restart();
         WriteEntitySection(data, uidEntityMap, entityUidMap);

--- a/Robust.Shared/Map/MapSerializationContext.cs
+++ b/Robust.Shared/Map/MapSerializationContext.cs
@@ -35,16 +35,24 @@ internal sealed class MapSerializationContext : ISerializationContext, IEntityLo
     /// </summary>
     public TimeSpan PauseTime;
 
+    /// <summary>
+    /// The parent of the entity being saved, This entity is not itself getting saved.
+    /// </summary>
+    private EntityUid? _parentUid;
+
     public MapSerializationContext()
     {
         SerializerProvider.RegisterSerializer(this);
     }
 
-    public void Set(Dictionary<int, EntityUid> uidEntityMap, Dictionary<EntityUid, int> entityUidMap, TimeSpan pauseTime)
+    public void Set(Dictionary<int, EntityUid> uidEntityMap, Dictionary<EntityUid, int> entityUidMap,
+        TimeSpan pauseTime, EntityUid? parentUid)
     {
         _uidEntityMap = uidEntityMap;
         _entityUidMap = entityUidMap;
         PauseTime = pauseTime;
+        if (parentUid != null && parentUid.Value.IsValid())
+            _parentUid = parentUid;
     }
 
     public void Clear()
@@ -94,12 +102,13 @@ internal sealed class MapSerializationContext : ISerializationContext, IEntityLo
     {
         if (!_entityUidMap.TryGetValue(value, out var entityUidMapped))
         {
-            // Terrible hack to mute this error on the grids themselves when serializing blueprints.
-            if (value.IsValid() || CurrentComponent != "Transform")
+            if (CurrentComponent == "Transform")
             {
-                Logger.ErrorS("map", "Encountered an invalid entityUid '{0}' while serializing a map.", value);
+                if (!value.IsValid() || value == _parentUid)
+                    return new ValueDataNode("invalid");
             }
 
+            Logger.ErrorS("map", "Encountered an invalid entityUid '{0}' while serializing a map.", value);
             return new ValueDataNode("invalid");
         }
 
@@ -112,14 +121,13 @@ internal sealed class MapSerializationContext : ISerializationContext, IEntityLo
         SerializationHookContext hookCtx,
         ISerializationContext? context, ISerializationManager.InstantiationDelegate<EntityUid>? _)
     {
-        int val = node.Value == "invalid" ? 0 : int.Parse(node.Value);
+        if (node.Value == "invalid" && CurrentComponent == "Transform")
+            return EntityUid.Invalid;
 
-        if (_uidEntityMap.TryGetValue(val, out var entity))
+        if (int.TryParse(node.Value, out var val) && _uidEntityMap.TryGetValue(val, out var entity))
             return entity;
 
-        if (CurrentComponent != "Transform" || val != 0)
-            Logger.ErrorS("map", "Error in map file: found local entity UID '{0}' which does not exist.", val);
-
+        Logger.ErrorS("map", "Error in map file: found local entity UID '{0}' which does not exist.", val);
         return EntityUid.Invalid;
 
     }

--- a/Robust.Shared/Map/MapSerializationContext.cs
+++ b/Robust.Shared/Map/MapSerializationContext.cs
@@ -119,7 +119,7 @@ internal sealed class MapSerializationContext : ISerializationContext, IEntityLo
 
         if (CurrentComponent != "Transform" || val != 0)
             Logger.ErrorS("map", "Error in map file: found local entity UID '{0}' which does not exist.", val);
-        
+
         return EntityUid.Invalid;
 
     }

--- a/Robust.Shared/Map/MapSerializationContext.cs
+++ b/Robust.Shared/Map/MapSerializationContext.cs
@@ -114,21 +114,14 @@ internal sealed class MapSerializationContext : ISerializationContext, IEntityLo
     {
         int val = node.Value == "invalid" ? 0 : int.Parse(node.Value);
 
-        if (val == 0)
-        {
-            if (CurrentComponent != "Transform")
-                Logger.ErrorS("map", "Error in map file: encountered an invalid entity uid", val);
+        if (_uidEntityMap.TryGetValue(val, out var entity))
+            return entity;
 
-            return EntityUid.Invalid;
-        }
-
-        if (!_uidEntityMap.TryGetValue(val, out var entity))
-        {
+        if (CurrentComponent != "Transform" || val != 0)
             Logger.ErrorS("map", "Error in map file: found local entity UID '{0}' which does not exist.", val);
-            return EntityUid.Invalid;
-        }
+        
+        return EntityUid.Invalid;
 
-        return entity;
     }
 
     [MustUseReturnValue]

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
+using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager;
@@ -244,7 +245,15 @@ namespace Robust.Shared.Prototypes
                 component = newComponent;
             }
 
+            if (context is not MapSerializationContext map)
+            {
+                serManager.CopyTo(data, ref component, context, notNullableOverride: true);
+                return;
+            }
+
+            map.CurrentComponent = compName;
             serManager.CopyTo(data, ref component, context, notNullableOverride: true);
+            map.CurrentComponent = null;
         }
 
         public override string ToString()

--- a/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
+++ b/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
@@ -99,11 +99,14 @@ entities:
             entMan.EnsureComponent<BroadphaseComponent>(mapUid);
 
             var mapLoad = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<MapLoaderSystem>();
-            var geid = mapLoad.LoadGrid(mapId, "/TestMap.yml");
+            if (!mapLoad.TryLoad(mapId, "/TestMap.yml", out var root)
+                || root.FirstOrDefault() is not { Valid:true } geid)
+            {
+                Assert.Fail();
+                return;
+            }
 
-            Assert.That(geid, NUnit.Framework.Is.Not.Null);
-
-            var entity = entMan.GetComponent<TransformComponent>(geid!.Value).Children.Single().Owner;
+            var entity = entMan.GetComponent<TransformComponent>(geid).Children.Single().Owner;
             var c = entMan.GetComponent<MapDeserializeTestComponent>(entity);
 
             Assert.That(c.Bar, Is.EqualTo(2));


### PR DESCRIPTION
We already error when saving with invalid UIDs, but not when loading them.
This should make sure that map-loading tests fail when people save bad maps.