### PR TITLE
Replaces the entity spawn window's bespoke method of object icon rendering with entityprototypeview

### DIFF
--- a/Robust.Client/UserInterface/Controllers/Implementations/EntitySpawningUIController.cs
+++ b/Robust.Client/UserInterface/Controllers/Implementations/EntitySpawningUIController.cs
@@ -327,8 +327,7 @@ public sealed class EntitySpawningUIController : UIController
         if (_window == null || _window.Disposed)
             return;
 
-        var textures = SpriteComponent.GetPrototypeTextures(prototype, _resources).Select(o => o.Default).ToList();
-        var button = _window.InsertEntityButton(prototype, insertFirst, index, textures);
+        var button = _window.InsertEntityButton(prototype, insertFirst, index);
 
         button.ActualButton.OnToggled += OnEntityButtonToggled;
     }

--- a/Robust.Client/UserInterface/CustomControls/EntitySpawnButton.cs
+++ b/Robust.Client/UserInterface/CustomControls/EntitySpawnButton.cs
@@ -12,7 +12,7 @@ public sealed class EntitySpawnButton : Control
     public EntityPrototype Prototype { get; set; } = default!;
     public Button ActualButton { get; private set; }
     public Label EntityLabel { get; private set; }
-    public LayeredTextureRect EntityTextureRects { get; private set; }
+    public EntityPrototypeView EntityTextureRects {get; private set; }
     public int Index { get; set; }
 
     public EntitySpawnButton()
@@ -27,13 +27,12 @@ public sealed class EntitySpawnButton : Control
             Orientation = BoxContainer.LayoutOrientation.Horizontal,
             Children =
             {
-                (EntityTextureRects = new LayeredTextureRect
+                (EntityTextureRects = new EntityPrototypeView
                 {
                     MinSize = new Vector2(32, 32),
                     HorizontalAlignment = HAlignment.Center,
                     VerticalAlignment = VAlignment.Center,
-                    Stretch = TextureRect.StretchMode.KeepAspectCentered,
-                    CanShrink = true
+                    Stretch = SpriteView.StretchMode.Fill
                 }),
                 (EntityLabel = new Label
                 {

--- a/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.xaml.cs
+++ b/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.xaml.cs
@@ -44,7 +44,7 @@ namespace Robust.Client.UserInterface.CustomControls
         }
 
         // Create a spawn button and insert it into the start or end of the list.
-        public EntitySpawnButton InsertEntityButton(EntityPrototype prototype, bool insertFirst, int index, List<Texture> textures)
+        public EntitySpawnButton InsertEntityButton(EntityPrototype prototype, bool insertFirst, int index)
         {
             var button = new EntitySpawnButton
             {
@@ -67,7 +67,7 @@ namespace Robust.Client.UserInterface.CustomControls
             }
 
             var rect = button.EntityTextureRects;
-            rect.Textures = textures;
+            rect.SetPrototype(prototype.ID);
 
             PrototypeList.AddChild(button);
             if (insertFirst)


### PR DESCRIPTION
Title.

Basically, this allows the entity spawn window to have (theoretical) rendering parity with the actual game world

Examples!
![dotnet_wgJV546bQw](https://github.com/space-wizards/RobustToolbox/assets/6356337/fa71d08c-6cb4-427d-9d76-4397c20401bc)

![dotnet_etmjJn1025](https://github.com/space-wizards/RobustToolbox/assets/6356337/abadf135-06b8-4dc2-aa24-e025d2b4c9b7)

Very straight-forward PR, overall