### PR TITLE
Add new spawn functions

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Spawn.cs
@@ -10,6 +10,9 @@ namespace Robust.Shared.GameObjects;
 
 public partial class EntityManager
 {
+    public EntityUid SpawnEntity(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null)
+        => SpawnAttachedTo(protoName, coordinates, overrides);
+    
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public EntityUid[] SpawnEntitiesAttachedTo(EntityCoordinates coordinates, params string?[] protoNames)
     {

--- a/Robust.Shared/GameObjects/EntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Spawn.cs
@@ -141,4 +141,29 @@ public partial class EntityManager
         uid = null;
         return false;
     }
+
+    public EntityUid SpawnNextToOrDrop(string? protoName, EntityUid target, ComponentRegistry? overrides = null)
+    {
+        var uid = Spawn(protoName, overrides);
+        _xforms.PlaceNextToOrDrop(uid, target);
+        return uid;
+    }
+
+    public EntityUid SpawnInContainerOrDrop(
+        string? protoName,
+        EntityUid containerUid,
+        string containerId,
+        ComponentRegistry? overrides = null)
+    {
+        var uid = Spawn(protoName, overrides);
+
+        if (!TryGetComponent(containerUid, out ContainerManagerComponent? containerComp)
+            || !containerComp.Containers.TryGetValue(containerId, out var container)
+            || !container.Insert(uid, this))
+        {
+            _xforms.PlaceNextToOrDrop(uid, containerUid);
+        }
+
+        return uid;
+    }
 }

--- a/Robust.Shared/GameObjects/EntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Spawn.cs
@@ -10,10 +10,11 @@ namespace Robust.Shared.GameObjects;
 
 public partial class EntityManager
 {
+    // This method will soon be marked as obsolete.
     public EntityUid SpawnEntity(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null)
         => SpawnAttachedTo(protoName, coordinates, overrides);
     
-    
+    // This method will soon be marked as obsolete.
     public EntityUid SpawnEntity(string? protoName, MapCoordinates coordinates, ComponentRegistry? overrides = null)
         => Spawn(protoName, coordinates, overrides);
     

--- a/Robust.Shared/GameObjects/EntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Spawn.cs
@@ -1,0 +1,144 @@
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Robust.Shared.Containers;
+
+namespace Robust.Shared.GameObjects;
+
+public partial class EntityManager
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public EntityUid[] SpawnEntitiesAttachedTo(EntityCoordinates coordinates, params string?[] protoNames)
+    {
+        var ents = new EntityUid[protoNames.Length];
+        for (var i = 0; i < protoNames.Length; i++)
+        {
+            ents[i] = SpawnAttachedTo(protoNames[i], coordinates);
+        }
+        return ents;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public EntityUid[] SpawnEntities(MapCoordinates coordinates, params string?[] protoNames)
+    {
+        var ents = new EntityUid[protoNames.Length];
+        for (var i = 0; i < protoNames.Length; i++)
+        {
+            ents[i] = Spawn(protoNames[i], coordinates);
+        }
+        return ents;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public EntityUid[] SpawnEntitiesAttachedTo(EntityCoordinates coordinates, List<string?> protoNames)
+    {
+        var ents = new EntityUid[protoNames.Count];
+        for (var i = 0; i < protoNames.Count; i++)
+        {
+            ents[i] = SpawnAttachedTo(protoNames[i], coordinates);
+        }
+        return ents;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public EntityUid[] SpawnEntities(MapCoordinates coordinates, List<string?> protoNames)
+    {
+        var ents = new EntityUid[protoNames.Count];
+        for (var i = 0; i < protoNames.Count; i++)
+        {
+            ents[i] = Spawn(protoNames[i], coordinates);
+        }
+        return ents;
+    }
+
+    public virtual EntityUid SpawnAttachedTo(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null)
+    {
+        if (!coordinates.IsValid(this))
+            throw new InvalidOperationException($"Tried to spawn entity {protoName} on invalid coordinates {coordinates}.");
+
+        var entity = CreateEntityUninitialized(protoName, coordinates, overrides);
+        InitializeAndStartEntity(entity, coordinates.GetMapId(this));
+        return entity;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public EntityUid Spawn(string? protoName = null, ComponentRegistry? overrides = null)
+        => Spawn(protoName, MapCoordinates.Nullspace, overrides);
+
+    public virtual EntityUid Spawn(string? protoName, MapCoordinates coordinates, ComponentRegistry? overrides = null)
+    {
+        var entity = CreateEntityUninitialized(protoName, coordinates, overrides);
+        InitializeAndStartEntity(entity, coordinates.MapId);
+        return entity;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public EntityUid SpawnAtPosition(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null)
+        => Spawn(protoName, coordinates.ToMap(this, _xforms), overrides);
+
+    public bool TrySpawnNextTo(
+        string? protoName,
+        EntityUid target,
+        [NotNullWhen(true)] out EntityUid? uid,
+        ComponentRegistry? overrides = null)
+    {
+        uid = null;
+        if (!_xformQuery.TryGetComponent(target, out var xform))
+            return false;
+
+        if (!_metaQuery.TryGetComponent(target, out var meta))
+            return false;
+
+        if ((meta.Flags & MetaDataFlags.InContainer) == 0)
+        {
+            uid = SpawnAttachedTo(protoName, xform.Coordinates, overrides);
+            return true;
+        }
+
+        if (!TryGetComponent(xform.ParentUid, out ContainerManagerComponent? containerComp))
+            return false;
+
+        foreach (var container in containerComp.Containers.Values)
+        {
+            if (!container.Contains(target))
+                continue;
+
+            uid = Spawn(protoName, overrides);
+            if (container.Insert(uid.Value, this))
+                return true;
+
+            DeleteEntity(uid.Value);
+            uid = null;
+            return false;
+        }
+
+        return false;
+    }
+
+    public bool TrySpawnInContainer(
+        string? protoName,
+        EntityUid containerUid,
+        string containerId,
+        [NotNullWhen(true)] out EntityUid? uid,
+        ComponentRegistry? overrides = null)
+    {
+        uid = null;
+        if (!TryGetComponent(containerUid, out ContainerManagerComponent? containerComp))
+            return false;
+
+        if (!containerComp.Containers.TryGetValue(containerId, out var container))
+            return false;
+
+        uid = Spawn(protoName, overrides);
+
+        if (container.Insert(uid.Value, this))
+            return true;
+
+        Deleted(uid.Value);
+        uid = null;
+        return false;
+    }
+}

--- a/Robust.Shared/GameObjects/EntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Spawn.cs
@@ -91,10 +91,11 @@ public partial class EntityManager
         string? protoName,
         EntityUid target,
         [NotNullWhen(true)] out EntityUid? uid,
+        TransformComponent? xform = null,
         ComponentRegistry? overrides = null)
     {
         uid = null;
-        if (!_xformQuery.TryGetComponent(target, out var xform))
+        if (!_xformQuery.Resolve(target, ref xform))
             return false;
 
         if (!xform.ParentUid.IsValid())

--- a/Robust.Shared/GameObjects/EntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Spawn.cs
@@ -135,10 +135,11 @@ public partial class EntityManager
         EntityUid containerUid,
         string containerId,
         [NotNullWhen(true)] out EntityUid? uid,
+        ContainerManagerComponent? containerComp = null, 
         ComponentRegistry? overrides = null)
     {
         uid = null;
-        if (!TryGetComponent(containerUid, out ContainerManagerComponent? containerComp))
+        if (containerComp == null && !TryGetComponent(containerUid, out containerComp))
             return false;
 
         if (!containerComp.Containers.TryGetValue(containerId, out var container))
@@ -154,9 +155,9 @@ public partial class EntityManager
         return false;
     }
 
-    public EntityUid SpawnNextToOrDrop(string? protoName, EntityUid target, ComponentRegistry? overrides = null)
+    public EntityUid SpawnNextToOrDrop(string? protoName, EntityUid target, TransformComponent? xform = null, ComponentRegistry? overrides = null)
     {
-        var xform = _xformQuery.GetComponent(target);
+        xform ??= _xformQuery.GetComponent(target);
         if (!xform.ParentUid.IsValid())
             return Spawn(protoName);
         
@@ -169,16 +170,18 @@ public partial class EntityManager
         string? protoName,
         EntityUid containerUid,
         string containerId,
+        TransformComponent? xform = null,
+        ContainerManagerComponent? containerComp = null,
         ComponentRegistry? overrides = null)
     {
         var uid = Spawn(protoName, overrides);
 
-        if (!TryGetComponent(containerUid, out ContainerManagerComponent? containerComp)
-            || !containerComp.Containers.TryGetValue(containerId, out var container)
-            || !container.Insert(uid, this))
+        if ((containerComp == null && !TryGetComponent(containerUid, out containerComp))
+             || !containerComp.Containers.TryGetValue(containerId, out var container)
+             || !container.Insert(uid, this))
         {
             
-            var xform = _xformQuery.GetComponent(containerUid);
+            xform ??= _xformQuery.GetComponent(containerUid);
             if (xform.ParentUid.IsValid())
                 _xforms.PlaceNextToOrDrop(uid, containerUid, targetXform: xform);
         }

--- a/Robust.Shared/GameObjects/EntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Spawn.cs
@@ -13,6 +13,10 @@ public partial class EntityManager
     public EntityUid SpawnEntity(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null)
         => SpawnAttachedTo(protoName, coordinates, overrides);
     
+    
+    public EntityUid SpawnEntity(string? protoName, MapCoordinates coordinates, ComponentRegistry? overrides = null)
+        => Spawn(protoName, coordinates, overrides);
+    
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public EntityUid[] SpawnEntitiesAttachedTo(EntityCoordinates coordinates, params string?[] protoNames)
     {

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -318,12 +318,7 @@ namespace Robust.Shared.GameObjects
         public virtual EntityUid CreateEntityUninitialized(string? prototypeName, EntityCoordinates coordinates, ComponentRegistry? overrides = null)
         {
             var newEntity = CreateEntity(prototypeName, default, overrides);
-
-            if (coordinates.IsValid(this))
-            {
-                _xforms.SetCoordinates(newEntity, _xformQuery.GetComponent(newEntity), coordinates, unanchor: false);
-            }
-
+            _xforms.SetCoordinates(newEntity, _xformQuery.GetComponent(newEntity), coordinates, unanchor: false);
             return newEntity;
         }
 
@@ -358,77 +353,6 @@ namespace Robust.Shared.GameObjects
             }
 
             return newEntity;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public EntityUid[] SpawnEntities(EntityCoordinates coordinates, params string?[] protoNames)
-        {
-            var ents = new EntityUid[protoNames.Length];
-
-            for (var i = 0; i < protoNames.Length; i++)
-            {
-                ents[i] = SpawnEntity(protoNames[i], coordinates);
-            }
-
-            return ents;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public EntityUid[] SpawnEntities(MapCoordinates coordinates, params string?[] protoNames)
-        {
-            var ents = new EntityUid[protoNames.Length];
-
-            for (var i = 0; i < protoNames.Length; i++)
-            {
-                ents[i] = SpawnEntity(protoNames[i], coordinates);
-            }
-
-            return ents;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public EntityUid[] SpawnEntities(EntityCoordinates coordinates, List<string?> protoNames)
-        {
-            var ents = new EntityUid[protoNames.Count];
-
-            for (var i = 0; i < protoNames.Count; i++)
-            {
-                ents[i] = SpawnEntity(protoNames[i], coordinates);
-            }
-
-            return ents;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public EntityUid[] SpawnEntities(MapCoordinates coordinates, List<string?> protoNames)
-        {
-            var ents = new EntityUid[protoNames.Count];
-
-            for (var i = 0; i < protoNames.Count; i++)
-            {
-                ents[i] = SpawnEntity(protoNames[i], coordinates);
-            }
-
-            return ents;
-        }
-
-        /// <inheritdoc />
-        public virtual EntityUid SpawnEntity(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null)
-        {
-            if (!coordinates.IsValid(this))
-                throw new InvalidOperationException($"Tried to spawn entity {protoName} on invalid coordinates {coordinates}.");
-
-            var entity = CreateEntityUninitialized(protoName, coordinates, overrides);
-            InitializeAndStartEntity(entity, coordinates.GetMapId(this));
-            return entity;
-        }
-
-        /// <inheritdoc />
-        public virtual EntityUid SpawnEntity(string? protoName, MapCoordinates coordinates, ComponentRegistry? overrides = null)
-        {
-            var entity = CreateEntityUninitialized(protoName, coordinates, overrides);
-            InitializeAndStartEntity(entity, coordinates.MapId);
-            return entity;
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
+using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
@@ -675,9 +676,10 @@ public partial class EntitySystem
         EntityUid containerUid,
         string containerId,
         [NotNullWhen(true)] out EntityUid? uid,
+        ContainerManagerComponent? containerComp = null,
         ComponentRegistry? overrides = null)
     {
-        return EntityManager.TrySpawnInContainer(protoName, containerUid, containerId, out uid, overrides);
+        return EntityManager.TrySpawnInContainer(protoName, containerUid, containerId, out uid, containerComp, overrides);
     }
 
     /// <inheritdoc cref="IEntityManager.TrySpawnNextTo" />
@@ -686,9 +688,34 @@ public partial class EntitySystem
         string? protoName,
         EntityUid target,
         [NotNullWhen(true)] out EntityUid? uid,
+        TransformComponent? xform = null,
         ComponentRegistry? overrides = null)
     {
-        return EntityManager.TrySpawnNextTo(protoName, target, out uid, overrides);
+        return EntityManager.TrySpawnNextTo(protoName, target, out uid, xform, overrides);
+    }
+
+    /// <inheritdoc cref="IEntityManager.SpawnNextToOrDrop" />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected EntityUid SpawnNextToOrDrop(
+        string? protoName, 
+        EntityUid target, 
+        TransformComponent? xform = null, 
+        ComponentRegistry? overrides = null)
+    {
+        return EntityManager.SpawnNextToOrDrop(protoName, target, xform, overrides);
+    }
+    
+    /// <inheritdoc cref="IEntityManager.SpawnInContainerOrDrop" />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected EntityUid SpawnInContainerOrDrop(
+        string? protoName,
+        EntityUid containerUid,
+        string containerId,
+        TransformComponent? xform = null,
+        ContainerManagerComponent? container = null, 
+        ComponentRegistry? overrides = null)
+    {
+        return EntityManager.SpawnInContainerOrDrop(protoName, containerUid, containerId, xform, container, overrides);
     }
 
     #endregion

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -635,18 +635,54 @@ public partial class EntitySystem
 
     #region Entity Spawning
 
-    /// <inheritdoc cref="IEntityManager.SpawnEntity(string?, EntityCoordinates, ComponentRegistry?)" />
+    // This method will be obsoleted soon.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected EntityUid Spawn(string? prototype, EntityCoordinates coordinates)
     {
-        return EntityManager.SpawnEntity(prototype, coordinates);
+        return ((IEntityManager)EntityManager).SpawnEntity(prototype, coordinates);
     }
 
-    /// <inheritdoc cref="IEntityManager.SpawnEntity(string?, MapCoordinates, ComponentRegistry?)" />
+    /// <inheritdoc cref="IEntityManager.Spawn(string?, MapCoordinates, ComponentRegistry?)" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected EntityUid Spawn(string? prototype, MapCoordinates coordinates)
+        => EntityManager.Spawn(prototype, coordinates);
+
+    /// <inheritdoc cref="IEntityManager.Spawn(string?, ComponentRegistry?)" />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected EntityUid Spawn(string? prototype)
+        => EntityManager.Spawn(prototype);
+
+    /// <inheritdoc cref="IEntityManager.SpawnAttachedTo" />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected EntityUid SpawnAttachedTo(string? prototype, EntityCoordinates coordinates)
+        => EntityManager.SpawnAttachedTo(prototype, coordinates);
+
+    /// <inheritdoc cref="IEntityManager.SpawnAtPosition" />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected EntityUid SpawnAtPosition(string? prototype, EntityCoordinates coordinates)
+        => EntityManager.SpawnAtPosition(prototype, coordinates);
+
+    /// <inheritdoc cref="IEntityManager.TrySpawnInContainer" />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected bool TrySpawnInContainer(
+        string? protoName,
+        EntityUid containerUid,
+        string containerId,
+        [NotNullWhen(true)] out EntityUid? uid,
+        ComponentRegistry? overrides = null)
     {
-        return EntityManager.SpawnEntity(prototype, coordinates);
+        return EntityManager.TrySpawnInContainer(protoName, containerUid, containerId, out uid, overrides);
+    }
+
+    /// <inheritdoc cref="IEntityManager.TrySpawnNextTo" />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected bool TrySpawnNextTo(
+        string? protoName,
+        EntityUid target,
+        [NotNullWhen(true)] out EntityUid? uid,
+        ComponentRegistry? overrides = null)
+    {
+        return EntityManager.TrySpawnNextTo(protoName, target, out uid, overrides);
     }
 
     #endregion

--- a/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
@@ -56,6 +56,16 @@ public partial interface IEntityManager
         ComponentRegistry? overrides = null);
 
     /// <summary>
+    /// Attempts to spawn an entity inside of a container. If it fails to insert into the container, it will
+    /// instead attempt to spawn the entity next to the target's parent.
+    /// </summary>
+    public EntityUid SpawnInContainerOrDrop(
+        string? protoName,
+        EntityUid containerUid,
+        string containerId,
+        ComponentRegistry? overrides = null);
+
+    /// <summary>
     /// Attempts to spawn an entity adjacent to some other entity. If the other entity is in a container, this will
     /// attempt to insert the new entity into the same container.
     /// </summary>
@@ -64,4 +74,11 @@ public partial interface IEntityManager
         EntityUid target,
         [NotNullWhen(true)] out EntityUid? uid,
         ComponentRegistry? overrides = null);
+
+    /// <summary>
+    /// Attempts to spawn an entity adjacent to some other entity. If the other entity is in a container, this will
+    /// attempt to insert the new entity into the same container. If it fails to insert into the container, it will
+    /// instead attempt to spawn the entity next to the target's parent.
+    /// </summary>
+    EntityUid SpawnNextToOrDrop(string? protoName, EntityUid target, ComponentRegistry? overrides = null);
 }

--- a/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
@@ -12,12 +12,10 @@ public partial interface IEntityManager
         => SpawnEntitiesAttachedTo(coordinates, protoNames);
 
     // This method will soon be marked as obsolete.
-    EntityUid SpawnEntity(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null)
-        => SpawnAttachedTo(protoName, coordinates, overrides);
+    EntityUid SpawnEntity(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null);
 
     // This method will soon be marked as obsolete.
-    EntityUid SpawnEntity(string? protoName, MapCoordinates coordinates, ComponentRegistry? overrides = null)
-        => Spawn(protoName, coordinates, overrides);
+    EntityUid SpawnEntity(string? protoName, MapCoordinates coordinates, ComponentRegistry? overrides = null);
 
     EntityUid[] SpawnEntities(MapCoordinates coordinates, params string?[] protoNames);
     EntityUid[] SpawnEntities(MapCoordinates coordinates, List<string?> protoNames);

--- a/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 
@@ -51,6 +52,7 @@ public partial interface IEntityManager
         EntityUid containerUid,
         string containerId,
         [NotNullWhen(true)] out EntityUid? uid,
+        ContainerManagerComponent? containerComp = null, 
         ComponentRegistry? overrides = null);
 
     /// <summary>
@@ -61,6 +63,8 @@ public partial interface IEntityManager
         string? protoName,
         EntityUid containerUid,
         string containerId,
+        TransformComponent? xform = null,
+        ContainerManagerComponent? containerComp = null, 
         ComponentRegistry? overrides = null);
 
     /// <summary>
@@ -79,5 +83,9 @@ public partial interface IEntityManager
     /// attempt to insert the new entity into the same container. If it fails to insert into the container, it will
     /// instead attempt to spawn the entity next to the target's parent.
     /// </summary>
-    EntityUid SpawnNextToOrDrop(string? protoName, EntityUid target, ComponentRegistry? overrides = null);
+    EntityUid SpawnNextToOrDrop(
+        string? protoName, 
+        EntityUid target, 
+        TransformComponent? xform = null, 
+        ComponentRegistry? overrides = null);
 }

--- a/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
@@ -71,6 +71,7 @@ public partial interface IEntityManager
         string? protoName,
         EntityUid target,
         [NotNullWhen(true)] out EntityUid? uid,
+        TransformComponent? xform = null,
         ComponentRegistry? overrides = null);
 
     /// <summary>

--- a/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Robust.Shared.GameObjects;
+
+public partial interface IEntityManager
+{
+    // This method will soon be marked as obsolete.
+    EntityUid[] SpawnEntities(EntityCoordinates coordinates, List<string?> protoNames)
+        => SpawnEntitiesAttachedTo(coordinates, protoNames);
+
+    // This method will soon be marked as obsolete.
+    EntityUid SpawnEntity(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null)
+        => SpawnAttachedTo(protoName, coordinates, overrides);
+
+    // This method will soon be marked as obsolete.
+    EntityUid SpawnEntity(string? protoName, MapCoordinates coordinates, ComponentRegistry? overrides = null)
+        => Spawn(protoName, coordinates, overrides);
+
+    EntityUid[] SpawnEntities(MapCoordinates coordinates, params string?[] protoNames);
+    EntityUid[] SpawnEntities(MapCoordinates coordinates, List<string?> protoNames);
+    EntityUid[] SpawnEntitiesAttachedTo(EntityCoordinates coordinates, List<string?> protoNames);
+    EntityUid[] SpawnEntitiesAttachedTo(EntityCoordinates coordinates, params string?[] protoNames);
+
+    /// <summary>
+    /// Spawns an entity in nullspace.
+    /// </summary>
+    EntityUid Spawn(string? protoName = null, ComponentRegistry? overrides = null);
+
+    /// <summary>
+    /// Spawns an entity at a specific world position. The entity will either be parented to the map or a grid.
+    /// </summary>
+    EntityUid Spawn(string? protoName, MapCoordinates coordinates, ComponentRegistry? overrides = null);
+
+    /// <summary>
+    /// Spawns an entity and then parents it to the entity that the given entity coordinates are relative to.
+    /// </summary>
+    EntityUid SpawnAttachedTo(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null);
+
+    /// <summary>
+    /// Resolves the given entity coordinates into world coordinates and spawns an entity at that location. The
+    /// entity will either be parented to the map or a grid.
+    /// </summary>
+    EntityUid SpawnAtPosition(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null);
+
+    /// <summary>
+    /// Attempts to spawn an entity inside of a container.
+    /// </summary>
+    bool TrySpawnInContainer(
+        string? protoName,
+        EntityUid containerUid,
+        string containerId,
+        [NotNullWhen(true)] out EntityUid? uid,
+        ComponentRegistry? overrides = null);
+
+    /// <summary>
+    /// Attempts to spawn an entity adjacent to some other entity. If the other entity is in a container, this will
+    /// attempt to insert the new entity into the same container.
+    /// </summary>
+    bool TrySpawnNextTo(
+        string? protoName,
+        EntityUid target,
+        [NotNullWhen(true)] out EntityUid? uid,
+        ComponentRegistry? overrides = null);
+}

--- a/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
@@ -57,7 +57,7 @@ public partial interface IEntityManager
 
     /// <summary>
     /// Attempts to spawn an entity inside of a container. If it fails to insert into the container, it will
-    /// instead attempt to spawn the entity next to the target's parent.
+    /// instead attempt to spawn the entity next to the target.
     /// </summary>
     public EntityUid SpawnInContainerOrDrop(
         string? protoName,

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -71,32 +71,6 @@ namespace Robust.Shared.GameObjects
 
         void StartEntity(EntityUid entity);
 
-        EntityUid[] SpawnEntities(EntityCoordinates coordinates, params string?[] protoNames);
-
-        EntityUid[] SpawnEntities(MapCoordinates coordinates, params string?[] protoNames);
-
-        EntityUid[] SpawnEntities(EntityCoordinates coordinates, List<string?> protoNames);
-
-        EntityUid[] SpawnEntities(MapCoordinates coordinates, List<string?> protoNames);
-
-        /// <summary>
-        /// Spawns an initialized entity and sets its local coordinates to the given entity coordinates. Note that this
-        /// means that if you specify coordinates relative to some entity, the newly spawned entity will be a child of
-        /// that entity.
-        /// </summary>
-        /// <param name="protoName">The prototype to clone. If this is null, the entity won't have a prototype.</param>
-        /// <param name="coordinates"></param>
-        /// <returns>Newly created entity.</returns>
-        EntityUid SpawnEntity(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null);
-
-        /// <summary>
-        /// Spawns an entity at a specific world position.
-        /// </summary>
-        /// <param name="protoName"></param>
-        /// <param name="coordinates"></param>
-        /// <returns></returns>
-        EntityUid SpawnEntity(string? protoName, MapCoordinates coordinates, ComponentRegistry? overrides = null);
-
         /// <summary>
         /// How many entities are currently active.
         /// </summary>

--- a/Robust.UnitTesting/Shared/Spawning/EntitySpawnHelpersTest.cs
+++ b/Robust.UnitTesting/Shared/Spawning/EntitySpawnHelpersTest.cs
@@ -1,0 +1,424 @@
+using System.Collections.Generic;
+using System.Numerics;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Robust.UnitTesting.Shared.Spawning;
+
+/// <summary>
+/// This test checks that the various <see cref="IEntityManager"/> spawn helpers (e.g.,
+/// <see cref="IEntityManager.TrySpawnNextTo"/>) work as intended.
+/// </summary>
+[TestFixture]
+[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+public sealed class EntitySpawnHelpersTest : RobustIntegrationTest
+{
+    private ServerIntegrationInstance _server = default!;
+    private IEntityManager _entMan = default!;
+    private IMapManager _mapMan = default!;
+    private SharedTransformSystem _xforms = default!;
+    private SharedContainerSystem _container = default!;
+    
+    private EntityUid _map;
+    private MapId _mapId;
+    private EntityUid _parent; // entity parented to the map.
+    private EntityUid _childA; // in a container, inside _parent
+    private EntityUid _childB; // in another container, inside _parent
+    private EntityUid _grandChildA; // in a container, inside _childA
+    private EntityUid _grandChildB; // attached to _childB, not directly in a container.
+    private EntityUid _greatGrandChildA; //  in a container, inside _grandChildA
+    private EntityUid _greatGrandChildB; //  in a container, inside _grandChildB
+
+    private EntityCoordinates _parentPos;
+    private EntityCoordinates _grandChildBPos;
+    
+    [Test]
+    public async Task TestTrySpawnNextTo()
+    {
+        await Setup();
+        
+        // Spawning next to an entity in a container will insert the entity into the container.
+        await _server.WaitPost(() =>
+        {
+            Assert.That(_entMan.TrySpawnNextTo(null, _childA, out var uid));
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid!.Value), Is.EqualTo(_parent));
+            Assert.That(_container.IsEntityInContainer(uid.Value));
+            Assert.That(_container.GetContainer(_parent, "childA").Contains(uid.Value));
+        });
+        
+        // The container is now full, spawning will fail.
+        await _server.WaitPost(() =>
+        {
+            int count = _entMan.EntityCount;
+            Assert.That(_entMan.TrySpawnNextTo(null, _childA, out var uid), Is.False);
+            Assert.That(_entMan.EntityCount, Is.EqualTo(count));
+            Assert.That(_entMan.EntityExists(uid), Is.False);
+        });
+        
+        // Spawning next to an entity that is not in a container will simply spawn it in the same position
+        await _server.WaitPost(() =>
+        {
+            Assert.That(_entMan.TrySpawnNextTo(null, _grandChildB, out var uid));
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid!.Value), Is.EqualTo(_childB));
+            Assert.That(_container.IsEntityInContainer(uid.Value), Is.False);
+            Assert.That(_container.IsEntityOrParentInContainer(uid.Value));
+            Assert.That(_entMan.GetComponent<TransformComponent>(uid.Value).Coordinates, Is.EqualTo(_grandChildBPos));
+        });
+        
+        // Spawning "next to" a nullspace entity will fail.
+        await _server.WaitPost(() =>
+        {
+            int count = _entMan.EntityCount;
+            Assert.That(_entMan.TrySpawnNextTo(null, _map, out var uid), Is.False);
+            Assert.That(_entMan.EntityCount, Is.EqualTo(count));
+            Assert.That(_entMan.EntityExists(uid), Is.False);
+        });
+        
+        await _server.WaitPost(() =>_mapMan.DeleteMap(_mapId));
+        _server.Dispose();
+    }
+    
+    [Test]
+    public async Task TestTrySpawnInContainer()
+    {
+        await Setup();
+        
+        // Spawning into a non-existent container does nothing.
+        await _server.WaitPost(() =>
+        {
+            int count = _entMan.EntityCount;
+            Assert.That(_entMan.TrySpawnInContainer(null, _childA, "foo", out var uid), Is.False);
+            Assert.That(_entMan.EntityCount, Is.EqualTo(count));
+            Assert.That(_entMan.EntityExists(uid), Is.False);
+            Assert.That(_entMan.TrySpawnInContainer(null, _grandChildB, "foo", out uid), Is.False);
+            Assert.That(_entMan.EntityCount, Is.EqualTo(count));
+            Assert.That(_entMan.EntityExists(uid), Is.False);
+        });
+        
+        // Spawning into a container works as expected.
+        await _server.WaitPost(() =>
+        {
+            Assert.That(_entMan.TrySpawnInContainer(null, _childA, "grandChildA", out var uid));
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid!.Value), Is.EqualTo(_childA));
+            Assert.That(_container.IsEntityInContainer(uid.Value));
+            Assert.That(_container.GetContainer(_childA, "grandChildA").Contains(uid.Value));
+        });
+        
+        // Spawning another entity will fail as the container is now full
+        await _server.WaitPost(() =>
+        {
+            int count = _entMan.EntityCount;
+            Assert.That(_entMan.TrySpawnInContainer(null, _childA, "grandChildA", out var uid), Is.False);
+            Assert.That(_entMan.EntityCount, Is.EqualTo(count));
+            Assert.That(_entMan.EntityExists(uid), Is.False);
+        });
+        
+        await _server.WaitPost(() =>_mapMan.DeleteMap(_mapId));
+        _server.Dispose();
+    }
+    
+    [Test]
+    public async Task TestSpawnNextToOrDrop()
+    {
+        await Setup();
+        
+        // Spawning next to an entity in a container will insert the entity into the container.
+        await _server.WaitPost(() =>
+        {
+            var uid = _entMan.SpawnNextToOrDrop(null, _greatGrandChildA);
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid), Is.EqualTo(_grandChildA));
+            Assert.That(_container.IsEntityInContainer(uid));
+            Assert.That(_container.GetContainer(_grandChildA, "greatGrandChildA").Contains(uid));
+        });
+        
+        // The container is now full, spawning will insert into the outer container.
+        await _server.WaitPost(() =>
+        {
+            var uid = _entMan.SpawnNextToOrDrop(null, _greatGrandChildA);
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid), Is.EqualTo(_childA));
+            Assert.That(_container.IsEntityInContainer(uid));
+            Assert.That(_container.GetContainer(_childA, "grandChildA").Contains(uid));
+        });
+        
+        // If outer two containers are full, will insert into outermost container.
+        await _server.WaitPost(() =>
+        {
+            var uid = _entMan.SpawnNextToOrDrop(null, _greatGrandChildA);
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid), Is.EqualTo(_parent));
+            Assert.That(_container.IsEntityInContainer(uid));
+            Assert.That(_container.GetContainer(_parent, "childA").Contains(uid));
+        });
+        
+        // Finally, this will drop the item on the map.
+        await _server.WaitPost(() =>
+        {
+            var uid = _entMan.SpawnNextToOrDrop(null, _greatGrandChildA);
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid), Is.EqualTo(_map));
+            Assert.That(_container.IsEntityInContainer(uid), Is.False);
+            Assert.That(_entMan.GetComponent<TransformComponent>(uid).Coordinates, Is.EqualTo(_parentPos));
+        });
+        
+        // Repeating this will just drop it on the map again.
+        await _server.WaitPost(() =>
+        {
+            var uid = _entMan.SpawnNextToOrDrop(null, _greatGrandChildA);
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid), Is.EqualTo(_map));
+            Assert.That(_container.IsEntityInContainer(uid), Is.False);
+            Assert.That(_entMan.GetComponent<TransformComponent>(uid).Coordinates, Is.EqualTo(_parentPos));
+        });
+
+        // Repeat the above but with the B-children. As _grandChildB is not actually IN a container, entities will
+        // simply be parented to _childB.
+        
+        // First insert works fine
+        await _server.WaitPost(() =>
+        {
+            var uid = _entMan.SpawnNextToOrDrop(null, _greatGrandChildB);
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid), Is.EqualTo(_grandChildB));
+            Assert.That(_container.IsEntityInContainer(uid));
+            Assert.That(_container.GetContainer(_grandChildB, "greatGrandChildB").Contains(uid));
+        });
+        
+        // Second insert will drop the entity next to _grandChildB
+        await _server.WaitPost(() =>
+        {
+            var uid = _entMan.SpawnNextToOrDrop(null, _greatGrandChildB);
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid), Is.EqualTo(_childB));
+            Assert.That(_container.IsEntityInContainer(uid), Is.False);
+            Assert.That(_entMan.GetComponent<TransformComponent>(uid).Coordinates, Is.EqualTo(_grandChildBPos));
+        });
+        
+        // Repeating this will just repeat the above behaviour.
+        await _server.WaitPost(() =>
+        {
+            var uid = _entMan.SpawnNextToOrDrop(null, _greatGrandChildB);
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid), Is.EqualTo(_childB));
+            Assert.That(_container.IsEntityInContainer(uid), Is.False);
+            Assert.That(_entMan.GetComponent<TransformComponent>(uid).Coordinates, Is.EqualTo(_grandChildBPos));
+        });
+        
+        // Spawning "next to" a map just drops the entity in nullspace
+        await _server.WaitPost(() =>
+        {
+            var uid = _entMan.SpawnNextToOrDrop(null, _map);
+            Assert.That(_entMan.EntityExists(uid));
+            var xform = _entMan.GetComponent<TransformComponent>(uid);
+            Assert.That(xform.ParentUid, Is.EqualTo(EntityUid.Invalid));
+            Assert.That(xform.MapID, Is.EqualTo(MapId.Nullspace));
+            Assert.Null(xform.MapUid);
+            Assert.Null(xform.GridUid);
+        });
+        
+        await _server.WaitPost(() =>_mapMan.DeleteMap(_mapId));
+        _server.Dispose();
+    }
+    
+    [Test]
+    public async Task TestSpawnInContainerOrDrop()
+    {
+        await Setup();
+        
+        // Spawning next to an entity in a container will insert the entity into the container.
+        await _server.WaitPost(() =>
+        {
+            var uid = _entMan.SpawnInContainerOrDrop(null, _grandChildA, "greatGrandChildA");
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid), Is.EqualTo(_grandChildA));
+            Assert.That(_container.IsEntityInContainer(uid));
+            Assert.That(_container.GetContainer(_grandChildA, "greatGrandChildA").Contains(uid));
+        });
+        
+        // The container is now full, spawning will insert into the outer container.
+        await _server.WaitPost(() =>
+        {
+            var uid = _entMan.SpawnInContainerOrDrop(null, _grandChildA, "greatGrandChildA");
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid), Is.EqualTo(_childA));
+            Assert.That(_container.IsEntityInContainer(uid));
+            Assert.That(_container.GetContainer(_childA, "grandChildA").Contains(uid));
+        });
+        
+        // If outer two containers are full, will insert into outermost container.
+        await _server.WaitPost(() =>
+        {
+            var uid = _entMan.SpawnInContainerOrDrop(null, _grandChildA, "greatGrandChildA");
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid), Is.EqualTo(_parent));
+            Assert.That(_container.IsEntityInContainer(uid));
+            Assert.That(_container.GetContainer(_parent, "childA").Contains(uid));
+        });
+        
+        // Finally, this will drop the item on the map.
+        await _server.WaitPost(() =>
+        {
+            var uid = _entMan.SpawnInContainerOrDrop(null, _grandChildA, "greatGrandChildA");
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid), Is.EqualTo(_map));
+            Assert.That(_container.IsEntityInContainer(uid), Is.False);
+            Assert.That(_entMan.GetComponent<TransformComponent>(uid).Coordinates, Is.EqualTo(_parentPos));
+        });
+        
+        // Repeating this will just drop it on the map again.
+        await _server.WaitPost(() =>
+        {
+            var uid = _entMan.SpawnInContainerOrDrop(null, _grandChildA, "greatGrandChildA");
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid), Is.EqualTo(_map));
+            Assert.That(_container.IsEntityInContainer(uid), Is.False);
+            Assert.That(_entMan.GetComponent<TransformComponent>(uid).Coordinates, Is.EqualTo(_parentPos));
+        });
+
+        // Repeat the above but with the B-children. As _grandChildB is not actually IN a container, entities will
+        // simply be parented to _childB.
+        
+        // First insert works fine
+        await _server.WaitPost(() =>
+        {
+            var uid = _entMan.SpawnInContainerOrDrop(null, _grandChildB, "greatGrandChildB");
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid), Is.EqualTo(_grandChildB));
+            Assert.That(_container.IsEntityInContainer(uid));
+            Assert.That(_container.GetContainer(_grandChildB, "greatGrandChildB").Contains(uid));
+        });
+        
+        // Second insert will drop the entity next to _grandChildB
+        await _server.WaitPost(() =>
+        {
+            var uid = _entMan.SpawnInContainerOrDrop(null, _grandChildB, "greatGrandChildB");
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid), Is.EqualTo(_childB));
+            Assert.That(_container.IsEntityInContainer(uid), Is.False);
+            Assert.That(_entMan.GetComponent<TransformComponent>(uid).Coordinates, Is.EqualTo(_grandChildBPos));
+        });
+        
+        // Repeating this will just repeat the above behaviour.
+        await _server.WaitPost(() =>
+        {
+            var uid = _entMan.SpawnInContainerOrDrop(null, _grandChildB, "greatGrandChildB");
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid), Is.EqualTo(_childB));
+            Assert.That(_container.IsEntityInContainer(uid), Is.False);
+            Assert.That(_entMan.GetComponent<TransformComponent>(uid).Coordinates, Is.EqualTo(_grandChildBPos));
+        });
+        
+        // Trying to spawning inside a non-existent container just drops the entity
+        await _server.WaitPost(() =>
+        {
+            var uid = _entMan.SpawnInContainerOrDrop(null, _grandChildB, "foo");
+            Assert.That(_entMan.EntityExists(uid));
+            Assert.That(_xforms.GetParentUid(uid), Is.EqualTo(_childB));
+            Assert.That(_container.IsEntityInContainer(uid), Is.False);
+            Assert.That(_entMan.GetComponent<TransformComponent>(uid).Coordinates, Is.EqualTo(_grandChildBPos));
+        });
+        
+        // Trying to spawning "inside" a map just drops the entity in nullspace
+        await _server.WaitPost(() =>
+        {
+            var uid = _entMan.SpawnInContainerOrDrop(null, _map, "foo");
+            Assert.That(_entMan.EntityExists(uid));
+            var xform = _entMan.GetComponent<TransformComponent>(uid);
+            Assert.That(xform.ParentUid, Is.EqualTo(EntityUid.Invalid));
+            Assert.That(xform.MapID, Is.EqualTo(MapId.Nullspace));
+            Assert.Null(xform.MapUid);
+            Assert.Null(xform.GridUid);
+        });
+        
+        await _server.WaitPost(() =>_mapMan.DeleteMap(_mapId));
+        _server.Dispose();
+    }
+    
+    public async Task Setup()
+    {
+        _server = StartServer();
+        await _server.WaitIdleAsync();
+        _mapMan = _server.ResolveDependency<IMapManager>();
+        _entMan = _server.ResolveDependency<IEntityManager>();
+        _xforms = _entMan.System<SharedTransformSystem>();
+        _container = _entMan.System<SharedContainerSystem>();
+
+        // Set up map and spawn several nested containers
+        await _server.WaitPost(() =>
+        {
+            _mapId = _mapMan.CreateMap();
+            _map = _mapMan.GetMapEntityId(_mapId);
+            _parent = _entMan.SpawnEntity(null, new EntityCoordinates(_map, new(1,2)));
+            _childA = _entMan.SpawnEntity(null, new EntityCoordinates(_map, default));
+            _childB = _entMan.SpawnEntity(null, new EntityCoordinates(_map, default));
+            _grandChildA = _entMan.SpawnEntity(null, new EntityCoordinates(_map, default));
+            _grandChildB = _entMan.SpawnEntity(null, new EntityCoordinates(_map, default));
+            _greatGrandChildA = _entMan.SpawnEntity(null, new EntityCoordinates(_map, default));
+            _greatGrandChildB = _entMan.SpawnEntity(null, new EntityCoordinates(_map, default));
+            _container.EnsureContainer<TestContainer>(_parent, "childA").Insert(_childA);
+            _container.EnsureContainer<TestContainer>(_parent, "childB").Insert(_childB);
+            _container.EnsureContainer<TestContainer>(_childA, "grandChildA").Insert(_grandChildA);
+            _xforms.SetCoordinates(_grandChildB, new EntityCoordinates(_childB, new(2,1)));
+            _container.EnsureContainer<TestContainer>(_grandChildA, "greatGrandChildA").Insert(_greatGrandChildA);
+            _container.EnsureContainer<TestContainer>(_grandChildB, "greatGrandChildB").Insert(_greatGrandChildB);
+        });
+        await _server.WaitRunTicks(5);
+        
+        // Ensure transform hierarchy is as expected
+        
+        Assert.That(_xforms.GetParentUid(_parent), Is.EqualTo(_map));
+        Assert.That(_xforms.GetParentUid(_childA), Is.EqualTo(_parent));
+        Assert.That(_xforms.GetParentUid(_childB), Is.EqualTo(_parent));
+        Assert.That(_xforms.GetParentUid(_grandChildA), Is.EqualTo(_childA));
+        Assert.That(_xforms.GetParentUid(_grandChildB), Is.EqualTo(_childB));
+        Assert.That(_xforms.GetParentUid(_greatGrandChildA), Is.EqualTo(_grandChildA));
+        Assert.That(_xforms.GetParentUid(_greatGrandChildB), Is.EqualTo(_grandChildB));
+        
+        Assert.That(_container.IsEntityInContainer(_parent), Is.False);
+        Assert.That(_container.IsEntityInContainer(_childA));
+        Assert.That(_container.IsEntityInContainer(_childB));
+        Assert.That(_container.IsEntityInContainer(_grandChildA));
+        Assert.That(_container.IsEntityInContainer(_grandChildB), Is.False);
+        Assert.That(_container.IsEntityOrParentInContainer(_grandChildB));
+        Assert.That(_container.IsEntityInContainer(_greatGrandChildA));
+        Assert.That(_container.IsEntityInContainer(_greatGrandChildB));
+        
+        Assert.That(_container.GetContainer(_parent, "childA").Contains(_childA));
+        Assert.That(_container.GetContainer(_parent, "childB").Contains(_childB));
+        Assert.That(_container.GetContainer(_childA, "grandChildA").Contains(_grandChildA));
+        Assert.That(_container.GetContainer(_grandChildA, "greatGrandChildA").Contains(_greatGrandChildA));
+        Assert.That(_container.GetContainer(_grandChildB, "greatGrandChildB").Contains(_greatGrandChildB));
+
+        _parentPos = _entMan.GetComponent<TransformComponent>(_parent).Coordinates;
+        _grandChildBPos = _entMan.GetComponent<TransformComponent>(_grandChildB).Coordinates;
+        
+        Assert.That(_parentPos.Position, Is.EqualTo(new Vector2(1, 2)));
+        Assert.That(_grandChildBPos.Position, Is.EqualTo(new Vector2(2, 1)));
+    }
+    
+    /// <summary>
+    /// Simple container that can store up to 2 entities.
+    /// </summary>
+    private sealed class TestContainer : BaseContainer
+    {
+        private readonly List<EntityUid> _ents = new();
+        private readonly List<EntityUid> _expected = new();
+        public override string ContainerType => nameof(TestContainer);
+        public override IReadOnlyList<EntityUid> ContainedEntities => _ents;
+        public override List<EntityUid> ExpectedEntities => _expected;
+        protected override void InternalInsert(EntityUid toInsert, IEntityManager entMan) => _ents.Add(toInsert);
+        protected override void InternalRemove(EntityUid toRemove, IEntityManager entMan) => _ents.Remove(toRemove);
+        public override bool Contains(EntityUid contained) => _ents.Contains(contained);
+        protected override void InternalShutdown(IEntityManager entMan, bool isClient) { }
+        public override bool CanInsert(EntityUid toinsert, IEntityManager? entMan = null)
+            => _ents.Count < 2 && !_ents.Contains(toinsert);
+    }
+}
+


### PR DESCRIPTION
This PR adds new `IEntityManager` functions and `EntitySystem` proxies for spawning entities. Some of these are just renamed versions of existing spawn functions. In a separate PR I'll refactor content & engine to remove uses of the old functions. In particular, the entity-coordinate variant needs to be renamed, as was discussed in a maintainer meeting.

If people think of better function names, let me know because I dislike some of them but can't think of anything that is clear & concise. E.g., I dislike the "...OrDrop" functions.

New spawn functions:
- `TrySpawnInContainer()` - Pretty self explanatory.
- `SpawnAtPosition()` - Converts entity coordinates into map coordinates before spawning.
- `SpawnAttachedTo()` - Intended to replace the old entity coordinate spawn method. Makes it clearer that this will set an entity's parent after spawning it.
- `TrySpawnNextTo()` - A function that takes in another entity uid and will try to spawn the new entity in the same location as the given entity. Acts sort of like a combination of `TrySpawnInContainer()` and `SpawnAttachedTo()`.
- `Spawn(string?, MapCoordinates)` - Intended to replace `SpawnEntity()`. Makes the function name consistent with the entity system proxy method.
- `SpawnInContainerOrDrop` and `SpawnNextToOrDrop` - Variants of the try-spawn functions that will drop the entity to the floor or some outer container instead of simply failing to spawn the entity.

This PR also adds `SharedTransformSystem.PlaceNextToOrDrop()` which acts like `SpawnNextToOrDrop()` except that it works on existing entities.