### PR TITLE
Fix SharedBroadphaseSystem.GetBroadphases

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Fixed `SharedBroadphaseSystem.GetBroadphases()` not returning the map itself, which was causing physics to not work properly off-grid.
 
 ### Other
 


### PR DESCRIPTION
Since #5440, `GetBroadphases` was using the `includeMap` option on `MapManager.FindGridsIntersecting` to include the map, which only works when the map is itself also a grid.

Fixes https://github.com/space-wizards/space-station-14/issues/34482