### PR TITLE
Add more map system helper methods.

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -1292,6 +1292,9 @@ public abstract partial class SharedMapSystem
     }
 
     public Vector2i GridTileToChunkIndices(EntityUid uid, MapGridComponent grid, Vector2i gridTile)
+        => GridTileToChunkIndices(grid, gridTile);
+
+    public Vector2i GridTileToChunkIndices(MapGridComponent grid, Vector2i gridTile)
     {
         var x = (int)Math.Floor(gridTile.X / (float) grid.ChunkSize);
         var y = (int)Math.Floor(gridTile.Y / (float) grid.ChunkSize);
@@ -1331,6 +1334,36 @@ public abstract partial class SharedMapSystem
 
         var cTileIndices = chunk.GridTileToChunkTile(indices);
         tile = GetTileRef(uid, grid, chunk, (ushort)cTileIndices.X, (ushort)cTileIndices.Y);
+        return true;
+    }
+
+    public bool TryGetTile(MapGridComponent grid, Vector2i indices, out Tile tile)
+    {
+        var chunkIndices = GridTileToChunkIndices(grid, indices);
+        if (!grid.Chunks.TryGetValue(chunkIndices, out var chunk))
+        {
+            tile = default;
+            return false;
+        }
+
+        var cTileIndices = chunk.GridTileToChunkTile(indices);
+        tile = chunk.Tiles[cTileIndices.X, cTileIndices.Y];
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to get the <see cref="ITileDefinition"/> for a given grid index. This will throw an exception if the tile
+    /// at this location has no registered tile definition.
+    /// </summary>
+    public bool TryGetTileDef(MapGridComponent grid, Vector2i indices, [NotNullWhen(true)] out ITileDefinition? tileDef)
+    {
+        if (!TryGetTile(grid, indices, out var tile))
+        {
+            tileDef = null;
+            return false;
+        }
+
+        tileDef = _tileMan[tile.TypeId];
         return true;
     }
 

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -1352,8 +1352,8 @@ public abstract partial class SharedMapSystem
     }
 
     /// <summary>
-    /// Attempts to get the <see cref="ITileDefinition"/> for a given grid index. This will throw an exception if the tile
-    /// at this location has no registered tile definition.
+    /// Attempts to get the <see cref="ITileDefinition"/> for the tile at the given grid indices. This will throw an
+    /// exception if the tile at this location has no registered tile definition.
     /// </summary>
     public bool TryGetTileDef(MapGridComponent grid, Vector2i indices, [NotNullWhen(true)] out ITileDefinition? tileDef)
     {

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
@@ -12,6 +12,7 @@ namespace Robust.Shared.GameObjects
 {
     public abstract partial class SharedMapSystem : EntitySystem
     {
+        [Dependency] private readonly ITileDefinitionManager _tileMan = default!;
         [Dependency] private readonly IGameTiming _timing = default!;
         [Dependency] protected readonly IMapManager MapManager = default!;
         [Dependency] private readonly IMapManagerInternal _mapInternal = default!;

--- a/Robust.Shared/Map/ITileDefinitionManager.cs
+++ b/Robust.Shared/Map/ITileDefinitionManager.cs
@@ -30,6 +30,7 @@ namespace Robust.Shared.Map
         /// <param name="id">The ID of the tile definition.</param>
         /// <returns>The tile definition.</returns>
         ITileDefinition this[int id] { get; }
+        // TODO add a try get and get-or-null variant.
 
         /// <summary>
         ///     The number of tile definitions contained inside of this manager.


### PR DESCRIPTION
Adds `TryGetTile()` and `TryGetTileDef()` to get a tile or `ITileDefinition` from a set of grid indices. This can already be achieved by using `TryGetTileRef()` and manually getting the definition, but the new methods are more convenient and slightly faster.