### PR TITLE
Respect ignored prototypes even if the kind name is registered

### DIFF
--- a/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
@@ -7,10 +7,8 @@ using Robust.Shared.Random;
 using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.Markdown.Sequence;
-using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Utility;
-using YamlDotNet.RepresentationModel;
 
 namespace Robust.Shared.Prototypes;
 
@@ -155,11 +153,11 @@ public partial class PrototypeManager
     private ExtractedMappingData? ExtractMapping(MappingDataNode dataNode)
     {
         var type = dataNode.Get<ValueDataNode>("type").Value;
+        if (_ignoredPrototypeTypes.Contains(type))
+            return null;
+
         if (!_kindNames.TryGetValue(type, out var kind))
         {
-            if (_ignoredPrototypeTypes.Contains(type))
-                return null;
-
             throw new PrototypeLoadException($"Unknown prototype type: '{type}'");
         }
 

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlValidate.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlValidate.cs
@@ -1,16 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager;
-using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Utility;
-using YamlDotNet.Core;
 using YamlDotNet.RepresentationModel;
 
 namespace Robust.Shared.Prototypes;
@@ -46,11 +42,11 @@ public partial class PrototypeManager
                 foreach (YamlMappingNode node in rootNode.Cast<YamlMappingNode>())
                 {
                     var typeId = node.GetNode("type").AsString();
+                    if (_ignoredPrototypeTypes.Contains(typeId))
+                        continue;
+
                     if (!_kindNames.TryGetValue(typeId, out var type))
                     {
-                        if (_ignoredPrototypeTypes.Contains(typeId))
-                            continue;
-
                         throw new PrototypeLoadException($"Unknown prototype type: '{typeId}'");
                     }
 


### PR DESCRIPTION
This makes it not parse a prototype kind even if that prototype class is found (for example with it being in shared)