### PR TITLE
Remove redundant DebugTools.AssertNotNull(netId) in ClientGameStateManager

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -500,7 +500,6 @@ namespace Robust.Client.GameStates
 
                 foreach (var (netId, comp) in netComps.Value)
                 {
-                    DebugTools.AssertNotNull(netId);
                     if (!comp.NetSyncEnabled)
                         continue;
 


### PR DESCRIPTION
It can never be null since it's an ushort, and also it allocated 1 gigabyte on debug for me.