### PR TITLE
Soft Layers Fixtures Component. 

### DIFF
--- a/Robust.Shared/Physics/Components/FixturesSemiSoftComponent.cs
+++ b/Robust.Shared/Physics/Components/FixturesSemiSoftComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.Manager.Attributes;
+
+namespace Robust.Shared.Physics.Components;
+
+
+/// <summary>
+/// Prevents collision on specific Fixture layers for an attached entity.
+/// These layers will effectively be considered "soft" for collision purposes.
+/// Start and End collide events will be raised but an entity's movement won't be stopped.
+/// Does nothing if the attached entity uses a soft fixture.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class FixturesSemiSoftComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public int Mask;
+}

--- a/Robust.Shared/Physics/Systems/FixturesSemiSoftSystem.cs
+++ b/Robust.Shared/Physics/Systems/FixturesSemiSoftSystem.cs
@@ -1,0 +1,31 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Events;
+
+namespace Robust.Shared.Physics.Systems;
+
+/// <summary>
+/// Prevents collision if the colliding fixture layers are completely contained within the
+/// <see cref="FixturesSemiSoftComponent"/> mask.
+/// </summary>
+public sealed class FixturesSemiSoftSystem : EntitySystem
+{
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<FixturesSemiSoftComponent, PreventCollideEvent>(OnPreventCollide);
+    }
+
+    private void OnPreventCollide(Entity<FixturesSemiSoftComponent> ent, ref PreventCollideEvent args)
+    {
+        if (args.Cancelled || !args.OurFixture.Hard || !args.OtherFixture.Hard)
+            return;
+
+        // Get the mask of the collision itself.
+        var collisionMask = args.OurFixture.CollisionLayer & args.OtherFixture.CollisionMask;
+
+        if ((ent.Comp.Mask | collisionMask) == ent.Comp.Mask)
+            args.Cancelled = true;
+
+    }
+}


### PR DESCRIPTION
### Description

Adds a component that allows you to declare certain layers as "Soft" on an entity. 

This allows you to have a hard fixture that doesn't stop movement on some of its layers but will still raise start and end collide events without having to give it a second fixture, by taking advantage of the "PreventCollideEvent."

System will find the layers that the collision is happening on and cancel it if all the layers are contained within the component's bitmask. 

Need it for funny furniture shenanigans where crawling over a piece of furniture will appropriately apply a speed reduction, while also still being a hard fixture.

This component may also be useful on mobs specifically in regard to the flammable fixture which needs to be soft so it doesn't cause hard collisions, and results in two collisions happening in some cases.

#### Additional Comments

The name I chose is kind of ass in my opinion. If a better name presents itself I will change the system and component name immediately. 