### PR TITLE
add an extra assert to RemoveComponentDeferred

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -593,6 +593,15 @@ namespace Robust.Shared.GameObjects
                 return;
             }
 
+            // No shutdown logic for components that are before the Initializing stage
+            if (component.LifeStage < ComponentLifeStage.Initializing)
+            {
+                DebugTools.Assert("Tried to defer component removal on a pre-initialized component. Use RemoveComponent instead!");
+
+                // Could fall back to immediate removal?
+                return;
+            }
+
             if (!_deleteSet.Add(component))
             {
                 // already deferred deletion


### PR DESCRIPTION
adding components that are before the Initializing lifestage to the deleteSet means it will reach Running by the time we call CullRemovedComponents at the end of the tick and it will fail since we can't shut them down - LifeShutdown only works for components that are past the Added stage

those components should just be removed with regular RemComp which calls LifeRemoveFromEntity
it means they will be deleted immediately but it works with all components past PreAdd, as opposed to LifeShutdown
its an extremely rare scenario when we try to call RemCompDeferred on a component that hasn't initialized yet, but still something we should be handling