### PR TITLE
Allow Physics to get Bounding Boxes in Object Space

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
@@ -631,7 +631,7 @@ public partial class SharedPhysicsSystem
         if (!Resolve(uid, ref manager, ref body))
             return new Box2();
 
-        var transform = new Transform(Vector2.Zero, 0);
+        var transform = new Transform(0);
 
         var bounds = new Box2(Vector2.Zero, Vector2.Zero);
 

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
@@ -624,6 +624,30 @@ public partial class SharedPhysicsSystem
     }
 
     /// <summary>
+    /// Gets the physics Object space AABB, only considering fixtures.
+    /// </summary>
+    public Box2 GetObjectAABB(EntityUid uid, FixturesComponent? manager = null, PhysicsComponent? body = null)
+    {
+        if (!Resolve(uid, ref manager, ref body))
+            return new Box2();
+
+        var transform = new Transform(Vector2.Zero, 0);
+
+        var bounds = new Box2(Vector2.Zero, Vector2.Zero);
+
+        foreach (var fixture in manager.Fixtures.Values)
+        {
+            for (var i = 0; i < fixture.Shape.ChildCount; i++)
+            {
+                var boundy = fixture.Shape.ComputeAABB(transform, i);
+                bounds = bounds.Union(boundy);
+            }
+        }
+
+        return bounds;
+    }
+
+    /// <summary>
     /// Gets the physics World AABB, only considering fixtures.
     /// </summary>
     public Box2 GetWorldAABB(EntityUid uid, FixturesComponent? manager = null, PhysicsComponent? body = null, TransformComponent? xform = null)


### PR DESCRIPTION
While defining bounding boxes in world-space is very valuable for determining if objects are in collision or should interact with each other, it is currently being misused in the game codebase. GetWorldAABB is being used to determine the true size of physics objects, but this produces inconsistent values as it means the size and shape of the bounding box varies with the rotation in world space.
By providing a way to define bounding boxes in object space, you can get a "canonical" bounding box for items that is based solely on the default assignment of their fixture shapes. For determining invariant values like total object size, this is invaluable.

I can cite the specific issues this causes if examples are wanted by anyone