### PR TITLE
Make CVar light.resolution_scale only changeable by server

### DIFF
--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -702,7 +702,7 @@ namespace Robust.Shared
         /// relative to the viewport framebuffer size.
         /// </summary>
         public static readonly CVarDef<float> LightResolutionScale =
-            CVarDef.Create("light.resolution_scale", 0.5f, CVar.CLIENTONLY | CVar.ARCHIVE);
+            CVarDef.Create("light.resolution_scale", 0.5f, CVar.SERVER | CVar.REPLICATED | CVar.ARCHIVE);
 
         /// <summary>
         /// Maximum amount of shadow-casting lights that can be rendered in a single viewport at once.


### PR DESCRIPTION
remove `CVar.CLIENTONLY` and add the `CVar.SERVER | CVar.REPLICATED`

reason:
`cvar light.resolution_scale 0.0001`
before:
![image](https://github.com/space-wizards/RobustToolbox/assets/45953835/d2f38604-8e82-40a5-8833-d81eb693ae03)
after:
![image](https://github.com/space-wizards/RobustToolbox/assets/45953835/40d724b2-95b1-4c13-ab37-58b35f92ff21)

the rest of the light cvars don't do anything to warrant making them server-changeable only