### PR TITLE
Revert "Make resetting contacts on the client only set is touching if it is true"

### DIFF
--- a/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
+++ b/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
@@ -31,6 +31,8 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Maths;
 using Robust.Shared.Physics.Collision;
 using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Physics.Components;
@@ -259,9 +261,7 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
             {
                 var manifold = Manifold;
                 Evaluate(ref manifold, bodyATransform, bodyBTransform);
-
-                if (IsTouching)
-                    IsTouching = manifold.PointCount > 0;
+                IsTouching = manifold.PointCount > 0;
             }
         }
 


### PR DESCRIPTION
Reverts space-wizards/RobustToolbox#5372

This causes issues with contact prediction when you stop contacting an entity it will play the collision event again. I checked with smug and probably no issues for RMC.