### PR TITLE
Make font drawing more generic

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
@@ -362,6 +362,11 @@ namespace Robust.Client.Graphics.Clyde
                         rect.BottomLeft, rect.BottomRight, color, subRegion);
                 }
 
+                public override void DrawTexture(Texture texture, Vector2 position, Color? modulate = null)
+                {
+                    base.DrawTexture(texture, position, modulate);
+                }
+
                 /// <summary>
                 /// Draws an entity.
                 /// </summary>

--- a/Robust.Client/Graphics/Drawing/DrawingHandleBase.cs
+++ b/Robust.Client/Graphics/Drawing/DrawingHandleBase.cs
@@ -211,6 +211,8 @@ namespace Robust.Client.Graphics
         public abstract void DrawLine(Vector2 from, Vector2 to, Color color);
 
         public abstract void RenderInRenderTarget(IRenderTarget target, Action a, Color? clearColor);
+
+        public abstract void DrawTexture(Texture texture, Vector2 position, Color? modulate = null);
     }
 
     /// <summary>

--- a/Robust.Client/Graphics/Drawing/DrawingHandleScreen.cs
+++ b/Robust.Client/Graphics/Drawing/DrawingHandleScreen.cs
@@ -92,7 +92,7 @@ namespace Robust.Client.Graphics
 
         public abstract void DrawTextureRectRegion(Texture texture, UIBox2 rect, UIBox2? subRegion = null, Color? modulate = null);
 
-        public void DrawTexture(Texture texture, Vector2 position, Color? modulate = null)
+        public override void DrawTexture(Texture texture, Vector2 position, Color? modulate = null)
         {
             CheckDisposed();
 

--- a/Robust.Client/Graphics/Drawing/DrawingHandleWorld.cs
+++ b/Robust.Client/Graphics/Drawing/DrawingHandleWorld.cs
@@ -74,7 +74,7 @@ namespace Robust.Client.Graphics
         /// <remarks>
         /// The sprite will have it's local dimensions calculated so that it has <see cref="EyeManager.PixelsPerMeter"/> texels per meter in the world.
         /// </remarks>
-        public void DrawTexture(Texture texture, Vector2 position, Color? modulate = null)
+        public override void DrawTexture(Texture texture, Vector2 position, Color? modulate = null)
         {
             CheckDisposed();
 

--- a/Robust.Client/Graphics/Font.cs
+++ b/Robust.Client/Graphics/Font.cs
@@ -2,7 +2,6 @@
 using System.Numerics;
 using System.Text;
 using Robust.Client.ResourceManagement;
-using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Maths;
 

--- a/Robust.Client/Graphics/Font.cs
+++ b/Robust.Client/Graphics/Font.cs
@@ -53,7 +53,7 @@ namespace Robust.Client.Graphics
         /// <param name="fallback">If the character is not available, render "�" instead.</param>
         /// <returns>How much to advance the cursor to draw the next character.</returns>
         public abstract float DrawChar(
-            DrawingHandleScreen handle, Rune rune, Vector2 baseline, float scale,
+            DrawingHandleBase handle, Rune rune, Vector2 baseline, float scale,
             Color color, bool fallback=true);
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace Robust.Client.Graphics
         public override int GetDescent(float scale) => Handle.GetDescent(scale);
         public override int GetLineHeight(float scale) => Handle.GetLineHeight(scale);
 
-        public override float DrawChar(DrawingHandleScreen handle, Rune rune, Vector2 baseline, float scale, Color color, bool fallback=true)
+        public override float DrawChar(DrawingHandleBase handle, Rune rune, Vector2 baseline, float scale, Color color, bool fallback=true)
         {
             var metrics = Handle.GetCharMetrics(rune, scale);
             if (!metrics.HasValue)
@@ -169,7 +169,7 @@ namespace Robust.Client.Graphics
         public override int GetLineHeight(float scale) => _main.GetLineHeight(scale);
 
         // DrawChar just proxies to the stack, or invokes _main's fallback.
-        public override float DrawChar(DrawingHandleScreen handle, Rune rune, Vector2 baseline, float scale, Color color, bool fallback=true)
+        public override float DrawChar(DrawingHandleBase handle, Rune rune, Vector2 baseline, float scale, Color color, bool fallback=true)
         {
             foreach (var f in Stack)
             {
@@ -207,7 +207,7 @@ namespace Robust.Client.Graphics
         public override int GetDescent(float scale) => default;
         public override int GetLineHeight(float scale) => default;
 
-        public override float DrawChar(DrawingHandleScreen handle, Rune rune, Vector2 baseline, float scale, Color color, bool fallback=true)
+        public override float DrawChar(DrawingHandleBase handle, Rune rune, Vector2 baseline, float scale, Color color, bool fallback=true)
         {
             // Nada, it's a dummy after all.
             return 0;

--- a/Robust.Client/Graphics/Font.cs
+++ b/Robust.Client/Graphics/Font.cs
@@ -2,6 +2,7 @@
 using System.Numerics;
 using System.Text;
 using Robust.Client.ResourceManagement;
+using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Maths;
 
@@ -132,7 +133,10 @@ namespace Robust.Client.Graphics
             }
 
             baseline += new Vector2(metrics.Value.BearingX, -metrics.Value.BearingY);
-            handle.DrawTexture(texture, baseline, color);
+            if(handle is DrawingHandleWorld worldhandle)
+                worldhandle.DrawTextureRect(texture,  Box2.FromDimensions(baseline, texture.Size));
+            else
+                handle.DrawTexture(texture, baseline, color);
             return metrics.Value.Advance;
         }
 

--- a/Robust.Client/UserInterface/RichTextEntry.cs
+++ b/Robust.Client/UserInterface/RichTextEntry.cs
@@ -14,7 +14,7 @@ namespace Robust.Client.UserInterface
     /// <summary>
     ///     Used by <see cref="OutputPanel"/> and <see cref="RichTextLabel"/> to handle rich text layout.
     /// </summary>
-    public struct RichTextEntry
+    internal struct RichTextEntry
     {
         private readonly Color _defaultColor;
         private readonly Type[]? _tagsAllowed;

--- a/Robust.Client/UserInterface/RichTextEntry.cs
+++ b/Robust.Client/UserInterface/RichTextEntry.cs
@@ -14,7 +14,7 @@ namespace Robust.Client.UserInterface
     /// <summary>
     ///     Used by <see cref="OutputPanel"/> and <see cref="RichTextLabel"/> to handle rich text layout.
     /// </summary>
-    internal struct RichTextEntry
+    public struct RichTextEntry
     {
         private readonly Color _defaultColor;
         private readonly Type[]? _tagsAllowed;
@@ -176,7 +176,7 @@ namespace Robust.Client.UserInterface
 
         public readonly void Draw(
             MarkupTagManager tagManager,
-            DrawingHandleScreen handle,
+            DrawingHandleBase handle,
             Font defaultFont,
             UIBox2 drawBox,
             float verticalOffset,


### PR DESCRIPTION
gonna steal this for OD's maptext implementation

it'd be helpful if I could draw it to `DrawingWorldHandle`