### PR TITLE
Lint for prototype IDs with spaces

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -36,6 +36,7 @@ END TEMPLATE-->
 ### Breaking changes
 
 * More members in `IntegrationInstance` now enforce that the instance is idle before accessing it.
+* `Prototype.ValidateDirectory` now requires that prototype IDs have no spaces in them.
 
 ### New features
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -36,7 +36,7 @@ END TEMPLATE-->
 ### Breaking changes
 
 * More members in `IntegrationInstance` now enforce that the instance is idle before accessing it.
-* `Prototype.ValidateDirectory` now requires that prototype IDs have no spaces in them.
+* `Prototype.ValidateDirectory` now requires that prototype IDs have no spaces or periods in them.
 
 ### New features
 

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlValidate.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlValidate.cs
@@ -13,6 +13,11 @@ namespace Robust.Shared.Prototypes;
 
 public partial class PrototypeManager
 {
+    // Characters that we don't allow in prototype IDs. Spaces and periods both
+    // break generated localization strings for entity prototypes, so we just
+    // disallow them for all prototypes.
+    private static readonly char[] DisallowedIdChars = [' ', '.'];
+
     public Dictionary<string, HashSet<ErrorNode>> ValidateDirectory(ResPath path) => ValidateDirectory(path, out _);
 
     public Dictionary<string, HashSet<ErrorNode>> ValidateDirectory(ResPath path,
@@ -56,11 +61,11 @@ public partial class PrototypeManager
                     var data = new PrototypeValidationData(id, mapping, resourcePath.ToString());
                     mapping.Remove("type");
 
-                    if (id.Contains(' '))
+                    if (DisallowedIdChars.TryFirstOrNull(c => id.Contains(c), out var letter))
                     {
                         dict.GetOrNew(data.File)
-                            .Add(new ErrorNode(mapping,
-                                $"Found prototype ID containing a space with ID '{id}' for type {type}."));
+                            .Add(new ErrorNode(mapping, $"Prototype '{id}' ({type}) contains disallowed "
+                                                        + $"character '{letter}'."));
                     }
 
                     if (prototypes.GetOrNew(type).TryAdd(id, data))

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlValidate.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlValidate.cs
@@ -56,6 +56,13 @@ public partial class PrototypeManager
                     var data = new PrototypeValidationData(id, mapping, resourcePath.ToString());
                     mapping.Remove("type");
 
+                    if (id.Contains(' '))
+                    {
+                        dict.GetOrNew(data.File)
+                            .Add(new ErrorNode(mapping,
+                                $"Found prototype ID containing a space with ID '{id}' for type {type}."));
+                    }
+
                     if (prototypes.GetOrNew(type).TryAdd(id, data))
                         continue;
 


### PR DESCRIPTION
Fixes space-wizards/space-station-14#6759, fixes  space-wizards/space-station-14#35092.

Arguably matters more for entities since as far as I know they're the only ones with auto-checked localization strings but in case that ever gets added to another prototype kind I figure it doesn't hurt. Only had one violation in Content. (space-wizards/space-station-14#39029)