### PR TITLE
[WiP] Direction-depend sprite layers ordering and Sprite ECS

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -65,6 +65,25 @@ namespace Robust.Client.GameObjects
         // VV convenience variable to examine layer objects using layer keys
         [ViewVariables]
         private Dictionary<object, Layer> _mappedLayers => LayerMap.ToDictionary(x => x.Key, x => Layers[x.Value]);
+        /// <summary>
+        /// VV convenience variable to examine cached layer order
+        /// </summary>
+        [ViewVariables]
+        private Dictionary<RsiDirection, List<string?>>  _cachedDirectionOrderStatesVV => CachedDirectionLayerOrder.ToDictionary(x => x.Key,
+        x => {
+            List<string?> result = new();
+            foreach (var index in x.Value)
+            {
+                result.Add(Layers[index].ActualState?.StateId.Name);
+            }
+            return result;
+        });
+
+        /// <summary>
+        /// VV convenience variable to examine state ids
+        /// </summary>
+        [ViewVariables]
+        private Dictionary<object, string?> _mappedLayersStateVV => LayerMap.ToDictionary(x => x.Key, x => Layers[x.Value].ActualState?.StateId.Name);
 
         [ViewVariables(VVAccess.ReadWrite)]
         public bool Visible
@@ -171,6 +190,34 @@ namespace Robust.Client.GameObjects
         [DataField("sprite", readOnly: true)] private string? rsi;
         [DataField("layers", readOnly: true)] private List<PrototypeLayerData> layerDatums = new();
 
+        /// <summary>
+        /// Dictionary which defines sprite's layers render order relative to direction.
+        /// map key is used to define which layer order specified
+        /// </summary>
+        [DataField("dirOrder", readOnly: true)]
+        internal Dictionary<RsiDirection, List<string>> _directionOrderUnparsed = new();
+
+        internal Dictionary<RsiDirection, List<object>> _directionOrder = new();
+
+        /// <summary>
+        /// Defines ordering strategy of non-ordered layers.
+        ///     True [default] - they will be first (render under the ordered ones)
+        ///     False - they will be last (rendered onto ordered ones)
+        /// </summary>
+        [DataField("unorderedFirst", readOnly: true)]
+        internal bool _unorderedFirst = false;
+
+        /// <summary>
+        /// Kinda optimization bool for not handling unused directions
+        /// </summary>
+        internal byte RsiDirectionTypes = 0;
+
+        /// <summary>
+        /// This flags goes for dividing Dir4 and Dir8 sprites.
+        /// Makes it people friendly to deal with.
+        /// </summary>
+        internal RsiDirectionType MaxRsiDirectionType;
+
         [DataField(readOnly: true)] private string? state;
         [DataField(readOnly: true)] private string? texture;
 
@@ -235,7 +282,7 @@ namespace Robust.Client.GameObjects
 
         [ViewVariables] internal Dictionary<object, int> LayerMap { get; set; } = new();
         [ViewVariables] internal List<Layer> Layers = new();
-
+        [ViewVariables] internal Dictionary<RsiDirection, List<int>> CachedDirectionLayerOrder = new ();
         [ViewVariables(VVAccess.ReadWrite)] public uint RenderOrder { get; set; }
 
         [ViewVariables(VVAccess.ReadWrite)] public bool IsInert { get; internal set; }

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.DirectionsCache.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.DirectionsCache.cs
@@ -1,0 +1,137 @@
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Robust.Client.Utility;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Graphics.RSI;
+using Robust.Shared.Utility;
+
+namespace Robust.Client.GameObjects;
+
+public sealed partial class SpriteSystem : EntitySystem
+{
+    public void UpdateOrientationCache(SpriteComponent component)
+    {
+        // this happened cause of building all in one method
+        if (component.Layers.Count == 0 || (component._directionOrderUnparsed.Count == 0 && component._directionOrder.Count == 0))
+            return;
+        // this should be in init/after deserialization
+
+        component._directionOrder.Clear();
+        component.CachedDirectionLayerOrder.Clear();
+        foreach (var (directionKey, unparsedOrder) in component._directionOrderUnparsed)
+        {
+            //TODO: move to component with other ParseKey calls
+            List<object> parsedOrder = new(unparsedOrder.Count);
+            foreach(var unparsed in unparsedOrder)
+            {
+                parsedOrder.Add(component.ParseKey(unparsed));
+            }
+            parsedOrder.TrimExcess();
+            component._directionOrder.Add(directionKey, parsedOrder);
+        }
+
+        foreach (var layer in component.Layers)
+        {
+            component.RsiDirectionTypes |= ((byte?)layer.ActualState?.RsiDirections) ?? (byte)RsiDirectionType.Dir1;
+        }
+
+        // parameters pre-process
+        // It should not be here. Only if its updated then to sort
+        // foreach (var (_, value) in _directionOrder)
+        // {
+        //     value.Sort();
+        // }
+
+        Dictionary<RsiDirection, List<int>> tempUnorderedLayers = new();
+        Dictionary<RsiDirection, SortedList<int, int>> tempOrderedLayers = new ();
+
+        foreach (var (mappedDirection,_) in component._directionOrder)
+        {
+            List<int> unorderedLayers = new(component.Layers.Count);
+            SortedList<int, int> orderedLayers = new(component.Layers.Count);
+
+            tempUnorderedLayers.Add(mappedDirection, unorderedLayers);
+            tempOrderedLayers.Add(mappedDirection, orderedLayers);
+        }
+
+        // Make cache section
+        // original order was by Layers, but they were overridden exactly by LayerMap, so...
+        // I need to double check how it worked
+        foreach (var (map, layerIndex) in component.LayerMap)
+        {
+            var layer = component.Layers[layerIndex];
+            // that could be removed but I need to think about it
+            component.MaxRsiDirectionType = layer.ActualState?.RsiDirections > component.MaxRsiDirectionType ?
+                                    layer.ActualState.RsiDirections : component.MaxRsiDirectionType;
+
+            DebugTools.Assert(layer is not null);
+
+            foreach (var iterDirection in Enum.GetValues<RsiDirection>())
+            {
+                // thats THE disaster
+                if ((component.RsiDirectionTypes & (byte)RsiDirectionType.Dir8) == 0 && iterDirection > RsiDirection.West)
+                    continue;
+
+                var direction = iterDirection.OffsetRsiDir(layer.DirOffset);
+
+                // it work bad at strings... needs cheking
+
+                int orderedIndex = component._directionOrder.TryGetValue(direction, out var objectOrder) ?
+                                    objectOrder.FindIndex(map.Equals) : -1;
+                                    // objectOrder.BinarySearch(map) : -1;
+
+
+                if (orderedIndex < 0)
+                {
+                    tempUnorderedLayers[direction].Add(layerIndex);
+                }
+                else
+                {
+                    // Logger.Debug($"Found match in {orderedIndex} layer map is {map} order map is {objectOrder?[orderedIndex]}.");
+                    tempOrderedLayers[direction].Add(orderedIndex ,layerIndex);
+                }
+            }
+        }
+
+        // SaveCache section
+        foreach (var (mappedDirection, orderedLayers) in tempOrderedLayers)
+        {
+
+#if DEBUG
+        // I need to double check that it is correct, just to make myself calm
+            int valIndex = 0;
+            int prevKey = -1;
+            foreach (var (key, value) in orderedLayers)
+            {
+                DebugTools.AssertEqual(value, orderedLayers.Values.ElementAt(valIndex));
+                DebugTools.Assert(prevKey < key);
+                valIndex++;
+                prevKey = key;
+            }
+#endif
+        DebugTools.Assert(tempUnorderedLayers[mappedDirection] is not null);
+        List<int> resultList = new(component.Layers.Count);
+
+        if (component._unorderedFirst)
+        {
+            resultList.AddRange(tempUnorderedLayers[mappedDirection]);
+            resultList.AddRange(orderedLayers.Values);
+        }
+        else
+        {
+            resultList.AddRange(orderedLayers.Values);
+            resultList.AddRange(tempUnorderedLayers[mappedDirection]);
+        }
+
+        resultList.TrimExcess();
+        component.CachedDirectionLayerOrder.Add(mappedDirection, resultList);
+        }
+
+        // will it clear lists inside? Do I even need to think of it?
+        tempOrderedLayers.Clear();
+        tempUnorderedLayers.Clear();
+    }
+}
+

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Layer.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Layer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
@@ -94,6 +95,8 @@ public sealed partial class SpriteSystem
         sprite.Comp.BoundsDirty = true;
         _tree.QueueTreeUpdate(sprite!);
         QueueUpdateIsInert(sprite!);
+        // TODO:
+        // UpdateOrientationCache();
         return true;
     }
 
@@ -228,6 +231,8 @@ public sealed partial class SpriteSystem
             SpriteSpecifier.Rsi rsi => AddRsiLayer(sprite, rsi.RsiState, rsi.RsiPath, newIndex),
             _ => throw new NotImplementedException()
         };
+        // TODO
+        //UpdateOrientationCache();
     }
 
     /// <summary>


### PR DESCRIPTION
! ATTENTION ! This is raw variant. I wanted to point that its being in work. Feel free to make suggestions and ask something be done with sprites.

# About PR #
What this PR do:
1. Adds Datafield to SpriteComponent which allows specifying layer ordering referred to current RsiDirection
2. Separate Layers and layer's order in rendering

Pros:
- Flexible sprite ordering

Cons:
- Heavy order cache update 

What I try to avoid:
- SpriteComponent uses this feature, when it has no need. (mostly cause of heavy cache update procedure)
- Restricting sprite layers to have same RsiDirsType  
- Removing any of existing feature

# ToDo #
- [x] Start ECSing SpriteComponent (primary to not do the heavy cache update every time)
- [ ] Make ordering changeable through methods (I need time to figure out how to make it fancy and not to step on same hard-ordering problem)
- [ ] Make human-readable VV/Debug (This PR makes 3 collection for sprite: layers, <map, layers>, <direction, layers>. Proper debug options have to be done)
- [ ] Make guideline/document how to use this changes 
- [ ] Prepare PR to SS14 repo

# Current state #
update date: 10.05.2025

Original idea was to make different layer order in each direction, so we can for example in ss14 hide tails under uniform in north direction and show it in south one. The example can be seen in pictures below:

![Снимок экрана 2025-05-09 223333](https://github.com/user-attachments/assets/a8951fcb-c9be-4ae6-9e79-e8f1b0714b34)
![Снимок экрана 2025-05-09 223339](https://github.com/user-attachments/assets/39e47de4-9aae-4f6c-8fb1-cbc48c65503e)
![Снимок экрана 2025-05-09 223345](https://github.com/user-attachments/assets/9e9fca48-6e3e-4a73-bf41-5f8430130094)

The same can be done with neck/backpack slots and for other species in SS14.

It has some problem due to its raw state: f.e. species marking 