### PR TITLE
Add IPrototypeManager.GetInstances()

### DIFF
--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -111,8 +111,18 @@ public interface IPrototypeManager
     bool TryIndex<T>(string id, [NotNullWhen(true)] out T? prototype) where T : class, IPrototype;
     bool TryIndex(Type kind, string id, [NotNullWhen(true)] out IPrototype? prototype);
 
+    /// <summary>
+    /// Attempts to get a dictionary containing all current instances of a given prototype kind.
+    /// The dictionary will be valid up until prototypes are next reloaded.
+    /// </summary>
     bool TryGetInstances<T>([NotNullWhen(true)] out FrozenDictionary<string, T>? instances)
         where T : IPrototype;
+
+    /// <summary>
+    /// Gets a dictionary containing all current instances of a given prototype kind.
+    /// The dictionary will be valid up until prototypes are next reloaded.
+    /// </summary>
+    FrozenDictionary<string, T> GetInstances<T>() where T : IPrototype;
 
     /// <inheritdoc cref="TryIndex{T}(string, out T)"/>
     bool TryIndex(EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype);

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -79,17 +79,7 @@ namespace Robust.Shared.Prototypes
         /// <inheritdoc />
         public IEnumerable<T> EnumeratePrototypes<T>() where T : class, IPrototype
         {
-            if (!_hasEverBeenReloaded)
-            {
-                throw new InvalidOperationException("No prototypes have been loaded yet.");
-            }
-
-            var data = _kinds[typeof(T)];
-
-            foreach (var proto in data.Instances.Values)
-            {
-                yield return (T)proto;
-            }
+            return GetInstances<T>().Values;
         }
 
         /// <inheritdoc />
@@ -757,6 +747,14 @@ namespace Robust.Shared.Prototypes
             return true;
         }
 
+        public FrozenDictionary<string, T> GetInstances<T>() where T : IPrototype
+        {
+            if (TryGetInstances<T>(out var dict))
+                return dict;
+
+            throw new Exception($"Failed to fetch instances for kind {nameof(T)}");
+        }
+
         public bool TryGetInstances<T>([NotNullWhen(true)] out FrozenDictionary<string, T>? instances)
             where T : IPrototype
         {
@@ -773,6 +771,9 @@ namespace Robust.Shared.Prototypes
 
         private bool TryGetInstances(Type kind, [NotNullWhen(true)] out object? instances)
         {
+            if (!_hasEverBeenReloaded)
+                throw new InvalidOperationException("No prototypes have been loaded yet.");
+
             DebugTools.Assert(kind.IsAssignableTo(typeof(IPrototype)));
             if (!_kinds.TryGetValue(kind, out var kindData))
             {


### PR DESCRIPTION
Adds a  non-try variant of `TryGetInstances`.

Also speeds up `EnumeratePrototypes` by making it enumerate over the instance dictionary values. 