### PR TITLE
Activate XAML hot reload on file rename (for VS support)

### DIFF
--- a/Robust.Client/UserInterface/XAML/Proxy/XamlHotReloadManager.cs
+++ b/Robust.Client/UserInterface/XAML/Proxy/XamlHotReloadManager.cs
@@ -58,16 +58,16 @@ internal sealed class XamlHotReloadManager : IXamlHotReloadManager
         var watcher = new FileSystemWatcher(location)
         {
             IncludeSubdirectories = true,
-            NotifyFilter = NotifyFilters.LastWrite,
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName,
         };
 
-        watcher.Changed += (_, args) =>
+        void OnWatcherEvent(object sender, FileSystemEventArgs args)
         {
             switch (args.ChangeType)
             {
-                case WatcherChangeTypes.Renamed:
                 case WatcherChangeTypes.Deleted:
                     return;
+                case WatcherChangeTypes.Renamed:
                 case WatcherChangeTypes.Created:
                 case WatcherChangeTypes.Changed:
                 case WatcherChangeTypes.All:
@@ -98,7 +98,10 @@ internal sealed class XamlHotReloadManager : IXamlHotReloadManager
 
                 _xamlProxyManager.SetImplementation(resourceFileName, newText);
             });
-        };
+        }
+
+        watcher.Changed += OnWatcherEvent;
+        watcher.Renamed += OnWatcherEvent;
         watcher.EnableRaisingEvents = true;
         return watcher;
     }


### PR DESCRIPTION
Turns out, Visual Studio does not just write new content into old file, but instead creates new with temp name, writes into it, deletes the old one and only then renames new file to original name (according to [this stack overflow answer](https://stackoverflow.com/a/681078/25056072)).
XAML hot reloader only wathes for file change, gets edited files with weird names in this case and can not do hot reload. I just adjusted watcher to watch for file renaming.