### PR TITLE
VisMask and EntityLifeStage changes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -36,6 +36,7 @@ END TEMPLATE-->
 ### Breaking changes
 
 * Various `IEntityManager` C# events now use `Entity<MetadataComponent>` instead of `EntityUid`
+* Entity visibility masks now use a ushort instead of an integer.
 
 ### New features
 

--- a/Robust.Server/GameObjects/Components/VisibilityComponent.cs
+++ b/Robust.Server/GameObjects/Components/VisibilityComponent.cs
@@ -12,6 +12,6 @@ namespace Robust.Server.GameObjects
         ///     Players whose visibility masks don't match this won't get state updates for it.
         /// </summary>
         [DataField("layer")]
-        public int Layer = 1;
+        public ushort Layer = 1;
     }
 }

--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -878,7 +878,7 @@ public sealed class MapLoaderSystem : EntitySystem
 
         if (data.MapIsPostInit)
         {
-            metadata.EntityLifeStage = EntityLifeStage.MapInitialized;
+            EntityManager.SetLifeStage(metadata, EntityLifeStage.MapInitialized);
         }
         else if (_mapManager.IsMapInitialized(data.TargetMap))
         {

--- a/Robust.Server/GameObjects/EntitySystems/VisibilitySystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/VisibilitySystem.cs
@@ -1,4 +1,4 @@
-using Robust.Server.GameStates;
+using System;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.ViewVariables;
@@ -7,7 +7,6 @@ namespace Robust.Server.GameObjects
 {
     public sealed class VisibilitySystem : EntitySystem
     {
-        [Dependency] private readonly PvsSystem _pvs = default!;
         [Dependency] private readonly IViewVariablesManager _vvManager = default!;
 
         private EntityQuery<TransformComponent> _xformQuery;
@@ -29,7 +28,7 @@ namespace Robust.Server.GameObjects
                     if (!Resolve(uid, ref comp))
                         return;
 
-                    SetLayer(uid, comp, value);
+                    SetLayer((uid, comp), value);
                 });
         }
 
@@ -39,12 +38,13 @@ namespace Robust.Server.GameObjects
             EntityManager.EntityInitialized -= OnEntityInit;
         }
 
+        [Obsolete("Use Entity<T> variant")]
         public void AddLayer(EntityUid uid, VisibilityComponent component, int layer, bool refresh = true)
         {
-            AddLayer((uid, component), layer, refresh);
+            AddLayer((uid, component), (ushort)layer, refresh);
         }
 
-        public void AddLayer(Entity<VisibilityComponent?> ent, int layer, bool refresh = true)
+        public void AddLayer(Entity<VisibilityComponent?> ent, ushort layer, bool refresh = true)
         {
             ent.Comp ??= _visibilityQuery.CompOrNull(ent.Owner) ?? AddComp<VisibilityComponent>(ent.Owner);
 
@@ -57,12 +57,14 @@ namespace Robust.Server.GameObjects
                 RefreshVisibility(ent);
         }
 
+
+        [Obsolete("Use Entity<T> variant")]
         public void RemoveLayer(EntityUid uid, VisibilityComponent component, int layer, bool refresh = true)
         {
-            RemoveLayer((uid, component), layer, refresh);
+            RemoveLayer((uid, component), (ushort)layer, refresh);
         }
 
-        public void RemoveLayer(Entity<VisibilityComponent?> ent, int layer, bool refresh = true)
+        public void RemoveLayer(Entity<VisibilityComponent?> ent, ushort layer, bool refresh = true)
         {
             if (!_visibilityQuery.Resolve(ent.Owner, ref ent.Comp, false))
                 return;
@@ -70,18 +72,19 @@ namespace Robust.Server.GameObjects
             if ((layer & ent.Comp.Layer) != layer)
                 return;
 
-            ent.Comp.Layer &= ~layer;
+            ent.Comp.Layer &= (ushort)~layer;
 
             if (refresh)
                 RefreshVisibility(ent);
         }
 
+        [Obsolete("Use Entity<T> variant")]
         public void SetLayer(EntityUid uid, VisibilityComponent component, int layer, bool refresh = true)
         {
-            SetLayer((uid, component), layer, refresh);
+            SetLayer((uid, component), (ushort)layer, refresh);
         }
 
-        public void SetLayer(Entity<VisibilityComponent?> ent, int layer, bool refresh = true)
+        public void SetLayer(Entity<VisibilityComponent?> ent, ushort layer, bool refresh = true)
         {
             ent.Comp ??= _visibilityQuery.CompOrNull(ent.Owner) ?? AddComp<VisibilityComponent>(ent.Owner);
 
@@ -123,7 +126,7 @@ namespace Robust.Server.GameObjects
             RecursivelyApplyVisibility(ent.Owner, mask, ent.Comp2);
         }
 
-        private void RecursivelyApplyVisibility(EntityUid uid, int mask, MetaDataComponent meta)
+        private void RecursivelyApplyVisibility(EntityUid uid, ushort mask, MetaDataComponent meta)
         {
             if (meta.VisibilityMask == mask)
                 return;
@@ -145,9 +148,9 @@ namespace Robust.Server.GameObjects
             }
         }
 
-        private int GetParentVisibilityMask(Entity<VisibilityComponent?> ent)
+        private ushort GetParentVisibilityMask(Entity<VisibilityComponent?> ent)
         {
-            int visMask = 1; // apparently some content expects everything to have the first bit/flag set to true.
+            ushort visMask = 1; // apparently some content expects everything to have the first bit/flag set to true.
             if (_visibilityQuery.Resolve(ent.Owner, ref ent.Comp, false))
                 visMask |= ent.Comp.Layer;
 

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -173,7 +173,7 @@ namespace Robust.Shared.GameObjects
         ///     Every entity will always have the first bit set to true.
         /// </remarks>
         [ViewVariables] // TODO ACCESS RRestrict writing to server-side visibility system
-        public int VisibilityMask { get; internal set; }= 1;
+        public ushort VisibilityMask { get; internal set; }= 1;
 
         [ViewVariables]
         public bool EntityPaused => PauseTime != null;

--- a/Robust.Shared/GameObjects/EntityLifeStage.cs
+++ b/Robust.Shared/GameObjects/EntityLifeStage.cs
@@ -3,7 +3,7 @@ namespace Robust.Shared.GameObjects
     /// <summary>
     /// The life stages of an ECS Entity.
     /// </summary>
-    public enum EntityLifeStage
+    public enum EntityLifeStage : byte
     {
         /// <summary>
         /// The entity has just been created, and needs to be initialized.

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -109,7 +109,7 @@ namespace Robust.Shared.GameObjects
             DebugTools.AssertOwner(uid, metadata);
             metadata ??= GetComponent<MetaDataComponent>(uid);
             DebugTools.Assert(metadata.EntityLifeStage == EntityLifeStage.PreInit);
-            metadata.EntityLifeStage = EntityLifeStage.Initializing;
+            SetLifeStage(metadata, EntityLifeStage.Initializing);
 
             // Initialize() can modify the collection of components. Copy them.
             FixedArray32<IComponent?> compsFixed = default;
@@ -136,7 +136,7 @@ namespace Robust.Shared.GameObjects
 
 #endif
             DebugTools.Assert(metadata.EntityLifeStage == EntityLifeStage.Initializing);
-            metadata.EntityLifeStage = EntityLifeStage.Initialized;
+            SetLifeStage(metadata, EntityLifeStage.Initialized);
         }
 
         public void StartComponents(EntityUid uid)

--- a/Robust.Shared/GameObjects/EntityManager.LifeCycle.cs
+++ b/Robust.Shared/GameObjects/EntityManager.LifeCycle.cs
@@ -90,4 +90,9 @@ public partial class EntityManager
         EventBus.RaiseComponentEvent(component, CompRemoveInstance);
         component.LifeStage = ComponentLifeStage.Deleted;
     }
+
+    internal virtual void SetLifeStage(MetaDataComponent meta, EntityLifeStage stage)
+    {
+        meta.EntityLifeStage = stage;
+    }
 }

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -46,7 +46,7 @@ namespace Robust.Shared.GameObjects
 
         public EntityQuery<MetaDataComponent> MetaQuery;
         public EntityQuery<TransformComponent> TransformQuery;
-        public EntityQuery<ActorComponent> _actorQuery;
+        private EntityQuery<ActorComponent> _actorQuery;
 
         #endregion Dependencies
 
@@ -92,7 +92,7 @@ namespace Robust.Shared.GameObjects
         /// Raised when an entity is queued for deletion. Not raised if an entity is deleted.
         /// </summary>
         public event Action<EntityUid>? EntityQueueDeleted;
-        public event Action<Entity<MetaDataComponent>>? EntityDirtied; // only raised after initialization
+        public event Action<Entity<MetaDataComponent>>? EntityDirtied;
 
         private string _xformName = string.Empty;
 
@@ -506,7 +506,7 @@ namespace Robust.Shared.GameObjects
             TransformComponent xform)
         {
             DebugTools.Assert(metadata.EntityLifeStage < EntityLifeStage.Terminating);
-            metadata.EntityLifeStage = EntityLifeStage.Terminating;
+            SetLifeStage(metadata, EntityLifeStage.Terminating);
 
             try
             {
@@ -591,8 +591,8 @@ namespace Robust.Shared.GameObjects
             }
 
             // Dispose all my components, in a safe order so transform is available
-            DisposeComponents(uid);
-            metadata.EntityLifeStage = EntityLifeStage.Deleted;
+            DisposeComponents(uid, metadata);
+            SetLifeStage(metadata, EntityLifeStage.Deleted);
 
             try
             {
@@ -850,7 +850,7 @@ namespace Robust.Shared.GameObjects
                 return; // Already map initialized, do nothing.
 
             DebugTools.Assert(meta.EntityLifeStage == EntityLifeStage.Initialized, $"Expected entity {ToPrettyString(entity)} to be initialized, was {meta.EntityLifeStage}");
-            meta.EntityLifeStage = EntityLifeStage.MapInitialized;
+            SetLifeStage(meta, EntityLifeStage.MapInitialized);
 
             EventBus.RaiseLocalEvent(entity, MapInitEventInstance, false);
         }

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -54,8 +54,11 @@ namespace Robust.Shared.GameObjects
         event Action<Entity<MetaDataComponent>>? EntityAdded;
         event Action<Entity<MetaDataComponent>>? EntityInitialized;
         event Action<Entity<MetaDataComponent>>? EntityDeleted;
-        event Action<Entity<MetaDataComponent>>? EntityDirtied; // only raised after initialization
 
+        /// <summary>
+        /// Invoked when an entity gets dirtied. This only gets raised after initialization, and at most once per tick.
+        /// </summary>
+        event Action<Entity<MetaDataComponent>>? EntityDirtied;
 
         /// <summary>
         /// Invoked just before all entities get deleted. See <see cref="FlushEntities"/>.


### PR DESCRIPTION
This PR changes entity visibility masks to use a ushort instead of integer, and changes how entity metadata lifestages are set internally. 

This PR was spun off from a PVS PR, and the ushort change is meant to help speed up PVS. If we really need more visibility layers, it could use 3 bytes without hurting the PVS PR, but I think 16 bits is probably enough? 