### PR TITLE
Use the color arg when drawing a font character in world space

### DIFF
--- a/Robust.Client/Graphics/Font.cs
+++ b/Robust.Client/Graphics/Font.cs
@@ -133,7 +133,7 @@ namespace Robust.Client.Graphics
 
             baseline += new Vector2(metrics.Value.BearingX, -metrics.Value.BearingY);
             if(handle is DrawingHandleWorld worldhandle)
-                worldhandle.DrawTextureRect(texture,  Box2.FromDimensions(baseline, texture.Size));
+                worldhandle.DrawTextureRect(texture, Box2.FromDimensions(baseline, texture.Size), color);
             else
                 handle.DrawTexture(texture, baseline, color);
             return metrics.Value.Advance;


### PR DESCRIPTION
This was previously ignored and would always draw the character as white.