### PR TITLE
Make ChildEnumerator out value non-nullable

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
@@ -324,32 +324,30 @@ namespace Robust.Client.GameObjects
             if (_pointLightQuery.TryGetComponent(entity, out var light))
                 _lightSys.SetContainerOccluded(entity, lightOccluded, light);
 
-            var childEnumerator = xform.ChildEnumerator;
-
             // Try to avoid TryComp if we already know stuff is occluded.
             if ((!spriteOccluded || !lightOccluded) && TryComp<ContainerManagerComponent>(entity, out var manager))
             {
-                while (childEnumerator.MoveNext(out var child))
+                foreach (var child in xform._children)
                 {
                     // Thank god it's by value and not by ref.
                     var childSpriteOccluded = spriteOccluded;
                     var childLightOccluded = lightOccluded;
 
                     // We already know either sprite or light is not occluding so need to check container.
-                    if (manager.TryGetContainer(child.Value, out var container))
+                    if (manager.TryGetContainer(child, out var container))
                     {
                         childSpriteOccluded = childSpriteOccluded || !container.ShowContents;
                         childLightOccluded = childLightOccluded || container.OccludesLight;
                     }
 
-                    UpdateEntity(child.Value, TransformQuery.GetComponent(child.Value), childSpriteOccluded, childLightOccluded);
+                    UpdateEntity(child, TransformQuery.GetComponent(child), childSpriteOccluded, childLightOccluded);
                 }
             }
             else
             {
-                while (childEnumerator.MoveNext(out var child))
+                foreach (var child in xform._children)
                 {
-                    UpdateEntity(child.Value, TransformQuery.GetComponent(child.Value), spriteOccluded, lightOccluded);
+                    UpdateEntity(child, TransformQuery.GetComponent(child), spriteOccluded, lightOccluded);
                 }
             }
         }

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -982,16 +982,15 @@ namespace Robust.Client.GameStates
                 xformSys.DetachParentToNull(ent, xform);
 
                 // Then detach all children.
-                var childEnumerator = xform.ChildEnumerator;
-                while (childEnumerator.MoveNext(out var child))
+                foreach (var child in xform._children)
                 {
-                    xformSys.DetachParentToNull(child.Value, xforms.GetComponent(child.Value), xform);
+                    xformSys.DetachParentToNull(child, xforms.GetComponent(child), xform);
 
                     if (deleteClientChildren
                         && !deleteClientEntities // don't add duplicates
-                        && _entities.IsClientSide(child.Value))
+                        && _entities.IsClientSide(child))
                     {
-                        _toDelete.Add(child.Value);
+                        _toDelete.Add(child);
                     }
                 }
 
@@ -1039,7 +1038,7 @@ namespace Robust.Client.GameStates
                 var childEnumerator = xform.ChildEnumerator;
                 while (childEnumerator.MoveNext(out var child))
                 {
-                    xformSys.DetachParentToNull(child.Value, xforms.GetComponent(child.Value), xform);
+                    xformSys.DetachParentToNull(child, xforms.GetComponent(child), xform);
                 }
 
                 // Finally, delete the entity.

--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -1075,11 +1075,10 @@ public sealed class MapLoaderSystem : EntitySystem
             withoutUid.Add(uid);
         }
 
-        var enumerator = transformQuery.GetComponent(uid).ChildEnumerator;
-
-        while (enumerator.MoveNext(out var child))
+        var xform = transformQuery.GetComponent(uid);
+        foreach (var child in xform._children)
         {
-            RecursivePopulate(child.Value, entities, uidEntityMap, withoutUid, metaQuery, transformQuery, saveCompQuery);
+            RecursivePopulate(child, entities, uidEntityMap, withoutUid, metaQuery, transformQuery, saveCompQuery);
         }
     }
 

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -350,15 +350,13 @@ internal sealed partial class PvsSystem : EntitySystem
         else
             _entityPvsCollection.UpdateIndex(metadata.NetEntity, xform.MapID, indices, forceDirty: forceDirty);
 
-        var children = xform.ChildEnumerator;
-
         // TODO PERFORMANCE
         // Given uid is the parent of its children, we already know that the child xforms will have to be relative to
         // coordinates.EntityId. So instead of calling GetMoverCoordinates() for each child we should just calculate it
         // directly.
-        while (children.MoveNext(out var child))
+        foreach (var child in xform._children)
         {
-            UpdateEntityRecursive(child.Value, _metaQuery.GetComponent(child.Value), _xformQuery.GetComponent(child.Value), coordinates, true, forceDirty);
+            UpdateEntityRecursive(child, _metaQuery.GetComponent(child), _xformQuery.GetComponent(child), coordinates, true, forceDirty);
         }
     }
 

--- a/Robust.Shared/ComponentTrees/RecursiveMoveSystem.cs
+++ b/Robust.Shared/ComponentTrees/RecursiveMoveSystem.cs
@@ -58,11 +58,10 @@ internal sealed class RecursiveMoveSystem : EntitySystem
         // annoyingly, containers aren't guaranteed to occlude sprites & lights
         // but AFAIK thats currently unused???
 
-        var childEnumerator = xform.ChildEnumerator;
-        while (childEnumerator.MoveNext(out var child))
+        foreach (var child in xform._children)
         {
-            if (_xformQuery.TryGetComponent(child.Value, out var childXform))
-                AnythingMovedSubHandler(child.Value, childXform);
+            if (_xformQuery.TryGetComponent(child, out var childXform))
+                AnythingMovedSubHandler(child, childXform);
         }
     }
 }

--- a/Robust.Shared/Containers/SharedContainerSystem.Insert.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.Insert.cs
@@ -186,13 +186,11 @@ public abstract partial class SharedContainerSystem
             _physics.SetCanCollide(entity, false, false, body: physics);
         }
 
-        var enumerator = entity.Comp1.ChildEnumerator;
-
-        while (enumerator.MoveNext(out var child))
+        foreach (var child in entity.Comp1._children)
         {
-            var childXform = TransformQuery.GetComponent(child.Value);
-            PhysicsQuery.TryGetComponent(child.Value, out var childPhysics);
-            RecursivelyUpdatePhysics((child.Value, childXform, childPhysics));
+            var childXform = TransformQuery.GetComponent(child);
+            PhysicsQuery.TryGetComponent(child, out var childPhysics);
+            RecursivelyUpdatePhysics((child, childXform, childPhysics));
         }
     }
 
@@ -205,12 +203,10 @@ public abstract partial class SharedContainerSystem
             _joint.RefreshRelay(entity, jointComp);
         }
 
-        var enumerator = entity.Comp.ChildEnumerator;
-
-        while (enumerator.MoveNext(out var child))
+        foreach (var child in entity.Comp._children)
         {
-            var childXform = TransformQuery.GetComponent(child.Value);
-            RecursivelyUpdateJoints((child.Value, childXform));
+            var childXform = TransformQuery.GetComponent(child);
+            RecursivelyUpdateJoints((child, childXform));
         }
     }
 }

--- a/Robust.Shared/Containers/SharedContainerSystem.Validation.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.Validation.cs
@@ -54,18 +54,17 @@ public abstract partial class SharedContainerSystem : EntitySystem
 
     private void ValidateChildren(TransformComponent xform, EntityQuery<TransformComponent> xformQuery, EntityQuery<PhysicsComponent> physicsQuery)
     {
-        var enumerator = xform.ChildEnumerator;
-        while (enumerator.MoveNext(out var child))
+        foreach (var child in xform._children)
         {
             if (!xformQuery.TryGetComponent(child, out var childXform))
                 continue;
 
             DebugTools.Assert(!xform.Anchored,
-                $"Child of contained entity is anchored, Entity: {ToPrettyString(child.Value)}");
+                $"Child of contained entity is anchored, Entity: {ToPrettyString(child)}");
             DebugTools.Assert(!physicsQuery.TryGetComponent(child, out var physics) || (!physics.Awake && !physics.CanCollide),
-                $"Child of contained entity is can collide, Entity: {ToPrettyString(child.Value)}");
+                $"Child of contained entity is can collide, Entity: {ToPrettyString(child)}");
             DebugTools.Assert(xform.Broadphase == null,
-                $"Child of contained entity is has non-null broadphase, Entity: {ToPrettyString(child.Value)}");
+                $"Child of contained entity is has non-null broadphase, Entity: {ToPrettyString(child)}");
             ValidateChildren(childXform, xformQuery, physicsQuery);
         }
     }

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -374,23 +374,6 @@ namespace Robust.Shared.GameObjects
             }
         }
 
-        [ViewVariables]
-        public IEnumerable<TransformComponent> Children
-        {
-            get
-            {
-                if (_children.Count == 0) yield break;
-
-                var xforms = _entMan.GetEntityQuery<TransformComponent>();
-                var children = ChildEnumerator;
-
-                while (children.MoveNext(out var child))
-                {
-                    yield return xforms.GetComponent(child.Value);
-                }
-            }
-        }
-
         [ViewVariables] public IEnumerable<EntityUid> ChildEntities => _children;
 
         public TransformChildrenEnumerator ChildEnumerator => new(_children.GetEnumerator());
@@ -446,15 +429,13 @@ namespace Robust.Shared.GameObjects
             EntityQuery<MetaDataComponent> metaQuery,
             MetaDataSystem system)
         {
-            var childEnumerator = ChildEnumerator;
-
-            while (childEnumerator.MoveNext(out var child))
+            foreach (var child in _children)
             {
                 //Set Paused state
-                var metaData = metaQuery.GetComponent(child.Value);
-                system.SetEntityPaused(child.Value, mapPaused, metaData);
+                var metaData = metaQuery.GetComponent(child);
+                system.SetEntityPaused(child, mapPaused, metaData);
 
-                var concrete = xformQuery.GetComponent(child.Value);
+                var concrete = xformQuery.GetComponent(child);
 
                 concrete.MapUid = newUid;
                 concrete.MapID = newMapId;
@@ -655,11 +636,11 @@ namespace Robust.Shared.GameObjects
             _children = children;
         }
 
-        public bool MoveNext([NotNullWhen(true)] out EntityUid? child)
+        public bool MoveNext(out EntityUid child)
         {
             if (!_children.MoveNext())
             {
-                child = null;
+                child = default;
                 return false;
             }
 

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -178,10 +178,9 @@ public sealed partial class EntityLookupSystem
         }
 
         toAdd.Add(uid);
-        var childEnumerator = xform.ChildEnumerator;
-        while (childEnumerator.MoveNext(out var child))
+        foreach (var child in xform._children)
         {
-            RecursiveAdd(child.Value, ref toAdd);
+            RecursiveAdd(child, ref toAdd);
         }
     }
 

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.ComponentQueries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.ComponentQueries.cs
@@ -307,31 +307,29 @@ public sealed partial class EntityLookupSystem
 
     private void RecursiveAdd<T>(EntityUid uid, ref ValueList<T> toAdd, EntityQuery<T> query) where T : IComponent
     {
-        var childEnumerator = _xformQuery.GetComponent(uid).ChildEnumerator;
-
-        while (childEnumerator.MoveNext(out var child))
+        var xform = _xformQuery.GetComponent(uid);
+        foreach (var child in xform._children)
         {
-            if (query.TryGetComponent(child.Value, out var compies))
+            if (query.TryGetComponent(child, out var compies))
             {
                 toAdd.Add(compies);
             }
 
-            RecursiveAdd(child.Value, ref toAdd, query);
+            RecursiveAdd(child, ref toAdd, query);
         }
     }
 
     private void RecursiveAdd<T>(EntityUid uid, ref ValueList<Entity<T>> toAdd, EntityQuery<T> query) where T : IComponent
     {
-        var childEnumerator = _xformQuery.GetComponent(uid).ChildEnumerator;
-
-        while (childEnumerator.MoveNext(out var child))
+        var xform = _xformQuery.GetComponent(uid);
+        foreach (var child in xform._children)
         {
-            if (query.TryGetComponent(child.Value, out var compies))
+            if (query.TryGetComponent(child, out var compies))
             {
-                toAdd.Add((child.Value, compies));
+                toAdd.Add((child, compies));
             }
 
-            RecursiveAdd(child.Value, ref toAdd, query);
+            RecursiveAdd(child, ref toAdd, query);
         }
     }
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -355,11 +355,9 @@ public abstract partial class SharedTransformSystem
 
         DebugTools.Assert(!HasComp<MapGridComponent>(uid) || gridId == uid);
         xform._gridUid = gridId;
-        var childEnumerator = xform.ChildEnumerator;
-
-        while (childEnumerator.MoveNext(out var child))
+        foreach (var child in xform._children)
         {
-            SetGridId(child.Value, XformQuery.GetComponent(child.Value), gridId);
+            SetGridId(child, XformQuery.GetComponent(child), gridId);
         }
     }
 

--- a/Robust.Shared/Map/MapManager.Pause.cs
+++ b/Robust.Shared/Map/MapManager.Pause.cs
@@ -39,11 +39,10 @@ namespace Robust.Shared.Map
             in MetaDataSystem system)
         {
             system.SetEntityPaused(entity, paused, metaQuery.GetComponent(entity));
-            var childEnumerator = xformQuery.GetComponent(entity).ChildEnumerator;
-
-            while (childEnumerator.MoveNext(out var child))
+            var xform = xformQuery.GetComponent(entity);
+            foreach (var child in xform._children)
             {
-                RecursiveSetPaused(child.Value, paused, in xformQuery, in metaQuery, in system);
+                RecursiveSetPaused(child, paused, in xformQuery, in metaQuery, in system);
             }
         }
 

--- a/Robust.Shared/Physics/Controllers/Gravity2DController.cs
+++ b/Robust.Shared/Physics/Controllers/Gravity2DController.cs
@@ -92,11 +92,9 @@ public sealed class Gravity2DController : VirtualController
         }
 
         var xform = xformQuery.GetComponent(uid);
-        var childEnumerator = xform.ChildEnumerator;
-
-        while (childEnumerator.MoveNext(out var child))
+        foreach (var child in xform._children)
         {
-            WakeBodiesRecursive(child.Value, xformQuery, bodyQuery);
+            WakeBodiesRecursive(child, xformQuery, bodyQuery);
         }
     }
 

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
@@ -217,13 +217,13 @@ namespace Robust.Shared.Physics.Systems
             if (jointQuery.TryGetComponent(uid, out var joint))
                 _joints.ClearJoints(uid, joint);
 
-            var childEnumerator = xform.ChildEnumerator;
-            while (childEnumerator.MoveNext(out var child))
+
+            foreach (var child in xform._children)
             {
                 if (xformQuery.TryGetComponent(child, out var childXform))
                 {
                     bodyQuery.TryGetComponent(child, out var childBody);
-                    RecursiveMapUpdate(child.Value, childXform, childBody, newMap, oldMap, bodyQuery, xformQuery, jointQuery);
+                    RecursiveMapUpdate(child, childXform, childBody, newMap, oldMap, bodyQuery, xformQuery, jointQuery);
                 }
             }
         }

--- a/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
+++ b/Robust.UnitTesting/Server/Maps/MapLoaderTest.cs
@@ -105,7 +105,7 @@ entities:
                 return;
             }
 
-            var entity = entMan.GetComponent<TransformComponent>(geid).Children.Single().Owner;
+            var entity = entMan.GetComponent<TransformComponent>(geid)._children.Single();
             var c = entMan.GetComponent<MapDeserializeTestComponent>(entity);
 
             Assert.That(c.Bar, Is.EqualTo(2));


### PR DESCRIPTION
Having to use `.Value` is somewhat annoying, and I feel like there is very little chance of people accidentally using invalid entity uids with this given that they are generally in a while() loop.  This also changes some engine code to use the internal child hash set directly.

Requires space-wizards/space-station-14/pull/22442