### PR TITLE
Optimize `DataDefinitionAnalyzer` a bit

### DIFF
--- a/Robust.Analyzers/DataDefinitionAnalyzer.cs
+++ b/Robust.Analyzers/DataDefinitionAnalyzer.cs
@@ -152,14 +152,13 @@ public sealed class DataDefinitionAnalyzer : DiagnosticAnalyzer
         if (context.Node is not FieldDeclarationSyntax field)
             return;
 
-        if (context.ContainingSymbol is not IFieldSymbol fieldSymbol)
-            return;
-
-        if (fieldSymbol.ContainingType is not INamedTypeSymbol type)
+        if (context.ContainingSymbol?.ContainingType is not INamedTypeSymbol type)
             return;
 
         foreach (var variable in field.Declaration.Variables)
         {
+            var fieldSymbol = context.SemanticModel.GetDeclaredSymbol(variable);
+
             if (fieldSymbol == null)
                 continue;
 

--- a/Robust.Analyzers/DataDefinitionAnalyzer.cs
+++ b/Robust.Analyzers/DataDefinitionAnalyzer.cs
@@ -207,7 +207,7 @@ public sealed class DataDefinitionAnalyzer : DiagnosticAnalyzer
         if (propertySymbol.ContainingType is not INamedTypeSymbol type)
             return;
 
-        if (!IsDataDefinition(type) || type.IsRecord || type.IsValueType)
+        if (type.IsRecord || type.IsValueType)
             return;
 
         if (propertySymbol == null)

--- a/Robust.Analyzers/DataDefinitionAnalyzer.cs
+++ b/Robust.Analyzers/DataDefinitionAnalyzer.cs
@@ -22,7 +22,7 @@ public sealed class DataDefinitionAnalyzer : DiagnosticAnalyzer
     private const string DataFieldAttributeName = "DataField";
     private const string ViewVariablesAttributeName = "ViewVariables";
 
-    public static readonly DiagnosticDescriptor DataDefinitionPartialRule = new(
+    private static readonly DiagnosticDescriptor DataDefinitionPartialRule = new(
         Diagnostics.IdDataDefinitionPartial,
         "Type must be partial",
         "Type {0} is a DataDefinition but is not partial",
@@ -32,7 +32,7 @@ public sealed class DataDefinitionAnalyzer : DiagnosticAnalyzer
         "Make sure to mark any type that is a data definition as partial."
     );
 
-    public static readonly DiagnosticDescriptor NestedDataDefinitionPartialRule = new(
+    private static readonly DiagnosticDescriptor NestedDataDefinitionPartialRule = new(
         Diagnostics.IdNestedDataDefinitionPartial,
         "Type must be partial",
         "Type {0} contains nested data definition {1} but is not partial",


### PR DESCRIPTION
`DataDefinitionAnalyzer` has been around for a while and has accumulated a bit of cruft. This PR sorts out some of the weirdness and improves its performance a bit.

- Instead of analyzing every type definition to see if it's a data definition, then analyzing every field/property to see if it's part of a datadefinition, the analyzer now checks every type definition to see if it's a data definition, then analyzes only the fields/properties within that type. Because of this, we can also skip the checks that the containing type is a data definition (because it has to be for the analysis to occur in the first place).
- `IsReadOnlyDataField`, `HasRedundantTag`, `HasVVReadWrite`, and `IsNotYamlSerializable` are called in sequence and all started by calling `IsDataField`. Now we just call `IsDataField` once before calling any of them, so we don't have to run the method just to get the same results 4 times.
- ~There was a `foreach` loop in `AnalyzeDataField` that iterated over each variable in the field declaration. However, none of the conditions actually use this information, so it's pointless. I don't believe we ever use multiple variable declarations on datafields (like `[DataField] public int foo, bar;` - would that even serialize?), so this probably doesn't help performance, but it's a bit cleaner.~