### PR TITLE
Split texture theme path and regular texture path

### DIFF
--- a/Robust.Client/UserInterface/Controls/TextureButton.cs
+++ b/Robust.Client/UserInterface/Controls/TextureButton.cs
@@ -17,7 +17,16 @@ namespace Robust.Client.UserInterface.Controls
         public const string StylePseudoClassHover = "hover";
         public const string StylePseudoClassDisabled = "disabled";
         public const string StylePseudoClassPressed = "pressed";
+
+        /// <summary>
+        /// Path specified from root of resources.
+        /// </summary>
         private string? _texturePath;
+
+        /// <summary>
+        /// Path specified relative to current theme.
+        /// </summary>
+        private string? _textureThemePath;
 
 
         public TextureButton()
@@ -39,8 +48,9 @@ namespace Robust.Client.UserInterface.Controls
         public string TextureThemePath
         {
             set {
-                TextureNormal = Theme.ResolveTexture(value);
-                _texturePath = value;
+                _textureThemePath = value;
+                _texturePath = null;
+                ApplyTexture();
             }
         }
 
@@ -48,15 +58,29 @@ namespace Robust.Client.UserInterface.Controls
         protected override void OnThemeUpdated()
         {
             base.OnThemeUpdated();
-            if (_texturePath != null) TextureNormal = Theme.ResolveTexture(_texturePath);
+            ApplyTexture();
         }
         public string TexturePath
         {
             set
             {
                 _texturePath = value;
-                if (_texturePath != null) TextureNormal = Theme.ResolveTexture(_texturePath);
+                _textureThemePath = null;
+                ApplyTexture();
             }
+        }
+
+        /// <summary>
+        /// Attempt to set TextureNormal based on _textureThemePath and _texturePath.
+        /// </summary>
+        private void ApplyTexture()
+        {
+            if (_textureThemePath != null)
+                TextureNormal = Theme.ResolveTexture(_textureThemePath);
+            else if (_texturePath != null)
+                TextureNormal = IoCManager.Resolve<IResourceCache>().GetResource<TextureResource>(_texturePath);
+            else
+                TextureNormal = null;
         }
 
         public Vector2 Scale

--- a/Robust.Client/UserInterface/Controls/TextureRect.cs
+++ b/Robust.Client/UserInterface/Controls/TextureRect.cs
@@ -40,15 +40,23 @@ namespace Robust.Client.UserInterface.Controls
             }
         }
 
+        /// <summary>
+        /// Path specified from root of resources.
+        /// </summary>
         private string? _texturePath;
+
+        /// <summary>
+        /// Path specified relative to current theme.
+        /// </summary>
+        private string? _textureThemePath;
 
         // TODO HUD REFACTOR BEFORE MERGE use or cleanup
         public string TextureThemePath
         {
-            set
-            {
-                Texture = Theme.ResolveTexture(value);
-                _texturePath = value;
+            set {
+                _textureThemePath = value;
+                _texturePath = null;
+                ApplyTexture();
             }
         }
 
@@ -57,10 +65,23 @@ namespace Robust.Client.UserInterface.Controls
         {
             set
             {
-                Texture = IoCManager.Resolve<IResourceCache>().GetResource<TextureResource>(value);
                 _texturePath = value;
+                _textureThemePath = null;
+                ApplyTexture();
             }
+        }
 
+        /// <summary>
+        /// Attempt to set TextureNormal based on _textureThemePath and _texturePath.
+        /// </summary>
+        private void ApplyTexture()
+        {
+            if (_textureThemePath != null)
+                Texture = Theme.ResolveTexture(_textureThemePath);
+            else if (_texturePath != null)
+                Texture = IoCManager.Resolve<IResourceCache>().GetResource<TextureResource>(_texturePath);
+            else
+                Texture = null;
         }
 
         protected override void OnThemeUpdated()


### PR DESCRIPTION
Based on [the other thread](https://github.com/space-wizards/RobustToolbox/pull/4042#issuecomment-1549211753), it looks like not all locations for texturepath can depend on texture theme path resolver.  Also looks like there was some code kinda managing this before, but in a way that didn't save whether the path was a theme-relative or root-relative path.

This PR splits the two different paths into two different variables, instead of trying to overload one variable in a way that the theme update event can't reliably differentiate between.

Also fixes broken images on paper, etc

:warning:  Requires https://github.com/space-wizards/space-station-14/pull/16498 on the content side to prevent action buttons becoming errors

@eoineoineoin

![image](https://github.com/space-wizards/RobustToolbox/assets/22365940/36f5a6d6-106d-4102-bff9-e9f476fb5a29)
