### PR TITLE
Remove prototype instantiation from `AssetPassAudioMetadata`

### DIFF
--- a/Robust.Packaging/AssetProcessing/Passes/AssetPassAudioMetadata.cs
+++ b/Robust.Packaging/AssetProcessing/Passes/AssetPassAudioMetadata.cs
@@ -14,7 +14,7 @@ namespace Robust.Packaging.AssetProcessing.Passes;
 /// </summary>
 public sealed class AssetPassAudioMetadata : AssetPass
 {
-    private readonly List<AudioMetadataPrototype> _audioMetadata = new();
+    private readonly List<(string ID, TimeSpan Length)> _audioMetadata = new();
     private readonly string _metadataPath;
 
     public AssetPassAudioMetadata(string metadataPath = "Prototypes/_audio_metadata.yml")
@@ -32,11 +32,7 @@ public sealed class AssetPassAudioMetadata : AssetPass
 
         lock (_audioMetadata)
         {
-            _audioMetadata.Add(new AudioMetadataPrototype()
-            {
-                ID = "/" + file.Path,
-                Length = metadata.Length,
-            });
+            _audioMetadata.Add(("/" + file.Path, metadata.Length));
         }
 
         return AssetFileAcceptResult.Consumed;


### PR DESCRIPTION
They were just being used to track a string and a TimeSpan for each item in a list, so we can just use a tuple instead.

https://github.com/space-wizards/space-station-14/issues/33279