### PR TITLE
Infer `VVAccess.ReadWrite` for all datafields

### DIFF
--- a/Robust.Shared/ViewVariables/ViewVariablesUtility.cs
+++ b/Robust.Shared/ViewVariables/ViewVariablesUtility.cs
@@ -40,7 +40,7 @@ namespace Robust.Shared.ViewVariables
 
             if (info.HasCustomAttribute<DataFieldAttribute>() || info.HasCustomAttribute<IncludeDataFieldAttribute>())
             {
-                access = VVAccess.ReadOnly;
+                access = VVAccess.ReadWrite;
                 return true;
             }
 


### PR DESCRIPTION
reduces boilerplate since people usually readwrite these anyway

i cant think of a situation where it would be bad for a datafield to be readwriteable imo. maybe in the case of stuff needing to go through systems for some behavior but i'd still rather allow people to write to these always