### PR TITLE
Make MappingDataNode ordered

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -1211,7 +1211,7 @@ public sealed class MapLoaderSystem : EntitySystem
                     // information that needs to be written.
                     if (compMapping.Children.Count != 0 || protMapping == null)
                     {
-                        compMapping.Add("type", new ValueDataNode(compName));
+                        compMapping.InsertAt(0, "type", new ValueDataNode(compName));
                         // Something actually got written!
                         components.Add(compMapping);
                     }


### PR DESCRIPTION
Main reason for this change is to update map serialization to put the component type before the component information.