### PR TITLE
Clean up all missing `EntitySystem` proxy method uses

### DIFF
--- a/Robust.Client/Debugging/DebugAnchoringSystem.cs
+++ b/Robust.Client/Debugging/DebugAnchoringSystem.cs
@@ -82,7 +82,7 @@ namespace Robust.Client.Debugging
 
             foreach (var ent in _mapSystem.GetAnchoredEntities(gridUid, grid, spot))
             {
-                if (EntityManager.TryGetComponent<MetaDataComponent>(ent, out var meta))
+                if (TryComp<MetaDataComponent>(ent, out var meta))
                 {
                     text.AppendLine($"uid: {ent}, {meta.EntityName}");
                 }

--- a/Robust.Client/Debugging/DebugAnchoringSystem.cs
+++ b/Robust.Client/Debugging/DebugAnchoringSystem.cs
@@ -82,7 +82,7 @@ namespace Robust.Client.Debugging
 
             foreach (var ent in _mapSystem.GetAnchoredEntities(gridUid, grid, spot))
             {
-                if (EntityManager.TryGetComponent<MetaDataComponent>(ent, out var meta))
+                if (TryComp(ent, out MetaDataComponent? meta))
                 {
                     text.AppendLine($"uid: {ent}, {meta.EntityName}");
                 }

--- a/Robust.Client/Debugging/DebugAnchoringSystem.cs
+++ b/Robust.Client/Debugging/DebugAnchoringSystem.cs
@@ -82,7 +82,7 @@ namespace Robust.Client.Debugging
 
             foreach (var ent in _mapSystem.GetAnchoredEntities(gridUid, grid, spot))
             {
-                if (TryComp(ent, out MetaDataComponent? meta))
+                if (EntityManager.TryGetComponent<MetaDataComponent>(ent, out var meta))
                 {
                     text.AppendLine($"uid: {ent}, {meta.EntityName}");
                 }

--- a/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
@@ -97,7 +97,7 @@ namespace Robust.Client.GameObjects
         [Obsolete("Use Play(EntityUid<AnimationPlayerComponent> ent, Animation animation, string key) instead")]
         public void Play(EntityUid uid, AnimationPlayerComponent? component, Animation animation, string key)
         {
-            component ??= EnsureComp<AnimationPlayerComponent>(uid);
+            component ??= EntityManager.EnsureComponent<AnimationPlayerComponent>(uid);
             Play(new Entity<AnimationPlayerComponent>(uid, component), animation, key);
         }
 
@@ -158,7 +158,7 @@ namespace Robust.Client.GameObjects
 
         public bool HasRunningAnimation(EntityUid uid, string key)
         {
-            return TryComp(uid, out AnimationPlayerComponent? component) &&
+            return EntityManager.TryGetComponent(uid, out AnimationPlayerComponent? component) &&
                    component.PlayingAnimations.ContainsKey(key);
         }
 

--- a/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
@@ -97,7 +97,7 @@ namespace Robust.Client.GameObjects
         [Obsolete("Use Play(EntityUid<AnimationPlayerComponent> ent, Animation animation, string key) instead")]
         public void Play(EntityUid uid, AnimationPlayerComponent? component, Animation animation, string key)
         {
-            component ??= EntityManager.EnsureComponent<AnimationPlayerComponent>(uid);
+            component ??= EnsureComp<AnimationPlayerComponent>(uid);
             Play(new Entity<AnimationPlayerComponent>(uid, component), animation, key);
         }
 
@@ -158,7 +158,7 @@ namespace Robust.Client.GameObjects
 
         public bool HasRunningAnimation(EntityUid uid, string key)
         {
-            return EntityManager.TryGetComponent(uid, out AnimationPlayerComponent? component) &&
+            return TryComp(uid, out AnimationPlayerComponent? component) &&
                    component.PlayingAnimations.ContainsKey(key);
         }
 

--- a/Robust.Client/GameObjects/EntitySystems/InputSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/InputSystem.cs
@@ -223,12 +223,12 @@ namespace Robust.Client.GameObjects
 
         private void SetEntityContextActive(IInputManager inputMan, EntityUid entity)
         {
-            if(entity == default || !EntityManager.EntityExists(entity))
+            if(entity == default || !Exists(entity))
                 throw new ArgumentNullException(nameof(entity));
 
-            if (!EntityManager.TryGetComponent(entity, out InputComponent? inputComp))
+            if (!TryComp(entity, out InputComponent? inputComp))
             {
-                _sawmillInputContext.Debug($"AttachedEnt has no InputComponent: entId={entity}, entProto={EntityManager.GetComponent<MetaDataComponent>(entity).EntityPrototype}. Setting default \"{InputContextContainer.DefaultContextName}\" context...");
+                _sawmillInputContext.Debug($"AttachedEnt has no InputComponent: entId={entity}, entProto={Comp<MetaDataComponent>(entity).EntityPrototype}. Setting default \"{InputContextContainer.DefaultContextName}\" context...");
                 inputMan.Contexts.SetActiveContext(InputContextContainer.DefaultContextName);
                 return;
             }
@@ -239,7 +239,7 @@ namespace Robust.Client.GameObjects
             }
             else
             {
-                _sawmillInputContext.Error($"Unknown context: entId={entity}, entProto={EntityManager.GetComponent<MetaDataComponent>(entity).EntityPrototype}, context={inputComp.ContextName}. . Setting default \"{InputContextContainer.DefaultContextName}\" context...");
+                _sawmillInputContext.Error($"Unknown context: entId={entity}, entProto={Comp<MetaDataComponent>(entity).EntityPrototype}, context={inputComp.ContextName}. . Setting default \"{InputContextContainer.DefaultContextName}\" context...");
                 inputMan.Contexts.SetActiveContext(InputContextContainer.DefaultContextName);
             }
         }

--- a/Robust.Client/GameObjects/EntitySystems/InputSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/InputSystem.cs
@@ -223,12 +223,12 @@ namespace Robust.Client.GameObjects
 
         private void SetEntityContextActive(IInputManager inputMan, EntityUid entity)
         {
-            if(entity == default || !Exists(entity))
+            if(entity == default || !EntityManager.EntityExists(entity))
                 throw new ArgumentNullException(nameof(entity));
 
-            if (!TryComp(entity, out InputComponent? inputComp))
+            if (!EntityManager.TryGetComponent(entity, out InputComponent? inputComp))
             {
-                _sawmillInputContext.Debug($"AttachedEnt has no InputComponent: entId={entity}, entProto={Comp<MetaDataComponent>(entity).EntityPrototype}. Setting default \"{InputContextContainer.DefaultContextName}\" context...");
+                _sawmillInputContext.Debug($"AttachedEnt has no InputComponent: entId={entity}, entProto={EntityManager.GetComponent<MetaDataComponent>(entity).EntityPrototype}. Setting default \"{InputContextContainer.DefaultContextName}\" context...");
                 inputMan.Contexts.SetActiveContext(InputContextContainer.DefaultContextName);
                 return;
             }
@@ -239,7 +239,7 @@ namespace Robust.Client.GameObjects
             }
             else
             {
-                _sawmillInputContext.Error($"Unknown context: entId={entity}, entProto={Comp<MetaDataComponent>(entity).EntityPrototype}, context={inputComp.ContextName}. . Setting default \"{InputContextContainer.DefaultContextName}\" context...");
+                _sawmillInputContext.Error($"Unknown context: entId={entity}, entProto={EntityManager.GetComponent<MetaDataComponent>(entity).EntityPrototype}, context={inputComp.ContextName}. . Setting default \"{InputContextContainer.DefaultContextName}\" context...");
                 inputMan.Contexts.SetActiveContext(InputContextContainer.DefaultContextName);
             }
         }

--- a/Robust.Client/GameObjects/EntitySystems/ShowPlayerVelocityDebugSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ShowPlayerVelocityDebugSystem.cs
@@ -51,7 +51,7 @@ public sealed class ShowPlayerVelocityDebugSystem : EntitySystem
 
         var player = _playerManager.LocalEntity;
 
-        if (player == null || !TryComp(player.Value, out PhysicsComponent? body))
+        if (player == null || !EntityManager.TryGetComponent(player.Value, out PhysicsComponent? body))
         {
             _label.Visible = false;
             return;

--- a/Robust.Client/GameObjects/EntitySystems/ShowPlayerVelocityDebugSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/ShowPlayerVelocityDebugSystem.cs
@@ -51,7 +51,7 @@ public sealed class ShowPlayerVelocityDebugSystem : EntitySystem
 
         var player = _playerManager.LocalEntity;
 
-        if (player == null || !EntityManager.TryGetComponent(player.Value, out PhysicsComponent? body))
+        if (player == null || !TryComp(player.Value, out PhysicsComponent? body))
         {
             _label.Visible = false;
             return;

--- a/Robust.Client/Physics/JointSystem.cs
+++ b/Robust.Client/Physics/JointSystem.cs
@@ -67,7 +67,7 @@ namespace Robust.Client.Physics
 
                 // Add new joint (if possible).
                 // Need to wait for BOTH joint components to come in first before we can add it. Yay dependencies!
-                if (!HasComp<JointComponent>(other))
+                if (!EntityManager.HasComponent<JointComponent>(other))
                     continue;
 
                 // TODO: if (other entity is outside of PVS range) continue;

--- a/Robust.Client/Physics/JointSystem.cs
+++ b/Robust.Client/Physics/JointSystem.cs
@@ -67,7 +67,7 @@ namespace Robust.Client.Physics
 
                 // Add new joint (if possible).
                 // Need to wait for BOTH joint components to come in first before we can add it. Yay dependencies!
-                if (!EntityManager.HasComponent<JointComponent>(other))
+                if (!HasComp<JointComponent>(other))
                     continue;
 
                 // TODO: if (other entity is outside of PVS range) continue;

--- a/Robust.Server/GameObjects/EntitySystems/MapSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapSystem.cs
@@ -60,7 +60,7 @@ namespace Robust.Server.GameObjects
 
                 foreach (var uid in toDelete)
                 {
-                    EntityManager.DeleteEntity(uid);
+                    Del(uid);
                 }
             }
         }
@@ -75,7 +75,7 @@ namespace Robust.Server.GameObjects
             if (!_deleteEmptyGrids || TerminatingOrDeleted(uid) || HasComp<MapComponent>(uid))
                 return;
 
-            EntityManager.DeleteEntity(args.GridId);
+            Del(args.GridId);
         }
     }
 }

--- a/Robust.Server/GameObjects/EntitySystems/MapSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapSystem.cs
@@ -60,7 +60,7 @@ namespace Robust.Server.GameObjects
 
                 foreach (var uid in toDelete)
                 {
-                    Del(uid);
+                    EntityManager.DeleteEntity(uid);
                 }
             }
         }
@@ -74,7 +74,8 @@ namespace Robust.Server.GameObjects
         {
             if (!_deleteEmptyGrids || TerminatingOrDeleted(uid) || HasComp<MapComponent>(uid))
                 return;
-            Del(args.GridId);
+
+            EntityManager.DeleteEntity(args.GridId);
         }
     }
 }

--- a/Robust.Server/GameObjects/EntitySystems/MapSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/MapSystem.cs
@@ -60,7 +60,7 @@ namespace Robust.Server.GameObjects
 
                 foreach (var uid in toDelete)
                 {
-                    EntityManager.DeleteEntity(uid);
+                    Del(uid);
                 }
             }
         }
@@ -74,8 +74,7 @@ namespace Robust.Server.GameObjects
         {
             if (!_deleteEmptyGrids || TerminatingOrDeleted(uid) || HasComp<MapComponent>(uid))
                 return;
-
-            EntityManager.DeleteEntity(args.GridId);
+            Del(args.GridId);
         }
     }
 }

--- a/Robust.Server/GameObjects/EntitySystems/ViewSubscriberSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/ViewSubscriberSystem.cs
@@ -20,7 +20,7 @@ public sealed class ViewSubscriberSystem : SharedViewSubscriberSystem
     public override void AddViewSubscriber(EntityUid uid, ICommonSession session)
     {
         // If the entity doesn't have the component, it will be added.
-        var viewSubscriber = EntityManager.EnsureComponent<Shared.GameObjects.ViewSubscriberComponent>(uid);
+        var viewSubscriber = EnsureComp<Shared.GameObjects.ViewSubscriberComponent>(uid);
 
         if (viewSubscriber.SubscribedSessions.Contains(session))
             return; // Already subscribed, do nothing else.
@@ -36,7 +36,7 @@ public sealed class ViewSubscriberSystem : SharedViewSubscriberSystem
     /// </summary>
     public override void RemoveViewSubscriber(EntityUid uid, ICommonSession session)
     {
-        if(!EntityManager.TryGetComponent(uid, out Shared.GameObjects.ViewSubscriberComponent? viewSubscriber))
+        if(!TryComp(uid, out Shared.GameObjects.ViewSubscriberComponent? viewSubscriber))
             return; // Entity didn't have any subscriptions, do nothing.
 
         if (!viewSubscriber.SubscribedSessions.Remove(session))

--- a/Robust.Server/GameObjects/EntitySystems/ViewSubscriberSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/ViewSubscriberSystem.cs
@@ -20,7 +20,7 @@ public sealed class ViewSubscriberSystem : SharedViewSubscriberSystem
     public override void AddViewSubscriber(EntityUid uid, ICommonSession session)
     {
         // If the entity doesn't have the component, it will be added.
-        var viewSubscriber = EnsureComp<Shared.GameObjects.ViewSubscriberComponent>(uid);
+        var viewSubscriber = EntityManager.EnsureComponent<Shared.GameObjects.ViewSubscriberComponent>(uid);
 
         if (viewSubscriber.SubscribedSessions.Contains(session))
             return; // Already subscribed, do nothing else.
@@ -36,7 +36,7 @@ public sealed class ViewSubscriberSystem : SharedViewSubscriberSystem
     /// </summary>
     public override void RemoveViewSubscriber(EntityUid uid, ICommonSession session)
     {
-        if(!TryComp(uid, out Shared.GameObjects.ViewSubscriberComponent? viewSubscriber))
+        if(!EntityManager.TryGetComponent(uid, out Shared.GameObjects.ViewSubscriberComponent? viewSubscriber))
             return; // Entity didn't have any subscriptions, do nothing.
 
         if (!viewSubscriber.SubscribedSessions.Remove(session))

--- a/Robust.Server/GameStates/PvsSystem.GetStates.cs
+++ b/Robust.Server/GameStates/PvsSystem.GetStates.cs
@@ -132,7 +132,7 @@ internal sealed partial class PvsSystem
 
         if (enumerateAll)
         {
-            var query = EntityManager.AllEntityQueryEnumerator<MetaDataComponent>();
+            var query = AllEntityQuery<MetaDataComponent>();
             while (query.MoveNext(out var uid, out var md))
             {
                 DebugTools.Assert(md.EntityLifeStage >= EntityLifeStage.Initialized, $"Entity {ToPrettyString(uid)} has not been initialized");

--- a/Robust.Server/GameStates/PvsSystem.GetStates.cs
+++ b/Robust.Server/GameStates/PvsSystem.GetStates.cs
@@ -132,7 +132,7 @@ internal sealed partial class PvsSystem
 
         if (enumerateAll)
         {
-            var query = AllEntityQuery<MetaDataComponent>();
+            var query = EntityManager.AllEntityQueryEnumerator<MetaDataComponent>();
             while (query.MoveNext(out var uid, out var md))
             {
                 DebugTools.Assert(md.EntityLifeStage >= EntityLifeStage.Initialized, $"Entity {ToPrettyString(uid)} has not been initialized");

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -199,7 +199,7 @@ internal sealed partial class PvsSystem : EntitySystem
 
         foreach (var uid in _toDelete)
         {
-            QueueDel(uid);
+            EntityManager.QueueDeleteEntity(uid);
         }
         _toDelete.Clear();
 

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -199,7 +199,7 @@ internal sealed partial class PvsSystem : EntitySystem
 
         foreach (var uid in _toDelete)
         {
-            EntityManager.QueueDeleteEntity(uid);
+            QueueDel(uid);
         }
         _toDelete.Clear();
 

--- a/Robust.Server/Player/FilterSystem.cs
+++ b/Robust.Server/Player/FilterSystem.cs
@@ -10,7 +10,7 @@ namespace Robust.Server.Player
         {
             foreach (var uid in entities)
             {
-                if (TryComp(uid, out ActorComponent? actor))
+                if (EntityManager.TryGetComponent(uid, out ActorComponent? actor))
                     filter.AddPlayer(actor.PlayerSession);
             }
 

--- a/Robust.Server/Player/FilterSystem.cs
+++ b/Robust.Server/Player/FilterSystem.cs
@@ -10,7 +10,7 @@ namespace Robust.Server.Player
         {
             foreach (var uid in entities)
             {
-                if (EntityManager.TryGetComponent(uid, out ActorComponent? actor))
+                if (TryComp(uid, out ActorComponent? actor))
                     filter.AddPlayer(actor.PlayerSession);
             }
 

--- a/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
+++ b/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
@@ -283,7 +283,7 @@ public abstract class ComponentTreeSystem<TTreeComp, TComp> : EntitySystem
             (EntityUid uid, MapGridComponent grid,
                 ref (EntityManager EntityManager, ValueList<(EntityUid, TTreeComp)> trees) tuple) =>
             {
-                if (TryComp<TTreeComp>(uid, out var treeComp))
+                if (EntityManager.TryGetComponent<TTreeComp>(uid, out var treeComp))
                 {
                     tuple.trees.Add((uid, treeComp));
                 }

--- a/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
+++ b/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
@@ -283,7 +283,7 @@ public abstract class ComponentTreeSystem<TTreeComp, TComp> : EntitySystem
             (EntityUid uid, MapGridComponent grid,
                 ref (EntityManager EntityManager, ValueList<(EntityUid, TTreeComp)> trees) tuple) =>
             {
-                if (EntityManager.TryGetComponent<TTreeComp>(uid, out var treeComp))
+                if (tuple.EntityManager.TryGetComponent<TTreeComp>(uid, out var treeComp))
                 {
                     tuple.trees.Add((uid, treeComp));
                 }

--- a/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
+++ b/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
@@ -283,7 +283,7 @@ public abstract class ComponentTreeSystem<TTreeComp, TComp> : EntitySystem
             (EntityUid uid, MapGridComponent grid,
                 ref (EntityManager EntityManager, ValueList<(EntityUid, TTreeComp)> trees) tuple) =>
             {
-                if (tuple.EntityManager.TryGetComponent<TTreeComp>(uid, out var treeComp))
+                if (EntityManager.TryGetComponent<TTreeComp>(uid, out var treeComp))
                 {
                     tuple.trees.Add((uid, treeComp));
                 }

--- a/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
+++ b/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
@@ -283,7 +283,7 @@ public abstract class ComponentTreeSystem<TTreeComp, TComp> : EntitySystem
             (EntityUid uid, MapGridComponent grid,
                 ref (EntityManager EntityManager, ValueList<(EntityUid, TTreeComp)> trees) tuple) =>
             {
-                if (EntityManager.TryGetComponent<TTreeComp>(uid, out var treeComp))
+                if (TryComp<TTreeComp>(uid, out var treeComp))
                 {
                     tuple.trees.Add((uid, treeComp));
                 }

--- a/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
+++ b/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
@@ -283,7 +283,7 @@ public abstract class ComponentTreeSystem<TTreeComp, TComp> : EntitySystem
             (EntityUid uid, MapGridComponent grid,
                 ref (EntityManager EntityManager, ValueList<(EntityUid, TTreeComp)> trees) tuple) =>
             {
-                if (tuple.EntityManager.TryGetComponent<TTreeComp>(uid, out var treeComp))
+                if (TryComp<TTreeComp>(uid, out var treeComp))
                 {
                     tuple.trees.Add((uid, treeComp));
                 }

--- a/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
+++ b/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
@@ -283,7 +283,7 @@ public abstract class ComponentTreeSystem<TTreeComp, TComp> : EntitySystem
             (EntityUid uid, MapGridComponent grid,
                 ref (EntityManager EntityManager, ValueList<(EntityUid, TTreeComp)> trees) tuple) =>
             {
-                if (TryComp<TTreeComp>(uid, out var treeComp))
+                if (tuple.EntityManager.TryGetComponent<TTreeComp>(uid, out var treeComp))
                 {
                     tuple.trees.Add((uid, treeComp));
                 }

--- a/Robust.Shared/GameObjects/Systems/CollideOnAnchorSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/CollideOnAnchorSystem.cs
@@ -18,7 +18,7 @@ namespace Robust.Shared.GameObjects
 
         private void OnStartup(EntityUid uid, CollideOnAnchorComponent component, ComponentStartup args)
         {
-            if (!TryComp(uid, out TransformComponent? transformComponent)) return;
+            if (!EntityManager.TryGetComponent(uid, out TransformComponent? transformComponent)) return;
 
             SetCollide(uid, component, transformComponent.Anchored);
         }
@@ -31,7 +31,7 @@ namespace Robust.Shared.GameObjects
 
         private void SetCollide(EntityUid uid, CollideOnAnchorComponent component, bool anchored)
         {
-            if (!TryComp(uid, out PhysicsComponent? body)) return;
+            if (!EntityManager.TryGetComponent(uid, out PhysicsComponent? body)) return;
 
             var enabled = component.Enable;
 

--- a/Robust.Shared/GameObjects/Systems/CollideOnAnchorSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/CollideOnAnchorSystem.cs
@@ -18,7 +18,7 @@ namespace Robust.Shared.GameObjects
 
         private void OnStartup(EntityUid uid, CollideOnAnchorComponent component, ComponentStartup args)
         {
-            if (!EntityManager.TryGetComponent(uid, out TransformComponent? transformComponent)) return;
+            if (!TryComp(uid, out TransformComponent? transformComponent)) return;
 
             SetCollide(uid, component, transformComponent.Anchored);
         }
@@ -31,7 +31,7 @@ namespace Robust.Shared.GameObjects
 
         private void SetCollide(EntityUid uid, CollideOnAnchorComponent component, bool anchored)
         {
-            if (!EntityManager.TryGetComponent(uid, out PhysicsComponent? body)) return;
+            if (!TryComp(uid, out PhysicsComponent? body)) return;
 
             var enabled = component.Enable;
 

--- a/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
@@ -73,8 +73,8 @@ internal sealed class PrototypeReloadSystem : EntitySystem
             var data = newPrototype.Components[name];
             var component = _componentFactory.GetComponent(name);
 
-            if (!EntityManager.HasComponent(entity, component.GetType()))
-                EntityManager.AddComponent(entity, component);
+            if (!HasComp(entity, component.GetType()))
+                AddComp(entity, component);
         }
 
         // Update entity metadata

--- a/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
@@ -73,8 +73,8 @@ internal sealed class PrototypeReloadSystem : EntitySystem
             var data = newPrototype.Components[name];
             var component = _componentFactory.GetComponent(name);
 
-            if (!HasComp(entity, component.GetType()))
-                AddComp(entity, component);
+            if (!EntityManager.HasComponent(entity, component.GetType()))
+                EntityManager.AddComponent(entity, component);
         }
 
         // Update entity metadata

--- a/Robust.Shared/GameObjects/Systems/SharedGridFixtureSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridFixtureSystem.cs
@@ -69,19 +69,19 @@ namespace Robust.Shared.GameObjects
             if (!_enabled)
                 return;
 
-            if (!EntityManager.TryGetComponent(uid, out PhysicsComponent? body))
+            if (!TryComp(uid, out PhysicsComponent? body))
             {
                 Log.Error($"Trying to regenerate collision for {uid} that doesn't have {nameof(body)}");
                 return;
             }
 
-            if (!EntityManager.TryGetComponent(uid, out FixturesComponent? manager))
+            if (!TryComp(uid, out FixturesComponent? manager))
             {
                 Log.Error($"Trying to regenerate collision for {uid} that doesn't have {nameof(manager)}");
                 return;
             }
 
-            if (!EntityManager.TryGetComponent(uid, out TransformComponent? xform))
+            if (!TryComp(uid, out TransformComponent? xform))
             {
                 Log.Error($"Trying to regenerate collision for {uid} that doesn't have {nameof(TransformComponent)}");
                 return;

--- a/Robust.Shared/GameObjects/Systems/SharedGridFixtureSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedGridFixtureSystem.cs
@@ -69,19 +69,19 @@ namespace Robust.Shared.GameObjects
             if (!_enabled)
                 return;
 
-            if (!TryComp(uid, out PhysicsComponent? body))
+            if (!EntityManager.TryGetComponent(uid, out PhysicsComponent? body))
             {
                 Log.Error($"Trying to regenerate collision for {uid} that doesn't have {nameof(body)}");
                 return;
             }
 
-            if (!TryComp(uid, out FixturesComponent? manager))
+            if (!EntityManager.TryGetComponent(uid, out FixturesComponent? manager))
             {
                 Log.Error($"Trying to regenerate collision for {uid} that doesn't have {nameof(manager)}");
                 return;
             }
 
-            if (!TryComp(uid, out TransformComponent? xform))
+            if (!EntityManager.TryGetComponent(uid, out TransformComponent? xform))
             {
                 Log.Error($"Trying to regenerate collision for {uid} that doesn't have {nameof(TransformComponent)}");
                 return;

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -158,7 +158,7 @@ public abstract partial class SharedMapSystem
         // Just MapLoader things.
         if (component.MapProxy == DynamicTree.Proxy.Free) return;
 
-        var xform = EntityManager.GetComponent<TransformComponent>(uid);
+        var xform = Comp<TransformComponent>(uid);
         var aabb = GetWorldAABB(uid, component, xform);
 
         if (TryComp<GridTreeComponent>(xform.MapUid, out var gridTree))

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -158,7 +158,7 @@ public abstract partial class SharedMapSystem
         // Just MapLoader things.
         if (component.MapProxy == DynamicTree.Proxy.Free) return;
 
-        var xform = Comp<TransformComponent>(uid);
+        var xform = EntityManager.GetComponent<TransformComponent>(uid);
         var aabb = GetWorldAABB(uid, component, xform);
 
         if (TryComp<GridTreeComponent>(xform.MapUid, out var gridTree))

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -636,7 +636,7 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
         if (!_timing.IsFirstTimePredicted)
             return;
 
-        EntityManager.RaisePredictiveEvent(new BoundUIWrapMessage(GetNetEntity(entity.Owner), new CloseBoundInterfaceMessage(), key));
+        RaisePredictiveEvent(new BoundUIWrapMessage(GetNetEntity(entity.Owner), new CloseBoundInterfaceMessage(), key));
     }
 
     /// <summary>
@@ -685,7 +685,7 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
             {
                 // Not guaranteed to open so rely upon the event handling it.
                 // Also lets client request it to be opened remotely too.
-                EntityManager.RaisePredictiveEvent(new BoundUIWrapMessage(GetNetEntity(entity.Owner), new OpenBoundInterfaceMessage(), key));
+                RaisePredictiveEvent(new BoundUIWrapMessage(GetNetEntity(entity.Owner), new OpenBoundInterfaceMessage(), key));
             }
         }
         else

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -682,6 +682,8 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
         {
             if (_timing.IsFirstTimePredicted)
             {
+                // Not guaranteed to open so rely upon the event handling it.
+                // Also lets client request it to be opened remotely too.
                 RaisePredictiveEvent(new BoundUIWrapMessage(GetNetEntity(entity.Owner), new OpenBoundInterfaceMessage(), key));
             }
         }

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -635,7 +635,8 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
 
         if (!_timing.IsFirstTimePredicted)
             return;
-        RaisePredictiveEvent(new BoundUIWrapMessage(GetNetEntity(entity.Owner), new CloseBoundInterfaceMessage(), key));
+
+        EntityManager.RaisePredictiveEvent(new BoundUIWrapMessage(GetNetEntity(entity.Owner), new CloseBoundInterfaceMessage(), key));
     }
 
     /// <summary>
@@ -682,7 +683,9 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
         {
             if (_timing.IsFirstTimePredicted)
             {
-                RaisePredictiveEvent(new BoundUIWrapMessage(GetNetEntity(entity.Owner), new OpenBoundInterfaceMessage(), key));
+                // Not guaranteed to open so rely upon the event handling it.
+                // Also lets client request it to be opened remotely too.
+                EntityManager.RaisePredictiveEvent(new BoundUIWrapMessage(GetNetEntity(entity.Owner), new OpenBoundInterfaceMessage(), key));
             }
         }
         else

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -635,8 +635,7 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
 
         if (!_timing.IsFirstTimePredicted)
             return;
-
-        EntityManager.RaisePredictiveEvent(new BoundUIWrapMessage(GetNetEntity(entity.Owner), new CloseBoundInterfaceMessage(), key));
+        RaisePredictiveEvent(new BoundUIWrapMessage(GetNetEntity(entity.Owner), new CloseBoundInterfaceMessage(), key));
     }
 
     /// <summary>
@@ -683,9 +682,7 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
         {
             if (_timing.IsFirstTimePredicted)
             {
-                // Not guaranteed to open so rely upon the event handling it.
-                // Also lets client request it to be opened remotely too.
-                EntityManager.RaisePredictiveEvent(new BoundUIWrapMessage(GetNetEntity(entity.Owner), new OpenBoundInterfaceMessage(), key));
+                RaisePredictiveEvent(new BoundUIWrapMessage(GetNetEntity(entity.Owner), new OpenBoundInterfaceMessage(), key));
             }
         }
         else

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -682,8 +682,6 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
         {
             if (_timing.IsFirstTimePredicted)
             {
-                // Not guaranteed to open so rely upon the event handling it.
-                // Also lets client request it to be opened remotely too.
                 RaisePredictiveEvent(new BoundUIWrapMessage(GetNetEntity(entity.Owner), new OpenBoundInterfaceMessage(), key));
             }
         }

--- a/Robust.Shared/GameObjects/Systems/TimerSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/TimerSystem.cs
@@ -12,7 +12,7 @@ namespace Robust.Shared.GameObjects
             base.Update(frameTime);
 
             // Avoid a collection was modified while enumerating.
-            var timers = EntityManager.EntityQueryEnumerator<TimerComponent>();
+            var timers = EntityQueryEnumerator<TimerComponent>();
             var timersList = new ValueList<(EntityUid, TimerComponent)>();
             while (timers.MoveNext(out var uid, out var timer))
             {
@@ -28,7 +28,7 @@ namespace Robust.Shared.GameObjects
             {
                 if (!timer.Deleted && !EntityManager.Deleted(uid) && timer.RemoveOnEmpty && timer.TimerCount == 0)
                 {
-                    EntityManager.RemoveComponent<TimerComponent>(uid);
+                    RemComp<TimerComponent>(uid);
                 }
             }
         }

--- a/Robust.Shared/GameObjects/Systems/TimerSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/TimerSystem.cs
@@ -12,7 +12,7 @@ namespace Robust.Shared.GameObjects
             base.Update(frameTime);
 
             // Avoid a collection was modified while enumerating.
-            var timers = EntityQueryEnumerator<TimerComponent>();
+            var timers = EntityManager.EntityQueryEnumerator<TimerComponent>();
             var timersList = new ValueList<(EntityUid, TimerComponent)>();
             while (timers.MoveNext(out var uid, out var timer))
             {
@@ -28,7 +28,7 @@ namespace Robust.Shared.GameObjects
             {
                 if (!timer.Deleted && !EntityManager.Deleted(uid) && timer.RemoveOnEmpty && timer.TimerCount == 0)
                 {
-                    RemComp<TimerComponent>(uid);
+                    EntityManager.RemoveComponent<TimerComponent>(uid);
                 }
             }
         }

--- a/Robust.Shared/Physics/Systems/FixtureSystem.cs
+++ b/Robust.Shared/Physics/Systems/FixtureSystem.cs
@@ -257,7 +257,7 @@ namespace Robust.Shared.Physics.Systems
             if (args.Current is not FixtureManagerComponentState state)
                 return;
 
-            if (!TryComp(uid, out PhysicsComponent? physics))
+            if (!EntityManager.TryGetComponent(uid, out PhysicsComponent? physics))
             {
                 Log.Error($"Tried to apply fixture state for an entity without physics: {ToPrettyString(uid)}");
                 return;

--- a/Robust.Shared/Physics/Systems/FixtureSystem.cs
+++ b/Robust.Shared/Physics/Systems/FixtureSystem.cs
@@ -257,7 +257,7 @@ namespace Robust.Shared.Physics.Systems
             if (args.Current is not FixtureManagerComponentState state)
                 return;
 
-            if (!EntityManager.TryGetComponent(uid, out PhysicsComponent? physics))
+            if (!TryComp(uid, out PhysicsComponent? physics))
             {
                 Log.Error($"Tried to apply fixture state for an entity without physics: {ToPrettyString(uid)}");
                 return;

--- a/Robust.Shared/Physics/Systems/SharedJointSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedJointSystem.cs
@@ -121,7 +121,7 @@ public abstract partial class SharedJointSystem : EntitySystem
         foreach (var joint in _dirtyJoints)
         {
             if (joint.Comp.Deleted || joint.Comp.JointCount != 0) continue;
-            EntityManager.RemoveComponent<JointComponent>(joint);
+            RemComp<JointComponent>(joint);
         }
 
         _dirtyJoints.Clear();
@@ -551,7 +551,7 @@ public abstract partial class SharedJointSystem : EntitySystem
             _physics.WakeBody(uidA);
         }
 
-        if (EntityManager.TryGetComponent<PhysicsComponent>(bodyBUid, out var bodyB) &&
+        if (TryComp<PhysicsComponent>(bodyBUid, out var bodyB) &&
             MetaData(bodyBUid).EntityLifeStage < EntityLifeStage.Terminating)
         {
             var uidB = jointComponentB.Relay ?? bodyBUid;

--- a/Robust.Shared/Physics/Systems/SharedJointSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedJointSystem.cs
@@ -121,7 +121,7 @@ public abstract partial class SharedJointSystem : EntitySystem
         foreach (var joint in _dirtyJoints)
         {
             if (joint.Comp.Deleted || joint.Comp.JointCount != 0) continue;
-            RemComp<JointComponent>(joint);
+            EntityManager.RemoveComponent<JointComponent>(joint);
         }
 
         _dirtyJoints.Clear();
@@ -551,7 +551,7 @@ public abstract partial class SharedJointSystem : EntitySystem
             _physics.WakeBody(uidA);
         }
 
-        if (TryComp<PhysicsComponent>(bodyBUid, out var bodyB) &&
+        if (EntityManager.TryGetComponent<PhysicsComponent>(bodyBUid, out var bodyB) &&
             MetaData(bodyBUid).EntityLifeStage < EntityLifeStage.Terminating)
         {
             var uidB = jointComponentB.Relay ?? bodyBUid;


### PR DESCRIPTION
Replaces all instances within `EntitySystem`-derived classes of `EntityManager.SomeMethodThatHasAProxy` with the appropriate proxy methods.

This is just the result of running the code fixer from https://github.com/space-wizards/RobustToolbox/pull/6026 on the RT solution.