### PR TITLE
Cleanup warnings: Commands

### DIFF
--- a/Robust.Shared/Console/Commands/MapCommands.cs
+++ b/Robust.Shared/Console/Commands/MapCommands.cs
@@ -37,7 +37,7 @@ sealed class AddMapCommand : LocalizedEntityCommands
 
 sealed class RemoveMapCommand : LocalizedCommands
 {
-    [Dependency] private readonly IMapManager _map = default!;
+    [Dependency] private readonly IEntitySystemManager _systems = default!;
 
     public override string Command => "rmmap";
     public override bool RequireServerOrSingleplayer => true;
@@ -51,14 +51,15 @@ sealed class RemoveMapCommand : LocalizedCommands
         }
 
         var mapId = new MapId(int.Parse(args[0]));
+        var mapSystem = _systems.GetEntitySystem<SharedMapSystem>();
 
-        if (!_map.MapExists(mapId))
+        if (!mapSystem.MapExists(mapId))
         {
             shell.WriteError($"Map {mapId.Value} does not exist.");
             return;
         }
 
-        _map.DeleteMap(mapId);
+        mapSystem.DeleteMap(mapId);
         shell.WriteLine($"Map {mapId.Value} was removed.");
     }
 }

--- a/Robust.Shared/Console/Commands/TeleportCommands.cs
+++ b/Robust.Shared/Console/Commands/TeleportCommands.cs
@@ -20,6 +20,7 @@ internal sealed class TeleportCommand : LocalizedEntityCommands
     [Dependency] private readonly IMapManager _map = default!;
     [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedMapSystem _mapSystem = default!;
 
     public override string Command => "tp";
     public override bool RequireServerOrSingleplayer => true;
@@ -46,7 +47,7 @@ internal sealed class TeleportCommand : LocalizedEntityCommands
         else
             mapId = transform.MapID;
 
-        if (!_map.MapExists(mapId))
+        if (!_mapSystem.MapExists(mapId))
         {
             shell.WriteError($"Map {mapId} doesn't exist!");
             return;
@@ -60,9 +61,11 @@ internal sealed class TeleportCommand : LocalizedEntityCommands
         }
         else
         {
-            var mapEnt = _map.GetMapEntityIdOrThrow(mapId);
-            _transform.SetWorldPosition((entity, transform), position);
-            _transform.SetParent(entity, transform, mapEnt);
+            if (_mapSystem.TryGetMap(mapId, out var mapEnt))
+            {
+                _transform.SetWorldPosition((entity, transform), position);
+                _transform.SetParent(entity, transform, mapEnt.Value);
+            }
         }
 
         shell.WriteLine($"Teleported {shell.Player} to {mapId}:{posX},{posY}.");

--- a/Robust.Shared/Map/Commands/AmbientLightCommand.cs
+++ b/Robust.Shared/Map/Commands/AmbientLightCommand.cs
@@ -11,7 +11,6 @@ namespace Robust.Shared.Map.Commands;
 /// </summary>
 public sealed class AmbientLightCommand : IConsoleCommand
 {
-    [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly IEntitySystemManager _systems = default!;
 
     public string Command => $"setambientlight";
@@ -32,10 +31,11 @@ public sealed class AmbientLightCommand : IConsoleCommand
         }
 
         var mapId = new MapId(mapInt);
+        var mapSystem = _systems.GetEntitySystem<SharedMapSystem>();
 
-        if (!_mapManager.MapExists(mapId))
+        if (!mapSystem.MapExists(mapId))
         {
-            shell.WriteError(Loc.GetString("cmd-parse-failure-mapid"));
+            shell.WriteError(Loc.GetString("cmd-parse-failure-mapid", ("arg", mapId.Value)));
             return;
         }
 
@@ -49,7 +49,6 @@ public sealed class AmbientLightCommand : IConsoleCommand
         }
 
         var color = Color.FromSrgb(new Color(r, g, b, a));
-        var mapSystem = _systems.GetEntitySystem<SharedMapSystem>();
         mapSystem.SetAmbientLight(mapId, color);
     }
 }


### PR DESCRIPTION
Removes warnings (5x) about using `IMapManager` in the code of some commands using `MapSystem`:
- MapCommands.cs
- TeleportCommands.cs
- AmbientLightCommand.cs

[https://github.com/space-wizards/space-station-14/issues/33279](https://github.com/space-wizards/space-station-14/issues/33279)