### PR TITLE
Fix TextureRect KeepCentered

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Fix TextureRect alignment where the strech mode is KeepCentered.
 
 ### Other
 

--- a/Robust.Client/UserInterface/Controls/TextureRect.cs
+++ b/Robust.Client/UserInterface/Controls/TextureRect.cs
@@ -213,7 +213,7 @@ namespace Robust.Client.UserInterface.Controls
                     return UIBox2.FromDimensions(Vector2.Zero, TextureSizeTarget * UIScale);
                 case StretchMode.KeepCentered:
                 {
-                    var position = (PixelSize - TextureSizeTarget) / 2;
+                    var position = (Size - TextureSizeTarget) / 2;
                     return UIBox2.FromDimensions(position, TextureSizeTarget * UIScale);
                 }
 


### PR DESCRIPTION
Easiest way to repro is set a non-1.0 UIScale and open the main menu up, the logo will be fonky. I checked the control dimensions and this aligned with my expectations.