### PR TITLE
fix default keybinds being applied on top of user set keybinds

### DIFF
--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -544,7 +544,7 @@ namespace Robust.Client.Input
                         }
                     }
 
-                    RegisterBinding(reg, markModified: defaultRegistration);
+                    RegisterBinding(reg, markModified: !defaultRegistration);
                 }
             }
 


### PR DESCRIPTION
Fixes https://github.com/space-wizards/space-station-14/issues/25309

`LoadKeyFile.defaultRegistration `
Whether or not this is a "default" keybind set. If it is, then it won't override the current configuration, only the defaults."

`RegisterBinding.markModified`
Whether or not to register the bind as having been modified

### Current behavior:
if a user keybinds file is detected, it will load changed entries. Every entry will pass "is this a default value?" FALSE, which is then interpreted mark this as modified? FALSE
The bound inputs are not marked as modified.

Then, the default values are loaded. It checks every bind to see if it has been marked as modified. Whether or not a user keybinds file was loaded, nothing will be marked as modified. Thus, every default value will be loaded. If no user keybinds were loaded, this will work as a proper default configuration. If they were, the defaults are loaded in addition to the user configured binds.

Either way, every binding registration call will also pass "is this a default value?" TRUE, which is then interpreted "mark this as modified"? TRUE 

You can confirm this without even looking at the code, by observing that no matter what happened, even if there was no user keybinds file and its all defaults, every entry will have the RESET button next to it active and pressable

**The problem: defaultRegistration is passed directly to markModified, when it should be inverted**

Inverting this one value pass seems to fix the keybinds behavior, and I have not been able to find any issues caused by this. 
I think this is how the whole thing was designed to work, and simply one of the two booleans was assigned a logically opposite "phrasing" than the code was written by mistake

# Please check my logic I am not to be trusted with engine code