### PR TITLE
Rework SetWorldPosition

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,7 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-* TransformSystem.SetWorldPosition will now also perform parent updates as necessary. Previously it would just set the entity's LocalPosition which may break if they were inside of a container. Now they will be removed from their container and TryFindGridAt will run to correctly parent them to the new position. If the old functionality is desired then you can use GetInvWorldMatrix to update the LocalPosition (bearing in mind containers may prevent this).
+* TransformSystem.SetWorldPosition and SetWorldPositionRotation will now also perform parent updates as necessary. Previously it would just set the entity's LocalPosition which may break if they were inside of a container. Now they will be removed from their container and TryFindGridAt will run to correctly parent them to the new position. If the old functionality is desired then you can use GetInvWorldMatrix to update the LocalPosition (bearing in mind containers may prevent this).
 
 ### New features
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,7 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* TransformSystem.SetWorldPosition will now also perform parent updates as necessary. Previously it would just set the entity's LocalPosition which may break if they were inside of a container. Now they will be removed from their container and TryFindGridAt will run to correctly parent them to the new position. If the old functionality is desired then you can use GetInvWorldMatrix to update the LocalPosition (bearing in mind containers may prevent this).
 
 ### New features
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -1003,7 +1003,7 @@ public abstract partial class SharedTransformSystem
             return;
         }
 
-        if (_mapManager.TryFindGridAt(component.MapUid.Value, worldPos, out var targetGrid, out _))
+        if (!_gridQuery.HasComponent(entity.Owner) && _mapManager.TryFindGridAt(component.MapUid.Value, worldPos, out var targetGrid, out _))
         {
             var invWorldMatrix = GetInvWorldMatrix(targetGrid);
             SetCoordinates(entity.Owner, entity, new EntityCoordinates(targetGrid, invWorldMatrix.Transform(worldPos)));

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -1092,7 +1092,7 @@ public abstract partial class SharedTransformSystem
             return;
         }
 
-        if (!_gridQuery.HasComponent(uid) && _mapManager.TryFindGridAt(component.MapUid.Value, worldPos, out var targetGrid, out _))
+        if (component.GridUid != uid && _mapManager.TryFindGridAt(component.MapUid.Value, worldPos, out var targetGrid, out _))
         {
             var (_, gridRot, invWorldMatrix) = GetWorldPositionRotationInvMatrix(targetGrid);
             var localRot = worldRot - gridRot;

--- a/Robust.UnitTesting/Server/GameObjects/Components/TransformIntegration_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/Components/TransformIntegration_Test.cs
@@ -1,0 +1,60 @@
+using System.Numerics;
+using NUnit.Framework;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Robust.UnitTesting.Server.GameObjects.Components;
+
+[TestFixture]
+public sealed class TransformIntegration_Test
+{
+    /// <summary>
+    /// Asserts that calling SetWorldPosition while in a container correctly removes the entity from its container.
+    /// </summary>
+    [Test]
+    public void WorldPositionContainerSet()
+    {
+        var factory = RobustServerSimulation.NewSimulation();
+
+        var sim = factory.InitializeInstance();
+
+        var entManager = sim.Resolve<IEntityManager>();
+        var mapManager = sim.Resolve<IMapManager>();
+        var containerSystem = entManager.System<SharedContainerSystem>();
+        var xformSystem = entManager.System<SharedTransformSystem>();
+
+        var map1Id = mapManager.CreateMap();
+        var map1 = mapManager.GetMapEntityId(map1Id);
+
+        var ent1 = entManager.SpawnEntity(null, new EntityCoordinates(map1, Vector2.Zero));
+        var ent2 = entManager.SpawnEntity(null, new EntityCoordinates(map1, Vector2.Zero));
+        var ent3 = entManager.SpawnEntity(null, new EntityCoordinates(map1, Vector2.Zero));
+
+        var container = containerSystem.EnsureContainer<ContainerSlot>(ent1, "a");
+
+        // Assert that setting worldpos updates parent correctly.
+        containerSystem.Insert(ent2, container, force: true);
+
+        Assert.That(containerSystem.IsEntityInContainer(ent2));
+
+        xformSystem.SetWorldPosition(ent2, Vector2.One);
+
+        Assert.That(!containerSystem.IsEntityInContainer(ent2));
+        Assert.That(xformSystem.GetWorldPosition(ent2), Is.EqualTo(Vector2.One));
+
+        // Assert that you can set recursively contained (but not directly contained) entities correctly.
+        containerSystem.Insert(ent2, container);
+        xformSystem.SetParent(ent3, ent2);
+
+        Assert.That(xformSystem.GetParentUid(ent3), Is.EqualTo(ent2));
+
+        xformSystem.SetWorldPosition(ent3, Vector2.One);
+
+        Assert.That(xformSystem.GetParentUid(ent3), Is.EqualTo(map1));
+        Assert.That(xformSystem.GetWorldPosition(ent3).Equals(Vector2.One));
+
+        // Cleanup
+        entManager.DeleteEntity(map1);
+    }
+}

--- a/Robust.UnitTesting/Shared/Map/GridSplit_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/GridSplit_Tests.cs
@@ -117,7 +117,6 @@ public sealed class GridSplit_Tests
         var mapSystem = sim.Resolve<IEntityManager>().System<SharedMapSystem>();
         var mapId = mapManager.CreateMap();
         var gridEnt = mapManager.CreateGridEntity(mapId);
-        var grid = gridEnt.Comp;
 
         for (var x = 0; x < 3; x++)
         {


### PR DESCRIPTION
How it currently works:
- Tries to set the entity's LocalPosition to the specified spot, transforming the new WorldPosition to something relative to their current parent. Problem with this is is it doesn't work with containers or if an entity gets moved off grid for grid traversal so content can very easily break this.

How I've changed it to work:
- It will de-parent and function as if the caller called AttachToGridOrMap immediately after which better aligns with expectations.

If someone wants the old method then either add a new method called "TrySetWorldPosition" that will drop it if they're in a container or do the matrix transform yourself and set localposition.

I have also added a test to verify this works going forward and doesn't break again.