### PR TITLE
fix yaml hotreloading

### DIFF
--- a/Robust.Client/Utility/ReloadManager.cs
+++ b/Robust.Client/Utility/ReloadManager.cs
@@ -25,6 +25,7 @@ internal sealed class ReloadManager : IReloadManager
     private readonly TimeSpan _reloadDelay = TimeSpan.FromMilliseconds(10);
     private CancellationTokenSource _reloadToken = new();
     private readonly HashSet<ResPath> _reloadQueue = new();
+    private List<FileSystemWatcher> _watchers = new(); // this list is never used but needed to prevent them from being garbage collected
 
     public event Action<ResPath>? OnChanged;
 
@@ -93,6 +94,7 @@ internal sealed class ReloadManager : IReloadManager
                 NotifyFilter = NotifyFilters.LastWrite
             };
 
+            _watchers.Add(watcher); // prevent garbage collection
 
             watcher.Changed += OnWatch;
 


### PR DESCRIPTION
Basically reverts only the code cleanup changes done to the `ReloadManager` in https://github.com/space-wizards/RobustToolbox/pull/5874
They were removed because the IDE is telling you the `_watchers` list is never used. Turns out it was load bearing. I assume it prevents the watchers from being garbage collected.

There is probably a prettier way to do this, but this just returns it to the original state and adds a code comment to prevent it from happening again.