### PR TITLE
Fix warnings for using async without any await

### DIFF
--- a/Robust.Shared/Toolshed/TypeParsers/BoolTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/BoolTypeParser.cs
@@ -51,7 +51,7 @@ public sealed class BoolTypeParser : TypeParser<bool>
 
     public override ValueTask<(CompletionResult? result, IConError? error)> TryAutocomplete(ParserContext parserContext, string? argName)
     {
-        return ValueTask<(CompletionResult?, IConError?)>.FromResult((CompletionResult.FromOptions(new[] {"true", "false"}), null));
+        return new ValueTask<(CompletionResult?, IConError?)>.FromResult((CompletionResult.FromOptions(new[] {"true", "false"}), null));
     }
 }
 

--- a/Robust.Shared/Toolshed/TypeParsers/BoolTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/BoolTypeParser.cs
@@ -49,9 +49,9 @@ public sealed class BoolTypeParser : TypeParser<bool>
         }
     }
 
-    public override async ValueTask<(CompletionResult? result, IConError? error)> TryAutocomplete(ParserContext parserContext, string? argName)
+    public override ValueTask<(CompletionResult? result, IConError? error)> TryAutocomplete(ParserContext parserContext, string? argName)
     {
-        return (CompletionResult.FromOptions(new[] {"true", "false"}), null);
+        return ValueTask<(CompletionResult?, IConError?)>.FromResult((CompletionResult.FromOptions(new[] {"true", "false"}), null));
     }
 }
 

--- a/Robust.Shared/Toolshed/TypeParsers/BoolTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/BoolTypeParser.cs
@@ -35,7 +35,8 @@ public sealed class BoolTypeParser : TypeParser<bool>
             result = true;
             error = null;
             return true;
-        } else if (word == "false" || word == "f" || word == "0")
+        }
+        else if (word == "false" || word == "f" || word == "0")
         {
             result = false;
             error = null;
@@ -51,7 +52,7 @@ public sealed class BoolTypeParser : TypeParser<bool>
 
     public override ValueTask<(CompletionResult? result, IConError? error)> TryAutocomplete(ParserContext parserContext, string? argName)
     {
-        return new ValueTask<(CompletionResult?, IConError?)>.FromResult((CompletionResult.FromOptions(new[] {"true", "false"}), null));
+        return new ValueTask<(CompletionResult?, IConError?)>((CompletionResult.FromOptions(new[] { "true", "false" }), null));
     }
 }
 

--- a/Robust.Shared/Toolshed/TypeParsers/EntityTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/EntityTypeParser.cs
@@ -41,7 +41,7 @@ internal sealed class EntityTypeParser : TypeParser<EntityUid>
     public override ValueTask<(CompletionResult? result, IConError? error)> TryAutocomplete(ParserContext parserContext,
         string? argName)
     {
-        return new ValueTask<(CompletionResult?, IConError?)>.FromResult((CompletionResult.FromHint("<NetEntity>"), null));
+        return new ValueTask<(CompletionResult?, IConError?)>((CompletionResult.FromHint("<NetEntity>"), null));
     }
 }
 

--- a/Robust.Shared/Toolshed/TypeParsers/EntityTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/EntityTypeParser.cs
@@ -38,10 +38,10 @@ internal sealed class EntityTypeParser : TypeParser<EntityUid>
         return true;
     }
 
-    public override async ValueTask<(CompletionResult? result, IConError? error)> TryAutocomplete(ParserContext parserContext,
+    public override ValueTask<(CompletionResult? result, IConError? error)> TryAutocomplete(ParserContext parserContext,
         string? argName)
     {
-        return (CompletionResult.FromHint("<NetEntity>"), null);
+        return ValueTask<(CompletionResult?, IConError?).FromResult((CompletionResult.FromHint("<NetEntity>"), null));
     }
 }
 

--- a/Robust.Shared/Toolshed/TypeParsers/EntityTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/EntityTypeParser.cs
@@ -41,7 +41,7 @@ internal sealed class EntityTypeParser : TypeParser<EntityUid>
     public override ValueTask<(CompletionResult? result, IConError? error)> TryAutocomplete(ParserContext parserContext,
         string? argName)
     {
-        return ValueTask<(CompletionResult?, IConError?).FromResult((CompletionResult.FromHint("<NetEntity>"), null));
+        return ValueTask<(CompletionResult?, IConError?)>.FromResult((CompletionResult.FromHint("<NetEntity>"), null));
     }
 }
 

--- a/Robust.Shared/Toolshed/TypeParsers/EntityTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/EntityTypeParser.cs
@@ -41,7 +41,7 @@ internal sealed class EntityTypeParser : TypeParser<EntityUid>
     public override ValueTask<(CompletionResult? result, IConError? error)> TryAutocomplete(ParserContext parserContext,
         string? argName)
     {
-        return ValueTask<(CompletionResult?, IConError?)>.FromResult((CompletionResult.FromHint("<NetEntity>"), null));
+        return new ValueTask<(CompletionResult?, IConError?)>.FromResult((CompletionResult.FromHint("<NetEntity>"), null));
     }
 }
 

--- a/Robust.Shared/Toolshed/TypeParsers/EnumTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/EnumTypeParser.cs
@@ -48,7 +48,7 @@ public sealed class EnumTypeParser<T> : TypeParser<T>
 
     public override ValueTask<(CompletionResult? result, IConError? error)> TryAutocomplete(ParserContext parserContext, string? argName)
     {
-        return ValueTask<(CompletionResult?, IConError?)>.FromResult((CompletionResult.FromOptions(Enum.GetNames<T>()), null));
+        return new ValueTask<(CompletionResult?, IConError?)>.FromResult((CompletionResult.FromOptions(Enum.GetNames<T>()), null));
     }
 }
 

--- a/Robust.Shared/Toolshed/TypeParsers/EnumTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/EnumTypeParser.cs
@@ -11,7 +11,7 @@ using Robust.Shared.Utility;
 namespace Robust.Shared.Toolshed.TypeParsers;
 
 public sealed class EnumTypeParser<T> : TypeParser<T>
-    where T: unmanaged, Enum
+    where T : unmanaged, Enum
 {
     public override bool TryParse(ParserContext parserContext, [NotNullWhen(true)] out object? result,
         out IConError? error)
@@ -48,12 +48,12 @@ public sealed class EnumTypeParser<T> : TypeParser<T>
 
     public override ValueTask<(CompletionResult? result, IConError? error)> TryAutocomplete(ParserContext parserContext, string? argName)
     {
-        return new ValueTask<(CompletionResult?, IConError?)>.FromResult((CompletionResult.FromOptions(Enum.GetNames<T>()), null));
+        return new ValueTask<(CompletionResult?, IConError?)>((CompletionResult.FromOptions(Enum.GetNames<T>()), null));
     }
 }
 
 public record InvalidEnum<T>(string Value) : IConError
-    where T: unmanaged, Enum
+    where T : unmanaged, Enum
 {
     public FormattedMessage DescribeInner()
     {

--- a/Robust.Shared/Toolshed/TypeParsers/EnumTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/EnumTypeParser.cs
@@ -46,9 +46,9 @@ public sealed class EnumTypeParser<T> : TypeParser<T>
         return true;
     }
 
-    public override async ValueTask<(CompletionResult? result, IConError? error)> TryAutocomplete(ParserContext parserContext, string? argName)
+    public override ValueTask<(CompletionResult? result, IConError? error)> TryAutocomplete(ParserContext parserContext, string? argName)
     {
-        return (CompletionResult.FromOptions(Enum.GetNames<T>()), null);
+        return ValueTask<(CompletionResult?, IConError?)>.FromResult((CompletionResult.FromOptions(Enum.GetNames<T>()), null));
     }
 }
 

--- a/Robust.Shared/Toolshed/TypeParsers/SessionTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/SessionTypeParser.cs
@@ -47,7 +47,7 @@ internal sealed class SessionTypeParser : TypeParser<ICommonSession>
         string? argName)
     {
         var opts = CompletionHelper.SessionNames(true, _player);
-        return ValueTask<(CompletionResult?, IConError?)>.FromResult((CompletionResult.FromHintOptions(opts, "<player session>"), null));
+        return new ValueTask<(CompletionResult?, IConError?)>.FromResult((CompletionResult.FromHintOptions(opts, "<player session>"), null));
     }
 
     public record InvalidUsername(ILocalizationManager Loc, string Username) : IConError

--- a/Robust.Shared/Toolshed/TypeParsers/SessionTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/SessionTypeParser.cs
@@ -47,7 +47,7 @@ internal sealed class SessionTypeParser : TypeParser<ICommonSession>
         string? argName)
     {
         var opts = CompletionHelper.SessionNames(true, _player);
-        return new ValueTask<(CompletionResult?, IConError?)>.FromResult((CompletionResult.FromHintOptions(opts, "<player session>"), null));
+        return new ValueTask<(CompletionResult?, IConError?)>((CompletionResult.FromHintOptions(opts, "<player session>"), null));
     }
 
     public record InvalidUsername(ILocalizationManager Loc, string Username) : IConError

--- a/Robust.Shared/Toolshed/TypeParsers/SessionTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/SessionTypeParser.cs
@@ -43,11 +43,11 @@ internal sealed class SessionTypeParser : TypeParser<ICommonSession>
         return false;
     }
 
-    public override async ValueTask<(CompletionResult? result, IConError? error)> TryAutocomplete(ParserContext parserContext,
+    public override ValueTask<(CompletionResult? result, IConError? error)> TryAutocomplete(ParserContext parserContext,
         string? argName)
     {
         var opts = CompletionHelper.SessionNames(true, _player);
-        return (CompletionResult.FromHintOptions(opts, "<player session>"), null);
+        return ValueTask<(CompletionResult?, IConError?)>.FromResult((CompletionResult.FromHintOptions(opts, "<player session>"), null));
     }
 
     public record InvalidUsername(ILocalizationManager Loc, string Username) : IConError


### PR DESCRIPTION
Fixes 4 compiler warnings CS1998 for defining async method that doesn't use any await statements