### PR TITLE
Revert "Add ICloneable support to ComponentNetworkGenerator"

### DIFF
--- a/Robust.Shared.CompNetworkGenerator/ComponentNetworkGenerator.cs
+++ b/Robust.Shared.CompNetworkGenerator/ComponentNetworkGenerator.cs
@@ -746,17 +746,7 @@ public partial class {componentName}{deltaInterface}
 
         private static bool IsCloneType(ITypeSymbol type)
         {
-            if (type is not INamedTypeSymbol named)
-            {
-                return false;
-            }
-
-            if (ImplementsInterface(named, nameof(ICloneable)))
-            {
-                return true;
-            }
-
-            if (!named.IsGenericType)
+            if (type is not INamedTypeSymbol named || !named.IsGenericType)
             {
                 return false;
             }
@@ -767,19 +757,6 @@ public partial class {componentName}{deltaInterface}
                 GlobalDictionaryName or GlobalHashSetName or GlobalListName => true,
                 _ => false
             };
-        }
-
-        private static bool ImplementsInterface(ITypeSymbol type, string interfaceName)
-        {
-            foreach (var interfaceType in type.AllInterfaces)
-            {
-                if (interfaceType.ToDisplayString().Contains(interfaceName))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
     }
 }


### PR DESCRIPTION
Reverts space-wizards/RobustToolbox#5656

Generates invalid code when using something like
```cs
[DataField, AutoNetworkedField]
public TestClass TestField = new();

[Serializable, NetSerializable]
public sealed class TestClass : ICloneable
{
    public object Clone() => new();
}
```

See https://discord.com/channels/310555209753690112/900426319433728030/1341968643646423210