### PR TITLE
Use metadata query in ToPrettyString()

### DIFF
--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -93,14 +93,10 @@ namespace Robust.Client.GameObjects
                 base.Dirty(uid, component, meta);
         }
 
-        [return: NotNullIfNotNull("uid")]
-        public override EntityStringRepresentation? ToPrettyString(EntityUid? uid)
+        public override EntityStringRepresentation ToPrettyString(EntityUid uid, MetaDataComponent? metaDataComponent = null)
         {
-            if (uid == null)
-                return null;
-
             if (_playerManager.LocalPlayer?.ControlledEntity == uid)
-                return base.ToPrettyString(uid).Value with { Session = _playerManager.LocalPlayer.Session };
+                return base.ToPrettyString(uid) with { Session = _playerManager.LocalPlayer.Session };
 
             return base.ToPrettyString(uid);
         }

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -109,15 +109,10 @@ namespace Robust.Server.GameObjects
             }
         }
 
-        [return: NotNullIfNotNull("uid")]
-        public override EntityStringRepresentation? ToPrettyString(EntityUid? uid)
+        public override EntityStringRepresentation ToPrettyString(EntityUid uid, MetaDataComponent? metadata = null)
         {
-            if (uid == null)
-                return null;
-
             TryGetComponent(uid, out ActorComponent? actor);
-
-            return base.ToPrettyString(uid).Value with { Session = actor?.PlayerSession };
+            return base.ToPrettyString(uid) with { Session = actor?.PlayerSession };
         }
 
         #region IEntityNetworkManager impl

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -42,6 +42,7 @@ namespace Robust.Server.GameObjects
 #endif
 
         private ISawmill _netEntSawmill = default!;
+        private EntityQuery<ActorComponent> _actorQuery;
 
         public override void Initialize()
         {
@@ -51,6 +52,12 @@ namespace Robust.Server.GameObjects
             ReceivedSystemMessage += (_, systemMsg) => EventBus.RaiseEvent(EventSource.Network, systemMsg);
 
             base.Initialize();
+        }
+
+        public override void Startup()
+        {
+            base.Startup();
+            _actorQuery = GetEntityQuery<ActorComponent>();
         }
 
         EntityUid IServerEntityManagerInternal.AllocEntity(EntityPrototype? prototype)
@@ -111,7 +118,7 @@ namespace Robust.Server.GameObjects
 
         public override EntityStringRepresentation ToPrettyString(EntityUid uid, MetaDataComponent? metadata = null)
         {
-            TryGetComponent(uid, out ActorComponent? actor);
+            _actorQuery.TryGetComponent(uid, out ActorComponent? actor);
             return base.ToPrettyString(uid) with { Session = actor?.PlayerSession };
         }
 

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -757,10 +757,8 @@ namespace Robust.Shared.GameObjects
             if (uid == null)
                 return null;
 
-            if (!_entTraitArray[CompIdx.ArrayIndex<MetaDataComponent>()].TryGetValue(uid.Value, out var component))
+            if (!MetaQuery.TryGetComponent(uid.Value, out var metadata))
                 return new EntityStringRepresentation(uid.Value, true);
-
-            var metadata = (MetaDataComponent) component;
 
             return ToPrettyString(uid.Value, metadata);
         }

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -751,34 +751,34 @@ namespace Robust.Shared.GameObjects
 
         /// <inheritdoc />
         [return: NotNullIfNotNull("uid")]
-        public virtual EntityStringRepresentation? ToPrettyString(EntityUid? uid)
+        public EntityStringRepresentation? ToPrettyString(EntityUid? uid, MetaDataComponent? metadata = null)
         {
-            // We want to retrieve the MetaData component even if it is deleted.
-            if (uid == null)
-                return null;
+            return uid == null ? null : ToPrettyString(uid.Value, metadata);
+        }
 
-            if (!MetaQuery.TryGetComponent(uid.Value, out var metadata))
-                return new EntityStringRepresentation(uid.Value, true);
+        /// <inheritdoc />
+        public virtual EntityStringRepresentation ToPrettyString(EntityUid uid, MetaDataComponent? metadata = null)
+        {
+            if (!MetaQuery.Resolve(uid, ref metadata, false))
+                return new EntityStringRepresentation(uid, true);
 
-            return ToPrettyString(uid.Value, metadata);
+            return new EntityStringRepresentation(uid, metadata.EntityDeleted, metadata.EntityName, metadata.EntityPrototype?.ID);
         }
 
         /// <inheritdoc />
         [return: NotNullIfNotNull("netEntity")]
         public EntityStringRepresentation? ToPrettyString(NetEntity? netEntity)
         {
-            return ToPrettyString(GetEntity(netEntity));
+            return netEntity == null ? null : ToPrettyString(netEntity.Value);
         }
 
-        public EntityStringRepresentation ToPrettyString(EntityUid uid)
-            => ToPrettyString((EntityUid?) uid).Value;
-
+        /// <inheritdoc />
         public EntityStringRepresentation ToPrettyString(NetEntity netEntity)
-            => ToPrettyString((NetEntity?) netEntity).Value;
-
-        private EntityStringRepresentation ToPrettyString(EntityUid uid, MetaDataComponent metadata)
         {
-            return new EntityStringRepresentation(uid, metadata.EntityDeleted, metadata.EntityName, metadata.EntityPrototype?.ID);
+            if (!TryGetEntityData(netEntity, out var uid, out var meta))
+                return new EntityStringRepresentation(EntityUid.Invalid, true);
+
+            return ToPrettyString(uid.Value, meta);
         }
 
         #endregion Entity Management

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -399,9 +399,9 @@ public partial class EntitySystem
     /// <inheritdoc cref="IEntityManager.ToPrettyString"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull("uid")]
-    protected EntityStringRepresentation? ToPrettyString(EntityUid? uid)
+    protected EntityStringRepresentation? ToPrettyString(EntityUid? uid, MetaDataComponent? metadata = null)
     {
-        return EntityManager.ToPrettyString(uid);
+        return EntityManager.ToPrettyString(uid, metadata);
     }
 
     /// <inheritdoc cref="IEntityManager.ToPrettyString"/>
@@ -414,13 +414,18 @@ public partial class EntitySystem
 
     /// <inheritdoc cref="IEntityManager.ToPrettyString"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected EntityStringRepresentation ToPrettyString(EntityUid uid, MetaDataComponent? metadata)
+        => EntityManager.ToPrettyString(uid, metadata);
+
+    /// <inheritdoc cref="IEntityManager.ToPrettyString"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected EntityStringRepresentation ToPrettyString(EntityUid uid)
-        => ToPrettyString((EntityUid?) uid).Value;
+        => EntityManager.ToPrettyString(uid);
 
     /// <inheritdoc cref="IEntityManager.ToPrettyString"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected EntityStringRepresentation ToPrettyString(NetEntity netEntity)
-        => ToPrettyString((NetEntity?) netEntity).Value;
+        => EntityManager.ToPrettyString(netEntity);
 
     #endregion
 

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -221,7 +221,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="uid">Entity to modify.</param>
         /// <param name="component">The output component after being ensured.</param>
         /// <typeparam name="T">Component to add.</typeparam>
-        /// <returns>The component in question</returns>
+        /// <returns>True if the component already existed</returns>
         bool EnsureComponent<T>(EntityUid uid, out T component) where T : Component, new();
 
         /// <summary>

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -127,7 +127,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         /// Returns a string representation of an entity with various information regarding it.
         /// </summary>
-        EntityStringRepresentation ToPrettyString(EntityUid uid);
+        EntityStringRepresentation ToPrettyString(EntityUid uid, MetaDataComponent? metadata = null);
 
         /// <summary>
         /// Returns a string representation of an entity with various information regarding it.
@@ -138,7 +138,7 @@ namespace Robust.Shared.GameObjects
         /// Returns a string representation of an entity with various information regarding it.
         /// </summary>
         [return: NotNullIfNotNull("uid")]
-        EntityStringRepresentation? ToPrettyString(EntityUid? uid);
+        EntityStringRepresentation? ToPrettyString(EntityUid? uid, MetaDataComponent? metadata = null);
 
         /// <summary>
         /// Returns a string representation of an entity with various information regarding it.

--- a/Robust.UnitTesting/RobustUnitTest.cs
+++ b/Robust.UnitTesting/RobustUnitTest.cs
@@ -128,6 +128,7 @@ namespace Robust.UnitTesting
 
             // Required components for the engine to work
             // Why are we still here? Just to suffer? Why can't we just use [RegisterComponent] magic?
+            // TODO End Suffering.
             var compFactory = deps.Resolve<IComponentFactory>();
 
             if (!compFactory.AllRegisteredTypes.Contains(typeof(EyeComponent)))
@@ -223,6 +224,11 @@ namespace Robust.UnitTesting
             if (!compFactory.AllRegisteredTypes.Contains(typeof(Gravity2DComponent)))
             {
                 compFactory.RegisterClass<Gravity2DComponent>();
+            }
+
+            if (!compFactory.AllRegisteredTypes.Contains(typeof(ActorComponent)))
+            {
+                compFactory.RegisterClass<ActorComponent>();
             }
 
             // So by default EntityManager does its own EntitySystemManager initialize during Startup.

--- a/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
+++ b/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
@@ -61,7 +61,6 @@ entities:
             var compFactory = IoCManager.Resolve<IComponentFactory>();
             compFactory.RegisterClass<MapDeserializeTestComponent>();
             compFactory.RegisterClass<VisibilityComponent>();
-            compFactory.RegisterClass<ActorComponent>();
             compFactory.RegisterClass<IgnoreUIRangeComponent>();
             compFactory.GenerateNetIds();
             IoCManager.Resolve<ISerializationManager>().Initialize();


### PR DESCRIPTION
- Uses metadata query
- Adds optional metadata argument
- Untangles some of the nullable override spaghetti. `ToPrettyString(EntityUid)` no longer redirects to `ToPrettyString(EntityUid?)`, 