### PR TITLE
Code cleanup: Purge calls to obsolete EntityCoordinates methods

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/InputSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/InputSystem.cs
@@ -26,6 +26,7 @@ namespace Robust.Client.GameObjects
         [Dependency] private readonly IConsoleHost _conHost = default!;
         [Dependency] private readonly IGameTiming _timing = default!;
         [Dependency] private readonly ILogManager _logManager = default!;
+        [Dependency] private readonly SharedTransformSystem _transform = default!;
 
         private ISawmill _sawmillInputContext = default!;
 
@@ -151,7 +152,7 @@ namespace Robust.Client.GameObjects
 
             var pxform = Transform(pent);
             var wPos = pxform.WorldPosition + new Vector2(float.Parse(args[2]), float.Parse(args[3]));
-            var coords = EntityCoordinates.FromMap(EntityManager, pent, new MapCoordinates(wPos, pxform.MapID));
+            var coords = EntityCoordinates.FromMap(pent, new MapCoordinates(wPos, pxform.MapID), _transform, EntityManager);
 
             var funcId = _inputManager.NetworkBindMap.KeyFunctionID(keyFunction);
 

--- a/Robust.Client/Placement/Modes/AlignSimilar.cs
+++ b/Robust.Client/Placement/Modes/AlignSimilar.cs
@@ -34,7 +34,7 @@ namespace Robust.Client.Placement.Modes
 
             var snapToEntities = EntitySystem.Get<EntityLookupSystem>().GetEntitiesInRange(MouseCoords, SnapToRange)
                 .Where(entity => pManager.EntityManager.GetComponent<MetaDataComponent>(entity).EntityPrototype == pManager.CurrentPrototype && pManager.EntityManager.GetComponent<TransformComponent>(entity).MapID == mapId)
-                .OrderBy(entity => (pManager.EntityManager.GetComponent<TransformComponent>(entity).WorldPosition - MouseCoords.ToMapPos(pManager.EntityManager)).LengthSquared())
+                .OrderBy(entity => (pManager.EntityManager.GetComponent<TransformComponent>(entity).WorldPosition - MouseCoords.ToMapPos(pManager.EntityManager, pManager.EntityManager.System<SharedTransformSystem>())).LengthSquared())
                 .ToList();
 
             if (snapToEntities.Count == 0)

--- a/Robust.Client/Placement/PlacementMode.cs
+++ b/Robust.Client/Placement/PlacementMode.cs
@@ -115,11 +115,12 @@ namespace Robust.Client.Placement
 
             var dirAng = pManager.Direction.ToAngle();
             var spriteSys = pManager.EntityManager.System<SpriteSystem>();
+            var transformSys = pManager.EntityManager.System<SharedTransformSystem>();
             foreach (var coordinate in locationcollection)
             {
                 if (!coordinate.IsValid(pManager.EntityManager))
                     return; // Just some paranoia just in case
-                var worldPos = coordinate.ToMapPos(pManager.EntityManager);
+                var worldPos = coordinate.ToMapPos(pManager.EntityManager, transformSys);
                 var worldRot = pManager.EntityManager.GetComponent<TransformComponent>(coordinate.EntityId).WorldRotation + dirAng;
 
                 sprite.Color = IsValidPosition(coordinate) ? ValidPlaceColor : InvalidPlaceColor;
@@ -136,11 +137,12 @@ namespace Robust.Client.Placement
         {
             var mouseScreen = pManager.InputManager.MouseScreenPosition;
             var mousePos = pManager.EyeManager.PixelToMap(mouseScreen);
+            var transformSys = pManager.EntityManager.System<SharedTransformSystem>();
 
             if (mousePos.MapId == MapId.Nullspace)
                 yield break;
 
-            var (_, (x, y)) = EntityCoordinates.FromMap(pManager.StartPoint.EntityId, mousePos, pManager.EntityManager) - pManager.StartPoint;
+            var (_, (x, y)) = EntityCoordinates.FromMap(pManager.StartPoint.EntityId, mousePos, transformSys, pManager.EntityManager) - pManager.StartPoint;
             float iterations;
             Vector2 distance;
             if (Math.Abs(x) > Math.Abs(y))
@@ -167,11 +169,12 @@ namespace Robust.Client.Placement
         {
             var mouseScreen = pManager.InputManager.MouseScreenPosition;
             var mousePos = pManager.EyeManager.PixelToMap(mouseScreen);
+            var transformSys = pManager.EntityManager.System<SharedTransformSystem>();
 
             if (mousePos.MapId == MapId.Nullspace)
                 yield break;
 
-            var placementdiff = EntityCoordinates.FromMap(pManager.StartPoint.EntityId, mousePos, pManager.EntityManager) - pManager.StartPoint;
+            var placementdiff = EntityCoordinates.FromMap(pManager.StartPoint.EntityId, mousePos, transformSys, pManager.EntityManager) - pManager.StartPoint;
 
             var xSign = Math.Sign(placementdiff.X);
             var ySign = Math.Sign(placementdiff.Y);
@@ -195,7 +198,7 @@ namespace Robust.Client.Placement
             var gridUidOpt = coordinates.GetGridUid(pManager.EntityManager);
             return gridUidOpt is EntityUid gridUid && gridUid.IsValid() ? pManager.MapManager.GetGrid(gridUid).GetTileRef(MouseCoords)
                 : new TileRef(gridUidOpt ?? EntityUid.Invalid,
-                    MouseCoords.ToVector2i(pManager.EntityManager, pManager.MapManager), Tile.Empty);
+                    MouseCoords.ToVector2i(pManager.EntityManager, pManager.MapManager, pManager.EntityManager.System<SharedTransformSystem>()), Tile.Empty);
         }
 
         public TextureResource GetSprite(string key)
@@ -223,7 +226,8 @@ namespace Robust.Client.Placement
             }
 
             var range = pManager.CurrentPermission!.Range;
-            if (range > 0 && !pManager.EntityManager.GetComponent<TransformComponent>(controlled).Coordinates.InRange(pManager.EntityManager, coordinates, range))
+            var transformSys = pManager.EntityManager.System<SharedTransformSystem>();
+            if (range > 0 && !pManager.EntityManager.GetComponent<TransformComponent>(controlled).Coordinates.InRange(pManager.EntityManager, transformSys, coordinates, range))
                 return false;
             return true;
         }
@@ -231,7 +235,8 @@ namespace Robust.Client.Placement
         public bool IsColliding(EntityCoordinates coordinates)
         {
             var bounds = pManager.ColliderAABB;
-            var mapCoords = coordinates.ToMap(pManager.EntityManager);
+            var transformSys = pManager.EntityManager.System<SharedTransformSystem>();
+            var mapCoords = coordinates.ToMap(pManager.EntityManager, transformSys);
             var (x, y) = mapCoords.Position;
 
             var collisionBox = Box2.FromDimensions(
@@ -261,7 +266,8 @@ namespace Robust.Client.Placement
                 return EntityCoordinates.FromMap(pManager.MapManager, mapCoords);
             }
 
-            return EntityCoordinates.FromMap(pManager.EntityManager, gridUid, mapCoords);
+            var transformSys = pManager.EntityManager.System<SharedTransformSystem>();
+            return EntityCoordinates.FromMap(gridUid, mapCoords, transformSys, pManager.EntityManager);
         }
     }
 }

--- a/Robust.Shared/Map/CoordinatesExtensions.cs
+++ b/Robust.Shared/Map/CoordinatesExtensions.cs
@@ -20,7 +20,8 @@ namespace Robust.Shared.Map
                 return mapSystem.GridTileToLocal(gridId.Value, mapGrid, mapSystem.CoordinatesToTile(gridId.Value, mapGrid, coords));
             }
 
-            var mapCoords = coords.ToMap(entityManager);
+            var transformSystem = entityManager.System<SharedTransformSystem>();
+            var mapCoords = coords.ToMap(entityManager, transformSystem);
 
             if (mapManager.TryFindGridAt(mapCoords, out var gridUid, out mapGrid))
             {

--- a/Robust.Shared/Map/EntityCoordinates.cs
+++ b/Robust.Shared/Map/EntityCoordinates.cs
@@ -110,7 +110,7 @@ namespace Robust.Shared.Map
         [Obsolete("Use ToMapPos() with TransformSystem overload")]
         public Vector2 ToMapPos(IEntityManager entityManager)
         {
-            return ToMap(entityManager).Position;
+            return ToMap(entityManager, entityManager.System<SharedTransformSystem>()).Position;
         }
 
         /// <summary>
@@ -160,7 +160,7 @@ namespace Robust.Shared.Map
         [Obsolete("Use overload with other parameter order.")]
         public static EntityCoordinates FromMap(IEntityManager entityManager, EntityUid entityUid, MapCoordinates coordinates)
         {
-            return FromMap(entityUid, coordinates, entityManager);
+            return FromMap(entityUid, coordinates, entityManager.System<SharedTransformSystem>(), entityManager);
         }
 
         /// <summary>

--- a/Robust.Shared/Player/Filter.cs
+++ b/Robust.Shared/Player/Filter.cs
@@ -64,7 +64,7 @@ namespace Robust.Shared.Player
         public Filter AddPlayersByPvs(EntityCoordinates origin, float rangeMultiplier = 2f, IEntityManager? entityMan = null, ISharedPlayerManager? playerMan = null)
         {
             IoCManager.Resolve(ref entityMan, ref playerMan);
-            return AddPlayersByPvs(origin.ToMap(entityMan), rangeMultiplier, entityMan, playerMan);
+            return AddPlayersByPvs(origin.ToMap(entityMan, entityMan.System<SharedTransformSystem>()), rangeMultiplier, entityMan, playerMan);
         }
 
         /// <summary>

--- a/Robust.UnitTesting/Shared/Map/EntityCoordinates_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/EntityCoordinates_Tests.cs
@@ -254,16 +254,18 @@ namespace Robust.UnitTesting.Shared.Map
             var entityManager = IoCManager.Resolve<IEntityManager>();
             var mapManager = IoCManager.Resolve<IMapManager>();
 
+            var transformSystem = entityManager.System<SharedTransformSystem>();
+
             var mapId = mapManager.CreateMap();
             var grid = mapManager.CreateGridEntity(mapId);
             var gridEnt = grid.Owner;
             var newEnt = entityManager.CreateEntityUninitialized(null, new EntityCoordinates(grid, entPos));
 
-            Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(newEnt).Coordinates.ToMap(entityManager), Is.EqualTo(new MapCoordinates(entPos, mapId)));
+            Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(newEnt).Coordinates.ToMap(entityManager, transformSystem), Is.EqualTo(new MapCoordinates(entPos, mapId)));
 
             IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(gridEnt).LocalPosition += gridPos;
 
-            Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(newEnt).Coordinates.ToMap(entityManager), Is.EqualTo(new MapCoordinates(entPos + gridPos, mapId)));
+            Assert.That(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(newEnt).Coordinates.ToMap(entityManager, transformSystem), Is.EqualTo(new MapCoordinates(entPos + gridPos, mapId)));
         }
 
         [Test]


### PR DESCRIPTION
Updated all calls to obsolete EntityCoordinates methods (ToMap, ToMapPos, FromMap, ToVector2i, InRange) to non-obsolete ones (by passing in SharedTransformSystem as an arg).