### PR TITLE
Make GamePrototypeLoadManager send a single message with all uploaded prototypes in a single message

### DIFF
--- a/Robust.Server/Upload/GamePrototypeLoadManager.cs
+++ b/Robust.Server/Upload/GamePrototypeLoadManager.cs
@@ -51,13 +51,10 @@ public sealed class GamePrototypeLoadManager : SharedPrototypeLoadManager
     internal void SendToNewUser(INetChannel channel)
     {
         // Just dump all the prototypes on connect, before them missing could be an issue.
-        foreach (var prototype in LoadedPrototypes)
+        var msg = new GamePrototypeLoadMessage
         {
-            var msg = new GamePrototypeLoadMessage
-            {
-                PrototypeData = prototype
-            };
-            channel.SendMessage(msg);
-        }
+            PrototypeData = string.Join("\n\n", LoadedPrototypes)
+        };
+        channel.SendMessage(msg);
     }
 }


### PR DESCRIPTION
Otherwise every single individual upload from an admin causes a separate reload of the prototypes, which takes around 2-3 seconds on my machine each, and you are stuck connecting for potentially minutes on end 