### PR TITLE
Fix ContainerSystem debug assert

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Fixes ContainerSystem failing client-side debug asserts when an entity gets unanchored & inserted into a container on the same tick.
 
 ### Other
 

--- a/Robust.Shared/Containers/SharedContainerSystem.Insert.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.Insert.cs
@@ -40,8 +40,8 @@ public abstract partial class SharedContainerSystem
 
         DebugTools.AssertOwner(container.Owner, containerXform);
         DebugTools.AssertOwner(toInsert, physics);
-        DebugTools.Assert(!container.ExpectedEntities.Contains(GetNetEntity(toInsert)));
-        DebugTools.Assert(container.Manager.Containers.ContainsKey(container.ID));
+        DebugTools.Assert(!container.ExpectedEntities.Contains(GetNetEntity(toInsert)), "entity is expected");
+        DebugTools.Assert(container.Manager.Containers.ContainsKey(container.ID), "manager does not own the container");
 
         // If someone is attempting to insert an entity into a container that is getting deleted, then we will
         // automatically delete that entity. I.e., the insertion automatically "succeeds" and both entities get deleted.
@@ -82,14 +82,14 @@ public abstract partial class SharedContainerSystem
         }
 
         // Update metadata first, so that parent change events can check IsInContainer.
-        DebugTools.Assert((meta.Flags & MetaDataFlags.InContainer) == 0);
+        DebugTools.Assert((meta.Flags & MetaDataFlags.InContainer) == 0, "invalid metadata flags before insertion");
         meta.Flags |= MetaDataFlags.InContainer;
 
         // Remove the entity and any children from broadphases.
         // This is done before changing can collide to avoid unecceary updates.
         // TODO maybe combine with RecursivelyUpdatePhysics to avoid fetching components and iterating parents twice?
         _lookup.RemoveFromEntityTree(toInsert, transform);
-        DebugTools.Assert(transform.Broadphase == null || !transform.Broadphase.Value.IsValid());
+        DebugTools.Assert(transform.Broadphase == null || !transform.Broadphase.Value.IsValid(), "invalid broadphase");
 
         // Avoid unnecessary broadphase updates while unanchoring, changing physics collision, and re-parenting.
         var old = transform.Broadphase;
@@ -111,7 +111,7 @@ public abstract partial class SharedContainerSystem
         transform.Broadphase = old;
 
         // the transform.AttachParent() could previously result in the flag being unset, so check that this hasn't happened.
-        DebugTools.Assert((meta.Flags & MetaDataFlags.InContainer) != 0);
+        DebugTools.Assert((meta.Flags & MetaDataFlags.InContainer) != 0, "invalid metadata flags after insertion");
 
         // Implementation specific insert logic
         container.InternalInsert(toInsert, EntityManager);
@@ -125,11 +125,11 @@ public abstract partial class SharedContainerSystem
         RaiseLocalEvent(toInsert, new EntGotInsertedIntoContainerMessage(toInsert, container), true);
 
         // The sheer number of asserts tells you about how little I trust container and parenting code.
-        DebugTools.Assert((meta.Flags & MetaDataFlags.InContainer) != 0);
-        DebugTools.Assert(!transform.Anchored);
-        DebugTools.Assert(transform.LocalPosition == Vector2.Zero);
-        DebugTools.Assert(MathHelper.CloseTo(transform.LocalRotation.Theta, Angle.Zero));
-        DebugTools.Assert(!PhysicsQuery.TryGetComponent(toInsert, out var phys) || (!phys.Awake && !phys.CanCollide));
+        DebugTools.Assert((meta.Flags & MetaDataFlags.InContainer) != 0, "invalid metadata flags after events");
+        DebugTools.Assert(!transform.Anchored, "entity is anchored");
+        DebugTools.AssertEqual(transform.LocalPosition, Vector2.Zero);
+        DebugTools.Assert(MathHelper.CloseTo(transform.LocalRotation.Theta, Angle.Zero), "Angle is not zero");
+        DebugTools.Assert(!PhysicsQuery.TryGetComponent(toInsert, out var phys) || (!phys.Awake && !phys.CanCollide), "Invalid physics");
 
         Dirty(container.Owner, container.Manager);
         return true;

--- a/Robust.Shared/Containers/SharedContainerSystem.Remove.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.Remove.cs
@@ -41,7 +41,7 @@ public abstract partial class SharedContainerSystem
             return false;
 
         DebugTools.AssertNotNull(container.Manager);
-        DebugTools.Assert(Exists(toRemove));
+        DebugTools.Assert(Exists(toRemove), "toRemove does not exist");
 
         if (!force && !CanRemove(toRemove, container))
             return false;
@@ -60,11 +60,11 @@ public abstract partial class SharedContainerSystem
             return false;
         }
 
-        DebugTools.Assert(meta.EntityLifeStage < EntityLifeStage.Terminating || (force && !reparent));
-        DebugTools.Assert(xform.Broadphase == null || !xform.Broadphase.Value.IsValid());
-        DebugTools.Assert(!xform.Anchored);
-        DebugTools.Assert((meta.Flags & MetaDataFlags.InContainer) != 0x0);
-        DebugTools.Assert(!TryComp(toRemove, out PhysicsComponent? phys) || (!phys.Awake && !phys.CanCollide));
+        DebugTools.Assert(meta.EntityLifeStage < EntityLifeStage.Terminating || (force && !reparent), "Entity is terminating");
+        DebugTools.Assert(xform.Broadphase == null || !xform.Broadphase.Value.IsValid(), "broadphase is invalid");
+        DebugTools.Assert(!xform.Anchored || _timing.ApplyingState, "anchor is invalid");
+        DebugTools.Assert((meta.Flags & MetaDataFlags.InContainer) != 0x0, "metadata is invalid");
+        DebugTools.Assert(!TryComp(toRemove, out PhysicsComponent? phys) || (!phys.Awake && !phys.CanCollide), "physics is invalid");
 
         // Unset flag (before parent change events are raised).
         meta.Flags &= ~MetaDataFlags.InContainer;
@@ -104,7 +104,7 @@ public abstract partial class SharedContainerSystem
         RaiseLocalEvent(container.Owner, new EntRemovedFromContainerMessage(toRemove, container), true);
         RaiseLocalEvent(toRemove, new EntGotRemovedFromContainerMessage(toRemove, container), false);
 
-        DebugTools.Assert(destination == null || xform.Coordinates.Equals(destination.Value));
+        DebugTools.Assert(destination == null || xform.Coordinates.Equals(destination.Value), "failed to set destination");
 
         Dirty(container.Owner, container.Manager);
         return true;

--- a/Robust.Shared/Utility/DebugTools.cs
+++ b/Robust.Shared/Utility/DebugTools.cs
@@ -220,14 +220,16 @@ namespace Robust.Shared.Utility
         ///     <paramref name="arg" /> is <see langword="null" />.
         /// </summary>
         /// <param name="arg">Condition that must be true.</param>
+        /// <param name="message">Exception message.</param>
         [Conditional("DEBUG")]
         [AssertionMethod]
         public static void AssertNotNull([AssertionCondition(AssertionConditionType.IS_NOT_NULL)]
-            object? arg)
+            object? arg,
+            string? message = null)
         {
             if (arg == null)
             {
-                throw new DebugAssertException();
+                throw new DebugAssertException(message?? "value cannot be null");
             }
         }
 
@@ -236,14 +238,16 @@ namespace Robust.Shared.Utility
         ///     <paramref name="arg" /> is not <see langword="null" />.
         /// </summary>
         /// <param name="arg">Condition that must be true.</param>
+        /// <param name="message">Exception message.</param>
         [Conditional("DEBUG")]
         [AssertionMethod]
         public static void AssertNull([AssertionCondition(AssertionConditionType.IS_NULL)]
-            object? arg)
+            object? arg,
+            string? message = null)
         {
             if (arg != null)
             {
-                throw new DebugAssertException();
+                throw new DebugAssertException(message ?? "value should be null");
             }
         }
 
@@ -290,7 +294,7 @@ namespace Robust.Shared.Utility
         {
         }
 
-        public DebugAssertException(string message) : base(message)
+        public DebugAssertException(string? message) : base(message)
         {
         }
     }


### PR DESCRIPTION
Adds a `|| _timing.ApplyingState` to a debug assert. Also adds descriptive exception messages to all the container asserts, to make bug reports more useful.