### PR TITLE
Always process networked events via the priority queue

### DIFF
--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -229,21 +229,6 @@ namespace Robust.Server.GameObjects
 
         private void HandleEntityNetworkMessage(MsgEntity message)
         {
-            var msgT = message.SourceTick;
-            var cT = _gameTiming.CurTick;
-
-            if (msgT <= cT)
-            {
-                if (msgT < cT && _logLateMsgs)
-                {
-                    _netEntSawmill.Warning("Got late MsgEntity! Diff: {0}, msgT: {2}, cT: {3}, player: {1}",
-                        (int) msgT.Value - (int) cT.Value, message.MsgChannel.UserName, msgT, cT);
-                }
-
-                DispatchEntityNetworkMessage(message);
-                return;
-            }
-
             _queue.Add(message);
         }
 


### PR DESCRIPTION
Currently, `HandleEntityNetworkMessage()` can try to immediately dispatch an event, despite there already being older messages already in the queue that should get dispatched first, resulting in out of order events. This PR just removes the immediate dispatch in favour of always using the queue. Ideally all events should arrive before they need to get dispatched anyways, so this should've already been happening in most cases.

AFAICT this was responsible for logging the 4-dir errors in space-wizards/space-station-14/issues/27510. Or at least, it seems like that was the cause whenever I was able to reproduce it locally. Though I haven't been able to reproduce bullets shooting in the wrong direction or not shooting at all.

This might also be partially responsible for space-wizards/RobustToolbox#7048? But the specific issue outlined in this [comment](https://github.com/space-wizards/RobustToolbox/issues/7048#issuecomment-1867898719) describes some other issue where messages are getting sent with incorrect ticks. The fix for that is probably to just not consider the tick at all when sorting the queue? But then you might need a queue per player?