### PR TITLE
Fix yaml linter & improve validation of static fields

### DIFF
--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Robust.Shared.Random;
+using Robust.Shared.Reflection;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Serialization.Markdown;
@@ -272,7 +273,8 @@ public interface IPrototypeManager
         out Dictionary<Type, HashSet<string>> prototypes);
 
     /// <summary>
-    /// This method uses reflection to validate that prototype id fields correspond to valid prototypes.
+    /// This method uses reflection to validate that all static prototype id fields correspond to valid prototypes.
+    /// This will validate all known to <see cref="IReflectionManager"/>
     /// </summary>
     /// <remarks>
     /// This will validate any field that has either a <see cref="ValidatePrototypeIdAttribute{T}"/> attribute, or a
@@ -280,7 +282,12 @@ public interface IPrototypeManager
     /// </remarks>
     /// <param name="prototypes">A collection prototypes to use for validation. Any prototype not in this collection
     /// will be considered invalid.</param>
-    List<string> ValidateFields(Dictionary<Type, HashSet<string>> prototypes);
+    List<string> ValidateStaticFields(Dictionary<Type, HashSet<string>> prototypes);
+
+    /// <summary>
+    /// This is a variant of <see cref="ValidateStaticFields(System.Collections.Generic.Dictionary{System.Type,System.Collections.Generic.HashSet{string}})"/> that only validates a single type.
+    /// </summary>
+    List<string> ValidateStaticFields(Type type, Dictionary<Type, HashSet<string>> prototypes);
 
     /// <summary>
     /// This method will serialize all loaded prototypes into yaml and then validate them. This can be used to ensure

--- a/Robust.Shared/Prototypes/PrototypeManager.ValidateFields.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.ValidateFields.cs
@@ -4,7 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Utility;
 using BindingFlags = System.Reflection.BindingFlags;
 
@@ -13,35 +12,41 @@ namespace Robust.Shared.Prototypes;
 public partial class PrototypeManager
 {
     /// <inheritdoc/>
-    public List<string> ValidateFields(Dictionary<Type, HashSet<string>> prototypes)
+    public List<string> ValidateStaticFields(Dictionary<Type, HashSet<string>> prototypes)
     {
         var errors = new List<string>();
         foreach (var type in _reflectionManager.FindAllTypes())
         {
             // TODO validate public static fields on abstract classes that have no implementations?
             if (!type.IsAbstract)
-                ValidateType(type, errors, prototypes);
+                ValidateStaticFieldsInternal(type, errors, prototypes);
         }
 
         return errors;
     }
 
-    /// <summary>
-    /// Validate all fields defined on this type and all base types.
-    /// </summary>
-    private void ValidateType(Type type, List<string> errors, Dictionary<Type, HashSet<string>> prototypes)
+    /// <inheritdoc/>
+    public List<string> ValidateStaticFields(Type type, Dictionary<Type, HashSet<string>> prototypes)
     {
-        object? instance = null;
-        Type? baseType = type;
+        var errors = new List<string>();
+        ValidateStaticFieldsInternal(type, errors, prototypes);
+        return errors;
+    }
 
-        var flags = BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public |
-                    BindingFlags.DeclaredOnly;
+    /// <summary>
+    /// Validate all static fields defined on this type and all base types.
+    /// </summary>
+    private void ValidateStaticFieldsInternal(Type type, List<string> errors, Dictionary<Type, HashSet<string>> prototypes)
+    {
+        var baseType = type;
+        var flags = BindingFlags.Static |  BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.DeclaredOnly;
 
         while (baseType != null)
         {
             foreach (var field in baseType.GetFields(flags))
             {
-                ValidateField(field, type, ref instance, errors, prototypes);
+                DebugTools.Assert(field.IsStatic);
+                ValidateStaticField(field, type, errors, prototypes);
             }
 
             // We need to get the fields on the base type separately in order to get the private fields
@@ -49,92 +54,110 @@ public partial class PrototypeManager
         }
     }
 
-    private void ValidateField(
+    private void ValidateStaticField(
         FieldInfo field,
         Type type,
-        ref object? instance,
         List<string> errors,
         Dictionary<Type, HashSet<string>> prototypes)
     {
+        DebugTools.Assert(field.IsStatic);
+        DebugTools.Assert(!field.HasCustomAttribute<DataFieldAttribute>(), "Datafields should not be static");
+
         // Is this even a prototype id related field?
-        if (!TryGetFieldPrototype(field, out var proto, out var canBeNull, out var canBeEmpty))
+        if (!TryGetFieldPrototype(field, out var proto))
             return;
 
-        if (!TryGetFieldValue(field, type, ref instance, errors, out var value))
-            return;
-
-        var id = value?.ToString();
-
-        if (id == null)
+        if (!prototypes.TryGetValue(proto, out var validIds))
         {
-            if (!canBeNull)
-                errors.Add($"Prototype id field failed validation. Fields should not be null. Field: {field.Name} in {type.FullName}");
+            errors.Add($"Prototype id field failed validation. Unknown prototype kind {proto.Name}. Field: {field.Name} in {type.FullName}");
             return;
         }
 
-        if (string.IsNullOrWhiteSpace(id))
+        if (!TryGetIds(field, proto, out var ids))
         {
-            if (!canBeEmpty)
-                errors.Add($"Prototype id field failed validation. Non-optional non-nullable data-fields must have a default value. Field: {field.Name} in {type.FullName}");
+            TryGetIds(field, proto, out _);
+            DebugTools.Assert($"Failed to get ids, despite resolving the field into a prototype kind?");
             return;
         }
 
-        if (!prototypes.TryGetValue(proto, out var ids))
+        foreach (var id in ids)
         {
-            errors.Add($"Prototype id field failed validation. Unknown prototype kind. Field: {field.Name} in {type.FullName}");
-            return;
-        }
-
-        if (!ids.Contains(id))
-        {
-            errors.Add($"Prototype id field failed validation. Unknown prototype: {id}. Field: {field.Name} in {type.FullName}");
+            if (!validIds.Contains(id))
+                errors.Add($"Prototype id field failed validation. Unknown prototype: {id} of type {proto.Name}. Field: {field.Name} in {type.FullName}");
         }
     }
 
     /// <summary>
-    /// Get the value of some field. If this is not a static field, this will create instance of the object in order to
-    /// validate default field values.
+    /// Extract prototype ids from a string, IEnumerable{string}, EntProtoId, IEnumerable{EntProtoId}, ProtoId{T}, or IEnumerable{ProtoId{T}} field.
     /// </summary>
-    private bool TryGetFieldValue(FieldInfo field, Type type, ref object? instance, List<string> errors, out object? value)
+    private bool TryGetIds(FieldInfo field, Type proto, [NotNullWhen(true)] out string[]? ids)
     {
-        value = null;
+        ids = null;
+        var value = field.GetValue(null);
+        if (value == null)
+            return false;
 
-        if (field.IsStatic || instance != null)
+        if (value is string str)
         {
-            value = field.GetValue(instance);
+            ids = [str];
             return true;
         }
 
-        var constructor = type.GetConstructor(
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
-            Type.EmptyTypes);
-
-        // TODO handle parameterless record constructors.
-        // Figure out how ISerializationManager does it, or just re-use that code somehow.
-        // In the meantime, record data fields need an explicit parameterless ctor.
-
-        if (constructor == null)
+        if (value is IEnumerable<string> strEnum)
         {
-            errors.Add($"Prototype id field failed validation. Could not create instance to validate default value. Field: {field.Name} in {type.FullName}");
-            return false;
+            ids = strEnum.ToArray();
+            return true;
         }
 
-        instance = constructor.Invoke(Array.Empty<object>());
-        value = field.GetValue(instance);
+        if (value is EntProtoId protoId)
+        {
+            ids = [protoId];
+            return true;
+        }
 
-        return true;
+        if (value is IEnumerable<EntProtoId> protoIdEnum)
+        {
+            ids = protoIdEnum.Select(x=> x.Id).ToArray();
+            return true;
+        }
+
+        if (field.FieldType.IsGenericType && field.FieldType.GetGenericTypeDefinition() == typeof(ProtoId<>))
+        {
+            ids = [value.ToString()!];
+            return true;
+        }
+
+        foreach (var iface in field.FieldType.GetInterfaces())
+        {
+            if (!iface.IsGenericType)
+                continue;
+
+            if (iface.GetGenericTypeDefinition() != typeof(IEnumerable<>))
+                continue;
+
+            var enumType = iface.GetGenericArguments().Single();
+            if (!enumType.IsGenericType)
+                continue;
+
+            if (enumType.GetGenericTypeDefinition() != typeof(ProtoId<>))
+                continue;
+
+            ids = GetIdsMethod.MakeGenericMethod(proto).Invoke(null, [value]) as string[];
+            return ids != null;
+        }
+
+        return false;
     }
 
-    private bool TryGetFieldPrototype(
-        FieldInfo field,
-        [NotNullWhen(true)] out Type? proto,
-        out bool canBeNull,
-        out bool canBeEmpty)
+    private static MethodInfo GetIdsMethod = typeof(PrototypeManager).GetMethod(nameof(GetIds), BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static string[] GetIds<T>(IEnumerable<ProtoId<T>> enumerable) where T : class, IPrototype
     {
-        proto = null;
-        canBeNull = false;
-        canBeEmpty = false;
+        return enumerable.Select(x => x.Id).ToArray();
+    }
 
+    private bool TryGetFieldPrototype(FieldInfo field, [NotNullWhen(true)] out Type? proto)
+    {
+        // Validate anything with the attribute
         var attrib = field.GetCustomAttribute(typeof(ValidatePrototypeIdAttribute<>), false);
         if (attrib != null)
         {
@@ -142,46 +165,40 @@ public partial class PrototypeManager
             return true;
         }
 
-        if (!field.TryGetCustomAttribute(out DataFieldAttribute? dataField))
-            return false;
+        if (TryGetPrototypeFromType(field.FieldType, out proto))
+            return true;
 
-        var fieldType = field.FieldType;
-        canBeEmpty = dataField.Required;
-        DebugTools.Assert(!field.IsStatic);
-
-        // Resolve nullable structs
-        if (fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() == typeof(Nullable<>))
+        // Allow validating arrays or lists.
+        foreach (var iface in field.FieldType.GetInterfaces().Where(x => x.IsGenericType))
         {
-            fieldType = fieldType.GetGenericArguments().Single();
-            canBeNull = true;
+            if (iface.GetGenericTypeDefinition() != typeof(IEnumerable<>))
+                continue;
+
+            var enumType = iface.GetGenericArguments().Single();
+            if (TryGetPrototypeFromType(enumType, out proto))
+                return true;
         }
 
-        if (fieldType == typeof(EntProtoId))
+        proto = null;
+        return false;
+    }
+
+    private bool TryGetPrototypeFromType(Type type, [NotNullWhen(true)] out Type? proto)
+    {
+        if (type == typeof(EntProtoId))
         {
             proto = typeof(EntityPrototype);
             return true;
         }
 
-        if (fieldType.IsGenericType && field.FieldType.GetGenericTypeDefinition() == typeof(ProtoId<>))
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ProtoId<>))
         {
-            proto = field.FieldType.GetGenericArguments().Single();
+            proto = type.GetGenericArguments().Single();
+            DebugTools.Assert(proto != typeof(EntityPrototype), "Use EntProtoId instead of ProtoId<EntityPrototype>");
             return true;
         }
 
-        // As far as I know there is no way to check for the nullability of a string field, so we will assume that null
-        // values imply that the field itself is properly marked as nullable.
-        canBeNull = true;
-
-        if (dataField.CustomTypeSerializer == null)
-            return false;
-
-        if (!dataField.CustomTypeSerializer.IsGenericType)
-            return false;
-
-        if (dataField.CustomTypeSerializer.GetGenericTypeDefinition() != typeof(PrototypeIdSerializer<>))
-            return false;
-
-        proto = dataField.CustomTypeSerializer.GetGenericArguments().First();
-        return true;
+        proto = null;
+        return false;
     }
 }

--- a/Robust.Shared/Prototypes/YamlValidationContext.cs
+++ b/Robust.Shared/Prototypes/YamlValidationContext.cs
@@ -1,0 +1,62 @@
+using System.Globalization;
+using JetBrains.Annotations;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+
+namespace Robust.Shared.Prototypes;
+
+internal sealed class YamlValidationContext : ISerializationContext, ITypeSerializer<EntityUid, ValueDataNode>
+{
+    public SerializationManager.SerializerProvider SerializerProvider { get; } = new();
+    public bool WritingReadingPrototypes => true;
+
+    public YamlValidationContext()
+    {
+        SerializerProvider.RegisterSerializer(this);
+    }
+
+    ValidationNode ITypeValidator<EntityUid, ValueDataNode>.Validate(ISerializationManager serializationManager,
+        ValueDataNode node, IDependencyCollection dependencies, ISerializationContext? context)
+    {
+        if (node.Value == "null" || node.Value == "invalid")
+            return new ValidatedValueNode(node);
+
+        return new ErrorNode(node, "Prototypes should not contain EntityUids", true);
+    }
+
+    public DataNode Write(ISerializationManager serializationManager, EntityUid value,
+        IDependencyCollection dependencies, bool alwaysWrite = false,
+        ISerializationContext? context = null)
+    {
+        if (!value.Valid)
+            return new ValueDataNode("invalid");
+
+        return new ValueDataNode(value.Id.ToString(CultureInfo.InvariantCulture));
+    }
+
+    EntityUid ITypeReader<EntityUid, ValueDataNode>.Read(ISerializationManager serializationManager,
+        ValueDataNode node,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context, ISerializationManager.InstantiationDelegate<EntityUid>? _)
+    {
+        if (node.Value == "invalid")
+            return EntityUid.Invalid;
+
+        return EntityUid.Parse(node.Value);
+    }
+
+    [MustUseReturnValue]
+    public EntityUid Copy(ISerializationManager serializationManager, EntityUid source, EntityUid target,
+        bool skipHook,
+        ISerializationContext? context = null)
+    {
+        return new((int)source);
+    }
+}

--- a/Robust.Shared/Serialization/Manager/Attributes/ValidatePrototypeIdAttribute.cs
+++ b/Robust.Shared/Serialization/Manager/Attributes/ValidatePrototypeIdAttribute.cs
@@ -4,8 +4,9 @@ using Robust.Shared.Prototypes;
 namespace Robust.Shared.Serialization.Manager.Attributes;
 
 /// <summary>
-/// This attribute should be used on string fields to validate that they correspond to a valid YAML prototype id.
-/// If the field needs to be have a default value.
+/// This attribute should be used on static string or string collection fields to validate that they correspond to
+/// valid YAML prototype ids. This attribute is not required for static <see cref="ProtoId{T}"/> and
+/// <see cref="EntProtoId"/> fields, as they automatically get validated.
 /// </summary>
 [AttributeUsage(AttributeTargets.Field)]
 public sealed class ValidatePrototypeIdAttribute<T> : Attribute where T : IPrototype

--- a/Robust.Shared/Serialization/Manager/Definition/DataDefinition.Emitters.cs
+++ b/Robust.Shared/Serialization/Manager/Definition/DataDefinition.Emitters.cs
@@ -143,7 +143,7 @@ namespace Robust.Shared.Serialization.Manager.Definition
                             nodeVariable),
                         call,
                         dfa.Required
-                            ? ExpressionUtils.ThrowExpression<RequiredFieldNotMappedException>(fieldDefinition.FieldType, tagConst)
+                            ? ExpressionUtils.ThrowExpression<RequiredFieldNotMappedException>(fieldDefinition.FieldType, tagConst, typeof(T))
                             : AssignIfNotDefaultExpression(i, targetParam, Expression.Constant(DefaultValues[i], fieldDefinition.FieldType))
                     )));
                 }

--- a/Robust.Shared/Serialization/Manager/Exceptions/RequiredFieldNotMappedException.cs
+++ b/Robust.Shared/Serialization/Manager/Exceptions/RequiredFieldNotMappedException.cs
@@ -4,7 +4,7 @@ namespace Robust.Shared.Serialization.Manager.Exceptions;
 
 public sealed class RequiredFieldNotMappedException : Exception
 {
-    public RequiredFieldNotMappedException(Type type, string field) : base($"Required field {field} of type {type} wasn't mapped.")
+    public RequiredFieldNotMappedException(Type type, string field, Type dataDef) : base($"Required field {field} of type {type} in {dataDef} wasn't mapped.")
     {
     }
 }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/PrototypeIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/PrototypeIdSerializer.cs
@@ -21,7 +21,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
 
     /// <summary>
     /// Checks that a string corresponds to a valid prototype id. Note that any data fields using this serializer will
-    /// also be validated by <see cref="IPrototypeManager.ValidateFields"/>
+    /// also be validated by <see cref="IPrototypeManager.ValidateStaticFields"/>
     /// </summary>
     [Virtual]
     public class PrototypeIdSerializer<TPrototype> : ITypeValidator<string, ValueDataNode> where TPrototype : class, IPrototype


### PR DESCRIPTION
This PR fixes an issue where the prototype validation methods used by the yaml linter would fail to properly validate prototypes with multiple parents.

It also changes how the old `ValidateFields()` method works. Previously it would look through all types known to `IReflectionManager` and look for fields with the dataField or `ValidatePrototypeId<T>` attribute to check if the default value of those fields are valid. This was both to check that the default values of data definitions were valid, and to validate hardcoded prototypes that get used by various systems.

This PR replaces this method with `ValidateStaticFields()`, which now only validates static fields, but also automatically validates `EntProtoId` and `ProtoId<T>` fields, not just strings. It also adds support for `IEnumerable<>` types. Datafields now instead just get validated directly when the yaml linter validates each prototype, though this does mean that the default values of non-prototype related datafields are no longer automatically validated.

I.e., previously the linter would only check strings like
```cs
[ValidatePrototypeId<TagPrototype>] static string Tag = "Wall";
```
However, now it will also check:
```cs
static ProtoId<TagPrototype> Tag = "AirAlarm";
static ProtoId<TagPrototype>[] Tags = { "AirAlarm", "Airlock" };
static HashSet<EntProtoId> Ents = new() { "AirAlarm", "Airlock" };
```

Requires space-wizards/space-station-14/pull/27188