### PR TITLE
Make `PrototypeManager.TryIndex` log errors when using invalid id structs

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* `IPrototypeManager.TryIndex` will now default to logging errors if passed an invalid prototype id struct (i,e., `EntProtoId` or `ProtoId<T>`). There is a new optional bool argument to disable logging errors.
 
 ### Bugfixes
 

--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -143,17 +143,20 @@ public interface IPrototypeManager
     /// </summary>
     FrozenDictionary<string, T> GetInstances<T>() where T : IPrototype;
 
-    /// <inheritdoc cref="TryIndex{T}(string, out T)"/>
-    bool TryIndex(EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype);
+    /// <inheritdoc cref="TryIndex{T}(ProtoId{T}, out T, bool)"/>
+    bool TryIndex(EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype,  bool logError = true);
 
-    /// <inheritdoc cref="TryIndex{T}(string, out T)"/>
-    bool TryIndex<T>(ProtoId<T> id, [NotNullWhen(true)] out T? prototype) where T : class, IPrototype;
+    /// <summary>
+    /// Attempt to retrieve the prototype corresponding to the given prototype id.
+    /// Unless otherwise specified, this will log an error if the id does not match any known prototype.
+    /// </summary>
+    bool TryIndex<T>(ProtoId<T> id, [NotNullWhen(true)] out T? prototype,  bool logError = true) where T : class, IPrototype;
 
-    /// <inheritdoc cref="TryIndex{T}(string, out T)"/>
-    bool TryIndex(EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype);
+    /// <inheritdoc cref="TryIndex{T}(ProtoId{T}, out T, bool)"/>
+    bool TryIndex(EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype,  bool logError = true);
 
-    /// <inheritdoc cref="TryIndex{T}(string, out T)"/>
-    bool TryIndex<T>(ProtoId<T>? id, [NotNullWhen(true)] out T? prototype) where T : class, IPrototype;
+    /// <inheritdoc cref="TryIndex{T}(ProtoId{T}, out T, bool)"/>
+    bool TryIndex<T>(ProtoId<T>? id, [NotNullWhen(true)] out T? prototype, bool logError = true) where T : class, IPrototype;
 
     bool HasMapping<T>(string id);
     bool TryGetMapping(Type kind, string id, [NotNullWhen(true)] out MappingDataNode? mappings);

--- a/Robust.Shared/Prototypes/PrototypeManager.Categories.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.Categories.cs
@@ -108,7 +108,7 @@ public abstract partial class PrototypeManager : IPrototypeManagerInternal
             }
         }
 
-        DebugTools.Assert(!TryIndex(id, out var instance)
+        DebugTools.Assert(!TryIndex(id, out var instance, false)
                           || instance.CategoriesInternal == null
                           || instance.CategoriesInternal.All(x =>
                               set.Any(y => y.ID == x)));
@@ -124,7 +124,7 @@ public abstract partial class PrototypeManager : IPrototypeManagerInternal
             }
         }
 
-        if (!TryIndex(id, out var protoInstance))
+        if (!TryIndex(id, out var protoInstance, false))
         {
             // Prototype is abstract
             cache.Add(id, set);

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -744,19 +744,29 @@ namespace Robust.Shared.Prototypes
         }
 
         /// <inheritdoc />
-        public bool TryIndex(EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype)
+        public bool TryIndex(EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype, bool logError = true)
         {
-            return TryIndex(id.Id, out prototype);
+            if (TryIndex(id.Id, out prototype))
+                return true;
+
+            if (logError)
+                Sawmill.Error($"Attempted to resolve invalid {nameof(EntProtoId)}: {id.Id}");
+            return false;
         }
 
         /// <inheritdoc />
-        public bool TryIndex<T>(ProtoId<T> id, [NotNullWhen(true)] out T? prototype) where T : class, IPrototype
+        public bool TryIndex<T>(ProtoId<T> id, [NotNullWhen(true)] out T? prototype, bool logError = true) where T : class, IPrototype
         {
-            return TryIndex(id.Id, out prototype);
+            if (TryIndex(id.Id, out prototype))
+                return true;
+
+            if (logError)
+                Sawmill.Error($"Attempted to resolve invalid ProtoId<{typeof(T).Name}>: {id.Id}");
+            return false;
         }
 
         /// <inheritdoc />
-        public bool TryIndex(EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype)
+        public bool TryIndex(EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype, bool logError = true)
         {
             if (id == null)
             {
@@ -764,11 +774,11 @@ namespace Robust.Shared.Prototypes
                 return false;
             }
 
-            return TryIndex(id.Value, out prototype);
+            return TryIndex(id.Value, out prototype, logError);
         }
 
         /// <inheritdoc />
-        public bool TryIndex<T>(ProtoId<T>? id, [NotNullWhen(true)] out T? prototype) where T : class, IPrototype
+        public bool TryIndex<T>(ProtoId<T>? id, [NotNullWhen(true)] out T? prototype, bool logError = true) where T : class, IPrototype
         {
             if (id == null)
             {
@@ -776,7 +786,7 @@ namespace Robust.Shared.Prototypes
                 return false;
             }
 
-            return TryIndex(id.Value, out prototype);
+            return TryIndex(id.Value, out prototype, logError);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Ideally all prototype id structs should have gotten linted at some point, and should just correspond to valid prototypes anyways, but its still safer to use `TryIndex()` instead of `Index()` to avoid throwing exceptions. And in those instances you would probably want to log an error.