### PR TITLE
Whitelist `IPEndPoint` for sandbox

### DIFF
--- a/Robust.Shared/ContentPack/Sandbox.yml
+++ b/Robust.Shared/ContentPack/Sandbox.yml
@@ -438,6 +438,7 @@ Types:
   System.Net:
     DnsEndPoint: { }
     IPAddress: { All: True }
+    IPEndPoint: { All: True }
     HttpStatusCode: { } # Enum
   System.Net.Sockets:
     AddressFamily: { }


### PR DESCRIPTION
Currently accessing `ServerChannel.RemoteEndPoint` is a sandbox violation. We need it not to be for OpenDream https://github.com/OpenDreamProject/OpenDream/pull/1869