### PR TITLE
Add ObjectSerializer, AppearanceComponent.AppearanceDataInit, and AppearanceSystem.AppendData

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,23 +35,20 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* Obsolete method `AppearanceComponent.TryGetData` is now access-restricted to `SharedAppearanceSystem`; use `SharedAppearanceSystem.TryGetData` instead.
 
 ### New features
 
-*None yet*
-
-### Bugfixes
-
-*None yet*
+* Added `SharedAppearanceSystem.AppendData`, which appends non-existing `AppearanceData` from one `AppearanceComponent` to another.
+* Added `AppearanceComponent.AppearanceDataInit`, which can be used to set initial `AppearanceData` entries in .yaml.
 
 ### Other
 
-*None yet*
+* Serialization will now add type tags (`!type:<T>`) for necessary `NodeData` when writing (currently only for `object` nodes).
 
 ### Internal
 
-*None yet*
+* Added `ObjectSerializer`, which handles serialization of the generic `object` type.
 
 
 ## 229.0.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -49,6 +49,7 @@ END TEMPLATE-->
 ### Other
 
 * Added obsoletion warning for `Control.Dispose()`. New code should not rely on it.
+* Reduced the default tickrate to 30 ticks.
 * Serialization will now add type tags (`!type:<T>`) for necessary `NodeData` when writing (currently only for `object` nodes).
 
 ### Internal

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -42,8 +42,13 @@ END TEMPLATE-->
 * Added `SharedAppearanceSystem.AppendData`, which appends non-existing `AppearanceData` from one `AppearanceComponent` to another.
 * Added `AppearanceComponent.AppearanceDataInit`, which can be used to set initial `AppearanceData` entries in .yaml.
 
+### Bugfixes
+
+* Fix multithreading bug in ParallelTracker that caused the game to crash randomly.
+
 ### Other
 
+* Added obsoletion warning for `Control.Dispose()`. New code should not rely on it.
 * Serialization will now add type tags (`!type:<T>`) for necessary `NodeData` when writing (currently only for `object` nodes).
 
 ### Internal

--- a/Robust.Shared/GameObjects/Components/Appearance/AppearanceComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Appearance/AppearanceComponent.cs
@@ -2,20 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.GameStates;
-using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.ViewVariables;
-
-
-
-using Robust.Shared.Reflection;
-using Robust.Shared.IoC;
-using Robust.Shared.Serialization.Manager;
-using Robust.Shared.Serialization.Markdown;
-using Robust.Shared.Serialization.Markdown.Mapping;
-using Robust.Shared.Serialization.Markdown.Validation;
-using Robust.Shared.Serialization.TypeSerializers.Interfaces;
-using Robust.Shared.Utility;
 
 namespace Robust.Shared.GameObjects;
 
@@ -43,7 +31,7 @@ public sealed partial class AppearanceComponent : Component
     /// </remarks>
     [ViewVariables] internal bool UpdateQueued;
 
-    [DataField(customTypeSerializer: typeof(AppearanceSerializer))]
+    [DataField]
     public Dictionary<Enum, object> AppearanceData = new();
 
     [Obsolete("Use SharedAppearanceSystem instead")]
@@ -57,105 +45,5 @@ public sealed partial class AppearanceComponent : Component
 
         data = default!;
         return false;
-    }
-
-    [DataDefinition, Serializable, NetSerializable]
-    public sealed partial class AppearanceDataDummy
-    {
-        public Dictionary<Enum, object> AppearanceData;
-    }
-}
-
-public sealed class AppearanceSerializer : ITypeReader<Dictionary<Enum, object>, MappingDataNode>, ITypeCopier<Dictionary<Enum, object>>
-{
-    public ValidationNode Validate(ISerializationManager serializationManager, MappingDataNode node,
-        IDependencyCollection dependencies, ISerializationContext? context = null)
-    {
-        var validated = new List<ValidationNode>();
-
-        if (node.Count <= 0)
-            return new ValidatedSequenceNode(validated);
-
-        var reflection = dependencies.Resolve<IReflectionManager>();
-
-        foreach (var data in node)
-        {
-            var key = data.Key.ToYamlNode().AsString();
-
-            if (data.Value.Tag == null)
-            {
-                validated.Add(new ErrorNode(data.Key, $"Unable to validate {key}'s type"));
-                continue;
-            }
-
-            var typeString = data.Value.Tag[6..];
-
-            if (!reflection.TryLooseGetType(typeString, out var type))
-            {
-                validated.Add(new ErrorNode(data.Key, $"Unable to find type for {typeString}"));
-                continue;
-            }
-
-            var validatedNode = serializationManager.ValidateNode(type, data.Value, context);
-            validated.Add(validatedNode);
-        }
-
-        return new ValidatedSequenceNode(validated);
-    }
-
-    public Dictionary<Enum, object> Read(ISerializationManager serializationManager, MappingDataNode node,
-        IDependencyCollection dependencies,
-        SerializationHookContext hookCtx, ISerializationContext? context = null,
-        ISerializationManager.InstantiationDelegate<Dictionary<Enum, object>>? instanceProvider = null)
-    {
-        var value = instanceProvider != null ? instanceProvider() : new Dictionary<Enum, object>();
-
-        if (node.Count <= 0)
-            return value;
-
-        var reflection = dependencies.Resolve<IReflectionManager>();
-
-        foreach (var data in node)
-        {
-            var key = data.Key.ToYamlNode().ToString();
-
-            if (!serializationManager.ReflectionManager.TryParseEnumReference(key, out var @enum))
-                throw new ArgumentException($"Failed to parse enum {key}");
-
-            if (data.Value.Tag == null)
-                throw new NullReferenceException($"Found null tag for {key}");
-
-            var typeString = data.Value.Tag[6..];
-
-            if (!reflection.TryLooseGetType(typeString, out var type))
-                throw new NullReferenceException($"Found null type for {key}");
-
-            var bbData = serializationManager.Read(type, data.Value, hookCtx, context);
-
-            if (bbData == null)
-                throw new NullReferenceException($"Found null data for {key}, expected {type}");
-
-            value[@enum] = bbData;
-        }
-
-        return value;
-    }
-
-    public void CopyTo(
-        ISerializationManager serializationManager,
-        Dictionary<Enum, object> source,
-        ref Dictionary<Enum, object> target,
-        IDependencyCollection dependencies,
-        SerializationHookContext hookCtx,
-        ISerializationContext? context = null)
-    {
-        target.Clear();
-        using var enumerator = source.GetEnumerator();
-
-        while (enumerator.MoveNext())
-        {
-            var current = enumerator.Current;
-            target[current.Key] = current.Value;
-        }
     }
 }

--- a/Robust.Shared/GameObjects/Components/Appearance/AppearanceComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Appearance/AppearanceComponent.cs
@@ -34,10 +34,18 @@ public sealed partial class AppearanceComponent : Component
 
     [ViewVariables] internal Dictionary<Enum, object> AppearanceData = new();
 
+    private Dictionary<Enum, object>? _appearanceDataInit;
+
     /// <summary>
-    /// Whether or not the appearance needs to be updated.
+    /// Sets starting values for AppearanceData.
     /// </summary>
-    [DataField(readOnly: true)] public Dictionary<Enum, object> AppearanceDataInit = new();
+    /// <remarks>
+    /// Should only be filled in via prototype .yaml; subsequent data must be set via SharedAppearanceSystem.SetData().
+    /// </remarks>
+    [DataField(readOnly: true)] public Dictionary<Enum, object>? AppearanceDataInit {
+        get { return _appearanceDataInit; }
+        set { AppearanceData = value ?? AppearanceData; _appearanceDataInit = value; }
+    }
 
     [Obsolete("Use SharedAppearanceSystem instead")]
     public bool TryGetData<T>(Enum key, [NotNullWhen(true)] out T data)

--- a/Robust.Shared/GameObjects/Components/Appearance/AppearanceComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Appearance/AppearanceComponent.cs
@@ -16,6 +16,7 @@ namespace Robust.Shared.GameObjects;
 ///     Visualization works client side with derivatives of the <see cref="Robust.Client.GameObjects.VisualizerSystem">VisualizerSystem</see> class and corresponding components.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
+[Access(typeof(SharedAppearanceSystem))]
 public sealed partial class AppearanceComponent : Component
 {
     /// <summary>

--- a/Robust.Shared/GameObjects/Components/Appearance/AppearanceComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Appearance/AppearanceComponent.cs
@@ -2,7 +2,20 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.ViewVariables;
+
+
+
+using Robust.Shared.Reflection;
+using Robust.Shared.IoC;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Mapping;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.GameObjects;
 
@@ -30,7 +43,8 @@ public sealed partial class AppearanceComponent : Component
     /// </remarks>
     [ViewVariables] internal bool UpdateQueued;
 
-    [ViewVariables] internal Dictionary<Enum, object> AppearanceData = new();
+    [DataField(customTypeSerializer: typeof(AppearanceSerializer))]
+    public Dictionary<Enum, object> AppearanceData = new();
 
     [Obsolete("Use SharedAppearanceSystem instead")]
     public bool TryGetData<T>(Enum key, [NotNullWhen(true)] out T data)
@@ -43,5 +57,105 @@ public sealed partial class AppearanceComponent : Component
 
         data = default!;
         return false;
+    }
+
+    [DataDefinition, Serializable, NetSerializable]
+    public sealed partial class AppearanceDataDummy
+    {
+        public Dictionary<Enum, object> AppearanceData;
+    }
+}
+
+public sealed class AppearanceSerializer : ITypeReader<Dictionary<Enum, object>, MappingDataNode>, ITypeCopier<Dictionary<Enum, object>>
+{
+    public ValidationNode Validate(ISerializationManager serializationManager, MappingDataNode node,
+        IDependencyCollection dependencies, ISerializationContext? context = null)
+    {
+        var validated = new List<ValidationNode>();
+
+        if (node.Count <= 0)
+            return new ValidatedSequenceNode(validated);
+
+        var reflection = dependencies.Resolve<IReflectionManager>();
+
+        foreach (var data in node)
+        {
+            var key = data.Key.ToYamlNode().AsString();
+
+            if (data.Value.Tag == null)
+            {
+                validated.Add(new ErrorNode(data.Key, $"Unable to validate {key}'s type"));
+                continue;
+            }
+
+            var typeString = data.Value.Tag[6..];
+
+            if (!reflection.TryLooseGetType(typeString, out var type))
+            {
+                validated.Add(new ErrorNode(data.Key, $"Unable to find type for {typeString}"));
+                continue;
+            }
+
+            var validatedNode = serializationManager.ValidateNode(type, data.Value, context);
+            validated.Add(validatedNode);
+        }
+
+        return new ValidatedSequenceNode(validated);
+    }
+
+    public Dictionary<Enum, object> Read(ISerializationManager serializationManager, MappingDataNode node,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx, ISerializationContext? context = null,
+        ISerializationManager.InstantiationDelegate<Dictionary<Enum, object>>? instanceProvider = null)
+    {
+        var value = instanceProvider != null ? instanceProvider() : new Dictionary<Enum, object>();
+
+        if (node.Count <= 0)
+            return value;
+
+        var reflection = dependencies.Resolve<IReflectionManager>();
+
+        foreach (var data in node)
+        {
+            var key = data.Key.ToYamlNode().ToString();
+
+            if (!serializationManager.ReflectionManager.TryParseEnumReference(key, out var @enum))
+                throw new ArgumentException($"Failed to parse enum {key}");
+
+            if (data.Value.Tag == null)
+                throw new NullReferenceException($"Found null tag for {key}");
+
+            var typeString = data.Value.Tag[6..];
+
+            if (!reflection.TryLooseGetType(typeString, out var type))
+                throw new NullReferenceException($"Found null type for {key}");
+
+            var bbData = serializationManager.Read(type, data.Value, hookCtx, context);
+
+            if (bbData == null)
+                throw new NullReferenceException($"Found null data for {key}, expected {type}");
+
+            value[@enum] = bbData;
+        }
+
+        return value;
+    }
+
+    public void CopyTo(
+        ISerializationManager serializationManager,
+        Dictionary<Enum, object> source,
+        ref Dictionary<Enum, object> target,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context = null)
+    {
+        target.Clear();
+        using var enumerator = source.GetEnumerator();
+
+        while (enumerator.MoveNext())
+        {
+            var current = enumerator.Current;
+            target[current.Key] = current.Value;
+        }
     }
 }

--- a/Robust.Shared/GameObjects/Components/Appearance/AppearanceComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Appearance/AppearanceComponent.cs
@@ -32,8 +32,12 @@ public sealed partial class AppearanceComponent : Component
     /// </remarks>
     [ViewVariables] internal bool UpdateQueued;
 
-    [DataField]
-    public Dictionary<Enum, object> AppearanceData = new();
+    [ViewVariables] internal Dictionary<Enum, object> AppearanceData = new();
+
+    /// <summary>
+    /// Whether or not the appearance needs to be updated.
+    /// </summary>
+    [DataField(readOnly: true)] public Dictionary<Enum, object> AppearanceDataInit = new();
 
     [Obsolete("Use SharedAppearanceSystem instead")]
     public bool TryGetData<T>(Enum key, [NotNullWhen(true)] out T data)

--- a/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
@@ -115,6 +115,32 @@ public abstract class SharedAppearanceSystem : EntitySystem
         Dirty(dest, dest.Comp);
         QueueUpdate(dest, dest.Comp);
     }
+
+    /// <summary>
+    /// Appends appearance data from <c>src</c> to <c>dest</c>. If a key/value pair already exists in <c>dest</c>, it gets replaced.
+    /// If <c>src</c> has no <see cref="AppearanceComponent"/> nothing is done.
+    /// If <c>dest</c> has no <c>AppearanceComponent</c> then it is created.
+    /// </summary>
+    public void AppendData(Entity<AppearanceComponent?> src, Entity<AppearanceComponent?> dest)
+    {
+        if (!Resolve(src, ref src.Comp, false))
+            return;
+
+        AppendData(src.Comp, dest);
+    }
+
+    public void AppendData(AppearanceComponent srcComp, Entity<AppearanceComponent?> dest)
+    {
+        dest.Comp ??= EnsureComp<AppearanceComponent>(dest);
+
+        foreach (var (key, value) in srcComp.AppearanceData)
+        {
+            dest.Comp.AppearanceData[key] = value;
+        }
+
+        Dirty(dest, dest.Comp);
+        QueueUpdate(dest, dest.Comp);
+    }
 }
 
 [Serializable, NetSerializable]

--- a/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
@@ -17,15 +17,6 @@ public abstract class SharedAppearanceSystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<AppearanceComponent, ComponentGetState>(OnAppearanceGetState);
-        SubscribeLocalEvent<AppearanceComponent, ComponentInit>(OnComponentInit);
-    }
-
-    private void OnComponentInit(EntityUid uid, AppearanceComponent component, ref ComponentInit args)
-    {
-        foreach(var (key, value) in component.AppearanceDataInit)
-        {
-            SetData(uid, key, value, component);
-        }
     }
 
     protected abstract void OnAppearanceGetState(EntityUid uid, AppearanceComponent component,

--- a/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedAppearanceSystem.cs
@@ -17,6 +17,15 @@ public abstract class SharedAppearanceSystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<AppearanceComponent, ComponentGetState>(OnAppearanceGetState);
+        SubscribeLocalEvent<AppearanceComponent, ComponentInit>(OnComponentInit);
+    }
+
+    private void OnComponentInit(EntityUid uid, AppearanceComponent component, ref ComponentInit args)
+    {
+        foreach(var (key, value) in component.AppearanceDataInit)
+        {
+            SetData(uid, key, value, component);
+        }
     }
 
     protected abstract void OnAppearanceGetState(EntityUid uid, AppearanceComponent component,

--- a/Robust.Shared/Serialization/Manager/SerializationManager.Writing.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.Writing.cs
@@ -260,7 +260,12 @@ public sealed partial class SerializationManager
             return ValueDataNode.Null();
         }
 
-        return GetOrCreateWriteGenericDelegate(value, notNullableOverride)(value, alwaysWrite, context);
+        var node = GetOrCreateWriteGenericDelegate(value, notNullableOverride)(value, alwaysWrite, context);
+
+        if (typeof(T) == typeof(object))
+            node.Tag = "!type:" + value.GetType().Name;
+
+        return node;
     }
 
     public DataNode WriteValue<T>(ITypeWriter<T> writer, T value, bool alwaysWrite = false,

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ObjectSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ObjectSerializer.cs
@@ -1,0 +1,92 @@
+using System;
+using Robust.Shared.Reflection;
+using Robust.Shared.IoC;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Serialization.Manager.Attributes;
+
+namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
+
+[TypeSerializer]
+public sealed class ObjectSerializer : ITypeSerializer<object, ValueDataNode>, ITypeCopier<object>
+{
+    #region Validate
+
+    public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
+        IDependencyCollection dependencies, ISerializationContext? context = null)
+    {
+        var reflection = dependencies.Resolve<IReflectionManager>();
+
+        if (node.Tag != null)
+        {
+            string? typeString = node.Tag[6..];
+
+            if (!reflection.TryLooseGetType(typeString, out var type))
+            {
+                return new ErrorNode(node, $"Unable to find type for {typeString}");
+            }
+
+            return serializationManager.ValidateNode(type, node, context);
+        }
+        return new ErrorNode(node, $"Unable to find type for {node}");
+    }
+
+    #endregion
+
+    #region Read
+    public object Read(ISerializationManager serializationManager, ValueDataNode node,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx, ISerializationContext? context = null,
+        ISerializationManager.InstantiationDelegate<object>? instanceProvider = null)
+    {
+        var reflection = dependencies.Resolve<IReflectionManager>();
+        var value = instanceProvider != null ? instanceProvider() : new object();
+
+        if (node.Tag != null)
+        {
+            string? typeString = node.Tag[6..];
+
+            if (!reflection.TryLooseGetType(typeString, out var type))
+                throw new NullReferenceException($"Found null type for {typeString}");
+
+            value = serializationManager.Read(type, node, hookCtx, context);
+
+            if (value == null)
+                throw new NullReferenceException($"Found null data for {node}, expected {type}");
+        }
+
+        return value;
+    }
+    #endregion
+
+    #region Write
+    public DataNode Write(ISerializationManager serializationManager, object value,
+            IDependencyCollection dependencies, bool alwaysWrite = false,
+            ISerializationContext? context = null)
+    {
+        var node = serializationManager.WriteValue(value.GetType(), value);
+
+        if (node == null)
+            throw new NullReferenceException($"Attempted to write node with type {value.GetType()}, node returned null");
+
+        return node;
+    }
+    #endregion
+
+    #region CopyTo
+
+    public void CopyTo(
+        ISerializationManager serializationManager,
+        object source,
+        ref object target,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context = null)
+    {
+        target = source;
+    }
+    #endregion
+}


### PR DESCRIPTION
**1. ObjectSerializer**

This PR adds ObjectSerializer, a serializer for the generic `object` type. The serializer attempts to get the type from the .yaml (use `!type:<type>` e.g. `!type:string`) via `ISerializationManager` and `IReflectionManager.TryLooseGetType`.

**2. AppearanceDataInit**

AppearanceSystem has a new property `AppearanceDataInit`. This property is used to set initial values for `AppearanceData` in yaml while also being compatible with serialization. The reason why `AppearanceData` isn't being set directly in yaml is because there are several components that, upon the entity being spawned, add entries to `AppearanceData`. Were it to be serializable this would cause excessive bloat when saving yaml prototypes and also causes the "Prototype modifies component on spawn" assert to fail. 

`AppearanceDataInit` adds the data to `AppearanceData` via the setter. The reason for it being done this way is because the addition must happen *before* the `AppearanceComponent` is initialized but *after* the yaml is parsed. This is to ensure reading the `AppearanceData` from a prototype directly still works (example: `SharedChameleonClothingSystem` reading the prototype via `EntityPrototype.TryGetComponent` to copy the `AppearanceData`). 

**3. AppendData**

AppearanceSystem also now has AppendData, which can be used to copy data from another AppearanceComponent without clearing the existing data.

**Breaking Changes**

This PR access-restricts `AppearanceComponent` to `SharedAppearanceSystem`. This breaks any outside system that uses the obsolete method `AppearanceComponent.TryGetData`. To fix this, any system outside `SharedAppearanceSystem` and its inheritors must change to using `SharedAppearanceSystem.TryGetData`.

Because of this, for SS14 https://github.com/space-wizards/space-station-14/pull/30550 must first be merged to avoid build errors.