### PR TITLE
Modify TryCopyComponents metadata TryGetComponent

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -1101,7 +1101,7 @@ namespace Robust.Shared.GameObjects
             MetaDataComponent? meta = null,
             params Type[] sourceComponents)
         {
-            if (!MetaQuery.TryGetComponent(source, out meta))
+            if (!MetaQuery.TryGetComponent(target, out meta))
                 return false;
 
             var allCopied = true;

--- a/Robust.UnitTesting/Shared/GameObjects/EntityManagerCopyTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityManagerCopyTests.cs
@@ -112,6 +112,46 @@ public sealed partial class EntityManagerCopyTests
         Assert.That(!ReferenceEquals(comp2, targetComp2));
     }
 
+    [Test]
+    public void CopyComponentMultipleViaTry()
+    {
+        var instant = RobustServerSimulation.NewSimulation();
+        instant.RegisterComponents(fac =>
+        {
+            fac.RegisterClass<AComponent>();
+            fac.RegisterClass<BComponent>();
+        });
+
+        var sim = instant.InitializeInstance();
+        var entManager = sim.Resolve<IEntityManager>();
+        var mapSystem = entManager.System<SharedMapSystem>();
+
+        mapSystem.CreateMap(out var mapId);
+
+        var original = entManager.Spawn(null, new MapCoordinates(Vector2.Zero, mapId));
+        var comp = entManager.AddComponent<AComponent>(original);
+        var comp2 = entManager.AddComponent<BComponent>(original);
+
+        Assert.That(comp.Value, Is.EqualTo(false));
+        comp.Value = true;
+
+        var target = entManager.Spawn(null, new MapCoordinates(Vector2.Zero, mapId));
+        Assert.That(!entManager.HasComponent<AComponent>(target));
+
+        entManager.TryCopyComponents(original, target, null, comp.GetType(), comp2.GetType());
+        var targetComp = entManager.GetComponent<AComponent>(target);
+        var targetComp2 = entManager.GetComponent<BComponent>(target);
+
+        Assert.That(targetComp!.Owner == target);
+        Assert.That(targetComp.Value, Is.EqualTo(comp.Value));
+
+        Assert.That(targetComp2!.Owner == target);
+        Assert.That(targetComp2.Value, Is.EqualTo(comp2.Value));
+
+        Assert.That(!ReferenceEquals(comp, targetComp));
+        Assert.That(!ReferenceEquals(comp2, targetComp2));
+    }
+    
     [DataDefinition]
     private sealed partial class AComponent : Component
     {


### PR DESCRIPTION
fixes `TryCopyComponents` where it attempts to pull the metadata from the source rather than the target required further down inside of CopyComponent.

Without this change, both providing a `Metadata(target)` or even `null` will cause a `Entity is not the owner of the Component. Component: MetaDataComponent` error