### PR TITLE
Remove CompIdx locks

### DIFF
--- a/Robust.Shared/GameObjects/CompIdx.cs
+++ b/Robust.Shared/GameObjects/CompIdx.cs
@@ -9,29 +9,19 @@ namespace Robust.Shared.GameObjects;
 
 public readonly struct CompIdx : IEquatable<CompIdx>
 {
-    private static readonly Dictionary<Type, CompIdx> SlowStore = new();
-
     internal readonly int Value;
 
     internal static CompIdx Index<T>() => Store<T>.Index;
 
-    internal static void Register(Type t)
+    internal static int ArrayIndex<T>() => Index<T>().Value;
+
+    internal static CompIdx GetIndex(Type type)
     {
-        var idx = (CompIdx)typeof(Store<>)
-            .MakeGenericType(t)
+        return (CompIdx)typeof(Store<>)
+            .MakeGenericType(type)
             .GetField(nameof(Store<int>.Index), BindingFlags.Static | BindingFlags.Public)!
             .GetValue(null)!;
-
-        SlowStore[t] = idx;
     }
-
-    internal static CompIdx Index(Type t)
-    {
-        return SlowStore[t];
-    }
-
-    internal static int ArrayIndex<T>() => Index<T>().Value;
-    internal static int ArrayIndex(Type type) => Index(type).Value;
 
     internal static void AssignArray<T>(ref T[] array, CompIdx idx, T value)
     {

--- a/Robust.Shared/GameObjects/ComponentFactory.cs
+++ b/Robust.Shared/GameObjects/ComponentFactory.cs
@@ -410,7 +410,10 @@ namespace Robust.Shared.GameObjects
             var added = new ComponentRegistration[types.Length];
             for (int i = 0; i < types.Length; i++)
             {
-                added[i] = Register(types[i], names, lowerCaseNames, typesDict, idxToType, ignored, overwrite);
+                var type = types[i];
+                CompIdx.Register(type);
+
+                added[i] = Register(type, names, lowerCaseNames, typesDict, idxToType, ignored, overwrite);
             }
 
             var st = RStopwatch.StartNew();

--- a/Robust.Shared/GameObjects/ComponentFactory.cs
+++ b/Robust.Shared/GameObjects/ComponentFactory.cs
@@ -24,7 +24,6 @@ namespace Robust.Shared.GameObjects
 
         // Bunch of dictionaries to allow lookups in all directions.
         /// <summary>
-        /// <summary>
         /// Mapping of component name to type.
         /// </summary>
         private FrozenDictionary<string, ComponentRegistration> _names
@@ -63,6 +62,11 @@ namespace Robust.Shared.GameObjects
         private FrozenDictionary<CompIdx, Type> _idxToType
             = FrozenDictionary<CompIdx, Type>.Empty;
 
+        /// <summary>
+        /// Slow-path for Type -> CompIdx mapping without generics.
+        /// </summary>
+        private FrozenDictionary<Type, CompIdx> _typeToIdx = FrozenDictionary<Type, CompIdx>.Empty;
+
         /// <inheritdoc />
         public event Action<ComponentRegistration[]>? ComponentsAdded;
 
@@ -78,6 +82,7 @@ namespace Robust.Shared.GameObjects
         private IEnumerable<ComponentRegistration> AllRegistrations => _types.Values;
 
         private ComponentRegistration Register(Type type,
+            CompIdx idx,
             Dictionary<string, ComponentRegistration> names,
             Dictionary<string, string> lowerCaseNames,
             Dictionary<Type, ComponentRegistration> types,
@@ -122,8 +127,6 @@ namespace Robust.Shared.GameObjects
                 throw new InvalidOperationException($"{lowerCaseName} is already registered, previous: {prevName}");
 
             var unsaved = type.HasCustomAttribute<UnsavedComponentAttribute>();
-
-            var idx = CompIdx.Index(type);
 
             var registration = new ComponentRegistration(name, type, idx, unsaved);
 
@@ -399,6 +402,20 @@ namespace Robust.Shared.GameObjects
             RegisterTypesInternal(types, false);
         }
 
+        /// <inheritdoc />
+        [Pure]
+        public CompIdx GetIndex(Type type)
+        {
+            return _typeToIdx[type];
+        }
+
+        /// <inheritdoc />
+        [Pure]
+        public int GetArrayIndex(Type type)
+        {
+            return _typeToIdx[type].Value;
+        }
+
         private void RegisterTypesInternal(Type[] types, bool overwrite)
         {
             var names = _names.ToDictionary();
@@ -408,15 +425,19 @@ namespace Robust.Shared.GameObjects
             var ignored = _ignored.ToHashSet();
 
             var added = new ComponentRegistration[types.Length];
+            var typeToidx = _typeToIdx.ToDictionary();
+
             for (int i = 0; i < types.Length; i++)
             {
                 var type = types[i];
-                CompIdx.Register(type);
+                var idx = CompIdx.GetIndex(type);
+                typeToidx[type] = idx;
 
-                added[i] = Register(type, names, lowerCaseNames, typesDict, idxToType, ignored, overwrite);
+                added[i] = Register(type, idx, names, lowerCaseNames, typesDict, idxToType, ignored, overwrite);
             }
 
             var st = RStopwatch.StartNew();
+            _typeToIdx = typeToidx.ToFrozenDictionary();
             _names = names.ToFrozenDictionary();
             _lowerCaseNames = lowerCaseNames.ToFrozenDictionary();
             _types = typesDict.ToFrozenDictionary();

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -138,7 +138,7 @@ namespace Robust.Shared.GameObjects
             DispatchComponent<TEvent>(
                 component.Owner,
                 component,
-                CompIdx.Index(component.GetType()),
+                _comFac.GetIndex(component.GetType()),
                 ref unitRef);
         }
 
@@ -161,7 +161,7 @@ namespace Robust.Shared.GameObjects
             DispatchComponent<TEvent>(
                 component.Owner,
                 component,
-                CompIdx.Index(component.GetType()),
+                _comFac.GetIndex(component.GetType()),
                 ref unitRef);
         }
 
@@ -390,7 +390,7 @@ namespace Robust.Shared.GameObjects
 
         public void OnComponentRemoved(in RemovedComponentEventArgs e)
         {
-            EntRemoveComponent(e.BaseArgs.Owner, CompIdx.Index(e.BaseArgs.Component.GetType()));
+            EntRemoveComponent(e.BaseArgs.Owner, _comFac.GetIndex(e.BaseArgs.Component.GetType()));
         }
 
         private void EntAddSubscription(

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -126,7 +126,7 @@ namespace Robust.Shared.GameObjects
             foreach (var comp in comps)
             {
                 if (comp is { LifeStage:  ComponentLifeStage.Added })
-                    LifeInitialize(comp, CompIdx.Index(comp.GetType()));
+                    LifeInitialize(comp, _componentFactory.GetIndex(comp.GetType()));
             }
 
 #if DEBUG
@@ -999,7 +999,7 @@ namespace Robust.Shared.GameObjects
 
         public EntityQuery<IComponent> GetEntityQuery(Type type)
         {
-            var comps = _entTraitArray[CompIdx.ArrayIndex(type)];
+            var comps = _entTraitArray[_componentFactory.GetArrayIndex(type)];
             DebugTools.Assert(comps != null, $"Unknown component: {type.Name}");
             return new EntityQuery<IComponent>(comps, _resolveSawmill);
         }

--- a/Robust.Shared/GameObjects/IComponentFactory.cs
+++ b/Robust.Shared/GameObjects/IComponentFactory.cs
@@ -78,6 +78,18 @@ namespace Robust.Shared.GameObjects
         ComponentAvailability GetComponentAvailability(string componentName, bool ignoreCase = false);
 
         /// <summary>
+        /// Slow-path for Type -> CompIdx mapping without generics.
+        /// </summary>
+        [Pure]
+        CompIdx GetIndex(Type type);
+
+        /// <summary>
+        /// Slow-path to get the component index for a specified type.
+        /// </summary>
+        [Pure]
+        int GetArrayIndex(Type type);
+
+        /// <summary>
         /// Registers a component class with the factory.
         /// </summary>
         /// <param name="overwrite">If the component already exists, will this replace it?</param>


### PR DESCRIPTION
So GetComponentState in PVS calls RaiseComponentEvent which in turn calls this. When you start getting a significant number of players it seems to run into lock contention considering every single compstate get will lock this.

Instead we'll just store a FrozenDictionary on ComponentFactory. This reference already exists everywhere we need it + now we replace both a lock and a dictionary for double-win in single-threaded and multi-threaded scenarios.

Resolves https://github.com/space-wizards/RobustToolbox/issues/5230