### PR TITLE
Add Fluent function for possessive nouns (thing's vs things')

### DIFF
--- a/Robust.Shared/Localization/LocalizationManager.Functions.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Functions.cs
@@ -40,6 +40,7 @@ namespace Robust.Shared.Localization
             // Misc
             AddCtxFunction(bundle, "ATTRIB", args => FuncAttrib(bundle, args));
             AddCtxFunction(bundle, "CAPITALIZE", FuncCapitalize);
+            AddCtxFunction(bundle, "APOSTROPHE-S", FuncApostropheS);
             AddCtxFunction(bundle, "INDEFINITE", FuncIndefinite);
         }
 
@@ -60,6 +61,23 @@ namespace Robust.Shared.Localization
             if (!String.IsNullOrEmpty(input))
                 return new LocValueString(input[0].ToString().ToUpper() + input.Substring(1));
             else return new LocValueString("");
+        }
+
+        /// <summary>
+        /// Returns the string passed in, with ' appended if it ends with
+        /// the letter s, or 's otherwise.
+        /// </summary>
+        /// <remarks>
+        /// Intended to get the possesive form of an arbitrary string
+        /// ("a slugcat's hand") while avoiding clumsy formatting for words that
+        /// end with S ("fifty slugcats' hands" as opposed to "fifty slugcats's hands").
+        /// </remarks>
+        private ILocValue FuncApostropheS(LocArgs args)
+        {
+            var input = args.Args[0].Format(new LocContext());
+            if (string.IsNullOrEmpty(input))
+                return new LocValueString("");
+            return new LocValueString(input.ToLower().EndsWith('s') ? $"{input}'" : $"{input}'s");
         }
 
         private static readonly string[] IndefExceptions = { "euler", "heir", "honest" };

--- a/Robust.Shared/Localization/LocalizationManager.Functions.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Functions.cs
@@ -25,6 +25,7 @@ namespace Robust.Shared.Localization
             AddCtxFunction(bundle, "DAT-OBJ", FuncDatObj);
             AddCtxFunction(bundle, "POSS-ADJ", FuncPossAdj);
             AddCtxFunction(bundle, "POSS-PRONOUN", FuncPossPronoun);
+            AddCtxFunction(bundle, "POSS-NOUN", FuncPossNoun);
             AddCtxFunction(bundle, "REFLEXIVE", FuncReflexive);
             AddCtxFunction(bundle, "COUNTER", FuncCounter);
 
@@ -40,7 +41,6 @@ namespace Robust.Shared.Localization
             // Misc
             AddCtxFunction(bundle, "ATTRIB", args => FuncAttrib(bundle, args));
             AddCtxFunction(bundle, "CAPITALIZE", FuncCapitalize);
-            AddCtxFunction(bundle, "POSS-NOUN", FuncPossNoun);
             AddCtxFunction(bundle, "INDEFINITE", FuncIndefinite);
         }
 
@@ -61,23 +61,6 @@ namespace Robust.Shared.Localization
             if (!String.IsNullOrEmpty(input))
                 return new LocValueString(input[0].ToString().ToUpper() + input.Substring(1));
             else return new LocValueString("");
-        }
-
-        /// <summary>
-        /// Returns the string passed in, with ' appended if it ends with
-        /// the letter s, or 's otherwise.
-        /// </summary>
-        /// <remarks>
-        /// Intended to get the possesive form of an arbitrary string
-        /// ("a slugcat's hand") while avoiding clumsy formatting for words that
-        /// end with S ("fifty slugcats' hands" as opposed to "fifty slugcats's hands").
-        /// </remarks>
-        private ILocValue FuncPossNoun(LocArgs args)
-        {
-            var input = args.Args[0].Format(new LocContext());
-            if (string.IsNullOrEmpty(input))
-                return new LocValueString("");
-            return new LocValueString(input.ToLower().EndsWith('s') ? $"{input}'" : $"{input}'s");
         }
 
         private static readonly string[] IndefExceptions = { "euler", "heir", "honest" };
@@ -246,6 +229,23 @@ namespace Robust.Shared.Localization
         private ILocValue FuncPossPronoun(LocArgs args)
         {
             return new LocValueString(GetString("zzzz-possessive-pronoun", ("ent", args.Args[0])));
+        }
+
+        /// <summary>
+        /// Returns the string passed in, with ' appended if it ends with
+        /// the letter s, or 's otherwise.
+        /// </summary>
+        /// <remarks>
+        /// Intended to get the possesive form of an arbitrary string
+        /// ("a slugcat's hand") while avoiding clumsy formatting for words that
+        /// end with S ("fifty slugcats' hands" as opposed to "fifty slugcats's hands").
+        /// </remarks>
+        private ILocValue FuncPossNoun(LocArgs args)
+        {
+            var input = args.Args[0].Format(new LocContext());
+            if (string.IsNullOrEmpty(input))
+                return new LocValueString("");
+            return new LocValueString(input.ToLower().EndsWith('s') ? $"{input}'" : $"{input}'s");
         }
 
         /// <summary>

--- a/Robust.Shared/Localization/LocalizationManager.Functions.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Functions.cs
@@ -232,11 +232,10 @@ namespace Robust.Shared.Localization
         }
 
         /// <summary>
-        /// Returns the string passed in, with ' appended if it ends with
-        /// the letter s, or 's otherwise.
+        /// Returns the possessive form of the noun passed in, by appending 's or ' as appropriate.
         /// </summary>
         /// <remarks>
-        /// Intended to get the possesive form of an arbitrary string
+        /// Intended to get the possessive form of an arbitrary string
         /// ("a slugcat's hand") while avoiding clumsy formatting for words that
         /// end with S ("fifty slugcats' hands" as opposed to "fifty slugcats's hands").
         /// </remarks>

--- a/Robust.Shared/Localization/LocalizationManager.Functions.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Functions.cs
@@ -40,7 +40,7 @@ namespace Robust.Shared.Localization
             // Misc
             AddCtxFunction(bundle, "ATTRIB", args => FuncAttrib(bundle, args));
             AddCtxFunction(bundle, "CAPITALIZE", FuncCapitalize);
-            AddCtxFunction(bundle, "APOSTROPHE-S", FuncApostropheS);
+            AddCtxFunction(bundle, "POSS-NOUN", FuncPossNoun);
             AddCtxFunction(bundle, "INDEFINITE", FuncIndefinite);
         }
 
@@ -72,7 +72,7 @@ namespace Robust.Shared.Localization
         /// ("a slugcat's hand") while avoiding clumsy formatting for words that
         /// end with S ("fifty slugcats' hands" as opposed to "fifty slugcats's hands").
         /// </remarks>
-        private ILocValue FuncApostropheS(LocArgs args)
+        private ILocValue FuncPossNoun(LocArgs args)
         {
             var input = args.Args[0].Format(new LocContext());
             if (string.IsNullOrEmpty(input))

--- a/Robust.UnitTesting/Shared/Localization/LocalizationTests.cs
+++ b/Robust.UnitTesting/Shared/Localization/LocalizationTests.cs
@@ -102,6 +102,12 @@ namespace Robust.UnitTesting.Shared.Localization
   - type: Grammar
     attributes:
       gender: Female
+
+- type: entity
+  id: ApostropheTestEntityEndingWithT
+
+- type: entity
+  id: ApostropheTestEntityEndingWithS
 ";
 
         private const string FluentCode = @"
@@ -121,6 +127,10 @@ ent-GenderTestEntityNoComp = Gender Test Entity
   .otherAttrib = sausages
 
 ent-GenderTestEntityWithComp = Gender Test Entity 2
+
+ent-ApostropheTestEntityEndingWithT = Struct
+
+ent-ApostropheTestEntityEndingWithS = Class
 
 ent-PropsInLoc = A
   .desc = B
@@ -153,6 +163,8 @@ test-message-proper = { PROPER($entity) ->
 }
 
 test-message-custom-attrib = { ATTRIB($entity, ""otherAttrib"") }
+
+test-message-apostrophe-s = { APOSTROPHE-S($entity) }
 ";
 
         [Test]
@@ -168,20 +180,26 @@ test-message-custom-attrib = { ATTRIB($entity, ""otherAttrib"") }
         [Test]
         public void TestCustomFunctions()
         {
-            var entMan          = IoCManager.Resolve<IEntityManager>();
-            var testEntNoComp   = entMan.CreateEntityUninitialized("GenderTestEntityNoComp");
-            var testEntWithComp = entMan.CreateEntityUninitialized("GenderTestEntityWithComp");
+            var entMan              = IoCManager.Resolve<IEntityManager>();
+            var testEntNoComp       = entMan.CreateEntityUninitialized("GenderTestEntityNoComp");
+            var testEntWithComp     = entMan.CreateEntityUninitialized("GenderTestEntityWithComp");
+            var testEntEndingWithT  = entMan.CreateEntityUninitialized("ApostropheTestEntityEndingWithT");
+            var testEntEndingWithS  = entMan.CreateEntityUninitialized("ApostropheTestEntityEndingWithS");
 
             var loc               = IoCManager.Resolve<ILocalizationManager>();
             var genderFromAttrib  = loc.GetString("test-message-gender", ("entity", testEntNoComp));
             var genderFromGrammar = loc.GetString("test-message-gender", ("entity", testEntWithComp));
             var customAttrib      = loc.GetString("test-message-custom-attrib", ("entity", testEntNoComp));
+            var apostropheT       = loc.GetString("test-message-apostrophe-s", ("entity", testEntEndingWithT));
+            var apostropheS       = loc.GetString("test-message-apostrophe-s", ("entity", testEntEndingWithS));
 
             Assert.Multiple(() =>
             {
                 Assert.That(genderFromAttrib, Is.EqualTo("male"));
                 Assert.That(genderFromGrammar, Is.EqualTo("female"));
                 Assert.That(customAttrib, Is.EqualTo("sausages"));
+                Assert.That(apostropheT, Is.EqualTo("Struct's"));
+                Assert.That(apostropheS, Is.EqualTo("Class'"));
             });
         }
 

--- a/Robust.UnitTesting/Shared/Localization/LocalizationTests.cs
+++ b/Robust.UnitTesting/Shared/Localization/LocalizationTests.cs
@@ -104,10 +104,10 @@ namespace Robust.UnitTesting.Shared.Localization
       gender: Female
 
 - type: entity
-  id: ApostropheTestEntityEndingWithT
+  id: TestEntityEndingWithT
 
 - type: entity
-  id: ApostropheTestEntityEndingWithS
+  id: TestEntityEndingWithS
 ";
 
         private const string FluentCode = @"
@@ -128,9 +128,9 @@ ent-GenderTestEntityNoComp = Gender Test Entity
 
 ent-GenderTestEntityWithComp = Gender Test Entity 2
 
-ent-ApostropheTestEntityEndingWithT = Struct
+ent-TestEntityEndingWithT = Struct
 
-ent-ApostropheTestEntityEndingWithS = Class
+ent-TestEntityEndingWithS = Class
 
 ent-PropsInLoc = A
   .desc = B
@@ -164,7 +164,7 @@ test-message-proper = { PROPER($entity) ->
 
 test-message-custom-attrib = { ATTRIB($entity, ""otherAttrib"") }
 
-test-message-apostrophe-s = { APOSTROPHE-S($entity) }
+test-message-poss-noun = { POSS-NOUN($entity) }
 ";
 
         [Test]
@@ -183,23 +183,23 @@ test-message-apostrophe-s = { APOSTROPHE-S($entity) }
             var entMan              = IoCManager.Resolve<IEntityManager>();
             var testEntNoComp       = entMan.CreateEntityUninitialized("GenderTestEntityNoComp");
             var testEntWithComp     = entMan.CreateEntityUninitialized("GenderTestEntityWithComp");
-            var testEntEndingWithT  = entMan.CreateEntityUninitialized("ApostropheTestEntityEndingWithT");
-            var testEntEndingWithS  = entMan.CreateEntityUninitialized("ApostropheTestEntityEndingWithS");
+            var testEntEndingWithT  = entMan.CreateEntityUninitialized("TestEntityEndingWithT");
+            var testEntEndingWithS  = entMan.CreateEntityUninitialized("TestEntityEndingWithS");
 
             var loc               = IoCManager.Resolve<ILocalizationManager>();
             var genderFromAttrib  = loc.GetString("test-message-gender", ("entity", testEntNoComp));
             var genderFromGrammar = loc.GetString("test-message-gender", ("entity", testEntWithComp));
             var customAttrib      = loc.GetString("test-message-custom-attrib", ("entity", testEntNoComp));
-            var apostropheT       = loc.GetString("test-message-apostrophe-s", ("entity", testEntEndingWithT));
-            var apostropheS       = loc.GetString("test-message-apostrophe-s", ("entity", testEntEndingWithS));
+            var possNounT       = loc.GetString("test-message-poss-noun", ("entity", testEntEndingWithT));
+            var possNounS       = loc.GetString("test-message-poss-noun", ("entity", testEntEndingWithS));
 
             Assert.Multiple(() =>
             {
                 Assert.That(genderFromAttrib, Is.EqualTo("male"));
                 Assert.That(genderFromGrammar, Is.EqualTo("female"));
                 Assert.That(customAttrib, Is.EqualTo("sausages"));
-                Assert.That(apostropheT, Is.EqualTo("Struct's"));
-                Assert.That(apostropheS, Is.EqualTo("Class'"));
+                Assert.That(possNounT, Is.EqualTo("Struct's"));
+                Assert.That(possNounS, Is.EqualTo("Class'"));
             });
         }
 


### PR DESCRIPTION
Adds a new function for localization that can be used to correctly format the possessive form of arbitrary strings.

For example:
`This is { POSS-NOUN($input) } house`
"Bob" -> "This is Bob's house"
"Chris" -> "This is Chris' house"

Works well in combos:
`This is { THE(POSS-NOUN($entity)) } favorite`
MobMouse -> "This is the mouse (234)'s favorite"
DrinkShotGlass -> "This is the shot glass' favorite"
BaseMobHuman-> "This is Urist McHands' favorite"
