### PR TITLE
Print stack trace when adding a component while iterating net comps in ResetPredictedEntities

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -164,9 +164,13 @@ namespace Robust.Client.GameStates
 
             _entities.ComponentAdded += args =>
             {
-                var comp = _compFactory.GetRegistration(args.ComponentType);
-                if (_resettingPredictedEntities && comp.NetID != null)
+                if (_resettingPredictedEntities)
                 {
+                    var comp = _compFactory.GetRegistration(args.ComponentType);
+
+                    if (comp.NetID == null)
+                        return;
+
                     _sawmill.Error($"Added component {comp.Name} with net id {comp.NetID}. Stack trace:\n{Environment.StackTrace}");
                 }
             };

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -162,28 +162,30 @@ namespace Robust.Client.GameStates
             _conHost.RegisterCommand("localdelete", Loc.GetString("cmd-local-delete-desc"), Loc.GetString("cmd-local-delete-help"), LocalDeleteEntCommand);
             _conHost.RegisterCommand("fullstatereset", Loc.GetString("cmd-full-state-reset-desc"), Loc.GetString("cmd-full-state-reset-help"), (_,_,_) => RequestFullState());
 
-            _entities.ComponentAdded += args =>
-            {
-                if (_resettingPredictedEntities)
-                {
-                    var comp = _compFactory.GetRegistration(args.ComponentType);
-
-                    if (comp.NetID == null)
-                        return;
-
-                    _sawmill.Error($"""
-                    Added component {comp.Name} with net id {comp.NetID} while resetting predicted entities.
-                    Stack trace:
-                    {Environment.StackTrace}
-                    """);
-                }
-            };
+            _entities.ComponentAdded += OnComponentAdded;
 
             var metaId = _compFactory.GetRegistration(typeof(MetaDataComponent)).NetID;
             if (!metaId.HasValue)
                 throw new InvalidOperationException("MetaDataComponent does not have a NetId.");
 
             _metaCompNetId = metaId.Value;
+        }
+
+        private void OnComponentAdded(AddedComponentEventArgs args)
+        {
+            if (_resettingPredictedEntities)
+            {
+                var comp = args.ComponentType;
+
+                if (comp.NetID == null)
+                    return;
+
+                _sawmill.Error($"""
+                    Added component {comp.Name} with net id {comp.NetID} while resetting predicted entities.
+                    Stack trace:
+                    {Environment.StackTrace}
+                    """);
+            }
         }
 
         /// <inheritdoc />

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -171,7 +171,11 @@ namespace Robust.Client.GameStates
                     if (comp.NetID == null)
                         return;
 
-                    _sawmill.Error($"Added component {comp.Name} with net id {comp.NetID}. Stack trace:\n{Environment.StackTrace}");
+                    _sawmill.Error($"""
+                    Added component {comp.Name} with net id {comp.NetID} while resetting predicted entities.
+                    Stack trace:
+                    {Environment.StackTrace}
+                    """);
                 }
             };
 

--- a/Robust.Shared/GameObjects/ComponentEventArgs.cs
+++ b/Robust.Shared/GameObjects/ComponentEventArgs.cs
@@ -31,9 +31,9 @@ namespace Robust.Shared.GameObjects
     public readonly struct AddedComponentEventArgs
     {
         public readonly ComponentEventArgs BaseArgs;
-        public readonly CompIdx ComponentType;
+        public readonly ComponentRegistration ComponentType;
 
-        public AddedComponentEventArgs(ComponentEventArgs baseArgs, CompIdx componentType)
+        public AddedComponentEventArgs(ComponentEventArgs baseArgs, ComponentRegistration componentType)
         {
             BaseArgs = baseArgs;
             ComponentType = componentType;

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -346,7 +346,7 @@ namespace Robust.Shared.GameObjects
         {
             _subscriptionLock = true;
 
-            EntAddComponent(e.BaseArgs.Owner, e.ComponentType);
+            EntAddComponent(e.BaseArgs.Owner, e.ComponentType.Idx);
         }
 
         public void OnComponentRemoved(in RemovedComponentEventArgs e)

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -317,7 +317,7 @@ namespace Robust.Shared.GameObjects
                 component.Networked = false;
             }
 
-            var eventArgs = new AddedComponentEventArgs(new ComponentEventArgs(component, uid), reg.Idx);
+            var eventArgs = new AddedComponentEventArgs(new ComponentEventArgs(component, uid), reg);
             ComponentAdded?.Invoke(eventArgs);
             _eventBus.OnComponentAdded(eventArgs);
 

--- a/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.ComponentEvent.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.ComponentEvent.cs
@@ -43,7 +43,9 @@ namespace Robust.UnitTesting.Shared.GameObjects
 
             // add a component to the system
             bus.OnEntityAdded(entUid);
-            bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(compInstance, entUid), CompIdx.Index<MetaDataComponent>()));
+
+            var reg = compFactory.GetRegistration(CompIdx.Index<MetaDataComponent>());
+            bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(compInstance, entUid), reg));
 
             // Raise
             var evntArgs = new TestEvent(5);
@@ -98,7 +100,9 @@ namespace Robust.UnitTesting.Shared.GameObjects
 
             // add a component to the system
             bus.OnEntityAdded(entUid);
-            bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(compInstance, entUid), CompIdx.Index<MetaDataComponent>()));
+
+            var reg = compFacMock.Object.GetRegistration(CompIdx.Index<MetaDataComponent>());
+            bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(compInstance, entUid), reg));
 
             // Raise
             var evntArgs = new TestEvent(5);
@@ -151,7 +155,9 @@ namespace Robust.UnitTesting.Shared.GameObjects
 
             // add a component to the system
             entManMock.Raise(m => m.EntityAdded += null, entUid);
-            entManMock.Raise(m => m.ComponentAdded += null, new AddedComponentEventArgs(new ComponentEventArgs(compInstance, entUid), CompIdx.Index<MetaDataComponent>()));
+
+            var reg = compFacMock.Object.GetRegistration<MetaDataComponent>();
+            entManMock.Raise(m => m.ComponentAdded += null, new AddedComponentEventArgs(new ComponentEventArgs(compInstance, entUid), reg));
 
             // Raise
             ((IEventBus)bus).RaiseComponentEvent(compInstance, new ComponentInit());
@@ -228,9 +234,14 @@ namespace Robust.UnitTesting.Shared.GameObjects
 
             // add a component to the system
             bus.OnEntityAdded(entUid);
-            bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(instA, entUid), CompIdx.Index<OrderAComponent>()));
-            bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(instB, entUid), CompIdx.Index<OrderBComponent>()));
-            bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(instC, entUid), CompIdx.Index<OrderCComponent>()));
+
+            var regA = compFacMock.Object.GetRegistration(CompIdx.Index<OrderAComponent>());
+            var regB = compFacMock.Object.GetRegistration(CompIdx.Index<OrderBComponent>());
+            var regC = compFacMock.Object.GetRegistration(CompIdx.Index<OrderCComponent>());
+
+            bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(instA, entUid), regA));
+            bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(instB, entUid), regB));
+            bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(instC, entUid), regC));
 
             // Raise
             var evntArgs = new TestEvent(5);


### PR DESCRIPTION
This also needs to be done for component removals too but adding seems like a more common issue.

Example:
```
Multiple failures or warnings in test:
  1) CLIENT: 0.026s [ERRO] state: Added component CollisionWake with net id 61 while resetting predicted entities. Stack trace:
   at System.Environment.get_StackTrace()
   at Robust.Client.GameStates.ClientGameStateManager.<Initialize>b__69_9(AddedComponentEventArgs args) in C:\Projects\CM14\RobustToolbox\Robust.Client\GameStates\ClientGameStateManager.cs:line 171
   at Robust.Shared.GameObjects.EntityManager.AddComponentInternal[T](EntityUid uid, T component, ComponentRegistration reg, Boolean overwrite, Boolean skipInit, MetaDataComponent metadata) in C:\Projects\CM14\RobustToolbox\Robust.Shared\GameObjects\EntityManager.Components.cs:line 321
   at Robust.Shared.GameObjects.EntityManager.AddComponentInternal[T](EntityUid uid, T component, Boolean overwrite, Boolean skipInit, MetaDataComponent metadata) in C:\Projects\CM14\RobustToolbox\Robust.Shared\GameObjects\EntityManager.Components.cs:line 267
   at Robust.Shared.GameObjects.EntityManager.AddComponent[T](EntityUid uid, T component, Boolean overwrite, MetaDataComponent metadata) in C:\Projects\CM14\RobustToolbox\Robust.Shared\GameObjects\EntityManager.Components.cs:line 260
   at Robust.Shared.GameObjects.EntityManager.AddComponent[T](EntityUid uid) in C:\Projects\CM14\RobustToolbox\Robust.Shared\GameObjects\EntityManager.Components.cs:line 183
   at Content.Shared.Mobs.Systems.MobStateSystem.OnStateEnteredSubscribers(EntityUid target, MobStateComponent component, MobState state) in C:\Projects\CM14\Content.Shared\Mobs\Systems\MobStateSystem.Subscribers.cs:line 85
   at Content.Shared.Mobs.Systems.MobStateSystem.OnEnterState(EntityUid entity, MobStateComponent component, MobState state) in C:\Projects\CM14\Content.Shared\Mobs\Systems\MobStateSystem.StateMachine.cs:line 68
   at Content.Shared.Mobs.Systems.MobStateSystem.ChangeState(EntityUid target, MobStateComponent component, MobState newState, Nullable`1 origin) in C:\Projects\CM14\Content.Shared\Mobs\Systems\MobStateSystem.StateMachine.cs:line 108
   at Content.Shared.Mobs.Systems.MobStateSystem.UpdateMobState(EntityUid entity, MobStateComponent component, Nullable`1 origin) in C:\Projects\CM14\Content.Shared\Mobs\Systems\MobStateSystem.StateMachine.cs:line 35
   at Content.Shared.Mobs.Systems.MobThresholdSystem.TriggerThreshold(EntityUid target, MobState newState, MobStateComponent mobState, MobThresholdsComponent thresholds, Nullable`1 origin) in C:\Projects\CM14\Content.Shared\Mobs\Systems\MobThresholdSystem.cs:line 365
   at Content.Shared.Mobs.Systems.MobThresholdSystem.CheckThresholds(EntityUid target, MobStateComponent mobStateComponent, MobThresholdsComponent thresholdsComponent, DamageableComponent damageableComponent, Nullable`1 origin) in C:\Projects\CM14\Content.Shared\Mobs\Systems\MobThresholdSystem.cs:line 341
   at Content.Shared.Mobs.Systems.MobThresholdSystem.OnDamaged(EntityUid target, MobThresholdsComponent thresholds, DamageChangedEvent args) in C:\Projects\CM14\Content.Shared\Mobs\Systems\MobThresholdSystem.cs:line 416
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass46_0`2.<SubscribeLocalEvent>g__EventHandler|0(EntityUid uid, IComponent comp, TEvent& args) in C:\Projects\CM14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 256
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass57_0`1.<EntSubscribe>b__0(EntityUid uid, IComponent comp, Unit& ev) in C:\Projects\CM14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 399
   at Robust.Shared.GameObjects.EntityEventBus.EntDispatch(EntityUid euid, Type eventType, Unit& args) in C:\Projects\CM14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 550
   at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEventCore(EntityUid uid, Unit& unitRef, Type type, Boolean broadcast) in C:\Projects\CM14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 224
   at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEvent[TEvent](EntityUid uid, TEvent args, Boolean broadcast) in C:\Projects\CM14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 184
   at Robust.Shared.GameObjects.EntitySystem.RaiseLocalEvent[TEvent](EntityUid uid, TEvent args, Boolean broadcast) in C:\Projects\CM14\RobustToolbox\Robust.Shared\GameObjects\EntitySystem.cs:line 149
   at Content.Shared.Damage.DamageableSystem.DamageChanged(EntityUid uid, DamageableComponent component, DamageSpecifier damageDelta, Boolean interruptsDoAfters, Nullable`1 origin) in C:\Projects\CM14\Content.Shared\Damage\Systems\DamageableSystem.cs:line 108
   at Content.Shared.Damage.DamageableSystem.DamageableHandleState(EntityUid uid, DamageableComponent component, ComponentHandleState& args) in C:\Projects\CM14\Content.Shared\Damage\Systems\DamageableSystem.cs:line 276
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass48_0`2.<SubscribeLocalEvent>g__EventHandler|0(EntityUid uid, IComponent comp, TEvent& args) in C:\Projects\CM14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 289
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass57_0`1.<EntSubscribe>b__0(EntityUid uid, IComponent comp, Unit& ev) in C:\Projects\CM14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 399
   at Robust.Shared.GameObjects.EntityEventBus.DispatchComponent[TEvent](EntityUid euid, IComponent component, CompIdx baseType, Unit& args) in C:\Projects\CM14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 584
   at Robust.Shared.GameObjects.EntityEventBus.Robust.Shared.GameObjects.IDirectedEventBus.RaiseComponentEvent[TEvent](IComponent component, TEvent& args) in C:\Projects\CM14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 165
   at Robust.Client.GameStates.ClientGameStateManager.ResetPredictedEntities() in C:\Projects\CM14\RobustToolbox\Robust.Client\GameStates\ClientGameStateManager.cs:line 595
   at Robust.Client.GameStates.ClientGameStateManager.ApplyGameState() in C:\Projects\CM14\RobustToolbox\Robust.Client\GameStates\ClientGameStateManager.cs:line 325
   at Robust.Client.GameController.Tick(FrameEventArgs frameEventArgs) in C:\Projects\CM14\RobustToolbox\Robust.Client\GameController\GameController.cs:line 532
   at Robust.Client.GameController.<StartupContinue>b__57_0(Object sender, FrameEventArgs args) in C:\Projects\CM14\RobustToolbox\Robust.Client\GameController\GameController.cs:line 220
   at Robust.UnitTesting.RobustIntegrationTest.IntegrationGameLoop.SingleThreadRunUntilEmpty() in C:\Projects\CM14\RobustToolbox\Robust.UnitTesting\RobustIntegrationTest.cs:line 1011
   at Robust.UnitTesting.RobustIntegrationTest.IntegrationGameLoop.Run() in C:\Projects\CM14\RobustToolbox\Robust.UnitTesting\RobustIntegrationTest.cs:line 988
   at Robust.UnitTesting.RobustIntegrationTest.ClientIntegrationInstance.ThreadMain() in C:\Projects\CM14\RobustToolbox\Robust.UnitTesting\RobustIntegrationTest.cs:line 813
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state) Exception: 
```