### PR TITLE
SIMD Colour multiplication

### DIFF
--- a/Robust.Shared.Maths/Color.cs
+++ b/Robust.Shared.Maths/Color.cs
@@ -1003,7 +1003,7 @@ namespace Robust.Shared.Maths
         /// </summary>
         /// <param name="other">The Color4 structure to compare to.</param>
         /// <returns>True if both Color4 structures contain the same components; false otherwise.</returns>
-        public readonly bool Equals(in Color other)
+        public readonly bool Equals(Color other)
         {
             // TODO COLOR why is this approximate
             // This method literally doesn't do what its docstring says it does.

--- a/Robust.Shared.Maths/Color.cs
+++ b/Robust.Shared.Maths/Color.cs
@@ -46,22 +46,22 @@ namespace Robust.Shared.Maths
     public struct Color : IEquatable<Color>, ISpanFormattable
     {
         /// <summary>
-        ///     The red component of this Color4 structure.
+        ///     The red component of this Color structure.
         /// </summary>
         public float R;
 
         /// <summary>
-        ///     The green component of this Color4 structure.
+        ///     The green component of this Color structure.
         /// </summary>
         public float G;
 
         /// <summary>
-        ///     The blue component of this Color4 structure.
+        ///     The blue component of this Color structure.
         /// </summary>
         public float B;
 
         /// <summary>
-        ///     The alpha component of this Color4 structure.
+        ///     The alpha component of this Color structure.
         /// </summary>
         public float A;
 
@@ -77,12 +77,12 @@ namespace Robust.Shared.Maths
         public readonly byte AByte => (byte) (A * byte.MaxValue);
 
         /// <summary>
-        ///     Constructs a new Color4 structure from the specified components.
+        ///     Constructs a new <see cref="Color"/> structure from the specified components.
         /// </summary>
-        /// <param name="r">The red component of the new Color4 structure.</param>
-        /// <param name="g">The green component of the new Color4 structure.</param>
-        /// <param name="b">The blue component of the new Color4 structure.</param>
-        /// <param name="a">The alpha component of the new Color4 structure.</param>
+        /// <param name="r">The red component of the new Color structure.</param>
+        /// <param name="g">The green component of the new Color structure.</param>
+        /// <param name="b">The blue component of the new Color structure.</param>
+        /// <param name="a">The alpha component of the new Color structure.</param>
         public Color(float r, float g, float b, float a = 1)
         {
             R = r;
@@ -92,7 +92,7 @@ namespace Robust.Shared.Maths
         }
 
         /// <summary>
-        ///     Constructs a new Color4 structure from the components in a <see cref="SysVector4"/>.
+        ///     Constructs a new Color structure from the components in a <see cref="SysVector4"/>.
         /// </summary>
         public Color(in SysVector4 vec)
         {
@@ -100,19 +100,19 @@ namespace Robust.Shared.Maths
         }
 
         /// <summary>
-        ///     Constructs a new Color4 structure by coping the contents of another color struct.
+        ///     Constructs a new Color structure by coping the contents of another color struct.
         /// </summary>
         public Color(in Color color) : this(color.RGBA)
         {
         }
 
         /// <summary>
-        ///     Constructs a new Color4 structure from the specified components.
+        ///     Constructs a new Color structure from the specified components.
         /// </summary>
-        /// <param name="r">The red component of the new Color4 structure.</param>
-        /// <param name="g">The green component of the new Color4 structure.</param>
-        /// <param name="b">The blue component of the new Color4 structure.</param>
-        /// <param name="a">The alpha component of the new Color4 structure.</param>
+        /// <param name="r">The red component of the new Color structure.</param>
+        /// <param name="g">The green component of the new Color structure.</param>
+        /// <param name="b">The blue component of the new Color structure.</param>
+        /// <param name="a">The alpha component of the new Color structure.</param>
         public Color(byte r, byte g, byte b, byte a = 255)
         {
             Unsafe.SkipInit(out this);
@@ -142,7 +142,7 @@ namespace Robust.Shared.Maths
         }
 
         /// <summary>
-        ///     Compares the specified Color4 structures for equality.
+        ///     Compares the specified Color structures for equality.
         /// </summary>
         /// <param name="left">The left-hand side of the comparison.</param>
         /// <param name="right">The right-hand side of the comparison.</param>
@@ -153,7 +153,7 @@ namespace Robust.Shared.Maths
         }
 
         /// <summary>
-        ///     Compares the specified Color4 structures for inequality.
+        ///     Compares the specified Color structures for inequality.
         /// </summary>
         /// <param name="left">The left-hand side of the comparison.</param>
         /// <param name="right">The right-hand side of the comparison.</param>
@@ -164,10 +164,10 @@ namespace Robust.Shared.Maths
         }
 
         /// <summary>
-        ///     Converts the specified System.Drawing.Color to a Color4 structure.
+        ///     Converts the specified System.Drawing.Color to a Color structure.
         /// </summary>
         /// <param name="color">The System.Drawing.Color to convert.</param>
-        /// <returns>A new Color4 structure containing the converted components.</returns>
+        /// <returns>A new Color structure containing the converted components.</returns>
         public static implicit operator Color(System.Drawing.Color color)
         {
             return new(color.R, color.G, color.B, color.A);
@@ -199,9 +199,9 @@ namespace Robust.Shared.Maths
         }
 
         /// <summary>
-        ///     Converts the specified Color4 to a System.Drawing.Color structure.
+        ///     Converts the specified Color to a System.Drawing.Color structure.
         /// </summary>
-        /// <param name="color">The Color4 to convert.</param>
+        /// <param name="color">The Color to convert.</param>
         /// <returns>A new System.Drawing.Color structure containing the converted components.</returns>
         public static explicit operator System.Drawing.Color(Color color)
         {
@@ -228,10 +228,10 @@ namespace Robust.Shared.Maths
         }
 
         /// <summary>
-        ///     Compares whether this Color4 structure is equal to the specified object.
+        ///     Compares whether this Color structure is equal to the specified object.
         /// </summary>
         /// <param name="obj">An object to compare to.</param>
-        /// <returns>True obj is a Color4 structure with the same components as this Color4; false otherwise.</returns>
+        /// <returns>True obj is a Color structure with the same components as this Color; false otherwise.</returns>
         public readonly override bool Equals(object? obj)
         {
             if (!(obj is Color))
@@ -241,18 +241,18 @@ namespace Robust.Shared.Maths
         }
 
         /// <summary>
-        ///     Calculates the hash code for this Color4 structure.
+        ///     Calculates the hash code for this Color structure.
         /// </summary>
-        /// <returns>A System.Int32 containing the hash code of this Color4 structure.</returns>
+        /// <returns>A System.Int32 containing the hash code of this Color structure.</returns>
         public readonly override int GetHashCode()
         {
             return ToArgb();
         }
 
         /// <summary>
-        ///     Creates a System.String that describes this Color4 structure.
+        ///     Creates a System.String that describes this Color structure.
         /// </summary>
-        /// <returns>A System.String that describes this Color4 structure.</returns>
+        /// <returns>A System.String that describes this Color structure.</returns>
         public readonly override string ToString()
         {
             return $"{{(R, G, B, A) = ({R}, {G}, {B}, {A})}}";
@@ -999,10 +999,10 @@ namespace Robust.Shared.Maths
         }
 
         /// <summary>
-        ///     Compares whether this Color4 structure is equal to the specified Color4.
+        ///     Compares whether this Color structure is equal to the specified Color.
         /// </summary>
-        /// <param name="other">The Color4 structure to compare to.</param>
-        /// <returns>True if both Color4 structures contain the same components; false otherwise.</returns>
+        /// <param name="other">The Color structure to compare to.</param>
+        /// <returns>True if both Color structures contain the same components; false otherwise.</returns>
         public readonly bool Equals(Color other)
         {
             // TODO COLOR why is this approximate

--- a/Robust.Shared.Maths/Color.cs
+++ b/Robust.Shared.Maths/Color.cs
@@ -42,38 +42,34 @@ namespace Robust.Shared.Maths
     ///     Represents a color with 4 floating-point components (R, G, B, A).
     /// </summary>
     [Serializable]
-    [StructLayout(LayoutKind.Explicit)]
+    [StructLayout(LayoutKind.Sequential)]
     public struct Color : IEquatable<Color>, ISpanFormattable
     {
         /// <summary>
         ///     The red component of this Color4 structure.
         /// </summary>
-        [FieldOffset(0)]
         public float R;
 
         /// <summary>
         ///     The green component of this Color4 structure.
         /// </summary>
-        [FieldOffset(sizeof(float))]
         public float G;
 
         /// <summary>
         ///     The blue component of this Color4 structure.
         /// </summary>
-        [FieldOffset(2*sizeof(float))]
         public float B;
 
         /// <summary>
         ///     The alpha component of this Color4 structure.
         /// </summary>
-        [FieldOffset(3*sizeof(float))]
         public float A;
 
         /// <summary>
         /// Vector representation, for easy SIMD operations.
         /// </summary>
-        [FieldOffset(0), NonSerialized]
-        public SysVector4 RGBA;
+        // ReSharper disable once InconsistentNaming
+        public readonly SysVector4 RGBA => Unsafe.BitCast<Color, SysVector4>(this);
 
         public readonly byte RByte => (byte) (R * byte.MaxValue);
         public readonly byte GByte => (byte) (G * byte.MaxValue);
@@ -89,20 +85,24 @@ namespace Robust.Shared.Maths
         /// <param name="a">The alpha component of the new Color4 structure.</param>
         public Color(float r, float g, float b, float a = 1)
         {
-            Unsafe.SkipInit(out this);
             R = r;
             G = g;
             B = b;
             A = a;
         }
 
-        public Color(SysVector4 vec)
+        /// <summary>
+        ///     Constructs a new Color4 structure from the components in a <see cref="SysVector4"/>.
+        /// </summary>
+        public Color(in SysVector4 vec)
         {
-            Unsafe.SkipInit(out this);
-            RGBA = vec;
+            this = Unsafe.BitCast<SysVector4, Color>(vec);
         }
 
-        public Color(Color color) : this(color.RGBA)
+        /// <summary>
+        ///     Constructs a new Color4 structure by coping the contents of another color struct.
+        /// </summary>
+        public Color(in Color color) : this(color.RGBA)
         {
         }
 

--- a/Robust.Shared.Maths/Color.cs
+++ b/Robust.Shared.Maths/Color.cs
@@ -140,7 +140,7 @@ namespace Robust.Shared.Maths
         /// <param name="left">The left-hand side of the comparison.</param>
         /// <param name="right">The right-hand side of the comparison.</param>
         /// <returns>True if left is equal to right; false otherwise.</returns>
-        public static bool operator ==(in Color left, in Color right)
+        public static bool operator ==(Color left, Color right)
         {
             return left.Equals(right);
         }
@@ -151,7 +151,7 @@ namespace Robust.Shared.Maths
         /// <param name="left">The left-hand side of the comparison.</param>
         /// <param name="right">The right-hand side of the comparison.</param>
         /// <returns>True if left is not equal to right; false otherwise.</returns>
-        public static bool operator !=(in Color left, in Color right)
+        public static bool operator !=(Color left, Color right)
         {
             return !left.Equals(right);
         }

--- a/Robust.Shared.Maths/Color.cs
+++ b/Robust.Shared.Maths/Color.cs
@@ -330,17 +330,17 @@ namespace Robust.Shared.Maths
             if (srgb.R <= 0.04045f)
                 r = srgb.R / 12.92f;
             else
-                r = (float) Math.Pow((srgb.R + 0.055f) / (1.0f + 0.055f), 2.4f);
+                r = MathF.Pow((srgb.R + 0.055f) / (1.0f + 0.055f), 2.4f);
 
             if (srgb.G <= 0.04045f)
                 g = srgb.G / 12.92f;
             else
-                g = (float) Math.Pow((srgb.G + 0.055f) / (1.0f + 0.055f), 2.4f);
+                g = MathF.Pow((srgb.G + 0.055f) / (1.0f + 0.055f), 2.4f);
 
             if (srgb.B <= 0.04045f)
                 b = srgb.B / 12.92f;
             else
-                b = (float) Math.Pow((srgb.B + 0.055f) / (1.0f + 0.055f), 2.4f);
+                b = MathF.Pow((srgb.B + 0.055f) / (1.0f + 0.055f), 2.4f);
 
             return new Color(r, g, b, srgb.A);
         }
@@ -359,17 +359,17 @@ namespace Robust.Shared.Maths
             if (rgb.R <= 0.0031308)
                 r = 12.92f * rgb.R;
             else
-                r = (1.0f + 0.055f) * (float) Math.Pow(rgb.R, 1.0f / 2.4f) - 0.055f;
+                r = (1.0f + 0.055f) * MathF.Pow(rgb.R, 1.0f / 2.4f) - 0.055f;
 
             if (rgb.G <= 0.0031308)
                 g = 12.92f * rgb.G;
             else
-                g = (1.0f + 0.055f) * (float) Math.Pow(rgb.G, 1.0f / 2.4f) - 0.055f;
+                g = (1.0f + 0.055f) * MathF.Pow(rgb.G, 1.0f / 2.4f) - 0.055f;
 
             if (rgb.B <= 0.0031308)
                 b = 12.92f * rgb.B;
             else
-                b = (1.0f + 0.055f) * (float) Math.Pow(rgb.B, 1.0f / 2.4f) - 0.055f;
+                b = (1.0f + 0.055f) * MathF.Pow(rgb.B, 1.0f / 2.4f) - 0.055f;
 
             return new Color(r, g, b, rgb.A);
         }

--- a/Robust.Shared.Maths/Color.cs
+++ b/Robust.Shared.Maths/Color.cs
@@ -100,13 +100,6 @@ namespace Robust.Shared.Maths
         }
 
         /// <summary>
-        ///     Constructs a new Color structure by coping the contents of another color struct.
-        /// </summary>
-        public Color(in Color color) : this(color.RGBA)
-        {
-        }
-
-        /// <summary>
         ///     Constructs a new Color structure from the specified components.
         /// </summary>
         /// <param name="r">The red component of the new Color structure.</param>

--- a/Robust.Shared.Maths/MathHelper.cs
+++ b/Robust.Shared.Maths/MathHelper.cs
@@ -15,6 +15,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using Vec4 = System.Numerics.Vector4;
 
 namespace Robust.Shared.Maths
 {
@@ -524,6 +525,27 @@ namespace Robust.Shared.Maths
             double epsilon = Math.Max(Math.Max(Math.Abs(a), Math.Abs(b)) * percentage, percentage);
             return Math.Abs(a - b) <= epsilon;
         }
+
+        /// <summary>
+        /// Returns whether two vectors are within <paramref name="percentage"/> of each other
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool CloseToPercent(Vec4 a, Vec4 b, float percentage = .00001f)
+        {
+            a = Vec4.Abs(a);
+            b = Vec4.Abs(b);
+            var p = new Vec4(percentage);
+            var epsilon = Vec4.Max(Vec4.Max(a, b) * p, p);
+            var delta = Vec4.Abs(a - b);
+            return delta.X <= epsilon.X && delta.Y <= epsilon.Y && delta.Z <= epsilon.Z && delta.W <= epsilon.W;
+        }
+
+        /// <summary>
+        /// Returns whether two colours are within <paramref name="percentage"/> of each other
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool CloseToPercent(Color a, Color b, float percentage = .00001f)
+            => CloseToPercent(a.RGBA, b.RGBA, percentage);
 
         /// <summary>
         /// Returns whether two floating point numbers are within <paramref name="percentage"/> of eachother


### PR DESCRIPTION
This PR changes colour multiplication & interpolation so that they just use `System.Numerics.Vector4`. I ran the content colour interpolation benchmarks, and they are unchanged, while a similar benchmark for multiplication is ~3 times faster.