### PR TITLE
Make SpriteSystem.LayerMapReserve not throw

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -47,7 +47,7 @@ END TEMPLATE-->
 
 ### Other
 
-*None yet*
+* `SpriteSystem.LayerMapReserve()` no longer throws an exception if the specified layer already exists. This makes it behave like the obsoleted `SpriteComponent.LayerMapReserveBlank()`.
 
 ### Internal
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,6 +44,7 @@ END TEMPLATE-->
 ### Bugfixes
 
 * OutputPanel and RichTextLabel now remove controls associated with rich text tags when the text is updated.
+* Fix `SpriteComponent.Visible` datafield not being read from yaml.
 
 ### Other
 

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -39,7 +39,6 @@ namespace Robust.Client.GameObjects
     [RegisterComponent]
     public sealed partial class SpriteComponent : Component, IComponentDebug, ISerializationHooks, IComponentTreeEntry<SpriteComponent>, IAnimationProperties
     {
-        #region ECSd
         public const string LogCategory = "go.comp.sprite";
 
         [Dependency] private readonly IResourceCache resourceCache = default!;
@@ -1052,8 +1051,6 @@ namespace Robust.Client.GameObjects
         {
             return Sys.CalculateBounds((Owner, this), worldPosition, worldRotation, eyeRot);
         }
-
-        #endregion
 
         /// <summary>
         ///     Enum to "offset" a cardinal direction.

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -59,12 +59,13 @@ namespace Robust.Client.GameObjects
         [DataField] // TODO Sprite access restrict.
         public bool GranularLayersRendering = false;
 
-        [DataField]
+        [DataField("visible")]
         internal bool _visible = true;
 
         // VV convenience variable to examine layer objects using layer keys
+        // ReSharper disable once UnusedMember.Local
         [ViewVariables]
-        private Dictionary<object, Layer> _mappedLayers => LayerMap.ToDictionary(x => x.Key, x => Layers[x.Value]);
+        private Dictionary<object, Layer> MappedLayers => LayerMap.ToDictionary(x => x.Key, x => Layers[x.Value]);
 
         [ViewVariables(VVAccess.ReadWrite)]
         public bool Visible
@@ -93,7 +94,7 @@ namespace Robust.Client.GameObjects
             set => Sys.SetDrawDepth((Owner, this), value);
         }
 
-        [DataField]
+        [DataField("scale")] // Explicit name, in case this field ever gets renamed
         internal Vector2 scale = Vector2.One;
 
         /// <summary>
@@ -108,7 +109,7 @@ namespace Robust.Client.GameObjects
             set => Sys.SetScale((Owner, this), value);
         }
 
-        [DataField]
+        [DataField("rotation")] // Explicit name, in case this field ever gets renamed
         internal Angle rotation = Angle.Zero;
 
         [Animatable]
@@ -120,7 +121,7 @@ namespace Robust.Client.GameObjects
             set => Sys.SetRotation((Owner, this), value);
         }
 
-        [DataField]
+        [DataField("offset")] // Explicit name, in case this field ever gets renamed
         internal Vector2 offset = Vector2.Zero;
 
         /// <summary>
@@ -135,7 +136,7 @@ namespace Robust.Client.GameObjects
             set => Sys.SetOffset((Owner, this), value);
         }
 
-        [DataField]
+        [DataField("color")] // Explicit name, in case this field ever gets renamed
         internal Color color = Color.White;
 
         [Animatable]

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.LayerMap.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.LayerMap.cs
@@ -213,32 +213,30 @@ public sealed partial class SpriteSystem
     }
 
     /// <summary>
-    /// Create a new blank layer and map the given key to it.
+    /// Ensures that a layer with the given key exists and return the layer's index.
+    /// If the layer does not yet exist, this will create and add a blank layer.
     /// </summary>
     public int LayerMapReserve(Entity<SpriteComponent?> sprite, Enum key)
     {
         if (!_query.Resolve(sprite.Owner, ref sprite.Comp))
             return -1;
 
-        if (LayerExists(sprite, key))
-            throw new Exception("Layer already exists");
+        if (LayerMapTryGet(sprite, key, out var layerIndex, false))
+            return layerIndex;
 
         var layer = AddBlankLayer(sprite!);
         LayerMapSet(sprite, key, layer.Index);
         return layer.Index;
     }
 
-    /// <summary>
-    /// A create a new blank layer and map the given key to it. If possible, it is preferred to use an enum key.
-    /// string keys mainly exist to make it easier to define custom layer keys in yaml.
-    /// </summary>
+    /// <inheritdoc cref="LayerMapReserve(Entity{SpriteComponent?},System.Enum)"/>
     public int LayerMapReserve(Entity<SpriteComponent?> sprite, string key)
     {
         if (!_query.Resolve(sprite.Owner, ref sprite.Comp))
             return -1;
 
-        if (LayerExists(sprite, key))
-            throw new Exception("Layer already exists");
+        if (LayerMapTryGet(sprite, key, out var layerIndex, false))
+            return layerIndex;
 
         var layer = AddBlankLayer(sprite!);
         LayerMapSet(sprite, key, layer.Index);

--- a/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
+++ b/Robust.Shared/GameObjects/Components/MetaDataComponent.cs
@@ -150,6 +150,7 @@ namespace Robust.Shared.GameObjects
         [ViewVariables, Access(typeof(EntityManager), Other = AccessPermissions.ReadExecute)]
         public EntityLifeStage EntityLifeStage { get; internal set; }
 
+        [ViewVariables(VVAccess.ReadOnly)]
         public MetaDataFlags Flags
         {
             get => _flags;


### PR DESCRIPTION
As pointed out in https://github.com/space-wizards/space-station-14/pull/37381 , the system & component methods behave differently if a sprite layer already exists. This PR changes the system method so it behaves like the old component method.

Also includes a fix for the `SpriteComponent._visible` data-field using the incorrect yaml name