### PR TITLE
Allow per-eye lighting toggling.

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -512,7 +512,7 @@ namespace Robust.Client.Graphics.Clyde
                         RenderOverlays(viewport, OverlaySpace.WorldSpaceBelowFOV, worldAABB, worldBounds);
                     }
 
-                    if (_lightManager.Enabled && _lightManager.DrawHardFov && eye.DrawFov)
+                    if (_lightManager.Enabled && _lightManager.DrawHardFov && eye.DrawLight && eye.DrawFov)
                     {
                         ApplyFovToBuffer(viewport, eye);
                     }

--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -332,7 +332,7 @@ namespace Robust.Client.Graphics.Clyde
 
         private void DrawLightsAndFov(Viewport viewport, Box2Rotated worldBounds, Box2 worldAABB, IEye eye)
         {
-            if (!_lightManager.Enabled)
+            if (!_lightManager.Enabled || !eye.DrawLight)
             {
                 return;
             }

--- a/Robust.Shared/GameObjects/Components/Eye/EyeComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Eye/EyeComponent.cs
@@ -31,6 +31,9 @@ namespace Robust.Shared.GameObjects
         [ViewVariables(VVAccess.ReadWrite), DataField("drawFov"), AutoNetworkedField]
         public bool DrawFov = true;
 
+        [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+        public bool DrawLight = true;
+
         // yes it's not networked, don't ask.
         [ViewVariables(VVAccess.ReadWrite), DataField("rotation")]
         public Angle Rotation;

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -154,18 +154,26 @@ public partial class EntitySystem
     ///     Marks a component as dirty. This also implicitly dirties the entity this component belongs to.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected void Dirty<T>(Entity<T> ent, MetaDataComponent? meta = null) where T : IComponent
+    protected void Dirty<T>(Entity<T> ent, MetaDataComponent? meta = null) where T : IComponent?
     {
-        EntityManager.Dirty(ent.Owner, ent.Comp, meta);
+        var comp = ent.Comp;
+        if (comp == null && !EntityManager.TryGetComponent(ent.Owner, out comp))
+            return;
+
+        EntityManager.Dirty(ent.Owner, comp, meta);
     }
 
     /// <summary>
     ///     Marks a component as dirty. This also implicitly dirties the entity this component belongs to.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected void Dirty<T>(Entity<T, MetaDataComponent> ent) where T : IComponent
+    protected void Dirty<T>(Entity<T, MetaDataComponent> ent) where T : IComponent?
     {
-        EntityManager.Dirty(ent.Owner, ent.Comp1, ent.Comp2);
+        var comp = ent.Comp1;
+        if (comp == null && !EntityManager.TryGetComponent(ent.Owner, out comp))
+            return;
+
+        EntityManager.Dirty(ent.Owner, comp, ent.Comp2);
     }
 
     /// <summary>

--- a/Robust.Shared/GameObjects/Systems/SharedEyeSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedEyeSystem.cs
@@ -6,8 +6,6 @@ namespace Robust.Shared.GameObjects;
 
 public abstract class SharedEyeSystem : EntitySystem
 {
-    [Dependency] protected readonly SharedTransformSystem TransformSystem = default!;
-
     /// <summary>
     /// Refreshes all values for IEye with the component.
     /// </summary>
@@ -19,6 +17,7 @@ public abstract class SharedEyeSystem : EntitySystem
 
         component.Eye.Offset = component.Offset;
         component.Eye.DrawFov = component.DrawFov;
+        component.Eye.DrawLight = component.DrawLight;
         component.Eye.Rotation = component.Rotation;
         component.Eye.Zoom = component.Zoom;
     }
@@ -32,10 +31,7 @@ public abstract class SharedEyeSystem : EntitySystem
             return;
 
         eyeComponent.Offset = value;
-        if (eyeComponent.Eye != null)
-        {
-            eyeComponent.Eye.Offset = value;
-        }
+        eyeComponent.Eye.Offset = value;
         Dirty(uid, eyeComponent);
     }
 
@@ -48,11 +44,21 @@ public abstract class SharedEyeSystem : EntitySystem
             return;
 
         eyeComponent.DrawFov = value;
-        if (eyeComponent.Eye != null)
-        {
-            eyeComponent.Eye.DrawFov = value;
-        }
+        eyeComponent.Eye.DrawFov = value;
         Dirty(uid, eyeComponent);
+    }
+
+    public void SetDrawLight(Entity<EyeComponent?> entity, bool value)
+    {
+        if (!Resolve(entity, ref entity.Comp))
+            return;
+
+        if (entity.Comp.DrawLight == value)
+            return;
+
+        entity.Comp.DrawLight = value;
+        entity.Comp.Eye.DrawLight = value;
+        Dirty(entity);
     }
 
     public void SetRotation(EntityUid uid, Angle rotation, EyeComponent? eyeComponent = null)
@@ -64,10 +70,7 @@ public abstract class SharedEyeSystem : EntitySystem
             return;
 
         eyeComponent.Rotation = rotation;
-        if (eyeComponent.Eye != null)
-        {
-            eyeComponent.Eye.Rotation = rotation;
-        }
+        eyeComponent.Eye.Rotation = rotation;
     }
 
     public void SetTarget(EntityUid uid, EntityUid? value, EyeComponent? eyeComponent = null)
@@ -91,10 +94,7 @@ public abstract class SharedEyeSystem : EntitySystem
             return;
 
         eyeComponent.Zoom = value;
-        if (eyeComponent.Eye != null)
-        {
-            eyeComponent.Eye.Zoom = value;
-        }
+        eyeComponent.Eye.Zoom = value;
     }
 
     public void SetVisibilityMask(EntityUid uid, int value, EyeComponent? eyeComponent = null)

--- a/Robust.Shared/Graphics/Eye.cs
+++ b/Robust.Shared/Graphics/Eye.cs
@@ -20,6 +20,10 @@ namespace Robust.Shared.Graphics
         public bool DrawFov { get; set; } = true;
 
         /// <inheritdoc />
+        [ViewVariables]
+        public bool DrawLight { get; set; } = true;
+
+        /// <inheritdoc />
         [ViewVariables(VVAccess.ReadWrite)]
         public virtual MapCoordinates Position
         {

--- a/Robust.Shared/Graphics/IEye.cs
+++ b/Robust.Shared/Graphics/IEye.cs
@@ -18,6 +18,11 @@ namespace Robust.Shared.Graphics
         bool DrawFov { get; set; }
 
         /// <summary>
+        /// Whether to draw lights for this eye.
+        /// </summary>
+        bool DrawLight { get; set; }
+
+        /// <summary>
         /// Current position of the center of the eye in the game world.
         /// </summary>
         MapCoordinates Position { get; }


### PR DESCRIPTION
This allows the light rendering to be set per eye, instead of just globally via `ILightManager`