### PR TITLE
Add misc helpful methods

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
@@ -103,7 +103,7 @@ internal sealed class SharedGridTraversalSystem : EntitySystem
             // Attach them to map / they are on an invalid grid
             if (oldGridId != null)
             {
-                _transform.SetParent(entity, xform, _mapManager.GetMapEntityIdOrThrow(xform.MapID));
+                _transform.SetParent(entity, xform, xform.MapUid!.Value);
                 var ev = new ChangedGridEvent(entity, oldGridId, null);
                 RaiseLocalEvent(entity, ref ev);
             }

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -986,10 +986,23 @@ public abstract partial class SharedMapSystem
         // create an entire chunk for it.
         var gridChunkPos = GridTileToChunkIndices(uid, grid, pos);
 
-        if (!grid.Chunks.TryGetValue(gridChunkPos, out var chunk)) return Enumerable.Empty<EntityUid>();
+        if (!grid.Chunks.TryGetValue(gridChunkPos, out var chunk))
+            return Enumerable.Empty<EntityUid>();
 
         var chunkTile = chunk.GridTileToChunkTile(pos);
         return chunk.GetSnapGridCell((ushort)chunkTile.X, (ushort)chunkTile.Y);
+    }
+
+    public void GetAnchoredEntities(Entity<MapGridComponent> grid, Vector2i pos, List<EntityUid> list)
+    {
+        var gridChunkPos = GridTileToChunkIndices(grid.Owner, grid.Comp, pos);
+        if (!grid.Comp.Chunks.TryGetValue(gridChunkPos, out var chunk))
+            return;
+
+        var chunkTile = chunk.GridTileToChunkTile(pos);
+        var anchored = chunk.GetSnapGrid((ushort) chunkTile.X, (ushort) chunkTile.Y);
+        if (anchored != null)
+            list.AddRange(anchored);
     }
 
     public AnchoredEntitiesEnumerator GetAnchoredEntitiesEnumerator(EntityUid uid, MapGridComponent grid, Vector2i pos)

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -246,6 +246,39 @@ namespace Robust.Shared.GameObjects
             // We're on a grid, need to convert the coordinates to grid tiles.
             return _map.CoordinatesToTile(xform.GridUid.Value, Comp<MapGridComponent>(xform.GridUid.Value), xform.Coordinates);
         }
+
+        /// <summary>
+        /// Helper method that returns the grid tile an entity is on.
+        /// </summary>
+        public Vector2i GetGridTilePositionOrDefault(Entity<TransformComponent?> entity, MapGridComponent? grid = null)
+        {
+            var xform = entity.Comp;
+            if(!Resolve(entity.Owner, ref xform) || xform.GridUid == null)
+                return Vector2i.Zero;
+
+            if (!Resolve(xform.GridUid.Value, ref grid))
+                return Vector2i.Zero;
+
+            return _map.CoordinatesToTile(xform.GridUid.Value, grid, xform.Coordinates);
+        }
+
+        /// <summary>
+        /// Helper method that returns the grid tile an entity is on.
+        /// </summary>
+        public bool TryGetGridTilePosition(Entity<TransformComponent?> entity, out Vector2i indices, MapGridComponent? grid = null)
+        {
+            indices = default;
+            var xform = entity.Comp;
+            if(!Resolve(entity.Owner, ref xform) || xform.GridUid == null)
+                return false;
+
+            if (!Resolve(xform.GridUid.Value, ref grid))
+                return false;
+
+            indices = _map.CoordinatesToTile(xform.GridUid.Value, grid, xform.Coordinates);
+            return true;
+        }
+
     }
 
     [ByRefEvent]

--- a/Robust.Shared/Utility/CollectionExtensions.cs
+++ b/Robust.Shared/Utility/CollectionExtensions.cs
@@ -222,6 +222,17 @@ namespace Robust.Shared.Utility
             return entry!;
         }
 
+        public static TValue GetOrNew<TKey, TValue>(this Dictionary<TKey, TValue> dict, TKey key, out bool exists)
+            where TValue : new()
+            where TKey : notnull
+        {
+            ref var entry = ref CollectionsMarshal.GetValueRefOrAddDefault(dict, key, out exists);
+            if (!exists)
+                entry = new TValue();
+
+            return entry!;
+        }
+
         // More efficient than LINQ.
         public static KeyValuePair<TKey, TValue>[] ToArray<TKey, TValue>(this Dictionary<TKey, TValue> dict)
             where TKey : notnull


### PR DESCRIPTION
Adds some useful variants of existing methods:
- A variant of `GetGridOrMapTilePosition()` that returns early if the entity is not on a grid.
- A `GetAnchoredEntities()` variant that takes in a `List<EntityUid>`
- A `GetOrNew()` variant that returns a bool that indicates whether or not the entry already existed.