### PR TITLE
Fix minor layout bugs in SplitContainer and BoxContainer

### DIFF
--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 using Robust.Shared.Maths;
 
@@ -56,7 +57,7 @@ namespace Robust.Client.UserInterface.Controls
         protected override Vector2 MeasureOverride(Vector2 availableSize)
         {
             // Account for separation.
-            var separation = ActualSeparation * (ChildCount - 1);
+            var separation = ActualSeparation * (Children.Where(c => c.Visible).Count() - 1);
             var desiredSize = Vector2.Zero;
             if (Vertical)
             {
@@ -136,13 +137,14 @@ namespace Robust.Client.UserInterface.Controls
         protected override Vector2 ArrangeOverride(Vector2 finalSize)
         {
             var separation = ActualSeparation;
+            var visibleChildCount = Children.Where(c => c.Visible).Count();
 
             var stretchAvail = Vertical ? finalSize.Y : finalSize.X;
-            stretchAvail -= separation * (ChildCount - 1);
+            stretchAvail -= separation * (visibleChildCount - 1);
             stretchAvail = Math.Max(0, stretchAvail);
 
             // Step one: figure out the sizes of all our children and whether they want to stretch.
-            var sizeList = new List<(Control control, float size, bool stretch)>(ChildCount);
+            var sizeList = new List<(Control control, float size, bool stretch)>(visibleChildCount);
             var totalStretchRatio = 0f;
             foreach (var child in Children)
             {

--- a/Robust.Client/UserInterface/Controls/SplitContainer.cs
+++ b/Robust.Client/UserInterface/Controls/SplitContainer.cs
@@ -268,12 +268,15 @@ namespace Robust.Client.UserInterface.Controls
                 var first = GetChild(0);
                 var second = GetChild(1);
 
-                firstMinSize ??= (Vertical ? first.DesiredSize.Y : first.DesiredSize.X);
-                secondMinSize ??= (Vertical ? second.DesiredSize.Y : second.DesiredSize.X);
-                var size = Vertical ? controlSize.Y : controlSize.X;
+                if (first.IsMeasureValid && second.IsMeasureValid)
+                {
+                    firstMinSize ??= (Vertical ? first.DesiredSize.Y : first.DesiredSize.X);
+                    secondMinSize ??= (Vertical ? second.DesiredSize.Y : second.DesiredSize.X);
+                    var size = Vertical ? controlSize.Y : controlSize.X;
 
-                _splitStart = MathHelper.Clamp(_splitStart, firstMinSize.Value,
-                    size - (secondMinSize.Value + _splitWidth));
+                    _splitStart = MathHelper.Clamp(_splitStart, firstMinSize.Value,
+                        size - (secondMinSize.Value + _splitWidth));
+                }
             }
         }
 


### PR DESCRIPTION
- Fix BoxContainer counting invisible children when subtracting separation from available size
  - Visible in separated UI when not an admin, as the invisible admin and sandbox menus lead to misalignment 
  - Before:
    ![image](https://github.com/user-attachments/assets/74416655-5351-4ef2-b84e-aaa4b1ee3518)
  - After: 
    ![image](https://github.com/user-attachments/assets/b7545dd4-2b55-479b-9c28-63aa8e35d22f)
- Fix SplitContainer using outdated measures when clamping SplitCenter
  - This helps make it less likely that the clickable SplitCenter ends up in a different place than the visual SplitCenter