### PR TITLE
Add FormattedMessage.TrimEnd

### DIFF
--- a/Robust.Shared/Utility/FormattedMessage.cs
+++ b/Robust.Shared/Utility/FormattedMessage.cs
@@ -183,31 +183,27 @@ public sealed partial class FormattedMessage : IReadOnlyList<MarkupNode>
     }
 
     /// <summary>
-    /// Removes extraneous newlines from the end of the message.
+    /// Removes extraneous whitespace from the end of the message.
     /// </summary>
-    public void TrimTrailingNewlines()
+    public void TrimEnd()
     {
         while (_nodes.Count > 1)
         {
             var last = _nodes[^1];
-            if (last.Name == null && last.Value.TryGetString(out var text) && text.EndsWith('\n'))
+            if (last.Name == null && last.Value.TryGetString(out var text))
             {
-                text = text.TrimEnd('\n');
-                if (text.Length == 0)
+                string trimmed = text.TrimEnd();
+                if (trimmed.Length == 0)
                 {
                     _nodes.Pop();
                     continue;
                 }
-                else
+                else if (trimmed != text)
                 {
-                    _nodes[^1] = new MarkupNode(text);
-                    break;
+                    _nodes[^1] = new MarkupNode(trimmed);
                 }
             }
-            else
-            {
-                break;
-            }
+            break;
         }
     }
 

--- a/Robust.Shared/Utility/FormattedMessage.cs
+++ b/Robust.Shared/Utility/FormattedMessage.cs
@@ -183,6 +183,35 @@ public sealed partial class FormattedMessage : IReadOnlyList<MarkupNode>
     }
 
     /// <summary>
+    /// Removes extraneous newlines from the end of the message.
+    /// </summary>
+    public void TrimTrailingNewlines()
+    {
+        while (_nodes.Count > 1)
+        {
+            var last = _nodes[^1];
+            if (last.Name == null && last.Value.TryGetString(out var text) && text.EndsWith('\n'))
+            {
+                text = text.TrimEnd('\n');
+                if (text.Length == 0)
+                {
+                    _nodes.Pop();
+                    continue;
+                }
+                else
+                {
+                    _nodes[^1] = new MarkupNode(text);
+                    break;
+                }
+            }
+            else
+            {
+                break;
+            }
+        }
+    }
+
+    /// <summary>
     /// Adds a new open node to the formatted message.
     /// The method for inserting closed nodes: <see cref="Pop"/>. It needs to be
     /// called once for each inserted open node that isn't self closing.


### PR DESCRIPTION
Add a utility function that can be used to remove accidentally-added trailing newlines after the rest of the message has been composed. Useful to avoid the blank line pop-in when examining things in SS14.

This is a little more final than trying to track down and stamp out every source of trailing newlines forever.

This has to be here because write access to `_nodes` is private.