### PR TITLE
Return map first for grid queries

### DIFF
--- a/Robust.Shared/Map/MapManager.Queries.cs
+++ b/Robust.Shared/Map/MapManager.Queries.cs
@@ -68,6 +68,14 @@ internal partial class MapManager
         {
             return;
         }
+
+        var mapUid = GetMapEntityId(mapId);
+
+        if (includeMap && EntityManager.TryGetComponent<MapGridComponent>(mapUid, out var grid))
+        {
+            callback(mapUid, grid, ref state);
+        }
+
         var physicsQuery = EntityManager.GetEntityQuery<PhysicsComponent>();
         var xformQuery = EntityManager.GetEntityQuery<TransformComponent>();
         var xformSystem = EntityManager.System<SharedTransformSystem>();
@@ -94,13 +102,6 @@ internal partial class MapManager
 
             return tuple.callback(data.Uid, data.Grid, ref tuple.state);
         }, worldAABB);
-
-        var mapUid = GetMapEntityId(mapId);
-
-        if (includeMap && EntityManager.TryGetComponent<MapGridComponent>(mapUid, out var grid))
-        {
-            callback(mapUid, grid, ref state);
-        }
 
         state = state2.state;
     }


### PR DESCRIPTION
This was inconsistent before though seems like some rendering stuff relies on map first so here we are.