### PR TITLE
Rewrite the entire lighting architecture on accident (to add normalmaps)

### DIFF
--- a/Robust.Client/Graphics/AtlasTexture.cs
+++ b/Robust.Client/Graphics/AtlasTexture.cs
@@ -1,7 +1,9 @@
+using System.Numerics;
 using JetBrains.Annotations;
 using Robust.Shared.Graphics;
 using Robust.Shared.Maths;
 using Robust.Shared.Utility;
+using Vector3 = Robust.Shared.Maths.Vector3;
 
 namespace Robust.Client.Graphics
 {
@@ -33,7 +35,7 @@ namespace Robust.Client.Graphics
         /// </summary>
         public UIBox2 SubRegion { get; }
 
-        public override Color GetPixel(int x, int y)
+        public override (Color, Vector3) GetPixel(int x, int y)
         {
             DebugTools.Assert(x < SubRegion.Right);
             DebugTools.Assert(y < SubRegion.Top);

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -308,9 +308,9 @@ namespace Robust.Client.Graphics.Clyde
                 // Just do nothing on mutate.
             }
 
-            public override Color GetPixel(int x, int y)
+            public override (Color, Vector3) GetPixel(int x, int y)
             {
-                return Color.Black;
+                return (Color.Black, Vector3.UnitZ);
             }
         }
 

--- a/Robust.Client/Graphics/Texture.cs
+++ b/Robust.Client/Graphics/Texture.cs
@@ -32,7 +32,7 @@ public abstract class Texture : IRsiStateLike
     /// </summary>
     public Vector2i Size { get; /*protected set;*/ }
 
-    public Color this[int x, int y] => this.GetPixel(x, y);
+    public (Color, Vector3) this[int x, int y] => this.GetPixel(x, y);
 
     protected Texture(Vector2i size)
     {
@@ -66,7 +66,7 @@ public abstract class Texture : IRsiStateLike
         return this;
     }
 
-    public abstract Color GetPixel(int x, int y);
+    public abstract (Color, Vector3) GetPixel(int x, int y);
 
     public static Texture Transparent =>
                 IoCManager.Resolve<IClydeInternal>().GetStockTexture(ClydeStockTexture.Transparent);

--- a/Robust.Shared/Resources/RsiLoading.cs
+++ b/Robust.Shared/Resources/RsiLoading.cs
@@ -40,7 +40,7 @@ internal static class RsiLoading
         {
             var stateObject = manifestJson.States[stateI];
             var stateName = stateObject.Name;
-            var normalName = stateObject.NormalName;
+            var normalName = stateObject.Normal;
             int dirValue;
 
             if (stateObject.Directions is { } dirVal)
@@ -140,7 +140,7 @@ internal static class RsiLoading
     private sealed record RsiJsonMetadata(Vector2i Size, StateJsonMetadata[] States);
 
     [UsedImplicitly]
-    private sealed record StateJsonMetadata(string Name, string NormalName, int? Directions, float[][]? Delays);
+    private sealed record StateJsonMetadata(string Name, string Normal, int? Directions, float[][]? Delays);
 }
 
 [Serializable]

--- a/Robust.Shared/Resources/RsiLoading.cs
+++ b/Robust.Shared/Resources/RsiLoading.cs
@@ -40,6 +40,7 @@ internal static class RsiLoading
         {
             var stateObject = manifestJson.States[stateI];
             var stateName = stateObject.Name;
+            var normalName = stateObject.NormalName;
             int dirValue;
 
             if (stateObject.Directions is { } dirVal)
@@ -90,7 +91,7 @@ internal static class RsiLoading
                 }
             }
 
-            states[stateI] = new StateMetadata(stateName, dirValue, delays);
+            states[stateI] = new StateMetadata(stateName, normalName, dirValue, delays);
         }
 
         return new RsiMetadata(size, states);
@@ -118,12 +119,14 @@ internal static class RsiLoading
     internal sealed class StateMetadata
     {
         public readonly string StateId;
+        public readonly string NormalId;
         public readonly int DirCount;
         public readonly float[][] Delays;
 
-        public StateMetadata(string stateId, int dirCount, float[][] delays)
+        public StateMetadata(string stateId, string normalId, int dirCount, float[][] delays)
         {
             StateId = stateId;
+            NormalId = normalId;
             DirCount = dirCount;
 
             Delays = delays;
@@ -137,7 +140,7 @@ internal static class RsiLoading
     private sealed record RsiJsonMetadata(Vector2i Size, StateJsonMetadata[] States);
 
     [UsedImplicitly]
-    private sealed record StateJsonMetadata(string Name, int? Directions, float[][]? Delays);
+    private sealed record StateJsonMetadata(string Name, string NormalName, int? Directions, float[][]? Delays);
 }
 
 [Serializable]

--- a/Robust.Shared/Resources/RsiLoading.cs
+++ b/Robust.Shared/Resources/RsiLoading.cs
@@ -119,7 +119,7 @@ internal static class RsiLoading
     internal sealed class StateMetadata
     {
         public readonly string StateId;
-        public readonly string NormalId;
+        public readonly string? NormalId;
         public readonly int DirCount;
         public readonly float[][] Delays;
 


### PR DESCRIPTION
## Lighting be like.

- [ ] Hope that I suddenly learn how to OpenGL
- [x] Weep
- [ ] Do the bare minimum
- [ ] Hope I don't have to

## Normals be like.

- [ ] Put a place for normal maps in RSIs
- [x] Allow loading from file into RSIs
- [x] Have a default normal map (0, 0, 1)
- [ ] Try not to rework the entire lighting engine
- [ ] Do that thing where I painstakingly change every single thing that requires a texture
- [ ] Come up with a better idea than a tuple
- [ ] Make everything use a tuple for textures
- [ ] Make normals actually do stuff with lighting
- [ ] Make sure it actually runs good (probably gonna be fine)