### PR TITLE
Fix serialization sharing instances when copying data definitions and not assigning null when the source is null

### DIFF
--- a/Robust.Serialization.Generator/Generator.cs
+++ b/Robust.Serialization.Generator/Generator.cs
@@ -435,25 +435,18 @@ if (serialization.TryCustomCopy(this, ref target, hookCtx, {definition.HasHooks.
                          type is not INamedTypeSymbol { TypeKind: TypeKind.Interface })
                 {
                     var nullability = type.IsValueType ? string.Empty : "?";
-                    var orNew = type.IsReferenceType
-                        ? $" ?? {name}{nullability}.Instantiate()"
-                        : string.Empty;
                     var nullable = !type.IsValueType || IsNullableType(type);
-
-
-                    builder.AppendLine($"var temp = {name}{orNew};");
 
                     if (nullable)
                     {
-                        builder.AppendLine("""
-                                           if (temp != null)
+                        builder.AppendLine($$"""
+                                           if ({{tempVarName}} != null)
                                            {
                                            """);
                     }
 
                     builder.AppendLine($$"""
-                                         {{name}}{{nullability}}.Copy(ref temp, serialization, hookCtx, context);
-                                         {{tempVarName}} = temp;
+                                         {{name}}{{nullability}}.Copy(ref {{tempVarName}}, serialization, hookCtx, context);
                                          """);
 
                     if (nullable)
@@ -468,18 +461,18 @@ if (serialization.TryCustomCopy(this, ref target, hookCtx, {definition.HasHooks.
 
                 builder.AppendLine("}");
 
-                if (isClass)
-                {
-                    builder.AppendLine("}");
-                }
-
                 if (definition.Type.IsValueType)
                 {
-                    structCopier.AppendLine($"{name} = {tempVarName},");
+                    structCopier.AppendLine($"{name} = {tempVarName}!,");
                 }
                 else
                 {
-                    builder.AppendLine($"target.{name} = {tempVarName};");
+                    builder.AppendLine($"target.{name} = {tempVarName}!;");
+                }
+
+                if (isClass)
+                {
+                    builder.AppendLine("}");
                 }
             }
         }

--- a/Robust.Shared/GameObjects/Component.cs
+++ b/Robust.Shared/GameObjects/Component.cs
@@ -13,6 +13,7 @@ namespace Robust.Shared.GameObjects
 {
     /// <inheritdoc />
     [Reflect(false)]
+    [ImplicitDataDefinitionForInheritors]
     public abstract partial class Component : IComponent
     {
         [DataField("netsync")]
@@ -109,7 +110,7 @@ namespace Robust.Shared.GameObjects
                 LifeStage = ComponentLifeStage.Stopped;
                 return;
             }
-            
+
             LifeStage = ComponentLifeStage.Stopping;
             entManager.EventBus.RaiseComponentEvent(this, CompShutdownInstance);
             LifeStage = ComponentLifeStage.Stopped;

--- a/Robust.Shared/Serialization/Manager/SerializationManager.SerializerProvider.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.SerializerProvider.cs
@@ -80,11 +80,6 @@ public sealed partial class SerializationManager
             if (copier != null)
             {
                 CopyTo(copier, source, ref target, hookCtx, context);
-
-                // copier.CopyTo(this, source, ref target, DependencyCollection, hookCtx, context);
-                //
-                // if (hasHooks)
-                //     RunAfterHook(target, hookCtx);
                 return true;
             }
 

--- a/Robust.Shared/Utility/SpriteSpecifier.cs
+++ b/Robust.Shared/Utility/SpriteSpecifier.cs
@@ -41,13 +41,6 @@ namespace Robust.Shared.Utility
             [DataField("state")]
             public string RsiState { get; internal set; }
 
-            // For serialization
-            private Rsi()
-            {
-                RsiPath = default!;
-                RsiState = default!;
-            }
-
             public Rsi(ResPath rsiPath, string rsiState)
             {
                 RsiPath = rsiPath;

--- a/Robust.UnitTesting/Shared/Serialization/PropertyAndFieldDefinitionTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/PropertyAndFieldDefinitionTest.cs
@@ -65,7 +65,7 @@ namespace Robust.UnitTesting.Shared.Serialization
 
             var propertyInfo = new SpecificPropertyInfo(property!);
             Assert.NotNull(propertyInfo.GetAttribute<DataFieldAttribute>());
-            Assert.NotNull(propertyInfo.GetBackingField()!.GetAttribute<AlwaysPushInheritanceAttribute>());
+            Assert.NotNull(propertyInfo.GetAttribute<AlwaysPushInheritanceAttribute>());
 
             // We check for the property info properly finding field targeted attributes as
             // well, otherwise we run the risk of the data field being targeted to the
@@ -92,8 +92,8 @@ namespace Robust.UnitTesting.Shared.Serialization
             propertyInfo = new SpecificPropertyInfo(property!);
 
             // Data field is targeted to the backing field
-            Assert.NotNull(propertyInfo.GetBackingField()!.GetAttribute<DataFieldAttribute>());
-            Assert.Null(propertyInfo.GetAttribute<DataFieldAttribute>());
+            Assert.NotNull(propertyInfo.GetAttribute<DataFieldAttribute>());
+            Assert.Null(propertyInfo.GetBackingField()!.GetAttribute<DataFieldAttribute>());
             Assert.NotNull(propertyInfo.GetAttribute<DataFieldAttribute>(true));
 
             // NeverPushInheritanceAttribute is targeted to the property
@@ -101,7 +101,7 @@ namespace Robust.UnitTesting.Shared.Serialization
             Assert.Null(propertyInfo.GetBackingField()!.GetAttribute<NeverPushInheritanceAttribute>());
             Assert.NotNull(propertyInfo.GetAttribute<NeverPushInheritanceAttribute>(true));
 
-            var neverPushDataField = propertyInfo.GetBackingField()!.GetAttribute<DataFieldAttribute>();
+            var neverPushDataField = propertyInfo.GetAttribute<DataFieldAttribute>();
             propertyDefinition =
                 dataDefinition!.BaseFieldDefinitions.Single(e => e.Attribute.Equals(neverPushDataField));
             inheritanceBehaviour = propertyDefinition.InheritanceBehavior;

--- a/Robust.UnitTesting/Shared/Serialization/SerializationTests/CommunitaryLungTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/SerializationTests/CommunitaryLungTest.cs
@@ -65,13 +65,13 @@ public sealed partial class CommunitaryLungTest : SerializationTest
     }
 
     [DataDefinition]
-    private partial class DataDefinition
+    private sealed partial class DataDefinition
     {
         [DataField("dict")] public Dictionary<int, string> Dict;
     }
 
     [DataDefinition]
-    private partial class NullableDataDefinition
+    private sealed partial class NullableDataDefinition
     {
         [DataField("dict")] public Dictionary<int, string>? Dict;
     }

--- a/Robust.UnitTesting/Shared/Serialization/SerializationTests/CommunitaryLungTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/SerializationTests/CommunitaryLungTest.cs
@@ -1,0 +1,78 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using Robust.Shared.Serialization.Manager.Attributes;
+
+namespace Robust.UnitTesting.Shared.Serialization.SerializationTests;
+
+[TestFixture]
+public sealed partial class CommunitaryLungTest : SerializationTest
+{
+    [Test]
+    public void Test()
+    {
+        var dict = new Dictionary<int, string>();
+        var def = new DataDefinition { Dict = dict };
+        var copy = Serialization.CreateCopy(def, notNullableOverride: true);
+
+        Assert.That(def.Dict == copy.Dict, Is.False);
+
+        // Sanity check
+        Assert.That(def.Dict == def.Dict, Is.True);
+
+        Serialization.CopyTo(def, ref copy, notNullableOverride: true);
+
+        Assert.That(def.Dict == copy.Dict, Is.False);
+
+        // Sanity check
+        Assert.That(def.Dict == def.Dict, Is.True);
+    }
+
+    [Test]
+    public void NullableNonNullTest()
+    {
+        var dict = new Dictionary<int, string>();
+        var def = new NullableDataDefinition { Dict = dict };
+        var copy = Serialization.CreateCopy(def, notNullableOverride: true);
+
+        Assert.That(def.Dict == copy.Dict, Is.False);
+        Assert.That(copy.Dict, Is.Not.Null);
+
+        // Sanity check
+        Assert.That(def.Dict == def.Dict, Is.True);
+
+        Serialization.CopyTo(def, ref copy, notNullableOverride: true);
+
+        Assert.That(def.Dict == copy.Dict, Is.False);
+        Assert.That(copy.Dict, Is.Not.Null);
+
+        // Sanity check
+        Assert.That(def.Dict == def.Dict, Is.True);
+    }
+
+    [Test]
+    public void NullableNullTest()
+    {
+        var def = new NullableDataDefinition();
+        var copy = Serialization.CreateCopy(def, notNullableOverride: true);
+
+        Assert.That(def.Dict, Is.Null);
+        Assert.That(copy.Dict, Is.Null);
+
+        Serialization.CopyTo(def, ref copy, notNullableOverride: true);
+
+        Assert.That(def.Dict, Is.Null);
+        Assert.That(copy.Dict, Is.Null);
+    }
+
+    [DataDefinition]
+    private partial class DataDefinition
+    {
+        [DataField("dict")] public Dictionary<int, string> Dict;
+    }
+
+    [DataDefinition]
+    private partial class NullableDataDefinition
+    {
+        [DataField("dict")] public Dictionary<int, string>? Dict;
+    }
+}

--- a/Robust.UnitTesting/Shared/Serialization/SerializationTests/DataDefinitionTests.cs
+++ b/Robust.UnitTesting/Shared/Serialization/SerializationTests/DataDefinitionTests.cs
@@ -222,7 +222,7 @@ public sealed partial class DataDefinitionTests : SerializationTest
         SetValue(target, fieldName, altValue());
         Serialization.CopyTo(source, ref target, notNullableOverride: true);
         Assert.NotNull(target);
-        Assert.Null(GetValue(target!, fieldName));
+        Assert.NotNull(GetValue(target!, fieldName));
     }
 
     [TestCaseSource(nameof(NullableFieldsData))]

--- a/Robust.UnitTesting/Shared/Serialization/SerializationTests/DataDefinitionTests.cs
+++ b/Robust.UnitTesting/Shared/Serialization/SerializationTests/DataDefinitionTests.cs
@@ -222,7 +222,7 @@ public sealed partial class DataDefinitionTests : SerializationTest
         SetValue(target, fieldName, altValue());
         Serialization.CopyTo(source, ref target, notNullableOverride: true);
         Assert.NotNull(target);
-        Assert.NotNull(GetValue(target!, fieldName));
+        Assert.Null(GetValue(target!, fieldName));
     }
 
     [TestCaseSource(nameof(NullableFieldsData))]


### PR DESCRIPTION
No more communitary lung bug