### PR TITLE
Remove IoCManager.Resolve calls in Resource.Load

### DIFF
--- a/Resources/EnginePrototypes/UserInterface/uiThemes.yml
+++ b/Resources/EnginePrototypes/UserInterface/uiThemes.yml
@@ -1,6 +1,6 @@
 ﻿- type: uiTheme
   id: Default
-  path: /Textures/Interface/Default
+  path: /Textures/Interface/Default/
   colors:
     # Root
     rootBackground: "#000000"

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -200,7 +200,6 @@ namespace Robust.Client.GameObjects
         private RSI? _baseRsi;
 
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("rsi", priority: 2)]
         public RSI? BaseRSI
         {
             get => _baseRsi;

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -167,7 +167,8 @@ namespace Robust.Client.GameObjects
 
         public bool TreeUpdateQueued { get; set; }
 
-        [DataField("layerDatums")]
+        [DataField("layerDatums",
+            priority:-1)] // Ensures that ISerializationHooks are run before this gets populated. Yes, this is very cursed.
         private List<PrototypeLayerData> LayerDatums
         {
             get

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -167,36 +167,6 @@ namespace Robust.Client.GameObjects
 
         public bool TreeUpdateQueued { get; set; }
 
-        [DataField("layerDatums")]
-        private List<PrototypeLayerData> LayerDatums
-        {
-            get
-            {
-                var layerDatums = new List<PrototypeLayerData>();
-                foreach (var layer in Layers)
-                {
-                    layerDatums.Add(layer.ToPrototypeData());
-                }
-
-                return layerDatums;
-            }
-            set
-            {
-                if (value == null) return;
-
-                Layers.Clear();
-                foreach (var layerDatum in value)
-                {
-                    AddLayer(layerDatum);
-                }
-
-                _layerMapShared = true;
-
-                QueueUpdateRenderTree();
-                QueueUpdateIsInert();
-            }
-        }
-
         private RSI? _baseRsi;
 
         [ViewVariables(VVAccess.ReadWrite)]
@@ -356,7 +326,16 @@ namespace Robust.Client.GameObjects
             if (layerDatums.Count != 0)
             {
                 LayerMap.Clear();
-                LayerDatums = layerDatums;
+                Layers.Clear();
+                foreach (var datum in layerDatums)
+                {
+                    AddLayer(datum);
+                }
+
+                _layerMapShared = true;
+
+                QueueUpdateRenderTree();
+                QueueUpdateIsInert();
             }
 
             UpdateLocalMatrix();

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -167,8 +167,7 @@ namespace Robust.Client.GameObjects
 
         public bool TreeUpdateQueued { get; set; }
 
-        [DataField("layerDatums",
-            priority:-1)] // Ensures that ISerializationHooks are run before this gets populated. Yes, this is very cursed.
+        [DataField("layerDatums")]
         private List<PrototypeLayerData> LayerDatums
         {
             get

--- a/Robust.Client/ResourceManagement/IResourceCache.cs
+++ b/Robust.Client/ResourceManagement/IResourceCache.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Robust.Client.Graphics;
 using Robust.Shared.ContentPack;
 using Robust.Shared.Utility;
 
@@ -40,5 +41,9 @@ namespace Robust.Client.ResourceManagement
         // Resource load callbacks so content can hook stuff like click maps.
         event Action<TextureLoadedEventArgs> OnRawTextureLoaded;
         event Action<RsiLoadedEventArgs> OnRsiLoaded;
+        
+        IClyde Clyde { get; }
+        IClydeAudio ClydeAudio { get; }
+        IFontManager FontManager { get; }
     }
 }

--- a/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
+++ b/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
@@ -18,7 +18,9 @@ namespace Robust.Client.ResourceManagement
 {
     internal partial class ResourceCache
     {
-        [Dependency] private readonly IClyde _clyde = default!;
+        [field: Dependency] public IClyde Clyde { get; } = default!;
+        [field: Dependency] public IClydeAudio ClydeAudio { get; } = default!;
+        [field: Dependency] public IFontManager FontManager { get; } = default!;
         [Dependency] private readonly ILogManager _logManager = default!;
         [Dependency] private readonly IConfigurationManager _configurationManager = default!;
 
@@ -70,7 +72,7 @@ namespace Robust.Client.ResourceManagement
 
                 try
                 {
-                    TextureResource.LoadTexture(_clyde, data);
+                    TextureResource.LoadTexture(Clyde, data);
                 }
                 catch (Exception e)
                 {
@@ -198,7 +200,7 @@ namespace Robust.Client.ResourceManagement
 
             void FinalizeMetaAtlas(int toIndex, Image<Rgba32> sheet)
             {
-                var atlas = _clyde.LoadTextureFromImage(sheet);
+                var atlas = Clyde.LoadTextureFromImage(sheet);
                 for (int i = finalized + 1; i <= toIndex; i++)
                 {
                     var rsi = rsiList[i];

--- a/Robust.Client/ResourceManagement/ResourceTypes/AudioResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/AudioResource.cs
@@ -20,14 +20,13 @@ namespace Robust.Client.ResourceManagement
 
             using (var fileStream = cache.ContentFileRead(path))
             {
-                var clyde = IoCManager.Resolve<IClydeAudio>();
                 if (path.Extension == "ogg")
                 {
-                    AudioStream = clyde.LoadAudioOggVorbis(fileStream, path.ToString());
+                    AudioStream = cache.ClydeAudio.LoadAudioOggVorbis(fileStream, path.ToString());
                 }
                 else if (path.Extension == "wav")
                 {
-                    AudioStream = clyde.LoadAudioWav(fileStream, path.ToString());
+                    AudioStream = cache.ClydeAudio.LoadAudioWav(fileStream, path.ToString());
                 }
                 else
                 {

--- a/Robust.Client/ResourceManagement/ResourceTypes/FontResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/FontResource.cs
@@ -18,7 +18,7 @@ namespace Robust.Client.ResourceManagement
 
             using (stream)
             {
-                FontFaceHandle = IoCManager.Resolve<IFontManagerInternal>().Load(stream);
+                FontFaceHandle = ((IFontManagerInternal)cache.FontManager).Load(stream);
             }
         }
 

--- a/Robust.Client/ResourceManagement/ResourceTypes/RSIResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/RSIResource.cs
@@ -34,12 +34,10 @@ namespace Robust.Client.ResourceManagement
 
         public override void Load(IResourceCache cache, ResPath path)
         {
-            var clyde = IoCManager.Resolve<IClyde>();
-
             var loadStepData = new LoadStepData {Path = path};
             LoadPreTexture(cache, loadStepData);
 
-            loadStepData.AtlasTexture = clyde.LoadTextureFromImage(
+            loadStepData.AtlasTexture = cache.Clyde.LoadTextureFromImage(
                 loadStepData.AtlasSheet,
                 loadStepData.Path.ToString());
 

--- a/Robust.Client/ResourceManagement/ResourceTypes/ShaderSourceResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/ShaderSourceResource.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Threading;
 using Robust.Client.Graphics;
+using Robust.Client.Graphics.Clyde;
 using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
 using Robust.Shared.Utility;
@@ -27,8 +28,7 @@ namespace Robust.Client.ResourceManagement
                 ParsedShader = ShaderParser.Parse(reader, cache);
             }
 
-            var clyde = IoCManager.Resolve<IClydeInternal>();
-            ClydeHandle = clyde.LoadShader(ParsedShader, path.ToString());
+            ClydeHandle = ((IClydeInternal)cache.Clyde).LoadShader(ParsedShader, path.ToString());
         }
 
         public override void Reload(IResourceCache cache, ResPath path, CancellationToken ct = default)
@@ -57,8 +57,7 @@ namespace Robust.Client.ResourceManagement
                 }
             }
 
-            var clyde = IoCManager.Resolve<IClydeInternal>();
-            clyde.ReloadShader(ClydeHandle, ParsedShader);
+            ((IClydeInternal)cache.Clyde).ReloadShader(ClydeHandle, ParsedShader);
         }
     }
 }

--- a/Robust.Client/ResourceManagement/ResourceTypes/TextureResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/TextureResource.cs
@@ -20,8 +20,6 @@ namespace Robust.Client.ResourceManagement
 
         public override void Load(IResourceCache cache, ResPath path)
         {
-            var clyde = IoCManager.Resolve<IClyde>();
-
             if (path.Directory.Filename.EndsWith(".rsi"))
             {
                 Logger.WarningS(
@@ -33,7 +31,7 @@ namespace Robust.Client.ResourceManagement
             var data = new LoadStepData {Path = path};
 
             LoadPreTexture(cache, data);
-            LoadTexture(clyde, data);
+            LoadTexture(cache.Clyde, data);
             LoadFinish(cache, data);
         }
 


### PR DESCRIPTION
Also makes minor fixes to `uiThemes.yml` and `SpriteComponent`. Required for tests to be able to validate some client prototypes.