### PR TITLE
Reduced damage option and multiplayer CVars

### DIFF
--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1010,6 +1010,19 @@ namespace Robust.Shared
         public static readonly CVarDef<string> PlayerName =
             CVarDef.Create("player.name", "JoeGenero", CVar.ARCHIVE | CVar.CLIENTONLY);
 
+        /// <summary>
+        /// Should damage done to player through self harm(melee only) be reduced.
+        /// If true cuts damage to 1/[ReducedSelfDamageMultiplier] of the original value.
+        /// </summary>
+        public static readonly CVarDef<bool> ReducedSelfDamage =
+            CVarDef.Create("player.reducedSelfDamage", true, CVar.ARCHIVE);
+
+        /// <summary>
+        /// If ReducedSelfDamage is enabled then cuts damage by this multiplier.
+        /// </summary>
+        public static readonly CVarDef<int> ReducedSelfDamageMultiplier =
+            CVarDef.Create("player.reducedSelfDamageMultiplier", 5, CVar.ARCHIVE);
+
         /*
          * PHYSICS
          */


### PR DESCRIPTION
Moved reduced damage and reduce multiplier as CVar. Made cables do damage on destroy. Fixed cables doing 0 damage.
Part of https://github.com/space-wizards/space-station-14/pull/16816