### PR TITLE
Fix RichTextLabel

### DIFF
--- a/Robust.Client/UserInterface/RichTextEntry.cs
+++ b/Robust.Client/UserInterface/RichTextEntry.cs
@@ -46,7 +46,7 @@ namespace Robust.Client.UserInterface
             LineBreaks = default;
             _defaultColor = defaultColor ?? new(200, 200, 200);
             _tagsAllowed = tagsAllowed;
-            Dictionary<int, Control>? tagControls = null;
+            Dictionary<int, Control>? tagControls = new Dictionary<int, Control>();
 
             var nodeIndex = -1;
             foreach (var node in Message)
@@ -59,9 +59,11 @@ namespace Robust.Client.UserInterface
                 if (!tagManager.TryGetMarkupTag(node.Name, _tagsAllowed, out var tag) || !tag.TryGetControl(node, out var control))
                     continue;
 
-                parent.Children.Add(control);
-                tagControls ??= new Dictionary<int, Control>();
+                if (tagControls.ContainsKey(nodeIndex))
+                    continue;
+
                 tagControls.Add(nodeIndex, control);
+                parent.Children.Add(control);
             }
 
             _tagControls = tagControls;


### PR DESCRIPTION
Fixes duplicate controls in richtextlabel, this is a critical issue because they start getting added without going into the right containers, be it chatbox or paper. This creates a duplication effect.

Examples:

![image](https://github.com/user-attachments/assets/fe5f9959-f03f-4138-961e-563f64d0109e)
![image](https://github.com/user-attachments/assets/115b1c0c-612f-4adf-b521-5f26de0b6416)
![image](https://github.com/user-attachments/assets/292a245a-0a3f-4434-8e3a-50b1069725d5)

![image](https://github.com/user-attachments/assets/e40102aa-e3db-4f77-890f-07cbc7758bd1)
