### PR TITLE
Add decimal type to sandbox whitelist

### DIFF
--- a/Robust.Shared/ContentPack/Sandbox.yml
+++ b/Robust.Shared/ContentPack/Sandbox.yml
@@ -1054,6 +1054,7 @@ Types:
     DateTime: { All: True }
     DateTimeKind: { } # Enum
     DateTimeOffset: { All: True }
+    Decimal: { All: True }
     Delegate:
       Methods:
       - "System.Delegate Combine(System.Delegate, System.Delegate)"


### PR DESCRIPTION
I see no reason not to allow the use of System.Decimal type.
Looks like its supported by serialization system and everything, it just needs to be whitelisted.
if you are wondering how I got to this point in the first place, I just need to perform some precise operations on decimal numbers.