### PR TITLE
PixelToMap

### DIFF
--- a/Robust.Client/Console/Commands/Debug.cs
+++ b/Robust.Client/Console/Commands/Debug.cs
@@ -630,7 +630,7 @@ namespace Robust.Client.Console.Commands
 
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            var mousePos = _eye.ScreenToMap(_input.MouseScreenPosition);
+            var mousePos = _eye.PixelToMap(_input.MouseScreenPosition);
 
             if (!_map.TryFindGridAt(mousePos, out var gridUid, out var grid))
             {

--- a/Robust.Client/Debugging/DebugAnchoringSystem.cs
+++ b/Robust.Client/Debugging/DebugAnchoringSystem.cs
@@ -61,7 +61,7 @@ namespace Robust.Client.Debugging
             }
 
             var mouseSpot = _inputManager.MouseScreenPosition;
-            var spot = _eyeManager.ScreenToMap(mouseSpot);
+            var spot = _eyeManager.PixelToMap(mouseSpot);
 
             if (!_mapManager.TryFindGridAt(spot, out var gridUid, out var grid))
             {

--- a/Robust.Client/Debugging/DebugPhysicsSystem.cs
+++ b/Robust.Client/Debugging/DebugPhysicsSystem.cs
@@ -371,7 +371,7 @@ namespace Robust.Client.Debugging
             if ((_debugPhysicsSystem.Flags & PhysicsDebugFlags.ShapeInfo) != 0x0)
             {
                 var hoverBodies = new List<PhysicsComponent>();
-                var bounds = Box2.UnitCentered.Translated(_eyeManager.ScreenToMap(mousePos.Position).Position);
+                var bounds = Box2.UnitCentered.Translated(_eyeManager.PixelToMap(mousePos.Position).Position);
 
                 foreach (var physBody in _physicsSystem.GetCollidingEntities(mapId, bounds))
                 {
@@ -404,7 +404,7 @@ namespace Robust.Client.Debugging
 
             if ((_debugPhysicsSystem.Flags & PhysicsDebugFlags.Distance) != 0x0)
             {
-                var mapPos = _eyeManager.ScreenToMap(mousePos);
+                var mapPos = _eyeManager.PixelToMap(mousePos);
 
                 if (mapPos.MapId != args.MapId)
                     return;

--- a/Robust.Client/Graphics/ClientEye/EyeManager.cs
+++ b/Robust.Client/Graphics/ClientEye/EyeManager.cs
@@ -24,6 +24,7 @@ namespace Robust.Client.Graphics
         [Dependency] private readonly IClyde _displayManager = default!;
         [Dependency] private readonly IEntityManager _entityManager = default!;
         [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
+        private ISawmill _logMill = default!;
 
         // We default to this when we get set to a null eye.
         private readonly FixedEye _defaultEye = new();
@@ -53,6 +54,7 @@ namespace Robust.Client.Graphics
         void IEyeManager.Initialize()
         {
             MainViewport = _uiManager.MainViewport;
+            _logMill = IoCManager.Resolve<ILogManager>().RootSawmill;
         }
 
         /// <inheritdoc />
@@ -129,14 +131,14 @@ namespace Robust.Client.Graphics
         /// <inheritdoc />
         public ScreenCoordinates CoordinatesToScreen(EntityCoordinates point)
         {
-            return MapToScreen(point.ToMap(_entityManager));
+            return MapToScreen(point.ToMap(_entityManager, _entityManager.System<SharedTransformSystem>()));
         }
 
         public ScreenCoordinates MapToScreen(MapCoordinates point)
         {
             if (CurrentEye.Position.MapId != point.MapId)
             {
-                Logger.Error($"Attempted to convert map coordinates ({point}) to screen coordinates with an eye on another map ({CurrentEye.Position.MapId})");
+                _logMill.Error($"Attempted to convert map coordinates ({point}) to screen coordinates with an eye on another map ({CurrentEye.Position.MapId})");
                 return new(default, WindowId.Invalid);
             }
 
@@ -146,18 +148,31 @@ namespace Robust.Client.Graphics
         /// <inheritdoc />
         public MapCoordinates ScreenToMap(ScreenCoordinates point)
         {
-            var (pos, window) = point;
-
             if (_uiManager.MouseGetControl(point) is not IViewportControl viewport)
                 return default;
 
-            return viewport.ScreenToMap(pos);
+            return viewport.ScreenToMap(point.Position);
         }
 
         /// <inheritdoc />
         public MapCoordinates ScreenToMap(Vector2 point)
         {
             return MainViewport.ScreenToMap(point);
+        }
+
+        /// <inheritdoc />
+        public MapCoordinates PixelToMap(ScreenCoordinates point)
+        {
+            if (_uiManager.MouseGetControl(point) is not IViewportControl viewport)
+                return default;
+
+            return viewport.PixelToMap(point.Position);
+        }
+
+        /// <inheritdoc />
+        public MapCoordinates PixelToMap(Vector2 point)
+        {
+            return MainViewport.PixelToMap(point);
         }
     }
 

--- a/Robust.Client/Graphics/ClientEye/IEyeManager.cs
+++ b/Robust.Client/Graphics/ClientEye/IEyeManager.cs
@@ -79,6 +79,16 @@ namespace Robust.Client.Graphics
         /// <returns>Corresponding point in the world.</returns>
         MapCoordinates ScreenToMap(Vector2 point);
 
+        /// <summary>
+        /// Similar to <see cref="ScreenToMap(ScreenCoordinates)"/>, except it should compensate for the effects of shaders on viewports.
+        /// </summary>
+        MapCoordinates PixelToMap(ScreenCoordinates point);
+
+        /// <summary>
+        /// Similar to <see cref="ScreenToMap(Vector2)"/>, except it should compensate for the effects of shaders on viewports.
+        /// </summary>
+        MapCoordinates PixelToMap(Vector2 point);
+
         void ClearCurrentEye();
         void Initialize();
     }

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -532,7 +532,7 @@ namespace Robust.Client.Placement
                     return false;
                 }
                 coordinates = EntityCoordinates.FromMap(MapManager,
-                                                        EyeManager.ScreenToMap(InputManager.MouseScreenPosition));
+                                                        EyeManager.PixelToMap(InputManager.MouseScreenPosition));
                 return true;
             }
         }

--- a/Robust.Client/Placement/PlacementMode.cs
+++ b/Robust.Client/Placement/PlacementMode.cs
@@ -134,7 +134,7 @@ namespace Robust.Client.Placement
         public IEnumerable<EntityCoordinates> LineCoordinates()
         {
             var mouseScreen = pManager.InputManager.MouseScreenPosition;
-            var mousePos = pManager.EyeManager.ScreenToMap(mouseScreen);
+            var mousePos = pManager.EyeManager.PixelToMap(mouseScreen);
 
             if (mousePos.MapId == MapId.Nullspace)
                 yield break;
@@ -165,7 +165,7 @@ namespace Robust.Client.Placement
         public IEnumerable<EntityCoordinates> GridCoordinates()
         {
             var mouseScreen = pManager.InputManager.MouseScreenPosition;
-            var mousePos = pManager.EyeManager.ScreenToMap(mouseScreen);
+            var mousePos = pManager.EyeManager.PixelToMap(mouseScreen);
 
             if (mousePos.MapId == MapId.Nullspace)
                 yield break;
@@ -254,7 +254,7 @@ namespace Robust.Client.Placement
 
         protected EntityCoordinates ScreenToCursorGrid(ScreenCoordinates coords)
         {
-            var mapCoords = pManager.EyeManager.ScreenToMap(coords.Position);
+            var mapCoords = pManager.EyeManager.PixelToMap(coords.Position);
             if (!pManager.MapManager.TryFindGridAt(mapCoords, out var gridUid, out var grid))
             {
                 return EntityCoordinates.FromMap(pManager.MapManager, mapCoords);

--- a/Robust.Client/UserInterface/CustomControls/DebugMonitorControls/DebugCoordsPanel.cs
+++ b/Robust.Client/UserInterface/CustomControls/DebugMonitorControls/DebugCoordsPanel.cs
@@ -65,7 +65,7 @@ namespace Robust.Client.UserInterface.CustomControls.DebugMonitorControls
             EntityCoordinates mouseGridPos;
             TileRef tile;
 
-            var mouseWorldMap = _eyeManager.ScreenToMap(mouseScreenPos);
+            var mouseWorldMap = _eyeManager.PixelToMap(mouseScreenPos);
             if (mouseWorldMap == MapCoordinates.Nullspace)
                 return;
 

--- a/Robust.Client/UserInterface/CustomControls/IViewportControl.cs
+++ b/Robust.Client/UserInterface/CustomControls/IViewportControl.cs
@@ -25,6 +25,11 @@ namespace Robust.Client.UserInterface.CustomControls
         MapCoordinates ScreenToMap(Vector2 coords);
 
         /// <summary>
+        /// Similar to <see cref="ScreenToMap(Vector2)"/>, except it should compensate for the effects of shaders on viewports.
+        /// </summary>
+        MapCoordinates PixelToMap(Vector2 point);
+
+        /// <summary>
         ///     Converts a point on the map to screen coordinates.
         /// </summary>
         /// <returns>

--- a/Robust.Client/UserInterface/CustomControls/ProjectionEvents.cs
+++ b/Robust.Client/UserInterface/CustomControls/ProjectionEvents.cs
@@ -1,0 +1,34 @@
+using Robust.Client.Graphics;
+using Robust.Shared.GameObjects;
+using System.Numerics;
+
+namespace Robust.Client.UserInterface.CustomControls;
+
+/// <summary>
+/// An event used to reverse distortion effects applied by shaders.
+/// Used to find the map position that visible pixels originate from so that severe distortion shaders do not make interaction nigh-impossible.
+/// </summary>
+[ByRefEvent]
+public record struct PixelToMapEvent(Vector2 LocalPosition, IViewportControl Control, IClydeViewport Viewport)
+{
+    /// <summary>
+    /// The local position of the pixel within the <see cref="Control"/> that we are trying to convert to a map position.
+    /// </summary>
+    public readonly Vector2 LocalPosition = LocalPosition;
+
+    /// <summary>
+    /// The original (or WIP) location of the pixel within the <see cref="Control"/> that we are trying to convert to a map position.
+    /// Used as the output of the event.
+    /// </summary>
+    public Vector2 VisiblePosition = LocalPosition;
+
+    /// <summary>
+    /// The control the pixel we are considering is located within.
+    /// </summary>
+    public readonly IViewportControl Control = Control;
+
+    /// <summary>
+    /// The viewport being displayed by the control we are considering.
+    /// </summary>
+    public readonly IClydeViewport Viewport = Viewport;
+}


### PR DESCRIPTION
Creates alternative versions of the various `ScreenToMap` methods which allow shaders or other systems to adjust for visual distortions.
Applies it to everything which converts mouse positions to a map position.
Required for https://github.com/space-wizards/space-station-14/pull/13925