### PR TITLE
Fix client-side entity error spam

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -185,7 +185,7 @@ namespace Robust.Client.GameStates
                 return;
 
             _sawmill.Error($"""
-                Added component {comp.Name} with net id {comp.NetID} while resetting predicted entities.
+                Added component {comp.Name} to entity {_entityManager.ToPrettyString(args.BaseArgs.Owner)} while resetting predicted entities.
                 Stack trace:
                 {Environment.StackTrace}
                 """);

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -174,19 +174,21 @@ namespace Robust.Client.GameStates
 
         private void OnComponentAdded(AddedComponentEventArgs args)
         {
-            if (_resettingPredictedEntities)
-            {
-                var comp = args.ComponentType;
+            if (!_resettingPredictedEntities)
+                return;
 
-                if (comp.NetID == null)
-                    return;
+            var comp = args.ComponentType;
+            if (comp.NetID == null)
+                return;
 
-                _sawmill.Error($"""
-                    Added component {comp.Name} with net id {comp.NetID} while resetting predicted entities.
-                    Stack trace:
-                    {Environment.StackTrace}
-                    """);
-            }
+            if (_entityManager.IsClientSide(args.BaseArgs.Owner))
+                return;
+
+            _sawmill.Error($"""
+                Added component {comp.Name} with net id {comp.NetID} while resetting predicted entities.
+                Stack trace:
+                {Environment.StackTrace}
+                """);
         }
 
         /// <inheritdoc />

--- a/Robust.Client/UserInterface/Controls/SpriteView.cs
+++ b/Robust.Client/UserInterface/Controls/SpriteView.cs
@@ -135,7 +135,7 @@ namespace Robust.Client.UserInterface.Controls
             if (!_entMan.TryGetComponent(uid, out SpriteComponent? sprite)
                 || !_entMan.TryGetComponent(uid, out TransformComponent? xform))
             {
-                SetEntity(null);
+                Entity = null;
                 return;
             }
 


### PR DESCRIPTION
Checks if the entity is a client-side entity before logging an error.
also fixes a recursion bug added in #4584. 