### PR TITLE
Add warning for unhandled replay messages

### DIFF
--- a/Robust.Client/Replays/Playback/ReplayPlaybackManager.Update.cs
+++ b/Robust.Client/Replays/Playback/ReplayPlaybackManager.Update.cs
@@ -97,8 +97,8 @@ internal sealed partial class ReplayPlaybackManager
 
             if (message is EntityEventArgs args)
                 _entMan.DispatchReceivedNetworkMsg(args);
-            else
-                _sawmill.Warning($"Unhandled replay message: {message.GetType()}");
+            else if (_warned.Add(message.GetType()))
+                _sawmill.Error($"Unhandled replay message: {message.GetType()}.");
         }
     }
 }

--- a/Robust.Client/Replays/Playback/ReplayPlaybackManager.Update.cs
+++ b/Robust.Client/Replays/Playback/ReplayPlaybackManager.Update.cs
@@ -97,6 +97,8 @@ internal sealed partial class ReplayPlaybackManager
 
             if (message is EntityEventArgs args)
                 _entMan.DispatchReceivedNetworkMsg(args);
+            else
+                _sawmill.Warning($"Unhandled replay message: {message.GetType()}");
         }
     }
 }

--- a/Robust.Client/Replays/Playback/ReplayPlaybackManager.cs
+++ b/Robust.Client/Replays/Playback/ReplayPlaybackManager.cs
@@ -55,6 +55,7 @@ internal sealed partial class ReplayPlaybackManager : IReplayPlaybackManager
 
     private bool _initialized;
     private ISawmill _sawmill = default!;
+    private HashSet<Type> _warned = new();
 
     public bool Playing
     {


### PR DESCRIPTION
Added a warning, as its a sign that replay has some message recorded for replaying but the content client doesn't handle it for whatever reason. Related to space-wizards/space-station-14/pull/18299