### PR TITLE
Make MappingDataNode use string keys

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,14 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* Yaml mappings/dictionaries now only support string keys instead of generic nodes
+  * Several `MappingDataNode` method arguments or return values now use strings instead of a DataNode object
+  * The MappingDataNode class has various helper methods that still accept a `ValueDataNode`, but these methods are marked as obsolete and may be removed in the future.
+  * yaml validators should use `MappingDataNode.GetKeyNode()` when validating mapping keys, so that errors can print node start & end information
+* ValueTuples yaml serialization has changed
+  * Previously they would get serialized into a single mapping with one entry (i.e., `{foo : bar }` 
+  * Now they serialize into a sequence (i.e., `[foo, bar]`
+  * The ValueTuple serializer will still try to read mappings, but may fail if the previously serialized "key" can't be read as a simple string
 
 ### New features
 
@@ -62,14 +69,6 @@ END TEMPLATE-->
   * This can be used to avoid having to change the light map texture, thus reducing draw batches.
   * Sprite layers that are set to use the "unshaded" shader prototype now use this.
   * Any fragment shaders that previously the `VtxModulate` colour modulation variable should instead use the new `MODULATE` variable, as the former may now contain negative values.
-* Yaml mappings/dictionaries now only support string keys instead of generic nodes
-  * Several `MappingDataNode` method arguments or return values now use strings instead of a DataNode object
-  * The MappingDataNode class has various helper methods that still accept a `ValueDataNode`, but these methods are marked as obsolete and may be removed in the future.
-  * yaml validators should use `MappingDataNode.GetKeyNode()` when validating mapping keys, so that errors can print node start & end information
-* ValueTuples yaml serialization has changed
-  * Previously they would get serialized into a single mapping with one entry (i.e., `{foo : bar }` 
-  * Now they serialize into a sequence (i.e., `[foo, bar]`
-  * The ValueTuple serializer will still try to read mappings, but may fail if the previously serialized "key" can't be read as a simple string
 
 ### New features
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -36,13 +36,13 @@ END TEMPLATE-->
 ### Breaking changes
 
 * Yaml mappings/dictionaries now only support string keys instead of generic nodes
-  * Several `MappingDataNode` method arguments or return values now use strings instead of a DataNode object
-  * The MappingDataNode class has various helper methods that still accept a `ValueDataNode`, but these methods are marked as obsolete and may be removed in the future.
+  * Several MappingDataNode method arguments or return values now use strings instead of a DataNode object
+  * The MappingDataNode class has various helper methods that still accept a ValueDataNode, but these methods are marked as obsolete and may be removed in the future.
   * yaml validators should use `MappingDataNode.GetKeyNode()` when validating mapping keys, so that errors can print node start & end information
-* ValueTuples yaml serialization has changed
+* ValueTuple yaml serialization has changed
   * Previously they would get serialized into a single mapping with one entry (i.e., `{foo : bar }` 
   * Now they serialize into a sequence (i.e., `[foo, bar]`
-  * The ValueTuple serializer will still try to read mappings, but may fail if the previously serialized "key" can't be read as a simple string
+  * The ValueTuple serializer will still try to read mappings, but due to the MappingDataNode this may fail if the previously serialized "key" can't be read as a simple string
 
 ### New features
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,6 +39,14 @@ END TEMPLATE-->
   * This can be used to avoid having to change the light map texture, thus reducing draw batches.
   * Sprite layers that are set to use the "unshaded" shader prototype now use this.
   * Any fragment shaders that previously the `VtxModulate` colour modulation variable should instead use the new `MODULATE` variable, as the former may now contain negative values.
+* Yaml mappings/dictionaries now only support string keys instead of generic nodes
+  * Several `MappingDataNode` method arguments or return values now use strings instead of a DataNode object
+  * The MappingDataNode class has various helper methods that still accept a `ValueDataNode`, but these methods are marked as obsolete and may be removed in the future.
+  * yaml validators should use `MappingDataNode.GetKeyNode()` when validating mapping keys, so that errors can print node start & end information
+* ValueTuples yaml serialization has changed
+  * Previously they would get serialized into a single mapping with one entry (i.e., `{foo : bar }` 
+  * Now they serialize into a sequence (i.e., `[foo, bar]`
+  * The ValueTuple serializer will still try to read mappings, but may fail if the previously serialized "key" can't be read as a simple string
 
 ### New features
 

--- a/Robust.Shared/EntitySerialization/EntityDeserializer.cs
+++ b/Robust.Shared/EntitySerialization/EntityDeserializer.cs
@@ -475,7 +475,7 @@ public sealed class EntityDeserializer :
 
         foreach (var (key, value) in tileMap.Children)
         {
-            var yamlTileId = ((ValueDataNode) key).AsInt();
+            var yamlTileId = int.Parse(key, CultureInfo.InvariantCulture);
             var tileName = ((ValueDataNode) value).Value;
             if (migrations.TryGetValue(tileName, out var @new))
                 tileName = @new;

--- a/Robust.Shared/EntitySerialization/MapChunkSerializer.cs
+++ b/Robust.Shared/EntitySerialization/MapChunkSerializer.cs
@@ -69,7 +69,7 @@ internal sealed class MapChunkSerializer : ITypeSerializer<MapChunk, MappingData
 
         var tileDefinitionManager = dependencies.Resolve<ITileDefinitionManager>();
 
-        node.TryGetValue(new ValueDataNode("version"), out var versionNode);
+        node.TryGetValue("version", out var versionNode);
         var version = ((ValueDataNode?) versionNode)?.AsInt() ?? 1;
 
         for (ushort y = 0; y < chunk.ChunkSize; y++)

--- a/Robust.Shared/Physics/FixtureSerializer.cs
+++ b/Robust.Shared/Physics/FixtureSerializer.cs
@@ -29,11 +29,9 @@ public sealed class FixtureSerializer : ITypeSerializer<Dictionary<string, Fixtu
 
         foreach (var subNode in node)
         {
-            var key = (ValueDataNode)subNode.Key;
-
-            if (!keys.Add(key.Value))
+            if (!keys.Add(subNode.Key))
             {
-                seq.Add(new ErrorNode(subNode.Key, $"Found duplicate fixture ID {key.Value}"));
+                seq.Add(new ErrorNode(new ValueDataNode(subNode.Key), $"Found duplicate fixture ID {subNode.Key}"));
                 continue;
             }
 
@@ -50,10 +48,8 @@ public sealed class FixtureSerializer : ITypeSerializer<Dictionary<string, Fixtu
 
         foreach (var subNode in node)
         {
-            var key = (ValueDataNode)subNode.Key;
-
             var fixture = serializationManager.Read<Fixture>(subNode.Value, hookCtx, context, notNullableOverride: true);
-            value.Add(key.Value, fixture);
+            value.Add(subNode.Key, fixture);
         }
 
         return value;

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
@@ -342,8 +342,7 @@ public partial class PrototypeManager
         {
             if (abstractNode is not ValueDataNode abstractValueNode)
             {
-                mapping.Remove(abstractNode);
-                mapping.Add("abstract", "true");
+                mapping["abstract"] = new ValueDataNode("true");
                 return;
             }
 

--- a/Robust.Shared/Replays/ReplayData.cs
+++ b/Robust.Shared/Replays/ReplayData.cs
@@ -112,7 +112,7 @@ public sealed class ReplayData
         ClientSideRecording = clientSideRecording;
         YamlData = yamlData;
 
-        if (YamlData.TryGet(new ValueDataNode(ReplayConstants.MetaKeyRecordedBy), out ValueDataNode? node)
+        if (YamlData.TryGet(ReplayConstants.MetaKeyRecordedBy, out ValueDataNode? node)
             && Guid.TryParse(node.Value, out var guid))
         {
             Recorder = new NetUserId(guid);

--- a/Robust.Shared/Serialization/Manager/Definition/DataDefinition.cs
+++ b/Robust.Shared/Serialization/Manager/Definition/DataDefinition.cs
@@ -266,27 +266,21 @@ namespace Robust.Shared.Serialization.Manager.Definition
 
             foreach (var (key, val) in mapping.Children)
             {
-                if (key is not ValueDataNode valueDataNode)
+                if (!TryGetIndex(key, out var idx))
                 {
-                    validatedMapping.Add(new ErrorNode(key, "Key not ValueDataNode."), new InconclusiveNode(val));
-                    continue;
-                }
-
-                if (!TryGetIndex(valueDataNode.Value, out var idx))
-                {
-                    if (TryGetIncludeMappingPair(includeValidations, valueDataNode.Value, out var validatedNotFoundPair))
+                    if (TryGetIncludeMappingPair(includeValidations, key, out var validatedNotFoundPair))
                     {
                         validatedMapping.Add(validatedNotFoundPair.Key, validatedNotFoundPair.Value);
                         continue;
                     }
 
-                    var error = new FieldNotFoundErrorNode(valueDataNode, typeof(T));
+                    var error = new FieldNotFoundErrorNode(mapping.GetKeyNode(key), typeof(T));
 
                     validatedMapping.Add(error, new InconclusiveNode(val));
                     continue;
                 }
 
-                var keyValidated = serialization.ValidateNode<string>(key, context);
+                var keyValidated = serialization.ValidateNode<string>(mapping.GetKeyNode(key), context);
 
                 ValidationNode valNode;
                 if (IsNull(val))
@@ -295,7 +289,7 @@ namespace Robust.Shared.Serialization.Manager.Definition
                     {
                         var error = new ErrorNode(
                             val,
-                            $"Field \"{valueDataNode.Value}\" had null value despite not being annotated as nullable.");
+                            $"Field \"{key}\" had null value despite not being annotated as nullable.");
 
                         validatedMapping.Add(keyValidated, error);
                         continue;
@@ -309,7 +303,7 @@ namespace Robust.Shared.Serialization.Manager.Definition
                 }
 
                 //include node errors override successful nodes on the main datadef
-                if (valNode is not ErrorNode && TryGetIncludeMappingPair(includeValidations, valueDataNode.Value, out var validatedPair))
+                if (valNode is not ErrorNode && TryGetIncludeMappingPair(includeValidations, key, out var validatedPair))
                 {
                     if (validatedPair.Value is ErrorNode)
                     {

--- a/Robust.Shared/Serialization/Manager/SerializationManager.Composition.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.Composition.cs
@@ -27,24 +27,16 @@ public partial class SerializationManager
     public DataNode PushComposition(Type type, DataNode[] parents, DataNode child, ISerializationContext? context = null)
     {
         // TODO SERIALIZATION
-        // Add variant that doesn't require a parent array.
-
-        // TODO SERIALIZATION
         // Change inheritance pushing so that it modifies the passed in child. This avoids re-creating the child
-        // multiple times when there are multiple children.
+        // multiple times when there are multiple parents.
         //
         // I.e., change the PushCompositionDelegate signature to not have a return value, and also add an override
-        // of this method that modified the given child.
+        // of this method that modifies the given child.
 
         if (parents.Length == 0)
             return child.Copy();
 
         DebugTools.Assert(parents.All(x => x.GetType() == child.GetType()));
-
-
-        // the child.Clone() statement to the beginning here, then make the delegate modify the clone.
-        // Currently pusing more than one parent requires multiple unnecessary clones.
-
         var pusher = GetOrCreatePushCompositionDelegate(type, child);
 
         var node = child;
@@ -178,7 +170,8 @@ public partial class SerializationManager
             {
                 // tag is set on data definition creation
                 if(!processedTags.Add(dfa.Tag!)) continue; //tag was already processed, probably because we are using the same tag in an include
-                var key = new ValueDataNode(dfa.Tag);
+
+                var key = dfa.Tag!;
                 if (parent.TryGetValue(key, out var parentValue))
                 {
                     if (newMapping.TryGetValue(key, out var childValue))

--- a/Robust.Shared/Serialization/Markdown/DataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/DataNode.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Robust.Shared.Serialization.Manager;
 using YamlDotNet.Core;
@@ -28,6 +29,7 @@ namespace Robust.Shared.Serialization.Markdown
         /// </summary>
         public abstract DataNode? Except(DataNode node);
 
+        [Obsolete("Use SerializationManager.PushComposition()")]
         public abstract DataNode PushInheritance(DataNode parent);
 
         public T CopyCast<T>() where T : DataNode
@@ -60,6 +62,7 @@ namespace Robust.Shared.Serialization.Markdown
 
         public abstract T? Except(T node);
 
+        [Obsolete("Use SerializationManager.PushComposition()")]
         public abstract T PushInheritance(T node);
 
         public override DataNode? Except(DataNode node)
@@ -67,6 +70,7 @@ namespace Robust.Shared.Serialization.Markdown
             return node is not T tNode ? throw new InvalidNodeTypeException() : Except(tNode);
         }
 
+        [Obsolete("Use SerializationManager.PushComposition()")]
         public override DataNode PushInheritance(DataNode parent)
         {
             return parent is not T tNode ? throw new InvalidNodeTypeException() : PushInheritance(tNode);

--- a/Robust.Shared/Serialization/Markdown/DataNodeHelpers.cs
+++ b/Robust.Shared/Serialization/Markdown/DataNodeHelpers.cs
@@ -25,10 +25,7 @@ public static class DataNodeHelpers
 
         foreach (var (k, v) in node)
         {
-            foreach (var child in GetAllNodes(k))
-            {
-                yield return child;
-            }
+            yield return node.GetKeyNode(k);
 
             foreach (var child in GetAllNodes(v))
             {

--- a/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNode.cs
@@ -129,6 +129,9 @@ namespace Robust.Shared.Serialization.Markdown.Mapping
         [Obsolete("Use TryGet")]
         public bool TryGetValue(ValueDataNode key, [NotNullWhen(true)] out DataNode? value)
             => TryGet(key.Value, out value);
+
+        // TODO consider changing these to unsorted collections
+        // I.e., just redirect to _children.Keys to avoid hidden linq & allocations.
         public ICollection<string> Keys => _list.Select(x => x.Key).ToArray();
         public ICollection<DataNode> Values => _list.Select(x => x.Value).ToArray();
 
@@ -193,6 +196,7 @@ namespace Robust.Shared.Serialization.Markdown.Mapping
                 }
                 else
                 {
+                    // This is matches the ValueDataNode -> YamlScalarNode cast operator
                     yamlKeyNode = new(key)
                     {
                         Style = ValueDataNode.IsNullLiteral(key) || string.IsNullOrWhiteSpace(key)

--- a/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNode.cs
@@ -122,13 +122,8 @@ namespace Robust.Shared.Serialization.Markdown.Mapping
         bool IDictionary<string, DataNode>.Remove(string key)
             => ((IDictionary<string, DataNode>)this).Remove(key);
 
-        [Obsolete("Use TryGet")]
         public bool TryGetValue(string key, [NotNullWhen(true)] out DataNode? value)
             => TryGet(key, out value);
-
-        [Obsolete("Use TryGet")]
-        public bool TryGetValue(ValueDataNode key, [NotNullWhen(true)] out DataNode? value)
-            => TryGet(key.Value, out value);
 
         // TODO consider changing these to unsorted collections
         // I.e., just redirect to _children.Keys to avoid hidden linq & allocations.
@@ -382,7 +377,9 @@ namespace Robust.Shared.Serialization.Markdown.Mapping
             return true;
         }
 
-        public IEnumerator<KeyValuePair<string, DataNode>> GetEnumerator() => _list.GetEnumerator();
+        public List<KeyValuePair<string, DataNode>>.Enumerator GetEnumerator() => _list.GetEnumerator();
+        IEnumerator<KeyValuePair<string, DataNode>> IEnumerable<KeyValuePair<string, DataNode>>.GetEnumerator() =>
+            _list.GetEnumerator();
 
         public override int GetHashCode()
         {
@@ -468,6 +465,10 @@ namespace Robust.Shared.Serialization.Markdown.Mapping
             get => this[key.Value];
             set => this[key.Value] = value;
         }
+
+        [Obsolete("Use string keys instead of ValueDataNode")]
+        public bool TryGetValue(ValueDataNode key, [NotNullWhen(true)] out DataNode? value)
+            => TryGet(key.Value, out value);
 
         [Obsolete("Use string keys instead of ValueDataNode")]
         public bool TryGet<T>(ValueDataNode key, [NotNullWhen(true)] out T? node) where T : DataNode

--- a/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNode.cs
@@ -368,8 +368,8 @@ namespace Robust.Shared.Serialization.Markdown.Mapping
 
             foreach (var (key, otherValue) in other)
             {
-                if (!_children.TryGetValue(key, out var ownValue) ||
-                    !otherValue.Equals(ownValue))
+                if (!_children.TryGetValue(key, out var ownValue)
+                    || !otherValue.Equals(ownValue))
                 {
                     return false;
                 }

--- a/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNodeExtensions.cs
+++ b/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNodeExtensions.cs
@@ -6,21 +6,15 @@ namespace Robust.Shared.Serialization.Markdown.Mapping
 {
     public static class MappingDataNodeExtensions
     {
-        public static MappingDataNode Add(this MappingDataNode mapping, string key, DataNode node)
-        {
-            mapping.Add(new ValueDataNode(key), node);
-            return mapping;
-        }
-
         public static MappingDataNode Add(this MappingDataNode mapping, string key, string value)
         {
-            mapping.Add(new ValueDataNode(key), new ValueDataNode(value));
+            mapping.Add(key, new ValueDataNode(value));
             return mapping;
         }
 
         public static MappingDataNode Add(this MappingDataNode mapping, string key, List<string> sequence)
         {
-            mapping.Add(new ValueDataNode(key), new SequenceDataNode(sequence));
+            mapping.Add(key, new SequenceDataNode(sequence));
             return mapping;
         }
     }

--- a/Robust.Shared/Serialization/Markdown/Sequence/SequenceDataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/Sequence/SequenceDataNode.cs
@@ -133,7 +133,8 @@ namespace Robust.Shared.Serialization.Markdown.Sequence
             return newSequence;
         }
 
-        public IEnumerator<DataNode> GetEnumerator() => _nodes.GetEnumerator();
+        public List<DataNode>.Enumerator GetEnumerator() => _nodes.GetEnumerator();
+        IEnumerator<DataNode> IEnumerable<DataNode>.GetEnumerator() => _nodes.GetEnumerator();
 
         public override int GetHashCode()
         {

--- a/Robust.Shared/Serialization/Markdown/Sequence/SequenceDataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/Sequence/SequenceDataNode.cs
@@ -192,6 +192,7 @@ namespace Robust.Shared.Serialization.Markdown.Sequence
             return true;
         }
 
+        [Obsolete("Use SerializationManager.PushComposition()")]
         public override SequenceDataNode PushInheritance(SequenceDataNode node)
         {
             var newNode = Copy();

--- a/Robust.Shared/Serialization/Markdown/Value/ValueDataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/Value/ValueDataNode.cs
@@ -58,7 +58,7 @@ namespace Robust.Shared.Serialization.Markdown.Value
 
         public override bool IsEmpty => string.IsNullOrWhiteSpace(Value);
 
-        private static bool IsNullLiteral(string? value) => value != null && value.Trim().ToLower() is "null" ;
+        public static bool IsNullLiteral(string? value) => value != null && value.Trim().ToLower() is "null" ;
 
         public override ValueDataNode Copy()
         {
@@ -76,6 +76,7 @@ namespace Robust.Shared.Serialization.Markdown.Value
             return node.Value == Value ? null : Copy();
         }
 
+        [Obsolete("Use SerializationManager.PushComposition()")]
         public override ValueDataNode PushInheritance(ValueDataNode node)
         {
             return Copy();

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/AbstractDictionarySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/AbstractDictionarySerializer.cs
@@ -58,7 +58,7 @@ public sealed class AbstractDictionarySerializer<TValue> : ITypeSerializer<Dicti
         {
             // TODO SERIALIZATION
             // Add some way to directly return a string w/o allocating a ValueDataNode
-            var keyNode = serializationManager.WriteValue(key, alwaysWrite, context, notNullableOverride: true);
+            var keyNode = serializationManager.WriteValue(key.Name, alwaysWrite, context, notNullableOverride: true);
             if (keyNode is not ValueDataNode valueNode)
                 throw new NotSupportedException();
 

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/AbstractDictionarySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/AbstractDictionarySerializer.cs
@@ -11,30 +11,25 @@ using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 /// <summary>
-/// A custom type serializer for reading a set of types that inherit from some base type. 
+/// A custom type serializer for reading a set of types that inherit from some base type.
 /// </summary>
-public sealed class AbstractDictionarySerializer<TValue> : ITypeSerializer<Dictionary<Type, TValue>, MappingDataNode> 
+public sealed class AbstractDictionarySerializer<TValue> : ITypeSerializer<Dictionary<Type, TValue>, MappingDataNode>
     where TValue : notnull
 {
     public ValidationNode Validate(ISerializationManager serializationManager, MappingDataNode node,
         IDependencyCollection dependencies, ISerializationContext? context = null)
-    {        
+    {
         var mapping = new Dictionary<ValidationNode, ValidationNode>();
-        foreach (var (keyNode, valueNode) in node.Children)
+        foreach (var (key, valueNode) in node.Children)
         {
-            if (keyNode is not ValueDataNode key)
-            {
-                mapping.Add(new ErrorNode(keyNode, $"Expected {nameof(ValueDataNode)} but was {keyNode.GetType()}"), new ValidatedValueNode(valueNode));
-                continue;
-            }
-            var type = serializationManager.ReflectionManager.YamlTypeTagLookup(typeof(TValue), key.Value);
+            var type = serializationManager.ReflectionManager.YamlTypeTagLookup(typeof(TValue), key);
             if (type == null)
             {
-                mapping.Add(new ErrorNode(keyNode, $"Could not resolve type: {key.Value}"), new ValidatedValueNode(valueNode));
+                mapping.Add(new ErrorNode(node.GetKeyNode(key), $"Could not resolve type: {key}"), new ValidatedValueNode(valueNode));
                 continue;
             }
-            
-            mapping.Add(new ValidatedValueNode(key), serializationManager.ValidateNode(type, valueNode, context));
+
+            mapping.Add(new ValidatedValueNode(node.GetKeyNode(key)), serializationManager.ValidateNode(type, valueNode, context));
         }
 
         return new ValidatedMappingNode(mapping);
@@ -44,10 +39,9 @@ public sealed class AbstractDictionarySerializer<TValue> : ITypeSerializer<Dicti
         SerializationHookContext hookCtx, ISerializationContext? context = null, ISerializationManager.InstantiationDelegate<Dictionary<Type, TValue>>? instanceProvider = null)
     {
         var dict = instanceProvider != null ? instanceProvider() : new Dictionary<Type, TValue>();
-        foreach (var (keyNode, valueNode) in node.Children)
+        foreach (var (key, valueNode) in node.Children)
         {
-            var key = (ValueDataNode) keyNode;
-            var type = serializationManager.ReflectionManager.YamlTypeTagLookup(typeof(TValue), key.Value)!;
+            var type = serializationManager.ReflectionManager.YamlTypeTagLookup(typeof(TValue), key)!;
             var value = (TValue) serializationManager.Read(type, valueNode, hookCtx, context, notNullableOverride:true)!;
             dict.Add(type, value);
         }
@@ -62,8 +56,14 @@ public sealed class AbstractDictionarySerializer<TValue> : ITypeSerializer<Dicti
 
         foreach (var (key, val) in value)
         {
+            // TODO SERIALIZATION
+            // Add some way to directly return a string w/o allocating a ValueDataNode
+            var keyNode = serializationManager.WriteValue(key, alwaysWrite, context, notNullableOverride: true);
+            if (keyNode is not ValueDataNode valueNode)
+                throw new NotSupportedException();
+
             mappingNode.Add(
-                serializationManager.WriteValue(key.Name, alwaysWrite, context, notNullableOverride:true),
+                valueNode.Value,
                 serializationManager.WriteValue(key, val, alwaysWrite, context));
         }
 

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/Dictionary/PrototypeIdDictionarySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/Dictionary/PrototypeIdDictionarySerializer.cs
@@ -32,13 +32,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
 
             foreach (var (key, val) in node.Children)
             {
-                if (key is not ValueDataNode value)
-                {
-                    mapping.Add(new ErrorNode(key, $"Cannot cast node {key} to ValueDataNode."), serializationManager.ValidateNode<TValue>(val, context));
-                    continue;
-                }
-
-                mapping.Add(PrototypeSerializer.Validate(serializationManager, value, dependencies, context), serializationManager.ValidateNode<TValue>(val, context));
+                var keyNode = new ValueDataNode(key);
+                mapping.Add(PrototypeSerializer.Validate(serializationManager, keyNode, dependencies, context), serializationManager.ValidateNode<TValue>(val, context));
             }
 
             return new ValidatedMappingNode(mapping);

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/Dictionary/PrototypeIdValueDictionarySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/Dictionary/PrototypeIdValueDictionarySerializer.cs
@@ -30,8 +30,9 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
         {
             var mapping = new Dictionary<ValidationNode, ValidationNode>();
 
-            foreach (var (key, val) in node.Children)
+            foreach (var (k, val) in node.Children)
             {
+                var key = node.GetKeyNode(k);
                 if (val is not ValueDataNode value)
                 {
                     mapping.Add(new ErrorNode(val, $"Cannot cast node {val} to ValueDataNode."), serializationManager.ValidateNode<TValue>(key, context));

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/DictionarySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/DictionarySerializer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,6 +9,7 @@ using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
@@ -59,7 +61,7 @@ public sealed class DictionarySerializer<TKey, TValue> :
         var mapping = new Dictionary<ValidationNode, ValidationNode>();
         foreach (var (key, val) in node.Children)
         {
-            mapping.Add(serializationManager.ValidateNode<TKey>(key, context),
+            mapping.Add(serializationManager.ValidateNode<TKey>(node.GetKeyNode(key), context),
                 serializationManager.ValidateNode<TValue>(val, context));
         }
 
@@ -79,8 +81,14 @@ public sealed class DictionarySerializer<TKey, TValue> :
         var mappingNode = new MappingDataNode();
         foreach (var (key, val) in value)
         {
+            // TODO SERIALIZATION
+            // Add some way to directly return a string w/o allocating a ValueDataNode
+            var keyNode = serializationManager.WriteValue(key, alwaysWrite, context);
+            if (keyNode is not ValueDataNode valueNode)
+                throw new NotSupportedException("Yaml mapping keys must serialize to a ValueDataNode (i.e. a string)");
+
             mappingNode.Add(
-                serializationManager.WriteValue(key, alwaysWrite, context),
+                valueNode.Value,
                 serializationManager.WriteValue(val, alwaysWrite, context));
         }
 
@@ -128,9 +136,11 @@ public sealed class DictionarySerializer<TKey, TValue> :
     {
         var dict = instanceProvider != null ? instanceProvider() : new Dictionary<TKey, TValue>();
 
+        var keyNode = new ValueDataNode();
         foreach (var (key, value) in node.Children)
         {
-            dict.Add(serializationManager.Read<TKey>(key, hookCtx, context),
+            keyNode.Value = key;
+            dict.Add(serializationManager.Read<TKey>(keyNode, hookCtx, context),
                 serializationManager.Read<TValue>(value, hookCtx, context));
         }
 
@@ -149,9 +159,11 @@ public sealed class DictionarySerializer<TKey, TValue> :
 
         var array = new KeyValuePair<TKey, TValue>[node.Children.Count];
         int i = 0;
+        var keyNode = new ValueDataNode();
         foreach (var (key, value) in node.Children)
         {
-            var k = serializationManager.Read<TKey>(key, hookCtx, context);
+            keyNode.Value = key;
+            var k = serializationManager.Read<TKey>(keyNode, hookCtx, context);
             var v = serializationManager.Read<TValue>(value, hookCtx, context);
             array[i++] = new(k,v);
         }
@@ -174,9 +186,11 @@ public sealed class DictionarySerializer<TKey, TValue> :
 
         var dict = new Dictionary<TKey, TValue>();
 
+        var keyNode = new ValueDataNode();
         foreach (var (key, value) in node.Children)
         {
-            dict.Add(serializationManager.Read<TKey>(key, hookCtx, context),
+            keyNode.Value = key;
+            dict.Add(serializationManager.Read<TKey>(keyNode, hookCtx, context),
                 serializationManager.Read<TValue>(value, hookCtx, context));
         }
 
@@ -190,10 +204,12 @@ public sealed class DictionarySerializer<TKey, TValue> :
         ISerializationManager.InstantiationDelegate<SortedDictionary<TKey, TValue>>? instanceProvider)
     {
         var dict = instanceProvider != null ? instanceProvider() : new SortedDictionary<TKey, TValue>();
+        var keyNode = new ValueDataNode();
 
         foreach (var (key, value) in node.Children)
         {
-            dict.Add(serializationManager.Read<TKey>(key, hookCtx, context),
+            keyNode.Value = key;
+            dict.Add(serializationManager.Read<TKey>(keyNode, hookCtx, context),
                 serializationManager.Read<TValue>(value, hookCtx, context));
         }
 

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ValueTupleSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ValueTupleSerializer.cs
@@ -7,10 +7,13 @@ using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
 {
+    AAAA
+        This needs to be converted to use sequence nodes.
     [TypeSerializer]
     public sealed class ValueTupleSerializer<T1, T2> : ITypeSerializer<ValueTuple<T1, T2>, MappingDataNode>, ITypeCopyCreator<ValueTuple<T1, T2>>
     {
@@ -23,7 +26,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
                 throw new InvalidMappingException("Less than or more than 1 mappings provided to ValueTupleSerializer");
 
             var entry = node.Children.First();
-            var v1 = serializationManager.Read<T1>(entry.Key, hookCtx, context);
+            var v1 = serializationManager.Read<T1>(node.GetKeyNode(entry.Key), hookCtx, context);
             var v2 = serializationManager.Read<T2>(entry.Value, hookCtx, context);
 
             return (v1, v2);
@@ -39,7 +42,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
             var dict = new Dictionary<ValidationNode, ValidationNode>
             {
                 {
-                    serializationManager.ValidateNode<T1>(entry.Key, context),
+                    serializationManager.ValidateNode<T1>(node.GetKeyNode(entry.Key), context),
                     serializationManager.ValidateNode<T2>(entry.Value, context)
                 }
             };
@@ -53,8 +56,12 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
         {
             var mapping = new MappingDataNode();
 
+            var keyNode = serializationManager.WriteValue(value.Item1, alwaysWrite, context);
+            if (keyNode is not ValueDataNode valueNode)
+                throw new NotSupportedException();
+
             mapping.Add(
-                serializationManager.WriteValue<T1>(value.Item1, alwaysWrite, context),
+                valueNode.Value,
                 serializationManager.WriteValue<T2>(value.Item2, alwaysWrite, context));
 
             return mapping;

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ValueTupleSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ValueTupleSerializer.cs
@@ -6,21 +6,25 @@ using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Mapping;
+using Robust.Shared.Serialization.Markdown.Sequence;
 using Robust.Shared.Serialization.Markdown.Validation;
-using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
 {
-    AAAA
-        This needs to be converted to use sequence nodes.
     [TypeSerializer]
-    public sealed class ValueTupleSerializer<T1, T2> : ITypeSerializer<ValueTuple<T1, T2>, MappingDataNode>, ITypeCopyCreator<ValueTuple<T1, T2>>
+    public sealed class ValueTupleSerializer<T1, T2> :
+        ITypeReader<ValueTuple<T1, T2>, MappingDataNode>,
+        ITypeSerializer<ValueTuple<T1, T2>, SequenceDataNode>,
+        ITypeCopyCreator<ValueTuple<T1, T2>>
     {
-        public (T1, T2) Read(ISerializationManager serializationManager, MappingDataNode node,
+        public (T1, T2) Read(
+            ISerializationManager serializationManager,
+            MappingDataNode node,
             IDependencyCollection dependencies,
             SerializationHookContext hookCtx,
-            ISerializationContext? context = null, ISerializationManager.InstantiationDelegate<(T1, T2)>? val = null)
+            ISerializationContext? context = null,
+            ISerializationManager.InstantiationDelegate<(T1, T2)>? instanceProvider = null)
         {
             if (node.Children.Count != 1)
                 throw new InvalidMappingException("Less than or more than 1 mappings provided to ValueTupleSerializer");
@@ -32,11 +36,31 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
             return (v1, v2);
         }
 
-        public ValidationNode Validate(ISerializationManager serializationManager, MappingDataNode node,
+        public (T1, T2) Read(
+            ISerializationManager serializationManager,
+            SequenceDataNode node,
+            IDependencyCollection dependencies,
+            SerializationHookContext hookCtx,
+            ISerializationContext? context = null,
+            ISerializationManager.InstantiationDelegate<(T1, T2)>? val = null)
+        {
+            if (node.Count != 2)
+                throw new InvalidMappingException("Sequence must contain exactly 2 elements.");
+
+            var v1 = serializationManager.Read<T1>(node[0], hookCtx, context);
+            var v2 = serializationManager.Read<T2>(node[1], hookCtx, context);
+
+            return (v1, v2);
+        }
+
+        public ValidationNode Validate(
+            ISerializationManager serializationManager,
+            MappingDataNode node,
             IDependencyCollection dependencies,
             ISerializationContext? context = null)
         {
-            if (node.Children.Count != 1) return new ErrorNode(node, "More or less than 1 Mapping for ValueTuple found.");
+            if (node.Children.Count != 1)
+                return new ErrorNode(node, "More or less than 1 Mapping for ValueTuple found.");
 
             var entry = node.Children.First();
             var dict = new Dictionary<ValidationNode, ValidationNode>
@@ -50,25 +74,44 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
             return new ValidatedMappingNode(dict);
         }
 
-        public DataNode Write(ISerializationManager serializationManager, (T1, T2) value,
-            IDependencyCollection dependencies, bool alwaysWrite = false,
+        public ValidationNode Validate(
+            ISerializationManager serializationManager,
+            SequenceDataNode node,
+            IDependencyCollection dependencies,
             ISerializationContext? context = null)
         {
-            var mapping = new MappingDataNode();
+            if (node.Count != 2)
+                throw new InvalidMappingException("Sequence must contain exactly 2 elements.");
 
-            var keyNode = serializationManager.WriteValue(value.Item1, alwaysWrite, context);
-            if (keyNode is not ValueDataNode valueNode)
-                throw new NotSupportedException();
+            var seq = new List<ValidationNode>
+            {
+                serializationManager.ValidateNode<T1>(node[0], context),
+                serializationManager.ValidateNode<T2>(node[1], context)
+            };
 
-            mapping.Add(
-                valueNode.Value,
-                serializationManager.WriteValue<T2>(value.Item2, alwaysWrite, context));
-
-            return mapping;
+            return new ValidatedSequenceNode(seq);
         }
 
-        public (T1, T2) CreateCopy(ISerializationManager serializationManager, (T1, T2) source,
-            IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context = null)
+        public DataNode Write(
+            ISerializationManager serializationManager,
+            (T1, T2) value,
+            IDependencyCollection dependencies,
+            bool alwaysWrite = false,
+            ISerializationContext? context = null)
+        {
+            return new SequenceDataNode(new List<DataNode>
+            {
+                serializationManager.WriteValue(value.Item1, alwaysWrite, context),
+                serializationManager.WriteValue(value.Item2, alwaysWrite, context)
+            });
+        }
+
+        public (T1, T2) CreateCopy(
+            ISerializationManager serializationManager,
+            (T1, T2) source,
+            IDependencyCollection dependencies,
+            SerializationHookContext hookCtx,
+            ISerializationContext? context = null)
         {
             return (serializationManager.CreateCopy(source.Item1, hookCtx, context),
                 serializationManager.CreateCopy(source.Item2, hookCtx, context));

--- a/Robust.UnitTesting/Shared/Serialization/SerializationTests/ManagerTests.cs
+++ b/Robust.UnitTesting/Shared/Serialization/SerializationTests/ManagerTests.cs
@@ -69,10 +69,10 @@ public sealed partial class ManagerTests : SerializationTest
             }, //ISelfSerialize
             new object[]
             {
-                new MappingDataNode(new Dictionary<DataNode, DataNode>
+                new MappingDataNode(new Dictionary<string, DataNode>
                 {
-                    { new ValueDataNode("one"), new ValueDataNode("valueOne") },
-                    { new ValueDataNode("two"), new SequenceDataNode("2", "3") },
+                    { "one", new ValueDataNode("valueOne") },
+                    { "two", new SequenceDataNode("2", "3") },
                 }){Tag = $"!type:{nameof(DataDefClass)}"},
                 () => (IDataDefBaseInterface)new DataDefClass
                 {
@@ -112,10 +112,10 @@ public sealed partial class ManagerTests : SerializationTest
         }, //array
         new object[]
         {
-            new MappingDataNode(new Dictionary<DataNode, DataNode>
+            new MappingDataNode(new Dictionary<string, DataNode>
             {
-                { new ValueDataNode("one"), new ValueDataNode("valueOne") },
-                { new ValueDataNode("two"), new SequenceDataNode("2", "3") },
+                { "one", new ValueDataNode("valueOne") },
+                { "two", new SequenceDataNode("2", "3") },
             }),
             () => new DataDefClass
             {
@@ -204,10 +204,10 @@ public sealed partial class ManagerTests : SerializationTest
     {
         new object[]
         {
-            new MappingDataNode(new Dictionary<DataNode, DataNode>()
+            new MappingDataNode(new Dictionary<string, DataNode>()
             {
-                { new ValueDataNode("one"), new ValueDataNode("valueOne") },
-                { new ValueDataNode("two"), new SequenceDataNode("2", "3") },
+                { "one", new ValueDataNode("valueOne") },
+                { "two", new SequenceDataNode("2", "3") },
             }),
             () => new DataDefStruct
             {

--- a/Robust.UnitTesting/Shared/Serialization/SerializationTests/ReadValueProviderTests.cs
+++ b/Robust.UnitTesting/Shared/Serialization/SerializationTests/ReadValueProviderTests.cs
@@ -77,7 +77,7 @@ public sealed partial class ReadValueProviderTests : SerializationTest
     public void DataDefinitionMappingBaseTest()
     {
         var data = "someData";
-        var mapping = new MappingDataNode(new Dictionary<DataNode, DataNode>{{ new ValueDataNode("data"), new ValueDataNode(data) }})
+        var mapping = new MappingDataNode(new Dictionary<string, DataNode>{{ "data", new ValueDataNode(data) }})
         {
             Tag = $"!type:{nameof(DataDefinitionValueProviderTestDummy)}"
         };


### PR DESCRIPTION
Requires space-wizards/space-station-14/pull/36111

This PR limits yaml mappings/dictionaries to using only string keys. This effectively changes MappingDataNode from a wrapper around `Dictionary<DataNode,DataNode>` to `Dictionary<string, DataNode>`. This was already brought up a few times in maintainer meetings, with the main reasons for this change including:
- Reducing allocations
- Removing the `static readonly ThreadLocal<ValueDataNode> FetchNode` jank
- Preventing issues due to using mutable objects as dictionary keys (nothing prevents you from changing the value or hashcode of a `ValueDataNode` after it has been used as a dictionary key) 
- Probably improves performance for adding or fetching entries.

This is obviously a breaking change, though I've added some helper methods to `MappingDataNode` that take in a `ValueDataNode` to make updating the engine version somewhat easier. Aside from that, two other issues came up while working on this PR

Firstly, yaml validators need to know the position of a key in the yaml file to report errors. Replacing the DataNode keys with strings removes this information. To fix this, mapping nodes loaded from a yaml file will still store the original ValueDataNode which can be retrieved via `MappingDataNode.GetKeyNode()`. However AFAIK this is only actually required when running the yaml linter, and should probably still somehow be disabled by default. And it could probably also be reworked to only store the `NodeMark` struct instead of the whole node, but its good enough for now.

Secondly, the tuple serializer currently only supports 2-item tuples and serializes them as a mapping with a single entry. I.e., `("foo", "bar")` serializes to `{ foo: bar }`. Given that mappings now require string keys, this would make it impossible to serialize tuples where the first item is null or can't be serialized as a yaml string. So this PR changes the serializer to use sequences instead (i..e, `[foo, bar]`). It can still try to read mappings, but actually reading the mapping might fail due to the other changes, which would require any old prototypes or maps to be manually migrated to using a sequence node.  It seems like tuple data fields aren't all that common, and this issue didn't seem to come up at all in ss14, so maybe its fine? I also think this is a change we should make anyways, because using mapping nodes obviously wouldn't work if we ever wanted to support tuple data fields with 3+ items, so they really should've been using sequence nodes from the very beginning.