### PR TITLE
Fix uncaught overflow exception when parsing NetEntities from strings.

### DIFF
--- a/Robust.Shared/GameObjects/NetEntity.cs
+++ b/Robust.Shared/GameObjects/NetEntity.cs
@@ -68,7 +68,7 @@ public readonly struct NetEntity : IEquatable<NetEntity>, IComparable<NetEntity>
             entity = Parse(uid);
             return true;
         }
-        catch (FormatException)
+        catch (Exception ex) when (ex is FormatException || ex is OverflowException)
         {
             entity = Invalid;
             return false;

--- a/Robust.Shared/GameObjects/NetEntity.cs
+++ b/Robust.Shared/GameObjects/NetEntity.cs
@@ -68,7 +68,7 @@ public readonly struct NetEntity : IEquatable<NetEntity>, IComparable<NetEntity>
             entity = Parse(uid);
             return true;
         }
-        catch (Exception ex) when (ex is FormatException || ex is OverflowException)
+        catch (Exception ex) when (ex is FormatException or OverflowException)
         {
             entity = Invalid;
             return false;


### PR DESCRIPTION
Passing a string representing a number that can't fit in an Int32 to NetEntity.TryParse causes an OverflowException to be thrown by int.Parse, which isn't caught by the try/catch block. This could cause logic (like RenameCommand) to abort prematurely, and other possible problems.

This change catches the exception in NetEntity.TryParse and handles it the same way as it already handles FormatExceptions.