### PR TITLE
Make `ActorSystem.Attach()` detach from existing entities.

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/ActorSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/ActorSystem.cs
@@ -15,15 +15,7 @@ namespace Robust.Server.GameObjects
         {
             base.Initialize();
 
-            SubscribeLocalEvent<AttachPlayerEvent>(OnActorPlayerAttach);
-            SubscribeLocalEvent<ActorComponent, DetachPlayerEvent>(OnActorPlayerDetach);
             SubscribeLocalEvent<ActorComponent, ComponentShutdown>(OnActorShutdown);
-        }
-
-        private void OnActorPlayerAttach(AttachPlayerEvent args)
-        {
-            args.Result = Attach(args.Uid, args.Player, args.Force, out var forceKicked);
-            args.ForceKicked = forceKicked;
         }
 
         /// <summary>
@@ -54,11 +46,8 @@ namespace Robust.Server.GameObjects
             if (player.AttachedEntity == entity)
                 return true;
 
-            if (!Detach(player))
-                return false;
-
-            if (entity is not {} uid)
-                return true;
+            if (entity is not { } uid)
+                return Detach(player);
 
             // Cannot attach to a deleted, nonexisting or terminating entity.
             if (!TryComp(uid, out MetaDataComponent? meta) || meta.EntityLifeStage > EntityLifeStage.MapInitialized)
@@ -71,17 +60,16 @@ namespace Robust.Server.GameObjects
             {
                 // If we're not forcing the attach, this fails.
                 if (!force)
-                {
                     return false;
-                }
 
                 // Set the event's force-kicked session before detaching it.
                 forceKicked = actor.PlayerSession;
-
-                // This detach cannot fail, as a player is attached to this entity.
-                // It's important to note that detaching the player removes the component.
-                RaiseLocalEvent(uid, new DetachPlayerEvent(), true);
+                Detach(uid, actor);
             }
+
+            // Detach from the currently attached entity.
+            if (!Detach(player))
+                return false;
 
             // We add the actor component.
             actor = EntityManager.AddComponent<ActorComponent>(uid);
@@ -95,23 +83,18 @@ namespace Robust.Server.GameObjects
             return true;
         }
 
-        // Not gonna make this method call Detach as all we have to do is remove a component...
-        private void OnActorPlayerDetach(EntityUid uid, ActorComponent component, DetachPlayerEvent args)
-        {
-            // Removing the component will call shutdown, and our subscription will handle the rest of the detach logic.
-            EntityManager.RemoveComponent<ActorComponent>(uid);
-            args.Result = true;
-        }
-
         /// <summary>
         ///     Detaches an attached session from the entity, if any.
         /// </summary>
         /// <param name="entity">The entity player sessions will be detached from.</param>
         /// <returns>Whether any player session was detached.</returns>
-        public bool Detach(EntityUid entity)
+        public bool Detach(EntityUid uid, ActorComponent? actor = null)
         {
-            // Removing the component will call shutdown, and our subscription will handle the rest of the detach logic.
-            return RemComp<ActorComponent>(entity);
+            if (!Resolve(uid, ref actor, false))
+                return false;
+
+            RemComp(uid, actor);
+            return true;
         }
 
         /// <summary>
@@ -133,64 +116,6 @@ namespace Robust.Server.GameObjects
             // The player is fully detached now that the component has shut down.
             RaiseLocalEvent(entity, new PlayerDetachedEvent(entity, component.PlayerSession), true);
         }
-    }
-
-    /// <summary>
-    ///     Raise this broadcast event to attach a player to an entity, optionally detaching the player attached to it.
-    /// </summary>
-    public sealed class AttachPlayerEvent : EntityEventArgs
-    {
-        /// <summary>
-        ///     Player to attach to the entity.
-        ///     Input parameter.
-        /// </summary>
-        public IPlayerSession Player { get; }
-
-        /// <summary>
-        ///     Entity to attach the player to.
-        ///     Input parameter.
-        /// </summary>
-        public EntityUid Uid { get; }
-
-        /// <summary>
-        ///     Whether to force-attach the player,
-        ///     detaching any players attached to it if any.
-        ///     Input parameter.
-        /// </summary>
-        public bool Force { get; }
-
-        /// <summary>
-        ///     If the attach was forced and there was a player attached to the entity before, this will be it.
-        ///     Output parameter.
-        /// </summary>
-        public IPlayerSession? ForceKicked { get; set; }
-
-        /// <summary>
-        ///     Whether the player was attached correctly.
-        ///     False if not forcing and the entity already had a player attached to it.
-        ///     Output parameter.
-        /// </summary>
-        public bool Result { get; set; } = false;
-
-        public AttachPlayerEvent(EntityUid uid, IPlayerSession player, bool force = false)
-        {
-            Uid = uid;
-            Player = player;
-            Force = force;
-        }
-    }
-
-    /// <summary>
-    ///     Raise this directed event to detach a player from an entity.
-    /// </summary>
-    public sealed class DetachPlayerEvent : EntityEventArgs
-    {
-        /// <summary>
-        ///     Whether the player was detached correctly.
-        ///     Fails if no player was attached to the entity.
-        ///     Output parameter.
-        /// </summary>
-        public bool Result { get; set; } = false;
     }
 
     /// <summary>

--- a/Robust.Server/Player/PlayerSession.cs
+++ b/Robust.Server/Player/PlayerSession.cs
@@ -116,24 +116,14 @@ namespace Robust.Server.Player
         [Obsolete("Use ActorSystem.Attach() instead.")]
         public void AttachToEntity(EntityUid? entity)
         {
-            DetachFromEntity();
-
-            if (entity == null)
-                return;
-
-            AttachToEntity((EntityUid) entity);
+            EntitySystem.Get<ActorSystem>().Attach(entity, this);
         }
 
         /// <inheritdoc />
         [Obsolete("Use ActorSystem.Attach() instead.")]
         public void AttachToEntity(EntityUid uid)
         {
-            DetachFromEntity();
-
-            if (!EntitySystem.Get<ActorSystem>().Attach(uid, this))
-            {
-                Logger.Warning($"Couldn't attach player \"{this}\" to entity \"{uid}\"! Did it have a player already attached to it?");
-            }
+            EntitySystem.Get<ActorSystem>().Attach(uid, this);
         }
 
         /// <inheritdoc />
@@ -143,22 +133,17 @@ namespace Robust.Server.Player
             if (AttachedEntity == null)
                 return;
 
-#if EXCEPTION_TOLERANCE
             if (IoCManager.Resolve<IEntityManager>().Deleted(AttachedEntity!.Value))
             {
-                Logger.Warning($"Player \"{this}\" was attached to an entity that was deleted. THIS SHOULD NEVER HAPPEN, BUT DOES.");
+                Logger.Error($"Player \"{this}\" was attached to an entity that was deleted. THIS SHOULD NEVER HAPPEN, BUT DOES.");
                 // We can't contact ActorSystem because trying to fire an entity event would crash.
                 // Work around it.
                 AttachedEntity = null;
                 UpdatePlayerState();
                 return;
             }
-#endif
 
-            if (!EntitySystem.Get<ActorSystem>().Detach(AttachedEntity.Value))
-            {
-                Logger.Warning($"Couldn't detach player \"{this}\" from entity \"{AttachedEntity}\"! Is it missing an ActorComponent?");
-            }
+            EntitySystem.Get<ActorSystem>().Detach(AttachedEntity.Value);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
The `AttachToEntity()` methods that were obsoleted in #4127 redirect users to a method that has slightly different functionality. This PR changes the system methods to behave more like the old obsolete methods. In particular the old methods would `Detach()` from any currently attached entity before attaching to the new one.

Also removes some unused method events in favour of just having people use the already public methods.

