### PR TITLE
Config load fail is now an error instead of a warning

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -47,7 +47,7 @@ END TEMPLATE-->
 
 ### Other
 
-*None yet*
+* ConfigurationManager will now report an error instead of warning if it fails to load the config file.
 
 ### Internal
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -47,7 +47,7 @@ END TEMPLATE-->
 
 ### Other
 
-* ConfigurationManager will now report an error instead of warning if it fails to load the config file.
+* The configuration system will now report an error instead of warning if it fails to load the config file.
 
 ### Internal
 

--- a/Robust.Shared/Configuration/ConfigurationManager.cs
+++ b/Robust.Shared/Configuration/ConfigurationManager.cs
@@ -82,7 +82,7 @@ namespace Robust.Shared.Configuration
             catch (Exception e)
             {
                 loaded.Clear();
-                _sawmill.Warning("Unable to load configuration from stream:\n{0}", e);
+                _sawmill.Error("Unable to load configuration from stream:\n{0}", e);
             }
 
             return loaded;
@@ -188,7 +188,7 @@ namespace Robust.Shared.Configuration
             }
             catch (Exception e)
             {
-                _sawmill.Warning("Unable to load configuration file:\n{0}", e);
+                _sawmill.Error("Unable to load configuration file:\n{0}", e);
                 return new HashSet<string>(0);
             }
         }


### PR DESCRIPTION
People keep ignoring it whenever they ask "Why is my config not working :(" till it is pointed out.

Plus this should be an error anyway in my opinion, we caught some exception, we are using defaults now cause of it. This is more serious then a warning, something is wrong.

This should make it more obvious.
