### PR TITLE
Fix PVS reconnect error

### DIFF
--- a/Robust.Server/GameStates/PVSCollection.cs
+++ b/Robust.Server/GameStates/PVSCollection.cs
@@ -349,8 +349,11 @@ public sealed class PVSCollection<TIndex> : IPVSCollection where TIndex : ICompa
 
     private GameTick _largestCulled;
 
-    public List<TIndex> GetDeletedIndices(GameTick fromTick)
+    public List<TIndex>? GetDeletedIndices(GameTick fromTick)
     {
+        if (fromTick == GameTick.Zero)
+            return null;
+
         // I'm 99% sure this can never happen, but it is hard to test real laggy/lossy networks with many players.
         if (_largestCulled > fromTick)
         {
@@ -365,7 +368,7 @@ public sealed class PVSCollection<TIndex> : IPVSCollection where TIndex : ICompa
                 list.Add(id);
         }
 
-        return list;
+        return list.Count > 0 ? list : null;
     }
 
     #endregion

--- a/Robust.Server/GameStates/PVSSystem.cs
+++ b/Robust.Server/GameStates/PVSSystem.cs
@@ -820,7 +820,6 @@ internal sealed partial class PVSSystem : EntitySystem
                 _visSetPool.Return(oldEntry.Value.Value);
         }
 
-        if (deletions.Count == 0) deletions = default;
         if (entityStates.Count == 0) entityStates = default;
         return (entityStates, deletions, leftView, sessionData.RequestedFull ? GameTick.Zero : fromTick);
     }
@@ -1072,10 +1071,7 @@ internal sealed partial class PVSSystem : EntitySystem
         }
 
         _uidSetPool.Return(toSend);
-        List<EntityUid>? deletions = _entityPvsCollection.GetDeletedIndices(fromTick);
-
-        if (deletions.Count == 0)
-            deletions = null;
+        var deletions = _entityPvsCollection.GetDeletedIndices(fromTick);
 
         if (stateEntities.Count == 0)
             stateEntities = null;


### PR DESCRIPTION
fixes #4050. I forgot to deal with the `GameTick == 0` case that happens when first connecting.