### PR TITLE
Revert "Fix replay int overflow issues."

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,7 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-* `replay.max_compressed_size` and `replay.max_uncompressed_size` CVars are now `long`.
+*None yet*
 
 ### New features
 
@@ -43,8 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-* Fixed integer overflows in replay max size calculation.
-* Explicitly capped `replay.replay_tick_batchSize` internally to avoid high values causing allocation failures.
+*None yet*
 
 ### Other
 

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1487,14 +1487,14 @@ namespace Robust.Shared
         /// <summary>
         /// Maximum compressed size of a replay recording (in kilobytes) before recording automatically stops.
         /// </summary>
-        public static readonly CVarDef<long> ReplayMaxCompressedSize = CVarDef.Create("replay.max_compressed_size",
-            1024L * 256, CVar.ARCHIVE);
+        public static readonly CVarDef<int> ReplayMaxCompressedSize = CVarDef.Create("replay.max_compressed_size",
+            1024 * 256, CVar.ARCHIVE);
 
         /// <summary>
         /// Maximum uncompressed size of a replay recording (in kilobytes) before recording automatically stops.
         /// </summary>
-        public static readonly CVarDef<long> ReplayMaxUncompressedSize = CVarDef.Create("replay.max_uncompressed_size",
-            1024L * 1024, CVar.ARCHIVE);
+        public static readonly CVarDef<int> ReplayMaxUncompressedSize = CVarDef.Create("replay.max_uncompressed_size",
+            1024 * 1024, CVar.ARCHIVE);
 
         /// <summary>
         /// Uncompressed size of individual files created by the replay (in kilobytes), where each file contains data


### PR DESCRIPTION
This reverts commit 9877323195c07e1b28f30beffbc5d88bdce1470a.

Causing test failures due to cvars not handling longs properly.