### PR TITLE
Add obsoletion warnings to serialization source generated methods, xmldocs

### DIFF
--- a/Robust.Serialization.Generator/Generator.cs
+++ b/Robust.Serialization.Generator/Generator.cs
@@ -209,6 +209,8 @@ using Robust.Shared.Serialization.TypeSerializers.Interfaces;
                         """;
 
              baseCopy = $$"""
+                          /// <seealso cref="ISerializationManager.CopyTo"/>
+                          [Obsolete("Use ISerializationManager.CopyTo instead")]
                           public override void Copy(ref {{baseName}} target, ISerializationManager serialization, SerializationHookContext hookCtx, ISerializationContext? context = null)
                           {
                               var cast = ({{definition.GenericTypeName}}) target;
@@ -216,6 +218,8 @@ using Robust.Shared.Serialization.TypeSerializers.Interfaces;
                               target = cast!;
                           }
 
+                          /// <seealso cref="ISerializationManager.CopyTo"/>
+                          [Obsolete("Use ISerializationManager.CopyTo instead")]
                           public override void Copy(ref object target, ISerializationManager serialization, SerializationHookContext hookCtx, ISerializationContext? context = null)
                           {
                               var cast = ({{definition.GenericTypeName}}) target;
@@ -227,6 +231,8 @@ using Robust.Shared.Serialization.TypeSerializers.Interfaces;
         else
         {
             baseCopy = $$"""
+                         /// <seealso cref="ISerializationManager.CopyTo"/>
+                         [Obsolete("Use ISerializationManager.CopyTo instead")]
                          public {{modifiers}} void Copy(ref object target, ISerializationManager serialization, SerializationHookContext hookCtx, ISerializationContext? context = null)
                          {
                              var cast = ({{definition.GenericTypeName}}) target;
@@ -237,12 +243,16 @@ using Robust.Shared.Serialization.TypeSerializers.Interfaces;
         }
 
         builder.AppendLine($$"""
+                             /// <seealso cref="ISerializationManager.CopyTo"/>
+                             [Obsolete("Use ISerializationManager.CopyTo instead")]
                              public {{modifiers}} void InternalCopy(ref {{definition.GenericTypeName}} target, ISerializationManager serialization, SerializationHookContext hookCtx, ISerializationContext? context = null)
                              {
                                 {{baseCall}}
                                 {{CopyDataFields(definition)}}
                              }
 
+                             /// <seealso cref="ISerializationManager.CopyTo"/>
+                             [Obsolete("Use ISerializationManager.CopyTo instead")]
                              public {{modifiers}} void Copy(ref {{definition.GenericTypeName}} target, ISerializationManager serialization, SerializationHookContext hookCtx, ISerializationContext? context = null)
                              {
                                  InternalCopy(ref target, serialization, hookCtx, context);
@@ -259,6 +269,8 @@ using Robust.Shared.Serialization.TypeSerializers.Interfaces;
             var interfaceName = @interface.ToDisplayString();
 
             builder.AppendLine($$"""
+                                 /// <seealso cref="ISerializationManager.CopyTo"/>
+                                 [Obsolete("Use ISerializationManager.CopyTo instead")]
                                  public {{interfaceModifiers}} void InternalCopy(ref {{interfaceName}} target, ISerializationManager serialization, SerializationHookContext hookCtx, ISerializationContext? context = null)
                                  {
                                      var def = ({{definition.GenericTypeName}}) target;
@@ -266,6 +278,8 @@ using Robust.Shared.Serialization.TypeSerializers.Interfaces;
                                      target = def;
                                  }
 
+                                 /// <seealso cref="ISerializationManager.CopyTo"/>
+                                 [Obsolete("Use ISerializationManager.CopyTo instead")]
                                  public {{interfaceModifiers}} void Copy(ref {{interfaceName}} target, ISerializationManager serialization, SerializationHookContext hookCtx, ISerializationContext? context = null)
                                  {
                                      InternalCopy(ref target, serialization, hookCtx, context);
@@ -290,6 +304,8 @@ using Robust.Shared.Serialization.TypeSerializers.Interfaces;
         {
             // TODO make abstract once data definitions are forced to be partial
             builder.AppendLine($$"""
+                                 /// <seealso cref="ISerializationManager.CreateCopy"/>
+                                 [Obsolete("Use ISerializationManager.CreateCopy instead")]
                                  public {{modifiers}} {{definition.GenericTypeName}} Instantiate()
                                  {
                                      throw new NotImplementedException();
@@ -299,6 +315,8 @@ using Robust.Shared.Serialization.TypeSerializers.Interfaces;
         else
         {
             builder.AppendLine($$"""
+                                 /// <seealso cref="ISerializationManager.CreateCopy"/>
+                                 [Obsolete("Use ISerializationManager.CreateCopy instead")]
                                  public {{modifiers}} {{definition.GenericTypeName}} Instantiate()
                                  {
                                      return new {{definition.GenericTypeName}}();

--- a/Robust.Shared/Serialization/ISerializationGenerated.cs
+++ b/Robust.Shared/Serialization/ISerializationGenerated.cs
@@ -7,6 +7,7 @@ namespace Robust.Shared.Serialization;
 
 public interface ISerializationGenerated<T> : ISerializationGenerated
 {
+    /// <seealso cref="ISerializationManager.CopyTo"/>
     [Obsolete("Use ISerializationManager.CopyTo instead")]
     void Copy(
         ref T target,
@@ -14,6 +15,7 @@ public interface ISerializationGenerated<T> : ISerializationGenerated
         SerializationHookContext hookCtx,
         ISerializationContext? context = null);
 
+    /// <seealso cref="ISerializationManager.CopyTo"/>
     [Obsolete("Use ISerializationManager.CopyTo instead")]
     void InternalCopy(
         ref T target,
@@ -21,12 +23,14 @@ public interface ISerializationGenerated<T> : ISerializationGenerated
         SerializationHookContext hookCtx,
         ISerializationContext? context = null);
 
+    /// <seealso cref="ISerializationManager.CreateCopy"/>
     [Obsolete("Use ISerializationManager.CreateCopy instead")]
     T Instantiate();
 }
 
 public interface ISerializationGenerated
 {
+    /// <seealso cref="ISerializationManager.CopyTo"/>
     [Obsolete("Use ISerializationManager.CopyTo instead")]
     void Copy(
         ref object target,


### PR DESCRIPTION
Really getting it across that these should not be used directly.
This makes the obsoletion warning show up if the methods are called on the concrete type directly instead of on the interface.