### PR TITLE
Make `IComponentFactory` argument in `EntityPrototype.TryGetComponent` non-optional

### DIFF
--- a/Robust.Shared/GameObjects/ComponentFactory.cs
+++ b/Robust.Shared/GameObjects/ComponentFactory.cs
@@ -290,6 +290,12 @@ namespace Robust.Shared.GameObjects
         }
 
         [Pure]
+        public string GetComponentName<T>() where T : IComponent, new()
+        {
+            return GetRegistration<T>().Name;
+        }
+
+        [Pure]
         public string GetComponentName(ushort netID)
         {
             return GetRegistration(netID).Name;
@@ -324,7 +330,7 @@ namespace Robust.Shared.GameObjects
 
         public ComponentRegistration GetRegistration<T>() where T : IComponent, new()
         {
-            return GetRegistration(typeof(T));
+            return GetRegistration(CompIdx.Index<T>());
         }
 
         public ComponentRegistration GetRegistration(IComponent component)

--- a/Robust.Shared/GameObjects/IComponentFactory.cs
+++ b/Robust.Shared/GameObjects/IComponentFactory.cs
@@ -160,6 +160,9 @@ namespace Robust.Shared.GameObjects
         [Pure]
         string GetComponentName(Type componentType);
 
+        [Pure]
+        string GetComponentName<T>() where T : IComponent, new();
+
         /// <summary>
         ///     Gets the name of a component, throwing an exception if it does not exist.
         /// </summary>

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -11,6 +11,7 @@ using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array;
+using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 
 namespace Robust.Shared.Prototypes
@@ -168,28 +169,37 @@ namespace Robust.Shared.Prototypes
             _loc = IoCManager.Resolve<ILocalizationManager>();
         }
 
-        public bool TryGetComponent<T>([NotNullWhen(true)] out T? component, IComponentFactory? factory = null) where T : IComponent
+        [Obsolete("Pass in IComponentFactory")]
+        public bool TryGetComponent<T>([NotNullWhen(true)] out T? component)
+            where T : IComponent
         {
-            if (factory == null)
-            {
-                factory = IoCManager.Resolve<IComponentFactory>();
-            }
+            var compName = IoCManager.Resolve<IComponentFactory>().GetComponentName(typeof(T));
+            return TryGetComponent(compName, out component);
+        }
 
-            var compName = factory.GetComponentName(typeof(T));
+        public bool TryGetComponent<T>([NotNullWhen(true)] out T? component, IComponentFactory factory) where T : IComponent, new()
+        {
+            var compName = factory.GetComponentName<T>();
             return TryGetComponent(compName, out component);
         }
 
         public bool TryGetComponent<T>(string name, [NotNullWhen(true)] out T? component) where T : IComponent
         {
+            DebugTools.AssertEqual(IoCManager.Resolve<IComponentFactory>().GetComponentName(typeof(T)), name);
+
             if (!Components.TryGetValue(name, out var componentUnCast))
             {
                 component = default;
                 return false;
             }
 
-            // There are no duplicate component names
-            // TODO Sanity check with names being in an attribute of the type instead
-            component = (T) componentUnCast.Component;
+            if (componentUnCast.Component is not T cast)
+            {
+                component = default;
+                return false;
+            }
+
+            component = cast;
             return true;
         }
 


### PR DESCRIPTION
Marks the old method as obsolete. Reason as always is that people never realise its an expected argument and it should probably never have been optional to begin with.