### PR TITLE
Add TryLoadGrid override

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Added a new `MapLoaderSystem.TryLoadGrid()` override that loads a grid onto a newly created map.
 
 ### Bugfixes
 

--- a/Resources/Locale/en-US/commands.ftl
+++ b/Resources/Locale/en-US/commands.ftl
@@ -293,7 +293,7 @@ cmd-lsgrid-desc = Lists grids.
 cmd-lsgrid-help = lsgrid
 
 cmd-addmap-desc = Adds a new empty map to the round. If the mapID already exists, this command does nothing.
-cmd-addmap-help = addmap <mapID> [initialize]
+cmd-addmap-help = addmap <mapID> [pre-init]
 
 cmd-rmmap-desc = Removes a map from the world. You cannot remove nullspace.
 cmd-rmmap-help = rmmap <mapId>


### PR DESCRIPTION
Adds a new `TryLoadGrid()` override that automatically creates a new map and load the grid onto it. Also tweaks the `addmap` command's help string to clarify what the optional argument does.