### PR TITLE
Fix replay teleportation command exception

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Fix some teleportation commands not working in singleplayer or replays
 
 ### Other
 

--- a/Robust.Shared/Console/Commands/TeleportCommands.cs
+++ b/Robust.Shared/Console/Commands/TeleportCommands.cs
@@ -145,7 +145,7 @@ public sealed class TeleportToCommand : LocalizedEntityCommands
             return true;
         }
 
-        if (_players.Sessions.TryFirstOrDefault(x => x.Channel.UserName == str, out var session)
+        if (_players.TryGetSessionByUsername(str, out var session)
             && _entities.TryGetComponent(session.AttachedEntity, out transform))
         {
             victimUid = session.AttachedEntity;


### PR DESCRIPTION
`Channel` is null on the client, so the LINQ query was throwing.