### PR TITLE
Fix wrong filename used if `log.path` is absolute

### DIFF
--- a/Robust.Server/BaseServer.cs
+++ b/Robust.Server/BaseServer.cs
@@ -223,10 +223,10 @@ namespace Robust.Server
 
                 if (!Path.IsPathRooted(fullPath))
                 {
-                    logPath = PathHelpers.ExecutableRelativeFile(fullPath);
+                    fullPath = PathHelpers.ExecutableRelativeFile(fullPath);
                 }
 
-                logHandler = new FileLogHandler(logPath);
+                logHandler = new FileLogHandler(fullPath);
             }
 
             _log.RootSawmill.Level = _config.GetCVar(CVars.LogLevel);


### PR DESCRIPTION
If `log.path` was absolute, the wrong variable was used, causing a file to be written at `log.path` exactly, instead of a new file within the directory named by `log.path`.