### PR TITLE
Update MapGrid_Tests to use MapSystem functions

### DIFF
--- a/Robust.UnitTesting/Shared/Map/MapGrid_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/MapGrid_Tests.cs
@@ -111,10 +111,13 @@ namespace Robust.UnitTesting.Shared.Map
         {
             var sim = SimulationFactory();
             var mapMan = sim.Resolve<IMapManager>();
+            var mapSystem = sim.Resolve<IEntityManager>().System<SharedMapSystem>();
             var mapId = sim.CreateMap().MapId;
-            var grid = mapMan.CreateGrid(mapId, 8);
+            var gridOptions = new GridCreateOptions();
+            gridOptions.ChunkSize = 8;
+            var grid = mapMan.CreateGridEntity(mapId, gridOptions);
 
-            var result = grid.GridTileToChunkIndices(new Vector2i(-9, -1));
+            var result = mapSystem.GridTileToChunkIndices(grid.Comp, new Vector2i(-9, -1));
 
             Assert.That(result, Is.EqualTo(new Vector2i(-2, -1)));
         }

--- a/Robust.UnitTesting/Shared/Map/MapGrid_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/MapGrid_Tests.cs
@@ -31,15 +31,17 @@ namespace Robust.UnitTesting.Shared.Map
         {
             var sim = SimulationFactory();
             var mapMan = sim.Resolve<IMapManager>();
+            var mapSystem = sim.Resolve<IEntityManager>().System<SharedMapSystem>();
             var mapId = sim.CreateMap().MapId;
-            var grid = mapMan.CreateGrid(mapId, 8);
+            var gridOptions = new GridCreateOptions();
+            gridOptions.ChunkSize = 8;
+            var grid = mapMan.CreateGridEntity(mapId, gridOptions);
 
-            grid.SetTile(new Vector2i(-9, -1), new Tile(1, (TileRenderFlag)1, 1));
+            mapSystem.SetTile(grid, new Vector2i(-9, -1), new Tile(1, (TileRenderFlag)1, 1));
+            var result = mapSystem.GetTileRef(grid.Owner, grid.Comp, new Vector2i(-9, -1));
 
-            var result = grid.GetTileRef(new Vector2i(-9, -1));
-
-            Assert.That(grid.ChunkCount, Is.EqualTo(1));
-            Assert.That(grid.GetMapChunks().Keys.ToList()[0], Is.EqualTo(new Vector2i(-2, -1)));
+            Assert.That(grid.Comp.ChunkCount, Is.EqualTo(1));
+            Assert.That(mapSystem.GetMapChunks(grid.Owner, grid.Comp).Keys.ToList()[0], Is.EqualTo(new Vector2i(-2, -1)));
             Assert.That(result, Is.EqualTo(new TileRef(grid.Owner, new Vector2i(-9,-1), new Tile(1, (TileRenderFlag)1, 1))));
         }
 
@@ -52,15 +54,18 @@ namespace Robust.UnitTesting.Shared.Map
             var sim = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
             var mapMan = sim.Resolve<IMapManager>();
+            var mapSystem = sim.Resolve<IEntityManager>().System<SharedMapSystem>();
+            var transformSystem = sim.Resolve<IEntityManager>().System<SharedTransformSystem>();
             var mapId = sim.CreateMap().MapId;
-            var grid = mapMan.CreateGrid(mapId, 8);
-            var gridXform = entMan.GetComponent<TransformComponent>(grid.Owner);
-            gridXform.WorldPosition = new Vector2(3, 5);
+            var gridOptions = new GridCreateOptions();
+            gridOptions.ChunkSize = 8;
+            var grid = mapMan.CreateGridEntity(mapId, gridOptions);
+            transformSystem.SetWorldPosition(grid, new Vector2(3, 5));
 
-            grid.SetTile(new Vector2i(-1, -2), new Tile(1));
-            grid.SetTile(new Vector2i(1, 2), new Tile(1));
+            mapSystem.SetTile(grid, new Vector2i(-1, -2), new Tile(1));
+            mapSystem.SetTile(grid, new Vector2i(1, 2), new Tile(1));
 
-            var bounds = gridXform.WorldMatrix.TransformBox(grid.LocalAABB);
+            var bounds = transformSystem.GetWorldMatrix(grid).TransformBox(grid.Comp.LocalAABB);
 
             // this is world, so add the grid world pos
             Assert.That(bounds.Bottom, Is.EqualTo(-2+5));
@@ -78,18 +83,21 @@ namespace Robust.UnitTesting.Shared.Map
             var sim = SimulationFactory();
             var entMan = sim.Resolve<IEntityManager>();
             var mapMan = sim.Resolve<IMapManager>();
+            var mapSystem = sim.Resolve<IEntityManager>().System<SharedMapSystem>();
+            var transformSystem = sim.Resolve<IEntityManager>().System<SharedTransformSystem>();
             var mapId = sim.CreateMap().MapId;
-            var grid = mapMan.CreateGrid(mapId, 8);
-            var gridXform = entMan.GetComponent<TransformComponent>(grid.Owner);
+            var gridOptions = new GridCreateOptions();
+            gridOptions.ChunkSize = 8;
+            var grid = mapMan.CreateGridEntity(mapId, gridOptions);
 
-            gridXform.WorldPosition = new Vector2(3, 5);
+            transformSystem.SetWorldPosition(grid, new Vector2(3, 5));
 
-            grid.SetTile(new Vector2i(-1, -2), new Tile(1));
-            grid.SetTile(new Vector2i(1, 2), new Tile(1));
+            mapSystem.SetTile(grid, new Vector2i(-1, -2), new Tile(1));
+            mapSystem.SetTile(grid, new Vector2i(1, 2), new Tile(1));
 
-            grid.SetTile(new Vector2i(1, 2), Tile.Empty);
+            mapSystem.SetTile(grid, new Vector2i(1, 2), Tile.Empty);
 
-            var bounds = gridXform.WorldMatrix.TransformBox(grid.LocalAABB);
+            var bounds = transformSystem.GetWorldMatrix(grid).TransformBox(grid.Comp.LocalAABB);
 
             // this is world, so add the grid world pos
             Assert.That(bounds.Bottom, Is.EqualTo(-2+5));
@@ -119,10 +127,13 @@ namespace Robust.UnitTesting.Shared.Map
         {
             var sim = SimulationFactory();
             var mapMan = sim.Resolve<IMapManager>();
+            var mapSystem = sim.Resolve<IEntityManager>().System<SharedMapSystem>();
             var mapId = sim.CreateMap().MapId;
-            var grid = mapMan.CreateGrid(mapId, 8);
+            var gridOptions = new GridCreateOptions();
+            gridOptions.ChunkSize = 8;
+            var grid = mapMan.CreateGridEntity(mapId, gridOptions);
 
-            var result = grid.GridTileToLocal(new Vector2i(0, 0)).Position;
+            var result = mapSystem.GridTileToLocal(grid.Owner, grid.Comp, new Vector2i(0, 0)).Position;
 
             Assert.That(result.X, Is.EqualTo(0.5f));
             Assert.That(result.Y, Is.EqualTo(0.5f));
@@ -133,14 +144,17 @@ namespace Robust.UnitTesting.Shared.Map
         {
             var sim = SimulationFactory();
             var mapMan = sim.Resolve<IMapManager>();
+            var mapSystem = sim.Resolve<IEntityManager>().System<SharedMapSystem>();
             var mapId = sim.CreateMap().MapId;
-            var grid = mapMan.CreateGrid(mapId, 8);
+            var gridOptions = new GridCreateOptions();
+            gridOptions.ChunkSize = 8;
+            var grid = mapMan.CreateGridEntity(mapId, gridOptions);
 
-            var foundTile = grid.TryGetTileRef(new Vector2i(-9, -1), out var tileRef);
-
+            var foundTile = mapSystem.TryGetTileRef(grid.Owner, grid.Comp, new Vector2i(-9, -1), out var tileRef)
+;
             Assert.That(foundTile, Is.False);
             Assert.That(tileRef, Is.EqualTo(new TileRef()));
-            Assert.That(grid.ChunkCount, Is.EqualTo(0));
+            Assert.That(grid.Comp.ChunkCount, Is.EqualTo(0));
         }
 
         [Test]
@@ -148,16 +162,19 @@ namespace Robust.UnitTesting.Shared.Map
         {
             var sim = SimulationFactory();
             var mapMan = sim.Resolve<IMapManager>();
+            var mapSystem = sim.Resolve<IEntityManager>().System<SharedMapSystem>();
             var mapId = sim.CreateMap().MapId;
-            var grid = mapMan.CreateGrid(mapId, 8);
+            var gridOptions = new GridCreateOptions();
+            gridOptions.ChunkSize = 8;
+            var grid = mapMan.CreateGridEntity(mapId, gridOptions);
 
-            grid.SetTile(new Vector2i(-9, -1), new Tile(1, (TileRenderFlag)1, 1));
+            mapSystem.SetTile(grid, new Vector2i(-9, -1), new Tile(1, (TileRenderFlag)1, 1));
 
-            var foundTile = grid.TryGetTileRef(new Vector2i(-9, -1), out var tileRef);
+            var foundTile = mapSystem.TryGetTileRef(grid.Owner, grid.Comp, new Vector2i(-9, -1), out var tileRef);
 
             Assert.That(foundTile, Is.True);
-            Assert.That(grid.ChunkCount, Is.EqualTo(1));
-            Assert.That(grid.GetMapChunks().Keys.ToList()[0], Is.EqualTo(new Vector2i(-2, -1)));
+            Assert.That(grid.Comp.ChunkCount, Is.EqualTo(1));
+            Assert.That(mapSystem.GetMapChunks(grid.Owner, grid.Comp).Keys.ToList()[0], Is.EqualTo(new Vector2i(-2, -1)));
             Assert.That(tileRef, Is.EqualTo(new TileRef(grid.Owner, new Vector2i(-9, -1), new Tile(1, (TileRenderFlag)1, 1))));
         }
 
@@ -166,12 +183,15 @@ namespace Robust.UnitTesting.Shared.Map
         {
             var sim = SimulationFactory();
             var mapMan = sim.Resolve<IMapManager>();
+            var mapSystem = sim.Resolve<IEntityManager>().System<SharedMapSystem>();
             var mapId = sim.CreateMap().MapId;
-            var grid = mapMan.CreateGrid(mapId, 8);
+            var gridOptions = new GridCreateOptions();
+            gridOptions.ChunkSize = 8;
+            var grid = mapMan.CreateGridEntity(mapId, gridOptions);
 
-            grid.SetTile(new Vector2i(19, 23), new Tile(1));
+            mapSystem.SetTile(grid, new Vector2i(19, 23), new Tile(1));
 
-            var result = grid.CollidesWithGrid(new Vector2i(19, 23));
+            var result = mapSystem.CollidesWithGrid(grid.Owner, grid.Comp, new Vector2i(19, 23));
 
             Assert.That(result, Is.True);
         }
@@ -181,12 +201,15 @@ namespace Robust.UnitTesting.Shared.Map
         {
             var sim = SimulationFactory();
             var mapMan = sim.Resolve<IMapManager>();
+            var mapSystem = sim.Resolve<IEntityManager>().System<SharedMapSystem>();
             var mapId = sim.CreateMap().MapId;
-            var grid = mapMan.CreateGrid(mapId, 8);
+            var gridOptions = new GridCreateOptions();
+            gridOptions.ChunkSize = 8;
+            var grid = mapMan.CreateGridEntity(mapId, gridOptions);
 
-            grid.SetTile(new Vector2i(19, 23), new Tile(1));
+            mapSystem.SetTile(grid, new Vector2i(19, 23), new Tile(1));
 
-            var result = grid.CollidesWithGrid(new Vector2i(19, 24));
+            var result = mapSystem.CollidesWithGrid(grid.Owner, grid.Comp, new Vector2i(19, 24));
 
             Assert.That(result, Is.False);
         }

--- a/Robust.UnitTesting/Shared/Map/MapGrid_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/MapGrid_Tests.cs
@@ -52,7 +52,6 @@ namespace Robust.UnitTesting.Shared.Map
         public void BoundsExpansion()
         {
             var sim = SimulationFactory();
-            var entMan = sim.Resolve<IEntityManager>();
             var mapMan = sim.Resolve<IMapManager>();
             var mapSystem = sim.Resolve<IEntityManager>().System<SharedMapSystem>();
             var transformSystem = sim.Resolve<IEntityManager>().System<SharedTransformSystem>();
@@ -81,7 +80,6 @@ namespace Robust.UnitTesting.Shared.Map
         public void BoundsContract()
         {
             var sim = SimulationFactory();
-            var entMan = sim.Resolve<IEntityManager>();
             var mapMan = sim.Resolve<IMapManager>();
             var mapSystem = sim.Resolve<IEntityManager>().System<SharedMapSystem>();
             var transformSystem = sim.Resolve<IEntityManager>().System<SharedTransformSystem>();


### PR DESCRIPTION
- Add `mapSystem` or `transformSystem` to tests depending on what's required
- Swap `mapMan.CreateGrid()` for `mapMan.CreateGridEntity()` which gives us the `Entity<T>` version of the component, to get the same ChunkSize of eight I needed to create a GridOptions object.
- Swap any functions usage for the non-obsoleted MapSystem versions with the same information

![image](https://github.com/user-attachments/assets/b0f53425-f4f1-444b-ae97-a0bff9d14725)
