### PR TITLE
add RecursiveGetAllEntitiesWithComp

### DIFF
--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -404,18 +404,18 @@ namespace Robust.Shared.Containers
         /// <summary>
         /// Recursively get all entities with Component T in all containers on the entity
         /// </summary>
-        /// <param name="containter">The root container to search in.</param>
+        /// <param name="root">The root container to search in.</param>
         /// <param name="maxDepth">The max depth that will be searched before aborting.</param>
         /// <typeparam name="T">The component being searched for.</typeparam>
         /// <returns>All entities with component T in container and all children</returns>
         public HashSet<Entity<T?>> RecursiveGetAllEntitiesWithComp<T>(
-            Entity<ContainerManagerComponent> containter,
+            Entity<ContainerManagerComponent> root,
             int maxDepth = 1000) where T : Component
         {
             var entities = new HashSet<Entity<T?>>();
 
             var stack = new Stack<EntityUid>();
-            stack.Push(containter);
+            stack.Push(root);
 
             while (stack.Count > 0)
             {

--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -422,13 +422,6 @@ namespace Robust.Shared.Containers
             stack ??= new Stack<EntityUid>();
             stack.Clear();
 
-            var allTargetComps = EntityQueryEnumerator<T>();
-            var targetEnts = new HashSet<EntityUid>();
-            while (allTargetComps.MoveNext(out var targetEnt, out _))
-            {
-                targetEnts.Add(targetEnt);
-            }
-
             stack.Push(root);
 
             while (stack.Count > 0)
@@ -442,10 +435,7 @@ namespace Robust.Shared.Containers
                 {
                     foreach (var entity in container.ContainedEntities)
                     {
-                        if (targetEnts.Contains(entity))
-                        {
-                            stack.Push(entity);
-                        }
+                        stack.Push(entity);
                     }
                 }
             }


### PR DESCRIPTION
added functionality in container system to get all entities with a component recursively. This will help in situations in which all entities with a certain component needs to be processed before a parent container does something. Such example as a polymorph dropping all MindContainerComponet entities before polymorphing so they are not sent to null-space.