### PR TITLE
Change default PVS LoD cvars

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,7 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* The `net.low_lod_distance` cvar has been replaced with a new `net.pvs_priority_range`. Instead of limiting the range at which all entities are sent to a player, it now extends the range at which high priorities can be sent. The default value of this new cvar is 32.5, which is larger than the default `net.pvs_range` value of 25.
 
 ### New features
 

--- a/Robust.Server/GameStates/PvsSystem.ToSendSet.cs
+++ b/Robust.Server/GameStates/PvsSystem.ToSendSet.cs
@@ -48,7 +48,7 @@ internal sealed partial class PvsSystem
         // We add chunk-size here so that its consistent with the normal PVS range setting.
         // I.e., distance here is the Chebyshev distance to the centre of each chunk, but the normal pvs range only
         // required that the chunk be touching the box, not the centre.
-        var count = distance < (_lowLodDistance + ChunkSize) / 2
+        var count = distance <=  (_viewSize + ChunkSize) / 2
             ? chunk.Contents.Count
             : chunk.LodCounts[0];
 

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -225,18 +225,24 @@ namespace Robust.Shared
             CVarDef.Create("net.pvs_async", true, CVar.ARCHIVE | CVar.SERVERONLY);
 
         /// <summary>
-        /// View size to take for PVS calculations,
-        /// as the size of the sides of a square centered on the view points of clients.
+        /// View size to take for PVS calculations, as the size of the sides of a square centered on the view points of
+        /// clients. See also <see cref="NetPvsPriorityRange"/>.
         /// </summary>
         public static readonly CVarDef<float> NetMaxUpdateRange =
             CVarDef.Create("net.pvs_range", 25f, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
 
         /// <summary>
-        /// Chunks whose centre is further than this distance away from a player's eye will contain fewer entities.
-        /// This has no effect if it is smaller than <see cref="NetMaxUpdateRange"/>
+        /// A variant of <see cref="NetMaxUpdateRange"/> that is used to limit the view-distance of entities with the
+        /// <see cref="MetaDataFlags.PvsPriority"/> flag set. This can be used to extend the range at which certain
+        /// entities become visible.
         /// </summary>
-        public static readonly CVarDef<float> NetLowLodRange =
-            CVarDef.Create("net.low_lod_distance", 100f, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
+        /// <remarks>
+        /// This is useful for entities like lights and occluders to try and prevent noticeable pop-in as players
+        /// move around. Note that this has no effect if it is less than <see cref="NetMaxUpdateRange"/>, and that this
+        /// only works for entities that are directly parented to a grid or map.
+        /// </remarks>
+        public static readonly CVarDef<float> NetPvsPriorityRange =
+            CVarDef.Create("net.pvs_priority_range", 32.5f, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
 
         /// <summary>
         /// Maximum allowed delay between the current tick and a client's last acknowledged tick before we send the


### PR DESCRIPTION
This PR renames the PVS LoD cvars that are meant to help reduce light/occluder pop-in, and changes the default values so that the feature is actually used. Instead of limiting/reducing the range at which pvs entities are sent, the cvar now extends the range, which IMO is more intuitive and will cause less issues for other systems that use the PVS range cvars (e.g., player filters for default audio ranges).

The new default values are enough to avoid light pop-in on the dev station, but are still small enough that it probably won't have a significant performance impact. I'm enabling it by default here instead of in the wizden configs because I assume its a feature that most servers want, but might not be aware of.

https://github.com/space-wizards/RobustToolbox/assets/60421075/ff531c8f-a12d-4e01-9cb3-2572fb8fd569
