### PR TITLE
Enables lightsample manipulation shenanigans

### DIFF
--- a/Robust.Client/Graphics/Clyde/Shaders/base-default.frag
+++ b/Robust.Client/Graphics/Clyde/Shaders/base-default.frag
@@ -12,9 +12,9 @@ void main()
 
     lowp vec4 COLOR;
 
-    // [SHADER_CODE]
-
     lowp vec3 lightSample = texture2D(lightMap, Pos).rgb;
+
+    // [SHADER_CODE]
 
     gl_FragColor = zAdjustResult(COLOR * VtxModulate * vec4(lightSample, 1.0));
 }


### PR DESCRIPTION
This PR is fairly straight-forward and self-explanatory; it moves the declaration of the `lightSample` variable in `base-default.frag` to be before the actual shader code. This, among other things, allows the `lightSample` var to be directly modified by shader code.

This PR is primarily intended for space-wizards/space-station-14#18343 , which uses this to make interaction outlines be influenced by the lightmap without affecting the rest of the object's rendering. However, this PR is likely to be useful even on it's own.

In theory this PR shouldn't affect anything, as there doesn't appear to be any code that directly modifies `lightMap` and expects `lightSample` to be declared at the very end of the shader (that would be hilariously inefficient, in all fairness). Any code that might exist that does indeed rely on the behavior would likely be extremely straight-forward to change