### PR TITLE
Auth is now required by default

### DIFF
--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -851,7 +851,7 @@ namespace Robust.Shared
         /// See the documentation of the <see cref="Network.AuthMode"/> enum for values.
         /// </summary>
         public static readonly CVarDef<int> AuthMode =
-            CVarDef.Create("auth.mode", (int) Network.AuthMode.Optional, CVar.SERVERONLY);
+            CVarDef.Create("auth.mode", (int) Network.AuthMode.Required, CVar.SERVERONLY);
 
         /// <summary>
         /// Allow unauthenticated localhost connections, even if the auth mode is set to required.


### PR DESCRIPTION
Most people are going to be using authentication anyway.

I tested and launching a local environment will still let you join as normal. This will just make sure servers who forget to change the ``auth.mode`` to required don't get a nasty surprise later on