### PR TITLE
Add `GetContainingContainers` method to `SharedContainerSystem`

### DIFF
--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -531,6 +531,39 @@ namespace Robust.Shared.Containers
         }
 
         /// <summary>
+        /// Returns the full chain of containers containing the entity passed in, from innermost to outermost.
+        /// </summary>
+        /// <remarks>
+        /// The resulting collection includes the container directly containing the entity (if any),
+        /// the container containing that container, and so on until reaching the outermost container.
+        /// </remarks>
+        public IEnumerable<BaseContainer> EnumerateContainingContainers(Entity<TransformComponent?> ent)
+        {
+            if (!ent.Owner.IsValid())
+                yield break;
+
+            if (!Resolve(ent, ref ent.Comp))
+                yield break;
+
+            var child = ent.Owner;
+            var parent = ent.Comp.ParentUid;
+
+            while (parent.IsValid())
+            {
+                if (((MetaQuery.GetComponent(child).Flags & MetaDataFlags.InContainer) == MetaDataFlags.InContainer) &&
+                    _managerQuery.TryGetComponent(parent, out var conManager) &&
+                    TryGetContainingContainer(parent, child, out var parentContainer, conManager))
+                {
+                    yield return parentContainer;
+                }
+
+                var parentXform = TransformQuery.GetComponent(parent);
+                child = parent;
+                parent = parentXform.ParentUid;
+            }
+        }
+
+        /// <summary>
         /// Gets the top-most container in the hierarchy for this entity, if it exists.
         /// </summary>
         public bool TryGetOuterContainer(EntityUid uid, TransformComponent xform, [NotNullWhen(true)] out BaseContainer? container)

--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -537,7 +537,7 @@ namespace Robust.Shared.Containers
         /// The resulting collection includes the container directly containing the entity (if any),
         /// the container containing that container, and so on until reaching the outermost container.
         /// </remarks>
-        public IEnumerable<BaseContainer> EnumerateContainingContainers(Entity<TransformComponent?> ent)
+        public IEnumerable<BaseContainer> GetContainingContainers(Entity<TransformComponent?> ent)
         {
             if (!ent.Owner.IsValid())
                 yield break;


### PR DESCRIPTION
Adds a new method to `SharedContainerSystem` that returns the full chain of containers containing the passed in entity, ordered from innermost to outermost.

So if someone is wearing a backpack with a full matchbox in it and you call `GetContainingContainers` on one of the matches, you'll get an `IEnumerable<BaseContainer>` with the matchbox's storage container, the backpack's storage container, and the person's inventory itemslot, in that order.

Yes, this is basically just `TryGetOuterContainer` with some yield statements, but it's useful! I'd like to have it for a content PR I'm working on.