### PR TITLE
Run MapInit on pmanager entities

### DIFF
--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -694,6 +694,9 @@ namespace Robust.Client.Placement
             IsActive = true;
 
             CurrentPlacementOverlayEntity = EntityManager.SpawnEntity(templateName, MapCoordinates.Nullspace);
+            EntityManager.RunMapInit(
+                CurrentPlacementOverlayEntity.Value,
+                EntityManager.GetComponent<MetaDataComponent>(CurrentPlacementOverlayEntity.Value));
         }
 
         public void PreparePlacementSprite(SpriteComponent sprite)


### PR DESCRIPTION
Client doesn't actually run it for actual entities but it's useful for placementmanager to predict what they might look like after placement.