### PR TITLE
Lower light defaults

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -47,7 +47,7 @@ END TEMPLATE-->
 
 ### Other
 
-*None yet*
+* Default lighting options have been lowered. `LightResolutionScale` is now `0.3` from `0.5` and `LightSoftShadows` is now `false`. This saves a decent bit of GPU usage while looking near identical.
 
 ### Internal
 

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -853,7 +853,7 @@ namespace Robust.Shared
         /// relative to the viewport framebuffer size.
         /// </summary>
         public static readonly CVarDef<float> LightResolutionScale =
-            CVarDef.Create("light.resolution_scale", 0.5f, CVar.CLIENTONLY | CVar.ARCHIVE);
+            CVarDef.Create("light.resolution_scale", 0.3f, CVar.CLIENTONLY | CVar.ARCHIVE);
 
         /// <summary>
         /// Maximum amount of shadow-casting lights that can be rendered in a single viewport at once.
@@ -865,7 +865,7 @@ namespace Robust.Shared
         /// Whether to give shadows a soft edge when rendering.
         /// </summary>
         public static readonly CVarDef<bool> LightSoftShadows =
-            CVarDef.Create("light.soft_shadows", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+            CVarDef.Create("light.soft_shadows", false, CVar.CLIENTONLY | CVar.ARCHIVE);
 
         /// <summary>
         /// Apply a gaussian blur to the final lighting framebuffer to smoothen it out a little.


### PR DESCRIPTION
These look exactly the same, but reduce gpu usage by quite a bit from my testing. I believe this should be the default for future clients.

Needed https://github.com/space-wizards/space-station-14/pull/36471 since these defaults are  the "medium" preset

I cannot (myself) tell a difference between the previous and the proposed lighting default.
