### PR TITLE
Reduce logging details in the Joint System

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedJointSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedJointSystem.cs
@@ -160,7 +160,9 @@ public abstract partial class SharedJointSystem : EntitySystem
         {
             if (existing.BodyBUid != bUid)
             {
+#if !RELEASE
                 Log.Error($"While adding joint {joint.ID} to entity {ToPrettyString(bUid)}, the connected entity {ToPrettyString(aUid)} already had a joint with the same ID connected to another entity {ToPrettyString(existing.BodyBUid)}.");
+#endif
                 return;
             }
 
@@ -174,17 +176,23 @@ public abstract partial class SharedJointSystem : EntitySystem
                 return;
             }
 
+#if !RELEASE
             Log.Error($"While adding joint {joint.ID} to entity {ToPrettyString(bUid)}, the joint already existed for the connected entity {ToPrettyString(aUid)}.");
+#endif
         }
         else if (!ignoreExisting && jointsB.TryGetValue(joint.ID, out existing))
         {
             if (existing.BodyAUid != aUid)
             {
+#if !RELEASE
                 Log.Error($"While adding joint {joint.ID} to entity {ToPrettyString(aUid)}, the connected entity {ToPrettyString(bUid)} already had a joint with the same ID connected to another entity {ToPrettyString(existing.BodyAUid)}.");
+#endif
                 return;
             }
 
+#if !RELEASE
             Log.Error($"While adding joint {joint.ID} to entity {ToPrettyString(aUid)}, the joint already existed for the connected entity {ToPrettyString(bUid)}.");
+#endif
         }
 
         jointsA.TryAdd(joint.ID, joint);

--- a/Robust.Shared/Physics/Systems/SharedJointSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedJointSystem.cs
@@ -160,9 +160,7 @@ public abstract partial class SharedJointSystem : EntitySystem
         {
             if (existing.BodyBUid != bUid)
             {
-#if !RELEASE
-                Log.Error($"While adding joint {joint.ID} to entity {ToPrettyString(bUid)}, the connected entity {ToPrettyString(aUid)} already had a joint with the same ID connected to another entity {ToPrettyString(existing.BodyBUid)}.");
-#endif
+                Log.Warning($"While adding joint {joint.ID} to entity {bUid}, the connected entity {aUid} already had a joint with the same ID connected to another entity {existing.BodyBUid}.");
                 return;
             }
 
@@ -176,23 +174,17 @@ public abstract partial class SharedJointSystem : EntitySystem
                 return;
             }
 
-#if !RELEASE
-            Log.Error($"While adding joint {joint.ID} to entity {ToPrettyString(bUid)}, the joint already existed for the connected entity {ToPrettyString(aUid)}.");
-#endif
+            Log.Warning($"While adding joint {joint.ID} to entity {bUid}, the joint already existed for the connected entity {aUid}.");
         }
         else if (!ignoreExisting && jointsB.TryGetValue(joint.ID, out existing))
         {
             if (existing.BodyAUid != aUid)
             {
-#if !RELEASE
-                Log.Error($"While adding joint {joint.ID} to entity {ToPrettyString(aUid)}, the connected entity {ToPrettyString(bUid)} already had a joint with the same ID connected to another entity {ToPrettyString(existing.BodyAUid)}.");
-#endif
+                Log.Warning($"While adding joint {joint.ID} to entity {aUid}, the connected entity {bUid} already had a joint with the same ID connected to another entity {existing.BodyAUid}.");
                 return;
             }
 
-#if !RELEASE
-            Log.Error($"While adding joint {joint.ID} to entity {ToPrettyString(aUid)}, the joint already existed for the connected entity {ToPrettyString(bUid)}.");
-#endif
+            Log.Warning($"While adding joint {joint.ID} to entity {aUid}, the joint already existed for the connected entity {bUid}.");
         }
 
         jointsA.TryAdd(joint.ID, joint);


### PR DESCRIPTION
When logging errors in the `SharedJointSystem`, the names of the players and some other information are displayed in the console, which in theory can be used for dishonest purposes. Of course, the chance of this is small, but it is there. 

The most common example is to find out about the presence of nuclear operatives or another antagonists by their name.

Fixes https://github.com/space-wizards/RobustToolbox/issues/5726

A good example is the log from [https://github.com/space-wizards/space-station-14/issues/11644](https://github.com/space-wizards/space-station-14/issues/11644)