### PR TITLE
Fix warning CS0168 in `EntityDeserializer`

### DIFF
--- a/Robust.Shared/EntitySerialization/EntityDeserializer.cs
+++ b/Robust.Shared/EntitySerialization/EntityDeserializer.cs
@@ -547,17 +547,14 @@ public sealed class EntityDeserializer :
         _stopwatch.Restart();
         foreach (var (entity, data) in Entities)
         {
+#if EXCEPTION_TOLERANCE
             try
             {
+#endif
                 CurrentReadingEntity = data;
                 LoadEntity(entity, _metaQuery.Comp(entity), data.Components, data.MissingComponents);
+#if EXCEPTION_TOLERANCE
             }
-#if !EXCEPTION_TOLERANCE
-            catch (Exception)
-            {
-                throw;
-            }
-#else
             catch (Exception e)
             {
                 ToDelete.Add(entity);

--- a/Robust.Shared/EntitySerialization/EntityDeserializer.cs
+++ b/Robust.Shared/EntitySerialization/EntityDeserializer.cs
@@ -552,15 +552,18 @@ public sealed class EntityDeserializer :
                 CurrentReadingEntity = data;
                 LoadEntity(entity, _metaQuery.Comp(entity), data.Components, data.MissingComponents);
             }
+#if !EXCEPTION_TOLERANCE
+            catch (Exception)
+            {
+                throw;
+            }
+#else
             catch (Exception e)
             {
-#if !EXCEPTION_TOLERANCE
-                throw;
-#else
                 ToDelete.Add(entity);
                 _log.Error($"Encountered error while loading entity. Yaml uid: {data.YamlId}. Loaded loaded entity: {EntMan.ToPrettyString(entity)}. Error:\n{e}.");
-#endif
             }
+#endif
         }
 
         CurrentReadingEntity = null;


### PR DESCRIPTION
**The variable 'e' is declared but never used** [CS0168](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0168))

With the current code, if `EXCEPTION_TOLERANCE` is unset, the code path looks like this:
```
try
{
    // stuff
}
catch (Exception e)
{
    throw;
}
```
That's a pretty pointless try-catch!

This PR restructures the precompiler directives so the try-catch blocks are only used if `EXCEPTION_TOLERANCE` is set. 

One more warning for [PZW](https://github.com/space-wizards/space-station-14/issues/33279)