### PR TITLE
Optimization RSI preloading / atlas creation

### DIFF
--- a/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
+++ b/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
@@ -195,7 +195,6 @@ namespace Robust.Client.ResourceManagement
             var deltaY = 0;
             Vector2i offset = default;
             int atlasRsiIndexStart = 0;
-            int atlasCount = 0;
             int filledPixels = 0;
             for (int i = 0; i < atlasList.Length; i++)
             {
@@ -223,7 +222,7 @@ namespace Robust.Client.ResourceManagement
                 }
 
                 deltaY = Math.Max(deltaY, rsi.AtlasSheet.Height);
-                rsiPositions[i] = (atlasCount, offset);
+                rsiPositions[i] = (finalMetaAtlases.Count, offset);
                 offset.X += rsi.AtlasSheet.Width;
                 filledPixels += rsi.AtlasSheet.Width * rsi.AtlasSheet.Height;
             }
@@ -308,7 +307,7 @@ namespace Robust.Client.ResourceManagement
             sawmill.Debug(
                 "Preloaded {CountLoaded} RSIs into {CountAtlas} Atlas(es?) ({CountNotAtlas} not atlassed, {CountErrored} errored) in {LoadTime}",
                 rsiList.Length,
-                atlasCount,
+                finalMetaAtlases.Count,
                 nonAtlasList.Length,
                 errors,
                 sw.Elapsed);

--- a/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
+++ b/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
@@ -18,10 +18,7 @@ using Robust.Shared.Log;
 using Robust.Shared.Maths;
 using Robust.Shared.Utility;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
-using Vector3 = System.Numerics.Vector3;
 
 namespace Robust.Client.ResourceManagement
 {
@@ -185,7 +182,7 @@ namespace Robust.Client.ResourceManagement
             // and cutting is free. The sorting is done by a slightly modified FFDH algorithm. The algorithm is exactly
             // the same as the standard FFDH algorithm with one main difference: We create new "levels" above placed
             // blocks. For example if the first block was 10x20, then the second was 10x10 units, we would create a
-            // 10x10 level bove the second block that would be treated as a normal level. This increases the packing
+            // 10x10 level above the second block that would be treated as a normal level. This increases the packing
             // efficiency from ~85% to ~95% with very little extra computational effort. The algorithm appears to be
             // ~97% effective for storing SS14s RSIs.
             //
@@ -201,16 +198,16 @@ namespace Robust.Client.ResourceManagement
 
             // THIS IS NOT GUARANTEED TO HAVE ANY PARTICULARLY LOGICAL ORDERING.
             // E.G you could have atlas 1 RSIs appear *before* you're done seeing atlas 2 RSIs.
-            var levels = new List<Level>();
+            var levels = new ValueList<Level>();
 
             // List of all the image atlases.
-            var imageAtlases = new List<Image<Rgba32>>();
+            var imageAtlases = new ValueList<Image<Rgba32>>();
 
             // List of all the actual atlases.
-            var finalAtlases = new List<OwnedTexture>();
+            var finalAtlases = new ValueList<OwnedTexture>();
 
             // Number of total pixels in each atlas.
-            var finalPixels = new List<int>();
+            var finalPixels = new ValueList<int>();
 
             // First we just find the location of all the RSIs in the atlas before actually placing them.
             // This allows us to effectively determine how much space we need to allocate for the images.
@@ -297,15 +294,10 @@ namespace Robust.Client.ResourceManagement
                 {
                     var box = new UIBox2i(0, 0, rsi.AtlasSheet.Width, rsi.AtlasSheet.Height);
 
-                    // var random = new Random();
-                    // var color = new Rgba32((byte)random.Next(256), (byte)random.Next(256), (byte)random.Next(256));
-                    // var image = new Image<Rgba32>(rsi.AtlasSheet.Width, rsi.AtlasSheet.Height, color);
-
                     rsi.AtlasSheet.Blit(box, imageAtlases[level.AtlasId], rsi.AtlasOffset);
                     finalPixels[level.AtlasId] += rsi.AtlasSheet.Width * rsi.AtlasSheet.Height;
                 }
             }
-            // atlases[0].Save("debug_output2.png", new PngEncoder());
 
             // Finalize the atlases.
             for (var i = 0; i < imageAtlases.Count; i++)

--- a/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
+++ b/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
@@ -9,6 +9,7 @@ using Robust.Client.Graphics;
 using Robust.Client.Utility;
 using Robust.Shared;
 using Robust.Shared.Audio;
+using Robust.Shared.Collections;
 using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
 using Robust.Shared.Graphics;
@@ -188,7 +189,7 @@ namespace Robust.Client.ResourceManagement
             var rsiPositions = new (int, Vector2i)[atlasList.Length];
 
             // (start rsi index, end rsi index, final meta atlas reference).
-            var finalMetaAtlases = new List<(int, int, Image<Rgba32>)>();
+            var finalMetaAtlases = new ValueList<(int, int, Image<Rgba32>)>();
 
             // First calculate the position of all sub atlases in the actual atlases.
             // This allows us to get the correct size of the atlases before allocating them.


### PR DESCRIPTION
When RSIs were preloaded they worked like this (big picture overview):
1.) Load all images and combine rsi files into mini atlases
2.) Create a new maxsize by maxsize image atlas
3.) Loop through all RSIs and load them onto the atlas. If the atlas gets filled, create a new one and lock in the current one.
4.) Create a new image that is only as big as necessary (If the final atlas didn't get filled up all the way)
5.) Fit the orignal final atlas into the new cropped one.

For ss14 specifically, there is only enough sprites to allocate about half of one max sized atlas so step 3 really never occurs. This means that we are allocating 1 maxed sized image and 1 ~ half max sized image. This isn't necessary so what I've done is basically just removed that first allocation!

My changes now make it work like this:
1.) Load all images and combine rsi files into mini atlases.
2.) Loop through all RSIs, pre determine what atlas they would go into and their offset inside of it. If we know an atlas will be filled up, allocate an image of the correct size (This is only done when we 100% know we will need the atlas). This also uses the a slightly modified [first-fit decreasing-height strip packing algorithm](https://en.wikipedia.org/w/index.php?title=Strip_packing_problem&oldid=1263496949#First-fit_decreasing-height_(FFDH)). More information about that below.
3.) Loop through all FFDH levels and actually put them in their respective atlas images.
4.) Finalize all atlases (Actually load the atlas into Clyde and give all rsis a reference to that atlas)

I did some brief testing on ss14 and got a minor but still "noticeable" speed boost to preloading textures (~11.5% or 0.3 seconds)! Texture loading has a lot of variance but its defiantly an improvement.

![image](https://github.com/user-attachments/assets/2583ab5e-00f6-4834-9dbe-794608155008)
(Before and after times - I ran each 10 times.)

For the atlas itself, it's now being stored using a slightly modified FFDH algorithm that I create. The algorithm is basically exactly the same, the only difference is I use the empty spaces above placed squares as new "levels" that you can insert stuff into.

![image](https://github.com/user-attachments/assets/f6530774-69ae-4d20-9221-8c1b83f7abac)
Those "Free" level spaces would be completely ignored in the standard FFDH algorithm, mine just makes them a normal level which is filled up like normal. 

Here is a compassion of SS14s atlas was filled:

(Before this PR `cropped utilization: 80.84%, fill percentage: 60.94%`)
![Screenshot from 2025-04-15 18-30-11](https://github.com/user-attachments/assets/2e4c4f72-4c13-4790-bc7f-af1a4f1b33bd)

(FFDH sorting only `cropped utilization: 89.22%, fill percentage: 55.21%`)
![Screenshot from 2025-04-15 18-27-39](https://github.com/user-attachments/assets/0ba13d6e-7e25-4f4b-912b-1b4fcc8cf5be)

(FFDH sorting w/ my modifications `cropped utilization: 97.00%, fill percentage: 50.78%`)
![Screenshot from 2025-04-15 18-25-24](https://github.com/user-attachments/assets/a01c80dc-db6a-4dce-a5a8-ecb417b3b6b9)

So this new algorithm is able to reduce SS14s atlas size by ~10%. For other repositories like Goob, the savings are even greater (They needed to allocate two atlases, this reduces it to 1!). This new allegorist saves them ~1.3 seconds (Mostly due to not having to allocate massive images for the second atlas).