### PR TITLE
Handle queuedel contacts during collidecontacts

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Move DestroyContact handling for physics outside of the QueueDel subscriber to CollideContacts.
 
 ### Other
 

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
@@ -178,21 +178,6 @@ public abstract partial class SharedPhysicsSystem
             4096);
 
         InitializePool();
-        EntityManager.EntityQueueDeleted += OnContactEntityQueueDel;
-    }
-
-    private void ShutdownContacts()
-    {
-        EntityManager.EntityQueueDeleted -= OnContactEntityQueueDel;
-    }
-
-    private void OnContactEntityQueueDel(EntityUid obj)
-    {
-        // If an entity is queuedeleted then we want to purge its contacts before SimulateWorld runs in the same tick.
-        if (!TryComp<PhysicsComponent>(obj, out var physicsComp))
-            return;
-
-        DestroyContacts(physicsComp);
     }
 
     private void InitializePool()
@@ -391,6 +376,12 @@ public abstract partial class SharedPhysicsSystem
             var bodyB = contact.BodyB!;
             var uidA = contact.EntityA;
             var uidB = contact.EntityB;
+
+            if (EntityManager.IsQueuedForDeletion(uidA) || EntityManager.IsQueuedForDeletion(uidB))
+            {
+                DestroyContact(contact);
+                continue;
+            }
 
             // Do not try to collide disabled bodies
             if (!bodyA.CanCollide || !bodyB.CanCollide)

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
@@ -245,13 +245,6 @@ namespace Robust.Shared.Physics.Systems
             SetBodyType(guid, BodyType.Static, manager: manager, body: body);
         }
 
-        public override void Shutdown()
-        {
-            base.Shutdown();
-
-            ShutdownContacts();
-        }
-
         private void UpdateMapAwakeState(EntityUid uid, PhysicsComponent body)
         {
             if (Transform(uid).MapUid is not {} map)


### PR DESCRIPTION
Doing it inside of queuedel can get messy so better to just do it here, there's probably a reason I didn't do it here before but now with the additional flags issues should get picked up earlier.

Supercedes https://github.com/space-wizards/RobustToolbox/pull/4883 and still works with the content PR.