### PR TITLE
Fix `TabContainer.CurrentTab` setter

### DIFF
--- a/Robust.Client/UserInterface/Controls/TabContainer.cs
+++ b/Robust.Client/UserInterface/Controls/TabContainer.cs
@@ -30,12 +30,12 @@ namespace Robust.Client.UserInterface.Controls
             get => _currentTab;
             set
             {
-                if (_currentTab < 0)
+                if (value < 0)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, "Current tab must be positive.");
                 }
 
-                if (_currentTab >= ChildCount)
+                if (value >= ChildCount)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value,
                         "Current tab must less than the amount of tabs.");


### PR DESCRIPTION
Fixes https://github.com/space-wizards/RobustToolbox/issues/6012.

The `CurrentTab` setter now checks that the value being passed in is in the correct range, rather than checking the current value.