### PR TITLE
Adds rotation to Map Position spawns

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Spawn.cs
@@ -87,7 +87,7 @@ public partial class EntityManager
     public EntityUid Spawn(string? protoName = null, ComponentRegistry? overrides = null)
         => Spawn(protoName, MapCoordinates.Nullspace, overrides);
 
-    public virtual EntityUid Spawn(string? protoName, MapCoordinates coordinates, ComponentRegistry? overrides = null, Angle rotation = new())
+    public virtual EntityUid Spawn(string? protoName, MapCoordinates coordinates, ComponentRegistry? overrides = null, Angle rotation = default!)
     {
         var entity = CreateEntityUninitialized(protoName, coordinates, overrides, rotation);
         InitializeAndStartEntity(entity, coordinates.MapId);

--- a/Robust.Shared/GameObjects/EntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Spawn.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Robust.Shared.Containers;
+using Robust.Shared.Maths;
 
 namespace Robust.Shared.GameObjects;
 
@@ -86,9 +87,9 @@ public partial class EntityManager
     public EntityUid Spawn(string? protoName = null, ComponentRegistry? overrides = null)
         => Spawn(protoName, MapCoordinates.Nullspace, overrides);
 
-    public virtual EntityUid Spawn(string? protoName, MapCoordinates coordinates, ComponentRegistry? overrides = null)
+    public virtual EntityUid Spawn(string? protoName, MapCoordinates coordinates, ComponentRegistry? overrides = null, Angle rotation = new())
     {
-        var entity = CreateEntityUninitialized(protoName, coordinates, overrides);
+        var entity = CreateEntityUninitialized(protoName, coordinates, overrides, rotation);
         InitializeAndStartEntity(entity, coordinates.MapId);
         return entity;
     }

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -9,6 +9,7 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Maths;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Profiling;
@@ -297,7 +298,7 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public virtual EntityUid CreateEntityUninitialized(string? prototypeName, MapCoordinates coordinates, ComponentRegistry? overrides = null)
+        public virtual EntityUid CreateEntityUninitialized(string? prototypeName, MapCoordinates coordinates, ComponentRegistry? overrides = null, Angle rotation = new())
         {
             var newEntity = CreateEntity(prototypeName, out _, overrides);
             var transform = TransformQuery.GetComponent(newEntity);
@@ -324,6 +325,7 @@ namespace Robust.Shared.GameObjects
             {
                 coords = new EntityCoordinates(mapEnt, coordinates.Position);
                 _xforms.SetCoordinates(newEntity, transform, coords, null, newParent: mapXform);
+                _xforms.SetWorldRotation(newEntity, rotation);
             }
 
             return newEntity;

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -298,7 +298,7 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public virtual EntityUid CreateEntityUninitialized(string? prototypeName, MapCoordinates coordinates, ComponentRegistry? overrides = null, Angle rotation = new())
+        public virtual EntityUid CreateEntityUninitialized(string? prototypeName, MapCoordinates coordinates, ComponentRegistry? overrides = null, Angle rotation = default!)
         {
             var newEntity = CreateEntity(prototypeName, out _, overrides);
             var transform = TransformQuery.GetComponent(newEntity);
@@ -324,8 +324,7 @@ namespace Robust.Shared.GameObjects
             else
             {
                 coords = new EntityCoordinates(mapEnt, coordinates.Position);
-                _xforms.SetCoordinates(newEntity, transform, coords, null, newParent: mapXform);
-                _xforms.SetWorldRotation(newEntity, rotation);
+                _xforms.SetCoordinates(newEntity, transform, coords, rotation, newParent: mapXform);
             }
 
             return newEntity;

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -710,7 +710,7 @@ public partial class EntitySystem
     /// <inheritdoc cref="IEntityManager.Spawn(string?, MapCoordinates, ComponentRegistry?)" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected EntityUid Spawn(string? prototype, MapCoordinates coordinates, Angle rotation = new())
-        => EntityManager.Spawn(prototype, coordinates);
+        => EntityManager.Spawn(prototype, coordinates, rotation: rotation);
 
     /// <inheritdoc cref="IEntityManager.Spawn(string?, ComponentRegistry?)" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -8,6 +8,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using TerraFX.Interop.Windows;
 
 namespace Robust.Shared.GameObjects;
 
@@ -709,7 +710,7 @@ public partial class EntitySystem
 
     /// <inheritdoc cref="IEntityManager.Spawn(string?, MapCoordinates, ComponentRegistry?)" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected EntityUid Spawn(string? prototype, MapCoordinates coordinates, Angle rotation = new())
+    protected EntityUid Spawn(string? prototype, MapCoordinates coordinates, Angle rotation = default!)
         => EntityManager.Spawn(prototype, coordinates, rotation: rotation);
 
     /// <inheritdoc cref="IEntityManager.Spawn(string?, ComponentRegistry?)" />

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
+using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -708,7 +709,7 @@ public partial class EntitySystem
 
     /// <inheritdoc cref="IEntityManager.Spawn(string?, MapCoordinates, ComponentRegistry?)" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected EntityUid Spawn(string? prototype, MapCoordinates coordinates)
+    protected EntityUid Spawn(string? prototype, MapCoordinates coordinates, Angle rotation = new())
         => EntityManager.Spawn(prototype, coordinates);
 
     /// <inheritdoc cref="IEntityManager.Spawn(string?, ComponentRegistry?)" />

--- a/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
@@ -33,7 +33,7 @@ public partial interface IEntityManager
     /// <summary>
     /// Spawns an entity at a specific world position. The entity will either be parented to the map or a grid.
     /// </summary>
-    EntityUid Spawn(string? protoName, MapCoordinates coordinates, ComponentRegistry? overrides = null, Angle rotation = new());
+    EntityUid Spawn(string? protoName, MapCoordinates coordinates, ComponentRegistry? overrides = null, Angle rotation = default!);
 
     /// <summary>
     /// Spawns an entity and then parents it to the entity that the given entity coordinates are relative to.

--- a/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
+using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
 
 namespace Robust.Shared.GameObjects;
@@ -32,7 +33,7 @@ public partial interface IEntityManager
     /// <summary>
     /// Spawns an entity at a specific world position. The entity will either be parented to the map or a grid.
     /// </summary>
-    EntityUid Spawn(string? protoName, MapCoordinates coordinates, ComponentRegistry? overrides = null);
+    EntityUid Spawn(string? protoName, MapCoordinates coordinates, ComponentRegistry? overrides = null, Angle rotation = new());
 
     /// <summary>
     /// Spawns an entity and then parents it to the entity that the given entity coordinates are relative to.

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -77,7 +77,7 @@ namespace Robust.Shared.GameObjects
 
         EntityUid CreateEntityUninitialized(string? prototypeName, EntityCoordinates coordinates, ComponentRegistry? overrides = null);
 
-        EntityUid CreateEntityUninitialized(string? prototypeName, MapCoordinates coordinates, ComponentRegistry? overrides = null, Angle rotation = new());
+        EntityUid CreateEntityUninitialized(string? prototypeName, MapCoordinates coordinates, ComponentRegistry? overrides = null, Angle rotation = default!);
 
         void InitializeAndStartEntity(EntityUid entity, MapId? mapId = null);
 

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 using Prometheus;
 using Robust.Shared.Map;
+using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -76,7 +77,7 @@ namespace Robust.Shared.GameObjects
 
         EntityUid CreateEntityUninitialized(string? prototypeName, EntityCoordinates coordinates, ComponentRegistry? overrides = null);
 
-        EntityUid CreateEntityUninitialized(string? prototypeName, MapCoordinates coordinates, ComponentRegistry? overrides = null);
+        EntityUid CreateEntityUninitialized(string? prototypeName, MapCoordinates coordinates, ComponentRegistry? overrides = null, Angle rotation = new());
 
         void InitializeAndStartEntity(EntityUid entity, MapId? mapId = null);
 


### PR DESCRIPTION
This is mostly for the Polymorph system so you can pass the parent polymorph's rotation to the child. Can be used in other applications at least.

Tested with polymorphing into a rod and using the rods linear velocity. I also tested the Tesla and lightning (beam system) behaves normally.

https://github.com/space-wizards/RobustToolbox/assets/54602815/39a7d227-7924-43f4-b5a5-e8e787966c5a

