### PR TITLE
fix: don't try to set non-existent window icons

### DIFF
--- a/Robust.Client/Graphics/Clyde/Windowing/Glfw.Windows.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Glfw.Windows.cs
@@ -662,6 +662,10 @@ namespace Robust.Client.Graphics.Clyde
             {
                 var icons = _clyde.LoadWindowIcons().ToArray();
 
+                // Done if no icon (e.g., macOS)
+                if (icons.Length == 0)
+                    return;
+
                 // Turn each image into a byte[] so we can actually pin their contents.
                 // Wish I knew a clean way to do this without allocations.
                 var images = icons


### PR DESCRIPTION
Extracted from #6000. This prevents an error message from showing up on macOS regarding an attempt to set an icon, as the code path ends up leaving glfwImages as an empty span that still gets passed to SetWindowIcon which then complains due to it being called on macOS. There weren't any other issues caused by this as far as I can tell, it's just about not having the random error show up.

Error in question:
```
[DEBG] clyde.win: GLFW initialized, version: 3.4.0 Cocoa NSGL Null EGL OSMesa monotonic dynamic.
[ERRO] clyde.win.glfw: GLFW Error: [65548] Cocoa: Regular windows do not have icons on macOS
[DEBG] clyde.ogl: OpenGL Vendor: Apple
```