### PR TITLE
Fix placement manager rotation jank

### DIFF
--- a/Robust.Server/Placement/PlacementManager.cs
+++ b/Robust.Server/Placement/PlacementManager.cs
@@ -172,16 +172,10 @@ namespace Robust.Server.Placement
                     }
                 }
 
-                var created = _entityManager.SpawnEntity(entityTemplateName, coordinates);
+                var created = _entityManager.Spawn(entityTemplateName, _xformSystem.ToMapCoordinates(coordinates), rotation: dirRcv.ToAngle());
 
                 var placementCreateEvent = new PlacementEntityEvent(created, coordinates, PlacementEventAction.Create, msg.MsgChannel.UserId);
                 _entityManager.EventBus.RaiseEvent(EventSource.Local, placementCreateEvent);
-
-                // Some entities immediately delete themselves
-                if (_entityManager.EntityExists(created))
-                {
-                    _entityManager.GetComponent<TransformComponent>(created).LocalRotation = dirRcv.ToAngle();
-                }
             }
             else
             {


### PR DESCRIPTION
placement manager engages in the anti-pattern of spawning shit and then rotating it which is absolutely goofy when you can just pass the rotation in to begin with. This fixes a bug with pipes in SS14 being placed, initializing, and then getting angry because CompInit gets raised _before_ the actual pipe gets rotated.