### PR TITLE
.NET 8

### DIFF
--- a/.github/workflows/build-docfx.yml
+++ b/.github/workflows/build-docfx.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3.2.0
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3.2.0
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3.2.0
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
 
     - name: Package client
       run: Tools/package_client_build.py -p windows mac linux

--- a/.github/workflows/test-content.yml
+++ b/.github/workflows/test-content.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3.2.0
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Disable submodule autoupdate
       run: touch BuildChecker/DISABLE_SUBMODULE_AUTOUPDATE
 

--- a/Lidgren.Network/Lidgren.Network.csproj
+++ b/Lidgren.Network/Lidgren.Network.csproj
@@ -12,7 +12,7 @@
     <SkipRobustAnalyzer>true</SkipRobustAnalyzer>
 
     <Nullable>enable</Nullable>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MSBuild/Robust.Engine.props
+++ b/MSBuild/Robust.Engine.props
@@ -1,8 +1,8 @@
 ﻿<Project>
     <!-- Engine-specific properties. Content should not use this file. -->
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
-        <LangVersion>11</LangVersion>
+        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>12</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>
     </PropertyGroup>

--- a/MSBuild/Robust.Properties.targets
+++ b/MSBuild/Robust.Properties.targets
@@ -3,7 +3,7 @@
   <!-- Import this at the end of any project files in Robust and Content. -->
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <Import Project="Robust.Custom.targets" Condition="Exists('Robust.Custom.targets')"/>

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,7 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* Robust now uses **.NET 8**. Nyoom.
 
 ### New features
 
@@ -401,7 +401,7 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-* Most methods in ActorSystem have been moved to ISharedPlayerManager. 
+* Most methods in ActorSystem have been moved to ISharedPlayerManager.
 * Several actor/player related components and events have been moved to shared.
 
 ### New features

--- a/Robust.Client/Robust.Client.csproj
+++ b/Robust.Client/Robust.Client.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.20348-rc2" PrivateAssets="compile" />
     <PackageReference Condition="'$(FullRelease)' != 'True'" Include="JetBrains.Profiler.Api" Version="1.2.0" PrivateAssets="compile" />
     <PackageReference Include="SpaceWizards.Sodium" Version="0.2.1" PrivateAssets="compile" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(EnableClientScripting)' == 'True'">
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.1" PrivateAssets="compile" />

--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="SpaceWizards.Sodium" Version="0.2.1" PrivateAssets="compile" />
     <PackageReference Include="SharpZstd.Interop" Version="1.5.2-beta2" PrivateAssets="compile" />
     <PackageReference Condition="'$(FullRelease)' != 'True'" Include="JetBrains.Profiler.Api" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Lidgren.Network\Lidgren.Network.csproj" />

--- a/Robust.Shared/Utility/NullableHelper.cs
+++ b/Robust.Shared/Utility/NullableHelper.cs
@@ -7,7 +7,21 @@ namespace Robust.Shared.Utility
 {
     public static class NullableHelper
     {
+        //
+        // Since .NET 8, System.Runtime.CompilerServices.NullableAttribute is included in the BCL.
+        // Before this, Roslyn emitted a copy of the attribute into every assembly compiled.
+        // In the latter case we need to find the type for every assembly that has it.
+        // Yeah most of this code can probably be removed now but just for safety I'm keeping it as a fallback path.
+        //
+
         private const int NotAnnotatedNullableFlag = 1;
+
+        private static readonly Type? BclNullableCache;
+
+        static NullableHelper()
+        {
+            BclNullableCache = Type.GetType("System.Runtime.CompilerServices.NullableAttribute");
+        }
 
         private static readonly Dictionary<Assembly, (Type AttributeType, FieldInfo NullableFlagsField)?>
             _nullableAttributeTypeCache = new();
@@ -130,6 +144,7 @@ namespace Robust.Shared.Utility
         private static void CacheNullableFieldInfo(Assembly assembly)
         {
             var nullableAttributeType = assembly.GetType("System.Runtime.CompilerServices.NullableAttribute");
+            nullableAttributeType ??= BclNullableCache;
             if (nullableAttributeType == null)
             {
                 _nullableAttributeTypeCache.Add(assembly, null);

--- a/Robust.Shared/Utility/NullableHelper.cs
+++ b/Robust.Shared/Utility/NullableHelper.cs
@@ -17,10 +17,12 @@ namespace Robust.Shared.Utility
         private const int NotAnnotatedNullableFlag = 1;
 
         private static readonly Type? BclNullableCache;
+        private static readonly Type? BclNullableContextCache;
 
         static NullableHelper()
         {
             BclNullableCache = Type.GetType("System.Runtime.CompilerServices.NullableAttribute");
+            BclNullableContextCache = Type.GetType("System.Runtime.CompilerServices.NullableContextAttribute");
         }
 
         private static readonly Dictionary<Assembly, (Type AttributeType, FieldInfo NullableFlagsField)?>
@@ -165,6 +167,7 @@ namespace Robust.Shared.Utility
         {
             var nullableContextAttributeType =
                 assembly.GetType("System.Runtime.CompilerServices.NullableContextAttribute");
+            nullableContextAttributeType ??= BclNullableContextCache;
             if (nullableContextAttributeType == null)
             {
                 _nullableContextAttributeTypeCache.Add(assembly, null);

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.114",
+    "version": "8.0.100",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
There were two issues with .NET 8: serv3 breaks on some nullable issue, and publishing is broken.

The serv3 issue is because System.Runtime.CompilerServices.NullableAttribute was moved into the BCL. This means the code to find the attribute broke. The lucky thing about this is that this is an API-level break, and versions of the game built against .NET 7 will keep working even when the launcher updates to .NET 8!

The publishing issue seems to just be because Microsoft.NET.ILLink.Tasks was moved out of the base SDK. Pulling it in from NuGet makes it work.