### PR TITLE
Improve transform & state handling exception tolerance

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,9 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* `EntParentChangedMessage.OldMapId` is now an `EntityUid` instead of `MapId`
+* `TransformSystem.DetachParentToNull()` is being renamed to `DetachEntity`
+* The order in which `MoveEvent` handlers are invoked has been changed to prioritise engine subscriptions 
 
 ### New features
 

--- a/Robust.Server/GameStates/PvsSystem.Entity.cs
+++ b/Robust.Server/GameStates/PvsSystem.Entity.cs
@@ -55,13 +55,10 @@ internal sealed partial class PvsSystem
             return;
         }
 
-        var root = (xform.GridUid ?? xform.MapUid);
-        DebugTools.AssertNotNull(root);
-
-        if (xform.ParentUid != root)
+        if (xform.ParentUid != xform.GridUid && xform.ParentUid != xform.MapUid)
             return;
 
-        var location = new PvsChunkLocation(root.Value, GetChunkIndices(xform._localPosition));
+        var location = new PvsChunkLocation(xform.ParentUid, GetChunkIndices(xform._localPosition));
         if (meta.LastPvsLocation == location)
             return;
 

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -134,7 +134,7 @@ internal sealed partial class PvsSystem : EntitySystem
         SubscribeLocalEvent<TransformComponent, TransformStartupEvent>(OnTransformStartup);
 
         _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
-        _transform.OnGlobalMoveEvent += OnEntityMove;
+        _transform.OnBeforeMoveEvent += OnEntityMove;
         EntityManager.EntityAdded += OnEntityAdded;
         EntityManager.EntityDeleted += OnEntityDeleted;
         EntityManager.AfterEntityFlush += AfterEntityFlush;
@@ -159,7 +159,7 @@ internal sealed partial class PvsSystem : EntitySystem
         base.Shutdown();
 
         _playerManager.PlayerStatusChanged -= OnPlayerStatusChanged;
-        _transform.OnGlobalMoveEvent -= OnEntityMove;
+        _transform.OnBeforeMoveEvent -= OnEntityMove;
         EntityManager.EntityAdded -= OnEntityAdded;
         EntityManager.EntityDeleted -= OnEntityDeleted;
         EntityManager.AfterEntityFlush -= AfterEntityFlush;

--- a/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
+++ b/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
@@ -71,6 +71,8 @@ public abstract class ComponentTreeSystem<TTreeComp, TComp> : EntitySystem
         }
         else
         {
+            // TODO EXCEPTION TOLERANCE
+            // Ensure lookup trees update before content code handles move events.
             SubscribeLocalEvent<TComp, MoveEvent>(HandleMove);
         }
 

--- a/Robust.Shared/ComponentTrees/RecursiveMoveSystem.cs
+++ b/Robust.Shared/ComponentTrees/RecursiveMoveSystem.cs
@@ -33,7 +33,7 @@ internal sealed class RecursiveMoveSystem : EntitySystem
     public override void Shutdown()
     {
         if (_subscribed)
-            _transform.OnGlobalMoveEvent -= AnythingMoved;
+            _transform.OnBeforeMoveEvent -= AnythingMoved;
 
         _subscribed = false;
     }
@@ -44,7 +44,7 @@ internal sealed class RecursiveMoveSystem : EntitySystem
             return;
 
         _subscribed = true;
-        _transform.OnGlobalMoveEvent += AnythingMoved;
+        _transform.OnBeforeMoveEvent += AnythingMoved;
     }
 
     private void AnythingMoved(ref MoveEvent args)

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -157,9 +157,7 @@ namespace Robust.Shared.GameObjects
                 if (!Initialized)
                     return;
 
-                var moveEvent = new MoveEvent((Owner, this, meta), Coordinates, Coordinates, oldRotation, _localRotation, _gameTiming.ApplyingState);
-                _entMan.EventBus.RaiseLocalEvent(Owner, ref moveEvent);
-                _entMan.System<SharedTransformSystem>().InvokeGlobalMoveEvent(ref moveEvent);
+                _entMan.System<SharedTransformSystem>().RaiseMoveEvent((Owner, this, meta), _parent, _localPosition, oldRotation, MapUid);
             }
         }
 
@@ -334,7 +332,9 @@ namespace Robust.Shared.GameObjects
                 if (_localPosition.EqualsApprox(value))
                     return;
 
-                var oldGridPos = Coordinates;
+                var oldParent = _parent;
+                var oldPos = _localPosition;
+
                 _localPosition = value;
                 var meta = _entMan.GetComponent<MetaDataComponent>(Owner);
                 _entMan.Dirty(Owner, this, meta);
@@ -343,9 +343,7 @@ namespace Robust.Shared.GameObjects
                 if (!Initialized)
                     return;
 
-                var moveEvent = new MoveEvent((Owner, this, meta), oldGridPos, Coordinates, _localRotation, _localRotation, _gameTiming.ApplyingState);
-                _entMan.EventBus.RaiseLocalEvent(Owner, ref moveEvent);
-                _entMan.System<SharedTransformSystem>().InvokeGlobalMoveEvent(ref moveEvent);
+                _entMan.System<SharedTransformSystem>().RaiseMoveEvent((Owner, this, meta), oldParent, oldPos, _localRotation, MapUid);
             }
         }
 
@@ -602,8 +600,12 @@ namespace Robust.Shared.GameObjects
     /// move events, subscribe to the <see cref="SharedTransformSystem.OnGlobalMoveEvent"/>.
     /// </summary>
     [ByRefEvent]
-    public readonly struct MoveEvent(Entity<TransformComponent, MetaDataComponent> entity, EntityCoordinates oldPos,
-        EntityCoordinates newPos, Angle oldRotation, Angle newRotation, bool stateHandling = false)
+    public readonly struct MoveEvent(
+        Entity<TransformComponent, MetaDataComponent> entity,
+        EntityCoordinates oldPos,
+        EntityCoordinates newPos,
+        Angle oldRotation,
+        Angle newRotation)
     {
         public readonly Entity<TransformComponent, MetaDataComponent> Entity = entity;
         public readonly EntityCoordinates OldPosition = oldPos;
@@ -615,15 +617,6 @@ namespace Robust.Shared.GameObjects
         public TransformComponent Component => Entity.Comp1;
 
         public bool ParentChanged => NewPosition.EntityId != OldPosition.EntityId;
-
-        [Obsolete("Check IGameTiming.ApplyingState")]
-        public readonly bool FromStateHandling = stateHandling;
-
-        [Obsolete]
-        public MoveEvent(EntityUid uid, EntityCoordinates oldPos, EntityCoordinates newPos, Angle oldRot, Angle newRot, TransformComponent xform, bool state)
-            : this((uid, xform, default!), oldPos, newPos, oldRot, newRot)
-        {
-        }
     }
 
     public struct TransformChildrenEnumerator : IDisposable

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -551,17 +551,7 @@ namespace Robust.Shared.GameObjects
 
             // Detach the base entity to null before iterating over children
             // This also ensures that the entity-lookup updates don't have to be re-run for every child (which recurses up the transform hierarchy).
-            if (transform.ParentUid != EntityUid.Invalid)
-            {
-                try
-                {
-                    _xforms.DetachParentToNull((uid, transform, metadata), parentXform, true);
-                }
-                catch (Exception e)
-                {
-                    _sawmill.Error($"Caught exception while trying to detach parent of entity '{ToPrettyString(uid, metadata)}' to null.\n{e}");
-                }
-            }
+            _xforms.DetachEntity(uid, transform, metadata, parentXform, true);
 
             foreach (var child in transform._children)
             {

--- a/Robust.Shared/GameObjects/EntitySystemMessages/EntParentChangedMessage.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/EntParentChangedMessage.cs
@@ -19,26 +19,26 @@ namespace Robust.Shared.GameObjects
         public EntityUid? OldParent { get; }
 
         /// <summary>
-        ///     The map Id that the entity was on before its parent changed.
+        ///     The map that the entity was on before its parent changed.
         /// </summary>
         /// <remarks>
         ///     If the old parent was detached to null without manually updating the map ID of its children, then this
         ///     is required as we cannot simply use the old parent's map ID. Also avoids having to fetch the old
         ///     parent's transform component.
         /// </remarks>
-        public MapId OldMapId { get; }
+        public readonly EntityUid? OldMapId;
 
         public TransformComponent Transform { get; }
 
         /// <summary>
         ///     Creates a new instance of <see cref="EntParentChangedMessage"/>.
         /// </summary>
-        public EntParentChangedMessage(EntityUid entity, EntityUid? oldParent, MapId oldMapId, TransformComponent xform)
+        public EntParentChangedMessage(EntityUid entity, EntityUid? oldParent, EntityUid? oldMapId, TransformComponent xform)
         {
             Entity = entity;
             OldParent = oldParent;
-            OldMapId = oldMapId;
             Transform = xform;
+            OldMapId = oldMapId;
         }
     }
 }

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -125,7 +125,7 @@ public sealed partial class EntityLookupSystem : EntitySystem
         SubscribeLocalEvent<GridAddEvent>(OnGridAdd);
         SubscribeLocalEvent<MapChangedEvent>(OnMapChange);
 
-        _transform.OnGlobalMoveEvent += OnMove;
+        _transform.OnBeforeMoveEvent += OnMove;
         EntityManager.EntityInitialized += OnEntityInit;
 
         SubscribeLocalEvent<TransformComponent, PhysicsBodyTypeChangedEvent>(OnBodyTypeChange);
@@ -142,7 +142,7 @@ public sealed partial class EntityLookupSystem : EntitySystem
     {
         base.Shutdown();
         EntityManager.EntityInitialized -= OnEntityInit;
-        _transform.OnGlobalMoveEvent -= OnMove;
+        _transform.OnBeforeMoveEvent -= OnMove;
     }
 
     #region DynamicTree

--- a/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
@@ -26,24 +26,12 @@ internal sealed class SharedGridTraversalSystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<TransformStartupEvent>(OnStartup);
-        _transform.OnGlobalMoveEvent += OnMove;
     }
 
     private void OnStartup(ref TransformStartupEvent ev)
     {
         CheckTraverse(ev.Entity.Owner, ev.Entity.Comp);
     }
-
-    public override void Shutdown()
-    {
-        _transform.OnGlobalMoveEvent -= OnMove;
-    }
-
-    private void OnMove(ref MoveEvent moveEv)
-    {
-        CheckTraverse(moveEv.Sender, moveEv.Component);
-    }
-
 
     internal void CheckTraverse(EntityUid uid, TransformComponent xform)
     {

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -43,21 +43,13 @@ public abstract partial class SharedTransformSystem
         xform._anchored = true;
         var oldPos = xform._localPosition;
         var oldRot = xform._localRotation;
+        var oldMap = xform.MapUid;
         xform._localPosition = tilePos + newGrid.TileSizeHalfVector;
         xform._localRotation += rotation;
 
         SetGridId(uid, xform, newGridUid, XformQuery);
-        var reParent = new EntParentChangedMessage(uid, oldGridUid, xform.MapID, xform);
-        RaiseLocalEvent(uid, ref reParent, true);
         var meta = MetaData(uid);
-        var movEevee = new MoveEvent((uid, xform, meta),
-            new EntityCoordinates(oldGridUid, oldPos),
-            new EntityCoordinates(newGridUid, xform._localPosition),
-            oldRot,
-            xform.LocalRotation,
-            _gameTiming.ApplyingState);
-        RaiseLocalEvent(uid, ref movEevee);
-        InvokeGlobalMoveEvent(ref movEevee);
+        RaiseMoveEvent((uid, xform, meta), oldGridUid, oldPos, oldRot, oldMap);
 
         DebugTools.Assert(XformQuery.GetComponent(oldGridUid).MapID == XformQuery.GetComponent(newGridUid).MapID);
         DebugTools.Assert(xform._anchored);
@@ -321,7 +313,7 @@ public abstract partial class SharedTransformSystem
 
         // I hate this too. Once again, required for shit like containers because they CBF doing their own init logic
         // and rely on parent changed messages instead. Might also be used by broadphase stuff?
-        var parentEv = new EntParentChangedMessage(uid, null, MapId.Nullspace, xform);
+        var parentEv = new EntParentChangedMessage(uid, null, null, xform);
         RaiseLocalEvent(uid, ref parentEv, true);
 
         var ev = new TransformStartupEvent((uid, xform));
@@ -449,9 +441,6 @@ public abstract partial class SharedTransformSystem
             return;
         }
 
-        var oldPosition = xform._parent.IsValid() ? new EntityCoordinates(xform._parent, xform._localPosition) : default;
-        var oldRotation = xform._localRotation;
-
         if (xform.Anchored && unanchor)
             Unanchor(uid, xform);
 
@@ -470,6 +459,11 @@ public abstract partial class SharedTransformSystem
             }
         }
 
+        var oldParentUid = xform._parent;
+        var oldPosition = xform._localPosition;
+        var oldRotation = xform._localRotation;
+        var oldMap = xform.MapUid;
+
         // Set new values
         Dirty(uid, xform, meta);
         xform.MatricesDirty = true;
@@ -485,7 +479,7 @@ public abstract partial class SharedTransformSystem
         {
             if (value.EntityId == uid)
             {
-                DetachParentToNull(uid, xform);
+                DetachEntity(uid, xform);
                 if (_netMan.IsServer || IsClientSide(uid))
                     QueueDel(uid);
                 throw new InvalidOperationException($"Attempted to parent an entity to itself: {ToPrettyString(uid)}");
@@ -495,7 +489,7 @@ public abstract partial class SharedTransformSystem
             {
                 if (!XformQuery.Resolve(value.EntityId, ref newParent, false))
                 {
-                    DetachParentToNull(uid, xform);
+                    DetachEntity(uid, xform);
                     if (_netMan.IsServer || IsClientSide(uid))
                         QueueDel(uid);
                     throw new InvalidOperationException($"Attempted to parent entity {ToPrettyString(uid)} to non-existent entity {value.EntityId}");
@@ -503,7 +497,7 @@ public abstract partial class SharedTransformSystem
 
                 if (newParent.LifeStage >= ComponentLifeStage.Stopping || LifeStage(value.EntityId) >= EntityLifeStage.Terminating)
                 {
-                    DetachParentToNull(uid, xform);
+                    DetachEntity(uid, xform);
                     if (_netMan.IsServer || IsClientSide(uid))
                         QueueDel(uid);
                     throw new InvalidOperationException($"Attempted to re-parent to a terminating object. Entity: {ToPrettyString(uid)}, new parent: {ToPrettyString(value.EntityId)}");
@@ -528,7 +522,7 @@ public abstract partial class SharedTransformSystem
                             // Even though its temporary, this can still cause the client to get stuck in infinite loops while applying the game state.
                             // So we will just break the loop by detaching to null and just trusting that the loop wasn't actually a real feature of the server state.
                             Log.Warning($"Encountered circular transform hierarchy while applying state for entity: {ToPrettyString(uid)}. Detaching child to null: {ToPrettyString(recursiveUid)}");
-                            DetachParentToNull(recursiveUid, recursiveXform);
+                            DetachEntity(recursiveUid, recursiveXform);
                             break;
                         }
 
@@ -545,7 +539,6 @@ public abstract partial class SharedTransformSystem
             newParent?._children.Add(uid);
 
             xform._parent = value.EntityId;
-            var oldMapId = xform.MapID;
 
             if (newParent != null)
             {
@@ -576,24 +569,18 @@ public abstract partial class SharedTransformSystem
                     xform._localRotation += GetWorldRotation(oldParent) - GetWorldRotation(newParent);
 
                 DebugTools.Assert(!xform.NoLocalRotation || xform.LocalRotation == 0);
-
-                var entParentChangedMessage = new EntParentChangedMessage(uid, oldParent?.Owner, oldMapId, xform);
-                RaiseLocalEvent(uid, ref entParentChangedMessage, true);
             }
         }
 
         if (!xform.Initialized)
             return;
 
-        var newPosition = xform._parent.IsValid() ? new EntityCoordinates(xform._parent, xform._localPosition) : default;
-#if DEBUG
+#if !DEBUG
         // If an entity is parented to the map, its grid uid should be null (unless it is itself a grid or we have a map-grid)
         if (xform.ParentUid == xform.MapUid)
             DebugTools.Assert(xform.GridUid == null || xform.GridUid == uid || xform.GridUid == xform.MapUid);
 #endif
-        var moveEvent = new MoveEvent((uid, xform, meta), oldPosition, newPosition, oldRotation, xform._localRotation, _gameTiming.ApplyingState);
-        RaiseLocalEvent(uid, ref moveEvent);
-        InvokeGlobalMoveEvent(ref moveEvent);
+        RaiseMoveEvent((uid, xform, meta), oldParentUid, oldPosition, oldRotation, oldMap);
     }
 
     public void SetCoordinates(
@@ -674,7 +661,7 @@ public abstract partial class SharedTransformSystem
 
         if (!parent.IsValid())
         {
-            DetachParentToNull(uid, xform);
+            DetachEntity(uid, xform);
             return;
         }
 
@@ -1143,7 +1130,8 @@ public abstract partial class SharedTransformSystem
         if (xform._localPosition.EqualsApprox(pos) && xform.LocalRotation.EqualsApprox(rot))
             return;
 
-        var oldPosition = xform.Coordinates;
+        var oldParent = xform._parent;
+        var oldPosition = xform._localPosition;
         var oldRotation = xform.LocalRotation;
 
         if (!xform.Anchored)
@@ -1161,9 +1149,7 @@ public abstract partial class SharedTransformSystem
         if (!xform.Initialized)
             return;
 
-        var moveEvent = new MoveEvent((uid, xform, meta), oldPosition, xform.Coordinates, oldRotation, rot, _gameTiming.ApplyingState);
-        RaiseLocalEvent(uid, ref moveEvent);
-        InvokeGlobalMoveEvent(ref moveEvent);
+        RaiseMoveEvent((uid, xform, meta), oldParent, oldPosition, oldRotation, xform.MapUid);
     }
 
     #endregion
@@ -1326,7 +1312,7 @@ public abstract partial class SharedTransformSystem
             if (!_mapManager.IsMap(uid))
                 Log.Warning($"Failed to attach entity to map or grid. Entity: ({ToPrettyString(uid)}). Trace: {Environment.StackTrace}");
 
-            DetachParentToNull(uid, xform);
+            DetachEntity(uid, xform);
             return;
         }
 
@@ -1362,21 +1348,50 @@ public abstract partial class SharedTransformSystem
 
     #region State Handling
 
+    [Obsolete("Use DetachEntity")]
     public void DetachParentToNull(EntityUid uid, TransformComponent xform)
+        => DetachEntity(uid, xform);
+
+    /// <inheritdoc cref="DetachEntityInternal"/>
+    public void DetachEntity(EntityUid uid, TransformComponent xform)
     {
         XformQuery.TryGetComponent(xform.ParentUid, out var oldXform);
-        DetachParentToNull(uid, xform, oldXform);
+        DetachEntity(uid, xform, MetaData(uid), oldXform);
     }
 
-    public void DetachParentToNull(EntityUid uid, TransformComponent xform, TransformComponent? oldXform)
+    /// <inheritdoc cref="DetachEntityInternal"/>
+    public void DetachEntity(
+        EntityUid uid,
+        TransformComponent xform,
+        MetaDataComponent meta,
+        TransformComponent? oldXform,
+        bool terminating = false)
     {
-        DetachParentToNull((uid, xform, MetaData(uid)), oldXform);
+#if !EXCEPTION_TOLERANCE
+        DetachEntityInternal(uid, xform, meta, oldXform, terminating);
+#else
+        try
+        {
+            DetachEntityInternal(uid, xform, meta, oldXform, terminating);
+        }
+        catch (Exception e)
+        {
+            Log.Error($"Caught exception while attempting to detach an entity to nullspace. Entity: {ToPrettyString(uid, meta)}. Exception: {e}");
+            // TODO detach without content event handling.
+        }
+#endif
     }
 
-    public void DetachParentToNull(Entity<TransformComponent,MetaDataComponent> entity, TransformComponent? oldXform, bool terminating = false)
+    /// <summary>
+    /// Remove an entity from the transform hierarchy and send it to null space
+    /// </summary>
+    internal void DetachEntityInternal(
+        EntityUid uid,
+        TransformComponent xform,
+        MetaDataComponent meta,
+        TransformComponent? oldXform,
+        bool terminating = false)
     {
-        var (uid, xform, meta) = entity;
-
         if (!terminating && meta.EntityLifeStage >= EntityLifeStage.Terminating)
         {
             // Something is attempting to remove the entity from this entity's parent while it is in the process of being deleted.
@@ -1393,15 +1408,14 @@ public abstract partial class SharedTransformSystem
             DebugTools.Assert((MetaData(uid).Flags & MetaDataFlags.InContainer) == 0x0,
                 $"Entity is in a container but has no parent? Entity: {ToPrettyString(uid)}");
 
-            if (xform.Broadphase != null)
-            {
-                DebugTools.Assert(
-                    xform.Broadphase == BroadphaseData.Invalid
-                    || xform.Broadphase.Value.Uid == uid
-                    || Deleted(xform.Broadphase.Value.Uid)
-                    || Terminating(xform.Broadphase.Value.Uid),
-                $"Entity has no parent but is on some broadphase? Entity: {ToPrettyString(uid)}. Broadphase: {ToPrettyString(xform.Broadphase.Value.Uid)}");
-            }
+            DebugTools.Assert(
+                xform.Broadphase == null
+                || xform.Broadphase == BroadphaseData.Invalid
+                || xform.Broadphase.Value.Uid == uid
+                || Deleted(xform.Broadphase.Value.Uid)
+                || Terminating(xform.Broadphase.Value.Uid),
+                $"Entity has no parent but is on some broadphase? Entity: {ToPrettyString(uid)}. Broadphase: {ToPrettyString(xform.Broadphase!.Value.Uid)}");
+
             return;
         }
 
@@ -1425,7 +1439,7 @@ public abstract partial class SharedTransformSystem
             RaiseLocalEvent(uid, ref anchorStateChangedEvent, true);
         }
 
-        SetCoordinates(entity, default, Angle.Zero, oldParent: oldXform);
+        SetCoordinates((uid, xform, meta), default, Angle.Zero, oldParent: oldXform);
 
         DebugTools.Assert((meta.Flags & MetaDataFlags.InContainer) == 0x0,
             $"Entity is in a container after having been detached to null-space? Entity: {ToPrettyString(uid)}");
@@ -1460,7 +1474,7 @@ public abstract partial class SharedTransformSystem
         var targetXform = target.Comp;
         if (!XformQuery.Resolve(target, ref targetXform) || !targetXform.ParentUid.IsValid())
         {
-            DetachParentToNull(entity, xform);
+            DetachEntity(entity, xform);
             return;
         }
 
@@ -1498,7 +1512,7 @@ public abstract partial class SharedTransformSystem
         var targetXform = target.Comp;
         if (!XformQuery.Resolve(target, ref targetXform) || !targetXform.ParentUid.IsValid())
         {
-            DetachParentToNull(entity, xform);
+            DetachEntity(entity, xform);
             return;
         }
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -575,12 +575,12 @@ public abstract partial class SharedTransformSystem
         if (!xform.Initialized)
             return;
 
-#if !DEBUG
+#if DEBUG
         // If an entity is parented to the map, its grid uid should be null (unless it is itself a grid or we have a map-grid)
         if (xform.ParentUid == xform.MapUid)
             DebugTools.Assert(xform.GridUid == null || xform.GridUid == uid || xform.GridUid == xform.MapUid);
 #endif
-        RaiseMoveEvent((uid, xform, meta), oldParentUid, oldPosition, oldRotation, oldMap);
+        RaiseMoveEvent(entity, oldParentUid, oldPosition, oldRotation, oldMap);
     }
 
     public void SetCoordinates(
@@ -655,7 +655,7 @@ public abstract partial class SharedTransformSystem
 
     public void SetParent(EntityUid uid, TransformComponent xform, EntityUid parent, EntityQuery<TransformComponent> xformQuery, TransformComponent? parentXform = null)
     {
-        DebugTools.Assert(uid == xform.Owner);
+        DebugTools.AssertOwner(uid, xform);
         if (xform.ParentUid == parent)
             return;
 

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Runtime.InteropServices;
 using JetBrains.Annotations;
 using Robust.Shared.Collections;

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Velocities.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Velocities.cs
@@ -198,7 +198,7 @@ public abstract partial class SharedPhysicsSystem
         return (linearVelocity + linearVelocityAngularContribution, angularVelocity);
     }
 
-    private void HandleParentChangeVelocity(EntityUid uid, PhysicsComponent physics, ref EntParentChangedMessage args, TransformComponent xform)
+    private void HandleParentChangeVelocity(EntityUid uid, PhysicsComponent physics, EntityUid oldParent, TransformComponent xform)
     {
         // If parent changed due to state handling, don't modify velocities. The physics comp state will take care of itself..
         if (_gameTiming.ApplyingState)
@@ -217,15 +217,13 @@ public abstract partial class SharedPhysicsSystem
         // I guess the question becomes, what do you do with conservation of momentum in that case. I guess its the job
         // of the teleporter to select a velocity at the after the parent has changed.
 
-        var xformQuery = GetEntityQuery<TransformComponent>();
-        var physicsQuery = GetEntityQuery<PhysicsComponent>();
         FixturesComponent? manager = null;
 
         // for the new velocities (that need to be updated), we can just use the existing function:
         var (newLinear, newAngular) = GetMapVelocities(uid, physics, xform);
 
         // for the old velocities, we need to re-implement this function while using the old parent and old local position:
-        if (args.OldParent is not { Valid: true } parent)
+        if (oldParent == EntityUid.Invalid)
         {
             // no previous parent --> simple
             // Old velocity + (old velocity - new velocity)
@@ -234,7 +232,8 @@ public abstract partial class SharedPhysicsSystem
             return;
         }
 
-        TransformComponent? parentXform = xformQuery.GetComponent(parent);
+        var parent = oldParent;
+        TransformComponent? parentXform = _xformQuery.GetComponent(parent);
         var localPos = _transform.GetInvWorldMatrix(parentXform).Transform(_transform.GetWorldPosition(xform));
 
         var oldLinear = physics.LinearVelocity;
@@ -243,7 +242,7 @@ public abstract partial class SharedPhysicsSystem
 
         do
         {
-            if (physicsQuery.TryGetComponent(parent, out var body))
+            if (PhysicsQuery.TryGetComponent(oldParent, out var body))
             {
                 oldAngular += body.AngularVelocity;
 
@@ -259,7 +258,7 @@ public abstract partial class SharedPhysicsSystem
             localPos = parentXform.LocalPosition + parentXform.LocalRotation.RotateVec(localPos);
             parent = parentXform.ParentUid;
 
-        } while (parent.IsValid() && xformQuery.TryGetComponent(parent, out parentXform));
+        } while (parent.IsValid() && _xformQuery.TryGetComponent(parent, out parentXform));
 
         oldLinear += linearAngularContribution;
 

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Velocities.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Velocities.cs
@@ -242,7 +242,7 @@ public abstract partial class SharedPhysicsSystem
 
         do
         {
-            if (PhysicsQuery.TryGetComponent(oldParent, out var body))
+            if (PhysicsQuery.TryGetComponent(parent, out var body))
             {
                 oldAngular += body.AngularVelocity;
 

--- a/Robust.UnitTesting/Shared/GameObjects/Systems/TransformSystemTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/Systems/TransformSystemTests.cs
@@ -92,7 +92,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             Assert.That(parentXform.MapID, Is.EqualTo(mapId));
             Assert.That(childXform.MapID, Is.EqualTo(mapId));
 
-            xformSystem.DetachParentToNull(parent, parentXform);
+            xformSystem.DetachEntity(parent, parentXform);
             Assert.That(parentXform.MapID, Is.EqualTo(MapId.Nullspace));
             Assert.That(childXform.MapID, Is.EqualTo(MapId.Nullspace));
         }

--- a/Robust.UnitTesting/Shared/Physics/Broadphase_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Broadphase_Test.cs
@@ -354,7 +354,7 @@ public sealed class Broadphase_Test
         Assert.That(lookup.FindBroadphase(child2), Is.EqualTo(mapBroadphase));
 
         // They should get deparented to the map and updated to the map's broadphase instead.
-        xformSystem.DetachParentToNull(parent, parentXform);
+        xformSystem.DetachEntity(parent, parentXform);
         Assert.That(lookup.FindBroadphase(parent), Is.EqualTo(null));
         Assert.That(lookup.FindBroadphase(child1), Is.EqualTo(null));
         Assert.That(lookup.FindBroadphase(child2), Is.EqualTo(null));


### PR DESCRIPTION
Requires space-wizards/space-station-14/pull/27455

This PR tries to improve exception tolerance in a few ways:
- `HandleEntityState` is now wrapped in a try-catch and will request a full server state if it fails.
- `DetachParentToNull` is now wrapped in a try-catch
  - I also renamed `DetachParentToNull()` to `DetachEntity()`. IMO the name was misleading as it implies that it modifies the parent entity somehow.
- Reworking the order in which move events are handled

Previously movement would result in:
1. A `EntParentChangedMessage` being broadcast, if applicable, 
2. Raising a directed `MoveEvent`, 
3. Invoking the `OnGlobalMoveEvent` c# event

Now it will instead:
1. Call `PhysicsSystem.OnParentChange()` if applicable
2. Invoke a new internal `OnBeforeMoveEvent` c# event
3. Broadcast a `EntParentChangedMessage` if applicable, 
4. Raise a directed `MoveEvent`, 
5. Invoke `OnGlobalMoveEvent`
6. Call `GridTraversalSystem.CheckTraverse()`

The rationale for this is that it ensures that PVS, physics, and (some) entity lookups can all get updated before some content code potentially throws an exception, which should hopefully make it a bit more exception tolerant and avoid things like deleted entitles on physics maps, by ensuring that `DetachEntity()` will at least partially succeed.