### PR TITLE
Update GridSplit_Tests.cs to not use Component.Owner

### DIFF
--- a/Robust.UnitTesting/Shared/Map/GridSplit_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/GridSplit_Tests.cs
@@ -143,6 +143,7 @@ public sealed class GridSplit_Tests
         var entManager = sim.Resolve<IEntityManager>();
         var mapManager = sim.Resolve<IMapManager>();
         var mapSystem = sim.Resolve<IEntityManager>().System<SharedMapSystem>();
+        var transformSystem = sim.Resolve<IEntityManager>().System<SharedTransformSystem>();
         var mapId = sim.CreateMap().MapId;
         var gridEnt = mapManager.CreateGridEntity(mapId);
         var grid = gridEnt.Comp;
@@ -158,13 +159,14 @@ public sealed class GridSplit_Tests
         var dummyXform = entManager.GetComponent<TransformComponent>(dummy);
         var anchored = entManager.SpawnEntity(null, new EntityCoordinates(gridEnt, new Vector2(3.5f, 0.5f)));
         var anchoredXform = entManager.GetComponent<TransformComponent>(anchored);
-        anchoredXform.Anchored = true;
+
+        transformSystem.AnchorEntity((anchored, anchoredXform), gridEnt);
         Assert.That(anchoredXform.Anchored);
 
         mapSystem.SetTile(gridEnt, new Vector2i(2, 0), Tile.Empty);
         Assert.That(mapManager.GetAllGrids(mapId).Count(), Is.EqualTo(2));
 
-        var newGrid = mapManager.GetAllMapGrids(mapId).First(x => x != grid);
+        var newGrid = mapManager.GetAllGrids(mapId).First(x => x.Comp != grid);
         var newGridXform = entManager.GetComponent<TransformComponent>(newGrid.Owner);
 
         Assert.Multiple(() =>


### PR DESCRIPTION
- xform.Anchored is obsolete, replaced with TransformSystem's AnchorEntity function
- Usage of `IEnumerable<MapGridComponent> GetAllMapGrids(MapId mapId)` replaced with `IEnumerable<Entity<MapGridComponent>> GetAllGrids(MapId mapId)`, all future references to .Owner are then properly taken from the `Entity<MapGridComponent>` instead of the `<MapGridComponent>` and don't need changing

![image](https://github.com/user-attachments/assets/c2f9b744-5767-4df2-8073-7386dffd8638)