### PR TITLE
Check entity for existence before drawing it in the SpriteView

### DIFF
--- a/Robust.Client/UserInterface/Controls/SpriteView.cs
+++ b/Robust.Client/UserInterface/Controls/SpriteView.cs
@@ -256,15 +256,22 @@ namespace Robust.Client.UserInterface.Controls
             [NotNullWhen(true)] out SpriteComponent? sprite,
             [NotNullWhen(true)] out TransformComponent? xform)
         {
-            if (Entity != null)
-            {
-                (uid, sprite, xform) = Entity.Value;
-                return true;
-            }
-
             sprite = null;
             xform = null;
             uid = default;
+
+            if (Entity != null)
+            {
+                if (!_entMan.EntityExists(Entity.Value))
+                {
+                    Entity = null;
+                    NetEnt = null;
+                    return false;
+                }
+
+                (uid, sprite, xform) = Entity.Value;
+                return true;
+            }
 
             if (NetEnt == null)
                 return false;

--- a/Robust.Client/UserInterface/Controls/SpriteView.cs
+++ b/Robust.Client/UserInterface/Controls/SpriteView.cs
@@ -16,7 +16,7 @@ namespace Robust.Client.UserInterface.Controls
     {
         private SpriteSystem? _sprite;
         private SharedTransformSystem? _transform;
-        IEntityManager _entMan;
+        private readonly IEntityManager _entMan;
 
         [ViewVariables]
         public SpriteComponent? Sprite => Entity?.Comp1;
@@ -143,6 +143,8 @@ namespace Robust.Client.UserInterface.Controls
             if (netEnt == NetEnt)
                 return;
 
+            // The Entity is getting set later in the ResolveEntity method
+            // because the client may not have received it yet.
             Entity = null;
             NetEnt = netEnt;
         }
@@ -256,35 +258,19 @@ namespace Robust.Client.UserInterface.Controls
             [NotNullWhen(true)] out SpriteComponent? sprite,
             [NotNullWhen(true)] out TransformComponent? xform)
         {
-            sprite = null;
-            xform = null;
-            uid = default;
+            if (NetEnt != null && Entity == null && _entMan.TryGetEntity(NetEnt, out var ent))
+                SetEntity(ent);
 
             if (Entity != null)
             {
-                if (!_entMan.EntityExists(Entity.Value))
-                {
-                    Entity = null;
-                    NetEnt = null;
-                    return false;
-                }
-
                 (uid, sprite, xform) = Entity.Value;
-                return true;
+                return !_entMan.Deleted(uid);
             }
 
-            if (NetEnt == null)
-                return false;
-
-            if (!_entMan.TryGetEntity(NetEnt, out var ent))
-                return false;
-
-            SetEntity(ent);
-            if (Entity == null)
-                return false;
-
-            (uid, sprite, xform) = Entity.Value;
-            return true;
+            sprite = null;
+            xform = null;
+            uid = default;
+            return false;
         }
     }
 }


### PR DESCRIPTION
## About the PR

I've noticed there is an issue with rendering the `SpriteView` in the round end summary window on the crew manifest tab. It appears that entities are getting terminated when you're getting back to the lobby after round end, which breaks the crew manifest tab. Locally, I've seen the following error spamming in the client's console:

```
runtime: Caught exception in "UserInterfaceManager"
System.ArgumentException: Tried to draw an entity has been deleted. (Parameter 'entity')
   at Robust.Client.Graphics.Clyde.Clyde.RenderHandle.DrawEntity(EntityUid entity, Vector2 position, Vector2 scale, Nullable`1 worldRot, Angle eyeRot, Nullable`1 overrideDirection, SpriteComponent sprite, TransformComponent xform, SharedTransformSystem xformSystem) in /space-station-14/RobustToolbox/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs:line 165
   at Robust.Client.UserInterface.Controls.SpriteView.DrawInternal(IRenderHandle renderHandle) in /space-station-14/RobustToolbox/Robust.Client/UserInterface/Controls/SpriteView.cs:line 250
   at Robust.Client.UserInterface.UserInterfaceManager._render(IRenderHandle renderHandle, Int32& total, Control control, Vector2i position, Color modulate, Nullable`1 scissorBox) in /space-station-14/RobustToolbox/Robust.Client/UserInterface/UserInterfaceManager.cs:line 388
   at Robust.Client.UserInterface.UserInterfaceManager._render(IRenderHandle renderHandle, Int32& total, Control control, Vector2i position, Color modulate, Nullable`1 scissorBox) in /space-station-14/RobustToolbox/Robust.Client/UserInterface/UserInterfaceManager.cs:line 395
   at Robust.Client.UserInterface.UserInterfaceManager._render(IRenderHandle renderHandle, Int32& total, Control control, Vector2i position, Color modulate, Nullable`1 scissorBox) in /space-station-14/RobustToolbox/Robust.Client/UserInterface/UserInterfaceManager.cs:line 395
   at Robust.Client.UserInterface.UserInterfaceManager._render(IRenderHandle renderHandle, Int32& total, Control control, Vector2i position, Color modulate, Nullable`1 scissorBox) in /space-station-14/RobustToolbox/Robust.Client/UserInterface/UserInterfaceManager.cs:line 395
   at Robust.Client.UserInterface.UserInterfaceManager._render(IRenderHandle renderHandle, Int32& total, Control control, Vector2i position, Color modulate, Nullable`1 scissorBox) in /space-station-14/RobustToolbox/Robust.Client/UserInterface/UserInterfaceManager.cs:line 395
   at Robust.Client.UserInterface.UserInterfaceManager._render(IRenderHandle renderHandle, Int32& total, Control control, Vector2i position, Color modulate, Nullable`1 scissorBox) in /space-station-14/RobustToolbox/Robust.Client/UserInterface/UserInterfaceManager.cs:line 395
   at Robust.Client.UserInterface.UserInterfaceManager._render(IRenderHandle renderHandle, Int32& total, Control control, Vector2i position, Color modulate, Nullable`1 scissorBox) in /space-station-14/RobustToolbox/Robust.Client/UserInterface/UserInterfaceManager.cs:line 395
   at Robust.Client.UserInterface.UserInterfaceManager._render(IRenderHandle renderHandle, Int32& total, Control control, Vector2i position, Color modulate, Nullable`1 scissorBox) in /space-station-14/RobustToolbox/Robust.Client/UserInterface/UserInterfaceManager.cs:line 395
   at Robust.Client.UserInterface.UserInterfaceManager._render(IRenderHandle renderHandle, Int32& total, Control control, Vector2i position, Color modulate, Nullable`1 scissorBox) in /space-station-14/RobustToolbox/Robust.Client/UserInterface/UserInterfaceManager.cs:line 395
   at Robust.Client.UserInterface.UserInterfaceManager._render(IRenderHandle renderHandle, Int32& total, Control control, Vector2i position, Color modulate, Nullable`1 scissorBox) in /space-station-14/RobustToolbox/Robust.Client/UserInterface/UserInterfaceManager.cs:line 395
   at Robust.Client.UserInterface.UserInterfaceManager._render(IRenderHandle renderHandle, Int32& total, Control control, Vector2i position, Color modulate, Nullable`1 scissorBox) in /space-station-14/RobustToolbox/Robust.Client/UserInterface/UserInterfaceManager.cs:line 395
   at Robust.Client.UserInterface.UserInterfaceManager.<>c__DisplayClass169_0.<Render>g__DoRender|0(WindowRoot root) in /space-station-14/RobustToolbox/Robust.Client/UserInterface/UserInterfaceManager.Layout.cs:line 135
```