### PR TITLE
Change access level of BoundUserInterface's IPlayerManager

### DIFF
--- a/Robust.Shared/GameObjects/Components/UserInterface/BoundUserInterface.cs
+++ b/Robust.Shared/GameObjects/Components/UserInterface/BoundUserInterface.cs
@@ -12,7 +12,7 @@ namespace Robust.Shared.GameObjects
     public abstract class BoundUserInterface : IDisposable
     {
         [Dependency] protected readonly IEntityManager EntMan = default!;
-        [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
+        [Dependency] protected readonly ISharedPlayerManager PlayerManager = default!;
         protected readonly SharedUserInterfaceSystem UiSystem;
 
         public readonly Enum UiKey;
@@ -79,7 +79,7 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         public void Close()
         {
-            UiSystem.CloseUi(Owner, UiKey, _playerManager.LocalEntity, predicted: true);
+            UiSystem.CloseUi(Owner, UiKey, PlayerManager.LocalEntity, predicted: true);
         }
 
         /// <summary>


### PR DESCRIPTION
Just changes the access level of the ISharedPlayerManager in BoundUserInterface.

This is a useful thing for UIs to be able to access; from a quick search, at least the Instrument, CargoOrderConsole, and CriminalRecordsConsole BUIs are re-adding this same dependency because it's not accessible. Coming up, in PR https://github.com/space-wizards/space-station-14/pull/32465, I'm adding the dependency to the APC BUI and am about to add it to the Paper BUI (https://github.com/eoineoineoin/space-station-14/commit/33e68f342429c40402a0ac9d86201bbd9e77fcab).

Would be nice to get this duplication under control now.