### PR TITLE
Don't defer grid traversals

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -532,7 +532,6 @@ namespace Robust.Client.GameStates
             using var __ = _timing.StartStateApplicationArea();
 
             // This is terrible, and I hate it. This also needs to run even when prediction is disabled.
-            _entitySystemManager.GetEntitySystem<SharedGridTraversalSystem>().QueuedEvents.Clear();
             _entitySystemManager.GetEntitySystem<TransformSystem>().Reset();
 
             if (!PredictionNeedsResetting)

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -625,6 +625,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         ///     If true, this event was generated during component state handling. This means it can be ignored in some instances.
         /// </summary>
+        [Obsolete("Check IGameTiming.ApplyingState")]
         public readonly bool FromStateHandling;
     }
 

--- a/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
@@ -57,7 +57,6 @@ internal sealed class SharedGridTraversalSystem : EntitySystem
         // - Is in nullspace
         // - Current parent is not a grid / map
 
-        // If move event arose from state handling, don't bother to run grid traversal logic.
         if (moveEv.FromStateHandling ||
             xform.Anchored ||
             (xform.GridUid != xform.ParentUid &&

--- a/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
@@ -14,6 +14,7 @@ internal sealed class SharedGridTraversalSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     private EntityQuery<MapGridComponent> _gridQuery;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     /// <summary>
     /// Enables or disables changing grid / map uid upon moving.
@@ -44,7 +45,7 @@ internal sealed class SharedGridTraversalSystem : EntitySystem
 
     private void OnMove(ref MoveEvent moveEv)
     {
-        if (!Enabled)
+        if (!Enabled || _timing.ApplyingState)
             return;
 
         var entity = moveEv.Sender;

--- a/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
@@ -68,7 +68,12 @@ internal sealed class SharedGridTraversalSystem : EntitySystem
             return;
         }
 
-        var mapPos = moveEv.NewPosition.ToMapPos(EntityManager, _transform);
+        DebugTools.Assert(!HasComp<MapGridComponent>(entity));
+        DebugTools.Assert(!HasComp<MapComponent>(entity));
+
+        var mapPos = xform.ParentUid == xform.MapUid
+            ? xform.LocalPosition
+            : Transform(xform.ParentUid).LocalMatrix.Transform(xform.LocalPosition);
 
         // Change parent if necessary
         if (_mapManager.TryFindGridAt(moveEv.Component.MapID, mapPos, out var gridUid, out _))

--- a/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
@@ -13,12 +13,17 @@ internal sealed class SharedGridTraversalSystem : EntitySystem
     [Dependency] private readonly IMapManagerInternal _mapManager = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
-    public Stack<MoveEvent> QueuedEvents = new();
-    private HashSet<EntityUid> _handledThisTick = new();
+    private EntityQuery<MapGridComponent> _gridQuery;
+
+    /// <summary>
+    /// Enables or disables changing grid / map uid upon moving.
+    /// </summary>
+    public bool Enabled = true;
 
     public override void Initialize()
     {
         base.Initialize();
+        _gridQuery = GetEntityQuery<MapGridComponent>();
         _transform.OnGlobalMoveEvent += OnMove;
     }
 
@@ -29,76 +34,49 @@ internal sealed class SharedGridTraversalSystem : EntitySystem
 
     internal void CheckTraverse(EntityUid uid, TransformComponent xform)
     {
-        QueuedEvents.Push(new MoveEvent(uid, xform.Coordinates, xform.Coordinates, xform.LocalRotation, xform.LocalRotation, xform, false));
+        if (!Enabled)
+            return;
+
+        var moveEv = new MoveEvent(uid, xform.Coordinates, xform.Coordinates, xform.LocalRotation, xform.LocalRotation, xform, false);
+
+        OnMove(ref moveEv);
     }
 
-    private void OnMove(ref MoveEvent ev)
+    private void OnMove(ref MoveEvent moveEv)
     {
+        if (!Enabled)
+            return;
+
+        var entity = moveEv.Sender;
+        var xform = moveEv.Component;
+
+        // Don't run logic if:
+        // - Part of state handling
+        // - Is anchored
+        // - Is a grid
+        // - Is in nullspace
+        // - Current parent is not a grid / map
+
         // If move event arose from state handling, don't bother to run grid traversal logic.
-        if (ev.FromStateHandling)
-            return;
-
-        if (ev.Component.MapID == MapId.Nullspace)
-            return;
-
-        QueuedEvents.Push(ev);
-    }
-
-    public void ProcessMovement()
-    {
-        var maps = GetEntityQuery<MapComponent>();
-        var grids = GetEntityQuery<MapGridComponent>();
-        var xforms = GetEntityQuery<TransformComponent>();
-        var metas = GetEntityQuery<MetaDataComponent>();
-
-        while (QueuedEvents.TryPop(out var moveEvent))
-        {
-            if (!_handledThisTick.Add(moveEvent.Sender)) continue;
-
-            HandleMove(ref moveEvent, xforms, maps, grids, metas);
-        }
-
-        _handledThisTick.Clear();
-    }
-
-    private void HandleMove(
-        ref MoveEvent moveEvent,
-        EntityQuery<TransformComponent> xforms,
-        EntityQuery<MapComponent> maps,
-        EntityQuery<MapGridComponent> grids,
-        EntityQuery<MetaDataComponent> metas)
-    {
-        var entity = moveEvent.Sender;
-
-        if (!metas.TryGetComponent(entity, out var meta) ||
-            meta.EntityDeleted ||
-            (meta.Flags & MetaDataFlags.InContainer) == MetaDataFlags.InContainer ||
-            maps.HasComponent(entity) ||
-            grids.HasComponent(entity) ||
-            !xforms.TryGetComponent(entity, out var xform) ||
-            // If the entity is anchored then we know for sure it's on the grid and not traversing
-            xform.Anchored)
+        if (moveEv.FromStateHandling ||
+            xform.Anchored ||
+            (xform.GridUid != xform.ParentUid &&
+             xform.MapUid != xform.ParentUid) ||
+            xform.MapID == MapId.Nullspace ||
+            _gridQuery.HasComponent(moveEv.Sender))
         {
             return;
         }
 
-        // DebugTools.Assert(!float.IsNaN(moveEvent.NewPosition.X) && !float.IsNaN(moveEvent.NewPosition.Y));
-
-        // We only do grid-traversal parent changes if the entity is currently parented to a map or a grid.
-        var parentIsMap = xform.GridUid == null && maps.HasComponent(xform.ParentUid);
-        if (!parentIsMap && !grids.HasComponent(xform.ParentUid))
-            return;
-        var mapPos = moveEvent.NewPosition.ToMapPos(EntityManager, _transform);
+        var mapPos = moveEv.NewPosition.ToMapPos(EntityManager, _transform);
 
         // Change parent if necessary
-        if (_mapManager.TryFindGridAt(xform.MapID, mapPos, out var gridUid, out _))
+        if (_mapManager.TryFindGridAt(moveEv.Component.MapID, mapPos, out var gridUid, out _))
         {
             // Some minor duplication here with AttachParent but only happens when going on/off grid so not a big deal ATM.
             if (gridUid != xform.GridUid)
             {
-                _transform.SetParent(entity, xform, gridUid, xforms);
-                var ev = new ChangedGridEvent(entity, xform.GridUid, gridUid);
-                RaiseLocalEvent(entity, ref ev);
+                _transform.SetParent(entity, xform, gridUid);
             }
         }
         else
@@ -109,17 +87,8 @@ internal sealed class SharedGridTraversalSystem : EntitySystem
             if (oldGridId != null)
             {
                 _transform.SetParent(entity, xform, xform.MapUid!.Value);
-                var ev = new ChangedGridEvent(entity, oldGridId, null);
-                RaiseLocalEvent(entity, ref ev);
             }
         }
     }
 }
 
-[ByRefEvent]
-public readonly record struct ChangedGridEvent(EntityUid Entity, EntityUid? OldGrid, EntityUid? NewGrid)
-{
-    public readonly EntityUid Entity = Entity;
-    public readonly EntityUid? OldGrid = OldGrid;
-    public readonly EntityUid? NewGrid = NewGrid;
-}

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
@@ -328,8 +328,6 @@ namespace Robust.Shared.Physics.Systems
                         FinalStep(comp);
                     }
                 }
-
-                _traversal.ProcessMovement();
             }
         }
 


### PR DESCRIPTION
Transform is in a slightly better state so we can remove this hacky thing.

It got to the point it was doing a bunch of unnecessary checks (no need to check container if you're just checking map / grid parent assuming no map / grid has containers).

The main concern now is: Does not deferring cause any issues, which it doesn't seem to (previously this mostly happened with transform state handling). On server-side the main worry is broadphasesystem seeing as this is being run manually to check for entities entering grids.