### PR TITLE
Fix grid fixtures using locale dependent ids

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -47,6 +47,7 @@ END TEMPLATE-->
 
 * Fix `EntityDeserializer` improperly setting entity lifestages when loading a post-mapinit map.
 * Fix `EntityManager.PredictedDeleteEntity()` not deleting pure client-side entities.
+* Fix grid fixtures using a locale dependent id. This could case some clients to crash/freeze when connected to a server with a different locale.
 
 ### Other
 

--- a/Robust.Shared/GameObjects/Systems/SharedGridFixtureSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridFixtureSystem.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using Robust.Shared.Collections;
 using Robust.Shared.Configuration;
 using Robust.Shared.IoC;
-using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Map.Events;
@@ -16,7 +16,6 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Serialization;
-using Robust.Shared.Utility;
 
 namespace Robust.Shared.GameObjects
 {
@@ -150,7 +149,8 @@ namespace Robust.Shared.GameObjects
                 };
 #pragma warning restore CS0618
 
-                newFixtures.Add(($"grid_chunk-{bounds.Left}-{bounds.Bottom}", newFixture));
+                var key = string.Create(CultureInfo.InvariantCulture, $"grid_chunk-{bounds.Left}-{bounds.Bottom}");
+                newFixtures.Add((key, newFixture));
             }
 
             // Check if we even need to issue an eventbus event


### PR DESCRIPTION
Use `InvariantCulture` instead of the current culture.
Fixes https://github.com/space-wizards/space-station-14/issues/34395