### PR TITLE
Mark `Entity` methods as readonly

### DIFF
--- a/Robust.Shared/GameObjects/Entity.cs
+++ b/Robust.Shared/GameObjects/Entity.cs
@@ -11,7 +11,7 @@ public record struct Entity<T> : IFluentEntityUid, IAsType<EntityUid>
 {
     public EntityUid Owner;
     public T Comp;
-    EntityUid IFluentEntityUid.FluentOwner => Owner;
+    readonly EntityUid IFluentEntityUid.FluentOwner => Owner;
 
     public Entity(EntityUid owner, T comp)
     {
@@ -48,9 +48,9 @@ public record struct Entity<T> : IFluentEntityUid, IAsType<EntityUid>
     }
 
 
-    public override int GetHashCode() => Owner.GetHashCode();
-    public Entity<T?> AsNullable() => new(Owner, Comp);
-    public EntityUid AsType() => Owner;
+    public override readonly int GetHashCode() => Owner.GetHashCode();
+    public readonly Entity<T?> AsNullable() => new(Owner, Comp);
+    public readonly EntityUid AsType() => Owner;
 }
 
 [NotYamlSerializable]
@@ -60,7 +60,7 @@ public record struct Entity<T1, T2> : IFluentEntityUid, IAsType<EntityUid>
     public EntityUid Owner;
     public T1 Comp1;
     public T2 Comp2;
-    EntityUid IFluentEntityUid.FluentOwner => Owner;
+    readonly EntityUid IFluentEntityUid.FluentOwner => Owner;
 
     public Entity(EntityUid owner, T1 comp1, T2 comp2)
     {
@@ -119,9 +119,9 @@ public record struct Entity<T1, T2> : IFluentEntityUid, IAsType<EntityUid>
         return new Entity<T1>(ent.Owner, ent.Comp1);
     }
 
-    public override int GetHashCode() => Owner.GetHashCode();
-    public Entity<T1?, T2?> AsNullable() => new(Owner, Comp1, Comp2);
-    public EntityUid AsType() => Owner;
+    public override readonly int GetHashCode() => Owner.GetHashCode();
+    public readonly Entity<T1?, T2?> AsNullable() => new(Owner, Comp1, Comp2);
+    public readonly EntityUid AsType() => Owner;
 }
 
 [NotYamlSerializable]
@@ -132,7 +132,7 @@ public record struct Entity<T1, T2, T3> : IFluentEntityUid, IAsType<EntityUid>
     public T1 Comp1;
     public T2 Comp2;
     public T3 Comp3;
-    EntityUid IFluentEntityUid.FluentOwner => Owner;
+    readonly EntityUid IFluentEntityUid.FluentOwner => Owner;
 
     public Entity(EntityUid owner, T1 comp1, T2 comp2, T3 comp3)
     {
@@ -226,9 +226,9 @@ public record struct Entity<T1, T2, T3> : IFluentEntityUid, IAsType<EntityUid>
 
 #endregion
 
-    public override int GetHashCode() => Owner.GetHashCode();
-    public Entity<T1?, T2?, T3?> AsNullable() => new(Owner, Comp1, Comp2, Comp3);
-    public EntityUid AsType() => Owner;
+    public override readonly int GetHashCode() => Owner.GetHashCode();
+    public readonly Entity<T1?, T2?, T3?> AsNullable() => new(Owner, Comp1, Comp2, Comp3);
+    public readonly EntityUid AsType() => Owner;
 }
 
 [NotYamlSerializable]
@@ -240,7 +240,7 @@ public record struct Entity<T1, T2, T3, T4> : IFluentEntityUid, IAsType<EntityUi
     public T2 Comp2;
     public T3 Comp3;
     public T4 Comp4;
-    EntityUid IFluentEntityUid.FluentOwner => Owner;
+    readonly EntityUid IFluentEntityUid.FluentOwner => Owner;
 
     public Entity(EntityUid owner, T1 comp1, T2 comp2, T3 comp3, T4 comp4)
     {
@@ -357,9 +357,9 @@ public record struct Entity<T1, T2, T3, T4> : IFluentEntityUid, IAsType<EntityUi
 
 #endregion
 
-    public override int GetHashCode() => Owner.GetHashCode();
-    public Entity<T1?, T2?, T3?, T4?> AsNullable() => new(Owner, Comp1, Comp2, Comp3, Comp4);
-    public EntityUid AsType() => Owner;
+    public override readonly int GetHashCode() => Owner.GetHashCode();
+    public readonly Entity<T1?, T2?, T3?, T4?> AsNullable() => new(Owner, Comp1, Comp2, Comp3, Comp4);
+    public readonly EntityUid AsType() => Owner;
 }
 
 [NotYamlSerializable]
@@ -372,7 +372,7 @@ public record struct Entity<T1, T2, T3, T4, T5> : IFluentEntityUid, IAsType<Enti
     public T3 Comp3;
     public T4 Comp4;
     public T5 Comp5;
-    EntityUid IFluentEntityUid.FluentOwner => Owner;
+    readonly EntityUid IFluentEntityUid.FluentOwner => Owner;
 
     public Entity(EntityUid owner, T1 comp1, T2 comp2, T3 comp3, T4 comp4, T5 comp5)
     {
@@ -512,9 +512,9 @@ public record struct Entity<T1, T2, T3, T4, T5> : IFluentEntityUid, IAsType<Enti
 
 #endregion
 
-    public override int GetHashCode() => Owner.GetHashCode();
-    public Entity<T1?, T2?, T3?, T4?, T5?> AsNullable() => new(Owner, Comp1, Comp2, Comp3, Comp4, Comp5);
-    public EntityUid AsType() => Owner;
+    public override readonly int GetHashCode() => Owner.GetHashCode();
+    public readonly Entity<T1?, T2?, T3?, T4?, T5?> AsNullable() => new(Owner, Comp1, Comp2, Comp3, Comp4, Comp5);
+    public readonly EntityUid AsType() => Owner;
 }
 
 [NotYamlSerializable]
@@ -528,7 +528,7 @@ public record struct Entity<T1, T2, T3, T4, T5, T6> : IFluentEntityUid, IAsType<
     public T4 Comp4;
     public T5 Comp5;
     public T6 Comp6;
-    EntityUid IFluentEntityUid.FluentOwner => Owner;
+    readonly EntityUid IFluentEntityUid.FluentOwner => Owner;
 
     public Entity(EntityUid owner, T1 comp1, T2 comp2, T3 comp3, T4 comp4, T5 comp5, T6 comp6)
     {
@@ -691,9 +691,9 @@ public record struct Entity<T1, T2, T3, T4, T5, T6> : IFluentEntityUid, IAsType<
 
 #endregion
 
-    public override int GetHashCode() => Owner.GetHashCode();
-    public Entity<T1?, T2?, T3?, T4?, T5?, T6?> AsNullable() => new(Owner, Comp1, Comp2, Comp3, Comp4, Comp5, Comp6);
-    public EntityUid AsType() => Owner;
+    public override readonly int GetHashCode() => Owner.GetHashCode();
+    public readonly Entity<T1?, T2?, T3?, T4?, T5?, T6?> AsNullable() => new(Owner, Comp1, Comp2, Comp3, Comp4, Comp5, Comp6);
+    public readonly EntityUid AsType() => Owner;
 }
 
 [NotYamlSerializable]
@@ -708,7 +708,7 @@ public record struct Entity<T1, T2, T3, T4, T5, T6, T7> : IFluentEntityUid, IAsT
     public T5 Comp5;
     public T6 Comp6;
     public T7 Comp7;
-    EntityUid IFluentEntityUid.FluentOwner => Owner;
+    readonly EntityUid IFluentEntityUid.FluentOwner => Owner;
 
     public Entity(EntityUid owner, T1 comp1, T2 comp2, T3 comp3, T4 comp4, T5 comp5, T6 comp6, T7 comp7)
     {
@@ -894,9 +894,9 @@ public record struct Entity<T1, T2, T3, T4, T5, T6, T7> : IFluentEntityUid, IAsT
 
 #endregion
 
-    public override int GetHashCode() => Owner.GetHashCode();
-    public Entity<T1?, T2?, T3?, T4?, T5?, T6?, T7?> AsNullable() => new(Owner, Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7);
-    public EntityUid AsType() => Owner;
+    public override readonly int GetHashCode() => Owner.GetHashCode();
+    public readonly Entity<T1?, T2?, T3?, T4?, T5?, T6?, T7?> AsNullable() => new(Owner, Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7);
+    public readonly EntityUid AsType() => Owner;
 }
 
 [NotYamlSerializable]
@@ -912,7 +912,7 @@ public record struct Entity<T1, T2, T3, T4, T5, T6, T7, T8> : IFluentEntityUid, 
     public T6 Comp6;
     public T7 Comp7;
     public T8 Comp8;
-    EntityUid IFluentEntityUid.FluentOwner => Owner;
+    readonly EntityUid IFluentEntityUid.FluentOwner => Owner;
 
     public Entity(EntityUid owner, T1 comp1, T2 comp2, T3 comp3, T4 comp4, T5 comp5, T6 comp6, T7 comp7, T8 comp8)
     {
@@ -1121,7 +1121,7 @@ public record struct Entity<T1, T2, T3, T4, T5, T6, T7, T8> : IFluentEntityUid, 
 
 #endregion
 
-    public override int GetHashCode() => Owner.GetHashCode();
-    public Entity<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?> AsNullable() => new(Owner, Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8);
-    public EntityUid AsType() => Owner;
+    public override readonly int GetHashCode() => Owner.GetHashCode();
+    public readonly Entity<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?> AsNullable() => new(Owner, Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8);
+    public readonly EntityUid AsType() => Owner;
 }

--- a/Robust.UnitTesting/Shared/GameObjects/GenericEntityPrint.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/GenericEntityPrint.cs
@@ -179,7 +179,7 @@ public sealed class GenericEntityPrint
                 {
                     public EntityUid Owner;
                 {{fields.ToString().TrimEnd()}}
-                    EntityUid IFluentEntityUid.FluentOwner => Owner;
+                    readonly EntityUid IFluentEntityUid.FluentOwner => Owner;
 
                     public Entity(EntityUid owner{{parameters}})
                     {
@@ -212,9 +212,9 @@ public sealed class GenericEntityPrint
                     }
                     {{castRegion}}
 
-                    public override int GetHashCode() => Owner.GetHashCode();
-                    public Entity<{{nullableGenerics}}> AsNullable() => new(Owner{{selfAccess}});
-                    public EntityUid AsType() => Owner;
+                    public readonly override int GetHashCode() => Owner.GetHashCode();
+                    public readonly Entity<{{nullableGenerics}}> AsNullable() => new(Owner{{selfAccess}});
+                    public readonly EntityUid AsType() => Owner;
                 }
 
 

--- a/Robust.UnitTesting/Shared/GameObjects/GenericEntityPrint.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/GenericEntityPrint.cs
@@ -212,7 +212,7 @@ public sealed class GenericEntityPrint
                     }
                     {{castRegion}}
 
-                    public readonly override int GetHashCode() => Owner.GetHashCode();
+                    public override readonly int GetHashCode() => Owner.GetHashCode();
                     public readonly Entity<{{nullableGenerics}}> AsNullable() => new(Owner{{selfAccess}});
                     public readonly EntityUid AsType() => Owner;
                 }


### PR DESCRIPTION
Marks the `GetHashCode()`, `AsNullable()`, `AsType()` methods, and the `FluentOwner` property of the `Entity` variants as `readonly`. This lets the compiler know that they are pure and allows them to be called on readonly `Entity`s (like in event args) without the compiler secretly making a deep copy of the struct.

More info on readonly struct methods [here](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/struct#readonly-instance-members).

This was prompted by [a Discord conversation](https://discord.com/channels/310555209753690112/560845886263918612/1370703755464409129) about running into a compiler warning when trying to call `AsNullable` on an `Entity` event argument:

<img width="644" alt="Screenshot 2025-05-10 at 10 29 39 AM" src="https://github.com/user-attachments/assets/1fb5464c-c2fe-469c-9119-5a3f43223da9" />
