### PR TITLE
Deprecate IPlayerSession methods to attach/detach entities to a player.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,7 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-* Obsoleted the following methods from IPlayerSession: AttachToEntity, DetachFromEntity. Use the methods in ActorSystem instead.
+* Obsoleted the following methods from `IPlayerSession`: `AttachToEntity`, `DetachFromEntity`. Use the methods in `ActorSystem` instead.
 
 ### New features
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,7 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* Obsoleted the following methods from IPlayerSession: AttachToEntity, DetachFromEntity. Use the methods in ActorSystem instead.
 
 ### New features
 

--- a/Robust.Server/Player/IPlayerSession.cs
+++ b/Robust.Server/Player/IPlayerSession.cs
@@ -23,6 +23,7 @@ namespace Robust.Server.Player
         ///     Do not call this directly for most content code.
         /// </summary>
         /// <param name="entity">The entity to attach to.</param>
+        [Obsolete("Use ActorSystem.Attach() instead.")]
         void AttachToEntity(EntityUid? entity);
 
         /// <summary>
@@ -31,6 +32,7 @@ namespace Robust.Server.Player
         ///     Do not call this directly for most content code.
         /// </summary>
         /// <param name="uid">The entity to attach to.</param>
+        [Obsolete("Use ActorSystem.Attach() instead.")]
         void AttachToEntity(EntityUid uid);
 
         /// <summary>
@@ -38,6 +40,7 @@ namespace Robust.Server.Player
         ///     NOTE: The content pack almost certainly has an alternative for this.
         ///     Do not call this directly for most content code.
         /// </summary>
+        [Obsolete("Use ActorSystem.Detach() instead.")]
         void DetachFromEntity();
         void OnConnect();
         void OnDisconnect();

--- a/Robust.Server/Player/PlayerSession.cs
+++ b/Robust.Server/Player/PlayerSession.cs
@@ -113,6 +113,7 @@ namespace Robust.Server.Player
         public event EventHandler<SessionStatusEventArgs>? PlayerStatusChanged;
 
         /// <inheritdoc />
+        [Obsolete("Use ActorSystem.Attach() instead.")]
         public void AttachToEntity(EntityUid? entity)
         {
             DetachFromEntity();
@@ -124,6 +125,7 @@ namespace Robust.Server.Player
         }
 
         /// <inheritdoc />
+        [Obsolete("Use ActorSystem.Attach() instead.")]
         public void AttachToEntity(EntityUid uid)
         {
             DetachFromEntity();
@@ -135,6 +137,7 @@ namespace Robust.Server.Player
         }
 
         /// <inheritdoc />
+        [Obsolete("Use ActorSystem.Detach() instead.")]
         public void DetachFromEntity()
         {
             if (AttachedEntity == null)


### PR DESCRIPTION
This has very few usages across content and engine already so might as well obsolete it before it gets used more.
Use ActorSystem methods instead.