### PR TITLE
Add entity description as tooltip on entity spawn panel

### DIFF
--- a/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.xaml.cs
+++ b/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.xaml.cs
@@ -59,6 +59,7 @@ namespace Robust.Client.UserInterface.CustomControls
             }
 
             button.EntityLabel.Text = entityLabelText;
+            button.ActualButton.ToolTip = prototype.Description;
 
             if (prototype == SelectedPrototype)
             {


### PR DESCRIPTION
We have the description loaded from the prototype already, why not show it? This can help make it more obvious what an entity is before spawning it.

<img width="458" alt="Screenshot 2025-03-20 at 5 49 50 PM" src="https://github.com/user-attachments/assets/ebd2b4cb-00be-4db6-a8ca-bb4aae6461b0" />
