### PR TITLE
Sort serializable types

### DIFF
--- a/Robust.Shared/Serialization/RobustSerializer.cs
+++ b/Robust.Shared/Serialization/RobustSerializer.cs
@@ -57,7 +57,10 @@ namespace Robust.Shared.Serialization
 
         public void Initialize()
         {
-            var types = _reflectionManager.FindTypesWithAttribute<NetSerializableAttribute>().ToList();
+            var types = _reflectionManager.FindTypesWithAttribute<NetSerializableAttribute>()
+                .OrderBy(x => x.FullName, StringComparer.InvariantCulture)
+                .ToList();
+
 #if DEBUG
             // confirm only shared types are marked for serialization, no client & server only types
             foreach (var type in types)


### PR DESCRIPTION
`Assembly.GetTypes()` isn't guaranteed to return types in any specific order. It's surprising that the game even works.