### PR TITLE
Add stack trace to some error logs and remove some audio error logs

### DIFF
--- a/Robust.Server/Audio/AudioSystem.cs
+++ b/Robust.Server/Audio/AudioSystem.cs
@@ -105,10 +105,7 @@ public sealed partial class AudioSystem : SharedAudioSystem
             return null;
 
         if (TerminatingOrDeleted(uid))
-        {
-            Log.Error($"Tried to play audio on a terminating / deleted entity {ToPrettyString(uid)}. Trace: {Environment.StackTrace}");
             return null;
-        }
 
         var entity = SetupAudio(filename, audioParams);
         // Move it after setting it up
@@ -125,10 +122,7 @@ public sealed partial class AudioSystem : SharedAudioSystem
             return null;
 
         if (TerminatingOrDeleted(uid))
-        {
-            Log.Error($"Tried to play audio on a terminating / deleted entity {ToPrettyString(uid)}. Trace: {Environment.StackTrace}");
             return null;
-        }
 
         var entity = SetupAudio(filename, audioParams);
         XformSystem.SetCoordinates(entity, new EntityCoordinates(uid, Vector2.Zero));

--- a/Robust.Shared/Containers/SharedContainerSystem.Insert.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.Insert.cs
@@ -49,14 +49,14 @@ public abstract partial class SharedContainerSystem
 
         if (!TryComp(container.Owner, out MetaDataComponent? ownerMeta))
         {
-            Log.Error($"Attempted to insert an entity {ToPrettyString(toInsert)} into a non-existent entity.");
+            Log.Error($"Attempted to insert an entity {ToPrettyString(toInsert)} into a non-existent entity. Trace: {Environment.StackTrace}");
             QueueDel(toInsert);
             return false;
         }
 
         if (ownerMeta.EntityLifeStage >= EntityLifeStage.Terminating)
         {
-            Log.Error($"Attempted to insert an entity {ToPrettyString(toInsert)} into an entity that is terminating. Entity: {ToPrettyString(container.Owner)}.");
+            Log.Error($"Attempted to insert an entity {ToPrettyString(toInsert)} into an entity that is terminating. Entity: {ToPrettyString(container.Owner)}. Trace: {Environment.StackTrace}");
             QueueDel(toInsert);
             return false;
         }
@@ -67,7 +67,7 @@ public abstract partial class SharedContainerSystem
 
         if (meta.EntityLifeStage >= EntityLifeStage.Terminating)
         {
-            Log.Error($"Attempted to insert a terminating entity {ToPrettyString(uid)} into a container {container.ID} in entity: {ToPrettyString(container.Owner)}.");
+            Log.Error($"Attempted to insert a terminating entity {ToPrettyString(uid)} into a container {container.ID} in entity: {ToPrettyString(container.Owner)}. Trace: {Environment.StackTrace}");
             return false;
         }
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Coordinates.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Coordinates.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 using Robust.Shared.Map;
 
@@ -47,7 +48,7 @@ public abstract partial class SharedTransformSystem
         if (!TryComp(coordinates.EntityId, out TransformComponent? xform))
         {
             if (logError)
-                Log.Error($"Attempted to convert coordinates with invalid entity: {coordinates}");
+                Log.Error($"Attempted to convert coordinates with invalid entity: {coordinates}. Trace: {Environment.StackTrace}");
             return MapCoordinates.Nullspace;
         }
 
@@ -72,13 +73,13 @@ public abstract partial class SharedTransformSystem
     {
         if (!Resolve(entity, ref entity.Comp, false))
         {
-            Log.Error($"Attempted to convert coordinates with invalid entity: {coordinates}");
+            Log.Error($"Attempted to convert coordinates with invalid entity: {coordinates}. Trace: {Environment.StackTrace}");
             return default;
         }
 
         if (entity.Comp.MapID != coordinates.MapId)
         {
-            Log.Error($"Attempted to convert map coordinates {coordinates} to entity coordinates on a different map. Entity: {ToPrettyString(entity)}");
+            Log.Error($"Attempted to convert map coordinates {coordinates} to entity coordinates on a different map. Entity: {ToPrettyString(entity)}. Trace: {Environment.StackTrace}");
             return default;
         }
 
@@ -94,7 +95,7 @@ public abstract partial class SharedTransformSystem
         if (_map.TryGetMap(coordinates.MapId, out var uid))
             return ToCoordinates(uid.Value, coordinates);
 
-        Log.Error($"Attempted to convert map coordinates with unknown map id: {coordinates}");
+        Log.Error($"Attempted to convert map coordinates with unknown map id: {coordinates}. Trace: {Environment.StackTrace}");
         return default;
 
     }


### PR DESCRIPTION
Adds stack traces to make debugging some errors easier and  removes the "Tried to play audio on a terminating / deleted entity" errors. AFAIK its not really a significant issue, and its the sort of error that is constantly going to keep coming up.