### PR TITLE
More StyleBox UiScale fixes.

### DIFF
--- a/Robust.Client/Graphics/Drawing/StyleBox.cs
+++ b/Robust.Client/Graphics/Drawing/StyleBox.cs
@@ -38,10 +38,16 @@ namespace Robust.Client.Graphics
             _paddingTop = other._paddingTop;
         }
 
+        /// <summary>
+        /// Minimum size, in virtual pixels.
+        /// </summary>
         public Vector2 MinimumSize =>
             new(GetContentMargin(Margin.Left) + GetContentMargin(Margin.Right),
                 GetContentMargin(Margin.Top) + GetContentMargin(Margin.Bottom));
 
+        /// <summary>
+        /// Left content margin, in virtual pixels.
+        /// </summary>
         public float? ContentMarginLeftOverride
         {
             get => _contentMarginLeftOverride;
@@ -56,6 +62,9 @@ namespace Robust.Client.Graphics
             }
         }
 
+        /// <summary>
+        /// Top content margin, in virtual pixels.
+        /// </summary>
         public float? ContentMarginTopOverride
         {
             get => _contentMarginTopOverride;
@@ -70,6 +79,9 @@ namespace Robust.Client.Graphics
             }
         }
 
+        /// <summary>
+        /// Right content margin, in virtual pixels.
+        /// </summary>
         public float? ContentMarginRightOverride
         {
             get => _contentMarginRightOverride;
@@ -84,6 +96,9 @@ namespace Robust.Client.Graphics
             }
         }
 
+        /// <summary>
+        /// Bottom content margin, in virtual pixels.
+        /// </summary>
         public float? ContentMarginBottomOverride
         {
             get => _contentMarginBottomOverride;
@@ -98,6 +113,9 @@ namespace Robust.Client.Graphics
             }
         }
 
+        /// <summary>
+        /// Left padding, in virtual pixels.
+        /// </summary>
         public float PaddingLeft
         {
             get => _paddingLeft;
@@ -112,6 +130,9 @@ namespace Robust.Client.Graphics
             }
         }
 
+        /// <summary>
+        /// Bottom padding, in virtual pixels.
+        /// </summary>
         public float PaddingBottom
         {
             get => _paddingBottom;
@@ -126,6 +147,9 @@ namespace Robust.Client.Graphics
             }
         }
 
+        /// <summary>
+        /// Right padding, in virtual pixels.
+        /// </summary>
         public float PaddingRight
         {
             get => _paddingRight;
@@ -140,6 +164,9 @@ namespace Robust.Client.Graphics
             }
         }
 
+        /// <summary>
+        /// Top padding, in virtual pixels.
+        /// </summary>
         public float PaddingTop
         {
             get => _paddingTop;
@@ -154,6 +181,9 @@ namespace Robust.Client.Graphics
             }
         }
 
+        /// <summary>
+        /// Padding, in virtual pixels.
+        /// </summary>
         public Thickness Padding
         {
             set
@@ -166,7 +196,7 @@ namespace Robust.Client.Graphics
         }
 
         /// <summary>
-        ///     Draw this style box to the screen at the specified coordinates.
+        ///     Draw this style box to the screen at the specified coordinates. This is using physical pixels, not virtual pixels.
         /// </summary>
         /// <param name="handle"></param>
         /// <param name="box"></param>
@@ -183,7 +213,7 @@ namespace Robust.Client.Graphics
         }
 
         /// <summary>
-        ///     Gets the offset from a margin of the box to where content should actually be drawn.
+        ///     Gets the offset from a margin of the box to where content should actually be drawn. This is in virtual pixels.
         /// </summary>
         /// <exception cref="ArgumentException">
         ///     Thrown if <paramref name="margin"/> is a compound is not a single margin flag.
@@ -213,6 +243,9 @@ namespace Robust.Client.Graphics
             return contentMargin + GetPadding(margin);
         }
 
+        /// <summary>
+        ///     Gets the padding. This is in virtual pixels.
+        /// </summary>
         public float GetPadding(Margin margin)
         {
             switch (margin)
@@ -231,24 +264,22 @@ namespace Robust.Client.Graphics
         }
 
         /// <summary>
-        ///     Returns the offsets of the content region of this box,
-        ///     if this box is drawn from the given position.
+        ///     Returns the offsets of the content region of this box when drawn from the given position. Input and
+        ///     output positions are in real pixels, though virtual pixels can also be used if the ui scale is set to 1.
         /// </summary>
-        public Vector2 GetContentOffset(Vector2 basePosition)
+        public Vector2 GetContentOffset(Vector2 basePosition, float uiScale)
         {
-            return basePosition + new Vector2(GetContentMargin(Margin.Left), GetContentMargin(Margin.Top));
+            return basePosition + uiScale * new Vector2(GetContentMargin(Margin.Left), GetContentMargin(Margin.Top));
         }
 
         /// <summary>
-        ///     Gets the box considered the "contents" of this style box, when drawn at a specific size.
-        ///     If <paramRef name="uiScale"/> is not 1.0, it should be set to the value of the UIScale
-        ///     property in the of the containing control and the <paramRef name="baseBox"/> should
-        ///     have units of pixels (and the output will have pixel units.)
+        ///     Gets the box considered the "contents" of this style box, when drawn at a specific size. Input and output
+        ///     boxes are in virtual pixels, though virtual pixels can also be used if the ui scale is set to 1.
         /// </summary>
         /// <exception cref="ArgumentException">
         ///     <paramref name="baseBox"/> is too small and the resultant box would have negative dimensions.
         /// </exception>
-        public UIBox2 GetContentBox(UIBox2 baseBox, float uiScale = 1.0f)
+        public UIBox2 GetContentBox(UIBox2 baseBox, float uiScale)
         {
             var left = baseBox.Left + GetContentMargin(Margin.Left) * uiScale;
             var top = baseBox.Top + GetContentMargin(Margin.Top) * uiScale;
@@ -261,9 +292,8 @@ namespace Robust.Client.Graphics
         /// <summary>
         ///     Gets the draw box, positioned at <paramref name="position"/>,
         ///     that envelops a box with the given dimensions perfectly given this box's content margins.
-        ///     If <paramref name="uiScale"/> is not 1.0, it should be set to the UIScale property in the
-        ///     control which contains this style box and the input (and output) coordinates are in
-        ///     pixel units.
+        ///     Input and output values are in physical pixels,  though virtual pixels can also be used if the ui scale
+        ///     is set to 1.
         /// </summary>
         /// <remarks>
         ///     It's basically a reverse <see cref="GetContentBox"/>.
@@ -275,7 +305,7 @@ namespace Robust.Client.Graphics
         ///     A box that, when ran through <see cref="GetContentBox"/>,
         ///     has a content box of size <paramref name="dimensions"/>
         /// </returns>
-        public UIBox2 GetEnvelopBox(Vector2 position, Vector2 dimensions, float uiScale = 1.0f)
+        public UIBox2 GetEnvelopBox(Vector2 position, Vector2 dimensions, float uiScale)
         {
             return UIBox2.FromDimensions(position, dimensions + MinimumSize * uiScale);
         }
@@ -326,6 +356,12 @@ namespace Robust.Client.Graphics
             }
         }
 
+        /// <summary>
+        /// Draw the style box in the given UI Box.
+        /// </summary>
+        /// <param name="handle"></param>
+        /// <param name="box">The area to draw in, in physical pixels</param>
+        /// <param name="uiScale">The UI scale to use.</param>
         protected abstract void DoDraw(DrawingHandleScreen handle, UIBox2 box, float uiScale);
 
         protected virtual float GetDefaultContentMargin(Margin margin)

--- a/Robust.Client/Graphics/Drawing/StyleBoxFlat.cs
+++ b/Robust.Client/Graphics/Drawing/StyleBoxFlat.cs
@@ -7,11 +7,16 @@ namespace Robust.Client.Graphics
     {
         public Color BackgroundColor { get; set; }
         public Color BorderColor { get; set; }
+
+        /// <summary>
+        /// Thickness of the border, in virtual pixels.
+        /// </summary>
         public Thickness BorderThickness { get; set; }
 
         protected override void DoDraw(DrawingHandleScreen handle, UIBox2 box, float uiScale)
         {
-            var (btl, btt, btr, btb) = BorderThickness;
+            var thickness = BorderThickness.Scale(uiScale);
+            var (btl, btt, btr, btb) = thickness;
             if (btl > 0)
                 handle.DrawRect(new UIBox2(box.Left, box.Top, box.Left + btl, box.Bottom), BorderColor);
 
@@ -24,7 +29,7 @@ namespace Robust.Client.Graphics
             if (btb > 0)
                 handle.DrawRect(new UIBox2(box.Left, box.Bottom - btb, box.Right, box.Bottom), BorderColor);
 
-            handle.DrawRect(BorderThickness.Deflate(box), BackgroundColor);
+            handle.DrawRect(thickness.Deflate(box), BackgroundColor);
         }
 
         public StyleBoxFlat()

--- a/Robust.Client/Graphics/Drawing/StyleBoxTexture.cs
+++ b/Robust.Client/Graphics/Drawing/StyleBoxTexture.cs
@@ -41,19 +41,54 @@ namespace Robust.Client.Graphics
             TextureScale = copy.TextureScale;
         }
 
+        /// <summary>
+        /// Left expansion size, in virtual pixels.
+        /// </summary>
+        /// <remarks>
+        /// This expands the size of the area where the left patches get drawn. This will cause the drawn texture to
+        /// extend beyond the box passed to the <see cref="StyleBox.Draw"/> function. This is not affected by
+        /// <see cref="TextureScale"/>.
+        /// </remarks>
         public float ExpandMarginLeft { get; set; }
 
+        /// <summary>
+        /// Top expansion size, in virtual pixels.
+        /// </summary>
+        /// <remarks>
+        /// This expands the size of the area where the left patches get drawn. This will cause the drawn texture to
+        /// extend beyond the box passed to the <see cref="StyleBox.Draw"/> function. This is not affected by
+        /// <see cref="TextureScale"/>.
+        /// </remarks>
         public float ExpandMarginTop { get; set; }
 
+        /// <summary>
+        /// Bottom expansion size, in virtual pixels.
+        /// </summary>
+        /// <remarks>
+        /// This expands the size of the area where the left patches get drawn. This will cause the drawn texture to
+        /// extend beyond the box passed to the <see cref="StyleBox.Draw"/> function. This is not affected by
+        /// <see cref="TextureScale"/>.
+        /// </remarks>
         public float ExpandMarginBottom { get; set; }
 
+        /// <summary>
+        /// Right expansion size, in virtual pixels.
+        /// </summary>
+        /// <remarks>
+        /// This expands the size of the area where the left patches get drawn. This will cause the drawn texture to
+        /// extend beyond the box passed to the <see cref="StyleBox.Draw"/> function. This is not affected by
+        /// <see cref="TextureScale"/>.
+        /// </remarks>
         public float ExpandMarginRight { get; set; }
 
         public StretchMode Mode { get; set; } = StretchMode.Stretch;
 
         private float _patchMarginLeft;
 
-        // Distance of the left patch margin from the image. In texture space.
+        /// <summary>
+        /// Distance of the left patch margin from the image. In texture space.
+        /// The size of this patch in virtual pixels can be obtained by scaling this with <see cref="TextureScale"/>.
+        /// </summary>
         public float PatchMarginLeft
         {
             get => _patchMarginLeft;
@@ -70,7 +105,10 @@ namespace Robust.Client.Graphics
 
         private float _patchMarginRight;
 
-        // Distance of the right patch margin from the image. In texture space.
+        /// <summary>
+        /// Distance of the right patch margin from the image. In texture space.
+        /// The size of this patch in virtual pixels can be obtained by scaling this with <see cref="TextureScale"/>.
+        /// </summary>
         public float PatchMarginRight
         {
             get => _patchMarginRight;
@@ -87,7 +125,10 @@ namespace Robust.Client.Graphics
 
         private float _patchMarginTop;
 
-        // Distance of the top patch margin from the image. In texture space.
+        /// <summary>
+        /// Distance of the top patch margin from the image. In texture space.
+        /// The size of this patch in virtual pixels can be obtained by scaling this with <see cref="TextureScale"/>.
+        /// </summary>
         public float PatchMarginTop
         {
             get => _patchMarginTop;
@@ -104,7 +145,10 @@ namespace Robust.Client.Graphics
 
         private float _patchMarginBottom;
 
-        // Distance of the bottom patch margin from the image. In texture space.
+        /// <summary>
+        /// Distance of the bottom patch margin from the image. In texture space.
+        /// The size of this patch in virtual pixels can be obtained by scaling this with <see cref="TextureScale"/>.
+        /// </summary>
         public float PatchMarginBottom
         {
             get => _patchMarginBottom;
@@ -123,7 +167,9 @@ namespace Robust.Client.Graphics
 
         public Texture? Texture { get; set; }
 
-        // Applies an additional x/y scale to the teture
+        /// <summary>
+        /// Additional scaling to use when drawing the texture.
+        /// </summary>
         public Vector2 TextureScale { get; set; } = Vector2.One;
 
         public void SetPatchMargin(Margin margin, float value)
@@ -180,10 +226,10 @@ namespace Robust.Client.Graphics
             }
 
             box = new UIBox2(
-                box.Left - ExpandMarginLeft,
-                box.Top - ExpandMarginTop,
-                box.Right + ExpandMarginRight,
-                box.Bottom + ExpandMarginBottom);
+                box.Left - ExpandMarginLeft * uiScale,
+                box.Top - ExpandMarginTop * uiScale,
+                box.Right + ExpandMarginRight * uiScale,
+                box.Bottom + ExpandMarginBottom * uiScale);
 
             var scaledMargin = new UIBox2(PatchMarginLeft * TextureScale.X * uiScale, PatchMarginTop * TextureScale.Y * uiScale,
                     PatchMarginRight * TextureScale.X * uiScale, PatchMarginBottom * TextureScale.Y * uiScale);

--- a/Robust.Client/Graphics/Drawing/StyleBoxTexture.cs
+++ b/Robust.Client/Graphics/Drawing/StyleBoxTexture.cs
@@ -45,7 +45,7 @@ namespace Robust.Client.Graphics
         /// Left expansion size, in virtual pixels.
         /// </summary>
         /// <remarks>
-        /// This expands the size of the area where the left patches get drawn. This will cause the drawn texture to
+        /// This expands the size of the area where the patches get drawn. This will cause the drawn texture to
         /// extend beyond the box passed to the <see cref="StyleBox.Draw"/> function. This is not affected by
         /// <see cref="TextureScale"/>.
         /// </remarks>
@@ -55,7 +55,7 @@ namespace Robust.Client.Graphics
         /// Top expansion size, in virtual pixels.
         /// </summary>
         /// <remarks>
-        /// This expands the size of the area where the left patches get drawn. This will cause the drawn texture to
+        /// This expands the size of the area where the patches get drawn. This will cause the drawn texture to
         /// extend beyond the box passed to the <see cref="StyleBox.Draw"/> function. This is not affected by
         /// <see cref="TextureScale"/>.
         /// </remarks>
@@ -65,7 +65,7 @@ namespace Robust.Client.Graphics
         /// Bottom expansion size, in virtual pixels.
         /// </summary>
         /// <remarks>
-        /// This expands the size of the area where the left patches get drawn. This will cause the drawn texture to
+        /// This expands the size of the area where the patches get drawn. This will cause the drawn texture to
         /// extend beyond the box passed to the <see cref="StyleBox.Draw"/> function. This is not affected by
         /// <see cref="TextureScale"/>.
         /// </remarks>
@@ -75,7 +75,7 @@ namespace Robust.Client.Graphics
         /// Right expansion size, in virtual pixels.
         /// </summary>
         /// <remarks>
-        /// This expands the size of the area where the left patches get drawn. This will cause the drawn texture to
+        /// This expands the size of the area where the patches get drawn. This will cause the drawn texture to
         /// extend beyond the box passed to the <see cref="StyleBox.Draw"/> function. This is not affected by
         /// <see cref="TextureScale"/>.
         /// </remarks>

--- a/Robust.Client/UserInterface/Controls/ContainerButton.cs
+++ b/Robust.Client/UserInterface/Controls/ContainerButton.cs
@@ -49,7 +49,8 @@ namespace Robust.Client.UserInterface.Controls
 
         protected override Vector2 ArrangeOverride(Vector2 finalSize)
         {
-            var contentBox = ActualStyleBox.GetContentBox(UIBox2.FromDimensions(Vector2.Zero, finalSize));
+            var box = UIBox2.FromDimensions(Vector2.Zero, finalSize);
+            var contentBox = ActualStyleBox.GetContentBox(box, 1);
 
             foreach (var child in Children)
             {

--- a/Robust.Client/UserInterface/Controls/LineEdit.cs
+++ b/Robust.Client/UserInterface/Controls/LineEdit.cs
@@ -289,9 +289,8 @@ namespace Robust.Client.UserInterface.Controls
         protected override Vector2 ArrangeOverride(Vector2 finalSize)
         {
             var style = _getStyleBox();
-
-            _renderBox.Arrange(
-                (UIBox2i) style.GetContentBox(UIBox2.FromDimensions(Vector2.Zero, finalSize)));
+            var box = UIBox2.FromDimensions(Vector2.Zero, finalSize);
+            _renderBox.Arrange(style.GetContentBox(box, 1));
 
             return finalSize;
         }

--- a/Robust.Client/UserInterface/Controls/OutputPanel.cs
+++ b/Robust.Client/UserInterface/Controls/OutputPanel.cs
@@ -171,7 +171,7 @@ namespace Robust.Client.UserInterface.Controls
 
             var styleBoxSize = _getStyleBox()?.MinimumSize.Y ?? 0;
 
-            _scrollBar.Page = Height - styleBoxSize;
+            _scrollBar.Page = UIScale * (Height - styleBoxSize);
             _invalidateEntries();
         }
 
@@ -224,6 +224,7 @@ namespace Robust.Client.UserInterface.Controls
         [System.Diagnostics.Contracts.Pure]
         private float _getScrollSpeed()
         {
+            // The scroll speed depends on the UI scale because the scroll bar is working with physical pixels.
             return GetScrollSpeed(_getFont(), UIScale);
         }
 

--- a/Robust.Client/UserInterface/Controls/PanelContainer.cs
+++ b/Robust.Client/UserInterface/Controls/PanelContainer.cs
@@ -36,7 +36,7 @@ namespace Robust.Client.UserInterface.Controls
         protected override Vector2 ArrangeOverride(Vector2 finalSize)
         {
             var ourSize = UIBox2.FromDimensions(Vector2.Zero, finalSize);
-            var contentBox = _getStyleBox()?.GetContentBox(ourSize) ?? ourSize;
+            var contentBox = _getStyleBox()?.GetContentBox(ourSize, 1) ?? ourSize;
 
             foreach (var child in Children)
             {

--- a/Robust.Client/UserInterface/Controls/Tree.cs
+++ b/Robust.Client/UserInterface/Controls/Tree.cs
@@ -117,7 +117,7 @@ namespace Robust.Client.UserInterface.Controls
             var background = _getBackground();
             if (background != null)
             {
-                position -= background.GetContentOffset(Vector2.Zero);
+                position -= background.GetContentOffset(Vector2.Zero, UIScale);
             }
 
             var vOffset = -_scrollBar.Value;
@@ -188,7 +188,7 @@ namespace Robust.Client.UserInterface.Controls
             if (background != null)
             {
                 background.Draw(handle, PixelSizeBox, UIScale);
-                var (bho, bvo) = background.GetContentOffset(Vector2.Zero);
+                var (bho, bvo) = background.GetContentOffset(Vector2.Zero, UIScale);
                 vOffset += bvo;
                 hOffset += bho;
             }
@@ -220,7 +220,7 @@ namespace Robust.Client.UserInterface.Controls
 
             if (!string.IsNullOrWhiteSpace(item.Text))
             {
-                var offset = itemSelected.GetContentOffset(Vector2.Zero);
+                var offset = itemSelected.GetContentOffset(Vector2.Zero, UIScale);
                 var baseLine = offset + new Vector2(hOffset, vOffset + font.GetAscent(UIScale));
                 foreach (var rune in item.Text.EnumerateRunes())
                 {

--- a/Robust.Shared.Maths/Thickness.cs
+++ b/Robust.Shared.Maths/Thickness.cs
@@ -40,6 +40,11 @@ namespace Robust.Shared.Maths
             Right = right;
             Bottom = bottom;
         }
+        
+        public Thickness Scale(float scale)
+        {
+            return new Thickness(Left * scale, Top * scale, Right * scale, Bottom * scale);
+        }
 
         [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
         public readonly bool Equals(Thickness other)

--- a/Robust.UnitTesting/Client/Graphics/StyleBoxTest.cs
+++ b/Robust.UnitTesting/Client/Graphics/StyleBoxTest.cs
@@ -16,7 +16,7 @@ namespace Robust.UnitTesting.Client.Graphics
             var styleBox = new StyleBoxFlat();
 
             Assert.That(
-                styleBox.GetEnvelopBox(Vector2.Zero, new Vector2(50, 50)),
+                styleBox.GetEnvelopBox(Vector2.Zero, new Vector2(50, 50), 1),
                 Is.EqualTo(new UIBox2(0, 0, 50, 50)));
 
             styleBox.ContentMarginLeftOverride = 3;
@@ -25,11 +25,11 @@ namespace Robust.UnitTesting.Client.Graphics
             styleBox.ContentMarginBottomOverride = 11;
 
             Assert.That(
-                styleBox.GetEnvelopBox(Vector2.Zero, new Vector2(50, 50)),
+                styleBox.GetEnvelopBox(Vector2.Zero, new Vector2(50, 50), 1),
                 Is.EqualTo(new UIBox2(0, 0, 60, 66)));
 
             Assert.That(
-                styleBox.GetEnvelopBox(new Vector2(10, 10), new Vector2(50, 50)),
+                styleBox.GetEnvelopBox(new Vector2(10, 10), new Vector2(50, 50), 1),
                 Is.EqualTo(new UIBox2(10, 10, 70, 76)));
 
             Assert.That(


### PR DESCRIPTION
Fixes some bugs added in #4165 and makes some more stylebox properties scale with UI scale:
- `OutputPanel.Resized()` now once again uses physical pixels for the scrollbar's page size. This was causing the scrollbar in the SS14 chat window to not work properly.
- The `Tree` control drawing & selection now scales.
- `StyleBoxFlat.BorderThickness` now gets scaled when drawing. It was already getting scaled for arrange & measure.
- `StyleBoxTexture` expansion margins now get scaled.
- Made the ui scale argument passed to `GetContentBox()` and `GetEnvelopBox()` non-optional, which should hopefully avoid people accidentally forgetting to pass in the UI scale when it is required.
- Added some comments to clarify whether various functions or properties are using virtual or physical pixels.