### PR TITLE
Add `AlwaysActive` to WebViewControl

### DIFF
--- a/Robust.Client.WebView/Cef/WebViewManagerCef.Control.cs
+++ b/Robust.Client.WebView/Cef/WebViewManagerCef.Control.cs
@@ -162,9 +162,10 @@ namespace Robust.Client.WebView.Cef
                 }
             }
 
+            public bool IsOpen => _data != null;
             public bool IsLoading => _data?.Browser.IsLoading ?? false;
 
-            public void EnteredTree()
+            public void StartBrowser()
             {
                 DebugTools.AssertNull(_data);
 
@@ -195,7 +196,7 @@ namespace Robust.Client.WebView.Cef
                 _data = new LiveData(texture, client, browser, renderer);
             }
 
-            public void ExitedTree()
+            public void CloseBrowser()
             {
                 DebugTools.AssertNotNull(_data);
 

--- a/Robust.Client.WebView/Headless/WebViewManagerHeadless.cs
+++ b/Robust.Client.WebView/Headless/WebViewManagerHeadless.cs
@@ -81,11 +81,13 @@ namespace Robust.Client.WebView.Headless
 
         private sealed class WebViewControlImplDummy : DummyBase, IWebViewControlImpl
         {
-            public void EnteredTree()
+            public bool IsOpen => false;
+
+            public void StartBrowser()
             {
             }
 
-            public void ExitedTree()
+            public void CloseBrowser()
             {
             }
 

--- a/Robust.Client.WebView/IWebViewControlImpl.cs
+++ b/Robust.Client.WebView/IWebViewControlImpl.cs
@@ -9,8 +9,10 @@ namespace Robust.Client.WebView
     /// </summary>
     internal interface IWebViewControlImpl : IWebViewControl
     {
-        void EnteredTree();
-        void ExitedTree();
+        public bool IsOpen { get; }
+
+        void StartBrowser();
+        void CloseBrowser();
         void MouseMove(GUIMouseMoveEventArgs args);
         void MouseExited();
         void MouseWheel(GUIMouseWheelEventArgs args);


### PR DESCRIPTION
OpenDream needs the javascript of browser controls to always be running, even if they're not in the UI tree. This adds an `AlwaysActive` property that allows that.