### PR TITLE
fix: crash client when window set maxsize

### DIFF
--- a/Robust.Client/UserInterface/Control.Layout.cs
+++ b/Robust.Client/UserInterface/Control.Layout.cs
@@ -715,7 +715,7 @@ namespace Robust.Client.UserInterface
             maxH = MathHelper.Clamp(maxConstraint, minH, maxH);
 
             minConstraint = float.IsNaN(setH) ? 0 : setH;
-            minH = MathHelper.Clamp(maxH, minConstraint, minH);
+            minH = MathHelper.Clamp(minConstraint, minH, maxH);
 
             return new Vector2(
                 Math.Clamp(avail.X, minW, maxW),


### PR DESCRIPTION
If a window is set MaxSize and then resized, the client crashes.

Example:
```xml
<!-- Content.Client/Paper/UI/PaperWindow.xaml -->
<paper:PaperWindow MaxSize="600 800" ... >
```

When resized window and Width > MaxWidth, client crashes.