### PR TITLE
Fix not running hooks when copying non-byref data definition fields without a custom serializer

### DIFF
--- a/Robust.Serialization.Generator/Types.cs
+++ b/Robust.Serialization.Generator/Types.cs
@@ -286,23 +286,6 @@ internal static class Types
         return true;
     }
 
-    internal static bool HasEmptyPublicConstructor(ITypeSymbol type)
-    {
-        if (type is not INamedTypeSymbol named)
-            return false;
-
-        foreach (var constructor in named.InstanceConstructors)
-        {
-            if (constructor.DeclaredAccessibility == Accessibility.Public &&
-                constructor.Parameters.Length == 0)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     internal static bool IsVirtualClass(ITypeSymbol type)
     {
         return type.IsReferenceType && !type.IsSealed && type.TypeKind != TypeKind.Interface;


### PR DESCRIPTION
See https://github.com/space-wizards/space-station-14/issues/19483 and https://github.com/space-wizards/space-station-14/pull/19554