### PR TITLE
Fix poly pooling

### DIFF
--- a/Robust.Shared/Physics/Collision/DistanceProxy.cs
+++ b/Robust.Shared/Physics/Collision/DistanceProxy.cs
@@ -71,13 +71,13 @@ internal ref struct DistanceProxy
             case ShapeType.Polygon:
                 if (shape is Polygon poly)
                 {
-                    Vertices = poly.Vertices;
+                    Vertices = poly.Vertices.AsSpan()[..poly.VertexCount];
                     Radius = poly.Radius;
                 }
                 else
                 {
                     var polyShape = Unsafe.As<PolygonShape>(shape);
-                    Vertices = polyShape.Vertices;
+                    Vertices = polyShape.Vertices.AsSpan()[..polyShape.VertexCount];
                     Radius = polyShape.Radius;
                 }
 

--- a/Robust.Shared/Physics/Shapes/Polygon.cs
+++ b/Robust.Shared/Physics/Shapes/Polygon.cs
@@ -16,7 +16,7 @@ internal record struct Polygon : IPhysShape
     [DataField]
     public Vector2[] Vertices;
 
-    public int VertexCount;
+    public byte VertexCount;
 
     public Vector2[] Normals;
 
@@ -42,13 +42,13 @@ internal record struct Polygon : IPhysShape
 
         Array.Copy(polyShape.Vertices, Vertices, Vertices.Length);
         Array.Copy(polyShape.Normals, Normals, Vertices.Length);
-        VertexCount = Vertices.Length;
+        VertexCount = (byte) Vertices.Length;
     }
 
     /// <summary>
     /// Manually constructed polygon for internal use to take advantage of pooling.
     /// </summary>
-    internal Polygon(Vector2[] vertices, Vector2[] normals, Vector2 centroid, int count)
+    internal Polygon(Vector2[] vertices, Vector2[] normals, Vector2 centroid, byte count)
     {
         Unsafe.SkipInit(out this);
         Vertices = vertices;
@@ -109,7 +109,7 @@ internal record struct Polygon : IPhysShape
             return;
         }
 
-        VertexCount = vertices.Length;
+        VertexCount = (byte) vertices.Length;
         Vertices = vertices;
         Normals = new Vector2[vertices.Length];
         Set(hull);

--- a/Robust.Shared/Physics/Shapes/Polygon.cs
+++ b/Robust.Shared/Physics/Shapes/Polygon.cs
@@ -16,7 +16,7 @@ internal record struct Polygon : IPhysShape
     [DataField]
     public Vector2[] Vertices;
 
-    public int VertexCount => Vertices.Length;
+    public int VertexCount;
 
     public Vector2[] Normals;
 
@@ -42,17 +42,19 @@ internal record struct Polygon : IPhysShape
 
         Array.Copy(polyShape.Vertices, Vertices, Vertices.Length);
         Array.Copy(polyShape.Normals, Normals, Vertices.Length);
+        VertexCount = Vertices.Length;
     }
 
     /// <summary>
     /// Manually constructed polygon for internal use to take advantage of pooling.
     /// </summary>
-    internal Polygon(Vector2[] vertices, Vector2[] normals, Vector2 centroid)
+    internal Polygon(Vector2[] vertices, Vector2[] normals, Vector2 centroid, int count)
     {
         Unsafe.SkipInit(out this);
         Vertices = vertices;
         Normals = normals;
         Centroid = centroid;
+        VertexCount = count;
     }
 
     public Polygon(Box2 aabb)
@@ -72,6 +74,7 @@ internal record struct Polygon : IPhysShape
         Normals[2] = new Vector2(0.0f, 1.0f);
         Normals[3] = new Vector2(-1.0f, 0.0f);
 
+        VertexCount = 4;
         Centroid = aabb.Center;
     }
 
@@ -89,6 +92,7 @@ internal record struct Polygon : IPhysShape
 
         CalculateNormals(Normals, 4);
 
+        VertexCount = 4;
         Centroid = bounds.Center;
     }
 
@@ -99,11 +103,13 @@ internal record struct Polygon : IPhysShape
 
         if (hull.Count < 3)
         {
+            VertexCount = 0;
             Vertices = [];
             Normals = [];
             return;
         }
 
+        VertexCount = vertices.Length;
         Vertices = vertices;
         Normals = new Vector2[vertices.Length];
         Set(hull);

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Pool.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Pool.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Numerics;
+using Microsoft.Extensions.ObjectPool;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics.Shapes;
 
@@ -7,15 +8,13 @@ namespace Robust.Shared.Physics.Systems;
 
 public abstract partial class SharedPhysicsSystem
 {
-    private ArrayPool<Vector2> _vectorPool = ArrayPool<Vector2>.Create(4, 128);
-
     /// <summary>
     /// Gets a polygon with pooled arrays backing it.
     /// </summary>
     internal Polygon GetPooled(Box2 box)
     {
-        var vertices = _vectorPool.Rent(4);
-        var normals = _vectorPool.Rent(4);
+        var vertices = ArrayPool<Vector2>.Shared.Rent(4);
+        var normals = ArrayPool<Vector2>.Shared.Rent(4);
         var centroid = box.Center;
 
         vertices[0] = box.BottomLeft;
@@ -28,13 +27,13 @@ public abstract partial class SharedPhysicsSystem
         normals[2] = new Vector2(0.0f, 1.0f);
         normals[3] = new Vector2(-1.0f, 0.0f);
 
-        return new Polygon(vertices, normals, centroid);
+        return new Polygon(vertices, normals, centroid, 4);
     }
 
     internal Polygon GetPooled(Box2Rotated box)
     {
-        var vertices = _vectorPool.Rent(4);
-        var normals = _vectorPool.Rent(4);
+        var vertices = ArrayPool<Vector2>.Shared.Rent(4);
+        var normals = ArrayPool<Vector2>.Shared.Rent(4);
         var centroid = box.Center;
 
         vertices[0] = box.BottomLeft;
@@ -42,7 +41,7 @@ public abstract partial class SharedPhysicsSystem
         vertices[2] = box.TopRight;
         vertices[3] = box.TopLeft;
 
-        var polygon = new Polygon(vertices, normals, centroid);
+        var polygon = new Polygon(vertices, normals, centroid, 4);
         polygon.CalculateNormals(normals, 4);
 
         return polygon;
@@ -50,7 +49,7 @@ public abstract partial class SharedPhysicsSystem
 
     internal void ReturnPooled(Polygon polygon)
     {
-        _vectorPool.Return(polygon.Vertices);
-        _vectorPool.Return(polygon.Normals);
+        ArrayPool<Vector2>.Shared.Return(polygon.Vertices);
+        ArrayPool<Vector2>.Shared.Return(polygon.Normals);
     }
 }


### PR DESCRIPTION
Need a better accessor to prevent vertices.length usage but it'll be fine for now. Would prefer to keep the pooling due to how much lookup is called.