### PR TITLE
Makes ItemList not run deselection callback on all list items

### DIFF
--- a/Robust.Client/UserInterface/Controls/ItemList.cs
+++ b/Robust.Client/UserInterface/Controls/ItemList.cs
@@ -344,9 +344,6 @@ namespace Robust.Client.UserInterface.Controls
                     continue;
 
                 var item = _itemList[i];
-                if (!item.Selected)
-                    continue;
-
                 item.Selected = false;
             }
         }
@@ -744,7 +741,7 @@ namespace Robust.Client.UserInterface.Controls
                 get => _selected;
                 set
                 {
-                    if (!Selectable) return;
+                    if (!Selectable || _selected == value) return;
                     _selected = value;
                     if(_selected) OnSelected?.Invoke(this);
                     else OnDeselected?.Invoke(this);

--- a/Robust.Client/UserInterface/Controls/ItemList.cs
+++ b/Robust.Client/UserInterface/Controls/ItemList.cs
@@ -340,8 +340,11 @@ namespace Robust.Client.UserInterface.Controls
         {
             for (var i = 0; i < _itemList.Count; i++)
             {
+                if (i == except)
+                    continue;
+
                 var item = _itemList[i];
-                if (i == except || !item.Selected)
+                if (!item.Selected)
                     continue;
 
                 item.Selected = false;

--- a/Robust.Client/UserInterface/Controls/ItemList.cs
+++ b/Robust.Client/UserInterface/Controls/ItemList.cs
@@ -340,10 +340,10 @@ namespace Robust.Client.UserInterface.Controls
         {
             for (var i = 0; i < _itemList.Count; i++)
             {
-                if (i == except || !_itemList[i].Selected)
+                var item = _itemList[i];
+                if (i == except || !item.Selected)
                     continue;
 
-                var item = _itemList[i];
                 item.Selected = false;
             }
         }

--- a/Robust.Client/UserInterface/Controls/ItemList.cs
+++ b/Robust.Client/UserInterface/Controls/ItemList.cs
@@ -340,7 +340,7 @@ namespace Robust.Client.UserInterface.Controls
         {
             for (var i = 0; i < _itemList.Count; i++)
             {
-                if (i == except)
+                if (i == except || !_itemList[i].Selected)
                     continue;
 
                 var item = _itemList[i];


### PR DESCRIPTION
even when they weren't selected.
I have no idea if this is the best way to do this.

Fixes a bug introduced [here](https://github.com/space-wizards/RobustToolbox/pull/5796/files#diff-c145b320f707ad74c95d4df3254cdc2703416c65b2bc8ea0a6987bdb9b78cfddL293) by iterating over all list items rather than just selected list items.
![image](https://github.com/user-attachments/assets/65d26bd9-7e27-4496-9356-7ac37bfeee01)
(screenshot of the diff in case the link to a line in a PR doesn't work)