### PR TITLE
Update SpriteSystem.Bounds.cs

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Bounds.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Bounds.cs
@@ -10,7 +10,7 @@ using static Robust.Client.GameObjects.SpriteComponent;
 
 namespace Robust.Client.GameObjects;
 
-// This partial class contains code related to updating a sprites bounding boxes and its position in the sprite tree.
+// This partial class contains code related to updating a sprite's bounding box and its position in the sprite tree.
 public sealed partial class SpriteSystem
 {
     /// <summary>
@@ -19,11 +19,8 @@ public sealed partial class SpriteSystem
     /// </summary>
     public Box2 GetLocalBounds(Entity<SpriteComponent> sprite)
     {
-        if (!sprite.Comp.BoundsDirty)
-        {
-            DebugTools.Assert(sprite.Comp.Layers.All(x => !x.BoundsDirty || !x.Drawn));
+        if (!sprite.Comp.BoundsDirty && sprite.Comp.Layers.All(x => !x.BoundsDirty || !x.Drawn))
             return sprite.Comp._bounds;
-        }
 
         var bounds = new Box2();
         foreach (var layer in sprite.Comp.Layers)


### PR DESCRIPTION
Original issue: When (older?) maps were loaded in the Space Station 14 dev environment, and subfloors were enabled, it would crash with a DebugAssertionError pointing to these lines
![image](https://github.com/user-attachments/assets/0e8ed4bb-543f-430c-8e11-95a9166a5810)

According to an issue opened on Space Station 14 it was related to the new Pipe system
(See [SS14 issue 37448](<https://github.com/space-wizards/RobustToolbox/issues/6002>))

I went ahead and changed it to this, preventing the crash while still functioning properly
(I also cleaned up the comment)
![image](https://github.com/user-attachments/assets/c347d9b2-0680-4d99-b51d-bfa2d9ebc51e)

Let me know if this will have any issues!
