### PR TITLE
Don't iterate over component events when removing components

### DIFF
--- a/Robust.Shared/GameObjects/EntityEventBus.Common.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Common.cs
@@ -37,8 +37,7 @@ internal sealed partial class EntityEventBus : IEventBus
     internal FrozenDictionary<Type, DirectedRegistration>[] _eventSubs = default!;
 
     /// <summary>
-    /// Array of component event handlers for events with the <see cref="ComponentEventAttribute"/>. The array is
-    /// indexed by a component's <see cref="CompIdx.Value"/>, while the dictionary is indexed by the event type.
+    /// Variant of <see cref="_eventSubs"/> that also includes events with the <see cref="ComponentEventAttribute"/>
     /// </summary>
     internal FrozenDictionary<Type, DirectedRegistration>[] _compEventSubs = default!;
 

--- a/Robust.Shared/GameObjects/EntityEventBus.Common.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Common.cs
@@ -29,20 +29,29 @@ internal sealed partial class EntityEventBus : IEventBus
     // See EventTable declaration for layout details
     internal Dictionary<EntityUid, EventTable> _entEventTables = new();
 
-    // CompType -> EventType -> Handler
-    internal FrozenDictionary<Type, DirectedRegistration>?[] _entSubscriptions = default!;
+    /// <summary>
+    /// Array of component events and their handlers. The array is indexed by a component's
+    /// <see cref="CompIdx.Value"/>, while the dictionary is indexed by the event type. This does not include events
+    /// with the <see cref="ComponentEventAttribute"/>
+    /// </summary>
+    internal FrozenDictionary<Type, DirectedRegistration>[] _eventSubs = default!;
 
-    // Variant of _entSubscriptions that omits any events with the ComponentEventAttribute
-    internal FrozenDictionary<Type, DirectedRegistration>?[] _entSubscriptionsNoCompEv = default!;
+    /// <summary>
+    /// Array of component event handlers for events with the <see cref="ComponentEventAttribute"/>. The array is
+    /// indexed by a component's <see cref="CompIdx.Value"/>, while the dictionary is indexed by the event type.
+    /// </summary>
+    internal FrozenDictionary<Type, DirectedRegistration>[] _compEventSubs = default!;
 
-    // pre-freeze _entSubscriptions data
-    internal Dictionary<Type, DirectedRegistration>?[] _entSubscriptionsUnfrozen =
-        Array.Empty<Dictionary<Type, DirectedRegistration>?>();
+    // pre-freeze event subscription data
+    internal Dictionary<Type, DirectedRegistration>?[] _eventSubsUnfrozen =
+        Array.Empty<Dictionary<Type, DirectedRegistration>>();
 
-    // EventType -> { CompType1, ... CompType N }
+    /// <summary>
+    /// Inverse of <see cref="_eventSubs"/>, mapping event types to sets of components.
+    /// </summary>
+    private Dictionary<Type, HashSet<CompIdx>> _eventSubsInv = new();
     // Only required to sort ordered subscriptions, which only happens during initialization
     // so doesn't need to be a frozen dictionary.
-    private Dictionary<Type, HashSet<CompIdx>> _entSubscriptionsInv = new();
 
     // prevents shitcode, get your subscriptions figured out before you start spawning entities
     private bool _subscriptionLock;

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -351,12 +351,22 @@ namespace Robust.Shared.GameObjects
             _subscriptionLock = true;
             _eventData = _eventDataUnfrozen.ToFrozenDictionary();
 
+            // Find last non-null entry.
+            var last = 0;
+            for (var i = 0; i < _eventSubsUnfrozen.Length; i++)
+            {
+                var entry = _eventSubsUnfrozen[i];
+                if (entry != null)
+                    last = i;
+            }
+            
             _compEventSubs = _eventSubsUnfrozen
+                .Take(last+1)
                 .Select(dict => dict?.Where(x => IsComponentEvent(x.Key)).ToFrozenDictionary()!)
                 .ToArray();
 
             _eventSubs = _eventSubsUnfrozen
-                .Where(dict => dict != null)
+                .Take(last+1)
                 .Select(dict => dict?.Where(x => !IsComponentEvent(x.Key)).ToFrozenDictionary()!)
                 .ToArray();
 

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -351,30 +351,13 @@ namespace Robust.Shared.GameObjects
             _subscriptionLock = true;
             _eventData = _eventDataUnfrozen.ToFrozenDictionary();
 
-            // null entries in _entSubscriptionsUnfrozen should all appear all together at the end.
-            // if not, something probably went wrong while adding component subscriptions or assigning CompIdx values.
-#if DEBUG
-            var firstNull = false;
-            foreach (var entry in _eventSubsUnfrozen)
-            {
-                if (entry == null)
-                {
-                    firstNull = true;
-                    continue;
-                }
-
-                DebugTools.Assert(!firstNull);
-            }
-#endif
-
             _compEventSubs = _eventSubsUnfrozen
-                .Where(dict => dict != null)
-                .Select(dict => dict!.Where(x => IsComponentEvent(x.Key)).ToFrozenDictionary())
+                .Select(dict => dict?.Where(x => IsComponentEvent(x.Key)).ToFrozenDictionary()!)
                 .ToArray();
 
             _eventSubs = _eventSubsUnfrozen
                 .Where(dict => dict != null)
-                .Select(dict => dict!.Where(x => !IsComponentEvent(x.Key)).ToFrozenDictionary())
+                .Select(dict => dict?.Where(x => !IsComponentEvent(x.Key)).ToFrozenDictionary()!)
                 .ToArray();
 
             CalcOrdering();

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -360,6 +360,11 @@ namespace Robust.Shared.GameObjects
                     last = i;
             }
 
+            // TODO PERFORMANCE
+            // make this only contain events that actually use comp-events
+            // Assuming it makes the frozen dictionaries more specialized and thus faster.
+            // AFAIK currently only MapInit is both a comp-event and a general event.
+            // It should probably be changed to just be a comp event.
             _compEventSubs = _eventSubsUnfrozen
                 .Take(last+1)
                 .Select(dict => dict?.ToFrozenDictionary()!)

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -359,10 +359,10 @@ namespace Robust.Shared.GameObjects
                 if (entry != null)
                     last = i;
             }
-            
+
             _compEventSubs = _eventSubsUnfrozen
                 .Take(last+1)
-                .Select(dict => dict?.Where(x => IsComponentEvent(x.Key)).ToFrozenDictionary()!)
+                .Select(dict => dict?.ToFrozenDictionary()!)
                 .ToArray();
 
             _eventSubs = _eventSubsUnfrozen

--- a/Robust.Shared/GameObjects/EntityEventBus.Ordering.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Ordering.cs
@@ -59,10 +59,10 @@ namespace Robust.Shared.GameObjects
 
             // Collect all subscriptions, broadcast and ordered.
             IEnumerable<OrderedRegistration> regs = sub.BroadcastRegistrations;
-            if (_entSubscriptionsInv.TryGetValue(eventType, out var comps))
+            if (_eventSubsInv.TryGetValue(eventType, out var comps))
             {
                 regs = regs.Concat(comps
-                    .Select(c => _entSubscriptions[c.Value])
+                    .Select(c => _eventSubs[c.Value])
                     .Where(c => c != null)
                     .Select(c => c![eventType]));
             }


### PR DESCRIPTION
This stops events with the `ComponentEventAttribute` from being iterated over when updating an entity's subscriptions during component removal.