### PR TITLE
Fixed some coding mistakes

### DIFF
--- a/Robust.Client.Injectors/XamlCompiler.cs
+++ b/Robust.Client.Injectors/XamlCompiler.cs
@@ -259,7 +259,7 @@ namespace Robust.Build.Tasks
                         var parameterlessCtor = classTypeDefinition.GetConstructors()
                             .FirstOrDefault(c => c.IsPublic && !c.IsStatic && !c.HasParameters);
 
-                        if (compiledBuildMethod != null && parameterlessCtor != null)
+                        if (compiledBuildMethod != null || parameterlessCtor != null)
                         {
                             var i = loaderDispatcherMethod.Body.Instructions;
                             var nop = Instruction.Create(OpCodes.Nop);

--- a/Robust.Client.Injectors/XamlCompiler.cs
+++ b/Robust.Client.Injectors/XamlCompiler.cs
@@ -110,25 +110,6 @@ namespace Robust.Build.Tasks
             var compiler =
                 new RobustXamlILCompiler(transformerconfig, emitConfig, true);
 
-            var loaderDispatcherDef = new TypeDefinition("CompiledRobustXaml", "!XamlLoader",
-                TypeAttributes.Class, asm.MainModule.TypeSystem.Object);
-
-            var loaderDispatcherMethod = new MethodDefinition("TryLoad",
-                MethodAttributes.Static | MethodAttributes.Public,
-                asm.MainModule.TypeSystem.Object)
-            {
-                Parameters = {new ParameterDefinition(asm.MainModule.TypeSystem.String)}
-            };
-            loaderDispatcherDef.Methods.Add(loaderDispatcherMethod);
-            asm.MainModule.Types.Add(loaderDispatcherDef);
-
-            var stringEquals = asm.MainModule.ImportReference(asm.MainModule.TypeSystem.String.Resolve().Methods.First(
-                m =>
-                    m.IsStatic && m.Name == "Equals" && m.Parameters.Count == 2 &&
-                    m.ReturnType.FullName == "System.Boolean"
-                    && m.Parameters[0].ParameterType.FullName == "System.String"
-                    && m.Parameters[1].ParameterType.FullName == "System.String"));
-
             bool CompileGroup(IResourceGroup group)
             {
                 var typeDef = new TypeDefinition("CompiledRobustXaml", "!" + group.Name, TypeAttributes.Class,
@@ -252,31 +233,6 @@ namespace Robust.Build.Tasks
                                     $"No call to RobustXamlLoader.Load(this) call found anywhere in the type {classType.FullName} and type seems to have custom constructors.");
                             }
                         }
-
-                        //add compiled build method
-                        var compiledBuildMethod = typeSystem.GetTypeReference(builder).Resolve().Methods
-                            .First(m => m.Name == buildName);
-                        var parameterlessCtor = classTypeDefinition.GetConstructors()
-                            .FirstOrDefault(c => c.IsPublic && !c.IsStatic && !c.HasParameters);
-
-                        if (compiledBuildMethod != null || parameterlessCtor != null)
-                        {
-                            var i = loaderDispatcherMethod.Body.Instructions;
-                            var nop = Instruction.Create(OpCodes.Nop);
-                            i.Add(Instruction.Create(OpCodes.Ldarg_0));
-                            i.Add(Instruction.Create(OpCodes.Ldstr, res.Uri));
-                            i.Add(Instruction.Create(OpCodes.Call, stringEquals));
-                            i.Add(Instruction.Create(OpCodes.Brfalse, nop));
-                            if (parameterlessCtor != null)
-                                i.Add(Instruction.Create(OpCodes.Newobj, parameterlessCtor));
-                            else
-                            {
-                                i.Add(Instruction.Create(OpCodes.Call, compiledBuildMethod));
-                            }
-
-                            i.Add(Instruction.Create(OpCodes.Ret));
-                            i.Add(nop);
-                        }
                     }
                     catch (Exception e)
                     {
@@ -293,8 +249,6 @@ namespace Robust.Build.Tasks
                     return false;
             }
 
-            loaderDispatcherMethod.Body.Instructions.Add(Instruction.Create(OpCodes.Ldnull));
-            loaderDispatcherMethod.Body.Instructions.Add(Instruction.Create(OpCodes.Ret));
             return true;
         }
 

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -98,7 +98,7 @@ namespace Robust.Client.GameObjects
             get => scale;
             set
             {
-                if (MathF.Abs(value.X) < 0.005f || MathF.Abs(value.X) < 0.005f)
+                if (MathF.Abs(value.X) < 0.005f || MathF.Abs(value.Y) < 0.005f)
                 {
                     // Scales of ~0.0025 or lower can lead to singular matrices due to rounding errors.
                     Logger.Error($"Attempted to set layer sprite scale to very small values. Entity: {entities.ToPrettyString(Owner)}. Scale: {value}");
@@ -1574,7 +1574,7 @@ namespace Robust.Client.GameObjects
                 {
                     if (_scale.EqualsApprox(value)) return;
 
-                    if (MathF.Abs(value.X) < 0.005f || MathF.Abs(value.X) < 0.005f)
+                    if (MathF.Abs(value.X) < 0.005f || MathF.Abs(value.Y) < 0.005f)
                     {
                         // Scales of ~0.0025 or lower can lead to singular matrices due to rounding errors.
                         Logger.Error($"Attempted to set layer sprite scale to very small values. Entity: {_parent.entities.ToPrettyString(_parent.Owner)}. Scale: {value}");

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -1038,7 +1038,7 @@ namespace Robust.Client.GameStates
         private void HandleEntityState(EntityUid uid, IEventBus bus, EntityState? curState,
             EntityState? nextState, GameTick lastApplied, GameTick toTick, bool enteringPvs)
         {
-            var size = curState?.ComponentChanges.Span.Length ?? 0 + nextState?.ComponentChanges.Span.Length ?? 0;
+            var size = (curState?.ComponentChanges.Span.Length ?? 0) + (nextState?.ComponentChanges.Span.Length ?? 0);
             var compStateWork = new Dictionary<ushort, (IComponent Component, ComponentState? curState, ComponentState? nextState)>(size);
 
             // First remove any deleted components

--- a/Robust.Client/UserInterface/Controls/TabContainer.cs
+++ b/Robust.Client/UserInterface/Controls/TabContainer.cs
@@ -308,7 +308,7 @@ namespace Robust.Client.UserInterface.Controls
 
                 var active = _currentTab == i;
                 var box = active ? boxActive : boxInactive;
-                var boxAdvance = titleLength + box?.MinimumSize.X ?? 0;
+                var boxAdvance = titleLength + (box?.MinimumSize.X ?? 0);
 
                 if (headerOffset < relX && headerOffset + boxAdvance > relX)
                 {

--- a/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
+++ b/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
@@ -131,7 +131,7 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
 
         public void ResetFriction()
         {
-            Friction = MathF.Sqrt(FixtureA?.Friction ?? 0.0f * FixtureB?.Friction ?? 0.0f);
+            Friction = MathF.Sqrt((FixtureA?.Friction ?? 0.0f) * (FixtureB?.Friction ?? 0.0f));
         }
 
         /// <summary>

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
@@ -457,7 +457,7 @@ public abstract partial class SharedPhysicsSystem
                             uidA = jointCompA.Relay.Value;
                         }
 
-                        if (jointQuery.TryGetComponent(uidA, out var jointCompB) &&
+                        if (jointQuery.TryGetComponent(uidB, out var jointCompB) &&
                             jointCompB.Relay != null)
                         {
                             uidB = jointCompB.Relay.Value;


### PR DESCRIPTION
- `XamlCompiler.cs`. In case this if is true `parameterlessCtor` will be always used
- `SharedPhysicsSystem.Island.cs`. Was checking `jointCompB` for `uidA`
- `SpriteComponent.cs`. Was checking only `X` in setter
- Others. `??` operator priority is lower than it's left part