### PR TITLE
Add a launch server bat file on build

### DIFF
--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -43,6 +43,9 @@
     <Content Include="server_config.toml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="run_server.bat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <EmbeddedResource Include="ExtraMappedSerializerStrings.txt">
       <LogicalName>Robust.Server.ExtraMappedSerializerStrings.txt</LogicalName>
     </EmbeddedResource>

--- a/Robust.Server/run_server.bat
+++ b/Robust.Server/run_server.bat
@@ -1,0 +1,2 @@
+Robust.Server.exe
+pause


### PR DESCRIPTION
People often have issues by not having net runtime installed when trying to start a sandbox. And the exe instantly closes before they can see any errors. Some users dont know how to use CMD in order to get this error shown. So we can force them to use cmd and review any errors while keeping it user friendly.

I can make a macos/linux version too if desired.