### PR TITLE
Fix log for adding duplicate component reference

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -1,17 +1,15 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Robust.Shared.GameStates;
-using Robust.Shared.Physics;
-using Robust.Shared.Players;
-using Robust.Shared.Utility;
 using System.Runtime.CompilerServices;
+using Robust.Shared.GameStates;
 using Robust.Shared.Log;
-using System.Diagnostics;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Players;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 #if EXCEPTION_TOLERANCE
 using Robust.Shared.Exceptions;
 #endif
@@ -264,7 +262,7 @@ namespace Robust.Shared.GameObjects
         {
             DebugTools.Assert(component is MetaDataComponent ||
                 GetComponent<MetaDataComponent>(uid).EntityLifeStage < EntityLifeStage.Terminating,
-                $"Attempted to add a {typeof(T).Name} component to an entity ({ToPrettyString(uid)}) while it is terminating");
+                $"Attempted to add a {component.GetType().Name} component to an entity ({ToPrettyString(uid)}) while it is terminating");
 
             // get interface aliases for mapping
             var reg = _componentFactory.GetRegistration(component);
@@ -278,7 +276,7 @@ namespace Robust.Shared.GameObjects
 
                 if (!overwrite && !duplicate.Deleted)
                     throw new InvalidOperationException(
-                        $"Component reference type {type} already occupied by {duplicate}");
+                        $"Component reference type {component.GetType().Name} already occupied by {duplicate}");
 
                 RemoveComponentImmediate(duplicate, uid, false);
             }

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -260,6 +260,7 @@ namespace Robust.Shared.GameObjects
 
         private void AddComponentInternal<T>(EntityUid uid, T component, bool overwrite, bool skipInit) where T : Component
         {
+            // We can't use typeof(T) here in case T is just Component
             DebugTools.Assert(component is MetaDataComponent ||
                 GetComponent<MetaDataComponent>(uid).EntityLifeStage < EntityLifeStage.Terminating,
                 $"Attempted to add a {component.GetType().Name} component to an entity ({ToPrettyString(uid)}) while it is terminating");


### PR DESCRIPTION
Old:
`System.InvalidOperationException: Component reference type Robust.Shared.GameObjects.CompIdx already occupied by Content.Server.Ghost.Roles.Components.GhostRoleComponent`

New:
`System.InvalidOperationException: Component reference type GhostRoleComponent already occupied by Content.Server.Ghost.Roles.Components.GhostRoleComponent`

typeof(T) also doesn't work when the generic parameter is Component, such as when using AddComponentCommand.