### PR TITLE
fix: apply scale when calculating sprite bounding box

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Sprite scale is now correctly applied to sprite boundaries in `SpriteSystem.GetLocalBounds`.
 
 ### Other
 

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Bounds.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Bounds.cs
@@ -32,7 +32,7 @@ public sealed partial class SpriteSystem
                 bounds = bounds.Union(GetLocalBounds(layer));
         }
 
-        sprite.Comp._bounds = bounds;
+        sprite.Comp._bounds = bounds.Scale(sprite.Comp.Scale);
         sprite.Comp.BoundsDirty = false;
         return sprite.Comp._bounds;
     }


### PR DESCRIPTION
Was present pre-sprite rework, looks like it just got dropped in the move.

Fixes space-wizards/space-station-14#38513.

Original implementation was https://github.com/space-wizards/RobustToolbox/blob/d24854d94ff7cfd942364ae3be7de1f67b389932/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs#L673-L684