### PR TITLE
Possible fix to some audio issues

### DIFF
--- a/Robust.Client/Audio/Sources/BaseAudioSource.cs
+++ b/Robust.Client/Audio/Sources/BaseAudioSource.cs
@@ -190,7 +190,7 @@ internal abstract class BaseAudioSource : IAudioSource
                 AL.GetSource(SourceHandle, ALSourcef.Gain, out var priorGain);
                 priorOcclusion = priorGain / _gain;
                 if (Double.IsNaN(priorOcclusion)) {
-                    priorOcclusion = 1f
+                    priorOcclusion = 1f;
                 }
             }
 

--- a/Robust.Client/Audio/Sources/BaseAudioSource.cs
+++ b/Robust.Client/Audio/Sources/BaseAudioSource.cs
@@ -188,7 +188,7 @@ internal abstract class BaseAudioSource : IAudioSource
             if (!IsEfxSupported)
             {
                 AL.GetSource(SourceHandle, ALSourcef.Gain, out var priorGain);
-                priorOcclusion = _gain == 0 ? 1f : priorGain / _gain;
+                priorOcclusion = _gain == 0 ? 0.5f : priorGain / _gain;
             }
 
             _gain = value;

--- a/Robust.Client/Audio/Sources/BaseAudioSource.cs
+++ b/Robust.Client/Audio/Sources/BaseAudioSource.cs
@@ -189,6 +189,9 @@ internal abstract class BaseAudioSource : IAudioSource
             {
                 AL.GetSource(SourceHandle, ALSourcef.Gain, out var priorGain);
                 priorOcclusion = priorGain / _gain;
+                if (Double.IsNaN(priorOcclusion)) {
+                    priorOcclusion = 1f
+                }
             }
 
             _gain = value;

--- a/Robust.Client/Audio/Sources/BaseAudioSource.cs
+++ b/Robust.Client/Audio/Sources/BaseAudioSource.cs
@@ -188,10 +188,7 @@ internal abstract class BaseAudioSource : IAudioSource
             if (!IsEfxSupported)
             {
                 AL.GetSource(SourceHandle, ALSourcef.Gain, out var priorGain);
-                priorOcclusion = priorGain / _gain;
-                if (Double.IsNaN(priorOcclusion)) {
-                    priorOcclusion = 1f;
-                }
+                priorOcclusion = _gain == 0 ? 1f : priorGain / _gain
             }
 
             _gain = value;

--- a/Robust.Client/Audio/Sources/BaseAudioSource.cs
+++ b/Robust.Client/Audio/Sources/BaseAudioSource.cs
@@ -188,7 +188,7 @@ internal abstract class BaseAudioSource : IAudioSource
             if (!IsEfxSupported)
             {
                 AL.GetSource(SourceHandle, ALSourcef.Gain, out var priorGain);
-                priorOcclusion = _gain == 0 ? 1f : priorGain / _gain
+                priorOcclusion = _gain == 0 ? 1f : priorGain / _gain;
             }
 
             _gain = value;


### PR DESCRIPTION
Whenever the gain in is set here to 0 https://github.com/space-wizards/RobustToolbox/blob/f5a2a710f0b4555620674509607293602cf0685a/Robust.Client/Audio/Sources/BaseAudioSource.cs#L175-L196
(As it does on audio startup here)
https://github.com/space-wizards/RobustToolbox/blob/f5a2a710f0b4555620674509607293602cf0685a/Robust.Client/Audio/AudioSystem.cs#L168-L169


_gain would be set to 0 and any next attempt to set the gain would encounter a division by zero and leave the volume muted. This is a proposed fix to the problem but I'm not sure if it would leave the audio stronger then it should. Would appreciate if more people could test this locally.  
When I tested it on my machine it fixed announcement sounds and ambient sounds that didn't work before.
My only guess on why some sounds are working and some aren't is because parallelism? But I'm not savvy enough in the codebase to figure out if that's logical or not