### PR TITLE
Fix mapped strings serializer not properly checking string size.

### DIFF
--- a/Robust.Shared/Serialization/RobustMappedStringSerializer.MappedStringDict.cs
+++ b/Robust.Shared/Serialization/RobustMappedStringSerializer.MappedStringDict.cs
@@ -131,14 +131,10 @@ namespace Robust.Shared.Serialization
 
                 foreach (var str in strings)
                 {
-                    DebugTools.Assert(str.Length < MaxMappedStringSize);
-
-                    if (Encoding.UTF8.GetByteCount(str) > MaxMappedStringSize)
-                    {
-                        // Ok so the code checks the goddamn string size before encoding to UTF-8 to check length.
-                        // Yes, this code sucks, but I don't care to fix it right now.
-                        continue;
-                    }
+                    // Ok so the code checks the goddamn string size before encoding to UTF-8 to check length.
+                    // Yes, this code sucks, but I don't care to fix it right now.
+                    if (str.Length > MaxMappedStringSize || Encoding.UTF8.GetByteCount(str) > MaxMappedStringSize)
+                        throw new Exception("Attempted to map a string that exceeds the maximum length.");
 
                     var l = Encoding.UTF8.GetBytes(str, buf);
 
@@ -178,10 +174,6 @@ namespace Robust.Shared.Serialization
             /// scoped names, this increases the likelyhood of a successful
             /// string mapping.
             /// </remarks>
-            /// <returns>
-            /// <c>true</c> if the string was added to the mapping for the first
-            /// time, <c>false</c> otherwise.
-            /// </returns>
             /// <exception cref="InvalidOperationException">
             /// Thrown if the string is not normalized (<see cref="String.IsNormalized()"/>).
             /// </exception>
@@ -400,6 +392,9 @@ namespace Robust.Shared.Serialization
 
             private bool TryAddString(string str)
             {
+                if (str.Length > MaxMappedStringSize || Encoding.UTF8.GetByteCount(str) > MaxMappedStringSize)
+                    return false;
+
                 // Yes this spends like half the CPU time of AddString in lock contention.
                 // But it's still faster than all my other attempts, so...
                 lock (_buildingStrings)


### PR DESCRIPTION
Was causing errors for cyrillic translations.