### PR TITLE
Fix `logMissing` option being ignored by some `EntitySystem.Resolve()` overloads

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,6 +44,7 @@ END TEMPLATE-->
 ### Bugfixes
 
 * Fix deferred component removal not setting the component's life stage to `ComponentLifeStage.Stopped` if the component has not yet been initialised.
+* Fix some `EntitySystem.Resolve()` overloads not respecting the optional `logMissing` argument.
 
 ### Other
 

--- a/Robust.Shared/GameObjects/EntitySystem.Resolve.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Resolve.cs
@@ -37,18 +37,22 @@ namespace Robust.Shared.GameObjects
 
         /// <inheritdoc cref="Resolve{TComp}(Robust.Shared.GameObjects.EntityUid,ref TComp?,bool)"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected bool Resolve(EntityUid uid, [NotNullWhen(true)] ref MetaDataComponent? component,
+        protected bool Resolve(
+            EntityUid uid,
+            [NotNullWhen(true)] ref MetaDataComponent? component,
             bool logMissing = true)
         {
-            return EntityManager.MetaQuery.Resolve(uid, ref component);
+            return EntityManager.MetaQuery.Resolve(uid, ref component, logMissing);
         }
 
         /// <inheritdoc cref="Resolve{TComp}(Robust.Shared.GameObjects.EntityUid,ref TComp?,bool)"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected bool Resolve(EntityUid uid, [NotNullWhen(true)] ref TransformComponent? component,
+        protected bool Resolve(
+            EntityUid uid,
+            [NotNullWhen(true)] ref TransformComponent? component,
             bool logMissing = true)
         {
-            return EntityManager.TransformQuery.Resolve(uid, ref component);
+            return EntityManager.TransformQuery.Resolve(uid, ref component, logMissing);
         }
 
         /// <summary>


### PR DESCRIPTION
This is responsible for at least one of the random test failures that come up (e.g., https://github.com/space-wizards/RobustToolbox/actions/runs/14415501928/job/40431314872)