### PR TITLE
Fix audio position on first tick

### DIFF
--- a/Robust.Client/Audio/AudioSystem.cs
+++ b/Robust.Client/Audio/AudioSystem.cs
@@ -161,11 +161,6 @@ public sealed partial class AudioSystem : SharedAudioSystem
         // Don't play until first frame so occlusion etc. are correct.
         component.Gain = 0f;
 
-        if (!MetaData(uid).EntityPaused)
-        {
-            component.StartPlaying();
-        }
-
         // If audio came into range then start playback at the correct position.
         var offset = (Timing.CurTime - component.AudioStart).TotalSeconds % GetAudioLength(component.FileName).TotalSeconds;
 
@@ -227,6 +222,11 @@ public sealed partial class AudioSystem : SharedAudioSystem
         // TODO:
         // I Originally tried to be fancier here but it caused audio issues so just trying
         // to replicate the old behaviour for now.
+        if (!component.Started)
+        {
+            component.Started = true;
+            component.StartPlaying();
+        }
 
         // If it's global but on another map (that isn't nullspace) then stop playing it.
         if (component.Global)

--- a/Robust.Shared/Audio/Components/AudioComponent.cs
+++ b/Robust.Shared/Audio/Components/AudioComponent.cs
@@ -49,6 +49,10 @@ public sealed partial class AudioComponent : Component, IAudioSource
 
     #endregion
 
+    // We can't just start playing on audio creation as we don't have the correct position yet.
+    // As such we'll wait for FrameUpdate before we start playing to avoid the position being cooked.
+    public bool Started = false;
+
     [AutoNetworkedField]
     [DataField(required: true)]
     public string FileName = string.Empty;


### PR DESCRIPTION
If entities started on their actual position this wouldn't be needed.