### PR TITLE
Cleanup warnings in `PlacementManager`

### DIFF
--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -47,6 +47,7 @@ namespace Robust.Client.Placement
 
         private SharedMapSystem Maps => EntityManager.System<SharedMapSystem>();
         private SharedTransformSystem XformSystem => EntityManager.System<SharedTransformSystem>();
+        private SpriteSystem Sprite => EntityManager.System<SpriteSystem>();
 
         /// <summary>
         ///     How long before a pending tile change is dropped.
@@ -708,11 +709,11 @@ namespace Robust.Client.Placement
             CurrentPlacementOverlayEntity = null;
         }
 
-        private SpriteComponent SetupPlacementOverlayEntity()
+        private Entity<SpriteComponent> SetupPlacementOverlayEntity()
         {
             EnsureNoPlacementOverlayEntity();
             CurrentPlacementOverlayEntity = EntityManager.SpawnEntity(null, MapCoordinates.Nullspace);
-            return EntityManager.EnsureComponent<SpriteComponent>(CurrentPlacementOverlayEntity.Value);
+            return (CurrentPlacementOverlayEntity.Value, EntityManager.EnsureComponent<SpriteComponent>(CurrentPlacementOverlayEntity.Value));
         }
 
         private void PreparePlacement(string templateName)
@@ -729,10 +730,16 @@ namespace Robust.Client.Placement
                 EntityManager.GetComponent<MetaDataComponent>(CurrentPlacementOverlayEntity.Value));
         }
 
-        public void PreparePlacementSprite(SpriteComponent sprite)
+        public void PreparePlacementSprite(Entity<SpriteComponent> sprite)
         {
             var sc = SetupPlacementOverlayEntity();
-            sc.CopyFrom(sprite);
+            Sprite.CopySprite(sprite.AsNullable(), sc.AsNullable());
+        }
+
+        [Obsolete("Use the Entity<SpriteComponent> overload.")]
+        public void PreparePlacementSprite(SpriteComponent sprite)
+        {
+            PreparePlacementSprite((sprite.Owner, sprite));
         }
 
         public void PreparePlacementTexList(List<IDirectionalTextureProvider>? texs, bool noRot, EntityPrototype? prototype)
@@ -743,27 +750,27 @@ namespace Robust.Client.Placement
                 // This one covers most cases (including Construction)
                 foreach (var v in texs)
                 {
-                    if (v is RSI.State)
+                    if (v is RSI.State st)
                     {
-                        var st = (RSI.State) v;
-                        sc.AddLayer(st.StateId, st.RSI);
+                        Sprite.AddRsiLayer(sc.AsNullable(), st.StateId, st.RSI);
                     }
                     else
                     {
                         // Fallback
-                        sc.AddLayer(v.Default);
+                        Sprite.AddTextureLayer(sc.AsNullable(), v.Default);
                     }
                 }
             }
             else
             {
-                sc.AddLayer(new ResPath("/Textures/Interface/tilebuildoverlay.png"));
+                Sprite.AddTextureLayer(sc.AsNullable(), new ResPath("/Textures/Interface/tilebuildoverlay.png"));
             }
-            sc.NoRotation = noRot;
+
+            sc.Comp.NoRotation = noRot;
 
             if (prototype != null && prototype.TryGetComponent<SpriteComponent>("Sprite", out var spriteComp))
             {
-                sc.Scale = spriteComp.Scale;
+                Sprite.SetScale(sc.AsNullable(), spriteComp.Scale);
             }
 
         }
@@ -771,7 +778,7 @@ namespace Robust.Client.Placement
         private void PreparePlacementTile()
         {
             var sc = SetupPlacementOverlayEntity();
-            sc.AddLayer(new ResPath("/Textures/Interface/tilebuildoverlay.png"));
+            Sprite.AddTextureLayer(sc.AsNullable(), new ResPath("/Textures/Interface/tilebuildoverlay.png"));
 
             IsActive = true;
         }


### PR DESCRIPTION
Fixes 6 warnings from `SpriteComponent` deprecated methods/properties in `PlacementManager`.

Adds an overload of `PlacementManager.PreparePlacementSprite` that takes an `Entity<SpriteComponent>` instead of a `SpriteComponent` and marks the old version as obsolete. Nothing in engine or content appears to call this method, but I'm keeping it around just to be safe.

Similarly, the private method `PlacementManager.SetupPlacementOverlayEntity` now returns an `Entity<SpriteComponent>` instead of a `SpriteComponent`. But it's private, so that's not a breaking change.

Placement preview still working:
<img width="234" alt="Screenshot 2025-05-17 at 2 12 17 PM" src="https://github.com/user-attachments/assets/5f4597c0-aa5d-403b-b5c7-cd28d25a23f5" />

https://github.com/space-wizards/space-station-14/issues/33279