### PR TITLE
Missing await WaitIdleAsync in unit test

### DIFF
--- a/Robust.UnitTesting/Shared/GameState/VisibilityTest.cs
+++ b/Robust.UnitTesting/Shared/GameState/VisibilityTest.cs
@@ -22,6 +22,7 @@ public sealed partial class VisibilityTest : RobustIntegrationTest
     public async Task UnknownEntityTest()
     {
         var server = StartServer();
+        await server.WaitIdleAsync();
 
         var xforms = server.System<SharedTransformSystem>();
         var vis = server.System<VisibilitySystem>();


### PR DESCRIPTION
I'll be honest that I'm out of my element here. I'm not at all confident with async, but this test fail gave me the run around all night on my machine and this fixed it. When scanning through the other tests, most if not all had some variant of this line after `StartServer()`, except for this test.