### PR TITLE
Validate that Toolshed command arguments have parsers

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,11 +35,11 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* Toolshed commands will now validate that each non-generic command argument is parseable (i.e., has a corresponding type parser). This check can be disabled by explicitly marking the argument as unparseable via `CommandArgumentAttribute.Unparseable`.
 
 ### New features
 
-*None yet*
+* `ToolshedManager.TryParse` now also supports nullable value types.
 
 ### Bugfixes
 

--- a/Robust.Shared/Toolshed/Attributes.cs
+++ b/Robust.Shared/Toolshed/Attributes.cs
@@ -46,8 +46,9 @@ public sealed class PipedArgumentAttribute : Attribute;
 [MeansImplicitUse]
 public sealed class CommandArgumentAttribute : Attribute
 {
-    public CommandArgumentAttribute(Type? customParser = null)
+    public CommandArgumentAttribute(Type? customParser = null, bool unparseable = false)
     {
+        Unparseable = unparseable;
         if (customParser == null)
             return;
 
@@ -55,6 +56,13 @@ public sealed class CommandArgumentAttribute : Attribute
         DebugTools.Assert(customParser.IsCustomParser(),
             $"Custom parser {customParser.PrettyName()} does not inherit from {typeof(CustomTypeParser<>).PrettyName()}");
     }
+
+    /// <summary>
+    /// Command initialization will validate that all of a command's arguments are parseable (i.e., have a type parser).
+    /// In some niche situations you might want to have a command that accepts unparseable arguments that must be
+    /// supplied via a toolshed variable or command block, in which case the check can be disabled via this property.
+    /// </summary>
+    public bool Unparseable { get; }
 
     public Type? CustomParser { get; }
 }

--- a/Robust.Shared/Toolshed/Commands/Entities/World/TpCommand.cs
+++ b/Robust.Shared/Toolshed/Commands/Entities/World/TpCommand.cs
@@ -11,8 +11,11 @@ internal sealed class TpCommand : ToolshedCommand
 {
     private SharedTransformSystem? _xform;
 
+    // TODO TOOLSHED
+    // add EntityCoordinates parser
+
     [CommandImplementation("coords")]
-    public EntityUid TpCoords([PipedArgument] EntityUid teleporter, EntityCoordinates target)
+    public EntityUid TpCoords([PipedArgument] EntityUid teleporter, [CommandArgument(unparseable:true)] EntityCoordinates target)
     {
         _xform ??= GetSys<SharedTransformSystem>();
         _xform.SetCoordinates(teleporter, target);
@@ -20,7 +23,7 @@ internal sealed class TpCommand : ToolshedCommand
     }
 
     [CommandImplementation("coords")]
-    public IEnumerable<EntityUid> TpCoords([PipedArgument] IEnumerable<EntityUid> teleporters, EntityCoordinates target)
+    public IEnumerable<EntityUid> TpCoords([PipedArgument] IEnumerable<EntityUid> teleporters, [CommandArgument(unparseable:true)] EntityCoordinates target)
         => teleporters.Select(x => TpCoords(x, target));
 
     [CommandImplementation("to")]

--- a/Robust.Shared/Toolshed/ToolshedCommand.cs
+++ b/Robust.Shared/Toolshed/ToolshedCommand.cs
@@ -239,7 +239,7 @@ public abstract partial class ToolshedCommand
             // This checks that each argument has a corresponding type parser, as people have sometimes created a command
             // without realising that the type is unparseable.
             var t = Nullable.GetUnderlyingType(arg.ParameterType) ?? arg.ParameterType;
-            var ignore = t.IsGenericType || t.ContainsGenericParameters;
+            var ignore = t.IsGenericType || t.IsArray || t.ContainsGenericParameters;
             if (!ignore && Toolshed.GetParserForType(t) == null)
                 throw new InvalidCommandImplementation($"{Name} command argument of type {t.PrettyName()} has no type parser. You either need to add a type parser or explicitly mark the argument as unparseable.");
         }

--- a/Robust.Shared/Toolshed/ToolshedCommand.cs
+++ b/Robust.Shared/Toolshed/ToolshedCommand.cs
@@ -124,12 +124,12 @@ public abstract partial class ToolshedCommand
             {
                 var hasAnyAttribute = false;
 
-                if (param.HasCustomAttribute<CommandArgumentAttribute>())
+                if (param.GetCustomAttribute<CommandArgumentAttribute>() is {} cmdAttr)
                 {
                     if (param.Name == null || !argNames.Add(param.Name))
                         throw new InvalidCommandImplementation($"Command arguments must have a unique name");
                     hasAnyAttribute = true;
-                    ValidateArg(param);
+                    ValidateArg(param, cmdAttr);
                 }
 
                 if (param.HasCustomAttribute<PipedArgumentAttribute>())
@@ -232,8 +232,18 @@ public abstract partial class ToolshedCommand
         }
     }
 
-    private void ValidateArg(ParameterInfo arg)
+    private void ValidateArg(ParameterInfo arg, CommandArgumentAttribute? cmdAttr = null)
     {
+        if (cmdAttr == null || cmdAttr.CustomParser == null && !cmdAttr.Unparseable)
+        {
+            // This checks that each argument has a corresponding type parser, as people have sometimes created a command
+            // without realising that the type is unparseable.
+            var t = Nullable.GetUnderlyingType(arg.ParameterType) ?? arg.ParameterType;
+            var ignore = t.IsGenericType || t.ContainsGenericParameters; // Must have explicit ty
+            if (!ignore && Toolshed.GetParserForType(t) == null)
+                throw new InvalidCommandImplementation($"{Name} command argument of type {t.PrettyName()} has no type parser. You either need to add a type parser or explicitly mark the argument as unparseable.");
+        }
+
         var isParams = arg.HasCustomAttribute<ParamArrayAttribute>();
         if (!isParams)
             return;

--- a/Robust.Shared/Toolshed/ToolshedCommand.cs
+++ b/Robust.Shared/Toolshed/ToolshedCommand.cs
@@ -239,7 +239,7 @@ public abstract partial class ToolshedCommand
             // This checks that each argument has a corresponding type parser, as people have sometimes created a command
             // without realising that the type is unparseable.
             var t = Nullable.GetUnderlyingType(arg.ParameterType) ?? arg.ParameterType;
-            var ignore = t.IsGenericType || t.ContainsGenericParameters; // Must have explicit ty
+            var ignore = t.IsGenericType || t.ContainsGenericParameters;
             if (!ignore && Toolshed.GetParserForType(t) == null)
                 throw new InvalidCommandImplementation($"{Name} command argument of type {t.PrettyName()} has no type parser. You either need to add a type parser or explicitly mark the argument as unparseable.");
         }

--- a/Robust.Shared/Toolshed/ToolshedManager.Parsing.cs
+++ b/Robust.Shared/Toolshed/ToolshedManager.Parsing.cs
@@ -231,7 +231,10 @@ public sealed partial class ToolshedManager
     /// <returns>Success.</returns>
     public bool TryParse<T>(ParserContext parserContext, [NotNullWhen(true)] out T? parsed)
     {
-        var res = TryParse(parserContext, typeof(T), out var p);
+        var t = typeof(T);
+        t = Nullable.GetUnderlyingType(t) ?? t;
+        var res = TryParse(parserContext, t, out var p);
+
         if (p is not null)
             parsed = (T?) p;
         else

--- a/Robust.Shared/Toolshed/TypeParsers/Math/SpanLikeTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/Math/SpanLikeTypeParser.cs
@@ -81,7 +81,7 @@ public abstract class SpanLikeTypeParser<T, TElem> : TypeParser<T>
 
     public override CompletionResult? TryAutocomplete(ParserContext parserContext, CommandArgument? arg)
     {
-        return CompletionResult.FromHint(typeof(T).PrettyName());
+        return CompletionResult.FromHint(GetArgHint(arg));
     }
 }
 

--- a/Robust.UnitTesting/Server/GameStates/PvsPauseTest.cs
+++ b/Robust.UnitTesting/Server/GameStates/PvsPauseTest.cs
@@ -136,39 +136,39 @@ public sealed class PvsPauseTest : RobustIntegrationTest
         await RunTicks();
         AssertEnt(paused: true, detached: false, clientPaused: true);
 
-         // Unpause the entity while out of range
-         {
-             await server.WaitPost(() => xforms.SetCoordinates(sEntMan.GetEntity(player), farAway));
-             await RunTicks();
-             AssertEnt(paused: true, detached: true, clientPaused: true);
+        // Unpause the entity while out of range
+        {
+            await server.WaitPost(() => xforms.SetCoordinates(sEntMan.GetEntity(player), farAway));
+            await RunTicks();
+            AssertEnt(paused: true, detached: true, clientPaused: true);
 
-             await server.WaitPost(() => metaSys.SetEntityPaused(sEnt, false));
-             await RunTicks();
-             AssertEnt(paused: false, detached: true, clientPaused: true);
+            await server.WaitPost(() => metaSys.SetEntityPaused(sEnt, false));
+            await RunTicks();
+            AssertEnt(paused: false, detached: true, clientPaused: true);
 
-             await server.WaitPost(() => xforms.SetCoordinates(sEntMan.GetEntity(player), coords));
-             await RunTicks();
-             AssertEnt(paused: false, detached: false, clientPaused: false);
-         }
+            await server.WaitPost(() => xforms.SetCoordinates(sEntMan.GetEntity(player), coords));
+            await RunTicks();
+            AssertEnt(paused: false, detached: false, clientPaused: false);
+        }
 
-         // Pause the entity while out of range
-         {
-             await server.WaitPost(() => xforms.SetCoordinates(sEntMan.GetEntity(player), farAway));
-             await RunTicks();
-             AssertEnt(paused: false, detached: true, clientPaused: true);
+        // Pause the entity while out of range
+        {
+            await server.WaitPost(() => xforms.SetCoordinates(sEntMan.GetEntity(player), farAway));
+            await RunTicks();
+            AssertEnt(paused: false, detached: true, clientPaused: true);
 
-             await server.WaitPost(() => metaSys.SetEntityPaused(sEnt, true));
-             await RunTicks();
-             AssertEnt(paused: true, detached: true, clientPaused: true);
+            await server.WaitPost(() => metaSys.SetEntityPaused(sEnt, true));
+            await RunTicks();
+            AssertEnt(paused: true, detached: true, clientPaused: true);
 
-             await server.WaitPost(() => xforms.SetCoordinates(sEntMan.GetEntity(player), coords));
-             await RunTicks();
-             AssertEnt(paused: true, detached: false, clientPaused: true);
-         }
+            await server.WaitPost(() => xforms.SetCoordinates(sEntMan.GetEntity(player), coords));
+            await RunTicks();
+            AssertEnt(paused: true, detached: false, clientPaused: true);
+        }
 
-         await client.WaitPost(() => netMan.ClientDisconnect(""));
-         await server.WaitRunTicks(5);
-         await client.WaitRunTicks(5);
+        await client.WaitPost(() => netMan.ClientDisconnect(""));
+        await server.WaitRunTicks(5);
+        await client.WaitRunTicks(5);
     }
 }
 

--- a/Robust.UnitTesting/Server/GameStates/PvsPauseTest.cs
+++ b/Robust.UnitTesting/Server/GameStates/PvsPauseTest.cs
@@ -165,6 +165,10 @@ public sealed class PvsPauseTest : RobustIntegrationTest
              await RunTicks();
              AssertEnt(paused: true, detached: false, clientPaused: true);
          }
+
+         await client.WaitPost(() => netMan.ClientDisconnect(""));
+         await server.WaitRunTicks(5);
+         await client.WaitRunTicks(5);
     }
 }
 

--- a/Robust.UnitTesting/Shared/Toolshed/ToolshedValidationTest.cs
+++ b/Robust.UnitTesting/Shared/Toolshed/ToolshedValidationTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using NUnit.Framework;
+using Robust.Shared.IoC;
 using Robust.Shared.Reflection;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Toolshed.TypeParsers;
@@ -43,6 +44,7 @@ public sealed class ToolshedValidationTest : ToolshedTest
             foreach (var type in types)
             {
                 var instance = (ToolshedCommand)Activator.CreateInstance(type)!;
+                Server.Resolve<IDependencyCollection>().InjectDependencies(instance, oneOff: true);
                 Assert.Throws<InvalidCommandImplementation>(instance.Init, $"{type.PrettyName()} did not throw a {nameof(InvalidCommandImplementation)} exception");
             }
         });


### PR DESCRIPTION
This adds a check to command initialization that validates that that each non-generic command argument is parseable (i.e., has a corresponding type parser). This check can be disabled by explicitly marking the argument as unparseable via `CommandArgumentAttribute.Unparseable`.

This is meant to prevent people from accidentally creating an unuseable command due to a missing parser. For example, various reagent related commands were unusable due to the lack of a FixedPoint2 parser (https://github.com/space-wizards/space-station-14/pull/38134).