### PR TITLE
Allow subclasses of RichTextLabel to get a copy of the parsed message

### DIFF
--- a/Robust.Client/UserInterface/Controls/RichTextLabel.cs
+++ b/Robust.Client/UserInterface/Controls/RichTextLabel.cs
@@ -75,6 +75,8 @@ namespace Robust.Client.UserInterface.Controls
 
         public string? GetMessage() => _message?.ToMarkup();
 
+        protected FormattedMessage? GetFormattedMessage() => _message != null ? new FormattedMessage(_message) : null;
+
         protected override Vector2 MeasureOverride(Vector2 availableSize)
         {
             if (_message == null)


### PR DESCRIPTION
  Needed to allow subclasses to modify the displayed message (add a colour) without having to parse the message string again.