### PR TITLE
Fix RecursiveMapInit

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Fixes map initialisation not always initialising all entities on a map.
 
 ### Other
 

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.MapInit.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.MapInit.cs
@@ -8,8 +8,6 @@ namespace Robust.Shared.GameObjects;
 
 public abstract partial class SharedMapSystem
 {
-    private List<EntityUid> _toInitialize = new();
-
     public bool IsInitialized(MapId mapId)
     {
         if (mapId == MapId.Nullspace)
@@ -67,23 +65,19 @@ public abstract partial class SharedMapSystem
 
     private void RecursiveMapInit(EntityUid entity)
     {
-        _toInitialize.Clear();
-        _toInitialize.Add(entity);
-
-        for (var i = 0; i < _toInitialize.Count; i++)
+        var toInitialize = new List<EntityUid> {entity};
+        for (var i = 0; i < toInitialize.Count; i++)
         {
-            var uid = _toInitialize[i];
-            // _toInitialize might contain deleted entities.
+            var uid = toInitialize[i];
+            // toInitialize might contain deleted entities.
             if(!_metaQuery.TryComp(uid, out var meta))
                 continue;
 
             if (meta.EntityLifeStage == EntityLifeStage.MapInitialized)
                 continue;
 
-            _toInitialize.AddRange(Transform(uid)._children);
+            toInitialize.AddRange(Transform(uid)._children);
             EntityManager.RunMapInit(uid, meta);
         }
-
-        _toInitialize.Clear();
     }
 }

--- a/Robust.Shared/Map/MapManager.cs
+++ b/Robust.Shared/Map/MapManager.cs
@@ -19,7 +19,7 @@ internal partial class MapManager : IMapManagerInternal, IEntityEventSubscriber
 
     [Dependency] private readonly IConsoleHost _conhost = default!;
 
-    private ISawmill _sawmill = default!;
+    private ISawmill _sawmill => _mapSystem.Log;
 
     private SharedMapSystem _mapSystem = default!;
     private SharedPhysicsSystem _physics = default!;
@@ -33,9 +33,6 @@ internal partial class MapManager : IMapManagerInternal, IEntityEventSubscriber
     {
         _gridTreeQuery = EntityManager.GetEntityQuery<GridTreeComponent>();
         _gridQuery = EntityManager.GetEntityQuery<MapGridComponent>();
-
-        _sawmill = Logger.GetSawmill("map");
-
         InitializeMapPausing();
     }
 


### PR DESCRIPTION
Also changes the mapmanager sawmill to use the same sawmill as the system, so you only need to configure one log level.