### PR TITLE
Add a workaround for MacOS' bad CoreAudio OpenAL gain behaviour

### DIFF
--- a/Robust.Client/Audio/AudioManager.Public.cs
+++ b/Robust.Client/Audio/AudioManager.Public.cs
@@ -223,6 +223,18 @@ internal partial class AudioManager
             return;
         }
 
+
+        #region Platform hack for MacOS
+        // HACK/BUG: Apple's OpenAL implementation has a bug where values of 0f for listener gain don't actually
+        // HACK/BUG: prevent sound playback. Workaround is to cap the minimum gain at a value just above 0.
+        if (OperatingSystem.IsMacOS() && newGain == 0f)
+        {
+            OpenALSawmill.Verbose("Not setting gain to 0 because Apple can't write an OpenAL implementation");
+            AL.Listener(ALListenerf.Gain, float.Epsilon);
+            return;
+        }
+        #endregion Platform hack for MacOS
+
         AL.Listener(ALListenerf.Gain, newGain);
     }
 
@@ -269,7 +281,7 @@ internal partial class AudioManager
         _bufferedAudioSources.Remove(handle);
     }
 
-    public IAudioSource? CreateAudioSource(AudioStream stream)
+    IAudioSource? IAudioInternal.CreateAudioSource(AudioStream stream)
     {
         var source = AL.GenSource();
 
@@ -290,7 +302,7 @@ internal partial class AudioManager
     }
 
     /// <inheritdoc/>
-    public IBufferedAudioSource? CreateBufferedAudioSource(int buffers, bool floatAudio=false)
+    IBufferedAudioSource? IAudioInternal.CreateBufferedAudioSource(int buffers, bool floatAudio=false)
     {
         var source = AL.GenSource();
 


### PR DESCRIPTION
I’ve tested that this works on an M1 Mac. Curse you, Apple Computer.

```diff
    public void SetMasterGain(float newGain)
    {
        // ...snip
+
+        #region Platform hack for MacOS
+        // HACK/BUG: Apple's OpenAL implementation has a bug where values of 0f for listener gain don't actually
+        // HACK/BUG: prevent sound playback. Workaround is to cap the minimum gain at a value just above 0.
+        if (OperatingSystem.IsMacOS() && newGain == 0f)
+        {
+            OpenALSawmill.Verbose("Not setting gain to 0 because Apple can't write an OpenAL implementation");
+            AL.Listener(ALListenerf.Gain, float.Epsilon);
+            return;
+        }
+        #endregion Platform hack for MacOS
+
        AL.Listener(ALListenerf.Gain, newGain);
    }
```