### PR TITLE
Smarter EntitySystem sawmill name conversion

### DIFF
--- a/Robust.Shared/GameObjects/EntitySystem.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using JetBrains.Annotations;
 using Robust.Shared.IoC;
@@ -41,8 +42,16 @@ namespace Robust.Shared.GameObjects
                     name = name.Substring(0, name.Length - "System".Length);
 
                 // Convert CamelCase to snake_case
-                name = string.Concat(name.Select(x => char.IsUpper(x) ? $"_{char.ToLower(x)}" : x.ToString()));
-                name = name.Trim('_');
+                // Ignore if all uppercase, assume acronym (e.g. NPC or HTN)
+                if (name.All(char.IsUpper))
+                {
+                    name = name.ToLower(CultureInfo.InvariantCulture);
+                }
+                else
+                {
+                    name = string.Concat(name.Select(x => char.IsUpper(x) ? $"_{char.ToLower(x)}" : x.ToString()));
+                    name = name.Trim('_');
+                }
 
                 return $"system.{name}";
             }


### PR DESCRIPTION
this was bothering me far more than it should have

b4

![rider64_2024-01-29_04-17-41](https://github.com/space-wizards/RobustToolbox/assets/19853115/186d6703-35b5-4006-ad41-db8e882b2e0e)

afta

![rider64_2024-01-29_04-18-33](https://github.com/space-wizards/RobustToolbox/assets/19853115/18abd49c-1308-49ae-99b2-d54ed9e176f9)
