### PR TITLE
Fixes clash between two different treatable errors with same value

### DIFF
--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/PrototypeIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/PrototypeIdSerializer.cs
@@ -27,7 +27,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
         {
             return dependencies.Resolve<IPrototypeManager>().HasIndex<TPrototype>(node.Value)
                 ? new ValidatedValueNode(node)
-                : new ErrorNode(node, $"PrototypeID {node.Value} for type {typeof(TPrototype)} not found");
+                : new ErrorNode(node, $"PrototypeID {node.Value} for type {typeof(TPrototype)} at {node.Start} not found");
         }
     }
 }


### PR DESCRIPTION
The ErrorNode used as a key in a map would happen to have the exact same value as a previously issued ErrorNode.

This patch includes the start position of the node to prevent clashing.

This is the traceback that motivated the change:
```
Unhandled exception. System.ArgumentException: An item with the same key has already been added. Key: Robust.Shared.Serialization.Markdown.Validation.ErrorNode
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary.PrototypeIdValueDictionarySerializer`2.Validate(ISerializationManager serializationManager, MappingDataNode node, IDependencyCollection dependencies, ISerializationContext context) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/Dictionary/PrototypeIdValueDictionarySerializer.cs:line 41
```
 
You can see it in full [at this YAML Linter github action run](https://github.com/rbertoche/space-station-14/actions/runs/4954300551/jobs/8862674668)

Cheers