### PR TITLE
Fix ContentGetDirectoryEntries skip directory by correctly treat empty relative path

### DIFF
--- a/Robust.Shared/Utility/ResPath.cs
+++ b/Robust.Shared/Utility/ResPath.cs
@@ -424,7 +424,7 @@ public readonly struct ResPath : IEquatable<ResPath>
         {
             var x = CanonPath[basePath.CanonPath.Length..]
                 .Trim('/');
-            relative = new ResPath(x);
+            relative = x == "" ? Self : new ResPath(x);
             return true;
         }
 


### PR DESCRIPTION
Fix problem where next code skip one segment if `path` is empty string that generated by `TryRelativeTo` method.
This fix some problems with console command path auto complete that I came across.
Condition `path == ResPath.Self` treated wrongly because path is not Self when must be.
https://github.com/space-wizards/RobustToolbox/blob/d309872334677da4d572e5447abcf3f22c133f2d/Robust.Shared/ContentPack/IContentRoot.cs#L46-L54
Tested locally