### PR TITLE
Modify container/spawn helper methods

### DIFF
--- a/Robust.Shared/Containers/SharedContainerSystem.Insert.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.Insert.cs
@@ -136,6 +136,25 @@ public abstract partial class SharedContainerSystem
     }
 
     /// <summary>
+    /// Attempts to insert an entity into a container. If it fails, it will instead drop the entity next to the
+    /// container entity.
+    /// </summary>
+    /// <returns>Whether or not the entity was successfully inserted</returns>
+    public bool InsertOrDrop(Entity<TransformComponent?, MetaDataComponent?, PhysicsComponent?> toInsert,
+        BaseContainer container,
+        TransformComponent? containerXform = null)
+    {
+        if (!Resolve(toInsert.Owner, ref toInsert.Comp1) || !Resolve(container.Owner, ref containerXform))
+            return false;
+
+        if (Insert(toInsert, container, containerXform))
+            return true;
+
+        _transform.DropNextTo(toInsert, (container.Owner, containerXform));
+        return false;
+    }
+
+    /// <summary>
     /// Checks if the entity can be inserted into the given container.
     /// </summary>
     /// <param name="assumeEmpty">If true, this will check whether the entity could be inserted if the container were

--- a/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
@@ -46,7 +46,7 @@ public partial interface IEntityManager
     EntityUid SpawnAtPosition(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null);
 
     /// <summary>
-    /// Attempts to spawn an entity inside of a container.
+    /// Attempt to spawn an entity and insert it into a container. If the insertion fails, the entity gets deleted.
     /// </summary>
     bool TrySpawnInContainer(
         string? protoName,
@@ -58,9 +58,9 @@ public partial interface IEntityManager
 
     /// <summary>
     /// Attempts to spawn an entity inside of a container. If it fails to insert into the container, it will
-    /// instead attempt to spawn the entity next to the target.
+    /// instead drop the entity next to the target (see <see cref="SpawnNextToOrDrop"/>).
     /// </summary>
-    public EntityUid SpawnInContainerOrDrop(
+    EntityUid SpawnInContainerOrDrop(
         string? protoName,
         EntityUid containerUid,
         string containerId,
@@ -68,9 +68,20 @@ public partial interface IEntityManager
         ContainerManagerComponent? containerComp = null,
         ComponentRegistry? overrides = null);
 
+    /// <inheritdoc cref="SpawnInContainerOrDrop(string?,Robust.Shared.GameObjects.EntityUid,string,Robust.Shared.GameObjects.TransformComponent?,Robust.Shared.Containers.ContainerManagerComponent?,Robust.Shared.Prototypes.ComponentRegistry?)"/>
+    EntityUid SpawnInContainerOrDrop(
+        string? protoName,
+        EntityUid containerUid,
+        string containerId,
+        out bool inserted,
+        TransformComponent? xform = null,
+        ContainerManagerComponent? containerComp = null,
+        ComponentRegistry? overrides = null);
+
     /// <summary>
-    /// Attempts to spawn an entity adjacent to some other entity. If the other entity is in a container, this will
-    /// attempt to insert the new entity into the same container.
+    /// Attempts to spawn an entity adjacent to some other target entity. If the target entity is in
+    /// a container, this will attempt to insert the spawned entity into the same container. If the insertion fails,
+    /// the entity is deleted. If the entity is not in a container, this behaves like <see cref="SpawnNextToOrDrop"/>.
     /// </summary>
     bool TrySpawnNextTo(
         string? protoName,

--- a/Robust.UnitTesting/Shared/Spawning/TrySpawnNextToTest.cs
+++ b/Robust.UnitTesting/Shared/Spawning/TrySpawnNextToTest.cs
@@ -31,15 +31,14 @@ public sealed class TrySpawnNextToTest : EntitySpawnHelpersTest
             Assert.That(EntMan.EntityExists(uid), Is.False);
         });
 
-        // Spawning next to an entity that is not in a container will simply spawn it in the same position
+        // Spawning next to an entity that is not in a container will drop it
         await Server.WaitPost(() =>
         {
             Assert.That(EntMan.TrySpawnNextTo(null, GrandChildB, out var uid));
             Assert.That(EntMan.EntityExists(uid));
-            Assert.That(Xforms.GetParentUid(uid!.Value), Is.EqualTo(ChildB));
-            Assert.That(Container.IsEntityInContainer(uid.Value), Is.False);
+            Assert.That(Xforms.GetParentUid(uid!.Value), Is.EqualTo(Parent));
+            Assert.That(Container.IsEntityInContainer(uid.Value));
             Assert.That(Container.IsEntityOrParentInContainer(uid.Value));
-            Assert.That(EntMan.GetComponent<TransformComponent>(uid.Value).Coordinates, Is.EqualTo(GrandChildBPos));
         });
 
         // Spawning "next to" a nullspace entity will fail.


### PR DESCRIPTION
- Adds `ContainerSystem.InsertOrDrop()`, 
- Modifies `IEntityManager.TrySpawnNextTo()` so that its behaviour is the same as `SpawnNextToOrDrop()` if the target entity is not in a container.
- Adds a new `SpawnInContainerOrDrop()` override that returns a bool indicating whether the entity was successfully inserted into the specified container.