### PR TITLE
Support transform states with unknown parents

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -700,7 +700,7 @@ namespace Robust.Client.GameStates
         {
             using var _ = _timing.StartStateApplicationArea();
 
-            // TODO repays optimize this.
+            // TODO replays optimize this.
             // This currently just saves game states as they are applied.
             // However this is inefficient and may have redundant data.
             // E.g., we may record states: [10 to 15] [11 to 16] *error* [0 to 18] [18 to 19] [18 to 20] ...

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -372,13 +372,6 @@ internal sealed partial class PvsSystem : EntitySystem
         {
             ref var data = ref pvsSession.DataMemory.GetRef(intPtr.Index);
             DebugTools.AssertEqual(data.LastSeen, _gameTiming.CurTick);
-
-            // if an entity is visible, its parents should always be visible.
-            if (_xformQuery.GetComponent(GetEntity(IndexToNetEntity(intPtr))).ParentUid is not {Valid: true} pUid)
-                continue;
-
-            DebugTools.Assert(toSendSet.Contains(GetNetEntity(pUid)),
-                $"Attempted to send an entity without sending it's parents. Entity: {ToPrettyString(pUid)}.");
         }
 
         pvsSession.PreviouslySent.TryGetValue(_gameTiming.CurTick - 1, out var lastSent);

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -722,10 +722,7 @@ public abstract partial class SharedTransformSystem
     {
         if (args.Current is TransformComponentState newState)
         {
-            var parent = GetEntity(newState.ParentID);
-            if (!parent.IsValid() && newState.ParentID.IsValid())
-                Log.Error($"Received transform component state with an unknown parent Id. Entity: {ToPrettyString(uid)}. Net parent: {newState.ParentID}");
-
+            var parent = EnsureEntity<TransformComponent>(newState.ParentID, uid);
             var oldAnchored = xform.Anchored;
 
             // update actual position data, if required

--- a/Robust.UnitTesting/RobustIntegrationTest.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.cs
@@ -303,6 +303,12 @@ namespace Robust.UnitTesting
                 return EntMan.GetComponent<MetaDataComponent>(uid);
             }
 
+            public MetaDataComponent MetaData(NetEntity uid)
+                => MetaData(EntMan.GetEntity(uid));
+
+            public TransformComponent Transform(NetEntity uid)
+                => Transform(EntMan.GetEntity(uid));
+
             public async Task ExecuteCommand(string cmd)
             {
                 await WaitPost(() => ConsoleHost.ExecuteCommand(cmd));

--- a/Robust.UnitTesting/Server/GameStates/MissingParentTest.cs
+++ b/Robust.UnitTesting/Server/GameStates/MissingParentTest.cs
@@ -1,0 +1,171 @@
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Robust.Shared;
+using Robust.Shared.Configuration;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+
+namespace Robust.UnitTesting.Server.GameStates;
+
+public sealed class MissingParentTest : RobustIntegrationTest
+{
+    /// <summary>
+    /// Check that PVS & clients can handle entities being sent before their parents are.
+    /// </summary>
+    [Test]
+    public async Task TestMissingParent()
+    {
+        var server = StartServer();
+        var client = StartClient();
+
+        await Task.WhenAll(client.WaitIdleAsync(), server.WaitIdleAsync());
+
+        var mapMan = server.ResolveDependency<IMapManager>();
+        var sEntMan = server.ResolveDependency<IEntityManager>();
+        var confMan = server.ResolveDependency<IConfigurationManager>();
+        var sPlayerMan = server.ResolveDependency<ISharedPlayerManager>();
+
+        var cEntMan = client.ResolveDependency<IEntityManager>();
+        var netMan = client.ResolveDependency<IClientNetManager>();
+        var cPlayerMan = client.ResolveDependency<ISharedPlayerManager>();
+        var cConfMan = client.ResolveDependency<IConfigurationManager>();
+
+        Assert.DoesNotThrow(() => client.SetConnectTarget(server));
+        client.Post(() => netMan.ClientConnect(null!, 0, null!));
+        server.Post(() => confMan.SetCVar(CVars.NetPVS, true));
+
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        // Limit client to receiving at most 1 entity per tick.
+        cConfMan.SetCVar(CVars.NetPVSEntityBudget, 1);
+
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        // Ensure client & server ticks are synced.
+        // Client runs 1 tick ahead
+        {
+            var sTick = (int)server.Timing.CurTick.Value;
+            var cTick = (int)client.Timing.CurTick.Value;
+            var delta = cTick - sTick;
+
+            if (delta > 1)
+                await server.WaitRunTicks(delta - 1);
+            else if (delta < 1)
+                await client.WaitRunTicks(1 - delta);
+
+            sTick = (int)server.Timing.CurTick.Value;
+            cTick = (int)client.Timing.CurTick.Value;
+            delta = cTick - sTick;
+            Assert.That(delta, Is.EqualTo(1));
+        }
+
+        // Set up map and spawn player
+        EntityUid map = default;
+        NetEntity player = default;
+        NetEntity entity = default;
+        EntityCoordinates coords = default;
+        NetCoordinates nCoords = default;
+        await server.WaitPost(() =>
+        {
+            var mapId = mapMan.CreateMap();
+            map = mapMan.GetMapEntityId(mapId);
+            coords = new(map, default);
+
+            var playerUid = sEntMan.SpawnEntity(null, coords);
+            var entUid = sEntMan.SpawnEntity(null, coords);
+            entity = sEntMan.GetNetEntity(entUid);
+            player = sEntMan.GetNetEntity(playerUid);
+            nCoords = sEntMan.GetNetCoordinates(coords);
+
+            // Attach player.
+            var session = sPlayerMan.Sessions.First();
+            server.PlayerMan.SetAttachedEntity(session, playerUid);
+            sPlayerMan.JoinGame(session);
+        });
+
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        Assert.That(player, Is.Not.EqualTo(NetEntity.Invalid));
+        Assert.That(entity, Is.Not.EqualTo(NetEntity.Invalid));
+
+        // Check player got properly attached, and has received the other entity.
+        Assert.That(cEntMan.TryGetEntityData(entity, out _, out var meta));
+        Assert.That(cEntMan.TryGetEntity(player, out var cPlayerUid));
+        Assert.That(cPlayerMan.LocalEntity, Is.EqualTo(cPlayerUid));
+        Assert.That(server.Transform(player).Coordinates, Is.EqualTo(coords));
+        Assert.That(client.Transform(player).Coordinates, Is.EqualTo(client.EntMan.GetCoordinates(nCoords)));
+        Assert.That(client.Transform(entity).ParentUid.IsValid(), Is.True);
+        Assert.That(client.MetaData(entity).Flags & MetaDataFlags.Detached, Is.EqualTo(MetaDataFlags.None));
+
+        // Spawn 20 new entities
+        NetEntity first = default;
+        NetEntity last = default;
+        await server.WaitPost(() =>
+        {
+            first = sEntMan.GetNetEntity(sEntMan.SpawnEntity(null, coords));
+            for (var i = 0; i < 18; i++)
+            {
+                sEntMan.SpawnEntity(null, coords);
+            }
+            last = sEntMan.GetNetEntity(sEntMan.SpawnEntity(null, coords));
+        });
+
+        // Wait for the client to receive some, but not all, of the entities
+        for (int i = 0; i < 8; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+        Assert.That(cEntMan.TryGetEntity(first, out _), Is.True);
+        Assert.That(cEntMan.TryGetEntity(last, out _), Is.False);
+
+        // Re-parent the known entity to an entity that the client has not received yet.
+        await server.WaitPost(() =>
+        {
+            var newCoords = new EntityCoordinates(sEntMan.GetEntity(last), default);
+            server.System<SharedTransformSystem>().SetCoordinates(sEntMan.GetEntity(entity), newCoords);
+        });
+
+        // Wait a few more ticks
+        for (int i = 0; i < 8; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        // Client should still not have received the new parent, however this shouldn't cause any issues.
+        // The already known entity should just have been moved to nullspace.
+        Assert.That(cEntMan.TryGetEntity(last, out _), Is.False);
+        Assert.That(client.Transform(entity).ParentUid.IsValid(), Is.False);
+        Assert.That(client.MetaData(entity).Flags & MetaDataFlags.Detached, Is.EqualTo(MetaDataFlags.None));
+
+        // Wait untill the client receives the parent entity
+        for (int i = 0; i < 10; i++)
+        {
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(1);
+        }
+
+        // now that the parent was received the entity should no longer be in nullspace.
+        Assert.That(cEntMan.TryGetEntity(last, out var newParent), Is.True);
+        Assert.That(client.Transform(entity).ParentUid.IsValid(), Is.True);
+        Assert.That(client.Transform(entity).ParentUid, Is.EqualTo(newParent));
+        Assert.That(client.MetaData(entity).Flags & MetaDataFlags.Detached, Is.EqualTo(MetaDataFlags.None));
+    }
+}
+


### PR DESCRIPTION
This makes transform state handling use `EnsureEntity()`, and reverts the bandaid fix from #4812.