### PR TITLE
Unbreak YAML linter in debug config

### DIFF
--- a/Robust.UnitTesting/Shared/Toolshed/TestCommands.cs
+++ b/Robust.UnitTesting/Shared/Toolshed/TestCommands.cs
@@ -197,21 +197,21 @@ public sealed class TestEnumerableCommand : ToolshedCommand
 public sealed class TestNestedArrayCommand : ToolshedCommand
 {
     [CommandImplementation]
-    public ProtoId<EntityPrototype>[] Impl() => Array.Empty<ProtoId<EntityPrototype>>();
+    public ProtoId<EntityCategoryPrototype>[] Impl() => [];
 }
 
 [ToolshedCommand]
 public sealed class TestNestedListCommand : ToolshedCommand
 {
     [CommandImplementation]
-    public List<ProtoId<EntityPrototype>> Impl() => new();
+    public List<ProtoId<EntityCategoryPrototype>> Impl() => new();
 }
 
 [ToolshedCommand]
 public sealed class TestNestedEnumerableCommand : ToolshedCommand
 {
-    private static ProtoId<EntityPrototype>[] _arr = Array.Empty<ProtoId<EntityPrototype>>();
+    private static ProtoId<EntityCategoryPrototype>[] _arr = [];
 
     [CommandImplementation]
-    public IEnumerable<ProtoId<EntityPrototype>> Impl() => _arr.OrderByDescending(x => x.Id);
+    public IEnumerable<ProtoId<EntityCategoryPrototype>> Impl() => _arr.OrderByDescending(x => x.Id);
 }

--- a/Robust.UnitTesting/Shared/Toolshed/ToolshedTests.cs
+++ b/Robust.UnitTesting/Shared/Toolshed/ToolshedTests.cs
@@ -383,11 +383,11 @@ public sealed class ToolshedTests : ToolshedTest
             AssertResult("testenumerable testenumerableinfer 1", typeof(int));
 
             // Repeat but with nested types. i.e. extracting T when piping ProtoId<T> -> IEnumerable<ProtoId<T>>
-            AssertResult("testnestedarray testnestedarrayinfer", typeof(EntityPrototype));
-            AssertResult("testnestedlist testnestedlistinfer", typeof(EntityPrototype));
-            AssertResult("testnestedarray testnestedenumerableinfer", typeof(EntityPrototype));
-            AssertResult("testnestedlist testnestedenumerableinfer", typeof(EntityPrototype));
-            AssertResult("testnestedenumerable testnestedenumerableinfer", typeof(EntityPrototype));
+            AssertResult("testnestedarray testnestedarrayinfer", typeof(EntityCategoryPrototype));
+            AssertResult("testnestedlist testnestedlistinfer", typeof(EntityCategoryPrototype));
+            AssertResult("testnestedarray testnestedenumerableinfer", typeof(EntityCategoryPrototype));
+            AssertResult("testnestedlist testnestedenumerableinfer", typeof(EntityCategoryPrototype));
+            AssertResult("testnestedenumerable testnestedenumerableinfer", typeof(EntityCategoryPrototype));
 
             // The map command used to work when the piped type was passed as an IEnumerable<T> directly, but would fail
             // when given a List<T> or something else that implemented the interface.


### PR DESCRIPTION
Content's YAML linter currently raises a debug assert due to encountering uses of `ProtoId<EntityPrototype>` in the toolshed test commands. This doesn't cause problems on github because the linter is built and run in Release configuration during the checks, but it's a bit of a nuisance when running the linter locally.

This PR fixes the issue by using `ProtoId<EntityCategoryPrototype>`s for the test instead. The tests still demonstrate the same functionality as before.

This change has been extracted from #5703 in the interest of fixing the linter faster. Note that #5703 will also prevent this kind of issue going unnoticed again.