### PR TITLE
Prevent `/tpgrid` from moving grids to nullspace

### DIFF
--- a/Resources/Locale/en-US/commands.ftl
+++ b/Resources/Locale/en-US/commands.ftl
@@ -9,6 +9,7 @@ cmd-parse-failure-float = {$arg} is not a valid float.
 cmd-parse-failure-bool = {$arg} is not a valid bool.
 cmd-parse-failure-uid = {$arg} is not a valid entity UID.
 cmd-parse-failure-mapid = {$arg} is not a valid MapId.
+cmd-parse-failure-grid = {$arg} is not a valid grid.
 cmd-parse-failure-entity-exist = UID {$arg} does not correspond to an existing entity.
 
 cmd-error-file-not-found = Could not find file: {$file}.

--- a/Robust.Shared/Console/CompletionHelper.cs
+++ b/Robust.Shared/Console/CompletionHelper.cs
@@ -142,6 +142,11 @@ public static class CompletionHelper
         return entManager.EntityQuery<MapComponent>(true).Select(o => new CompletionOption(o.MapId.ToString()));
     }
 
+    public static IEnumerable<CompletionOption> MapUids(IEntityManager? entManager = null)
+    {
+        return Components<MapComponent>(string.Empty, entManager);
+    }
+
     public static IEnumerable<CompletionOption> NetEntities(string text, IEntityManager? entManager = null)
     {
         return Components<MetaDataComponent>(text, entManager);

--- a/Robust.Shared/Console/CompletionHelper.cs
+++ b/Robust.Shared/Console/CompletionHelper.cs
@@ -142,33 +142,9 @@ public static class CompletionHelper
         return entManager.EntityQuery<MapComponent>(true).Select(o => new CompletionOption(o.MapId.ToString()));
     }
 
-    public static IEnumerable<CompletionOption> MapUids(IEntityManager? entManager = null)
-    {
-        IoCManager.Resolve(ref entManager);
-
-        var query = entManager.AllEntityQueryEnumerator<MapComponent>();
-        while (query.MoveNext(out var uid, out _))
-        {
-            yield return new CompletionOption(uid.ToString());
-        }
-    }
-
     public static IEnumerable<CompletionOption> NetEntities(string text, IEntityManager? entManager = null)
     {
-        IoCManager.Resolve(ref entManager);
-
-        foreach (var ent in entManager.GetEntities())
-        {
-            if (!entManager.TryGetNetEntity(ent, out var netEntity))
-                continue;
-
-            var netString = netEntity.Value.ToString();
-
-            if (!netString.StartsWith(text))
-                continue;
-
-            yield return new CompletionOption(netString);
-        }
+        return Components<MetaDataComponent>(text, entManager);
     }
 
     public static IEnumerable<CompletionOption> Components<T>(string text, IEntityManager? entManager = null) where T : IComponent
@@ -187,7 +163,7 @@ public static class CompletionHelper
             if (!netString.StartsWith(text))
                 continue;
 
-            yield return new CompletionOption(netString);
+            yield return new CompletionOption(netString, metadata.EntityName);
         }
     }
 }


### PR DESCRIPTION
Also adds completion hints, and makes completion helper hints include entity names