### PR TITLE
Fix for server consoles without width and length

### DIFF
--- a/Robust.Server/Console/SystemConsoleManager.cs
+++ b/Robust.Server/Console/SystemConsoleManager.cs
@@ -278,7 +278,7 @@ namespace Robust.Server.Console
 
         public void DrawCommandLine()
         {
-        	if (Con.WindowWidth <= 0) return;
+            if (Con.WindowWidth <= 0) return;
             ClearCurrentLine();
             Con.SetCursorPosition(0, Con.CursorTop);
             Con.Write("> " + currentBuffer);

--- a/Robust.Server/Console/SystemConsoleManager.cs
+++ b/Robust.Server/Console/SystemConsoleManager.cs
@@ -174,7 +174,8 @@ namespace Robust.Server.Console
             while (Con.KeyAvailable)
             {
                 ConsoleKeyInfo key = Con.ReadKey(true);
-                Con.SetCursorPosition(0, Con.CursorTop);
+                if (Con.WindowWidth > 0)
+               		Con.SetCursorPosition(0, Con.CursorTop);
                 if (!Char.IsControl(key.KeyChar))
                 {
                     currentBuffer = currentBuffer.Insert(internalCursor++, key.KeyChar.ToString());
@@ -277,6 +278,7 @@ namespace Robust.Server.Console
 
         public void DrawCommandLine()
         {
+        	if (Con.WindowWidth <= 0) return;
             ClearCurrentLine();
             Con.SetCursorPosition(0, Con.CursorTop);
             Con.Write("> " + currentBuffer);


### PR DESCRIPTION
Everything is described here https://github.com/pelican-eggs/games-standalone/issues/19. I test this fix in pterodactyl and it's work. Funny that `if (Con.CursorTop> 0)` cause strange behavior and bugs, but `if (Con.WindowWidth > 0)` works fine. Why? I don't know.

![image](https://github.com/user-attachments/assets/1bdbf30b-1a1c-4bb4-8f4e-7d4c3d51435e)
