### PR TITLE
More serialization related changes,

### DIFF
--- a/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
+++ b/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
@@ -20,7 +20,7 @@ namespace Robust.Client.Graphics
     public sealed class ShaderPrototype : IPrototype, ISerializationHooks
     {
         [ViewVariables]
-        [IdDataFieldAttribute]
+        [IdDataField]
         public string ID { get; } = default!;
 
         [ViewVariables] private ShaderKind Kind;
@@ -65,12 +65,12 @@ namespace Robust.Client.Graphics
 
                 case ShaderKind.Canvas:
 
-                    var hasLight = rawMode != "unshaded";
+                    var hasLight = _rawMode != "unshaded";
                     ShaderBlendMode? blend = null;
-                    if (rawBlendMode != null)
+                    if (_rawBlendMode != null)
                     {
-                        if (!Enum.TryParse<ShaderBlendMode>(rawBlendMode.ToUpper(), out var parsed))
-                            Logger.Error($"invalid mode: {rawBlendMode}");
+                        if (!Enum.TryParse<ShaderBlendMode>(_rawBlendMode.ToUpper(), out var parsed))
+                            Logger.Error($"invalid mode: {_rawBlendMode}");
                         else
                             blend = parsed;
                     }
@@ -94,11 +94,20 @@ namespace Robust.Client.Graphics
             return Instance().Duplicate();
         }
 
-        [DataField("kind", readOnly: true, required: true)] private string _rawKind = default!;
-        [DataField("path", readOnly: true)] private ResPath path;
-        [DataField("params", readOnly: true)] private Dictionary<string, string>? paramMapping;
-        [DataField("light_mode", readOnly: true)] private string? rawMode;
-        [DataField("blend_mode", readOnly: true)] private string? rawBlendMode;
+        [DataField("kind", required: true)]
+        private readonly string _rawKind = default!;
+
+        [DataField("path")]
+        private readonly ResPath? _path;
+
+        [DataField("params")]
+        private readonly Dictionary<string, string>? _paramMapping;
+
+        [DataField("light_mode")]
+        private readonly string? _rawMode;
+
+        [DataField("blend_mode")]
+        private readonly string? _rawBlendMode;
 
         void ISerializationHooks.AfterDeserialization()
         {
@@ -106,18 +115,22 @@ namespace Robust.Client.Graphics
             {
                 case "source":
                     Kind = ShaderKind.Source;
-                    if (path == null) throw new InvalidOperationException();
-                    _source = IoCManager.Resolve<IResourceCache>().GetResource<ShaderSourceResource>(path);
 
-                    if (paramMapping != null)
+                    // TODO use a custom type serializer.
+                    if (_path == null)
+                        throw new InvalidOperationException("Source shaders must specify a source file.");
+
+                    _source = IoCManager.Resolve<IResourceCache>().GetResource<ShaderSourceResource>(_path.Value);
+
+                    if (_paramMapping != null)
                     {
                         _params = new Dictionary<string, object>();
-                        foreach (var item in paramMapping!)
+                        foreach (var item in _paramMapping!)
                         {
                             var name = item.Key;
                             if (!_source.ParsedShader.Uniforms.TryGetValue(name, out var uniformDefinition))
                             {
-                                Logger.ErrorS("shader", "Shader param '{0}' does not exist on shader '{1}'", name, path);
+                                Logger.ErrorS("shader", "Shader param '{0}' does not exist on shader '{1}'", name, _path);
                                 continue;
                             }
 

--- a/Robust.Shared/GameObjects/Components/UserInterface/SharedUserInterfaceComponent.cs
+++ b/Robust.Shared/GameObjects/Components/UserInterface/SharedUserInterfaceComponent.cs
@@ -16,11 +16,11 @@ namespace Robust.Shared.GameObjects
         [DataDefinition]
         public sealed class PrototypeData
         {
-            [DataField("key", readOnly: true, required: true)]
-            public Enum UiKey { get; set; } = default!;
+            [DataField("key", required: true)]
+            public Enum UiKey { get; } = default!;
 
-            [DataField("type", readOnly: true, required: true)]
-            public string ClientType { get; set; } = default!;
+            [DataField("type", required: true)]
+            public string ClientType { get; } = default!;
 
             /// <summary>
             ///     Maximum range before a BUI auto-closes. A non-positive number means there is no limit.


### PR DESCRIPTION
This mainly changes read-only & required data fields to only required. There's no real reason that any of these had to be read-only, and this makes write-read-write validation tests possible. Also renames some fields in ShaderProtoype to be consistent with the private field naming convention.