### PR TITLE
Improve Toolshed type intersection mechanism, add WithCommand for ProtoId pipe param

### DIFF
--- a/Robust.Shared/Toolshed/Attributes.cs
+++ b/Robust.Shared/Toolshed/Attributes.cs
@@ -67,10 +67,11 @@ public sealed class CommandInvocationContextAttribute : Attribute
 }
 
 /// <summary>
-///     Marks a command implementation as taking the type of the previous command in sequence as a generic argument.
+///     Marks a command implementation as taking the type of the previous command in sequence as a generic argument. Supports only one generic type.
 /// </summary>
 /// <remarks>
-///     If the argument marked with <see cref="PipedArgumentAttribute"/> is not <c>T</c> but instead a pattern like <c>IEnumerable&lt;T&gt;</c>, Toolshed will account for this.
+///     If the argument marked with <see cref="PipedArgumentAttribute"/> is not <c>T</c> but instead a pattern like <c>IEnumerable&lt;T&gt;</c>,
+///     Toolshed will account for this by using <see cref="ReflectionExtensions.IntersectWithGeneric"/>. It's not very precise.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method)]
 public sealed class TakesPipedTypeAsGenericAttribute : Attribute

--- a/Robust.Shared/Toolshed/Commands/Entities/WithCommand.cs
+++ b/Robust.Shared/Toolshed/Commands/Entities/WithCommand.cs
@@ -11,6 +11,7 @@ namespace Robust.Shared.Toolshed.Commands.Entities;
 internal sealed class WithCommand : ToolshedCommand
 {
     [Dependency] private readonly IComponentFactory _componentFactory = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
 
     [CommandImplementation]
     public IEnumerable<EntityUid> With(
@@ -31,5 +32,15 @@ internal sealed class WithCommand : ToolshedCommand
     {
         var name = _componentFactory.GetComponentName(ty.Ty);
         return input.Where(x => x.Components.ContainsKey(name) ^ inverted);
+    }
+
+    [CommandImplementation, TakesPipedTypeAsGeneric]
+    public IEnumerable<ProtoId<T>> With<T>(
+        [PipedArgument] IEnumerable<ProtoId<T>> input,
+        [CommandArgument] ProtoId<T> protoId,
+        [CommandInverted] bool inverted
+    ) where T : class, IPrototype
+    {
+        return input.Where(x => (x == protoId) ^ inverted);
     }
 }

--- a/Robust.Shared/Toolshed/Commands/Generic/AsCommand.cs
+++ b/Robust.Shared/Toolshed/Commands/Generic/AsCommand.cs
@@ -5,8 +5,12 @@ namespace Robust.Shared.Toolshed.Commands.Generic;
 [ToolshedCommand]
 public sealed class AsCommand : ToolshedCommand
 {
-    public override Type[] TypeParameterParsers => new[] {typeof(Type)};
+    public override Type[] TypeParameterParsers => [ typeof(Type) ];
 
+    /// <summary>
+    ///     Uses a typecast to convert a type. It does not handle implicit casts, nor explicit ones.
+    ///     If you're thinking to extend this, you probably want to look into making a <see cref="TypeParser{T}"/>
+    /// </summary>
     [CommandImplementation, TakesPipedTypeAsGeneric]
     public TOut? As<TOut, TIn>([PipedArgument] TIn value)
         => (TOut?)(object?)value;

--- a/Robust.Shared/Toolshed/ToolshedCommand.Implementations.cs
+++ b/Robust.Shared/Toolshed/ToolshedCommand.Implementations.cs
@@ -29,6 +29,9 @@ public abstract partial class ToolshedCommand
         return false;
     }
 
+    /// <summary>
+    /// Does its best to find an implementation that can deal with the given types
+    /// </summary>
     internal List<MethodInfo> GetConcreteImplementations(Type? pipedType, Type[] typeArguments,
         string? subCommand)
     {
@@ -97,8 +100,8 @@ public abstract partial class ToolshedCommand
                         if (x.HasCustomAttribute<TakesPipedTypeAsGenericAttribute>())
                         {
                             var paramT = x.ConsoleGetPipedArgument()!.ParameterType;
-                            var t = pipedType!.Intersect(paramT);
-                            return x.MakeGenericMethod(typeArguments.Append(t).ToArray());
+                            var t = pipedType!.IntersectWithGeneric(paramT, Toolshed, true);
+                            return x.MakeGenericMethod([.. typeArguments, .. t]);
                         }
                         else
                             return x.MakeGenericMethod(typeArguments);


### PR DESCRIPTION
So that stuff like `entities with Tag where { tag:list with CanPilot any }` can actually work~

Also tiny bit of comments there and here