### PR TITLE
Make sawmill levels work differently.

### DIFF
--- a/Robust.Shared/Log/LogManager.Sawmill.cs
+++ b/Robust.Shared/Log/LogManager.Sawmill.cs
@@ -77,6 +77,10 @@ namespace Robust.Shared.Log
                     return;
 
                 var msg = new LogEvent(DateTimeOffset.Now, level.ToSerilog(), exception, parsedTemplate, properties);
+
+                if (level < GetPracticalLevel())
+                    return;
+
                 LogInternal(Name, msg);
             }
 
@@ -99,11 +103,6 @@ namespace Robust.Shared.Log
 
             private void LogInternal(string sourceSawmill, LogEvent message)
             {
-                if (message.Level.ToRobust() < GetPracticalLevel())
-                {
-                    return;
-                }
-
                 _handlerLock.EnterReadLock();
                 try
                 {


### PR DESCRIPTION
Before, sawmill log levels were very clunky to use. We set the root sawmill to something like debug or info, but then it becomes impossible to specify specific sawmills to be verbose. This is because sawmills checked the log level at every part of the hierarchy when navigating "up" to find log handlers to write into.

This changes the behavior so that the filter log level is the FIRST set log level encountered on the hierarchy. This means the log level is compared only once, and a sawmill down the hierarchy that has a level like Verbose set can cause verbose messages to come up even if the root is still set to Debug. This matches the logging behavior in libraries such as ASP.NET Core.