### PR TITLE
Fix MultiRootInheritanceGraph not detecting circular inheritance

### DIFF
--- a/Robust.Shared/Prototypes/MultiRootInheritanceGraph.cs
+++ b/Robust.Shared/Prototypes/MultiRootInheritanceGraph.cs
@@ -35,21 +35,12 @@ public sealed class MultiRootInheritanceGraph<T> where T : notnull
 
     public void Add(T id, params T[] parents)
     {
-        _rootNodes.Remove(id);
-
-        foreach (var parent in parents)
-        {
-            var edges = _edges.GetOrNew(parent);
-            edges.Add(id);
-            _parents[id] = parents;
-
-            if (!_parents.ContainsKey(parent))
-                _rootNodes.Add(parent);
-        }
-
         //check for circular inheritance
         foreach (var parent in parents)
         {
+            if (EqualityComparer<T>.Default.Equals(parent,id))
+                throw new InvalidOperationException($"Circular Inheritance detected for id \"{id}\" and parent \"{parent}\"");
+
             var parentsL1 = GetParents(parent);
             if(parentsL1 == null) continue;
 
@@ -68,6 +59,18 @@ public sealed class MultiRootInheritanceGraph<T> where T : notnull
                     }
                 }
             }
+        }
+
+        _rootNodes.Remove(id);
+
+        foreach (var parent in parents)
+        {
+            var edges = _edges.GetOrNew(parent);
+            edges.Add(id);
+            _parents[id] = parents;
+
+            if (!_parents.ContainsKey(parent))
+                _rootNodes.Add(parent);
         }
     }
 

--- a/Robust.Shared/Prototypes/MultiRootInheritanceGraph.cs
+++ b/Robust.Shared/Prototypes/MultiRootInheritanceGraph.cs
@@ -38,8 +38,8 @@ public sealed class MultiRootInheritanceGraph<T> where T : notnull
         //check for circular inheritance
         foreach (var parent in parents)
         {
-            if (EqualityComparer<T>.Default.Equals(parent,id))
-                throw new InvalidOperationException($"Circular Inheritance detected for id \"{id}\" and parent \"{parent}\"");
+            if (EqualityComparer<T>.Default.Equals(parent, id))
+                throw new InvalidOperationException($"Self Inheritance detected for id \"{id}\"!");
 
             var parentsL1 = GetParents(parent);
             if(parentsL1 == null) continue;

--- a/Robust.Shared/Prototypes/MultiRootInheritanceGraph.cs
+++ b/Robust.Shared/Prototypes/MultiRootInheritanceGraph.cs
@@ -35,6 +35,18 @@ public sealed class MultiRootInheritanceGraph<T> where T : notnull
 
     public void Add(T id, params T[] parents)
     {
+        _rootNodes.Remove(id);
+
+        foreach (var parent in parents)
+        {
+            var edges = _edges.GetOrNew(parent);
+            edges.Add(id);
+            _parents[id] = parents;
+
+            if (!_parents.ContainsKey(parent))
+                _rootNodes.Add(parent);
+        }
+
         //check for circular inheritance
         foreach (var parent in parents)
         {
@@ -56,18 +68,6 @@ public sealed class MultiRootInheritanceGraph<T> where T : notnull
                     }
                 }
             }
-        }
-
-        _rootNodes.Remove(id);
-
-        foreach (var parent in parents)
-        {
-            var edges = _edges.GetOrNew(parent);
-            edges.Add(id);
-            _parents[id] = parents;
-
-            if (!_parents.ContainsKey(parent))
-                _rootNodes.Add(parent);
         }
     }
 

--- a/Robust.UnitTesting/Shared/Prototypes/MultiRootGraphTest.cs
+++ b/Robust.UnitTesting/Shared/Prototypes/MultiRootGraphTest.cs
@@ -109,6 +109,6 @@ public sealed class MultiRootGraphTest
     public void IsOwnParentTest()
     {
         var graph = new MultiRootInheritanceGraph<string>();
-        Assert.Throws<InvalidOperationException>(() => graph.Add(Id1, new []{Id1}));
+        Assert.Throws<InvalidOperationException>(() => graph.Add(Id1, new []{ Id1 }));
     }
 }

--- a/Robust.UnitTesting/Shared/Prototypes/MultiRootGraphTest.cs
+++ b/Robust.UnitTesting/Shared/Prototypes/MultiRootGraphTest.cs
@@ -104,4 +104,11 @@ public sealed class MultiRootGraphTest
         Assert.Throws<InvalidOperationException>(() => graph.Add(Id3, new[] { Id1 }));
 
     }
+
+    [Test]
+    public void IsOwnParentTest()
+    {
+        var graph = new MultiRootInheritanceGraph<string>();
+        Assert.Throws<InvalidOperationException>(() => graph.Add(Id1, new []{Id1}));
+    }
 }


### PR DESCRIPTION
`MultiRootInheritanceGraph` failed to properly detect the case of you being your own parent! This caused an infinite loop on start up of SS14 if you had a prototype whose parent was itself.

Example:
```
- type: entity
  parent: CoolEntity
  id: CoolEntity
```

I think the fix is just to add yourself to the data structure before checking for circular inheritance but I could be wrong! You could also just manually check that you don't have yourself as a parent but that seemed hacky. This makes sense and does appear to work.