### PR TITLE
Add analyzer/fixer for replacing ProtoId<EntityPrototype> with EntProtoId

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.NUnit" Version="1.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.8.0" />

--- a/Robust.Analyzers.Tests/PreferOtherTypeAnalyzerTest.cs
+++ b/Robust.Analyzers.Tests/PreferOtherTypeAnalyzerTest.cs
@@ -55,7 +55,7 @@ public sealed class PreferOtherTypeAnalyzerTest
             """;
 
         await Verifier(code,
-            // /0/Test0.cs(12,12): warning RA0031: Use the specific type EntProtoId instead of ProtoId when T is EntityPrototype
+            // /0/Test0.cs(12,12): warning RA0031: Use the specific type EntProtoId instead of ProtoId when the type argument is EntityPrototype
             VerifyCS.Diagnostic().WithSpan(12, 12, 12, 48).WithArguments("EntProtoId", "ProtoId", "EntityPrototype")
         );
     }

--- a/Robust.Analyzers.Tests/PreferOtherTypeAnalyzerTest.cs
+++ b/Robust.Analyzers.Tests/PreferOtherTypeAnalyzerTest.cs
@@ -1,0 +1,62 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using NUnit.Framework;
+using VerifyCS =
+    Microsoft.CodeAnalysis.CSharp.Testing.NUnit.AnalyzerVerifier<Robust.Analyzers.PreferOtherTypeAnalyzer>;
+
+namespace Robust.Analyzers.Tests;
+
+[Parallelizable(ParallelScope.All | ParallelScope.Fixtures)]
+[TestFixture]
+public sealed class PreferOtherTypeAnalyzerTest
+{
+    private static Task Verifier(string code, params DiagnosticResult[] expected)
+    {
+        var test = new CSharpAnalyzerTest<PreferOtherTypeAnalyzer, NUnitVerifier>()
+        {
+            TestState =
+            {
+                Sources = { code },
+            },
+        };
+
+        TestHelper.AddEmbeddedSources(
+            test.TestState,
+            "Robust.Shared.Analyzers.PreferOtherTypeAttribute.cs"
+        );
+
+        // ExpectedDiagnostics cannot be set, so we need to AddRange here...
+        test.TestState.ExpectedDiagnostics.AddRange(expected);
+
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task Test()
+    {
+        const string code = """
+            using Robust.Shared.Analyzers;
+
+            public class EntityPrototype { };
+            public class EntProtoId { };
+            public class ReagentPrototype { };
+
+            [PreferOtherType(typeof(EntityPrototype), typeof(EntProtoId))]
+            public class ProtoId<T> { };
+
+            public class Test
+            {
+                public ProtoId<EntityPrototype> Bad = new();
+
+                public ProtoId<ReagentPrototype> Good = new();
+            }
+            """;
+
+        await Verifier(code,
+            // /0/Test0.cs(12,12): warning RA0031: Use the specific type EntProtoId instead of ProtoId when T is EntityPrototype
+            VerifyCS.Diagnostic().WithSpan(12, 12, 12, 48).WithArguments("EntProtoId", "ProtoId", "EntityPrototype")
+        );
+    }
+}

--- a/Robust.Analyzers.Tests/PreferOtherTypeFixerTest.cs
+++ b/Robust.Analyzers.Tests/PreferOtherTypeFixerTest.cs
@@ -75,7 +75,7 @@ public sealed class PreferOtherTypeFixerTest
             """;
 
         await Verifier(code, fixedCode,
-        // /0/Test0.cs(12,12): error RA0031: Use the specific type EntProtoId instead of ProtoId when T is EntityPrototype
+        // /0/Test0.cs(12,12): error RA0031: Use the specific type EntProtoId instead of ProtoId when the type argument is EntityPrototype
         VerifyCS.Diagnostic().WithSpan(12, 12, 12, 48).WithArguments("EntProtoId", "ProtoId", "EntityPrototype"));
     }
 }

--- a/Robust.Analyzers.Tests/PreferOtherTypeFixerTest.cs
+++ b/Robust.Analyzers.Tests/PreferOtherTypeFixerTest.cs
@@ -1,0 +1,81 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using NUnit.Framework;
+using VerifyCS =
+    Microsoft.CodeAnalysis.CSharp.Testing.NUnit.AnalyzerVerifier<Robust.Analyzers.PreferOtherTypeAnalyzer>;
+
+namespace Robust.Analyzers.Tests;
+
+public sealed class PreferOtherTypeFixerTest
+{
+    private static Task Verifier(string code, string fixedCode, params DiagnosticResult[] expected)
+    {
+        var test = new CSharpCodeFixTest<PreferOtherTypeAnalyzer, PreferOtherTypeFixer, NUnitVerifier>()
+        {
+            TestState =
+            {
+                Sources = { code },
+            },
+            FixedState =
+            {
+                Sources = { fixedCode },
+            }
+        };
+
+        TestHelper.AddEmbeddedSources(
+            test.TestState,
+            "Robust.Shared.Analyzers.PreferOtherTypeAttribute.cs"
+        );
+
+        TestHelper.AddEmbeddedSources(
+            test.FixedState,
+            "Robust.Shared.Analyzers.PreferOtherTypeAttribute.cs"
+        );
+
+        test.TestState.ExpectedDiagnostics.AddRange(expected);
+
+        return test.RunAsync();
+    }
+
+    [Test]
+    public async Task Test()
+    {
+        const string code = """
+            using Robust.Shared.Analyzers;
+
+            public class EntityPrototype { };
+            public class EntProtoId { };
+            public class ReagentPrototype { };
+
+            [PreferOtherType(typeof(EntityPrototype), typeof(EntProtoId))]
+            public class ProtoId<T> { };
+
+            public class Test
+            {
+                public ProtoId<EntityPrototype> Foo = new();
+            }
+            """;
+
+        const string fixedCode = """
+            using Robust.Shared.Analyzers;
+
+            public class EntityPrototype { };
+            public class EntProtoId { };
+            public class ReagentPrototype { };
+
+            [PreferOtherType(typeof(EntityPrototype), typeof(EntProtoId))]
+            public class ProtoId<T> { };
+
+            public class Test
+            {
+                public EntProtoId Foo = new();
+            }
+            """;
+
+        await Verifier(code, fixedCode,
+        // /0/Test0.cs(12,12): error RA0031: Use the specific type EntProtoId instead of ProtoId when T is EntityPrototype
+        VerifyCS.Diagnostic().WithSpan(12, 12, 12, 48).WithArguments("EntProtoId", "ProtoId", "EntityPrototype"));
+    }
+}

--- a/Robust.Analyzers.Tests/Robust.Analyzers.Tests.csproj
+++ b/Robust.Analyzers.Tests/Robust.Analyzers.Tests.csproj
@@ -12,6 +12,7 @@
     <EmbeddedResource Include="..\Robust.Shared\Analyzers\AccessPermissions.cs" LogicalName="Robust.Shared.Analyzers.AccessPermissions.cs" LinkBase="Implementations" />
     <EmbeddedResource Include="..\Robust.Shared\Analyzers\MustCallBaseAttribute.cs" LogicalName="Robust.Shared.IoC.MustCallBaseAttribute.cs" LinkBase="Implementations" />
     <EmbeddedResource Include="..\Robust.Shared\Analyzers\PreferNonGenericVariantForAttribute.cs" LogicalName="Robust.Shared.Analyzers.PreferNonGenericVariantForAttribute.cs" LinkBase="Implementations" />
+    <EmbeddedResource Include="..\Robust.Shared\Analyzers\PreferOtherTypeAttribute.cs" LogicalName="Robust.Shared.Analyzers.PreferOtherTypeAttribute.cs" LinkBase="Implementations" />
     <EmbeddedResource Include="..\Robust.Shared\IoC\DependencyAttribute.cs" LogicalName="Robust.Shared.IoC.DependencyAttribute.cs" LinkBase="Implementations" />
   </ItemGroup>
 

--- a/Robust.Analyzers.Tests/Robust.Analyzers.Tests.csproj
+++ b/Robust.Analyzers.Tests/Robust.Analyzers.Tests.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzer.Testing"/>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp"/>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.NUnit"/>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces"/>
     <PackageReference Include="NUnit"/>
     <PackageReference Include="NUnit3TestAdapter"/>

--- a/Robust.Analyzers/PreferOtherTypeAnalyzer.cs
+++ b/Robust.Analyzers/PreferOtherTypeAnalyzer.cs
@@ -35,8 +35,6 @@ public sealed class PreferOtherTypeAnalyzer : DiagnosticAnalyzer
 
     private void AnalyzeField(SyntaxNodeAnalysisContext context)
     {
-        var preferOtherTypeAttribute = context.Compilation.GetTypeByMetadataName(AttributeType);
-
         if (context.Node is not VariableDeclarationSyntax node)
             return;
 
@@ -51,6 +49,8 @@ public sealed class PreferOtherTypeAnalyzer : DiagnosticAnalyzer
         var symbolInfo = context.SemanticModel.GetSymbolInfo(node.Type);
         if (symbolInfo.Symbol?.GetAttributes() is not { } attributes)
             return;
+
+        var preferOtherTypeAttribute = context.Compilation.GetTypeByMetadataName(AttributeType);
 
         foreach (var attribute in attributes)
         {

--- a/Robust.Analyzers/PreferOtherTypeAnalyzer.cs
+++ b/Robust.Analyzers/PreferOtherTypeAnalyzer.cs
@@ -1,0 +1,70 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Robust.Roslyn.Shared;
+
+namespace Robust.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class PreferOtherTypeAnalyzer : DiagnosticAnalyzer
+{
+    private const string AttributeType = "Robust.Shared.Analyzers.PreferOtherTypeAttribute";
+
+    private static readonly DiagnosticDescriptor PreferOtherTypeDescriptor = new(
+        Diagnostics.IdPreferOtherType,
+        "Use the specific type",
+        "Use the specific type {0} instead of {1} when T is {2}",
+        "Usage",
+        DiagnosticSeverity.Error,
+        true,
+        "Use the specific type.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+        PreferOtherTypeDescriptor
+    );
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.ReportDiagnostics | GeneratedCodeAnalysisFlags.Analyze);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeField, SyntaxKind.VariableDeclaration);
+    }
+
+    private void AnalyzeField(SyntaxNodeAnalysisContext context)
+    {
+        var preferOtherTypeAttribute = context.Compilation.GetTypeByMetadataName(AttributeType);
+
+        if (context.Node is not VariableDeclarationSyntax node)
+            return;
+
+        // Get the type of the generic being used
+        if (node.Type is not GenericNameSyntax genericName)
+            return;
+        var genericSyntax = genericName.TypeArgumentList.Arguments[0];
+        var genericType = context.SemanticModel.GetSymbolInfo(genericSyntax).Symbol;
+
+        // Look for the PreferOtherTypeAttribute
+        var symbolInfo = context.SemanticModel.GetSymbolInfo(node.Type);
+        var attributes = symbolInfo.Symbol.GetAttributes();
+        foreach (var attribute in attributes)
+        {
+            if (!SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, preferOtherTypeAttribute))
+                continue;
+
+            // See if the generic type argument matches the type the attribute specifies
+            var checkedType = attribute.ConstructorArguments[0].Value as ITypeSymbol;
+            if (!SymbolEqualityComparer.Default.Equals(checkedType, genericType))
+                continue;
+
+            var replacementType = attribute.ConstructorArguments[1].Value as ITypeSymbol;
+            context.ReportDiagnostic(Diagnostic.Create(PreferOtherTypeDescriptor,
+                context.Node.GetLocation(),
+                replacementType.Name,
+                symbolInfo.Symbol.Name,
+                genericType.Name));
+
+        }
+    }
+}

--- a/Robust.Analyzers/PreferOtherTypeAnalyzer.cs
+++ b/Robust.Analyzers/PreferOtherTypeAnalyzer.cs
@@ -16,7 +16,7 @@ public sealed class PreferOtherTypeAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor PreferOtherTypeDescriptor = new(
         Diagnostics.IdPreferOtherType,
         "Use the specific type",
-        "Use the specific type {0} instead of {1} when T is {2}",
+        "Use the specific type {0} instead of {1} when the type argument is {2}",
         "Usage",
         DiagnosticSeverity.Error,
         true,

--- a/Robust.Analyzers/PreferOtherTypeFixer.cs
+++ b/Robust.Analyzers/PreferOtherTypeFixer.cs
@@ -1,0 +1,97 @@
+#nullable enable
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Robust.Roslyn.Shared.Diagnostics;
+
+namespace Robust.Analyzers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp)]
+public sealed class PreferOtherTypeFixer : CodeFixProvider
+{
+    private const string PreferOtherTypeAttributeName = "PreferOtherTypeAttribute";
+
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(
+        IdPreferOtherType
+    );
+
+    public override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    public override Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            switch (diagnostic.Id)
+            {
+                case IdPreferOtherType:
+                    return RegisterReplaceType(context, diagnostic);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static async Task RegisterReplaceType(CodeFixContext context, Diagnostic diagnostic)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken);
+        var span = diagnostic.Location.SourceSpan;
+        var token = root?.FindToken(span.Start).Parent?.AncestorsAndSelf().OfType<VariableDeclarationSyntax>().First();
+
+        if (token == null)
+            return;
+
+        context.RegisterCodeFix(CodeAction.Create(
+            "Replace type",
+            c => ReplaceType(context.Document, token, c),
+            "Replace type"
+        ), diagnostic);
+    }
+
+    private static async Task<Document> ReplaceType(Document document, VariableDeclarationSyntax syntax, CancellationToken cancellation)
+    {
+        var root = (CompilationUnitSyntax?) await document.GetSyntaxRootAsync(cancellation);
+        var model = await document.GetSemanticModelAsync(cancellation);
+
+        if (model == null)
+            return document;
+
+        if (syntax.Type is not GenericNameSyntax genericNameSyntax)
+            return document;
+        var genericTypeSyntax = genericNameSyntax.TypeArgumentList.Arguments[0];
+        if (model.GetSymbolInfo(genericTypeSyntax).Symbol is not {} genericTypeSymbol)
+            return document;
+
+        var symbolInfo = model.GetSymbolInfo(syntax.Type);
+        if (symbolInfo.Symbol?.GetAttributes() is not { } attributes)
+            return document;
+
+        foreach (var attribute in attributes)
+        {
+            if (attribute.AttributeClass?.Name != PreferOtherTypeAttributeName)
+                continue;
+
+            if (attribute.ConstructorArguments[0].Value is not ITypeSymbol checkedTypeSymbol)
+                continue;
+
+            if (!SymbolEqualityComparer.Default.Equals(checkedTypeSymbol, genericTypeSymbol))
+                continue;
+
+            if (attribute.ConstructorArguments[1].Value is not ITypeSymbol replacementTypeSymbol)
+                continue;
+
+            var replacementIdentifier = SyntaxFactory.IdentifierName(replacementTypeSymbol.Name);
+            var replacementSyntax = syntax.WithType(replacementIdentifier);
+
+            root = root!.ReplaceNode(syntax, replacementSyntax);
+            return document.WithSyntaxRoot(root);
+        }
+
+        return document;
+    }
+}

--- a/Robust.Analyzers/Robust.Analyzers.csproj
+++ b/Robust.Analyzers/Robust.Analyzers.csproj
@@ -22,6 +22,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Needed for PreferOtherTypeAnalyzer. -->
+    <Compile Include="..\Robust.Shared\Analyzers\PreferOtherTypeAttribute.cs" LinkBase="Implementations" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Needed for DataDefinitionAnalyzer. -->
     <Compile Include="..\Robust.Shared\Serialization\Manager\Definition\DataDefinitionUtility.cs" LinkBase="Implementations" />
     <Compile Include="..\Robust.Shared\ViewVariables\ViewVariablesAttribute.cs" LinkBase="Implementations" />

--- a/Robust.Roslyn.Shared/Diagnostics.cs
+++ b/Robust.Roslyn.Shared/Diagnostics.cs
@@ -34,6 +34,7 @@ public static class Diagnostics
     public const string IdMustCallBase = "RA0028";
     public const string IdDataFieldNoVVReadWrite = "RA0029";
     public const string IdUseNonGenericVariant = "RA0030";
+    public const string IdPreferOtherType = "RA0031";
 
     public static SuppressionDescriptor MeansImplicitAssignment =>
         new SuppressionDescriptor("RADC1000", "CS0649", "Marked as implicitly assigned.");

--- a/Robust.Shared/Analyzers/PreferOtherTypeAttribute.cs
+++ b/Robust.Shared/Analyzers/PreferOtherTypeAttribute.cs
@@ -1,0 +1,18 @@
+using System;
+
+#if ROBUST_ANALYZERS_IMPL
+namespace Robust.Shared.Analyzers.Implementation;
+#else
+namespace Robust.Shared.Analyzers;
+#endif
+
+/// <summary>
+/// Marks that use of a generic Type should be replaced with a specific other Type
+/// when the type argument T is a certain Type.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+public sealed class PreferOtherTypeAttribute(Type type, Type otherType) : Attribute
+{
+    public readonly Type Type = type;
+    public readonly Type OtherType = otherType;
+}

--- a/Robust.Shared/Analyzers/PreferOtherTypeAttribute.cs
+++ b/Robust.Shared/Analyzers/PreferOtherTypeAttribute.cs
@@ -11,8 +11,8 @@ namespace Robust.Shared.Analyzers;
 /// when the type argument T is a certain Type.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
-public sealed class PreferOtherTypeAttribute(Type type, Type otherType) : Attribute
+public sealed class PreferOtherTypeAttribute(Type genericType, Type replacementType) : Attribute
 {
-    public readonly Type Type = type;
-    public readonly Type OtherType = otherType;
+    public readonly Type GenericArgument = genericType;
+    public readonly Type ReplacementType = replacementType;
 }

--- a/Robust.Shared/Prototypes/ProtoId.cs
+++ b/Robust.Shared/Prototypes/ProtoId.cs
@@ -13,6 +13,7 @@ namespace Robust.Shared.Prototypes;
 /// </remarks>
 /// <remarks><seealso cref="EntProtoId"/> for an <see cref="EntityPrototype"/> alias.</remarks>
 [Serializable]
+[PreferOtherType(typeof(EntityPrototype), typeof(EntProtoId))]
 public readonly record struct ProtoId<T>(string Id) : IEquatable<string>, IComparable<ProtoId<T>> where T : class, IPrototype
 {
     public static implicit operator string(ProtoId<T> protoId)


### PR DESCRIPTION
Adds an analyzer that detects any use of `ProtoId<EntityPrototype>` and flags it as an error. To make life easier, also adds a code fixer that will swap it with `EntProtoId` for you.

This is implemented as a new attribute: `PreferOtherTypeAttribute`. It can be applied to a generic class or struct and takes two arguments: the type to look for as the T type argument for the generic, and the type that should be used as a replacement. This is applied to `ProtoId<T>` like this:
```c#
[PreferOtherType(typeof(EntityPrototype), typeof(EntProtoId))]
```
Hopefully that's self-explanatory enough.

If you're thinking that flagging it as an error seems excessive, I'm inclined to agree, but I want to make note of the fact that any use of `ProtoId<EntityPrototype>` will trip a [debug assert](https://github.com/space-wizards/RobustToolbox/blob/2664061993545007b7accc1e5a3b4058dfb70280/Robust.Shared/Prototypes/PrototypeManager.ValidateFields.cs#L197) when running the YAML linter. It might make sense to remove the debug assert in favor of this analyzer and possibly downgrade this from an error to a warning, so let me know if that would be preferred.

I also had to add the nuget package for NUnit code fix verifiers, since trying to develop analyzers/fixers without a functioning unit test is a miserable time. If that's not desired, let me know and I can get rid of the test and the package import.