### PR TITLE
Add cvar for lidgren pool size

### DIFF
--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -55,7 +55,7 @@ namespace Robust.Shared
 
         /// <summary>
         /// Size of the pool for Lidgren's array buffers to send messages.
-        /// Set to 0 to disable pooling.
+        /// Set to 0 to disable pooling; max is 8192.
         /// </summary>
         /// <remarks>
         /// Higher just means more potentially wasted space and slower pool retrieval.

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -54,6 +54,15 @@ namespace Robust.Shared
             CVarDef.Create("net.receivebuffersize", 131071, CVar.ARCHIVE);
 
         /// <summary>
+        /// Size of the pool for Lidgren's array buffers to send messages.
+        /// </summary>
+        /// <remarks>
+        /// Set really high because it's probably constant across a server how much is getting used.
+        /// </remarks>
+        public static readonly CVarDef<int> NetPoolSize =
+            CVarDef.Create("net.pool_size", 512, CVar.CLIENT | CVar.SERVER);
+
+        /// <summary>
         /// Maximum UDP payload size to send.
         /// </summary>
         /// <seealso cref="NetMtuExpand"/>

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -55,9 +55,10 @@ namespace Robust.Shared
 
         /// <summary>
         /// Size of the pool for Lidgren's array buffers to send messages.
+        /// Set to 0 to disable pooling.
         /// </summary>
         /// <remarks>
-        /// Set really high because it's probably constant across a server how much is getting used.
+        /// Higher just means more potentially wasted space and slower pool retrieval.
         /// </remarks>
         public static readonly CVarDef<int> NetPoolSize =
             CVarDef.Create("net.pool_size", 512, CVar.CLIENT | CVar.SERVER);

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -576,6 +576,8 @@ namespace Robust.Shared.Network
             // ping the client once per second.
             netConfig.PingInterval = 1f;
 
+            netConfig.RecycledCacheMaxCount = _config.GetCVar(CVars.NetPoolSize);
+
             netConfig.SendBufferSize = _config.GetCVar(CVars.NetSendBufferSize);
             netConfig.ReceiveBufferSize = _config.GetCVar(CVars.NetReceiveBufferSize);
             netConfig.MaximumHandshakeAttempts = 5;

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -576,7 +576,16 @@ namespace Robust.Shared.Network
             // ping the client once per second.
             netConfig.PingInterval = 1f;
 
-            netConfig.RecycledCacheMaxCount = _config.GetCVar(CVars.NetPoolSize);
+            var poolSize = _config.GetCVar(CVars.NetPoolSize);
+
+            if (poolSize <= 0)
+            {
+                netConfig.UseMessageRecycling = false;
+            }
+            else
+            {
+                netConfig.RecycledCacheMaxCount = Math.Min(poolSize, 8192);
+            }
 
             netConfig.SendBufferSize = _config.GetCVar(CVars.NetSendBufferSize);
             netConfig.ReceiveBufferSize = _config.GetCVar(CVars.NetReceiveBufferSize);


### PR DESCRIPTION
Locally I've never seen this go above like 160-ish but just in case. On Lidgren's side the default is 64 which is frequently gone over.

In Lidgren the pool is a List<byte[]> and doesn't rely on the same objects being returned to the pool unlike ArrayPool.