### PR TITLE
Fix prob definition inequality

### DIFF
--- a/Robust.Shared/Random/RandomExtensions.cs
+++ b/Robust.Shared/Random/RandomExtensions.cs
@@ -78,7 +78,7 @@ namespace Robust.Shared.Random
         {
             DebugTools.Assert(chance <= 1 && chance >= 0, $"Chance must be in the range 0-1. It was {chance}.");
 
-            return random.NextDouble() <= chance;
+            return random.NextDouble() < chance;
         }
 
         internal static void Shuffle<T>(Span<T> array, System.Random random)


### PR DESCRIPTION
Current implementation has a tiny teeny chance to return true even when chance is 0. Changing the inequality to `<` fixes this issue and does not introduce a new issue on the chance 1 end because `NextDouble()` returns numbers in the `[0, 1)` interval.