### PR TITLE
Make some `PlacementManager` dependency fields public

### DIFF
--- a/Robust.Client/Placement/IPlacementManager.cs
+++ b/Robust.Client/Placement/IPlacementManager.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using Robust.Client.Graphics;
 using Robust.Shared.Enums;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Timing;
 
@@ -17,6 +20,10 @@ namespace Robust.Client.Placement
         bool Replacement { get; set; }
         PlacementMode? CurrentMode { get; set; }
         PlacementInformation? CurrentPermission { get; set; }
+
+        IEntityManager EntityManager { get; }
+        IEyeManager EyeManager { get; }
+        IMapManager MapManager { get; }
 
         /// <summary>
         /// The direction to spawn the entity in (presently exposed for EntitySpawnWindow UI)

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -32,12 +32,12 @@ namespace Robust.Client.Placement
         [Dependency] internal readonly IPlayerManager PlayerManager = default!;
         [Dependency] internal readonly IResourceCache ResourceCache = default!;
         [Dependency] private readonly IReflectionManager _reflectionManager = default!;
-        [Dependency] internal readonly IMapManager MapManager = default!;
+        [Dependency] public readonly IMapManager MapManager = default!;
         [Dependency] private readonly IGameTiming _time = default!;
-        [Dependency] internal readonly IEyeManager EyeManager = default!;
+        [Dependency] public readonly IEyeManager EyeManager = default!;
         [Dependency] internal readonly IInputManager InputManager = default!;
         [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
-        [Dependency] internal readonly IEntityManager EntityManager = default!;
+        [Dependency] public readonly IEntityManager EntityManager = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly IBaseClient _baseClient = default!;
         [Dependency] private readonly IOverlayManager _overlayManager = default!;

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -32,16 +32,20 @@ namespace Robust.Client.Placement
         [Dependency] internal readonly IPlayerManager PlayerManager = default!;
         [Dependency] internal readonly IResourceCache ResourceCache = default!;
         [Dependency] private readonly IReflectionManager _reflectionManager = default!;
-        [Dependency] internal readonly IMapManager MapManager = default!;
+        [Dependency] private readonly IMapManager _mapManager = default!;
         [Dependency] private readonly IGameTiming _time = default!;
-        [Dependency] internal readonly IEyeManager EyeManager = default!;
+        [Dependency] private readonly IEyeManager _eyeManager = default!;
         [Dependency] internal readonly IInputManager InputManager = default!;
         [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
-        [Dependency] internal readonly IEntityManager EntityManager = default!;
+        [Dependency] private readonly IEntityManager _entityManager = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly IBaseClient _baseClient = default!;
         [Dependency] private readonly IOverlayManager _overlayManager = default!;
         [Dependency] internal readonly IClyde Clyde = default!;
+
+        public IEntityManager EntityManager => _entityManager;
+        public IEyeManager EyeManager => _eyeManager;
+        public IMapManager MapManager => _mapManager;
 
         private ISawmill _sawmill = default!;
 

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -32,12 +32,12 @@ namespace Robust.Client.Placement
         [Dependency] internal readonly IPlayerManager PlayerManager = default!;
         [Dependency] internal readonly IResourceCache ResourceCache = default!;
         [Dependency] private readonly IReflectionManager _reflectionManager = default!;
-        [Dependency] public readonly IMapManager MapManager = default!;
+        [Dependency] internal readonly IMapManager MapManager = default!;
         [Dependency] private readonly IGameTiming _time = default!;
-        [Dependency] public readonly IEyeManager EyeManager = default!;
+        [Dependency] internal readonly IEyeManager EyeManager = default!;
         [Dependency] internal readonly IInputManager InputManager = default!;
         [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
-        [Dependency] public readonly IEntityManager EntityManager = default!;
+        [Dependency] internal readonly IEntityManager EntityManager = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly IBaseClient _baseClient = default!;
         [Dependency] private readonly IOverlayManager _overlayManager = default!;


### PR DESCRIPTION
Changes `PlacementManager` fields `MapManager`, `EyeManager`, and `EntityManager` from internal to public.

This is to allow content-defined placement modes to access these managers the same way as engine-defined placement modes, rather than having to IoC resolve them.