### PR TITLE
Fix visibility layers not updating on children

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/ServerMetaDataSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/ServerMetaDataSystem.cs
@@ -75,13 +75,4 @@ public sealed class ServerMetaDataSystem : MetaDataSystem
                 Dirty(uid, comp);
         }
     }
-
-    public override void SetVisibilityMask(EntityUid uid, int value, MetaDataComponent? meta = null)
-    {
-        if (!Resolve(uid, ref meta) || meta.VisibilityMask == value)
-            return;
-
-        base.SetVisibilityMask(uid, value, meta);
-        _pvsSystem.MarkDirty(uid);
-    }
 }

--- a/Robust.Server/GameObjects/EntitySystems/VisibilitySystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/VisibilitySystem.cs
@@ -37,7 +37,7 @@ namespace Robust.Server.GameObjects
             component.Layer |= layer;
 
             if (refresh)
-                RefreshVisibility(uid, vis: component);
+                RefreshVisibility(uid, visibilityComponent: component);
         }
 
         [Obsolete("Use overload that takes an EntityUid instead")]
@@ -54,7 +54,7 @@ namespace Robust.Server.GameObjects
             component.Layer &= ~layer;
 
             if (refresh)
-                RefreshVisibility(uid, vis: component);
+                RefreshVisibility(uid, visibilityComponent: component);
         }
 
         [Obsolete("Use overload that takes an EntityUid instead")]
@@ -71,7 +71,7 @@ namespace Robust.Server.GameObjects
             component.Layer = layer;
 
             if (refresh)
-                RefreshVisibility(uid, vis: component);
+                RefreshVisibility(uid, visibilityComponent: component);
         }
 
         [Obsolete("Use overload that takes an EntityUid instead")]
@@ -91,14 +91,14 @@ namespace Robust.Server.GameObjects
         }
 
         public void RefreshVisibility(EntityUid uid,
-            MetaDataComponent? meta = null,
-            VisibilityComponent? vis = null)
+            VisibilityComponent? visibilityComponent = null,
+            MetaDataComponent? meta = null)
         {
             if (!_metaQuery.Resolve(uid, ref meta, false))
                 return;
 
             // Iterate up through parents and calculate the cumulative visibility mask.
-            var mask = GetParentVisibilityMask(uid, vis);
+            var mask = GetParentVisibilityMask(uid, visibilityComponent);
 
             // Iterate down through children and propagate mask changes.
             RecursivelyApplyVisibility(uid, mask, meta);
@@ -130,7 +130,7 @@ namespace Robust.Server.GameObjects
         [Obsolete("Use overload that takes an EntityUid instead")]
         public void RefreshVisibility(VisibilityComponent visibilityComponent)
         {
-            RefreshVisibility(visibilityComponent.Owner, null, visibilityComponent);
+            RefreshVisibility(visibilityComponent.Owner, visibilityComponent);
         }
 
         private int GetParentVisibilityMask(EntityUid uid, VisibilityComponent? visibilityComponent = null)

--- a/Robust.Server/GameStates/PvsSystem.Dirty.cs
+++ b/Robust.Server/GameStates/PvsSystem.Dirty.cs
@@ -92,9 +92,9 @@ namespace Robust.Server.GameStates
         /// <summary>
         ///     Marks an entity's current chunk as dirty.
         /// </summary>
-        internal void MarkDirty(EntityUid uid)
+        internal void MarkDirty(EntityUid uid, TransformComponent xform)
         {
-            var coordinates = _transform.GetMoverCoordinates(uid);
+            var coordinates = _transform.GetMoverCoordinates(uid, xform);
             _entityPvsCollection.MarkDirty(_entityPvsCollection.GetChunkIndex(coordinates));
         }
     }

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -189,8 +189,8 @@ namespace Robust.Shared.GameObjects
         /// <remarks>
         ///     Every entity will always have the first bit set to true.
         /// </remarks>
-        [ViewVariables] // TODO access restrict wriiting to server-side visibility system
-        public int VisibilityMask = 1;
+        [ViewVariables] // TODO ACCESS RRestrict writing to server-side visibility system
+        public int VisibilityMask { get; internal set; }= 1;
 
         [ViewVariables]
         public bool EntityPaused => PauseTime != null;

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -189,15 +189,8 @@ namespace Robust.Shared.GameObjects
         /// <remarks>
         ///     Every entity will always have the first bit set to true.
         /// </remarks>
-        [Access(typeof(MetaDataSystem))]
+        [ViewVariables] // TODO access restrict wriiting to server-side visibility system
         public int VisibilityMask = 1;
-
-        [UsedImplicitly, ViewVariables(VVAccess.ReadWrite)]
-        private int VVVisibilityMask
-        {
-            get => VisibilityMask;
-            set => IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<MetaDataSystem>().SetVisibilityMask(Owner, value, this);
-        }
 
         [ViewVariables]
         public bool EntityPaused => PauseTime != null;

--- a/Robust.Shared/GameObjects/Systems/MetaDataSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/MetaDataSystem.cs
@@ -15,10 +15,12 @@ public abstract class MetaDataSystem : EntitySystem
     private EntityPausedEvent _pausedEvent;
 
     private EntityQuery<MetaDataComponent> _metaQuery;
+    private EntityQuery<TransformComponent> _transformQuery;
 
     public override void Initialize()
     {
         _metaQuery = GetEntityQuery<MetaDataComponent>();
+        _transformQuery = GetEntityQuery<TransformComponent>();
         SubscribeLocalEvent<MetaDataComponent, ComponentHandleState>(OnMetaDataHandle);
         SubscribeLocalEvent<MetaDataComponent, ComponentGetState>(OnMetaDataGetState);
     }
@@ -147,12 +149,6 @@ public abstract class MetaDataSystem : EntitySystem
         RaiseLocalEvent(uid, ref ev, true);
 
         component.Flags &= ~ev.ToRemove;
-    }
-
-    public virtual void SetVisibilityMask(EntityUid uid, int value, MetaDataComponent? meta = null)
-    {
-        if (Resolve(uid, ref meta))
-            meta.VisibilityMask = value;
     }
 }
 

--- a/Robust.Shared/GameObjects/Systems/MetaDataSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/MetaDataSystem.cs
@@ -15,12 +15,10 @@ public abstract class MetaDataSystem : EntitySystem
     private EntityPausedEvent _pausedEvent;
 
     private EntityQuery<MetaDataComponent> _metaQuery;
-    private EntityQuery<TransformComponent> _transformQuery;
 
     public override void Initialize()
     {
         _metaQuery = GetEntityQuery<MetaDataComponent>();
-        _transformQuery = GetEntityQuery<TransformComponent>();
         SubscribeLocalEvent<MetaDataComponent, ComponentHandleState>(OnMetaDataHandle);
         SubscribeLocalEvent<MetaDataComponent, ComponentGetState>(OnMetaDataGetState);
     }

--- a/Robust.UnitTesting/Shared/GameState/VisibilityTest.cs
+++ b/Robust.UnitTesting/Shared/GameState/VisibilityTest.cs
@@ -1,0 +1,131 @@
+using System.Linq;
+using System.Numerics;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Robust.Server.GameObjects;
+using Robust.Server.Player;
+using Robust.Shared;
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameStates;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Network;
+
+namespace Robust.UnitTesting.Shared.GameState;
+
+public sealed partial class VisibilityTest : RobustIntegrationTest
+{
+    /// <summary>
+    /// This tests checks that entity visibility masks are recursively applied to children.
+    /// </summary>
+    [Test]
+    public async Task UnknownEntityTest()
+    {
+        var server = StartServer();
+
+        var xforms = server.System<SharedTransformSystem>();
+        var vis = server.System<VisibilitySystem>();
+
+        const int RequiredMask = 1;
+        // All entities need to have this mask set ... which defeat the whole point of that bit?
+
+        // Spawn a stack of entities
+        int N = 6;
+        var ents = new EntityUid[N];
+        var metaComp = new MetaDataComponent[N];
+        var visComp = new VisibilityComponent[N];
+        await server.WaitPost(() =>
+        {
+            for (int i = 0; i < N; i++)
+            {
+                var ent = server.EntMan.Spawn();
+
+                ents[i] = ent;
+                metaComp[i] = server.EntMan.GetComponent<MetaDataComponent>(ent);
+                visComp[i] = server.EntMan.AddComponent<VisibilityComponent>(ent);
+
+                vis.AddLayer(ent, visComp[i], 1 << i);
+                if (i > 0)
+                    xforms.SetParent(ent, ents[i - 1]);
+            }
+        });
+
+        // Each entity's visibility mask should include the parent's mask
+        var mask = RequiredMask;
+        for (int i = 0; i < N; i++)
+        {
+            mask |= 1 << i;
+            var meta = metaComp[i];
+            Assert.That(meta.VisibilityMask, Is.EqualTo(mask));
+        }
+
+        // Adding a layer to the root entity's mask will apply it to all children
+        var extraMask = 1 << (N + 1);
+        mask = RequiredMask | extraMask;
+        vis.AddLayer(ents[0], visComp[0], extraMask);
+        for (int i = 0; i < N; i++)
+        {
+            mask |= 1 << i;
+            var meta = metaComp[i];
+            Assert.That(meta.VisibilityMask, Is.EqualTo(mask));
+        }
+
+        // Removing the removes it from all children.
+        vis.RemoveLayer(ents[0], visComp[0], extraMask);
+        mask = RequiredMask;
+        for (int i = 0; i < N; i++)
+        {
+            mask |= 1 << i;
+            var meta = metaComp[i];
+            Assert.That(meta.VisibilityMask, Is.EqualTo(mask));
+        }
+
+        // Detaching an entity from the stack updates it, and it's children's mask
+        var split = N / 2;
+        await server.WaitPost(() => xforms.SetParent(ents[split], EntityUid.Invalid));
+
+        mask = RequiredMask;
+        for (int i = 0; i < split; i++)
+        {
+            mask |= 1 << i;
+            var meta = metaComp[i];
+            Assert.That(meta.VisibilityMask, Is.EqualTo(mask));
+        }
+
+        mask = RequiredMask;
+        for (int i = split; i < N; i++)
+        {
+            mask |= 1 << i;
+            var meta = metaComp[i];
+            Assert.That(meta.VisibilityMask, Is.EqualTo(mask));
+        }
+
+        // Re-attaching the entity also updates the masks.
+        await server.WaitPost(() => xforms.SetParent(ents[split], ents[split-1]));
+        mask = RequiredMask;
+        for (int i = 0; i < N; i++)
+        {
+            mask |= 1 << i;
+            var meta = metaComp[i];
+            Assert.That(meta.VisibilityMask, Is.EqualTo(mask));
+        }
+
+        // Setting a mask on a child does not propagate upwards, only downwards
+        vis.AddLayer(ents[split], visComp[split], extraMask);
+        mask = RequiredMask;
+        for (int i = 0; i < split; i++)
+        {
+            mask |= 1 << i;
+            var meta = metaComp[i];
+            Assert.That(meta.VisibilityMask, Is.EqualTo(mask));
+        }
+
+        mask |= extraMask;
+        for (int i = split; i < N; i++)
+        {
+            mask |= 1 << i;
+            var meta = metaComp[i];
+            Assert.That(meta.VisibilityMask, Is.EqualTo(mask));
+        }
+    }
+}


### PR DESCRIPTION
The visibility masks of child entities were never updated when the parent's visibility layer changes. This PR fixes that and adds a test.