### PR TITLE
Increase default value of res.rsi_atlas_size cvar

### DIFF
--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1374,7 +1374,7 @@ namespace Robust.Shared
         /// the purpose of using an atlas if it gets too small.
         /// </summary>
         public static readonly CVarDef<int> ResRSIAtlasSize =
-            CVarDef.Create("res.rsi_atlas_size", 8192, CVar.CLIENTONLY);
+            CVarDef.Create("res.rsi_atlas_size", 12288, CVar.CLIENTONLY);
 
         // TODO: Currently unimplemented.
         /// <summary>


### PR DESCRIPTION
Even with #5249, and probably even with optimal packing, I think SS14's RSI atlas will now just exceed the current default value. So this PR increase the default by 50%, from 8k to 12k. Note that its still limited by `GL.GetInteger(GetPName.MaxTextureSize)`, so hopefully it shouldn't cause any issues for devices that don't support larger textures, though I also don't know if increasing it might somehow hurt performance on some machines.