### PR TITLE
Give map and grid entities a default name

### DIFF
--- a/Robust.Shared/Map/MapManager.GridCollection.cs
+++ b/Robust.Shared/Map/MapManager.GridCollection.cs
@@ -151,7 +151,9 @@ internal partial class MapManager
         var fallbackParentEuid = GetMapEntityIdOrThrow(currentMapId);
         EntityManager.GetComponent<TransformComponent>(gridEnt).AttachParent(fallbackParentEuid);
 
-        EntityManager.InitializeComponents(gridEnt);
+        var meta = EntityManager.GetComponent<MetaDataComponent>(gridEnt);
+        EntityManager.System<MetaDataSystem>().SetEntityName(gridEnt, $"grid", meta);
+        EntityManager.InitializeComponents(gridEnt, meta);
         EntityManager.StartComponents(gridEnt);
         return grid;
     }

--- a/Robust.Shared/Map/MapManager.MapCollection.cs
+++ b/Robust.Shared/Map/MapManager.MapCollection.cs
@@ -236,8 +236,10 @@ internal partial class MapManager
 
                 var mapComp = EntityManager.AddComponent<MapComponent>(newEnt);
                 mapComp.MapId = actualId;
-                EntityManager.Dirty(mapComp);
-                EntityManager.InitializeComponents(newEnt);
+                var meta = EntityManager.GetComponent<MetaDataComponent>(newEnt);
+                EntityManager.System<MetaDataSystem>().SetEntityName(newEnt, $"map {actualId}", meta);
+                EntityManager.Dirty(newEnt, mapComp, meta);
+                EntityManager.InitializeComponents(newEnt, meta);
                 EntityManager.StartComponents(newEnt);
                 _sawmill.Debug($"Binding map {actualId} to entity {newEnt}");
             }


### PR DESCRIPTION
The name isn't localized because its only really meant to help with debugging by making it easier to identify what a prototype-less entity is supposed to be.