### PR TITLE
Don't attempt to insert entities into deleted containers

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -495,7 +495,7 @@ public abstract partial class SharedTransformSystem
                     throw new InvalidOperationException($"Attempted to parent entity {ToPrettyString(uid)} to non-existent entity {value.EntityId}");
                 }
 
-                if (newParent.LifeStage > ComponentLifeStage.Running || LifeStage(value.EntityId) > EntityLifeStage.MapInitialized)
+                if (newParent.LifeStage >= ComponentLifeStage.Stopping || LifeStage(value.EntityId) >= EntityLifeStage.Terminating)
                 {
                     DetachParentToNull(uid, xform);
                     if (_netMan.IsServer || IsClientSide(uid))


### PR DESCRIPTION
Previously this would trigger an unclear transform error and delete the entity. Now it gives a clearer error, though it still just deletes the entity.