### PR TITLE
Sharpening shader

### DIFF
--- a/Resources/Shaders/sharpening.swsl
+++ b/Resources/Shaders/sharpening.swsl
@@ -1,0 +1,26 @@
+uniform sampler2D SCREEN_TEXTURE;
+uniform mediump float Sharpness;
+uniform highp vec2 viewportSize;
+
+void fragment()
+{
+    highp vec2 uv = UV;
+    
+    highp vec2 texelSize = vec2(1.0) / viewportSize;
+    
+    highp vec3 center = texture(SCREEN_TEXTURE, uv).rgb;
+    highp vec3 up = texture(SCREEN_TEXTURE, uv + vec2(0.0, texelSize.y)).rgb;
+    highp vec3 down = texture(SCREEN_TEXTURE, uv - vec2(0.0, texelSize.y)).rgb;
+    highp vec3 left = texture(SCREEN_TEXTURE, uv - vec2(texelSize.x, 0.0)).rgb;
+    highp vec3 right = texture(SCREEN_TEXTURE, uv + vec2(texelSize.x, 0.0)).rgb;
+    
+    highp vec3 blur = (up + down + left + right) * 0.25;
+    highp vec3 edge = center - blur;
+    
+    highp float edgeStrength = length(edge) * 2.0;
+    highp float adaptiveSharp = Sharpness * (1.0 - smoothstep(0.1, 0.5, edgeStrength));
+    
+    highp vec3 sharpened = center + edge * adaptiveSharp * 1.5;
+    
+    COLOR = vec4(clamp(sharpened, 0.0, 1.0), 1.0);
+}

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -584,6 +584,37 @@ namespace Robust.Client.Graphics.Clyde
 
                 _currentViewport = oldVp;
             }, viewport.ClearColor);
+
+            if (Sharpness > 0)
+            {
+                using (_prof.Group("PostProcessing"))
+                {
+                    RenderInRenderTarget(viewport.PostProcessRenderTarget, () =>
+                    {
+                        _renderHandle.Clear(default, 0, ClearBufferMask.ColorBufferBit);
+
+                        _renderHandle.UseShader(_sharpeningShaderInstance);
+                        _sharpeningShaderInstance.SetParameter("viewportSize", viewport.Size);
+                        _sharpeningShaderInstance.SetParameter("Sharpness", Sharpness);
+                        _sharpeningShaderInstance.SetParameter("SCREEN_TEXTURE", viewport.RenderTarget.Texture);
+                        
+                        _renderHandle.DrawingHandleScreen.DrawTextureRect(
+                            viewport.RenderTarget.Texture,
+                            UIBox2.FromDimensions(Vector2.Zero, viewport.Size),
+                            Color.White
+                        );
+                    });
+
+                    RenderInRenderTarget(viewport.RenderTarget, () =>
+                    {
+                        _renderHandle.DrawingHandleScreen.DrawTextureRect(
+                            viewport.PostProcessRenderTarget.Texture,
+                            UIBox2.FromDimensions(Vector2.Zero, viewport.Size),
+                            Color.White
+                        );
+                    });
+                }
+            }
         }
 
         private static Box2 GetAABB(IEye eye, Viewport viewport)

--- a/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
@@ -19,6 +19,7 @@ namespace Robust.Client.Graphics.Clyde
     {
         [ViewVariables]
         private ClydeShaderInstance _defaultShader = default!;
+        private ClydeShaderInstance _sharpeningShaderInstance = default!;
 
         private string _shaderLibrary = default!;
 
@@ -163,6 +164,11 @@ namespace Robust.Client.Graphics.Clyde
             _defaultShader = (ClydeShaderInstance) InstanceShader(defaultLoadedShader);
 
             _queuedShaderInstance = _defaultShader;
+
+            var sharpeningLoadedShader = _resourceCache
+                .GetResource<ShaderSourceResource>("/Shaders/sharpening.swsl");
+
+            _sharpeningShaderInstance = (ClydeShaderInstance) InstanceShader(sharpeningLoadedShader);
         }
 
         private string ReadEmbeddedShader(string fileName)

--- a/Robust.Client/Graphics/Clyde/Clyde.Viewport.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Viewport.cs
@@ -31,6 +31,12 @@ namespace Robust.Client.Graphics.Clyde
 
             _viewports.Add(handle, new WeakReference<Viewport>(viewport));
 
+            viewport.PostProcessRenderTarget = CreateRenderTarget(size,
+                new RenderTargetFormatParameters(RenderTargetColorFormat.Rgba8Srgb, true),
+                sampleParameters: new TextureSampleParameters {Filter = false},
+                name: $"{name}-PostProcess"
+            );
+
             return viewport;
         }
 
@@ -103,6 +109,8 @@ namespace Robust.Client.Graphics.Clyde
             // We need two of them because efficient blur works in two stages and also we're doing multiple iterations.
             public RenderTexture WallBleedIntermediateRenderTarget1 = default!;
             public RenderTexture WallBleedIntermediateRenderTarget2 = default!;
+
+            public RenderTexture PostProcessRenderTarget = default!;
 
             public string? Name { get; }
 

--- a/Robust.Client/Graphics/Clyde/Clyde.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.cs
@@ -90,6 +90,8 @@ namespace Robust.Client.Graphics.Clyde
         private bool _earlyGLInit;
         private bool _threadWindowApi;
 
+        private float Sharpness;
+
         public Clyde()
         {
             _currentBoundRenderTarget = default!;
@@ -122,6 +124,7 @@ namespace Robust.Client.Graphics.Clyde
             _cfg.OnValueChanged(CVars.MaxLightCount, MaxLightsChanged, true);
             _cfg.OnValueChanged(CVars.MaxOccluderCount, MaxOccludersChanged, true);
             _cfg.OnValueChanged(CVars.RenderTileEdges, RenderTileEdgesChanges, true);
+            _cfg.OnValueChanged(CVars.DisplaySharpening, OnSharpnessChanged, true);
             // I can't be bothered to tear down and set these threads up in a cvar change handler.
 
             // Windows and Linux can be trusted to not explode with threaded windowing,
@@ -131,6 +134,7 @@ namespace Robust.Client.Graphics.Clyde
 
             _threadWindowBlit = _cfg.GetCVar(CVars.DisplayThreadWindowBlit);
             _threadWindowApi = _cfg.GetCVar(CVars.DisplayThreadWindowApi);
+            Sharpness = _cfg.GetCVar(CVars.DisplaySharpening) / 10f;
 
             InitKeys();
 
@@ -601,6 +605,11 @@ namespace Robust.Client.Graphics.Clyde
         private bool IsMainThread()
         {
             return Thread.CurrentThread == _gameThread;
+        }
+
+        private void OnSharpnessChanged(int value)
+        {
+            Sharpness = value / 10f;
         }
     }
 }

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1008,6 +1008,12 @@ namespace Robust.Shared
             CVarDef.Create("display.windowmode", 0, CVar.ARCHIVE | CVar.CLIENTONLY);
 
         /// <summary>
+        /// Sharpening render effect.
+        /// </summary>
+        public static readonly CVarDef<int> DisplaySharpening = 
+            CVarDef.Create("display.sharpening", 0, CVar.ARCHIVE | CVar.CLIENTONLY);
+
+        /// <summary>
         /// Initial width of the game window when running on windowed mode.
         /// </summary>
         public static readonly CVarDef<int> DisplayWidth =


### PR DESCRIPTION
Adds a sharpness shader based on the `Adaptive Unsharp Masking` algorithm. 
It was previously implemented via an overlay in [(36481)](https://github.com/space-wizards/space-station-14/pull/36481) PR, but now it has been directly transferred to `Viewport` render. Now that PR just adds a slider in the graphics settings to set the sharpness value.

It wasn't easy for me to figure out the rendering, so if I did something wrong or you have any advice, feedback is welcome.