### PR TITLE
Mark `NetEntity` as `NotYamlSerializable`

### DIFF
--- a/Robust.Shared/GameObjects/NetEntity.cs
+++ b/Robust.Shared/GameObjects/NetEntity.cs
@@ -13,7 +13,7 @@ namespace Robust.Shared.GameObjects;
 /// <summary>
 /// Network identifier for entities; used by client and server to refer to the same entity where their local <see cref="EntityUid"/> may differ.
 /// </summary>
-[Serializable, NetSerializable, CopyByRef]
+[Serializable, NetSerializable, CopyByRef, NotYamlSerializable]
 public readonly struct NetEntity : IEquatable<NetEntity>, IComparable<NetEntity>, ISpanFormattable
 {
     public readonly int Id;


### PR DESCRIPTION
Adds the `NotYamlSerializable` attribute to `NetEntity`, so the DataDefinition analyzer will prevent it being used as a DataField.

This should not be merged until violations are cleaned up in content - see https://github.com/space-wizards/space-station-14/issues/37464