### PR TITLE
Fixes two moderate security issues in ImageSharp

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,7 +55,7 @@
     <PackageVersion Include="Serilog" Version="3.1.1" />
     <PackageVersion Include="Serilog.Sinks.Loki" Version="4.0.0-beta3" />
     <PackageVersion Include="SharpZstd.Interop" Version="1.5.2-beta2" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.3" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.4" />
     <PackageVersion Include="SpaceWizards.HttpListener" Version="0.1.1" />
     <PackageVersion Include="SpaceWizards.NFluidsynth" Version="0.1.1" />
     <PackageVersion Include="SpaceWizards.SharpFont" Version="1.0.2" />


### PR DESCRIPTION
Two moderate issues were fixed in ImageSharp 3.1.4:
* https://github.com/SixLabors/ImageSharp/security/advisories/GHSA-g85r-6x2q-45w7
* https://github.com/SixLabors/ImageSharp/security/advisories/GHSA-5x7m-6737-26cr