### PR TITLE
Fix DirectoryNotFoundException when saving map or grid on Unix systems

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -47,6 +47,7 @@ END TEMPLATE-->
 ### Bugfixes
 
 * Fix serialization source generator breaking if a class has two partial locations.
+* Fix map saving throwing a `DirectoryNotFoundException` when given a path with a non-existent directory. Now it once again creates any missing directories.
 
 ### Other
 

--- a/Robust.Shared/EntitySerialization/Systems/MapLoaderSystem.cs
+++ b/Robust.Shared/EntitySerialization/Systems/MapLoaderSystem.cs
@@ -47,6 +47,7 @@ public sealed partial class MapLoaderSystem : EntitySystem
         Log.Info($"Saving serialized results to {path}");
         path = path.ToRootedPath();
         var document = new YamlDocument(data.ToYaml());
+        _resourceManager.UserData.CreateDir(path.Directory);
         using var writer = _resourceManager.UserData.OpenWriteText(path);
         {
             var stream = new YamlStream {document};


### PR DESCRIPTION
Someone forgor to create directory before saving map or grid, this caused an exception on trying to save smth anywhere else than `/`.

Probably SafeFileHandle.Unix.cs doesn't handle directory creating itself as on Windows(I haven't checked), so it worked on most local servers, but not on production servers.

This fix has been tested on local linux server.

An exception itself:
![image](https://github.com/user-attachments/assets/29efc8c0-ea7d-46c2-9421-19bb0b56e3dd)