### PR TITLE
Increase replay compressed size default cvar

### DIFF
--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1498,7 +1498,7 @@ namespace Robust.Shared
         /// Maximum compressed size of a replay recording (in kilobytes) before recording automatically stops.
         /// </summary>
         public static readonly CVarDef<long> ReplayMaxCompressedSize = CVarDef.Create("replay.max_compressed_size",
-            1024L * 256, CVar.ARCHIVE);
+            1024L * 512, CVar.ARCHIVE);
 
         /// <summary>
         /// Maximum uncompressed size of a replay recording (in kilobytes) before recording automatically stops.


### PR DESCRIPTION
They tend to get cut off (or well did on wizden before pjb changed it to this exact value bigger along with another patch). 

Before you got around 2ish hours in a replay before it stopped suddenly. 

I doubt most servers will reach 6ish hours before this takes effect. But those servers can increase this value if needed.