### PR TITLE
Replace some obsolete TileAccess methods

### DIFF
--- a/Robust.Client/Placement/Modes/AlignTileAny.cs
+++ b/Robust.Client/Placement/Modes/AlignTileAny.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 
@@ -14,16 +15,16 @@ namespace Robust.Client.Placement.Modes
         public override void AlignPlacementMode(ScreenCoordinates mouseScreen)
         {
             // Go over diagonal size so when placing in a line it doesn't stop snapping.
-            const float SearchBoxSize = 2f; // size of search box in meters
+            const float searchBoxSize = 2f; // size of search box in meters
 
-            MouseCoords = ScreenToCursorGrid(mouseScreen).AlignWithClosestGridTile(SearchBoxSize, pManager.EntityManager, pManager.MapManager);
+            MouseCoords = ScreenToCursorGrid(mouseScreen).AlignWithClosestGridTile(searchBoxSize, pManager.EntityManager, pManager.MapManager);
 
-            var gridId = MouseCoords.GetGridUid(pManager.EntityManager);
+            var gridId = pManager.EntityManager.System<SharedTransformSystem>().GetGrid(MouseCoords);
 
             if (!pManager.EntityManager.TryGetComponent<MapGridComponent>(gridId, out var mapGrid))
                 return;
 
-            CurrentTile = mapGrid.GetTileRef(MouseCoords);
+            CurrentTile = pManager.EntityManager.System<SharedMapSystem>().GetTileRef(gridId.Value, mapGrid, MouseCoords);
             float tileSize = mapGrid.TileSize; //convert from ushort to float
             GridDistancing = tileSize;
 

--- a/Robust.Client/Placement/Modes/AlignTileEmpty.cs
+++ b/Robust.Client/Placement/Modes/AlignTileEmpty.cs
@@ -23,7 +23,7 @@ namespace Robust.Client.Placement.Modes
             if (gridIdOpt is { } gridId && gridId.IsValid())
             {
                 var mapGrid = pManager.EntityManager.GetComponent<MapGridComponent>(gridId);
-                CurrentTile =  pManager.EntityManager.System<SharedMapSystem>().GetTileRef(gridId, mapGrid ,MouseCoords);
+                CurrentTile = pManager.EntityManager.System<SharedMapSystem>().GetTileRef(gridId, mapGrid ,MouseCoords);
                 tileSize = mapGrid.TileSize; //convert from ushort to float
             }
 

--- a/Robust.Client/Placement/Modes/AlignTileEmpty.cs
+++ b/Robust.Client/Placement/Modes/AlignTileEmpty.cs
@@ -1,6 +1,5 @@
 ﻿using System.Numerics;
 using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
@@ -19,12 +18,12 @@ namespace Robust.Client.Placement.Modes
             MouseCoords = ScreenToCursorGrid(mouseScreen);
 
             var tileSize = 1f;
-            var gridIdOpt = MouseCoords.GetGridUid(pManager.EntityManager);
+            var gridIdOpt = pManager.EntityManager.System<SharedTransformSystem>().GetGrid(MouseCoords);
 
-            if (gridIdOpt is EntityUid gridId && gridId.IsValid())
+            if (gridIdOpt is { } gridId && gridId.IsValid())
             {
                 var mapGrid = pManager.EntityManager.GetComponent<MapGridComponent>(gridId);
-                CurrentTile = mapGrid.GetTileRef(MouseCoords);
+                CurrentTile =  pManager.EntityManager.System<SharedMapSystem>().GetTileRef(gridId, mapGrid ,MouseCoords);
                 tileSize = mapGrid.TileSize; //convert from ushort to float
             }
 
@@ -50,12 +49,12 @@ namespace Robust.Client.Placement.Modes
                 return false;
             }
 
-            var map = MouseCoords.GetMapId(pManager.EntityManager);
+            var map = pManager.EntityManager.System<SharedTransformSystem>().GetMapId(MouseCoords);
             var bottomLeft = new Vector2(CurrentTile.X, CurrentTile.Y);
             var topRight = new Vector2(CurrentTile.X + 0.99f, CurrentTile.Y + 0.99f);
             var box = new Box2(bottomLeft, topRight);
 
-            return !EntitySystem.Get<EntityLookupSystem>().AnyEntitiesIntersecting(map, box);
+            return !pManager.EntityManager.System<EntityLookupSystem>().AnyEntitiesIntersecting(map, box);
         }
     }
 }

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -754,14 +754,14 @@ namespace Robust.Client.Placement
 
             if (CurrentPermission.IsTile)
             {
-                var gridIdOpt = coordinates.GetGridUid(EntityManager);
+                var gridIdOpt = EntityManager.System<SharedTransformSystem>().GetGrid(coordinates);
                 // If we have actually placed something on a valid grid...
-                if (gridIdOpt is EntityUid gridId && gridId.IsValid())
+                if (gridIdOpt is { } gridId && gridId.IsValid())
                 {
                     var grid = EntityManager.GetComponent<MapGridComponent>(gridId);
 
                     // no point changing the tile to the same thing.
-                    if (grid.GetTileRef(coordinates).Tile.TypeId == CurrentPermission.TileType)
+                    if (EntityManager.System<SharedMapSystem>().GetTileRef(gridId, grid, coordinates).Tile.TypeId == CurrentPermission.TileType)
                         return;
                 }
 

--- a/Robust.Client/Placement/PlacementMode.cs
+++ b/Robust.Client/Placement/PlacementMode.cs
@@ -197,8 +197,9 @@ namespace Robust.Client.Placement
         /// </summary>
         public TileRef GetTileRef(EntityCoordinates coordinates)
         {
-            var gridUidOpt = coordinates.GetGridUid(pManager.EntityManager);
-            return gridUidOpt is EntityUid gridUid && gridUid.IsValid() ? pManager.EntityManager.GetComponent<MapGridComponent>(gridUid).GetTileRef(MouseCoords)
+            var gridUidOpt = pManager.EntityManager.System<SharedTransformSystem>().GetGrid(coordinates);
+            return gridUidOpt is { } gridUid && gridUid.IsValid()
+                ? pManager.EntityManager.System<SharedMapSystem>().GetTileRef(gridUid, pManager.EntityManager.GetComponent<MapGridComponent>(gridUid), MouseCoords)
                 : new TileRef(gridUidOpt ?? EntityUid.Invalid,
                     MouseCoords.ToVector2i(pManager.EntityManager, pManager.MapManager, pManager.EntityManager.System<SharedTransformSystem>()), Tile.Empty);
         }

--- a/Robust.UnitTesting/Shared/Map/GridRotation_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/GridRotation_Tests.cs
@@ -30,7 +30,7 @@ namespace Robust.UnitTesting.Shared.Map
 
             await server.WaitAssertion(() =>
             {
-                entMan.System<SharedMapSystem>().CreateMap(out var mapId);
+                mapSystem.CreateMap(out var mapId);
                 var grid = mapMan.CreateGridEntity(mapId);
                 var gridEnt = grid.Owner;
                 var coordinates = new EntityCoordinates(gridEnt, new Vector2(10, 0));
@@ -41,18 +41,18 @@ namespace Robust.UnitTesting.Shared.Map
                 Assert.That(mapSystem.WorldToLocal(grid.Owner, grid.Comp, coordinates.Position), Is.EqualTo(coordinates.Position));
 
                 // Rotate 180 degrees should show -10, 0 for the position in map-terms and 10, 0 for the position in entity terms (i.e. no change).
-                entMan.GetComponent<TransformComponent>(gridEnt).WorldRotation += new Angle(MathF.PI);
+                transformSystem.SetWorldRotation(gridEnt, transformSystem.GetWorldRotation(gridEnt) + new Angle(MathF.PI));
                 Assert.That(transformSystem.GetWorldRotation(gridEnt), Is.EqualTo(new Angle(MathF.PI)));
                 // Check the map coordinate rotates correctly
-                Assert.That(mapSystem.WorldToLocal(grid.Owner, grid.Comp, new Vector2(10, 0)).EqualsApprox(new Vector2(-10, 0), 0.01f));
-                Assert.That(mapSystem.LocalToWorld(grid.Owner, grid.Comp, coordinates.Position).EqualsApprox(new Vector2(-10, 0), 0.01f));
+                Assert.That(mapSystem.WorldToLocal(gridEnt, grid.Comp, new Vector2(10, 0)).EqualsApprox(new Vector2(-10, 0), 0.01f));
+                Assert.That(mapSystem.LocalToWorld(gridEnt, grid.Comp, coordinates.Position).EqualsApprox(new Vector2(-10, 0), 0.01f));
 
                 // Now we'll do the same for 180 degrees.
-                entMan.GetComponent<TransformComponent>(gridEnt).WorldRotation += MathF.PI / 2f;
+                transformSystem.SetWorldRotation(gridEnt, transformSystem.GetWorldRotation(gridEnt) + MathF.PI / 2f);
                 // If grid facing down then worldpos of 10, 0 gets rotated 90 degrees CCW and hence should be 0, 10
-                Assert.That(mapSystem.WorldToLocal(grid.Owner, grid.Comp, new Vector2(10, 0)).EqualsApprox(new Vector2(0, 10), 0.01f));
+                Assert.That(mapSystem.WorldToLocal(gridEnt, grid.Comp, new Vector2(10, 0)).EqualsApprox(new Vector2(0, 10), 0.01f));
                 // If grid facing down then local 10,0 pos should just return 0, -10 given it's aligned with the rotation.
-                Assert.That(mapSystem.LocalToWorld(grid.Owner, grid.Comp, coordinates.Position).EqualsApprox(new Vector2(0, -10), 0.01f));
+                Assert.That(mapSystem.LocalToWorld(gridEnt, grid.Comp, coordinates.Position).EqualsApprox(new Vector2(0, -10), 0.01f));
             });
         }
 
@@ -70,7 +70,7 @@ namespace Robust.UnitTesting.Shared.Map
 
             await server.WaitAssertion(() =>
             {
-                entMan.System<SharedMapSystem>().CreateMap(out var mapId);
+                mapSystem.CreateMap(out var mapId);
                 var grid = mapMan.CreateGridEntity(mapId);
                 var gridEnt = grid.Owner;
 
@@ -85,7 +85,7 @@ namespace Robust.UnitTesting.Shared.Map
                     }
                 }
 
-                var chunks = mapSystem.GetMapChunks(grid.Owner, grid.Comp).Select(c => c.Value).ToList();
+                var chunks = mapSystem.GetMapChunks(gridEnt, grid.Comp).Select(c => c.Value).ToList();
 
                 Assert.That(chunks.Count, Is.EqualTo(1));
                 var chunk = chunks[0];

--- a/Robust.UnitTesting/Shared/Physics/CollisionWake_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/CollisionWake_Test.cs
@@ -42,6 +42,8 @@ namespace Robust.UnitTesting.Shared.Physics
 
             var entManager = server.ResolveDependency<IEntityManager>();
             var mapManager = server.ResolveDependency<IMapManager>();
+            var mapSystem = entManager.System<SharedMapSystem>();
+            var transformSystem = entManager.System<SharedTransformSystem>();
 
             Entity<MapGridComponent> grid = default!;
             MapId mapId = default!;
@@ -51,14 +53,15 @@ namespace Robust.UnitTesting.Shared.Physics
 
             await server.WaitPost(() =>
             {
-                entManager.System<SharedMapSystem>().CreateMap(out mapId);
+                mapSystem.CreateMap(out mapId);
                 grid = mapManager.CreateGridEntity(mapId);
-                grid.Comp.SetTile(Vector2i.Zero, new Tile(1));
+                mapSystem.SetTile(grid, Vector2i.Zero, new Tile(1));
 
                 var entityOne = entManager.SpawnEntity("CollisionWakeTestItem", new MapCoordinates(Vector2.One * 2f, mapId));
                 entityOnePhysics = entManager.GetComponent<PhysicsComponent>(entityOne);
                 xform = entManager.GetComponent<TransformComponent>(entityOne);
-                Assert.That(xform.ParentUid == mapManager.GetMapEntityId(mapId));
+                mapSystem.TryGetMap(mapId, out var mapUid);
+                Assert.That(xform.ParentUid == mapUid);
 
                 var entityTwo = entManager.SpawnEntity("CollisionWakeTestItem", new EntityCoordinates(grid, new Vector2(0.5f, 0.5f)));
                 entityTwoPhysics = entManager.GetComponent<PhysicsComponent>(entityTwo);


### PR DESCRIPTION
I'm going to replace all of obsolete methods in `MapGridComponent`, so project would have a bit less warnings.