### PR TITLE
Fix chunkenumerator allocs

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -1053,9 +1053,6 @@ public abstract partial class SharedMapSystem
             compAABB = grid.LocalAABB.Intersect(localAABB);
         }
 
-        if (compAABB.IsEmpty())
-            return ChunkEnumerator.Empty;
-
         return new ChunkEnumerator(grid.Chunks, compAABB, grid.ChunkSize);
     }
 

--- a/Robust.Shared/Map/Enumerators/ChunkEnumerator.cs
+++ b/Robust.Shared/Map/Enumerators/ChunkEnumerator.cs
@@ -7,13 +7,8 @@ using Robust.Shared.Maths;
 
 namespace Robust.Shared.Map.Enumerators;
 
-internal struct ChunkEnumerator
+internal ref struct ChunkEnumerator
 {
-    /// <summary>
-    /// An empty enumerator that will return nothing.
-    /// </summary>
-    public static ChunkEnumerator Empty => new(new Dictionary<Vector2i, MapChunk>(), Box2.Empty, 1);
-
     private Dictionary<Vector2i, MapChunk> _chunks;
     private Vector2i _chunkLB;
     private Vector2i _chunkRT;


### PR DESCRIPTION
This was number 2 to pathfinding sitting afk on a server. I thought the property would cache it but apparently not. Ref struct is just nicety and it's internal and not exposed to content anyway so.