### PR TITLE
Fix warning for using non-generic variant of TryComp for `MetaDataComponent` and `TransformComponent` RA0030

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ContainerSystem.cs
@@ -241,7 +241,7 @@ namespace Robust.Client.GameObjects
 #if DEBUG
             var uid = GetEntity(netEntity);
 
-            if (TryComp<MetaDataComponent>(uid, out var meta))
+            if (TryComp(uid, out MetaDataComponent? meta))
             {
                 DebugTools.Assert((meta.Flags & ( MetaDataFlags.Detached | MetaDataFlags.InContainer) ) == MetaDataFlags.Detached,
                     $"Adding entity {ToPrettyString(uid)} to list of expected entities for container {container.ID} in {ToPrettyString(container.Owner)}, despite it already being in a container.");

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -532,7 +532,7 @@ public abstract partial class SharedMapSystem
     private void OnGridRemove(EntityUid uid, MapGridComponent component, ComponentShutdown args)
     {
         Log.Info($"Removing grid {ToPrettyString(uid)}");
-        if (TryComp<TransformComponent>(uid, out var xform) && xform.MapUid != null)
+        if (TryComp(uid, out TransformComponent? xform) && xform.MapUid != null)
         {
             RemoveGrid(uid, component, xform.MapUid.Value);
         }


### PR DESCRIPTION
Based on this:
https://github.com/space-wizards/RobustToolbox/blob/92b0e7f1a853979a1361ed24d2fb5ffc11f43f66/Robust.Shared/GameObjects/EntitySystem.Proxy.cs#L431-L450

it is more preferable.

Fixes 2 compiler RA0030 warnings