### PR TITLE
Fixed client crash on devwindow inspect control's property which throws exception

### DIFF
--- a/Robust.Client/Console/Commands/Debug.cs
+++ b/Robust.Client/Console/Commands/Debug.cs
@@ -579,7 +579,16 @@ namespace Robust.Client.Console.Commands
         private static string GetMemberValue(MemberInfo? member, Control control, string separator, string
                 wrap = "{0}")
         {
-            var value = member?.GetValue(control);
+            object? value = null;
+            try
+            {
+                value = member?.GetValue(control);
+            }
+            catch (Exception exception)
+            {
+                var exceptionToPrint = exception.InnerException ?? exception;
+                value = $"{exceptionToPrint.GetType()}: {exceptionToPrint.Message}";
+            }
             var o = value switch
             {
                 ICollection<Control> controls => string.Join(separator,

--- a/Robust.Client/Console/Commands/Debug.cs
+++ b/Robust.Client/Console/Commands/Debug.cs
@@ -584,10 +584,14 @@ namespace Robust.Client.Console.Commands
             {
                 value = member?.GetValue(control);
             }
-            catch (Exception exception)
+            catch (TargetInvocationException exception)
             {
                 var exceptionToPrint = exception.InnerException ?? exception;
                 value = $"{exceptionToPrint.GetType()}: {exceptionToPrint.Message}";
+            }
+            catch (Exception exception)
+            {
+                value = $"{exception.GetType()}: {exception.Message}";
             }
             var o = value switch
             {


### PR DESCRIPTION
Some control properties even in engine itself (e.g. Label.Text) may throw exceptions. devwindow scans all properties and does not handle any exceptions, which leads to crash in case of one. I think this is not right for debugging purpuses, so I did that in such case exception just printed as a value of faulty property:

![](https://github.com/user-attachments/assets/d4a1f346-13ab-4cae-b7e7-cbbafb184488)
