### PR TITLE
Shutdown before main loop reason logging

### DIFF
--- a/Robust.Server/BaseServer.cs
+++ b/Robust.Server/BaseServer.cs
@@ -566,7 +566,7 @@ namespace Robust.Server
             // Don't start the main loop. This only works if a reason is passed to Shutdown(...)
             if (_shutdownReason != null)
             {
-                _logger.Fatal("Shutdown has been requested before the main loop has been started, complying.");
+                _logger.Fatal("Shutdown has been requested before the main loop has been started, complying. Reason: {0}", _shutdownReason);
             }
             else _mainLoop.Run();
 


### PR DESCRIPTION
+ Server now also logs reason of shutdown when shutting down before main loop starts

Right now, the server just logs "Shutdown has been requested..." without any reasons for this particular shutdown, which may confuse someone who just uses server as is without checking anything on the inside . This PR aims to resolve this issue by logging actual reason of restart on the same line, so that:

this:
<img width="685" alt="Screenshot 2024-10-07 at 15 37 44" src="https://github.com/user-attachments/assets/9fd9fd8a-406d-4f96-84d2-ccacc908b592"><br>
becomes that:
<img width="845" alt="Screenshot 2024-10-07 at 15 25 01" src="https://github.com/user-attachments/assets/4f942135-5f8e-4f49-864f-8d07a3f65cdb"><br>