### PR TITLE
Update CI to use setup-dotnet 3.2.0 and checkout 3.6.0

### DIFF
--- a/.github/workflows/build-docfx.yml
+++ b/.github/workflows/build-docfx.yml
@@ -7,12 +7,12 @@ jobs:
   docfx:
    runs-on: ubuntu-latest
    steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.6.0
       with:
         submodules: true
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3.2.0
       with:
         dotnet-version: 7.0.x
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.6.0
       with:
         submodules: true
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3.2.0
       with:
         dotnet-version: 7.0.x
     - name: Install dependencies

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,12 +35,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.6.0
       with:
         submodules: true
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3.2.0
       with:
         dotnet-version: 7.0.x
 

--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -16,12 +16,12 @@ jobs:
         $ver = [regex]::Match($env:GITHUB_REF, "refs/tags/v?(.+)").Groups[1].Value
         echo ("::set-output name=version::{0}" -f $ver)
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.6.0
       with:
         submodules: true
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3.2.0
       with:
         dotnet-version: 7.0.x
 

--- a/.github/workflows/test-content.yml
+++ b/.github/workflows/test-content.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
     - name: Check out content
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.6.0
       with:
         repository: space-wizards/space-station-14
         submodules: recursive
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3.2.0
       with:
         dotnet-version: 7.0.x
     - name: Disable submodule autoupdate


### PR DESCRIPTION
Some of these have performance improvements and fixes for some of the CI build errors that we keep seeing, like ECONNRESET.