### PR TITLE
Set sprite flicks immediately

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
@@ -143,6 +143,14 @@ namespace Robust.Client.GameObjects
             }
 #endif
 
+            foreach (var track in animation.AnimationTracks)
+            {
+                if (track is not AnimationTrackSpriteFlick)
+                    continue;
+
+                track.AdvancePlayback(ent.Owner, 0, 0, 0f);
+            }
+
             ent.Comp.PlayingAnimations.Add(key, playback);
         }
 


### PR DESCRIPTION
So on content we have an issue where the animation is played in doorsystem but sprite layer visibility is controlled by airlocksystem. The issue then is that we get a single frame where the incorrect sprite is shown before it corrects itself when the animation runs next frame. The easiest way to reproduce this is to walk into a door that denies you and observe it shows the incorrect sprite then flickers to the denied one.

There might be more systems with these issues which is why I did this here instead.