### PR TITLE
Add `IUserInterfaceManager.UpdateHovered()`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Added `UpdateHovered()` and `SetHovered()` to `IUserInterfaceManager`, for updating or modifying the currently hovered control.
 
 ### Bugfixes
 
@@ -47,7 +47,7 @@ END TEMPLATE-->
 
 ### Other
 
-*None yet*
+* If the currently hovered control is disposed, `UserInterfaceManager` will now look for a new control, rather than just setting the hovered control to null.
 
 ### Internal
 

--- a/Robust.Client/UserInterface/IUserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/IUserInterfaceManager.cs
@@ -135,6 +135,17 @@ namespace Robust.Client.UserInterface
         /// Plays the UI hover sound if relevant.
         /// </summary>
         void HoverSound();
+
+        /// <summary>
+        /// Sets <see cref="CurrentlyHovered"/> to the given control.
+        /// </summary>
+        void SetHovered(Control? control);
+
+        /// <summary>
+        /// Forces <see cref="CurrentlyHovered"/> to get updated. This is done automatically when the mouse is moved,
+        /// but not necessarily a new or existing control is rearranged.
+        /// </summary>
+        void UpdateHovered();
     }
 
     public readonly struct PostDrawUIRootEventArgs

--- a/Robust.Client/UserInterface/UserInterfaceManager.Input.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Input.cs
@@ -9,6 +9,7 @@ using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.Input;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
+using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 
 namespace Robust.Client.UserInterface;
@@ -20,9 +21,10 @@ internal partial class UserInterfaceManager
     private bool _needUpdateActiveCursor;
     [ViewVariables] public Control? KeyboardFocused { get; private set; }
 
-    [ViewVariables] public Control? CurrentlyHovered { get; private set; } = default!;
+    [ViewVariables] public Control? CurrentlyHovered { get; private set; }
 
     private Control? _controlFocused;
+
     [ViewVariables]
     public Control? ControlFocused
     {
@@ -100,6 +102,7 @@ internal partial class UserInterfaceManager
             return;
         }
 
+
         var guiArgs = new GUIBoundKeyEventArgs(args.Function, args.State, args.PointerLocation, args.CanFocus,
             args.PointerLocation.Position / control.UIScale - control.GlobalPosition,
             args.PointerLocation.Position - control.GlobalPixelPosition);
@@ -111,16 +114,18 @@ internal partial class UserInterfaceManager
             args.Handle();
         }
 
+        // Attempt to ensure that keybind-up events only get raised after a single keybind-down.
+        DebugTools.Assert(!_focusedControls.ContainsKey(args.Function));
         _focusedControls[args.Function] = control;
+
         OnKeyBindDown?.Invoke(control);
     }
 
     public void KeyBindUp(BoundKeyEventArgs args)
     {
-        if (!_focusedControls.TryGetValue(args.Function, out var control))
-        {
+        // Only raise keybind-up for the control on which we previously raised keybind-down
+        if (!_focusedControls.Remove(args.Function, out var control) || control.Disposed)
             return;
-        }
 
         var guiArgs = new GUIBoundKeyEventArgs(args.Function, args.State, args.PointerLocation, args.CanFocus,
             args.PointerLocation.Position / control.UIScale - control.GlobalPosition,
@@ -131,7 +136,6 @@ internal partial class UserInterfaceManager
         // Always mark this as handled.
         // The only case it should not be is if we do not have a control to click on,
         // in which case we never reach this.
-        _focusedControls.Remove(args.Function);
         args.Handle();
     }
 
@@ -140,23 +144,7 @@ internal partial class UserInterfaceManager
         _resetTooltipTimer();
         // Update which control is considered hovered.
         var newHovered = MouseGetControl(mouseMoveEventArgs.Position);
-        if (newHovered != CurrentlyHovered)
-        {
-            _clearTooltip();
-            CurrentlyHovered?.MouseExited();
-            CurrentlyHovered = newHovered;
-            CurrentlyHovered?.MouseEntered();
-            if (CurrentlyHovered != null)
-            {
-                _tooltipDelay = CurrentlyHovered.TooltipDelay ?? TooltipDelay;
-            }
-            else
-            {
-                _tooltipDelay = null;
-            }
-
-            _needUpdateActiveCursor = true;
-        }
+        SetHovered(newHovered);
 
         var target = ControlFocused ?? newHovered;
         if (target != null)
@@ -170,6 +158,33 @@ internal partial class UserInterfaceManager
 
             _doMouseGuiInput(target, guiArgs, (c, ev) => c.MouseMove(ev));
         }
+    }
+
+    public void UpdateHovered()
+    {
+        var ctrl =  MouseGetControl(_inputManager.MouseScreenPosition);
+        SetHovered(ctrl);
+    }
+
+    public void SetHovered(Control? control)
+    {
+        if (control == CurrentlyHovered)
+            return;
+
+        _clearTooltip();
+        CurrentlyHovered?.MouseExited();
+        CurrentlyHovered = control;
+        CurrentlyHovered?.MouseEntered();
+        if (CurrentlyHovered != null)
+        {
+            _tooltipDelay = CurrentlyHovered.TooltipDelay ?? TooltipDelay;
+        }
+        else
+        {
+            _tooltipDelay = null;
+        }
+
+        _needUpdateActiveCursor = true;
     }
 
     private void UpdateActiveCursor()

--- a/Robust.Client/UserInterface/UserInterfaceManager.Layout.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Layout.cs
@@ -77,15 +77,12 @@ internal sealed partial class UserInterfaceManager
 
             ReleaseKeyboardFocus(control);
             RemoveModal(control);
-            if (control == CurrentlyHovered)
-            {
-                control.MouseExited();
-                CurrentlyHovered = null;
-                _clearTooltip();
-            }
 
-            if (control != ControlFocused) return;
-            ControlFocused = null;
+            if (control == ControlFocused)
+                ControlFocused = null;
+
+            if (control == CurrentlyHovered)
+                UpdateHovered();
         }
 
         public void PushModal(Control modal)

--- a/Robust.UnitTesting/Client/UserInterface/UserInterfaceManagerTest.cs
+++ b/Robust.UnitTesting/Client/UserInterface/UserInterfaceManagerTest.cs
@@ -97,6 +97,7 @@ namespace Robust.UnitTesting.Client.UserInterface
             control4.OnKeyBindDown += _ => Assert.Fail("Control 4 should not get a mouse event.");
 
             _userInterfaceManager.KeyBindDown(mouseEvent);
+            _userInterfaceManager.KeyBindUp(mouseEvent);
 
             Assert.Multiple(() =>
             {
@@ -124,6 +125,7 @@ namespace Robust.UnitTesting.Client.UserInterface
             control2.MouseFilter = Control.MouseFilterMode.Pass;
 
             _userInterfaceManager.KeyBindDown(mouseEvent);
+            _userInterfaceManager.KeyBindUp(mouseEvent);
 
             Assert.Multiple(() =>
             {
@@ -247,6 +249,7 @@ namespace Robust.UnitTesting.Client.UserInterface
                 pos, true, pos.Position / 1 - control.GlobalPosition, pos.Position - control.GlobalPixelPosition);
 
             _userInterfaceManager.KeyBindDown(mouseEvent);
+            _userInterfaceManager.KeyBindUp(mouseEvent);
 
             Assert.That(_userInterfaceManager.KeyboardFocused, NUnit.Framework.Is.Null);
 


### PR DESCRIPTION
Adds `UpdateHovered()` and `SetHovered()` to `IUserInterfaceManager`, for updating or modifying the currently hovered control. Also changes the behaviour when the currently hovered control is disposed so that it now looks for a new control, rather than just setting the hovered control to null.