### PR TITLE
Include sensors in default entity lookups

### DIFF
--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -54,9 +54,11 @@ public enum LookupFlags : byte
     /// </summary>
     Sensors = 1 << 6,
 
-    Uncontained = Dynamic | Static | Sundries,
+    Uncontained = Dynamic | Static | Sundries | Sensors,
 
     StaticSundries = Static | Sundries,
+
+    All = Contained | Dynamic | Static | Sundries | Sensors
 }
 
 /// <summary>
@@ -90,7 +92,7 @@ public sealed partial class EntityLookupSystem : EntitySystem
     /// <summary>
     /// Returns all non-grid entities. Consider using your own flags if you wish for a faster query.
     /// </summary>
-    public const LookupFlags DefaultFlags = LookupFlags.Contained | LookupFlags.Dynamic | LookupFlags.Static | LookupFlags.Sundries;
+    public const LookupFlags DefaultFlags = LookupFlags.All;
 
     public override void Initialize()
     {


### PR DESCRIPTION
Fixes some bugs where entities weren't being returned by lookups.
E.g., this was stopping kudzu from showing up on the nodevis overlay.
Probably not related to the spreading bug, as that uses `GetAnchoredEntitiesEnumerator()`