### PR TITLE
Avoid read lock in `GetEntityQuery`

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -999,7 +999,7 @@ namespace Robust.Shared.GameObjects
 
         public EntityQuery<IComponent> GetEntityQuery(Type type)
         {
-            var comps = _entTraitArray[CompIdx.ArrayIndex(type)];
+            var comps = _entTraitDict[type];
             DebugTools.Assert(comps != null, $"Unknown component: {type.Name}");
             return new EntityQuery<IComponent>(comps, _resolveSawmill);
         }


### PR DESCRIPTION
~~Probably causing #5230? At least AFAICT this is the only place were it `Index(Type t)` gets used somewhere were it might be multithreaded.~~ nvm forgot about get state events. But probably still worthwhile even with #5231