### PR TITLE
Fix error when using `tpto` on a grid

### DIFF
--- a/Robust.Shared/Console/Commands/TeleportCommands.cs
+++ b/Robust.Shared/Console/Commands/TeleportCommands.cs
@@ -139,7 +139,7 @@ public sealed class TeleportToCommand : LocalizedEntityCommands
 
         foreach (var victim in victims)
         {
-            _transform.SetCoordinates(victim.Entity, targetCoords);
+            _transform.SetMapCoordinates(victim.Entity, _transform.ToMapCoordinates(targetCoords));
             _transform.AttachToGridOrMap(victim.Entity, victim.Transform);
         }
     }

--- a/Robust.Shared/Console/Commands/TeleportCommands.cs
+++ b/Robust.Shared/Console/Commands/TeleportCommands.cs
@@ -137,9 +137,10 @@ public sealed class TeleportToCommand : LocalizedEntityCommands
             }
         }
 
+        var targetMapCoords = _transform.ToMapCoordinates(targetCoords);
         foreach (var victim in victims)
         {
-            _transform.SetMapCoordinates(victim.Entity, _transform.ToMapCoordinates(targetCoords));
+            _transform.SetMapCoordinates(victim.Entity, targetMapCoords);
             _transform.AttachToGridOrMap(victim.Entity, victim.Transform);
         }
     }


### PR DESCRIPTION
Fixes https://github.com/space-wizards/space-station-14/issues/36415.

When using `tpto` to move a grid, if the target entity is not on a grid, the command will attempt to parent the grid to the target entity (it works by setting the teleported entity as the target's child with `SetCoordinates`, then calling `AttachToGridOrMap`). The server does not like that, so it crashes.

To fix this, we use `SetMapCoordinates` to move the entity to the map coordinates of the target instead of parenting to the target.