### PR TITLE
Rename a Dirty() proxy method to DirtyEntity()

### DIFF
--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -186,7 +186,7 @@ public partial class EntitySystem
     ///     Marks an entity as dirty.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected void Dirty(EntityUid uid, MetaDataComponent? meta = null)
+    protected void DirtyEntity(EntityUid uid, MetaDataComponent? meta = null)
     {
         EntityManager.DirtyEntity(uid, meta);
     }
@@ -296,7 +296,7 @@ public partial class EntitySystem
         if (!Exists(uid))
             return false;
 
-        Dirty(uid);
+        DirtyEntity(uid);
         return true;
     }
 

--- a/Robust.Shared/GameObjects/Systems/MetaDataSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/MetaDataSystem.cs
@@ -48,7 +48,7 @@ public abstract class MetaDataSystem : EntitySystem
             return;
 
         metadata._entityName = value;
-        Dirty(uid, metadata);
+        Dirty(uid, metadata, metadata);
     }
 
     public void SetEntityDescription(EntityUid uid, string value, MetaDataComponent? metadata = null)
@@ -57,7 +57,7 @@ public abstract class MetaDataSystem : EntitySystem
             return;
 
         metadata._entityDescription = value;
-        Dirty(uid, metadata);
+        Dirty(uid, metadata, metadata);
     }
 
     internal void SetEntityPrototype(EntityUid uid, EntityPrototype? value, MetaDataComponent? metadata = null)
@@ -100,7 +100,7 @@ public abstract class MetaDataSystem : EntitySystem
             RaiseLocalEvent(uid, ref ev);
         }
 
-        Dirty(uid, metadata);
+        Dirty(uid, metadata, metadata);
     }
 
     /// <summary>


### PR DESCRIPTION
Avoids confusion and people accidentally dirtying the entity rather than a component. E.g., #4247 accidentally did this because it was using the wrong Dirty() override.

Requires https://github.com/space-wizards/space-station-14/pull/18933