### PR TITLE
Zstd Nuget Update

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,8 +7,8 @@
     <PackageVersion Include="JetBrains.Profiler.Api" Version="1.4.0" />
     <PackageVersion Include="Linguini.Bundle" Version="0.1.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.1"/>
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit" Version="1.1.1"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit" Version="1.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.8.0" />
@@ -44,7 +44,7 @@
     <PackageVersion Include="SQLitePCLRaw.provider.sqlite3" Version="2.1.7" />
     <PackageVersion Include="Serilog" Version="3.1.1" />
     <PackageVersion Include="Serilog.Sinks.Loki" Version="4.0.0-beta3" />
-    <PackageVersion Include="SharpZstd.Interop" Version="1.5.2-beta2" />
+    <PackageVersion Include="SharpZstd.Interop" Version="1.5.5-beta1" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.3" />
     <PackageVersion Include="SpaceWizards.HttpListener" Version="0.1.0" />
     <PackageVersion Include="SpaceWizards.NFluidsynth" Version="0.1.1" />


### PR DESCRIPTION
I updated the nuget, so I can start the client/server on my laptop (Mac M1). Without it I crash with a dylib error.
Any whitespace changes were done by rider. I figured it would be better to just let it have it's way with that.