### PR TITLE
Invalid keybinds will no longer mess up your game.

### DIFF
--- a/Robust.Client/Input/IInputManager.cs
+++ b/Robust.Client/Input/IInputManager.cs
@@ -40,7 +40,7 @@ namespace Robust.Client.Input
         void KeyDown(KeyEventArgs e);
         void KeyUp(KeyEventArgs e);
 
-        IKeyBinding RegisterBinding(in KeyBindingRegistration reg, bool markModified=true);
+        IKeyBinding RegisterBinding(in KeyBindingRegistration reg, bool markModified=true, bool invalid=false);
 
         void RemoveBinding(IKeyBinding binding, bool markModified=true);
 

--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -530,7 +530,7 @@ namespace Robust.Client.Input
 
                     if (reg.Type != KeyBindingType.Command && !NetworkBindMap.FunctionExists(reg.Function.FunctionName))
                     {
-                        Logger.ErrorS("input", "Key function in {0} does not exist: '{1}'", file,
+                        Logger.DebugS("input", "Key function in {0} does not exist: '{1}'.", file,
                             reg.Function);
                         invalid = true;
                     }

--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -559,7 +559,7 @@ namespace Robust.Client.Input
                 {
                     // Adding to _modifiedKeyFunctions means that these keybinds won't be loaded from the base file.
                     // Because they've been explicitly cleared.
-                    _modifiedKeyFunctions.UnionWith(leaveEmpty);
+                    _modifiedKeyFunctions.Add(bind);
 
                     // Adding to bindingsByFunction because if the keybind is not valid(For example if it's from another
                     // server then we will have problems saving the file)


### PR DESCRIPTION
fixes #4898

When a key wasn't valid there would be an exception when attempting to save keybinds. This is because they would be skipped, and not entered into _bindingsByFunction which would cause an exception whenever that key was looked up. 

This pr makes it so those keys are entered into that dictionary but not shown to players. It also means they won't be obliterated when the config saves in case those keys are valid another server. 