### PR TITLE
Remove debug assert

### DIFF
--- a/Robust.Shared/Serialization/Manager/SerializationManager.Composition.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.Composition.cs
@@ -51,10 +51,6 @@ public partial class SerializationManager
         foreach (var parent in parents)
         {
             var newNode = pusher(type, parent, node, context);
-
-            // Currently delegate pusher should be returning a new instance, and not modifying the passed in child.
-            DebugTools.Assert(!ReferenceEquals(newNode, node));
-
             node = newNode;
         }
 


### PR DESCRIPTION
This seems to cause a debug assert in certain usages of composition, so until that is fixed, this is a band-aid. As a good reference point, [this](https://github.com/Goob-Station/Goob-Station/blob/7d65e6e36e23ac7640588a68a1b48c8f5ec9ac18/Resources/Prototypes/_Shitmed/Body/Parts/generic.yml#L85) seems to cause it consistently.