### PR TITLE
fix: don't delete people who are tpto'd to themselves

### DIFF
--- a/Robust.Shared/Console/Commands/TeleportCommands.cs
+++ b/Robust.Shared/Console/Commands/TeleportCommands.cs
@@ -127,10 +127,10 @@ public sealed class TeleportToCommand : LocalizedEntityCommands
         {
             foreach (var victim in args)
             {
-                if (victim == target)
+                if (!TryGetTransformFromUidOrUsername(victim, shell, out var uid, out var victimTransform))
                     continue;
 
-                if (!TryGetTransformFromUidOrUsername(victim, shell, out var uid, out var victimTransform))
+                if (uid == targetUid)
                     continue;
 
                 victims.Add((uid.Value, victimTransform));


### PR DESCRIPTION
`tpto JoeGenero 1234` when you're entity 1234 just deletes yourself. Telefragging is funny but not that funny.

Let me know if this needs a changelog.