### PR TITLE
Check equatable on client-predicted BUI states

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -755,8 +755,11 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
         // Predict the change on client
         if (state != null && _netManager.IsClient && entity.Comp.ClientOpenInterfaces.TryGetValue(key, out var bui))
         {
-            bui.UpdateState(state);
-            bui.Update();
+            if (bui.State?.Equals(state) != true)
+            {
+                bui.UpdateState(state);
+                bui.Update();
+            }
         }
 
         DirtyField(entity, nameof(UserInterfaceComponent.States));


### PR DESCRIPTION
We do this for state handling so this just makes it consistent between the two.