### PR TITLE
Fix issue regarding Tilemaps not saving when modified

### DIFF
--- a/Robust.Shared/EntitySerialization/EntitySerializer.cs
+++ b/Robust.Shared/EntitySerialization/EntitySerializer.cs
@@ -593,7 +593,7 @@ public sealed class EntitySerializer : ISerializationContext,
     public MappingDataNode Write()
     {
         DebugTools.AssertEqual(Maps.ToHashSet().Count, Maps.Count, "Duplicate maps?");
-        DebugTools.AssertEqual(Grids.ToHashSet().Count, Grids.Count, "Duplicate frids?");
+        DebugTools.AssertEqual(Grids.ToHashSet().Count, Grids.Count, "Duplicate grids?");
         DebugTools.AssertEqual(Orphans.ToHashSet().Count, Orphans.Count, "Duplicate orphans?");
         DebugTools.AssertEqual(Nullspace.ToHashSet().Count, Nullspace.Count, "Duplicate nullspace?");
 
@@ -641,11 +641,12 @@ public sealed class EntitySerializer : ISerializationContext,
         var map = new MappingDataNode();
         foreach (var (tileId, yamlTileId) in _tileMap.OrderBy(x => x.Key))
         {
-            // This can come up if tests try to serialize test maps with custom / placeholder tile ids without registering them with the tile def manager..
+            // This can come up if tests try to serialize test maps with custom / Zplaceholder tile ids without registering them with the tile def manager..
             if (!_tileDef.TryGetDefinition(tileId, out var def))
                 throw new Exception($"Attempting to serialize a tile {tileId} with no valid tile definition.");
 
-            var yamlId = yamlTileId.ToString(CultureInfo.InvariantCulture);
+            // If the tilemap changes between saves, we will need to reallocate the tile ID, GetYamlTileId does that for us.
+            var yamlId = GetYamlTileId(tileId).ToString(CultureInfo.InvariantCulture);
             map.Add(yamlId, def.ID);
         }
         return map;

--- a/Robust.Shared/EntitySerialization/EntitySerializer.cs
+++ b/Robust.Shared/EntitySerialization/EntitySerializer.cs
@@ -641,7 +641,7 @@ public sealed class EntitySerializer : ISerializationContext,
         var map = new MappingDataNode();
         foreach (var (tileId, yamlTileId) in _tileMap.OrderBy(x => x.Key))
         {
-            // This can come up if tests try to serialize test maps with custom / Zplaceholder tile ids without registering them with the tile def manager..
+            // This can come up if tests try to serialize test maps with custom / placeholder tile ids without registering them with the tile def manager..
             if (!_tileDef.TryGetDefinition(tileId, out var def))
                 throw new Exception($"Attempting to serialize a tile {tileId} with no valid tile definition.");
 

--- a/Robust.Shared/EntitySerialization/EntitySerializer.cs
+++ b/Robust.Shared/EntitySerialization/EntitySerializer.cs
@@ -271,7 +271,10 @@ public sealed class EntitySerializer : ISerializationContext,
         foreach (var (origId, prototypeId) in savedMap)
         {
             if (_tileDef.TryGetDefinition(prototypeId, out var definition))
+            {
                 _tileMap.TryAdd(definition.TileId, origId);
+                _yamlTileIds.Add(origId); // Make sure we record the IDs we're using so when we need to reserve new ones we can
+            }
         }
     }
 
@@ -645,8 +648,7 @@ public sealed class EntitySerializer : ISerializationContext,
             if (!_tileDef.TryGetDefinition(tileId, out var def))
                 throw new Exception($"Attempting to serialize a tile {tileId} with no valid tile definition.");
 
-            // If the tilemap changes between saves, we will need to reallocate the tile ID, GetYamlTileId does that for us.
-            var yamlId = GetYamlTileId(tileId).ToString(CultureInfo.InvariantCulture);
+            var yamlId = yamlTileId.ToString(CultureInfo.InvariantCulture);
             map.Add(yamlId, def.ID);
         }
         return map;


### PR DESCRIPTION
When new tiles are added to a map, the serializer wasn't able to properly allocate new IDs for the tilemap because the list of known tile IDs wasn't getting populated. This PR makes that list get populated now.