### PR TITLE
Cleanup: CollisionWake_Test

### DIFF
--- a/Robust.UnitTesting/Shared/Physics/CollisionWake_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/CollisionWake_Test.cs
@@ -51,23 +51,28 @@ namespace Robust.UnitTesting.Shared.Physics
             TransformComponent xform = default!;
             PhysicsComponent entityTwoPhysics = default!;
 
+            EntityUid? entityOne = null;
+            EntityUid? entityTwo = null;
             await server.WaitPost(() =>
             {
                 mapSystem.CreateMap(out mapId);
                 grid = mapManager.CreateGridEntity(mapId);
                 mapSystem.SetTile(grid, Vector2i.Zero, new Tile(1));
 
-                var entityOne = entManager.SpawnEntity("CollisionWakeTestItem", new MapCoordinates(Vector2.One * 2f, mapId));
-                entityOnePhysics = entManager.GetComponent<PhysicsComponent>(entityOne);
-                xform = entManager.GetComponent<TransformComponent>(entityOne);
+                entityOne = entManager.SpawnEntity("CollisionWakeTestItem", new MapCoordinates(Vector2.One * 2f, mapId));
+                entityOnePhysics = entManager.GetComponent<PhysicsComponent>(entityOne.Value);
+                xform = entManager.GetComponent<TransformComponent>(entityOne.Value);
                 mapSystem.TryGetMap(mapId, out var mapUid);
                 Assert.That(xform.ParentUid == mapUid);
 
-                var entityTwo = entManager.SpawnEntity("CollisionWakeTestItem", new EntityCoordinates(grid, new Vector2(0.5f, 0.5f)));
-                entityTwoPhysics = entManager.GetComponent<PhysicsComponent>(entityTwo);
-                Assert.That(entManager.GetComponent<TransformComponent>(entityTwo).ParentUid == grid.Owner);
+                entityTwo = entManager.SpawnEntity("CollisionWakeTestItem", new EntityCoordinates(grid, new Vector2(0.5f, 0.5f)));
+                entityTwoPhysics = entManager.GetComponent<PhysicsComponent>(entityTwo.Value);
+                Assert.That(entManager.GetComponent<TransformComponent>(entityTwo.Value).ParentUid == grid.Owner);
 
             });
+
+            Assert.That(entityOne, Is.Not.Null);
+            Assert.That(entityTwo, Is.Not.Null);
 
             // Item 1 Should still be collidable
             await server.WaitRunTicks(1);
@@ -77,8 +82,8 @@ namespace Robust.UnitTesting.Shared.Physics
                 Assert.That(entityOnePhysics.Awake, Is.EqualTo(false));
                 Assert.That(entityOnePhysics.CanCollide, Is.EqualTo(true));
 
-                xform.LocalPosition = new Vector2(0.5f, 0.5f);
-                xform.AttachParent(grid);
+                transformSystem.SetLocalPosition(entityOne.Value, new Vector2(0.5f, 0.5f), xform);
+                transformSystem.SetParent(entityOne.Value, xform, grid);
 
                 // Entity 2 should immediately not be collidable on spawn
                 Assert.That(entityTwoPhysics.Awake, Is.EqualTo(false));
@@ -92,8 +97,8 @@ namespace Robust.UnitTesting.Shared.Physics
                 Assert.That(entityOnePhysics.Awake, Is.EqualTo(false));
                 Assert.That(entityOnePhysics.CanCollide, Is.EqualTo(false));
 
-                xform.LocalPosition = Vector2.One * 2f;
-                xform.AttachParent(mapManager.GetMapEntityId(mapId));
+                transformSystem.SetLocalPosition(entityOne.Value, Vector2.One * 2f);
+                transformSystem.SetParent(entityOne.Value, xform, mapSystem.GetMapOrInvalid(mapId));
             });
 
             // Juussttt in case we'll re-parent it to the map and check its collision is back on.


### PR DESCRIPTION
Fixes 5 warnings in `CollisionWake_Test`.

**2x 'TransformComponent.LocalPosition.set' is obsolete: 'Use the system method instead' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Replaced with `TransformSystem.SetLocalPosition`.

**2x 'TransformComponent.AttachParent(EntityUid)' is obsolete: 'Use TransformSystem.SetParent() instead' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Replaced with `TransformSystem.SetParent`.

**1x 'IMapManager.GetMapEntityId(MapId)' is obsolete: 'Use MapSystem' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Replaced with `SharedMapSystem.GetMapOrInvalid`.

https://github.com/space-wizards/space-station-14/issues/33279