### PR TITLE
Better compatibility for `Texture.GetPixel()`

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.Textures.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Textures.cs
@@ -664,7 +664,7 @@ namespace Robust.Client.Graphics.Clyde
 
                 fixed (byte* p = buffer)
                 {
-                    GL.GetnTexImage(TextureTarget.Texture2D, 0, PF.Rgba, PT.UnsignedByte, bufSize, (IntPtr) p);
+                    GL.GetTexImage(TextureTarget.Texture2D, 0, PF.Rgba, PT.UnsignedByte, (IntPtr) p);
                 }
 
                 GL.BindTexture(TextureTarget.Texture2D, curTexture2D);


### PR DESCRIPTION
A few people have been reporting crashes with the current on OpenDream. Swapping from `GetnTexImage` to `GetTexImage` gives us way more backwards compatibility with older versions of opengl. 

If I understand the very unclear opengl docs correctly, the only difference is that we don't need to pass buffer size to the opengl call? Apparently this is a memory safety thing introduced in 4.5