### PR TITLE
optimize ToMapCoordinates

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Coordinates.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Coordinates.cs
@@ -53,8 +53,14 @@ public abstract partial class SharedTransformSystem
             return MapCoordinates.Nullspace;
         }
 
-        var worldPos = Vector2.Transform(coordinates.Position, GetWorldMatrix(xform));
-        return new MapCoordinates(worldPos, xform.MapID);
+        Vector2 pos = xform._localRotation.RotateVec(coordinates.Position) + xform._localPosition;
+
+        while (xform.ParentUid != xform.MapUid && xform.ParentUid.IsValid())
+        {
+            xform = XformQuery.GetComponent(xform.ParentUid);
+            pos = xform._localRotation.RotateVec(pos) + xform._localPosition;
+        }
+        return new MapCoordinates(pos, xform.MapID);
     }
 
     /// <summary>
@@ -65,6 +71,41 @@ public abstract partial class SharedTransformSystem
     {
         var eCoords = GetCoordinates(coordinates);
         return ToMapCoordinates(eCoords);
+    }
+
+    /// <summary>
+    /// Converts entity-local coordinates into map terms.
+    /// The same as ToMapCoordinates(coordinates, logError).Position, but doesn't have to construct the MapCoordinates first.
+    /// </summary>
+    public Vector2 ToWorldPosition(EntityCoordinates coordinates, bool logError = true)
+    {
+        if (!TryComp(coordinates.EntityId, out TransformComponent? xform))
+        {
+            if (logError)
+                Log.Error($"Attempted to convert coordinates with invalid entity: {coordinates}. Trace: {Environment.StackTrace}");
+            return Vector2.Zero;
+        }
+
+        Vector2 pos = xform._localRotation.RotateVec(coordinates.Position) + xform._localPosition;
+
+        while (xform.ParentUid != xform.MapUid && xform.ParentUid.IsValid())
+        {
+            xform = XformQuery.GetComponent(xform.ParentUid);
+            pos = xform._localRotation.RotateVec(pos) + xform._localPosition;
+        }
+
+        return pos;
+    }
+
+    /// <summary>
+    /// Converts entity-local coordinates into map terms.
+    /// The same as ToMapCoordinates(coordinates).Position, but doesn't have to construct the MapCoordinates first.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Vector2 ToWorldPosition(NetCoordinates coordinates)
+    {
+        var eCoords = GetCoordinates(coordinates);
+        return ToWorldPosition(eCoords);
     }
 
     /// <summary>

--- a/Robust.UnitTesting/Shared/Map/EntityCoordinates_Tests.cs
+++ b/Robust.UnitTesting/Shared/Map/EntityCoordinates_Tests.cs
@@ -248,12 +248,15 @@ namespace Robust.UnitTesting.Shared.Map
             var grid = mapManager.CreateGridEntity(mapId);
             var gridEnt = grid.Owner;
             var newEnt = entityManager.CreateEntityUninitialized(null, new EntityCoordinates(grid, entPos));
+            var newXform = entityManager.GetComponent<TransformComponent>(newEnt);
 
-            Assert.That(xformSys.ToMapCoordinates(entityManager.GetComponent<TransformComponent>(newEnt).Coordinates), Is.EqualTo(new MapCoordinates(entPos, mapId)));
+            Assert.That(xformSys.ToMapCoordinates(newXform.Coordinates), Is.EqualTo(new MapCoordinates(entPos, mapId)));
+            Assert.That(xformSys.ToMapCoordinates(newXform.Coordinates).Position, Is.EqualTo(xformSys.ToWorldPosition(newXform.Coordinates)));
 
             xformSys.SetLocalPosition(gridEnt, entityManager.GetComponent<TransformComponent>(gridEnt).LocalPosition + gridPos);
 
-            Assert.That(xformSys.ToMapCoordinates(entityManager.GetComponent<TransformComponent>(newEnt).Coordinates), Is.EqualTo(new MapCoordinates(entPos + gridPos, mapId)));
+            Assert.That(xformSys.ToMapCoordinates(newXform.Coordinates), Is.EqualTo(new MapCoordinates(entPos + gridPos, mapId)));
+            Assert.That(xformSys.ToMapCoordinates(newXform.Coordinates).Position, Is.EqualTo(xformSys.ToWorldPosition(newXform.Coordinates)));
         }
 
         [Test]


### PR DESCRIPTION
Basically instead of 
$v_{map} = (... W_3 W_2 W_1)v_{local}$
we are doing
$v_{map} = (... W_3 (W_2 (W_1 v_{local})))$
which is mathematically equivalent.
The $W_i$ are the coordinate transformations from an entity to its parent's coordinates.
If you compare this to the previously used `GetWorldPositionRotation`
![grafik](https://github.com/user-attachments/assets/e63a0afa-0540-437b-b510-288dcd66d4ae)
it is mostly identical, we just do the final transformation first, but we don't have to sum up the angle along the way.

This also skips this part of the previous code where the matrix was created in the end
![grafik](https://github.com/user-attachments/assets/04cd3a7a-c352-4f2d-a6b3-5271276cb5e8)
but that optimization was a little dubious because of floating point errors.

Might make sense to benchmark this somehow before merging.

I also added a `ToWorldPosition` method with is equal to `toMapCoordinates(...).Position`, but does not create the map coordinates first. Mostly to have nicer syntax and to have an equivalent to `GetWorldPosition`.