### PR TITLE
fix the lifestage checks on predicted entity deletion

### DIFF
--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -296,7 +296,7 @@ namespace Robust.Client.GameObjects
         public override void PredictedDeleteEntity(Entity<MetaDataComponent?, TransformComponent?> ent)
         {
             if (!MetaQuery.Resolve(ent.Owner, ref ent.Comp1)
-                || ent.Comp1.EntityDeleted
+                || ent.Comp1.EntityLifeStage >= EntityLifeStage.Terminating
                 || !TransformQuery.Resolve(ent.Owner, ref ent.Comp2))
             {
                 return;
@@ -322,7 +322,7 @@ namespace Robust.Client.GameObjects
         {
             if (IsQueuedForDeletion(ent.Owner)
                 || !MetaQuery.Resolve(ent.Owner, ref ent.Comp1)
-                || ent.Comp1.EntityDeleted
+                || ent.Comp1.EntityLifeStage >= EntityLifeStage.Terminating
                 || !TransformQuery.Resolve(ent.Owner, ref ent.Comp2))
             {
                 return;


### PR DESCRIPTION
Fixes an issue where `ClientEntityManager.PredictedQueueDeleteEntity()` & `ClientEntityManager.PredictedDeleteEntity()` will log an error if the entity is already being deleted by something else, as they only check if the entity has been deleted while `SharedTransformSystem.DetachEntityInternal()` checks if the entity is terminating.

Currently only happens when the client closes so it won't cause any major issues, but can cause unrelated test fails.