### PR TITLE
Cleanup warnings in ClientGameStateManager

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -384,7 +384,6 @@ namespace Robust.Client.GameStates
                     _processor.UpdateFullRep(curState);
                 }
 
-                IEnumerable<NetEntity> createdEntities;
                 using (_prof.Group("ApplyGameState"))
                 {
                     if (_timing.LastProcessedTick < targetProcessedTick && nextState != null)

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -699,8 +699,9 @@ namespace Robust.Client.GameStates
 
 #if !EXCEPTION_TOLERANCE
                     throw new KeyNotFoundException();
-#endif
+#else
                     continue;
+#endif
                 }
 
                 var compData = _compDataPool.Get();
@@ -961,8 +962,9 @@ namespace Robust.Client.GameStates
                 RequestFullState();
 #if !EXCEPTION_TOLERANCE
                 throw;
-#endif
+#else
                 return;
+#endif
             }
 
             if (data.Created)
@@ -980,8 +982,9 @@ namespace Robust.Client.GameStates
                     RequestFullState();
 #if !EXCEPTION_TOLERANCE
                     throw;
-#endif
+#else
                     return;
+#endif
                 }
             }
 


### PR DESCRIPTION
Fixes 4 warnings in `ClientGameStateManager.cs`

**3x Unreachable code detected [CS0162](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0162))**
Caused by `#if !EXCEPTION_TOLERANCE` precompiler directives. Added `#else` directives so either `throw` **or** `return` is used, and never both.

**1x The variable 'createdEntities' is declared but never used [CS0168](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0168))**
`IEnumerable<NetEntity> createdEntities` is declared but never used. Deleted.

https://github.com/space-wizards/space-station-14/issues/33279