### PR TITLE
Fix prototype manager not being initialized in tests

### DIFF
--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -47,9 +47,7 @@ namespace Robust.Shared.Prototypes
         public virtual void Initialize()
         {
             if (_initialized)
-            {
-                throw new InvalidOperationException($"{nameof(PrototypeManager)} has already been initialized.");
-            }
+                return;
 
             Sawmill = _logManager.GetSawmill("proto");
 

--- a/Robust.UnitTesting/Server/RobustServerSimulation.cs
+++ b/Robust.UnitTesting/Server/RobustServerSimulation.cs
@@ -322,6 +322,7 @@ namespace Robust.UnitTesting.Server
             container.Resolve<ISerializationManager>().Initialize();
 
             var protoMan = container.Resolve<IPrototypeManager>();
+            protoMan.Initialize();
             protoMan.RegisterKind(typeof(EntityPrototype));
             _protoDelegate?.Invoke(protoMan);
             protoMan.ResolveResults();


### PR DESCRIPTION
Was causes a NRE when tests fail to find a prototype.