### PR TITLE
Fix autocompletion hint for toolshed strings

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Console completion options now have a new flag `CompletionOptionFlags.Literal`, which will prevent options from being escaped or quoted.
 
 ### Bugfixes
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-* Console completion options now have a new flag `CompletionOptionFlags.Literal`, which will prevent options from being escaped or quoted.
+* Console completion options now have a new flags for preventing suggestions from being escaped or quoted.
 
 ### Bugfixes
 

--- a/Robust.Client/UserInterface/CustomControls/DebugConsole.xaml.Completions.cs
+++ b/Robust.Client/UserInterface/CustomControls/DebugConsole.xaml.Completions.cs
@@ -276,16 +276,12 @@ public sealed partial class DebugConsole
                 // This means that letter casing will match the completion suggestion.
                 CommandBar.CursorPosition = lastRange.end;
                 CommandBar.SelectionStart = lastRange.start;
-                var insertValue = completion;
-                var mustQuote = false;
 
-                if ((completionFlags & CompletionOptionFlags.Literal) == 0)
-                {
-                    insertValue = CommandParsing.Escape(completion);
+                var insertValue = (completionFlags & CompletionOptionFlags.NoEscape) == 0
+                    ? CommandParsing.Escape(completion)
+                    : completion;
 
-                    // If the replacement contains a space, we must quote it to treat it as a single argument.
-                    mustQuote = insertValue.Contains(' ');
-                }
+                var mustQuote = (completionFlags & CompletionOptionFlags.NoQuote) == 0 && insertValue.Contains(' ');
 
                 if ((completionFlags & CompletionOptionFlags.PartialCompletion) == 0)
                 {

--- a/Robust.Client/UserInterface/CustomControls/DebugConsole.xaml.Completions.cs
+++ b/Robust.Client/UserInterface/CustomControls/DebugConsole.xaml.Completions.cs
@@ -281,6 +281,7 @@ public sealed partial class DebugConsole
                     ? CommandParsing.Escape(completion)
                     : completion;
 
+                // If the replacement contains a space, we must quote it to treat it as a single argument.
                 var mustQuote = (completionFlags & CompletionOptionFlags.NoQuote) == 0 && insertValue.Contains(' ');
 
                 if ((completionFlags & CompletionOptionFlags.PartialCompletion) == 0)

--- a/Robust.Client/UserInterface/CustomControls/DebugConsole.xaml.Completions.cs
+++ b/Robust.Client/UserInterface/CustomControls/DebugConsole.xaml.Completions.cs
@@ -276,10 +276,17 @@ public sealed partial class DebugConsole
                 // This means that letter casing will match the completion suggestion.
                 CommandBar.CursorPosition = lastRange.end;
                 CommandBar.SelectionStart = lastRange.start;
-                var insertValue = CommandParsing.Escape(completion);
+                var insertValue = completion;
+                var mustQuote = false;
 
-                // If the replacement contains a space, we must quote it to treat it as a single argument.
-                var mustQuote = insertValue.Contains(' ');
+                if ((completionFlags & CompletionOptionFlags.Literal) == 0)
+                {
+                    insertValue = CommandParsing.Escape(completion);
+
+                    // If the replacement contains a space, we must quote it to treat it as a single argument.
+                    mustQuote = insertValue.Contains(' ');
+                }
+
                 if ((completionFlags & CompletionOptionFlags.PartialCompletion) == 0)
                 {
                     if (mustQuote)

--- a/Robust.Shared/Console/CompletionResult.cs
+++ b/Robust.Shared/Console/CompletionResult.cs
@@ -85,6 +85,4 @@ public enum CompletionOptionFlags
     /// Prevents suggestions from being escaped using <see cref="CommandParsing.Escape"/>.
     /// </summary>
     NoEscape = 1 << 2,
-
-    Literal = NoQuote | NoEscape,
 }

--- a/Robust.Shared/Console/CompletionResult.cs
+++ b/Robust.Shared/Console/CompletionResult.cs
@@ -77,9 +77,14 @@ public enum CompletionOptionFlags
     PartialCompletion = 1 << 0,
 
     /// <summary>
-    /// The completion should be inserted as-is, and shouldn't be quoted or escaped using
-    /// <see cref="CommandParsing.Escape"/>. Unless it is a <see cref="PartialCompletion"/>, a space will still be
-    /// inserted at the end.
+    /// Prevents suggestions containing spaces from being automatically wrapped in quotes.
     /// </summary>
-    Literal = 1 << 1,
+    NoQuote = 1 << 1,
+
+    /// <summary>
+    /// Prevents suggestions from being escaped using <see cref="CommandParsing.Escape"/>.
+    /// </summary>
+    NoEscape = 1 << 2,
+
+    Literal = NoQuote | NoEscape,
 }

--- a/Robust.Shared/Console/CompletionResult.cs
+++ b/Robust.Shared/Console/CompletionResult.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Console;
 
@@ -74,4 +75,11 @@ public enum CompletionOptionFlags
     /// (instead of adding a space to go to the next one).
     /// </summary>
     PartialCompletion = 1 << 0,
+
+    /// <summary>
+    /// The completion should be inserted as-is, and shouldn't be quoted or escaped using
+    /// <see cref="CommandParsing.Escape"/>. Unless it is a <see cref="PartialCompletion"/>, a space will still be
+    /// inserted at the end.
+    /// </summary>
+    Literal = 1 << 1,
 }

--- a/Robust.Shared/Toolshed/TypeParsers/StringTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/StringTypeParser.cs
@@ -11,8 +11,8 @@ namespace Robust.Shared.Toolshed.TypeParsers;
 
 internal sealed class StringTypeParser : TypeParser<string>
 {
-    // Completion option for hinting that all strings must start with an quote
-    private static readonly CompletionOption[] Option = [new("\"", Flags: CompletionOptionFlags.PartialCompletion)];
+    // Completion option for hinting that all strings must start with a quote
+    private static readonly CompletionOption[] Option = [new("\"", Flags: CompletionOptionFlags.PartialCompletion | CompletionOptionFlags.Literal)];
 
     public override bool TryParse(ParserContext ctx, [NotNullWhen(true)] out string? result)
     {

--- a/Robust.Shared/Toolshed/TypeParsers/StringTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/StringTypeParser.cs
@@ -12,7 +12,7 @@ namespace Robust.Shared.Toolshed.TypeParsers;
 internal sealed class StringTypeParser : TypeParser<string>
 {
     // Completion option for hinting that all strings must start with a quote
-    private static readonly CompletionOption[] Option = [new("\"", Flags: CompletionOptionFlags.PartialCompletion | CompletionOptionFlags.Literal)];
+    private static readonly CompletionOption[] Option = [new("\"", Flags: CompletionOptionFlags.PartialCompletion | CompletionOptionFlags.NoEscape)];
 
     public override bool TryParse(ParserContext ctx, [NotNullWhen(true)] out string? result)
     {


### PR DESCRIPTION
Prevents the hint/suggestion that strings must start with a quote `"` from being escaped as `\"`.