### PR TITLE
Network base not adjusted audio params

### DIFF
--- a/Robust.Client/Audio/AudioSystem.cs
+++ b/Robust.Client/Audio/AudioSystem.cs
@@ -62,6 +62,18 @@ public sealed partial class AudioSystem : SharedAudioSystem
         {
             _zOffset = value;
             _audio.SetZOffset(value);
+
+            var query = AllEntityQuery<AudioComponent>();
+
+            while (query.MoveNext(out var audio))
+            {
+                // Pythagoras back to normal then adjust.
+                var maxDistance = GetAudioDistance(audio.Params.MaxDistance);
+                var refDistance = GetAudioDistance(audio.Params.ReferenceDistance);
+
+                audio.MaxDistance = maxDistance;
+                audio.ReferenceDistance = refDistance;
+            }
         }
     }
 
@@ -606,7 +618,6 @@ public sealed partial class AudioSystem : SharedAudioSystem
         source.PlaybackPosition = offset;
 
         // For server we will rely on the adjusted one but locally we will have to adjust it ourselves.
-        audioP = GetAdjustedParams(audioP);
         ApplyAudioParams(audioP, comp);
         comp.Params = audioP;
         source.StartPlaying();
@@ -621,8 +632,8 @@ public sealed partial class AudioSystem : SharedAudioSystem
         source.Pitch = audioParams.Pitch;
         source.Volume = audioParams.Volume;
         source.RolloffFactor = audioParams.RolloffFactor;
-        source.MaxDistance = audioParams.MaxDistance;
-        source.ReferenceDistance = audioParams.ReferenceDistance;
+        source.MaxDistance = GetAudioDistance(audioParams.MaxDistance);
+        source.ReferenceDistance = GetAudioDistance(audioParams.ReferenceDistance);
         source.Looping = audioParams.Loop;
     }
 

--- a/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
+++ b/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
@@ -63,21 +63,7 @@ public abstract partial class SharedAudioSystem : EntitySystem
 
     protected void SetZOffset(float value)
     {
-        var query = AllEntityQuery<AudioComponent>();
-        var oldZOffset = ZOffset;
         ZOffset = value;
-
-        while (query.MoveNext(out var uid, out var audio))
-        {
-            // Pythagoras back to normal then adjust.
-            var maxDistance = MathF.Pow(audio.Params.MaxDistance, 2) - oldZOffset;
-            var refDistance = MathF.Pow(audio.Params.ReferenceDistance, 2) - oldZOffset;
-
-            audio.Params.MaxDistance = maxDistance;
-            audio.Params.ReferenceDistance = refDistance;
-            audio.Params = GetAdjustedParams(audio.Params);
-            Dirty(uid, audio);
-        }
     }
 
     protected virtual void OnAudioUnpaused(EntityUid uid, AudioComponent component, ref EntityUnpausedEvent args)
@@ -141,9 +127,9 @@ public abstract partial class SharedAudioSystem : EntitySystem
     {
         DebugTools.Assert(!string.IsNullOrEmpty(fileName));
         audioParams ??= AudioParams.Default;
-        var comp = AddComp<Components.AudioComponent>(uid);
+        var comp = AddComp<AudioComponent>(uid);
         comp.FileName = fileName;
-        comp.Params = GetAdjustedParams(audioParams.Value);
+        comp.Params = audioParams.Value;
         comp.AudioStart = Timing.CurTime;
 
         if (!audioParams.Value.Loop)
@@ -156,19 +142,6 @@ public abstract partial class SharedAudioSystem : EntitySystem
         }
 
         return comp;
-    }
-
-    /// <summary>
-    /// Accounts for ZOffset on audio distance.
-    /// </summary>
-    protected AudioParams GetAdjustedParams(AudioParams audioParams)
-    {
-        var maxDistance = GetAudioDistance(audioParams.MaxDistance);
-        var refDistance = GetAudioDistance(audioParams.ReferenceDistance);
-
-        return audioParams
-            .WithMaxDistance(maxDistance)
-            .WithReferenceDistance(refDistance);
     }
 
     public static float GainToVolume(float value)


### PR DESCRIPTION
Cleans it up a bit so we always pretend as if the maxdistance / refdistance in params are correct when we just use the adjusted ones internally (and content can still access it obviously).

Resolves https://github.com/space-wizards/RobustToolbox/issues/4678