### PR TITLE
Move EntityUid.IsValid to EntityManager

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -994,7 +994,7 @@ namespace Robust.Client.GameStates
                     meta.LastStateApplied = lastStateApplied.Value;
 
                 var xform = xforms.GetComponent(ent);
-                if (xform.ParentUid.IsValid())
+                if (IsValid(xform.ParentUid))
                 {
                     lookupSys.RemoveFromEntityTree(ent, xform);
                     xform.Broadphase = BroadphaseData.Invalid;
@@ -1237,7 +1237,7 @@ namespace Robust.Client.GameStates
             var containerSys = _entities.EntitySysManager.GetEntitySystem<ContainerSystem>();
 
             var xform = _entities.GetComponent<TransformComponent>(uid);
-            if (xform.ParentUid.IsValid())
+            if (IsValid(xform.ParentUid))
             {
                 IContainer? container = null;
                 if ((meta.Flags & MetaDataFlags.InContainer) != 0 &&

--- a/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
@@ -66,7 +66,7 @@ internal partial class Clyde
         {
             var treeXform = query.GetComponent(treeOwner);
             var bounds = xformSystem.GetInvWorldMatrix(treeOwner).TransformBox(worldBounds);
-            DebugTools.Assert(treeXform.MapUid == treeXform.ParentUid || !treeXform.ParentUid.IsValid());
+            DebugTools.Assert(treeXform.MapUid == treeXform.ParentUid || !treeIsValid(xform.ParentUid));
 
             treeData = treeData with
             {

--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -655,7 +655,7 @@ public sealed class MapLoaderSystem : EntitySystem
 
                         var xform = xformQuery.GetComponent(ent);
 
-                        if (!xform.ParentUid.IsValid() || xform.ParentUid.Equals(oldRootUid))
+                        if (!IsValid(xform.ParentUid) || xform.ParentUid.Equals(oldRootUid))
                         {
                             _transform.SetParent(ent, xform, newRootUid);
                         }
@@ -704,7 +704,7 @@ public sealed class MapLoaderSystem : EntitySystem
 
                 var xform = xformQuery.GetComponent(ent);
 
-                if (!xform.ParentUid.IsValid())
+                if (!IsValid(xform.ParentUid))
                 {
                     _transform.SetParent(ent, xform, mapNode);
                 }
@@ -843,7 +843,7 @@ public sealed class MapLoaderSystem : EntitySystem
 
     private bool IsRoot(TransformComponent xform, EntityQuery<MapComponent> mapQuery)
     {
-        return !xform.ParentUid.IsValid() || mapQuery.HasComponent(xform.ParentUid);
+        return !IsValid(xform.ParentUid) || mapQuery.HasComponent(xform.ParentUid);
     }
 
     private void StartupEntity(EntityUid uid, MetaDataComponent metadata, MapData data)

--- a/Robust.Server/GameObjects/EntitySystems/VisibilitySystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/VisibilitySystem.cs
@@ -101,7 +101,7 @@ namespace Robust.Server.GameObjects
                 visMask |= visibilityComponent.Layer;
 
             // Include parent vis masks
-            if (Resolve(uid, ref xform) && xform.ParentUid.IsValid())
+            if (Resolve(uid, ref xform) && IsValid(xform.ParentUid))
                 visMask |= GetVisibilityMask(xform.ParentUid);
 
             return visMask;

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -666,7 +666,7 @@ internal sealed partial class PvsSystem : EntitySystem
         var xform = transform.GetComponent(uid);
 
         // is this a map or grid?
-        var isRoot = !xform.ParentUid.IsValid() || uid == xform.GridUid;
+        var isRoot = !IsValid(xform.ParentUid) || uid == xform.GridUid;
         if (isRoot)
         {
             DebugTools.Assert(_mapManager.IsGrid(uid) || _mapManager.IsMap(uid));

--- a/Robust.Shared/Containers/ContainerHelpers.cs
+++ b/Robust.Shared/Containers/ContainerHelpers.cs
@@ -40,7 +40,7 @@ namespace Robust.Shared.Containers
             DebugTools.Assert(entMan.EntityExists(entity));
 
             var parent = entMan.GetComponent<TransformComponent>(entity).ParentUid;
-            if (parent.IsValid() && TryGetManagerComp(parent, out manager, entMan) && manager.ContainsEntity(entity))
+            if (entMan.IsValid(parent) && TryGetManagerComp(parent, out manager, entMan) && manager.ContainsEntity(entity))
                 return true;
 
             manager = default;

--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -214,7 +214,7 @@ namespace Robust.Shared.Containers
                 xform = xforms.Value.GetComponent(uid);
             }
 
-            if (!xform.ParentUid.Valid)
+            if (!IsValid(xform.ParentUid))
                 return false;
 
             return IsEntityOrParentInContainer(xform.ParentUid, metas: metas, xforms: xforms);
@@ -320,7 +320,7 @@ namespace Robust.Shared.Containers
         {
             container = null;
 
-            if (!uid.IsValid())
+            if (!IsValid(uid))
                 return false;
 
             var conQuery = EntityManager.GetEntityQuery<ContainerManagerComponent>();
@@ -328,7 +328,7 @@ namespace Robust.Shared.Containers
             var child = uid;
             var parent = xform.ParentUid;
 
-            while (parent.IsValid())
+            while (IsValid(parent))
             {
                 if (((metaQuery.GetComponent(child).Flags & MetaDataFlags.InContainer) == MetaDataFlags.InContainer) &&
                     conQuery.TryGetComponent(parent, out var conManager) &&
@@ -423,19 +423,24 @@ namespace Robust.Shared.Containers
             // TODO make this check upwards for any container, and parent to that.
             // Currently this just checks the direct parent, so entities will still teleport through containers.
 
-            if (!transform.ParentUid.IsValid()
+            if (!IsValid(transform.ParentUid)
                 || !TryGetContainingContainer(transform.ParentUid, out var container)
                 || !TryInsertIntoContainer(transform, container))
+            {
                 transform.AttachToGridOrMap();
+            }
         }
 
         private bool TryInsertIntoContainer(TransformComponent transform, IContainer container)
         {
-            if (container.Insert(transform.Owner)) return true;
+            if (container.Insert(transform.Owner))
+                return true;
 
-            if (Transform(container.Owner).ParentUid.IsValid()
+            if (IsValid(Transform(container.Owner).ParentUid)
                 && TryGetContainingContainer(container.Owner, out var newContainer))
+            {
                 return TryInsertIntoContainer(transform, newContainer);
+            }
 
             return false;
         }
@@ -449,8 +454,10 @@ namespace Robust.Shared.Containers
 
             // RECURSION ALERT
             var transform = Transform(entity);
-            if (transform.ParentUid.IsValid())
+            if (IsValid(transform.ParentUid))
+            {
                 return TryGetManagerComp(transform.ParentUid, out manager);
+            }
 
             return false;
         }

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -239,7 +239,7 @@ namespace Robust.Shared.GameObjects
             var newComponent = (T)_componentFactory.GetComponent(reg);
             newComponent.Owner = uid;
 
-            if (!uid.IsValid() || !EntityExists(uid))
+            if (!IsValid(uid) || !EntityExists(uid))
                 throw new ArgumentException($"Entity {uid} is not valid.", nameof(uid));
 
             if (newComponent == null) throw new ArgumentNullException(nameof(newComponent));
@@ -254,7 +254,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public void AddComponent<T>(EntityUid uid, T component, bool overwrite = false) where T : Component
         {
-            if (!uid.IsValid() || !EntityExists(uid))
+            if (!IsValid(uid) || !EntityExists(uid))
                 throw new ArgumentException($"Entity {uid} is not valid.", nameof(uid));
 
             if (component == null) throw new ArgumentNullException(nameof(component));

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -521,6 +521,20 @@ namespace Robust.Shared.GameObjects
             RecursiveDeleteEntity(e, meta, metaQuery, xformQuery, xformSys);
         }
 
+        /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsValid(EntityUid uid)
+        {
+            return uid.GetHashCode() > 0;
+        }
+
+        /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsValid(EntityUid? uid)
+        {
+            return uid != null && IsValid(uid.Value);
+        }
+
         private void RecursiveFlagEntityTermination(
             EntityUid uid,
             MetaDataComponent metadata,

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -13,6 +13,20 @@ public partial class EntitySystem
 {
     #region Entity LifeStage
 
+    /// <inheritdoc cref="IEntityManager.IsValid(EntityUid)" />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected bool IsValid(EntityUid uid)
+    {
+        return EntityManager.IsValid(uid);
+    }
+
+    /// <inheritdoc cref="IEntityManager.IsValid(EntityUid?)" />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected bool IsValid(EntityUid? uid)
+    {
+        return EntityManager.IsValid(uid);
+    }
+
     /// <inheritdoc cref="IEntityManager.EntityExists(EntityUid)" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected bool Exists(EntityUid uid)

--- a/Robust.Shared/GameObjects/EntityUid.cs
+++ b/Robust.Shared/GameObjects/EntityUid.cs
@@ -37,12 +37,10 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         ///     Creates an instance of this structure, with the given network ID.
         /// </summary>
-        public EntityUid(int uid)
+        internal EntityUid(int uid)
         {
             _uid = uid;
         }
-
-        public bool Valid => IsValid();
 
         /// <summary>
         ///     Creates an entity UID by parsing a string number.
@@ -71,16 +69,6 @@ namespace Robust.Shared.GameObjects
                 entityUid = Invalid;
                 return false;
             }
-        }
-
-        /// <summary>
-        ///     Checks if the ID value is valid. Does not check if it identifies
-        ///     a valid Entity.
-        /// </summary>
-        [Pure]
-        public bool IsValid()
-        {
-            return _uid > 0;
         }
 
         [Pure]

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -125,6 +125,16 @@ namespace Robust.Shared.GameObjects
         void DeleteEntity(EntityUid uid);
 
         /// <summary>
+        /// Returns whether a given <see cref="EntityUid"/> could point to an entity.
+        /// </summary>
+        bool IsValid(EntityUid uid);
+
+        /// <summary>
+        /// Returns whether a given <see cref="EntityUid"/> could point to an entity.
+        /// </summary>
+        bool IsValid(EntityUid? uid);
+
+        /// <summary>
         /// Checks whether an entity with the specified ID exists.
         /// </summary>
         bool EntityExists(EntityUid uid);

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -479,8 +479,8 @@ public sealed partial class EntityLookupSystem : EntitySystem
         var fixturesQuery = GetEntityQuery<FixturesComponent>();
 
         DebugTools.Assert(HasComp<MapGridComponent>(args.Sender));
-        DebugTools.Assert(!newMap.IsValid() || HasComp<MapComponent>(newMap));
-        DebugTools.Assert(!oldMap.IsValid() || HasComp<MapComponent>(oldMap));
+        DebugTools.Assert(!IsValid(newMap) || HasComp<MapComponent>(newMap));
+        DebugTools.Assert(!IsValid(oldMap) || HasComp<MapComponent>(oldMap));
 
         var oldBuffer = CompOrNull<PhysicsMapComponent>(oldMap)?.MoveBuffer;
         var newBuffer = CompOrNull<PhysicsMapComponent>(newMap)?.MoveBuffer;
@@ -513,7 +513,7 @@ public sealed partial class EntityLookupSystem : EntitySystem
         if (xform.Broadphase == null || !xform.Broadphase.Value.CanCollide)
             return;
 
-        DebugTools.Assert(_netMan.IsClient || !xform.Broadphase.Value.PhysicsMap.IsValid() || xform.Broadphase.Value.PhysicsMap == oldMap);
+        DebugTools.Assert(_netMan.IsClient || !IsValid(xform.Broadphase.Value.PhysicsMap) || xform.Broadphase.Value.PhysicsMap == oldMap);
         xform.Broadphase = xform.Broadphase.Value with { PhysicsMap = newMap };
 
         if (!fixturesQuery.TryGetComponent(uid, out var fixtures))
@@ -850,7 +850,7 @@ public sealed partial class EntityLookupSystem : EntitySystem
         var parent = xform.ParentUid;
 
         // TODO provide variant that also returns world rotation (and maybe position). Avoids having to iterate though parents twice.
-        while (parent.IsValid())
+        while (IsValid(parent))
         {
             if (_broadQuery.TryGetComponent(parent, out broadphase))
                 return true;

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -167,7 +167,7 @@ public abstract partial class SharedTransformSystem
     public bool ContainsEntity(TransformComponent xform, TransformComponent entityTransform, EntityQuery<TransformComponent> xformQuery)
     {
         // Is the entity the scene root
-        if (!entityTransform.ParentUid.IsValid())
+        if (!IsValid(entityTransform.ParentUid))
             return false;
 
         // Is this the direct parent of the entity
@@ -195,7 +195,7 @@ public abstract partial class SharedTransformSystem
 
             MapId value;
 
-            if (xform.ParentUid.IsValid())
+            if (entMan.IsValid(xform.ParentUid))
             {
                 value = FindMapIdAndSet(xform.ParentUid, xformQuery.GetComponent(xform.ParentUid), entMan, xformQuery, mapManager);
             }
@@ -226,7 +226,7 @@ public abstract partial class SharedTransformSystem
         }
 
         // Has to be done if _parent is set from ExposeData.
-        if (component.ParentUid.IsValid())
+        if (IsValid(component.ParentUid))
         {
             // Note that _children is a HashSet<EntityUid>,
             // so duplicate additions (which will happen) don't matter.
@@ -294,7 +294,7 @@ public abstract partial class SharedTransformSystem
             return;
         }
 
-        if (!xform._parent.IsValid())
+        if (!IsValid(xform._parent))
             return;
 
         var parentXform = _xformQuery.GetComponent(xform._parent);
@@ -311,7 +311,7 @@ public abstract partial class SharedTransformSystem
         // this event on every entity that gets created.
         if (xform.Anchored)
         {
-            DebugTools.Assert(xform.ParentUid == xform.GridUid && xform.ParentUid.IsValid());
+            DebugTools.Assert(xform.ParentUid == xform.GridUid && IsValid(xform.ParentUid));
             var anchorEv = new AnchorStateChangedEvent(xform);
             RaiseLocalEvent(uid, ref anchorEv, true);
         }
@@ -484,7 +484,7 @@ public abstract partial class SharedTransformSystem
                 throw new InvalidOperationException($"Attempted to parent an entity to itself: {ToPrettyString(uid)}");
             }
 
-            if (value.EntityId.IsValid())
+            if (IsValid(value.EntityId))
             {
                 if (!_xformQuery.Resolve(value.EntityId, ref newParent, false))
                 {
@@ -507,7 +507,7 @@ public abstract partial class SharedTransformSystem
                 {
                     var recursiveUid = value.EntityId;
                     var recursiveXform = newParent;
-                    while (recursiveXform.ParentUid.IsValid())
+                    while (recursiveIsValid(xform.ParentUid))
                     {
                         if (recursiveXform.ParentUid == uid)
                         {
@@ -529,7 +529,7 @@ public abstract partial class SharedTransformSystem
                 }
             }
 
-            if (xform._parent.IsValid())
+            if (IsValid(xform._parent))
                 _xformQuery.Resolve(xform._parent, ref oldParent);
 
             oldParent?._children.Remove(uid);
@@ -634,7 +634,7 @@ public abstract partial class SharedTransformSystem
 
     public TransformComponent? GetParent(TransformComponent xform, EntityQuery<TransformComponent> xformQuery)
     {
-        if (!xform.ParentUid.IsValid()) return null;
+        if (!IsValid(xform.ParentUid)) return null;
         return xformQuery.GetComponent(xform.ParentUid);
     }
 
@@ -880,7 +880,7 @@ public abstract partial class SharedTransformSystem
         var xform = component;
         while (xform.ParentUid != relative)
         {
-            if (xform.ParentUid.IsValid() && query.TryGetComponent(xform.ParentUid, out xform))
+            if (IsValid(xform.ParentUid) && query.TryGetComponent(xform.ParentUid, out xform))
             {
                 rot += xform._localRotation;
                 pos = xform._localRotation.RotateVec(pos) + xform._localPosition;
@@ -912,7 +912,7 @@ public abstract partial class SharedTransformSystem
         var xform = component;
         while (xform.ParentUid != relative)
         {
-            if (xform.ParentUid.IsValid() && query.TryGetComponent(xform.ParentUid, out xform))
+            if (IsValid(xform.ParentUid) && query.TryGetComponent(xform.ParentUid, out xform))
             {
                 pos = xform._localRotation.RotateVec(pos) + xform._localPosition;
                 continue;
@@ -1241,7 +1241,7 @@ public abstract partial class SharedTransformSystem
 
     public void AttachToGridOrMap(EntityUid uid, TransformComponent xform, EntityQuery<TransformComponent> query)
     {
-        if (!xform.ParentUid.IsValid() || xform.ParentUid == xform.GridUid)
+        if (!IsValid(xform.ParentUid) || xform.ParentUid == xform.GridUid)
             return;
 
         EntityUid newParent;
@@ -1279,7 +1279,7 @@ public abstract partial class SharedTransformSystem
         if (!_xformQuery.Resolve(uid, ref xform))
             return false;
 
-        if (!xform.ParentUid.IsValid())
+        if (!IsValid(xform.ParentUid))
             return false;
 
         EntityUid newParent;
@@ -1315,7 +1315,7 @@ public abstract partial class SharedTransformSystem
         DebugTools.Assert(uid == xform.Owner);
 
         var parent = xform._parent;
-        if (!parent.IsValid())
+        if (!IsValid(parent))
         {
             DebugTools.Assert(!xform.Anchored,
                 $"Entity is anchored but has no parent? Entity: {ToPrettyString(uid)}");

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -154,7 +154,7 @@ namespace Robust.Shared.GameObjects
         public EntityCoordinates GetMoverCoordinates(EntityUid uid, TransformComponent xform)
         {
             // Nullspace (or map)
-            if (!xform.ParentUid.IsValid())
+            if (!IsValid(xform.ParentUid))
                 return xform.Coordinates;
 
             // GriddUid is only set after init.
@@ -188,7 +188,7 @@ namespace Robust.Shared.GameObjects
             var parentUid = coordinates.EntityId;
 
             // Nullspace coordinates?
-            if (!parentUid.IsValid())
+            if (!IsValid(parentUid))
                 return coordinates;
 
             var parentXform = _xformQuery.GetComponent(parentUid);
@@ -222,7 +222,7 @@ namespace Robust.Shared.GameObjects
         public (EntityCoordinates Coords, Angle worldRot) GetMoverCoordinateRotation(EntityUid uid, TransformComponent xform)
         {
             // Nullspace (or map)
-            if (!xform.ParentUid.IsValid())
+            if (!IsValid(xform.ParentUid))
                 return (xform.Coordinates, xform.LocalRotation);
 
             // GriddUid is only set after init.

--- a/Robust.Shared/Map/EntityCoordinates.cs
+++ b/Robust.Shared/Map/EntityCoordinates.cs
@@ -193,7 +193,7 @@ namespace Robust.Shared.Map
 
             var mapSystem = entityManager.System<SharedMapSystem>();
             var gridIdOpt = GetGridUid(entityManager);
-            if (gridIdOpt is { } gridId && gridId.IsValid())
+            if (gridIdOpt is { } gridId && entityManager.IsValid(gridId))
             {
                 var grid = mapManager.GetGrid(gridId);
                 return mapSystem.GetTileRef(gridId, grid, this).GridIndices;

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Velocities.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Velocities.cs
@@ -56,7 +56,7 @@ public abstract partial class SharedPhysicsSystem
         var velocity = component.LinearVelocity;
         Vector2 angularComponent = Vector2.Zero;
 
-        while (parent != xform.MapUid && parent.IsValid())
+        while (parent != xform.MapUid && IsValid(parent))
         {
             xform = xformQuery.Value.GetComponent(parent);
 
@@ -102,7 +102,7 @@ public abstract partial class SharedPhysicsSystem
 
         var angularVelocity = component.AngularVelocity;
 
-        while (xform.ParentUid != xform.MapUid && xform.ParentUid.IsValid())
+        while (xform.ParentUid != xform.MapUid && IsValid(xform.ParentUid))
         {
             if (physicsQuery.Value.TryGetComponent(xform.ParentUid, out var body))
                 angularVelocity += body.AngularVelocity;
@@ -220,7 +220,7 @@ public abstract partial class SharedPhysicsSystem
             localPos = parentXform.LocalPosition + parentXform.LocalRotation.RotateVec(localPos);
             parent = parentXform.ParentUid;
 
-        } while (parent.IsValid() && xformQuery.TryGetComponent(parent, out parentXform));
+        } while (IsValid(parent) && xformQuery.TryGetComponent(parent, out parentXform));
 
         oldLinear += linearAngularContribution;
 

--- a/Robust.UnitTesting/Shared/Map/EntityCoordinates_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/EntityCoordinates_Tests.cs
@@ -95,12 +95,13 @@ namespace Robust.UnitTesting.Shared.Map
         public void EntityCoordinates_Map()
         {
             var mapManager = IoCManager.Resolve<IMapManager>();
+            var entManager = IoCManager.Resolve<IEntityManager>();
 
             var mapId = mapManager.CreateMap();
             var mapEntity = mapManager.CreateNewMapEntity(mapId);
 
-            Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(mapEntity).ParentUid.IsValid(), Is.False);
-            Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(mapEntity).Coordinates.EntityId, Is.EqualTo(mapEntity));
+            Assert.That(entManager.IsValid(entManager.GetComponent<TransformComponent>(mapEntity).ParentUid), Is.False);
+            Assert.That(entManager.GetComponent<TransformComponent>(mapEntity).Coordinates.EntityId, Is.EqualTo(mapEntity));
         }
 
         /// <summary>


### PR DESCRIPTION
Makes EntityUid update for Arch easier. Arch has IsAlive but that is both IsValid and !Deleted combined and also takes in a world so just refactoring this out separately is easier.