### PR TITLE
Resolve instances of the CS8974 warning

### DIFF
--- a/Robust.UnitTesting/Shared/Serialization/SerializationTests/ManagerTests.cs
+++ b/Robust.UnitTesting/Shared/Serialization/SerializationTests/ManagerTests.cs
@@ -137,8 +137,8 @@ public sealed partial class ManagerTests : SerializationTest
         new object[]
         {
             SerializerRanDataNode,
-            SerializerClass.SerializerReturn,
-            SerializerClass.SerializerReturnAlt,
+            (object)SerializerClass.SerializerReturn,
+            (object)SerializerClass.SerializerReturnAlt,
             false,
             new Func<SerializerClass, object>[]
             {
@@ -149,8 +149,8 @@ public sealed partial class ManagerTests : SerializationTest
         new object[]
         {
             SerializerRanCustomDataNode,
-            SerializerClass.SerializerCustomReturn,
-            SerializerClass.SerializerCustomReturnAlt,
+            (object)SerializerClass.SerializerCustomReturn,
+            (object)SerializerClass.SerializerCustomReturnAlt,
             true,
             new Func<SerializerClass, object>[]
             {
@@ -229,8 +229,8 @@ public sealed partial class ManagerTests : SerializationTest
         new object[]
         {
             SerializerRanDataNode,
-            SerializerStruct.SerializerReturn,
-            SerializerStruct.SerializerReturnAlt,
+            (object)SerializerStruct.SerializerReturn,
+            (object)SerializerStruct.SerializerReturnAlt,
             false,
             new Func<SerializerStruct, object>[]
             {
@@ -241,8 +241,8 @@ public sealed partial class ManagerTests : SerializationTest
         new object[]
         {
             SerializerRanCustomDataNode,
-            SerializerStruct.SerializerCustomReturn,
-            SerializerStruct.SerializerCustomReturnAlt,
+            (object)SerializerStruct.SerializerCustomReturn,
+            (object)SerializerStruct.SerializerCustomReturnAlt,
             true,
             new Func<SerializerStruct, object>[]
             {


### PR DESCRIPTION
Some test config data was causing the warning `CS8974 (Accidental method group)`. Basically the compiler sees that we're assigning a function value to something that isn't a delegate type, so it warns us because normally we don't want to do this. Adding the explicit cast to `object` satisfies the compiler and the warning goes away.

The tests as pass as normal. I don't think this explicit conversion adds any boxing shenanigans or gotcha side-effects.