### PR TITLE
Isolate net messages in integration tests.

### DIFF
--- a/Lidgren.Network/CursedHorrorsBeyondOurWildestImagination.cs
+++ b/Lidgren.Network/CursedHorrorsBeyondOurWildestImagination.cs
@@ -1,0 +1,9 @@
+﻿using System.Runtime.CompilerServices;
+
+// So I wanted to mess with NetIncomingMessage and NetOutgoingMessage from tests.
+// Now.. the instructors are internal...
+// Unless...
+// I mean we have this project here from the weird way we're compiling Lidgren.
+// I could just put this in here... it wouldn't touch the main Lidgren repo at all...
+[assembly: InternalsVisibleTo("Robust.UnitTesting")]
+

--- a/Lidgren.Network/Lidgren.Network.csproj
+++ b/Lidgren.Network/Lidgren.Network.csproj
@@ -16,6 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="CursedHorrorsBeyondOurWildestImagination.cs" />
+
     <Compile Include="Lidgren.Network\Lidgren.Network\**\*.cs">
      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -47,7 +47,7 @@ END TEMPLATE-->
 
 ### Other
 
-*None yet*
+* Integration tests now run `NetMessage`s through serialization rather than passing the objects between client and server. This causes tests that missed `[NetSerializer]` attributes on any objects that need them to fail.
 
 ### Internal
 

--- a/Robust.Shared/Serialization/RobustSerializer.cs
+++ b/Robust.Shared/Serialization/RobustSerializer.cs
@@ -100,6 +100,11 @@ namespace Robust.Shared.Serialization
         public byte[] GetSerializableTypesHash() => Convert.FromHexString(_serializer.GetSHA256());
         public string GetSerializableTypesHashString() => _serializer.GetSHA256();
 
+        internal void GetHashManifest(Stream stream, bool writeNewline=false)
+        {
+            _serializer.GetHashManifest(stream, writeNewline);
+        }
+
         public (byte[] Hash, byte[] Package) GetStringSerializerPackage() => MappedStringSerializer.GeneratePackage();
 
         public Dictionary<Type, uint> GetTypeMap() => _serializer.GetTypeMap();

--- a/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
@@ -1,14 +1,17 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using Lidgren.Network;
 using Robust.Shared.Asynchronous;
 using Robust.Shared.IoC;
 using Robust.Shared.Network;
 using Robust.Shared.Network.Messages;
+using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -20,6 +23,8 @@ namespace Robust.UnitTesting
         {
             [Dependency] private readonly IGameTiming _gameTiming = default!;
             [Dependency] private readonly ITaskManager _taskManager = default!;
+            [Dependency] private readonly IRobustSerializer _robustSerializer = default!;
+
             public bool IsServer { get; private set; }
             public bool IsClient => !IsServer;
             public bool IsRunning { get; private set; }
@@ -52,6 +57,10 @@ namespace Robust.UnitTesting
             ///     The channel we will connect to when <see cref="ClientConnect"/> is called.
             /// </summary>
             public ChannelWriter<object>? NextConnectChannel { get; set; }
+
+            // Used for faking NetMessage.ReadFromBuffer and WriteToBuffer.
+            private readonly NetOutgoingMessage _serializationMessage = new();
+            private readonly NetIncomingMessage _deserializationMessage = new();
 
             private int _genConnectionUid()
             {
@@ -171,7 +180,7 @@ namespace Robust.UnitTesting
                                 channel = ServerChannel;
                             }
 
-                            var message = data.Message;
+                            var message = DeserializeNetMessage(data);
                             message.MsgChannel = channel;
                             if (_callbacks.TryGetValue(message.GetType(), out var callback))
                             {
@@ -263,7 +272,7 @@ namespace Robust.UnitTesting
                 }
 
                 var channel = (IntegrationNetChannel) recipient;
-                channel.OtherChannel.TryWrite(new DataMessage(message, channel.RemoteUid));
+                channel.OtherChannel.TryWrite(SerializeNetMessage(message, channel.RemoteUid));
             }
 
             public void ServerSendToMany(NetMessage message, List<INetChannel> recipients)
@@ -380,7 +389,7 @@ namespace Robust.UnitTesting
                     throw new InvalidOperationException("Not connected.");
                 }
 
-                channel.OtherChannel.TryWrite(new DataMessage(message, channel.RemoteUid));
+                channel.OtherChannel.TryWrite(SerializeNetMessage(message, channel.RemoteUid));
             }
 
             public void DispatchLocalNetMessage(NetMessage message)
@@ -389,6 +398,42 @@ namespace Robust.UnitTesting
                 {
                     callback(message);
                 }
+            }
+
+            private DataMessage SerializeNetMessage(NetMessage netMessage, int remoteUid)
+            {
+                byte[] pooledBuffer;
+                int length;
+                lock (_serializationMessage)
+                {
+                    netMessage.WriteToBuffer(_serializationMessage, _robustSerializer);
+                    length = _serializationMessage.LengthBytes;
+                    pooledBuffer = ArrayPool<byte>.Shared.Rent(length);
+                    _serializationMessage.Data.AsSpan(0, length).CopyTo(pooledBuffer);
+                    _serializationMessage.Position = 0;
+                    _serializationMessage.LengthBytes = 0;
+                }
+
+                return new DataMessage(pooledBuffer, length, netMessage.GetType(), remoteUid);
+            }
+
+            private NetMessage DeserializeNetMessage(DataMessage message)
+            {
+                var buffer = message.PooledNetBuffer;
+                var netMessage = (NetMessage) Activator.CreateInstance(message.MessageType)!;
+                lock (_deserializationMessage)
+                {
+                    _deserializationMessage.m_data = buffer;
+                    _deserializationMessage.LengthBytes = message.Length;
+                    _deserializationMessage.Position = 0;
+
+                    netMessage.ReadFromBuffer(_deserializationMessage, _robustSerializer);
+
+                    _deserializationMessage.m_data = null;
+                }
+
+                ArrayPool<byte>.Shared.Return(buffer);
+                return netMessage;
             }
 
             private sealed class IntegrationNetChannel : INetChannel
@@ -486,17 +531,7 @@ namespace Robust.UnitTesting
             {
             }
 
-            private sealed class DataMessage
-            {
-                public DataMessage(NetMessage message, int connection)
-                {
-                    Message = message;
-                    Connection = connection;
-                }
-
-                public NetMessage Message { get; }
-                public int Connection { get; }
-            }
+            private sealed record DataMessage(byte[] PooledNetBuffer, int Length, Type MessageType, int Connection);
 
             private sealed class DisconnectMessage
             {

--- a/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
@@ -258,19 +258,6 @@ namespace Robust.UnitTesting
             {
                 DebugTools.Assert(IsServer);
 
-                if (message is MsgState stateMsg)
-                {
-                    // MsgState sending method depends on the size of the possible compressed buffer. But tests bypass buffer read/write.
-                    stateMsg._hasWritten = true;
-
-                    // Need to duplicate the state to avoid the server & client storing references to the same collections.
-                    stateMsg.State = stateMsg.State.Clone();
-                }
-                else if (message is MsgStateLeavePvs leaveMsg)
-                {
-                    leaveMsg.Entities = leaveMsg.Entities.ShallowClone();
-                }
-
                 var channel = (IntegrationNetChannel) recipient;
                 channel.OtherChannel.TryWrite(SerializeNetMessage(message, channel.RemoteUid));
             }

--- a/Robust.UnitTesting/RobustIntegrationTest.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.cs
@@ -34,6 +34,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Reflection;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using ServerProgram = Robust.Server.Program;
@@ -679,6 +680,7 @@ namespace Robust.UnitTesting
                 deps.BuildGraph();
                 //ServerProgram.SetupLogging();
                 ServerProgram.InitReflectionManager(deps);
+                deps.Resolve<IReflectionManager>().LoadAssemblies(typeof(RobustIntegrationTest).Assembly);
 
                 var server = DependencyCollection.Resolve<BaseServer>();
 

--- a/Robust.UnitTesting/RobustIntegrationTest.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.cs
@@ -862,6 +862,7 @@ namespace Robust.UnitTesting
                 deps.BuildGraph();
 
                 GameController.RegisterReflection(deps);
+                deps.Resolve<IReflectionManager>().LoadAssemblies(typeof(RobustIntegrationTest).Assembly);
 
                 var client = DependencyCollection.Resolve<GameController>();
 

--- a/Robust.UnitTesting/Server/GameObjects/ComponentMapInitTest.cs
+++ b/Robust.UnitTesting/Server/GameObjects/ComponentMapInitTest.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using NUnit.Framework;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
+using Robust.Shared.Reflection;
 
 namespace Robust.UnitTesting.Server.GameObjects;
 
@@ -38,6 +39,7 @@ public sealed partial class ComponentMapInitTest
         mapManager.DeleteMap(mapId);
     }
 
+    [Reflect(false)]
     private sealed class MapInitTestSystem : EntitySystem
     {
         public override void Initialize()
@@ -52,6 +54,7 @@ public sealed partial class ComponentMapInitTest
         }
     }
 
+    [Reflect(false)]
     private sealed partial class MapInitTestComponent : Component
     {
         public int Count = 0;

--- a/Robust.UnitTesting/Shared/GameObjects/DeferredEntityDeletionTest.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/DeferredEntityDeletionTest.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
+using Robust.Shared.Reflection;
 
 namespace Robust.UnitTesting.Shared.GameObjects;
 
@@ -89,6 +90,7 @@ public sealed partial class DeferredEntityDeletionTest : RobustIntegrationTest
         await server.WaitIdleAsync();
     }
 
+    [Reflect(false)]
     private sealed class DeferredDeletionTestSystem : EntitySystem
     {
         public override void Initialize()
@@ -104,6 +106,7 @@ public sealed partial class DeferredEntityDeletionTest : RobustIntegrationTest
         }
     }
 
+    [Reflect(false)]
     private sealed class OtherDeferredDeletionTestSystem : EntitySystem
     {
         public override void Initialize() => SubscribeLocalEvent<OtherDeferredDeletionTestComponent, DeferredDeletionTestEvent>(OnTestEvent);
@@ -117,10 +120,12 @@ public sealed partial class DeferredEntityDeletionTest : RobustIntegrationTest
     }
 
     [RegisterComponent]
+    [Reflect(false)]
     private sealed partial class DeferredDeletionTestComponent : Component
     {
     }
 
+    [Reflect(false)]
     private sealed partial class OtherDeferredDeletionTestComponent : Component
     {
     }

--- a/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.OrderedEvents.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.OrderedEvents.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
+using Robust.Shared.Reflection;
 using Robust.UnitTesting.Server;
 
 namespace Robust.UnitTesting.Shared.GameObjects;
@@ -41,6 +42,7 @@ public sealed partial class EntityEventBusTests
         Assert.That(foo.EventOrder, Is.EquivalentTo(new[]{"Foo", "Transform", "Metadata"}).Or.EquivalentTo(new[]{"Foo", "Metadata", "Transform"}));
     }
 
+    [Reflect(false)]
     private sealed class DifferentComponentsSameKeySubSystem : EntitySystem
     {
         public override void Initialize()
@@ -50,6 +52,7 @@ public sealed partial class EntityEventBusTests
         }
     }
 
+    [Reflect(false)]
     private sealed class DifferentComponentsSameKeySubSystem2 : EntitySystem
     {
         public override void Initialize()
@@ -60,7 +63,7 @@ public sealed partial class EntityEventBusTests
         }
     }
 
-
+    [Reflect(false)]
     private sealed partial class FooComponent : Component
     {
 

--- a/Robust.UnitTesting/Shared/GameObjects/EntitySystemManagerOrderTest.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntitySystemManagerOrderTest.cs
@@ -27,6 +27,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             public int X;
         }
 
+        [Reflect(false)]
         private abstract class TestSystemBase : IEntitySystem
         {
             public Counter? Counter;
@@ -47,21 +48,25 @@ namespace Robust.UnitTesting.Shared.GameObjects
 
         // Expected update order is is A -> D -> C -> B
 
+        [Reflect(false)]
         private sealed class TestSystemA : TestSystemBase
         {
 
         }
 
+        [Reflect(false)]
         private sealed class TestSystemB : TestSystemBase
         {
             public override IEnumerable<Type> UpdatesAfter => new[] {typeof(TestSystemA)};
         }
 
+        [Reflect(false)]
         private sealed class TestSystemC : TestSystemBase
         {
             public override IEnumerable<Type> UpdatesBefore => new[] {typeof(TestSystemB)};
         }
 
+        [Reflect(false)]
         private sealed class TestSystemD : TestSystemBase
         {
             public override IEnumerable<Type> UpdatesAfter => new[] {typeof(TestSystemA)};

--- a/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
@@ -9,6 +9,7 @@ using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Reflection;
 using Robust.UnitTesting.Server;
 
 // ReSharper disable AccessToStaticMemberViaDerivedType
@@ -88,8 +89,10 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         }
 
         [ComponentProtoName("AnchorOnInit")]
+        [Reflect(false)]
         private sealed partial class AnchorOnInitComponent : Component { };
 
+        [Reflect(false)]
         private sealed class AnchorOnInitTestSystem : EntitySystem
         {
             public override void Initialize()
@@ -99,6 +102,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             }
         }
 
+        [Reflect(false)]
         internal sealed class MoveEventTestSystem : EntitySystem
         {
             [Dependency] private readonly SharedTransformSystem _transform = default!;

--- a/Robust.UnitTesting/Shared/GameState/ComponentStateTests.cs
+++ b/Robust.UnitTesting/Shared/GameState/ComponentStateTests.cs
@@ -8,6 +8,7 @@ using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
+using Robust.Shared.Reflection;
 using Robust.Shared.Serialization.Manager.Attributes;
 
 namespace Robust.UnitTesting.Shared.GameState;
@@ -23,20 +24,8 @@ public sealed partial class ComponentStateTests : RobustIntegrationTest
     public async Task UnknownEntityTest()
     {
         // Setup auto-comp-states. I hate this. Someone please fix reflection in RobustIntegrationTest
-        var compReg = () => IoCManager.Resolve<IComponentFactory>().RegisterClass<UnknownEntityTestComponent>();
-        var sysReg = () => IoCManager.Resolve<IEntitySystemManager>().LoadExtraSystemType<UnknownEntityTestComponent.UnknownEntityTestComponent_AutoNetworkSystem>();
-        var serverOpts = new ServerIntegrationOptions
-        {
-            Pool = false,
-            BeforeRegisterComponents = compReg,
-            BeforeStart = sysReg,
-        };
-        var clientOpts = new ClientIntegrationOptions
-        {
-            Pool = false,
-            BeforeRegisterComponents = compReg,
-            BeforeStart = sysReg,
-        };
+        var serverOpts = new ServerIntegrationOptions { Pool = false };
+        var clientOpts = new ClientIntegrationOptions { Pool = false };
         var server = StartServer(serverOpts);
         var client = StartClient(clientOpts);
 
@@ -159,20 +148,8 @@ public sealed partial class ComponentStateTests : RobustIntegrationTest
     public async Task UnknownEntityDeleteTest()
     {
         // The first chunk of the test just follows UnknownEntityTest
-        var compReg = () => IoCManager.Resolve<IComponentFactory>().RegisterClass<UnknownEntityTestComponent>();
-        var sysReg = () => IoCManager.Resolve<IEntitySystemManager>().LoadExtraSystemType<UnknownEntityTestComponent.UnknownEntityTestComponent_AutoNetworkSystem>();
-        var serverOpts = new ServerIntegrationOptions
-        {
-            Pool = false,
-            BeforeRegisterComponents = compReg,
-            BeforeStart = sysReg,
-        };
-        var clientOpts = new ClientIntegrationOptions
-        {
-            Pool = false,
-            BeforeRegisterComponents = compReg,
-            BeforeStart = sysReg,
-        };
+        var serverOpts = new ServerIntegrationOptions { Pool = false };
+        var clientOpts = new ClientIntegrationOptions { Pool = false };
         var server = StartServer(serverOpts);
         var client = StartClient(clientOpts);
 

--- a/Robust.UnitTesting/Shared/TestRobustSerializerHash.cs
+++ b/Robust.UnitTesting/Shared/TestRobustSerializerHash.cs
@@ -1,0 +1,43 @@
+﻿using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Robust.Shared.IoC;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+
+namespace Robust.UnitTesting.Shared;
+
+[Parallelizable(ParallelScope.All)]
+internal sealed class TestRobustSerializerHash : RobustIntegrationTest
+{
+    /// <summary>
+    /// Test that the serializer hash on client and server matches.
+    /// </summary>
+    [Test]
+    public async Task Test()
+    {
+        var server = StartServer();
+        var client = StartClient();
+
+        var manifestServerStream = new MemoryStream();
+        var manifestClientStream = new MemoryStream();
+
+        await server.WaitPost(() =>
+        {
+            var serializer = (RobustSerializer) IoCManager.Resolve<IRobustSerializer>();
+            serializer.GetHashManifest(manifestServerStream, writeNewline: true);
+        });
+
+        await client.WaitPost(() =>
+        {
+            var serializer = (RobustSerializer) IoCManager.Resolve<IRobustSerializer>();
+            serializer.GetHashManifest(manifestClientStream, writeNewline: true);
+        });
+
+        var manifestServer = Encoding.UTF8.GetString(manifestServerStream.AsSpan());
+        var manifestClient = Encoding.UTF8.GetString(manifestClientStream.AsSpan());
+
+        Assert.That(manifestServer, NUnit.Framework.Is.EqualTo(manifestClient));
+    }
+}


### PR DESCRIPTION
Integration tests don't use Lidgren to connect client and send, instead they just use some in-process channels to communicate. Because of this, the original implementation of net messages *directly* passed the net message instances between client and server instances. This caused issues whenever content would mutate data in a NetMessage after it "passed through".

Now we run the messages through WriteToBuffer() and ReadFromBuffer() so they pass through binary serialization. This means there's no more implicit sharing of the objects.

Note that this requires some trickery: Lidgren's message types have internal constructors. Really ideally we'd change the engine to make this more testable... but that's a content breaking change. Instead I just added InternalsVisibleTo to Lidgren so we can mess with it. We maintain the library ourselves anyways I can do what I want.

Fixes #4836