### PR TITLE
Give CVar light.resolution_scale a minimum of 0.05

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -1201,7 +1201,7 @@ namespace Robust.Client.Graphics.Clyde
 
         private void LightResolutionScaleChanged(float newValue)
         {
-            _lightResolutionScale = newValue;
+            _lightResolutionScale = newValue > 0.05f ? newValue : 0.05f;
             RegenAllLightRts();
         }
 


### PR DESCRIPTION
#4941 part 2

about how low i could get it before it started becoming A Problem

0.5 (default)
![image](https://github.com/space-wizards/RobustToolbox/assets/45953835/9423be44-c9b7-41c9-b32e-eda1b4500664)
0.05
![image](https://github.com/space-wizards/RobustToolbox/assets/45953835/625925cd-9deb-4b87-a24a-3c2fba877813)
0.01 (for comparison)
![image](https://github.com/space-wizards/RobustToolbox/assets/45953835/13e6525a-0631-42f7-bd9b-2f72fdddd679)
