### PR TITLE
Allow for use of new .NET 8 MSBuild property <UseArtifactsOutput>

### DIFF
--- a/MSBuild/XamlIL.targets
+++ b/MSBuild/XamlIL.targets
@@ -24,12 +24,16 @@
     <RobustInjectorsConfiguration>$(Configuration)</RobustInjectorsConfiguration>
     <RobustInjectorsConfiguration Condition="'$(Configuration)' == 'DebugOpt'">Debug</RobustInjectorsConfiguration>
     <RobustInjectorsConfiguration Condition="'$(Configuration)' == 'Tools'">Release</RobustInjectorsConfiguration>
+    <RobustInjectorsConfiguration Condition="'$(UseArtifactsOutput)' == 'true' And '$(RuntimeIdentifier)' != ''">$(RobustInjectorsConfiguration)_$(RuntimeIdentifier)</RobustInjectorsConfiguration>
+    <RobustInjectorsConfiguration Condition="'$(UseArtifactsOutput)' == 'true'">$(RobustInjectorsConfiguration.ToLower())</RobustInjectorsConfiguration>
+    <CompileRobustXamlTaskAssemblyFile Condition="'$(UseArtifactsOutput)' != 'true'">$(MSBuildThisFileDirectory)\..\Robust.Client.Injectors\bin\$(RobustInjectorsConfiguration)\netstandard2.0\Robust.Client.Injectors.dll</CompileRobustXamlTaskAssemblyFile>
+    <CompileRobustXamlTaskAssemblyFile Condition="'$(UseArtifactsOutput)' == 'true'">$(MSBuildThisFileDirectory)\..\..\artifacts\bin\Robust.Client.Injectors\$(RobustInjectorsConfiguration)\Robust.Client.Injectors.dll</CompileRobustXamlTaskAssemblyFile>
   </PropertyGroup>
 
   <UsingTask
     Condition="'$(_RobustUseExternalMSBuild)' != 'true' And $(DesignTimeBuild) != true"
     TaskName="CompileRobustXamlTask"
-    AssemblyFile="$(MSBuildThisFileDirectory)\..\Robust.Client.Injectors\bin\$(RobustInjectorsConfiguration)\netstandard2.0\Robust.Client.Injectors.dll"/>
+    AssemblyFile="$(CompileRobustXamlTaskAssemblyFile)"/>
   <Target
     Name="CompileRobustXaml"
     Condition="Exists('@(IntermediateAssembly)')"


### PR DESCRIPTION
Allow for use of UseArtifactsOutput MSBuild property, new in .NET 8. Redirects build products (bin, obj, etc) to e.g. `artifacts/bin/$(Project name)` in the Content working copy.

Had to change some code in RobustToolbox to look at the new path.

Can be enabled either with inclusion of the property in each `.csproj` prior to importing the SDK, e.g.:
```xml
<!-- <Project Sdk="Microsoft.NET.Sdk"> -->
<Project>
  <Import Project="..\MSBuild\PreSDK.props" />
  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
  <Import Project="..\MSBuild\Robust.Engine.props" />
  <PropertyGroup>
    <OutputPath>../bin/Client</OutputPath>
    [...]
  </PropertyGroup>
  <Import Project="..\MSBuild\Robust.Properties.targets" />
  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
</Project>
```

Or placing a `Directory.Build.props` in Content local copy (or via CLI build `dotnet build -p:UseArtifactsOutput=true Content.Client`):
```xml
<Project>
  <PropertyGroup>
    <UseArtifactsOutput>true</UseArtifactsOutput>
  </PropertyGroup>
</Project>
```

The latter would be used by the end user customizing the build, but I thought to mention the former just in case it might be useful.

Note that `<OutputPath>` when specified takes precedence, the relevant outputs of the projects specifying that won't be redirected to the artifacts path. So the expected structure in `./bin` and `./RobustToolbox/bin` will remain the same.