### PR TITLE
Add helper command for Player toolshed commands

### DIFF
--- a/Robust.Server/Toolshed/Commands/Players/PlayersCommand.cs
+++ b/Robust.Server/Toolshed/Commands/Players/PlayersCommand.cs
@@ -69,6 +69,12 @@ public sealed class PlayerCommand : ToolshedCommand
     {
         return sessions.AttachedEntity ?? default;
     }
+
+    [CommandImplementation("entity")]
+    public EntityUid GetPlayerEntity([CommandInvocationContext] IInvocationContext ctx, [CommandArgument] string username)
+    {
+        return GetPlayerEntity(Immediate(ctx, username));
+    }
 }
 
 public record struct NoSuchPlayerError(string Username) : IConError


### PR DESCRIPTION
Allows you to invoke players:entity with a username to immediate get that player's attached entity(if any).

This is just a convenience to allow you to immediately get a player's attached entity with just their username instead of having to go through player:imm. 

For example:

"> player:imm "Gamer" player:entity laws:get" -> "> player:entity "Gamer" laws:get".