### PR TITLE
Makes the StartCollideEvent constructor public.

### DIFF
--- a/Robust.Shared/Physics/Events/StartCollideEvent.cs
+++ b/Robust.Shared/Physics/Events/StartCollideEvent.cs
@@ -29,7 +29,7 @@ public readonly struct StartCollideEvent
     public Vector2[] WorldPoints => _worldPoints.AsSpan[..PointCount].ToArray();
 
 
-    internal StartCollideEvent(
+    public StartCollideEvent(
         EntityUid ourEntity,
         EntityUid otherEntity,
         string ourFixtureId,

--- a/Robust.Shared/Physics/Events/StartCollideEvent.cs
+++ b/Robust.Shared/Physics/Events/StartCollideEvent.cs
@@ -21,7 +21,7 @@ public readonly struct StartCollideEvent
     public readonly Fixture OurFixture;
     public readonly Fixture OtherFixture;
 
-    internal readonly FixedArray2<Vector2> _worldPoints;
+    public readonly FixedArray2<Vector2> _worldPoints;
 
     public readonly int PointCount;
     public readonly Vector2 WorldNormal;


### PR DESCRIPTION
The Hullrot codebase manually builds and raises theis event to prevent bullets phasing through things they shouldn't without raising the physics tickrate.
It also allows people to create special effects/mechanics by forcing collisions only under certain conditions , etc.