### PR TITLE
Add support for forcing prototypes in a file or directory to be parsed as abstract

### DIFF
--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -350,6 +350,30 @@ public interface IPrototypeManager
     /// Get the yaml data for a given prototype.
     /// </summary>
     IReadOnlyDictionary<string, MappingDataNode> GetPrototypeData(EntityPrototype prototype);
+
+    /// <summary>
+    ///     Forces all prototypes in the given file to be abstract.
+    ///     This makes them be read as abstract prototypes (mappings) instead of regular prototype instances.
+    ///     Calling this method will not retroactively abstract prototypes that have already been read.
+    /// </summary>
+    /// <param name="path">
+    ///     The directory to ignore prototypes in.
+    ///     This must start from the Resources-level directory, but not include Resources itself.
+    ///     For example: /Prototypes/Guidebook/antagonist.yml
+    /// </param>
+    void AbstractFile(ResPath path);
+
+    /// <summary>
+    ///     Forces all prototypes in files recursively within this directory to be abstract.
+    ///     This makes them be read as abstract prototypes (mappings) instead of regular prototype instances.
+    ///     Calling this method will not retroactively abstract prototypes that have already been read.
+    /// </summary>
+    /// <param name="path">
+    ///     The directory to ignore prototypes in.
+    ///     This must start from the Resources-level directory, but not include Resources itself.
+    ///     For example: /Prototypes/Guidebook
+    /// </param>
+    void AbstractDirectory(ResPath path);
 }
 
 internal interface IPrototypeManagerInternal : IPrototypeManager

--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -357,7 +357,7 @@ public interface IPrototypeManager
     ///     Calling this method will not retroactively abstract prototypes that have already been read.
     /// </summary>
     /// <param name="path">
-    ///     The directory to ignore prototypes in.
+    ///     The file to force prototypes to be abstract in.
     ///     This must start from the Resources-level directory, but not include Resources itself.
     ///     For example: /Prototypes/Guidebook/antagonist.yml
     /// </param>
@@ -369,7 +369,7 @@ public interface IPrototypeManager
     ///     Calling this method will not retroactively abstract prototypes that have already been read.
     /// </summary>
     /// <param name="path">
-    ///     The directory to ignore prototypes in.
+    ///     The directory to force prototypes to be abstract in.
     ///     This must start from the Resources-level directory, but not include Resources itself.
     ///     For example: /Prototypes/Guidebook
     /// </param>

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
@@ -17,19 +17,12 @@ public partial class PrototypeManager
     /// <summary>
     ///     Which files to force all prototypes within to be abstract.
     /// </summary>
-    private readonly HashSet<ResPath> _abstractFiles = new();
+    private readonly List<ResPath> _abstractFiles = new();
 
     /// <summary>
     ///     Which directories to force all prototypes recursively within to be abstract.
     /// </summary>
-    private readonly HashSet<ResPath> _abstractDirectories = new();
-
-    /// <summary>
-    ///     Whether or not any prototypes may be potentially forced to be abstract.
-    ///     This is true if either <see cref="_abstractFiles"/> or <see cref="_abstractDirectories"/> contain elements,
-    ///     and false otherwise.
-    /// </summary>
-    private bool _hasForcedAbstractPrototypes;
+    private readonly List<ResPath> _abstractDirectories = new();
 
     public event Action<DataNodeDocument>? LoadedData;
 
@@ -311,21 +304,16 @@ public partial class PrototypeManager
 
     public void AbstractFile(ResPath path)
     {
-        _hasForcedAbstractPrototypes = true;
         _abstractFiles.Add(path);
     }
 
     public void AbstractDirectory(ResPath path)
     {
-        _hasForcedAbstractPrototypes = true;
         _abstractDirectories.Add(path);
     }
 
     private bool IsFileAbstract(ResPath file)
     {
-        if (!_hasForcedAbstractPrototypes)
-            return false;
-
         if (_abstractFiles.Count > 0)
         {
             foreach (var abstractFile in _abstractFiles)

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
@@ -354,7 +354,7 @@ public partial class PrototypeManager
             if (abstractNode is not ValueDataNode abstractValueNode)
             {
                 mapping.Remove(abstractNode);
-                mapping.Add("abstract", new ValueDataNode("true"));
+                mapping.Add("abstract", "true");
                 return;
             }
 


### PR DESCRIPTION
For downstreams that want to force some prototypes to be abstract.
This is specially useful in cases where content calls EnumeratePrototypes and loops over them.
You can now for example ignore all Guidebook entries from upstream without modifying them or any code that enumerates them.
The alternative would be either modifying those prototypes (likely to get conflicts) or the code that enumerates those prototypes (also likely to get conflicts), this allows for example for a call to be placed in EntryPoint Init (less likely to get conflicts), or in the future an event listener to do this (0 conflicts).
The reason to parse them as abstract instead of not at all is that this lets you inherit those prototypes.
Not used upstream.
Haven't profiled it but hopefully the single boolean check when not used makes it fast enough™️.
Callers must handle how to determine which files or directories to ignore on their own, there is intentionally no engine API for this to keep the API surface small.

@EmoGarbage404 