### PR TITLE
Add method to TrimEnd FormattedMessage

### DIFF
--- a/Robust.Shared/Utility/FormattedMessage.cs
+++ b/Robust.Shared/Utility/FormattedMessage.cs
@@ -236,6 +236,40 @@ public sealed partial class FormattedMessage : IReadOnlyList<MarkupNode>
     }
 
     /// <summary>
+    /// Removes excess whitespace at the end of markup.
+    /// </summary>
+    public void TrimEnd()
+    {
+        for (var i = _nodes.Count - 1; i >= 0; i--)
+        {
+            var node = _nodes[i];
+            var markup = node.Value;
+
+            if (markup.StringValue == null)
+                break;
+
+            var value = markup.StringValue.Trim();
+
+            // If we stripped all text then remove the node and continue.
+            if (string.IsNullOrEmpty(value))
+            {
+                _nodes.RemoveAt(i);
+                continue;
+            }
+
+            // Only trimmed some of it so update node and stop.
+            if (value != node.Value.StringValue)
+            {
+                _nodes.RemoveAt(i);
+                markup = markup with { StringValue = value };
+                _nodes.Add(new MarkupNode(value, markup, node.Attributes));
+            }
+
+            break;
+        }
+    }
+
+    /// <summary>
     /// Returns an enumerator that enumerates every rune for each text node contained in this formatted text instance.
     /// </summary>
     public FormattedMessageRuneEnumerator EnumerateRunes()

--- a/Robust.UnitTesting/Shared/Utility/FormattedMessage_Test.cs
+++ b/Robust.UnitTesting/Shared/Utility/FormattedMessage_Test.cs
@@ -10,6 +10,30 @@ namespace Robust.UnitTesting.Shared.Utility
     [TestOf(typeof(FormattedMessage))]
     public sealed class FormattedMessage_Test
     {
+        private static (FormattedMessage Message, bool Trimmed)[] _trimMessages = new[]
+        {
+            (FormattedMessage.FromUnformatted("weh"), false),
+            (FormattedMessage.FromUnformatted("weh "), true),
+            (FormattedMessage.Empty, false),
+            (FormattedMessage.FromUnformatted("weh\n"), true),
+        };
+
+        [Test, TestCaseSource(nameof(_trimMessages))]
+        public static void TestTrimEnd((FormattedMessage message, bool shouldTrim) test)
+        {
+            var copy = FormattedMessage.FromUnformatted(test.message.ToString());
+            copy.TrimEnd();
+
+            if (test.shouldTrim)
+            {
+                Assert.That(copy.ToString(), Is.Not.EqualTo(test.message.ToString()));
+            }
+            else
+            {
+                Assert.That(copy.ToString(), Is.EqualTo(test.message.ToString()));
+            }
+        }
+
         [Test]
         public static void TestParseMarkup()
         {


### PR DESCRIPTION
Sometimes you may want to deliberately add a newline at the end so better to just give this control instead of implicitly do it.