### PR TITLE
Add padding to glyphs in atlas

### DIFF
--- a/Robust.Client/Graphics/FontManager.cs
+++ b/Robust.Client/Graphics/FontManager.cs
@@ -188,7 +188,8 @@ namespace Robust.Client.Graphics
                 info.Texture = atlasTexture;
 
                 scaled.CurSheetMaxY = Math.Max(scaled.CurSheetMaxY, scaled.CurSheetY + bitmap.Rows);
-                scaled.CurSheetX += bitmap.Width;
+                // Add a pixel of horizontal padding, to avoid artifacts when aliasing
+                scaled.CurSheetX += bitmap.Width + 1;
             }
 
             scaled.GlyphInfos.Add(glyph, info);

--- a/Robust.Client/Graphics/FontManager.cs
+++ b/Robust.Client/Graphics/FontManager.cs
@@ -162,7 +162,8 @@ namespace Robust.Client.Graphics
                 if (sheetW - scaled.CurSheetX < img.Width)
                 {
                     scaled.CurSheetX = 0;
-                    scaled.CurSheetY = scaled.CurSheetMaxY;
+                    // +1 Adds a pixel of vertical padding, to avoid arifacts when aliasing
+                    scaled.CurSheetY = scaled.CurSheetMaxY + 1;
                 }
 
                 if (sheetH - scaled.CurSheetY < img.Height)
@@ -188,7 +189,7 @@ namespace Robust.Client.Graphics
                 info.Texture = atlasTexture;
 
                 scaled.CurSheetMaxY = Math.Max(scaled.CurSheetMaxY, scaled.CurSheetY + bitmap.Rows);
-                // Add a pixel of horizontal padding, to avoid artifacts when aliasing
+                // +1 adds a pixel of horizontal padding, to avoid artifacts when aliasing
                 scaled.CurSheetX += bitmap.Width + 1;
             }
 


### PR DESCRIPTION
Fixes visual artifacts when anti-aliasing glyph textures; I wanted to multi-sample the texture used by glyph rendering, but at the borders of each glyph, was picking up pixels from adjacent glyphs. Note the artifacts that appear between some of the letters:

![2023-05-07_14-55_1](https://user-images.githubusercontent.com/1676295/236687325-e7c1db82-fc59-440e-96d1-f73cf3f5a5c7.png)

By adding a pixel of padding in between each one, the multisampled text looks like:

![2023-05-07_14-55](https://user-images.githubusercontent.com/1676295/236687343-1732e09e-8a9d-48a8-9c8e-dd9b137afc59.png)
