### PR TITLE
added an option for snapping directional hallway signs

### DIFF
--- a/Robust.Client/Placement/Modes/AlignWallSigns.cs
+++ b/Robust.Client/Placement/Modes/AlignWallSigns.cs
@@ -27,11 +27,13 @@ namespace Robust.Client.Placement.Modes
 
             var offsets = new Vector2[]
             {
+                new(0.5f, 0.0625f),
+                new(0.5f, 0.28125f),
                 new(0.5f, 0.5f),
-                new(0.5f, 0.25f),
-                new(0.5f, 0.75f),
+                new(0.5f, 0.71875f),
+                new(0.5f, 0.9375f),
             };
-
+            
             var closestNode = offsets
                 .Select(o => tileCoordinates.Offset(o))
                 .MinBy(node => node.TryDistance(pManager.EntityManager, MouseCoords, out var distance) ?

--- a/Robust.Client/Placement/Modes/AlignWallSigns.cs
+++ b/Robust.Client/Placement/Modes/AlignWallSigns.cs
@@ -1,0 +1,58 @@
+using System.Linq;
+using Robust.Shared.Map;
+using Vector2 = System.Numerics.Vector2;
+
+namespace Robust.Client.Placement.Modes
+{
+    /// <summary>
+    ///     Used for snapping the directional signs to walls.
+    /// </summary>
+    public sealed class AlignWallSigns : PlacementMode
+    {
+        public AlignWallSigns(PlacementManager pMan) : base(pMan)
+        {
+        }
+
+        public override void AlignPlacementMode(ScreenCoordinates mouseScreen)
+        {
+            MouseCoords = ScreenToCursorGrid(mouseScreen);
+            CurrentTile = GetTileRef(MouseCoords);
+
+            if (pManager.CurrentPermission!.IsTile)
+            {
+                return;
+            }
+
+            var tileCoordinates = new EntityCoordinates(MouseCoords.EntityId, CurrentTile.GridIndices);
+
+            var offsets = new Vector2[]
+            {
+                new(0.5f, 0.5f),
+                new(0.5f, 0.25f),
+                new(0.5f, 0.75f),
+            };
+
+            var closestNode = offsets
+                .Select(o => tileCoordinates.Offset(o))
+                .MinBy(node => node.TryDistance(pManager.EntityManager, MouseCoords, out var distance) ?
+                    distance :
+                    (float?) null);
+
+            MouseCoords = closestNode;
+        }
+
+        public override bool IsValidPosition(EntityCoordinates position)
+        {
+            if (pManager.CurrentPermission!.IsTile)
+            {
+                return false;
+            }
+            else if (!RangeCheck(position))
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.xaml.cs
+++ b/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.xaml.cs
@@ -26,6 +26,7 @@ namespace Robust.Client.UserInterface.CustomControls
             "AlignTileDense",
             "AlignWall",
             "AlignWallProper",
+            "AlignWallSigns",
         };
 
         public EntitySpawnButton? SelectedButton;


### PR DESCRIPTION
## about
I added a new snapping option that allows for consistent placement of directional hallway signs
https://github.com/user-attachments/assets/5671a523-c2aa-46b5-8a46-f0601e357715

## Technical details
I basically copied AlignWallProper but changed the offsets. That's it. I also added it to the list.

There is a related PR on the ss14 repo to also update sandbox.txt https://github.com/space-wizards/space-station-14/pull/37967
