### PR TITLE
Fix SpriteSpecifier yaml validator

### DIFF
--- a/Robust.Client/Serialization/ClientSpriteSpecifierSerializer.cs
+++ b/Robust.Client/Serialization/ClientSpriteSpecifierSerializer.cs
@@ -1,5 +1,4 @@
 using Robust.Client.ResourceManagement;
-using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Attributes;
@@ -29,7 +28,7 @@ public sealed class ClientSpriteSpecifierSerializer : SpriteSpecifierSerializer
         }
 
         var res = dependencies.Resolve<IResourceCache>();
-        var rsiPath = SpriteSpecifierSerializer.TextureRoot / valuePathNode.Value;
+        var rsiPath = TextureRoot / valuePathNode.Value;
         if (!res.TryGetResource(rsiPath, out RSIResource? resource))
         {
             return new ErrorNode(node, "Failed to load RSI");
@@ -40,6 +39,10 @@ public sealed class ClientSpriteSpecifierSerializer : SpriteSpecifierSerializer
             return new ErrorNode(node, "Invalid RSI state");
         }
 
-        return new ValidatedMappingNode(new());
+        return new ValidatedMappingNode(new()
+        {
+            { new ValidatedValueNode(new ValueDataNode("sprite")), new ValidatedValueNode(pathNode)},
+            { new ValidatedValueNode(new ValueDataNode("state")), new ValidatedValueNode(valueStateNode)},
+        });
     }
 }

--- a/Robust.Server/Serialization/ServerSpriteSpecifierSerializer.cs
+++ b/Robust.Server/Serialization/ServerSpriteSpecifierSerializer.cs
@@ -1,4 +1,3 @@
-using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Attributes;
@@ -34,7 +33,7 @@ public sealed class ServerSpriteSpecifierSerializer : SpriteSpecifierSerializer
         }
 
         var path = serializationManager.ValidateNode<ResPath>(
-            new ValueDataNode($"{SpriteSpecifierSerializer.TextureRoot / valuePathNode.Value}"), context);
+            new ValueDataNode($"{TextureRoot / valuePathNode.Value}"), context);
 
         if (path is ErrorNode) return path;
 
@@ -44,11 +43,15 @@ public sealed class ServerSpriteSpecifierSerializer : SpriteSpecifierSerializer
         // meta.json
 
         var statePath = serializationManager.ValidateNode<ResPath>(
-            new ValueDataNode($"{SpriteSpecifierSerializer.TextureRoot / valuePathNode.Value / valueStateNode.Value}.png"),
+            new ValueDataNode($"{TextureRoot / valuePathNode.Value / valueStateNode.Value}.png"),
             context);
 
         if (statePath is ErrorNode) return statePath;
 
-        return new ValidatedMappingNode(new());
+        return new ValidatedMappingNode(new()
+        {
+            { new ValidatedValueNode(new ValueDataNode("sprite")), new ValidatedValueNode(pathNode)},
+            { new ValidatedValueNode(new ValueDataNode("state")), new ValidatedValueNode(valueStateNode)},
+        });
     }
 }


### PR DESCRIPTION
The IncludeDataField attribute relies on the validated nodes being properly populated.