### PR TITLE
Add CollisionLayerChangeEvent

### DIFF
--- a/Robust.Shared/Physics/Events/CollisionLayerChangeEvent.cs
+++ b/Robust.Shared/Physics/Events/CollisionLayerChangeEvent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.Physics.Components;
+
+namespace Robust.Shared.Physics.Events
+{
+    /// <summary>
+    ///     These events are broadcast (not directed) whenever an entity's ability to collide changes.
+    /// </summary>
+    [ByRefEvent]
+    public readonly struct CollisionLayerChangeEvent
+    {
+        public readonly PhysicsComponent Body;
+
+        public CollisionLayerChangeEvent(PhysicsComponent body)
+        {
+            Body = body;
+        }
+    }
+}

--- a/Robust.Shared/Physics/Systems/FixtureSystem.cs
+++ b/Robust.Shared/Physics/Systems/FixtureSystem.cs
@@ -9,6 +9,7 @@ using Robust.Shared.Log;
 using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
+using Robust.Shared.Physics.Events;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 
@@ -348,6 +349,12 @@ namespace Robust.Shared.Physics.Systems
 
             if (resetMass)
                 _physics.ResetMassData(uid, manager, body);
+
+            if (body.CollisionLayer != layer)
+            {
+                var ev = new CollisionLayerChangeEvent(body);
+                RaiseLocalEvent(ref ev);
+            }
 
             // Normally this method is called when fixtures need to be dirtied anyway so no point in returning early I think
             body.CollisionMask = mask;

--- a/Robust.Shared/Physics/Systems/FixtureSystem.cs
+++ b/Robust.Shared/Physics/Systems/FixtureSystem.cs
@@ -350,11 +350,8 @@ namespace Robust.Shared.Physics.Systems
             if (resetMass)
                 _physics.ResetMassData(uid, manager, body);
 
-            if (body.CollisionLayer != layer)
-            {
-                var ev = new CollisionLayerChangeEvent(body);
-                RaiseLocalEvent(ref ev);
-            }
+            // Save the old layer to see if an event should be raised later.
+            var oldLayer = body.CollisionLayer;
 
             // Normally this method is called when fixtures need to be dirtied anyway so no point in returning early I think
             body.CollisionMask = mask;
@@ -363,6 +360,12 @@ namespace Robust.Shared.Physics.Systems
 
             if (manager.FixtureCount == 0)
                 _physics.SetCanCollide(uid, false, manager: manager, body: body);
+
+            if (oldLayer != layer)
+            {
+                var ev = new CollisionLayerChangeEvent(body);
+                RaiseLocalEvent(ref ev);
+            }
 
             if (dirty)
                 Dirty(manager);


### PR DESCRIPTION
Intended for Content, to catch when closets change their collision layers, for dynamic pathfinding.