### PR TITLE
Fix IPrototypeManager.TryGetKindFrom()

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Fixed `IPrototypeManager.TryGetKindFrom()` not working for prototypes with automatically inferred kind names.
 
 ### Other
 

--- a/Robust.Shared/Prototypes/Attributes.cs
+++ b/Robust.Shared/Prototypes/Attributes.cs
@@ -15,6 +15,9 @@ namespace Robust.Shared.Prototypes;
 [Virtual]
 public class PrototypeAttribute : Attribute
 {
+    /// <summary>
+    /// Override for the name of this kind of prototype. If not specified, this is automatically inferred via <see cref="PrototypeManager.CalculatePrototypeName"/>
+    /// </summary>
     public string? Type { get; internal set; }
     public readonly int LoadPriority = 1;
 
@@ -23,7 +26,7 @@ public class PrototypeAttribute : Attribute
         Type = type;
         LoadPriority = loadPriority;
     }
-    
+
     public PrototypeAttribute(int loadPriority)
     {
         Type = null;

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -824,22 +824,10 @@ namespace Robust.Shared.Prototypes
         public bool TryGetKindFrom(Type type, [NotNullWhen(true)] out string? kind)
         {
             kind = null;
-
-            // If the type doesn't implement IPrototype, this fails.
-            if (!(typeof(IPrototype).IsAssignableFrom(type)))
+            if (!_kinds.TryGetValue(type, out var kindData))
                 return false;
 
-            var attribute = (PrototypeAttribute?)Attribute.GetCustomAttribute(type, typeof(PrototypeAttribute));
-
-            // If the prototype type doesn't have the attribute, this fails.
-            if (attribute == null)
-                return false;
-
-            // If the variant isn't registered, this fails.
-            if (attribute.Type == null || !HasKind(attribute.Type))
-                return false;
-
-            kind = attribute.Type;
+            kind = kindData.Name;
             return true;
         }
 
@@ -945,13 +933,13 @@ namespace Robust.Shared.Prototypes
                     "No " + nameof(PrototypeAttribute) + " to give it a type string.");
             }
 
-            attribute.Type ??= CalculatePrototypeName(kind);
+            var name = attribute.Type ?? CalculatePrototypeName(kind);
 
-            if (_kindNames.TryGetValue(attribute.Type, out var name))
+            if (_kindNames.TryGetValue(name, out var existing))
             {
                 throw new InvalidImplementationException(kind,
                     typeof(IPrototype),
-                    $"Duplicate prototype type ID: {attribute.Type}. Current: {name}");
+                    $"Duplicate prototype type ID: {attribute.Type}. Current: {existing}");
             }
 
             var foundIdAttribute = false;
@@ -1019,10 +1007,10 @@ namespace Robust.Shared.Prototypes
                     $"Did not find any member annotated with the {nameof(ParentDataFieldAttribute)} and/or {nameof(AbstractDataFieldAttribute)}");
             }
 
-            _kindNames[attribute.Type] = kind;
+            _kindNames[name] = kind;
             _kindPriorities[kind] = attribute.LoadPriority;
 
-            var kindData = new KindData(kind);
+            var kindData = new KindData(kind, name);
             kinds[kind] = kindData;
 
             if (kind.IsAssignableTo(typeof(IInheritingPrototype)))
@@ -1032,7 +1020,7 @@ namespace Robust.Shared.Prototypes
         /// <inheritdoc />
         public event Action<PrototypesReloadedEventArgs>? PrototypesReloaded;
 
-        private sealed class KindData(Type kind)
+        private sealed class KindData(Type kind, string name)
         {
             public Dictionary<string, IPrototype>? UnfrozenInstances;
 
@@ -1041,6 +1029,7 @@ namespace Robust.Shared.Prototypes
             public readonly Dictionary<string, MappingDataNode> Results = new();
 
             public readonly Type Type = kind;
+            public readonly string Name = name;
 
             // Only initialized if prototype is inheriting.
             public MultiRootInheritanceGraph<string>? Inheritance;


### PR DESCRIPTION
The method only ever worked for prototypes that explicitly defined their prototype name, and was just broken for anything with automatically inferred names.