### PR TITLE
Fix predicted audio not using adjust params

### DIFF
--- a/Robust.Client/Audio/AudioSystem.cs
+++ b/Robust.Client/Audio/AudioSystem.cs
@@ -593,6 +593,8 @@ public sealed partial class AudioSystem : SharedAudioSystem
         offset = Math.Clamp(offset, 0f, (float) stream.Length.TotalSeconds - 0.01f);
         source.PlaybackPosition = offset;
 
+        // For server we will rely on the adjusted one but locally we will have to adjust it ourselves.
+        audioP = GetAdjustedParams(audioP);
         ApplyAudioParams(audioP, comp);
         comp.Params = audioP;
         source.StartPlaying();

--- a/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
+++ b/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
@@ -161,7 +161,7 @@ public abstract partial class SharedAudioSystem : EntitySystem
     /// <summary>
     /// Accounts for ZOffset on audio distance.
     /// </summary>
-    private AudioParams GetAdjustedParams(AudioParams audioParams)
+    protected AudioParams GetAdjustedParams(AudioParams audioParams)
     {
         var maxDistance = GetAudioDistance(audioParams.MaxDistance);
         var refDistance = GetAudioDistance(audioParams.ReferenceDistance);
@@ -205,6 +205,7 @@ public abstract partial class SharedAudioSystem : EntitySystem
             return;
 
         component.Params.Volume = value;
+        component.Volume = value;
         Dirty(entity.Value, component);
     }
 


### PR DESCRIPTION
These account for z-offset when using maxdistance and refdistance which were getting clipped for low range stuff.