### PR TITLE
removed warning for glibc

### DIFF
--- a/Robust.Shared/Utility/GlibcBug.cs
+++ b/Robust.Shared/Utility/GlibcBug.cs
@@ -19,7 +19,8 @@ internal static unsafe class GlibcBug
             var versionString = Marshal.PtrToStringUTF8((IntPtr) gnu_get_libc_version());
             var version = Version.Parse(versionString!);
             var badVersion = new Version(2, 35);
-            if (version >= badVersion)
+            var fixedVersion = new Version(2, 37);
+            if (version >= badVersion && version < fixedVersion)
             {
                 C.ForegroundColor = ConsoleColor.Yellow;
                 C.WriteLine($"!!!WARNING!!!: glibc {badVersion} or higher detected (you have {version}).");


### PR DESCRIPTION
The glibc bug has reportedly (I never experienced the issue) been fixed as of version 2.37 so the warning introduced with #2998 is no longer necessary
https://sourceware.org/bugzilla/show_bug.cgi?id=28937