### PR TITLE
Add `IContentRoot.FileExists()`

### DIFF
--- a/Robust.Client/ResourceManagement/ResourceCache.LoaderApi.cs
+++ b/Robust.Client/ResourceManagement/ResourceCache.LoaderApi.cs
@@ -35,6 +35,11 @@ namespace Robust.Client.ResourceManagement
                 return false;
             }
 
+            public bool FileExists(ResPath relPath)
+            {
+                return _api.TryOpen($"{_prefix}{relPath}", out _);
+            }
+
             public IEnumerable<ResPath> FindFiles(ResPath path)
             {
                 foreach (var relPath in _api.AllFiles)

--- a/Robust.Shared/ContentPack/DirLoader.cs
+++ b/Robust.Shared/ContentPack/DirLoader.cs
@@ -58,6 +58,12 @@ namespace Robust.Shared.ContentPack
                 return true;
             }
 
+            public bool FileExists(ResPath relPath)
+            {
+                var path = GetPath(relPath);
+                return File.Exists(path);
+            }
+
             internal string GetPath(ResPath relPath)
             {
                 return Path.GetFullPath(Path.Combine(_directory.FullName, relPath.ToRelativeSystemPath()));

--- a/Robust.Shared/ContentPack/IContentRoot.cs
+++ b/Robust.Shared/ContentPack/IContentRoot.cs
@@ -26,6 +26,11 @@ namespace Robust.Shared.ContentPack
         bool TryGetFile(ResPath relPath, [NotNullWhen(true)] out Stream? stream);
 
         /// <summary>
+        ///     Returns true if the given file exists.
+        /// </summary>
+        public bool FileExists(ResPath relPath);
+
+        /// <summary>
         ///     Recursively finds all files in a directory and all sub directories.
         /// </summary>
         /// <param name="path">Directory to search inside of.</param>

--- a/Robust.Shared/ContentPack/MemoryContentRoot.cs
+++ b/Robust.Shared/ContentPack/MemoryContentRoot.cs
@@ -55,6 +55,19 @@ public sealed class MemoryContentRoot : IContentRoot, IDisposable
         }
     }
 
+    public bool FileExists(ResPath relPath)
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            return _files.ContainsKey(relPath);
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+    }
+
     /// <inheritdoc />
     public bool TryGetFile(ResPath relPath, [NotNullWhen(true)] out Stream? stream)
     {

--- a/Robust.Shared/ContentPack/PackLoader.cs
+++ b/Robust.Shared/ContentPack/PackLoader.cs
@@ -75,6 +75,11 @@ namespace Robust.Shared.ContentPack
                 return true;
             }
 
+            public bool FileExists(ResPath relPath)
+            {
+                return _zip.GetEntry(relPath.ToString()) != null;
+            }
+
             /// <inheritdoc />
             public IEnumerable<ResPath> FindFiles(ResPath path)
             {

--- a/Robust.Shared/ContentPack/ResourceManager.SingleStreamLoader.cs
+++ b/Robust.Shared/ContentPack/ResourceManager.SingleStreamLoader.cs
@@ -40,6 +40,9 @@ namespace Robust.Shared.ContentPack
                 return false;
             }
 
+            public bool FileExists(ResPath relPath)
+                => relPath == _resourcePath;
+
             public IEnumerable<ResPath> FindFiles(ResPath path)
             {
                 if (_resourcePath.TryRelativeTo(path, out var relative))


### PR DESCRIPTION
Generally faster than having to use `TryGetFile(path, out _)`