### PR TITLE
Combine TileChangedEvents in SetTiles

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
@@ -412,8 +412,11 @@ namespace Robust.Client.Graphics.Clyde
         private void _updateTileMapOnUpdate(ref TileChangedEvent args)
         {
             var gridData = _mapChunkData.GetOrNew(args.Entity);
-            if (gridData.TryGetValue(args.ChunkIndex, out var data))
-                data.Dirty = true;
+            foreach (var change in args.Changes)
+            {
+                if (gridData.TryGetValue(change.ChunkIndex, out var data))
+                    data.Dirty = true;
+            }
         }
 
         private void _updateOnGridCreated(GridStartupEvent ev)

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -362,9 +362,9 @@ namespace Robust.Client.Placement
             foreach (var change in args.Changes)
             {
                 var coords = Maps.GridTileToLocal(
-                change.NewTile.GridUid,
+                args.Entity,
                 args.Entity.Comp,
-                change.NewTile.GridIndices);
+                change.GridIndices);
 
                 _pendingTileChanges.RemoveAll(c => c.Item1 == coords);
             }

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -363,7 +363,7 @@ namespace Robust.Client.Placement
             {
                 var coords = Maps.GridTileToLocal(
                 change.NewTile.GridUid,
-                EntityManager.GetComponent<MapGridComponent>(change.NewTile.GridUid),
+                args.Entity.Comp,
                 change.NewTile.GridIndices);
 
                 _pendingTileChanges.RemoveAll(c => c.Item1 == coords);

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -359,12 +359,15 @@ namespace Robust.Client.Placement
 
         private void HandleTileChanged(ref TileChangedEvent args)
         {
-            var coords = Maps.GridTileToLocal(
-                args.NewTile.GridUid,
-                EntityManager.GetComponent<MapGridComponent>(args.NewTile.GridUid),
-                args.NewTile.GridIndices);
+            foreach (var change in args.Changes)
+            {
+                var coords = Maps.GridTileToLocal(
+                change.NewTile.GridUid,
+                EntityManager.GetComponent<MapGridComponent>(change.NewTile.GridUid),
+                change.NewTile.GridIndices);
 
-            _pendingTileChanges.RemoveAll(c => c.Item1 == coords);
+                _pendingTileChanges.RemoveAll(c => c.Item1 == coords);
+            }
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -868,8 +868,7 @@ public abstract partial class SharedMapSystem
             if (SetChunkTile(uid, grid, chunk, (ushort)offset.X, (ushort)offset.Y, tile, out var oldTile))
             {
                 modified.Add(chunk);
-                var newTile = new TileRef(uid, gridIndices, tile);
-                tileChanges.Add(new TileChangedEntry(newTile, oldTile, offset));
+                tileChanges.Add(new TileChangedEntry(tile, oldTile, offset, gridIndices));
             }
         }
 

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -878,14 +878,14 @@ public abstract partial class SharedMapSystem
             chunk.SuppressCollisionRegeneration = false;
         }
 
+        RegenerateCollision(uid, grid, modified);
+
         // Notify of all tile changes in one event
         var ev = new TileChangedEvent((uid, grid), tileChanges.ToArray());
         RaiseLocalEvent(uid, ref ev, true);
 
         // Back to normal
         MapManager.SuppressOnTileChanged = false;
-
-        RegenerateCollision(uid, grid, modified);
     }
 
     public TilesEnumerator GetLocalTilesEnumerator(EntityUid uid, MapGridComponent grid, Box2 aabb,

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -843,7 +843,7 @@ public abstract partial class SharedMapSystem
             return;
 
         var modified = new HashSet<MapChunk>(Math.Max(1, tiles.Count / grid.ChunkSize));
-        var tileChanges = new ValueList<TileChangedEntry>();
+        var tileChanges = new ValueList<TileChangedEntry>(tiles.Count);
 
         // Suppress sending out events for each tile changed
         // We're going to send them all out together at the end

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.GridChunk.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.GridChunk.cs
@@ -14,9 +14,9 @@ public abstract partial class SharedMapSystem
     /// <param name="xIndex">The X tile index relative to the chunk.</param>
     /// <param name="yIndex">The Y tile index relative to the chunk.</param>
     /// <param name="tile">The new tile to insert.</param>
-    internal bool SetChunkTile(EntityUid uid, MapGridComponent grid, MapChunk chunk, ushort xIndex, ushort yIndex, Tile tile)
+    internal bool SetChunkTile(EntityUid uid, MapGridComponent grid, MapChunk chunk, ushort xIndex, ushort yIndex, Tile tile, out Tile oldTile)
     {
-        if (!chunk.TrySetTile(xIndex, yIndex, tile, out var oldTile, out var shapeChanged))
+        if (!chunk.TrySetTile(xIndex, yIndex, tile, out oldTile, out var shapeChanged))
             return false;
 
         var tileIndices = new Vector2i(xIndex, yIndex);

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
@@ -178,13 +178,22 @@ namespace Robust.Shared.GameObjects
     [ByRefEvent]
     public readonly record struct TileChangedEvent
     {
+        /// <inheritdoc cref="TileChangedEvent(Entity{MapGridComponent}, Tile, Tile, Vector2i, Vector2i)"/>
+        public TileChangedEvent(Entity<MapGridComponent> entity, TileRef newTile, Tile oldTile, Vector2i chunkIndex)
+            : this(entity, newTile.Tile, oldTile, chunkIndex, newTile.GridIndices) { }
+
         /// <summary>
         /// Creates a new instance of this event for a single changed tile.
         /// </summary>
-        public TileChangedEvent(Entity<MapGridComponent> entity, TileRef newTile, Tile oldTile, Vector2i chunkIndex)
+        /// <param name="entity">The grid entity containing the changed tile(s)</param>
+        /// <param name="newTile">New tile that replaced the old one.</param>
+        /// <param name="oldTile">Old tile that was replaced.</param>
+        /// <param name="chunkIndex">The index of the grid-chunk that this tile belongs to.</param>
+        /// <param name="gridIndices">The positional indices of this tile on the grid.</param>
+        public TileChangedEvent(Entity<MapGridComponent> entity, Tile newTile, Tile oldTile, Vector2i chunkIndex, Vector2i gridIndices)
         {
             Entity = entity;
-            Changes = [new TileChangedEntry(newTile, oldTile, chunkIndex)];
+            Changes = [new TileChangedEntry(newTile, oldTile, chunkIndex, gridIndices)];
         }
 
         /// <summary>
@@ -213,11 +222,12 @@ namespace Robust.Shared.GameObjects
     /// <param name="NewTile">New tile that replaced the old one.</param>
     /// <param name="OldTile">Old tile that was replaced.</param>
     /// <param name="ChunkIndex">The index of the grid-chunk that this tile belongs to.</param>
-    public readonly record struct TileChangedEntry(TileRef NewTile, Tile OldTile, Vector2i ChunkIndex)
+    /// <param name="GridIndices">The positional indices of this tile on the grid.</param>
+    public readonly record struct TileChangedEntry(Tile NewTile, Tile OldTile, Vector2i ChunkIndex, Vector2i GridIndices)
     {
         /// <summary>
         /// Was the tile previously empty or is it now empty.
         /// </summary>
-        public bool EmptyChanged => OldTile.IsEmpty != NewTile.Tile.IsEmpty;
+        public bool EmptyChanged => OldTile.IsEmpty != NewTile.IsEmpty;
     }
 }

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.cs
@@ -173,45 +173,51 @@ namespace Robust.Shared.GameObjects
     }
 
     /// <summary>
-    ///     Arguments for when a single tile on a grid is changed locally or remotely.
+    /// Raised directed at the grid when tiles are changed locally or remotely.
     /// </summary>
     [ByRefEvent]
     public readonly record struct TileChangedEvent
     {
         /// <summary>
-        ///     Creates a new instance of this class.
+        /// Creates a new instance of this event for a single changed tile.
         /// </summary>
         public TileChangedEvent(Entity<MapGridComponent> entity, TileRef newTile, Tile oldTile, Vector2i chunkIndex)
         {
             Entity = entity;
-            NewTile = newTile;
-            OldTile = oldTile;
-            ChunkIndex = chunkIndex;
+            Changes = [new TileChangedEntry(newTile, oldTile, chunkIndex)];
         }
 
         /// <summary>
-        /// Was the tile previously empty or is it now empty.
+        /// Creates a new instance of this event for multiple changed tiles.
         /// </summary>
-        public bool EmptyChanged => OldTile.IsEmpty != NewTile.Tile.IsEmpty;
+        public TileChangedEvent(Entity<MapGridComponent> entity, TileChangedEntry[] changes)
+        {
+            Entity = entity;
+            Changes = changes;
+        }
 
         /// <summary>
-        ///     Entity of the grid with the tile-change. TileRef stores the GridId.
+        /// Entity of the grid with the tile-change. TileRef stores the GridId.
         /// </summary>
         public readonly Entity<MapGridComponent> Entity;
 
         /// <summary>
-        ///     New tile that replaced the old one.
+        /// An array of all the tiles that were changed.
         /// </summary>
-        public readonly TileRef NewTile;
+        public readonly TileChangedEntry[] Changes;
+    }
 
+    /// <summary>
+    /// Data about a single tile that was changed as part of a <see cref="TileChangedEvent"/>.
+    /// </summary>
+    /// <param name="NewTile">New tile that replaced the old one.</param>
+    /// <param name="OldTile">Old tile that was replaced.</param>
+    /// <param name="ChunkIndex">The index of the grid-chunk that this tile belongs to.</param>
+    public readonly record struct TileChangedEntry(TileRef NewTile, Tile OldTile, Vector2i ChunkIndex)
+    {
         /// <summary>
-        ///     Old tile that was replaced.
+        /// Was the tile previously empty or is it now empty.
         /// </summary>
-        public readonly Tile OldTile;
-
-        /// <summary>
-        ///     The index of the grid-chunk that this tile belongs to.
-        /// </summary>
-        public readonly Vector2i ChunkIndex;
+        public bool EmptyChanged => OldTile.IsEmpty != NewTile.Tile.IsEmpty;
     }
 }

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -73,7 +73,7 @@ namespace Robust.Shared.GameObjects
             foreach (var change in e.Changes)
             {
                 if(change.NewTile.Tile != Tile.Empty)
-                    return;
+                    continue;
 
                 // TODO optimize this for when multiple tiles get empties simultaneously (e.g., explosions).
                 DeparentAllEntsOnTile(change.NewTile.GridUid, change.NewTile.GridIndices);

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -70,11 +70,14 @@ namespace Robust.Shared.GameObjects
 
         private void MapManagerOnTileChanged(ref TileChangedEvent e)
         {
-            if(e.NewTile.Tile != Tile.Empty)
-                return;
+            foreach (var change in e.Changes)
+            {
+                if(change.NewTile.Tile != Tile.Empty)
+                    return;
 
-            // TODO optimize this for when multiple tiles get empties simultaneously (e.g., explosions).
-            DeparentAllEntsOnTile(e.NewTile.GridUid, e.NewTile.GridIndices);
+                // TODO optimize this for when multiple tiles get empties simultaneously (e.g., explosions).
+                DeparentAllEntsOnTile(change.NewTile.GridUid, change.NewTile.GridIndices);
+            }
         }
 
         /// <summary>

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -72,11 +72,11 @@ namespace Robust.Shared.GameObjects
         {
             foreach (var change in e.Changes)
             {
-                if(change.NewTile.Tile != Tile.Empty)
+                if(change.NewTile != Tile.Empty)
                     continue;
 
                 // TODO optimize this for when multiple tiles get empties simultaneously (e.g., explosions).
-                DeparentAllEntsOnTile(change.NewTile.GridUid, change.NewTile.GridIndices);
+                DeparentAllEntsOnTile(e.Entity, change.GridIndices);
             }
         }
 


### PR DESCRIPTION
Instead of raising a `TileChangedEvent` for each tile, `SharedMapSystem.SetTiles` now raises a single event containing an array of all of the changed tiles. The existing system to suppress `TileChangedEvent`s is used to prevent the individual events and a combined event is raised at the end.

`TileChangedEvent` was modified to support this - it now holds an array of `TileChangedEntry`s containing data about the changed tiles. A constructor for events with a single tile changed is included and can be used identically to the old version of the event.

Notably, `TileChangedEntry` replaces the `TileRef` used for the new tile with a `Tile` and a `Vector2i` for the grid position. This avoid including a redundant reference to the grid entity.

Naturally, everything that subscribes to `TileChangedEvent` has to be modified to support multiple changes. This is fairly easy to implement, as `foreach` on `TileChangedEvent.Changes` will provide the expected data within the loop, but it does require significant changes.

Requires https://github.com/space-wizards/space-station-14/pull/37229 for content changes.

(Hopefully) fixes https://github.com/space-wizards/space-station-14/issues/37133