### PR TITLE
Remove redundant prototype resolving

### DIFF
--- a/Robust.Client/GameController/GameController.cs
+++ b/Robust.Client/GameController/GameController.cs
@@ -167,7 +167,6 @@ namespace Robust.Client
             _reflectionManager.Initialize();
             _prototypeManager.Initialize();
             _prototypeManager.LoadDefaultPrototypes();
-            _prototypeManager.ResolveResults();
             _userInterfaceManager.Initialize();
             _eyeManager.Initialize();
             _entityManager.Initialize();

--- a/Robust.Server/BaseServer.cs
+++ b/Robust.Server/BaseServer.cs
@@ -369,7 +369,6 @@ namespace Robust.Server
             // otherwise the prototypes will be cleared
             _prototype.Initialize();
             _prototype.LoadDefaultPrototypes();
-            _prototype.ResolveResults();
             _refMan.Initialize();
 
             IoCManager.Resolve<ToolshedManager>().Initialize();

--- a/Robust.UnitTesting/Shared/Prototypes/HotReloadTest.cs
+++ b/Robust.UnitTesting/Shared/Prototypes/HotReloadTest.cs
@@ -1,3 +1,4 @@
+#if TOOLS
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
@@ -114,3 +115,4 @@ namespace Robust.UnitTesting.Shared.Prototypes
     {
     }
 }
+#endif


### PR DESCRIPTION
LoadDefaultPrototypes() already calls ResolveResults()