### PR TITLE
Reduce the default TPS

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -47,7 +47,7 @@ END TEMPLATE-->
 
 ### Other
 
-*None yet*
+* Reduced the default tickrate to 30 ticks.
 
 ### Internal
 

--- a/Robust.Server/server_config.toml
+++ b/Robust.Server/server_config.toml
@@ -9,7 +9,7 @@ level = 1
 enabled = false
 
 [net]
-tickrate = 60
+tickrate = 30
 port = 1212
 bindto = "::,0.0.0.0"
 max_connections = 256

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -289,7 +289,7 @@ namespace Robust.Shared
         /// This influences both how frequently game code processes, and how frequently updates are sent to clients.
         /// </summary>
         public static readonly CVarDef<int> NetTickrate =
-            CVarDef.Create("net.tickrate", 60, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
+            CVarDef.Create("net.tickrate", 30, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
 
         /// <summary>
         /// Offset CurTime at server start by this amount (in seconds).


### PR DESCRIPTION
It is our suggestion for a long while to keep the TPS at 30 for servers. However the default was always 60.

I believe its better to have it as a default.