### PR TITLE
Move tpto command to shared.

### DIFF
--- a/Resources/Locale/en-US/commands.ftl
+++ b/Resources/Locale/en-US/commands.ftl
@@ -379,6 +379,8 @@ cmd-tp-help = tp <x> <y> [<mapID>]
 
 cmd-tpto-desc = Teleports the current player or the specified players/entities to the location of last player/entity specified.d.
 cmd-tpto-help = tpto <username|uid> [username|uid]...
+cmd-tpto-destination-hint = destination (uid or username)
+cmd-tpto-victim-hint = entity to teleport (uid or username)
 
 cmd-listplayers-desc = Lists all players currently connected.
 cmd-listplayers-help = listplayers

--- a/Resources/Locale/en-US/commands.ftl
+++ b/Resources/Locale/en-US/commands.ftl
@@ -11,6 +11,7 @@ cmd-parse-failure-uid = {$arg} is not a valid entity UID.
 cmd-parse-failure-mapid = {$arg} is not a valid MapId.
 cmd-parse-failure-entity-exist = UID {$arg} does not correspond to an existing entity.
 
+cmd-failure-no-attached-entity = There is no entity attached to this shell.
 
 ## 'help' command
 cmd-help-desc = Display general help or help text for a specific command
@@ -381,6 +382,7 @@ cmd-tpto-desc = Teleports the current player or the specified players/entities t
 cmd-tpto-help = tpto <username|uid> [username|uid]...
 cmd-tpto-destination-hint = destination (uid or username)
 cmd-tpto-victim-hint = entity to teleport (uid or username)
+cmd-tpto-parse-error = Cant resolve entity or player: {$str}
 
 cmd-listplayers-desc = Lists all players currently connected.
 cmd-listplayers-help = listplayers

--- a/Resources/Locale/en-US/commands.ftl
+++ b/Resources/Locale/en-US/commands.ftl
@@ -378,7 +378,7 @@ cmd-netaudit-help = netaudit
 cmd-tp-desc = Teleports a player to any location in the round.
 cmd-tp-help = tp <x> <y> [<mapID>]
 
-cmd-tpto-desc = Teleports the current player or the specified players/entities to the location of last player/entity specified.d.
+cmd-tpto-desc = Teleports the current player or the specified players/entities to the location of the first player/entity.
 cmd-tpto-help = tpto <username|uid> [username|uid]...
 cmd-tpto-destination-hint = destination (uid or username)
 cmd-tpto-victim-hint = entity to teleport (uid or username)

--- a/Robust.Server/Console/Commands/PlayerCommands.cs
+++ b/Robust.Server/Console/Commands/PlayerCommands.cs
@@ -1,102 +1,13 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using Robust.Server.Player;
 using Robust.Shared.Console;
-using Robust.Shared.Enums;
-using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Network;
 
 namespace Robust.Server.Console.Commands
 {
-    public sealed class TeleportToCommand : LocalizedCommands
-    {
-        [Dependency] private readonly IPlayerManager _players = default!;
-        [Dependency] private readonly IEntityManager _entities = default!;
-
-        public override string Command => "tpto";
-
-        public override void Execute(IConsoleShell shell, string argStr, string[] args)
-        {
-            if (args.Length == 0)
-                return;
-
-            var target = args[^1];
-
-            if (!TryGetTransformFromUidOrUsername(target, shell, _entities, _players, out _, out var targetTransform))
-                return;
-
-            var transformSystem = _entities.System<SharedTransformSystem>();
-            var targetCoords = targetTransform.Coordinates;
-
-            if (args.Length == 1)
-            {
-                var player = shell.Player as IPlayerSession;
-                if (player?.Status != SessionStatus.InGame)
-                {
-                    shell.WriteError("You need to be in game to teleport to an entity.");
-                    return;
-                }
-
-                if (!_entities.TryGetComponent(player.AttachedEntity, out TransformComponent? playerTransform))
-                {
-                    shell.WriteError("You don't have an entity.");
-                    return;
-                }
-
-                transformSystem.SetCoordinates(player.AttachedEntity!.Value, targetCoords);
-                playerTransform.AttachToGridOrMap();
-            }
-            else
-            {
-                foreach (var victim in args)
-                {
-                    if (victim == target)
-                        continue;
-
-                    if (!TryGetTransformFromUidOrUsername(victim, shell, _entities, _players, out var uid, out var victimTransform))
-                        return;
-
-                    transformSystem.SetCoordinates(uid.Value, targetCoords);
-                    victimTransform.AttachToGridOrMap();
-                }
-            }
-        }
-
-        private static bool TryGetTransformFromUidOrUsername(
-            string str,
-            IConsoleShell shell,
-            IEntityManager entMan,
-            IPlayerManager playerMan,
-            [NotNullWhen(true)] out EntityUid? victimUid,
-            [NotNullWhen(true)] out TransformComponent? transform)
-        {
-            if (EntityUid.TryParse(str, out var uid) && entMan.TryGetComponent(uid, out transform))
-            {
-                victimUid = uid;
-                return true;
-            }
-
-            if (playerMan.TryGetSessionByUsername(str, out var session)
-                && entMan.TryGetComponent(session.AttachedEntity, out transform))
-            {
-                victimUid = session.AttachedEntity;
-                return true;
-            }
-
-            if (session == null)
-                shell.WriteError("Can't find username/id: " + str);
-            else
-                shell.WriteError(str + " does not have an entity.");
-
-            transform = null;
-            victimUid = default;
-            return false;
-        }
-    }
-
     public sealed class ListPlayers : LocalizedCommands
     {
         [Dependency] private readonly IPlayerManager _players = default!;

--- a/Robust.Shared/Console/Commands/TeleportCommands.cs
+++ b/Robust.Shared/Console/Commands/TeleportCommands.cs
@@ -1,9 +1,15 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Localization;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
+using Robust.Shared.Players;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Console.Commands;
 
@@ -59,6 +65,106 @@ internal sealed class TeleportCommand : LocalizedCommands
         }
 
         shell.WriteLine($"Teleported {shell.Player} to {mapId}:{posX},{posY}.");
+    }
+}
+
+public sealed class TeleportToCommand : LocalizedCommands
+{
+    [Dependency] private readonly ISharedPlayerManager _players = default!;
+    [Dependency] private readonly IEntityManager _entities = default!;
+
+    public override string Command => "tpto";
+    public override bool RequireServerOrSingleplayer => true;
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length == 0)
+            return;
+
+        var target = args[^1];
+
+        if (!TryGetTransformFromUidOrUsername(target, shell, _entities, _players, out _, out var targetTransform))
+            return;
+
+        var transformSystem = _entities.System<SharedTransformSystem>();
+        var targetCoords = targetTransform.Coordinates;
+
+        if (args.Length == 1)
+        {
+            var ent = shell.Player?.AttachedEntity;
+
+            if (!_entities.TryGetComponent(ent, out TransformComponent? playerTransform))
+            {
+                shell.WriteError(Loc.GetString("cmd-failure-no-attached-entity"));
+                return;
+            }
+
+            transformSystem.SetCoordinates(ent.Value, targetCoords);
+            playerTransform.AttachToGridOrMap();
+        }
+        else
+        {
+            foreach (var victim in args)
+            {
+                if (victim == target)
+                    continue;
+
+                if (!TryGetTransformFromUidOrUsername(victim, shell, _entities, _players, out var uid, out var victimTransform))
+                    return;
+
+                transformSystem.SetCoordinates(uid.Value, targetCoords);
+                victimTransform.AttachToGridOrMap();
+            }
+        }
+    }
+
+    private static bool TryGetTransformFromUidOrUsername(
+        string str,
+        IConsoleShell shell,
+        IEntityManager entMan,
+        ISharedPlayerManager playerMan,
+        [NotNullWhen(true)] out EntityUid? victimUid,
+        [NotNullWhen(true)] out TransformComponent? transform)
+    {
+        if (EntityUid.TryParse(str, out var uid) && entMan.TryGetComponent(uid, out transform))
+        {
+            victimUid = uid;
+            return true;
+        }
+
+        if (playerMan.Sessions.TryFirstOrDefault(x => x.ConnectedClient.UserName == str, out var session)
+            && entMan.TryGetComponent(session.AttachedEntity, out transform))
+        {
+            victimUid = session.AttachedEntity;
+            return true;
+        }
+
+        shell.WriteError(Loc.GetString("cmd-tpto-parse-error", ("str",str)));
+
+        transform = null;
+        victimUid = default;
+        return false;
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 0)
+            return CompletionResult.Empty;
+        ;
+        var last = args[^1];
+
+        var users = _players.Sessions
+            .Select(x => x.ConnectedClient.UserName ?? string.Empty)
+            .Where(x => !string.IsNullOrWhiteSpace(x) && x.StartsWith(last, StringComparison.CurrentCultureIgnoreCase));
+
+        var hint = args.Length == 1 ? "cmd-tpto-destination-hint" : "cmd-tpto-victim-hint";
+        hint = Loc.GetString(hint);
+
+        var opts = CompletionResult.FromHintOptions(users, hint);
+        if (last != string.Empty && !EntityUid.TryParse(last, out _))
+            return opts;
+
+        return CompletionResult.FromHintOptions(opts.Options.Concat(CompletionHelper.EntityUids(last, _entities)), hint);
     }
 }
 

--- a/Robust.Shared/Console/Commands/TeleportCommands.cs
+++ b/Robust.Shared/Console/Commands/TeleportCommands.cs
@@ -81,7 +81,7 @@ public sealed class TeleportToCommand : LocalizedCommands
         if (args.Length == 0)
             return;
 
-        var target = args[^1];
+        var target = args[0];
 
         if (!TryGetTransformFromUidOrUsername(target, shell, _entities, _players, out _, out var targetTransform))
             return;


### PR DESCRIPTION
Allows single-player games & replays to use the command. Also adds completions & localization.

Also changes the order of the arguments. The destination entity is now the first entity, rather than the last.
I initially assumed that that was how it worked, and without changing the order there is no way to give meaningful completion hints for what the argument represents.