### PR TITLE
feat: added audio system predicted method for only one receiver

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-* SharedAudioSystem now have method for playing sound for one player (PlayLocal)
+* SharedAudioSystem now has PlayLocal which only runs audio locally on the client.
 
 ### Bugfixes
 
@@ -58,7 +58,7 @@ END TEMPLATE-->
 
 ### New features
 
-* Add GetGridEntities and another GetEntitiesIntersecting overload to EntityLookupSystem. 
+* Add GetGridEntities and another GetEntitiesIntersecting overload to EntityLookupSystem.
 * `MarkupNode` is now `IEquatable<MarkupNode>`. It already supported equality checks, now it implements the interface.
 * Added `Entity<T>` overloads to the following `SharedMapSystem` methods: `GetTileRef`, `GetAnchoredEntities`, `TileIndicesFor`.
 * Added `EntityUid`-only overloads to the following `SharedTransformSystem` methods: `AnchorEntity`, `Unanchor`.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* SharedAudioSystem now have method for playing sound for one player with prediction
 
 ### Bugfixes
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-* SharedAudioSystem now have method for playing sound for one player with prediction
+* SharedAudioSystem now have method for playing sound for one player (PlayLocal)
 
 ### Bugfixes
 

--- a/Robust.Client/Audio/AudioSystem.cs
+++ b/Robust.Client/Audio/AudioSystem.cs
@@ -453,6 +453,18 @@ public sealed partial class AudioSystem : SharedAudioSystem
         return null; // uhh Lets hope predicted audio never needs to somehow store the playing audio....
     }
 
+    /// <inheritdoc />
+    public override (EntityUid Entity, AudioComponent Component)? PlayPredicted(
+        SoundSpecifier? sound,
+        EntityUid source,
+        EntityUid? soundInitiator,
+        EntityUid receiver,
+        AudioParams? audioParams = null
+    )
+    {
+        return PlayPredicted(sound, source, soundInitiator, audioParams);
+    }
+
     public override (EntityUid Entity, AudioComponent Component)? PlayPredicted(SoundSpecifier? sound, EntityCoordinates coordinates, EntityUid? user, AudioParams? audioParams = null)
     {
         if (Timing.IsFirstTimePredicted && sound != null)

--- a/Robust.Client/Audio/AudioSystem.cs
+++ b/Robust.Client/Audio/AudioSystem.cs
@@ -454,11 +454,10 @@ public sealed partial class AudioSystem : SharedAudioSystem
     }
 
     /// <inheritdoc />
-    public override (EntityUid Entity, AudioComponent Component)? PlayPredicted(
+    public override (EntityUid Entity, AudioComponent Component)? PlayLocal(
         SoundSpecifier? sound,
         EntityUid source,
         EntityUid? soundInitiator,
-        EntityUid receiver,
         AudioParams? audioParams = null
     )
     {

--- a/Robust.Server/Audio/AudioSystem.cs
+++ b/Robust.Server/Audio/AudioSystem.cs
@@ -191,6 +191,18 @@ public sealed partial class AudioSystem : SharedAudioSystem
     }
 
     /// <inheritdoc />
+    public override (EntityUid Entity, AudioComponent Component)? PlayPredicted(
+        SoundSpecifier? sound,
+        EntityUid source,
+        EntityUid? soundInitiator,
+        EntityUid receiver,
+        AudioParams? audioParams = null
+    )
+    {
+        return default;
+    }
+
+    /// <inheritdoc />
     public override (EntityUid Entity, AudioComponent Component)? PlayPredicted(SoundSpecifier? sound, EntityCoordinates coordinates, EntityUid? user, AudioParams? audioParams = null)
     {
         if (sound == null)

--- a/Robust.Server/Audio/AudioSystem.cs
+++ b/Robust.Server/Audio/AudioSystem.cs
@@ -176,6 +176,17 @@ public sealed partial class AudioSystem : SharedAudioSystem
     }
 
     /// <inheritdoc />
+    public override (EntityUid Entity, AudioComponent Component)? PlayLocal(
+        SoundSpecifier? sound,
+        EntityUid source,
+        EntityUid? soundInitiator,
+        AudioParams? audioParams = null
+    )
+    {
+        return null;
+    }
+
+    /// <inheritdoc />
     public override (EntityUid Entity, AudioComponent Component)? PlayPredicted(SoundSpecifier? sound, EntityUid source, EntityUid? user, AudioParams? audioParams = null)
     {
         if (sound == null)
@@ -188,18 +199,6 @@ public sealed partial class AudioSystem : SharedAudioSystem
 
         audio.Value.Component.ExcludedEntity = user;
         return audio;
-    }
-
-    /// <inheritdoc />
-    public override (EntityUid Entity, AudioComponent Component)? PlayPredicted(
-        SoundSpecifier? sound,
-        EntityUid source,
-        EntityUid? soundInitiator,
-        EntityUid receiver,
-        AudioParams? audioParams = null
-    )
-    {
-        return default;
     }
 
     /// <inheritdoc />

--- a/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
+++ b/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
@@ -575,6 +575,15 @@ public abstract partial class SharedAudioSystem : EntitySystem
         AudioParams? audioParams = null);
 
     /// <summary>
+    /// Plays a predicted sound following an entity for only one entity. The client-side system plays this sound as normal, server will do nothing.
+    /// </summary>
+    /// <param name="sound">The sound specifier that points the audio file(s) that should be played.</param>
+    /// <param name="source">The UID of the entity "emitting" the audio.</param>
+    /// <param name="soundInitiator">The UID of the user that initiated this sound. This is usually some player's controlled entity.</param>
+    [return: NotNullIfNotNull("sound")]
+    public abstract (EntityUid Entity, Components.AudioComponent Component)? PlayLocal(SoundSpecifier? sound, EntityUid source, EntityUid? soundInitiator, AudioParams? audioParams = null);
+
+    /// <summary>
     /// Plays a predicted sound following an entity. The server will send the sound to every player in PVS range,
     /// unless that player is attached to the "user" entity that initiated the sound. The client-side system plays
     /// this sound as normal
@@ -584,16 +593,6 @@ public abstract partial class SharedAudioSystem : EntitySystem
     /// <param name="user">The UID of the user that initiated this sound. This is usually some player's controlled entity.</param>
     [return: NotNullIfNotNull("sound")]
     public abstract (EntityUid Entity, Components.AudioComponent Component)? PlayPredicted(SoundSpecifier? sound, EntityUid source, EntityUid? user, AudioParams? audioParams = null);
-
-    /// <summary>
-    /// Plays a predicted sound following an entity for only one entity. The client-side system plays this sound as normal, server will do nothing.
-    /// </summary>
-    /// <param name="sound">The sound specifier that points the audio file(s) that should be played.</param>
-    /// <param name="source">The UID of the entity "emitting" the audio.</param>
-    /// <param name="soundInitiator">The UID of the user that initiated this sound. This is usually some player's controlled entity.</param>
-    /// <param name="receiver">The UID of entity, that have to receive audio.</param>
-    [return: NotNullIfNotNull("sound")]
-    public abstract (EntityUid Entity, Components.AudioComponent Component)? PlayPredicted(SoundSpecifier? sound, EntityUid source, EntityUid? soundInitiator, EntityUid receiver, AudioParams? audioParams = null);
 
     /// <summary>
     /// Plays a predicted sound following an EntityCoordinates. The server will send the sound to every player in PVS range,

--- a/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
+++ b/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
@@ -586,6 +586,16 @@ public abstract partial class SharedAudioSystem : EntitySystem
     public abstract (EntityUid Entity, Components.AudioComponent Component)? PlayPredicted(SoundSpecifier? sound, EntityUid source, EntityUid? user, AudioParams? audioParams = null);
 
     /// <summary>
+    /// Plays a predicted sound following an entity for only one entity. The client-side system plays this sound as normal, server will do nothing.
+    /// </summary>
+    /// <param name="sound">The sound specifier that points the audio file(s) that should be played.</param>
+    /// <param name="source">The UID of the entity "emitting" the audio.</param>
+    /// <param name="soundInitiator">The UID of the user that initiated this sound. This is usually some player's controlled entity.</param>
+    /// <param name="receiver">The UID of entity, that have to receive audio.</param>
+    [return: NotNullIfNotNull("sound")]
+    public abstract (EntityUid Entity, Components.AudioComponent Component)? PlayPredicted(SoundSpecifier? sound, EntityUid source, EntityUid? soundInitiator, EntityUid receiver, AudioParams? audioParams = null);
+
+    /// <summary>
     /// Plays a predicted sound following an EntityCoordinates. The server will send the sound to every player in PVS range,
     /// unless that player is attached to the "user" entity that initiated the sound. The client-side system plays
     /// this sound as normal


### PR DESCRIPTION
Added method for cases when AudioSystem could be used with prediction, but there should be only one one player to be receiver of sound.