### PR TITLE
Toolshed command help usage

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -40,6 +40,7 @@ END TEMPLATE-->
 ### New features
 
 * Added a `Finished` boolean to `AnimationCompletedEvent` which allows distinguishing if an animation was removed prematurely or completed naturally.
+* Added command usage with types to Toolshed command help.
 
 ### Bugfixes
 

--- a/Robust.Shared/Toolshed/ToolshedCommand.Help.cs
+++ b/Robust.Shared/Toolshed/ToolshedCommand.Help.cs
@@ -39,15 +39,16 @@ public abstract partial class ToolshedCommand
 
         // Usage
         var usage = new StringBuilder();
-        usage.Append("Usage: ");
+        usage.AppendLine();
+        usage.Append(Loc.GetString("command-description-usage"));
         foreach (var (pipedType, parameters) in ReadonlyParameters[subCommand ?? ""])
         {
-            usage.AppendLine();
-
+            usage.Append(Environment.NewLine + "  ");
             // Piped type
             if (pipedType != null)
-                // arguments.Append(Loc.GetString("piped-type-string", ("pipedType", pipedType.ToString())));
-                usage.Append($"(PipedType: {pipedType.ToString()})");
+                // usage.Append($"(PipedType: {pipedType.ToString()})");
+                usage.Append(Loc.GetString("command-description-usage-pipedtype",
+                    ("typeName", GetFriendlyName(pipedType))));
 
             // Name
             usage.Append(Name);

--- a/Robust.Shared/Toolshed/ToolshedCommand.Help.cs
+++ b/Robust.Shared/Toolshed/ToolshedCommand.Help.cs
@@ -41,14 +41,16 @@ public abstract partial class ToolshedCommand
         var usage = new StringBuilder();
         usage.AppendLine();
         usage.Append(Loc.GetString("command-description-usage"));
-        foreach (var (pipedType, parameters) in ReadonlyParameters[subCommand ?? ""])
+        foreach (var (pipedType, parameters) in _readonlyParameters[subCommand ?? ""])
         {
             usage.Append(Environment.NewLine + "  ");
+
             // Piped type
             if (pipedType != null)
-                // usage.Append($"(PipedType: {pipedType.ToString()})");
+            {
                 usage.Append(Loc.GetString("command-description-usage-pipedtype",
                     ("typeName", GetFriendlyName(pipedType))));
+            }
 
             // Name
             usage.Append(Name);
@@ -56,7 +58,6 @@ public abstract partial class ToolshedCommand
             // Parameters
             foreach (var param in parameters)
             {
-                // arguments.Append($"{Loc.GetString($"command-description-{Name}-param-{param.Key}")}({param.Value}");
                 usage.Append($" <{GetFriendlyName(param)}>");
             }
         }

--- a/Robust.Shared/Toolshed/ToolshedCommand.Help.cs
+++ b/Robust.Shared/Toolshed/ToolshedCommand.Help.cs
@@ -39,6 +39,7 @@ public abstract partial class ToolshedCommand
 
         // Usage
         var usage = new StringBuilder();
+        usage.Append("Usage: ");
         foreach (var (pipedType, parameters) in ReadonlyParameters[subCommand ?? ""])
         {
             usage.AppendLine();
@@ -46,10 +47,10 @@ public abstract partial class ToolshedCommand
             // Piped type
             if (pipedType != null)
                 // arguments.Append(Loc.GetString("piped-type-string", ("pipedType", pipedType.ToString())));
-                usage.Append($"PipedType: {pipedType.ToString()}");
+                usage.Append($"(PipedType: {pipedType.ToString()})");
 
             // Name
-            usage.Append($"Usage: {Name}");
+            usage.Append(Name);
 
             // Parameters
             foreach (var param in parameters)

--- a/Robust.Shared/Toolshed/ToolshedCommand.Help.cs
+++ b/Robust.Shared/Toolshed/ToolshedCommand.Help.cs
@@ -37,14 +37,21 @@ public abstract partial class ToolshedCommand
             ? $"{Name}: {Description(null)}"
             : $"{Name}:{subCommand}: {Description(subCommand)}";
 
-        // Arguments
+        // Usage
         var usage = new StringBuilder();
-        usage.Append($"Usage: {Name}");
         foreach (var (pipedType, parameters) in ReadonlyParameters[subCommand ?? ""])
         {
+            usage.AppendLine();
+
+            // Piped type
             if (pipedType != null)
                 // arguments.Append(Loc.GetString("piped-type-string", ("pipedType", pipedType.ToString())));
-                usage.Append($" PipedType: {pipedType.ToString()}");
+                usage.Append($"PipedType: {pipedType.ToString()}");
+
+            // Name
+            usage.Append($"Usage: {Name}");
+
+            // Parameters
             foreach (var param in parameters)
             {
                 // arguments.Append($"{Loc.GetString($"command-description-{Name}-param-{param.Key}")}({param.Value}");
@@ -52,7 +59,7 @@ public abstract partial class ToolshedCommand
             }
         }
 
-        return string.Join("\n", [description, usage]);
+        return description + usage;
     }
 
     /// <inheritdoc/>

--- a/Robust.Shared/Toolshed/ToolshedCommand.cs
+++ b/Robust.Shared/Toolshed/ToolshedCommand.cs
@@ -76,10 +76,10 @@ public abstract partial class ToolshedCommand
     public IEnumerable<string> Subcommands => _implementors.Keys.Where(x => x != "");
 
     /// <summary>
-    /// List of parameters for this command and all sub commands.
-    /// Dictionary((subCommand, pipedType), SortedDictionary(parameterName, parameterType))
+    /// List of parameters for this command and all sub commands. Used for command help usage.
+    /// Dictionary(subCommand, List(pipedType, List(parameterType)))
     /// </summary>
-    public Dictionary<string, List<(Type?, List<Type>)>> ReadonlyParameters;
+    private readonly Dictionary<string, List<(Type?, List<Type>)>> _readonlyParameters;
 
     protected ToolshedCommand()
     {
@@ -110,7 +110,7 @@ public abstract partial class ToolshedCommand
         var impls = GetGenericImplementations();
         Dictionary<(string, Type?), SortedDictionary<string, Type>> parameters = new();
 
-        ReadonlyParameters = new();
+        _readonlyParameters = new();
 
         foreach (var impl in impls)
         {
@@ -149,7 +149,7 @@ public abstract partial class ToolshedCommand
             var key = (subCmd ?? "", pipedType);
             if (parameters.TryAdd(key, myParams))
             {
-                var readParam = ReadonlyParameters.GetOrNew(subCmd ?? "");
+                var readParam = _readonlyParameters.GetOrNew(subCmd ?? "");
                 readParam.Add((pipedType, orderedParams));
                 continue;
             }

--- a/Robust.Shared/Toolshed/ToolshedCommand.cs
+++ b/Robust.Shared/Toolshed/ToolshedCommand.cs
@@ -136,7 +136,6 @@ public abstract partial class ToolshedCommand
                 {
                     if (myParams.TryAdd(param.Name!, param.ParameterType))
                         orderedParams.Add(param.ParameterType);
-                    param.GetModifiedParameterType();
                 }
 
                 if (param.GetCustomAttribute<PipedArgumentAttribute>() is not null)


### PR DESCRIPTION
Adds usage of commands to the Toolshed help text. This includes the type of the piped in arguments and the required arguments.

Using this code for formatting type names: GetFriendlyName https://stackoverflow.com/a/26429045

GetHelp code is run once per player when connecting to the server.

![Toolshed usage help](https://github.com/space-wizards/RobustToolbox/assets/10494922/b4f3c4e5-cf32-4fc3-a067-0ca2e5bb240d)

![Piped help usage](https://github.com/space-wizards/RobustToolbox/assets/10494922/118b7db8-c386-498b-a09c-d1aa096894e8)
