### PR TITLE
Nuke some non-approx grid queries

### DIFF
--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -40,7 +40,7 @@ public sealed partial class EntityLookupSystem
 
                     tuple.intersecting.Add(value.Entity);
                     return true;
-                }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+                }, localAABB, true);
         }
 
         if ((flags & LookupFlags.Static) != 0x0)
@@ -53,7 +53,7 @@ public sealed partial class EntityLookupSystem
 
                     tuple.intersecting.Add(value.Entity);
                     return true;
-                }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+                }, localAABB, true);
         }
 
         if ((flags & LookupFlags.StaticSundries) == LookupFlags.StaticSundries)
@@ -63,7 +63,7 @@ public sealed partial class EntityLookupSystem
                 {
                     state.Add(value);
                     return true;
-                }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+                }, localAABB, true);
         }
 
         if ((flags & LookupFlags.Sundries) != 0x0)
@@ -73,7 +73,7 @@ public sealed partial class EntityLookupSystem
                 {
                     state.Add(value);
                     return true;
-                }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+                }, localAABB, true);
         }
     }
 
@@ -109,7 +109,7 @@ public sealed partial class EntityLookupSystem
 
                 tuple.found = true;
                 return false;
-            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+            }, localAABB, true);
 
             if (state.found)
                 return true;
@@ -124,7 +124,7 @@ public sealed partial class EntityLookupSystem
 
                 tuple.found = true;
                 return false;
-            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+            }, localAABB, true);
 
             if (state.found)
                 return true;
@@ -139,7 +139,7 @@ public sealed partial class EntityLookupSystem
 
                 tuple.found = true;
                 return false;
-            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+            }, localAABB, true);
 
             if (state.found)
                 return true;
@@ -154,7 +154,7 @@ public sealed partial class EntityLookupSystem
 
                 tuple.found = true;
                 return false;
-            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+            }, localAABB, true);
         }
 
         return state.found;
@@ -270,7 +270,7 @@ public sealed partial class EntityLookupSystem
 
                 tuple.found = true;
                 return false;
-            });
+            }, approx: true);
 
         if (state.found)
             return true;
@@ -314,7 +314,7 @@ public sealed partial class EntityLookupSystem
                 }
 
                 return true;
-            });
+            }, approx: true);
 
         // Get map entities
         var mapUid = _mapManager.GetMapEntityId(mapId);
@@ -345,7 +345,7 @@ public sealed partial class EntityLookupSystem
                     return false;
                 }
                 return true;
-            });
+            }, approx: true);
 
         if (state.found)
             return true;
@@ -373,7 +373,7 @@ public sealed partial class EntityLookupSystem
         {
             tuple.lookup.AddEntitiesIntersecting(uid, tuple.intersecting, tuple.worldBounds, tuple.flags);
             return true;
-        });
+        }, approx: true);
 
         // Get map entities
         var mapUid = _mapManager.GetMapEntityId(mapId);
@@ -411,7 +411,7 @@ public sealed partial class EntityLookupSystem
                 }
 
                 return true;
-            });
+            }, approx: true);
 
         var mapUid = _mapManager.GetMapEntityId(mapID);
         return AnyEntitiesIntersecting(mapUid, worldAABB, flags, uid);
@@ -446,7 +446,7 @@ public sealed partial class EntityLookupSystem
             }
 
             return true;
-        });
+        }, approx: true);
 
         var mapUid = _mapManager.GetMapEntityId(mapPos.MapId);
         return AnyEntitiesIntersecting(mapUid, worldAABB, flags, uid);
@@ -646,7 +646,7 @@ public sealed partial class EntityLookupSystem
                     }
 
                     return true;
-                }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+                }, localAABB, true);
         }
 
         if ((flags & LookupFlags.Static) != 0x0)
@@ -661,7 +661,7 @@ public sealed partial class EntityLookupSystem
                     }
 
                     return true;
-                }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+                }, localAABB, true);
         }
 
         if ((flags & LookupFlags.StaticSundries) == LookupFlags.StaticSundries)
@@ -752,7 +752,7 @@ public sealed partial class EntityLookupSystem
             {
                 tuple.callback(uid, tuple._broadQuery.GetComponent(uid));
                 return true;
-            });
+            }, approx: true);
     }
 
     #endregion

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.ComponentQueries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.ComponentQueries.cs
@@ -40,7 +40,7 @@ public sealed partial class EntityLookupSystem
 
                 tuple.intersecting.Add((value.Entity, comp));
                 return true;
-            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+            }, localAABB, true);
         }
 
         if ((flags & (LookupFlags.Static)) != 0x0)
@@ -52,7 +52,7 @@ public sealed partial class EntityLookupSystem
 
                 tuple.intersecting.Add((value.Entity, comp));
                 return true;
-            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+            }, localAABB, true);
         }
 
         if ((flags & LookupFlags.StaticSundries) == LookupFlags.StaticSundries)
@@ -64,7 +64,7 @@ public sealed partial class EntityLookupSystem
 
                 tuple.intersecting.Add((value, comp));
                 return true;
-            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+            }, localAABB, true);
         }
 
         if ((flags & LookupFlags.Sundries) != 0x0)
@@ -76,7 +76,7 @@ public sealed partial class EntityLookupSystem
 
                 tuple.intersecting.Add((value, comp));
                 return true;
-            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+            }, localAABB, true);
         }
     }
 
@@ -123,7 +123,7 @@ public sealed partial class EntityLookupSystem
 
                 state.Intersecting.Add((value.Entity, comp));
                 return true;
-            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+            }, localAABB, true);
         }
 
         if ((flags & (LookupFlags.Static)) != 0x0)
@@ -144,7 +144,7 @@ public sealed partial class EntityLookupSystem
 
                 state.Intersecting.Add((value.Entity, comp));
                 return true;
-            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+            }, localAABB, true);
         }
 
         if ((flags & LookupFlags.StaticSundries) == LookupFlags.StaticSundries)
@@ -184,7 +184,7 @@ public sealed partial class EntityLookupSystem
                     state.Intersecting.Add((value, comp));
 
                 return true;
-            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+            }, localAABB, true);
         }
 
         if ((flags & LookupFlags.Sundries) != 0x0)
@@ -225,7 +225,7 @@ public sealed partial class EntityLookupSystem
                     state.Intersecting.Add((value, comp));
 
                 return true;
-            }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+            }, localAABB, true);
         }
     }
 
@@ -251,7 +251,7 @@ public sealed partial class EntityLookupSystem
 
                     tuple.found = true;
                     return false;
-                }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+                }, localAABB, true);
 
             if (state.found)
                 return true;
@@ -267,7 +267,7 @@ public sealed partial class EntityLookupSystem
 
                     tuple.found = true;
                     return false;
-                }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+                }, localAABB, true);
 
             if (state.found)
                 return true;
@@ -283,7 +283,7 @@ public sealed partial class EntityLookupSystem
 
                     tuple.found = true;
                     return false;
-                }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+                }, localAABB, true);
 
             if (state.found)
                 return true;
@@ -299,7 +299,7 @@ public sealed partial class EntityLookupSystem
 
                     tuple.found = true;
                     return false;
-                }, localAABB, (flags & LookupFlags.Approximate) != 0x0);
+                }, localAABB, true);
         }
 
         return state.found;
@@ -439,7 +439,7 @@ public sealed partial class EntityLookupSystem
                         return true;
                     tuple.found = true;
                     return false;
-                }, (flags & LookupFlags.Approximate) != 0x0);
+                }, approx: true);
 
             // Get map entities
             var mapUid = _mapManager.GetMapEntityId(mapId);
@@ -489,7 +489,7 @@ public sealed partial class EntityLookupSystem
                 {
                     tuple.system.AddEntitiesIntersecting(uid, tuple.intersecting, tuple.worldAABB, tuple.flags, tuple.query);
                     return true;
-                }, (flags & LookupFlags.Approximate) != 0x0);
+                }, approx: true);
 
             // Get map entities
             var mapUid = _mapManager.GetMapEntityId(mapId);
@@ -529,7 +529,7 @@ public sealed partial class EntityLookupSystem
                 {
                     tuple.system.AddEntitiesIntersecting(uid, tuple.intersecting, tuple.worldAABB, tuple.flags, tuple.query);
                     return true;
-                }, (flags & LookupFlags.Approximate) != 0x0);
+                }, approx: true);
 
             // Get map entities
             var mapUid = _mapManager.GetMapEntityId(mapId);
@@ -609,7 +609,7 @@ public sealed partial class EntityLookupSystem
                 {
                     state.Lookup.AddEntitiesIntersecting(uid, state.Intersecting, state.Shape, state.WorldAABB, state.Flags, state.Query);
                     return true;
-                }, (flags & LookupFlags.Approximate) != 0x0);
+                }, approx: true);
 
             // Get map entities
             var mapUid = _mapManager.GetMapEntityId(mapId);
@@ -684,7 +684,7 @@ public sealed partial class EntityLookupSystem
                 {
                     tuple.system.AddEntitiesIntersecting(uid, tuple.intersecting, tuple.shape, tuple.worldAABB, tuple.flags, tuple.query);
                     return true;
-                }, (flags & LookupFlags.Approximate) != 0x0);
+                }, approx: true);
 
             // Get map entities
             var mapUid = _mapManager.GetMapEntityId(mapId);

--- a/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
@@ -520,7 +520,7 @@ namespace Robust.Shared.Physics.Systems
                         ref var buffer = ref tuple.pairBuffer;
                         tuple.system.FindPairs(tuple.proxy, tuple.worldAABB, uid, buffer);
                         return true;
-                    });
+                    }, approx: true, includeMap: false);
 
                 // Struct ref moment, I have no idea what's fastest.
                 buffer = state.buffer;


### PR DESCRIPTION
They should just be calling TestOverlap with shapes and not this whacky-ass hook that dynamictree has. I also fixed the most expensive victims of this.

See https://github.com/space-wizards/RobustToolbox/issues/4636 for what needs doing.