### PR TITLE
Fix audio position floating point imprecision

### DIFF
--- a/Robust.Client/Audio/AudioSystem.cs
+++ b/Robust.Client/Audio/AudioSystem.cs
@@ -314,6 +314,13 @@ public sealed partial class AudioSystem : SharedAudioSystem
         var delta = worldPos - listener.Position;
         var distance = delta.Length();
 
+        if (distance > 0f && distance < 0.01f)
+        {
+            worldPos = listener.Position;
+            delta = Vector2.Zero;
+            distance = 0f;
+        }
+
         // Out of range so just clip it for us.
         if (distance > component.MaxDistance)
         {

--- a/Robust.Client/Audio/Midi/MidiManager.cs
+++ b/Robust.Client/Audio/Midi/MidiManager.cs
@@ -442,6 +442,14 @@ internal sealed partial class MidiManager : IMidiManager
                 return;
             }
 
+            // Same imprecision suppression as audiosystem.
+            if (distance > 0f && distance < 0.01f)
+            {
+                worldPos = listener.Position;
+                delta = Vector2.Zero;
+                distance = 0f;
+            }
+
             renderer.Source.Position = worldPos;
 
             // Update velocity (doppler).


### PR DESCRIPTION
I still want to try relative audio I think but this fixes oddities now that it's not being hidden by the attenuation setting.