### PR TITLE
Miscellaneous replay related changes

### DIFF
--- a/Robust.Server/BaseServer.cs
+++ b/Robust.Server/BaseServer.cs
@@ -388,6 +388,11 @@ namespace Robust.Server
             _protoLoadMan.Initialize();
             _netResMan.Initialize();
 
+            // String serializer has to be locked before PostInit as content can depend on it (e.g., replays that start
+            // automatically recording on startup).
+            AddFinalStringsToSerializer();
+            _stringSerializer.LockStrings();
+
             _modLoader.BroadcastRunLevel(ModRunLevel.PostInit);
 
             _statusHost.Start();
@@ -396,9 +401,6 @@ namespace Robust.Server
             AppDomain.CurrentDomain.ProcessExit += ProcessExiting;
 
             _watchdogApi.Initialize();
-
-            AddFinalStringsToSerializer();
-            _stringSerializer.LockStrings();
 
             if (OperatingSystem.IsWindows() && _config.GetCVar(CVars.SysWinTickPeriod) >= 0)
             {

--- a/Robust.Shared/ContentPack/VirtualWritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/VirtualWritableDirProvider.cs
@@ -43,7 +43,7 @@ namespace Robust.Shared.ContentPack
             {
                 if (directory.Children.TryGetValue(segment, out var child))
                 {
-                    if (!(child is DirectoryNode childDir))
+                    if (child is not DirectoryNode childDir)
                     {
                         throw new ArgumentException("A file already exists at that location.");
                     }
@@ -55,6 +55,7 @@ namespace Robust.Shared.ContentPack
                 var newDir = new DirectoryNode();
 
                 directory.Children.Add(segment, newDir);
+                directory = newDir;
             }
         }
 
@@ -205,7 +206,28 @@ namespace Robust.Shared.ContentPack
 
         public void Rename(ResPath oldPath, ResPath newPath)
         {
-            throw new NotImplementedException();
+            if (!oldPath.IsRooted)
+                throw new ArgumentException("Path must be rooted", nameof(oldPath));
+
+            if (!newPath.IsRooted)
+                throw new ArgumentException("Path must be rooted", nameof(newPath));
+
+            if (!TryGetNodeAt(oldPath.Directory, out var parent) || parent is not DirectoryNode sourceDir)
+                throw new ArgumentException("Source directory does not exist.");
+
+            if (!TryGetNodeAt(newPath.Directory, out var target) || target is not DirectoryNode targetDir)
+                throw new ArgumentException("Target directory does not exist.");
+
+            var newFile = newPath.Filename;
+            if (targetDir.Children.ContainsKey(newFile))
+                throw new ArgumentException("Target node already exists");
+
+            var oldFile = oldPath.Filename;
+            if (!sourceDir.Children.TryGetValue(oldFile, out var node))
+                throw new ArgumentException("Node does not exist in original directory.");
+
+            sourceDir.Children.Remove(oldFile);
+            targetDir.Children.Add(newFile, node);
         }
 
         public void OpenOsWindow(ResPath path)

--- a/Robust.Shared/Replays/IReplayRecordingManager.cs
+++ b/Robust.Shared/Replays/IReplayRecordingManager.cs
@@ -124,6 +124,11 @@ public interface IReplayRecordingManager
     /// Thrown if we are currently recording (<see cref="IsRecording"/> true).
     /// </exception>
     Task WaitWriteTasks();
+
+    /// <summary>
+    /// Returns true if there are any currently running write tasks.
+    /// </summary>
+    bool IsWriting();
 }
 
 /// <summary>

--- a/Robust.Shared/Replays/SharedReplayRecordingManager.Write.cs
+++ b/Robust.Shared/Replays/SharedReplayRecordingManager.Write.cs
@@ -187,6 +187,12 @@ internal abstract partial class SharedReplayRecordingManager
         }
     }
 
+    public bool IsWriting()
+    {
+        UpdateWriteTasks();
+        return _finalizingWriteTasks.Count > 0;
+    }
+
     public Task WaitWriteTasks()
     {
         if (IsRecording)

--- a/Robust.UnitTesting/IntegrationMappedStringSerializer.cs
+++ b/Robust.UnitTesting/IntegrationMappedStringSerializer.cs
@@ -78,7 +78,7 @@ namespace Robust.UnitTesting
 
         public (byte[] mapHash, byte[] package) GeneratePackage()
         {
-            throw new NotSupportedException();
+            return (Array.Empty<byte>(), Array.Empty<byte>());
         }
 
         public void SetPackage(byte[] hash, byte[] package)


### PR DESCRIPTION
- `IRobustMappedStringSerializer` mapped string finalization/locking now occurs before the `ModRunLevel.PostInit` broadcast.
  - Not sure if this has any side effects, but its required if auto recording replays are enabled (PostInit -> round start -> recording start` 
  - I have no idea how this isn't causing issues for automatic recordings, but it causes errors when testing locally.
  - If this can't be moved, we might actually need to add post-post-init level. Or find some other way to fix the initialization spaghetti
- Fixes `VirtualWritableDirProvider.CreateDir()` not properly creating nested directories
- Implements `VirtualWritableDirProvider.Rename()`
- Changes `IntegrationMappedStringSerializer` slightly so that replays can be recorded in integration tests.
  - Not sure if the recordings actually work, but at least they record without erroring now. 