### PR TITLE
Remove IsTouching set on physics prediction

### DIFF
--- a/Robust.Client/Physics/PhysicsSystem.Predict.cs
+++ b/Robust.Client/Physics/PhysicsSystem.Predict.cs
@@ -156,7 +156,6 @@ public sealed partial class PhysicsSystem
 
             if (activeA == false && activeB == false)
             {
-                contact.IsTouching = false;
                 continue;
             }
 

--- a/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
+++ b/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
@@ -35,6 +35,7 @@ using Robust.Shared.Physics.Collision;
 using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.ViewVariables;
 
 namespace Robust.Shared.Physics.Dynamics.Contacts
 {
@@ -94,11 +95,13 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
         /// <summary>
         ///     Determines whether the contact is touching.
         /// </summary>
+        [ViewVariables]
         public bool IsTouching { get; internal set; }
 
         /// Enable/disable this contact. This can be used inside the pre-solve
         /// contact listener. The contact is only disabled for the current
         /// time step (or sub-step in continuous collisions).
+        [ViewVariables]
         public bool Enabled { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Just because an entity sleeps doesn't mean it's not touching necessarily. This causes client to mispredict against server and continuously fire collision events if we try to move into an entity.

I don't think it causes any issues and better physics prediction is still months away.

Easiest way to reproduced is to walk into a locked airlock and watch it flicker constantly.