### PR TITLE
Drop debug allocs a lot

### DIFF
--- a/Robust.Server/GameStates/PvsData.cs
+++ b/Robust.Server/GameStates/PvsData.cs
@@ -20,6 +20,10 @@ namespace Robust.Server.GameStates;
 /// </summary>
 internal sealed class PvsSession(ICommonSession session, ResizableMemoryRegion<PvsData> memoryRegion)
 {
+#if DEBUG
+    public HashSet<NetEntity> ToSendSet = new();
+#endif
+
     public readonly ICommonSession Session = session;
 
     public readonly ResizableMemoryRegion<PvsData> DataMemory = memoryRegion;
@@ -197,7 +201,7 @@ internal struct PvsMetadata
     {
         DebugTools.AssertEqual(NetEntity, comp.NetEntity);
         DebugTools.AssertEqual(VisMask, comp.VisibilityMask);
-        DebugTools.AssertEqual(LifeStage, comp.EntityLifeStage);
+        DebugTools.Assert(LifeStage == comp.EntityLifeStage);
         DebugTools.Assert(LastModifiedTick == comp.EntityLastModifiedTick || LastModifiedTick.Value == 0);
     }
 }

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -302,7 +302,9 @@ internal sealed partial class PvsSystem : EntitySystem
         // Process all entities in visible PVS chunks
         AddPvsChunks(session);
 
+#if DEBUG
         VerifySessionData(session);
+#endif
 
         var toSend = session.ToSend!;
         session.ToSend = null;
@@ -332,11 +334,12 @@ internal sealed partial class PvsSystem : EntitySystem
         session.Overflow = oldEntry.Value;
     }
 
-    [Conditional("DEBUG")]
+#if DEBUG
     private void VerifySessionData(PvsSession pvsSession)
     {
-        var toSend = pvsSession.ToSend;
-        var toSendSet = new HashSet<NetEntity>(toSend!.Count);
+        var toSend = pvsSession.ToSend!;
+        var toSendSet = pvsSession.ToSendSet;
+        toSendSet.Clear();
 
         foreach (var intPtr in toSend)
         {
@@ -360,6 +363,7 @@ internal sealed partial class PvsSystem : EntitySystem
                               || data.LastSeen == _gameTiming.CurTick - 1);
         }
     }
+#endif
 
     private (Vector2 worldPos, float range, EntityUid? map) CalcViewBounds(Entity<TransformComponent, EyeComponent?> eye)
     {


### PR DESCRIPTION
IDK why the lifestage one in particular ballooned my dotmemory one up in particular but it did; I would've thought if it's boxing the other ones would've shown up. Doesn't matter for release just QOL to drop allocs by more than half.