### PR TITLE
Fix grid chunk bugs

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.cs
@@ -173,7 +173,6 @@ namespace Robust.Client.Graphics.Clyde
             _entityManager.EventBus.SubscribeEvent<TileChangedEvent>(EventSource.Local, this, _updateTileMapOnUpdate);
             _entityManager.EventBus.SubscribeEvent<GridStartupEvent>(EventSource.Local, this, _updateOnGridCreated);
             _entityManager.EventBus.SubscribeEvent<GridRemovalEvent>(EventSource.Local, this, _updateOnGridRemoved);
-            _entityManager.EventBus.SubscribeEvent<GridModifiedEvent>(EventSource.Local, this, _updateOnGridModified);
         }
 
         public void ShutdownGridEcsEvents()
@@ -181,7 +180,6 @@ namespace Robust.Client.Graphics.Clyde
             _entityManager.EventBus.UnsubscribeEvent<TileChangedEvent>(EventSource.Local, this);
             _entityManager.EventBus.UnsubscribeEvent<GridStartupEvent>(EventSource.Local, this);
             _entityManager.EventBus.UnsubscribeEvent<GridRemovalEvent>(EventSource.Local, this);
-            _entityManager.EventBus.UnsubscribeEvent<GridModifiedEvent>(EventSource.Local, this);
         }
 
         private void GLInitBindings(bool gles)

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -259,7 +259,6 @@ public abstract partial class SharedMapSystem
             chunk.ValidateChunk();
             DebugTools.Assert(chunk.FilledTiles > 0);
         }
-        DebugTools.Assert(component.Chunks.Count > 0);
 #endif
     }
 

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.GridChunk.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.GridChunk.cs
@@ -14,12 +14,13 @@ public abstract partial class SharedMapSystem
     /// <param name="xIndex">The X tile index relative to the chunk.</param>
     /// <param name="yIndex">The Y tile index relative to the chunk.</param>
     /// <param name="tile">The new tile to insert.</param>
-    internal void SetChunkTile(EntityUid uid, MapGridComponent grid, MapChunk chunk, ushort xIndex, ushort yIndex, Tile tile)
+    internal bool SetChunkTile(EntityUid uid, MapGridComponent grid, MapChunk chunk, ushort xIndex, ushort yIndex, Tile tile)
     {
         if (!chunk.TrySetTile(xIndex, yIndex, tile, out var oldTile, out var shapeChanged))
-            return;
+            return false;
 
         var tileIndices = new Vector2i(xIndex, yIndex);
         OnTileModified(uid, grid, chunk, tileIndices, tile, oldTile, shapeChanged);
+        return true;
     }
 }

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
@@ -126,11 +126,12 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         ///     Creates a new instance of this class.
         /// </summary>
-        public TileChangedEvent(EntityUid uid, TileRef newTile, Tile oldTile)
+        public TileChangedEvent(EntityUid uid, TileRef newTile, Tile oldTile, Vector2i chunkIndex)
         {
             Entity = uid;
             NewTile = newTile;
             OldTile = oldTile;
+            ChunkIndex = chunkIndex;
         }
 
         /// <summary>
@@ -147,45 +148,10 @@ namespace Robust.Shared.GameObjects
         ///     Old tile that was replaced.
         /// </summary>
         public readonly Tile OldTile;
-    }
-
-    /// <summary>
-    ///     Arguments for when a one or more tiles on a grid are modified at once.
-    /// </summary>
-    public sealed class GridModifiedEvent : EntityEventArgs
-    {
-        /// <summary>
-        ///     The id of the grid being changed.
-        /// </summary>
-        public EntityUid GridEnt { get; }
 
         /// <summary>
-        ///     Grid being changed.
+        ///     The index of the grid-chunk that this tile belongs to.
         /// </summary>
-        public MapGridComponent Grid { get; }
-
-        /// <summary>
-        /// Set of tiles that were modified. Note that this does not necessarily include tiles in chunks that have been
-        /// removed entirely. See <see cref="RemovedChunks"/> for that.
-        /// </summary>
-        public IReadOnlyCollection<(Vector2i position, Tile tile)> Modified { get; }
-
-        /// <summary>
-        /// List of chunks that have been entirely removed. All of the tiles in this chunk are now empty.
-        /// Note that these tiles are not included in <see cref="Modified"/>.
-        /// </summary>
-        public readonly List<Vector2i> RemovedChunks;
-
-        /// <summary>
-        ///     Creates a new instance of this class.
-        /// </summary>
-        public GridModifiedEvent(EntityUid gridEnt, MapGridComponent grid,
-            IReadOnlyCollection<(Vector2i position, Tile tile)> modified, List<Vector2i> removedChunks)
-        {
-            GridEnt = gridEnt;
-            Grid = grid;
-            Modified = modified;
-            RemovedChunks = removedChunks;
-        }
+        public readonly Vector2i ChunkIndex;
     }
 }

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
@@ -165,18 +165,27 @@ namespace Robust.Shared.GameObjects
         public MapGridComponent Grid { get; }
 
         /// <summary>
-        /// Set of tiles that were modified.
+        /// Set of tiles that were modified. Note that this does not necessarily include tiles in chunks that have been
+        /// removed entirely. See <see cref="RemovedChunks"/> for that.
         /// </summary>
         public IReadOnlyCollection<(Vector2i position, Tile tile)> Modified { get; }
 
         /// <summary>
+        /// List of chunks that have been entirely removed. All of the tiles in this chunk are now empty.
+        /// Note that these tiles are not included in <see cref="Modified"/>.
+        /// </summary>
+        public readonly List<Vector2i> RemovedChunks;
+
+        /// <summary>
         ///     Creates a new instance of this class.
         /// </summary>
-        public GridModifiedEvent(EntityUid gridEnt, MapGridComponent grid, IReadOnlyCollection<(Vector2i position, Tile tile)> modified)
+        public GridModifiedEvent(EntityUid gridEnt, MapGridComponent grid,
+            IReadOnlyCollection<(Vector2i position, Tile tile)> modified, List<Vector2i> removedChunks)
         {
             GridEnt = gridEnt;
             Grid = grid;
             Modified = modified;
+            RemovedChunks = removedChunks;
         }
     }
 }

--- a/Robust.Shared/GameStates/GameStateMapData.cs
+++ b/Robust.Shared/GameStates/GameStateMapData.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
@@ -13,11 +14,12 @@ namespace Robust.Shared.GameStates
         // Definitely wasteful to send EVERY tile.
         // Optimize away future coder.
         // Also it's stored row-major.
-        public readonly Tile[] TileData;
+        public readonly Tile[]? TileData;
 
+        [MemberNotNullWhen(false, nameof(TileData))]
         public bool IsDeleted()
         {
-            return TileData == default;
+            return TileData == null;
         }
 
         private ChunkDatum(Vector2i index, Tile[] tileData)
@@ -33,7 +35,7 @@ namespace Robust.Shared.GameStates
 
         public static ChunkDatum CreateDeleted(Vector2i index)
         {
-            return new ChunkDatum(index, default!);
+            return new ChunkDatum(index, null!);
         }
     }
 }

--- a/Robust.Shared/Map/IMapManagerInternal.cs
+++ b/Robust.Shared/Map/IMapManagerInternal.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.GameObjects;
+using Robust.Shared.Maths;
 using Robust.Shared.Timing;
 
 namespace Robust.Shared.Map
@@ -13,7 +14,7 @@ namespace Robust.Shared.Map
         /// </summary>
         /// <param name="tileRef">A reference to the new tile.</param>
         /// <param name="oldTile">The old tile that got replaced.</param>
-        void RaiseOnTileChanged(TileRef tileRef, Tile oldTile);
+        void RaiseOnTileChanged(TileRef tileRef, Tile oldTile, Vector2i chunk);
 
         MapId CreateMap(MapId? mapId, EntityUid euid);
 

--- a/Robust.Shared/Map/MapManager.GridCollection.cs
+++ b/Robust.Shared/Map/MapManager.GridCollection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Maths;
 using Robust.Shared.Utility;
 
 // All the obsolete warnings about GridId are probably useless here.
@@ -138,7 +139,7 @@ internal partial class MapManager
     /// </summary>
     /// <param name="tileRef">A reference to the new tile.</param>
     /// <param name="oldTile">The old tile that got replaced.</param>
-    public void RaiseOnTileChanged(TileRef tileRef, Tile oldTile)
+    public void RaiseOnTileChanged(TileRef tileRef, Tile oldTile, Vector2i chunk)
     {
 #if DEBUG
         DebugTools.Assert(_dbgGuardRunning);
@@ -148,7 +149,7 @@ internal partial class MapManager
             return;
 
         var euid = tileRef.GridUid;
-        var ev = new TileChangedEvent(euid, tileRef, oldTile);
+        var ev = new TileChangedEvent(euid, tileRef, oldTile, chunk);
         EntityManager.EventBus.RaiseLocalEvent(euid, ref ev, true);
     }
 

--- a/Robust.Shared/Map/MapManager.Queries.cs
+++ b/Robust.Shared/Map/MapManager.Queries.cs
@@ -215,14 +215,14 @@ internal partial class MapManager
             // you account for the fact that fixtures are shrunk slightly!
             var chunkIndices = SharedMapSystem.GetChunkIndices(localPos, iGrid.ChunkSize);
 
-            if (!tuple.mapSystem.HasChunk(iUid, iGrid, chunkIndices))
+            if (!iGrid.Chunks.TryGetValue(chunkIndices, out var chunk))
                 return true;
 
-            var chunk = tuple.mapSystem.GetOrAddChunk(iUid, iGrid, chunkIndices);
             var chunkRelative = SharedMapSystem.GetChunkRelative(localPos, iGrid.ChunkSize);
             var chunkTile = chunk.GetTile(chunkRelative);
 
-            if (chunkTile.IsEmpty) return true;
+            if (chunkTile.IsEmpty)
+                return true;
 
             tuple.uid = iUid;
             tuple.grid = iGrid;


### PR DESCRIPTION
Fixes a couple of grid chunk related bugs, including the bug where a deleted chunk would continue getting rendered, and a bug where some grid/anchoring queries would add empty chunks to the component.

This PR also removes the `GridModifiedEvent`, which was only ever used by the client. Now there is only a `TileModifiedEvent`, though I plan to change it in a follow up PR to support lists of modified tiles. Removal of `GridModifiedEvent` requires space-wizards/space-station-14/pull/21291.

Heres a video of current master, showing the grid rendering bug & empty grids. Note that grid splitting is disabled.

https://github.com/space-wizards/RobustToolbox/assets/60421075/40ec59f9-8972-4131-8a38-dad58c783083

And here is an equivalent video with the changes in this PR:

https://github.com/space-wizards/RobustToolbox/assets/60421075/7867f79d-0d10-44e7-b5a9-fb1fd51839e9


