### PR TITLE
Separate window creation in `OSWindow.Show()` to allow creation in the background

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.Events.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Events.cs
@@ -109,6 +109,9 @@ namespace Robust.Client.Graphics.Clyde
 
         private void SendWindowResized(WindowReg reg, Vector2i oldSize)
         {
+            if (!reg.IsVisible) // Only send this for open windows
+                return;
+
             var loaded = RtToLoaded(reg.RenderTarget);
             loaded.Size = reg.FramebufferSize;
 

--- a/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
@@ -444,6 +444,12 @@ namespace Robust.Client.Graphics.Clyde
             _windowing!.CursorSet(_mainWindow!, cursor);
         }
 
+        private void SetWindowSize(WindowReg reg, Vector2i size)
+        {
+            DebugTools.AssertNotNull(_windowing);
+
+            _windowing!.WindowSetSize(reg, size);
+        }
 
         private void SetWindowVisible(WindowReg reg, bool visible)
         {
@@ -533,7 +539,11 @@ namespace Robust.Client.Graphics.Clyde
                 _clyde.DoDestroyWindow(Reg);
             }
 
-            public Vector2i Size => Reg.FramebufferSize;
+            public Vector2i Size
+            {
+                get => Reg.FramebufferSize;
+                set => _clyde.SetWindowSize(Reg, value);
+            }
 
             public IRenderTarget RenderTarget => Reg.RenderTarget;
 

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -517,7 +517,7 @@ namespace Robust.Client.Graphics.Clyde
                 RenderTarget = renderTarget;
             }
 
-            public Vector2i Size { get; } = default;
+            public Vector2i Size { get; set; } = default;
             public bool IsDisposed { get; private set; }
             public WindowId Id { get; set; }
             public IRenderTarget RenderTarget { get; }

--- a/Robust.Client/Graphics/Clyde/Windowing/Glfw.WindowThread.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Glfw.WindowThread.cs
@@ -85,6 +85,10 @@ namespace Robust.Client.Graphics.Clyde
                         WinThreadWinSetMonitor(cmd);
                         break;
 
+                    case CmdWinSetSize cmd:
+                        WinThreadWinSetSize(cmd);
+                        break;
+
                     case CmdWinSetVisible cmd:
                         WinThreadWinSetVisible(cmd);
                         break;
@@ -232,6 +236,11 @@ namespace Robust.Client.Graphics.Clyde
 
             private sealed record CmdWinSetFullscreen(
                 nint Window
+            ) : CmdBase;
+
+            private sealed record CmdWinSetSize(
+                nint Window,
+                int W, int H
             ) : CmdBase;
 
             private sealed record CmdWinSetVisible(

--- a/Robust.Client/Graphics/Clyde/Windowing/Glfw.Windows.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Glfw.Windows.cs
@@ -84,12 +84,26 @@ namespace Robust.Client.Graphics.Clyde
                 );
             }
 
+            public void WindowSetSize(WindowReg window, Vector2i size)
+            {
+                var reg = (GlfwWindowReg) window;
+
+                SendCmd(new CmdWinSetSize((nint) reg.GlfwWindow, size.X, size.Y));
+            }
+
             public void WindowSetVisible(WindowReg window, bool visible)
             {
                 var reg = (GlfwWindowReg) window;
                 reg.IsVisible = visible;
 
                 SendCmd(new CmdWinSetVisible((nint) reg.GlfwWindow, visible));
+            }
+
+            private void WinThreadWinSetSize(CmdWinSetSize cmd)
+            {
+                var win = (Window*) cmd.Window;
+
+                GLFW.SetWindowSize(win, cmd.W, cmd.H);
             }
 
             private void WinThreadWinSetVisible(CmdWinSetVisible cmd)

--- a/Robust.Client/Graphics/Clyde/Windowing/IWindowingImpl.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/IWindowingImpl.cs
@@ -39,6 +39,7 @@ namespace Robust.Client.Graphics.Clyde
             void WindowDestroy(WindowReg reg);
             void WindowSetTitle(WindowReg window, string title);
             void WindowSetMonitor(WindowReg window, IClydeMonitor monitor);
+            void WindowSetSize(WindowReg window, Vector2i size);
             void WindowSetVisible(WindowReg window, bool visible);
             void WindowRequestAttention(WindowReg window);
             void WindowSwapBuffers(WindowReg window);

--- a/Robust.Client/Graphics/Clyde/Windowing/Sdl2.WindowThread.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Sdl2.WindowThread.cs
@@ -93,6 +93,10 @@ internal partial class Clyde
                     WinThreadWinRequestAttention(cmd);
                     break;
 
+                case CmdWinSetSize cmd:
+                    WinThreadWinSetSize(cmd);
+                    break;
+
                 case CmdWinSetVisible cmd:
                     WinThreadWinSetVisible(cmd);
                     break;
@@ -244,6 +248,11 @@ internal partial class Clyde
 
         private sealed record CmdWinRequestAttention(
             nint Window
+        ) : CmdBase;
+
+        private sealed record CmdWinSetSize(
+            nint Window,
+            int W, int H
         ) : CmdBase;
 
         private sealed record CmdWinSetVisible(

--- a/Robust.Client/Graphics/Clyde/Windowing/Sdl2.Windows.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Sdl2.Windows.cs
@@ -338,12 +338,18 @@ internal partial class Clyde
 
         public void WindowSetSize(WindowReg window, Vector2i size)
         {
-            //TODO
+            SendCmd(new CmdWinSetSize(WinPtr(window), size.X, size.Y));
         }
 
         public void WindowSetVisible(WindowReg window, bool visible)
         {
+            window.IsVisible = visible;
             SendCmd(new CmdWinSetVisible(WinPtr(window), visible));
+        }
+
+        private static void WinThreadWinSetSize(CmdWinSetSize cmd)
+        {
+            SDL_SetWindowSize(cmd.Window, cmd.W, cmd.H);
         }
 
         private static void WinThreadWinSetVisible(CmdWinSetVisible cmd)

--- a/Robust.Client/Graphics/Clyde/Windowing/Sdl2.Windows.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Sdl2.Windows.cs
@@ -336,6 +336,11 @@ internal partial class Clyde
             _sawmill.Warning("WindowSetMonitor not implemented on SDL2");
         }
 
+        public void WindowSetSize(WindowReg window, Vector2i size)
+        {
+            //TODO
+        }
+
         public void WindowSetVisible(WindowReg window, bool visible)
         {
             SendCmd(new CmdWinSetVisible(WinPtr(window), visible));

--- a/Robust.Client/Graphics/IClydeWindow.cs
+++ b/Robust.Client/Graphics/IClydeWindow.cs
@@ -14,7 +14,7 @@ namespace Robust.Client.Graphics
         WindowId Id { get; }
         IRenderTarget RenderTarget { get; }
         string Title { get; set; }
-        Vector2i Size { get; }
+        Vector2i Size { get; set; }
         bool IsFocused { get; }
         bool IsMinimized { get; }
         bool IsVisible { get; set; }

--- a/Robust.Client/UserInterface/Controls/OSWindow.cs
+++ b/Robust.Client/UserInterface/Controls/OSWindow.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Numerics;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.IoC;
 using Robust.Shared.Maths;
+using TerraFX.Interop.Windows;
 
 namespace Robust.Client.UserInterface.Controls
 {
@@ -27,17 +27,6 @@ namespace Robust.Client.UserInterface.Controls
         public IClydeWindow? ClydeWindow { get; private set; }
 
         /// <summary>
-        /// The window that will "own" this window.
-        /// Owned windows always appear on top of their owners and have some other misc behavior depending on the OS.
-        /// </summary>
-        public IClydeWindow? Owner { get; set; }
-
-        /// <summary>
-        /// Whether the window is currently open.
-        /// </summary>
-        public bool IsOpen => ClydeWindow != null;
-
-        /// <summary>
         /// The title of the window.
         /// </summary>
         /// <remarks>
@@ -49,35 +38,10 @@ namespace Robust.Client.UserInterface.Controls
             set
             {
                 _title = value;
-
                 if (ClydeWindow != null)
-                    ClydeWindow.Title = value;
+                    ClydeWindow.Title = _title;
             }
         }
-
-        /// <summary>
-        /// The location to place the window at when it is opened.
-        /// </summary>
-        /// <remarks>
-        /// Changing this while the window is open has no effect.
-        /// </remarks>
-        public WindowStartupLocation StartupLocation { get; set; }
-
-        /// <summary>
-        /// Controls whether to automatically size one or both axis of the window to fit the content.
-        /// </summary>
-        /// <remarks>
-        /// Changing this while the window is open has no effect.
-        /// </remarks>
-        public WindowSizeToContent SizeToContent { get; set; }
-
-        /// <summary>
-        /// Specifies window styling options for the window.
-        /// </summary>
-        /// <remarks>
-        /// Changing this while the window is open has no effect.
-        /// </remarks>
-        public OSWindowStyles WindowStyles { get; set; }
 
         /// <summary>
         /// Raised when the window is being closed
@@ -91,42 +55,30 @@ namespace Robust.Client.UserInterface.Controls
         /// </summary>
         public event Action? Closed;
 
-        public OSWindow()
+        public OSWindow() : this(title: null) { }
+
+        /// <param name="title">The title of the window.</param>
+        /// <param name="windowStyles">Specifies window styling options for the window.</param>
+        /// <param name="owner">
+        /// The window that will "own" this window.
+        /// Owned windows always appear on top of their owners and have some other misc behavior depending on the OS.
+        /// </param>
+        /// <param name="startupLocation">The location to place the window at when it is opened.</param>
+        public OSWindow(string? title = null, OSWindowStyles windowStyles = OSWindowStyles.None, IClydeWindow? owner = null, WindowStartupLocation startupLocation = WindowStartupLocation.Manual)
         {
             IoCManager.InjectDependencies(this);
-        }
 
-        /// <summary>
-        /// Show the window to the user.
-        /// </summary>
-        public void Show()
-        {
-            if (IsOpen)
-                return;
+            if (title != null)
+                Title = title;
 
-            var parameters = new WindowCreateParameters();
-
-            if (!float.IsNaN(SetWidth))
-                parameters.Width = (int) SetWidth;
-
-            if (!float.IsNaN(SetHeight))
-                parameters.Height = (int) SetHeight;
-
-            if (SizeToContent != WindowSizeToContent.Manual)
+            var parameters = new WindowCreateParameters
             {
-                Measure(Vector2Helpers.Infinity);
-
-                if ((SizeToContent & WindowSizeToContent.Width) != 0)
-                    parameters.Width = (int)DesiredSize.X;
-
-                if ((SizeToContent & WindowSizeToContent.Height) != 0)
-                    parameters.Height = (int)DesiredSize.Y;
-            }
-
-            parameters.Title = _title;
-            parameters.Styles = WindowStyles;
-            parameters.Owner = Owner;
-            parameters.StartupLocation = StartupLocation;
+                Title = Title,
+                Styles = windowStyles,
+                Owner = owner,
+                StartupLocation = startupLocation,
+                Visible = false
+            };
 
             ClydeWindow = _clyde.CreateWindow(parameters);
             ClydeWindow.RequestClosed += OnWindowRequestClosed;
@@ -135,7 +87,16 @@ namespace Robust.Client.UserInterface.Controls
 
             _root = UserInterfaceManager.CreateWindowRoot(ClydeWindow);
             _root.AddChild(this);
+        }
 
+        /// <summary>
+        /// Show the window to the user.
+        /// </summary>
+        public void Show() {
+            if (ClydeWindow == null)
+                return;
+
+            ClydeWindow.IsVisible = true;
             Shown();
         }
 
@@ -161,6 +122,34 @@ namespace Robust.Client.UserInterface.Controls
                 return;
 
             ClydeWindow.Dispose();
+        }
+
+        public void Resize(Vector2i size)
+        {
+            if (ClydeWindow == null)
+                return;
+
+            ClydeWindow.Size = size;
+        }
+
+        /// <summary>
+        /// Sizes one or both axis of the window to fit the content.
+        /// </summary>
+        public void ResizeToContent(WindowSizeToContent axis)
+        {
+            if (ClydeWindow == null)
+                return;
+
+            Measure(Vector2Helpers.Infinity);
+
+            Vector2i size = ClydeWindow.Size;
+
+            if ((axis & WindowSizeToContent.Width) != 0)
+                size.X = (int)DesiredSize.X;
+            if ((axis & WindowSizeToContent.Height) != 0)
+                size.Y = (int)DesiredSize.Y;
+
+            ClydeWindow.Size = size;
         }
 
         private void OnWindowRequestClosed(WindowRequestClosedEventArgs eventArgs)
@@ -196,7 +185,6 @@ namespace Robust.Client.UserInterface.Controls
     [Flags]
     public enum WindowSizeToContent : byte
     {
-        Manual = 0,
         Width = 1 << 0,
         Height = 1 << 1,
         WidthAndHeight = Width | Height

--- a/Robust.Client/UserInterface/Controls/OSWindow.cs
+++ b/Robust.Client/UserInterface/Controls/OSWindow.cs
@@ -33,9 +33,9 @@ namespace Robust.Client.UserInterface.Controls
         public IClydeWindow? Owner { get; set; }
 
         /// <summary>
-        /// Whether the window is currently open.
+        /// Whether the window is created and currently open.
         /// </summary>
-        public bool IsOpen => ClydeWindow != null;
+        public bool IsOpen => ClydeWindow?.IsVisible ?? false;
 
         /// <summary>
         /// The title of the window.
@@ -97,12 +97,12 @@ namespace Robust.Client.UserInterface.Controls
         }
 
         /// <summary>
-        /// Show the window to the user.
+        /// Create the window if not already created.
+        /// This window is not visible by default, call <see cref="Show"/> to display it.
         /// </summary>
-        public void Show()
-        {
-            if (IsOpen)
-                return;
+        public IClydeWindow Create() {
+            if (ClydeWindow != null)
+                return ClydeWindow;
 
             var parameters = new WindowCreateParameters();
 
@@ -127,6 +127,7 @@ namespace Robust.Client.UserInterface.Controls
             parameters.Styles = WindowStyles;
             parameters.Owner = Owner;
             parameters.StartupLocation = StartupLocation;
+            parameters.Visible = false;
 
             ClydeWindow = _clyde.CreateWindow(parameters);
             ClydeWindow.RequestClosed += OnWindowRequestClosed;
@@ -135,6 +136,16 @@ namespace Robust.Client.UserInterface.Controls
 
             _root = UserInterfaceManager.CreateWindowRoot(ClydeWindow);
             _root.AddChild(this);
+
+            return ClydeWindow;
+        }
+
+        /// <summary>
+        /// Show the window to the user, creating it if necessary
+        /// </summary>
+        public void Show() {
+            ClydeWindow = Create();
+            ClydeWindow.IsVisible = true;
 
             Shown();
         }

--- a/Robust.Client/UserInterface/Controls/OSWindow.cs
+++ b/Robust.Client/UserInterface/Controls/OSWindow.cs
@@ -100,7 +100,8 @@ namespace Robust.Client.UserInterface.Controls
         /// Create the window if not already created.
         /// This window is not visible by default, call <see cref="Show"/> to display it.
         /// </summary>
-        public IClydeWindow Create() {
+        public IClydeWindow Create()
+        {
             if (ClydeWindow != null)
                 return ClydeWindow;
 
@@ -143,7 +144,8 @@ namespace Robust.Client.UserInterface.Controls
         /// <summary>
         /// Show the window to the user, creating it if necessary
         /// </summary>
-        public void Show() {
+        public void Show()
+        {
             ClydeWindow = Create();
             ClydeWindow.IsVisible = true;
 


### PR DESCRIPTION
OSWindow wouldn't create the window and its UI root until `Show()` was called. This caused issues for controls we needed to initialize & run before ever being visible. Now they are both created immediately, with `Show()` being used to make them visible.

This also required being able to set a window's size after creation, so I added the ability to do that. This is something OpenDream was going to need at some point anyway.