### PR TITLE
fix DirtyFields params, add an extra overload for Entity<T?>

### DIFF
--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -117,7 +117,7 @@ namespace Robust.Client.GameObjects
                 base.DirtyField(uid, comp, fieldName, metadata);
         }
 
-        public override void DirtyFields<T>(EntityUid uid, T comp, MetaDataComponent? meta, params ReadOnlySpan<string> fields)
+        public override void DirtyFields<T>(EntityUid uid, T comp, MetaDataComponent? meta, params string[] fields)
         {
             // TODO Prediction
             // does the client actually need to dirty the field?

--- a/Robust.Shared/GameObjects/EntityManager.ComponentDeltas.cs
+++ b/Robust.Shared/GameObjects/EntityManager.ComponentDeltas.cs
@@ -59,7 +59,7 @@ public abstract partial class EntityManager
         Dirty(uid, comp, metadata);
     }
 
-    public virtual void DirtyFields<T>(EntityUid uid, T comp, MetaDataComponent? meta, params ReadOnlySpan<string> fields)
+    public virtual void DirtyFields<T>(EntityUid uid, T comp, MetaDataComponent? meta, params string[] fields)
         where T : IComponentDelta
     {
         var compReg = ComponentFactory.GetRegistration(CompIdx.Index<T>());

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -172,10 +172,20 @@ public partial class EntitySystem
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected void DirtyFields<T>(EntityUid uid, T comp, MetaDataComponent? meta, params ReadOnlySpan<string> fields)
+    protected void DirtyFields<T>(EntityUid uid, T comp, MetaDataComponent? meta, params string[] fields)
         where T : IComponentDelta
     {
         EntityManager.DirtyFields(uid, comp, meta, fields);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected void DirtyFields<T>(Entity<T?> ent, MetaDataComponent? meta, params string[] fields)
+        where T : IComponentDelta
+    {
+        if (!Resolve(ent, ref ent.Comp))
+            return;
+
+        EntityManager.DirtyFields(ent, ent.Comp, meta, fields);
     }
 
     /// <summary>


### PR DESCRIPTION
changed `ReadOnlySpan<string>` to `string[]` because spans arent sandboxes and you literally cant use it in content lmao

the Entity<T?> overload is just convenient, the base DirtyField does it so idk why this one didn't