### PR TITLE
Improve markup node equals method and implement `GetHashCode`

### DIFF
--- a/Robust.Shared/Utility/MarkupNode.cs
+++ b/Robust.Shared/Utility/MarkupNode.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
 
@@ -32,8 +33,9 @@ public sealed class MarkupNode : IComparable<MarkupNode>
     }
 
     public override bool Equals(object? obj) =>
-        obj is MarkupNode node &&
-        (node.Name, node.Value, node.Attributes, node.Closing).Equals((Name, Value, Attributes, Closing));
+        obj is MarkupNode node
+        &&  node.Attributes.Count == Attributes.Count && !node.Attributes.Except(Attributes).Any()
+        && (node.Name, node.Value, node.Closing).Equals((Name, Value, Closing));
 
     public override int GetHashCode() => (Name, Value, Attributes, Closing).GetHashCode();
 

--- a/Robust.Shared/Utility/MarkupNode.cs
+++ b/Robust.Shared/Utility/MarkupNode.cs
@@ -31,6 +31,12 @@ public sealed class MarkupNode : IComparable<MarkupNode>
         Closing = closing;
     }
 
+    public override bool Equals(object? obj) =>
+        obj is MarkupNode node &&
+        (node.Name, node.Value, node.Attributes, node.Closing).Equals((Name, Value, Attributes, Closing));
+
+    public override int GetHashCode() => (Name, Value, Attributes, Closing).GetHashCode();
+
     public override string ToString()
     {
         if(Name == null)
@@ -43,21 +49,6 @@ public sealed class MarkupNode : IComparable<MarkupNode>
         }
 
         return $"[{(Closing ? "/" : "")}{Name}{Value.ToString().ReplaceLineEndings("\\n") ?? ""}{attributesString}]";
-    }
-
-    public override bool Equals(object? obj)
-    {
-        return obj is MarkupNode node && Equals(node);
-    }
-
-    public bool Equals(MarkupNode node)
-    {
-        var equal = Name == node.Name;
-        equal &= Value.Equals(node.Value);
-        equal &= Attributes.Count == 0 && node.Attributes.Count == 0 || Attributes.Equals(node.Attributes);
-        equal &= Closing == node.Closing;
-
-        return equal;
     }
 
     public int CompareTo(MarkupNode? other)

--- a/Robust.UnitTesting/Shared/Utility/FormattedMessage_Test.cs
+++ b/Robust.UnitTesting/Shared/Utility/FormattedMessage_Test.cs
@@ -59,6 +59,19 @@ namespace Robust.UnitTesting.Shared.Utility
         }
 
         [Test]
+        public static void TestEquality()
+        {
+            var a = new MarkupNode("A");
+            var b = new MarkupNode("A");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(a.GetHashCode(), NUnit.Framework.Is.EqualTo(b.GetHashCode()));
+                Assert.That(a, NUnit.Framework.Is.EqualTo(b));
+            });
+        }
+
+        [Test]
         [TestCase("foo[color=#aabbcc bar")]
         public static void TestParsePermissiveMarkup(string text)
         {

--- a/Robust.UnitTesting/Shared/Utility/FormattedMessage_Test.cs
+++ b/Robust.UnitTesting/Shared/Utility/FormattedMessage_Test.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using Robust.Shared.Maths;
@@ -36,6 +37,23 @@ namespace Robust.UnitTesting.Shared.Utility
                 new("color", new MarkupParameter(Color.Orange), null),
                 new("bar"),
                 new("color", null, null, true),
+                new("baz")
+            }));
+        }
+
+        [Test]
+        public static void TestParseMarkupAttributes()
+        {
+            var msg = FormattedMessage.FromMarkup("foo[font=\"Roboto\" size=10]bar[/font]baz");
+
+            var attributes = new Dictionary<string, MarkupParameter> {{"size", new MarkupParameter(10)}};
+
+            Assert.That(msg.Nodes, NUnit.Framework.Is.EquivalentTo(new MarkupNode[]
+            {
+                new("foo"),
+                new("font", new MarkupParameter("Roboto"), attributes),
+                new("bar"),
+                new("font", null, null, true),
                 new("baz")
             }));
         }


### PR DESCRIPTION
What it says on the tin.

The equals method wasn't implemented correctly. I looked up how it and `GetHashCode` is supposed to be implemented and fixed the implementation accordingly.