### PR TITLE
Flick implementation for AnimationPlayer

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
@@ -39,6 +39,7 @@ namespace Robust.Client.GameObjects
             Flick(uid.Value, ev.StateId, ev.LayerKey);
         }
 
+        /// <inheritdoc/>
         public override void Flick(EntityUid uid, string stateId, object layerKey)
         {
             if (!_spriteQuery.TryGetComponent(uid, out var sprite))

--- a/Robust.Server/GameObjects/EntitySystems/AnimationPlayerSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/AnimationPlayerSystem.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Animations;
+using Robust.Shared.GameObjects;
+
+namespace Robust.Server.GameObjects;
+
+public sealed class AnimationPlayerSystem : SharedAnimationPlayerSystem
+{
+    public override void Flick(EntityUid uid, string stateId, object layerKey)
+    {
+        var ev = new AnimationFlickEvent(GetNetEntity(uid), stateId, layerKey);
+        RaiseNetworkEvent(ev);
+    }
+}

--- a/Robust.Server/GameObjects/EntitySystems/AnimationPlayerSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/AnimationPlayerSystem.cs
@@ -5,6 +5,7 @@ namespace Robust.Server.GameObjects;
 
 public sealed class AnimationPlayerSystem : SharedAnimationPlayerSystem
 {
+    /// <inheritdoc/>
     public override void Flick(EntityUid uid, string stateId, object layerKey)
     {
         var ev = new AnimationFlickEvent(GetNetEntity(uid), stateId, layerKey);

--- a/Robust.Shared/Animations/SharedAnimationPlayerSystem.cs
+++ b/Robust.Shared/Animations/SharedAnimationPlayerSystem.cs
@@ -6,6 +6,12 @@ namespace Robust.Shared.Animations;
 
 public abstract class SharedAnimationPlayerSystem : EntitySystem
 {
+    /// <summary>
+    /// Plays an <see cref="AnimationTrackSpriteFlick"/> for a target entity for the full duration of the state.
+    /// </summary>
+    /// <param name="uid">The entity to play the animation on.</param>
+    /// <param name="stateId">The state we are playing.</param>
+    /// <param name="layerKey">A key for the sprite layer. Must be NetSerializable.</param>
     public abstract void Flick(EntityUid uid, string stateId, object layerKey);
 }
 

--- a/Robust.Shared/Animations/SharedAnimationPlayerSystem.cs
+++ b/Robust.Shared/Animations/SharedAnimationPlayerSystem.cs
@@ -1,0 +1,25 @@
+using System;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Serialization;
+
+namespace Robust.Shared.Animations;
+
+public abstract class SharedAnimationPlayerSystem : EntitySystem
+{
+    public abstract void Flick(EntityUid uid, string stateId, object layerKey);
+}
+
+[Serializable, NetSerializable]
+public sealed class AnimationFlickEvent : EntityEventArgs
+{
+    public NetEntity Entity;
+    public string StateId;
+    public object LayerKey;
+
+    public AnimationFlickEvent(NetEntity entity, string stateId, object layerKey)
+    {
+        Entity = entity;
+        StateId = stateId;
+        LayerKey = layerKey;
+    }
+}


### PR DESCRIPTION
Adds a mirrored implementation of Byond's `Flick()` for AnimationPlayer.

This is a function you can call from server or shared code to run a state's animation on a target layer. The goal is to reduce lots of duplicated content code that exists simply to network state and run animation boilerplate. 

No breaking changes.