### PR TITLE
Add global rectangles for controls

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Add GlobalRect and GlobalPixelRect for controls to get their UIBox2i in screen terms.
 
 ### Bugfixes
 

--- a/Robust.Client/UserInterface/Control.Layout.cs
+++ b/Robust.Client/UserInterface/Control.Layout.cs
@@ -226,6 +226,10 @@ namespace Robust.Client.UserInterface
         /// <seealso cref="Rect"/>
         public UIBox2i PixelRect => UIBox2i.FromDimensions(PixelPosition, PixelSize);
 
+        public UIBox2 GlobalRect => UIBox2.FromDimensions(GlobalPosition, _size);
+
+        public UIBox2i GlobalPixelRect => UIBox2i.FromDimensions(GlobalPixelPosition, PixelSize);
+
         /// <summary>
         /// Horizontal alignment mode.
         /// This determines how the control should be laid out horizontally


### PR DESCRIPTION
Like my other PR used to check if mouse is inbounds on the control without doing some skrunkly caching with mousemove.