### PR TITLE
Fix metadata assert

### DIFF
--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -94,7 +94,8 @@ namespace Robust.Shared.GameObjects
         public GameTick LastStateApplied { get; internal set; } = GameTick.Zero;
 
         /// <summary>
-        ///     This is the most recent tick at which some component was removed from this entity.
+        ///     This is the most recent tick at which a networked component was removed from this entity.
+        ///     Currently only reliable server-side, client side prediction may cause the value to be wrong.
         /// </summary>
         [ViewVariables]
         public GameTick LastComponentRemoved { get; internal set; } = GameTick.Zero;

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -618,7 +618,9 @@ namespace Robust.Shared.GameObjects
             // _entCompIndex.Remove(uid) gets called later on anyways.
             _entCompIndex.Remove(entityUid, component);
 
-            DebugTools.Assert(metadata.EntityLastModifiedTick >= metadata.LastComponentRemoved);
+
+            DebugTools.Assert(_netMan.IsClient // Client side prediction can set LastComponentRemoved to some future tick,
+                              || metadata.EntityLastModifiedTick >= metadata.LastComponentRemoved);
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using Prometheus;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
+using Robust.Shared.Network;
 using Robust.Shared.Profiling;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager;
@@ -32,6 +33,7 @@ namespace Robust.Shared.GameObjects
         [IoC.Dependency] private readonly IGameTiming _gameTiming = default!;
         [IoC.Dependency] private readonly ISerializationManager _serManager = default!;
         [IoC.Dependency] private readonly ProfManager _prof = default!;
+        [IoC.Dependency] private readonly INetManager _netMan = default!;
 
         // I feel like PJB might shed me for putting a system dependency here, but its required for setting entity
         // positions on spawn....


### PR DESCRIPTION
Fixes an issue I introduced in #4408, where I forgot to check `Component.NetSyncEnabled` before modifying the `LastComponentRemoved` tick, which was causing a debug asserts to fail. This also moves some duplicated code that was always prefixing `DeleteComponent()` into the method.