### PR TITLE
Cleanup warnings: CS0649

### DIFF
--- a/Robust.Client/Graphics/Clyde/Windowing/Glfw.Cursors.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Glfw.Cursors.cs
@@ -87,11 +87,13 @@ namespace Robust.Client.Graphics.Clyde
                 if (cmd.Cursor != default)
                     ptr = _winThreadCursors[cmd.Cursor].Ptr;
 
+#if DEBUG
                 if (_win32Experience)
                 {
                     // Based on a true story.
                     Thread.Sleep(15);
                 }
+#endif
 
                 GLFW.SetCursor(window, ptr);
             }

--- a/Robust.Client/Graphics/Clyde/Windowing/Glfw.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Glfw.cs
@@ -23,7 +23,9 @@ namespace Robust.Client.Graphics.Clyde
             private readonly ISawmill _sawmillGlfw;
 
             private bool _glfwInitialized;
-            private bool _win32Experience = false;
+#pragma warning disable CS0649
+            private bool _win32Experience;
+#pragma warning restore CS0649
 
             public GlfwWindowingImpl(Clyde clyde, IDependencyCollection deps)
             {

--- a/Robust.Client/Graphics/Clyde/Windowing/Glfw.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Glfw.cs
@@ -23,7 +23,7 @@ namespace Robust.Client.Graphics.Clyde
             private readonly ISawmill _sawmillGlfw;
 
             private bool _glfwInitialized;
-            private bool _win32Experience;
+            private bool _win32Experience = false;
 
             public GlfwWindowingImpl(Clyde clyde, IDependencyCollection deps)
             {

--- a/Robust.Client/Graphics/Clyde/Windowing/Glfw.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Glfw.cs
@@ -23,9 +23,9 @@ namespace Robust.Client.Graphics.Clyde
             private readonly ISawmill _sawmillGlfw;
 
             private bool _glfwInitialized;
-#pragma warning disable CS0649
+#if DEBUG
             private bool _win32Experience;
-#pragma warning restore CS0649
+#endif
 
             public GlfwWindowingImpl(Clyde clyde, IDependencyCollection deps)
             {

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
@@ -625,6 +625,11 @@ public abstract partial class SharedPhysicsSystem
     {
         public IEntityManager EntManager;
 
+        public UpdateTreesJob()
+        {
+            EntManager = default!;
+        }
+
         public void Execute()
         {
             var query = EntManager.AllEntityQueryEnumerator<BroadphaseComponent>();

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
@@ -621,29 +621,6 @@ public abstract partial class SharedPhysicsSystem
         ArrayPool<Vector2>.Shared.Return(worldPoints);
     }
 
-    private record struct UpdateTreesJob : IRobustJob
-    {
-        public IEntityManager EntManager;
-
-        public UpdateTreesJob()
-        {
-            EntManager = default!;
-        }
-
-        public void Execute()
-        {
-            var query = EntManager.AllEntityQueryEnumerator<BroadphaseComponent>();
-
-            while (query.MoveNext(out var broadphase))
-            {
-                broadphase.DynamicTree.Rebuild(false);
-                broadphase.StaticTree.Rebuild(false);
-                broadphase.SundriesTree._b2Tree.Rebuild(false);
-                broadphase.StaticSundriesTree._b2Tree.Rebuild(false);
-            }
-        }
-    }
-
     private void BuildManifolds(Contact[] contacts, int count, ContactStatus[] status, Vector2[] worldPoints)
     {
         if (count == 0)


### PR DESCRIPTION
Remove 2x `CS0649` warnings

[CS0649](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0649): Field 'field' is never assigned to, and will always have its default value 'value'.

[https://github.com/space-wizards/space-station-14/issues/33279](https://github.com/space-wizards/space-station-14/issues/33279)