### PR TITLE
Allow deletion of FileLogHandler logs while engine is running

### DIFF
--- a/Robust.Shared/Log/FileLogHandler.cs
+++ b/Robust.Shared/Log/FileLogHandler.cs
@@ -12,7 +12,10 @@ namespace Robust.Shared.Log
         public FileLogHandler(string path)
         {
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-            writer = TextWriter.Synchronized(new StreamWriter(path, true, EncodingHelpers.UTF8));
+            writer = TextWriter.Synchronized(
+                new StreamWriter(
+                    new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read | FileShare.Delete),
+                    EncodingHelpers.UTF8));
         }
 
         public void Dispose()


### PR DESCRIPTION
This is prompted by a warning in TGS with OpenDream.

TGS has an option to either preserve or delete engine logs. It tries to delete the log immediately after the process terminates, but before the `System.Diagnostics.Process` is disposed. On Windows, this fails due to the handle still being considered open.

Create the FileStream manually instead. Parameters are exactly the same as before with the exception that the handle now allows other processes to delete the file while it's open.