### PR TITLE
Reduce lookup allocs significantly

### DIFF
--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using JetBrains.Annotations;
 using Robust.Shared.Collections;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -11,7 +9,6 @@ using Robust.Shared.Physics;
 using Robust.Shared.Physics.Collision;
 using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Physics.Dynamics;
-using Robust.Shared.Physics.Shapes;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Utility;
 
@@ -716,12 +713,12 @@ public sealed partial class EntityLookupSystem
         return entities;
     }
 
-    public void GetEntitiesIntersecting(
+    public void GetEntitiesIntersecting<T>(
         MapId mapId,
-        IPhysShape shape,
+        T shape,
         Transform transform,
         HashSet<EntityUid> entities,
-        LookupFlags flags = LookupFlags.All)
+        LookupFlags flags = LookupFlags.All) where T : IPhysShape
     {
         if (mapId == MapId.Nullspace)
             return;

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -77,14 +77,14 @@ public sealed partial class EntityLookupSystem
     /// <summary>
     /// Wrapper around the per-grid version.
     /// </summary>
-    private void AddEntitiesIntersecting(MapId mapId,
+    private void AddEntitiesIntersecting<T>(MapId mapId,
         HashSet<EntityUid> intersecting,
-        IPhysShape shape,
+        T shape,
         Transform shapeTransform,
-        LookupFlags flags)
+        LookupFlags flags) where T : IPhysShape
     {
         var worldAABB = shape.ComputeAABB(shapeTransform, 0);
-        var state = new EntityQueryState(intersecting,
+        var state = new EntityQueryState<T>(intersecting,
             shape,
             shapeTransform,
             _fixtures,
@@ -96,7 +96,7 @@ public sealed partial class EntityLookupSystem
 
         // Need to include maps
         _mapManager.FindGridsIntersecting(mapId, worldAABB, ref state,
-            static (EntityUid uid, MapGridComponent _, ref EntityQueryState state) =>
+            static (EntityUid uid, MapGridComponent _, ref EntityQueryState<T> state) =>
             {
                 var localTransform = state.Physics.GetRelativePhysicsTransform(state.Transform, uid);
                 var localAabb = state.Shape.ComputeAABB(localTransform, 0);
@@ -112,19 +112,19 @@ public sealed partial class EntityLookupSystem
         AddContained(intersecting, flags);
     }
 
-    private void AddEntitiesIntersecting(
+    private void AddEntitiesIntersecting<T>(
         EntityUid lookupUid,
         HashSet<EntityUid> intersecting,
-        IPhysShape shape,
+        T shape,
         Box2 localAABB,
         Transform localShapeTransform,
         LookupFlags flags,
-        BroadphaseComponent? lookup = null)
+        BroadphaseComponent? lookup = null) where T : IPhysShape
     {
         if (!_broadQuery.Resolve(lookupUid, ref lookup))
             return;
 
-        var state = new EntityQueryState(
+        var state = new EntityQueryState<T>(
             intersecting,
             shape,
             localShapeTransform,
@@ -157,7 +157,7 @@ public sealed partial class EntityLookupSystem
 
         return;
 
-        static bool PhysicsQuery(ref EntityQueryState state, in FixtureProxy value)
+        static bool PhysicsQuery(ref EntityQueryState<T> state, in FixtureProxy value)
         {
             var sensors = (state.Flags & LookupFlags.Sensors) != 0x0;
 
@@ -179,7 +179,7 @@ public sealed partial class EntityLookupSystem
             return true;
         }
 
-        static bool SundriesQuery(ref EntityQueryState state, in EntityUid value)
+        static bool SundriesQuery(ref EntityQueryState<T> state, in EntityUid value)
         {
             var approx = (state.Flags & LookupFlags.Approximate) != 0x0;
 
@@ -227,14 +227,14 @@ public sealed partial class EntityLookupSystem
     /// <summary>
     /// Wrapper around the per-grid version.
     /// </summary>
-    private bool AnyEntitiesIntersecting(MapId mapId,
-        IPhysShape shape,
+    private bool AnyEntitiesIntersecting<T>(MapId mapId,
+        T shape,
         Transform shapeTransform,
         LookupFlags flags,
-        EntityUid? ignored = null)
+        EntityUid? ignored = null) where T : IPhysShape
     {
         var worldAABB = shape.ComputeAABB(shapeTransform, 0);
-        var state = new AnyEntityQueryState(false,
+        var state = new AnyEntityQueryState<T>(false,
             ignored,
             shape,
             shapeTransform,
@@ -247,7 +247,7 @@ public sealed partial class EntityLookupSystem
 
         // Need to include maps
         _mapManager.FindGridsIntersecting(mapId, worldAABB, ref state,
-            static (EntityUid uid, MapGridComponent _, ref AnyEntityQueryState state) =>
+            static (EntityUid uid, MapGridComponent _, ref AnyEntityQueryState<T> state) =>
             {
                 var localTransform = state.Physics.GetRelativePhysicsTransform(state.Transform, uid);
                 var localAabb = state.Shape.ComputeAABB(localTransform, 0);
@@ -272,18 +272,18 @@ public sealed partial class EntityLookupSystem
         return state.Found;
     }
 
-    private bool AnyEntitiesIntersecting(EntityUid lookupUid,
-        IPhysShape shape,
+    private bool AnyEntitiesIntersecting<T>(EntityUid lookupUid,
+        T shape,
         Box2 localAABB,
         Transform shapeTransform,
         LookupFlags flags,
         EntityUid? ignored = null,
-        BroadphaseComponent? lookup = null)
+        BroadphaseComponent? lookup = null) where T : IPhysShape
     {
         if (!_broadQuery.Resolve(lookupUid, ref lookup))
             return false;
 
-        var state = new AnyEntityQueryState(false,
+        var state = new AnyEntityQueryState<T>(false,
             ignored,
             shape,
             shapeTransform,
@@ -325,7 +325,7 @@ public sealed partial class EntityLookupSystem
 
         return state.Found;
 
-        static bool PhysicsQuery(ref AnyEntityQueryState state, in FixtureProxy value)
+        static bool PhysicsQuery(ref AnyEntityQueryState<T> state, in FixtureProxy value)
         {
             if (state.Ignored == value.Entity)
                 return true;
@@ -350,7 +350,7 @@ public sealed partial class EntityLookupSystem
             return false;
         }
 
-        static bool SundriesQuery(ref AnyEntityQueryState state, in EntityUid value)
+        static bool SundriesQuery(ref AnyEntityQueryState<T> state, in EntityUid value)
         {
             if (state.Ignored == value)
                 return true;
@@ -409,9 +409,16 @@ public sealed partial class EntityLookupSystem
         var broadphaseInv = _transform.GetInvWorldMatrix(lookupUid);
 
         var localBounds = broadphaseInv.TransformBounds(worldBounds);
-        var shape = new Polygon(localBounds);
+        var polygon = _physics.GetPooled(localBounds);
+        var result = AnyEntitiesIntersecting(lookupUid,
+            polygon,
+            localBounds.CalcBoundingBox(),
+            Physics.Transform.Empty,
+            flags,
+            ignored);
 
-        return AnyEntitiesIntersecting(lookupUid, shape, localBounds.CalcBoundingBox(), Physics.Transform.Empty, flags, ignored);
+        _physics.ReturnPooled(polygon);
+        return result;
     }
 
     #endregion
@@ -454,8 +461,10 @@ public sealed partial class EntityLookupSystem
     {
         if (mapId == MapId.Nullspace) return false;
 
-        var shape = new Polygon(worldAABB);
-        return AnyEntitiesIntersecting(mapId, shape, Physics.Transform.Empty, flags);
+        var polygon = _physics.GetPooled(worldAABB);
+        var result = AnyEntitiesIntersecting(mapId, polygon, Physics.Transform.Empty, flags);
+        _physics.ReturnPooled(polygon);
+        return result;
     }
 
     public HashSet<EntityUid> GetEntitiesIntersecting(MapId mapId, Box2 worldAABB, LookupFlags flags = DefaultFlags)
@@ -469,8 +478,9 @@ public sealed partial class EntityLookupSystem
     {
         if (mapId == MapId.Nullspace) return;
 
-        var shape = new Polygon(worldAABB);
-        AddEntitiesIntersecting(mapId, intersecting, shape, Physics.Transform.Empty, flags);
+        var polygon = _physics.GetPooled(worldAABB);
+        AddEntitiesIntersecting(mapId, intersecting, polygon, Physics.Transform.Empty, flags);
+        _physics.ReturnPooled(polygon);
     }
 
     #endregion
@@ -480,15 +490,18 @@ public sealed partial class EntityLookupSystem
     public bool AnyEntitiesIntersecting(MapId mapId, Box2Rotated worldBounds, LookupFlags flags = DefaultFlags)
     {
         // Don't need to check contained entities as they have the same bounds as the parent.
-        var shape = new Polygon(worldBounds);
-        return AnyEntitiesIntersecting(mapId, shape, Physics.Transform.Empty, flags);
+        var polygon = _physics.GetPooled(worldBounds);
+        var result = AnyEntitiesIntersecting(mapId, polygon, Physics.Transform.Empty, flags);
+        _physics.ReturnPooled(polygon);
+        return result;
     }
 
     public HashSet<EntityUid> GetEntitiesIntersecting(MapId mapId, Box2Rotated worldBounds, LookupFlags flags = DefaultFlags)
     {
         var intersecting = new HashSet<EntityUid>();
-        var shape = new Polygon(worldBounds);
-        AddEntitiesIntersecting(mapId, intersecting, shape, Physics.Transform.Empty, flags);
+        var polygon = _physics.GetPooled(worldBounds);
+        AddEntitiesIntersecting(mapId, intersecting, polygon, Physics.Transform.Empty, flags);
+        _physics.ReturnPooled(polygon);
         return intersecting;
     }
 
@@ -751,10 +764,11 @@ public sealed partial class EntityLookupSystem
             return;
 
         var localAABB = _transform.GetInvWorldMatrix(gridId).TransformBox(worldAABB);
-        var shape = new Polygon(localAABB);
+        var polygon = _physics.GetPooled(localAABB);
 
-        AddEntitiesIntersecting(gridId, intersecting, shape, localAABB, Physics.Transform.Empty, flags, lookup);
+        AddEntitiesIntersecting(gridId, intersecting, polygon, localAABB, Physics.Transform.Empty, flags, lookup);
         AddContained(intersecting, flags);
+        _physics.ReturnPooled(polygon);
     }
 
     public void GetEntitiesIntersecting(EntityUid gridId, Box2Rotated worldBounds, HashSet<EntityUid> intersecting, LookupFlags flags = DefaultFlags)
@@ -763,10 +777,11 @@ public sealed partial class EntityLookupSystem
             return;
 
         var localBounds = _transform.GetInvWorldMatrix(gridId).TransformBounds(worldBounds);
-        var shape = new Polygon(localBounds);
+        var polygon = _physics.GetPooled(localBounds);
 
-        AddEntitiesIntersecting(gridId, intersecting, shape, localBounds.CalcBoundingBox(), Physics.Transform.Empty, flags, lookup);
+        AddEntitiesIntersecting(gridId, intersecting, polygon, localBounds.CalcBoundingBox(), Physics.Transform.Empty, flags, lookup);
         AddContained(intersecting, flags);
+        _physics.ReturnPooled(polygon);
     }
 
     #endregion
@@ -832,10 +847,10 @@ public sealed partial class EntityLookupSystem
 
     #endregion
 
-    private record struct AnyEntityQueryState(
+    private record struct AnyEntityQueryState<T>(
         bool Found,
         EntityUid? Ignored,
-        IPhysShape Shape,
+        T Shape,
         Transform Transform,
         FixtureSystem Fixtures,
         EntityLookupSystem Lookup,
@@ -843,11 +858,11 @@ public sealed partial class EntityLookupSystem
         IManifoldManager Manifolds,
         EntityQuery<FixturesComponent> FixturesQuery,
         LookupFlags Flags
-    );
+    ) where T : IPhysShape;
 
-    private readonly record struct EntityQueryState(
+    private readonly record struct EntityQueryState<T>(
         HashSet<EntityUid> Intersecting,
-        IPhysShape Shape,
+        T Shape,
         Transform Transform,
         FixtureSystem Fixtures,
         EntityLookupSystem Lookup,
@@ -855,5 +870,5 @@ public sealed partial class EntityLookupSystem
         IManifoldManager Manifolds,
         EntityQuery<FixturesComponent> FixturesQuery,
         LookupFlags Flags
-    );
+    ) where T : IPhysShape;
 }

--- a/Robust.Shared/Map/IMapManager.cs
+++ b/Robust.Shared/Map/IMapManager.cs
@@ -77,11 +77,11 @@ namespace Robust.Shared.Map
 
         #region MapId
 
-        public void FindGridsIntersecting(MapId mapId, IPhysShape shape, Transform transform,
-            ref List<Entity<MapGridComponent>> grids, bool approx = Approximate, bool includeMap = IncludeMap);
+        public void FindGridsIntersecting<T>(MapId mapId, T shape, Transform transform,
+            ref List<Entity<MapGridComponent>> grids, bool approx = Approximate, bool includeMap = IncludeMap) where T : IPhysShape;
 
-        public void FindGridsIntersecting(MapId mapId, IPhysShape shape, Transform transform, GridCallback callback,
-            bool approx = Approximate, bool includeMap = IncludeMap);
+        public void FindGridsIntersecting<T>(MapId mapId, T shape, Transform transform, GridCallback callback,
+            bool approx = Approximate, bool includeMap = IncludeMap) where T : IPhysShape;
 
         public void FindGridsIntersecting(MapId mapId, Box2 worldAABB, GridCallback callback, bool approx = Approximate,
             bool includeMap = IncludeMap);
@@ -107,11 +107,11 @@ namespace Robust.Shared.Map
 
         #region MapEnt
 
-        public void FindGridsIntersecting(EntityUid mapEnt, IPhysShape shape, Transform transform, GridCallback callback,
-            bool approx = Approximate, bool includeMap = IncludeMap);
+        public void FindGridsIntersecting<T>(EntityUid mapEnt, T shape, Transform transform, GridCallback callback,
+            bool approx = Approximate, bool includeMap = IncludeMap) where T : IPhysShape;
 
-        public void FindGridsIntersecting<TState>(EntityUid mapEnt, IPhysShape shape, Transform transform,
-            ref TState state, GridCallback<TState> callback, bool approx = Approximate, bool includeMap = IncludeMap);
+        public void FindGridsIntersecting<T, TState>(EntityUid mapEnt, T shape, Transform transform,
+            ref TState state, GridCallback<TState> callback, bool approx = Approximate, bool includeMap = IncludeMap) where T : IPhysShape;
 
         /// <summary>
         /// Returns true if any grids overlap the specified shapes.
@@ -119,8 +119,8 @@ namespace Robust.Shared.Map
         public void FindGridsIntersecting(EntityUid mapEnt, List<IPhysShape> shapes, Transform transform,
             ref List<Entity<MapGridComponent>> entities, bool approx = Approximate, bool includeMap = IncludeMap);
 
-        public void FindGridsIntersecting(EntityUid mapEnt, IPhysShape shape, Transform transform,
-            ref List<Entity<MapGridComponent>> grids, bool approx = Approximate, bool includeMap = IncludeMap);
+        public void FindGridsIntersecting<T>(EntityUid mapEnt, T shape, Transform transform,
+            ref List<Entity<MapGridComponent>> grids, bool approx = Approximate, bool includeMap = IncludeMap) where T : IPhysShape;
 
         public void FindGridsIntersecting(EntityUid mapEnt, Box2 worldAABB, GridCallback callback,
             bool approx = Approximate, bool includeMap = IncludeMap);

--- a/Robust.Shared/Map/MapManager.Queries.cs
+++ b/Robust.Shared/Map/MapManager.Queries.cs
@@ -356,29 +356,6 @@ internal partial class MapManager
 
     #endregion
 
-    private readonly record struct GridQueryState(
-        GridCallback Callback,
-        Box2 WorldAABB,
-        IPhysShape Shape,
-        Transform Transform,
-        B2DynamicTree<(EntityUid Uid, FixturesComponent Fixtures, MapGridComponent Grid)> Tree,
-        SharedMapSystem MapSystem,
-        MapManager MapManager,
-        SharedTransformSystem TransformSystem,
-        bool Approximate);
-
-    private record struct GridQueryState<TState>(
-        GridCallback<TState> Callback,
-        TState State,
-        Box2 WorldAABB,
-        IPhysShape Shape,
-        Transform Transform,
-        B2DynamicTree<(EntityUid Uid, FixturesComponent Fixtures, MapGridComponent Grid)> Tree,
-        SharedMapSystem MapSystem,
-        MapManager MapManager,
-        SharedTransformSystem TransformSystem,
-        bool Approximate);
-
     private record struct GridQueryState<T, TState>(
         GridCallback<TState> Callback,
         TState State,

--- a/Robust.Shared/Map/MapManager.Queries.cs
+++ b/Robust.Shared/Map/MapManager.Queries.cs
@@ -42,14 +42,14 @@ internal partial class MapManager
 
     #region MapId
 
-    public void FindGridsIntersecting(MapId mapId, IPhysShape shape, Transform transform,
-        ref List<Entity<MapGridComponent>> grids, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    public void FindGridsIntersecting<T>(MapId mapId, T shape, Transform transform,
+        ref List<Entity<MapGridComponent>> grids, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap) where T : IPhysShape
     {
         if (_mapEntities.TryGetValue(mapId, out var mapEnt))
             FindGridsIntersecting(mapEnt, shape, transform, ref grids, approx, includeMap);
     }
 
-    public void FindGridsIntersecting(MapId mapId, IPhysShape shape, Transform transform, GridCallback callback, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    public void FindGridsIntersecting<T>(MapId mapId, T shape, Transform transform, GridCallback callback, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap) where T : IPhysShape
     {
         if (_mapEntities.TryGetValue(mapId, out var mapEnt))
             FindGridsIntersecting(mapEnt, shape, transform, callback, includeMap, approx);
@@ -99,18 +99,18 @@ internal partial class MapManager
 
     #region MapEnt
 
-    public void FindGridsIntersecting(
+    public void FindGridsIntersecting<T>(
         EntityUid mapEnt,
-        IPhysShape shape,
+        T shape,
         Transform transform,
         GridCallback callback,
         bool approx = IMapManager.Approximate,
-        bool includeMap = IMapManager.IncludeMap)
+        bool includeMap = IMapManager.IncludeMap) where T : IPhysShape
     {
         FindGridsIntersecting(mapEnt, shape, shape.ComputeAABB(transform, 0), transform, callback, approx, includeMap);
     }
 
-    private void FindGridsIntersecting(EntityUid mapEnt, IPhysShape shape, Box2 worldAABB, Transform transform, GridCallback callback, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    private void FindGridsIntersecting<T>(EntityUid mapEnt, T shape, Box2 worldAABB, Transform transform, GridCallback callback, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap) where T : IPhysShape
     {
         // This is here so we don't double up on code.
         var state = callback;
@@ -120,14 +120,14 @@ internal partial class MapManager
             approx: approx, includeMap: includeMap);
     }
 
-    public void FindGridsIntersecting<TState>(
+    public void FindGridsIntersecting<T, TState>(
         EntityUid mapEnt,
-        IPhysShape shape,
+        T shape,
         Transform transform,
         ref TState state,
         GridCallback<TState> callback,
         bool approx = IMapManager.Approximate,
-        bool includeMap = IMapManager.IncludeMap)
+        bool includeMap = IMapManager.IncludeMap) where T : IPhysShape
     {
         FindGridsIntersecting(mapEnt, shape, shape.ComputeAABB(transform, 0), transform, ref state, callback, approx, includeMap);
     }
@@ -203,14 +203,14 @@ internal partial class MapManager
         }
     }
 
-    public void FindGridsIntersecting(EntityUid mapEnt, IPhysShape shape, Transform transform,
-        ref List<Entity<MapGridComponent>> grids, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    public void FindGridsIntersecting<T>(EntityUid mapEnt, T shape, Transform transform,
+        ref List<Entity<MapGridComponent>> grids, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap) where T : IPhysShape
     {
         FindGridsIntersecting(mapEnt, shape, shape.ComputeAABB(transform, 0), transform, ref grids, approx, includeMap);
     }
 
-    public void FindGridsIntersecting(EntityUid mapEnt, IPhysShape shape, Box2 worldAABB, Transform transform,
-        ref List<Entity<MapGridComponent>> grids, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap)
+    public void FindGridsIntersecting<T>(EntityUid mapEnt, T shape, Box2 worldAABB, Transform transform,
+        ref List<Entity<MapGridComponent>> grids, bool approx = IMapManager.Approximate, bool includeMap = IMapManager.IncludeMap) where T : IPhysShape
     {
         var state = grids;
 

--- a/Robust.Shared/Physics/Collision/CollisionManager.Overlap.cs
+++ b/Robust.Shared/Physics/Collision/CollisionManager.Overlap.cs
@@ -12,12 +12,12 @@ internal sealed partial class CollisionManager
     /// <param name="xfA">The transform for the first shape.</param>
     /// <param name="xfB">The transform for the seconds shape.</param>
     /// <returns></returns>
-    public bool TestOverlap(IPhysShape shapeA, int childIndexA, IPhysShape shapeB, int childIndexB, in Transform xfA, in Transform xfB)
+    public bool TestOverlap<T, U>(T shapeA, int indexA, U shapeB, int indexB, in Transform xfA, in Transform xfB) where T : IPhysShape where U : IPhysShape
     {
         var input = new DistanceInput();
 
-        input.ProxyA.Set(shapeA, childIndexA);
-        input.ProxyB.Set(shapeB, childIndexB);
+        input.ProxyA.Set(shapeA, indexA);
+        input.ProxyB.Set(shapeB, indexB);
         input.TransformA = xfA;
         input.TransformB = xfB;
         input.UseRadii = true;

--- a/Robust.Shared/Physics/Collision/DistanceProxy.cs
+++ b/Robust.Shared/Physics/Collision/DistanceProxy.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
@@ -56,12 +57,12 @@ internal ref struct DistanceProxy
     /// must remain in scope while the proxy is in use.
     /// </summary>
     /// <param name="shape">The shape.</param>
-    public void Set(IPhysShape shape, int index)
+    internal void Set<T>(T shape, int index) where T : IPhysShape
     {
         switch (shape.ShapeType)
         {
             case ShapeType.Circle:
-                PhysShapeCircle circle = (PhysShapeCircle) shape;
+                var circle = Unsafe.As<PhysShapeCircle>(shape);
                 Buffer._00 = circle.Position;
                 Vertices = Buffer.AsSpan[..1];
                 Radius = circle.Radius;
@@ -75,7 +76,7 @@ internal ref struct DistanceProxy
                 }
                 else
                 {
-                    var polyShape = (PolygonShape) shape;
+                    var polyShape = Unsafe.As<PolygonShape>(shape);
                     Vertices = polyShape.Vertices;
                     Radius = polyShape.Radius;
                 }
@@ -83,7 +84,7 @@ internal ref struct DistanceProxy
                 break;
 
             case ShapeType.Chain:
-                ChainShape chain = (ChainShape) shape;
+                var chain = Unsafe.As<ChainShape>(shape);
                 Debug.Assert(0 <= index && index < chain.Vertices.Length);
 
                 Buffer._00 = chain.Vertices[index];
@@ -93,7 +94,7 @@ internal ref struct DistanceProxy
                 Radius = chain.Radius;
                 break;
             case ShapeType.Edge:
-                EdgeShape edge = (EdgeShape) shape;
+                var edge = Unsafe.As<EdgeShape>(shape);
 
                 Buffer._00 = edge.Vertex1;
                 Buffer._01 = edge.Vertex2;

--- a/Robust.Shared/Physics/Collision/IManifoldManager.cs
+++ b/Robust.Shared/Physics/Collision/IManifoldManager.cs
@@ -12,7 +12,9 @@ internal interface IManifoldManager
 
     void ReturnEdge(EdgeShape edge);
 
-    bool TestOverlap(IPhysShape shapeA, int indexA, IPhysShape shapeB, int indexB, in Transform xfA, in Transform xfB);
+    bool TestOverlap<T, U>(T shapeA, int indexA, U shapeB, int indexB, in Transform xfA, in Transform xfB)
+        where T : IPhysShape
+        where U : IPhysShape;
 
     void CollideCircles(ref Manifold manifold, PhysShapeCircle circleA, in Transform xfA,
         PhysShapeCircle circleB, in Transform xfB);

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Pool.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Pool.cs
@@ -1,0 +1,56 @@
+using System.Buffers;
+using System.Numerics;
+using Robust.Shared.Maths;
+using Robust.Shared.Physics.Shapes;
+
+namespace Robust.Shared.Physics.Systems;
+
+public abstract partial class SharedPhysicsSystem
+{
+    private ArrayPool<Vector2> _vectorPool = ArrayPool<Vector2>.Create(4, 128);
+
+    /// <summary>
+    /// Gets a polygon with pooled arrays backing it.
+    /// </summary>
+    internal Polygon GetPooled(Box2 box)
+    {
+        var vertices = _vectorPool.Rent(4);
+        var normals = _vectorPool.Rent(4);
+        var centroid = box.Center;
+
+        vertices[0] = box.BottomLeft;
+        vertices[1] = box.BottomRight;
+        vertices[2] = box.TopRight;
+        vertices[3] = box.TopLeft;
+
+        normals[0] = new Vector2(0.0f, -1.0f);
+        normals[1] = new Vector2(1.0f, 0.0f);
+        normals[2] = new Vector2(0.0f, 1.0f);
+        normals[3] = new Vector2(-1.0f, 0.0f);
+
+        return new Polygon(vertices, normals, centroid);
+    }
+
+    internal Polygon GetPooled(Box2Rotated box)
+    {
+        var vertices = _vectorPool.Rent(4);
+        var normals = _vectorPool.Rent(4);
+        var centroid = box.Center;
+
+        vertices[0] = box.BottomLeft;
+        vertices[1] = box.BottomRight;
+        vertices[2] = box.TopRight;
+        vertices[3] = box.TopLeft;
+
+        var polygon = new Polygon(vertices, normals, centroid);
+        polygon.CalculateNormals(normals, 4);
+
+        return polygon;
+    }
+
+    internal void ReturnPooled(Polygon polygon)
+    {
+        _vectorPool.Return(polygon.Vertices);
+        _vectorPool.Return(polygon.Normals);
+    }
+}

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
@@ -24,7 +24,6 @@ namespace Robust.Shared.Physics.Systems
         /*
          * TODO:
 
-         * Raycasts for non-box shapes.
          * TOI Solver (continuous collision detection)
          * Poly cutting
          */


### PR DESCRIPTION
- Use generics over interfaces for internal methods (no breaking and can do public later)
- Pool the polygon arrays in-engine as generics only gets us like 10% of the way there.

Pretty significant difference.

![image](https://github.com/user-attachments/assets/d97fd824-d62e-4e86-9407-1e8be78fbeb9)
