### PR TITLE
Changes for audio

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AudioSystem.cs
@@ -486,7 +486,18 @@ public sealed class AudioSystem : SharedAudioSystem
         public EntityCoordinates? TrackingCoordinates;
         public EntityCoordinates? TrackingFallbackCoordinates;
         public bool Done;
-        public float Volume;
+
+        public float Volume
+        {
+            get => _volume;
+            set
+            {
+                _volume = value;
+                Source.SetVolume(value);
+            }
+        }
+
+        private float _volume;
 
         public float MaxDistance;
         public float ReferenceDistance;

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -59,11 +59,6 @@ namespace Robust.Shared.GameObjects
     [ByRefEvent]
     public record struct WorldAABBEvent
     {
-        /// <summary>
-        /// If the event is not handled then <see cref="FixturesComponent"/> will be used.
-        /// </summary>
-        public bool Handled;
-
         public Box2 AABB;
     }
 


### PR DESCRIPTION
- GetComponents API will check if an ent is contained before returning it under the flag.
- Add setter for audio stream volumes so you don't have to go through the source (I'll cleanup audio in a month or two).