### PR TITLE
Fix never setting BoundUserInterface.State

### DIFF
--- a/Robust.Shared/GameObjects/Components/UserInterface/BoundUserInterface.cs
+++ b/Robust.Shared/GameObjects/Components/UserInterface/BoundUserInterface.cs
@@ -19,7 +19,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         ///     The last received state object sent from the server.
         /// </summary>
-        protected BoundUserInterfaceState? State { get; private set; }
+        protected internal BoundUserInterfaceState? State { get; set; }
 
         protected BoundUserInterface(EntityUid owner, Enum uiKey)
         {

--- a/Robust.Shared/GameObjects/Components/UserInterface/BoundUserInterface.cs
+++ b/Robust.Shared/GameObjects/Components/UserInterface/BoundUserInterface.cs
@@ -19,7 +19,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         ///     The last received state object sent from the server.
         /// </summary>
-        protected internal BoundUserInterfaceState? State { get; set; }
+        protected internal BoundUserInterfaceState? State { get; internal set; }
 
         protected BoundUserInterface(EntityUid owner, Enum uiKey)
         {

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -387,6 +387,7 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
             if (!ent.Comp.ClientOpenInterfaces.TryGetValue(key, out var cBui))
                 continue;
 
+            cBui.State = buiState;
             cBui.UpdateState(buiState);
         }
 
@@ -432,6 +433,7 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
 
         if (entity.Comp.States.TryGetValue(key, out var buiState))
         {
+            boundUserInterface.State = buiState;
             boundUserInterface.UpdateState(buiState);
         }
     }


### PR DESCRIPTION
I don't know if the one in line 436 is strictly necessary but this should be the same as the old behavior.