### PR TITLE
Fix loadprototype

### DIFF
--- a/Robust.Server/BaseServer.cs
+++ b/Robust.Server/BaseServer.cs
@@ -104,6 +104,7 @@ namespace Robust.Server
         [Dependency] private readonly IComponentFactory _componentFactory = default!;
         [Dependency] private readonly IReplayRecordingManagerInternal _replay = default!;
         [Dependency] private readonly IGamePrototypeLoadManager _protoLoadMan = default!;
+        [Dependency] private readonly UploadedContentManager _uploadedContMan = default!;
         [Dependency] private readonly NetworkResourceManager _netResMan = default!;
         [Dependency] private readonly IReflectionManager _refMan = default!;
 
@@ -393,6 +394,7 @@ namespace Robust.Server
             _scriptHost.Initialize();
             _protoLoadMan.Initialize();
             _netResMan.Initialize();
+            _uploadedContMan.Initialize();
 
             // String serializer has to be locked before PostInit as content can depend on it (e.g., replays that start
             // automatically recording on startup).


### PR DESCRIPTION
The new manager from #5293 was never initialized, so just doing so fixed it

Fixes space-wizards/space-station-14#30602

## Steps to ensure it's working
1. Upload a prototype via `loadprototype`
2. Spawn the entity
3. Fully close the client
4. Launch it again
5. Connect
6. Either see an error or the custom entity