### PR TITLE
set default pitch variation for all sounds at -0.08

### DIFF
--- a/Robust.Shared/Audio/AudioParams.cs
+++ b/Robust.Shared/Audio/AudioParams.cs
@@ -93,14 +93,14 @@ namespace Robust.Shared.Audio
         ///     If not null, this will randomly modify the pitch scale by adding a number drawn from a normal distribution with this deviation.
         /// </summary>
         [DataField]
-        public float? Variation { get; set; } = null;
+        public float? Variation { get; set; } = Default.Variation;
 
         // For the max distance value: it's 2000 in Godot, but I assume that's PIXELS due to the 2D positioning,
         // so that's divided by 32 (EyeManager.PIXELSPERMETER).
         /// <summary>
         ///     The "default" audio configuration.
         /// </summary>
-        public static readonly AudioParams Default = new(0, 1, SharedAudioSystem.DefaultSoundRange, 1, 1, false, 0f);
+        public static readonly AudioParams Default = new(0, 1, SharedAudioSystem.DefaultSoundRange, 1, 1, false, 0f, -0.08f);
 
         // explicit parameterless constructor required so that default values get set properly.
         public AudioParams() { }


### PR DESCRIPTION
This adjusts the default pitch variation for all sounds to -0.08f. The current default is 'null', which (in my experience and for many other players) results in significant ear fatigue; in my case it also results in headaches.

A value of -0.08 reduces ear fatigue without significantly altering how recognizable a given sound is for the purposes of gameplay dynamics such as overhearing nefarious activities or knowing who is walking around on the other side of a wall. I intend to make other modifications to some of the sound systems for Space Station 14, but this variable here is defined within the game engine itself. Down the line it may be wiser to define sound defaults as their own .yml, but at this time I think this sufficiently addresses the problems of ear fatigue.

No variation:

https://github.com/user-attachments/assets/a81a8213-f60f-4b27-83f1-e4b7a176c7db

-0.08f variation:


https://github.com/user-attachments/assets/d149a480-f504-4704-a647-577765cd886d



