### PR TITLE
Remove personally-identifiable file paths from client logs

### DIFF
--- a/Robust.Shared/Configuration/ConfigurationManager.cs
+++ b/Robust.Shared/Configuration/ConfigurationManager.cs
@@ -130,7 +130,7 @@ namespace Robust.Shared.Configuration
                 using var file = File.OpenRead(configFile);
                 var result = LoadFromTomlStream(file);
                 _configFile = configFile;
-                _sawmill.Info($"Configuration Loaded from '{Path.GetFullPath(configFile)}'");
+                _sawmill.Info($"Configuration loaded from file");
                 return result;
             }
             catch (Exception e)

--- a/Robust.Shared/ContentPack/AssemblyTypeChecker.cs
+++ b/Robust.Shared/ContentPack/AssemblyTypeChecker.cs
@@ -69,6 +69,10 @@ namespace Robust.Shared.ContentPack
             {
                 _sawmill.Debug("Robust directory not available");
             }
+            else
+            {
+                loadDirs.Add(Path.GetDirectoryName(ourPath)!);
+            }
 
             if (EngineModuleDirectories != null)
             {

--- a/Robust.Shared/ContentPack/AssemblyTypeChecker.cs
+++ b/Robust.Shared/ContentPack/AssemblyTypeChecker.cs
@@ -69,13 +69,6 @@ namespace Robust.Shared.ContentPack
             {
                 _sawmill.Debug("Robust directory not available");
             }
-            else
-            {
-                _sawmill.Debug("Robust directory is {0}", ourPath);
-                loadDirs.Add(Path.GetDirectoryName(ourPath)!);
-            }
-
-            _sawmill.Debug(".NET runtime directory is {0}", dotnetDir);
 
             if (EngineModuleDirectories != null)
             {


### PR DESCRIPTION
This removes PII from client logs, per [the discussion in #maintainers](https://discord.com/channels/310555209753690112/900426319433728030/1140754747566071828.) Removed are the full paths to the client config file, Robust directory for IL verification, and path to .NET root.