### PR TITLE
Tweak UserInterfaceComponent shutdown to prevent bugs

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -41,11 +41,6 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
     /// </summary>
     private readonly List<(BoundUserInterface Bui, bool value)> _queuedBuis = new();
 
-    /// <summary>
-    /// Temporary storage for BUI keys
-    /// </summary>
-    private ValueList<Enum> _keys = new();
-
     public override void Initialize()
     {
         base.Initialize();
@@ -896,12 +891,13 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
         if (actor.Comp.OpenInterfaces.Count == 0)
             return;
 
+        var keys = new ValueList<Enum>();
         foreach (var (uid, enums) in actor.Comp.OpenInterfaces)
         {
-            _keys.Clear();
-            _keys.AddRange(enums);
+            keys.Clear();
+            keys.AddRange(enums);
 
-            foreach (var weh in _keys)
+            foreach (var weh in keys)
             {
                 if (weh is not T)
                     continue;
@@ -922,12 +918,14 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
         if (actor.Comp.OpenInterfaces.Count == 0)
             return;
 
+        var keys = new ValueList<Enum>();
+
         foreach (var (uid, enums) in actor.Comp.OpenInterfaces)
         {
-            _keys.Clear();
-            _keys.AddRange(enums);
+            keys.Clear();
+            keys.AddRange(enums);
 
-            foreach (var key in _keys)
+            foreach (var key in keys)
             {
                 CloseUiInternal(uid, key, actor.Owner);
             }

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -46,8 +46,6 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
     /// </summary>
     private ValueList<Enum> _keys = new();
 
-    private ValueList<EntityUid> _entList = new();
-
     public override void Initialize()
     {
         base.Initialize();
@@ -288,11 +286,12 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
 
     protected virtual void OnUserInterfaceShutdown(Entity<UserInterfaceComponent> ent, ref ComponentShutdown args)
     {
+        var ents = new ValueList<EntityUid>();
         foreach (var (key, acts) in ent.Comp.Actors)
         {
-            _entList.Clear();
-            _entList.AddRange(acts);
-            foreach (var actor in _entList)
+            ents.Clear();
+            ents.AddRange(acts);
+            foreach (var actor in ents)
             {
                 CloseUiInternal(ent!, key, actor);
                 DebugTools.Assert(!acts.Contains(actor));


### PR DESCRIPTION
This reverts some of the changes made in #5503 and #5650 that were meant to reduce allocations, because AFAICT they could potentially cause bugs if ever shutting down or closing one BUI could trigger other buis to shut down / close via `BoundUIClosedEvent` or other events. AFAIK this isn't currently an issue, this is just preventative.