### PR TITLE
- add: grid priority finding

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -254,6 +254,8 @@ public abstract partial class SharedMapSystem
                     "Can't modify chunk size of an existing grid.");
 
                 component.ChunkSize = delta.ChunkSize;
+                component.Priority = delta.Priority;
+
                 if (delta.ChunkData == null)
                     return;
 
@@ -273,6 +275,7 @@ public abstract partial class SharedMapSystem
 
                 component.LastTileModifiedTick = state.LastTileModifiedTick;
                 component.ChunkSize = state.ChunkSize;
+                component.Priority = state.Priority;
 
                 foreach (var index in component.Chunks.Keys)
                 {
@@ -420,7 +423,7 @@ public abstract partial class SharedMapSystem
             }
         }
 
-        args.State = new MapGridComponentDeltaState(component.ChunkSize, chunkData, component.LastTileModifiedTick);
+        args.State = new MapGridComponentDeltaState(component.ChunkSize, component.Priority, chunkData, component.LastTileModifiedTick);
 
 #if DEBUG
         if (chunkData == null)
@@ -456,7 +459,7 @@ public abstract partial class SharedMapSystem
             chunkData.Add(index, tileBuffer);
         }
 
-        args.State = new MapGridComponentState(component.ChunkSize, chunkData, component.LastTileModifiedTick);
+        args.State = new MapGridComponentState(component.ChunkSize, component.Priority, chunkData, component.LastTileModifiedTick);
 
 #if DEBUG
         foreach (var chunk in chunkData.Values)

--- a/Robust.Shared/Map/Components/MapGridComponent.cs
+++ b/Robust.Shared/Map/Components/MapGridComponent.cs
@@ -32,7 +32,7 @@ namespace Robust.Shared.Map.Components
         [DataField("chunkSize")] internal ushort ChunkSize = 16;
 
         // Used for priority think in query. Useful for Z grid leveling, while grid is vehicle etc.
-        [DataField] internal int Priority;
+        [DataField] internal bool Priority;
 
         [ViewVariables]
         public int ChunkCount => Chunks.Count;
@@ -338,7 +338,7 @@ namespace Robust.Shared.Map.Components
     ///     Serialized state of a <see cref="MapGridComponentState"/>.
     /// </summary>
     [Serializable, NetSerializable]
-    internal sealed class MapGridComponentState(ushort chunkSize,int priority, Dictionary<Vector2i, Tile[]> fullGridData, GameTick lastTileModifiedTick) : ComponentState
+    internal sealed class MapGridComponentState(ushort chunkSize,bool priority, Dictionary<Vector2i, Tile[]> fullGridData, GameTick lastTileModifiedTick) : ComponentState
     {
         /// <summary>
         ///     The size of the chunks in the map grid.
@@ -348,7 +348,7 @@ namespace Robust.Shared.Map.Components
         /// <summary>
         ///     The priority of grid <see cref="MapGridComponent.Priority"/>
         /// </summary>
-        public int Priority = priority;
+        public bool Priority = priority;
 
         /// <summary>
         /// Networked chunk data containing the full grid state.
@@ -365,7 +365,7 @@ namespace Robust.Shared.Map.Components
     ///     Serialized state of a <see cref="MapGridComponentState"/>.
     /// </summary>
     [Serializable, NetSerializable]
-    internal sealed class MapGridComponentDeltaState(ushort chunkSize,int priority, List<ChunkDatum>? chunkData, GameTick lastTileModifiedTick)
+    internal sealed class MapGridComponentDeltaState(ushort chunkSize,bool priority, List<ChunkDatum>? chunkData, GameTick lastTileModifiedTick)
         : ComponentState, IComponentDeltaState<MapGridComponentState>
     {
         /// <summary>
@@ -376,7 +376,7 @@ namespace Robust.Shared.Map.Components
         /// <summary>
         ///     The priority of grid <see cref="MapGridComponent.Priority"/>
         /// </summary>
-        public readonly int Priority = priority;
+        public readonly bool Priority = priority;
 
         /// <summary>
         /// Networked chunk data.

--- a/Robust.Shared/Map/Components/MapGridComponent.cs
+++ b/Robust.Shared/Map/Components/MapGridComponent.cs
@@ -31,6 +31,9 @@ namespace Robust.Shared.Map.Components
 
         [DataField("chunkSize")] internal ushort ChunkSize = 16;
 
+        // Used for priority think in query. Useful for Z grid leveling, while grid is vehicle etc.
+        [DataField] internal int Priority;
+
         [ViewVariables]
         public int ChunkCount => Chunks.Count;
 
@@ -335,12 +338,17 @@ namespace Robust.Shared.Map.Components
     ///     Serialized state of a <see cref="MapGridComponentState"/>.
     /// </summary>
     [Serializable, NetSerializable]
-    internal sealed class MapGridComponentState(ushort chunkSize, Dictionary<Vector2i, Tile[]> fullGridData, GameTick lastTileModifiedTick) : ComponentState
+    internal sealed class MapGridComponentState(ushort chunkSize,int priority, Dictionary<Vector2i, Tile[]> fullGridData, GameTick lastTileModifiedTick) : ComponentState
     {
         /// <summary>
         ///     The size of the chunks in the map grid.
         /// </summary>
         public ushort ChunkSize = chunkSize;
+
+        /// <summary>
+        ///     The priority of grid <see cref="MapGridComponent.Priority"/>
+        /// </summary>
+        public int Priority = priority;
 
         /// <summary>
         /// Networked chunk data containing the full grid state.
@@ -357,13 +365,18 @@ namespace Robust.Shared.Map.Components
     ///     Serialized state of a <see cref="MapGridComponentState"/>.
     /// </summary>
     [Serializable, NetSerializable]
-    internal sealed class MapGridComponentDeltaState(ushort chunkSize, List<ChunkDatum>? chunkData, GameTick lastTileModifiedTick)
+    internal sealed class MapGridComponentDeltaState(ushort chunkSize,int priority, List<ChunkDatum>? chunkData, GameTick lastTileModifiedTick)
         : ComponentState, IComponentDeltaState<MapGridComponentState>
     {
         /// <summary>
         ///     The size of the chunks in the map grid.
         /// </summary>
         public readonly ushort ChunkSize = chunkSize;
+
+        /// <summary>
+        ///     The priority of grid <see cref="MapGridComponent.Priority"/>
+        /// </summary>
+        public readonly int Priority = priority;
 
         /// <summary>
         /// Networked chunk data.
@@ -378,6 +391,7 @@ namespace Robust.Shared.Map.Components
         public void ApplyToFullState(MapGridComponentState state)
         {
             state.ChunkSize = ChunkSize;
+            state.Priority = Priority;
 
             if (ChunkData == null)
                 return;
@@ -403,7 +417,7 @@ namespace Robust.Shared.Map.Components
                 Array.Copy(value, arr, value.Length);
             }
 
-            var newState = new MapGridComponentState(ChunkSize, fullGridData, LastTileModifiedTick);
+            var newState = new MapGridComponentState(ChunkSize, Priority, fullGridData, LastTileModifiedTick);
             ApplyToFullState(newState);
             return newState;
         }

--- a/Robust.UnitTesting/Shared/GameObjects/EntityState_Tests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityState_Tests.cs
@@ -69,7 +69,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
                     new NetEntity(64),
                     new []
                     {
-                        new ComponentChange(0, new MapGridComponentDeltaState(16, chunkData: null, default), default)
+                        new ComponentChange(0, new MapGridComponentDeltaState(16, 0, chunkData: null, default), default)
                     }, default);
 
                 serializer.Serialize(stream, payload);

--- a/Robust.UnitTesting/Shared/GameObjects/EntityState_Tests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityState_Tests.cs
@@ -69,7 +69,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
                     new NetEntity(64),
                     new []
                     {
-                        new ComponentChange(0, new MapGridComponentDeltaState(16, 0, chunkData: null, default), default)
+                        new ComponentChange(0, new MapGridComponentDeltaState(16, false, chunkData: null, default), default)
                     }, default);
 
                 serializer.Serialize(stream, payload);


### PR DESCRIPTION
Add grid priority. Its useful for building vehicles from grids or somethink else.

https://github.com/user-attachments/assets/9375e0d9-3d5a-4702-9100-9e60d2f16c2a

By default its zero, and it doesn't affect performance.