### PR TITLE
Add ICloneable support to ComponentNetworkGenerator

### DIFF
--- a/Robust.Shared.CompNetworkGenerator/ComponentNetworkGenerator.cs
+++ b/Robust.Shared.CompNetworkGenerator/ComponentNetworkGenerator.cs
@@ -723,7 +723,17 @@ public partial class {componentName}{deltaInterface}
 
         private static bool IsCloneType(ITypeSymbol type)
         {
-            if (type is not INamedTypeSymbol named || !named.IsGenericType)
+            if (type is not INamedTypeSymbol named)
+            {
+                return false;
+            }
+
+            if (ImplementsInterface(named, nameof(ICloneable)))
+            {
+                return true;
+            }
+
+            if (!named.IsGenericType)
             {
                 return false;
             }
@@ -734,6 +744,19 @@ public partial class {componentName}{deltaInterface}
                 GlobalDictionaryName or GlobalHashSetName or GlobalListName => true,
                 _ => false
             };
+        }
+
+        private static bool ImplementsInterface(ITypeSymbol type, string interfaceName)
+        {
+            foreach (var interfaceType in type.AllInterfaces)
+            {
+                if (interfaceType.ToDisplayString().Contains(interfaceName))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
ComponentNetworkGenerator now clones component fields that implement ICloneable.

As suggested here: https://github.com/space-wizards/space-station-14/pull/34838#discussion_r1938672739