### PR TITLE
Add entity gen to hashcode

### DIFF
--- a/Robust.Shared/GameObjects/EntityUid.cs
+++ b/Robust.Shared/GameObjects/EntityUid.cs
@@ -115,7 +115,10 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            return Id;
+            unchecked
+            {
+                return Id.GetHashCode() * 397 ^ Version.GetHashCode();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
A bunch of stuff legitimately breaks on content (I think mostly just tests and not the game?) so I need to fix that.