### PR TITLE
feat: shaders now can accept array of Color as parameter

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -487,6 +487,9 @@ namespace Robust.Client.Graphics.Clyde
                     case Color color:
                         program.SetUniform(name, color);
                         break;
+                    case Color[] colorArr:
+                        program.SetUniform(name, colorArr);
+                        break;
                     case int i:
                         program.SetUniform(name, i);
                         break;

--- a/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
@@ -485,6 +485,13 @@ namespace Robust.Client.Graphics.Clyde
                 data.Parameters[name] = value;
             }
 
+            private protected override void SetParameterImpl(string name, Color[] value)
+            {
+                var data = Parent._shaderInstances[Handle];
+                data.ParametersDirty = true;
+                data.Parameters[name] = value;
+            }
+
             private protected override void SetParameterImpl(string name, int value)
             {
                 var data = Parent._shaderInstances[Handle];

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -352,6 +352,10 @@ namespace Robust.Client.Graphics.Clyde
             {
             }
 
+            private protected override void SetParameterImpl(string name, Color[] value)
+            {
+            }
+
             private protected override void SetParameterImpl(string name, int value)
             {
             }

--- a/Robust.Client/Graphics/Clyde/GLObjects/Clyde.ShaderProgram.cs
+++ b/Robust.Client/Graphics/Clyde/GLObjects/Clyde.ShaderProgram.cs
@@ -334,7 +334,7 @@ namespace Robust.Client.Graphics.Clyde
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private void SetUniformDirect(int slot, in Color color, bool convertToLinear=true)
+            private void SetUniformDirect(int slot, in Color color, bool convertToLinear = true)
             {
                 var converted = color;
                 if (convertToLinear)
@@ -346,6 +346,33 @@ namespace Robust.Client.Graphics.Clyde
                 {
                     GL.Uniform4(slot, 1, (float*) &converted);
                     _clyde.CheckGlError();
+                }
+            }
+
+            public void SetUniform(string uniformName, in Color[] colors)
+            {
+                var uniformId = GetUniform(uniformName);
+                SetUniformDirect(uniformId, colors);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private void SetUniformDirect(int slot, Color[] colors, bool convertToLinear = true)
+            {
+                unsafe
+                {
+                    if (convertToLinear)
+                    {
+                        for (int i = 0; i < colors.Length; i++)
+                        {
+                            colors[i] = Color.FromSrgb(colors[i]);
+                        }
+                    }
+
+                    fixed (Color* ptr = &colors[0])
+                    {
+                        GL.Uniform4(slot, colors.Length, (float*)ptr);
+                        _clyde.CheckGlError();
+                    }
                 }
             }
 

--- a/Robust.Client/Graphics/Shaders/ParsedShader.cs
+++ b/Robust.Client/Graphics/Shaders/ParsedShader.cs
@@ -221,7 +221,7 @@ namespace Robust.Client.Graphics
 
         public static bool TypeSupportsArrays(this ShaderDataType type)
         {
-            // TODO: add support for int, and vec3/4 arrays
+            // TODO: add support for int, and vec3 arrays
             return
                 (type == ShaderDataType.Float) ||
                 (type == ShaderDataType.Vec2) ||

--- a/Robust.Client/Graphics/Shaders/ParsedShader.cs
+++ b/Robust.Client/Graphics/Shaders/ParsedShader.cs
@@ -225,7 +225,8 @@ namespace Robust.Client.Graphics
             return
                 (type == ShaderDataType.Float) ||
                 (type == ShaderDataType.Vec2) ||
-                (type == ShaderDataType.Bool);
+                (type == ShaderDataType.Bool) ||
+                (type == ShaderDataType.Vec4);
         }
 
         [SuppressMessage("ReSharper", "StringLiteralTypo")]

--- a/Robust.Client/Graphics/Shaders/ShaderInstance.cs
+++ b/Robust.Client/Graphics/Shaders/ShaderInstance.cs
@@ -113,6 +113,13 @@ namespace Robust.Client.Graphics
             SetParameterImpl(name, value);
         }
 
+        public void SetParameter(string name, Color[] value)
+        {
+            EnsureAlive();
+            EnsureMutable();
+            SetParameterImpl(name, value);
+        }
+
         public void SetParameter(string name, Vector4 value)
         {
             EnsureAlive();
@@ -223,6 +230,7 @@ namespace Robust.Client.Graphics
         private protected abstract void SetParameterImpl(string name, Vector3 value);
         private protected abstract void SetParameterImpl(string name, Vector4 value);
         private protected abstract void SetParameterImpl(string name, Color value);
+        private protected abstract void SetParameterImpl(string name, Color[] value);
         private protected abstract void SetParameterImpl(string name, int value);
         private protected abstract void SetParameterImpl(string name, Vector2i value);
         private protected abstract void SetParameterImpl(string name, bool value);


### PR DESCRIPTION
Added overload ShaderInstance.SetParameterImpl that accepts array of colors and translates it to vec4[] in shader. Corrected respective code, tested that it works (on one sample).
```
void SetParameterImpl(string name, Color[] value);
```

Was required by visual component that have list of buttons, each one of which could have own background color (radial menu).