### PR TITLE
Add comment to rga.yml

### DIFF
--- a/Schemas/rga.yml
+++ b/Schemas/rga.yml
@@ -1,3 +1,5 @@
+# If this gets updated, make sure to also update https://github.com/space-wizards/RobustToolboxSpecifications
+
 list(include('attribution'), min=1)
 ---
 attribution:


### PR DESCRIPTION
Just adds a yml comment mentioning space-wizards/RobustToolboxSpecifications, cause I didn't even know it existed.