### PR TITLE
Avoid unnecessary DirtyField() calls

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Added `EntityManager.DirtyFields()`, which allows components with delta states to simultaneously mark several fields as dirty at the same time.
 
 ### Bugfixes
 

--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -101,9 +101,31 @@ namespace Robust.Client.GameObjects
         /// <inheritdoc />
         public override void Dirty<T>(Entity<T> ent, MetaDataComponent? meta = null)
         {
-            //  Client only dirties during prediction
+            // Client only dirties during prediction
             if (_gameTiming.InPrediction)
                 base.Dirty(ent, meta);
+        }
+
+        public override void DirtyField<T>(EntityUid uid, T comp, string fieldName, MetaDataComponent? metadata = null)
+        {
+            // TODO Prediction
+            // does the client actually need to dirty the field?
+            // I.e., can't it just dirty the whole component to trigger a reset?
+
+            // Client only dirties during prediction
+            if (_gameTiming.InPrediction)
+                base.DirtyField(uid, comp, fieldName, metadata);
+        }
+
+        public override void DirtyFields<T>(EntityUid uid, T comp, MetaDataComponent? meta, params ReadOnlySpan<string> fields)
+        {
+            // TODO Prediction
+            // does the client actually need to dirty the field?
+            // I.e., can't it just dirty the whole component to trigger a reset?
+
+            // Client only dirties during prediction
+            if (_gameTiming.InPrediction)
+                base.DirtyFields(uid, comp, meta, fields);
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/Containers/SharedContainerSystem.Insert.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.Insert.cs
@@ -197,6 +197,10 @@ public abstract partial class SharedContainerSystem
     {
         if (entity.Comp2 is { } physics)
         {
+            // TODO CONTAINER
+            // Is this actually needed?
+            // I.e., shouldn't this just do a if (_timing.ApplyingState) return
+
             // Here we intentionally don't dirty the physics comp. Client-side state handling will apply these same
             // changes. This also ensures that the server doesn't have to send the physics comp state to every
             // player for any entity inside of a container during init.

--- a/Robust.Shared/GameObjects/EntityManager.ComponentDeltas.cs
+++ b/Robust.Shared/GameObjects/EntityManager.ComponentDeltas.cs
@@ -59,7 +59,6 @@ public abstract partial class EntityManager
         Dirty(uid, comp, metadata);
     }
 
-
     public virtual void DirtyFields<T>(EntityUid uid, T comp, MetaDataComponent? meta, params ReadOnlySpan<string> fields)
         where T : IComponentDelta
     {

--- a/Robust.Shared/GameObjects/EntityManager.ComponentDeltas.cs
+++ b/Robust.Shared/GameObjects/EntityManager.ComponentDeltas.cs
@@ -1,3 +1,4 @@
+using System;
 using Robust.Shared.Timing;
 
 namespace Robust.Shared.GameObjects;
@@ -38,11 +39,14 @@ public abstract partial class EntityManager
         Dirty(uid, comp, metadata);
     }
 
-    public void DirtyField<T>(EntityUid uid, T comp, string fieldName, MetaDataComponent? metadata = null)
+    public virtual void DirtyField<T>(EntityUid uid, T comp, string fieldName, MetaDataComponent? metadata = null)
         where T : IComponentDelta
     {
         var compReg = ComponentFactory.GetRegistration(CompIdx.Index<T>());
 
+        // TODO
+        // consider storing this on MetaDataComponent?
+        // We alsready store other dirtying information there anyways, and avoids having to fetch the registration.
         if (!compReg.NetworkedFieldLookup.TryGetValue(fieldName, out var idx))
         {
             _sawmill.Error($"Tried to dirty delta field {fieldName} on {ToPrettyString(uid)} that isn't implemented.");
@@ -53,6 +57,25 @@ public abstract partial class EntityManager
         comp.LastFieldUpdate = curTick;
         comp.LastModifiedFields[idx] = curTick;
         Dirty(uid, comp, metadata);
+    }
+
+
+    public virtual void DirtyFields<T>(EntityUid uid, T comp, MetaDataComponent? meta, params ReadOnlySpan<string> fields)
+        where T : IComponentDelta
+    {
+        var compReg = ComponentFactory.GetRegistration(CompIdx.Index<T>());
+
+        var curTick = _gameTiming.CurTick;
+        foreach (var field in fields)
+        {
+            if (!compReg.NetworkedFieldLookup.TryGetValue(field, out var idx))
+                _sawmill.Error($"Tried to dirty delta field {field} on {ToPrettyString(uid)} that isn't implemented.");
+            else
+                comp.LastModifiedFields[idx] = curTick;
+        }
+
+        comp.LastFieldUpdate = curTick;
+        Dirty(uid, comp, meta);
     }
 }
 

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -1694,7 +1694,6 @@ namespace Robust.Shared.GameObjects
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [Pure]
         public bool Resolve(EntityUid uid, [NotNullWhen(true)] ref TComp1? component, bool logMissing = true)
         {
             if (component != null)
@@ -1717,7 +1716,7 @@ namespace Robust.Shared.GameObjects
             return false;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining), Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Resolve(ref Entity<TComp1?> entity, bool logMissing = true)
         {
             return Resolve(entity.Owner, ref entity.Comp, logMissing);

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -171,6 +171,13 @@ public partial class EntitySystem
         EntityManager.DirtyField(uid, component, fieldName, meta);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected void DirtyFields<T>(EntityUid uid, T comp, MetaDataComponent? meta, params ReadOnlySpan<string> fields)
+        where T : IComponentDelta
+    {
+        EntityManager.DirtyFields(uid, comp, meta);
+    }
+
     /// <summary>
     ///     Marks a component as dirty. This also implicitly dirties the entity this component belongs to.
     /// </summary>

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
@@ -83,6 +83,13 @@ namespace Robust.Shared.Physics.Systems
 
             _physicsReg = EntityManager.ComponentFactory.GetRegistration(CompIdx.Index<PhysicsComponent>());
 
+            // TODO PHYSICS STATE
+            // Consider condensing the possible fields into just Linear velocity, angular velocity, and "Other"
+            // Or maybe even just "velocity" & "other"
+            // Then get-state doesn't have to iterate over a 10-element array.
+            // And it simplifies the DirtyField calls.
+            // Though I guess combining fixtures & physics will complicate it a bit more again.
+
             // If you update this then update the delta state + GetState + HandleState!
             EntityManager.ComponentFactory.RegisterNetworkedFields(_physicsReg,
                 nameof(PhysicsComponent.CanCollide),


### PR DESCRIPTION
Small collection of miscellaneous physics & delta state changes:
- Makes the client's `DirtyField()` check `IGameTiming.InPrediction`
- Makes various setter methods in PhysicsSystem check the `dirty` bool
  - I'm not sure why, but they were all removed in #5155
  - I'm not even sure if they're required if `InPrediction` gets checked, but might keep using the argument while it exists.
- Adds a new `DirtyFields()` method for simultaneously marking several fields as dirty. 
  - I love `params ReadOnlySpan<>`
- Sets `PhysicsComponent.Force` to zero when changing body type. I think this was just accidentally removed in #5155?

This PR also removes the Pure attribute from the `EntityQuery<T>.Resolve()` methods, making them them consistent with the other Resolves.   