### PR TITLE
Code cleanup: Dirty(Comp)

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Light.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Light.cs
@@ -11,13 +11,14 @@ public abstract partial class SharedMapSystem
 {
     public void SetAmbientLight(MapId mapId, Color color)
     {
-        var mapComp = EnsureComp<MapLightComponent>(MapManager.GetMapEntityId(mapId));
+        var mapUid = MapManager.GetMapEntityId(mapId);
+        var mapComp = EnsureComp<MapLightComponent>(mapUid);
 
         if (mapComp.AmbientLightColor.Equals(color))
             return;
 
         mapComp.AmbientLightColor = color;
-        Dirty(mapComp);
+        Dirty(mapUid, mapComp);
     }
 
     private void OnMapLightGetState(EntityUid uid, MapLightComponent component, ref ComponentGetState args)

--- a/Robust.Shared/Physics/Controllers/Gravity2DController.cs
+++ b/Robust.Shared/Physics/Controllers/Gravity2DController.cs
@@ -67,7 +67,7 @@ public sealed class Gravity2DController : VirtualController
 
         gravity.Gravity = value;
         WakeBodiesRecursive(uid, GetEntityQuery<TransformComponent>(), GetEntityQuery<PhysicsComponent>());
-        Dirty(gravity);
+        Dirty(uid, gravity);
     }
 
     public void SetGravity(MapId mapId, Vector2 value)
@@ -80,7 +80,7 @@ public sealed class Gravity2DController : VirtualController
 
         gravity.Gravity = value;
         WakeBodiesRecursive(mapUid, GetEntityQuery<TransformComponent>(), GetEntityQuery<PhysicsComponent>());
-        Dirty(gravity);
+        Dirty(mapUid, gravity);
     }
 
     private void WakeBodiesRecursive(EntityUid uid, EntityQuery<TransformComponent> xformQuery, EntityQuery<PhysicsComponent> bodyQuery)

--- a/Robust.Shared/Physics/Systems/FixtureSystem.cs
+++ b/Robust.Shared/Physics/Systems/FixtureSystem.cs
@@ -114,7 +114,7 @@ namespace Robust.Shared.Physics.Systems
                 // Don't need to dirty here as we'll just manually call it after (we 100% need to call it).
                 FixtureUpdate(uid, false, manager: manager, body: body);
                 // Don't need to ResetMassData as FixtureUpdate already does it.
-                Dirty(manager);
+                Dirty(uid, manager);
             }
             // TODO: Set newcontacts to true.
         }
@@ -361,7 +361,7 @@ namespace Robust.Shared.Physics.Systems
             }
 
             if (dirty)
-                Dirty(manager);
+                Dirty(uid, manager);
         }
 
         public int GetFixtureCount(EntityUid uid, FixturesComponent? manager = null)

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
@@ -99,9 +99,9 @@ public partial class SharedPhysicsSystem
         SetLinearVelocity(uid, newState.LinearVelocity, body: component, manager: manager);
         SetAngularVelocity(uid, newState.AngularVelocity, body: component, manager: manager);
         SetBodyType(uid, newState.BodyType, manager, component);
-        SetFriction(component, newState.Friction);
-        SetLinearDamping(component, newState.LinearDamping);
-        SetAngularDamping(component, newState.AngularDamping);
+        SetFriction(uid, component, newState.Friction);
+        SetLinearDamping(uid, component, newState.LinearDamping);
+        SetAngularDamping(uid, component, newState.AngularDamping);
     }
 
     #endregion
@@ -202,7 +202,7 @@ public partial class SharedPhysicsSystem
     /// <summary>
     /// Completely resets a dynamic body.
     /// </summary>
-    public void ResetDynamics(PhysicsComponent body, bool dirty = true)
+    public void ResetDynamics(EntityUid uid, PhysicsComponent body, bool dirty = true)
     {
         var updated = false;
 
@@ -231,7 +231,13 @@ public partial class SharedPhysicsSystem
         }
 
         if (updated && dirty)
-            Dirty(body);
+            Dirty(uid, body);
+    }
+
+    [Obsolete("Use overload that takes EntityUid")]
+    public void ResetDynamics(PhysicsComponent body, bool dirty = true)
+    {
+        ResetDynamics(body.Owner, body, dirty);
     }
 
     public void ResetMassData(EntityUid uid, FixturesComponent? manager = null, PhysicsComponent? body = null)
@@ -350,7 +356,7 @@ public partial class SharedPhysicsSystem
             Dirty(uid, body);
     }
 
-    public void SetAngularDamping(PhysicsComponent body, float value, bool dirty = true)
+    public void SetAngularDamping(EntityUid uid, PhysicsComponent body, float value, bool dirty = true)
     {
         if (MathHelper.CloseTo(body.AngularDamping, value))
             return;
@@ -358,10 +364,16 @@ public partial class SharedPhysicsSystem
         body.AngularDamping = value;
 
         if (dirty)
-            Dirty(body);
+            Dirty(uid, body);
     }
 
-    public void SetLinearDamping(PhysicsComponent body, float value, bool dirty = true)
+    [Obsolete("Use overload that takes EntityUid")]
+    public void SetAngularDamping(PhysicsComponent body, float value, bool dirty = true)
+    {
+        SetAngularDamping(body.Owner, body, value, dirty);
+    }
+
+    public void SetLinearDamping(EntityUid uid, PhysicsComponent body, float value, bool dirty = true)
     {
         if (MathHelper.CloseTo(body.LinearDamping, value))
             return;
@@ -369,7 +381,13 @@ public partial class SharedPhysicsSystem
         body.LinearDamping = value;
 
         if (dirty)
-            Dirty(body);
+            Dirty(uid, body);
+    }
+
+    [Obsolete("Use overload that takes EntityUid")]
+    public void SetLinearDamping(PhysicsComponent body, float value, bool dirty = true)
+    {
+        SetLinearDamping(body.Owner, body, value, dirty);
     }
 
     [Obsolete("Use SetAwake with EntityUid<PhysicsComponent>")]
@@ -403,7 +421,7 @@ public partial class SharedPhysicsSystem
         {
             var ev = new PhysicsSleepEvent(uid, body);
             RaiseLocalEvent(uid, ref ev, true);
-            ResetDynamics(body, dirty: false);
+            ResetDynamics(ent, body, dirty: false);
         }
 
         // Update wake system last, if sleeping but still colliding.
@@ -470,7 +488,7 @@ public partial class SharedPhysicsSystem
         }
     }
 
-    public void SetBodyStatus(PhysicsComponent body, BodyStatus status, bool dirty = true)
+    public void SetBodyStatus(EntityUid uid, PhysicsComponent body, BodyStatus status, bool dirty = true)
     {
         if (body.BodyStatus == status)
             return;
@@ -478,7 +496,13 @@ public partial class SharedPhysicsSystem
         body.BodyStatus = status;
 
         if (dirty)
-            Dirty(body);
+            Dirty(uid, body);
+    }
+
+    [Obsolete("Use overload that takes EntityUid")]
+    public void SetBodyStatus(PhysicsComponent body, BodyStatus status, bool dirty = true)
+    {
+        SetBodyStatus(body.Owner, body, status, dirty);
     }
 
     /// <summary>
@@ -549,7 +573,7 @@ public partial class SharedPhysicsSystem
             Dirty(uid, body);
     }
 
-    public void SetFriction(PhysicsComponent body, float value, bool dirty = true)
+    public void SetFriction(EntityUid uid, PhysicsComponent body, float value, bool dirty = true)
     {
         if (MathHelper.CloseTo(body.Friction, value))
             return;
@@ -557,10 +581,16 @@ public partial class SharedPhysicsSystem
         body._friction = value;
 
         if (dirty)
-            Dirty(body);
+            Dirty(uid, body);
     }
 
-    public void SetInertia(PhysicsComponent body, float value, bool dirty = true)
+    [Obsolete("Use overload that takes EntityUid")]
+    public void SetFriction(PhysicsComponent body, float value, bool dirty = true)
+    {
+        SetFriction(body.Owner, body, value, dirty);
+    }
+
+    public void SetInertia(EntityUid uid, PhysicsComponent body, float value, bool dirty = true)
     {
         DebugTools.Assert(!float.IsNaN(value));
 
@@ -575,8 +605,14 @@ public partial class SharedPhysicsSystem
             body.InvI = 1.0f / body._inertia;
 
             if (dirty)
-                Dirty(body);
+                Dirty(uid, body);
         }
+    }
+
+    [Obsolete("Use overload that takes EntityUid")]
+    public void SetInertia(PhysicsComponent body, float value, bool dirty = true)
+    {
+        SetInertia(body.Owner, body, value, dirty);
     }
 
     public void SetLocalCenter(EntityUid uid, PhysicsComponent body, Vector2 value)

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
@@ -132,7 +132,7 @@ public partial class SharedPhysicsSystem
 
         body.Force += force;
         body.Torque += Vector2Helpers.Cross(point - body._localCenter, force);
-        Dirty(body);
+        Dirty(uid, body);
     }
 
     public void ApplyForce(EntityUid uid, Vector2 force, FixturesComponent? manager = null, PhysicsComponent? body = null)
@@ -143,7 +143,7 @@ public partial class SharedPhysicsSystem
         }
 
         body.Force += force;
-        Dirty(body);
+        Dirty(uid, body);
     }
 
     public void ApplyTorque(EntityUid uid, float torque, FixturesComponent? manager = null, PhysicsComponent? body = null)
@@ -154,7 +154,7 @@ public partial class SharedPhysicsSystem
         }
 
         body.Torque += torque;
-        Dirty(body);
+        Dirty(uid, body);
     }
 
     public void ApplyLinearImpulse(EntityUid uid, Vector2 impulse, FixturesComponent? manager = null, PhysicsComponent? body = null)
@@ -261,7 +261,7 @@ public partial class SharedPhysicsSystem
         if (((int) body.BodyType & (int) (BodyType.Kinematic | BodyType.Static)) != 0)
         {
             body._localCenter = Vector2.Zero;
-            Dirty(body);
+            Dirty(uid, body);
             return;
         }
 
@@ -296,7 +296,7 @@ public partial class SharedPhysicsSystem
 
         // Update center of mass velocity.
         body.LinearVelocity += Vector2Helpers.Cross(body.AngularVelocity, localCenter - oldCenter);
-        Dirty(body);
+        Dirty(uid, body);
     }
 
     public void SetAngularVelocity(EntityUid uid, float value, bool dirty = true, FixturesComponent? manager = null, PhysicsComponent? body = null)
@@ -531,7 +531,7 @@ public partial class SharedPhysicsSystem
         }
 
         if (dirty)
-            Dirty(body);
+            Dirty(uid, body);
 
         return value;
     }
@@ -546,7 +546,7 @@ public partial class SharedPhysicsSystem
         ResetMassData(uid, manager: manager, body: body);
 
         if (dirty)
-            Dirty(body);
+            Dirty(uid, body);
     }
 
     public void SetFriction(PhysicsComponent body, float value, bool dirty = true)
@@ -599,7 +599,7 @@ public partial class SharedPhysicsSystem
         body.SleepingAllowed = value;
 
         if (dirty)
-            Dirty(body);
+            Dirty(uid, body);
     }
 
     public void SetSleepTime(PhysicsComponent body, float value)

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
@@ -1049,7 +1049,7 @@ public abstract partial class SharedPhysicsSystem
             }
 
             // TODO: Should check if the values update.
-            Dirty(body, metaQuery.GetComponent(uid));
+            Dirty(uid, body, metaQuery.GetComponent(uid));
         }
     }
 

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Shapes.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Shapes.cs
@@ -65,7 +65,7 @@ public abstract partial class SharedPhysicsSystem
             _lookup.CreateProxies(uid, fixtureId, fixture, xform, body);
         }
 
-        Dirty(manager);
+        Dirty(uid, manager);
     }
 
     public void SetPosition(
@@ -91,7 +91,7 @@ public abstract partial class SharedPhysicsSystem
             _lookup.CreateProxies(uid, fixtureId, fixture, xform, body);
         }
 
-        Dirty(manager);
+        Dirty(uid, manager);
     }
 
     #endregion


### PR DESCRIPTION
Replaces all uses of Dirty(Component) with Dirty(EntityUid, Component).

Most were simple. SharedPhysicsSystem needed some changes to public method signatures to take in EntityUids. The old method signatures call the new methods (with a gross use of component.Owner) and are marked Obsolete.