### PR TITLE
Convert some physics code from `PhysicsComponent` to `Entity<PhysicsComponent>`

### DIFF
--- a/Robust.Client/Physics/DebugPhysicsIslandSystem.cs
+++ b/Robust.Client/Physics/DebugPhysicsIslandSystem.cs
@@ -47,7 +47,7 @@ namespace Robust.Client.Physics
          * This will draw above every body involved in a particular island solve.
          */
 
-        public readonly Queue<(TimeSpan Time, List<PhysicsComponent> Bodies)> IslandSolve = new();
+        public readonly Queue<(TimeSpan Time, List<Entity<PhysicsComponent>> Bodies)> IslandSolve = new();
         public const float SolveDuration = 0.1f;
 
         public override void Initialize()

--- a/Robust.Client/Physics/PhysicsSystem.cs
+++ b/Robust.Client/Physics/PhysicsSystem.cs
@@ -49,19 +49,19 @@ namespace Robust.Client.Physics
             base.Cleanup(component, frameTime);
         }
 
-        protected override void UpdateLerpData(PhysicsMapComponent component, List<PhysicsComponent> bodies, EntityQuery<TransformComponent> xformQuery)
+        protected override void UpdateLerpData(PhysicsMapComponent component, List<Entity<PhysicsComponent>> bodies, EntityQuery<TransformComponent> xformQuery)
         {
-            foreach (var body in bodies)
+            foreach (var (uid, body) in bodies)
             {
                 if (body.BodyType == BodyType.Static ||
-                    component.LerpData.TryGetValue(body.Owner, out var lerpData) ||
-                    !xformQuery.TryGetComponent(body.Owner, out var xform) ||
+                    component.LerpData.TryGetValue(uid, out var lerpData) ||
+                    !xformQuery.TryGetComponent(uid, out var xform) ||
                     lerpData.ParentUid == xform.ParentUid)
                 {
                     continue;
                 }
 
-                component.LerpData[xform.Owner] = (xform.ParentUid, xform.LocalPosition, xform.LocalRotation);
+                component.LerpData[uid] = (xform.ParentUid, xform.LocalPosition, xform.LocalRotation);
             }
         }
 

--- a/Robust.Client/Physics/PhysicsSystem.cs
+++ b/Robust.Client/Physics/PhysicsSystem.cs
@@ -31,13 +31,13 @@ namespace Robust.Client.Physics
             // (and serializing it over the network isn't necessary?)
             // This is a client-only problem.
             // Also need to suss out having the client build the island anyway and just... not solving it?
-            foreach (var body in component.AwakeBodies)
+            foreach (var (uid, body) in component.AwakeBodies)
             {
                 if (!body.SleepingAllowed || body.LinearVelocity.Length() > LinearToleranceSqr / 2f || body.AngularVelocity * body.AngularVelocity > AngularToleranceSqr / 2f) continue;
                 body.SleepTime += frameTime;
                 if (body.SleepTime > TimeToSleep)
                 {
-                    toRemove.Add(new Entity<PhysicsComponent>(body.Owner, body));
+                    toRemove.Add(new Entity<PhysicsComponent>(uid, body));
                 }
             }
 

--- a/Robust.Shared/Physics/Dynamics/PhysicsMapComponent.cs
+++ b/Robust.Shared/Physics/Dynamics/PhysicsMapComponent.cs
@@ -20,7 +20,9 @@
 * 3. This notice may not be removed or altered from any source distribution.
 */
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
@@ -51,7 +53,7 @@ public sealed partial class PhysicsMapComponent : Component
     ///     All awake bodies on this map.
     /// </summary>
     [ViewVariables]
-    public readonly HashSet<PhysicsComponent> AwakeBodies = new();
+    public readonly HashSet<Entity<PhysicsComponent>> AwakeBodies = new();
 
     /// <summary>
     ///     Store last tick's invDT

--- a/Robust.Shared/Physics/Dynamics/PhysicsMapComponent.cs
+++ b/Robust.Shared/Physics/Dynamics/PhysicsMapComponent.cs
@@ -20,9 +20,7 @@
 * 3. This notice may not be removed or altered from any source distribution.
 */
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;

--- a/Robust.Shared/Physics/IslandSolveMessage.cs
+++ b/Robust.Shared/Physics/IslandSolveMessage.cs
@@ -4,13 +4,8 @@ using Robust.Shared.Physics.Components;
 
 namespace Robust.Shared.Physics
 {
-    internal sealed class IslandSolveMessage : EntityEventArgs
+    internal sealed class IslandSolveMessage(List<Entity<PhysicsComponent>> bodies) : EntityEventArgs
     {
-        public List<PhysicsComponent> Bodies { get; }
-
-        public IslandSolveMessage(List<PhysicsComponent> bodies)
-        {
-            Bodies = bodies;
-        }
+        public List<Entity<PhysicsComponent>> Bodies { get; } = bodies;
     }
 }

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
@@ -978,7 +978,7 @@ public abstract partial class SharedPhysicsSystem
 
             var xform = xformQuery.GetComponent(bodyUid);
             var parentXform = xformQuery.GetComponent(xform.ParentUid);
-            var (_, parentRot, parentInvMatrix) = parentXform.GetWorldPositionRotationInvMatrix(xformQuery);
+            var (_, parentRot, parentInvMatrix) = _transform.GetWorldPositionRotationInvMatrix(parentXform);
             var worldRot = (float) (parentRot + xform._localRotation);
 
             var angle = angles[i];

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Map.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Map.cs
@@ -29,7 +29,7 @@ public partial class SharedPhysicsSystem
         }
 
         DebugTools.Assert(body.Awake);
-        map.AwakeBodies.Add(body);
+        map.AwakeBodies.Add((uid, body));
     }
 
     internal void AddAwakeBody(EntityUid uid, PhysicsComponent body, EntityUid mapUid, PhysicsMapComponent? map = null)
@@ -40,7 +40,7 @@ public partial class SharedPhysicsSystem
 
     internal void RemoveSleepBody(EntityUid uid, PhysicsComponent body, PhysicsMapComponent? map = null)
     {
-        map?.AwakeBodies.Remove(body);
+        map?.AwakeBodies.Remove((uid, body));
     }
 
     internal void RemoveSleepBody(EntityUid uid, PhysicsComponent body, EntityUid mapUid, PhysicsMapComponent? map = null)

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
@@ -239,7 +239,7 @@ namespace Robust.Shared.Physics.Systems
                     DebugTools.Assert(body.Awake);
                 }
                 else
-                    DebugTools.Assert(oldMap?.AwakeBodies.Contains(body) != true);
+                    DebugTools.Assert(oldMap?.AwakeBodies.Contains((uid, body)) != true);
             }
 
             _joints.ClearJoints(uid);

--- a/Robust.UnitTesting/Shared/Physics/PhysicsMap_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/PhysicsMap_Test.cs
@@ -46,7 +46,7 @@ public sealed class PhysicsMap_Test
         physSystem.SetSleepingAllowed(parent, parentBody, false);
         fixtureSystem.CreateFixture(parent, "fix1", new Fixture(new PhysShapeCircle(0.5f), 0, 0, false), body: parentBody);
         physSystem.WakeBody(parent);
-        Assert.That(physicsMap.AwakeBodies, Does.Contain(parentBody));
+        Assert.That(physicsMap.AwakeBodies, Does.Contain(new Entity<PhysicsComponent>(parent, parentBody)));
 
         var child = entManager.SpawnEntity(null, new EntityCoordinates(parent, Vector2.Zero));
         var childBody = entManager.AddComponent<PhysicsComponent>(child);
@@ -56,7 +56,7 @@ public sealed class PhysicsMap_Test
         fixtureSystem.CreateFixture(child, "fix1", new Fixture(new PhysShapeCircle(0.5f), 0, 0, false), body: childBody);
         physSystem.WakeBody(child, body: childBody);
 
-        Assert.That(physicsMap.AwakeBodies, Does.Contain(childBody));
+        Assert.That(physicsMap.AwakeBodies, Does.Contain(new Entity<PhysicsComponent>(child, childBody)));
 
         xformSystem.SetParent(parent, parentXform, mapUid2);
 


### PR DESCRIPTION
Updates some parts of the physics code that use `PhysicsComponent` to use `Entity<PhysicsComponent>` instead. This allows the removal of a bunch of `.Owner` uses throughout the physics code.

This is a breaking change for `PhysicsMapComponent`, but all other changes are internal.

Requires https://github.com/space-wizards/space-station-14/pull/37647 for one change in content.

Note that while I have tested that things still work, I have not done any performance comparison to the old code. I would expect that the change from a single component to an `Entity` wouldn't be too significant, but physics code is pretty performance-sensitive, so this is something to consider.

[PZW](https://github.com/space-wizards/space-station-14/issues/33279)

## Breaking changes
`PhysicsMapComponent.AwakeBodies` is now a `HashSet<Entity<PhysicsComponent>>` instead of a `HashSet<PhysicsComponent>`.