### PR TITLE
Expose IFileDialogManager.GetSaveFileName to content

### DIFF
--- a/Robust.Client/UserInterface/DummyFileDialogManager.cs
+++ b/Robust.Client/UserInterface/DummyFileDialogManager.cs
@@ -17,5 +17,10 @@ namespace Robust.Client.UserInterface
         {
             return Task.FromResult<(Stream fileStream, bool alreadyExisted)?>(null);
         }
+
+        public Task<string?> GetSaveFileName(FileDialogFilters? filters = null)
+        {
+            return Task.FromResult<string?>(null);
+        }
     }
 }

--- a/Robust.Client/UserInterface/FileDialogManager.cs
+++ b/Robust.Client/UserInterface/FileDialogManager.cs
@@ -69,7 +69,7 @@ namespace Robust.Client.UserInterface
             }
         }
 
-        private async Task<string?> GetSaveFileName(FileDialogFilters? filters)
+        public async Task<string?> GetSaveFileName(FileDialogFilters? filters)
         {
             if (await IsKDialogAvailable())
             {

--- a/Robust.Client/UserInterface/IFileDialogManager.cs
+++ b/Robust.Client/UserInterface/IFileDialogManager.cs
@@ -29,5 +29,14 @@ namespace Robust.Client.UserInterface
         /// Null if the user cancelled the action.
         /// </returns>
         Task<(Stream fileStream, bool alreadyExisted)?> SaveFile(FileDialogFilters? filters = null);
+
+        /// <summary>
+        ///     Open a file dialog used for saving a single file.
+        /// </summary>
+        /// <returns>
+        /// The path the user chose to save to.
+        /// Null if the user cancelled the action.
+        /// </returns>
+        Task<string?> GetSaveFileName(FileDialogFilters? filters = null);
     }
 }


### PR DESCRIPTION
@PJB3005 

This is the part of SaveFile (which is already sandboxed) that gets the path from the user-selected file.
As far as I know this should be safe to sandbox as well.
You can't cast the stream returned by SaveFile to FileStream then get its name because that is not sandboxed.
