### PR TITLE
Serialize TimeSpan from text

### DIFF
--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/TimespanSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/TimespanSerializer.cs
@@ -89,7 +89,7 @@ public sealed class TimespanSerializer : ITypeSerializer<TimeSpan, ValueDataNode
             return false;
 
         // Check the last character of the input for time unit indicators
-        switch (node.Value.AsSpan()[^1])
+        switch (node.Value[^1])
         {
             case 's':
                 timeSpan = TimeSpan.FromSeconds(number);

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/TimespanSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/TimespanSerializer.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using JetBrains.Annotations;
 using Robust.Shared.IoC;
@@ -22,6 +24,9 @@ public sealed class TimespanSerializer : ITypeSerializer<TimeSpan, ValueDataNode
         ISerializationContext? context = null,
         ISerializationManager.InstantiationDelegate<TimeSpan>? instanceProvider = null)
     {
+        if (TryTimeSpan(node, out var time))
+            return time.Value;
+
         var seconds = double.Parse(node.Value, CultureInfo.InvariantCulture);
         return TimeSpan.FromSeconds(seconds);
     }
@@ -33,6 +38,7 @@ public sealed class TimespanSerializer : ITypeSerializer<TimeSpan, ValueDataNode
         ISerializationContext? context = null)
     {
         return double.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
+               || TryTimeSpan(node, out _)
             ? new ValidatedValueNode(node)
             : new ErrorNode(node, "Failed parsing TimeSpan");
     }
@@ -56,5 +62,43 @@ public sealed class TimespanSerializer : ITypeSerializer<TimeSpan, ValueDataNode
         ISerializationContext? context = null)
     {
         return source;
+    }
+
+    /// <summary>
+    /// Convert strings from the compatible format into TimeSpan and output it. Returns true if successful.
+    /// The string must start with a number and end with a single letter referring to the time unit used.
+    /// It can NOT combine multiple types (like "1h30m"), but it CAN use decimals ("1.5h")
+    /// </summary>
+    private bool TryTimeSpan(ValueDataNode node, [NotNullWhen(true)] out TimeSpan? timeSpan)
+    {
+        timeSpan = null;
+        var units = new List<string>{"h", "m", "s"};
+
+        var input = node.Value.Replace(" ","");
+        var unit = input[^1].ToString();
+        var number = input.Substring(0, input.Length - 1);
+        var valid = false;
+
+        if (units.Contains(unit)
+            && double.TryParse(number, out var d))
+        {
+            switch (unit)
+            {
+                case "s":
+                    timeSpan = TimeSpan.FromSeconds(d);
+                    valid = true;
+                    break;
+                case "m":
+                    timeSpan = TimeSpan.FromMinutes(d);
+                    valid = true;
+                    break;
+                case "h":
+                    timeSpan = TimeSpan.FromHours(d);
+                    valid = true;
+                    break;
+            }
+        }
+
+        return valid;
     }
 }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/TimespanSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/TimespanSerializer.cs
@@ -9,42 +9,52 @@ using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 
-namespace Robust.Shared.Serialization.TypeSerializers.Implementations
+namespace Robust.Shared.Serialization.TypeSerializers.Implementations;
+
+[TypeSerializer]
+public sealed class TimespanSerializer : ITypeSerializer<TimeSpan, ValueDataNode>, ITypeCopyCreator<TimeSpan>
 {
-    [TypeSerializer]
-    public sealed class TimespanSerializer : ITypeSerializer<TimeSpan, ValueDataNode>, ITypeCopyCreator<TimeSpan>
+    public TimeSpan Read(
+        ISerializationManager serializationManager,
+        ValueDataNode node,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context = null,
+        ISerializationManager.InstantiationDelegate<TimeSpan>? instanceProvider = null)
     {
-        public TimeSpan Read(ISerializationManager serializationManager, ValueDataNode node,
-            IDependencyCollection dependencies,
-            SerializationHookContext hookCtx,
-            ISerializationContext? context = null,
-            ISerializationManager.InstantiationDelegate<TimeSpan>? instanceProvider = null)
-        {
-            var seconds = double.Parse(node.Value, CultureInfo.InvariantCulture);
-            return TimeSpan.FromSeconds(seconds);
-        }
+        var seconds = double.Parse(node.Value, CultureInfo.InvariantCulture);
+        return TimeSpan.FromSeconds(seconds);
+    }
 
-        public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
-            IDependencyCollection dependencies,
-            ISerializationContext? context = null)
-        {
-            return double.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
-                ? new ValidatedValueNode(node)
-                : new ErrorNode(node, "Failed parsing TimeSpan");
-        }
+    public ValidationNode Validate(
+        ISerializationManager serializationManager,
+        ValueDataNode node,
+        IDependencyCollection dependencies,
+        ISerializationContext? context = null)
+    {
+        return double.TryParse(node.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out _)
+            ? new ValidatedValueNode(node)
+            : new ErrorNode(node, "Failed parsing TimeSpan");
+    }
 
-        public DataNode Write(ISerializationManager serializationManager, TimeSpan value,
-            IDependencyCollection dependencies, bool alwaysWrite = false,
-            ISerializationContext? context = null)
-        {
-            return new ValueDataNode(value.TotalSeconds.ToString(CultureInfo.InvariantCulture));
-        }
+    public DataNode Write(
+        ISerializationManager serializationManager,
+        TimeSpan value,
+        IDependencyCollection dependencies,
+        bool alwaysWrite = false,
+        ISerializationContext? context = null)
+    {
+        return new ValueDataNode(value.TotalSeconds.ToString(CultureInfo.InvariantCulture));
+    }
 
-        [MustUseReturnValue]
-        public TimeSpan CreateCopy(ISerializationManager serializationManager, TimeSpan source,
-            IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context = null)
-        {
-            return source;
-        }
+    [MustUseReturnValue]
+    public TimeSpan CreateCopy(
+        ISerializationManager serializationManager,
+        TimeSpan source,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context = null)
+    {
+        return source;
     }
 }

--- a/Robust.UnitTesting/Shared/Serialization/TypeSerializers/TimespanSerializerTest.cs
+++ b/Robust.UnitTesting/Shared/Serialization/TypeSerializers/TimespanSerializerTest.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using NUnit.Framework;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Implementations;
+
+namespace Robust.UnitTesting.Shared.Serialization.TypeSerializers;
+
+[TestFixture]
+[TestOf(typeof(TimespanSerializer))]
+internal sealed class TimespanSerializerTest : SerializationTest
+{
+    [Test]
+    public void ReadTest()
+    {
+        var input1 = "21600";
+        var input2 = "21600s";
+        var input3 = "360m";
+        var input4 = "6h";
+
+        var result1 = Serialization.Read<TimeSpan>(Serialization.WriteValueAs<ValueDataNode>(input1));
+        var result2 = Serialization.Read<TimeSpan>(Serialization.WriteValueAs<ValueDataNode>(input2));
+        var result3 = Serialization.Read<TimeSpan>(Serialization.WriteValueAs<ValueDataNode>(input3));
+        var result4 = Serialization.Read<TimeSpan>(Serialization.WriteValueAs<ValueDataNode>(input4));
+
+        var time = TimeSpan.FromHours(6);
+
+        Assert.That(result1, Is.EqualTo(time));
+        Assert.That(result2, Is.EqualTo(time));
+        Assert.That(result3, Is.EqualTo(time));
+        Assert.That(result4, Is.EqualTo(time));
+    }
+
+    [Test]
+    public void DecimalTest()
+    {
+        var input1 = "6.0h";
+        var input2 = "6.0001h";
+
+        var result1 = Serialization.Read<TimeSpan>(Serialization.WriteValueAs<ValueDataNode>(input1));
+        var result2 = Serialization.Read<TimeSpan>(Serialization.WriteValueAs<ValueDataNode>(input2));
+
+        var time = TimeSpan.FromHours(6);
+
+        Assert.That(result1, Is.EqualTo(time));
+        Assert.That(result2, Is.Not.EqualTo(time));
+    }
+}


### PR DESCRIPTION
TimeSpanSerializer can now convert strings from the compatible format
The string must start with a number and end with a single letter referring to the time unit used.
It can NOT combine multiple types (like "1h30m"), but it CAN use decimals ("1.5h").



This makes it possible to use more easily readable values on time-related datafields, most prominently role time requirements. It also continues to be compatible with the existing format of digits only, interpreted as seconds.
![Screenshot_2025-05-04_090614](https://github.com/user-attachments/assets/4115b44a-1421-4558-8976-32138862ce57)


(For optimal reviewing experience, check the two commits separately. The first one is only formatting)

