### PR TITLE
Fixed data race in ParallelTracker

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Fix multithreading bug in ParallelTracker that caused the game to crash randomly.
 
 ### Other
 

--- a/Robust.Shared/Threading/ParallelManager.cs
+++ b/Robust.Shared/Threading/ParallelManager.cs
@@ -290,9 +290,9 @@ internal sealed class ParallelManager : IParallelManagerInternal
         /// </summary>
         public void Set()
         {
-            Interlocked.Decrement(ref PendingTasks);
-
-            if (PendingTasks <= 0)
+            // We should atomically get new value of PendingTasks
+            // as the result of Decrement call and use it to prevent data race.
+            if (Interlocked.Decrement(ref PendingTasks) <= 0)
                 Event.Set();
         }
     }


### PR DESCRIPTION
Judging by the tests I have done, this should fix the [random client crash](https://github.com/space-wizards/RobustToolbox/issues/5309). At least it won't work any worse anyway.
Race may occur in changed piece of code because, for example, 2 last threads will do `Decrement()`, first one then enter if statement and encounder 0 of PendingTasks, setting event. This will release control on the calling side of parallel manager and new parallel job can be queued. Meanwhile, one last thread may still be right after if statement and only now decide to continue execution, setting event which may alredy be used for other parallel job.