### PR TITLE
Optimise ChunkEnumerator

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -51,7 +51,7 @@ END TEMPLATE-->
 
 ### Internal
 
-*None yet*
+* Significantly optimise ChunkEnumerator / FindGridsIntersecting in certain use cases by unionising the grid's AABB with the local AABB to avoid iterating dummy chunks.
 
 
 ## 210.0.3

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -51,7 +51,7 @@ END TEMPLATE-->
 
 ### Internal
 
-* Significantly optimise ChunkEnumerator / FindGridsIntersecting in certain use cases by unionising the grid's AABB with the local AABB to avoid iterating dummy chunks.
+* Significantly optimise ChunkEnumerator / FindGridsIntersecting in certain use cases by intersecting the grid's AABB with the local AABB to avoid iterating dummy chunks.
 
 
 ## 210.0.3

--- a/Robust.Shared.Maths/Box2.cs
+++ b/Robust.Shared.Maths/Box2.cs
@@ -186,10 +186,10 @@ namespace Robust.Shared.Maths
         [Pure]
         public readonly Box2 Intersect(in Box2 other)
         {
-            var ourLeftBottom = new Vector2(Left, Bottom);
-            var ourRightTop = new Vector2(Right, Top);
-            var otherLeftBottom = new Vector2(other.Left, other.Bottom);
-            var otherRightTop = new Vector2(other.Right, other.Top);
+            var ourLeftBottom = BottomLeft;
+            var ourRightTop = TopRight;
+            var otherLeftBottom = other.BottomLeft;
+            var otherRightTop = other.TopRight;
 
             var max = Vector2.Max(ourLeftBottom, otherLeftBottom);
             var min = Vector2.Min(ourRightTop, otherRightTop);
@@ -219,10 +219,10 @@ namespace Robust.Shared.Maths
         [Pure]
         public readonly Box2 Union(in Box2 other)
         {
-            var ourLeftBottom = new Vector2(Left, Bottom);
-            var otherLeftBottom = new Vector2(other.Left, other.Bottom);
-            var ourRightTop = new Vector2(Right, Top);
-            var otherRightTop = new Vector2(other.Right, other.Top);
+            var ourLeftBottom = BottomLeft;
+            var otherLeftBottom = other.BottomLeft;
+            var ourRightTop = TopRight;
+            var otherRightTop = other.TopRight;
 
             var leftBottom = Vector2.Min(ourLeftBottom, otherLeftBottom);
             var rightTop = Vector2.Max(ourRightTop, otherRightTop);

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -974,19 +974,19 @@ public abstract partial class SharedMapSystem
     internal ChunkEnumerator GetMapChunks(EntityUid uid, MapGridComponent grid, Box2 worldAABB)
     {
         var localAABB = _transform.GetInvWorldMatrix(uid).TransformBox(worldAABB);
-        return new ChunkEnumerator(grid.Chunks, localAABB, grid.ChunkSize);
+        return new ChunkEnumerator(grid.LocalAABB, grid.Chunks, localAABB, grid.ChunkSize);
     }
 
     internal ChunkEnumerator GetMapChunks(EntityUid uid, MapGridComponent grid, Box2Rotated worldArea)
     {
         var matrix = _transform.GetInvWorldMatrix(uid);
         var localArea = matrix.TransformBox(worldArea);
-        return new ChunkEnumerator(grid.Chunks, localArea, grid.ChunkSize);
+        return new ChunkEnumerator(grid.LocalAABB, grid.Chunks, localArea, grid.ChunkSize);
     }
 
     internal ChunkEnumerator GetLocalMapChunks(EntityUid uid, MapGridComponent grid, Box2 localAABB)
     {
-        return new ChunkEnumerator(grid.Chunks, localAABB, grid.ChunkSize);
+        return new ChunkEnumerator(grid.LocalAABB, grid.Chunks, localAABB, grid.ChunkSize);
     }
 
     #endregion ChunkAccess

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -974,19 +974,34 @@ public abstract partial class SharedMapSystem
     internal ChunkEnumerator GetMapChunks(EntityUid uid, MapGridComponent grid, Box2 worldAABB)
     {
         var localAABB = _transform.GetInvWorldMatrix(uid).TransformBox(worldAABB);
-        return new ChunkEnumerator(grid.LocalAABB, grid.Chunks, localAABB, grid.ChunkSize);
+        var compAABB = grid.LocalAABB.Intersect(localAABB);
+
+        if (compAABB.IsEmpty())
+            return ChunkEnumerator.Empty;
+
+        return new ChunkEnumerator(grid.Chunks, compAABB, grid.ChunkSize);
     }
 
     internal ChunkEnumerator GetMapChunks(EntityUid uid, MapGridComponent grid, Box2Rotated worldArea)
     {
         var matrix = _transform.GetInvWorldMatrix(uid);
         var localArea = matrix.TransformBox(worldArea);
-        return new ChunkEnumerator(grid.LocalAABB, grid.Chunks, localArea, grid.ChunkSize);
+        var compAABB = grid.LocalAABB.Intersect(localArea);
+
+        if (compAABB.IsEmpty())
+            return ChunkEnumerator.Empty;
+
+        return new ChunkEnumerator(grid.Chunks, compAABB, grid.ChunkSize);
     }
 
     internal ChunkEnumerator GetLocalMapChunks(EntityUid uid, MapGridComponent grid, Box2 localAABB)
     {
-        return new ChunkEnumerator(grid.LocalAABB, grid.Chunks, localAABB, grid.ChunkSize);
+        var compAABB = grid.LocalAABB.Intersect(localAABB);
+
+        if (compAABB.IsEmpty())
+            return ChunkEnumerator.Empty;
+
+        return new ChunkEnumerator(grid.Chunks, compAABB, grid.ChunkSize);
     }
 
     #endregion ChunkAccess

--- a/Robust.Shared/Map/Enumerators/ChunkEnumerator.cs
+++ b/Robust.Shared/Map/Enumerators/ChunkEnumerator.cs
@@ -14,12 +14,13 @@ internal struct ChunkEnumerator
     private int _xIndex;
     private int _yIndex;
 
-    internal ChunkEnumerator(Dictionary<Vector2i, MapChunk> chunks, Box2 localAABB, int chunkSize)
+    internal ChunkEnumerator(Box2 gridAABB, Dictionary<Vector2i, MapChunk> chunks, Box2 localAABB, int chunkSize)
     {
         _chunks = chunks;
+        var compAABB = gridAABB.Union(localAABB);
 
-        _chunkLB = new Vector2i((int)Math.Floor(localAABB.Left / chunkSize), (int)Math.Floor(localAABB.Bottom / chunkSize));
-        _chunkRT = new Vector2i((int)Math.Floor(localAABB.Right / chunkSize), (int)Math.Floor(localAABB.Top / chunkSize));
+        _chunkLB = new Vector2i((int)Math.Floor(compAABB.Left / chunkSize), (int)Math.Floor(compAABB.Bottom / chunkSize));
+        _chunkRT = new Vector2i((int)Math.Floor(compAABB.Right / chunkSize), (int)Math.Floor(compAABB.Top / chunkSize));
 
         _xIndex = _chunkLB.X;
         _yIndex = _chunkLB.Y;

--- a/Robust.Shared/Map/Enumerators/ChunkEnumerator.cs
+++ b/Robust.Shared/Map/Enumerators/ChunkEnumerator.cs
@@ -1,12 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
 
 namespace Robust.Shared.Map.Enumerators;
 
 internal struct ChunkEnumerator
 {
+    public static ChunkEnumerator Empty => new(new Dictionary<Vector2i, MapChunk>(), Box2.Empty, 16);
+
     private Dictionary<Vector2i, MapChunk> _chunks;
     private Vector2i _chunkLB;
     private Vector2i _chunkRT;
@@ -14,13 +18,12 @@ internal struct ChunkEnumerator
     private int _xIndex;
     private int _yIndex;
 
-    internal ChunkEnumerator(Box2 gridAABB, Dictionary<Vector2i, MapChunk> chunks, Box2 localAABB, int chunkSize)
+    internal ChunkEnumerator(Dictionary<Vector2i, MapChunk> chunks, Box2 localAABB, int chunkSize)
     {
         _chunks = chunks;
-        var compAABB = gridAABB.Union(localAABB);
 
-        _chunkLB = new Vector2i((int)Math.Floor(compAABB.Left / chunkSize), (int)Math.Floor(compAABB.Bottom / chunkSize));
-        _chunkRT = new Vector2i((int)Math.Floor(compAABB.Right / chunkSize), (int)Math.Floor(compAABB.Top / chunkSize));
+        _chunkLB = new Vector2i((int)Math.Floor(localAABB.Left / chunkSize), (int)Math.Floor(localAABB.Bottom / chunkSize));
+        _chunkRT = new Vector2i((int)Math.Floor(localAABB.Right / chunkSize), (int)Math.Floor(localAABB.Top / chunkSize));
 
         _xIndex = _chunkLB.X;
         _yIndex = _chunkLB.Y;


### PR DESCRIPTION
It never unioned the AABB passed in with the grid's AABB so it might inadvertantly iterate a lot more dummy chunks than it needs to.

This helps speedup FindGridsIntersecting.