### PR TITLE
.NET 9

### DIFF
--- a/.github/workflows/build-docfx.yml
+++ b/.github/workflows/build-docfx.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4.1.0
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Install dependencies
         run: dotnet restore

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4.1.0
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4.1.0
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Package client
         run: Tools/package_client_build.py -p windows mac linux

--- a/.github/workflows/test-content.yml
+++ b/.github/workflows/test-content.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4.1.0
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
       - name: Disable submodule autoupdate
         run: touch BuildChecker/DISABLE_SUBMODULE_AUTOUPDATE
 

--- a/Lidgren.Network/Lidgren.Network.csproj
+++ b/Lidgren.Network/Lidgren.Network.csproj
@@ -12,7 +12,7 @@
     <SkipRobustAnalyzer>true</SkipRobustAnalyzer>
 
     <Nullable>enable</Nullable>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>13.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MSBuild/Robust.Engine.props
+++ b/MSBuild/Robust.Engine.props
@@ -1,8 +1,8 @@
 ﻿<Project>
     <!-- Engine-specific properties. Content should not use this file. -->
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>12</LangVersion>
+        <TargetFramework>net9.0</TargetFramework>
+        <LangVersion>13</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>
     </PropertyGroup>

--- a/MSBuild/Robust.Properties.targets
+++ b/MSBuild/Robust.Properties.targets
@@ -3,7 +3,7 @@
   <!-- Import this at the end of any project files in Robust and Content. -->
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,4 @@
-# Release notes for RobustToolbox.
+﻿# Release notes for RobustToolbox.
 
 <!--
 NOTE: automatically updated sometimes by version.py.
@@ -35,7 +35,7 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* Robust now uses **.NET 9**.
 
 ### New features
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
Closes #5527 

The Rider bugs in that issue have a resolved status, so afaik .NET 9 should be good to go.

Launcher PR: https://github.com/space-wizards/SS14.Launcher/pull/196

Content PR: When you code it.

I pretty much just repeated https://github.com/space-wizards/RobustToolbox/pull/4712

I don't think the "Test content master against engine" workflow will pass until there's a content PR for .NET 9?