### PR TITLE
Fixes for rendering in multiple windows

### DIFF
--- a/Robust.Client/Graphics/Clyde/GLContext/GLContextWindow.cs
+++ b/Robust.Client/Graphics/Clyde/GLContext/GLContextWindow.cs
@@ -43,13 +43,10 @@ namespace Robust.Client.Graphics.Clyde
 
                     return new[]
                     {
+                        GetVersionSpec(RendererOpenGLVersion.GL33),
                         GetVersionSpec(RendererOpenGLVersion.GL31),
                         GetVersionSpec(RendererOpenGLVersion.GLES3),
                         GetVersionSpec(RendererOpenGLVersion.GLES2),
-                        // Preferentially create renderers with versions other than 3.3
-                        // As activating the Steam Overlay with multiple 3.3 windows
-                        // causes the overlay to get corrupted.
-                        GetVersionSpec(RendererOpenGLVersion.GL33),
                     };
                 }
             }

--- a/Robust.Client/Graphics/Clyde/GLContext/GLContextWindow.cs
+++ b/Robust.Client/Graphics/Clyde/GLContext/GLContextWindow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Channels;
@@ -212,8 +212,8 @@ namespace Robust.Client.Graphics.Clyde
                 GL.DrawArrays(PrimitiveType.TriangleStrip, 0, 4);
                 Clyde.CheckGlError();
 
-                window.BlitDoneEvent?.Set();
                 Clyde._windowing!.WindowSwapBuffers(window.Reg);
+                window.BlitDoneEvent?.Set();
             }
 
             private unsafe void BlitThreadInit(WindowData reg)

--- a/Robust.Client/Graphics/Clyde/GLContext/GLContextWindow.cs
+++ b/Robust.Client/Graphics/Clyde/GLContext/GLContextWindow.cs
@@ -176,6 +176,7 @@ namespace Robust.Client.Graphics.Clyde
                         window.BlitDoneEvent!.Reset();
                         window.BlitStartEvent!.Set();
                         window.BlitDoneEvent.Wait();
+                        window.UnlockBeforeSwap = Clyde._cfg.GetCVar(CVars.DisplayThreadUnlockBeforeSwap);
                     }
                 }
                 else
@@ -212,8 +213,15 @@ namespace Robust.Client.Graphics.Clyde
                 GL.DrawArrays(PrimitiveType.TriangleStrip, 0, 4);
                 Clyde.CheckGlError();
 
+                if (window.UnlockBeforeSwap)
+                {
+                    window.BlitDoneEvent?.Set();
+                }
                 Clyde._windowing!.WindowSwapBuffers(window.Reg);
-                window.BlitDoneEvent?.Set();
+                if (!window.UnlockBeforeSwap)
+                {
+                    window.BlitDoneEvent?.Set();
+                }
             }
 
             private unsafe void BlitThreadInit(WindowData reg)
@@ -336,6 +344,7 @@ namespace Robust.Client.Graphics.Clyde
                 public Thread? BlitThread;
                 public ManualResetEventSlim? BlitStartEvent;
                 public ManualResetEventSlim? BlitDoneEvent;
+                public bool UnlockBeforeSwap;
             }
         }
     }

--- a/Robust.Client/Graphics/Clyde/GLContext/GLContextWindow.cs
+++ b/Robust.Client/Graphics/Clyde/GLContext/GLContextWindow.cs
@@ -43,10 +43,13 @@ namespace Robust.Client.Graphics.Clyde
 
                     return new[]
                     {
-                        GetVersionSpec(RendererOpenGLVersion.GL33),
                         GetVersionSpec(RendererOpenGLVersion.GL31),
                         GetVersionSpec(RendererOpenGLVersion.GLES3),
                         GetVersionSpec(RendererOpenGLVersion.GLES2),
+                        // Preferentially create renderers with versions other than 3.3
+                        // As activating the Steam Overlay with multiple 3.3 windows
+                        // causes the overlay to get corrupted.
+                        GetVersionSpec(RendererOpenGLVersion.GL33),
                     };
                 }
             }

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1106,6 +1106,14 @@ namespace Robust.Shared
             CVarDef.Create("display.thread_window_blit", true, CVar.CLIENTONLY);
 
         /// <summary>
+        /// Diagnostic flag for testing. When using a separate thread for multi-window blitting,
+        /// should the worker be unblocked before the SwapBuffers(). Setting to true may improve
+        /// performance but may cause crashes or rendering errors.
+        /// </summary>
+        public static readonly CVarDef<bool> DisplayThreadUnlockBeforeSwap =
+            CVarDef.Create("display.thread_unlock_before_swap", false, CVar.CLIENTONLY);
+
+        /// <summary>
         /// Buffer size of input command channel from windowing thread to main game thread.
         /// </summary>
         public static readonly CVarDef<int> DisplayInputBufferSize =


### PR DESCRIPTION
Two items:

* When rendering non-main windows on worker threads, a semaphore was released too early, resulting in a race condition changing the gl context, potential crashes/junk rendering. Probably fixes https://github.com/space-wizards/space-station-14/issues/31752

* Workaround steam overlay being non-functional when multiple windows are open - doesn't seem to be anything that Robust is doing wrong here, but opening multiple 3.3 window contexts seems to cause problems, so just move that renderer down the priority list. Hopefully this is temporary.