### PR TITLE
add `ref readonly` to sandbox

### DIFF
--- a/Robust.Shared/ContentPack/Sandbox.yml
+++ b/Robust.Shared/ContentPack/Sandbox.yml
@@ -654,6 +654,7 @@ Types:
     PreserveBaseOverridesAttribute: { All: True }
     RefSafetyRulesAttribute: { All: True }
     RequiredMemberAttribute: { All: True }
+    RequiresLocationAttribute: { All: True }
     RuntimeCompatibilityAttribute: { All: True }
     RuntimeHelpers: { All: True }
     SwitchExpressionException: { All: True }


### PR DESCRIPTION
lets you do `proc(ref readonly variable)` in proc defs