### PR TITLE
Make integration tests fail when logging console errors

### DIFF
--- a/Robust.Client/Console/ClientConsoleHost.Completions.cs
+++ b/Robust.Client/Console/ClientConsoleHost.Completions.cs
@@ -8,7 +8,7 @@ using Robust.Shared.Network.Messages;
 
 namespace Robust.Client.Console;
 
-internal sealed partial class ClientConsoleHost
+internal partial class ClientConsoleHost
 {
     private readonly Dictionary<int, PendingCompletion> _completionsPending = new();
     private int _completionSeq;

--- a/Robust.Client/Console/ClientConsoleHost.cs
+++ b/Robust.Client/Console/ClientConsoleHost.cs
@@ -47,7 +47,8 @@ namespace Robust.Client.Console
     }
 
     /// <inheritdoc cref="IClientConsoleHost" />
-    internal sealed partial class ClientConsoleHost : ConsoleHost, IClientConsoleHost, IConsoleHostInternal, IPostInjectInit
+    [Virtual]
+    internal partial class ClientConsoleHost : ConsoleHost, IClientConsoleHost, IConsoleHostInternal, IPostInjectInit
     {
         [Dependency] private readonly IClientConGroupController _conGroup = default!;
         [Dependency] private readonly IConfigurationManager _cfg = default!;

--- a/Robust.Server/Console/ServerConsoleHost.cs
+++ b/Robust.Server/Console/ServerConsoleHost.cs
@@ -15,7 +15,8 @@ using Robust.Shared.Utility;
 namespace Robust.Server.Console
 {
     /// <inheritdoc cref="IServerConsoleHost" />
-    internal sealed class ServerConsoleHost : ConsoleHost, IServerConsoleHost, IConsoleHostInternal
+    [Virtual]
+    internal class ServerConsoleHost : ConsoleHost, IServerConsoleHost, IConsoleHostInternal
     {
         [Dependency] private readonly IConGroupController _groupController = default!;
         [Dependency] private readonly IPlayerManager _players = default!;
@@ -127,10 +128,16 @@ namespace Robust.Server.Console
                     // toolshed time
                     _toolshed.InvokeCommand(shell, command, null, out var res, out var ctx);
 
+                    bool anyErrors = false;
                     foreach (var err in ctx.GetErrors())
                     {
+                        anyErrors = true;
                         ctx.WriteLine(err.Describe());
                     }
+
+                    // why does ctx not have any write-error support?
+                    if (anyErrors)
+                        shell.WriteError($"Failed to execute toolshed command");
 
                     shell.WriteLine(FormattedMessage.FromMarkupPermissive(_toolshed.PrettyPrintType(res, out var more, moreUsed: true)));
                     ctx.WriteVar("more", more);

--- a/Robust.UnitTesting/RobustIntegrationTest.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.cs
@@ -272,6 +272,7 @@ namespace Robust.UnitTesting
             public IGameTiming Timing { get; private set; } = default!;
             public IMapManager MapMan { get; private set; } = default!;
             public IConsoleHost ConsoleHost { get; private set; } = default!;
+            public ISawmill Log { get; private set; } = default!;
 
             protected virtual void ResolveIoC(IDependencyCollection deps)
             {
@@ -282,6 +283,7 @@ namespace Robust.UnitTesting
                 Timing = deps.Resolve<IGameTiming>();
                 MapMan = deps.Resolve<IMapManager>();
                 ConsoleHost = deps.Resolve<IConsoleHost>();
+                Log = deps.Resolve<ILogManager>().GetSawmill("test");
             }
 
             public T System<T>() where T : IEntitySystem

--- a/Robust.UnitTesting/RobustIntegrationTest.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
 using Robust.Client;
+using Robust.Client.Console;
 using Robust.Client.GameStates;
 using Robust.Client.Player;
 using Robust.Client.Timing;
@@ -668,6 +669,9 @@ namespace Robust.UnitTesting
                 deps.Register<TestingModLoader, TestingModLoader>(true);
                 deps.RegisterInstance<IStatusHost>(new Mock<IStatusHost>().Object, true);
                 deps.Register<IRobustMappedStringSerializer, IntegrationMappedStringSerializer>(true);
+                deps.Register<IServerConsoleHost, TestingServerConsoleHost>(true);
+                deps.Register<IConsoleHost, TestingServerConsoleHost>(true);
+                deps.Register<IConsoleHostInternal, TestingServerConsoleHost>(true);
                 Options?.InitIoC?.Invoke();
                 deps.BuildGraph();
                 //ServerProgram.SetupLogging();
@@ -836,6 +840,9 @@ namespace Robust.UnitTesting
                 deps.Register<IModLoaderInternal, TestingModLoader>(true);
                 deps.Register<TestingModLoader, TestingModLoader>(true);
                 deps.Register<IRobustMappedStringSerializer, IntegrationMappedStringSerializer>(true);
+                deps.Register<IClientConsoleHost, TestingClientConsoleHost>(true);
+                deps.Register<IConsoleHost, TestingClientConsoleHost>(true);
+                deps.Register<IConsoleHostInternal, TestingClientConsoleHost>(true);
                 Options?.InitIoC?.Invoke();
                 deps.BuildGraph();
 

--- a/Robust.UnitTesting/Shared/EngineIntegrationTest_Test.cs
+++ b/Robust.UnitTesting/Shared/EngineIntegrationTest_Test.cs
@@ -28,6 +28,24 @@ namespace Robust.UnitTesting.Shared
         }
 
         [Test]
+        public async Task  ConsoleErrorsFailTest()
+        {
+            var server = StartServer();
+            var client = StartClient();
+            await Task.WhenAll(client.WaitIdleAsync(), server.WaitIdleAsync());
+
+            // test missing commands
+            await client.WaitPost(() => Assert.Throws<AssertionException>(() => client.ConsoleHost.ExecuteCommand("aaaaaaaa")));
+
+            // test invalid commands / missing arguments
+            await client.WaitPost(() => Assert.Throws<AssertionException>(() => client.ConsoleHost.ExecuteCommand("cvar")));
+
+            // and repeat for the server
+            await server.WaitPost(() => Assert.Throws<AssertionException>(() => server.ConsoleHost.ExecuteCommand("aaaaaaaa")));
+            await server.WaitPost(() => Assert.Throws<AssertionException>(() => server.ConsoleHost.ExecuteCommand("cvar")));
+        }
+
+        [Test]
         public async Task ServerClientPairConnectCorrectlyTest()
         {
             var server = StartServer();

--- a/Robust.UnitTesting/TestingConsoleHost.cs
+++ b/Robust.UnitTesting/TestingConsoleHost.cs
@@ -1,0 +1,24 @@
+﻿using NUnit.Framework;
+using Robust.Client.Console;
+using Robust.Server.Console;
+using Robust.Shared.Player;
+
+namespace Robust.UnitTesting;
+
+internal sealed class TestingServerConsoleHost : ServerConsoleHost
+{
+    public override void WriteError(ICommonSession? session, string text)
+    {
+        base.WriteError(session, text);
+        Assert.Fail($"Console command encountered an error: {text}");
+    }
+}
+
+internal sealed class TestingClientConsoleHost : ClientConsoleHost
+{
+    public override void WriteError(ICommonSession? session, string text)
+    {
+        base.WriteError(session, text);
+        Assert.Fail($"Console command encountered an error: {text}");
+    }
+}


### PR DESCRIPTION
Several tests rely on console commands, and apparently there is nothing that actually ensures that tests fail if the command doesn't exist or is invalid.