### PR TITLE
Adjust how OpenAL extensions are requested

### DIFF
--- a/Robust.Client/Audio/AudioManager.cs
+++ b/Robust.Client/Audio/AudioManager.cs
@@ -57,8 +57,8 @@ internal sealed partial class AudioManager : IAudioInternal
         _checkAlError();
 
         // Load up AL context extensions.
-        var s = ALC.GetString(ALDevice.Null, AlcGetString.Extensions) ?? "";
-        foreach (var extension in s.Split(' '))
+        var s = ALC.GetString(_openALDevice, AlcGetString.Extensions) ?? "";
+        foreach (var extension in s.Split(' ', StringSplitOptions.RemoveEmptyEntries))
         {
             _alContextExtensions.Add(extension);
         }

--- a/Robust.Client/Graphics/Clyde/Windowing/Glfw.Windows.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Glfw.Windows.cs
@@ -662,10 +662,6 @@ namespace Robust.Client.Graphics.Clyde
             {
                 var icons = _clyde.LoadWindowIcons().ToArray();
 
-                // Done if no icon (e.g., macOS)
-                if (icons.Length == 0)
-                    return;
-
                 // Turn each image into a byte[] so we can actually pin their contents.
                 // Wish I knew a clean way to do this without allocations.
                 var images = icons

--- a/Robust.Client/Graphics/Clyde/Windowing/Glfw.Windows.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Glfw.Windows.cs
@@ -662,6 +662,10 @@ namespace Robust.Client.Graphics.Clyde
             {
                 var icons = _clyde.LoadWindowIcons().ToArray();
 
+                // Done if no icon (e.g., macOS)
+                if (icons.Length == 0)
+                    return;
+
                 // Turn each image into a byte[] so we can actually pin their contents.
                 // Wish I knew a clean way to do this without allocations.
                 var images = icons


### PR DESCRIPTION
This fixes a few things:
1. ~~Make Clyde stop trying to set a window icon when it doesn't have any. This can happen on macOS, and just leads to a random error getting logged and nothing else.~~ Moved into #6016.
2. Fixes an OpenAL error that was caused by attempting to query extensions with a null device. I _think_ this is an error that only comes on on macOS's ancient OpenAL implementation, as when I switch over to using OpenAL Soft (no comment on the pains it took to get that working, though I'll be making an issue about letting macOS builds use it in a moment) I end up without any issue and the same set of extensions registered.
3. Shouldn't ever matter, but make sure we don't put in empty strings onto _alContextExtensions.

Here's the error in question that I was getting:
```
[ERRO] clyde.oal: [LoadAudioOggVorbis:133] AL error: InvalidName
```
Note the LoadAudioOggVorbis method name is a red herring; it is caused by the GetString, there just isn't an error check until there.

Also PR number 6000 :tada:.