### PR TITLE
Remove static ILocalizationManager resolves.

### DIFF
--- a/Robust.Shared/GameObjects/EntitySystem.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JetBrains.Annotations;
 using Robust.Shared.IoC;
+using Robust.Shared.Localization;
 using Robust.Shared.Log;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
@@ -26,6 +27,7 @@ namespace Robust.Shared.GameObjects
         [Dependency] protected readonly ILogManager LogManager = default!;
         [Dependency] private readonly ISharedPlayerManager _playerMan = default!;
         [Dependency] private readonly IReplayRecordingManager _replayMan = default!;
+        [Dependency] protected readonly ILocalizationManager Loc = default!;
 
         public ISawmill Log { get; private set; } = default!;
 


### PR DESCRIPTION
This PR adds a `ILocalizationManager` dependency to entity systems. The field is just called `Loc` so that existing `Loc.GetString()` calls should just use the new field instead of using the static IoC resolves. 

This might cause some confusion when the static method gets obsoleted, so maybe it'd be better to just use refactoring tools to rename it to something else?

Requires space-wizards/space-station-14/pull/17392