### PR TITLE
Make pointlight setting use an attempt event

### DIFF
--- a/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
@@ -95,6 +95,15 @@ namespace Robust.Shared.GameObjects
         public string? MaskPath;
     }
 
+    /// <summary>
+    /// Raised directed on an entity when attempting to enable / disable it.
+    /// </summary>
+    [ByRefEvent]
+    public record struct AttemptPointLightToggleEvent(bool Enabled)
+    {
+        public bool Cancelled;
+    }
+
     public sealed class PointLightToggleEvent : EntityEventArgs
     {
         public bool Enabled;

--- a/Robust.Shared/GameObjects/Systems/SharedPointLightSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPointLightSystem.cs
@@ -42,6 +42,12 @@ public abstract class SharedPointLightSystem : EntitySystem
         if (!ResolveLight(uid, ref comp) || enabled == comp.Enabled)
             return;
 
+        var attempt = new AttemptPointLightToggleEvent(enabled);
+        RaiseLocalEvent(uid, ref attempt);
+
+        if (attempt.Cancelled)
+            return;
+
         comp.Enabled = enabled;
         RaiseLocalEvent(uid, new PointLightToggleEvent(comp.Enabled));
         if (!Resolve(uid, ref meta))


### PR DESCRIPTION
Makes it easy for content to add functionality if multiple things try to set it without having to funnel every piece of code through a content system.