### PR TITLE
Add GetEncoding to Sandbox

### DIFF
--- a/Robust.Shared/ContentPack/Sandbox.yml
+++ b/Robust.Shared/ContentPack/Sandbox.yml
@@ -626,6 +626,7 @@ Types:
       - "System.Text.Encoding get_UTF7()"
       - "System.Text.Encoding get_UTF8()"
       - "System.Text.Encoding get_UTF32()"
+      - "System.Text.Encoding GetEncoding(string)"
     NormalizationForm: { } # Enum
     Rune: { All: True }
     StringBuilder:


### PR DESCRIPTION
Required for using encoding to filter out unwanted characters from a string.

eg:
```
    /// <summary>
    /// Returns a string with all characters not in ISO-8851-1 replaced with question marks
    /// </summary>
    private static string RemoveNonLatin(string input)
    {
        if (string.IsNullOrEmpty(input))
            return "";

        // I think there's only three valid ones in dotnet core; ascii, iso-8859-1 and utf-8
        // We can extend but it requires annoying whitelisting
        var bytes = Encoding.GetEncoding("iso-8859-1").GetBytes(input);
        return Encoding.UTF8.GetString(bytes);
    }
```