### PR TITLE
Fix test checking that Robust's and .NET's colors are equal

### DIFF
--- a/Robust.UnitTesting/Shared/Maths/Color_Test.cs
+++ b/Robust.UnitTesting/Shared/Maths/Color_Test.cs
@@ -202,7 +202,9 @@ namespace Robust.UnitTesting.Shared.Maths
             Assert.That(sysColor, Is.EqualTo((System.Drawing.Color) color));
         }
 
-        static IEnumerable<string> DefaultColorNames => Color.GetAllDefaultColors().Select(e => e.Key);
+        static IEnumerable<string> DefaultColorNames => Color.GetAllDefaultColors()
+            .Where(e => System.Drawing.Color.FromName(e.Key).IsKnownColor)
+            .Select(e => e.Key);
 
         [Test]
         public void GetAllDefaultColorsFromName([ValueSource(nameof(DefaultColorNames))] string colorName)


### PR DESCRIPTION
Fixes https://github.com/space-wizards/RobustToolbox/commit/63423d96b4c9eabee3294282401bbf0553c25236
Now it checks if the color exists in .NET