### PR TITLE
Add colour gradients to sliders

### DIFF
--- a/Resources/EnginePrototypes/Shaders/stockshaders.yml
+++ b/Resources/EnginePrototypes/Shaders/stockshaders.yml
@@ -12,3 +12,8 @@
   id: bgra
   kind: source
   path: "/Shaders/Internal/bgra.swsl"
+
+- type: shader
+  id: ColorPicker
+  kind: source
+  path: "/Shaders/color_picker.swsl"

--- a/Resources/Shaders/color_picker.swsl
+++ b/Resources/Shaders/color_picker.swsl
@@ -1,0 +1,46 @@
+// Simple shader for creating a box with colours varying along the x and y axes.
+
+uniform highp vec2 size;
+uniform highp vec2 offset;
+
+uniform highp vec4 xAxis;
+uniform highp vec4 yAxis;
+uniform highp vec4 baseColor;
+
+uniform bool hsv;
+
+void fragment() 
+{
+    // Calculate local uv coordinates.
+    // I.e., if using this shader to draw a box to the screen, (0,0) is the bottom left of the box.
+    
+    highp float yCoords = 1.0/SCREEN_PIXEL_SIZE.y - FRAGCOORD.y;
+    highp vec2 uv = new vec2(FRAGCOORD.x - offset.x,  yCoords - offset.y);
+    uv /= size;
+    uv.y = 1.0 - uv.y;
+    
+    highp vec4 modulate = baseColor + uv.x * xAxis + uv.y * yAxis;
+    
+    if (hsv)
+    {
+        modulate.xyz = hsv2rgb(modulate.xyz);
+    }
+    
+    // The UV used for the texture lookup is the TEXTURE UV coordinate, which is different from the coordinates computed above.
+	COLOR = zTexture(UV) * modulate;
+}
+
+
+// hsv to RGB conversion taken from www.shadertoy.com/view/MsS3Wc
+
+// The MIT License
+// Copyright © 2014 Inigo Quilez
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// https://www.youtube.com/c/InigoQuilez
+// https://iquilezles.org
+
+highp vec3 hsv2rgb( in highp vec3 c )
+{
+    highp vec3 rgb = clamp( abs(mod(c.x*6.0+vec3(0.0,4.0,2.0),6.0)-3.0)-1.0, 0.0, 1.0 );
+	return c.z * mix( vec3(1.0), rgb, c.y);
+}

--- a/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
@@ -38,6 +38,11 @@ namespace Robust.Client.Graphics.Clyde
                 _clyde.DrawSetModelTransform(matrix);
             }
 
+            public Matrix3 GetModelTransform()
+            {
+                return _clyde.DrawGetModelTransform();
+            }
+
             public void SetProjView(in Matrix3 proj, in Matrix3 view)
             {
                 _clyde.DrawSetProjViewTransform(proj, view);
@@ -222,7 +227,14 @@ namespace Robust.Client.Graphics.Clyde
 
                 var clydeShader = (ClydeShaderInstance?) shader;
 
-                _clyde.DrawUseShader(clydeShader?.Handle ?? _clyde._defaultShader.Handle);
+                _clyde.DrawUseShader(clydeShader ?? _clyde._defaultShader);
+            }
+
+            public ShaderInstance? GetShader()
+            {
+                return _clyde._queuedShaderInstance == _clyde._defaultShader
+                    ? null
+                    : _clyde._queuedShaderInstance;
             }
 
             public void Viewport(Box2i viewport)
@@ -285,9 +297,19 @@ namespace Robust.Client.Graphics.Clyde
                     _renderHandle.SetModelTransform(matrix);
                 }
 
+                public override Matrix3 GetTransform()
+                {
+                    return _renderHandle.GetModelTransform();
+                }
+
                 public override void UseShader(ShaderInstance? shader)
                 {
                     _renderHandle.UseShader(shader);
+                }
+
+                public override ShaderInstance? GetShader()
+                {
+                    return _renderHandle.GetShader();
                 }
 
                 public override void DrawPrimitives(DrawPrimitiveTopology primitiveTopology, Texture texture,
@@ -380,9 +402,19 @@ namespace Robust.Client.Graphics.Clyde
                     _renderHandle.SetModelTransform(matrix);
                 }
 
+                public override Matrix3 GetTransform()
+                {
+                    return _renderHandle.GetModelTransform();
+                }
+
                 public override void UseShader(ShaderInstance? shader)
                 {
                     _renderHandle.UseShader(shader);
+                }
+
+                public override ShaderInstance? GetShader()
+                {
+                    return _renderHandle.GetShader();
                 }
 
                 public override void DrawCircle(Vector2 position, float radius, Color color, bool filled = true)

--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -78,7 +78,9 @@ namespace Robust.Client.Graphics.Clyde
 
         // private LoadedTexture? _batchLoadedTexture;
         // Contains the shader instance that's currently being used by the (queue) stage for new commands.
-        private ClydeHandle _queuedShader;
+        private ClydeHandle _queuedShader => _queuedShaderInstance.Handle;
+
+        private ClydeShaderInstance _queuedShaderInstance = default!;
 
         // Current projection & view matrices that are being used ot render.
         // This gets updated to keep track during (queue) and (misc), but not during (submit).
@@ -314,7 +316,7 @@ namespace Robust.Client.Graphics.Clyde
 
             // Reset renderer state.
             _currentMatrixModel = Matrix3.Identity;
-            _queuedShader = _defaultShader.Handle;
+            _queuedShaderInstance = _defaultShader;
             SetScissorFull(null);
         }
 
@@ -531,6 +533,11 @@ namespace Robust.Client.Graphics.Clyde
             _currentMatrixModel = matrix;
         }
 
+        private Matrix3 DrawGetModelTransform()
+        {
+            return _currentMatrixModel;
+        }
+
         private void DrawSetProjViewTransform(in Matrix3 proj, in Matrix3 view)
         {
             BreakBatch();
@@ -700,9 +707,9 @@ namespace Robust.Client.Graphics.Clyde
             _currentScissorState = scissorBox;
         }
 
-        private void DrawUseShader(ClydeHandle handle)
+        private void DrawUseShader(ClydeShaderInstance instance)
         {
-            _queuedShader = handle;
+            _queuedShaderInstance = instance;
         }
 
         private void DrawClear(Color color, int stencil, ClearBufferMask mask)
@@ -875,7 +882,7 @@ namespace Robust.Client.Graphics.Clyde
             SetScissorFull(null);
             BindRenderTargetFull(_mainWindow!.RenderTarget);
             _batchMetaData = null;
-            _queuedShader = _defaultShader.Handle;
+            _queuedShaderInstance = _defaultShader;
 
             GL.Viewport(0, 0, _mainWindow!.FramebufferSize.X, _mainWindow!.FramebufferSize.Y);
         }

--- a/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
@@ -158,7 +158,7 @@ namespace Robust.Client.Graphics.Clyde
 
             _defaultShader = (ClydeShaderInstance) InstanceShader(defaultLoadedShader);
 
-            _queuedShader = _defaultShader.Handle;
+            _queuedShaderInstance = _defaultShader;
         }
 
         private string ReadEmbeddedShader(string fileName)

--- a/Robust.Client/Graphics/Drawing/DrawingHandleBase.cs
+++ b/Robust.Client/Graphics/Drawing/DrawingHandleBase.cs
@@ -55,7 +55,11 @@ namespace Robust.Client.Graphics
 
         public abstract void SetTransform(in Matrix3 matrix);
 
+        public abstract Matrix3 GetTransform();
+
         public abstract void UseShader(ShaderInstance? shader);
+
+        public abstract ShaderInstance? GetShader();
 
         // ---- DrawPrimitives: Vector2 API ----
 

--- a/Robust.Client/Graphics/Drawing/StyleBoxTexture.cs
+++ b/Robust.Client/Graphics/Drawing/StyleBoxTexture.cs
@@ -15,7 +15,8 @@ namespace Robust.Client.Graphics
     ///     which can be either stretched or tiled to fill up
     ///     the space the box is being drawn in.
     /// </summary>
-    public sealed class StyleBoxTexture : StyleBox
+    [Virtual]
+    public class StyleBoxTexture : StyleBox
     {
         public StyleBoxTexture()
         {

--- a/Robust.Client/UserInterface/Controls/ColorSelectorSliders.cs
+++ b/Robust.Client/UserInterface/Controls/ColorSelectorSliders.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using Robust.Client.Graphics;
+using Robust.Client.ResourceManagement;
+using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Maths;
-using Robust.Shared.Log;
 
 namespace Robust.Client.UserInterface.Controls;
 
@@ -87,12 +89,19 @@ public sealed class ColorSelectorSliders : Control
     private OptionButton _typeSelector;
     private List<ColorSelectorType> _types = new();
 
+    private static ShaderInstance _shader = default!;
+
+    private ColorSelectorStyleBox _topStyle;
+    private ColorSelectorStyleBox _middleStyle;
+    private ColorSelectorStyleBox _bottomStyle;
+
     public ColorSelectorSliders()
     {
         _topColorSlider = new ColorableSlider
         {
             HorizontalExpand = true,
             VerticalAlignment = VAlignment.Center,
+            BackgroundStyleBoxOverride = _topStyle = new(),
             MaxValue = 1.0f
         };
 
@@ -100,6 +109,7 @@ public sealed class ColorSelectorSliders : Control
         {
             HorizontalExpand = true,
             VerticalAlignment = VAlignment.Center,
+            BackgroundStyleBoxOverride = _middleStyle = new(),
             MaxValue = 1.0f
         };
 
@@ -107,6 +117,7 @@ public sealed class ColorSelectorSliders : Control
         {
             HorizontalExpand = true,
             VerticalAlignment = VAlignment.Center,
+            BackgroundStyleBoxOverride = _bottomStyle = new(),
             MaxValue = 1.0f
         };
 
@@ -231,7 +242,7 @@ public sealed class ColorSelectorSliders : Control
         rootBox.AddChild(bodyBox);
 
         UpdateType();
-        Update();
+        Color = _currentColor;
     }
 
     private void UpdateType()
@@ -241,6 +252,11 @@ public sealed class ColorSelectorSliders : Control
         _topSliderLabel.Text = labels.topLabel;
         _middleSliderLabel.Text = labels.middleLabel;
         _bottomSliderLabel.Text = labels.bottomLabel;
+
+        bool hsv = SelectorType == ColorSelectorType.Hsv;
+        _topStyle.ConfigureSlider( hsv ? ColorSelectorStyleBox.ColorSliderPreset.Hue : ColorSelectorStyleBox.ColorSliderPreset.Red);
+        _middleStyle.ConfigureSlider( hsv ? ColorSelectorStyleBox.ColorSliderPreset.Saturation : ColorSelectorStyleBox.ColorSliderPreset.Green);
+        _bottomStyle.ConfigureSlider( hsv ? ColorSelectorStyleBox.ColorSliderPreset.Value : ColorSelectorStyleBox.ColorSliderPreset.Blue);
     }
 
     private void Update()
@@ -251,9 +267,9 @@ public sealed class ColorSelectorSliders : Control
             return;
 
         _updating = true;
-        _topColorSlider.SetColor(_currentColor);
-        _middleColorSlider.SetColor(_currentColor);
-        _bottomColorSlider.SetColor(_currentColor);
+        _topStyle.SetBaseColor(_colorData);
+        _middleStyle.SetBaseColor(_colorData);
+        _bottomStyle.SetBaseColor(_colorData);
 
         switch (SelectorType)
         {

--- a/Robust.Client/UserInterface/Controls/ColorSelectorStyleBox.cs
+++ b/Robust.Client/UserInterface/Controls/ColorSelectorStyleBox.cs
@@ -1,0 +1,130 @@
+using Robust.Client.Graphics;
+using Robust.Client.ResourceManagement;
+using Robust.Shared.IoC;
+using Robust.Shared.Maths;
+using Robust.Shared.Prototypes;
+
+namespace Robust.Client.UserInterface.Controls;
+
+/// <summary>
+/// Style box for colouring sliders and 2-d colour selectors. E.g., this could be used to draw the typical HSV colour
+/// selection rainbow.
+/// </summary>
+public sealed class ColorSelectorStyleBox : StyleBoxTexture
+{
+    public const string TexturePath = "/Textures/Interface/Nano/slider_fill.svg.96dpi.png";
+    public static ProtoId<ShaderPrototype> Prototype = "ColorPicker";
+
+    private ShaderInstance _shader;
+
+    /// <summary>
+    /// Base background colour.
+    /// </summary>
+    public Vector4 BaseColor;
+
+    /// <summary>
+    /// Colour to add to the background colour along the X-axis.
+    /// I.e., from left to right the background colour will vary from (BaseColour) to (BaseColour + XAxis)
+    /// </summary>
+    public Vector4 XAxis;
+
+    /// <summary>
+    /// Colour to add to the background colour along the y-axis.
+    /// I.e., from left to right the background colour will vary from (BaseColour) to (BaseColour + XAxis)
+    /// </summary>
+    public Vector4 YAxis;
+
+    /// <summary>
+    /// If true, then <see cref="BaseColor"/>, <see cref="XAxis"/>, and <see cref="YAxis"/> will be interpreted as HSVa
+    /// colours.
+    /// </summary>
+    public bool Hsv;
+
+    public ColorSelectorStyleBox(ColorSliderPreset preset = ColorSliderPreset.Red)
+    {
+        Texture = IoCManager.Resolve<IResourceCache>().GetResource<TextureResource>(TexturePath);
+        _shader = IoCManager.Resolve<IPrototypeManager>().Index(Prototype).InstanceUnique();
+        SetPatchMargin(Margin.All, 12);
+        ConfigureSlider(preset);
+    }
+
+    protected override void DoDraw(DrawingHandleScreen handle, UIBox2 box, float uiScale)
+    {
+        var old = handle.GetShader();
+        handle.UseShader(_shader);
+
+        var globalPixelPos = handle.GetTransform().Transform(default);
+        _shader.SetParameter("size", box.Size);
+        _shader.SetParameter("offset", globalPixelPos);
+        _shader.SetParameter("xAxis", XAxis);
+        _shader.SetParameter("yAxis", YAxis);
+        _shader.SetParameter("baseColor", BaseColor);
+        _shader.SetParameter("hsv", Hsv);
+
+        base.DoDraw(handle, box, uiScale);
+        handle.UseShader(old);
+    }
+
+    public void ConfigureSlider(ColorSliderPreset preset)
+    {
+        Hsv = preset > ColorSliderPreset.Blue;
+
+        if (preset == ColorSliderPreset.HueValue)
+        {
+            XAxis = new(1, 0, 0, 0); // Hue;
+            YAxis = new(0, 0, 1, 0); // value;
+            return;
+        }
+
+        YAxis = default;
+        XAxis = preset switch
+        {
+            ColorSliderPreset.Red or ColorSliderPreset.Hue => new(1, 0, 0, 0),
+            ColorSliderPreset.Green or ColorSliderPreset.Saturation => new(0, 1, 0, 0),
+            _ => new(0, 0, 1, 0),
+        };
+    }
+
+    /// <summary>
+    /// Helper method that sets the base color by taking in some color and removing the components that are controlled by the x and y axes.
+    /// </summary>
+    public void SetBaseColor(Color color)
+    {
+        var colorData = Hsv
+            ? Color.ToHsv(color)
+            : new Vector4(color.R, color.G, color.B, color.A);
+        SetBaseColor(colorData);
+    }
+
+    /// <summary>
+    /// Helper method that sets the base color by taking in some color and removing the components that are controlled by the x and y axes.
+    /// </summary>
+    public void SetBaseColor(Vector4 colorData)
+    {
+        BaseColor = colorData - colorData * XAxis - colorData * YAxis;
+    }
+
+    public enum ColorSliderPreset : byte
+    {
+        // Horizontal red slider
+        Red = 1,
+
+        // Horizontal green slider
+        Green = 2,
+
+        // Horizontal blue slider
+        Blue = 3,
+
+        // Horizontal hue slider
+        Hue = 4,
+
+        // Horizontal situation slider
+        Saturation = 5,
+
+        // Horizontal saturation slider
+        Value = 6,
+
+        // 2-D hue-value box
+        HueValue = 7
+    }
+}


### PR DESCRIPTION
This PR adds colour gradients to the colour picker sliders to make it easier to select a colour. The colours are drawn using a new shader. I haven't checked if the HSV-to-RGB shader code is equivalent to `Color.FromHsv()`, I'm just trusting that it is. The slider colour mapping probably isn't all that accurate for clicking anyways due to the size of the grabber, but it seems to work well enough.

https://github.com/space-wizards/RobustToolbox/assets/60421075/03ba7cea-5ca5-4633-8d69-484cc48f2d81

This PR also adds some new methods to render handles & clyde:
- `GetShader()` returns the currently used shader, so that controls can temporarily change the shader before resetting it
- `GetTransform()` returns the model matrix currently being used to render.