### PR TITLE
Add cvar to limit entities passed into nearby command

### DIFF
--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1776,5 +1776,12 @@ namespace Robust.Shared
         /// </summary>
         public static readonly CVarDef<int> ToolshedNearbyLimit =
             CVarDef.Create("toolshed.nearby_limit", 200, CVar.SERVER | CVar.REPLICATED);
+
+        /// <summary>
+        ///     The max amount of entities that can be passed to the nearby toolshed command.
+        ///     Any higher value will cause an exception.
+        /// </summary>
+        public static readonly CVarDef<int> ToolshedNearbyEntitiesLimit =
+            CVarDef.Create("toolshed.nearby_entities_limit", 5, CVar.SERVER | CVar.REPLICATED);
     }
 }

--- a/Robust.Shared/Toolshed/Commands/Entities/NearbyCommand.cs
+++ b/Robust.Shared/Toolshed/Commands/Entities/NearbyCommand.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Toolshed.Commands.Entities;
 
@@ -21,9 +22,13 @@ internal sealed class NearbyCommand : ToolshedCommand
             [CommandArgument] float range
         )
     {
-        var limit = _cfg.GetCVar(CVars.ToolshedNearbyLimit);
-        if (range > limit)
-            throw new ArgumentException($"Tried to query too many entities with nearby ({range})! Limit: {limit}. Change the {CVars.ToolshedNearbyLimit.Name} cvar to increase this at your own risk.");
+        var entitiesLimit = _cfg.GetCVar(CVars.ToolshedNearbyEntitiesLimit);
+        if (input.HasMoreThan(entitiesLimit))
+            throw new ArgumentException($"Too many entities were passed to nearby ({range})! Limit: {entitiesLimit}. Change the {CVars.ToolshedNearbyEntitiesLimit.Name} cvar to increase this at your own risk.");
+
+        var rangeLimit = _cfg.GetCVar(CVars.ToolshedNearbyLimit);
+        if (range > rangeLimit)
+            throw new ArgumentException($"Tried to query too big of a range with nearby ({range})! Limit: {rangeLimit}. Change the {CVars.ToolshedNearbyLimit.Name} cvar to increase this at your own risk.");
 
         _lookup ??= GetSys<EntityLookupSystem>();
         return input.SelectMany(x => _lookup.GetEntitiesInRange(x, range)).Distinct();

--- a/Robust.Shared/Toolshed/Commands/Entities/NearbyCommand.cs
+++ b/Robust.Shared/Toolshed/Commands/Entities/NearbyCommand.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
-using Robust.Shared.Utility;
 
 namespace Robust.Shared.Toolshed.Commands.Entities;
 
@@ -22,15 +21,24 @@ internal sealed class NearbyCommand : ToolshedCommand
             [CommandArgument] float range
         )
     {
-        var entitiesLimit = _cfg.GetCVar(CVars.ToolshedNearbyEntitiesLimit);
-        if (input.HasMoreThan(entitiesLimit))
-            throw new ArgumentException($"Too many entities were passed to nearby ({range})! Limit: {entitiesLimit}. Change the {CVars.ToolshedNearbyEntitiesLimit.Name} cvar to increase this at your own risk.");
-
         var rangeLimit = _cfg.GetCVar(CVars.ToolshedNearbyLimit);
         if (range > rangeLimit)
             throw new ArgumentException($"Tried to query too big of a range with nearby ({range})! Limit: {rangeLimit}. Change the {CVars.ToolshedNearbyLimit.Name} cvar to increase this at your own risk.");
 
         _lookup ??= GetSys<EntityLookupSystem>();
-        return input.SelectMany(x => _lookup.GetEntitiesInRange(x, range)).Distinct();
+
+        var i = 0;
+        var entitiesLimit = _cfg.GetCVar(CVars.ToolshedNearbyEntitiesLimit);
+        return input.SelectMany(x =>
+            {
+                if (i++ > entitiesLimit)
+                {
+                    throw new ArgumentException(
+                        $"Too many entities were passed to nearby ({i})! Limit: {entitiesLimit}. Change the {CVars.ToolshedNearbyEntitiesLimit.Name} cvar to increase this at your own risk.");
+                }
+
+                return _lookup.GetEntitiesInRange(x, range);
+            })
+            .Distinct();
     }
 }

--- a/Robust.Shared/Utility/CollectionExtensions.cs
+++ b/Robust.Shared/Utility/CollectionExtensions.cs
@@ -283,24 +283,5 @@ namespace Robust.Shared.Utility
             value = default;
             return false;
         }
-
-        public static bool HasMoreThan<T>(this IEnumerable<T> enumerable, int than)
-        {
-            if (enumerable.TryGetNonEnumeratedCount(out var count))
-                return count > than;
-
-            using var enumerator = enumerable.GetEnumerator();
-            checked
-            {
-                while (enumerator.MoveNext())
-                {
-                    than--;
-                    if (than < 0)
-                        return true;
-                }
-            }
-
-            return false;
-        }
     }
 }

--- a/Robust.Shared/Utility/CollectionExtensions.cs
+++ b/Robust.Shared/Utility/CollectionExtensions.cs
@@ -283,5 +283,24 @@ namespace Robust.Shared.Utility
             value = default;
             return false;
         }
+
+        public static bool HasMoreThan<T>(this IEnumerable<T> enumerable, int than)
+        {
+            if (enumerable.TryGetNonEnumeratedCount(out var count))
+                return count > than;
+
+            using var enumerator = enumerable.GetEnumerator();
+            checked
+            {
+                while (enumerator.MoveNext())
+                {
+                    than--;
+                    if (than < 0)
+                        return true;
+                }
+            }
+
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Another day another one of my admins crashed rmc14
See https://github.com/space-wizards/RobustToolbox/pull/5282 for reasoning
Default 5 (you are usually doing self nearby not entities nearby which was the problem)