### PR TITLE
fully remove the obsolete version of TryGetContainingContainer

### DIFF
--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -279,16 +279,6 @@ namespace Robust.Shared.Containers
 
         #region Container Helpers
 
-        [Obsolete("Use Entity<T> variant")]
-        public bool TryGetContainingContainer(
-            EntityUid uid,
-            [NotNullWhen(true)] out BaseContainer? container,
-            MetaDataComponent? meta = null,
-            TransformComponent? transform = null)
-        {
-            return TryGetContainingContainer((uid, transform, meta), out container);
-        }
-
         public bool TryGetContainingContainer(
             Entity<TransformComponent?, MetaDataComponent?> ent,
             [NotNullWhen(true)] out BaseContainer? container)


### PR DESCRIPTION
All the remaining cases in the content repo will automatically cast to the `Entity<TransformComponent?, MetaDataComponent?>` variant, which also gets rid of all the warnings.

Currently what people are doing to get rid of the warning is this
![grafik](https://github.com/user-attachments/assets/267f71ff-4463-45e4-b2ac-a6a2d956ab25)