### PR TITLE
Add an entry to RSI meta.json for controlling RSI atlas grouping

### DIFF
--- a/Robust.Client/ResourceManagement/ResourceTypes/RSIResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/RSIResource.cs
@@ -183,6 +183,7 @@ namespace Robust.Client.ResourceManagement
             data.DimX = dimensionX;
             data.CallbackOffsets = callbackOffsets;
             data.LoadParameters = metadata.LoadParameters;
+            data.AtlasGroup = metadata.AtlasGroup;
         }
 
         internal static void LoadPostTexture(LoadStepData data)
@@ -386,6 +387,24 @@ namespace Robust.Client.ResourceManagement
             public Vector2i AtlasOffset;
             public RSI Rsi = default!;
             public TextureLoadParameters LoadParameters;
+
+            /// <summary>
+            /// Integer used to identify how different textures should be grouped together into atlases.
+            /// Negative values imply that the texture should not be put on an atlas.
+            /// </summary>
+            public int AtlasGroup;
+
+            /// <summary>
+            /// Comparer used for determining the order in which textures should be placed into the texture atlas.
+            /// </summary>
+            public static int Comparison(LoadStepData b, LoadStepData a)
+            {
+                var cmp = b.AtlasGroup.CompareTo(a.AtlasGroup);
+                if (cmp != 0)
+                    return cmp;
+
+                return (b.AtlasSheet?.Height ?? 0).CompareTo(a.AtlasSheet?.Height ?? 0);
+            }
         }
 
         internal struct StateReg

--- a/Robust.Shared/Resources/RsiLoading.cs
+++ b/Robust.Shared/Resources/RsiLoading.cs
@@ -104,7 +104,7 @@ internal static class RsiLoading
             };
         }
 
-        return new RsiMetadata(size, states, textureParams);
+        return new RsiMetadata(size, states, textureParams, manifestJson.AtlasGroup);
     }
 
     public static void Warmup()
@@ -114,11 +114,12 @@ internal static class RsiLoading
         JsonSerializer.Deserialize<RsiJsonMetadata>(warmupJson, SerializerOptions);
     }
 
-    internal sealed class RsiMetadata(Vector2i size, StateMetadata[] states, TextureLoadParameters loadParameters)
+    internal sealed class RsiMetadata(Vector2i size, StateMetadata[] states, TextureLoadParameters loadParameters, int atlasGroup)
     {
         public readonly Vector2i Size = size;
         public readonly StateMetadata[] States = states;
         public readonly TextureLoadParameters LoadParameters = loadParameters;
+        public readonly int AtlasGroup = atlasGroup;
     }
 
     internal sealed class StateMetadata
@@ -140,7 +141,7 @@ internal static class RsiLoading
 
     // To be directly deserialized.
     [UsedImplicitly]
-    private sealed record RsiJsonMetadata(Vector2i Size, StateJsonMetadata[] States, RsiJsonLoad? Load);
+    private sealed record RsiJsonMetadata(Vector2i Size, StateJsonMetadata[] States, RsiJsonLoad? Load, int AtlasGroup = 0);
 
     [UsedImplicitly]
     private sealed record StateJsonMetadata(string Name, int? Directions, float[][]? Delays);

--- a/Schemas/rsi.json
+++ b/Schemas/rsi.json
@@ -50,7 +50,8 @@
                         ]
                     ]
                 }
-            ]
+            ],
+            "atlasGroup": 0
         }
     ],
     "required": [
@@ -184,6 +185,13 @@
                     }
                 }
             }
+        },
+        "atlasGroup": {
+            "$id": "#/properties/atlasGroup",
+            "default": "",
+            "description": "An integer that is used to group RSIs into the same texture atlas. Defaults to 0. Negative values prevent the RSI from being put into a larger atlas.",
+            "title": "atlasGroup",
+            "type": "integer"
         }
     },
     "additionalProperties": true


### PR DESCRIPTION
This adds an "atlasGroup" integer to the RSI meta.json that is intended to allow RSIs to try and control how they are inserted into the RSI atlases. Currently this doesn't actually ensure that each "group" has its own atlas, but ideally that's what it would do eventually (rectangle packing when).  Currently its mainly useful for trying to prevent large & niche RSIs from taking up space in the main atlas.