### PR TITLE
Fix upload folder command

### DIFF
--- a/Robust.Client/Upload/Commands/UploadFolderCommand.cs
+++ b/Robust.Client/Upload/Commands/UploadFolderCommand.cs
@@ -52,7 +52,7 @@ public sealed class UploadFolderCommand : IConsoleCommand
         //Grab all files in specified folder and upload them
         foreach (var filepath in _resourceManager.UserData.Find($"{folderPath.ToRelativePath()}/").files )
         {
-            
+
             await using var filestream = _resourceManager.UserData.Open(filepath,FileMode.Open);
             {
                 var sizeLimit = _configManager.GetCVar(CVars.ResourceUploadingLimitMb);

--- a/Robust.Client/Upload/Commands/UploadFolderCommand.cs
+++ b/Robust.Client/Upload/Commands/UploadFolderCommand.cs
@@ -50,8 +50,9 @@ public sealed class UploadFolderCommand : IConsoleCommand
         }
 
         //Grab all files in specified folder and upload them
-        foreach (var filepath in _resourceManager.UserData.Find($"{folderPath.ToRelativePath()}/").files)
+        foreach (var filepath in _resourceManager.UserData.Find($"{folderPath.ToRelativePath()}/").files )
         {
+            
             await using var filestream = _resourceManager.UserData.Open(filepath,FileMode.Open);
             {
                 var sizeLimit = _configManager.GetCVar(CVars.ResourceUploadingLimitMb);

--- a/Robust.Shared/ContentPack/WritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/WritableDirProvider.cs
@@ -67,12 +67,12 @@ namespace Robust.Shared.ContentPack
 
             foreach (var file in files)
             {
-                resFiles.Add(new ResPath(file.Substring(rootLen)));
+                resFiles.Add(ResPath.FromRelativeSystemPath(file.Substring(rootLen)));
             }
 
             foreach (var dir in dirs)
             {
-                resDirs.Add(new ResPath(dir.Substring(rootLen)));
+                resDirs.Add(ResPath.FromRelativeSystemPath(dir.Substring(rootLen)));
             }
 
             return (resFiles, resDirs);
@@ -127,7 +127,7 @@ namespace Robust.Shared.ContentPack
         {
             if (!path.IsRooted)
             {
-                throw new ArgumentException("Path must be rooted.");
+                throw new ArgumentException($"Path must be rooted. Path: {path}");
             }
 
             path = path.Clean();
@@ -142,7 +142,7 @@ namespace Robust.Shared.ContentPack
             {
                 // Hard cap on any exploit smuggling a .. in there.
                 // Since that could allow leaving sandbox.
-                throw new InvalidOperationException("This branch should never be reached.");
+                throw new InvalidOperationException($"This branch should never be reached. Path: {path}");
             }
 
             return Path.GetFullPath(Path.Combine(root, relPath));

--- a/Robust.Shared/ContentPack/WritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/WritableDirProvider.cs
@@ -67,12 +67,18 @@ namespace Robust.Shared.ContentPack
 
             foreach (var file in files)
             {
-                resFiles.Add(ResPath.FromRelativeSystemPath(file.Substring(rootLen)));
+                if (file.Contains("\\..") || file.Contains("/.."))
+                    continue;
+
+                resFiles.Add(ResPath.FromRelativeSystemPath(file.Substring(rootLen)).ToRootedPath());
             }
 
             foreach (var dir in dirs)
             {
-                resDirs.Add(ResPath.FromRelativeSystemPath(dir.Substring(rootLen)));
+                if (dir.Contains("\\..") || dir.Contains("/.."))
+                    continue;
+
+                resDirs.Add(ResPath.FromRelativeSystemPath(dir.Substring(rootLen)).ToRootedPath());
             }
 
             return (resFiles, resDirs);

--- a/Robust.Shared/ContentPack/WritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/WritableDirProvider.cs
@@ -58,7 +58,7 @@ namespace Robust.Shared.ContentPack
         {
             if (pattern.Contains(".."))
                 throw new InvalidOperationException($"Pattern may not contain '..'. Pattern: {pattern}.");
-            
+
             var rootLen = RootDir.Length - 1;
             var option = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
 

--- a/Robust.Shared/ContentPack/WritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/WritableDirProvider.cs
@@ -56,6 +56,9 @@ namespace Robust.Shared.ContentPack
         /// <inheritdoc />
         public (IEnumerable<ResPath> files, IEnumerable<ResPath> directories) Find(string pattern, bool recursive = true)
         {
+            if (pattern.Contains(".."))
+                throw new InvalidOperationException($"Pattern may not contain '..'. Pattern: {pattern}.");
+            
             var rootLen = RootDir.Length - 1;
             var option = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
 

--- a/Robust.Shared/Utility/ResPath.cs
+++ b/Robust.Shared/Utility/ResPath.cs
@@ -452,9 +452,11 @@ public readonly struct ResPath : IEquatable<ResPath>
             return this;
         }
 
-        return this == Root
-            ? Self
-            : new ResPath(CanonPath[1..]);
+        if (this == Root)
+            return Self;
+
+        var newPath = new ResPath(CanonPath[1..]);
+        return newPath.IsRelative ? newPath : newPath.ToRelativePath();
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes the upload folder command & `Find()` file function, which was missing a `FromRelativeSystemPath()`. Previously this meant that paths would `\` instead of `/` on windows. This also changes `ToRelativePath()` to ensure that it actually returns a relative path in the event that it is given given something like "//folder".