### PR TITLE
Fix PVS exception

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/UserInterfaceSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/UserInterfaceSystem.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Robust.Server.GameStates;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Utility;
 
 namespace Robust.Server.GameObjects;
 
@@ -23,6 +24,8 @@ public sealed class UserInterfaceSystem : SharedUserInterfaceSystem
 
         foreach (var ui in buis)
         {
+            DebugTools.Assert(ent.Comp.OpenInterfaces[ui].Count > 0);
+            DebugTools.Assert(HasComp<UserInterfaceComponent>(ui));
             args.Entities.Add(ui);
         }
     }

--- a/Robust.Server/GameStates/PvsSystem.Overrides.cs
+++ b/Robust.Server/GameStates/PvsSystem.Overrides.cs
@@ -100,7 +100,13 @@ internal sealed partial class PvsSystem
     /// </summary>
     private bool RecursivelyAddOverride(PvsSession session, EntityUid uid, GameTick fromTick, bool addChildren)
     {
-        var xform = _xformQuery.GetComponent(uid);
+        if (!_xformQuery.TryGetComponent(uid, out var xform))
+        {
+            // Can happen if systems add deleted entities to PVS move event.
+            Log.Error($"Attempted to add non-existent entity {uid} to PVS override for session {session.Session}");
+            return false;
+        }
+
         var parent = xform.ParentUid;
 
         // First we process all parents. This is because while this entity may already have been added


### PR DESCRIPTION
Turns an exception into an error log. Doesn't actually fix whatever was causing:

```
Caught exception while generating mail for Zomil.
System.Collections.Generic.KeyNotFoundException: Entity 308840 does not have a component of type Robust.Shared.GameObjects.TransformComponent
   at Robust.Server.GameStates.PvsSystem.RecursivelyAddOverride(PvsSession session, EntityUid uid, GameTick fromTick, Boolean addChildren) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.Overrides.cs:line 103
   at Robust.Server.GameStates.PvsSystem.RaiseExpandEvent(PvsSession session, GameTick fromTick) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.Overrides.cs:line 85
   at Robust.Server.GameStates.PvsSystem.AddAllOverrides(PvsSession session) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.Overrides.cs:line 23
   at Robust.Server.GameStates.PvsSystem.GetEntityStates(PvsSession session) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.cs:line 327
   at Robust.Server.GameStates.PvsSystem.ComputeSessionState(PvsSession session) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.Session.cs:line 88
   at Robust.Server.GameStates.PvsSystem.SendStateUpdate(ICommonSession session, PvsThreadResources resources) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.Session.cs:line 32
   at Robust.Server.GameStates.PvsSystem.<>c__DisplayClass73_0.<SendStates>g__SendPlayer|0(Int32 i, ParallelLoopState state, PvsThreadResources resource) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.cs:line 219
 Sawmill=system.pvs
```