### PR TITLE
Make PVS ignore duplicate view subscriber

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,7 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* `SharedEyeSystem..SetTarget()` will now also automatically remove the old target from the session's ViewSubscriptions
 
 ### New features
 

--- a/Robust.Server/GameStates/PvsSystem.Chunks.cs
+++ b/Robust.Server/GameStates/PvsSystem.Chunks.cs
@@ -184,10 +184,9 @@ internal sealed partial class PvsSystem
             return;
         }
 
-        int i = 0;
+        var i = 0;
         if (session.AttachedEntity is { } local)
         {
-            DebugTools.Assert(!session.ViewSubscriptions.Contains(local));
             Array.Resize(ref pvsSession.Viewers, session.ViewSubscriptions.Count + 1);
             pvsSession.Viewers[i++] = (local, Transform(local), _eyeQuery.CompOrNull(local));
         }
@@ -198,7 +197,8 @@ internal sealed partial class PvsSystem
 
         foreach (var ent in session.ViewSubscriptions)
         {
-            pvsSession.Viewers[i++] =  (ent, Transform(ent), _eyeQuery.CompOrNull(ent));
+            if (ent != session.AttachedEntity)
+                pvsSession.Viewers[i++] =  (ent, Transform(ent), _eyeQuery.CompOrNull(ent));
         }
     }
 

--- a/Robust.Shared/GameObjects/Systems/SharedEyeSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedEyeSystem.cs
@@ -120,14 +120,10 @@ public abstract class SharedEyeSystem : EntitySystem
         if (TryComp(uid, out ActorComponent? actorComp))
         {
             if (value != null)
-            {
                 _views.AddViewSubscriber(value.Value, actorComp.PlayerSession);
-            }
-            else
-            {
-                // Should never be null here
-                _views.RemoveViewSubscriber(eyeComponent.Target!.Value, actorComp.PlayerSession);
-            }
+
+            if (eyeComponent.Target is { } old)
+                _views.RemoveViewSubscriber(old, actorComp.PlayerSession);
         }
 
         eyeComponent.Target = value;


### PR DESCRIPTION
Changes `PvsSystem.GetSessionViewers()` so that it just ignores a view subscription if the player is already attached to the entity.
Also changes `SharedEyeSystem.SetTarget()` so that it removes the old target from the view subscription. I'm not sure if it was intentional. but adding them automatically, without also removing them automatically could've lead to players running around with a bunch of old view subs.