### PR TITLE
Re-attempt `FlushEntities()` on failure

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -50,7 +50,7 @@ END TEMPLATE-->
 
 ### Other
 
-*None yet*
+* If `EntityManager.FlushEntities()` fails to delete all entities, it will now attempt to do so a second time before throwing an exception.
 
 ### Internal
 

--- a/Robust.Server/GameStates/PvsSystem.DataStorage.cs
+++ b/Robust.Server/GameStates/PvsSystem.DataStorage.cs
@@ -300,7 +300,8 @@ internal sealed partial class PvsSystem
     /// </summary>
     private void AfterEntityFlush()
     {
-        DebugTools.Assert(EntityManager.EntityCount == 0);
+        if (EntityManager.EntityCount > 0)
+            throw new Exception("Cannot reset PVS data without first deleting all entities.");
 
         ClearPvsData();
         ShrinkDataMemory();

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -693,6 +693,25 @@ namespace Robust.Shared.GameObjects
         public virtual void FlushEntities()
         {
             BeforeEntityFlush?.Invoke();
+            FlushEntitiesInternal();
+
+            if (Entities.Count != 0)
+                _sawmill.Error("Failed to flush all entities");
+
+#if EXCEPTION_TOLERANCE
+            // Attempt to flush entities a second time, just in case something somehow caused an entity to be spawned
+            // while flushing entities
+            FlushEntitiesInternal();
+#endif
+
+            if (Entities.Count != 0)
+                throw new Exception("Failed to flush all entities");
+
+            AfterEntityFlush?.Invoke();
+        }
+
+        private void FlushEntitiesInternal()
+        {
             QueuedDeletions.Clear();
             QueuedDeletionsSet.Clear();
 
@@ -738,11 +757,6 @@ namespace Robust.Shared.GameObjects
 #endif
                 }
             }
-
-            if (Entities.Count != 0)
-                _sawmill.Error("Entities were spawned while flushing entities.");
-
-            AfterEntityFlush?.Invoke();
         }
 
         /// <summary>


### PR DESCRIPTION
If `EntityManager.FlushEntities()` fails to delete all entities, it will now attempt to do so a second time before throwing an exception. Previously it would only log an error, which would probably have then lead to various confusing PVS bugs that would crash the server anyways.