### PR TITLE
PVS NetEntity related changes

### DIFF
--- a/Robust.Shared/GameObjects/NetEntity.cs
+++ b/Robust.Shared/GameObjects/NetEntity.cs
@@ -84,7 +84,7 @@ public readonly struct NetEntity : IEquatable<NetEntity>, IComparable<NetEntity>
     public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj)) return false;
-        return obj is EntityUid id && Equals(id);
+        return obj is NetEntity id && Equals(id);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
- Removes some unnecessary get-component and dictionary lookups from PVS.
- Re-adds  the HashSet<EntityUid> pooling
- Fixes one of the NetEntity equality methods