### PR TITLE
Add FormattedMessage.RemoveMarkupPermissive

### DIFF
--- a/Robust.Shared/Utility/FormattedMessage.cs
+++ b/Robust.Shared/Utility/FormattedMessage.cs
@@ -90,6 +90,17 @@ public sealed partial class FormattedMessage
     }
 
     /// <summary>
+    ///     Remove all markup, leaving only the basic text content behind.
+    /// </summary>
+    /// <remarks>
+    ///     Uses <see cref="FromMarkupPermissive"/>, so bad markup doesn't throw an exception.
+    /// </remarks>
+    public static string RemoveMarkupPermissive(string text)
+    {
+        return FromMarkupPermissive(text).ToString();
+    }
+
+    /// <summary>
     /// Adds a text node.
     /// This node doesn't need to be closed with <see cref="Pop"/>.
     /// </summary>


### PR DESCRIPTION
Adds a version of FormattedMessage.RemoveMarkup that uses FromMarkupPermissive so it doesn't throw an exception on bad markup.

Intended to make space-wizards/space-station-14#28256 very slightly cleaner, and just good to have.