### PR TITLE
Try optimize `NetEntities` console completion helper

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,7 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* `NetEntity.Parse` and `TryParse` will now fail to parse empty strings.
 
 ### New features
 

--- a/Resources/Locale/en-US/commands.ftl
+++ b/Resources/Locale/en-US/commands.ftl
@@ -382,9 +382,9 @@ cmd-tp-desc = Teleports a player to any location in the round.
 cmd-tp-help = tp <x> <y> [<mapID>]
 
 cmd-tpto-desc = Teleports the current player or the specified players/entities to the location of the first player/entity.
-cmd-tpto-help = tpto <username|uid> [username|uid]...
-cmd-tpto-destination-hint = destination (uid or username)
-cmd-tpto-victim-hint = entity to teleport (uid or username)
+cmd-tpto-help = tpto <username|uid> [username|NetEntity]...
+cmd-tpto-destination-hint = destination (NetEntity or username)
+cmd-tpto-victim-hint = entity to teleport (NetEntity or username)
 cmd-tpto-parse-error = Cant resolve entity or player: {$str}
 
 cmd-listplayers-desc = Lists all players currently connected.

--- a/Robust.Shared/Console/Commands/TeleportCommands.cs
+++ b/Robust.Shared/Console/Commands/TeleportCommands.cs
@@ -174,12 +174,7 @@ public sealed class TeleportToCommand : LocalizedCommands
 
         var hint = args.Length == 1 ? "cmd-tpto-destination-hint" : "cmd-tpto-victim-hint";
         hint = Loc.GetString(hint);
-
-        var opts = CompletionResult.FromHintOptions(users, hint);
-        if (last != string.Empty && !NetEntity.TryParse(last, out _))
-            return opts;
-
-        return CompletionResult.FromHintOptions(opts.Options.Concat(CompletionHelper.NetEntities(last, _entities)), hint);
+        return CompletionResult.FromHintOptions(users, hint);
     }
 }
 

--- a/Robust.Shared/Console/CompletionHelper.cs
+++ b/Robust.Shared/Console/CompletionHelper.cs
@@ -214,6 +214,9 @@ public static class CompletionHelper
 
     public static IEnumerable<CompletionOption> Components<T>(string text, IEntityManager? entManager = null, int limit = 20) where T : IComponent
     {
+        if (!NetEntity.TryParse(text, out _))
+            yield break;
+
         IoCManager.Resolve(ref entManager);
         var query = entManager.AllEntityQueryEnumerator<T, MetaDataComponent>();
 

--- a/Robust.Shared/Console/CompletionHelper.cs
+++ b/Robust.Shared/Console/CompletionHelper.cs
@@ -189,27 +189,42 @@ public static class CompletionHelper
         return Components<MapComponent>(string.Empty, entManager);
     }
 
-    public static IEnumerable<CompletionOption> NetEntities(string text, IEntityManager? entManager = null)
+    /// <summary>
+    /// Return all existing entities as possible completions. You should generally avoid using this unless you need to.
+    /// </summary>
+    public static IEnumerable<CompletionOption> NetEntities(string text, IEntityManager? entManager = null, int limit = 20)
     {
-        return Components<MetaDataComponent>(text, entManager);
-    }
+        if (!NetEntity.TryParse(text, out _))
+            yield break;
 
-    public static IEnumerable<CompletionOption> Components<T>(string text, IEntityManager? entManager = null) where T : IComponent
-    {
         IoCManager.Resolve(ref entManager);
+        var query = entManager.AllEntityQueryEnumerator<MetaDataComponent>();
 
-        var query = entManager.AllEntityQueryEnumerator<T, MetaDataComponent>();
-
-        while (query.MoveNext(out var uid, out _, out var metadata))
+        var i = 0;
+        while (i < limit && query.MoveNext(out var metadata))
         {
-            if (!entManager.TryGetNetEntity(uid, out var netEntity, metadata: metadata))
-                continue;
-
-            var netString = netEntity.Value.ToString();
-
+            var netString = metadata.NetEntity.ToString();
             if (!netString.StartsWith(text))
                 continue;
 
+            i++;
+            yield return new CompletionOption(netString, metadata.EntityName);
+        }
+    }
+
+    public static IEnumerable<CompletionOption> Components<T>(string text, IEntityManager? entManager = null, int limit = 20) where T : IComponent
+    {
+        IoCManager.Resolve(ref entManager);
+        var query = entManager.AllEntityQueryEnumerator<T, MetaDataComponent>();
+
+        var i = 0;
+        while (i < limit && query.MoveNext(out _, out var metadata))
+        {
+            var netString = metadata.NetEntity.ToString();
+            if (!netString.StartsWith(text))
+                continue;
+
+            i++;
             yield return new CompletionOption(netString, metadata.EntityName);
         }
     }

--- a/Robust.Shared/GameObjects/NetEntity.cs
+++ b/Robust.Shared/GameObjects/NetEntity.cs
@@ -49,7 +49,7 @@ public readonly struct NetEntity : IEquatable<NetEntity>, IComparable<NetEntity>
     public static NetEntity Parse(ReadOnlySpan<char> uid)
     {
         if (uid.Length == 0)
-            return default;
+            throw new FormatException($"An empty string is not a valid NetEntity");
 
         if (uid[0] != 'c')
             return new NetEntity(int.Parse(uid));


### PR DESCRIPTION
Might help alleviate the lag seen in space-wizards/space-station-14/issues/28258, though this PR also outright removes the non-player completions for the tpto command as the helper will still typically iterate over many entities, and is thus still very slow.