### PR TITLE
Fix TileEdgeOverlay drawing over grids

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/MapSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/MapSystem.cs
@@ -8,30 +8,28 @@ using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics.Dynamics;
 
-namespace Robust.Client.GameObjects
+namespace Robust.Client.GameObjects;
+
+public sealed class MapSystem : SharedMapSystem
 {
-    public sealed class MapSystem : SharedMapSystem
+    [Dependency] private readonly IOverlayManager _overlayManager = default!;
+    [Dependency] private readonly IResourceCache _resource = default!;
+    [Dependency] private readonly ITileDefinitionManager _tileDefinitionManager = default!;
+
+    public override void Initialize()
     {
-        [Dependency] private readonly IMapManager _mapManager = default!;
-        [Dependency] private readonly IOverlayManager _overlayManager = default!;
-        [Dependency] private readonly IResourceCache _resource = default!;
-        [Dependency] private readonly ITileDefinitionManager _tileDefinitionManager = default!;
+        base.Initialize();
+        _overlayManager.AddOverlay(new TileEdgeOverlay(EntityManager, _resource, _tileDefinitionManager));
+    }
 
-        public override void Initialize()
-        {
-            base.Initialize();
-            _overlayManager.AddOverlay(new TileEdgeOverlay(EntityManager, _mapManager, _resource, _tileDefinitionManager));
-        }
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        _overlayManager.RemoveOverlay<TileEdgeOverlay>();
+    }
 
-        public override void Shutdown()
-        {
-            base.Shutdown();
-            _overlayManager.RemoveOverlay<TileEdgeOverlay>();
-        }
-
-        protected override void OnMapAdd(EntityUid uid, MapComponent component, ComponentAdd args)
-        {
-            EnsureComp<PhysicsMapComponent>(uid);
-        }
+    protected override void OnMapAdd(EntityUid uid, MapComponent component, ComponentAdd args)
+    {
+        EnsureComp<PhysicsMapComponent>(uid);
     }
 }

--- a/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
@@ -92,6 +92,7 @@ namespace Robust.Client.Graphics.Clyde
                     }
 
                     iGrid.Grid = mapGrid;
+                    iGrid.RequiresFlush = false;
                     RenderSingleWorldOverlay(overlay, viewport, OverlaySpace.WorldSpaceGrids, worldAABB, worldBounds);
                     requiresFlush |= iGrid.RequiresFlush;
                 }

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -497,7 +497,7 @@ namespace Robust.Client.Graphics.Clyde
                     using (DebugGroup("Grids"))
                     using (_prof.Group("Grids"))
                     {
-                        _drawGrids(viewport, worldBounds, eye);
+                        _drawGrids(viewport, worldAABB, worldBounds, eye);
                     }
 
                     // We will also render worldspace overlays here so we can do them under / above entities as necessary

--- a/Robust.Client/Graphics/Clyde/Clyde.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.cs
@@ -76,6 +76,7 @@ namespace Robust.Client.Graphics.Clyde
 
         private Thread? _gameThread;
 
+        private ISawmill _clydeSawmill = default!;
         private ISawmill _sawmillOgl = default!;
 
         private IBindingsContext _glBindingsContext = default!;
@@ -91,6 +92,7 @@ namespace Robust.Client.Graphics.Clyde
 
         public bool InitializePreWindowing()
         {
+            _clydeSawmill = _logManager.GetSawmill("clyde");
             _sawmillOgl = _logManager.GetSawmill("clyde.ogl");
 
             _cfg.OnValueChanged(CVars.DisplayOGLCheckErrors, b => _checkGLErrors = b, true);

--- a/Robust.Client/Graphics/Overlays/GridOverlay.cs
+++ b/Robust.Client/Graphics/Overlays/GridOverlay.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.Enums;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map.Components;
+
+namespace Robust.Client.Graphics;
+
+public abstract class GridOverlay : Overlay, IGridOverlay
+{
+    public override OverlaySpace Space => OverlaySpace.WorldSpaceGrids;
+
+    public Entity<MapGridComponent> Grid { get; set; }
+
+    public bool RequiresFlush { get; set; }
+}

--- a/Robust.Client/Graphics/Overlays/IGridOverlay.cs
+++ b/Robust.Client/Graphics/Overlays/IGridOverlay.cs
@@ -1,0 +1,18 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map.Components;
+
+namespace Robust.Client.Graphics;
+
+/// <summary>
+/// Marks this overlay as implementing per-grid rendering.
+/// </summary>
+public interface IGridOverlay
+{
+    Entity<MapGridComponent> Grid { get; set; }
+
+    /// <summary>
+    /// Should we flush the render or can we keep going.
+    /// </summary>
+    public bool RequiresFlush { get; set; }
+}
+

--- a/Robust.Client/Map/TileEdgeOverlay.cs
+++ b/Robust.Client/Map/TileEdgeOverlay.cs
@@ -1,12 +1,9 @@
 using System;
-using System.Collections.Generic;
 using System.Numerics;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
-using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
-using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
 
 namespace Robust.Client.Map;
@@ -14,21 +11,15 @@ namespace Robust.Client.Map;
 /// <summary>
 /// Draws border sprites for tiles that support them.
 /// </summary>
-public sealed class TileEdgeOverlay : Overlay
+public sealed class TileEdgeOverlay : GridOverlay
 {
     private readonly IEntityManager _entManager;
-    private readonly IMapManager _mapManager;
     private readonly IResourceCache _resource;
     private readonly ITileDefinitionManager _tileDefManager;
 
-    public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowEntities;
-
-    private List<Entity<MapGridComponent>> _grids = new();
-
-    public TileEdgeOverlay(IEntityManager entManager, IMapManager mapManager, IResourceCache resource, ITileDefinitionManager tileDefManager)
+    public TileEdgeOverlay(IEntityManager entManager, IResourceCache resource, ITileDefinitionManager tileDefManager)
     {
         _entManager = entManager;
-        _mapManager = mapManager;
         _resource = resource;
         _tileDefManager = tileDefManager;
         ZIndex = -1;
@@ -39,97 +30,97 @@ public sealed class TileEdgeOverlay : Overlay
         if (args.MapId == MapId.Nullspace)
             return;
 
-        _grids.Clear();
-        _mapManager.FindGridsIntersecting(args.MapId, args.WorldBounds, ref _grids);
-
         var mapSystem = _entManager.System<SharedMapSystem>();
         var xformSystem = _entManager.System<SharedTransformSystem>();
 
-        foreach (var grid in _grids)
+        var tileSize = Grid.Comp.TileSize;
+        var tileDimensions = new Vector2(tileSize, tileSize);
+        var (_, _, worldMatrix, invMatrix) = xformSystem.GetWorldPositionRotationMatrixWithInv(Grid.Owner);
+        args.WorldHandle.SetTransform(worldMatrix);
+        var localAABB = invMatrix.TransformBox(args.WorldBounds);
+
+        var enumerator = mapSystem.GetLocalTilesEnumerator(Grid.Owner, Grid, localAABB, false);
+        var needsFlush = false;
+
+        while (enumerator.MoveNext(out var tileRef))
         {
-            var tileSize = grid.Comp.TileSize;
-            var tileDimensions = new Vector2(tileSize, tileSize);
-            var (_, _, worldMatrix, invMatrix) = xformSystem.GetWorldPositionRotationMatrixWithInv(grid.Owner);
-            args.WorldHandle.SetTransform(worldMatrix);
-            var localAABB = invMatrix.TransformBox(args.WorldBounds);
+            var tileDef = _tileDefManager[tileRef.Tile.TypeId];
 
-            var enumerator = mapSystem.GetLocalTilesEnumerator(grid.Owner, grid.Comp, localAABB, false);
+            if (tileDef.EdgeSprites.Count == 0)
+                continue;
 
-            while (enumerator.MoveNext(out var tileRef))
+            // Get what tiles border us to determine what sprites we need to draw.
+            for (var x = -1; x <= 1; x++)
             {
-                var tileDef = _tileDefManager[tileRef.Tile.TypeId];
-
-                if (tileDef.EdgeSprites.Count == 0)
-                    continue;
-
-                // Get what tiles border us to determine what sprites we need to draw.
-                for (var x = -1; x <= 1; x++)
+                for (var y = -1; y <= 1; y++)
                 {
-                    for (var y = -1; y <= 1; y++)
+                    if (x == 0 && y == 0)
+                        continue;
+
+                    var neighborIndices = new Vector2i(tileRef.GridIndices.X + x, tileRef.GridIndices.Y + y);
+                    var neighborTile = mapSystem.GetTileRef(Grid.Owner, Grid, neighborIndices);
+                    var neighborDef = _tileDefManager[neighborTile.Tile.TypeId];
+
+                    // If it's the same tile then no edge to be drawn.
+                    if (tileRef.Tile.TypeId == neighborTile.Tile.TypeId)
+                        continue;
+
+                    // Don't draw if the the neighbor tile edges should draw over us (or if we have the same priority)
+                    if (neighborDef.EdgeSprites.Count != 0 && neighborDef.EdgeSpritePriority >= tileDef.EdgeSpritePriority)
+                        continue;
+
+                    var direction = new Vector2i(x, y).AsDirection();
+
+                    // No edge tile
+                    if (!tileDef.EdgeSprites.TryGetValue(direction, out var edgePath))
+                        continue;
+
+                    var texture = _resource.GetResource<TextureResource>(edgePath);
+                    var box = Box2.FromDimensions(neighborIndices, tileDimensions);
+
+                    var angle = Angle.Zero;
+
+                    // If we ever need one for both cardinals and corners then update this.
+                    switch (direction)
                     {
-                        if (x == 0 && y == 0)
-                            continue;
-
-                        var neighborIndices = new Vector2i(tileRef.GridIndices.X + x, tileRef.GridIndices.Y + y);
-                        var neighborTile = mapSystem.GetTileRef(grid.Owner, grid.Comp, neighborIndices);
-                        var neighborDef = _tileDefManager[neighborTile.Tile.TypeId];
-
-                        // If it's the same tile then no edge to be drawn.
-                        if (tileRef.Tile.TypeId == neighborTile.Tile.TypeId)
-                            continue;
-
-                        // Don't draw if the the neighbor tile edges should draw over us (or if we have the same priority)
-                        if (neighborDef.EdgeSprites.Count != 0 && neighborDef.EdgeSpritePriority >= tileDef.EdgeSpritePriority)
-                            continue;
-
-                        var direction = new Vector2i(x, y).AsDirection();
-
-                        // No edge tile
-                        if (!tileDef.EdgeSprites.TryGetValue(direction, out var edgePath))
-                            continue;
-
-                        var texture = _resource.GetResource<TextureResource>(edgePath);
-                        var box = Box2.FromDimensions(neighborIndices, tileDimensions);
-
-                        var angle = Angle.Zero;
-
-                        // If we ever need one for both cardinals and corners then update this.
-                        switch (direction)
-                        {
-                            // Corner sprites
-                            case Direction.SouthEast:
-                                break;
-                            case Direction.NorthEast:
-                                angle = new Angle(MathF.PI / 2f);
-                                break;
-                            case Direction.NorthWest:
-                                angle = new Angle(MathF.PI);
-                                break;
-                            case Direction.SouthWest:
-                                angle = new Angle(MathF.PI * 1.5f);
-                                break;
-                            // Edge sprites
-                            case Direction.South:
-                                break;
-                            case Direction.East:
-                                angle = new Angle(MathF.PI / 2f);
-                                break;
-                            case Direction.North:
-                                angle = new Angle(MathF.PI);
-                                break;
-                            case Direction.West:
-                                angle = new Angle(MathF.PI * 1.5f);
-                                break;
-                        }
-
-                        if (angle == Angle.Zero)
-                            args.WorldHandle.DrawTextureRect(texture.Texture, box);
-                        else
-                            args.WorldHandle.DrawTextureRect(texture.Texture, new Box2Rotated(box, angle, box.Center));
+                        // Corner sprites
+                        case Direction.SouthEast:
+                            break;
+                        case Direction.NorthEast:
+                            angle = new Angle(MathF.PI / 2f);
+                            break;
+                        case Direction.NorthWest:
+                            angle = new Angle(MathF.PI);
+                            break;
+                        case Direction.SouthWest:
+                            angle = new Angle(MathF.PI * 1.5f);
+                            break;
+                        // Edge sprites
+                        case Direction.South:
+                            break;
+                        case Direction.East:
+                            angle = new Angle(MathF.PI / 2f);
+                            break;
+                        case Direction.North:
+                            angle = new Angle(MathF.PI);
+                            break;
+                        case Direction.West:
+                            angle = new Angle(MathF.PI * 1.5f);
+                            break;
                     }
+
+                    if (angle == Angle.Zero)
+                        args.WorldHandle.DrawTextureRect(texture.Texture, box);
+                    else
+                        args.WorldHandle.DrawTextureRect(texture.Texture, new Box2Rotated(box, angle, box.Center));
+
+                    needsFlush = true;
                 }
             }
         }
+
+        if (needsFlush)
+            RequiresFlush = true;
 
         args.WorldHandle.SetTransform(Matrix3.Identity);
     }

--- a/Robust.Client/Map/TileEdgeOverlay.cs
+++ b/Robust.Client/Map/TileEdgeOverlay.cs
@@ -40,7 +40,6 @@ public sealed class TileEdgeOverlay : GridOverlay
         var localAABB = invMatrix.TransformBox(args.WorldBounds);
 
         var enumerator = mapSystem.GetLocalTilesEnumerator(Grid.Owner, Grid, localAABB, false);
-        var needsFlush = false;
 
         while (enumerator.MoveNext(out var tileRef))
         {
@@ -114,13 +113,10 @@ public sealed class TileEdgeOverlay : GridOverlay
                     else
                         args.WorldHandle.DrawTextureRect(texture.Texture, new Box2Rotated(box, angle, box.Center));
 
-                    needsFlush = true;
+                    RequiresFlush = true;
                 }
             }
         }
-
-        if (needsFlush)
-            RequiresFlush = true;
 
         args.WorldHandle.SetTransform(Matrix3.Identity);
     }

--- a/Robust.Shared/Enums/OverlaySpaces.cs
+++ b/Robust.Shared/Enums/OverlaySpaces.cs
@@ -2,12 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Robust.Shared.Enums {
+namespace Robust.Shared.Enums
+{
     /// <summary>
     ///     Determines in which canvas layers an overlay gets drawn.
     /// </summary>
     [Flags]
-    public enum OverlaySpace : byte {
+    public enum OverlaySpace : ushort
+    {
         /// <summary>
         ///     Used for matching bit flags.
         /// </summary>
@@ -35,18 +37,23 @@ namespace Robust.Shared.Enums {
         WorldSpaceEntities = 1 << 4,
 
         /// <summary>
+        ///     Drawn after every grid.
+        /// </summary>
+        WorldSpaceGrids = 1 << 5,
+
+        /// <summary>
         ///     This overlay will be drawn beneath entities, lighting, and FOV; above grids.
         /// </summary>
-        WorldSpaceBelowEntities = 1 << 5,
+        WorldSpaceBelowEntities = 1 << 6,
 
         /// <summary>
         ///     This overlay will be drawn in screen coordinates behind the world.
         /// </summary>
-        ScreenSpaceBelowWorld = 1 << 6,
+        ScreenSpaceBelowWorld = 1 << 7,
 
         /// <summary>
         ///     Overlay will be rendered below grids, entities, and everything else. In world space.
         /// </summary>
-        WorldSpaceBelowWorld = 1 << 7
+        WorldSpaceBelowWorld = 1 << 8
     }
 }


### PR DESCRIPTION
Need to flush the render queue after every grid. This is done lazily so if the tileedgeoverlay never runs we won't flush, this is somewhat similar to what we have to do with ProcessSpriteEntities.

![image](https://github.com/space-wizards/RobustToolbox/assets/31366439/ec681827-c4da-43f9-8de1-a10e22f634a9)