### PR TITLE
Fix full state updates

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -18,7 +18,7 @@ Don't change the format without looking at the script!
 
 ### Bugfixes
 
-*None yet*
+* Fixed broken full state updates and excluded it from PVS budged.
 
 ### Other
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -18,7 +18,7 @@ Don't change the format without looking at the script!
 
 ### Bugfixes
 
-* Fixed broken full state updates and excluded it from PVS budged.
+*None yet*
 
 ### Other
 
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Fixe broken full state updates and exclude it from PVS budged.
 
 ### Other
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-* Fixe broken full state updates and exclude it from PVS budged.
+* Fix broken full state updates and exclude it from the PVS budget.
 
 ### Other
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-* Fix broken full state updates and exclude it from the PVS budget.
+* Fix broken full state updates.
 
 ### Other
 

--- a/Robust.Server/GameStates/PvsSystem.Session.cs
+++ b/Robust.Server/GameStates/PvsSystem.Session.cs
@@ -193,5 +193,6 @@ internal sealed partial class PvsSystem
 
         session.PreviouslySent.Clear();
         session.LastSent = null;
+        session.Entities.Clear();
     }
 }

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -294,19 +294,15 @@ internal sealed partial class PvsSystem : EntitySystem
 
         // After processing the entity's viewers, we set actual, budget limits.
         // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-        if (!session.RequestedFull)
+        if (session.Channel != null)
         {
-            if (session.Channel != null)
-            {
-                session.Budget.NewLimit = _netConfigManager.GetClientCVar(session.Channel, CVars.NetPVSEntityBudget);
-                session.Budget.EnterLimit =
-                    _netConfigManager.GetClientCVar(session.Channel, CVars.NetPVSEntityEnterBudget);
-            }
-            else
-            {
-                session.Budget.NewLimit = CVars.NetPVSEntityBudget.DefaultValue;
-                session.Budget.EnterLimit = CVars.NetPVSEntityEnterBudget.DefaultValue;
-            }
+            session.Budget.NewLimit= _netConfigManager.GetClientCVar(session.Channel, CVars.NetPVSEntityBudget);
+            session.Budget.EnterLimit = _netConfigManager.GetClientCVar(session.Channel, CVars.NetPVSEntityEnterBudget);
+        }
+        else
+        {
+            session.Budget.NewLimit= CVars.NetPVSEntityBudget.DefaultValue;
+            session.Budget.EnterLimit = CVars.NetPVSEntityEnterBudget.DefaultValue;
         }
 
         // Process all PVS overrides.

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -294,15 +294,19 @@ internal sealed partial class PvsSystem : EntitySystem
 
         // After processing the entity's viewers, we set actual, budget limits.
         // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-        if (session.Channel != null)
+        if (!session.RequestedFull)
         {
-            session.Budget.NewLimit= _netConfigManager.GetClientCVar(session.Channel, CVars.NetPVSEntityBudget);
-            session.Budget.EnterLimit = _netConfigManager.GetClientCVar(session.Channel, CVars.NetPVSEntityEnterBudget);
-        }
-        else
-        {
-            session.Budget.NewLimit= CVars.NetPVSEntityBudget.DefaultValue;
-            session.Budget.EnterLimit = CVars.NetPVSEntityEnterBudget.DefaultValue;
+            if (session.Channel != null)
+            {
+                session.Budget.NewLimit = _netConfigManager.GetClientCVar(session.Channel, CVars.NetPVSEntityBudget);
+                session.Budget.EnterLimit =
+                    _netConfigManager.GetClientCVar(session.Channel, CVars.NetPVSEntityEnterBudget);
+            }
+            else
+            {
+                session.Budget.NewLimit = CVars.NetPVSEntityBudget.DefaultValue;
+                session.Budget.EnterLimit = CVars.NetPVSEntityEnterBudget.DefaultValue;
+            }
         }
 
         // Process all PVS overrides.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Hopefully, address the weird issue with broken full state updates https://github.com/space-wizards/RobustToolbox/issues/4832

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I noticed that `session.Entities` isn't cleared properly, causing the engine to mistakenly think that the client already seen/ack entities. Also, I think that the full update should skip PVS budgets, as it helps to address UI glitches during the update even though it causes a CPU and network utilization spike.