### PR TITLE
Optimise physics networking a lot

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
@@ -313,55 +313,60 @@ public partial class SharedPhysicsSystem
         Dirty(uid, body);
     }
 
-    public void SetAngularVelocity(EntityUid uid, float value, bool dirty = true, FixturesComponent? manager = null, PhysicsComponent? body = null)
+    public bool SetAngularVelocity(EntityUid uid, float value, bool dirty = true, FixturesComponent? manager = null, PhysicsComponent? body = null)
     {
         if (!Resolve(uid, ref body))
-            return;
+            return false;
 
         if (body.BodyType == BodyType.Static)
-            return;
+            return false;
 
         if (value * value > 0.0f)
         {
             if (!WakeBody(uid, manager: manager, body: body))
-                return;
+                return false;
         }
 
         // CloseToPercent tolerance needs to be small enough such that an angular velocity just above
         // sleep-tolerance can damp down to sleeping.
 
         if (MathHelper.CloseToPercent(body.AngularVelocity, value, 0.00001f))
-            return;
+            return false;
 
         body.AngularVelocity = value;
 
         if (dirty)
             Dirty(uid, body);
+
+        return true;
     }
 
     /// <summary>
     /// Attempts to set the body to collidable, wake it, then move it.
     /// </summary>
-    public void SetLinearVelocity(EntityUid uid, Vector2 velocity, bool dirty = true, bool wakeBody = true, FixturesComponent? manager = null, PhysicsComponent? body = null)
+    public bool SetLinearVelocity(EntityUid uid, Vector2 velocity, bool dirty = true, bool wakeBody = true, FixturesComponent? manager = null, PhysicsComponent? body = null)
     {
         if (!Resolve(uid, ref body))
-            return;
+            return false;
 
-        if (body.BodyType == BodyType.Static) return;
+        if (body.BodyType == BodyType.Static)
+            return false;
 
         if (wakeBody && Vector2.Dot(velocity, velocity) > 0.0f)
         {
             if (!WakeBody(uid, manager: manager, body: body))
-                return;
+                return false;
         }
 
         if (body.LinearVelocity.EqualsApprox(velocity, 0.0000001f))
-            return;
+            return false;
 
         body.LinearVelocity = velocity;
 
         if (dirty)
             Dirty(uid, body);
+
+        return true;
     }
 
     public void SetAngularDamping(EntityUid uid, PhysicsComponent body, float value, bool dirty = true)

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
@@ -660,13 +660,11 @@ public abstract partial class SharedPhysicsSystem
         });
 
         // Update data sequentially
-        var metaQuery = GetEntityQuery<MetaDataComponent>();
-
         for (var i = 0; i < actualIslands.Length; i++)
         {
             var island = actualIslands[i];
 
-            UpdateBodies(in island, solvedPositions, solvedAngles, linearVelocities, angularVelocities, xformQuery, metaQuery);
+            UpdateBodies(in island, solvedPositions, solvedAngles, linearVelocities, angularVelocities, xformQuery);
             SleepBodies(in island, sleepStatus);
         }
 
@@ -1001,8 +999,7 @@ public abstract partial class SharedPhysicsSystem
         float[] angles,
         Vector2[] linearVelocities,
         float[] angularVelocities,
-        EntityQuery<TransformComponent> xformQuery,
-        EntityQuery<MetaDataComponent> metaQuery)
+        EntityQuery<TransformComponent> xformQuery)
     {
         foreach (var (joint, error) in island.BrokenJoints)
         {
@@ -1035,21 +1032,22 @@ public abstract partial class SharedPhysicsSystem
             }
 
             var linVelocity = linearVelocities[offset + i];
+            var physicsDirtied = false;
 
             if (!float.IsNaN(linVelocity.X) && !float.IsNaN(linVelocity.Y))
             {
-                SetLinearVelocity(uid, linVelocity, false, body: body);
+                physicsDirtied |= SetLinearVelocity(uid, linVelocity, false, body: body);
             }
 
             var angVelocity = angularVelocities[offset + i];
 
             if (!float.IsNaN(angVelocity))
             {
-                SetAngularVelocity(uid, angVelocity, false, body: body);
+                physicsDirtied |= SetAngularVelocity(uid, angVelocity, false, body: body);
             }
 
-            // TODO: Should check if the values update.
-            Dirty(uid, body, metaQuery.GetComponent(uid));
+            if (physicsDirtied)
+                Dirty(uid, body);
         }
     }
 


### PR DESCRIPTION
Avoids unnecessarily dirtying every single tick when a mob is moving. Also avoids the getcomponent every time which is nice.