### PR TITLE
Allow ref structs in most events

### DIFF
--- a/Robust.Client/UserInterface/Controllers/UiController.Subscriptions.cs
+++ b/Robust.Client/UserInterface/Controllers/UiController.Subscriptions.cs
@@ -9,7 +9,7 @@ public abstract partial class UIController : IEntityEventSubscriber
     protected void SubscribeLocalEvent<T>(
         EntityEventHandler<T> handler,
         Type[]? before = null, Type[]? after = null)
-        where T : notnull
+        where T : notnull, allows ref struct
     {
         EntityManager.EventBus.SubscribeEvent(EventSource.Local, this, handler, GetType(), before, after);
     }
@@ -17,13 +17,13 @@ public abstract partial class UIController : IEntityEventSubscriber
     protected void SubscribeLocalEvent<T>(
         EntityEventRefHandler<T> handler,
         Type[]? before = null, Type[]? after = null)
-        where T : notnull
+        where T : notnull, allows ref struct
     {
         EntityManager.EventBus.SubscribeEvent(EventSource.Local, this, handler, GetType(), before, after);
     }
 
     protected void UnSubscribeLocalEvent<T>()
-        where T : notnull
+        where T : notnull, allows ref struct
     {
         EntityManager.EventBus.UnsubscribeEvent<T>(EventSource.Local, this);
     }
@@ -37,7 +37,7 @@ public abstract partial class UIController : IEntityEventSubscriber
     }
 
     protected void UnSubscribeNetworkEvent<T>()
-        where T : notnull
+        where T : notnull, allows ref struct
     {
         EntityManager.EventBus.UnsubscribeEvent<T>(EventSource.Network, this);
     }
@@ -51,7 +51,7 @@ public abstract partial class UIController : IEntityEventSubscriber
     }
 
     protected void UnSubscribeAllEvent<T>()
-        where T : notnull
+        where T : notnull, allows ref struct
     {
         EntityManager.EventBus.UnsubscribeEvent<T>(EventSource.All, this);
     }

--- a/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs
@@ -23,7 +23,7 @@ namespace Robust.Shared.GameObjects
         /// <seealso cref="SubscribeEvent{T}(EventSource, IEntityEventSubscriber, EntityEventRefHandler{T})"/>
         // [Obsolete("Subscribe to the event by ref instead (EntityEventRefHandler)")]
         void SubscribeEvent<T>(EventSource source, IEntityEventSubscriber subscriber,
-            EntityEventHandler<T> eventHandler) where T : notnull;
+            EntityEventHandler<T> eventHandler) where T : notnull, allows ref struct;
 
         /// <seealso cref="SubscribeEvent{T}(EventSource, IEntityEventSubscriber, EntityEventRefHandler{T})"/>
         // [Obsolete("Subscribe to the event by ref instead (EntityEventRefHandler)")]
@@ -34,10 +34,10 @@ namespace Robust.Shared.GameObjects
             Type orderType,
             Type[]? before = null,
             Type[]? after = null)
-            where T : notnull;
+            where T : notnull, allows ref struct;
 
         void SubscribeEvent<T>(EventSource source, IEntityEventSubscriber subscriber,
-            EntityEventRefHandler<T> eventHandler) where T : notnull;
+            EntityEventRefHandler<T> eventHandler) where T : notnull, allows ref struct;
 
         void SubscribeEvent<T>(
             EventSource source,
@@ -46,7 +46,7 @@ namespace Robust.Shared.GameObjects
             Type orderType,
             Type[]? before = null,
             Type[]? after = null)
-            where T : notnull;
+            where T : notnull, allows ref struct;
 
         /// <summary>
         /// Unsubscribes all event handlers of a given type.
@@ -54,7 +54,7 @@ namespace Robust.Shared.GameObjects
         /// <typeparam name="T">Event type being unsubscribed from.</typeparam>
         /// <param name="source"></param>
         /// <param name="subscriber">Subscriber that owns the handlers.</param>
-        void UnsubscribeEvent<T>(EventSource source, IEntityEventSubscriber subscriber) where T : notnull;
+        void UnsubscribeEvent<T>(EventSource source, IEntityEventSubscriber subscriber) where T : notnull, allows ref struct;
 
         /// <summary>
         /// Immediately raises an event onto the bus.
@@ -63,9 +63,9 @@ namespace Robust.Shared.GameObjects
         /// <param name="toRaise">Event being raised.</param>
         void RaiseEvent(EventSource source, object toRaise);
 
-        void RaiseEvent<T>(EventSource source, T toRaise) where T : notnull;
+        void RaiseEvent<T>(EventSource source, T toRaise) where T : notnull, allows ref struct;
 
-        void RaiseEvent<T>(EventSource source, ref T toRaise) where T : notnull;
+        void RaiseEvent<T>(EventSource source, ref T toRaise) where T : notnull, allows ref struct;
 
         /// <summary>
         /// Queues an event to be raised at a later time.
@@ -146,7 +146,7 @@ namespace Robust.Shared.GameObjects
             EventSource source,
             IEntityEventSubscriber subscriber,
             EntityEventHandler<T> eventHandler)
-            where T : notnull
+            where T : notnull, allows ref struct
         {
             if (eventHandler == null)
                 throw new ArgumentNullException(nameof(eventHandler));
@@ -162,7 +162,7 @@ namespace Robust.Shared.GameObjects
             Type orderType,
             Type[]? before = null,
             Type[]? after = null)
-            where T : notnull
+            where T : notnull, allows ref struct
         {
             if (eventHandler == null)
                 throw new ArgumentNullException(nameof(eventHandler));
@@ -174,7 +174,7 @@ namespace Robust.Shared.GameObjects
         }
 
         public void SubscribeEvent<T>(EventSource source, IEntityEventSubscriber subscriber,
-            EntityEventRefHandler<T> eventHandler) where T : notnull
+            EntityEventRefHandler<T> eventHandler) where T : notnull, allows ref struct
         {
             SubscribeEventCommon<T>(source, subscriber, (ref Unit ev) =>
             {
@@ -185,7 +185,7 @@ namespace Robust.Shared.GameObjects
 
         public void SubscribeEvent<T>(EventSource source, IEntityEventSubscriber subscriber,
             EntityEventRefHandler<T> eventHandler,
-            Type orderType, Type[]? before = null, Type[]? after = null) where T : notnull
+            Type orderType, Type[]? before = null, Type[]? after = null) where T : notnull, allows ref struct
         {
             var order = CreateOrderingData(orderType, before, after);
 
@@ -203,7 +203,7 @@ namespace Robust.Shared.GameObjects
             object equalityToken,
             OrderingData? order,
             bool byRef)
-            where T : notnull
+            where T : notnull, allows ref struct
         {
             if (source == EventSource.None)
                 throw new ArgumentOutOfRangeException(nameof(source));
@@ -240,7 +240,7 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public void UnsubscribeEvent<T>(EventSource source, IEntityEventSubscriber subscriber) where T : notnull
+        public void UnsubscribeEvent<T>(EventSource source, IEntityEventSubscriber subscriber) where T : notnull, allows ref struct
         {
             if (source == EventSource.None)
                 throw new ArgumentOutOfRangeException(nameof(source));
@@ -267,7 +267,7 @@ namespace Robust.Shared.GameObjects
             ProcessSingleEvent(source, ref unitRef, eventType);
         }
 
-        public void RaiseEvent<T>(EventSource source, T toRaise) where T : notnull
+        public void RaiseEvent<T>(EventSource source, T toRaise) where T : notnull, allows ref struct
         {
             if (source == EventSource.None)
                 throw new ArgumentOutOfRangeException(nameof(source));
@@ -275,7 +275,7 @@ namespace Robust.Shared.GameObjects
             ProcessSingleEvent(source, ref Unsafe.As<T, Unit>(ref toRaise), typeof(T));
         }
 
-        public void RaiseEvent<T>(EventSource source, ref T toRaise) where T : notnull
+        public void RaiseEvent<T>(EventSource source, ref T toRaise) where T : notnull, allows ref struct
         {
             if (source == EventSource.None)
                 throw new ArgumentOutOfRangeException(nameof(source));

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -18,48 +18,48 @@ namespace Robust.Shared.GameObjects
     public interface IDirectedEventBus
     {
         void RaiseLocalEvent<TEvent>(EntityUid uid, TEvent args, bool broadcast = false)
-            where TEvent : notnull;
+            where TEvent : notnull, allows ref struct;
 
         void RaiseLocalEvent(EntityUid uid, object args, bool broadcast = false);
 
         void SubscribeLocalEvent<TComp, TEvent>(ComponentEventHandler<TComp, TEvent> handler)
             where TComp : IComponent
-            where TEvent : notnull;
+            where TEvent : notnull, allows ref struct;
 
         void SubscribeLocalEvent<TComp, TEvent>(
             ComponentEventHandler<TComp, TEvent> handler,
             Type orderType, Type[]? before = null, Type[]? after = null)
             where TComp : IComponent
-            where TEvent : notnull;
+            where TEvent : notnull, allows ref struct;
 
         #region Ref Subscriptions
 
         void RaiseLocalEvent<TEvent>(EntityUid uid, ref TEvent args, bool broadcast = false)
-            where TEvent : notnull;
+            where TEvent : notnull, allows ref struct;
 
         void RaiseLocalEvent(EntityUid uid, ref object args, bool broadcast = false);
 
         void SubscribeLocalEvent<TComp, TEvent>(ComponentEventRefHandler<TComp, TEvent> handler)
             where TComp : IComponent
-            where TEvent : notnull;
+            where TEvent : notnull, allows ref struct;
 
         void SubscribeLocalEvent<TComp, TEvent>(
             ComponentEventRefHandler<TComp, TEvent> handler,
             Type orderType, Type[]? before = null, Type[]? after = null)
             where TComp : IComponent
-            where TEvent : notnull;
+            where TEvent : notnull, allows ref struct;
 
         void SubscribeLocalEvent<TComp, TEvent>(
             EntityEventRefHandler<TComp, TEvent> handler,
             Type orderType, Type[]? before = null, Type[]? after = null)
             where TComp : IComponent
-            where TEvent : notnull;
+            where TEvent : notnull, allows ref struct;
 
         #endregion
 
         void UnsubscribeLocalEvent<TComp, TEvent>()
             where TComp : IComponent
-            where TEvent : notnull;
+            where TEvent : notnull, allows ref struct;
 
         /// <summary>
         /// Dispatches an event directly to a specific component.
@@ -70,29 +70,29 @@ namespace Robust.Shared.GameObjects
         /// is because of the component network source generator.
         /// </remarks>
         public void RaiseComponentEvent<TEvent, TComponent>(EntityUid uid, TComponent component, TEvent args)
-            where TEvent : notnull
+            where TEvent : notnull, allows ref struct
             where TComponent : IComponent;
 
         /// <inheritdoc cref="RaiseComponentEvent{TEvent,TComponent}(Robust.Shared.GameObjects.EntityUid,TComponent,TEvent)"/>
         public void RaiseComponentEvent<TEvent>(EntityUid uid, IComponent component, TEvent args)
-            where TEvent : notnull;
+            where TEvent : notnull, allows ref struct;
 
         /// <inheritdoc cref="RaiseComponentEvent{TEvent,TComponent}(Robust.Shared.GameObjects.EntityUid,TComponent,TEvent)"/>
         public void RaiseComponentEvent<TEvent>(EntityUid uid, IComponent component, CompIdx idx, TEvent args)
-            where TEvent : notnull;
+            where TEvent : notnull, allows ref struct;
 
         /// <inheritdoc cref="RaiseComponentEvent{TEvent,TComponent}(Robust.Shared.GameObjects.EntityUid,TComponent,TEvent)"/>
         public void RaiseComponentEvent<TEvent>(EntityUid uid, IComponent component, ref TEvent args)
-            where TEvent : notnull;
+            where TEvent : notnull, allows ref struct;
 
         /// <inheritdoc cref="RaiseComponentEvent{TEvent,TComponent}(Robust.Shared.GameObjects.EntityUid,TComponent,TEvent)"/>
         public void RaiseComponentEvent<TEvent, TComponent>(EntityUid uid, TComponent component, ref TEvent args)
-            where TEvent : notnull
+            where TEvent : notnull, allows ref struct
             where TComponent : IComponent;
 
         /// <inheritdoc cref="RaiseComponentEvent{TEvent,TComponent}(Robust.Shared.GameObjects.EntityUid,TComponent,TEvent)"/>
         public void RaiseComponentEvent<TEvent>(EntityUid uid, IComponent component, CompIdx idx, ref TEvent args)
-            where TEvent : notnull;
+            where TEvent : notnull, allows ref struct;
 
         public void OnlyCallOnRobustUnitTestISwearToGodPleaseSomebodyKillThisNightmare();
     }
@@ -102,7 +102,7 @@ namespace Robust.Shared.GameObjects
         internal delegate void DirectedEventHandler(EntityUid uid, IComponent comp, ref Unit args);
 
         private delegate void DirectedEventHandler<TEvent>(EntityUid uid, IComponent comp, ref TEvent args)
-            where TEvent : notnull;
+            where TEvent : notnull, allows ref struct;
 
         /// <summary>
         /// Max size of a components event subscription linked list.
@@ -132,7 +132,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void RaiseComponentEvent<TEvent>(EntityUid uid, IComponent component, TEvent args)
-            where TEvent : notnull
+            where TEvent : notnull, allows ref struct
         {
             RaiseComponentEvent(uid, component, _comFac.GetIndex(component.GetType()), ref args);
         }
@@ -140,7 +140,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void RaiseComponentEvent<TEvent, TComponent>(EntityUid uid, TComponent component, TEvent args)
-            where TEvent : notnull
+            where TEvent : notnull, allows ref struct
             where TComponent : IComponent
         {
             RaiseComponentEvent(uid, component, CompIdx.Index<TComponent>(), ref args);
@@ -149,7 +149,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void RaiseComponentEvent<TEvent>(EntityUid uid, IComponent component, CompIdx type, TEvent args)
-            where TEvent : notnull
+            where TEvent : notnull, allows ref struct
         {
             RaiseComponentEvent(uid, component, type, ref args);
         }
@@ -157,7 +157,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void RaiseComponentEvent<TEvent>(EntityUid uid, IComponent component, ref TEvent args)
-            where TEvent : notnull
+            where TEvent : notnull, allows ref struct
         {
             RaiseComponentEvent(uid, component, _comFac.GetIndex(component.GetType()), ref args);
         }
@@ -165,7 +165,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void RaiseComponentEvent<TEvent, TComponent>(EntityUid uid, TComponent component, ref TEvent args)
-            where TEvent : notnull
+            where TEvent : notnull, allows ref struct
             where TComponent : IComponent
         {
             RaiseComponentEvent(uid, component, CompIdx.Index<TComponent>(), ref args);
@@ -174,7 +174,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void RaiseComponentEvent<TEvent>(EntityUid uid, IComponent component, CompIdx type, ref TEvent args)
-            where TEvent : notnull
+            where TEvent : notnull, allows ref struct
         {
             ref var unitRef = ref Unsafe.As<TEvent, Unit>(ref args);
 
@@ -192,7 +192,7 @@ namespace Robust.Shared.GameObjects
 
         /// <inheritdoc />
         public void RaiseLocalEvent<TEvent>(EntityUid uid, TEvent args, bool broadcast = false)
-            where TEvent : notnull
+            where TEvent : notnull, allows ref struct
         {
             var type = typeof(TEvent);
             ref var unitRef = ref Unsafe.As<TEvent, Unit>(ref args);
@@ -210,7 +210,7 @@ namespace Robust.Shared.GameObjects
         }
 
         public void RaiseLocalEvent<TEvent>(EntityUid uid, ref TEvent args, bool broadcast = false)
-            where TEvent : notnull
+            where TEvent : notnull, allows ref struct
         {
             var type = typeof(TEvent);
             ref var unitRef = ref Unsafe.As<TEvent, Unit>(ref args);
@@ -247,7 +247,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public void SubscribeLocalEvent<TComp, TEvent>(ComponentEventHandler<TComp, TEvent> handler)
             where TComp : IComponent
-            where TEvent : notnull
+            where TEvent : notnull, allows ref struct
         {
             void EventHandler(EntityUid uid, IComponent comp, ref TEvent args)
                 => handler(uid, (TComp)comp, args);
@@ -266,7 +266,7 @@ namespace Robust.Shared.GameObjects
             Type[]? before = null,
             Type[]? after = null)
             where TComp : IComponent
-            where TEvent : notnull
+            where TEvent : notnull, allows ref struct
         {
             void EventHandler(EntityUid uid, IComponent comp, ref TEvent args)
                 => handler(uid, (TComp)comp, args);
@@ -284,7 +284,7 @@ namespace Robust.Shared.GameObjects
         }
 
         public void SubscribeLocalEvent<TComp, TEvent>(ComponentEventRefHandler<TComp, TEvent> handler)
-            where TComp : IComponent where TEvent : notnull
+            where TComp : IComponent where TEvent : notnull, allows ref struct
         {
             void EventHandler(EntityUid uid, IComponent comp, ref TEvent args)
                 => handler(uid, (TComp)comp, ref args);
@@ -299,7 +299,7 @@ namespace Robust.Shared.GameObjects
 
         public void SubscribeLocalEvent<TComp, TEvent>(ComponentEventRefHandler<TComp, TEvent> handler, Type orderType,
             Type[]? before = null,
-            Type[]? after = null) where TComp : IComponent where TEvent : notnull
+            Type[]? after = null) where TComp : IComponent where TEvent : notnull, allows ref struct
         {
             void EventHandler(EntityUid uid, IComponent comp, ref TEvent args)
                 => handler(uid, (TComp)comp, ref args);
@@ -318,7 +318,7 @@ namespace Robust.Shared.GameObjects
 
         public void SubscribeLocalEvent<TComp, TEvent>(EntityEventRefHandler<TComp, TEvent> handler, Type orderType,
             Type[]? before = null,
-            Type[]? after = null) where TComp : IComponent where TEvent : notnull
+            Type[]? after = null) where TComp : IComponent where TEvent : notnull, allows ref struct
         {
             void EventHandler(EntityUid uid, IComponent comp, ref TEvent args)
                 => handler(new Entity<TComp>(uid, (TComp) comp), ref args);
@@ -338,7 +338,7 @@ namespace Robust.Shared.GameObjects
         /// <inheritdoc />
         public void UnsubscribeLocalEvent<TComp, TEvent>()
             where TComp : IComponent
-            where TEvent : notnull
+            where TEvent : notnull, allows ref struct
         {
             EntUnsubscribe(CompIdx.Index<TComp>(), typeof(TEvent));
         }
@@ -451,7 +451,7 @@ namespace Robust.Shared.GameObjects
             Type eventType,
             DirectedEventHandler<TEvent> handler,
             OrderingData? order)
-            where TEvent : notnull
+            where TEvent : notnull, allows ref struct
         {
             EntAddSubscription(compType, compTypeObj, eventType, new DirectedRegistration(handler, order,
                 (EntityUid uid, IComponent comp, ref Unit ev) =>
@@ -672,7 +672,7 @@ namespace Robust.Shared.GameObjects
             IComponent component,
             CompIdx baseType,
             ref Unit args)
-            where TEvent : notnull
+            where TEvent : notnull, allows ref struct
         {
             if (_compEventSubs[baseType.Value].TryGetValue(typeof(TEvent), out var reg))
                 reg.Handler(euid, component, ref args);
@@ -759,13 +759,13 @@ namespace Robust.Shared.GameObjects
     // [Obsolete("Use ComponentEventRefHandler instead")]
     public delegate void ComponentEventHandler<in TComp, in TEvent>(EntityUid uid, TComp component, TEvent args)
         where TComp : IComponent
-        where TEvent : notnull;
+        where TEvent : notnull, allows ref struct;
 
     public delegate void ComponentEventRefHandler<in TComp, TEvent>(EntityUid uid, TComp component, ref TEvent args)
         where TComp : IComponent
-        where TEvent : notnull;
+        where TEvent : notnull, allows ref struct;
 
     public delegate void EntityEventRefHandler<TComp, TEvent>(Entity<TComp> ent, ref TEvent args)
         where TComp : IComponent
-        where TEvent : notnull;
+        where TEvent : notnull, allows ref struct;
 }

--- a/Robust.Shared/GameObjects/EntityEvents.cs
+++ b/Robust.Shared/GameObjects/EntityEvents.cs
@@ -6,8 +6,8 @@ namespace Robust.Shared.GameObjects
 {
     public interface IEntityEventSubscriber { }
 
-    public delegate void EntityEventHandler<in T>(T ev);
-    public delegate void EntityEventRefHandler<T>(ref T ev);
+    public delegate void EntityEventHandler<in T>(T ev) where T : allows ref struct;
+    public delegate void EntityEventRefHandler<T>(ref T ev) where T : allows ref struct;
     public delegate void EntitySessionEventHandler<in T>(T msg, EntitySessionEventArgs args);
 
     [Serializable, NetSerializable]

--- a/Robust.Shared/GameObjects/EntitySystem.Subscriptions.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Subscriptions.cs
@@ -19,7 +19,7 @@ namespace Robust.Shared.GameObjects
         protected void SubscribeNetworkEvent<T>(
             EntityEventHandler<T> handler,
             Type[]? before = null, Type[]? after = null)
-            where T : notnull
+            where T : notnull, allows ref struct
         {
             SubEvent(EventSource.Network, handler, before, after);
         }
@@ -29,7 +29,7 @@ namespace Robust.Shared.GameObjects
         protected void SubscribeLocalEvent<T>(
             EntityEventHandler<T> handler,
             Type[]? before = null, Type[]? after = null)
-            where T : notnull
+            where T : notnull, allows ref struct
         {
             SubEvent(EventSource.Local, handler, before, after);
         }
@@ -37,7 +37,7 @@ namespace Robust.Shared.GameObjects
         protected void SubscribeLocalEvent<T>(
             EntityEventRefHandler<T> handler,
             Type[]? before = null, Type[]? after = null)
-            where T : notnull
+            where T : notnull, allows ref struct
         {
             SubEvent(EventSource.Local, handler, before, after);
         }
@@ -45,7 +45,7 @@ namespace Robust.Shared.GameObjects
         protected void SubscribeAllEvent<T>(
             EntityEventHandler<T> handler,
             Type[]? before = null, Type[]? after = null)
-            where T : notnull
+            where T : notnull, allows ref struct
         {
             SubEvent(EventSource.All, handler, before, after);
         }
@@ -80,7 +80,7 @@ namespace Robust.Shared.GameObjects
             EventSource src,
             EntityEventHandler<T> handler,
             Type[]? before, Type[]? after)
-            where T : notnull
+            where T : notnull, allows ref struct
         {
             EntityManager.EventBus.SubscribeEvent(src, this, handler, GetType(), before, after);
 
@@ -91,7 +91,7 @@ namespace Robust.Shared.GameObjects
             EventSource src,
             EntityEventRefHandler<T> handler,
             Type[]? before, Type[]? after)
-            where T : notnull
+            where T : notnull, allows ref struct
         {
             EntityManager.EventBus.SubscribeEvent(src, this, handler, GetType(), before, after);
 
@@ -243,7 +243,7 @@ namespace Robust.Shared.GameObjects
             public abstract void Unsubscribe(EntitySystem sys, IEventBus bus);
         }
 
-        private sealed class SubBroadcast<T> : SubBase where T : notnull
+        private sealed class SubBroadcast<T> : SubBase where T : notnull, allows ref struct
         {
             private readonly EventSource _source;
 

--- a/Robust.Shared/GameObjects/EntitySystem.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.cs
@@ -95,12 +95,12 @@ namespace Robust.Shared.GameObjects
 
         #region Event Proxy
 
-        protected void RaiseLocalEvent<T>(T message) where T : notnull
+        protected void RaiseLocalEvent<T>(T message) where T : notnull, allows ref struct
         {
             EntityManager.EventBus.RaiseEvent(EventSource.Local, message);
         }
 
-        protected void RaiseLocalEvent<T>(ref T message) where T : notnull
+        protected void RaiseLocalEvent<T>(ref T message) where T : notnull, allows ref struct
         {
             EntityManager.EventBus.RaiseEvent(EventSource.Local, ref message);
         }
@@ -154,7 +154,7 @@ namespace Robust.Shared.GameObjects
         }
 
         protected void RaiseLocalEvent<TEvent>(EntityUid uid, TEvent args, bool broadcast = false)
-            where TEvent : notnull
+            where TEvent : notnull, allows ref struct
         {
             EntityManager.EventBus.RaiseLocalEvent(uid, args, broadcast);
         }
@@ -165,7 +165,7 @@ namespace Robust.Shared.GameObjects
         }
 
         protected void RaiseLocalEvent<TEvent>(EntityUid uid, ref TEvent args, bool broadcast = false)
-            where TEvent : notnull
+            where TEvent : notnull, allows ref struct
         {
             EntityManager.EventBus.RaiseLocalEvent(uid, ref args, broadcast);
         }


### PR DESCRIPTION
Please let me use `ReadOnlySpan<T>` in events.