### PR TITLE
Add new EnsureEntity variants

### DIFF
--- a/Robust.Shared.CompNetworkGenerator/ComponentNetworkGenerator.cs
+++ b/Robust.Shared.CompNetworkGenerator/ComponentNetworkGenerator.cs
@@ -167,7 +167,7 @@ namespace Robust.Shared.CompNetworkGenerator
                         getStateInit.Append($@"
                 {name} = GetNetEntitySet(component.{name}),");
                         handleStateSetters.Append($@"
-            component.{name} = EnsureEntitySet<{componentName}>(state.{name}, uid);");
+            EnsureEntitySet<{componentName}>(state.{name}, uid, component.{name});");
 
                         break;
                     case GlobalEntityUidListName:
@@ -177,7 +177,7 @@ namespace Robust.Shared.CompNetworkGenerator
                         getStateInit.Append($@"
                 {name} = GetNetEntityList(component.{name}),");
                         handleStateSetters.Append($@"
-            component.{name} = EnsureEntityList<{componentName}>(state.{name}, uid);");
+            EnsureEntityList<{componentName}>(state.{name}, uid, component.{name});");
 
                         break;
                     default:

--- a/Robust.Shared/GameObjects/EntityManager.Network.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Network.cs
@@ -256,8 +256,7 @@ public partial class EntityManager
     /// <inheritdoc />
     public HashSet<EntityUid> GetEntitySet(HashSet<NetEntity> netEntities)
     {
-        var entities = new HashSet<EntityUid>();
-        entities.EnsureCapacity(netEntities.Count);
+        var entities = new HashSet<EntityUid>(netEntities.Count);
 
         foreach (var netEntity in netEntities)
         {
@@ -292,6 +291,16 @@ public partial class EntityManager
         return entities;
     }
 
+    public void EnsureEntitySet<T>(HashSet<NetEntity> netEntities, EntityUid callerEntity, HashSet<EntityUid> entities)
+    {
+        entities.Clear();
+        entities.EnsureCapacity(netEntities.Count);
+        foreach (var netEntity in netEntities)
+        {
+            entities.Add(EnsureEntity<T>(netEntity, callerEntity));
+        }
+    }
+
     /// <inheritdoc />
     public List<EntityUid> EnsureEntityList<T>(List<NetEntity> netEntities, EntityUid callerEntity)
     {
@@ -303,6 +312,16 @@ public partial class EntityManager
         }
 
         return entities;
+    }
+
+    public void EnsureEntityList<T>(List<NetEntity> netEntities, EntityUid callerEntity, List<EntityUid> entities)
+    {
+        entities.Clear();
+        entities.EnsureCapacity(netEntities.Count);
+        foreach (var netEntity in netEntities)
+        {
+            entities.Add(EnsureEntity<T>(netEntity, callerEntity));
+        }
     }
 
     /// <inheritdoc />

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -1025,9 +1025,21 @@ public partial class EntitySystem
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected void EnsureEntitySet<T>(HashSet<NetEntity> netEntities, EntityUid callerEntity, HashSet<EntityUid> entities)
+    {
+        EntityManager.EnsureEntitySet<T>(netEntities, callerEntity, entities);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected List<EntityUid> EnsureEntityList<T>(List<NetEntity> netEntities, EntityUid callerEntity)
     {
         return EntityManager.EnsureEntityList<T>(netEntities, callerEntity);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected void EnsureEntityList<T>(List<NetEntity> netEntities, EntityUid callerEntity, List<EntityUid> entities)
+    {
+        EntityManager.EnsureEntityList<T>(netEntities, callerEntity, entities);
     }
 
     /// <summary>

--- a/Robust.Shared/Physics/Systems/SharedJointSystem.Relay.cs
+++ b/Robust.Shared/Physics/Systems/SharedJointSystem.Relay.cs
@@ -43,8 +43,7 @@ public abstract partial class SharedJointSystem
         if (args.Current is not JointRelayComponentState state)
             return;
 
-        component.Relayed.Clear();
-        component.Relayed.UnionWith(EnsureEntitySet<JointRelayTargetComponent>(state.Entities, uid));
+        EnsureEntitySet<JointRelayTargetComponent>(state.Entities, uid, component.Relayed);
     }
 
     private void OnRelayShutdown(EntityUid uid, JointRelayTargetComponent component, ComponentShutdown args)


### PR DESCRIPTION
Adds new variants of the `EnsureEntitySet` and `EnsureEntityList` methods that take in existing collections and makes the source generator use them.