### PR TITLE
fix TryQueueDeleteEntity not doing anything

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -498,7 +498,7 @@ namespace Robust.Shared.GameObjects
             if (Deleted(uid.Value))
                 return false;
 
-            if (!QueuedDeletionsSet.Add(uid.Value))
+            if (QueuedDeletionsSet.Contains(uid.Value))
                 return false;
 
             QueueDeleteEntity(uid);

--- a/Robust.UnitTesting/Shared/GameObjects/DeferredEntityDeletionTest.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/DeferredEntityDeletionTest.cs
@@ -33,8 +33,8 @@ public sealed partial class DeferredEntityDeletionTest : RobustIntegrationTest
         var server = StartServer(options);
         await server.WaitIdleAsync();
 
-        EntityUid uid1 = default, uid2 = default, uid3 = default;
-        DeferredDeletionTestComponent comp1 = default!, comp2 = default!, comp3 = default!;
+        EntityUid uid1 = default, uid2 = default, uid3 = default, uid4 = default;
+        DeferredDeletionTestComponent comp1 = default!, comp2 = default!, comp3 = default!, comp4 = default!;
         IEntityManager entMan = default!;
 
         await server.WaitAssertion(() =>
@@ -46,14 +46,17 @@ public sealed partial class DeferredEntityDeletionTest : RobustIntegrationTest
             uid1 = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
             uid2 = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
             uid3 = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            uid4 = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
 
             comp1 = entMan.AddComponent<DeferredDeletionTestComponent>(uid1);
             comp2 = entMan.AddComponent<DeferredDeletionTestComponent>(uid2);
-            comp3 =entMan.AddComponent<DeferredDeletionTestComponent>(uid3);
+            comp3 = entMan.AddComponent<DeferredDeletionTestComponent>(uid3);
+            comp4 = entMan.AddComponent<DeferredDeletionTestComponent>(uid4);
 
             entMan.AddComponent<OtherDeferredDeletionTestComponent>(uid1);
             entMan.AddComponent<OtherDeferredDeletionTestComponent>(uid2);
             entMan.AddComponent<OtherDeferredDeletionTestComponent>(uid3);
+            entMan.AddComponent<OtherDeferredDeletionTestComponent>(uid4);
         });
 
         await server.WaitRunTicks(1);
@@ -76,17 +79,23 @@ public sealed partial class DeferredEntityDeletionTest : RobustIntegrationTest
             var ev = new DeferredDeletionTestEvent();
             entMan.EventBus.RaiseLocalEvent(uid2, ev);
             entMan.EventBus.RaiseLocalEvent(uid3, ev);
+            entMan.EventBus.RaiseLocalEvent(uid4, ev);
             entMan.DeleteEntity(uid2);
             entMan.QueueDeleteEntity(uid3);
+            entMan.TryQueueDeleteEntity(uid4);
             Assert.That(entMan.Deleted(uid2));
             Assert.That(!entMan.Deleted(uid3));
+            Assert.That(!entMan.Deleted(uid4));
             Assert.That(comp2.LifeStage == ComponentLifeStage.Deleted);
             Assert.That(comp3.LifeStage == ComponentLifeStage.Stopped);
+            Assert.That(comp4.LifeStage == ComponentLifeStage.Stopped);
         });
 
         await server.WaitRunTicks(1);
         Assert.That(comp3.LifeStage == ComponentLifeStage.Deleted);
+        Assert.That(comp4.LifeStage == ComponentLifeStage.Deleted);
         Assert.That(entMan.Deleted(uid3));
+        Assert.That(entMan.Deleted(uid4));
         await server.WaitIdleAsync();
     }
 


### PR DESCRIPTION
Thanks to @Fildrance for finding the bug!

`TryQueueDeleteEntity` adds the uid to `QueuedDeletionsSet` and then calls `QueueDeleteEntity`, which tries to add it again and fails because it is already in there. So the entity is never deleted.

I also added `TryQueueDeleteEntity` to the integration test.

I noticed this because dummy entities in the spawn menu were never deleted and kept accumulating, which made debugging update loops pretty much impossible.

#### Changelog
- Fixed `TryQueueDeleteEntity` not deleting entities.