### PR TITLE
Fix console backspace exception

### DIFF
--- a/Robust.Server/Console/SystemConsoleManager.cs
+++ b/Robust.Server/Console/SystemConsoleManager.cs
@@ -196,7 +196,7 @@ namespace Robust.Server.Console
                             break;
 
                         case ConsoleKey.Backspace:
-                            if (currentBuffer.Length > 0)
+                            if (currentBuffer.Length > 0 && internalCursor > 0)
                             {
                                 currentBuffer = currentBuffer.Remove(internalCursor - 1, 1);
                                 internalCursor--;


### PR DESCRIPTION
Fixes an exception that gets throw when using backspace while the cursor is at the beginning of a non-empty line.