### PR TITLE
Darken SnapgridCenter placement grid

### DIFF
--- a/Robust.Client/Placement/Modes/AlignSnapgridCenter.cs
+++ b/Robust.Client/Placement/Modes/AlignSnapgridCenter.cs
@@ -34,13 +34,13 @@ namespace Robust.Client.Placement.Modes
                 {
                     var from = ScreenToWorld(new Vector2(a, 0));
                     var to = ScreenToWorld(new Vector2(a, viewportSize.Y));
-                    args.WorldHandle.DrawLine(from, to, new Color(0, 0, 1f));
+                    args.WorldHandle.DrawLine(from, to, new Color(0, 0, 0.3f));
                 }
                 for (var a = gridstart.Y; a < viewportSize.Y; a += SnapSize * EyeManager.PixelsPerMeter)
                 {
                     var from = ScreenToWorld(new Vector2(0, a));
                     var to = ScreenToWorld(new Vector2(viewportSize.X, a));
-                    args.WorldHandle.DrawLine(from, to, new Color(0, 0, 1f));
+                    args.WorldHandle.DrawLine(from, to, new Color(0, 0, 0.3f));
                 }
             }
 


### PR DESCRIPTION
In SS14, the bright blue placement grid was making other game objects difficult to see in low lighting conditions.
I simply made it a bit darker.

There has to be a nicer way to make the grid more visible under all conditions, but this was quick to try out.

Before:
![v0010](https://github.com/space-wizards/RobustToolbox/assets/262623/03e69f6a-f5d6-4b72-9cee-983897074646)

PR'ed change:
![v003p0](https://github.com/space-wizards/RobustToolbox/assets/262623/06ddac51-e14d-4c01-98df-bc4595a9047a)
