### PR TITLE
Forbids EyeComponents from ever possessing a single visibility flag.

### DIFF
--- a/Robust.Shared/GameObjects/Components/Eye/EyeComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Eye/EyeComponent.cs
@@ -48,6 +48,8 @@ namespace Robust.Shared.GameObjects
         public Vector2 Offset;
 
         public const int DefaultVisibilityMask = 1;
+        /// <summary>A single visibility flag that should _never_ be added to <see cref="VisibilityMask"/>.</summary>
+        public const int PvsIgnoreVisibilityFlag = 1 << 31;
 
         /// <summary>
         ///     The visibility mask for this eye.

--- a/Robust.Shared/GameObjects/Systems/SharedEyeSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedEyeSystem.cs
@@ -101,7 +101,7 @@ public abstract class SharedEyeSystem : EntitySystem
         if (!Resolve(uid, ref eyeComponent))
             return;
 
-        value &= ~EyeComponent.PvsIgnoreVisibilityFlag;
+        value &= ~EyeComponent.PvsIgnoreVisibilityFlag; // Ensures that setting the MSB (most significant bit) on entities visibility masks is a safe way to render them invisible to clients without risking someone setting an eye to ~0 and revealing them all.
         if (eyeComponent.VisibilityMask.Equals(value))
             return;
 

--- a/Robust.Shared/GameObjects/Systems/SharedEyeSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedEyeSystem.cs
@@ -101,6 +101,7 @@ public abstract class SharedEyeSystem : EntitySystem
         if (!Resolve(uid, ref eyeComponent))
             return;
 
+        value &= ~EyeComponent.PvsIgnoreVisibilityFlag;
         if (eyeComponent.VisibilityMask.Equals(value))
             return;
 


### PR DESCRIPTION
Forbids EyeComponents from ever setting the MSB on their visibility mask.
This makes setting the MSB on the visibility mask for _entities_ a safe way to prevent that entity from being broadcast to clients.
Required for https://github.com/space-wizards/space-station-14/pull/20744