### PR TITLE
Fix RemCompDeferred not always setting lifestage

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Fix deferred component removal not setting the component's life stage to `ComponentLifeStage.Stopped` if the component has not yet been initialised.
 
 ### Other
 

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -595,12 +595,23 @@ namespace Robust.Shared.GameObjects
 
             if (!_deleteSet.Add(component))
             {
-                // already deferred deletion
+                // Already deferring deletion
+                DebugTools.Assert(component.LifeStage >= ComponentLifeStage.Stopped);
                 return;
             }
 
-            if (component.LifeStage >= ComponentLifeStage.Initialized && component.LifeStage <= ComponentLifeStage.Running)
+            DebugTools.Assert(component.LifeStage >= ComponentLifeStage.Added);
+
+            if (component.LifeStage is >= ComponentLifeStage.Initialized and < ComponentLifeStage.Stopping)
                 LifeShutdown(uid, component, _componentFactory.GetIndex(component.GetType()));
+            else if (component.LifeStage == ComponentLifeStage.Added)
+            {
+                // The component was added, but never initialized or started. It's kinda weird to add and then
+                // immediately deffer-remove a component, but oh well. Let's just set the life stage directly and not
+                // raise shutdown events? The removal events will still get called later.
+                // This is also what LifeShutdown() would also do, albeit behind a DebugAssert.
+                component.LifeStage = ComponentLifeStage.Stopped;
+            }
 #if EXCEPTION_TOLERANCE
             }
             catch (Exception e)

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -607,7 +607,7 @@ namespace Robust.Shared.GameObjects
             else if (component.LifeStage == ComponentLifeStage.Added)
             {
                 // The component was added, but never initialized or started. It's kinda weird to add and then
-                // immediately deffer-remove a component, but oh well. Let's just set the life stage directly and not
+                // immediately defer-remove a component, but oh well. Let's just set the life stage directly and not
                 // raise shutdown events? The removal events will still get called later.
                 // This is also what LifeShutdown() would also do, albeit behind a DebugAssert.
                 component.LifeStage = ComponentLifeStage.Stopped;

--- a/Robust.Shared/GameObjects/EntityManager.LifeCycle.cs
+++ b/Robust.Shared/GameObjects/EntityManager.LifeCycle.cs
@@ -16,6 +16,7 @@ public partial class EntityManager
     /// </summary>
     internal void LifeAddToEntity(EntityUid uid, IComponent component, CompIdx idx)
     {
+        DebugTools.Assert(!_deleteSet.Contains(component));
         DebugTools.Assert(component.LifeStage == ComponentLifeStage.PreAdd);
 
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -34,6 +35,7 @@ public partial class EntityManager
     /// </summary>
     internal void LifeInitialize(EntityUid uid, IComponent component, CompIdx idx)
     {
+        DebugTools.Assert(!_deleteSet.Contains(component));
         DebugTools.Assert(component.LifeStage == ComponentLifeStage.Added);
 
         component.LifeStage = ComponentLifeStage.Initializing;
@@ -47,6 +49,7 @@ public partial class EntityManager
     /// </summary>
     internal void LifeStartup(EntityUid uid, IComponent component, CompIdx idx)
     {
+        DebugTools.Assert(!_deleteSet.Contains(component));
         DebugTools.Assert(component.LifeStage == ComponentLifeStage.Initialized);
 
         component.LifeStage = ComponentLifeStage.Starting;


### PR DESCRIPTION
Makes deferred component removal mark components as stopped even if they have not yet been initialized. AFAIK this isn't a serious issue, and just results in a warning being logged in `CullRemovedComponents()`, but that can cause some tests to fail.