### PR TITLE
Fix `UserInterface.SetActiveTheme` didn't update theme

### DIFF
--- a/Robust.Client/UserInterface/UserInterfaceManager.Themes.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Themes.cs
@@ -29,7 +29,7 @@ internal partial class UserInterfaceManager
     public void SetActiveTheme(string themeName)
     {
         if (!_themes.TryGetValue(themeName, out var theme) || (theme == CurrentTheme)) return;
-        CurrentTheme = theme;
+        UpdateTheme(theme);
     }
 
     public void SetDefaultTheme(string themeId)


### PR DESCRIPTION
`UserInterface.SetActiveTheme` doesn't call `RootControl.ThemeUpdateRecursive` after selecting a theme, which, as I think, is the main (and sole) point of the function.

As the reason why it should, `UserInterface.SetDefaultTheme` does so.