### PR TITLE
Add cvar to limit nearby command range

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,7 +22,7 @@ Don't change the format without looking at the script!
 
 ### Other
 
-* Added a CVar to limit the maximum range of the nearby command. Defaults to 200.
+*None yet*
 
 ### Internal
 
@@ -47,7 +47,7 @@ END TEMPLATE-->
 
 ### Other
 
-*None yet*
+* Added a toolshed.nearby_limit cvar to limit the maximum range of the nearby command. Defaults to 200.
 
 ### Internal
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,7 +22,7 @@ Don't change the format without looking at the script!
 
 ### Other
 
-*None yet*
+* Added a CVar to limit the maximum range of the nearby command. Defaults to 200.
 
 ### Internal
 

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.InteropServices;
 using System.Threading;
 using Lidgren.Network;
 using Robust.Shared.Audio;
@@ -1759,5 +1758,16 @@ namespace Robust.Shared
         /// </summary>
         public static readonly CVarDef<bool> LaunchContentBundle =
             CVarDef.Create("launch.content_bundle", false, CVar.CLIENTONLY);
+
+        /*
+         * TOOLSHED
+         */
+
+        /// <summary>
+        ///     Whether or not to show a button that opens the guidebook when a player changes their species,
+        ///     explaining the difference between each.
+        /// </summary>
+        public static readonly CVarDef<int> ToolshedNearbyLimit =
+            CVarDef.Create("toolshed.nearby_limit", 200, CVar.SERVER | CVar.REPLICATED);
     }
 }

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1764,8 +1764,8 @@ namespace Robust.Shared
          */
 
         /// <summary>
-        ///     Whether or not to show a button that opens the guidebook when a player changes their species,
-        ///     explaining the difference between each.
+        ///     The max range that can be passed to the nearby toolshed command.
+        ///     Any higher value will cause an exception.
         /// </summary>
         public static readonly CVarDef<int> ToolshedNearbyLimit =
             CVarDef.Create("toolshed.nearby_limit", 200, CVar.SERVER | CVar.REPLICATED);

--- a/Robust.Shared/Toolshed/Commands/Entities/NearbyCommand.cs
+++ b/Robust.Shared/Toolshed/Commands/Entities/NearbyCommand.cs
@@ -1,20 +1,30 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 
 namespace Robust.Shared.Toolshed.Commands.Entities;
 
 [ToolshedCommand]
 internal sealed class NearbyCommand : ToolshedCommand
 {
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+
     private EntityLookupSystem? _lookup;
 
     [CommandImplementation]
     public IEnumerable<EntityUid> Nearby(
+            [CommandInvocationContext] IInvocationContext ctx,
             [PipedArgument] IEnumerable<EntityUid> input,
             [CommandArgument] float range
         )
     {
+        var limit = _cfg.GetCVar(CVars.ToolshedNearbyLimit);
+        if (range > limit)
+            throw new ArgumentException($"Tried to query too many entities with nearby ({range})! Limit: {limit}");
+
         _lookup ??= GetSys<EntityLookupSystem>();
         return input.SelectMany(x => _lookup.GetEntitiesInRange(x, range)).Distinct();
     }

--- a/Robust.Shared/Toolshed/Commands/Entities/NearbyCommand.cs
+++ b/Robust.Shared/Toolshed/Commands/Entities/NearbyCommand.cs
@@ -23,7 +23,7 @@ internal sealed class NearbyCommand : ToolshedCommand
     {
         var limit = _cfg.GetCVar(CVars.ToolshedNearbyLimit);
         if (range > limit)
-            throw new ArgumentException($"Tried to query too many entities with nearby ({range})! Limit: {limit}");
+            throw new ArgumentException($"Tried to query too many entities with nearby ({range})! Limit: {limit}. Change the {CVars.ToolshedNearbyLimit.Name} cvar to increase this at your own risk.");
 
         _lookup ??= GetSys<EntityLookupSystem>();
         return input.SelectMany(x => _lookup.GetEntitiesInRange(x, range)).Distinct();


### PR DESCRIPTION
Admins don't necessarily know the implications of a very large range. It caused a server crash in RMC14.
Default 200.
Also I can't do this from content so here it is.