### PR TITLE
Remove unused private members/local vars

### DIFF
--- a/Robust.Client/UserInterface/Controls/LineEdit.cs
+++ b/Robust.Client/UserInterface/Controls/LineEdit.cs
@@ -21,7 +21,6 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class LineEdit : Control
     {
-        [Dependency] private readonly IClyde _clyde = default!;
         [Dependency] private readonly IConfigurationManager _cfgManager = default!;
         [Dependency] private readonly IGameTiming _timing = default!;
 

--- a/Robust.Client/UserInterface/Controls/TextEdit.cs
+++ b/Robust.Client/UserInterface/Controls/TextEdit.cs
@@ -38,7 +38,6 @@ namespace Robust.Client.UserInterface.Controls;
 public sealed class TextEdit : Control
 {
     [Dependency] private readonly IClipboardManager _clipboard = null!;
-    [Dependency] private readonly IClyde _clyde = null!;
 
     // @formatter:off
     public const string StylePropertyCursorColor    = "cursor-color";

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
@@ -22,7 +22,6 @@ namespace Robust.Shared.GameObjects
         [Dependency] private readonly FixtureSystem _fixtures = default!;
         [Dependency] private readonly SharedPhysicsSystem _physics = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
-        [Dependency] private readonly IComponentFactory _factory = default!;
         [Dependency] private readonly MetaDataSystem _meta = default!;
 
         private EntityQuery<FixturesComponent> _fixturesQuery;

--- a/Robust.Shared/Map/TileDefinitionManager.cs
+++ b/Robust.Shared/Map/TileDefinitionManager.cs
@@ -10,7 +10,6 @@ namespace Robust.Shared.Map
     [Virtual]
     internal class TileDefinitionManager : ITileDefinitionManager
     {
-        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         protected readonly List<ITileDefinition> TileDefs;
         private readonly Dictionary<string, ITileDefinition> _tileNames;
         private readonly Dictionary<string, List<string>> _awaitingAliases;

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs
@@ -35,7 +35,6 @@ namespace Robust.Shared.Physics.Systems
         public bool TryCollideRect(Box2 collider, MapId mapId, bool approximate = true)
         {
             var state = (collider, mapId, found: false);
-            var broadphases = new ValueList<Entity<BroadphaseComponent>>();
 
             _broadphase.GetBroadphases(mapId,
                 collider,


### PR DESCRIPTION
They weren't doing anything other than throwing warnings every time we compile.