### PR TITLE
Tweaked how ExpandPvsEvent is raised

### DIFF
--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -807,7 +807,7 @@ internal sealed partial class PvsSystem : EntitySystem
         var expandEvent = new ExpandPvsEvent(session);
 
         if (session.AttachedEntity != null)
-            RaiseLocalEvent(session.AttachedEntity.Value, ref expandEvent);
+            RaiseLocalEvent(session.AttachedEntity.Value, ref expandEvent, true);
 
         if (expandEvent.Entities != null)
         {

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -808,6 +808,8 @@ internal sealed partial class PvsSystem : EntitySystem
 
         if (session.AttachedEntity != null)
             RaiseLocalEvent(session.AttachedEntity.Value, ref expandEvent, true);
+        else
+            RaiseLocalEvent(ref expandEvent);
 
         if (expandEvent.Entities != null)
         {

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -807,7 +807,7 @@ internal sealed partial class PvsSystem : EntitySystem
         var expandEvent = new ExpandPvsEvent(session);
 
         if (session.AttachedEntity != null)
-            RaiseLocalEvent(session.AttachedEntity.Value, ref expandEvent, true);
+            RaiseLocalEvent(session.AttachedEntity.Value, ref expandEvent);
 
         if (expandEvent.Entities != null)
         {

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -805,7 +805,10 @@ internal sealed partial class PvsSystem : EntitySystem
         }
 
         var expandEvent = new ExpandPvsEvent(session);
-        RaiseLocalEvent(ref expandEvent);
+
+        if (session.AttachedEntity != null)
+            RaiseLocalEvent(session.AttachedEntity.Value, ref expandEvent, true);
+
         if (expandEvent.Entities != null)
         {
             foreach (var entityUid in expandEvent.Entities)


### PR DESCRIPTION
Changes how ExpandPvsEvent is raised; it's now raised on the session's attached entity

Shouldn't cause any issues, as nothing is subscribed to this event

Required for #20927