### PR TITLE
Remove some asserts

### DIFF
--- a/Robust.Shared/Map/MapManager.Queries.cs
+++ b/Robust.Shared/Map/MapManager.Queries.cs
@@ -14,7 +14,6 @@ internal partial class MapManager
 {
     public IEnumerable<MapGridComponent> FindGridsIntersecting(MapId mapId, Box2Rotated bounds, bool approx = false)
     {
-        DebugTools.Assert(mapId != MapId.Nullspace);
         var aabb = bounds.CalcBoundingBox();
         // TODO: We can do slower GJK checks to check if 2 bounds actually intersect, but WYCI.
         return FindGridsIntersecting(mapId, aabb, approx);
@@ -22,7 +21,6 @@ internal partial class MapManager
 
     public void FindGridsIntersectingApprox(MapId mapId, Box2 worldAABB, GridCallback callback)
     {
-        DebugTools.Assert(mapId != MapId.Nullspace);
         if (!_gridTrees.TryGetValue(mapId, out var gridTree))
             return;
 
@@ -46,7 +44,6 @@ internal partial class MapManager
 
     public void FindGridsIntersectingApprox<TState>(MapId mapId, Box2 worldAABB, ref TState state, GridCallback<TState> callback)
     {
-        DebugTools.Assert(mapId != MapId.Nullspace);
         if (!_gridTrees.TryGetValue(mapId, out var gridTree))
             return;
 
@@ -72,7 +69,6 @@ internal partial class MapManager
 
     public IEnumerable<MapGridComponent> FindGridsIntersecting(MapId mapId, Box2 worldAabb, bool approx = false)
     {
-        DebugTools.Assert(mapId != MapId.Nullspace);
         if (!_gridTrees.ContainsKey(mapId)) return Enumerable.Empty<MapGridComponent>();
 
         var xformQuery = EntityManager.GetEntityQuery<TransformComponent>();
@@ -91,7 +87,6 @@ internal partial class MapManager
         EntityQuery<PhysicsComponent> physicsQuery,
         bool approx = false)
     {
-        DebugTools.Assert(mapId != MapId.Nullspace);
         if (!_gridTrees.TryGetValue(mapId, out var gridTree)) return Enumerable.Empty<MapGridComponent>();
 
         DebugTools.Assert(grids.Count == 0);


### PR DESCRIPTION
Removes some asserts added in #4040. It's currently causing content tests to fail at random and its not really that bad if people try to do a lookup in null space, even if it is a sign that something might be going wrong somewhere.