### PR TITLE
Add style property overrides to ContainerButton and TabContainer

### DIFF
--- a/Robust.Client/Graphics/Drawing/StyleBoxTexture.cs
+++ b/Robust.Client/Graphics/Drawing/StyleBoxTexture.cs
@@ -167,6 +167,8 @@ namespace Robust.Client.Graphics
 
         public Color Modulate { get; set; } = Color.White;
 
+        public Color BackgroundColor { get; set; } = Color.Transparent;
+
         public Texture? Texture { get; set; }
 
         /// <summary>
@@ -232,6 +234,8 @@ namespace Robust.Client.Graphics
                 box.Top - ExpandMarginTop * uiScale,
                 box.Right + ExpandMarginRight * uiScale,
                 box.Bottom + ExpandMarginBottom * uiScale);
+
+            handle.DrawRect(box, BackgroundColor);
 
             var scaledMargin = new UIBox2(PatchMarginLeft * TextureScale.X * uiScale, PatchMarginTop * TextureScale.Y * uiScale,
                     PatchMarginRight * TextureScale.X * uiScale, PatchMarginBottom * TextureScale.Y * uiScale);

--- a/Robust.Client/Graphics/Drawing/StyleBoxTexture.cs
+++ b/Robust.Client/Graphics/Drawing/StyleBoxTexture.cs
@@ -167,8 +167,6 @@ namespace Robust.Client.Graphics
 
         public Color Modulate { get; set; } = Color.White;
 
-        public Color BackgroundColor { get; set; } = Color.Transparent;
-
         public Texture? Texture { get; set; }
 
         /// <summary>
@@ -234,8 +232,6 @@ namespace Robust.Client.Graphics
                 box.Top - ExpandMarginTop * uiScale,
                 box.Right + ExpandMarginRight * uiScale,
                 box.Bottom + ExpandMarginBottom * uiScale);
-
-            handle.DrawRect(box, BackgroundColor);
 
             var scaledMargin = new UIBox2(PatchMarginLeft * TextureScale.X * uiScale, PatchMarginTop * TextureScale.Y * uiScale,
                     PatchMarginRight * TextureScale.X * uiScale, PatchMarginBottom * TextureScale.Y * uiScale);

--- a/Robust.Client/UserInterface/Controls/ContainerButton.cs
+++ b/Robust.Client/UserInterface/Controls/ContainerButton.cs
@@ -15,6 +15,8 @@ namespace Robust.Client.UserInterface.Controls
         public const string StylePseudoClassHover = "hover";
         public const string StylePseudoClassDisabled = "disabled";
 
+        public StyleBox? StyleBoxOverride { get; set; }
+
         public ContainerButton()
         {
             DrawModeChanged();
@@ -24,6 +26,11 @@ namespace Robust.Client.UserInterface.Controls
         {
             get
             {
+                if (StyleBoxOverride != null)
+                {
+                    return StyleBoxOverride;
+                }
+
                 if (TryGetStyleProperty<StyleBox>(StylePropertyStyleBox, out var box))
                 {
                     return box;

--- a/Robust.Client/UserInterface/Controls/TabContainer.cs
+++ b/Robust.Client/UserInterface/Controls/TabContainer.cs
@@ -65,6 +65,8 @@ namespace Robust.Client.UserInterface.Controls
             }
         }
 
+        public StyleBox? PanelStyleBoxOverride { get; set; }
+
         public event Action<int>? OnTabChanged;
 
         public TabContainer()
@@ -381,6 +383,9 @@ namespace Robust.Client.UserInterface.Controls
         [System.Diagnostics.Contracts.Pure]
         private StyleBox? _getPanel()
         {
+            if (PanelStyleBoxOverride != null)
+                return PanelStyleBoxOverride;
+
             TryGetStyleProperty<StyleBox>(StylePropertyPanelStyleBox, out var box);
             return box;
         }

--- a/Robust.Client/UserInterface/Controls/TabContainer.cs
+++ b/Robust.Client/UserInterface/Controls/TabContainer.cs
@@ -17,7 +17,6 @@ namespace Robust.Client.UserInterface.Controls
         public const string StylePropertyTabStyleBoxInactive = "tab-stylebox-inactive";
         public const string stylePropertyTabFontColor = "tab-font-color";
         public const string StylePropertyTabFontColorInactive = "tab-font-color-inactive";
-        public const string StylePropertyBackgroundStyleBox = "panel-background-stylebox";
         public const string StylePropertyPanelStyleBox = "panel-stylebox";
 
         private int _currentTab;
@@ -66,7 +65,6 @@ namespace Robust.Client.UserInterface.Controls
             }
         }
 
-        public StyleBox? BackgroundStyleBoxOverride { get; set; }
         public StyleBox? PanelStyleBoxOverride { get; set; }
         public Color? TabFontColorOverride { get; set; }
         public Color? TabFontColorInactiveOverride { get; set; }
@@ -144,12 +142,7 @@ namespace Robust.Client.UserInterface.Controls
         {
             base.Draw(handle);
 
-            // First, draw background panel.
-            var backgroundPanel = _getBackgroundPanel();
-
-            backgroundPanel?.Draw(handle, PixelSizeBox, UIScale);
-
-            // Second, draw tab panel.
+            // First, draw panel.
             var headerSize = _getHeaderSize();
             var panel = _getPanel();
             var panelBox = new UIBox2(0, headerSize, PixelWidth, PixelHeight);
@@ -393,16 +386,6 @@ namespace Robust.Client.UserInterface.Controls
                 return color;
             }
             return Color.Gray;
-        }
-
-        [System.Diagnostics.Contracts.Pure]
-        private StyleBox? _getBackgroundPanel()
-        {
-            if (BackgroundStyleBoxOverride != null)
-                return BackgroundStyleBoxOverride;
-
-            TryGetStyleProperty<StyleBox>(StylePropertyBackgroundStyleBox, out var box);
-            return box;
         }
 
         [System.Diagnostics.Contracts.Pure]

--- a/Robust.Client/UserInterface/Controls/TabContainer.cs
+++ b/Robust.Client/UserInterface/Controls/TabContainer.cs
@@ -17,6 +17,7 @@ namespace Robust.Client.UserInterface.Controls
         public const string StylePropertyTabStyleBoxInactive = "tab-stylebox-inactive";
         public const string stylePropertyTabFontColor = "tab-font-color";
         public const string StylePropertyTabFontColorInactive = "tab-font-color-inactive";
+        public const string StylePropertyBackgroundStyleBox = "panel-background-stylebox";
         public const string StylePropertyPanelStyleBox = "panel-stylebox";
 
         private int _currentTab;
@@ -65,7 +66,10 @@ namespace Robust.Client.UserInterface.Controls
             }
         }
 
+        public StyleBox? BackgroundStyleBoxOverride { get; set; }
         public StyleBox? PanelStyleBoxOverride { get; set; }
+        public Color? TabFontColorOverride { get; set; }
+        public Color? TabFontColorInactiveOverride { get; set; }
 
         public event Action<int>? OnTabChanged;
 
@@ -140,7 +144,12 @@ namespace Robust.Client.UserInterface.Controls
         {
             base.Draw(handle);
 
-            // First, draw panel.
+            // First, draw background panel.
+            var backgroundPanel = _getBackgroundPanel();
+
+            backgroundPanel?.Draw(handle, PixelSizeBox, UIScale);
+
+            // Second, draw tab panel.
             var headerSize = _getHeaderSize();
             var panel = _getPanel();
             var panelBox = new UIBox2(0, headerSize, PixelWidth, PixelHeight);
@@ -363,6 +372,9 @@ namespace Robust.Client.UserInterface.Controls
         [System.Diagnostics.Contracts.Pure]
         private Color _getTabFontColorActive()
         {
+            if (TabFontColorOverride != null)
+                return TabFontColorOverride.Value;
+
             if (TryGetStyleProperty(stylePropertyTabFontColor, out Color color))
             {
                 return color;
@@ -373,11 +385,24 @@ namespace Robust.Client.UserInterface.Controls
         [System.Diagnostics.Contracts.Pure]
         private Color _getTabFontColorInactive()
         {
+            if (TabFontColorInactiveOverride != null)
+                return TabFontColorInactiveOverride.Value;
+
             if (TryGetStyleProperty(StylePropertyTabFontColorInactive, out Color color))
             {
                 return color;
             }
             return Color.Gray;
+        }
+
+        [System.Diagnostics.Contracts.Pure]
+        private StyleBox? _getBackgroundPanel()
+        {
+            if (BackgroundStyleBoxOverride != null)
+                return BackgroundStyleBoxOverride;
+
+            TryGetStyleProperty<StyleBox>(StylePropertyBackgroundStyleBox, out var box);
+            return box;
         }
 
         [System.Diagnostics.Contracts.Pure]


### PR DESCRIPTION
OpenDream needs these to modify the background and text colors of these controls.