### PR TITLE
Fix `System.ArgumentException: '0' cannot be greater than -0.01` for very fast audios

### DIFF
--- a/Robust.Client/Audio/AudioSystem.cs
+++ b/Robust.Client/Audio/AudioSystem.cs
@@ -669,7 +669,8 @@ public sealed partial class AudioSystem : SharedAudioSystem
 
         // TODO clamp the offset inside of SetPlaybackPosition() itself.
         var offset = audioP.PlayOffsetSeconds;
-        offset = Math.Clamp(offset, 0f, (float) stream.Length.TotalSeconds - 0.01f);
+        var maxOffset = Math.Max((float) stream.Length.TotalSeconds - 0.01f, 0f)
+        offset = Math.Clamp(offset, 0f, maxOffset);
         source.PlaybackPosition = offset;
 
         // For server we will rely on the adjusted one but locally we will have to adjust it ourselves.

--- a/Robust.Client/Audio/AudioSystem.cs
+++ b/Robust.Client/Audio/AudioSystem.cs
@@ -669,7 +669,7 @@ public sealed partial class AudioSystem : SharedAudioSystem
 
         // TODO clamp the offset inside of SetPlaybackPosition() itself.
         var offset = audioP.PlayOffsetSeconds;
-        var maxOffset = Math.Max((float) stream.Length.TotalSeconds - 0.01f, 0f)
+        var maxOffset = Math.Max((float) stream.Length.TotalSeconds - 0.01f, 0f);
         offset = Math.Clamp(offset, 0f, maxOffset);
         source.PlaybackPosition = offset;
 


### PR DESCRIPTION
On servers with TTS systems sometimes it is the case that TTS files with length between 0. and 0.01 (or maybe you start to listen only the final part of the phrase). This means that during the execution of the code you may sometimes get something like this:
```
Math.Clamp(offset, 0f, eps - 0.01f);
```
leading to an exception like this:
```
[ERRO] runtime: Caught exception in "entsys"
System.ArgumentException: '0' cannot be greater than -0.01.
   at System.Math.ThrowMinMaxException[T](T min, T max)
   at Robust.Client.Audio.AudioSystem.CreateAndStartPlayingStream(Nullable`1 audioParams, AudioStream stream) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/Audio/AudioSystem.cs:line 663
   at Robust.Client.Audio.AudioSystem.PlayEntity(String filename, EntityUid entity, Nullable`1 audioParams, Boolean recordReplay) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/Audio/AudioSystem.cs:line 531
   at Robust.Client.Audio.AudioSystem.PlayEntity(String filename, EntityUid recipient, EntityUid uid, Nullable`1 audioParams) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/Audio/AudioSystem.cs:line 646
   at Robust.Shared.Audio.Systems.SharedAudioSystem.PlayEntity(SoundSpecifier sound, EntityUid recipient, EntityUid uid, Nullable`1 audioParams) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/Audio/Systems/SharedAudioSystem.cs:line 522
   at Content.Client.SS220.TTS.TTSSystem.FrameUpdate(Single frameTime) in /opt/ss14/watchdog/instances/perseus/source/Content.Client/SS220/TTS/TTSSystem.cs:line 169
   at Robust.Shared.GameObjects.EntitySystemManager.FrameUpdate(Single frameTime) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/GameObjects/EntitySystemManager.cs:line 333
```