### PR TITLE
ScrollContainer niceties

### DIFF
--- a/Robust.Client/UserInterface/Controls/ScrollContainer.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollContainer.cs
@@ -20,6 +20,11 @@ namespace Robust.Client.UserInterface.Controls
 
         private bool _suppressScrollValueChanged;
 
+        /// <summary>
+        /// If true then if we have a y-axis scroll it will convert it to an x-axis scroll.
+        /// </summary>
+        public bool FallbackDeltaScroll { get; set; } = true;
+
         public int ScrollSpeedX { get; set; } = 50;
         public int ScrollSpeedY { get; set; } = 50;
 
@@ -246,8 +251,18 @@ namespace Robust.Client.UserInterface.Controls
 
             if (_hScrollEnabled)
             {
-                _hScrollBar.ValueTarget += args.Delta.X * ScrollSpeedX;
+                var delta =
+                    args.Delta.X == 0f &&
+                    !_vScrollEnabled &&
+                    FallbackDeltaScroll ?
+                        -args.Delta.Y :
+                        args.Delta.X;
+
+                _hScrollBar.ValueTarget += delta * ScrollSpeedX;
             }
+
+            if (!_vScrollVisible && !_hScrollVisible)
+                return;
 
             args.Handle();
         }


### PR DESCRIPTION
- If scroll is not visible we don't handle it. This means nested containers don't interfere with their parents anymore.
- Fallback to Y-scrolling for H-scroll only containers.