### PR TITLE
Small shader code cleanup

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
@@ -33,7 +33,7 @@ namespace Robust.Client.Graphics.Clyde
             SetTexture(TextureUnit.Texture0, _tileDefinitionManager.TileTextureAtlas);
             SetTexture(TextureUnit.Texture1, _lightingReady ? viewport.LightRenderTarget.Texture : _stockTextureWhite);
 
-            var (gridProgram, _) = ActivateShaderInstance(_defaultShader.Handle);
+            var gridProgram = ActivateShaderInstance(_defaultShader.Handle).Item1;
             SetupGlobalUniformsImmediate(gridProgram, (ClydeTexture) _tileDefinitionManager.TileTextureAtlas);
 
             gridProgram.SetUniformTextureMaybe(UniIMainTexture, TextureUnit.Texture0);

--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -187,7 +187,7 @@ namespace Robust.Client.Graphics.Clyde
             _fovCalculationProgram = _compileProgram(depthVert, depthFrag, attribLocations, "Shadow Depth Program");
 
             var debugShader = _resourceCache.GetResource<ShaderSourceResource>("/Shaders/Internal/depth-debug.swsl");
-            _fovDebugShaderInstance = (ClydeShaderInstance)InstanceShader(debugShader.ClydeHandle);
+            _fovDebugShaderInstance = (ClydeShaderInstance)InstanceShader(debugShader);
 
             ClydeHandle LoadShaderHandle(string path)
             {

--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -406,7 +406,7 @@ namespace Robust.Client.Graphics.Clyde
             return Color.FromSrgb(color);
         }
 
-        private (GLShaderProgram, LoadedShader) ActivateShaderInstance(ClydeHandle handle)
+        private (GLShaderProgram, LoadedShaderInstance) ActivateShaderInstance(ClydeHandle handle)
         {
             var instance = _shaderInstances[handle];
             var shader = _loadedShaders[instance.ShaderHandle];
@@ -439,7 +439,7 @@ namespace Robust.Client.Graphics.Clyde
             }
 
             if (!instance.ParametersDirty)
-                return (program, shader);
+                return (program, instance);
 
             instance.ParametersDirty = false;
 
@@ -505,7 +505,7 @@ namespace Robust.Client.Graphics.Clyde
                 }
             }
 
-            return (program, shader);
+            return (program, instance);
         }
 
         [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Robust.Client.Audio;
 using Robust.Client.Input;
+using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
@@ -30,7 +31,7 @@ namespace Robust.Client.Graphics.Clyde
         private readonly List<IClydeWindow> _windows = new();
         private int _nextWindowId = 2;
 
-        public ShaderInstance InstanceShader(ClydeHandle handle)
+        public ShaderInstance InstanceShader(ShaderSourceResource handle, bool? light = null, ShaderBlendMode? blend = null)
         {
             return new DummyShaderInstance();
         }
@@ -480,27 +481,11 @@ namespace Robust.Client.Graphics.Clyde
             {
             }
 
-            private protected override void SetStencilOpImpl(StencilOp op)
+            private protected override void SetStencilImpl(StencilParameters value)
             {
             }
 
-            private protected override void SetStencilFuncImpl(StencilFunc func)
-            {
-            }
-
-            private protected override void SetStencilTestEnabledImpl(bool enabled)
-            {
-            }
-
-            private protected override void SetStencilRefImpl(int @ref)
-            {
-            }
-
-            private protected override void SetStencilWriteMaskImpl(int mask)
-            {
-            }
-
-            private protected override void SetStencilReadMaskRefImpl(int mask)
+            public override void Dispose()
             {
             }
         }

--- a/Robust.Client/Graphics/IClydeInternal.cs
+++ b/Robust.Client/Graphics/IClydeInternal.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Robust.Client.Input;
+using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
@@ -40,8 +41,7 @@ namespace Robust.Client.Graphics
         /// <summary>
         ///     Creates a new instance of a shader.
         /// </summary>
-        /// <param name="handle">The handle of the loaded shader as returned by <see cref="LoadShader"/>.</param>
-        ShaderInstance InstanceShader(ClydeHandle handle);
+        ShaderInstance InstanceShader(ShaderSourceResource handle, bool? light = null, ShaderBlendMode? blend = null);
 
         /// <summary>
         ///     This is purely a hook for <see cref="IInputManager"/>, use that instead.

--- a/Robust.Client/Graphics/Shaders/ParsedShader.cs
+++ b/Robust.Client/Graphics/Shaders/ParsedShader.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.Utility;
+using Robust.Shared.ViewVariables;
 
 namespace Robust.Client.Graphics
 {
@@ -22,14 +23,14 @@ namespace Robust.Client.Graphics
             Constants = constants;
         }
 
-        public IReadOnlyDictionary<string, ShaderUniformDefinition> Uniforms { get; }
-        public IReadOnlyDictionary<string, ShaderVaryingDefinition> Varyings { get; }
-        public IReadOnlyDictionary<string, ShaderConstantDefinition> Constants { get; }
-        public IList<ShaderFunctionDefinition> Functions { get; }
-        public ShaderLightMode LightMode { get; }
-        public ShaderBlendMode BlendMode { get; }
-        public ShaderPreset Preset { get; }
-        public ICollection<ResPath> Includes { get; }
+        [ViewVariables] public IReadOnlyDictionary<string, ShaderUniformDefinition> Uniforms { get; }
+        [ViewVariables] public IReadOnlyDictionary<string, ShaderVaryingDefinition> Varyings { get; }
+        [ViewVariables] public IReadOnlyDictionary<string, ShaderConstantDefinition> Constants { get; }
+        [ViewVariables] public IList<ShaderFunctionDefinition> Functions { get; }
+        [ViewVariables] public ShaderLightMode LightMode { get; }
+        [ViewVariables] public ShaderBlendMode BlendMode { get; }
+        [ViewVariables] public ShaderPreset Preset { get; }
+        [ViewVariables] public ICollection<ResPath> Includes { get; }
 
     }
 

--- a/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
+++ b/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
@@ -16,32 +16,18 @@ namespace Robust.Client.Graphics
     [Prototype("shader")]
     public sealed class ShaderPrototype : IPrototype, ISerializationHooks
     {
-        [Dependency] private readonly IResourceCache _resourceCache = default!;
-
         [ViewVariables]
         [IdDataFieldAttribute]
         public string ID { get; } = default!;
 
-        private ShaderKind Kind;
-
-        // Source shader variables.
-        private ShaderSourceResource? Source;
-        private Dictionary<string, object>? ShaderParams;
-
-        // Canvas shader variables.
-        private ClydeHandle CompiledCanvasShader;
-
-        private ShaderInstance? _cachedInstance;
-
-        private bool _stencilEnabled;
-        private int _stencilRef => StencilDataHolder?.StencilRef ?? 0;
-        private int _stencilReadMask => StencilDataHolder?.ReadMask ?? unchecked((int) uint.MaxValue);
-        private int _stencilWriteMask => StencilDataHolder?.WriteMask ?? unchecked((int) uint.MaxValue);
-        private StencilFunc _stencilFunc => StencilDataHolder?.StencilFunc ?? StencilFunc.Always;
-        private StencilOp _stencilOp => StencilDataHolder?.StencilOp ?? StencilOp.Keep;
+        [ViewVariables] private ShaderKind Kind;
+        [ViewVariables] private Dictionary<string, object>? _params;
+        [ViewVariables] private ShaderSourceResource? _source;
+        [ViewVariables] private ShaderInstance? _cachedInstance;
+        [ViewVariables] private ParsedShader? _parsed => _source?.ParsedShader;
 
         [DataField("stencil")]
-        private StencilData? StencilDataHolder;
+        private StencilParameters? _stencil;
 
         /// <summary>
         ///     Retrieves a ready-to-use instance of this shader.
@@ -70,27 +56,31 @@ namespace Robust.Client.Graphics
             switch (Kind)
             {
                 case ShaderKind.Source:
-                    instance = IoCManager.Resolve<IClydeInternal>().InstanceShader(Source!.ClydeHandle);
+                    instance = IoCManager.Resolve<IClydeInternal>().InstanceShader(_source!);
                     _applyDefaultParameters(instance);
                     break;
 
                 case ShaderKind.Canvas:
-                    instance = IoCManager.Resolve<IClydeInternal>().InstanceShader(CompiledCanvasShader);
+
+                    var hasLight = rawMode != "unshaded";
+                    ShaderBlendMode? blend = null;
+                    if (rawBlendMode != null)
+                    {
+                        if (!Enum.TryParse<ShaderBlendMode>(rawBlendMode.ToUpper(), out var parsed))
+                            Logger.Error($"invalid mode: {rawBlendMode}");
+                        else
+                            blend = parsed;
+                    }
+
+                    instance = IoCManager.Resolve<IClydeInternal>().InstanceShader(_source!, hasLight, blend);
                     break;
 
                 default:
                     throw new ArgumentOutOfRangeException();
             }
 
-            if (_stencilEnabled)
-            {
-                instance.StencilTestEnabled = true;
-                instance.StencilRef = _stencilRef;
-                instance.StencilFunc = _stencilFunc;
-                instance.StencilOp = _stencilOp;
-                instance.StencilReadMask = _stencilReadMask;
-                instance.StencilWriteMask = _stencilWriteMask;
-            }
+            if (_stencil is {} data)
+                instance.Stencil = data with { Enabled = true};
 
             instance.MakeImmutable();
             _cachedInstance = instance;
@@ -114,95 +104,34 @@ namespace Robust.Client.Graphics
                 case "source":
                     Kind = ShaderKind.Source;
                     if (path == null) throw new InvalidOperationException();
-                    Source = IoCManager.Resolve<IResourceCache>().GetResource<ShaderSourceResource>(path);
+                    _source = IoCManager.Resolve<IResourceCache>().GetResource<ShaderSourceResource>(path);
 
                     if (paramMapping != null)
                     {
-                        ShaderParams = new Dictionary<string, object>();
+                        _params = new Dictionary<string, object>();
                         foreach (var item in paramMapping!)
                         {
                             var name = item.Key;
-                            if (!Source.ParsedShader.Uniforms.TryGetValue(name, out var uniformDefinition))
+                            if (!_source.ParsedShader.Uniforms.TryGetValue(name, out var uniformDefinition))
                             {
                                 Logger.ErrorS("shader", "Shader param '{0}' does not exist on shader '{1}'", name, path);
                                 continue;
                             }
 
                             var value = _parseUniformValue(item.Value, uniformDefinition.Type.Type);
-                            ShaderParams.Add(name, value);
+                            _params.Add(name, value);
                         }
                     }
                     break;
 
                 case "canvas":
                     Kind = ShaderKind.Canvas;
-                    var source = "";
-
-                    if(rawMode != null)
-                    {
-                        switch (rawMode)
-                        {
-                            case "normal":
-                                break;
-
-                            case "unshaded":
-                                source += "light_mode unshaded;\n";
-                                break;
-
-                            default:
-                                throw new InvalidOperationException($"Invalid light mode: '{rawMode}'");
-                        }
-                    }
-
-                    if(rawBlendMode != null){
-                        switch (rawBlendMode)
-                        {
-                            case "mix":
-                                source += "blend_mode mix;\n";
-                                break;
-
-                            case "add":
-                                source += "blend_mode add;\n";
-                                break;
-
-                            case "subtract":
-                                source += "blend_mode subtract;\n";
-                                break;
-
-                            case "multiply":
-                                source += "blend_mode multiply;\n";
-                                break;
-
-                            default:
-                                throw new InvalidOperationException($"Invalid blend mode: '{rawBlendMode}'");
-                        }
-                    }
-
-                    source += "void fragment() {\n    COLOR = zTexture(UV);\n}";
-
-                    var preset = ShaderParser.Parse(source, _resourceCache);
-                    CompiledCanvasShader = IoCManager.Resolve<IClydeInternal>().LoadShader(preset, $"canvas_preset_{ID}");
+                    _source = IoCManager.Resolve<IResourceCache>().GetResource<ShaderSourceResource>("/Shaders/Internal/default-sprite.swsl");
                     break;
 
                 default:
                     throw new InvalidOperationException($"Invalid shader kind: '{_rawKind}'");
             }
-
-            if (StencilDataHolder != null) _stencilEnabled = true;
-        }
-
-        [DataDefinition]
-        public sealed class StencilData
-        {
-            [DataField("ref")] public int StencilRef;
-
-            [DataField("op")] public StencilOp StencilOp;
-
-            [DataField("func")] public StencilFunc StencilFunc;
-
-            [DataField("readMask")] public int ReadMask = unchecked((int) uint.MaxValue);
-
-            [DataField("writeMask")] public int WriteMask = unchecked((int) uint.MaxValue);
         }
 
         private static object _parseUniformValue(YamlNode node, ShaderDataType dataType)
@@ -241,12 +170,12 @@ namespace Robust.Client.Graphics
 
         private void _applyDefaultParameters(ShaderInstance instance)
         {
-            if (ShaderParams == null)
+            if (_params == null)
             {
                 return;
             }
 
-            foreach (var (key, value) in ShaderParams)
+            foreach (var (key, value) in _params)
             {
                 switch (value)
                 {

--- a/Robust.Client/ResourceManagement/ResourceTypes/ShaderSourceResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/ShaderSourceResource.cs
@@ -4,6 +4,7 @@ using Robust.Client.Graphics;
 using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
 using Robust.Shared.Utility;
+using Robust.Shared.ViewVariables;
 
 namespace Robust.Client.ResourceManagement
 {
@@ -12,7 +13,10 @@ namespace Robust.Client.ResourceManagement
     /// </summary>
     internal sealed class ShaderSourceResource : BaseResource
     {
+        [ViewVariables]
         internal ClydeHandle ClydeHandle { get; private set; }
+
+        [ViewVariables]
         internal ParsedShader ParsedShader { get; private set; } = default!;
 
         public override void Load(IResourceCache cache, ResPath path)


### PR DESCRIPTION
Small shader cleanup. Should have no effect on functionality. Maybe some of this was intentionally like this for some reason I don't know about, but IMO these changes make shader code somewhat less convoluted to read. 

Shaders are still a mess of confusingly differentiated shader objects which make it a pain to parse the code. E.g., ShaderPrototype, ShaderSourceResource, ShaderInstance, LoadedShaderInstance, LoadedShader, ParsedShader, and GLShaderProgram & a bunch of ClydeHandles that could ambiguously be referring to several different kinds of shader objects.

- Combines the `StencilData` and `StencilParameters` structs into one. 
- Adds view-variables attributes to a bunch of things
- Moves the lighting & blend-mode data from `LoadedShader` to `LoadedShaderInstance`
  - The stencil data was already stored in `LoadedShaderInstance` 
  - I have no idea if there was a reason they were stored separately before, but it meant that you **needed** to compile a separate shader program despite only wanting to toggle lighting or blending properties.
- Makes the canvas shaders use the default sprite shader.
  - Before this they were using a separate but completely identical shaders, each with their own OpenGL program.