### PR TITLE
Add RSI key to disable meta-atlas

### DIFF
--- a/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
+++ b/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
@@ -143,9 +143,9 @@ namespace Robust.Client.ResourceManagement
                 }
             });
 
-            // Do not meta-atlas RSIs with custom load parameters.
-            var atlasList = rsiList.Where(x => x.LoadParameters == TextureLoadParameters.Default).ToArray();
-            var nonAtlasList = rsiList.Where(x => x.LoadParameters != TextureLoadParameters.Default).ToArray();
+            var atlasLookup = rsiList.ToLookup(ShouldMetaAtlas);
+            var atlasList = atlasLookup[true].ToArray();
+            var nonAtlasList = atlasLookup[false].ToArray();
 
             foreach (var data in nonAtlasList)
             {
@@ -225,8 +225,9 @@ namespace Robust.Client.ResourceManagement
 
             void FinalizeMetaAtlas(int toIndex, Image<Rgba32> sheet)
             {
-                var atlas = Clyde.LoadTextureFromImage(sheet);
-                for (int i = finalized + 1; i <= toIndex; i++)
+                var fromIndex = finalized + 1;
+                var atlas = Clyde.LoadTextureFromImage(sheet, $"Meta atlas {fromIndex}-{toIndex}");
+                for (int i = fromIndex; i <= toIndex; i++)
                 {
                     var rsi = atlasList[i];
                     rsi.AtlasTexture = atlas;
@@ -282,7 +283,11 @@ namespace Robust.Client.ResourceManagement
                 nonAtlasList.Length,
                 errors,
                 sw.Elapsed);
+        }
 
+        private static bool ShouldMetaAtlas(RSIResource.LoadStepData rsi)
+        {
+            return rsi.MetaAtlas && rsi.LoadParameters == TextureLoadParameters.Default;
         }
     }
 }

--- a/Robust.Client/ResourceManagement/ResourceTypes/RSIResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/RSIResource.cs
@@ -183,6 +183,7 @@ namespace Robust.Client.ResourceManagement
             data.DimX = dimensionX;
             data.CallbackOffsets = callbackOffsets;
             data.LoadParameters = metadata.LoadParameters;
+            data.MetaAtlas = metadata.MetaAtlas;
         }
 
         internal static void LoadPostTexture(LoadStepData data)
@@ -386,6 +387,7 @@ namespace Robust.Client.ResourceManagement
             public Vector2i AtlasOffset;
             public RSI Rsi = default!;
             public TextureLoadParameters LoadParameters;
+            public bool MetaAtlas;
         }
 
         internal struct StateReg

--- a/Robust.Shared/Resources/RsiLoading.cs
+++ b/Robust.Shared/Resources/RsiLoading.cs
@@ -104,7 +104,7 @@ internal static class RsiLoading
             };
         }
 
-        return new RsiMetadata(size, states, textureParams);
+        return new RsiMetadata(size, states, textureParams, manifestJson.MetaAtlas);
     }
 
     public static void Warmup()
@@ -114,11 +114,12 @@ internal static class RsiLoading
         JsonSerializer.Deserialize<RsiJsonMetadata>(warmupJson, SerializerOptions);
     }
 
-    internal sealed class RsiMetadata(Vector2i size, StateMetadata[] states, TextureLoadParameters loadParameters)
+    internal sealed class RsiMetadata(Vector2i size, StateMetadata[] states, TextureLoadParameters loadParameters, bool metaAtlas)
     {
         public readonly Vector2i Size = size;
         public readonly StateMetadata[] States = states;
         public readonly TextureLoadParameters LoadParameters = loadParameters;
+        public readonly bool MetaAtlas = metaAtlas;
     }
 
     internal sealed class StateMetadata
@@ -140,7 +141,11 @@ internal static class RsiLoading
 
     // To be directly deserialized.
     [UsedImplicitly]
-    private sealed record RsiJsonMetadata(Vector2i Size, StateJsonMetadata[] States, RsiJsonLoad? Load);
+    private sealed record RsiJsonMetadata(
+        Vector2i Size,
+        StateJsonMetadata[] States,
+        RsiJsonLoad? Load,
+        bool MetaAtlas = true);
 
     [UsedImplicitly]
     private sealed record StateJsonMetadata(string Name, int? Directions, float[][]? Delays);


### PR DESCRIPTION
This allows huge textures (e.g. Ratvar) to be removed from the meta-atlas. This saves a significant chunk of VRAM from the meta atlas in SS14 (~126 MB) which might help a bit with low-VRAM systems.