### PR TITLE
Fix mapping not pausing maps

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Fix map-loader not pausing pre-init maps when not actively overwriting an existing map.
 
 ### Other
 

--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -706,6 +706,7 @@ public sealed class MapLoaderSystem : EntitySystem
             }
             else
             {
+                data.MapIsPaused = !data.MapIsPostInit;
                 mapComp.MapId = data.TargetMap;
                 DebugTools.Assert(mapComp.LifeStage < ComponentLifeStage.Initializing);
                 EnsureComp<LoadedMapComponent>(rootNode);


### PR DESCRIPTION
Fixes map-loader not pausing pre-init maps when not overwriting an existing map.
