### PR TITLE
Allow overriding joint relays

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedJointSystem.Relay.cs
+++ b/Robust.Shared/Physics/Systems/SharedJointSystem.Relay.cs
@@ -55,21 +55,32 @@ public abstract partial class SharedJointSystem
             if (Deleted(relay) || !_jointsQuery.TryGetComponent(relay, out var joint))
                 continue;
 
-            RefreshRelay(relay, joint);
+            RefreshRelay(relay, component: joint);
         }
     }
 
+    /// <summary>
+    /// Refreshes the joint relay for this entity, prefering its containing container or nothing.
+    /// </summary>
     public void RefreshRelay(EntityUid uid, JointComponent? component = null)
     {
-        if (!Resolve(uid, ref component))
-            return;
-
         EntityUid? relay = null;
 
         if (_container.TryGetOuterContainer(uid, Transform(uid), out var container))
         {
             relay = container.Owner;
         }
+
+        RefreshRelay(uid, relay, component);
+    }
+
+    /// <summary>
+    /// Refreshes the joint relay for this entity.
+    /// </summary>
+    public void RefreshRelay(EntityUid uid, EntityUid? relay, JointComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return;
 
         if (component.Relay == relay)
             return;


### PR DESCRIPTION
Content may wish to not default to containers.

I think I might revisit this whenever I cleanup the joints mess (and just make it apply for every non-grid / map parent change?) but for now this is the easiest way to fix some content stuff.