### PR TITLE
Add GridUidChangedEvent and MapUidChangedEvent

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -40,6 +40,7 @@ END TEMPLATE-->
 ### New features
 
 * The client localisation manager now supports hot-reloading ftl files. 
+* TransformSystem can now raise `GridUidChangedEvent` and `MapUidChangedEvent` when a entity's grid or map changes. This event is only raised if the `ExtraTransformEvents` metadata flag is enabled.
 
 ### Bugfixes
 

--- a/Robust.Server/GameObjects/EntitySystems/PointLightSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/PointLightSystem.cs
@@ -15,7 +15,7 @@ public sealed class PointLightSystem : SharedPointLightSystem
         SubscribeLocalEvent<PointLightComponent, ComponentGetState>(OnLightGetState);
         SubscribeLocalEvent<PointLightComponent, ComponentStartup>(OnLightStartup);
         SubscribeLocalEvent<PointLightComponent, ComponentShutdown>(OnLightShutdown);
-        SubscribeLocalEvent<PointLightComponent, MetaFlagRemoveAttemptEvent>(OnFlagRemove);
+        SubscribeLocalEvent<PointLightComponent, MetaFlagRemoveAttemptEvent>(OnFlagRemoveAttempt);
     }
 
     private void OnLightShutdown(Entity<PointLightComponent> ent, ref ComponentShutdown args)
@@ -23,7 +23,7 @@ public sealed class PointLightSystem : SharedPointLightSystem
         UpdatePriority(ent.Owner, ent.Comp, MetaData(ent.Owner));
     }
 
-    private void OnFlagRemove(Entity<PointLightComponent> ent, ref MetaFlagRemoveAttemptEvent args)
+    private void OnFlagRemoveAttempt(Entity<PointLightComponent> ent, ref MetaFlagRemoveAttemptEvent args)
     {
         if (IsHighPriority(ent.Comp))
             args.ToRemove &= ~MetaDataFlags.PvsPriority;

--- a/Robust.Server/GameObjects/EntitySystems/PointLightSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/PointLightSystem.cs
@@ -14,6 +14,19 @@ public sealed class PointLightSystem : SharedPointLightSystem
         base.Initialize();
         SubscribeLocalEvent<PointLightComponent, ComponentGetState>(OnLightGetState);
         SubscribeLocalEvent<PointLightComponent, ComponentStartup>(OnLightStartup);
+        SubscribeLocalEvent<PointLightComponent, ComponentShutdown>(OnLightShutdown);
+        SubscribeLocalEvent<PointLightComponent, MetaFlagRemoveAttemptEvent>(OnFlagRemove);
+    }
+
+    private void OnLightShutdown(Entity<PointLightComponent> ent, ref ComponentShutdown args)
+    {
+        UpdatePriority(ent.Owner, ent.Comp, MetaData(ent.Owner));
+    }
+
+    private void OnFlagRemove(Entity<PointLightComponent> ent, ref MetaFlagRemoveAttemptEvent args)
+    {
+        if (IsHighPriority(ent.Comp))
+            args.ToRemove &= ~MetaDataFlags.PvsPriority;
     }
 
     private void OnLightStartup(EntityUid uid, PointLightComponent component, ComponentStartup args)
@@ -21,10 +34,14 @@ public sealed class PointLightSystem : SharedPointLightSystem
         UpdatePriority(uid, component, MetaData(uid));
     }
 
+    private bool IsHighPriority(SharedPointLightComponent comp)
+    {
+        return comp is {Enabled: true, CastShadows: true, Radius: > 7, LifeStage: <= ComponentLifeStage.Running};
+    }
+
     protected override void UpdatePriority(EntityUid uid, SharedPointLightComponent comp, MetaDataComponent meta)
     {
-        var isHighPriority = comp.Enabled && comp.CastShadows && (comp.Radius > 7);
-        _metadata.SetFlag((uid, meta), MetaDataFlags.PvsPriority, isHighPriority);
+        _metadata.SetFlag((uid, meta), MetaDataFlags.PvsPriority, IsHighPriority(comp));
     }
 
     private void OnLightGetState(EntityUid uid, PointLightComponent component, ref ComponentGetState args)

--- a/Robust.Server/GameObjects/EntitySystems/ServerOccluderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/ServerOccluderSystem.cs
@@ -12,10 +12,10 @@ public sealed class ServerOccluderSystem : OccluderSystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<OccluderComponent, MetaFlagRemoveAttemptEvent>(OnFlagRemove);
+        SubscribeLocalEvent<OccluderComponent, MetaFlagRemoveAttemptEvent>(OnFlagRemoveAttempt);
     }
 
-    private void OnFlagRemove(Entity<OccluderComponent> ent, ref MetaFlagRemoveAttemptEvent args)
+    private void OnFlagRemoveAttempt(Entity<OccluderComponent> ent, ref MetaFlagRemoveAttemptEvent args)
     {
         if (ent.Comp is {Enabled: true, LifeStage: <= ComponentLifeStage.Running})
             args.ToRemove &= ~MetaDataFlags.PvsPriority;

--- a/Robust.Server/GameObjects/EntitySystems/ServerOccluderSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/ServerOccluderSystem.cs
@@ -9,10 +9,28 @@ public sealed class ServerOccluderSystem : OccluderSystem
 {
     [Dependency] private readonly MetaDataSystem _metadata = default!;
 
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<OccluderComponent, MetaFlagRemoveAttemptEvent>(OnFlagRemove);
+    }
+
+    private void OnFlagRemove(Entity<OccluderComponent> ent, ref MetaFlagRemoveAttemptEvent args)
+    {
+        if (ent.Comp is {Enabled: true, LifeStage: <= ComponentLifeStage.Running})
+            args.ToRemove &= ~MetaDataFlags.PvsPriority;
+    }
+
     protected override void OnCompStartup(EntityUid uid, OccluderComponent component, ComponentStartup args)
     {
         base.OnCompStartup(uid, component, args);
         _metadata.SetFlag(uid, MetaDataFlags.PvsPriority, component.Enabled);
+    }
+
+    protected override void OnCompRemoved(EntityUid uid, OccluderComponent component, ComponentRemove args)
+    {
+        base.OnCompRemoved(uid, component, args);
+        _metadata.SetFlag(uid, MetaDataFlags.PvsPriority, false);
     }
 
     public override void SetEnabled(EntityUid uid, bool enabled, OccluderComponent? comp = null, MetaDataComponent? meta = null)

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -240,7 +240,7 @@ namespace Robust.Shared.GameObjects
         PvsPriority = 1 << 4,
 
         /// <summary>
-        /// If set, transform system will raise events directed at this entity whenever its GridUid or MapUid are modified.
+        /// If set, transform system will raise events directed at this entity whenever the GridUid or MapUid are modified.
         /// </summary>
         ExtraTransformEvents = 1 << 5,
     }

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -238,6 +238,11 @@ namespace Robust.Shared.GameObjects
         /// a grid or map.
         /// </summary>
         PvsPriority = 1 << 4,
+
+        /// <summary>
+        /// If set, transform system will raise events directed at this entity whenever its GridUid or MapUid are modified.
+        /// </summary>
+        ExtraTransformEvents = 1 << 5,
     }
 
     /// <summary>

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -402,32 +402,6 @@ namespace Robust.Shared.GameObjects
             _entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().AttachToGridOrMap(Owner, this);
         }
 
-        internal void UpdateChildMapIdsRecursive(
-            MapId newMapId,
-            EntityUid? newUid,
-            bool mapPaused,
-            EntityQuery<TransformComponent> xformQuery,
-            EntityQuery<MetaDataComponent> metaQuery,
-            MetaDataSystem system)
-        {
-            foreach (var child in _children)
-            {
-                //Set Paused state
-                var metaData = metaQuery.GetComponent(child);
-                system.SetEntityPaused(child, mapPaused, metaData);
-
-                var concrete = xformQuery.GetComponent(child);
-
-                concrete.MapUid = newUid;
-                concrete.MapID = newMapId;
-
-                if (concrete.ChildCount != 0)
-                {
-                    concrete.UpdateChildMapIdsRecursive(newMapId, newUid, mapPaused, xformQuery, metaQuery, system);
-                }
-            }
-        }
-
         [Obsolete("Use TransformSystem.SetParent() instead")]
         public void AttachParent(EntityUid parent)
         {

--- a/Robust.Shared/GameObjects/EntitySystemMessages/GridUidChangedEvent.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/GridUidChangedEvent.cs
@@ -6,7 +6,8 @@ namespace Robust.Shared.GameObjects;
 /// </summary>
 /// <remarks>
 /// Event handlers should not modify positions or delete the entity, because the move event that triggered this event
-/// is still being processed. This may also mean that positional entity queries are not currently reliable.
+/// is still being processed. This may also mean that the entity's current position/parent has not yet been updated,
+/// positional entity queries are not reliable.
 /// </remarks>
 [ByRefEvent]
 public readonly struct GridUidChangedEvent(Entity<TransformComponent, MetaDataComponent> ent, EntityUid? old)

--- a/Robust.Shared/GameObjects/EntitySystemMessages/GridUidChangedEvent.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/GridUidChangedEvent.cs
@@ -7,7 +7,7 @@ namespace Robust.Shared.GameObjects;
 /// <remarks>
 /// Event handlers should not modify positions or delete the entity, because the move event that triggered this event
 /// is still being processed. This may also mean that the entity's current position/parent has not yet been updated,
-/// positional entity queries are not reliable.
+/// and that positional entity queries are not reliable.
 /// </remarks>
 [ByRefEvent]
 public readonly struct GridUidChangedEvent(Entity<TransformComponent, MetaDataComponent> ent, EntityUid? old)

--- a/Robust.Shared/GameObjects/EntitySystemMessages/GridUidChangedEvent.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/GridUidChangedEvent.cs
@@ -1,0 +1,21 @@
+namespace Robust.Shared.GameObjects;
+
+/// <summary>
+/// Raised directed at an entity when <see cref="TransformComponent.GridUid"/> is modified.
+/// This event is only raised if the entity has the <see cref="MetaDataFlags.ExtraTransformEvents"/> flag set.
+/// </summary>
+/// <remarks>
+/// Event handlers should not modify positions or delete the entity, because the move event that triggered this event
+/// is still being processed. This may also mean that positional entity queries are not currently reliable.
+/// </remarks>
+[ByRefEvent]
+public readonly struct GridUidChangedEvent(Entity<TransformComponent, MetaDataComponent> ent, EntityUid? old)
+{
+    public readonly Entity<TransformComponent, MetaDataComponent> Entity = ent;
+    public readonly EntityUid? OldGrid = old;
+
+    public EntityUid? NewGrid => Entity.Comp1.GridUid;
+    public EntityUid Uid => Entity.Owner;
+    public TransformComponent Transform => Entity.Comp1;
+    public MetaDataComponent Meta => Entity.Comp2;
+}

--- a/Robust.Shared/GameObjects/EntitySystemMessages/GridUidChangedEvent.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/GridUidChangedEvent.cs
@@ -10,11 +10,10 @@ namespace Robust.Shared.GameObjects;
 /// and that positional entity queries are not reliable.
 /// </remarks>
 [ByRefEvent]
-public readonly struct GridUidChangedEvent(Entity<TransformComponent, MetaDataComponent> ent, EntityUid? old)
+public readonly record struct GridUidChangedEvent(
+    Entity<TransformComponent, MetaDataComponent> Entity,
+    EntityUid? OldGrid)
 {
-    public readonly Entity<TransformComponent, MetaDataComponent> Entity = ent;
-    public readonly EntityUid? OldGrid = old;
-
     public EntityUid? NewGrid => Entity.Comp1.GridUid;
     public EntityUid Uid => Entity.Owner;
     public TransformComponent Transform => Entity.Comp1;

--- a/Robust.Shared/GameObjects/EntitySystemMessages/MapUidChangedEvent.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/MapUidChangedEvent.cs
@@ -12,12 +12,11 @@ namespace Robust.Shared.GameObjects;
 /// and that positional entity queries are not reliable.
 /// </remarks>
 [ByRefEvent]
-public readonly struct MapUidChangedEvent(Entity<TransformComponent, MetaDataComponent> entity, EntityUid? oldUid, MapId oldMapId)
+public readonly record struct MapUidChangedEvent(
+    Entity<TransformComponent, MetaDataComponent> Entity,
+    EntityUid? OldMap,
+    MapId OldMapId)
 {
-    public readonly Entity<TransformComponent, MetaDataComponent> Entity = entity;
-    public readonly EntityUid? OldMap = oldUid;
-    public readonly MapId? OldMapId = oldMapId;
-
     public EntityUid? NewMap => Entity.Comp1.MapUid;
     public MapId? NewMapId => Entity.Comp1.MapID;
     public EntityUid Uid => Entity.Owner;

--- a/Robust.Shared/GameObjects/EntitySystemMessages/MapUidChangedEvent.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/MapUidChangedEvent.cs
@@ -8,7 +8,8 @@ namespace Robust.Shared.GameObjects;
 /// </summary>
 /// <remarks>
 /// Event handlers should not modify positions or delete the entity, because the move event that triggered this event
-/// is still being processed. This may also mean that positional entity queries are not currently reliable.
+/// is still being processed. This may also mean that the entity's current position/parent has not yet been updated,
+/// positional entity queries are not reliable.
 /// </remarks>
 [ByRefEvent]
 public readonly struct MapUidChangedEvent(Entity<TransformComponent, MetaDataComponent> entity, EntityUid? newUid, MapId newMapId)

--- a/Robust.Shared/GameObjects/EntitySystemMessages/MapUidChangedEvent.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/MapUidChangedEvent.cs
@@ -1,0 +1,25 @@
+using Robust.Shared.Map;
+
+namespace Robust.Shared.GameObjects;
+
+/// <summary>
+/// Raised directed at an entity when <see cref="TransformComponent.MapUid"/> is modified.
+/// This event is only raised if the entity has the <see cref="MetaDataFlags.ExtraTransformEvents"/> flag set.
+/// </summary>
+/// <remarks>
+/// Event handlers should not modify positions or delete the entity, because the move event that triggered this event
+/// is still being processed. This may also mean that positional entity queries are not currently reliable.
+/// </remarks>
+[ByRefEvent]
+public readonly struct MapUidChangedEvent(Entity<TransformComponent, MetaDataComponent> entity, EntityUid? newUid, MapId newMapId)
+{
+    public readonly Entity<TransformComponent, MetaDataComponent> Entity = entity;
+    public readonly EntityUid? OldMap;
+    public readonly MapId? OldMapId;
+
+    public EntityUid? NewMap => Entity.Comp1.MapUid;
+    public MapId? NewMapId => Entity.Comp1.MapID;
+    public EntityUid Uid => Entity.Owner;
+    public TransformComponent Transform => Entity.Comp1;
+    public MetaDataComponent Meta => Entity.Comp2;
+}

--- a/Robust.Shared/GameObjects/EntitySystemMessages/MapUidChangedEvent.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/MapUidChangedEvent.cs
@@ -9,7 +9,7 @@ namespace Robust.Shared.GameObjects;
 /// <remarks>
 /// Event handlers should not modify positions or delete the entity, because the move event that triggered this event
 /// is still being processed. This may also mean that the entity's current position/parent has not yet been updated,
-/// positional entity queries are not reliable.
+/// and that positional entity queries are not reliable.
 /// </remarks>
 [ByRefEvent]
 public readonly struct MapUidChangedEvent(Entity<TransformComponent, MetaDataComponent> entity, EntityUid? newUid, MapId newMapId)

--- a/Robust.Shared/GameObjects/EntitySystemMessages/MapUidChangedEvent.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/MapUidChangedEvent.cs
@@ -12,11 +12,11 @@ namespace Robust.Shared.GameObjects;
 /// and that positional entity queries are not reliable.
 /// </remarks>
 [ByRefEvent]
-public readonly struct MapUidChangedEvent(Entity<TransformComponent, MetaDataComponent> entity, EntityUid? newUid, MapId newMapId)
+public readonly struct MapUidChangedEvent(Entity<TransformComponent, MetaDataComponent> entity, EntityUid? oldUid, MapId oldMapId)
 {
     public readonly Entity<TransformComponent, MetaDataComponent> Entity = entity;
-    public readonly EntityUid? OldMap;
-    public readonly MapId? OldMapId;
+    public readonly EntityUid? OldMap = oldUid;
+    public readonly MapId? OldMapId = oldMapId;
 
     public EntityUid? NewMap => Entity.Comp1.MapUid;
     public MapId? NewMapId => Entity.Comp1.MapID;

--- a/Robust.Shared/GameObjects/Systems/MetaDataSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/MetaDataSystem.cs
@@ -159,6 +159,8 @@ public abstract class MetaDataSystem : EntitySystem
         if (toRemove == 0x0)
             return;
 
+        // TODO PERF
+        // does this need to be a broadcast event?
         var ev = new MetaFlagRemoveAttemptEvent(toRemove);
         RaiseLocalEvent(uid, ref ev, true);
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -48,7 +48,7 @@ public abstract partial class SharedTransformSystem
         xform._localRotation += rotation;
 
         var meta = MetaData(uid);
-        SetGridId(new(uid, xform, meta), newGridUid);
+        SetGridId((uid, xform, meta), newGridUid);
         RaiseMoveEvent((uid, xform, meta), oldGridUid, oldPos, oldRot, oldMap);
 
         DebugTools.Assert(XformQuery.GetComponent(oldGridUid).MapID == XformQuery.GetComponent(newGridUid).MapID);
@@ -396,7 +396,7 @@ public abstract partial class SharedTransformSystem
 
         foreach (var child in ent.Comp1._children)
         {
-            SetGridId(new(child, XformQuery.GetComponent(child), null), gridId);
+            SetGridId((child, XformQuery.GetComponent(child), null), gridId);
         }
     }
 
@@ -1561,7 +1561,7 @@ public abstract partial class SharedTransformSystem
         var meta = MetaData(uid);
         if (meta.EntityLifeStage > EntityLifeStage.Initialized)
         {
-            SetGridId(new(uid, component, meta), uid);
+            SetGridId((uid, component, meta), uid);
             return;
         }
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -678,7 +678,7 @@ public abstract partial class SharedTransformSystem
 
 #if DEBUG
             // Lets check content didn't do anything silly with the event.
-            DebugTools.AssertEqual(ent.Comp1.GridUid, newMap);
+            DebugTools.AssertEqual(ent.Comp1.MapUid, newMap);
             DebugTools.AssertEqual(ent.Comp1.MapID, newMapId);
             DebugTools.AssertEqual(ent.Comp1.ChildCount, childCount);
             DebugTools.AssertEqual(ent.Comp1.ParentUid, oldParent);

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -380,7 +380,7 @@ public abstract partial class SharedTransformSystem
             var oldParent = ent.Comp1.ParentUid;
 #endif
 
-            var ev = new GridUidChangedEvent(ent!, ent.Comp1._gridUid);
+            var ev = new GridUidChangedEvent((ent.Owner, ent.Comp1, ent.Comp2), ent.Comp1._gridUid);
             ent.Comp1._gridUid = gridId;
             RaiseLocalEvent(ent, ref ev);
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -354,15 +354,16 @@ public abstract partial class SharedTransformSystem
 
     #region GridId
 
+    /// <inheritdoc cref="SetGridId(Entity{TransformComponent,MetaDataComponent},EntityUid?)"/>
+    public void SetGridId(EntityUid uid, TransformComponent xform, EntityUid? gridId, EntityQuery<TransformComponent>? xformQuery = null)
+    {
+        SetGridId((uid, xform, MetaData(uid)), gridId);
+    }
+
     /// <summary>
     /// Sets <see cref="TransformComponent.GridUid"/> for the entity and any children. Note that this does not dirty
     /// the component, as this is implicitly networked via the transform hierarchy.
     /// </summary>
-    public void SetGridId(EntityUid uid, TransformComponent xform, EntityUid? gridId, EntityQuery<TransformComponent>? xformQuery = null)
-    {
-        SetGridId((uid,  xform, MetaData(uid)), gridId);
-    }
-
     public void SetGridId(Entity<TransformComponent, MetaDataComponent?> ent, EntityUid? gridId)
     {
         if (!ent.Comp1._gridInitialized || ent.Comp1._gridUid == gridId || ent.Comp1.GridUid == ent.Owner)


### PR DESCRIPTION
Makes transform system optionally raise events when setting the grid or map uid. IIRC we are currently not doing this to help improve performance when entities change maps/grids, seeing as it has to recursively iterate through all children to update these fields. 

This tries to mitigate that by only raising the event if a a new metadata flag is set. I.e., each entity has to opt-in to enable these events. This shouldn't noticeably impact map change perf, seeing as the metadata component already has to be fetched. But it will somewhat slow down griduid changes, as it does now also fetch the metadata comp of children. However, it's still going to be faster than just globally enabling the event. And having an event makes it much easier for content to implement some functionality that is dependent on the current grid (e.g., see [this discussion](https://discord.com/channels/310555209753690112/900426319433728030/1365494889797914624))

This PR also fixes an issue where occluders & lights weren't properly clearing & setting the `PvsPriority` metadata flag.