### PR TITLE
Ensure shaders parameters are updated when swapping instances

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -443,9 +443,13 @@ namespace Robust.Client.Graphics.Clyde
                 _isStencilling = false;
             }
 
-            if (!instance.ParametersDirty)
+            if (instance.Parameters.Count == 0)
                 return (program, instance);
 
+            if (shader.LastInstance == instance && !instance.ParametersDirty)
+                return (program, instance);
+
+            shader.LastInstance = instance;
             instance.ParametersDirty = false;
 
             int textureUnitVal = 0;

--- a/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
@@ -48,6 +48,10 @@ namespace Robust.Client.Graphics.Clyde
 
             [ViewVariables]
             public string? Name;
+
+            // Last instance that used this shader.
+            // Used to ensure that shader uniforms get updated.
+            public LoadedShaderInstance? LastInstance;
         }
 
         private sealed class LoadedShaderInstance


### PR DESCRIPTION
Fixes some shader bugs, like the interaction highlight using the wrong colour. This will make performance slightly worse in instances were people are using multiple unique instances of a shader with the same shader parameters. The easiest way to fix that would probably to make shader instance cloning lazier, so that it only creates a new instance when a shader parameter is actually updated.

Below are videos demonstrating interaction highlight changes for drag-drop interactions. The drag interaction range has been increased here to make it easer to demonstrate.

old:

https://github.com/space-wizards/RobustToolbox/assets/60421075/fe217c0b-4296-4e86-9262-1b4d9b30b2a0

new:

https://github.com/space-wizards/RobustToolbox/assets/60421075/5aff7622-b60d-4aa5-8ff6-afbff706e3f1

