### PR TITLE
Fix enum serialization

### DIFF
--- a/Robust.Client/GameController/GameController.cs
+++ b/Robust.Client/GameController/GameController.cs
@@ -33,6 +33,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Profiling;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Reflection;
 using Robust.Shared.Replays;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager;
@@ -85,6 +86,7 @@ namespace Robust.Client
         [Dependency] private readonly IReplayLoadManager _replayLoader = default!;
         [Dependency] private readonly IReplayPlaybackManager _replayPlayback = default!;
         [Dependency] private readonly IReplayRecordingManagerInternal _replayRecording = default!;
+        [Dependency] private readonly IReflectionManager _reflectionManager = default!;
 
         private IWebViewManagerHook? _webViewHook;
 
@@ -162,6 +164,7 @@ namespace Robust.Client
             // before prototype load.
             ProgramShared.FinishCheckBadFileExtensions(checkBadExtensions);
 
+            _reflectionManager.Initialize();
             _prototypeManager.Initialize();
             _prototypeManager.LoadDefaultPrototypes();
             _prototypeManager.ResolveResults();

--- a/Robust.Server/BaseServer.cs
+++ b/Robust.Server/BaseServer.cs
@@ -30,6 +30,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Profiling;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Reflection;
 using Robust.Shared.Replays;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager;
@@ -101,6 +102,7 @@ namespace Robust.Server
         [Dependency] private readonly IReplayRecordingManagerInternal _replay = default!;
         [Dependency] private readonly IGamePrototypeLoadManager _protoLoadMan = default!;
         [Dependency] private readonly NetworkResourceManager _netResMan = default!;
+        [Dependency] private readonly IReflectionManager _refMan = default!;
 
         private readonly Stopwatch _uptimeStopwatch = new();
 
@@ -367,6 +369,7 @@ namespace Robust.Server
             _prototype.Initialize();
             _prototype.LoadDefaultPrototypes();
             _prototype.ResolveResults();
+            _refMan.Initialize();
 
             _consoleHost.Initialize();
             _entityManager.Startup();

--- a/Robust.Shared/Reflection/IReflectionManager.cs
+++ b/Robust.Shared/Reflection/IReflectionManager.cs
@@ -119,5 +119,7 @@ namespace Robust.Shared.Reflection
 
         Type? YamlTypeTagLookup(Type baseType, string typeName);
         IEnumerable<Type> FindAllTypes();
+
+        void Initialize();
     }
 }

--- a/Robust.Shared/Serialization/Manager/SerializationManager.Reading.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.Reading.cs
@@ -278,6 +278,10 @@ namespace Robust.Shared.Serialization.Manager
             }
             else if (actualType.IsEnum)
             {
+                // Does not include cases where the target type is System.Enum.
+                // Those get handled by the generic enum serializer which uses reflection to resolve strings into enums.
+                DebugTools.Assert(actualType != typeof(Enum));
+
                 if (nodeType == typeof(ValueDataNode))
                 {
                     call = Expression.Call(managerConst, nameof(ReadEnumValue), new[] { actualType },

--- a/Robust.Shared/Serialization/Manager/SerializationManager.Validation.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.Validation.cs
@@ -66,6 +66,10 @@ public sealed partial class SerializationManager
             }
             else if (key.type.IsEnum)
             {
+                // Does not include cases where the target type is System.Enum.
+                // Those get handled by the generic enum serializer which uses reflection to resolve strings into enums.
+                DebugTools.Assert(key.type != typeof(Enum));
+
                 call = Expression.Call(
                     managerConst,
                     nameof(ValidateEnum),

--- a/Robust.Shared/Serialization/Manager/SerializationManager.Writing.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.Writing.cs
@@ -95,7 +95,7 @@ public sealed partial class SerializationManager
                 // When writing generic enums, we want to use the enum serializer.
                 // Otherwise, we fall back to the default IConvertible behaviour.
 
-                if (baseType == actualType ||
+                if (baseType != typeof(Enum) ||
                     !serializationManager._regularSerializerProvider.TryGetTypeSerializer(typeof(ITypeWriter<>),
                         typeof(Enum), out serializer))
                 {

--- a/Robust.Shared/Serialization/Manager/SerializationManager.Writing.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.Writing.cs
@@ -92,13 +92,33 @@ public sealed partial class SerializationManager
             }
             else if (actualType.IsEnum)
             {
-                // Enums implement IConvertible.
-                // Need it for the culture overload.
-                call = Expression.Call(
-                    instanceParam,
-                    nameof(WriteConvertible),
-                    Type.EmptyTypes,
-                    Expression.Convert(objParam, typeof(IConvertible)));
+                // When writing generic enums, we want to use the enum serializer.
+                // Otherwise, we fall back to the default IConvertible behaviour.
+
+                if (baseType == actualType ||
+                    !serializationManager._regularSerializerProvider.TryGetTypeSerializer(typeof(ITypeWriter<>),
+                        typeof(Enum), out serializer))
+                {
+                    call = Expression.Call(
+                        instanceParam,
+                        nameof(WriteConvertible),
+                        Type.EmptyTypes,
+                        Expression.Convert(objParam, typeof(IConvertible)));
+                }
+                else
+                {
+                    var serializerConst = Expression.Constant(serializer);
+                    call = Expression.Call(
+                        instanceParam,
+                        nameof(WriteValue),
+                        new []{typeof(Enum)},
+                        serializerConst,
+                        Expression.Convert(objParam, typeof(Enum)),
+                        alwaysWriteParam,
+                        contextParam,
+                        Expression.Constant(notNullableOverride)
+                    );
+                }
             }
             else if (actualType.IsArray)
             {

--- a/Robust.UnitTesting/RobustUnitTest.cs
+++ b/Robust.UnitTesting/RobustUnitTest.cs
@@ -70,6 +70,7 @@ namespace Robust.UnitTesting
             var configurationManager = deps.Resolve<IConfigurationManagerInternal>();
 
             configurationManager.Initialize(Project == UnitTestProject.Server);
+            deps.Resolve<IReflectionManager>().Initialize();
 
             foreach (var assembly in assemblies)
             {


### PR DESCRIPTION
Currently `System.Enum` datafields get serialized incorrectly. E.g., when serializing `BodyType.Static` it simply always writes "Static" whereas it should write "enum.BodyType.Static", which is what is expected when reading & validating yaml.

I have no idea how long its been broken or how the game keeps running.

Also fixes a some bugs in `IReflectionManager`:
- `GetEnumReference()` could attempt to open a read lock while inside of a write lock.
- `GetEnumReference()` was caching strings with the "enum." prefix, while `TryParse()` was caching them without the prefix.
- Adds actual warnings when conflicting enum references get added E.g., two different strings with different levels of specificity. 