### PR TITLE
Adjustment to data clearance when beginning a hijacked placement

### DIFF
--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -357,6 +357,12 @@ namespace Robust.Client.Placement
 
         public void Clear()
         {
+            ClearWithoutDeactivation();
+            IsActive = false;
+        }
+
+        private void ClearWithoutDeactivation()
+        {
             PlacementChanged?.Invoke(this, EventArgs.Empty);
             Hijack = null;
             EnsureNoPlacementOverlayEntity();
@@ -365,7 +371,6 @@ namespace Robust.Client.Placement
             CurrentMode = null;
             DeactivateSpecialPlacement();
             _placenextframe = false;
-            IsActive = false;
             Eraser = false;
             EraserRect = null;
             PlacementOffset = Vector2i.Zero;
@@ -480,7 +485,7 @@ namespace Robust.Client.Placement
 
         public void BeginHijackedPlacing(PlacementInformation info, PlacementHijack? hijack = null)
         {
-            Clear();
+            ClearWithoutDeactivation();
 
             CurrentPermission = info;
 


### PR DESCRIPTION
When beginning a hijacked placement (i.e., when starting to place a construction ghost), PlacementManager.IsActive is set to false. This, in turn, changes the input context used from 'editor' to the entity-specific input context, resulting in a small pause in registering the keys that are currently held by the player

Content PR [36124](https://github.com/space-wizards/space-station-14/pull/36124) introduces a way to dynamically change  hijacked placers based on the position of the cursor with respect to the tile it is currently hovering over; this is to allow players to easily place atmos pipes on different layers (see https://github.com/space-wizards/space-station-14/pull/36124#issuecomment-2812107465 for a demonstration)

However, if the player attempts to move while placing a pipe, this movement will inevitably cause the hijacked placer to update, changing the input context and interrupting movement. This means the player is effectively locked in place while attempting to place construction ghosts for pipes

This PR changes how stale placer data is cleared when beginning a new placement hijack, so that IsActive is not set to false unless actually required