### PR TITLE
remove XAMLIL from assembly after use

### DIFF
--- a/Robust.Client.Injectors/XamlCompiler.cs
+++ b/Robust.Client.Injectors/XamlCompiler.cs
@@ -239,6 +239,7 @@ namespace Robust.Build.Tasks
                         engine.LogErrorEvent(new BuildErrorEventArgs("XAMLIL", "", res.FilePath, 0, 0, 0, 0,
                             $"{res.FilePath}: {e.Message}", "", "CompileRobustXaml"));
                     }
+                    res.Remove();
                 }
                 return true;
             }


### PR DESCRIPTION
Simple. These embedded resources (probably) aren't used after we generate the populate method and inject it into the `BaseWindow` constructors. Therefore, we can just get rid of them. 

The savings are incredible.

**`Robust.Client.dll`**: 1,833 KiB (1,876,992 B) → 1,816 KiB (1,859,584 B) 
**`Content.Client.dll`**: 3,116 KiB (3,190,784 B) → 3,105 KiB (3,180,032 B)

I'm like, pretty sure this doesn't break anything. UIs still open and everything, so, it's probably fine.