### PR TITLE
offgrid friction in island solver

### DIFF
--- a/Robust.Shared/Physics/Components/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/Physics/Components/PhysicsComponent.Physics.cs
@@ -222,6 +222,12 @@ public sealed partial class PhysicsComponent : Component
     public float LinearDamping = 0.2f;
 
     /// <summary>
+    ///     This is a set amount that the body's linear velocity is reduced by every tick when the body is off-grid.
+    /// </summary>
+    [DataField, Access(typeof(SharedPhysicsSystem), Friend = AccessPermissions.ReadWriteExecute, Other = AccessPermissions.Read)]
+    public float OffGridLinearDamping = 0.05f;
+
+    /// <summary>
     ///     This is a set amount that the body's angular velocity is reduced every tick.
     ///     Combined with the tile friction.
     /// </summary>

--- a/Robust.Shared/Physics/Components/PhysicsComponent.Physics.cs
+++ b/Robust.Shared/Physics/Components/PhysicsComponent.Physics.cs
@@ -222,12 +222,6 @@ public sealed partial class PhysicsComponent : Component
     public float LinearDamping = 0.2f;
 
     /// <summary>
-    ///     This is a set amount that the body's linear velocity is reduced by every tick when the body is off-grid.
-    /// </summary>
-    [DataField, Access(typeof(SharedPhysicsSystem), Friend = AccessPermissions.ReadWriteExecute, Other = AccessPermissions.Read)]
-    public float OffGridLinearDamping = 0.05f;
-
-    /// <summary>
     ///     This is a set amount that the body's angular velocity is reduced every tick.
     ///     Combined with the tile friction.
     /// </summary>

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
@@ -197,7 +197,7 @@ public abstract partial class SharedPhysicsSystem
     private const int PositionConstraintsPerThread = 16;
 
     [ByRefEvent]
-    public struct GetLinearDampingOverrideEvent
+    public struct GetLinearDampingOverrideEvent(Entity<PhysicsComponent> Entity)
     {
         public float? LinearDampingOverride;
     }
@@ -759,7 +759,7 @@ public abstract partial class SharedPhysicsSystem
 
                 angularVelocity += body.InvI * body.Torque * data.FrameTime;
 
-                var ev = new GetLinearDampingOverrideEvent();
+                var ev = new GetLinearDampingOverrideEvent((body.Owner, body));
                 OnGetLinearDampingOverride?.Invoke(ref ev);
                 var linearDamping = ev.LinearDampingOverride ?? body.LinearDamping;
 

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
@@ -197,7 +197,7 @@ public abstract partial class SharedPhysicsSystem
     private const int PositionConstraintsPerThread = 16;
 
     [ByRefEvent]
-    public struct GetLinearDampingOverrideEvent(Entity<PhysicsComponent> Entity)
+    public struct GetLinearDampingOverrideEvent(Entity<PhysicsComponent, TransformComponent> Entity)
     {
         public float? LinearDampingOverride;
     }
@@ -759,7 +759,7 @@ public abstract partial class SharedPhysicsSystem
 
                 angularVelocity += body.InvI * body.Torque * data.FrameTime;
 
-                var ev = new GetLinearDampingOverrideEvent((body.Owner, body));
+                var ev = new GetLinearDampingOverrideEvent((body.Owner, body, xform));
                 OnGetLinearDampingOverride?.Invoke(ref ev);
                 var linearDamping = ev.LinearDampingOverride ?? body.LinearDamping;
 

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
@@ -5,7 +5,6 @@ using System.Numerics;
 using System.Threading.Tasks;
 using Microsoft.Extensions.ObjectPool;
 using Robust.Shared.GameObjects;
-using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
@@ -196,13 +196,7 @@ public abstract partial class SharedPhysicsSystem
     private const int VelocityConstraintsPerThread = 16;
     private const int PositionConstraintsPerThread = 16;
 
-    [ByRefEvent]
-    public struct GetLinearDampingOverrideEvent(Entity<PhysicsComponent, TransformComponent> Entity)
-    {
-        public float? LinearDampingOverride;
-    }
-
-    public delegate void LinearDampingOverrideHandler(ref GetLinearDampingOverrideEvent ev);
+    public delegate void LinearDampingOverrideHandler(ref Entity<PhysicsComponent, TransformComponent> entity, ref float? linearDampingOverride);
 
     /// <summary>
     ///     Invoked to allow content to override linear damping for objects.
@@ -759,9 +753,10 @@ public abstract partial class SharedPhysicsSystem
 
                 angularVelocity += body.InvI * body.Torque * data.FrameTime;
 
-                var ev = new GetLinearDampingOverrideEvent((body.Owner, body, xform));
-                OnGetLinearDampingOverride?.Invoke(ref ev);
-                var linearDamping = ev.LinearDampingOverride ?? body.LinearDamping;
+                float? linearDampingOverride = null;
+                var entity = new Entity<PhysicsComponent, TransformComponent>(body.Owner, body, xform);
+                OnGetLinearDampingOverride?.Invoke(ref entity, ref linearDampingOverride);
+                var linearDamping = linearDampingOverride ?? body.LinearDamping;
 
                 linearVelocity *= Math.Clamp(1.0f - data.FrameTime * linearDamping, 0.0f, 1.0f);
                 angularVelocity *= Math.Clamp(1.0f - data.FrameTime * body.AngularDamping, 0.0f, 1.0f);


### PR DESCRIPTION
part 2 of https://github.com/space-wizards/space-station-14/pull/29383

adds support for friction to be modified when off grid.
this is primarily to help facilitate different gameplay levels when working off-grid vs while working on a weightless grid.

pretty shrimple pr.