### PR TITLE
Update Session Dict Before invoking PlayerStatusChanged

### DIFF
--- a/Robust.Server/Player/PlayerManager.cs
+++ b/Robust.Server/Player/PlayerManager.cs
@@ -103,6 +103,7 @@ namespace Robust.Server.Player
             if (!TryGetSessionById(user, out var session))
                 return;
 
+            RemoveSession(session.UserId);
             SetStatus(session, SessionStatus.Disconnected);
             SetAttachedEntity(session, null, out _, true);
 
@@ -112,7 +113,6 @@ namespace Robust.Server.Player
                 viewSys.RemoveViewSubscriber(eye, session);
             }
 
-            RemoveSession(session.UserId);
             PlayerCountMetric.Set(PlayerCount);
             Dirty();
         }


### PR DESCRIPTION
Tested with SS14 master

Stops session existing in `InternalSessions` while `PlayerStatusChanged` is invoked

fix space-wizards/space-station-14#32926