### PR TITLE
Truncate discord rich presence strings

### DIFF
--- a/Robust.Client/Utility/DiscordRichPresence.cs
+++ b/Robust.Client/Utility/DiscordRichPresence.cs
@@ -2,7 +2,6 @@ using System;
 using System.Text;
 using DiscordRPC;
 using DiscordRPC.Logging;
-using Microsoft.VisualBasic;
 using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.IoC;

--- a/Robust.Client/Utility/DiscordRichPresence.cs
+++ b/Robust.Client/Utility/DiscordRichPresence.cs
@@ -1,5 +1,8 @@
+using System;
+using System.Text;
 using DiscordRPC;
 using DiscordRPC.Logging;
+using Microsoft.VisualBasic;
 using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.IoC;
@@ -95,18 +98,58 @@ namespace Robust.Client.Utility
 
         public void Update(string serverName, string username, string maxUsers, string users)
         {
-            _activePresence = new RichPresence
+            if (_client == null)
+                return;
+
+            try
             {
-                Details = _loc.GetString("discord-rpc-on-server", ("servername", serverName)),
-                State = _loc.GetString("discord-rpc-players", ("players", users), ("maxplayers", maxUsers)),
-                Assets = new Assets
+                var details = _loc.GetString("discord-rpc-on-server", ("servername", serverName));
+                var state = _loc.GetString("discord-rpc-players", ("players", users), ("maxplayers", maxUsers));
+                var imageText = _loc.GetString("discord-rpc-character", ("username", username));
+
+                // Strings are limited by byte count. See the setters in RichPresence. Hence the truncate calls.
+                _activePresence = new RichPresence
                 {
-                    LargeImageKey = "devstation",
-                    LargeImageText = _loc.GetString("discord-rpc-character", ("username", username)),
-                    SmallImageKey = "logo"
-                }
-            };
-            _client?.SetPresence(_activePresence);
+                    Details = Truncate(details, 128),
+                    State = Truncate(state, 128),
+                    Assets = new Assets
+                    {
+                        LargeImageKey = Truncate("devstation", 32),
+                        LargeImageText = Truncate(imageText, 128),
+                        SmallImageKey = Truncate("logo", 32)
+                    }
+                };
+                _client.SetPresence(_activePresence);
+            }
+            catch (Exception ex)
+            {
+                _client.Logger.Error($"Caught exception while updating discord rich presence. Exception:\n{ex}");
+            }
+        }
+
+        private string Truncate(string value, int bytes, string postfix = "...")
+            => Truncate(value, bytes, postfix, Encoding.UTF8);
+
+        /// <summary>
+        /// Truncate strings down to some minimum byte count. If the string gets truncated, it will have the postfix appended.
+        /// </summary>
+        private string Truncate(string value, int bytes, string postfix, Encoding encoding)
+        {
+            value = value.Trim();
+            var output = value;
+
+            // Theres probably a better way of doing this, but I don't know how.
+            // If this wasn't a crude hack this function should
+            while (encoding.GetByteCount(output) > bytes)
+            {
+                if (value.Length == 0)
+                    return string.Empty;
+
+                value = value.Substring(0, value.Length - 1);
+                output = value + postfix;
+            }
+
+            return output;
         }
 
         public void ClearPresence()


### PR DESCRIPTION
Stops exceptions from being thrown while applying game states.