### PR TITLE
More arch backports

### DIFF
--- a/Robust.Client/Placement/Modes/AlignSimilar.cs
+++ b/Robust.Client/Placement/Modes/AlignSimilar.cs
@@ -44,7 +44,7 @@ namespace Robust.Client.Placement.Modes
 
             var closestEntity = snapToEntities[0];
             var closestTransform = pManager.EntityManager.GetComponent<TransformComponent>(closestEntity);
-            if (!pManager.EntityManager.TryGetComponent<SpriteComponent?>(closestEntity, out var component) || component.BaseRSI == null)
+            if (!pManager.EntityManager.TryGetComponent<SpriteComponent>(closestEntity, out var component) || component.BaseRSI == null)
             {
                 return;
             }

--- a/Robust.Client/Player/LocalPlayer.cs
+++ b/Robust.Client/Player/LocalPlayer.cs
@@ -73,7 +73,7 @@ namespace Robust.Client.Player
             ControlledEntity = entity;
             InternalSession.AttachedEntity = entity;
 
-            if (!entMan.TryGetComponent<EyeComponent?>(entity, out var eye))
+            if (!entMan.TryGetComponent<EyeComponent>(entity, out var eye))
             {
                 eye = entMan.AddComponent<EyeComponent>(entity);
 

--- a/Robust.Server/Placement/PlacementManager.cs
+++ b/Robust.Server/Placement/PlacementManager.cs
@@ -243,7 +243,7 @@ namespace Robust.Server.Placement
         /// </summary>
         public void SendPlacementBegin(EntityUid mob, int range, string objectType, string alignOption)
         {
-            if (!_entityManager.TryGetComponent<ActorComponent?>(mob, out var actor))
+            if (!_entityManager.TryGetComponent<ActorComponent>(mob, out var actor))
                 return;
 
             var playerConnection = actor.PlayerSession.ConnectedClient;
@@ -264,7 +264,7 @@ namespace Robust.Server.Placement
         /// </summary>
         public void SendPlacementBeginTile(EntityUid mob, int range, string tileType, string alignOption)
         {
-            if (!_entityManager.TryGetComponent<ActorComponent?>(mob, out var actor))
+            if (!_entityManager.TryGetComponent<ActorComponent>(mob, out var actor))
                 return;
 
             var playerConnection = actor.PlayerSession.ConnectedClient;
@@ -285,7 +285,7 @@ namespace Robust.Server.Placement
         /// </summary>
         public void SendPlacementCancel(EntityUid mob)
         {
-            if (!_entityManager.TryGetComponent<ActorComponent?>(mob, out var actor))
+            if (!_entityManager.TryGetComponent<ActorComponent>(mob, out var actor))
                 return;
 
             var playerConnection = actor.PlayerSession.ConnectedClient;

--- a/Robust.Shared/GameObjects/ComponentFactory.cs
+++ b/Robust.Shared/GameObjects/ComponentFactory.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using Robust.Shared.GameStates;
@@ -259,7 +260,7 @@ namespace Robust.Shared.GameObjects
 
         public IComponent GetComponent(ComponentRegistration reg)
         {
-            return (IComponent) _typeFactory.CreateInstanceUnchecked(reg.Type);
+            return Unsafe.As<IComponent>(_typeFactory.CreateInstanceUnchecked(reg.Type));
         }
 
         public IComponent GetComponent(string componentName, bool ignoreCase = false)

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -8,6 +8,7 @@ using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 using System;
+using System.Collections.Generic;
 
 namespace Robust.Shared.GameObjects
 {
@@ -62,6 +63,12 @@ namespace Robust.Shared.GameObjects
         [DataField("name")] internal string? _entityName;
         [DataField("desc")] internal string? _entityDescription;
         internal EntityPrototype? _entityPrototype;
+
+        /// <summary>
+        /// The components attached to the entity that are currently networked.
+        /// </summary>
+        [ViewVariables]
+        public Dictionary<ushort, Component> NetComponents = new();
 
         /// <summary>
         /// Network identifier for this entity.

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -386,7 +386,7 @@ namespace Robust.Shared.GameObjects
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void RemoveComponent(EntityUid uid, IComponent component, MetaDataComponent? meta = null)
         {
-        	// Probably can't Unsafe.As<T> in case something on content overrides it.
+            // Can't Unsafe.As<T> in case something on content implements something with IComponent.
             RemoveComponent(uid, (Component)component, meta);
         }
 
@@ -431,7 +431,8 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public void RemoveComponentDeferred(EntityUid owner, IComponent component)
         {
-            RemoveComponentDeferred(Unsafe.As<Component>(component), owner, false);
+            // Can't Unsafe.As<T> in case something on content implements something with IComponent.
+            RemoveComponentDeferred((Component)component, owner, false);
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -351,7 +351,7 @@ namespace Robust.Shared.GameObjects
             if (!TryGetComponent(uid, type, out var comp))
                 return false;
 
-            RemoveComponentImmediate((Component)comp, uid, false);
+            RemoveComponentImmediate(Unsafe.As<Component>(comp), uid, false);
             return true;
         }
 
@@ -362,7 +362,7 @@ namespace Robust.Shared.GameObjects
             if (!TryGetComponent(uid, netId, out var comp))
                 return false;
 
-            RemoveComponentImmediate((Component)comp, uid, false);
+            RemoveComponentImmediate(Unsafe.As<Component>(comp), uid, false);
             return true;
         }
 
@@ -370,7 +370,7 @@ namespace Robust.Shared.GameObjects
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void RemoveComponent(EntityUid uid, IComponent component)
         {
-            RemoveComponent(uid, (Component)component);
+            RemoveComponent(uid, Unsafe.As<Component>(component));
         }
 
         /// <inheritdoc />
@@ -393,7 +393,7 @@ namespace Robust.Shared.GameObjects
             if (!TryGetComponent(uid, type, out var comp))
                 return false;
 
-            RemoveComponentDeferred((Component)comp, uid, false);
+            RemoveComponentDeferred(Unsafe.As<Component>(comp), uid, false);
             return true;
         }
 
@@ -404,14 +404,14 @@ namespace Robust.Shared.GameObjects
             if (!TryGetComponent(uid, netId, out var comp))
                 return false;
 
-            RemoveComponentDeferred((Component)comp, uid, false);
+            RemoveComponentDeferred(Unsafe.As<Component>(comp), uid, false);
             return true;
         }
 
         /// <inheritdoc />
         public void RemoveComponentDeferred(EntityUid owner, IComponent component)
         {
-            RemoveComponentDeferred((Component)component, owner, false);
+            RemoveComponentDeferred(Unsafe.As<Component>(component), owner, false);
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -35,9 +35,6 @@ namespace Robust.Shared.GameObjects
 
         private static readonly ComponentState DefaultComponentState = new();
 
-        private readonly Dictionary<EntityUid, Dictionary<ushort, Component>> _netComponents
-            = new(EntityCapacity);
-
         private readonly Dictionary<Type, Dictionary<EntityUid, Component>> _entTraitDict
             = new();
 
@@ -70,7 +67,6 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         public void ClearComponents()
         {
-            _netComponents.Clear();
             _entCompIndex.Clear();
             _deleteSet.Clear();
             foreach (var dict in _entTraitDict.Values)
@@ -249,7 +245,7 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public void AddComponent<T>(EntityUid uid, T component, bool overwrite = false) where T : Component
+        public void AddComponent<T>(EntityUid uid, T component, bool overwrite = false, MetaDataComponent? metadata = null) where T : Component
         {
             if (!uid.IsValid() || !EntityExists(uid))
                 throw new ArgumentException($"Entity {uid} is not valid.", nameof(uid));
@@ -267,18 +263,22 @@ namespace Robust.Shared.GameObjects
             }
 #pragma warning restore CS0618 // Type or member is obsolete
 
-            AddComponentInternal(uid, component, overwrite, false);
+            AddComponentInternal(uid, component, overwrite, false, metadata);
         }
 
-        private void AddComponentInternal<T>(EntityUid uid, T component, bool overwrite, bool skipInit) where T : Component
+        private void AddComponentInternal<T>(EntityUid uid, T component, bool overwrite, bool skipInit, MetaDataComponent? metadata = null) where T : Component
+        {
+            // get interface aliases for mapping
+            var reg = _componentFactory.GetRegistration(component);
+            AddComponentInternal(uid, component, reg, overwrite, skipInit, metadata);
+        }
+
+        private void AddComponentInternal<T>(EntityUid uid, T component, ComponentRegistration reg, bool overwrite, bool skipInit, MetaDataComponent? metadata = null) where T : Component
         {
             // We can't use typeof(T) here in case T is just Component
             DebugTools.Assert(component is MetaDataComponent ||
-                GetComponent<MetaDataComponent>(uid).EntityLifeStage < EntityLifeStage.Terminating,
+                              (metadata ?? MetaQuery.GetComponent(uid)).EntityLifeStage < EntityLifeStage.Terminating,
                 $"Attempted to add a {component.GetType().Name} component to an entity ({ToPrettyString(uid)}) while it is terminating");
-
-            // get interface aliases for mapping
-            var reg = _componentFactory.GetRegistration(component);
 
             // Check that there is no existing component.
             var type = reg.Idx;
@@ -303,14 +303,8 @@ namespace Robust.Shared.GameObjects
             {
                 // the main comp grid keeps this in sync
                 var netId = reg.NetID.Value;
-
-                if (!_netComponents.TryGetValue(uid, out var netSet))
-                {
-                    netSet = new Dictionary<ushort, Component>(NetComponentCapacity);
-                    _netComponents.Add(uid, netSet);
-                }
-
-                netSet.Add(netId, component);
+                metadata ??= MetaQuery.GetComponent(uid);
+                metadata.NetComponents.Add(netId, component);
             }
             else
             {
@@ -326,7 +320,7 @@ namespace Robust.Shared.GameObjects
             if (skipInit)
                 return;
 
-            var metadata = GetComponent<MetaDataComponent>(uid);
+            metadata ??= MetaQuery.GetComponent(uid);
 
             if (!metadata.EntityInitialized && !metadata.EntityInitializing)
                 return;
@@ -467,7 +461,6 @@ namespace Robust.Shared.GameObjects
             }
 
             _entCompIndex.Remove(uid);
-            _netComponents.Remove(uid);
         }
 
         private void RemoveComponentDeferred(Component component, EntityUid uid, bool terminating)
@@ -589,20 +582,17 @@ namespace Robust.Shared.GameObjects
             _deleteSet.Clear();
         }
 
-        private void DeleteComponent(EntityUid entityUid, Component component, bool terminating)
+        private void DeleteComponent(EntityUid entityUid, Component component, bool terminating, MetaDataComponent? metadata = null)
         {
-            var type = component.GetType();
-            var reg = _componentFactory.GetRegistration(type);
+            var reg = _componentFactory.GetRegistration(component);
 
-            if (!terminating && reg.NetID != null && _netComponents.TryGetValue(entityUid, out var netSet))
+            if (!terminating && reg.NetID != null)
             {
-                if (netSet.Count == 1)
-                    _netComponents.Remove(entityUid);
-                else
-                    netSet.Remove(reg.NetID.Value);
+                metadata ??= MetaQuery.GetComponent(entityUid);
+                var netSet = metadata.NetComponents;
 
-                if (component.NetSyncEnabled)
-                    DirtyEntity(entityUid);
+                if (netSet.Remove(reg.NetID.Value) && component.NetSyncEnabled)
+                    DirtyEntity(entityUid, metadata);
             }
 
             _entTraitArray[reg.Idx.Value].Remove(entityUid);
@@ -653,8 +643,7 @@ namespace Robust.Shared.GameObjects
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool HasComponent(EntityUid uid, ushort netId)
         {
-            return _netComponents.TryGetValue(uid, out var netSet)
-                   && netSet.ContainsKey(netId);
+            return MetaQuery.TryGetComponent(uid, out var metadata) && metadata.NetComponents.ContainsKey(netId);
         }
 
         /// <inheritdoc />
@@ -666,8 +655,7 @@ namespace Robust.Shared.GameObjects
                 return false;
             }
 
-            return _netComponents.TryGetValue(uid.Value, out var netSet)
-                   && netSet.ContainsKey(netId);
+            return HasComponent(uid.Value, netId);
         }
 
         /// <inheritdoc />
@@ -754,7 +742,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public IComponent GetComponent(EntityUid uid, ushort netId)
         {
-            return _netComponents[uid][netId];
+            return MetaQuery.GetComponent(uid).NetComponents[netId];
         }
 
         /// <inheritdoc />
@@ -870,8 +858,8 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public bool TryGetComponent(EntityUid uid, ushort netId, [MaybeNullWhen(false)] out IComponent component)
         {
-            if (_netComponents.TryGetValue(uid, out var netSet)
-                && netSet.TryGetValue(netId, out var comp))
+            if (MetaQuery.TryGetComponent(uid, out var metadata)
+                && metadata.NetComponents.TryGetValue(netId, out var comp))
             {
                 component = comp;
                 return true;
@@ -891,15 +879,7 @@ namespace Robust.Shared.GameObjects
                 return false;
             }
 
-            if (_netComponents.TryGetValue(uid.Value, out var netSet)
-                && netSet.TryGetValue(netId, out var comp))
-            {
-                component = comp;
-                return true;
-            }
-
-            component = default;
-            return false;
+            return TryGetComponent(uid.Value, netId, out component);
         }
 
         public EntityQuery<TComp1> GetEntityQuery<TComp1>() where TComp1 : Component
@@ -969,15 +949,15 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public NetComponentEnumerable GetNetComponents(EntityUid uid)
         {
-            return new NetComponentEnumerable(_netComponents[uid]);
+            return new NetComponentEnumerable(MetaQuery.GetComponent(uid).NetComponents);
         }
 
         /// <inheritdoc />
         public NetComponentEnumerable? GetNetComponentsOrNull(EntityUid uid)
         {
-            return _netComponents.TryGetValue(uid, out var data)
-                    ? new NetComponentEnumerable(data)
-                    : null;
+            return MetaQuery.TryGetComponent(uid, out var metadata)
+                ? new NetComponentEnumerable(metadata.NetComponents)
+                : null;
         }
 
         #region Join Functions

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -235,7 +235,7 @@ namespace Robust.Shared.GameObjects
         public CompInitializeHandle<T> AddComponentUninitialized<T>(EntityUid uid) where T : Component, new()
         {
             var reg = _componentFactory.GetRegistration<T>();
-            var newComponent = (T)_componentFactory.GetComponent(reg);
+            var newComponent = Unsafe.As<T>(_componentFactory.GetComponent(reg));
 #pragma warning disable CS0618 // Type or member is obsolete
             newComponent.Owner = uid;
 #pragma warning restore CS0618 // Type or member is obsolete
@@ -714,9 +714,9 @@ namespace Robust.Shared.GameObjects
             DebugTools.Assert(dict != null, $"Unknown component: {typeof(T).Name}");
             if (dict!.TryGetValue(uid, out var comp))
             {
-                if (!comp!.Deleted)
+                if (!comp.Deleted)
                 {
-                    return (T)(IComponent) comp;
+                    return (T) Unsafe.As<IComponent>(comp);
                 }
             }
 
@@ -763,7 +763,7 @@ namespace Robust.Shared.GameObjects
             var dict = _entTraitArray[type.Value];
             if (dict.TryGetValue(uid, out var comp))
             {
-                    return comp;
+                return comp;
             }
 
             throw new KeyNotFoundException($"Entity {uid} does not have a component of type {type}");
@@ -771,7 +771,7 @@ namespace Robust.Shared.GameObjects
 
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool TryGetComponent<T>(EntityUid uid, [NotNullWhen(true)] out T? component)
+        public bool TryGetComponent<T>(EntityUid uid, [NotNullWhen(true)] out T? component) where T : IComponent
         {
             var dict = _entTraitArray[CompIdx.ArrayIndex<T>()];
             DebugTools.Assert(dict != null, $"Unknown component: {typeof(T).Name}");
@@ -779,7 +779,7 @@ namespace Robust.Shared.GameObjects
             {
                 if (!comp.Deleted)
                 {
-                    component = (T)(IComponent)comp;
+                    component = (T)Unsafe.As<IComponent>(comp);
                     return true;
                 }
             }
@@ -789,7 +789,7 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public bool TryGetComponent<T>([NotNullWhen(true)] EntityUid? uid, [NotNullWhen(true)] out T? component)
+        public bool TryGetComponent<T>([NotNullWhen(true)] EntityUid? uid, [NotNullWhen(true)] out T? component) where T : IComponent
         {
             if (!uid.HasValue)
             {
@@ -1103,7 +1103,7 @@ namespace Robust.Shared.GameObjects
                 {
                     if (t1Comp.Deleted) continue;
 
-                    yield return (T)(object)t1Comp;
+                    yield return (T) Unsafe.As<object>(t1Comp);
                 }
             }
             else
@@ -1114,7 +1114,7 @@ namespace Robust.Shared.GameObjects
 
                     if (metaComp.EntityPaused) continue;
 
-                    yield return (T)(object)t1Comp;
+                    yield return (T) Unsafe.As<object>(t1Comp);
                 }
             }
         }
@@ -1137,8 +1137,8 @@ namespace Robust.Shared.GameObjects
                         continue;
 
                     yield return (
-                        (TComp1)(object)t1Comp,
-                        (TComp2)(object)t2Comp);
+                        (TComp1)Unsafe.As<object>(t1Comp),
+                        (TComp2)Unsafe.As<object>(t2Comp));
                 }
             }
             else
@@ -1158,8 +1158,8 @@ namespace Robust.Shared.GameObjects
                     if (meta.EntityPaused) continue;
 
                     yield return (
-                        (TComp1)(object)t1Comp,
-                        (TComp2)(object)t2Comp);
+                        (TComp1)Unsafe.As<object>(t1Comp),
+                        (TComp2)Unsafe.As<object>(t2Comp));
                 }
             }
         }
@@ -1185,9 +1185,9 @@ namespace Robust.Shared.GameObjects
                         continue;
 
                     yield return (
-                        (TComp1)(object)t1Comp,
-                        (TComp2)(object)t2Comp,
-                        (TComp3)(object)t3Comp);
+                        (TComp1)Unsafe.As<object>(t1Comp),
+                        (TComp2)Unsafe.As<object>(t2Comp),
+                        (TComp3)Unsafe.As<object>(t3Comp));
                 }
             }
             else
@@ -1210,9 +1210,9 @@ namespace Robust.Shared.GameObjects
                     if (meta.EntityPaused) continue;
 
                     yield return (
-                        (TComp1)(object)t1Comp,
-                        (TComp2)(object)t2Comp,
-                        (TComp3)(object)t3Comp);
+                        (TComp1)Unsafe.As<object>(t1Comp),
+                        (TComp2)Unsafe.As<object>(t2Comp),
+                        (TComp3)Unsafe.As<object>(t3Comp));
                 }
             }
         }
@@ -1244,10 +1244,10 @@ namespace Robust.Shared.GameObjects
                         continue;
 
                     yield return (
-                        (TComp1)(object)t1Comp,
-                        (TComp2)(object)t2Comp,
-                        (TComp3)(object)t3Comp,
-                        (TComp4)(object)t4Comp);
+                        (TComp1)Unsafe.As<object>(t1Comp),
+                        (TComp2)Unsafe.As<object>(t2Comp),
+                        (TComp3)Unsafe.As<object>(t3Comp),
+                        (TComp4)Unsafe.As<object>(t4Comp));
                 }
             }
             else
@@ -1273,10 +1273,10 @@ namespace Robust.Shared.GameObjects
                     if (meta.EntityPaused) continue;
 
                     yield return (
-                        (TComp1)(object)t1Comp,
-                        (TComp2)(object)t2Comp,
-                        (TComp3)(object)t3Comp,
-                        (TComp4)(object)t4Comp);
+                        (TComp1)Unsafe.As<object>(t1Comp),
+                        (TComp2)Unsafe.As<object>(t2Comp),
+                        (TComp3)Unsafe.As<object>(t3Comp),
+                        (TComp4)Unsafe.As<object>(t4Comp));
                 }
             }
         }
@@ -1384,7 +1384,7 @@ namespace Robust.Shared.GameObjects
         public TComp1 GetComponent(EntityUid uid)
         {
             if (_traitDict.TryGetValue(uid, out var comp) && !comp.Deleted)
-                return (TComp1) comp;
+                return Unsafe.As<TComp1>(comp);
 
             throw new KeyNotFoundException($"Entity {uid} does not have a component of type {typeof(TComp1)}");
         }
@@ -1408,7 +1408,7 @@ namespace Robust.Shared.GameObjects
         {
             if (_traitDict.TryGetValue(uid, out var comp) && !comp.Deleted)
             {
-                component = (TComp1) comp;
+                component = Unsafe.As<TComp1>(comp);
                 return true;
             }
 
@@ -1444,7 +1444,7 @@ namespace Robust.Shared.GameObjects
 
             if (_traitDict.TryGetValue(uid, out var comp) && !comp.Deleted)
             {
-                component = (TComp1)comp;
+                component = Unsafe.As<TComp1>(comp);
                 return true;
             }
 
@@ -1474,7 +1474,7 @@ namespace Robust.Shared.GameObjects
         internal TComp1 GetComponentInternal(EntityUid uid)
         {
             if (_traitDict.TryGetValue(uid, out var comp))
-                return (TComp1) comp;
+                return Unsafe.As<TComp1>(comp);
 
             throw new KeyNotFoundException($"Entity {uid} does not have a component of type {typeof(TComp1)}");
         }
@@ -1504,7 +1504,7 @@ namespace Robust.Shared.GameObjects
         {
             if (_traitDict.TryGetValue(uid, out var comp))
             {
-                component = (TComp1) comp;
+                component = Unsafe.As<TComp1>(comp);
                 return true;
             }
 
@@ -1539,7 +1539,7 @@ namespace Robust.Shared.GameObjects
 
             if (_traitDict.TryGetValue(uid, out var comp))
             {
-                component = (TComp1)comp;
+                component = Unsafe.As<TComp1>(comp);
                 return true;
             }
 
@@ -1607,7 +1607,7 @@ namespace Robust.Shared.GameObjects
                 }
 
                 uid = current.Key;
-                comp1 = (TComp1)current.Value;
+                comp1 = Unsafe.As<TComp1>(current.Value);
                 return true;
             }
         }
@@ -1675,8 +1675,8 @@ namespace Robust.Shared.GameObjects
                 }
 
                 uid = current.Key;
-                comp1 = (TComp1)current.Value;
-                comp2 = (TComp2)comp2Obj;
+                comp1 = Unsafe.As<TComp1>(current.Value);
+                comp2 = Unsafe.As<TComp2>(comp2Obj);
                 return true;
             }
         }
@@ -1754,9 +1754,9 @@ namespace Robust.Shared.GameObjects
                 }
 
                 uid = current.Key;
-                comp1 = (TComp1)current.Value;
-                comp2 = (TComp2)comp2Obj;
-                comp3 = (TComp3)comp3Obj;
+                comp1 = Unsafe.As<TComp1>(current.Value);
+                comp2 = Unsafe.As<TComp2>(comp2Obj);
+                comp3 = Unsafe.As<TComp3>(comp3Obj);
                 return true;
             }
         }
@@ -1847,10 +1847,10 @@ namespace Robust.Shared.GameObjects
                 }
 
                 uid = current.Key;
-                comp1 = (TComp1)current.Value;
-                comp2 = (TComp2)comp2Obj;
-                comp3 = (TComp3)comp3Obj;
-                comp4 = (TComp4)comp4Obj;
+                comp1 = Unsafe.As<TComp1>(current.Value);
+                comp2 = Unsafe.As<TComp2>(comp2Obj);
+                comp3 = Unsafe.As<TComp3>(comp3Obj);
+                comp4 = Unsafe.As<TComp4>(comp4Obj);
                 return true;
             }
         }
@@ -1908,7 +1908,7 @@ namespace Robust.Shared.GameObjects
                 }
 
                 uid = current.Key;
-                comp1 = (TComp1)current.Value;
+                comp1 = Unsafe.As<TComp1>(current.Value);
                 return true;
             }
         }
@@ -1968,8 +1968,8 @@ namespace Robust.Shared.GameObjects
                 }
 
                 uid = current.Key;
-                comp1 = (TComp1)current.Value;
-                comp2 = (TComp2)comp2Obj;
+                comp1 = Unsafe.As<TComp1>(current.Value);
+                comp2 = Unsafe.As<TComp2>(comp2Obj);
                 return true;
             }
         }
@@ -2039,9 +2039,9 @@ namespace Robust.Shared.GameObjects
                 }
 
                 uid = current.Key;
-                comp1 = (TComp1)current.Value;
-                comp2 = (TComp2)comp2Obj;
-                comp3 = (TComp3)comp3Obj;
+                comp1 = Unsafe.As<TComp1>(current.Value);
+                comp2 = Unsafe.As<TComp2>(comp2Obj);
+                comp3 = Unsafe.As<TComp3>(comp3Obj);
                 return true;
             }
         }
@@ -2124,10 +2124,10 @@ namespace Robust.Shared.GameObjects
                 }
 
                 uid = current.Key;
-                comp1 = (TComp1)current.Value;
-                comp2 = (TComp2)comp2Obj;
-                comp3 = (TComp3)comp3Obj;
-                comp4 = (TComp4)comp4Obj;
+                comp1 = Unsafe.As<TComp1>(current.Value);
+                comp2 = Unsafe.As<TComp2>(comp2Obj);
+                comp3 = Unsafe.As<TComp3>(comp3Obj);
+                comp4 = Unsafe.As<TComp4>(comp4Obj);
                 return true;
             }
         }

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -303,7 +303,7 @@ namespace Robust.Shared.GameObjects
             {
                 // the main comp grid keeps this in sync
                 var netId = reg.NetID.Value;
-                metadata ??= MetaQuery.GetComponent(uid);
+                metadata ??= MetaQuery.GetComponentInternal(uid);
                 metadata.NetComponents.Add(netId, component);
             }
             else
@@ -320,7 +320,7 @@ namespace Robust.Shared.GameObjects
             if (skipInit)
                 return;
 
-            metadata ??= MetaQuery.GetComponent(uid);
+            metadata ??= MetaQuery.GetComponentInternal(uid);
 
             if (!metadata.EntityInitialized && !metadata.EntityInitializing)
                 return;
@@ -643,7 +643,7 @@ namespace Robust.Shared.GameObjects
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool HasComponent(EntityUid uid, ushort netId)
         {
-            return MetaQuery.TryGetComponent(uid, out var metadata) && metadata.NetComponents.ContainsKey(netId);
+            return MetaQuery.TryGetComponentInternal(uid, out var metadata) && metadata.NetComponents.ContainsKey(netId);
         }
 
         /// <inheritdoc />
@@ -742,7 +742,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public IComponent GetComponent(EntityUid uid, ushort netId)
         {
-            return MetaQuery.GetComponent(uid).NetComponents[netId];
+            return MetaQuery.GetComponentInternal(uid).NetComponents[netId];
         }
 
         /// <inheritdoc />
@@ -751,7 +751,7 @@ namespace Robust.Shared.GameObjects
             var dict = _entTraitArray[type.Value];
             if (dict.TryGetValue(uid, out var comp))
             {
-                    return comp;
+                return comp;
             }
 
             throw new KeyNotFoundException($"Entity {uid} does not have a component of type {type}");
@@ -858,7 +858,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public bool TryGetComponent(EntityUid uid, ushort netId, [MaybeNullWhen(false)] out IComponent component)
         {
-            if (MetaQuery.TryGetComponent(uid, out var metadata)
+            if (MetaQuery.TryGetComponentInternal(uid, out var metadata)
                 && metadata.NetComponents.TryGetValue(netId, out var comp))
             {
                 component = comp;
@@ -949,13 +949,13 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public NetComponentEnumerable GetNetComponents(EntityUid uid)
         {
-            return new NetComponentEnumerable(MetaQuery.GetComponent(uid).NetComponents);
+            return new NetComponentEnumerable(MetaQuery.GetComponentInternal(uid).NetComponents);
         }
 
         /// <inheritdoc />
         public NetComponentEnumerable? GetNetComponentsOrNull(EntityUid uid)
         {
-            return MetaQuery.TryGetComponent(uid, out var metadata)
+            return MetaQuery.TryGetComponentInternal(uid, out var metadata)
                 ? new NetComponentEnumerable(metadata.NetComponents)
                 : null;
         }

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Prometheus;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
@@ -85,6 +86,9 @@ namespace Robust.Shared.GameObjects
 
         private string _xformName = string.Empty;
 
+        private ComponentRegistration _metaReg = default!;
+        private ComponentRegistration _xformReg = default!;
+
         private SharedMapSystem _mapSystem = default!;
 
         private ISawmill _sawmill = default!;
@@ -111,7 +115,9 @@ namespace Robust.Shared.GameObjects
             _eventBus = new EntityEventBus(this);
 
             InitializeComponents();
-            _xformName = _componentFactory.GetComponentName(typeof(TransformComponent));
+            _metaReg = _componentFactory.GetRegistration(typeof(MetaDataComponent));
+            _xformReg = _componentFactory.GetRegistration(typeof(TransformComponent));
+            _xformName = _xformReg.Name;
             _sawmill = LogManager.GetSawmill("entity");
             _resolveSawmill = LogManager.GetSawmill("resolve");
 
@@ -645,10 +651,12 @@ namespace Robust.Shared.GameObjects
 
             Entities.Add(uid);
             // add the required MetaDataComponent directly.
-            AddComponentInternal(uid, metadata, false, false);
+            AddComponentInternal(uid, metadata, _metaReg, false, true, metadata);
 
             // allocate the required TransformComponent
-            AddComponent<TransformComponent>(uid);
+            var xformComp = Unsafe.As<TransformComponent>(_componentFactory.GetComponent(_xformReg));
+            xformComp.Owner = uid;
+            AddComponentInternal(uid, xformComp, false, true, metadata);
 
             return uid;
         }

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -559,7 +559,7 @@ namespace Robust.Shared.GameObjects
 
         public bool EntityExists(EntityUid uid)
         {
-            return _entTraitArray[CompIdx.ArrayIndex<MetaDataComponent>()].ContainsKey(uid);
+            return MetaQuery.HasComponentInternal(uid);
         }
 
         public bool EntityExists(EntityUid? uid)
@@ -758,10 +758,9 @@ namespace Robust.Shared.GameObjects
 
         public EntityStringRepresentation ToPrettyString(EntityUid uid)
         {
-            if (!_entTraitArray[CompIdx.ArrayIndex<MetaDataComponent>()].TryGetValue(uid, out var component))
+            if (!MetaQuery.TryGetComponentInternal(uid, out var metadata))
                 return new EntityStringRepresentation(uid, true);
 
-            var metadata = Unsafe.As<MetaDataComponent>(component);
             return ToPrettyString(uid, metadata);
         }
 

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -415,12 +415,12 @@ public partial class EntitySystem
     /// <inheritdoc cref="IEntityManager.ToPrettyString"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected EntityStringRepresentation ToPrettyString(EntityUid uid)
-        => ToPrettyString((EntityUid?) uid).Value;
+        => EntityManager.ToPrettyString(uid);
 
     /// <inheritdoc cref="IEntityManager.ToPrettyString"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected EntityStringRepresentation ToPrettyString(NetEntity netEntity)
-        => ToPrettyString((NetEntity?) netEntity).Value;
+        => EntityManager.ToPrettyString(netEntity);
 
     #endregion
 
@@ -453,14 +453,14 @@ public partial class EntitySystem
 
     /// <inheritdoc cref="IEntityManager.TryGetComponent&lt;T&gt;(EntityUid, out T)"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected bool TryComp<T>(EntityUid uid, [NotNullWhen(true)] out T? comp)
+    protected bool TryComp<T>(EntityUid uid, [NotNullWhen(true)] out T? comp) where T : IComponent
     {
         return EntityManager.TryGetComponent(uid, out comp);
     }
 
     /// <inheritdoc cref="IEntityManager.TryGetComponent&lt;T&gt;(EntityUid?, out T)"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected bool TryComp<T>([NotNullWhen(true)] EntityUid? uid, [NotNullWhen(true)] out T? comp)
+    protected bool TryComp<T>([NotNullWhen(true)] EntityUid? uid, [NotNullWhen(true)] out T? comp) where T : IComponent
     {
         if (!uid.HasValue)
         {

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -70,7 +70,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="uid">Entity being modified.</param>
         /// <param name="component">Component to add.</param>
         /// <param name="overwrite">Should it overwrite existing components?</param>
-        void AddComponent<T>(EntityUid uid, T component, bool overwrite = false) where T : Component;
+        void AddComponent<T>(EntityUid uid, T component, bool overwrite = false, MetaDataComponent? metadata = null) where T : Component;
 
         /// <summary>
         ///     Removes the component with the specified reference type,
@@ -187,7 +187,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="uid">Entity UID to check.</param>
         /// <param name="type">A trait or component type to check for.</param>
         /// <returns>True if the entity has the component type, otherwise false.</returns>
-        bool HasComponent(EntityUid ?uid, Type type);
+        bool HasComponent(EntityUid? uid, Type type);
 
         /// <summary>
         ///     Checks if the entity has a component with a given network ID. This does not check

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -272,7 +272,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="uid">Entity UID to check.</param>
         /// <param name="component">Component of the specified type (if exists).</param>
         /// <returns>If the component existed in the entity.</returns>
-        bool TryGetComponent<T>(EntityUid uid, [NotNullWhen(true)] out T? component);
+        bool TryGetComponent<T>(EntityUid uid, [NotNullWhen(true)] out T? component) where T : IComponent;
 
         /// <summary>
         ///     Returns the component of a specific type.
@@ -281,7 +281,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="uid">Entity UID to check.</param>
         /// <param name="component">Component of the specified type (if exists).</param>
         /// <returns>If the component existed in the entity.</returns>
-        bool TryGetComponent<T>([NotNullWhen(true)] EntityUid? uid, [NotNullWhen(true)] out T? component);
+        bool TryGetComponent<T>([NotNullWhen(true)] EntityUid? uid, [NotNullWhen(true)] out T? component)  where T : IComponent;
 
         /// <summary>
         ///     Returns the component of a specific type.

--- a/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
@@ -76,7 +76,6 @@ internal sealed class PrototypeReloadSystem : EntitySystem
         foreach (var (name, _) in newPrototypeComponents.Where(t => !ignoredComponents.Contains(t.name))
                      .Except(oldPrototypeComponents))
         {
-            var data = newPrototype.Components[name];
             var component = (Component)_componentFactory.GetComponent(name);
             component.Owner = entity;
             EntityManager.AddComponent(entity, component);

--- a/Robust.Shared/Localization/LocalizationManager.Entity.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Entity.cs
@@ -25,7 +25,7 @@ namespace Robust.Shared.Localization
 
         private bool TryGetEntityLocAttrib(EntityUid entity, string attribute, [NotNullWhen(true)] out string? value)
         {
-            if (_entMan.TryGetComponent<GrammarComponent?>(entity, out var grammar) &&
+            if (_entMan.TryGetComponent<GrammarComponent>(entity, out var grammar) &&
                 grammar.Attributes.TryGetValue(attribute, out value))
             {
                 return true;

--- a/Robust.Shared/Localization/LocalizationManager.Functions.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Functions.cs
@@ -174,7 +174,7 @@ namespace Robust.Shared.Localization
             {
                 EntityUid entity = (EntityUid)entity0.Value;
 
-                if (_entMan.TryGetComponent<GrammarComponent?>(entity, out var grammar) && grammar.Gender.HasValue)
+                if (_entMan.TryGetComponent<GrammarComponent>(entity, out var grammar) && grammar.Gender.HasValue)
                 {
                     return new LocValueString(grammar.Gender.Value.ToString().ToLowerInvariant());
                 }
@@ -307,7 +307,7 @@ namespace Robust.Shared.Localization
             {
                 EntityUid entity = (EntityUid)entity0.Value;
 
-                if (_entMan.TryGetComponent<GrammarComponent?>(entity, out var grammar) && grammar.ProperNoun.HasValue)
+                if (_entMan.TryGetComponent<GrammarComponent>(entity, out var grammar) && grammar.ProperNoun.HasValue)
                 {
                     return new LocValueString(grammar.ProperNoun.Value.ToString().ToLowerInvariant());
                 }


### PR DESCRIPTION
- ToPrettyString did a whacky cast that sometimes was annoying so I just made it more normal (i.e. pass the nullable value to a non-null method rather than doing a cast).
- Remove all of the _entTraitArray stuff and just use entitymanager's entityquery<T> directly.
- Sprinkly some speedholes AKA Unsafe.As<T> around the place.
- Fix some generic constraints on some entitymanager methods.

Content PR is https://github.com/space-wizards/space-station-14/pull/20241