### PR TITLE
Fix replay playback bugs

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Fixed a state handling bug in replays, which was causing exceptions to be thrown when applying delta states.
 
 ### Other
 

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -399,7 +399,7 @@ namespace Robust.Client.GameStates
 
                 using (_prof.Group("MergeImplicitData"))
                 {
-                    MergeImplicitData(createdEntities);
+                    GenerateImplicitStates(createdEntities);
                 }
 
                 if (_lastProcessedInput < curState.LastProcessedInput)
@@ -671,7 +671,7 @@ namespace Robust.Client.GameStates
         ///     initial server state for any newly created entity. It does this by simply using the standard <see
         ///     cref="IEntityManager.GetComponentState"/>.
         /// </remarks>
-        private void MergeImplicitData(IEnumerable<NetEntity> createdEntities)
+        public void GenerateImplicitStates(IEnumerable<NetEntity> createdEntities)
         {
             var bus = _entityManager.EventBus;
 

--- a/Robust.Client/GameStates/IClientGameStateManager.cs
+++ b/Robust.Client/GameStates/IClientGameStateManager.cs
@@ -83,6 +83,12 @@ namespace Robust.Client.GameStates
         IEnumerable<NetEntity> ApplyGameState(GameState curState, GameState? nextState);
 
         /// <summary>
+        ///     Generates implicit component states for newly created entities.
+        ///     This should always be called after running <see cref="ApplyGameState(GameState, GameState)"/>.
+        /// </summary>
+        void GenerateImplicitStates(IEnumerable<NetEntity> states);
+
+        /// <summary>
         ///     Resets any entities that have changed while predicting future ticks.
         /// </summary>
         void ResetPredictedEntities();

--- a/Robust.Client/Replays/Playback/ReplayPlaybackManager.Update.cs
+++ b/Robust.Client/Replays/Playback/ReplayPlaybackManager.Update.cs
@@ -44,7 +44,8 @@ internal sealed partial class ReplayPlaybackManager
             _gameState.UpdateFullRep(state, cloneDelta: true);
             var next = Replay.NextState;
             BeforeApplyState?.Invoke((state, next));
-            _gameState.ApplyGameState(state, next);
+            var created = _gameState.ApplyGameState(state, next);
+            _gameState.GenerateImplicitStates(created);
             DebugTools.Assert(Replay.LastApplied >= state.FromSequence);
             DebugTools.Assert(Replay.LastApplied + 1 <= state.ToSequence);
             Replay.LastApplied = state.ToSequence;

--- a/Robust.Shared/GameObjects/ComponentState.cs
+++ b/Robust.Shared/GameObjects/ComponentState.cs
@@ -40,17 +40,17 @@ public interface IComponentDeltaState<TState> : IComponentDeltaState where TStat
 
     void IComponentDeltaState.ApplyToFullState(IComponentState fullState)
     {
-        if (fullState is TState state)
-            ApplyToFullState(state);
-        else
-            throw new Exception($"Unexpected type. Expected {nameof(TState)} but got {fullState.GetType().Name}");
+        if (fullState is not TState state)
+            throw new Exception($"Unexpected type. Expected {typeof(TState).Name} but got {fullState.GetType().Name}");
+
+        ApplyToFullState(state);
     }
 
     IComponentState IComponentDeltaState.CreateNewFullState(IComponentState fullState)
     {
-        if (fullState is TState state)
-            return CreateNewFullState(state);
-        else
-            throw new Exception($"Unexpected type. Expected {nameof(TState)} but got {fullState.GetType().Name}");
+        if (fullState is not TState state)
+            throw new Exception($"Unexpected type. Expected {typeof(TState).Name} but got {fullState.GetType().Name}");
+
+        return CreateNewFullState(state);
     }
 }


### PR DESCRIPTION
Fixes replays never creating implicit component states, which was causing exceptions when trying to apply physics component delta states. Also fixes a bug where entities were being initialized out of order, though I'm not sure if this actually caused issues, but its been making a debug assert added in #5343 fail. 