### PR TITLE
Sandbox whitelist for calendar stuff.

### DIFF
--- a/Robust.Shared/ContentPack/Sandbox.yml
+++ b/Robust.Shared/ContentPack/Sandbox.yml
@@ -497,6 +497,23 @@ Types:
     DebuggerVisualizerAttribute: { All: True }
     Stopwatch: { All: True }
   System.Globalization:
+  # all the calendars are here, screw making our own.
+    Calendar: { All: True }
+    ChineseLunisolarCalendar: { All: True }
+    GregorianCalendar: { All: True }
+    HebrewCalendar: { All: True }
+    HijriCalendar: { All: True }
+    JapaneseCalendar: { All: True }
+    JapaneseLunisolarCalendar:  { All: True }
+    JulianCalendar: { All: True }
+    KoreanCalendar: { All: True }
+    KoreanLunisolarCalendar: { All: True }
+    PersianCalendar: { All: True }
+    TaiwanCalendar: { All: True }
+    TaiwanLunisolarCalendar: { All: True }
+    ThaiBuddhistCalendar: { All: True }
+    UmAlQuraCalendar: { All: True }
+ #end calendars
     CompareOptions: { }
     CultureInfo: { All: True }
     DateTimeStyles: { All: True } # Enum
@@ -1071,6 +1088,7 @@ Types:
     DateTime: { All: True }
     DateTimeKind: { } # Enum
     DateTimeOffset: { All: True }
+    DayOfWeek: { } # Enum
     Decimal: { All: True }
     Delegate:
       Methods:


### PR DESCRIPTION
Adds calendars from System.Globalization into the sandbox whitelist because theres no reason to make our own.

Adds System.DayOfWeek for similar reasons.

https://github.com/space-wizards/space-station-14/pull/36865 related