### PR TITLE
Replace deprecated mapManager methods with the mapSystem API

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
@@ -30,7 +30,8 @@ namespace Robust.Client.Graphics.Clyde
         private void _drawGrids(Viewport viewport, Box2 worldAABB, Box2Rotated worldBounds, IEye eye)
         {
             var mapId = eye.Position.MapId;
-            if (!_mapManager.MapExists(mapId))
+            var mapSystem = _entityManager.System<SharedMapSystem>();
+            if (!mapSystem.MapExists(mapId))
             {
                 // fall back to nullspace map
                 mapId = MapId.Nullspace;
@@ -42,7 +43,6 @@ namespace Robust.Client.Graphics.Clyde
             var requiresFlush = true;
             GLShaderProgram gridProgram = default!;
             var gridOverlays = GetOverlaysForSpace(OverlaySpace.WorldSpaceGrids);
-            var mapSystem = _entityManager.System<SharedMapSystem>();
 
             foreach (var mapGrid in _grids)
             {

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -126,7 +126,7 @@ namespace Robust.Client.Graphics.Clyde
             DebugTools.Assert(space != OverlaySpace.ScreenSpaceBelowWorld && space != OverlaySpace.ScreenSpace);
 
             var mapId = vp.Eye!.Position.MapId;
-            var args = new OverlayDrawArgs(space, null, vp, _renderHandle, new UIBox2i((0, 0), vp.Size), _mapSystem.GetMapOrInvalid(mapId), mapId, worldBox, worldBounds);
+            var args = new OverlayDrawArgs(space, null, vp, _renderHandle, new UIBox2i((0, 0), vp.Size), _mapSystem.GetMap(mapId), mapId, worldBox, worldBounds);
 
             if (!overlay.BeforeDraw(args))
                 return;
@@ -178,7 +178,7 @@ namespace Robust.Client.Graphics.Clyde
             var worldAABB = worldBounds.CalcBoundingBox();
             var mapId = vp.Eye!.Position.MapId;
 
-            var args = new OverlayDrawArgs(space, vpControl, vp, handle, bounds, _mapSystem.GetMapOrInvalid(mapId), mapId, worldAABB, worldBounds);
+            var args = new OverlayDrawArgs(space, vpControl, vp, handle, bounds, _mapSystem.GetMap(mapId), mapId, worldAABB, worldBounds);
 
             foreach (var overlay in list)
             {

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -126,7 +126,7 @@ namespace Robust.Client.Graphics.Clyde
             DebugTools.Assert(space != OverlaySpace.ScreenSpaceBelowWorld && space != OverlaySpace.ScreenSpace);
 
             var mapId = vp.Eye!.Position.MapId;
-            var args = new OverlayDrawArgs(space, null, vp, _renderHandle, new UIBox2i((0, 0), vp.Size), _mapSystem.GetMap(mapId), mapId, worldBox, worldBounds);
+            var args = new OverlayDrawArgs(space, null, vp, _renderHandle, new UIBox2i((0, 0), vp.Size), _mapSystem.GetMapOrInvalid(mapId), mapId, worldBox, worldBounds);
 
             if (!overlay.BeforeDraw(args))
                 return;
@@ -178,7 +178,7 @@ namespace Robust.Client.Graphics.Clyde
             var worldAABB = worldBounds.CalcBoundingBox();
             var mapId = vp.Eye!.Position.MapId;
 
-            var args = new OverlayDrawArgs(space, vpControl, vp, handle, bounds, _mapSystem.GetMap(mapId), mapId, worldAABB, worldBounds);
+            var args = new OverlayDrawArgs(space, vpControl, vp, handle, bounds, _mapSystem.GetMapOrInvalid(mapId), mapId, worldAABB, worldBounds);
 
             foreach (var overlay in list)
             {

--- a/Robust.Shared/Console/Commands/MapCommands.cs
+++ b/Robust.Shared/Console/Commands/MapCommands.cs
@@ -25,7 +25,7 @@ sealed class AddMapCommand : LocalizedEntityCommands
         if (!_mapSystem.MapExists(mapId))
         {
             var init = args.Length < 2 || !bool.Parse(args[1]);
-            EntityManager.System<SharedMapSystem>().CreateMap(mapId, runMapInit: init);
+            _mapSystem.CreateMap(mapId, runMapInit: init);
 
             shell.WriteLine($"Map with ID {mapId} created.");
             return;
@@ -37,7 +37,9 @@ sealed class AddMapCommand : LocalizedEntityCommands
 
 sealed class RemoveMapCommand : LocalizedCommands
 {
-    [Dependency] private readonly IMapManager _map = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+
+    private SharedMapSystem _mapSystem => _entityManager.System<SharedMapSystem>();
 
     public override string Command => "rmmap";
     public override bool RequireServerOrSingleplayer => true;
@@ -52,13 +54,13 @@ sealed class RemoveMapCommand : LocalizedCommands
 
         var mapId = new MapId(int.Parse(args[0]));
 
-        if (!_map.MapExists(mapId))
+        if (!_mapSystem.MapExists(mapId))
         {
             shell.WriteError($"Map {mapId.Value} does not exist.");
             return;
         }
 
-        _map.DeleteMap(mapId);
+        _mapSystem.DeleteMap(mapId);
         shell.WriteLine($"Map {mapId.Value} was removed.");
     }
 }

--- a/Robust.Shared/Console/Commands/TeleportCommands.cs
+++ b/Robust.Shared/Console/Commands/TeleportCommands.cs
@@ -20,6 +20,7 @@ internal sealed class TeleportCommand : LocalizedEntityCommands
     [Dependency] private readonly IMapManager _map = default!;
     [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedMapSystem _mapSystem = default!;
 
     public override string Command => "tp";
     public override bool RequireServerOrSingleplayer => true;
@@ -46,7 +47,7 @@ internal sealed class TeleportCommand : LocalizedEntityCommands
         else
             mapId = transform.MapID;
 
-        if (!_map.MapExists(mapId))
+        if (!_mapSystem.MapExists(mapId))
         {
             shell.WriteError($"Map {mapId} doesn't exist!");
             return;
@@ -60,7 +61,7 @@ internal sealed class TeleportCommand : LocalizedEntityCommands
         }
         else
         {
-            var mapEnt = _map.GetMapEntityIdOrThrow(mapId);
+            var mapEnt = _mapSystem.GetMap(mapId);
             _transform.SetWorldPosition((entity, transform), position);
             _transform.SetParent(entity, transform, mapEnt);
         }

--- a/Robust.Shared/Map/Commands/AmbientLightCommand.cs
+++ b/Robust.Shared/Map/Commands/AmbientLightCommand.cs
@@ -11,8 +11,7 @@ namespace Robust.Shared.Map.Commands;
 /// </summary>
 public sealed class AmbientLightCommand : IConsoleCommand
 {
-    [Dependency] private readonly IMapManager _mapManager = default!;
-    [Dependency] private readonly IEntitySystemManager _systems = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!;
 
     public string Command => $"setambientlight";
     public string Description => Loc.GetString("cmd-set-ambient-light-desc");
@@ -33,7 +32,9 @@ public sealed class AmbientLightCommand : IConsoleCommand
 
         var mapId = new MapId(mapInt);
 
-        if (!_mapManager.MapExists(mapId))
+        var mapSystem = _entityManager.System<SharedMapSystem>();
+
+        if (!mapSystem.MapExists(mapId))
         {
             shell.WriteError(Loc.GetString("cmd-parse-failure-mapid"));
             return;
@@ -49,7 +50,6 @@ public sealed class AmbientLightCommand : IConsoleCommand
         }
 
         var color = Color.FromSrgb(new Color(r, g, b, a));
-        var mapSystem = _systems.GetEntitySystem<SharedMapSystem>();
         mapSystem.SetAmbientLight(mapId, color);
     }
 }

--- a/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
@@ -26,6 +26,7 @@ namespace Robust.Shared.Physics.Systems
         [Dependency] private readonly EntityLookupSystem _lookup = default!;
         [Dependency] private readonly SharedGridTraversalSystem _traversal = default!;
         [Dependency] private readonly SharedMapSystem _map = default!;
+        [Dependency] private readonly SharedMapSystem _mapSystem = default!;
         [Dependency] private readonly SharedPhysicsSystem _physicsSystem = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
 
@@ -196,7 +197,7 @@ namespace Robust.Shared.Physics.Systems
             if (moveBuffer.Count == 0)
                 return;
 
-            _contactJob.MapUid = _mapManager.GetMapEntityIdOrThrow(mapId);
+            _contactJob.MapUid = _mapSystem.GetMap(mapId);
             _contactJob.MoveBuffer.Clear();
 
             foreach (var (proxy, aabb) in moveBuffer)

--- a/Robust.UnitTesting/Server/GameObjects/ComponentMapInitTest.cs
+++ b/Robust.UnitTesting/Server/GameObjects/ComponentMapInitTest.cs
@@ -27,7 +27,9 @@ public sealed partial class ComponentMapInitTest
         var sim = simFactory.InitializeInstance();
         var entManager = sim.Resolve<IEntityManager>();
         var mapManager = sim.Resolve<IMapManager>();
-        sim.Resolve<IEntityManager>().System<SharedMapSystem>().CreateMap(out var mapId);
+        var mapSystem = entManager.System<SharedMapSystem>();
+
+        mapSystem.CreateMap(out var mapId);
 
         var ent = entManager.SpawnEntity(null, new MapCoordinates(Vector2.Zero, mapId));
         Assert.That(entManager.GetComponent<MetaDataComponent>(ent).EntityLifeStage, Is.EqualTo(EntityLifeStage.MapInitialized));
@@ -36,7 +38,7 @@ public sealed partial class ComponentMapInitTest
 
         Assert.That(comp.Count, Is.EqualTo(1));
 
-        mapManager.DeleteMap(mapId);
+        mapSystem.DeleteMap(mapId);
     }
 
     [Reflect(false)]

--- a/Robust.UnitTesting/Shared/EntityLookup_Test.cs
+++ b/Robust.UnitTesting/Shared/EntityLookup_Test.cs
@@ -102,7 +102,7 @@ namespace Robust.UnitTesting.Shared
             var outcome = lookup.AnyLocalEntitiesIntersecting(grid.Owner, queryBounds, LookupFlags.All);
 
             Assert.That(outcome, Is.EqualTo(result));
-            mapManager.DeleteMap(spawnPos.MapId);
+            mapSystem.DeleteMap(spawnPos.MapId);
         }
 
         [Test, TestCaseSource(nameof(Box2Cases))]
@@ -127,7 +127,7 @@ namespace Robust.UnitTesting.Shared
             var outcome = lookup.AnyLocalEntitiesIntersecting(grid.Owner, queryBounds, LookupFlags.All);
 
             Assert.That(outcome, Is.EqualTo(result));
-            mapManager.DeleteMap(spawnPos.MapId);
+            mapSystem.DeleteMap(spawnPos.MapId);
         }
 
         /// <summary>
@@ -156,7 +156,7 @@ namespace Robust.UnitTesting.Shared
             lookup.GetLocalEntitiesIntersecting(grid.Owner, queryBounds, entities);
 
             Assert.That(entities.Count > 0, Is.EqualTo(result));
-            mapManager.DeleteMap(spawnPos.MapId);
+            mapSystem.DeleteMap(spawnPos.MapId);
         }
 
         /// <summary>
@@ -185,7 +185,7 @@ namespace Robust.UnitTesting.Shared
             lookup.GetLocalEntitiesIntersecting(grid.Owner, queryTile, entities);
 
             Assert.That(entities.Count > 0, Is.EqualTo(result));
-            mapManager.DeleteMap(spawnPos.MapId);
+            mapSystem.DeleteMap(spawnPos.MapId);
         }
 
         #endregion
@@ -201,6 +201,7 @@ namespace Robust.UnitTesting.Shared
             var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
             var entManager = server.Resolve<IEntityManager>();
             var mapManager = server.Resolve<IMapManager>();
+            var mapSystem = entManager.System<SharedMapSystem>();
 
             entManager.System<SharedMapSystem>().CreateMap(spawnPos.MapId);
 
@@ -210,7 +211,7 @@ namespace Robust.UnitTesting.Shared
                 entManager.Spawn(null, spawnPos);
 
             Assert.That(lookup.GetEntitiesInRange(queryPos.MapId, queryPos.Position, range).Count > 0, Is.EqualTo(result));
-            mapManager.DeleteMap(spawnPos.MapId);
+            mapSystem.DeleteMap(spawnPos.MapId);
         }
 
         [Test, TestCaseSource(nameof(IntersectingCases))]
@@ -236,7 +237,7 @@ namespace Robust.UnitTesting.Shared
             var bounds = new Box2Rotated(Box2.CenteredAround(queryPos.Position, new Vector2(range, range)));
 
             Assert.That(lookup.GetEntitiesIntersecting(queryPos.MapId, bounds).Count > 0, Is.EqualTo(result));
-            mapManager.DeleteMap(spawnPos.MapId);
+            mapSystem.DeleteMap(spawnPos.MapId);
         }
 
         [Test, TestCaseSource(nameof(InRangeCases))]
@@ -260,7 +261,7 @@ namespace Robust.UnitTesting.Shared
 
             _ = entManager.SpawnEntity(null, spawnPos);
             Assert.That(lookup.GetEntitiesInRange(queryPos.MapId, queryPos.Position, range).Count > 0, Is.EqualTo(result));
-            mapManager.DeleteMap(spawnPos.MapId);
+            mapSystem.DeleteMap(spawnPos.MapId);
         }
 
         [Test, TestCaseSource(nameof(InRangeCases))]
@@ -272,6 +273,7 @@ namespace Robust.UnitTesting.Shared
             var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
             var entManager = server.Resolve<IEntityManager>();
             var mapManager = server.Resolve<IMapManager>();
+            var mapSystem = entManager.System<SharedMapSystem>();
 
             entManager.System<SharedMapSystem>().CreateMap(spawnPos.MapId);
 
@@ -281,7 +283,7 @@ namespace Robust.UnitTesting.Shared
                 entManager.Spawn(null, spawnPos);
 
             Assert.That(lookup.GetEntitiesInRange(queryPos.MapId, queryPos.Position, range).Count > 0, Is.EqualTo(result));
-            mapManager.DeleteMap(spawnPos.MapId);
+            mapSystem.DeleteMap(spawnPos.MapId);
         }
 
         /// <summary>
@@ -309,7 +311,7 @@ namespace Robust.UnitTesting.Shared
             var outcome = lookup.AnyLocalEntitiesIntersecting(grid.Owner, queryBounds, LookupFlags.All);
 
             Assert.That(outcome, Is.EqualTo(result));
-            mapManager.DeleteMap(spawnPos.MapId);
+            mapSystem.DeleteMap(spawnPos.MapId);
         }
 
         /// <summary>
@@ -338,7 +340,7 @@ namespace Robust.UnitTesting.Shared
             lookup.GetLocalEntitiesIntersecting(grid.Owner, queryBounds, entities);
 
             Assert.That(entities.Count > 0, Is.EqualTo(result));
-            mapManager.DeleteMap(spawnPos.MapId);
+            mapSystem.DeleteMap(spawnPos.MapId);
         }
 
         #endregion
@@ -383,7 +385,7 @@ namespace Robust.UnitTesting.Shared
 
             entManager.DeleteEntity(dummy);
             entManager.DeleteEntity(grid);
-            mapManager.DeleteMap(mapId);
+            mapSystem.DeleteMap(mapId);
         }
     }
 }

--- a/Robust.UnitTesting/Shared/GameObjects/IEntityManagerTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/IEntityManagerTests.cs
@@ -40,12 +40,13 @@ namespace Robust.UnitTesting.Shared.GameObjects
 
             var entManager = sim.Resolve<IEntityManager>();
             var mapManager = sim.Resolve<IMapManager>();
+            var mapSystem = entManager.System<SharedMapSystem>();
 
             Assert.That(entManager.Count<TransformComponent>(), Is.EqualTo(0));
 
             var mapId = sim.CreateMap().MapId;
             Assert.That(entManager.Count<TransformComponent>(), Is.EqualTo(1));
-            mapManager.DeleteMap(mapId);
+            mapSystem.DeleteMap(mapId);
             Assert.That(entManager.Count<TransformComponent>(), Is.EqualTo(0));
         }
     }

--- a/Robust.UnitTesting/Shared/Map/MapManager_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/MapManager_Tests.cs
@@ -27,12 +27,13 @@ namespace Robust.UnitTesting.Shared.Map
         {
             var sim = SimulationFactory();
             var mapMan = sim.Resolve<IMapManager>();
+            var mapSystem = sim.Resolve<IEntitySystemManager>().GetEntitySystem<SharedMapSystem>();
 
             var mapID = sim.CreateMap().MapId;
 
             mapMan.Restart();
 
-            Assert.That(mapMan.MapExists(mapID), Is.False);
+            Assert.That(mapSystem.MapExists(mapID), Is.False);
         }
 
         /// <summary>

--- a/Robust.UnitTesting/Shared/Physics/Collision_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Collision_Test.cs
@@ -25,6 +25,7 @@ using System.Numerics;
 using NUnit.Framework;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Collision.Shapes;
@@ -122,12 +123,15 @@ public sealed class Collision_Test
     {
         var sim = RobustServerSimulation.NewSimulation().InitializeInstance();
         var entManager = sim.Resolve<IEntityManager>();
-        var mapManager = sim.Resolve<IMapManager>();
+        var mapSystem = entManager.System<SharedMapSystem>();
         var fixtures = entManager.System<FixtureSystem>();
         var physics = entManager.System<SharedPhysicsSystem>();
         var xformSystem = entManager.System<SharedTransformSystem>();
-        var mapId = sim.CreateMap().MapId;
-        var mapId2 = sim.CreateMap().MapId;
+
+        var mapUid = mapSystem.CreateMap();
+        var mapId = entManager.GetComponent<MapComponent>(mapUid).MapId;
+        var mapUid2 = mapSystem.CreateMap();
+        var mapId2 = entManager.GetComponent<MapComponent>(mapUid).MapId;
 
         var ent1 = entManager.SpawnEntity(null, new MapCoordinates(Vector2.Zero, mapId));
         var ent2 = entManager.SpawnEntity(null, new MapCoordinates(Vector2.Zero, mapId));
@@ -151,7 +155,7 @@ public sealed class Collision_Test
         Assert.That(body1.ContactCount == 1 && body2.ContactCount == 1);
 
         // Reparent body2 and assert the contact is destroyed
-        xformSystem.SetParent(ent2, mapManager.GetMapEntityId(mapId2));
+        xformSystem.SetParent(ent2, mapUid2);
         physics.Update(0.01f);
 
         Assert.That(body1.ContactCount == 0 && body2.ContactCount == 0);

--- a/Robust.UnitTesting/Shared/Physics/Fixtures_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Fixtures_Test.cs
@@ -20,13 +20,13 @@ public sealed class Fixtures_Test
         var sim = RobustServerSimulation.NewSimulation().InitializeInstance();
 
         var entManager = sim.Resolve<IEntityManager>();
-        var mapManager = sim.Resolve<IMapManager>();
+        var mapSystem = entManager.System<SharedMapSystem>();
         var sysManager = sim.Resolve<IEntitySystemManager>();
         var fixturesSystem = sysManager.GetEntitySystem<FixtureSystem>();
         var physicsSystem = sysManager.GetEntitySystem<SharedPhysicsSystem>();
-        var map = sim.CreateMap().MapId;
+        var mapId = sim.CreateMap().MapId;
 
-        var ent = sim.SpawnEntity(null, new MapCoordinates(Vector2.Zero, map));
+        var ent = sim.SpawnEntity(null, new MapCoordinates(Vector2.Zero, mapId));
         var body = entManager.AddComponent<PhysicsComponent>(ent);
         physicsSystem.SetBodyType(ent, BodyType.Dynamic, body: body);
         var fixture = new Fixture();
@@ -36,6 +36,6 @@ public sealed class Fixtures_Test
         Assert.That(fixture.Density, Is.EqualTo(10f));
         Assert.That(body.Mass, Is.EqualTo(10f));
 
-        mapManager.DeleteMap(map);
+        mapSystem.DeleteMap(mapId);
     }
 }

--- a/Robust.UnitTesting/Shared/Physics/Joints_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Joints_Test.cs
@@ -24,7 +24,7 @@ public sealed class Joints_Test
         var sim = factory.InitializeInstance();
 
         var entManager = sim.Resolve<IEntityManager>();
-        var mapManager = sim.Resolve<IMapManager>();
+        var mapSystem = entManager.System<SharedMapSystem>();
         var jointSystem = entManager.System<SharedJointSystem>();
 
         var mapId = sim.CreateMap().MapId;
@@ -53,7 +53,7 @@ public sealed class Joints_Test
             Assert.That(entManager.GetComponent<JointRelayTargetComponent>(uidC).Relayed, Is.Empty);
             Assert.That(entManager.GetComponent<JointComponent>(uidA).Relay, Is.EqualTo(null));
         });
-        mapManager.DeleteMap(mapId);
+        mapSystem.DeleteMap(mapId);
     }
 
     /// <summary>
@@ -65,7 +65,7 @@ public sealed class Joints_Test
         var factory = RobustServerSimulation.NewSimulation();
         var server = factory.InitializeInstance();
         var entManager = server.Resolve<IEntityManager>();
-        var mapManager = server.Resolve<IMapManager>();
+        var mapSystem = entManager.System<SharedMapSystem>();
         var fixtureSystem = entManager.EntitySysManager.GetEntitySystem<FixtureSystem>();
         var jointSystem = entManager.EntitySysManager.GetEntitySystem<JointSystem>();
         var broadphaseSystem = entManager.EntitySysManager.GetEntitySystem<SharedBroadphaseSystem>();
@@ -106,6 +106,6 @@ public sealed class Joints_Test
         broadphaseSystem.FindNewContacts(mapId);
         Assert.That(body1.Contacts, Has.Count.EqualTo(1));
 
-        mapManager.DeleteMap(mapId);
+        mapSystem.DeleteMap(mapId);
     }
 }

--- a/Robust.UnitTesting/Shared/Physics/PhysicsMap_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/PhysicsMap_Test.cs
@@ -23,21 +23,18 @@ public sealed class PhysicsMap_Test
     {
         var sim = RobustServerSimulation.NewSimulation().InitializeInstance();
         var entManager = sim.Resolve<IEntityManager>();
-        var mapManager = sim.Resolve<IMapManager>();
-        var system = entManager.EntitySysManager;
-        var physSystem = system.GetEntitySystem<SharedPhysicsSystem>();
-        var fixtureSystem = system.GetEntitySystem<FixtureSystem>();
-        var xformSystem = system.GetEntitySystem<SharedTransformSystem>();
+        var mapSystem = entManager.System<SharedMapSystem>();
+        var physSystem = entManager.System<SharedPhysicsSystem>();
+        var fixtureSystem = entManager.System<FixtureSystem>();
+        var xformSystem = entManager.System<SharedTransformSystem>();
 
-        var mapId = sim.CreateMap().MapId;
-        var mapId2 = sim.CreateMap().MapId;
-        var mapUid = mapManager.GetMapEntityId(mapId);
-        var mapUid2 = mapManager.GetMapEntityId(mapId2);
+        var mapUid = mapSystem.CreateMap();
+        var mapUid2 = mapSystem.CreateMap();
 
         var physicsMap = entManager.GetComponent<PhysicsMapComponent>(mapUid);
         var physicsMap2 = entManager.GetComponent<PhysicsMapComponent>(mapUid2);
 
-        var parent = entManager.SpawnEntity(null, new MapCoordinates(Vector2.Zero, mapId));
+        var parent = entManager.SpawnEntity(null, new EntityCoordinates(mapUid, Vector2.Zero));
         var parentXform = entManager.GetComponent<TransformComponent>(parent);
         var parentBody = entManager.AddComponent<PhysicsComponent>(parent);
 

--- a/Robust.UnitTesting/Shared/Spawning/SpawnInContainerOrDropTest.cs
+++ b/Robust.UnitTesting/Shared/Spawning/SpawnInContainerOrDropTest.cs
@@ -116,7 +116,11 @@ public sealed class SpawnInContainerOrDropTest : EntitySpawnHelpersTest
             Assert.That(xform.GridUid, Is.Null);
         });
 
-        await Server.WaitPost(() =>MapMan.DeleteMap(MapId));
+        await Server.WaitPost(() =>
+        {
+            var mapSystem = EntMan.System<SharedMapSystem>();
+            mapSystem.DeleteMap(MapId);
+        });
         Server.Dispose();
     }
 }

--- a/Robust.UnitTesting/Shared/Spawning/SpawnNextToOrDropTest.cs
+++ b/Robust.UnitTesting/Shared/Spawning/SpawnNextToOrDropTest.cs
@@ -121,7 +121,11 @@ public sealed class SpawnNextToOrDropTest : EntitySpawnHelpersTest
             Assert.That(EntMan.GetComponent<MetaDataComponent>(uid).EntityLifeStage, Is.LessThan(EntityLifeStage.MapInitialized));
         });
 
-        await Server.WaitPost(() =>MapMan.DeleteMap(MapId));
+        await Server.WaitPost(() =>
+        {
+            var mapSystem = EntMan.System<SharedMapSystem>();
+            mapSystem.DeleteMap(MapId);
+        });
         Server.Dispose();
     }
 }

--- a/Robust.UnitTesting/Shared/Spawning/TrySpawnInContainerTest.cs
+++ b/Robust.UnitTesting/Shared/Spawning/TrySpawnInContainerTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using NUnit.Framework;
+using Robust.Shared.GameObjects;
 
 namespace Robust.UnitTesting.Shared.Spawning;
 
@@ -42,7 +43,11 @@ public sealed class TrySpawnInContainerTest : EntitySpawnHelpersTest
             Assert.That(EntMan.EntityExists(uid), Is.False);
         });
 
-        await Server.WaitPost(() =>MapMan.DeleteMap(MapId));
+        await Server.WaitPost(() =>
+        {
+            var mapSystem = EntMan.System<SharedMapSystem>();
+            mapSystem.DeleteMap(MapId);
+        });
         Server.Dispose();
     }
 }

--- a/Robust.UnitTesting/Shared/Spawning/TrySpawnNextToTest.cs
+++ b/Robust.UnitTesting/Shared/Spawning/TrySpawnNextToTest.cs
@@ -50,7 +50,11 @@ public sealed class TrySpawnNextToTest : EntitySpawnHelpersTest
             Assert.That(EntMan.EntityExists(uid), Is.False);
         });
 
-        await Server.WaitPost(() =>MapMan.DeleteMap(MapId));
+        await Server.WaitPost(() =>
+        {
+            var mapSystem = EntMan.System<SharedMapSystem>();
+            mapSystem.DeleteMap(MapId);
+        });
         Server.Dispose();
     }
 }


### PR DESCRIPTION
In most places where `mapManager` was deprecated, it was replaced by `mapSystem`
(Attempt 2)
