### PR TITLE
Add method for getting type of var from serializer

### DIFF
--- a/Robust.Shared/Serialization/Manager/ISerializationManager.cs
+++ b/Robust.Shared/Serialization/Manager/ISerializationManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 using Robust.Shared.Reflection;
 using Robust.Shared.Serialization.Markdown;
@@ -440,5 +441,7 @@ namespace Robust.Shared.Serialization.Manager
         }
 
         #endregion
+
+        public bool TryGetVariableType(Type type, string variableName, [NotNullWhen(true)] out Type? variableType);
     }
 }

--- a/Robust.Shared/Serialization/Manager/SerializationManager.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.cs
@@ -264,6 +264,26 @@ namespace Robust.Shared.Serialization.Manager
             return dataDefinition != null;
         }
 
+        public bool TryGetVariableType(Type type, string variableName, [NotNullWhen(true)] out Type? variableType)
+        {
+            if (!TryGetDefinition(type, out var definition))
+            {
+                variableType = null;
+                return false;
+            }
+            var foundFieldDef = definition.BaseFieldDefinitions.FirstOrDefault(fieldDef => fieldDef?.BackingField.Name==variableName, null);
+            if(foundFieldDef != null)
+            {
+                variableType = foundFieldDef.BackingField.FieldType;
+                return true;
+            }
+            else
+            {
+                variableType = null;
+                return false;
+            }
+        }
+
         private Type ResolveConcreteType(Type baseType, string typeName)
         {
             var type = ReflectionManager.YamlTypeTagLookup(baseType, typeName);


### PR DESCRIPTION
OpenDream is abusing the serializer to do DMF parsing, and as a result of https://github.com/OpenDreamProject/OpenDream/pull/1757 I need to know the subtype of the vars at runtime.

This PR adds a function on the `SerializationManager`  which gets the `Type` of a variable on another `Type` by it's `DataField` tag.