### PR TITLE
Improve location reporting for non-writeable DataFields

### DIFF
--- a/Robust.Analyzers.Tests/DataDefinitionAnalyzerTest.cs
+++ b/Robust.Analyzers.Tests/DataDefinitionAnalyzerTest.cs
@@ -118,4 +118,35 @@ public sealed class DataDefinitionAnalyzerTest
             VerifyCS.Diagnostic(DataDefinitionAnalyzer.DataFieldWritableRule).WithSpan(15, 12, 15, 20).WithArguments("Bad", "Foo")
         );
     }
+
+    [Test]
+    public async Task ReadOnlyPropertyTest()
+    {
+        const string code = """
+            using System;
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            namespace Robust.Shared.Serialization.Manager.Attributes
+            {
+                public class DataFieldBaseAttribute : Attribute;
+                public class DataFieldAttribute : DataFieldBaseAttribute;
+                public sealed class DataDefinitionAttribute : Attribute;
+            }
+
+            [DataDefinition]
+            public sealed partial class Foo
+            {
+                [DataField]
+                public int Bad { get; }
+
+                [DataField]
+                public int Good { get; private set; }
+            }
+            """;
+
+        await Verifier(code,
+            // /0/Test0.cs(15,20): error RA0020: Data field property Bad in data definition Foo does not have a setter
+            VerifyCS.Diagnostic(DataDefinitionAnalyzer.DataFieldPropertyWritableRule).WithSpan(15, 20, 15, 28).WithArguments("Bad", "Foo")
+        );
+    }
 }

--- a/Robust.Analyzers.Tests/DataDefinitionAnalyzerTest.cs
+++ b/Robust.Analyzers.Tests/DataDefinitionAnalyzerTest.cs
@@ -87,4 +87,35 @@ public sealed class DataDefinitionAnalyzerTest
             VerifyCS.Diagnostic(DataDefinitionAnalyzer.DataFieldNoVVReadWriteRule).WithSpan(35, 17, 35, 50).WithArguments("Bad", "Foo")
         );
     }
+
+    [Test]
+    public async Task ReadOnlyFieldTest()
+    {
+        const string code = """
+            using System;
+            using Robust.Shared.Serialization.Manager.Attributes;
+
+            namespace Robust.Shared.Serialization.Manager.Attributes
+            {
+                public class DataFieldBaseAttribute : Attribute;
+                public class DataFieldAttribute : DataFieldBaseAttribute;
+                public sealed class DataDefinitionAttribute : Attribute;
+            }
+
+            [DataDefinition]
+            public sealed partial class Foo
+            {
+                [DataField]
+                public readonly int Bad;
+
+                [DataField]
+                public int Good;
+            }
+            """;
+
+        await Verifier(code,
+            // /0/Test0.cs(15,12): error RA0019: Data field Bad in data definition Foo is readonly
+            VerifyCS.Diagnostic(DataDefinitionAnalyzer.DataFieldWritableRule).WithSpan(15, 12, 15, 20).WithArguments("Bad", "Foo")
+        );
+    }
 }

--- a/Robust.Analyzers/DataDefinitionAnalyzer.cs
+++ b/Robust.Analyzers/DataDefinitionAnalyzer.cs
@@ -41,7 +41,7 @@ public sealed class DataDefinitionAnalyzer : DiagnosticAnalyzer
         "Make sure to mark any type containing a nested data definition as partial."
     );
 
-    private static readonly DiagnosticDescriptor DataFieldWritableRule = new(
+    public static readonly DiagnosticDescriptor DataFieldWritableRule = new(
         Diagnostics.IdDataFieldWritable,
         "Data field must not be readonly",
         "Data field {0} in data definition {1} is readonly",
@@ -149,7 +149,8 @@ public sealed class DataDefinitionAnalyzer : DiagnosticAnalyzer
 
             if (IsReadOnlyDataField(type, fieldSymbol))
             {
-                context.ReportDiagnostic(Diagnostic.Create(DataFieldWritableRule, context.Node.GetLocation(), fieldSymbol.Name, type.Name));
+                TryGetModifierLocation(field, "readonly", out var location);
+                context.ReportDiagnostic(Diagnostic.Create(DataFieldWritableRule, location, fieldSymbol.Name, type.Name));
             }
 
             if (HasRedundantTag(fieldSymbol))
@@ -281,6 +282,20 @@ public sealed class DataDefinitionAnalyzer : DiagnosticAnalyzer
             }
         }
         // Default to the declaration syntax's location
+        location = syntax.GetLocation();
+        return false;
+    }
+
+    private static bool TryGetModifierLocation(MemberDeclarationSyntax syntax, string modifierName, out Location location)
+    {
+        foreach (var modifier in syntax.Modifiers)
+        {
+            if (modifier.ValueText == modifierName)
+            {
+                location = modifier.GetLocation();
+                return true;
+            }
+        }
         location = syntax.GetLocation();
         return false;
     }

--- a/Robust.Analyzers/DataDefinitionAnalyzer.cs
+++ b/Robust.Analyzers/DataDefinitionAnalyzer.cs
@@ -149,7 +149,7 @@ public sealed class DataDefinitionAnalyzer : DiagnosticAnalyzer
 
             if (IsReadOnlyDataField(type, fieldSymbol))
             {
-                TryGetModifierLocation(field, "readonly", out var location);
+                TryGetModifierLocation(field, SyntaxKind.ReadOnlyKeyword, out var location);
                 context.ReportDiagnostic(Diagnostic.Create(DataFieldWritableRule, location, fieldSymbol.Name, type.Name));
             }
 
@@ -287,11 +287,11 @@ public sealed class DataDefinitionAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static bool TryGetModifierLocation(MemberDeclarationSyntax syntax, string modifierName, out Location location)
+    private static bool TryGetModifierLocation(MemberDeclarationSyntax syntax, SyntaxKind modifierKind, out Location location)
     {
         foreach (var modifier in syntax.Modifiers)
         {
-            if (modifier.ValueText == modifierName)
+            if (modifier.IsKind(modifierKind))
             {
                 location = modifier.GetLocation();
                 return true;

--- a/Robust.Analyzers/DataDefinitionAnalyzer.cs
+++ b/Robust.Analyzers/DataDefinitionAnalyzer.cs
@@ -51,7 +51,7 @@ public sealed class DataDefinitionAnalyzer : DiagnosticAnalyzer
         "Make sure to remove the readonly modifier."
     );
 
-    private static readonly DiagnosticDescriptor DataFieldPropertyWritableRule = new(
+    public static readonly DiagnosticDescriptor DataFieldPropertyWritableRule = new(
         Diagnostics.IdDataFieldPropertyWritable,
         "Data field property must have a setter",
         "Data field property {0} in data definition {1} does not have a setter",
@@ -186,7 +186,8 @@ public sealed class DataDefinitionAnalyzer : DiagnosticAnalyzer
 
         if (IsReadOnlyDataField(type, propertySymbol))
         {
-            context.ReportDiagnostic(Diagnostic.Create(DataFieldPropertyWritableRule, context.Node.GetLocation(), propertySymbol.Name, type.Name));
+            var location = property.AccessorList != null ? property.AccessorList.GetLocation() : property.GetLocation();
+            context.ReportDiagnostic(Diagnostic.Create(DataFieldPropertyWritableRule, location, propertySymbol.Name, type.Name));
         }
 
         if (HasRedundantTag(propertySymbol))


### PR DESCRIPTION
Just some quick tweaks to location reporting.

## Before
<img width="690" alt="Screenshot 2025-02-28 at 7 42 09 PM" src="https://github.com/user-attachments/assets/53ef00cd-bd2f-427d-8081-6633f400cffd" />
<img width="798" alt="Screenshot 2025-02-28 at 7 42 31 PM" src="https://github.com/user-attachments/assets/9fa73f92-9aea-42e1-9490-e78df0950c4b" />
 
## After
<img width="713" alt="Screenshot 2025-02-28 at 7 09 04 PM" src="https://github.com/user-attachments/assets/f991f9bb-0961-473c-9429-c410982cc461" />
<img width="936" alt="Screenshot 2025-02-28 at 7 09 32 PM" src="https://github.com/user-attachments/assets/4893068c-2025-4201-b8c2-8606739a9450" />

Also adds tests for those diagnostics.