### PR TITLE
MidiRenderer master/puppet and various improvements/cleanup

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,15 +35,18 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* Obsoleted unused `IMidiRenderer.VolumeBoost` property. Use `IMidiRenderer.VelocityOverride` instead.
 
 ### New features
 
-*None yet*
+* Added `Master` property to `IMidiRenderer`, which allows it to copy all MIDI events from another renderer.
+* Added `FilteredChannels` property to `IMidiRenderer`, which allows it to filter out notes from certain channels.
+* Added `SystemReset` helper property to `IMidiRenderer`, which allows you to easily send it a SystemReset MIDI message.
 
 ### Bugfixes
 
-*None yet*
+* Fixed some cases were `MidiRenderer` would not respect the `MidiBank` and `MidiProgram.
+* Fixed `ItemList` item selection unselecting everything when in `Multiple` mode.
 
 ### Other
 

--- a/Robust.Client/Audio/Midi/IMidiRenderer.cs
+++ b/Robust.Client/Audio/Midi/IMidiRenderer.cs
@@ -184,7 +184,7 @@ public interface IMidiRenderer : IDisposable
     ///     This is only used if <see cref="Mono"/> is set to True
     ///     and <see cref="TrackingEntity"/> is null.
     /// </summary>
-    EntityCoordinates? TrackingCoordinates { get; set; }
+    MapCoordinates? TrackingCoordinates { get; set; }
 
     MidiRendererState RendererState { get; }
 

--- a/Robust.Client/Audio/Midi/IMidiRenderer.cs
+++ b/Robust.Client/Audio/Midi/IMidiRenderer.cs
@@ -17,7 +17,6 @@ public enum MidiRendererStatus : byte
 
 public interface IMidiRenderer : IDisposable
 {
-
     /// <summary>
     ///     The buffered audio source of this renderer.
     /// </summary>
@@ -32,6 +31,12 @@ public interface IMidiRenderer : IDisposable
     ///     This controls whether the midi file being played will loop or not.
     /// </summary>
     bool LoopMidi { get; set; }
+
+    /// <summary>
+    ///     This increases all note on velocities to 127.
+    /// </summary>
+    [Obsolete($"Use {nameof(VelocityOverride)} instead, you can set it to 127 to achieve the same effect.")]
+    bool VolumeBoost { get; set; }
 
     /// <summary>
     ///     The midi program (instrument) the renderer is using.

--- a/Robust.Client/Audio/Midi/IMidiRenderer.cs
+++ b/Robust.Client/Audio/Midi/IMidiRenderer.cs
@@ -139,6 +139,11 @@ public interface IMidiRenderer : IDisposable
     void StopAllNotes();
 
     /// <summary>
+    ///     Reset renderer back to a clean state.
+    /// </summary>
+    void SystemReset();
+
+    /// <summary>
     /// Clears all scheduled events.
     /// </summary>
     void ClearAllEvents();

--- a/Robust.Client/Audio/Midi/IMidiRenderer.cs
+++ b/Robust.Client/Audio/Midi/IMidiRenderer.cs
@@ -93,18 +93,13 @@ public interface IMidiRenderer : IDisposable
 
     /// <summary>
     ///     Whether this renderer will subscribe to another and copy its events.
-    ///     Requires <see cref="MasterChannels"/> to have channels in it.
+    ///     See <see cref="FilteredChannels"/> to filter specific channels.
     /// </summary>
     IMidiRenderer? Master { get; set; }
 
-    // NOTE: Why are the two properties below BitArray, you ask?
+    // NOTE: Why is the properties below BitArray, you ask?
     // Well see, MIDI 2.0 supports up to 256(!) channels as opposed to MIDI 1.0's meekly 16 channels...
     // I'd like us to support MIDI 2.0 one day so I'm just future-proofing here. Also BitArray is cool!
-
-    /// <summary>
-    ///     Channels to copy from the <see cref="Master"/> renderer.
-    /// </summary>
-    BitArray MasterChannels { get; }
 
     /// <summary>
     ///     Allows you to filter out note events from certain channels.
@@ -200,7 +195,7 @@ public interface IMidiRenderer : IDisposable
     /// <summary>
     ///     Apply a certain state to the renderer.
     /// </summary>
-    void ApplyState(MidiRendererState state, bool filterByMasterChannels = false);
+    void ApplyState(MidiRendererState state, bool filterChannels = false);
 
     /// <summary>
     ///     Actually disposes of this renderer. Do NOT use outside the MIDI thread.

--- a/Robust.Client/Audio/Midi/IMidiRenderer.cs
+++ b/Robust.Client/Audio/Midi/IMidiRenderer.cs
@@ -187,7 +187,8 @@ public interface IMidiRenderer : IDisposable
     ///     Send a midi event for the renderer to play.
     /// </summary>
     /// <param name="midiEvent">The midi event to be played</param>
-    void SendMidiEvent(RobustMidiEvent midiEvent);
+    /// <param name="raiseEvent">Whether to raise an event for this event.</param>
+    void SendMidiEvent(RobustMidiEvent midiEvent, bool raiseEvent = true);
 
     /// <summary>
     ///     Schedule a MIDI event to be played at a later time.

--- a/Robust.Client/Audio/Midi/MidiManager.cs
+++ b/Robust.Client/Audio/Midi/MidiManager.cs
@@ -9,6 +9,7 @@ using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Shared;
 using Robust.Shared.Asynchronous;
+using Robust.Shared.Audio.Midi;
 using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
 using Robust.Shared.Exceptions;
@@ -189,8 +190,6 @@ internal sealed partial class MidiManager : IMidiManager
             _settings["synth.lock-memory"].IntValue = 0;
             _settings["synth.threadsafe-api"].IntValue = 1;
             _settings["synth.gain"].DoubleValue = 1.0d;
-            _settings["synth.polyphony"].IntValue = Math.Min(1024 + (int)(Math.Log2(_parallel.ParallelProcessCount) * 2048), 65535);
-            _settings["synth.cpu-cores"].IntValue = _parallel.ParallelProcessCount;
             _settings["synth.midi-channels"].IntValue = 16;
             _settings["synth.overflow.age"].DoubleValue = 3000;
             _settings["audio.driver"].StringValue = "file";
@@ -198,6 +197,7 @@ internal sealed partial class MidiManager : IMidiManager
             _settings["audio.period-size"].IntValue = 4096;
             _settings["midi.autoconnect"].IntValue = 1;
             _settings["player.reset-synth"].IntValue = 0;
+            _settings["synth.midi-channels"].IntValue = Math.Clamp(RobustMidiEvent.MaxChannels, 16, 256);
             _settings["synth.midi-bank-select"].StringValue = "gm";
             //_settings["synth.verbose"].IntValue = 1; // Useful for debugging.
 
@@ -224,8 +224,8 @@ internal sealed partial class MidiManager : IMidiManager
         if (_settings == null)
             return;
 
-        _settings["synth.polyphony"].IntValue = Math.Min(1024 + (int)(Math.Log2(_parallel.ParallelProcessCount) * 2048), 65535);
-        _settings["synth.cpu-cores"].IntValue = Math.Min(_parallel.ParallelProcessCount, 256);
+        _settings["synth.polyphony"].IntValue = Math.Clamp(1024 + (int)(Math.Log2(_parallel.ParallelProcessCount) * 2048), 1, 65535);
+        _settings["synth.cpu-cores"].IntValue = Math.Clamp(_parallel.ParallelProcessCount, 1, 256);
 
         _midiSawmill.Debug($"Synth Cores: {_settings["synth.cpu-cores"].IntValue}");
         _midiSawmill.Debug($"Synth Polyphony: {_settings["synth.polyphony"].IntValue}");

--- a/Robust.Client/Audio/Midi/MidiManager.cs
+++ b/Robust.Client/Audio/Midi/MidiManager.cs
@@ -306,11 +306,11 @@ internal sealed partial class MidiManager : IMidiManager
 
             // Load every soundfont from the user data directory last, since those may override any other soundfont.
             _midiSawmill.Debug($"Loading soundfonts from user data directory {userDataPath}");
-            var enumerator = _resourceManager.UserData.Find($"{CustomSoundfontDirectory.ToRelativePath()}/*").Item1;
+            var enumerator = _resourceManager.UserData.Find($"{CustomSoundfontDirectory.ToRelativePath()}*").Item1;
             foreach (var file in enumerator)
             {
                 if (file.Extension != "sf2" && file.Extension != "dls" && file.Extension != "sf3") continue;
-                _midiSawmill.Debug($"Loading user soundfont {{USERDATA}} {file}");
+                _midiSawmill.Debug($"Loading user soundfont {file}");
                 renderer.LoadSoundfont(file.ToString());
             }
 

--- a/Robust.Client/Audio/Midi/MidiManager.cs
+++ b/Robust.Client/Audio/Midi/MidiManager.cs
@@ -380,20 +380,19 @@ internal sealed partial class MidiManager : IMidiManager
             if (_renderers.Count == 0)
                 return;
 
-            var transSystem = _entityManager.System<TransformSystem>();
             var transQuery = _entityManager.GetEntityQuery<TransformComponent>();
             var physicsQuery = _entityManager.GetEntityQuery<PhysicsComponent>();
             var opts = new ParallelOptions { MaxDegreeOfParallelism = _parallel.ParallelProcessCount };
 
             if (_renderers.Count > _minRendererParallel)
             {
-                Parallel.ForEach(_renderers, opts, renderer => UpdateRenderer(renderer, transQuery, physicsQuery, transSystem));
+                Parallel.ForEach(_renderers, opts, renderer => UpdateRenderer(renderer, transQuery, physicsQuery));
             }
             else
             {
                 foreach (var renderer in _renderers)
                 {
-                    UpdateRenderer(renderer, transQuery, physicsQuery, transSystem);
+                    UpdateRenderer(renderer, transQuery, physicsQuery);
                 }
             }
 
@@ -408,7 +407,7 @@ internal sealed partial class MidiManager : IMidiManager
         _volumeDirty = false;
     }
     private void UpdateRenderer(IMidiRenderer renderer, EntityQuery<TransformComponent> transQuery,
-        EntityQuery<PhysicsComponent> physicsQuery, TransformSystem transformSystem)
+        EntityQuery<PhysicsComponent> physicsQuery)
     {
         try
         {

--- a/Robust.Client/Audio/Midi/MidiManager.cs
+++ b/Robust.Client/Audio/Midi/MidiManager.cs
@@ -175,7 +175,7 @@ internal sealed partial class MidiManager : IMidiManager
             _settings["synth.threadsafe-api"].IntValue = 1;
             _settings["synth.gain"].DoubleValue = 1.0d;
             _settings["synth.polyphony"].IntValue = 1024;
-            _settings["synth.cpu-cores"].IntValue = 2;
+            _settings["synth.cpu-cores"].IntValue = _parallel.ParallelProcessCount;
             _settings["synth.midi-channels"].IntValue = 16;
             _settings["synth.overflow.age"].DoubleValue = 3000;
             _settings["audio.driver"].StringValue = "file";

--- a/Robust.Client/Audio/Midi/MidiManager.cs
+++ b/Robust.Client/Audio/Midi/MidiManager.cs
@@ -238,7 +238,7 @@ internal sealed partial class MidiManager : IMidiManager
 
             var renderer = new MidiRenderer(_settings!, soundfontLoader, mono, this, _clydeAudio, _taskManager, _midiSawmill);
 
-            _midiSawmill.Debug($"Loading soundfont {FallbackSoundfont}");
+            _midiSawmill.Debug($"Loading fallback soundfont {FallbackSoundfont}");
             // Since the last loaded soundfont takes priority, we load the fallback soundfont before the soundfont.
             renderer.LoadSoundfont(FallbackSoundfont);
 
@@ -252,8 +252,8 @@ internal sealed partial class MidiManager : IMidiManager
 
                     try
                     {
+                        _midiSawmill.Debug($"Loading OS soundfont {filepath}");
                         renderer.LoadSoundfont(filepath);
-                        _midiSawmill.Debug($"Loaded Linux soundfont {filepath}");
                     }
                     catch (Exception)
                     {
@@ -267,7 +267,7 @@ internal sealed partial class MidiManager : IMidiManager
             {
                 if (File.Exists(OsxSoundfont) && SoundFont.IsSoundFont(OsxSoundfont))
                 {
-                    _midiSawmill.Debug($"Loading soundfont {OsxSoundfont}");
+                    _midiSawmill.Debug($"Loading OS soundfont {OsxSoundfont}");
                     renderer.LoadSoundfont(OsxSoundfont);
                 }
             }
@@ -275,7 +275,7 @@ internal sealed partial class MidiManager : IMidiManager
             {
                 if (File.Exists(WindowsSoundfont) && SoundFont.IsSoundFont(WindowsSoundfont))
                 {
-                    _midiSawmill.Debug($"Loading soundfont {WindowsSoundfont}");
+                    _midiSawmill.Debug($"Loading OS soundfont {WindowsSoundfont}");
                     renderer.LoadSoundfont(WindowsSoundfont);
                 }
             }
@@ -286,27 +286,31 @@ internal sealed partial class MidiManager : IMidiManager
             {
                 if (File.Exists(soundfontOverride) && SoundFont.IsSoundFont(soundfontOverride))
                 {
-                    _midiSawmill.Debug($"Loading soundfont {soundfontOverride} from environment variable.");
+                    _midiSawmill.Debug($"Loading environment variable soundfont {soundfontOverride}");
                     renderer.LoadSoundfont(soundfontOverride);
                 }
             }
 
             // Load content-specific custom soundfonts, which should override the system/fallback soundfont.
-            _midiSawmill.Debug($"Loading soundfonts from {ContentCustomSoundfontDirectory}");
+            _midiSawmill.Debug($"Loading soundfonts from content directory {ContentCustomSoundfontDirectory}");
             foreach (var file in _resourceManager.ContentFindFiles(ContentCustomSoundfontDirectory))
             {
                 if (file.Extension != "sf2" && file.Extension != "dls" && file.Extension != "sf3") continue;
-                _midiSawmill.Debug($"Loading soundfont {file}");
+                _midiSawmill.Debug($"Loading content soundfont {file}");
                 renderer.LoadSoundfont(file.ToString());
             }
 
+            var userDataPath = _resourceManager.UserData.RootDir == null
+                ? CustomSoundfontDirectory
+                : new ResPath(_resourceManager.UserData.RootDir) / CustomSoundfontDirectory.ToRelativePath();
+
             // Load every soundfont from the user data directory last, since those may override any other soundfont.
-            _midiSawmill.Debug($"Loading soundfonts from {{USERDATA}} {CustomSoundfontDirectory}");
+            _midiSawmill.Debug($"Loading soundfonts from user data directory {userDataPath}");
             var enumerator = _resourceManager.UserData.Find($"{CustomSoundfontDirectory.ToRelativePath()}/*").Item1;
             foreach (var file in enumerator)
             {
                 if (file.Extension != "sf2" && file.Extension != "dls" && file.Extension != "sf3") continue;
-                _midiSawmill.Debug($"Loading soundfont {{USERDATA}} {file}");
+                _midiSawmill.Debug($"Loading user soundfont {{USERDATA}} {file}");
                 renderer.LoadSoundfont(file.ToString());
             }
 

--- a/Robust.Client/Audio/Midi/MidiManager.cs
+++ b/Robust.Client/Audio/Midi/MidiManager.cs
@@ -416,7 +416,12 @@ internal sealed partial class MidiManager : IMidiManager
                 {
                     var renderer = _renderers[i];
                     if (!renderer.Disposed)
+                    {
+                        if (renderer.Master is { Disposed: true })
+                            renderer.Master = null;
+
                         renderer.Render();
+                    }
                     else
                     {
                         renderer.InternalDispose();

--- a/Robust.Client/Audio/Midi/MidiManager.cs
+++ b/Robust.Client/Audio/Midi/MidiManager.cs
@@ -190,7 +190,7 @@ internal sealed partial class MidiManager : IMidiManager
             _settings["synth.lock-memory"].IntValue = 0;
             _settings["synth.threadsafe-api"].IntValue = 1;
             _settings["synth.gain"].DoubleValue = 1.0d;
-            _settings["synth.polyphony"].IntValue = 1024;
+            _settings["synth.polyphony"].IntValue = Math.Min(1024 + (int)(Math.Log2(_parallel.ParallelProcessCount) * 2048), 65535);
             _settings["synth.cpu-cores"].IntValue = _parallel.ParallelProcessCount;
             _settings["synth.midi-channels"].IntValue = 16;
             _settings["synth.overflow.age"].DoubleValue = 3000;

--- a/Robust.Client/Audio/Midi/MidiRenderer.cs
+++ b/Robust.Client/Audio/Midi/MidiRenderer.cs
@@ -200,7 +200,7 @@ internal sealed class MidiRenderer : IMidiRenderer
     public EntityUid? TrackingEntity { get; set; } = null;
 
     [ViewVariables(VVAccess.ReadWrite)]
-    public EntityCoordinates? TrackingCoordinates { get; set; } = null;
+    public MapCoordinates? TrackingCoordinates { get; set; } = null;
 
     [ViewVariables]
     public BitArray FilteredChannels { get; } = new(RobustMidiEvent.MaxChannels);

--- a/Robust.Client/Audio/Midi/MidiRenderer.cs
+++ b/Robust.Client/Audio/Midi/MidiRenderer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using JetBrains.Annotations;
 using NFluidsynth;
 using Robust.Client.Graphics;
 using Robust.Shared.Asynchronous;
@@ -238,6 +239,9 @@ internal sealed class MidiRenderer : IMidiRenderer
             MidiBank = _midiBank;
         }
     }
+
+    [ViewVariables, UsedImplicitly]
+    private double CpuLoad => !_synth.Disposed ? _synth.CpuLoad : 0;
 
     public event Action<RobustMidiEvent>? OnMidiEvent;
     public event Action? OnMidiPlayerFinished;

--- a/Robust.Client/Audio/Midi/MidiRenderer.cs
+++ b/Robust.Client/Audio/Midi/MidiRenderer.cs
@@ -188,6 +188,14 @@ internal sealed class MidiRenderer : IMidiRenderer
     }
 
     [ViewVariables(VVAccess.ReadWrite)]
+    [Obsolete($"Use {nameof(VelocityOverride)} instead, you can set it to 127 to achieve the same effect.")]
+    public bool VolumeBoost
+    {
+        get => VelocityOverride == 127;
+        set => VelocityOverride = value ? 127 : null;
+    }
+
+    [ViewVariables(VVAccess.ReadWrite)]
     public EntityUid? TrackingEntity { get; set; } = null;
 
     [ViewVariables(VVAccess.ReadWrite)]

--- a/Robust.Client/Audio/Midi/MidiRendererState.cs
+++ b/Robust.Client/Audio/Midi/MidiRendererState.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using Robust.Shared.Utility;
+using Robust.Shared.ViewVariables;
 
 namespace Robust.Client.Audio.Midi;
 
@@ -12,7 +13,7 @@ public struct MidiRendererState
     internal FixedArray16<byte> ChannelPressure;
     internal FixedArray16<ushort> PitchBend;
 
-    internal Span<byte> AsSpan => MemoryMarshal.CreateSpan(ref NoteVelocities._00._00, 4160);
+    [ViewVariables] internal Span<byte> AsSpan => MemoryMarshal.CreateSpan(ref NoteVelocities._00._00, 4160);
 
     static unsafe MidiRendererState()
     {

--- a/Robust.Client/UserInterface/Controls/ItemList.cs
+++ b/Robust.Client/UserInterface/Controls/ItemList.cs
@@ -448,7 +448,8 @@ namespace Robust.Client.UserInterface.Controls
                 {
                     if (item.Selected && SelectMode != ItemListSelectMode.Button)
                     {
-                        ClearSelected();
+                        if(SelectMode != ItemListSelectMode.Multiple)
+                            ClearSelected();
                         item.Selected = false;
                         return;
                     }

--- a/Robust.Client/UserInterface/Controls/ItemList.cs
+++ b/Robust.Client/UserInterface/Controls/ItemList.cs
@@ -88,9 +88,9 @@ namespace Robust.Client.UserInterface.Controls
                 _scrollBar.MoveToEnd();
         }
 
-        public Item AddItem(string text, Texture? icon = null, bool selectable = true)
+        public Item AddItem(string text, Texture? icon = null, bool selectable = true, object? metadata = null)
         {
-            var item = new Item(this) {Text = text, Icon = icon, Selectable = selectable};
+            var item = new Item(this) {Text = text, Icon = icon, Selectable = selectable, Metadata = metadata};
             Add(item);
             return item;
         }

--- a/Robust.Shared/Audio/Midi/RobustMidiEvent.cs
+++ b/Robust.Shared/Audio/Midi/RobustMidiEvent.cs
@@ -9,6 +9,8 @@ namespace Robust.Shared.Audio.Midi
     [Serializable, NetSerializable]
     public readonly struct RobustMidiEvent
     {
+        public const int MaxChannels = 16;
+
         #region Data
 
         /// <summary>
@@ -46,6 +48,17 @@ namespace Robust.Shared.Audio.Midi
             Status = status;
             Data1 = data1;
             Data2 = data2;
+            Tick = tick;
+        }
+
+        /// <summary>
+        ///     Clones another event but with a different tick value.
+        /// </summary>
+        public RobustMidiEvent(RobustMidiEvent ev, uint tick)
+        {
+            Status = ev.Status;
+            Data1 = ev.Data1;
+            Data2 = ev.Data2;
             Tick = tick;
         }
 

--- a/Robust.Shared/Audio/Midi/RobustMidiEvent.cs
+++ b/Robust.Shared/Audio/Midi/RobustMidiEvent.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Robust.Shared.Serialization;
 
 namespace Robust.Shared.Audio.Midi
@@ -10,6 +11,7 @@ namespace Robust.Shared.Audio.Midi
     public readonly struct RobustMidiEvent
     {
         public const int MaxChannels = 16;
+        public const int PercussionChannel = 9;
 
         #region Data
 

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1262,7 +1262,7 @@ namespace Robust.Shared
             CVarDef.Create("midi.min_renderers_parallel_update", 3, CVar.CLIENTONLY | CVar.ARCHIVE);
 
         public static readonly CVarDef<float> MidiPositionUpdateDelay =
-            CVarDef.Create("midi.occlusion_update_delay", 0.25f, CVar.CLIENTONLY | CVar.ARCHIVE);
+            CVarDef.Create("midi.position_update_delay", 0.25f, CVar.CLIENTONLY | CVar.ARCHIVE);
 
         public static readonly CVarDef<float> MidiOcclusionUpdateDelay =
             CVarDef.Create("midi.occlusion_update_delay", 0.75f, CVar.CLIENTONLY | CVar.ARCHIVE);

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1258,6 +1258,15 @@ namespace Robust.Shared
         public static readonly CVarDef<float> MidiVolume =
             CVarDef.Create("midi.volume", 0f, CVar.CLIENTONLY | CVar.ARCHIVE);
 
+        public static readonly CVarDef<int> MidiMinRendererParallel =
+            CVarDef.Create("midi.min_renderers_parallel_update", 3, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+        public static readonly CVarDef<float> MidiPositionUpdateDelay =
+            CVarDef.Create("midi.occlusion_update_delay", 0.25f, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+        public static readonly CVarDef<float> MidiOcclusionUpdateDelay =
+            CVarDef.Create("midi.occlusion_update_delay", 0.75f, CVar.CLIENTONLY | CVar.ARCHIVE);
+
         /*
          * HUB
          * CVars related to public master server hub

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1268,10 +1268,10 @@ namespace Robust.Shared
             CVarDef.Create("midi.min_renderers_parallel_update", 3, CVar.CLIENTONLY | CVar.ARCHIVE);
 
         public static readonly CVarDef<float> MidiPositionUpdateDelay =
-            CVarDef.Create("midi.position_update_delay", 0.25f, CVar.CLIENTONLY | CVar.ARCHIVE);
+            CVarDef.Create("midi.position_update_delay", 0.125f, CVar.CLIENTONLY | CVar.ARCHIVE);
 
         public static readonly CVarDef<float> MidiOcclusionUpdateDelay =
-            CVarDef.Create("midi.occlusion_update_delay", 0.75f, CVar.CLIENTONLY | CVar.ARCHIVE);
+            CVarDef.Create("midi.occlusion_update_delay", 0.25f, CVar.CLIENTONLY | CVar.ARCHIVE);
 
         /*
          * HUB

--- a/Robust.Shared/ContentPack/Sandbox.yml
+++ b/Robust.Shared/ContentPack/Sandbox.yml
@@ -305,6 +305,7 @@ Types:
     ConcurrentQueue`1: { All: True }
     ConcurrentStack`1: { All: True }
   System.Collections:
+    BitArray: { All: True }
     IEnumerable: { All: True }
     IEnumerator: { All: True }
     IReadOnlyList`1: { All: True }


### PR DESCRIPTION
Required by https://github.com/space-wizards/space-station-14/pull/17995
- Add a Master property to MidiRenderer, which allows it to clone all events from another renderer.
- Add a property to filter out notes in selected MIDI channels.
- Some fixes with MidiBank and stuff--
- Fixes ItemList selection breaking with "Multiple" mode. Turns out there was no other code in the codebase using the "multiple" mode...