### PR TITLE
Don't recreate _entTraitDict on disconnect

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -77,7 +77,10 @@ namespace Robust.Shared.GameObjects
             _netComponents.Clear();
             _entCompIndex.Clear();
             _deleteSet.Clear();
-            FillComponentDict();
+            foreach (var dict in _entTraitDict.Values)
+            {
+                dict.Clear();
+            }
         }
 
         private void AddComponentRefType(CompIdx type)


### PR DESCRIPTION
This was causing a bug where `MapManager._physicsQuery` and other entity queries introduced in #4185 (and possible other queries in other managers) pointed to an old component dictionary after disconecting & reconnecting to a server.

If for whatever reason this was required, then we need to stop caching entity queries outside of entity systems or somehow update them after calling `FillComponentDict()`.