### PR TITLE
Fix warnings in PhysicsMap_Test

### DIFF
--- a/Robust.UnitTesting/Shared/Physics/PhysicsMap_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/PhysicsMap_Test.cs
@@ -23,16 +23,17 @@ public sealed class PhysicsMap_Test
     {
         var sim = RobustServerSimulation.NewSimulation().InitializeInstance();
         var entManager = sim.Resolve<IEntityManager>();
-        var mapManager = sim.Resolve<IMapManager>();
         var system = entManager.EntitySysManager;
         var physSystem = system.GetEntitySystem<SharedPhysicsSystem>();
         var fixtureSystem = system.GetEntitySystem<FixtureSystem>();
         var xformSystem = system.GetEntitySystem<SharedTransformSystem>();
 
-        var mapId = sim.CreateMap().MapId;
-        var mapId2 = sim.CreateMap().MapId;
-        var mapUid = mapManager.GetMapEntityId(mapId);
-        var mapUid2 = mapManager.GetMapEntityId(mapId2);
+        var map = sim.CreateMap();
+        var map2 = sim.CreateMap();
+        var mapId = map.MapId;
+        var mapId2 = map2.MapId;
+        var mapUid = map.Uid;
+        var mapUid2 = map2.Uid;
 
         var physicsMap = entManager.GetComponent<PhysicsMapComponent>(mapUid);
         var physicsMap2 = entManager.GetComponent<PhysicsMapComponent>(mapUid2);


### PR DESCRIPTION
Fixes 2 warnings in `PhysicsMap_Test.cs`

**2x 'IMapManager.GetMapEntityId(MapId)' is obsolete: 'Use MapSystem' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
`ISimulation.CreateMap` returns a tuple containing both the MapId and the map's EntityUid, so there's actually no need to call `IMapManager.GetMapEntityId` - we can just use the value from the tuple.

https://github.com/space-wizards/space-station-14/issues/33279