### PR TITLE
Avoid unnecessary UpdateState calls for BUIs

### DIFF
--- a/Robust.Shared/GameObjects/Components/UserInterface/BoundUserInterface.cs
+++ b/Robust.Shared/GameObjects/Components/UserInterface/BoundUserInterface.cs
@@ -15,6 +15,8 @@ namespace Robust.Shared.GameObjects
         [Dependency] protected readonly ISharedPlayerManager PlayerManager = default!;
         protected readonly SharedUserInterfaceSystem UiSystem;
 
+        public bool IsOpened { get; protected set; }
+
         public readonly Enum UiKey;
         public EntityUid Owner { get; }
 
@@ -43,6 +45,10 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         protected internal virtual void Open()
         {
+            if (IsOpened)
+                return;
+
+            IsOpened = true;
         }
 
         /// <summary>
@@ -93,6 +99,10 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         public void Close()
         {
+            if (!IsOpened)
+                return;
+
+            IsOpened = false;
             UiSystem.CloseUi(Owner, UiKey, PlayerManager.LocalEntity, predicted: true);
         }
 

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -487,7 +487,7 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
 
                 ent.Comp.States[key] = buiState;
 
-                if (!ent.Comp.ClientOpenInterfaces.TryGetValue(key, out var cBui))
+                if (!ent.Comp.ClientOpenInterfaces.TryGetValue(key, out var cBui) || !cBui.IsOpened)
                     continue;
 
                 cBui.State = buiState;


### PR DESCRIPTION
Don't need to run these if the BUI isn't open, saves performance and some sanity on content.