### PR TITLE
Add audio helpers for map-based audio

### DIFF
--- a/Robust.Server/Audio/AudioSystem.cs
+++ b/Robust.Server/Audio/AudioSystem.cs
@@ -42,6 +42,17 @@ public sealed partial class AudioSystem : SharedAudioSystem
         component.Source = new DummyAudioSource();
     }
 
+    public override void SetMapAudio(Entity<AudioComponent>? audio)
+    {
+        if (audio == null)
+            return;
+
+        base.SetMapAudio(audio);
+
+        // Also need a global override because clients not near 0,0 won't get the audio.
+        _pvs.AddGlobalOverride(audio.Value);
+    }
+
     private void AddAudioFilter(EntityUid uid, AudioComponent component, Filter filter)
     {
         var count = filter.Count;

--- a/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
+++ b/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
@@ -8,6 +8,7 @@ using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -32,6 +33,7 @@ public abstract partial class SharedAudioSystem : EntitySystem
     [Dependency] private   readonly INetManager _netManager = default!;
     [Dependency] protected readonly IPrototypeManager ProtoMan = default!;
     [Dependency] protected readonly IRobustRandom RandMan = default!;
+    [Dependency] protected readonly MetaDataSystem MetadataSys = default!;
 
     /// <summary>
     /// Default max range at which the sound can be heard.
@@ -129,6 +131,18 @@ public abstract partial class SharedAudioSystem : EntitySystem
     private float GetPlaybackPosition(AudioComponent component)
     {
         return (float) (Timing.CurTime - (component.PauseTime ?? TimeSpan.Zero) - component.AudioStart).TotalSeconds;
+    }
+
+    /// <summary>
+    /// Marks this audio as being map-based.
+    /// </summary>
+    public virtual void SetMapAudio(Entity<AudioComponent>? audio)
+    {
+        if (audio == null)
+            return;
+
+        audio.Value.Comp.Global = true;
+        MetadataSys.AddFlag(audio.Value.Owner, MetaDataFlags.Undetachable);
     }
 
     /// <summary>

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
@@ -146,6 +146,11 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <summary>
+        /// Was the tile previously empty or is it now empty.
+        /// </summary>
+        public bool EmptyChanged => OldTile.IsEmpty != NewTile.Tile.IsEmpty;
+
+        /// <summary>
         ///     EntityUid of the grid with the tile-change. TileRef stores the GridId.
         /// </summary>
         public readonly EntityUid Entity;


### PR DESCRIPTION
Doesn't need to be a flag because we just set it as global, whereas gridaudio cares about stuff every frame.