### PR TITLE
Misc SpriteSystem fixes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Fix `SpriteComponent.Layer.Visible` setter not marking a sprite's bounding box as dirty.
 
 ### Other
 

--- a/Robust.Client/ComponentTrees/SpriteTreeSystem.cs
+++ b/Robust.Client/ComponentTrees/SpriteTreeSystem.cs
@@ -21,7 +21,7 @@ public sealed class SpriteTreeSystem : ComponentTreeSystem<SpriteTreeComponent, 
     protected override Box2 ExtractAabb(in ComponentTreeEntry<SpriteComponent> entry, Vector2 pos, Angle rot)
     {
         // TODO SPRITE optimize this
-        // Because the just take the BB of the rotated BB, I'mt pretty sure we do a lot of unnecessary maths.
+        // Because the just take the BB of the rotated BB, I'm pretty sure we do a lot of unnecessary maths.
         return _sprite.CalculateBounds((entry.Uid, entry.Component), pos, rot, default).CalcBoundingBox();
     }
 

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1791,76 +1791,15 @@ namespace Robust.Client.GameObjects
         [Obsolete("Use SpriteSystem.GetPrototypeTextures() instead")]
         public static IEnumerable<IDirectionalTextureProvider> GetPrototypeTextures(EntityPrototype prototype, IResourceCache resourceCache, out bool noRot)
         {
-            var results = new List<IDirectionalTextureProvider>();
-            noRot = false;
-
-            // TODO when moving to a non-static method in a system, pass in IComponentFactory
-            if (prototype.TryGetComponent(out IconComponent? icon))
-            {
-                var sys = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SpriteSystem>();
-                results.Add(sys.GetIcon(icon));
-                return results;
-            }
-
-            if (!prototype.Components.TryGetValue("Sprite", out _))
-            {
-                results.Add(resourceCache.GetFallback<TextureResource>().Texture);
-                return results;
-            }
-
-            var entityManager = IoCManager.Resolve<IEntityManager>();
-            var dummy = entityManager.SpawnEntity(prototype.ID, MapCoordinates.Nullspace);
-            var spriteComponent = entityManager.EnsureComponent<SpriteComponent>(dummy);
-            EntitySystem.Get<AppearanceSystem>().OnChangeData(dummy, spriteComponent);
-
-            foreach (var layer in spriteComponent.AllLayers)
-            {
-                if (!layer.Visible) continue;
-
-                if (layer.Texture != null)
-                {
-                    results.Add(layer.Texture);
-                    continue;
-                }
-
-                if (!layer.RsiState.IsValid) continue;
-
-                var rsi = layer.Rsi ?? spriteComponent.BaseRSI;
-                if (rsi == null ||
-                    !rsi.TryGetState(layer.RsiState, out var state))
-                    continue;
-
-                results.Add(state);
-            }
-
-            noRot = spriteComponent.NoRotation;
-
-            entityManager.DeleteEntity(dummy);
-
-            if (results.Count == 0)
-                results.Add(resourceCache.GetFallback<TextureResource>().Texture);
-
-            return results;
+            var sys = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SpriteSystem>();
+            return sys.GetPrototypeTextures(prototype, out noRot);
         }
 
         [Obsolete("Use SpriteSystem.GetPrototypeIcon() instead")]
         public static IRsiStateLike GetPrototypeIcon(EntityPrototype prototype, IResourceCache resourceCache)
         {
             var sys = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SpriteSystem>();
-            // TODO when moving to a non-static method in a system, pass in IComponentFactory
-            if (prototype.TryGetComponent(out IconComponent? icon))
-                return sys.GetIcon(icon);
-
-            if (!prototype.Components.ContainsKey("Sprite"))
-                return sys.GetFallbackState();
-
-            var entityManager = IoCManager.Resolve<IEntityManager>();
-            var dummy = entityManager.SpawnEntity(prototype.ID, MapCoordinates.Nullspace);
-            var spriteComponent = entityManager.EnsureComponent<SpriteComponent>(dummy);
-            var result = spriteComponent.Icon ?? sys.GetFallbackState();
-            entityManager.DeleteEntity(dummy);
-
-            return result;
+            return sys.GetPrototypeIcon(prototype);
         }
     }
 }

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1224,6 +1224,8 @@ namespace Robust.Client.GameObjects
                         return;
                     _visible = value;
 
+                    Owner.Comp.BoundsDirty = true;
+
                     // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
                     if (_parent.Owner != EntityUid.Invalid)
                         Owner.Comp.Sys?.QueueUpdateIsInert(Owner);

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
@@ -34,8 +34,10 @@ namespace Robust.Client.GameObjects
         [Dependency] private readonly IPrototypeManager _proto = default!;
         [Dependency] private readonly IResourceCache _resourceCache = default!;
         [Dependency] private readonly ILogManager _logManager = default!;
+        [Dependency] private readonly IComponentFactory _factory = default!;
         [Dependency] private readonly SharedTransformSystem _xforms = default!;
         [Dependency] private readonly SpriteTreeSystem _tree = default!;
+        [Dependency] private readonly AppearanceSystem _appearance = default!;
 
         public static readonly ProtoId<ShaderPrototype> UnshadedId = "unshaded";
         private readonly Queue<SpriteComponent> _inertUpdateQueue = new();

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
@@ -35,6 +35,8 @@ namespace Robust.Client.GameObjects
         [Dependency] private readonly IResourceCache _resourceCache = default!;
         [Dependency] private readonly ILogManager _logManager = default!;
         [Dependency] private readonly IComponentFactory _factory = default!;
+
+        // Note that any new system dependencies have to be added to RobustUnitTest.BaseSetup()
         [Dependency] private readonly SharedTransformSystem _xforms = default!;
         [Dependency] private readonly SpriteTreeSystem _tree = default!;
         [Dependency] private readonly AppearanceSystem _appearance = default!;

--- a/Robust.UnitTesting/RobustUnitTest.cs
+++ b/Robust.UnitTesting/RobustUnitTest.cs
@@ -28,6 +28,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Reflection;
 using Robust.Shared.Threading;
 using Robust.Shared.Utility;
+using AppearanceSystem = Robust.Client.GameObjects.AppearanceSystem;
 using InputSystem = Robust.Server.GameObjects.InputSystem;
 using MapSystem = Robust.Server.GameObjects.MapSystem;
 using PointLightComponent = Robust.Client.GameObjects.PointLightComponent;
@@ -141,6 +142,7 @@ namespace Robust.UnitTesting
                 systems.LoadExtraSystemType<RecursiveMoveSystem>();
                 systems.LoadExtraSystemType<SpriteSystem>();
                 systems.LoadExtraSystemType<SpriteTreeSystem>();
+                systems.LoadExtraSystemType<AppearanceSystem>();
                 systems.LoadExtraSystemType<GridChunkBoundsDebugSystem>();
             }
             else


### PR DESCRIPTION
- Fixes the #6002, caused by the `Layer.Visible` setter not marking sprite bounds as dirty.
- The static `SpriteComponent.GetPrototypeTextures` method was prematurely marked as obsolete without actually having added the equivalent system method. This PR moves the method over to the system.
- Fixes an issue where some `SpriteSystem.GetPrototypeIcon()` overloads weren't caching results. 