### PR TITLE
Cleanup `TypeSerializer` `Logger` warnings

### DIFF
--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/PrototypeFlagsTypeSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/PrototypeFlagsTypeSerializer.cs
@@ -45,8 +45,11 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
             IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context = null,
             ISerializationManager.InstantiationDelegate<PrototypeFlags<T>>? instanceProvider = null)
         {
-            if(instanceProvider != null)
-                Logger.Warning($"Provided value to a Read-call for a {nameof(PrototypeFlags<T>)}. Ignoring...");
+            if (instanceProvider != null)
+            {
+                var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
+                sawmill.Warning($"Provided value to a Read-call for a {nameof(PrototypeFlags<T>)}. Ignoring...");
+            }
 
             var flags = new List<string>(node.Sequence.Count);
 
@@ -78,8 +81,11 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
             IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context = null,
             ISerializationManager.InstantiationDelegate<PrototypeFlags<T>>? instanceProvider = null)
         {
-            if(instanceProvider != null)
-                Logger.Warning($"Provided value to a Read-call for a {nameof(PrototypeFlags<T>)}. Ignoring...");
+            if (instanceProvider != null)
+            {
+                var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
+                sawmill.Warning($"Provided value to a Read-call for a {nameof(PrototypeFlags<T>)}. Ignoring...");
+            }
 
             return new PrototypeFlags<T>(node.Value);
         }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/DictionarySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/DictionarySerializer.cs
@@ -153,7 +153,8 @@ public sealed class DictionarySerializer<TKey, TValue> :
     {
         if (instanceProvider != null)
         {
-            Logger.Warning(
+            var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
+            sawmill.Warning(
                 $"Provided value to a Read-call for a {nameof(FrozenDictionary<TKey, TValue>)}. Ignoring...");
         }
 
@@ -180,7 +181,8 @@ public sealed class DictionarySerializer<TKey, TValue> :
     {
         if (instanceProvider != null)
         {
-            Logger.Warning(
+            var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
+            sawmill.Warning(
                 $"Provided value to a Read-call for a {nameof(IReadOnlyDictionary<TKey, TValue>)}. Ignoring...");
         }
 

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/HashSetSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/HashSetSerializer.cs
@@ -45,7 +45,10 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
             SerializationHookContext hookCtx, ISerializationContext? context = null, ISerializationManager.InstantiationDelegate<FrozenSet<T>>? instanceProvider = null)
         {
             if (instanceProvider != null)
-                Logger.Warning($"Provided value to a Read-call for a {nameof(FrozenSet<T>)}. Ignoring...");
+            {
+                var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
+                sawmill.Warning($"Provided value to a Read-call for a {nameof(FrozenSet<T>)}. Ignoring...");
+            }
 
             var array = new T[node.Sequence.Count];
             var i = 0;
@@ -65,7 +68,10 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
             ISerializationManager.InstantiationDelegate<ImmutableHashSet<T>>? instanceProvider)
         {
             if (instanceProvider != null)
-                Logger.Warning($"Provided value to a Read-call for a {nameof(ImmutableHashSet<T>)}. Ignoring...");
+            {
+                var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
+                sawmill.Warning($"Provided value to a Read-call for a {nameof(ImmutableHashSet<T>)}. Ignoring...");
+            }
             var set = ImmutableHashSet.CreateBuilder<T>();
 
             foreach (var dataNode in node.Sequence)

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ListSerializers.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ListSerializers.cs
@@ -127,8 +127,11 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
             SerializationHookContext hookCtx, ISerializationContext? context,
             ISerializationManager.InstantiationDelegate<IReadOnlyList<T>>? instanceProvider)
         {
-            if(instanceProvider != null)
-                Logger.Warning($"Provided value to a Read-call for a {nameof(IReadOnlySet<T>)}. Ignoring...");
+            if (instanceProvider != null)
+            {
+                var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
+                sawmill.Warning($"Provided value to a Read-call for a {nameof(IReadOnlySet<T>)}. Ignoring...");
+            }
 
             var list = new List<T>();
 
@@ -146,8 +149,11 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
             SerializationHookContext hookCtx, ISerializationContext? context,
             ISerializationManager.InstantiationDelegate<IReadOnlyCollection<T>>? instanceProvider)
         {
-            if(instanceProvider != null)
-                Logger.Warning($"Provided value to a Read-call for a {nameof(IReadOnlyCollection<T>)}. Ignoring...");
+            if (instanceProvider != null)
+            {
+                var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
+                sawmill.Warning($"Provided value to a Read-call for a {nameof(IReadOnlyCollection<T>)}. Ignoring...");
+            }
 
             var list = new List<T>();
 
@@ -165,8 +171,11 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
             SerializationHookContext hookCtx, ISerializationContext? context,
             ISerializationManager.InstantiationDelegate<ImmutableList<T>>? instanceProvider)
         {
-            if(instanceProvider != null)
-                Logger.Warning($"Provided value to a Read-call for a {nameof(ImmutableList<T>)}. Ignoring...");
+            if (instanceProvider != null)
+            {
+                var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
+                sawmill.Warning($"Provided value to a Read-call for a {nameof(ImmutableList<T>)}. Ignoring...");
+            }
 
             var list = ImmutableList.CreateBuilder<T>();
 


### PR DESCRIPTION
Replaces uses of the static `Logger` methods in 4 type serializer classes with code that gets `ILogManager` from the passed `IDependencyCollection` and uses the "szr" sawmill instead.

Fixes 9 warnings.
https://github.com/space-wizards/space-station-14/issues/33279