### PR TITLE
add AsNullable() extension method to Entity<T>

### DIFF
--- a/Robust.Shared/GameObjects/EntityExt.cs
+++ b/Robust.Shared/GameObjects/EntityExt.cs
@@ -1,0 +1,104 @@
+namespace Robust.Shared.GameObjects;
+
+public static class EntityExt
+{
+    /// <summary>
+    ///     Converts an Entity{T} to Entity{T?}, making it compatible with methods that take nullable components.
+    /// </summary>
+    /// <typeparam name="T">The component type. Must implement IComponent.</typeparam>
+    /// <param name="ent">The source entity to convert.</param>
+    /// <returns>An Entity{T?} with the same owner and component as the source entity.</returns>
+    /// <example>
+    ///     <code>
+    /// // Instead of:
+    /// Entity{MyComponent?} nullable = (ent, ent.Comp);
+    ///
+    /// // You can write:
+    /// Entity{MyComponent?} nullable = ent.AsNullable();
+    /// </code>
+    /// </example>
+    public static Entity<T?> AsNullable<T>(this Entity<T> ent) where T : IComponent
+    {
+        return (ent.Owner, ent.Comp);
+    }
+
+    /// <inheritdoc cref="AsNullable{T}" />
+    public static Entity<T1?, T2?> AsNullable<T1, T2>(this Entity<T1, T2> ent)
+        where T1 : IComponent
+        where T2 : IComponent
+    {
+        return (ent.Owner, ent.Comp1, ent.Comp2);
+    }
+
+    /// <inheritdoc cref="AsNullable{T}" />
+    public static Entity<T1?, T2?, T3?> AsNullable<T1, T2, T3>(this Entity<T1, T2, T3> ent)
+        where T1 : IComponent
+        where T2 : IComponent
+        where T3 : IComponent
+    {
+        return (ent.Owner, ent.Comp1, ent.Comp2, ent.Comp3);
+    }
+
+    /// <inheritdoc cref="AsNullable{T}" />
+    public static Entity<T1?, T2?, T3?, T4?> AsNullable<T1, T2, T3, T4>(this Entity<T1, T2, T3, T4> ent)
+        where T1 : IComponent
+        where T2 : IComponent
+        where T3 : IComponent
+        where T4 : IComponent
+    {
+        return (ent.Owner, ent.Comp1, ent.Comp2, ent.Comp3, ent.Comp4);
+    }
+
+    /// <inheritdoc cref="AsNullable{T}" />
+    public static Entity<T1?, T2?, T3?, T4?, T5?> AsNullable<T1, T2, T3, T4, T5>(this Entity<T1, T2, T3, T4, T5> ent)
+        where T1 : IComponent
+        where T2 : IComponent
+        where T3 : IComponent
+        where T4 : IComponent
+        where T5 : IComponent
+    {
+        return (ent.Owner, ent.Comp1, ent.Comp2, ent.Comp3, ent.Comp4, ent.Comp5);
+    }
+
+    /// <inheritdoc cref="AsNullable{T}" />
+    public static Entity<T1?, T2?, T3?, T4?, T5?, T6?> AsNullable<T1, T2, T3, T4, T5, T6>(
+        this Entity<T1, T2, T3, T4, T5, T6> ent)
+        where T1 : IComponent
+        where T2 : IComponent
+        where T3 : IComponent
+        where T4 : IComponent
+        where T5 : IComponent
+        where T6 : IComponent
+    {
+        return (ent.Owner, ent.Comp1, ent.Comp2, ent.Comp3, ent.Comp4, ent.Comp5, ent.Comp6);
+    }
+
+    /// <inheritdoc cref="AsNullable{T}" />
+    public static Entity<T1?, T2?, T3?, T4?, T5?, T6?, T7?> AsNullable<T1, T2, T3, T4, T5, T6, T7>(
+        this Entity<T1, T2, T3, T4, T5, T6, T7> ent)
+        where T1 : IComponent
+        where T2 : IComponent
+        where T3 : IComponent
+        where T4 : IComponent
+        where T5 : IComponent
+        where T6 : IComponent
+        where T7 : IComponent
+    {
+        return (ent.Owner, ent.Comp1, ent.Comp2, ent.Comp3, ent.Comp4, ent.Comp5, ent.Comp6, ent.Comp7);
+    }
+
+    /// <inheritdoc cref="AsNullable{T}" />
+    public static Entity<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?> AsNullable<T1, T2, T3, T4, T5, T6, T7, T8>(
+        this Entity<T1, T2, T3, T4, T5, T6, T7, T8> ent)
+        where T1 : IComponent
+        where T2 : IComponent
+        where T3 : IComponent
+        where T4 : IComponent
+        where T5 : IComponent
+        where T6 : IComponent
+        where T7 : IComponent
+        where T8 : IComponent
+    {
+        return (ent.Owner, ent.Comp1, ent.Comp2, ent.Comp3, ent.Comp4, ent.Comp5, ent.Comp6, ent.Comp7, ent.Comp8);
+    }
+}

--- a/Robust.Shared/GameObjects/EntityExt.cs
+++ b/Robust.Shared/GameObjects/EntityExt.cs
@@ -19,7 +19,7 @@ public static class EntityExt
     /// </example>
     public static Entity<T?> AsNullable<T>(this Entity<T> ent) where T : IComponent
     {
-        return (ent.Owner, ent.Comp);
+        return new(ent.Owner, ent.Comp);
     }
 
     /// <inheritdoc cref="AsNullable{T}" />
@@ -27,7 +27,7 @@ public static class EntityExt
         where T1 : IComponent
         where T2 : IComponent
     {
-        return (ent.Owner, ent.Comp1, ent.Comp2);
+        return new(ent.Owner, ent.Comp1, ent.Comp2);
     }
 
     /// <inheritdoc cref="AsNullable{T}" />
@@ -36,7 +36,7 @@ public static class EntityExt
         where T2 : IComponent
         where T3 : IComponent
     {
-        return (ent.Owner, ent.Comp1, ent.Comp2, ent.Comp3);
+        return new(ent.Owner, ent.Comp1, ent.Comp2, ent.Comp3);
     }
 
     /// <inheritdoc cref="AsNullable{T}" />
@@ -46,7 +46,7 @@ public static class EntityExt
         where T3 : IComponent
         where T4 : IComponent
     {
-        return (ent.Owner, ent.Comp1, ent.Comp2, ent.Comp3, ent.Comp4);
+        return new(ent.Owner, ent.Comp1, ent.Comp2, ent.Comp3, ent.Comp4);
     }
 
     /// <inheritdoc cref="AsNullable{T}" />
@@ -57,7 +57,7 @@ public static class EntityExt
         where T4 : IComponent
         where T5 : IComponent
     {
-        return (ent.Owner, ent.Comp1, ent.Comp2, ent.Comp3, ent.Comp4, ent.Comp5);
+        return new(ent.Owner, ent.Comp1, ent.Comp2, ent.Comp3, ent.Comp4, ent.Comp5);
     }
 
     /// <inheritdoc cref="AsNullable{T}" />
@@ -70,7 +70,7 @@ public static class EntityExt
         where T5 : IComponent
         where T6 : IComponent
     {
-        return (ent.Owner, ent.Comp1, ent.Comp2, ent.Comp3, ent.Comp4, ent.Comp5, ent.Comp6);
+        return new(ent.Owner, ent.Comp1, ent.Comp2, ent.Comp3, ent.Comp4, ent.Comp5, ent.Comp6);
     }
 
     /// <inheritdoc cref="AsNullable{T}" />
@@ -84,7 +84,7 @@ public static class EntityExt
         where T6 : IComponent
         where T7 : IComponent
     {
-        return (ent.Owner, ent.Comp1, ent.Comp2, ent.Comp3, ent.Comp4, ent.Comp5, ent.Comp6, ent.Comp7);
+        return new(ent.Owner, ent.Comp1, ent.Comp2, ent.Comp3, ent.Comp4, ent.Comp5, ent.Comp6, ent.Comp7);
     }
 
     /// <inheritdoc cref="AsNullable{T}" />
@@ -99,6 +99,6 @@ public static class EntityExt
         where T7 : IComponent
         where T8 : IComponent
     {
-        return (ent.Owner, ent.Comp1, ent.Comp2, ent.Comp3, ent.Comp4, ent.Comp5, ent.Comp6, ent.Comp7, ent.Comp8);
+        return new(ent.Owner, ent.Comp1, ent.Comp2, ent.Comp3, ent.Comp4, ent.Comp5, ent.Comp6, ent.Comp7, ent.Comp8);
     }
 }


### PR DESCRIPTION
the closest we'll ever get to `Entity<T>` casting to `Entity<T?>`
having to pass `(ent, ent.Comp)` to all methods with the `Entity<T?>` signature seems really stupid especially once you get into the `Entity<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?>` territory 

you could explicitly get the EntityUid with `ent.Owner` and pass that instead but it's incredibly dumb if you already have the component, because then Resolve() becomes a slower TryComp()

now you can just do `ent.AsNullable()` instead! isn't that so much cleaner?