### PR TITLE
Raise an event when an entity's name is changed

### DIFF
--- a/Robust.Shared/GameObjects/EntitySystemMessages/EntityRenamedEvent.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/EntityRenamedEvent.cs
@@ -1,0 +1,7 @@
+namespace Robust.Shared.GameObjects;
+
+/// <summary>
+/// Raised directed on an entity when its name is changed.
+/// </summary>
+[ByRefEvent]
+public readonly record struct EntityRenamedEvent(string NewName);

--- a/Robust.Shared/GameObjects/Systems/MetaDataSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/MetaDataSystem.cs
@@ -42,12 +42,19 @@ public abstract class MetaDataSystem : EntitySystem
         component.PauseTime = state.PauseTime;
     }
 
-    public void SetEntityName(EntityUid uid, string value, MetaDataComponent? metadata = null)
+    public void SetEntityName(EntityUid uid, string value, MetaDataComponent? metadata = null, bool raiseEvents = true)
     {
         if (!_metaQuery.Resolve(uid, ref metadata) || value.Equals(metadata.EntityName))
             return;
 
         metadata._entityName = value;
+
+        if (raiseEvents)
+        {
+            var ev = new EntityRenamedEvent(value);
+            RaiseLocalEvent(uid, ref ev);
+        }
+
         Dirty(uid, metadata, metadata);
     }
 


### PR DESCRIPTION
Adds `EntityRenamedEvent`, which is raised by `MetaDataSystem` directed at an entity when its name is changed by `SetEntityName`.

This is needed for space-wizards/space-station-14#27863 and may also be useful for other stuff (like Identity).