### PR TITLE
Remove unneeded to disabling RA0003 warning in FastNoise

### DIFF
--- a/Robust.Shared/Noise/FastNoise.cs
+++ b/Robust.Shared/Noise/FastNoise.cs
@@ -41,10 +41,8 @@ using System.Runtime.CompilerServices;
 
 namespace Robust.Shared.Noise
 {
-#pragma warning disable RA0003
     [Obsolete("Use FastNoiseLite")]
     public sealed class FastNoise
-#pragma warning restore RA0003
     {
         private const MethodImplOptions FN_INLINE = MethodImplOptions.AggressiveInlining;
         private const int FN_CELLULAR_INDEX_MAX = 3;


### PR DESCRIPTION
`RA0003` warning is:
```
Class must be explicitly marked as [Virtual], abstract, static or sealed
```

Class `FastNoise` is `sealed` so warning doesn't appear anyway.