### PR TITLE
Mark ValidatePrototypeIdAttribute as obsolete

### DIFF
--- a/Robust.Shared/Serialization/Manager/Attributes/ValidatePrototypeIdAttribute.cs
+++ b/Robust.Shared/Serialization/Manager/Attributes/ValidatePrototypeIdAttribute.cs
@@ -8,6 +8,7 @@ namespace Robust.Shared.Serialization.Manager.Attributes;
 /// valid YAML prototype ids. This attribute is not required for static <see cref="ProtoId{T}"/> and
 /// <see cref="EntProtoId"/> fields, as they automatically get validated.
 /// </summary>
+[Obsolete("Use a static readonly ProtoId<T> instead")]
 [AttributeUsage(AttributeTargets.Field)]
 public sealed class ValidatePrototypeIdAttribute<T> : Attribute where T : IPrototype
 {


### PR DESCRIPTION
These have completely fallen out of favor in exchange for the static ProtoIds so we should just mark them as obsolete so we can start to get rid of them and people can stop using them.