### PR TITLE
Add Regex.Count and StringBuilder.set_Chars to sandbox whitelist

### DIFF
--- a/Robust.Shared/ContentPack/Sandbox.yml
+++ b/Robust.Shared/ContentPack/Sandbox.yml
@@ -736,6 +736,15 @@ Types:
       - "void .ctor(string)"
       - "void .ctor(string, System.Text.RegularExpressions.RegexOptions)"
       - "void .ctor(string, System.Text.RegularExpressions.RegexOptions, System.TimeSpan)"
+      - "int Count(string)"
+      - "int Count(System.ReadOnlySpan`1<char>)"
+      - "int Count(System.ReadOnlySpan`1<char>, int)"
+      - "int Count(string, string)"
+      - "int Count(string, string, System.Text.RegularExpressions.RegexOptions)"
+      - "int Count(string, string, System.Text.RegularExpressions.RegexOptions, System.TimeSpan)"
+      - "int Count(System.ReadOnlySpan`1<char>, string)"
+      - "int Count(System.ReadOnlySpan`1<char>, string, System.Text.RegularExpressions.RegexOptions)"
+      - "int Count(System.ReadOnlySpan`1<char>, string, System.Text.RegularExpressions.RegexOptions, System.TimeSpan)"
     RegexMatchTimeoutException: { All: True }
     RegexOptions: { } # Enum
     RegexParseError: { }
@@ -789,6 +798,7 @@ Types:
       - "bool Equals(System.ReadOnlySpan`1<char>)"
       - "bool Equals(System.Text.StringBuilder)"
       - "char get_Chars(int)"
+      - "void set_Chars(int, char)"
       - "int EnsureCapacity(int)"
       - "int get_Capacity()"
       - "int get_Length()"


### PR DESCRIPTION
Accent systems currently use these two functions, but since I'm moving accents from Content.Server to Content.Shared it's throwing sandbox violations for the client.
To clarify, `set_Chars` is invoked as `stringBuilder[i] = char`

They don't seem dangerous to whitelist, but if they are, feel free to yell at me for this PR.