### PR TITLE
SharedPhysicsSystem.Island: set position after velocity

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
@@ -1026,12 +1026,6 @@ public abstract partial class SharedPhysicsSystem
             var angle = angles[offset + i];
             var xform = xformQuery.GetComponent(uid);
 
-            // Temporary NaN guards until PVS is fixed.
-            if (!float.IsNaN(position.X) && !float.IsNaN(position.Y))
-            {
-                _transform.SetLocalPositionRotation(xform, xform.LocalPosition + position, xform.LocalRotation + angle);
-            }
-
             var linVelocity = linearVelocities[offset + i];
             var physicsDirtied = false;
 
@@ -1045,6 +1039,13 @@ public abstract partial class SharedPhysicsSystem
             if (!float.IsNaN(angVelocity))
             {
                 physicsDirtied |= SetAngularVelocity(uid, angVelocity, false, body: body);
+            }
+
+            // Temporary NaN guards until PVS is fixed.
+            // May reparent object and change body's velocity.
+            if (!float.IsNaN(position.X) && !float.IsNaN(position.Y))
+            {
+                _transform.SetLocalPositionRotation(xform, xform.LocalPosition + position, xform.LocalRotation + angle);
             }
 
             if (physicsDirtied)

--- a/Robust.UnitTesting/Shared/Physics/GridReparentVelocity_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/GridReparentVelocity_Test.cs
@@ -1,0 +1,280 @@
+using System.Numerics;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
+
+namespace Robust.UnitTesting.Shared.Physics;
+
+[TestFixture, TestOf(typeof(SharedPhysicsSystem))]
+public sealed class GridReparentVelocity_Test : RobustIntegrationTest
+{
+    private static readonly string Prototypes = @"
+- type: entity
+  id: ReparentTestObject
+  components:
+  - type: Physics
+    bodyType: Dynamic
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: '-0.1,-0.1,0.1,0.1'
+        hard: false
+";
+
+    // Moves an object off of a moving grid, checks for conservation of linear velocity.
+    [Test]
+    public async Task TestLinearVelocityOnlyMoveOffGrid()
+    {
+        var serverOpts = new ServerIntegrationOptions { Pool = false, ExtraPrototypes = Prototypes };
+        var server = StartServer(serverOpts);
+
+        await server.WaitIdleAsync();
+
+        var systems = server.ResolveDependency<IEntitySystemManager>();
+        var fixtureSystem = systems.GetEntitySystem<FixtureSystem>();
+        var mapManager = server.ResolveDependency<IMapManager>();
+        var entManager = server.ResolveDependency<IEntityManager>();
+        var physSystem = systems.GetEntitySystem<SharedPhysicsSystem>();
+        var transformSystem = entManager.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
+        var mapSystem = entManager.EntitySysManager.GetEntitySystem<SharedMapSystem>();
+
+        // Set up entities
+        EntityUid map = default;
+        EntityUid grid = default;
+        EntityUid obj = default;
+        await server.WaitPost(() =>
+        {
+            map = mapSystem.CreateMap(out var mapId);
+
+            // Spawn a grid with one tile, ensure it's movable and its velocity has no damping.
+            var gridEnt = mapManager.CreateGridEntity(mapId);
+            physSystem.SetCanCollide(gridEnt, true);
+            physSystem.SetBodyType(gridEnt, BodyType.Dynamic);
+            physSystem.SetLinearDamping(gridEnt, entManager.GetComponent<PhysicsComponent>(gridEnt), 0.0f);
+
+            mapSystem.SetTile(gridEnt, Vector2i.Zero, new Tile(1));
+            grid = gridEnt.Owner;
+
+            // Spawn our test object in the middle of the grid, ensure it has no damping.
+            obj = server.EntMan.SpawnEntity("ReparentTestObject", new EntityCoordinates(grid, 0.5f, 0.5f));
+            physSystem.SetCanCollide(obj, true);
+            physSystem.SetLinearDamping(obj, entManager.GetComponent<PhysicsComponent>(obj), 0.0f);
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            // Our object should start on the grid.
+            Assert.That(entManager.GetComponent<TransformComponent>(obj).ParentUid, Is.EqualTo(grid));
+            
+            // Set the velocity of the grid and our object.
+            Assert.That(physSystem.SetLinearVelocity(obj, new Vector2(3.5f, 4.75f)), Is.True);
+            Assert.That(physSystem.SetLinearVelocity(grid, new Vector2(1.0f, 2.0f)), Is.True);
+
+            // Wait a second to clear the grid
+            physSystem.Update(1.0f);
+
+            // The object should be parented to the map and maintain its map velocity, the grid should be unchanged.
+            Assert.That(entManager.GetComponent<TransformComponent>(obj).ParentUid, Is.EqualTo(map));
+            Assert.That(entManager.GetComponent<PhysicsComponent>(obj).LinearVelocity, Is.EqualTo(new Vector2(4.5f, 6.75f)));
+            Assert.That(entManager.GetComponent<PhysicsComponent>(grid).LinearVelocity, Is.EqualTo(new Vector2(1.0f, 2.0f)));
+        });
+    }
+
+    // Moves an object onto a moving grid, checks for conservation of linear velocity.
+    [Test]
+    public async Task TestLinearVelocityOnlyMoveOntoGrid()
+    {
+        var serverOpts = new ServerIntegrationOptions { Pool = false, ExtraPrototypes = Prototypes };
+        var server = StartServer(serverOpts);
+
+        await server.WaitIdleAsync();
+
+        var systems = server.ResolveDependency<IEntitySystemManager>();
+        var fixtureSystem = systems.GetEntitySystem<FixtureSystem>();
+        var mapManager = server.ResolveDependency<IMapManager>();
+        var entManager = server.ResolveDependency<IEntityManager>();
+        var physSystem = systems.GetEntitySystem<SharedPhysicsSystem>();
+        var transformSystem = entManager.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
+        var mapSystem = entManager.EntitySysManager.GetEntitySystem<SharedMapSystem>();
+
+        // Set up entities
+        EntityUid map = default;
+        EntityUid grid = default;
+        EntityUid obj = default;
+        await server.WaitPost(() =>
+        {
+            map = mapSystem.CreateMap(out var mapId);
+
+            // Spawn a grid with one tile, ensure it's movable and its velocity has no damping.
+            var gridEnt = mapManager.CreateGridEntity(mapId);
+            physSystem.SetCanCollide(gridEnt, true);
+            physSystem.SetBodyType(gridEnt, BodyType.Dynamic);
+            physSystem.SetLinearDamping(gridEnt, entManager.GetComponent<PhysicsComponent>(gridEnt), 0.0f);
+
+            mapSystem.SetTile(gridEnt, Vector2i.Zero, new Tile(1));
+            grid = gridEnt.Owner;
+
+            // Spawn our test object 1 m off of the middle of the grid in both directions, ensure it has no damping.
+            obj = server.EntMan.SpawnEntity("ReparentTestObject", new EntityCoordinates(map, 1.5f, 1.5f));
+            physSystem.SetCanCollide(obj, true);
+            physSystem.SetLinearDamping(obj, entManager.GetComponent<PhysicsComponent>(obj), 0.0f);
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            // Assert that we start off the grid.
+            Assert.That(entManager.GetComponent<TransformComponent>(obj).ParentUid, Is.EqualTo(map));
+            
+            // Set the velocity of the grid and our object.
+            Assert.That(physSystem.SetLinearVelocity(obj, new Vector2(-2.0f, -3.0f)), Is.True);
+            Assert.That(physSystem.SetLinearVelocity(grid, new Vector2(-1.0f, -2.0f)), Is.True);
+
+            // Wait a second to move onto the middle of the grid
+            physSystem.Update(1.0f);
+
+            // The object should be parented to the grid and maintain its map velocity (slowing down), the grid should be unchanged.
+            Assert.That(entManager.GetComponent<TransformComponent>(obj).ParentUid, Is.EqualTo(grid));
+            Assert.That(entManager.GetComponent<PhysicsComponent>(obj).LinearVelocity, Is.EqualTo(new Vector2(-1.0f, -1.0f)));
+            Assert.That(entManager.GetComponent<PhysicsComponent>(grid).LinearVelocity, Is.EqualTo(new Vector2(-1.0f, -2.0f)));
+        });
+    }
+
+    // Moves a rotating object off of a rotating grid, checks for conservation of angular velocity.
+    [Test]
+    public async Task TestLinearAndAngularVelocityMoveOffGrid()
+    {
+        var serverOpts = new ServerIntegrationOptions { Pool = false, ExtraPrototypes = Prototypes };
+        var server = StartServer(serverOpts);
+
+        await server.WaitIdleAsync();
+
+        var systems = server.ResolveDependency<IEntitySystemManager>();
+        var fixtureSystem = systems.GetEntitySystem<FixtureSystem>();
+        var mapManager = server.ResolveDependency<IMapManager>();
+        var entManager = server.ResolveDependency<IEntityManager>();
+        var physSystem = systems.GetEntitySystem<SharedPhysicsSystem>();
+        var transformSystem = entManager.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
+        var mapSystem = entManager.EntitySysManager.GetEntitySystem<SharedMapSystem>();
+
+        // Set up entities
+        EntityUid map = default;
+        EntityUid grid = default;
+        EntityUid obj = default;
+        await server.WaitPost(() =>
+        {
+            map = mapSystem.CreateMap(out var mapId);
+
+            // Spawn a grid with one tile, ensure it's movable and its velocities have no damping.
+            var gridEnt = mapManager.CreateGridEntity(mapId);
+            physSystem.SetCanCollide(gridEnt, true);
+            physSystem.SetBodyType(gridEnt, BodyType.Dynamic);
+            physSystem.SetLinearDamping(gridEnt, entManager.GetComponent<PhysicsComponent>(gridEnt), 0.0f);
+            physSystem.SetAngularDamping(gridEnt, entManager.GetComponent<PhysicsComponent>(gridEnt), 0.0f);
+
+            mapSystem.SetTile(gridEnt, Vector2i.Zero, new Tile(1));
+            grid = gridEnt.Owner;
+
+            // Spawn our test object in the middle of the grid, ensure it has no damping.
+            obj = server.EntMan.SpawnEntity("ReparentTestObject", new EntityCoordinates(grid, 0.5f, 0.5f));
+            physSystem.SetCanCollide(obj, true);
+            physSystem.SetLinearDamping(obj, entManager.GetComponent<PhysicsComponent>(obj), 0.0f);
+            physSystem.SetAngularDamping(obj, entManager.GetComponent<PhysicsComponent>(obj), 0.0f);
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            // Our object should start on the grid.
+            Assert.That(entManager.GetComponent<TransformComponent>(obj).ParentUid, Is.EqualTo(grid));
+            
+            // Set the velocity of the grid and our object.
+            Assert.That(physSystem.SetLinearVelocity(obj, new Vector2(3.5f, 4.75f)), Is.True);
+            Assert.That(physSystem.SetAngularVelocity(obj, 1.0f), Is.True);
+            Assert.That(physSystem.SetLinearVelocity(grid, new Vector2(1.0f, 2.0f)), Is.True);
+            Assert.That(physSystem.SetAngularVelocity(grid, 2.0f), Is.True);
+
+            // Wait a second to clear the grid
+            physSystem.Update(1.0f);
+
+            // The object should be parented to the map and maintain its map velocity, the grid should be unchanged.
+            Assert.That(entManager.GetComponent<TransformComponent>(obj).ParentUid, Is.EqualTo(map));
+            // Not checking object's linear velocity in this case, non-zero contribution from grid angular velocity.
+            Assert.That(entManager.GetComponent<PhysicsComponent>(obj).AngularVelocity, Is.EqualTo(3.0f));
+            var gridPhys = entManager.GetComponent<PhysicsComponent>(grid);
+            Assert.That(gridPhys.LinearVelocity, Is.EqualTo(new Vector2(1.0f, 2.0f)));
+            Assert.That(gridPhys.AngularVelocity, Is.EqualTo(2.0f));
+        });
+    }
+
+    // Moves a rotating object onto a rotating grid, checks for conservation of angular velocity.
+    [Test]
+    public async Task TestLinearAndAngularVelocityMoveOntoGrid()
+    {
+        var serverOpts = new ServerIntegrationOptions { Pool = false, ExtraPrototypes = Prototypes };
+        var server = StartServer(serverOpts);
+
+        await server.WaitIdleAsync();
+
+        var systems = server.ResolveDependency<IEntitySystemManager>();
+        var fixtureSystem = systems.GetEntitySystem<FixtureSystem>();
+        var mapManager = server.ResolveDependency<IMapManager>();
+        var entManager = server.ResolveDependency<IEntityManager>();
+        var physSystem = systems.GetEntitySystem<SharedPhysicsSystem>();
+        var transformSystem = entManager.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
+        var mapSystem = entManager.EntitySysManager.GetEntitySystem<SharedMapSystem>();
+
+        // Set up entities
+        EntityUid map = default;
+        EntityUid grid = default;
+        EntityUid obj = default;
+        await server.WaitPost(() =>
+        {
+            map = mapSystem.CreateMap(out var mapId);
+
+            // Spawn a grid with one tile, ensure it's movable and its velocity has no damping.
+            var gridEnt = mapManager.CreateGridEntity(mapId);
+            physSystem.SetCanCollide(gridEnt, true);
+            physSystem.SetBodyType(gridEnt, BodyType.Dynamic);
+            physSystem.SetLinearDamping(gridEnt, entManager.GetComponent<PhysicsComponent>(gridEnt), 0.0f);
+            physSystem.SetAngularDamping(gridEnt, entManager.GetComponent<PhysicsComponent>(gridEnt), 0.0f);
+
+            mapSystem.SetTile(gridEnt, Vector2i.Zero, new Tile(1));
+            grid = gridEnt.Owner;
+
+            // Spawn our test object 1 m off of the middle of the grid in both directions, ensure it has no damping.
+            obj = server.EntMan.SpawnEntity("ReparentTestObject", new EntityCoordinates(map, 1.5f, 1.5f));
+            physSystem.SetCanCollide(obj, true);
+            physSystem.SetLinearDamping(obj, entManager.GetComponent<PhysicsComponent>(obj), 0.0f);
+            physSystem.SetAngularDamping(obj, entManager.GetComponent<PhysicsComponent>(obj), 0.0f);
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            // Assert that we start off the grid.
+            Assert.That(entManager.GetComponent<TransformComponent>(obj).ParentUid, Is.EqualTo(map));
+            
+            // Set the velocity of the grid and our object.
+            Assert.That(physSystem.SetLinearVelocity(obj, new Vector2(-2.0f, -3.0f)), Is.True);
+            Assert.That(physSystem.SetAngularVelocity(obj, 1.0f), Is.True);
+            Assert.That(physSystem.SetLinearVelocity(grid, new Vector2(-1.0f, -2.0f)), Is.True);
+            Assert.That(physSystem.SetAngularVelocity(grid, 2.0f), Is.True);
+
+            // Wait a second to move onto the middle of the grid
+            physSystem.Update(1.0f);
+
+            // The object should be parented to the grid and maintain its map velocity (slowing down), the grid should be unchanged.
+            Assert.That(entManager.GetComponent<TransformComponent>(obj).ParentUid, Is.EqualTo(grid));
+            // Not checking object's linear velocity in this case, non-zero contribution from grid angular velocity.
+            Assert.That(entManager.GetComponent<PhysicsComponent>(obj).AngularVelocity, Is.EqualTo(-1.0f));
+            var gridPhys = entManager.GetComponent<PhysicsComponent>(grid);
+            Assert.That(gridPhys.LinearVelocity, Is.EqualTo(new Vector2(-1.0f, -2.0f)));
+            Assert.That(gridPhys.AngularVelocity, Is.EqualTo(2.0f));
+        });
+    }
+}

--- a/Robust.UnitTesting/Shared/Physics/GridReparentVelocity_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/GridReparentVelocity_Test.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Numerics;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -5,276 +6,210 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
+using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Systems;
+using Robust.UnitTesting.Server;
 
 namespace Robust.UnitTesting.Shared.Physics;
 
 [TestFixture, TestOf(typeof(SharedPhysicsSystem))]
 public sealed class GridReparentVelocity_Test : RobustIntegrationTest
 {
-    private static readonly string Prototypes = @"
-- type: entity
-  id: ReparentTestObject
-  components:
-  - type: Physics
-    bodyType: Dynamic
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeAabb
-          bounds: '-0.1,-0.1,0.1,0.1'
-        hard: false
-";
+    private ISimulation _sim = default!;
+    private IEntitySystemManager _systems = default!;
+    private IEntityManager _entManager = default!;
+    private IMapManager _mapManager = default!;
+    private FixtureSystem _fixtureSystem = default!;
+    private SharedMapSystem _mapSystem = default!;
+    private SharedPhysicsSystem _physSystem = default!;
+
+    // Test objects.
+    private EntityUid _mapUid = default!;
+    private MapId _mapId = default!;
+    private EntityUid _gridUid = default!;
+    private EntityUid _objUid = default!;
+
+    [OneTimeSetUp]
+    public void FixtureSetup()
+    {
+        _sim = RobustServerSimulation.NewSimulation()
+            .InitializeInstance();
+
+        _systems = _sim.Resolve<IEntitySystemManager>();
+        _entManager = _sim.Resolve<IEntityManager>();
+        _mapManager = _sim.Resolve<IMapManager>();
+        _fixtureSystem = _systems.GetEntitySystem<FixtureSystem>();
+        _mapSystem = _systems.GetEntitySystem<SharedMapSystem>();
+        _physSystem = _systems.GetEntitySystem<SharedPhysicsSystem>();
+        
+        _mapUid = _mapSystem.CreateMap(out _mapId);
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        // Spawn a 1x1 grid centered at (0.5, 0.5), ensure it's movable and its velocity has no damping.
+        var gridEnt = _mapManager.CreateGridEntity(_mapId);
+        var gridPhys = _entManager.GetComponent<PhysicsComponent>(gridEnt);
+        _physSystem.SetBodyType(gridEnt, BodyType.Dynamic, body: gridPhys);
+        _physSystem.SetCanCollide(gridEnt, true, body: gridPhys);
+        _physSystem.SetLinearDamping(gridEnt, gridPhys, 0.0f);
+        _physSystem.SetAngularDamping(gridEnt, gridPhys, 0.0f);
+
+        _mapSystem.SetTile(gridEnt, Vector2i.Zero, new Tile(1));
+        _gridUid = gridEnt.Owner;
+    }
+
+    [TearDown]
+    public void Teardown()
+    {
+        _entManager.DeleteEntity(_gridUid);
+        _gridUid = default!;
+        _entManager.DeleteEntity(_objUid);
+        _objUid = default!;
+    }
 
     // Moves an object off of a moving grid, checks for conservation of linear velocity.
     [Test]
     public async Task TestLinearVelocityOnlyMoveOffGrid()
     {
-        var serverOpts = new ServerIntegrationOptions { Pool = false, ExtraPrototypes = Prototypes };
-        var server = StartServer(serverOpts);
+        // Spawn our test object in the middle of the grid, ensure it has no damping.
+        _objUid = SetupTestObject(new EntityCoordinates(_gridUid, 0.5f, 0.5f));
 
-        await server.WaitIdleAsync();
-
-        var systems = server.ResolveDependency<IEntitySystemManager>();
-        var fixtureSystem = systems.GetEntitySystem<FixtureSystem>();
-        var mapManager = server.ResolveDependency<IMapManager>();
-        var entManager = server.ResolveDependency<IEntityManager>();
-        var physSystem = systems.GetEntitySystem<SharedPhysicsSystem>();
-        var transformSystem = entManager.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
-        var mapSystem = entManager.EntitySysManager.GetEntitySystem<SharedMapSystem>();
-
-        // Set up entities
-        EntityUid map = default;
-        EntityUid grid = default;
-        EntityUid obj = default;
-        await server.WaitPost(() =>
-        {
-            map = mapSystem.CreateMap(out var mapId);
-
-            // Spawn a grid with one tile, ensure it's movable and its velocity has no damping.
-            var gridEnt = mapManager.CreateGridEntity(mapId);
-            physSystem.SetCanCollide(gridEnt, true);
-            physSystem.SetBodyType(gridEnt, BodyType.Dynamic);
-            physSystem.SetLinearDamping(gridEnt, entManager.GetComponent<PhysicsComponent>(gridEnt), 0.0f);
-
-            mapSystem.SetTile(gridEnt, Vector2i.Zero, new Tile(1));
-            grid = gridEnt.Owner;
-
-            // Spawn our test object in the middle of the grid, ensure it has no damping.
-            obj = server.EntMan.SpawnEntity("ReparentTestObject", new EntityCoordinates(grid, 0.5f, 0.5f));
-            physSystem.SetCanCollide(obj, true);
-            physSystem.SetLinearDamping(obj, entManager.GetComponent<PhysicsComponent>(obj), 0.0f);
-        });
-
-        await server.WaitAssertion(() =>
+        Assert.Multiple(() =>
         {
             // Our object should start on the grid.
-            Assert.That(entManager.GetComponent<TransformComponent>(obj).ParentUid, Is.EqualTo(grid));
+            Assert.That(_entManager.GetComponent<TransformComponent>(_objUid).ParentUid, Is.EqualTo(_gridUid));
             
             // Set the velocity of the grid and our object.
-            Assert.That(physSystem.SetLinearVelocity(obj, new Vector2(3.5f, 4.75f)), Is.True);
-            Assert.That(physSystem.SetLinearVelocity(grid, new Vector2(1.0f, 2.0f)), Is.True);
+            Assert.That(_physSystem.SetLinearVelocity(_objUid, new Vector2(3.5f, 4.75f)), Is.True);
+            Assert.That(_physSystem.SetLinearVelocity(_gridUid, new Vector2(1.0f, 2.0f)), Is.True);
 
             // Wait a second to clear the grid
-            physSystem.Update(1.0f);
+            _physSystem.Update(1.0f);
 
             // The object should be parented to the map and maintain its map velocity, the grid should be unchanged.
-            Assert.That(entManager.GetComponent<TransformComponent>(obj).ParentUid, Is.EqualTo(map));
-            Assert.That(entManager.GetComponent<PhysicsComponent>(obj).LinearVelocity, Is.EqualTo(new Vector2(4.5f, 6.75f)));
-            Assert.That(entManager.GetComponent<PhysicsComponent>(grid).LinearVelocity, Is.EqualTo(new Vector2(1.0f, 2.0f)));
+            Assert.That(_entManager.GetComponent<TransformComponent>(_objUid).ParentUid, Is.EqualTo(_mapUid));
+            Assert.That(_entManager.GetComponent<PhysicsComponent>(_objUid).LinearVelocity, Is.EqualTo(new Vector2(4.5f, 6.75f)));
+            Assert.That(_entManager.GetComponent<PhysicsComponent>(_gridUid).LinearVelocity, Is.EqualTo(new Vector2(1.0f, 2.0f)));
         });
     }
 
-    // Moves an object onto a moving grid, checks for conservation of linear velocity.
     [Test]
+    // Moves an object onto a moving grid, checks for conservation of linear velocity.
     public async Task TestLinearVelocityOnlyMoveOntoGrid()
     {
-        var serverOpts = new ServerIntegrationOptions { Pool = false, ExtraPrototypes = Prototypes };
-        var server = StartServer(serverOpts);
+        // Spawn our test object 1 m off of the middle of the grid in both directions.
+        _objUid = SetupTestObject(new EntityCoordinates(_mapUid, 1.5f, 1.5f));
 
-        await server.WaitIdleAsync();
-
-        var systems = server.ResolveDependency<IEntitySystemManager>();
-        var fixtureSystem = systems.GetEntitySystem<FixtureSystem>();
-        var mapManager = server.ResolveDependency<IMapManager>();
-        var entManager = server.ResolveDependency<IEntityManager>();
-        var physSystem = systems.GetEntitySystem<SharedPhysicsSystem>();
-        var transformSystem = entManager.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
-        var mapSystem = entManager.EntitySysManager.GetEntitySystem<SharedMapSystem>();
-
-        // Set up entities
-        EntityUid map = default;
-        EntityUid grid = default;
-        EntityUid obj = default;
-        await server.WaitPost(() =>
-        {
-            map = mapSystem.CreateMap(out var mapId);
-
-            // Spawn a grid with one tile, ensure it's movable and its velocity has no damping.
-            var gridEnt = mapManager.CreateGridEntity(mapId);
-            physSystem.SetCanCollide(gridEnt, true);
-            physSystem.SetBodyType(gridEnt, BodyType.Dynamic);
-            physSystem.SetLinearDamping(gridEnt, entManager.GetComponent<PhysicsComponent>(gridEnt), 0.0f);
-
-            mapSystem.SetTile(gridEnt, Vector2i.Zero, new Tile(1));
-            grid = gridEnt.Owner;
-
-            // Spawn our test object 1 m off of the middle of the grid in both directions, ensure it has no damping.
-            obj = server.EntMan.SpawnEntity("ReparentTestObject", new EntityCoordinates(map, 1.5f, 1.5f));
-            physSystem.SetCanCollide(obj, true);
-            physSystem.SetLinearDamping(obj, entManager.GetComponent<PhysicsComponent>(obj), 0.0f);
-        });
-
-        await server.WaitAssertion(() =>
+        Assert.Multiple(() =>
         {
             // Assert that we start off the grid.
-            Assert.That(entManager.GetComponent<TransformComponent>(obj).ParentUid, Is.EqualTo(map));
+            Assert.That(_entManager.GetComponent<TransformComponent>(_objUid).ParentUid, Is.EqualTo(_mapUid));
             
             // Set the velocity of the grid and our object.
-            Assert.That(physSystem.SetLinearVelocity(obj, new Vector2(-2.0f, -3.0f)), Is.True);
-            Assert.That(physSystem.SetLinearVelocity(grid, new Vector2(-1.0f, -2.0f)), Is.True);
+            Assert.That(_physSystem.SetLinearVelocity(_objUid, new Vector2(-2.0f, -3.0f)), Is.True);
+            Assert.That(_physSystem.SetLinearVelocity(_gridUid, new Vector2(-1.0f, -2.0f)), Is.True);
 
             // Wait a second to move onto the middle of the grid
-            physSystem.Update(1.0f);
+            _physSystem.Update(1.0f);
 
             // The object should be parented to the grid and maintain its map velocity (slowing down), the grid should be unchanged.
-            Assert.That(entManager.GetComponent<TransformComponent>(obj).ParentUid, Is.EqualTo(grid));
-            Assert.That(entManager.GetComponent<PhysicsComponent>(obj).LinearVelocity, Is.EqualTo(new Vector2(-1.0f, -1.0f)));
-            Assert.That(entManager.GetComponent<PhysicsComponent>(grid).LinearVelocity, Is.EqualTo(new Vector2(-1.0f, -2.0f)));
+            Assert.That(_entManager.GetComponent<TransformComponent>(_objUid).ParentUid, Is.EqualTo(_gridUid));
+            Assert.That(_entManager.GetComponent<PhysicsComponent>(_objUid).LinearVelocity, Is.EqualTo(new Vector2(-1.0f, -1.0f)));
+            Assert.That(_entManager.GetComponent<PhysicsComponent>(_gridUid).LinearVelocity, Is.EqualTo(new Vector2(-1.0f, -2.0f)));
         });
     }
 
-    // Moves a rotating object off of a rotating grid, checks for conservation of angular velocity.
     [Test]
+    // Moves a rotating object off of a rotating grid, checks for conservation of angular velocity.
     public async Task TestLinearAndAngularVelocityMoveOffGrid()
     {
-        var serverOpts = new ServerIntegrationOptions { Pool = false, ExtraPrototypes = Prototypes };
-        var server = StartServer(serverOpts);
+        // Spawn our test object in the middle of the grid.
+        _objUid = SetupTestObject(new EntityCoordinates(_gridUid, 0.5f, 0.5f));
 
-        await server.WaitIdleAsync();
-
-        var systems = server.ResolveDependency<IEntitySystemManager>();
-        var fixtureSystem = systems.GetEntitySystem<FixtureSystem>();
-        var mapManager = server.ResolveDependency<IMapManager>();
-        var entManager = server.ResolveDependency<IEntityManager>();
-        var physSystem = systems.GetEntitySystem<SharedPhysicsSystem>();
-        var transformSystem = entManager.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
-        var mapSystem = entManager.EntitySysManager.GetEntitySystem<SharedMapSystem>();
-
-        // Set up entities
-        EntityUid map = default;
-        EntityUid grid = default;
-        EntityUid obj = default;
-        await server.WaitPost(() =>
-        {
-            map = mapSystem.CreateMap(out var mapId);
-
-            // Spawn a grid with one tile, ensure it's movable and its velocities have no damping.
-            var gridEnt = mapManager.CreateGridEntity(mapId);
-            physSystem.SetCanCollide(gridEnt, true);
-            physSystem.SetBodyType(gridEnt, BodyType.Dynamic);
-            physSystem.SetLinearDamping(gridEnt, entManager.GetComponent<PhysicsComponent>(gridEnt), 0.0f);
-            physSystem.SetAngularDamping(gridEnt, entManager.GetComponent<PhysicsComponent>(gridEnt), 0.0f);
-
-            mapSystem.SetTile(gridEnt, Vector2i.Zero, new Tile(1));
-            grid = gridEnt.Owner;
-
-            // Spawn our test object in the middle of the grid, ensure it has no damping.
-            obj = server.EntMan.SpawnEntity("ReparentTestObject", new EntityCoordinates(grid, 0.5f, 0.5f));
-            physSystem.SetCanCollide(obj, true);
-            physSystem.SetLinearDamping(obj, entManager.GetComponent<PhysicsComponent>(obj), 0.0f);
-            physSystem.SetAngularDamping(obj, entManager.GetComponent<PhysicsComponent>(obj), 0.0f);
-        });
-
-        await server.WaitAssertion(() =>
+        Assert.Multiple(() =>
         {
             // Our object should start on the grid.
-            Assert.That(entManager.GetComponent<TransformComponent>(obj).ParentUid, Is.EqualTo(grid));
+            Assert.That(_entManager.GetComponent<TransformComponent>(_objUid).ParentUid, Is.EqualTo(_gridUid));
             
             // Set the velocity of the grid and our object.
-            Assert.That(physSystem.SetLinearVelocity(obj, new Vector2(3.5f, 4.75f)), Is.True);
-            Assert.That(physSystem.SetAngularVelocity(obj, 1.0f), Is.True);
-            Assert.That(physSystem.SetLinearVelocity(grid, new Vector2(1.0f, 2.0f)), Is.True);
-            Assert.That(physSystem.SetAngularVelocity(grid, 2.0f), Is.True);
+            Assert.That(_physSystem.SetLinearVelocity(_objUid, new Vector2(3.5f, 4.75f)), Is.True);
+            Assert.That(_physSystem.SetAngularVelocity(_objUid, 1.0f), Is.True);
+            Assert.That(_physSystem.SetLinearVelocity(_gridUid, new Vector2(1.0f, 2.0f)), Is.True);
+            Assert.That(_physSystem.SetAngularVelocity(_gridUid, 2.0f), Is.True);
 
             // Wait a second to clear the grid
-            physSystem.Update(1.0f);
+            _physSystem.Update(1.0f);
 
             // The object should be parented to the map and maintain its map velocity, the grid should be unchanged.
-            Assert.That(entManager.GetComponent<TransformComponent>(obj).ParentUid, Is.EqualTo(map));
+            Assert.That(_entManager.GetComponent<TransformComponent>(_objUid).ParentUid, Is.EqualTo(_mapUid));
             // Not checking object's linear velocity in this case, non-zero contribution from grid angular velocity.
-            Assert.That(entManager.GetComponent<PhysicsComponent>(obj).AngularVelocity, Is.EqualTo(3.0f));
-            var gridPhys = entManager.GetComponent<PhysicsComponent>(grid);
+            Assert.That(_entManager.GetComponent<PhysicsComponent>(_objUid).AngularVelocity, Is.EqualTo(3.0f));
+            var gridPhys = _entManager.GetComponent<PhysicsComponent>(_gridUid);
             Assert.That(gridPhys.LinearVelocity, Is.EqualTo(new Vector2(1.0f, 2.0f)));
             Assert.That(gridPhys.AngularVelocity, Is.EqualTo(2.0f));
         });
     }
 
-    // Moves a rotating object onto a rotating grid, checks for conservation of angular velocity.
     [Test]
+    // Moves a rotating object onto a rotating grid, checks for conservation of angular velocity.
     public async Task TestLinearAndAngularVelocityMoveOntoGrid()
     {
-        var serverOpts = new ServerIntegrationOptions { Pool = false, ExtraPrototypes = Prototypes };
-        var server = StartServer(serverOpts);
+        // Spawn our test object 1 m off of the middle of the grid in both directions.
+        _objUid = SetupTestObject(new EntityCoordinates(_mapUid, 1.5f, 1.5f));
 
-        await server.WaitIdleAsync();
-
-        var systems = server.ResolveDependency<IEntitySystemManager>();
-        var fixtureSystem = systems.GetEntitySystem<FixtureSystem>();
-        var mapManager = server.ResolveDependency<IMapManager>();
-        var entManager = server.ResolveDependency<IEntityManager>();
-        var physSystem = systems.GetEntitySystem<SharedPhysicsSystem>();
-        var transformSystem = entManager.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
-        var mapSystem = entManager.EntitySysManager.GetEntitySystem<SharedMapSystem>();
-
-        // Set up entities
-        EntityUid map = default;
-        EntityUid grid = default;
-        EntityUid obj = default;
-        await server.WaitPost(() =>
-        {
-            map = mapSystem.CreateMap(out var mapId);
-
-            // Spawn a grid with one tile, ensure it's movable and its velocity has no damping.
-            var gridEnt = mapManager.CreateGridEntity(mapId);
-            physSystem.SetCanCollide(gridEnt, true);
-            physSystem.SetBodyType(gridEnt, BodyType.Dynamic);
-            physSystem.SetLinearDamping(gridEnt, entManager.GetComponent<PhysicsComponent>(gridEnt), 0.0f);
-            physSystem.SetAngularDamping(gridEnt, entManager.GetComponent<PhysicsComponent>(gridEnt), 0.0f);
-
-            mapSystem.SetTile(gridEnt, Vector2i.Zero, new Tile(1));
-            grid = gridEnt.Owner;
-
-            // Spawn our test object 1 m off of the middle of the grid in both directions, ensure it has no damping.
-            obj = server.EntMan.SpawnEntity("ReparentTestObject", new EntityCoordinates(map, 1.5f, 1.5f));
-            physSystem.SetCanCollide(obj, true);
-            physSystem.SetLinearDamping(obj, entManager.GetComponent<PhysicsComponent>(obj), 0.0f);
-            physSystem.SetAngularDamping(obj, entManager.GetComponent<PhysicsComponent>(obj), 0.0f);
-        });
-
-        await server.WaitAssertion(() =>
+        Assert.Multiple(() =>
         {
             // Assert that we start off the grid.
-            Assert.That(entManager.GetComponent<TransformComponent>(obj).ParentUid, Is.EqualTo(map));
+            Assert.That(_entManager.GetComponent<TransformComponent>(_objUid).ParentUid, Is.EqualTo(_mapUid));
             
             // Set the velocity of the grid and our object.
-            Assert.That(physSystem.SetLinearVelocity(obj, new Vector2(-2.0f, -3.0f)), Is.True);
-            Assert.That(physSystem.SetAngularVelocity(obj, 1.0f), Is.True);
-            Assert.That(physSystem.SetLinearVelocity(grid, new Vector2(-1.0f, -2.0f)), Is.True);
-            Assert.That(physSystem.SetAngularVelocity(grid, 2.0f), Is.True);
+            Assert.That(_physSystem.SetLinearVelocity(_objUid, new Vector2(-2.0f, -3.0f)), Is.True);
+            Assert.That(_physSystem.SetAngularVelocity(_objUid, 1.0f), Is.True);
+            Assert.That(_physSystem.SetLinearVelocity(_gridUid, new Vector2(-1.0f, -2.0f)), Is.True);
+            Assert.That(_physSystem.SetAngularVelocity(_gridUid, 2.0f), Is.True);
 
             // Wait a second to move onto the middle of the grid
-            physSystem.Update(1.0f);
+            _physSystem.Update(1.0f);
 
             // The object should be parented to the grid and maintain its map velocity (slowing down), the grid should be unchanged.
-            Assert.That(entManager.GetComponent<TransformComponent>(obj).ParentUid, Is.EqualTo(grid));
+            Assert.That(_entManager.GetComponent<TransformComponent>(_objUid).ParentUid, Is.EqualTo(_gridUid));
             // Not checking object's linear velocity in this case, non-zero contribution from grid angular velocity.
-            Assert.That(entManager.GetComponent<PhysicsComponent>(obj).AngularVelocity, Is.EqualTo(-1.0f));
-            var gridPhys = entManager.GetComponent<PhysicsComponent>(grid);
+            Assert.That(_entManager.GetComponent<PhysicsComponent>(_objUid).AngularVelocity, Is.EqualTo(-1.0f));
+            var gridPhys = _entManager.GetComponent<PhysicsComponent>(_gridUid);
             Assert.That(gridPhys.LinearVelocity, Is.EqualTo(new Vector2(-1.0f, -2.0f)));
             Assert.That(gridPhys.AngularVelocity, Is.EqualTo(2.0f));
         });
+    }
+
+    // Spawn a bullet-like test object at the given position.
+    public EntityUid SetupTestObject(EntityCoordinates coords)
+    {
+        var obj = _entManager.SpawnEntity(null, coords);
+
+        _entManager.EnsureComponent<PhysicsComponent>(obj);
+        _entManager.EnsureComponent<FixturesComponent>(obj);
+
+        // Set up fixture.
+        var poly = new PolygonShape();
+        poly.Set(new List<Vector2>()
+        {
+            new(0.1f, -0.1f),
+            new(0.1f, 0.1f),
+            new(-0.1f, 0.1f),
+            new(-0.1f, -0.1f),
+        });
+        _fixtureSystem.CreateFixture(obj, "fix1", new Fixture(poly, 0, 0, false));
+
+        // Set up physics (no velocity damping, dynamic body, physics enabled)
+        _physSystem.SetBodyType(obj, BodyType.Dynamic);
+        _physSystem.SetCanCollide(obj, true);
+        _physSystem.SetLinearDamping(obj, _entManager.GetComponent<PhysicsComponent>(obj), 0.0f);
+        _physSystem.SetAngularDamping(obj, _entManager.GetComponent<PhysicsComponent>(obj), 0.0f);
+
+        return obj;
     }
 }

--- a/Robust.UnitTesting/Shared/Physics/GridReparentVelocity_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/GridReparentVelocity_Test.cs
@@ -101,7 +101,7 @@ public sealed class GridReparentVelocity_Test
 
     // Moves an object off of a moving grid, checks for conservation of linear velocity.
     [Test]
-    public async Task TestLinearVelocityOnlyMoveOffGrid()
+    public void TestLinearVelocityOnlyMoveOffGrid()
     {
         // Spawn our test object in the middle of the grid, ensure it has no damping.
         _objUid = SetupTestObject(new EntityCoordinates(_gridUid, 0.5f, 0.5f));
@@ -129,7 +129,7 @@ public sealed class GridReparentVelocity_Test
 
     [Test]
     // Moves an object onto a moving grid, checks for conservation of linear velocity.
-    public async Task TestLinearVelocityOnlyMoveOntoGrid()
+    public void TestLinearVelocityOnlyMoveOntoGrid()
     {
         // Spawn our test object 1 m off of the middle of the grid in both directions.
         _objUid = SetupTestObject(new EntityCoordinates(_mapUid, 1.5f, 1.5f));
@@ -157,7 +157,7 @@ public sealed class GridReparentVelocity_Test
 
     [Test]
     // Moves a rotating object off of a rotating grid, checks for conservation of angular velocity.
-    public async Task TestLinearAndAngularVelocityMoveOffGrid()
+    public void TestLinearAndAngularVelocityMoveOffGrid()
     {
         // Spawn our test object in the middle of the grid.
         _objUid = SetupTestObject(new EntityCoordinates(_gridUid, 0.5f, 0.5f));
@@ -190,7 +190,7 @@ public sealed class GridReparentVelocity_Test
 
     [Test]
     // Moves a rotating object onto a rotating grid, checks for conservation of angular velocity.
-    public async Task TestLinearAndAngularVelocityMoveOntoGrid()
+    public void TestLinearAndAngularVelocityMoveOntoGrid()
     {
         // Spawn our test object 1 m off of the middle of the grid in both directions.
         _objUid = SetupTestObject(new EntityCoordinates(_mapUid, 1.5f, 1.5f));


### PR DESCRIPTION
Resolves #5800.

Currently, if moving an object reparents it, it may change its velocity, so that should be done afterwards.

Video comparing the test case from #5800 before and after the fix.

Before:

https://github.com/user-attachments/assets/7f9fa46c-38dc-45e3-bd17-c728acfea8de

After:

https://github.com/user-attachments/assets/ae1888db-b19b-4e28-8dfa-4ee799d49ed4