### PR TITLE
Try prevent eventbus loops

### DIFF
--- a/Robust.Shared/Console/Commands/DumpEventTablesCommand.cs
+++ b/Robust.Shared/Console/Commands/DumpEventTablesCommand.cs
@@ -34,7 +34,7 @@ internal sealed class DumpEventTablesCommand : LocalizedCommands
         {
             shell.WriteLine($"{evType}:");
 
-            var idx = comps;
+            var idx = comps.Start;
             while (idx != -1)
             {
                 ref var entry = ref table.ComponentLists[idx];

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -488,7 +488,7 @@ namespace Robust.Shared.GameObjects
 
                 DebugTools.Assert(eventTable.Free >= 0);
 
-                ref var eventStartIdx = ref CollectionsMarshal.GetValueRefOrAddDefault(
+                ref var indices = ref CollectionsMarshal.GetValueRefOrAddDefault(
                     eventTable.EventIndices,
                     evType,
                     out var exists);
@@ -500,10 +500,11 @@ namespace Robust.Shared.GameObjects
 
                 // Set it up
                 entry.Component = compType;
-                entry.Next = exists ? eventStartIdx : -1;
+                entry.Next = exists ? indices.Start : -1;
 
                 // Assign new list entry to EventIndices dictionary.
-                eventStartIdx = entryIdx;
+                indices.Start = entryIdx;
+                indices.Count++;
             }
         }
 
@@ -541,40 +542,37 @@ namespace Robust.Shared.GameObjects
             foreach (var evType in compSubs.Keys)
             {
                 DebugTools.Assert(!_eventData[evType].ComponentEvent);
-                ref var dictIdx = ref CollectionsMarshal.GetValueRefOrNullRef(eventTable.EventIndices, evType);
-                if (Unsafe.IsNullRef(ref dictIdx))
+                ref var indices = ref CollectionsMarshal.GetValueRefOrNullRef(eventTable.EventIndices, evType);
+                if (Unsafe.IsNullRef(ref indices))
                 {
                     DebugTools.Assert("This should not be possible. Were the events for this component never added?");
                     continue;
                 }
 
-                ref var updateNext = ref dictIdx;
+                var entryIdx = indices.Start;
+                ref var entry = ref eventTable.ComponentLists[entryIdx];
 
-                // Go over linked list to find index of component.
-                var entryIdx = dictIdx;
-                ref var entry = ref Unsafe.NullRef<EventTableListEntry>();
-                while (true)
-                {
-                    entry = ref eventTable.ComponentLists[entryIdx];
-                    if (entry.Component == compType)
-                    {
-                        // Found
-                        break;
-                    }
-
-                    entryIdx = entry.Next;
-                    updateNext = ref entry.Next;
-                }
-
-                if (entry.Next == -1 && Unsafe.AreSame(ref dictIdx, ref updateNext))
+                if (indices.Count == 1)
                 {
                     // Last entry for this event type, remove from dict.
+                    DebugTools.AssertEqual(entry.Next, -1);
                     eventTable.EventIndices.Remove(evType);
                 }
                 else
                 {
+                    ref var updateNext = ref indices.Start;
+
+                    // Go over linked list to find index of component.
+                    while (entry.Component != compType)
+                    {
+                        updateNext = ref entry.Next;
+                        entryIdx = entry.Next;
+                        entry = ref eventTable.ComponentLists[entryIdx];
+                    }
+
                     // Rewrite previous index to point to next in chain.
                     updateNext = entry.Next;
+                    indices.Count--;
                 }
 
                 // Push entry back onto free list.
@@ -585,15 +583,33 @@ namespace Robust.Shared.GameObjects
 
         private void EntDispatch(EntityUid euid, Type eventType, ref Unit args)
         {
-            if (!EntTryGetSubscriptions(eventType, euid, out var enumerator))
+            if (!_entEventTables.TryGetValue(euid, out var eventTable))
                 return;
 
-            while (enumerator.MoveNext(out var component, out var reg))
-            {
-                if (component.Deleted)
-                    continue;
+            if (!eventTable.EventIndices.TryGetValue(eventType, out var indices))
+                return;
 
-                reg.Handler(euid, component, ref args);
+            DebugTools.Assert(indices.Count > 0);
+            DebugTools.Assert(indices.Start >= 0);
+
+            // First, collect all subscribing components.
+            // This is to avoid infinite loops over the linked list if subscription handlers add or remove components.
+            Span<CompIdx> compIds = stackalloc CompIdx[indices.Count];
+            var idx = indices.Start;
+            for (var index = 0; index < compIds.Length; index++)
+            {
+                DebugTools.Assert(idx >= 0);
+                ref var entry = ref eventTable.ComponentLists[idx];
+                idx = entry.Next;
+                compIds[index] = entry.Component;
+            }
+
+            foreach (var compIdx in compIds)
+            {
+                if (!_entMan.TryGetComponent(euid, compIdx, out var comp))
+                    continue;
+                var compSubs = _eventSubs[compIdx.Value];
+                compSubs[eventType].Handler(euid, comp, ref args);
             }
         }
 
@@ -602,16 +618,30 @@ namespace Robust.Shared.GameObjects
             Type eventType,
             ref ValueList<OrderedEventDispatch> found)
         {
-            if (!EntTryGetSubscriptions(eventType, euid, out var enumerator))
+            if (!_entEventTables.TryGetValue(euid, out var eventTable))
                 return;
 
-            while (enumerator.MoveNext(out var component, out var reg))
+            if (!eventTable.EventIndices.TryGetValue(eventType, out var indices))
+                return;
+
+            DebugTools.Assert(indices.Count > 0);
+            DebugTools.Assert(indices.Start >= 0);
+            var idx = indices.Start;
+            while (idx != -1)
             {
-                found.Add(new OrderedEventDispatch((ref Unit ev) =>
-                {
-                    if (!component.Deleted)
-                        reg.Handler(euid, component, ref ev);
-                }, reg.Order));
+                ref var entry = ref eventTable.ComponentLists[idx];
+                idx = entry.Next;
+                var comp = _entMan.GetComponentInternal(euid, entry.Component);
+                var compSubs = _eventSubs[entry.Component.Value];
+                var reg = compSubs[eventType];
+
+                found.Add(new OrderedEventDispatch(
+                    (ref Unit ev) =>
+                    {
+                        if (!comp.Deleted)
+                            reg.Handler(euid, comp, ref ev);
+                    },
+                    reg.Order));
             }
         }
 
@@ -624,28 +654,6 @@ namespace Robust.Shared.GameObjects
         {
             if (_compEventSubs[baseType.Value].TryGetValue(typeof(TEvent), out var reg))
                 reg.Handler(euid, component, ref args);
-        }
-
-        /// <summary>
-        ///     Enumerates all subscriptions for an event on a specific entity, returning the component instances and registrations.
-        /// </summary>
-        private bool EntTryGetSubscriptions(Type eventType, EntityUid euid, out SubscriptionsEnumerator enumerator)
-        {
-            if (!_entEventTables.TryGetValue(euid, out var eventTable))
-            {
-                enumerator = default!;
-                return false;
-            }
-
-            // No subscriptions to this event type, return null.
-            if (!eventTable.EventIndices.TryGetValue(eventType, out var startEntry))
-            {
-                enumerator = default;
-                return false;
-            }
-
-            enumerator = new(eventType, startEntry, eventTable.ComponentLists, _eventSubs, euid, _entMan);
-            return true;
         }
 
         public void ClearSubscriptions()
@@ -678,59 +686,6 @@ namespace Robust.Shared.GameObjects
             _eventSubsInv = null!;
         }
 
-        private struct SubscriptionsEnumerator
-        {
-            private readonly Type _eventType;
-            private readonly EntityUid _uid;
-            private readonly FrozenDictionary<Type, DirectedRegistration>[] _subscriptions;
-            private readonly IEntityManager _entityManager;
-            private readonly EventTableListEntry[] _list;
-            private int _idx;
-
-            public SubscriptionsEnumerator(
-                Type eventType,
-                int startEntry,
-                EventTableListEntry[] list,
-                FrozenDictionary<Type, DirectedRegistration>[] subscriptions,
-                EntityUid uid,
-                IEntityManager entityManager)
-            {
-                _eventType = eventType;
-                _list = list;
-                _subscriptions = subscriptions;
-                _idx = startEntry;
-                _entityManager = entityManager;
-                _uid = uid;
-            }
-
-            public bool MoveNext(
-                [NotNullWhen(true)] out IComponent? component,
-                [NotNullWhen(true)] out DirectedRegistration? registration)
-            {
-                if (_idx == -1)
-                {
-                    component = null;
-                    registration = null;
-                    return false;
-                }
-
-                ref var entry = ref _list[_idx];
-                _idx = entry.Next;
-
-                var compType = entry.Component;
-                var compSubs = _subscriptions[compType.Value];
-
-                if (!compSubs.TryGetValue(_eventType, out registration))
-                {
-                    component = default;
-                    return false;
-                }
-
-                component = _entityManager.GetComponentInternal(_uid, compType);
-                return true;
-            }
-        }
-
         internal sealed class DirectedRegistration : OrderedRegistration
         {
             public readonly Delegate Original;
@@ -760,7 +715,7 @@ namespace Robust.Shared.GameObjects
             // Free contains the first free linked list node, or -1 if there is none.
             // Free nodes form their own linked list.
             // ComponentList is the actual region of memory containing linked list nodes.
-            public readonly Dictionary<Type, int> EventIndices = new();
+            public readonly Dictionary<Type, (int Start, int Count)> EventIndices = new();
             public int Free;
             public EventTableListEntry[] ComponentLists = new EventTableListEntry[InitialListSize];
 

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -115,6 +115,15 @@ namespace Robust.Shared.GameObjects
             where TEvent : notnull;
 
         /// <summary>
+        /// Max size of a components event subscription linked list.
+        /// Used to limit the stackalloc in <see cref="EntDispatch"/>
+        /// </summary>
+        /// <remarks>
+        /// SS14 currently requires only 18, I doubt it will ever need to exceed 256.
+        /// </remarks>
+        private const int MaxEventLinkedListSize = 256;
+
+        /// <summary>
         /// Constructs a new instance of <see cref="EntityEventBus"/>.
         /// </summary>
         /// <param name="entMan">The entity manager to watch for entity/component events.</param>
@@ -505,6 +514,8 @@ namespace Robust.Shared.GameObjects
                 // Assign new list entry to EventIndices dictionary.
                 indices.Start = entryIdx;
                 indices.Count++;
+                if (indices.Count > MaxEventLinkedListSize)
+                    throw new NotSupportedException($"Exceeded maximum event linked list size. Need to implement stackalloc fallback.");
             }
         }
 

--- a/Robust.Shared/GameObjects/EntityEventBus.Ordering.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Ordering.cs
@@ -35,6 +35,9 @@ namespace Robust.Shared.GameObjects
             if (broadcast)
                 CollectBroadcastOrdered(EventSource.Local, subs, ref found);
 
+            // TODO PERF
+            // consider ordering the linked list itself?
+            // Then make broadcast events always a lower priority and replace the valuelist with stackalloc?
             EntCollectOrdered(uid, eventType, ref found);
 
             DispatchOrderedEvents(ref unitRef, ref found);

--- a/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.ComponentEvent.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityEventBusTests.ComponentEvent.cs
@@ -262,6 +262,94 @@ namespace Robust.UnitTesting.Shared.GameObjects
             Assert.That(c, Is.True, "C did not fire");
         }
 
+        [Test]
+        public void CompEventLoop()
+        {
+            var entUid = new EntityUid(7);
+
+            var entManMock = new Mock<IEntityManager>();
+            var compFacMock = new Mock<IComponentFactory>();
+            var reflectMock = new Mock<IReflectionManager>();
+
+            List<ComponentRegistration> allRefTypes = new();
+            void Setup<T>(out T instance) where T : IComponent, new()
+            {
+                IComponent? inst = instance = new T();
+                var reg = new ComponentRegistration(
+                    typeof(T).Name,
+                    typeof(T),
+                    CompIdx.Index<T>());
+
+                compFacMock.Setup(m => m.GetRegistration(CompIdx.Index<T>())).Returns(reg);
+                entManMock.Setup(m => m.TryGetComponent(entUid, CompIdx.Index<T>(), out inst)).Returns(true);
+                entManMock.Setup(m => m.GetComponent(entUid, CompIdx.Index<T>())).Returns(inst);
+                entManMock.Setup(m => m.GetComponentInternal(entUid, CompIdx.Index<T>())).Returns(inst);
+                allRefTypes.Add(reg);
+            }
+
+            Setup<OrderAComponent>(out var instA);
+            Setup<OrderBComponent>(out var instB);
+
+            compFacMock.Setup(m => m.GetAllRegistrations()).Returns(allRefTypes.ToArray());
+
+            entManMock.Setup(m => m.ComponentFactory).Returns(compFacMock.Object);
+            var bus = new EntityEventBus(entManMock.Object, reflectMock.Object);
+            bus.OnlyCallOnRobustUnitTestISwearToGodPleaseSomebodyKillThisNightmare();
+
+            var regA = compFacMock.Object.GetRegistration(CompIdx.Index<OrderAComponent>());
+            var regB = compFacMock.Object.GetRegistration(CompIdx.Index<OrderBComponent>());
+
+            var handlerACount = 0;
+            void HandlerA(EntityUid uid, Component comp, TestEvent ev)
+            {
+                Assert.That(handlerACount, Is.EqualTo(0));
+                handlerACount++;
+
+                // add and then remove component B
+                bus.OnComponentRemoved(new RemovedComponentEventArgs(new ComponentEventArgs(instB, entUid), false, default!));
+                bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(instB, entUid), regB));
+            }
+
+            var handlerBCount = 0;
+            void HandlerB(EntityUid uid, Component comp, TestEvent ev)
+            {
+                Assert.That(handlerBCount, Is.EqualTo(0));
+                handlerBCount++;
+
+                // add and then remove component A
+                bus.OnComponentRemoved(new RemovedComponentEventArgs(new ComponentEventArgs(instA, entUid), false, default!));
+                bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(instA, entUid), regA));
+            }
+
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(HandlerA, typeof(OrderAComponent));
+            bus.SubscribeLocalEvent<OrderBComponent, TestEvent>(HandlerB, typeof(OrderBComponent));
+            bus.LockSubscriptions();
+
+            // add a component to the system
+            bus.OnEntityAdded(entUid);
+
+            bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(instA, entUid), regA));
+            bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(instB, entUid), regB));
+
+            // Event subscriptions currently use a linked list.
+            // Currently expect event subscriptions to be raised in order: handlerB -> handlerA
+            // If a component gets removed and added again, it gets moved back to the front of the linked list.
+            // I.e., adding and then removing compA changes the linked list order:  handlerA -> handlerB
+            //
+            // This could in principle cause the event raising code to  enter an infinite loop.
+            // Adding and removing a comp in an event handler may seem silly but:
+            // - it doesn't have to be the same component if you had a chain of three or more components
+            // - some event handlers raise other events and can lead to convoluted chains of interactions that might inadvertently trigger something like this.
+
+            // Raise
+            bus.RaiseLocalEvent(entUid, new TestEvent(0));
+
+            // Assert
+            Assert.That(handlerACount, Is.LessThanOrEqualTo(1));
+            Assert.That(handlerBCount, Is.LessThanOrEqualTo(1));
+            Assert.That(handlerACount+handlerBCount, Is.GreaterThan(0));
+        }
+
         private sealed partial class DummyComponent : Component
         {
         }


### PR DESCRIPTION
As far as I can tell, you can currently trigger infinite loops when raising an event if the event handlers somehow happen to add and remove components in a specific order. This PR adds a `CompEventLoop` test that currently fails on master. I vaguely recall that it would previously error with a "collection was modified" exception, but it seems like thats not the case?

This PR makes the event raising ignore changes to the event subscription linked list by just iterating over it and populating a `stackalloc CompIdx[]` before invoking any event handlers. As far as I can tell it works and only makes event raising somewhat slower. A simple ref struct event benchmark went from 598.7 us to 647.5 us.