### PR TITLE
Remove empty planet-map chunks

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/MapSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapSystem.cs
@@ -66,9 +66,8 @@ namespace Robust.Server.GameObjects
 
         private void HandleGridEmpty(EntityUid uid, MapGridComponent component, EmptyGridEvent args)
         {
-            if (!_deleteEmptyGrids) return;
-            if (!EntityManager.EntityExists(uid)) return;
-            if (EntityManager.GetComponent<MetaDataComponent>(uid).EntityLifeStage >= EntityLifeStage.Terminating) return;
+            if (!_deleteEmptyGrids || TerminatingOrDeleted(uid) || HasComp<MapComponent>(uid))
+                return;
 
             MapManager.DeleteGrid(args.GridId);
         }


### PR DESCRIPTION
Stops the the grid component state debug assert from being triggered.
This also fixes a bug in `SetTile()` where I used `return` instead of `continue` 