### PR TITLE
VV editor for EntProtoId?

### DIFF
--- a/Robust.Client/ViewVariables/ClientViewVariablesManager.cs
+++ b/Robust.Client/ViewVariables/ClientViewVariablesManager.cs
@@ -126,8 +126,12 @@ namespace Robust.Client.ViewVariables
                 return new VVPropEditorString();
             }
 
-            if (type == typeof(EntProtoId) ||
-                type == typeof(EntProtoId?))
+            if (type == typeof(EntProtoId?))
+            {
+                return new VVPropEditorNullableEntProtoId();
+            }
+
+            if (type == typeof(EntProtoId))
             {
                 return new VVPropEditorEntProtoId();
             }

--- a/Robust.Client/ViewVariables/Editors/VVPropEditorNullableEntProtoId.cs
+++ b/Robust.Client/ViewVariables/Editors/VVPropEditorNullableEntProtoId.cs
@@ -1,0 +1,35 @@
+﻿using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Prototypes;
+
+namespace Robust.Client.ViewVariables.Editors;
+
+internal sealed class VVPropEditorNullableEntProtoId : VVPropEditor
+{
+    protected override Control MakeUI(object? value)
+    {
+        var lineEdit = new LineEdit
+        {
+            Text = value is EntProtoId protoId ?  protoId.Id : "",
+            Editable = !ReadOnly,
+            HorizontalExpand = true,
+        };
+
+        if (!ReadOnly)
+        {
+            lineEdit.OnTextEntered += e =>
+            {
+                if (string.IsNullOrWhiteSpace(e.Text))
+                {
+                    ValueChanged(null);
+                }
+                else
+                {
+                    ValueChanged((EntProtoId) e.Text);
+                }
+            };
+        }
+
+        return lineEdit;
+    }
+}


### PR DESCRIPTION
I was fixing this: https://github.com/space-wizards/space-station-14/issues/26237

I noticed that there is at least one place that is only checking EntProtoId for null, and proceeding onward if it's not. That means that casting "" to an EntProtoId for EntProtoId? can result in a crash if you do it in VV. So to fix this rendering issue, and to prevent VV edited nullable EntProtoId's from causing a crash in a random system. I seperated the editor for the nullable EntProtoId, and the non-nullable EntProtoId.