### PR TITLE
Inline manifold points

### DIFF
--- a/Robust.Shared/Physics/Collision/CollisionManager.Circles.cs
+++ b/Robust.Shared/Physics/Collision/CollisionManager.Circles.cs
@@ -27,7 +27,7 @@ internal sealed partial class CollisionManager
         manifold.LocalNormal = Vector2.Zero;
         manifold.PointCount = 1;
 
-        ref var p0 = ref manifold.Points[0];
+        ref var p0 = ref manifold.Points._00;
 
         p0.LocalPoint = Vector2.Zero; // Also here
         p0.Id.Key = 0;

--- a/Robust.Shared/Physics/Collision/CollisionManager.EdgeCircle.cs
+++ b/Robust.Shared/Physics/Collision/CollisionManager.EdgeCircle.cs
@@ -79,9 +79,9 @@ internal sealed partial class CollisionManager
 		        manifold.Type = ManifoldType.Circles;
 		        manifold.LocalNormal = Vector2.Zero;
 		        manifold.LocalPoint = P;
-		        manifold.Points[0].Id.Key = 0;
-		        manifold.Points[0].Id.Features = cf;
-		        manifold.Points[0].LocalPoint = circleB.Position;
+		        manifold.Points._00.Id.Key = 0;
+		        manifold.Points._00.Id.Features = cf;
+		        manifold.Points._00.LocalPoint = circleB.Position;
 		        return;
 	        }
 
@@ -114,9 +114,9 @@ internal sealed partial class CollisionManager
 		        manifold.Type = ManifoldType.Circles;
 		        manifold.LocalNormal = Vector2.Zero;
 		        manifold.LocalPoint = P;
-		        manifold.Points[0].Id.Key = 0;
-		        manifold.Points[0].Id.Features = cf;
-		        manifold.Points[0].LocalPoint = circleB.Position;
+		        manifold.Points._00.Id.Key = 0;
+		        manifold.Points._00.Id.Features = cf;
+		        manifold.Points._00.LocalPoint = circleB.Position;
 		        return;
 	        }
 
@@ -142,8 +142,8 @@ internal sealed partial class CollisionManager
 	        manifold.Type = ManifoldType.FaceA;
 	        manifold.LocalNormal = n;
 	        manifold.LocalPoint = A;
-	        manifold.Points[0].Id.Key = 0;
-	        manifold.Points[0].Id.Features = cf;
-	        manifold.Points[0].LocalPoint = circleB.Position;
+	        manifold.Points._00.Id.Key = 0;
+	        manifold.Points._00.Id.Features = cf;
+	        manifold.Points._00.LocalPoint = circleB.Position;
         }
 }

--- a/Robust.Shared/Physics/Collision/CollisionManager.EdgePolygon.cs
+++ b/Robust.Shared/Physics/Collision/CollisionManager.EdgePolygon.cs
@@ -238,15 +238,15 @@ internal sealed partial class CollisionManager
 	    }
 
 	    var pointCount = 0;
+        var points = manifold.Points.AsSpan;
+
 	    for (var i = 0; i < 2; ++i)
 	    {
-		    float separation;
-
-		    separation = Vector2.Dot(refFace.normal, clipPoints2[i].V - refFace.v1);
+            var separation = Vector2.Dot(refFace.normal, clipPoints2[i].V - refFace.v1);
 
 		    if (separation <= radius)
 		    {
-			    ref var cp = ref manifold.Points[pointCount];
+			    ref var cp = ref points[pointCount];
 
 			    if (primaryAxis.Type == EPAxisType.EdgeA)
 			    {

--- a/Robust.Shared/Physics/Collision/CollisionManager.PolygonCircle.cs
+++ b/Robust.Shared/Physics/Collision/CollisionManager.PolygonCircle.cs
@@ -64,7 +64,7 @@ internal sealed partial class CollisionManager
 		    manifold.LocalNormal = normals[normalIndex];
 		    manifold.LocalPoint = (v1 + v2) * 0.5f;
 
-            ref var p0 = ref manifold.Points[0];
+            ref var p0 = ref manifold.Points._00;
 
 		    p0.LocalPoint = circleB.Position;
 		    p0.Id.Key = 0;
@@ -88,7 +88,7 @@ internal sealed partial class CollisionManager
 		    manifold.LocalNormal = (cLocal - v1).Normalized();
             manifold.LocalPoint = v1;
 
-            ref var p0 = ref manifold.Points[0];
+            ref var p0 = ref manifold.Points._00;
 
 		    p0.LocalPoint = circleB.Position;
 		    p0.Id.Key = 0;
@@ -107,7 +107,7 @@ internal sealed partial class CollisionManager
 		    manifold.LocalNormal = (cLocal - v2).Normalized();
             manifold.LocalPoint = v2;
 
-            ref var p0 = ref manifold.Points[0];
+            ref var p0 = ref manifold.Points._00;
 
 		    p0.LocalPoint = circleB.Position;
 		    p0.Id.Key = 0;
@@ -126,7 +126,7 @@ internal sealed partial class CollisionManager
 		    manifold.LocalNormal = normals[vertIndex1];
 		    manifold.LocalPoint = faceCenter;
 
-            ref var p0 = ref manifold.Points[0];
+            ref var p0 = ref manifold.Points._00;
 
 		    p0.LocalPoint = circleB.Position;
             p0.Id.Key = 0;

--- a/Robust.Shared/Physics/Collision/CollisionManager.Polygons.cs
+++ b/Robust.Shared/Physics/Collision/CollisionManager.Polygons.cs
@@ -238,6 +238,8 @@ internal sealed partial class CollisionManager
         manifold.LocalPoint = planePoint;
 
         int pointCount = 0;
+        var points = manifold.Points.AsSpan;
+
         for (int i = 0; i < 2; ++i)
         {
             Vector2 value = clipPoints2[i].V;
@@ -245,7 +247,7 @@ internal sealed partial class CollisionManager
 
             if (separation <= totalRadius)
             {
-                ref var cp = ref manifold.Points[pointCount];
+                ref var cp = ref points[pointCount];
                 cp.LocalPoint = Transform.MulT(xf2, clipPoints2[i].V);
                 cp.Id = clipPoints2[i].ID;
 

--- a/Robust.Shared/Physics/Collision/CollisionManager.cs
+++ b/Robust.Shared/Physics/Collision/CollisionManager.cs
@@ -51,15 +51,18 @@ internal sealed partial class CollisionManager : IManifoldManager
         in Manifold manifold2)
     {
         // Detect persists and removes.
+        var points1 = manifold1.Points.AsSpan;
+        var points2 = manifold2.Points.AsSpan;
+
         for (int i = 0; i < manifold1.PointCount; ++i)
         {
-            ContactID id = manifold1.Points[i].Id;
+            var id = points1[i].Id;
 
             state1[i] = PointState.Remove;
 
             for (int j = 0; j < manifold2.PointCount; ++j)
             {
-                if (manifold2.Points[j].Id.Key == id.Key)
+                if (points2[j].Id.Key == id.Key)
                 {
                     state1[i] = PointState.Persist;
                     break;
@@ -70,13 +73,13 @@ internal sealed partial class CollisionManager : IManifoldManager
         // Detect persists and adds.
         for (int i = 0; i < manifold2.PointCount; ++i)
         {
-            ContactID id = manifold2.Points[i].Id;
+            var id = points2[i].Id;
 
             state2[i] = PointState.Add;
 
-            for (int j = 0; j < manifold1.PointCount; ++j)
+            for (var j = 0; j < manifold1.PointCount; ++j)
             {
-                if (manifold1.Points[j].Id.Key == id.Key)
+                if (points1[j].Id.Key == id.Key)
                 {
                     state2[i] = PointState.Persist;
                     break;

--- a/Robust.Shared/Physics/Collision/Manifold.cs
+++ b/Robust.Shared/Physics/Collision/Manifold.cs
@@ -25,6 +25,7 @@ using System.Numerics;
 using System.Runtime.InteropServices;
 using Robust.Shared.Localization;
 using Robust.Shared.Maths;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Physics.Collision;
 
@@ -146,7 +147,7 @@ public struct Manifold : IEquatable<Manifold>, IApproxEquatable<Manifold>
     /// <summary>
     ///     Points of contact, can only be 0 -> 2.
     /// </summary>
-    internal ManifoldPoint[] Points;
+    internal FixedArray2<ManifoldPoint> Points;
 
     public ManifoldType Type;
 
@@ -157,9 +158,12 @@ public struct Manifold : IEquatable<Manifold>, IApproxEquatable<Manifold>
               LocalNormal.Equals(other.LocalNormal) &&
               LocalPoint.Equals(other.LocalPoint))) return false;
 
+        var points = Points.AsSpan;
+        var otherPoints = other.Points.AsSpan;
+
         for (var i = 0; i < PointCount; i++)
         {
-            if (!Points[i].Equals(other.Points[i])) return false;
+            if (!points[i].Equals(otherPoints[i])) return false;
         }
 
         return true;
@@ -172,9 +176,12 @@ public struct Manifold : IEquatable<Manifold>, IApproxEquatable<Manifold>
               LocalNormal.EqualsApprox(other.LocalNormal) &&
               LocalPoint.EqualsApprox(other.LocalPoint))) return false;
 
+        var points = Points.AsSpan;
+        var otherPoints = other.Points.AsSpan;
+
         for (var i = 0; i < PointCount; i++)
         {
-            if (!Points[i].EqualsApprox(other.Points[i])) return false;
+            if (!points[i].EqualsApprox(otherPoints[i])) return false;
         }
 
         return true;
@@ -187,12 +194,25 @@ public struct Manifold : IEquatable<Manifold>, IApproxEquatable<Manifold>
               LocalNormal.EqualsApprox(other.LocalNormal, tolerance) &&
               LocalPoint.EqualsApprox(other.LocalPoint, tolerance))) return false;
 
+        var points = Points.AsSpan;
+        var otherPoints = other.Points.AsSpan;
+
         for (var i = 0; i < PointCount; i++)
         {
-            if (!Points[i].EqualsApprox(other.Points[i], tolerance)) return false;
+            if (!points[i].EqualsApprox(otherPoints[i], tolerance)) return false;
         }
 
         return true;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is Manifold manifold && Equals(manifold);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(LocalNormal, LocalPoint, PointCount, Points, (int)Type);
     }
 }
 

--- a/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
+++ b/Robust.Shared/Physics/Dynamics/Contacts/Contact.cs
@@ -206,16 +206,19 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
 
                 // Match old contact ids to new contact ids and copy the
                 // stored impulses to warm start the solver.
+                var points = Manifold.Points.AsSpan;
+                var oldPoints = oldManifold.Points.AsSpan;
+
                 for (var i = 0; i < Manifold.PointCount; ++i)
                 {
-                    var mp2 = Manifold.Points[i];
+                    var mp2 = points[i];
                     mp2.NormalImpulse = 0.0f;
                     mp2.TangentImpulse = 0.0f;
                     var id2 = mp2.Id;
 
                     for (var j = 0; j < oldManifold.PointCount; ++j)
                     {
-                        var mp1 = oldManifold.Points[j];
+                        var mp1 = oldPoints[j];
 
                         if (mp1.Id.Key == id2.Key)
                         {
@@ -225,7 +228,7 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
                         }
                     }
 
-                    Manifold.Points[i] = mp2;
+                    points[i] = mp2;
                 }
 
                 if (touching != wasTouching)

--- a/Robust.Shared/Physics/Dynamics/Contacts/ContactPositionConstraint.cs
+++ b/Robust.Shared/Physics/Dynamics/Contacts/ContactPositionConstraint.cs
@@ -22,6 +22,7 @@
 
 using System.Numerics;
 using Robust.Shared.Physics.Collision;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Physics.Dynamics.Contacts
 {
@@ -37,7 +38,7 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
         /// </summary>
         public int IndexB { get; set; }
 
-        public Vector2[] LocalPoints;
+        internal FixedArray2<Vector2> LocalPoints;
 
         public Vector2 LocalNormal;
 

--- a/Robust.Shared/Physics/Dynamics/Contacts/ContactVelocityConstraint.cs
+++ b/Robust.Shared/Physics/Dynamics/Contacts/ContactVelocityConstraint.cs
@@ -21,6 +21,7 @@
 */
 
 using System.Numerics;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Physics.Dynamics.Contacts
 {
@@ -39,13 +40,13 @@ namespace Robust.Shared.Physics.Dynamics.Contacts
         public int IndexB;
 
         // Use 2 as its the max number of manifold points.
-        public VelocityConstraintPoint[] Points;
+        public FixedArray2<VelocityConstraintPoint> Points;
 
         public Vector2 Normal;
 
-        public System.Numerics.Vector4 NormalMass;
+        public Vector4 NormalMass;
 
-        public System.Numerics.Vector4 K;
+        public Vector4 K;
 
         public float InvMassA;
         public float InvMassB;

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
@@ -113,10 +113,7 @@ public abstract partial class SharedPhysicsSystem
 #if DEBUG
             contact._debugPhysics = _debugPhysicsSystem;
 #endif
-            contact.Manifold = new Manifold
-            {
-                Points = new ManifoldPoint[2]
-            };
+            contact.Manifold = new Manifold();
 
             return contact;
         }

--- a/Robust.Shared/Utility/FixedArray.cs
+++ b/Robust.Shared/Utility/FixedArray.cs
@@ -79,12 +79,34 @@ namespace Robust.Shared.Utility
         }
     }
 
-    internal struct FixedArray2<T>
+    internal struct FixedArray2<T> : IEquatable<FixedArray2<T>>
     {
         public T _00;
         public T _01;
 
         public Span<T> AsSpan => MemoryMarshal.CreateSpan(ref _00, 2);
+
+        internal FixedArray2(T x0, T x1)
+        {
+            _00 = x0;
+            _01 = x1;
+        }
+
+        public bool Equals(FixedArray2<T> other)
+        {
+            return EqualityComparer<T>.Default.Equals(_00, other._00) &&
+                   EqualityComparer<T>.Default.Equals(_01, other._01);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is FixedArray2<T> other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(_00, _01);
+        }
     }
 
     internal struct FixedArray4<T> : IEquatable<FixedArray4<T>>
@@ -96,12 +118,20 @@ namespace Robust.Shared.Utility
 
         public Span<T> AsSpan => MemoryMarshal.CreateSpan(ref _00, 4);
 
+        internal FixedArray4(T x0, T x1, T x2, T x3)
+        {
+            _00 = x0;
+            _01 = x1;
+            _02 = x2;
+            _03 = x3;
+        }
+
         public bool Equals(FixedArray4<T> other)
         {
-            return _00?.Equals(other._00) == true &&
-                   _01?.Equals(other._01) == true &&
-                   _02?.Equals(other._02) == true &&
-                   _03?.Equals(other._03) == true;
+            return EqualityComparer<T>.Default.Equals(_00, other._00) &&
+                   EqualityComparer<T>.Default.Equals(_01, other._01) &&
+                   EqualityComparer<T>.Default.Equals(_01, other._02) &&
+                   EqualityComparer<T>.Default.Equals(_01, other._03);
         }
 
         public override bool Equals(object? obj)
@@ -128,16 +158,28 @@ namespace Robust.Shared.Utility
 
         public Span<T> AsSpan => MemoryMarshal.CreateSpan(ref _00, 8);
 
+        internal FixedArray8(T x0, T x1, T x2, T x3, T x4, T x5, T x6, T x7)
+        {
+            _00 = x0;
+            _01 = x1;
+            _02 = x2;
+            _03 = x3;
+            _04 = x4;
+            _05 = x5;
+            _06 = x6;
+            _07 = x7;
+        }
+
         public bool Equals(FixedArray8<T> other)
         {
-            return _00?.Equals(other._00) == true &&
-                   _01?.Equals(other._01) == true &&
-                   _02?.Equals(other._02) == true &&
-                   _03?.Equals(other._03) == true &&
-                   _04?.Equals(other._04) == true &&
-                   _05?.Equals(other._05) == true &&
-                   _06?.Equals(other._06) == true &&
-                   _07?.Equals(other._07) == true;
+            return EqualityComparer<T>.Default.Equals(_00, other._00) &&
+                   EqualityComparer<T>.Default.Equals(_01, other._01) &&
+                   EqualityComparer<T>.Default.Equals(_02, other._02) &&
+                   EqualityComparer<T>.Default.Equals(_03, other._03) &&
+                   EqualityComparer<T>.Default.Equals(_04, other._04) &&
+                   EqualityComparer<T>.Default.Equals(_05, other._05) &&
+                   EqualityComparer<T>.Default.Equals(_06, other._06) &&
+                   EqualityComparer<T>.Default.Equals(_07, other._07);
         }
 
         public override bool Equals(object? obj)

--- a/Robust.Shared/Utility/FixedArray.cs
+++ b/Robust.Shared/Utility/FixedArray.cs
@@ -130,8 +130,8 @@ namespace Robust.Shared.Utility
         {
             return EqualityComparer<T>.Default.Equals(_00, other._00) &&
                    EqualityComparer<T>.Default.Equals(_01, other._01) &&
-                   EqualityComparer<T>.Default.Equals(_01, other._02) &&
-                   EqualityComparer<T>.Default.Equals(_01, other._03);
+                   EqualityComparer<T>.Default.Equals(_02, other._02) &&
+                   EqualityComparer<T>.Default.Equals(_03, other._03);
         }
 
         public override bool Equals(object? obj)

--- a/Robust.UnitTesting/Shared/Physics/ManifoldManager_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/ManifoldManager_Test.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Collision;
 using Robust.Shared.Physics.Collision.Shapes;
+using Robust.Shared.Utility;
 
 namespace Robust.UnitTesting.Shared.Physics
 {
@@ -76,10 +77,7 @@ namespace Robust.UnitTesting.Shared.Physics
         {
             var transformB = new Transform(Vector2.One, 0f);
             var transformA = new Transform(transformB.Position + new Vector2(0.5f, 0.0f), 0f);
-            var manifold = new Manifold()
-            {
-                Points = new ManifoldPoint[2]
-            };
+            var manifold = new Manifold();
 
             var expectedManifold = new Manifold
             {
@@ -87,17 +85,24 @@ namespace Robust.UnitTesting.Shared.Physics
                 LocalNormal = new Vector2(-1, 0),
                 LocalPoint = new Vector2(-0.5f, 0),
                 PointCount = 2,
-                Points = new ManifoldPoint[]
-                {
-                    new() {LocalPoint = new Vector2(0.5f, -0.5f), Id = new ContactID {Key = 65795}},
-                    new() {LocalPoint = new Vector2(0.5f, 0.5f), Id = new ContactID {Key = 66051}}
-                }
+                Points = new FixedArray2<ManifoldPoint>(
+                    new ManifoldPoint
+                    {
+                        LocalPoint = new Vector2(0.5f, -0.5f),
+                        Id = new ContactID {Key = 65795}
+                    },
+                    new ManifoldPoint
+                    {
+                        LocalPoint = new Vector2(0.5f, 0.5f),
+                        Id = new ContactID {Key = 66051}
+                    }
+                )
             };
             _manifoldManager.CollidePolygons(ref manifold, _polyA, transformA, _polyB, transformB);
 
-            for (var i = 0; i < manifold.Points.Length; i++)
+            for (var i = 0; i < manifold.PointCount; i++)
             {
-                Assert.That(manifold.Points[i], Is.EqualTo(expectedManifold.Points[i]));
+                Assert.That(manifold.Points.AsSpan[i], Is.EqualTo(expectedManifold.Points.AsSpan[i]));
             }
 
             Assert.That(manifold, Is.EqualTo(expectedManifold));


### PR DESCRIPTION
Max is 2 so no reason to use an array over a fixedarray. Solver stuff getting re-written soon but manifolds are similar with v3 so might as well get used to fixedarray stuff now.

Tumbler benchmark was 1.349s / 1.18s with the change and 1.571 / 1.249s without the change.