### PR TITLE
Entitylookup approx / shape changes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,8 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* Update EntityLookup internally so non-approximate queries use the GJK solver and are much more accurate. This also means the approximate flag matters much more if you don't need narrowphase checks.
+* Add shape versions of queries for both EntityLookup and MapManager.
 
 ### New features
 
@@ -51,7 +52,7 @@ END TEMPLATE-->
 
 ### Internal
 
-*None yet*
+* Remove a lot of duplicate code internally from EntityLookup and MapManager.
 
 
 ## 206.0.0

--- a/Robust.Client/Physics/PhysicsSystem.Predict.cs
+++ b/Robust.Client/Physics/PhysicsSystem.Predict.cs
@@ -207,8 +207,8 @@ public sealed partial class PhysicsSystem
             var contact = contacts[i];
             var uidA = contact.EntityA;
             var uidB = contact.EntityB;
-            var bodyATransform = GetPhysicsTransform(uidA, xformQuery.GetComponent(uidA), xformQuery);
-            var bodyBTransform = GetPhysicsTransform(uidB, xformQuery.GetComponent(uidB), xformQuery);
+            var bodyATransform = GetPhysicsTransform(uidA, xformQuery.GetComponent(uidA));
+            var bodyBTransform = GetPhysicsTransform(uidB, xformQuery.GetComponent(uidB));
             contact.UpdateIsTouching(bodyATransform, bodyBTransform);
         }
 

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -133,7 +133,11 @@ public sealed partial class EntityLookupSystem
             {
                 state.Lookup.AddEntitiesIntersecting(uid, state.Intersecting, state.Shape, state.Transform, state.Flags);
                 return true;
-            }, approx: true);
+            }, approx: true, includeMap: false);
+
+        var mapUid = _mapManager.GetMapEntityId(mapId);
+        state.Lookup.AddEntitiesIntersecting(mapUid, intersecting, shape, shapeTransform, flags);
+        AddContained(intersecting, flags);
     }
 
     private void AddEntitiesIntersecting(
@@ -285,7 +289,13 @@ public sealed partial class EntityLookupSystem
                 }
 
                 return true;
-            }, true);
+            }, approx: true, includeMap: false);
+
+        if (!state.Found)
+        {
+            var mapUid = _mapManager.GetMapEntityId(mapId);
+            state.Found = AnyEntitiesIntersecting(mapUid, shape, shapeTransform, flags, ignored);
+        }
 
         return state.Found;
     }
@@ -507,7 +517,7 @@ public sealed partial class EntityLookupSystem
 
                 tuple.found = true;
                 return false;
-            }, approx: true);
+            }, approx: true, includeMap: false);
 
         if (state.found)
             return true;
@@ -551,13 +561,11 @@ public sealed partial class EntityLookupSystem
                 }
 
                 return true;
-            }, approx: true);
+            }, approx: true, includeMap: false);
 
         // Get map entities
         var mapUid = _mapManager.GetMapEntityId(mapId);
-        // Transform just in case future proofing?
-        var localAABB = _transform.GetInvWorldMatrix(mapUid).TransformBox(worldAABB);
-        AddLocalEntitiesIntersecting(mapUid, intersecting, localAABB, flags);
+        AddLocalEntitiesIntersecting(mapUid, intersecting, worldAABB, flags);
         AddContained(intersecting, flags);
     }
 
@@ -582,7 +590,7 @@ public sealed partial class EntityLookupSystem
                     return false;
                 }
                 return true;
-            }, approx: true);
+            }, approx: true, includeMap: false);
 
         if (state.found)
             return true;
@@ -611,7 +619,7 @@ public sealed partial class EntityLookupSystem
             var localAABB = tuple.lookup._transform.GetInvWorldMatrix(uid).TransformBox(tuple.worldBounds);
             tuple.lookup.AddLocalEntitiesIntersecting(uid, tuple.intersecting, localAABB, tuple.flags);
             return true;
-        }, approx: true);
+        }, approx: true, includeMap: false);
 
         // Get map entities
         var mapUid = _mapManager.GetMapEntityId(mapId);
@@ -663,7 +671,12 @@ public sealed partial class EntityLookupSystem
             }
 
             return true;
-        }, approx: true);
+        }, approx: true, includeMap: false);
+
+        if (state.found)
+        {
+            return true;
+        }
 
         var mapUid = _mapManager.GetMapEntityId(mapPos.MapId);
         return AnyLocalEntitiesIntersecting(mapUid, worldAABB, flags, uid);
@@ -731,7 +744,7 @@ public sealed partial class EntityLookupSystem
                 }
 
                 return true;
-            }, approx: true);
+            }, approx: true, includeMap: false);
 
         GetEntitiesIntersecting(mapId, worldAABB, intersecting, flags);
 
@@ -908,7 +921,10 @@ public sealed partial class EntityLookupSystem
             {
                 tuple.callback(uid, tuple._broadQuery.GetComponent(uid));
                 return true;
-            }, approx: true);
+            }, approx: true, includeMap: false);
+
+        var mapUid = _mapManager.GetMapEntityId(mapId);
+        callback(mapUid, _broadQuery.GetComponent(mapUid));
     }
 
     #endregion

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -538,11 +538,11 @@ public sealed partial class EntityLookupSystem
         if (mapId == MapId.Nullspace) return;
 
         // Get grid entities
-        var state = (this, _map, intersecting, worldAABB, _transform, flags);
+        var state = (this, intersecting, worldAABB, _transform, flags);
 
         _mapManager.FindGridsIntersecting(mapId, worldAABB, ref state,
-            static (EntityUid gridUid, MapGridComponent grid, ref (
-                EntityLookupSystem lookup, SharedMapSystem _map, HashSet<EntityUid> intersecting,
+            static (EntityUid gridUid, MapGridComponent _, ref (
+                EntityLookupSystem lookup, HashSet<EntityUid> intersecting,
                 Box2 worldAABB, SharedTransformSystem xformSystem, LookupFlags flags) tuple) =>
             {
                 var localAABB = tuple.xformSystem.GetInvWorldMatrix(gridUid).TransformBox(tuple.worldAABB);

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -716,7 +716,8 @@ public sealed partial class EntityLookupSystem
                 {
                     foreach (var fixture in fixturesComp.Fixtures.Values)
                     {
-                        if (!fixture.Hard && (tuple.flags & LookupFlags.Sensors) != 0x0)
+                        // If our own fixture isn't hard and sensors ignored then ignore it.
+                        if (!fixture.Hard && (tuple.flags & LookupFlags.Sensors) == 0x0)
                             continue;
 
                         tuple.lookup.AddEntitiesIntersecting(gridUid, tuple.intersecting, fixture.Shape, tuple.transform, tuple.flags);

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -716,6 +716,9 @@ public sealed partial class EntityLookupSystem
                 {
                     foreach (var fixture in fixturesComp.Fixtures.Values)
                     {
+                        if (!fixture.Hard && (tuple.flags & LookupFlags.Sensors) != 0x0)
+                            continue;
+
                         tuple.lookup.AddEntitiesIntersecting(gridUid, tuple.intersecting, fixture.Shape, tuple.transform, tuple.flags);
                     }
                 }

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -547,19 +547,6 @@ public sealed partial class EntityLookupSystem
             {
                 var localAABB = tuple.xformSystem.GetInvWorldMatrix(gridUid).TransformBox(tuple.worldAABB);
                 tuple.lookup.AddLocalEntitiesIntersecting(gridUid, tuple.intersecting, localAABB, tuple.flags);
-
-                if ((tuple.flags & LookupFlags.Static) != 0x0)
-                {
-                    // TODO: Need a struct enumerator version.
-                    foreach (var uid in tuple._map.GetAnchoredEntities(gridUid, grid, tuple.worldAABB))
-                    {
-                        if (tuple.lookup.Deleted(uid))
-                            continue;
-
-                        tuple.intersecting.Add(uid);
-                    }
-                }
-
                 return true;
             }, approx: true, includeMap: false);
 

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.ComponentQueries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.ComponentQueries.cs
@@ -486,7 +486,12 @@ public sealed partial class EntityLookupSystem
 
                     tuple.found = true;
                     return false;
-                }, approx: true);
+                }, approx: true, includeMap: false);
+
+            if (state.found)
+            {
+                return true;
+            }
 
             // Get map entities
             var mapUid = _mapManager.GetMapEntityId(mapId);
@@ -556,7 +561,10 @@ public sealed partial class EntityLookupSystem
                 {
                     state.Lookup.AddEntitiesIntersecting(uid, state.Intersecting, state.Shape, state.Transform, state.Flags, state.Query);
                     return true;
-                }, approx: true);
+                }, approx: true, includeMap: false);
+
+            var mapUid = _mapManager.GetMapEntityId(mapId);
+            AddEntitiesIntersecting(mapUid, intersecting, shape, shapeTransform, flags, query);
 
             AddContained(intersecting, flags, query);
         }
@@ -592,9 +600,12 @@ public sealed partial class EntityLookupSystem
                 {
                     state.Lookup.AddEntitiesIntersecting(uid, state.Intersecting, state.Shape, state.Transform, state.Flags, state.Query);
                     return true;
-                }, approx: true);
+                }, approx: true, includeMap: false);
 
             // Get map entities
+            var mapUid = _mapManager.GetMapEntityId(mapId);
+            AddEntitiesIntersecting(mapUid, entities, shape, shapeTransform, flags, query);
+
             AddContained(entities, flags, query);
         }
     }

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -98,6 +98,11 @@ public sealed partial class EntityLookupSystem : EntitySystem
     public const float TileEnlargementRadius = -PhysicsConstants.PolygonRadius * 4f;
 
     /// <summary>
+    /// The minimum size an entity is assumed to be for point purposes.
+    /// </summary>
+    public const float LookupEpsilon = float.Epsilon * 10f;
+
+    /// <summary>
     /// Returns all non-grid entities. Consider using your own flags if you wish for a faster query.
     /// </summary>
     public const LookupFlags DefaultFlags = LookupFlags.All;

--- a/Robust.Shared/Map/CoordinatesExtensions.cs
+++ b/Robust.Shared/Map/CoordinatesExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Numerics;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -42,7 +43,9 @@ namespace Robust.Shared.Map
             var gridSearchBox = Box2.UnitCentered.Scale(searchBoxSize).Translated(mapCoords.Position);
 
             // find grids in search box
-            var gridsInArea = mapManager.FindGridsIntersecting(mapCoords.MapId, gridSearchBox);
+            var gridsInArea = new List<Entity<MapGridComponent>>();
+
+            mapManager.FindGridsIntersecting(mapCoords.MapId, gridSearchBox, ref gridsInArea);
 
             // find closest grid intersecting our search box.
             gridUid = EntityUid.Invalid;
@@ -57,7 +60,7 @@ namespace Robust.Shared.Map
                 // TODO: Use CollisionManager to get nearest edge.
 
                 // figure out closest intersect
-                var gridIntersect = gridSearchBox.Intersect(gridXform.WorldMatrix.TransformBox(grid.LocalAABB));
+                var gridIntersect = gridSearchBox.Intersect(gridXform.WorldMatrix.TransformBox(grid.Comp.LocalAABB));
                 var gridDist = (gridIntersect.Center - mapCoords.Position).LengthSquared();
 
                 if (gridDist >= distance)

--- a/Robust.Shared/Map/IMapManager.cs
+++ b/Robust.Shared/Map/IMapManager.cs
@@ -107,7 +107,7 @@ namespace Robust.Shared.Map
 
         IEnumerable<Entity<MapGridComponent>> GetAllGrids(MapId mapId);
 
-        #region Queries
+        #region MapId
 
         public void FindGridsIntersecting(MapId mapId, IPhysShape shape, Transform transform,
             ref List<Entity<MapGridComponent>> grids, bool approx = Approximate, bool includeMap = IncludeMap);
@@ -196,6 +196,40 @@ namespace Robust.Shared.Map
         /// </summary>
         public bool TryFindGridAt(MapCoordinates mapCoordinates, out EntityUid uid,
             [NotNullWhen(true)] out MapGridComponent? grid);
+
+        #endregion
+
+        #region Obsolete
+
+        [Obsolete]
+        public bool TryFindGridAt(MapId mapId, Vector2 worldPos, EntityQuery<TransformComponent> query, out EntityUid uid, [NotNullWhen(true)] out MapGridComponent? grid)
+        {
+            return TryFindGridAt(mapId, worldPos, out uid, out grid);
+        }
+
+        [Obsolete]
+        public IEnumerable<MapGridComponent> FindGridsIntersecting(MapId mapId, Box2 worldAabb, bool approx = false, bool includeMap = true)
+        {
+            var grids = new List<Entity<MapGridComponent>>();
+            FindGridsIntersecting(mapId, worldAabb, ref grids, approx, includeMap);
+
+            foreach (var grid in grids)
+            {
+                yield return grid.Comp;
+            }
+        }
+
+        [Obsolete]
+        public IEnumerable<MapGridComponent> FindGridsIntersecting(MapId mapId, Box2Rotated worldArea, bool approx = false, bool includeMap = true)
+        {
+            var grids = new List<Entity<MapGridComponent>>();
+            FindGridsIntersecting(mapId, worldArea, ref grids, approx, includeMap);
+
+            foreach (var grid in grids)
+            {
+                yield return grid.Comp;
+            }
+        }
 
         #endregion
 

--- a/Robust.Shared/Map/IMapManager.cs
+++ b/Robust.Shared/Map/IMapManager.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Collision.Shapes;
 
 namespace Robust.Shared.Map
 {
@@ -18,6 +20,9 @@ namespace Robust.Shared.Map
     /// </summary>
     public interface IMapManager
     {
+        public const bool Approximate = false;
+        public const bool IncludeMap = true;
+
         [Obsolete("Use EntityQuery<MapGridComponent>")]
         IEnumerable<MapGridComponent> GetAllGrids();
 
@@ -102,82 +107,97 @@ namespace Robust.Shared.Map
 
         IEnumerable<Entity<MapGridComponent>> GetAllGrids(MapId mapId);
 
+        #region Queries
+
+        public void FindGridsIntersecting(MapId mapId, IPhysShape shape, Transform transform,
+            ref List<Entity<MapGridComponent>> grids, bool approx = Approximate, bool includeMap = IncludeMap);
+
+        public void FindGridsIntersecting(MapId mapId, PolygonShape shape, Transform transform, GridCallback callback,
+            bool approx = Approximate, bool includeMap = IncludeMap);
+
+        public void FindGridsIntersecting(MapId mapId, Box2 worldAABB, GridCallback callback, bool approx = Approximate,
+            bool includeMap = IncludeMap);
+
+        public void FindGridsIntersecting<TState>(MapId mapId, Box2 worldAABB, ref TState state,
+            GridCallback<TState> callback, bool approx = Approximate, bool includeMap = IncludeMap);
+
+        public void FindGridsIntersecting(MapId mapId, Box2 worldAABB, ref List<Entity<MapGridComponent>> grids,
+            bool approx = Approximate, bool includeMap = IncludeMap);
+
+        public void FindGridsIntersecting(MapId mapId, Box2Rotated worldBounds, GridCallback callback,
+            bool approx = Approximate,
+            bool includeMap = IncludeMap);
+
+        public void FindGridsIntersecting<TState>(MapId mapId, Box2Rotated worldBounds, ref TState state,
+            GridCallback<TState> callback,
+            bool approx = Approximate, bool includeMap = IncludeMap);
+
+        public void FindGridsIntersecting(MapId mapId, Box2Rotated worldBounds, ref List<Entity<MapGridComponent>> grids,
+            bool approx = Approximate, bool includeMap = IncludeMap);
+
+        #endregion
+
+        #region MapEnt
+
+        public void FindGridsIntersecting(EntityUid mapEnt, PolygonShape shape, Transform transform, GridCallback callback,
+            bool approx = Approximate, bool includeMap = IncludeMap);
+
+        public void FindGridsIntersecting<TState>(EntityUid mapEnt, IPhysShape shape, Transform transform,
+            ref TState state, GridCallback<TState> callback, bool approx = Approximate, bool includeMap = IncludeMap);
+
+        /// <summary>
+        /// Returns true if any grids overlap the specified shapes.
+        /// </summary>
+        public void FindGridsIntersecting(EntityUid mapEnt, List<IPhysShape> shapes, Transform transform,
+            ref List<Entity<MapGridComponent>> entities, bool approx = Approximate, bool includeMap = IncludeMap);
+
+        public void FindGridsIntersecting(EntityUid mapEnt, IPhysShape shape, Transform transform,
+            ref List<Entity<MapGridComponent>> grids, bool approx = Approximate, bool includeMap = IncludeMap);
+
+        public void FindGridsIntersecting(EntityUid mapEnt, Box2 worldAABB, GridCallback callback,
+            bool approx = Approximate, bool includeMap = IncludeMap);
+
+        public void FindGridsIntersecting<TState>(EntityUid mapEnt, Box2 worldAABB, ref TState state,
+            GridCallback<TState> callback, bool approx = Approximate, bool includeMap = IncludeMap);
+
+        public void FindGridsIntersecting(EntityUid mapEnt, Box2 worldAABB, ref List<Entity<MapGridComponent>> grids,
+            bool approx = Approximate, bool includeMap = IncludeMap);
+
+        public void FindGridsIntersecting(EntityUid mapEnt, Box2Rotated worldBounds, GridCallback callback,
+            bool approx = Approximate,
+            bool includeMap = IncludeMap);
+
+        public void FindGridsIntersecting<TState>(EntityUid mapEnt, Box2Rotated worldBounds, ref TState state,
+            GridCallback<TState> callback,
+            bool approx = Approximate, bool includeMap = IncludeMap);
+
+        public void FindGridsIntersecting(EntityUid mapEnt, Box2Rotated worldBounds,
+            ref List<Entity<MapGridComponent>> grids,
+            bool approx = Approximate, bool includeMap = IncludeMap);
+
+        #endregion
+
+        #region TryFindGridAt
+
+        public bool TryFindGridAt(
+            EntityUid mapEnt,
+            Vector2 worldPos,
+            out EntityUid uid,
+            [NotNullWhen(true)] out MapGridComponent? grid);
+
         /// <summary>
         /// Attempts to find the map grid under the map location.
         /// </summary>
-        /// <remarks>
-        /// This method will never return the map's default grid.
-        /// </remarks>
-        /// <param name="mapId">Map to search.</param>
-        /// <param name="worldPos">Location on the map to check for a grid.</param>
-        /// <param name="grid">Grid that was found, if any.</param>
-        /// <returns>Returns true when a grid was found under the location.</returns>
-        bool TryFindGridAt(MapId mapId, Vector2 worldPos, out EntityUid uid, [NotNullWhen(true)] out MapGridComponent? grid);
+        public bool TryFindGridAt(MapId mapId, Vector2 worldPos, out EntityUid uid,
+            [NotNullWhen(true)] out MapGridComponent? grid);
 
         /// <summary>
         /// Attempts to find the map grid under the map location.
         /// </summary>
-        /// <remarks>
-        /// This method will never return the map's default grid.
-        /// </remarks>
-        /// <param name="mapId">Map to search.</param>
-        /// <param name="worldPos">Location on the map to check for a grid.</param>
-        /// <param name="grid">Grid that was found, if any.</param>
-        /// <returns>Returns true when a grid was found under the location.</returns>
-        bool TryFindGridAt(EntityUid mapId, Vector2 worldPos, out EntityUid uid, [NotNullWhen(true)] out MapGridComponent? grid);
+        public bool TryFindGridAt(MapCoordinates mapCoordinates, out EntityUid uid,
+            [NotNullWhen(true)] out MapGridComponent? grid);
 
-        /// <summary>
-        /// Attempts to find the map grid under the map location.
-        /// </summary>
-        /// <remarks>
-        /// This method will never return the map's default grid.
-        /// </remarks>
-        /// <param name="mapId">Map to search.</param>
-        /// <param name="worldPos">Location on the map to check for a grid.</param>
-        /// <param name="grid">Grid that was found, if any.</param>
-        /// <returns>Returns true when a grid was found under the location.</returns>
-        bool TryFindGridAt(MapId mapId, Vector2 worldPos, EntityQuery<TransformComponent> query, out EntityUid uid, [NotNullWhen(true)] out MapGridComponent? grid);
-
-        /// <summary>
-        /// Attempts to find the map grid under the map location.
-        /// </summary>
-        /// <remarks>
-        /// This method will never return the map's default grid.
-        /// </remarks>
-        /// <param name="mapCoordinates">Location on the map to check for a grid.</param>
-        /// <param name="grid">Grid that was found, if any.</param>
-        /// <returns>Returns true when a grid was found under the location.</returns>
-        bool TryFindGridAt(MapCoordinates mapCoordinates, out EntityUid uid, [NotNullWhen(true)] out MapGridComponent? grid);
-
-        void FindGridsIntersecting(MapId mapId, Box2 worldAABB, GridCallback callback, bool approx = false, bool includeMap = true);
-
-        void FindGridsIntersecting<TState>(MapId mapId, Box2 worldAABB, ref TState state, GridCallback<TState> callback, bool approx = false, bool includeMap = true);
-
-        void FindGridsIntersecting(MapId mapId, Box2 worldAABB, ref List<Entity<MapGridComponent>> state, bool approx = false, bool includeMap = true);
-        void FindGridsIntersecting(EntityUid map, Box2 worldAABB, ref List<Entity<MapGridComponent>> state, bool approx = false, bool includeMap = true);
-
-        void FindGridsIntersecting(MapId mapId, Box2Rotated worldBounds, GridCallback callback, bool approx = false, bool includeMap = true);
-
-        void FindGridsIntersecting<TState>(MapId mapId, Box2Rotated worldBounds, ref TState state, GridCallback<TState> callback, bool approx = false, bool includeMap = true);
-
-        void FindGridsIntersecting(MapId mapId, Box2Rotated worldBounds, ref List<Entity<MapGridComponent>> state, bool approx = false, bool includeMap = true);
-
-        /// <summary>
-        /// Returns the grids intersecting this AABB.
-        /// </summary>
-        /// <param name="mapId">The relevant MapID</param>
-        /// <param name="worldAabb">The AABB to intersect</param>
-        /// <param name="approx">Set to false if you wish to accurately get the grid bounds per-tile.</param>
-        /// <returns></returns>
-        IEnumerable<MapGridComponent> FindGridsIntersecting(MapId mapId, Box2 worldAabb, bool approx = false, bool includeMap = true);
-
-        /// <summary>
-        /// Returns the grids intersecting this AABB.
-        /// </summary>
-        /// <param name="mapId">The relevant MapID</param>
-        /// <param name="worldArea">The AABB to intersect</param>
-        /// <param name="approx">Set to false if you wish to accurately get the grid bounds per-tile.</param>
-        IEnumerable<MapGridComponent> FindGridsIntersecting(MapId mapId, Box2Rotated worldArea, bool approx = false, bool includeMap = true);
+        #endregion
 
         void DeleteGrid(EntityUid euid);
 

--- a/Robust.Shared/Map/MapManager.Queries.cs
+++ b/Robust.Shared/Map/MapManager.Queries.cs
@@ -336,9 +336,9 @@ internal partial class MapManager
             tuple.uid = iUid;
             tuple.grid = iGrid;
             return false;
-        }, approx: true);
+        }, approx: true, includeMap: false);
 
-        if (state.grid == null && EntityManager.TryGetComponent<MapGridComponent>(mapEnt, out var mapGrid))
+        if (state.grid == null && _gridQuery.TryGetComponent(mapEnt, out var mapGrid))
         {
             uid = mapEnt;
             grid = mapGrid;

--- a/Robust.Shared/Map/MapManager.Queries.cs
+++ b/Robust.Shared/Map/MapManager.Queries.cs
@@ -202,10 +202,10 @@ internal partial class MapManager
             }
 
             var callbackState = state.State;
-            state.Callback(data.Uid, data.Grid, ref callbackState);
+            var result = state.Callback(data.Uid, data.Grid, ref callbackState);
             state.State = callbackState;
 
-            return true;
+            return result;
         }, worldAABB);
 
         // By-ref things

--- a/Robust.Shared/Map/MapManager.Queries.cs
+++ b/Robust.Shared/Map/MapManager.Queries.cs
@@ -4,228 +4,285 @@ using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Map.Enumerators;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
+using Robust.Shared.Physics.Collision;
+using Robust.Shared.Physics.Collision.Shapes;
+using Robust.Shared.Physics.Systems;
 
 namespace Robust.Shared.Map;
 
 internal partial class MapManager
 {
-    [Obsolete("Use the FindGridsIntersecting callback")]
-    public IEnumerable<MapGridComponent> FindGridsIntersecting(MapId mapId, Box2Rotated bounds, bool approx = false, bool includeMap = true)
-    {
-        var aabb = bounds.CalcBoundingBox();
-        // TODO: We can do slower GJK checks to check if 2 bounds actually intersect, but WYCI.
-        return FindGridsIntersecting(mapId, aabb, includeMap, approx);
-    }
-
-    public void FindGridsIntersecting(MapId mapId, Box2 worldAABB, GridCallback callback, bool approx = false, bool includeMap = true)
-    {
-        if (_mapEntities.TryGetValue(mapId, out var map))
-            FindGridsIntersecting(map, worldAABB, callback, approx, includeMap);
-    }
-
-    public void FindGridsIntersecting(EntityUid mapEnt, Box2 worldAABB, GridCallback callback, bool approx = false, bool includeMap = true)
-    {
-        if (!EntityManager.TryGetComponent<GridTreeComponent>(mapEnt, out var gridTree))
-            return;
-
-        var state = (worldAABB, gridTree.Tree, callback, approx, this, _transformSystem);
-
-        gridTree.Tree.Query(ref state,
-            static (ref (Box2 worldAABB,
-                    B2DynamicTree<(EntityUid Uid, MapGridComponent Grid)> gridTree,
-                    GridCallback callback,
-                    bool approx,
-                    MapManager mapManager,
-                    SharedTransformSystem xformSystem) tuple,
-                DynamicTree.Proxy proxy) =>
-            {
-                var data = tuple.gridTree.GetUserData(proxy);
-
-                if (!tuple.approx && !tuple.mapManager.IsIntersecting(tuple.worldAABB, data.Uid, data.Grid))
-                {
-                    return true;
-                }
-
-                return tuple.callback(data.Uid, data.Grid);
-            }, worldAABB); ;
-
-        if (includeMap && EntityManager.TryGetComponent<MapGridComponent>(mapEnt, out var grid))
-        {
-            callback(mapEnt, grid);
-        }
-    }
-
-    public void FindGridsIntersecting<TState>(MapId mapId, Box2 worldAABB, ref TState state, GridCallback<TState> callback, bool approx = false, bool includeMap = true)
-    {
-        if (_mapEntities.TryGetValue(mapId, out var map))
-            FindGridsIntersecting(map, worldAABB, ref state, callback, approx, includeMap);
-    }
-
-    public void FindGridsIntersecting<TState>(EntityUid mapUid, Box2 worldAABB, ref TState state, GridCallback<TState> callback, bool approx = false, bool includeMap = true)
-    {
-        if (!EntityManager.TryGetComponent<GridTreeComponent>(mapUid, out var gridTree))
-            return;
-
-        if (includeMap && EntityManager.TryGetComponent<MapGridComponent>(mapUid, out var grid))
-        {
-            callback(mapUid, grid, ref state);
-        }
-
-        var state2 = (state, worldAABB, gridTree.Tree, callback, approx, this, _transformSystem);
-
-        gridTree.Tree.Query(ref state2, static (ref (
-                TState state,
-                Box2 worldAABB,
-                B2DynamicTree<(EntityUid Uid, MapGridComponent Grid)> gridTree,
-                GridCallback<TState> callback,
-                bool approx,
-                MapManager mapManager,
-                SharedTransformSystem xformSystem) tuple,
-            DynamicTree.Proxy proxy) =>
-        {
-            var data = tuple.gridTree.GetUserData(proxy);
-
-            if (!tuple.approx && !tuple.mapManager.IsIntersecting(tuple.worldAABB, data.Uid, data.Grid))
-            {
-                return true;
-            }
-
-            return tuple.callback(data.Uid, data.Grid, ref tuple.state);
-        }, worldAABB);
-
-        state = state2.state;
-    }
-
-    public void FindGridsIntersecting(MapId mapId, Box2 worldAABB, ref List<Entity<MapGridComponent>> state,
-        bool approx = false, bool includeMap = true)
-    {
-        if (_mapEntities.TryGetValue(mapId, out var map))
-            FindGridsIntersecting(map, worldAABB, ref state, approx, includeMap);
-    }
-
-    public void FindGridsIntersecting(EntityUid map, Box2 worldAABB, ref List<Entity<MapGridComponent>> state,
-        bool approx = false, bool includeMap = true)
-    {
-        FindGridsIntersecting(map, worldAABB, ref state, static (EntityUid uid, MapGridComponent grid,
-            ref List<Entity<MapGridComponent>> list) =>
-        {
-            list.Add((uid, grid));
-            return true;
-        }, approx, includeMap);
-    }
-
-    public void FindGridsIntersecting(EntityUid mapId, Box2Rotated worldBounds, GridCallback callback, bool approx = false,
-        bool includeMap = true)
-    {
-        FindGridsIntersecting(mapId, worldBounds.CalcBoundingBox(), callback, approx, includeMap);
-    }
-
-    public void FindGridsIntersecting(MapId mapId, Box2Rotated worldBounds, GridCallback callback, bool approx = false,
-        bool includeMap = true)
-    {
-        FindGridsIntersecting(mapId, worldBounds.CalcBoundingBox(), callback, approx, includeMap);
-    }
-
-    public void FindGridsIntersecting<TState>(EntityUid mapId, Box2Rotated worldBounds, ref TState state, GridCallback<TState> callback,
-        bool approx = false, bool includeMap = true)
-    {
-        FindGridsIntersecting(mapId, worldBounds.CalcBoundingBox(), ref state, callback, approx, includeMap);
-    }
-
-    public void FindGridsIntersecting<TState>(MapId mapId, Box2Rotated worldBounds, ref TState state, GridCallback<TState> callback,
-        bool approx = false, bool includeMap = true)
-    {
-        FindGridsIntersecting(mapId, worldBounds.CalcBoundingBox(), ref state, callback, approx, includeMap);
-    }
-
-    public void FindGridsIntersecting(MapId mapId, Box2Rotated worldBounds, ref List<Entity<MapGridComponent>> state,
-        bool approx = false, bool includeMap = true)
-    {
-        if (_mapEntities.TryGetValue(mapId, out var map))
-            FindGridsIntersecting(map, worldBounds, ref state, approx, includeMap);
-    }
-
-    public void FindGridsIntersecting(EntityUid mapId, Box2Rotated worldBounds, ref List<Entity<MapGridComponent>> state,
-        bool approx = false, bool includeMap = true)
-    {
-        FindGridsIntersecting(mapId, worldBounds, ref state, static (EntityUid uid, MapGridComponent grid,
-            ref List<Entity<MapGridComponent>> list) =>
-        {
-            list.Add((uid, grid));
-            return true;
-        }, approx, includeMap);
-    }
-
     private bool IsIntersecting(
-        Box2 aabb,
-        EntityUid gridUid,
-        MapGridComponent grid)
+        ChunkEnumerator enumerator,
+        IPhysShape shape,
+        Transform shapeTransform,
+        EntityUid gridUid)
     {
-        var (worldPos, worldRot, matrix, invMatrix) = _transformSystem.GetWorldPositionRotationMatrixWithInv(gridUid);
-        var overlap = matrix.TransformBox(grid.LocalAABB).Intersect(aabb);
-        var localAABB = invMatrix.TransformBox(overlap);
+        var gridTransform = _physics.GetPhysicsTransform(gridUid);
 
-        if (_physicsQuery.HasComponent(gridUid))
+        while (enumerator.MoveNext(out var chunk))
         {
-            var enumerator = _mapSystem.GetLocalMapChunks(gridUid, grid, localAABB);
-
-            var transform = new Transform(worldPos, worldRot);
-
-            while (enumerator.MoveNext(out var chunk))
+            foreach (var fixture in chunk.Fixtures.Values)
             {
-                foreach (var fixture in chunk.Fixtures.Values)
+                for (var j = 0; j < fixture.Shape.ChildCount; j++)
                 {
-                    for (var j = 0; j < fixture.Shape.ChildCount; j++)
+                    if (_manifolds.TestOverlap(shape, 0, fixture.Shape, j, shapeTransform, gridTransform))
                     {
-                        // TODO: Should do shape intersects given this is supposed to be non-approx.
-                        if (!fixture.Shape.ComputeAABB(transform, j).Intersects(aabb)) continue;
-
                         return true;
                     }
                 }
             }
         }
 
-        return grid.ChunkCount == 0 && aabb.Contains(worldPos);
-    }
-
-    [Obsolete("Use the FindGridsIntersecting callback")]
-    public IEnumerable<MapGridComponent> FindGridsIntersecting(MapId mapId, Box2 worldAabb, bool approx = false, bool includeMap = true)
-    {
-        var grids = new List<MapGridComponent>();
-        var state = grids;
-
-        FindGridsIntersecting(mapId, worldAabb, ref state,
-            (EntityUid _, MapGridComponent grid, ref List<MapGridComponent> list) =>
-            {
-                list.Add(grid);
-                return true;
-            }, approx);
-
-        return grids;
-    }
-
-    public bool TryFindGridAt(
-        MapId mapId,
-        Vector2 worldPos,
-        EntityQuery<TransformComponent> xformQuery,
-        out EntityUid uid,
-        [NotNullWhen(true)] out MapGridComponent? grid)
-    {
-        if (_mapEntities.TryGetValue(mapId, out var map))
-            return TryFindGridAt(map, worldPos, xformQuery, out uid, out grid);
-
-        uid = default;
-        grid = null;
         return false;
     }
 
+    #region MapId
+
+    public void FindGridsIntersecting(MapId mapId, IPhysShape shape, Transform transform,
+        ref List<Entity<MapGridComponent>> grids, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    {
+        if (_mapEntities.TryGetValue(mapId, out var mapEnt))
+            FindGridsIntersecting(mapEnt, shape, transform, ref grids, approx, includeMap);
+    }
+
+    public void FindGridsIntersecting(MapId mapId, PolygonShape shape, Transform transform, GridCallback callback, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    {
+        if (_mapEntities.TryGetValue(mapId, out var mapEnt))
+            FindGridsIntersecting(mapEnt, shape, transform, callback, includeMap, approx);
+    }
+
+    public void FindGridsIntersecting(MapId mapId, Box2 worldAABB, GridCallback callback, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    {
+        if (_mapEntities.TryGetValue(mapId, out var mapEnt))
+            FindGridsIntersecting(mapEnt, worldAABB, callback, approx, includeMap);
+    }
+
+    public void FindGridsIntersecting<TState>(MapId mapId, Box2 worldAABB, ref TState state, GridCallback<TState> callback, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    {
+        if (_mapEntities.TryGetValue(mapId, out var map))
+            FindGridsIntersecting(map, worldAABB, ref state, callback, approx, includeMap);
+    }
+
+    public void FindGridsIntersecting(MapId mapId, Box2 worldAABB, ref List<Entity<MapGridComponent>> grids,
+        bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    {
+        if (_mapEntities.TryGetValue(mapId, out var map))
+            FindGridsIntersecting(map, worldAABB, ref grids, approx, includeMap);
+    }
+
+    public void FindGridsIntersecting(MapId mapId, Box2Rotated worldBounds, GridCallback callback, bool approx = IMapManager.Approximate,
+        bool includeMap = IMapManager.IncludeMap)
+    {
+        if (_mapEntities.TryGetValue(mapId, out var mapEnt))
+            FindGridsIntersecting(mapEnt, worldBounds, callback, approx, includeMap);
+    }
+
+    public void FindGridsIntersecting<TState>(MapId mapId, Box2Rotated worldBounds, ref TState state, GridCallback<TState> callback,
+        bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    {
+        if (_mapEntities.TryGetValue(mapId, out var mapEnt))
+            FindGridsIntersecting(mapEnt, worldBounds, ref state, callback, approx, includeMap);
+    }
+
+    public void FindGridsIntersecting(MapId mapId, Box2Rotated worldBounds, ref List<Entity<MapGridComponent>> grids,
+        bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    {
+        if (_mapEntities.TryGetValue(mapId, out var mapEnt))
+            FindGridsIntersecting(mapEnt, worldBounds, ref grids, approx, includeMap);
+    }
+
+    #endregion
+
+    #region MapEnt
+
+    public void FindGridsIntersecting(EntityUid mapEnt, PolygonShape shape, Transform transform, GridCallback callback, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    {
+        if (!_gridTreeQuery.TryGetComponent(mapEnt, out var gridTree))
+            return;
+
+        if (includeMap && _gridQuery.TryGetComponent(mapEnt, out var mapGrid))
+        {
+            callback(mapEnt, mapGrid);
+        }
+
+        var worldAABB = shape.ComputeAABB(transform, 0);
+
+        var gridState = new GridQueryState(
+            callback,
+            worldAABB,
+            shape,
+            transform,
+            gridTree.Tree,
+            _mapSystem,
+            this,
+            _fixtureSystem,
+            _physics,
+            _manifolds,
+            _fixturesQuery,
+            approx);
+
+
+        gridTree.Tree.Query(ref gridState, static (ref GridQueryState state, DynamicTree.Proxy proxy) =>
+        {
+            // Even for approximate we'll check if any chunks roughly overlap.
+            var data = state.Tree.GetUserData(proxy);
+            var localAABB = new Box2();
+            var overlappingChunks = state.MapSystem.GetLocalMapChunks(data.Uid, data.Grid, localAABB);
+
+            if (state.Approximate)
+            {
+                if (!overlappingChunks.MoveNext(out _))
+                    return true;
+            }
+            else if (!state.MapManager.IsIntersecting(overlappingChunks, state.Shape, state.Transform, data.Uid))
+            {
+                return true;
+            }
+
+            state.Callback(data.Uid, data.Grid);
+
+            return true;
+        }, worldAABB);
+    }
+
+    public void FindGridsIntersecting<TState>(EntityUid mapEnt, IPhysShape shape, Transform transform,
+        ref TState state, GridCallback<TState> callback, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    {
+        if (!_gridTreeQuery.TryGetComponent(mapEnt, out var gridTree))
+            return;
+
+        if (includeMap && _gridQuery.TryGetComponent(mapEnt, out var mapGrid))
+        {
+            callback(mapEnt, mapGrid, ref state);
+        }
+
+        var worldAABB = shape.ComputeAABB(transform, 0);
+
+        var gridState = new GridQueryState<TState>(
+            callback,
+            state,
+            worldAABB,
+            shape,
+            transform,
+            gridTree.Tree,
+            _mapSystem,
+            this,
+            _fixtureSystem,
+            _physics,
+            _manifolds,
+            _fixturesQuery,
+            approx);
+
+
+        gridTree.Tree.Query(ref gridState, static (ref GridQueryState<TState> state, DynamicTree.Proxy proxy) =>
+        {
+            // Even for approximate we'll check if any chunks roughly overlap.
+            var data = state.Tree.GetUserData(proxy);
+            var localAABB = new Box2();
+            var overlappingChunks = state.MapSystem.GetLocalMapChunks(data.Uid, data.Grid, localAABB);
+
+            if (state.Approximate)
+            {
+                if (!overlappingChunks.MoveNext(out _))
+                    return true;
+            }
+            else if (!state.MapManager.IsIntersecting(overlappingChunks, state.Shape, state.Transform, data.Uid))
+            {
+                return true;
+            }
+
+            var callbackState = state.State;
+            state.Callback(data.Uid, data.Grid, ref callbackState);
+            state.State = callbackState;
+
+            return true;
+        }, worldAABB);
+    }
+
+    /// <summary>
+    /// Returns true if any grids overlap the specified shapes.
+    /// </summary>
+    public void FindGridsIntersecting(EntityUid mapEnt, List<IPhysShape> shapes, Transform transform, ref List<Entity<MapGridComponent>> entities, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    {
+        foreach (var shape in shapes)
+        {
+            FindGridsIntersecting(mapEnt, shape, transform, ref entities);
+        }
+    }
+
+    public void FindGridsIntersecting(EntityUid mapEnt, IPhysShape shape, Transform transform,
+        ref List<Entity<MapGridComponent>> grids, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    {
+        var state = grids;
+
+        FindGridsIntersecting(mapEnt, shape, transform, ref state,
+            static (EntityUid uid, MapGridComponent grid, ref List<Entity<MapGridComponent>> list) =>
+            {
+                list.Add((uid, grid));
+                return true;
+            }, approx, includeMap);
+    }
+
+    public void FindGridsIntersecting(EntityUid mapEnt, Box2 worldAABB, GridCallback callback, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    {
+        var shape = new PolygonShape();
+        shape.SetAsBox(worldAABB);
+        FindGridsIntersecting(mapEnt, shape, Transform.Empty, callback, approx, includeMap);
+    }
+
+    public void FindGridsIntersecting<TState>(EntityUid mapEnt, Box2 worldAABB, ref TState state, GridCallback<TState> callback, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    {
+        var shape = new PolygonShape();
+        shape.SetAsBox(worldAABB);
+        FindGridsIntersecting(mapEnt, shape, Transform.Empty, ref state, callback, approx, includeMap);
+    }
+
+    public void FindGridsIntersecting(EntityUid mapEnt, Box2 worldAABB, ref List<Entity<MapGridComponent>> grids,
+        bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    {
+        var shape = new PolygonShape();
+        shape.SetAsBox(worldAABB);
+        FindGridsIntersecting(mapEnt, shape, Transform.Empty, ref grids, approx, includeMap);
+    }
+
+    public void FindGridsIntersecting(EntityUid mapEnt, Box2Rotated worldBounds, GridCallback callback, bool approx = IMapManager.Approximate,
+        bool includeMap = IMapManager.IncludeMap)
+    {
+        var shape = new PolygonShape();
+        shape.Set(worldBounds);
+
+        FindGridsIntersecting(mapEnt, shape, Transform.Empty, callback, approx, includeMap);
+    }
+
+    public void FindGridsIntersecting<TState>(EntityUid mapEnt, Box2Rotated worldBounds, ref TState state, GridCallback<TState> callback,
+        bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    {
+        var shape = new PolygonShape();
+        shape.Set(worldBounds);
+
+        FindGridsIntersecting(mapEnt, shape, Transform.Empty, ref state, callback, approx, includeMap);
+    }
+
+    public void FindGridsIntersecting(EntityUid mapEnt, Box2Rotated worldBounds, ref List<Entity<MapGridComponent>> grids,
+        bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    {
+        var shape = new PolygonShape();
+        shape.Set(worldBounds);
+
+        FindGridsIntersecting(mapEnt, shape, Transform.Empty, ref grids, approx, includeMap);
+    }
+
+    #endregion
+
+    #region TryFindGridAt
+
     public bool TryFindGridAt(
-        EntityUid mapId,
+        EntityUid mapEnt,
         Vector2 worldPos,
-        EntityQuery<TransformComponent> xformQuery,
         out EntityUid uid,
         [NotNullWhen(true)] out MapGridComponent? grid)
     {
@@ -238,7 +295,7 @@ internal partial class MapManager
         grid = null;
         var state = (uid, grid, worldPos, _mapSystem, _transformSystem);
 
-        FindGridsIntersecting(mapId, aabb, ref state, static (EntityUid iUid, MapGridComponent iGrid, ref (
+        FindGridsIntersecting(mapEnt, aabb, ref state, static (EntityUid iUid, MapGridComponent iGrid, ref (
             EntityUid uid,
             MapGridComponent? grid,
             Vector2 worldPos,
@@ -272,9 +329,9 @@ internal partial class MapManager
             return false;
         }, approx: true);
 
-        if (state.grid == null && EntityManager.TryGetComponent<MapGridComponent>(mapId, out var mapGrid))
+        if (state.grid == null && EntityManager.TryGetComponent<MapGridComponent>(mapEnt, out var mapGrid))
         {
-            uid = mapId;
+            uid = mapEnt;
             grid = mapGrid;
             return true;
         }
@@ -287,18 +344,10 @@ internal partial class MapManager
     /// <summary>
     /// Attempts to find the map grid under the map location.
     /// </summary>
-    public bool TryFindGridAt(EntityUid mapId, Vector2 worldPos, out EntityUid uid, [NotNullWhen(true)] out MapGridComponent? grid)
-    {
-        return TryFindGridAt(mapId, worldPos, _xformQuery, out uid, out grid);
-    }
-
-    /// <summary>
-    /// Attempts to find the map grid under the map location.
-    /// </summary>
     public bool TryFindGridAt(MapId mapId, Vector2 worldPos, out EntityUid uid, [NotNullWhen(true)] out MapGridComponent? grid)
     {
         if (_mapEntities.TryGetValue(mapId, out var map))
-            return TryFindGridAt(map, worldPos, _xformQuery, out uid, out grid);
+            return TryFindGridAt(map, worldPos, out uid, out grid);
 
         uid = default;
         grid = null;
@@ -312,4 +361,69 @@ internal partial class MapManager
     {
         return TryFindGridAt(mapCoordinates.MapId, mapCoordinates.Position, out uid, out grid);
     }
+
+    #endregion
+
+    #region Obsolete
+
+    [Obsolete]
+    public bool TryFindGridAt(MapId mapId, Vector2 worldPos, EntityQuery<TransformComponent> query, out EntityUid uid, [NotNullWhen(true)] out MapGridComponent? grid)
+    {
+        return TryFindGridAt(mapId, worldPos, out uid, out grid);
+    }
+
+    [Obsolete]
+    public IEnumerable<MapGridComponent> FindGridsIntersecting(MapId mapId, Box2 worldAabb, bool approx = false, bool includeMap = true)
+    {
+        var grids = new List<Entity<MapGridComponent>>();
+        FindGridsIntersecting(mapId, worldAabb, ref grids, approx, includeMap);
+
+        foreach (var grid in grids)
+        {
+            yield return grid.Comp;
+        }
+    }
+
+    [Obsolete]
+    public IEnumerable<MapGridComponent> FindGridsIntersecting(MapId mapId, Box2Rotated worldArea, bool approx = false, bool includeMap = true)
+    {
+        var grids = new List<Entity<MapGridComponent>>();
+        FindGridsIntersecting(mapId, worldArea, ref grids, approx, includeMap);
+
+        foreach (var grid in grids)
+        {
+            yield return grid.Comp;
+        }
+    }
+
+    #endregion
+
+    private readonly record struct GridQueryState(
+        GridCallback Callback,
+        Box2 WorldAABB,
+        IPhysShape Shape,
+        Transform Transform,
+        B2DynamicTree<(EntityUid Uid, MapGridComponent Grid)> Tree,
+        SharedMapSystem MapSystem,
+        MapManager MapManager,
+        FixtureSystem Fixtures,
+        SharedPhysicsSystem Physics,
+        IManifoldManager Manifolds,
+        EntityQuery<FixturesComponent> FixturesQuery,
+        bool Approximate);
+
+    private record struct GridQueryState<TState>(
+        GridCallback<TState> Callback,
+        TState State,
+        Box2 WorldAABB,
+        IPhysShape Shape,
+        Transform Transform,
+        B2DynamicTree<(EntityUid Uid, MapGridComponent Grid)> Tree,
+        SharedMapSystem MapSystem,
+        MapManager MapManager,
+        FixtureSystem Fixtures,
+        SharedPhysicsSystem Physics,
+        IManifoldManager Manifolds,
+        EntityQuery<FixturesComponent> FixturesQuery,
+        bool Approximate);
 }

--- a/Robust.Shared/Map/MapManager.Queries.cs
+++ b/Robust.Shared/Map/MapManager.Queries.cs
@@ -7,9 +7,7 @@ using Robust.Shared.Map.Components;
 using Robust.Shared.Map.Enumerators;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
-using Robust.Shared.Physics.Collision;
 using Robust.Shared.Physics.Collision.Shapes;
-using Robust.Shared.Physics.Systems;
 
 namespace Robust.Shared.Map;
 
@@ -119,11 +117,7 @@ internal partial class MapManager
             gridTree.Tree,
             _mapSystem,
             this,
-            _fixtureSystem,
-            _physics,
             _transformSystem,
-            _manifolds,
-            _fixturesQuery,
             approx);
 
 
@@ -174,11 +168,7 @@ internal partial class MapManager
             gridTree.Tree,
             _mapSystem,
             this,
-            _fixtureSystem,
-            _physics,
             _transformSystem,
-            _manifolds,
-            _fixturesQuery,
             approx);
 
 
@@ -381,11 +371,7 @@ internal partial class MapManager
         B2DynamicTree<(EntityUid Uid, MapGridComponent Grid)> Tree,
         SharedMapSystem MapSystem,
         MapManager MapManager,
-        FixtureSystem Fixtures,
-        SharedPhysicsSystem Physics,
         SharedTransformSystem TransformSystem,
-        IManifoldManager Manifolds,
-        EntityQuery<FixturesComponent> FixturesQuery,
         bool Approximate);
 
     private record struct GridQueryState<TState>(
@@ -397,10 +383,6 @@ internal partial class MapManager
         B2DynamicTree<(EntityUid Uid, MapGridComponent Grid)> Tree,
         SharedMapSystem MapSystem,
         MapManager MapManager,
-        FixtureSystem Fixtures,
-        SharedPhysicsSystem Physics,
         SharedTransformSystem TransformSystem,
-        IManifoldManager Manifolds,
-        EntityQuery<FixturesComponent> FixturesQuery,
         bool Approximate);
 }

--- a/Robust.Shared/Map/MapManager.Queries.cs
+++ b/Robust.Shared/Map/MapManager.Queries.cs
@@ -121,6 +121,7 @@ internal partial class MapManager
             this,
             _fixtureSystem,
             _physics,
+            _transformSystem,
             _manifolds,
             _fixturesQuery,
             approx);
@@ -130,7 +131,9 @@ internal partial class MapManager
         {
             // Even for approximate we'll check if any chunks roughly overlap.
             var data = state.Tree.GetUserData(proxy);
-            var localAABB = new Box2();
+            var gridInvMatrix = state.TransformSystem.GetInvWorldMatrix(data.Uid);
+            var localAABB = gridInvMatrix.TransformBox(state.WorldAABB);
+
             var overlappingChunks = state.MapSystem.GetLocalMapChunks(data.Uid, data.Grid, localAABB);
 
             if (state.Approximate)
@@ -173,6 +176,7 @@ internal partial class MapManager
             this,
             _fixtureSystem,
             _physics,
+            _transformSystem,
             _manifolds,
             _fixturesQuery,
             approx);
@@ -182,7 +186,9 @@ internal partial class MapManager
         {
             // Even for approximate we'll check if any chunks roughly overlap.
             var data = state.Tree.GetUserData(proxy);
-            var localAABB = new Box2();
+            var gridInvMatrix = state.TransformSystem.GetInvWorldMatrix(data.Uid);
+            var localAABB = gridInvMatrix.TransformBox(state.WorldAABB);
+
             var overlappingChunks = state.MapSystem.GetLocalMapChunks(data.Uid, data.Grid, localAABB);
 
             if (state.Approximate)
@@ -201,6 +207,9 @@ internal partial class MapManager
 
             return true;
         }, worldAABB);
+
+        // By-ref things
+        state = gridState.State;
     }
 
     /// <summary>
@@ -364,40 +373,6 @@ internal partial class MapManager
 
     #endregion
 
-    #region Obsolete
-
-    [Obsolete]
-    public bool TryFindGridAt(MapId mapId, Vector2 worldPos, EntityQuery<TransformComponent> query, out EntityUid uid, [NotNullWhen(true)] out MapGridComponent? grid)
-    {
-        return TryFindGridAt(mapId, worldPos, out uid, out grid);
-    }
-
-    [Obsolete]
-    public IEnumerable<MapGridComponent> FindGridsIntersecting(MapId mapId, Box2 worldAabb, bool approx = false, bool includeMap = true)
-    {
-        var grids = new List<Entity<MapGridComponent>>();
-        FindGridsIntersecting(mapId, worldAabb, ref grids, approx, includeMap);
-
-        foreach (var grid in grids)
-        {
-            yield return grid.Comp;
-        }
-    }
-
-    [Obsolete]
-    public IEnumerable<MapGridComponent> FindGridsIntersecting(MapId mapId, Box2Rotated worldArea, bool approx = false, bool includeMap = true)
-    {
-        var grids = new List<Entity<MapGridComponent>>();
-        FindGridsIntersecting(mapId, worldArea, ref grids, approx, includeMap);
-
-        foreach (var grid in grids)
-        {
-            yield return grid.Comp;
-        }
-    }
-
-    #endregion
-
     private readonly record struct GridQueryState(
         GridCallback Callback,
         Box2 WorldAABB,
@@ -408,6 +383,7 @@ internal partial class MapManager
         MapManager MapManager,
         FixtureSystem Fixtures,
         SharedPhysicsSystem Physics,
+        SharedTransformSystem TransformSystem,
         IManifoldManager Manifolds,
         EntityQuery<FixturesComponent> FixturesQuery,
         bool Approximate);
@@ -423,6 +399,7 @@ internal partial class MapManager
         MapManager MapManager,
         FixtureSystem Fixtures,
         SharedPhysicsSystem Physics,
+        SharedTransformSystem TransformSystem,
         IManifoldManager Manifolds,
         EntityQuery<FixturesComponent> FixturesQuery,
         bool Approximate);

--- a/Robust.Shared/Map/MapManager.cs
+++ b/Robust.Shared/Map/MapManager.cs
@@ -4,7 +4,10 @@ using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Collision;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -16,19 +19,29 @@ internal partial class MapManager : IMapManagerInternal, IEntityEventSubscriber
 {
     [field: Dependency] public IGameTiming GameTiming { get; } = default!;
     [field: Dependency] public IEntityManager EntityManager { get; } = default!;
+    [Dependency] private readonly IManifoldManager _manifolds = default!;
 
     [Dependency] private readonly IConsoleHost _conhost = default!;
 
     private ISawmill _sawmill = default!;
 
+    private FixtureSystem _fixtureSystem = default!;
     private SharedMapSystem _mapSystem = default!;
+    private SharedPhysicsSystem _physics = default!;
     private SharedTransformSystem _transformSystem = default!;
+
+    private EntityQuery<FixturesComponent> _fixturesQuery;
+    private EntityQuery<GridTreeComponent> _gridTreeQuery;
+    private EntityQuery<MapGridComponent> _gridQuery;
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<TransformComponent> _xformQuery;
 
     /// <inheritdoc />
     public void Initialize()
     {
+        _fixturesQuery = EntityManager.GetEntityQuery<FixturesComponent>();
+        _gridTreeQuery = EntityManager.GetEntityQuery<GridTreeComponent>();
+        _gridQuery = EntityManager.GetEntityQuery<MapGridComponent>();
         _physicsQuery = EntityManager.GetEntityQuery<PhysicsComponent>();
         _xformQuery = EntityManager.GetEntityQuery<TransformComponent>();
 
@@ -45,6 +58,8 @@ internal partial class MapManager : IMapManagerInternal, IEntityEventSubscriber
     /// <inheritdoc />
     public void Startup()
     {
+        _fixtureSystem = EntityManager.System<FixtureSystem>();
+        _physics = EntityManager.System<SharedPhysicsSystem>();
         _transformSystem = EntityManager.System<SharedTransformSystem>();
         _mapSystem = EntityManager.System<SharedMapSystem>();
 

--- a/Robust.Shared/Physics/Collision/Shapes/PolygonShape.cs
+++ b/Robust.Shared/Physics/Collision/Shapes/PolygonShape.cs
@@ -188,6 +188,24 @@ namespace Robust.Shared.Physics.Collision.Shapes
             Set(Vertices.AsSpan(), VertexCount);
         }
 
+        public void SetAsBox(Box2 box)
+        {
+            Array.Resize(ref Vertices, 4);
+            Array.Resize(ref Normals, 4);
+
+            Vertices[0] = box.BottomLeft;
+            Vertices[1] = box.BottomRight;
+            Vertices[2] = box.TopRight;
+            Vertices[3] = box.TopLeft;
+
+            Normals[0] = new Vector2(0.0f, -1.0f);
+            Normals[1] = new Vector2(1.0f, 0.0f);
+            Normals[2] = new Vector2(0.0f, 1.0f);
+            Normals[3] = new Vector2(-1.0f, 0.0f);
+
+            Centroid = box.Center;
+        }
+
         public void SetAsBox(float halfWidth, float halfHeight)
         {
             Array.Resize(ref Vertices, 4);

--- a/Robust.Shared/Physics/Collision/Shapes/PolygonShape.cs
+++ b/Robust.Shared/Physics/Collision/Shapes/PolygonShape.cs
@@ -188,6 +188,19 @@ namespace Robust.Shared.Physics.Collision.Shapes
             Set(Vertices.AsSpan(), VertexCount);
         }
 
+        public bool Set(Box2Rotated bounds)
+        {
+            Span<Vector2> vertices = stackalloc Vector2[]
+            {
+                bounds.BottomLeft,
+                bounds.BottomRight,
+                bounds.TopRight,
+                bounds.TopLeft,
+            };
+
+            return Set(vertices, 4);
+        }
+
         public void SetAsBox(Box2 box)
         {
             Array.Resize(ref Vertices, 4);

--- a/Robust.Shared/Physics/Systems/FixtureSystem.cs
+++ b/Robust.Shared/Physics/Systems/FixtureSystem.cs
@@ -248,7 +248,7 @@ namespace Robust.Shared.Physics.Systems
             var computeProperties = false;
 
             // Given a bunch of data isn't serialized need to sort of re-initialise it
-            var newFixtures = new Dictionary<string, Fixture>(state.Fixtures.Count());
+            var newFixtures = new Dictionary<string, Fixture>(state.Fixtures.Count);
 
             foreach (var (id, fixture) in state.Fixtures)
             {

--- a/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
@@ -287,7 +287,7 @@ namespace Robust.Shared.Physics.Systems
                 // TODO: Need to handle grids colliding with non-grid entities with the same layer
                 // (nothing in SS14 does this yet).
 
-                var transform = _physicsSystem.GetPhysicsTransform(gridUid, xformQuery: _xformQuery);
+                var transform = _physicsSystem.GetPhysicsTransform(gridUid);
                 var state = (gridUid, grid, transform, worldMatrix, invWorldMatrix, _map, _physicsSystem, _transform, _physicsQuery, _xformQuery);
 
                 _mapManager.FindGridsIntersecting(mapId, aabb, ref state,
@@ -311,7 +311,7 @@ namespace Robust.Shared.Physics.Systems
 
                         var (_, _, otherGridMatrix, otherGridInvMatrix) =  tuple.xformSystem.GetWorldPositionRotationMatrixWithInv(collidingXform, tuple.xformQuery);
                         var otherGridBounds = otherGridMatrix.TransformBox(component.LocalAABB);
-                        var otherTransform = tuple._physicsSystem.GetPhysicsTransform(uid, xformQuery: tuple.xformQuery);
+                        var otherTransform = tuple._physicsSystem.GetPhysicsTransform(uid);
 
                         // Get Grid2 AABB in grid1 ref
                         var aabb1 = tuple.grid.LocalAABB.Intersect(tuple.invWorldMatrix.TransformBox(otherGridBounds));

--- a/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
@@ -227,7 +227,7 @@ namespace Robust.Shared.Physics.Systems
                             ref var buffer = ref tuple.pairBuffer;
                             tuple.system.FindPairs(tuple.proxy, tuple.worldAABB, uid, buffer);
                             return true;
-                        }, approx: true);
+                        }, approx: true, includeMap: false);
 
                     // Struct ref moment, I have no idea what's fastest.
                     buffer = state.buffer;

--- a/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
@@ -227,7 +227,7 @@ namespace Robust.Shared.Physics.Systems
                             ref var buffer = ref tuple.pairBuffer;
                             tuple.system.FindPairs(tuple.proxy, tuple.worldAABB, uid, buffer);
                             return true;
-                        });
+                        }, approx: true);
 
                     // Struct ref moment, I have no idea what's fastest.
                     buffer = state.buffer;
@@ -360,7 +360,7 @@ namespace Robust.Shared.Physics.Systems
                         }
 
                         return true;
-                    }, includeMap: false);
+                    }, approx: true, includeMap: false);
             }
         }
 

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
@@ -628,7 +628,7 @@ public partial class SharedPhysicsSystem
 
     #endregion
 
-    public Transform GetPhysicsTransform(EntityUid uid, TransformComponent? xform = null, EntityQuery<TransformComponent>? xformQuery = null)
+    public Transform GetPhysicsTransform(EntityUid uid, TransformComponent? xform = null)
     {
         if (!_xformQuery.Resolve(uid, ref xform))
             return Physics.Transform.Empty;

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
@@ -436,8 +436,8 @@ public abstract partial class SharedPhysicsSystem
             // Special-case grid contacts.
             if ((contact.Flags & ContactFlags.Grid) != 0x0)
             {
-                var gridABounds = fixtureA.Shape.ComputeAABB(GetPhysicsTransform(uidA, xformA, _xformQuery), 0);
-                var gridBBounds = fixtureB.Shape.ComputeAABB(GetPhysicsTransform(uidB, xformB, _xformQuery), 0);
+                var gridABounds = fixtureA.Shape.ComputeAABB(GetPhysicsTransform(uidA, xformA), 0);
+                var gridBBounds = fixtureB.Shape.ComputeAABB(GetPhysicsTransform(uidB, xformB), 0);
 
                 if (!gridABounds.Intersects(gridBBounds))
                 {

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
@@ -54,7 +54,6 @@ namespace Robust.Shared.Physics.Systems
         [Dependency] private readonly SharedBroadphaseSystem _broadphase = default!;
         [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
         [Dependency] private readonly SharedDebugPhysicsSystem _debugPhysics = default!;
-        [Dependency] private readonly SharedGridTraversalSystem _traversal = default!;
         [Dependency] private readonly SharedJointSystem _joints = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
         [Dependency] private readonly CollisionWakeSystem _wakeSystem = default!;

--- a/Robust.Shared/Physics/Transform.cs
+++ b/Robust.Shared/Physics/Transform.cs
@@ -32,7 +32,7 @@ namespace Robust.Shared.Physics
     // TODO: Probably replace this internally with just the Vector2 and radians but I'd need to re-learn trig so yeah....
     public struct Transform
     {
-        public static readonly Transform Empty = new Transform();
+        public static readonly Transform Empty = new Transform(0f);
 
         public Vector2 Position;
         public Quaternion2D Quaternion2D;


### PR DESCRIPTION
- Make the shape queries respect the approx flag.
- Make everything use shape queries.
- Hopefully reduce some of the internal cruft.
- Add some new methods I need for trade station.

I also ended up cleaning up MapManager a bit too as it was on my TODO list and the ideas are vaguely similar.