### PR TITLE
Minor PVS stuff

### DIFF
--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -37,6 +37,9 @@ namespace Robust.Server.GameStates
         // Mapping of net UID of clients -> last known acked state.
         private GameTick _lastOldestAck = GameTick.Zero;
 
+        private HashSet<int>[] _playerChunks = Array.Empty<HashSet<int>>();
+        private EntityUid[][] _viewerEntities = Array.Empty<EntityUid[]>();
+
         private PvsSystem _pvs = default!;
 
         [Dependency] private readonly EntityManager _entityManager = default!;
@@ -267,7 +270,7 @@ Oldest acked clients: {string.Join(", ", players)}
 
         private PvsData? GetPVSData(ICommonSession[] players)
         {
-            var (chunks, playerChunks, viewerEntities) = _pvs.GetChunks(players);
+            var chunks= _pvs.GetChunks(players, ref _playerChunks, ref _viewerEntities);
             const int ChunkBatchSize = 2;
             var chunksCount = chunks.Count;
             var chunkBatches = (int)MathF.Ceiling((float)chunksCount / ChunkBatchSize);
@@ -310,8 +313,8 @@ Oldest acked clients: {string.Join(", ", players)}
             ArrayPool<bool>.Shared.Return(reuse);
             return new PvsData()
             {
-                PlayerChunks = playerChunks,
-                ViewerEntities = viewerEntities,
+                PlayerChunks = _playerChunks,
+                ViewerEntities = _viewerEntities,
                 ChunkCache = chunkCache,
             };
         }


### PR DESCRIPTION
The array one is probably most risky in terms of re-using old data but all the array entries are getting cleared every tick (PVSData is only used inside of PVS)