### PR TITLE
Remove debug assert for Fixture.Owner equality

### DIFF
--- a/Robust.Shared/Physics/Dynamics/Fixture.cs
+++ b/Robust.Shared/Physics/Dynamics/Fixture.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Physics.Components;
@@ -181,9 +182,6 @@ namespace Robust.Shared.Physics.Dynamics
         {
             if (other == null) return false;
 
-            // Owner field shouldn't be required, fixtures on other entities shouldn't be getting compared to each other.
-            // This is mainly here because it might've intruded some physics bugs, so this is here just in case.
-            DebugTools.Assert(Owner == other.Owner);
             return Equivalent(other) && Owner == other.Owner;
         }
     }

--- a/Robust.Shared/Physics/Dynamics/Fixture.cs
+++ b/Robust.Shared/Physics/Dynamics/Fixture.cs
@@ -24,7 +24,6 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Physics.Components;


### PR DESCRIPTION
This appears to be the source of at least one heisentest.
Here are a couple instances of it popping up:
https://github.com/space-wizards/space-station-14/actions/runs/8809629859/job/24180738876
https://github.com/space-wizards/space-station-14/actions/runs/8715968289/job/23908703315

The Equals method for Fixtures checks has a debug assert to make sure that the fixtures being compared don't belong to different entities:

https://github.com/space-wizards/RobustToolbox/blob/eb638099999dce3a43d90772ca976ae010d649c0/Robust.Shared/Physics/Dynamics/Fixture.cs#L180-L188

The problem is in SharedPhysicsSystem.AddPair, where a check is done to see if a Contact already exists between the two Fixtures:

https://github.com/space-wizards/RobustToolbox/blob/eb638099999dce3a43d90772ca976ae010d649c0/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs#L255-L260

The call to ContainsKey winds up comparing the input Fixture key with existing keys in the Contacts dictionary, which uses Equals. In this situation, the Fixtures are actually expected to be on different entities. But we have that debug assert that says we shouldn't be doing this sort of comparison.

This fix just deletes the debug assert, since it doesn't really seem super helpful anyway. I suppose a better fix might be to introduce a custom IEqualityComparer for the Contacts dictionary? That seems a bit excessive to me, but I can do it if that would be preferred.