### PR TITLE
Fixing guidebook not resizable from left and right

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Fixed `BaseWindow` sometimes not properly updating the mouse cursor shape.
 
 ### Other
 

--- a/Robust.Client/UserInterface/CustomControls/BaseWindow.cs
+++ b/Robust.Client/UserInterface/CustomControls/BaseWindow.cs
@@ -102,27 +102,23 @@ namespace Robust.Client.UserInterface.CustomControls
             {
                 var cursor = CursorShape.Arrow;
                 var previewDragMode = GetDragModeFor(args.RelativePosition);
-                previewDragMode &= ~DragMode.Move;
                 switch (previewDragMode)
                 {
-                    case DragMode.Top:
-                    case DragMode.Bottom:
-                        cursor = CursorShape.VResize;
+                    case var _ when (previewDragMode & (DragMode.Bottom | DragMode.Left)) == (DragMode.Bottom | DragMode.Left):
+                    case var _ when (previewDragMode & (DragMode.Top | DragMode.Right)) == (DragMode.Top | DragMode.Right):
+                        cursor = CursorShape.Crosshair;
                         break;
-
-                    case DragMode.Left:
-                    case DragMode.Right:
+                    case var _ when (previewDragMode & (DragMode.Bottom | DragMode.Right)) == (DragMode.Bottom | DragMode.Right):
+                    case var _ when (previewDragMode & (DragMode.Top | DragMode.Left)) == (DragMode.Top | DragMode.Left):
+                        cursor = CursorShape.Crosshair;
+                        break;
+                    case var _ when (previewDragMode & DragMode.Left) != 0:
+                    case var _ when (previewDragMode & DragMode.Right) != 0:
                         cursor = CursorShape.HResize;
                         break;
-
-                    case DragMode.Bottom | DragMode.Left:
-                    case DragMode.Top | DragMode.Right:
-                        cursor = CursorShape.Crosshair;
-                        break;
-
-                    case DragMode.Bottom | DragMode.Right:
-                    case DragMode.Top | DragMode.Left:
-                        cursor = CursorShape.Crosshair;
+                    case var _ when (previewDragMode & DragMode.Top) != 0:
+                    case var _ when (previewDragMode & DragMode.Bottom) != 0:
+                        cursor = CursorShape.VResize;
                         break;
                 }
 

--- a/Robust.Client/UserInterface/CustomControls/BaseWindow.cs
+++ b/Robust.Client/UserInterface/CustomControls/BaseWindow.cs
@@ -102,6 +102,7 @@ namespace Robust.Client.UserInterface.CustomControls
             {
                 var cursor = CursorShape.Arrow;
                 var previewDragMode = GetDragModeFor(args.RelativePosition);
+                previewDragMode &= ~DragMode.Move;
                 switch (previewDragMode)
                 {
                     case DragMode.Top:

--- a/Robust.Client/UserInterface/CustomControls/BaseWindow.cs
+++ b/Robust.Client/UserInterface/CustomControls/BaseWindow.cs
@@ -102,23 +102,25 @@ namespace Robust.Client.UserInterface.CustomControls
             {
                 var cursor = CursorShape.Arrow;
                 var previewDragMode = GetDragModeFor(args.RelativePosition);
+                previewDragMode &= ~DragMode.Move;
+
                 switch (previewDragMode)
                 {
-                    case var _ when (previewDragMode & (DragMode.Bottom | DragMode.Left)) == (DragMode.Bottom | DragMode.Left):
-                    case var _ when (previewDragMode & (DragMode.Top | DragMode.Right)) == (DragMode.Top | DragMode.Right):
-                        cursor = CursorShape.Crosshair;
+                    case DragMode.Top:
+                    case DragMode.Bottom:
+                        cursor = CursorShape.VResize;
                         break;
-                    case var _ when (previewDragMode & (DragMode.Bottom | DragMode.Right)) == (DragMode.Bottom | DragMode.Right):
-                    case var _ when (previewDragMode & (DragMode.Top | DragMode.Left)) == (DragMode.Top | DragMode.Left):
-                        cursor = CursorShape.Crosshair;
-                        break;
-                    case var _ when (previewDragMode & DragMode.Left) != 0:
-                    case var _ when (previewDragMode & DragMode.Right) != 0:
+
+                    case DragMode.Left:
+                    case DragMode.Right:
                         cursor = CursorShape.HResize;
                         break;
-                    case var _ when (previewDragMode & DragMode.Top) != 0:
-                    case var _ when (previewDragMode & DragMode.Bottom) != 0:
-                        cursor = CursorShape.VResize;
+
+                    case DragMode.Bottom | DragMode.Left:
+                    case DragMode.Top | DragMode.Right:
+                    case DragMode.Bottom | DragMode.Right:
+                    case DragMode.Top | DragMode.Left:
+                        cursor = CursorShape.Crosshair;
                         break;
                 }
 
@@ -157,15 +159,6 @@ namespace Robust.Client.UserInterface.CustomControls
                 var rect = new UIBox2(left, top, right, bottom);
                 LayoutContainer.SetPosition(this, rect.TopLeft);
                 SetSize = rect.Size;
-
-                /*
-                var timing = IoCManager.Resolve<IGameTiming>();
-
-                var l = GetValue<float>(LayoutContainer.MarginLeftProperty);
-                var t = GetValue<float>(LayoutContainer.MarginTopProperty);
-
-                Logger.Debug($"{timing.CurFrame}: {rect.TopLeft}/({l}, {t}), {rect.Size}/{SetSize}");
-                */
             }
         }
 


### PR DESCRIPTION
issue [34504](https://github.com/space-wizards/space-station-14/issues/34504) in space-wizards/space-station-14 needs this fix

It happens that the value DragMode.Move prevents the switch case from catching left and right because the code in ss14 looks like this 

```
var mode = DragMode.Move; ##note that removing this line from ss14 will leave the window unmovable##

if (Resizable)
{
    if (relativeMousePos.Y < DRAG_MARGIN_SIZE)
    {
        mode = DragMode.Top;
    }
    else if (relativeMousePos.Y > Size.Y - DRAG_MARGIN_SIZE)
    {
        mode = DragMode.Bottom;
    }

    if (relativeMousePos.X < DRAG_MARGIN_SIZE)
    {
        mode |= DragMode.Left;
    }
    else if (relativeMousePos.X > Size.X - DRAG_MARGIN_SIZE)
    {
        mode |= DragMode.Right;
    }
}

return mode;
```

so basically the equal sign removes the Move value in every other case leaving the guidebook window cursor not changing on left and right and here is a video of working solution 

https://drive.google.com/file/d/1UTgJGoV_96P2-TyJa1No1gHP9FXIL7Kd/view?usp=sharing

and i also fixed the corresponding code on ss14 repo and will make another pull request there