### PR TITLE
Add DataNode.ToString()

### DIFF
--- a/Robust.Shared/Serialization/Markdown/DataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/DataNode.cs
@@ -1,4 +1,7 @@
+using System.IO;
 using Robust.Shared.Serialization.Manager;
+using YamlDotNet.Core;
+using YamlDotNet.RepresentationModel;
 
 namespace Robust.Shared.Serialization.Markdown
 {
@@ -30,6 +33,20 @@ namespace Robust.Shared.Serialization.Markdown
         public T CopyCast<T>() where T : DataNode
         {
             return (T) Copy();
+        }
+
+        public void Write(TextWriter writer)
+        {
+            var yaml = this.ToYamlNode();
+            var stream = new YamlStream { new(yaml) };
+            stream.Save(new YamlMappingFix(new Emitter(writer)), false);
+        }
+
+        public override string ToString()
+        {
+            StringWriter sw = new StringWriter();
+            Write(sw);
+            return sw.ToString();
         }
     }
 


### PR DESCRIPTION
Not sure if there was a reason that this wasn't implemented, but it makes it much easier to write yaml files and also makes debugging much nicer, as you can just inspect the contents of a mapping. E.g.:

![rider64_wFfaHSf2rf](https://github.com/space-wizards/RobustToolbox/assets/60421075/d822eb59-e8d9-4816-9117-be6bb3081c7e)
