### PR TITLE
Set sawmill default to info on release

### DIFF
--- a/Robust.Shared/GameObjects/EntitySystem.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.cs
@@ -206,6 +206,10 @@ namespace Robust.Shared.GameObjects
         void IPostInjectInit.PostInject()
         {
             Log = LogManager.GetSawmill(SawmillName);
+
+#if !DEBUG
+            Log.Level = LogLevel.Info;
+#endif
         }
     }
 }


### PR DESCRIPTION
The new helper defaults to verbose but I only really care for that on debug mode; anyone that wants differently can just set it on system initialize.