### PR TITLE
Make screen-space overlays use `BeforeDraw()`

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -178,6 +178,18 @@ namespace Robust.Client.Graphics.Clyde
             {
                 try
                 {
+                    if (!overlay.BeforeDraw(args))
+                        return;
+
+                    if (overlay.RequestScreenTexture)
+                    {
+                        FlushRenderQueue();
+                        overlay.ScreenTexture = CopyScreenTexture(vp.RenderTarget);
+                    }
+
+                    if (overlay.OverwriteTargetFrameBuffer)
+                        ClearFramebuffer(default);
+
                     overlay.Draw(args);
                 }
                 catch (Exception e)

--- a/Robust.Client/Graphics/Overlays/Overlay.cs
+++ b/Robust.Client/Graphics/Overlays/Overlay.cs
@@ -71,6 +71,10 @@ namespace Robust.Client.Graphics
         /// not get drawn to this view-port. Useful for avoiding unnecessary screen-texture fetching or frame buffer
         /// clearing.
         /// </summary>
+        /// <remarks>
+        /// If you do not use <see cref="RequestScreenTexture"/> or <see cref="OverwriteTargetFrameBuffer"/>, you don't
+        /// need to use this and can just perform these checks inside of <see cref="Draw"/> instead.
+        /// </remarks>
         protected internal virtual bool BeforeDraw(in OverlayDrawArgs args)
         {
             return true;

--- a/Robust.Shared/Enums/OverlaySpaces.cs
+++ b/Robust.Shared/Enums/OverlaySpaces.cs
@@ -24,7 +24,7 @@ namespace Robust.Shared.Enums {
         WorldSpace = 1 << 2,
 
         /// <summary>
-        ///     This overlay will be drawn beneath FOV; above lighting and entities.
+        ///     This overlay will be drawn beneath FOV and lighting, but above entities.
         /// </summary>
         WorldSpaceBelowFOV = 1 << 3,
 


### PR DESCRIPTION
Also allows them to use the other overlay arguments and fixes or clarifies some comments.
