### PR TITLE
Make BoxContainer's MesureOverride account for stretching

### DIFF
--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -121,6 +121,12 @@ namespace Robust.Client.UserInterface.Controls
                     desiredSize.X += child.DesiredSize.X;
                     desiredSize.Y = Math.Max(desiredSize.Y, child.DesiredSize.Y);
                 }
+
+                // TODO Maybe make BoxContainer.MeasureOverride more rigorous.
+                // This should check if size < desired size. If it is, treat child as non-stretching (see the code in
+                // ArrangeOverride). This requires remeasuring all stretching controls + the control that just became
+                // non-stretching. But the re-measured controls might then become smaller (e.g. rich text wrapping),
+                // leading to a recursion problem.
             }
 
             return desiredSize;

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -167,7 +167,7 @@ namespace Robust.Client.UserInterface.Controls
                 // We will treat stretching children that fail to reach their desired size as non-stretching.
                 // This then requires all stretching children to be re-stretched
                 bool stretchAvailChanged = true;
-                while (stretchAvailChanged && totalStretchRatio > 0)
+                while (stretchAvailChanged)
                 {
                     stretchAvailChanged = false;
                     for (var i = 0; i < sizeList.Count; i++)

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -167,7 +167,7 @@ namespace Robust.Client.UserInterface.Controls
                 // We will treat stretching children that fail to reach their desired size as non-stretching.
                 // This then requires all stretching children to be re-stretched
                 bool stretchAvailChanged = true;
-                while (stretchAvailChanged && stretchAvail > 0 && totalStretchRatio > 0)
+                while (stretchAvailChanged && totalStretchRatio > 0)
                 {
                     stretchAvailChanged = false;
                     for (var i = 0; i < sizeList.Count; i++)

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -158,12 +158,11 @@ namespace Robust.Client.UserInterface.Controls
             }
             stretchAvail = Math.Max(0, stretchAvail);
 
-
+            // Step two: allocate space for all the stretchable children.
             float offset = 0;
             var anyStretch = totalStretchRatio > 0;
             if (anyStretch)
             {
-                // Step two: allocate space for all the stretchable children.
                 // We will treat stretching children that fail to reach their desired size as non-stretching.
                 // This then requires all stretching children to be re-stretched
                 bool stretchAvailChanged = true;


### PR DESCRIPTION
BoxContainer now measures non-stretching children before measuring stretching children with available sizes based on their stretch ratios. Previously box container would just blindly reduce the available space for each subsequent child, which would cause issues when arranging children that base their desired size on the available size (e.g. rich text wrapping). This also changes the arrange logic slightly to properly deal with situations where stretching controls fail to get sufficient space, but I think it should otherwise leave the behaviour unchanged.

Given how commonplace box controls are this might cause unexpected issues somewhere, but I didn't encounter anything while just poking around some SS14 windows.

Below is a demo video containing stretching controls. The controls have a maximum width and contain wrapping text.

https://github.com/space-wizards/RobustToolbox/assets/60421075/8a5598f6-8bb3-4d58-ac17-3d7989cdac39


This is what it looked like before:

https://github.com/space-wizards/RobustToolbox/assets/60421075/1d5c0c8a-44f6-4e23-a433-7a93fe553d8e

