### PR TITLE
Reduce EntityManager.IsDefault allocations

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -208,9 +208,7 @@ namespace Robust.Shared.GameObjects
                     return false;
                 }
 
-                var diff = compMapping.Except(protoMapping);
-
-                if (diff != null && diff.Children.Count != 0)
+                if (compMapping.AnyExcept(protoMapping))
                     return false;
             }
 

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -189,9 +189,11 @@ namespace Robust.Shared.GameObjects
                     return false;
 
                 var compType = component.GetType();
-                var compName = _componentFactory.GetComponentName(compType);
-                if (compName == _xformName || compName == _metaReg.Name)
+
+                if (compType == typeof(TransformComponent) || compType == typeof(MetaDataComponent))
                     continue;
+
+                var compName = _componentFactory.GetComponentName(compType);
 
                 // If the component isn't on the prototype then it's custom.
                 if (!protoData.TryGetValue(compName, out var protoMapping))

--- a/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNode.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -350,6 +351,29 @@ namespace Robust.Shared.Serialization.Markdown.Mapping
             }
 
             return mappingNode._children.Count == 0 ? null : mappingNode;
+        }
+
+        /// <summary>
+        /// Returns true if there are any nodes on this node that aren't in the other node.
+        /// </summary>
+        [Pure]
+        public bool AnyExcept(MappingDataNode node)
+        {
+            foreach (var (key, val) in _list)
+            {
+                var other = node._list.FirstOrNull(p => p.Key.Equals(key));
+
+                if (other == null)
+                {
+                    return true;
+                }
+
+                // We only keep the entry if the values are not equal
+                if (!val.Equals(other.Value.Value))
+                    return true;
+            }
+
+            return false;
         }
 
         public override bool Equals(object? obj)


### PR DESCRIPTION
We don't actually need the MappingDataNode so we can avoid allocating the entire class per entity.