### PR TITLE
Add audio stream name to entity name

### DIFF
--- a/Robust.Client/Audio/AudioSystem.cs
+++ b/Robust.Client/Audio/AudioSystem.cs
@@ -671,7 +671,7 @@ public sealed partial class AudioSystem : SharedAudioSystem
     private (EntityUid Entity, AudioComponent Component) CreateAndStartPlayingStream(AudioParams? audioParams, AudioStream stream)
     {
         var audioP = audioParams ?? AudioParams.Default;
-        var entity = EntityManager.CreateEntityUninitialized("Audio", MapCoordinates.Nullspace);
+        var entity = EntityManager.CreateEntityUninitialized($"Audio {stream.Name}", MapCoordinates.Nullspace);
         var comp = SetupAudio(entity, null, audioP, stream.Length);
         LoadStream((entity, comp), stream);
         EntityManager.InitializeAndStartEntity(entity);


### PR DESCRIPTION
Not sure if this is the correct way to do this, but having the audio name when debugging helps a lot when figuring out where audio came from.