### PR TITLE
Fix TabContainer click detection when UIScale was not == 1.0

### DIFF
--- a/Robust.Client/UserInterface/Controls/TabContainer.cs
+++ b/Robust.Client/UserInterface/Controls/TabContainer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Numerics;
 using Robust.Client.Graphics;
 using Robust.Shared.Input;
@@ -21,6 +22,8 @@ namespace Robust.Client.UserInterface.Controls
 
         private int _currentTab;
         private bool _tabsVisible = true;
+        // The right-most coordinate of each tab header
+        private List<float> _tabRight = new();
 
         public int CurrentTab
         {
@@ -157,11 +160,14 @@ namespace Robust.Client.UserInterface.Controls
 
             var headerOffset = 0f;
 
+            _tabRight.Clear();
+
             // Then, draw the tabs.
             for (var i = 0; i < ChildCount; i++)
             {
                 if (!GetTabVisible(i))
                 {
+                    _tabRight.Add(headerOffset);
                     continue;
                 }
 
@@ -200,6 +206,7 @@ namespace Robust.Client.UserInterface.Controls
                     contentBox = UIBox2.FromDimensions(topLeft, size);
                 }
 
+
                 var baseLine = new Vector2(0, font.GetAscent(UIScale)) + contentBox.TopLeft;
 
                 foreach (var rune in title.EnumerateRunes())
@@ -214,6 +221,8 @@ namespace Robust.Client.UserInterface.Controls
                 }
 
                 headerOffset += boxAdvance;
+                // Remember the right-most point of this tab, for testing clicked areas
+                _tabRight.Add(headerOffset);
             }
         }
 
@@ -283,46 +292,17 @@ namespace Robust.Client.UserInterface.Controls
             args.Handle();
 
             var relX = args.RelativePixelPosition.X;
-
-            var font = _getFont();
-            var boxActive = _getTabBoxActive();
-            var boxInactive = _getTabBoxInactive();
-
-            var headerOffset = 0f;
-
+            float tabLeft = 0;
             for (var i = 0; i < ChildCount; i++)
             {
-                if (!GetTabVisible(i))
+                if (relX > tabLeft && relX <= _tabRight[i])
                 {
-                    continue;
-                }
-
-                var title = GetActualTabTitle(i);
-
-                var titleLength = 0;
-                // Get string length.
-                foreach (var rune in title.EnumerateRunes())
-                {
-                    if (!font.TryGetCharMetrics(rune, UIScale, out var metrics))
-                    {
-                        continue;
-                    }
-
-                    titleLength += metrics.Advance;
-                }
-
-                var active = _currentTab == i;
-                var box = active ? boxActive : boxInactive;
-                var boxAdvance = titleLength + (box?.MinimumSize.X ?? 0);
-
-                if (headerOffset < relX && headerOffset + boxAdvance > relX)
-                {
-                    // Got em.
                     CurrentTab = i;
                     return;
                 }
 
-                headerOffset += boxAdvance;
+                // Next tab starts here
+                tabLeft = _tabRight[i];
             }
         }
 

--- a/Robust.Client/UserInterface/Controls/TabContainer.cs
+++ b/Robust.Client/UserInterface/Controls/TabContainer.cs
@@ -206,7 +206,6 @@ namespace Robust.Client.UserInterface.Controls
                     contentBox = UIBox2.FromDimensions(topLeft, size);
                 }
 
-
                 var baseLine = new Vector2(0, font.GetAscent(UIScale)) + contentBox.TopLeft;
 
                 foreach (var rune in title.EnumerateRunes())


### PR DESCRIPTION
Fixes #5321.

Draw() and KeyBindDown() had copy-pasted-but-slightly-different code for calculating the size of each tab. The KeyBindDown() version didn't account for UIScale. Now, Draw() will just store the coordinates for each tab, and KeyBindDown() will look up the click location - removes code duplication, unnecessary calculations and fixes the bug. 