### PR TITLE
Fix EndCollideEvent being raised when a contact is destroyed but the two entities are still colliding

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
@@ -326,10 +326,23 @@ public abstract partial class SharedPhysicsSystem
 
         if (contact.IsTouching)
         {
-            var ev1 = new EndCollideEvent(aUid, bUid, contact.FixtureAId, contact.FixtureBId ,fixtureA, fixtureB, bodyA, bodyB);
-            var ev2 = new EndCollideEvent(bUid, aUid, contact.FixtureBId, contact.FixtureAId, fixtureB, fixtureA, bodyB, bodyA);
-            RaiseLocalEvent(aUid, ref ev1);
-            RaiseLocalEvent(bUid, ref ev2);
+            var stillTouching = false;
+            foreach (var fixture in fixtureA.Contacts)
+            {
+                if (fixture.Key == fixtureB)
+                    continue;
+
+                if (fixture.Key.Owner == bUid)
+                    stillTouching = true;
+            }
+
+            if (!stillTouching)
+            {
+                var ev1 = new EndCollideEvent(aUid, bUid, contact.FixtureAId, contact.FixtureBId ,fixtureA, fixtureB, bodyA, bodyB);
+                var ev2 = new EndCollideEvent(bUid, aUid, contact.FixtureBId, contact.FixtureAId, fixtureB, fixtureA, bodyB, bodyA);
+                RaiseLocalEvent(aUid, ref ev1);
+                RaiseLocalEvent(bUid, ref ev2);
+            }
         }
 
         if (contact.Manifold.PointCount > 0 && contact.FixtureA?.Hard == true && contact.FixtureB?.Hard == true)


### PR DESCRIPTION
I hope there is a better way to do this than looping the contacts dictionary.
@metalgearsloth 

Stopping climbing will make step trigger system think that you are no longer colliding with something that you still are colliding with, so climbing destroys the climbing fixture which destroys any contacts, if one of those contacts happens to be something that step trigger system is tracking it will remove it, if it leaves StepTriggerComponent.Colliding without elements it removes StepTriggerActiveComponent and prevents step trigger system from registering that you are stepping on something until you stop colliding and then start colliding again.
This only happens if the entity you were and still are colliding with shares a collision group with the climbing fixture.