### PR TITLE
Upgrade GitHub actions in workflows

### DIFF
--- a/.github/workflows/build-docfx.yml
+++ b/.github/workflows/build-docfx.yml
@@ -5,30 +5,30 @@ on:
     - cron: "0 0 * * 0"
 jobs:
   docfx:
-   runs-on: ubuntu-latest
-   steps:
-    - uses: actions/checkout@v3.6.0
-      with:
-        submodules: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          submodules: true
 
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v3.2.0
-      with:
-        dotnet-version: 8.0.x
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4.1.0
+        with:
+          dotnet-version: 8.0.x
 
-    - name: Install dependencies
-      run: dotnet restore
+      - name: Install dependencies
+        run: dotnet restore
 
-    - name: Build Project
-      run: dotnet build --no-restore /p:WarningsAsErrors=nullable
+      - name: Build Project
+        run: dotnet build --no-restore /p:WarningsAsErrors=nullable
 
-    - name: Build DocFX
-      uses: nikeee/docfx-action@v1.0.0
-      with:
-        args: Robust.Docfx/docfx.json
+      - name: Build DocFX
+        uses: nikeee/docfx-action@v1.0.0
+        with:
+          args: Robust.Docfx/docfx.json
 
-    - name: Publish Docfx Documentation on GitHub Pages
-      uses: maxheld83/ghpages@master
-      env:
-        BUILD_DIR: Robust.Docfx/_robust-site
-        GH_PAT: ${{ secrets.GH_PAT }}
+      - name: Publish Docfx Documentation on GitHub Pages
+        uses: maxheld83/ghpages@master
+        env:
+          BUILD_DIR: Robust.Docfx/_robust-site
+          GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,33 +2,32 @@ name: Build & Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest ] # , macos-latest] - temporarily disabled due to libfreetype.dll errors.
+        os: [ubuntu-latest, windows-latest] # , macos-latest] - temporarily disabled due to libfreetype.dll errors.
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3.6.0
-      with:
-        submodules: true
+      - uses: actions/checkout@v4.2.2
+        with:
+          submodules: true
 
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v3.2.0
-      with:
-        dotnet-version: 8.0.x
-    - name: Install dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore /p:WarningsAsErrors=nullable
-    - name: Robust.UnitTesting
-      run: dotnet test --no-build Robust.UnitTesting/Robust.UnitTesting.csproj -- NUnit.ConsoleOut=0
-    - name: Robust.Analyzers.Tests
-      run: dotnet test --no-build Robust.Analyzers.Tests/Robust.Analyzers.Tests.csproj -- NUnit.ConsoleOut=0
-
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4.1.0
+        with:
+          dotnet-version: 8.0.x
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore /p:WarningsAsErrors=nullable
+      - name: Robust.UnitTesting
+        run: dotnet test --no-build Robust.UnitTesting/Robust.UnitTesting.csproj -- NUnit.ConsoleOut=0
+      - name: Robust.Analyzers.Tests
+        run: dotnet test --no-build Robust.Analyzers.Tests/Robust.Analyzers.Tests.csproj -- NUnit.ConsoleOut=0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,50 +28,50 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'csharp' ]
+        language: ["csharp"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3.6.0
-      with:
-        submodules: true
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
+        with:
+          submodules: true
 
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v3.2.0
-      with:
-        dotnet-version: 7.0.x
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4.1.0
+        with:
+          dotnet-version: 7.0.x
 
-    - name: Build
-      run: dotnet build
+      - name: Build
+        run: dotnet build
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -3,51 +3,50 @@
 on:
   push:
     tags:
-    - 'v*'
+      - "v*"
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Parse version
-      id: parse_version
-      shell: pwsh
-      run: |
-        $ver = [regex]::Match($env:GITHUB_REF, "refs/tags/v?(.+)").Groups[1].Value
-        echo ("::set-output name=version::{0}" -f $ver)
+      - name: Parse version
+        id: parse_version
+        shell: pwsh
+        run: |
+          $ver = [regex]::Match($env:GITHUB_REF, "refs/tags/v?(.+)").Groups[1].Value
+          echo ("::set-output name=version::{0}" -f $ver)
 
-    - uses: actions/checkout@v3.6.0
-      with:
-        submodules: true
+      - uses: actions/checkout@v4.2.2
+        with:
+          submodules: true
 
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v3.2.0
-      with:
-        dotnet-version: 8.0.x
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4.1.0
+        with:
+          dotnet-version: 8.0.x
 
-    - name: Package client
-      run: Tools/package_client_build.py -p windows mac linux
+      - name: Package client
+        run: Tools/package_client_build.py -p windows mac linux
 
-    - name: Shuffle files around
-      run: |
-        mkdir "release/${{ steps.parse_version.outputs.version }}"
-        mv release/*.zip "release/${{ steps.parse_version.outputs.version }}"
+      - name: Shuffle files around
+        run: |
+          mkdir "release/${{ steps.parse_version.outputs.version }}"
+          mv release/*.zip "release/${{ steps.parse_version.outputs.version }}"
 
-    - name: Upload files to Suns
-      uses: appleboy/scp-action@master
-      with:
-        host: suns.spacestation14.com
-        username: robust-build-push
-        key: ${{ secrets.CENTCOMM_ROBUST_BUILDS_PUSH_KEY }}
-        source: "release/${{ steps.parse_version.outputs.version }}"
-        target: "/var/lib/robust-builds/builds/"
-        strip_components: 1
+      - name: Upload files to Suns
+        uses: appleboy/scp-action@master
+        with:
+          host: suns.spacestation14.com
+          username: robust-build-push
+          key: ${{ secrets.CENTCOMM_ROBUST_BUILDS_PUSH_KEY }}
+          source: "release/${{ steps.parse_version.outputs.version }}"
+          target: "/var/lib/robust-builds/builds/"
+          strip_components: 1
 
-    - name: Update manifest JSON
-      uses: appleboy/ssh-action@master
-      with:
-        host: suns.spacestation14.com
-        username: robust-build-push
-        key: ${{ secrets.CENTCOMM_ROBUST_BUILDS_PUSH_KEY }}
-        script: /home/robust-build-push/push.ps1 ${{ steps.parse_version.outputs.version }}
-
+      - name: Update manifest JSON
+        uses: appleboy/ssh-action@master
+        with:
+          host: suns.spacestation14.com
+          username: robust-build-push
+          key: ${{ secrets.CENTCOMM_ROBUST_BUILDS_PUSH_KEY }}
+          script: /home/robust-build-push/push.ps1 ${{ steps.parse_version.outputs.version }}

--- a/.github/workflows/test-content.yml
+++ b/.github/workflows/test-content.yml
@@ -2,40 +2,39 @@ name: Test content master against engine
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - name: Check out content
-      uses: actions/checkout@v3.6.0
-      with:
-        repository: space-wizards/space-station-14
-        submodules: recursive
+      - name: Check out content
+        uses: actions/checkout@v4.2.0
+        with:
+          repository: space-wizards/space-station-14
+          submodules: recursive
 
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v3.2.0
-      with:
-        dotnet-version: 8.0.x
-    - name: Disable submodule autoupdate
-      run: touch BuildChecker/DISABLE_SUBMODULE_AUTOUPDATE
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4.1.0
+        with:
+          dotnet-version: 8.0.x
+      - name: Disable submodule autoupdate
+        run: touch BuildChecker/DISABLE_SUBMODULE_AUTOUPDATE
 
-    - name: Check out engine version
-      run: |
-        cd RobustToolbox
-        git fetch origin ${{ github.sha }}
-        git checkout FETCH_HEAD
-        git submodule update --init --recursive
-    - name: Install dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --configuration Tools --no-restore
-    - name: Content.Tests
-      run: dotnet test --no-build Content.Tests/Content.Tests.csproj -v n
-    - name: Content.IntegrationTests
-      run: COMPlus_gcServer=1 dotnet test --no-build Content.IntegrationTests/Content.IntegrationTests.csproj -v n
+      - name: Check out engine version
+        run: |
+          cd RobustToolbox
+          git fetch origin ${{ github.sha }}
+          git checkout FETCH_HEAD
+          git submodule update --init --recursive
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Tools --no-restore
+      - name: Content.Tests
+        run: dotnet test --no-build Content.Tests/Content.Tests.csproj -v n
+      - name: Content.IntegrationTests
+        run: COMPlus_gcServer=1 dotnet test --no-build Content.IntegrationTests/Content.IntegrationTests.csproj -v n

--- a/.github/workflows/test-content.yml
+++ b/.github/workflows/test-content.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Check out content
-        uses: actions/checkout@v4.2.0
+        uses: actions/checkout@v4.2.2
         with:
           repository: space-wizards/space-station-14
           submodules: recursive


### PR DESCRIPTION
Fixes GitHub Actions warning that actions that we should use `node20` actions instead of `node16` 
Upgrade `actions/checkout` from `3.6.0` to `4.2.2`
Upgrade `actions/setup-dotnet` from `3.2.0` to `4.1.0`

Also autoformat .yml files (if you don't want that let me know)

Test:
https://github.com/CrafterKolyan/RobustToolbox/actions/runs/12000783383