### PR TITLE
Add `IWritableDirProvider.OpenOsWindow()`

### DIFF
--- a/Robust.Shared/ContentPack/IWritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/IWritableDirProvider.cs
@@ -98,5 +98,11 @@ namespace Robust.Shared.ContentPack
         /// <param name="newPath">New name of the file.</param>
         /// <returns></returns>
         void Rename(ResPath oldPath, ResPath newPath);
+
+        /// <summary>
+        /// Opens up an external file window for some subdirectory. For example, this could be used to create a button
+        /// that opens up the screenshot directory using the operating system's file explorer.
+        /// </summary>
+        void OpenOsWindow(ResPath path);
     }
 }

--- a/Robust.Shared/ContentPack/VirtualWritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/VirtualWritableDirProvider.cs
@@ -209,6 +209,11 @@ namespace Robust.Shared.ContentPack
             throw new NotImplementedException();
         }
 
+        public void OpenOsWindow(ResPath path)
+        {
+            throw new NotImplementedException();
+        }
+
         private bool TryGetNodeAt(ResPath path, [NotNullWhen(true)] out INode? node)
         {
             if (!path.IsRooted)

--- a/Robust.Shared/ContentPack/VirtualWritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/VirtualWritableDirProvider.cs
@@ -211,7 +211,7 @@ namespace Robust.Shared.ContentPack
 
         public void OpenOsWindow(ResPath path)
         {
-            throw new NotImplementedException();
+            // Not valid for virtual directories. As this has no effect on the rest of the game no exception is thrown.
         }
 
         private bool TryGetNodeAt(ResPath path, [NotNullWhen(true)] out INode? node)

--- a/Robust.Shared/ContentPack/WritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/WritableDirProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Robust.Shared.Log;
@@ -128,6 +129,19 @@ namespace Robust.Shared.ContentPack
             var fullOldPath = GetFullPath(oldPath);
             var fullNewPath = GetFullPath(newPath);
             File.Move(fullOldPath, fullNewPath);
+        }
+
+        public void OpenOsWindow(ResPath path)
+        {
+            if (!IsDir(path))
+                path = path.Directory;
+
+            var fullPath = GetFullPath(path);
+            Process.Start(new ProcessStartInfo
+            {
+                UseShellExecute = true,
+                FileName = fullPath,
+            });
         }
 
         #endregion


### PR DESCRIPTION
Adds a function that opens an external file browser for folder, so that you can do things like add a button that opens the screenshots or a save file directory. I'm not sure if `IWritableDirProvider` is the best place to put this, but I couldn't think of anything better.