### PR TITLE
Fix LocalizedEntityCommands breaking content unit tests.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* `LocalizedEntityCommands` are now not initialized inside `RobustUnitTest`, fixing guaranteed test failures.
 
 ### Other
 

--- a/Robust.Shared/Console/EntityConsoleHost.cs
+++ b/Robust.Shared/Console/EntityConsoleHost.cs
@@ -21,9 +21,20 @@ internal sealed class EntityConsoleHost
 
     private readonly HashSet<string> _entityCommands = [];
 
+    /// <summary>
+    /// If disabled, don't automatically discover commands via reflection.
+    /// </summary>
+    /// <remarks>
+    /// This gets disabled in certain unit tests.
+    /// </remarks>
+    public bool DiscoverCommands { get; set; } = true;
+
     public void Startup()
     {
         DebugTools.Assert(_entityCommands.Count == 0);
+
+        if (!DiscoverCommands)
+            return;
 
         var deps = ((EntitySystemManager)_entitySystemManager).SystemDependencyCollection;
 

--- a/Robust.UnitTesting/RobustUnitTest.cs
+++ b/Robust.UnitTesting/RobustUnitTest.cs
@@ -10,6 +10,7 @@ using Robust.Server.GameStates;
 using Robust.Server.Physics;
 using Robust.Shared.ComponentTrees;
 using Robust.Shared.Configuration;
+using Robust.Shared.Console;
 using Robust.Shared.Containers;
 using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
@@ -164,6 +165,10 @@ namespace Robust.UnitTesting
 
             var entMan = deps.Resolve<IEntityManager>();
             var mapMan = deps.Resolve<IMapManager>();
+
+            // Avoid discovering EntityCommands since they may depend on systems
+            // that aren't available in a unit test context.
+            deps.Resolve<EntityConsoleHost>().DiscoverCommands = false;
 
             // Required components for the engine to work
             // Why are we still here? Just to suffer? Why can't we just use [RegisterComponent] magic?


### PR DESCRIPTION
They are now not loaded inside content unit tests.

Fixes #5374