### PR TITLE
Update theme on child add.

### DIFF
--- a/Robust.Client/UserInterface/Control.cs
+++ b/Robust.Client/UserInterface/Control.cs
@@ -73,19 +73,37 @@ namespace Robust.Client.UserInterface
         //    _nameScope = nameScope;
         //}
 
-        public UITheme Theme { get; set; }
+        public UITheme Theme { get; internal set; }
 
-        protected virtual void OnThemeUpdated(){}
-        internal void ThemeUpdateRecursive()
+        private UITheme? _themeOverride;
+
+        public UITheme? ThemeOverride
         {
-            var curTheme = UserInterfaceManager.CurrentTheme;
-            if (Theme == curTheme) return; //don't update themes if the themes are up to date
-            Theme = curTheme;
+            get => _themeOverride;
+            set
+            {
+                if (_themeOverride == value)
+                    return;
+                _themeOverride = value;
+                ThemeUpdateRecursive(Parent?.Theme ?? UserInterfaceManager.CurrentTheme);
+            }
+        }
+        
+        protected virtual void OnThemeUpdated()
+        {
+        }
+
+        public void ThemeUpdateRecursive(UITheme theme)
+        {
+            theme = _themeOverride ?? theme;
+            if (Theme == theme)
+                return;
+
+            Theme = theme;
             OnThemeUpdated();
             foreach (var child in Children)
             {
-                // Don't descent into children that have a style sheet since those aren't affected.
-                child.ThemeUpdateRecursive();
+                child.ThemeUpdateRecursive(Theme);
             }
         }
 
@@ -668,6 +686,7 @@ namespace Robust.Client.UserInterface
         protected virtual void ChildAdded(Control newChild)
         {
             OnChildAdded?.Invoke(newChild);
+            newChild.ThemeUpdateRecursive(Theme);
             InvalidateMeasure();
         }
 

--- a/Robust.Client/UserInterface/Controls/TextureButton.cs
+++ b/Robust.Client/UserInterface/Controls/TextureButton.cs
@@ -36,20 +36,12 @@ namespace Robust.Client.UserInterface.Controls
             }
         }
 
-        public string TextureThemePath
-        {
-            set {
-                TextureNormal = Theme.ResolveTexture(value);
-                _texturePath = value;
-            }
-        }
-
-
         protected override void OnThemeUpdated()
         {
             if (_texturePath != null) TextureNormal = Theme.ResolveTexture(_texturePath);
             base.OnThemeUpdated();
         }
+
         public string TexturePath
         {
             set

--- a/Robust.Client/UserInterface/Controls/TextureRect.cs
+++ b/Robust.Client/UserInterface/Controls/TextureRect.cs
@@ -42,17 +42,6 @@ namespace Robust.Client.UserInterface.Controls
 
         private string? _texturePath;
 
-        // TODO HUD REFACTOR BEFORE MERGE use or cleanup
-        public string TextureThemePath
-        {
-            set
-            {
-                Texture = Theme.ResolveTexture(value);
-                _texturePath = value;
-            }
-        }
-
-        // TODO HUD REFACTOR BEFORE MERGE use or cleanup
         public string TexturePath
         {
             set

--- a/Robust.Client/UserInterface/Stylesheets/DefaultStylesheet.cs
+++ b/Robust.Client/UserInterface/Stylesheets/DefaultStylesheet.cs
@@ -101,7 +101,7 @@ public sealed class DefaultStylesheet
 
             Element().Class(DefaultWindow.StyleClassWindowCloseButton)
                 // Button texture
-                .Prop(TextureButton.StylePropertyTexture, theme.ResolveTexture(res, "cross"))
+                .Prop(TextureButton.StylePropertyTexture, theme.ResolveTexture("cross"))
                 // Normal button color
                 .Prop(Control.StylePropertyModulateSelf, theme.ResolveColorOrSpecified("windowCloseButton", Color.FromHex("#FFFFFF"))),
 

--- a/Robust.Client/UserInterface/Themes/UiTheme.cs
+++ b/Robust.Client/UserInterface/Themes/UiTheme.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Shared.IoC;
+using Robust.Shared.Log;
 using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager.Attributes;
@@ -14,9 +16,14 @@ namespace Robust.Client.UserInterface.Themes;
 
 [Prototype("uiTheme")]
 public sealed class UITheme : IPrototype
-{ //this is used for ease of access
+{
+    private IResourceCache? _cache;
+    private IUserInterfaceManager? _uiMan;
+
+    //this is used for ease of access
     public const string DefaultPath = "/Textures/Interface";
     public const string DefaultName = "Default";
+    public static ResPath DefaultThemePath = new ($"{DefaultPath}/{DefaultName}");
 
     [ViewVariables]
     [IdDataField]
@@ -25,7 +32,7 @@ public sealed class UITheme : IPrototype
     [DataField("path")]
     private ResPath _path;
 
-    [DataField("colors", readOnly: true)]
+    [DataField("colors", readOnly: true)] // This is a prototype, why is this readonly??
     public Dictionary<string, Color>? Colors { get; }
     public ResPath Path => _path == default ? new ResPath(DefaultPath+"/"+ID) : _path;
 
@@ -34,24 +41,57 @@ public sealed class UITheme : IPrototype
         var foundFolders = resourceCache.ContentFindFiles(Path.ToRootedPath());
         if (!foundFolders.Any()) throw new Exception("UITheme: "+ID+" not found in resources!");
     }
-    //helper to autoresolve dependencies
+
     public Texture ResolveTexture(string texturePath)
     {
-        return ResolveTexture(IoCManager.Resolve<IResourceCache>(), texturePath);
+        if (TryResolveTexture(texturePath, out var texture))
+            return texture;
+
+        Logger.Error($"Failed to resolve texture {texturePath}. Resorting to fallback.");
+        return _cache!.GetFallback<TextureResource>();
     }
-    public Texture ResolveTexture(IResourceCache cache, string texturePath)
+
+    public TextureResource? ResolveTextureOrNull(string? texturePath)
     {
-        return cache.TryGetResource<TextureResource>( new ResPath($"{Path}/{texturePath}.png"), out var texture) ? texture :
-            cache.GetResource<TextureResource>($"{DefaultPath}/{DefaultName}/{texturePath}.png");
+        return TryResolveTexture(texturePath, out var texture) ? texture : null;
+    }
+
+    public bool TryResolveTexture(
+        string? texturePath,
+        [NotNullWhen(true)] out TextureResource? texture)
+    {
+        IoCManager.Resolve(ref _cache);
+
+        if (texturePath == null)
+        {
+            texture = null;
+            return false;
+        }
+
+        var resPath = new ResPath($"{texturePath}.png");
+        if (resPath.IsRelative)
+        {
+            if (_cache.TryGetResource( Path / resPath, out texture))
+                return true;
+
+            if (_cache.TryGetResource( DefaultThemePath / resPath, out texture))
+                return true;
+        }
+
+        // using texturePath instead of resPath as absolute paths do not need to have .png appended.
+        return _cache.TryGetResource(texturePath, out texture);
     }
 
     public Color? ResolveColor(string colorName)
     {
-        if (Colors == null) return null;
+        if (Colors == null)
+            return null;
 
         if (Colors.TryGetValue(colorName, out var color))
             return color;
-        else if (IoCManager.Resolve<IUserInterfaceManager>().DefaultTheme.Colors?.TryGetValue(colorName, out color) ?? false)
+
+        IoCManager.Resolve(ref _uiMan);
+        if (_uiMan.DefaultTheme.Colors?.TryGetValue(colorName, out color) ?? false)
             return color;
 
         return null;

--- a/Robust.Client/UserInterface/UserInterfaceManager.Themes.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Themes.cs
@@ -53,9 +53,11 @@ internal partial class UserInterfaceManager
 
     private void UpdateTheme(UITheme newTheme)
     {
-        if (newTheme == CurrentTheme) return; //do not update if the theme is unchanged
+        if (newTheme == CurrentTheme)
+            return;
+
         CurrentTheme = newTheme;
-        _userInterfaceManager.RootControl.ThemeUpdateRecursive();
+        _userInterfaceManager.RootControl.ThemeUpdateRecursive(CurrentTheme);
     }
 
     //Try to set the current theme, if the theme is not found leave the previous theme


### PR DESCRIPTION
Replacement for #3973. This updates the theme whenever a child control is added, and adds support for controls to override themes.

This caused some content errors for controls that try to resolve empty strings as texture paths, so this requires a content PR (space-wizards/space-station-14/pull/16519) and I've also made some changes to theme resolves, particularly the solution I proposed in #4048, so this PR would also supersede that PR.