### PR TITLE
Otel Preparation: Hide Prometheus dependency, etc

### DIFF
--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Prometheus;
 using Robust.Client.GameStates;
 using Robust.Client.Player;
 using Robust.Client.Timing;
@@ -8,6 +7,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Network;
 using Robust.Shared.Network.Messages;
+using Robust.Shared.Observability;
 using Robust.Shared.Player;
 using Robust.Shared.Replays;
 using Robust.Shared.Utility;
@@ -203,7 +203,7 @@ namespace Robust.Client.GameObjects
 
         public override void TickUpdate(float frameTime, bool noPredictions, Histogram? histogram)
         {
-            using (histogram?.WithLabels("EntityNet").NewTimer())
+            using (histogram?.Timer("EntityNet"))
             {
                 while (_queue.Count != 0 && _queue.Peek().msg.SourceTick <= _gameTiming.LastRealTick)
                 {

--- a/Robust.Client/IGameController.cs
+++ b/Robust.Client/IGameController.cs
@@ -22,7 +22,7 @@ public interface IGameController
 
     /// <summary>
     ///     This event gets invoked prior to performing entity tick update logic. If this is null the game
-    ///     controller will simply call <see cref="IEntityManager.TickUpdate(float, bool, Prometheus.Histogram?)"/>.
+    ///     controller will simply call <see cref="IEntityManager.TickUpdate(float, bool, Robust.Shared.Observability.Histogram?)"/>.
     ///     This exists to give content module more control over tick updating.
     /// </summary>
     event Action<FrameEventArgs>? TickUpdateOverride;

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
-using Prometheus;
 using Robust.Server.GameStates;
 using Robust.Server.Player;
 using Robust.Shared;
@@ -15,6 +14,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Network;
 using Robust.Shared.Network.Messages;
+using Robust.Shared.Observability;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Replays;
@@ -29,7 +29,7 @@ namespace Robust.Server.GameObjects
     [UsedImplicitly] // DI Container
     public sealed class ServerEntityManager : EntityManager, IServerEntityManager
     {
-        private static readonly Gauge EntitiesCount = Metrics.CreateGauge(
+        private static readonly Gauge EntitiesCount = Metrics.Gauge(
             "robust_entities_count",
             "Amount of alive entities.");
 
@@ -159,7 +159,7 @@ namespace Robust.Server.GameObjects
         /// <inheritdoc />
         public override void TickUpdate(float frameTime, bool noPredictions, Histogram? histogram)
         {
-            using (histogram?.WithLabels("EntityNet").NewTimer())
+            using (histogram?.Timer("EntityNet"))
             {
                 while (_queue.Count != 0 && _queue.Peek().SourceTick <= _gameTiming.CurTick)
                 {

--- a/Robust.Server/GameStates/PvsSystem.Ack.cs
+++ b/Robust.Server/GameStates/PvsSystem.Ack.cs
@@ -2,10 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;
-using Prometheus;
 using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Log;
+using Robust.Shared.Observability;
 using Robust.Shared.Player;
 using Robust.Shared.Threading;
 using Robust.Shared.Timing;
@@ -54,7 +54,7 @@ internal sealed partial class PvsSystem
 
         if (!_async)
         {
-            using var _= Histogram.WithLabels("Process Acks").NewTimer();
+            using var _ = Histogram.Timer("Process Acks");
             _parallelManager.ProcessNow(_ackJob, _ackJob.Count);
             return null;
         }

--- a/Robust.Server/GameStates/PvsSystem.Chunks.cs
+++ b/Robust.Server/GameStates/PvsSystem.Chunks.cs
@@ -4,12 +4,12 @@ using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Prometheus;
 using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Map.Enumerators;
 using Robust.Shared.Maths;
+using Robust.Shared.Observability;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
 
@@ -82,7 +82,7 @@ internal sealed partial class PvsSystem
     /// </summary>
     internal void GetVisibleChunks()
     {
-        using var _= Histogram.WithLabels("Get Chunks").NewTimer();
+        using var _= Histogram.Timer("Get Chunks");
 
         DebugTools.Assert(!_chunks.Values.Any(x=> x.UpdateQueued));
         _dirtyChunks.Clear();
@@ -204,7 +204,7 @@ internal sealed partial class PvsSystem
 
     private void ProcessVisibleChunks()
     {
-        using var _= Histogram.WithLabels("Update Chunks & Overrides").NewTimer();
+        using var _= Histogram.Timer("Update Chunks & Overrides");
         var task = _parallelMgr.Process(_chunkJob, _chunkJob.Count);
 
         UpdateCleanChunks();

--- a/Robust.Server/GameStates/PvsSystem.Dirty.cs
+++ b/Robust.Server/GameStates/PvsSystem.Dirty.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using Prometheus;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Observability;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -77,7 +77,7 @@ namespace Robust.Server.GameStates
 
         private void CleanupDirty()
         {
-            using var _ = Histogram.WithLabels("Clean Dirty").NewTimer();
+            using var _ = Histogram.Timer("Clean Dirty");
             if (!CullingEnabled)
             {
                 _seenAllEnts.Clear();

--- a/Robust.Server/GameStates/PvsSystem.Leave.cs
+++ b/Robust.Server/GameStates/PvsSystem.Leave.cs
@@ -2,10 +2,10 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
-using Prometheus;
 using Robust.Shared.Enums;
 using Robust.Shared.Log;
 using Robust.Shared.Network.Messages;
+using Robust.Shared.Observability;
 using Robust.Shared.Player;
 using Robust.Shared.Threading;
 using Robust.Shared.Utility;
@@ -30,7 +30,7 @@ internal sealed partial class PvsSystem
             return;
         }
 
-        using var _ = Histogram.WithLabels("Process Leave").NewTimer();
+        using var _ = Histogram.Timer("Process Leave");
         _parallelMgr.ProcessNow(_leaveJob, _leaveJob.Count);
     }
 

--- a/Robust.Server/GameStates/PvsSystem.Send.cs
+++ b/Robust.Server/GameStates/PvsSystem.Send.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Threading.Tasks;
-using Prometheus;
 using Robust.Shared.Log;
 using Robust.Shared.Network.Messages;
+using Robust.Shared.Observability;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
 
@@ -22,7 +22,7 @@ internal sealed partial class PvsSystem
         // If this does get run async, then ProcessDisconnections() has to ensure that the job has finished before modifying
         // the sessions array
 
-        using var _ = Histogram.WithLabels("Send States").NewTimer();
+        using var _ = Histogram.Timer("Send States");
         var opts = new ParallelOptions {MaxDegreeOfParallelism = _parallelMgr.ParallelProcessCount};
         Parallel.ForEach(_sessions, opts, _threadResourcesPool.Get, SendSessionState, _threadResourcesPool.Return);
     }

--- a/Robust.Server/GameStates/PvsSystem.Serialize.cs
+++ b/Robust.Server/GameStates/PvsSystem.Serialize.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Threading.Tasks;
-using Prometheus;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
+using Robust.Shared.Observability;
 using Robust.Shared.Player;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
@@ -21,7 +21,7 @@ internal sealed partial class PvsSystem
     /// </summary>
     private void SerializeStates()
     {
-        using var _ = Histogram.WithLabels("Serialize States").NewTimer();
+        using var _ = Histogram.Timer("Serialize States");
         var opts = new ParallelOptions {MaxDegreeOfParallelism = _parallelMgr.ParallelProcessCount};
         _oldestAck = GameTick.MaxValue.Value;
         Parallel.For(-1, _sessions.Length, opts, SerializeState);

--- a/Robust.Server/Observability/Prometheus/MetricsManager.Factory.cs
+++ b/Robust.Server/Observability/Prometheus/MetricsManager.Factory.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.Metrics;
 using System.Linq;
 using Robust.Shared.Utility;
 
-namespace Robust.Server.DataMetrics;
+namespace Robust.Server.Observability.Prometheus;
 
 internal sealed partial class MetricsManager : IMeterFactory
 {

--- a/Robust.Server/Observability/Prometheus/MetricsManager.UpdateMetrics.cs
+++ b/Robust.Server/Observability/Prometheus/MetricsManager.UpdateMetrics.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Asynchronous;
 using Robust.Shared.IoC;
 using Robust.Shared.Timing;
 
-namespace Robust.Server.DataMetrics;
+namespace Robust.Server.Observability.Prometheus;
 
 internal sealed partial class MetricsManager
 {

--- a/Robust.Server/Player/PlayerManager.cs
+++ b/Robust.Server/Player/PlayerManager.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
-using Prometheus;
 using Robust.Server.Configuration;
 using Robust.Server.GameObjects;
 using Robust.Shared.Enums;
@@ -13,6 +12,7 @@ using Robust.Shared.Input;
 using Robust.Shared.IoC;
 using Robust.Shared.Network;
 using Robust.Shared.Network.Messages;
+using Robust.Shared.Observability;
 using Robust.Shared.Player;
 using Robust.Shared.Reflection;
 using Robust.Shared.Timing;
@@ -26,7 +26,7 @@ namespace Robust.Server.Player
     internal sealed class PlayerManager : SharedPlayerManager, IPlayerManager
     {
         private static readonly Gauge PlayerCountMetric = Metrics
-            .CreateGauge("robust_player_count", "Number of players on the server.");
+            .Gauge("robust_player_count", "Number of players on the server.");
 
         [Dependency] private readonly IBaseServer _baseServer = default!;
         [Dependency] private readonly IGameTiming _timing = default!;

--- a/Robust.Server/ServerIoC.cs
+++ b/Robust.Server/ServerIoC.cs
@@ -1,9 +1,9 @@
 using System.Diagnostics.Metrics;
 using Robust.Server.Configuration;
 using Robust.Server.Console;
-using Robust.Server.DataMetrics;
 using Robust.Server.GameObjects;
 using Robust.Server.GameStates;
+using Robust.Server.Observability.Prometheus;
 using Robust.Server.Placement;
 using Robust.Server.Player;
 using Robust.Server.Prototypes;
@@ -23,6 +23,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
+using Robust.Shared.Observability;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Reflection;

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using Prometheus;
 using Robust.Shared.Console;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
@@ -13,6 +12,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
 using Robust.Shared.Network;
+using Robust.Shared.Observability;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Player;
 using Robust.Shared.Profiling;
@@ -267,19 +267,19 @@ namespace Robust.Shared.GameObjects
 
         public virtual void TickUpdate(float frameTime, bool noPredictions, Histogram? histogram)
         {
-            using (histogram?.WithLabels("EntitySystems").NewTimer())
+            using (histogram?.Timer("EntitySystems"))
             using (_prof.Group("Systems"))
             {
                 _entitySystemManager.TickUpdate(frameTime, noPredictions);
             }
 
-            using (histogram?.WithLabels("EntityEventBus").NewTimer())
+            using (histogram?.Timer("EntityEventBus"))
             using (_prof.Group("Events"))
             {
                 _eventBus.ProcessEventQueue();
             }
 
-            using (histogram?.WithLabels("QueuedDeletion").NewTimer())
+            using (histogram?.Timer("QueuedDeletion"))
             using (_prof.Group("QueueDel"))
             {
                 while (QueuedDeletions.TryDequeue(out var uid))
@@ -290,7 +290,7 @@ namespace Robust.Shared.GameObjects
                 QueuedDeletionsSet.Clear();
             }
 
-            using (histogram?.WithLabels("ComponentCull").NewTimer())
+            using (histogram?.Timer("ComponentCull"))
             using (_prof.Group("ComponentCull"))
             {
                 CullRemovedComponents();

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -2,9 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
-using Prometheus;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
+using Robust.Shared.Observability;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -8,10 +8,10 @@ using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Lidgren.Network;
-using Prometheus;
 using Robust.Shared.Configuration;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
+using Robust.Shared.Observability;
 using Robust.Shared.Player;
 using Robust.Shared.Profiling;
 using Robust.Shared.Serialization;
@@ -41,39 +41,39 @@ namespace Robust.Shared.Network
     {
         internal const int SharedKeyLength = CryptoAeadXChaCha20Poly1305Ietf.KeyBytes; // 32 bytes
 
-        private static readonly Counter SentPacketsMetrics = Metrics.CreateCounter(
+        private static readonly Counter SentPacketsMetrics = Metrics.Counter(
             "robust_net_sent_packets",
             "Number of packets sent since server startup.");
 
-        private static readonly Counter RecvPacketsMetrics = Metrics.CreateCounter(
+        private static readonly Counter RecvPacketsMetrics = Metrics.Counter(
             "robust_net_recv_packets",
             "Number of packets received since server startup.");
 
-        private static readonly Counter SentMessagesMetrics = Metrics.CreateCounter(
+        private static readonly Counter SentMessagesMetrics = Metrics.Counter(
             "robust_net_sent_messages",
             "Number of messages sent since server startup.");
 
-        private static readonly Counter RecvMessagesMetrics = Metrics.CreateCounter(
+        private static readonly Counter RecvMessagesMetrics = Metrics.Counter(
             "robust_net_recv_messages",
             "Number of messages received since server startup.");
 
-        private static readonly Counter SentBytesMetrics = Metrics.CreateCounter(
+        private static readonly Counter SentBytesMetrics = Metrics.Counter(
             "robust_net_sent_bytes",
             "Number of bytes sent since server startup.");
 
-        private static readonly Counter RecvBytesMetrics = Metrics.CreateCounter(
+        private static readonly Counter RecvBytesMetrics = Metrics.Counter(
             "robust_net_recv_bytes",
             "Number of bytes received since server startup.");
 
-        private static readonly Counter MessagesResentDelayMetrics = Metrics.CreateCounter(
+        private static readonly Counter MessagesResentDelayMetrics = Metrics.Counter(
             "robust_net_resent_delay",
             "Number of messages that had to be re-sent due to delay.");
 
-        private static readonly Counter MessagesResentHoleMetrics = Metrics.CreateCounter(
+        private static readonly Counter MessagesResentHoleMetrics = Metrics.Counter(
             "robust_net_resent_hole",
             "Number of messages that had to be re-sent due to holes.");
 
-        private static readonly Counter MessagesDroppedMetrics = Metrics.CreateCounter(
+        private static readonly Counter MessagesDroppedMetrics = Metrics.Counter(
             "robust_net_dropped",
             "Number of incoming messages that have been dropped.");
 

--- a/Robust.Shared/Observability/Counter.cs
+++ b/Robust.Shared/Observability/Counter.cs
@@ -1,0 +1,30 @@
+using Prometheus;
+using System;
+
+namespace Robust.Shared.Observability;
+
+public abstract record Counter {
+    public void Inc(int value = 1) {
+        switch(this) {
+            case PrometheusCounter counter:
+                counter.Wrapped.Inc(value);
+
+                return;
+            default:
+                throw new NotImplementedException();
+        }
+    }
+
+    public void IncTo(long value) {
+        switch(this) {
+            case PrometheusCounter counter:
+                counter.Wrapped.IncTo(value);
+
+                return;
+            default:
+                throw new NotImplementedException();
+        }
+    }
+}
+
+internal record PrometheusCounter(Prometheus.Counter Wrapped) : Counter;

--- a/Robust.Shared/Observability/Gauge.cs
+++ b/Robust.Shared/Observability/Gauge.cs
@@ -1,0 +1,21 @@
+using Prometheus;
+using System;
+
+namespace Robust.Shared.Observability;
+
+// Wrapper so we can hide Prom dep
+public abstract record Gauge
+{
+    public void Set(double val) {
+        switch(this) {
+            case PrometheusGauge gauge:
+                gauge.Wrapped.Set(val);
+
+                return;
+            default:
+                throw new NotImplementedException();
+        }
+    }
+}
+
+internal record PrometheusGauge(Prometheus.Gauge Wrapped) : Gauge;

--- a/Robust.Shared/Observability/Histogram.cs
+++ b/Robust.Shared/Observability/Histogram.cs
@@ -1,0 +1,41 @@
+using Prometheus;
+using System;
+
+namespace Robust.Shared.Observability;
+
+public abstract record Histogram {
+    public void Observe(double val) {
+        switch(this) {
+            case PrometheusParent histogram:
+                histogram.Wrapped.Observe(val);
+
+                return;
+            case PrometheusChild histogram:
+                histogram.Wrapped.Observe(val);
+
+                return;
+        }
+    }
+
+    public Histogram Child(string name) {
+        return this switch
+        {
+            PrometheusParent histogram => new PrometheusChild(histogram.Wrapped.WithLabels(name)),
+            // TODO: This is sloppy; this should be an error if you do child-of-child that says so.
+            _ => throw new NotImplementedException(),
+        };
+    }
+
+    public Timer Timer(string label = "") {
+        return this switch
+        {
+            PrometheusParent parent => new PrometheusTimer(parent.Wrapped.WithLabels(label).NewTimer()),
+            PrometheusChild child => new PrometheusTimer(child.Wrapped.NewTimer()),
+            _ => throw new NotImplementedException(),
+        };
+    }
+}
+
+internal record PrometheusParent(Prometheus.Histogram Wrapped) : Histogram;
+
+internal record PrometheusChild(Prometheus.Histogram.Child Wrapped) : Histogram;

--- a/Robust.Shared/Observability/Metrics.cs
+++ b/Robust.Shared/Observability/Metrics.cs
@@ -1,0 +1,35 @@
+using System;
+using Prometheus;
+
+namespace Robust.Shared.Observability;
+
+// Stand-in for the Prometheus Metrics class.
+public static class Metrics {
+    public static Gauge Gauge(string name, string help) {
+        return new PrometheusGauge(Prometheus.Metrics.CreateGauge(name, help));
+    }
+
+    public static Histogram Histogram(
+        string name,
+        string help,
+        string? labelName,
+        double bucketsStart,
+        double bucketsFactor,
+        int bucketsCount
+    ) {
+        var conf = new HistogramConfiguration
+        {
+            Buckets = Prometheus.Histogram.ExponentialBuckets(bucketsStart, bucketsFactor, bucketsCount)
+        };
+
+        if (labelName != null) {
+            conf.LabelNames = [labelName];
+        }
+
+        return new PrometheusParent(Prometheus.Metrics.CreateHistogram(name, help, conf));
+    }
+
+    public static Counter Counter(string name, string help) {
+        return new PrometheusCounter(Prometheus.Metrics.CreateCounter(name, help));
+    }
+}

--- a/Robust.Shared/Observability/MetricsManager.cs
+++ b/Robust.Shared/Observability/MetricsManager.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Robust.Shared.Observability;
+
+/// <summary>
+/// Manages metrics exposure.
+/// </summary>
+/// <remarks>
+/// <para>
+/// If enabled via <see cref="CVars.MetricsEnabled"/>, metrics about the game server are exposed via a HTTP server
+/// in an OpenTelemetry-compatible format.
+/// </para>
+/// <para>
+/// Metrics can be added through the types in <c>System.Diagnostics.Metrics</c> or <c>Robust.Shared.Observability</c>.
+/// IoC contains an implementation of <see cref="IMeterFactory"/> that can be used to instantiate meters.
+/// </para>
+/// </remarks>
+public interface IMetricsManager
+{
+    /// <summary>
+    /// An event that gets raised on the main thread when complex metrics should be updated.
+    /// </summary>
+    /// <remarks>
+    /// This event is raised on the main thread before a Prometheus collection happens,
+    /// and also with a fixed interval if <see cref="CVars.MetricsUpdateInterval"/> is set.
+    /// You can use it to update complex metrics that can't "just" be stuffed into a counter.
+    /// </remarks>
+    event Action UpdateMetrics;
+}
+
+internal interface IMetricsManagerInternal : IMetricsManager
+{
+    void Initialize();
+    void FrameUpdate();
+}

--- a/Robust.Shared/Observability/Timer.cs
+++ b/Robust.Shared/Observability/Timer.cs
@@ -1,0 +1,35 @@
+using Prometheus;
+using System;
+
+namespace Robust.Shared.Observability;
+
+/// <summary>
+/// A timer that is used to observe a duration of elapsed time.
+/// </summary>
+public abstract record Timer : IDisposable
+{
+    public void Dispose()
+    {
+        switch(this) {
+            case PrometheusTimer timer:
+                timer.Wrapped.Dispose();
+                // Doing this because the linter told me so :godo:
+                // TODO: Confirm what to do about this w/ C# experts.
+                GC.SuppressFinalize(this);
+
+                return;
+            default:
+                throw new NotImplementedException();
+        }
+    }
+
+    public TimeSpan ObserveDuration() {
+        return this switch
+        {
+            PrometheusTimer timer => timer.Wrapped.ObserveDuration(),
+            _ => throw new NotImplementedException(),
+        };
+    }
+}
+
+internal record PrometheusTimer(ITimer Wrapped) : Timer;

--- a/Robust.Shared/Physics/Controllers/VirtualController.cs
+++ b/Robust.Shared/Physics/Controllers/VirtualController.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
-using Prometheus;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Observability;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
@@ -18,8 +18,8 @@ namespace Robust.Shared.Physics.Controllers
 
         private static readonly Stopwatch Stopwatch = new();
 
-        public Histogram.Child BeforeMonitor = default!;
-        public Histogram.Child AfterMonitor = default!;
+        public Histogram BeforeMonitor = default!;
+        public Histogram AfterMonitor = default!;
 
         #region Boilerplate
 
@@ -27,8 +27,8 @@ namespace Robust.Shared.Physics.Controllers
         {
             base.Initialize();
 
-            BeforeMonitor = SharedPhysicsSystem.TickUsageControllerBeforeSolveHistogram.WithLabels(GetType().Name);
-            AfterMonitor = SharedPhysicsSystem.TickUsageControllerAfterSolveHistogram.WithLabels(GetType().Name);
+            BeforeMonitor = SharedPhysicsSystem.TickUsageControllerBeforeSolveHistogram.Child(GetType().Name);
+            AfterMonitor = SharedPhysicsSystem.TickUsageControllerAfterSolveHistogram.Child(GetType().Name);
 
             var updatesBefore = UpdatesBefore.ToArray();
             var updatesAfter = UpdatesAfter.ToArray();

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
@@ -1,5 +1,4 @@
 using System;
-using Prometheus;
 using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
@@ -7,6 +6,7 @@ using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Observability;
 using Robust.Shared.Physics.Collision;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Controllers;
@@ -28,19 +28,23 @@ namespace Robust.Shared.Physics.Systems
          * Poly cutting
          */
 
-        public static readonly Histogram TickUsageControllerBeforeSolveHistogram = Metrics.CreateHistogram("robust_entity_physics_controller_before_solve",
-            "Amount of time spent running a controller's UpdateBeforeSolve", new HistogramConfiguration
-            {
-                LabelNames = new[] {"controller"},
-                Buckets = Histogram.ExponentialBuckets(0.000_001, 1.5, 25)
-            });
+        public static readonly Histogram TickUsageControllerBeforeSolveHistogram = Metrics.Histogram(
+            "robust_entity_physics_controller_before_solve",
+            "Amount of time spent running a controller's UpdateBeforeSolve",
+            "controller",
+            0.000_001,
+            1.5,
+            25
+        );
 
-        public static readonly Histogram TickUsageControllerAfterSolveHistogram = Metrics.CreateHistogram("robust_entity_physics_controller_after_solve",
-            "Amount of time spent running a controller's UpdateAfterSolve", new HistogramConfiguration
-            {
-                LabelNames = new[] {"controller"},
-                Buckets = Histogram.ExponentialBuckets(0.000_001, 1.5, 25)
-            });
+        public static readonly Histogram TickUsageControllerAfterSolveHistogram = Metrics.Histogram(
+            "robust_entity_physics_controller_after_solve",
+            "Amount of time spent running a controller's UpdateAfterSolve",
+            "controller",
+            0.000_001,
+            1.5,
+            25
+        );
 
         [Dependency] private readonly IManifoldManager _manifoldManager = default!;
         [Dependency] private readonly IMapManager _mapManager = default!;

--- a/Robust.Shared/Serialization/RobustMappedStringSerializer.cs
+++ b/Robust.Shared/Serialization/RobustMappedStringSerializer.cs
@@ -8,12 +8,12 @@ using System.Reflection.Emit;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using NetSerializer;
-using Prometheus;
 using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Network;
 using Robust.Shared.Network.Messages;
+using Robust.Shared.Observability;
 using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Utility;
 using YamlDotNet.RepresentationModel;
@@ -41,15 +41,15 @@ namespace Robust.Shared.Serialization
     /// </remarks>
     internal sealed partial class RobustMappedStringSerializer : IDynamicTypeSerializer, IRobustMappedStringSerializer
     {
-        private static readonly Counter StringsHitMetric = Metrics.CreateCounter(
+        private static readonly Counter StringsHitMetric = Metrics.Counter(
             "robust_net_string_hit",
             "Amount of strings sent that hit the mapped string dictionary.");
 
-        private static readonly Counter StringsMissMetric = Metrics.CreateCounter(
+        private static readonly Counter StringsMissMetric = Metrics.Counter(
             "robust_net_string_miss",
             "Amount of strings sent that missed the mapped string dictionary.");
 
-        private static readonly Counter StringsMissCharsMetric = Metrics.CreateCounter(
+        private static readonly Counter StringsMissCharsMetric = Metrics.Counter(
             "robust_net_string_miss_chars",
             "Amount of extra chars (UTF-16, not bytes!!!) that have to be sent due to mapped string misses.");
 

--- a/Robust.Shared/Timing/GameLoop.cs
+++ b/Robust.Shared/Timing/GameLoop.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.Tracing;
 using System.Threading;
 using Robust.Shared.Log;
 using Robust.Shared.Exceptions;
-using Prometheus;
+using Robust.Shared.Observability;
 using Robust.Shared.Configuration;
 using Robust.Shared.Profiling;
 
@@ -53,13 +53,14 @@ namespace Robust.Shared.Timing
 
         public const string ProfTextStartFrame = "Start Frame";
 
-        private static readonly Histogram _frameTimeHistogram = Metrics.CreateHistogram(
+        private static readonly Histogram _frameTimeHistogram = Metrics.Histogram(
             "robust_game_loop_frametime",
             "Histogram of frametimes in ms",
-            new HistogramConfiguration
-            {
-                Buckets = Histogram.ExponentialBuckets(.001, 1.5, 10)
-            });
+            null,
+            .001,
+            1.5,
+            10
+        );
 
         private readonly IGameTiming _timing;
         private TimeSpan _lastKeepUp; // last wall time keep up announcement
@@ -230,7 +231,7 @@ namespace Robust.Shared.Timing
 
                         if (EnableMetrics)
                         {
-                            using (_frameTimeHistogram.NewTimer())
+                            using (_frameTimeHistogram.Timer())
                             {
                                 Tick?.Invoke(this, simFrameEvent);
                             }


### PR DESCRIPTION
Yup, making an RT PR. 😨 

---

This is a *draft* PR to get some feedback on where the Prom exposure on the project currently is and how to encapsulate it in a new `Robust.Shared.Observability` (and `Robust.Server.Observability` for server-side implementation of the connection to Prom).

The focus here is on removing direct references to Prom from RT except in implementation; this means we don't have to mess with any code outside of the `Observability` namespaces when actually moving onto using the `OpenTelemetry` libraries.

At the moment I've avoided moving the Prometheus implementation of IMetricsManager out of Server, althought that was my first instinct. I've moved its interfaces to Shared, though.

In terms of whacky nonsense:

1. I've gone through and neatened up the Prom API calls. E.g.`TickUsage.WithLabels("GameState").NewTimer()` is now just `TickUsage.Timer("GameState")`.
2. I've _attempted_ to find a tidy way to use records rather than classes for the wrappers for the Prom objects, and use pattern matching to implement polymorphism. I personally prefer approaches like these, but I am anticipating pushback.

Just as a reminder, I'm not a professional C# developer, and I currently don't have a rigged up sandbox to assert these changes haven't bricked the connection to Prom. I've just made sure this code compiles, and don't want to do any further legwork without getting some feedback on structure.

This PR currently would break the SS14 build due to a _single_ reference to metrics on the frontend, used to track the admin count inside AdminManager.