### PR TITLE
Add an `EffectiveCurTime` for physics subticks

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Added `SharedPhysicsSystem.EffectiveCurTime`. This is effectively a variation of `IGameTiming.CurTime` that takes into account the current physics sub-step.
 
 ### Bugfixes
 

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
@@ -737,7 +737,7 @@ public partial class SharedPhysicsSystem
 
     public (int Layer, int Mask) GetHardCollision(EntityUid uid, FixturesComponent? manager = null)
     {
-        if (!Resolve(uid, ref manager))
+        if (!_fixturesQuery.Resolve(uid, ref manager, false))
         {
             return (0, 0);
         }

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
@@ -60,6 +60,8 @@ namespace Robust.Shared.Physics.Systems
 
         private int _substeps;
 
+        public TimeSpan? EffectiveCurTime;
+
         public bool MetricsEnabled { get; protected set; }
 
         private EntityQuery<FixturesComponent> _fixturesQuery;
@@ -284,6 +286,7 @@ namespace Robust.Shared.Physics.Systems
         {
             var frameTime = deltaTime / _substeps;
 
+            EffectiveCurTime = _gameTiming.CurTime;
             for (int i = 0; i < _substeps; i++)
             {
                 var updateBeforeSolve = new PhysicsUpdateBeforeSolveEvent(prediction, frameTime);
@@ -323,7 +326,11 @@ namespace Robust.Shared.Physics.Systems
                         FinalStep(comp);
                     }
                 }
+
+                EffectiveCurTime += TimeSpan.FromSeconds(frameTime);
             }
+
+            EffectiveCurTime = null;
         }
 
         protected virtual void FinalStep(PhysicsMapComponent component)

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
@@ -13,6 +13,7 @@ using Robust.Shared.Physics.Controllers;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Threading;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using DependencyAttribute = Robust.Shared.IoC.DependencyAttribute;
 
@@ -60,6 +61,10 @@ namespace Robust.Shared.Physics.Systems
 
         private int _substeps;
 
+        /// <summary>
+        /// A variation of <see cref="IGameTiming.CurTime"/> that takes into account the current physics sub-step.
+        /// Useful for some entities that need to interpolate their positions during sub-steps.
+        /// </summary>
         public TimeSpan? EffectiveCurTime;
 
         public bool MetricsEnabled { get; protected set; }


### PR DESCRIPTION
This PR adds a kind of `IGameTiming.CurTime` field to `SharedPhysicsSystem` that can be used during physics substeps. There might already be some way to do this that I just don't know about. 

I want this for an april fools PR, so its not strictly required, but it also shouldn't cause any problems?

Also changes a fixture system method to use the system's fixture query.