### PR TITLE
Cleanup warnings: CS0162

### DIFF
--- a/Robust.Shared/ProfileOptSetup.cs
+++ b/Robust.Shared/ProfileOptSetup.cs
@@ -9,15 +9,13 @@ namespace Robust.Shared
         public static void Setup(IConfigurationManager cfg)
         {
             // Disabled on non-release since I don't want this to start creating files in Steam's bin directory.
-#if RELEASE
-            return;
-#endif
-
+#if !RELEASE
             if (!cfg.GetCVar(CVars.SysProfileOpt))
                 return;
 
             ProfileOptimization.SetProfileRoot(PathHelpers.GetExecutableDirectory());
             ProfileOptimization.StartProfile("profile_opt");
+#endif
         }
     }
 }


### PR DESCRIPTION
A small, simple fix that removes the `CS0162` warning.

[CS0162](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0162): Unreachable code detected.

[https://github.com/space-wizards/space-station-14/issues/33279](https://github.com/space-wizards/space-station-14/issues/33279)