### PR TITLE
Add more CollectionExtension methods

### DIFF
--- a/Robust.Shared/Utility/CollectionExtensions.cs
+++ b/Robust.Shared/Utility/CollectionExtensions.cs
@@ -8,9 +8,27 @@ namespace Robust.Shared.Utility
 {
     public static class Extensions
     {
+        /// <summary>
+        /// Ensures that the specified array has the specified length.
+        /// </summary>
+        public static void EnsureLength<T>(ref T[] array, int length)
+        {
+            if (array.Length > length)
+                return;
+
+            Array.Resize(ref array, length);
+        }
+
         public static IList<T> Clone<T>(this IList<T> listToClone) where T : ICloneable
         {
-            return listToClone.Select(item => (T)item.Clone()).ToList();
+            var clone = new List<T>(listToClone.Count);
+
+            foreach (var value in listToClone)
+            {
+                clone.Add((T) value.Clone());
+            }
+
+            return clone;
         }
 
         /// <summary>


### PR DESCRIPTION
Maybe array.resize is bad for sandbox coin, in which case I'd also settle for changing it to a list instead.