### PR TITLE
Add cycle detection when setting MIDI renderer masters

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,4 @@
-﻿# Release notes for RobustToolbox.
+# Release notes for RobustToolbox.
 
 <!--
 NOTE: automatically updated sometimes by version.py.
@@ -50,7 +50,7 @@ END TEMPLATE-->
 
 ### Other
 
-*None yet*
+* Add logic to block cycles in master MIDI renderers, which could otherwise cause client freezes.
 
 ### Internal
 

--- a/Robust.Client/Audio/Midi/MidiRenderer.cs
+++ b/Robust.Client/Audio/Midi/MidiRenderer.cs
@@ -226,6 +226,9 @@ internal sealed class MidiRenderer : IMidiRenderer
             if (value == _master)
                 return;
 
+            if (CheckMasterCycle(value))
+                throw new InvalidOperationException("Tried to set master to a child of this renderer!");
+
             if (_master is { Disposed: false })
             {
                 try
@@ -728,5 +731,23 @@ internal sealed class MidiRenderer : IMidiRenderer
 
         _synth?.Dispose();
         _player?.Dispose();
+    }
+
+    /// <summary>
+    /// Check that a given renderer is not already a child of this renderer, i.e. it would introduce a cycle if set as master of this renderer.
+    /// </summary>
+    private bool CheckMasterCycle(IMidiRenderer? otherRenderer)
+    {
+        // Doesn't inside drift, cringe.
+
+        while (otherRenderer != null)
+        {
+            if (otherRenderer == this)
+                return true;
+
+            otherRenderer = otherRenderer.Master;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
If these things ever get in a cycle (as they did in some SS14 replays), it'll likely get the client stuck in an infinite loop. Avoid that.