### PR TITLE
Revert #3827

### DIFF
--- a/Robust.Client/UserInterface/Controls/SplitContainer.cs
+++ b/Robust.Client/UserInterface/Controls/SplitContainer.cs
@@ -223,23 +223,8 @@ namespace Robust.Client.UserInterface.Controls
                 var first = GetChild(0);
                 var second = GetChild(1);
 
-                var firstDesiredSize = firstMinSize ?? (Vertical ? first.DesiredSize.Y : first.DesiredSize.X);
-                var secondDesiredSize = secondMinSize ??  (Vertical ? second.DesiredSize.Y : second.DesiredSize.X);
-                var firstOrientedMinSize = Vertical ? first.MinSize.Y : first.MinSize.X;
-                var secondOrientedMinSize = Vertical ? second.MinSize.Y : second.MinSize.X;
-
-                if (firstOrientedMinSize > firstDesiredSize && firstOrientedMinSize != 0)
-                {
-                    first.Measure(controlSize);
-                }
-
-                if (secondOrientedMinSize > secondDesiredSize && secondOrientedMinSize != 0)
-                {
-                    second.Measure(controlSize);
-                }
-
-                firstMinSize = Vertical ? first.DesiredSize.Y : first.DesiredSize.X;
-                secondMinSize = Vertical ? second.DesiredSize.Y : second.DesiredSize.X;
+                firstMinSize ??= (Vertical ? first.DesiredSize.Y : first.DesiredSize.X);
+                secondMinSize ??= (Vertical ? second.DesiredSize.Y : second.DesiredSize.X);
                 var size = Vertical ? controlSize.Y : controlSize.X;
 
                 _splitStart = MathHelper.Clamp(_splitStart, firstMinSize.Value,


### PR DESCRIPTION
This reverts commit 5924d9d0173d5d46ed9348e9db103f6d271d3374.

Reasons for reverting:
- With the changes the PR added the split container will measure while arranging, which can cause issues. See #4176 
- The added measure code is out of date and no longer performs the same measurements that are done by `MeasureOverride()`. While it could be updated, it also means having more code duplication & may introduce bugs if the measure code is update in the future
- I would add an alternative fix for the bug the PR was originally meant to fix, but I can't even reproduce the bug anymore, so it seems like something else might've fixed it elsewhere?
