### PR TITLE
Added multi prototype loading

### DIFF
--- a/Robust.Client/GameControllerOptions.cs
+++ b/Robust.Client/GameControllerOptions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Robust.Shared;
 using Robust.Shared.Utility;
 
@@ -54,9 +55,13 @@ namespace Robust.Client
         public ResPath AssemblyDirectory { get; init; } = new(@"/Assemblies/");
 
         /// <summary>
-        ///     Directory to load all prototypes from.
+        ///     Directories to load all prototypes from.
         /// </summary>
-        public ResPath PrototypeDirectory { get; init; } = new(@"/Prototypes/");
+        public HashSet<ResPath> PrototypeDirectories { get; init; } = new()
+        {
+            new("/EnginePrototypes/"),
+            new("/Prototypes")
+        };
 
         /// <summary>
         /// Directory resource path containing window icons to load.

--- a/Robust.Client/Prototypes/ClientPrototypeManager.cs
+++ b/Robust.Client/Prototypes/ClientPrototypeManager.cs
@@ -44,8 +44,11 @@ namespace Robust.Client.Prototypes
 
         public override void LoadDefaultPrototypes(Dictionary<Type, HashSet<string>>? changed = null)
         {
-            LoadDirectory(new("/EnginePrototypes/"), changed: changed);
-            LoadDirectory(_controller.Options.PrototypeDirectory, changed: changed);
+            foreach (var directory in _controller.Options.PrototypeDirectories)
+            {
+                LoadDirectory(directory, changed: changed);
+            }
+
             ResolveResults();
         }
 

--- a/Robust.Server/Prototypes/ServerPrototypeManager.cs
+++ b/Robust.Server/Prototypes/ServerPrototypeManager.cs
@@ -51,8 +51,11 @@ namespace Robust.Server.Prototypes
 
         public override void LoadDefaultPrototypes(Dictionary<Type, HashSet<string>>? changed = null)
         {
-            LoadDirectory(new("/EnginePrototypes/"), changed: changed);
-            LoadDirectory(_server.Options.PrototypeDirectory, changed: changed);
+            foreach (var directory in _server.Options.PrototypeDirectories)
+            {
+                LoadDirectory(directory, changed: changed);
+            }
+
             ResolveResults();
         }
     }

--- a/Robust.Server/ServerOptions.cs
+++ b/Robust.Server/ServerOptions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Robust.Shared;
 using Robust.Shared.Utility;
 
@@ -32,9 +33,13 @@ namespace Robust.Server
         public ResPath AssemblyDirectory { get; init; } = new(@"/Assemblies");
 
         /// <summary>
-        ///     Directory to load all prototypes from.
+        ///     Directories to load all prototypes from.
         /// </summary>
-        public ResPath PrototypeDirectory { get; init; } = new(@"/Prototypes");
+        public HashSet<ResPath> PrototypeDirectories { get; init; } = new()
+        {
+            new("/EnginePrototypes/"),
+            new("/Prototypes")
+        };
 
         /// <summary>
         ///     Whether to disable mounting the "Resources/" folder on FULL_RELEASE.


### PR DESCRIPTION
## About PR
The server and client prototype manager now accept the directory list when loading standard prototypes

## Why
It's weird that we only have 1 single folder that we can sub prototypes from by default