### PR TITLE
Use non-generic `TryComp()` for metadata & transform

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
@@ -242,7 +242,7 @@ namespace Robust.Client.GameObjects
 #if DEBUG
             var uid = GetEntity(netEntity);
 
-            if (TryComp<MetaDataComponent>(uid, out var meta))
+            if (TryComp(uid, out MetaDataComponent? meta))
             {
                 DebugTools.Assert((meta.Flags & ( MetaDataFlags.Detached | MetaDataFlags.InContainer) ) == MetaDataFlags.Detached,
                     $"Adding entity {ToPrettyString(uid)} to list of expected entities for container {container.ID} in {ToPrettyString(container.Owner)}, despite it already being in a container.");

--- a/Robust.Client/GameObjects/EntitySystems/EyeSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/EyeSystem.cs
@@ -56,7 +56,7 @@ public sealed class EyeSystem : SharedEyeSystem
             if (eyeComponent.Eye == null)
                 continue;
 
-            if (!TryComp<TransformComponent>(eyeComponent.Target, out var xform))
+            if (!TryComp(eyeComponent.Target, out TransformComponent? xform))
             {
                 xform = Transform(uid);
                 eyeComponent.Target = null;

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -508,7 +508,7 @@ public abstract partial class SharedMapSystem
     private void OnGridRemove(EntityUid uid, MapGridComponent component, ComponentShutdown args)
     {
         Log.Info($"Removing grid {ToPrettyString(uid)}");
-        if (TryComp<TransformComponent>(uid, out var xform) && xform.MapUid != null)
+        if (TryComp(uid, out TransformComponent? xform) && xform.MapUid != null)
         {
             RemoveGrid(uid, component, xform.MapUid.Value);
         }


### PR DESCRIPTION
Allows entity systems to use the cached xform & metadata queries 