### PR TITLE
Obsolete some static localization methods

### DIFF
--- a/Robust.Shared/Localization/Loc.cs
+++ b/Robust.Shared/Localization/Loc.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using JetBrains.Annotations;
-using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
 
 namespace Robust.Shared.Localization
@@ -36,6 +34,7 @@ namespace Robust.Shared.Localization
             return LocalizationManager.GetString(messageId);
         }
 
+        [Obsolete("Use ILocalizationManager")]
         public static bool TryGetString(string messageId, [NotNullWhen(true)] out string? message)
         {
             return LocalizationManager.TryGetString(messageId, out message);
@@ -49,6 +48,7 @@ namespace Robust.Shared.Localization
             return LocalizationManager.GetString(messageId, args);
         }
 
+        [Obsolete("Use ILocalizationManager")]
         public static bool TryGetString(
             string messageId,
             [NotNullWhen(true)] out string? value,


### PR DESCRIPTION
This just marks two more of the static localization manager methods as obsolete. One is already unused by ss14, and the other has a total of 4 uses.