### PR TITLE
Remove obsolete `Fixture.Body` references

### DIFF
--- a/Robust.Client/Debugging/DebugPhysicsSystem.cs
+++ b/Robust.Client/Debugging/DebugPhysicsSystem.cs
@@ -128,8 +128,8 @@ namespace Robust.Client.Debugging
                 CollisionManager.GetPointStates(ref state1, ref state2, oldManifold, manifold);
 
                 Span<Vector2> points = stackalloc Vector2[2];
-                var transformA = _physics.GetPhysicsTransform(fixtureA.Body.Owner);
-                var transformB = _physics.GetPhysicsTransform(fixtureB.Body.Owner);
+                var transformA = _physics.GetPhysicsTransform(contact.EntityA);
+                var transformB = _physics.GetPhysicsTransform(contact.EntityB);
                 contact.GetWorldManifold(transformA, transformB, out var normal, points);
 
                 ContactPoint cp = Points[PointCount];

--- a/Robust.Client/GameObjects/EntitySystems/DebugEntityLookupSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/DebugEntityLookupSystem.cs
@@ -81,13 +81,13 @@ public sealed class EntityLookupOverlay : Overlay
 
             lookup.DynamicTree.QueryAabb(ref ents, static (ref List<EntityUid> state, in FixtureProxy value) =>
             {
-                state.Add(value.Fixture.Body.Owner);
+                state.Add(value.Entity);
                 return true;
             }, lookupAABB);
 
             lookup.StaticTree.QueryAabb(ref ents, static (ref List<EntityUid> state, in FixtureProxy value) =>
             {
-                state.Add(value.Fixture.Body.Owner);
+                state.Add(value.Entity);
                 return true;
             }, lookupAABB);
 

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -38,7 +38,7 @@ public sealed partial class EntityLookupSystem
             lookup.DynamicTree.QueryAabb(ref intersecting,
                 static (ref HashSet<EntityUid> state, in FixtureProxy value) =>
                 {
-                    state.Add(value.Fixture.Body.Owner);
+                    state.Add(value.Entity);
                     return true;
                 }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
         }
@@ -48,7 +48,7 @@ public sealed partial class EntityLookupSystem
             lookup.StaticTree.QueryAabb(ref intersecting,
                 static (ref HashSet<EntityUid> state, in FixtureProxy value) =>
                 {
-                    state.Add(value.Fixture.Body.Owner);
+                    state.Add(value.Entity);
                     return true;
                 }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
         }
@@ -92,7 +92,7 @@ public sealed partial class EntityLookupSystem
             lookup.DynamicTree.QueryAabb(ref intersecting,
             static (ref HashSet<EntityUid> state, in FixtureProxy value) =>
             {
-                state.Add(value.Fixture.Body.Owner);
+                state.Add(value.Entity);
                 return true;
             }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
         }
@@ -102,7 +102,7 @@ public sealed partial class EntityLookupSystem
             lookup.StaticTree.QueryAabb(ref intersecting,
             static (ref HashSet<EntityUid> state, in FixtureProxy value) =>
             {
-                state.Add(value.Fixture.Body.Owner);
+                state.Add(value.Entity);
                 return true;
             }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
         }
@@ -143,7 +143,7 @@ public sealed partial class EntityLookupSystem
         {
             lookup.DynamicTree.QueryAabb(ref state, (ref (EntityUid? ignored, bool found) tuple, in FixtureProxy value) =>
             {
-                if (tuple.ignored == value.Fixture.Body.Owner)
+                if (tuple.ignored == value.Entity)
                     return true;
 
                 tuple.found = true;
@@ -155,7 +155,7 @@ public sealed partial class EntityLookupSystem
         {
             lookup.StaticTree.QueryAabb(ref state, (ref (EntityUid? ignored, bool found) tuple, in FixtureProxy value) =>
             {
-                if (tuple.ignored == value.Fixture.Body.Owner)
+                if (tuple.ignored == value.Entity)
                     return true;
 
                 tuple.found = true;
@@ -208,7 +208,7 @@ public sealed partial class EntityLookupSystem
         {
             lookup.DynamicTree.QueryAabb(ref state, (ref (EntityUid? ignored, bool found) tuple, in FixtureProxy value) =>
             {
-                if (tuple.ignored == value.Fixture.Body.Owner)
+                if (tuple.ignored == value.Entity)
                     return true;
 
                 tuple.found = true;
@@ -220,7 +220,7 @@ public sealed partial class EntityLookupSystem
         {
             lookup.StaticTree.QueryAabb(ref state, (ref (EntityUid? ignored, bool found) tuple, in FixtureProxy value) =>
             {
-                if (tuple.ignored == value.Fixture.Body.Owner)
+                if (tuple.ignored == value.Entity)
                     return true;
 
                 tuple.found = true;
@@ -607,7 +607,7 @@ public sealed partial class EntityLookupSystem
             {
                 lookup.DynamicTree.QueryAabb(ref intersecting, static (ref HashSet<EntityUid> state, in FixtureProxy value) =>
                 {
-                    state.Add(value.Fixture.Body.Owner);
+                    state.Add(value.Entity);
                     return true;
                 }, aabb, (flags & LookupFlags.Approximate) != 0x0);
             }
@@ -616,7 +616,7 @@ public sealed partial class EntityLookupSystem
             {
                 lookup.StaticTree.QueryAabb(ref intersecting, static (ref HashSet<EntityUid> state, in FixtureProxy value) =>
                 {
-                    state.Add(value.Fixture.Body.Owner);
+                    state.Add(value.Entity);
                     return true;
                 }, aabb, (flags & LookupFlags.Approximate) != 0x0);
             }
@@ -665,7 +665,7 @@ public sealed partial class EntityLookupSystem
             lookup.DynamicTree.QueryAabb(ref intersecting,
                 static (ref HashSet<EntityUid> intersecting, in FixtureProxy value) =>
                 {
-                    intersecting.Add(value.Fixture.Body.Owner);
+                    intersecting.Add(value.Entity);
                     return true;
                 }, aabb, (flags & LookupFlags.Approximate) != 0x0);
         }
@@ -675,7 +675,7 @@ public sealed partial class EntityLookupSystem
             lookup.StaticTree.QueryAabb(ref intersecting,
                 static (ref HashSet<EntityUid> intersecting, in FixtureProxy value) =>
                 {
-                    intersecting.Add(value.Fixture.Body.Owner);
+                    intersecting.Add(value.Entity);
                     return true;
                 }, aabb, (flags & LookupFlags.Approximate) != 0x0);
         }
@@ -754,7 +754,7 @@ public sealed partial class EntityLookupSystem
         {
             component.DynamicTree.QueryAabb(ref intersecting, static (ref HashSet<EntityUid> intersecting, in FixtureProxy value) =>
             {
-                intersecting.Add(value.Fixture.Body.Owner);
+                intersecting.Add(value.Entity);
                 return true;
             }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
         }
@@ -763,7 +763,7 @@ public sealed partial class EntityLookupSystem
         {
             component.StaticTree.QueryAabb(ref intersecting, static (ref HashSet<EntityUid> intersecting, in FixtureProxy value) =>
             {
-                intersecting.Add(value.Fixture.Body.Owner);
+                intersecting.Add(value.Entity);
                 return true;
             }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
         }
@@ -799,7 +799,7 @@ public sealed partial class EntityLookupSystem
         {
             component.DynamicTree.QueryAabb(ref intersecting, static (ref HashSet<EntityUid> intersecting, in FixtureProxy value) =>
             {
-                intersecting.Add(value.Fixture.Body.Owner);
+                intersecting.Add(value.Entity);
                 return true;
             }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
         }
@@ -808,7 +808,7 @@ public sealed partial class EntityLookupSystem
         {
             component.StaticTree.QueryAabb(ref intersecting, static (ref HashSet<EntityUid> intersecting, in FixtureProxy value) =>
             {
-                intersecting.Add(value.Fixture.Body.Owner);
+                intersecting.Add(value.Entity);
                 return true;
             }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
         }

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.ComponentQueries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.ComponentQueries.cs
@@ -30,7 +30,7 @@ public sealed partial class EntityLookupSystem
         {
             lookup.DynamicTree.QueryAabb(ref state, static (ref (HashSet<T> intersecting, EntityQuery<T> query) tuple, in FixtureProxy value) =>
             {
-                if (!tuple.query.TryGetComponent(value.Fixture.Body.Owner, out var comp))
+                if (!tuple.query.TryGetComponent(value.Entity, out var comp))
                     return true;
 
                 tuple.intersecting.Add(comp);
@@ -42,7 +42,7 @@ public sealed partial class EntityLookupSystem
         {
             lookup.StaticTree.QueryAabb(ref state, static (ref (HashSet<T> intersecting, EntityQuery<T> query) tuple, in FixtureProxy value) =>
             {
-                if (!tuple.query.TryGetComponent(value.Fixture.Body.Owner, out var comp))
+                if (!tuple.query.TryGetComponent(value.Entity, out var comp))
                     return true;
 
                 tuple.intersecting.Add(comp);

--- a/Robust.Shared/GameObjects/Systems/SharedGridFixtureSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridFixtureSystem.cs
@@ -95,8 +95,8 @@ namespace Robust.Shared.GameObjects
                 fixtures.AddRange(chunk.Fixtures);
             }
 
-            _fixtures.FixtureUpdate(uid, manager: manager, body: body);
             EntityManager.EventBus.RaiseLocalEvent(uid,new GridFixtureChangeEvent {NewFixtures = fixtures}, true);
+            _fixtures.FixtureUpdate(uid, manager: manager, body: body);
 
             CheckSplit(uid, mapChunks, removedChunks);
         }
@@ -202,6 +202,10 @@ namespace Robust.Shared.GameObjects
         }
     }
 
+    /// <summary>
+    /// Event raised after a grids fixtures have changed, but before <see cref="FixtureSystem.FixtureUpdate"/> is called.
+    /// Allows content to modify some fixture properties, like density.
+    /// </summary>
     public sealed class GridFixtureChangeEvent : EntityEventArgs
     {
         public List<Fixture> NewFixtures { get; init; } = default!;

--- a/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
+++ b/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
@@ -71,6 +71,9 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
         public Fixture? FixtureA;
         public Fixture? FixtureB;
 
+        public PhysicsComponent? BodyA;
+        public PhysicsComponent? BodyB;
+
         public Manifold Manifold;
 
         internal ContactType Type;
@@ -315,7 +318,7 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
         public override int GetHashCode()
         {
             // TODO: Need to suss this out
-            return HashCode.Combine((FixtureA != null ? FixtureA.Body.Owner : EntityUid.Invalid), (FixtureB != null ? FixtureB.Body.Owner : EntityUid.Invalid));
+            return HashCode.Combine(EntityA, EntityB);
         }
     }
 

--- a/Robust.Shared/Physics/Dynamics/Fixture.cs
+++ b/Robust.Shared/Physics/Dynamics/Fixture.cs
@@ -66,7 +66,7 @@ namespace Robust.Shared.Physics.Dynamics
         [Obsolete("Use other means to obtain the PhysicsComponent for the fixture.")]
         [ViewVariables]
         [field:NonSerialized]
-        public PhysicsComponent Body { get; internal set; } = default!;
+        internal PhysicsComponent Body { get; set; } = default!;
 
         /// <summary>
         /// All of the other fixtures this fixture has a contact with.

--- a/Robust.Shared/Physics/Dynamics/FixtureProxy.cs
+++ b/Robust.Shared/Physics/Dynamics/FixtureProxy.cs
@@ -20,13 +20,18 @@
 * 3. This notice may not be removed or altered from any source distribution.
 */
 
+using Robust.Shared.GameObjects;
 using Robust.Shared.Maths;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.ViewVariables;
 
 namespace Robust.Shared.Physics.Dynamics
 {
     public sealed class FixtureProxy
     {
+        public EntityUid Entity;
+        public PhysicsComponent Body;
+
         /// <summary>
         ///     Grid-based AABB of this proxy.
         /// </summary>
@@ -47,8 +52,10 @@ namespace Robust.Shared.Physics.Dynamics
         [ViewVariables]
         public DynamicTree.Proxy ProxyId = DynamicTree.Proxy.Free;
 
-        public FixtureProxy(Box2 aabb, Fixture fixture, int childIndex)
+        public FixtureProxy(EntityUid uid, PhysicsComponent body, Box2 aabb, Fixture fixture, int childIndex)
         {
+            Entity = uid;
+            Body = body;
             AABB = aabb;
             Fixture = fixture;
             ChildIndex = childIndex;

--- a/Robust.Shared/Physics/Events/EndCollideEvent.cs
+++ b/Robust.Shared/Physics/Events/EndCollideEvent.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.GameObjects;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
 
 namespace Robust.Shared.Physics.Events;
@@ -9,14 +10,25 @@ public readonly struct EndCollideEvent
     public readonly EntityUid OurEntity;
     public readonly EntityUid OtherEntity;
 
+    public readonly PhysicsComponent OurBody;
+    public readonly PhysicsComponent OtherBody;
+
     public readonly Fixture OurFixture;
     public readonly Fixture OtherFixture;
 
-    public EndCollideEvent(EntityUid ourEntity, EntityUid otherEntity, Fixture ourFixture, Fixture otherFixture)
+    public EndCollideEvent(
+        EntityUid ourEntity,
+        EntityUid otherEntity,
+        Fixture ourFixture,
+        Fixture otherFixture,
+        PhysicsComponent ourBody,
+        PhysicsComponent otherBody)
     {
         OurEntity = ourEntity;
         OtherEntity = otherEntity;
         OurFixture = ourFixture;
         OtherFixture = otherFixture;
+        OtherBody = otherBody;
+        OurBody = ourBody;
     }
 }

--- a/Robust.Shared/Physics/Events/StartCollideEvent.cs
+++ b/Robust.Shared/Physics/Events/StartCollideEvent.cs
@@ -1,5 +1,6 @@
 using Robust.Shared.GameObjects;
 using Robust.Shared.Maths;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
 
 namespace Robust.Shared.Physics.Events;
@@ -10,16 +11,28 @@ public readonly struct StartCollideEvent
     public readonly EntityUid OurEntity;
     public readonly EntityUid OtherEntity;
 
+    public readonly PhysicsComponent OurBody;
+    public readonly PhysicsComponent OtherBody;
+
     public readonly Fixture OurFixture;
     public readonly Fixture OtherFixture;
     public readonly Vector2 WorldPoint;
 
-    public StartCollideEvent(EntityUid ourEntity, EntityUid otherEntity, Fixture ourFixture, Fixture otherFixture, Vector2 worldPoint)
+    public StartCollideEvent(
+        EntityUid ourEntity,
+        EntityUid otherEntity,
+        Fixture ourFixture,
+        Fixture otherFixture,
+        PhysicsComponent ourBody,
+        PhysicsComponent otherBody,
+        Vector2 worldPoint)
     {
         OurEntity = ourEntity;
         OtherEntity = otherEntity;
         OurFixture = ourFixture;
         OtherFixture = otherFixture;
         WorldPoint = worldPoint;
+        OtherBody = otherBody;
+        OurBody = ourBody;
     }
 }

--- a/Robust.Shared/Physics/Systems/FixtureSystem.cs
+++ b/Robust.Shared/Physics/Systems/FixtureSystem.cs
@@ -104,7 +104,7 @@ namespace Robust.Shared.Physics.Systems
 
             if (body.CanCollide && Resolve(uid, ref xform))
             {
-                _lookup.CreateProxies(xform, fixture);
+                _lookup.CreateProxies(uid, xform, fixture, body);
             }
 
             // Supposed to be wrapped in density but eh
@@ -170,12 +170,11 @@ namespace Robust.Shared.Physics.Systems
             }
 
             // TODO: Assert world locked
-            DebugTools.Assert(fixture.Body == body);
             DebugTools.Assert(manager.FixtureCount > 0);
 
             if (!manager.Fixtures.Remove(fixture.ID))
             {
-                Logger.ErrorS("fixtures", $"Tried to remove fixture from {body.Owner} that was already removed.");
+                Logger.ErrorS("fixtures", $"Tried to remove fixture from {ToPrettyString(uid)} that was already removed.");
                 return;
             }
 
@@ -188,7 +187,7 @@ namespace Robust.Shared.Physics.Systems
             {
                 var map = Transform(broadphase.Owner).MapUid;
                 TryComp<PhysicsMapComponent>(map, out var physicsMap);
-                _lookup.DestroyProxies(fixture, xform, broadphase, physicsMap);
+                _lookup.DestroyProxies(uid, fixture, xform, broadphase, physicsMap);
             }
 
 

--- a/Robust.Shared/Physics/Systems/SharedJointSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedJointSystem.cs
@@ -531,7 +531,7 @@ public abstract class SharedJointSystem : EntitySystem
 
     internal void FilterContactsForJoint(Joint joint, PhysicsComponent? bodyA = null, PhysicsComponent? bodyB = null)
     {
-        if (!Resolve(joint.BodyAUid, ref bodyA) || !Resolve(joint.BodyBUid, ref bodyB))
+        if (!Resolve(joint.BodyBUid, ref bodyB))
             return;
 
         var node = bodyB.Contacts.First;
@@ -541,8 +541,8 @@ public abstract class SharedJointSystem : EntitySystem
             var contact = node.Value;
             node = node.Next;
 
-            if (contact.FixtureA?.Body == bodyA ||
-                contact.FixtureB?.Body == bodyA)
+            if (contact.EntityA == joint.BodyAUid ||
+                contact.EntityB == joint.BodyAUid)
             {
                 // Flag the contact for filtering at the next time step (where either
                 // body is awake).

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
@@ -138,6 +138,9 @@ public abstract partial class SharedPhysicsSystem
         contact.FixtureA = fixtureA;
         contact.FixtureB = fixtureB;
 
+        contact.BodyA = fixtureA?.Body;
+        contact.BodyB = fixtureB?.Body;
+
         contact.ChildIndexA = indexA;
         contact.ChildIndexB = indexB;
 
@@ -231,8 +234,8 @@ public abstract partial class SharedPhysicsSystem
         // Contact creation may swap fixtures.
         fixtureA = contact.FixtureA!;
         fixtureB = contact.FixtureB!;
-        bodyA = fixtureA.Body;
-        bodyB = fixtureB.Body;
+        bodyA = contact.BodyA!;
+        bodyB = contact.BodyB!;
 
         // Insert into world
         _activeContacts.AddLast(contact.MapNode);
@@ -253,7 +256,7 @@ public abstract partial class SharedPhysicsSystem
     /// </summary>
     internal void AddPair(in FixtureProxy proxyA, in FixtureProxy proxyB)
     {
-        AddPair(proxyA.Fixture.Body.Owner, proxyB.Fixture.Body.Owner, proxyA.Fixture, proxyA.ChildIndex, proxyB.Fixture, proxyB.ChildIndex);
+        AddPair(proxyA.Entity, proxyB.Entity, proxyA.Fixture, proxyA.ChildIndex, proxyB.Fixture, proxyB.ChildIndex);
     }
 
     internal static bool ShouldCollide(Fixture fixtureA, Fixture fixtureB)
@@ -266,15 +269,15 @@ public abstract partial class SharedPhysicsSystem
     {
         Fixture fixtureA = contact.FixtureA!;
         Fixture fixtureB = contact.FixtureB!;
-        PhysicsComponent bodyA = fixtureA.Body;
-        PhysicsComponent bodyB = fixtureB.Body;
+        var bodyA = contact.BodyA!;
+        var bodyB = contact.BodyB!;
         var aUid = bodyA.Owner;
         var bUid = bodyB.Owner;
 
         if (contact.IsTouching)
         {
-            var ev1 = new EndCollideEvent(aUid, bUid, fixtureA, fixtureB);
-            var ev2 = new EndCollideEvent(bUid, aUid, fixtureB, fixtureA);
+            var ev1 = new EndCollideEvent(aUid, bUid, fixtureA, fixtureB, bodyA, bodyB);
+            var ev2 = new EndCollideEvent(bUid, aUid, fixtureB, fixtureA, bodyB, bodyA);
             RaiseLocalEvent(aUid, ref ev1);
             RaiseLocalEvent(bUid, ref ev2);
         }
@@ -329,8 +332,8 @@ public abstract partial class SharedPhysicsSystem
             int indexA = contact.ChildIndexA;
             int indexB = contact.ChildIndexB;
 
-            var bodyA = fixtureA.Body;
-            var bodyB = fixtureB.Body;
+            var bodyA = contact.BodyA!;
+            var bodyB = contact.BodyB!;
             var uidA = contact.EntityA;
             var uidB = contact.EntityB;
 
@@ -475,12 +478,14 @@ public abstract partial class SharedPhysicsSystem
 
                     var fixtureA = contact.FixtureA!;
                     var fixtureB = contact.FixtureB!;
+                    var bodyA = fixtureA.Body;
+                    var bodyB = fixtureB.Body;
                     var uidA = contact.EntityA;
                     var uidB = contact.EntityB;
                     var worldPoint = worldPoints[i];
 
-                    var ev1 = new StartCollideEvent(uidA, uidB, fixtureA, fixtureB, worldPoint);
-                    var ev2 = new StartCollideEvent(uidB, uidA, fixtureB, fixtureA, worldPoint);
+                    var ev1 = new StartCollideEvent(uidA, uidB, fixtureA, fixtureB, bodyA, bodyB, worldPoint);
+                    var ev2 = new StartCollideEvent(uidB, uidA, fixtureB, fixtureA, bodyB, bodyA, worldPoint);
 
                     RaiseLocalEvent(uidA, ref ev1, true);
                     RaiseLocalEvent(uidB, ref ev2, true);
@@ -497,13 +502,13 @@ public abstract partial class SharedPhysicsSystem
                     // then we'll just skip the EndCollide.
                     if (fixtureA == null || fixtureB == null) continue;
 
-                    var bodyA = fixtureA.Body;
-                    var bodyB = fixtureB.Body;
+                    var bodyA = contact.BodyA!;
+                    var bodyB = contact.BodyB!;
                     var uidA = contact.EntityA;
                     var uidB = contact.EntityB;
 
-                    var ev1 = new EndCollideEvent(uidA, uidB, fixtureA, fixtureB);
-                    var ev2 = new EndCollideEvent(uidB, uidA, fixtureB, fixtureA);
+                    var ev1 = new EndCollideEvent(uidA, uidB, fixtureA, fixtureB, bodyA, bodyB);
+                    var ev2 = new EndCollideEvent(uidB, uidA, fixtureB, fixtureA, bodyB, bodyA);
 
                     RaiseLocalEvent(uidA, ref ev1);
                     RaiseLocalEvent(uidB, ref ev2);
@@ -549,8 +554,8 @@ public abstract partial class SharedPhysicsSystem
             if (!shouldWake) continue;
 
             var contact = contacts[i];
-            var bodyA = contact.FixtureA!.Body;
-            var bodyB = contact.FixtureB!.Body;
+            var bodyA = contact.BodyA!;
+            var bodyB = contact.BodyB!;
             var aUid = contact.EntityA;
             var bUid = contact.EntityB;
 

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Fixtures.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Fixtures.cs
@@ -23,7 +23,7 @@ public abstract partial class SharedPhysicsSystem
         fixture.Density = value;
 
         if (update)
-            _fixtures.FixtureUpdate(uid, manager: manager, body: fixture.Body);
+            _fixtures.FixtureUpdate(uid, manager: manager);
     }
 
     public void SetFriction(EntityUid uid, Fixture fixture, float value, bool update = true, FixturesComponent? manager = null)
@@ -39,7 +39,7 @@ public abstract partial class SharedPhysicsSystem
         fixture.Friction = value;
 
         if (update)
-            _fixtures.FixtureUpdate(uid, manager: manager, body: fixture.Body);
+            _fixtures.FixtureUpdate(uid, manager: manager);
     }
 
     public void SetHard(EntityUid uid, Fixture fixture, bool value, FixturesComponent? manager = null)
@@ -51,8 +51,8 @@ public abstract partial class SharedPhysicsSystem
             return;
 
         fixture.Hard = value;
-        _fixtures.FixtureUpdate(uid, manager: manager, body:fixture.Body);
-        WakeBody(uid, body: fixture.Body);
+        _fixtures.FixtureUpdate(uid, manager: manager);
+        WakeBody(uid);
     }
 
     public void SetRestitution(EntityUid uid, Fixture fixture, float value, bool update = true, FixturesComponent? manager = null)
@@ -68,7 +68,7 @@ public abstract partial class SharedPhysicsSystem
         fixture.Restitution = value;
 
         if (update)
-            _fixtures.FixtureUpdate(uid, manager: manager, body: fixture.Body);
+            _fixtures.FixtureUpdate(uid, manager: manager);
     }
 
     #region Collision Masks & Layers
@@ -88,7 +88,7 @@ public abstract partial class SharedPhysicsSystem
             _fixtures.FixtureUpdate(uid, manager: manager, body: body);
         }
 
-        _broadphase.Refilter(fixture);
+        _broadphase.Refilter(uid, fixture);
     }
 
     public void SetCollisionMask(EntityUid uid, Fixture fixture, int mask, FixturesComponent? manager = null, PhysicsComponent? body = null)
@@ -106,7 +106,7 @@ public abstract partial class SharedPhysicsSystem
             _fixtures.FixtureUpdate(uid, manager: manager, body: body);
         }
 
-        _broadphase.Refilter(fixture);
+        _broadphase.Refilter(uid, fixture);
     }
 
     public void RemoveCollisionMask(EntityUid uid, Fixture fixture, int mask, FixturesComponent? manager = null, PhysicsComponent? body = null)
@@ -124,7 +124,7 @@ public abstract partial class SharedPhysicsSystem
             _fixtures.FixtureUpdate(uid, manager: manager, body: body);
         }
 
-        _broadphase.Refilter(fixture);
+        _broadphase.Refilter(uid, fixture);
     }
 
     public void AddCollisionLayer(EntityUid uid, Fixture fixture, int layer, FixturesComponent? manager = null, PhysicsComponent? body = null)
@@ -142,7 +142,7 @@ public abstract partial class SharedPhysicsSystem
             _fixtures.FixtureUpdate(uid, manager: manager, body: body);
         }
 
-        _broadphase.Refilter(fixture);
+        _broadphase.Refilter(uid, fixture);
     }
 
     public void SetCollisionLayer(EntityUid uid, Fixture fixture, int layer, FixturesComponent? manager = null, PhysicsComponent? body = null)
@@ -160,7 +160,7 @@ public abstract partial class SharedPhysicsSystem
             _fixtures.FixtureUpdate(uid, manager: manager, body: body);
         }
 
-        _broadphase.Refilter(fixture);
+        _broadphase.Refilter(uid, fixture);
     }
 
     public void RemoveCollisionLayer(EntityUid uid, Fixture fixture, int layer, FixturesComponent? manager = null, PhysicsComponent? body = null)
@@ -175,7 +175,7 @@ public abstract partial class SharedPhysicsSystem
             _fixtures.FixtureUpdate(uid, manager: manager, body: body);
         }
 
-        _broadphase.Refilter(fixture);
+        _broadphase.Refilter(uid, fixture);
     }
 
     #endregion

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
@@ -385,8 +385,8 @@ public abstract partial class SharedPhysicsSystem
 
                     contacts.Add(contact);
                     contact.Flags |= ContactFlags.Island;
-                    var bodyA = contact.FixtureA!.Body;
-                    var bodyB = contact.FixtureB!.Body;
+                    var bodyA = contact.BodyA!;
+                    var bodyB = contact.BodyB!;
 
                     var other = bodyA == body ? bodyB : bodyA;
 

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Shapes.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Shapes.cs
@@ -28,8 +28,8 @@ public abstract partial class SharedPhysicsSystem
             TryComp<BroadphaseComponent>(xform.Broadphase?.Uid, out var broadphase) &&
             TryComp<PhysicsMapComponent>(xform.MapUid, out var physicsMap))
         {
-            _lookup.DestroyProxies(fixture, xform, broadphase, physicsMap);
-            _lookup.CreateProxies(xform, fixture);
+            _lookup.DestroyProxies(uid, fixture, xform, broadphase, physicsMap);
+            _lookup.CreateProxies(uid, xform, fixture, body);
         }
 
         _fixtures.FixtureUpdate(uid, manager: manager, body: body);
@@ -58,8 +58,8 @@ public abstract partial class SharedPhysicsSystem
             TryComp<BroadphaseComponent>(xform.Broadphase?.Uid, out var broadphase) &&
             TryComp<PhysicsMapComponent>(xform.MapUid, out var physicsMap))
         {
-            _lookup.DestroyProxies(fixture, xform, broadphase, physicsMap);
-            _lookup.CreateProxies(xform, fixture);
+            _lookup.DestroyProxies(uid, fixture, xform, broadphase, physicsMap);
+            _lookup.CreateProxies(uid, xform, fixture, body);
         }
 
         Dirty(manager);
@@ -83,8 +83,8 @@ public abstract partial class SharedPhysicsSystem
             TryComp<BroadphaseComponent>(xform.Broadphase?.Uid, out var broadphase) &&
             TryComp<PhysicsMapComponent>(xform.MapUid, out var physicsMap))
         {
-            _lookup.DestroyProxies(fixture, xform, broadphase, physicsMap);
-            _lookup.CreateProxies(xform, fixture);
+            _lookup.DestroyProxies(uid, fixture, xform, broadphase, physicsMap);
+            _lookup.CreateProxies(uid, xform, fixture, body);
         }
 
         Dirty(manager);
@@ -118,8 +118,8 @@ public abstract partial class SharedPhysicsSystem
             TryComp<BroadphaseComponent>(xform.Broadphase?.Uid, out var broadphase) &&
             TryComp<PhysicsMapComponent>(xform.MapUid, out var physicsMap))
         {
-            _lookup.DestroyProxies(fixture, xform, broadphase, physicsMap);
-            _lookup.CreateProxies(xform, fixture);
+            _lookup.DestroyProxies(uid, fixture, xform, broadphase, physicsMap);
+            _lookup.CreateProxies(uid, xform, fixture, body);
         }
 
         _fixtures.FixtureUpdate(uid, manager: manager, body: body);
@@ -147,8 +147,8 @@ public abstract partial class SharedPhysicsSystem
             TryComp<BroadphaseComponent>(xform.Broadphase?.Uid, out var broadphase) &&
             TryComp<PhysicsMapComponent>(xform.MapUid, out var physicsMap))
         {
-            _lookup.DestroyProxies(fixture, xform, broadphase, physicsMap);
-            _lookup.CreateProxies(xform, fixture);
+            _lookup.DestroyProxies(uid, fixture, xform, broadphase, physicsMap);
+            _lookup.CreateProxies(uid, xform, fixture, body);
         }
 
         _fixtures.FixtureUpdate(uid, manager: manager, body: body);

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Solver.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Solver.cs
@@ -53,8 +53,8 @@ public abstract partial class SharedPhysicsSystem
             var shapeB = fixtureB.Shape;
             float radiusA = shapeA.Radius;
             float radiusB = shapeB.Radius;
-            var bodyA = fixtureA.Body;
-            var bodyB = fixtureB.Body;
+            var bodyA = contact.BodyA!;
+            var bodyB = contact.BodyB!;
             var manifold = contact.Manifold;
 
             int pointCount = manifold.PointCount;

--- a/Robust.UnitTesting/Shared/Map/GridCollision_Test.cs
+++ b/Robust.UnitTesting/Shared/Map/GridCollision_Test.cs
@@ -59,8 +59,8 @@ namespace Robust.UnitTesting.Shared.Map
                     var contact = node.Value;
                     node = node.Next;
 
-                    var bodyA = contact.FixtureA!.Body;
-                    var bodyB = contact.FixtureB!.Body;
+                    var bodyA = contact.BodyA;
+                    var bodyB = contact.BodyB;
 
                     var other = physics1 == bodyA ? bodyB : bodyA;
 
@@ -89,8 +89,8 @@ namespace Robust.UnitTesting.Shared.Map
                     if (!contact.IsTouching)
                         continue;
 
-                    var bodyA = contact.FixtureA!.Body;
-                    var bodyB = contact.FixtureB!.Body;
+                    var bodyA = contact.BodyA;
+                    var bodyB = contact.BodyB;
 
                     var other = physics1 == bodyA ? bodyB : bodyA;
 


### PR DESCRIPTION
Removes several references to `Fixture.Body` & `Fixture.Body.Owner`. This also adds new `PhysicsComponent` and EntityUid fields to the collision events and `FixtureProxy` & `Contact` classes.

Requires space-wizards/space-station-14/pull/16259