### PR TITLE
AudioSystem logging extension

### DIFF
--- a/Robust.Client/Audio/AudioSystem.cs
+++ b/Robust.Client/Audio/AudioSystem.cs
@@ -582,7 +582,17 @@ public sealed partial class AudioSystem : SharedAudioSystem
     {
         if (TerminatingOrDeleted(entity))
         {
-            Log.Error($"Tried to play coordinates audio on a terminating / deleted entity {ToPrettyString(entity)}");
+            string soundInfo = "unknown sound";
+
+            if (specifier != null)
+            {
+                if (specifier is ResolvedPathSpecifier pathSpec)
+                    soundInfo = $"path: {pathSpec.Path}";
+                else if (specifier is ResolvedCollectionSpecifier collSpec)
+                    soundInfo = $"collection: {collSpec.Collection}, index: {collSpec.Index}";
+            }
+
+            Log.Error($"Tried to play coordinates audio on a terminating / deleted entity {ToPrettyString(entity)}. Sound: {soundInfo}. Trace: {Environment.StackTrace}");
             return null;
         }
 
@@ -626,7 +636,17 @@ public sealed partial class AudioSystem : SharedAudioSystem
     {
         if (TerminatingOrDeleted(coordinates.EntityId))
         {
-            Log.Error($"Tried to play coordinates audio on a terminating / deleted entity {ToPrettyString(coordinates.EntityId)}");
+            string soundInfo = "unknown sound";
+
+            if (specifier != null)
+            {
+                if (specifier is ResolvedPathSpecifier pathSpec)
+                    soundInfo = $"path: {pathSpec.Path}";
+                else if (specifier is ResolvedCollectionSpecifier collSpec)
+                    soundInfo = $"collection: {collSpec.Collection}, index: {collSpec.Index}";
+            }
+
+            Log.Error($"Tried to play coordinates audio on a terminating / deleted entity {ToPrettyString(coordinates.EntityId)}. Sound: {soundInfo}. Trace: {Environment.StackTrace}");
             return null;
         }
 

--- a/Robust.Client/Audio/AudioSystem.cs
+++ b/Robust.Client/Audio/AudioSystem.cs
@@ -582,7 +582,7 @@ public sealed partial class AudioSystem : SharedAudioSystem
     {
         if (TerminatingOrDeleted(entity))
         {
-            LogAudioError(specifier, entity);
+            LogAudioPlaybackOnInvalidEntity(specifier, entity);
             return null;
         }
 
@@ -626,7 +626,7 @@ public sealed partial class AudioSystem : SharedAudioSystem
     {
         if (TerminatingOrDeleted(coordinates.EntityId))
         {
-            LogAudioError(specifier, coordinates.EntityId);
+            LogAudioPlaybackOnInvalidEntity(specifier, coordinates.EntityId);
             return null;
         }
 
@@ -753,9 +753,9 @@ public sealed partial class AudioSystem : SharedAudioSystem
         return _resourceCache.GetResource<AudioResource>(filename).AudioStream.Length;
     }
 
-    private void LogAudioError(ResolvedSoundSpecifier? specifier, EntityUid entityId)
+    private void LogAudioPlaybackOnInvalidEntity(ResolvedSoundSpecifier? specifier, EntityUid entityId)
     {
-        var soundInfo = specifier?.GetDebugString() ?? "unknown sound";
+        var soundInfo = specifier?.ToString() ?? "unknown sound";
         Log.Error($"Tried to play coordinates audio on a terminating / deleted entity {ToPrettyString(entityId)}. Sound: {soundInfo}. Trace: {Environment.StackTrace}");
     }
 

--- a/Robust.Client/Audio/AudioSystem.cs
+++ b/Robust.Client/Audio/AudioSystem.cs
@@ -582,17 +582,7 @@ public sealed partial class AudioSystem : SharedAudioSystem
     {
         if (TerminatingOrDeleted(entity))
         {
-            string soundInfo = "unknown sound";
-
-            if (specifier != null)
-            {
-                if (specifier is ResolvedPathSpecifier pathSpec)
-                    soundInfo = $"path: {pathSpec.Path}";
-                else if (specifier is ResolvedCollectionSpecifier collSpec)
-                    soundInfo = $"collection: {collSpec.Collection}, index: {collSpec.Index}";
-            }
-
-            Log.Error($"Tried to play coordinates audio on a terminating / deleted entity {ToPrettyString(entity)}. Sound: {soundInfo}. Trace: {Environment.StackTrace}");
+            LogAudioError(specifier, entity);
             return null;
         }
 
@@ -636,17 +626,7 @@ public sealed partial class AudioSystem : SharedAudioSystem
     {
         if (TerminatingOrDeleted(coordinates.EntityId))
         {
-            string soundInfo = "unknown sound";
-
-            if (specifier != null)
-            {
-                if (specifier is ResolvedPathSpecifier pathSpec)
-                    soundInfo = $"path: {pathSpec.Path}";
-                else if (specifier is ResolvedCollectionSpecifier collSpec)
-                    soundInfo = $"collection: {collSpec.Collection}, index: {collSpec.Index}";
-            }
-
-            Log.Error($"Tried to play coordinates audio on a terminating / deleted entity {ToPrettyString(coordinates.EntityId)}. Sound: {soundInfo}. Trace: {Environment.StackTrace}");
+            LogAudioError(specifier, coordinates.EntityId);
             return null;
         }
 
@@ -771,6 +751,12 @@ public sealed partial class AudioSystem : SharedAudioSystem
     protected override TimeSpan GetAudioLengthImpl(string filename)
     {
         return _resourceCache.GetResource<AudioResource>(filename).AudioStream.Length;
+    }
+
+    private void LogAudioError(ResolvedSoundSpecifier? specifier, EntityUid entityId)
+    {
+        var soundInfo = specifier?.GetDebugString() ?? "unknown sound";
+        Log.Error($"Tried to play coordinates audio on a terminating / deleted entity {ToPrettyString(entityId)}. Sound: {soundInfo}. Trace: {Environment.StackTrace}");
     }
 
     #region Jobs

--- a/Robust.Server/Audio/AudioSystem.cs
+++ b/Robust.Server/Audio/AudioSystem.cs
@@ -137,7 +137,7 @@ public sealed partial class AudioSystem : SharedAudioSystem
 
         if (TerminatingOrDeleted(coordinates.EntityId))
         {
-            LogAudioError(specifier, coordinates.EntityId);
+            LogAudioPlaybackOnInvalidEntity(specifier, coordinates.EntityId);
             return null;
         }
 
@@ -160,7 +160,7 @@ public sealed partial class AudioSystem : SharedAudioSystem
 
         if (TerminatingOrDeleted(coordinates.EntityId))
         {
-            LogAudioError(specifier, coordinates.EntityId);
+            LogAudioPlaybackOnInvalidEntity(specifier, coordinates.EntityId);
             return null;
         }
 
@@ -282,9 +282,9 @@ public sealed partial class AudioSystem : SharedAudioSystem
         // TODO: Yeah remove this...
     }
 
-    private void LogAudioError(ResolvedSoundSpecifier? specifier, EntityUid entityId)
+    private void LogAudioPlaybackOnInvalidEntity(ResolvedSoundSpecifier? specifier, EntityUid entityId)
     {
-        var soundInfo = specifier?.GetDebugString() ?? "unknown sound";
+        var soundInfo = specifier?.ToString() ?? "unknown sound";
         Log.Error($"Tried to play coordinates audio on a terminating / deleted entity {ToPrettyString(entityId)}. Sound: {soundInfo}. Trace: {Environment.StackTrace}");
     }
 }

--- a/Robust.Server/Audio/AudioSystem.cs
+++ b/Robust.Server/Audio/AudioSystem.cs
@@ -137,14 +137,7 @@ public sealed partial class AudioSystem : SharedAudioSystem
 
         if (TerminatingOrDeleted(coordinates.EntityId))
         {
-            string soundInfo = "unknown sound";
-
-            if (specifier is ResolvedPathSpecifier pathSpec)
-                soundInfo = $"path: {pathSpec.Path}";
-            else if (specifier is ResolvedCollectionSpecifier collSpec)
-                soundInfo = $"collection: {collSpec.Collection}, index: {collSpec.Index}";
-
-            Log.Error($"Tried to play coordinates audio on a terminating / deleted entity {ToPrettyString(coordinates.EntityId)}. Sound: {soundInfo}. Trace: {Environment.StackTrace}");
+            LogAudioError(specifier, coordinates.EntityId);
             return null;
         }
 
@@ -167,14 +160,7 @@ public sealed partial class AudioSystem : SharedAudioSystem
 
         if (TerminatingOrDeleted(coordinates.EntityId))
         {
-            string soundInfo = "unknown sound";
-
-            if (specifier is ResolvedPathSpecifier pathSpec)
-                soundInfo = $"path: {pathSpec.Path}";
-            else if (specifier is ResolvedCollectionSpecifier collSpec)
-                soundInfo = $"collection: {collSpec.Collection}, index: {collSpec.Index}";
-
-            Log.Error($"Tried to play coordinates audio on a terminating / deleted entity {ToPrettyString(coordinates.EntityId)}. Sound: {soundInfo}. Trace: {Environment.StackTrace}");
+            LogAudioError(specifier, coordinates.EntityId);
             return null;
         }
 
@@ -294,5 +280,11 @@ public sealed partial class AudioSystem : SharedAudioSystem
     public override void LoadStream<T>(Entity<AudioComponent> entity, T stream)
     {
         // TODO: Yeah remove this...
+    }
+
+    private void LogAudioError(ResolvedSoundSpecifier? specifier, EntityUid entityId)
+    {
+        var soundInfo = specifier?.GetDebugString() ?? "unknown sound";
+        Log.Error($"Tried to play coordinates audio on a terminating / deleted entity {ToPrettyString(coordinates.EntityId)}. Sound: {soundInfo}. Trace: {Environment.StackTrace}");
     }
 }

--- a/Robust.Server/Audio/AudioSystem.cs
+++ b/Robust.Server/Audio/AudioSystem.cs
@@ -285,6 +285,6 @@ public sealed partial class AudioSystem : SharedAudioSystem
     private void LogAudioError(ResolvedSoundSpecifier? specifier, EntityUid entityId)
     {
         var soundInfo = specifier?.GetDebugString() ?? "unknown sound";
-        Log.Error($"Tried to play coordinates audio on a terminating / deleted entity {ToPrettyString(coordinates.EntityId)}. Sound: {soundInfo}. Trace: {Environment.StackTrace}");
+        Log.Error($"Tried to play coordinates audio on a terminating / deleted entity {ToPrettyString(entityId)}. Sound: {soundInfo}. Trace: {Environment.StackTrace}");
     }
 }

--- a/Robust.Server/Audio/AudioSystem.cs
+++ b/Robust.Server/Audio/AudioSystem.cs
@@ -137,7 +137,14 @@ public sealed partial class AudioSystem : SharedAudioSystem
 
         if (TerminatingOrDeleted(coordinates.EntityId))
         {
-            Log.Error($"Tried to play coordinates audio on a terminating / deleted entity {ToPrettyString(coordinates.EntityId)}.  Trace: {Environment.StackTrace}");
+            string soundInfo = "unknown sound";
+
+            if (specifier is ResolvedPathSpecifier pathSpec)
+                soundInfo = $"path: {pathSpec.Path}";
+            else if (specifier is ResolvedCollectionSpecifier collSpec)
+                soundInfo = $"collection: {collSpec.Collection}, index: {collSpec.Index}";
+
+            Log.Error($"Tried to play coordinates audio on a terminating / deleted entity {ToPrettyString(coordinates.EntityId)}. Sound: {soundInfo}. Trace: {Environment.StackTrace}");
             return null;
         }
 
@@ -160,7 +167,14 @@ public sealed partial class AudioSystem : SharedAudioSystem
 
         if (TerminatingOrDeleted(coordinates.EntityId))
         {
-            Log.Error($"Tried to play coordinates audio on a terminating / deleted entity {ToPrettyString(coordinates.EntityId)}.  Trace: {Environment.StackTrace}");
+            string soundInfo = "unknown sound";
+
+            if (specifier is ResolvedPathSpecifier pathSpec)
+                soundInfo = $"path: {pathSpec.Path}";
+            else if (specifier is ResolvedCollectionSpecifier collSpec)
+                soundInfo = $"collection: {collSpec.Collection}, index: {collSpec.Index}";
+
+            Log.Error($"Tried to play coordinates audio on a terminating / deleted entity {ToPrettyString(coordinates.EntityId)}. Sound: {soundInfo}. Trace: {Environment.StackTrace}");
             return null;
         }
 

--- a/Robust.Shared/Audio/ResolvedSoundSpecifier.cs
+++ b/Robust.Shared/Audio/ResolvedSoundSpecifier.cs
@@ -19,6 +19,8 @@ public abstract partial class ResolvedSoundSpecifier {
     [Obsolete("String literals for sounds are deprecated, use a SoundSpecifier or ResolvedSoundSpecifier as appropriate instead")]
     public static implicit operator ResolvedSoundSpecifier(ResPath s) => new ResolvedPathSpecifier(s);
 
+    public abstract string GetDebugString();
+
     /// <summary>
     /// Returns whether <c>s</c> is null, or if it contains an empty path/collection ID.
     /// </summary>
@@ -45,6 +47,11 @@ public sealed partial class ResolvedPathSpecifier : ResolvedSoundSpecifier {
 
     override public string ToString() =>
         $"ResolvedPathSpecifier({Path})";
+
+    public override string GetDebugString()
+    {
+        return $"path: {Path}";
+    }
 
     [UsedImplicitly]
     private ResolvedPathSpecifier()
@@ -76,6 +83,11 @@ public sealed partial class ResolvedCollectionSpecifier : ResolvedSoundSpecifier
 
     override public string ToString() =>
         $"ResolvedCollectionSpecifier({Collection}, {Index})";
+
+    public override string GetDebugString()
+    {
+        return $"collection: {Collection}, index: {Index}";
+    }
 
     [UsedImplicitly]
     private ResolvedCollectionSpecifier()

--- a/Robust.Shared/Audio/ResolvedSoundSpecifier.cs
+++ b/Robust.Shared/Audio/ResolvedSoundSpecifier.cs
@@ -19,8 +19,6 @@ public abstract partial class ResolvedSoundSpecifier {
     [Obsolete("String literals for sounds are deprecated, use a SoundSpecifier or ResolvedSoundSpecifier as appropriate instead")]
     public static implicit operator ResolvedSoundSpecifier(ResPath s) => new ResolvedPathSpecifier(s);
 
-    public abstract string GetDebugString();
-
     /// <summary>
     /// Returns whether <c>s</c> is null, or if it contains an empty path/collection ID.
     /// </summary>
@@ -47,11 +45,6 @@ public sealed partial class ResolvedPathSpecifier : ResolvedSoundSpecifier {
 
     override public string ToString() =>
         $"ResolvedPathSpecifier({Path})";
-
-    public override string GetDebugString()
-    {
-        return $"path: {Path}";
-    }
 
     [UsedImplicitly]
     private ResolvedPathSpecifier()
@@ -83,11 +76,6 @@ public sealed partial class ResolvedCollectionSpecifier : ResolvedSoundSpecifier
 
     override public string ToString() =>
         $"ResolvedCollectionSpecifier({Collection}, {Index})";
-
-    public override string GetDebugString()
-    {
-        return $"collection: {Collection}, index: {Index}";
-    }
 
     [UsedImplicitly]
     private ResolvedCollectionSpecifier()


### PR DESCRIPTION
This PR makes logging in the `AudioSystem` more detailed, which will allow players to effectively find the source of the error (now there is only the Id of the entity, which does not really help).