### PR TITLE
Allows getting the light rendertarget from overlays

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.Viewport.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Viewport.cs
@@ -198,6 +198,7 @@ namespace Robust.Client.Graphics.Clyde
             }
 
             IRenderTexture IClydeViewport.RenderTarget => RenderTarget;
+            IRenderTexture IClydeViewport.LightRenderTarget => LightRenderTarget;
             public IEye? Eye { get; set; }
         }
     }

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -463,6 +463,9 @@ namespace Robust.Client.Graphics.Clyde
             public IRenderTexture RenderTarget { get; } =
                 new DummyRenderTexture(Vector2i.One, new DummyTexture(Vector2i.One));
 
+            public IRenderTexture LightRenderTarget { get; } =
+                new DummyRenderTexture(Vector2i.One, new DummyTexture(Vector2i.One));
+
             public IEye? Eye { get; set; }
             public Vector2i Size { get; }
             public Color? ClearColor { get; set; } = Color.Black;

--- a/Robust.Client/Graphics/IClydeViewport.cs
+++ b/Robust.Client/Graphics/IClydeViewport.cs
@@ -17,6 +17,7 @@ namespace Robust.Client.Graphics
         ///     The render target that is rendered to when rendering this viewport.
         /// </summary>
         IRenderTexture RenderTarget { get; }
+        IRenderTexture LightRenderTarget { get; }
         IEye? Eye { get; set; }
         Vector2i Size { get; }
 


### PR DESCRIPTION
Title! We're making use of this for the blindness rework we're working on for SS14, but we imagine it'll probably be incredibly useful for other purposes in the future.