### PR TITLE
Heavily optimise entitylookup

### DIFF
--- a/Robust.Shared.Maths/Matrix3Helpers.cs
+++ b/Robust.Shared.Maths/Matrix3Helpers.cs
@@ -26,6 +26,13 @@ public static class Matrix3Helpers
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Box2Rotated TransformBounds(this Matrix3x2 refFromBox, Box2Rotated box)
+    {
+        var matty = Matrix3x2.Multiply(refFromBox, box.Transform);
+        return new Box2Rotated(Vector2.Transform(box.BottomLeft, matty), Vector2.Transform(box.TopRight, matty));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Box2 TransformBox(this Matrix3x2 refFromBox, Box2Rotated box)
     {
         return (box.Transform * refFromBox).TransformBox(box.Box);

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -97,12 +97,17 @@ public sealed partial class EntityLookupSystem
         _mapManager.FindGridsIntersecting(mapId, worldAABB, ref state,
             static (EntityUid uid, MapGridComponent _, ref EntityQueryState state) =>
             {
-                state.Lookup.AddEntitiesIntersecting(uid, state.Intersecting, state.Shape, state.Transform, state.Flags);
+                var localTransform = state.Physics.GetRelativePhysicsTransform(state.Transform, uid);
+                var localAabb = state.Shape.ComputeAABB(localTransform, 0);
+                state.Lookup.AddEntitiesIntersecting(uid, state.Intersecting, state.Shape, localAabb, state.Transform, state.Flags);
                 return true;
             }, approx: true, includeMap: false);
 
         var mapUid = _map.GetMapOrInvalid(mapId);
-        AddEntitiesIntersecting(mapUid, intersecting, shape, shapeTransform, flags);
+        var localTransform = state.Physics.GetRelativePhysicsTransform(state.Transform, mapUid);
+        var localAabb = state.Shape.ComputeAABB(localTransform, 0);
+
+        AddEntitiesIntersecting(mapUid, intersecting, shape, localAabb, shapeTransform, flags);
         AddContained(intersecting, flags);
     }
 
@@ -110,23 +115,18 @@ public sealed partial class EntityLookupSystem
         EntityUid lookupUid,
         HashSet<EntityUid> intersecting,
         IPhysShape shape,
-        Transform shapeTransform,
+        Box2 localAABB,
+        Transform localShapeTransform,
         LookupFlags flags,
         BroadphaseComponent? lookup = null)
     {
         if (!_broadQuery.Resolve(lookupUid, ref lookup))
             return;
 
-        var (_, lookupRot, lookupInvMatrix) = _transform.GetWorldPositionRotationInvMatrix(lookupUid);
-        var lookupTransform = new Transform(Vector2.Transform(shapeTransform.Position, lookupInvMatrix),
-            shapeTransform.Quaternion2D.Angle - lookupRot);
-
-        var localAABB = shape.ComputeAABB(lookupTransform, 0);
-
         var state = new EntityQueryState(
             intersecting,
             shape,
-            shapeTransform,
+            localShapeTransform,
             _fixtures,
             this,
             _physics,
@@ -167,7 +167,7 @@ public sealed partial class EntityLookupSystem
 
             if (!approx)
             {
-                var intersectingTransform = state.Physics.GetPhysicsTransform(value.Entity);
+                var intersectingTransform = state.Physics.GetLocalPhysicsTransform(value.Entity);
                 if (!state.Manifolds.TestOverlap(state.Shape, 0, value.Fixture.Shape, value.ChildIndex, state.Transform, intersectingTransform))
                 {
                     return true;
@@ -188,7 +188,7 @@ public sealed partial class EntityLookupSystem
                 return true;
             }
 
-            var intersectingTransform = state.Physics.GetPhysicsTransform(value);
+            var intersectingTransform = state.Physics.GetLocalPhysicsTransform(value);
 
             if (state.FixturesQuery.TryGetComponent(value, out var fixtures))
             {
@@ -248,7 +248,10 @@ public sealed partial class EntityLookupSystem
         _mapManager.FindGridsIntersecting(mapId, worldAABB, ref state,
             static (EntityUid uid, MapGridComponent _, ref AnyEntityQueryState state) =>
             {
-                if (state.Lookup.AnyEntitiesIntersecting(uid, state.Shape, state.Transform, state.Flags, ignored: state.Ignored))
+                var localTransform = state.Physics.GetRelativePhysicsTransform(state.Transform, uid);
+                var localAabb = state.Shape.ComputeAABB(localTransform, 0);
+
+                if (state.Lookup.AnyEntitiesIntersecting(uid, state.Shape, localAabb, state.Transform, state.Flags, ignored: state.Ignored))
                 {
                     state.Found = true;
                     return false;
@@ -260,7 +263,9 @@ public sealed partial class EntityLookupSystem
         if (!state.Found)
         {
             var mapUid = _map.GetMapOrInvalid(mapId);
-            state.Found = AnyEntitiesIntersecting(mapUid, shape, shapeTransform, flags, ignored);
+            var localTransform = state.Physics.GetRelativePhysicsTransform(state.Transform, mapUid);
+            var localAabb = state.Shape.ComputeAABB(localTransform, 0);
+            state.Found = AnyEntitiesIntersecting(mapUid, shape, localAabb, shapeTransform, flags, ignored);
         }
 
         return state.Found;
@@ -268,6 +273,7 @@ public sealed partial class EntityLookupSystem
 
     private bool AnyEntitiesIntersecting(EntityUid lookupUid,
         IPhysShape shape,
+        Box2 localAABB,
         Transform shapeTransform,
         LookupFlags flags,
         EntityUid? ignored = null,
@@ -286,15 +292,6 @@ public sealed partial class EntityLookupSystem
             _manifoldManager,
             _fixturesQuery,
             flags);
-
-        // Shape gets passed in via local terms
-        // Transform is in world terms
-        // Need to convert both back to lookup-local for AABB.
-        var (_, lookupRot, lookupInvMatrix) = _transform.GetWorldPositionRotationInvMatrix(lookupUid);
-        var lookupTransform = new Transform(Vector2.Transform(shapeTransform.Position, lookupInvMatrix),
-            shapeTransform.Quaternion2D.Angle - lookupRot);
-
-        var localAABB = shape.ComputeAABB(lookupTransform, 0);
 
         if ((flags & LookupFlags.Dynamic) != 0x0)
         {
@@ -341,7 +338,7 @@ public sealed partial class EntityLookupSystem
 
             if (!approx)
             {
-                var intersectingTransform = state.Physics.GetPhysicsTransform(value.Entity);
+                var intersectingTransform = state.Physics.GetLocalPhysicsTransform(value.Entity);
                 if (!state.Manifolds.TestOverlap(state.Shape, 0, value.Fixture.Shape, value.ChildIndex, state.Transform, intersectingTransform))
                 {
                     return true;
@@ -365,7 +362,7 @@ public sealed partial class EntityLookupSystem
                 return false;
             }
 
-            var intersectingTransform = state.Physics.GetPhysicsTransform(value);
+            var intersectingTransform = state.Physics.GetLocalPhysicsTransform(value);
 
             if (state.FixturesQuery.TryGetComponent(value, out var fixtures))
             {
@@ -408,11 +405,13 @@ public sealed partial class EntityLookupSystem
         LookupFlags flags,
         EntityUid? ignored = null)
     {
-        var shape = new PolygonShape();
-        shape.Set(worldBounds);
-        var transform = Physics.Transform.Empty;
+        var broadphaseInv = _transform.GetInvWorldMatrix(lookupUid);
 
-        return AnyEntitiesIntersecting(lookupUid, shape, transform, flags, ignored);
+        var localBounds = broadphaseInv.TransformBounds(worldBounds);
+        var shape = new PolygonShape();
+        shape.Set(localBounds);
+
+        return AnyEntitiesIntersecting(lookupUid, shape, localBounds.CalcBoundingBox(), Physics.Transform.Empty, flags, ignored);
     }
 
     #endregion
@@ -549,22 +548,37 @@ public sealed partial class EntityLookupSystem
         // Get grid entities
         var shape = new PolygonShape();
         shape.Set(worldBounds);
+        var transform = Physics.Transform.Empty;
 
-        var state = (this, intersecting, shape, flags);
+        var state = (this, _physics, intersecting, transform, shape, flags);
 
-        _mapManager.FindGridsIntersecting(mapUid, shape, Physics.Transform.Empty, ref state, static
-        (EntityUid uid, MapGridComponent _,
-            ref (EntityLookupSystem lookup,
-                HashSet<EntityUid> intersecting,
-                PolygonShape shape,
-                LookupFlags flags) tuple) =>
-        {
-            tuple.lookup.AddEntitiesIntersecting(uid, tuple.intersecting, tuple.shape, Physics.Transform.Empty, tuple.flags);
-            return true;
-        }, approx: true, includeMap: false);
+        _mapManager.FindGridsIntersecting(mapUid, shape, transform, ref state,
+            static (
+                EntityUid uid,
+                MapGridComponent grid,
+                ref (EntityLookupSystem lookup,
+                    SharedPhysicsSystem _physics,
+                    HashSet<EntityUid> intersecting,
+                    Transform transform,
+                    PolygonShape shape, LookupFlags flags) state) =>
+            {
+                var localTransform = state._physics.GetRelativePhysicsTransform(state.transform, uid);
+                var localAabb = state.shape.ComputeAABB(localTransform, 0);
+
+                state.lookup.AddEntitiesIntersecting(uid,
+                    state.intersecting,
+                    state.shape,
+                    localAabb,
+                    state.transform,
+                    state.flags);
+                return true;
+            });
 
         // Get map entities
-        AddEntitiesIntersecting(mapUid, intersecting, shape, Physics.Transform.Empty, flags);
+        var localTransform = _physics.GetRelativePhysicsTransform(transform, mapUid);
+        var localAabb = shape.ComputeAABB(localTransform, 0);
+
+        AddEntitiesIntersecting(mapUid, intersecting, shape, localAabb, transform, flags);
         AddContained(intersecting, flags);
 
         return intersecting;
@@ -591,19 +605,24 @@ public sealed partial class EntityLookupSystem
         var circle = new PhysShapeCircle(range, mapPos.Position);
 
         const bool found = false;
-        var state = (this, worldAABB, circle, flags, found, uid);
+        var transform = Physics.Transform.Empty;
+        var state = (this, _physics, transform, circle, flags, found, uid);
 
         _mapManager.FindGridsIntersecting(mapPos.MapId, worldAABB, ref state, static (
             EntityUid gridUid,
             MapGridComponent _, ref (
                 EntityLookupSystem lookup,
-                Box2 worldAABB,
+                SharedPhysicsSystem physics,
+                Transform worldTransform,
                 PhysShapeCircle circle,
                 LookupFlags flags,
                 bool found,
                 EntityUid ignored) tuple) =>
         {
-            if (tuple.lookup.AnyEntitiesIntersecting(gridUid, tuple.circle, Physics.Transform.Empty, tuple.flags, tuple.ignored))
+            var localTransform = tuple.physics.GetRelativePhysicsTransform(tuple.worldTransform, gridUid);
+            var localAabb = tuple.circle.ComputeAABB(localTransform, 0);
+
+            if (tuple.lookup.AnyEntitiesIntersecting(gridUid, tuple.circle, localAabb, localTransform, tuple.flags, tuple.ignored))
             {
                 tuple.found = true;
                 return false;
@@ -618,7 +637,10 @@ public sealed partial class EntityLookupSystem
         }
 
         var mapUid = _map.GetMapOrInvalid(mapPos.MapId);
-        return AnyEntitiesIntersecting(mapUid, circle, Physics.Transform.Empty, flags, uid);
+        var localTransform = _physics.GetRelativePhysicsTransform(transform, uid);
+        var localAabb = circle.ComputeAABB(localTransform, 0);
+
+        return AnyEntitiesIntersecting(mapUid, circle, localAabb, localTransform, flags, uid);
     }
 
     public HashSet<EntityUid> GetEntitiesInRange(EntityUid uid, float range, LookupFlags flags = DefaultFlags)
@@ -656,15 +678,16 @@ public sealed partial class EntityLookupSystem
         var worldAABB = GetAABBNoContainer(uid, worldPos, worldRot);
         var existing = intersecting.Contains(uid);
         var transform = new Transform(worldPos, worldRot);
-        var state = (uid, transform, intersecting, _fixturesQuery, this, flags);
+
+        var state = (uid, transform, intersecting, _fixturesQuery, this, _physics, flags);
 
         // Unfortuantely I can't think of a way to de-dupe this with the other ones as it's slightly different.
         _mapManager.FindGridsIntersecting(mapId, worldAABB, ref state,
             static (EntityUid gridUid, MapGridComponent grid,
                 ref (EntityUid entity, Transform transform, HashSet<EntityUid> intersecting,
-                    EntityQuery<FixturesComponent> fixturesQuery, EntityLookupSystem lookup, LookupFlags flags) tuple) =>
+                    EntityQuery<FixturesComponent> fixturesQuery, EntityLookupSystem lookup, SharedPhysicsSystem physics, LookupFlags flags) state) =>
             {
-                EntityIntersectingQuery(gridUid, tuple);
+                EntityIntersectingQuery(gridUid, state);
 
                 return true;
             }, approx: true, includeMap: false);
@@ -681,24 +704,29 @@ public sealed partial class EntityLookupSystem
         return;
 
         static void EntityIntersectingQuery(EntityUid lookupUid, (EntityUid entity, Transform shapeTransform, HashSet<EntityUid> intersecting,
-            EntityQuery<FixturesComponent> fixturesQuery, EntityLookupSystem lookup, LookupFlags flags) tuple)
+            EntityQuery<FixturesComponent> fixturesQuery, EntityLookupSystem lookup, SharedPhysicsSystem physics, LookupFlags flags) state)
         {
-            if (tuple.fixturesQuery.TryGetComponent(tuple.entity, out var fixturesComp))
+            var localTransform = state.physics.GetRelativePhysicsTransform(state.shapeTransform, lookupUid);
+
+            if (state.fixturesQuery.TryGetComponent(state.entity, out var fixturesComp))
             {
                 foreach (var fixture in fixturesComp.Fixtures.Values)
                 {
                     // If our own fixture isn't hard and sensors ignored then ignore it.
-                    if (!fixture.Hard && (tuple.flags & LookupFlags.Sensors) == 0x0)
+                    if (!fixture.Hard && (state.flags & LookupFlags.Sensors) == 0x0)
                         continue;
 
-                    tuple.lookup.AddEntitiesIntersecting(lookupUid, tuple.intersecting, fixture.Shape, tuple.shapeTransform, tuple.flags);
+                    var localAabb = fixture.Shape.ComputeAABB(localTransform, 0);
+                    state.lookup.AddEntitiesIntersecting(lookupUid, state.intersecting, fixture.Shape, localAabb, localTransform, state.flags);
                 }
             }
             // Single point check
             else
             {
                 var shape = new PhysShapeCircle(LookupEpsilon);
-                tuple.lookup.AddEntitiesIntersecting(lookupUid, tuple.intersecting, shape, tuple.shapeTransform, tuple.flags);
+                var localAabb = shape.ComputeAABB(localTransform, 0);
+
+                state.lookup.AddEntitiesIntersecting(lookupUid, state.intersecting, shape, localAabb, localTransform, state.flags);
             }
         }
     }
@@ -840,10 +868,11 @@ public sealed partial class EntityLookupSystem
         if (!_broadQuery.TryGetComponent(gridId, out var lookup))
             return;
 
+        var localAABB = _transform.GetInvWorldMatrix(gridId).TransformBox(worldAABB);
         var shape = new PolygonShape();
-        shape.SetAsBox(worldAABB);
+        shape.SetAsBox(localAABB);
 
-        AddEntitiesIntersecting(gridId, intersecting, shape, Physics.Transform.Empty, flags, lookup);
+        AddEntitiesIntersecting(gridId, intersecting, shape, localAABB, Physics.Transform.Empty, flags, lookup);
         AddContained(intersecting, flags);
     }
 
@@ -852,10 +881,11 @@ public sealed partial class EntityLookupSystem
         if (!_broadQuery.TryGetComponent(gridId, out var lookup))
             return;
 
+        var localBounds = _transform.GetInvWorldMatrix(gridId).TransformBounds(worldBounds);
         var shape = new PolygonShape();
-        shape.Set(worldBounds);
+        shape.Set(localBounds);
 
-        AddEntitiesIntersecting(gridId, intersecting, shape, Physics.Transform.Empty, flags, lookup);
+        AddEntitiesIntersecting(gridId, intersecting, shape, localBounds.CalcBoundingBox(), Physics.Transform.Empty, flags, lookup);
         AddContained(intersecting, flags);
     }
 

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -99,7 +99,7 @@ public sealed partial class EntityLookupSystem
             {
                 var localTransform = state.Physics.GetRelativePhysicsTransform(state.Transform, uid);
                 var localAabb = state.Shape.ComputeAABB(localTransform, 0);
-                state.Lookup.AddEntitiesIntersecting(uid, state.Intersecting, state.Shape, localAabb, state.Transform, state.Flags);
+                state.Lookup.AddEntitiesIntersecting(uid, state.Intersecting, state.Shape, localAabb, localTransform, state.Flags);
                 return true;
             }, approx: true, includeMap: false);
 
@@ -107,7 +107,7 @@ public sealed partial class EntityLookupSystem
         var localTransform = state.Physics.GetRelativePhysicsTransform(state.Transform, mapUid);
         var localAabb = state.Shape.ComputeAABB(localTransform, 0);
 
-        AddEntitiesIntersecting(mapUid, intersecting, shape, localAabb, shapeTransform, flags);
+        AddEntitiesIntersecting(mapUid, intersecting, shape, localAabb, localTransform, flags);
         AddContained(intersecting, flags);
     }
 

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.ComponentQueries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.ComponentQueries.cs
@@ -121,17 +121,8 @@ public sealed partial class EntityLookupSystem
         if (!_broadQuery.Resolve(lookupUid, ref lookup))
             return;
 
-        PolygonShape lookupPoly;
-
-        if ((flags & LookupFlags.Approximate) == 0x0)
-        {
-            lookupPoly = new PolygonShape();
-            lookupPoly.SetAsBox(localAABB);
-        }
-        else
-        {
-            lookupPoly = _dummy;
-        }
+        var lookupPoly = new PolygonShape();
+        lookupPoly.SetAsBox(localAABB);
 
         AddEntitiesIntersecting(lookupUid, intersecting, lookupPoly, localAABB, Physics.Transform.Empty, flags, query, lookup);
     }

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.ComponentQueries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.ComponentQueries.cs
@@ -121,19 +121,27 @@ public sealed partial class EntityLookupSystem
         if (!_broadQuery.Resolve(lookupUid, ref lookup))
             return;
 
-        var lookupPoly = new PolygonShape();
-        lookupPoly.SetAsBox(localAABB);
-        var (lookupPos, lookupRot) = _transform.GetWorldPositionRotation(lookupUid);
-        var transform = new Transform(lookupPos, lookupRot);
+        PolygonShape lookupPoly;
 
-        AddEntitiesIntersecting(lookupUid, intersecting, lookupPoly, transform, flags, query, lookup);
+        if ((flags & LookupFlags.Approximate) == 0x0)
+        {
+            lookupPoly = new PolygonShape();
+            lookupPoly.SetAsBox(localAABB);
+        }
+        else
+        {
+            lookupPoly = _dummy;
+        }
+
+        AddEntitiesIntersecting(lookupUid, intersecting, lookupPoly, localAABB, Physics.Transform.Empty, flags, query, lookup);
     }
 
     private void AddEntitiesIntersecting<T>(
         EntityUid lookupUid,
         HashSet<Entity<T>> intersecting,
         IPhysShape shape,
-        Transform shapeTransform,
+        Box2 localAABB,
+        Transform localTransform,
         LookupFlags flags,
         EntityQuery<T> query,
         BroadphaseComponent? lookup = null) where T : IComponent
@@ -141,19 +149,10 @@ public sealed partial class EntityLookupSystem
         if (!_broadQuery.Resolve(lookupUid, ref lookup))
             return;
 
-        // Shape gets passed in via local terms
-        // Transform is in world terms
-        // Need to convert both back to lookup-local for AABB.
-        var (_, lookupRot, lookupInvMatrix) = _transform.GetWorldPositionRotationInvMatrix(lookupUid);
-        var lookupTransform = new Transform(Vector2.Transform(shapeTransform.Position, lookupInvMatrix),
-            shapeTransform.Quaternion2D.Angle - lookupRot);
-
-        var localAABB = shape.ComputeAABB(lookupTransform, 0);
-
         var state = new QueryState<T>(
             intersecting,
             shape,
-            shapeTransform,
+            localTransform,
             _fixtures,
             _physics,
             _manifoldManager,
@@ -195,7 +194,7 @@ public sealed partial class EntityLookupSystem
 
             if (!state.Approximate)
             {
-                var intersectingTransform = state.Physics.GetPhysicsTransform(value.Entity);
+                var intersectingTransform = state.Physics.GetLocalPhysicsTransform(value.Entity);
                 if (!state.Manifolds.TestOverlap(state.Shape, 0, value.Fixture.Shape, value.ChildIndex, state.Transform, intersectingTransform))
                 {
                     return true;
@@ -217,7 +216,7 @@ public sealed partial class EntityLookupSystem
                 return true;
             }
 
-            var intersectingTransform = state.Physics.GetPhysicsTransform(value);
+            var intersectingTransform = state.Physics.GetLocalPhysicsTransform(value);
 
             if (state.FixturesQuery.TryGetComponent(value, out var fixtures))
             {
@@ -266,12 +265,13 @@ public sealed partial class EntityLookupSystem
         var (lookupPos, lookupRot) = _transform.GetWorldPositionRotation(lookupUid);
         var transform = new Transform(lookupPos, lookupRot);
 
-        return AnyComponentsIntersecting(lookupUid, shape, transform, flags, query, ignored, lookup);
+        return AnyComponentsIntersecting(lookupUid, shape, localAABB, transform, flags, query, ignored, lookup);
     }
 
     private bool AnyComponentsIntersecting<T>(
         EntityUid lookupUid,
         IPhysShape shape,
+        Box2 localAABB,
         Transform shapeTransform,
         LookupFlags flags,
         EntityQuery<T> query,
@@ -285,12 +285,6 @@ public sealed partial class EntityLookupSystem
 
         if (!_broadQuery.Resolve(lookupUid, ref lookup))
             return false;
-
-        var (_, lookupRot, lookupInvMatrix) = _transform.GetWorldPositionRotationInvMatrix(lookupUid);
-        var lookupTransform = new Transform(Vector2.Transform(shapeTransform.Position, lookupInvMatrix),
-            shapeTransform.Quaternion2D.Angle - lookupRot);
-
-        var localAABB = shape.ComputeAABB(lookupTransform, 0);
 
         var state = new AnyQueryState<T>(false,
             ignored,
@@ -554,17 +548,22 @@ public sealed partial class EntityLookupSystem
             var query = EntityManager.GetEntityQuery(type);
 
             // Get grid entities
-            var state = new GridQueryState<IComponent>(intersecting, shape, shapeTransform, this, flags, query);
+            var state = new GridQueryState<IComponent>(intersecting, shape, shapeTransform, this, _physics, flags, query);
 
             _mapManager.FindGridsIntersecting(mapId, worldAABB, ref state,
                 static (EntityUid uid, MapGridComponent grid, ref GridQueryState<IComponent> state) =>
                 {
-                    state.Lookup.AddEntitiesIntersecting(uid, state.Intersecting, state.Shape, state.Transform, state.Flags, state.Query);
+                    var localTransform = state.Physics.GetRelativePhysicsTransform(state.Transform, uid);
+                    var localAabb = state.Shape.ComputeAABB(localTransform, 0);
+                    state.Lookup.AddEntitiesIntersecting(uid, state.Intersecting, state.Shape, localAabb, state.Transform, state.Flags, state.Query);
                     return true;
                 }, approx: true, includeMap: false);
 
             var mapUid = _map.GetMapOrInvalid(mapId);
-            AddEntitiesIntersecting(mapUid, intersecting, shape, shapeTransform, flags, query);
+            var localTransform = state.Physics.GetRelativePhysicsTransform(state.Transform, mapUid);
+            var localAabb = state.Shape.ComputeAABB(localTransform, 0);
+
+            AddEntitiesIntersecting(mapUid, intersecting, shape, localAabb, shapeTransform, flags, query);
 
             AddContained(intersecting, flags, query);
         }
@@ -593,19 +592,23 @@ public sealed partial class EntityLookupSystem
             var query = GetEntityQuery<T>();
 
             // Get grid entities
-            var state = new GridQueryState<T>(entities, shape, shapeTransform, this, flags, query);
+            var state = new GridQueryState<T>(entities, shape, shapeTransform, this, _physics, flags, query);
 
             _mapManager.FindGridsIntersecting(mapId, worldAABB, ref state,
                 static (EntityUid uid, MapGridComponent grid, ref GridQueryState<T> state) =>
                 {
-                    state.Lookup.AddEntitiesIntersecting(uid, state.Intersecting, state.Shape, state.Transform, state.Flags, state.Query);
+                    var localTransform = state.Physics.GetRelativePhysicsTransform(state.Transform, uid);
+                    var localAabb = state.Shape.ComputeAABB(localTransform, 0);
+                    state.Lookup.AddEntitiesIntersecting(uid, state.Intersecting, state.Shape, localAabb, state.Transform, state.Flags, state.Query);
                     return true;
                 }, approx: true, includeMap: false);
 
             // Get map entities
             var mapUid = _map.GetMapOrInvalid(mapId);
-            AddEntitiesIntersecting(mapUid, entities, shape, shapeTransform, flags, query);
+            var localTransform = state.Physics.GetRelativePhysicsTransform(state.Transform, mapUid);
+            var localAabb = state.Shape.ComputeAABB(localTransform, 0);
 
+            AddEntitiesIntersecting(mapUid, entities, shape, localAabb, shapeTransform, flags, query);
             AddContained(entities, flags, query);
         }
     }
@@ -778,6 +781,20 @@ public sealed partial class EntityLookupSystem
         AddContained(intersecting, flags, query);
     }
 
+    /// <summary>
+    /// Gets the entities intersecting the specified broadphase entity using a local AABB.
+    /// </summary>
+    public void GetLocalEntitiesIntersecting<T>(
+        Entity<BroadphaseComponent> grid,
+        Box2 localAABB,
+        HashSet<Entity<T>> intersecting,
+        EntityQuery<T> query,
+        LookupFlags flags = DefaultFlags) where T : IComponent
+    {
+        AddLocalEntitiesIntersecting(grid, intersecting, localAABB, flags, query, grid.Comp);
+        AddContained(intersecting, flags, query);
+    }
+
     #endregion
 
     /// <summary>
@@ -819,6 +836,7 @@ public sealed partial class EntityLookupSystem
         IPhysShape Shape,
         Transform Transform,
         EntityLookupSystem Lookup,
+        SharedPhysicsSystem Physics,
         LookupFlags Flags,
         EntityQuery<T> Query
     ) where T : IComponent;

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.LocalQueries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.LocalQueries.cs
@@ -27,10 +27,7 @@ public sealed partial class EntityLookupSystem
 
         var lookupPoly = new PolygonShape();
         lookupPoly.SetAsBox(localAABB);
-        var (lookupPos, lookupRot) = _transform.GetWorldPositionRotation(lookupUid);
-        var lookupTransform = new Transform(lookupPos, lookupRot);
-
-        AddEntitiesIntersecting(lookupUid, intersecting, lookupPoly, lookupTransform, flags, lookup);
+        AddEntitiesIntersecting(lookupUid, intersecting, lookupPoly, localAABB, Physics.Transform.Empty, flags, lookup);
     }
 
     private void AddLocalEntitiesIntersecting(
@@ -45,9 +42,9 @@ public sealed partial class EntityLookupSystem
 
         var shape = new PolygonShape();
         shape.Set(localBounds);
+        var localAABB = localBounds.CalcBoundingBox();
 
-        var transform = _physics.GetPhysicsTransform(lookupUid);
-        AddEntitiesIntersecting(lookupUid, intersecting, shape, transform, flags);
+        AddEntitiesIntersecting(lookupUid, intersecting, shape, localAABB, Physics.Transform.Empty, flags);
     }
 
     public bool AnyLocalEntitiesIntersecting(EntityUid lookupUid,
@@ -61,8 +58,7 @@ public sealed partial class EntityLookupSystem
 
         var shape = new PolygonShape();
         shape.SetAsBox(localAABB);
-        var transform = _physics.GetPhysicsTransform(lookupUid);
-        return AnyEntitiesIntersecting(lookupUid, shape, transform, flags, ignored, lookup);
+        return AnyEntitiesIntersecting(lookupUid, shape, localAABB, Physics.Transform.Empty, flags, ignored, lookup);
     }
 
     public HashSet<EntityUid> GetLocalEntitiesIntersecting(EntityUid gridId, Vector2i gridIndices, float enlargement = TileEnlargementRadius, LookupFlags flags = DefaultFlags, MapGridComponent? gridComp = null)
@@ -88,7 +84,7 @@ public sealed partial class EntityLookupSystem
         }
 
         var localAABB = GetLocalBounds(localTile, tileSize);
-        localAABB = localAABB.Enlarged(TileEnlargementRadius);
+        localAABB = localAABB.Enlarged(enlargement);
         GetLocalEntitiesIntersecting(gridUid, localAABB, intersecting, flags);
     }
 

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -107,9 +107,7 @@ public sealed partial class EntityLookupSystem : EntitySystem
     /// Returns all non-grid entities. Consider using your own flags if you wish for a faster query.
     /// </summary>
     public const LookupFlags DefaultFlags = LookupFlags.All;
-
-    private PolygonShape _dummy = new();
-
+    
     public override void Initialize()
     {
         base.Initialize();

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -12,6 +12,7 @@ using Robust.Shared.Network;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.BroadPhase;
 using Robust.Shared.Physics.Collision;
+using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Events;
@@ -106,6 +107,8 @@ public sealed partial class EntityLookupSystem : EntitySystem
     /// Returns all non-grid entities. Consider using your own flags if you wish for a faster query.
     /// </summary>
     public const LookupFlags DefaultFlags = LookupFlags.All;
+
+    private PolygonShape _dummy = new();
 
     public override void Initialize()
     {

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -96,6 +96,10 @@ public sealed partial class EntityLookupSystem : EntitySystem
     private EntityQuery<PhysicsMapComponent> _mapQuery;
     private EntityQuery<TransformComponent> _xformQuery;
 
+    /// <summary>
+    /// 1 x 1 polygons can overlap neighboring tiles (even without considering the polygon skin around them.
+    /// When querying for specific tile fixtures we shrink the bounds by this amount to avoid this overlap.
+    /// </summary>
     public const float TileEnlargementRadius = -PhysicsConstants.PolygonRadius * 4f;
 
     /// <summary>
@@ -107,7 +111,7 @@ public sealed partial class EntityLookupSystem : EntitySystem
     /// Returns all non-grid entities. Consider using your own flags if you wish for a faster query.
     /// </summary>
     public const LookupFlags DefaultFlags = LookupFlags.All;
-    
+
     public override void Initialize()
     {
         base.Initialize();

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
@@ -692,6 +692,54 @@ public partial class SharedPhysicsSystem
 
     #endregion
 
+    public Transform GetRelativePhysicsTransform(Transform worldTransform, Entity<TransformComponent?> relative)
+    {
+        if (!_xformQuery.Resolve(relative.Owner, ref relative.Comp))
+            return Physics.Transform.Empty;
+
+        var (_, broadphaseRot, _, broadphaseInv) = _transform.GetWorldPositionRotationMatrixWithInv(relative.Comp);
+
+        return new Transform(Vector2.Transform(worldTransform.Position, broadphaseInv),
+            worldTransform.Quaternion2D.Angle - broadphaseRot);
+    }
+
+    /// <summary>
+    /// Gets the physics transform relative to another entity.
+    /// </summary>
+    public Transform GetRelativePhysicsTransform(
+        Entity<TransformComponent?> entity,
+        Entity<TransformComponent?> relative)
+    {
+        if (!_xformQuery.Resolve(entity.Owner, ref entity.Comp) ||
+            !_xformQuery.Resolve(relative.Owner, ref relative.Comp))
+        {
+            return Physics.Transform.Empty;
+        }
+
+        var (worldPos, worldRot) = _transform.GetWorldPositionRotation(entity.Comp);
+        var (_, broadphaseRot, _, broadphaseInv) = _transform.GetWorldPositionRotationMatrixWithInv(relative.Comp);
+
+        return new Transform(Vector2.Transform(worldPos, broadphaseInv), worldRot - broadphaseRot);
+    }
+
+    /// <summary>
+    /// Gets broadphase relevant transform.
+    /// </summary>
+    public Transform GetLocalPhysicsTransform(EntityUid uid, TransformComponent? xform = null)
+    {
+        if (!_xformQuery.Resolve(uid, ref xform) || xform.Broadphase == null)
+            return Physics.Transform.Empty;
+
+        var broadphase = xform.Broadphase.Value.Uid;
+
+        if (xform.ParentUid == broadphase)
+        {
+            return new Transform(xform.LocalPosition, xform.LocalRotation);
+        }
+
+        return GetRelativePhysicsTransform((uid, xform), broadphase);
+    }
+
     public Transform GetPhysicsTransform(EntityUid uid, TransformComponent? xform = null)
     {
         if (!_xformQuery.Resolve(uid, ref xform))

--- a/Robust.UnitTesting/Shared/EntityLookup_Test.cs
+++ b/Robust.UnitTesting/Shared/EntityLookup_Test.cs
@@ -16,7 +16,39 @@ namespace Robust.UnitTesting.Shared
     [TestFixture, TestOf(typeof(EntityLookupSystem))]
     public sealed class EntityLookupTest
     {
-        private static readonly MapId _mapId = new MapId(1);
+        private static readonly MapId MapId = new MapId(1);
+
+        private static readonly TestCaseData[] InRangeCases = new[]
+        {
+            new TestCaseData(true, new MapCoordinates(Vector2.One, MapId), new MapCoordinates(Vector2.Zero, MapId), 0.5f, false),
+            new TestCaseData(true, new MapCoordinates(new Vector2(10f, 10f), MapId), new MapCoordinates(new Vector2(9.5f, 9.5f), MapId), 0.5f, true),
+            // Close but no cigar
+            new TestCaseData(true, new MapCoordinates(new Vector2(10f, 10f), MapId), new MapCoordinates(new Vector2(9f, 9f), MapId), 0.5f, false),
+            // Large area so useboundsquery
+            new TestCaseData(true, new MapCoordinates(new Vector2(0f, 0f), MapId), new MapCoordinates(new Vector2(0f, 1000f), MapId), 999f, false),
+            new TestCaseData(true, new MapCoordinates(new Vector2(0f, 0f), MapId), new MapCoordinates(new Vector2(0f, 999f), MapId), 999f, true),
+
+            // NoFixturecases
+            new TestCaseData(false, new MapCoordinates(Vector2.One, MapId), new MapCoordinates(Vector2.Zero, MapId), 0.5f, false),
+            new TestCaseData(false, new MapCoordinates(new Vector2(10f, 10f), MapId), new MapCoordinates(new Vector2(9.5f, 9.5f), MapId), 0.5f, false),
+            // Close but no cigar
+            new TestCaseData(false, new MapCoordinates(new Vector2(10f, 10f), MapId), new MapCoordinates(new Vector2(9f, 9f), MapId), 0.5f, false),
+        };
+
+        // Remember this test data is relative.
+        private static readonly TestCaseData[] Box2Cases = new[]
+        {
+            new TestCaseData(true, new MapCoordinates(Vector2.One, MapId), Box2.UnitCentered, false),
+            new TestCaseData(true, new MapCoordinates(new Vector2(10f, 10f), MapId), Box2.UnitCentered, true),
+        };
+
+        private static readonly TestCaseData[] TileCases = new[]
+        {
+            new TestCaseData(true, new MapCoordinates(Vector2.One, MapId), Vector2i.Zero, false),
+            new TestCaseData(true, new MapCoordinates(new Vector2(10f, 10f), MapId), Vector2i.Zero, true),
+            // Need to make sure we don't pull out neighbor fixtures even if they barely touch our tile
+            new TestCaseData(true, new MapCoordinates(new Vector2(11f + 0.35f, 10f), MapId), Vector2i.Zero, false),
+        };
 
         private EntityUid GetPhysicsEntity(IEntityManager entManager, MapCoordinates spawnPos)
         {
@@ -35,148 +67,6 @@ namespace Robust.UnitTesting.Shared
             return grid;
         }
 
-        #region EntityUid
-
-        private static readonly TestCaseData[] MapInRangeCases = new[]
-        {
-            new TestCaseData(new MapCoordinates(Vector2.One, _mapId), new MapCoordinates(Vector2.Zero, _mapId), 0.5f, false),
-            new TestCaseData(new MapCoordinates(Vector2.One, _mapId), new MapCoordinates(Vector2.One, _mapId), 0.5f, true),
-        };
-
-        private static readonly TestCaseData[] GridInRangeCases = new[]
-        {
-            new TestCaseData(new MapCoordinates(Vector2.One, _mapId), new MapCoordinates(Vector2.Zero, _mapId), 0.5f, false),
-            new TestCaseData(new MapCoordinates(new Vector2(10f, 10f), _mapId), new MapCoordinates(new Vector2(9.5f, 9.5f), _mapId), 0.5f, true),
-            // Close but no cigar
-            new TestCaseData(new MapCoordinates(new Vector2(10f, 10f), _mapId), new MapCoordinates(new Vector2(9f, 9f), _mapId), 0.5f, false),
-        };
-
-        private static readonly TestCaseData[] GridNoFixtureInRangeCases = new[]
-        {
-            new TestCaseData(new MapCoordinates(Vector2.One, _mapId), new MapCoordinates(Vector2.Zero, _mapId), 0.5f, false),
-            new TestCaseData(new MapCoordinates(new Vector2(10f, 10f), _mapId), new MapCoordinates(new Vector2(9.5f, 9.5f), _mapId), 0.5f, false),
-            // Close but no cigar
-            new TestCaseData(new MapCoordinates(new Vector2(10f, 10f), _mapId), new MapCoordinates(new Vector2(9f, 9f), _mapId), 0.5f, false),
-        };
-
-        // Remember this test data is relative.
-        private static readonly TestCaseData[] GridBox2Cases = new[]
-        {
-            new TestCaseData(new MapCoordinates(Vector2.One, _mapId), Box2.UnitCentered, false),
-            new TestCaseData(new MapCoordinates(new Vector2(10f, 10f), _mapId), Box2.UnitCentered, true),
-        };
-
-        private static readonly TestCaseData[] GridTileCases = new[]
-        {
-            new TestCaseData(new MapCoordinates(Vector2.One, _mapId), Vector2i.Zero, false),
-            new TestCaseData(new MapCoordinates(new Vector2(10f, 10f), _mapId), Vector2i.Zero, true),
-            // Need to make sure we don't pull out neighbor fixtures even if they barely touch our tile
-            new TestCaseData(new MapCoordinates(new Vector2(11f + 0.35f, 10f), _mapId), Vector2i.Zero, false),
-        };
-
-        [Test, TestCaseSource(nameof(MapInRangeCases))]
-        public void TestMapInRange(MapCoordinates spawnPos, MapCoordinates queryPos, float range, bool result)
-        {
-            var sim = RobustServerSimulation.NewSimulation();
-            var server = sim.InitializeInstance();
-
-            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
-            var entManager = server.Resolve<IEntityManager>();
-            var mapManager = server.Resolve<IMapManager>();
-
-            entManager.System<SharedMapSystem>().CreateMap(spawnPos.MapId);
-            GetPhysicsEntity(entManager, spawnPos);
-
-            Assert.That(lookup.GetEntitiesInRange(queryPos.MapId, queryPos.Position, range).Count > 0, Is.EqualTo(result));
-            mapManager.DeleteMap(spawnPos.MapId);
-        }
-
-        [Test, TestCaseSource(nameof(GridInRangeCases))]
-        public void TestGridInRange(MapCoordinates spawnPos, MapCoordinates queryPos, float range, bool result)
-        {
-            var sim = RobustServerSimulation.NewSimulation();
-            var server = sim.InitializeInstance();
-
-            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
-            var entManager = server.Resolve<IEntityManager>();
-            var mapManager = server.Resolve<IMapManager>();
-            var mapSystem = entManager.System<SharedMapSystem>();
-
-            mapSystem.CreateMap(spawnPos.MapId);
-            var grid = SetupGrid(spawnPos.MapId, mapSystem, entManager, mapManager);
-            entManager.System<SharedTransformSystem>().SetLocalPosition(grid.Owner, new Vector2(10f, 10f));
-
-            GetPhysicsEntity(entManager, spawnPos);
-
-            _ = entManager.SpawnEntity(null, spawnPos);
-            Assert.That(lookup.GetEntitiesInRange(queryPos.MapId, queryPos.Position, range).Count > 0, Is.EqualTo(result));
-            mapManager.DeleteMap(spawnPos.MapId);
-        }
-
-        [Test, TestCaseSource(nameof(MapInRangeCases))]
-        public void TestMapNoFixtureInRange(MapCoordinates spawnPos, MapCoordinates queryPos, float range, bool result)
-        {
-            var sim = RobustServerSimulation.NewSimulation();
-            var server = sim.InitializeInstance();
-
-            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
-            var entManager = server.Resolve<IEntityManager>();
-            var mapManager = server.Resolve<IMapManager>();
-
-            entManager.System<SharedMapSystem>().CreateMap(spawnPos.MapId);
-
-            _ = entManager.SpawnEntity(null, spawnPos);
-            Assert.That(lookup.GetEntitiesInRange(queryPos.MapId, queryPos.Position, range).Count > 0, Is.EqualTo(result));
-            mapManager.DeleteMap(spawnPos.MapId);
-        }
-
-        /// <summary>
-        /// Tests Box2 local queries for a particular lookup ID.
-        /// </summary>
-        [Test, TestCaseSource(nameof(GridBox2Cases))]
-        public void TestGridLocalIntersecting(MapCoordinates spawnPos, Box2 queryBounds, bool result)
-        {
-            var sim = RobustServerSimulation.NewSimulation();
-            var server = sim.InitializeInstance();
-
-            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
-            var entManager = server.Resolve<IEntityManager>();
-            var mapManager = server.Resolve<IMapManager>();
-            var mapSystem = entManager.System<SharedMapSystem>();
-
-            mapSystem.CreateMap(spawnPos.MapId);
-            var grid = SetupGrid(spawnPos.MapId, mapSystem, entManager, mapManager);
-
-            GetPhysicsEntity(entManager, spawnPos);
-            var entities = new HashSet<EntityUid>();
-            lookup.GetLocalEntitiesIntersecting(grid.Owner, queryBounds, entities);
-
-            Assert.That(entities.Count > 0, Is.EqualTo(result));
-            mapManager.DeleteMap(spawnPos.MapId);
-        }
-
-        [Test, TestCaseSource(nameof(GridNoFixtureInRangeCases))]
-        public void TestGridNoFixtureInRange(MapCoordinates spawnPos, MapCoordinates queryPos, float range, bool result)
-        {
-            var sim = RobustServerSimulation.NewSimulation();
-            var server = sim.InitializeInstance();
-
-            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
-            var entManager = server.Resolve<IEntityManager>();
-            var mapManager = server.Resolve<IMapManager>();
-            var mapSystem = entManager.System<SharedMapSystem>();
-
-            mapSystem.CreateMap(spawnPos.MapId);
-            var grid = SetupGrid(spawnPos.MapId, mapSystem, entManager, mapManager);
-            var ent = entManager.SpawnEntity(null, spawnPos);
-            var entities = lookup.GetEntitiesInRange(queryPos.MapId, queryPos.Position, range);
-
-            Assert.That(entities.Count > 0, Is.EqualTo(result));
-            mapManager.DeleteMap(spawnPos.MapId);
-        }
-
-        #endregion
-
         #region Entity
 
         /*
@@ -184,11 +74,8 @@ namespace Robust.UnitTesting.Shared
          *
          */
 
-        /// <summary>
-        /// Tests Box2 local queries for a particular lookup ID.
-        /// </summary>
-        [Test, TestCaseSource(nameof(GridBox2Cases))]
-        public void TestEntityGridNoFixtureLocalIntersecting(MapCoordinates spawnPos, Box2 queryBounds, bool result)
+        [Test, TestCaseSource(nameof(Box2Cases))]
+        public void TestEntityAnyIntersecting(bool physics, MapCoordinates spawnPos, Box2 queryBounds, bool result)
         {
             var sim = RobustServerSimulation.NewSimulation();
             var server = sim.InitializeInstance();
@@ -201,7 +88,64 @@ namespace Robust.UnitTesting.Shared
             mapSystem.CreateMap(spawnPos.MapId);
             var grid = SetupGrid(spawnPos.MapId, mapSystem, entManager, mapManager);
 
-            var ent = entManager.Spawn(null, spawnPos);
+            if (physics)
+                GetPhysicsEntity(entManager, spawnPos);
+            else
+                entManager.Spawn(null, spawnPos);
+
+            var outcome = lookup.AnyLocalEntitiesIntersecting(grid.Owner, queryBounds, LookupFlags.All);
+
+            Assert.That(outcome, Is.EqualTo(result));
+            mapManager.DeleteMap(spawnPos.MapId);
+        }
+
+        [Test, TestCaseSource(nameof(Box2Cases))]
+        public void TestEntityAnyLocalIntersecting(bool physics, MapCoordinates spawnPos, Box2 queryBounds, bool result)
+        {
+            var sim = RobustServerSimulation.NewSimulation();
+            var server = sim.InitializeInstance();
+
+            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
+            var entManager = server.Resolve<IEntityManager>();
+            var mapManager = server.Resolve<IMapManager>();
+            var mapSystem = entManager.System<SharedMapSystem>();
+
+            mapSystem.CreateMap(spawnPos.MapId);
+            var grid = SetupGrid(spawnPos.MapId, mapSystem, entManager, mapManager);
+
+            if (physics)
+                GetPhysicsEntity(entManager, spawnPos);
+            else
+                entManager.Spawn(null, spawnPos);
+
+            var outcome = lookup.AnyLocalEntitiesIntersecting(grid.Owner, queryBounds, LookupFlags.All);
+
+            Assert.That(outcome, Is.EqualTo(result));
+            mapManager.DeleteMap(spawnPos.MapId);
+        }
+
+        /// <summary>
+        /// Tests Box2 local queries for a particular lookup ID.
+        /// </summary>
+        [Test, TestCaseSource(nameof(Box2Cases))]
+        public void TestEntityGridLocalIntersecting(bool physics, MapCoordinates spawnPos, Box2 queryBounds, bool result)
+        {
+            var sim = RobustServerSimulation.NewSimulation();
+            var server = sim.InitializeInstance();
+
+            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
+            var entManager = server.Resolve<IEntityManager>();
+            var mapManager = server.Resolve<IMapManager>();
+            var mapSystem = entManager.System<SharedMapSystem>();
+
+            mapSystem.CreateMap(spawnPos.MapId);
+            var grid = SetupGrid(spawnPos.MapId, mapSystem, entManager, mapManager);
+
+            if (physics)
+                GetPhysicsEntity(entManager, spawnPos);
+            else
+                entManager.Spawn(null, spawnPos);
+
             var entities = new HashSet<Entity<TransformComponent>>();
             lookup.GetLocalEntitiesIntersecting(grid.Owner, queryBounds, entities);
 
@@ -212,8 +156,8 @@ namespace Robust.UnitTesting.Shared
         /// <summary>
         /// Tests Box2 local queries for a particular lookup ID.
         /// </summary>
-        [Test, TestCaseSource(nameof(GridBox2Cases))]
-        public void TestEntityGridLocalIntersecting(MapCoordinates spawnPos, Box2 queryBounds, bool result)
+        [Test, TestCaseSource(nameof(TileCases))]
+        public void TestEntityGridTileIntersecting(bool physics, MapCoordinates spawnPos, Vector2i queryTile, bool result)
         {
             var sim = RobustServerSimulation.NewSimulation();
             var server = sim.InitializeInstance();
@@ -226,32 +170,11 @@ namespace Robust.UnitTesting.Shared
             mapSystem.CreateMap(spawnPos.MapId);
             var grid = SetupGrid(spawnPos.MapId, mapSystem, entManager, mapManager);
 
-            GetPhysicsEntity(entManager, spawnPos);
-            var entities = new HashSet<Entity<TransformComponent>>();
-            lookup.GetLocalEntitiesIntersecting(grid.Owner, queryBounds, entities);
+            if (physics)
+                GetPhysicsEntity(entManager, spawnPos);
+            else
+                entManager.Spawn(null, spawnPos);
 
-            Assert.That(entities.Count > 0, Is.EqualTo(result));
-            mapManager.DeleteMap(spawnPos.MapId);
-        }
-
-        /// <summary>
-        /// Tests Box2 local queries for a particular lookup ID.
-        /// </summary>
-        [Test, TestCaseSource(nameof(GridTileCases))]
-        public void TestEntityGridTileIntersecting(MapCoordinates spawnPos, Vector2i queryTile, bool result)
-        {
-            var sim = RobustServerSimulation.NewSimulation();
-            var server = sim.InitializeInstance();
-
-            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
-            var entManager = server.Resolve<IEntityManager>();
-            var mapManager = server.Resolve<IMapManager>();
-            var mapSystem = entManager.System<SharedMapSystem>();
-
-            mapSystem.CreateMap(spawnPos.MapId);
-            var grid = SetupGrid(spawnPos.MapId, mapSystem, entManager, mapManager);
-
-            var ent = GetPhysicsEntity(entManager, spawnPos);
             var entities = new HashSet<Entity<TransformComponent>>();
             lookup.GetLocalEntitiesIntersecting(grid.Owner, queryTile, entities);
 
@@ -261,15 +184,10 @@ namespace Robust.UnitTesting.Shared
 
         #endregion
 
-        /*
-         * TODO: Add EntityUid tile test
-         * Fix copy-paste between them
-            - AnyEntitiesIntersecting
-            - Check huge area (UseBoundsQuery) works
-         */
+        #region EntityUid
 
-        [Test]
-        public void AnyIntersecting()
+        [Test, TestCaseSource(nameof(InRangeCases))]
+        public void TestMapInRange(bool physics, MapCoordinates spawnPos, MapCoordinates queryPos, float range, bool result)
         {
             var sim = RobustServerSimulation.NewSimulation();
             var server = sim.InitializeInstance();
@@ -278,14 +196,120 @@ namespace Robust.UnitTesting.Shared
             var entManager = server.Resolve<IEntityManager>();
             var mapManager = server.Resolve<IMapManager>();
 
-            var mapId = server.CreateMap().MapId;
+            entManager.System<SharedMapSystem>().CreateMap(spawnPos.MapId);
 
-            var theMapSpotBeingUsed = new Box2(Vector2.Zero, Vector2.One);
+            if (physics)
+                GetPhysicsEntity(entManager, spawnPos);
+            else
+                entManager.Spawn(null, spawnPos);
 
-            _ = entManager.SpawnEntity(null, new MapCoordinates(Vector2.Zero, mapId));
-            Assert.That(lookup.AnyEntitiesIntersecting(mapId, theMapSpotBeingUsed));
-            mapManager.DeleteMap(mapId);
+            Assert.That(lookup.GetEntitiesInRange(queryPos.MapId, queryPos.Position, range).Count > 0, Is.EqualTo(result));
+            mapManager.DeleteMap(spawnPos.MapId);
         }
+
+        [Test, TestCaseSource(nameof(InRangeCases))]
+        public void TestGridInRange(bool physics, MapCoordinates spawnPos, MapCoordinates queryPos, float range, bool result)
+        {
+            var sim = RobustServerSimulation.NewSimulation();
+            var server = sim.InitializeInstance();
+
+            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
+            var entManager = server.Resolve<IEntityManager>();
+            var mapManager = server.Resolve<IMapManager>();
+            var mapSystem = entManager.System<SharedMapSystem>();
+
+            mapSystem.CreateMap(spawnPos.MapId);
+            var grid = SetupGrid(spawnPos.MapId, mapSystem, entManager, mapManager);
+
+            if (physics)
+                GetPhysicsEntity(entManager, spawnPos);
+            else
+                entManager.Spawn(null, spawnPos);
+
+            _ = entManager.SpawnEntity(null, spawnPos);
+            Assert.That(lookup.GetEntitiesInRange(queryPos.MapId, queryPos.Position, range).Count > 0, Is.EqualTo(result));
+            mapManager.DeleteMap(spawnPos.MapId);
+        }
+
+        [Test, TestCaseSource(nameof(InRangeCases))]
+        public void TestMapNoFixtureInRange(bool physics, MapCoordinates spawnPos, MapCoordinates queryPos, float range, bool result)
+        {
+            var sim = RobustServerSimulation.NewSimulation();
+            var server = sim.InitializeInstance();
+
+            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
+            var entManager = server.Resolve<IEntityManager>();
+            var mapManager = server.Resolve<IMapManager>();
+
+            entManager.System<SharedMapSystem>().CreateMap(spawnPos.MapId);
+
+            if (physics)
+                GetPhysicsEntity(entManager, spawnPos);
+            else
+                entManager.Spawn(null, spawnPos);
+
+            Assert.That(lookup.GetEntitiesInRange(queryPos.MapId, queryPos.Position, range).Count > 0, Is.EqualTo(result));
+            mapManager.DeleteMap(spawnPos.MapId);
+        }
+
+        /// <summary>
+        /// Tests Box2 local queries for a particular lookup ID.
+        /// </summary>
+        [Test, TestCaseSource(nameof(Box2Cases))]
+        public void TestGridAnyIntersecting(bool physics, MapCoordinates spawnPos, Box2 queryBounds, bool result)
+        {
+            var sim = RobustServerSimulation.NewSimulation();
+            var server = sim.InitializeInstance();
+
+            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
+            var entManager = server.Resolve<IEntityManager>();
+            var mapManager = server.Resolve<IMapManager>();
+            var mapSystem = entManager.System<SharedMapSystem>();
+
+            mapSystem.CreateMap(spawnPos.MapId);
+            var grid = SetupGrid(spawnPos.MapId, mapSystem, entManager, mapManager);
+
+            if (physics)
+                GetPhysicsEntity(entManager, spawnPos);
+            else
+                entManager.Spawn(null, spawnPos);
+
+            var outcome = lookup.AnyLocalEntitiesIntersecting(grid.Owner, queryBounds, LookupFlags.All);
+
+            Assert.That(outcome, Is.EqualTo(result));
+            mapManager.DeleteMap(spawnPos.MapId);
+        }
+
+        /// <summary>
+        /// Tests Box2 local queries for a particular lookup ID.
+        /// </summary>
+        [Test, TestCaseSource(nameof(Box2Cases))]
+        public void TestGridLocalIntersecting(bool physics, MapCoordinates spawnPos, Box2 queryBounds, bool result)
+        {
+            var sim = RobustServerSimulation.NewSimulation();
+            var server = sim.InitializeInstance();
+
+            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
+            var entManager = server.Resolve<IEntityManager>();
+            var mapManager = server.Resolve<IMapManager>();
+            var mapSystem = entManager.System<SharedMapSystem>();
+
+            mapSystem.CreateMap(spawnPos.MapId);
+            var grid = SetupGrid(spawnPos.MapId, mapSystem, entManager, mapManager);
+
+            if (physics)
+                GetPhysicsEntity(entManager, spawnPos);
+            else
+                entManager.Spawn(null, spawnPos);
+
+            var entities = new HashSet<EntityUid>();
+            lookup.GetLocalEntitiesIntersecting(grid.Owner, queryBounds, entities);
+
+            Assert.That(entities.Count > 0, Is.EqualTo(result));
+            mapManager.DeleteMap(spawnPos.MapId);
+        }
+
+        #endregion
 
         /// <summary>
         /// Is the entity correctly removed / added to EntityLookup when anchored

--- a/Robust.UnitTesting/Shared/EntityLookup_Test.cs
+++ b/Robust.UnitTesting/Shared/EntityLookup_Test.cs
@@ -1,9 +1,14 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using NUnit.Framework;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
+using Robust.Shared.Physics.Collision.Shapes;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
 using Robust.UnitTesting.Server;
 
 namespace Robust.UnitTesting.Shared
@@ -11,6 +16,142 @@ namespace Robust.UnitTesting.Shared
     [TestFixture, TestOf(typeof(EntityLookupSystem))]
     public sealed class EntityLookupTest
     {
+        private static readonly MapId _mapId = new MapId(1);
+
+        private EntityUid GetPhysicsEntity(IEntityManager entManager, MapCoordinates spawnPos)
+        {
+            var ent = entManager.SpawnEntity(null, spawnPos);
+            var comp = entManager.AddComponent<PhysicsComponent>(ent);
+            entManager.System<FixtureSystem>().TryCreateFixture(ent, new PhysShapeCircle(0.35f, Vector2.Zero), "fix1");
+            return ent;
+        }
+
+        private Entity<MapGridComponent> SetupGrid(MapId mapId, SharedMapSystem mapSystem, IEntityManager entManager, IMapManager mapManager)
+        {
+            mapSystem.CreateMap(mapId);
+            var grid = mapManager.CreateGridEntity(mapId);
+            entManager.System<SharedTransformSystem>().SetLocalPosition(grid.Owner, new Vector2(10f, 10f));
+            mapSystem.SetTile(grid, Vector2i.Zero, new Tile(1));
+            return grid;
+        }
+
+        private static readonly TestCaseData[] MapInRangeCases = new[]
+        {
+            new TestCaseData(new MapCoordinates(Vector2.One, _mapId), new MapCoordinates(Vector2.Zero, _mapId), 0.5f, false),
+            new TestCaseData(new MapCoordinates(Vector2.One, _mapId), new MapCoordinates(Vector2.One, _mapId), 0.5f, true),
+        };
+
+        private static readonly TestCaseData[] GridInRangeCases = new[]
+        {
+            new TestCaseData(new MapCoordinates(Vector2.One, _mapId), new MapCoordinates(Vector2.Zero, _mapId), 0.5f, false),
+            new TestCaseData(new MapCoordinates(new Vector2(10f, 10f), _mapId), new MapCoordinates(new Vector2(10f, 10f), _mapId), 0.5f, true),
+        };
+
+        // Remember this test data is relative.
+        private static readonly TestCaseData[] GridBox2Cases = new[]
+        {
+            new TestCaseData(new MapCoordinates(Vector2.One, _mapId), Box2.UnitCentered, false),
+            new TestCaseData(new MapCoordinates(new Vector2(10f, 10f), _mapId), Box2.UnitCentered, true),
+        };
+
+        [Test, TestCaseSource(nameof(MapInRangeCases))]
+        public void TestMapInRange(MapCoordinates spawnPos, MapCoordinates queryPos, float range, bool result)
+        {
+            var sim = RobustServerSimulation.NewSimulation();
+            var server = sim.InitializeInstance();
+
+            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
+            var entManager = server.Resolve<IEntityManager>();
+            var mapManager = server.Resolve<IMapManager>();
+
+            entManager.System<SharedMapSystem>().CreateMap(spawnPos.MapId);
+            GetPhysicsEntity(entManager, spawnPos);
+
+            Assert.That(lookup.GetEntitiesInRange(queryPos.MapId, queryPos.Position, range).Count > 0, Is.EqualTo(result));
+            mapManager.DeleteMap(spawnPos.MapId);
+        }
+
+        [Test, TestCaseSource(nameof(GridInRangeCases))]
+        public void TestGridInRange(MapCoordinates spawnPos, MapCoordinates queryPos, float range, bool result)
+        {
+            var sim = RobustServerSimulation.NewSimulation();
+            var server = sim.InitializeInstance();
+
+            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
+            var entManager = server.Resolve<IEntityManager>();
+            var mapManager = server.Resolve<IMapManager>();
+            var mapSystem = entManager.System<SharedMapSystem>();
+
+            mapSystem.CreateMap(spawnPos.MapId);
+            var grid = mapManager.CreateGridEntity(spawnPos.MapId);
+            entManager.System<SharedTransformSystem>().SetLocalPosition(grid.Owner, new Vector2(10f, 10f));
+
+            GetPhysicsEntity(entManager, spawnPos);
+
+            _ = entManager.SpawnEntity(null, spawnPos);
+            Assert.That(lookup.GetEntitiesInRange(queryPos.MapId, queryPos.Position, range).Count > 0, Is.EqualTo(result));
+            mapManager.DeleteMap(spawnPos.MapId);
+        }
+
+        [Test, TestCaseSource(nameof(MapInRangeCases))]
+        public void TestMapNoFixtureInRange(MapCoordinates spawnPos, MapCoordinates queryPos, float range, bool result)
+        {
+            var sim = RobustServerSimulation.NewSimulation();
+            var server = sim.InitializeInstance();
+
+            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
+            var entManager = server.Resolve<IEntityManager>();
+            var mapManager = server.Resolve<IMapManager>();
+
+            entManager.System<SharedMapSystem>().CreateMap(spawnPos.MapId);
+
+            _ = entManager.SpawnEntity(null, spawnPos);
+            Assert.That(lookup.GetEntitiesInRange(queryPos.MapId, queryPos.Position, range).Count > 0, Is.EqualTo(result));
+            mapManager.DeleteMap(spawnPos.MapId);
+        }
+
+        /// <summary>
+        /// Tests Box2 local queries for a particular lookup ID.
+        /// </summary>
+        [Test, TestCaseSource(nameof(GridBox2Cases))]
+        public void TestGridLocalIntersecting(MapCoordinates spawnPos, Box2 queryBounds, bool result)
+        {
+            var sim = RobustServerSimulation.NewSimulation();
+            var server = sim.InitializeInstance();
+
+            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
+            var entManager = server.Resolve<IEntityManager>();
+            var mapManager = server.Resolve<IMapManager>();
+            var mapSystem = entManager.System<SharedMapSystem>();
+
+            var grid = SetupGrid(spawnPos.MapId, mapSystem, entManager, mapManager);
+
+            GetPhysicsEntity(entManager, spawnPos);
+            var entities = new HashSet<EntityUid>();
+            lookup.GetLocalEntitiesIntersecting(grid.Owner, queryBounds, entities);
+
+            Assert.That(entities.Count > 0, Is.EqualTo(result));
+            mapManager.DeleteMap(spawnPos.MapId);
+        }
+
+        [Test, TestCaseSource(nameof(GridInRangeCases))]
+        public void TestGridNoFixtureInRange(MapCoordinates spawnPos, MapCoordinates queryPos, float range, bool result)
+        {
+            var sim = RobustServerSimulation.NewSimulation();
+            var server = sim.InitializeInstance();
+
+            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
+            var entManager = server.Resolve<IEntityManager>();
+            var mapManager = server.Resolve<IMapManager>();
+            var mapSystem = entManager.System<SharedMapSystem>();
+
+            var grid = SetupGrid(spawnPos.MapId, mapSystem, entManager, mapManager);
+
+            var ent = entManager.SpawnEntity(null, spawnPos);
+            Assert.That(lookup.GetEntitiesInRange(queryPos.MapId, queryPos.Position, range).Count > 0, Is.EqualTo(result));
+            mapManager.DeleteMap(spawnPos.MapId);
+        }
+
         [Test]
         public void AnyIntersecting()
         {
@@ -25,7 +166,7 @@ namespace Robust.UnitTesting.Shared
 
             var theMapSpotBeingUsed = new Box2(Vector2.Zero, Vector2.One);
 
-            var dummy = entManager.SpawnEntity(null, new MapCoordinates(Vector2.Zero, mapId));
+            _ = entManager.SpawnEntity(null, new MapCoordinates(Vector2.Zero, mapId));
             Assert.That(lookup.AnyEntitiesIntersecting(mapId, theMapSpotBeingUsed));
             mapManager.DeleteMap(mapId);
         }


### PR DESCRIPTION
Previously I made it so MOST of entitylookup goes through the same 4 or 5 codepaths and uses shapes. The downside was some codepaths were made much slower in the process due to shapes being transformed into worldspace every time.

This PR changes it so all the transforms are local-space which in most cases means we can simply get Transform(localposition, localrotation).

It should also be faster than the pre-shapes version because GetLocalPhysicsTransform is being used for the non-approx queries and most entities are parented directly to their broadphase.

I've also added more test coverage as well.