### PR TITLE
Add `SpriteSystem` dependency to `VisualizerSystem`

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/VisualizerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/VisualizerSystem.cs
@@ -11,6 +11,7 @@ public abstract class VisualizerSystem<T> : EntitySystem
 {
     [Dependency] protected readonly AppearanceSystem AppearanceSystem = default!;
     [Dependency] protected readonly AnimationPlayerSystem AnimationSystem = default!;
+    [Dependency] protected readonly SpriteSystem spriteSystem = default!;
 
     public override void Initialize()
     {

--- a/Robust.Client/GameObjects/EntitySystems/VisualizerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/VisualizerSystem.cs
@@ -11,7 +11,7 @@ public abstract class VisualizerSystem<T> : EntitySystem
 {
     [Dependency] protected readonly AppearanceSystem AppearanceSystem = default!;
     [Dependency] protected readonly AnimationPlayerSystem AnimationSystem = default!;
-    [Dependency] protected readonly SpriteSystem spriteSystem = default!;
+    [Dependency] protected readonly SpriteSystem SpriteSystem = default!;
 
     public override void Initialize()
     {


### PR DESCRIPTION
Now that `SpriteComponent` methods have been deprecated in favor of `SpriteSystem` methods, it makes sense to include a reference to `SpriteSystem` in `VisualizerSystem`, seeing as most visualizers need to manipulate sprites.

I've been fixing up warnings in content and it seems silly to add a `SpriteSystem` dependency to every single one when we could just have one in the base class.