### PR TITLE
Remove assert in UserInterfaceManager.KeyBindDown

### DIFF
--- a/Robust.Client/UserInterface/UserInterfaceManager.Input.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Input.cs
@@ -103,7 +103,6 @@ internal partial class UserInterfaceManager
             return;
         }
 
-
         var guiArgs = new GUIBoundKeyEventArgs(args.Function, args.State, args.PointerLocation, args.CanFocus,
             args.PointerLocation.Position / control.UIScale - control.GlobalPosition,
             args.PointerLocation.Position - control.GlobalPixelPosition);
@@ -115,10 +114,6 @@ internal partial class UserInterfaceManager
             args.Handle();
         }
 
-        // Attempt to ensure that keybind-up events get raised after a keybind-down.
-        DebugTools.Assert(!_focusedControls.TryGetValue(args.Function, out var existing)
-                          || !existing.VisibleInTree
-                          || args.IsRepeat && existing == control);
         _focusedControls[args.Function] = control;
 
         OnKeyBindDown?.Invoke(control);


### PR DESCRIPTION
The assert was just poorly thought out and pretty consistently fails, so this just removes it. Fixes #5099

The original rationale for the assert was that any control that receives a key-down event should be able to assume that it will eventually receive a corresponding key-up event. The assert was implicitly trying to check that this happens by preventing the control value stored in `_focusedControls` from being overridden. 

But that's just not how the UI/key stuff currently works, and maybe was never how it was meant to work and I just made an incorrect assumption. The assert is easily triggered by holding down a repeatable key (e.g., backspace) and moving the mouse to focus on another control.