### PR TITLE
AnimationTrackProperty.KeyFrames to public

### DIFF
--- a/Robust.Client/Animations/AnimationTrackProperty.cs
+++ b/Robust.Client/Animations/AnimationTrackProperty.cs
@@ -13,7 +13,7 @@ namespace Robust.Client.Animations
     /// </summary>
     public abstract class AnimationTrackProperty : AnimationTrack
     {
-        public List<KeyFrame> KeyFrames { get; protected set; } = new();
+        public List<KeyFrame> KeyFrames { get; set; } = new();
 
         /// <summary>
         ///     How to interpolate values when between two keyframes.


### PR DESCRIPTION
I removed the protected property from the set property for the KeyFrames list.

This allows you to create methods to auto-generate and calculate entire animations as a list of keyframes and then feed that list directly into a new animation instead of having to handcraft each individual keyframe.

Allows for "real time" animation creation (you still have to create methods that make the lists but you can alter how many keyframes there are and such in real time).