### PR TITLE
Percentage range. Percentage and percentage range type serializers

### DIFF
--- a/Robust.Shared.Maths/PercentageRange.cs
+++ b/Robust.Shared.Maths/PercentageRange.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Robust.Shared.Maths;
+
+[Serializable]
+public struct PercentageRange : IEquatable<PercentageRange>
+{
+    /// <summary>
+    /// Minimum range value, e.g. 0.01f == 1%
+    /// </summary>
+    public float Min;
+
+    /// <summary>
+    /// Maximum range value, e.g. 1f == 100%
+    /// </summary>
+    public float Max;
+
+    public bool IsValid()
+    {
+        return IsValid(this, out _);
+    }
+
+    private bool IsValid([NotNullWhen(false)] out string? exception)
+    {
+        return IsValid(this, out exception);
+    }
+
+    private static bool IsValid(PercentageRange range, [NotNullWhen(false)] out string? exception)
+    {
+        return IsValid(range.Min, range.Max, out exception);
+    }
+
+    private static bool IsValid((float, float) range, [NotNullWhen(false)] out string? exception)
+    {
+        return IsValid(range.Item1, range.Item2, out exception);
+    }
+
+    private static bool IsValid(float min, float max, [NotNullWhen(false)] out string? exception)
+    {
+        exception = (min, max) switch
+        {
+            _ when min < 0 || max > 1 => $"Incorrect min and max values. Got: {min}, {max}; expected to be in 0.0 - 1.0 range",
+            _ when min > max => $"Incorrect min and max values. Min value is greater than max value: {min}>{max}",
+            _ => null
+        };
+
+        return exception == null;
+    }
+
+    public PercentageRange(float min = 0, float max = 1)
+    {
+        if (!IsValid(min, max, out var message))
+            throw new ArgumentException(message);
+
+        Min = min;
+        Max = max;
+    }
+
+    public PercentageRange((float, float) range) : this(range.Item1, range.Item2)
+    {
+    }
+
+    public PercentageRange(ReadOnlySpan<float> range)
+    {
+        if (range.Length != 2)
+            throw new ArgumentException($"An array with 2 items was expected, got: {range.Length}");
+
+        if (!IsValid(range[0], range[1], out var message))
+            throw new ArgumentException(message);
+
+        Min = range[0];
+        Max = range[1];
+    }
+
+    public PercentageRange(IReadOnlyList<float> range)
+    {
+        if (range.Count != 2)
+            throw new ArgumentException($"A list with 2 items was expected, got: {range.Count}");
+
+        if (!IsValid(range[0], range[1], out var message))
+            throw new ArgumentException(message);
+
+        Min = range[0];
+        Max = range[1];
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is PercentageRange other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Min, Max);
+    }
+
+    public bool Equals(PercentageRange range)
+    {
+        const double tolerance = 0.0001;
+        return Math.Abs(range.Max - Max) < tolerance && Math.Abs(range.Min - Min) < tolerance;
+    }
+
+    public static implicit operator (float, float)(PercentageRange r)
+    {
+        return (r.Min, r.Max);
+    }
+
+    public static explicit operator PercentageRange((float, float) r)
+    {
+        return new PercentageRange(r);
+    }
+
+    public static implicit operator (string, string)(PercentageRange r)
+    {
+        return (((int)(r.Min * 100)).ToString() + '%', ((int)(r.Max * 100)).ToString() + '%');
+    }
+
+    public static bool operator ==(PercentageRange range1, PercentageRange range2)
+    {
+        return range1.Equals(range2);
+    }
+
+    public static bool operator !=(PercentageRange range1, PercentageRange range2)
+    {
+        return !(range1 == range2);
+    }
+
+    public override string ToString()
+    {
+        return $"{Min * 100}-{Max * 100}%";
+    }
+}

--- a/Robust.Shared/Random/PercentageRangeExt.cs
+++ b/Robust.Shared/Random/PercentageRangeExt.cs
@@ -1,0 +1,11 @@
+﻿using Robust.Shared.Maths;
+
+namespace Robust.Shared.Random;
+
+public static class PercentageRangeExt
+{
+    public static float NextFloat(this PercentageRange range, IRobustRandom random)
+    {
+        return random.NextFloat(range.Min, range.Max);
+    }
+}

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Percents/PercentageRangeSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Percents/PercentageRangeSerializer.cs
@@ -1,0 +1,37 @@
+﻿using Robust.Shared.IoC;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Percents;
+
+public sealed class PercentageRangeSerializer : ITypeSerializer<(float,float), ValueDataNode>
+{
+    public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
+        IDependencyCollection dependencies, ISerializationContext? context = null)
+    {
+        return PercentageSerializerUtility.TryParseRange(node.Value, out var range) && range.Length == 2
+            ? new ValidatedValueNode(node)
+            : new ErrorNode(node, "Failed parsing values for percentage range");
+    }
+
+    public (float, float) Read(ISerializationManager serializationManager, ValueDataNode node,
+        IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context = null,
+        ISerializationManager.InstantiationDelegate<(float, float)>? instanceProvider = null)
+    {
+        if (!PercentageSerializerUtility.TryParseRange(node.Value, out var range) || range.Length != 2)
+            throw new InvalidMappingException("Could not parse percentage range");
+
+        return (range[0], range[1]);
+    }
+
+    public DataNode Write(ISerializationManager serializationManager, (float, float) value, IDependencyCollection dependencies,
+        bool alwaysWrite = false,
+        ISerializationContext? context = null)
+    {
+        return new ValueDataNode($"{value.Item1 * 100}%, {value.Item2 * 100}%");
+    }
+}

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Percents/PercentageRangeSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Percents/PercentageRangeSerializer.cs
@@ -1,5 +1,7 @@
 ﻿using Robust.Shared.IoC;
+using Robust.Shared.Maths;
 using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
@@ -8,30 +10,31 @@ using Robust.Shared.Utility;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Percents;
 
-public sealed class PercentageRangeSerializer : ITypeSerializer<(float,float), ValueDataNode>
+[TypeSerializer]
+public sealed class PercentageRangeSerializer : ITypeSerializer<PercentageRange, ValueDataNode>
 {
     public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
         IDependencyCollection dependencies, ISerializationContext? context = null)
     {
-        return PercentageSerializerUtility.TryParseRange(node.Value, out var range) && range.Length == 2
+        return PercentageSerializerUtility.TryParseRange(node.Value, out _)
             ? new ValidatedValueNode(node)
             : new ErrorNode(node, "Failed parsing values for percentage range");
     }
 
-    public (float, float) Read(ISerializationManager serializationManager, ValueDataNode node,
+    public PercentageRange Read(ISerializationManager serializationManager, ValueDataNode node,
         IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context = null,
-        ISerializationManager.InstantiationDelegate<(float, float)>? instanceProvider = null)
+        ISerializationManager.InstantiationDelegate<PercentageRange>? instanceProvider = null)
     {
-        if (!PercentageSerializerUtility.TryParseRange(node.Value, out var range) || range.Length != 2)
+        if (!PercentageSerializerUtility.TryParseRange(node.Value, out var range))
             throw new InvalidMappingException("Could not parse percentage range");
 
-        return (range[0], range[1]);
+        return range.Value;
     }
 
-    public DataNode Write(ISerializationManager serializationManager, (float, float) value, IDependencyCollection dependencies,
+    public DataNode Write(ISerializationManager serializationManager, PercentageRange value, IDependencyCollection dependencies,
         bool alwaysWrite = false,
         ISerializationContext? context = null)
     {
-        return new ValueDataNode($"{value.Item1 * 100}%, {value.Item2 * 100}%");
+        return new ValueDataNode(value.ToString());
     }
 }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Percents/PercentageSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Percents/PercentageSerializer.cs
@@ -1,0 +1,37 @@
+﻿using Robust.Shared.IoC;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Percents;
+
+public sealed class PercentageSerializer : ITypeSerializer<float, ValueDataNode>
+{
+    public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
+        IDependencyCollection dependencies, ISerializationContext? context = null)
+    {
+        return PercentageSerializerUtility.TryParse(node.Value, out _)
+            ? new ValidatedValueNode(node)
+            : new ErrorNode(node, "Failed parsing values for percentage");
+    }
+
+    public float Read(ISerializationManager serializationManager, ValueDataNode node,
+        IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context = null,
+        ISerializationManager.InstantiationDelegate<float>? instanceProvider = null)
+    {
+        if (!PercentageSerializerUtility.TryParse(node.Value, out var @float))
+            throw new InvalidMappingException("Could not parse percentage");
+
+        return @float.Value;
+    }
+
+    public DataNode Write(ISerializationManager serializationManager, float value, IDependencyCollection dependencies,
+        bool alwaysWrite = false,
+        ISerializationContext? context = null)
+    {
+        return new ValueDataNode($"{value * 100}%");
+    }
+}

--- a/Robust.Shared/Utility/PercentageSerializerUtility.cs
+++ b/Robust.Shared/Utility/PercentageSerializerUtility.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Robust.Shared.Utility;
+
+public sealed class PercentageSerializerUtility
+{
+    public static bool TryParse(string value, [NotNullWhen(true)] out float? result)
+    {
+        result = null;
+
+        if (float.TryParse(value, out var @float))
+        {
+            if (@float is < 0 or > 1)
+                return false;
+
+            result = @float;
+            return true;
+        }
+
+        if (value.Replace(" ", "")[^1] == '%' && int.TryParse(value[..^1], out var @int))
+        {
+            if (@int is < 0 or > 100)
+                return false;
+
+            result = (float) @int / 100;
+            return true;
+        }
+
+        return false;
+    }
+
+    public static bool TryParseRange(string value, [NotNullWhen(true)] out float[]? result)
+    {
+        result = null;
+        var values = new List<float>();
+
+        foreach (var val in value.Split(','))
+        {
+            if (!TryParse(val, out var res))
+                return false;
+
+            values.Add(res.Value);
+        }
+
+        result = values.ToArray();
+        return false;
+    }
+}

--- a/Robust.Shared/Utility/PercentageSerializerUtility.cs
+++ b/Robust.Shared/Utility/PercentageSerializerUtility.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.Maths;
 
 namespace Robust.Shared.Utility;
 
@@ -30,12 +31,37 @@ public sealed class PercentageSerializerUtility
         return false;
     }
 
-    public static bool TryParseRange(string value, [NotNullWhen(true)] out float[]? result)
+    public static bool TryParseRange(string value, [NotNullWhen(true)] out PercentageRange? result)
     {
         result = null;
         var values = new List<float>();
 
-        foreach (var val in value.Split(','))
+        var commas = value.Split(',');
+
+        if (commas.Length == 2)
+        {
+            foreach (var val in value.Split(','))
+            {
+                if (!TryParse(val, out var res))
+                    return false;
+
+                values.Add(res.Value);
+            }
+
+            result = new PercentageRange(values);
+            return true;
+        }
+
+        values.Clear();
+
+        var dashes = value.Split('-');
+
+        if (dashes.Length != 2)
+            return false;
+
+        dashes[0] = dashes[0] + '%';
+
+        foreach (var val in dashes)
         {
             if (!TryParse(val, out var res))
                 return false;
@@ -43,7 +69,7 @@ public sealed class PercentageSerializerUtility
             values.Add(res.Value);
         }
 
-        result = values.ToArray();
-        return false;
+        result = new PercentageRange(values);
+        return true;
     }
 }


### PR DESCRIPTION
# Percentage range
Added a new **Percentage range** struct that keeps two values:
- Min value
- Max value
## What is it used for?
Can be used for getting a random discount of an item, for random chance of getting hit from something, as an example.
## What do Max and Min values have to be?
- Min value can’t be greater than Max value
- Min and Max values should be in 0-100% range:
  - 0.0f ≤ `Min/Max` ≤ 1.0f
  - 0% ≤ `Min/Max` ≤ 100%
## `NextFloat()`
This method is a part of an extension that is in `Robust.Shared.Random` that requires `IRobustRabdom` as the only parameter. What it does is basically `random.NextFloat(this.Min, this.Max`, where:
- `random` is the `IRobustRabdom` parameter
- `this` is a `PercentageRange` object
# Type serializers
## Percentage type serializer
Converts a YAML string into a float.
### Valid syntaxes
- `0.02`
  - would be `0.02` after reading it with serialization manager 
- `2%`
  - would also be `0.02` in C# code
## Percentage range serializer
Converts a YAML string into a `PercentageRange`.
### Valid syntaxes
- `0.05, 0.28`
  - `Min = 0.05` and `Max = 0.28`
- `20%, 75%`
  - `Min = 0.2` and `Max = 0.75`
- `12-25%`
  - `Min = 0.12` and `Max = 0.25`