### PR TITLE
Add doc clarification to CopyByRef inheritance for the future coder

### DIFF
--- a/Robust.Shared/Serialization/Manager/Attributes/CopyByRefAttribute.cs
+++ b/Robust.Shared/Serialization/Manager/Attributes/CopyByRefAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace Robust.Shared.Serialization.Manager.Attributes;
 
 /// <summary>
-///     Makes a type always be copied by reference when calling
+///     Makes a type always be copied by reference when using it as the generic type in
 ///     <see cref="ISerializationManager.CopyTo"/> and <see cref="ISerializationManager.CreateCopy"/>.
 ///     This means that the source instance is returned directly.
 ///     <remarks>

--- a/Robust.Shared/Serialization/Manager/Attributes/CopyByRefAttribute.cs
+++ b/Robust.Shared/Serialization/Manager/Attributes/CopyByRefAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace Robust.Shared.Serialization.Manager.Attributes;
 
 /// <summary>
-///     Makes a type always be copied by reference when using it as the generic type in
+///     Makes a type always be copied by reference when using it as the generic parameter in
 ///     <see cref="ISerializationManager.CopyTo"/> and <see cref="ISerializationManager.CreateCopy"/>.
 ///     This means that the source instance is returned directly.
 ///     <remarks>

--- a/Robust.Shared/Serialization/Manager/Attributes/CopyByRefAttribute.cs
+++ b/Robust.Shared/Serialization/Manager/Attributes/CopyByRefAttribute.cs
@@ -1,14 +1,52 @@
 using System;
 
-namespace Robust.Shared.Serialization.Manager.Attributes
+namespace Robust.Shared.Serialization.Manager.Attributes;
+
+/// <summary>
+///     Makes a type always be copied by reference when calling
+///     <see cref="ISerializationManager.CopyTo"/> and <see cref="ISerializationManager.CreateCopy"/>.
+///     This means that the source instance is returned directly.
+///     <remarks>
+///         Note that when calling any of the generic <see cref="ISerializationManager.CopyTo{T}"/> and
+///         <see cref="ISerializationManager.CreateCopy{T}"/> methods, this attribute will only be respected
+///         if the generic type passed to the copying methods has this attribute.
+///         For example, if a copy method is called with a generic type T that is not annotated with this attribute,
+///         but the actual type of the source parameter IS annotated with this attribute, it will not be copied by ref.
+///         <code>
+///             public class A {}
+///
+///             [CopyByRef]
+///             public class B : A {}
+///
+///             public class C : B {}
+///
+///             public class Copier(ISerializationManager manager)
+///             {
+///                 var a = new A();
+///                 var b = new B();
+///                 var c = new C();
+///
+///                 // false, not copied by ref
+///                 manager.CreateCopy(a) == a
+///
+///                 // true, copied by ref
+///                 manager.CreateCopy(b) == b
+///
+///                 // false, not copied by ref
+///                 manager.CreateCopy(c) == c
+///
+///                 // true, copied by ref
+///                 manager.CreateCopy&lt;B&gt;(c) == c
+///             }
+///         </code>
+///     </remarks>
+/// </summary>
+[AttributeUsage(
+    AttributeTargets.Class |
+    AttributeTargets.Struct |
+    AttributeTargets.Enum |
+    AttributeTargets.Interface,
+    Inherited = false)]
+public sealed class CopyByRefAttribute : Attribute
 {
-    [AttributeUsage(
-        AttributeTargets.Class |
-        AttributeTargets.Struct |
-        AttributeTargets.Enum |
-        AttributeTargets.Interface,
-        Inherited = false)]
-    public sealed class CopyByRefAttribute : Attribute
-    {
-    }
 }

--- a/Robust.Shared/Serialization/Manager/Attributes/CopyByRefAttribute.cs
+++ b/Robust.Shared/Serialization/Manager/Attributes/CopyByRefAttribute.cs
@@ -6,12 +6,18 @@ namespace Robust.Shared.Serialization.Manager.Attributes;
 ///     Makes a type always be copied by reference when using it as the generic parameter in
 ///     <see cref="ISerializationManager.CopyTo"/> and <see cref="ISerializationManager.CreateCopy"/>.
 ///     This means that the source instance is returned directly.
+///     This attribute is not inherited.
 ///     <remarks>
 ///         Note that when calling any of the generic <see cref="ISerializationManager.CopyTo{T}"/> and
 ///         <see cref="ISerializationManager.CreateCopy{T}"/> methods, this attribute will only be respected
-///         if the generic type passed to the copying methods has this attribute.
-///         For example, if a copy method is called with a generic type T that is not annotated with this attribute,
-///         but the actual type of the source parameter IS annotated with this attribute, it will not be copied by ref.
+///         if the generic parameter passed to the copying methods has this attribute.
+///         For example, if a copy method is called with a generic parameter T that is not annotated with this attribute,
+///         but the actual type of the source parameter is annotated with this attribute, it will not be copied by ref.
+///         Conversely, if the generic parameter T is annotated with this attribute, but the actual type of the source
+///         is an inheritor which is not annotated with this attribute, it will still be copied by ref.
+///         If the generic parameter T is a type derived from another that is annotated with the attribute,
+///         but it itself is not annotated with this attribute, source will not be copied by ref as this attribute
+///         is not inherited.
 ///         <code>
 ///             public class A {}
 ///
@@ -28,6 +34,9 @@ namespace Robust.Shared.Serialization.Manager.Attributes;
 ///
 ///                 // false, not copied by ref
 ///                 manager.CreateCopy(a) == a
+///
+///                 // false, not copied by ref
+///                 manager.CreateCopy&lt;A&gt;(b) == b
 ///
 ///                 // true, copied by ref
 ///                 manager.CreateCopy(b) == b


### PR DESCRIPTION
See doc for details.
There is presently no case in content or engine where this matters, but the behaviour is documented regardless.
This behaviour has remained the same since serv3, both before and after https://github.com/space-wizards/RobustToolbox/pull/4286, but we never documented it.
We should probably make this more consistent at some point so we don't have a .NET moment with EqualityComparer and comparing arrays.