### PR TITLE
Rejig time offset serializer

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -915,7 +915,14 @@ public sealed class MapLoaderSystem : EntitySystem
         _logLoader.Debug($"Populated entity list in {_stopwatch.Elapsed}");
         var metadata = Comp<MetaDataComponent>(uid);
         var pauseTime = _meta.GetPauseTime(uid, metadata);
-        var postInit = metadata.EntityLifeStage >= EntityLifeStage.MapInitialized;
+
+        // TODO replace MapPreInit with the map's entity lifestage
+        // Yes, post-init maps do not have EntityLifeStage >= EntityLifeStage.MapInitialized
+        bool postInit;
+        if (TryComp(uid, out MapComponent? mapComp))
+            postInit = !mapComp.MapPreInit;
+        else
+            postInit = metadata.EntityLifeStage >= EntityLifeStage.MapInitialized;
 
         var rootXform = _serverEntityManager.GetComponent<TransformComponent>(uid);
         _context.Set(uidEntityMap, entityUidMap, postInit, pauseTime, rootXform.ParentUid);

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -64,7 +64,8 @@ namespace Robust.Shared.GameObjects
         internal EntityPrototype? _entityPrototype;
 
         /// <summary>
-        /// When this entity was paused, if applicable
+        /// When this entity was paused, if applicable. Note that this is the actual time, not the duration which gets
+        /// returned by <see cref="MetaDataSystem.GetPauseTime"/>.
         /// </summary>
         internal TimeSpan? PauseTime;
 

--- a/Robust.Shared/Map/Components/MapComponent.cs
+++ b/Robust.Shared/Map/Components/MapComponent.cs
@@ -21,6 +21,7 @@ namespace Robust.Shared.Map.Components
         [ViewVariables(VVAccess.ReadOnly)]
         public bool MapPaused { get; set; } = false;
 
+        //TODO replace MapPreInit with the map's entity life stage
         [ViewVariables(VVAccess.ReadOnly)]
         public bool MapPreInit { get; set; } = false;
     }

--- a/Robust.Shared/Map/IMapManager.cs
+++ b/Robust.Shared/Map/IMapManager.cs
@@ -166,6 +166,7 @@ namespace Robust.Shared.Map
 
         void DoMapInitialize(MapId mapId);
 
+        // TODO rename this to actually be descriptive or just remove it.
         void AddUninitializedMap(MapId mapId);
 
         [Pure]

--- a/Robust.Shared/Map/MapSerializationContext.cs
+++ b/Robust.Shared/Map/MapSerializationContext.cs
@@ -12,6 +12,7 @@ using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Timing;
 
 namespace Robust.Shared.Map;
 
@@ -26,6 +27,8 @@ internal sealed class MapSerializationContext : ISerializationContext, IEntityLo
     public HashSet<string> CurrentlyIgnoredComponents = new();
     public string? CurrentComponent;
     public EntityUid? CurrentWritingEntity;
+    public IEntityManager EntityManager;
+    public IGameTiming Timing;
 
     private Dictionary<int, EntityUid> _uidEntityMap = new();
     private Dictionary<EntityUid, int> _entityUidMap = new();
@@ -50,8 +53,10 @@ internal sealed class MapSerializationContext : ISerializationContext, IEntityLo
     /// </summary>
     private EntityUid? _parentUid;
 
-    public MapSerializationContext()
+    public MapSerializationContext(IEntityManager entityManager, IGameTiming timing)
     {
+        EntityManager = entityManager;
+        Timing = timing;
         SerializerProvider.RegisterSerializer(this);
     }
 

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/TimeOffsetSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/TimeOffsetSerializer.cs
@@ -1,22 +1,28 @@
 using System;
 using System.Globalization;
-using JetBrains.Annotations;
+using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization.Manager;
-using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 /// <summary>
-/// Offsets the timespan by the CurTime.
+/// This serializer offsets a timespan by the game's current time. If the entity is currently paused, the pause time
+/// will also be accounted for,
 /// </summary>
-public sealed class TimeOffsetSerializer : ITypeSerializer<TimeSpan, ValueDataNode>, ITypeCopier<TimeSpan>
+/// <remarks>
+/// Prototypes and pre map-init entities will always serialize this as zero. This is done mainly as a brute force fix
+/// to prevent time-offsets from being unintentionally saved to maps while mapping. If an entity must have an initial
+/// non-zero time, then that time should just be configured during map-init.
+/// </remarks>
+public sealed class TimeOffsetSerializer : ITypeSerializer<TimeSpan, ValueDataNode>
 {
     public TimeSpan Read(ISerializationManager serializationManager, ValueDataNode node,
         IDependencyCollection dependencies,
@@ -24,8 +30,22 @@ public sealed class TimeOffsetSerializer : ITypeSerializer<TimeSpan, ValueDataNo
         ISerializationContext? context = null,
         ISerializationManager.InstantiationDelegate<TimeSpan>? instanceProvider = null)
     {
+        // Caveat: if non-zero times are to be supported for prototypes, then this method needs to be changed so that
+        // the time is added when copying, instead of when reading.
+        if (context == null || context.WritingReadingPrototypes)
+            return TimeSpan.Zero;
+
+        IGameTiming? timing = null;
+        if (context is MapSerializationContext mapContext)
+        {
+            if (!mapContext.MapInitialized)
+                return TimeSpan.Zero;
+            timing = mapContext.Timing;
+        }
+
+        timing ??= dependencies.Resolve<IGameTiming>();
         var seconds = double.Parse(node.Value, CultureInfo.InvariantCulture);
-        return TimeSpan.FromSeconds(seconds);
+        return TimeSpan.FromSeconds(seconds) + timing.CurTime;
     }
 
     public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
@@ -43,25 +63,34 @@ public sealed class TimeOffsetSerializer : ITypeSerializer<TimeSpan, ValueDataNo
         // If we're reading from the prototype (e.g. for diffs) then ignore.
         if (context == null || context.WritingReadingPrototypes)
         {
+            DebugTools.Assert(value == TimeSpan.Zero,
+                "non-zero time offsets in prototypes are not supported. If required, initialize offsets on map-init");
+
+            return new ValueDataNode("0");
+        }
+
+        if (context is not MapSerializationContext mapContext)
+        {
+            value -= dependencies.Resolve<IGameTiming>().CurTime;
             return new ValueDataNode(value.TotalSeconds.ToString(CultureInfo.InvariantCulture));
         }
 
-        var curTime = dependencies.Resolve<IGameTiming>().CurTime;
+        if (!mapContext.MapInitialized)
+            return new ValueDataNode("0");
 
-        // We want to get the offset relative to the current time
-        // Because paused entities never update their timeoffsets we'll subtract how long it's been paused.
-        if (context is MapSerializationContext map)
+        if (mapContext.EntityManager.TryGetComponent(mapContext.CurrentWritingEntity, out MetaDataComponent? meta))
         {
-            curTime -= map.PauseTime;
+            // Here, PauseTime is a time -- not a duration.
+            if (meta.PauseTime != null)
+                value -= meta.PauseTime.Value;
+        }
+        else
+        {
+            // But here, PauseTime is a duration instead of a time
+            // What jolly fun.
+            value = value - mapContext.Timing.CurTime + mapContext.PauseTime;
         }
 
-        return new ValueDataNode((value - curTime).TotalSeconds.ToString(CultureInfo.InvariantCulture));
-    }
-
-
-    public void CopyTo(ISerializationManager serializationManager, TimeSpan source, ref TimeSpan target,
-        IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context = null)
-    {
-        target = source + dependencies.Resolve<IGameTiming>().CurTime;
+        return new ValueDataNode(value.TotalSeconds.ToString(CultureInfo.InvariantCulture));
     }
 }

--- a/Robust.UnitTesting/Shared/GameObjects/ContainerTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/ContainerTests.cs
@@ -293,10 +293,9 @@ namespace Robust.UnitTesting.Shared.GameObjects
                 var containerSys = entMan.EntitySysManager.GetEntitySystem<Robust.Server.Containers.ContainerSystem>();
 
                 // build the map
-                var mapIdOne = new MapId(1);
                 var mapManager = IoCManager.Resolve<IMapManager>();
 
-                mapManager.CreateMap(mapIdOne);
+                var mapIdOne = mapManager.CreateMap();
                 Assert.That(mapManager.IsMapInitialized(mapIdOne), Is.True);
 
                 var containerEnt = entMan.SpawnEntity(null, new MapCoordinates(1, 1, mapIdOne));
@@ -322,9 +321,9 @@ namespace Robust.UnitTesting.Shared.GameObjects
 
             await server.WaitAssertion(() =>
             {
-                var mapIdTwo = new MapId(2);
                 var mapManager = IoCManager.Resolve<IMapManager>();
                 var mapLoader = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<MapLoaderSystem>();
+                var mapIdTwo = mapManager.CreateMap();
 
                 // load the map
                 mapLoader.Load(mapIdTwo, "container_test.yml");

--- a/Robust.UnitTesting/Shared/Serialization/TypeSerializers/Custom/TimeOffsetSerializer.cs
+++ b/Robust.UnitTesting/Shared/Serialization/TypeSerializers/Custom/TimeOffsetSerializer.cs
@@ -2,7 +2,8 @@ using System;
 using System.Globalization;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using Robust.Shared.Serialization;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
@@ -18,18 +19,63 @@ public sealed class TimeOffsetSerializerTest : RobustIntegrationTest
     {
         var sim = StartServer();
         await sim.WaitIdleAsync();
-
         var serialization = sim.ResolveDependency<ISerializationManager>();
+        var timing = sim.ResolveDependency<IGameTiming>();
+        var entMan = sim.ResolveDependency<IEntityManager>();
+        var ctx = new MapSerializationContext(entMan, timing);
 
         await sim.WaitRunTicks(10);
+        Assert.That(timing.CurTime.TotalSeconds, Is.GreaterThan(0));
 
-        var curTime = sim.ResolveDependency<IGameTiming>().CurTime;
+        // "pause" a map at this time
+        var pauseTime = timing.CurTime;
+        await sim.WaitRunTicks(10);
+
+        // Spawn a paused entity
+        var uid = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+        var metaSys = entMan.System<MetaDataSystem>();
+        metaSys.SetEntityPaused(uid, true);
+
+        await sim.WaitRunTicks(10);
+        Assert.That(metaSys.GetPauseTime(uid).TotalSeconds, Is.GreaterThan(0));
+
+        var curTime = timing.CurTime;
+        var dataTime = curTime + TimeSpan.FromSeconds(2);
+        ctx.PauseTime = curTime - pauseTime;
+        var entPauseDuration = metaSys.GetPauseTime(uid);
 
         Assert.That(curTime.TotalSeconds, Is.GreaterThan(0));
+        Assert.That(entPauseDuration.TotalSeconds, Is.GreaterThan(0));
+        Assert.That(ctx.PauseTime.TotalSeconds, Is.GreaterThan(0));
 
-        var dataTime = curTime + TimeSpan.FromSeconds(2);
-        var node = serialization.WriteValue<TimeSpan, TimeOffsetSerializer>(dataTime);
-        Assert.That(((ValueDataNode) node).Value, Is.EqualTo(dataTime.TotalSeconds.ToString(CultureInfo.InvariantCulture)));
+        Assert.That(ctx.PauseTime, Is.Not.EqualTo(curTime));
+        Assert.That(ctx.PauseTime, Is.Not.EqualTo(entPauseDuration));
+        Assert.That(entPauseDuration, Is.Not.EqualTo(curTime));
+
+        // time gets properly offset when reading a post-init map
+        ctx.MapInitialized = true;
+        var node = serialization.WriteValue<TimeSpan, TimeOffsetSerializer>(dataTime, context: ctx);
+        var value = ((ValueDataNode) node).Value;
+        var expected = (dataTime - curTime + ctx.PauseTime).TotalSeconds.ToString(CultureInfo.InvariantCulture);
+        Assert.That(value, Is.EqualTo(expected));
+
+        // When writing paused entities, it will instead use the entity's pause time:
+        ctx.CurrentWritingEntity = uid;
+        node = serialization.WriteValue<TimeSpan, TimeOffsetSerializer>(dataTime, context: ctx);
+        value = ((ValueDataNode) node).Value;
+        expected = (dataTime - curTime + entPauseDuration).TotalSeconds.ToString(CultureInfo.InvariantCulture);
+        Assert.That(value, Is.EqualTo(expected));
+
+        // Uninitialized maps always serialize as zero
+        ctx.MapInitialized = false;
+        node = serialization.WriteValue<TimeSpan, TimeOffsetSerializer>(dataTime, context: ctx);
+        value = ((ValueDataNode) node).Value;
+        Assert.That(value, Is.EqualTo("0"));
+
+        ctx.CurrentWritingEntity = null;
+        node = serialization.WriteValue<TimeSpan, TimeOffsetSerializer>(dataTime, context: ctx);
+        value = ((ValueDataNode) node).Value;
+        Assert.That(value, Is.EqualTo("0"));
     }
 
     [Test]
@@ -42,13 +88,24 @@ public sealed class TimeOffsetSerializerTest : RobustIntegrationTest
 
         await sim.WaitRunTicks(10);
 
-        var curTime = sim.ResolveDependency<IGameTiming>().CurTime;
-        var serializer = new TimeOffsetSerializer();
-
+        var timing = sim.ResolveDependency<IGameTiming>();
+        var entMan = sim.ResolveDependency<IEntityManager>();
+        var ctx = new MapSerializationContext(entMan, timing);
+        var curTime = timing.CurTime;
         var node = new ValueDataNode("2");
-        var time = TimeSpan.Zero;
-        var basic = serialization.Read<TimeSpan, ValueDataNode, TimeOffsetSerializer>(node);
-        serialization.CopyTo(serializer, basic, ref time);
+
+        // time gets properly offset when reading a post-init map
+        ctx.MapInitialized = true;
+        var time = serialization.Read<TimeSpan, ValueDataNode, TimeOffsetSerializer>(node, ctx);
         Assert.That(time, Is.EqualTo(curTime + TimeSpan.FromSeconds(2)));
+
+        // pre-init maps read time offsets as 0.
+        ctx.MapInitialized = false;
+        time = serialization.Read<TimeSpan, ValueDataNode, TimeOffsetSerializer>(node, ctx);
+        Assert.That(time, Is.EqualTo(TimeSpan.Zero));
+
+        // Same goes for no-context reads
+        time = serialization.Read<TimeSpan, ValueDataNode, TimeOffsetSerializer>(node);
+        Assert.That(time, Is.EqualTo(TimeSpan.Zero));
     }
 }


### PR DESCRIPTION
The main goal of this PR is to prevent issues were time offsets unintentionally get saved to maps.

- The time offset serializer will now always write zeros when serializing prototypes or pre-mapinit entities
- The pause time calculation now uses an entity's pause time, rather than the map's pause time. Can be important if entities get added to already paused maps.
- Map saving now logs errors when saving a pre-mapinit map that contains post-mapinit entities.

Requires a https://github.com/space-wizards/space-station-14/pull/17580