### PR TITLE
Stop toolshed from generating completions for non-toolshed commands

### DIFF
--- a/Robust.Server/Console/ServerConsoleHost.cs
+++ b/Robust.Server/Console/ServerConsoleHost.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -246,8 +247,15 @@ namespace Robust.Server.Console
                     goto done;
                 }
                 var (shedRes, _) = await completions.Value;
-                shedRes ??= CompletionResult.Empty;
-                result = new CompletionResult(shedRes.Options.Concat(result?.Options ?? Array.Empty<CompletionOption>()).ToArray(), result?.Hint ?? shedRes.Hint);
+
+                IEnumerable<CompletionOption> options = result?.Options ?? Array.Empty<CompletionOption>();
+
+                if (shedRes != null)
+                    options = options.Concat(shedRes.Options);
+
+                var hints = result?.Hint ?? shedRes?.Hint;
+
+                result = new CompletionResult(options.ToArray(), hints);
             }
 
             done:

--- a/Robust.Shared/Console/ConsoleHost.cs
+++ b/Robust.Shared/Console/ConsoleHost.cs
@@ -341,6 +341,11 @@ namespace Robust.Shared.Console
 
                 return ValueTask.FromResult(CompletionResult.Empty);
             }
+
+            public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+            {
+                return CompletionCallback?.Invoke(shell, args) ?? CompletionResult.Empty;
+            }
         }
     }
 }


### PR DESCRIPTION
E.g., typing `forcemap Aspid ` (with the trailing space) will no longer suddenly list all toolshed commands as completion suggestions.