### PR TITLE
Fix MappingDataNode.TryAddCopy()

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Fixed an error in `MappingDataNode.TryAddCopy()`, which was causing yaml inheritance/deserialization bugs.
 
 ### Other
 

--- a/Robust.Server/Upload/GamePrototypeLoadManager.cs
+++ b/Robust.Server/Upload/GamePrototypeLoadManager.cs
@@ -50,6 +50,9 @@ public sealed class GamePrototypeLoadManager : SharedPrototypeLoadManager
 
     internal void SendToNewUser(INetChannel channel)
     {
+        if (LoadedPrototypes.Count == 0)
+            return;
+
         // Just dump all the prototypes on connect, before them missing could be an issue.
         var msg = new GamePrototypeLoadMessage
         {

--- a/Robust.Shared/Serialization/Manager/SerializationManager.Composition.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.Composition.cs
@@ -26,14 +26,23 @@ public partial class SerializationManager
 
     public DataNode PushComposition(Type type, DataNode[] parents, DataNode child, ISerializationContext? context = null)
     {
+        // TODO SERIALIZATION
+        // Add variant that doesn't require a parent array.
+
+        // TODO SERIALIZATION
+        // Change inheritance pushing so that it modifies the passed in child. This avoids re-creating the child
+        // multiple times when there are multiple children.
+        //
+        // I.e., change the PushCompositionDelegate signature to not have a return value, and also add an override
+        // of this method that modified the given child.
+
         if (parents.Length == 0)
             return child.Copy();
 
         DebugTools.Assert(parents.All(x => x.GetType() == child.GetType()));
 
-        // TODO SERIALIZATION
-        // Change inheritance pushing so that it modifies the passed in child.
-        // I.e., move the child.Clone() statement to the beginning here, then make the delegate modify the clone.
+
+        // the child.Clone() statement to the beginning here, then make the delegate modify the clone.
         // Currently pusing more than one parent requires multiple unnecessary clones.
 
         var pusher = GetOrCreatePushCompositionDelegate(type, child);

--- a/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNode.cs
@@ -400,7 +400,11 @@ namespace Robust.Shared.Serialization.Markdown.Mapping
 
         public bool TryAdd(DataNode key, DataNode value)
         {
-            return _children.TryAdd(key, value);
+            if (!_children.TryAdd(key, value))
+                return false;
+
+            _list.Add(new(key, value));
+            return true;
         }
 
         public bool TryAddCopy(DataNode key, DataNode value)
@@ -410,6 +414,7 @@ namespace Robust.Shared.Serialization.Markdown.Mapping
                 return false;
 
             entry = value.Copy();
+            _list.Add(new(key, entry));
             return true;
         }
     }


### PR DESCRIPTION
Fixed an error in `MappingDataNode.TryAddCopy()` that was introdued by #5612, which was causing yaml inheritance/deserialization bugs.
