### PR TITLE
more placement manager fixes

### DIFF
--- a/Robust.Server/Placement/PlacementManager.cs
+++ b/Robust.Server/Placement/PlacementManager.cs
@@ -172,7 +172,7 @@ namespace Robust.Server.Placement
                     }
                 }
 
-                var created = _entityManager.Spawn(entityTemplateName, _xformSystem.ToMapCoordinates(coordinates), rotation: dirRcv.ToAngle());
+                var created = _entityManager.SpawnAttachedTo(entityTemplateName, coordinates, rotation: dirRcv.ToAngle());
 
                 var placementCreateEvent = new PlacementEntityEvent(created, coordinates, PlacementEventAction.Create, msg.MsgChannel.UserId);
                 _entityManager.EventBus.RaiseEvent(EventSource.Local, placementCreateEvent);

--- a/Robust.Shared/GameObjects/EntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Spawn.cs
@@ -73,12 +73,12 @@ public partial class EntityManager
         return ents;
     }
 
-    public virtual EntityUid SpawnAttachedTo(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null)
+    public virtual EntityUid SpawnAttachedTo(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null, Angle rotation = default)
     {
         if (!coordinates.IsValid(this))
             throw new InvalidOperationException($"Tried to spawn entity {protoName} on invalid coordinates {coordinates}.");
 
-        var entity = CreateEntityUninitialized(protoName, coordinates, overrides);
+        var entity = CreateEntityUninitialized(protoName, coordinates, overrides, rotation);
         InitializeAndStartEntity(entity, coordinates.GetMapId(this));
         return entity;
     }

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -301,8 +301,7 @@ namespace Robust.Shared.GameObjects
             var newEntity = CreateEntity(prototypeName, out _, overrides);
 
             var xformComp = TransformQuery.GetComponent(newEntity);
-            var newRotation = rotation;
-            _xforms.SetCoordinates(newEntity, xformComp, coordinates, rotation: newRotation, unanchor: false);
+            _xforms.SetCoordinates(newEntity, xformComp, coordinates, rotation: rotation, unanchor: false);
             return newEntity;
         }
 

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -296,10 +296,13 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public virtual EntityUid CreateEntityUninitialized(string? prototypeName, EntityCoordinates coordinates, ComponentRegistry? overrides = null)
+        public virtual EntityUid CreateEntityUninitialized(string? prototypeName, EntityCoordinates coordinates, ComponentRegistry? overrides = null, Angle rotation = default)
         {
             var newEntity = CreateEntity(prototypeName, out _, overrides);
-            _xforms.SetCoordinates(newEntity, TransformQuery.GetComponent(newEntity), coordinates, unanchor: false);
+
+            var xformComp = TransformQuery.GetComponent(newEntity);
+            var newRotation = rotation;
+            _xforms.SetCoordinates(newEntity, xformComp, coordinates, rotation: newRotation, unanchor: false);
             return newEntity;
         }
 

--- a/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Spawn.cs
@@ -38,7 +38,7 @@ public partial interface IEntityManager
     /// <summary>
     /// Spawns an entity and then parents it to the entity that the given entity coordinates are relative to.
     /// </summary>
-    EntityUid SpawnAttachedTo(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null);
+    EntityUid SpawnAttachedTo(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null, Angle rotation = default);
 
     /// <summary>
     /// Resolves the given entity coordinates into world coordinates and spawns an entity at that location. The

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -96,7 +96,7 @@ namespace Robust.Shared.GameObjects
         /// <param name="coordinates">Coordinates to set position and parent of the newly spawned entity to.</param>
         /// <param name="overrides"><inheritdoc cref="CreateEntityUninitialized(string?, MapCoordinates , ComponentRegistry?, Angle)"/></param>
         /// <returns><inheritdoc cref="CreateEntityUninitialized(string?, MapCoordinates , ComponentRegistry?, Angle)"/></returns>
-        EntityUid CreateEntityUninitialized(string? prototypeName, EntityCoordinates coordinates, ComponentRegistry? overrides = null);
+        EntityUid CreateEntityUninitialized(string? prototypeName, EntityCoordinates coordinates, ComponentRegistry? overrides = null, Angle rotation = default);
 
         /// <summary>
         /// Creates an uninitialized entity and puts it on the grid or map at the MapCoordinates provided.


### PR DESCRIPTION
the last change from using entitycoordinates to mapcoordinates broke the rotation on rotated grids. This remedies that by changing it to use entitycoordinates again and simply updates the SpawnAttachedTo method to support using rotation like the mapcoordinate method.