### PR TITLE
Allow RequestScreenTexture to be set in overlays

### DIFF
--- a/Robust.Client/Graphics/Overlays/Overlay.cs
+++ b/Robust.Client/Graphics/Overlays/Overlay.cs
@@ -22,7 +22,7 @@ namespace Robust.Client.Graphics
         ///     If set to true, <see cref="ScreenTexture"/> will be set to the current frame (at the moment before the overlay is rendered). This can be costly to performance, but
         ///     some shaders will require it as a passed in uniform to operate.
         /// </summary>
-        public virtual bool RequestScreenTexture => false;
+        public virtual bool RequestScreenTexture { get; set; } = false;
 
         /// <summary>
         ///     If <see cref="RequestScreenTexture"> is true, then this will be set to the texture corresponding to the current frame. If false, it will always be null.


### PR DESCRIPTION
My first engine PR, so please someone double check that I didn't mess up with git somewhere.

This makes it possible to set RequestScreenTexture, allowing overlays to set it to false when no longer needed and improving performance.

I need this for a change in the FlashOverlay.