### PR TITLE
Pvs cleanup & expose methods for benchmarking

### DIFF
--- a/Robust.Benchmarks/Transform/RecursiveMoveBenchmark.cs
+++ b/Robust.Benchmarks/Transform/RecursiveMoveBenchmark.cs
@@ -190,7 +190,7 @@ public class RecursiveMoveBenchmark : RobustIntegrationTest
     private void PvsTick()
     {
         _session.ClearState();
-        _pvs.GetVisibleChunks(_players, null);
+        _pvs.GetVisibleChunks(_players);
         _pvs.ProcessVisibleChunksSequential();
     }
 

--- a/Robust.Server/GameObjects/EntitySystems/InputSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/InputSystem.cs
@@ -73,7 +73,7 @@ namespace Robust.Server.GameObjects
 
         public uint GetLastInputCommand(ICommonSession? session)
         {
-            return session == null ? default : _lastProcessedInputCmd[session];
+            return session == null ? default : _lastProcessedInputCmd.GetValueOrDefault(session);
         }
 
         private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs args)

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -158,7 +158,7 @@ namespace Robust.Server.GameObjects
 
         public uint GetLastMessageSequence(ICommonSession? session)
         {
-            return session == null ? default : _lastProcessedSequencesCmd[session];
+            return session == null ? default : _lastProcessedSequencesCmd.GetValueOrDefault(session);
         }
 
         /// <inheritdoc />

--- a/Robust.Server/GameStates/PvsData.cs
+++ b/Robust.Server/GameStates/PvsData.cs
@@ -126,10 +126,9 @@ internal sealed class PvsSession(ICommonSession session)
 /// <summary>
 /// Class for storing session-specific information about when an entity was last sent to a player.
 /// </summary>
-internal sealed class PvsData(Entity<MetaDataComponent> entity) : IEquatable<PvsData>
+internal sealed class PvsData(NetEntity entity) : IEquatable<PvsData>
 {
-    public readonly Entity<MetaDataComponent> Entity = entity;
-    public readonly NetEntity NetEntity = entity.Comp.NetEntity;
+    public readonly NetEntity NetEntity = entity;
 
     /// <summary>
     /// Tick at which this entity was last sent to a player.
@@ -148,34 +147,15 @@ internal sealed class PvsData(Entity<MetaDataComponent> entity) : IEquatable<Pvs
     /// </summary>
     public GameTick EntityLastAcked;
 
-    /// <summary>
-    /// Entity visibility state when it was last sent to this player.
-    /// </summary>
-    public PvsEntityVisibility Visibility;
-    // this is currently no longer strictly required, but maybe in future we want to separate out the get-state code
-    // from the get-visible/to-send code. If we do that, we need to have this to quickly distinguish between dirty,
-    // entering, and unmodified entities.
-
     public bool Equals(PvsData? other)
     {
-#if DEBUG
-        // Each this class should be unique for each entity-session combination, and should never be getting compared
-        // across sessions.
-        if (Entity.Owner == other?.Entity.Owner)
-            DebugTools.Assert(ReferenceEquals(this, other));
-#endif
-        return Entity.Owner == other?.Entity.Owner;
+        DebugTools.Assert((NetEntity != other?.NetEntity) || ReferenceEquals(this, other));
+        return NetEntity == other?.NetEntity;
     }
 
     public override int GetHashCode()
     {
-        return Entity.Owner.GetHashCode();
-    }
-
-    public override string ToString()
-    {
-        var rep = new EntityStringRepresentation(Entity);
-        return $"PVS Entity: {rep} - {LastSeen}/{LastLeftView}/{EntityLastAcked} - {Visibility}";
+        return NetEntity.GetHashCode();
     }
 }
 

--- a/Robust.Server/GameStates/PvsSystem.Ack.cs
+++ b/Robust.Server/GameStates/PvsSystem.Ack.cs
@@ -33,7 +33,7 @@ internal sealed partial class PvsSystem
     ///     Processes queued client acks in parallel
     /// </summary>
     /// <param name="histogram"></param>
-    internal WaitHandle? ProcessQueuedAcks(Histogram? histogram)
+    private WaitHandle? ProcessQueuedAcks()
     {
         if (PendingAcks.Count == 0)
             return null;
@@ -49,7 +49,7 @@ internal sealed partial class PvsSystem
 
         if (!_async)
         {
-            using var _= histogram?.WithLabels("Process Acks").NewTimer();
+            using var _= Histogram.WithLabels("Process Acks").NewTimer();
             _parallelManager.ProcessNow(_ackJob, _toAck.Count);
             return null;
         }

--- a/Robust.Server/GameStates/PvsSystem.Ack.cs
+++ b/Robust.Server/GameStates/PvsSystem.Ack.cs
@@ -124,7 +124,6 @@ internal sealed partial class PvsSystem
         foreach (var data in CollectionsMarshal.AsSpan(ackedEnts))
         {
             data.EntityLastAcked = ackedTick;
-            DebugTools.Assert(data.Visibility > PvsEntityVisibility.Unsent);
             DebugTools.Assert(data.LastSeen >= ackedTick); // LastSent may equal ackedTick if the packet was sent reliably.
             DebugTools.Assert(!sessionData.Entities.TryGetValue(data.NetEntity, out var old)
                               || ReferenceEquals(data, old));

--- a/Robust.Server/GameStates/PvsSystem.Dirty.cs
+++ b/Robust.Server/GameStates/PvsSystem.Dirty.cs
@@ -69,9 +69,9 @@ namespace Robust.Server.GameStates
             return true;
         }
 
-        public void CleanupDirty(ICommonSession[] sessions, Histogram? histogram)
+        private void CleanupDirty(ICommonSession[] sessions)
         {
-            using var _ = histogram?.WithLabels("Clean Dirty").NewTimer();
+            using var _ = Histogram.WithLabels("Clean Dirty").NewTimer();
             if (!CullingEnabled)
             {
                 _seenAllEnts.Clear();

--- a/Robust.Server/GameStates/PvsSystem.GetStates.cs
+++ b/Robust.Server/GameStates/PvsSystem.GetStates.cs
@@ -98,7 +98,7 @@ internal sealed partial class PvsSystem
     /// <summary>
     /// Gets all entity states that have been modified after and including the provided tick.
     /// </summary>
-    public void GetAllEntityStates(PvsSession pvsSession)
+    private void GetAllEntityStates(PvsSession pvsSession)
     {
         var session = pvsSession.Session;
         var toTick = _gameTiming.CurTick;

--- a/Robust.Server/GameStates/PvsSystem.ToSendSet.cs
+++ b/Robust.Server/GameStates/PvsSystem.ToSendSet.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map.Components;
@@ -52,10 +53,8 @@ internal sealed partial class PvsSystem
             : chunk.LodCounts[0];
 
         // Send entities on the chunk.
-        var span = CollectionsMarshal.AsSpan(chunk.Contents);
-        for (var i = 0; i < count; i++)
+        foreach (ref var ent in CollectionsMarshal.AsSpan(chunk.Contents))
         {
-            var ent = span[i];
             if ((mask & ent.Comp.VisibilityMask) == ent.Comp.VisibilityMask)
                 AddEntity(session, ent, fromTick);
         }
@@ -64,11 +63,13 @@ internal sealed partial class PvsSystem
     /// <summary>
     /// Attempt to add an entity to the to-send lists, while respecting pvs budgets.
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool AddEntity(PvsSession session, Entity<MetaDataComponent> entity, GameTick fromTick)
     {
-        ref var data = ref CollectionsMarshal.GetValueRefOrAddDefault(session.Entities, entity.Comp.NetEntity, out var exists);
+        var nuid = entity.Comp.NetEntity;
+        ref var data = ref CollectionsMarshal.GetValueRefOrAddDefault(session.Entities, nuid, out var exists);
         if (!exists)
-            data = new(entity);
+            data = new(nuid);
 
         if (entity.Comp.Deleted)
         {
@@ -78,44 +79,28 @@ internal sealed partial class PvsSystem
         }
 
         DebugTools.AssertEqual(data!.NetEntity, entity.Comp.NetEntity);
-        DebugTools.AssertEqual(data.LastSeen == GameTick.Zero, data.Visibility <= PvsEntityVisibility.Unsent);
-        DebugTools.AssertEqual(data.Entity, entity);
         if (data.LastSeen == _gameTiming.CurTick)
             return true;
 
         var (entered,budgetExceeded) = IsEnteringPvsRange(data, fromTick, ref session.Budget);
 
-        if (!budgetExceeded)
-        {
-            if (!AddToSendList(session, data, fromTick, entered))
-                return false;
-
-            DebugTools.AssertNotEqual(data.LastSeen, GameTick.Zero);
-            return true;
-        }
-
-        // Sending this entity would go over the player's budget, so we will not add it. However, we  do not
-        // stop iterating over this (or other chunks). This is to avoid sending bad pvs-leave messages.
-        // I.e., other entities may have just stayed in view, and we can send them without exceeding our
-        // budget. E.g., this might be the very first chunk we are iterating over, and it just so happens
-        // to be a chunk that just entered their PVS range.
-
-        if (data.Visibility != PvsEntityVisibility.Invalid)
+        if (budgetExceeded)
             return false;
 
-        // This entity was never sent to the player, and isn't being sent now.
-        // However, the data has already been added to the entityData dictionary.
-        // In order for debug asserts and other sanity checks to keep working, we mark the entity as
-        // explicitly unsent.
-        data.Visibility = PvsEntityVisibility.Unsent;
-        return false;
+        if (!AddToSendList(session, data, entity, fromTick, entered))
+            return false;
+
+        DebugTools.AssertNotEqual(data.LastSeen, GameTick.Zero);
+        return true;
     }
 
     /// <summary>
     /// This method adds an entity to the list of visible entities, updates the last-seen tick, and computes any
     /// required game states.
     /// </summary>
-    private bool AddToSendList(PvsSession session, PvsData data, GameTick fromTick, bool entered)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool AddToSendList(PvsSession session, PvsData data, Entity<MetaDataComponent> entity, GameTick fromTick,
+        bool entered)
     {
         DebugTools.Assert(fromTick < _gameTiming.CurTick);
 
@@ -128,23 +113,23 @@ internal sealed partial class PvsSystem
 
         DebugTools.AssertNotEqual(data.LastSeen, _gameTiming.CurTick);
         DebugTools.Assert(data.EntityLastAcked <= fromTick || fromTick == GameTick.Zero);
-        var (uid, meta) = data.Entity;
+        var (uid, meta) = entity;
 
         // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         if (meta == null)
         {
-            Log.Error($"Encountered null metadata in EntityData. Entity: {ToPrettyString(data?.Entity)}");
+            Log.Error($"Encountered null metadata in EntityData. Entity: {ToPrettyString(entity.Owner)}");
             return false;
         }
 
         if (meta.EntityLifeStage >= EntityLifeStage.Terminating)
         {
-            var rep = new EntityStringRepresentation(data.Entity);
-            Log.Error($"Attempted to add a deleted entity to PVS send set: '{rep}'. Deletion queued: {EntityManager.IsQueuedForDeletion(data.Entity)}. Trace:\n{Environment.StackTrace}");
+            var rep = new EntityStringRepresentation(entity);
+            Log.Error($"Attempted to add a deleted entity to PVS send set: '{rep}'. Deletion queued: {EntityManager.IsQueuedForDeletion(entity)}. Trace:\n{Environment.StackTrace}");
 
             // This can happen if some entity was some removed from it's parent while that parent was being deleted.
             // As a result the entity was marked for deletion but was never actually properly deleted.
-            EntityManager.QueueDeleteEntity(data.Entity);
+            EntityManager.QueueDeleteEntity(entity);
             return false;
         }
 
@@ -154,14 +139,13 @@ internal sealed partial class PvsSystem
 
         if (session.RequestedFull)
         {
-            state = GetFullEntityState(session.Session, data.Entity.Owner, data.Entity.Comp);
+            state = GetFullEntityState(session.Session, uid, meta);
             session.States.Add(state);
             return true;
         }
 
         if (entered)
         {
-            data.Visibility = PvsEntityVisibility.Entered;
             state = GetEntityState(session.Session, uid, data.EntityLastAcked, meta);
             session.States.Add(state);
             return true;
@@ -170,11 +154,9 @@ internal sealed partial class PvsSystem
         if (meta.EntityLastModifiedTick <= fromTick)
         {
             //entity has been sent before and hasn't been updated since
-            data.Visibility = PvsEntityVisibility.Unchanged;
             return true;
         }
 
-        data.Visibility = PvsEntityVisibility.Dirty;
         state = GetEntityState(session.Session, uid, fromTick , meta);
 
         if (!state.Empty)
@@ -187,13 +169,12 @@ internal sealed partial class PvsSystem
     /// This method figures out whether a given entity is currently entering a player's PVS range.
     /// This method will also check that the player's PVS entry budget is not being exceeded.
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private (bool Entering, bool BudgetExceeded) IsEnteringPvsRange(
         PvsData data,
         GameTick fromTick,
         ref PvsBudget budget)
     {
-        DebugTools.AssertEqual(data.LastSeen == GameTick.Zero, data.Visibility <= PvsEntityVisibility.Unsent);
-
         var enteredSinceLastSent = fromTick == GameTick.Zero
                                    || data.LastSeen == GameTick.Zero
                                    || data.LastSeen != _gameTiming.CurTick - 1;

--- a/Robust.Server/Replays/ReplayRecordingManager.cs
+++ b/Robust.Server/Replays/ReplayRecordingManager.cs
@@ -44,7 +44,7 @@ internal sealed class ReplayRecordingManager : SharedReplayRecordingManager, ISe
             return;
         }
 
-        _pvs.GetSessionData(_pvsSession);
+        _pvs.ComputeSessionState(_pvsSession);
         Update(_pvsSession.State);
         _pvsSession.ClearState();
         _pvsSession.LastReceivedAck = Timing.CurTick;

--- a/Robust.UnitTesting/RobustIntegrationTest.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.cs
@@ -19,6 +19,7 @@ using Robust.Client.Timing;
 using Robust.Client.UserInterface;
 using Robust.Server;
 using Robust.Server.Console;
+using Robust.Server.GameStates;
 using Robust.Server.ServerStatus;
 using Robust.Shared;
 using Robust.Shared.Asynchronous;
@@ -741,6 +742,16 @@ namespace Robust.UnitTesting
                 ResolveIoC(deps);
 
                 return server;
+            }
+
+            /// <summary>
+            /// Force a PVS update. This is mainly here to expose internal PVS methods to content benchmarks.
+            /// </summary>
+            public void PvsTick(ICommonSession[] players)
+            {
+                var pvs = EntMan.System<PvsSystem>();
+                pvs.SendGameStates(players);
+                Timing.CurTick += 1;
             }
         }
 

--- a/Robust.UnitTesting/RobustUnitTest.cs
+++ b/Robust.UnitTesting/RobustUnitTest.cs
@@ -23,6 +23,7 @@ using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Reflection;
+using Robust.Shared.Threading;
 using Robust.Shared.Utility;
 using InputSystem = Robust.Server.GameObjects.InputSystem;
 using MapSystem = Robust.Server.GameObjects.MapSystem;
@@ -243,6 +244,8 @@ namespace Robust.UnitTesting
             {
                 compFactory.RegisterClass<ActorComponent>();
             }
+
+            deps.Resolve<IParallelManagerInternal>().Initialize();
 
             // So by default EntityManager does its own EntitySystemManager initialize during Startup.
             // We want to bypass this and load our own systems hence we will manually initialize it here.


### PR DESCRIPTION
This PR moves several functions from `ServerGameStateManager` into `PvsSystem` and makes PVS function with "dummy" sessions for benchmarks.