### PR TITLE
Fix CA2264 in Resource Manager

### DIFF
--- a/Robust.Shared/ContentPack/ResourceManager.cs
+++ b/Robust.Shared/ContentPack/ResourceManager.cs
@@ -273,8 +273,6 @@ namespace Robust.Shared.ContentPack
 
         public IEnumerable<string> ContentGetDirectoryEntries(ResPath path)
         {
-            ArgumentNullException.ThrowIfNull(path, nameof(path));
-
             if (!path.IsRooted)
                 throw new ArgumentException("Path is not rooted", nameof(path));
 


### PR DESCRIPTION
Fixes CA2264 warning in the `ResourceManager.cs` by removing the line `ArgumentNullException.ThrowIfNull(path, nameof(path));`

[CA2264: Do not pass a non-nullable value to 'ArgumentNullException.ThrowIfNull'](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2264)

[https://github.com/space-wizards/space-station-14/issues/33279](https://github.com/space-wizards/space-station-14/issues/33279)