### PR TITLE
PlacementManager CurrentEraserMouseCoordinates fix

### DIFF
--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -536,13 +536,14 @@ namespace Robust.Client.Placement
             }
             else
             {
+                var mousePosition = EyeManager.PixelToMap(InputManager.MouseScreenPosition);
                 var map = EntityManager.GetComponent<TransformComponent>(ent).MapID;
-                if (map == MapId.Nullspace || !Eraser)
+                if (map == MapId.Nullspace || !Eraser || mousePosition.MapId == MapId.Nullspace)
                 {
                     coordinates = new EntityCoordinates();
                     return false;
                 }
-                coordinates = XformSystem.ToCoordinates(ent, EyeManager.PixelToMap(InputManager.MouseScreenPosition));
+                coordinates = XformSystem.ToCoordinates(mousePosition);
                 return true;
             }
         }


### PR DESCRIPTION
Resolves #5575

With the recent modification to this method to remove deprecated calls, it appears a bug was introduced which messed up the coordinates being used in `PlacementManager`'s `CurrentEraserMouseCoordinates`. It appears the issue has something to do with how the call to the `ToCoordinates` method includes an entity which causes it to seemingly convert the coordinates to be relative to the entity, which isn't very conducive to the erase method here. One day I hope to understand the coordinate systems in this game so I can know if my read on this is correct, but today is not that day.

I've resolved the issue by using a different method overload for `EntityCoordinates`'s `ToCoordinates` which doesn't have an argument for the entity. 

This seems to work rather well, however during testing I noticed a new bug, which threw an endless stream of error messages if I happened to mouse over any UI element. I've added an additional fix for this, which simply checks whether the MapId we're moused over is equal to the `MapId.Nullspace` value. This bug is also present in the current version of the code, so I figured I'd resolve it as well.

My fix for this simply causes the method to return its false result, which functionally just makes the selector freeze in place while you're mousing over UI elements. It doesn't feel the best, but I fail to understand the coordinate systems in this game, so I won't be resolving that.

https://github.com/user-attachments/assets/cee375de-1a31-4ddb-9a2a-00804f059239

