### PR TITLE
added new smallTag

### DIFF
--- a/Robust.Client/UserInterface/RichText/MarkupTagManager.cs
+++ b/Robust.Client/UserInterface/RichText/MarkupTagManager.cs
@@ -24,6 +24,7 @@ public sealed class MarkupTagManager
         new CommandLinkTag(),
         new FontTag(),
         new HeadingTag(),
+        new SmallTag(),
         new ItalicTag()
     }.ToDictionary(x => x.Name.ToLower(), x => x);
 
@@ -39,6 +40,7 @@ public sealed class MarkupTagManager
         typeof(CommandLinkTag),
         typeof(FontTag),
         typeof(HeadingTag),
+        typeof(SmallTag),
         typeof(ItalicTag)
     };
 

--- a/Robust.Client/UserInterface/RichText/SmallTag.cs
+++ b/Robust.Client/UserInterface/RichText/SmallTag.cs
@@ -1,0 +1,36 @@
+using System;
+using Robust.Client.ResourceManagement;
+using Robust.Shared.IoC;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Robust.Client.UserInterface.RichText;
+
+public sealed class SmallTag : IMarkupTagHandler
+{
+    [Dependency] private readonly IResourceCache _resourceCache = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+    public string Name => "small";
+
+    /// <inheritdoc/>
+    public void PushDrawContext(MarkupNode node, MarkupDrawingContext context)
+    {
+        if (!node.Value.TryGetLong(out var levelParam))
+            return;
+
+        var level = Math.Min(Math.Max((int)levelParam, 1), 3);
+        node.Attributes["size"] = new MarkupParameter(
+            (int)Math.Ceiling(FontTag.DefaultSize - ((level*0.1)*FontTag.DefaultSize))
+        );
+
+        var font = FontTag.CreateFont(context.Font, node, _resourceCache, _prototypeManager, FontTag.DefaultFont);
+        context.Font.Push(font);
+    }
+
+    /// <inheritdoc/>
+    public void PopDrawContext(MarkupNode node, MarkupDrawingContext context)
+    {
+        context.Font.Pop();
+    }
+}


### PR DESCRIPTION
## About
The new small tag allows for smaller text in richtext, without using [font] (which isn't generally available to players anyway)

Similar to [head], it provides 3 levels of smaller text, with the smallest being 70% the size of regular text. I could go smaller but I don't necessarily want to allow players to make tiny unreadable text.

3 levels may also be redundant, I could lower the amount of levels to 2 but change the math so the smallest is still 2/3, but I don't know if I should. I am open to feedback on that.

## Why
sometimes small fonts are useful, for disclaimers, higher detailed graphics, and surely players will find more ways to use them than I can think of.

## Demonstration
Here is an ingame demonstration of what this looks like when used:
![2025-05-25_02-08](https://github.com/user-attachments/assets/7eb37a7f-4075-40d5-95f7-5717ba5286c1)

## Problems
Right now, [bold], [italic], and [bolditalic] do not work with this tag. it will overwrite bold/italic and always be regular font.
*I don't know how to fix this.* If someone knows how, please feel free to let me know (or to do it yourself), but I am already thoroughly in over my head to begin with.

## How it works
I basically just copied the existing HeadingTag, but made it make text smaller, and used different math. Header also forces bold, but usually you don't want tiny text to also be bold (its even harder to read!) so I also changed that.
The math that calculates the size is: `(int)Math.Ceiling(FontTag.DefaultSize - ((level*0.1)*FontTag.DefaultSize))`

## related ss14 PR
Here is the related ss14 pull request that requires this one https://github.com/space-wizards/space-station-14/pull/37811