### PR TITLE
Tooltip QoL

### DIFF
--- a/Robust.Client/UserInterface/Tooltips.cs
+++ b/Robust.Client/UserInterface/Tooltips.cs
@@ -38,20 +38,22 @@ namespace Robust.Client.UserInterface
         /// <param name="tooltip">control to position (current size will be used to determine bounds)</param>
         public static void PositionTooltip(Vector2 screenBounds, Vector2 screenPosition, Control tooltip)
         {
-            LayoutContainer.SetPosition(tooltip, screenPosition);
-
             tooltip.Measure(Vector2Helpers.Infinity);
             var combinedMinSize = tooltip.DesiredSize;
-            var (right, bottom) = tooltip.Position + combinedMinSize;
+
+            LayoutContainer.SetPosition(tooltip, new Vector2(screenPosition.X, screenPosition.Y - combinedMinSize.Y));
+
+            var right = tooltip.Position.X + combinedMinSize.X;
+            var top = tooltip.Position.Y - combinedMinSize.Y;
 
             if (right > screenBounds.X)
             {
                 LayoutContainer.SetPosition(tooltip, new(screenPosition.X - combinedMinSize.X, tooltip.Position.Y));
             }
 
-            if (bottom > screenBounds.Y)
+            if (top < 0f)
             {
-                LayoutContainer.SetPosition(tooltip, new(tooltip.Position.X, screenPosition.Y - combinedMinSize.Y));
+                LayoutContainer.SetPosition(tooltip, new(tooltip.Position.X, 0f));
             }
         }
     }

--- a/Robust.Client/UserInterface/UserInterfaceManager.Input.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Input.cs
@@ -39,7 +39,7 @@ internal partial class UserInterfaceManager
     private float? _tooltipDelay;
     private bool _showingTooltip;
     private Control? _suppliedTooltip;
-    private const float TooltipDelay = 1;
+    private const float TooltipDelay = 0.25f;
 
     private WindowRoot? _focusedRoot;
 


### PR DESCRIPTION
- Reduce time to 0.25 globally because content overwhelmingly makes it shorter.
- Anchors to bottom-left at cursor instead of top-left so I can read it (idk if there's an easier way to do this but it works).

![image](https://github.com/space-wizards/RobustToolbox/assets/31366439/c7530368-8bbe-48ae-a4d2-99ba8faa822a)
