### PR TITLE
remove ResetMassData call from SetFixedRotation

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
@@ -618,8 +618,6 @@ public partial class SharedPhysicsSystem
 
         if (dirty)
             DirtyFields(uid, body, null, nameof(PhysicsComponent.FixedRotation), nameof(PhysicsComponent.AngularVelocity));
-
-        ResetMassData(uid, manager: manager, body: body);
     }
 
     public void SetFriction(EntityUid uid, PhysicsComponent body, float value, bool dirty = true)


### PR DESCRIPTION
Doesn't look like it's needed there? It recalculates the fixture mass, center of mass and inertia, so we only need to call it when the fixtures change.
`SetFixedRotation` only sets the angular velocity, so no need to call it.