### PR TITLE
Fix CompileRobustXamlTask for benchmarks

### DIFF
--- a/MSBuild/XamlIL.targets
+++ b/MSBuild/XamlIL.targets
@@ -71,6 +71,6 @@
     </PropertyGroup>
     <Exec
       Condition="'$(_RobustUseExternalMSBuild)' == 'true'"
-      Command="&quot;$(DOTNET_HOST_PATH)&quot; msbuild /nodereuse:false $(MSBuildProjectFile) /t:CompileRobustXaml /p:_RobustForceInternalMSBuild=true /p:Configuration=$(Configuration) /p:RuntimeIdentifier=$(RuntimeIdentifier) /p:TargetFramework=$(TargetFramework) /p:BuildProjectReferences=false /p:IntermediateOutputPath=&quot;$(IntermediateOutputPath)&quot;"/>
+      Command="&quot;$(DOTNET_HOST_PATH)&quot; msbuild /nodereuse:false $(MSBuildProjectFile) /t:CompileRobustXaml /p:_RobustForceInternalMSBuild=true /p:Configuration=$(Configuration) /p:RuntimeIdentifier=$(RuntimeIdentifier) /p:TargetFramework=$(TargetFramework) /p:BuildProjectReferences=false /p:IntermediateOutputPath=&quot;$(IntermediateOutputPath.TrimEnd('\'))/&quot;"/>
   </Target>
 </Project>

--- a/MSBuild/XamlIL.targets
+++ b/MSBuild/XamlIL.targets
@@ -71,6 +71,6 @@
     </PropertyGroup>
     <Exec
       Condition="'$(_RobustUseExternalMSBuild)' == 'true'"
-      Command="&quot;$(DOTNET_HOST_PATH)&quot; msbuild /nodereuse:false $(MSBuildProjectFile) /t:CompileRobustXaml /p:_RobustForceInternalMSBuild=true /p:Configuration=$(Configuration) /p:RuntimeIdentifier=$(RuntimeIdentifier) /p:TargetFramework=$(TargetFramework) /p:BuildProjectReferences=false"/>
+      Command="&quot;$(DOTNET_HOST_PATH)&quot; msbuild /nodereuse:false $(MSBuildProjectFile) /t:CompileRobustXaml /p:_RobustForceInternalMSBuild=true /p:Configuration=$(Configuration) /p:RuntimeIdentifier=$(RuntimeIdentifier) /p:TargetFramework=$(TargetFramework) /p:BuildProjectReferences=false /p:IntermediateOutputPath=&quot;$(IntermediateOutputPath)&quot;"/>
   </Target>
 </Project>


### PR DESCRIPTION
It seems like increasing the BenchmarkDotNet version in #5590 broke xaml generation for our benchmarks due to the changes in the [build toolchain](https://github.com/dotnet/BenchmarkDotNet/releases/tag/v0.14.0) (so much time wasted trying to undertand how xaml hotreloading could've caused this only to realize its probably unrelated).

After a fruitless attempt to understand how xaml & the build process work, I think I figured out how to fix this, but I'm not at all sure if its the right fix, or if its somehow going to cause problems elsewhere.

AFAICT the issue boils down to the fact that the command/exec task will cause the `CompileRobustXamlTask` task to run with the default location & assembly. So `@(IntermediateAssembly)` would always point to `RobustToolbox\Robust.Client\obj\Release\Robust.Client.dll`. With these changes, it will point to the actual dll that the benchmark is trying to use (e.g. `space-station-14\bin\Content.Benchmarks\1cd01747-e703-4505-ab68-5fe253e1d8f9\obj\Release\net9.0/Robust.Client.dll`)