### PR TITLE
Add RotationDirection to SpriteComponent

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -129,8 +129,6 @@ namespace Robust.Client.GameObjects
         public bool RotationDirection
         {
             get => rotationDirection;
-            [Obsolete("Use SpriteSystem.SetRotationDirection() instead.")]
-            set => Sys.SetRotationDirection((Owner, this), value);
         }
 
         [DataField("offset")] // Explicit name, in case this field ever gets renamed

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -121,14 +121,14 @@ namespace Robust.Client.GameObjects
         }
 
         [DataField]
-        internal float rotationInfluencesDirection = 0;
+        internal bool rotationDirection = false;
 
         /// <summary>
         ///     If <see cref="Rotation"/> will change the rendered RSI direction of the sprite
         /// </summary>
-        public float RotationInfluencesDirection
+        public bool RotationDirection
         {
-            get => rotationInfluencesDirection;
+            get => rotationDirection;
         }
 
         [DataField("offset")] // Explicit name, in case this field ever gets renamed

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -121,14 +121,14 @@ namespace Robust.Client.GameObjects
         }
 
         [DataField]
-        internal bool rotationDirection = false;
+        internal float rotationInfluencesDirection = 0;
 
         /// <summary>
         ///     If <see cref="Rotation"/> will change the rendered RSI direction of the sprite
         /// </summary>
-        public bool RotationDirection
+        public float RotationInfluencesDirection
         {
-            get => rotationDirection;
+            get => rotationInfluencesDirection;
         }
 
         [DataField("offset")] // Explicit name, in case this field ever gets renamed

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -120,6 +120,19 @@ namespace Robust.Client.GameObjects
             set => Sys.SetRotation((Owner, this), value);
         }
 
+        [DataField]
+        internal bool rotationDirection = false;
+
+        /// <summary>
+        ///     If <see cref="Rotation"/> will change the rendered RSI direction of the sprite
+        /// </summary>
+        public bool RotationDirection
+        {
+            get => rotationDirection;
+            [Obsolete("Use SpriteSystem.SetRotationDirection() instead.")]
+            set => Sys.SetRotationDirection((Owner, this), value);
+        }
+
         [DataField("offset")] // Explicit name, in case this field ever gets renamed
         internal Vector2 offset = Vector2.Zero;
 

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Render.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Render.cs
@@ -116,16 +116,22 @@ public sealed partial class SpriteSystem
             return;
 
         var state = layer._actualState;
+        var sprite = layer.Owner.Comp;
         var dir = state == null ? RsiDirection.South : Layer.GetDirection(state.RsiDirections, angle);
 
         // Set the drawing transform for this layer
-        layer.GetLayerDrawMatrix(dir, out var layerMatrix, layer.Owner.Comp.NoRotation);
+        layer.GetLayerDrawMatrix(dir, out var layerMatrix, sprite.NoRotation);
 
         // The direction used to draw the sprite can differ from the one that the angle would naively suggest,
         // due to direction overrides or offsets.
         if (overrideDirection != null && state != null)
             dir = overrideDirection.Value.Convert(state.RsiDirections);
-        dir = dir.OffsetRsiDir(layer.DirOffset);
+
+        if (sprite.RotationDirection)
+            dir = (-layer.Owner.Comp.Rotation).RotateDir(dir.OffsetRsiDir(layer.DirOffset).Convert())
+                .Convert(state?.RsiDirections ?? RsiDirectionType.Dir1);
+        else
+            dir = dir.OffsetRsiDir(layer.DirOffset);
 
         var texture = state?.GetFrame(dir, layer.AnimationFrame) ?? layer.Texture ?? GetFallbackTexture();
 

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Render.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Render.cs
@@ -127,11 +127,12 @@ public sealed partial class SpriteSystem
         if (overrideDirection != null && state != null)
             dir = overrideDirection.Value.Convert(state.RsiDirections);
 
+        dir = dir.OffsetRsiDir(layer.DirOffset);
+
         if (sprite.RotationDirection && !sprite.Rotation.EqualsApprox(Angle.Zero))
-            dir = (-sprite.Rotation).RotateDir(dir.OffsetRsiDir(layer.DirOffset).Convert())
+            dir = (-sprite.Rotation).RotateDir(dir.Convert())
                 .Convert(state?.RsiDirections ?? RsiDirectionType.Dir1);
-        else
-            dir = dir.OffsetRsiDir(layer.DirOffset);
+
 
         var texture = state?.GetFrame(dir, layer.AnimationFrame) ?? layer.Texture ?? GetFallbackTexture();
 

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Render.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Render.cs
@@ -131,7 +131,7 @@ public sealed partial class SpriteSystem
 
         if (sprite.RotationInfluencesDirection != 0f && !sprite.Rotation.EqualsApprox(Angle.Zero))
         {
-            Angle totalRotation = sprite.Rotation * sprite.RotationInfluencesDirection;
+            Angle totalRotation = -sprite.Rotation * sprite.RotationInfluencesDirection;
 
             dir = totalRotation.RotateDir(dir.Convert())
                 .Convert(state?.RsiDirections ?? RsiDirectionType.Dir1);

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Render.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Render.cs
@@ -128,7 +128,7 @@ public sealed partial class SpriteSystem
             dir = overrideDirection.Value.Convert(state.RsiDirections);
 
         if (sprite.RotationDirection)
-            dir = (-layer.Owner.Comp.Rotation).RotateDir(dir.OffsetRsiDir(layer.DirOffset).Convert())
+            dir = (-sprite.Rotation).RotateDir(dir.OffsetRsiDir(layer.DirOffset).Convert())
                 .Convert(state?.RsiDirections ?? RsiDirectionType.Dir1);
         else
             dir = dir.OffsetRsiDir(layer.DirOffset);
@@ -151,7 +151,7 @@ public sealed partial class SpriteSystem
         if (layer.Shader != null)
             drawingHandle.UseShader(layer.Shader);
 
-        var layerColor = layer.Owner.Comp.color * layer.Color;
+        var layerColor = sprite.color * layer.Color;
         var textureSize = texture.Size / (float) EyeManager.PixelsPerMeter;
         var quad = Box2.FromDimensions(textureSize / -2, textureSize);
 

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Render.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Render.cs
@@ -129,9 +129,13 @@ public sealed partial class SpriteSystem
 
         dir = dir.OffsetRsiDir(layer.DirOffset);
 
-        if (sprite.RotationDirection && !sprite.Rotation.EqualsApprox(Angle.Zero))
-            dir = (-sprite.Rotation).RotateDir(dir.Convert())
+        if (sprite.RotationInfluencesDirection != 0f && !sprite.Rotation.EqualsApprox(Angle.Zero))
+        {
+            Angle totalRotation = sprite.Rotation * sprite.RotationInfluencesDirection;
+
+            dir = totalRotation.RotateDir(dir.Convert())
                 .Convert(state?.RsiDirections ?? RsiDirectionType.Dir1);
+        }
 
 
         var texture = state?.GetFrame(dir, layer.AnimationFrame) ?? layer.Texture ?? GetFallbackTexture();

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Render.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Render.cs
@@ -127,7 +127,7 @@ public sealed partial class SpriteSystem
         if (overrideDirection != null && state != null)
             dir = overrideDirection.Value.Convert(state.RsiDirections);
 
-        if (sprite.RotationDirection)
+        if (sprite.RotationDirection && !sprite.Rotation.EqualsApprox(Angle.Zero))
             dir = (-sprite.Rotation).RotateDir(dir.OffsetRsiDir(layer.DirOffset).Convert())
                 .Convert(state?.RsiDirections ?? RsiDirectionType.Dir1);
         else

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Render.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Render.cs
@@ -129,13 +129,9 @@ public sealed partial class SpriteSystem
 
         dir = dir.OffsetRsiDir(layer.DirOffset);
 
-        if (sprite.RotationInfluencesDirection != 0f && !sprite.Rotation.EqualsApprox(Angle.Zero))
-        {
-            Angle totalRotation = -sprite.Rotation * sprite.RotationInfluencesDirection;
-
-            dir = totalRotation.RotateDir(dir.Convert())
+        if (sprite.RotationDirection && !sprite.Rotation.EqualsApprox(Angle.Zero))
+            dir = (-sprite.Rotation).RotateDir(dir.Convert())
                 .Convert(state?.RsiDirections ?? RsiDirectionType.Dir1);
-        }
 
 
         var texture = state?.GetFrame(dir, layer.AnimationFrame) ?? layer.Texture ?? GetFallbackTexture();

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Setters.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Setters.cs
@@ -50,15 +50,15 @@ public sealed partial class SpriteSystem
             in sprite.Comp.scale);
     }
 
-    public void SetRotationDirection(Entity<SpriteComponent?> sprite, bool value)
+    public void SetRotationDirection(Entity<SpriteComponent?> sprite, float value)
     {
         if (!_query.Resolve(sprite.Owner, ref sprite.Comp))
             return;
 
-        if (sprite.Comp.RotationDirection == value)
+        if (sprite.Comp.RotationInfluencesDirection == value)
             return;
 
-        sprite.Comp.rotationDirection = value;
+        sprite.Comp.rotationInfluencesDirection = value;
     }
 
     public void SetOffset(Entity<SpriteComponent?> sprite, Vector2 value)

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Setters.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Setters.cs
@@ -59,7 +59,6 @@ public sealed partial class SpriteSystem
             return;
 
         sprite.Comp.rotationDirection = value;
-        _tree.QueueTreeUpdate(sprite!);
     }
 
     public void SetOffset(Entity<SpriteComponent?> sprite, Vector2 value)

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Setters.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Setters.cs
@@ -50,15 +50,15 @@ public sealed partial class SpriteSystem
             in sprite.Comp.scale);
     }
 
-    public void SetRotationDirection(Entity<SpriteComponent?> sprite, float value)
+    public void SetRotationDirection(Entity<SpriteComponent?> sprite, bool value)
     {
         if (!_query.Resolve(sprite.Owner, ref sprite.Comp))
             return;
 
-        if (sprite.Comp.RotationInfluencesDirection == value)
+        if (sprite.Comp.RotationDirection == value)
             return;
 
-        sprite.Comp.rotationInfluencesDirection = value;
+        sprite.Comp.rotationDirection = value;
     }
 
     public void SetOffset(Entity<SpriteComponent?> sprite, Vector2 value)

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Setters.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Setters.cs
@@ -50,6 +50,18 @@ public sealed partial class SpriteSystem
             in sprite.Comp.scale);
     }
 
+    public void SetRotationDirection(Entity<SpriteComponent?> sprite, bool value)
+    {
+        if (!_query.Resolve(sprite.Owner, ref sprite.Comp))
+            return;
+
+        if (sprite.Comp.RotationDirection == value)
+            return;
+
+        sprite.Comp.rotationDirection = value;
+        _tree.QueueTreeUpdate(sprite!);
+    }
+
     public void SetOffset(Entity<SpriteComponent?> sprite, Vector2 value)
     {
         if (!_query.Resolve(sprite.Owner, ref sprite.Comp))


### PR DESCRIPTION
When enabled, the sprite of anything that possesses both a rotation and an RSI with directions will have the direction rotated with the sprite

<img width="267" height="250" alt="image" src="https://github.com/user-attachments/assets/9bc3a55a-34b4-4fcb-bc4b-47bff501f5db" />