### PR TITLE
Cleanup prototype instantiation warnings in tests

### DIFF
--- a/Robust.UnitTesting/Shared/EntitySerialization/AutoIncludeSerializationTest.cs
+++ b/Robust.UnitTesting/Shared/EntitySerialization/AutoIncludeSerializationTest.cs
@@ -17,10 +17,19 @@ namespace Robust.UnitTesting.Shared.EntitySerialization;
 [TestFixture]
 public sealed partial class AutoIncludeSerializationTest : RobustIntegrationTest
 {
+    private const string TestTileDefId = "a";
+    private const string TestPrototypes = $@"
+- type: testTileDef
+  id: space
+
+- type: testTileDef
+  id: {TestTileDefId}
+    ";
+
     [Test]
     public async Task TestAutoIncludeSerialization()
     {
-        var server = StartServer(new() {Pool = false}); // Pool=false due to TileDef registration
+        var server = StartServer(new() { Pool = false, ExtraPrototypes = TestPrototypes }); // Pool=false due to TileDef registration
         await server.WaitIdleAsync();
         var entMan = server.EntMan;
         var mapSys = server.System<SharedMapSystem>();
@@ -30,9 +39,8 @@ public sealed partial class AutoIncludeSerializationTest : RobustIntegrationTest
         var mapPath = new ResPath($"{nameof(AutoIncludeSerializationTest)}_map.yml");
         var gridPath = new ResPath($"{nameof(AutoIncludeSerializationTest)}_grid.yml");
 
-        tileMan.Register(new TileDef("space"));
-        var tDef = new TileDef("a");
-        tileMan.Register(tDef);
+        SerializationTestHelper.LoadTileDefs(server.ProtoMan, tileMan, "space");
+        var tDef = server.ProtoMan.Index<TileDef>(TestTileDefId);
 
         // Create a map that contains an entity that references a nullspace entity.
         MapId mapId = default;

--- a/Robust.UnitTesting/Shared/EntitySerialization/BackwardsCompatibilityTest.v3.cs
+++ b/Robust.UnitTesting/Shared/EntitySerialization/BackwardsCompatibilityTest.v3.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Robust.Shared.ContentPack;
@@ -35,11 +36,7 @@ public sealed partial class BackwardsCompatibilityTest
         var tileMan = server.ResolveDependency<ITileDefinitionManager>();
         var resourceManager = server.ResolveDependency<IResourceManagerInternal>();
 
-        tileMan.Register(new TileDef("Space"));
-        for (var i = 1; i <= 88; i++)
-        {
-            tileMan.Register(new TileDef(i.ToString()));
-        }
+        SerializationTestHelper.LoadTileDefs(server.ProtoMan, tileMan);
         var gridPath = new ResPath($"{nameof(MapDataV3Grid)}.yml");
         resourceManager.MountString(gridPath.ToString(), MapDataV3Grid);
 
@@ -425,11 +422,29 @@ entities:
 ...
 ";
 
-    private const string PrototypeV3 = @"
+    private static string GenerateTileDefs(int count)
+    {
+        var sb = new StringBuilder();
+        for (var i = 0; i < count; i++)
+        {
+            sb.Append($@"
+- type: testTileDef
+  id: {i}"
+            );
+        }
+        return sb.ToString();
+    }
+
+    private static readonly string PrototypeV3 = $@"
 - type: entity
   id: V3TestProto
   components:
   - type: EntitySaveTest
     list: [ 1, 2 ]
+
+- type: testTileDef
+  id: Space
+
+{GenerateTileDefs(88)}
 ";
 }

--- a/Robust.UnitTesting/Shared/EntitySerialization/BackwardsCompatibilityTest.v4.cs
+++ b/Robust.UnitTesting/Shared/EntitySerialization/BackwardsCompatibilityTest.v4.cs
@@ -33,9 +33,7 @@ public sealed partial class BackwardsCompatibilityTest
         var tileMan = server.ResolveDependency<ITileDefinitionManager>();
         var resourceManager = server.ResolveDependency<IResourceManagerInternal>();
 
-        tileMan.Register(new TileDef("Space"));
-        tileMan.Register(new TileDef("A"));
-        tileMan.Register(new TileDef("B"));
+        SerializationTestHelper.LoadTileDefs(server.ProtoMan, tileMan, "Space");
         var gridPath = new ResPath($"{nameof(MapDataV4Grid)}.yml");
         resourceManager.MountString(gridPath.ToString(), MapDataV4Grid);
 
@@ -256,5 +254,14 @@ entities:
   components:
   - type: EntitySaveTest
     list: [ 1, 2 ]
+
+- type: testTileDef
+  id: Space
+
+- type: testTileDef
+  id: A
+
+- type: testTileDef
+  id: B
 ";
 }

--- a/Robust.UnitTesting/Shared/EntitySerialization/BackwardsCompatibilityTest.v5.cs
+++ b/Robust.UnitTesting/Shared/EntitySerialization/BackwardsCompatibilityTest.v5.cs
@@ -33,9 +33,7 @@ public sealed partial class BackwardsCompatibilityTest
         var tileMan = server.ResolveDependency<ITileDefinitionManager>();
         var resourceManager = server.ResolveDependency<IResourceManagerInternal>();
 
-        tileMan.Register(new TileDef("Space"));
-        tileMan.Register(new TileDef("A"));
-        tileMan.Register(new TileDef("B"));
+        SerializationTestHelper.LoadTileDefs(server.ProtoMan, tileMan, "Space");
         var gridPath = new ResPath($"{nameof(MapDataV5Grid)}.yml");
         resourceManager.MountString(gridPath.ToString(), MapDataV5Grid);
 
@@ -255,5 +253,14 @@ entities:
   components:
   - type: EntitySaveTest
     list: [ 1, 2 ]
+
+- type: testTileDef
+  id: Space
+
+- type: testTileDef
+  id: A
+
+- type: testTileDef
+  id: B
 ";
 }

--- a/Robust.UnitTesting/Shared/EntitySerialization/BackwardsCompatibilityTest.v6.cs
+++ b/Robust.UnitTesting/Shared/EntitySerialization/BackwardsCompatibilityTest.v6.cs
@@ -33,9 +33,7 @@ public sealed partial class BackwardsCompatibilityTest
         var tileMan = server.ResolveDependency<ITileDefinitionManager>();
         var resourceManager = server.ResolveDependency<IResourceManagerInternal>();
 
-        tileMan.Register(new TileDef("Space"));
-        tileMan.Register(new TileDef("A"));
-        tileMan.Register(new TileDef("B"));
+        SerializationTestHelper.LoadTileDefs(server.ProtoMan, tileMan, "Space");
         var gridPath = new ResPath($"{nameof(MapDataV6Grid)}.yml");
         resourceManager.MountString(gridPath.ToString(), MapDataV6Grid);
 
@@ -262,5 +260,14 @@ entities:
   components:
   - type: EntitySaveTest
     list: [ 1, 2 ]
+
+- type: testTileDef
+  id: Space
+
+- type: testTileDef
+  id: A
+
+- type: testTileDef
+  id: B
 ";
 }

--- a/Robust.UnitTesting/Shared/EntitySerialization/BackwardsCompatibilityTest.v7.cs
+++ b/Robust.UnitTesting/Shared/EntitySerialization/BackwardsCompatibilityTest.v7.cs
@@ -30,7 +30,7 @@ public sealed partial class BackwardsCompatibilityTest : RobustIntegrationTest
     [Test]
     public async Task TestLoadV7()
     {
-        var server = StartServer();
+        var server = StartServer(new ServerIntegrationOptions { ExtraPrototypes = PrototypeV7 });
         await server.WaitIdleAsync();
         var entMan = server.EntMan;
         var mapSys = server.System<SharedMapSystem>();
@@ -38,8 +38,7 @@ public sealed partial class BackwardsCompatibilityTest : RobustIntegrationTest
         var tileMan = server.ResolveDependency<ITileDefinitionManager>();
         var resourceManager = server.ResolveDependency<IResourceManagerInternal>();
 
-        tileMan.Register(new TileDef("space"));
-        tileMan.Register(new TileDef("a"));
+        SerializationTestHelper.LoadTileDefs(server.ProtoMan, tileMan, "space");
 
         void AssertCount(int expected) => Assert.That(entMan.Count<EntitySaveTestComponent>(), Is.EqualTo(expected));
         Assert.That(entMan.Count<LoadedMapComponent>(), Is.EqualTo(0));
@@ -342,5 +341,12 @@ entities:
     - type: EntitySaveTest
       list: []
       id: nullC
+";
+    private const string PrototypeV7 = @"
+- type: testTileDef
+  id: space
+
+- type: testTileDef
+  id: a
 ";
 }

--- a/Robust.UnitTesting/Shared/EntitySerialization/CategorizationTest.cs
+++ b/Robust.UnitTesting/Shared/EntitySerialization/CategorizationTest.cs
@@ -13,6 +13,15 @@ namespace Robust.UnitTesting.Shared.EntitySerialization;
 [TestFixture]
 public sealed partial class CategorizationTest : RobustIntegrationTest
 {
+    private const string TestTileDefId = "a";
+    private const string TestPrototypes = $@"
+- type: testTileDef
+  id: space
+
+- type: testTileDef
+  id: {TestTileDefId}
+    ";
+
     /// <summary>
     /// Check that file categories are correctly assigned when saving & loading different combinations of entites.
     /// </summary>
@@ -20,7 +29,7 @@ public sealed partial class CategorizationTest : RobustIntegrationTest
     [TestOf(typeof(FileCategory))]
     public async Task TestCategorization()
     {
-        var server = StartServer(new() {Pool = false}); // Pool=false due to TileDef registration
+        var server = StartServer(new() { Pool = false, ExtraPrototypes = TestPrototypes }); // Pool=false due to TileDef registration
         await server.WaitIdleAsync();
         var entMan = server.EntMan;
         var meta = server.System<MetaDataSystem>();
@@ -30,9 +39,8 @@ public sealed partial class CategorizationTest : RobustIntegrationTest
         var tileMan = server.ResolveDependency<ITileDefinitionManager>();
         var path = new ResPath($"{nameof(TestCategorization)}.yml");
 
-        tileMan.Register(new TileDef("space"));
-        var tDef = new TileDef("a");
-        tileMan.Register(tDef);
+        SerializationTestHelper.LoadTileDefs(server.ProtoMan, tileMan, "space");
+        var tDef = server.ProtoMan.Index<TileDef>(TestTileDefId);
 
         EntityUid mapA = default;
         EntityUid mapB = default;

--- a/Robust.UnitTesting/Shared/EntitySerialization/MapMergeTest.cs
+++ b/Robust.UnitTesting/Shared/EntitySerialization/MapMergeTest.cs
@@ -18,10 +18,19 @@ namespace Robust.UnitTesting.Shared.EntitySerialization;
 [TestFixture]
 public sealed partial class MapMergeTest : RobustIntegrationTest
 {
+    private const string TestTileDefId = "a";
+    private const string TestPrototypes = $@"
+- type: testTileDef
+  id: space
+
+- type: testTileDef
+  id: {TestTileDefId}
+    ";
+
     [Test]
     public async Task TestMapMerge()
     {
-        var server = StartServer(new() {Pool = false}); // Pool=false due to TileDef registration
+        var server = StartServer(new() { Pool = false, ExtraPrototypes = TestPrototypes }); // Pool=false due to TileDef registration
         await server.WaitIdleAsync();
         var entMan = server.EntMan;
         var mapSys = server.System<SharedMapSystem>();
@@ -32,9 +41,8 @@ public sealed partial class MapMergeTest : RobustIntegrationTest
         var mapPath = new ResPath($"{nameof(TestMapMerge)}_map.yml");
         var gridPath = new ResPath($"{nameof(TestMapMerge)}_grid.yml");
 
-        tileMan.Register(new TileDef("space"));
-        var tDef = new TileDef("a");
-        tileMan.Register(tDef);
+        SerializationTestHelper.LoadTileDefs(server.ProtoMan, tileMan, "space");
+        var tDef = server.ProtoMan.Index<TileDef>(TestTileDefId);
 
         MapId mapId = default;
         Entity<TransformComponent, EntitySaveTestComponent> map = default;

--- a/Robust.UnitTesting/Shared/EntitySerialization/OrphanSerializationTest.cs
+++ b/Robust.UnitTesting/Shared/EntitySerialization/OrphanSerializationTest.cs
@@ -15,6 +15,15 @@ namespace Robust.UnitTesting.Shared.EntitySerialization;
 [TestFixture]
 public sealed partial class OrphanSerializationTest : RobustIntegrationTest
 {
+    private const string TestTileDefId = "a";
+    private const string TestPrototypes = $@"
+- type: testTileDef
+  id: space
+
+- type: testTileDef
+  id: {TestTileDefId}
+    ";
+
     /// <summary>
     /// Check that we can save & load a file containing multiple orphaned (non-grid) entities.
     /// </summary>
@@ -114,7 +123,7 @@ public sealed partial class OrphanSerializationTest : RobustIntegrationTest
     [Test]
     public async Task TestOrphanedGridSerialization()
     {
-        var server = StartServer(new() {Pool = false}); // Pool=false due to TileDef registration
+        var server = StartServer(new() { Pool = false, ExtraPrototypes = TestPrototypes }); // Pool=false due to TileDef registration
         await server.WaitIdleAsync();
         var entMan = server.EntMan;
         var mapSys = server.System<SharedMapSystem>();
@@ -126,9 +135,8 @@ public sealed partial class OrphanSerializationTest : RobustIntegrationTest
         var pathB = new ResPath($"{nameof(TestOrphanedGridSerialization)}_B.yml");
         var pathCombined = new ResPath($"{nameof(TestOrphanedGridSerialization)}_C.yml");
 
-        tileMan.Register(new TileDef("space"));
-        var tDef = new TileDef("a");
-        tileMan.Register(tDef);
+        SerializationTestHelper.LoadTileDefs(server.ProtoMan, tileMan, "space");
+        var tDef = server.ProtoMan.Index<TileDef>(TestTileDefId);
 
         // Spawn multiple entities on a map
         MapId mapId = default;

--- a/Robust.UnitTesting/Shared/EntitySerialization/SerializationTestHelper.cs
+++ b/Robust.UnitTesting/Shared/EntitySerialization/SerializationTestHelper.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Robust.UnitTesting.Shared.EntitySerialization;
+
+public static class SerializationTestHelper
+{
+    public static void LoadTileDefs(IPrototypeManager protoMan, ITileDefinitionManager tileMan, string? spaceId = "Space")
+    {
+        var prototypeList = new List<TileDef>();
+        foreach (var tileDef in protoMan.EnumeratePrototypes<TileDef>())
+        {
+            if (tileDef.ID == spaceId)
+            {
+                // Filter out the space tile def and register it first
+                tileMan.Register(tileDef);
+                continue;
+            }
+
+            prototypeList.Add(tileDef);
+        }
+
+        prototypeList.Sort((a, b) => string.Compare(a.ID, b.ID, StringComparison.Ordinal));
+
+        // Register the rest
+        foreach (var tileDef in prototypeList)
+        {
+            tileMan.Register(tileDef);
+        }
+    }
+}

--- a/Robust.UnitTesting/Shared/EntitySerialization/TestComponents.cs
+++ b/Robust.UnitTesting/Shared/EntitySerialization/TestComponents.cs
@@ -46,13 +46,13 @@ public sealed partial class EntitySaveTestComponent : Component
 /// Dummy tile definition for serializing grids.
 /// </summary>
 [Prototype("testTileDef")]
-public sealed class TileDef(string id) : ITileDefinition
+public sealed partial class TileDef : ITileDefinition
 {
     public ushort TileId { get; set; }
-    public string Name => id;
+    public string Name => ID;
 
     [IdDataField]
-    public string ID => id;
+    public string ID { get; private set; } = default!;
     public ResPath? Sprite => null;
     public Dictionary<Direction, ResPath> EdgeSprites => new();
     public int EdgeSpritePriority => 0;


### PR DESCRIPTION
Fixes 21 warnings from prototypes being manually instantiated in the Entity Serialization "unit" tests.

- The test `TileDef` dummy prototype was updated to actually meet the requirements of a prototype, enabling `PrototypeManager` to load instances from YAML.
- Tests now define the needed test tile def prototypes in YAML strings which are loaded using the `ExtraPrototypes` test option.
- Added a static helper class `SerializationTestHelper` with a method that gets the test tile defs from `PrototypeManager` and registers them with `TileDefinitionManager`, mimicking the behavior of Content's `EntryPoint`.

https://github.com/space-wizards/space-station-14/issues/33279