### PR TITLE
Move Component lifecycle methods to EntityManager

### DIFF
--- a/Robust.Shared/Containers/ContainerManagerComponent.cs
+++ b/Robust.Shared/Containers/ContainerManagerComponent.cs
@@ -39,7 +39,7 @@ namespace Robust.Shared.Containers
         }
 
         /// <inheritdoc />
-        protected override void OnRemove()
+        protected internal override void OnRemove()
         {
             base.OnRemove();
 

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -122,7 +122,7 @@ namespace Robust.Shared.GameObjects
             foreach (var comp in comps)
             {
                 if (comp is { LifeStage:  ComponentLifeStage.Added })
-                    comp.LifeInitialize(this, CompIdx.Index(comp.GetType()));
+                    LifeInitialize(comp, CompIdx.Index(comp.GetType()));
             }
 
 #if DEBUG
@@ -155,20 +155,20 @@ namespace Robust.Shared.GameObjects
             // Init transform first, we always have it.
             var transform = GetComponent<TransformComponent>(uid);
             if (transform.LifeStage == ComponentLifeStage.Initialized)
-                transform.LifeStartup(this);
+                LifeStartup(transform);
 
             // Init physics second if it exists.
             if (TryGetComponent<PhysicsComponent>(uid, out var phys)
                 && phys.LifeStage == ComponentLifeStage.Initialized)
             {
-                phys.LifeStartup(this);
+                LifeStartup(phys);
             }
 
             // Do rest of components.
             foreach (var comp in comps)
             {
                 if (comp is { LifeStage: ComponentLifeStage.Initialized })
-                    comp.LifeStartup(this);
+                    LifeStartup(comp);
             }
         }
 
@@ -216,10 +216,10 @@ namespace Robust.Shared.GameObjects
                     return;
 
                 if (!Comp.Initialized)
-                    Comp.LifeInitialize(_entMan, CompType);
+                    ((EntityManager) _entMan).LifeInitialize(Comp, CompType);
 
                 if (metadata.EntityInitialized && !Comp.Running)
-                    Comp.LifeStartup(_entMan);
+                    ((EntityManager) _entMan).LifeStartup(Comp);
             }
 
             public static implicit operator T(CompInitializeHandle<T> handle)
@@ -328,7 +328,7 @@ namespace Robust.Shared.GameObjects
             ComponentAdded?.Invoke(eventArgs);
             _eventBus.OnComponentAdded(eventArgs);
 
-            component.LifeAddToEntity(this, reg.Idx);
+            LifeAddToEntity(component, reg.Idx);
 
             if (skipInit)
                 return;
@@ -341,10 +341,10 @@ namespace Robust.Shared.GameObjects
             if (component.Networked)
                 DirtyEntity(uid, metadata);
 
-            component.LifeInitialize(this, reg.Idx);
+            LifeInitialize(component, reg.Idx);
 
             if (metadata.EntityInitialized)
-                component.LifeStartup(this);
+                LifeStartup(component);
 
             if (metadata.EntityLifeStage >= EntityLifeStage.MapInitialized)
                 EventBus.RaiseComponentEvent(component, MapInitEventInstance);
@@ -515,7 +515,7 @@ namespace Robust.Shared.GameObjects
             }
 
             if (component.LifeStage >= ComponentLifeStage.Initialized && component.LifeStage <= ComponentLifeStage.Running)
-                component.LifeShutdown(this);
+                LifeShutdown(component);
 #if EXCEPTION_TOLERANCE
             }
             catch (Exception e)
@@ -547,10 +547,10 @@ namespace Robust.Shared.GameObjects
             }
 
             if (component.Running)
-                component.LifeShutdown(this);
+                LifeShutdown(component);
 
             if (component.LifeStage != ComponentLifeStage.PreAdd)
-                component.LifeRemoveFromEntity(this); // Sets delete
+                LifeRemoveFromEntity(component); // Sets delete
 
 #if EXCEPTION_TOLERANCE
             }
@@ -581,11 +581,11 @@ namespace Robust.Shared.GameObjects
                 {
                     // TODO add options to cancel deferred deletion?
                     _sawmill.Warning($"Found a running component while culling deferred deletions, owner={ToPrettyString(uid)}, type={component.GetType()}");
-                    component.LifeShutdown(this);
+                    LifeShutdown(component);
                 }
 
                 if (component.LifeStage != ComponentLifeStage.PreAdd)
-                    component.LifeRemoveFromEntity(this);
+                    LifeRemoveFromEntity(component);
 
 #if EXCEPTION_TOLERANCE
             }

--- a/Robust.Shared/GameObjects/EntityManager.LifeCycle.cs
+++ b/Robust.Shared/GameObjects/EntityManager.LifeCycle.cs
@@ -1,0 +1,99 @@
+﻿using Robust.Shared.Utility;
+
+namespace Robust.Shared.GameObjects;
+
+public partial class EntityManager
+{
+    private static readonly ComponentAdd CompAddInstance = new();
+    private static readonly ComponentInit CompInitInstance = new();
+    private static readonly ComponentStartup CompStartupInstance = new();
+    private static readonly ComponentShutdown CompShutdownInstance = new();
+    private static readonly ComponentRemove CompRemoveInstance = new();
+
+    /// <summary>
+    /// Increases the life stage from <see cref="ComponentLifeStage.PreAdd" /> to <see cref="ComponentLifeStage.Added" />,
+    /// after raising a <see cref="ComponentAdd"/> event.
+    /// </summary>
+    internal void LifeAddToEntity(Component component, CompIdx type)
+    {
+        DebugTools.Assert(component.LifeStage == ComponentLifeStage.PreAdd);
+
+        component.LifeStage = ComponentLifeStage.Adding;
+        component.CreationTick = CurrentTick;
+        // networked components are assumed to be dirty when added to entities. See also: ClearTicks()
+        component.LastModifiedTick = CurrentTick;
+        EventBus.RaiseComponentEvent(component, type, CompAddInstance);
+        component.LifeStage = ComponentLifeStage.Added;
+    }
+
+    /// <summary>
+    /// Increases the life stage from <see cref="ComponentLifeStage.Added" /> to <see cref="ComponentLifeStage.Initialized" />,
+    /// calling <see cref="Initialize" />.
+    /// </summary>
+    internal void LifeInitialize(Component component, CompIdx type)
+    {
+        DebugTools.Assert(component.LifeStage == ComponentLifeStage.Added);
+
+        component.LifeStage = ComponentLifeStage.Initializing;
+        EventBus.RaiseComponentEvent(component, type, CompInitInstance);
+        component.LifeStage = ComponentLifeStage.Initialized;
+    }
+
+    /// <summary>
+    /// Increases the life stage from <see cref="ComponentLifeStage.Initialized" /> to
+    /// <see cref="ComponentLifeStage.Running" />, calling <see cref="Startup" />.
+    /// </summary>
+    internal void LifeStartup(Component component)
+    {
+        DebugTools.Assert(component.LifeStage == ComponentLifeStage.Initialized);
+
+        component.LifeStage = ComponentLifeStage.Starting;
+        EventBus.RaiseComponentEvent(component, CompStartupInstance);
+        component.LifeStage = ComponentLifeStage.Running;
+    }
+
+    /// <summary>
+    /// Increases the life stage from <see cref="ComponentLifeStage.Running" /> to <see cref="ComponentLifeStage.Stopped" />,
+    /// calling <see cref="Shutdown" />.
+    /// </summary>
+    /// <remarks>
+    /// Components are allowed to remove themselves in their own Startup function.
+    /// </remarks>
+    internal void LifeShutdown(Component component)
+    {
+        DebugTools.Assert(component.LifeStage is >= ComponentLifeStage.Initializing and < ComponentLifeStage.Stopping);
+
+        if (component.LifeStage <= ComponentLifeStage.Initialized)
+        {
+            // Component was never started, no shutdown logic necessary. Simply mark it as stopped.
+            component.LifeStage = ComponentLifeStage.Stopped;
+            return;
+        }
+
+        component.LifeStage = ComponentLifeStage.Stopping;
+        EventBus.RaiseComponentEvent(component, CompShutdownInstance);
+        component.LifeStage = ComponentLifeStage.Stopped;
+    }
+
+    /// <summary>
+    /// Increases the life stage from <see cref="ComponentLifeStage.Stopped" /> to <see cref="ComponentLifeStage.Deleted" />,
+    /// calling <see cref="Component.OnRemove" />.
+    /// </summary>
+    internal void LifeRemoveFromEntity(Component component)
+    {
+        // can be called at any time after PreAdd, including inside other life stage events.
+        DebugTools.Assert(component.LifeStage != ComponentLifeStage.PreAdd);
+
+        component.LifeStage = ComponentLifeStage.Removing;
+        EventBus.RaiseComponentEvent(component, CompRemoveInstance);
+
+        component.OnRemove();
+
+#if DEBUG
+        if (component.LifeStage != ComponentLifeStage.Deleted)
+        {
+            DebugTools.Assert($"Component {component.GetType().Name} did not call base {nameof(component.OnRemove)} in derived method.");
+        }
+#endif
+    }
+}

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -524,7 +524,7 @@ namespace Robust.Shared.GameObjects
                 {
                     try
                     {
-                        component.LifeShutdown(this);
+                        LifeShutdown(component);
                     }
                     catch (Exception e)
                     {


### PR DESCRIPTION
On the road to making generic constraints use IComponent instead of Component.