### PR TITLE
Backport some arch comp net changes

### DIFF
--- a/Robust.Client/GameStates/ClientDirtySystem.cs
+++ b/Robust.Client/GameStates/ClientDirtySystem.cs
@@ -1,7 +1,6 @@
 using Robust.Client.Timing;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
-using Robust.Shared.Log;
 using Robust.Shared.Utility;
 using System;
 using System.Collections.Generic;
@@ -54,7 +53,7 @@ public sealed class ClientDirtySystem : EntitySystem
 
         var uid = args.BaseArgs.Owner;
         var comp = args.BaseArgs.Component;
-        if (!_timing.InPrediction || !comp.NetSyncEnabled || IsClientSide(uid))
+        if (!_timing.InPrediction || !comp.NetSyncEnabled || IsClientSide(uid, args.Meta))
             return;
 
         // Was this component added during prediction? If yes, then there is no need to re-add it when resetting.

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -47,7 +47,7 @@ namespace Robust.Client.GameStates
                 = new();
 
         // Game state dictionaries that get used every tick.
-        private readonly Dictionary<EntityUid, (NetEntity NetEntity, bool EnteringPvs, GameTick LastApplied, EntityState? curState, EntityState? nextState)> _toApply = new();
+        private readonly Dictionary<EntityUid, (NetEntity NetEntity, MetaDataComponent Meta, bool EnteringPvs, GameTick LastApplied, EntityState? curState, EntityState? nextState)> _toApply = new();
         private readonly Dictionary<NetEntity, EntityState> _toCreate = new();
         private readonly Dictionary<ushort, (IComponent Component, ComponentState? curState, ComponentState? nextState)> _compStateWork = new();
         private readonly Dictionary<EntityUid, HashSet<Type>> _pendingReapplyNetStates = new();
@@ -497,11 +497,7 @@ namespace Robust.Client.GameStates
 
                 countReset += 1;
 
-                var netComps = _entityManager.GetNetComponentsOrNull(entity);
-                if (netComps == null)
-                    continue;
-
-                foreach (var (netId, comp) in netComps.Value)
+                foreach (var (netId, comp) in meta.NetComponents)
                 {
                     if (!comp.NetSyncEnabled)
                         continue;
@@ -549,13 +545,13 @@ namespace Robust.Client.GameStates
                 {
                     foreach (var netId in netIds)
                     {
-                        if (_entities.HasComponent(entity, netId))
+                        if (meta.NetComponents.ContainsKey(netId))
                             continue;
 
                         if (!last.TryGetValue(netId, out var state))
                             continue;
 
-                        var comp = _entityManager.AddComponent(entity, netId);
+                        var comp = _entityManager.AddComponent(entity, netId, meta);
 
                         if (_sawmill.Level <= LogLevel.Debug)
                             _sawmill.Debug($"  A component was removed: {comp.GetType()}");
@@ -597,11 +593,11 @@ namespace Robust.Client.GameStates
 
             foreach (var netEntity in createdEntities)
             {
-                var createdEntity = _entityManager.GetEntity(netEntity);
+                var (createdEntity, meta) = _entityManager.GetEntityData(netEntity);
                 var compData = new Dictionary<ushort, ComponentState>();
                 outputData.Add(netEntity, compData);
 
-                foreach (var (netId, component) in _entityManager.GetNetComponents(createdEntity))
+                foreach (var (netId, component) in meta.NetComponents)
                 {
                     if (!component.NetSyncEnabled)
                         continue;
@@ -692,9 +688,9 @@ namespace Robust.Client.GameStates
 
                     var uid = _entities.CreateEntity(metaState.PrototypeId);
                     _toCreate.Add(es.NetEntity, es);
-                    _toApply.Add(uid, (es.NetEntity, false, GameTick.Zero, es, null));
-
                     var newMeta = metas.GetComponent(uid);
+                    _toApply.Add(uid, (es.NetEntity, newMeta, false, GameTick.Zero, es, null));
+
 
                     // Client creates a client-side net entity for the newly created entity.
                     // We need to clear this mapping before assigning the real net id.
@@ -742,7 +738,7 @@ namespace Robust.Client.GameStates
                     continue;
                 }
 
-                _toApply.Add(uid, (es.NetEntity, isEnteringPvs, meta.LastStateApplied, es, null));
+                _toApply.Add(uid, (es.NetEntity, meta, isEnteringPvs, meta.LastStateApplied, es, null));
                 meta.LastStateApplied = curState.ToSequence;
             }
 
@@ -756,19 +752,17 @@ namespace Robust.Client.GameStates
             {
                 foreach (var es in nextState.EntityStates.Span)
                 {
-                    if (!_entityManager.TryGetEntity(es.NetEntity, out var uid))
+                    if (!_entityManager.TryGetEntityData(es.NetEntity, out var uid, out var meta))
                         continue;
-
-                    DebugTools.Assert(metas.HasComponent(uid));
 
                     // Does the next state actually have any future information about this entity that could be used for interpolation?
                     if (es.EntityLastModified != nextState.ToSequence)
                         continue;
 
                     if (_toApply.TryGetValue(uid.Value, out var state))
-                        _toApply[uid.Value] = (es.NetEntity, state.EnteringPvs, state.LastApplied, state.curState, es);
+                        _toApply[uid.Value] = (es.NetEntity, meta, state.EnteringPvs, state.LastApplied, state.curState, es);
                     else
-                        _toApply[uid.Value] = (es.NetEntity, false, GameTick.Zero, null, es);
+                        _toApply[uid.Value] = (es.NetEntity, meta, false, GameTick.Zero, null, es);
                 }
             }
 
@@ -783,7 +777,7 @@ namespace Robust.Client.GameStates
                 if (!metas.TryGetComponent(uid, out var meta))
                     continue;
 
-                _toApply[uid] = (_entityManager.GetNetEntity(uid, meta), false, GameTick.Zero, null, null);
+                _toApply[uid] = (meta.NetEntity, meta, false, GameTick.Zero, null, null);
             }
 
             var queuedBroadphaseUpdates = new List<(EntityUid, TransformComponent)>(enteringPvs);
@@ -793,7 +787,7 @@ namespace Robust.Client.GameStates
             {
                 foreach (var (entity, data) in _toApply)
                 {
-                    HandleEntityState(entity, data.NetEntity, _entities.EventBus, data.curState,
+                    HandleEntityState(entity, data.NetEntity, data.Meta, _entities.EventBus, data.curState,
                         data.nextState, data.LastApplied, curState.ToSequence, data.EnteringPvs);
 
                     if (!data.EnteringPvs)
@@ -1133,7 +1127,7 @@ namespace Robust.Client.GameStates
 #endif
         }
 
-        private void HandleEntityState(EntityUid uid, NetEntity netEntity, IEventBus bus, EntityState? curState,
+        private void HandleEntityState(EntityUid uid, NetEntity netEntity, MetaDataComponent meta, IEventBus bus, EntityState? curState,
             EntityState? nextState, GameTick lastApplied, GameTick toTick, bool enteringPvs)
         {
             _compStateWork.Clear();
@@ -1142,7 +1136,7 @@ namespace Robust.Client.GameStates
             if (curState?.NetComponents != null)
             {
                 RemQueue<Component> toRemove = new();
-                foreach (var (id, comp) in _entities.GetNetComponents(uid))
+                foreach (var (id, comp) in meta.NetComponents)
                 {
                     if (comp.NetSyncEnabled && !curState.NetComponents.Contains(id))
                         toRemove.Add(comp);
@@ -1150,6 +1144,7 @@ namespace Robust.Client.GameStates
 
                 foreach (var comp in toRemove)
                 {
+                    // TODO PERFORMANCE pass metadata into component removal.
                     _entities.RemoveComponent(uid, comp);
                 }
             }
@@ -1163,12 +1158,11 @@ namespace Robust.Client.GameStates
                 // the entity. most notably, all entities will have been ejected from their containers.
                 foreach (var (id, state) in _processor.GetLastServerStates(netEntity))
                 {
-                    if (!_entityManager.TryGetComponent(uid, id, out var comp))
+                    if (!meta.NetComponents.TryGetValue(id, out var comp))
                     {
-                        comp = _compFactory.GetComponent(id);
-                        var newComp = (Component)comp;
-                        newComp.Owner = uid;
-                        _entityManager.AddComponent(uid, newComp, true);
+                        comp = (Component) _compFactory.GetComponent(id);
+                        comp.Owner = uid;
+                        _entityManager.AddComponent(uid, comp, true, metadata: meta);
                     }
 
                     _compStateWork[id] = (comp, state, null);
@@ -1178,12 +1172,11 @@ namespace Robust.Client.GameStates
             {
                 foreach (var compChange in curState.ComponentChanges.Span)
                 {
-                    if (!_entityManager.TryGetComponent(uid, compChange.NetID, out var comp))
+                    if (!meta.NetComponents.TryGetValue(compChange.NetID, out var comp))
                     {
-                        comp = _compFactory.GetComponent(compChange.NetID);
-                        var newComp = (Component)comp;
-                        newComp.Owner = uid;
-                        _entityManager.AddComponent(uid, newComp, true);
+                        comp = (Component) _compFactory.GetComponent(compChange.NetID);
+                        comp.Owner = uid;
+                        _entityManager.AddComponent(uid, comp, true, metadata:meta);
                     }
                     else if (compChange.LastModifiedTick <= lastApplied && lastApplied != GameTick.Zero)
                         continue;
@@ -1199,7 +1192,7 @@ namespace Robust.Client.GameStates
                     if (compState.LastModifiedTick != toTick + 1)
                         continue;
 
-                    if (!_entityManager.TryGetComponent(uid, compState.NetID, out var comp))
+                    if (!meta.NetComponents.TryGetValue(compState.NetID, out var comp))
                     {
                         // The component can be null here due to interp, because the NEXT state will have a new
                         // component, but the component does not yet exist.
@@ -1227,7 +1220,7 @@ namespace Robust.Client.GameStates
                         continue;
 
                     if (_compStateWork.ContainsKey(netId.Value) ||
-                        !_entityManager.TryGetComponent(uid, type, out var comp) ||
+                        !meta.NetComponents.TryGetValue(netId.Value, out var comp) ||
                         !lastState.TryGetValue(netId.Value, out var lastCompState))
                     {
                         continue;
@@ -1398,12 +1391,11 @@ namespace Robust.Client.GameStates
 
             foreach (var (id, state) in lastState)
             {
-                if (!_entityManager.TryGetComponent(uid, id, out var comp))
+                if (!meta.NetComponents.TryGetValue(id, out var comp))
                 {
-                    comp = _compFactory.GetComponent(id);
-                    var newComp = (Component)comp;
-                    newComp.Owner = uid;
-                    _entityManager.AddComponent(uid, newComp, true);
+                    comp = (Component) _compFactory.GetComponent(id);
+                    comp.Owner = uid;
+                    _entityManager.AddComponent(uid, comp, true, meta);
                 }
 
                 var handleState = new ComponentHandleState(state, null);
@@ -1412,7 +1404,7 @@ namespace Robust.Client.GameStates
 
             // ensure we don't have any extra components
             RemQueue<Component> toRemove = new();
-            foreach (var (id, comp) in _entities.GetNetComponents(uid))
+            foreach (var (id, comp) in meta.NetComponents)
             {
                 if (comp.NetSyncEnabled && !lastState.ContainsKey(id))
                     toRemove.Add(comp);

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -1144,8 +1144,7 @@ namespace Robust.Client.GameStates
 
                 foreach (var comp in toRemove)
                 {
-                    // TODO PERFORMANCE pass metadata into component removal.
-                    _entities.RemoveComponent(uid, comp);
+                    _entities.RemoveComponent(uid, comp, meta);
                 }
             }
 

--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -879,7 +879,7 @@ public sealed class MapLoaderSystem : EntitySystem
             return;
         }
 
-        foreach (var (netId, component) in EntityManager.GetNetComponents(entity))
+        foreach (var component in metadata.NetComponents.Values)
         {
             var compName = _factory.GetComponentName(component.GetType());
 

--- a/Robust.Server/GameObjects/EntitySystems/ServerMetaDataSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/ServerMetaDataSystem.cs
@@ -43,15 +43,11 @@ public sealed class ServerMetaDataSystem : MetaDataSystem
     /// </summary>
     private void OnComponentRemoved(RemovedComponentEventArgs obj)
     {
-        // TODO PERFORMANCE just include metadata in the base event?
-        if (!_mQuery.TryGetComponent(obj.BaseArgs.Owner, out var meta))
-            return;
-
         var removed = obj.BaseArgs.Component;
         if (obj.Terminating || !removed.NetSyncEnabled || (!removed.SessionSpecific && !removed.SendOnlyToOwner))
             return;
 
-        foreach (var comp in meta.NetComponents.Values)
+        foreach (var comp in obj.Meta.NetComponents.Values)
         {
             if (comp.LifeStage >= ComponentLifeStage.Removing)
                 continue;
@@ -61,7 +57,7 @@ public sealed class ServerMetaDataSystem : MetaDataSystem
         }
 
         // remove the flag
-        meta.Flags &= ~MetaDataFlags.SessionSpecific;
+        obj.Meta.Flags &= ~MetaDataFlags.SessionSpecific;
     }
 
     /// <summary>

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -139,9 +139,6 @@ namespace Robust.Server.GameObjects
         {
             _networkManager.RegisterNetMessage<MsgEntity>(HandleEntityNetworkMessage);
 
-            // For syncing component deletions.
-            ComponentRemoved += OnComponentRemoved;
-
             _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
 
             _configurationManager.OnValueChanged(CVars.NetLogLateMsg, b => _logLateMsgs = b, true);
@@ -166,15 +163,6 @@ namespace Robust.Server.GameObjects
         public uint GetLastMessageSequence(IPlayerSession session)
         {
             return _lastProcessedSequencesCmd[session];
-        }
-
-        private void OnComponentRemoved(RemovedComponentEventArgs e)
-        {
-            if (e.Terminating || !e.BaseArgs.Component.NetSyncEnabled)
-                return;
-
-            if (TryGetComponent(e.BaseArgs.Owner, out MetaDataComponent? meta))
-                meta.LastComponentRemoved = _gameTiming.CurTick;
         }
 
         /// <inheritdoc />

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -1204,7 +1204,7 @@ Transform last modified: {Transform(uid).LastModifiedTick}");
         bool sendCompList = meta.LastComponentRemoved > fromTick;
         HashSet<ushort>? netComps = sendCompList ? new() : null;
 
-        foreach (var (netId, component) in EntityManager.GetNetComponents(entityUid))
+        foreach (var (netId, component) in meta.NetComponents)
         {
             if (!component.NetSyncEnabled)
                 continue;
@@ -1253,7 +1253,7 @@ Transform last modified: {Transform(uid).LastModifiedTick}");
 
         HashSet<ushort> netComps = new();
 
-        foreach (var (netId, component) in EntityManager.GetNetComponents(entityUid))
+        foreach (var (netId, component) in meta.NetComponents)
         {
             if (!component.NetSyncEnabled)
                 continue;

--- a/Robust.Shared/GameObjects/ComponentEventArgs.cs
+++ b/Robust.Shared/GameObjects/ComponentEventArgs.cs
@@ -46,10 +46,13 @@ namespace Robust.Shared.GameObjects
 
         public readonly bool Terminating;
 
-        public RemovedComponentEventArgs(ComponentEventArgs baseArgs, bool terminating)
+        public readonly MetaDataComponent Meta;
+
+        public RemovedComponentEventArgs(ComponentEventArgs baseArgs, bool terminating, MetaDataComponent meta)
         {
             BaseArgs = baseArgs;
             Terminating = terminating;
+            Meta = meta;
         }
     }
 

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -8,6 +8,7 @@ using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 using System;
+using System.Collections.Generic;
 
 namespace Robust.Shared.GameObjects
 {
@@ -62,6 +63,12 @@ namespace Robust.Shared.GameObjects
         [DataField("name")] internal string? _entityName;
         [DataField("desc")] internal string? _entityDescription;
         internal EntityPrototype? _entityPrototype;
+
+        /// <summary>
+        /// The components attached to the entity that are currently networked.
+        /// </summary>
+        [ViewVariables]
+        public Dictionary<ushort, Component> NetComponents = new();
 
         /// <summary>
         /// Network identifier for this entity.

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -68,7 +68,7 @@ namespace Robust.Shared.GameObjects
         /// The components attached to the entity that are currently networked.
         /// </summary>
         [ViewVariables]
-        public Dictionary<ushort, Component> NetComponents = new();
+        internal readonly Dictionary<ushort, Component> NetComponents = new();
 
         /// <summary>
         /// Network identifier for this entity.

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -35,9 +35,6 @@ namespace Robust.Shared.GameObjects
 
         private static readonly ComponentState DefaultComponentState = new();
 
-        private readonly Dictionary<EntityUid, Dictionary<ushort, Component>> _netComponents
-            = new(EntityCapacity);
-
         private readonly Dictionary<Type, Dictionary<EntityUid, Component>> _entTraitDict
             = new();
 
@@ -70,7 +67,6 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         public void ClearComponents()
         {
-            _netComponents.Clear();
             _entCompIndex.Clear();
             _deleteSet.Clear();
             foreach (var dict in _entTraitDict.Values)
@@ -249,7 +245,7 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public void AddComponent<T>(EntityUid uid, T component, bool overwrite = false) where T : Component
+        public void AddComponent<T>(EntityUid uid, T component, bool overwrite = false, MetaDataComponent? metadata = null) where T : Component
         {
             if (!uid.IsValid() || !EntityExists(uid))
                 throw new ArgumentException($"Entity {uid} is not valid.", nameof(uid));
@@ -267,18 +263,22 @@ namespace Robust.Shared.GameObjects
             }
 #pragma warning restore CS0618 // Type or member is obsolete
 
-            AddComponentInternal(uid, component, overwrite, false);
+            AddComponentInternal(uid, component, overwrite, false, metadata);
         }
 
-        private void AddComponentInternal<T>(EntityUid uid, T component, bool overwrite, bool skipInit) where T : Component
+        private void AddComponentInternal<T>(EntityUid uid, T component, bool overwrite, bool skipInit, MetaDataComponent? metadata = null) where T : Component
+        {
+            // get interface aliases for mapping
+            var reg = _componentFactory.GetRegistration(component);
+            AddComponentInternal(uid, component, reg, overwrite, skipInit, metadata);
+        }
+
+        private void AddComponentInternal<T>(EntityUid uid, T component, ComponentRegistration reg, bool overwrite, bool skipInit, MetaDataComponent? metadata = null) where T : Component
         {
             // We can't use typeof(T) here in case T is just Component
             DebugTools.Assert(component is MetaDataComponent ||
-                GetComponent<MetaDataComponent>(uid).EntityLifeStage < EntityLifeStage.Terminating,
+                              (metadata ?? MetaQuery.GetComponent(uid)).EntityLifeStage < EntityLifeStage.Terminating,
                 $"Attempted to add a {component.GetType().Name} component to an entity ({ToPrettyString(uid)}) while it is terminating");
-
-            // get interface aliases for mapping
-            var reg = _componentFactory.GetRegistration(component);
 
             // Check that there is no existing component.
             var type = reg.Idx;
@@ -303,14 +303,8 @@ namespace Robust.Shared.GameObjects
             {
                 // the main comp grid keeps this in sync
                 var netId = reg.NetID.Value;
-
-                if (!_netComponents.TryGetValue(uid, out var netSet))
-                {
-                    netSet = new Dictionary<ushort, Component>(NetComponentCapacity);
-                    _netComponents.Add(uid, netSet);
-                }
-
-                netSet.Add(netId, component);
+                metadata ??= MetaQuery.GetComponent(uid);
+                metadata.NetComponents.Add(netId, component);
             }
             else
             {
@@ -326,7 +320,7 @@ namespace Robust.Shared.GameObjects
             if (skipInit)
                 return;
 
-            var metadata = GetComponent<MetaDataComponent>(uid);
+            metadata ??= MetaQuery.GetComponent(uid);
 
             if (!metadata.EntityInitialized && !metadata.EntityInitializing)
                 return;
@@ -467,7 +461,6 @@ namespace Robust.Shared.GameObjects
             }
 
             _entCompIndex.Remove(uid);
-            _netComponents.Remove(uid);
         }
 
         private void RemoveComponentDeferred(Component component, EntityUid uid, bool terminating)
@@ -589,20 +582,17 @@ namespace Robust.Shared.GameObjects
             _deleteSet.Clear();
         }
 
-        private void DeleteComponent(EntityUid entityUid, Component component, bool terminating)
+        private void DeleteComponent(EntityUid entityUid, Component component, bool terminating, MetaDataComponent? metadata = null)
         {
-            var type = component.GetType();
-            var reg = _componentFactory.GetRegistration(type);
+            var reg = _componentFactory.GetRegistration(component);
 
-            if (!terminating && reg.NetID != null && _netComponents.TryGetValue(entityUid, out var netSet))
+            if (!terminating && reg.NetID != null)
             {
-                if (netSet.Count == 1)
-                    _netComponents.Remove(entityUid);
-                else
-                    netSet.Remove(reg.NetID.Value);
+                metadata ??= MetaQuery.GetComponent(entityUid);
+                var netSet = metadata.NetComponents;
 
-                if (component.NetSyncEnabled)
-                    DirtyEntity(entityUid);
+                if (netSet.Remove(reg.NetID.Value) && component.NetSyncEnabled)
+                    DirtyEntity(entityUid, metadata);
             }
 
             _entTraitArray[reg.Idx.Value].Remove(entityUid);
@@ -653,8 +643,7 @@ namespace Robust.Shared.GameObjects
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool HasComponent(EntityUid uid, ushort netId)
         {
-            return _netComponents.TryGetValue(uid, out var netSet)
-                   && netSet.ContainsKey(netId);
+            return MetaQuery.TryGetComponent(uid, out var metadata) && metadata.NetComponents.ContainsKey(netId);
         }
 
         /// <inheritdoc />
@@ -666,8 +655,7 @@ namespace Robust.Shared.GameObjects
                 return false;
             }
 
-            return _netComponents.TryGetValue(uid.Value, out var netSet)
-                   && netSet.ContainsKey(netId);
+            return HasComponent(uid.Value, netId);
         }
 
         /// <inheritdoc />
@@ -754,7 +742,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public IComponent GetComponent(EntityUid uid, ushort netId)
         {
-            return _netComponents[uid][netId];
+            return MetaQuery.GetComponent(uid).NetComponents[netId];
         }
 
         /// <inheritdoc />
@@ -870,8 +858,8 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public bool TryGetComponent(EntityUid uid, ushort netId, [MaybeNullWhen(false)] out IComponent component)
         {
-            if (_netComponents.TryGetValue(uid, out var netSet)
-                && netSet.TryGetValue(netId, out var comp))
+            if (MetaQuery.TryGetComponent(uid, out var metadata)
+                && metadata.NetComponents.TryGetValue(netId, out var comp))
             {
                 component = comp;
                 return true;
@@ -891,15 +879,7 @@ namespace Robust.Shared.GameObjects
                 return false;
             }
 
-            if (_netComponents.TryGetValue(uid.Value, out var netSet)
-                && netSet.TryGetValue(netId, out var comp))
-            {
-                component = comp;
-                return true;
-            }
-
-            component = default;
-            return false;
+            return TryGetComponent(uid.Value, netId, out component);
         }
 
         public EntityQuery<TComp1> GetEntityQuery<TComp1>() where TComp1 : Component
@@ -969,15 +949,15 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public NetComponentEnumerable GetNetComponents(EntityUid uid)
         {
-            return new NetComponentEnumerable(_netComponents[uid]);
+            return new NetComponentEnumerable(MetaQuery.GetComponent(uid).NetComponents);
         }
 
         /// <inheritdoc />
         public NetComponentEnumerable? GetNetComponentsOrNull(EntityUid uid)
         {
-            return _netComponents.TryGetValue(uid, out var data)
-                    ? new NetComponentEnumerable(data)
-                    : null;
+            return MetaQuery.TryGetComponent(uid, out var metadata)
+                ? new NetComponentEnumerable(metadata.NetComponents)
+                : null;
         }
 
         #region Join Functions

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -755,7 +755,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public IComponent GetComponent(EntityUid uid, ushort netId, MetaDataComponent? meta = null)
         {
-            return (meta ?? MetaQuery.GetComponent(uid)).NetComponents[netId];
+            return (meta ?? MetaQuery.GetComponentInternal(uid)).NetComponents[netId];
         }
 
         /// <inheritdoc />
@@ -963,7 +963,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public NetComponentEnumerable GetNetComponents(EntityUid uid, MetaDataComponent? meta = null)
         {
-            meta ??= MetaQuery.GetComponent(uid);
+            meta ??= MetaQuery.GetComponentInternal(uid);
             return new NetComponentEnumerable(meta.NetComponents);
         }
 

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -303,7 +303,7 @@ namespace Robust.Shared.GameObjects
             {
                 // the main comp grid keeps this in sync
                 var netId = reg.NetID.Value;
-                metadata ??= MetaQuery.GetComponent(uid);
+                metadata ??= MetaQuery.GetComponentInternal(uid);
                 metadata.NetComponents.Add(netId, component);
             }
             else
@@ -320,7 +320,7 @@ namespace Robust.Shared.GameObjects
             if (skipInit)
                 return;
 
-            metadata ??= MetaQuery.GetComponent(uid);
+            metadata ??= MetaQuery.GetComponentInternal(uid);
 
             if (!metadata.EntityInitialized && !metadata.EntityInitializing)
                 return;
@@ -643,7 +643,7 @@ namespace Robust.Shared.GameObjects
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool HasComponent(EntityUid uid, ushort netId)
         {
-            return MetaQuery.TryGetComponent(uid, out var metadata) && metadata.NetComponents.ContainsKey(netId);
+            return MetaQuery.TryGetComponentInternal(uid, out var metadata) && metadata.NetComponents.ContainsKey(netId);
         }
 
         /// <inheritdoc />
@@ -742,7 +742,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public IComponent GetComponent(EntityUid uid, ushort netId)
         {
-            return MetaQuery.GetComponent(uid).NetComponents[netId];
+            return MetaQuery.GetComponentInternal(uid).NetComponents[netId];
         }
 
         /// <inheritdoc />
@@ -751,7 +751,7 @@ namespace Robust.Shared.GameObjects
             var dict = _entTraitArray[type.Value];
             if (dict.TryGetValue(uid, out var comp))
             {
-                    return comp;
+                return comp;
             }
 
             throw new KeyNotFoundException($"Entity {uid} does not have a component of type {type}");
@@ -858,7 +858,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public bool TryGetComponent(EntityUid uid, ushort netId, [MaybeNullWhen(false)] out IComponent component)
         {
-            if (MetaQuery.TryGetComponent(uid, out var metadata)
+            if (MetaQuery.TryGetComponentInternal(uid, out var metadata)
                 && metadata.NetComponents.TryGetValue(netId, out var comp))
             {
                 component = comp;
@@ -949,13 +949,13 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public NetComponentEnumerable GetNetComponents(EntityUid uid)
         {
-            return new NetComponentEnumerable(MetaQuery.GetComponent(uid).NetComponents);
+            return new NetComponentEnumerable(MetaQuery.GetComponentInternal(uid).NetComponents);
         }
 
         /// <inheritdoc />
         public NetComponentEnumerable? GetNetComponentsOrNull(EntityUid uid)
         {
-            return MetaQuery.TryGetComponent(uid, out var metadata)
+            return MetaQuery.TryGetComponentInternal(uid, out var metadata)
                 ? new NetComponentEnumerable(metadata.NetComponents)
                 : null;
         }

--- a/Robust.Shared/GameObjects/EntityManager.Network.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Network.cs
@@ -73,6 +73,21 @@ public partial class EntityManager
     }
 
     /// <inheritdoc />
+    public bool TryGetEntityData(NetEntity nEntity, [NotNullWhen(true)] out EntityUid? entity, [NotNullWhen(true)] out MetaDataComponent? meta)
+    {
+        if (NetEntityLookup.TryGetValue(nEntity, out var went))
+        {
+            entity = went.Item1;
+            meta = went.Item2;
+            return true;
+        }
+
+        entity = null;
+        meta = null;
+        return false;
+    }
+
+    /// <inheritdoc />
     public bool TryGetEntity(NetEntity? nEntity, [NotNullWhen(true)] out EntityUid? entity)
     {
         if (nEntity == null)

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Prometheus;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
@@ -85,6 +86,9 @@ namespace Robust.Shared.GameObjects
 
         private string _xformName = string.Empty;
 
+        private ComponentRegistration _metaReg = default!;
+        private ComponentRegistration _xformReg = default!;
+
         private SharedMapSystem _mapSystem = default!;
 
         private ISawmill _sawmill = default!;
@@ -111,7 +115,9 @@ namespace Robust.Shared.GameObjects
             _eventBus = new EntityEventBus(this);
 
             InitializeComponents();
-            _xformName = _componentFactory.GetComponentName(typeof(TransformComponent));
+            _metaReg = _componentFactory.GetRegistration(typeof(MetaDataComponent));
+            _xformReg = _componentFactory.GetRegistration(typeof(TransformComponent));
+            _xformName = _xformReg.Name;
             _sawmill = LogManager.GetSawmill("entity");
             _resolveSawmill = LogManager.GetSawmill("resolve");
 
@@ -645,10 +651,12 @@ namespace Robust.Shared.GameObjects
 
             Entities.Add(uid);
             // add the required MetaDataComponent directly.
-            AddComponentInternal(uid, metadata, false, false);
+            AddComponentInternal(uid, metadata, _metaReg, false, true, metadata);
 
             // allocate the required TransformComponent
-            AddComponent<TransformComponent>(uid);
+            var xformComp = Unsafe.As<TransformComponent>(_componentFactory.GetComponent(_xformReg));
+            xformComp.Owner = uid;
+            AddComponentInternal(uid, xformComp, false, true, metadata);
 
             return uid;
         }

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -915,9 +915,9 @@ public partial class EntitySystem
     #region NetEntities
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected bool IsClientSide(EntityUid entity)
+    protected bool IsClientSide(EntityUid entity, MetaDataComponent? meta = null)
     {
-        return EntityManager.IsClientSide(entity);
+        return EntityManager.IsClientSide(entity, meta);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -70,7 +70,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="uid">Entity being modified.</param>
         /// <param name="component">Component to add.</param>
         /// <param name="overwrite">Should it overwrite existing components?</param>
-        void AddComponent<T>(EntityUid uid, T component, bool overwrite = false) where T : Component;
+        void AddComponent<T>(EntityUid uid, T component, bool overwrite = false, MetaDataComponent? metadata = null) where T : Component;
 
         /// <summary>
         ///     Removes the component with the specified reference type,
@@ -187,7 +187,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="uid">Entity UID to check.</param>
         /// <param name="type">A trait or component type to check for.</param>
         /// <returns>True if the entity has the component type, otherwise false.</returns>
-        bool HasComponent(EntityUid ?uid, Type type);
+        bool HasComponent(EntityUid? uid, Type type);
 
         /// <summary>
         ///     Checks if the entity has a component with a given network ID. This does not check

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -49,7 +49,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         ///     Adds a Component with a given network id to an entity.
         /// </summary>
-        Component AddComponent(EntityUid uid, ushort netId);
+        Component AddComponent(EntityUid uid, ushort netId, MetaDataComponent? meta = null);
 
         /// <summary>
         ///     Adds an uninitialized Component type to an entity.
@@ -94,7 +94,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="uid">Entity UID to modify.</param>
         /// <param name="netID">Network ID of the component to remove.</param>
         /// <returns>Returns false if the entity did not have the specified component.</returns>
-        bool RemoveComponent(EntityUid uid, ushort netID);
+        bool RemoveComponent(EntityUid uid, ushort netID, MetaDataComponent? meta = null);
 
         /// <summary>
         ///     Removes the specified component. Throws if the given component does not belong to the entity.
@@ -125,7 +125,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="uid">Entity UID to modify.</param>
         /// <param name="netID">Network ID of the component to remove.</param>
         /// <returns>Returns false if the entity did not have the specified component.</returns>
-        bool RemoveComponentDeferred(EntityUid uid, ushort netID);
+        bool RemoveComponentDeferred(EntityUid uid, ushort netID, MetaDataComponent? meta = null);
 
         /// <summary>
         ///     Immediately shuts down a component, but defers the removal and deletion until the end of the tick.
@@ -196,7 +196,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="uid">Entity UID to check.</param>
         /// <param name="netId">Network ID to check for.</param>
         /// <returns>True if the entity has a component with the given network ID, otherwise false.</returns>
-        bool HasComponent(EntityUid uid, ushort netId);
+        bool HasComponent(EntityUid uid, ushort netId, MetaDataComponent? meta = null);
 
         /// <summary>
         ///     Checks if the entity has a component with a given network ID. This does not check
@@ -205,7 +205,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="uid">Entity UID to check.</param>
         /// <param name="netId">Network ID to check for.</param>
         /// <returns>True if the entity has a component with the given network ID, otherwise false.</returns>
-        bool HasComponent(EntityUid? uid, ushort netId);
+        bool HasComponent(EntityUid? uid, ushort netId, MetaDataComponent? meta = null);
 
         /// <summary>
         ///     This method will always return a component for a certain entity, adding it if it's not there already.
@@ -255,7 +255,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="uid">Entity UID to look on.</param>
         /// <param name="netId">Network ID of the component to retrieve.</param>
         /// <returns>The component with the specified network id.</returns>
-        IComponent GetComponent(EntityUid uid, ushort netId);
+        IComponent GetComponent(EntityUid uid, ushort netId, MetaDataComponent? meta = null);
 
         /// <summary>
         ///     Returns the component of a specific type, even if it has been marked for deletion.
@@ -318,7 +318,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="netId">Component Network ID to check for.</param>
         /// <param name="component">Component with the specified network id.</param>
         /// <returns>If the component existed in the entity.</returns>
-        bool TryGetComponent(EntityUid uid, ushort netId, [NotNullWhen(true)] out IComponent? component);
+        bool TryGetComponent(EntityUid uid, ushort netId, [NotNullWhen(true)] out IComponent? component, MetaDataComponent? meta = null);
 
         /// <summary>
         ///     Returns the component with a specified network ID. This does not check
@@ -328,7 +328,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="netId">Component Network ID to check for.</param>
         /// <param name="component">Component with the specified network id.</param>
         /// <returns>If the component existed in the entity.</returns>
-        bool TryGetComponent([NotNullWhen(true)] EntityUid? uid, ushort netId, [NotNullWhen(true)] out IComponent? component);
+        bool TryGetComponent([NotNullWhen(true)] EntityUid? uid, ushort netId, [NotNullWhen(true)] out IComponent? component, MetaDataComponent? meta = null);
 
         /// <summary>
         /// Returns a cached struct enumerator with the specified component.
@@ -364,7 +364,7 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         /// <param name="uid">Entity UID to look on.</param>
         /// <returns>All components that have a network ID.</returns>
-        NetComponentEnumerable GetNetComponents(EntityUid uid);
+        NetComponentEnumerable GetNetComponents(EntityUid uid, MetaDataComponent? meta = null);
 
         /// <summary>
         ///     Returns ALL networked components on an entity, including deleted ones. Returns null if the entity does
@@ -372,7 +372,7 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         /// <param name="uid">Entity UID to look on.</param>
         /// <returns>All components that have a network ID.</returns>
-        public NetComponentEnumerable? GetNetComponentsOrNull(EntityUid uid);
+        public NetComponentEnumerable? GetNetComponentsOrNull(EntityUid uid, MetaDataComponent? meta = null);
 
         /// <summary>
         ///     Gets a component state.

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -78,7 +78,7 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         /// <typeparam name="T">The component reference type to remove.</typeparam>
         /// <param name="uid">Entity UID to modify.</param>
-        bool RemoveComponent<T>(EntityUid uid);
+        bool RemoveComponent<T>(EntityUid uid, MetaDataComponent? meta = null);
 
         /// <summary>
         ///     Removes the component with a specified type.
@@ -86,7 +86,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="uid">Entity UID to modify.</param>
         /// <param name="type">A trait or component type to check for.</param>
         /// <returns>Returns false if the entity did not have the specified component.</returns>
-        bool RemoveComponent(EntityUid uid, Type type);
+        bool RemoveComponent(EntityUid uid, Type type, MetaDataComponent? meta = null);
 
         /// <summary>
         ///     Removes the component with a specified network ID.
@@ -101,7 +101,7 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         /// <param name="uid">Entity UID to modify.</param>
         /// <param name="component">Component to remove.</param>
-        void RemoveComponent(EntityUid uid, IComponent component);
+        void RemoveComponent(EntityUid uid, IComponent component, MetaDataComponent? meta = null);
 
         /// <summary>
         ///     Immediately shuts down a component, but defers the removal and deletion until the end of the tick.
@@ -147,7 +147,7 @@ namespace Robust.Shared.GameObjects
         ///     Removes all components from an entity, except the required components.
         /// </summary>
         /// <param name="uid">Entity UID to modify.</param>
-        void RemoveComponents(EntityUid uid);
+        void RemoveComponents(EntityUid uid, MetaDataComponent? meta = null);
 
         /// <summary>
         ///     Removes ALL components from an entity. This includes the required components,
@@ -155,7 +155,7 @@ namespace Robust.Shared.GameObjects
         ///     used when deleting an entity.
         /// </summary>
         /// <param name="uid">Entity UID to modify.</param>
-        void DisposeComponents(EntityUid uid);
+        void DisposeComponents(EntityUid uid, MetaDataComponent? meta = null);
 
         /// <summary>
         ///     Checks if the entity has a component type.

--- a/Robust.Shared/GameObjects/IEntityManager.Network.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Network.cs
@@ -23,6 +23,12 @@ public partial interface IEntityManager
     public bool TryGetEntity(NetEntity? nEntity, [NotNullWhen(true)] out EntityUid? entity);
 
     /// <summary>
+    /// Tries to returns the corresponding local <see cref="EntityUid"/> along with the metdata component.
+    /// </summary>
+    public bool TryGetEntityData(NetEntity nEntity, [NotNullWhen(true)] out EntityUid? entity,
+        [NotNullWhen(true)] out MetaDataComponent? meta);
+
+    /// <summary>
     /// TryGet version of <see cref="GetNetEntity"/>
     /// </summary>
     public bool TryGetNetEntity(EntityUid uid, [NotNullWhen(true)] out NetEntity? netEntity, MetaDataComponent? metadata = null);


### PR DESCRIPTION
In the interest of minimising long-term conflicts while I get it faster I'm going to backport the easy wins.
- NetComponents is stored on MetaDataComponent rather than on a separate dictionary.
- Remove GetRegistration in a few spots and store the metadata / transform defaults.
- Remove some GetComponent<MetaDataComponent> on entity spawns though needs some other changes to be backported to really take advantage of it.