### PR TITLE
Add new `SerializationManager.PushComposition()` overload

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Add a new `SerializationManager.PushComposition()` overload that takes in a single parent instead of an array of parents.
 
 ### Bugfixes
 

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -408,16 +408,26 @@ namespace Robust.Shared.Prototypes
                             if (nonPushedParent)
                                 continue;
 
-                            var parentMaps = new MappingDataNode[parents.Length];
-                            for (var i = 0; i < parentMaps.Length; i++)
+                            if (parents.Length == 1)
                             {
-                                parentMaps[i] = kindData.Results[parents[i]];
+                                kindData.Results[id] = _serializationManager.PushCompositionWithGenericNode(
+                                    kind,
+                                    kindData.Results[parents[0]],
+                                    kindData.RawResults[id]);
                             }
+                            else
+                            {
+                                var parentMaps = new MappingDataNode[parents.Length];
+                                for (var i = 0; i < parentMaps.Length; i++)
+                                {
+                                    parentMaps[i] = kindData.Results[parents[i]];
+                                }
 
-                            kindData.Results[id] = _serializationManager.PushCompositionWithGenericNode(
-                                kind,
-                                parentMaps,
-                                kindData.RawResults[id]);
+                                kindData.Results[id] = _serializationManager.PushCompositionWithGenericNode(
+                                    kind,
+                                    parentMaps,
+                                    kindData.RawResults[id]);
+                            }
                         }
                         else
                         {
@@ -629,16 +639,26 @@ namespace Robust.Shared.Prototypes
                 {
                     if (tree.TryGetParents(id, out var parents))
                     {
-                        var parentNodes = new MappingDataNode[parents.Length];
-                        for (var i = 0; i < parents.Length; i++)
+                        if (parents.Length == 1)
                         {
-                            parentNodes[i] = results[parents[i]].Result;
+                            datum.Result = _serializationManager.PushCompositionWithGenericNode(
+                                kind,
+                                results[parents[0]].Result,
+                                datum.Result);
                         }
+                        else
+                        {
+                            var parentNodes = new MappingDataNode[parents.Length];
+                            for (var i = 0; i < parents.Length; i++)
+                            {
+                                parentNodes[i] = results[parents[i]].Result;
+                            }
 
-                        datum.Result = _serializationManager.PushCompositionWithGenericNode(
-                            kind,
-                            parentNodes,
-                            datum.Result);
+                            datum.Result = _serializationManager.PushCompositionWithGenericNode(
+                                kind,
+                                parentNodes,
+                                datum.Result);
+                        }
                     }
 
                     if (tree.TryGetChildren(id, out var children))

--- a/Robust.Shared/Serialization/Manager/ISerializationManager.cs
+++ b/Robust.Shared/Serialization/Manager/ISerializationManager.cs
@@ -421,11 +421,18 @@ namespace Robust.Shared.Serialization.Manager
         #region Composition
 
         DataNode PushComposition(Type type, DataNode[] parents, DataNode child, ISerializationContext? context = null);
+        DataNode PushComposition(Type type, DataNode parent, DataNode child, ISerializationContext? context = null);
 
         public TNode PushComposition<TType, TNode>(TNode[] parents, TNode child, ISerializationContext? context = null) where TNode : DataNode
         {
             // ReSharper disable once CoVariantArrayConversion
             return (TNode)PushComposition(typeof(TType), parents, child, context);
+        }
+
+        public TNode PushComposition<TType, TNode>(TNode parent, TNode child, ISerializationContext? context = null)
+            where TNode : DataNode
+        {
+            return (TNode) PushComposition(typeof(TType), parent, child, context);
         }
 
         TNode PushInheritance<TType, TNode>(ITypeInheritanceHandler<TType, TNode> inheritanceHandler, TNode parent, TNode child,
@@ -439,6 +446,12 @@ namespace Robust.Shared.Serialization.Manager
         {
             // ReSharper disable once CoVariantArrayConversion
             return (TNode) PushComposition(type, parents, child, context);
+        }
+
+        public TNode PushCompositionWithGenericNode<TNode>(Type type, TNode parent, TNode child, ISerializationContext? context = null)
+            where TNode : DataNode
+        {
+            return (TNode) PushComposition(type, parent, child, context);
         }
 
         /// <summary>

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentRegistrySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentRegistrySerializer.cs
@@ -207,7 +207,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
                     {
                         newCompReg[idx] = serializationManager.PushCompositionWithGenericNode(
                             reg.Type,
-                            new[] { parent[mapping] },
+                            parent[mapping],
                             newCompReg[idx],
                             context);
 


### PR DESCRIPTION
Adds a new `SerializationManager.PushComposition()` overload that takes in a single parent instead of an array of parents. Avoids allocating some arrays. Probably not all that significant even though the majority of prototypes only have a single parent, but it just irks me whenever I see the method called with `new[] { parent }`