### PR TITLE
Fix rotation not being passed in properly in entitymanager methods

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -324,7 +324,7 @@ namespace Robust.Shared.GameObjects
             if (transform.Anchored && _mapManager.TryFindGridAt(coordinates, out var gridUid, out var grid))
             {
                 coords = new EntityCoordinates(gridUid, _mapSystem.WorldToLocal(gridUid, grid, coordinates.Position));
-                _xforms.SetCoordinates(newEntity, transform, coords, unanchor: false);
+                _xforms.SetCoordinates(newEntity, transform, coords, rotation, unanchor: false);
             }
             else
             {


### PR DESCRIPTION
in entityManager.CreateEntityUninitialized, passing in a rotation doesn't actually work if the entity is anchored and on a grid. I don't really see why this is the case as it makes it impossible to spawn in rotated anchored entities and i need this for content.

mlem