### PR TITLE
Fully obsolete some old SharedContainerSystem methods

### DIFF
--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -391,13 +391,6 @@ namespace Robust.Shared.Containers
             return TryFindComponentsOnEntityContainerOrParent(xform.ParentUid, entityQuery, foundComponents);
         }
 
-
-        [Obsolete("Use Entity<T> variant")]
-        public bool IsInSameOrNoContainer(EntityUid user, EntityUid other)
-        {
-            return IsInSameOrNoContainer((user, null, null), (other, null, null));
-        }
-
         /// <summary>
         ///     Returns true if the two entities are not contained, or are contained in the same container.
         /// </summary>
@@ -416,13 +409,6 @@ namespace Robust.Shared.Containers
 
             // Both entities are in the same container
             return userContainer == otherContainer;
-        }
-
-
-        [Obsolete("Use Entity<T> variant")]
-        public bool IsInSameOrParentContainer(EntityUid user, EntityUid other)
-        {
-            return IsInSameOrParentContainer((user, null), other);
         }
 
         /// <summary>
@@ -457,21 +443,6 @@ namespace Robust.Shared.Containers
 
             // Both entities are in the same container
             return userContainer == otherContainer;
-        }
-
-        [Obsolete("Use Entity<T> variant")]
-        public bool IsInSameOrTransparentContainer(
-            EntityUid user,
-            EntityUid other,
-            BaseContainer? userContainer = null,
-            BaseContainer? otherContainer = null,
-            bool userSeeInsideSelf = false)
-        {
-            return IsInSameOrTransparentContainer((user, null),
-                other,
-                userContainer,
-                otherContainer,
-                userSeeInsideSelf);
         }
 
         /// <summary>


### PR DESCRIPTION
Needed for https://github.com/space-wizards/space-station-14/issues/33279
The remaining use cases in content will automatically cast into the `Entity<T>` overload, removing the warnings.

Also part of https://github.com/space-wizards/RobustToolbox/pull/5675 but the review requested it to be atomized.

#### Changelog
- Fully removed the obsolete overloads of IsInSameOrNoContainer, IsInSameOrParentContainer and IsInSameOrTransparentContainer. Use the `Entity<T>` variant instead.