### PR TITLE
Fix playing audio streams

### DIFF
--- a/Robust.Client/ResourceManagement/IResourceCache.cs
+++ b/Robust.Client/ResourceManagement/IResourceCache.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Robust.Client.Audio;
 using Robust.Client.Graphics;
 using Robust.Shared.ContentPack;
 using Robust.Shared.Utility;
@@ -23,6 +24,8 @@ public interface IResourceCache : IResourceManager
 
     bool TryGetResource<T>(ResPath path, [NotNullWhen(true)] out T? resource)
         where T : BaseResource, new();
+
+    bool TryGetResource(AudioStream stream, [NotNullWhen(true)] out AudioResource? resource);
 
     void ReloadResource<T>(string path)
         where T : BaseResource, new();

--- a/Robust.Client/ResourceManagement/ResourceCache.cs
+++ b/Robust.Client/ResourceManagement/ResourceCache.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using Robust.Client.Audio;
 using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
@@ -93,6 +94,12 @@ internal sealed partial class ResourceCache : ResourceManager, IResourceCacheInt
             resource = null;
             return false;
         }
+    }
+
+    public bool TryGetResource(AudioStream stream, [NotNullWhen(true)] out AudioResource? resource)
+    {
+        resource = new AudioResource(stream);
+        return true;
     }
 
     public void ReloadResource<T>(string path) where T : BaseResource, new()

--- a/Robust.Client/ResourceManagement/ResourceTypes/AudioResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/AudioResource.cs
@@ -44,6 +44,13 @@ public sealed class AudioResource : BaseResource
         }
     }
 
+    public AudioResource(AudioStream stream) : base()
+    {
+        AudioStream = stream;
+    }
+
+    public AudioResource() : base(){}
+
     public static implicit operator AudioStream(AudioResource res)
     {
         return res.AudioStream;

--- a/Robust.Client/ResourceManagement/ResourceTypes/AudioResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/AudioResource.cs
@@ -12,6 +12,11 @@ public sealed class AudioResource : BaseResource
 {
     public AudioStream AudioStream { get; private set; } = default!;
 
+    public void Load(AudioStream stream)
+    {
+        AudioStream = stream;
+    }
+
     public override void Load(IDependencyCollection dependencies, ResPath path)
     {
         var cache = dependencies.Resolve<IResourceManager>();

--- a/Robust.Server/Audio/AudioSystem.cs
+++ b/Robust.Server/Audio/AudioSystem.cs
@@ -238,4 +238,8 @@ public sealed partial class AudioSystem : SharedAudioSystem
             return loadedMetadata.Length;
         }
     }
+
+    public override void LoadStream<T>(AudioComponent component, T stream)
+    {
+    }
 }

--- a/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
+++ b/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
@@ -123,45 +123,23 @@ public abstract partial class SharedAudioSystem : EntitySystem
 
     #region AudioParams
 
-    protected AudioComponent SetupAudio(EntityUid uid, string fileName, AudioParams? audioParams)
+    protected AudioComponent SetupAudio(EntityUid uid, string? fileName, AudioParams? audioParams, TimeSpan? length = null)
     {
-        DebugTools.Assert(!string.IsNullOrEmpty(fileName));
+        DebugTools.Assert((!string.IsNullOrEmpty(fileName) || length is not null));
         audioParams ??= AudioParams.Default;
         var comp = AddComp<AudioComponent>(uid);
-        comp.FileName = fileName;
-        comp.Params = audioParams.Value;
-        comp.AudioStart = Timing.CurTime;
-
-        if (!audioParams.Value.Loop)
-        {
-            var length = GetAudioLength(fileName);
-
-            var despawn = AddComp<TimedDespawnComponent>(uid);
-            // Don't want to clip audio too short due to imprecision.
-            despawn.Lifetime = (float) length.TotalSeconds + 0.01f;
-        }
-
-        if (comp.Params.Variation != null && comp.Params.Variation.Value != 0f)
-        {
-            comp.Params.Pitch *= (float) RandMan.NextGaussian(1, comp.Params.Variation.Value);
-        }
-
-        return comp;
-    }
-
-    protected AudioComponent SetupAudio(EntityUid uid, TimeSpan length, AudioParams? audioParams)
-    {
-        audioParams ??= AudioParams.Default;
-        var comp = AddComp<AudioComponent>(uid);
+        comp.FileName = fileName ?? string.Empty;
         comp.Params = audioParams.Value;
         comp.AudioStart = Timing.CurTime;
 
 
         if (!audioParams.Value.Loop)
         {
+            length ??= GetAudioLength(fileName!);
+
             var despawn = AddComp<TimedDespawnComponent>(uid);
             // Don't want to clip audio too short due to imprecision.
-            despawn.Lifetime = (float) length.TotalSeconds + 0.01f;
+            despawn.Lifetime = (float) length.Value.TotalSeconds + 0.01f;
         }
 
         if (comp.Params.Variation != null && comp.Params.Variation.Value != 0f)


### PR DESCRIPTION
Attempting to play an audio stream would cause an exception due to the filename being null, completely breaking audio in OpenDream.

OpenDream's audio is now fixed (make sure to unmute the video):

https://github.com/space-wizards/RobustToolbox/assets/5714543/6b2b8c40-fe95-4cad-b92e-80abd7cb0ef2

