### PR TITLE
GameController: init LocalizationManager earlier

### DIFF
--- a/Robust.Client/GameController/GameController.cs
+++ b/Robust.Client/GameController/GameController.cs
@@ -160,6 +160,7 @@ namespace Robust.Client
             }
 
             _serializationManager.Initialize();
+            _loc.Initialize();
 
             // Call Init in game assemblies.
             _modLoader.BroadcastRunLevel(ModRunLevel.PreInit);
@@ -182,7 +183,6 @@ namespace Robust.Client
             _serializer.Initialize();
             _inputManager.Initialize();
             _console.Initialize();
-            _loc.Initialize();
 
             // Make sure this is done before we try to load prototypes,
             // avoid any possibility of race conditions causing the check to not finish


### PR DESCRIPTION
Moves the LocalizationManager's initialization up next to the SerializationManager in GameController.

Fixes #5964.

If the localization manager is expected to be used in the content layer in or after broadcasting an init run level, it should probably be set up to be used before then.  I don't think this can be only solved through content.