### PR TITLE
Allow replay loading to ignore some errors

### DIFF
--- a/Robust.Client/Replays/Loading/ReplayLoadManager.Implicit.cs
+++ b/Robust.Client/Replays/Loading/ReplayLoadManager.Implicit.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using Robust.Client.GameStates;
+using Robust.Shared;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -64,6 +66,18 @@ public sealed partial class ReplayLoadManager
             }
         }
 
-        throw new Exception("Missing metadata component");
+        if (!entState.ComponentChanges.HasContents)
+        {
+            // This shouldn't be possible, yet it has happened?
+            // TODO this should probably also throw an exception.
+            _sawmill.Error($"Encountered blank entity state? Entity: {entState.Uid}. Last modified: {entState.EntityLastModified}. Attempting to continue.");
+            return null;
+        }
+
+        if (!_confMan.GetCVar(CVars.ReplayIgnoreErrors))
+            throw new MissingMetadataException(entState.Uid);
+
+        _sawmill.Error($"Missing metadata component. Entity: {entState.Uid}. Last modified: {entState.EntityLastModified}.");
+        return null;
     }
 }

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1509,8 +1509,8 @@ namespace Robust.Shared
         public static readonly CVarDef<bool> ReplayDynamicalScrubbing = CVarDef.Create("replay.dynamical_scrubbing", true);
 
         /// <summary>
-        /// When recording replays,
-        /// should we attempt to make a valid content bundle that can be directly executed by the launcher?
+        /// When recording replays, should we attempt to make a valid content bundle that can be directly executed by
+        /// the launcher?
         /// </summary>
         /// <remarks>
         /// This requires the server's build information to be sufficiently filled out.
@@ -1518,6 +1518,16 @@ namespace Robust.Shared
         public static readonly CVarDef<bool> ReplayMakeContentBundle =
             CVarDef.Create("replay.make_content_bundle", true);
 
+        /// <summary>
+        /// If true, this will cause the replay client to ignore some errors while loading a replay file.
+        /// </summary>
+        /// <remarks>
+        /// This might make otherwise broken replays playable, but ignoring these errors is also very likely to
+        /// cause unexpected and confusing errors elsewhere. By default this is disabled so that users report the
+        /// original exception rather than sending people on a wild-goose chase to find a non-existent bug.
+        /// </remarks>
+        public static readonly CVarDef<bool> ReplayIgnoreErrors =
+            CVarDef.Create("replay.ignore_errors", false, CVar.CLIENTONLY | CVar.ARCHIVE);
         /*
          * CFG
          */


### PR DESCRIPTION
Also turns an empty-state exception into just an error log, as its currently stopping some replays from being loaded. 
I have no idea what causes it, but (for the replay I was testing) it seemed like the error could just be ignored?

Might be some entity that gets created and deleted in the same tick, but is somehow still sent in the game state? The entity in question didn't have logs associated with it on grafana.