### PR TITLE
PVS pooling

### DIFF
--- a/Robust.Server/GameStates/PvsSystem.Deletion.cs
+++ b/Robust.Server/GameStates/PvsSystem.Deletion.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Robust.Server.GameStates;
+
+internal sealed partial class PvsSystem
+{
+    /// <summary>
+    /// History of deletion-tuples, containing the <see cref="GameTick"/> of the deletion, as well as the <see cref="TIndex"/> of the object which was deleted.
+    /// </summary>
+    private readonly List<(GameTick tick, NetEntity ent)> _deletionHistory = new();
+
+    /// <inheritdoc />
+    public void CullDeletionHistoryUntil(GameTick tick)
+    {
+        if (tick == GameTick.MaxValue)
+        {
+            _deletionHistory.Clear();
+            return;
+        }
+
+        for (var i = _deletionHistory.Count - 1; i >= 0; i--)
+        {
+            var hist = _deletionHistory[i].tick;
+            if (hist <= tick)
+            {
+                _deletionHistory.RemoveSwap(i);
+                if (_largestCulled < hist)
+                    _largestCulled = hist;
+            }
+        }
+    }
+
+    private GameTick _largestCulled;
+
+    public void GetDeletedEntities(GameTick fromTick, IList<NetEntity> ents)
+    {
+        if (fromTick == GameTick.Zero)
+            return;
+
+        // I'm 99% sure this can never happen, but it is hard to test real laggy/lossy networks with many players.
+        if (_largestCulled > fromTick)
+        {
+            Log.Error($"Culled required deletion history! culled: {_largestCulled}. requested: > {fromTick}");
+            _largestCulled = GameTick.Zero;
+        }
+
+        foreach (var (tick, id) in _deletionHistory)
+        {
+            if (tick > fromTick)
+                ents.Add(id);
+        }
+    }
+}

--- a/Robust.Server/GameStates/PvsSystem.Dirty.cs
+++ b/Robust.Server/GameStates/PvsSystem.Dirty.cs
@@ -18,8 +18,8 @@ namespace Robust.Server.GameStates
         /// <summary>
         /// if it's a new entity we need to GetEntityState from tick 0.
         /// </summary>
-        private HashSet<EntityUid>[] _addEntities = new HashSet<EntityUid>[DirtyBufferSize];
-        private HashSet<EntityUid>[] _dirtyEntities = new HashSet<EntityUid>[DirtyBufferSize];
+        private readonly HashSet<EntityUid>[] _addEntities = new HashSet<EntityUid>[DirtyBufferSize];
+        private readonly HashSet<EntityUid>[] _dirtyEntities = new HashSet<EntityUid>[DirtyBufferSize];
         private int _currentIndex = 1;
 
         private void InitializeDirty()

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -112,7 +112,7 @@ internal sealed partial class PvsSystem : EntitySystem
         new DefaultObjectPool<List<ComponentChange>>(new ListPolicy<ComponentChange>(), MaxVisPoolSize);
 
     private readonly ObjectPool<HashSet<ushort>> _netCompPool =
-        new DefaultObjectPool<HashSet<ushort>>(new SetPolicy<ushort>(), MaxVisPoolSize);
+        new DefaultObjectPool<HashSet<ushort>>(new SetPolicy<ushort>(), MaxVisPoolSize * 8);
 
     private readonly Dictionary<int, Dictionary<MapChunkLocation, int>> _mapIndices = new(4);
     private readonly Dictionary<int, Dictionary<GridChunkLocation, int>> _gridIndices = new(4);

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -839,7 +839,8 @@ internal sealed partial class PvsSystem : EntitySystem
             {
                 (uid, meta) = GetEntityData(netEntity);
                 changed = _compChangePool.Get();
-                entityStates.Add(GetFullEntityState(session, uid, meta, changed));
+                var netComps = _netCompPool.Get();
+                entityStates.Add(GetFullEntityState(session, uid, meta, netComps, changed));
                 continue;
             }
 
@@ -1294,10 +1295,14 @@ Transform last modified: {Transform(uid).LastModifiedTick}");
     /// <summary>
     ///     Variant of <see cref="GetEntityState"/> that includes all entity data, including data that can be inferred implicitly from the entity prototype.
     /// </summary>
-    private EntityState GetFullEntityState(ICommonSession player, EntityUid entityUid, MetaDataComponent meta, List<ComponentChange> changed)
+    private EntityState GetFullEntityState(
+        ICommonSession player,
+        EntityUid entityUid,
+        MetaDataComponent meta,
+        HashSet<ushort> netComps,
+        List<ComponentChange> changed)
     {
         var bus = EntityManager.EventBus;
-        var netComps = _netCompPool.Get();
 
         foreach (var (netId, component) in meta.NetComponents)
         {

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -109,7 +109,7 @@ namespace Robust.Server.GameStates
                 .Select(x => x.Key)
                 .Select(x => $"{x.Name} ({_entityManager.ToPrettyString(x.AttachedEntity)})");
 
-            var deletedNents = new List<NetEntity>();
+            var deletedNents = _nentListPool.Get();
             _pvs.GetDeletedEntities(GameTick.First, deletedNents);
 
             shell.WriteLine($@"Current tick: {_gameTiming.CurTick}
@@ -118,6 +118,8 @@ Deletion history size: {deletedNents.Count}
 Actual oldest: {ack}
 Oldest acked clients: {string.Join(", ", players)}
 ");
+            
+            _nentListPool.Return(deletedNents);
         }
 
         private void ResetParallelism()

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -68,7 +68,7 @@ namespace Robust.Server.GameStates
             new DefaultObjectPool<List<NetEntity>>(new ListPolicy<NetEntity>(), Environment.ProcessorCount * 4);
 
         private ObjectPool<List<EntityState>> _entStatePool =
-            new DefaultObjectPool<List<EntityState>>(new ListPolicy<EntityState>());
+            new DefaultObjectPool<List<EntityState>>(new ListPolicy<EntityState>(), Environment.ProcessorCount * 4);
 
         private ObjectPool<List<SessionState>> _playerStatePool =
             new DefaultObjectPool<List<SessionState>>(new ListPolicy<SessionState>());

--- a/Robust.Shared/GameObjects/EntityState.cs
+++ b/Robust.Shared/GameObjects/EntityState.cs
@@ -33,6 +33,23 @@ namespace Robust.Shared.GameObjects
             EntityLastModified = lastModified;
             NetComponents = netComps;
         }
+
+        public EntityState Clone()
+        {
+            HashSet<ushort>? netComps = null;
+
+            if (NetComponents?.Count == 0)
+            {
+                netComps = new HashSet<ushort>();
+                netComps.UnionWith(NetComponents);
+            }
+
+            return new EntityState(
+                NetEntity,
+                new List<ComponentChange>(ComponentChanges.Value),
+                EntityLastModified,
+                netComps);
+        }
     }
 
     [Serializable, NetSerializable]

--- a/Robust.Shared/Network/INetManager.cs
+++ b/Robust.Shared/Network/INetManager.cs
@@ -86,7 +86,8 @@ namespace Robust.Shared.Network
         /// </summary>
         /// <param name="message">Message to send.</param>
         /// <param name="recipient">Channel to send the message over.</param>
-        void ServerSendMessage(NetMessage message, INetChannel recipient);
+        /// <returns>True if the message is sent and can be disposed.</returns>
+        bool ServerSendMessage(NetMessage message, INetChannel recipient);
 
         /// <summary>
         ///     Sends a message to a collection of channels.

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -1013,7 +1013,7 @@ namespace Robust.Shared.Network
                 return;
 
             DebugTools.Assert(IsServer);
-            if (!(recipient is NetChannel channel))
+            if (recipient is not NetChannel channel)
                 throw new ArgumentException($"Not of type {typeof(NetChannel).FullName}", nameof(recipient));
 
             var peer = channel.Connection.Peer;

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -1005,12 +1005,12 @@ namespace Robust.Shared.Network
         }
 
         /// <inheritdoc />
-        public void ServerSendMessage(NetMessage message, INetChannel recipient)
+        public bool ServerSendMessage(NetMessage message, INetChannel recipient)
         {
             // TODO: Does the entity manager HAVE to shut down after network manager?
             // Though tbf theres no real point in sending messages anymore at that point.
             if (!_initialized)
-                return;
+                return true;
 
             DebugTools.Assert(IsServer);
             if (recipient is not NetChannel channel)
@@ -1024,6 +1024,7 @@ namespace Robust.Shared.Network
             var method = message.DeliveryMethod;
             peer.SendMessage(packet, channel.Connection, method);
             LogSend(message, method, packet);
+            return true;
         }
 
         private static void LogSend(NetMessage message, NetDeliveryMethod method, NetOutgoingMessage packet)

--- a/Robust.Shared/Player/ISharedPlayerManager.cs
+++ b/Robust.Shared/Player/ISharedPlayerManager.cs
@@ -115,7 +115,7 @@ public interface ISharedPlayerManager
 
     IEnumerable<SessionData> GetAllPlayerData();
 
-    List<SessionState>? GetPlayerStates(GameTick fromTick);
+    void GetPlayerStates(IList<SessionState> playerStates, GameTick fromTick);
     void UpdateState(ICommonSession commonSession);
 
     void RemoveSession(ICommonSession session, bool removeData = false);

--- a/Robust.Shared/Player/SharedPlayerManager.State.cs
+++ b/Robust.Shared/Player/SharedPlayerManager.State.cs
@@ -13,26 +13,28 @@ internal abstract partial class SharedPlayerManager
         LastStateUpdate = Timing.CurTick;
     }
 
-    public List<SessionState>? GetPlayerStates(GameTick fromTick)
+    public void GetPlayerStates(IList<SessionState> playerStates, GameTick fromTick)
     {
         if (LastStateUpdate < fromTick)
         {
-            return null;
+            return;
         }
 
         Lock.EnterReadLock();
         try
         {
 #if FULL_RELEASE
-                return InternalSessions.Values
-                    .Select(s => s.State)
-                    .ToList();
+            foreach (var ses in InternalSessions.Values)
+            {
+                playerStates.Add(ses.State);
+            }
 #else
             // Integration tests need to clone data before "sending" it to the client. Otherwise they reference the
             // same object.
-            return InternalSessions.Values
-                .Select(s => s.State.Clone())
-                .ToList();
+            foreach (var ses in InternalSessions.Values)
+            {
+                playerStates.Add(ses.State.Clone());
+            }
 #endif
         }
         finally

--- a/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
@@ -258,12 +258,6 @@ namespace Robust.UnitTesting
                     stateMsg._hasWritten = true;
                 }
 
-                // Clone as above because we don't write immediately in tests.
-                if (message is MsgStateLeavePvs leavePvs)
-                {
-                    leavePvs.Entities = new List<NetEntity>(leavePvs.Entities);
-                }
-
                 var channel = (IntegrationNetChannel) recipient;
                 channel.OtherChannel.TryWrite(new DataMessage(message, channel.RemoteUid));
                 return false;

--- a/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
@@ -297,6 +297,12 @@ namespace Robust.UnitTesting
                         deletions.Count == 0 ? null : deletions);
                 }
 
+                // Clone as above because we don't write immediately in tests.
+                if (message is MsgStateLeavePvs leavePvs)
+                {
+                    leavePvs.Entities = new List<NetEntity>(leavePvs.Entities);
+                }
+
                 var channel = (IntegrationNetChannel) recipient;
                 channel.OtherChannel.TryWrite(new DataMessage(message, channel.RemoteUid));
             }


### PR DESCRIPTION
- Pool a lot more stuff with PVS under the assumption once GameState / MsgState are serialized it's safe to fuck with it. I tried using Collections.Pooled although then you need IList and it becomes a lot more scrunkly with serializing it so I just kept using ObjectPool for now. Maybe someday it'd be better to swap as the pooled data could be re-used across more systems although this PVS data allocs to shit on live.
- Move _deletionHistory out of PVSCollection to PvsSystem with the goal of nuking RobustTree someday.
- Use 1 pool for RobustTree rather than pool per tree, at least until we kill it.

API is skrunkly though Leviathan is barely edging out over 30ms so maybe this will help it just stay under for a bit.