### PR TITLE
Update map physics after events

### DIFF
--- a/Robust.Shared/Physics/PhysicsWakeEvent.cs
+++ b/Robust.Shared/Physics/PhysicsWakeEvent.cs
@@ -1,11 +1,16 @@
 using Robust.Shared.GameObjects;
 using Robust.Shared.Physics.Components;
 
-namespace Robust.Shared.Physics
-{
-    [ByRefEvent]
-    public readonly record struct PhysicsWakeEvent(EntityUid Entity, PhysicsComponent Body);
+namespace Robust.Shared.Physics;
 
-    [ByRefEvent]
-    public readonly record struct PhysicsSleepEvent(EntityUid Entity, PhysicsComponent Body);
-}
+[ByRefEvent]
+public readonly record struct PhysicsWakeEvent(EntityUid Entity, PhysicsComponent Body);
+
+[ByRefEvent]
+public record struct PhysicsSleepEvent(EntityUid Entity, PhysicsComponent Body)
+{
+    /// <summary>
+    /// Marks the entity as still being awake and cancels sleeping.
+    /// </summary>
+    public bool Cancelled;
+};

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
@@ -399,11 +399,28 @@ public partial class SharedPhysicsSystem
         {
             var ev = new PhysicsSleepEvent(uid, body);
             RaiseLocalEvent(uid, ref ev, true);
+
+            // Reset the sleep timer.
+            if (ev.Cancelled)
+            {
+                if (updateSleepTime)
+                    SetSleepTime(body, 0);
+
+                return;
+            }
+
             ResetDynamics(body);
         }
 
         if (updateSleepTime)
             SetSleepTime(body, 0);
+
+        if (body.Awake != value)
+        {
+            Log.Error($"Found a corrupted physics awake state for {ToPrettyString(ent)}! Did you forget to cancel the sleep subscription? Forcing body awake");
+            DebugTools.Assert(false);
+            body.Awake = true;
+        }
 
         UpdateMapAwakeState(uid, body);
         Dirty(ent);

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
@@ -405,6 +405,7 @@ public partial class SharedPhysicsSystem
         if (updateSleepTime)
             SetSleepTime(body, 0);
 
+        UpdateMapAwakeState(uid, body);
         Dirty(ent);
     }
 

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
@@ -75,8 +75,6 @@ namespace Robust.Shared.Physics.Systems
             _xformQuery = GetEntityQuery<TransformComponent>();
 
             SubscribeLocalEvent<GridAddEvent>(OnGridAdd);
-            SubscribeLocalEvent<PhysicsWakeEvent>(OnWake);
-            SubscribeLocalEvent<PhysicsSleepEvent>(OnSleep);
             SubscribeLocalEvent<CollisionChangeEvent>(OnCollisionChange);
             SubscribeLocalEvent<PhysicsComponent, EntGotRemovedFromContainerMessage>(HandleContainerRemoved);
             SubscribeLocalEvent<EntParentChangedMessage>(OnParentChange);
@@ -254,26 +252,20 @@ namespace Robust.Shared.Physics.Systems
             _configManager.UnsubValueChanged(CVars.AutoClearForces, OnAutoClearChange);
         }
 
-        private void OnWake(ref PhysicsWakeEvent @event)
+        private void UpdateMapAwakeState(EntityUid uid, PhysicsComponent body)
         {
-            var mapId = EntityManager.GetComponent<TransformComponent>(@event.Entity).MapID;
-
+            var mapId = EntityManager.GetComponent<TransformComponent>(uid).MapID;
             if (mapId == MapId.Nullspace)
                 return;
-
             var tempQualifier = _mapManager.GetMapEntityId(mapId);
-            AddAwakeBody(@event.Entity, @event.Body, tempQualifier);
-        }
-
-        private void OnSleep(ref PhysicsSleepEvent @event)
-        {
-            var mapId = EntityManager.GetComponent<TransformComponent>(@event.Entity).MapID;
-
-            if (mapId == MapId.Nullspace)
-                return;
-
-            var tempQualifier = _mapManager.GetMapEntityId(mapId);
-            RemoveSleepBody(@event.Entity, @event.Body, tempQualifier);
+            if (body.Awake)
+            {
+                AddAwakeBody(uid, body, tempQualifier);
+            }
+            else
+            {
+                RemoveSleepBody(uid, body, tempQualifier);
+            }
         }
 
         private void HandleContainerRemoved(EntityUid uid, PhysicsComponent physics, EntGotRemovedFromContainerMessage message)


### PR DESCRIPTION
This should fix: https://github.com/space-wizards/space-station-14/issues/21747

See: https://discord.com/channels/310555209753690112/560845886263918612/1181065068557893773

TLDR is:
- Throw system wakes up physics when it's being slept
- Which can sometimes cause the map to lose track of what is actually awake

This is a bit of a bandaid fix, but it makes nested events with physics a bit more reasonable.

(My first contribution to engine, so let me know if I'm messed up something wack)