### PR TITLE
Pass AnimationPlayerComponent in AnimationCompletionEvent

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
@@ -76,7 +76,7 @@ namespace Robust.Client.GameObjects
             foreach (var key in remie)
             {
                 component.PlayingAnimations.Remove(key);
-                var completedEvent = new AnimationCompletedEvent(component, key, true) {Uid = uid};
+                var completedEvent = new AnimationCompletedEvent(uid, component, key, true);
                 EntityManager.EventBus.RaiseLocalEvent(uid, completedEvent, true);
             }
 
@@ -187,7 +187,7 @@ namespace Robust.Client.GameObjects
                 return;
             }
 
-            var completedEvent = new AnimationCompletedEvent(entity.Comp, key, false) {Uid = entity.Owner};
+            var completedEvent = new AnimationCompletedEvent(entity.Owner, entity.Comp, key, false);
             EntityManager.EventBus.RaiseLocalEvent(entity.Owner, completedEvent, true);
         }
 
@@ -205,10 +205,6 @@ namespace Robust.Client.GameObjects
         /// <summary>
         /// The entity associated with the event.
         /// </summary>
-        /// <remarks>
-        /// This field is redundant since the event was raised on the entity in question.
-        /// </remarks>
-        [Obsolete]
         public EntityUid Uid { get; init; }
 
         /// <summary>
@@ -223,12 +219,13 @@ namespace Robust.Client.GameObjects
 
         /// <summary>
         /// If true, the animation finished by getting to its natural end.
-        /// If false, it was removed prematurely via <see cref="AnimationPlayerSystem.Stop(Robust.Client.GameObjects.AnimationPlayerComponent,string)"/> or similar overloads.
+        /// If false, it was removed prematurely via <see cref="AnimationPlayerSystem.Stop(EntityUid,AnimationPlayerComponent,string)"/> or similar overloads.
         /// </summary>
         public bool Finished { get; init; }
 
-        public AnimationCompletedEvent(AnimationPlayerComponent animationPlayer, string key, bool finished = true)
+        public AnimationCompletedEvent(EntityUid uid, AnimationPlayerComponent animationPlayer, string key, bool finished = true)
         {
+            Uid = uid;
             AnimationPlayer = animationPlayer;
             Key = key;
             Finished = finished;

--- a/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
@@ -76,7 +76,7 @@ namespace Robust.Client.GameObjects
             foreach (var key in remie)
             {
                 component.PlayingAnimations.Remove(key);
-                var completedEvent = new AnimationCompletedEvent {Uid = uid, Key = key, Finished = true};
+                var completedEvent = new AnimationCompletedEvent {Uid = uid, Key = key, Finished = true, AnimationPlayer = component};
                 EntityManager.EventBus.RaiseLocalEvent(uid, completedEvent, true);
             }
 
@@ -187,7 +187,7 @@ namespace Robust.Client.GameObjects
                 return;
             }
 
-            var completedEvent = new AnimationCompletedEvent {Uid = entity.Owner, Key = key, Finished = false};
+            var completedEvent = new AnimationCompletedEvent {Uid = entity.Owner, Key = key, Finished = false, AnimationPlayer = entity.Comp};
             EntityManager.EventBus.RaiseLocalEvent(entity.Owner, completedEvent, true);
         }
 
@@ -210,5 +210,10 @@ namespace Robust.Client.GameObjects
         /// If false, it was removed prematurely via <see cref="AnimationPlayerSystem.Stop(Robust.Client.GameObjects.AnimationPlayerComponent,string)"/> or similar overloads.
         /// </summary>
         public bool Finished { get; init; }
+
+        /// <summary>
+        /// The entity animation player component
+        /// </summary>
+        public AnimationPlayerComponent? AnimationPlayer { get; init; }
     }
 }

--- a/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
@@ -76,7 +76,7 @@ namespace Robust.Client.GameObjects
             foreach (var key in remie)
             {
                 component.PlayingAnimations.Remove(key);
-                var completedEvent = new AnimationCompletedEvent {Uid = uid, Key = key, Finished = true, AnimationPlayer = component};
+                var completedEvent = new AnimationCompletedEvent(component, key, true) {Uid = uid};
                 EntityManager.EventBus.RaiseLocalEvent(uid, completedEvent, true);
             }
 
@@ -187,7 +187,7 @@ namespace Robust.Client.GameObjects
                 return;
             }
 
-            var completedEvent = new AnimationCompletedEvent {Uid = entity.Owner, Key = key, Finished = false, AnimationPlayer = entity.Comp};
+            var completedEvent = new AnimationCompletedEvent(entity.Comp, key, false) {Uid = entity.Owner};
             EntityManager.EventBus.RaiseLocalEvent(entity.Owner, completedEvent, true);
         }
 
@@ -202,7 +202,23 @@ namespace Robust.Client.GameObjects
     /// </summary>
     public sealed class AnimationCompletedEvent : EntityEventArgs
     {
+        /// <summary>
+        /// The entity associated with the event.
+        /// </summary>
+        /// <remarks>
+        /// This field is redundant since the event was raised on the entity in question.
+        /// </remarks>
+        [Obsolete]
         public EntityUid Uid { get; init; }
+
+        /// <summary>
+        /// The animation player component associated with the entity this event was raised on.
+        /// </summary>
+        public AnimationPlayerComponent AnimationPlayer { get; init; }
+
+        /// <summary>
+        /// The key associated with the animation that was completed.
+        /// </summary>
         public string Key { get; init; } = string.Empty;
 
         /// <summary>
@@ -211,9 +227,11 @@ namespace Robust.Client.GameObjects
         /// </summary>
         public bool Finished { get; init; }
 
-        /// <summary>
-        /// The entity animation player component
-        /// </summary>
-        public AnimationPlayerComponent? AnimationPlayer { get; init; }
+        public AnimationCompletedEvent(AnimationPlayerComponent animationPlayer, string key, bool finished = true)
+        {
+            AnimationPlayer = animationPlayer;
+            Key = key;
+            Finished = finished;
+        }
     }
 }


### PR DESCRIPTION
This PR makes it so the animation player component associated with the entity is passed when it raises the animation completion event

Required for content PR https://github.com/space-wizards/space-station-14/pull/35123 