### PR TITLE
Cleanup warning in `Clyde.Sprite`

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
@@ -153,7 +153,7 @@ internal partial class Clyde
 
             // special casing angle = n*pi/2 to avoid box rotation & bounding calculations doesn't seem to give significant speedups.
             data.SpriteScreenBB = TransformCenteredBox(
-                data.Sprite.Bounds,
+                _spriteSystem.GetLocalBounds((data.Uid, data.Sprite)),
                 finalRotation,
                 pos + batch.PreScaleViewOffset,
                 batch.ViewScale);

--- a/Robust.Client/Graphics/Clyde/Clyde.Systems.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Systems.cs
@@ -10,6 +10,7 @@ internal sealed partial class Clyde
     private MapSystem _mapSystem = default!;
     private LightTreeSystem _lightTreeSystem = default!;
     private TransformSystem _transformSystem = default!;
+    private SpriteSystem _spriteSystem = default!;
     private SpriteTreeSystem _spriteTreeSystem = default!;
     private ClientOccluderSystem _occluderSystem = default!;
 
@@ -24,6 +25,7 @@ internal sealed partial class Clyde
         _mapSystem = _entitySystemManager.GetEntitySystem<MapSystem>();
         _lightTreeSystem = _entitySystemManager.GetEntitySystem<LightTreeSystem>();
         _transformSystem = _entitySystemManager.GetEntitySystem<TransformSystem>();
+        _spriteSystem = _entitySystemManager.GetEntitySystem<SpriteSystem>();
         _spriteTreeSystem = _entitySystemManager.GetEntitySystem<SpriteTreeSystem>();
         _occluderSystem = _entitySystemManager.GetEntitySystem<ClientOccluderSystem>();
     }
@@ -33,6 +35,7 @@ internal sealed partial class Clyde
         _mapSystem = null!;
         _lightTreeSystem = null!;
         _transformSystem = null!;
+        _spriteSystem = null!;
         _spriteTreeSystem = null!;
         _occluderSystem = null!;
     }


### PR DESCRIPTION
Fixes 1 warning from `SpriteComponent.Bounds` deprecation in `Clyde.Sprite`

Calls `SpriteSystem.GetLocalBounds` instead.

Adds a reference to `SpriteSystem` in `Clyde.Systems`.

https://github.com/space-wizards/space-station-14/issues/33279