### PR TITLE
Added method to search nested containers for a specified component

### DIFF
--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -226,28 +226,16 @@ namespace Robust.Shared.Containers
         public bool TryFindComponentOnEntityContainerOrParent<T>(
             EntityUid uid,
             out T? foundComponent,
-            MetaDataComponent? meta = null,
-            TransformComponent? xform = null,
-            EntityQuery<MetaDataComponent>? metas = null,
-            EntityQuery<TransformComponent>? xforms = null) where T : Component
+            EntityQuery<MetaDataComponent> metas,
+            EntityQuery<TransformComponent> xforms) where T : Component
         {
             foundComponent = null;
 
-            if (meta == null)
-            {
-                metas ??= EntityManager.GetEntityQuery<MetaDataComponent>();
-                meta = metas.Value.GetComponent(uid);
-            }
-
+            var meta = metas.GetComponent(uid);
             if ((meta.Flags & MetaDataFlags.InContainer) != MetaDataFlags.InContainer)
                 return false;
 
-            if (xform == null)
-            {
-                xforms ??= EntityManager.GetEntityQuery<TransformComponent>();
-                xform = xforms.Value.GetComponent(uid);
-            }
-
+            var xform = xforms.GetComponent(uid);
             if (!xform.ParentUid.Valid)
                 return false;
 
@@ -263,35 +251,23 @@ namespace Robust.Shared.Containers
         public bool TryFindComponentsOnEntityContainerOrParent<T>(
             EntityUid uid,
             out List<T> foundComponents,
-            MetaDataComponent? meta = null,
-            TransformComponent? xform = null,
-            EntityQuery<MetaDataComponent>? metas = null,
-            EntityQuery<TransformComponent>? xforms = null) where T : Component
+            EntityQuery<MetaDataComponent> metas,
+            EntityQuery<TransformComponent> xforms) where T : Component
         {
             foundComponents = new List<T>();
 
-            if (meta == null)
-            {
-                metas ??= EntityManager.GetEntityQuery<MetaDataComponent>();
-                meta = metas.Value.GetComponent(uid);
-            }
-
+            var meta = metas.GetComponent(uid);
             if ((meta.Flags & MetaDataFlags.InContainer) != MetaDataFlags.InContainer)
                 return foundComponents.Any();
 
-            if (xform == null)
-            {
-                xforms ??= EntityManager.GetEntityQuery<TransformComponent>();
-                xform = xforms.Value.GetComponent(uid);
-            }
-
+            var xform = xforms.GetComponent(uid);
             if (!xform.ParentUid.Valid)
                 return foundComponents.Any();
 
             if (TryComp<T>(xform.ParentUid, out var foundComponent) && foundComponent != null)
                 foundComponents.Add(foundComponent);
 
-            if (TryFindComponentsOnEntityContainerOrParent<T>(xform.ParentUid, out var extraComponents, metas: metas, xforms: xforms))
+            if (TryFindComponentsOnEntityContainerOrParent<T>(xform.ParentUid, out var extraComponents, metas, xforms))
                 foundComponents = foundComponents.Concat(extraComponents).ToList();
 
             return foundComponents.Any();

--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -260,12 +260,10 @@ namespace Robust.Shared.Containers
         public bool TryFindComponentsOnEntityContainerOrParent<T>(
             EntityUid uid,
             EntityQuery<T> entityQuery,
-            ref List<T> foundComponents,
+            List<T> foundComponents,
             MetaDataComponent? meta = null,
             TransformComponent? xform = null) where T : Component
         {
-            T? foundComponent = null;
-
             if (!_metas.Resolve(uid, ref meta))
                 return foundComponents.Any();
 
@@ -278,10 +276,10 @@ namespace Robust.Shared.Containers
             if (!xform.ParentUid.Valid)
                 return foundComponents.Any();
 
-            if (entityQuery.Resolve(xform.ParentUid, ref foundComponent, false) && foundComponent != null)
+            if (EntityManager.TryGetComponent(xform.ParentUid, out T? foundComponent) && foundComponent != null)
                 foundComponents.Add(foundComponent);
 
-            return TryFindComponentsOnEntityContainerOrParent(xform.ParentUid, entityQuery, ref foundComponents);
+            return TryFindComponentsOnEntityContainerOrParent(xform.ParentUid, entityQuery, foundComponents);
         }
 
         /// <summary>

--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -250,7 +250,7 @@ namespace Robust.Shared.Containers
             if (!xform.ParentUid.Valid)
                 return false;
 
-            if (entityQuery.Resolve(xform.ParentUid, ref foundComponent))
+            if (entityQuery.Resolve(xform.ParentUid, ref foundComponent, false))
                 return true;
 
             return TryFindComponentOnEntityContainerOrParent(xform.ParentUid, entityQuery, out foundComponent);
@@ -281,7 +281,7 @@ namespace Robust.Shared.Containers
             if (!xform.ParentUid.Valid)
                 return foundComponents.Any();
 
-            if (entityQuery.Resolve(xform.ParentUid, ref foundComponent) && foundComponent != null)
+            if (entityQuery.Resolve(xform.ParentUid, ref foundComponent, false) && foundComponent != null)
                 foundComponents.Add(foundComponent);
 
             if (TryFindComponentsOnEntityContainerOrParent(xform.ParentUid, entityQuery, out var extraComponents))

--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -232,12 +232,10 @@ namespace Robust.Shared.Containers
         public bool TryFindComponentOnEntityContainerOrParent<T>(
             EntityUid uid,
             EntityQuery<T> entityQuery,
-            [NotNullWhen(true)] out T? foundComponent,
+            [NotNullWhen(true)] ref T? foundComponent,
             MetaDataComponent? meta = null,
             TransformComponent? xform = null) where T : Component
         {
-            foundComponent = null;
-
             if (!_metas.Resolve(uid, ref meta))
                 return false;
 
@@ -253,7 +251,7 @@ namespace Robust.Shared.Containers
             if (entityQuery.Resolve(xform.ParentUid, ref foundComponent, false))
                 return true;
 
-            return TryFindComponentOnEntityContainerOrParent(xform.ParentUid, entityQuery, out foundComponent);
+            return TryFindComponentOnEntityContainerOrParent(xform.ParentUid, entityQuery, ref foundComponent);
         }
 
         /// <summary>
@@ -262,12 +260,11 @@ namespace Robust.Shared.Containers
         public bool TryFindComponentsOnEntityContainerOrParent<T>(
             EntityUid uid,
             EntityQuery<T> entityQuery,
-            out List<T> foundComponents,
+            ref List<T> foundComponents,
             MetaDataComponent? meta = null,
             TransformComponent? xform = null) where T : Component
         {
             T? foundComponent = null;
-            foundComponents = new List<T>();
 
             if (!_metas.Resolve(uid, ref meta))
                 return foundComponents.Any();
@@ -284,10 +281,7 @@ namespace Robust.Shared.Containers
             if (entityQuery.Resolve(xform.ParentUid, ref foundComponent, false) && foundComponent != null)
                 foundComponents.Add(foundComponent);
 
-            if (TryFindComponentsOnEntityContainerOrParent(xform.ParentUid, entityQuery, out var extraComponents))
-                foundComponents = foundComponents.Concat(extraComponents).ToList();
-
-            return foundComponents.Any();
+            return TryFindComponentsOnEntityContainerOrParent(xform.ParentUid, entityQuery, ref foundComponents);
         }
 
         /// <summary>

--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -276,7 +276,7 @@ namespace Robust.Shared.Containers
             if (!xform.ParentUid.Valid)
                 return foundComponents.Any();
 
-            if (EntityManager.TryGetComponent(xform.ParentUid, out T? foundComponent) && foundComponent != null)
+            if (EntityManager.TryGetComponent(xform.ParentUid, out T? foundComponent))
                 foundComponents.Add(foundComponent);
 
             return TryFindComponentsOnEntityContainerOrParent(xform.ParentUid, entityQuery, foundComponents);


### PR DESCRIPTION
Adds two new methods to SharedContainerSystem that allow you to recursively search the parent objects of a contained entity for a specified component

The first method returns the first matching component found, and the second returns a list of matching components found across all recursive parent entities