### PR TITLE
Add length comparison helpers for Vector2

### DIFF
--- a/Robust.Shared.Maths/Vector2Helpers.cs
+++ b/Robust.Shared.Maths/Vector2Helpers.cs
@@ -60,6 +60,192 @@ public static class Vector2Helpers
     }
 
     /// <summary>
+    /// Compares the lengths of two vectors.
+    /// </summary>
+    /// <remarks>
+    /// Avoids square root computations by using squared lengths.
+    /// </remarks>
+    /// <returns>
+    /// a positive value if <paramref name="a"/> is longer than <paramref name="b"/>,
+    /// a negative value if <paramref name="b"/> is longer than <paramref name="a"/>,
+    /// or 0 if <paramref name="a"/> and <paramref name="b"/> have equal lengths.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float CompareLength(Vector2 a, Vector2 b)
+    {
+        return a.LengthSquared() - b.LengthSquared();
+    }
+
+    /// <summary>
+    /// Compares the length of a vector with a scalar.
+    /// </summary>
+    /// <remarks>
+    /// Avoids a square root computation by using squared length.
+    /// </remarks>
+    /// <returns>
+    /// a positive value if <paramref name="vec"/> is longer than <paramref name="scalar"/>,
+    /// a negative value if <paramref name="vec"/> is shorter than <paramref name="scalar"/>,
+    /// or 0 if <paramref name="vec"/> has a length equal to <paramref name="scalar"/>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float CompareLength(Vector2 vec, float scalar)
+    {
+        return vec.LengthSquared() - (scalar * scalar);
+    }
+
+    /// <summary>
+    /// Compares the length of this vector with a scalar.
+    /// </summary>
+    /// <remarks>
+    /// Avoids a square root computation by using squared length.
+    /// </remarks>
+    /// <returns>
+    /// a positive value if this vector is longer than <paramref name="scalar"/>,
+    /// a negative value if this vector is shorter than <paramref name="scalar"/>,
+    /// or 0 if this vector has a length equal to <paramref name="scalar"/>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float CompareLengthTo(this Vector2 vec, float scalar)
+    {
+        return CompareLength(vec, scalar);
+    }
+
+    /// <summary>
+    /// Compares the length of this vector with another.
+    /// </summary>
+    /// <remarks>
+    /// Avoids square root computations by using squared lengths.
+    /// </remarks>
+    /// <returns>
+    /// a positive value if this vector is longer than <paramref name="otherVec"/>,
+    /// a negative value if this vector is shorter than <paramref name="otherVec"/>,
+    /// or 0 if this vector and <paramref name="otherVec"/> have equal lengths.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float CompareLengthTo(this Vector2 thisVec, Vector2 otherVec)
+    {
+        return CompareLength(thisVec, otherVec);
+    }
+
+    /// <summary>
+    /// Is the length of this vector greater than <paramref name="scalar"/>?
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsLongerThan(this Vector2 vec, float scalar)
+    {
+        return CompareLength(vec, scalar) > 0;
+    }
+
+    /// <summary>
+    /// Is the length of this vector greater than the length of <paramref name="otherVec"/>?
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsLongerThan(this Vector2 thisVec, Vector2 otherVec)
+    {
+        return CompareLength(thisVec, otherVec) > 0;
+    }
+
+    /// <summary>
+    /// Is the length of this vector greater than or equal to <paramref name="scalar"/>?
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsLongerThanOrEqualTo(this Vector2 vec, float scalar)
+    {
+        return CompareLength(vec, scalar) >= 0;
+    }
+
+    /// <summary>
+    /// Is the length of this vector greater than or equal to the length of <paramref name="otherVec"/>?
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsLongerThanOrEqualTo(this Vector2 thisVec, Vector2 otherVec)
+    {
+        return CompareLength(thisVec, otherVec) >= 0;
+    }
+
+    /// <summary>
+    /// Is the length of this vector less than <paramref name="scalar"/>?
+    /// </summary>
+    /// <param name="vec"></param>
+    /// <param name="scalar"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsShorterThan(this Vector2 vec, float scalar)
+    {
+        return CompareLength(vec, scalar) < 0;
+    }
+
+    /// <summary>
+    /// Is the length of this vector less than the length of <paramref name="otherVec"/>?
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsShorterThan(this Vector2 thisVec, Vector2 otherVec)
+    {
+        return CompareLength(thisVec, otherVec) < 0;
+    }
+
+    /// <summary>
+    /// Is the length of this vector less than or equal to <paramref name="scalar"/>?
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsShorterThanOrEqualTo(this Vector2 vec, float scalar)
+    {
+        return CompareLength(vec, scalar) <= 0;
+    }
+
+    /// <summary>
+    /// Is the length of this vector less than or equal to the length of <paramref name="otherVec"/>?
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsShorterThanOrEqualTo(this Vector2 thisVec, Vector2 otherVec)
+    {
+        return CompareLength(thisVec, otherVec) <= 0;
+    }
+
+    /// <summary>
+    /// Returns true if this vector's length is equal to <paramref name="scalar"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool LengthEquals(this Vector2 thisVec, float scalar)
+    {
+        return CompareLength(thisVec, scalar) == 0;
+    }
+
+    /// <summary>
+    /// Is this vector the same length as <paramref name="otherVec"/>?
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsEqualLengthTo(this Vector2 thisVec, Vector2 otherVec)
+    {
+        return CompareLength(thisVec, otherVec) == 0;
+    }
+
+    /// <summary>
+    /// Compares the length of a vector with a scalar.
+    /// </summary>
+    /// <remarks>
+    /// Avoids a square root computation by using squared length.
+    /// </remarks>
+    /// <returns>
+    /// a positive value if <paramref name="vec"/> is shorter than <paramref name="scalar"/>,
+    /// a negative value if <paramref name="vec"/> is longer than <paramref name="scalar"/>,
+    /// or 0 if <paramref name="vec"/> has a length equal to <paramref name="scalar"/>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float CompareLength(float scalar, Vector2 vec)
+    {
+        return (scalar * scalar) - vec.LengthSquared();
+    }
+
+    /// <summary>
+    /// Is the length of this vector zero?
+    /// </summary>
+    public static bool IsLengthZero(this Vector2 vec)
+    {
+        return vec.LengthSquared() == 0;
+    }
+
+    /// <summary>
     /// Perform the cross product on a scalar and a vector. In 2D this produces
     /// a vector.
     /// </summary>


### PR DESCRIPTION
Adds a set of methods in Vector2Helpers for comparing the lengths of vectors without doing expensive square root calculations.

Old:
```C#
if (myVector.Length() > someFloat)
   return;

if (myVector.Length() <= myOtherVector.Length()
   return;
```

New:
```C#
if (myVector.IsLongerThan(someFloat))
   return;

if (myVector.IsShorterThanOrEqualTo(myOtherVector))
   return;
```

This is intended for use in space-wizards/space-station-14#26395 and future uses.

