### PR TITLE
fix: fixed EntityPrototypeView not reacting on SetPrototype when EnteredTree already was called with _currentPrototype empty

### DIFF
--- a/Robust.Client/UserInterface/Controls/EntityPrototypeView.cs
+++ b/Robust.Client/UserInterface/Controls/EntityPrototypeView.cs
@@ -9,6 +9,7 @@ public class EntityPrototypeView : SpriteView
 {
     private string? _currentPrototype;
     private EntityUid? _ourEntity;
+    private bool _isShowing;
 
     public EntityPrototypeView()
     {
@@ -31,7 +32,7 @@ public class EntityPrototypeView : SpriteView
 
         _currentPrototype = entProto;
 
-        if (_ourEntity != null)
+        if (_ourEntity != null || _isShowing)
         {
             UpdateEntity();
         }
@@ -45,6 +46,8 @@ public class EntityPrototypeView : SpriteView
         {
             UpdateEntity();
         }
+
+        _isShowing = true;
     }
 
     protected override void ExitedTree()
@@ -52,6 +55,8 @@ public class EntityPrototypeView : SpriteView
         base.ExitedTree();
         EntMan.TryQueueDeleteEntity(_ourEntity);
         _ourEntity = null;
+
+        _isShowing = false;
     }
 
     private void UpdateEntity()


### PR DESCRIPTION
If EntityPrototypeView got rendered (EnteredTree) before any prototype was assigned (SetPrototype call) then any further calls to SetPrototype won't lead to entity spawn and display updates. Added flag '_isShowing' to track if EnteredTree was called and ExitedTree was not yet called.