### PR TITLE
make EntityPrototype.Categories use ProtoId

### DIFF
--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -60,9 +60,9 @@ namespace Robust.Shared.Prototypes
         [DataField("suffix")]
         public string? SetSuffix { get; private set; }
 
-        [DataField("categories")]
+        [DataField]
         [AlwaysPushInheritance]
-        public HashSet<string> Categories = new();
+        public HashSet<ProtoId<EntityCategoryPrototype>> Categories = new();
 
         [ViewVariables]
         public IReadOnlyDictionary<string, string> LocProperties => _locPropertiesSet ?? LocPropertiesDefault;


### PR DESCRIPTION
no reason not to, the hideSpawnMenu id even uses ValidatePrototypeId