### PR TITLE
Reduce robust mapped string allocs

### DIFF
--- a/Robust.Shared/Serialization/RobustMappedStringSerializer.MappedStringDict.cs
+++ b/Robust.Shared/Serialization/RobustMappedStringSerializer.MappedStringDict.cs
@@ -259,8 +259,11 @@ namespace Robust.Shared.Serialization
                     {
                         for (var sl = 1; sl <= parts.Length - si; ++sl)
                         {
-                            var subSubStr = String.Concat(parts.Skip(si).Take(sl));
-                            AddString(subSubStr);
+                            // Don't ask me what the original was doing; we just skip by si and take sl
+                            // Use string interning as this is quite intensive.
+                            var end = si + sl;
+                            var subBetter = string.Concat(parts[si..^(parts.Length - end)]);
+                            AddString(subBetter);
                         }
                     }
                 }

--- a/Robust.Shared/Serialization/RobustMappedStringSerializer.MappedStringDict.cs
+++ b/Robust.Shared/Serialization/RobustMappedStringSerializer.MappedStringDict.cs
@@ -260,7 +260,7 @@ namespace Robust.Shared.Serialization
                         for (var sl = 1; sl <= parts.Length - si; ++sl)
                         {
                             // Don't ask me what the original was doing; we just skip by si and take sl
-                            // Use string interning as this is quite intensive.
+                            // Can be reduced even further if you know what you're doin
                             var end = si + sl;
                             var subBetter = string.Concat(parts[si..^(parts.Length - end)]);
                             AddString(subBetter);


### PR DESCRIPTION
![image](https://github.com/space-wizards/RobustToolbox/assets/31366439/24bc16e1-b9c1-4906-8d70-931ba1a61a3b)

Top entry disappears.

Was tempted to use string.Intern as the string.Concat features heavily but wasn't sure if it would cause issues due to new data being sent or whatever and have opted to leave it for now.