### PR TITLE
Try and ensure that parents are always initialized before children

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -51,7 +51,7 @@ END TEMPLATE-->
 
 ### Internal
 
-*None yet*
+* `ClientGameStateManager` now only initialises or starts entities after their parents have already been initialized. There are also some new debug asserts to try ensure that this rule isn't broken elsewhere. 
 
 
 ## 229.1.1

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -81,6 +81,7 @@ namespace Robust.Server.GameObjects
             InitializeEntity(entity, meta);
         }
 
+        [Obsolete("Use StartEntity")]
         void IServerEntityManagerInternal.FinishEntityStartup(EntityUid entity)
         {
             StartEntity(entity);

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -110,6 +110,7 @@ namespace Robust.Shared.GameObjects
             return dict.Count;
         }
 
+        [Obsolete("Use InitializeEntity")]
         public void InitializeComponents(EntityUid uid, MetaDataComponent? metadata = null)
         {
             DebugTools.AssertOwner(uid, metadata);
@@ -145,6 +146,7 @@ namespace Robust.Shared.GameObjects
             SetLifeStage(metadata, EntityLifeStage.Initialized);
         }
 
+        [Obsolete("Use StartEntity")]
         public void StartComponents(EntityUid uid)
         {
             // Startup() can modify _components

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -864,15 +864,35 @@ namespace Robust.Shared.GameObjects
 
         public void InitializeEntity(EntityUid entity, MetaDataComponent? meta = null)
         {
+            // Ideally, entities only ever get initialized once their parent has already been initialized.
+            // Note that this doesn't guarantee that an uninitialized entity will never have initialized children.
+            // In particular, for the client this might happen when applying a new game state that re-parents an
+            // existing entity to a newly created entity. The new entity only gets initialiuzed & started at the end,
+            // after the old/existing entity was already moved to the new parent.
+            DebugTools.Assert(TransformQuery.GetComponent(entity).ParentUid is not { Valid: true } parent
+                || MetaQuery.GetComponent(parent).EntityLifeStage >= EntityLifeStage.Initialized);
+
             DebugTools.AssertOwner(entity, meta);
             meta ??= GetComponent<MetaDataComponent>(entity);
+#pragma warning disable CS0618 // Type or member is obsolete
             InitializeComponents(entity, meta);
+#pragma warning restore CS0618 // Type or member is obsolete
             EntityInitialized?.Invoke((entity, meta));
         }
 
         public void StartEntity(EntityUid entity)
         {
+            // Ideally, entities only ever get initialized once their parent has already been initialized.
+            // Note that this doesn't guarantee that an uninitialized entity will never have initialized children.
+            // In particular, for the client this might happen when applying a new game state that re-parents an
+            // existing entity to a newly created entity. The new entity only gets initialiuzed & started at the end,
+            // after the old/existing entity was already moved to the new parent.
+            DebugTools.Assert(TransformQuery.GetComponent(entity).ParentUid is not { Valid: true } parent
+                              || MetaQuery.GetComponent(parent).EntityLifeStage >= EntityLifeStage.Initialized);
+
+#pragma warning disable CS0618 // Type or member is obsolete
             StartComponents(entity);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public void RunMapInit(EntityUid entity, MetaDataComponent meta)

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -22,11 +22,13 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         ///     Calls Initialize() on all registered components of the entity.
         /// </summary>
+        [Obsolete("Use InitializeEntity")]
         void InitializeComponents(EntityUid uid, MetaDataComponent? meta = null);
 
         /// <summary>
         ///     Calls Startup() on all registered components of the entity.
         /// </summary>
+        [Obsolete("Use StartEntity")]
         void StartComponents(EntityUid uid);
 
         /// <summary>


### PR DESCRIPTION
This PR adds some debug asserts to check that entities only get initialized/started after their parents, and changes `ClientGameStateManager` so that follows that rule while creating new entities.