### PR TITLE
Add a copy to clipboard button on alert popups.

### DIFF
--- a/Resources/Locale/en-US/userinterface.ftl
+++ b/Resources/Locale/en-US/userinterface.ftl
@@ -1,0 +1,2 @@
+popup-copy-button = Copy
+popup-title = Alert!

--- a/Robust.Client/UserInterface/IUserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/IUserInterfaceManager.cs
@@ -64,7 +64,7 @@ namespace Robust.Client.UserInterface
 
         IDebugMonitors DebugMonitors { get; }
 
-        void Popup(string contents, string title = "Alert!", bool clipboardButton = true);
+        void Popup(string contents, string? title = null, bool clipboardButton = true);
 
         Control? MouseGetControl(ScreenCoordinates coordinates);
 

--- a/Robust.Client/UserInterface/IUserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/IUserInterfaceManager.cs
@@ -64,7 +64,7 @@ namespace Robust.Client.UserInterface
 
         IDebugMonitors DebugMonitors { get; }
 
-        void Popup(string contents, string title = "Alert!", string clipboardButton = "Copy");
+        void Popup(string contents, string title = "Alert!", bool clipboardButton = true);
 
         Control? MouseGetControl(ScreenCoordinates coordinates);
 

--- a/Robust.Client/UserInterface/IUserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/IUserInterfaceManager.cs
@@ -64,7 +64,7 @@ namespace Robust.Client.UserInterface
 
         IDebugMonitors DebugMonitors { get; }
 
-        void Popup(string contents, string title = "Alert!");
+        void Popup(string contents, string title = "Alert!", string clipboardButton = "Copy");
 
         Control? MouseGetControl(ScreenCoordinates coordinates);
 

--- a/Robust.Client/UserInterface/UserInterfaceManager.Layout.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Layout.cs
@@ -53,14 +53,45 @@ internal sealed partial class UserInterfaceManager
             }
         }
 
-        public void Popup(string contents, string title = "Alert!")
+        public void Popup(string contents, string title = "Alert!", string clipboardButton = "Copy")
         {
             var popup = new DefaultWindow
             {
-                Title = title
+                Title = title,
             };
 
-            popup.Contents.AddChild(new Label {Text = contents});
+            var label = new Label { Text = contents };
+            var copyButton = new Button
+            {
+                Text = clipboardButton,
+                MinSize = new Vector2(100, 30),
+            };
+
+            copyButton.OnPressed += _ =>
+            {
+                _clipboard.SetText(contents);
+            };
+
+            var grid = new GridContainer
+            {
+                Columns = 1,
+                VSeparationOverride = 10,
+            };
+
+            grid.AddChild(label);
+
+            var buttonContainer = new GridContainer
+            {
+                Columns = 2,
+                HSeparationOverride = 10,
+            };
+
+            buttonContainer.AddChild(copyButton);
+
+            grid.AddChild(buttonContainer);
+
+            popup.Contents.AddChild(grid);
+
             popup.OpenCentered();
         }
 

--- a/Robust.Client/UserInterface/UserInterfaceManager.Layout.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Layout.cs
@@ -53,44 +53,55 @@ internal sealed partial class UserInterfaceManager
             }
         }
 
-        public void Popup(string contents, string title = "Alert!", string clipboardButton = "Copy")
+        public void Popup(string contents, string title = "Alert!", bool clipboardButton = true)
         {
             var popup = new DefaultWindow
             {
-                Title = title,
+                Title = title
             };
 
             var label = new Label { Text = contents };
-            var copyButton = new Button
+
+            // Create a vertical box container to stack the elements vertically
+            var vBox = new BoxContainer
             {
-                Text = clipboardButton,
-                MinSize = new Vector2(100, 30),
+                Orientation = BoxContainer.LayoutOrientation.Vertical
             };
 
-            copyButton.OnPressed += _ =>
+            vBox.AddChild(label);
+
+            if (clipboardButton)
             {
-                _clipboard.SetText(contents);
-            };
+                var copyButton = new Button
+                {
+                    Text = "Copy",
+                    MinSize = new Vector2(100, 30)
+                };
 
-            var grid = new GridContainer
-            {
-                Columns = 1,
-                VSeparationOverride = 10,
-            };
+                copyButton.OnPressed += _ =>
+                {
+                    _clipboard.SetText(contents);
+                };
 
-            grid.AddChild(label);
+                // Create a horizontal box container to align the button to the right
+                var hBox = new BoxContainer
+                {
+                    Orientation = BoxContainer.LayoutOrientation.Horizontal
+                };
 
-            var buttonContainer = new GridContainer
-            {
-                Columns = 2,
-                HSeparationOverride = 10,
-            };
+                var spacer = new Control
+                {
+                    MinSize = new Vector2(0, 30), // This will grow to take available space
+                    HorizontalExpand = true
+                };
 
-            buttonContainer.AddChild(copyButton);
+                hBox.AddChild(spacer); // Spacer to push the button to the right
+                hBox.AddChild(copyButton);
 
-            grid.AddChild(buttonContainer);
+                vBox.AddChild(hBox); // Add the horizontal box to the vertical box
+            }
 
-            popup.Contents.AddChild(grid);
+            popup.Contents.AddChild(vBox); // Add the vertical box to the popup
 
             popup.OpenCentered();
         }

--- a/Robust.Client/UserInterface/UserInterfaceManager.Layout.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Layout.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared.Localization;
 using Robust.Shared.Log;
 using Robust.Shared.Maths;
 using Robust.Shared.Profiling;
@@ -53,19 +54,18 @@ internal sealed partial class UserInterfaceManager
             }
         }
 
-        public void Popup(string contents, string title = "Alert!", bool clipboardButton = true)
+        public void Popup(string contents, string? title = null, bool clipboardButton = true)
         {
             var popup = new DefaultWindow
             {
-                Title = title
+                Title = string.IsNullOrEmpty(title) ? Loc.GetString("popup-title") : title,
             };
 
             var label = new Label { Text = contents };
 
-            // Create a vertical box container to stack the elements vertically
             var vBox = new BoxContainer
             {
-                Orientation = BoxContainer.LayoutOrientation.Vertical
+                Orientation = BoxContainer.LayoutOrientation.Vertical,
             };
 
             vBox.AddChild(label);
@@ -74,8 +74,8 @@ internal sealed partial class UserInterfaceManager
             {
                 var copyButton = new Button
                 {
-                    Text = "Copy",
-                    MinSize = new Vector2(100, 30)
+                    Text = Loc.GetString("popup-copy-button"),
+                    HorizontalExpand = true,
                 };
 
                 copyButton.OnPressed += _ =>
@@ -83,25 +83,17 @@ internal sealed partial class UserInterfaceManager
                     _clipboard.SetText(contents);
                 };
 
-                // Create a horizontal box container to align the button to the right
                 var hBox = new BoxContainer
                 {
-                    Orientation = BoxContainer.LayoutOrientation.Horizontal
+                    Orientation = BoxContainer.LayoutOrientation.Horizontal,
+                    HorizontalAlignment = Control.HAlignment.Right,
                 };
 
-                var spacer = new Control
-                {
-                    MinSize = new Vector2(0, 30), // This will grow to take available space
-                    HorizontalExpand = true
-                };
-
-                hBox.AddChild(spacer); // Spacer to push the button to the right
                 hBox.AddChild(copyButton);
-
-                vBox.AddChild(hBox); // Add the horizontal box to the vertical box
+                vBox.AddChild(hBox);
             }
 
-            popup.Contents.AddChild(vBox); // Add the vertical box to the popup
+            popup.Contents.AddChild(vBox);
 
             popup.OpenCentered();
         }

--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -54,6 +54,7 @@ namespace Robust.Client.UserInterface
         [Dependency] private readonly IEntitySystemManager _systemManager = default!;
         [Dependency] private readonly ILogManager _logManager = default!;
         [Dependency] private readonly IRuntimeLog _runtime = default!;
+        [Dependency] private readonly IClipboardManager _clipboard = null!;
 
         private IAudioSource? _clickSource;
         private IAudioSource? _hoverSource;


### PR DESCRIPTION
This is my first RT PR, Apologies if have done any of this incorrectly.

Changes:
- Added copy button that stores UI alert message popups to clipboard. 

For fixing [this issue](https://github.com/space-wizards/space-station-14/issues/28560) about copying out ban messages but would be good for relaying connection issues and other errors shown here.

![image](https://github.com/user-attachments/assets/0442a1a9-e45d-4505-804e-5337d0dc3ff8)
