### PR TITLE
Remove texture IoC resolves

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
@@ -26,8 +26,9 @@ namespace Robust.Client.Graphics.Clyde
                 _clyde = clyde;
                 _entities = entities;
 
-                DrawingHandleScreen = new DrawingHandleScreenImpl(this);
-                DrawingHandleWorld = new DrawingHandleWorldImpl(this);
+                var white = _clyde.GetStockTexture(ClydeStockTexture.White);
+                DrawingHandleScreen = new DrawingHandleScreenImpl(white, this);
+                DrawingHandleWorld = new DrawingHandleWorldImpl(white, this);
             }
 
             public void SetModelTransform(in Matrix3 matrix)
@@ -272,7 +273,7 @@ namespace Robust.Client.Graphics.Clyde
             {
                 private readonly RenderHandle _renderHandle;
 
-                public DrawingHandleScreenImpl(RenderHandle renderHandle)
+                public DrawingHandleScreenImpl(Texture white, RenderHandle renderHandle) : base(white)
                 {
                     _renderHandle = renderHandle;
                 }
@@ -313,7 +314,7 @@ namespace Robust.Client.Graphics.Clyde
                 {
                     if (filled)
                     {
-                        DrawTextureRect(Texture.White, rect, color);
+                        DrawTextureRect(White, rect, color);
                     }
                     else
                     {
@@ -367,7 +368,7 @@ namespace Robust.Client.Graphics.Clyde
             {
                 private readonly RenderHandle _renderHandle;
 
-                public DrawingHandleWorldImpl(RenderHandle renderHandle)
+                public DrawingHandleWorldImpl(Texture white, RenderHandle renderHandle) : base(white)
                 {
                     _renderHandle = renderHandle;
                 }
@@ -413,7 +414,7 @@ namespace Robust.Client.Graphics.Clyde
                             filledTriangle[1] = new DrawVertexUV2DColor(endPos + position, colorReal);
                             filledTriangle[2] = new DrawVertexUV2DColor(position, colorReal);
 
-                            _renderHandle.DrawPrimitives(DrawPrimitiveTopology.TriangleList, Texture.White, filledTriangle);
+                            _renderHandle.DrawPrimitives(DrawPrimitiveTopology.TriangleList, White, filledTriangle);
                         }
                     }
                 }
@@ -432,7 +433,7 @@ namespace Robust.Client.Graphics.Clyde
                 {
                     if (filled)
                     {
-                        DrawTextureRect(Texture.White, rect, color);
+                        DrawTextureRect(White, rect, color);
                     }
                     else
                     {
@@ -447,7 +448,7 @@ namespace Robust.Client.Graphics.Clyde
                 {
                     if (filled)
                     {
-                        DrawTextureRect(Texture.White, rect, color);
+                        DrawTextureRect(White, rect, color);
                     }
                     else
                     {

--- a/Robust.Client/Graphics/Drawing/DrawingHandleBase.cs
+++ b/Robust.Client/Graphics/Drawing/DrawingHandleBase.cs
@@ -11,9 +11,9 @@ namespace Robust.Client.Graphics
     /// </summary>
     public abstract class DrawingHandleBase : IDisposable
     {
-        //private protected IRenderHandle _renderHandle;
         private protected readonly int _handleId;
         public bool Disposed { get; private set; }
+
         /// <summary>
         ///     Drawing commands that do NOT receive per-vertex modulation get modulated by this.
         ///     Specifically, *DrawPrimitives w/ DrawVertexUV2DColor IS NOT AFFECTED BY THIS*.
@@ -24,6 +24,13 @@ namespace Robust.Client.Graphics
         ///     I still wish it a prolonged death - it's a performance nightmare. - 20kdc
         /// </summary>
         public Color Modulate { get; set; } = Color.White;
+
+        protected Texture White;
+
+        public DrawingHandleBase(Texture white)
+        {
+            White = white;
+        }
 
         public void Dispose()
         {
@@ -65,7 +72,7 @@ namespace Robust.Client.Graphics
             Span<DrawVertexUV2DColor> drawVertices = stackalloc DrawVertexUV2DColor[vertices.Length];
             PadVerticesV2(vertices, drawVertices, realColor);
 
-            DrawPrimitives(primitiveTopology, Texture.White, drawVertices);
+            DrawPrimitives(primitiveTopology, White, drawVertices);
         }
 
         /// <summary>
@@ -84,7 +91,7 @@ namespace Robust.Client.Graphics
             Span<DrawVertexUV2DColor> drawVertices = stackalloc DrawVertexUV2DColor[vertices.Length];
             PadVerticesV2(vertices, drawVertices, realColor);
 
-            DrawPrimitives(primitiveTopology, Texture.White, indices, drawVertices);
+            DrawPrimitives(primitiveTopology, White, indices, drawVertices);
         }
 
         private void PadVerticesV2(ReadOnlySpan<Vector2> input, Span<DrawVertexUV2DColor> output, Color color)

--- a/Robust.Client/Graphics/Drawing/DrawingHandleScreen.cs
+++ b/Robust.Client/Graphics/Drawing/DrawingHandleScreen.cs
@@ -8,6 +8,10 @@ namespace Robust.Client.Graphics
 {
     public abstract class DrawingHandleScreen : DrawingHandleBase
     {
+        protected DrawingHandleScreen(Texture white) : base(white)
+        {
+        }
+
         public abstract void DrawRect(UIBox2 rect, Color color, bool filled = true);
 
         public abstract void DrawTextureRectRegion(Texture texture, UIBox2 rect, UIBox2? subRegion = null, Color? modulate = null);

--- a/Robust.Client/Graphics/Drawing/DrawingHandleWorld.cs
+++ b/Robust.Client/Graphics/Drawing/DrawingHandleWorld.cs
@@ -4,6 +4,10 @@ namespace Robust.Client.Graphics
 {
     public abstract class DrawingHandleWorld : DrawingHandleBase
     {
+        protected DrawingHandleWorld(Texture white) : base(white)
+        {
+        }
+
         private const int Ppm = EyeManager.PixelsPerMeter;
 
         /// <summary>


### PR DESCRIPTION
Remove `Texture.White` references in `RenderHandle`. No more IoC resolves every time you draw a square.