### PR TITLE
Error on duplicate broadcast subscriptions

### DIFF
--- a/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs
@@ -225,8 +225,10 @@ namespace Robust.Shared.GameObjects
             var inverseSubscription = _inverseEventSubscriptions.GetOrNew(subscriber);
             if (!inverseSubscription.TryAdd(eventType, subscriptionTuple))
             {
-                // Maybe this might need to be supported in future if we want to support separate local & network subs.
-                // For now, local+network broadcast subs break and don't unsubscribe properly.
+                // If this needs to be supported in the future, then event subscribing needs to be updated.
+                // Also, we need to ensure that separate local + network subs dont break anything. If the event handlers
+                // are identical, local+network subs should be combined into a single sub anyways. Separate subs are
+                // probably just erroneous.
                 var name = subscriber.GetType().Name;
                 throw new InvalidOperationException(
                     $"{name} attempted to subscribe twice to the same event: {eventType.Name}");

--- a/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs
@@ -223,8 +223,14 @@ namespace Robust.Shared.GameObjects
                 subscriptions.BroadcastRegistrations.Add(subscriptionTuple);
 
             var inverseSubscription = _inverseEventSubscriptions.GetOrNew(subscriber);
-            if (!inverseSubscription.ContainsKey(eventType))
-                inverseSubscription.Add(eventType, subscriptionTuple);
+            if (!inverseSubscription.TryAdd(eventType, subscriptionTuple))
+            {
+                // Maybe this might need to be supported in future if we want to support separate local & network subs.
+                // For now, local+network broadcast subs break and don't unsubscribe properly.
+                var name = subscriber.GetType().Name;
+                throw new InvalidOperationException(
+                    $"{name} attempted to subscribe twice to the same event: {eventType.Name}");
+            }
         }
 
         /// <inheritdoc />

--- a/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.SystemEvent.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.SystemEvent.cs
@@ -51,6 +51,27 @@ namespace Robust.UnitTesting.Shared.GameObjects
         }
 
         /// <summary>
+        /// Duplicate Event subscriptions are not allowed.
+        /// </summary>
+        [Test]
+        public void SubscribeEvent_DuplicateSubscription_Invalid()
+        {
+            // Arrange
+            var bus = BusFactory();
+            var subscriber = new TestEventSubscriber();
+
+            int delegateCallCount = 0;
+            void Handler(TestEventArgs ev) => delegateCallCount++;
+
+            // 2 subscriptions 1 handler
+            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, Handler);
+
+            Assert.Throws<InvalidOperationException>(() => bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, Handler));
+        }
+
+        // TODO if ever duplicate events are allowed, re-enable these tests.
+        /*
+        /// <summary>
         /// Unlike C# events, the set of event handler delegates is unique.
         /// Subscribing the same delegate multiple times will only call the handler once.
         /// </summary>
@@ -99,6 +120,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             Assert.That(delFooCount, Is.EqualTo(1));
             Assert.That(delBarCount, Is.EqualTo(1));
         }
+        */
 
         /// <summary>
         /// A subscriber's handlers are properly called only when the specified event type is raised.


### PR DESCRIPTION
This only applies when a single subscriber subscribes to the same event more than once. This is already not supported, but it just allows it to happen without any error which can introduce hidden bugs as events are not properly unsubscribed. E.g., after a client has disconnected and then reconnected to a sever. This currently causes some obscure bugs in integration tests.

Requires content PR: space-wizards/space-station-14/pull/18635