### PR TITLE
Fix map netId completions

### DIFF
--- a/Robust.Shared/Console/CompletionHelper.cs
+++ b/Robust.Shared/Console/CompletionHelper.cs
@@ -188,7 +188,7 @@ public static class CompletionHelper
     {
         IoCManager.Resolve(ref entManager);
 
-        return Components<MapComponent>(string.Empty, entManager, limit: int.MaxValue); // faster just to pass the max value than bother unlimiting it.
+        return Components<MapComponent>(string.Empty, entManager, limit: 128);
     }
 
     /// <summary>

--- a/Robust.Shared/Console/CompletionHelper.cs
+++ b/Robust.Shared/Console/CompletionHelper.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using JetBrains.Annotations;
@@ -186,7 +186,9 @@ public static class CompletionHelper
 
     public static IEnumerable<CompletionOption> MapUids(IEntityManager? entManager = null)
     {
-        return Components<MapComponent>(string.Empty, entManager);
+        IoCManager.Resolve(ref entManager);
+
+        return Components<MapComponent>(string.Empty, entManager, limit: int.MaxValue); // faster just to pass the max value than bother unlimiting it.
     }
 
     /// <summary>
@@ -194,7 +196,7 @@ public static class CompletionHelper
     /// </summary>
     public static IEnumerable<CompletionOption> NetEntities(string text, IEntityManager? entManager = null, int limit = 20)
     {
-        if (!NetEntity.TryParse(text, out _))
+        if (text != string.Empty && !NetEntity.TryParse(text, out _))
             yield break;
 
         IoCManager.Resolve(ref entManager);
@@ -214,7 +216,7 @@ public static class CompletionHelper
 
     public static IEnumerable<CompletionOption> Components<T>(string text, IEntityManager? entManager = null, int limit = 20) where T : IComponent
     {
-        if (!NetEntity.TryParse(text, out _))
+        if (text != string.Empty && !NetEntity.TryParse(text, out _))
             yield break;
 
         IoCManager.Resolve(ref entManager);


### PR DESCRIPTION
Map netId's completion helpers didn't work because empty strings fail NetEntity.TryParse. I special cased it.
Also made the helper pull all maps because it would be unhelpful if it didn't.