### PR TITLE
Try prevent infinite measure/arrange loops

### DIFF
--- a/Robust.Client/UserInterface/Control.Styling.cs
+++ b/Robust.Client/UserInterface/Control.Styling.cs
@@ -228,6 +228,9 @@ namespace Robust.Client.UserInterface
             }
 
             StylePropertiesChanged();
+
+            // Setting this at the end of the function to prevent style updates from ever re-queueing a style update,
+            // which would cause an infinite loop.
             _stylingDirty = false;
         }
 

--- a/Robust.Client/UserInterface/Control.Styling.cs
+++ b/Robust.Client/UserInterface/Control.Styling.cs
@@ -148,7 +148,6 @@ namespace Robust.Client.UserInterface
 
         internal void DoStyleUpdate()
         {
-            _stylingDirty = false;
             _styleProperties.Clear();
 
             if (_stylesheetUpdateNeeded)
@@ -229,6 +228,7 @@ namespace Robust.Client.UserInterface
             }
 
             StylePropertiesChanged();
+            _stylingDirty = false;
         }
 
         protected virtual void StylePropertiesChanged()

--- a/Robust.Client/UserInterface/UserInterfaceManager.Layout.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Layout.cs
@@ -161,7 +161,7 @@ internal sealed partial class UserInterfaceManager
         }
 
         /// <summary>
-        /// Queues a control so that it gets rearranged in the next frame update. Does not queue an measure update.
+        /// Queues a control so that it gets rearranged in the next frame update. Does not queue a measure update.
         /// </summary>
         public void QueueArrangeUpdate(Control control)
         {

--- a/Robust.Client/UserInterface/UserInterfaceManager.Layout.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Layout.cs
@@ -152,12 +152,17 @@ internal sealed partial class UserInterfaceManager
             _styleUpdateQueue.Enqueue(control);
         }
 
+        /// <summary>
+        /// Queues a control so that it gets remeasured in the next frame update. Does not queue an arrange update.
+        /// </summary>
         public void QueueMeasureUpdate(Control control)
         {
             _measureUpdateQueue.Enqueue(control);
-            _arrangeUpdateQueue.Enqueue(control);
         }
 
+        /// <summary>
+        /// Queues a control so that it gets rearranged in the next frame update. Does not queue an measure update.
+        /// </summary>
         public void QueueArrangeUpdate(Control control)
         {
             _arrangeUpdateQueue.Enqueue(control);

--- a/Robust.Client/UserInterface/UserInterfaceManager.Roots.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Roots.cs
@@ -38,6 +38,7 @@ internal sealed partial class UserInterfaceManager
         newRoot.StyleSheetUpdate();
         newRoot.InvalidateMeasure();
         QueueMeasureUpdate(newRoot);
+        QueueArrangeUpdate(newRoot);
 
         if (window.IsFocused)
             FocusRoot(newRoot);

--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -287,7 +287,7 @@ namespace Robust.Client.UserInterface
 
                     RunArrange(control);
                     if (!control.IsArrangeValid)
-                        _sawmillUI.Warning($"Control's arrangement is invalid after arramgomg. Control: {control}. Parent: {control.Parent}.");
+                        _sawmillUI.Warning($"Control's arrangement is invalid after arranging. Control: {control}. Parent: {control.Parent}.");
                     total += 1;
                 }
 

--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -286,7 +286,7 @@ namespace Robust.Client.UserInterface
                         continue;
 
                     RunArrange(control);
-                    if (!control.IsArrangeValid)
+                    if (!control.IsArrangeValid && control.IsInsideTree)
                         _sawmillUI.Warning($"Control's arrangement is invalid after arranging. Control: {control}. Parent: {control.Parent}.");
                     total += 1;
                 }

--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -26,6 +26,7 @@ using Robust.Shared.Profiling;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Reflection;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 
 namespace Robust.Client.UserInterface
@@ -53,6 +54,12 @@ namespace Robust.Client.UserInterface
         [Dependency] private readonly IEntitySystemManager _systemManager = default!;
         [Dependency] private readonly ILogManager _logManager = default!;
         [Dependency] private readonly IRuntimeLog _runtime = default!;
+
+        /// <summary>
+        /// Upper limit on the number of times that controls can be measured / arranged each tick before deferring to
+        /// the next loop. This is just meant to prevent infinite loops from locking up the UI completely.
+        /// </summary>
+        public const int ControlUpdateLimit = 25_000;
 
         [ViewVariables] public InterfaceTheme ThemeDefaults { get; private set; } = default!;
         [ViewVariables]
@@ -220,6 +227,12 @@ namespace Robust.Client.UserInterface
                 var total = 0;
                 while (_styleUpdateQueue.Count != 0)
                 {
+                    if (total >= ControlUpdateLimit)
+                    {
+                        _sawmillUI.Warning($"Hit style update limit. Queued: {_styleUpdateQueue.Count}. Next in queue: {_styleUpdateQueue.Peek()}. Parent: {_styleUpdateQueue.Peek().Parent}");
+                        break;
+                    }
+
                     var control = _styleUpdateQueue.Dequeue();
 
                     if (control.Disposed)
@@ -237,12 +250,20 @@ namespace Robust.Client.UserInterface
                 var total = 0;
                 while (_measureUpdateQueue.Count != 0)
                 {
+                    if (total >= ControlUpdateLimit)
+                    {
+                        _sawmillUI.Warning($"Hit style update limit. Queued: {_measureUpdateQueue.Count}. Next in queue: {_measureUpdateQueue.Peek()}. Parent: {_measureUpdateQueue.Peek().Parent}");
+                        break;
+                    }
+
                     var control = _measureUpdateQueue.Dequeue();
 
                     if (control.Disposed)
                         continue;
 
                     RunMeasure(control);
+                    if (!control.IsMeasureValid && control.IsInsideTree)
+                        _sawmillUI.Warning($"Control's measure is invalid after measuring. Control: {control}. Parent: {control.Parent}.");
                     total += 1;
                 }
 
@@ -254,12 +275,19 @@ namespace Robust.Client.UserInterface
                 var total = 0;
                 while (_arrangeUpdateQueue.Count != 0)
                 {
+                    if (total >= ControlUpdateLimit)
+                    {
+                        _sawmillUI.Warning($"Hit style update limit. Queued: {_arrangeUpdateQueue.Count}. Next in queue: {_arrangeUpdateQueue.Peek()}. Parent: {_arrangeUpdateQueue.Peek().Parent}");
+                        break;
+                    }
                     var control = _arrangeUpdateQueue.Dequeue();
 
                     if (control.Disposed)
                         continue;
 
                     RunArrange(control);
+                    if (!control.IsArrangeValid)
+                        _sawmillUI.Warning($"Control's arrangement is invalid after arramgomg. Control: {control}. Parent: {control.Parent}.");
                     total += 1;
                 }
 

--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -252,7 +252,7 @@ namespace Robust.Client.UserInterface
                 {
                     if (total >= ControlUpdateLimit)
                     {
-                        _sawmillUI.Warning($"Hit style update limit. Queued: {_measureUpdateQueue.Count}. Next in queue: {_measureUpdateQueue.Peek()}. Parent: {_measureUpdateQueue.Peek().Parent}");
+                        _sawmillUI.Warning($"Hit measure update limit. Queued: {_measureUpdateQueue.Count}. Next in queue: {_measureUpdateQueue.Peek()}. Parent: {_measureUpdateQueue.Peek().Parent}");
                         break;
                     }
 
@@ -277,7 +277,7 @@ namespace Robust.Client.UserInterface
                 {
                     if (total >= ControlUpdateLimit)
                     {
-                        _sawmillUI.Warning($"Hit style update limit. Queued: {_arrangeUpdateQueue.Count}. Next in queue: {_arrangeUpdateQueue.Peek()}. Parent: {_arrangeUpdateQueue.Peek().Parent}");
+                        _sawmillUI.Warning($"Hit arrange update limit. Queued: {_arrangeUpdateQueue.Count}. Next in queue: {_arrangeUpdateQueue.Peek()}. Parent: {_arrangeUpdateQueue.Peek().Parent}");
                         break;
                     }
                     var control = _arrangeUpdateQueue.Dequeue();

--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -56,8 +56,8 @@ namespace Robust.Client.UserInterface
         [Dependency] private readonly IRuntimeLog _runtime = default!;
 
         /// <summary>
-        /// Upper limit on the number of times that controls can be measured / arranged each tick before deferring to
-        /// the next loop. This is just meant to prevent infinite loops from locking up the UI completely.
+        /// Upper limit on the number of times that controls can be measured / arranged each tick before being deferred
+        /// to the next frame update. This is just meant to prevent infinite loops from completely locking up the UI.
         /// </summary>
         public const int ControlUpdateLimit = 25_000;
 


### PR DESCRIPTION
Its currently possible for a control's measure/arrange code to inadvertently trigger infinite measure/arrange loops, which causes the game to freeze even in release mode. E.g., #3827 added a bug like this for split containers, which can be triggered by just resizing the window while using the "old chat" layout.

This PR tries to stop that from being possible in the first place by preventing measure/arrange/style updates from being queued while a update is already taking place. It also adds an arbitrary upper limit on the number of updates. When the limit is reached it'll log a warning and continue processing next frame.