### PR TITLE
Make BoundUserInterfaceMessageAttempt broadcast again

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -40,6 +40,8 @@ END TEMPLATE-->
 ### New features
 
 * Add a new `SerializationManager.PushComposition()` overload that takes in a single parent instead of an array of parents.
+* `BoundUserInterfaceMessageAttempt` once again gets raised as a broadcast event, in addition to being directed.
+  * This effectively reverts the breaking part of the changes made in v252.0.0
 
 ### Bugfixes
 

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -121,6 +121,11 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
         if (msg.Message is not CloseBoundInterfaceMessage && ui.RequireInputValidation)
         {
             var attempt = new BoundUserInterfaceMessageAttempt(sender, uid, msg.UiKey, msg.Message);
+
+            RaiseLocalEvent(attempt);
+            if (attempt.Cancelled)
+                return;
+
             RaiseLocalEvent(uid, attempt);
             if (attempt.Cancelled)
                 return;


### PR DESCRIPTION
This effectively undoes the breaking change in #5811, though the event will still get raised directed at the UI entity.