### PR TITLE
AudioComponents can now set volume on client side

### DIFF
--- a/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
+++ b/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
@@ -353,19 +353,19 @@ public abstract partial class SharedAudioSystem : EntitySystem
     /// <summary>
     /// Sets the audio params volume for an entity.
     /// </summary>
-    public void SetGain(EntityUid? entity, float value, AudioComponent? component = null)
+    public void SetGain(EntityUid? entity, float value, AudioComponent? component = null, bool dirty = true)
     {
         if (entity == null || !Resolve(entity.Value, ref component))
             return;
 
         var volume = GainToVolume(value);
-        SetVolume(entity, volume, component);
+        SetVolume(entity, volume, component, dirty);
     }
 
     /// <summary>
     /// Sets the audio params volume for an entity.
     /// </summary>
-    public void SetVolume(EntityUid? entity, float value, AudioComponent? component = null)
+    public void SetVolume(EntityUid? entity, float value, AudioComponent? component = null, bool dirty = true)
     {
         if (entity == null || !Resolve(entity.Value, ref component))
             return;
@@ -375,7 +375,8 @@ public abstract partial class SharedAudioSystem : EntitySystem
 
         component.Params.Volume = value;
         component.Volume = value;
-        Dirty(entity.Value, component);
+        if(dirty)
+            Dirty(entity.Value, component);
     }
 
     #endregion


### PR DESCRIPTION
This PR adds an additional argument `dirty` to the `SetVolume` and `SetGain` methods.

I've been trying to set up a jukebox volume slider for a few days, and the only way I can get volume changes to change on client-side is by preventing the component from being marked as dirty on the client.