### PR TITLE
Replace MapManager.DeleteMap with SharedMapSystem.DeleteMap in misc tests

### DIFF
--- a/Robust.UnitTesting/Server/GameObjects/ComponentMapInitTest.cs
+++ b/Robust.UnitTesting/Server/GameObjects/ComponentMapInitTest.cs
@@ -26,8 +26,8 @@ public sealed partial class ComponentMapInitTest
 
         var sim = simFactory.InitializeInstance();
         var entManager = sim.Resolve<IEntityManager>();
-        var mapManager = sim.Resolve<IMapManager>();
-        sim.Resolve<IEntityManager>().System<SharedMapSystem>().CreateMap(out var mapId);
+        var mapSystem = entManager.System<SharedMapSystem>();
+        mapSystem.CreateMap(out var mapId);
 
         var ent = entManager.SpawnEntity(null, new MapCoordinates(Vector2.Zero, mapId));
         Assert.That(entManager.GetComponent<MetaDataComponent>(ent).EntityLifeStage, Is.EqualTo(EntityLifeStage.MapInitialized));
@@ -36,7 +36,7 @@ public sealed partial class ComponentMapInitTest
 
         Assert.That(comp.Count, Is.EqualTo(1));
 
-        mapManager.DeleteMap(mapId);
+        mapSystem.DeleteMap(mapId);
     }
 
     [Reflect(false)]

--- a/Robust.UnitTesting/Shared/GameObjects/IEntityManagerTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/IEntityManagerTests.cs
@@ -39,13 +39,13 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var sim = RobustServerSimulation.NewSimulation().InitializeInstance();
 
             var entManager = sim.Resolve<IEntityManager>();
-            var mapManager = sim.Resolve<IMapManager>();
+            var mapSystem = entManager.System<SharedMapSystem>();
 
             Assert.That(entManager.Count<TransformComponent>(), Is.EqualTo(0));
 
             var mapId = sim.CreateMap().MapId;
             Assert.That(entManager.Count<TransformComponent>(), Is.EqualTo(1));
-            mapManager.DeleteMap(mapId);
+            mapSystem.DeleteMap(mapId);
             Assert.That(entManager.Count<TransformComponent>(), Is.EqualTo(0));
         }
     }

--- a/Robust.UnitTesting/Shared/Map/GridSplit_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/GridSplit_Tests.cs
@@ -53,7 +53,7 @@ public sealed class GridSplit_Tests
         mapSystem.SetTile(gridEnt, new Vector2i(2, 0), Tile.Empty);
         Assert.That(mapManager.GetAllGrids(mapId).Count(), Is.EqualTo(2));
 
-        mapManager.DeleteMap(mapId);
+        mapSystem.DeleteMap(mapId);
     }
 
     [Test]
@@ -75,7 +75,7 @@ public sealed class GridSplit_Tests
         mapSystem.SetTile(gridEnt, new Vector2i(1, 0), Tile.Empty);
         Assert.That(mapManager.GetAllGrids(mapId).Count(), Is.EqualTo(2));
 
-        mapManager.DeleteMap(mapId);
+        mapSystem.DeleteMap(mapId);
     }
 
     [Test]
@@ -106,7 +106,7 @@ public sealed class GridSplit_Tests
         mapSystem.SetTile(gridEnt, new Vector2i(1, 0), Tile.Empty);
         Assert.That(mapManager.GetAllGrids(mapId).Count(), Is.EqualTo(2));
 
-        mapManager.DeleteMap(mapId);
+        mapSystem.DeleteMap(mapId);
     }
 
     [Test]
@@ -130,7 +130,7 @@ public sealed class GridSplit_Tests
         mapSystem.SetTile(gridEnt, new Vector2i(1, 0), Tile.Empty);
         Assert.That(mapManager.GetAllGrids(mapId).Count(), Is.EqualTo(3));
 
-        mapManager.DeleteMap(mapId);
+        mapSystem.DeleteMap(mapId);
     }
 
     /// <summary>
@@ -181,6 +181,6 @@ public sealed class GridSplit_Tests
             Assert.That(dummyXform.GridUid, Is.EqualTo(newGrid.Owner));
             Assert.That(newGridXform._children, Does.Contain(dummy));
         });
-        mapManager.DeleteMap(mapId);
+        mapSystem.DeleteMap(mapId);
     }
 }

--- a/Robust.UnitTesting/Shared/Map/MapGridMap_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/MapGridMap_Tests.cs
@@ -39,6 +39,7 @@ public sealed class MapGridMap_Tests
 
         var entManager = sim.Resolve<IEntityManager>();
         var mapManager = sim.Resolve<IMapManager>();
+        var mapSystem = entManager.System<SharedMapSystem>();
 
         var mapId = sim.CreateMap().MapId;
         mapManager.CreateGridEntity(mapId);
@@ -49,6 +50,6 @@ public sealed class MapGridMap_Tests
             entManager.TickUpdate(0.016f, false);
         });
 
-        mapManager.DeleteMap(mapId);
+        mapSystem.DeleteMap(mapId);
     }
 }

--- a/Robust.UnitTesting/Shared/Physics/Fixtures_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Fixtures_Test.cs
@@ -20,10 +20,10 @@ public sealed class Fixtures_Test
         var sim = RobustServerSimulation.NewSimulation().InitializeInstance();
 
         var entManager = sim.Resolve<IEntityManager>();
-        var mapManager = sim.Resolve<IMapManager>();
         var sysManager = sim.Resolve<IEntitySystemManager>();
         var fixturesSystem = sysManager.GetEntitySystem<FixtureSystem>();
         var physicsSystem = sysManager.GetEntitySystem<SharedPhysicsSystem>();
+        var mapSystem = sysManager.GetEntitySystem<SharedMapSystem>();
         var map = sim.CreateMap().MapId;
 
         var ent = sim.SpawnEntity(null, new MapCoordinates(Vector2.Zero, map));
@@ -36,6 +36,6 @@ public sealed class Fixtures_Test
         Assert.That(fixture.Density, Is.EqualTo(10f));
         Assert.That(body.Mass, Is.EqualTo(10f));
 
-        mapManager.DeleteMap(map);
+        mapSystem.DeleteMap(map);
     }
 }

--- a/Robust.UnitTesting/Shared/Physics/Joints_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Joints_Test.cs
@@ -24,8 +24,8 @@ public sealed class Joints_Test
         var sim = factory.InitializeInstance();
 
         var entManager = sim.Resolve<IEntityManager>();
-        var mapManager = sim.Resolve<IMapManager>();
         var jointSystem = entManager.System<SharedJointSystem>();
+        var mapSystem = entManager.System<SharedMapSystem>();
 
         var mapId = sim.CreateMap().MapId;
 
@@ -53,7 +53,7 @@ public sealed class Joints_Test
             Assert.That(entManager.GetComponent<JointRelayTargetComponent>(uidC).Relayed, Is.Empty);
             Assert.That(entManager.GetComponent<JointComponent>(uidA).Relay, Is.EqualTo(null));
         });
-        mapManager.DeleteMap(mapId);
+        mapSystem.DeleteMap(mapId);
     }
 
     /// <summary>
@@ -65,11 +65,11 @@ public sealed class Joints_Test
         var factory = RobustServerSimulation.NewSimulation();
         var server = factory.InitializeInstance();
         var entManager = server.Resolve<IEntityManager>();
-        var mapManager = server.Resolve<IMapManager>();
         var fixtureSystem = entManager.EntitySysManager.GetEntitySystem<FixtureSystem>();
         var jointSystem = entManager.EntitySysManager.GetEntitySystem<JointSystem>();
         var broadphaseSystem = entManager.EntitySysManager.GetEntitySystem<SharedBroadphaseSystem>();
         var physicsSystem = server.Resolve<IEntitySystemManager>().GetEntitySystem<SharedPhysicsSystem>();
+        var mapSystem = entManager.System<SharedMapSystem>();
 
         var mapId = server.CreateMap().MapId;
 
@@ -106,6 +106,6 @@ public sealed class Joints_Test
         broadphaseSystem.FindNewContacts(mapId);
         Assert.That(body1.Contacts, Has.Count.EqualTo(1));
 
-        mapManager.DeleteMap(mapId);
+        mapSystem.DeleteMap(mapId);
     }
 }

--- a/Robust.UnitTesting/Shared/Spawning/EntitySpawnHelpersTest.cs
+++ b/Robust.UnitTesting/Shared/Spawning/EntitySpawnHelpersTest.cs
@@ -24,6 +24,9 @@ public abstract partial class EntitySpawnHelpersTest : RobustIntegrationTest
     protected SharedTransformSystem Xforms = default!;
     protected SharedContainerSystem Container = default!;
 
+    // Even if unused, content / downstream tests might use this class, so removal would be a breaking change?
+    protected IMapManager MapMan = default!; 
+
     protected EntityUid Map;
     protected MapId MapId;
     protected EntityUid Parent; // entity parented to the map.
@@ -41,6 +44,7 @@ public abstract partial class EntitySpawnHelpersTest : RobustIntegrationTest
     {
         Server = StartServer();
         await Server.WaitIdleAsync();
+        MapMan = Server.ResolveDependency<IMapManager>();
         EntMan = Server.ResolveDependency<IEntityManager>();
         MapSys = EntMan.System<SharedMapSystem>();
         Xforms = EntMan.System<SharedTransformSystem>();

--- a/Robust.UnitTesting/Shared/Spawning/EntitySpawnHelpersTest.cs
+++ b/Robust.UnitTesting/Shared/Spawning/EntitySpawnHelpersTest.cs
@@ -20,7 +20,7 @@ public abstract partial class EntitySpawnHelpersTest : RobustIntegrationTest
 {
     protected ServerIntegrationInstance Server = default!;
     protected IEntityManager EntMan = default!;
-    protected IMapManager MapMan = default!;
+    protected SharedMapSystem MapSys = default!;
     protected SharedTransformSystem Xforms = default!;
     protected SharedContainerSystem Container = default!;
 
@@ -41,8 +41,8 @@ public abstract partial class EntitySpawnHelpersTest : RobustIntegrationTest
     {
         Server = StartServer();
         await Server.WaitIdleAsync();
-        MapMan = Server.ResolveDependency<IMapManager>();
         EntMan = Server.ResolveDependency<IEntityManager>();
+        MapSys = EntMan.System<SharedMapSystem>();
         Xforms = EntMan.System<SharedTransformSystem>();
         Container = EntMan.System<SharedContainerSystem>();
 

--- a/Robust.UnitTesting/Shared/Spawning/SpawnInContainerOrDropTest.cs
+++ b/Robust.UnitTesting/Shared/Spawning/SpawnInContainerOrDropTest.cs
@@ -116,7 +116,7 @@ public sealed class SpawnInContainerOrDropTest : EntitySpawnHelpersTest
             Assert.That(xform.GridUid, Is.Null);
         });
 
-        await Server.WaitPost(() =>MapMan.DeleteMap(MapId));
+        await Server.WaitPost(() => MapSys.DeleteMap(MapId));
         Server.Dispose();
     }
 }

--- a/Robust.UnitTesting/Shared/Spawning/SpawnNextToOrDropTest.cs
+++ b/Robust.UnitTesting/Shared/Spawning/SpawnNextToOrDropTest.cs
@@ -121,7 +121,7 @@ public sealed class SpawnNextToOrDropTest : EntitySpawnHelpersTest
             Assert.That(EntMan.GetComponent<MetaDataComponent>(uid).EntityLifeStage, Is.LessThan(EntityLifeStage.MapInitialized));
         });
 
-        await Server.WaitPost(() =>MapMan.DeleteMap(MapId));
+        await Server.WaitPost(() => MapSys.DeleteMap(MapId));
         Server.Dispose();
     }
 }

--- a/Robust.UnitTesting/Shared/Spawning/TrySpawnInContainerTest.cs
+++ b/Robust.UnitTesting/Shared/Spawning/TrySpawnInContainerTest.cs
@@ -42,7 +42,7 @@ public sealed class TrySpawnInContainerTest : EntitySpawnHelpersTest
             Assert.That(EntMan.EntityExists(uid), Is.False);
         });
 
-        await Server.WaitPost(() =>MapMan.DeleteMap(MapId));
+        await Server.WaitPost(() => MapSys.DeleteMap(MapId));
         Server.Dispose();
     }
 }

--- a/Robust.UnitTesting/Shared/Spawning/TrySpawnNextToTest.cs
+++ b/Robust.UnitTesting/Shared/Spawning/TrySpawnNextToTest.cs
@@ -50,7 +50,7 @@ public sealed class TrySpawnNextToTest : EntitySpawnHelpersTest
             Assert.That(EntMan.EntityExists(uid), Is.False);
         });
 
-        await Server.WaitPost(() =>MapMan.DeleteMap(MapId));
+        await Server.WaitPost(() => MapSys.DeleteMap(MapId));
         Server.Dispose();
     }
 }


### PR DESCRIPTION
These are dead simple warnings to fix, so I'm grouping a bunch of them together instead of making a bunch of little PRs.

Some instances already had a reference to `SharedMapSystem` in scope, and were incredibly simple to change. Others required using `EntityManager.System` to get it, which is still simple.

Probably the most nuanced change is that the abstract class `EntitySpawnHelpersTest` which serves as parent to a few other tests had its `MapManager` reference replaced with a `SharedMapSystem` reference. Initially I just added the system reference, but it turns out that every use of `MapMan` in the child tests was to call `DeleteMap`, so I removed it.

https://github.com/space-wizards/space-station-14/issues/33279