### PR TITLE
LineEdit placeholder tweaks

### DIFF
--- a/Robust.Client/UserInterface/Controls/LineEdit.cs
+++ b/Robust.Client/UserInterface/Controls/LineEdit.cs
@@ -8,7 +8,6 @@ using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.Input;
 using Robust.Shared.IoC;
-using Robust.Shared.Log;
 using Robust.Shared.Maths;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -54,7 +53,7 @@ namespace Robust.Client.UserInterface.Controls
         private TimeSpan? _lastClickTime;
         private Vector2? _lastClickPosition;
 
-        private bool IsPlaceHolderVisible => !(HidePlaceHolderOnFocus && Focused) && string.IsNullOrEmpty(_text) && _placeHolder != null;
+        private bool IsPlaceHolderVisible => !(HidePlaceHolderOnFocus && HasKeyboardFocus()) && string.IsNullOrEmpty(_text) && _placeHolder != null;
 
         public event Action<LineEditEventArgs>? OnTextChanged;
         public event Action<LineEditEventArgs>? OnTextEntered;
@@ -187,9 +186,7 @@ namespace Robust.Client.UserInterface.Controls
         public int SelectionLower => Math.Min(_selectionStart, _cursorPosition);
         public int SelectionUpper => Math.Max(_selectionStart, _cursorPosition);
 
-        public bool Focused;
-
-        public bool HidePlaceHolderOnFocus;
+        public bool HidePlaceHolderOnFocus { get; set; }
 
         public bool IgnoreNext { get; set; }
 
@@ -866,7 +863,6 @@ namespace Robust.Client.UserInterface.Controls
             // Reset this so the cursor is always visible immediately after gaining focus..
             _blink.Reset();
             OnFocusEnter?.Invoke(new LineEditEventArgs(this, _text));
-            Focused = true;
 
             if (Editable)
             {
@@ -879,7 +875,6 @@ namespace Robust.Client.UserInterface.Controls
             base.KeyboardFocusExited();
 
             OnFocusExit?.Invoke(new LineEditEventArgs(this, _text));
-            Focused = false;
 
             _clyde.TextInputStop();
             AbortIme(delete: false);

--- a/Robust.Client/UserInterface/Controls/LineEdit.cs
+++ b/Robust.Client/UserInterface/Controls/LineEdit.cs
@@ -8,6 +8,7 @@ using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.Input;
 using Robust.Shared.IoC;
+using Robust.Shared.Log;
 using Robust.Shared.Maths;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -53,7 +54,7 @@ namespace Robust.Client.UserInterface.Controls
         private TimeSpan? _lastClickTime;
         private Vector2? _lastClickPosition;
 
-        private bool IsPlaceHolderVisible => string.IsNullOrEmpty(_text) && _placeHolder != null && (HidePlaceHolderOnFocus && !Focused);
+        private bool IsPlaceHolderVisible => !(HidePlaceHolderOnFocus && Focused) && string.IsNullOrEmpty(_text) && _placeHolder != null;
 
         public event Action<LineEditEventArgs>? OnTextChanged;
         public event Action<LineEditEventArgs>? OnTextEntered;

--- a/Robust.Client/UserInterface/Controls/LineEdit.cs
+++ b/Robust.Client/UserInterface/Controls/LineEdit.cs
@@ -53,7 +53,7 @@ namespace Robust.Client.UserInterface.Controls
         private TimeSpan? _lastClickTime;
         private Vector2? _lastClickPosition;
 
-        private bool IsPlaceHolderVisible => string.IsNullOrEmpty(_text) && _placeHolder != null;
+        private bool IsPlaceHolderVisible => string.IsNullOrEmpty(_text) && _placeHolder != null && (HidePlaceHolderOnFocus && !Focused);
 
         public event Action<LineEditEventArgs>? OnTextChanged;
         public event Action<LineEditEventArgs>? OnTextEntered;
@@ -185,6 +185,10 @@ namespace Robust.Client.UserInterface.Controls
 
         public int SelectionLower => Math.Min(_selectionStart, _cursorPosition);
         public int SelectionUpper => Math.Max(_selectionStart, _cursorPosition);
+
+        public bool Focused;
+
+        public bool HidePlaceHolderOnFocus;
 
         public bool IgnoreNext { get; set; }
 
@@ -861,6 +865,7 @@ namespace Robust.Client.UserInterface.Controls
             // Reset this so the cursor is always visible immediately after gaining focus..
             _blink.Reset();
             OnFocusEnter?.Invoke(new LineEditEventArgs(this, _text));
+            Focused = true;
 
             if (Editable)
             {
@@ -873,6 +878,7 @@ namespace Robust.Client.UserInterface.Controls
             base.KeyboardFocusExited();
 
             OnFocusExit?.Invoke(new LineEditEventArgs(this, _text));
+            Focused = false;
 
             _clyde.TextInputStop();
             AbortIme(delete: false);


### PR DESCRIPTION
Adds a new field `HidePlaceHolderOnFocus` that dictates whether or not to hide a placeholder when we focus on the line input