### PR TITLE
Update PlayerManager.cs to not use Component.Owner

### DIFF
--- a/Robust.Client/Player/PlayerManager.cs
+++ b/Robust.Client/Player/PlayerManager.cs
@@ -167,7 +167,6 @@ namespace Robust.Client.Player
                 if (_client.RunLevel != ClientRunLevel.SinglePlayerGame)
                     Sawmill.Warning($"Attaching local player to an entity {EntManager.ToPrettyString(uid)} without an eye. This eye will not be netsynced and may cause issues.");
                 var eye = (EyeComponent) Factory.GetComponent(typeof(EyeComponent));
-                eye.Owner = uid.Value;
                 eye.NetSyncEnabled = false;
                 EntManager.AddComponent(uid.Value, eye);
             }


### PR DESCRIPTION
The SharedEyeSystem seems to properly make use of the `Entity<T>`.Owner EntityUid elsewhere, setting the Owner of the component here doesn't seem to be necessary at all