### PR TITLE
Don't overide the robust injectors and always use the build configuration

### DIFF
--- a/MSBuild/XamlIL.targets
+++ b/MSBuild/XamlIL.targets
@@ -22,8 +22,6 @@
   <!-- XamlIL does not make use of special Robust configurations like DebugOpt. Convert these down. -->
   <PropertyGroup>
     <RobustInjectorsConfiguration>$(Configuration)</RobustInjectorsConfiguration>
-    <RobustInjectorsConfiguration Condition="'$(Configuration)' == 'DebugOpt'">Debug</RobustInjectorsConfiguration>
-    <RobustInjectorsConfiguration Condition="'$(Configuration)' == 'Tools'">Release</RobustInjectorsConfiguration>
     <RobustInjectorsConfiguration Condition="'$(UseArtifactsOutput)' == 'true' And '$(RuntimeIdentifier)' != ''">$(RobustInjectorsConfiguration)_$(RuntimeIdentifier)</RobustInjectorsConfiguration>
     <RobustInjectorsConfiguration Condition="'$(UseArtifactsOutput)' == 'true'">$(RobustInjectorsConfiguration.ToLower())</RobustInjectorsConfiguration>
     <CompileRobustXamlTaskAssemblyFile Condition="'$(UseArtifactsOutput)' != 'true'">$(MSBuildThisFileDirectory)\..\Robust.Client.Injectors\bin\$(RobustInjectorsConfiguration)\netstandard2.0\Robust.Client.Injectors.dll</CompileRobustXamlTaskAssemblyFile>


### PR DESCRIPTION
Space station 14 has a "build client tools" batch file, as it turned out it error out instantly if you had never compiled release due to it overiding msbuild to forcibly use the release version. This pr removes that feature and just compiles it again for the target config.