### PR TITLE
Use non-generic `TryComp` to get `MetaDataComponent` in `DebugAnchoringSystem`

### DIFF
--- a/Robust.Client/Debugging/DebugAnchoringSystem.cs
+++ b/Robust.Client/Debugging/DebugAnchoringSystem.cs
@@ -82,7 +82,7 @@ namespace Robust.Client.Debugging
 
             foreach (var ent in _mapSystem.GetAnchoredEntities(gridUid, grid, spot))
             {
-                if (TryComp<MetaDataComponent>(ent, out var meta))
+                if (TryComp(ent, out MetaDataComponent? meta))
                 {
                     text.AppendLine($"uid: {ent}, {meta.EntityName}");
                 }


### PR DESCRIPTION
Fixes the `RA0030 (Use non-generic variant)` warning.