### PR TITLE
Make InitializeEntity() and StartEntity() public

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -724,13 +724,13 @@ namespace Robust.Shared.GameObjects
             }
         }
 
-        protected void InitializeEntity(EntityUid entity, MetaDataComponent? meta = null)
+        public void InitializeEntity(EntityUid entity, MetaDataComponent? meta = null)
         {
             InitializeComponents(entity, meta);
             EntityInitialized?.Invoke(entity);
         }
 
-        protected void StartEntity(EntityUid entity)
+        public void StartEntity(EntityUid entity)
         {
             StartComponents(entity);
             EntityStarted?.Invoke(entity);

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -66,6 +66,10 @@ namespace Robust.Shared.GameObjects
 
         void InitializeAndStartEntity(EntityUid entity, MapId? mapId = null);
 
+        void InitializeEntity(EntityUid entity, MetaDataComponent? meta = null);
+
+        void StartEntity(EntityUid entity);
+
         /// <summary>
         /// Spawns an initialized entity at the default location, using the given prototype.
         /// </summary>


### PR DESCRIPTION
Gives content more control over entity spawning.