### PR TITLE
Code cleanup: Purge obsolete MapManager methods

### DIFF
--- a/Robust.Client/Console/Commands/Debug.cs
+++ b/Robust.Client/Console/Commands/Debug.cs
@@ -294,7 +294,6 @@ namespace Robust.Client.Console.Commands
     internal sealed class SnapGridGetCell : LocalizedCommands
     {
         [Dependency] private readonly IEntityManager _entManager = default!;
-        [Dependency] private readonly IMapManager _map = default!;
 
         public override string Command => "sggcell";
 
@@ -320,7 +319,7 @@ namespace Robust.Client.Console.Commands
                 return;
             }
 
-            if (_map.TryGetGrid(_entManager.GetEntity(gridNet), out var grid))
+            if (_entManager.TryGetComponent<MapGridComponent>(_entManager.GetEntity(gridNet), out var grid))
             {
                 foreach (var entity in grid.GetAnchoredEntities(new Vector2i(
                              int.Parse(indices.Split(',')[0], CultureInfo.InvariantCulture),
@@ -429,7 +428,6 @@ namespace Robust.Client.Console.Commands
     internal sealed class GridTileCount : LocalizedCommands
     {
         [Dependency] private readonly IEntityManager _entManager = default!;
-        [Dependency] private readonly IMapManager _map = default!;
 
         public override string Command => "gridtc";
 
@@ -448,7 +446,7 @@ namespace Robust.Client.Console.Commands
                 return;
             }
 
-            if (_map.TryGetGrid(gridUid, out var grid))
+            if (_entManager.TryGetComponent<MapGridComponent>(gridUid, out var grid))
             {
                 shell.WriteLine(grid.GetAllTiles().Count().ToString());
             }

--- a/Robust.Client/Placement/Modes/AlignSnapgridBorder.cs
+++ b/Robust.Client/Placement/Modes/AlignSnapgridBorder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Numerics;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
 
 namespace Robust.Client.Placement.Modes
@@ -24,7 +25,7 @@ namespace Robust.Client.Placement.Modes
             SnapSize = 1f;
             if (gridIdOpt is EntityUid gridId && gridId.IsValid())
             {
-                Grid = pManager.MapManager.GetGrid(gridId);
+                Grid = pManager.EntityManager.GetComponent<MapGridComponent>(gridId);
                 SnapSize = Grid.TileSize; //Find snap size for the grid.
             }
             else

--- a/Robust.Client/Placement/Modes/AlignSnapgridCenter.cs
+++ b/Robust.Client/Placement/Modes/AlignSnapgridCenter.cs
@@ -56,7 +56,7 @@ namespace Robust.Client.Placement.Modes
             SnapSize = 1f;
             if (gridIdOpt is EntityUid gridId && gridId.IsValid())
             {
-                Grid = pManager.MapManager.GetGrid(gridId);
+                Grid = pManager.EntityManager.GetComponent<MapGridComponent>(gridId);
                 SnapSize = Grid.TileSize; //Find snap size for the grid.
             }
             else

--- a/Robust.Client/Placement/Modes/AlignTileAny.cs
+++ b/Robust.Client/Placement/Modes/AlignTileAny.cs
@@ -1,5 +1,6 @@
 ﻿using System.Numerics;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 
 namespace Robust.Client.Placement.Modes
 {
@@ -19,7 +20,7 @@ namespace Robust.Client.Placement.Modes
 
             var gridId = MouseCoords.GetGridUid(pManager.EntityManager);
 
-            if (!pManager.MapManager.TryGetGrid(gridId, out var mapGrid))
+            if (!pManager.EntityManager.TryGetComponent<MapGridComponent>(gridId, out var mapGrid))
                 return;
 
             CurrentTile = mapGrid.GetTileRef(MouseCoords);

--- a/Robust.Client/Placement/Modes/AlignTileDense.cs
+++ b/Robust.Client/Placement/Modes/AlignTileDense.cs
@@ -1,6 +1,7 @@
 ﻿using System.Numerics;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 
 namespace Robust.Client.Placement.Modes
 {
@@ -20,7 +21,7 @@ namespace Robust.Client.Placement.Modes
 
             if (gridIdOpt is EntityUid gridId && gridId.IsValid())
             {
-                var mapGrid = pManager.MapManager.GetGrid(gridId);
+                var mapGrid = pManager.EntityManager.GetComponent<MapGridComponent>(gridId);
                 tileSize = mapGrid.TileSize; //convert from ushort to float
             }
 

--- a/Robust.Client/Placement/Modes/AlignTileEmpty.cs
+++ b/Robust.Client/Placement/Modes/AlignTileEmpty.cs
@@ -2,6 +2,7 @@
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
 
 namespace Robust.Client.Placement.Modes
@@ -22,7 +23,7 @@ namespace Robust.Client.Placement.Modes
 
             if (gridIdOpt is EntityUid gridId && gridId.IsValid())
             {
-                var mapGrid = pManager.MapManager.GetGrid(gridId);
+                var mapGrid = pManager.EntityManager.GetComponent<MapGridComponent>(gridId);
                 CurrentTile = mapGrid.GetTileRef(MouseCoords);
                 tileSize = mapGrid.TileSize; //convert from ushort to float
             }

--- a/Robust.Client/Placement/Modes/AlignTileNonDense.cs
+++ b/Robust.Client/Placement/Modes/AlignTileNonDense.cs
@@ -1,6 +1,7 @@
 ﻿using System.Numerics;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 
 namespace Robust.Client.Placement.Modes
 {
@@ -20,7 +21,7 @@ namespace Robust.Client.Placement.Modes
             var gridIdOpt = MouseCoords.GetGridUid(pManager.EntityManager);
             if (gridIdOpt is EntityUid gridId && gridId.IsValid())
             {
-                var mapGrid = pManager.MapManager.GetGrid(gridId);
+                var mapGrid = pManager.EntityManager.GetComponent<MapGridComponent>(gridId);
                 tileSize = mapGrid.TileSize; //convert from ushort to float
             }
 

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -21,6 +21,7 @@ using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Robust.Shared.Log;
 using Direction = Robust.Shared.Maths.Direction;
+using Robust.Shared.Map.Components;
 
 namespace Robust.Client.Placement
 {
@@ -332,7 +333,7 @@ namespace Robust.Client.Placement
 
         private void HandleTileChanged(ref TileChangedEvent args)
         {
-            var coords = MapManager.GetGrid(args.NewTile.GridUid).GridTileToLocal(args.NewTile.GridIndices);
+            var coords = EntityManager.GetComponent<MapGridComponent>(args.NewTile.GridUid).GridTileToLocal(args.NewTile.GridIndices);
             _pendingTileChanges.RemoveAll(c => c.Item1 == coords);
         }
 
@@ -753,7 +754,7 @@ namespace Robust.Client.Placement
                 // If we have actually placed something on a valid grid...
                 if (gridIdOpt is EntityUid gridId && gridId.IsValid())
                 {
-                    var grid = MapManager.GetGrid(gridId);
+                    var grid = EntityManager.GetComponent<MapGridComponent>(gridId);
 
                     // no point changing the tile to the same thing.
                     if (grid.GetTileRef(coordinates).Tile.TypeId == CurrentPermission.TileType)

--- a/Robust.Client/Placement/PlacementMode.cs
+++ b/Robust.Client/Placement/PlacementMode.cs
@@ -11,6 +11,7 @@ using Robust.Shared.Graphics;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Utility;
@@ -193,7 +194,7 @@ namespace Robust.Client.Placement
         public TileRef GetTileRef(EntityCoordinates coordinates)
         {
             var gridUidOpt = coordinates.GetGridUid(pManager.EntityManager);
-            return gridUidOpt is EntityUid gridUid && gridUid.IsValid() ? pManager.MapManager.GetGrid(gridUid).GetTileRef(MouseCoords)
+            return gridUidOpt is EntityUid gridUid && gridUid.IsValid() ? pManager.EntityManager.GetComponent<MapGridComponent>(gridUid).GetTileRef(MouseCoords)
                 : new TileRef(gridUidOpt ?? EntityUid.Invalid,
                     MouseCoords.ToVector2i(pManager.EntityManager, pManager.MapManager), Tile.Empty);
         }

--- a/Robust.Server/Physics/GridFixtureSystem.cs
+++ b/Robust.Server/Physics/GridFixtureSystem.cs
@@ -236,7 +236,7 @@ namespace Robust.Server.Physics
                 grids.Add(foundSplits);
             }
 
-            var oldGrid = _mapManager.GetGrid(uid);
+            var oldGrid = Comp<MapGridComponent>(uid);
             var oldGridUid = uid;
 
             // Split time
@@ -605,7 +605,7 @@ namespace Robust.Server.Physics
 
             DebugTools.Assert(chunk.FilledTiles > 0);
 
-            var grid = _mapManager.GetGrid(gridEuid);
+            var grid = Comp<MapGridComponent>(gridEuid);
             var group = CreateNodes(gridEuid, grid, chunk);
             _nodes[gridEuid][chunk.Indices] = group;
 

--- a/Robust.Shared.Scripting/ScriptGlobalsShared.cs
+++ b/Robust.Shared.Scripting/ScriptGlobalsShared.cs
@@ -67,12 +67,12 @@ namespace Robust.Shared.Scripting
 
         public MapGridComponent getgrid(int i)
         {
-            return map.GetGrid(new EntityUid(i));
+            return ent.GetComponent<MapGridComponent>(new EntityUid(i));
         }
 
         public MapGridComponent getgrid(EntityUid mapId)
         {
-            return map.GetGrid(mapId);
+            return ent.GetComponent<MapGridComponent>(mapId);
         }
 
         public T res<T>()

--- a/Robust.Shared/Console/Commands/MapCommands.cs
+++ b/Robust.Shared/Console/Commands/MapCommands.cs
@@ -84,7 +84,7 @@ sealed class RemoveGridCommand : LocalizedCommands
 
         var gridIdNet = NetEntity.Parse(args[0]);
 
-        if (!_entManager.TryGetEntity(gridIdNet, out var gridId) || !_map.GridExists(gridId))
+        if (!_entManager.TryGetEntity(gridIdNet, out var gridId) || !_entManager.HasComponent<MapGridComponent>(gridId))
         {
             shell.WriteError($"Grid {gridId} does not exist.");
             return;

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -80,7 +80,7 @@ namespace Robust.Shared.GameObjects
         /// </remarks>
         private void DeparentAllEntsOnTile(EntityUid gridId, Vector2i tileIndices)
         {
-            if (!TryComp(gridId, out BroadphaseComponent? lookup) || !_mapManager.TryGetGrid(gridId, out var grid))
+            if (!TryComp(gridId, out BroadphaseComponent? lookup) || !TryComp<MapGridComponent>(gridId, out var grid))
                 return;
 
             if (!XformQuery.TryGetComponent(gridId, out var gridXform))

--- a/Robust.Shared/Map/CoordinatesExtensions.cs
+++ b/Robust.Shared/Map/CoordinatesExtensions.cs
@@ -15,7 +15,7 @@ namespace Robust.Shared.Map
             var gridId = coords.GetGridUid(entityManager);
             var mapSystem = entityManager.System<SharedMapSystem>();
 
-            if (mapManager.TryGetGrid(gridId, out var mapGrid))
+            if (entityManager.TryGetComponent<MapGridComponent>(gridId, out var mapGrid))
             {
                 return mapSystem.GridTileToLocal(gridId.Value, mapGrid, mapSystem.CoordinatesToTile(gridId.Value, mapGrid, coords));
             }

--- a/Robust.Shared/Map/EntityCoordinates.cs
+++ b/Robust.Shared/Map/EntityCoordinates.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
@@ -200,7 +201,7 @@ namespace Robust.Shared.Map
             var gridIdOpt = GetGridUid(entityManager);
             if (gridIdOpt is { } gridId && gridId.IsValid())
             {
-                var grid = mapManager.GetGrid(gridId);
+                var grid = entityManager.GetComponent<MapGridComponent>(gridId);
                 return mapSystem.GetTileRef(gridId, grid, this).GridIndices;
             }
 

--- a/Robust.Shared/Map/MapManager.GridCollection.cs
+++ b/Robust.Shared/Map/MapManager.GridCollection.cs
@@ -113,7 +113,7 @@ internal partial class MapManager
 #endif
 
         // Possible the grid was already deleted / is invalid
-        if (!TryGetGrid(euid, out var iGrid))
+        if (!EntityManager.TryGetComponent<MapGridComponent>(euid, out var iGrid))
         {
             DebugTools.Assert($"Calling {nameof(DeleteGrid)} with unknown uid {euid}.");
             return; // Silently fail on release

--- a/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
@@ -71,12 +72,11 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
-            var mapMan = sim.Resolve<IMapManager>();
 
             var coordinates = new MapCoordinates(new Vector2(7, 7), TestMapId);
 
             // can only be anchored to a tile
-            var grid = mapMan.GetGrid(gridId);
+            var grid = entMan.GetComponent<MapGridComponent>(gridId);
             grid.SetTile(grid.TileIndicesFor(coordinates), new Tile(1));
 
             var ent1 = entMan.SpawnEntity(null, coordinates); // this raises MoveEvent, subscribe after
@@ -196,12 +196,11 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
-            var mapMan = sim.Resolve<IMapManager>();
 
             var coordinates = new MapCoordinates(new Vector2(7, 7), TestMapId);
 
             // can only be anchored to a tile
-            var grid = mapMan.GetGrid(gridId);
+            var grid = entMan.GetComponent<MapGridComponent>(gridId);
             grid.SetTile(grid.TileIndicesFor(coordinates), new Tile(1));
 
             var traversal = entMan.System<SharedGridTraversalSystem>();
@@ -224,9 +223,8 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
-            var mapMan = sim.Resolve<IMapManager>();
 
-            var grid = mapMan.GetGrid(gridId);
+            var grid = entMan.GetComponent<MapGridComponent>(gridId);
             var ent1 = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(7, 7), TestMapId));
             var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, Tile.Empty);
@@ -247,9 +245,8 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
-            var mapMan = sim.Resolve<IMapManager>();
 
-            var grid = mapMan.GetGrid(gridId);
+            var grid = entMan.GetComponent<MapGridComponent>(gridId);
             var ent1 = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(7, 7), TestMapId));
             var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
@@ -274,14 +271,12 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
-            var mapMan = sim.Resolve<IMapManager>();
-            var xform = entMan.System<SharedTransformSystem>();
 
             // coordinates are already tile centered to prevent snapping and MoveEvent
             var coordinates = new MapCoordinates(new Vector2(7.5f, 7.5f), TestMapId);
 
             // can only be anchored to a tile
-            var grid = mapMan.GetGrid(gridId);
+            var grid = entMan.GetComponent<MapGridComponent>(gridId);
             grid.SetTile(grid.TileIndicesFor(coordinates), new Tile(1));
 
             var ent1 = entMan.SpawnEntity(null, coordinates); // this raises MoveEvent, subscribe after
@@ -308,7 +303,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
 
             var coordinates = new MapCoordinates(new Vector2(7, 7), TestMapId);
 
-            var grid = mapMan.GetGrid(gridId);
+            var grid = entMan.GetComponent<MapGridComponent>(gridId);
 
             var ent1 = entMan.SpawnEntity(null, coordinates);
             var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
@@ -333,9 +328,8 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
-            var mapMan = sim.Resolve<IMapManager>();
 
-            var grid = mapMan.GetGrid(gridId);
+            var grid = entMan.GetComponent<MapGridComponent>(gridId);
             var ent1 = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(7, 7), TestMapId));
             var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
@@ -356,9 +350,8 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
-            var mapMan = sim.Resolve<IMapManager>();
 
-            var grid = mapMan.GetGrid(gridId);
+            var grid = entMan.GetComponent<MapGridComponent>(gridId);
             var ent1 = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(7, 7), TestMapId));
             var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
@@ -385,9 +378,8 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
-            var mapMan = sim.Resolve<IMapManager>();
 
-            var grid = mapMan.GetGrid(gridId);
+            var grid = entMan.GetComponent<MapGridComponent>(gridId);
             var ent1 = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(7, 7), TestMapId));
             var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
@@ -414,9 +406,8 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
-            var mapMan = sim.Resolve<IMapManager>();
 
-            var grid = mapMan.GetGrid(gridId);
+            var grid = entMan.GetComponent<MapGridComponent>(gridId);
             var ent1 = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(7, 7), TestMapId));
             var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
@@ -437,13 +428,12 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
-            var mapMan = sim.Resolve<IMapManager>();
             var physSystem = sim.Resolve<IEntitySystemManager>().GetEntitySystem<SharedPhysicsSystem>();
 
             var coordinates = new MapCoordinates(new Vector2(7, 7), TestMapId);
 
             // can only be anchored to a tile
-            var grid = mapMan.GetGrid(gridId);
+            var grid = entMan.GetComponent<MapGridComponent>(gridId);
             grid.SetTile(grid.TileIndicesFor(coordinates), new Tile(1));
 
             var ent1 = entMan.SpawnEntity(null, coordinates);
@@ -464,9 +454,8 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
-            var mapMan = sim.Resolve<IMapManager>();
 
-            var grid = mapMan.GetGrid(gridId);
+            var grid = entMan.GetComponent<MapGridComponent>(gridId);
             var ent1 = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(7, 7), TestMapId));
             var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
@@ -487,9 +476,8 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
-            var mapMan = sim.Resolve<IMapManager>();
 
-            var grid = mapMan.GetGrid(gridId);
+            var grid = entMan.GetComponent<MapGridComponent>(gridId);
 
             // Act
             var ent1 = entMan.SpawnEntity("anchoredEnt", new MapCoordinates(new Vector2(7, 7), TestMapId));
@@ -508,9 +496,8 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
-            var mapMan = sim.Resolve<IMapManager>();
 
-            var grid = mapMan.GetGrid(gridId);
+            var grid = entMan.GetComponent<MapGridComponent>(gridId);
             var ent1 = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(7, 7), TestMapId));
             var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
@@ -542,7 +529,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             var coordinates = new MapCoordinates(new Vector2(7, 7), TestMapId);
 
             // can only be anchored to a tile
-            var grid = mapMan.GetGrid(gridId);
+            var grid = entMan.GetComponent<MapGridComponent>(gridId);
             grid.SetTile(grid.TileIndicesFor(coordinates), new Tile(1));
 
             var traversal = entMan.System<SharedGridTraversalSystem>();
@@ -565,12 +552,11 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
-            var mapMan = sim.Resolve<IMapManager>();
 
             var coordinates = new MapCoordinates(new Vector2(7, 7), TestMapId);
 
             // can only be anchored to a tile
-            var grid = mapMan.GetGrid(gridId);
+            var grid = entMan.GetComponent<MapGridComponent>(gridId);
             grid.SetTile(grid.TileIndicesFor(coordinates), new Tile(1));
             var ent1 = entMan.SpawnEntity("anchoredEnt", grid.MapToGrid(coordinates));
 

--- a/Robust.UnitTesting/Shared/Map/MapManager_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/MapManager_Tests.cs
@@ -44,6 +44,7 @@ namespace Robust.UnitTesting.Shared.Map
         {
             var sim = SimulationFactory();
             var mapMan = sim.Resolve<IMapManager>();
+            var entMan = sim.Resolve<IEntityManager>();
 
             var mapID = new MapId(11);
             mapMan.CreateMap(mapID);
@@ -51,7 +52,7 @@ namespace Robust.UnitTesting.Shared.Map
 
             mapMan.Restart();
 
-            Assert.That(mapMan.GridExists(grid), Is.False);
+            Assert.That(entMan.HasComponent<MapGridComponent>(grid), Is.False);
         }
 
         /// <summary>


### PR DESCRIPTION
Removes every use of obsolete MapManager methods (GetGrid, GridExists, and TryGetGrid), replacing them with appropriate EntityManager methods or their corresponding EntitySystem extension methods.

This is definitely low -hanging fruit on the code cleanup tree, but clearing out compiler warnings is always nice.