### PR TITLE
Fix rich text entry measure

### DIFF
--- a/Robust.Client/UserInterface/RichTextEntry.cs
+++ b/Robust.Client/UserInterface/RichTextEntry.cs
@@ -141,7 +141,7 @@ namespace Robust.Client.UserInterface
                 if (Controls == null || !Controls.TryGetValue(nodeIndex, out var control))
                     continue;
 
-                control.Measure(new Vector2(Width, Height));
+                control.Measure(new Vector2(maxSizeX, Height));
 
                 var desiredSize = control.DesiredPixelSize;
                 var controlMetrics = new CharMetrics(


### PR DESCRIPTION
Replaced `Width` with `maxSizeX` when calculating the space required for `RichTextEntry`

The problem was found when I tried to add `Control` in chat on my fork to render job icons near character name

A `Label` is placed next to the character's name, showing their job title in the color of the corresponding department.

Without fix:
The text overflows the chat boundaries because the label's size is not taken into account.

![image](https://github.com/user-attachments/assets/9424dc68-047d-4532-ac50-4c38d8484f1a)

With fix:
Everything renders correctly.

![Screenshot 2025-06-01 152029](https://github.com/user-attachments/assets/1bf513c2-1fb3-4368-b86f-ee3d8f8f8763)
