### PR TITLE
More UniqueIndex fixes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Fix `UniqueIndex<,>.RemoveRange()` and`UniqueIndexHkm<,>.RemoveRange()` clearing the whole set instead of just removing the specified values.
 
 ### Other
 

--- a/Robust.Shared/Utility/UniqueIndex.cs
+++ b/Robust.Shared/Utility/UniqueIndex.cs
@@ -87,7 +87,7 @@ namespace Robust.Shared.Utility
                 return false;
             }
 
-            var newIndex = _index.SetItem(key, new HashSet<TValue>());
+            var newIndex = _index.Remove(key);
 
             if (_index != newIndex)
             {
@@ -126,7 +126,7 @@ namespace Robust.Shared.Utility
 
             var c = set.Count;
 
-            set.ExceptWith(set);
+            set.ExceptWith(values);
 
             return c - set.Count;
         }

--- a/Robust.Shared/Utility/UniqueIndexHkm.cs
+++ b/Robust.Shared/Utility/UniqueIndexHkm.cs
@@ -89,14 +89,11 @@ namespace Robust.Shared.Utility
         {
             InitializedCheck();
 
-            if (_index.Count == 0) return 0;
-
-            if (!_index.TryGetValue(key, out var set)) return 0;
+            if (!_index.TryGetValue(key, out var set))
+                return 0;
 
             var c = set.Count;
-
-            set.ExceptWith(set);
-
+            set.ExceptWith(values);
             return c - set.Count;
         }
 


### PR DESCRIPTION
Applies the `UniqueIndexHkm<,>` changes from 6b43036 to `UniqueIndex<,>`, and also stops `RemoveRange()` from clearing the whole set instead of just removing the specified values.