### PR TITLE
Block some parent-child collisions

### DIFF
--- a/Robust.Client/Physics/PhysicsSystem.Predict.cs
+++ b/Robust.Client/Physics/PhysicsSystem.Predict.cs
@@ -138,10 +138,13 @@ public sealed partial class PhysicsSystem
                 continue;
             }
 
+            var xformA = xformQuery.GetComponent(uidA);
+            var xformB = xformQuery.GetComponent(uidB);
+
             if ((contact.Flags & ContactFlags.Filter) != 0x0)
             {
                 if (!ShouldCollide(fixtureA, fixtureB) ||
-                    !ShouldCollide(uidA, uidB, bodyA, bodyB, fixtureA, fixtureB))
+                    !ShouldCollide(uidA, uidB, bodyA, bodyB, fixtureA, fixtureB, xformA, xformB))
                 {
                     contact.IsTouching = false;
                     continue;
@@ -156,9 +159,6 @@ public sealed partial class PhysicsSystem
                 contact.IsTouching = false;
                 continue;
             }
-
-            var xformA = xformQuery.GetComponent(uidA);
-            var xformB = xformQuery.GetComponent(uidB);
 
             if (xformA.MapUid == null || xformA.MapUid != xformB.MapUid)
             {

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
@@ -224,8 +224,11 @@ public abstract partial class SharedPhysicsSystem
 
         DebugTools.Assert(!fixtureB.Contacts.ContainsKey(fixtureA));
 
+        var xformA = _xformQuery.GetComponent(uidA);
+        var xformB = _xformQuery.GetComponent(uidB);
+
         // Does a joint override collision? Is at least one body dynamic?
-        if (!ShouldCollide(uidA, uidB, bodyA, bodyB, fixtureA, fixtureB))
+        if (!ShouldCollide(uidA, uidB, bodyA, bodyB, fixtureA, fixtureB, xformA, xformB))
             return;
 
         // Call the factory.
@@ -324,9 +327,6 @@ public abstract partial class SharedPhysicsSystem
         // TODO: check for null instead?
         // Work out which contacts are still valid before we decide to update manifolds.
         var node = _activeContacts.First;
-        var metaQuery = GetEntityQuery<MetaDataComponent>();
-        var bodyQuery = GetEntityQuery<PhysicsComponent>();
-        var xformQuery = GetEntityQuery<TransformComponent>();
 
         while (node != null)
         {
@@ -350,12 +350,15 @@ public abstract partial class SharedPhysicsSystem
                 continue;
             }
 
+            var xformA = _xformQuery.GetComponent(uidA);
+            var xformB = _xformQuery.GetComponent(uidB);
+
             // Is this contact flagged for filtering?
             if ((contact.Flags & ContactFlags.Filter) != 0x0)
             {
                 // Check default filtering
                 if (!ShouldCollide(fixtureA, fixtureB) ||
-                    !ShouldCollide(uidA, uidB, bodyA, bodyB, fixtureA, fixtureB))
+                    !ShouldCollide(uidA, uidB, bodyA, bodyB, fixtureA, fixtureB, xformA, xformB))
                 {
                     DestroyContact(contact);
                     continue;
@@ -374,8 +377,6 @@ public abstract partial class SharedPhysicsSystem
                 continue;
             }
 
-            var xformA = xformQuery.GetComponent(uidA);
-            var xformB = xformQuery.GetComponent(uidB);
 
             if (xformA.MapUid == null || xformA.MapUid != xformB.MapUid)
             {
@@ -386,8 +387,8 @@ public abstract partial class SharedPhysicsSystem
             // Special-case grid contacts.
             if ((contact.Flags & ContactFlags.Grid) != 0x0)
             {
-                var gridABounds = fixtureA.Shape.ComputeAABB(GetPhysicsTransform(uidA, xformA, xformQuery), 0);
-                var gridBBounds = fixtureB.Shape.ComputeAABB(GetPhysicsTransform(uidB, xformB, xformQuery), 0);
+                var gridABounds = fixtureA.Shape.ComputeAABB(GetPhysicsTransform(uidA, xformA, _xformQuery), 0);
+                var gridBBounds = fixtureB.Shape.ComputeAABB(GetPhysicsTransform(uidB, xformB, _xformQuery), 0);
 
                 if (!gridABounds.Intersects(gridBBounds))
                 {
@@ -440,8 +441,8 @@ public abstract partial class SharedPhysicsSystem
                     // Instead of transforming both boxes (which enlarges both aabbs), maybe just transform one box.
                     // I.e. use (matrixA * invMatrixB).TransformBox(). Or (invMatrixB * matrixA), whichever is correct.
                     // Alternatively, maybe just directly construct the relative transform matrix?
-                    var proxyAWorldAABB = _transform.GetWorldMatrix(xformQuery.GetComponent(broadphaseA.Value), xformQuery).TransformBox(proxyA.AABB);
-                    var proxyBWorldAABB = _transform.GetWorldMatrix(xformQuery.GetComponent(broadphaseB.Value), xformQuery).TransformBox(proxyB.AABB);
+                    var proxyAWorldAABB = _transform.GetWorldMatrix(_xformQuery.GetComponent(broadphaseA.Value), _xformQuery).TransformBox(proxyA.AABB);
+                    var proxyBWorldAABB = _transform.GetWorldMatrix(_xformQuery.GetComponent(broadphaseB.Value), _xformQuery).TransformBox(proxyB.AABB);
                     overlap = proxyAWorldAABB.Intersects(proxyBWorldAABB);
                 }
             }
@@ -578,8 +579,6 @@ public abstract partial class SharedPhysicsSystem
 
     private void UpdateContacts(Contact[] contacts, int start, int end, ContactStatus[] status, bool[] wake, Vector2[] worldPoints)
     {
-        var xformQuery = GetEntityQuery<TransformComponent>();
-
         for (var i = start; i < end; i++)
         {
             var contact = contacts[i];
@@ -597,8 +596,8 @@ public abstract partial class SharedPhysicsSystem
 
             var uidA = contact.EntityA;
             var uidB = contact.EntityB;
-            var bodyATransform = GetPhysicsTransform(uidA, xformQuery.GetComponent(uidA), xformQuery);
-            var bodyBTransform = GetPhysicsTransform(uidB, xformQuery.GetComponent(uidB), xformQuery);
+            var bodyATransform = GetPhysicsTransform(uidA, Transform(uidA));
+            var bodyBTransform = GetPhysicsTransform(uidB, Transform(uidB));
 
             var contactStatus = contact.Update(bodyATransform, bodyBTransform, out wake[i]);
             status[i] = contactStatus;
@@ -613,39 +612,64 @@ public abstract partial class SharedPhysicsSystem
     /// <summary>
     ///     Used to prevent bodies from colliding; may lie depending on joints.
     /// </summary>
-    protected bool ShouldCollide(EntityUid aUid, EntityUid bUid, PhysicsComponent body, PhysicsComponent other, Fixture fixture, Fixture otherFixture)
+    protected bool ShouldCollide(
+        EntityUid uid,
+        EntityUid other,
+        PhysicsComponent body,
+        PhysicsComponent otherBody,
+        Fixture fixture,
+        Fixture otherFixture,
+        TransformComponent xform,
+        TransformComponent otherXform)
     {
         if (((body.BodyType & (BodyType.Kinematic | BodyType.Static)) != 0 &&
-             (other.BodyType & (BodyType.Kinematic | BodyType.Static)) != 0) ||
+             (otherBody.BodyType & (BodyType.Kinematic | BodyType.Static)) != 0) ||
             // Kinematic controllers can't collide.
             (fixture.Hard && body.BodyType == BodyType.KinematicController &&
-             otherFixture.Hard && other.BodyType == BodyType.KinematicController))
+             otherFixture.Hard && otherBody.BodyType == BodyType.KinematicController))
         {
             return false;
+        }
+
+        if (fixture.Hard && otherFixture.Hard)
+        {
+            // Prevent self-propelling entities. I.e., prevent a fixture on a static child entity from propelling the
+            // parent forwards.
+            // TODO Add recursive parent checks, without somehow killing performance.
+            if (uid == other)
+                return false;
+
+            if (other == xform.ParentUid && body.BodyType == BodyType.Static)
+                return false;
+
+            if (uid == otherXform.ParentUid && otherBody.BodyType == BodyType.Static)
+                return false;
         }
 
         // Does a joint prevent collision?
         // if one of them doesn't have jointcomp then they can't share a common joint.
         // otherwise, only need to iterate over the joints of one component as they both store the same joint.
-        if (TryComp(aUid, out JointComponent? jointComponentA) && HasComp<JointComponent>(bUid))
+        if (TryComp(uid, out JointComponent? jointComponentA) && HasComp<JointComponent>(other))
         {
             foreach (var joint in jointComponentA.Joints.Values)
             {
                 // Check if either: the joint even allows collisions OR the other body on the joint is actually the other body we're checking.
-                if (!joint.CollideConnected && (bUid == joint.BodyAUid || bUid == joint.BodyBUid))
+                if (!joint.CollideConnected && (other == joint.BodyAUid || other == joint.BodyBUid))
                     return false;
             }
         }
 
-        var preventCollideMessage = new PreventCollideEvent(aUid, bUid, body, other, fixture, otherFixture);
-        RaiseLocalEvent(aUid, ref preventCollideMessage);
+        var preventCollideMessage = new PreventCollideEvent(uid, other, body, otherBody, fixture, otherFixture);
+        RaiseLocalEvent(uid, ref preventCollideMessage);
 
-        if (preventCollideMessage.Cancelled) return false;
+        if (preventCollideMessage.Cancelled)
+            return false;
 
-        preventCollideMessage = new PreventCollideEvent(bUid, aUid, other, body, otherFixture, fixture);
-        RaiseLocalEvent(bUid, ref preventCollideMessage);
+        preventCollideMessage = new PreventCollideEvent(other, uid, otherBody, body, otherFixture, fixture);
+        RaiseLocalEvent(other, ref preventCollideMessage);
 
-        if (preventCollideMessage.Cancelled) return false;
+        if (preventCollideMessage.Cancelled)
+            return false;
 
         return true;
     }

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
@@ -64,12 +64,16 @@ namespace Robust.Shared.Physics.Systems
 
         private ISawmill _sawmill = default!;
 
+        private EntityQuery<TransformComponent> _xformQuery;
+
         public override void Initialize()
         {
             base.Initialize();
 
             _sawmill = Logger.GetSawmill("physics");
             _sawmill.Level = LogLevel.Info;
+
+            _xformQuery = GetEntityQuery<TransformComponent>();
 
             SubscribeLocalEvent<GridAddEvent>(OnGridAdd);
             SubscribeLocalEvent<PhysicsWakeEvent>(OnWake);


### PR DESCRIPTION
Prevents entities from propelling themselves by colliding with their own children, specifically when the child is a static object.