### PR TITLE
vv perm tweaks

### DIFF
--- a/Robust.Client/ViewVariables/ClientViewVariablesManager.cs
+++ b/Robust.Client/ViewVariables/ClientViewVariablesManager.cs
@@ -418,7 +418,7 @@ namespace Robust.Client.ViewVariables
             tcs.SetException(new SessionDenyException(message.Reason));
         }
 
-        protected override bool CheckPermissions(INetChannel channel)
+        protected override bool CheckPermissions(INetChannel channel, string command)
         {
             // Acquiesce, client!! Do what the server tells you.
             return true;

--- a/Robust.Server/Console/ConGroupController.cs
+++ b/Robust.Server/Console/ConGroupController.cs
@@ -11,11 +11,6 @@ namespace Robust.Server.Console
             return Implementation?.CanCommand(session, cmdName) ?? false;
         }
 
-        public bool CanViewVar(IPlayerSession session)
-        {
-            return Implementation?.CanViewVar(session) ?? false;
-        }
-
         public bool CanAdminPlace(IPlayerSession session)
         {
             return Implementation?.CanAdminPlace(session) ?? false;

--- a/Robust.Server/Console/IConGroupControllerImplementation.cs
+++ b/Robust.Server/Console/IConGroupControllerImplementation.cs
@@ -5,7 +5,6 @@ namespace Robust.Server.Console
     public interface IConGroupControllerImplementation
     {
         bool CanCommand(IPlayerSession session, string cmdName);
-        bool CanViewVar(IPlayerSession session);
         bool CanAdminPlace(IPlayerSession session);
         bool CanScript(IPlayerSession session);
         bool CanAdminMenu(IPlayerSession session);

--- a/Robust.Server/ViewVariables/ServerViewVariablesManager.cs
+++ b/Robust.Server/ViewVariables/ServerViewVariablesManager.cs
@@ -112,7 +112,7 @@ namespace Robust.Server.ViewVariables
             }
 
             var player = _playerManager.GetSessionByChannel(message.MsgChannel);
-            if (!_groupController.CanViewVar(player))
+            if (!_groupController.CanCommand(player, "vv"))
             {
                 Deny(ViewVariablesResponseCode.NoAccess);
                 return;
@@ -286,16 +286,16 @@ namespace Robust.Server.ViewVariables
             }
         }
 
-        protected override bool CheckPermissions(INetChannel channel)
+        protected override bool CheckPermissions(INetChannel channel, string command)
         {
-            return _playerManager.TryGetSessionByChannel(channel, out var session) && _groupController.CanViewVar(session);
+            return _playerManager.TryGetSessionByChannel(channel, out var session) && _groupController.CanCommand(session, command);
         }
 
         protected override bool TryGetSession(Guid guid, [NotNullWhen(true)] out ICommonSession? session)
         {
             if (guid != Guid.Empty
                 && _playerManager.TryGetSessionById(new NetUserId(guid), out var player)
-                && !_groupController.CanViewVar(player)) // Can't VV other admins.
+                && !_groupController.CanCommand(player, "vv")) // Can't VV other admins.
             {
                 session = player;
                 return true;

--- a/Robust.Shared/ViewVariables/Commands/ViewVariablesInvokeCommand.cs
+++ b/Robust.Shared/ViewVariables/Commands/ViewVariablesInvokeCommand.cs
@@ -5,7 +5,8 @@ namespace Robust.Shared.ViewVariables.Commands;
 
 public sealed class ViewVariablesInvokeCommand : ViewVariablesBaseCommand
 {
-    public override string Command => "vvinvoke";
+    public const string Comm = "vvinvoke";
+    public override string Command => Comm;
 
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {

--- a/Robust.Shared/ViewVariables/Commands/ViewVariablesReadCommand.cs
+++ b/Robust.Shared/ViewVariables/Commands/ViewVariablesReadCommand.cs
@@ -4,7 +4,9 @@ namespace Robust.Shared.ViewVariables.Commands;
 
 public sealed class ViewVariablesReadCommand : ViewVariablesBaseCommand
 {
-    public override string Command => "vvread";
+    public const string Comm = "vvread";
+
+    public override string Command => Comm;
 
     public override async void Execute(IConsoleShell shell, string argStr, string[] args)
     {

--- a/Robust.Shared/ViewVariables/Commands/ViewVariablesWriteCommand.cs
+++ b/Robust.Shared/ViewVariables/Commands/ViewVariablesWriteCommand.cs
@@ -4,7 +4,8 @@ namespace Robust.Shared.ViewVariables.Commands;
 
 public sealed class ViewVariablesWriteCommand : ViewVariablesBaseCommand
 {
-    public override string Command => "vvwrite";
+    public const string Comm = "vvwrite";
+    public override string Command => Comm;
 
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {

--- a/Robust.Shared/ViewVariables/ViewVariablesManager.Remote.cs
+++ b/Robust.Shared/ViewVariables/ViewVariablesManager.Remote.cs
@@ -6,6 +6,7 @@ using System.Security.AccessControl;
 using System.Threading.Tasks;
 using Robust.Shared.Network;
 using Robust.Shared.Players;
+using Robust.Shared.ViewVariables.Commands;
 
 namespace Robust.Shared.ViewVariables;
 
@@ -117,7 +118,7 @@ internal abstract partial class ViewVariablesManager
 
     private async void ReadRemotePathRequest(MsgViewVariablesReadPathReq req)
     {
-        if (!CheckPermissions(req.MsgChannel))
+        if (!CheckPermissions(req.MsgChannel, ViewVariablesReadCommand.Comm))
         {
             SendMessage(new MsgViewVariablesReadPathRes(req)
             {
@@ -155,7 +156,7 @@ internal abstract partial class ViewVariablesManager
 
     private async void WriteRemotePathRequest(MsgViewVariablesWritePathReq req)
     {
-        if (!CheckPermissions(req.MsgChannel))
+        if (!CheckPermissions(req.MsgChannel, ViewVariablesWriteCommand.Comm))
         {
             _netMan.ServerSendMessage(new MsgViewVariablesWritePathRes(req)
             {
@@ -202,7 +203,7 @@ internal abstract partial class ViewVariablesManager
 
     private async void InvokeRemotePathRequest(MsgViewVariablesInvokePathReq req)
     {
-        if (!CheckPermissions(req.MsgChannel))
+        if (!CheckPermissions(req.MsgChannel, ViewVariablesInvokeCommand.Comm))
         {
             _netMan.ServerSendMessage(new MsgViewVariablesInvokePathRes(req)
             {
@@ -268,7 +269,7 @@ internal abstract partial class ViewVariablesManager
 
     private async void ListRemotePathRequest(MsgViewVariablesListPathReq req)
     {
-        if (!CheckPermissions(req.MsgChannel))
+        if (!CheckPermissions(req.MsgChannel, "vv"))
         {
             _netMan.ServerSendMessage(new MsgViewVariablesListPathRes(req)
             {
@@ -377,6 +378,6 @@ internal abstract partial class ViewVariablesManager
         }
     }
 
-    protected abstract bool CheckPermissions(INetChannel channel);
+    protected abstract bool CheckPermissions(INetChannel channel, string command);
     protected abstract bool TryGetSession(Guid guid, [NotNullWhen(true)] out ICommonSession? session);
 }


### PR DESCRIPTION
I think this doesn't functionallity change anything except if you had access to vv (e.g. via the debug perm group) then you had access to the other vv commands.

Previously all the commands checked "CanViewVar" which only checked for "vv" perm.