### PR TITLE
Add `IConfigurationManager.OnCvarValueChanged` event

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -40,7 +40,7 @@ END TEMPLATE-->
 ### New features
 
 * A new `replay.checkpoint_min_interval` cvar has been added. It can be used to limit the frequency at which checkpoints are generated when loading a replay.
-* Added `IConfigurationManager.OnCvarValueChanged`. This is a c# event that gets invoked whenever any cvar value changes.
+* Added `IConfigurationManager.OnCVarValueChanged`. This is a c# event that gets invoked whenever any cvar value changes.
 
 ### Bugfixes
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -40,6 +40,7 @@ END TEMPLATE-->
 ### New features
 
 * A new `replay.checkpoint_min_interval` cvar has been added. It can be used to limit the frequency at which checkpoints are generated when loading a replay.
+* Added `IConfigurationManager.OnCvarValueChanged`. This is a c# event that gets invoked whenever any cvar value changes.
 
 ### Bugfixes
 

--- a/Robust.Shared/Configuration/ConfigurationManager.cs
+++ b/Robust.Shared/Configuration/ConfigurationManager.cs
@@ -852,16 +852,18 @@ namespace Robust.Shared.Configuration
             {
                 if (Registered)
                 {
-                    DebugTools.AssertNotNull(Type);
                     DebugTools.AssertNotNull(DefaultValue);
                     DebugTools.AssertEqual(DefaultValue.GetType(), Type);
                     DebugTools.Assert(Value == null || Value.GetType() == Type);
                     return;
                 }
 
-                DebugTools.AssertNull(Type);
-                DebugTools.AssertNotNull(DefaultValue);
-                DebugTools.Assert(Value == null || DefaultValue.GetType() == Value.GetType());
+                if (_defaultValue == null)
+                    throw new NullReferenceException("Must specify default value before registering");
+
+                if (Value != null && DefaultValue.GetType() != Value.GetType())
+                    throw new Exception($"The cvar value & default value must be of the same type");
+
                 Type = DefaultValue.GetType();
                 Registered = true;
             }

--- a/Robust.Shared/Configuration/ConfigurationManager.cs
+++ b/Robust.Shared/Configuration/ConfigurationManager.cs
@@ -32,7 +32,7 @@ namespace Robust.Shared.Configuration
 
         private ISawmill _sawmill = default!;
 
-        public event Action<CVarChangeInfo>? OnCvarValueChanged;
+        public event Action<CVarChangeInfo>? OnCVarValueChanged;
 
         /// <summary>
         ///     Constructs a new ConfigurationManager.
@@ -707,7 +707,7 @@ namespace Robust.Shared.Configuration
 
         private void InvokeValueChanged(in ValueChangedInvoke invoke)
         {
-            OnCvarValueChanged?.Invoke(invoke.Info);
+            OnCVarValueChanged?.Invoke(invoke.Info);
             foreach (var entry in invoke.Invoke.Entries)
             {
                 entry.Value!.Invoke(invoke.Value, in invoke.Info);

--- a/Robust.Shared/Configuration/ConfigurationManager.cs
+++ b/Robust.Shared/Configuration/ConfigurationManager.cs
@@ -850,7 +850,15 @@ namespace Robust.Shared.Configuration
 
             public void Register()
             {
-                DebugTools.Assert(!Registered);
+                if (Registered)
+                {
+                    DebugTools.AssertNotNull(Type);
+                    DebugTools.AssertNotNull(DefaultValue);
+                    DebugTools.AssertEqual(DefaultValue.GetType(), Type);
+                    DebugTools.Assert(Value == null || Value.GetType() == Type);
+                    return;
+                }
+
                 DebugTools.AssertNull(Type);
                 DebugTools.AssertNotNull(DefaultValue);
                 DebugTools.Assert(Value == null || DefaultValue.GetType() == Value.GetType());

--- a/Robust.Shared/Configuration/IConfigurationManager.cs
+++ b/Robust.Shared/Configuration/IConfigurationManager.cs
@@ -252,5 +252,8 @@ namespace Robust.Shared.Configuration
         /// <typeparam name="T">The type of value contained in this CVar.</typeparam>
         void UnsubValueChanged<T>(string name, CVarChanged<T> onValueChanged)
             where T : notnull;
+
+        public event Action<CvarChangeArgs>? OnCvarValueChanged;
+        public readonly record struct CvarChangeArgs(string Name, object NewValue, object OldValue, GameTick Tick);
     }
 }

--- a/Robust.Shared/Configuration/IConfigurationManager.cs
+++ b/Robust.Shared/Configuration/IConfigurationManager.cs
@@ -263,6 +263,6 @@ namespace Robust.Shared.Configuration
         void UnsubValueChanged<T>(string name, CVarChanged<T> onValueChanged)
             where T : notnull;
 
-        public event Action<CVarChangeInfo>? OnCvarValueChanged;
+        public event Action<CVarChangeInfo>? OnCVarValueChanged;
     }
 }

--- a/Robust.Shared/Configuration/IConfigurationManager.cs
+++ b/Robust.Shared/Configuration/IConfigurationManager.cs
@@ -8,12 +8,12 @@ namespace Robust.Shared.Configuration
     /// <summary>
     /// Additional information about a CVar change.
     /// </summary>
-    public readonly struct CVarChangeInfo(string name, GameTick tickChanged, object newValue, object oldValue)
+    public readonly struct CVarChangeInfo
     {
         /// <summary>
         /// The name of the cvar that was changed.
         /// </summary>
-        public readonly string Name = name;
+        public readonly string Name;
 
         /// <summary>
         /// The tick this CVar changed at.
@@ -23,17 +23,25 @@ namespace Robust.Shared.Configuration
         /// however due to poor network conditions it is possible for CVars to get applied late.
         /// In this case, this is effectively "this is the tick it was SUPPOSED to have been applied at".
         /// </remarks>
-        public readonly GameTick TickChanged = tickChanged;
+        public readonly GameTick TickChanged;
 
         /// <summary>
         /// The new value.
         /// </summary>
-        public readonly object NewValue = newValue;
+        public readonly object NewValue;
 
         /// <summary>
         /// The previous value.
         /// </summary>
-        public readonly object OldValue = oldValue;
+        public readonly object OldValue;
+
+        internal CVarChangeInfo(string name, GameTick tickChanged, object newValue, object oldValue)
+        {
+            Name = name;
+            TickChanged = tickChanged;
+            NewValue = newValue;
+            OldValue = oldValue;
+        }
     }
 
     public delegate void CVarChanged<in T>(T newValue, in CVarChangeInfo info);

--- a/Robust.Shared/Configuration/IConfigurationManager.cs
+++ b/Robust.Shared/Configuration/IConfigurationManager.cs
@@ -8,8 +8,13 @@ namespace Robust.Shared.Configuration
     /// <summary>
     /// Additional information about a CVar change.
     /// </summary>
-    public readonly struct CVarChangeInfo
+    public readonly struct CVarChangeInfo(string name, GameTick tickChanged, object newValue, object oldValue)
     {
+        /// <summary>
+        /// The name of the cvar that was changed.
+        /// </summary>
+        public readonly string Name = name;
+
         /// <summary>
         /// The tick this CVar changed at.
         /// </summary>
@@ -18,12 +23,17 @@ namespace Robust.Shared.Configuration
         /// however due to poor network conditions it is possible for CVars to get applied late.
         /// In this case, this is effectively "this is the tick it was SUPPOSED to have been applied at".
         /// </remarks>
-        public readonly GameTick TickChanged;
+        public readonly GameTick TickChanged = tickChanged;
 
-        internal CVarChangeInfo(GameTick tickChanged)
-        {
-            TickChanged = tickChanged;
-        }
+        /// <summary>
+        /// The new value.
+        /// </summary>
+        public readonly object NewValue = newValue;
+
+        /// <summary>
+        /// The previous value.
+        /// </summary>
+        public readonly object OldValue = oldValue;
     }
 
     public delegate void CVarChanged<in T>(T newValue, in CVarChangeInfo info);
@@ -253,7 +263,6 @@ namespace Robust.Shared.Configuration
         void UnsubValueChanged<T>(string name, CVarChanged<T> onValueChanged)
             where T : notnull;
 
-        public event Action<CvarChangeArgs>? OnCvarValueChanged;
-        public readonly record struct CvarChangeArgs(string Name, object NewValue, object OldValue, GameTick Tick);
+        public event Action<CVarChangeInfo>? OnCvarValueChanged;
     }
 }


### PR DESCRIPTION
Adds an event that gets invoked whenever any cvar value changes. Required for a content PR.

This also changes some cvar setting logic & adds some debug asserts to ensure that cvars never change their type once they have been registered.