### PR TITLE
Make map-grids set TransformComponent.GridUid

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
@@ -17,6 +17,7 @@ namespace Robust.Client.GameObjects
             base.Initialize();
 
             SubscribeLocalEvent<ClientAppearanceComponent, ComponentInit>(OnAppearanceInit);
+            SubscribeLocalEvent<ClientAppearanceComponent, ComponentStartup>(OnAppearanceStartup);
             SubscribeLocalEvent<ClientAppearanceComponent, ComponentHandleState>(OnAppearanceHandleState);
         }
 
@@ -32,7 +33,10 @@ namespace Robust.Client.GameObjects
             {
                 visual.InitializeEntity(uid);
             }
+        }
 
+        private void OnAppearanceStartup(EntityUid uid, ClientAppearanceComponent component, ComponentStartup args)
+        {
             MarkDirty(component);
         }
 
@@ -103,10 +107,9 @@ namespace Robust.Client.GameObjects
             var metaQuery = GetEntityQuery<MetaDataComponent>();
             while (_queuedUpdates.TryDequeue(out var appearance))
             {
-                if (appearance.Deleted)
-                    continue;
-
                 appearance.AppearanceDirty = false;
+                if (!appearance.Running)
+                    continue;
 
                 // If the entity is no longer within the clients PVS, don't bother updating.
                 if ((metaQuery.GetComponent(appearance.Owner).Flags & MetaDataFlags.Detached) != 0 && !appearance.UpdateDetached)

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -16,6 +16,7 @@ using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
+using Robust.Shared.Physics;
 using Robust.Shared.Players;
 using Robust.Shared.Threading;
 using Robust.Shared.Timing;
@@ -253,8 +254,8 @@ internal sealed partial class PVSSystem : EntitySystem
     private void OnEntityMove(ref MoveEvent ev)
     {
         // GriddUid is only set after init.
-        if (ev.Component.LifeStage < ComponentLifeStage.Initialized && ev.Component.GridUid == null)
-            _transform.SetGridId(ev.Component, ev.Component.FindGridEntityId(GetEntityQuery<TransformComponent>()));
+        if (!ev.Component._gridInitialized)
+            _transform.InitializeGridUid(ev.Sender, ev.Component, GetEntityQuery<TransformComponent>(), GetEntityQuery<MapGridComponent>());
 
         // since elements are cached grid-/map-relative, we dont need to update a given grids/maps children
         if (ev.Component.GridUid == ev.Sender)

--- a/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
+++ b/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
@@ -167,6 +167,9 @@ public abstract class ComponentTreeSystem<TTreeComp, TComp> : EntitySystem
             var (comp, xform) = entry;
 
             comp.TreeUpdateQueued = false;
+            if (!comp.Running)
+                continue;
+
             if (!_updated.Add(comp.Owner))
                 continue;
 

--- a/Robust.Shared/ComponentTrees/RecursiveMoveSystem.cs
+++ b/Robust.Shared/ComponentTrees/RecursiveMoveSystem.cs
@@ -43,6 +43,8 @@ internal sealed class RecursiveMoveSystem : EntitySystem
         TransformComponent xform,
         EntityQuery<TransformComponent> xformQuery)
     {
+        // TODO maybe use a c# event? This event gets raised a lot.
+        // Would probably help with server performance and is also the main bottleneck for replay scrubbing.
         var ev = new TreeRecursiveMoveEvent(xform);
         RaiseLocalEvent(uid, ref ev);
 

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -94,6 +94,7 @@ namespace Robust.Shared.GameObjects
         public MapId MapID { get; internal set; }
 
         internal bool _mapIdInitialized;
+        internal bool _gridInitialized;
 
         // TODO: Cache this.
         /// <summary>
@@ -392,30 +393,6 @@ namespace Robust.Shared.GameObjects
         [ViewVariables] public int ChildCount => _children.Count;
 
         [ViewVariables] internal EntityUid LerpParent { get; set; }
-
-        internal EntityUid? FindGridEntityId(EntityQuery<TransformComponent> xformQuery)
-        {
-            if (_entMan.HasComponent<MapComponent>(Owner))
-            {
-                return null;
-            }
-
-            if (_entMan.HasComponent<MapGridComponent>(Owner))
-            {
-                return Owner;
-            }
-
-            if (_parent.IsValid())
-            {
-                var parentXform = xformQuery.GetComponent(_parent);
-                if (parentXform.GridUid != null || parentXform.LifeStage >= ComponentLifeStage.Initialized)
-                    return parentXform.GridUid;
-                else
-                    return parentXform.FindGridEntityId(xformQuery);
-            }
-
-            return _mapManager.TryFindGridAt(MapID, WorldPosition, out var mapgrid) ? mapgrid.Owner : null;
-        }
 
         /// <summary>
         /// Detaches this entity from its parent.

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -92,9 +92,15 @@ namespace Robust.Shared.GameObjects
             SubscribeLocalEvent<MoveEvent>(OnMove);
 
             SubscribeLocalEvent<TransformComponent, PhysicsBodyTypeChangedEvent>(OnBodyTypeChange);
+            SubscribeLocalEvent<PhysicsComponent, ComponentStartup>(OnBodyStartup);
             SubscribeLocalEvent<CollisionChangeEvent>(OnPhysicsUpdate);
 
             EntityManager.EntityInitialized += OnEntityInit;
+        }
+
+        private void OnBodyStartup(EntityUid uid, PhysicsComponent component, ComponentStartup args)
+        {
+            UpdatePhysicsBroadphase(uid, Transform(uid), component);
         }
 
         public override void Shutdown()
@@ -269,6 +275,9 @@ namespace Robust.Shared.GameObjects
 
         private void UpdatePhysicsBroadphase(EntityUid uid, TransformComponent xform, PhysicsComponent body)
         {
+            if (body.LifeStage <= ComponentLifeStage.Initializing)
+                return;
+
             if (xform.GridUid == uid)
                 return;
             DebugTools.Assert(!_mapManager.IsGrid(uid));

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -259,6 +259,7 @@ namespace Robust.Shared.GameObjects
             // ensure that the cached broadphase is correct.
             DebugTools.Assert(_timing.ApplyingState
                 || xform.Broadphase == null
+                || ev.Body.LifeStage <= ComponentLifeStage.Initializing
                 || !xform.Broadphase.Value.IsValid()
                 || ((xform.Broadphase.Value.CanCollide == ev.Body.CanCollide)
                 && (xform.Broadphase.Value.Static == (ev.Body.BodyType == BodyType.Static))));

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -289,7 +289,6 @@ public abstract partial class SharedMapSystem
 
     private void OnGridAdd(EntityUid uid, MapGridComponent component, ComponentAdd args)
     {
-        // GridID is not set yet so we don't include it.
         var msg = new GridAddEvent(uid);
         RaiseLocalEvent(uid, msg, true);
     }
@@ -298,9 +297,6 @@ public abstract partial class SharedMapSystem
     {
         var xformQuery = GetEntityQuery<TransformComponent>();
         var xform = xformQuery.GetComponent(uid);
-
-        // Adding grids to existing entities is not currently supported.
-        DebugTools.Assert(LifeStage(uid) == EntityLifeStage.Initializing || xform.ChildCount == 0);
 
         // Force networkedmapmanager to send it due to non-ECS legacy code.
         var curTick = _timing.CurTick;

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -299,6 +299,9 @@ public abstract partial class SharedMapSystem
         var xformQuery = GetEntityQuery<TransformComponent>();
         var xform = xformQuery.GetComponent(uid);
 
+        // Adding grids to existing entities is not currently supported.
+        DebugTools.Assert(LifeStage(uid) == EntityLifeStage.Initializing || xform.ChildCount == 0);
+
         // Force networkedmapmanager to send it due to non-ECS legacy code.
         var curTick = _timing.CurTick;
 
@@ -310,23 +313,8 @@ public abstract partial class SharedMapSystem
 
         component.LastTileModifiedTick = curTick;
 
-        var mapId = xform.MapID;
-
-        if (MapManager.HasMapEntity(mapId))
-        {
-            var mapUid = MapManager.GetMapEntityIdOrThrow(mapId);
-
-            // Mapgrid moment
-            if (mapUid != uid)
-                _transform.SetParent(uid, xform, MapManager.GetMapEntityIdOrThrow(mapId), xformQuery);
-
-            _transform.SetGridIdNoRecursive(xform, uid);
-        }
-        else
-        {
-            // Just in case.
-            _transform.SetGridId(xform, uid, xformQuery);
-        }
+        if (xform.MapUid != null && xform.MapUid != uid)
+            _transform.SetParent(uid, xform, xform.MapUid.Value, xformQuery);
 
         var msg = new GridInitializeEvent(uid);
         RaiseLocalEvent(uid, msg, true);

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -1347,8 +1347,12 @@ public abstract partial class SharedTransformSystem
 
     private void OnGridAdd(EntityUid uid, TransformComponent component, GridAddEvent args)
     {
+        if (LifeStage(uid) > EntityLifeStage.Initialized)
+        {
+            SetGridId(uid, component, uid, GetEntityQuery<TransformComponent>());
+            return;
+        }
         component._gridInitialized = true;
         component._gridUid = uid;
-        DebugTools.Assert(LifeStage(uid) < EntityLifeStage.Initialized || component.ChildCount == 0);
     }
 }

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -36,6 +36,7 @@ namespace Robust.Shared.GameObjects
             SubscribeLocalEvent<TransformComponent, ComponentStartup>(OnCompStartup);
             SubscribeLocalEvent<TransformComponent, ComponentGetState>(OnGetState);
             SubscribeLocalEvent<TransformComponent, ComponentHandleState>(OnHandleState);
+            SubscribeLocalEvent<TransformComponent, GridAddEvent>(OnGridAdd);
             SubscribeLocalEvent<EntParentChangedMessage>(OnParentChange);
         }
 
@@ -145,8 +146,8 @@ namespace Robust.Shared.GameObjects
                 return xform.Coordinates;
 
             // GriddUid is only set after init.
-            if (xform.LifeStage < ComponentLifeStage.Initialized && xform.GridUid == null)
-                SetGridId(xform, xform.FindGridEntityId(xformQuery));
+            if (!xform._gridInitialized)
+                InitializeGridUid(xform.Owner, xform, xformQuery, GetEntityQuery<MapGridComponent>());
 
             // Is the entity directly parented to the grid?
             if (xform.GridUid == xform.ParentUid)
@@ -176,8 +177,8 @@ namespace Robust.Shared.GameObjects
             var parentXform = xformQuery.GetComponent(parentUid);
 
             // GriddUid is only set after init.
-            if (parentXform.LifeStage < ComponentLifeStage.Initialized && parentXform.GridUid == null)
-                SetGridId(parentXform, parentXform.FindGridEntityId(xformQuery));
+            if (!parentXform._gridInitialized)
+                InitializeGridUid(parentUid, parentXform, xformQuery, GetEntityQuery<MapGridComponent>());
 
             // Is the entity directly parented to the grid?
             if (parentXform.GridUid == parentUid)
@@ -208,8 +209,8 @@ namespace Robust.Shared.GameObjects
                 return (xform.Coordinates, xform.LocalRotation);
 
             // GriddUid is only set after init.
-            if (xform.LifeStage < ComponentLifeStage.Initialized && xform.GridUid == null)
-                SetGridId(xform, xform.FindGridEntityId(xformQuery));
+            if (!xform._gridInitialized)
+                InitializeGridUid(xform.Owner, xform, xformQuery, GetEntityQuery<MapGridComponent>());
 
             // Is the entity directly parented to the grid?
             if (xform.GridUid == xform.ParentUid)

--- a/Robust.Shared/Map/MapManager.Queries.cs
+++ b/Robust.Shared/Map/MapManager.Queries.cs
@@ -1,9 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Robust.Shared.GameObjects;
-using Robust.Shared.Log;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
@@ -16,6 +14,7 @@ internal partial class MapManager
 {
     public IEnumerable<MapGridComponent> FindGridsIntersecting(MapId mapId, Box2Rotated bounds, bool approx = false)
     {
+        DebugTools.Assert(mapId != MapId.Nullspace);
         var aabb = bounds.CalcBoundingBox();
         // TODO: We can do slower GJK checks to check if 2 bounds actually intersect, but WYCI.
         return FindGridsIntersecting(mapId, aabb, approx);
@@ -23,6 +22,7 @@ internal partial class MapManager
 
     public void FindGridsIntersectingApprox(MapId mapId, Box2 worldAABB, GridCallback callback)
     {
+        DebugTools.Assert(mapId != MapId.Nullspace);
         if (!_gridTrees.TryGetValue(mapId, out var gridTree))
             return;
 
@@ -46,6 +46,7 @@ internal partial class MapManager
 
     public void FindGridsIntersectingApprox<TState>(MapId mapId, Box2 worldAABB, ref TState state, GridCallback<TState> callback)
     {
+        DebugTools.Assert(mapId != MapId.Nullspace);
         if (!_gridTrees.TryGetValue(mapId, out var gridTree))
             return;
 
@@ -71,6 +72,7 @@ internal partial class MapManager
 
     public IEnumerable<MapGridComponent> FindGridsIntersecting(MapId mapId, Box2 worldAabb, bool approx = false)
     {
+        DebugTools.Assert(mapId != MapId.Nullspace);
         if (!_gridTrees.ContainsKey(mapId)) return Enumerable.Empty<MapGridComponent>();
 
         var xformQuery = EntityManager.GetEntityQuery<TransformComponent>();
@@ -89,6 +91,7 @@ internal partial class MapManager
         EntityQuery<PhysicsComponent> physicsQuery,
         bool approx = false)
     {
+        DebugTools.Assert(mapId != MapId.Nullspace);
         if (!_gridTrees.TryGetValue(mapId, out var gridTree)) return Enumerable.Empty<MapGridComponent>();
 
         DebugTools.Assert(grids.Count == 0);
@@ -161,6 +164,7 @@ internal partial class MapManager
         EntityQuery<TransformComponent> xformQuery,
         [NotNullWhen(true)] out MapGridComponent? grid)
     {
+        DebugTools.Assert(mapId != MapId.Nullspace);
         // Need to enlarge the AABB by at least the grid shrinkage size.
         var aabb = new Box2(worldPos - 0.2f, worldPos + 0.2f);
 


### PR DESCRIPTION
Previously the `GridUid` would be null if an entity is on a map-grid, which causes issues for some components which use the grid uid to fetch the grid component.

This change runs afoul of some convoluted entity init ordering issues, so it also reworks how GridUid is initially set, though the overall behaviour is the same. In particular, GridUid is still not guaranteed to be set correctly until after the transform component has initialized.