### PR TITLE
Slight map manager cleanup

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Map.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Map.cs
@@ -1,6 +1,8 @@
 using Robust.Shared.GameStates;
+using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.GameObjects;
 
@@ -51,9 +53,11 @@ public abstract partial class SharedMapSystem
 
     private void OnMapRemoved(EntityUid uid, MapComponent component, ComponentShutdown args)
     {
-        var iMap = (IMapManagerInternal)MapManager;
+        DebugTools.Assert(component.MapId != MapId.Nullspace);
+        Logger.InfoS("map", $"Deleting map {component.MapId}");
 
-        iMap.TrueDeleteMap(component.MapId);
+        var iMap = (IMapManagerInternal)MapManager;
+        iMap.RemoveMapId(component.MapId);
 
         var msg = new MapChangedEvent(uid, component.MapId, false);
         RaiseLocalEvent(uid, msg, true);

--- a/Robust.Shared/Map/IMapManagerInternal.cs
+++ b/Robust.Shared/Map/IMapManagerInternal.cs
@@ -34,7 +34,7 @@ namespace Robust.Shared.Map
 
         MapId CreateMap(MapId? mapId, EntityUid euid);
 
-        void TrueDeleteMap(MapId mapId);
+        void RemoveMapId(MapId mapId);
         void OnGridBoundsChange(EntityUid uid, MapGridComponent grid);
     }
 }

--- a/Robust.Shared/Map/MapManager.GridTrees.cs
+++ b/Robust.Shared/Map/MapManager.GridTrees.cs
@@ -74,12 +74,14 @@ internal partial class MapManager
         _movedGrids.Add(e.Map, new HashSet<MapGridComponent>());
     }
 
-    private void OnMapDestroyedGridTree(MapEventArgs e)
+    public void RemoveMapId(MapId mapId)
     {
-        if (e.Map == MapId.Nullspace) return;
+        if (mapId == MapId.Nullspace)
+            return;
 
-        _gridTrees.Remove(e.Map);
-        _movedGrids.Remove(e.Map);
+        _mapEntities.Remove(mapId);
+        _gridTrees.Remove(mapId);
+        _movedGrids.Remove(mapId);
     }
 
     private Box2 GetWorldAABB(MapGridComponent grid, TransformComponent? xform = null)

--- a/Robust.Shared/Map/MapManager.MapCollection.cs
+++ b/Robust.Shared/Map/MapManager.MapCollection.cs
@@ -39,39 +39,10 @@ internal partial class MapManager
         DebugTools.Assert(_dbgGuardRunning);
 #endif
 
-        if (!_mapEntities.TryGetValue(mapId, out var ent))
+        if (!_mapEntities.TryGetValue(mapId, out var ent) || !ent.IsValid())
             throw new InvalidOperationException($"Attempted to delete nonexistent map '{mapId}'");
 
-        if (ent != EntityUid.Invalid)
-        {
-            EntityManager.DeleteEntity(ent);
-        }
-        else
-        {
-            // unbound map
-            TrueDeleteMap(mapId);
-        }
-    }
-
-    /// <inheritdoc />
-    public void TrueDeleteMap(MapId mapId)
-    {
-        // grids are cached because Delete modifies collection
-        var grids = GetAllMapGrids(mapId).ToList();
-
-        foreach (var grid in grids)
-        {
-            DeleteGrid(grid.Owner);
-        }
-
-        if (mapId != MapId.Nullspace)
-        {
-            var args = new MapEventArgs(mapId);
-            OnMapDestroyedGridTree(args);
-            _mapEntities.Remove(mapId);
-        }
-
-        Logger.InfoS("map", $"Deleting map {mapId}");
+        EntityManager.DeleteEntity(ent);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
- `DeleteMap()` now just directly deletes the entity (afaik "unbound map" is no longer a thing)
- Replaces `OnMapDestroyedGridTree())` with `RemoveMapId()`
- Removes `TrueDeleteMap()`
  - Grid deletion should be handled by entity deletion.
  - Other functionality is moved to  `RemoveMapId()` or the system's `OnMapRemoved()` event handler. 