### PR TITLE
Fix error when JointRelayTargetComponent shuts down while applying state

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedJointSystem.Relay.cs
+++ b/Robust.Shared/Physics/Systems/SharedJointSystem.Relay.cs
@@ -48,6 +48,9 @@ public abstract partial class SharedJointSystem
 
     private void OnRelayShutdown(EntityUid uid, JointRelayTargetComponent component, ComponentShutdown args)
     {
+        if (_gameTiming.ApplyingState)
+            return;
+
         foreach (var relay in component.Relayed)
         {
             if (TerminatingOrDeleted(relay) || !_jointsQuery.TryGetComponent(relay, out var joint))


### PR DESCRIPTION
```
[ERRO] runtime: Caught exception in "ResetPredictedEntities"
Robust.Shared.Utility.DebugAssertException: Exception of type 'Robust.Shared.Utility.DebugAssertException' was thrown.
   at Robust.Shared.Utility.DebugTools.Assert(Boolean condition) in C:\Projects\CM-14\RobustToolbox\Robust.Shared\Utility\DebugTools.cs:line 37
   at Robust.Shared.GameObjects.EntityManager.LifeShutdown(IComponent component) in C:\Projects\CM-14\RobustToolbox\Robust.Shared\GameObjects\EntityManager.LifeCycle.cs:line 66
   at Robust.Shared.GameObjects.EntityManager.RemoveComponentImmediate(IComponent component, EntityUid uid, Boolean terminating, MetaDataComponent meta) in C:\Projects\CM-14\RobustToolbox\Robust.Shared\GameObjects\EntityManager.Components.cs:line 600
   at Robust.Shared.Physics.Systems.SharedJointSystem.SetRelay(EntityUid uid, Nullable`1 relay, JointComponent component) in C:\Projects\CM-14\RobustToolbox\Robust.Shared\Physics\Systems\SharedJointSystem.Relay.cs:line 118
   at Robust.Shared.Physics.Systems.SharedJointSystem.RefreshRelay(EntityUid uid, JointComponent component) in C:\Projects\CM-14\RobustToolbox\Robust.Shared\Physics\Systems\SharedJointSystem.Relay.cs:line 87
   at Robust.Shared.Physics.Systems.SharedJointSystem.OnRelayShutdown(EntityUid uid, JointRelayTargetComponent component, ComponentShutdown args) in C:\Projects\CM-14\RobustToolbox\Robust.Shared\Physics\Systems\SharedJointSystem.Relay.cs:line 56
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass48_0`2.<SubscribeLocalEvent>g__EventHandler|0(EntityUid uid, IComponent comp, TEvent& args) in C:\Projects\CM-14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 249
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass62_0`1.<EntSubscribe>b__0(EntityUid uid, IComponent comp, Unit& ev) in C:\Projects\CM-14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 432
   at Robust.Shared.GameObjects.EntityEventBus.DispatchComponent[TEvent](EntityUid euid, IComponent component, CompIdx baseType, Unit& args) in C:\Projects\CM-14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 616
   at Robust.Shared.GameObjects.EntityEventBus.Robust.Shared.GameObjects.IDirectedEventBus.RaiseComponentEvent[TEvent](IComponent component, TEvent args) in C:\Projects\CM-14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 135
   at Robust.Shared.GameObjects.EntityManager.LifeShutdown(IComponent component) in C:\Projects\CM-14\RobustToolbox\Robust.Shared\GameObjects\EntityManager.LifeCycle.cs:line 76
   at Robust.Shared.GameObjects.EntityManager.RemoveComponentImmediate(IComponent component, EntityUid uid, Boolean terminating, MetaDataComponent meta) in C:\Projects\CM-14\RobustToolbox\Robust.Shared\GameObjects\EntityManager.Components.cs:line 600
   at Robust.Client.GameStates.ClientGameStateManager.ResetPredictedEntities() in C:\Projects\CM-14\RobustToolbox\Robust.Client\GameStates\ClientGameStateManager.cs:line 616
   at Robust.Client.GameStates.ClientGameStateManager.ApplyGameState() in C:\Projects\CM-14\RobustToolbox\Robust.Client\GameStates\ClientGameStateManager.cs:line 338
```