### PR TITLE
Fix richtext inline controll scaling

### DIFF
--- a/Robust.Client/UserInterface/RichText/IMarkupTag.cs
+++ b/Robust.Client/UserInterface/RichText/IMarkupTag.cs
@@ -14,7 +14,7 @@ public interface IMarkupTag
     /// Called when an opening node for this tag is encountered.<br/>
     /// Used for pushing new values used for rendering text contained within this tag.<br/>
     /// Important: Push some kind of default value into the context or throw when missing a required parameter
-    /// or attribute. The order in which state gets poped of the context breaks.
+    /// or attribute. The order in which state gets popped of the context breaks otherwise.
     /// </summary>
     /// <param name="node">The markup node containing the parameter and attributes</param>
     /// <param name="context">The context to push the state on</param>
@@ -54,7 +54,6 @@ public interface IMarkupTag
     }
 
     /// <summary>
-    /// Rendering inline controls is currently not implemented!
     /// Called inside the constructor of <see cref="RichTextEntry"/> to
     /// supply a control that gets rendered inline before this tags children<br/>
     /// Text continues to the right of the control until the next line and then continues bellow it

--- a/Robust.Client/UserInterface/RichTextEntry.cs
+++ b/Robust.Client/UserInterface/RichTextEntry.cs
@@ -176,7 +176,7 @@ namespace Robust.Client.UserInterface
             var globalBreakCounter = 0;
             var lineBreakIndex = 0;
             var baseLine = drawBox.TopLeft + new Vector2(0, defaultFont.GetAscent(uiScale) + verticalOffset);
-            var controlYAdvance = 0;
+            var controlYAdvance = 0f;
 
             var nodeIndex = -1;
             foreach (var node in Message.Nodes)
@@ -208,10 +208,12 @@ namespace Robust.Client.UserInterface
                 if (!_tagControls.TryGetValue(nodeIndex, out var control))
                     continue;
 
-                control.Position = new Vector2(baseLine.X, baseLine.Y - defaultFont.GetAscent(uiScale));
+                var invertedScale = 1f / uiScale;
+
+                control.Position = new Vector2(baseLine.X * invertedScale, (baseLine.Y - defaultFont.GetAscent(uiScale)) * invertedScale);
                 control.Measure(new Vector2(Width, Height));
                 var advanceX = control.DesiredPixelSize.X;
-                controlYAdvance = Math.Max(0, control.DesiredPixelSize.Y - font.GetLineHeight(uiScale));
+                controlYAdvance = Math.Max(0f, (control.DesiredPixelSize.Y - font.GetLineHeight(uiScale)) * invertedScale);
                 baseLine += new Vector2(advanceX, 0);
             }
         }


### PR DESCRIPTION
This fixes an issue where richtexts inline controls didn't respond to UI scaling.

**Before the fix:**
![image](https://github.com/space-wizards/RobustToolbox/assets/8915246/1de6ab9e-4b3a-45b1-a8f3-60517fafcb56)

**After the fix:**

https://github.com/space-wizards/RobustToolbox/assets/8915246/3ece1786-7cf6-451b-bd63-0614f2b41216

Fixes #4120 