### PR TITLE
Safe dictionary assignment in map saving.

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapLoaderSystem.cs
@@ -1017,8 +1017,8 @@ public sealed class MapLoaderSystem : EntitySystem
                 // Skip removed tile definitions.
                 if (!_tileDefManager.TryGetDefinition(prototypeId, out var definition))
                     continue;
-
-                tileIdMap.Add(definition.TileId, origId);
+                if (!tileIdMap.ContainsKey(definition.TileId))
+                    tileIdMap.Add(definition.TileId, origId);
             }
 
             // Assign new IDs for all new tile types.


### PR DESCRIPTION
It wasn't safe and would get royally fucked when you went to save maps if something stupid happened. I'm not 100% sure what caused it, I think deleting an entity and then replacing it with the same prototype in the same tile or something stupid like that. May or may not have something to do with entity linking.

Idk.

Shit pissed me off though.

If this isn't the appropriate solution I'll probably just put up a revert PR for the change that tries to re-save maps to preserve the .yml because some bulldozed changes are infinitely less annoying than losing *hours* of your time on map making. 

Honestly, kinda tempted to revert that stuff anyway because I have no idea why this has no way to just tell the engine to get fucked and serialize the map anyway.