### PR TITLE
Make resetting contacts on the client only set is touching if it is true

### DIFF
--- a/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
+++ b/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
@@ -31,8 +31,6 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Maths;
 using Robust.Shared.Physics.Collision;
 using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Physics.Components;
@@ -258,7 +256,9 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
             {
                 var manifold = Manifold;
                 Evaluate(ref manifold, bodyATransform, bodyBTransform);
-                IsTouching = manifold.PointCount > 0;
+
+                if (IsTouching)
+                    IsTouching = manifold.PointCount > 0;
             }
         }
 


### PR DESCRIPTION
For sloth to vibe check
Long story but making guns predicted leads to projectiles on the client not properly getting StartCollideEvent raised because resetcontacts blindly sets this to true and that makes physics never raise a start collide event because by the time it checks and it is true it has already been set to true by this