### PR TITLE
Fix warnings in Joints_Test

### DIFF
--- a/Robust.UnitTesting/Shared/Physics/Joints_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Joints_Test.cs
@@ -71,7 +71,9 @@ public sealed class Joints_Test
         var physicsSystem = server.Resolve<IEntitySystemManager>().GetEntitySystem<SharedPhysicsSystem>();
         var mapSystem = entManager.System<SharedMapSystem>();
 
-        var mapId = server.CreateMap().MapId;
+        var map = server.CreateMap();
+        var mapId = map.MapId;
+        var physicsMapComp = entManager.GetComponent<PhysicsMapComponent>(map.Uid);
 
         var ent1 = entManager.SpawnEntity(null, new MapCoordinates(Vector2.Zero, mapId));
         var ent2 = entManager.SpawnEntity(null, new MapCoordinates(Vector2.Zero, mapId));
@@ -93,7 +95,7 @@ public sealed class Joints_Test
         Assert.That(entManager.HasComponent<JointComponent>(ent1), Is.EqualTo(true));
 
         // We should have a contact in both situations.
-        broadphaseSystem.FindNewContacts(mapId);
+        broadphaseSystem.FindNewContacts(physicsMapComp, mapId);
         Assert.That(body1.Contacts, Has.Count.EqualTo(1));
 
         // Alright now try the other way
@@ -103,7 +105,7 @@ public sealed class Joints_Test
         jointSystem.Update(0.016f);
         Assert.That(entManager.HasComponent<JointComponent>(ent1));
 
-        broadphaseSystem.FindNewContacts(mapId);
+        broadphaseSystem.FindNewContacts(physicsMapComp, mapId);
         Assert.That(body1.Contacts, Has.Count.EqualTo(1));
 
         mapSystem.DeleteMap(mapId);


### PR DESCRIPTION
Fixes 2 warnings in `Joints_Test`.

**2x 'SharedBroadphaseSystem.FindNewContacts(MapId)' is obsolete: 'Use the overload with SharedPhysicsMapComponent' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Replaced with the suggested overload. Used the map's EntityUid from `ISimulation.CreateMap` to get the `PhysicsMapComponent`.

https://github.com/space-wizards/space-station-14/issues/33279