### PR TITLE
Validate default values of ProtoId and EntProtoId fields

### DIFF
--- a/Robust.Shared/Localization/LocId.cs
+++ b/Robust.Shared/Localization/LocId.cs
@@ -38,4 +38,6 @@ public readonly record struct LocId(string Id) : IEquatable<string>, IComparable
     {
         return string.Compare(Id, other.Id, StringComparison.Ordinal);
     }
+
+    public override string ToString() => Id ?? String.Empty;
 }

--- a/Robust.Shared/Prototypes/EntProtoId.cs
+++ b/Robust.Shared/Prototypes/EntProtoId.cs
@@ -39,4 +39,6 @@ public readonly record struct EntProtoId(string Id) : IEquatable<string>, ICompa
     {
         return string.Compare(Id, other.Id, StringComparison.Ordinal);
     }
+
+    public override string ToString() => Id ?? string.Empty;
 }

--- a/Robust.Shared/Prototypes/ProtoId.cs
+++ b/Robust.Shared/Prototypes/ProtoId.cs
@@ -39,4 +39,6 @@ public readonly record struct ProtoId<T>(string Id) : IEquatable<string>, ICompa
     {
         return string.Compare(Id, other.Id, StringComparison.Ordinal);
     }
+
+    public override string ToString() => Id ?? string.Empty;
 }


### PR DESCRIPTION
Currently the default values of string fields with custom prototype id serializers get validated, but the new PrototId and EntPrototId fields don't. This fixes that.

Requires space-wizards/space-station-14/pull/20611