### PR TITLE
Automatically create a sawmill for each entity system.

### DIFF
--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
-using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
@@ -796,26 +795,6 @@ public partial class EntitySystem
     {
         EntityManager.RaisePredictiveEvent(msg);
     }
-
-    #endregion
-
-    #region Logging
-
-    protected void LogDebug(string message, params object?[] args) => Sawmill.Debug(message, args);
-    protected void LogDebug(string message) => Sawmill.Debug(message);
-    protected void LogInfo(string message, params object?[] args) => Sawmill.Info(message, args);
-    protected void LogInfo(string message) => Sawmill.Info(message);
-    protected void LogWarning(string message, params object?[] args) => Sawmill.Warning(message);
-    protected void LogWarning(string message) => Sawmill.Warning(message);
-    protected void LogError(string message, params object?[] args) => Sawmill.Error(message, args);
-    protected void LogError(string message) => Sawmill.Error(message);
-    protected void LogFatal(string message, params object?[] args) => Sawmill.Fatal(message, args);
-    protected void LogFatal(string message) => Sawmill.Fatal(message);
-    protected void Log(LogLevel level, string message) => Sawmill.Log(level, message);
-    protected void Log(LogLevel level, string message, params object?[] args) => Sawmill.Log(level, message, args);
-
-    protected void Log(LogLevel level, Exception? exception, string message, params object?[] args)
-        => Sawmill.Log(level, exception, message, args);
 
     #endregion
 }

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
+using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
@@ -795,6 +796,26 @@ public partial class EntitySystem
     {
         EntityManager.RaisePredictiveEvent(msg);
     }
+
+    #endregion
+
+    #region Logging
+
+    protected void LogDebug(string message, params object?[] args) => Sawmill.Debug(message, args);
+    protected void LogDebug(string message) => Sawmill.Debug(message);
+    protected void LogInfo(string message, params object?[] args) => Sawmill.Info(message, args);
+    protected void LogInfo(string message) => Sawmill.Info(message);
+    protected void LogWarning(string message, params object?[] args) => Sawmill.Warning(message);
+    protected void LogWarning(string message) => Sawmill.Warning(message);
+    protected void LogError(string message, params object?[] args) => Sawmill.Error(message, args);
+    protected void LogError(string message) => Sawmill.Error(message);
+    protected void LogFatal(string message, params object?[] args) => Sawmill.Fatal(message, args);
+    protected void LogFatal(string message) => Sawmill.Fatal(message);
+    protected void Log(LogLevel level, string message) => Sawmill.Log(level, message);
+    protected void Log(LogLevel level, string message, params object?[] args) => Sawmill.Log(level, message, args);
+
+    protected void Log(LogLevel level, Exception? exception, string message, params object?[] args)
+        => Sawmill.Log(level, exception, message, args);
 
     #endregion
 }

--- a/Robust.Shared/GameObjects/EntitySystem.Resolve.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Resolve.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using Robust.Shared.Log;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.GameObjects
@@ -29,7 +27,7 @@ namespace Robust.Shared.GameObjects
             var found = EntityManager.TryGetComponent(uid, out component);
 
             if(logMissing && !found)
-                Logger.ErrorS("resolve", $"Can't resolve \"{typeof(TComp)}\" on entity {uid}!\n{new StackTrace(1, true)}");
+                Log.Error($"Can't resolve \"{typeof(TComp)}\" on entity {uid}!\n{new StackTrace(1, true)}");
 
             return found;
         }

--- a/Robust.Shared/GameObjects/EntitySystem.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.cs
@@ -39,8 +39,6 @@ namespace Robust.Shared.GameObjects
                 if (name.EndsWith("System"))
                     name = name.Substring(0, name.Length - "System".Length);
 
-
-
                 // Convert CamelCase to snake_case
                 name = string.Concat(name.Select(x => char.IsUpper(x) ? $"_{char.ToLower(x)}" : x.ToString()));
                 name = name.Trim('_');

--- a/Robust.Shared/GameObjects/EntitySystem.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.cs
@@ -43,7 +43,6 @@ namespace Robust.Shared.GameObjects
                 name = string.Concat(name.Select(x => char.IsUpper(x) ? $"_{char.ToLower(x)}" : x.ToString()));
                 name = name.Trim('_');
 
-
                 return $"system.{name}";
             }
         }

--- a/Robust.Shared/GameObjects/EntitySystem.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
@@ -27,7 +25,21 @@ namespace Robust.Shared.GameObjects
         [Dependency] private readonly ISharedPlayerManager _playerMan = default!;
         [Dependency] private readonly IReplayRecordingManager _replayMan = default!;
         [Dependency] private readonly ILogManager _logMan = default!;
-        protected ISawmill Sawmill = default!;
+        public ISawmill Log { get; private set; } = default!;
+
+        protected virtual string SawmillName
+        {
+            get
+            {
+                var name = GetType().Name;
+                if (name.EndsWith("System"))
+                    name = name.Substring(0, name.Length - "System".Length);
+
+                // Convention is foo.bar_baz
+                // But fuck trying to automatically snake_case something like "PVSOverrideSystem"
+                return $"system.{name.ToLowerInvariant()}";
+            }
+        }
 
         protected internal List<Type> UpdatesAfter { get; } = new();
         protected internal List<Type> UpdatesBefore { get; } = new();
@@ -185,15 +197,7 @@ namespace Robust.Shared.GameObjects
 
         public void PostInject()
         {
-            var name = GetType().Name;
-
-            if (name.EndsWith("System"))
-                name = name.Substring(0, name.Length - "System".Length);
-
-            // Convention is foo.bar_baz
-            // But fuck trying to automatically snake_case something like "PVSSystem"
-            name = name.ToLowerInvariant();
-            Sawmill = _logMan.GetSawmill($"system.{name}");
+            Log = _logMan.GetSawmill(SawmillName);
         }
     }
 }


### PR DESCRIPTION
Entity systems now automatically create a Sawmill with a name based on the class name. E.g., `FixtureSystem` becomes `ILogMan.GetSawmill("system.fixture")`.  Originally I also added proxy methods (e.g. `LogError() -> Sawmill.Error())`), but decided to just name the sawmill `Log` instead, so that systems can just use `Log.Error()`.

The samill names can be overridden by systems, The automatic sawmill names don't currently properly convert to snake_case. E.g. `PVSOverrideSystem` just becomes `system.pvsoverride` instead of `system.pvs_override`.