### PR TITLE
Add new `Dirty()` override for `Component.Owner` removal

### DIFF
--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -81,11 +81,11 @@ namespace Robust.Client.GameObjects
         }
 
         /// <inheritdoc />
-        public override void Dirty(Component component, MetaDataComponent? meta = null)
+        public override void Dirty(EntityUid uid, Component component, MetaDataComponent? meta = null)
         {
             //  Client only dirties during prediction
             if (_gameTiming.InPrediction)
-                base.Dirty(component, meta);
+                base.Dirty(uid, component, meta);
         }
 
         public override EntityStringRepresentation ToPrettyString(EntityUid uid)

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -404,21 +404,18 @@ namespace Robust.Shared.GameObjects
             }
         }
 
-        public virtual void Dirty(Component component, MetaDataComponent? meta = null)
+        [Obsolete("use override with an EntityUid")]
+        public void Dirty(Component component, MetaDataComponent? meta = null)
         {
-#pragma warning disable CS0618
-            var owner = component.Owner;
-#pragma warning restore CS0618
+            Dirty(component.Owner, component, meta);
+        }
 
-            // Deserialization will cause this to be true.
-            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-            if (!owner.IsValid() || component.LifeStage >= ComponentLifeStage.Removing)
+        public virtual void Dirty(EntityUid uid, Component component, MetaDataComponent? meta = null)
+        {
+            if (component.LifeStage >= ComponentLifeStage.Removing || !component.NetSyncEnabled)
                 return;
 
-            if (!component.NetSyncEnabled)
-                return;
-
-            DirtyEntity(owner, meta);
+            DirtyEntity(uid, meta);
             component.LastModifiedTick = CurrentTick;
         }
 

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -201,6 +201,15 @@ public partial class EntitySystem
     }
 
     /// <summary>
+    ///     Marks a component as dirty. This also implicitly dirties the entity this component belongs to.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected void Dirty(EntityUid uid, Component component, MetaDataComponent? meta = null)
+    {
+        EntityManager.Dirty(uid, component, meta);
+    }
+
+    /// <summary>
     ///     Retrieves the name of an entity.
     /// </summary>
     /// <exception cref="KeyNotFoundException">Thrown when the entity doesn't exist.</exception>

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -102,6 +102,8 @@ namespace Robust.Shared.GameObjects
 
         public void Dirty(Component component, MetaDataComponent? metadata = null);
 
+        public void Dirty(EntityUid uid, Component component, MetaDataComponent? meta = null);
+
         public void QueueDeleteEntity(EntityUid uid);
 
         public bool IsQueuedForDeletion(EntityUid uid);


### PR DESCRIPTION
Obsoletes the IEntityManager method (only has ~40 uses), but not the entity system proxy method, because that has 400+ uses and apparently the number of warnings is already causing issues.