### PR TITLE
Stop terminating entities from being prematurely detached to nullspace

### DIFF
--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -1102,8 +1102,13 @@ internal sealed partial class PvsSystem : EntitySystem
         if (metaDataComponent.EntityLifeStage >= EntityLifeStage.Terminating)
         {
             toSend.Remove(netEntity);
-            var rep = new EntityStringRepresentation(GetEntity(netEntity), metaDataComponent.EntityDeleted, metaDataComponent.EntityName, metaDataComponent.EntityPrototype?.ID);
-            Log.Error($"Attempted to add a deleted entity to PVS send set: '{rep}'. Trace:\n{Environment.StackTrace}");
+            var ent = GetEntity(netEntity);
+            var rep = new EntityStringRepresentation(ent, metaDataComponent.EntityDeleted, metaDataComponent.EntityName, metaDataComponent.EntityPrototype?.ID);
+            Log.Error($"Attempted to add a deleted entity to PVS send set: '{rep}'. Deletion queued: {EntityManager.IsQueuedForDeletion(ent)}. Trace:\n{Environment.StackTrace}");
+
+            // This can happen if some entity was some removed from it's parent while that parent was being deleted.
+            // As a result the entity was marked for deletion but was never actually properly deleted.
+            EntityManager.QueueDeleteEntity(ent);
             return;
         }
 

--- a/Robust.Shared/Containers/BaseContainer.cs
+++ b/Robust.Shared/Containers/BaseContainer.cs
@@ -294,7 +294,14 @@ namespace Robust.Shared.Containers
                 return false;
             }
 
-            DebugTools.Assert(meta.EntityLifeStage < EntityLifeStage.Terminating || (force && !reparent));
+            // Terminating entities should not get re-parented. However, this removal will still be forced when
+            // detaching to null-space just before deletion happens.
+            if (meta.EntityLifeStage >= EntityLifeStage.Terminating && (!force || reparent))
+            {
+                Logger.Error($"Attempting to remove an entity from a container while it is terminating. Entity: {entMan.ToPrettyString(toRemove, meta)}. Container: {entMan.ToPrettyString(Owner)}. Trace: {{Environment.StackTrace}}");
+                return false;
+            }
+
             DebugTools.Assert(xform.Broadphase == null || !xform.Broadphase.Value.IsValid());
             DebugTools.Assert(!xform.Anchored);
             DebugTools.Assert((meta.Flags & MetaDataFlags.InContainer) != 0x0);

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -415,7 +415,7 @@ namespace Robust.Shared.GameObjects
             EntityUid uid,
             MetaDataComponent metadata)
         {
-            var transform = TransformQuery.GetComponent(uid);
+            DebugTools.Assert(metadata.EntityLifeStage < EntityLifeStage.Terminating);
             metadata.EntityLifeStage = EntityLifeStage.Terminating;
 
             try
@@ -428,6 +428,7 @@ namespace Robust.Shared.GameObjects
                 _sawmill.Error($"Caught exception while raising event {nameof(EntityTerminatingEvent)} on entity {ToPrettyString(uid, metadata)}\n{e}");
             }
 
+            var transform = TransformQuery.GetComponent(uid);
             foreach (var child in transform._children)
             {
                 if (!MetaQuery.TryGetComponent(child, out var childMeta) || childMeta.EntityDeleted)
@@ -458,7 +459,7 @@ namespace Robust.Shared.GameObjects
             {
                 try
                 {
-                    _xforms.DetachParentToNull(uid, transform, parentXform);
+                    _xforms.DetachParentToNull((uid, transform, metadata), parentXform, true);
                 }
                 catch (Exception e)
                 {

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -1286,10 +1286,7 @@ public abstract partial class SharedTransformSystem
     /// Attempts to re-parent the given entity to the grid or map that the entity is on.
     /// If no valid map or grid is found, this will detach the entity to null-space and queue it for deletion.
     /// </summary>
-    /// <param name="uid">The Entity</param>
-    /// <param name="xform">The entity's transform component</param>
-    /// <param name="delete">Whether to delete the entity if no valid map or grid is found.</param>
-    public void AttachToGridOrMap(EntityUid uid, TransformComponent? xform = null, bool delete = true)
+    public void AttachToGridOrMap(EntityUid uid, TransformComponent? xform = null)
     {
         if (TerminatingOrDeleted(uid))
             return;
@@ -1318,10 +1315,6 @@ public abstract partial class SharedTransformSystem
                 Log.Warning($"Failed to attach entity to map or grid. Entity: ({ToPrettyString(uid)}). Trace: {Environment.StackTrace}");
 
             DetachParentToNull(uid, xform);
-
-            if (delete)
-                QueueDel(uid);
-
             return;
         }
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -1301,8 +1301,8 @@ public abstract partial class SharedTransformSystem
             return;
 
         EntityUid newParent;
-        var oldPos = GetWorldPosition(xform, XformQuery);
-        if (_mapManager.TryFindGridAt(xform.MapID, oldPos, XformQuery, out var gridUid, out _)
+        var oldPos = GetWorldPosition(xform);
+        if (_mapManager.TryFindGridAt(xform.MapID, oldPos, out var gridUid, out _)
             && !TerminatingOrDeleted(gridUid))
         {
             newParent = gridUid;
@@ -1317,17 +1317,18 @@ public abstract partial class SharedTransformSystem
             if (!_mapManager.IsMap(uid))
                 Log.Warning($"Failed to attach entity to map or grid. Entity: ({ToPrettyString(uid)}). Trace: {Environment.StackTrace}");
 
+            DetachParentToNull(uid, xform);
+
             if (delete)
                 QueueDel(uid);
 
-            DetachParentToNull(uid, xform);
             return;
         }
 
-        if (newParent == xform.ParentUid)
+        if (newParent == xform.ParentUid || newParent == uid)
             return;
 
-        var newPos = GetInvWorldMatrix(newParent, XformQuery).Transform(oldPos);
+        var newPos = GetInvWorldMatrix(newParent).Transform(oldPos);
         SetCoordinates(uid, xform, new(newParent, newPos));
     }
 


### PR DESCRIPTION
Its currently possible for entities that are being deleted to prematurely detached to null-space when their parent entity gets deleted. i.e., after getting flagged for deletion, but before actually getting deleted by iterating through the transform hierarchy. This results in "terminating" entities that sit around in null-space and can cause some PVS error spam. This PR tries to stop that from happening.