### PR TITLE
Cange richtext tags to be overridable by content

### DIFF
--- a/Robust.Client/UserInterface/RichText/MarkupTagManager.cs
+++ b/Robust.Client/UserInterface/RichText/MarkupTagManager.cs
@@ -45,7 +45,7 @@ public sealed class MarkupTagManager
                 continue;
 
             var instance = (IMarkupTag)_sandboxHelper.CreateInstance(type);
-            _markupTagTypes.Add(instance.Name.ToLower(),  instance);
+            _markupTagTypes[instance.Name.ToLower()] = instance;
         }
 
         foreach (var (_, tag) in _markupTagTypes)

--- a/Robust.Shared/Utility/FormattedMessage.MarkupParser.cs
+++ b/Robust.Shared/Utility/FormattedMessage.MarkupParser.cs
@@ -72,8 +72,7 @@ public sealed partial class FormattedMessage
     private static readonly Parser<char, List<MarkupNode>> Text =
          EscapeSequence.Or(Token(c => c != '[' && c != '\\'))
                 .AtLeastOnceString()
-                .Select(s => new MarkupNode(s))
-                .Select(tag => new List<MarkupNode>{tag});
+                .Select(s => new List<MarkupNode>{new(s)});
 
     //Parses a string of letters or digits beginning with a letter
 	private static readonly Parser<char, string> Identifier =


### PR DESCRIPTION
Tags that have the same name as ones that are already present will override them now instead of failing.
Also removes a redundant linq select.