### PR TITLE
Increase audio despawn buffer

### DIFF
--- a/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
+++ b/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
@@ -37,6 +37,8 @@ public abstract partial class SharedAudioSystem : EntitySystem
     [Dependency] protected readonly MetaDataSystem MetadataSys = default!;
     [Dependency] protected readonly SharedTransformSystem XformSystem = default!;
 
+    private const float AudioDespawnBuffer = 1f;
+
     /// <summary>
     /// Default max range at which the sound can be heard.
     /// </summary>
@@ -234,7 +236,7 @@ public abstract partial class SharedAudioSystem : EntitySystem
                 {
                     var timed = EnsureComp<TimedDespawnComponent>(entity.Value);
                     var audioLength = GetAudioLength(component.FileName);
-                    timed.Lifetime = (float) audioLength.TotalSeconds + 0.01f;
+                    timed.Lifetime = (float) audioLength.TotalSeconds + AudioDespawnBuffer;
                 }
                 break;
         }
@@ -322,7 +324,7 @@ public abstract partial class SharedAudioSystem : EntitySystem
 
             var despawn = AddComp<TimedDespawnComponent>(uid);
             // Don't want to clip audio too short due to imprecision.
-            despawn.Lifetime = (float) length.Value.TotalSeconds + 0.01f;
+            despawn.Lifetime = (float) length.Value.TotalSeconds + AudioDespawnBuffer;
         }
 
         if (comp.Params.Variation != null && comp.Params.Variation.Value != 0f)


### PR DESCRIPTION
Apparently it can clip and the buffer is really just there so we despawn 'at some point' and rather than hunching over my debugger for potentially an hour this is easier and almost no impact.

I've also considered flagging some audio as "play the full thing" if someone misses the start of it but need to thonk on that one a bit in future.