### PR TITLE
Remove ISerializationHooks obsoletion

### DIFF
--- a/Robust.Shared/Serialization/ISerializationHooks.cs
+++ b/Robust.Shared/Serialization/ISerializationHooks.cs
@@ -1,17 +1,13 @@
-using System;
+namespace Robust.Shared.Serialization;
 
-namespace Robust.Shared.Serialization
+/// <summary>
+/// Provides a method that gets executed after deserialization is complete and a method that gets executed before serialization
+/// </summary>
+[RequiresExplicitImplementation]
+public interface ISerializationHooks
 {
     /// <summary>
-    /// Provides a method that gets executed after deserialization is complete and a method that gets executed before serialization
+    /// Gets executed after deserialization is complete
     /// </summary>
-    [RequiresExplicitImplementation]
-    [Obsolete($"Avoid using ISerializationHooks in favour of (Custom)TypeSerializers or ComponentInit-Events.")]
-    public interface ISerializationHooks
-    {
-        /// <summary>
-        /// Gets executed after deserialization is complete
-        /// </summary>
-        void AfterDeserialization() {}
-    }
+    void AfterDeserialization() {}
 }


### PR DESCRIPTION
Still needed in rare cases so not really deprecated and we already discourage coders from using it where possible.