### PR TITLE
More informative logging for PVS deleted/uninitialized entity errors

### DIFF
--- a/Robust.Server/GameStates/PvsSystem.GetStates.cs
+++ b/Robust.Server/GameStates/PvsSystem.GetStates.cs
@@ -32,7 +32,7 @@ internal sealed partial class PvsSystem
 
             if (component.Deleted || !component.Initialized)
             {
-                Log.Error("Entity manager returned deleted or uninitialized components while sending entity data");
+                Log.Error($"Entity manager returned deleted or uninitialized component of type {component.GetType()} on entity {ToPrettyString(entityUid)} while generating entity state data for {player?.Name ?? "replay"}");
                 continue;
             }
 


### PR DESCRIPTION
```Entity manager returned deleted or uninitialized components while sending entity data Sawmill=system.pvs``` is not a very helpful error log entry.

The updated message includes the type of the component, the name and ID of the entity, and the username of the player the PVS state is being generated for.