### PR TITLE
Use engine font instead of SS14-specific font in a few places.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -18,7 +18,7 @@ Don't change the format without looking at the script!
 
 ### Bugfixes
 
-*None yet*
+* Fix certain debug commands and tools crashing on non-SS14 RobustToolbox games due to a missing font.
 
 ### Other
 

--- a/Robust.Client/Debugging/DebugPhysicsSystem.cs
+++ b/Robust.Client/Debugging/DebugPhysicsSystem.cs
@@ -218,7 +218,7 @@ namespace Robust.Client.Debugging
             _debugPhysicsSystem = system;
             _lookup = lookup;
             _physicsSystem = physicsSystem;
-            _font = new VectorFont(cache.GetResource<FontResource>("/Fonts/NotoSans/NotoSans-Regular.ttf"), 10);
+            _font = new VectorFont(cache.GetResource<FontResource>("/EngineFonts/NotoSans/NotoSans-Regular.ttf"), 10);
         }
 
         private void DrawWorld(DrawingHandleWorld worldHandle, OverlayDrawArgs args)

--- a/Robust.Client/GameStates/NetEntityOverlay.cs
+++ b/Robust.Client/GameStates/NetEntityOverlay.cs
@@ -41,7 +41,7 @@ namespace Robust.Client.GameStates
         {
             IoCManager.InjectDependencies(this);
             var cache = IoCManager.Resolve<IResourceCache>();
-            _font = new VectorFont(cache.GetResource<FontResource>("/Fonts/NotoSans/NotoSans-Regular.ttf"), 10);
+            _font = new VectorFont(cache.GetResource<FontResource>("/EngineFonts/NotoSans/NotoSans-Regular.ttf"), 10);
             _lineHeight = _font.GetLineHeight(1);
 
             _gameStateManager.GameStateApplied += HandleGameStateApplied;

--- a/Robust.Client/GameStates/NetGraphOverlay.cs
+++ b/Robust.Client/GameStates/NetGraphOverlay.cs
@@ -53,7 +53,7 @@ namespace Robust.Client.GameStates
         {
             IoCManager.InjectDependencies(this);
             var cache = IoCManager.Resolve<IResourceCache>();
-            _font = new VectorFont(cache.GetResource<FontResource>("/Fonts/NotoSans/NotoSans-Regular.ttf"), 10);
+            _font = new VectorFont(cache.GetResource<FontResource>("/EngineFonts/NotoSans/NotoSans-Regular.ttf"), 10);
 
             _gameStateManager.GameStateApplied += HandleGameStateApplied;
         }

--- a/Robust.Client/Profiling/LiveProfileViewControl.cs
+++ b/Robust.Client/Profiling/LiveProfileViewControl.cs
@@ -24,7 +24,7 @@ public sealed class LiveProfileViewControl : Control
     {
         IoCManager.InjectDependencies(this);
 
-        if (!_resourceCache.TryGetResource<FontResource>("/Fonts/NotoSans/NotoSans-Regular.ttf", out var font))
+        if (!_resourceCache.TryGetResource<FontResource>("/EngineFonts/NotoSans/NotoSans-Regular.ttf", out var font))
             return;
 
         _font = font.MakeDefault();

--- a/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceEntity.cs
+++ b/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceEntity.cs
@@ -88,7 +88,7 @@ namespace Robust.Client.ViewVariables.Instances
                 var stringified = PrettyPrint.PrintUserFacingWithType(obj, out var typeStringified);
                 if (typeStringified != "")
                 {
-                    //var smallFont = new VectorFont(_resourceCache.GetResource<FontResource>("/Fonts/CALIBRI.TTF"), 10);
+                    //var smallFont = new VectorFont(_resourceCache.GetResource<FontResource>("/EngineFonts/NotoSans/NotoSans-Regular.ttf"), 10);
                     // Custom ToString() implementation.
                     var headBox = new BoxContainer
                     {

--- a/Robust.Client/ViewVariables/ViewVariablesInstance.cs
+++ b/Robust.Client/ViewVariables/ViewVariablesInstance.cs
@@ -121,7 +121,7 @@ namespace Robust.Client.ViewVariables
             }
 
             //var smallFont =
-            //    new VectorFont(IoCManager.Resolve<IResourceCache>().GetResource<FontResource>("/Fonts/CALIBRI.TTF"),
+            //    new VectorFont(IoCManager.Resolve<IResourceCache>().GetResource<FontResource>("/EngineFonts/NotoSans/NotoSans-Regular.ttf"),
             //        10);
 
             // Custom ToString() implementation.

--- a/Robust.Client/ViewVariables/ViewVariablesPropertyControl.cs
+++ b/Robust.Client/ViewVariables/ViewVariablesPropertyControl.cs
@@ -57,7 +57,7 @@ namespace Robust.Client.ViewVariables
             };
             VBox.AddChild(BottomContainer);
 
-            //var smallFont = new VectorFont(_resourceCache.GetResource<FontResource>("/Fonts/CALIBRI.TTF"), 10);
+            //var smallFont = new VectorFont(_resourceCache.GetResource<FontResource>("/EngineFonts/NotoSans/NotoSans-Regular.ttf"), 10);
 
             _bottomLabel = new Label
             {


### PR DESCRIPTION
Fixes certain debug tools/commands in non-SS14 games.