### PR TITLE
Prevent scrollbar overlap in OutputPanel

### DIFF
--- a/Robust.Client/UserInterface/Controls/OutputPanel.cs
+++ b/Robust.Client/UserInterface/Controls/OutputPanel.cs
@@ -230,7 +230,9 @@ namespace Robust.Client.UserInterface.Controls
         private UIBox2 _getContentBox()
         {
             var style = _getStyleBox();
-            return style?.GetContentBox(PixelSizeBox) ?? PixelSizeBox;
+            var box = style?.GetContentBox(PixelSizeBox) ?? PixelSizeBox;
+            box.Right -= _scrollBar.DesiredSize.X;
+            return box;
         }
 
         protected internal override void UIScaleChanged()

--- a/Robust.Client/UserInterface/Controls/OutputPanel.cs
+++ b/Robust.Client/UserInterface/Controls/OutputPanel.cs
@@ -231,7 +231,7 @@ namespace Robust.Client.UserInterface.Controls
         {
             var style = _getStyleBox();
             var box = style?.GetContentBox(PixelSizeBox) ?? PixelSizeBox;
-            box.Right -= _scrollBar.DesiredSize.X;
+            box.Right = Math.Max(box.Left, box.Right - _scrollBar.DesiredPixelSize.X);
             return box;
         }
 


### PR DESCRIPTION
E.g., prevents text in the ss14 chat control from being drawn under the scrollbar.