### PR TITLE
Entities filtering for forks

### DIFF
--- a/Resources/EnginePrototypes/entityCategory.yml
+++ b/Resources/EnginePrototypes/entityCategory.yml
@@ -18,3 +18,9 @@
   description: entity-category-desc-hide
   hideSpawnMenu: true
   inheritable: false
+
+# Entity prototypes added by the fork. With CVar you can hide all entities without this category
+- type: entityCategory
+  id: ForkFiltered
+  name: entity-category-name-fork
+  description: entity-category-desc-fork

--- a/Resources/Locale/en-US/entity-category.ftl
+++ b/Resources/Locale/en-US/entity-category.ftl
@@ -7,3 +7,6 @@ entity-category-desc-spawner = Entity prototypes that spawn other entities.
 
 entity-category-name-hide = Hidden
 entity-category-desc-hide = Entity prototypes that should be hidden from entity spawn menus
+
+entity-category-name-fork = Fork Filtered
+entity-category-desc-fork = Entity prototypes added by the fork. With CVar you can hide all entities without this category

--- a/Robust.Client/UserInterface/Controllers/Implementations/EntitySpawningUIController.cs
+++ b/Robust.Client/UserInterface/Controllers/Implementations/EntitySpawningUIController.cs
@@ -7,6 +7,8 @@ using Robust.Client.Placement;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared;
+using Robust.Shared.Configuration;
 using Robust.Shared.Enums;
 using Robust.Shared.IoC;
 using Robust.Shared.Prototypes;
@@ -19,6 +21,7 @@ namespace Robust.Client.UserInterface.Controllers.Implementations;
 
 public sealed class EntitySpawningUIController : UIController
 {
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IPlacementManager _placement = default!;
     [Dependency] private readonly IPrototypeManager _prototypes = default!;
 
@@ -192,6 +195,9 @@ public sealed class EntitySpawningUIController : UIController
         _window.SelectedButton = null;
         searchStr = searchStr?.ToLowerInvariant();
 
+        var categoryFilter = _cfg.GetCVar(CVars.EntitiesCategoryFilter);
+        _prototypes.TryIndex<EntityCategoryPrototype>(categoryFilter, out var filter);
+
         foreach (var prototype in _prototypes.EnumeratePrototypes<EntityPrototype>())
         {
             if (prototype.Abstract)
@@ -200,6 +206,11 @@ public sealed class EntitySpawningUIController : UIController
             }
 
             if (prototype.HideSpawnMenu)
+            {
+                continue;
+            }
+
+            if (filter is not null && !prototype.Categories.Contains(filter))
             {
                 continue;
             }

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -683,6 +683,13 @@ namespace Robust.Shared
         public static readonly CVarDef<string> BuildManifestHash =
             CVarDef.Create("build.manifest_hash", "");
 
+        /// <summary>
+        /// Allows you to disable the display of all entities in the spawn menu that are not labeled with the ShowSpawnMenu category.
+        /// This is useful for forks that just want to disable the standard upstream content
+        /// </summary>
+        public static readonly CVarDef<string> EntitiesCategoryFilter =
+            CVarDef.Create("build.entities_category_filter", "");
+
         /*
          * WATCHDOG
          */


### PR DESCRIPTION
A new entity category “ForkFiltered” has been added. Added new CVar “build.entities_category_filter”, where this category can be assigned.

Forks can assign this CVar to their server, and assign the new category to all their entities to safely hide all upstream content from spawn menu without causing conflicts. 