### PR TITLE
Add EntProtoId<T>

### DIFF
--- a/Robust.Shared/Prototypes/EntProtoId.cs
+++ b/Robust.Shared/Prototypes/EntProtoId.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations;
 
@@ -41,4 +44,60 @@ public readonly record struct EntProtoId(string Id) : IEquatable<string>, ICompa
     }
 
     public override string ToString() => Id ?? string.Empty;
+}
+
+/// <inheritdoc cref="EntProtoId"/>
+[Serializable]
+public readonly record struct EntProtoId<T>(string Id) : IEquatable<string>, IComparable<EntProtoId> where T : IComponent, new()
+{
+    public static implicit operator string(EntProtoId<T> protoId)
+    {
+        return protoId.Id;
+    }
+
+    public static implicit operator EntProtoId(EntProtoId<T> protoId)
+    {
+        return new EntProtoId(protoId.Id);
+    }
+
+    public static implicit operator EntProtoId<T>(string id)
+    {
+        return new EntProtoId<T>(id);
+    }
+
+    public static implicit operator EntProtoId<T>?(string? id)
+    {
+        return id == null ? default(EntProtoId<T>?) : new EntProtoId<T>(id);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Id == other;
+    }
+
+    public int CompareTo(EntProtoId other)
+    {
+        return string.Compare(Id, other.Id, StringComparison.Ordinal);
+    }
+
+    public override string ToString() => Id ?? string.Empty;
+
+    public T Get(IPrototypeManager? prototypes = null, IComponentFactory? compFactory = null)
+    {
+        prototypes ??= IoCManager.Resolve<IPrototypeManager>();
+        var proto = prototypes.Index(this);
+        if (!proto.TryGetComponent(out T? comp, compFactory))
+        {
+            throw new ArgumentException($"{nameof(EntityPrototype)} {proto.ID} has no {nameof(T)}");
+        }
+
+        return comp;
+    }
+
+    public bool TryGet([NotNullWhen(true)] out T? comp, IPrototypeManager? prototypes = null, IComponentFactory? compFactory = null)
+    {
+        prototypes ??= IoCManager.Resolve<IPrototypeManager>();
+        var proto = prototypes.Index(this);
+        return proto.TryGetComponent(out comp, compFactory);
+    }
 }

--- a/Robust.Shared/Prototypes/EntProtoId.cs
+++ b/Robust.Shared/Prototypes/EntProtoId.cs
@@ -82,7 +82,7 @@ public readonly record struct EntProtoId<T>(string Id) : IEquatable<string>, ICo
 
     public override string ToString() => Id ?? string.Empty;
 
-    public T Get(IPrototypeManager? prototypes = null, IComponentFactory? compFactory = null)
+    public T Get(IPrototypeManager? prototypes, IComponentFactory? compFactory)
     {
         prototypes ??= IoCManager.Resolve<IPrototypeManager>();
         var proto = prototypes.Index(this);
@@ -94,7 +94,7 @@ public readonly record struct EntProtoId<T>(string Id) : IEquatable<string>, ICo
         return comp;
     }
 
-    public bool TryGet([NotNullWhen(true)] out T? comp, IPrototypeManager? prototypes = null, IComponentFactory? compFactory = null)
+    public bool TryGet([NotNullWhen(true)] out T? comp, IPrototypeManager? prototypes, IComponentFactory? compFactory)
     {
         prototypes ??= IoCManager.Resolve<IPrototypeManager>();
         var proto = prototypes.Index(this);

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
@@ -54,10 +54,10 @@ public sealed class EntProtoIdSerializer<T> : ITypeSerializer<EntProtoId<T>, Val
     {
         var prototypes = dependencies.Resolve<IPrototypeManager>();
         if (!prototypes.TryGetMapping(typeof(EntityPrototype), node.Value, out var mapping))
-            return new ErrorNode(node, $"No {nameof(EntityPrototype)} found with id {node.Value} that has a {typeof(T)}");
+            return new ErrorNode(node, $"No {nameof(EntityPrototype)} found with id {node.Value} that has a {typeof(T).Name}");
 
         if (!mapping.TryGet("components", out SequenceDataNode? components))
-            return new ErrorNode(node, $"{nameof(EntityPrototype)} {node.Value} doesn't have a {typeof(T)}.");
+            return new ErrorNode(node, $"{nameof(EntityPrototype)} {node.Value} doesn't have a {typeof(T).Name}.");
 
         var compFactory = dependencies.Resolve<IComponentFactory>();
         var registration = compFactory.GetRegistration<T>();
@@ -71,7 +71,7 @@ public sealed class EntProtoIdSerializer<T> : ITypeSerializer<EntProtoId<T>, Val
             }
         }
 
-        return new ErrorNode(node, $"{nameof(EntityPrototype)} {node.Value} doesn't have a {typeof(T)}.");
+        return new ErrorNode(node, $"{nameof(EntityPrototype)} {node.Value} doesn't have a {typeof(T).Name}.");
     }
 
     public EntProtoId<T> Read(ISerializationManager serialization, ValueDataNode node, IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context = null, InstantiationDelegate<EntProtoId<T>>? instanceProvider = null)

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
@@ -53,11 +53,11 @@ public sealed class EntProtoIdSerializer<T> : ITypeSerializer<EntProtoId<T>, Val
     public ValidationNode Validate(ISerializationManager serialization, ValueDataNode node, IDependencyCollection dependencies, ISerializationContext? context = null)
     {
         var prototypes = dependencies.Resolve<IPrototypeManager>();
-        if (!prototypes.TryGetMapping(typeof(EntityPrototype), node.Value, out MappingDataNode? mapping))
-            return new ErrorNode(node, $"No {nameof(EntityPrototype)} found with id {node.Value}");
+        if (!prototypes.TryGetMapping(typeof(EntityPrototype), node.Value, out var mapping))
+            return new ErrorNode(node, $"No {nameof(EntityPrototype)} found with id {node.Value} that has a {typeof(T)}");
 
         if (!mapping.TryGet("components", out SequenceDataNode? components))
-            return new ErrorNode(node, $"{nameof(EntityPrototype)} {node.Value} doesn't have a {nameof(T)}.");
+            return new ErrorNode(node, $"{nameof(EntityPrototype)} {node.Value} doesn't have a {typeof(T)}.");
 
         var compFactory = dependencies.Resolve<IComponentFactory>();
         var registration = compFactory.GetRegistration<T>();
@@ -71,7 +71,7 @@ public sealed class EntProtoIdSerializer<T> : ITypeSerializer<EntProtoId<T>, Val
             }
         }
 
-        return new ErrorNode(node, $"{nameof(EntityPrototype)} {node.Value} doesn't have a {nameof(T)}.");
+        return new ErrorNode(node, $"{nameof(EntityPrototype)} {node.Value} doesn't have a {typeof(T)}.");
     }
 
     public EntProtoId<T> Read(ISerializationManager serialization, ValueDataNode node, IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context = null, InstantiationDelegate<EntProtoId<T>>? instanceProvider = null)

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
@@ -1,8 +1,11 @@
-﻿using Robust.Shared.IoC;
+﻿using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Mapping;
+using Robust.Shared.Serialization.Markdown.Sequence;
 using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
@@ -36,6 +39,52 @@ public sealed class EntProtoIdSerializer : ITypeSerializer<EntProtoId, ValueData
     }
 
     public EntProtoId CreateCopy(ISerializationManager serializationManager, EntProtoId source, IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context = null)
+    {
+        return source;
+    }
+}
+
+/// <summary>
+///     Serializer used automatically for <see cref="EntProtoId"/> types.
+/// </summary>
+[TypeSerializer]
+public sealed class EntProtoIdSerializer<T> : ITypeSerializer<EntProtoId<T>, ValueDataNode>, ITypeCopyCreator<EntProtoId<T>> where T : IComponent, new()
+{
+    public ValidationNode Validate(ISerializationManager serialization, ValueDataNode node, IDependencyCollection dependencies, ISerializationContext? context = null)
+    {
+        var prototypes = dependencies.Resolve<IPrototypeManager>();
+        if (!prototypes.TryGetMapping(typeof(EntityPrototype), node.Value, out MappingDataNode? mapping))
+            return new ErrorNode(node, $"No {nameof(EntityPrototype)} found with id {node.Value}");
+
+        if (!mapping.TryGet("components", out SequenceDataNode? components))
+            return new ErrorNode(node, $"{nameof(EntityPrototype)} {node.Value} doesn't have a {nameof(T)}.");
+
+        var compFactory = dependencies.Resolve<IComponentFactory>();
+        var registration = compFactory.GetRegistration<T>();
+        foreach (var componentNode in components)
+        {
+            if (componentNode is MappingDataNode component &&
+                component.TryGet("type", out ValueDataNode? compName) &&
+                compName.Value == registration.Name)
+            {
+                return new ValidatedValueNode(node);
+            }
+        }
+
+        return new ErrorNode(node, $"{nameof(EntityPrototype)} {node.Value} doesn't have a {nameof(T)}.");
+    }
+
+    public EntProtoId<T> Read(ISerializationManager serialization, ValueDataNode node, IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context = null, InstantiationDelegate<EntProtoId<T>>? instanceProvider = null)
+    {
+        return new EntProtoId<T>(node.Value);
+    }
+
+    public DataNode Write(ISerializationManager serialization, EntProtoId<T> value, IDependencyCollection dependencies, bool alwaysWrite = false, ISerializationContext? context = null)
+    {
+        return new ValueDataNode(value.Id);
+    }
+
+    public EntProtoId<T> CreateCopy(ISerializationManager serializationManager, EntProtoId<T> source, IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context = null)
     {
         return source;
     }


### PR DESCRIPTION
This makes the yaml linter validate that the given id has a specific component.
For example:
```csharp
[DataField]
public EntProtoId<InstantActionComponent> Action = "ActionToggleGuardian";
```

Example error message:
```
::error file=/Prototypes/_CM14/Roles/Jobs/Command/staff_officer.yml,line=12,col=12::/Prototypes/_CM14/Roles/Jobs/Command/staff_officer.yml(12,12)  EntityPrototype CMDepartmentsHuman doesn't have a DepartmentGroupComponent.
```

Multi-T EntProtoId tbd