### PR TITLE
Fix Timer drift

### DIFF
--- a/Robust.Shared/Timing/Timer.cs
+++ b/Robust.Shared/Timing/Timer.cs
@@ -11,7 +11,7 @@ namespace Robust.Shared.Timing
         /// <summary>
         /// Counts the time (in milliseconds) before firing again.
         /// </summary>
-        private int _timeCounter;
+        private float _timeCounter;
 
         /// <summary>
         /// Time (in milliseconds) between firings.
@@ -46,7 +46,7 @@ namespace Robust.Shared.Timing
         {
             if (IsActive)
             {
-                _timeCounter -= (int)(frameTime * 1000);
+                _timeCounter -= frameTime * 1000;
 
                 if (_timeCounter <= 0)
                 {


### PR DESCRIPTION
Fixes #4298

As described in the issue, the cast to `int` causes fractions of a millisecond to be lost. This means the timer actually counts down slower than real time. If the game runs at a stable (exact) 60 fps, the timer is _guaranteed_ to drift by 4%. At an (exact) 59 fps, the drift increases to 5.6%.

Changing `_timeCounter` to a float and removing the cast fixes the problem and appears to have no performance impact whatsoever.

Note, however: due to floating point error accumulation, this fix will actually make timers run slightly _faster_. In my testing, a 300 s timer ran on average 30 ms (0.01%) faster. I would argue that a 0.01% speedup is acceptable compared to a _guaranteed_ slowdown.

I have been told the `Timer` class is not used much in newer code. Nevertheless, this drift issue noticeably affects the round restart time on Salamander, and I posit that it's better to fix a known problem.