### PR TITLE
Fixes luminance underflow in FromHCY

### DIFF
--- a/Robust.Shared.Maths/Color.cs
+++ b/Robust.Shared.Maths/Color.cs
@@ -735,7 +735,7 @@ namespace Robust.Shared.Maths
                 b = 0.0f;
             }
 
-            var m = luminance - (0.30f * r + 0.59f * g + 0.11f * b);
+            var m = Math.Abs(luminance - (0.30f * r + 0.59f * g + 0.11f * b));
             return new Color(r + m, g + m, b + m, hcy.W);
         }
 

--- a/Robust.Shared.Maths/Color.cs
+++ b/Robust.Shared.Maths/Color.cs
@@ -735,8 +735,13 @@ namespace Robust.Shared.Maths
                 b = 0.0f;
             }
 
-            var m = Math.Abs(luminance - (0.30f * r + 0.59f * g + 0.11f * b));
-            return new Color(r + m, g + m, b + m, hcy.W);
+            var m = luminance - (0.30f * r + 0.59f * g + 0.11f * b);
+
+            var rN = Math.Max(r + m, 0);
+            var gN = Math.Max(g + m, 0);
+            var bN = Math.Max(b + m, 0);
+
+            return new Color(rN, gN, bN, hcy.W);
         }
 
         /// <summary>


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/f16fec42-84d8-4933-861c-369f46902696)


![image](https://github.com/user-attachments/assets/4e9aaf10-7c11-4fc3-801f-ee93a78668ff)

was working on OD was confused by the blue gradient then realized that the blue value was negative and this fixes that