### PR TITLE
don't normalize direction vector when calling atan2

### DIFF
--- a/Robust.Shared.Maths/Angle.cs
+++ b/Robust.Shared.Maths/Angle.cs
@@ -39,7 +39,6 @@ namespace Robust.Shared.Maths
         /// <param name="dir"></param>
         public Angle(Vector2 dir)
         {
-            dir = dir.Normalized();
             Theta = Math.Atan2(dir.Y, dir.X);
         }
 


### PR DESCRIPTION
Very minor optimization, but it annoyed me enough to make a PR.
The atan 2 function does not need the vector to be normalized, so we can skip that.
https://en.wikipedia.org/wiki/Atan2