### PR TITLE
Surround BUI Open/Dispose calls in try/catch blocks.

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -1064,11 +1064,11 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
             {
                 if (open)
                 {
-                    bui.Open();
 #if EXCEPTION_TOLERANCE
                     try
                     {
 #endif
+                    bui.Open();
 
                     if (UIQuery.TryComp(bui.Owner, out var uiComp))
                     {
@@ -1096,8 +1096,20 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
                         uiComp.ClientOpenInterfaces.Remove(bui.UiKey);
                     }
 
+#if EXCEPTION_TOLERANCE
+                    try
+                    {
+#endif
                     SavePosition(bui);
                     bui.Dispose();
+#if EXCEPTION_TOLERANCE
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Error(
+                            $"Caught exception while attempting to dispose of a BUI {bui.UiKey} with type {bui.GetType()} on entity {ToPrettyString(bui.Owner)}. Exception: {e}");
+                    }
+#endif
                 }
             }
 


### PR DESCRIPTION
Pushes BUI Open/Dispose calls into try/catch blocks.

Should resolve https://github.com/space-wizards/space-station-14/issues/35494, https://github.com/space-wizards/space-station-14/issues/35542 and https://github.com/space-wizards/space-station-14/issues/35528.

If any operation in this fails, the queued BUI open/close list should still be cleared - no repeated open or close calls.