### PR TITLE
Add mover to the container insert and remove methods

### DIFF
--- a/Robust.Shared/Containers/Events/ContainerAttemptEvents.cs
+++ b/Robust.Shared/Containers/Events/ContainerAttemptEvents.cs
@@ -10,7 +10,7 @@ public abstract class ContainerAttemptEventBase : CancellableEntityEventArgs
     public readonly EntityUid EntityUid;
 
     /// <summary>
-    /// The entity that tries to insert or remove the entity from/into the container.
+    /// The entity that tries to insert or remove the entity into/from the container.
     /// </summary>
     public readonly EntityUid? Mover;
 

--- a/Robust.Shared/Containers/Events/ContainerAttemptEvents.cs
+++ b/Robust.Shared/Containers/Events/ContainerAttemptEvents.cs
@@ -9,10 +9,16 @@ public abstract class ContainerAttemptEventBase : CancellableEntityEventArgs
     public readonly BaseContainer Container;
     public readonly EntityUid EntityUid;
 
-    public ContainerAttemptEventBase(BaseContainer container, EntityUid entityUid)
+    /// <summary>
+    /// The entity that tries to insert or remove the entity from/into the container.
+    /// </summary>
+    public readonly EntityUid? Mover;
+
+    public ContainerAttemptEventBase(BaseContainer container, EntityUid entityUid, EntityUid? mover)
     {
         Container = container;
         EntityUid = entityUid;
+        Mover = mover;
     }
 }
 
@@ -27,8 +33,8 @@ public sealed class ContainerIsInsertingAttemptEvent : ContainerAttemptEventBase
     /// </summary>
     public bool AssumeEmpty { get; set; }
 
-    public ContainerIsInsertingAttemptEvent(BaseContainer container, EntityUid entityUid, bool assumeEmpty)
-        : base(container, entityUid)
+    public ContainerIsInsertingAttemptEvent(BaseContainer container, EntityUid entityUid, bool assumeEmpty, EntityUid? mover)
+        : base(container, entityUid, mover)
     {
         AssumeEmpty = assumeEmpty;
     }
@@ -45,8 +51,8 @@ public sealed class ContainerGettingInsertedAttemptEvent : ContainerAttemptEvent
     /// </summary>
     public bool AssumeEmpty { get; set; }
 
-    public ContainerGettingInsertedAttemptEvent(BaseContainer container, EntityUid entityUid, bool assumeEmpty)
-        : base(container, entityUid)
+    public ContainerGettingInsertedAttemptEvent(BaseContainer container, EntityUid entityUid, bool assumeEmpty, EntityUid? mover)
+        : base(container, entityUid, mover)
     {
         AssumeEmpty = assumeEmpty;
     }
@@ -57,7 +63,7 @@ public sealed class ContainerGettingInsertedAttemptEvent : ContainerAttemptEvent
 /// </summary>
 public sealed class ContainerIsRemovingAttemptEvent : ContainerAttemptEventBase
 {
-    public ContainerIsRemovingAttemptEvent(BaseContainer container, EntityUid entityUid) : base(container, entityUid)
+    public ContainerIsRemovingAttemptEvent(BaseContainer container, EntityUid entityUid, EntityUid? mover) : base(container, entityUid, mover)
     {
     }
 }
@@ -67,7 +73,7 @@ public sealed class ContainerIsRemovingAttemptEvent : ContainerAttemptEventBase
 /// </summary>
 public sealed class ContainerGettingRemovedAttemptEvent : ContainerAttemptEventBase
 {
-    public ContainerGettingRemovedAttemptEvent(BaseContainer container, EntityUid entityUid) : base(container, entityUid)
+    public ContainerGettingRemovedAttemptEvent(BaseContainer container, EntityUid entityUid, EntityUid? mover) : base(container, entityUid, mover)
     {
     }
 }

--- a/Robust.Shared/Containers/Events/ContainerModifiedMessage.cs
+++ b/Robust.Shared/Containers/Events/ContainerModifiedMessage.cs
@@ -20,7 +20,7 @@ namespace Robust.Shared.Containers
         public EntityUid Entity { get; }
 
         /// <summary>
-        /// The entity that inserted or removed the entity from/into the container.
+        /// The entity that inserted or removed the entity into/from the container.
         /// </summary>
         public EntityUid? Mover { get; }
 

--- a/Robust.Shared/Containers/Events/ContainerModifiedMessage.cs
+++ b/Robust.Shared/Containers/Events/ContainerModifiedMessage.cs
@@ -19,10 +19,16 @@ namespace Robust.Shared.Containers
         /// </summary>
         public EntityUid Entity { get; }
 
-        protected ContainerModifiedMessage(EntityUid entity, BaseContainer container)
+        /// <summary>
+        /// The entity that inserted or removed the entity from/into the container.
+        /// </summary>
+        public EntityUid? Mover { get; }
+
+        protected ContainerModifiedMessage(EntityUid entity, BaseContainer container, EntityUid? mover)
         {
             Entity = entity;
             Container = container;
+            Mover = mover;
         }
     }
 }

--- a/Robust.Shared/Containers/Events/EntGotInsertedIntoContainerMessage.cs
+++ b/Robust.Shared/Containers/Events/EntGotInsertedIntoContainerMessage.cs
@@ -9,5 +9,5 @@ namespace Robust.Shared.Containers;
 [PublicAPI]
 public sealed class EntGotInsertedIntoContainerMessage : ContainerModifiedMessage
 {
-    public EntGotInsertedIntoContainerMessage(EntityUid entity, BaseContainer container) : base(entity, container) { }
+    public EntGotInsertedIntoContainerMessage(EntityUid entity, BaseContainer container, EntityUid? mover) : base(entity, container, mover) { }
 }

--- a/Robust.Shared/Containers/Events/EntInsertedIntoContainerMessage.cs
+++ b/Robust.Shared/Containers/Events/EntInsertedIntoContainerMessage.cs
@@ -11,7 +11,7 @@ namespace Robust.Shared.Containers
     {
         public readonly EntityUid OldParent;
 
-        public EntInsertedIntoContainerMessage(EntityUid entity, EntityUid oldParent, BaseContainer container) : base(entity, container)
+        public EntInsertedIntoContainerMessage(EntityUid entity, EntityUid oldParent, BaseContainer container, EntityUid? mover) : base(entity, container, mover)
         {
             OldParent = oldParent;
         }

--- a/Robust.Shared/Containers/Events/EntRemovedFromContainerMessage.cs
+++ b/Robust.Shared/Containers/Events/EntRemovedFromContainerMessage.cs
@@ -9,7 +9,7 @@ namespace Robust.Shared.Containers
     [PublicAPI]
     public sealed class EntRemovedFromContainerMessage : ContainerModifiedMessage
     {
-        public EntRemovedFromContainerMessage(EntityUid entity, BaseContainer container) : base(entity, container) { }
+        public EntRemovedFromContainerMessage(EntityUid entity, BaseContainer container, EntityUid? mover) : base(entity, container, mover) { }
     }
 
     /// <summary>
@@ -18,6 +18,6 @@ namespace Robust.Shared.Containers
     [PublicAPI]
     public sealed class EntGotRemovedFromContainerMessage : ContainerModifiedMessage
     {
-        public EntGotRemovedFromContainerMessage(EntityUid entity, BaseContainer container) : base(entity, container) { }
+        public EntGotRemovedFromContainerMessage(EntityUid entity, BaseContainer container, EntityUid? mover) : base(entity, container, mover) { }
     }
 }


### PR DESCRIPTION
This would allow us to move logic from custom ``CanInsert``/``CanRemove``/``TryInsert``/``TryRemove`` methods in SS14 into event subscriptions, since we would be able to pass the user as the mover and show popups or perform checks against them.