### PR TITLE
Update themes when adding root controls.

### DIFF
--- a/Robust.Client/UserInterface/Control.cs
+++ b/Robust.Client/UserInterface/Control.cs
@@ -73,18 +73,22 @@ namespace Robust.Client.UserInterface
         //    _nameScope = nameScope;
         //}
 
-        public UITheme Theme { get; set; }
+        public UITheme Theme { get; internal set; }
 
-        protected virtual void OnThemeUpdated(){}
-        internal void ThemeUpdateRecursive()
+        protected virtual void OnThemeUpdated()
+        {
+        }
+
+        public void ThemeUpdateRecursive()
         {
             var curTheme = UserInterfaceManager.CurrentTheme;
-            if (Theme == curTheme) return; //don't update themes if the themes are up to date
+            if (Theme == curTheme)
+                return;
+
             Theme = curTheme;
             OnThemeUpdated();
             foreach (var child in Children)
             {
-                // Don't descent into children that have a style sheet since those aren't affected.
                 child.ThemeUpdateRecursive();
             }
         }

--- a/Robust.Client/UserInterface/Controls/WindowRoot.cs
+++ b/Robust.Client/UserInterface/Controls/WindowRoot.cs
@@ -1,6 +1,4 @@
 ﻿using Robust.Client.Graphics;
-using Robust.Shared.Maths;
-using Robust.Shared.ViewVariables;
 
 namespace Robust.Client.UserInterface.Controls
 {

--- a/Robust.Client/UserInterface/UserInterfaceManager.Themes.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Themes.cs
@@ -53,7 +53,8 @@ internal partial class UserInterfaceManager
 
     private void UpdateTheme(UITheme newTheme)
     {
-        if (newTheme == CurrentTheme) return; //do not update if the theme is unchanged
+        if (newTheme == CurrentTheme)
+            return;
         CurrentTheme = newTheme;
         _userInterfaceManager.RootControl.ThemeUpdateRecursive();
     }

--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -177,6 +177,21 @@ namespace Robust.Client.UserInterface
                 MouseFilter = Control.MouseFilterMode.Ignore
             };
             RootControl.AddChild(PopupRoot);
+
+            MainViewport.OnChildAdded += OnRootChildAdded;
+            StateRoot.OnChildAdded += OnRootChildAdded;
+            WindowRoot.OnChildAdded += OnRootChildAdded;
+            ModalRoot.OnChildAdded += OnRootChildAdded;
+            PopupRoot.OnChildAdded += OnRootChildAdded;
+            RootControl.OnChildAdded += OnRootChildAdded;
+        }
+
+        private void OnRootChildAdded(Control ctrl)
+        {
+            // Ensure themes are up to date. Required to ensure that the theme is updated for things like windows that
+            // were closed during the last theme change. Other orphaned controls need to be updated by whatever
+            // system/controller is in charge of them.
+            ctrl.ThemeUpdateRecursive();
         }
 
         public void InitializeTesting()


### PR DESCRIPTION
Replacement for #3973. Alternatively, maybe this should just become part of the base AddChild method (see #4059).