### PR TITLE
Don't stop playing audio on game disposal

### DIFF
--- a/Robust.Client/Audio/AudioManager.Public.cs
+++ b/Robust.Client/Audio/AudioManager.Public.cs
@@ -324,7 +324,6 @@ internal partial class AudioManager
         {
             if (source.TryGetTarget(out var target))
             {
-                target.Playing = false;
                 target.Dispose();
             }
         }
@@ -335,7 +334,6 @@ internal partial class AudioManager
         {
             if (source.TryGetTarget(out var target))
             {
-                target.Playing = false;
                 target.Dispose();
             }
         }


### PR DESCRIPTION
Buffered audio is stopped / disposed elsewhere so this will just throw.