### PR TITLE
Mark a bunch of NuGet dependencies as private compile assets

### DIFF
--- a/Robust.Client/Robust.Client.csproj
+++ b/Robust.Client/Robust.Client.csproj
@@ -10,25 +10,26 @@
     <RobustILLink>true</RobustILLink>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DiscordRichPresence" Version="1.0.175" />
+    <PackageReference Include="DiscordRichPresence" Version="1.0.175" PrivateAssets="compile" />
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="6.0.9" />
-    <PackageReference Include="SQLitePCLRaw.provider.sqlite3" Version="2.1.2" Condition="'$(UseSystemSqlite)' == 'True'" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.2" Condition="'$(UseSystemSqlite)' != 'True'" />
-    <PackageReference Include="SpaceWizards.NFluidsynth" Version="0.1.1" />
-    <PackageReference Include="NVorbis" Version="0.10.1" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="6.0.9" PrivateAssets="compile" />
+    <PackageReference Include="SQLitePCLRaw.provider.sqlite3" Version="2.1.2" Condition="'$(UseSystemSqlite)' == 'True'" PrivateAssets="compile" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.2" Condition="'$(UseSystemSqlite)' != 'True'" PrivateAssets="compile" />
+    <PackageReference Include="SpaceWizards.NFluidsynth" Version="0.1.1" PrivateAssets="compile" />
+    <PackageReference Include="NVorbis" Version="0.10.1" PrivateAssets="compile" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
-    <PackageReference Include="OpenToolkit.Graphics" Version="4.0.0-pre9.1" />
-    <PackageReference Include="OpenTK.OpenAL" Version="4.7.5" />
-    <PackageReference Include="SpaceWizards.SharpFont" Version="1.0.1" />
+    <PackageReference Include="OpenToolkit.Graphics" Version="4.0.0-pre9.1" PrivateAssets="compile" />
+    <PackageReference Include="OpenTK.OpenAL" Version="4.7.5" PrivateAssets="compile" />
+    <PackageReference Include="SpaceWizards.SharpFont" Version="1.0.1" PrivateAssets="compile" />
     <PackageReference Include="Robust.Natives" Version="0.1.1" />
-    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.20348-rc2" />
-    <PackageReference Condition="'$(FullRelease)' != 'True'" Include="JetBrains.Profiler.Api" Version="1.2.0" />
+    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.20348-rc2" PrivateAssets="compile" />
+    <PackageReference Condition="'$(FullRelease)' != 'True'" Include="JetBrains.Profiler.Api" Version="1.2.0" PrivateAssets="compile" />
+    <PackageReference Include="SpaceWizards.Sodium" Version="0.2.1" PrivateAssets="compile" />
   </ItemGroup>
   <ItemGroup Condition="'$(EnableClientScripting)' == 'True'">
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.1" PrivateAssets="compile" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.0.1" PrivateAssets="compile" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" PrivateAssets="compile" />
 
     <ProjectReference Include="..\Robust.Shared.Scripting\Robust.Shared.Scripting.csproj" />
   </ItemGroup>

--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -13,15 +13,18 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" PrivateAssets="All" />
-    <PackageReference Include="SpaceWizards.HttpListener" Version="0.1.0" />
-    <!--  -->
+    <PackageReference Include="SpaceWizards.HttpListener" Version="0.1.0" PrivateAssets="compile" />
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="6.0.9" />
-    <PackageReference Include="SQLitePCLRaw.provider.sqlite3" Version="2.1.4" Condition="'$(UseSystemSqlite)' == 'True'" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.4" Condition="'$(UseSystemSqlite)' != 'True'" />
+    <PackageReference Include="SQLitePCLRaw.provider.sqlite3" Version="2.1.4" Condition="'$(UseSystemSqlite)' == 'True'" PrivateAssets="compile" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.4" Condition="'$(UseSystemSqlite)' != 'True'" PrivateAssets="compile" />
     <PackageReference Include="prometheus-net" Version="4.1.1" />
-    <PackageReference Include="Serilog.Sinks.Loki" Version="4.0.0-beta3" />
+    <PackageReference Include="Serilog.Sinks.Loki" Version="4.0.0-beta3" PrivateAssets="compile" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />
     <PackageReference Include="prometheus-net.DotNetRuntime" Version="4.2.2" />
+    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.20348-rc2" PrivateAssets="compile"/>
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="6.0.2" PrivateAssets="compile" />
+    <PackageReference Include="SpaceWizards.Sodium" Version="0.2.1" PrivateAssets="compile" />
+    <PackageReference Include="SharpZstd.Interop" Version="1.5.2-beta2" PrivateAssets="compile" />
     <PackageReference Condition="'$(FullRelease)' != 'True'" Include="JetBrains.Profiler.Api" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Robust.Shared.Maths/Robust.Shared.Maths.csproj
+++ b/Robust.Shared.Maths/Robust.Shared.Maths.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" PrivateAssets="All" />
-    <PackageReference Condition="'$(TargetFramework)' == 'net472'" Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
   </ItemGroup>
 
   <Import Project="..\MSBuild\Robust.Properties.targets" />

--- a/Robust.Shared/Robust.Shared.csproj
+++ b/Robust.Shared/Robust.Shared.csproj
@@ -8,19 +8,19 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="6.0.2" />
-    <PackageReference Include="Microsoft.ILVerification" Version="6.0.0" />
-    <PackageReference Include="Nett" Version="0.15.0" />
+    <PackageReference Include="Microsoft.ILVerification" Version="6.0.0" PrivateAssets="compile" />
+    <PackageReference Include="Nett" Version="0.15.0" PrivateAssets="compile" />
     <PackageReference Include="Pidgin" Version="2.5.0" />
     <PackageReference Include="prometheus-net" Version="4.1.1" />
     <PackageReference Include="Robust.Shared.AuthLib" Version="0.1.2" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="YamlDotNet" Version="12.0.0" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" PrivateAssets="compile" />
     <PackageReference Include="Linguini.Bundle" Version="0.1.3" />
-    <PackageReference Include="SharpZstd.Interop" Version="1.5.2-beta2" />
-    <PackageReference Include="SpaceWizards.Sodium" Version="0.2.1" />
+    <PackageReference Include="SharpZstd.Interop" Version="1.5.2-beta2" PrivateAssets="compile" />
+    <PackageReference Include="SpaceWizards.Sodium" Version="0.2.1" PrivateAssets="compile" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
-    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.20348-rc2" />
+    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.20348-rc2" PrivateAssets="compile" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Lidgren.Network\Lidgren.Network.csproj" />

--- a/Robust.UnitTesting/Shared/Physics/Broadphase_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Broadphase_Test.cs
@@ -12,7 +12,6 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Systems;
 using Robust.UnitTesting.Server;
-using SharpFont.PostScript;
 
 namespace Robust.UnitTesting.Shared.Physics;
 

--- a/Robust.UnitTesting/Shared/Serialization/CompositionTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/CompositionTest.cs
@@ -2,7 +2,6 @@
 using NUnit.Framework;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Serialization.Markdown.Mapping;
-using TerraFX.Interop.Windows;
 
 namespace Robust.UnitTesting.Shared.Serialization;
 


### PR DESCRIPTION
Means content can't accidentally include TerraFX anymore. Nice.