### PR TITLE
Compress large networked entity events

### DIFF
--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -185,19 +185,19 @@ namespace Robust.Client.GameObjects
         }
 
         /// <inheritdoc />
-        public void SendSystemNetworkMessage(EntityEventArgs message, bool recordReplay = true)
+        public void SendSystemNetworkMessage(EntityEventArgs message, bool recordReplay = true, ZStdCompressionContext? ctx = null)
         {
-            SendSystemNetworkMessage(message, default(uint));
+            SendSystemNetworkMessage(message, default(uint), ctx);
         }
 
-        public void SendSystemNetworkMessage(EntityEventArgs message, uint sequence)
+        public void SendSystemNetworkMessage(EntityEventArgs message, uint sequence, ZStdCompressionContext? ctx = null)
         {
-            var msg = new MsgEntity(message, sequence, _gameTiming.CurTick, CompressionThreshold, CompressionCtx);
+            var msg = new MsgEntity(message, sequence, _gameTiming.CurTick, CompressionThreshold, ctx ?? CompressionCtx);
             _networkManager.ClientSendMessage(msg);
         }
 
         /// <inheritdoc />
-        public void SendSystemNetworkMessage(EntityEventArgs message, INetChannel? channel)
+        public void SendSystemNetworkMessage(EntityEventArgs message, INetChannel? channel, ZStdCompressionContext? ctx = null)
         {
             throw new NotSupportedException();
         }

--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -192,12 +192,7 @@ namespace Robust.Client.GameObjects
 
         public void SendSystemNetworkMessage(EntityEventArgs message, uint sequence)
         {
-            var msg = new MsgEntity();
-            msg.Type = EntityMessageType.SystemMessage;
-            msg.SystemMessage = message;
-            msg.SourceTick = _gameTiming.CurTick;
-            msg.Sequence = sequence;
-
+            var msg = new MsgEntity(message, sequence, _gameTiming.CurTick, CompressionThreshold, CompressionCtx);
             _networkManager.ClientSendMessage(msg);
         }
 
@@ -223,18 +218,11 @@ namespace Robust.Client.GameObjects
 
         private void DispatchReceivedNetworkMsg(MsgEntity message)
         {
-            switch (message.Type)
-            {
-                case EntityMessageType.SystemMessage:
-
-                    // TODO REPLAYS handle late messages.
-                    // If a message was received late, it will be recorded late here.
-                    // Maybe process the replay to prevent late messages when playing back?
-                    _replayRecording.RecordReplayMessage(message.SystemMessage);
-
-                    DispatchReceivedNetworkMsg(message.SystemMessage);
-                    return;
-            }
+            // TODO REPLAYS handle late messages.
+            // If a message was received late, it will be recorded late here.
+            // Maybe process the replay to prevent late messages when playing back?
+            _replayRecording.RecordReplayMessage(message.Event);
+            DispatchReceivedNetworkMsg(message.Event);
         }
 
         public void DispatchReceivedNetworkMsg(EntityEventArgs msg)

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -272,7 +272,7 @@ namespace Robust.Server.GameObjects
 #if EXCEPTION_TOLERANCE
             catch (Exception e)
             {
-                _runtimeLog.LogException(e, $"{nameof(DispatchEntityNetworkMessage)}({message.Type})");
+                _runtimeLog.LogException(e, $"{nameof(DispatchEntityNetworkMessage)}");
             }
 #endif
         }

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -205,25 +205,19 @@ namespace Robust.Server.GameObjects
         /// <inheritdoc />
         public void SendSystemNetworkMessage(EntityEventArgs message, bool recordReplay = true)
         {
-            var newMsg = new MsgEntity();
-            newMsg.Type = EntityMessageType.SystemMessage;
-            newMsg.SystemMessage = message;
-            newMsg.SourceTick = _gameTiming.CurTick;
+            var newMsg = new MsgEntity(message, default, _gameTiming.CurTick, CompressionThreshold, CompressionCtx);
 
             if (recordReplay)
                 _replay.RecordServerMessage(message);
 
+            // TODO NetMessage: NetSerialize & compress this message once, instead of once per-client.
             _networkManager.ServerSendToAll(newMsg);
         }
 
         /// <inheritdoc />
         public void SendSystemNetworkMessage(EntityEventArgs message, INetChannel targetConnection)
         {
-            var newMsg = new MsgEntity();
-            newMsg.Type = EntityMessageType.SystemMessage;
-            newMsg.SystemMessage = message;
-            newMsg.SourceTick = _gameTiming.CurTick;
-
+            var newMsg = new MsgEntity(message, default, _gameTiming.CurTick, CompressionThreshold, CompressionCtx);
             _networkManager.ServerSendMessage(newMsg, targetConnection);
         }
 
@@ -269,17 +263,11 @@ namespace Robust.Server.GameObjects
             try
 #endif
             {
-                switch (message.Type)
-                {
-                    case EntityMessageType.SystemMessage:
-                        var msg = message.SystemMessage;
-                        var sessionType = typeof(EntitySessionMessage<>).MakeGenericType(msg.GetType());
-                        var sessionMsg =
-                            Activator.CreateInstance(sessionType, new EntitySessionEventArgs(player), msg)!;
-                        ReceivedSystemMessage?.Invoke(this, msg);
-                        ReceivedSystemMessage?.Invoke(this, sessionMsg);
-                        return;
-                }
+                var msg = message.Event;
+                var sessionType = typeof(EntitySessionMessage<>).MakeGenericType(msg.GetType());
+                var sessionMsg = Activator.CreateInstance(sessionType, new EntitySessionEventArgs(player), msg)!;
+                ReceivedSystemMessage?.Invoke(this, msg);
+                ReceivedSystemMessage?.Invoke(this, sessionMsg);
             }
 #if EXCEPTION_TOLERANCE
             catch (Exception e)

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -203,9 +203,9 @@ namespace Robust.Server.GameObjects
         }
 
         /// <inheritdoc />
-        public void SendSystemNetworkMessage(EntityEventArgs message, bool recordReplay = true)
+        public void SendSystemNetworkMessage(EntityEventArgs message, bool recordReplay = true, ZStdCompressionContext? ctx = null)
         {
-            var newMsg = new MsgEntity(message, default, _gameTiming.CurTick, CompressionThreshold, CompressionCtx);
+            var newMsg = new MsgEntity(message, default, _gameTiming.CurTick, CompressionThreshold, ctx ?? CompressionCtx);
 
             if (recordReplay)
                 _replay.RecordServerMessage(message);
@@ -215,9 +215,9 @@ namespace Robust.Server.GameObjects
         }
 
         /// <inheritdoc />
-        public void SendSystemNetworkMessage(EntityEventArgs message, INetChannel targetConnection)
+        public void SendSystemNetworkMessage(EntityEventArgs message, INetChannel targetConnection, ZStdCompressionContext? ctx = null)
         {
-            var newMsg = new MsgEntity(message, default, _gameTiming.CurTick, CompressionThreshold, CompressionCtx);
+            var newMsg = new MsgEntity(message, default, _gameTiming.CurTick, CompressionThreshold, ctx ?? CompressionCtx);
             _networkManager.ServerSendMessage(newMsg, targetConnection);
         }
 

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -274,10 +274,16 @@ namespace Robust.Shared
             CVarDef.Create("net.pvs_exit_budget", 75, CVar.ARCHIVE | CVar.CLIENTONLY);
 
         /// <summary>
-        /// ZSTD compression level to use when compressing game states. Used by both networking and replays.
+        /// ZSTD compression level to use when compressing game states, networked messages, and replays.
         /// </summary>
         public static readonly CVarDef<int> NetPvsCompressLevel =
             CVarDef.Create("net.pvs_compress_level", 3, CVar.ARCHIVE);
+
+        /// <summary>
+        /// Minimum size (in bytes) for networked system events to get compressed.
+        /// </summary>
+        public static readonly CVarDef<int> NetEventCompressThreshold =
+            CVarDef.Create("net.event_compress_threshold", 1024, CVar.ARCHIVE);
 
         /// <summary>
         /// Log late input messages from clients.

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -226,10 +226,6 @@ namespace Robust.Shared.GameObjects
             ClearComponents();
             ShuttingDown = false;
             Started = false;
-
-            _compressionCtx?.Dispose();
-            _compressionCtx = default!;
-            _cfgMan.UnsubValueChanged(CVars.NetEventCompressThreshold, OnCompressThresholdChanged);
         }
 
         public virtual void Cleanup()
@@ -241,6 +237,10 @@ namespace Robust.Shared.GameObjects
             _eventBus.Dispose();
             _eventBus = null!;
             ClearComponents();
+
+            _compressionCtx?.Dispose();
+            _compressionCtx = default!;
+            _cfgMan.UnsubValueChanged(CVars.NetEventCompressThreshold, OnCompressThresholdChanged);
 
             ShuttingDown = false;
             Initialized = false;

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -227,7 +227,7 @@ namespace Robust.Shared.GameObjects
             ShuttingDown = false;
             Started = false;
 
-            _compressionCtx.Dispose();
+            _compressionCtx?.Dispose();
             _compressionCtx = default!;
             _cfgMan.UnsubValueChanged(CVars.NetEventCompressThreshold, OnCompressThresholdChanged);
         }

--- a/Robust.Shared/GameObjects/EntitySystem.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.cs
@@ -11,6 +11,7 @@ using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Reflection;
 using Robust.Shared.Replays;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.GameObjects
 {
@@ -114,19 +115,19 @@ namespace Robust.Shared.GameObjects
             EntityManager.EventBus.QueueEvent(EventSource.Local, message);
         }
 
-        protected void RaiseNetworkEvent(EntityEventArgs message)
+        protected void RaiseNetworkEvent(EntityEventArgs message, bool recordReplay = true, ZStdCompressionContext? ctx = null)
         {
-            EntityManager.EntityNetManager?.SendSystemNetworkMessage(message);
+            EntityManager.EntityNetManager?.SendSystemNetworkMessage(message, recordReplay, ctx);
         }
 
-        protected void RaiseNetworkEvent(EntityEventArgs message, INetChannel channel)
+        protected void RaiseNetworkEvent(EntityEventArgs message, INetChannel channel, ZStdCompressionContext? ctx = null)
         {
-            EntityManager.EntityNetManager?.SendSystemNetworkMessage(message, channel);
+            EntityManager.EntityNetManager?.SendSystemNetworkMessage(message, channel, ctx);
         }
 
-        protected void RaiseNetworkEvent(EntityEventArgs message, ICommonSession session)
+        protected void RaiseNetworkEvent(EntityEventArgs message, ICommonSession session, ZStdCompressionContext? ctx = null)
         {
-            EntityManager.EntityNetManager?.SendSystemNetworkMessage(message, session.Channel);
+            EntityManager.EntityNetManager?.SendSystemNetworkMessage(message, session.Channel, ctx);
         }
 
         /// <summary>

--- a/Robust.Shared/GameObjects/IEntityNetworkManager.cs
+++ b/Robust.Shared/GameObjects/IEntityNetworkManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Robust.Shared.Network;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.GameObjects
 {
@@ -26,9 +27,9 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         /// <param name="message">Message that should be sent.</param>
         /// <param name="recordReplay">Whether or not this message should be saved to replays.</param>
-        void SendSystemNetworkMessage(EntityEventArgs message, bool recordReplay = true);
+        void SendSystemNetworkMessage(EntityEventArgs message, bool recordReplay = true, ZStdCompressionContext? ctx = null);
 
-        void SendSystemNetworkMessage(EntityEventArgs message, uint sequence)
+        void SendSystemNetworkMessage(EntityEventArgs message, uint sequence, ZStdCompressionContext? ctx = null)
         {
             throw new NotSupportedException();
         }
@@ -42,6 +43,6 @@ namespace Robust.Shared.GameObjects
         /// <exception cref="NotSupportedException">
         ///    Thrown if called on the client.
         /// </exception>
-        void SendSystemNetworkMessage(EntityEventArgs message, INetChannel channel);
+        void SendSystemNetworkMessage(EntityEventArgs message, INetChannel channel, ZStdCompressionContext? ctx = null);
     }
 }

--- a/Robust.Shared/Network/CompressedNetMessage.cs
+++ b/Robust.Shared/Network/CompressedNetMessage.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Buffers;
+using Lidgren.Network;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Network;
+
+public abstract class CompressedNetMessage : NetMessage
+{
+    protected int ReadCompressed<T>(NetIncomingMessage buffer, IRobustSerializer serializer, out T obj, bool direct)
+    {
+        var uncompressedLength = buffer.ReadVariableInt32();
+        using var finalStream = RobustMemoryManager.GetMemoryStream(uncompressedLength);
+
+        if (uncompressedLength >= 0)
+        {
+            // Object is uncompressed.
+            buffer.ReadAlignedMemory(finalStream, uncompressedLength);
+            if (direct)
+                serializer.DeserializeDirect(finalStream, out obj);
+            else
+                obj = serializer.Deserialize<T>(finalStream);
+            return uncompressedLength;
+        }
+
+        // Negative uncompressed length implies that the object is compressed.
+        uncompressedLength = -uncompressedLength;
+        var compressedLength = buffer.ReadVariableInt32();
+
+        var stream = RobustMemoryManager.GetMemoryStream(compressedLength);
+        buffer.ReadAlignedMemory(stream, compressedLength);
+        using var decompressStream = new ZStdDecompressStream(stream);
+
+        finalStream.SetLength(uncompressedLength);
+        decompressStream.CopyTo(finalStream, uncompressedLength);
+        finalStream.Position = 0;
+
+        if (direct)
+            serializer.DeserializeDirect(finalStream, out obj);
+        else
+            obj = serializer.Deserialize<T>(finalStream);
+
+        return uncompressedLength;
+    }
+
+    protected int WriteCompressed<T>(
+        NetOutgoingMessage buffer,
+        IRobustSerializer serializer,
+        T obj,
+        int threshold,
+        ZStdCompressionContext? ctx,
+        bool direct)
+        where T : notnull
+    {
+        using var stateStream = RobustMemoryManager.GetMemoryStream();
+        if (direct)
+            serializer.SerializeDirect(stateStream, obj);
+        else
+            serializer.Serialize(stateStream, obj);
+
+        var uncompressedLength = (int) stateStream.Length;
+
+        if (stateStream.Length <= threshold)
+        {
+            buffer.WriteVariableInt32(uncompressedLength);
+            buffer.Write(stateStream.AsSpan());
+            return uncompressedLength;
+        }
+
+        // Negative uncompressed length implies that the object is compressed.
+        buffer.WriteVariableInt32(-uncompressedLength);
+        stateStream.Position = 0;
+        var buf = ArrayPool<byte>.Shared.Rent(ZStd.CompressBound((int)stateStream.Length));
+        var length = ctx?.Compress2(buf, stateStream.AsSpan()) ?? ZStd.Compress(buf, stateStream.AsSpan());
+
+        buffer.WriteVariableInt32(length);
+        buffer.Write(buf.AsSpan(0, length));
+
+        ArrayPool<byte>.Shared.Return(buf);
+        return uncompressedLength;
+    }
+}

--- a/Robust.UnitTesting/Server/GameObjects/ServerEntityNetworkManagerTest.cs
+++ b/Robust.UnitTesting/Server/GameObjects/ServerEntityNetworkManagerTest.cs
@@ -17,12 +17,12 @@ namespace Robust.UnitTesting.Server.GameObjects
             var tickA = new GameTick(5);
             var tickB = new GameTick(3);
             var channel = new Mock<INetChannel>().Object;
-            var msgA = new MsgEntity() {MsgChannel = channel, Type = EntityMessageType.SystemMessage, SourceTick = tickA, Sequence = 10};
-            var msgB = new MsgEntity() {MsgChannel = channel, Type = EntityMessageType.SystemMessage, SourceTick = tickA, Sequence = 13};
-            var msgC = new MsgEntity() {MsgChannel = channel, Type = EntityMessageType.SystemMessage, SourceTick = tickA, Sequence = 12};
-            var msgD = new MsgEntity() {MsgChannel = channel, Type = EntityMessageType.SystemMessage, SourceTick = tickA, Sequence = 14};
-            var msgE = new MsgEntity() {MsgChannel = channel, Type = EntityMessageType.SystemMessage, SourceTick = tickB, Sequence = 7};
-            var msgF = new MsgEntity() {MsgChannel = channel, Type = EntityMessageType.SystemMessage, SourceTick = tickB, Sequence = 4};
+            var msgA = new MsgEntity() {MsgChannel = channel, SourceTick = tickA, Sequence = 10};
+            var msgB = new MsgEntity() {MsgChannel = channel, SourceTick = tickA, Sequence = 13};
+            var msgC = new MsgEntity() {MsgChannel = channel, SourceTick = tickA, Sequence = 12};
+            var msgD = new MsgEntity() {MsgChannel = channel, SourceTick = tickA, Sequence = 14};
+            var msgE = new MsgEntity() {MsgChannel = channel, SourceTick = tickB, Sequence = 7};
+            var msgF = new MsgEntity() {MsgChannel = channel, SourceTick = tickB, Sequence = 4};
 
             var pq = new PriorityQueue<MsgEntity>(new ServerEntityManager.MessageSequenceComparer())
             {


### PR DESCRIPTION
This PR makes networked `EntityEventArgs` get automatically compressed if they are over 1024 bytes (game states currently get compressed above 256 bytes). This is probably useful for systems that consistently send easily compressible data (e.g., gas tile overlay), or just send large messages (e.g., some admin/debug overlays). 

I'm somewhat unsure about what to do in the case of multi-threaded message sending. `RaiseNetworkEvent` now takes in an optional `ZStdCompressionContext`, so callers could use something like the `PvsThreadResources` pool, but it defaults to using a `ThreadLocal<ZStdCompressionContext>`.

This PR also removes the `EntityMessageType` enum, seeing as it was unused, and I'm not sure what it was event meant to be used for.