### PR TITLE
Downgrade VorbisPizza back to 1.3.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -62,7 +62,7 @@
     <PackageVersion Include="SpaceWizards.Sodium" Version="0.2.1" />
     <PackageVersion Include="TerraFX.Interop.Windows" Version="10.0.26100.1" />
     <PackageVersion Include="TerraFX.Interop.Xlib" Version="6.4.0" />
-    <PackageVersion Include="VorbisPizza" Version="1.4.2" />
+    <PackageVersion Include="VorbisPizza" Version="1.3.0" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="prometheus-net" Version="8.2.1" />
     <PackageVersion Include="prometheus-net.DotNetRuntime" Version="4.4.0" />


### PR DESCRIPTION
Somewhere between [1.3.0 and 1.4.0](https://github.com/TechPizzaDev/VorbisPizza/compare/7852e46bc06ba83a03d6335950de9e2205968a80..v1.4.0) (I tested all versions) exists a bug that for some reason messes with the audio on some devices.

A proper fix would require us trying to make contact with the developer of VorbisPizza, find the buggy commit and waiting them to update their package. This repo has been inactive for 8 months. I doubt we can get support unless we fork it and find the bug ourselves. This is the path of least resistance to at least get the effected players back.

Closes & fixes #5605 and https://github.com/space-wizards/space-station-14/issues/34418

Reproduced?: Yes, myself: Macbook Air M1 2020.
A total of 34~ players have expressed this bug exists. On different operating systems and hardware. Primerly low spec hardware.

## I request an engine release, as some forks and devs are effected currently.