### PR TITLE
Fix pvs bug

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/MapSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Robust.Server.GameStates;
 using Robust.Shared;
 using Robust.Shared.Collections;
 using Robust.Shared.Configuration;
@@ -13,8 +14,15 @@ namespace Robust.Server.GameObjects
     public sealed class MapSystem : SharedMapSystem
     {
         [Dependency] private readonly IConfigurationManager _cfg = default!;
+        [Dependency] private readonly PvsSystem _pvs = default!;
 
         private bool _deleteEmptyGrids;
+
+
+        protected override void UpdatePvsChunks(Entity<TransformComponent, MetaDataComponent> grid)
+        {
+            _pvs.GridParentChanged(grid);
+        }
 
         public override void Initialize()
         {

--- a/Robust.Server/GameObjects/EntitySystems/MapSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapSystem.cs
@@ -18,7 +18,6 @@ namespace Robust.Server.GameObjects
 
         private bool _deleteEmptyGrids;
 
-
         protected override void UpdatePvsChunks(Entity<TransformComponent, MetaDataComponent> grid)
         {
             _pvs.GridParentChanged(grid);

--- a/Robust.Server/GameStates/PvsSystem.ToSendSet.cs
+++ b/Robust.Server/GameStates/PvsSystem.ToSendSet.cs
@@ -27,11 +27,10 @@ internal sealed partial class PvsSystem
     /// </summary>
     private void AddPvsChunk(PvsChunk chunk, float distance, PvsSession session)
     {
-#if DEBUG
         // Each root nodes should simply be a map or a grid entity.
-        DebugTools.Assert(Exists(chunk.Root), $"Root node does not exist. Node {chunk.Root.Owner}. Session: {session.Session}");
+        DebugTools.Assert(Exists(chunk.Root), $"Chunk root does not exist!");
+        DebugTools.Assert(Exists(chunk.Map), $"Map does not exist!.");
         DebugTools.Assert(HasComp<MapComponent>(chunk.Root) || HasComp<MapGridComponent>(chunk.Root));
-#endif
 
         var fromTick = session.FromTick;
         var mask = session.VisMask;

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -379,6 +380,9 @@ internal sealed partial class PvsSystem : EntitySystem
 
     public void BeforeSendState(ICommonSession[] players, Histogram histogram)
     {
+        DebugTools.Assert(_chunks.Values.All(x => Exists(x.Map) && Exists(x.Root)));
+        DebugTools.Assert(_chunkSets.Keys.All(Exists));
+
         var ackJob = ProcessQueuedAcks(histogram);
 
         // Figure out what chunks players can see and cache some chunk data.

--- a/Robust.UnitTesting/RobustUnitTest.cs
+++ b/Robust.UnitTesting/RobustUnitTest.cs
@@ -86,7 +86,6 @@ namespace Robust.UnitTesting
 
             var systems = deps.Resolve<IEntitySystemManager>();
             // Required systems
-            systems.LoadExtraSystemType<MapSystem>();
             systems.LoadExtraSystemType<EntityLookupSystem>();
 
             // uhhh so maybe these are the wrong system for the client, but I CBF adding sprite system and all the rest,
@@ -108,6 +107,7 @@ namespace Robust.UnitTesting
                 systems.LoadExtraSystemType<Robust.Client.Debugging.DebugRayDrawingSystem>();
                 systems.LoadExtraSystemType<PrototypeReloadSystem>();
                 systems.LoadExtraSystemType<Robust.Client.Debugging.DebugPhysicsSystem>();
+                systems.LoadExtraSystemType<Robust.Client.GameObjects.MapSystem>();
             }
             else
             {
@@ -123,6 +123,7 @@ namespace Robust.UnitTesting
                 systems.LoadExtraSystemType<DebugPhysicsSystem>();
                 systems.LoadExtraSystemType<InputSystem>();
                 systems.LoadExtraSystemType<PvsOverrideSystem>();
+                systems.LoadExtraSystemType<MapSystem>();
             }
 
             var entMan = deps.Resolve<IEntityManager>();

--- a/Robust.UnitTesting/Server/GameStates/PvsChunkTest.cs
+++ b/Robust.UnitTesting/Server/GameStates/PvsChunkTest.cs
@@ -1,0 +1,153 @@
+using System.Linq;
+using System.Numerics;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Robust.Client.GameStates;
+using Robust.Client.Timing;
+using Robust.Server.GameObjects;
+using Robust.Shared;
+using Robust.Shared.Configuration;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+
+namespace Robust.UnitTesting.Server.GameStates;
+
+public sealed class PvsChunkTest : RobustIntegrationTest
+{
+    [Test]
+    public async Task TestGridMapChange()
+    {
+        var server = StartServer();
+        var client = StartClient();
+
+        await Task.WhenAll(client.WaitIdleAsync(), server.WaitIdleAsync());
+
+        var mapMan = server.ResolveDependency<IMapManager>();
+        var sEntMan = server.ResolveDependency<IEntityManager>();
+        var confMan = server.ResolveDependency<IConfigurationManager>();
+        var sPlayerMan = server.ResolveDependency<ISharedPlayerManager>();
+        var xforms = sEntMan.System<SharedTransformSystem>();
+        var mapSys = sEntMan.System<MapSystem>();
+
+        var cEntMan = client.ResolveDependency<IEntityManager>();
+        var netMan = client.ResolveDependency<IClientNetManager>();
+
+        Assert.DoesNotThrow(() => client.SetConnectTarget(server));
+        client.Post(() => netMan.ClientConnect(null!, 0, null!));
+        server.Post(() => confMan.SetCVar(CVars.NetPVS, true));
+
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        // Ensure client & server ticks are synced.
+        // Client runs 1 tick ahead
+        {
+            var sTick = (int)server.Timing.CurTick.Value;
+            var cTick = (int)client.Timing.CurTick.Value;
+            var delta = cTick - sTick;
+
+            if (delta > 1)
+                await server.WaitRunTicks(delta - 1);
+            else if (delta < 1)
+                await client.WaitRunTicks(1 - delta);
+
+            sTick = (int)server.Timing.CurTick.Value;
+            cTick = (int)client.Timing.CurTick.Value;
+            delta = cTick - sTick;
+            Assert.That(delta, Is.EqualTo(1));
+        }
+
+        // Set up entities
+        EntityUid map1 = default;
+        EntityUid map2 = default;
+        EntityUid grid = default;
+        EntityUid player = default;
+        EntityUid entity = default;
+        EntityCoordinates mapCoords = default;
+        await server.WaitPost(() =>
+        {
+            var mapId = mapMan.CreateMap();
+            map1 = mapMan.GetMapEntityId(mapId);
+            mapCoords = new(map1, default);
+
+            var map2Id = mapMan.CreateMap();
+            map2 = mapMan.GetMapEntityId(map2Id);
+
+            var gridComp = mapMan.CreateGridEntity(map2Id);
+            grid = gridComp.Owner;
+            mapSys.SetTile(grid, gridComp, Vector2i.Zero, new Tile(1));
+            var gridCoords = new EntityCoordinates(grid, .5f, .5f);
+
+            player = sEntMan.SpawnEntity(null, mapCoords);
+            entity = sEntMan.SpawnEntity(null, gridCoords);
+
+            // Attach player.
+            var session = sPlayerMan.Sessions.First();
+            server.PlayerMan.SetAttachedEntity(session, player);
+            sPlayerMan.JoinGame(session);
+        });
+
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        var nEntity = sEntMan.GetNetEntity(entity);
+        var nGrid = sEntMan.GetNetEntity(grid);
+        var nMap1 = sEntMan.GetNetEntity(map1);
+        var nMap2 = sEntMan.GetNetEntity(map2);
+
+        var xform = sEntMan.GetComponent<TransformComponent>(entity);
+        Assert.That(xform.ParentUid, Is.EqualTo(grid));
+        Assert.That(xform.GridUid, Is.EqualTo(grid));
+        Assert.That(xform.MapUid, Is.EqualTo(map2));
+
+        Assert.That(!cEntMan.TryGetEntity(nEntity, out _));
+        Assert.That(cEntMan.TryGetEntity(nMap1, out _));
+        Assert.That(cEntMan.TryGetEntity(nMap2, out _));
+        Assert.That(cEntMan.TryGetEntity(nGrid, out _));
+
+        // Teleport grid to new map
+        await server.WaitPost(() => xforms.SetCoordinates(grid, mapCoords));
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        Assert.That(xform.ParentUid, Is.EqualTo(grid));
+        Assert.That(xform.GridUid, Is.EqualTo(grid));
+        Assert.That(xform.MapUid, Is.EqualTo(map1));
+
+        Assert.That(cEntMan.TryGetEntity(nEntity, out _));
+        Assert.That(cEntMan.TryGetEntity(nMap1, out _));
+        Assert.That(cEntMan.TryGetEntity(nMap2, out _));
+        Assert.That(cEntMan.TryGetEntity(nGrid, out _));
+
+        // Delete the original map.
+        await server.WaitPost(() => sEntMan.DeleteEntity(map2));
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        Assert.That(xform.ParentUid, Is.EqualTo(grid));
+        Assert.That(xform.GridUid, Is.EqualTo(grid));
+        Assert.That(xform.MapUid, Is.EqualTo(map1));
+
+        Assert.That(cEntMan.TryGetEntity(nEntity, out _));
+        Assert.That(cEntMan.TryGetEntity(nMap1, out _));
+        Assert.That(!cEntMan.TryGetEntity(nMap2, out _));
+        Assert.That(cEntMan.TryGetEntity(nGrid, out _));
+    }
+}
+


### PR DESCRIPTION
Fixes a bug in #4759 where pvs chunks never updated their map id when grids were moved across maps. This caused errors if a grid's initial map gets deleted (e.g., most shuttles).