### PR TITLE
Add conditional formatting to SpinBox buttons text

### DIFF
--- a/Robust.Client/UserInterface/Controls/SpinBox.cs
+++ b/Robust.Client/UserInterface/Controls/SpinBox.cs
@@ -127,11 +127,11 @@ namespace Robust.Client.UserInterface.Controls
             ClearButtons();
             foreach (var num in leftButtons)
             {
-                AddLeftButton(num, num.ToString());
+                AddLeftButton(num, num.ToString("+#;-#;0"));
             }
             foreach (var num in rightButtons)
             {
-                AddRightButton(num, num.ToString());
+                AddRightButton(num, num.ToString("+#;-#;0"));
             }
         }
 


### PR DESCRIPTION
Minor cosmetic change to `SpinBox` buttons. 

Conditional formatting makes positive numbers signed, which better reflects the function of the button (add 5, instead of set to 5).

**Example with SS14 cargo request UI**
Before the change
![before](https://github.com/user-attachments/assets/2ca849b3-3f4b-4807-ac84-a9faf28f2606)

After the change
![after](https://github.com/user-attachments/assets/be33b01f-e04c-4c66-9964-a4797077cf3d)
