### PR TITLE
TryFindComponentOnEntityContainerOrParent no fail please

### DIFF
--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -380,9 +380,6 @@ namespace Robust.Shared.Containers
             if (entityQuery.TryComp(xform.ParentUid, out foundComponent))
                 return true;
 
-//            if (entityQuery.Resolve(xform.ParentUid, ref foundComponent, false))
-//                return true;
-
             return TryFindComponentOnEntityContainerOrParent(xform.ParentUid, entityQuery, ref foundComponent);
         }
 

--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -377,8 +377,11 @@ namespace Robust.Shared.Containers
             if (!xform.ParentUid.Valid)
                 return false;
 
-            if (entityQuery.Resolve(xform.ParentUid, ref foundComponent, false))
+            if (entityQuery.TryComp(xform.ParentUid, out foundComponent))
                 return true;
+
+//            if (entityQuery.Resolve(xform.ParentUid, ref foundComponent, false))
+//                return true;
 
             return TryFindComponentOnEntityContainerOrParent(xform.ParentUid, entityQuery, ref foundComponent);
         }

--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -361,12 +361,10 @@ namespace Robust.Shared.Containers
         public bool TryFindComponentOnEntityContainerOrParent<T>(
             EntityUid uid,
             EntityQuery<T> entityQuery,
-            [NotNullWhen(true)] out T? foundComponent,
+            [NotNullWhen(true)] ref T? foundComponent,
             MetaDataComponent? meta = null,
             TransformComponent? xform = null) where T : IComponent
         {
-            foundComponent = default;
-
             if (!MetaQuery.Resolve(uid, ref meta))
                 return false;
 
@@ -382,7 +380,7 @@ namespace Robust.Shared.Containers
             if (entityQuery.TryComp(xform.ParentUid, out foundComponent))
                 return true;
 
-            return TryFindComponentOnEntityContainerOrParent(xform.ParentUid, entityQuery, out foundComponent);
+            return TryFindComponentOnEntityContainerOrParent(xform.ParentUid, entityQuery, ref foundComponent);
         }
 
         /// <summary>

--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -361,10 +361,12 @@ namespace Robust.Shared.Containers
         public bool TryFindComponentOnEntityContainerOrParent<T>(
             EntityUid uid,
             EntityQuery<T> entityQuery,
-            [NotNullWhen(true)] ref T? foundComponent,
+            [NotNullWhen(true)] out T? foundComponent,
             MetaDataComponent? meta = null,
             TransformComponent? xform = null) where T : IComponent
         {
+            foundComponent = default;
+
             if (!MetaQuery.Resolve(uid, ref meta))
                 return false;
 
@@ -380,7 +382,7 @@ namespace Robust.Shared.Containers
             if (entityQuery.TryComp(xform.ParentUid, out foundComponent))
                 return true;
 
-            return TryFindComponentOnEntityContainerOrParent(xform.ParentUid, entityQuery, ref foundComponent);
+            return TryFindComponentOnEntityContainerOrParent(xform.ParentUid, entityQuery, out foundComponent);
         }
 
         /// <summary>


### PR DESCRIPTION
TryFindComponentOnEntityContainerOrParent
would fail trying to Resolve on parents that don't have the component its searching for. This prevents that by changing the Resolve to TryComp.