### PR TITLE
[Fixture] fixed bug with null pointer execution while updating dead bodies

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
@@ -458,6 +458,9 @@ namespace Robust.Shared.Physics.Systems
                 contact.Flags |= ContactFlags.Filter;
             }
 
+            if (fixture.Body == null)
+                return;
+
             if (!Resolve(fixture.Body.Owner, ref xform))
                 return;
 


### PR DESCRIPTION
### Description:
If u had dead bodies which is not visible in while died, and if they will update u will had null pointer on their bodies, and in this code this didn't handled.
![image](https://user-images.githubusercontent.com/33431126/236880363-c0547d07-7e4c-4826-aa09-fdb8daa8b6bd.png)
some screenshots from stack trace
![image](https://user-images.githubusercontent.com/33431126/236880660-27c20d83-7d95-4f6f-8fdf-71aa3cbd0892.png)
