### PR TITLE
Resolve engine/content test pool manager conflicts

### DIFF
--- a/Robust.UnitTesting/Pool/ExternalTestContext.cs
+++ b/Robust.UnitTesting/Pool/ExternalTestContext.cs
@@ -1,0 +1,12 @@
+using System.IO;
+
+namespace Robust.UnitTesting.Pool;
+
+/// <summary>
+/// Generic implementation of <see cref="ITestContextLike"/> for usage outside of actual tests.
+/// </summary>
+public sealed class ExternalTestContext(string name, TextWriter writer) : ITestContextLike
+{
+    public string FullName => name;
+    public TextWriter Out => writer;
+}

--- a/Robust.UnitTesting/Pool/ITestContextLike.cs
+++ b/Robust.UnitTesting/Pool/ITestContextLike.cs
@@ -1,0 +1,14 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Robust.UnitTesting.Pool;
+
+/// <summary>
+/// Something that looks like a <see cref="TestContext"/>, for passing to integration tests.
+/// </summary>
+public interface ITestContextLike
+{
+    string FullName { get; }
+    TextWriter Out { get; }
+}
+

--- a/Robust.UnitTesting/Pool/NUnitTestContextWrap.cs
+++ b/Robust.UnitTesting/Pool/NUnitTestContextWrap.cs
@@ -1,0 +1,13 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Robust.UnitTesting.Pool;
+
+/// <summary>
+/// Canonical implementation of <see cref="ITestContextLike"/> for usage in actual NUnit tests.
+/// </summary>
+public sealed class NUnitTestContextWrap(TestContext context, TextWriter writer) : ITestContextLike
+{
+    public string FullName => context.Test.FullName;
+    public TextWriter Out => writer;
+}

--- a/Robust.UnitTesting/Pool/TestPair.Recycle.cs
+++ b/Robust.UnitTesting/Pool/TestPair.Recycle.cs
@@ -8,6 +8,7 @@ using Robust.Shared;
 using Robust.Shared.Exceptions;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
+using Robust.Shared.Utility;
 
 namespace Robust.UnitTesting.Pool;
 
@@ -79,6 +80,7 @@ public partial class TestPair<TServer, TClient>
 
         var returnTime = Watch.Elapsed;
         await TestOut.WriteLineAsync($"{nameof(CleanReturnAsync)}: PoolManager took {returnTime.TotalMilliseconds} ms to put pair {Id} back into the pool");
+        State = PairState.Ready;
     }
 
     public async ValueTask CleanReturnAsync()
@@ -89,7 +91,7 @@ public partial class TestPair<TServer, TClient>
         await TestOut.WriteLineAsync($"{nameof(CleanReturnAsync)}: Return of pair {Id} started");
         State = PairState.CleanDisposed;
         await OnCleanDispose();
-        State = PairState.Ready;
+        DebugTools.Assert(State is PairState.Dead or PairState.Ready);
         Manager.Return(this);
         ClearContext();
     }


### PR DESCRIPTION
This PR fixes conflicts between https://github.com/space-wizards/space-station-14/pull/36797 & https://github.com/space-wizards/space-station-14/pull/38357. I.e., this is basically just a continuation of #5877 which moves some of the changes from https://github.com/space-wizards/space-station-14/pull/38357 to engine
