### PR TITLE
Fix IEye not updating always

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/EyeSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/EyeSystem.cs
@@ -17,10 +17,16 @@ public sealed class EyeSystem : SharedEyeSystem
         SubscribeLocalEvent<EyeComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<EyeComponent, PlayerDetachedEvent>(OnEyeDetached);
         SubscribeLocalEvent<EyeComponent, PlayerAttachedEvent>(OnEyeAttached);
+        SubscribeLocalEvent<EyeComponent, AfterAutoHandleStateEvent>(OnEyeAutoState);
 
         // Make sure this runs *after* entities have been moved by interpolation and movement.
         UpdatesAfter.Add(typeof(TransformSystem));
         UpdatesAfter.Add(typeof(PhysicsSystem));
+    }
+
+    private void OnEyeAutoState(EntityUid uid, EyeComponent component, ref AfterAutoHandleStateEvent args)
+    {
+        UpdateEye(component);
     }
 
     private void OnEyeAttached(EntityUid uid, EyeComponent component, PlayerAttachedEvent args)

--- a/Robust.Shared/GameObjects/Components/Eye/EyeComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Eye/EyeComponent.cs
@@ -9,7 +9,7 @@ using Robust.Shared.ViewVariables;
 
 namespace Robust.Shared.GameObjects
 {
-    [RegisterComponent, NetworkedComponent, Access(typeof(SharedEyeSystem)), AutoGenerateComponentState]
+    [RegisterComponent, NetworkedComponent, Access(typeof(SharedEyeSystem)), AutoGenerateComponentState(true)]
     public sealed partial class EyeComponent : Component
     {
         #region Client

--- a/Robust.Shared/GameObjects/Systems/SharedEyeSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedEyeSystem.cs
@@ -8,6 +8,20 @@ public abstract class SharedEyeSystem : EntitySystem
 {
     [Dependency] protected readonly SharedTransformSystem TransformSystem = default!;
 
+    /// <summary>
+    /// Refreshes all values for IEye with the component.
+    /// </summary>
+    public void UpdateEye(EyeComponent component)
+    {
+        if (component._eye == null)
+            return;
+
+        component._eye.Offset = component.Offset;
+        component._eye.DrawFov = component.DrawFov;
+        component._eye.Rotation = component.Rotation;
+        component._eye.Zoom = component.Zoom;
+    }
+
     public void SetOffset(EntityUid uid, Vector2 value, EyeComponent? eyeComponent = null)
     {
         if (!Resolve(uid, ref eyeComponent))


### PR DESCRIPTION
If the server state overwrote the client state the eye would never correct its values.

This happens rarely on joining devmap from the gravity shake not being corrected so you'd be stuck offset.