### PR TITLE
Add `EntitySystem<TComp>` class

### DIFF
--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -563,7 +563,7 @@ public partial class EntitySystem
 
     /// <inheritdoc cref="IEntityManager.AddComponent&lt;T&gt;(EntityUid)"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected T AddComp<T>(EntityUid uid) where T :  Component, new()
+    protected T AddComp<T>(EntityUid uid) where T :  IComponent, new()
     {
         return EntityManager.AddComponent<T>(uid);
     }

--- a/Robust.Shared/GameObjects/EntitySystem.Query.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Query.cs
@@ -1,0 +1,49 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Robust.Shared.GameObjects;
+
+/// <summary>
+/// Variant of <see cref="EntitySystem"/> that has some convenience features for working with a specific component.
+/// </summary>
+public abstract partial class EntitySystem<TComp> : EntitySystem where TComp : IComponent, new()
+{
+    protected EntityQuery<TComp> Query;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        Query = GetEntityQuery<TComp>();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected bool HasComp(EntityUid uid)
+    {
+        return Query.HasComponent(uid);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected TComp Comp(EntityUid uid)
+    {
+        return Query.GetComponent(uid);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected bool TryComp(EntityUid uid, [NotNullWhen(true)] out TComp? comp)
+    {
+        return Query.TryGetComponent(uid, out comp);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected bool Resolve(EntityUid uid, ref TComp? comp)
+    {
+        return Query.Resolve(uid, ref comp);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected TComp EnsureComp(EntityUid uid)
+    {
+        Query.TryGetComponent(uid, out var comp);
+        return comp ?? EntityManager.AddComponent<TComp>(uid);
+    }
+}


### PR DESCRIPTION
Adds a new abstract class that caches a `EntityQuery<TComp>` and provides some helper methods that use the query.