### PR TITLE
Fix doc comments & typos

### DIFF
--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -317,7 +317,7 @@ internal sealed partial class PvsSystem : EntitySystem
 
         // TODO PERFORMANCE
         // Given uid is the parent of its children, we already know that the child xforms will have to be relative to
-        // coordiantes.EntityId. So instead of calling GetMoverCoordinates() for each child we should just calculate it
+        // coordinates.EntityId. So instead of calling GetMoverCoordinates() for each child we should just calculate it
         // directly.
         while (children.MoveNext(out var child))
         {

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -635,14 +635,14 @@ public partial class EntitySystem
 
     #region Entity Spawning
 
-    /// <inheritdoc cref="IEntityManager.SpawnEntity(string?, EntityCoordinates)" />
+    /// <inheritdoc cref="IEntityManager.SpawnEntity(string?, EntityCoordinates, ComponentRegistry?)" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected EntityUid Spawn(string? prototype, EntityCoordinates coordinates)
     {
         return EntityManager.SpawnEntity(prototype, coordinates);
     }
 
-    /// <inheritdoc cref="IEntityManager.SpawnEntity(string?, MapCoordinates)" />
+    /// <inheritdoc cref="IEntityManager.SpawnEntity(string?, MapCoordinates, ComponentRegistry?)" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected EntityUid Spawn(string? prototype, MapCoordinates coordinates)
     {

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -80,7 +80,9 @@ namespace Robust.Shared.GameObjects
         EntityUid[] SpawnEntities(MapCoordinates coordinates, List<string?> protoNames);
 
         /// <summary>
-        /// Spawns an initialized entity at the default location, using the given prototype.
+        /// Spawns an initialized entity and sets its local coordinates to the given entity coordinates. Note that this
+        /// means that if you specify coordinates relative to some entity, the newly spawned entity will be a child of
+        /// that entity.
         /// </summary>
         /// <param name="protoName">The prototype to clone. If this is null, the entity won't have a prototype.</param>
         /// <param name="coordinates"></param>
@@ -88,7 +90,7 @@ namespace Robust.Shared.GameObjects
         EntityUid SpawnEntity(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null);
 
         /// <summary>
-        /// Spawns an entity at a specific position
+        /// Spawns an entity at a specific world position.
         /// </summary>
         /// <param name="protoName"></param>
         /// <param name="coordinates"></param>

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -271,7 +271,7 @@ public abstract partial class SharedTransformSystem
         }
         else
         {
-            // Entity may not be directly parented to the grid (e.g., spawned using some relative entity coordiantes)
+            // Entity may not be directly parented to the grid (e.g., spawned using some relative entity coordinates)
             // in that case, we attempt to attach to a grid.
             var pos = new MapCoordinates(GetWorldPosition(component), component.MapID);
             _mapManager.TryFindGridAt(pos, out _, out grid);

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -172,7 +172,7 @@ namespace Robust.Shared.GameObjects
         {
             var parentUid = coordinates.EntityId;
 
-            // Nullspace coordiantes?
+            // Nullspace coordinates?
             if (!parentUid.IsValid())
                 return coordinates;
 


### PR DESCRIPTION
This fixes the `Spawn(string?, EntityCoordinates)` doc comment so that it is actually accurate and fixes some other misc typos in comments,