### PR TITLE
Account for scale when calculating sprite offset in SpriteView

### DIFF
--- a/Robust.Client/UserInterface/Controls/SpriteView.cs
+++ b/Robust.Client/UserInterface/Controls/SpriteView.cs
@@ -245,7 +245,7 @@ namespace Robust.Client.UserInterface.Controls
 
             var offset = SpriteOffset
                 ? Vector2.Zero
-                : - (-_eyeRotation).RotateVec(sprite.Offset) * new Vector2(1, -1) * EyeManager.PixelsPerMeter;
+                : - (-_eyeRotation).RotateVec(sprite.Offset * _scale) * new Vector2(1, -1) * EyeManager.PixelsPerMeter;
 
             var position = PixelSize / 2 + offset * stretch * UIScale;
             var scale = Scale * UIScale * stretch;


### PR DESCRIPTION
When a sprite had a non-zero offset and was displayed in a SpriteView with non-unity scale, the position to draw the sprite was calculated incorrectly.

Before:
![2024-09-28_13-11](https://github.com/user-attachments/assets/c4c752c1-0b9a-4dbc-b810-08458c14471e)

After:
![2024-09-28_13-26](https://github.com/user-attachments/assets/ceb47c5d-d9c8-4e5e-adfe-966a9e6f4731)

I went through all the other SpriteViews after making this change to check that nothing broke. All looks fine.