### PR TITLE
Add entity categories

### DIFF
--- a/Resources/EnginePrototypes/Debug/rotation.yml
+++ b/Resources/EnginePrototypes/Debug/rotation.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: debugRotation
   abstract: true
-  suffix: DEBUG
+  categories: [ debug ]
   components:
   - type: Sprite
     netsync: false

--- a/Resources/EnginePrototypes/entityCategory.yml
+++ b/Resources/EnginePrototypes/entityCategory.yml
@@ -1,0 +1,17 @@
+# debug related entities
+- type: entityCategory
+  id: debug
+  name: entity-category-name-debug
+  description: entity-category-desc-debug
+
+# entities that spawn other entities
+- type: entityCategory
+  id: spawner
+  name: entity-category-name-spawner
+  description: entity-category-desc-spawner
+
+# entities that should be hidden from the spawn menu
+- type: entityCategory
+  id: hideSpawnMenu
+  name: entity-category-name-hide
+  description: entity-category-desc-hide

--- a/Resources/Locale/en-US/entity-category.ftl
+++ b/Resources/Locale/en-US/entity-category.ftl
@@ -1,0 +1,8 @@
+entity-category-name-debug = Debug
+entity-category-desc-debug = Entity prototypes intended for debugging & testing.
+
+entity-category-name-spawner = Spawner
+entity-category-desc-spawner = Entity prototypes that spawn other entities.
+
+entity-category-name-hide = Hidden
+entity-category-desc-hide = Entity prototypes that should be hidden from the spawn menu

--- a/Robust.Client/UserInterface/Controllers/Implementations/EntitySpawningUIController.cs
+++ b/Robust.Client/UserInterface/Controllers/Implementations/EntitySpawningUIController.cs
@@ -10,6 +10,7 @@ using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.Enums;
 using Robust.Shared.IoC;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Utility;
 using static Robust.Client.UserInterface.Controls.BaseButton;
 using static Robust.Client.UserInterface.Controls.LineEdit;
@@ -199,7 +200,7 @@ public sealed class EntitySpawningUIController : UIController
                 continue;
             }
 
-            if (prototype.NoSpawn)
+            if (prototype.HideSpawnMenu)
             {
                 continue;
             }

--- a/Robust.Server/Prototypes/ServerPrototypeManager.cs
+++ b/Robust.Server/Prototypes/ServerPrototypeManager.cs
@@ -51,6 +51,7 @@ namespace Robust.Server.Prototypes
 
         public override void LoadDefaultPrototypes(Dictionary<Type, HashSet<string>>? changed = null)
         {
+            LoadDirectory(new("/EnginePrototypes/"), changed: changed);
             LoadDirectory(_server.Options.PrototypeDirectory, changed: changed);
             ResolveResults();
         }

--- a/Robust.Shared/Prototypes/EntityCategoryPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityCategoryPrototype.cs
@@ -1,0 +1,25 @@
+using Robust.Shared.Serialization.Manager.Attributes;
+
+namespace Robust.Shared.Prototypes;
+
+/// <summary>
+/// Prototype that represents game entities.
+/// </summary>
+[Prototype("entityCategory")]
+public sealed class EntityCategoryPrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    /// <summary>
+    /// Localized name of the category, for use in entity spawn menus.
+    /// </summary>
+    [DataField("name")]
+    public string? Name { get; private set; }
+
+    /// <summary>
+    /// Localized description of the category, for use in entity spawn menus.
+    /// </summary>
+    [DataField("description")]
+    public string? Description { get; private set; }
+}

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -4,7 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
-using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
@@ -12,6 +11,7 @@ using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Set;
 using Robust.Shared.ViewVariables;
 
 namespace Robust.Shared.Prototypes
@@ -26,6 +26,9 @@ namespace Robust.Shared.Prototypes
         private ILocalizationManager _loc = default!;
 
         private static readonly Dictionary<string, string> LocPropertiesDefault = new();
+
+        [ValidatePrototypeId<EntityCategoryPrototype>]
+        private const string HideCategory = "hideSpawnMenu";
 
         // LOCALIZATION NOTE:
         // Localization-related properties in here are manually localized in LocalizationManager.
@@ -56,6 +59,10 @@ namespace Robust.Shared.Prototypes
 
         [DataField("suffix")]
         public string? SetSuffix { get; private set; }
+
+        [DataField("categories")]
+        [AlwaysPushInheritance]
+        public HashSet<string> Categories = new();
 
         [ViewVariables]
         public IReadOnlyDictionary<string, string> LocProperties => _locPropertiesSet ?? LocPropertiesDefault;
@@ -92,7 +99,10 @@ namespace Robust.Shared.Prototypes
         [ViewVariables]
         [NeverPushInheritance]
         [DataField("noSpawn")]
+        [Obsolete("Use the HideSpawnMenu")]
         public bool NoSpawn { get; private set; }
+
+        public bool HideSpawnMenu => Categories.Contains(HideCategory);
 
         [DataField("placement")]
         private EntityPlacementProperties PlacementProperties = new();

--- a/Robust.Shared/Serialization/Manager/SerializationManager.Composition.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.Composition.cs
@@ -112,14 +112,40 @@ public partial class SerializationManager
         }, (node, this));
     }
 
-    private SequenceDataNode PushInheritanceSequence(SequenceDataNode child, SequenceDataNode _)
+    private SequenceDataNode PushInheritanceSequence(SequenceDataNode child, SequenceDataNode parent)
     {
-        return child; //todo implement different inheritancebehaviours for yamlfield
+        //todo implement different inheritancebehaviours for yamlfield
+        // I have NFI what this comment means.
+
+        var result = new SequenceDataNode(child.Count + parent.Count);
+        foreach (var entry in parent)
+        {
+            result.Add(entry);
+        }
+        foreach (var entry in child)
+        {
+            result.Add(entry);
+        }
+
+        return result;
     }
 
-    private MappingDataNode PushInheritanceMapping(MappingDataNode child, MappingDataNode _)
+    private MappingDataNode PushInheritanceMapping(MappingDataNode child, MappingDataNode parent)
     {
-        return child; //todo implement different inheritancebehaviours for yamlfield
+        //todo implement different inheritancebehaviours for yamlfield
+        // I have NFI what this comment means.
+
+        var result = new MappingDataNode(child.Count + parent.Count);
+        foreach (var (k, v) in parent)
+        {
+            result[k] = v;
+        }
+        foreach (var (k, v) in child)
+        {
+            result[k] = v;
+        }
+
+        return result;
     }
 
     private MappingDataNode PushInheritanceDefinition(MappingDataNode child, MappingDataNode parent,


### PR DESCRIPTION
Entity prototypes should have some sort of way to tag/categorize them so that they can be easily be filtered in spawn menus.
This PR adds a new prototype kind (EntityCategoryPrototype), and gives entity prototypes a new category id hashset. Entity prototypes always inherit all categories from all parents. This PR also adds 3 basic categories, which I want to use to eventually replace the current uses of `suffix: DEBUG`, and `noSpawn: true`. Currently categories are just names & descriptions, but they could always be extended in future to have more information (e.g., icons). 
