### PR TITLE
Expand and comment SharedTransformSystem anchoring methods

### DIFF
--- a/Robust.Shared/Containers/SharedContainerSystem.Insert.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.Insert.cs
@@ -96,7 +96,7 @@ public abstract partial class SharedContainerSystem
         transform.Broadphase = BroadphaseData.Invalid;
 
         // Unanchor the entity (without changing physics body types).
-        _transform.Unanchor(toInsert, transform, false);
+        _transform.Unanchor((toInsert, transform), setPhysics: false);
 
         // Next, update physics. Note that this cannot just be done in the physics system via parent change events,
         // because the insertion may not result in a parent change. This could alternatively be done via a

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -365,25 +365,7 @@ namespace Robust.Shared.GameObjects
         {
             get => _anchored;
             [Obsolete("Use the SharedTransformSystem.AnchorEntity/Unanchor methods instead.")]
-            set
-            {
-                // This will be set again when the transform initializes, actually anchoring it.
-                if (!Initialized)
-                {
-                    _anchored = value;
-                }
-                else if (value && !_anchored && _mapManager.TryFindGridAt(MapPosition, out _, out var grid))
-                {
-                    _anchored = _entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().AnchorEntity(Owner, this, grid);
-                }
-                else if (!value && _anchored)
-                {
-                    // An anchored entity is always parented to the grid.
-                    // If Transform.Anchored is true in the prototype but the entity was not spawned with a grid as the parent,
-                    // then this will be false.
-                    _entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().Unanchor(Owner, this);
-                }
-            }
+            set { _entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().SetAnchor((Owner, this), value); }
         }
 
         public TransformChildrenEnumerator ChildEnumerator => new(_children.GetEnumerator());

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -335,7 +335,7 @@ namespace Robust.Shared.GameObjects
             if (coordinates.MapId == MapId.Nullspace)
             {
                 transform._parent = EntityUid.Invalid;
-                transform.Anchored = false;
+                transform._anchored = false;
                 return newEntity;
             }
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -135,12 +135,14 @@ public abstract partial class SharedTransformSystem
     }
 
     /// <inheritdoc cref="Unanchor(Entity{TransformComponent}, bool)"/>
+    [Obsolete("Use Entity<T> varients")]
     public void Unanchor(EntityUid uid)
     {
         Unanchor(uid, XformQuery.GetComponent(uid));
     }
 
     /// <inheritdoc cref="Unanchor(Entity{TransformComponent}, bool)"/>
+    [Obsolete("Use Entity<T> varients")]
     public void Unanchor(EntityUid uid, TransformComponent xform, bool setPhysics = true)
     {
         Unanchor((uid, xform), setPhysics);

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -223,7 +223,7 @@ public abstract partial class SharedTransformSystem
         // An anchored entity is always parented to the grid.
         // If Transform.Anchored is true in the prototype but the entity was not spawned with a grid as the parent,
         // then this will be false.
-        Unanchor(uid, entity);
+        Unanchor(entity);
         return true;
     }
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -274,8 +274,8 @@ public abstract partial class SharedTransformSystem
             return true;
         }
 
-        if (value && _mapManager.TryFindGridAt(GetMapCoordinates(entity), out var gridUid, out var gridComp))
-            return AnchorEntity(entity, (gridUid, gridComp));
+        if (value)
+            return AnchorEntity(entity);
 
         // An anchored entity is always parented to the grid.
         // If Transform.Anchored is true in the prototype but the entity was not spawned with a grid as the parent,

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -61,21 +61,16 @@ public abstract partial class SharedTransformSystem
         RaiseLocalEvent(uid, ref ev);
     }
 
-    [Obsolete("Use Entity<T> variant")]
-    public bool AnchorEntity(
-        EntityUid uid,
-        TransformComponent xform,
-        EntityUid gridUid,
-        MapGridComponent grid,
-        Vector2i tileIndices)
-    {
-        return AnchorEntity((uid, xform), (gridUid, grid), tileIndices);
-    }
+    // AnchorEntity:
+    // - Entity<TransformComponent>, Entity<MapGridComponent>, Vector2i
+    // - Entity<TransformComponent>, Entity<MapGridComponent>? = null
+    //
+    // - [Obsolete] EntityUid, TransformComponent, EntityUid, MapGridComponent, Vector2i
+    // - [Obsolete] EntityUid, TransformComponent, MapGridComponent
+    // - [Obsolete] EntityUid, TransformComponent
+    // - [Obsolete] EntityUid
 
-    public bool AnchorEntity(
-        Entity<TransformComponent> entity,
-        Entity<MapGridComponent> grid,
-        Vector2i tileIndices)
+    public bool AnchorEntity(Entity<TransformComponent> entity, Entity<MapGridComponent> grid, Vector2i tileIndices)
     {
         var (uid, xform) = entity;
         if (!_map.AddToSnapGridCell(grid, grid, tileIndices, uid))
@@ -101,23 +96,6 @@ public abstract partial class SharedTransformSystem
         return true;
     }
 
-    [Obsolete("Use Entity<T> variants")]
-    public bool AnchorEntity(EntityUid uid, TransformComponent xform, MapGridComponent grid)
-    {
-        var tileIndices = _map.TileIndicesFor(grid.Owner, grid, xform.Coordinates);
-        return AnchorEntity(uid, xform, grid.Owner, grid, tileIndices);
-    }
-
-    public bool AnchorEntity(EntityUid uid)
-    {
-        return AnchorEntity(uid, XformQuery.GetComponent(uid));
-    }
-
-    public bool AnchorEntity(EntityUid uid, TransformComponent xform)
-    {
-        return AnchorEntity((uid, xform));
-    }
-
     public bool AnchorEntity(Entity<TransformComponent> entity, Entity<MapGridComponent>? grid = null)
     {
         DebugTools.Assert(grid == null || grid.Value.Owner == entity.Comp.GridUid,
@@ -132,6 +110,34 @@ public abstract partial class SharedTransformSystem
 
         var tileIndices =  _map.TileIndicesFor(grid.Value, grid.Value, entity.Comp.Coordinates);
         return AnchorEntity(entity, grid.Value, tileIndices);
+    }
+
+    [Obsolete("Use Entity<T> variant")]
+    public bool AnchorEntity(
+        EntityUid uid,
+        TransformComponent xform,
+        EntityUid gridUid,
+        MapGridComponent grid,
+        Vector2i tileIndices)
+    {
+        return AnchorEntity((uid, xform), (gridUid, grid), tileIndices);
+    }
+
+    [Obsolete("Use Entity<T> variants")]
+    public bool AnchorEntity(EntityUid uid, TransformComponent xform, MapGridComponent grid)
+    {
+        var tileIndices = _map.TileIndicesFor(grid.Owner, grid, xform.Coordinates);
+        return AnchorEntity(uid, xform, grid.Owner, grid, tileIndices);
+    }
+
+    public bool AnchorEntity(EntityUid uid, TransformComponent xform)
+    {
+        return AnchorEntity((uid, xform));
+    }
+
+    public bool AnchorEntity(EntityUid uid)
+    {
+        return AnchorEntity(uid, XformQuery.GetComponent(uid));
     }
 
     /// <inheritdoc cref="Unanchor(Entity{TransformComponent}, bool)"/>

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -67,7 +67,7 @@ public abstract partial class SharedTransformSystem
     /// <param name="entity">The entity that will be attempted to anchor to <paramref name="grid"/> at <paramref name="tileIndices"/>.</param>
     /// <param name="grid">The grid that <paramref name="entity"/> will attempt to anchor to.</param>
     /// <param name="tileIndices">The location of the tile on <paramref name="grid"/> that <paramref name="entity"/> will attempt to anchor to.</param>
-    /// <returns></returns>
+    /// <returns>True if the entity was successfully anchored to the target tile on the target grid, false otherwise.</returns>
     public bool AnchorEntity(Entity<TransformComponent> entity, Entity<MapGridComponent> grid, Vector2i tileIndices)
     {
         var (uid, xform) = entity;
@@ -131,8 +131,6 @@ public abstract partial class SharedTransformSystem
 
     /// <summary>
     /// Attempts to anchor an entity to a given tile.
-    /// <br/>Will fail if the tiles entity lacks a <see cref="MapGridComponent"/>.
-    /// <br/>Will fail if the target tile cannot be anchored to (ex: does not exist, is space, etc).
     /// </summary>
     /// <param name="ent">The entity that will attempt to anchor to <paramref name="tile"/>.</param>
     /// <param name="tile">A reference to an extant tile that <paramref name="ent"/> will attempt to anchor to.</param>
@@ -145,12 +143,6 @@ public abstract partial class SharedTransformSystem
         return AnchorEntity(ent, (tile.GridUid, gridComp), tile.GridIndices);
     }
 
-    /// <summary>
-    /// <inheritdoc cref="AnchorEntity(Entity{TransformComponent}, Entity{MapGridComponent}?, Vector2i?)"/>
-    /// <br/>Will fail if the anchoring entity lacks a <see cref="TransformComponent"/>.
-    /// <br/>Will fail if the target entity lacks a <see cref="MapGridComponent"/>.
-    /// <br/>Will fail if the target tile cannot be anchored to (ex: does not exist, is space, etc).
-    /// </summary>
     /// <inheritdoc cref="AnchorEntity(Entity{TransformComponent}, Entity{MapGridComponent}?, Vector2i?)"/>
     public bool TryAnchorEntity(Entity<TransformComponent?> ent, Entity<MapGridComponent?>? grid = null, Vector2i? tileIndices = null)
     {
@@ -171,10 +163,6 @@ public abstract partial class SharedTransformSystem
         return AnchorEntity(ent!, gridEnt!, tileIndices);
     }
 
-    /// <summary>
-    /// <inheritdoc cref="AnchorEntity(Entity{TransformComponent}, TileRef)"/>
-    /// <br/>Will fail if the anchoring entity lacks a <see cref="TransformComponent"/>.
-    /// </summary>
     /// <inheritdoc cref="AnchorEntity(Entity{TransformComponent}, TileRef)"/>
     public bool TryAnchorEntity(Entity<TransformComponent?> ent, TileRef tile)
     {
@@ -274,7 +262,7 @@ public abstract partial class SharedTransformSystem
     /// <returns>True if the entity was successfully anchored or unanchored, false otherwise. Will return true if the entity was already in the desired state.</returns>
     public bool SetAnchor(Entity<TransformComponent> entity, bool value)
     {
-        var (uid, comp) = entity;
+        var (_, comp) = entity;
 
         if (value == comp._anchored)
             return true;
@@ -296,9 +284,7 @@ public abstract partial class SharedTransformSystem
         return true;
     }
 
-    /// <summary>
-    /// Attempts to anchor an entity that may or may not have a <see cref="TransformComponent"/>.
-    /// </summary>
+    /// <inheritdoc cref="SetAnchor"/>
     public bool TrySetAnchor(Entity<TransformComponent?> entity, bool value)
     {
         if (!XformQuery.Resolve(entity, ref entity.Comp))

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -164,6 +164,28 @@ public abstract partial class SharedTransformSystem
         RaiseLocalEvent(uid, ref ev, true);
     }
 
+    /// <summary>
+    /// Anchors or unanchors an entity as needed.
+    /// </summary>
+    public void SetAnchor(Entity<TransformComponent> entity, bool value)
+    {
+        var (uid, comp) = entity;
+
+        if (value == comp._anchored)
+            return;
+
+        if (!comp.Initialized)
+        {
+            comp._anchored = value;
+            return;
+        }
+
+        if (value && _mapManager.TryFindGridAt(GetMapCoordinates(entity), out var gridUid, out var gridComp))
+            AnchorEntity(entity, (gridUid, gridComp));
+        else
+            Unanchor(uid, entity);
+    }
+
     #endregion
 
     #region Contains

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -167,23 +167,24 @@ public abstract partial class SharedTransformSystem
     /// <summary>
     /// Anchors or unanchors an entity as needed.
     /// </summary>
-    public void SetAnchor(Entity<TransformComponent> entity, bool value)
+    public bool TrySetAnchor(Entity<TransformComponent> entity, bool value)
     {
         var (uid, comp) = entity;
 
         if (value == comp._anchored)
-            return;
+            return true;
 
         if (!comp.Initialized)
         {
             comp._anchored = value;
-            return;
+            return true;
         }
 
         if (value && _mapManager.TryFindGridAt(GetMapCoordinates(entity), out var gridUid, out var gridComp))
-            AnchorEntity(entity, (gridUid, gridComp));
-        else
-            Unanchor(uid, entity);
+            return AnchorEntity(entity, (gridUid, gridComp));
+
+        Unanchor(uid, entity);
+        return true;
     }
 
     #endregion

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -202,38 +202,16 @@ public abstract partial class SharedTransformSystem
         return AnchorEntity(uid, xform, grid.Owner, grid, tileIndices);
     }
 
+    [Obsolete("Use Entity<T> variants")]
     public bool AnchorEntity(EntityUid uid, TransformComponent xform)
     {
         return AnchorEntity((uid, xform));
     }
 
+    [Obsolete("Use Entity<T> variants")]
     public bool AnchorEntity(EntityUid uid)
     {
         return AnchorEntity(uid, XformQuery.GetComponent(uid));
-    }
-
-    /// <inheritdoc cref="Unanchor(Entity{TransformComponent}, bool)"/>
-    [Obsolete("Use Entity<T> varients")]
-    public void Unanchor(EntityUid uid)
-    {
-        Unanchor(uid, XformQuery.GetComponent(uid));
-    }
-
-    /// <inheritdoc cref="Unanchor(Entity{TransformComponent}, bool)"/>
-    [Obsolete("Use Entity<T> varients")]
-    public void Unanchor(EntityUid uid, TransformComponent xform, bool setPhysics = true)
-    {
-        Unanchor((uid, xform), setPhysics);
-    }
-
-    /// <inheritdoc cref="Unanchor(Entity{TransformComponent}, bool)"/>
-    public void TryUnanchor(Entity<TransformComponent?> entity, bool setPhysics = true)
-    {
-        if (!XformQuery.Resolve(entity, ref entity.Comp))
-            return;
-
-        Unanchor(entity!, setPhysics);
-        return;
     }
 
     /// <summary>
@@ -266,15 +244,28 @@ public abstract partial class SharedTransformSystem
         RaiseLocalEvent(uid, ref ev, true);
     }
 
-    /// <summary>
-    /// Attempts to anchor an entity that may or may not have a <see cref="TransformComponent"/>.
-    /// </summary>
-    public bool TrySetAnchor(Entity<TransformComponent?> entity, bool value)
+    /// <inheritdoc cref="Unanchor(Entity{TransformComponent}, bool)"/>
+    public void TryUnanchor(Entity<TransformComponent?> entity, bool setPhysics = true)
     {
         if (!XformQuery.Resolve(entity, ref entity.Comp))
-            return false;
+            return;
 
-        return SetAnchor(entity!, value);
+        Unanchor(entity!, setPhysics);
+        return;
+    }
+
+    /// <inheritdoc cref="Unanchor(Entity{TransformComponent}, bool)"/>
+    [Obsolete("Use Entity<T> varients")]
+    public void Unanchor(EntityUid uid)
+    {
+        Unanchor(uid, XformQuery.GetComponent(uid));
+    }
+
+    /// <inheritdoc cref="Unanchor(Entity{TransformComponent}, bool)"/>
+    [Obsolete("Use Entity<T> varients")]
+    public void Unanchor(EntityUid uid, TransformComponent xform, bool setPhysics = true)
+    {
+        Unanchor((uid, xform), setPhysics);
     }
 
     /// <summary>
@@ -303,6 +294,17 @@ public abstract partial class SharedTransformSystem
         // then this will be false.
         Unanchor(entity);
         return true;
+    }
+
+    /// <summary>
+    /// Attempts to anchor an entity that may or may not have a <see cref="TransformComponent"/>.
+    /// </summary>
+    public bool TrySetAnchor(Entity<TransformComponent?> entity, bool value)
+    {
+        if (!XformQuery.Resolve(entity, ref entity.Comp))
+            return false;
+
+        return SetAnchor(entity!, value);
     }
 
     #endregion

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -105,7 +105,7 @@ public abstract partial class SharedTransformSystem
     /// <returns>True if the entity was successfully anchored to the target tile on the target grid, false otherwise.</returns>
     public bool AnchorEntity(Entity<TransformComponent> entity, Entity<MapGridComponent>? grid = null, Vector2i? tileIndices = null)
     {
-        if (grid == null)
+        if (grid is null)
         {
             var gridUid = entity.Comp.GridUid;
             if (!TryComp(gridUid, out MapGridComponent? gridComp))

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -108,7 +108,7 @@ public abstract partial class SharedTransformSystem
         if (grid is null)
         {
             var gridUid = entity.Comp.GridUid;
-            if (!TryComp(gridUid, out MapGridComponent? gridComp))
+            if (!_gridQuery.TryGetComponent(gridUid, out MapGridComponent? gridComp))
                 return false;
 
             grid = (gridUid.Value, gridComp);

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -235,7 +235,7 @@ public abstract partial class SharedTransformSystem
     [Obsolete("Use Entity<T> varients")]
     public void Unanchor(EntityUid uid)
     {
-        Unanchor(uid, XformQuery.GetComponent(uid));
+        Unanchor((uid, XformQuery.GetComponent(uid)));
     }
 
     /// <inheritdoc cref="Unanchor(Entity{TransformComponent}, bool)"/>

--- a/Robust.UnitTesting/Shared/EntityLookup_Test.cs
+++ b/Robust.UnitTesting/Shared/EntityLookup_Test.cs
@@ -373,11 +373,11 @@ namespace Robust.UnitTesting.Shared
             var xform = entManager.GetComponent<TransformComponent>(dummy);
 
             // When anchoring it should still get returned.
-            transformSystem.AnchorEntity(dummy, xform);
+            transformSystem.AnchorEntity((dummy, xform));
             Assert.That(xform.Anchored, Is.True);
             Assert.That(lookup.GetEntitiesIntersecting(mapId, theMapSpotBeingUsed).ToList(), Has.Count.EqualTo(1));
 
-            transformSystem.Unanchor(dummy, xform);
+            transformSystem.Unanchor((dummy, xform));
             Assert.That(xform.Anchored, Is.False);
             Assert.That(lookup.GetEntitiesIntersecting(mapId, theMapSpotBeingUsed).ToList().Count, Is.EqualTo(1));
 

--- a/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
@@ -74,7 +74,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
 
             // Act
             sim.System<MoveEventTestSystem>().ResetCounters();
-            xformSys.AnchorEntity(ent1);
+            xformSys.AnchorEntity((ent1, sim.Transform(ent1)));
             Assert.That(xformSys.GetWorldPosition(ent1), Is.EqualTo(new Vector2(7.5f, 7.5f))); // centered on tile
             sim.System<MoveEventTestSystem>().AssertMoved(false);
         }
@@ -224,7 +224,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             mapSys.SetTile(grid, tileIndices, Tile.Empty);
 
             // Act
-            xformSys.AnchorEntity(ent1);
+            xformSys.AnchorEntity((ent1, sim.Transform(ent1)));
 
             Assert.That(mapSys.GetAnchoredEntities(grid, tileIndices).Count(), Is.EqualTo(0));
             Assert.That(mapSys.GetTileRef(grid, tileIndices).Tile, Is.EqualTo(Tile.Empty));
@@ -292,7 +292,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             var ent1 = sim.SpawnEntity(null, coordinates);
             var tileIndices = mapSys.TileIndicesFor(grid, sim.Transform(ent1).Coordinates);
             mapSys.SetTile(grid, tileIndices, new Tile(1));
-            xformSys.AnchorEntity(ent1);
+            xformSys.AnchorEntity((ent1, sim.Transform(ent1)));
 
             // Act
             xformSys.SetParent(ent1, mapSys.GetMap(coordinates.MapId));
@@ -337,7 +337,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             var tileIndices = mapSys.TileIndicesFor(grid, sim.Transform(ent1).Coordinates);
             mapSys.SetTile(grid, tileIndices, new Tile(1));
             mapSys.SetTile(grid, new Vector2i(100, 100), new Tile(1)); // Prevents the grid from being deleted when the Act happens
-            xformSys.AnchorEntity(ent1);
+            xformSys.AnchorEntity((ent1, sim.Transform(ent1)));
 
             // Act
             mapSys.SetTile(grid, tileIndices, Tile.Empty);
@@ -363,7 +363,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             var ent1 = sim.SpawnEntity(null, coords);
             var tileIndices = mapSys.TileIndicesFor(grid, sim.Transform(ent1).Coordinates);
             mapSys.SetTile(grid, tileIndices, new Tile(1));
-            xformSys.AnchorEntity(ent1);
+            xformSys.AnchorEntity((ent1, sim.Transform(ent1)));
 
             // Act
             // We purposefully use the grid as container so parent stays the same, reparent will unanchor
@@ -390,7 +390,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             var ent1 = sim.SpawnEntity(null, coords);
             var tileIndices = mapSys.TileIndicesFor(grid, sim.Transform(ent1).Coordinates);
             mapSys.SetTile(grid, tileIndices, new Tile(1));
-            xformSys.AnchorEntity(ent1);
+            xformSys.AnchorEntity((ent1, sim.Transform(ent1)));
 
             // Act
             // assumed default body is Dynamic
@@ -417,7 +417,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             physSystem.SetBodyType(ent1, BodyType.Dynamic, body: physComp);
 
             // Act
-            xformSys.AnchorEntity(ent1);
+            xformSys.AnchorEntity((ent1, sim.Transform(ent1)));
 
             Assert.That(physComp.BodyType, Is.EqualTo(BodyType.Static));
         }
@@ -479,7 +479,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             containerSys.Insert(ent1, container);
 
             // Act
-            xformSys.AnchorEntity(ent1);
+            xformSys.AnchorEntity((ent1, sim.Transform(ent1)));
 
             Assert.That(sim.Transform(ent1).Anchored, Is.False);
             Assert.That(mapSys.GetAnchoredEntities(grid, tileIndices).Count(), Is.EqualTo(0));

--- a/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/Systems/AnchoredSystemTests.cs
@@ -438,7 +438,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             xformSys.SetAnchor((ent1, sim.Transform(ent1)), true);
 
             // Act
-            xformSys.Unanchor(ent1);
+            xformSys.Unanchor((ent1, sim.Transform(ent1)));
 
             Assert.That(physComp.BodyType, Is.EqualTo(BodyType.Dynamic));
         }
@@ -504,7 +504,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
 
             // Act
             sim.System<MoveEventTestSystem>().FailOnMove = true;
-            xformSys.Unanchor(ent1);
+            xformSys.Unanchor((ent1, sim.Transform(ent1)));
             Assert.That(sim.Transform(ent1).ParentUid, Is.EqualTo(mapSys.GetMap(coordinates.MapId)));
             sim.System<MoveEventTestSystem>().FailOnMove = false;
             traversal.Enabled = true;
@@ -523,7 +523,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             mapSys.SetTile(grid, mapSys.TileIndicesFor(grid, coordinates), new Tile(1));
             var ent1 = entMan.SpawnEntity("anchoredEnt", mapSys.MapToGrid(grid, coordinates));
 
-            xformSys.Unanchor(ent1);
+            xformSys.Unanchor((ent1, sim.Transform(ent1)));
 
             Assert.That(sim.Transform(ent1).ParentUid, Is.EqualTo(grid.Owner));
         }


### PR DESCRIPTION
Biggest change here is making the default anchor setter use the entities current grid instead of calculating it from scratch.
Doesn't seem to break anything and Sloth says it shouldn't.

Otherwise, this is just expanding and adding doc comments to the TransformSystem anchoring API.

Required for https://github.com/space-wizards/space-station-14/pull/34938