### PR TITLE
Fix JSON Serialization of ResPath

### DIFF
--- a/Robust.Shared/Utility/ResPath.cs
+++ b/Robust.Shared/Utility/ResPath.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 using Robust.Shared.Collections;
 using Robust.Shared.Serialization;
@@ -91,6 +92,7 @@ public readonly struct ResPath : IEquatable<ResPath>
     ///     Assert.AreEqual("/foo", new ResPath("/foo/x.txt").Directory.ToString());
     /// </code>
     /// </example>
+    [JsonIgnore]
     public ResPath Directory
     {
         get


### PR DESCRIPTION
Removed ResPath.Directory from the JSON Serialization, because it would result in an infinitely deep tree.

Caused Space Station 14's Update Wiki workflow to fail when it hit object depth limit. Example log:
https://github.com/space-wizards/space-station-14/actions/runs/4945710402/jobs/8842799335

For the record, ResourcePath also had the same issue before it was replaced by ResPath, but the workflow didn't serialize any files that had ResourcePaths back then.

## Testing
Run the same command as the SS14 workflow:
`dotnet ./bin/Content.Server/Content.Server.dll --cvar autogen.destination_file=prototypes.json`