### PR TITLE
Cleanup warning in `SpriteBoundsOverlay`

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteBoundsOverlay.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteBoundsOverlay.cs
@@ -59,10 +59,9 @@ namespace Robust.Client.GameObjects
     {
         public override OverlaySpace Space => OverlaySpace.WorldSpace;
 
-        private readonly IEntityManager _entMan = entMan;
-        private SharedTransformSystem XformSystem => _entMan.System<SharedTransformSystem>();
-        private SpriteSystem SpriteSystem => _entMan.System<SpriteSystem>();
-        private SpriteTreeSystem RenderTree => _entMan.System<SpriteTreeSystem>();
+        private readonly SharedTransformSystem _xformSystem = entMan.System<SharedTransformSystem>();
+        private readonly SpriteSystem _spriteSystem = entMan.System<SpriteSystem>();
+        private readonly SpriteTreeSystem _renderTree = entMan.System<SpriteTreeSystem>();
 
         protected internal override void Draw(in OverlayDrawArgs args)
         {
@@ -70,11 +69,11 @@ namespace Robust.Client.GameObjects
             var currentMap = args.MapId;
             var viewport = args.WorldBounds;
 
-            foreach (var entry in RenderTree.QueryAabb(currentMap, viewport))
+            foreach (var entry in _renderTree.QueryAabb(currentMap, viewport))
             {
                 var (sprite, xform) = entry;
-                var (worldPos, worldRot) = XformSystem.GetWorldPositionRotation(xform);
-                var bounds = SpriteSystem.CalculateBounds((entry.Uid, sprite), worldPos, worldRot, args.Viewport.Eye?.Rotation ?? default);
+                var (worldPos, worldRot) = _xformSystem.GetWorldPositionRotation(xform);
+                var bounds = _spriteSystem.CalculateBounds((entry.Uid, sprite), worldPos, worldRot, args.Viewport.Eye?.Rotation ?? default);
 
                 // Get scaled down bounds used to indicate the "south" of a sprite.
                 var localBound = bounds.Box;

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteBoundsOverlay.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteBoundsOverlay.cs
@@ -24,9 +24,7 @@ namespace Robust.Client.GameObjects
 
     public sealed class SpriteBoundsSystem : EntitySystem
     {
-        [Dependency] private readonly SharedTransformSystem _xformSystem = default!;
         [Dependency] private readonly IOverlayManager _overlayManager = default!;
-        [Dependency] private readonly SpriteTreeSystem _spriteTree = default!;
 
         private SpriteBoundsOverlay? _overlay;
 
@@ -42,7 +40,7 @@ namespace Robust.Client.GameObjects
                 if (_enabled)
                 {
                     DebugTools.AssertNull(_overlay);
-                    _overlay = new SpriteBoundsOverlay(_spriteTree, _xformSystem);
+                    _overlay = new SpriteBoundsOverlay(EntityManager);
                     _overlayManager.AddOverlay(_overlay);
                 }
                 else
@@ -57,18 +55,14 @@ namespace Robust.Client.GameObjects
         private bool _enabled;
     }
 
-    public sealed class SpriteBoundsOverlay : Overlay
+    public sealed class SpriteBoundsOverlay(IEntityManager entMan) : Overlay
     {
         public override OverlaySpace Space => OverlaySpace.WorldSpace;
 
-        private readonly SharedTransformSystem _xformSystem;
-        private SpriteTreeSystem _renderTree;
-
-        public SpriteBoundsOverlay(SpriteTreeSystem renderTree, SharedTransformSystem xformSystem)
-        {
-            _renderTree = renderTree;
-            _xformSystem = xformSystem;
-        }
+        private readonly IEntityManager _entMan = entMan;
+        private SharedTransformSystem XformSystem => _entMan.System<SharedTransformSystem>();
+        private SpriteSystem SpriteSystem => _entMan.System<SpriteSystem>();
+        private SpriteTreeSystem RenderTree => _entMan.System<SpriteTreeSystem>();
 
         protected internal override void Draw(in OverlayDrawArgs args)
         {
@@ -76,10 +70,11 @@ namespace Robust.Client.GameObjects
             var currentMap = args.MapId;
             var viewport = args.WorldBounds;
 
-            foreach (var (sprite, xform) in _renderTree.QueryAabb(currentMap, viewport))
+            foreach (var entry in RenderTree.QueryAabb(currentMap, viewport))
             {
-                var (worldPos, worldRot) = _xformSystem.GetWorldPositionRotation(xform);
-                var bounds = sprite.CalculateRotatedBoundingBox(worldPos, worldRot, args.Viewport.Eye?.Rotation ?? default);
+                var (sprite, xform) = entry;
+                var (worldPos, worldRot) = XformSystem.GetWorldPositionRotation(xform);
+                var bounds = SpriteSystem.CalculateBounds((entry.Uid, sprite), worldPos, worldRot, args.Viewport.Eye?.Rotation ?? default);
 
                 // Get scaled down bounds used to indicate the "south" of a sprite.
                 var localBound = bounds.Box;


### PR DESCRIPTION
Fixes a `SpriteComponent` obsolete warning in `SpriteBoundsOverlay`.

I'm doing this one as a single PR because it does some minor refactoring too.

Specifically, instead of taking in each dependency as a constructor argument, the `SpriteBoundsOverlay` class now just takes in `IEntityManager` in its constructor and retrieves the specific systems from that when it needs them.

<img width="1272" alt="Screenshot 2025-05-18 at 11 57 46 AM" src="https://github.com/user-attachments/assets/67ad0895-d0d5-4948-a84f-968fe18eb107" />

https://github.com/space-wizards/space-station-14/issues/33279