### PR TITLE
Fix false SoundFont validation errors in MIDI system

### DIFF
--- a/Robust.Client/Audio/Midi/MidiManager.cs
+++ b/Robust.Client/Audio/Midi/MidiManager.cs
@@ -238,7 +238,9 @@ internal sealed partial class MidiManager : IMidiManager
             NFluidsynth.Logger.LogLevel.Debug => LogLevel.Debug,
             _ => LogLevel.Debug
         };
-        _fluidsynthSawmill.Log(rLevel, message);
+
+        if (!message.Contains("Not a SoundFont file"))
+            _fluidsynthSawmill.Log(rLevel, message);
     }
 
     public IMidiRenderer? GetNewRenderer(bool mono = true)


### PR DESCRIPTION
This PR suppresses the "Not a SoundFont file" error. In fact, this error is fictitious. It is called by the [FluidSynth](https://github.com/FluidSynth/fluidsynth) library under this condition:

```
if(chunk.id != SFBK_FCC)
{
    /* error if not SFBK_ID */
    FLUID_LOG(FLUID_ERR, "Not a SoundFont file");
    return FALSE;
}
```

The problem is that there are only two .sf2 files in the Robust Toolbox and Space Station 14, and the library causes an error for both of them (I checked them in the HEX editor - all the necessary chunks are valid). I checked on other, exactly valid files - it still causes an error. 
I do not know what the problem is, but the only solution on our part is to ignore the error (otherwise, with any interaction with musical instruments, it clogs up the console). At least I don't understand this library and I can't name the reason for these fictitious triggers.
    