### PR TITLE
Use local session for local client-side shells.

### DIFF
--- a/Robust.Client/Console/ClientConsoleHost.cs
+++ b/Robust.Client/Console/ClientConsoleHost.cs
@@ -171,7 +171,7 @@ namespace Robust.Client.Console
             }
 
             args.RemoveAt(0);
-            var shell = new ConsoleShell(this, null);
+            var shell = new ConsoleShell(this, session ?? _player.LocalPlayer?.Session, session == null);
             var cmdArgs = args.ToArray();
 
             AnyCommandExecuted?.Invoke(shell, commandName, command, cmdArgs);

--- a/Robust.Server/Console/ServerConsoleHost.cs
+++ b/Robust.Server/Console/ServerConsoleHost.cs
@@ -27,7 +27,7 @@ namespace Robust.Server.Console
         /// <inheritdoc />
         public override void ExecuteCommand(ICommonSession? session, string command)
         {
-            var shell = new ConsoleShell(this, session);
+            var shell = new ConsoleShell(this, session, session == null);
             ExecuteInShell(shell, command);
         }
 
@@ -183,7 +183,7 @@ namespace Robust.Server.Console
         private async void HandleConCompletions(MsgConCompletion message)
         {
             var session = _players.GetSessionByChannel(message.MsgChannel);
-            var shell = new ConsoleShell(this, session);
+            var shell = new ConsoleShell(this, session, false);
 
             var result = await CalcCompletions(shell, message.Args);
 
@@ -236,6 +236,7 @@ namespace Robust.Server.Console
             public IConsoleHost ConsoleHost => _host;
             public bool IsServer => _owner.IsServer;
             public ICommonSession? Player => _owner.Player;
+            public bool IsLocal => _owner.IsLocal;
 
             public void ExecuteCommand(string command)
             {

--- a/Robust.Shared/Console/ConsoleHost.cs
+++ b/Robust.Shared/Console/ConsoleHost.cs
@@ -45,7 +45,7 @@ namespace Robust.Shared.Console
         protected ConsoleHost(bool isServer)
         {
             IsServer = isServer;
-            LocalShell = new ConsoleShell(this, null);
+            LocalShell = new ConsoleShell(this, null, true);
         }
 
         /// <inheritdoc />
@@ -190,7 +190,7 @@ namespace Robust.Shared.Console
             if (session.Status >= SessionStatus.Disconnected)
                 throw new InvalidOperationException("Tried to get the session shell of a disconnected peer.");
 
-            return new ConsoleShell(this, session);
+            return new ConsoleShell(this, session, false);
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/Console/ConsoleShell.cs
+++ b/Robust.Shared/Console/ConsoleShell.cs
@@ -9,12 +9,13 @@ namespace Robust.Shared.Console
         /// Constructs a new instance of <see cref="ConsoleShell"/>.
         /// </summary>
         /// <param name="host">Console Host that owns this shell.</param>
-        /// <param name="session">Player Session that this shell represents. If this is null, then
-        /// the shell is representing the local console.</param>
-        public ConsoleShell(IConsoleHost host, ICommonSession? session)
+        /// <param name="session">Player Session that this shell represents. May be null if this is a local server-side shell.</param>
+        /// <param name="isLocal">Whether this is a local or remote shell.</param>
+        public ConsoleShell(IConsoleHost host, ICommonSession? session, bool isLocal)
         {
             ConsoleHost = host;
             Player = session;
+            IsLocal = isLocal;
         }
 
         /// <inheritdoc />
@@ -25,6 +26,9 @@ namespace Robust.Shared.Console
 
         /// <inheritdoc />
         public ICommonSession? Player { get; }
+
+        /// <inheritdoc />
+        public bool IsLocal { get; }
 
         /// <inheritdoc />
         public void ExecuteCommand(string command)

--- a/Robust.Shared/Console/IConsoleShell.cs
+++ b/Robust.Shared/Console/IConsoleShell.cs
@@ -19,9 +19,9 @@ namespace Robust.Shared.Console
         bool IsClient => !IsServer;
 
         /// <summary>
-        /// Is the shell running in a local context (no remote peer session)? If true, <see cref="Player" /> will be null.
+        /// Is the shell running in a local context (no remote peer session)?.
         /// </summary>
-        bool IsLocal => Player is not null;
+        bool IsLocal { get; }
 
         /// <summary>
         /// Is the shell running on the server?
@@ -29,7 +29,7 @@ namespace Robust.Shared.Console
         bool IsServer { get; }
 
         /// <summary>
-        /// The remote peer that owns this shell. This is null if the shell is running local (<see cref="IsLocal" /> is true.).
+        /// The remote peer that owns this shell, or the local player if this is a client-side local shell (<see cref="IsLocal" /> is true and <see cref="IsClient"/> is true).
         /// </summary>
         ICommonSession? Player { get; }
 


### PR DESCRIPTION
Fixes #3962. Makes adding shared (multiplayer or single-player) commands much easier.