### PR TITLE
Fix codeql-analysis workflow breaking in every fork repo that enables GitHub Actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,14 +11,8 @@
 #
 name: "CodeQL"
 
-#on:
-#  push:
-#    branches: [ master ]
-#  pull_request:
-#    # The branches below must be a subset of the branches above
-#    branches: [ master ]
-#  schedule:
-#    - cron: '30 18 * * 6'
+on:
+  workflow_dispatch
 
 jobs:
   analyze:


### PR DESCRIPTION
The error looks like this:
https://github.com/CrafterKolyan/RobustToolbox/actions/runs/12001036858

```
on:
  workflow_dispatch
```

allows you to run it manually.

By the way it now doesn't break and you may want to enable it instead (it was disabled for 3 years)

Here is the test:
https://github.com/CrafterKolyan/RobustToolbox/actions/runs/12000847963