### PR TITLE
msbuild option for generating xmldoc file for engine client / shared / server

### DIFF
--- a/MSBuild/Robust.Properties.targets
+++ b/MSBuild/Robust.Properties.targets
@@ -19,7 +19,7 @@
     <EnableClientScripting>False</EnableClientScripting>
     <!-- Client scripting is only enabled on tools builds for security and size reasons. -->
     <EnableClientScripting Condition="'$(RobustToolsBuild)' == 'true'">True</EnableClientScripting>
-    <GenerateXMLDocFile>False</GenerateXMLDocFile>
+    <RobustGenerateXMLDocFile>False</RobustGenerateXMLDocFile>
   </PropertyGroup>
 
   <!-- built-in define constants -->

--- a/MSBuild/Robust.Properties.targets
+++ b/MSBuild/Robust.Properties.targets
@@ -19,6 +19,7 @@
     <EnableClientScripting>False</EnableClientScripting>
     <!-- Client scripting is only enabled on tools builds for security and size reasons. -->
     <EnableClientScripting Condition="'$(RobustToolsBuild)' == 'true'">True</EnableClientScripting>
+    <GenerateXMLDocFile>False</GenerateXMLDocFile>
   </PropertyGroup>
 
   <!-- built-in define constants -->

--- a/Robust.Client/Robust.Client.csproj
+++ b/Robust.Client/Robust.Client.csproj
@@ -9,7 +9,7 @@
     <OutputPath>../bin/Client</OutputPath>
     <RobustILLink>true</RobustILLink>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' == 'Tools' Or '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'DebugOpt'">
+  <PropertyGroup Condition="'$(GenerateXMLDocFile)' == 'true'">
     <DocumentationFile>../bin/Client/Robust.Client.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/Robust.Client/Robust.Client.csproj
+++ b/Robust.Client/Robust.Client.csproj
@@ -9,6 +9,9 @@
     <OutputPath>../bin/Client</OutputPath>
     <RobustILLink>true</RobustILLink>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Tools' Or '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'DebugOpt'">
+    <DocumentationFile>../bin/Client/Robust.Client.xml</DocumentationFile>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DiscordRichPresence" PrivateAssets="compile" />
     <PackageReference Include="JetBrains.Annotations" PrivateAssets="All" />

--- a/Robust.Client/Robust.Client.csproj
+++ b/Robust.Client/Robust.Client.csproj
@@ -9,7 +9,7 @@
     <OutputPath>../bin/Client</OutputPath>
     <RobustILLink>true</RobustILLink>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(GenerateXMLDocFile)' == 'true'">
+  <PropertyGroup Condition="'$(RobustGenerateXMLDocFile)' == 'true'">
     <DocumentationFile>../bin/Client/Robust.Client.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -12,6 +12,9 @@
     <RobustILLink>true</RobustILLink>
     <NoWarn>CA1416</NoWarn>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Tools' Or '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'DebugOpt'">
+    <DocumentationFile>../bin/Server/Robust.Server.xml</DocumentationFile>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" PrivateAssets="All" />
     <PackageReference Include="SpaceWizards.HttpListener" PrivateAssets="compile" />

--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -12,7 +12,7 @@
     <RobustILLink>true</RobustILLink>
     <NoWarn>CA1416</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(GenerateXMLDocFile)' == 'true'">
+  <PropertyGroup Condition="'$(RobustGenerateXMLDocFile)' == 'true'">
     <DocumentationFile>../bin/Server/Robust.Server.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -12,7 +12,7 @@
     <RobustILLink>true</RobustILLink>
     <NoWarn>CA1416</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' == 'Tools' Or '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'DebugOpt'">
+  <PropertyGroup Condition="'$(GenerateXMLDocFile)' == 'true'">
     <DocumentationFile>../bin/Server/Robust.Server.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/Robust.Shared/Robust.Shared.csproj
+++ b/Robust.Shared/Robust.Shared.csproj
@@ -6,6 +6,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CA1416</NoWarn>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Tools' Or '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'DebugOpt'">
+    <DocumentationFile>../bin/Shared/Robust.Shared.xml</DocumentationFile>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" />

--- a/Robust.Shared/Robust.Shared.csproj
+++ b/Robust.Shared/Robust.Shared.csproj
@@ -6,7 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CA1416</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(GenerateXMLDocFile)' == 'true'">
+  <PropertyGroup Condition="'$(RobustGenerateXMLDocFile)' == 'true'">
     <DocumentationFile>../bin/Shared/Robust.Shared.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/Robust.Shared/Robust.Shared.csproj
+++ b/Robust.Shared/Robust.Shared.csproj
@@ -6,7 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CA1416</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' == 'Tools' Or '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'DebugOpt'">
+  <PropertyGroup Condition="'$(GenerateXMLDocFile)' == 'true'">
     <DocumentationFile>../bin/Shared/Robust.Shared.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
need this for something secret (useful)

so i can `dotnet build --property:RobustGenerateXMLDocFile=true` and just have it work