### PR TITLE
Fix NRE in screen-space overlays

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -45,6 +45,7 @@ END TEMPLATE-->
 
 * Fix deferred component removal not setting the component's life stage to `ComponentLifeStage.Stopped` if the component has not yet been initialised.
 * Fix some `EntitySystem.Resolve()` overloads not respecting the optional `logMissing` argument.
+* Fix screen-space overlays not being useable without first initializing/starting entity manager & systems
 
 ### Other
 

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -123,9 +123,13 @@ namespace Robust.Client.Graphics.Clyde
 
         private void RenderSingleWorldOverlay(Overlay overlay, Viewport vp, OverlaySpace space, in Box2 worldBox, in Box2Rotated worldBounds)
         {
+            // Check that entity manager has started.
+            // This is required for us to be able to use MapSystem.
+            DebugTools.Assert(_entityManager.Started, "Entity manager should be started/initialized before rendering world-space overlays");
+
             DebugTools.Assert(space != OverlaySpace.ScreenSpaceBelowWorld && space != OverlaySpace.ScreenSpace);
 
-            var mapId = vp.Eye!.Position.MapId;
+            var mapId = vp.Eye?.Position.MapId ?? MapId.Nullspace;
             var args = new OverlayDrawArgs(space, null, vp, _renderHandle, new UIBox2i((0, 0), vp.Size), _mapSystem.GetMapOrInvalid(mapId), mapId, worldBox, worldBounds);
 
             if (!overlay.BeforeDraw(args))
@@ -152,6 +156,7 @@ namespace Robust.Client.Graphics.Clyde
 
         private void RenderOverlays(Viewport vp, OverlaySpace space, in Box2 worldBox, in Box2Rotated worldBounds)
         {
+            DebugTools.Assert(space != OverlaySpace.ScreenSpaceBelowWorld && space != OverlaySpace.ScreenSpace);
             using (DebugGroup($"Overlays: {space}"))
             {
                 foreach (var overlay in GetOverlaysForSpace(space))
@@ -176,9 +181,14 @@ namespace Robust.Client.Graphics.Clyde
 
             var worldBounds = CalcWorldBounds(vp);
             var worldAABB = worldBounds.CalcBoundingBox();
-            var mapId = vp.Eye!.Position.MapId;
+            var mapId = vp.Eye?.Position.MapId ?? MapId.Nullspace;
+            var mapUid = EntityUid.Invalid;
 
-            var args = new OverlayDrawArgs(space, vpControl, vp, handle, bounds, _mapSystem.GetMapOrInvalid(mapId), mapId, worldAABB, worldBounds);
+            // Screen space overlays may be getting used before entity manager & entity systems have been initialized.
+            if (_entityManager.Started)
+                mapUid = _mapSystem.GetMapOrInvalid(mapId);
+
+            var args = new OverlayDrawArgs(space, vpControl, vp, handle, bounds, mapUid, mapId, worldAABB, worldBounds);
 
             foreach (var overlay in list)
             {

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -185,8 +185,12 @@ namespace Robust.Client.Graphics.Clyde
             var mapUid = EntityUid.Invalid;
 
             // Screen space overlays may be getting used before entity manager & entity systems have been initialized.
-            if (_entityManager.Started)
+            // This might mean that _mapSystem is currently null.
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+            if (_entityManager.Started && _mapSystem != null)
                 mapUid = _mapSystem.GetMapOrInvalid(mapId);
+
+            DebugTools.Assert(_mapSystem != null || !_entityManager.Initialized);
 
             var args = new OverlayDrawArgs(space, vpControl, vp, handle, bounds, mapUid, mapId, worldAABB, worldBounds);
 


### PR DESCRIPTION
Tries to fix a NRE when rendering screen-space overlays without first initializing entity manager/systems.
Probably fixes #5738, but I haven't actually properly tested it.

Note that world-space overlays will still throw an NRE. ~~The issue links to the world-space method, but I assume that was a mistake and it was meant to link to the screen-space one?~~ Yep the actual stack trace was for the screen-space method

We could still make the world-space one not throw, but it feels somewhat weird to have "world space" rendering before systems/entities exist.