### PR TITLE
changes SpriteComponent to use object as LayerKey

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -615,7 +615,7 @@ namespace Robust.Client.GameObjects
 
             if (layerDatum.CopyToShaderParameters is { } copyParameters)
             {
-                layer.CopyToShaderParameters = new CopyToShaderParameters(ParseKey(copyParameters.LayerKey))
+                layer.CopyToShaderParameters = new CopyToShaderParameters(copyParameters.LayerKey ?? "this is impossible")
                 {
                     ParameterTexture = copyParameters.ParameterTexture,
                     ParameterUV = copyParameters.ParameterUV

--- a/Robust.Shared/GameObjects/Components/Renderable/SpriteLayerData.cs
+++ b/Robust.Shared/GameObjects/Components/Renderable/SpriteLayerData.cs
@@ -60,7 +60,7 @@ public sealed partial class PrototypeCopyToShaderParameters
     /// <summary>
     /// The map key of the layer that will have its shader modified.
     /// </summary>
-    [DataField(required: true)] public string LayerKey;
+    [DataField(required: true)] public object? LayerKey;
 
     /// <summary>
     /// The name of the shader parameter that will receive the actual selected texture.


### PR DESCRIPTION
The layer/displacement system uses objects as keys throughout, except in this one place, which is causing issues when one tries to apply a displacement to a layer using a HumanoidVisualLayers-object as a key, which - as far as I can tell - is the entire reason the system got switched from String to Object in the first place.

Goes together with sister PR on the non-engine side of things: 
Requires https://github.com/space-wizards/space-station-14/pull/38351