### PR TITLE
Fix HideSpawnMenu

### DIFF
--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -102,7 +102,7 @@ namespace Robust.Shared.Prototypes
         [Obsolete("Use the HideSpawnMenu")]
         public bool NoSpawn { get; private set; }
 
-        public bool HideSpawnMenu => Categories.Contains(HideCategory);
+        public bool HideSpawnMenu => Categories.Contains(HideCategory) || NoSpawn;
 
         [DataField("placement")]
         private EntityPlacementProperties PlacementProperties = new();


### PR DESCRIPTION
`NoSpawn` is obsolete, but it was still meant to work.