### PR TITLE
Cleanup warnings: CS0414

### DIFF
--- a/Robust.Shared/Physics/Systems/FixtureSystem.cs
+++ b/Robust.Shared/Physics/Systems/FixtureSystem.cs
@@ -21,7 +21,9 @@ namespace Robust.Shared.Physics.Systems
     /// </summary>
     public sealed partial class FixtureSystem : EntitySystem
     {
+#pragma warning disable CS0414
         [Dependency] private readonly IGameTiming _timing = default!;
+#pragma warning restore CS0414
         [Dependency] private readonly EntityLookupSystem _lookup = default!;
         [Dependency] private readonly SharedBroadphaseSystem _broadphase = default!;
         [Dependency] private readonly SharedPhysicsSystem _physics = default!;


### PR DESCRIPTION
Remove 1x `CS0414` warning

[CS0414](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0414): The private field 'field' is assigned but its value is never used.

`_timing` is only used in the debug build, so the warning should be suppressed.

[https://github.com/space-wizards/space-station-14/issues/33279](https://github.com/space-wizards/space-station-14/issues/33279)