### PR TITLE
Validate that ProtoId values are not abstract

### DIFF
--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
@@ -25,7 +25,7 @@ public sealed class EntProtoIdSerializer : ITypeSerializer<EntProtoId, ValueData
         if (prototypes.TryGetKindFrom<EntityPrototype>(out _) && prototypes.HasMapping<EntityPrototype>(node.Value))
         {
             if (!prototypes.TryIndex<EntityPrototype>(node.Value, out _))
-                return new ErrorNode(node, $"{typeof(EntityPrototype)} {node.Value} is abstract!");
+                return new ErrorNode(node, $"{nameof(EntityPrototype)} {node.Value} is abstract!");
 
             return new ValidatedValueNode(node);
         }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
@@ -24,7 +24,7 @@ public sealed class EntProtoIdSerializer : ITypeSerializer<EntProtoId, ValueData
         var prototypes = dependencies.Resolve<IPrototypeManager>();
         if (prototypes.TryGetKindFrom<EntityPrototype>(out _) && prototypes.HasMapping<EntityPrototype>(node.Value))
         {
-            if (!prototypes.TryIndex<EntityPrototype>(node.Value, out _))
+            if (!prototypes.HasIndex<EntityPrototype>(node.Value))
                 return new ErrorNode(node, $"{nameof(EntityPrototype)} {node.Value} is abstract!");
 
             return new ValidatedValueNode(node);

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
@@ -23,7 +23,12 @@ public sealed class EntProtoIdSerializer : ITypeSerializer<EntProtoId, ValueData
     {
         var prototypes = dependencies.Resolve<IPrototypeManager>();
         if (prototypes.TryGetKindFrom<EntityPrototype>(out _) && prototypes.HasMapping<EntityPrototype>(node.Value))
+        {
+            if (!prototypes.TryIndex<EntityPrototype>(node.Value, out _))
+                return new ErrorNode(node, $"{typeof(EntityPrototype)} {node.Value} is abstract!");
+
             return new ValidatedValueNode(node);
+        }
 
         return new ErrorNode(node, $"No {nameof(EntityPrototype)} found with id {node.Value}");
     }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
@@ -22,7 +22,7 @@ public sealed class EntProtoIdSerializer : ITypeSerializer<EntProtoId, ValueData
     public ValidationNode Validate(ISerializationManager serialization, ValueDataNode node, IDependencyCollection dependencies, ISerializationContext? context = null)
     {
         var prototypes = dependencies.Resolve<IPrototypeManager>();
-        if (prototypes.TryGetKindFrom<EntityPrototype>(out _) && prototypes.HasMapping<EntityPrototype>(node.Value))
+        if (prototypes.TryGetKindFrom<EntityPrototype>(out _))
         {
             if (!prototypes.HasIndex<EntityPrototype>(node.Value))
                 return new ErrorNode(node, $"{nameof(EntityPrototype)} {node.Value} is abstract!");

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ProtoIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ProtoIdSerializer.cs
@@ -20,7 +20,7 @@ public sealed class ProtoIdSerializer<T> : ITypeSerializer<ProtoId<T>, ValueData
     public ValidationNode Validate(ISerializationManager serialization, ValueDataNode node, IDependencyCollection dependencies, ISerializationContext? context = null)
     {
         var prototypes = dependencies.Resolve<IPrototypeManager>();
-        if (prototypes.TryGetKindFrom<T>(out _) && prototypes.HasMapping<T>(node.Value))
+        if (prototypes.TryGetKindFrom<T>(out _))
         {
             if (!prototypes.HasIndex<T>(node.Value))
                 return new ErrorNode(node, $"{typeof(T)} {node.Value} is abstract!");

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ProtoIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ProtoIdSerializer.cs
@@ -21,7 +21,12 @@ public sealed class ProtoIdSerializer<T> : ITypeSerializer<ProtoId<T>, ValueData
     {
         var prototypes = dependencies.Resolve<IPrototypeManager>();
         if (prototypes.TryGetKindFrom<T>(out _) && prototypes.HasMapping<T>(node.Value))
+        {
+            if (!prototypes.TryIndex<T>(node.Value, out _))
+                return new ErrorNode(node, $"{typeof(T)} {node.Value} is abstract!");
+
             return new ValidatedValueNode(node);
+        }
 
         return new ErrorNode(node, $"No {typeof(T)} found with id {node.Value}");
     }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ProtoIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ProtoIdSerializer.cs
@@ -22,7 +22,7 @@ public sealed class ProtoIdSerializer<T> : ITypeSerializer<ProtoId<T>, ValueData
         var prototypes = dependencies.Resolve<IPrototypeManager>();
         if (prototypes.TryGetKindFrom<T>(out _) && prototypes.HasMapping<T>(node.Value))
         {
-            if (!prototypes.TryIndex<T>(node.Value, out _))
+            if (!prototypes.HasIndex<T>(node.Value))
                 return new ErrorNode(node, $"{typeof(T)} {node.Value} is abstract!");
 
             return new ValidatedValueNode(node);


### PR DESCRIPTION
Adds an extra validation step to `ProtoId<T>` and `EntProtoId` which makes sure that the prototype is not abstract. This lets YAML linter prevent attempts to spawn abstract prototypes (example: https://github.com/space-wizards/space-station-14/pull/35562)

If there's a valid reason to have a `ProtoId` field for an abstract prototype, then go ahead and close this. I can't think of one, and there don't seem to be any existing uses of it.