### PR TITLE
Code cleanup: Dirty(comp) followup

### DIFF
--- a/Robust.Server/Console/Commands/SpinCommand.cs
+++ b/Robust.Server/Console/Commands/SpinCommand.cs
@@ -66,7 +66,7 @@ public sealed class SpinCommand : LocalizedCommands
         }
 
         var physicsSystem = _entities.System<SharedPhysicsSystem>();
-        physicsSystem.SetAngularDamping(physics, drag);
+        physicsSystem.SetAngularDamping(target.Value, physics, drag);
         physicsSystem.SetAngularVelocity(target.Value, speed, body: physics);
     }
 }

--- a/Robust.UnitTesting/Shared/Physics/Stack_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Stack_Test.cs
@@ -207,7 +207,7 @@ public sealed class PhysicsTestBedTest : RobustIntegrationTest
                     var circle = entityManager.AddComponent<PhysicsComponent>(circleUid);
                     var manager = entityManager.EnsureComponent<FixturesComponent>(circleUid);
 
-                    physSystem.SetLinearDamping(circle, 0.05f);
+                    physSystem.SetLinearDamping(circleUid, circle, 0.05f);
                     physSystem.SetBodyType(circleUid, BodyType.Dynamic, manager: manager, body: circle);
                     shape = new PhysShapeCircle(0.5f);
                     fixtureSystem.CreateFixture(circleUid, "fix1",  new Fixture(shape, 1, 1, true), manager: manager, body: circle);


### PR DESCRIPTION
A couple of the methods I marked as obsolete in #4979 were used elsewhere in Robust Toolbox, which I missed at the time.
This just cleans them up to use the new overloads.