### PR TITLE
Item Lists use list of textures, add methods to render layered textures

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
@@ -6,6 +6,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Maths;
 using OpenToolkit.Graphics.OpenGL4;
 using Robust.Shared.Graphics;
+using System.Collections.Generic;
 
 namespace Robust.Client.Graphics.Clyde
 {
@@ -124,13 +125,13 @@ namespace Robust.Client.Graphics.Clyde
                     sr = subRegion ?? new UIBox2(0, 0, texture.Width, texture.Height);
                 }
 
-                var clydeTexture = (ClydeTexture) texture;
+                var clydeTexture = (ClydeTexture)texture;
                 return clydeTexture;
             }
 
             public void RenderInRenderTarget(IRenderTarget target, Action a, Color? clearColor)
             {
-                _clyde.RenderInRenderTarget((RenderTargetBase) target, a, clearColor);
+                _clyde.RenderInRenderTarget((RenderTargetBase)target, a, clearColor);
             }
 
             public void SetScissor(UIBox2i? scissorBox)
@@ -192,7 +193,7 @@ namespace Robust.Client.Graphics.Clyde
                     ofsY /= -EyeManager.PixelsPerMeter;
 
                     // Maaaaybe this is meant to have a minus sign.
-                    var rot = -(float) eyeRot.Theta;
+                    var rot = -(float)eyeRot.Theta;
 
                     var view = Matrix3.CreateTransform(ofsX, ofsY, rot, scale.X, scale.Y);
                     SetProjView(proj, view);
@@ -230,7 +231,7 @@ namespace Robust.Client.Graphics.Clyde
                     throw new ArgumentException("Unable to use disposed shader instance.", nameof(shader));
                 }
 
-                var clydeShader = (ClydeShaderInstance?) shader;
+                var clydeShader = (ClydeShaderInstance?)shader;
 
                 _clyde.DrawUseShader(clydeShader ?? _clyde._defaultShader);
             }
@@ -249,7 +250,7 @@ namespace Robust.Client.Graphics.Clyde
 
             public void UseRenderTarget(IRenderTarget? renderTarget)
             {
-                var target = (RenderTexture?) renderTarget;
+                var target = (RenderTexture?)renderTarget;
 
                 _clyde.DrawRenderTarget(target?.Handle ?? default);
             }
@@ -362,6 +363,17 @@ namespace Robust.Client.Graphics.Clyde
                         rect.BottomLeft, rect.BottomRight, color, subRegion);
                 }
 
+                public override void DrawLayeredTextureRectRegion(List<Texture> textures, UIBox2 rect, UIBox2? subRegion = null, Color? modulate = null)
+                {
+                    var color = (modulate ?? Color.White) * Modulate;
+
+                    foreach (var texture in textures)
+                    {
+                        _renderHandle.DrawTextureScreen(texture, rect.TopLeft, rect.TopRight,
+                            rect.BottomLeft, rect.BottomRight, color, subRegion);
+                    }
+                }
+
                 /// <summary>
                 /// Draws an entity.
                 /// </summary>
@@ -424,7 +436,7 @@ namespace Robust.Client.Graphics.Clyde
 
                 public override void DrawCircle(Vector2 position, float radius, Color color, bool filled = true)
                 {
-                    int divisions = Math.Max(16,(int)(radius * 16));
+                    int divisions = Math.Max(16, (int)(radius * 16));
                     float arcLength = MathF.PI * 2 / divisions;
 
                     var colorReal = color * Modulate;
@@ -443,9 +455,9 @@ namespace Robust.Client.Graphics.Clyde
                     for (int i = 0; i < divisions; i++)
                     {
                         var startPos = new Vector2(MathF.Cos(arcLength * i) * radius, MathF.Sin(arcLength * i) * radius);
-                        var endPos = new Vector2(MathF.Cos(arcLength * (i+1)) * radius, MathF.Sin(arcLength * (i + 1)) * radius);
+                        var endPos = new Vector2(MathF.Cos(arcLength * (i + 1)) * radius, MathF.Sin(arcLength * (i + 1)) * radius);
 
-                        if(!filled)
+                        if (!filled)
                             _renderHandle.DrawLine(startPos + position, endPos + position, colorReal);
                         else
                         {

--- a/Robust.Client/Graphics/Drawing/DrawingHandleScreen.cs
+++ b/Robust.Client/Graphics/Drawing/DrawingHandleScreen.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Numerics;
 using System.Text;
 using Robust.Client.GameObjects;
@@ -92,6 +93,9 @@ namespace Robust.Client.Graphics
 
         public abstract void DrawTextureRectRegion(Texture texture, UIBox2 rect, UIBox2? subRegion = null, Color? modulate = null);
 
+        public abstract void DrawLayeredTextureRectRegion(List<Texture> textures, UIBox2 rect, UIBox2? subRegion = null, Color? modulate = null);
+
+
         public void DrawTexture(Texture texture, Vector2 position, Color? modulate = null)
         {
             CheckDisposed();
@@ -106,6 +110,13 @@ namespace Robust.Client.Graphics
             DrawTextureRectRegion(texture, rect, null, modulate);
         }
 
+        public void DrawLayeredTextureRect(List<Texture> textures, UIBox2 rect, Color? modulate = null)
+        {
+            CheckDisposed();
+
+            DrawLayeredTextureRectRegion(textures, rect, null, modulate);
+        }
+
         public override void DrawCircle(Vector2 position, float radius, Color color, bool filled = true)
         {
             const int segments = 64;
@@ -113,7 +124,7 @@ namespace Robust.Client.Graphics
 
             for (var i = 0; i <= segments; i++)
             {
-                var angle = i / (float) segments * MathHelper.TwoPi;
+                var angle = i / (float)segments * MathHelper.TwoPi;
                 var pos = new Vector2(MathF.Sin(angle), MathF.Cos(angle));
 
                 buffer[i] = position + pos * radius;


### PR DESCRIPTION
Sorry for the bunch of automatic formatting changes

- Adds a DrawLayeredTextureRectRegion function that just does what DrawTextureRectRegion does but with a foreach for each texture (should I just not add this basically duplicate function and just foreach on DrawTextureTectRegion instead?)
- Changes ItemList's Icon from a Texture to a List of Textures, added an overload to AddItem() that supports a single texture and a list of textures

The queue for lathe recipes uses ItemList, ItemList doesn't support LayeredTextures so the icons appear wrong, this lets me fix it

Before:

https://github.com/space-wizards/RobustToolbox/assets/58439124/57ed2f67-3dd3-42a1-8018-ae7cd39299f7


After:

https://github.com/space-wizards/RobustToolbox/assets/58439124/7c136934-0d32-43d4-b313-9a451c057df5
