### PR TITLE
Add InterpolatedStringHandlerArgumentAttribute to sandbox whitelist

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Added `InterpolatedStringHandlerArgumentAttribute` to the sandbox whitelist.
 
 ### Bugfixes
 

--- a/Robust.Shared/ContentPack/Sandbox.yml
+++ b/Robust.Shared/ContentPack/Sandbox.yml
@@ -507,6 +507,7 @@ Types:
     IAsyncStateMachine: { All: True }
     InternalsVisibleToAttribute: { All: True }
     InterpolatedStringHandlerAttribute: { All: True }
+    InterpolatedStringHandlerArgumentAttribute: { All: True }
     IsByRefLikeAttribute: { All: True }
     IsExternalInit: { All: True }
     IsReadOnlyAttribute: { All: True }


### PR DESCRIPTION
AFAIK should be safe, and `InterpolatedStringHandlerAttribute` is already whitelisted.