### PR TITLE
Added  a copy visuals function to the point light system

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/PointLightSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/PointLightSystem.cs
@@ -120,5 +120,14 @@ namespace Robust.Client.GameObjects
                 _lightTree.QueueTreeUpdate(uid, clientComp);
         }
         #endregion
+
+        public void CopyVisuals(EntityUid uid, PointLightComponent otherPointLight, PointLightComponent? pointlight = null) {
+            base.CopyVisuals(uid, otherPointLight, pointlight);
+
+            if (!Resolve(uid, ref pointlight))
+                return;
+
+            SetMask(pointlight.MaskPath, pointlight);
+        }
     }
 }

--- a/Robust.Client/GameObjects/EntitySystems/PointLightSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/PointLightSystem.cs
@@ -121,10 +121,10 @@ namespace Robust.Client.GameObjects
         }
         #endregion
 
-        public void CopyVisuals(EntityUid uid, PointLightComponent otherPointLight, PointLightComponent? pointlight = null) {
-            base.CopyVisuals(uid, otherPointLight, pointlight);
+        public void CopyVisuals(Entity<SharedPointLightComponent?> pointLightEntity, PointLightComponent? otherPointLight = null) {
+            base.CopyVisuals(pointLightEntity, otherPointLight);
 
-            if (!Resolve(uid, ref pointlight))
+            if (pointLightEntity.Comp is not PointLightComponent pointlight)
                 return;
 
             SetMask(pointlight.MaskPath, pointlight);

--- a/Robust.Shared/GameObjects/Systems/SharedPointLightSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPointLightSystem.cs
@@ -92,26 +92,26 @@ public abstract class SharedPointLightSystem : EntitySystem
     /// <summary>
     ///     Copy visuals from one pointlight to another.
     /// </summary>
-    public void CopyVisuals(EntityUid uid, SharedPointLightComponent otherPointLight, SharedPointLightComponent? pointlight = null, bool forceDisabled = false)
+    public void CopyVisuals(Entity<SharedPointLightComponent?> pointLightEntity, SharedPointLightComponent? otherPointLight = null, bool forceDisabled = false)
     {
-        if (!Resolve(uid, ref pointlight))
+        if (pointLightEntity.Comp is not SharedPointLightComponent pointLight || otherPointLight == null)
             return;
 
-        pointlight.Color = otherPointLight.Color;
-        pointlight.Energy = otherPointLight.Energy;
-        pointlight.Offset = otherPointLight.Offset;
-        pointlight.Radius = otherPointLight.Radius;
-        pointlight.Softness = otherPointLight.Softness;
-        pointlight.CastShadows = otherPointLight.CastShadows;
-        pointlight.Rotation = otherPointLight.Rotation;
-        pointlight.MaskAutoRotate = otherPointLight.MaskAutoRotate;
-        pointlight.MaskPath = otherPointLight.MaskPath;
-        pointlight.ContainerOccluded = otherPointLight.ContainerOccluded;
-        pointlight.NetSyncEnabled = false;
+        pointLight.Color = otherPointLight.Color;
+        pointLight.Energy = otherPointLight.Energy;
+        pointLight.Offset = otherPointLight.Offset;
+        pointLight.Radius = otherPointLight.Radius;
+        pointLight.Softness = otherPointLight.Softness;
+        pointLight.CastShadows = otherPointLight.CastShadows;
+        pointLight.Rotation = otherPointLight.Rotation;
+        pointLight.MaskAutoRotate = otherPointLight.MaskAutoRotate;
+        pointLight.MaskPath = otherPointLight.MaskPath;
+        pointLight.ContainerOccluded = otherPointLight.ContainerOccluded;
+        pointLight.NetSyncEnabled = false;
 
         if (forceDisabled)
-            pointlight.Enabled = false;
+            pointLight.Enabled = false;
 
-        Dirty(uid, pointlight);
+        Dirty(pointLightEntity);
     }
 }

--- a/Robust.Shared/GameObjects/Systems/SharedPointLightSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPointLightSystem.cs
@@ -87,4 +87,31 @@ public abstract class SharedPointLightSystem : EntitySystem
         comp.Softness = value;
         Dirty(uid, comp);
     }
+
+
+    /// <summary>
+    ///     Copy visuals from one pointlight to another.
+    /// </summary>
+    public void CopyVisuals(EntityUid uid, SharedPointLightComponent otherPointLight, SharedPointLightComponent? pointlight = null, bool forceDisabled = false)
+    {
+        if (!Resolve(uid, ref pointlight))
+            return;
+
+        pointlight.Color = otherPointLight.Color;
+        pointlight.Energy = otherPointLight.Energy;
+        pointlight.Offset = otherPointLight.Offset;
+        pointlight.Radius = otherPointLight.Radius;
+        pointlight.Softness = otherPointLight.Softness;
+        pointlight.CastShadows = otherPointLight.CastShadows;
+        pointlight.Rotation = otherPointLight.Rotation;
+        pointlight.MaskAutoRotate = otherPointLight.MaskAutoRotate;
+        pointlight.MaskPath = otherPointLight.MaskPath;
+        pointlight.ContainerOccluded = otherPointLight.ContainerOccluded;
+        pointlight.NetSyncEnabled = false;
+
+        if (forceDisabled)
+            pointlight.Enabled = false;
+
+        Dirty(uid, pointlight);
+    }
 }


### PR DESCRIPTION
# Background
While working on my pull request for a `ChameleonHardsuit`in the Wizden repository I ran into the problem, that I had to copy details from one `PointLightComponent` to another. Since only the PointLightSystem had full access to those properties, I had to add it in there. I hope that is not a problem.

# Technical details
- Added a CopyVisuals to the SharedPointLightSystem. This right now copies the relevant properties
- Added a CopyVisuals to the PointLightSystem which calls SetMask which was required to have the visual cone show up.

# PR in Wizden Repo
[Chameleon Hardsuit PR](https://github.com/space-wizards/space-station-14/pull/35798)