### PR TITLE
Set priorGain to 0 if gain is 0

### DIFF
--- a/Robust.Client/Audio/Sources/BaseAudioSource.cs
+++ b/Robust.Client/Audio/Sources/BaseAudioSource.cs
@@ -188,7 +188,8 @@ internal abstract class BaseAudioSource : IAudioSource
             if (!IsEfxSupported)
             {
                 AL.GetSource(SourceHandle, ALSourcef.Gain, out var priorGain);
-                priorOcclusion = _gain == 0 ? 0.5f : priorGain / _gain;
+                // Default to 0 to avoid spiking audio, just means it will be muted for a frame in this case.
+                priorOcclusion = _gain == 0 ? 0f : priorGain / _gain;
             }
 
             _gain = value;


### PR DESCRIPTION
I think silencing the audio for a frame rather than setting it to an arbitary mid is better.