### PR TITLE
BQL paused handling changes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Added BQL `paused` selector.
 
 ### Bugfixes
 
@@ -47,7 +47,7 @@ END TEMPLATE-->
 
 ### Other
 
-*None yet*
+* BQL `with` now includes paused entities.
 
 ### Internal
 

--- a/Robust.Server/Bql/BqlQuerySelector.Builtin.cs
+++ b/Robust.Server/Bql/BqlQuerySelector.Builtin.cs
@@ -29,7 +29,7 @@ namespace Robust.Server.Bql
                 return base.DoInitialSelection(arguments, isInverted, entityManager);
             }
 
-            return entityManager.GetAllComponents((Type) arguments[0])
+            return entityManager.GetAllComponents((Type) arguments[0], includePaused: true)
                 .Select(x => x.Owner);
         }
     }
@@ -350,6 +350,19 @@ namespace Robust.Server.Bql
         public override IEnumerable<EntityUid> DoSelection(IEnumerable<EntityUid> input, IReadOnlyList<object> arguments, bool isInverted, IEntityManager entityManager)
         {
             return input.Where(e => (entityManager.TryGetComponent<TransformComponent>(e, out var transform) && transform.Anchored) ^ isInverted);
+        }
+    }
+
+    [RegisterBqlQuerySelector]
+    public sealed class PausedQuerySelector : BqlQuerySelector
+    {
+        public override string Token => "paused";
+
+        public override QuerySelectorArgument[] Arguments => Array.Empty<QuerySelectorArgument>();
+
+        public override IEnumerable<EntityUid> DoSelection(IEnumerable<EntityUid> input, IReadOnlyList<object> arguments, bool isInverted, IEntityManager entityManager)
+        {
+            return input.Where(e => entityManager.GetComponent<MetaDataComponent>(e).EntityPaused ^ isInverted);
         }
     }
 }


### PR DESCRIPTION
`with` selector now includes paused entities.
Added new `paused` selector (so use `with X not paused` for the previous behavior)