### PR TITLE
Try fix pvs null exception

### DIFF
--- a/Robust.Server/GameStates/PvsSystem.Ack.cs
+++ b/Robust.Server/GameStates/PvsSystem.Ack.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Prometheus;
+using Robust.Shared.Enums;
+using Robust.Shared.Log;
 using Robust.Shared.Player;
 using Robust.Shared.Threading;
 using Robust.Shared.Timing;
@@ -43,7 +45,8 @@ internal sealed partial class PvsSystem
 
         foreach (var session in PendingAcks)
         {
-            _toAck.Add(GetOrNewPvsSession(session));
+            if (session.Status != SessionStatus.Disconnected)
+                _toAck.Add(GetOrNewPvsSession(session));
         }
 
         PendingAcks.Clear();
@@ -66,7 +69,14 @@ internal sealed partial class PvsSystem
 
         public void Execute(int index)
         {
-            _pvs.ProcessQueuedAck(_pvs._toAck[index]);
+            try
+            {
+                _pvs.ProcessQueuedAck(_pvs._toAck[index]);
+            }
+            catch (Exception e)
+            {
+                _pvs.Log.Log(LogLevel.Error, e, $"Caught exception while processing PVS acks.");
+            }
         }
     }
 
@@ -78,7 +88,14 @@ internal sealed partial class PvsSystem
 
         public void Execute(int index)
         {
-            _pvs.UpdateDirtyChunks(index);
+            try
+            {
+                _pvs.UpdateDirtyChunks(index);
+            }
+            catch (Exception e)
+            {
+                _pvs.Log.Log(LogLevel.Error, e, $"Caught exception while updating dirty PVS chunks.");
+            }
         }
     }
 

--- a/Robust.Server/GameStates/PvsSystem.Leave.cs
+++ b/Robust.Server/GameStates/PvsSystem.Leave.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Prometheus;
 using Robust.Shared.Enums;
+using Robust.Shared.Log;
 using Robust.Shared.Network.Messages;
 using Robust.Shared.Player;
 using Robust.Shared.Threading;
@@ -77,7 +78,14 @@ internal sealed partial class PvsSystem
 
         public void Execute(int index)
         {
-            _pvs.ProcessLeavePvs(_sessions[index]);
+            try
+            {
+                _pvs.ProcessLeavePvs(_sessions[index]);
+            }
+            catch (Exception e)
+            {
+                _pvs.Log.Log(LogLevel.Error, e, $"Caught exception while processing pvs-leave messages.");
+            }
         }
 
         public void Setup(ICommonSession[] sessions)

--- a/Robust.Server/GameStates/PvsSystem.Session.cs
+++ b/Robust.Server/GameStates/PvsSystem.Session.cs
@@ -24,6 +24,8 @@ internal sealed partial class PvsSystem
 
     internal readonly Dictionary<ICommonSession, PvsSession> PlayerData = new();
 
+    private List<ICommonSession> _disconnected = new();
+
     private void SendStateUpdate(ICommonSession session, PvsThreadResources resources)
     {
         var data = GetOrNewPvsSession(session);
@@ -174,13 +176,8 @@ internal sealed partial class PvsSystem
 
     private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs e)
     {
-        if (e.NewStatus != SessionStatus.Disconnected)
-            return;
-
-        if (!PlayerData.Remove(e.Session, out var session))
-            return;
-
-        ClearSendHistory(session);
+        if (e.NewStatus == SessionStatus.Disconnected)
+            _disconnected.Add(e.Session);
     }
 
     private void ClearSendHistory(PvsSession session)

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -252,6 +252,8 @@ internal sealed partial class PvsSystem : EntitySystem
 
     private void ForceFullState(PvsSession session)
     {
+        _leaveTask?.WaitOne();
+        _leaveTask = null;
         session.LastReceivedAck = _gameTiming.CurTick;
         session.RequestedFull = true;
         ClearSendHistory(session);
@@ -405,6 +407,15 @@ internal sealed partial class PvsSystem : EntitySystem
         DebugTools.Assert(_chunks.Values.All(x => Exists(x.Map) && Exists(x.Root)));
         DebugTools.Assert(_chunkSets.Keys.All(Exists));
 
+        _leaveTask?.WaitOne();
+        _leaveTask = null;
+
+        foreach (var session in _disconnected)
+        {
+            if (PlayerData.Remove(session, out var pvsSession))
+                ClearSendHistory(pvsSession);
+        }
+
         var ackJob = ProcessQueuedAcks();
 
         // Figure out what chunks players can see and cache some chunk data.
@@ -415,10 +426,6 @@ internal sealed partial class PvsSystem : EntitySystem
         }
 
         ackJob?.WaitOne();
-
-        // Ensure any pvs leave tasks have finished before we get the next state & overwrite the "last sent" list.
-        _leaveTask?.WaitOne();
-        _leaveTask = null;
     }
 
     internal void CacheSessionData(ICommonSession[] players)


### PR DESCRIPTION
Ensures that `ClearSendHistory()` doesn't get called while the pvs-leave job is still running.