### PR TITLE
Make PVS session overrides recursive

### DIFF
--- a/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceEntity.cs
+++ b/Robust.Client/ViewVariables/Instances/ViewVariablesInstanceEntity.cs
@@ -270,7 +270,7 @@ namespace Robust.Client.ViewVariables.Instances
                 button.OnPressed += _ =>
                 {
                     ViewVariablesManager.OpenVV(
-                        new ViewVariablesComponentSelector(_entityManager.GetNetEntity(_entity), componentType.FullName));
+                        new ViewVariablesComponentSelector(_netEntity, componentType.FullName));
                 };
                 removeButton.OnPressed += _ =>
                 {

--- a/Robust.Server/GameStates/PvsOverrideSystem.cs
+++ b/Robust.Server/GameStates/PvsOverrideSystem.cs
@@ -22,13 +22,14 @@ public sealed class PvsOverrideSystem : EntitySystem
     }
 
     /// <summary>
-    ///     Used to ensure that an entity is always sent to a specific client. Overrides any global or pre-existing
-    ///     client-specific overrides.
+    ///     Used to ensure that an entity is always sent to a specific client. By default this overrides any global or pre-existing
+    ///     client-specific overrides. Unlike global overrides, this is always recursive.
     /// </summary>
     /// <param name="removeExistingOverride">Whether or not to supersede existing overrides.</param>
-    public void AddSessionOverride(EntityUid uid, ICommonSession session,bool removeExistingOverride = true)
+    /// <param name="recursive">If true, this will also recursively send any children of the given index.</param>
+    public void AddSessionOverride(EntityUid uid, ICommonSession session, bool removeExistingOverride = true)
     {
-        _pvs.EntityPVSCollection.UpdateIndex(GetNetEntity(uid), session, removeExistingOverride);
+        _pvs.EntityPVSCollection.AddSessionOverride(GetNetEntity(uid), session, removeExistingOverride);
     }
 
     /// <summary>

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -756,15 +756,15 @@ internal sealed partial class PvsSystem : EntitySystem
         }
         globalRecursiveEnumerator.Dispose();
 
-        var localEnumerator = _entityPvsCollection.GetElementsForSession(session);
-        while (localEnumerator.MoveNext())
+        var sessionOverrides = _entityPvsCollection.GetSessionOverrides(session);
+        while (sessionOverrides.MoveNext())
         {
-            var netEntity = localEnumerator.Current;
+            var netEntity = sessionOverrides.Current;
             var uid = GetEntity(netEntity);
             RecursivelyAddOverride(in uid, lastAcked, lastSent, visibleEnts, lastSeen,in fromTick,
-                ref newEntityCount, ref enteredEntityCount, ref entStateCount, in newEntityBudget, in enteredEntityBudget);
+                ref newEntityCount, ref enteredEntityCount, ref entStateCount, in newEntityBudget, in enteredEntityBudget, true);
         }
-        localEnumerator.Dispose();
+        sessionOverrides.Dispose();
 
         foreach (var viewerEntity in viewers)
         {

--- a/Robust.Server/ViewVariables/ViewVariablesTrait.cs
+++ b/Robust.Server/ViewVariables/ViewVariablesTrait.cs
@@ -94,7 +94,7 @@ namespace Robust.Server.ViewVariables
             }
 
             if (value is EntityUid uid)
-                return IoCManager.Resolve<IEntityManager>().GetNetEntity(uid);
+                return IoCManager.Resolve<IEntityManager>().GetComponentOrNull<MetaDataComponent>(uid)?.NetEntity ?? NetEntity.Invalid;
 
             var valType = value.GetType();
             if (!valType.IsValueType)


### PR DESCRIPTION
Required for mind actions. I could've separated out a session-override and a recursive-session-override, but I don't think its likely that there'd be a situation where you want to send a player an entity in null space while excluding children.

This PR also renames the "local override" related variables to "session override" and fixes a VV error when VVing entities that the client doesn't yet know about.