### PR TITLE
Add more info to AnchorEntity debug assert

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -119,7 +119,8 @@ public abstract partial class SharedTransformSystem
 
     public bool AnchorEntity(Entity<TransformComponent> entity, Entity<MapGridComponent>? grid = null)
     {
-        DebugTools.Assert(grid == null || grid.Value.Owner == entity.Comp.GridUid);
+        DebugTools.Assert(grid == null || grid.Value.Owner == entity.Comp.GridUid,
+            $"Tried to anchor entity {Name(entity)} to a grid ({grid!.Value.Owner}) different from its GridUid ({entity.Comp.GridUid})");
 
         if (grid == null)
         {


### PR DESCRIPTION
AnchorEntity now prints out the name of the entity being anchored and the IDs of the target grid and the entity's GridUid.

Attempting to track down a heisenbug (https://github.com/space-wizards/space-station-14/actions/runs/13267425885/job/37038312514#step:10:159)