### PR TITLE
fix named toolshed command

### DIFF
--- a/Resources/Locale/en-US/toolshed-commands.ftl
+++ b/Resources/Locale/en-US/toolshed-commands.ftl
@@ -108,7 +108,7 @@ command-description-where =
 command-description-do =
     Backwards compatibility with BQL, applies the given old commands over the input sequence.
 command-description-named =
-    Filters the input entities by their name, with the regex $selector^.
+    Filters the input entities by their name, with the regex ^selector$.
 command-description-prototyped =
     Filters the input entities by their prototype.
 command-description-nearby =

--- a/Robust.Shared/Toolshed/Commands/Entities/NamedCommand.cs
+++ b/Robust.Shared/Toolshed/Commands/Entities/NamedCommand.cs
@@ -11,7 +11,7 @@ internal sealed class NamedCommand : ToolshedCommand
     [CommandImplementation]
     public IEnumerable<EntityUid> Named([PipedArgument] IEnumerable<EntityUid> input, [CommandArgument] string regex, [CommandInverted] bool inverted)
     {
-        var compiled = new Regex($"${regex}^");
+        var compiled = new Regex($"^{regex}$");
         return input.Where(x => compiled.IsMatch(EntName(x)) ^ inverted);
     }
 }


### PR DESCRIPTION
Today I webedit the engine. The regex was flipped. I have not tested this.