### PR TITLE
Add per-session force send pvs override

### DIFF
--- a/Robust.Server/GameStates/PvsSystem.Overrides.cs
+++ b/Robust.Server/GameStates/PvsSystem.Overrides.cs
@@ -52,6 +52,14 @@ internal sealed partial class PvsSystem
         {
             RecursivelyAddOverride(session, uid, fromTick, addChildren: false);
         }
+
+        if (!_pvsOverride.SessionForceSend.TryGetValue(session.Session, out var sessionForce))
+            return;
+
+        foreach (var uid in sessionForce)
+        {
+            RecursivelyAddOverride(session, uid, fromTick, addChildren: false);
+        }
     }
 
     private void RaiseExpandEvent(PvsSession session, GameTick fromTick)

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -326,11 +326,11 @@ internal sealed partial class PvsSystem : EntitySystem
             session.Budget.EnterLimit = CVars.NetPVSEntityEnterBudget.DefaultValue;
         }
 
-        // Process all entities in visible PVS chunks
-        AddPvsChunks(session);
-
         // Process all PVS overrides.
         AddAllOverrides(session);
+
+        // Process all entities in visible PVS chunks
+        AddPvsChunks(session);
 
         VerifySessionData(session);
 


### PR DESCRIPTION
Apparently OD relied on being able to force-send entities per session.
Also changes the ordering to always prefer sending entities in pvs overrides over entities in pvs chunks