### PR TITLE
add EntGridChangedEvent 

### DIFF
--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -238,6 +238,11 @@ namespace Robust.Shared.GameObjects
         /// a grid or map.
         /// </summary>
         PvsPriority = 1 << 4,
+
+        /// <summary>
+        /// Whether we should raise the <see cref="EntGridChangedEvent"/> whenever this entity changes grids.
+        /// </summary>
+        GridTracking = 1 << 5,
     }
 
     /// <summary>

--- a/Robust.Shared/GameObjects/EntitySystemMessages/EntGridChangedEvent.cs
+++ b/Robust.Shared/GameObjects/EntitySystemMessages/EntGridChangedEvent.cs
@@ -1,0 +1,33 @@
+namespace Robust.Shared.GameObjects;
+
+/// <summary>
+/// Raised when an entity's grid changes.
+/// </summary>
+[ByRefEvent]
+public readonly record struct EntGridChangedEvent(
+    EntityUid Entity,
+    EntityUid? OldGrid,
+    EntityUid? NewGrid,
+    TransformComponent Transform)
+{
+    /// <summary>
+    /// Entity whose grid has changed. The transform component has a property with the new grid.
+    /// </summary>
+    public readonly EntityUid Entity = Entity;
+
+    /// <summary>
+    /// Old grid that the entity was on.
+    /// </summary>
+    public readonly EntityUid? OldGrid = OldGrid;
+
+    /// <summary>
+    /// New grid that the entity is now on.
+    /// </summary>
+    public readonly EntityUid? NewGrid = NewGrid;
+
+    /// <summary>
+    /// The <see cref="TransformComponent" /> of <see cref="Entity" />.
+    /// </summary>
+    public readonly TransformComponent Transform = Transform;
+}
+


### PR DESCRIPTION
Adds the EntGridChangedEvent that is raised whenever an entity changes grids, if they have the GridTracking flag. This is because EntParentChangedMessage doesn't work inside containers and out of all solutions, this seemed like the least sketchy one.

~~I'm not entirely sure on adding a separate flag for it since we could maybe reuse InContainer? Realistically you only need this when an entity isn't parented to the grid, so for stuff like inventory and storage, because you can use EntParentChanged for everything else. But maybe that changes in the future?~~

merge with https://github.com/space-wizards/space-station-14/pull/36972

B/C 
changed the signature of `SetGridId` from `(EntityUid uid, TransformComponent xform, EntityUid? gridId, EntityQuery<TransformComponent>? xformQuery = null)` to `(EntityUid uid, TransformComponent xform, MetaDataComponent meta, EntityUid? gridId)`
i'll write release notes later if no one else does, want a vibe check first