### PR TITLE
Fixes parsing of ShaderBlendMode in ShaderPrototype

### DIFF
--- a/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
+++ b/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
@@ -67,10 +67,9 @@ namespace Robust.Client.Graphics
 
                     var hasLight = _rawMode != "unshaded";
                     ShaderBlendMode? blend = null;
-                    if (!string.IsNullOrEmpty(_rawBlendMode))
+                    if (_rawBlendMode != null)
                     {
-                        var modeCapitalized = char.ToUpper(_rawBlendMode[0]) + _rawBlendMode[1..];
-                        if (!Enum.TryParse<ShaderBlendMode>(modeCapitalized, out var parsed))
+                        if (!Enum.TryParse<ShaderBlendMode>(_rawBlendMode, true, out var parsed))
                             Logger.Error($"invalid mode: {_rawBlendMode}");
                         else
                             blend = parsed;

--- a/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
+++ b/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using Robust.Client.ResourceManagement;
@@ -67,9 +67,10 @@ namespace Robust.Client.Graphics
 
                     var hasLight = _rawMode != "unshaded";
                     ShaderBlendMode? blend = null;
-                    if (_rawBlendMode != null)
+                    if (!string.IsNullOrEmpty(_rawBlendMode))
                     {
-                        if (!Enum.TryParse<ShaderBlendMode>(_rawBlendMode.ToUpper(), out var parsed))
+                        var modeCapitalized = char.ToUpper(_rawBlendMode[0]) + _rawBlendMode[1..];
+                        if (!Enum.TryParse<ShaderBlendMode>(modeCapitalized, out var parsed))
                             Logger.Error($"invalid mode: {_rawBlendMode}");
                         else
                             blend = parsed;


### PR DESCRIPTION
Fixes an issue with ShaderPrototype - it's not currently possible to set the ShaderBlendMode by YAML due to an issue with how it was parsed.

Currently, it takes the blend mode in YAML and uses ToUpper() which converts the string to ALL upper case, when it should only be capitalizing the first letter, because:

It uses Enum.TryParse<ShaderBlendMode>() to convert the string to a ShaderBlendMode enum value. However, Enum.TryParse() is case sensitive. "SUBTRACT" does not get converted to ShaderBlendMode.Subtract, only "Subtract" would, so the method always fails to get an enum value.

To resolve this, I made only the first letter get capitalized.