### PR TITLE
Entity timers

### DIFF
--- a/Robust.Shared/GameObjects/Components/Timers/EntityTimerComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Timers/EntityTimerComponent.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Robust.Shared.GameObjects;
+
+/// <summary>
+/// This component is attached to timer entities, which are then parented to the entity that <see cref="Event"/>
+/// will be raised on after some specified amount of time.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class EntityTimerComponent : Component
+{
+    /// <summary>
+    ///     The event to raise on fire. Should be initialized.
+    /// </summary>
+    [DataField(required: true)]
+    public IEntityTimerEvent Event = default!;
+
+    /// <summary>
+    ///     The absolute time at which to fire this timer. Should be initialized.
+    /// </summary>
+    [DataField(required: true, customTypeSerializer:typeof(TimeOffsetSerializer))]
+    public TimeSpan AbsoluteTime = default!;
+}

--- a/Robust.Shared/GameObjects/Components/Timers/RepeatingEntityTimerComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Timers/RepeatingEntityTimerComponent.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Robust.Shared.Serialization.Manager.Attributes;
+
+namespace Robust.Shared.GameObjects;
+
+/// <summary>
+/// This is used for marking repeating timer entities, which will not delete after one fire
+/// and have some metadata.
+/// </summary>
+[RegisterComponent]
+public sealed partial class RepeatingEntityTimerComponent : Component
+{
+    /// <summary>
+    ///     Relative delay for setting the next absolute time in <see cref="EntityTimerComponent"/> after each repetition.
+    ///     This can be modified during subscription to determine when the next fire should happen.
+    /// </summary>
+    [DataField(required: true)]
+    public TimeSpan Delay;
+
+    /// <summary>
+    ///     Total number of times this timer has already fired.
+    ///     Starts at 0 for the first fire and is only incremented after.
+    /// </summary>
+    [DataField, Access(typeof(EntityTimerSystem))]
+    public int TotalRepetitions;
+
+    /// <summary>
+    ///     Maximum number of times the event can be raised
+    ///     before the repeating timer will be deleted.
+    /// </summary>
+    [DataField]
+    public int MaxRepetitions = int.MaxValue;
+}

--- a/Robust.Shared/GameObjects/Components/Timers/TimerEvents.cs
+++ b/Robust.Shared/GameObjects/Components/Timers/TimerEvents.cs
@@ -1,0 +1,59 @@
+﻿using Robust.Shared.Serialization.Manager.Attributes;
+
+namespace Robust.Shared.GameObjects;
+
+/// <summary>
+///     Base method for all events that should be relayed through an entity timer.
+///     Required to use <see cref="EntityTimerEvent{TEvent}"/>.
+///
+///     Since this event will be stored for some amount of time and may need to be serialized,
+///     its fields should be DataFields.
+/// </summary>
+[ImplicitDataDefinitionForInheritors]
+public abstract partial class BaseEntityTimerEvent
+{
+}
+
+[ImplicitDataDefinitionForInheritors]
+public partial interface IEntityTimerEvent
+{
+}
+
+/// <summary>
+///     Wrapper class event for a <see cref="TEvent"/> event to be raised on timer fire.
+/// </summary>
+public sealed partial class EntityTimerEvent<TEvent> : IEntityTimerEvent
+    where TEvent: BaseEntityTimerEvent
+{
+    [DataField]
+    public TEvent Data;
+
+    [DataField]
+    public EntityUid Timer;
+
+    public EntityTimerEvent(TEvent data, EntityUid timer)
+    {
+        Data = data;
+        Timer = timer;
+    }
+}
+
+/// <summary>
+///     Wrapper class event for a repeating <see cref="TEvent"/> event. Contains fields to modify
+///     next repeated timer behavior when handled.
+/// </summary>
+public sealed partial class RepeatingEntityTimerEvent<TEvent> : IEntityTimerEvent
+    where TEvent: BaseEntityTimerEvent
+{
+    [DataField]
+    public TEvent Data;
+
+    [DataField]
+    public EntityUid Timer;
+
+    public RepeatingEntityTimerEvent(TEvent data, EntityUid timer)
+    {
+        Data = data;
+        Timer = timer;
+    }
+}

--- a/Robust.Shared/GameObjects/Components/Timers/TimerExtensions.cs
+++ b/Robust.Shared/GameObjects/Components/Timers/TimerExtensions.cs
@@ -15,43 +15,6 @@ namespace Robust.Shared.GameObjects
             return entMan.EnsureComponent<TimerComponent>(entity);
         }
 
-        public static void AddTimer(this EntityUid entity, Timer timer, CancellationToken cancellationToken = default)
-        {
-            entity
-                .EnsureTimerComponent()
-                .AddTimer(timer, cancellationToken);
-        }
-
-        /// <summary>
-        ///     Creates a task that will complete after a given delay.
-        ///     The task is resumed on the main game logic thread.
-        /// </summary>
-        /// <param name="entity">The entity to add the timer to.</param>
-        /// <param name="milliseconds">The length of time, in milliseconds, to delay for.</param>
-        /// <param name="cancellationToken"></param>
-        /// <returns>The task that can be awaited.</returns>
-        public static Task DelayTask(this EntityUid entity, int milliseconds, CancellationToken cancellationToken = default)
-        {
-            return entity
-                .EnsureTimerComponent()
-                .Delay(milliseconds, cancellationToken);
-        }
-
-        /// <summary>
-        ///     Creates a task that will complete after a given delay.
-        ///     The task is resumed on the main game logic thread.
-        /// </summary>
-        /// <param name="entity">The entity to add the timer to.</param>
-        /// <param name="duration">The length of time to delay for.</param>
-        /// <param name="cancellationToken"></param>
-        /// <returns>The task that can be awaited.</returns>
-        public static Task DelayTask(this EntityUid entity, TimeSpan duration, CancellationToken cancellationToken = default)
-        {
-            return entity
-                .EnsureTimerComponent()
-                .Delay((int) duration.TotalMilliseconds, cancellationToken);
-        }
-
         /// <summary>
         ///     Schedule an action to be fired after a certain delay.
         ///     The action will be resumed on the main game logic thread.
@@ -82,21 +45,6 @@ namespace Robust.Shared.GameObjects
             entity
                 .EnsureTimerComponent()
                 .Spawn((int) duration.TotalMilliseconds, onFired, cancellationToken);
-        }
-
-        /// <summary>
-        ///     Schedule an action that repeatedly fires after a delay specified in milliseconds.
-        /// </summary>
-        /// <param name="entity">The entity to add the timer to.</param>
-        /// <param name="milliseconds">The length of time, in milliseconds, to delay before firing the repeated action.</param>
-        /// <param name="onFired">The action to fire.</param>
-        /// <param name="cancellationToken">The CancellationToken for stopping the Timer.</param>
-        [Obsolete("Use a system update loop instead")]
-        public static void SpawnRepeatingTimer(this EntityUid entity, int milliseconds, Action onFired, CancellationToken cancellationToken)
-        {
-            entity
-                .EnsureTimerComponent()
-                .SpawnRepeating(milliseconds, onFired, cancellationToken);
         }
 
         /// <summary>

--- a/Robust.Shared/GameObjects/Systems/EntityTimerSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityTimerSystem.cs
@@ -79,7 +79,7 @@ public sealed class EntityTimerSystem : EntitySystem
         // TODO not sure how pause should be handled exactly for this use case
         AddComp(timerEnt, new EntityTimerComponent
         {
-            Event = new EntityTimerEvent<TEvent> { Data = args, Timer = timerEnt },
+            Event = new EntityTimerEvent<TEvent>(args, timerEnt),
             AbsoluteTime = _timing.CurTime - _metaData.GetPauseTime(attachedTo.Value) + delay,
         });
 
@@ -106,14 +106,14 @@ public sealed class EntityTimerSystem : EntitySystem
 
         AddComp(timerEnt, new EntityTimerComponent
         {
-            Event = new RepeatingEntityTimerEvent<TEvent> { Data = args, Timer = timerEnt },
+            Event = new RepeatingEntityTimerEvent<TEvent>(args, timerEnt),
             AbsoluteTime = _timing.CurTime - _metaData.GetPauseTime(attachedTo.Value) + delay,
         });
 
         AddComp(timerEnt, new RepeatingEntityTimerComponent
         {
             MaxRepetitions = maxRepetitions,
-            NextDelay = delay
+            Delay = delay
         });
 
         return timerEnt;

--- a/Robust.Shared/GameObjects/Systems/EntityTimerSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityTimerSystem.cs
@@ -1,0 +1,121 @@
+﻿
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.IoC;
+using Robust.Shared.Timing;
+
+namespace Robust.Shared.GameObjects;
+
+/// <summary>
+/// This handles spawning timer entities used for delaying directed event raises.
+/// </summary>
+public sealed class EntityTimerSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedTransformSystem _xform = default!;
+    [Dependency] private readonly MetaDataSystem _metaData = default!;
+
+    private EntityQuery<RepeatingEntityTimerComponent> _repeatingQuery = default!;
+
+    public override void Initialize()
+    {
+        _repeatingQuery = GetEntityQuery<RepeatingEntityTimerComponent>();
+    }
+
+    public override void Update(float frameTime)
+    {
+        var query = EntityQueryEnumerator<EntityTimerComponent>();
+
+        while (query.MoveNext(out var uid, out var timer))
+        {
+            if (_timing.CurTime < timer.AbsoluteTime)
+                continue;
+
+            var target = _xform.GetParentUid(uid);
+            RaiseLocalEvent(target, timer.Event);
+
+            // deletion behavior based on type
+            if (!_repeatingQuery.TryGetComponent(uid, out var repeating))
+            {
+                QueueDel(uid);
+                continue;
+            }
+
+            if (repeating.TotalRepetitions >= repeating.MaxRepetitions)
+            {
+                QueueDel(uid);
+                continue;
+            }
+
+            repeating.TotalRepetitions += 1;
+            timer.AbsoluteTime = _timing.CurTime + repeating.Delay;
+        }
+    }
+
+    private bool CheckAttachedEntityValid([NotNullWhen(true)] EntityUid? uid)
+    {
+        // Entity timers should not be getting attached to entities
+        // which are either being deleted, are deleted, or are not yet
+        // map initialized.
+        return uid is { } attachedTo
+               && LifeStage(attachedTo) == EntityLifeStage.MapInitialized;
+    }
+
+    public EntityUid? SpawnEntityTimer<TEvent>(
+        EntityUid? attachedTo,
+        TimeSpan delay,
+        TEvent args
+        ) where TEvent: BaseEntityTimerEvent
+    {
+        if (!CheckAttachedEntityValid(attachedTo))
+            return null;
+
+        // Timer ent will have the same lifetime as the entity it is attached to.
+        var timerEnt = Spawn();
+
+        // debug purposes
+        _metaData.SetEntityName(timerEnt, $"{args.GetType().Name} Timer - {delay.TotalMilliseconds:F} millis");
+
+        // TODO not sure how pause should be handled exactly for this use case
+        AddComp(timerEnt, new EntityTimerComponent
+        {
+            Event = new EntityTimerEvent<TEvent> { Data = args, Timer = timerEnt },
+            AbsoluteTime = _timing.CurTime - _metaData.GetPauseTime(attachedTo.Value) + delay,
+        });
+
+        _xform.SetParent(timerEnt, attachedTo.Value);
+
+        return timerEnt;
+    }
+
+    public EntityUid? SpawnRepeatingEntityTimer<TEvent>(
+        EntityUid? attachedTo,
+        TimeSpan delay,
+        TEvent args,
+        int maxRepetitions = int.MaxValue
+    ) where TEvent: BaseEntityTimerEvent
+    {
+        if (!CheckAttachedEntityValid(attachedTo))
+            return null;
+
+        // Timer ent will have the same lifetime as the entity it is attached to.
+        var timerEnt = Spawn();
+
+        // debug purposes
+        _metaData.SetEntityName(timerEnt, $"{args.GetType().Name} Repeating Timer - {delay.TotalMilliseconds:F} millis");
+
+        AddComp(timerEnt, new EntityTimerComponent
+        {
+            Event = new RepeatingEntityTimerEvent<TEvent> { Data = args, Timer = timerEnt },
+            AbsoluteTime = _timing.CurTime - _metaData.GetPauseTime(attachedTo.Value) + delay,
+        });
+
+        AddComp(timerEnt, new RepeatingEntityTimerComponent
+        {
+            MaxRepetitions = maxRepetitions,
+            NextDelay = delay
+        });
+
+        return timerEnt;
+    }
+}


### PR DESCRIPTION
basic idea. this is basically proof of concept
- remove old timercomponent API sucked and was old and thus no one used it,  replace with entity timers
- entity timers are entities which get parented to the entity they're relevant to
- entity timers store an event which they raise on their parent after a given delay
- goes through all the normal entity methods--delete it to end the timer, reparent it to change its target, so on. spawn has its own API.
- deleted when the entity its relevant to is deleted
- also handles repeating timers
- fully serializable handles saving/loading etc
- can be added to any entity, doesnt involve ensuring a comp, all good

draft bc:

todo
- [ ] phase out engine uses of timercomp. content uses later
- [ ] consider PVS like who should we be sending these to. also clientside entity timers
- [ ] add broadcast timers (entity timers which are in nullspace) opt-in you just have to accept that they wont be serializable, attach them to something if you want them to be you freak
- [ ] add `DeferEvent` helper which basically just sets the delay to minimum so it's raised next tick