### PR TITLE
Run ProcessQueuedAcks asynchronously

### DIFF
--- a/Robust.Server/GameStates/PvsSystem.Ack.cs
+++ b/Robust.Server/GameStates/PvsSystem.Ack.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Player;
 using Robust.Shared.Threading;
@@ -29,10 +30,12 @@ internal sealed partial class PvsSystem
     /// <summary>
     ///     Processes queued client acks in parallel
     /// </summary>
-    internal void ProcessQueuedAcks()
+    internal WaitHandle ProcessQueuedAcks()
     {
         if (PendingAcks.Count == 0)
-            return;
+        {
+            return ParallelManager.DummyResetEvent.WaitHandle;
+        }
 
         _toAck.Clear();
 
@@ -41,8 +44,8 @@ internal sealed partial class PvsSystem
             _toAck.Add(session);
         }
 
-        _parallelManager.ProcessNow(_ackJob, _toAck.Count);
         PendingAcks.Clear();
+        return _parallelManager.Process(_ackJob, _toAck.Count);
     }
 
     private record struct PvsAckJob : IParallelRobustJob

--- a/Robust.Server/GameStates/ServerGameStateManager.cs
+++ b/Robust.Server/GameStates/ServerGameStateManager.cs
@@ -175,6 +175,7 @@ Oldest acked clients: {string.Join(", ", players)}
             var players = _playerManager.Sessions.Where(o => o.Status == SessionStatus.InGame).ToArray();
 
             // Update client acks, which is used to figure out what data needs to be sent to clients
+            // This only needs SessionData which isn't touched during GetPVSData or ProcessCollections.
             var ackJob = _pvs.ProcessQueuedAcks();
 
             // Update entity positions in PVS chunks/collections

--- a/Robust.Shared/Threading/ParallelManager.cs
+++ b/Robust.Shared/Threading/ParallelManager.cs
@@ -51,6 +51,8 @@ internal sealed class ParallelManager : IParallelManagerInternal
     public event Action? ParallelCountChanged;
     public int ParallelProcessCount { get; private set; }
 
+    public static readonly ManualResetEventSlim DummyResetEvent = new();
+
     // Without pooling it's hard to keep task allocations down for classes
     // This lets us avoid re-allocating the ManualResetEventSlims constantly when we just need a way to signal job completion.
 
@@ -68,6 +70,7 @@ internal sealed class ParallelManager : IParallelManagerInternal
 
     public void Initialize()
     {
+        DummyResetEvent.Set();
         _cfg.OnValueChanged(CVars.ThreadParallelCount, UpdateCVar, true);
     }
 

--- a/Robust.Shared/Threading/ParallelManager.cs
+++ b/Robust.Shared/Threading/ParallelManager.cs
@@ -51,7 +51,7 @@ internal sealed class ParallelManager : IParallelManagerInternal
     public event Action? ParallelCountChanged;
     public int ParallelProcessCount { get; private set; }
 
-    public static readonly ManualResetEventSlim DummyResetEvent = new();
+    public static readonly ManualResetEventSlim DummyResetEvent = new(true);
 
     // Without pooling it's hard to keep task allocations down for classes
     // This lets us avoid re-allocating the ManualResetEventSlims constantly when we just need a way to signal job completion.
@@ -70,7 +70,6 @@ internal sealed class ParallelManager : IParallelManagerInternal
 
     public void Initialize()
     {
-        DummyResetEvent.Set();
         _cfg.OnValueChanged(CVars.ThreadParallelCount, UpdateCVar, true);
     }
 


### PR DESCRIPTION
Grafana says this can take up to 2ms which is probably rounding upwards but still we can run it in the background during ProcessCollections and GetPVSData if we need to.

Wasn't really sure what to do about the grafana timer.