### PR TITLE
Lower default MTU to 900

### DIFF
--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -69,7 +69,7 @@ namespace Robust.Shared
         /// </summary>
         /// <seealso cref="NetMtuExpand"/>
         public static readonly CVarDef<int> NetMtu =
-            CVarDef.Create("net.mtu", 1000, CVar.ARCHIVE);
+            CVarDef.Create("net.mtu", 900, CVar.ARCHIVE);
 
         /// <summary>
         /// If set, automatically try to detect MTU above <see cref="NetMtu"/>.


### PR DESCRIPTION
Some players continue to have "stuck at connected" issues connecting to most servers, but apparently this issue has become more prominent in the last two weeks or so?

It is almost certainly an MTU problem because there are at least two servers on the hub that run a lower default MTU, and these players had no problem connecting to them. For one of these reporters, I actually increased the MTU to 1000 and they could no longer connect, and could connect again once it was lowered to 900.

It's not clear what recent changes, either to the codebase or to the public Internet that have been exercising this MTU issue more. For those experiencing MTU issues, it seems that connecting to a less full server results in higher probability of success.

Nevertheless, bringing down the default MTU and then possibly enabling MTU expansion in the future would make this game playable for a small but not insignificant bit of players.

[Implicitly approved by @PJB3005](https://discord.com/channels/310555209753690112/900426319433728030/1220198244672606208)