### PR TITLE
Cache prototype data for `IEntityManager.IsDefault()`

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -136,15 +136,6 @@ namespace Robust.Shared.GameObjects
 
             var prototype = metadata.EntityPrototype;
 
-            // Prototype may or may not have metadata / transforms
-            var protoComps = prototype.Components.Keys.ToList();
-
-            protoComps.Remove(_xformName);
-
-            // Fast check if the component counts match.
-            if (protoComps.Count != ComponentCount(uid) - 2)
-                return false;
-
             // Check if entity name / description match
             if (metadata.EntityName != prototype.Name ||
                 metadata.EntityDescription != prototype.Description)
@@ -152,43 +143,26 @@ namespace Robust.Shared.GameObjects
                 return false;
             }
 
-            // Get default prototype data
-            Dictionary<string, MappingDataNode> protoData = new();
-            try
-            {
-                _context.WritingReadingPrototypes = true;
+            var protoData = PrototypeManager.GetPrototypeData(prototype);
+            var comps = _entCompIndex[uid];
 
-                foreach (var compType in protoComps)
-                {
-                    if (compType == _xformName)
-                        continue;
-
-                    var comp = prototype.Components[compType];
-                    protoData.Add(compType, _serManager.WriteValueAs<MappingDataNode>(comp.Component.GetType(), comp.Component, alwaysWrite: true, context: _context));
-                }
-
-                _context.WritingReadingPrototypes = false;
-            }
-            catch (Exception e)
-            {
-                _sawmill.Error($"Failed to convert prototype {prototype.ID} into yaml. Exception: {e.Message}");
+            // Fast check if the component counts match.
+            // Note that transform and metadata are not included in the prototype data.
+            if (protoData.Count + 2 != comps.Count)
                 return false;
-            }
 
-            var comps = new HashSet<IComponent>(GetComponents(uid));
-            var compNames = new HashSet<string>(protoComps.Count);
             foreach (var component in comps)
             {
+                if (component.Deleted)
+                    return false;
+
                 var compType = component.GetType();
                 var compName = _componentFactory.GetComponentName(compType);
-
-                if (compType == typeof(MetaDataComponent) || compType == typeof(TransformComponent))
+                if (compName == _xformName || compName == _metaReg.Name)
                     continue;
 
-                compNames.Add(compName);
-
                 // If the component isn't on the prototype then it's custom.
-                if (!protoComps.Contains(compName))
+                if (!protoData.TryGetValue(compName, out var protoMapping))
                     return false;
 
                 MappingDataNode compMapping;
@@ -202,25 +176,9 @@ namespace Robust.Shared.GameObjects
                     return false;
                 }
 
-                if (protoData.TryGetValue(compName, out var protoMapping))
-                {
-                    var diff = compMapping.Except(protoMapping);
+                var diff = compMapping.Except(protoMapping);
 
-                    if (diff != null && diff.Children.Count != 0)
-                    {
-                        return false;
-                    }
-                }
-                else
-                {
-                    return false;
-                }
-            }
-
-            // An entity may also remove components on init -> check no components are missing.
-            foreach (var compType in protoComps)
-            {
-                if (!compNames.Contains(compType))
+                if (diff != null && diff.Children.Count != 0)
                     return false;
             }
 
@@ -814,18 +772,6 @@ namespace Robust.Shared.GameObjects
         /// Generates a unique network id and increments <see cref="NextNetworkId"/>
         /// </summary>
         protected virtual NetEntity GenerateNetEntity() => new(NextNetworkId++);
-
-        private sealed class EntityDiffContext : ISerializationContext
-        {
-            public SerializationManager.SerializerProvider SerializerProvider { get; }
-            public bool WritingReadingPrototypes { get; set; }
-
-            public EntityDiffContext()
-            {
-                SerializerProvider = new();
-                SerializerProvider.RegisterSerializer(this);
-            }
-        }
     }
 
     public enum EntityMessageType : byte

--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -331,6 +331,11 @@ public interface IPrototypeManager
     ///     This does NOT fire on initial prototype load.
     /// </remarks>
     event Action<PrototypesReloadedEventArgs> PrototypesReloaded;
+
+    /// <summary>
+    /// Get the yaml data for a given prototype.
+    /// </summary>
+    IReadOnlyDictionary<string, MappingDataNode> GetPrototypeData(EntityPrototype prototype);
 }
 
 internal interface IPrototypeManagerInternal : IPrototypeManager

--- a/Robust.Shared/Serialization/Manager/ISerializationContext.cs
+++ b/Robust.Shared/Serialization/Manager/ISerializationContext.cs
@@ -11,3 +11,15 @@ public interface ISerializationContext
     /// </summary>
     bool WritingReadingPrototypes { get; }
 }
+
+public sealed class EntityDiffContext : ISerializationContext
+{
+    public SerializationManager.SerializerProvider SerializerProvider { get; }
+    public bool WritingReadingPrototypes { get; set; } = true;
+
+    public EntityDiffContext()
+    {
+        SerializerProvider = new();
+        SerializerProvider.RegisterSerializer(this);
+    }
+}


### PR DESCRIPTION
This moves some of the logic in `EntityManager.IsDefault()` into `PrototypeManager` and caches it, so that it doesn't get re-computed for each entity that gets checked. Should make the planet-map / biome chunk unloading faster.