### PR TITLE
Temporarily disable macos tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest ] # , macos-latest] - temporarily disabled due to libfreetype.dll errors.
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
They constantly fail due to libfreetype errors that I'm not sure how to fix.