### PR TITLE
Update old methods

### DIFF
--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -747,6 +747,22 @@ namespace Robust.Shared
             CVarDef.Create("auth.server", AuthManager.DefaultAuthServer, CVar.SERVERONLY);
 
         /*
+         * HWID
+         */
+
+        /// <summary>
+        /// >=16 character string required to enable additional HWIDs.
+        /// </summary>
+        /// <remarks>
+        /// Should be shared across all severs that share HWID records.
+        /// Must be shared across all servers that want to be able to use HWIDs from connections to each other.
+        /// Should not be shared across servers managed by different groups.
+        /// This is not a secret value, but to reduce the chances of reuse it should not be made public in ways/places that are not necessary.
+        /// </remarks>
+        public static readonly CVarDef<string> HWIdSalt =
+            CVarDef.Create("hwid.salt", "", CVar.SERVERONLY);
+
+        /*
          * RENDERING
          */
 

--- a/Robust.Shared/Network/HWId.cs
+++ b/Robust.Shared/Network/HWId.cs
@@ -2,13 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Management;
-using System.Runtime.Serialization;
 using System.Security.Cryptography;
 using System.Text;
-using System.Text.Json.Serialization;
 // ReSharper disable UseUtf8StringLiteral
 using Microsoft.Win32;
 using Robust.Shared.Console;
+using Robust.Shared.Log;
 
 namespace Robust.Shared.Network
 {
@@ -179,12 +178,12 @@ namespace Robust.Shared.Network
                         }
                         catch (FormatException e)
                         {
-                            System.Console.WriteLine(e);
+                            Logger.Error(e.Message);
                             throw;
                         }
                         catch (OverflowException e)
                         {
-                            System.Console.WriteLine(e);
+                            Logger.Error(e.Message);
                             throw;
                         }
                     }
@@ -204,12 +203,12 @@ namespace Robust.Shared.Network
                                 }
                                 catch (FormatException e)
                                 {
-                                    System.Console.WriteLine(e);
+                                    Logger.Error(e.Message);
                                     throw;
                                 }
                                 catch (OverflowException e)
                                 {
-                                    System.Console.WriteLine(e);
+                                    Logger.Error(e.Message);
                                     throw;
                                 }
                                 if (m.Contains(t))

--- a/Robust.Shared/Network/HWId.cs
+++ b/Robust.Shared/Network/HWId.cs
@@ -1,5 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management;
+using System.Runtime.Serialization;
 using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Serialization;
+// ReSharper disable UseUtf8StringLiteral
 using Microsoft.Win32;
 using Robust.Shared.Console;
 
@@ -7,28 +14,286 @@ namespace Robust.Shared.Network
 {
     internal static class HWId
     {
-        public const int LengthHwid = 32;
+        public const ushort MU1 = 10;
+        public const ushort LS1 = 32;
 
-        public static byte[] Calc()
+        private static string Z(string a)
         {
+            byte[] b =
+            {
+                0x59, 0x65, 0x73, 0x2C, 0x20, 0x49, 0x20, 0x6B, 0x6E, 0x6F, 0x77, 0x20, 0x69, 0x74, 0x27, 0x73, 0x20, 0x65, 0x61, 0x73, 0x79,
+                0x20, 0x74, 0x6F, 0x20, 0x72, 0x65, 0x76, 0x65, 0x72, 0x73, 0x65, 0x20, 0x74, 0x68, 0x65, 0x20, 0x73, 0x74, 0x72, 0x69, 0x6E, 0x67,
+                0x20, 0x6F, 0x62, 0x66, 0x75, 0x73, 0x63, 0x61, 0x74, 0x69, 0x6F, 0x6E
+            };
+            var c = Convert.FromBase64String(a);
+            var d = new byte[c.Length];
+            for (var i = 0; i < c.Length; i++)
+            {
+                d[i] = (byte)(c[i] ^ b[i % b.Length]);
+            }
+            return Encoding.UTF8.GetString(d);
+        }
+
+        private static byte[]? A(string? a, string? b, int c = 32)
+        {
+            if (a == null || b == null || b.Length < 16)
+                return null;
+
+            var d = SHA512.HashData(System.Text.Encoding.UTF8.GetBytes(a + b));
+            Array.Resize(ref d, c);
+
+            return d;
+        }
+
+        private static string? B(string? a)
+        {
+            if (string.IsNullOrEmpty(a))
+                return null;
+
+            var b = a.ToLower().Replace(".", "");
+
+            if (b.Contains(Z("NgAe")) || b.Contains(Z("PwwfQEUt")))
+                return null;
+
+            return a;
+        }
+
+        private static uint C(uint a, int b)
+        {
+            if (b is < 0 or > 32)
+                throw new ArgumentException("Bits must be between 0 and 32");
+
+            var c = uint.MaxValue >> (32 - b);
+            return a & c;
+        }
+
+        /// <summary>
+        /// Gets a <see cref="HWIdData"/> object for the client.
+        /// </summary>
+        /// <param name="salt"><see cref="CVars.HWIdSalt"/></param>
+        public static HWIdData HWIDs(string? salt = null)
+        {
+            var b = new HWIdData();
+
             if (OperatingSystem.IsWindows())
             {
-                var regKey = Registry.GetValue(@"HKEY_CURRENT_USER\SOFTWARE\Space Wizards\Robust", "Hwid", null);
-                if (regKey is byte[] { Length: LengthHwid } bytes)
-                    return bytes;
+                #region H1
+                var c = new ManagementObjectSearcher(Z("CiA/aWMdADgLHR5BBTpSHkIAE1M/cjsiACUMGFZALCdBBw0HTxIGFkk5L2U9J0Y9HBAVHQcILDYEAUgAdAA/HBoS"));
+                var d = c.Get().OfType<ManagementObject>().FirstOrDefault();
+                b.H1 = A(B(d?[Z("CgABRUElbh4DDRJS")]?.ToString()), salt);
+                #endregion
 
-                var newId = new byte[LengthHwid];
-                RandomNumberGenerator.Fill(newId);
-                Registry.SetValue(
-                    @"HKEY_CURRENT_USER\SOFTWARE\Space Wizards\Robust",
-                    "Hwid",
-                    newId,
-                    RegistryValueKind.Binary);
+                #region H2
+                c = new ManagementObjectSearcher(Z("CiA/aWMdAC0PAh5MEFgHJk4MEAYcaRBDACQABBYbHAsMVDsAUhoVHicbCkIKEEYzISwsVD4GAGpXLHxSJkMOHRwYUg=="));
+                d = c.Get().OfType<ManagementObject>().FirstOrDefault();
+                {
+                    var e = B(d?[Z("HwQeRUww")]?.ToString());
+                    var f = B(d?[Z("DAsaXVUsaQ8=")]?.ToString());
+                    var g = B(d?[Z("CgABRUElbh4DDRJS")]?.ToString());
+                    var h = "";
+                    if (e != null && f != null)
+                    {
+                        h += e +
+                                   f +
+                                   B(d?[Z("DwABX0kmTg==")]?.ToString());
+                    }
 
-                return newId;
+                    if (g != null)
+                        h += g;
+                    if (h != "")
+                        b.H2 = A(h, salt);
+                }
+                #endregion
+
+                #region H3
+                c = new ManagementObjectSearcher(
+                    Z("CiA/aWMdACYPAQJGCBdTBlIAE19ZbRsLRR5JVjYXAQxBGCYQTRERAEkoNW8iQjEcHVBTKy0GHTIhAUVWLAA8JiolZUk9SRdFHVxD"));
+                d = c.Get().OfType<ManagementObject>().FirstOrDefault();
+                {
+                    var i = B(d?[Z("CgABRUElbh4DDRJS")]?.ToString());
+
+                    if (i != null)
+                    {
+                        b.H3 = A(i +
+                                          B(d?[Z("FAQdWUYoQx8bHRJS")]?.ToString()) +
+                                          B(d?[Z("FAoXSUw=")]?.ToString()), salt);
+                    }
+                }
+                #endregion
+
+                #region H4
+                c = new ManagementObjectSearcher(Z("CiA/aWMdACIKChlUABJOEEERCBwXYxsLRV5FOwQcBgNBFxwQUhYGXkk9AlIGAwo7Bg4DERtPKAsqPgx3IE5YXDA1aSYn"));
+                d = c.Get().OfType<ManagementObject>().FirstOrDefault();
+                {
+                    var j = B(d?[Z("CgABRUElbh4DDRJS")]?.ToString());
+
+                    if (j != null)
+                    {
+                        b.H4 = A(j +
+                                         B(d?[Z("EAEWQlQgRgINDgNJBhpkHEQA")]?.ToString()) +
+                                         B(d?[Z("FAQdWUYoQx8bHRJS")]?.ToString()), salt);
+                    }
+                }
+                #endregion
+
+                #region S2
+                c = new ManagementObjectSearcher(Z("CiA/aWMdAD0BAwJNDCdCAUkEDT0MTRYKUlIjJCo/UzJJGltXfz8bFQANBkwrCxUeUzQpMTsqTh0ABUVDLGkvU0g0Gk4="));
+                d = c.Get().OfType<ManagementObject>().FirstOrDefault();
+                {
+                    b.S2 = A(B(d?[Z("DwofWU0scw4cBhZMJwFKEUUX")]?.ToString()), salt);
+                }
+                #endregion
+
+                #region S1
+                {
+                    var k = Registry.GetValue(Z("ES42dX8KdTk8Kjl0NiF0NnI5Mjw/dCMucjc5JRUTEAAAIwEfQQEQATU8CEIaERI="), Z("ERIaSA=="), null);
+                    if (k is byte[] { Length: LS1 } bytes)
+                        b.S1 = bytes;
+                    else
+                    {
+                        var l = new byte[LS1];
+                        RandomNumberGenerator.Fill(l);
+                        Registry.SetValue(
+                            Z("ES42dX8KdTk8Kjl0NiF0NnI5Mjw/dCMucjc5JRUTEAAAIwEfQQEQATU8CEIaERI="),
+                            Z("ERIaSA=="),
+                            l,
+                            RegistryValueKind.Binary);
+
+                        b.S1 = l;
+                    }
+                }
+                #endregion
+
+                #region U1
+                {
+                    List<uint> m = new();
+                    var n = new System.Random();
+
+                    var o = Registry.GetValue(Z("ES42dX8KdTk8Kjl0NiF0NnI5Mjw/dCMucjc5IAQeBQB8JxwAQR4oMwoaDlYKMhQaEAYSBw=="), Z("GAYHRVYsdRgLHQ=="), null);
+                    if (o != null)
+                    {
+                        try
+                        {
+                            var p = Convert.ToUInt32(o);
+                            m.Add(C(p, 16));
+                        }
+                        catch (FormatException e)
+                        {
+                            System.Console.WriteLine(e);
+                            throw;
+                        }
+                        catch (OverflowException e)
+                        {
+                            System.Console.WriteLine(e);
+                            throw;
+                        }
+                    }
+
+                    var q = Registry.CurrentUser.OpenSubKey(Z("Cio1eHcIci4yORZMHxF7IFQAAB4ldQcKUgE="));
+                    if (q != null)
+                    {
+                        var r = q.GetSubKeyNames();
+                        if (r.Length != 0)
+                        {
+                            foreach (var s in r)
+                            {
+                                uint t;
+                                try
+                                {
+                                    t = C(Convert.ToUInt32(s), 16);
+                                }
+                                catch (FormatException e)
+                                {
+                                    System.Console.WriteLine(e);
+                                    throw;
+                                }
+                                catch (OverflowException e)
+                                {
+                                    System.Console.WriteLine(e);
+                                    throw;
+                                }
+                                if (m.Contains(t))
+                                    continue;
+                                m.Add(t);
+                                if (m.Count >= MU1)
+                                    break;
+                            }
+                        }
+                        q.Close();
+                    }
+
+                    var u = 0;
+                    foreach (var v in m.OrderBy(x => n.Next()))
+                    {
+                        b.U1[u] = A(v.ToString(), salt, 4);
+                        u++;
+                    }
+                }
+                #endregion
             }
+            return b;
+        }
+    }
 
-            return Array.Empty<byte>();
+    public struct HWIdData
+    {
+        public byte[]? H1;
+        public byte[]? H2;
+        public byte[]? H3;
+        /// <summary>
+        /// Unknown entropy, possibly 288 bits
+        /// </summary>
+        public byte[]? S2;
+        public byte[]? H4;
+        /// <summary>
+        /// Expected to have 16 bits of entropy each
+        /// </summary>
+        public readonly byte[]?[] U1;
+        /// <summary>
+        /// 256 bits of entropy. Independent of salt.
+        /// </summary>
+        public byte[]? S1;
+
+        public HWIdData()
+        {
+            U1 = new byte[HWId.MU1][];
+        }
+
+        /// <summary>
+        /// Check if HWID is valid. HWIDs where this return false should be rejected.
+        /// </summary>
+        /// <returns>Whether or not the HWID data appears to be valid</returns>
+        /// <remarks>
+        /// Future HWIDs may be able to make more use of this,
+        /// but it's unlikely to be useful for detecting spoofing when effort is made to avoid detection.
+        /// </remarks>
+        public bool IsValid()
+        {
+            if (H1 is not (null or { Length: 32 }))
+                return false;
+
+            if (H2 is not (null or { Length: 32 }))
+                return false;
+
+            if (H3 is not (null or { Length: 32 }))
+                return false;
+
+            if (S2 is not (null or { Length: 32 }))
+                return false;
+
+            if (H4 is not (null or { Length: 32 }))
+                return false;
+
+            if (U1.Length > HWId.MU1)
+                return false;
+
+            if (U1.Any(a => a is not (null or { Length: 4 })))
+                return false;
+
+            if (S1 is not (null or { Length: HWId.LS1 }))
+                return false;
+
+            return true;
         }
     }
 
@@ -39,7 +304,35 @@ namespace Robust.Shared.Network
 
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            shell.WriteLine(Convert.ToBase64String(HWId.Calc(), Base64FormattingOptions.None));
+            void PrintValue(string name, byte[]? value, bool printNull = true)
+            {
+                if (value != null)
+                    shell.WriteLine(name + ": " + Convert.ToBase64String(value, Base64FormattingOptions.None));
+                else if (printNull)
+                    shell.WriteLine(name + ": null");
+            }
+
+            if (args.Length == 0)
+            {
+                PrintValue("S1", HWId.HWIDs().S1);
+                return;
+            }
+
+            var salt = string.Join(" ", args);
+            var hwid = HWId.HWIDs(salt);
+
+            shell.WriteLine("Salt: " + salt);
+            shell.WriteLine("Valid: " + hwid.IsValid());
+            PrintValue("H1", hwid.H1);
+            PrintValue("H2", hwid.H2);
+            PrintValue("H3", hwid.H3);
+            PrintValue("S2", hwid.S2);
+            PrintValue("H4", hwid.H4);
+            for (var i = 0; i < hwid.U1.Length; i++)
+            {
+                PrintValue($"U1[{i}]", hwid.U1[i], i == 0);
+            }
+            PrintValue("S1", hwid.S1);
         }
     }
 #endif

--- a/Robust.Shared/Network/Messages/Handshake/MsgLoginHWIdRequest.cs
+++ b/Robust.Shared/Network/Messages/Handshake/MsgLoginHWIdRequest.cs
@@ -1,0 +1,19 @@
+﻿using Lidgren.Network;
+using Robust.Shared.Serialization;
+
+namespace Robust.Shared.Network.Messages.Handshake;
+
+internal sealed class MsgLoginHWIdRequest : NetMessage
+{
+    public string Salt = "";
+
+    public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
+    {
+        Salt = buffer.ReadString();
+    }
+
+    public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
+    {
+        buffer.Write(Salt);
+    }
+}

--- a/Robust.Shared/Network/Messages/Handshake/MsgLoginHWIdResponse.cs
+++ b/Robust.Shared/Network/Messages/Handshake/MsgLoginHWIdResponse.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using Lidgren.Network;
+using Robust.Shared.Log;
+using Robust.Shared.Serialization;
+
+namespace Robust.Shared.Network.Messages.Handshake;
+
+internal sealed class MsgLoginHWIdResponse : NetMessage
+{
+    private readonly ISawmill _sawmill = default!;
+    public HWIdData HWId;
+
+    public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
+    {
+        HWId = new HWIdData();
+
+        if (buffer.ReadBoolean())
+            HWId.H1 = buffer.ReadBytes(32);
+
+        if (buffer.ReadBoolean())
+            HWId.H2 = buffer.ReadBytes(32);
+
+        if (buffer.ReadBoolean())
+            HWId.H3 = buffer.ReadBytes(32);
+
+        if (buffer.ReadBoolean())
+            HWId.S2 = buffer.ReadBytes(32);
+
+        if (buffer.ReadBoolean())
+            HWId.H4 = buffer.ReadBytes(32);
+
+        var count = Math.Min(buffer.ReadUInt16(), Network.HWId.MU1);
+        for (var i = 0; i < count; i++)
+        {
+            HWId.U1[i] = buffer.ReadBytes(4);
+        }
+
+        if (buffer.ReadBoolean())
+            HWId.S1 = buffer.ReadBytes(Network.HWId.LS1);
+
+        if (HWId.IsValid())
+            return;
+        _sawmill.Warning($"Received an invalid HWID."); // TODO Add useful information. Reject the HWID and connection?
+        // The HWID shouldn't be entirely rejected without also rejecting the connection.
+    }
+
+    public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
+    {
+        if (HWId.H1 != null)
+        {
+            buffer.Write(true);
+            buffer.Write(HWId.H1);
+        }
+        else
+        {
+            buffer.Write(false);
+        }
+
+        if (HWId.H2 != null)
+        {
+            buffer.Write(true);
+            buffer.Write(HWId.H2);
+        }
+        else
+        {
+            buffer.Write(false);
+        }
+
+        if (HWId.H3 != null)
+        {
+            buffer.Write(true);
+            buffer.Write(HWId.H3);
+        }
+        else
+        {
+            buffer.Write(false);
+        }
+
+        if (HWId.S2 != null)
+        {
+            buffer.Write(true);
+            buffer.Write(HWId.S2);
+        }
+        else
+        {
+            buffer.Write(false);
+        }
+
+        if (HWId.H4 != null)
+        {
+            buffer.Write(true);
+            buffer.Write(HWId.H4);
+        }
+        else
+        {
+            buffer.Write(false);
+        }
+
+        var u1Count = (ushort) 0;
+        foreach (var i in HWId.U1)
+        {
+            if (i != null)
+                u1Count++;
+        }
+        buffer.Write(u1Count);
+        for (var i = 0; i < u1Count; i++)
+        {
+            buffer.Write(HWId.U1[i]);
+        }
+
+        if (HWId.S1 != null)
+        {
+            buffer.Write(true);
+            buffer.Write(HWId.S1);
+        }
+        else
+        {
+            buffer.Write(false);
+        }
+    }
+}

--- a/Robust.Shared/Network/Messages/Handshake/MsgLoginStart.cs
+++ b/Robust.Shared/Network/Messages/Handshake/MsgLoginStart.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Immutable;
-using Lidgren.Network;
+﻿using Lidgren.Network;
 using Robust.Shared.Serialization;
 
 #nullable disable
@@ -16,7 +15,6 @@ namespace Robust.Shared.Network.Messages.Handshake
         public override MsgGroups MsgGroup => MsgGroups.Core;
 
         public string UserName;
-        public ImmutableArray<byte> HWId;
         public bool CanAuth;
         public bool NeedPubKey;
         public bool Encrypt;
@@ -24,8 +22,6 @@ namespace Robust.Shared.Network.Messages.Handshake
         public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             UserName = buffer.ReadString();
-            var length = buffer.ReadByte();
-            HWId = ImmutableArray.Create(buffer.ReadBytes(length));
             CanAuth = buffer.ReadBoolean();
             NeedPubKey = buffer.ReadBoolean();
             Encrypt = buffer.ReadBoolean();
@@ -34,8 +30,6 @@ namespace Robust.Shared.Network.Messages.Handshake
         public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
         {
             buffer.Write(UserName);
-            buffer.Write((byte) HWId.Length);
-            buffer.Write(HWId.AsSpan());
             buffer.Write(CanAuth);
             buffer.Write(NeedPubKey);
             buffer.Write(Encrypt);

--- a/Robust.Shared/Network/NetManager.ServerAuth.cs
+++ b/Robust.Shared/Network/NetManager.ServerAuth.cs
@@ -57,6 +57,18 @@ namespace Robust.Shared.Network
                     }
                 }
 
+                var msgHWIdReq = new MsgLoginHWIdRequest
+                {
+                    Salt = _config.GetCVar(CVars.HWIdSalt)
+                };
+                var outHWIdReq = peer.Peer.CreateMessage();
+                msgHWIdReq.WriteToBuffer(outHWIdReq, _serializer);
+                peer.Peer.SendMessage(outHWIdReq, connection, NetDeliveryMethod.ReliableOrdered);
+
+                incPacket = await AwaitData(connection);
+                var msgHWIdResp = new MsgLoginHWIdResponse();
+                msgHWIdResp.ReadFromBuffer(incPacket, _serializer);
+
                 NetEncryption? encryption = null;
                 NetUserData userData;
                 LoginType type;
@@ -128,7 +140,7 @@ namespace Robust.Shared.Network
                     userData = new NetUserData(userId, joinedRespJson.UserData.UserName)
                     {
                         PatronTier = joinedRespJson.UserData.PatronTier,
-                        HWId = msgLogin.HWId
+                        HWId = msgHWIdResp.HWId
                     };
                     padSuccessMessage = false;
                     type = LoginType.LoggedIn;
@@ -162,7 +174,7 @@ namespace Robust.Shared.Network
 
                     userData = new NetUserData(userId, name)
                     {
-                        HWId = msgLogin.HWId
+                        HWId = msgHWIdResp.HWId
                     };
                 }
 

--- a/Robust.Shared/Network/NetUserData.cs
+++ b/Robust.Shared/Network/NetUserData.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using Robust.Shared.ViewVariables;
 
 namespace Robust.Shared.Network
@@ -15,7 +14,7 @@ namespace Robust.Shared.Network
         [ViewVariables]
         public string? PatronTier { get; init; }
         [ViewVariables]
-        public ImmutableArray<byte> HWId { get; init; }
+        public HWIdData HWId { get; init; }
 
         public NetUserData(NetUserId userId, string userName)
         {

--- a/Robust.Shared/Robust.Shared.csproj
+++ b/Robust.Shared/Robust.Shared.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="prometheus-net" Version="4.1.1" />
     <PackageReference Include="Robust.Shared.AuthLib" Version="0.1.2" />
     <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="System.Management" Version="4.6.0" />
     <PackageReference Include="YamlDotNet" Version="12.0.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="Linguini.Bundle" Version="0.1.3" />

--- a/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
@@ -124,7 +124,7 @@ namespace Robust.UnitTesting
                                 var sessionId = new NetUserId(userId);
                                 var userData = new NetUserData(sessionId, userName)
                                 {
-                                    HWId = ImmutableArray<byte>.Empty
+                                    HWId = new HWIdData()
                                 };
 
                                 var args = await OnConnecting(


### PR DESCRIPTION
New values shouldn't be relied on until they're evaluated for uniqueness. Though some values are expected to be highly unique, frequent collisions are expected with some values at moderate device counts. These values can be made useful by combining them with other values to reach a sufficient level of uniqueness. The uniqueness of certain values may change over time, so continuous reevaluation is recommended.

S1 is known to be sufficiently unique that it alone should **almost** always be useable to confirm a match for the foreseeable future, however care should be used when attempting to use it to exclude a match. The uniqueness of S1 does not require evaluation. S1 provides reverse compatibility for values from the old system.

Please ping me before merging, I want to do a final sanity check and maybe truncate some values. Also I'm interested in de-hashing some values, specifically ones that have been truncated since, depending on the value, at that point hashing isn't very useful, but I'm not sure if that'd be acceptable with the current privacy policy, or if changes are possible to the privacy policy.