### PR TITLE
Fix cursor sticking when click-dragging off of a control

### DIFF
--- a/Robust.Client/UserInterface/UserInterfaceManager.Input.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Input.cs
@@ -35,6 +35,7 @@ internal partial class UserInterfaceManager
                 return;
             _controlFocused?.ControlFocusExited();
             _controlFocused = value;
+            _needUpdateActiveCursor = true;
         }
     }
 


### PR DESCRIPTION
When the mouse is held and dragged, the hovered element updates but the focused element does not. When the mouse is released, the focused element changes, but the hovered element doesn't, so the cursor is not dirtied and stays stuck on the focused element until a different element is hovered.

The cursor depends on both the focused and hovered element so it should be dirtied when either one changes.

Specific examples:
* Resizing a window or split container beyond its maximum size
* Pressing on the chat text entry and releasing anywhere else on the screen

Fixes https://github.com/space-wizards/space-station-14/issues/26106.