### PR TITLE
FlushEntity() and EntityManager event changes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,11 +35,12 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* Various `IEntityManager` C# events now use `Entity<MetadataComponent>` instead of `EntityUid`
 
 ### New features
 
-*None yet*
+* Added two new `IEntityManager` C# events that get raiseed before and after deleting ("flushing") all entities.
+* Added a new `DeleteEntity()` override that takes in the entity's metadata and transform components.
 
 ### Bugfixes
 

--- a/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
@@ -54,9 +54,10 @@ namespace Robust.Client.GameObjects
             DebugTools.Assert(ExpectedEntities.TryGetValue(netEntity, out var expectedContainer) && expectedContainer == cont && cont.ExpectedEntities.Contains(netEntity));
         }
 
-        private void HandleEntityInitialized(EntityUid uid)
+        private void HandleEntityInitialized(Entity<MetaDataComponent> ent)
         {
-            if (!RemoveExpectedEntity(GetNetEntity(uid), out var container))
+            var (uid, meta) = ent;
+            if (!RemoveExpectedEntity(meta.NetEntity, out var container))
                 return;
 
             Insert((uid, TransformQuery.GetComponent(uid), MetaQuery.GetComponent(uid), null), container);

--- a/Robust.Client/GameStates/ClientDirtySystem.cs
+++ b/Robust.Client/GameStates/ClientDirtySystem.cs
@@ -71,9 +71,9 @@ public sealed class ClientDirtySystem : EntitySystem
         RemovedComponents.Clear();
     }
 
-    private void OnEntityDirty(EntityUid e)
+    private void OnEntityDirty(Entity<MetaDataComponent> e)
     {
-        if (_timing.InPrediction && !IsClientSide(e))
+        if (_timing.InPrediction && !IsClientSide(e, e))
             DirtyEntities.Add(e);
     }
 }

--- a/Robust.Server/GameObjects/EntitySystems/VisibilitySystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/VisibilitySystem.cs
@@ -99,9 +99,9 @@ namespace Robust.Server.GameObjects
             RefreshVisibility(ev.Entity);
         }
 
-        private void OnEntityInit(EntityUid uid)
+        private void OnEntityInit(Entity<MetaDataComponent> ent)
         {
-            RefreshVisibility(uid);
+            RefreshVisibility(ent.Owner, null, ent.Comp);
         }
 
         public void RefreshVisibility(EntityUid uid,

--- a/Robust.Server/GameStates/PvsOverrideSystem.cs
+++ b/Robust.Server/GameStates/PvsOverrideSystem.cs
@@ -46,9 +46,9 @@ public sealed class PvsOverrideSystem : EntitySystem
         _player.PlayerStatusChanged -= OnPlayerStatusChanged;
     }
 
-    private void OnDeleted(EntityUid uid, MetaDataComponent meta)
+    private void OnDeleted(Entity<MetaDataComponent> entity)
     {
-        Clear(uid);
+        Clear(entity);
     }
 
     private void Clear(EntityUid uid)

--- a/Robust.Server/GameStates/PvsSystem.Dirty.cs
+++ b/Robust.Server/GameStates/PvsSystem.Dirty.cs
@@ -40,14 +40,14 @@ namespace Robust.Server.GameStates
             EntityManager.EntityDirtied -= OnEntityDirty;
         }
 
-        private void OnEntityAdd(EntityUid e)
+        private void OnEntityAdd(Entity<MetaDataComponent> e)
         {
             DebugTools.Assert(_currentIndex == _gameTiming.CurTick.Value % DirtyBufferSize ||
                 _gameTiming.GetType().Name == "IGameTimingProxy");// Look I have NFI how best to excuse this assert if the game timing isn't real (a Mock<IGameTiming>).
             _addEntities[_currentIndex].Add(e);
         }
 
-        private void OnEntityDirty(EntityUid uid)
+        private void OnEntityDirty(Entity<MetaDataComponent> uid)
         {
             if (!_addEntities[_currentIndex].Contains(uid))
                 _dirtyEntities[_currentIndex].Add(uid);

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -8,6 +8,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Profiling;
@@ -81,15 +82,17 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public IEventBus EventBus => _eventBus;
 
-        public event Action<EntityUid>? EntityAdded;
-        public event Action<EntityUid>? EntityInitialized;
-        public event Action<EntityUid, MetaDataComponent>? EntityDeleted;
+        public event Action<Entity<MetaDataComponent>>? EntityAdded;
+        public event Action<Entity<MetaDataComponent>>? EntityInitialized;
+        public event Action<Entity<MetaDataComponent>>? EntityDeleted;
+        public event Action? BeforeEntityFlush;
+        public event Action? AfterEntityFlush;
 
         /// <summary>
         /// Raised when an entity is queued for deletion. Not raised if an entity is deleted.
         /// </summary>
         public event Action<EntityUid>? EntityQueueDeleted;
-        public event Action<EntityUid>? EntityDirtied; // only raised after initialization
+        public event Action<Entity<MetaDataComponent>>? EntityDirtied; // only raised after initialization
 
         private string _xformName = string.Empty;
 
@@ -346,7 +349,7 @@ namespace Robust.Shared.GameObjects
 
             if (metadata.EntityLifeStage > EntityLifeStage.Initializing)
             {
-                EntityDirtied?.Invoke(uid);
+                EntityDirtied?.Invoke((uid, metadata));
             }
         }
 
@@ -449,12 +452,10 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         /// Shuts-down and removes given Entity. This is also broadcast to all clients.
         /// </summary>
-        /// <param name="e">Entity to remove</param>
         public virtual void DeleteEntity(EntityUid? uid)
         {
             if (uid == null)
                 return;
-            var e = uid.Value;
 
             // Some UIs get disposed after entity-manager has shut down and already deleted all entities.
             if (!Started)
@@ -463,7 +464,20 @@ namespace Robust.Shared.GameObjects
             // Networking blindly spams entities at this function, they can already be
             // deleted from being a child of a previously deleted entity
             // TODO: Why does networking need to send deletes for child entities?
-            if (!MetaQuery.TryGetComponent(e, out var meta) || meta.EntityDeleted)
+            if (MetaQuery.TryGetComponent(uid.Value, out var meta))
+                DeleteEntity(uid.Value, meta, TransformQuery.GetComponent(uid.Value));
+        }
+
+        /// <summary>
+        /// Shuts-down and removes given Entity. This is also broadcast to all clients.
+        /// </summary>
+        public void DeleteEntity(EntityUid e, MetaDataComponent meta, TransformComponent xform)
+        {
+            // Some UIs get disposed after entity-manager has shut down and already deleted all entities.
+            if (!Started)
+                return;
+
+            if (meta.EntityLifeStage >= EntityLifeStage.Deleted)
                 return;
 
             if (meta.EntityLifeStage == EntityLifeStage.Terminating)
@@ -477,9 +491,8 @@ namespace Robust.Shared.GameObjects
             }
 
             // Notify all entities they are being terminated prior to detaching & deleting
-            RecursiveFlagEntityTermination(e, meta);
+            RecursiveFlagEntityTermination(e, meta, xform);
 
-            var xform = TransformQuery.GetComponent(e);
             TransformComponent? parentXform = null;
             if (xform.ParentUid.IsValid())
                 TransformQuery.Resolve(xform.ParentUid, ref parentXform);
@@ -488,9 +501,9 @@ namespace Robust.Shared.GameObjects
             RecursiveDeleteEntity(e, meta, xform, parentXform);
         }
 
-        private void RecursiveFlagEntityTermination(
-            EntityUid uid,
-            MetaDataComponent metadata)
+        private void RecursiveFlagEntityTermination(EntityUid uid,
+            MetaDataComponent metadata,
+            TransformComponent xform)
         {
             DebugTools.Assert(metadata.EntityLifeStage < EntityLifeStage.Terminating);
             metadata.EntityLifeStage = EntityLifeStage.Terminating;
@@ -505,17 +518,16 @@ namespace Robust.Shared.GameObjects
                 _sawmill.Error($"Caught exception while raising event {nameof(EntityTerminatingEvent)} on entity {ToPrettyString(uid, metadata)}\n{e}");
             }
 
-            var transform = TransformQuery.GetComponent(uid);
-            foreach (var child in transform._children)
+            foreach (var child in xform._children)
             {
                 if (!MetaQuery.TryGetComponent(child, out var childMeta) || childMeta.EntityDeleted)
                 {
                     _sawmill.Error($"A deleted entity was still the transform child of another entity. Parent: {ToPrettyString(uid, metadata)}.");
-                    transform._children.Remove(child);
+                    xform._children.Remove(child);
                     continue;
                 }
 
-                RecursiveFlagEntityTermination(child, childMeta);
+                RecursiveFlagEntityTermination(child, childMeta, TransformQuery.GetComponent(child));
             }
         }
 
@@ -584,7 +596,7 @@ namespace Robust.Shared.GameObjects
 
             try
             {
-                EntityDeleted?.Invoke(uid, metadata);
+                EntityDeleted?.Invoke((uid, metadata));
             }
             catch (Exception e)
             {
@@ -645,15 +657,57 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         public virtual void FlushEntities()
         {
+            BeforeEntityFlush?.Invoke();
             QueuedDeletions.Clear();
             QueuedDeletionsSet.Clear();
-            foreach (var e in GetEntities().ToArray())
+
+            // First, we directly delete all maps. This will delete most entities while reducing the number of component
+            // lookups
+
+            var maps = _entTraitDict[typeof(MapComponent)].Keys.ToArray();
+            foreach (var map in maps)
             {
-                DeleteEntity(e);
+                try
+                {
+                    DeleteEntity(map);
+                }
+                catch (Exception e)
+                {
+                    _sawmill.Log(LogLevel.Error, e,
+                        $"Caught exception while trying to delete map entity {ToPrettyString(map)}, this might corrupt the game state...");
+#if !EXCEPTION_TOLERANCE
+                    throw;
+#endif
+                }
+            }
+
+            // Then delete all other entities.
+            var ents = _entTraitDict[typeof(MetaDataComponent)].ToArray();
+            DebugTools.Assert(ents.Length == Entities.Count);
+            foreach (var (uid, comp) in ents)
+            {
+                var meta = (MetaDataComponent) comp;
+                if (meta.EntityLifeStage >= EntityLifeStage.Terminating)
+                    continue;
+
+                try
+                {
+                    DeleteEntity(uid, meta, TransformQuery.GetComponent(uid));
+                }
+                catch (Exception e)
+                {
+                    _sawmill.Log(LogLevel.Error, e,
+                        $"Caught exception while trying to delete entity {ToPrettyString(uid, meta)}, this might corrupt the game state...");
+#if !EXCEPTION_TOLERANCE
+                    throw;
+#endif
+                }
             }
 
             if (Entities.Count != 0)
                 _sawmill.Error("Entities were spawned while flushing entities.");
+
+            AfterEntityFlush?.Invoke();
         }
 
         /// <summary>
@@ -683,11 +737,6 @@ namespace Robust.Shared.GameObjects
             }
 #endif
 
-            // we want this called before adding components
-            EntityAdded?.Invoke(uid);
-            _eventBus.OnEntityAdded(uid);
-            var netEntity = GenerateNetEntity();
-
             metadata = new MetaDataComponent
             {
 #pragma warning disable CS0618
@@ -696,7 +745,12 @@ namespace Robust.Shared.GameObjects
                 EntityLastModifiedTick = _gameTiming.CurTick
             };
 
+            var netEntity = GenerateNetEntity();
             SetNetEntity(uid, netEntity, metadata);
+
+            // we want this called before adding components
+            EntityAdded?.Invoke((uid, metadata));
+            _eventBus.OnEntityAdded(uid);
 
             Entities.Add(uid);
             // add the required MetaDataComponent directly.
@@ -779,8 +833,10 @@ namespace Robust.Shared.GameObjects
 
         public void InitializeEntity(EntityUid entity, MetaDataComponent? meta = null)
         {
+            DebugTools.AssertOwner(entity, meta);
+            meta ??= GetComponent<MetaDataComponent>(entity);
             InitializeComponents(entity, meta);
-            EntityInitialized?.Invoke(entity);
+            EntityInitialized?.Invoke((entity, meta));
         }
 
         public void StartEntity(EntityUid entity)

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -51,10 +51,21 @@ namespace Robust.Shared.GameObjects
 
         #region Entity Management
 
-        event Action<EntityUid>? EntityAdded;
-        event Action<EntityUid>? EntityInitialized;
-        event Action<EntityUid, MetaDataComponent>? EntityDeleted;
-        event Action<EntityUid>? EntityDirtied; // only raised after initialization
+        event Action<Entity<MetaDataComponent>>? EntityAdded;
+        event Action<Entity<MetaDataComponent>>? EntityInitialized;
+        event Action<Entity<MetaDataComponent>>? EntityDeleted;
+        event Action<Entity<MetaDataComponent>>? EntityDirtied; // only raised after initialization
+
+
+        /// <summary>
+        /// Invoked just before all entities get deleted. See <see cref="FlushEntities"/>.
+        /// </summary>
+        public event Action? BeforeEntityFlush;
+
+        /// <summary>
+        /// Invoked just after all entities got deleted. See <see cref="FlushEntities"/>.
+        /// </summary>
+        public event Action? AfterEntityFlush;
 
         EntityUid CreateEntityUninitialized(string? prototypeName, EntityUid euid, ComponentRegistry? overrides = null);
 
@@ -114,6 +125,11 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         /// <param name="uid">Uid of entity to remove.</param>
         void DeleteEntity(EntityUid? uid);
+
+        /// <summary>
+        /// Shuts-down and removes the entity with the given <see cref="Robust.Shared.GameObjects.EntityUid"/>. This is also broadcast to all clients.
+        /// </summary>
+        void DeleteEntity(EntityUid uid, MetaDataComponent meta, TransformComponent xform);
 
         /// <summary>
         /// Checks whether an entity with the specified ID exists.

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -137,6 +137,7 @@ public sealed partial class EntityLookupSystem : EntitySystem
         EntityManager.EntityInitialized -= OnEntityInit;
         _transform.OnGlobalMoveEvent -= OnMove;
     }
+
     #region DynamicTree
 
     private void OnBroadphaseTerminating(EntityUid uid, BroadphaseComponent component, ref EntityTerminatingEvent args)
@@ -443,9 +444,9 @@ public sealed partial class EntityLookupSystem : EntitySystem
         (staticBody ? broadphase.StaticSundriesTree : broadphase.SundriesTree).AddOrUpdate(uid, aabb);
     }
 
-    private void OnEntityInit(EntityUid uid)
+    private void OnEntityInit(Entity<MetaDataComponent> uid)
     {
-        if (_container.IsEntityOrParentInContainer(uid) || _mapManager.IsMap(uid) || _mapManager.IsGrid(uid))
+        if (_container.IsEntityOrParentInContainer(uid, uid) || _mapManager.IsMap(uid) || _mapManager.IsGrid(uid))
             return;
 
         // TODO can this just be done implicitly via transform startup?


### PR DESCRIPTION
- Changes various entity manager C# events to use `Entity<MetadataComponent>` instead of just `EntityUid`
- Changes how `FlushEntities()` works. It now deletes maps before deleting all entities, which should make it a smidge faster.
- Adds C# events before and after flushing all entities. Intended to be used to avoid unnecessary processing when all entities are getting wiped