### PR TITLE
Fix instances of warning CS0162

### DIFF
--- a/Robust.Shared/EntitySerialization/EntityDeserializer.cs
+++ b/Robust.Shared/EntitySerialization/EntityDeserializer.cs
@@ -556,9 +556,10 @@ public sealed class EntityDeserializer :
             {
 #if !EXCEPTION_TOLERANCE
                 throw;
-#endif
+#else
                 ToDelete.Add(entity);
                 _log.Error($"Encountered error while loading entity. Yaml uid: {data.YamlId}. Loaded loaded entity: {EntMan.ToPrettyString(entity)}. Error:\n{e}.");
+#endif
             }
         }
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -217,9 +217,10 @@ public abstract partial class SharedTransformSystem
             {
 #if !EXCEPTION_TOLERANCE
                 throw new Exception("Transform is initialising before map ids have been assigned?");
-#endif
+#else
                 Log.Error($"Transform is initialising before map ids have been assigned?");
                 _map.AssignMapId((uid, mapComp));
+#endif
             }
 
             xform.MapUid = uid;


### PR DESCRIPTION
Fixes 2 instances of warning CS0162 (unreachable code detected).

The same logic is used here as was used in https://github.com/space-wizards/RobustToolbox/pull/5774 - add an `#else` directive so the unreachable code isn't included when the `#if` directive is true.

[PZW](https://github.com/space-wizards/space-station-14/issues/33279)