### PR TITLE
Add method to clear all scheduled midi events.

### DIFF
--- a/Robust.Client/Audio/Midi/IMidiRenderer.cs
+++ b/Robust.Client/Audio/Midi/IMidiRenderer.cs
@@ -121,6 +121,11 @@ public interface IMidiRenderer : IDisposable
     void StopAllNotes();
 
     /// <summary>
+    /// Clears all scheduled events.
+    /// </summary>
+    void ClearEvents();
+
+    /// <summary>
     ///     Render and play MIDI to the audio source.
     /// </summary>
     internal void Render();

--- a/Robust.Client/Audio/Midi/IMidiRenderer.cs
+++ b/Robust.Client/Audio/Midi/IMidiRenderer.cs
@@ -123,7 +123,7 @@ public interface IMidiRenderer : IDisposable
     /// <summary>
     /// Clears all scheduled events.
     /// </summary>
-    void ClearEvents();
+    void ClearAllEvents();
 
     /// <summary>
     ///     Render and play MIDI to the audio source.

--- a/Robust.Client/Audio/Midi/MidiRenderer.cs
+++ b/Robust.Client/Audio/Midi/MidiRenderer.cs
@@ -354,9 +354,8 @@ internal sealed class MidiRenderer : IMidiRenderer
         }
     }
 
-    public void ClearEvents()
+    public void ClearAllEvents()
     {
-        // I have no idea what I am doing. Please forgive me vera.
         _sequencer.RemoveEvents(SequencerClientId.Wildcard, SequencerClientId.Wildcard, -1);
     }
 

--- a/Robust.Client/Audio/Midi/MidiRenderer.cs
+++ b/Robust.Client/Audio/Midi/MidiRenderer.cs
@@ -354,6 +354,12 @@ internal sealed class MidiRenderer : IMidiRenderer
         }
     }
 
+    public void ClearEvents()
+    {
+        // I have no idea what I am doing. Please forgive me vera.
+        _sequencer.RemoveEvents(SequencerClientId.Wildcard, SequencerClientId.Wildcard, -1);
+    }
+
     public void LoadSoundfont(string filename, bool resetPresets = true)
     {
         lock (_playerStateLock)


### PR DESCRIPTION
Adds a method that, AFAIK, does what was described by @Zumorica [ on discord](https://discord.com/channels/310555209753690112/900426319433728030/1041288570553511997). I tested a bit with space-wizards/space-station-14/pull/15001 and it seems to not cause any issues and paused replays no longer have stuck notes.