### PR TITLE
Mark GetCollidingEntities as obsolete

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs
@@ -137,6 +137,7 @@ namespace Robust.Shared.Physics.Systems
         /// <summary>
         /// Get all entities colliding with a certain body.
         /// </summary>
+        [Obsolete("Use EntityLookupSystem")]
         public IEnumerable<PhysicsComponent> GetCollidingEntities(MapId mapId, in Box2 worldAABB)
         {
             if (mapId == MapId.Nullspace) return Array.Empty<PhysicsComponent>();
@@ -169,6 +170,7 @@ namespace Robust.Shared.Physics.Systems
         /// <summary>
         /// Get all entities colliding with a certain body.
         /// </summary>
+        [Obsolete("Use EntityLookupSystem")]
         public IEnumerable<Entity<PhysicsComponent>> GetCollidingEntities(MapId mapId, in Box2Rotated worldBounds)
         {
             if (mapId == MapId.Nullspace)


### PR DESCRIPTION
Bad methods, entitylookup is better (it does everything for area queries) and anyone who wants contacts should be querying those directly.