### PR TITLE
Changes SharedGridTraversalSystem accesibility from internal to public

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
@@ -21,6 +21,10 @@ public sealed class SharedGridTraversalSystem : EntitySystem
 
     /// <summary>
     /// Enables or disables changing grid / map uid upon moving.
+    /// WARNING: If you do this in a live-game. You need to make sure that the parented entity
+    /// doesn't move too far away from the grid. As it will cause Entity Lookups to not see it
+    /// (because the grid its parented to is not close enough and all parented entities are assumed
+    /// to be on the grid through the broadphase component)
     /// </summary>
     public bool Enabled = true;
 

--- a/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridTraversalSystem.cs
@@ -11,7 +11,7 @@ namespace Robust.Shared.GameObjects;
 /// <summary>
 ///     Handles moving entities between grids as they move around.
 /// </summary>
-internal sealed class SharedGridTraversalSystem : EntitySystem
+public sealed class SharedGridTraversalSystem : EntitySystem
 {
     [Dependency] private readonly IMapManagerInternal _mapManager = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;


### PR DESCRIPTION
Lets people disable/enable this system at will with this change.  Done mainly because this prevents anyone from implementing custom parenting/unparenting behaviour and limits everyone to grid-parenting preety much. 