### PR TITLE
Fix some joint bugs

### DIFF
--- a/Robust.Client/Physics/JointSystem.cs
+++ b/Robust.Client/Physics/JointSystem.cs
@@ -32,6 +32,14 @@ namespace Robust.Client.Physics
                 return;
             }
 
+            foreach (var j in AddedJoints)
+            {
+                if ((j.BodyAUid == uid || j.BodyBUid == uid) && !jointState.Joints.ContainsKey(j.ID))
+                    _toRemove.Add(j);
+            }
+            AddedJoints.ExceptWith(_toRemove);
+            _toRemove.Clear();
+
             var removed = new List<Joint>();
             foreach (var (existing, j) in component.Joints)
             {

--- a/Robust.Client/Physics/JointSystem.cs
+++ b/Robust.Client/Physics/JointSystem.cs
@@ -35,10 +35,10 @@ namespace Robust.Client.Physics
             foreach (var j in AddedJoints)
             {
                 if ((j.BodyAUid == uid || j.BodyBUid == uid) && !jointState.Joints.ContainsKey(j.ID))
-                    _toRemove.Add(j);
+                    ToRemove.Add(j);
             }
-            AddedJoints.ExceptWith(_toRemove);
-            _toRemove.Clear();
+            AddedJoints.ExceptWith(ToRemove);
+            ToRemove.Clear();
 
             var removed = new List<Joint>();
             foreach (var (existing, j) in component.Joints)

--- a/Robust.Shared/Physics/Systems/SharedJointSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedJointSystem.cs
@@ -25,7 +25,7 @@ public abstract class SharedJointSystem : EntitySystem
     // we can delete the component.
     private readonly HashSet<JointComponent> _dirtyJoints = new();
     protected readonly HashSet<Joint> AddedJoints = new();
-    protected readonly List<Joint> _toRemove = new();
+    protected readonly List<Joint> ToRemove = new();
 
     private ISawmill _sawmill = default!;
 
@@ -436,10 +436,10 @@ public abstract class SharedJointSystem : EntitySystem
         foreach (var j in AddedJoints)
         {
             if (j.BodyAUid == uid || j.BodyBUid == uid)
-                _toRemove.Add(j);
+                ToRemove.Add(j);
         }
-        AddedJoints.ExceptWith(_toRemove);
-        _toRemove.Clear();
+        AddedJoints.ExceptWith(ToRemove);
+        ToRemove.Clear();
 
         if(_gameTiming.IsFirstTimePredicted)
         {

--- a/Robust.Shared/Physics/Systems/SharedJointSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedJointSystem.cs
@@ -25,6 +25,7 @@ public abstract class SharedJointSystem : EntitySystem
     // we can delete the component.
     private readonly HashSet<JointComponent> _dirtyJoints = new();
     protected readonly HashSet<Joint> AddedJoints = new();
+    protected readonly List<Joint> _toRemove = new();
 
     private ISawmill _sawmill = default!;
 
@@ -404,6 +405,11 @@ public abstract class SharedJointSystem : EntitySystem
         }
 
         // Need to defer this for prediction reasons, yay!
+        // This can also break prediction for reasons, yay!
+        // Whenever a joint is added or removed, you need to check if its queued for adding.
+        // The client can apply multiple game states in a row without running a tick update,
+        // which can lead to things like cross-map joints.
+        // TODO is this actually needed. Its bad for performance coin.
         AddedJoints.Add(joint);
 
         if (_gameTiming.IsFirstTimePredicted)
@@ -427,6 +433,14 @@ public abstract class SharedJointSystem : EntitySystem
             RemoveJoint(a);
         }
 
+        foreach (var j in AddedJoints)
+        {
+            if (j.BodyAUid == uid || j.BodyBUid == uid)
+                _toRemove.Add(j);
+        }
+        AddedJoints.ExceptWith(_toRemove);
+        _toRemove.Clear();
+
         if(_gameTiming.IsFirstTimePredicted)
         {
             _sawmill.Debug($"Removed all joints from entity {ToPrettyString(uid)}");
@@ -441,6 +455,7 @@ public abstract class SharedJointSystem : EntitySystem
 
     public void RemoveJoint(Joint joint)
     {
+        AddedJoints.Remove(joint);
         var bodyAUid = joint.BodyAUid;
         var bodyBUid = joint.BodyBUid;
 


### PR DESCRIPTION
This just ensures that joints being removed will also get removed from the system's `AddedJoints` set. I don't think this is actually responsible for any of the common joint error logs, but it can cause issues in some situations, especially for replays.