### PR TITLE
Localization support for any prototypes via a YAML tag

### DIFF
--- a/Robust.Shared/Serialization/Manager/SerializationManager.Reading.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.Reading.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Localization;
 using Robust.Shared.Serialization.Manager.Definition;
 using Robust.Shared.Serialization.Manager.Exceptions;
 using Robust.Shared.Serialization.Markdown;
@@ -77,6 +78,12 @@ namespace Robust.Shared.Serialization.Manager
                     (typeof(T), type, node.GetType()!, notNullableOverride),
                     static (tuple, manager) => ReadDelegateValueFactory(tuple.baseType, tuple.actualType, tuple.node, tuple.notNullableOverride, manager),
                     this))(node, hookCtx, context, instanceProvider);
+            }
+
+            if (node.Tag == "!Loc" && node is ValueDataNode valueNode && typeof(T) == typeof(string))
+            {
+                var loc = DependencyCollection.Resolve<ILocalizationManager>();
+                return (T)(object)loc.GetString(valueNode.Value);
             }
 
             return ((ReadGenericDelegate<T>)_readGenericDelegates.GetOrAdd((typeof(T), node.GetType()!, notNullableOverride),


### PR DESCRIPTION
## About the PR

[Yet another](https://github.com/space-wizards/RobustToolbox/pull/4335) attempt to have localization for those pesky hard-coded YAML strings.

So, my idea is to add `!Loc` YAML tag, passing tagged strings through the localization manager.

## Example

Here is a prototype for a jug that contains aluminium. The `name` and the `currentLabel` fields are hard-coded player facing strings that don't allow localization. While the `name` field uses [a smart trick](https://github.com/space-wizards/RobustToolbox/blob/20a411e6cee4b82b0fda1c1ba2070a2a2d60f90e/Robust.Shared/Prototypes/EntityPrototype.cs#L53-L54), replacing it [with a localized version later](https://github.com/space-wizards/RobustToolbox/blob/20a411e6cee4b82b0fda1c1ba2070a2a2d60f90e/Robust.Shared/Prototypes/EntityPrototype.cs#L73). The `currentLabel` can't use a similar trick, as it holds a free-form string, allowing players to change it with the Hand labeler any time.

```yaml
# Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
- type: entity
  parent: Jug
  name: jug (aluminium)
  id: JugAluminium
  noSpawn: true
  components:
    - type: Label
      currentLabel: aluminium
    - type: SolutionContainerManager
      solutions:
        beaker:
          reagents:
            - ReagentId: Aluminium
              Quantity: 200
```

My idea is to allow tagging strings in prototypes so that they can get swapped with localized versions right at the moment when prototypes are being loaded.

```yaml
      currentLabel: !Loc 'reagent-name-aluminium'
```

This approach seems to be working fine, here is a reagents dispenser screenshot of the Corvax SS14 build, that uses the jug prototype

![image](https://github.com/space-wizards/RobustToolbox/assets/1192090/d74bc789-646d-4915-9b74-2f786273f5b4)
