### PR TITLE
Add saved BUI positions

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,11 +35,11 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* RemoveChild is called after OnClose for BaseWindow.
 
 ### New features
 
-*None yet*
+* BUIs now have their positions saved when closed and re-used when opened when using the `CreateWindow<T>` helper or via manually registering it via RegisterControl.
 
 ### Bugfixes
 

--- a/Robust.Client/GameObjects/EntitySystems/UserInterfaceSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/UserInterfaceSystem.cs
@@ -1,10 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Robust.Client.UserInterface;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Robust.Client.GameObjects;
 
 public sealed class UserInterfaceSystem : SharedUserInterfaceSystem
 {
+    private Dictionary<EntityUid, Dictionary<Enum, Vector2>> _savedPositions = new();
+    private Dictionary<BoundUserInterface, Control> _registeredControls = new();
+
     public override void Initialize()
     {
         base.Initialize();
@@ -15,6 +23,59 @@ public sealed class UserInterfaceSystem : SharedUserInterfaceSystem
     {
         base.Shutdown();
         ProtoManager.PrototypesReloaded -= OnProtoReload;
+    }
+
+    protected override void OnUserInterfaceShutdown(Entity<UserInterfaceComponent> ent, ref ComponentShutdown args)
+    {
+        base.OnUserInterfaceShutdown(ent, ref args);
+        _savedPositions.Remove(ent.Owner);
+    }
+
+    /// <inheritdoc />
+    public override void OpenUi(Entity<UserInterfaceComponent?> entity, Enum key, bool predicted = false)
+    {
+        var player = Player.LocalEntity;
+
+        if (player == null)
+            return;
+
+        OpenUi(entity, key, player.Value, predicted);
+    }
+
+    protected override void SavePosition(BoundUserInterface bui)
+    {
+        if (!_registeredControls.Remove(bui, out var control))
+            return;
+
+        var keyed = _savedPositions[bui.Owner];
+        keyed[bui.UiKey] = control.Position;
+    }
+
+    /// <summary>
+    /// Registers a control so it will later have its position stored by <see cref="SavePosition"/> when the BUI is closed.
+    /// </summary>
+    public void RegisterControl(BoundUserInterface bui, Control control)
+    {
+        DebugTools.Assert(!_registeredControls.ContainsKey(bui));
+        _registeredControls[bui] = control;
+        _savedPositions.GetOrNew(bui.Owner);
+    }
+
+    public override bool TryGetPosition(Entity<UserInterfaceComponent?> entity, Enum key, out Vector2 position)
+    {
+        position = default;
+
+        if (!_savedPositions.TryGetValue(entity.Owner, out var keyed))
+        {
+            return false;
+        }
+
+        if (!keyed.TryGetValue(key, out position))
+        {
+            return false;
+        }
+
+        return true;
     }
 
     private void OnProtoReload(PrototypesReloadedEventArgs obj)

--- a/Robust.Client/UserInterface/BoundUserInterfaceExt.cs
+++ b/Robust.Client/UserInterface/BoundUserInterfaceExt.cs
@@ -1,4 +1,5 @@
 using System;
+using Robust.Client.GameObjects;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.GameObjects;
 
@@ -6,14 +7,47 @@ namespace Robust.Client.UserInterface;
 
 public static class BoundUserInterfaceExt
 {
+    private static T GetWindow<T>(BoundUserInterface bui) where T : BaseWindow, new()
+    {
+        var window = bui.CreateDisposableControl<T>();
+        window.OnClose += bui.Close;
+        var system = bui.EntMan.System<UserInterfaceSystem>();
+        system.RegisterControl(bui, window);
+        return window;
+    }
+
     /// <summary>
     /// Helper method to create a window and also handle closing the BUI when it's closed.
     /// </summary>
     public static T CreateWindow<T>(this BoundUserInterface bui) where T : BaseWindow, new()
     {
-        var window = bui.CreateDisposableControl<T>();
-        window.OpenCentered();
-        window.OnClose += bui.Close;
+        var window = GetWindow<T>(bui);
+
+        if (bui.EntMan.System<UserInterfaceSystem>().TryGetPosition(bui.Owner, bui.UiKey, out var position))
+        {
+            window.Open(position);
+        }
+        else
+        {
+            window.OpenCentered();
+        }
+
+        return window;
+    }
+
+    public static T CreateWindowCenteredLeft<T>(this BoundUserInterface bui) where T : BaseWindow, new()
+    {
+        var window = GetWindow<T>(bui);
+
+        if (bui.EntMan.System<UserInterfaceSystem>().TryGetPosition(bui.Owner, bui.UiKey, out var position))
+        {
+            window.Open(position);
+        }
+        else
+        {
+            window.OpenCenteredLeft();
+        }
+
         return window;
     }
 

--- a/Robust.Client/UserInterface/CustomControls/BaseWindow.cs
+++ b/Robust.Client/UserInterface/CustomControls/BaseWindow.cs
@@ -5,6 +5,7 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Input;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
+using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Timing;
 
@@ -36,8 +37,8 @@ namespace Robust.Client.UserInterface.CustomControls
                 return;
             }
 
-            Parent.RemoveChild(this);
             OnClose?.Invoke();
+            Parent.RemoveChild(this);
         }
 
         protected internal override void KeyBindDown(GUIBoundKeyEventArgs args)
@@ -227,6 +228,16 @@ namespace Robust.Client.UserInterface.CustomControls
 
             Opened();
             OnOpen?.Invoke();
+        }
+
+        /// <summary>
+        /// Opens the window and places it at the specified position.
+        /// </summary>
+        public void Open(Vector2 position)
+        {
+            Measure(Vector2Helpers.Infinity);
+            Open();
+            LayoutContainer.SetPosition(this, position);
         }
 
         public void OpenCentered() => OpenCenteredAt(new Vector2(0.5f, 0.5f));

--- a/Robust.Shared/GameObjects/Components/UserInterface/BoundUserInterface.cs
+++ b/Robust.Shared/GameObjects/Components/UserInterface/BoundUserInterface.cs
@@ -11,7 +11,7 @@ namespace Robust.Shared.GameObjects
     /// </summary>
     public abstract class BoundUserInterface : IDisposable
     {
-        [Dependency] protected readonly IEntityManager EntMan = default!;
+        [Dependency] protected internal readonly IEntityManager EntMan = default!;
         [Dependency] protected readonly ISharedPlayerManager PlayerManager = default!;
         protected readonly SharedUserInterfaceSystem UiSystem;
 

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -46,6 +46,8 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
     /// </summary>
     private ValueList<Enum> _keys = new();
 
+    private ValueList<EntityUid> _entList = new();
+
     public override void Initialize()
     {
         base.Initialize();
@@ -283,8 +285,6 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
             AddQueued(bui, true);
         }
     }
-
-    private List<EntityUid> _entList = new();
 
     protected virtual void OnUserInterfaceShutdown(Entity<UserInterfaceComponent> ent, ref ComponentShutdown args)
     {


### PR DESCRIPTION
BUIs get removed entirely so need to store these somewhere. This does it universally via the CreateWindow helper method so BUIs don't need to manually re-implement this.