### PR TITLE
Add `TryComp` and `HasComp` to `EntityQuery<T>`

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -1454,6 +1454,24 @@ namespace Robust.Shared.GameObjects
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [Pure]
+        public bool TryComp(EntityUid uid, [NotNullWhen(true)] out TComp1? component)
+            => TryGetComponent(uid, out component);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Pure]
+        public bool TryComp(EntityUid? uid, [NotNullWhen(true)] out TComp1? component)
+            => TryGetComponent(uid, out component);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Pure]
+        public bool HasComp(EntityUid uid) => HasComponent(uid);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Pure]
+        public bool HasComp(EntityUid? uid) => HasComponent(uid);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Pure]
         public bool HasComponent(EntityUid uid)
         {
             return _traitDict.TryGetValue(uid, out var comp) && !comp.Deleted;


### PR DESCRIPTION
Just adds more compact aliases of `TryGetComponent` and `HasComponent` that get used in systems