### PR TITLE
Try improve PVS exception tolerance a bit more

### DIFF
--- a/Robust.Server/GameStates/PvsChunk.cs
+++ b/Robust.Server/GameStates/PvsChunk.cs
@@ -141,9 +141,10 @@ internal sealed class PvsChunk
         {
             // TODO ARCH multi-component queries
             if (!meta.TryGetComponent(child, out var childMeta)
-                || !xform.TryGetComponent(child, out var childXform))
+                || !xform.TryGetComponent(child, out var childXform)
+                || childMeta.EntityLifeStage >= EntityLifeStage.Terminating)
             {
-                DebugTools.Assert($"PVS chunk contains a deleted entity: {child}");
+                DebugTools.Assert($"PVS chunk contains a delete or terminating entity: {child}");
                 MarkDirty();
                 return false;
             }
@@ -188,9 +189,10 @@ internal sealed class PvsChunk
                 {
                     // TODO ARCH multi-component queries
                     if (!meta.TryGetComponent(child, out var childMeta)
-                        || !xform.TryGetComponent(child, out var childXform))
+                        || !xform.TryGetComponent(child, out var childXform)
+                        || childMeta.EntityLifeStage >= EntityLifeStage.Terminating)
                     {
-                        DebugTools.Assert($"PVS chunk contains a deleted entity: {child}");
+                        DebugTools.Assert($"PVS chunk contains a delete or terminating entity: {child}");
                         MarkDirty();
                         return false;
                     }

--- a/Robust.Server/GameStates/PvsSystem.Chunks.cs
+++ b/Robust.Server/GameStates/PvsSystem.Chunks.cs
@@ -232,6 +232,7 @@ internal sealed partial class PvsSystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void AddEntityToChunk(EntityUid uid, MetaDataComponent meta, PvsChunkLocation location)
     {
+        DebugTools.Assert(meta.EntityLifeStage < EntityLifeStage.Terminating);
         ref var chunk = ref CollectionsMarshal.GetValueRefOrAddDefault(_chunks, location, out var existing);
         if (!existing)
         {

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -129,7 +129,6 @@ internal sealed partial class PvsSystem : EntitySystem
 
         SubscribeLocalEvent<MapChangedEvent>(OnMapChanged);
         SubscribeLocalEvent<GridRemovalEvent>(OnGridRemoved);
-        SubscribeLocalEvent<EntityTerminatingEvent>(OnEntityTerminating);
         SubscribeLocalEvent<TransformComponent, TransformStartupEvent>(OnTransformStartup);
 
         _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
@@ -137,6 +136,7 @@ internal sealed partial class PvsSystem : EntitySystem
         EntityManager.EntityAdded += OnEntityAdded;
         EntityManager.EntityDeleted += OnEntityDeleted;
         EntityManager.AfterEntityFlush += AfterEntityFlush;
+        EntityManager.BeforeEntityTerminating += OnEntityTerminating;
 
         Subs.CVar(_configManager, CVars.NetPVS, SetPvs, true);
         Subs.CVar(_configManager, CVars.NetMaxUpdateRange, OnViewsizeChanged, true);
@@ -162,6 +162,7 @@ internal sealed partial class PvsSystem : EntitySystem
         EntityManager.EntityAdded -= OnEntityAdded;
         EntityManager.EntityDeleted -= OnEntityDeleted;
         EntityManager.AfterEntityFlush -= AfterEntityFlush;
+        EntityManager.BeforeEntityTerminating -= OnEntityTerminating;
 
         _parallelMgr.ParallelCountChanged -= ResetParallelism;
 

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -93,6 +93,14 @@ namespace Robust.Shared.GameObjects
         public event Action<Entity<MetaDataComponent>>? EntityAdded;
         public event Action<Entity<MetaDataComponent>>? EntityInitialized;
         public event Action<Entity<MetaDataComponent>>? EntityDeleted;
+
+        /// <summary>
+        /// Internal termination event handlers. This is mainly for exception tolerance, we want to ensure that PVS,
+        /// and other important engine systems can get updated before some content code throws an exception.
+        /// </summary>
+        internal event TerminatingEventHandler? BeforeEntityTerminating;
+        public delegate void TerminatingEventHandler(ref EntityTerminatingEvent ev);
+
         public event Action? BeforeEntityFlush;
         public event Action? AfterEntityFlush;
 
@@ -556,6 +564,7 @@ namespace Robust.Shared.GameObjects
             try
             {
                 var ev = new EntityTerminatingEvent((uid, metadata));
+                BeforeEntityTerminating?.Invoke(ref ev);
                 EventBus.RaiseLocalEvent(uid, ref ev, true);
             }
             catch (Exception e)


### PR DESCRIPTION
Instead of using the normal `EntityTerminatingEvent` system subscription, PVS system now uses  a separate C# event that gets invoked before the normal system event. This might prevent some bugs caused by content code throwing exceptions while handling the event?

I don't know if thats what caused this, but smug just keeps discovering cursed PVS errors:
```
 at Robust.Shared.Utility.DebugTools.AssertNull(Object arg, String message) in /home/runner/work/RMC-14/RMC-14/RobustToolbox/Robust.Shared/Utility/DebugTools.cs:line 250
   at Robust.Server.GameStates.PvsSystem.UpdatePosition(EntityUid uid, TransformComponent xform, MetaDataComponent meta, EntityUid oldParent) in /home/runner/work/RMC-14/RMC-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.Entity.cs:line 38
   at Robust.Server.GameStates.PvsSystem.OnEntityMove(MoveEvent& ev) in /home/runner/work/RMC-14/RMC-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.Entity.cs:line 14
   at Robust.Shared.GameObjects.SharedTransformSystem.RaiseMoveEvent(Entity`2 ent, EntityUid oldParent, Vector2 oldPosition, Angle oldRotation, Nullable`1 oldMap) in /home/runner/work/RMC-14/RMC-14/RobustToolbox/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs:line 283
   at Robust.Shared.GameObjects.SharedTransformSystem.SetCoordinates(Entity`2 entity, EntityCoordinates value, Nullable`1 rotation, Boolean unanchor, TransformComponent newParent, TransformComponent oldParent) in /home/runner/work/RMC-14/RMC-14/RobustToolbox/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs:line 585
   at Robust.Shared.GameObjects.SharedTransformSystem.DetachEntityInternal(EntityUid uid, TransformComponent xform, MetaDataComponent meta, TransformComponent oldXform, Boolean terminating) in /home/runner/work/RMC-14/RMC-14/RobustToolbox/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs:line 1470
   at Robust.Shared.GameObjects.SharedTransformSystem.DetachEntity(EntityUid uid, TransformComponent xform, MetaDataComponent meta, TransformComponent oldXform, Boolean terminating) in /home/runner/work/RMC-14/RMC-14/RobustToolbox/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs:line 1399
   at Robust.Shared.GameObjects.EntityManager.RecursiveDeleteEntity(EntityUid uid, MetaDataComponent metadata, TransformComponent transform, TransformComponent parentXform) in /home/runner/work/RMC-14/RMC-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 581
   at Robust.Shared.GameObjects.EntityManager.DeleteEntity(EntityUid e, MetaDataComponent meta, TransformComponent xform) in /home/runner/work/RMC-14/RMC-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 535
   at Robust.Shared.GameObjects.EntityManager.DeleteEntity(Nullable`1 uid) in /home/runner/work/RMC-14/RMC-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 502
   at Content.IntegrationTests.Tests.EntityTest.<>c__DisplayClass5_0.<AllComponentsOneToOneDeleteTest>b__1() in /home/runner/work/RMC-14/RMC-14/Content.IntegrationTests/Tests/EntityTest.cs:line 409
   at NUnit.Framework.Assert.Multiple(TestDelegate testDelegate)
   at Content.IntegrationTests.Tests.EntityTest.<>c__DisplayClass5_0.<AllComponentsOneToOneDeleteTest>b__0() in /home/runner/work/RMC-14/RMC-14/Content.IntegrationTests/Tests/EntityTest.cs:line 375
   at Robust.UnitTesting.RobustIntegrationTest.IntegrationGameLoop.SingleThreadRunUntilEmpty() in /home/runner/work/RMC-14/RMC-14/RobustToolbox/Robust.UnitTesting/RobustIntegrationTest.cs:line 1097
```