### PR TITLE
replace IsMap and IsGrid calls with HasComp

### DIFF
--- a/Robust.Server/Physics/GridFixtureSystem.cs
+++ b/Robust.Server/Physics/GridFixtureSystem.cs
@@ -289,7 +289,7 @@ namespace Robust.Server.Physics
                     }
 
                     _maps.SetTiles(newGrid.Owner, newGrid.Comp, tileData);
-                    DebugTools.Assert(_mapManager.IsGrid(newGridUid), "A split grid had no tiles?");
+                    DebugTools.Assert(HasComp<MapGridComponent>(newGridUid), "A split grid had no tiles?");
 
                     // Set tiles on new grid + update anchored entities
                     foreach (var node in group)

--- a/Robust.Shared/ComponentTrees/RecursiveMoveSystem.cs
+++ b/Robust.Shared/ComponentTrees/RecursiveMoveSystem.cs
@@ -1,6 +1,7 @@
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.ComponentTrees;
@@ -52,8 +53,8 @@ internal sealed class RecursiveMoveSystem : EntitySystem
         if (args.Component.MapUid == args.Sender || args.Component.GridUid == args.Sender)
             return;
 
-        DebugTools.Assert(!_mapManager.IsMap(args.Sender));
-        DebugTools.Assert(!_mapManager.IsGrid(args.Sender));
+        DebugTools.Assert(!HasComp<MapComponent>(args.Sender));
+        DebugTools.Assert(!HasComp<MapGridComponent>(args.Sender));
 
         AnythingMovedSubHandler(args.Sender, args.Component);
     }

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.cs
@@ -174,7 +174,7 @@ public sealed partial class EntityLookupSystem : EntitySystem
                 continue;
 
             DebugTools.Assert(childXform.Broadphase.Value.Uid == component.Owner);
-            DebugTools.Assert(!_mapManager.IsGrid(child));
+            DebugTools.Assert(!HasComp<MapGridComponent>(child));
 
             if (childXform.Broadphase.Value.CanCollide && _fixturesQuery.TryGetComponent(child, out var fixtures))
             {
@@ -380,7 +380,7 @@ public sealed partial class EntityLookupSystem : EntitySystem
 
         if (xform.GridUid == uid)
             return;
-        DebugTools.Assert(!_mapManager.IsGrid(uid));
+        DebugTools.Assert(!HasComp<MapGridComponent>(uid));
 
         if (xform.Broadphase is not { Valid: true } old)
             return; // entity is not on any broadphase
@@ -525,7 +525,7 @@ public sealed partial class EntityLookupSystem : EntitySystem
 
     private void OnEntityInit(Entity<MetaDataComponent> uid)
     {
-        if (_container.IsEntityOrParentInContainer(uid, uid) || _mapManager.IsMap(uid) || _mapManager.IsGrid(uid))
+        if (_container.IsEntityOrParentInContainer(uid, uid) || HasComp<MapComponent>(uid) || HasComp<MapGridComponent>(uid))
             return;
 
         // TODO can this just be done implicitly via transform startup?
@@ -541,11 +541,11 @@ public sealed partial class EntityLookupSystem : EntitySystem
                 OnGridChangedMap(args);
             return;
         }
-        DebugTools.Assert(!_mapManager.IsGrid(args.Sender));
+        DebugTools.Assert(!HasComp<MapGridComponent>(args.Sender));
 
         if (args.Component.MapUid == args.Sender)
             return;
-        DebugTools.Assert(!_mapManager.IsMap(args.Sender));
+        DebugTools.Assert(!HasComp<MapComponent>(args.Sender));
 
         if (args.ParentChanged)
             UpdateParent(args.Sender, args.Component);

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -1361,7 +1361,7 @@ public abstract partial class SharedTransformSystem
         }
         else
         {
-            if (!_mapManager.IsMap(uid))
+            if (!HasComp<MapComponent>(uid))
                 Log.Warning($"Failed to attach entity to map or grid. Entity: ({ToPrettyString(uid)}). Trace: {Environment.StackTrace}");
 
             DetachEntity(uid, xform);

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -133,7 +133,7 @@ namespace Robust.Shared.GameObjects
             if (xform.GridUid == xform.ParentUid)
                 return xform.Coordinates;
 
-            DebugTools.Assert(!_mapManager.IsGrid(uid) && !_mapManager.IsMap(uid));
+            DebugTools.Assert(!HasComp<MapGridComponent>(uid) && !HasComp<MapComponent>(uid));
 
             // Not parented to grid so convert their pos back to the grid.
             var worldPos = GetWorldPosition(xform, XformQuery);
@@ -174,7 +174,7 @@ namespace Robust.Shared.GameObjects
             if (mapId == parentUid)
                 return coordinates;
 
-            DebugTools.Assert(!_mapManager.IsGrid(parentUid) && !_mapManager.IsMap(parentUid));
+            DebugTools.Assert(!HasComp<MapGridComponent>(parentUid) && !HasComp<MapComponent>(parentUid));
 
             // Not parented to grid so convert their pos back to the grid.
             var worldPos = Vector2.Transform(coordinates.Position, GetWorldMatrix(parentXform, XformQuery));

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
@@ -30,6 +30,7 @@ using Robust.Shared.Collections;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
@@ -581,13 +582,13 @@ public partial class SharedPhysicsSystem
                 if (_containerSystem.IsEntityOrParentInContainer(uid))
                     return false;
 
-                if (!_fixturesQuery.Resolve(uid, ref manager) || manager.FixtureCount == 0 && !_mapManager.IsGrid(uid))
+                if (!_fixturesQuery.Resolve(uid, ref manager) || manager.FixtureCount == 0 && !HasComp<MapGridComponent>(uid))
                     return false;
             }
             else
             {
                 DebugTools.Assert(!_containerSystem.IsEntityOrParentInContainer(uid));
-                DebugTools.Assert((Resolve(uid, ref manager) && manager.FixtureCount > 0) || _mapManager.IsGrid(uid));
+                DebugTools.Assert((Resolve(uid, ref manager) && manager.FixtureCount > 0) || HasComp<MapGridComponent>(uid));
             }
         }
 


### PR DESCRIPTION
As the title says, replaces all obsolete IsMap and IsGrid calls with their respective HasComp counterparts. I believe this is pretty straight forward and shouldn't break anything.