### PR TITLE
Add BeforeSaveEvent

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -12,6 +12,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Map.Events;
 using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -895,6 +896,9 @@ public sealed class MapLoaderSystem : EntitySystem
 
     private MappingDataNode GetSaveData(EntityUid uid)
     {
+        var ev = new BeforeSaveEvent(uid, Transform(uid).MapUid);
+        RaiseLocalEvent(ev);
+
         var data = new MappingDataNode();
         WriteMetaSection(data, uid);
 

--- a/Robust.Shared/Map/Events/MapSerializationEvents.cs
+++ b/Robust.Shared/Map/Events/MapSerializationEvents.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
+using Robust.Shared.GameObjects;
 
-namespace Robust.Server.Maps;
+namespace Robust.Shared.Map.Events;
 
 /// <summary>
 /// This event is broadcast just before the map loader reads the entity section. It can be used to somewhat modify
@@ -24,4 +25,27 @@ public sealed class BeforeEntityReadEvent
     /// might cause unexpected errors, user beware.
     /// </summary>
     public readonly Dictionary<string, string> RenamedPrototypes = new();
+}
+
+/// <summary>
+/// This event is broadcast just before the map loader reads the entity section. It can be used to somewhat modify
+/// how the map data is read, as a super basic kind of map migration tool.
+/// </summary>
+public sealed class BeforeSaveEvent
+{
+    /// <summary>
+    /// The entity that is going to be saved. usually a map or grid.
+    /// </summary>
+    public EntityUid Entity;
+
+    /// <summary>
+    /// The map that the <see cref="Entity"/> is on.
+    /// </summary>
+    public EntityUid? Map;
+
+    public BeforeSaveEvent(EntityUid entity, EntityUid? map)
+    {
+        Entity = entity;
+        Map = map;
+    }
 }


### PR DESCRIPTION
Adds an event that gets raised before entities get saved to yml.
Also moves `BeforeEntityReadEvent` to shared, and thus requires space-wizards/space-station-14/pull/16146