### PR TITLE
Add button to jump to live chat when scrolled up

### DIFF
--- a/Resources/Locale/en-US/custom-controls.ftl
+++ b/Resources/Locale/en-US/custom-controls.ftl
@@ -14,6 +14,10 @@ tile-spawn-window-title = Place Tiles
 
 console-line-edit-placeholder = Command Here
 
+## OutputPanel
+
+output-panel-scroll-down-button-text = Scroll Down
+
 ## Common Used
 
 window-erase-button-text = Erase Mode

--- a/Robust.Client/UserInterface/Controls/OutputPanel.cs
+++ b/Robust.Client/UserInterface/Controls/OutputPanel.cs
@@ -22,6 +22,8 @@ namespace Robust.Client.UserInterface.Controls
 
         public const string StylePropertyStyleBox = "stylebox";
 
+        public bool ShowScrollDownButton { get; set; } = false;
+
         private readonly RingBufferList<RichTextEntry> _entries = new();
         private bool _isAtBottom = true;
 
@@ -64,7 +66,7 @@ namespace Robust.Client.UserInterface.Controls
             _scrollBar.OnValueChanged += _ =>
             {
                 _isAtBottom = _scrollBar.IsAtEnd;
-                _scrollDownButton.Visible = !_isAtBottom;
+                _scrollDownButton.Visible = ShowScrollDownButton && !_isAtBottom;
             };
         }
 
@@ -206,7 +208,7 @@ namespace Robust.Client.UserInterface.Controls
             var styleBoxSize = _getStyleBox()?.MinimumSize.Y ?? 0;
 
             _scrollBar.Page = UIScale * (Height - styleBoxSize);
-            _scrollDownButton.Visible = !_scrollBar.IsAtEnd;
+            _scrollDownButton.Visible = ShowScrollDownButton && !_scrollBar.IsAtEnd;
             _invalidateEntries();
         }
 

--- a/Robust.Client/UserInterface/Controls/OutputPanel.cs
+++ b/Robust.Client/UserInterface/Controls/OutputPanel.cs
@@ -4,6 +4,7 @@ using Robust.Client.Graphics;
 using Robust.Client.UserInterface.RichText;
 using Robust.Shared.Collections;
 using Robust.Shared.IoC;
+using Robust.Shared.Localization;
 using Robust.Shared.Maths;
 using Robust.Shared.Utility;
 
@@ -26,6 +27,7 @@ namespace Robust.Client.UserInterface.Controls
         private bool _firstLine = true;
         private StyleBox? _styleBoxOverride;
         private VScrollBar _scrollBar;
+        private Button _scrollDownButton;
 
         public bool ScrollFollowing { get; set; } = true;
 
@@ -43,7 +45,25 @@ namespace Robust.Client.UserInterface.Controls
                 HorizontalAlignment = HAlignment.Right
             };
             AddChild(_scrollBar);
-            _scrollBar.OnValueChanged += _ => _isAtBottom = _scrollBar.IsAtEnd;
+
+            AddChild(_scrollDownButton = new Button()
+            {
+                Name = "scrollLiveBtn",
+                StyleClasses = { "chatScrollDownButton" },
+                VerticalAlignment = VAlignment.Bottom,
+                HorizontalAlignment = HAlignment.Center,
+                Text = String.Format("⬇    {0}    ⬇", Loc.GetString("hud-output-scroll-down")),
+                MaxWidth = 300,
+                Visible = false,
+            });
+
+            _scrollDownButton.OnPressed += _ => ScrollToBottom();
+
+            _scrollBar.OnValueChanged += _ =>
+            {
+                _isAtBottom = _scrollBar.IsAtEnd;
+                _scrollDownButton.Visible = !_isAtBottom;
+            };
         }
 
         public int EntryCount => _entries.Count;
@@ -184,6 +204,7 @@ namespace Robust.Client.UserInterface.Controls
             var styleBoxSize = _getStyleBox()?.MinimumSize.Y ?? 0;
 
             _scrollBar.Page = UIScale * (Height - styleBoxSize);
+            _scrollDownButton.Visible = !_scrollBar.IsAtEnd;
             _invalidateEntries();
         }
 

--- a/Robust.Client/UserInterface/Controls/OutputPanel.cs
+++ b/Robust.Client/UserInterface/Controls/OutputPanel.cs
@@ -66,7 +66,7 @@ namespace Robust.Client.UserInterface.Controls
             _scrollBar.OnValueChanged += _ =>
             {
                 _isAtBottom = _scrollBar.IsAtEnd;
-                _scrollDownButton.Visible = ShowScrollDownButton && !_isAtBottom;
+                _updateScrollButtonVisibility();
             };
         }
 
@@ -208,7 +208,7 @@ namespace Robust.Client.UserInterface.Controls
             var styleBoxSize = _getStyleBox()?.MinimumSize.Y ?? 0;
 
             _scrollBar.Page = UIScale * (Height - styleBoxSize);
-            _scrollDownButton.Visible = ShowScrollDownButton && !_scrollBar.IsAtEnd;
+            _updateScrollButtonVisibility();
             _invalidateEntries();
         }
 
@@ -308,6 +308,11 @@ namespace Robust.Client.UserInterface.Controls
                 _invalidateEntries();
                 _invalidOnVisible = false;
             }
+        }
+
+        private void _updateScrollButtonVisibility()
+        {
+            _scrollDownButton.Visible = ShowScrollDownButton && !_isAtBottom;
         }
     }
 }

--- a/Robust.Client/UserInterface/Controls/OutputPanel.cs
+++ b/Robust.Client/UserInterface/Controls/OutputPanel.cs
@@ -16,6 +16,8 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class OutputPanel : Control
     {
+        public const string StyleClassOutputPanelScrollDownButton = "outputPanelScrollDownButton";
+
         [Dependency] private readonly MarkupTagManager _tagManager = default!;
 
         public const string StylePropertyStyleBox = "stylebox";
@@ -49,7 +51,7 @@ namespace Robust.Client.UserInterface.Controls
             AddChild(_scrollDownButton = new Button()
             {
                 Name = "scrollLiveBtn",
-                StyleClasses = { "chatScrollDownButton" },
+                StyleClasses = { StyleClassOutputPanelScrollDownButton },
                 VerticalAlignment = VAlignment.Bottom,
                 HorizontalAlignment = HAlignment.Center,
                 Text = String.Format("⬇    {0}    ⬇", Loc.GetString("hud-output-scroll-down")),

--- a/Robust.Client/UserInterface/Controls/OutputPanel.cs
+++ b/Robust.Client/UserInterface/Controls/OutputPanel.cs
@@ -54,7 +54,7 @@ namespace Robust.Client.UserInterface.Controls
                 StyleClasses = { StyleClassOutputPanelScrollDownButton },
                 VerticalAlignment = VAlignment.Bottom,
                 HorizontalAlignment = HAlignment.Center,
-                Text = String.Format("⬇    {0}    ⬇", Loc.GetString("hud-output-scroll-down")),
+                Text = String.Format("⬇    {0}    ⬇", Loc.GetString("output-panel-scroll-down-button-text")),
                 MaxWidth = 300,
                 Visible = false,
             });

--- a/Robust.Client/UserInterface/Controls/OutputPanel.cs
+++ b/Robust.Client/UserInterface/Controls/OutputPanel.cs
@@ -22,7 +22,16 @@ namespace Robust.Client.UserInterface.Controls
 
         public const string StylePropertyStyleBox = "stylebox";
 
-        public bool ShowScrollDownButton { get; set; } = false;
+        public bool ShowScrollDownButton
+        {
+            get => _showScrollDownButton;
+            set
+            {
+                _showScrollDownButton = value;
+                _updateScrollButtonVisibility();
+            }
+        }
+        private bool _showScrollDownButton;
 
         private readonly RingBufferList<RichTextEntry> _entries = new();
         private bool _isAtBottom = true;

--- a/Robust.Client/UserInterface/CustomControls/DebugConsole.xaml
+++ b/Robust.Client/UserInterface/CustomControls/DebugConsole.xaml
@@ -1,7 +1,7 @@
 <Control xmlns="https://spacestation14.io"
          xmlns:gfx="clr-namespace:Robust.Client.Graphics">
     <BoxContainer Orientation="Vertical">
-        <OutputPanel Name="Output" VerticalExpand="True" StyleClasses="monospace">
+        <OutputPanel Name="Output" VerticalExpand="True" StyleClasses="monospace" ShowScrollDownButton="True">
             <OutputPanel.StyleBoxOverride>
                 <gfx:StyleBoxFlat BackgroundColor="#25252add"
                                   ContentMarginLeftOverride="3" ContentMarginRightOverride="3"


### PR DESCRIPTION
The intent here is to make it clear when the player is missing live incoming chat or radio comms, while also providing quick way to resume the live feed.

![image](https://github.com/user-attachments/assets/a6508050-7748-40c7-a0d1-77ee863352b1)

Initially I had experimented with a simple arrow icon 
![image](https://github.com/user-attachments/assets/0dd8bd60-e3bb-4b3c-b2e5-928af53f5672)

but I’ve currently settled on having a button which matches the style of the other chat buttons around it.


There has been some feedback in Discord discussions but I’ve opened this PR to get directed, collected feedback on the UI look so I can work on whatever may need to be changed.


Also of note is that this change currently affects everywhere an `OutputPanel` is being used (e.g. the console, `csi`…). I see no reason this functionality wouldn’t be wanted anywhere there is an `OutputPanel` but it can be amended to only affect the chat feed if preferred.