### PR TITLE
Adding "Attribution-NonCommercial-NoDerivatives 4.0 International"

### DIFF
--- a/Schemas/rga_validators.py
+++ b/Schemas/rga_validators.py
@@ -14,7 +14,7 @@ class License(Validator):
         "CC-BY-NC-SA-4.0",
         "CC-BY-ND-3.0",
         "CC-BY-ND-4.0",
-        "CC-BY-NC-ND-4.0"
+        "CC-BY-NC-ND-4.0",
         "CC0-1.0",
         "MIT",
         "Custom" # implies that the license is described in the copyright field.

--- a/Schemas/rga_validators.py
+++ b/Schemas/rga_validators.py
@@ -14,6 +14,7 @@ class License(Validator):
         "CC-BY-NC-SA-4.0",
         "CC-BY-ND-3.0",
         "CC-BY-ND-4.0",
+        "CC-BY-NC-ND-4.0"
         "CC0-1.0",
         "MIT",
         "Custom" # implies that the license is described in the copyright field.


### PR DESCRIPTION
Adding the "Attribution-NonCommercial-NoDerivatives 4.0 International" License type, this is getting marked as an "invalid" license with automated tests when its actually a valid license.

Error message:
"Error: [/Resources/Audio/Lobby/attributions.yml] 6.license: 'CC-BY-NC-ND-4.0' is not a license."

[License link](https://creativecommons.org/licenses/by-nc-nd/4.0/)