### PR TITLE
Fix TileEdgeOverlay flickering with tiles that are barely out of view

### DIFF
--- a/Robust.Client/Map/TileEdgeOverlay.cs
+++ b/Robust.Client/Map/TileEdgeOverlay.cs
@@ -37,7 +37,9 @@ public sealed class TileEdgeOverlay : GridOverlay
         var tileDimensions = new Vector2(tileSize, tileSize);
         var (_, _, worldMatrix, invMatrix) = xformSystem.GetWorldPositionRotationMatrixWithInv(Grid.Owner);
         args.WorldHandle.SetTransform(worldMatrix);
-        var localAABB = invMatrix.TransformBox(args.WorldBounds);
+        var bounds = args.WorldBounds;
+        bounds = new Box2Rotated(bounds.Box.Enlarged(1), bounds.Rotation, bounds.Origin);
+        var localAABB = invMatrix.TransformBox(bounds);
 
         var enumerator = mapSystem.GetLocalTilesEnumerator(Grid.Owner, Grid, localAABB, false);
 


### PR DESCRIPTION
Not noticeable under normal gameplay but if a tile that has an edge overlay is out of view it won't have its edge drawn until it is within view of the viewport.
![Content Client_cA7dvJWwnP](https://github.com/space-wizards/RobustToolbox/assets/10968691/f2459fe7-218b-435f-8272-35c4b5018a8f)
