### PR TITLE
Fix checking wrong property in `TryGetVariableType()`

### DIFF
--- a/Robust.Shared/Serialization/Manager/SerializationManager.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.cs
@@ -271,7 +271,7 @@ namespace Robust.Shared.Serialization.Manager
                 variableType = null;
                 return false;
             }
-            var foundFieldDef = definition.BaseFieldDefinitions.FirstOrDefault(fieldDef => fieldDef?.BackingField.Name==variableName, null);
+            var foundFieldDef = definition.BaseFieldDefinitions.FirstOrDefault(fieldDef => fieldDef?.Attribute is DataFieldAttribute attr && attr.Tag==variableName, null);
             if(foundFieldDef != null)
             {
                 variableType = foundFieldDef.BackingField.FieldType;


### PR DESCRIPTION
I guess I only tested the case where the tag and variable name happened to match. Whoops.

`BackingField.Name` is the var name ie `BackgroundColor`
`Attribute.Tag` is the `DataField` tag name ie `background-color`