### PR TITLE
 Fix RichTextLabel.Text property not setting _message if null

### DIFF
--- a/Robust.Client/UserInterface/Controls/RichTextLabel.cs
+++ b/Robust.Client/UserInterface/Controls/RichTextLabel.cs
@@ -44,9 +44,12 @@ namespace Robust.Client.UserInterface.Controls
             set
             {
                 if (value == null)
+                {
                     _message?.Clear();
-                else
-                    _message?.AddMarkupPermissive(value);
+                    return;
+                }
+
+                SetMessage(FormattedMessage.FromMarkupPermissive(value));
             }
         }
 


### PR DESCRIPTION
Small blunder in https://github.com/space-wizards/RobustToolbox/pull/5280 I did not realize that it doesn't get created on the constructor