### PR TITLE
Fix GetWorldViewbounds() and GetWorldViewport()

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* `IEyeManager.GetWorldViewbounds()` and `IEyeManager.GetWorldViewbounds()` should now return the correct bounds if the main viewport does not take up the whole screen.
 
 ### Other
 

--- a/Robust.Client/Debugging/DebugPhysicsSystem.cs
+++ b/Robust.Client/Debugging/DebugPhysicsSystem.cs
@@ -225,7 +225,7 @@ namespace Robust.Client.Debugging
         {
             var viewBounds = args.WorldBounds;
             var viewAABB = args.WorldAABB;
-            var mapId = _eyeManager.CurrentMap;
+            var mapId = args.MapId;
 
             if ((_debugPhysicsSystem.Flags & PhysicsDebugFlags.Shapes) != 0)
             {
@@ -373,7 +373,7 @@ namespace Robust.Client.Debugging
 
         private void DrawScreen(DrawingHandleScreen screenHandle, OverlayDrawArgs args)
         {
-            var mapId = _eyeManager.CurrentMap;
+            var mapId = args.MapId;
             var mousePos = _inputManager.MouseScreenPosition;
 
             if ((_debugPhysicsSystem.Flags & PhysicsDebugFlags.ShapeInfo) != 0x0)

--- a/Robust.Client/GameObjects/EntitySystems/DebugLightTreeSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/DebugLightTreeSystem.cs
@@ -63,7 +63,7 @@ namespace Robust.Client.GameObjects
 
             protected internal override void Draw(in OverlayDrawArgs args)
             {
-                var map = _eyeManager.CurrentMap;
+                var map = args.MapId;
                 if (map == MapId.Nullspace) return;
 
                 foreach (var (_, treeComp) in _trees.GetIntersectingTrees(map, args.WorldBounds))

--- a/Robust.Client/GameObjects/EntitySystems/GridChunkBoundsDebugSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/GridChunkBoundsDebugSystem.cs
@@ -70,7 +70,7 @@ namespace Robust.Client.GameObjects
 
         protected internal override void Draw(in OverlayDrawArgs args)
         {
-            var currentMap = _eyeManager.CurrentMap;
+            var currentMap = args.MapId;
             var viewport = args.WorldBounds;
             var worldHandle = args.WorldHandle;
 

--- a/Robust.Client/GameStates/NetInterpOverlay.cs
+++ b/Robust.Client/GameStates/NetInterpOverlay.cs
@@ -49,7 +49,7 @@ namespace Robust.Client.GameStates
             while (query.MoveNext(out var uid, out var transform))
             {
                 // if not on the same map, continue
-                if (transform.MapID != _eyeManager.CurrentMap || _container.IsEntityInContainer(uid))
+                if (transform.MapID != args.MapId || _container.IsEntityInContainer(uid))
                     continue;
 
                 if (transform.GridUid == uid)

--- a/Robust.Client/Graphics/ClientEye/EyeManager.cs
+++ b/Robust.Client/Graphics/ClientEye/EyeManager.cs
@@ -64,25 +64,17 @@ namespace Robust.Client.Graphics
         /// <inheritdoc />
         public Box2 GetWorldViewport()
         {
-            var vpSize = _displayManager.ScreenSize;
-
-            var topLeft = ScreenToMap(Vector2.Zero);
-            var topRight = ScreenToMap(new Vector2(vpSize.X, 0));
-            var bottomRight = ScreenToMap(vpSize);
-            var bottomLeft = ScreenToMap(new Vector2(0, vpSize.Y));
-
-            var left = MathHelper.Min(topLeft.X, topRight.X, bottomRight.X, bottomLeft.X);
-            var bottom = MathHelper.Min(topLeft.Y, topRight.Y, bottomRight.Y, bottomLeft.Y);
-            var right = MathHelper.Max(topLeft.X, topRight.X, bottomRight.X, bottomLeft.X);
-            var top = MathHelper.Max(topLeft.Y, topRight.Y, bottomRight.Y, bottomLeft.Y);
-
-            return new Box2(left, bottom, right, top);
+            return GetWorldViewbounds().CalcBoundingBox();
         }
 
         /// <inheritdoc />
         public Box2Rotated GetWorldViewbounds()
         {
-            var vpSize = _displayManager.ScreenSize;
+            // This is an inefficient and roundabout way of geting the viewport.
+            // But its a method that shouldn't get used much.
+
+            var vp = MainViewport as Control;
+            var vpSize = vp?.PixelSize ?? _displayManager.ScreenSize;
 
             var topRight = ScreenToMap(new Vector2(vpSize.X, 0)).Position;
             var bottomLeft = ScreenToMap(new Vector2(0, vpSize.Y)).Position;

--- a/Robust.Client/Graphics/ClientEye/EyeManager.cs
+++ b/Robust.Client/Graphics/ClientEye/EyeManager.cs
@@ -79,6 +79,7 @@ namespace Robust.Client.Graphics
             var topRight = ScreenToMap(new Vector2(vpSize.X, 0)).Position;
             var bottomLeft = ScreenToMap(new Vector2(0, vpSize.Y)).Position;
 
+            // This assumes the main viewports eye and the main eye are the same.
             var rotation = new Angle(CurrentEye.Rotation);
             var center = (bottomLeft + topRight) / 2;
 

--- a/Robust.Client/Graphics/ClientEye/IEyeManager.cs
+++ b/Robust.Client/Graphics/ClientEye/IEyeManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System;
+using System.Numerics;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.Graphics;
 using Robust.Shared.Map;
@@ -13,26 +14,29 @@ namespace Robust.Client.Graphics
     public interface IEyeManager
     {
         /// <summary>
-        /// The current eye that is being used to render the game.
+        /// The primary eye, which is usually the eye associated with the main viewport.
         /// </summary>
         /// <remarks>
+        /// Generally, you should avoid using this whenever possible. E.g., when rendering overlays should use the
+        /// eye & viewbounds that gets passed to the draw method.
         /// Setting this property to null will use the default eye.
         /// </remarks>
         IEye CurrentEye { get; set; }
 
         IViewportControl MainViewport { get; set; }
 
-        /// <summary>
-        /// The ID of the map on which the current eye is "placed".
-        /// </summary>
+        [Obsolete]
         MapId CurrentMap { get; }
 
         /// <summary>
-        /// A world-space box that is at LEAST the area covered by the viewport.
+        /// A world-space box that is at LEAST the area covered by the main viewport.
         /// May be larger due to say rotation.
         /// </summary>
         Box2 GetWorldViewport();
 
+        /// <summary>
+        /// A world-space box of the area visible in the main viewport.
+        /// </summary>
         Box2Rotated GetWorldViewbounds();
 
         /// <summary>
@@ -43,7 +47,7 @@ namespace Robust.Client.Graphics
         void GetScreenProjectionMatrix(out Matrix3 projMatrix);
 
         /// <summary>
-        /// Projects a point from world space to UI screen space using the current camera.
+        /// Projects a point from world space to UI screen space using the main viewport.
         /// </summary>
         /// <param name="point">Point in world to transform.</param>
         /// <returns>Corresponding point in UI screen space.</returns>

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -480,7 +480,7 @@ namespace Robust.Client.Graphics.Clyde
                 var worldBounds = CalcWorldBounds(viewport);
                 var worldAABB = worldBounds.CalcBoundingBox();
 
-                if (_eyeManager.CurrentMap != MapId.Nullspace)
+                if (eye.Position.MapId != MapId.Nullspace)
                 {
                     using (DebugGroup("Lights"))
                     using (_prof.Group("Lights"))
@@ -544,9 +544,12 @@ namespace Robust.Client.Graphics.Clyde
                         UIBox2.FromDimensions(Vector2.Zero, viewport.Size), new Color(1, 1, 1, 0.5f));
                 }
 
-                using (_prof.Group("Overlays WS"))
+                if (eye.Position.MapId != MapId.Nullspace)
                 {
-                    RenderOverlays(viewport, OverlaySpace.WorldSpace, worldAABB, worldBounds);
+                    using (_prof.Group("Overlays WS"))
+                    {
+                        RenderOverlays(viewport, OverlaySpace.WorldSpace, worldAABB, worldBounds);
+                    }
                 }
 
                 _currentViewport = oldVp;

--- a/Robust.Client/Placement/Modes/AlignSnapgridCenter.cs
+++ b/Robust.Client/Placement/Modes/AlignSnapgridCenter.cs
@@ -19,7 +19,7 @@ namespace Robust.Client.Placement.Modes
 
         public SnapgridCenter(PlacementManager pMan) : base(pMan) { }
 
-        public override void Render(DrawingHandleWorld handle)
+        public override void Render(in OverlayDrawArgs args)
         {
             if (Grid != null)
             {
@@ -34,18 +34,18 @@ namespace Robust.Client.Placement.Modes
                 {
                     var from = ScreenToWorld(new Vector2(a, 0));
                     var to = ScreenToWorld(new Vector2(a, viewportSize.Y));
-                    handle.DrawLine(from, to, new Color(0, 0, 1f));
+                    args.WorldHandle.DrawLine(from, to, new Color(0, 0, 1f));
                 }
                 for (var a = gridstart.Y; a < viewportSize.Y; a += SnapSize * EyeManager.PixelsPerMeter)
                 {
                     var from = ScreenToWorld(new Vector2(0, a));
                     var to = ScreenToWorld(new Vector2(viewportSize.X, a));
-                    handle.DrawLine(from, to, new Color(0, 0, 1f));
+                    args.WorldHandle.DrawLine(from, to, new Color(0, 0, 1f));
                 }
             }
 
             // Draw grid BELOW the ghost thing.
-            base.Render(handle);
+            base.Render(args);
         }
 
         public override void AlignPlacementMode(ScreenCoordinates mouseScreen)

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -628,20 +628,20 @@ namespace Robust.Client.Placement
             return true;
         }
 
-        private void Render(DrawingHandleWorld handle)
+        private void Render(in OverlayDrawArgs args)
         {
             if (CurrentMode == null || !IsActive)
             {
                 if (EraserRect.HasValue)
                 {
-                    handle.UseShader(_drawingShader);
-                    handle.DrawRect(EraserRect.Value, new Color(255, 0, 0, 50));
-                    handle.UseShader(null);
+                    args.WorldHandle.UseShader(_drawingShader);
+                    args.WorldHandle.DrawRect(EraserRect.Value, new Color(255, 0, 0, 50));
+                    args.WorldHandle.UseShader(null);
                 }
                 return;
             }
 
-            CurrentMode.Render(handle);
+            CurrentMode.Render(args);
 
             if (CurrentPermission is not {Range: > 0} ||
                 !CurrentMode.RangeRequired ||
@@ -650,7 +650,7 @@ namespace Robust.Client.Placement
 
             var worldPos = EntityManager.GetComponent<TransformComponent>(controlled).WorldPosition;
 
-            handle.DrawCircle(worldPos, CurrentPermission.Range, new Color(1, 1, 1, 0.25f));
+            args.WorldHandle.DrawCircle(worldPos, CurrentPermission.Range, new Color(1, 1, 1, 0.25f));
         }
 
         private void HandleStartPlacement(MsgPlacement msg)

--- a/Robust.Client/Placement/PlacementMode.cs
+++ b/Robust.Client/Placement/PlacementMode.cs
@@ -88,7 +88,7 @@ namespace Robust.Client.Placement
         /// <returns></returns>
         public abstract bool IsValidPosition(EntityCoordinates position);
 
-        public virtual void Render(DrawingHandleWorld handle)
+        public virtual void Render(in OverlayDrawArgs args)
         {
             var uid = pManager.CurrentPlacementOverlayEntity;
             if (!pManager.EntityManager.TryGetComponent(uid, out SpriteComponent? sprite) || !sprite.Visible)
@@ -125,7 +125,8 @@ namespace Robust.Client.Placement
                 var worldRot = pManager.EntityManager.GetComponent<TransformComponent>(coordinate.EntityId).WorldRotation + dirAng;
 
                 sprite.Color = IsValidPosition(coordinate) ? ValidPlaceColor : InvalidPlaceColor;
-                spriteSys.Render(uid.Value, sprite, handle, pManager.EyeManager.CurrentEye.Rotation, worldRot, worldPos);
+                var rot = args.Viewport.Eye?.Rotation ?? default;
+                spriteSys.Render(uid.Value, sprite, args.WorldHandle, rot, worldRot, worldPos);
             }
         }
 

--- a/Robust.Client/Placement/PlacementOverlay.cs
+++ b/Robust.Client/Placement/PlacementOverlay.cs
@@ -19,7 +19,7 @@ namespace Robust.Client.Placement
 
             protected internal override void Draw(in OverlayDrawArgs args)
             {
-                _manager.Render(args.WorldHandle);
+                _manager.Render(args);
             }
         }
     }


### PR DESCRIPTION
Fixes some IEyeManager methods that were assuming that the size of the main viewport and the size of the screen were the same.
It also gets rid of some uses of CurrentMap and CurrentEye in overlay rendering code.