### PR TITLE
Add Type tracking to FieldNotFoundErrorNode

### DIFF
--- a/Robust.Shared/Serialization/Markdown/Validation/FieldNotFoundErrorNode.cs
+++ b/Robust.Shared/Serialization/Markdown/Validation/FieldNotFoundErrorNode.cs
@@ -5,7 +5,9 @@ namespace Robust.Shared.Serialization.Markdown.Validation;
 
 public sealed class FieldNotFoundErrorNode : ErrorNode
 {
+    public Type Type;
     public FieldNotFoundErrorNode(ValueDataNode key, Type type) : base(key, $"Field \"{key.Value}\" not found in \"{type}\".", false)
     {
+        Type = type;
     }
 }

--- a/Robust.Shared/Serialization/Markdown/Validation/FieldNotFoundErrorNode.cs
+++ b/Robust.Shared/Serialization/Markdown/Validation/FieldNotFoundErrorNode.cs
@@ -3,11 +3,10 @@ using Robust.Shared.Serialization.Markdown.Value;
 
 namespace Robust.Shared.Serialization.Markdown.Validation;
 
-public sealed class FieldNotFoundErrorNode : ErrorNode
+public sealed class FieldNotFoundErrorNode(ValueDataNode key, Type type) : ErrorNode(key, $"Field \"{key.Value}\" not found in \"{type}\".", false)
 {
-    public Type Type;
-    public FieldNotFoundErrorNode(ValueDataNode key, Type type) : base(key, $"Field \"{key.Value}\" not found in \"{type}\".", false)
-    {
-        Type = type;
-    }
+    /// <summary>
+    /// The Type in which the field was not found.
+    /// </summary>
+    public Type FieldType { get; } = type;
 }


### PR DESCRIPTION
FieldNotFoundErrorNode now stores the Type of the datadef that the error relates to (because the type does not have the field in question). This information was already being used as part of the error description; this change just makes the node keep a record of it for future use.

This is intended for use in a Content PR to improve the YAML linter.