### PR TITLE
Use Entity<T> for TileChangedEvent

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
@@ -159,9 +159,9 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         ///     Creates a new instance of this class.
         /// </summary>
-        public TileChangedEvent(EntityUid uid, TileRef newTile, Tile oldTile, Vector2i chunkIndex)
+        public TileChangedEvent(Entity<MapGridComponent> entity, TileRef newTile, Tile oldTile, Vector2i chunkIndex)
         {
-            Entity = uid;
+            Entity = entity;
             NewTile = newTile;
             OldTile = oldTile;
             ChunkIndex = chunkIndex;
@@ -173,9 +173,9 @@ namespace Robust.Shared.GameObjects
         public bool EmptyChanged => OldTile.IsEmpty != NewTile.Tile.IsEmpty;
 
         /// <summary>
-        ///     EntityUid of the grid with the tile-change. TileRef stores the GridId.
+        ///     Entity of the grid with the tile-change. TileRef stores the GridId.
         /// </summary>
-        public readonly EntityUid Entity;
+        public readonly Entity<MapGridComponent> Entity;
 
         /// <summary>
         ///     New tile that replaced the old one.

--- a/Robust.Shared/Map/IMapManagerInternal.cs
+++ b/Robust.Shared/Map/IMapManagerInternal.cs
@@ -1,3 +1,5 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
 
 namespace Robust.Shared.Map
@@ -10,6 +12,6 @@ namespace Robust.Shared.Map
         /// </summary>
         /// <param name="tileRef">A reference to the new tile.</param>
         /// <param name="oldTile">The old tile that got replaced.</param>
-        void RaiseOnTileChanged(TileRef tileRef, Tile oldTile, Vector2i chunk);
+        void RaiseOnTileChanged(Entity<MapGridComponent> entity, TileRef tileRef, Tile oldTile, Vector2i chunk);
     }
 }

--- a/Robust.Shared/Map/MapManager.GridCollection.cs
+++ b/Robust.Shared/Map/MapManager.GridCollection.cs
@@ -96,14 +96,13 @@ internal partial class MapManager
     /// </summary>
     /// <param name="tileRef">A reference to the new tile.</param>
     /// <param name="oldTile">The old tile that got replaced.</param>
-    public void RaiseOnTileChanged(TileRef tileRef, Tile oldTile, Vector2i chunk)
+    void IMapManagerInternal.RaiseOnTileChanged(Entity<MapGridComponent> entity, TileRef tileRef, Tile oldTile, Vector2i chunk)
     {
         if (SuppressOnTileChanged)
             return;
 
-        var euid = tileRef.GridUid;
-        var ev = new TileChangedEvent(euid, tileRef, oldTile, chunk);
-        EntityManager.EventBus.RaiseLocalEvent(euid, ref ev, true);
+        var ev = new TileChangedEvent(entity, tileRef, oldTile, chunk);
+        EntityManager.EventBus.RaiseLocalEvent(entity.Owner, ref ev, true);
     }
 
     protected Entity<MapGridComponent> CreateGrid(EntityUid map, ushort chunkSize, EntityUid forcedGridEuid)


### PR DESCRIPTION
Content is manually resolving this in a few spots so we can avoid that overhead.

Breaking change technically.