### PR TITLE
Clip labels by default

### DIFF
--- a/Robust.Client/UserInterface/Controls/Label.cs
+++ b/Robust.Client/UserInterface/Controls/Label.cs
@@ -31,6 +31,7 @@ namespace Robust.Client.UserInterface.Controls
         public Label()
         {
             VerticalAlignment = VAlignment.Center;
+            ClipText = true;
         }
 
         /// <summary>

--- a/Robust.Client/UserInterface/Controls/RichTextLabel.cs
+++ b/Robust.Client/UserInterface/Controls/RichTextLabel.cs
@@ -21,6 +21,7 @@ namespace Robust.Client.UserInterface.Controls
         {
             IoCManager.InjectDependencies(this);
             VerticalAlignment = VAlignment.Center;
+            RectClipContent = true;
         }
 
         public void SetMessage(FormattedMessage message, Type[]? tagsAllowed = null, Color? defaultColor = null)


### PR DESCRIPTION
I imagine situations where you don't want to clip these are rare. I mainly noticed this on FancyWindow and Button but if we don't want it globally I'll just update it as I see it.