### PR TITLE
Fix volume setting values being over or under 1 making the client unable to connect to servers

### DIFF
--- a/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
+++ b/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
@@ -154,7 +154,7 @@ public abstract partial class SharedAudioSystem : EntitySystem
     {
         if (value < 0f)
         {
-            throw new InvalidOperationException($"Tried to get volume calculation for gain of {value}.");
+            value = 0f;
         }
 
         return 10f * MathF.Log10(value);


### PR DESCRIPTION
Fixes https://github.com/space-wizards/space-station-14/issues/23491

I wanted to make this do logging. However i cant get Log.Error to work on static context and Im not sure how much of a challenge or how much it will break if i make it non static so i just left it

This will shrimply turn the value to 0.

Maybe update engine after merging on content since its kinda is a hotfix