### PR TITLE
Adds event for mass and angular inertia changes.

### DIFF
--- a/Robust.Shared/Physics/Events/MassChangedEvent.cs
+++ b/Robust.Shared/Physics/Events/MassChangedEvent.cs
@@ -8,24 +8,21 @@ namespace Robust.Shared.Physics.Events;
 /// By-ref directed event raised when the mass or angular inertia or center of mass of a physics body changes.
 /// </summary>
 /// <param name="Entity">The physics body that changed.</param>
-/// <param name="NewMass">The new mass of the physics body.</param>
-/// <param name="NewInertia">The new angular inertia of the physics body.</param>
-/// <param name="NewCenter">The new (local) center of mass of the physics body.</param>
 /// <param name="OldMass">The old mass of the physics body.</param>
 /// <param name="OldInertia">The old angular inertia of the physics body.</param>
 /// <param name="OldCenter">The old (local) center of mass of the physics body.</param>
 [ByRefEvent]
 public readonly record struct MassDataChangedEvent(
     Entity<PhysicsComponent, FixturesComponent> Entity,
-    float NewMass,
-    float NewInertia,
-    Vector2 NewCenter,
     float OldMass,
     float OldInertia,
     Vector2 OldCenter
 )
 {
-    public readonly bool MassChanged = NewMass != OldMass;
-    public readonly bool InertiaChanged = NewInertia != OldInertia;
-    public readonly bool CenterChanged = NewCenter != OldCenter;
+    public float NewMass => Entity.Comp._mass;
+    public float NewInertia => Entity.Comp._inertia;
+    public float NewCenter => Entity.Comp._localCenter;
+    public bool MassChanged => NewMass != OldMass;
+    public bool InertiaChanged => NewInertia != OldInertia;
+    public bool CenterChanged => NewCenter != OldCenter;
 }

--- a/Robust.Shared/Physics/Events/MassChangedEvent.cs
+++ b/Robust.Shared/Physics/Events/MassChangedEvent.cs
@@ -1,0 +1,31 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.Physics.Components;
+using System.Numerics;
+
+namespace Robust.Shared.Physics.Events;
+
+/// <summary>
+/// By-ref directed event raised when the mass or angular inertia or center of mass of a physics body changes.
+/// </summary>
+/// <param name="Entity">The physics body that changed.</param>
+/// <param name="NewMass">The new mass of the physics body.</param>
+/// <param name="NewInertia">The new angular inertia of the physics body.</param>
+/// <param name="NewCenter">The new (local) center of mass of the physics body.</param>
+/// <param name="OldMass">The old mass of the physics body.</param>
+/// <param name="OldInertia">The old angular inertia of the physics body.</param>
+/// <param name="OldCenter">The old (local) center of mass of the physics body.</param>
+[ByRefEvent]
+public readonly record struct MassDataChangedEvent(
+    Entity<PhysicsComponent, FixturesComponent> Entity,
+    float NewMass,
+    float NewInertia,
+    Vector2 NewCenter,
+    float OldMass,
+    float OldInertia,
+    Vector2 OldCenter
+)
+{
+    public readonly bool MassChanged = NewMass != OldMass;
+    public readonly bool InertiaChanged = NewInertia != OldInertia;
+    public readonly bool CenterChanged = NewCenter != OldCenter;
+}

--- a/Robust.Shared/Physics/Events/MassChangedEvent.cs
+++ b/Robust.Shared/Physics/Events/MassChangedEvent.cs
@@ -21,7 +21,7 @@ public readonly record struct MassDataChangedEvent(
 {
     public float NewMass => Entity.Comp1._mass;
     public float NewInertia => Entity.Comp1._inertia;
-    public float NewCenter => Entity.Comp1._localCenter;
+    public Vector2 NewCenter => Entity.Comp1._localCenter;
     public bool MassChanged => NewMass != OldMass;
     public bool InertiaChanged => NewInertia != OldInertia;
     public bool CenterChanged => NewCenter != OldCenter;

--- a/Robust.Shared/Physics/Events/MassChangedEvent.cs
+++ b/Robust.Shared/Physics/Events/MassChangedEvent.cs
@@ -19,9 +19,9 @@ public readonly record struct MassDataChangedEvent(
     Vector2 OldCenter
 )
 {
-    public float NewMass => Entity.Comp._mass;
-    public float NewInertia => Entity.Comp._inertia;
-    public float NewCenter => Entity.Comp._localCenter;
+    public float NewMass => Entity.Comp1._mass;
+    public float NewInertia => Entity.Comp1._inertia;
+    public float NewCenter => Entity.Comp1._localCenter;
     public bool MassChanged => NewMass != OldMass;
     public bool InertiaChanged => NewInertia != OldInertia;
     public bool CenterChanged => NewCenter != OldCenter;

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
@@ -256,6 +256,9 @@ public partial class SharedPhysicsSystem
         if (!_fixturesQuery.Resolve(uid, ref manager))
             return;
 
+        var oldMass = body._mass;
+        var oldInertia = body._inertia;
+
         body._mass = 0.0f;
         body._invMass = 0.0f;
         body._inertia = 0.0f;
@@ -314,6 +317,12 @@ public partial class SharedPhysicsSystem
         // Update center of mass velocity.
         body.LinearVelocity += Vector2Helpers.Cross(body.AngularVelocity, localCenter - oldCenter);
         Dirty(uid, body);
+
+        if (body._mass == oldMass && body._inertia == oldInertia && oldCenter == localCenter)
+            return;
+
+        var ev = new MassDataChangedEvent((uid, body, manager), body._mass, body._inertia, localCenter, oldMass, oldInertia, oldCenter);
+        RaiseLocalEvent(uid, ref ev);
     }
 
     public bool SetAngularVelocity(EntityUid uid, float value, bool dirty = true, FixturesComponent? manager = null, PhysicsComponent? body = null)

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
@@ -321,7 +321,7 @@ public partial class SharedPhysicsSystem
         if (body._mass == oldMass && body._inertia == oldInertia && oldCenter == localCenter)
             return;
 
-        var ev = new MassDataChangedEvent((uid, body, manager), body._mass, body._inertia, localCenter, oldMass, oldInertia, oldCenter);
+        var ev = new MassDataChangedEvent((uid, body, manager), oldMass, oldInertia, oldCenter);
         RaiseLocalEvent(uid, ref ev);
     }
 


### PR DESCRIPTION
Adds `MassDataChangedEvent` which is raised when the mass or angular inertia of an entity changes.
This allows other systems to respond to such changes.