### PR TITLE
Fix some window UIScale bugs

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
@@ -343,6 +343,8 @@ namespace Robust.Client.Graphics.Clyde
                 if (isMain)
                     _mainWindow = reg;
 
+                reg.IsVisible = parameters.Visible;
+
                 _windows.Add(reg);
                 _windowHandles.Add(reg.Handle);
 

--- a/Robust.Client/UserInterface/Controls/OSWindow.cs
+++ b/Robust.Client/UserInterface/Controls/OSWindow.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Numerics;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.IoC;
@@ -138,6 +137,8 @@ namespace Robust.Client.UserInterface.Controls
             _root = UserInterfaceManager.CreateWindowRoot(ClydeWindow);
             _root.AddChild(this);
 
+            // Resize the window by our UIScale
+            ClydeWindow.Size = new((int)(ClydeWindow.Size.X * UIScale), (int)(ClydeWindow.Size.Y * UIScale));
             return ClydeWindow;
         }
 
@@ -192,7 +193,7 @@ namespace Robust.Client.UserInterface.Controls
 
         private void OnWindowResized(WindowResizedEventArgs obj)
         {
-            SetSize = obj.NewSize;
+            SetSize = obj.NewSize / UIScale;
         }
 
         private void RealClosed()

--- a/Robust.Client/UserInterface/UserInterfaceManager.Roots.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Roots.cs
@@ -25,14 +25,14 @@ internal sealed partial class UserInterfaceManager
             throw new ArgumentException("Window already has a UI root.");
         }
 
-        var cvarScale = _configurationManager.GetCVar(CVars.DisplayUIScale);
         var newRoot = new WindowRoot(window)
         {
             MouseFilter = Control.MouseFilterMode.Ignore,
             HorizontalAlignment = Control.HAlignment.Stretch,
-            VerticalAlignment = Control.VAlignment.Stretch,
-            UIScaleSet = cvarScale == 0f ? window.ContentScale.X : cvarScale
+            VerticalAlignment = Control.VAlignment.Stretch
         };
+
+        newRoot.UIScaleSet = CalculateAutoScale(newRoot);
 
         _roots.Add(newRoot);
         _windowsToRoot.Add(window.Id, newRoot);

--- a/Robust.Client/UserInterface/UserInterfaceManager.Roots.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Roots.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface.Controls;
+using Robust.Shared;
 using Robust.Shared.Map;
 using Robust.Shared.Utility;
 
@@ -24,12 +25,13 @@ internal sealed partial class UserInterfaceManager
             throw new ArgumentException("Window already has a UI root.");
         }
 
+        var cvarScale = _configurationManager.GetCVar(CVars.DisplayUIScale);
         var newRoot = new WindowRoot(window)
         {
             MouseFilter = Control.MouseFilterMode.Ignore,
             HorizontalAlignment = Control.HAlignment.Stretch,
             VerticalAlignment = Control.VAlignment.Stretch,
-            UIScaleSet = window.ContentScale.X
+            UIScaleSet = cvarScale == 0f ? window.ContentScale.X : cvarScale
         };
 
         _roots.Add(newRoot);


### PR DESCRIPTION
Windows were being created with a UIScale based on the window api's scaling hints. If this contradicted the `display.uiScale` cvar, it would be replaced by that the next time the window was resized. I changed it to respect the cvar from the beginning.

OSWindow also kept its `SetSize` up-to-date using its physical pixel size. If its UIScale was anything other than 1, this led to broken positioning and sizing of controls. Now it keeps UIScale in mind when updating its `SetSize`, and also multiplies its initial size by UIScale.

I also fixed a bug with `WindowReg.IsVisible` that caused it to be incorrect on window creation.