### PR TITLE
Hidden tiles

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* `ITileDefinition.EditorHidden` allows hiding a tile from the tile spawn panel.
 
 ### Bugfixes
 

--- a/Robust.Client/UserInterface/Controllers/Implementations/TileSpawningUIController.cs
+++ b/Robust.Client/UserInterface/Controllers/Implementations/TileSpawningUIController.cs
@@ -146,6 +146,8 @@ public sealed class TileSpawningUIController : UIController
 
         foreach (var entry in _shownTiles)
         {
+            if (entry.Hidden) continue;
+            
             Texture? texture = null;
             var path = entry.Sprite?.ToString();
 

--- a/Robust.Client/UserInterface/Controllers/Implementations/TileSpawningUIController.cs
+++ b/Robust.Client/UserInterface/Controllers/Implementations/TileSpawningUIController.cs
@@ -135,8 +135,8 @@ public sealed class TileSpawningUIController : UIController
         if (!string.IsNullOrEmpty(searchStr))
         {
             tileDefs = tileDefs.Where(s =>
-                Loc.GetString(s.Name).Contains(searchStr, StringComparison.CurrentCultureIgnoreCase) ||
-                s.ID.Contains(searchStr, StringComparison.OrdinalIgnoreCase));
+                (Loc.GetString(s.Name).Contains(searchStr, StringComparison.CurrentCultureIgnoreCase) ||
+                s.ID.Contains(searchStr, StringComparison.OrdinalIgnoreCase)) && !s.EditorHidden);
         }
 
         tileDefs = tileDefs.OrderBy(d => Loc.GetString(d.Name));
@@ -146,8 +146,6 @@ public sealed class TileSpawningUIController : UIController
 
         foreach (var entry in _shownTiles)
         {
-            if (entry.EditorHidden) continue;
-
             Texture? texture = null;
             var path = entry.Sprite?.ToString();
 

--- a/Robust.Client/UserInterface/Controllers/Implementations/TileSpawningUIController.cs
+++ b/Robust.Client/UserInterface/Controllers/Implementations/TileSpawningUIController.cs
@@ -146,7 +146,7 @@ public sealed class TileSpawningUIController : UIController
 
         foreach (var entry in _shownTiles)
         {
-            if (entry.Hidden) continue;
+            if (entry.EditorHidden) continue;
 
             Texture? texture = null;
             var path = entry.Sprite?.ToString();

--- a/Robust.Client/UserInterface/Controllers/Implementations/TileSpawningUIController.cs
+++ b/Robust.Client/UserInterface/Controllers/Implementations/TileSpawningUIController.cs
@@ -130,13 +130,13 @@ public sealed class TileSpawningUIController : UIController
 
         _window.TileList.Clear();
 
-        IEnumerable<ITileDefinition> tileDefs = _tiles;
+        IEnumerable<ITileDefinition> tileDefs = _tiles.Where(def => !def.EditorHidden);
 
         if (!string.IsNullOrEmpty(searchStr))
         {
             tileDefs = tileDefs.Where(s =>
-                (Loc.GetString(s.Name).Contains(searchStr, StringComparison.CurrentCultureIgnoreCase) ||
-                s.ID.Contains(searchStr, StringComparison.OrdinalIgnoreCase)) && !s.EditorHidden);
+                Loc.GetString(s.Name).Contains(searchStr, StringComparison.CurrentCultureIgnoreCase) ||
+                s.ID.Contains(searchStr, StringComparison.OrdinalIgnoreCase));
         }
 
         tileDefs = tileDefs.OrderBy(d => Loc.GetString(d.Name));

--- a/Robust.Client/UserInterface/Controllers/Implementations/TileSpawningUIController.cs
+++ b/Robust.Client/UserInterface/Controllers/Implementations/TileSpawningUIController.cs
@@ -147,7 +147,7 @@ public sealed class TileSpawningUIController : UIController
         foreach (var entry in _shownTiles)
         {
             if (entry.Hidden) continue;
-            
+
             Texture? texture = null;
             var path = entry.Sprite?.ToString();
 

--- a/Robust.Shared/Map/ITileDefinition.cs
+++ b/Robust.Shared/Map/ITileDefinition.cs
@@ -55,5 +55,10 @@ namespace Robust.Shared.Map
         /// </summary>
         /// <param name="id">The new tile ID for this tile definition.</param>
         void AssignTileId(ushort id);
+
+        /// <summary>
+        ///     Allows you to hide tiles from the tile spawn menu.
+        /// </summary>
+        bool Hidden { get; }
     }
 }

--- a/Robust.Shared/Map/ITileDefinition.cs
+++ b/Robust.Shared/Map/ITileDefinition.cs
@@ -59,6 +59,6 @@ namespace Robust.Shared.Map
         /// <summary>
         ///     Allows you to hide tiles from the tile spawn menu.
         /// </summary>
-        bool Hidden { get; }
+        bool EditorHidden { get; }
     }
 }

--- a/Robust.Shared/Map/ITileDefinition.cs
+++ b/Robust.Shared/Map/ITileDefinition.cs
@@ -59,6 +59,6 @@ namespace Robust.Shared.Map
         /// <summary>
         ///     Allows you to hide tiles from the tile spawn menu.
         /// </summary>
-        bool EditorHidden { get; }
+        bool EditorHidden => false;
     }
 }


### PR DESCRIPTION
A small addition that allows you to hide some tiles from the spawn menu. This is useful for downstrimes, disabling the ability to see standard tiles, but not causing huge problems with cutting them from everywhere they are used.