### PR TITLE
Set EntityLastModifiedTick when an entity spawns

### DIFF
--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -1129,8 +1129,8 @@ internal sealed partial class PvsSystem : EntitySystem
             var query = EntityManager.AllEntityQueryEnumerator<MetaDataComponent>();
             while (query.MoveNext(out var uid, out var md))
             {
-                DebugTools.Assert(md.EntityLifeStage >= EntityLifeStage.Initialized);
-                DebugTools.Assert(md.EntityLifeStage < EntityLifeStage.Terminating);
+                DebugTools.Assert(md.EntityLifeStage >= EntityLifeStage.Initialized, $"Entity {ToPrettyString(uid)} has not been initialized");
+                DebugTools.Assert(md.EntityLifeStage < EntityLifeStage.Terminating, $"Entity {ToPrettyString(uid)} is/has been terminated");
                 if (md.EntityLastModifiedTick <= fromTick)
                     continue;
 
@@ -1165,10 +1165,10 @@ Transform last modified: {Transform(uid).LastModifiedTick}");
                     if (!toSend.Add(uid) || !_metaQuery.TryGetComponent(uid, out var md))
                         continue;
 
-                    DebugTools.Assert(md.EntityLifeStage >= EntityLifeStage.Initialized);
-                    DebugTools.Assert(md.EntityLifeStage < EntityLifeStage.Terminating);
-                    DebugTools.Assert(md.EntityLastModifiedTick >= md.CreationTick);
-                    DebugTools.Assert(md.EntityLastModifiedTick > fromTick);
+                    DebugTools.Assert(md.EntityLifeStage >= EntityLifeStage.Initialized, $"Entity {ToPrettyString(uid)} has not been initialized");
+                    DebugTools.Assert(md.EntityLifeStage < EntityLifeStage.Terminating, $"Entity {ToPrettyString(uid)} is/has been terminated");
+                    DebugTools.Assert(md.EntityLastModifiedTick >= md.CreationTick, $"Entity {ToPrettyString(uid)} last modified tick is less than creation tick");
+                    DebugTools.Assert(md.EntityLastModifiedTick > fromTick, $"Entity {ToPrettyString(uid)} last modified tick is less than from tick");
 
                     var state = GetEntityState(player, uid, fromTick, md);
 
@@ -1192,10 +1192,10 @@ Transform last modified: {Transform(uid).LastModifiedTick}");
                     if (!toSend.Add(uid) || !_metaQuery.TryGetComponent(uid, out var md))
                         continue;
 
-                    DebugTools.Assert(md.EntityLifeStage >= EntityLifeStage.Initialized);
-                    DebugTools.Assert(md.EntityLifeStage < EntityLifeStage.Terminating);
-                    DebugTools.Assert(md.EntityLastModifiedTick >= md.CreationTick);
-                    DebugTools.Assert(md.EntityLastModifiedTick > fromTick);
+                    DebugTools.Assert(md.EntityLifeStage >= EntityLifeStage.Initialized, $"Entity {ToPrettyString(uid)} has not been initialized");
+                    DebugTools.Assert(md.EntityLifeStage < EntityLifeStage.Terminating, $"Entity {ToPrettyString(uid)} is/has been terminated");
+                    DebugTools.Assert(md.EntityLastModifiedTick >= md.CreationTick, $"Entity {ToPrettyString(uid)} last modified tick is less than creation tick");
+                    DebugTools.Assert(md.EntityLastModifiedTick > fromTick, $"Entity {ToPrettyString(uid)} last modified tick is less than from tick");
 
                     var state = GetEntityState(player, uid, fromTick, md);
                     if (!state.Empty)

--- a/Robust.Shared/GameObjects/EntityManager.LifeCycle.cs
+++ b/Robust.Shared/GameObjects/EntityManager.LifeCycle.cs
@@ -18,12 +18,14 @@ public partial class EntityManager
     {
         DebugTools.Assert(component.LifeStage == ComponentLifeStage.PreAdd);
 
+#pragma warning disable CS0618 // Type or member is obsolete
         component.LifeStage = ComponentLifeStage.Adding;
         component.CreationTick = CurrentTick;
         // networked components are assumed to be dirty when added to entities. See also: ClearTicks()
         component.LastModifiedTick = CurrentTick;
         EventBus.RaiseComponentEvent(component, type, CompAddInstance);
         component.LifeStage = ComponentLifeStage.Added;
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     /// <summary>

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -657,6 +657,7 @@ namespace Robust.Shared.GameObjects
 #pragma warning disable CS0618
                 Owner = uid,
 #pragma warning restore CS0618
+                EntityLastModifiedTick = _gameTiming.CurTick
             };
 
             SetNetEntity(uid, netEntity, metadata);

--- a/Robust.UnitTesting/Server/GameStates/DefaultEntityTest.cs
+++ b/Robust.UnitTesting/Server/GameStates/DefaultEntityTest.cs
@@ -1,0 +1,111 @@
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Robust.Server.GameObjects;
+using Robust.Server.Player;
+using Robust.Shared;
+using Robust.Shared.Configuration;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Network;
+
+namespace Robust.UnitTesting.Server.GameStates;
+
+public sealed class DefaultEntityTest : RobustIntegrationTest
+{
+    /// <summary>
+    /// Simple test that just spawns a default entity without any components or modifications and checks that the
+    /// client receives the entity.
+    /// </summary>
+    [Test]
+    public async Task TestSpawnDefaultEntity()
+    {
+        var server = StartServer();
+        var client = StartClient();
+
+        await Task.WhenAll(client.WaitIdleAsync(), server.WaitIdleAsync());
+
+        var sEntMan = server.ResolveDependency<IEntityManager>();
+        var cEntMan = client.ResolveDependency<IEntityManager>();
+        var netMan = client.ResolveDependency<IClientNetManager>();
+        var playerMan = server.ResolveDependency<IPlayerManager>();
+        var confMan = server.ResolveDependency<IConfigurationManager>();
+        var mapMan = server.ResolveDependency<IMapManager>();
+
+        client.SetConnectTarget(server);
+        client.Post(() => netMan.ClientConnect(null!, 0, null!));
+        server.Post(() => confMan.SetCVar(CVars.NetPVS, false));
+
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        var session = (IPlayerSession)playerMan.Sessions.First();
+        await server.WaitPost(() => session.JoinGame());
+
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        // Spawn a default unmodified entity.
+        NetEntity ent = default;
+        await server.WaitPost(() =>
+        {
+            ent = sEntMan.GetNetEntity(sEntMan.Spawn());
+        });
+
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        // Check that server & client both think the entity exists.
+        Assert.That(sEntMan.EntityExists(sEntMan.GetEntity(ent)));
+        Assert.That(cEntMan.EntityExists(cEntMan.GetEntity(ent)));
+
+        // Enable PVS and repeat the test.
+        server.Post(() => confMan.SetCVar(CVars.NetPVS, true));
+
+        // Set up map and spawn player entity
+        NetEntity player = default;
+        EntityCoordinates coords = default!;
+        await server.WaitPost(() =>
+        {
+            var mapId = mapMan.CreateMap();
+            var map = mapMan.GetMapEntityId(mapId);
+            coords = new(map, default);
+            var playerUid = sEntMan.SpawnEntity(null, coords);
+            player = sEntMan.GetNetEntity(playerUid);
+            sEntMan.System<ActorSystem>().Attach(playerUid, session);
+        });
+
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        Assert.That(sEntMan.EntityExists(sEntMan.GetEntity(player)));
+        Assert.That(cEntMan.EntityExists(cEntMan.GetEntity(player)));
+
+        await server.WaitPost(() =>
+        {
+            ent = sEntMan.GetNetEntity(sEntMan.SpawnAtPosition(null, coords));
+        });
+
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        Assert.That(sEntMan.EntityExists(sEntMan.GetEntity(ent)));
+        Assert.That(cEntMan.EntityExists(cEntMan.GetEntity(ent)));
+    }
+}
+


### PR DESCRIPTION
AFAIK this won't cause any issues and this stops some erroneous debug asserts from triggering when PVS is disabled.