### PR TITLE
Respect the manifest's assemblyPrefix value on the server

### DIFF
--- a/Robust.Client/GameController/GameController.RobustModules.cs
+++ b/Robust.Client/GameController/GameController.RobustModules.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
 using Robust.Client.WebViewHook;
+using Robust.Shared.ContentPack;
 using Robust.Shared.Log;
 using Robust.Shared.Utility;
 

--- a/Robust.Client/GameController/GameController.cs
+++ b/Robust.Client/GameController/GameController.cs
@@ -287,78 +287,6 @@ namespace Robust.Client
             return true;
         }
 
-        private ResourceManifestData LoadResourceManifest()
-        {
-            // Parses /manifest.yml for game-specific settings that cannot be exclusively set up by content code.
-            if (!_resourceCache.TryContentFileRead("/manifest.yml", out var stream))
-                return ResourceManifestData.Default;
-
-            var yamlStream = new YamlStream();
-            using (stream)
-            {
-                using var streamReader = new StreamReader(stream, EncodingHelpers.UTF8);
-                yamlStream.Load(streamReader);
-            }
-
-            if (yamlStream.Documents.Count == 0)
-                return ResourceManifestData.Default;
-
-            if (yamlStream.Documents.Count != 1 || yamlStream.Documents[0].RootNode is not YamlMappingNode mapping)
-            {
-                throw new InvalidOperationException(
-                    "Expected a single YAML document with root mapping for /manifest.yml");
-            }
-
-            var modules = ReadStringArray(mapping, "modules") ?? Array.Empty<string>();
-
-            string? assemblyPrefix = null;
-            if (mapping.TryGetNode("assemblyPrefix", out var prefixNode))
-                assemblyPrefix = prefixNode.AsString();
-
-            string? defaultWindowTitle = null;
-            if (mapping.TryGetNode("defaultWindowTitle", out var winTitleNode))
-                defaultWindowTitle = winTitleNode.AsString();
-
-            string? windowIconSet = null;
-            if (mapping.TryGetNode("windowIconSet", out var iconSetNode))
-                windowIconSet = iconSetNode.AsString();
-
-            string? splashLogo = null;
-            if (mapping.TryGetNode("splashLogo", out var splashNode))
-                splashLogo = splashNode.AsString();
-
-            bool autoConnect = true;
-            if (mapping.TryGetNode("autoConnect", out var autoConnectNode))
-                autoConnect = autoConnectNode.AsBool();
-
-            var clientAssemblies = ReadStringArray(mapping, "clientAssemblies");
-
-            return new ResourceManifestData(
-                modules,
-                assemblyPrefix,
-                defaultWindowTitle,
-                windowIconSet,
-                splashLogo,
-                autoConnect,
-                clientAssemblies
-            );
-
-            static string[]? ReadStringArray(YamlMappingNode mapping, string key)
-            {
-                if (!mapping.TryGetNode(key, out var node))
-                    return null;
-
-                var sequence = (YamlSequenceNode)node;
-                var array = new string[sequence.Children.Count];
-                for (var i = 0; i < array.Length; i++)
-                {
-                    array[i] = sequence[i].AsString();
-                }
-
-                return array;
-            }
-        }
-
         internal bool StartupSystemSplash(
             GameControllerOptions options,
             Func<ILogHandler>? logHandlerFactory,
@@ -457,7 +385,7 @@ namespace Robust.Client
                 _modLoader.VerifierExtraLoadHandler = VerifierExtraLoadHandler;
             }
 
-            _resourceManifest = LoadResourceManifest();
+            _resourceManifest = ResourceManifestData.LoadResourceManifest(_resourceCache);
 
             {
                 // Handle GameControllerOptions implicit CVar overrides.
@@ -784,20 +712,6 @@ namespace Robust.Client
         {
             _clyde.Shutdown();
             _clydeAudio.Shutdown();
-        }
-
-        private sealed record ResourceManifestData(
-            string[] Modules,
-            string? AssemblyPrefix,
-            string? DefaultWindowTitle,
-            string? WindowIconSet,
-            string? SplashLogo,
-            bool AutoConnect,
-            string[]? ClientAssemblies
-        )
-        {
-            public static readonly ResourceManifestData Default =
-                new ResourceManifestData(Array.Empty<string>(), null, null, null, null, true, null);
         }
 
         public event Action<FrameEventArgs>? TickUpdateOverride;

--- a/Robust.Server/BaseServer.cs
+++ b/Robust.Server/BaseServer.cs
@@ -306,7 +306,9 @@ namespace Robust.Server
             _modLoader.SetUseLoadContext(!ContentStart);
             _modLoader.SetEnableSandboxing(Options.Sandboxing);
 
-            if (!_modLoader.TryLoadModulesFrom(Options.AssemblyDirectory, Options.ContentModulePrefix))
+            var resourceManifest = ResourceManifestData.LoadResourceManifest(_resources);
+
+            if (!_modLoader.TryLoadModulesFrom(Options.AssemblyDirectory, resourceManifest.AssemblyPrefix ?? Options.ContentModulePrefix))
             {
                 _logger.Fatal("Errors while loading content assemblies.");
                 return true;

--- a/Robust.Shared/ContentPack/ResourceManifestData.cs
+++ b/Robust.Shared/ContentPack/ResourceManifestData.cs
@@ -1,0 +1,92 @@
+using System;
+using System.IO;
+using Robust.Shared.Utility;
+using YamlDotNet.RepresentationModel;
+
+namespace Robust.Shared.ContentPack;
+
+internal sealed record ResourceManifestData(
+    string[] Modules,
+    string? AssemblyPrefix,
+    string? DefaultWindowTitle,
+    string? WindowIconSet,
+    string? SplashLogo,
+    bool AutoConnect,
+    string[]? ClientAssemblies
+)
+{
+    public static readonly ResourceManifestData Default =
+        new ResourceManifestData(Array.Empty<string>(), null, null, null, null, true, null);
+
+    public static ResourceManifestData LoadResourceManifest(IResourceManager res)
+    {
+        // Parses /manifest.yml for game-specific settings that cannot be exclusively set up by content code.
+        if (!res.TryContentFileRead("/manifest.yml", out var stream))
+            return ResourceManifestData.Default;
+
+        var yamlStream = new YamlStream();
+        using (stream)
+        {
+            using var streamReader = new StreamReader(stream, EncodingHelpers.UTF8);
+            yamlStream.Load(streamReader);
+        }
+
+        if (yamlStream.Documents.Count == 0)
+            return ResourceManifestData.Default;
+
+        if (yamlStream.Documents.Count != 1 || yamlStream.Documents[0].RootNode is not YamlMappingNode mapping)
+        {
+            throw new InvalidOperationException(
+                "Expected a single YAML document with root mapping for /manifest.yml");
+        }
+
+        var modules = ReadStringArray(mapping, "modules") ?? Array.Empty<string>();
+
+        string? assemblyPrefix = null;
+        if (mapping.TryGetNode("assemblyPrefix", out var prefixNode))
+            assemblyPrefix = prefixNode.AsString();
+
+        string? defaultWindowTitle = null;
+        if (mapping.TryGetNode("defaultWindowTitle", out var winTitleNode))
+            defaultWindowTitle = winTitleNode.AsString();
+
+        string? windowIconSet = null;
+        if (mapping.TryGetNode("windowIconSet", out var iconSetNode))
+            windowIconSet = iconSetNode.AsString();
+
+        string? splashLogo = null;
+        if (mapping.TryGetNode("splashLogo", out var splashNode))
+            splashLogo = splashNode.AsString();
+
+        bool autoConnect = true;
+        if (mapping.TryGetNode("autoConnect", out var autoConnectNode))
+            autoConnect = autoConnectNode.AsBool();
+
+        var clientAssemblies = ReadStringArray(mapping, "clientAssemblies");
+
+        return new ResourceManifestData(
+            modules,
+            assemblyPrefix,
+            defaultWindowTitle,
+            windowIconSet,
+            splashLogo,
+            autoConnect,
+            clientAssemblies
+        );
+
+        static string[]? ReadStringArray(YamlMappingNode mapping, string key)
+        {
+            if (!mapping.TryGetNode(key, out var node))
+                return null;
+
+            var sequence = (YamlSequenceNode)node;
+            var array = new string[sequence.Children.Count];
+            for (var i = 0; i < array.Length; i++)
+            {
+                array[i] = sequence[i].AsString();
+            }
+
+            return array;
+        }
+    }
+}


### PR DESCRIPTION
I made the server respect the `assemblyPrefix` value in the `manifest.yml` so the prefix can be changed from `Content.` in a full release.