### PR TITLE
Soften rotation mirroring check for OD

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
@@ -254,9 +254,9 @@ namespace Robust.Client.Graphics.Clyde
                             region = regionMaybe[tile.Variant];
                         }
 
-                        var rotationMirroring = _tileDefinitionManager[tile.TypeId].AllowRotationMirror
-                            ? tile.RotationMirroring
-                            : 0;
+                        var rotationMirroring = (_tileDefinitionManager.TryGetDefinition(tile.TypeId, out var tileDef) && tileDef.AllowRotationMirror) ?
+                                                    tile.RotationMirroring
+                                                    : 0;
 
                         WriteTileToBuffers(i, gridX, gridY, vertexBuffer, indexBuffer, region, rotationMirroring);
                         i += 1;


### PR DESCRIPTION
OD does not register with the `TileDefinitionManager` for *reasons* so hard checks in the viewport pipeline throw errors. 

