### PR TITLE
Fix Build Error with Auto-networked EntityUid Dictionaries

### DIFF
--- a/Robust.Shared.CompNetworkGenerator/ComponentNetworkGenerator.cs
+++ b/Robust.Shared.CompNetworkGenerator/ComponentNetworkGenerator.cs
@@ -329,7 +329,7 @@ namespace Robust.Shared.CompNetworkGenerator
                                     cast = $"({castString})";
 
                                     handleStateSetters.Append($@"
-                    EnsureEntityDictionary<{ensureGeneric}>(state.{name}, uid, component.{name})");
+                    EnsureEntityDictionary<{ensureGeneric}>(state.{name}, uid, component.{name});");
 
                                     deltaHandleFields.Append($@"
                             EnsureEntityDictionary<{ensureGeneric}>({cast} {fieldHandleValue}, uid, component.{name});");


### PR DESCRIPTION
A missing semi-colon prevented any entity-based auto-networked dictionary from being properly sourcegenned, causing a build error.

Pretty urgent.