### PR TITLE
Allow pre-startup components to be shut down.

### DIFF
--- a/Robust.Shared/GameObjects/Component.cs
+++ b/Robust.Shared/GameObjects/Component.cs
@@ -100,9 +100,15 @@ namespace Robust.Shared.GameObjects
         /// </remarks>
         internal void LifeShutdown(IEntityManager entManager)
         {
-            // Starting allows a component to remove itself in it's own Startup function.
-            DebugTools.Assert(LifeStage == ComponentLifeStage.Starting || LifeStage == ComponentLifeStage.Running);
+            DebugTools.Assert(LifeStage is >= ComponentLifeStage.Initializing and < ComponentLifeStage.Stopping);
 
+            if (LifeStage <= ComponentLifeStage.Initialized)
+            {
+                // Component was never started, no shutdown logic necessary. Simply mark it as stopped.
+                LifeStage = ComponentLifeStage.Stopped;
+                return;
+            }
+            
             LifeStage = ComponentLifeStage.Stopping;
             entManager.EventBus.RaiseComponentEvent(this, CompShutdownInstance);
             LifeStage = ComponentLifeStage.Stopped;

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -131,7 +131,7 @@ namespace Robust.Shared.GameObjects
 
             foreach (var comp in comps)
             {
-                if (comp is { LifeStage: < ComponentLifeStage.Initialized })
+                if (comp is { LifeStage:  ComponentLifeStage.Added })
                     comp.LifeInitialize(this, CompIdx.Index(comp.GetType()));
             }
 
@@ -490,7 +490,7 @@ namespace Robust.Shared.GameObjects
                 return;
             }
 
-            if (component.Running)
+            if (component.LifeStage >= ComponentLifeStage.Initialized && component.LifeStage <= ComponentLifeStage.Running)
                 component.LifeShutdown(this);
 #if EXCEPTION_TOLERANCE
             }


### PR DESCRIPTION
Fixes a bug that comes up in the event that a component attempts to remove another component that has not yet been started.