### PR TITLE
equatable FormattedMessage, take 2

### DIFF
--- a/Robust.Shared/Utility/FormattedMessage.cs
+++ b/Robust.Shared/Utility/FormattedMessage.cs
@@ -281,13 +281,30 @@ public sealed partial class FormattedMessage : IEquatable<FormattedMessage>, IRe
     /// <inheritdoc />
     public bool Equals(FormattedMessage? other)
     {
-        return other?.ToMarkup() == ToMarkup();
+        if (_nodes.Count != other?._nodes.Count)
+            return false;
+
+        for (var i = 0; i < _nodes.Count; i++)
+        {
+            if (!_nodes[i].Equals(other?._nodes[i]))
+                return false;
+        }
+
+        return true;
     }
 
     /// <inheritdoc />
     public override int GetHashCode()
     {
-        return ToMarkup().GetHashCode();
+        var hash = 0;
+        var i = 1;
+        foreach (var node in _nodes)
+        {
+            hash += node.GetHashCode() * i;
+            i++;
+        }
+
+        return hash;
     }
 
     /// <returns>The string without markup tags.</returns>

--- a/Robust.Shared/Utility/FormattedMessage.cs
+++ b/Robust.Shared/Utility/FormattedMessage.cs
@@ -297,11 +297,9 @@ public sealed partial class FormattedMessage : IEquatable<FormattedMessage>, IRe
     public override int GetHashCode()
     {
         var hash = 0;
-        var i = 1;
         foreach (var node in _nodes)
         {
-            hash += node.GetHashCode() * i;
-            i++;
+            hash = HashCode.Combine(hash, node.GetHashCode());
         }
 
         return hash;


### PR DESCRIPTION
No more markup conversions. Addressing the point/request brought up on #5772