### PR TITLE
Stream replay loading using seperate Decompression and Seserialize tasks

### DIFF
--- a/Robust.Client/Replays/Loading/IReplayLoadManager.cs
+++ b/Robust.Client/Replays/Loading/IReplayLoadManager.cs
@@ -31,7 +31,7 @@ public interface IReplayLoadManager
     /// <param name="fileReader">A reader containing the replay files. Disposed when loading is done.</param>
     /// <param name="callback">A callback delegate that invoked to provide information about the current loading
     /// progress. This callback can be used to invoke <see cref="Job{T}.SuspendIfOutOfTime"/>. </param>
-    Task<ReplayData> LoadReplayAsync(IReplayFileReader fileReader, LoadReplayCallback callback);
+    Task<ReplayData> LoadReplayAsync(IReplayFileReader fileReader, LoadReplayJob? job, LoadReplayCallback callback);
 
     /// <summary>
     /// Async task that loads the initial state of a replay, including spawning and initializing all entities. Note that
@@ -56,7 +56,7 @@ public interface IReplayLoadManager
     /// <param name="fileReader">A reader containing the replay files. Disposed when loading is done.</param>
     /// <param name="callback">A callback delegate that invoked to provide information about the current loading
     /// progress. This callback can be used to invoke <see cref="Job{T}.SuspendIfOutOfTime"/>. </param>
-    Task LoadAndStartReplayAsync(IReplayFileReader fileReader, LoadReplayCallback? callback = null);
+    Task LoadAndStartReplayAsync(IReplayFileReader fileReader, LoadReplayJob? job, LoadReplayCallback? callback = null);
 
     /// <summary>
     /// This is a variant of <see cref="LoadAndStartReplayAsync"/> that will first invoke <see cref="LoadOverride"/>

--- a/Robust.Client/Replays/Loading/LoadReplayJob.cs
+++ b/Robust.Client/Replays/Loading/LoadReplayJob.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Robust.Shared.ContentPack;
 using System.Threading.Tasks;
 using Robust.Shared.CPUJob.JobQueues;
@@ -27,7 +28,7 @@ public class LoadReplayJob : Job<bool>
 
     protected override async Task<bool> Process()
     {
-        await _loadMan.LoadAndStartReplayAsync(_fileReader, Yield);
+        await _loadMan.LoadAndStartReplayAsync(_fileReader, this, Yield);
         return true;
     }
 
@@ -39,5 +40,19 @@ public class LoadReplayJob : Job<bool>
             await SuspendNow();
         else
             await SuspendIfOutOfTime();
+    }
+
+    public new IAsyncEnumerable<TEnum> WrapAsyncEnumerator<TEnum>(IAsyncEnumerable<TEnum> innerEnum)
+    {
+        return base.WrapAsyncEnumerator(innerEnum);
+    }
+
+    public new ValueTask<TTask> WaitAsyncTask<TTask>(ValueTask<TTask> task)
+    {
+        return base.WaitAsyncTask(task);
+    }
+    public new Task WaitAsyncTask(Task task)
+    {
+        return base.WaitAsyncTask(task);
     }
 }

--- a/Robust.Client/Replays/Loading/LoadReplayJob.cs
+++ b/Robust.Client/Replays/Loading/LoadReplayJob.cs
@@ -42,11 +42,6 @@ public class LoadReplayJob : Job<bool>
             await SuspendIfOutOfTime();
     }
 
-    public new IAsyncEnumerable<TEnum> WrapAsyncEnumerator<TEnum>(IAsyncEnumerable<TEnum> innerEnum)
-    {
-        return base.WrapAsyncEnumerator(innerEnum);
-    }
-
     public new ValueTask<TTask> WaitAsyncTask<TTask>(ValueTask<TTask> task)
     {
         return base.WaitAsyncTask(task);

--- a/Robust.Client/Replays/Loading/ReplayLoadManager.Checkpoints.cs
+++ b/Robust.Client/Replays/Loading/ReplayLoadManager.Checkpoints.cs
@@ -104,6 +104,7 @@ public sealed partial class ReplayLoadManager
         var detachQueue = new Dictionary<GameTick, List<NetEntity>>();
 
         var firstData = await states.ReadAsync();
+        await callback(firstData.Progress, firstData.MaxProgress, LoadingState.ProcessingFiles, false);
         if (initMessages != null)
             UpdateMessages(initMessages, uploadedFiles, prototypes, cvars, detachQueue, ref timeBase, true);
         UpdateMessages(firstData.Messages, uploadedFiles, prototypes, cvars, detachQueue, ref timeBase, true);

--- a/Robust.Client/Replays/Loading/ReplayLoadManager.Checkpoints.cs
+++ b/Robust.Client/Replays/Loading/ReplayLoadManager.Checkpoints.cs
@@ -208,8 +208,8 @@ public sealed partial class ReplayLoadManager
             }
         }
 
-        _sawmill.Info($"Finished generating {checkPoints.Count} checkpoints. Elapsed time: {st.Elapsed}. Checkpoint every {(float)states.Count / checkPoints.Count} ticks on average");
-        _sawmill.Info($"Finished generating checkpoints. Elapsed time: {st.Elapsed}");
+        _sawmill.Info($"Finished generating {checkPoints.Count} checkpoints. Elapsed time: {st.Elapsed}. Checkpoint every {(float)lastStateId / checkPoints.Count} ticks on average");
+        _sawmill.Info($"Checkpoint stats - Spawning: {stats_due_spawned} StateChanges: {stats_due_state} Ticks: {stats_due_ticks}. ");
         await callback(10000, 10000, LoadingState.ProcessingFiles, false);
         return (checkPoints.ToArray(), serverTime.ToArray());
     }

--- a/Robust.Client/Replays/Loading/ReplayLoadManager.Read.cs
+++ b/Robust.Client/Replays/Loading/ReplayLoadManager.Read.cs
@@ -131,11 +131,6 @@ public sealed partial class ReplayLoadManager
                 // Send the memory stream back for reuse
                 await reuseFileChannel.Writer.WriteAsync(decompressed.Stream);
                 i += 1;
-
-                if (i % 10 == 1)
-                {
-                    _sawmill.Info($"Deserialized {i}. Decompressed files {decompressedFileChannel.Reader.Count}. Queued states {checkpointChannel.Reader.Count}. Total ticks {states.Count}");
-                }
             }
 
             // Done creating replay data to process in the background

--- a/Robust.Client/Replays/Loading/ReplayLoadManager.Start.cs
+++ b/Robust.Client/Replays/Loading/ReplayLoadManager.Start.cs
@@ -25,10 +25,11 @@ public sealed partial class ReplayLoadManager
 
     public async Task LoadAndStartReplayAsync(
         IReplayFileReader fileReader,
+        LoadReplayJob? job = null,
         LoadReplayCallback? callback = null)
     {
         callback ??= (_, _, _, _) => Task.CompletedTask;
-        var data = await LoadReplayAsync(fileReader, callback);
+        var data = await LoadReplayAsync(fileReader, job, callback);
         await StartReplayAsync(data, callback);
     }
 

--- a/Robust.Shared/CPUJob/JobQueues/Job.cs
+++ b/Robust.Shared/CPUJob/JobQueues/Job.cs
@@ -86,19 +86,6 @@ namespace Robust.Shared.CPUJob.JobQueues
             return new ValueTask(SuspendNow());
         }
 
-        protected async IAsyncEnumerable<TEnum> WrapAsyncEnumerator<TEnum>(IAsyncEnumerable<TEnum> innerEnum)
-        {
-            var e = innerEnum.GetAsyncEnumerator();
-            try
-            {
-                while (await WaitAsyncTask(e.MoveNextAsync()))
-                {
-                    yield return e.Current;
-                }
-            }
-            finally { if (e != null) await WaitAsyncTask(e.DisposeAsync()); }
-        }
-
         /// <summary>
         ///     Wrapper to await on an external ValueTask.
         /// </summary>
@@ -193,7 +180,6 @@ namespace Robust.Shared.CPUJob.JobQueues
                 "Run() called without resume. Was this called while the job is in Waiting state?");
             var resume = _resume;
             _resume = null;
-            Logger.Info($"Job: Run return state {Status} resume {resume}");
 
             Status = JobStatus.Running;
 


### PR DESCRIPTION
- Improves memory locality by immediately processing replay data that just got loaded into checkpoints (no time to flush from caches & page to disc)
- Reads data in parallel to checkpoint processing so 2x faster by better using multiple CPU cores
- Improves https://github.com/space-wizards/space-station-14/issues/28052 by ensuring low memory systems don't have to do a second pass over replay data that has likely been paged out 

How it works
- A decompression task opens and decompresses replay files, handing those MemoryStreams on using a channel
- A deserialization task processes each replay file, creating states and passing those on using a channel
- Checkpoint processing remains in the main thread, reading states as they are deseralized and processing these

On my system, the deserialization task remains a bottleneck (after other Replay Prs merged). We could deserialize with two tasks instead of one to further improve performance but I didn't want to over-complicate this PR.

There's also reuse of decompressed memory stream memory.

- Respects the Job system, using wrapped async waits if there is a Loading Job