### PR TITLE
PredictedDeleteEntity fixes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -46,6 +46,7 @@ END TEMPLATE-->
 ### Bugfixes
 
 * Fix `EntityDeserializer` improperly setting entity lifestages when loading a post-mapinit map.
+* Fix `EntityManager.PredictedDeleteEntity()` not deleting pure client-side entities.
 
 ### Other
 
@@ -81,8 +82,8 @@ END TEMPLATE-->
   * The MappingDataNode class has various helper methods that still accept a ValueDataNode, but these methods are marked as obsolete and may be removed in the future.
   * yaml validators should use `MappingDataNode.GetKeyNode()` when validating mapping keys, so that errors can print node start & end information
 * ValueTuple yaml serialization has changed
-  * Previously they would get serialized into a single mapping with one entry (i.e., `{foo : bar }` 
-  * Now they serialize into a sequence (i.e., `[foo, bar]`
+  * Previously they would get serialized into a single mapping with one entry (i.e., `{foo : bar }`)
+  * Now they serialize into a sequence (i.e., `[foo, bar]`)
   * The ValueTuple serializer will still try to read mappings, but due to the MappingDataNode this may fail if the previously serialized "key" can't be read as a simple string
 
 ### New features

--- a/Robust.Client/GameObjects/ClientEntityManager.Spawn.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.Spawn.cs
@@ -118,9 +118,6 @@ public sealed partial class ClientEntityManager
         DebugTools.Assert(IsClientSide(ent.Owner, ent.Comp));
         EnsureComponent<PredictedSpawnComponent>(ent.Owner);
 
-        // Server has no knowledge of the entity we are so we generate a clientside nentity and send it to server.
-        DebugTools.Assert(ent.Comp.NetEntity.IsClientSide());
-
         // TODO: Need to map call site or something, needs to be consistent between client and server.
     }
 }

--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -306,6 +306,7 @@ namespace Robust.Client.GameObjects
             // 1. Networked entity we just move to nullspace and rely on state handling.
             // 2. Clientside predicted entity we delete and rely on state handling.
             // 3. Clientside only entity that actually needs deleting here.
+
             if (ent.Comp1.NetEntity.IsClientSide())
             {
                 DeleteEntity(ent, ent.Comp1, ent.Comp2);
@@ -331,6 +332,7 @@ namespace Robust.Client.GameObjects
             {
                 // client-side QueueDeleteEntity re-fetches MetadataComp and checks IsClientSide().
                 // base call to skip that.
+                // TODO create override that takes in metadata comp
                 base.QueueDeleteEntity(ent);
             }
             else

--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -295,17 +295,20 @@ namespace Robust.Client.GameObjects
         /// <inheritdoc />
         public override void PredictedDeleteEntity(Entity<MetaDataComponent?, TransformComponent?> ent)
         {
-            if (Deleted(ent.Owner) || !TransformQuery.Resolve(ent.Owner, ref ent.Comp2))
+            if (!MetaQuery.Resolve(ent.Owner, ref ent.Comp1)
+                || ent.Comp1.EntityDeleted
+                || !TransformQuery.Resolve(ent.Owner, ref ent.Comp2))
+            {
                 return;
+            }
 
             // So there's 3 scenarios:
             // 1. Networked entity we just move to nullspace and rely on state handling.
             // 2. Clientside predicted entity we delete and rely on state handling.
             // 3. Clientside only entity that actually needs deleting here.
-
-            if (HasComponent<PredictedSpawnComponent>(ent.Owner))
+            if (ent.Comp1.NetEntity.IsClientSide())
             {
-                DeleteEntity(ent);
+                DeleteEntity(ent, ent.Comp1, ent.Comp2);
             }
             else
             {
@@ -316,12 +319,19 @@ namespace Robust.Client.GameObjects
         /// <inheritdoc />
         public override void PredictedQueueDeleteEntity(Entity<MetaDataComponent?, TransformComponent?> ent)
         {
-            if (IsQueuedForDeletion(ent.Owner) || !TransformQuery.Resolve(ent.Owner, ref ent.Comp2))
-                return;
-
-            if (HasComponent<PredictedSpawnComponent>(ent.Owner))
+            if (IsQueuedForDeletion(ent.Owner)
+                || !MetaQuery.Resolve(ent.Owner, ref ent.Comp1)
+                || ent.Comp1.EntityDeleted
+                || !TransformQuery.Resolve(ent.Owner, ref ent.Comp2))
             {
-                QueueDeleteEntity(ent);
+                return;
+            }
+
+            if (ent.Comp1.NetEntity.IsClientSide())
+            {
+                // client-side QueueDeleteEntity re-fetches MetadataComp and checks IsClientSide().
+                // base call to skip that.
+                base.QueueDeleteEntity(ent);
             }
             else
             {


### PR DESCRIPTION
Based on the "3 scenarios" comment in `PredictedDeleteEntity` I assume theres currently a bug and the method should delete "pure" client-side entities instead of moving them into nullspace. So this replaces a `HasComponent<PredictedSpawnComponent>(ent.Owner)` with a `IsClientSide()` check in `PredictedDeleteEntity`. Also removes some unnecessary metadata comp fetching. 