### PR TITLE
Automatically generate sawmill instances for `UIController`s

### DIFF
--- a/Robust.Client/UserInterface/Controllers/UIController.cs
+++ b/Robust.Client/UserInterface/Controllers/UIController.cs
@@ -1,6 +1,9 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Log;
 using Robust.Shared.Timing;
 
 namespace Robust.Client.UserInterface.Controllers;
@@ -11,11 +14,14 @@ namespace Robust.Client.UserInterface.Controllers;
 ///     and <see cref="UISystemDependencyAttribute"/> to depend on <see cref="EntitySystem"/>s, which will be automatically
 ///     injected once they are created.
 /// </summary>
-public abstract partial class UIController
+public abstract partial class UIController : IPostInjectInit
 {
     [Dependency] protected readonly IUserInterfaceManager UIManager = default!;
     [Dependency] protected readonly IEntitySystemManager EntitySystemManager = default!;
     [Dependency] protected readonly IEntityManager EntityManager = default!;
+    [Dependency] protected readonly ILogManager LogManager = default!;
+
+    public ISawmill Log { get; protected set; } = default!;
 
     public virtual void Initialize()
     {
@@ -23,5 +29,40 @@ public abstract partial class UIController
 
     public virtual void FrameUpdate(FrameEventArgs args)
     {
+    }
+
+    protected virtual string SawmillName
+    {
+        get
+        {
+            var name = GetType().Name;
+
+            // Strip trailing "UIController"
+            if (name.EndsWith("UIController"))
+                name = name.Substring(0, name.Length - "UIController".Length);
+
+            // Convert CamelCase to snake_case
+            // Ignore if all uppercase, assume acronym (e.g. NPC or HTN)
+            if (name.All(char.IsUpper))
+            {
+                name = name.ToLower(CultureInfo.InvariantCulture);
+            }
+            else
+            {
+                name = string.Concat(name.Select(x => char.IsUpper(x) ? $"_{char.ToLower(x)}" : x.ToString()));
+                name = name.Trim('_');
+            }
+
+            return $"ui.{name}";
+        }
+    }
+
+    public void PostInject()
+    {
+        Log = LogManager.GetSawmill(SawmillName);
+
+#if !DEBUG
+        Log.Level = LogLevel.Info;
+#endif
     }
 }


### PR DESCRIPTION
`UIController`s now have automatically-named `ISawmill` instances just like `EntitySystem`s. They can be accessed by the `Log` property.

This is intended to make it easier to do logging within `UIController`s without a bunch of boilerplate, so we can get rid of a bunch of static logger calls in content.