### PR TITLE
Cleanup: Remove redundant Prototype names

### DIFF
--- a/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
+++ b/Robust.Client/Graphics/Shaders/ShaderPrototype.cs
@@ -16,7 +16,7 @@ using Vector4 = Robust.Shared.Maths.Vector4;
 
 namespace Robust.Client.Graphics
 {
-    [Prototype("shader")]
+    [Prototype]
     public sealed partial class ShaderPrototype : IPrototype, ISerializationHooks
     {
         [ViewVariables]

--- a/Robust.Client/UserInterface/RichText/FontPrototype.cs
+++ b/Robust.Client/UserInterface/RichText/FontPrototype.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Utility;
 
 namespace Robust.Client.UserInterface.RichText;
 
-[Prototype("font")]
+[Prototype]
 public sealed partial class FontPrototype : IPrototype
 {
     [IdDataField]

--- a/Robust.Shared/Audio/AudioMetadataPrototype.cs
+++ b/Robust.Shared/Audio/AudioMetadataPrototype.cs
@@ -9,7 +9,9 @@ namespace Robust.Shared.Audio;
 /// These prototypes get automatically generated when packaging the server,
 /// to allow the server to know audio lengths without shipping the large audio files themselves.
 /// </summary>
+#pragma warning disable RA0035 // Redundant Prototype Type specification
 [Prototype(ProtoName)]
+#pragma warning restore RA0035 // Redundant Prototype Type specification
 public sealed partial class AudioMetadataPrototype : IPrototype
 {
     public const string ProtoName = "audioMetadata";

--- a/Robust.Shared/Audio/AudioMetadataPrototype.cs
+++ b/Robust.Shared/Audio/AudioMetadataPrototype.cs
@@ -9,9 +9,7 @@ namespace Robust.Shared.Audio;
 /// These prototypes get automatically generated when packaging the server,
 /// to allow the server to know audio lengths without shipping the large audio files themselves.
 /// </summary>
-#pragma warning disable RA0035 // Redundant Prototype Type specification
 [Prototype(ProtoName)]
-#pragma warning restore RA0035 // Redundant Prototype Type specification
 public sealed partial class AudioMetadataPrototype : IPrototype
 {
     public const string ProtoName = "audioMetadata";

--- a/Robust.Shared/Audio/AudioMetadataPrototype.cs
+++ b/Robust.Shared/Audio/AudioMetadataPrototype.cs
@@ -9,7 +9,7 @@ namespace Robust.Shared.Audio;
 /// These prototypes get automatically generated when packaging the server,
 /// to allow the server to know audio lengths without shipping the large audio files themselves.
 /// </summary>
-[Prototype]
+[Prototype(ProtoName)]
 public sealed partial class AudioMetadataPrototype : IPrototype
 {
     public const string ProtoName = "audioMetadata";

--- a/Robust.Shared/Audio/AudioMetadataPrototype.cs
+++ b/Robust.Shared/Audio/AudioMetadataPrototype.cs
@@ -9,7 +9,7 @@ namespace Robust.Shared.Audio;
 /// These prototypes get automatically generated when packaging the server,
 /// to allow the server to know audio lengths without shipping the large audio files themselves.
 /// </summary>
-[Prototype(ProtoName)]
+[Prototype]
 public sealed partial class AudioMetadataPrototype : IPrototype
 {
     public const string ProtoName = "audioMetadata";

--- a/Robust.Shared/Audio/AudioPresetPrototype.cs
+++ b/Robust.Shared/Audio/AudioPresetPrototype.cs
@@ -8,7 +8,7 @@ namespace Robust.Shared.Audio;
 /// Contains audio defaults to set for sounds.
 /// This can be used by <see cref="Content.Shared.Audio.SharedContentAudioSystem"/> to apply an audio preset.
 /// </summary>
-[Prototype("audioPreset")]
+[Prototype]
 public sealed partial class AudioPresetPrototype : IPrototype
 {
     [IdDataField]

--- a/Robust.Shared/Audio/SoundCollectionPrototype.cs
+++ b/Robust.Shared/Audio/SoundCollectionPrototype.cs
@@ -6,7 +6,7 @@ using Robust.Shared.ViewVariables;
 
 namespace Robust.Shared.Audio;
 
-[Prototype("soundCollection")]
+[Prototype]
 public sealed partial class SoundCollectionPrototype : IPrototype
 {
     [ViewVariables]

--- a/Robust.Shared/Prototypes/EntityCategoryPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityCategoryPrototype.cs
@@ -9,7 +9,7 @@ namespace Robust.Shared.Prototypes;
 /// Prototype that represents some entity prototype category.
 /// Useful for sorting or grouping entity prototypes for mapping/spawning UIs.
 /// </summary>
-[Prototype("entityCategory")]
+[Prototype]
 public sealed partial class EntityCategoryPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -21,7 +21,7 @@ namespace Robust.Shared.Prototypes
     /// <summary>
     /// Prototype that represents game entities.
     /// </summary>
-    [Prototype("entity", -1)]
+    [Prototype(-1)]
     public sealed partial class EntityPrototype : IPrototype, IInheritingPrototype, ISerializationHooks
     {
         private ILocalizationManager _loc = default!;

--- a/Robust.Shared/Prototypes/TileAliasPrototype.cs
+++ b/Robust.Shared/Prototypes/TileAliasPrototype.cs
@@ -6,7 +6,7 @@ namespace Robust.Shared.Prototypes;
 /// <summary>
 /// Prototype that represents an alias from one tile ID to another. These are used when deserializing entities from yaml.
 /// </summary>
-[Prototype("tileAlias")]
+[Prototype]
 public sealed partial class TileAliasPrototype : IPrototype
 {
     /// <summary>


### PR DESCRIPTION
Removes manually-specified name strings from all Prototype attributes where the autogenerated name would match.

Yes, this was just using #5718 and selecting Fix All -> Solution

~`AudioMetadataPrototype` was allowed to stay redundant since it's pulled from a const value which is used elsewhere and it's important that those values match.~ the analyzer has been updated so it permits redundancy if the attribute argument is not a string literal.