### PR TITLE
Generic variants of `AssertEqual` methods

### DIFF
--- a/Robust.Shared/IoC/DependencyCollection.cs
+++ b/Robust.Shared/IoC/DependencyCollection.cs
@@ -267,8 +267,7 @@ namespace Robust.Shared.IoC
                 _pendingResolves.Enqueue(interfaceType);
             }
         }
-
-        [AssertionMethod]
+        
         private void CheckRegisterInterface(Type interfaceType, Type implementationType, bool overwrite)
         {
             lock (_serviceBuildLock)

--- a/Robust.Shared/Utility/DebugTools.cs
+++ b/Robust.Shared/Utility/DebugTools.cs
@@ -42,7 +42,6 @@ namespace Robust.Shared.Utility
         ///     <see cref="objA"/> and <see cref="objB"/> are not equal.
         /// </summary>
         [Conditional("DEBUG")]
-        [AssertionMethod]
         public static void AssertEqual(object? objA, object? objB)
         {
             if (ReferenceEquals(objA, objB))
@@ -57,7 +56,6 @@ namespace Robust.Shared.Utility
         ///     <see cref="objA"/> and <see cref="objB"/> are not equal.
         /// </summary>
         [Conditional("DEBUG")]
-        [AssertionMethod]
         public static void AssertEqual(object? objA, object? objB, string message)
         {
             if (ReferenceEquals(objA, objB))
@@ -72,7 +70,6 @@ namespace Robust.Shared.Utility
         ///     <see cref="objA"/> and <see cref="objB"/> are not equal.
         /// </summary>
         [Conditional("DEBUG")]
-        [AssertionMethod]
         public static void AssertEqual<T>(T? objA, T? objB)
             where T: IEquatable<T>
         {
@@ -88,7 +85,6 @@ namespace Robust.Shared.Utility
         ///     <see cref="objA"/> and <see cref="objB"/> are not equal.
         /// </summary>
         [Conditional("DEBUG")]
-        [AssertionMethod]
         public static void AssertEqual<T>(T? objA, T? objB, string message)
             where T: IEquatable<T>
         {
@@ -104,7 +100,6 @@ namespace Robust.Shared.Utility
         ///     <see cref="objA"/> and <see cref="objB"/> are equal.
         /// </summary>
         [Conditional("DEBUG")]
-        [AssertionMethod]
         public static void AssertNotEqual(object? objA, object? objB)
         {
             if (ReferenceEquals(objA, objB))
@@ -121,7 +116,6 @@ namespace Robust.Shared.Utility
         ///     <see cref="objA"/> and <see cref="objB"/> are not equal.
         /// </summary>
         [Conditional("DEBUG")]
-        [AssertionMethod]
         public static void AssertNotEqual(object? objA, object? objB, string message)
         {
             if (ReferenceEquals(objA, objB))
@@ -138,7 +132,6 @@ namespace Robust.Shared.Utility
         ///     <see cref="objA"/> and <see cref="objB"/> are equal.
         /// </summary>
         [Conditional("DEBUG")]
-        [AssertionMethod]
         public static void AssertNotEqual<T>(T? objA, T? objB)
             where T: IEquatable<T>
         {
@@ -156,7 +149,6 @@ namespace Robust.Shared.Utility
         ///     <see cref="objA"/> and <see cref="objB"/> are not equal.
         /// </summary>
         [Conditional("DEBUG")]
-        [AssertionMethod]
         public static void AssertNotEqual<T>(T? objA, T? objB, string message)
             where T: IEquatable<T>
         {
@@ -170,7 +162,6 @@ namespace Robust.Shared.Utility
         }
 
         [Conditional("DEBUG")]
-        [AssertionMethod]
         public static void AssertOwner(EntityUid? uid, IComponent? component)
         {
             if (component == null)

--- a/Robust.Shared/Utility/DebugTools.cs
+++ b/Robust.Shared/Utility/DebugTools.cs
@@ -37,6 +37,10 @@ namespace Robust.Shared.Utility
                 throw new DebugAssertException();
         }
 
+        /// <summary>
+        ///     An assertion that will <see langword="throw"/> an exception if
+        ///     <see cref="objA"/> and <see cref="objB"/> are not equal.
+        /// </summary>
         [Conditional("DEBUG")]
         [AssertionMethod]
         public static void AssertEqual(object? objA, object? objB)
@@ -48,6 +52,10 @@ namespace Robust.Shared.Utility
                 throw new DebugAssertException($"Expected: {objB ?? "null"} but was {objA ?? "null"}");
         }
 
+        /// <summary>
+        ///     An assertion that will <see langword="throw"/> an exception with <see cref="message"/> embedded if
+        ///     <see cref="objA"/> and <see cref="objB"/> are not equal.
+        /// </summary>
         [Conditional("DEBUG")]
         [AssertionMethod]
         public static void AssertEqual(object? objA, object? objB, string message)
@@ -59,6 +67,42 @@ namespace Robust.Shared.Utility
                 throw new DebugAssertException($"{message}\nExpected: {objB ?? "null"} but was {objA ?? "null"}");
         }
 
+        /// <summary>
+        ///     A non-boxing assertion that will <see langword="throw"/> an exception if
+        ///     <see cref="objA"/> and <see cref="objB"/> are not equal.
+        /// </summary>
+        [Conditional("DEBUG")]
+        [AssertionMethod]
+        public static void AssertEqual<T>(T? objA, T? objB)
+            where T: IEquatable<T>
+        {
+            if (objA == null && objB == null)
+                return;
+
+            if (objA == null || !objA.Equals(objB))
+                throw new DebugAssertException($"Expected: {objB?.ToString() ?? "null"} but was {objA?.ToString() ?? "null"}");
+        }
+
+        /// <summary>
+        ///     A non-boxing assertion that will <see langword="throw"/> an exception with <see cref="message"/> embedded if
+        ///     <see cref="objA"/> and <see cref="objB"/> are not equal.
+        /// </summary>
+        [Conditional("DEBUG")]
+        [AssertionMethod]
+        public static void AssertEqual<T>(T? objA, T? objB, string message)
+            where T: IEquatable<T>
+        {
+            if (objA == null && objB == null)
+                return;
+
+            if (objA == null || !objA.Equals(objB))
+                throw new DebugAssertException($"{message}\nExpected: {objB?.ToString() ?? "null"} but was {objA?.ToString() ?? "null"}");
+        }
+
+        /// <summary>
+        ///     An assertion that will <see langword="throw"/> an exception if
+        ///     <see cref="objA"/> and <see cref="objB"/> are equal.
+        /// </summary>
         [Conditional("DEBUG")]
         [AssertionMethod]
         public static void AssertNotEqual(object? objA, object? objB)
@@ -72,6 +116,10 @@ namespace Robust.Shared.Utility
             throw new DebugAssertException($"Expected: not {objB}");
         }
 
+        /// <summary>
+        ///     An assertion that will <see langword="throw"/> an exception with <see cref="message"/> embedded if
+        ///     <see cref="objA"/> and <see cref="objB"/> are not equal.
+        /// </summary>
         [Conditional("DEBUG")]
         [AssertionMethod]
         public static void AssertNotEqual(object? objA, object? objB, string message)
@@ -83,6 +131,42 @@ namespace Robust.Shared.Utility
                 return;
 
             throw new DebugAssertException($"{message}\nExpected: not {objB}");
+        }
+
+        /// <summary>
+        ///     A non-boxing assertion that will <see langword="throw"/> an exception if
+        ///     <see cref="objA"/> and <see cref="objB"/> are equal.
+        /// </summary>
+        [Conditional("DEBUG")]
+        [AssertionMethod]
+        public static void AssertNotEqual<T>(T? objA, T? objB)
+            where T: IEquatable<T>
+        {
+            if (objA == null && objB == null)
+                throw new DebugAssertException("Expected: not null");
+
+            if (objA == null || !objA.Equals(objB))
+                return;
+
+            throw new DebugAssertException($"Expected: not {objB?.ToString() ?? "null"}");
+        }
+
+        /// <summary>
+        ///     An assertion that will <see langword="throw"/> an exception with <see cref="message"/> embedded if
+        ///     <see cref="objA"/> and <see cref="objB"/> are not equal.
+        /// </summary>
+        [Conditional("DEBUG")]
+        [AssertionMethod]
+        public static void AssertNotEqual<T>(T? objA, T? objB, string message)
+            where T: IEquatable<T>
+        {
+            if (objA == null && objB == null)
+                throw new DebugAssertException($"{message}\nExpected: not null");
+
+            if (objA == null || !objA.Equals(objB))
+                return;
+
+            throw new DebugAssertException($"{message}\nExpected: not {objB?.ToString() ?? "null"}");
         }
 
         [Conditional("DEBUG")]


### PR DESCRIPTION
these should(?) not box, the object ones were boxing enough to be a major source of allocations in pvs in debug

existing ones seem to select the generic overload if the types passed in are `IEquatable` which is nice