### PR TITLE
Make overlay manager accept multiple overlays of the same type

### DIFF
--- a/Robust.Client/Graphics/Overlays/IOverlayManager.cs
+++ b/Robust.Client/Graphics/Overlays/IOverlayManager.cs
@@ -22,6 +22,7 @@ public interface IOverlayManager
 
     bool HasOverlay(Type overlayClass);
     bool HasOverlay<T>() where T : Overlay;
+    bool HasOverlay(Overlay overlay);
 
     IEnumerable<Overlay> AllOverlays { get; }
 }


### PR DESCRIPTION
This can be really necessary for some use cases, I personally run into such limitation of the OverlayManager and it is almost impossible to completely bypass without changing the engine. This change does not introduce any breaking changes and does not spoil performance.
