### PR TITLE
Remove uneccesary `Exists()` checks in container system

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -1138,7 +1138,7 @@ namespace Robust.Client.GameStates
                     if ((meta.Flags & MetaDataFlags.InContainer) != 0 &&
                         metas.TryGetComponent(xform.ParentUid, out var containerMeta) &&
                         (containerMeta.Flags & MetaDataFlags.Detached) == 0 &&
-                        containerSys.TryGetContainingContainer(xform.ParentUid, ent.Value, out container, null, true))
+                        containerSys.TryGetContainingContainer(xform.ParentUid, ent.Value, out container))
                     {
                         containerSys.Remove((ent.Value, xform, meta), container, false, true);
                     }
@@ -1414,7 +1414,7 @@ namespace Robust.Client.GameStates
                     _entities.TryGetComponent(xform.ParentUid, out MetaDataComponent? containerMeta) &&
                     (containerMeta.Flags & MetaDataFlags.Detached) == 0)
                 {
-                    containerSys.TryGetContainingContainer(xform.ParentUid, uid, out container, null, true);
+                    containerSys.TryGetContainingContainer(xform.ParentUid, uid, out container);
                 }
 
                 _entities.EntitySysManager.GetEntitySystem<TransformSystem>().DetachParentToNull(uid, xform);

--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -178,7 +178,7 @@ namespace Robust.Shared.Containers
 
         public bool TryGetContainingContainer(EntityUid uid, EntityUid containedUid, [NotNullWhen(true)] out BaseContainer? container, ContainerManagerComponent? containerManager = null)
         {
-            DebugTools.Assert(Exists(uid));
+            DebugTools.Assert(Exists(containedUid));
             if (!Resolve(uid, ref containerManager, false))
             {
                 container = null;
@@ -200,7 +200,7 @@ namespace Robust.Shared.Containers
 
         public bool ContainsEntity(EntityUid uid, EntityUid containedUid, ContainerManagerComponent? containerManager = null)
         {
-            DebugTools.Assert(Exists(uid));
+            DebugTools.Assert(Exists(containedUid));
             if (!Resolve(uid, ref containerManager, false))
                 return false;
 

--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -168,9 +168,18 @@ namespace Robust.Shared.Containers
             return containerManager.Containers.TryGetValue(id, out container);
         }
 
-        public bool TryGetContainingContainer(EntityUid uid, EntityUid containedUid, [NotNullWhen(true)] out BaseContainer? container, ContainerManagerComponent? containerManager = null, bool skipExistCheck = false)
+        [Obsolete("Use variant without skipExistCheck argument")]
+        public bool TryGetContainingContainer(EntityUid uid, EntityUid containedUid,
+            // ReSharper disable once MethodOverloadWithOptionalParameter
+            [NotNullWhen(true)] out BaseContainer? container, ContainerManagerComponent? containerManager = null, bool skipExistCheck = false)
         {
-            if (!Resolve(uid, ref containerManager, false) || !(skipExistCheck || Exists(containedUid)))
+            return TryGetContainingContainer(uid, containedUid, out container, containerManager);
+        }
+
+        public bool TryGetContainingContainer(EntityUid uid, EntityUid containedUid, [NotNullWhen(true)] out BaseContainer? container, ContainerManagerComponent? containerManager = null)
+        {
+            DebugTools.Assert(Exists(uid));
+            if (!Resolve(uid, ref containerManager, false))
             {
                 container = null;
                 return false;
@@ -191,7 +200,8 @@ namespace Robust.Shared.Containers
 
         public bool ContainsEntity(EntityUid uid, EntityUid containedUid, ContainerManagerComponent? containerManager = null)
         {
-            if (!Resolve(uid, ref containerManager, false) || !Exists(containedUid))
+            DebugTools.Assert(Exists(uid));
+            if (!Resolve(uid, ref containerManager, false))
                 return false;
 
             foreach (var container in containerManager.Containers.Values)
@@ -251,7 +261,7 @@ namespace Robust.Shared.Containers
             if (!Resolve(uid, ref transform, false))
                 return false;
 
-            return TryGetContainingContainer(transform.ParentUid, uid, out container, skipExistCheck: true);
+            return TryGetContainingContainer(transform.ParentUid, uid, out container);
         }
 
         /// <summary>

--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -169,11 +169,9 @@ namespace Robust.Shared.Containers
         }
 
         [Obsolete("Use variant without skipExistCheck argument")]
-        public bool TryGetContainingContainer(EntityUid uid, EntityUid containedUid,
-            // ReSharper disable once MethodOverloadWithOptionalParameter
-            [NotNullWhen(true)] out BaseContainer? container, ContainerManagerComponent? containerManager = null, bool skipExistCheck = false)
+        public bool TryGetContainingContainer(EntityUid uid, EntityUid containedUid, [NotNullWhen(true)] out BaseContainer? container, bool skipExistCheck)
         {
-            return TryGetContainingContainer(uid, containedUid, out container, containerManager);
+            return TryGetContainingContainer(uid, containedUid, out container);
         }
 
         public bool TryGetContainingContainer(EntityUid uid, EntityUid containedUid, [NotNullWhen(true)] out BaseContainer? container, ContainerManagerComponent? containerManager = null)

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -1453,8 +1453,7 @@ public abstract partial class SharedTransformSystem
         while (targetXform.ParentUid.IsValid())
         {
             if (_container.IsEntityInContainer(targetUid)
-                && _container.TryGetContainingContainer(targetXform.ParentUid, targetUid, out var container,
-                    skipExistCheck: true)
+                && _container.TryGetContainingContainer(targetXform.ParentUid, targetUid, out var container)
                 && _container.Insert((entity, xform, null, null), container))
             {
                 return;


### PR DESCRIPTION
As far as I can tell, this is just unnecessary code that was accidentally introduced in the IEntity purge. 