### PR TITLE
Add RaiseSharedEvent

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Add EntityManager.RaiseSharedEvent where the event won't go to the attached client but will be predicted locally on their end.
 
 ### Bugfixes
 

--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -8,6 +8,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Network;
 using Robust.Shared.Network.Messages;
+using Robust.Shared.Player;
 using Robust.Shared.Replays;
 using Robust.Shared.Utility;
 
@@ -132,6 +133,24 @@ namespace Robust.Client.GameObjects
             var eventArgs = new EntitySessionEventArgs(session!);
             EventBus.RaiseEvent(EventSource.Local, msg);
             EventBus.RaiseEvent(EventSource.Local, new EntitySessionMessage<T>(eventArgs, msg));
+        }
+
+        /// <inheritdoc />
+        public override void RaiseSharedEvent<T>(T message, EntityUid? user = null)
+        {
+            if (user == null || user != _playerManager.LocalEntity || !_gameTiming.IsFirstTimePredicted)
+                return;
+
+            EventBus.RaiseEvent(EventSource.Local, ref message);
+        }
+
+        /// <inheritdoc />
+        public override void RaiseSharedEvent<T>(T message, ICommonSession? user = null)
+        {
+            if (user == null || user != _playerManager.LocalSession || !_gameTiming.IsFirstTimePredicted)
+                return;
+
+            EventBus.RaiseEvent(EventSource.Local, ref message);
         }
 
         #region IEntityNetworkManager impl

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -103,6 +103,40 @@ namespace Robust.Server.GameObjects
             return entity;
         }
 
+        /// <inheritdoc />
+        public override void RaiseSharedEvent<T>(T message, EntityUid? user = null)
+        {
+            if (user != null)
+            {
+                var filter = Filter.Broadcast().RemoveWhereAttachedEntity(e => e == user.Value);
+                foreach (var session in filter.Recipients)
+                {
+                    EntityNetManager.SendSystemNetworkMessage(message, session.Channel);
+                }
+            }
+            else
+            {
+                EntityNetManager.SendSystemNetworkMessage(message);
+            }
+        }
+
+        /// <inheritdoc />
+        public override void RaiseSharedEvent<T>(T message, ICommonSession? user = null)
+        {
+            if (user != null)
+            {
+                var filter = Filter.Broadcast().RemovePlayer(user);
+                foreach (var session in filter.Recipients)
+                {
+                    EntityNetManager.SendSystemNetworkMessage(message, session.Channel);
+                }
+            }
+            else
+            {
+                EntityNetManager.SendSystemNetworkMessage(message);
+            }
+        }
+
         private void ClearTicks(EntityUid entity, EntityPrototype prototype)
         {
             foreach (var (netId, component) in GetNetComponents(entity))

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -907,6 +907,16 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <summary>
+        /// Raises an event locally on client or networked on server.
+        /// </summary>
+        public abstract void RaiseSharedEvent<T>(T message, EntityUid? user = null) where T : EntityEventArgs;
+
+        /// <summary>
+        /// Raises an event locally on client or networked on server.
+        /// </summary>
+        public abstract void RaiseSharedEvent<T>(T message, ICommonSession? user = null) where T : EntityEventArgs;
+
+        /// <summary>
         ///     Factory for generating a new EntityUid for an entity currently being created.
         /// </summary>
         internal EntityUid GenerateEntityUid()


### PR DESCRIPTION
Used in some rare cases on content (popups + pickup prediction). I was too lazy to make system proxy methods because it's very infrequent.

Different to RaisePredictiveEvent.