### PR TITLE
Fix ordered subscriptions not working when targeting a parent system type

### DIFF
--- a/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs
@@ -167,10 +167,7 @@ namespace Robust.Shared.GameObjects
             if (eventHandler == null)
                 throw new ArgumentNullException(nameof(eventHandler));
 
-            ExpandOrdering(ref before);
-            ExpandOrdering(ref after);
-
-            var order = new OrderingData(orderType, before ?? Array.Empty<Type>(), after ?? Array.Empty<Type>());
+            var order = CreateOrderingData(orderType, before, after);
 
             SubscribeEventCommon<T>(source, subscriber,
                 (ref Unit ev) => eventHandler(Unsafe.As<Unit, T>(ref ev)), eventHandler, order, false);
@@ -190,10 +187,7 @@ namespace Robust.Shared.GameObjects
             EntityEventRefHandler<T> eventHandler,
             Type orderType, Type[]? before = null, Type[]? after = null) where T : notnull
         {
-            ExpandOrdering(ref before);
-            ExpandOrdering(ref after);
-
-            var order = new OrderingData(orderType, before ?? Array.Empty<Type>(), after ?? Array.Empty<Type>());
+            var order = CreateOrderingData(orderType, before, after);
 
             SubscribeEventCommon<T>(source, subscriber, (ref Unit ev) =>
             {

--- a/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs
@@ -167,6 +167,9 @@ namespace Robust.Shared.GameObjects
             if (eventHandler == null)
                 throw new ArgumentNullException(nameof(eventHandler));
 
+            ExpandOrdering(ref before);
+            ExpandOrdering(ref after);
+
             var order = new OrderingData(orderType, before ?? Array.Empty<Type>(), after ?? Array.Empty<Type>());
 
             SubscribeEventCommon<T>(source, subscriber,
@@ -187,6 +190,9 @@ namespace Robust.Shared.GameObjects
             EntityEventRefHandler<T> eventHandler,
             Type orderType, Type[]? before = null, Type[]? after = null) where T : notnull
         {
+            ExpandOrdering(ref before);
+            ExpandOrdering(ref after);
+
             var order = new OrderingData(orderType, before ?? Array.Empty<Type>(), after ?? Array.Empty<Type>());
 
             SubscribeEventCommon<T>(source, subscriber, (ref Unit ev) =>

--- a/Robust.Shared/GameObjects/EntityEventBus.Common.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Common.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using JetBrains.Annotations;
 using Robust.Shared.Collections;
+using Robust.Shared.Reflection;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.GameObjects;
@@ -13,6 +14,7 @@ internal sealed partial class EntityEventBus : IEventBus
 {
     private IEntityManager _entMan;
     private IComponentFactory _comFac;
+    private IReflectionManager _reflection;
 
     // Data on individual events. Used to check ordering info and fire broadcast events.
     private FrozenDictionary<Type, EventData> _eventData = FrozenDictionary<Type, EventData>.Empty;
@@ -48,6 +50,8 @@ internal sealed partial class EntityEventBus : IEventBus
     private bool _subscriptionLock;
 
     public bool IgnoreUnregisteredComponents;
+
+    private readonly List<Type> _subscriptionTypesTemp = [];
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static ref Unit ExtractUnitRef(ref object obj, Type objType)

--- a/Robust.Shared/GameObjects/EntityEventBus.Common.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Common.cs
@@ -51,7 +51,7 @@ internal sealed partial class EntityEventBus : IEventBus
 
     public bool IgnoreUnregisteredComponents;
 
-    private readonly List<Type> _subscriptionTypesTemp = [];
+    private readonly List<Type> _childrenTypesTemp = [];
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static ref Unit ExtractUnitRef(ref object obj, Type objType)

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -251,10 +251,7 @@ namespace Robust.Shared.GameObjects
             void EventHandler(EntityUid uid, IComponent comp, ref TEvent args)
                 => handler(uid, (TComp)comp, args);
 
-            ExpandOrdering(ref before);
-            ExpandOrdering(ref after);
-
-            var orderData = new OrderingData(orderType, before ?? Array.Empty<Type>(), after ?? Array.Empty<Type>());
+            var orderData = CreateOrderingData(orderType, before, after);
 
             EntSubscribe<TEvent>(
                 CompIdx.Index<TComp>(),
@@ -287,10 +284,7 @@ namespace Robust.Shared.GameObjects
             void EventHandler(EntityUid uid, IComponent comp, ref TEvent args)
                 => handler(uid, (TComp)comp, ref args);
 
-            ExpandOrdering(ref before);
-            ExpandOrdering(ref after);
-
-            var orderData = new OrderingData(orderType, before ?? Array.Empty<Type>(), after ?? Array.Empty<Type>());
+            var orderData = CreateOrderingData(orderType, before, after);
 
             EntSubscribe<TEvent>(
                 CompIdx.Index<TComp>(),
@@ -309,10 +303,7 @@ namespace Robust.Shared.GameObjects
             void EventHandler(EntityUid uid, IComponent comp, ref TEvent args)
                 => handler(new Entity<TComp>(uid, (TComp) comp), ref args);
 
-            ExpandOrdering(ref before);
-            ExpandOrdering(ref after);
-
-            var orderData = new OrderingData(orderType, before ?? Array.Empty<Type>(), after ?? Array.Empty<Type>());
+            var orderData = CreateOrderingData(orderType, before, after);
 
             EntSubscribe<TEvent>(
                 CompIdx.Index<TComp>(),

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -251,6 +251,9 @@ namespace Robust.Shared.GameObjects
             void EventHandler(EntityUid uid, IComponent comp, ref TEvent args)
                 => handler(uid, (TComp)comp, args);
 
+            ExpandOrdering(ref before);
+            ExpandOrdering(ref after);
+
             var orderData = new OrderingData(orderType, before ?? Array.Empty<Type>(), after ?? Array.Empty<Type>());
 
             EntSubscribe<TEvent>(
@@ -284,6 +287,9 @@ namespace Robust.Shared.GameObjects
             void EventHandler(EntityUid uid, IComponent comp, ref TEvent args)
                 => handler(uid, (TComp)comp, ref args);
 
+            ExpandOrdering(ref before);
+            ExpandOrdering(ref after);
+
             var orderData = new OrderingData(orderType, before ?? Array.Empty<Type>(), after ?? Array.Empty<Type>());
 
             EntSubscribe<TEvent>(
@@ -302,27 +308,6 @@ namespace Robust.Shared.GameObjects
         {
             void EventHandler(EntityUid uid, IComponent comp, ref TEvent args)
                 => handler(new Entity<TComp>(uid, (TComp) comp), ref args);
-
-            void ExpandOrdering(ref Type[]? original)
-            {
-                if (original == null || original.Length == 0)
-                    return;
-
-                _subscriptionTypesTemp.Clear();
-                foreach (var beforeType in original)
-                {
-                    foreach (var child in _reflection.GetAllChildren(beforeType))
-                    {
-                        _subscriptionTypesTemp.Add(child);
-                    }
-                }
-
-                if (_subscriptionTypesTemp.Count > 0)
-                {
-                    Array.Resize(ref original, original.Length + _subscriptionTypesTemp.Count);
-                    _subscriptionTypesTemp.CopyTo(original, original.Length - _subscriptionTypesTemp.Count);
-                }
-            }
 
             ExpandOrdering(ref before);
             ExpandOrdering(ref after);

--- a/Robust.Shared/GameObjects/EntityEventBus.Ordering.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Ordering.cs
@@ -200,5 +200,26 @@ namespace Robust.Shared.GameObjects
                 }
             }
         }
+
+        private void ExpandOrdering(ref Type[]? original)
+        {
+            if (original == null || original.Length == 0)
+                return;
+
+            _subscriptionTypesTemp.Clear();
+            foreach (var beforeType in original)
+            {
+                foreach (var child in _reflection.GetAllChildren(beforeType))
+                {
+                    _subscriptionTypesTemp.Add(child);
+                }
+            }
+
+            if (_subscriptionTypesTemp.Count > 0)
+            {
+                Array.Resize(ref original, original.Length + _subscriptionTypesTemp.Count);
+                _subscriptionTypesTemp.CopyTo(original, original.Length - _subscriptionTypesTemp.Count);
+            }
+        }
     }
 }

--- a/Robust.Shared/GameObjects/EntityEventBus.Ordering.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Ordering.cs
@@ -201,24 +201,31 @@ namespace Robust.Shared.GameObjects
             }
         }
 
-        private void ExpandOrdering(ref Type[]? original)
+        private OrderingData CreateOrderingData(Type orderType, Type[]? before, Type[]? after)
+        {
+            AddChildrenTypes(ref before);
+            AddChildrenTypes(ref after);
+            return new OrderingData(orderType, before ?? [], after ?? []);
+        }
+
+        private void AddChildrenTypes(ref Type[]? original)
         {
             if (original == null || original.Length == 0)
                 return;
 
-            _subscriptionTypesTemp.Clear();
+            _childrenTypesTemp.Clear();
             foreach (var beforeType in original)
             {
                 foreach (var child in _reflection.GetAllChildren(beforeType))
                 {
-                    _subscriptionTypesTemp.Add(child);
+                    _childrenTypesTemp.Add(child);
                 }
             }
 
-            if (_subscriptionTypesTemp.Count > 0)
+            if (_childrenTypesTemp.Count > 0)
             {
-                Array.Resize(ref original, original.Length + _subscriptionTypesTemp.Count);
-                _subscriptionTypesTemp.CopyTo(original, original.Length - _subscriptionTypesTemp.Count);
+                Array.Resize(ref original, original.Length + _childrenTypesTemp.Count);
+                _childrenTypesTemp.CopyTo(original, original.Length - _childrenTypesTemp.Count);
             }
         }
     }

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -15,6 +15,7 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Player;
 using Robust.Shared.Profiling;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Reflection;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Timing;
@@ -40,6 +41,7 @@ namespace Robust.Shared.GameObjects
         [IoC.Dependency] private readonly ISerializationManager _serManager = default!;
         [IoC.Dependency] private readonly ProfManager _prof = default!;
         [IoC.Dependency] private readonly INetManager _netMan = default!;
+        [IoC.Dependency] private readonly IReflectionManager _reflection = default!;
 
         // I feel like PJB might shed me for putting a system dependency here, but its required for setting entity
         // positions on spawn....
@@ -125,7 +127,7 @@ namespace Robust.Shared.GameObjects
             if (Initialized)
                 throw new InvalidOperationException("Initialize() called multiple times");
 
-            _eventBus = new EntityEventBus(this);
+            _eventBus = new EntityEventBus(this, _reflection);
 
             InitializeComponents();
             _metaReg = _componentFactory.GetRegistration(typeof(MetaDataComponent));

--- a/Robust.Shared/GameObjects/EntitySystem.Subscriptions.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Subscriptions.cs
@@ -109,6 +109,17 @@ namespace Robust.Shared.GameObjects
             _subscriptions.Add(new SubBroadcast<EntitySessionMessage<T>>(src));
         }
 
+        protected void SubscribeLocalEvent<TComp, TEvent>(
+            EntityEventRefHandler<TComp, TEvent> handler,
+            Type[]? before = null, Type[]? after = null)
+            where TComp : IComponent
+            where TEvent : notnull
+        {
+            EntityManager.EventBus.SubscribeLocalEvent(handler, GetType(), before, after);
+
+            _subscriptions.Add(new SubLocal<TComp, TEvent>());
+        }
+
         /// <seealso cref="SubscribeLocalEvent{TComp, TEvent}(ComponentEventRefHandler{TComp, TEvent}, Type[], Type[])"/>
         // [Obsolete("Subscribe to the event by ref instead (ComponentEventRefHandler)")]
         protected void SubscribeLocalEvent<TComp, TEvent>(
@@ -124,17 +135,6 @@ namespace Robust.Shared.GameObjects
 
         protected void SubscribeLocalEvent<TComp, TEvent>(
             ComponentEventRefHandler<TComp, TEvent> handler,
-            Type[]? before = null, Type[]? after = null)
-            where TComp : IComponent
-            where TEvent : notnull
-        {
-            EntityManager.EventBus.SubscribeLocalEvent(handler, GetType(), before, after);
-
-            _subscriptions.Add(new SubLocal<TComp, TEvent>());
-        }
-
-        protected void SubscribeLocalEvent<TComp, TEvent>(
-            EntityEventRefHandler<TComp, TEvent> handler,
             Type[]? before = null, Type[]? after = null)
             where TComp : IComponent
             where TEvent : notnull

--- a/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.ComponentEvent.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.ComponentEvent.cs
@@ -1,10 +1,10 @@
-using System;
 using System.Collections.Generic;
 using Moq;
 using NUnit.Framework;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
+using Robust.Shared.Reflection;
 using Robust.UnitTesting.Shared.Reflection;
 
 namespace Robust.UnitTesting.Shared.GameObjects
@@ -21,6 +21,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var compInstance = new MetaDataComponent();
 
             var entManMock = new Mock<IEntityManager>();
+            var reflectMock = new Mock<IReflectionManager>();
 
             compFactory.RegisterClass<MetaDataComponent>();
             entManMock.Setup(m => m.ComponentFactory).Returns(compFactory);
@@ -35,7 +36,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             entManMock.Setup(m => m.GetComponentInternal(entUid, CompIdx.Index<MetaDataComponent>()))
                 .Returns(compInstance);
 
-            var bus = new EntityEventBus(entManMock.Object);
+            var bus = new EntityEventBus(entManMock.Object, reflectMock.Object);
             bus.OnlyCallOnRobustUnitTestISwearToGodPleaseSomebodyKillThisNightmare();
 
             // Subscribe
@@ -80,6 +81,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
                 CompIdx.Index<MetaDataComponent>());
 
             var compFacMock = new Mock<IComponentFactory>();
+            var reflectMock = new Mock<IReflectionManager>();
 
             compFacMock.Setup(m => m.GetRegistration(CompIdx.Index<MetaDataComponent>())).Returns(compRegistration);
             compFacMock.Setup(m => m.GetAllRegistrations()).Returns(new[] { compRegistration });
@@ -92,7 +94,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             entManMock.Setup(m => m.GetComponent(entUid, typeof(MetaDataComponent)))
                 .Returns(compInstance);
 
-            var bus = new EntityEventBus(entManMock.Object);
+            var bus = new EntityEventBus(entManMock.Object, reflectMock.Object);
             bus.OnlyCallOnRobustUnitTestISwearToGodPleaseSomebodyKillThisNightmare();
 
             // Subscribe
@@ -137,6 +139,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
                 CompIdx.Index<MetaDataComponent>());
 
             var compFacMock = new Mock<IComponentFactory>();
+            var reflectMock = new Mock<IReflectionManager>();
 
             compFacMock.Setup(m => m.GetRegistration(CompIdx.Index<MetaDataComponent>())).Returns(compRegistration);
             compFacMock.Setup(m => m.GetAllRegistrations()).Returns(new[] { compRegistration });
@@ -149,7 +152,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             entManMock.Setup(m => m.GetComponent(entUid, typeof(MetaDataComponent)))
                 .Returns(compInstance);
 
-            var bus = new EntityEventBus(entManMock.Object);
+            var bus = new EntityEventBus(entManMock.Object, reflectMock.Object);
             bus.OnlyCallOnRobustUnitTestISwearToGodPleaseSomebodyKillThisNightmare();
 
             // Subscribe
@@ -184,6 +187,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
 
             var entManMock = new Mock<IEntityManager>();
             var compFacMock = new Mock<IComponentFactory>();
+            var reflectMock = new Mock<IReflectionManager>();
 
             List<ComponentRegistration> allRefTypes = new();
             void Setup<T>(out T instance) where T : IComponent, new()
@@ -208,7 +212,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             compFacMock.Setup(m => m.GetAllRegistrations()).Returns(allRefTypes.ToArray());
 
             entManMock.Setup(m => m.ComponentFactory).Returns(compFacMock.Object);
-            var bus = new EntityEventBus(entManMock.Object);
+            var bus = new EntityEventBus(entManMock.Object, reflectMock.Object);
             bus.OnlyCallOnRobustUnitTestISwearToGodPleaseSomebodyKillThisNightmare();
 
             // Subscribe

--- a/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.SystemEvent.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.SystemEvent.cs
@@ -2,6 +2,7 @@ using System;
 using Moq;
 using NUnit.Framework;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Reflection;
 
 namespace Robust.UnitTesting.Shared.GameObjects
 {
@@ -12,8 +13,9 @@ namespace Robust.UnitTesting.Shared.GameObjects
         {
             var compFacMock = new Mock<IComponentFactory>();
             var entManMock = new Mock<IEntityManager>();
+            var reflectMock = new Mock<IReflectionManager>();
             entManMock.SetupGet(e => e.ComponentFactory).Returns(compFacMock.Object);
-            var bus = new EntityEventBus(entManMock.Object);
+            var bus = new EntityEventBus(entManMock.Object, reflectMock.Object);
             return bus;
         }
 


### PR DESCRIPTION
This makes it so if you subscribe before or after a SharedSystem, you also subscribe before or after any types derived from that SharedSystem.