### PR TITLE
Add AppearanceSystem Data dictionaries and RemoveData

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
@@ -29,6 +29,11 @@ public abstract class SharedAppearanceSystem : EntitySystem
     {
     }
 
+    private bool CheckIfApplyingState(AppearanceComponent component)
+    {
+        return _timing.ApplyingState && component.NetSyncEnabled; // TODO consider removing this and avoiding the component resolve altogether.
+    }
+
     public void SetData(EntityUid uid, Enum key, object value, AppearanceComponent? component = null)
     {
         if (!Resolve(uid, ref component, false))
@@ -36,8 +41,7 @@ public abstract class SharedAppearanceSystem : EntitySystem
 
         // If appearance data is changing due to server state application, the server's comp state is getting applied
         // anyways, so we can skip this.
-        if (_timing.ApplyingState
-            && component.NetSyncEnabled) // TODO consider removing this and avoiding the component resolve altogether.
+        if (CheckIfApplyingState(component))
             return;
 
         if (component.AppearanceData.TryGetValue(key, out var existing) && existing.Equals(value))
@@ -56,10 +60,7 @@ public abstract class SharedAppearanceSystem : EntitySystem
         if (!Resolve(uid, ref component, false))
             return;
 
-        // If appearance data is changing due to server state application, the server's comp state is getting applied
-        // anyways, so we can skip this.
-        if (_timing.ApplyingState
-            && component.NetSyncEnabled) // TODO consider removing this and avoiding the component resolve altogether.
+        if (CheckIfApplyingState(component))
             return;
 
         component.AppearanceData.Remove(key);


### PR DESCRIPTION
## What?

This PR allows AppearanceSystem to send and store dictionaries in its Data property, using `SerializationManager.CopyTo` as an alternative to ICloneable.*

It also adds `SharedAppearanceSystem.RemoveData`, as there is currently no way to remove a Data entry (only set the entry value to empty).

## Why?

This change makes AppearanceSystem Data more flexible; since Data keys must be enums it becomes difficult to send dynamic data for systems that don't want to have predefined enums (e.g. ClothingSystem). Dictionary support solves this without bystepping the scoping as the dictionary itself must still be keyed to an enum.

There's also no method to remove a Data entry at the moment and instead forces systems to rely on setting an empty value for a key it no longer wants to interact with, when a more elegant solution would be to simply remove the entry. 

- - -
*Note that this also comments out a Debug.Assert for SetData, as there appears to currently not be any way to check if an object can be parsed via CopyTo without actually copying the object. 