### PR TITLE
Remove `ITileDefinition.ID`

### DIFF
--- a/Robust.Shared/Map/ITileDefinition.cs
+++ b/Robust.Shared/Map/ITileDefinition.cs
@@ -21,11 +21,6 @@ namespace Robust.Shared.Map
         string Name { get; }
 
         /// <summary>
-        ///     Internal name of the definition.
-        /// </summary>
-        string ID { get; }
-
-        /// <summary>
         ///     The path of the sprite to draw.
         /// </summary>
         ResPath? Sprite { get; }


### PR DESCRIPTION
`ITileDefinition` implements `IPrototype`, so it already has an identical `ID` field.

Fixes a warning CS0108 for [PZW](https://github.com/space-wizards/space-station-14/issues/33279).