### PR TITLE
Add ability to reset loaded prototypes.

### DIFF
--- a/Robust.Client/GameController/GameController.cs
+++ b/Robust.Client/GameController/GameController.cs
@@ -164,8 +164,7 @@ namespace Robust.Client
             ProgramShared.FinishCheckBadFileExtensions(checkBadExtensions);
 
             _prototypeManager.Initialize();
-            _prototypeManager.LoadDirectory(new("/EnginePrototypes/"));
-            _prototypeManager.LoadDirectory(Options.PrototypeDirectory);
+            _prototypeManager.LoadDefaultPrototypes();
             _prototypeManager.ResolveResults();
             _userInterfaceManager.Initialize();
             _eyeManager.Initialize();

--- a/Robust.Client/Prototypes/ClientPrototypeManager.cs
+++ b/Robust.Client/Prototypes/ClientPrototypeManager.cs
@@ -42,13 +42,11 @@ namespace Robust.Client.Prototypes
             WatchResources();
         }
 
-        public override Dictionary<Type, HashSet<string>> LoadDefaultPrototypes()
+        public override void LoadDefaultPrototypes(Dictionary<Type, HashSet<string>>? changed = null)
         {
-            var prototypes = new Dictionary<Type, HashSet<string>>();
-            LoadDirectory(new("/EnginePrototypes/"), changed: prototypes);
-            LoadDirectory(_controller.Options.PrototypeDirectory, changed: prototypes);
+            LoadDirectory(new("/EnginePrototypes/"), changed: changed);
+            LoadDirectory(_controller.Options.PrototypeDirectory, changed: changed);
             ResolveResults();
-            return prototypes;
         }
 
         private void WindowFocusedChanged(WindowFocusedEventArgs args)

--- a/Robust.Client/Prototypes/ClientPrototypeManager.cs
+++ b/Robust.Client/Prototypes/ClientPrototypeManager.cs
@@ -8,7 +8,6 @@ using Robust.Client.Graphics;
 using Robust.Client.Timing;
 using Robust.Shared;
 using Robust.Shared.Configuration;
-using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Network;
@@ -25,6 +24,7 @@ namespace Robust.Client.Prototypes
         [Dependency] private readonly INetManager _netManager = default!;
         [Dependency] private readonly IClientGameTiming _timing = default!;
         [Dependency] private readonly IConfigurationManager _cfg = default!;
+        [Dependency] private readonly IGameControllerInternal _controller = default!;
 
         private readonly List<FileSystemWatcher> _watchers = new();
         private readonly TimeSpan _reloadDelay = TimeSpan.FromMilliseconds(10);
@@ -40,6 +40,15 @@ namespace Robust.Client.Prototypes
             _clyde.OnWindowFocused += WindowFocusedChanged;
 
             WatchResources();
+        }
+
+        public override Dictionary<Type, HashSet<string>> LoadDefaultPrototypes()
+        {
+            var prototypes = new Dictionary<Type, HashSet<string>>();
+            LoadDirectory(new("/EnginePrototypes/"), changed: prototypes);
+            LoadDirectory(_controller.Options.PrototypeDirectory, changed: prototypes);
+            ResolveResults();
+            return prototypes;
         }
 
         private void WindowFocusedChanged(WindowFocusedEventArgs args)

--- a/Robust.Server/BaseServer.cs
+++ b/Robust.Server/BaseServer.cs
@@ -365,7 +365,7 @@ namespace Robust.Server
             // because of 'reasons' this has to be called after the last assembly is loaded
             // otherwise the prototypes will be cleared
             _prototype.Initialize();
-            _prototype.LoadDirectory(Options.PrototypeDirectory);
+            _prototype.LoadDefaultPrototypes();
             _prototype.ResolveResults();
 
             _consoleHost.Initialize();

--- a/Robust.Server/Prototypes/ServerPrototypeManager.cs
+++ b/Robust.Server/Prototypes/ServerPrototypeManager.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Robust.Server.Console;
 using Robust.Server.Player;
@@ -14,6 +16,7 @@ namespace Robust.Server.Prototypes
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly IConGroupController _conGroups = default!;
         [Dependency] private readonly INetManager _netManager = default!;
+        [Dependency] private readonly IBaseServerInternal _server = default!;
 
         public ServerPrototypeManager()
         {
@@ -46,5 +49,13 @@ namespace Robust.Server.Prototypes
 #endif
         }
 
+        public override Dictionary<Type, HashSet<string>> LoadDefaultPrototypes()
+        {
+            var prototypes = new Dictionary<Type, HashSet<string>>();
+            LoadDirectory(new("/EnginePrototypes/"), changed: prototypes);
+            LoadDirectory(_server.Options.PrototypeDirectory, changed: prototypes);
+            ResolveResults();
+            return prototypes;
+        }
     }
 }

--- a/Robust.Server/Prototypes/ServerPrototypeManager.cs
+++ b/Robust.Server/Prototypes/ServerPrototypeManager.cs
@@ -49,13 +49,10 @@ namespace Robust.Server.Prototypes
 #endif
         }
 
-        public override Dictionary<Type, HashSet<string>> LoadDefaultPrototypes()
+        public override void LoadDefaultPrototypes(Dictionary<Type, HashSet<string>>? changed = null)
         {
-            var prototypes = new Dictionary<Type, HashSet<string>>();
-            LoadDirectory(new("/EnginePrototypes/"), changed: prototypes);
-            LoadDirectory(_server.Options.PrototypeDirectory, changed: prototypes);
+            LoadDirectory(_server.Options.PrototypeDirectory, changed: changed);
             ResolveResults();
-            return prototypes;
         }
     }
 }

--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -224,7 +224,8 @@ public interface IPrototypeManager
     /// <summary>
     /// Loads prototypes from the default directories.
     /// </summary>
-    Dictionary<Type, HashSet<string>> LoadDefaultPrototypes();
+    /// <param name="loaded">Dictionary that will be filled with all the loaded prototypes.</param>
+    void LoadDefaultPrototypes(Dictionary<Type, HashSet<string>>? loaded = null);
 
     /// <summary>
     /// Syncs all inter-prototype data. Call this when operations adding new prototypes are done.

--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -212,15 +212,31 @@ public interface IPrototypeManager
     void Clear();
 
     /// <summary>
+    /// Calls <see cref="Clear"/> and then rediscovers all prototype kinds.
+    /// </summary>
+    void ReloadPrototypeKinds();
+
+    /// <summary>
+    /// Calls <see cref="ReloadPrototypeKinds"/> and then loads prototypes from the default directories.
+    /// </summary>
+    void Reset();
+
+    /// <summary>
+    /// Loads prototypes from the default directories.
+    /// </summary>
+    Dictionary<Type, HashSet<string>> LoadDefaultPrototypes();
+
+    /// <summary>
     /// Syncs all inter-prototype data. Call this when operations adding new prototypes are done.
     /// </summary>
     void ResolveResults();
 
     /// <summary>
-    /// Reload the changes from LoadString
+    /// Invokes <see cref="PrototypesReloaded"/> with information about the modified prototypes.
+    /// When built with development tools, this will also push inheritance for reloaded prototypes/
     /// </summary>
-    /// <param name="prototypes">Changes from load string</param>
-    void ReloadPrototypes(Dictionary<Type, HashSet<string>> prototypes);
+    void ReloadPrototypes(Dictionary<Type, HashSet<string>> modified,
+        Dictionary<Type, HashSet<string>>? removed = null);
 
     /// <summary>
     ///     Registers a specific prototype name to be ignored.
@@ -245,7 +261,7 @@ public interface IPrototypeManager
     void RegisterKind(Type kind);
 
     /// <summary>
-    ///     Fired when prototype are reloaded. The event args contain the modified prototypes.
+    ///     Fired when prototype are reloaded. The event args contain the modified and removed prototypes.
     /// </summary>
     /// <remarks>
     ///     This does NOT fire on initial prototype load.
@@ -259,7 +275,8 @@ internal interface IPrototypeManagerInternal : IPrototypeManager
 }
 
 public sealed record PrototypesReloadedEventArgs(
-    IReadOnlyDictionary<Type, PrototypesReloadedEventArgs.PrototypeChangeSet> ByType)
+    IReadOnlyDictionary<Type, PrototypesReloadedEventArgs.PrototypeChangeSet> ByType,
+    IReadOnlyDictionary<Type, HashSet<string>>? Removed = null)
 {
     public sealed record PrototypeChangeSet(IReadOnlyDictionary<string, IPrototype> Modified);
 }

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -194,9 +194,10 @@ namespace Robust.Shared.Prototypes
                 x => x.Value.Instances.Keys.ToHashSet());
 
             ReloadPrototypeKinds();
-            var protos = LoadDefaultPrototypes();
+            Dictionary<Type, HashSet<string>> prototypes = new();
+            LoadDefaultPrototypes(prototypes);
 
-            foreach (var (kind, ids) in protos)
+            foreach (var (kind, ids) in prototypes)
             {
                 if (!removed.TryGetValue(kind, out var removedIds))
                     continue;
@@ -206,11 +207,11 @@ namespace Robust.Shared.Prototypes
                     removed.Remove(kind);
             }
 
-            ReloadPrototypes(protos, removed);
+            ReloadPrototypes(prototypes, removed);
             _locMan.ReloadLocalizations();
         }
 
-        public abstract Dictionary<Type, HashSet<string>> LoadDefaultPrototypes();
+        public abstract void LoadDefaultPrototypes(Dictionary<Type, HashSet<string>>? changed = null);
 
         private int SortPrototypesByPriority(Type a, Type b)
         {

--- a/Robust.UnitTesting/Server/RobustServerSimulation.cs
+++ b/Robust.UnitTesting/Server/RobustServerSimulation.cs
@@ -211,6 +211,7 @@ namespace Robust.UnitTesting.Server
                 .Setup(x => x.FindAllTypes())
                 .Returns(() => realReflection.FindAllTypes());
 
+            container.RegisterInstance<IBaseServerInternal>(new Mock<IBaseServerInternal>().Object);
             container.RegisterInstance<IReflectionManager>(reflectionManager.Object); // tests should not be searching for types
             container.RegisterInstance<IRobustSerializer>(new Mock<IRobustSerializer>().Object);
             container.RegisterInstance<IResourceManager>(new Mock<IResourceManager>().Object); // no disk access for tests

--- a/Robust.UnitTesting/Server/RobustServerSimulation.cs
+++ b/Robust.UnitTesting/Server/RobustServerSimulation.cs
@@ -12,6 +12,7 @@ using Robust.Server.GameObjects;
 using Robust.Server.GameStates;
 using Robust.Server.Physics;
 using Robust.Server.Player;
+using Robust.Server.Prototypes;
 using Robust.Server.Reflection;
 using Robust.Server.Replays;
 using Robust.Shared;
@@ -221,7 +222,7 @@ namespace Robust.UnitTesting.Server
             container.Register<EntityManager, EntityManager>();
             container.Register<IMapManager, MapManager>();
             container.Register<ISerializationManager, SerializationManager>();
-            container.Register<IPrototypeManager, PrototypeManager>();
+            container.Register<IPrototypeManager, ServerPrototypeManager>();
             container.Register<IComponentFactory, ComponentFactory>();
             container.Register<IEntitySystemManager, EntitySystemManager>();
             container.Register<IManifoldManager, CollisionManager>();


### PR DESCRIPTION
Adds some new and existing functions to `IPrototypeManager`, including `Reset()`, which is effectively a brute force way of unloading any extra loaded prototypes by just clearing all prototypes & reloading the default directories. 