### PR TITLE
Bound methods to IComponent, Unsafe.As cast instead of direct casting

### DIFF
--- a/Robust.Client/Placement/Modes/AlignSimilar.cs
+++ b/Robust.Client/Placement/Modes/AlignSimilar.cs
@@ -44,7 +44,7 @@ namespace Robust.Client.Placement.Modes
 
             var closestEntity = snapToEntities[0];
             var closestTransform = pManager.EntityManager.GetComponent<TransformComponent>(closestEntity);
-            if (!pManager.EntityManager.TryGetComponent<SpriteComponent?>(closestEntity, out var component) || component.BaseRSI == null)
+            if (!pManager.EntityManager.TryGetComponent<SpriteComponent>(closestEntity, out var component) || component.BaseRSI == null)
             {
                 return;
             }

--- a/Robust.Server/Placement/PlacementManager.cs
+++ b/Robust.Server/Placement/PlacementManager.cs
@@ -251,7 +251,7 @@ namespace Robust.Server.Placement
         /// </summary>
         public void SendPlacementBegin(EntityUid mob, int range, string objectType, string alignOption)
         {
-            if (!_entityManager.TryGetComponent<ActorComponent?>(mob, out var actor))
+            if (!_entityManager.TryGetComponent<ActorComponent>(mob, out var actor))
                 return;
 
             var playerConnection = actor.PlayerSession.Channel;
@@ -272,7 +272,7 @@ namespace Robust.Server.Placement
         /// </summary>
         public void SendPlacementBeginTile(EntityUid mob, int range, string tileType, string alignOption)
         {
-            if (!_entityManager.TryGetComponent<ActorComponent?>(mob, out var actor))
+            if (!_entityManager.TryGetComponent<ActorComponent>(mob, out var actor))
                 return;
 
             var playerConnection = actor.PlayerSession.Channel;
@@ -293,7 +293,7 @@ namespace Robust.Server.Placement
         /// </summary>
         public void SendPlacementCancel(EntityUid mob)
         {
-            if (!_entityManager.TryGetComponent<ActorComponent?>(mob, out var actor))
+            if (!_entityManager.TryGetComponent<ActorComponent>(mob, out var actor))
                 return;
 
             var playerConnection = actor.PlayerSession.Channel;

--- a/Robust.Shared.Scripting/ScriptGlobalsShared.cs
+++ b/Robust.Shared.Scripting/ScriptGlobalsShared.cs
@@ -193,7 +193,7 @@ namespace Robust.Shared.Scripting
         public bool TryComp<T>(EntityUid uid, out T? comp) where T : IComponent
             => ent.TryGetComponent(uid, out comp);
 
-        public bool HasComp<T>(EntityUid uid)
+        public bool HasComp<T>(EntityUid uid) where T: IComponent
             => ent.HasComponent<T>(uid);
 
         public EntityUid Spawn(string? prototype, EntityCoordinates position)

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -154,7 +154,7 @@ public partial class EntitySystem
     ///     Marks a component as dirty. This also implicitly dirties the entity this component belongs to.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected void Dirty<T>(Entity<T> ent, MetaDataComponent? meta = null) where T : IComponent?
+    protected void Dirty<T>(Entity<T> ent, MetaDataComponent? meta = null) where T : IComponent
     {
         var comp = ent.Comp;
         if (comp == null && !EntityManager.TryGetComponent(ent.Owner, out comp))
@@ -167,7 +167,7 @@ public partial class EntitySystem
     ///     Marks a component as dirty. This also implicitly dirties the entity this component belongs to.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected void Dirty<T>(Entity<T, MetaDataComponent> ent) where T : IComponent?
+    protected void Dirty<T>(Entity<T, MetaDataComponent> ent) where T : IComponent
     {
         var comp = ent.Comp1;
         if (comp == null && !EntityManager.TryGetComponent(ent.Owner, out comp))
@@ -480,6 +480,7 @@ public partial class EntitySystem
     /// <inheritdoc cref="IEntityManager.GetComponents&lt;T&gt;"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected IEnumerable<T> AllComps<T>(EntityUid uid)
+        where T: IComponent
     {
         return EntityManager.GetComponents<T>(uid);
     }
@@ -526,6 +527,7 @@ public partial class EntitySystem
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected bool HasComp<T>(EntityUid uid)
+        where T: IComponent
     {
         return EntityManager.HasComponent<T>(uid);
     }
@@ -544,6 +546,7 @@ public partial class EntitySystem
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected bool HasComp<T>([NotNullWhen(true)] EntityUid? uid)
+        where T: IComponent
     {
         return EntityManager.HasComponent<T>(uid);
     }

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -79,7 +79,7 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         /// <typeparam name="T">The component reference type to remove.</typeparam>
         /// <param name="uid">Entity UID to modify.</param>
-        bool RemoveComponent<T>(EntityUid uid, MetaDataComponent? meta = null);
+        bool RemoveComponent<T>(EntityUid uid, MetaDataComponent? meta = null) where T: IComponent;
 
         /// <summary>
         ///     Removes the component with a specified type.
@@ -110,7 +110,7 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         /// <typeparam name="T">The component reference type to remove.</typeparam>
         /// <param name="uid">Entity UID to modify.</param>
-        bool RemoveComponentDeferred<T>(EntityUid uid);
+        bool RemoveComponentDeferred<T>(EntityUid uid) where T: IComponent;
 
         /// <summary>
         ///     Immediately shuts down a component, but defers the removal and deletion until the end of the tick.
@@ -164,7 +164,7 @@ namespace Robust.Shared.GameObjects
         /// <typeparam name="T">Component reference type to check for.</typeparam>
         /// <param name="uid">Entity UID to check.</param>
         /// <returns>True if the entity has the component type, otherwise false.</returns>
-        bool HasComponent<T>(EntityUid uid);
+        bool HasComponent<T>(EntityUid uid) where T : IComponent;
 
         /// <summary>
         ///     Checks if the entity has a component type.
@@ -172,7 +172,7 @@ namespace Robust.Shared.GameObjects
         /// <typeparam name="T">Component reference type to check for.</typeparam>
         /// <param name="uid">Entity UID to check.</param>
         /// <returns>True if the entity has the component type, otherwise false.</returns>
-        bool HasComponent<T>(EntityUid? uid);
+        bool HasComponent<T>(EntityUid? uid) where T : IComponent;
 
         /// <summary>
         ///     Checks if the entity has a component type.
@@ -281,7 +281,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="uid">Entity UID to check.</param>
         /// <param name="component">Component of the specified type (if exists).</param>
         /// <returns>If the component existed in the entity.</returns>
-        bool TryGetComponent<T>(EntityUid uid, [NotNullWhen(true)] out T? component);
+        bool TryGetComponent<T>(EntityUid uid, [NotNullWhen(true)] out T? component) where T : IComponent;
 
         /// <summary>
         ///     Returns the component of a specific type.
@@ -290,7 +290,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="uid">Entity UID to check.</param>
         /// <param name="component">Component of the specified type (if exists).</param>
         /// <returns>If the component existed in the entity.</returns>
-        bool TryGetComponent<T>([NotNullWhen(true)] EntityUid? uid, [NotNullWhen(true)] out T? component);
+        bool TryGetComponent<T>([NotNullWhen(true)] EntityUid? uid, [NotNullWhen(true)] out T? component) where T : IComponent;
 
         /// <summary>
         ///     Returns the component of a specific type.
@@ -361,7 +361,7 @@ namespace Robust.Shared.GameObjects
         /// <typeparam name="T">A trait or type of a component to retrieve.</typeparam>
         /// <param name="uid">Entity UID to look on.</param>
         /// <returns>All components that are assignable to the specified type.</returns>
-        IEnumerable<T> GetComponents<T>(EntityUid uid);
+        IEnumerable<T> GetComponents<T>(EntityUid uid) where T : IComponent;
 
         /// <summary>
         /// Returns the number of components on this entity.

--- a/Robust.Shared/GameObjects/Systems/SharedEyeSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedEyeSystem.cs
@@ -58,7 +58,9 @@ public abstract class SharedEyeSystem : EntitySystem
 
         entity.Comp.DrawLight = value;
         entity.Comp.Eye.DrawLight = value;
-        Dirty(entity);
+
+        var e = new Entity<EyeComponent>(entity.Owner, entity.Comp);
+        Dirty(e);
     }
 
     public void SetRotation(EntityUid uid, Angle rotation, EyeComponent? eyeComponent = null)

--- a/Robust.Shared/Localization/LocalizationManager.Entity.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Entity.cs
@@ -25,7 +25,7 @@ namespace Robust.Shared.Localization
 
         private bool TryGetEntityLocAttrib(EntityUid entity, string attribute, [NotNullWhen(true)] out string? value)
         {
-            if (_entMan.TryGetComponent<GrammarComponent?>(entity, out var grammar) &&
+            if (_entMan.TryGetComponent<GrammarComponent>(entity, out var grammar) &&
                 grammar.Attributes.TryGetValue(attribute, out value))
             {
                 return true;

--- a/Robust.Shared/Localization/LocalizationManager.Functions.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Functions.cs
@@ -174,7 +174,7 @@ namespace Robust.Shared.Localization
             {
                 EntityUid entity = (EntityUid)entity0.Value;
 
-                if (_entMan.TryGetComponent<GrammarComponent?>(entity, out var grammar) && grammar.Gender.HasValue)
+                if (_entMan.TryGetComponent<GrammarComponent>(entity, out var grammar) && grammar.Gender.HasValue)
                 {
                     return new LocValueString(grammar.Gender.Value.ToString().ToLowerInvariant());
                 }
@@ -307,7 +307,7 @@ namespace Robust.Shared.Localization
             {
                 EntityUid entity = (EntityUid)entity0.Value;
 
-                if (_entMan.TryGetComponent<GrammarComponent?>(entity, out var grammar) && grammar.ProperNoun.HasValue)
+                if (_entMan.TryGetComponent<GrammarComponent>(entity, out var grammar) && grammar.ProperNoun.HasValue)
                 {
                     return new LocValueString(grammar.ProperNoun.Value.ToString().ToLowerInvariant());
                 }


### PR DESCRIPTION
unsafe.as is faster than a (T) cast in situations where its guaranteed to be of the correct type, and with the bounds these all should be

it is possible this isnt safe and im missing something! so dont merge if you dont know either

this i think redoes some of the work from reverted PRs for arch? but either way this should be done regardless of arch

requires https://github.com/space-wizards/space-station-14/pull/22692