### PR TITLE
Fix TileEdge rendering

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
@@ -314,8 +314,8 @@ namespace Robust.Client.Graphics.Clyde
                             if (tile.TypeId == neighborTile.TypeId || neighborDef.EdgeSprites.Count == 0)
                                 continue;
 
-                            // If neighbor is a lower priority then us then don't draw on our tile.
-                            if (neighborDef.EdgeSpritePriority < tileDef.EdgeSpritePriority)
+                            // If neighbor is a lower or same priority then us then don't draw on our tile.
+                            if (neighborDef.EdgeSpritePriority <= tileDef.EdgeSpritePriority)
                                 continue;
 
                             var direction = new Vector2i(nx, ny).AsDirection().GetOpposite();


### PR DESCRIPTION
Fixes messy when 2 tiles with the same EdgePriority level draw edges at the same time

before

![image](https://github.com/user-attachments/assets/315c9deb-c7c8-4d5d-9c1f-f398437e6a92)
![image](https://github.com/user-attachments/assets/19a8792c-5c0b-4fc4-9779-6b0c696b3500)

after

![image](https://github.com/user-attachments/assets/4c61c747-8b89-490d-bbd6-e98b64f4b1ab)
