### PR TITLE
Make version related cvars not server-only

### DIFF
--- a/Robust.Server/ServerStatus/StatusHost.cs
+++ b/Robust.Server/ServerStatus/StatusHost.cs
@@ -200,13 +200,6 @@ namespace Robust.Server.ServerStatus
                 SetCVarIfUnmodified(CVars.BuildManifestUrl, info.ManifestUrl ?? "");
             }
 
-            // Automatically determine engine version if no other source has provided a result
-            var asmVer = typeof(StatusHost).Assembly.GetName().Version;
-            if (asmVer != null)
-            {
-                SetCVarIfUnmodified(CVars.BuildEngineVersion, asmVer.ToString(4));
-            }
-
             void SetCVarIfUnmodified(CVarDef<string> cvar, string val)
             {
                 if (_cfg.GetCVar(cvar) == "")

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -478,21 +478,23 @@ namespace Robust.Shared
         /// Engine version that launcher needs to connect to this server.
         /// </summary>
         public static readonly CVarDef<string> BuildEngineVersion =
-            CVarDef.Create("build.engine_version", "", CVar.SERVERONLY);
+            CVarDef.Create("build.engine_version",
+                typeof(CVars).Assembly.GetName().Version?.ToString(4) ?? String.Empty,
+                CVar.SERVER | CVar.REPLICATED);
 
         /// <summary>
         /// Fork ID, as a hint to the launcher to manage local files.
         /// This can be anything, it does not need a strict format.
         /// </summary>
         public static readonly CVarDef<string> BuildForkId =
-            CVarDef.Create("build.fork_id", "", CVar.SERVERONLY);
+            CVarDef.Create("build.fork_id", "", CVar.SERVER | CVar.REPLICATED);
 
         /// <summary>
         /// Version string, as a hint to the launcher to manage local files.
         /// This can be anything, it does not need a strict format.
         /// </summary>
         public static readonly CVarDef<string> BuildVersion =
-            CVarDef.Create("build.version", "", CVar.SERVERONLY);
+            CVarDef.Create("build.version", "", CVar.SERVER | CVar.REPLICATED);
 
         /// <summary>
         /// Content pack the launcher should download to connect to this server.


### PR DESCRIPTION
Also moves the default engine version code out of `ServerStatus.StatusHost` and into the cvar itself, so that single player games have a default engine version. Mainly useful so that replays can check version information for useful errors/warnings and so that client-side recordings can save that information.