### PR TITLE
Fix incorrect saved window positions

### DIFF
--- a/Robust.Client/UserInterface/CustomControls/DefaultWindow.xaml.cs
+++ b/Robust.Client/UserInterface/CustomControls/DefaultWindow.xaml.cs
@@ -145,6 +145,9 @@ namespace Robust.Client.UserInterface.CustomControls
 
         protected override void FrameUpdate(FrameEventArgs args)
         {
+            if (!IsMeasureValid)
+                return;
+
             var (spaceX, spaceY) = Parent!.Size;
 
             var maxX = spaceX - ((AllowOffScreen & DirectionFlag.West) == 0 ? Size.X : WindowEdgeSeparation);

--- a/Robust.Client/UserInterface/CustomControls/DefaultWindow.xaml.cs
+++ b/Robust.Client/UserInterface/CustomControls/DefaultWindow.xaml.cs
@@ -145,6 +145,8 @@ namespace Robust.Client.UserInterface.CustomControls
 
         protected override void FrameUpdate(FrameEventArgs args)
         {
+            // This is to avoid unnecessarily setting a position where our size isn't yet fully updated.
+            // This most commonly happens with saved window positions if your window position is <= 0.
             if (!IsMeasureValid)
                 return;
 


### PR DESCRIPTION
As of however many UI PRs ago windows store their last position on the client and it re-opens windows at that position.

The issue is that the code to avoid windows being able to go off-screen was immediately bulldozing this value, at least if the x <= 0. Now we just don't run it until we have a valid measure (probably the frame after) and avoid unnecessarily having an incorrect position applied.

Thought I made an issue but supposedly not.