### PR TITLE
Allow AutoNetworkedField to work with inherited datafields

### DIFF
--- a/Robust.Roslyn.Shared/TypeSymbolHelper.cs
+++ b/Robust.Roslyn.Shared/TypeSymbolHelper.cs
@@ -36,4 +36,22 @@ public static class TypeSymbolHelper
 
         return false;
     }
+
+    /// <summary>
+    /// Gets all Members of a symbol, including those that are inherited.
+    /// We need this because sometimes Components have abstract parents with autonetworked datafields.
+    /// </summary>
+    public static IEnumerable<ISymbol> GetAllMembersIncludingInherited(INamedTypeSymbol type)
+    {
+        var current = type;
+        while (current != null)
+        {
+            foreach (var member in current.GetMembers())
+            {
+                yield return member;
+            }
+
+            current = current.BaseType;
+        }
+    }
 }

--- a/Robust.Shared.CompNetworkGenerator/ComponentNetworkGenerator.cs
+++ b/Robust.Shared.CompNetworkGenerator/ComponentNetworkGenerator.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 using static Microsoft.CodeAnalysis.SymbolDisplayFormat;
 using static Microsoft.CodeAnalysis.SymbolDisplayMiscellaneousOptions;
+using Robust.Roslyn.Shared;
 
 // Yes dude I know this source generator isn't incremental, I'll fix it eventually.
 #pragma warning disable RS1035
@@ -48,7 +49,7 @@ namespace Robust.Shared.CompNetworkGenerator
             var componentName = classSymbol.Name;
             var stateName = $"{componentName}_AutoState";
 
-            var members = classSymbol.GetMembers();
+            var members = TypeSymbolHelper.GetAllMembersIncludingInherited(classSymbol);
             var fields = new List<(ITypeSymbol Type, string FieldName)>();
             var fieldAttr = comp.GetTypeByMetadataName(MemberAttributeName);
 
@@ -715,7 +716,7 @@ public partial class {componentName}{deltaInterface}
 
                 if (relevantAttribute == null)
                 {
-                    foreach (var mem in typeSymbol.GetMembers())
+                    foreach (var mem in TypeSymbolHelper.GetAllMembersIncludingInherited(typeSymbol))
                     {
                         var attribute = mem.GetAttributes().FirstOrDefault(a =>
                             a.AttributeClass != null &&

--- a/Robust.UnitTesting/Shared/GameState/AutoNetworkingTest.cs
+++ b/Robust.UnitTesting/Shared/GameState/AutoNetworkingTest.cs
@@ -13,7 +13,7 @@ namespace Robust.UnitTesting.Shared.GameState;
 public sealed partial class AutoNetworkingTests : RobustIntegrationTest
 {
     /// <summary>
-    /// Does basic testing for AutoNetworkedFieldAttribute and AutoGenerateComponentAttribute
+    /// Does basic testing for AutoNetworkedFieldAttribute and AutoGenerateComponentStateAttribute
     /// to make sure the datafields are correctly networked to the client when dirtied.
     /// TODO: Add test for field deltas.
     /// </summary>

--- a/Robust.UnitTesting/Shared/GameState/AutoNetworkingTest.cs
+++ b/Robust.UnitTesting/Shared/GameState/AutoNetworkingTest.cs
@@ -79,12 +79,9 @@ public sealed partial class AutoNetworkingTests : RobustIntegrationTest
         // check client
         await client.WaitPost(() =>
         {
-            Assert.Multiple(() =>
-            {
-                // Check player got properly attached
-                Assert.That(client.AttachedEntity, Is.EqualTo(cPlayer));
-                Assert.That(client.EntMan.EntityExists(cPlayer));
-            });
+            // Check player got properly attached
+            Assert.That(client.AttachedEntity, Is.EqualTo(cPlayer));
+            Assert.That(client.EntMan.EntityExists(cPlayer));
 
             // Get the client-side entities
             cPlayer = client.EntMan.GetEntity(server.EntMan.GetNetEntity(player));
@@ -98,7 +95,7 @@ public sealed partial class AutoNetworkingTests : RobustIntegrationTest
             Assert.That(client.EntMan.TryGetComponent(clientEnt3, out AutoNetworkingTestEmptyChildComponent? cmpClient3));
 
             // All datafields should be the default value
-            Assert.That(cmpClient1?.NetworkedField, Is.EqualTo(1));
+            Assert.That(cmpClient1?.IsNetworked, Is.EqualTo(1));
             Assert.That(cmpClient1?.NotNetworked, Is.EqualTo(2));
 
             Assert.That(cmpClient2?.ChildNetworked, Is.EqualTo(1));
@@ -119,7 +116,7 @@ public sealed partial class AutoNetworkingTests : RobustIntegrationTest
             var cmpServer3 = server.EntMan.GetComponent<AutoNetworkingTestEmptyChildComponent>(serverEnt3);
 
             // All datafields should be the default value
-            Assert.That(cmpServer1.NetworkedField, Is.EqualTo(1));
+            Assert.That(cmpServer1.IsNetworked, Is.EqualTo(1));
             Assert.That(cmpServer1.NotNetworked, Is.EqualTo(2));
 
             Assert.That(cmpServer2.ChildNetworked, Is.EqualTo(1));
@@ -131,7 +128,7 @@ public sealed partial class AutoNetworkingTests : RobustIntegrationTest
             Assert.That(cmpServer3.Parent, Is.EqualTo(4));
 
             // change the datafields and dirty them
-            cmpServer1.NetworkedField = 101;
+            cmpServer1.IsNetworked = 101;
             cmpServer1.NotNetworked = 102;
             cmpServer2.ChildNetworked = 101;
             cmpServer2.Child = 102;
@@ -162,7 +159,7 @@ public sealed partial class AutoNetworkingTests : RobustIntegrationTest
             Assert.That(client.EntMan.TryGetComponent(clientEnt3, out AutoNetworkingTestEmptyChildComponent? cmpClient3));
 
             // All datafields should be the default value
-            Assert.That(cmpClient1?.NetworkedField, Is.EqualTo(101));
+            Assert.That(cmpClient1?.IsNetworked, Is.EqualTo(101));
             Assert.That(cmpClient1?.NotNetworked, Is.EqualTo(2)); // unchanged
 
             Assert.That(cmpClient2?.ChildNetworked, Is.EqualTo(101));
@@ -187,38 +184,38 @@ public sealed partial class AutoNetworkingTests : RobustIntegrationTest
         await server.WaitRunTicks(5);
         await client.WaitRunTicks(5);
     }
+}
 
-    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-    public sealed partial class AutoNetworkingTestComponent : Component
-    {
-        [DataField, AutoNetworkedField]
-        public int NetworkedField = 1;
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class AutoNetworkingTestComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public int IsNetworked = 1;
 
-        [DataField]
-        public int NotNetworked = 2;
-    }
+    [DataField]
+    public int NotNetworked = 2;
+}
 
-    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-    public sealed partial class AutoNetworkingTestChildComponent : AutoNetworkingTestParentComponent
-    {
-        [DataField, AutoNetworkedField]
-        public int ChildNetworked = 1;
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class AutoNetworkingTestChildComponent : AutoNetworkingTestParentComponent
+{
+    [DataField, AutoNetworkedField]
+    public int ChildNetworked = 1;
 
-        [DataField]
-        public int Child = 2;
-    }
+    [DataField]
+    public int Child = 2;
+}
 
-    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-    public sealed partial class AutoNetworkingTestEmptyChildComponent : AutoNetworkingTestParentComponent
-    {
-    }
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class AutoNetworkingTestEmptyChildComponent : AutoNetworkingTestParentComponent
+{
+}
 
-    public abstract partial class AutoNetworkingTestParentComponent : Component
-    {
-        [DataField, AutoNetworkedField]
-        public int ParentNetworked = 3;
+public abstract partial class AutoNetworkingTestParentComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public int ParentNetworked = 3;
 
-        [DataField]
-        public int Parent = 4;
-    }
+    [DataField]
+    public int Parent = 4;
 }

--- a/Robust.UnitTesting/Shared/GameState/AutoNetworkingTest.cs
+++ b/Robust.UnitTesting/Shared/GameState/AutoNetworkingTest.cs
@@ -1,0 +1,224 @@
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Robust.Shared;
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameStates;
+using Robust.Shared.Map;
+using Robust.Shared.Network;
+using Robust.Shared.Serialization.Manager.Attributes;
+
+namespace Robust.UnitTesting.Shared.GameState;
+
+public sealed partial class AutoNetworkingTests : RobustIntegrationTest
+{
+    /// <summary>
+    /// Does basic testing for AutoNetworkedFieldAttribute and AutoGenerateComponentAttribute
+    /// to make sure the datafields are correctly networked to the client when dirtied.
+    /// TODO: Add test for field deltas.
+    /// </summary>
+    [Test]
+    public async Task AutoNetworkingTest()
+    {
+        var serverOpts = new ServerIntegrationOptions { Pool = false };
+        var clientOpts = new ClientIntegrationOptions { Pool = false };
+        var server = StartServer(serverOpts);
+        var client = StartClient(clientOpts);
+
+        await Task.WhenAll(client.WaitIdleAsync(), server.WaitIdleAsync());
+        var netMan = client.ResolveDependency<IClientNetManager>();
+
+        Assert.DoesNotThrow(() => client.SetConnectTarget(server));
+        client.Post(() => netMan.ClientConnect(null!, 0, null!));
+        server.Post(() => server.CfgMan.SetCVar(CVars.NetPVS, true));
+
+        // Set up map.
+        EntityUid map = default;
+        server.Post(() =>
+        {
+            map = server.System<SharedMapSystem>().CreateMap();
+        });
+
+        await RunTicks();
+
+        // Spawn entities
+        var coords = new EntityCoordinates(map, default);
+        EntityUid player = default;
+        EntityUid cPlayer = default;
+        EntityUid serverEnt1 = default;
+        EntityUid serverEnt2 = default;
+        EntityUid serverEnt3 = default;
+        NetEntity serverNet1 = default;
+        NetEntity serverNet2 = default;
+        NetEntity serverNet3 = default;
+
+        await server.WaitPost(() =>
+        {
+            // Attach player.
+            player = server.EntMan.Spawn();
+            var session = server.PlayerMan.Sessions.First();
+            server.PlayerMan.SetAttachedEntity(session, player);
+            server.PlayerMan.JoinGame(session);
+
+            // Spawn test entities.
+            serverEnt1 = server.EntMan.SpawnAttachedTo(null, coords);
+            serverEnt2 = server.EntMan.SpawnAttachedTo(null, coords);
+            serverEnt3 = server.EntMan.SpawnAttachedTo(null, coords);
+            serverNet1 = server.EntMan.GetNetEntity(serverEnt1);
+            serverNet2 = server.EntMan.GetNetEntity(serverEnt2);
+            serverNet3 = server.EntMan.GetNetEntity(serverEnt3);
+
+            // Setup components
+            server.EntMan.EnsureComponent<AutoNetworkingTestComponent>(serverEnt1);
+            server.EntMan.EnsureComponent<AutoNetworkingTestChildComponent>(serverEnt2);
+            server.EntMan.EnsureComponent<AutoNetworkingTestEmptyChildComponent>(serverEnt3);
+        });
+
+        await RunTicks();
+
+        // check client
+        await client.WaitPost(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                // Check player got properly attached
+                Assert.That(client.AttachedEntity, Is.EqualTo(cPlayer));
+                Assert.That(client.EntMan.EntityExists(cPlayer));
+            });
+
+            // Get the client-side entities
+            cPlayer = client.EntMan.GetEntity(server.EntMan.GetNetEntity(player));
+            var clientEnt1 = client.EntMan.GetEntity(serverNet1);
+            var clientEnt2 = client.EntMan.GetEntity(serverNet2);
+            var clientEnt3 = client.EntMan.GetEntity(serverNet3);
+
+            // Get the client-side components
+            Assert.That(client.EntMan.TryGetComponent(clientEnt1, out AutoNetworkingTestComponent? cmpClient1));
+            Assert.That(client.EntMan.TryGetComponent(clientEnt2, out AutoNetworkingTestChildComponent? cmpClient2));
+            Assert.That(client.EntMan.TryGetComponent(clientEnt3, out AutoNetworkingTestEmptyChildComponent? cmpClient3));
+
+            // All datafields should be the default value
+            Assert.That(cmpClient1?.NetworkedField, Is.EqualTo(1));
+            Assert.That(cmpClient1?.NotNetworked, Is.EqualTo(2));
+
+            Assert.That(cmpClient2?.ChildNetworked, Is.EqualTo(1));
+            Assert.That(cmpClient2?.Child, Is.EqualTo(2));
+            Assert.That(cmpClient2?.ParentNetworked, Is.EqualTo(3));
+            Assert.That(cmpClient2?.Parent, Is.EqualTo(4));
+
+            Assert.That(cmpClient3?.ParentNetworked, Is.EqualTo(3));
+            Assert.That(cmpClient3?.Parent, Is.EqualTo(4));
+        });
+
+        // make changes on the server
+        await server.WaitPost(() =>
+        {
+            // Get the server-side components
+            var cmpServer1 = server.EntMan.GetComponent<AutoNetworkingTestComponent>(serverEnt1);
+            var cmpServer2 = server.EntMan.GetComponent<AutoNetworkingTestChildComponent>(serverEnt2);
+            var cmpServer3 = server.EntMan.GetComponent<AutoNetworkingTestEmptyChildComponent>(serverEnt3);
+
+            // All datafields should be the default value
+            Assert.That(cmpServer1.NetworkedField, Is.EqualTo(1));
+            Assert.That(cmpServer1.NotNetworked, Is.EqualTo(2));
+
+            Assert.That(cmpServer2.ChildNetworked, Is.EqualTo(1));
+            Assert.That(cmpServer2.Child, Is.EqualTo(2));
+            Assert.That(cmpServer2.ParentNetworked, Is.EqualTo(3));
+            Assert.That(cmpServer2.Parent, Is.EqualTo(4));
+
+            Assert.That(cmpServer3.ParentNetworked, Is.EqualTo(3));
+            Assert.That(cmpServer3.Parent, Is.EqualTo(4));
+
+            // change the datafields and dirty them
+            cmpServer1.NetworkedField = 101;
+            cmpServer1.NotNetworked = 102;
+            cmpServer2.ChildNetworked = 101;
+            cmpServer2.Child = 102;
+            cmpServer2.ParentNetworked = 103;
+            cmpServer2.Parent = 104;
+            cmpServer3.ParentNetworked = 103;
+            cmpServer3.Parent = 104;
+
+            server.EntMan.Dirty(serverEnt1, cmpServer1);
+            server.EntMan.Dirty(serverEnt2, cmpServer2);
+            server.EntMan.Dirty(serverEnt3, cmpServer3);
+        });
+
+        await RunTicks();
+
+        // check the client again
+        await client.WaitPost(() =>
+        {
+            // Get the client-side entities
+            cPlayer = client.EntMan.GetEntity(server.EntMan.GetNetEntity(player));
+            var clientEnt1 = client.EntMan.GetEntity(serverNet1);
+            var clientEnt2 = client.EntMan.GetEntity(serverNet2);
+            var clientEnt3 = client.EntMan.GetEntity(serverNet3);
+
+            // Get the client-side components
+            Assert.That(client.EntMan.TryGetComponent(clientEnt1, out AutoNetworkingTestComponent? cmpClient1));
+            Assert.That(client.EntMan.TryGetComponent(clientEnt2, out AutoNetworkingTestChildComponent? cmpClient2));
+            Assert.That(client.EntMan.TryGetComponent(clientEnt3, out AutoNetworkingTestEmptyChildComponent? cmpClient3));
+
+            // All datafields should be the default value
+            Assert.That(cmpClient1?.NetworkedField, Is.EqualTo(101));
+            Assert.That(cmpClient1?.NotNetworked, Is.EqualTo(2)); // unchanged
+
+            Assert.That(cmpClient2?.ChildNetworked, Is.EqualTo(101));
+            Assert.That(cmpClient2?.Child, Is.EqualTo(2)); // unchanged
+            Assert.That(cmpClient2?.ParentNetworked, Is.EqualTo(103));
+            Assert.That(cmpClient2?.Parent, Is.EqualTo(4)); // unchanged
+
+            Assert.That(cmpClient3?.ParentNetworked, Is.EqualTo(103));
+            Assert.That(cmpClient3?.Parent, Is.EqualTo(4)); // unchanged
+        });
+
+        async Task RunTicks()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                await server!.WaitRunTicks(1);
+                await client!.WaitRunTicks(1);
+            }
+        }
+
+        await client.WaitPost(() => netMan.ClientDisconnect(""));
+        await server.WaitRunTicks(5);
+        await client.WaitRunTicks(5);
+    }
+
+    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+    public sealed partial class AutoNetworkingTestComponent : Component
+    {
+        [DataField, AutoNetworkedField]
+        public int NetworkedField = 1;
+
+        [DataField]
+        public int NotNetworked = 2;
+    }
+
+    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+    public sealed partial class AutoNetworkingTestChildComponent : AutoNetworkingTestParentComponent
+    {
+        [DataField, AutoNetworkedField]
+        public int ChildNetworked = 1;
+
+        [DataField]
+        public int Child = 2;
+    }
+
+    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+    public sealed partial class AutoNetworkingTestEmptyChildComponent : AutoNetworkingTestParentComponent
+    {
+    }
+
+    public abstract partial class AutoNetworkingTestParentComponent : Component
+    {
+        [DataField, AutoNetworkedField]
+        public int ParentNetworked = 3;
+
+        [DataField]
+        public int Parent = 4;
+    }
+}

--- a/Robust.UnitTesting/Shared/GameState/AutoNetworkingTest.cs
+++ b/Robust.UnitTesting/Shared/GameState/AutoNetworkingTest.cs
@@ -22,8 +22,8 @@ public sealed partial class AutoNetworkingTests : RobustIntegrationTest
     {
         var serverOpts = new ServerIntegrationOptions { Pool = false };
         var clientOpts = new ClientIntegrationOptions { Pool = false };
-        var server = StartServer(serverOpts);
-        var client = StartClient(clientOpts);
+        using var server = StartServer(serverOpts);
+        using var client = StartClient(clientOpts);
 
         await Task.WhenAll(client.WaitIdleAsync(), server.WaitIdleAsync());
         var netMan = client.ResolveDependency<IClientNetManager>();

--- a/Robust.UnitTesting/Shared/GameState/AutoNetworkingTest.cs
+++ b/Robust.UnitTesting/Shared/GameState/AutoNetworkingTest.cs
@@ -55,7 +55,7 @@ public sealed partial class AutoNetworkingTests : RobustIntegrationTest
         await server.WaitPost(() =>
         {
             // Attach player.
-            player = server.EntMan.Spawn();
+            player = server.EntMan.SpawnAttachedTo(null, coords);
             var session = server.PlayerMan.Sessions.First();
             server.PlayerMan.SetAttachedEntity(session, player);
             server.PlayerMan.JoinGame(session);
@@ -79,15 +79,15 @@ public sealed partial class AutoNetworkingTests : RobustIntegrationTest
         // check client
         await client.WaitPost(() =>
         {
-            // Check player got properly attached
-            Assert.That(client.AttachedEntity, Is.EqualTo(cPlayer));
-            Assert.That(client.EntMan.EntityExists(cPlayer));
-
             // Get the client-side entities
             cPlayer = client.EntMan.GetEntity(server.EntMan.GetNetEntity(player));
             var clientEnt1 = client.EntMan.GetEntity(serverNet1);
             var clientEnt2 = client.EntMan.GetEntity(serverNet2);
             var clientEnt3 = client.EntMan.GetEntity(serverNet3);
+
+            // Check player got properly attached
+            Assert.That(client.AttachedEntity, Is.EqualTo(cPlayer));
+            Assert.That(client.EntMan.EntityExists(cPlayer));
 
             // Get the client-side components
             Assert.That(client.EntMan.TryGetComponent(clientEnt1, out AutoNetworkingTestComponent? cmpClient1));


### PR DESCRIPTION
#### About the PR
I know OOP is frowned upon in an ECS codebase, but hear me out:

Currently `AutoNetworkedField` is simply doing nothing when added to an abstract component and then inherited, because the source generator uses `GetMembers`, which only returns the direct members of the component, but not any inherited ones.

Abstract components are used all over the content repo, and I would argue using them makes sense in cases where it avoids a lot of copy-pasting between multiple similar components. See for example https://github.com/space-wizards/space-station-14/pull/35030 which had to rely on manual networking because the autogenerated networking wasn't working, so a lot of boilerplate code had to be added. With this PR that can be cleaned up.

#### Technical details
Added a new type symbol helper that iterates through base classes to find all AutoNetworkedField attributes in a component, including the inherited ones.
I could not find an existing integration test for autonetworking, so I added one that tests if everything works (mostly copied from ComponentStateTest).

Needs some content fixes https://github.com/space-wizards/space-station-14/pull/39086