### PR TITLE
Obsolete TransformComponent.ChildEntities

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -1430,7 +1430,7 @@ namespace Robust.Client.GameStates
             void _recursiveRemoveState(NetEntity netEntity, TransformComponent xform, EntityQuery<MetaDataComponent> metaQuery, EntityQuery<TransformComponent> xformQuery)
             {
                 _processor._lastStateFullRep.Remove(netEntity);
-                foreach (var child in xform.ChildEntities)
+                foreach (var child in xform._children)
                 {
                     if (xformQuery.TryGetComponent(child, out var childXform) &&
                         metaQuery.TryGetComponent(child, out var childMeta))

--- a/Robust.Server/GameObjects/EntitySystems/VisibilitySystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/VisibilitySystem.cs
@@ -105,15 +105,15 @@ namespace Robust.Server.GameObjects
             meta.VisibilityMask = mask;
             _pvs.MarkDirty(uid, xform);
 
-            foreach (var child in xform.ChildEntities)
+            foreach (var child in xform._children)
             {
                 if (!_metaQuery.TryGetComponent(child, out var childMeta))
                     continue;
 
                 var childMask = mask;
 
-                if (_visiblityQuery.TryGetComponent(child, out VisibilityComponent? hildVis))
-                    childMask |= hildVis.Layer;
+                if (_visiblityQuery.TryGetComponent(child, out var childVis))
+                    childMask |= childVis.Layer;
 
                 RecursivelyApplyVisibility(child, childMask, childMeta);
             }

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -1043,7 +1043,7 @@ internal sealed partial class PvsSystem : EntitySystem
         in int newEntityBudget,
         in int enteredEntityBudget)
     {
-        foreach (var child in xform.ChildEntities)
+        foreach (var child in xform._children)
         {
             if (!_xformQuery.TryGetComponent(child, out var childXform))
                 continue;

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -374,24 +374,8 @@ namespace Robust.Shared.GameObjects
             }
         }
 
-        [ViewVariables]
-        public IEnumerable<TransformComponent> Children
-        {
-            get
-            {
-                if (_children.Count == 0) yield break;
-
-                var xforms = _entMan.GetEntityQuery<TransformComponent>();
-                var children = ChildEnumerator;
-
-                while (children.MoveNext(out var child))
-                {
-                    yield return xforms.GetComponent(child.Value);
-                }
-            }
-        }
-
-        [ViewVariables] public IEnumerable<EntityUid> ChildEntities => _children;
+        [Obsolete("Use ChildEnumerator")]
+        public IEnumerable<EntityUid> ChildEntities => _children;
 
         public TransformChildrenEnumerator ChildEnumerator => new(_children.GetEnumerator());
 

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -452,7 +452,7 @@ namespace Robust.Shared.GameObjects
             TransformComponent? parentXform)
         {
             DebugTools.Assert(transform.ParentUid.IsValid() == (parentXform != null));
-            DebugTools.Assert(parentXform == null || parentXform.ChildEntities.Contains(uid));
+            DebugTools.Assert(parentXform == null || parentXform._children.Contains(uid));
 
             // Note about this method: #if EXCEPTION_TOLERANCE is not used here because we're gonna it in the future...
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -180,6 +180,17 @@ public abstract partial class SharedTransformSystem
         return ContainsEntity(parent, (child.Comp.ParentUid, parentXform));
     }
 
+    /// <summary>
+    /// Checks whether the given component is the parent of the entity without having to fetch the child's
+    /// transform component.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsParentOf(TransformComponent parent, EntityUid child)
+    {
+        return parent._children.Contains(child);
+    }
+
+
     #endregion
 
     #region Component Lifetime

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -190,7 +190,6 @@ public abstract partial class SharedTransformSystem
         return parent._children.Contains(child);
     }
 
-
     #endregion
 
     #region Component Lifetime

--- a/Robust.UnitTesting/Server/GameObjects/Components/Container_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/Components/Container_Test.cs
@@ -218,7 +218,7 @@ namespace Robust.UnitTesting.Server.GameObjects.Components
             Assert.That(container.ContainedEntities.Count, Is.EqualTo(1));
 
             Assert.That(entManager.GetComponent<TransformComponent>(containerEntity).ChildCount, Is.EqualTo(1));
-            Assert.That(entManager.GetComponent<TransformComponent>(containerEntity).ChildEntities.First(), Is.EqualTo(insertEntity));
+            Assert.That(entManager.GetComponent<TransformComponent>(containerEntity)._children.First(), Is.EqualTo(insertEntity));
 
             result = containerSys.TryGetContainingContainer(insertEntity, out var resultContainerMan);
             Assert.That(result, Is.True);

--- a/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
+++ b/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
@@ -105,7 +105,7 @@ entities:
                 return;
             }
 
-            var entity = entMan.GetComponent<TransformComponent>(geid).Children.Single().Owner;
+            var entity = entMan.GetComponent<TransformComponent>(geid)._children.Single();
             var c = entMan.GetComponent<MapDeserializeTestComponent>(entity);
 
             Assert.That(c.Bar, Is.EqualTo(2));


### PR DESCRIPTION
Marks `TransformComponent.ChildEntities` as obsolete and removes some uses. This is what was causing the silly high allocs during round end.

Also removes the `Children` field, and adds a new `IsParentOf()` method to the system.