### PR TITLE
Make entity system proxy methods use Metadata & Transform queries

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Spawn.cs
@@ -95,7 +95,7 @@ public partial class EntityManager
         ComponentRegistry? overrides = null)
     {
         uid = null;
-        if (!_xformQuery.Resolve(target, ref xform))
+        if (!TransformQuery.Resolve(target, ref xform))
             return false;
 
         if (!xform.ParentUid.IsValid())
@@ -157,7 +157,7 @@ public partial class EntityManager
 
     public EntityUid SpawnNextToOrDrop(string? protoName, EntityUid target, TransformComponent? xform = null, ComponentRegistry? overrides = null)
     {
-        xform ??= _xformQuery.GetComponent(target);
+        xform ??= TransformQuery.GetComponent(target);
         if (!xform.ParentUid.IsValid())
             return Spawn(protoName);
 
@@ -181,7 +181,7 @@ public partial class EntityManager
              || !container.Insert(uid, this))
         {
 
-            xform ??= _xformQuery.GetComponent(containerUid);
+            xform ??= TransformQuery.GetComponent(containerUid);
             if (xform.ParentUid.IsValid())
                 _xforms.PlaceNextToOrDrop(uid, containerUid, targetXform: xform);
         }

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -61,7 +61,7 @@ public partial class EntitySystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected bool Deleted(EntityUid uid, MetaDataComponent? metaData = null)
     {
-        if (!Resolve(uid, ref metaData, false))
+        if (!EntityManager.MetaQuery.Resolve(uid, ref metaData, false))
             return true;
 
         return metaData.EntityDeleted;
@@ -73,7 +73,7 @@ public partial class EntitySystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected bool TerminatingOrDeleted(EntityUid uid, MetaDataComponent? metaData = null)
     {
-        if (!Resolve(uid, ref metaData, false))
+        if (!EntityManager.MetaQuery.Resolve(uid, ref metaData, false))
             return true;
 
         return metaData.EntityLifeStage >= EntityLifeStage.Terminating;
@@ -104,7 +104,7 @@ public partial class EntitySystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected EntityLifeStage LifeStage(EntityUid uid, MetaDataComponent? metaData = null)
     {
-        if (!Resolve(uid, ref metaData, false))
+        if (!EntityManager.MetaQuery.Resolve(uid, ref metaData, false))
             throw CompNotFound<MetaDataComponent>(uid);
 
         return metaData.EntityLifeStage;
@@ -169,7 +169,7 @@ public partial class EntitySystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected bool TryLifeStage(EntityUid uid, [NotNullWhen(true)] out EntityLifeStage? lifeStage, MetaDataComponent? metaData = null)
     {
-        if (!Resolve(uid, ref metaData))
+        if (!EntityManager.MetaQuery.Resolve(uid, ref metaData, false))
         {
             lifeStage = null;
             return false;
@@ -227,7 +227,7 @@ public partial class EntitySystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected string Name(EntityUid uid, MetaDataComponent? metaData = null)
     {
-        if(!Resolve(uid, ref metaData, false))
+        if (!EntityManager.MetaQuery.Resolve(uid, ref metaData, false))
             throw CompNotFound<MetaDataComponent>(uid);
 
         return metaData.EntityName;
@@ -240,7 +240,7 @@ public partial class EntitySystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected string Description(EntityUid uid, MetaDataComponent? metaData = null)
     {
-        if(!Resolve(uid, ref metaData, false))
+        if (!EntityManager.MetaQuery.Resolve(uid, ref metaData, false))
             throw CompNotFound<MetaDataComponent>(uid);
 
         return metaData.EntityDescription;
@@ -253,7 +253,7 @@ public partial class EntitySystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected EntityPrototype? Prototype(EntityUid uid, MetaDataComponent? metaData = null)
     {
-        if (!Resolve(uid, ref metaData, false))
+        if (!EntityManager.MetaQuery.Resolve(uid, ref metaData, false))
             throw CompNotFound<MetaDataComponent>(uid);
 
         return metaData.EntityPrototype;
@@ -265,7 +265,7 @@ public partial class EntitySystem
     /// <exception cref="KeyNotFoundException">Thrown when the entity doesn't exist.</exception>
     protected GameTick LastModifiedTick(EntityUid uid, MetaDataComponent? metaData = null)
     {
-        if (!Resolve(uid, ref metaData, false))
+        if (!EntityManager.MetaQuery.Resolve(uid, ref metaData, false))
             throw CompNotFound<MetaDataComponent>(uid);
 
         return metaData.EntityLastModifiedTick;
@@ -278,7 +278,7 @@ public partial class EntitySystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected bool Paused(EntityUid uid, MetaDataComponent? metaData = null)
     {
-        if (!Resolve(uid, ref metaData, false))
+        if (!EntityManager.MetaQuery.Resolve(uid, ref metaData, false))
             throw CompNotFound<MetaDataComponent>(uid);
 
         return metaData.EntityPaused;
@@ -291,7 +291,7 @@ public partial class EntitySystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected void SetPaused(EntityUid uid, bool paused, MetaDataComponent? metaData = null)
     {
-        if (!Resolve(uid, ref metaData, false))
+        if (!EntityManager.MetaQuery.Resolve(uid, ref metaData, false))
             throw CompNotFound<MetaDataComponent>(uid);
 
         EntityManager.EntitySysManager.GetEntitySystem<MetaDataSystem>().SetEntityPaused(uid, paused, metaData);
@@ -302,12 +302,12 @@ public partial class EntitySystem
     /// </summary>
     /// <returns>Whether the operation succeeded.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected bool TryDirty(EntityUid uid)
+    protected bool TryDirty(EntityUid uid, MetaDataComponent? metaData = null)
     {
-        if (!Exists(uid))
+        if (!EntityManager.MetaQuery.Resolve(uid, ref metaData, false))
             return false;
 
-        DirtyEntity(uid);
+        DirtyEntity(uid, metaData);
         return true;
     }
 
@@ -318,7 +318,7 @@ public partial class EntitySystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected bool TryName(EntityUid uid, [NotNullWhen(true)] out string? name, MetaDataComponent? metaData = null)
     {
-        if (!Resolve(uid, ref metaData, false))
+        if (!EntityManager.MetaQuery.Resolve(uid, ref metaData, false))
         {
             name = null;
             return false;
@@ -335,7 +335,7 @@ public partial class EntitySystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected bool TryDescription(EntityUid uid, [NotNullWhen(true)] out string? description, MetaDataComponent? metaData = null)
     {
-        if (!Resolve(uid, ref metaData, false))
+        if (!EntityManager.MetaQuery.Resolve(uid, ref metaData, false))
         {
             description = null;
             return false;
@@ -352,7 +352,7 @@ public partial class EntitySystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected bool TryPrototype(EntityUid uid, [NotNullWhen(true)] out EntityPrototype? prototype, MetaDataComponent? metaData = null)
     {
-        if (!Resolve(uid, ref metaData, false))
+        if (!EntityManager.MetaQuery.Resolve(uid, ref metaData, false))
         {
             prototype = null;
             return false;
@@ -369,7 +369,7 @@ public partial class EntitySystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected bool TryLastModifiedTick(EntityUid uid, [NotNullWhen(true)] out GameTick? lastModifiedTick, MetaDataComponent? metaData = null)
     {
-        if (!Resolve(uid, ref metaData, false))
+        if (!EntityManager.MetaQuery.Resolve(uid, ref metaData, false))
         {
             lastModifiedTick = null;
             return false;
@@ -386,7 +386,7 @@ public partial class EntitySystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected bool TryPaused(EntityUid uid, [NotNullWhen(true)] out bool? paused, MetaDataComponent? metaData = null)
     {
-        if (!Resolve(uid, ref metaData, false))
+        if (!EntityManager.MetaQuery.Resolve(uid, ref metaData, false))
         {
             paused = null;
             return false;
@@ -458,6 +458,20 @@ public partial class EntitySystem
         return EntityManager.TryGetComponent(uid, out comp);
     }
 
+    /// <inheritdoc cref="IEntityManager.TryGetComponent&lt;T&gt;(EntityUid, out T)"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected bool TryComp(EntityUid uid, [NotNullWhen(true)] out TransformComponent? comp)
+    {
+        return EntityManager.TransformQuery.TryGetComponent(uid, out comp);
+    }
+
+    /// <inheritdoc cref="IEntityManager.TryGetComponent&lt;T&gt;(EntityUid, out T)"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected bool TryComp(EntityUid uid, [NotNullWhen(true)] out MetaDataComponent? comp)
+    {
+        return EntityManager.MetaQuery.TryGetComponent(uid, out comp);
+    }
+
     /// <inheritdoc cref="IEntityManager.TryGetComponent&lt;T&gt;(EntityUid?, out T)"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected bool TryComp<T>([NotNullWhen(true)] EntityUid? uid, [NotNullWhen(true)] out T? comp)
@@ -469,6 +483,30 @@ public partial class EntitySystem
         }
 
         return EntityManager.TryGetComponent(uid.Value, out comp);
+    }
+
+    /// <inheritdoc cref="IEntityManager.TryGetComponent&lt;T&gt;(EntityUid?, out T)"/>
+    protected bool TryComp([NotNullWhen(true)] EntityUid? uid, [NotNullWhen(true)] out TransformComponent? comp)
+    {
+        if (!uid.HasValue)
+        {
+            comp = default;
+            return false;
+        }
+
+        return EntityManager.TransformQuery.TryGetComponent(uid.Value, out comp);
+    }
+
+    /// <inheritdoc cref="IEntityManager.TryGetComponent&lt;T&gt;(EntityUid?, out T)"/>
+    protected bool TryComp([NotNullWhen(true)] EntityUid? uid, [NotNullWhen(true)] out MetaDataComponent? comp)
+    {
+        if (!uid.HasValue)
+        {
+            comp = default;
+            return false;
+        }
+
+        return EntityManager.MetaQuery.TryGetComponent(uid.Value, out comp);
     }
 
     /// <inheritdoc cref="IEntityManager.GetComponents"/>
@@ -492,7 +530,7 @@ public partial class EntitySystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected TransformComponent Transform(EntityUid uid)
     {
-        return EntityManager.GetComponent<TransformComponent>(uid);
+        return EntityManager.TransformQuery.GetComponent(uid);
     }
 
     /// <summary>
@@ -502,7 +540,7 @@ public partial class EntitySystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected MetaDataComponent MetaData(EntityUid uid)
     {
-        return EntityManager.GetComponent<MetaDataComponent>(uid);
+        return EntityManager.MetaQuery.GetComponent(uid);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Robust.Shared/GameObjects/EntitySystem.Resolve.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Resolve.cs
@@ -32,6 +32,22 @@ namespace Robust.Shared.GameObjects
             return found;
         }
 
+        /// <inheritdoc cref="Resolve{TComp}"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected bool Resolve(EntityUid uid, [NotNullWhen(true)] ref MetaDataComponent? component,
+            bool logMissing = true)
+        {
+            return EntityManager.MetaQuery.Resolve(uid, ref component);
+        }
+
+        /// <inheritdoc cref="Resolve{TComp}"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected bool Resolve(EntityUid uid, [NotNullWhen(true)] ref TransformComponent? component,
+            bool logMissing = true)
+        {
+            return EntityManager.TransformQuery.Resolve(uid, ref component);
+        }
+
         /// <summary>
         ///     Resolves the components on the entity for the null component references.
         /// </summary>


### PR DESCRIPTION
This PR makes methods like `Transform()` & `MetaData()` use the cached transform & metadata queries. Main reason for this PR is just that I like being able to use `Transform(uid)`, but rarely ever use it because using the queries is faster. This also adds variants for Resolve & TryComp, which has the side effect that `TryComp<MetadataComponent>(uid, out var _)` is now slower than `TryComp(uid, out MetadataComponent? _)`. I didn't bother with `HasComp()` because that is redundant with `Exists()`.

This PR has some overlap with #4409 because both replace some _entTraitArray stuff with the queires, but the conflicts should be trivial/auto-resolvable