### PR TITLE
Push clientside transform GridUids to children

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/TransformSystem.Component.cs
+++ b/Robust.Client/GameObjects/EntitySystems/TransformSystem.Component.cs
@@ -8,6 +8,21 @@ namespace Robust.Client.GameObjects;
 
 public sealed partial class TransformSystem
 {
+    protected override void OnCompStartup(EntityUid uid, TransformComponent xform, ComponentStartup args)
+    {
+        // When parenting a transform to an entity that doesn't yet exist on the client (ex: outside of PVS),
+        // the parenting will be done before the target entity's transform is initialized.
+        // The parent transforms will have their GridUids set on initialize, but this value
+        // won't be copied to their children. Thus we need to push the GridUid to the children once
+        // we have it set up.
+        foreach (var child in xform._children)
+        {
+            SetGridId(child, XformQuery.GetComponent(child), xform._gridUid);
+        }
+
+        base.OnCompStartup(uid, xform, args);
+    }
+
     public override void SetLocalPosition(EntityUid uid, Vector2 value, TransformComponent? xform = null)
     {
         if (!XformQuery.Resolve(uid, ref xform))

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -309,7 +309,7 @@ public abstract partial class SharedTransformSystem
         xform._gridUid = parentXform._gridUid;
     }
 
-    private void OnCompStartup(EntityUid uid, TransformComponent xform, ComponentStartup args)
+    protected virtual void OnCompStartup(EntityUid uid, TransformComponent xform, ComponentStartup args)
     {
         // TODO PERFORMANCE remove AnchorStateChangedEvent and EntParentChangedMessage events here.
 


### PR DESCRIPTION
When an entity is parented to another entity that does not currently exist on the client (such as when the new parent is outside of the client's PVS), the child entity does not have its GridUid set properly. This can cause issues with other systems that rely on the GridUid.

For example, when using the Follow button from the ghost roles panel, if the target entity is outside of PVS, the camera will be left at a strange rotation until the user moves:
<img width="1392" alt="Screenshot 2025-01-06 at 4 37 29 PM" src="https://github.com/user-attachments/assets/861b1733-75aa-4f03-bd31-80ec0f3f0ed5" />

This will also happen when parenting to a newly-created entity (see https://github.com/space-wizards/space-station-14/pull/33878#issuecomment-2544274891)

To fix this, a handler for `ComponentStartup` is added to the clientside TransformSystem, which calls `SetGridId` on any children of the parent. `SetGridId` handles recursing through children-of-children and aborting in the case of uninitialized transforms.