### PR TITLE
Add `ForbidLiteral` to `IPrototypeManager` methods

### DIFF
--- a/Robust.Client/GameStates/NetInterpOverlay.cs
+++ b/Robust.Client/GameStates/NetInterpOverlay.cs
@@ -13,6 +13,8 @@ namespace Robust.Client.GameStates
 {
     internal sealed class NetInterpOverlay : Overlay
     {
+        private static readonly ProtoId<ShaderPrototype> UnshadedShader = "unshaded";
+
         [Dependency] private readonly IGameTiming _timing = default!;
         [Dependency] private readonly IEntityManager _entityManager = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
@@ -32,7 +34,7 @@ namespace Robust.Client.GameStates
         {
             IoCManager.InjectDependencies(this);
             _lookup = lookup;
-            _shader = _prototypeManager.Index<ShaderPrototype>("unshaded").Instance();
+            _shader = _prototypeManager.Index(UnshadedShader).Instance();
             _container = _entityManager.System<SharedContainerSystem>();
             _xform = _entityManager.System<SharedTransformSystem>();
         }

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -43,6 +43,8 @@ namespace Robust.Client.Placement
         [Dependency] private readonly IOverlayManager _overlayManager = default!;
         [Dependency] internal readonly IClyde Clyde = default!;
 
+        private static readonly ProtoId<ShaderPrototype> UnshadedShader = "unshaded";
+
         public IEntityManager EntityManager => _entityManager;
         public IEyeManager EyeManager => _eyeManager;
         public IMapManager MapManager => _mapManager;
@@ -213,7 +215,7 @@ namespace Robust.Client.Placement
 
         public void Initialize()
         {
-            _drawingShader = _prototypeManager.Index<ShaderPrototype>("unshaded").Instance();
+            _drawingShader = _prototypeManager.Index(UnshadedShader).Instance();
             _sawmill = _logManager.GetSawmill("placement");
 
             _networkManager.RegisterNetMessage<MsgPlacement>(HandlePlacementMessage);

--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -94,13 +94,13 @@ public interface IPrototypeManager
     /// <exception cref="UnknownPrototypeException">
     /// Thrown if the type of prototype is not registered.
     /// </exception>
-    T Index<T>(string id) where T : class, IPrototype;
+    T Index<T>([ForbidLiteral] string id) where T : class, IPrototype;
 
     /// <inheritdoc cref="Index{T}(string)"/>
-    EntityPrototype Index(EntProtoId id);
+    EntityPrototype Index([ForbidLiteral] EntProtoId id);
 
     /// <inheritdoc cref="Index{T}(string)"/>
-    T Index<T>(ProtoId<T> id) where T : class, IPrototype;
+    T Index<T>([ForbidLiteral] ProtoId<T> id) where T : class, IPrototype;
 
     /// <summary>
     /// Index for a <see cref="IPrototype"/> by ID.
@@ -108,27 +108,27 @@ public interface IPrototypeManager
     /// <exception cref="UnknownPrototypeException">
     /// Thrown if the ID does not exist or the kind of prototype is not registered.
     /// </exception>
-    IPrototype Index(Type kind, string id);
+    IPrototype Index(Type kind, [ForbidLiteral] string id);
 
     /// <summary>
     ///     Returns whether a prototype of type <typeparamref name="T"/> with the specified <param name="id"/> exists.
     /// </summary>
-    bool HasIndex<T>(string id) where T : class, IPrototype;
+    bool HasIndex<T>([ForbidLiteral] string id) where T : class, IPrototype;
 
     /// <inheritdoc cref="HasIndex{T}(string)"/>
-    bool HasIndex(EntProtoId id);
+    bool HasIndex([ForbidLiteral] EntProtoId id);
 
     /// <inheritdoc cref="HasIndex{T}(string)"/>
-    bool HasIndex<T>(ProtoId<T> id) where T : class, IPrototype;
+    bool HasIndex<T>([ForbidLiteral] ProtoId<T> id) where T : class, IPrototype;
 
     /// <inheritdoc cref="HasIndex{T}(string)"/>
-    bool HasIndex(EntProtoId? id);
+    bool HasIndex([ForbidLiteral] EntProtoId? id);
 
     /// <inheritdoc cref="HasIndex{T}(string)"/>
-    bool HasIndex<T>(ProtoId<T>? id) where T : class, IPrototype;
+    bool HasIndex<T>([ForbidLiteral] ProtoId<T>? id) where T : class, IPrototype;
 
-    bool TryIndex<T>(string id, [NotNullWhen(true)] out T? prototype) where T : class, IPrototype;
-    bool TryIndex(Type kind, string id, [NotNullWhen(true)] out IPrototype? prototype);
+    bool TryIndex<T>([ForbidLiteral] string id, [NotNullWhen(true)] out T? prototype) where T : class, IPrototype;
+    bool TryIndex(Type kind, [ForbidLiteral] string id, [NotNullWhen(true)] out IPrototype? prototype);
 
     /// <summary>
     /// Attempts to get a dictionary containing all current instances of a given prototype kind.
@@ -144,19 +144,19 @@ public interface IPrototypeManager
     FrozenDictionary<string, T> GetInstances<T>() where T : IPrototype;
 
     /// <inheritdoc cref="TryIndex{T}(ProtoId{T}, out T, bool)"/>
-    bool TryIndex(EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype,  bool logError = true);
+    bool TryIndex([ForbidLiteral] EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype,  bool logError = true);
 
     /// <summary>
     /// Attempt to retrieve the prototype corresponding to the given prototype id.
     /// Unless otherwise specified, this will log an error if the id does not match any known prototype.
     /// </summary>
-    bool TryIndex<T>(ProtoId<T> id, [NotNullWhen(true)] out T? prototype,  bool logError = true) where T : class, IPrototype;
+    bool TryIndex<T>([ForbidLiteral] ProtoId<T> id, [NotNullWhen(true)] out T? prototype,  bool logError = true) where T : class, IPrototype;
 
     /// <inheritdoc cref="TryIndex{T}(ProtoId{T}, out T, bool)"/>
-    bool TryIndex(EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype,  bool logError = true);
+    bool TryIndex([ForbidLiteral] EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype,  bool logError = true);
 
     /// <inheritdoc cref="TryIndex{T}(ProtoId{T}, out T, bool)"/>
-    bool TryIndex<T>(ProtoId<T>? id, [NotNullWhen(true)] out T? prototype, bool logError = true) where T : class, IPrototype;
+    bool TryIndex<T>([ForbidLiteral] ProtoId<T>? id, [NotNullWhen(true)] out T? prototype, bool logError = true) where T : class, IPrototype;
 
     bool HasMapping<T>(string id);
     bool TryGetMapping(Type kind, string id, [NotNullWhen(true)] out MappingDataNode? mappings);

--- a/Robust.UnitTesting/Shared/GameObjects/EntityManager_Components_Tests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntityManager_Components_Tests.cs
@@ -16,9 +16,10 @@ namespace Robust.UnitTesting.Shared.GameObjects
     [TestFixture, Parallelizable ,TestOf(typeof(EntityManager))]
     public sealed partial class EntityManager_Components_Tests
     {
-        private const string DummyLoad = @"
+        private const string DummyLoadId = "DummyLoad";
+        private const string DummyLoad = $@"
         - type: entity
-          id: DummyLoad
+          id: {DummyLoadId}
           name: weh
           components:
           - type: Joint
@@ -40,7 +41,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             var coords = new EntityCoordinates(map, default);
             var entity = entMan.SpawnEntity(null, coords);
             Assert.That(!entMan.HasComponent<PhysicsComponent>(entity));
-            var proto = protoManager.Index<EntityPrototype>("DummyLoad");
+            var proto = protoManager.Index<EntityPrototype>(DummyLoadId);
 
             entMan.AddComponents(entity, proto);
             Assert.Multiple(() =>
@@ -63,8 +64,8 @@ namespace Robust.UnitTesting.Shared.GameObjects
 
             var map = sim.CreateMap().Uid;
             var coords = new EntityCoordinates(map, default);
-            var entity = entMan.SpawnEntity("DummyLoad", coords);
-            var proto = protoManager.Index<EntityPrototype>("DummyLoad");
+            var entity = entMan.SpawnEntity(DummyLoadId, coords);
+            var proto = protoManager.Index<EntityPrototype>(DummyLoadId);
 
             entMan.RemoveComponents(entity, proto);
             Assert.Multiple(() =>

--- a/Robust.UnitTesting/Shared/Prototypes/PrototypeManagerCategoriesTest.cs
+++ b/Robust.UnitTesting/Shared/Prototypes/PrototypeManagerCategoriesTest.cs
@@ -30,12 +30,12 @@ public sealed class PrototypeManagerCategoriesTest : RobustUnitTest
     [Test]
     public void TestExplicitCategories()
     {
-        var @default = _protoMan.Index<EntityPrototype>("Default");
+        var @default = _protoMan.Index<EntityPrototype>(DefaultEntity);
         Assert.That(@default.Categories, Is.Empty);
         Assert.That(@default.CategoriesInternal, Is.Null);
         Assert.That(@default.HideSpawnMenu, Is.False);
 
-        var hide = _protoMan.Index<EntityPrototype>("Hide");
+        var hide = _protoMan.Index<EntityPrototype>(HideEntity);
         Assert.That(hide.Categories.Count, Is.EqualTo(1));
         Assert.That(hide.CategoriesInternal?.Count, Is.EqualTo(1));
         Assert.That(hide.HideSpawnMenu, Is.True);
@@ -44,16 +44,16 @@ public sealed class PrototypeManagerCategoriesTest : RobustUnitTest
     [Test]
     public void TestInheritance()
     {
-        var child = _protoMan.Index<EntityPrototype>("InheritChild");
+        var child = _protoMan.Index<EntityPrototype>(InheritChildEntity);
         Assert.That(child.Categories.Count, Is.EqualTo(1));
         Assert.That(child.CategoriesInternal, Is.Null);
         Assert.That(child.HideSpawnMenu, Is.True);
 
-        var noInheritParent = _protoMan.Index<EntityPrototype>("NoInheritParent");
+        var noInheritParent = _protoMan.Index<EntityPrototype>(NoInheritParentEntity);
         Assert.That(noInheritParent.Categories.Count, Is.EqualTo(1));
         Assert.That(noInheritParent.CategoriesInternal?.Count, Is.EqualTo(1));
 
-        var noInheritChild = _protoMan.Index<EntityPrototype>("NoInheritChild");
+        var noInheritChild = _protoMan.Index<EntityPrototype>(NoInheritChildEntity);
         Assert.That(noInheritChild.Categories, Is.Empty);
         Assert.That(noInheritChild.CategoriesInternal, Is.Null);
     }
@@ -61,58 +61,58 @@ public sealed class PrototypeManagerCategoriesTest : RobustUnitTest
     [Test]
     public void TestAbstractInheritance()
     {
-        Assert.That(_protoMan.HasIndex<EntityPrototype>("AbstractParent"), Is.False);
-        Assert.That(_protoMan.HasIndex<EntityPrototype>("AbstractGrandChild"), Is.False);
+        Assert.That(_protoMan.HasIndex<EntityPrototype>(AbstractParentEntity), Is.False);
+        Assert.That(_protoMan.HasIndex<EntityPrototype>(AbstractGrandChildEntity), Is.False);
 
-        var concreteChild = _protoMan.Index<EntityPrototype>("ConcreteChild");
+        var concreteChild = _protoMan.Index<EntityPrototype>(ConcreteChildEntity);
         Assert.That(concreteChild.Categories.Select(x => x.ID),
-            Is.EquivalentTo(new []{"Default"}));
+            Is.EquivalentTo(new []{DefaultCategory}));
         Assert.That(concreteChild.CategoriesInternal, Is.Null);
 
-        var composition = _protoMan.Index<EntityPrototype>("CompositionAbstract");
+        var composition = _protoMan.Index<EntityPrototype>(CompositionAbstractEntity);
         Assert.That(composition.Categories.Select(x => x.ID),
-            Is.EquivalentTo(new []{"Default", "Hide", "Auto"}));
+            Is.EquivalentTo(new []{DefaultCategory, HideCategory, AutoCategory}));
         Assert.That(composition.CategoriesInternal, Is.Null);
     }
 
     [Test]
     public void TestComposition()
     {
-        var compA = _protoMan.Index<EntityPrototype>("CompositionA");
+        var compA = _protoMan.Index<EntityPrototype>(CompositionAEntity);
         Assert.That(compA.Categories.Select(x => x.ID),
-            Is.EquivalentTo(new []{"Default", "Hide"}));
+            Is.EquivalentTo(new []{DefaultCategory, HideCategory}));
         Assert.That(compA.CategoriesInternal?.Count, Is.EqualTo(2));
 
-        var compB = _protoMan.Index<EntityPrototype>("CompositionB");
+        var compB = _protoMan.Index<EntityPrototype>(CompositionBEntity);
         Assert.That(compB.Categories.Select(x => x.ID),
-            Is.EquivalentTo(new []{"Default", "NoInherit", "Auto"}));
+            Is.EquivalentTo(new []{DefaultCategory, NoInheritCategory, AutoCategory}));
         Assert.That(compB.CategoriesInternal?.Count, Is.EqualTo(3));
 
-        var childA = _protoMan.Index<EntityPrototype>("CompositionChildA");
+        var childA = _protoMan.Index<EntityPrototype>(CompositionChildAEntity);
         Assert.That(childA.Categories.Select(x => x.ID),
-            Is.EquivalentTo(new []{"Default", "Hide", "Auto"}));
+            Is.EquivalentTo(new []{DefaultCategory, HideCategory, AutoCategory}));
         Assert.That(childA.CategoriesInternal, Is.Null);
 
-        var childB = _protoMan.Index<EntityPrototype>("CompositionChildB");
+        var childB = _protoMan.Index<EntityPrototype>(CompositionChildBEntity);
         Assert.That(childB.Categories.Select(x => x.ID),
-            Is.EquivalentTo(new []{"Default", "Hide", "Auto", "Default2"}));
+            Is.EquivalentTo(new []{DefaultCategory, HideCategory, AutoCategory, Default2Category}));
         Assert.That(childB.CategoriesInternal?.Count, Is.EqualTo(1));
     }
 
     [Test]
     public void TestAutoCategorization()
     {
-        var auto = _protoMan.Index<EntityPrototype>("Auto");
-        Assert.That(auto.Categories.Select(x => x.ID), Is.EquivalentTo(new []{"Auto"}));
+        var auto = _protoMan.Index<EntityPrototype>(AutoEntity);
+        Assert.That(auto.Categories.Select(x => x.ID), Is.EquivalentTo(new []{AutoCategory}));
         Assert.That(auto.CategoriesInternal, Is.Null);
 
         //var autoAttrib = _protoMan.Index<EntityPrototype>("AutoAttribute");
         //Assert.That(autoAttrib.Categories.Select(x => x.ID), Is.EquivalentTo(new []{"Auto"}));
         //Assert.That(autoAttrib.CategoriesInternal, Is.Null);
 
-        var autoChild = _protoMan.Index<EntityPrototype>("AutoChild");
+        var autoChild = _protoMan.Index<EntityPrototype>(AutoChildEntity);
         Assert.That(autoChild.Categories.Select(x => x.ID),
-            Is.EquivalentTo(new []{"Auto", "Default"}));
+            Is.EquivalentTo(new []{AutoCategory, DefaultCategory}));
         Assert.That(autoChild.CategoriesInternal?.Count, Is.EqualTo(1));
 
 
@@ -121,104 +121,128 @@ public sealed class PrototypeManagerCategoriesTest : RobustUnitTest
     [Test]
     public void TestCategoryGrouping()
     {
-        var none = _protoMan.Categories[new("None")].Select(x=> x.ID);
+        var none = _protoMan.Categories[new(NoneCategory)].Select(x=> x.ID);
         Assert.That(none, Is.Empty);
 
-        var @default = _protoMan.Categories[new("Default")].Select(x=> x.ID);
-        Assert.That(@default, Is.EquivalentTo(new[] {"ConcreteChild", "CompositionAbstract", "CompositionA", "CompositionB", "CompositionChildA", "CompositionChildB", "AutoChild"}));
+        var @default = _protoMan.Categories[new(DefaultCategory)].Select(x=> x.ID);
+        Assert.That(@default, Is.EquivalentTo(new[] {ConcreteChildEntity, CompositionAbstractEntity, CompositionAEntity, CompositionBEntity, CompositionChildAEntity, CompositionChildBEntity, AutoChildEntity}));
 
-        var default2 = _protoMan.Categories[new("Default2")].Select(x=> x.ID);
-        Assert.That(default2, Is.EquivalentTo(new[] {"CompositionChildB"}));
+        var default2 = _protoMan.Categories[new(Default2Category)].Select(x=> x.ID);
+        Assert.That(default2, Is.EquivalentTo(new[] {CompositionChildBEntity}));
 
-        var hide = _protoMan.Categories[new("Hide")].Select(x=> x.ID);
-        Assert.That(hide, Is.EquivalentTo(new[] {"Hide", "CompositionAbstract", "CompositionA", "CompositionChildA", "CompositionChildB", "InheritChild"}));
+        var hide = _protoMan.Categories[new(HideCategory)].Select(x=> x.ID);
+        Assert.That(hide, Is.EquivalentTo(new[] {HideEntity, CompositionAbstractEntity, CompositionAEntity, CompositionChildAEntity, CompositionChildBEntity, InheritChildEntity}));
 
-        var noInherit = _protoMan.Categories[new("NoInherit")].Select(x=> x.ID);
-        Assert.That(noInherit, Is.EquivalentTo(new[] {"NoInheritParent", "CompositionB"}));
+        var noInherit = _protoMan.Categories[new(NoInheritCategory)].Select(x=> x.ID);
+        Assert.That(noInherit, Is.EquivalentTo(new[] {NoInheritParentEntity, CompositionBEntity}));
 
-        var auto = _protoMan.Categories[new("Auto")].Select(x=> x.ID);
-        Assert.That(auto, Is.EquivalentTo(new[] {"CompositionAbstract", "CompositionB", "CompositionChildA", "CompositionChildB", "Auto", "AutoChild"}));//, "AutoAttribute"}));
+        var auto = _protoMan.Categories[new(AutoCategory)].Select(x=> x.ID);
+        Assert.That(auto, Is.EquivalentTo(new[] {CompositionAbstractEntity, CompositionBEntity, CompositionChildAEntity, CompositionChildBEntity, AutoEntity, AutoChildEntity}));//, "AutoAttribute"}));
     }
 
-    const string TestPrototypes = @"
+    const string NoneCategory = "None";
+    const string DefaultCategory = "Default";
+    const string Default2Category = "Default2";
+    const string HideCategory = "Hide";
+    const string NoInheritCategory = "NoInherit";
+    const string AutoCategory = "Auto";
+
+    const string DefaultEntity = "Default";
+    const string HideEntity = "Hide";
+    const string InheritChildEntity = "InheritChild";
+    const string NoInheritParentEntity = "NoInheritParent";
+    const string NoInheritChildEntity = "NoInheritChild";
+    const string CompositionAEntity = "CompositionA";
+    const string CompositionBEntity = "CompositionB";
+    const string CompositionChildAEntity = "CompositionChildA";
+    const string CompositionChildBEntity = "CompositionChildB";
+    const string AbstractParentEntity = "AbstractParent";
+    const string ConcreteChildEntity = "ConcreteChild";
+    const string AbstractGrandChildEntity = "AbstractGrandChild";
+    const string CompositionAbstractEntity = "CompositionAbstract";
+    const string AutoEntity = "Auto";
+    const string AutoParentEntity = "AutoParent";
+    const string AutoChildEntity = "AutoChild";
+
+    const string TestPrototypes = $@"
 - type: entityCategory
-  id: None
+  id: {NoneCategory}
 
 - type: entityCategory
-  id: Default
+  id: {DefaultCategory}
 
 - type: entityCategory
-  id: Default2
+  id: {Default2Category}
 
 - type: entityCategory
-  id: Hide
+  id: {HideCategory}
   hideSpawnMenu: true
 
 - type: entityCategory
-  id: NoInherit
+  id: {NoInheritCategory}
   inheritable: false
 
 - type: entityCategory
-  id: Auto
+  id: {AutoCategory}
   components: [ AutoCategory ]
 
 - type: entity
-  id: Default
+  id: {DefaultEntity}
 
 - type: entity
-  id: Hide
-  categories: [ Hide ]
+  id: {HideEntity}
+  categories: [ {HideCategory} ]
 
 - type: entity
-  id: InheritChild
+  id: {InheritChildEntity}
   parent: Hide
 
 - type: entity
-  id: NoInheritParent
-  categories: [ NoInherit ]
+  id: {NoInheritParentEntity}
+  categories: [ {NoInheritCategory} ]
 
 - type: entity
-  id: NoInheritChild
+  id: {NoInheritChildEntity}
   parent: NoInheritParent
 
 - type: entity
-  id: CompositionA
-  categories: [ Default, Hide ]
+  id: {CompositionAEntity}
+  categories: [ {DefaultCategory}, {HideCategory} ]
 
 - type: entity
-  id: CompositionB
-  categories: [ Default, NoInherit, Auto ]
+  id: {CompositionBEntity}
+  categories: [ {DefaultCategory}, {NoInheritCategory}, {AutoCategory} ]
 
 - type: entity
-  id: CompositionChildA
-  parent: [CompositionA, CompositionB]
+  id: {CompositionChildAEntity}
+  parent: [{CompositionAEntity}, {CompositionBEntity}]
 
 - type: entity
-  id: CompositionChildB
-  parent: [CompositionA, CompositionB]
-  categories: [ Default2 ]
+  id: {CompositionChildBEntity}
+  parent: [{CompositionAEntity}, {CompositionBEntity}]
+  categories: [ {Default2Category} ]
 
 - type: entity
-  id: AbstractParent
+  id: {AbstractParentEntity}
   abstract: true
-  categories: [ Default ]
+  categories: [ {DefaultCategory} ]
 
 - type: entity
-  id: ConcreteChild
-  parent: AbstractParent
+  id: {ConcreteChildEntity}
+  parent: {AbstractParentEntity}
 
 - type: entity
   abstract: true
-  id: AbstractGrandChild
-  parent: ConcreteChild
-  categories: [ Hide ]
+  id: {AbstractGrandChildEntity}
+  parent: {ConcreteChildEntity}
+  categories: [ {HideCategory} ]
 
 - type: entity
-  id: CompositionAbstract
-  parent: [ AbstractGrandChild, CompositionB ]
+  id: {CompositionAbstractEntity}
+  parent: [ {AbstractGrandChildEntity}, {CompositionBEntity} ]
 
 - type: entity
-  id: Auto
+  id: {AutoEntity}
   components:
   - type: AutoCategory
 
@@ -228,16 +252,16 @@ public sealed class PrototypeManagerCategoriesTest : RobustUnitTest
 #  - type: AttributeAutoCategory
 
 - type: entity
-  id: AutoParent
+  id: {AutoParentEntity}
   abstract: true
-  categories: [ NoInherit ]
+  categories: [ {NoInheritCategory} ]
   components:
   - type: AutoCategory
 
 - type: entity
-  id: AutoChild
-  parent: AutoParent
-  categories: [ Default ]
+  id: {AutoChildEntity}
+  parent: {AutoParentEntity}
+  categories: [ {DefaultCategory} ]
 ";
 }
 

--- a/Robust.UnitTesting/Shared/Prototypes/PrototypeManager_Test.cs
+++ b/Robust.UnitTesting/Shared/Prototypes/PrototypeManager_Test.cs
@@ -19,6 +19,10 @@ namespace Robust.UnitTesting.Shared.Prototypes
     [TestFixture]
     public sealed class PrototypeManager_Test : RobustUnitTest
     {
+        private const string FakeWrenchProtoId = "wrench";
+        private const string YamlTesterProtoId = "yamltester";
+        private const string MountTesterProtoId = "mounttester";
+        private const string PlacementInheritanceTesterProtoId = "PlaceInheritTester";
         private const string LoadStringTestDummyId = "LoadStringTestDummy";
         private IPrototypeManager manager = default!;
 
@@ -37,7 +41,7 @@ namespace Robust.UnitTesting.Shared.Prototypes
         [Test]
         public void TestBasicPrototype()
         {
-            var prototype = manager.Index<EntityPrototype>("wrench");
+            var prototype = manager.Index<EntityPrototype>(FakeWrenchProtoId);
             Assert.That(prototype.Name, Is.EqualTo("Not a wrench. Tricked!"));
 
             var mapping = prototype.Components["TestBasicPrototype"].Component as TestBasicPrototypeComponent;
@@ -65,7 +69,7 @@ namespace Robust.UnitTesting.Shared.Prototypes
         [Test]
         public void TestYamlHelpersPrototype()
         {
-            var prototype = manager.Index<EntityPrototype>("yamltester");
+            var prototype = manager.Index<EntityPrototype>(YamlTesterProtoId);
             Assert.That(prototype.Components, Contains.Key("TestBasicPrototype"));
 
             var componentData = prototype.Components["TestBasicPrototype"].Component as TestBasicPrototypeComponent;
@@ -89,7 +93,7 @@ namespace Robust.UnitTesting.Shared.Prototypes
         [Test]
         public void TestPlacementProperties()
         {
-            var prototype = manager.Index<EntityPrototype>("mounttester");
+            var prototype = manager.Index<EntityPrototype>(MountTesterProtoId);
 
             Assert.That(prototype.MountingPoints, Is.EquivalentTo(new int[] { 1, 2, 3 }));
             Assert.That(prototype.PlacementMode, Is.EqualTo("AlignWall"));
@@ -100,7 +104,7 @@ namespace Robust.UnitTesting.Shared.Prototypes
         [Test]
         public void TestPlacementInheritance()
         {
-            var prototype = manager.Index<EntityPrototype>("PlaceInheritTester");
+            var prototype = manager.Index<EntityPrototype>(PlacementInheritanceTesterProtoId);
 
             Assert.That(prototype.PlacementMode, Is.EqualTo("SnapgridCenter"));
         }
@@ -158,9 +162,9 @@ namespace Robust.UnitTesting.Shared.Prototypes
             Bar
         }
 
-        const string DOCUMENT = @"
+        const string DOCUMENT = $@"
 - type: entity
-  id: wrench
+  id: {FakeWrenchProtoId}
   name: Not a wrench. Tricked!
   components:
   - type: TestBasicPrototype
@@ -180,7 +184,7 @@ namespace Robust.UnitTesting.Shared.Prototypes
   parent: wallLight
 
 - type: entity
-  id: yamltester
+  id: {YamlTesterProtoId}
   components:
   - type: TestBasicPrototype
     str: hi!
@@ -198,7 +202,7 @@ namespace Robust.UnitTesting.Shared.Prototypes
     enumb: Bar
 
 - type: entity
-  id: mounttester
+  id: {MountTesterProtoId}
   placement:
     mode: AlignWall
     range: 300
@@ -209,8 +213,8 @@ namespace Robust.UnitTesting.Shared.Prototypes
     - 3
 
 - type: entity
-  id: PlaceInheritTester
-  parent: mounttester
+  id: {PlacementInheritanceTesterProtoId}
+  parent: {MountTesterProtoId}
   placement:
     mode: SnapgridCenter
 ";


### PR DESCRIPTION
Adds `ForbidLiteralAttribute` to `IPrototypeManager` methods that take a string, `EntProtoId`, or `ProtoId` parameter to lookup a prototype (`Index`, `HasIndex`, `TryIndex`).

Also fixes all violations of this in engine. Two were `ShaderPrototype`s which are now validated `static ProtoId`s. The rest were test prototypes which now use `const string`s.

Content violations [are](https://github.com/space-wizards/space-station-14/pull/38728) [already](https://github.com/space-wizards/space-station-14/pull/38745) [fixed](https://github.com/space-wizards/space-station-14/pull/38747).