### PR TITLE
Traversal + lerping stuff

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/TransformSystem.Component.cs
+++ b/Robust.Client/GameObjects/EntitySystems/TransformSystem.Component.cs
@@ -3,6 +3,7 @@ using Robust.Client.Player;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Maths;
+using Robust.Shared.Utility;
 
 namespace Robust.Client.GameObjects;
 
@@ -13,9 +14,10 @@ public sealed partial class TransformSystem
         if (!XformQuery.Resolve(uid, ref xform))
             return;
 
-        xform.NextPosition = value;
         ActivateLerp(uid, xform);
         base.SetLocalPosition(uid, value, xform);
+
+        xform.NextPosition = xform.LocalPosition;
     }
 
     public override void SetLocalRotation(EntityUid uid, Angle value, TransformComponent? xform = null)
@@ -23,9 +25,10 @@ public sealed partial class TransformSystem
         if (!XformQuery.Resolve(uid, ref xform))
             return;
 
-        xform.NextRotation = value;
         ActivateLerp(uid, xform);
         base.SetLocalRotation(uid, value, xform);
+
+        xform.NextRotation = xform.LocalRotation;
     }
 
     public override void SetLocalPositionRotation(EntityUid uid, Vector2 pos, Angle rot, TransformComponent? xform = null)
@@ -33,9 +36,11 @@ public sealed partial class TransformSystem
         if (!XformQuery.Resolve(uid, ref xform))
             return;
 
-        xform.NextPosition = pos;
-        xform.NextRotation = rot;
         ActivateLerp(uid, xform);
         base.SetLocalPositionRotation(uid, pos, rot, xform);
+
+        // Setting the pos itself may get mutated due to subscribers or grid traversal.
+        xform.NextPosition = xform.LocalPosition;
+        xform.NextRotation = xform.LocalRotation;
     }
 }

--- a/Robust.Client/GameObjects/EntitySystems/TransformSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/TransformSystem.cs
@@ -168,9 +168,9 @@ namespace Robust.Client.GameObjects
                         if (transform.LerpParent != transform.ParentUid)
                         {
                             var oldParentMatrix = GetWorldMatrix(transform.LerpParent);
-                            var parentMatrix = GetInvWorldMatrix(transform.ParentUid);
+                            var parentInvMatrix = GetInvWorldMatrix(transform.ParentUid);
 
-                            var finalMatrix = Matrix3x2.Multiply(parentMatrix, oldParentMatrix);
+                            var finalMatrix = Matrix3x2.Multiply(oldParentMatrix, parentInvMatrix);
                             lerpSource = Vector2.Transform(lerpSource, finalMatrix);
                         }
 

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -405,6 +405,8 @@ namespace Robust.Shared
         public static readonly CVarDef<bool> NetHWId =
             CVarDef.Create("net.hwid", true, CVar.SERVERONLY);
 
+        public static readonly CVarDef<bool> TransformLerping =
+            CVarDef.Create("transform.lerping", true, CVar.CLIENTONLY);
 
         /**
          * SUS

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -150,25 +150,8 @@ namespace Robust.Shared.GameObjects
         public Angle LocalRotation
         {
             get => _localRotation;
-            set
-            {
-                if(_noLocalRotation)
-                    return;
-
-                if (_localRotation.EqualsApprox(value))
-                    return;
-
-                var oldRotation = _localRotation;
-                _localRotation = value;
-                var meta = _entMan.GetComponent<MetaDataComponent>(Owner);
-                _entMan.Dirty(Owner, this, meta);
-                MatricesDirty = true;
-
-                if (!Initialized)
-                    return;
-
-                _entMan.System<SharedTransformSystem>().RaiseMoveEvent((Owner, this, meta), _parent, _localPosition, oldRotation, MapUid, checkTraversal: false);
-            }
+            [Obsolete("Use the system method instead")]
+            set => _entMan.System<SharedTransformSystem>().SetLocalRotationInternal((Owner, this), value);
         }
 
         /// <summary>
@@ -334,27 +317,7 @@ namespace Robust.Shared.GameObjects
         {
             get => _localPosition;
             [Obsolete("Use the system method instead")]
-            set
-            {
-                if(Anchored)
-                    return;
-
-                if (_localPosition.EqualsApprox(value))
-                    return;
-
-                var oldParent = _parent;
-                var oldPos = _localPosition;
-
-                _localPosition = value;
-                var meta = _entMan.GetComponent<MetaDataComponent>(Owner);
-                _entMan.Dirty(Owner, this, meta);
-                MatricesDirty = true;
-
-                if (!Initialized)
-                    return;
-
-                _entMan.System<SharedTransformSystem>().RaiseMoveEvent((Owner, this, meta), oldParent, oldPos, _localRotation, MapUid);
-            }
+            set => _entMan.System<SharedTransformSystem>().SetLocalPositionInternal((Owner, this), value);
         }
 
         /// <summary>

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.cs
@@ -20,13 +20,13 @@ namespace Robust.Shared.GameObjects
     {
         [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly IMapManager _mapManager = default!;
-        [Dependency] private readonly EntityLookupSystem _lookup = default!;
-        [Dependency] private readonly SharedMapSystem _map = default!;
-        [Dependency] private readonly MetaDataSystem _metaData = default!;
-        [Dependency] private readonly SharedPhysicsSystem _physics = default!;
         [Dependency] private readonly INetManager _netMan = default!;
+        [Dependency] private readonly EntityLookupSystem _lookup = default!;
+        [Dependency] private readonly MetaDataSystem _metaData = default!;
         [Dependency] private readonly SharedContainerSystem _container = default!;
-        [Dependency] private readonly SharedGridTraversalSystem _traversal = default!;
+        [Dependency] private readonly SharedMapSystem _map = default!;
+        [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+        [Dependency] protected readonly SharedGridTraversalSystem Traversal = default!;
 
         private EntityQuery<MapComponent> _mapQuery;
         private EntityQuery<MapGridComponent> _gridQuery;
@@ -298,7 +298,7 @@ namespace Robust.Shared.GameObjects
             // have finished running first. Ideally this shouldn't be required, but this is here just in case
             if (checkTraversal)
             {
-                _traversal.CheckTraverse(ent);
+                Traversal.CheckTraverse(ent);
             }
         }
     }


### PR DESCRIPTION
- Undisables cross-parent lerping so grid traversal doesn't lurch.
- Fixes some subtly incorrect lerp values if traversal was run in the setter.
- Disable traversal when lerping in the rare case it traverses us onto a grid.
- Mark the LocalRotation setter as obsolete, was probably just forgotten but this aligns with LocalPosition.

@ElectroJr 

I imagine this may break some stuff but content stuff like container setting or w/e should use the no-lerp version maybe? Or we add a setcoordinates no lerp version helper?

Draft because grid <> grid lerps still lurch