### PR TITLE
Remove container IoC resolves

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
@@ -120,7 +120,7 @@ namespace Robust.Client.GameObjects
                 {
                     var type = _serializer.FindSerializedType(typeof(BaseContainer), data.ContainerType);
                     container = _dynFactory.CreateInstanceUnchecked<BaseContainer>(type!, inject:false);
-                    InitContainer(container, (uid, component), id);
+                    container.Init(this, id, (uid, component));
                     component.Containers.Add(id, container);
                 }
 

--- a/Robust.Shared/Containers/BaseContainer.cs
+++ b/Robust.Shared/Containers/BaseContainer.cs
@@ -1,16 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Numerics;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
-using Robust.Shared.Log;
-using Robust.Shared.Map;
-using Robust.Shared.Maths;
-using Robust.Shared.Network;
-using Robust.Shared.Physics;
-using Robust.Shared.Physics.Components;
-using Robust.Shared.Physics.Systems;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
@@ -23,6 +15,19 @@ namespace Robust.Shared.Containers
     [ImplicitDataDefinitionForInheritors]
     public abstract partial class BaseContainer
     {
+        // Will be null until after the component has been initialized.
+        protected SharedContainerSystem? System;
+
+        [Access(typeof(SharedContainerSystem), typeof(ContainerManagerComponent))]
+        internal void Init(SharedContainerSystem system, string id, Entity<ContainerManagerComponent> owner)
+        {
+            DebugTools.Assert(ID == null || ID == id);
+            ID = id;
+            Owner = owner;
+            Manager = owner;
+            System = system;
+        }
+
         /// <summary>
         /// Readonly collection of all the entities contained within this specific container
         /// </summary>

--- a/Robust.Shared/Containers/Container.cs
+++ b/Robust.Shared/Containers/Container.cs
@@ -2,10 +2,8 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.Containers
@@ -51,14 +49,7 @@ namespace Robust.Shared.Containers
             if (!_containerList.Contains(contained))
                 return false;
 
-#if DEBUG
-            if (IoCManager.Resolve<IGameTiming>().ApplyingState)
-                return true;
-
-            var entMan = IoCManager.Resolve<IEntityManager>();
-            var flags = entMan.GetComponent<MetaDataComponent>(contained).Flags;
-            DebugTools.Assert((flags & MetaDataFlags.InContainer) != 0, $"Entity has bad container flags. Ent: {entMan.ToPrettyString(contained)}. Container: {ID}, Owner: {entMan.ToPrettyString(Owner)}");
-#endif
+            System?.AssertInContainer(contained, this);
             return true;
         }
 

--- a/Robust.Shared/Containers/ContainerManagerComponent.cs
+++ b/Robust.Shared/Containers/ContainerManagerComponent.cs
@@ -30,9 +30,7 @@ namespace Robust.Shared.Containers
         {
             foreach (var (id, container) in Containers)
             {
-                container.ID = id;
-                container.Owner = Owner;
-                container.Manager = this;
+                container.Init(default!, id, (Owner, this));
             }
         }
 

--- a/Robust.Shared/Containers/ContainerSlot.cs
+++ b/Robust.Shared/Containers/ContainerSlot.cs
@@ -2,11 +2,9 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.Containers
@@ -59,14 +57,7 @@ namespace Robust.Shared.Containers
             if (contained != ContainedEntity)
                 return false;
 
-#if DEBUG
-            if (IoCManager.Resolve<IGameTiming>().ApplyingState)
-                return true;
-
-            var entMan = IoCManager.Resolve<IEntityManager>();
-            var flags = entMan.GetComponent<MetaDataComponent>(contained).Flags;
-            DebugTools.Assert((flags & MetaDataFlags.InContainer) != 0, $"Entity has bad container flags. Ent: {entMan.ToPrettyString(contained)}. Container: {ID}, Owner: {entMan.ToPrettyString(Owner)}");
-#endif
+            System?.AssertInContainer(contained, this);
             return true;
         }
 

--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Robust.Shared.GameObjects;
@@ -12,6 +13,7 @@ using Robust.Shared.Network;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.Containers
@@ -24,6 +26,7 @@ namespace Robust.Shared.Containers
         [Dependency] private readonly EntityLookupSystem _lookup = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
         [Dependency] private readonly SharedJointSystem _joint = default!;
+        [Dependency] private readonly IGameTiming _timing = default!;
 
         private EntityQuery<ContainerManagerComponent> _managerQuery;
         private EntityQuery<MapGridComponent> _gridQuery;
@@ -39,6 +42,7 @@ namespace Robust.Shared.Containers
             base.Initialize();
 
             SubscribeLocalEvent<EntParentChangedMessage>(OnParentChanged);
+            SubscribeLocalEvent<ContainerManagerComponent, ComponentInit>(OnInit);
             SubscribeLocalEvent<ContainerManagerComponent, ComponentStartup>(OnStartupValidation);
             SubscribeLocalEvent<ContainerManagerComponent, ComponentGetState>(OnContainerGetState);
             SubscribeLocalEvent<ContainerManagerComponent, ComponentRemove>(OnContainerManagerRemove);
@@ -50,6 +54,14 @@ namespace Robust.Shared.Containers
             PhysicsQuery = GetEntityQuery<PhysicsComponent>();
             JointQuery = GetEntityQuery<JointComponent>();
             TransformQuery = GetEntityQuery<TransformComponent>();
+        }
+
+        private void OnInit(Entity<ContainerManagerComponent> ent, ref ComponentInit args)
+        {
+            foreach (var (id, container) in ent.Comp.Containers)
+            {
+                container.Init(this, id, ent);
+            }
         }
 
         private void OnContainerGetState(EntityUid uid, ContainerManagerComponent component, ref ComponentGetState args)
@@ -101,16 +113,10 @@ namespace Robust.Shared.Containers
                 throw new ArgumentException($"Container with specified ID already exists: '{id}'");
 
             var container = _dynFactory.CreateInstanceUnchecked<T>(typeof(T), inject: false);
-            InitContainer(container, (uid, containerManager), id);
+            container.Init(this, id, (uid, containerManager));
             containerManager.Containers[id] = container;
             Dirty(uid, containerManager);
             return container;
-        }
-
-        protected void InitContainer(BaseContainer container, Entity<ContainerManagerComponent> containerEnt, string id)
-        {
-            DebugTools.AssertNull(container.ID);
-            ((container.Owner, container.Manager), container.ID) = (containerEnt, id);
         }
 
         public virtual void ShutdownContainer(BaseContainer container)
@@ -178,7 +184,13 @@ namespace Robust.Shared.Containers
                 return false;
             }
 
-            return containerManager.Containers.TryGetValue(id, out container);
+            if (!containerManager.Containers.TryGetValue(id, out container))
+                return false;
+
+            DebugTools.AssertEqual(container.ID, id);
+            DebugTools.AssertNotNull(container.Manager);
+            DebugTools.AssertNotEqual(container.Owner, EntityUid.Invalid);
+            return true;
         }
 
         [Obsolete("Use variant without skipExistCheck argument")]
@@ -688,6 +700,17 @@ namespace Robust.Shared.Containers
             // Eject entities from their parent container if the parent change is done via setting the transform.
             if (TryComp(message.OldParent, out ContainerManagerComponent? containerManager))
                 RemoveEntity(message.OldParent.Value, message.Entity, containerManager, message.Transform, meta,  reparent: false, force: true);
+        }
+
+        [Conditional("DEBUG"), Access(typeof(BaseContainer))]
+        public void AssertInContainer(EntityUid uid, BaseContainer container)
+        {
+            if (_timing.ApplyingState)
+                return; // Entity might not yet have had its state updated.
+
+            var flags = MetaData(uid).Flags;
+            DebugTools.Assert((flags & MetaDataFlags.InContainer) != 0,
+                $"Entity has bad container flags. Ent: {ToPrettyString(uid)}. Container: {container.ID}, Owner: {ToPrettyString(container.Owner)}");
         }
     }
 }


### PR DESCRIPTION
Replaces the debug related IoC resolves with a method in the container system. Avoids ioc thread / no-context exceptions, which currently get triggered whenever you have multiple clients with UIs open in debug mode.