### PR TITLE
Add missing return calls for positions and angles in SolveIsland

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
@@ -5,7 +5,6 @@ using System.Numerics;
 using System.Threading.Tasks;
 using Microsoft.Extensions.ObjectPool;
 using Robust.Shared.GameObjects;
-using Robust.Shared.Maths;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Dynamics.Contacts;
@@ -960,6 +959,8 @@ public abstract partial class SharedPhysicsSystem
         }
 
         // Cleanup
+        ArrayPool<Vector2>.Shared.Return(positions);
+        ArrayPool<float>.Shared.Return(angles);
         ArrayPool<ContactVelocityConstraint>.Shared.Return(velocityConstraints);
         ArrayPool<ContactPositionConstraint>.Shared.Return(positionConstraints);
     }
@@ -985,7 +986,7 @@ public abstract partial class SharedPhysicsSystem
 
             var solvedPosition = Vector2.Transform(adjustedPosition, parentInvMatrix);
             solvedPositions[offset + i] = solvedPosition - xform.LocalPosition;
-            solvedAngles[offset + i] = angles[i] - worldRot;
+            solvedAngles[offset + i] = angle - worldRot;
         }
     }
 


### PR DESCRIPTION
Idk if this gets stored anywhere but doesn't look like it and I trust sloth to look it over
Also angle was being accessed again for seemingly no reason