### PR TITLE
Add InterfaceData constructor

### DIFF
--- a/Robust.Shared/GameObjects/Components/UserInterface/UserInterfaceComponent.cs
+++ b/Robust.Shared/GameObjects/Components/UserInterface/UserInterfaceComponent.cs
@@ -69,6 +69,12 @@ namespace Robust.Shared.GameObjects
         [DataField]
         public bool RequireInputValidation = true;
 
+        public InterfaceData(string clientType, float interactionRange = 2f, bool requireInputValidation = true)
+        {
+            ClientType = clientType;
+            InteractionRange = interactionRange;
+            RequireInputValidation = requireInputValidation;
+        }
         public InterfaceData(InterfaceData data)
         {
             ClientType = data.ClientType;


### PR DESCRIPTION
### What
Add an InterfaceData constructor to UserInterfaceComponent's InterfaceData to allow for dynamic setting using setUi
### Why
Allows Component Systems to create BoundUi's dynamically (By ensuring a `UserInterfaceComponent` onto the entity and then utilizing `SharedUserInterfaceSystem.setUi()` to set the interface)  and be able to receive messages from them without needing a separate entity and a relay.
