### PR TITLE
EntityPrototypeView has become disposable

### DIFF
--- a/Robust.Client/UserInterface/Controls/EntityPrototypeView.cs
+++ b/Robust.Client/UserInterface/Controls/EntityPrototypeView.cs
@@ -56,4 +56,15 @@ public class EntityPrototypeView : SpriteView
         base.ExitedTree();
         EntMan.TryQueueDeleteEntity(_ourEntity);
     }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (!disposing)
+            return;
+
+        if (_ourEntity is not null)
+            EntMan.DeleteEntity(_ourEntity);
+    }
 }


### PR DESCRIPTION
EntityPrototypeView does not delete an entity unless done manually via `SetPrototype(null)`. This causes the test to fail in https://github.com/space-wizards/space-station-14/pull/32339.