### PR TITLE
add the MustCallBase attribute to bui Open method

### DIFF
--- a/Robust.Shared/GameObjects/Components/UserInterface/BoundUserInterface.cs
+++ b/Robust.Shared/GameObjects/Components/UserInterface/BoundUserInterface.cs
@@ -43,6 +43,7 @@ namespace Robust.Shared.GameObjects
         ///     Invoked when the UI is opened.
         ///     Do all creation and opening of things like windows in here.
         /// </summary>
+        [MustCallBase]
         protected internal virtual void Open()
         {
             if (IsOpened)


### PR DESCRIPTION
if you dont call it then IsOpened isnt being set properly and this causes issues with sending the first BUI update so you should always do it