### PR TITLE
Cleanup redundant parentheses

### DIFF
--- a/Robust.Shared/Map/Components/MapComponent.cs
+++ b/Robust.Shared/Map/Components/MapComponent.cs
@@ -12,7 +12,7 @@ namespace Robust.Shared.Map.Components
     public sealed class MapComponent : Component
     {
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField(("lightingEnabled"))]
+        [DataField("lightingEnabled")]
         public bool LightingEnabled { get; set; } = true;
 
         [ViewVariables(VVAccess.ReadOnly)]


### PR DESCRIPTION
Not a syntax error but a funny.
Removing these means I don't have to parse the oddity in a tool I made.