### PR TITLE
Fix hidden action numbers by updating UI theme

### DIFF
--- a/Robust.Client/UserInterface/Control.cs
+++ b/Robust.Client/UserInterface/Control.cs
@@ -75,18 +75,9 @@ namespace Robust.Client.UserInterface
 
         public UITheme Theme { get; set; }
 
-        protected virtual void OnThemeUpdated(){}
-        internal void ThemeUpdateRecursive()
+        protected virtual void OnThemeUpdated()
         {
-            var curTheme = UserInterfaceManager.CurrentTheme;
-            if (Theme == curTheme) return; //don't update themes if the themes are up to date
-            Theme = curTheme;
-            OnThemeUpdated();
-            foreach (var child in Children)
-            {
-                // Don't descent into children that have a style sheet since those aren't affected.
-                child.ThemeUpdateRecursive();
-            }
+            Theme = UserInterfaceManager.CurrentTheme;
         }
 
         public NameScope? FindNameScope()
@@ -507,6 +498,8 @@ namespace Robust.Client.UserInterface
             Children = new OrderedChildCollection(this);
             Theme = UserInterfaceManagerInternal.CurrentTheme;
             XamlChildren = Children;
+
+            UserInterfaceManager.ThemeUpdated += OnThemeUpdated;
         }
 
         /// <summary>
@@ -563,6 +556,8 @@ namespace Robust.Client.UserInterface
             }
 
             UserInterfaceManagerInternal.HideTooltipFor(this);
+
+            UserInterfaceManager.ThemeUpdated -= OnThemeUpdated;
 
             DisposeAllChildren();
             Parent?.RemoveChild(this);

--- a/Robust.Client/UserInterface/Controls/TextureButton.cs
+++ b/Robust.Client/UserInterface/Controls/TextureButton.cs
@@ -47,8 +47,8 @@ namespace Robust.Client.UserInterface.Controls
 
         protected override void OnThemeUpdated()
         {
-            if (_texturePath != null) TextureNormal = Theme.ResolveTexture(_texturePath);
             base.OnThemeUpdated();
+            if (_texturePath != null) TextureNormal = Theme.ResolveTexture(_texturePath);
         }
         public string TexturePath
         {

--- a/Robust.Client/UserInterface/Controls/TextureRect.cs
+++ b/Robust.Client/UserInterface/Controls/TextureRect.cs
@@ -65,8 +65,8 @@ namespace Robust.Client.UserInterface.Controls
 
         protected override void OnThemeUpdated()
         {
-            if (_texturePath != null) Texture = Theme.ResolveTexture(_texturePath);
             base.OnThemeUpdated();
+            if (_texturePath != null) Texture = Theme.ResolveTexture(_texturePath);
         }
 
         /// <summary>

--- a/Robust.Client/UserInterface/IUserInterfaceManager.Themes.cs
+++ b/Robust.Client/UserInterface/IUserInterfaceManager.Themes.cs
@@ -1,4 +1,5 @@
 ﻿using Robust.Client.UserInterface.Themes;
+using System;
 
 namespace Robust.Client.UserInterface;
 
@@ -10,4 +11,5 @@ public partial interface IUserInterfaceManager
     public void SetActiveTheme(string themeName);
     public UITheme DefaultTheme { get; }
     public void SetDefaultTheme(string themeId);
+    public event Action? ThemeUpdated;
 }

--- a/Robust.Client/UserInterface/UserInterfaceManager.Themes.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Themes.cs
@@ -2,11 +2,13 @@
 using Robust.Client.UserInterface.Themes;
 using Robust.Shared;
 using Robust.Shared.Log;
+using System;
 
 namespace Robust.Client.UserInterface;
 
 internal partial class UserInterfaceManager
 {
+    public event Action? ThemeUpdated;
     private readonly Dictionary<string, UITheme> _themes = new();
 
     public UITheme CurrentTheme { get; private set; } = default!;
@@ -55,7 +57,8 @@ internal partial class UserInterfaceManager
     {
         if (newTheme == CurrentTheme) return; //do not update if the theme is unchanged
         CurrentTheme = newTheme;
-        _userInterfaceManager.RootControl.ThemeUpdateRecursive();
+        if (ThemeUpdated != null)
+            ThemeUpdated();
     }
 
     //Try to set the current theme, if the theme is not found leave the previous theme


### PR DESCRIPTION
Per [this bug](https://github.com/space-wizards/space-station-14/issues/15743), I discovered that action numbers were broken by [this change](https://github.com/space-wizards/RobustToolbox/pull/3940/files).

The reordering meant that when the action buttons are created, they were using Robust's "Default" theme instead of the "SS14DefaultTheme" theme.  That meant the normally off-white numbers text was displaying as fully transparent black text.

In theory, with the new init ordering, the ss14 theme should be applied and the new color settings applied... but theming only applies to elements attached to the UI tree.  And action buttons aren't attached at init time.  Thus, they stayed transparent black.

So, this PR changes how theme updates are pushed, so they are pushed to **all** UI elements (even ones that are not in the root UI tree yet).  Since if the UI theme is being changed, it seems like all UI elements would want to be aware of that.

NOTE 1 - This doesn't fix the issue where UI themes are not actually applied when selecting them via the options menu.  That has something to do with the ccvar not being listened to, I think (?), but is outside the scope of this change.

NOTE 2 - Now that the theme is actually being applied to elements instead of a null theme, a game [content update](https://github.com/space-wizards/space-station-14/pull/15840) for SS14 is also needed lest the wrong paths be tried.

NOTE 3 - This fix has somehow pushed upward the actionbar by 9px.  Somehow the BoxContainer is gaining a 9px, but I have no idea why.  I'm hacking around this by hacking the margin back -9px, but if anyone knows a proper solution I would prefer that ^.^  Here are some screenshots showing the mystery 9px sneaking in:

![actions-0](https://user-images.githubusercontent.com/22365940/235284260-27dbc939-ff3e-4a64-bbdd-244e6f465073.png)

![actions-1](https://user-images.githubusercontent.com/22365940/235284254-a0545095-a82c-4efe-8aff-f9abf104acfb.png)

![actions-2](https://user-images.githubusercontent.com/22365940/235284263-62a1c9d5-7219-457d-979b-a1e7aede171a.png)

