### PR TITLE
Augment audio system with the ability to have captions 

### DIFF
--- a/Robust.Client/ComponentTrees/CaptionTreeSystem.cs
+++ b/Robust.Client/ComponentTrees/CaptionTreeSystem.cs
@@ -1,0 +1,46 @@
+using System.Numerics;
+using Robust.Client.GameObjects;
+using Robust.Shared.ComponentTrees;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Maths;
+using Robust.Shared.Physics;
+using Robust.Shared.Audio.Components;
+using Robust.Shared.IoC;
+
+namespace Robust.Client.ComponentTrees;
+
+public sealed class CaptionTreeSystem : ComponentTreeSystem<CaptionTreeComponent, CaptionComponent>
+{
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+
+    #region Component Tree Overrides
+    protected override bool DoFrameUpdate => false;
+    protected override bool DoTickUpdate => true;
+    protected override bool Recursive => true;
+    protected override int InitialCapacity => 128;
+
+    protected override Box2 ExtractAabb(in ComponentTreeEntry<CaptionComponent> entry, Vector2 pos, Angle rot)
+    {
+        if (_entityManager.TryGetComponent(entry.Uid, out AudioComponent? audio))
+        {
+            var radius = audio.MaxDistance;
+            var radiusVec = new Vector2(radius, radius);
+            return new Box2(pos - radiusVec, pos + radiusVec);
+        }
+        return default;
+    }
+
+    protected override Box2 ExtractAabb(in ComponentTreeEntry<CaptionComponent> entry)
+    {
+        if (entry.Component.TreeUid == null)
+            return default;
+
+        var pos = XformSystem.GetRelativePosition(
+            entry.Transform,
+            entry.Component.TreeUid.Value,
+            GetEntityQuery<TransformComponent>());
+
+        return ExtractAabb(in entry, pos, default);
+    }
+    #endregion
+}

--- a/Robust.Client/ComponentTrees/CaptionTreeSystem.cs
+++ b/Robust.Client/ComponentTrees/CaptionTreeSystem.cs
@@ -9,10 +9,11 @@ using Robust.Shared.IoC;
 
 namespace Robust.Client.ComponentTrees;
 
+/// <summary>
+/// ComponentTreeSystem tracking the audible ranges of captioned audio entities
+/// </summary>
 public sealed class CaptionTreeSystem : ComponentTreeSystem<CaptionTreeComponent, CaptionComponent>
 {
-    [Dependency] private readonly IEntityManager _entityManager = default!;
-
     #region Component Tree Overrides
     protected override bool DoFrameUpdate => false;
     protected override bool DoTickUpdate => true;
@@ -21,7 +22,7 @@ public sealed class CaptionTreeSystem : ComponentTreeSystem<CaptionTreeComponent
 
     protected override Box2 ExtractAabb(in ComponentTreeEntry<CaptionComponent> entry, Vector2 pos, Angle rot)
     {
-        if (_entityManager.TryGetComponent(entry.Uid, out AudioComponent? audio))
+        if (TryComp<AudioComponent>(entry.Uid, out var audio))
         {
             var radius = audio.MaxDistance;
             var radiusVec = new Vector2(radius, radius);

--- a/Robust.Shared/Audio/Components/CaptionComponent.cs
+++ b/Robust.Shared/Audio/Components/CaptionComponent.cs
@@ -1,0 +1,30 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.Localization;
+using Robust.Shared.ViewVariables;
+using Robust.Shared.Physics;
+using Robust.Shared.ComponentTrees;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.GameStates;
+
+namespace Robust.Shared.Audio.Components;
+
+/// <summary>
+/// Stores the caption data for an audio entity.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
+public sealed partial class CaptionComponent : Component, IComponentTreeEntry<CaptionComponent>
+{
+    [DataField, AutoNetworkedField]
+    public LocId? Caption { get; set; }
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    public string? LocalizedCaption => Caption != null ? Loc.GetString(Caption) : null;
+
+    public EntityUid? TreeUid { get; set; }
+
+    public DynamicTree<ComponentTreeEntry<CaptionComponent>>? Tree { get; set; }
+
+    public bool AddToTree => true;
+
+    public bool TreeUpdateQueued { get; set; }
+}

--- a/Robust.Shared/Audio/Components/CaptionTreeComponent.cs
+++ b/Robust.Shared/Audio/Components/CaptionTreeComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.Physics;
+using Robust.Shared.ComponentTrees;
+using Robust.Shared.GameObjects;
+
+namespace Robust.Shared.Audio.Components;
+
+/// <summary>
+/// Samples nearby <see cref="CaptionComponent"/>.
+/// </summary>
+[RegisterComponent]
+public sealed partial class CaptionTreeComponent : Component, IComponentTreeComponent<CaptionComponent>
+{
+    public DynamicTree<ComponentTreeEntry<CaptionComponent>> Tree { get; set; } = default!;
+}

--- a/Robust.Shared/Audio/SoundCollectionPrototype.cs
+++ b/Robust.Shared/Audio/SoundCollectionPrototype.cs
@@ -3,6 +3,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
+using Robust.Shared.Localization;
 
 namespace Robust.Shared.Audio;
 
@@ -12,6 +13,9 @@ public sealed partial class SoundCollectionPrototype : IPrototype
     [ViewVariables]
     [IdDataField]
     public string ID { get; private set; } = default!;
+
+    [DataField]
+    public LocId? Caption { get; private set; }
 
     [DataField("files")]
     public List<ResPath> PickFiles { get; private set; } = new();

--- a/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
+++ b/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
@@ -344,6 +344,15 @@ public abstract partial class SharedAudioSystem : EntitySystem
         comp.FileName = fileName ?? string.Empty;
         comp.Params = audioParams.Value;
         comp.AudioStart = Timing.CurTime;
+        if (specifier is ResolvedCollectionSpecifier collection && collection.Collection is {} collectionID)
+        {
+            var caption = ProtoMan.Index(collectionID).Caption;
+            if (caption is not null)
+            {
+                var capt = AddComp<CaptionComponent>(uid);
+                capt.Caption = caption;
+            }
+        }
 
         if (!audioParams.Value.Loop)
         {


### PR DESCRIPTION
Mainly manages `CaptionComponent`s attached to the audio entities whenever they should display a visible caption. Can't use a `Caption` field on the `AudioComponent` due to the `ComponentTreeSystem` wanting to listen to the `ComponentStartup`/`ComponentShutdown` events that are already being listened to by the client `AudioSystem`.