### PR TITLE
Make colour equality not approximate

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,7 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* The `Color` struct's equality methods now check for exact equality. Use `MathHelper.CloseToPercent(Color, Color)` for the previous functionality.
 
 ### New features
 

--- a/Robust.Shared.Maths/Color.cs
+++ b/Robust.Shared.Maths/Color.cs
@@ -997,12 +997,7 @@ namespace Robust.Shared.Maths
         /// <param name="other">The Color structure to compare to.</param>
         /// <returns>True if both Color structures contain the same components; false otherwise.</returns>
         public readonly bool Equals(Color other)
-        {
-            // TODO COLOR why is this approximate
-            // This method literally doesn't do what its docstring says it does.
-            // If people wanted approximate equality, they can check that manually.
-            return MathHelper.CloseToPercent(this, other);
-        }
+            => RGBA == other.RGBA;
 
         [PublicAPI]
         public enum BlendFactor : byte

--- a/Robust.UnitTesting/Shared/Maths/Color_Test.cs
+++ b/Robust.UnitTesting/Shared/Maths/Color_Test.cs
@@ -344,7 +344,7 @@ namespace Robust.UnitTesting.Shared.Maths
             var controlColor = new Color(rf, gf, bf, af);
             var color = Color.FromSrgb(Color.ToSrgb(controlColor));
 
-            Assert.That(color, Is.EqualTo(controlColor));
+            Assert.That(MathHelper.CloseToPercent(color, controlColor));
         }
 
         [Test]
@@ -355,7 +355,7 @@ namespace Robust.UnitTesting.Shared.Maths
             var controlColor = new Color(rf, gf, bf, af);
             var color = Color.FromHsl(Color.ToHsl(controlColor));
 
-            Assert.That(color, Is.EqualTo(controlColor));
+            Assert.That(MathHelper.CloseToPercent(color, controlColor));
         }
 
         [Test]
@@ -366,7 +366,7 @@ namespace Robust.UnitTesting.Shared.Maths
             var controlColor = new Color(rf, gf, bf, af);
             var color = Color.FromHsv(Color.ToHsv(controlColor));
 
-            Assert.That(color, Is.EqualTo(controlColor));
+            Assert.That(MathHelper.CloseToPercent(color, controlColor));
         }
 
         [Test]
@@ -393,7 +393,7 @@ namespace Robust.UnitTesting.Shared.Maths
             var controlColor = new Color(rf, gf, bf, af);
             var color = Color.FromYcbcr(Color.ToYcbcr(controlColor));
 
-            Assert.That(color, Is.EqualTo(controlColor));
+            Assert.That(MathHelper.CloseToPercent(color, controlColor));
         }
 
         [Test]
@@ -404,7 +404,7 @@ namespace Robust.UnitTesting.Shared.Maths
             var controlColor = new Color(rf, gf, bf, af);
             var color = Color.FromHcy(Color.ToHcy(controlColor));
 
-            Assert.That(color, Is.EqualTo(controlColor));
+            Assert.That(MathHelper.CloseToPercent(color, controlColor));
         }
 
         static IEnumerable<float> InterpolationValues => new float[]
@@ -430,7 +430,7 @@ namespace Robust.UnitTesting.Shared.Maths
             var interColor = Color.InterpolateBetween(color1, color2, interpolation);
             var inverseInterColor = Color.InterpolateBetween(color2, color1, 1 - interpolation);
 
-            Assert.That(interColor, Is.EqualTo(inverseInterColor));
+            Assert.That(MathHelper.CloseToPercent(interColor, inverseInterColor));
         }
 
         [Test]


### PR DESCRIPTION
Currently the colour equality methods use `MathHelper.CloseToPercent()` instead of actually checking equality, which directly contradicts the method's own documentation. IMO equality should just check equality. If approximate equality is desired, that should be explicitly checked.

I'm not sure why exactly it was using approximate equality before. Maybe it was trying to avoid unnecessary shader/rendering changes? In which case maybe this PR should also update those checks.