### PR TITLE
Make `ComponentRegistry` not implement `ISerializationContext`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,7 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* `ComponentRegistry` no longer implements `ISerializationContext`
 
 ### New features
 

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -402,7 +402,7 @@ namespace Robust.Shared.Prototypes
         }*/
     }
 
-    public sealed class ComponentRegistry : Dictionary<string, EntityPrototype.ComponentRegistryEntry>, IEntityLoadContext, ISerializationContext
+    public sealed class ComponentRegistry : Dictionary<string, EntityPrototype.ComponentRegistryEntry>, IEntityLoadContext
     {
         public ComponentRegistry()
         {
@@ -429,8 +429,5 @@ namespace Robust.Shared.Prototypes
         {
             return false; //Registries cannot represent the "remove this component" state.
         }
-
-        public SerializationManager.SerializerProvider SerializerProvider { get; } = new();
-        public bool WritingReadingPrototypes { get; } = true;
     }
 }


### PR DESCRIPTION
I have NFI why ComponentRegistry has that interface, but I'm pretty sure it doesn't need it, and it was probably just accidentally added in #4068 due to confusion between `IEntityLoadContext` and `ISerializationContext`?

The PR that added it wasn't really thoroughly reviewed, though there was some discussion on [discord ](https://discord.com/channels/310555209753690112/770682801607278632/1108814803948032090)