### PR TITLE
Raise ECS event on prototype-reload

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Specifier.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Specifier.cs
@@ -122,14 +122,13 @@ public sealed partial class SpriteSystem
         return GetFallbackState();
     }
 
-    private void OnPrototypesReloaded(PrototypesReloadedEventArgs protoReloaded)
+    private void OnPrototypesReloaded(PrototypesReloadedEvent args)
     {
-        // Check if any EntityPrototype has been changed.
-        if (!protoReloaded.ByType.TryGetValue(typeof(EntityPrototype), out var changedSet))
+        if (!args.TryGetModified<EntityPrototype>(out var modified))
             return;
 
         // Remove all changed prototypes from the cache, if they're there.
-        foreach (var (prototype, _) in changedSet.Modified)
+        foreach (var prototype in modified)
         {
             // Let's be lazy and not regenerate them until something needs them again.
             _cachedPrototypeIcons.Remove(prototype);

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Specifier.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Specifier.cs
@@ -122,7 +122,7 @@ public sealed partial class SpriteSystem
         return GetFallbackState();
     }
 
-    private void OnPrototypesReloaded(PrototypesReloadedEvent args)
+    private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)
     {
         if (!args.TryGetModified<EntityPrototype>(out var modified))
             return;

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
@@ -58,7 +58,7 @@ namespace Robust.Client.GameObjects
 
             UpdatesAfter.Add(typeof(SpriteTreeSystem));
 
-            _proto.PrototypesReloaded += OnPrototypesReloaded;
+            SubscribeLocalEvent<PrototypesReloadedEvent>(OnPrototypesReloaded);
             SubscribeLocalEvent<SpriteComponent, SpriteUpdateInertEvent>(QueueUpdateInert);
             SubscribeLocalEvent<SpriteComponent, ComponentInit>(OnInit);
 
@@ -75,7 +75,6 @@ namespace Robust.Client.GameObjects
         public override void Shutdown()
         {
             base.Shutdown();
-            _proto.PrototypesReloaded -= OnPrototypesReloaded;
             _cfg.UnsubValueChanged(CVars.RenderSpriteDirectionBias, OnBiasChanged);
         }
 

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
@@ -58,7 +58,7 @@ namespace Robust.Client.GameObjects
 
             UpdatesAfter.Add(typeof(SpriteTreeSystem));
 
-            SubscribeLocalEvent<PrototypesReloadedEvent>(OnPrototypesReloaded);
+            SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
             SubscribeLocalEvent<SpriteComponent, SpriteUpdateInertEvent>(QueueUpdateInert);
             SubscribeLocalEvent<SpriteComponent, ComponentInit>(OnInit);
 

--- a/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
@@ -16,17 +16,10 @@ internal sealed class PrototypeReloadSystem : EntitySystem
 
     public override void Initialize()
     {
-        _prototypes.PrototypesReloaded += OnPrototypesReloaded;
+        SubscribeLocalEvent<PrototypesReloadedEvent>(OnPrototypesReloaded);
     }
 
-    public override void Shutdown()
-    {
-        base.Shutdown();
-
-        _prototypes.PrototypesReloaded -= OnPrototypesReloaded;
-    }
-
-    private void OnPrototypesReloaded(PrototypesReloadedEventArgs eventArgs)
+    private void OnPrototypesReloaded(PrototypesReloadedEvent eventArgs)
     {
         if (!eventArgs.ByType.TryGetValue(typeof(EntityPrototype), out var set))
             return;

--- a/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
@@ -16,10 +16,10 @@ internal sealed class PrototypeReloadSystem : EntitySystem
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<PrototypesReloadedEvent>(OnPrototypesReloaded);
+        SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
     }
 
-    private void OnPrototypesReloaded(PrototypesReloadedEvent eventArgs)
+    private void OnPrototypesReloaded(PrototypesReloadedEventArgs eventArgs)
     {
         if (!eventArgs.ByType.TryGetValue(typeof(EntityPrototype), out var set))
             return;

--- a/Robust.Shared/Localization/LocalizationManager.Entity.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Entity.cs
@@ -42,12 +42,10 @@ namespace Robust.Shared.Localization
         }
 
         // Flush caches conservatively on prototype/localization changes.
-        private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)
+        private void OnPrototypesReloaded(PrototypesReloadedEvent args)
         {
-            if (!args.ByType.ContainsKey(typeof(EntityPrototype)))
-                return;
-
-            FlushEntityCache();
+            if (args.WasModified<EntityPrototype>())
+                FlushEntityCache();
         }
 
         private EntityLocData CalcEntityLoc(string prototypeId)

--- a/Robust.Shared/Localization/LocalizationManager.Entity.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Entity.cs
@@ -42,7 +42,7 @@ namespace Robust.Shared.Localization
         }
 
         // Flush caches conservatively on prototype/localization changes.
-        private void OnPrototypesReloaded(PrototypesReloadedEvent args)
+        private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)
         {
             if (args.WasModified<EntityPrototype>())
                 FlushEntityCache();

--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -334,7 +334,7 @@ public interface IPrototypeManager
     /// <remarks>
     ///     This does NOT fire on initial prototype load.
     /// </remarks>
-    event Action<PrototypesReloadedEvent> PrototypesReloaded;
+    event Action<PrototypesReloadedEventArgs> PrototypesReloaded;
 
     /// <summary>
     /// Get the yaml data for a given prototype.
@@ -351,8 +351,8 @@ internal interface IPrototypeManagerInternal : IPrototypeManager
 /// This is event contains information about prototypes that have been modified. It is broadcast as a system event,
 /// whenever <see cref="IPrototypeManager.PrototypesReloaded"/> gets invoked.
 /// </summary>
-public sealed record PrototypesReloadedEvent(HashSet<Type> Modified,
-    IReadOnlyDictionary<Type, PrototypesReloadedEvent.PrototypeChangeSet> ByType,
+public sealed record PrototypesReloadedEventArgs(HashSet<Type> Modified,
+    IReadOnlyDictionary<Type, PrototypesReloadedEventArgs.PrototypeChangeSet> ByType,
     IReadOnlyDictionary<Type, HashSet<string>>? Removed = null)
 {
     public sealed record PrototypeChangeSet(IReadOnlyDictionary<string, IPrototype> Modified);

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -368,7 +368,7 @@ namespace Robust.Shared.Prototypes
             var byType = modified
                 .ToDictionary(
                     g => g.Key,
-                    g => new PrototypesReloadedEvent.PrototypeChangeSet(
+                    g => new PrototypesReloadedEventArgs.PrototypeChangeSet(
                         g.Value.Where(x => _kinds[g.Key].Instances.ContainsKey(x))
                             .ToDictionary(a => a, a => _kinds[g.Key].Instances[a])));
 
@@ -376,7 +376,7 @@ namespace Robust.Shared.Prototypes
             if (removed != null)
                 modifiedTypes.UnionWith(removed.Keys);
 
-            var ev = new PrototypesReloadedEvent(modifiedTypes, byType, removed);
+            var ev = new PrototypesReloadedEventArgs(modifiedTypes, byType, removed);
             PrototypesReloaded?.Invoke(ev);
             _entMan.EventBus.RaiseEvent(EventSource.Local, ev);
         }
@@ -932,7 +932,7 @@ namespace Robust.Shared.Prototypes
         }
 
         /// <inheritdoc />
-        public event Action<PrototypesReloadedEvent>? PrototypesReloaded;
+        public event Action<PrototypesReloadedEventArgs>? PrototypesReloaded;
 
         private sealed class KindData(Type kind)
         {
@@ -975,7 +975,7 @@ namespace Robust.Shared.Prototypes
             }
         }
 
-        private void OnReload(PrototypesReloadedEvent args)
+        private void OnReload(PrototypesReloadedEventArgs args)
         {
             if (args.ByType.TryGetValue(typeof(EntityPrototype), out var modified))
             {

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -34,6 +34,7 @@ namespace Robust.Shared.Prototypes
         [Dependency] private readonly ILogManager _logManager = default!;
         [Dependency] private readonly ILocalizationManager _locMan = default!;
         [Dependency] private readonly IComponentFactory _factory = default!;
+        [Dependency] private readonly IEntityManager _entMan = default!;
 
         private readonly Dictionary<string, Dictionary<string, MappingDataNode>> _prototypeDataCache = new();
         private EntityDiffContext _context = new();
@@ -364,15 +365,20 @@ namespace Robust.Shared.Prototypes
 #endif
 
             //todo paul i hate it but i am not opening that can of worms in this refactor
-            PrototypesReloaded?.Invoke(
-                new PrototypesReloadedEventArgs(
-                    modified
-                        .ToDictionary(
-                            g => g.Key,
-                            g => new PrototypesReloadedEventArgs.PrototypeChangeSet(
-                                g.Value.Where(x => _kinds[g.Key].Instances.ContainsKey(x))
-                                    .ToDictionary(a => a, a => _kinds[g.Key].Instances[a]))),
-                    removed));
+            var byType = modified
+                .ToDictionary(
+                    g => g.Key,
+                    g => new PrototypesReloadedEvent.PrototypeChangeSet(
+                        g.Value.Where(x => _kinds[g.Key].Instances.ContainsKey(x))
+                            .ToDictionary(a => a, a => _kinds[g.Key].Instances[a])));
+
+            var modifiedTypes = new HashSet<Type>(byType.Keys);
+            if (removed != null)
+                modifiedTypes.UnionWith(removed.Keys);
+
+            var ev = new PrototypesReloadedEvent(modifiedTypes, byType, removed);
+            PrototypesReloaded?.Invoke(ev);
+            _entMan.EventBus.RaiseEvent(EventSource.Local, ev);
         }
 
         private void Freeze(HashSet<KindData> kinds)
@@ -926,7 +932,7 @@ namespace Robust.Shared.Prototypes
         }
 
         /// <inheritdoc />
-        public event Action<PrototypesReloadedEventArgs>? PrototypesReloaded;
+        public event Action<PrototypesReloadedEvent>? PrototypesReloaded;
 
         private sealed class KindData(Type kind)
         {
@@ -969,7 +975,7 @@ namespace Robust.Shared.Prototypes
             }
         }
 
-        private void OnReload(PrototypesReloadedEventArgs args)
+        private void OnReload(PrototypesReloadedEvent args)
         {
             if (args.ByType.TryGetValue(typeof(EntityPrototype), out var modified))
             {


### PR DESCRIPTION
The vast majority of the subscribers are systems, and they often forget to unsubscribe to the C# event.