### PR TITLE
fix GetMapLinearVelocity

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Velocities.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Velocities.cs
@@ -89,6 +89,8 @@ public abstract partial class SharedPhysicsSystem
         if (!_xformQuery.Resolve(uid, ref xform))
             return Vector2.Zero;
 
+        PhysicsQuery.Resolve(uid, ref component);
+
         var parent = xform.ParentUid;
         var localPos = xform.LocalPosition;
 

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Velocities.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Velocities.cs
@@ -89,7 +89,7 @@ public abstract partial class SharedPhysicsSystem
         if (!_xformQuery.Resolve(uid, ref xform))
             return Vector2.Zero;
 
-        PhysicsQuery.Resolve(uid, ref component);
+        PhysicsQuery.Resolve(uid, ref component, false);
 
         var parent = xform.ParentUid;
         var localPos = xform.LocalPosition;
@@ -133,13 +133,12 @@ public abstract partial class SharedPhysicsSystem
         PhysicsComponent? component = null,
         TransformComponent? xform = null)
     {
-        if (!PhysicsQuery.Resolve(uid, ref component))
-            return 0;
-
         if (!_xformQuery.Resolve(uid, ref xform))
             return 0f;
 
-        var angularVelocity = component.AngularVelocity;
+        PhysicsQuery.Resolve(uid, ref component, false);
+
+        var angularVelocity = component?.AngularVelocity ?? 0;
 
         while (xform.ParentUid != xform.MapUid && xform.ParentUid.IsValid())
         {
@@ -162,18 +161,17 @@ public abstract partial class SharedPhysicsSystem
         PhysicsComponent? component = null,
         TransformComponent? xform = null)
     {
-        if (!PhysicsQuery.Resolve(uid, ref component))
-            return (Vector2.Zero, 0);
-
         if (!_xformQuery.Resolve(uid, ref xform))
             return (Vector2.Zero, 0);
+
+        PhysicsQuery.Resolve(uid, ref component, false);
 
         var parent = xform.ParentUid;
 
         var localPos = xform.LocalPosition;
 
-        var linearVelocity = component.LinearVelocity;
-        var angularVelocity = component.AngularVelocity;
+        var linearVelocity = component?.LinearVelocity ?? Vector2.Zero;
+        var angularVelocity = component?.AngularVelocity ?? 0;
         Vector2 linearVelocityAngularContribution = Vector2.Zero;
 
         while (parent != xform.MapUid && parent.IsValid())


### PR DESCRIPTION
It was missing a resolve, causing the given entity's velocity to be ignored for the calculation, but only if the component was not passed in. The integration test did not catch this because it does pass the component in everywhere.

Notably among a few other bugs this fixes the doppler effect for sounds not working:
before


https://github.com/user-attachments/assets/dcdcb294-8234-48e7-b76d-1ec9a3d3dd04



![doppler_broken](https://github.com/user-attachments/assets/4509a3c5-4af1-42ea-aa7c-15cd5ac48579)

after


https://github.com/user-attachments/assets/bdd3149f-9cbc-4e04-8955-54afcfbdee3b



![doppler_fixed](https://github.com/user-attachments/assets/f373e96e-f28d-4b64-b224-1e7ea1651d9e)

