### PR TITLE
Add IComparable to ProtoId, EntProtoId and LocId

### DIFF
--- a/Robust.Shared/Localization/LocId.cs
+++ b/Robust.Shared/Localization/LocId.cs
@@ -12,7 +12,7 @@ namespace Robust.Shared.Localization;
 ///     This will be automatically validated by <see cref="LocIdSerializer"/> if used in data fields.</remarks>
 /// <seealso cref="Loc.GetString(string)"/>
 [Serializable, NetSerializable]
-public readonly record struct LocId(string Id)
+public readonly record struct LocId(string Id) : IEquatable<string>, IComparable<LocId>
 {
     public static implicit operator string(LocId locId)
     {
@@ -22,5 +22,20 @@ public readonly record struct LocId(string Id)
     public static implicit operator LocId(string id)
     {
         return new LocId(id);
+    }
+
+    public static implicit operator LocId?(string? id)
+    {
+        return id == null ? default(LocId?) : new LocId(id);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Id == other;
+    }
+
+    public int CompareTo(LocId other)
+    {
+        return string.Compare(Id, other.Id, StringComparison.Ordinal);
     }
 }

--- a/Robust.Shared/Prototypes/EntProtoId.cs
+++ b/Robust.Shared/Prototypes/EntProtoId.cs
@@ -13,7 +13,7 @@ namespace Robust.Shared.Prototypes;
 /// </remarks>
 /// <remarks><seealso cref="ProtoId{T}"/> for a wrapper of other prototype kinds.</remarks>
 [Serializable, NetSerializable]
-public readonly record struct EntProtoId(string Id)
+public readonly record struct EntProtoId(string Id) : IEquatable<string>, IComparable<EntProtoId>
 {
     public static implicit operator string(EntProtoId protoId)
     {
@@ -33,5 +33,10 @@ public readonly record struct EntProtoId(string Id)
     public bool Equals(string? other)
     {
         return Id == other;
+    }
+
+    public int CompareTo(EntProtoId other)
+    {
+        return string.Compare(Id, other.Id, StringComparison.Ordinal);
     }
 }

--- a/Robust.Shared/Prototypes/ProtoId.cs
+++ b/Robust.Shared/Prototypes/ProtoId.cs
@@ -13,7 +13,7 @@ namespace Robust.Shared.Prototypes;
 /// </remarks>
 /// <remarks><seealso cref="EntProtoId"/> for an <see cref="EntityPrototype"/> alias.</remarks>
 [Serializable]
-public readonly record struct ProtoId<T>(string Id) : IEquatable<string> where T : class, IPrototype
+public readonly record struct ProtoId<T>(string Id) : IEquatable<string>, IComparable<ProtoId<T>> where T : class, IPrototype
 {
     public static implicit operator string(ProtoId<T> protoId)
     {
@@ -33,5 +33,10 @@ public readonly record struct ProtoId<T>(string Id) : IEquatable<string> where T
     public bool Equals(string? other)
     {
         return Id == other;
+    }
+
+    public int CompareTo(ProtoId<T> other)
+    {
+        return string.Compare(Id, other.Id, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
Fixes the hop id card computer not opening because of a sort