### PR TITLE
Add force ack threshold

### DIFF
--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -34,9 +34,15 @@ internal sealed partial class PvsSystem : EntitySystem
     public const float ChunkSize = 8;
 
     // TODO make this a cvar. Make it in terms of seconds and tie it to tick rate?
+    // Main issue is that I CBF figuring out the logic for handling it changing mid-game.
     public const int DirtyBufferSize = 20;
     // Note: If a client has ping higher than TickBuffer / TickRate, then the server will treat every entity as if it
     // had entered PVS for the first time. Note that due to the PVS budget, this buffer is easily overwhelmed.
+
+    /// <summary>
+    /// See <see cref="CVars.NetForceAckThreshold"/>.
+    /// </summary>
+    public int ForceAckThreshold { get; private set; }
 
     /// <summary>
     /// Maximum number of pooled objects
@@ -138,6 +144,7 @@ internal sealed partial class PvsSystem : EntitySystem
 
         _configManager.OnValueChanged(CVars.NetPVS, SetPvs, true);
         _configManager.OnValueChanged(CVars.NetMaxUpdateRange, OnViewsizeChanged, true);
+        _configManager.OnValueChanged(CVars.NetForceAckThreshold, OnForceAckChanged, true);
 
         _serverGameStateManager.ClientAck += OnClientAck;
         _serverGameStateManager.ClientRequestFull += OnClientRequestFull;
@@ -155,6 +162,7 @@ internal sealed partial class PvsSystem : EntitySystem
 
         _configManager.UnsubValueChanged(CVars.NetPVS, SetPvs);
         _configManager.UnsubValueChanged(CVars.NetMaxUpdateRange, OnViewsizeChanged);
+        _configManager.UnsubValueChanged(CVars.NetForceAckThreshold, OnForceAckChanged);
 
         _serverGameStateManager.ClientAck -= OnClientAck;
         _serverGameStateManager.ClientRequestFull -= OnClientRequestFull;
@@ -208,6 +216,11 @@ internal sealed partial class PvsSystem : EntitySystem
     private void OnViewsizeChanged(float obj)
     {
         _viewSize = obj * 2;
+    }
+
+    private void OnForceAckChanged(int value)
+    {
+        ForceAckThreshold = value;
     }
 
     private void SetPvs(bool value)

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -375,6 +375,21 @@ Last ack players: {string.Join(", ", players)}
             // If the state is too big we let Lidgren send it reliably. This is to avoid a situation where a state is so
             // large that it (or part of it) consistently gets dropped. When we send reliably, we immediately update the
             // ack so that the next state will not also be huge.
+            //
+            // We also do this if the client's last ack is too old. This helps prevent things like the entity deletion
+            // history from becoming too bloated if a bad client fails to send acks for whatever reason.
+
+            if (_gameTiming.CurTick.Value > lastAck.Value + _pvs.ForceAckThreshold)
+            {
+                stateUpdateMessage.ForceSendReliably = true;
+
+                // Aside from the time shortly after connecting, this shouldn't be common. If it is happening,
+                // something is probably wrong. If it is more frequent than I think, this can be downgraded to a warning.
+                var connectedTime = (DateTime.UtcNow - session.ConnectedTime).TotalMinutes;
+                if (lastAck > GameTick.Zero && connectedTime > 1)
+                    _logger.Error($"Client {session} exceeded ack-tick threshold. Last ack: {lastAck}. Cur tick: {_gameTiming.CurTick}. Connect time: {connectedTime} minutes");
+            }
+
             if (stateUpdateMessage.ShouldSendReliably())
             {
                 sessionData.LastReceivedAck = _gameTiming.CurTick;

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -173,6 +173,13 @@ namespace Robust.Shared
             CVarDef.Create("net.maxupdaterange", 12.5f, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
 
         /// <summary>
+        /// Maximum allowed delay between the current tick and a client's last acknowledged tick before we send the
+        /// next game state reliably and simply force update the acked tick,
+        /// </summary>
+        public static readonly CVarDef<int> NetForceAckThreshold =
+            CVarDef.Create("net.force_ack_threshold", 40, CVar.ARCHIVE | CVar.SERVERONLY);
+
+        /// <summary>
         /// This limits the number of new entities that can be sent to a client in a single game state. This exists to
         /// avoid stuttering on the client when it has to spawn a bunch of entities in a single tick. If ever entity
         /// spawning isn't hot garbage, this can be increased.

--- a/Robust.Shared/Network/Messages/MsgState.cs
+++ b/Robust.Shared/Network/Messages/MsgState.cs
@@ -95,6 +95,8 @@ namespace Robust.Shared.Network.Messages
             MsgSize = buffer.LengthBytes;
         }
 
+        public bool ForceSendReliably;
+
         /// <summary>
         ///     Whether this state message is large enough to warrant being sent reliably.
         ///     This is only valid after
@@ -103,7 +105,7 @@ namespace Robust.Shared.Network.Messages
         public bool ShouldSendReliably()
         {
             DebugTools.Assert(_hasWritten, "Attempted to determine sending method before determining packet size.");
-            return MsgSize > ReliableThreshold;
+            return ForceSendReliably || MsgSize > ReliableThreshold;
         }
 
         public override NetDeliveryMethod DeliveryMethod


### PR DESCRIPTION
Prevents very old client acks from slowing down the server. I don't know if this is the current cause of slowdowns, and even if it is, it doesn't actually fix whatever is causing the client to not send acks (or for disconnected clients to not disconnect)