### PR TITLE
Change default state reset behaviour

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -270,7 +270,7 @@ namespace Robust.Client.GameStates
                     _processor.LastFullStateRequested = null;
                     _timing.LastProcessedTick = curState.ToSequence;
                     DebugTools.Assert(curState.FromSequence == GameTick.Zero);
-                    PartialStateReset(curState, true, true);
+                    PartialStateReset(curState, true);
                 }
                 else
                     _timing.LastProcessedTick += 1;
@@ -792,7 +792,11 @@ namespace Robust.Client.GameStates
         }
 
         /// <inheritdoc />
-        public void PartialStateReset(GameState state, bool resetAllEnts, bool deleteClientSideEnts)
+        public void PartialStateReset(
+            GameState state,
+            bool resetAllEntities,
+            bool deleteClientEntities = false,
+            bool deleteClientChildren = true)
         {
             using var _ = _timing.StartStateApplicationArea();
 
@@ -822,14 +826,14 @@ namespace Robust.Client.GameStates
             {
                 if (ent.IsClientSide())
                 {
-                    if (deleteClientSideEnts)
+                    if (deleteClientEntities)
                         toDelete.Add(ent);
                     continue;
                 }
 
                 if (stateEnts.Contains(ent) && metas.TryGetComponent(ent, out var meta))
                 {
-                    if (resetAllEnts || meta.LastStateApplied > state.ToSequence)
+                    if (resetAllEntities || meta.LastStateApplied > state.ToSequence)
                         meta.LastStateApplied = GameTick.Zero; // TODO track last-state-applied for individual components? Is it even worth it?
                     continue;
                 }
@@ -837,17 +841,20 @@ namespace Robust.Client.GameStates
                 if (!xforms.TryGetComponent(ent, out var xform))
                     continue;
 
-                // this entity is going to get deleted, but maybe some if its children won't be, so lets detach them to null.
+                // This entity is going to get deleted, but maybe some if its children won't be, so lets detach them to
+                // null. First we will detach the parent in order to reduce the number of broadphase/lookup updates.
                 xformSys.DetachParentToNull(ent, xform, xforms, metas);
+
+                // Then detach all children.
                 var childEnumerator = xform.ChildEnumerator;
                 while (childEnumerator.MoveNext(out var child))
                 {
                     xformSys.DetachParentToNull(child.Value, xforms.GetComponent(child.Value), xforms, metas, xform);
 
-                    if (!deleteClientSideEnts && child.Value.IsClientSide())
+                    if (deleteClientChildren
+                        && !deleteClientEntities // don't add duplicates
+                        && child.Value.IsClientSide())
                     {
-                        // Even though we aren't meant to be deleting client-side entities here, this client-side entity is getting detached to null space, so we will delete it anyways).
-                        _sawmill.Warning($"Deleting client-side entity ({_entities.ToPrettyString(child.Value)}) as it was parented to a server side entity that is getting deleted ({_entities.ToPrettyString(ent)})");
                         toDelete.Add(child.Value);
                     }
                 }

--- a/Robust.Client/GameStates/IClientGameStateManager.cs
+++ b/Robust.Client/GameStates/IClientGameStateManager.cs
@@ -103,15 +103,36 @@ namespace Robust.Client.GameStates
         void UpdateFullRep(GameState state, bool cloneDelta = false);
 
         /// <summary>
-        ///     This will perform some setup in order to reset the game to an earlier state by deleting entities and
-        ///     marking ensuring component states will get applied properly. <see cref="ApplyGameState(GameState,
-        ///     GameState?)"/> Still needs to be called separately after this is run.
+        /// This will perform some setup in order to reset the game to an earlier state. To fully reset the state
+        /// <see cref="ApplyGameState()"/> still needs to be called separately.
         /// </summary>
-        /// <param name="state">The state to reset to.</param>
-        /// <param name="resetAllEnts">Whether to apply component states to all entities, or only those that have been
-        /// modified some time after the state's to-sequence</param>
-        /// <param name="deleteClientSideEnts">Whether to delete all client-side entities (which are never part of the
-        /// networked game state).</param>
-        void PartialStateReset(GameState state, bool resetAllEnts, bool deleteClientSideEnts);
+        /// <remarks>
+        /// This function will delete any networked entities that are not present in the given game state. Any child
+        /// entities that are in the state will simply be sent to null-space. This will also reset
+        /// <see cref="MetaDataComponent.LastStateApplied"/> to zero, so that <see cref="ApplyGameState()"/> will
+        /// actually apply the state.
+        /// </remarks>
+        /// <param name="state">
+        /// The state to reset to.
+        /// </param>
+        /// <param name="resetAllEntities">
+        /// Whether or not to reset <see cref="MetaDataComponent.LastStateApplied"/> for all entities, or only those
+        /// that have been modified some after the states <see cref="GameState.ToSequence"/>. This effectively
+        /// determines whether we should do a full-state reset, or only reset recently modified entities.
+        /// </param>
+        /// <param name="deleteClientEntities">
+        /// Whether to delete all client-side entities (which are never part of the networked game state).
+        /// </param>
+        /// <param name="deleteClientChildren">
+        /// Whether to delete client-side entities that are parented to networked that are about to be deleted during
+        /// the partial reset. E.g., if this is true, then a client-side muzzle flash effect entity that is parented to
+        /// a networked gun entity will get deleted if that gun is about to be deleted. If false, the entity will
+        /// simply be detached to nullspace. This option has no effect if <see cref="deleteClientEntities"/> is true.
+        /// </param>
+        void PartialStateReset(
+            GameState state,
+            bool resetAllEntities,
+            bool deleteClientEntities = false,
+            bool deleteClientChildren = true);
     }
 }


### PR DESCRIPTION
Full state resets now only delete client side entities if they are parented to a networked entity that is getting deleted. Should avoid issues where client-side nullspace entities that are being used for things like UIs unintentionally get deleted.

Breaking change because the `PartialStateReset()` arguments have changed:
- Changed the `deleteClientSideEnts` bool  argument to an optional argument that defaults to false.
- Added a new argument that controls whether or not to delete client-side entities parented to networked entities (defaults to true).
