### PR TITLE
Generalize sprite view

### DIFF
--- a/Resources/EnginePrototypes/Debug/rotation.yml
+++ b/Resources/EnginePrototypes/Debug/rotation.yml
@@ -1,0 +1,53 @@
+- type: entity
+  id: debugRotation1
+  name: dbg_rotation1
+  suffix: DEBUG
+  components:
+  - type: Tag
+    tags:
+      - Debug
+  - type: Clickable
+  - type: InteractionOutline
+  - type: Sprite
+    netsync: false
+    visible: true
+    sprite: debugRotation.rsi
+    state: direction1
+  placement:
+    mode: AlignTileAny
+
+- type: entity
+  id: debugRotation4
+  name: dbg_rotation4
+  suffix: DEBUG
+  components:
+  - type: Tag
+    tags:
+      - Debug
+  - type: Clickable
+  - type: InteractionOutline
+  - type: Sprite
+    netsync: false
+    visible: true
+    sprite: debugRotation.rsi
+    state: direction4
+  placement:
+    mode: AlignTileAny
+
+- type: entity
+  id: debugRotationTex
+  name: dbg_rotationTex
+  suffix: DEBUG
+  components:
+  - type: Tag
+    tags:
+      - Debug
+  - type: Clickable
+  - type: InteractionOutline
+  - type: Sprite
+    netsync: false
+    visible: true
+    sprite: debugRotation.rsi
+    state: direction1
+  placement:
+    mode: AlignTileAny

--- a/Resources/EnginePrototypes/Debug/rotation.yml
+++ b/Resources/EnginePrototypes/Debug/rotation.yml
@@ -1,53 +1,34 @@
 - type: entity
-  id: debugRotation1
-  name: dbg_rotation1
+  id: debugRotation
+  abstract: true
   suffix: DEBUG
   components:
-  - type: Tag
-    tags:
-      - Debug
-  - type: Clickable
-  - type: InteractionOutline
   - type: Sprite
     netsync: false
     visible: true
     sprite: debugRotation.rsi
     state: direction1
-  placement:
-    mode: AlignTileAny
+
+- type: entity
+  id: debugRotation1
+  parent: debugRotation
+  name: dbg_rotation1
+  components:
+  - type: Sprite
+    state: direction1
 
 - type: entity
   id: debugRotation4
+  parent: debugRotation
   name: dbg_rotation4
-  suffix: DEBUG
   components:
-  - type: Tag
-    tags:
-      - Debug
-  - type: Clickable
-  - type: InteractionOutline
   - type: Sprite
-    netsync: false
-    visible: true
-    sprite: debugRotation.rsi
     state: direction4
-  placement:
-    mode: AlignTileAny
 
 - type: entity
   id: debugRotationTex
+  parent: debugRotation
   name: dbg_rotationTex
-  suffix: DEBUG
   components:
-  - type: Tag
-    tags:
-      - Debug
-  - type: Clickable
-  - type: InteractionOutline
   - type: Sprite
-    netsync: false
-    visible: true
-    sprite: debugRotation.rsi
     state: direction1
-  placement:
-    mode: AlignTileAny

--- a/Robust.Client/Console/Commands/UITestCommand.TabSpriteView.cs
+++ b/Robust.Client/Console/Commands/UITestCommand.TabSpriteView.cs
@@ -52,8 +52,9 @@ internal sealed partial class UITestControl
 
             _box.AddChild(new Label
             {
-                Text = "This control contains a bunch of sprite views with different transform (rotation) and sprite\n"+
-                       "based transformations applied. Except for the fixed-size no-stretch view, the sprites should never leave the boxes.\n"
+                Text = "This control contains a bunch of sprite views. They are grouped based on SpriteView properties.\n" +
+                       "Each group has views with different rotation and sprite transformations applied.\n" +
+                       "Except for the fixed-size no-stretch view, the sprites should never leave the boxes.\n"
             });
 
             _box.AddChild(new Label

--- a/Robust.Client/Console/Commands/UITestCommand.TabSpriteView.cs
+++ b/Robust.Client/Console/Commands/UITestCommand.TabSpriteView.cs
@@ -95,7 +95,7 @@ internal sealed partial class UITestControl
             _box.AddChild(new Label
             {
                 Text = "============================\n" +
-                       "No override + Transform + Fixed Size + No Stretch.\n" +
+                       "No override + Transform + Fixed Size + No Stretch (sprites can leave).\n" +
                        "============================"
             });
 

--- a/Robust.Client/Console/Commands/UITestCommand.TabSpriteView.cs
+++ b/Robust.Client/Console/Commands/UITestCommand.TabSpriteView.cs
@@ -1,0 +1,255 @@
+﻿using System;
+using System.Collections.Generic;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Timing;
+
+namespace Robust.Client.Console.Commands;
+
+internal sealed partial class UITestControl
+{
+    private sealed class TabSpriteView : Control
+    {
+        private const string EntityId = "debugRotation4";
+
+        private readonly IEntityManager _entMan;
+        private readonly BoxContainer _box;
+
+        private record Entry(EntityUid Uid, SpriteComponent Sprite, TransformComponent Transform,
+            SpriteView View, Action<Entry, float>? Update);
+
+        private List<Entry> _entries = new();
+
+        private float _degreesPerSecond = 45;
+
+        public TabSpriteView()
+        {
+            IoCManager.Resolve(ref _entMan);
+            SetValue(TabContainer.TabTitleProperty, nameof(SpriteView));
+            _box = new BoxContainer
+            {
+                Orientation = BoxContainer.LayoutOrientation.Vertical,
+                Margin = new Thickness(10),
+            };
+            AddChild(new ScrollContainer() { Children = { _box }});
+
+            var level = IoCManager.Resolve<IBaseClient>().RunLevel;
+            if (level != ClientRunLevel.InGame && level != ClientRunLevel.SinglePlayerGame)
+            {
+                _box.AddChild(new Label
+                {
+                    Text = "You need to be in-game for this UI to work."
+                });
+                return;
+            }
+
+            _box.AddChild(new Label
+            {
+                Text = "============================\n" +
+                       "Default SpriteView arguments\n" +// override sprite offset, world rotation, fit to control
+                       "============================"
+            });
+            AddEntries();
+
+            _box.AddChild(new Label
+            {
+                Text = "============================\n" +
+                       " Respect entity properties  \n" +// no overrides for offset, rotation, but still fit to control.
+                       "============================"
+            });
+            var added = AddEntries();
+            foreach (var e in added)
+            {
+                e.View.SpriteOffset = true;
+                e.View.WorldRotation = null;
+            }
+
+            _box.AddChild(new Label
+            {
+                Text = "============================\n" +
+                       "   Transformed SpriteView   \n" +// Default + view transform
+                       "============================"
+            });
+            added = AddEntries();
+            foreach (var e in added)
+            {
+                e.View.Scale = (1,2);
+                e.View.EyeRotation = Angle.FromDegrees(45);
+                e.View.Offset = (40, 10);
+                e.View.WorldRotation = null;
+            }
+
+            _box.AddChild(new Label
+            {
+                Text = "============================\n" +
+                       "   64 x 64   - No Stretch   \n" +// as above, but with a fixed UI size & different stretch modes.
+                       "==========================="
+            });
+            added = AddEntries();
+            foreach (var e in added)
+            {
+                e.View.SetSize = (64, 64);
+                e.View.Stretch = SpriteView.StretchMode.None;
+                e.View.Scale = (1,2);
+                e.View.EyeRotation = Angle.FromDegrees(45);
+                e.View.Offset = (40, 10);
+                e.View.WorldRotation = null;
+            }
+
+            _box.AddChild(new Label
+            {
+                Text = "============================\n" +
+                       "  32 x 32   -  Fit to view  \n" +
+                       "==========================="
+            });
+            added = AddEntries();
+            foreach (var e in added)
+            {
+                e.View.SetSize = (32, 32);
+                e.View.Stretch = SpriteView.StretchMode.Fit;
+                e.View.Scale = (1,2);
+                e.View.EyeRotation = Angle.FromDegrees(45);
+                e.View.Offset = (40, 10);
+                e.View.WorldRotation = null;
+            }
+
+            _box.AddChild(new Label
+            {
+                Text = "============================\n" +
+                       "  128 x 128   -   Fill view \n" +
+                       "==========================="
+            });
+            added = AddEntries();
+            foreach (var e in added)
+            {
+                e.View.SetSize = (96, 96);
+                e.View.Stretch = SpriteView.StretchMode.Fill;
+                e.View.Scale = (1,2);
+                e.View.EyeRotation = Angle.FromDegrees(45);
+                e.View.Offset = (40, 10);
+                e.View.WorldRotation = null;
+            }
+        }
+
+        public void OnClosed()
+        {
+            foreach (var e in _entries)
+            {
+                _entMan.DeleteEntity(e.Uid);
+            }
+        }
+
+        private List<Entry> AddEntries()
+        {
+            var added = new List<Entry>();
+
+            var entry = AddEntry("Default", null);
+            added.Add(entry);
+
+            entry = AddEntry("World Rotated", (e, time) =>
+            {
+                e.Transform.LocalRotation += time;
+                e.View.InvalidateMeasure();
+            });
+            added.Add(entry);
+
+            entry = AddEntry("World Rotated (NoRot)", (e, time) =>
+            {
+                e.Transform.LocalRotation = Angle.FromDegrees(time * _degreesPerSecond);
+                e.View.InvalidateMeasure();
+            });
+            entry.Sprite.NoRotation = true;
+            added.Add(entry);
+
+            entry = AddEntry("Offset", (e, time) =>
+            {
+                e.Sprite.Offset = Angle.FromDegrees(time * _degreesPerSecond).RotateVec(Vector2.One);
+                e.View.InvalidateMeasure();
+            });
+            added.Add(entry);
+
+            entry = AddEntry("Scaled", (e, time) =>
+            {
+                var theta = (float) Angle.FromDegrees(_degreesPerSecond * time).Theta;
+                e.Sprite.Scale = Vector2.One * 1.5f + (MathF.Sin(theta), MathF.Cos(theta));
+                e.View.InvalidateMeasure();
+            });
+            added.Add(entry);
+
+            entry = AddEntry("Rotated", (e, time) =>
+            {
+                e.Sprite.Rotation = Angle.FromDegrees(time * _degreesPerSecond);
+            });
+            added.Add(entry);
+
+            entry = AddEntry("Combination", (e, time) =>
+            {
+                var theta = (float) Angle.FromDegrees(_degreesPerSecond * time * 2).Theta;
+                e.Sprite.Scale = Vector2.One * 1.5f + (MathF.Sin(theta), MathF.Cos(theta));
+                e.Sprite.Offset = Angle.FromDegrees(time * _degreesPerSecond).RotateVec(Vector2.One);
+                e.Sprite.Rotation = Angle.FromDegrees(0.5 * time * _degreesPerSecond);
+                e.Transform.LocalRotation = Angle.FromDegrees(0.25 * time * _degreesPerSecond);
+                e.View.InvalidateMeasure();
+            });
+            added.Add(entry);
+
+            return added;
+        }
+
+        protected override void FrameUpdate(FrameEventArgs args)
+        {
+            base.FrameUpdate(args);
+            foreach (var entry in _entries)
+            {
+                entry.Update?.Invoke(entry, args.DeltaSeconds);
+            }
+        }
+
+        private Entry AddEntry(string text, Action<Entry, float>? onUpdate)
+        {
+            var box = new BoxContainer
+            {
+                Orientation = BoxContainer.LayoutOrientation.Horizontal,
+                Margin = new Thickness(10)
+            };
+
+            var label = new Label()
+            {
+                MinWidth = 200,
+                Text = text
+            };
+
+            var ent = _entMan.SpawnEntity(EntityId, MapCoordinates.Nullspace);
+            var view = new SpriteView();
+            view.SetEntity(ent);
+
+            var viewBox = new PanelContainer()
+            {
+                Children = { view },
+                PanelOverride = new StyleBoxFlat
+                {
+                    BackgroundColor = Color.White,
+                    BorderColor = Color.Black,
+                    BorderThickness = new(4),
+                }
+            };
+
+            box.AddChild(label);
+            box.AddChild(viewBox);
+            box.Name = text;
+            _box.AddChild(box);
+
+            var sprite = _entMan.GetComponent<SpriteComponent>(ent);
+            var xform = _entMan.GetComponent<TransformComponent>(ent);
+            var entry = new Entry(ent, sprite, xform, view, onUpdate);
+            _entries.Add(entry);
+            return entry;
+        }
+    }
+}

--- a/Robust.Client/Console/Commands/UITestCommand.cs
+++ b/Robust.Client/Console/Commands/UITestCommand.cs
@@ -11,7 +11,7 @@ using Robust.Shared.Utility;
 
 namespace Robust.Client.Console.Commands;
 
-internal sealed class UITestControl : Control
+internal sealed partial class UITestControl : Control
 {
     private const string Lipsum = @"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer sed interdum diam. Duis erat risus, tincidunt at pulvinar non, accumsan non dui. Morbi feugiat nisi in odio consectetur, ac suscipit nulla mollis. Nulla consequat neque sit amet neque venenatis feugiat. Proin placerat eget mauris sit amet tincidunt. Sed pulvinar purus sed ex varius, et lobortis risus efficitur. Integer blandit eu neque quis elementum. Vivamus lacinia sem non lacinia eleifend. Integer sit amet est ac risus tempus iaculis sed quis leo. Proin eu dui tincidunt orci ornare elementum. Curabitur molestie enim scelerisque, porttitor ipsum vitae, posuere libero. Donec finibus placerat accumsan. Nam et arcu lacus.
 
@@ -26,6 +26,7 @@ Suspendisse hendrerit blandit urna ut laoreet. Suspendisse ac elit at erat males
 
 
     private readonly TabContainer _tabContainer;
+    private readonly TabSpriteView _sprite;
 
     public UITestControl()
     {
@@ -150,6 +151,14 @@ Suspendisse hendrerit blandit urna ut laoreet. Suspendisse ac elit at erat males
 
         _tabContainer.AddChild(TabTextEdit());
         _tabContainer.AddChild(TabRichText());
+
+        _sprite = new TabSpriteView();
+        _tabContainer.AddChild(_sprite);
+    }
+
+    public void OnClosed()
+    {
+        _sprite.OnClosed();
     }
 
     private Control TabTextEdit()
@@ -216,6 +225,7 @@ Suspendisse hendrerit blandit urna ut laoreet. Suspendisse ac elit at erat males
         Untitled4 = 5,
         TextEdit = 6,
         RichText = 7,
+        SpriteView = 8,
     }
 }
 
@@ -225,8 +235,10 @@ internal sealed class UITestCommand : LocalizedCommands
 
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        var window = new DefaultWindow { MinSize = (500, 400) };
-        window.Contents.AddChild(new UITestControl());
+        var window = new DefaultWindow { MinSize = (800, 600) };
+        var control = new UITestControl();
+        window.OnClose += control.OnClosed;
+        window.Contents.AddChild(control);
 
         window.OpenCentered();
     }
@@ -267,7 +279,7 @@ internal sealed class UITest2Command : LocalizedCommands
 
         var root = _uiMgr.CreateWindowRoot(window);
         window.DisposeOnClose = true;
-
+        window.RequestClosed += _ => control.OnClosed();
         root.AddChild(control);
     }
 

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -258,6 +258,10 @@ namespace Robust.Client.GameObjects
 
         private Box2 _bounds;
 
+        /// <summary>
+        ///     The bounds of the sprite. This does factor in the sprite's <see cref="Scale"/> but not the
+        ///     <see cref="Rotation"/> and <see cref="Offset"/>
+        /// </summary>
         public Box2 Bounds => _bounds;
 
         [ViewVariables(VVAccess.ReadWrite)] internal bool _inertUpdateQueued;

--- a/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
@@ -175,13 +175,13 @@ namespace Robust.Client.Graphics.Clyde
 
                     var ofsX = position.X - _clyde._currentRenderTarget.Size.X / 2f;
                     var ofsY = position.Y - _clyde._currentRenderTarget.Size.Y / 2f;
+                    ofsX /= EyeManager.PixelsPerMeter;
+                    ofsY /= -EyeManager.PixelsPerMeter;
 
-                    var view = Matrix3.Identity;
-                    view.R0C0 = scale.X;
-                    view.R1C1 = scale.Y;
-                    view.R0C2 = ofsX / EyeManager.PixelsPerMeter;
-                    view.R1C2 = -ofsY / EyeManager.PixelsPerMeter;
+                    // Maaaaybe this is meant to have a minus sign.
+                    var rot = -(float) eyeRot.Theta;
 
+                    var view = Matrix3.CreateTransform(ofsX, ofsY, rot, scale.X, scale.Y);
                     SetProjView(proj, view);
                 }
 

--- a/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
@@ -125,14 +125,39 @@ namespace Robust.Client.Graphics.Clyde
                 _clyde.DrawSetScissor(scissorBox);
             }
 
-            public void DrawEntity(EntityUid entity, Vector2 position, Vector2 scale, Direction? overrideDirection)
+            /// <summary>
+            /// Draws an entity.
+            /// </summary>
+            /// <param name="entity">The entity to draw</param>
+            /// <param name="position">The local pixel position where the entity should be drawn.</param>
+            /// <param name="scale">Scales the drawn entity</param>
+            /// <param name="worldRot">The world rotation to use when drawing the entity.
+            /// This impacts the sprites RSI direction. Null will retrieve the entity's actual rotation.
+            /// </param>
+            /// <param name="eyeRot">The effective "eye" angle.
+            /// This will cause the entity to be rotated, and may also affect the RSI directions.
+            /// Draws the entity at some given angle.</param>
+            /// <param name="overrideDirection">RSI direction override.</param>
+            /// <param name="sprite">The entity's sprite component</param>
+            /// <param name="xform">The entity's transform component.
+            /// Only required if <see cref="overrideDirection"/> is null.</param>
+            /// <param name="xformSystem">The transform system</param>
+            public void DrawEntity(EntityUid entity,
+                Vector2 position,
+                Vector2 scale,
+                Angle? worldRot,
+                Angle eyeRot = default,
+                Direction? overrideDirection = null,
+                SpriteComponent? sprite = null,
+                TransformComponent? xform = null,
+                SharedTransformSystem? xformSystem = null)
             {
                 if (_entities.Deleted(entity))
                 {
                     throw new ArgumentException("Tried to draw an entity has been deleted.", nameof(entity));
                 }
 
-                var sprite = _entities.GetComponent<SpriteComponent>(entity);
+                sprite ??= _entities.GetComponent<SpriteComponent>(entity);
 
                 var oldProj = _clyde._currentMatrixProj;
                 var oldView = _clyde._currentMatrixView;
@@ -160,13 +185,19 @@ namespace Robust.Client.Graphics.Clyde
                     SetProjView(proj, view);
                 }
 
+                if (worldRot == null)
+                {
+                    xformSystem ??= _entities.System<SharedTransformSystem>();
+                    var query = _entities.GetEntityQuery<TransformComponent>();
+                    xform ??= query.GetComponent(entity);
+                    worldRot = xformSystem.GetWorldRotation(xform, query);
+                }
+
                 // Draw the entity.
                 sprite.Render(
                     DrawingHandleWorld,
-                    Angle.Zero,
-                    overrideDirection == null
-                        ? _entities.GetComponent<TransformComponent>(entity).WorldRotation
-                        : Angle.Zero,
+                    eyeRot,
+                    worldRot.Value,
                     overrideDirection);
 
                 // Reset to screen space
@@ -301,9 +332,34 @@ namespace Robust.Client.Graphics.Clyde
                         rect.BottomLeft, rect.BottomRight, color, subRegion);
                 }
 
-                public override void DrawEntity(EntityUid entity, Vector2 position, Vector2 scale, Direction? overrideDirection)
+                /// <summary>
+                /// Draws an entity.
+                /// </summary>
+                /// <param name="entity">The entity to draw</param>
+                /// <param name="position">The local pixel position where the entity should be drawn.</param>
+                /// <param name="scale">Scales the drawn entity</param>
+                /// <param name="worldRot">The world rotation to use when drawing the entity.
+                /// This impacts the sprites RSI direction. Null will retrieve the entity's actual rotation.
+                /// </param>
+                /// <param name="eyeRot">The effective "eye" angle.
+                /// This will cause the entity to be rotated, and may also affect the RSI directions.
+                /// Draws the entity at some given angle.</param>
+                /// <param name="overrideDirection">RSI direction override.</param>
+                /// <param name="sprite">The entity's sprite component</param>
+                /// <param name="xform">The entity's transform component.
+                /// Only required if <see cref="overrideDirection"/> is null.</param>
+                /// <param name="xformSystem">The transform system</param>
+                public override void DrawEntity(EntityUid entity,
+                    Vector2 position,
+                    Vector2 scale,
+                    Angle? worldRot,
+                    Angle eyeRot = default,
+                    Direction? overrideDirection = null,
+                    SpriteComponent? sprite = null,
+                    TransformComponent? xform = null,
+                    SharedTransformSystem? xformSystem = null)
                 {
-                    _renderHandle.DrawEntity(entity, position, scale, overrideDirection);
+                    _renderHandle.DrawEntity(entity, position, scale, worldRot, eyeRot, overrideDirection, sprite, xform, xformSystem);
                 }
             }
 

--- a/Robust.Client/Graphics/Drawing/DrawingHandleScreen.cs
+++ b/Robust.Client/Graphics/Drawing/DrawingHandleScreen.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Maths;
 
@@ -126,6 +127,31 @@ namespace Robust.Client.Graphics
             return advanceTotal;
         }
 
-        public abstract void DrawEntity(EntityUid entity, Vector2 position, Vector2 scale, Direction? overrideDirection);
+        /// <summary>
+        /// Draws an entity.
+        /// </summary>
+        /// <param name="entity">The entity to draw</param>
+        /// <param name="position">The local pixel position where the entity should be drawn.</param>
+        /// <param name="scale">Scales the drawn entity</param>
+        /// <param name="worldRot">The world rotation to use when drawing the entity.
+        /// This impacts the sprites RSI direction. Null will retrieve the entity's actual rotation.
+        /// </param>
+        /// <param name="eyeRotation">The effective "eye" angle.
+        /// This will cause the entity to be rotated, and may also affect the RSI directions.
+        /// Draws the entity at some given angle.</param>
+        /// <param name="overrideDirection">RSI direction override.</param>
+        /// <param name="sprite">The entity's sprite component</param>
+        /// <param name="xform">The entity's transform component.
+        /// Only required if <see cref="overrideDirection"/> is null.</param>
+        /// <param name="xformSystem">The transform system</param>
+        public abstract void DrawEntity(EntityUid entity,
+            Vector2 position,
+            Vector2 scale,
+            Angle? worldRot,
+            Angle eyeRotation = default,
+            Direction? overrideDirection = null,
+            SpriteComponent? sprite = null,
+            TransformComponent? xform = null,
+            SharedTransformSystem? xformSystem = null);
     }
 }

--- a/Robust.Client/Graphics/IRenderHandle.cs
+++ b/Robust.Client/Graphics/IRenderHandle.cs
@@ -1,4 +1,5 @@
 using System;
+using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Maths;
 
@@ -12,6 +13,32 @@ namespace Robust.Client.Graphics
         void RenderInRenderTarget(IRenderTarget target, Action a, Color? clearColor);
 
         void SetScissor(UIBox2i? scissorBox);
-        void DrawEntity(EntityUid entity, Vector2 position, Vector2 scale, Direction? overrideDirection);
+
+        /// <summary>
+        /// Draws an entity.
+        /// </summary>
+        /// <param name="entity">The entity to draw</param>
+        /// <param name="position">The local pixel position where the entity should be drawn.</param>
+        /// <param name="scale">Scales the drawn entity</param>
+        /// <param name="worldRot">The world rotation to use when drawing the entity.
+        /// This impacts the sprites RSI direction. Null will retrieve the entity's actual rotation.
+        /// </param>
+        /// <param name="eyeRotation">The effective "eye" angle.
+        /// This will cause the entity to be rotated, and may also affect the RSI directions.
+        /// Draws the entity at some given angle.</param>
+        /// <param name="overrideDirection">RSI direction override.</param>
+        /// <param name="sprite">The entity's sprite component</param>
+        /// <param name="xform">The entity's transform component.
+        /// Only required if <see cref="overrideDirection"/> is null.</param>
+        /// <param name="xformSystem">The transform system</param>
+        void DrawEntity(EntityUid entity,
+            Vector2 position,
+            Vector2 scale,
+            Angle? worldRot,
+            Angle eyeRotation = default,
+            Direction? overrideDirection = null,
+            SpriteComponent? sprite = null,
+            TransformComponent? xform = null,
+            SharedTransformSystem? xformSystem = null);
     }
 }

--- a/Robust.Client/UserInterface/Controls/SpriteView.cs
+++ b/Robust.Client/UserInterface/Controls/SpriteView.cs
@@ -77,7 +77,7 @@ namespace Robust.Client.UserInterface.Controls
         }
 
         /// <summary>
-        /// used to override the entity's world rotation. Note that the desired size of the control will not
+        /// Used to override the entity's world rotation. Note that the desired size of the control will not
         /// automatically get updated as the entity's world rotation changes.
         /// </summary>
         public Angle? WorldRotation

--- a/Robust.Client/UserInterface/Controls/SpriteView.cs
+++ b/Robust.Client/UserInterface/Controls/SpriteView.cs
@@ -169,7 +169,8 @@ namespace Robust.Client.UserInterface.Controls
             DebugTools.Assert(box.Contains(Vector2.Zero));
             DebugTools.Assert(box.TopLeft.EqualsApprox(-box.BottomRight));
 
-            if (_worldRotation != null)
+            if (_worldRotation != null
+                && _eyeRotation == Angle.Zero) // TODO This shouldn't need to be here, but I just give up at this point I am going fucking insane looking at rotating blobs of pixels. I doubt anyone will ever even use rotated sprite views.?
             {
                 _spriteSize = box.Size;
                 return;
@@ -205,7 +206,10 @@ namespace Robust.Client.UserInterface.Controls
                 _ => Vector2.One,
             };
 
-            var offset = SpriteOffset ? Vector2.Zero : - _sprite.Offset * (1, -1) * EyeManager.PixelsPerMeter;
+            var offset = SpriteOffset
+                ? Vector2.Zero
+                : - (-_eyeRotation).RotateVec(_sprite.Offset) * (1, -1) * EyeManager.PixelsPerMeter;
+
             var position = PixelSize / 2 + offset * stretch * UIScale;
             var scale = Scale * UIScale * stretch;
             renderHandle.DrawEntity(uid, position, scale, _worldRotation, _eyeRotation, OverrideDirection, _sprite);

--- a/Robust.Client/UserInterface/Controls/SpriteView.cs
+++ b/Robust.Client/UserInterface/Controls/SpriteView.cs
@@ -1,9 +1,10 @@
+using System;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Maths;
-using Robust.Shared.ViewVariables;
+using Robust.Shared.Utility;
 
 namespace Robust.Client.UserInterface.Controls
 {
@@ -11,9 +12,103 @@ namespace Robust.Client.UserInterface.Controls
     public class SpriteView : Control
     {
         private SpriteSystem? _spriteSystem;
+        private SharedTransformSystem? _transformSystem;
+        IEntityManager _entMan;
 
-        private Vector2 _scale = (1, 1);
+        private SpriteComponent? _sprite;
+        public SpriteComponent? Sprite
+        {
+            get => _sprite;
+            [Obsolete("Use SetEntity()")]
+            set => SetEntity(value?.Owner);
+        }
 
+        public EntityUid? Entity { get; private set; }
+
+        /// <summary>
+        /// If true this will scale the sprite up or down to fit within the control's actual size.
+        /// </summary>
+        public StretchMode Stretch  { get; set; } = StretchMode.Fit;
+
+        public enum StretchMode
+        {
+            /// <summary>
+            /// Don't scale the sprite at all.
+            /// </summary>
+            None,
+
+            /// <summary>
+            /// Scales the sprite down so that it fits within the control. Does not scale the sprite up.
+            /// </summary>
+            Fit,
+
+            /// <summary>
+            ///  Scale the sprite so that it fills the whole control.
+            /// </summary>
+            Fill
+        }
+
+        /// <summary>
+        /// Overrides the direction used to render the sprite.
+        /// </summary>
+        /// <remarks>
+        /// If null, the world space orientation of the entity will be used. Otherwise the specified direction will be
+        /// used.
+        /// </remarks>
+        public Direction? OverrideDirection { get; set; }
+
+        #region Transform
+
+        private Vector2 _offset = Vector2.Zero;
+        private Vector2 _scale = Vector2.One;
+        private Angle _eyeRotation = Angle.Zero;
+        private Angle? _worldRotation = Angle.Zero;
+
+        /// <summary>
+        /// If true, the offset scale and rotations are also applied when calculating the control's desired size.
+        /// </summary>
+        public bool TransformMeasure = true;
+
+        /// <summary>
+        /// Offset to apply when rendering the sprite, in virtual pixels. This is separate from the sprite's offset.
+        /// </summary>
+        public Vector2 Offset
+        {
+            get => _offset;
+            set
+            {
+                _offset = value;
+                InvalidateMeasure();
+            }
+        }
+
+        public Angle EyeRotation
+        {
+            get => _eyeRotation;
+            set
+            {
+                _eyeRotation = value;
+                InvalidateMeasure();
+            }
+        }
+
+        /// <summary>
+        /// used to override the entity's world rotation. Note that the desired size of the control will not
+        /// automatically get updated as the entity's world rotation changes.
+        /// </summary>
+        public Angle? WorldRotation
+        {
+            get => _worldRotation;
+            set
+            {
+                _worldRotation = value;
+                InvalidateMeasure();
+            }
+        }
+
+        /// <summary>
+        /// Scale to apply when rendering the sprite. This is separate from the sprite's scale.
+        /// </summary>
         public Vector2 Scale
         {
             get => _scale;
@@ -24,55 +119,101 @@ namespace Robust.Client.UserInterface.Controls
             }
         }
 
-        [ViewVariables]
-        public SpriteComponent? Sprite { get; set; }
+        /// <summary>
+        /// Cached desired size. Differs from <see cref="Control.DesiredSize"/> as it it is not clamped by the
+        /// minimum/maximum size options.
+        /// </summary>
+        private Vector2 _spriteSize;
 
         /// <summary>
-        /// Should the sprite's offset be applied to the control.
+        /// Determines whether or not the sprite's offset be applied to the control.
         /// </summary>
-        public bool SpriteOffset { get; set; } = true;
+        public bool SpriteOffset { get; set; }
 
-        /// <summary>
-        ///     Overrides the direction used to render the sprite.
-        /// </summary>
-        /// <remarks>
-        ///     If null, the world space orientation of the entity will be used.
-        ///     Otherwise the specified direction will be used.
-        /// </remarks>
-        public Direction? OverrideDirection { get; set; }
+        #endregion
 
         public SpriteView()
         {
+            _entMan = IoCManager.Resolve<IEntityManager>();
+            _entMan.TryGetComponent(Entity, out _sprite);
             RectClipContent = true;
+        }
+
+        public void SetEntity(EntityUid? uid)
+        {
+            Entity = uid;
+            _entMan.TryGetComponent(Entity, out _sprite);
         }
 
         protected override Vector2 MeasureOverride(Vector2 availableSize)
         {
-            // TODO: make this not hardcoded.
-            // It'll break on larger things.
-            return (32, 32) * Scale;
+            UpdateSize();
+            return _spriteSize;
+        }
+
+        private void UpdateSize()
+        {
+            if (Entity == null || _sprite == null)
+            {
+                _spriteSize = default;
+                return;
+            }
+
+            // Size does not auto-update with world rotation
+            var wRot = _worldRotation ?? Angle.Zero;
+
+            var spriteBox = _sprite.CalculateRotatedBoundingBox(default, wRot, _eyeRotation)
+                .CalcBoundingBox();
+
+            if (!SpriteOffset)
+            {
+                // re-center the box.
+                spriteBox = spriteBox.Translated(-spriteBox.Center);
+            }
+
+            if (!TransformMeasure)
+            {
+                _spriteSize = spriteBox.Size * EyeManager.PixelsPerMeter;
+                return;
+            }
+
+            spriteBox = spriteBox.Scale(_scale * EyeManager.PixelsPerMeter).Translated(_offset);
+
+            // This view will be centered on (0,0). If the sprite was shifted by (1,2) the actual size of the control
+            // would need to be at least (2,4). This is easiest to do by just negating the box and taking the union.
+            var negated = new Box2(-spriteBox.TopRight, -spriteBox.BottomLeft);
+            var box = spriteBox.Union(negated);
+            DebugTools.Assert(box.Contains(Vector2.Zero));
+            DebugTools.Assert(box.TopLeft.EqualsApprox(-box.BottomRight));
+            _spriteSize = box.Size;
         }
 
         internal override void DrawInternal(IRenderHandle renderHandle)
         {
-            if (Sprite == null || Sprite.Deleted)
+            if (Entity is not {} uid || _sprite == null)
+                return;
+
+            if (_sprite.Deleted)
             {
+                SetEntity(null);
                 return;
             }
 
-            var uid = Sprite.Owner;
-            var offsetAdj = Vector2.Zero;
+            // Ensure the sprite is animated despite possible not being visible in any viewport.
+            _spriteSystem ??= _entMan.System<SpriteSystem>();
+            _spriteSystem.ForceUpdate(uid);
 
-            //Set SpriteOffset, If the sprite is > 32px, adjust the SpriteOffset center point
-            if(Sprite.Bounds.Height > 1)
+            var stretch = Stretch switch
             {
-                offsetAdj = (SpriteOffset ? Sprite.Offset : new Vector2(0,(1.0f/(32*Sprite.Bounds.Height))*32));
-            }
+                StretchMode.Fit => Vector2.ComponentMin(Size / _spriteSize, Vector2.One),
+                StretchMode.Fill => Size / _spriteSize,
+                _ => Vector2.One,
+            };
 
-            _spriteSystem ??= IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SpriteSystem>();
-            _spriteSystem?.ForceUpdate(uid);
-
-            renderHandle.DrawEntity(uid, PixelSize / 2 + PixelSize * offsetAdj, Scale * UIScale, OverrideDirection);
+            var offset = SpriteOffset ? _offset : _offset - _sprite.Offset * (1, -1) * EyeManager.PixelsPerMeter;
+            var position = PixelSize / 2 + offset * stretch * UIScale;
+            var scale = Scale * UIScale * stretch;
+            renderHandle.DrawEntity(uid, position, scale, _worldRotation, _eyeRotation, OverrideDirection, _sprite);
         }
     }
 }


### PR DESCRIPTION
This PR is meant to try remove any hard coded assumptions about sprite sizes from the SpriteView control, among some other things:

- You can now specify a sprite's world-rotation
- You can set the "eye" rotation
- The control will try and to place the centre of the sprite's bounding box in the centre of the view
- Sprite offsets are now ignored by default.
- The view now properly measures the size required to draw the sprite.
- There is a new Stretch-mode field which determines how sprites are stretched
  - The default is `Fit`, which will scale sprits down if the available size is insufficient to draw the sprite
  - `Fill` will scale a sprite up in order to fill the available size
  - `None` does no sprite scaling, and may lead to the sprite getting cropped if there is insufficient size

I started going insane trying to test & fix all the misc transform issues, so I've also added a new sprite view tab to the UI test window to make it easier to look for bugs in the future. The UI code itself is pretty shitty, but it is a test UI. I CBF improving it so if its an issue I can just remove it instead.


https://user-images.githubusercontent.com/60421075/235285511-16802070-384a-49de-b1ee-5fe233edb482.mp4

Requires space-wizards/space-station-14/pull/15881
