### PR TITLE
Remove obsoletion from localized and console commands

### DIFF
--- a/Robust.Shared/Console/IConsoleCommand.cs
+++ b/Robust.Shared/Console/IConsoleCommand.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -9,7 +8,7 @@ namespace Robust.Shared.Console
     /// Basic interface to handle console commands. Any class implementing this will be
     /// registered with the console system through reflection.
     /// </summary>
-    [UsedImplicitly(ImplicitUseTargetFlags.WithInheritors), Obsolete("New commands should utilize ToolshedCommand.")]
+    [UsedImplicitly(ImplicitUseTargetFlags.WithInheritors)]
     public interface IConsoleCommand
     {
         /// <summary>

--- a/Robust.Shared/Console/LocalizedCommands.cs
+++ b/Robust.Shared/Console/LocalizedCommands.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Robust.Shared.IoC;
@@ -6,7 +5,6 @@ using Robust.Shared.Localization;
 
 namespace Robust.Shared.Console;
 
-[Obsolete("You should use ToolshedCommand instead.")]
 public abstract class LocalizedCommands : IConsoleCommand
 {
     [Dependency] protected readonly ILocalizationManager LocalizationManager = default!;


### PR DESCRIPTION
![image](https://github.com/space-wizards/RobustToolbox/assets/10968691/98f2402f-d8f5-4c7c-b824-1d1c9c112e82)

They also don't work on the client and don't support every usecase on the server either, enforce it through review instead.