### PR TITLE
Add tile overlay edge priority

### DIFF
--- a/Robust.Client/Map/TileEdgeOverlay.cs
+++ b/Robust.Client/Map/TileEdgeOverlay.cs
@@ -61,9 +61,14 @@ public sealed class TileEdgeOverlay : Overlay
 
                         var neighborIndices = new Vector2i(tileRef.GridIndices.X + x, tileRef.GridIndices.Y + y);
                         var neighborTile = grid.GetTileRef(neighborIndices);
+                        var neighborDef = _tileDefManager[neighborTile.Tile.TypeId];
 
                         // If it's the same tile then no edge to be drawn.
                         if (tileRef.Tile.TypeId == neighborTile.Tile.TypeId)
+                            continue;
+
+                        // Don't draw if the the neighbor tile edges should draw over us (or if we have the same priority)
+                        if (neighborDef.EdgeSprites.Count != 0 && neighborDef.EdgeSpritePriority >= tileDef.EdgeSpritePriority)
                             continue;
 
                         var direction = new Vector2i(x, y).AsDirection();

--- a/Robust.Shared/Map/ITileDefinition.cs
+++ b/Robust.Shared/Map/ITileDefinition.cs
@@ -30,9 +30,15 @@ namespace Robust.Shared.Map
         ResPath? Sprite { get; }
 
         /// <summary>
-        /// Possible sprites to use if we're neighboring another tile.
+        ///     Possible sprites to use if we're neighboring another tile.
         /// </summary>
         Dictionary<Direction, ResPath> EdgeSprites { get; }
+
+        /// <summary>
+        ///     When drawing adjacent tiles that both specify edge sprites, the one with the higher priority
+        ///     is always solely drawn.
+        /// </summary>
+        int EdgeSpritePriority { get; }
 
         /// <summary>
         ///     Physics objects that are interacting on this tile are slowed down by this float.


### PR DESCRIPTION
needed for rendering multiple tiles with edges next to eachother

higher prio -> render over, same or less prio -> dont render them at all

needs https://github.com/space-wizards/space-station-14/pull/19689

b4
![image](https://github.com/space-wizards/RobustToolbox/assets/19853115/27cb4b7a-4b1b-4d4c-95d2-e03fdaa91aa2)

afta
![image-1](https://github.com/space-wizards/RobustToolbox/assets/19853115/29680678-5030-4f22-ad11-9778d0867919)
