### PR TITLE
Add styleclass to OptionsButton popup background widget

### DIFF
--- a/Robust.Client/UserInterface/Controls/OptionButton.cs
+++ b/Robust.Client/UserInterface/Controls/OptionButton.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using Robust.Client.Graphics;
@@ -14,6 +14,7 @@ namespace Robust.Client.UserInterface.Controls
         public const string StyleClassOptionButton = "optionButton";
         public const string StyleClassPopup = "optionButtonPopup";
         public const string StyleClassOptionTriangle = "optionTriangle";
+        public const string StyleClassOptionsBackground = "optionsBackground";
         public readonly ScrollContainer OptionsScroll;
 
         private readonly List<ButtonData> _buttonData = new();
@@ -75,7 +76,12 @@ namespace Robust.Client.UserInterface.Controls
 
             _popup = new Popup()
             {
-                Children = { new PanelContainer(), OptionsScroll },
+                Children = {
+                    new PanelContainer {
+                        StyleClasses = { StyleClassOptionsBackground }
+                    },
+                    OptionsScroll
+                },
                 StyleClasses = { StyleClassPopup }
             };
             _popup.OnPopupHide += OnPopupHide;

--- a/Robust.Client/UserInterface/Controls/OptionButton.cs
+++ b/Robust.Client/UserInterface/Controls/OptionButton.cs
@@ -14,7 +14,7 @@ namespace Robust.Client.UserInterface.Controls
         public const string StyleClassOptionButton = "optionButton";
         public const string StyleClassPopup = "optionButtonPopup";
         public const string StyleClassOptionTriangle = "optionTriangle";
-        public const string StyleClassOptionsBackground = "optionsBackground";
+        public const string StyleClassOptionsBackground = "optionButtonBackground";
         public readonly ScrollContainer OptionsScroll;
 
         private readonly List<ButtonData> _buttonData = new();


### PR DESCRIPTION
Allows customization of the background used by the OptionButton popup items, instead of always rendering transparent. I suspect that it wasn't always transparent, because the code was _almost_ setup to have a background, but probably bitrot away. 

End result is essentially the same as https://github.com/space-wizards/RobustToolbox/pull/5201, but this change is significantly smaller. Has no effect by default; will make a content PR to supply a reasonable default.