### PR TITLE
Make `AddComp` type constraints consistent with `AddComponent`

### DIFF
--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -665,7 +665,7 @@ public partial class EntitySystem
 
     /// <inheritdoc cref="IEntityManager.AddComponent&lt;T&gt;(EntityUid)"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected T AddComp<T>(EntityUid uid) where T :  Component, new()
+    protected T AddComp<T>(EntityUid uid) where T :  IComponent, new()
     {
         return EntityManager.AddComponent<T>(uid);
     }


### PR DESCRIPTION
`EntitySystem.AddComp` has the constraint `where T :  Component, new()`
`EntityManager.AddComponent` has the constraint `where T : IComponent, new()`

All the other proxy methods in `EntitySystem` also use `IComponent` instead of `Component`.

This PR changes the constraint on `AddComp` to `where T :  IComponent, new()` so that it matches the constraint of `AddComponent`. I see no reason not to do this, as there is no reason for `AddComp` to be more restrictive with its type arguments.

This came up because https://github.com/space-wizards/RobustToolbox/pull/6026 (as part of https://github.com/space-wizards/space-station-14/pull/38353) replaced an instance of `EntityManager.AddComponent(IComponent)` with `AddComp(IComponent)` which wound up invalid, because `AddComp` cannot accept `IComponent`. I'll fix the analyzer so it notices differences in type constraints, but this particular instance seems like a bug.

## Changelog 
`EntitySystem.AddComp<T>` now accepts any `IComponent` as a type argument instead of only `Component`. This matches the type constraints of `EntityManager.AddComponent<T>`