### PR TITLE
Replace obsolete functions in GridRotation Tests

### DIFF
--- a/Robust.UnitTesting/Shared/Map/GridRotation_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/GridRotation_Tests.cs
@@ -25,6 +25,8 @@ namespace Robust.UnitTesting.Shared.Map
 
             var entMan = server.ResolveDependency<IEntityManager>();
             var mapMan = server.ResolveDependency<IMapManager>();
+            var mapSystem = entMan.System<SharedMapSystem>();
+            var transformSystem = entMan.System<SharedTransformSystem>();
 
             await server.WaitAssertion(() =>
             {
@@ -34,22 +36,23 @@ namespace Robust.UnitTesting.Shared.Map
                 var coordinates = new EntityCoordinates(gridEnt, new Vector2(10, 0));
 
                 // if no rotation and 0,0 position should just be the same coordinate.
-                Assert.That(entMan.GetComponent<TransformComponent>(gridEnt).WorldRotation, Is.EqualTo(Angle.Zero));
-                Assert.That(grid.Comp.WorldToLocal(coordinates.Position), Is.EqualTo(coordinates.Position));
+                Assert.That(transformSystem.GetWorldRotation(gridEnt), Is.EqualTo(Angle.Zero));
+
+                Assert.That(mapSystem.WorldToLocal(grid.Owner, grid.Comp, coordinates.Position), Is.EqualTo(coordinates.Position));
 
                 // Rotate 180 degrees should show -10, 0 for the position in map-terms and 10, 0 for the position in entity terms (i.e. no change).
                 entMan.GetComponent<TransformComponent>(gridEnt).WorldRotation += new Angle(MathF.PI);
-                Assert.That(entMan.GetComponent<TransformComponent>(gridEnt).WorldRotation, Is.EqualTo(new Angle(MathF.PI)));
+                Assert.That(transformSystem.GetWorldRotation(gridEnt), Is.EqualTo(new Angle(MathF.PI)));
                 // Check the map coordinate rotates correctly
-                Assert.That(grid.Comp.WorldToLocal(new Vector2(10, 0)).EqualsApprox(new Vector2(-10, 0), 0.01f));
-                Assert.That(grid.Comp.LocalToWorld(coordinates.Position).EqualsApprox(new Vector2(-10, 0), 0.01f));
+                Assert.That(mapSystem.WorldToLocal(grid.Owner, grid.Comp, new Vector2(10, 0)).EqualsApprox(new Vector2(-10, 0), 0.01f));
+                Assert.That(mapSystem.LocalToWorld(grid.Owner, grid.Comp, coordinates.Position).EqualsApprox(new Vector2(-10, 0), 0.01f));
 
                 // Now we'll do the same for 180 degrees.
                 entMan.GetComponent<TransformComponent>(gridEnt).WorldRotation += MathF.PI / 2f;
                 // If grid facing down then worldpos of 10, 0 gets rotated 90 degrees CCW and hence should be 0, 10
-                Assert.That(grid.Comp.WorldToLocal(new Vector2(10, 0)).EqualsApprox(new Vector2(0, 10), 0.01f));
+                Assert.That(mapSystem.WorldToLocal(grid.Owner, grid.Comp, new Vector2(10, 0)).EqualsApprox(new Vector2(0, 10), 0.01f));
                 // If grid facing down then local 10,0 pos should just return 0, -10 given it's aligned with the rotation.
-                Assert.That(grid.Comp.LocalToWorld(coordinates.Position).EqualsApprox(new Vector2(0, -10), 0.01f));
+                Assert.That(mapSystem.LocalToWorld(grid.Owner, grid.Comp, coordinates.Position).EqualsApprox(new Vector2(0, -10), 0.01f));
             });
         }
 
@@ -78,11 +81,11 @@ namespace Robust.UnitTesting.Shared.Map
                 {
                     for (var y = 0; y < 10; y++)
                     {
-                        grid.Comp.SetTile(new Vector2i(x, y), tile);
+                        mapSystem.SetTile(grid, new Vector2i(x, y), tile);
                     }
                 }
 
-                var chunks = grid.Comp.GetMapChunks().Select(c => c.Value).ToList();
+                var chunks = mapSystem.GetMapChunks(grid.Owner, grid.Comp).Select(c => c.Value).ToList();
 
                 Assert.That(chunks.Count, Is.EqualTo(1));
                 var chunk = chunks[0];


### PR DESCRIPTION
Project zero warnings.