### PR TITLE
Add new Vertical property to progress bars

### DIFF
--- a/Robust.Client/UserInterface/Controls/ProgressBar.cs
+++ b/Robust.Client/UserInterface/Controls/ProgressBar.cs
@@ -14,6 +14,27 @@ namespace Robust.Client.UserInterface.Controls
         private StyleBox? _backgroundStyleBoxOverride;
         private StyleBox? _foregroundStyleBoxOverride;
 
+        private bool _vertical;
+
+        /// <summary>
+        /// Whether the progress bar is oriented vertically.
+        /// </summary>
+        /// <remarks>
+        /// A vertical progress bar fills from bottom to top.
+        /// </remarks>
+        public bool Vertical
+        {
+            get => _vertical;
+            set
+            {
+                if (_vertical != value)
+                {
+                    _vertical = value;
+                    InvalidateMeasure();
+                }
+            }
+        }
+
         public StyleBox? BackgroundStyleBoxOverride
         {
             get => _backgroundStyleBoxOverride;
@@ -70,11 +91,23 @@ namespace Robust.Client.UserInterface.Controls
             {
                 return;
             }
-            var minSize = fg.MinimumSize;
-            var size = PixelWidth * GetAsRatio() - minSize.X;
-            if (size > 0)
+
+            if (_vertical)
             {
-                fg.Draw(handle, UIBox2.FromDimensions(0, 0, minSize.X + size, PixelHeight), UIScale);
+                var size = PixelHeight * GetAsRatio();
+                if (size > 0)
+                {
+                    fg.Draw(handle, UIBox2.FromDimensions(0, PixelHeight - size, PixelWidth, size), UIScale);
+                }
+            }
+            else
+            {
+                var minSize = fg.MinimumSize;
+                var size = PixelWidth * GetAsRatio() - minSize.X;
+                if (size > 0)
+                {
+                    fg.Draw(handle, UIBox2.FromDimensions(0, 0, minSize.X + size, PixelHeight), UIScale);
+                }
             }
         }
 


### PR DESCRIPTION
This PR adds a new Vertical property to `ProgressBar`, which allows you to specify vertical progress bars for whatever you may need. If no property is specified it simply uses the default horizontal bar.

Required for content PR https://github.com/space-wizards/space-station-14/pull/36708

![Content Client_P6uiY8mQbW](https://github.com/user-attachments/assets/987301af-2f5b-463d-a62c-5a7497e7dedd)

All other progress bars, like in APCs and in the powernet monitor, seem to work fine.

![image](https://github.com/user-attachments/assets/d9434fc2-d535-49f6-8503-29afc42e93ca)
