### PR TITLE
Reduce `Loc.GetString` allocs

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* `LocalizationManager` now supports multiple fallback cultures
 
 ### Bugfixes
 

--- a/Robust.Shared/Localization/ILocalizationManager.cs
+++ b/Robust.Shared/Localization/ILocalizationManager.cs
@@ -52,6 +52,34 @@ namespace Robust.Shared.Localization
         string GetString(string messageId, params (string, object)[] args);
 
         /// <summary>
+        ///     Version of <see cref="GetString(string)"/> that supports arguments.
+        /// </summary>
+        string GetString(string messageId, (string, object) arg);
+
+        /// <summary>
+        ///     Version of <see cref="GetString(string)"/> that supports arguments.
+        /// </summary>
+        string GetString(string messageId, (string, object) arg, (string, object) arg2);
+
+        /// <summary>
+        ///     Try- version of <see cref="GetString(string, (string, object)[])"/>
+        /// </summary>
+        /// <remarks>
+        ///     Does not log a warning if the message does not exist.
+        ///     Does however log errors if any occur while formatting.
+        /// </remarks>
+        bool TryGetString(string messageId, [NotNullWhen(true)] out string? value, (string, object) arg);
+
+        /// <summary>
+        ///     Try- version of <see cref="GetString(string, (string, object)[])"/>
+        /// </summary>
+        /// <remarks>
+        ///     Does not log a warning if the message does not exist.
+        ///     Does however log errors if any occur while formatting.
+        /// </remarks>
+        bool TryGetString(string messageId, [NotNullWhen(true)] out string? value, (string, object) arg1, (string, object) arg2);
+
+        /// <summary>
         ///     Try- version of <see cref="GetString(string, (string, object)[])"/>
         /// </summary>
         /// <remarks>

--- a/Robust.Shared/Localization/ILocalizationManager.cs
+++ b/Robust.Shared/Localization/ILocalizationManager.cs
@@ -75,7 +75,7 @@ namespace Robust.Shared.Localization
         /// <summary>
         ///     Sets culture to be used in the absence of the main one.
         /// </summary>
-        void SetFallbackCluture(CultureInfo culture);
+        void SetFallbackCluture(params CultureInfo[] culture);
 
         /// <summary>
         ///     Immediately reload ALL localizations from resources.

--- a/Robust.Shared/Localization/LocalizationManager.cs
+++ b/Robust.Shared/Localization/LocalizationManager.cs
@@ -31,8 +31,8 @@ namespace Robust.Shared.Localization
         private ISawmill _logSawmill = default!;
         private readonly Dictionary<CultureInfo, FluentBundle> _contexts = new();
 
-        private CultureInfo? _defaultCulture;
-        private CultureInfo? _fallbackCulture;
+        private (CultureInfo, FluentBundle)? _defaultCulture;
+        private (CultureInfo, FluentBundle)[]? _fallbackCultures;
 
         void IPostInjectInit.PostInject()
         {
@@ -47,25 +47,24 @@ namespace Robust.Shared.Localization
 
             if (!TryGetString(messageId, out var msg))
             {
-                _logSawmill.Debug("Unknown messageId ({culture}): {messageId}", _defaultCulture.Name, messageId);
+                _logSawmill.Debug("Unknown messageId ({culture}): {messageId}", _defaultCulture.Value.Item1.Name, messageId);
                 msg = messageId;
             }
 
             return msg;
         }
 
-        public string GetString(string messageId, params (string, object)[] args0)
+        public string GetString(string messageId, params (string, object)[] args)
         {
             if (_defaultCulture == null)
                 return messageId;
 
-            if (!TryGetString(messageId, out var msg, args0))
-            {
-                _logSawmill.Debug("Unknown messageId ({culture}): {messageId}", _defaultCulture.Name, messageId);
-                msg = messageId;
-            }
+            if (TryGetString(messageId, out var argMsg, args))
+                return argMsg;
 
-            return msg;
+            _logSawmill.Debug("Unknown messageId ({culture}): {messageId}", _defaultCulture.Value.Item1.Name, messageId);
+            return  messageId;
+
         }
 
         public bool HasString(string messageId)
@@ -75,26 +74,69 @@ namespace Robust.Shared.Localization
 
         public bool TryGetString(string messageId, [NotNullWhen(true)] out string? value)
         {
-            return TryGetString(messageId, out value, null);
-        }
-
-        public bool TryGetString(string messageId, [NotNullWhen(true)] out string? value,
-            params (string, object)[]? keyArgs)
-        {
-            if (!HasMessage(messageId, out var bundle))
+            if (_defaultCulture == null)
             {
                 value = null;
                 return false;
             }
 
-            var context = new LocContext(bundle);
-            var args = new Dictionary<string, IFluentType>();
-            if (keyArgs != null)
+            if (TryGetString(messageId, _defaultCulture.Value, out value))
+                return true;
+
+            if (_fallbackCultures == null)
             {
-                foreach (var (k, v) in keyArgs)
+                value = null;
+                return false;
+            }
+
+            foreach (var fallback in  _fallbackCultures)
+            {
+                if (TryGetString(messageId, fallback, out value))
+                    return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        public bool TryGetString(string messageId, (CultureInfo, FluentBundle) bundle, [NotNullWhen(true)] out string? value)
+        {
+            try
+            {
+                // TODO LINGUINI error list nullable.
+                var result = bundle.Item2.TryGetAttrMsg(messageId, null, out var errs, out value);
+                foreach (var err in errs)
                 {
-                    args.Add(k, v.FluentFromObject(context));
+                    _logSawmill.Error("{culture}/{messageId}: {error}", bundle.Item1.Name, messageId, err);
                 }
+
+                return result;
+            }
+            catch (Exception e)
+            {
+                _logSawmill.Error("{culture}/{messageId}: {exception}", bundle.Item1.Name, messageId, e);
+                value = null;
+                return false;
+            }
+        }
+
+        public bool TryGetString(string messageId, [NotNullWhen(true)] out string? value,
+            params (string, object)[] keyArgs)
+        {
+            // TODO LINGUINI add try-get-message variant that takes in a (string, object)[]
+            // I.e., get rid of this has-message check
+            if (!HasMessage(messageId, out var culture))
+            {
+                value = null;
+                return false;
+            }
+
+            var (info, bundle) = culture.Value;
+            var context = new LocContext(bundle);
+            var args = new Dictionary<string, IFluentType>(keyArgs.Length);
+            foreach (var (k, v) in keyArgs)
+            {
+                args.Add(k, v.FluentFromObject(context));
             }
 
             try
@@ -102,14 +144,14 @@ namespace Robust.Shared.Localization
                 var result = bundle.TryGetAttrMsg(messageId, args, out var errs, out value);
                 foreach (var err in errs)
                 {
-                    _logSawmill.Error("{culture}/{messageId}: {error}", _defaultCulture!.Name, messageId, err);
+                    _logSawmill.Error("{culture}/{messageId}: {error}", info.Name, messageId, err);
                 }
 
                 return result;
             }
             catch (Exception e)
             {
-                _logSawmill.Error("{culture}/{messageId}: {exception}", _defaultCulture!.Name, messageId, e);
+                _logSawmill.Error("{culture}/{messageId}: {exception}", info.Name, messageId, e);
                 value = null;
                 return false;
             }
@@ -117,24 +159,37 @@ namespace Robust.Shared.Localization
 
         private bool HasMessage(
             string messageId,
-            [NotNullWhen(true)] out FluentBundle? bundle)
+            [NotNullWhen(true)] out (CultureInfo, FluentBundle)? culture)
         {
-            foreach (var culture in new[] { _defaultCulture, _fallbackCulture })
+            if (_defaultCulture == null)
             {
-                if (culture != null && _contexts.TryGetValue(culture, out bundle))
-                {
-                    if (messageId.Contains('.'))
-                    {
-                        var split = messageId.Split('.');
-                        if (bundle.HasMessage(split[0]))
-                            return true;
-                    }
-                    if (bundle.HasMessage(messageId))
-                        return true;
-                }
+                culture = null;
+                return false;
             }
 
-            bundle = null;
+            var idx = messageId.IndexOf('.');
+            if (idx != -1 )
+                messageId = messageId.Remove(idx);
+
+            culture = _defaultCulture;
+            if (culture.Value.Item2.HasMessage(messageId))
+                return true;
+
+
+            if (_fallbackCultures == null)
+            {
+                culture = null;
+                return false;
+            }
+
+            foreach (var fallback in  _fallbackCultures)
+            {
+                culture = fallback;
+                if (culture.Value.Item2.HasMessage(messageId))
+                    return true;
+            }
+
+            culture = null;
             return false;
         }
 
@@ -143,17 +198,31 @@ namespace Robust.Shared.Localization
             [NotNullWhen(true)] out FluentBundle? bundle,
             [NotNullWhen(true)] out AstMessage? message)
         {
-            foreach (var culture in new[] { _defaultCulture, _fallbackCulture })
+            if (_defaultCulture == null)
             {
-                if (culture != null && _contexts.TryGetValue(culture, out bundle))
-                {
-                    if (bundle.TryGetAstMessage(messageId, out message))
-                        return true;
-                }
+                bundle = null;
+                message = null;
+                return false;
+            }
+
+            bundle = _defaultCulture.Value.Item2;
+            if (bundle.TryGetAstMessage(messageId, out message))
+                return true;
+
+            if (_fallbackCultures == null)
+            {
+                bundle = null;
+                return false;
+            }
+
+            foreach (var fallback in  _fallbackCultures)
+            {
+                bundle = fallback.Item2;
+                if (bundle.TryGetAstMessage(messageId, out message))
+                    return true;
             }
 
             bundle = null;
-            message = null;
             return false;
         }
 
@@ -169,20 +238,18 @@ namespace Robust.Shared.Localization
 
         public CultureInfo? DefaultCulture
         {
-            get => _defaultCulture;
+            get => _defaultCulture?.Item1;
             set
             {
                 if (value == null)
-                {
                     throw new ArgumentNullException(nameof(value));
-                }
 
-                if (!_contexts.ContainsKey(value))
+                if (!_contexts.TryGetValue(value, out var bundle))
                 {
                     throw new ArgumentException("That culture is not yet loaded and cannot be used.", nameof(value));
                 }
 
-                _defaultCulture = value;
+                _defaultCulture = (value, bundle);
                 CultureInfo.CurrentCulture = value;
                 CultureInfo.CurrentUICulture = value;
             }
@@ -204,14 +271,20 @@ namespace Robust.Shared.Localization
             DefaultCulture ??= culture;
         }
 
-        public void SetFallbackCluture(CultureInfo culture)
+        public void SetFallbackCluture(params CultureInfo[] cultures)
         {
-            if (!_contexts.ContainsKey(culture))
+            _fallbackCultures = null;
+            var tuples = new (CultureInfo, FluentBundle)[cultures.Length];
+            var i = 0;
+            foreach (var culture in cultures)
             {
-                throw new ArgumentException("That culture is not loaded.", nameof(culture));
+                if (!_contexts.TryGetValue(culture, out var bundle))
+                    throw new ArgumentException("That culture is not loaded.", nameof(culture));
+
+                tuples[i++] = (culture, bundle);
             }
 
-            _fallbackCulture = culture;
+            _fallbackCultures = tuples;
         }
 
         public void AddLoadedToStringSerializer(IRobustMappedStringSerializer serializer)

--- a/Robust.Shared/Localization/LocalizationManager.cs
+++ b/Robust.Shared/Localization/LocalizationManager.cs
@@ -32,7 +32,7 @@ namespace Robust.Shared.Localization
         private readonly Dictionary<CultureInfo, FluentBundle> _contexts = new();
 
         private (CultureInfo, FluentBundle)? _defaultCulture;
-        private (CultureInfo, FluentBundle)[]? _fallbackCultures;
+        private (CultureInfo, FluentBundle)[] _fallbackCultures = Array.Empty<(CultureInfo, FluentBundle)>();
 
         void IPostInjectInit.PostInject()
         {
@@ -82,12 +82,6 @@ namespace Robust.Shared.Localization
 
             if (TryGetString(messageId, _defaultCulture.Value, out value))
                 return true;
-
-            if (_fallbackCultures == null)
-            {
-                value = null;
-                return false;
-            }
 
             foreach (var fallback in  _fallbackCultures)
             {
@@ -175,13 +169,6 @@ namespace Robust.Shared.Localization
             if (culture.Value.Item2.HasMessage(messageId))
                 return true;
 
-
-            if (_fallbackCultures == null)
-            {
-                culture = null;
-                return false;
-            }
-
             foreach (var fallback in  _fallbackCultures)
             {
                 culture = fallback;
@@ -208,12 +195,6 @@ namespace Robust.Shared.Localization
             bundle = _defaultCulture.Value.Item2;
             if (bundle.TryGetAstMessage(messageId, out message))
                 return true;
-
-            if (_fallbackCultures == null)
-            {
-                bundle = null;
-                return false;
-            }
 
             foreach (var fallback in  _fallbackCultures)
             {
@@ -273,7 +254,7 @@ namespace Robust.Shared.Localization
 
         public void SetFallbackCluture(params CultureInfo[] cultures)
         {
-            _fallbackCultures = null;
+            _fallbackCultures = Array.Empty<(CultureInfo, FluentBundle)>();;
             var tuples = new (CultureInfo, FluentBundle)[cultures.Length];
             var i = 0;
             foreach (var culture in cultures)


### PR DESCRIPTION
Gets rid of an array & dictionary allocation, and a dictionary lookup.
Also adds support for arbitrarily many fallback cultures