### PR TITLE
pvs5 (pfives)

### DIFF
--- a/Robust.Server/GameStates/PvsSystem.Ack.cs
+++ b/Robust.Server/GameStates/PvsSystem.Ack.cs
@@ -1,4 +1,7 @@
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Player;
 using Robust.Shared.Threading;
@@ -29,10 +32,14 @@ internal sealed partial class PvsSystem
     /// <summary>
     ///     Processes queued client acks in parallel
     /// </summary>
-    internal void ProcessQueuedAcks()
+    internal WaitHandle ProcessQueuedAcks()
     {
         if (PendingAcks.Count == 0)
-            return;
+        {
+            var slim = new ManualResetEventSlim();
+            slim.Set();
+            return slim.WaitHandle;
+        }
 
         _toAck.Clear();
 
@@ -41,8 +48,9 @@ internal sealed partial class PvsSystem
             _toAck.Add(session);
         }
 
-        _parallelManager.ProcessNow(_ackJob, _toAck.Count);
+        var handle = _parallelManager.Process(_ackJob, _toAck.Count);
         PendingAcks.Clear();
+        return handle;
     }
 
     private record struct PvsAckJob : IParallelRobustJob

--- a/Robust.Server/GameStates/PvsSystem.Chunksets.cs
+++ b/Robust.Server/GameStates/PvsSystem.Chunksets.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+using Robust.Shared.Threading;
+
+namespace Robust.Server.GameStates;
+
+internal sealed partial class PvsSystem
+{
+    public WaitHandle ProcessDynamicChunksets()
+    {
+        // TODO: Get viewers
+        // TODO: Get AABBs
+        // TODO: Get chunks in range
+        // TODO: Use vismask and get chunksets
+        var job = new DynamicChunksetJob();
+        var handle = _parallelManager.Process(job, 1);
+        return handle;
+    }
+
+    private record struct DynamicChunksetJob : IParallelRobustJob
+    {
+        public int BatchSize => 1;
+
+        public void Execute(int index)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Draft but I want to work on it over xmas.

Goal is to combine current pvs and last pvs (anchoring). Roughly 3/4 of all entities in range (approx. 2k on average) are anchored and we used to have a fast path for this where we can make assumptions that let us skip iterating large numbers of entities for compstates and just for hierarchy traversal in general.

Additionally, by splitting we can potentially bump the pvs range for static bodies and fix several audio and lighting issues as well as help alleviate client stuttering (remember when the client didn't stutter on entity popin?) without also requiring the much-needed entity init refactor.

The main advantage current pvs brought was removing unnecessary dictionary.FindValues and let us hit 200 pop though the dictionary creep addressing more and more bugs has hit it particularly hard.

Anchoring was pretty fast but at the time we were still doing per-player work for entitylookups which limited it. Now with chunking players in range it should be able to get much faster.

My rough outline on discord https://discord.com/channels/310555209753690112/1153246232064569394/1181760500137197708