### PR TITLE
Fix keyboard not focusing on search bar of the tile spawn window on open

### DIFF
--- a/Robust.Client/UserInterface/Controllers/Implementations/TileSpawningUIController.cs
+++ b/Robust.Client/UserInterface/Controllers/Implementations/TileSpawningUIController.cs
@@ -87,7 +87,6 @@ public sealed class TileSpawningUIController : UIController
             return;
         _window = UIManager.CreateWindow<TileSpawnWindow>();
         LayoutContainer.SetAnchorPreset(_window,LayoutContainer.LayoutPreset.CenterLeft);
-        _window.SearchBar.GrabKeyboardFocus();
         _window.ClearButton.OnPressed += OnTileClearPressed;
         _window.SearchBar.OnTextChanged += OnTileSearchChanged;
         _window.TileList.OnItemSelected += OnTileItemSelected;

--- a/Robust.Client/UserInterface/CustomControls/TileSpawnWindow.xaml.cs
+++ b/Robust.Client/UserInterface/CustomControls/TileSpawnWindow.xaml.cs
@@ -10,4 +10,11 @@ public sealed partial class TileSpawnWindow : DefaultWindow
     {
         RobustXamlLoader.Load(this);
     }
+
+    protected override void Opened()
+    {
+        base.Opened();
+        
+        SearchBar.GrabKeyboardFocus();
+    }
 }


### PR DESCRIPTION
Fix keyboard not focusing on search bar when opening the tile spawning window (F6).

Changes to how GrabKeyboardFocus is implemented require it to be called after the LineEdit has entered the tree.