### PR TITLE
Use FrozenDictionary for prototype instances

### DIFF
--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -111,7 +111,7 @@ public interface IPrototypeManager
     bool TryIndex<T>(string id, [NotNullWhen(true)] out T? prototype) where T : class, IPrototype;
     bool TryIndex(Type kind, string id, [NotNullWhen(true)] out IPrototype? prototype);
 
-    bool TryGetKindInstances<T>([NotNullWhen(true)] out FrozenDictionary<string, T>? instances)
+    bool TryGetInstances<T>([NotNullWhen(true)] out FrozenDictionary<string, T>? instances)
         where T : IPrototype;
 
     /// <inheritdoc cref="TryIndex{T}(string, out T)"/>

--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -109,6 +110,9 @@ public interface IPrototypeManager
 
     bool TryIndex<T>(string id, [NotNullWhen(true)] out T? prototype) where T : class, IPrototype;
     bool TryIndex(Type kind, string id, [NotNullWhen(true)] out IPrototype? prototype);
+
+    bool TryGetKindInstances<T>([NotNullWhen(true)] out FrozenDictionary<string, T>? instances)
+        where T : IPrototype;
 
     /// <inheritdoc cref="TryIndex{T}(string, out T)"/>
     bool TryIndex(EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype);

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
@@ -253,6 +253,7 @@ public partial class PrototypeManager
     {
         var reader = new StringReader(prototypes);
 
+        var modified = new HashSet<KindData>();
         foreach (var document in DataNodeParser.ParseYamlStream(reader))
         {
             var root = (SequenceDataNode)document.Root;
@@ -271,10 +272,14 @@ public partial class PrototypeManager
                 if (kindData.Inheritance is { } tree)
                     tree.Remove(id, true);
 
-                kindData.Instances.Remove(id);
+                kindData.UnfrozenInstances ??= kindData.Instances.ToDictionary();
+                kindData.UnfrozenInstances.Remove(id);
                 kindData.Results.Remove(id);
+                modified.Add(kindData);
             }
         }
+
+        Freeze(modified);
     }
 
     // All these fields can be null in case the

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -757,10 +757,10 @@ namespace Robust.Shared.Prototypes
             return true;
         }
 
-        public bool TryGetKindInstances<T>([NotNullWhen(true)] out FrozenDictionary<string, T>? instances)
+        public bool TryGetInstances<T>([NotNullWhen(true)] out FrozenDictionary<string, T>? instances)
             where T : IPrototype
         {
-            if (!TryGetKindInstances(typeof(T), out var dict))
+            if (!TryGetInstances(typeof(T), out var dict))
             {
                 instances = null;
                 return false;
@@ -771,7 +771,7 @@ namespace Robust.Shared.Prototypes
             return instances != null;
         }
 
-        private bool TryGetKindInstances(Type kind, [NotNullWhen(true)] out object? instances)
+        private bool TryGetInstances(Type kind, [NotNullWhen(true)] out object? instances)
         {
             DebugTools.Assert(kind.IsAssignableTo(typeof(IPrototype)));
             if (!_kinds.TryGetValue(kind, out var kindData))

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -377,8 +377,7 @@ namespace Robust.Shared.Prototypes
 
         private void Freeze(HashSet<KindData> kinds)
         {
-            var st = new Stopwatch();
-            st.Start();
+            var st = RStopwatch.StartNew();
             foreach (var kind in kinds)
             {
                 kind.Freeze();

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -385,7 +385,7 @@ namespace Robust.Shared.Prototypes
             }
 
             // fun fact: Sawmill can be null in tests????
-            Sawmill?.Info($"Freezing prototype instances took {st.Elapsed.TotalMilliseconds:f2}ms");
+            Sawmill?.Verbose($"Freezing prototype instances took {st.Elapsed.TotalMilliseconds:f2}ms");
         }
 
         /// <summary>

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -765,6 +765,7 @@ namespace Robust.Shared.Prototypes
                 return false;
             }
 
+            DebugTools.Assert(dict is FrozenDictionary<string, T>);
             instances = dict as FrozenDictionary<string, T>;
             return instances != null;
         }


### PR DESCRIPTION
Also adds a new method to `IPrototypeManager` that returns a `FrozenDictionary` for a specific kind. I.e., if you have to look up many entity prototypes, you can now directly retrieve a `FrozenDictionary<string, EntityPrototype>` instead of having to use the prototype manager index methods, which requires two dictionary lookups and a cast from `IPrototype`.