### PR TITLE
Modify replay recording directory selection

### DIFF
--- a/Resources/Locale/en-US/commands.ftl
+++ b/Resources/Locale/en-US/commands.ftl
@@ -535,10 +535,13 @@ cmd-vvinvoke-desc = Invoke/Call a path with arguments using VV.
 cmd-vvinvoke-help = Usage: vvinvoke <path> [arguments...]
 
 cmd-replaystart-desc = Starts a replay recording, optionally with some time limit.
-cmd-replaystart-help = Usage: replaystart [minutes] [name/directory] [overwrite bool]
+cmd-replaystart-help = Usage: replaystart [time limit (minutes)] [path] [overwrite bool]
 cmd-replaystart-success = Started recording a replay.
 cmd-replaystart-already-recording = Already recording a replay.
 cmd-replaystart-error = An error occurred while trying to start the recording.
+cmd-replaystart-hint-time = [optional time limit (minutes)]
+cmd-replaystart-hint-name = [optional path]
+cmd-replaystart-hint-overwrite = [overwrite path (bool)]
 
 cmd-replaystop-desc = Stops a replay recording.
 cmd-replaystop-help = Usage: replaystop

--- a/Resources/Locale/en-US/commands.ftl
+++ b/Resources/Locale/en-US/commands.ftl
@@ -535,7 +535,7 @@ cmd-vvinvoke-desc = Invoke/Call a path with arguments using VV.
 cmd-vvinvoke-help = Usage: vvinvoke <path> [arguments...]
 
 cmd-replaystart-desc = Starts a replay recording, optionally with some time limit.
-cmd-replaystart-help = Usage: replaystart [minutes] [directory] [overwrite bool]
+cmd-replaystart-help = Usage: replaystart [minutes] [name/directory] [overwrite bool]
 cmd-replaystart-success = Started recording a replay.
 cmd-replaystart-already-recording = Already recording a replay.
 cmd-replaystart-error = An error occurred while trying to start the recording.

--- a/Robust.Server/Replays/IServerReplayRecordingManager.cs
+++ b/Robust.Server/Replays/IServerReplayRecordingManager.cs
@@ -1,12 +1,29 @@
 using Robust.Shared.Replays;
 using System;
+using Robust.Shared;
 
 namespace Robust.Server.Replays;
 
 public interface IServerReplayRecordingManager : IReplayRecordingManager
 {
     void ToggleRecording();
-    bool TryStartRecording(string? directory = null, bool overwrite = false, TimeSpan? duration = null);
+
+    /// <summary>
+    ///     Starts recording a replay.
+    /// </summary>
+    /// <param name="replayName">
+    /// The name of the replay. This determines the name of the <see cref="CVars.ReplayDirectory"/> subfolder where the
+    /// data will be saved. If not provided, will default to using the current time.
+    /// </param>
+    /// <param name="overwrite">
+    /// Whether to overwrite the folder, if it already exists.
+    /// </param>
+    /// <param name="duration">
+    /// Optional time limit for the recording.
+    /// </param>
+    /// <returns>Returns true if the recording was successfully started.</returns>
+    bool TryStartRecording(string? replayName = null, bool overwrite = false, TimeSpan? duration = null);
+
     void StopRecording();
 
     /// <summary>

--- a/Robust.Server/Replays/IServerReplayRecordingManager.cs
+++ b/Robust.Server/Replays/IServerReplayRecordingManager.cs
@@ -11,18 +11,18 @@ public interface IServerReplayRecordingManager : IReplayRecordingManager
     /// <summary>
     ///     Starts recording a replay.
     /// </summary>
-    /// <param name="replayName">
-    /// The name of the replay. This determines the name of the <see cref="CVars.ReplayDirectory"/> subfolder where the
-    /// data will be saved. If not provided, will default to using the current time.
+    /// <param name="path">
+    /// The folder where the replay will be stored. This will be some folder within  <see cref="CVars.ReplayDirectory"/>.
+    /// If not provided, will default to using the current time.
     /// </param>
     /// <param name="overwrite">
-    /// Whether to overwrite the folder, if it already exists.
+    /// Whether to overwrite the specified path if a folder already exists.
     /// </param>
     /// <param name="duration">
     /// Optional time limit for the recording.
     /// </param>
     /// <returns>Returns true if the recording was successfully started.</returns>
-    bool TryStartRecording(string? replayName = null, bool overwrite = false, TimeSpan? duration = null);
+    bool TryStartRecording(string? path = null, bool overwrite = false, TimeSpan? duration = null);
 
     void StopRecording();
 

--- a/Robust.Server/Replays/ReplayCommands.cs
+++ b/Robust.Server/Replays/ReplayCommands.cs
@@ -47,6 +47,20 @@ internal sealed class ReplayStartCommand : LocalizedCommands
         else
             shell.WriteLine(Loc.GetString("cmd-replaystart-error"));
     }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+            return CompletionResult.FromHint(Loc.GetString("cmd-replaystart-hint-time"));
+
+        if (args.Length == 2)
+            return CompletionResult.FromHint(Loc.GetString("cmd-replaystart-hint-name"));
+
+        if (args.Length == 3)
+            return CompletionResult.FromHint(Loc.GetString("cmd-replaystart-hint-overwrite"));
+
+        return CompletionResult.Empty;
+    }
 }
 
 internal sealed class ReplayStopCommand : LocalizedCommands

--- a/Robust.Server/Replays/ReplayRecordingManager.cs
+++ b/Robust.Server/Replays/ReplayRecordingManager.cs
@@ -39,6 +39,9 @@ internal sealed class ReplayRecordingManager : IInternalReplayRecordingManager
     private PVSSystem _pvs = default!;
     private List<object> _queuedMessages = new();
 
+    // date format for default replay names. Like the sortable template, but without colons.
+    private const string DefaultReplayNameFormat = "yyyy-MM-dd_HH-mm-ss";
+
     private int _maxCompressedSize;
     private int _maxUncompressedSize;
     private int _tickBatchSize;
@@ -106,7 +109,7 @@ internal sealed class ReplayRecordingManager : IInternalReplayRecordingManager
         if (!_enabled || _curStream != null)
             return false;
 
-        replayName ??= DateTime.UtcNow.ToString("s");
+        replayName ??= DateTime.UtcNow.ToString(DefaultReplayNameFormat);
 
         var dir = _netConf.GetCVar(CVars.ReplayDirectory);
         _path = new ResPath($"{dir}/{replayName}").ToRootedPath();

--- a/Robust.Server/Replays/ReplayRecordingManager.cs
+++ b/Robust.Server/Replays/ReplayRecordingManager.cs
@@ -117,12 +117,12 @@ internal sealed class ReplayRecordingManager : IInternalReplayRecordingManager
         }
         else
         {
-            subDir = new ResPath(path);
-            if (subDir == ResPath.Root)
+            subDir = new ResPath(path).Clean();
+            if (subDir == ResPath.Root || subDir == ResPath.Empty || subDir == ResPath.Self)
                 subDir = new ResPath(DateTime.UtcNow.ToString(DefaultReplayNameFormat));
         }
 
-        subDir = subDir.Clean().ToRootedPath();
+        subDir = subDir.ToRootedPath();
 
         // apparently OpenSubdirectory is the only way to prevent escaping a directory with ".."???
         var basePath = new ResPath(_netConf.GetCVar(CVars.ReplayDirectory)).ToRootedPath();

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1413,10 +1413,9 @@ namespace Robust.Shared
          */
 
         /// <summary>
-        /// The folder within the server data directory where a replay will be recorded. Note that existing files in
-        /// this directory will be removed when starting a new recording.
+        /// A relative path pointing to a folder within the server data directory where all replays will be stored.
         /// </summary>
-        public static readonly CVarDef<string> ReplayDirectory = CVarDef.Create("replay.directory", "replay", CVar.SERVERONLY | CVar.ARCHIVE);
+        public static readonly CVarDef<string> ReplayDirectory = CVarDef.Create("replay.directory", "replays", CVar.SERVERONLY | CVar.ARCHIVE);
 
         /// <summary>
         /// Maximum compressed size of a replay recording (in kilobytes) before recording automatically stops.


### PR DESCRIPTION
This PR changes the behaviour of `TryStartRecording()` and the `replaystart` command and adds console completion hints.

Previously it would try to write the data to any folder in the server's userdata directory. The folder could either be specified by the user/caller or default to using a cvar. 

Now, all replays are stored as subfolders within a cvar-specified folder inside of the userdata dir. The names of the subfolders are either provided by the user/caller or will default to the current time (e.g., "2023-05-18_04-10-13"). The main motivation for this change is so that its easy to have all replays saved to some symlink folder.

This also renames some of the yml keys, and adds the recording start time (not server time) to the yml file.