### PR TITLE
Remove redundant new() constraint from EntitySystem.AddComp with a comp instance

### DIFF
--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -539,7 +539,7 @@ public partial class EntitySystem
 
     /// <inheritdoc cref="IEntityManager.AddComponent&lt;T&gt;(EntityUid, T, bool)"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected void AddComp<T>(EntityUid uid, T component, bool overwrite = false) where T :  Component, new()
+    protected void AddComp<T>(EntityUid uid, T component, bool overwrite = false) where T : Component
     {
         EntityManager.AddComponent(uid, component, overwrite);
     }


### PR DESCRIPTION
The one in EntityManager doesn't have it which allows for abstract generic types such as Component.