### PR TITLE
Monospace Support for Rich Text

### DIFF
--- a/Robust.Client/UserInterface/RichText/MarkupTagManager.cs
+++ b/Robust.Client/UserInterface/RichText/MarkupTagManager.cs
@@ -24,7 +24,8 @@ public sealed class MarkupTagManager
         new CommandLinkTag(),
         new FontTag(),
         new HeadingTag(),
-        new ItalicTag()
+        new ItalicTag(),
+        new MonoTag()
     }.ToDictionary(x => x.Name.ToLower(), x => x);
 
     /// <summary>
@@ -39,7 +40,8 @@ public sealed class MarkupTagManager
         typeof(CommandLinkTag),
         typeof(FontTag),
         typeof(HeadingTag),
-        typeof(ItalicTag)
+        typeof(ItalicTag),
+        typeof(MonoTag)
     };
 
     public void Initialize()

--- a/Robust.Client/UserInterface/RichText/MonoTag.cs
+++ b/Robust.Client/UserInterface/RichText/MonoTag.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+using Robust.Client.ResourceManagement;
+using Robust.Shared.IoC;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Robust.Client.UserInterface.RichText;
+
+/// <summary>
+/// Sets the font to a monospaced variant
+/// </summary>
+public sealed class MonoTag : IMarkupTag
+{
+    public const string MonoFont = "Monospace";
+
+    [Dependency] private readonly IResourceCache _resourceCache = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+    public string Name => "mono";
+
+    /// <inheritdoc/>
+    public void PushDrawContext(MarkupNode node, MarkupDrawingContext context)
+    {
+        var font = FontTag.CreateFont(context.Font, node, _resourceCache, _prototypeManager, MonoFont);
+        context.Font.Push(font);
+    }
+
+    /// <inheritdoc/>
+    public void PopDrawContext(MarkupNode node, MarkupDrawingContext context)
+    {
+        context.Font.Pop();
+    }
+}


### PR DESCRIPTION
This adds the new `[mono]` tag to the RichText system allowing for monospaced text in player-created paper documents.

## Technical Details 

Created the new [MonoTag.cs](Robust.Client/UserInterface/RichText/MonoTag.cs) class which handles the [mono] tag when it appears in rich text documents. This loads the Monospace font described in the [Prototypes/fonts.yml](https://github.com/space-wizards/space-station-14/tree/67d444feb0b47b63a54221a7124e2277a214972f/Resources/Prototypes/fonts.yml) file and pushes it onto the MarkupDrawingContext object. 

Also added the `MonoTag` entry to the [MarkupTagManager.cs](Robust.Client/UserInterface/RichText/MarkupTagManager.cs) list of valid tags. Forks will need to also need to add this tag to the list of their [PaperWindow.xaml.cs](https://github.com/space-wizards/space-station-14/blob/67d444feb0b47b63a54221a7124e2277a214972f/Content.Client/Paper/UI/PaperWindow.xaml.cs#L40) `_allowedTags` attribute. However, I will be opening a PR on Wizden to account for this so it should propagate neatly. 

## Breaking Changes

If a branch does not have a monospace font defined in its `Resources/Prototypes/fonts.yml` and if someone tries to use the `[mono]` tag in a text document it will likely cause a huge issue. That being said this isn't something that seems to be handled in the similar BoldTag.cs or ItalicTag.cs so I'm gonna assume it's fine. 

## Demonstration
Using the Wizden SS14 debug build.

https://github.com/user-attachments/assets/e01cbc4c-219e-4dec-a6d0-9f9ef9bf3f62


