### PR TITLE
Do not crash failing to load user keybindings

### DIFF
--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -124,7 +124,14 @@ namespace Robust.Client.Input
             var path = new ResPath(KeybindsPath);
             if (_resourceMan.UserData.Exists(path))
             {
-                LoadKeyFile(path, true);
+                try
+                {
+                    LoadKeyFile(path, true);
+                }
+                catch (Exception e)
+                {
+                    Logger.ErrorS("input", "Failed to load user keybindings: " + e);
+                }
             }
 
             if (_resourceMan.ContentFileExists(path))


### PR DESCRIPTION
A player sent me a log that showed the client crashing due to a corrupt user `keybinds.yml` (located in `%APPDATA%/Space Station 14/data/keybinds.yml` or the Linux/Unix equivalent):

```
Unhandled exception. System.InvalidOperationException: Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
   at Robust.Client.Input.InputManager.LoadKeyFile(ResPath file, Boolean userData) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/Input/InputManager.cs:line 506
   at Robust.Client.Input.InputManager.Initialize() in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/Input/InputManager.cs:line 127
   at Robust.Client.GameController.StartupContinue(DisplayMode displayMode) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/GameController/GameController.cs:line 163
   at Robust.Client.GameController.ContinueStartupAndLoop(DisplayMode mode) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/GameController/GameController.Standalone.cs:line 155
   at Robust.Client.GameController.GameThreadMain(DisplayMode mode) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/GameController/GameController.Standalone.cs:line 147
   at Robust.Client.GameController.<>c__DisplayClass100_0.<Run>b__0() in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/GameController/GameController.Standalone.cs:line 106
```

I asked for their `keybinds.yml` and it was indeed corrupt.

## Steps to Reproduce
Mess up your own user-local `keybinds.yml` and the client will crash while loading keybinds, whatever server you pick.

## Fix
Wrap loading user-local keybinds in a try/catch and print out an error message. This will just skip loading the corrupt keybinds, and the error will go away once the keybinds are saved again.