### PR TITLE
Store metadata component in NetEntity lookup dictionary

### DIFF
--- a/Robust.Client/GameObjects/ClientEntityManager.Network.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.Network.cs
@@ -35,14 +35,14 @@ public sealed partial class ClientEntityManager
 
         if (NetEntityLookup.TryGetValue(nEntity, out var entity))
         {
-            return entity;
+            return entity.Item1;
         }
 
         // Flag the callerEntity to have their state potentially re-run later.
         var pending = PendingNetEntityStates.GetOrNew(nEntity);
         pending.Add((typeof(T), callerEntity));
 
-        return entity;
+        return entity.Item1;
     }
 
     public override EntityCoordinates EnsureCoordinates<T>(NetCoordinates netCoordinates, EntityUid callerEntity)

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -613,8 +613,7 @@ internal sealed partial class PvsSystem : EntitySystem
         var tree = _treePool.Get();
         foreach (var netEntity in chunk)
         {
-            var uid = GetEntity(netEntity);
-            var meta = _metaQuery.GetComponent(uid);
+            var (uid, meta) = GetEntityData(netEntity);
             AddToChunkSetRecursively(in uid, in netEntity, meta, visMask, tree, chunkSet);
 #if DEBUG
             var xform = _xformQuery.GetComponent(uid);
@@ -794,6 +793,7 @@ internal sealed partial class PvsSystem : EntitySystem
         foreach (var (netEntity, visiblity) in visibleEnts)
         {
             EntityUid uid;
+            MetaDataComponent meta;
 #if DEBUG
             uid = GetEntity(netEntity);
             // if an entity is visible, its parents should always be visible.
@@ -804,18 +804,18 @@ internal sealed partial class PvsSystem : EntitySystem
 
             if (sessionData.RequestedFull)
             {
-                uid = GetEntity(netEntity);
-                entityStates.Add(GetFullEntityState(session, uid, _metaQuery.GetComponent(uid)));
+                (uid, meta) = GetEntityData(netEntity);
+                entityStates.Add(GetFullEntityState(session, uid, meta));
                 continue;
             }
 
             if (visiblity == PvsEntityVisibility.StayedUnchanged)
                 continue;
 
-            uid = GetEntity(netEntity);
+            (uid, meta) = GetEntityData(netEntity);
             var entered = visiblity == PvsEntityVisibility.Entered;
             var entFromTick = entered ? lastSeen.GetValueOrDefault(netEntity) : fromTick;
-            var state = GetEntityState(session, uid, entFromTick, _metaQuery.GetComponent(uid));
+            var state = GetEntityState(session, uid, entFromTick, meta);
 
             if (entered || !state.Empty)
                 entityStates.Add(state);

--- a/Robust.Shared/GameObjects/EntityManager.Network.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Network.cs
@@ -16,7 +16,7 @@ public partial class EntityManager
     /// Inverse lookup for net entities.
     /// Regular lookup uses MetadataComponent.
     /// </summary>
-    protected readonly Dictionary<NetEntity, EntityUid> NetEntityLookup = new(EntityCapacity);
+    protected readonly Dictionary<NetEntity, (EntityUid, MetaDataComponent)> NetEntityLookup = new(EntityCapacity);
 
     /// <summary>
     /// Clears an old inverse lookup for a particular entityuid.
@@ -34,7 +34,7 @@ public partial class EntityManager
     internal void SetNetEntity(EntityUid uid, NetEntity netEntity, MetaDataComponent component)
     {
         DebugTools.Assert(!NetEntityLookup.ContainsKey(netEntity));
-        NetEntityLookup[netEntity] = uid;
+        NetEntityLookup[netEntity] = (uid, component);
         component.NetEntity = netEntity;
     }
 
@@ -64,7 +64,7 @@ public partial class EntityManager
     {
         if (NetEntityLookup.TryGetValue(nEntity, out var went))
         {
-            entity = went;
+            entity = went.Item1;
             return true;
         }
 
@@ -141,7 +141,15 @@ public partial class EntityManager
         if (nEntity == NetEntity.Invalid)
             return EntityUid.Invalid;
 
-        return NetEntityLookup.GetValueOrDefault(nEntity);
+        if (!NetEntityLookup.TryGetValue(nEntity, out var tuple))
+            return EntityUid.Invalid;
+
+        return tuple.Item1;
+    }
+
+    public (EntityUid, MetaDataComponent) GetEntityData(NetEntity nEntity)
+    {
+        return NetEntityLookup[nEntity];
     }
 
     /// <inheritdoc />

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -493,6 +493,12 @@ public partial class EntitySystem
         return EntityManager.GetComponent<MetaDataComponent>(uid);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected (EntityUid, MetaDataComponent)  GetEntityData(NetEntity nuid)
+    {
+        return EntityManager.GetEntityData(nuid);
+    }
+
     #endregion
 
     #region Component Has

--- a/Robust.Shared/GameObjects/IEntityManager.Network.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Network.cs
@@ -191,4 +191,10 @@ public partial interface IEntityManager
     public NetCoordinates[] GetNetCoordinatesArray(EntityCoordinates[] entities);
 
     public NetCoordinates?[] GetNetCoordinatesArray(EntityCoordinates?[] entities);
+
+    /// <summary>
+    /// Returns the corresponding local <see cref="EntityUid"/> along with the metdata component.
+    /// throws an exception if the net entity does not exist.
+    /// </summary>
+    (EntityUid, MetaDataComponent) GetEntityData(NetEntity nEntity);
 }

--- a/Robust.Shared/GameObjects/NetEntity.cs
+++ b/Robust.Shared/GameObjects/NetEntity.cs
@@ -84,7 +84,7 @@ public readonly struct NetEntity : IEquatable<NetEntity>, IComparable<NetEntity>
     public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj)) return false;
-        return obj is EntityUid id && Equals(id);
+        return obj is NetEntity id && Equals(id);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
This PR replaces the `Dictionary<NetEntity, EntityUid>` with a `Dictionary<NetEntity, (EntityUid, MetaDataComponent)>`, mainly to avoid fetching the component in PVS.

This PR also contains #4399, just look at the most recent commit for the actual changes.