### PR TITLE
Change prof tree style & add basic stylesheet support

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -273,6 +273,7 @@ namespace Robust.Client.Graphics.Clyde
                 BatchPrimitiveType.TriangleStrip => PrimitiveType.TriangleStrip,
                 BatchPrimitiveType.LineList => PrimitiveType.Lines,
                 BatchPrimitiveType.LineStrip => PrimitiveType.LineStrip,
+                BatchPrimitiveType.LineLoop => PrimitiveType.LineLoop,
                 BatchPrimitiveType.PointList => PrimitiveType.Points,
                 _ => PrimitiveType.Triangles
             };
@@ -649,6 +650,7 @@ namespace Robust.Client.Graphics.Clyde
                 DrawPrimitiveTopology.TriangleStrip => BatchPrimitiveType.TriangleStrip,
                 DrawPrimitiveTopology.LineList => BatchPrimitiveType.LineList,
                 DrawPrimitiveTopology.LineStrip => BatchPrimitiveType.LineStrip,
+                DrawPrimitiveTopology.LineLoop => BatchPrimitiveType.LineLoop,
                 DrawPrimitiveTopology.PointList => BatchPrimitiveType.PointList,
                 _ => BatchPrimitiveType.TriangleList
             };
@@ -1033,6 +1035,7 @@ namespace Robust.Client.Graphics.Clyde
             TriangleStrip,
             LineList,
             LineStrip,
+            LineLoop,
             PointList,
         }
 

--- a/Robust.Client/Graphics/Drawing/DrawPrimitiveTopology.cs
+++ b/Robust.Client/Graphics/Drawing/DrawPrimitiveTopology.cs
@@ -13,6 +13,7 @@ namespace Robust.Client.Graphics
         TriangleFan,
         TriangleStrip,
         LineList,
-        LineStrip
+        LineStrip,
+        LineLoop
     }
 }

--- a/Robust.Client/UserInterface/Control.Styling.cs
+++ b/Robust.Client/UserInterface/Control.Styling.cs
@@ -248,9 +248,9 @@ namespace Robust.Client.UserInterface
 
         public bool TryGetStyleProperty<T>(string param, [MaybeNullWhen(false)] out T value)
         {
-            if (_styleProperties.TryGetValue(param, out var val))
+            if (_styleProperties.TryGetValue(param, out var val) && val is T cast)
             {
-                value = (T) val;
+                value = cast;
                 return true;
             }
 

--- a/Robust.Client/UserInterface/DevWindow/ExpanderArrow.cs
+++ b/Robust.Client/UserInterface/DevWindow/ExpanderArrow.cs
@@ -8,6 +8,10 @@ internal sealed class ExpanderArrow : Control
 {
     public bool Rotated { get; set; }
 
+    public Color Color = Color.White;
+
+    public Color? OutlineColor;
+
     protected internal override void Draw(DrawingHandleScreen handle)
     {
         Span<Vector2> triangle = stackalloc Vector2[3];
@@ -27,6 +31,8 @@ internal sealed class ExpanderArrow : Control
             t *= PixelSize;
         }
 
-        handle.DrawPrimitives(DrawPrimitiveTopology.TriangleList, triangle, Color.White);
+        handle.DrawPrimitives(DrawPrimitiveTopology.TriangleList, triangle, Color);
+        if (OutlineColor != null)
+            handle.DrawPrimitives(DrawPrimitiveTopology.LineLoop, triangle, OutlineColor.Value);
     }
 }

--- a/Robust.Client/UserInterface/DevWindow/ProfAltBackground.cs
+++ b/Robust.Client/UserInterface/DevWindow/ProfAltBackground.cs
@@ -6,10 +6,19 @@ namespace Robust.Client.UserInterface;
 internal sealed class ProfAltBackground : Control
 {
     public bool IsAltBackground { get; set; }
+    public Color Color = DefaultColor;
+    public static readonly Color DefaultColor = new (255, 255, 255, 16);
+
+    protected override void StylePropertiesChanged()
+    {
+        base.StylePropertiesChanged();
+        if (!TryGetStyleProperty("color", out Color))
+            Color = DefaultColor;
+    }
 
     protected internal override void Draw(DrawingHandleScreen handle)
     {
         if (IsAltBackground)
-            handle.DrawRect(PixelSizeBox, new Color(0, 0, 0, 128));
+            handle.DrawRect(PixelSizeBox, Color);
     }
 }

--- a/Robust.Client/UserInterface/DevWindow/ProfAltBackground.cs
+++ b/Robust.Client/UserInterface/DevWindow/ProfAltBackground.cs
@@ -7,7 +7,7 @@ internal sealed class ProfAltBackground : Control
 {
     public bool IsAltBackground { get; set; }
     public Color Color = DefaultColor;
-    public static readonly Color DefaultColor = new (255, 255, 255, 16);
+    public static readonly Color DefaultColor = Color.FromHex("#222222");
 
     protected override void StylePropertiesChanged()
     {

--- a/Robust.Client/UserInterface/DevWindow/ProfTreeEntry.xaml.cs
+++ b/Robust.Client/UserInterface/DevWindow/ProfTreeEntry.xaml.cs
@@ -13,6 +13,17 @@ internal sealed partial class ProfTreeEntry : Control
     private readonly ProfTree.TreeExpand _parentExpand;
     public readonly (int str, int i) Id;
 
+    protected override void StylePropertiesChanged()
+    {
+        base.StylePropertiesChanged();
+
+        if (!TryGetStyleProperty("arrowColor", out Arrow.Color))
+            Arrow.Color = Color.White;
+
+        if (!TryGetStyleProperty("arrowOutline", out Arrow.OutlineColor))
+            Arrow.OutlineColor = Color.Black;
+    }
+
     public ProfTreeEntry(
         ProfTree tab,
         ProfTree.TreeExpand parentExpand,


### PR DESCRIPTION
Makes the alternating rows visible again after the background colour was changed to black.


![Content Client_JszXtN6b54](https://github.com/space-wizards/RobustToolbox/assets/60421075/55fff9d8-882d-4cd7-af3a-76ba523120dd)
