### PR TITLE
Remove obsolete anchor entity functions

### DIFF
--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -373,9 +373,9 @@ namespace Robust.Shared.GameObjects
                 {
                     _anchored = value;
                 }
-                else if (value && !_anchored && _mapManager.TryFindGridAt(MapPosition, out _, out var grid))
+                else if (value && !_anchored && _mapManager.TryFindGridAt(MapPosition, out var gridUid, out var gridComp))
                 {
-                    _anchored = _entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().AnchorEntity(Owner, this, grid);
+                    _anchored = _entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().AnchorEntity((Owner, this), (gridUid, gridComp));
                 }
                 else if (!value && _anchored)
                 {

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -232,10 +232,12 @@ public abstract partial class SharedTransformSystem
             return;
 
         MapGridComponent? grid;
+        EntityUid gridUid;
 
         // First try find grid via parent:
         if (component.GridUid == component.ParentUid && TryComp(component.ParentUid, out MapGridComponent? gridComp))
         {
+            gridUid = component.ParentUid;
             grid = gridComp;
         }
         else
@@ -243,7 +245,7 @@ public abstract partial class SharedTransformSystem
             // Entity may not be directly parented to the grid (e.g., spawned using some relative entity coordinates)
             // in that case, we attempt to attach to a grid.
             var pos = new MapCoordinates(GetWorldPosition(component), component.MapID);
-            _mapManager.TryFindGridAt(pos, out _, out grid);
+            _mapManager.TryFindGridAt(pos, out gridUid, out grid);
         }
 
         if (grid == null)
@@ -252,7 +254,7 @@ public abstract partial class SharedTransformSystem
             return;
         }
 
-        if (!AnchorEntity(uid, component, grid))
+        if (!AnchorEntity((uid, component), (gridUid, grid)))
             component._anchored = false;
     }
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -96,8 +96,6 @@ public abstract partial class SharedTransformSystem
 
     public bool AnchorEntity(Entity<TransformComponent> entity, Entity<MapGridComponent>? grid = null)
     {
-        DebugTools.Assert(grid == null);
-
         if (grid == null)
         {
             if (!TryComp(entity.Comp.GridUid, out MapGridComponent? gridComp))

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -96,7 +96,7 @@ public abstract partial class SharedTransformSystem
 
     public bool AnchorEntity(Entity<TransformComponent> entity, Entity<MapGridComponent>? grid = null)
     {
-        DebugTools.Assert(grid == null || grid.Value.Owner == entity.Comp.GridUid);
+        DebugTools.Assert(grid == null);
 
         if (grid == null)
         {
@@ -227,7 +227,7 @@ public abstract partial class SharedTransformSystem
         InitializeGridUid(uid, component);
         component.MatricesDirty = true;
 
-        DebugTools.Assert(component._gridUid == uid || !HasComp<MapGridComponent>(uid));
+        DebugTools.Assert((component._gridUid == uid) || !HasComp<MapGridComponent>(uid));
         if (!component._anchored)
             return;
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -60,17 +60,6 @@ public abstract partial class SharedTransformSystem
         RaiseLocalEvent(uid, ref ev);
     }
 
-    [Obsolete("Use Entity<T> variant")]
-    public bool AnchorEntity(
-        EntityUid uid,
-        TransformComponent xform,
-        EntityUid gridUid,
-        MapGridComponent grid,
-        Vector2i tileIndices)
-    {
-        return AnchorEntity((uid, xform), (gridUid, grid), tileIndices);
-    }
-
     public bool AnchorEntity(
         Entity<TransformComponent> entity,
         Entity<MapGridComponent> grid,
@@ -98,13 +87,6 @@ public abstract partial class SharedTransformSystem
         var pos = new EntityCoordinates(grid, _map.GridTileToLocal(grid, grid, tileIndices).Position);
         SetCoordinates((uid, xform, meta), pos, unanchor: false);
         return true;
-    }
-
-    [Obsolete("Use Entity<T> variants")]
-    public bool AnchorEntity(EntityUid uid, TransformComponent xform, MapGridComponent grid)
-    {
-        var tileIndices = _map.TileIndicesFor(grid.Owner, grid, xform.Coordinates);
-        return AnchorEntity(uid, xform, grid.Owner, grid, tileIndices);
     }
 
     public bool AnchorEntity(EntityUid uid, TransformComponent xform)

--- a/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
@@ -91,10 +91,11 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         [Reflect(false)]
         private sealed class AnchorOnInitTestSystem : EntitySystem
         {
+            [Dependency] private readonly SharedTransformSystem _transform = default!;
             public override void Initialize()
             {
                 base.Initialize();
-                SubscribeLocalEvent<AnchorOnInitComponent, ComponentInit>((e, _, _) => Transform(e).Anchored = true);
+                SubscribeLocalEvent<AnchorOnInitComponent, ComponentInit>((e, _, _) => _transform.AnchorEntity(e, Transform(e)));
             }
         }
 
@@ -406,12 +407,13 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId, coords) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
+            var transformSystem = entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
 
             var grid = entMan.GetComponent<MapGridComponent>(gridId);
             var ent1 = entMan.SpawnEntity(null, coords);
             var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
-            entMan.GetComponent<TransformComponent>(ent1).Anchored = true;
+            transformSystem.AnchorEntity((ent1, entMan.GetComponent<TransformComponent>(ent1)), (gridId, grid), tileIndices);
 
             // Act
             // assumed default body is Dynamic

--- a/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
@@ -195,7 +195,8 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
 
             // can only be anchored to a tile
             var grid = entMan.GetComponent<MapGridComponent>(gridId);
-            grid.SetTile(grid.TileIndicesFor(coordinates), new Tile(1));
+            var tileIndices = grid.TileIndicesFor(coordinates);
+            grid.SetTile(tileIndices, new Tile(1));
 
             var traversal = entMan.System<SharedGridTraversalSystem>();
             traversal.Enabled = false;
@@ -203,7 +204,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
 
             // Act
             entMan.System<MoveEventTestSystem>().ResetCounters();
-            entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().AnchorEntity((ent1, entMan.GetComponent<TransformComponent>(ent1)), (gridId, grid));
+            entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().AnchorEntity((ent1, entMan.GetComponent<TransformComponent>(ent1)), (gridId, grid), tileIndices);
             Assert.That(entMan.GetComponent<TransformComponent>(ent1).ParentUid, Is.EqualTo(grid.Owner));
             entMan.System<MoveEventTestSystem>().AssertMoved();
             traversal.Enabled = true;

--- a/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
@@ -192,6 +192,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId, coordinates) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
+            var transformSystem = entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
 
             // can only be anchored to a tile
             var grid = entMan.GetComponent<MapGridComponent>(gridId);
@@ -204,7 +205,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
 
             // Act
             entMan.System<MoveEventTestSystem>().ResetCounters();
-            entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().AnchorEntity((ent1, entMan.GetComponent<TransformComponent>(ent1)), (gridId, grid), tileIndices);
+            transformSystem.AnchorEntity((ent1, entMan.GetComponent<TransformComponent>(ent1)), (gridId, grid), tileIndices);
             Assert.That(entMan.GetComponent<TransformComponent>(ent1).ParentUid, Is.EqualTo(grid.Owner));
             entMan.System<MoveEventTestSystem>().AssertMoved();
             traversal.Enabled = true;
@@ -240,6 +241,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId, coords) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
+            var transformSystem = entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
 
             var grid = entMan.GetComponent<MapGridComponent>(gridId);
             var ent1 = entMan.SpawnEntity(null, coords);
@@ -247,7 +249,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             grid.SetTile(tileIndices, new Tile(1));
 
             // Act
-            entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().AnchorEntity((ent1, entMan.GetComponent<TransformComponent>(ent1)), (gridId, grid), tileIndices);
+            transformSystem.AnchorEntity((ent1, entMan.GetComponent<TransformComponent>(ent1)), (gridId, grid), tileIndices);
 
             Assert.That(grid.GetAnchoredEntities(tileIndices).First(), Is.EqualTo(ent1));
             Assert.That(grid.GetTileRef(tileIndices).Tile, Is.Not.EqualTo(Tile.Empty));
@@ -295,12 +297,14 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             var (sim, gridId, coordinates) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
             var mapMan = sim.Resolve<IMapManager>();
+            var transformSystem = entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
 
             var grid = entMan.GetComponent<MapGridComponent>(gridId);
 
             var ent1 = entMan.SpawnEntity(null, coordinates);
             var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
+            transformSystem.AnchorEntity((ent1, entMan.GetComponent<TransformComponent>(ent1)), (gridId, grid), tileIndices);
             entMan.GetComponent<TransformComponent>(ent1).Anchored = true;
 
             // Act
@@ -321,12 +325,13 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId, coords) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
+            var transformSystem = entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
 
             var grid = entMan.GetComponent<MapGridComponent>(gridId);
             var ent1 = entMan.SpawnEntity(null, coords);
             var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
-            entMan.GetComponent<TransformComponent>(ent1).Anchored = true;
+            transformSystem.AnchorEntity((ent1, entMan.GetComponent<TransformComponent>(ent1)), (gridId, grid), tileIndices);
 
             // Act
             entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().SetParent(ent1, grid.Owner);
@@ -343,13 +348,14 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId, coords) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
+            var transformSystem = entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
 
             var grid = entMan.GetComponent<MapGridComponent>(gridId);
             var ent1 = entMan.SpawnEntity(null, coords);
             var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
             grid.SetTile(new Vector2i(100, 100), new Tile(1)); // Prevents the grid from being deleted when the Act happens
-            entMan.GetComponent<TransformComponent>(ent1).Anchored = true;
+            transformSystem.AnchorEntity((ent1, entMan.GetComponent<TransformComponent>(ent1)), (gridId, grid), tileIndices);
 
             // Act
             grid.SetTile(tileIndices, Tile.Empty);
@@ -371,12 +377,13 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId, coords) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
+            var transformSystem = entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
 
             var grid = entMan.GetComponent<MapGridComponent>(gridId);
             var ent1 = entMan.SpawnEntity(null, coords);
             var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
-            entMan.GetComponent<TransformComponent>(ent1).Anchored = true;
+            transformSystem.AnchorEntity((ent1, entMan.GetComponent<TransformComponent>(ent1)), (gridId, grid), tileIndices);
 
             // Act
             // We purposefully use the grid as container so parent stays the same, reparent will unanchor
@@ -445,15 +452,16 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         {
             var (sim, gridId, coords) = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
+            var transformSystem = entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
 
             var grid = entMan.GetComponent<MapGridComponent>(gridId);
             var ent1 = entMan.SpawnEntity(null, coords);
             var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
             var physComp = entMan.AddComponent<PhysicsComponent>(ent1);
-            entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().AnchorEntity((ent1, entMan.GetComponent<TransformComponent>(ent1)), (gridId, grid), tileIndices);
+            transformSystem.AnchorEntity((ent1, entMan.GetComponent<TransformComponent>(ent1)), (gridId, grid), tileIndices);
             // Act
-            entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().Unanchor(ent1, entMan.GetComponent<TransformComponent>(ent1));
+            transformSystem.Unanchor(ent1, entMan.GetComponent<TransformComponent>(ent1));
 
             Assert.That(physComp.BodyType, Is.EqualTo(BodyType.Dynamic));
         }

--- a/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
@@ -203,7 +203,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
 
             // Act
             entMan.System<MoveEventTestSystem>().ResetCounters();
-            entMan.GetComponent<TransformComponent>(ent1).Anchored = true;
+            entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().AnchorEntity((ent1, entMan.GetComponent<TransformComponent>(ent1)), (gridId, grid));
             Assert.That(entMan.GetComponent<TransformComponent>(ent1).ParentUid, Is.EqualTo(grid.Owner));
             entMan.System<MoveEventTestSystem>().AssertMoved();
             traversal.Enabled = true;
@@ -246,7 +246,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             grid.SetTile(tileIndices, new Tile(1));
 
             // Act
-            entMan.GetComponent<TransformComponent>(ent1).Anchored = true;
+            entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().AnchorEntity((ent1, entMan.GetComponent<TransformComponent>(ent1)), (gridId, grid), tileIndices);
 
             Assert.That(grid.GetAnchoredEntities(tileIndices).First(), Is.EqualTo(ent1));
             Assert.That(grid.GetTileRef(tileIndices).Tile, Is.Not.EqualTo(Tile.Empty));
@@ -450,10 +450,9 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             var tileIndices = grid.TileIndicesFor(entMan.GetComponent<TransformComponent>(ent1).Coordinates);
             grid.SetTile(tileIndices, new Tile(1));
             var physComp = entMan.AddComponent<PhysicsComponent>(ent1);
-            entMan.GetComponent<TransformComponent>(ent1).Anchored = true;
-
+            entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().AnchorEntity((ent1, entMan.GetComponent<TransformComponent>(ent1)), (gridId, grid), tileIndices);
             // Act
-            entMan.GetComponent<TransformComponent>(ent1).Anchored = false;
+            entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().Unanchor(ent1, entMan.GetComponent<TransformComponent>(ent1));
 
             Assert.That(physComp.BodyType, Is.EqualTo(BodyType.Dynamic));
         }


### PR DESCRIPTION
Requires https://github.com/space-wizards/space-station-14/pull/28613


- Remove obsolete AnchorEntity() variants in favor of Entity<T> versions
- Update TransformComponent and SharedTransformSystem to use the Entity<T> versions by tupling the Transform and Grid Entities
- Update tests to use the Entity<T> version by tupling the Transform and Grid entities
- OnInitAnchored_AddedToLookup test had all of its obsolete functions updated to preferred methods while I was trying to figure out why it was failing
- Got rid of an unnecessary debug assertion on line 117 that doesn't actually check for a problem