### PR TITLE
Update XamlIL.targets

### DIFF
--- a/MSBuild/XamlIL.targets
+++ b/MSBuild/XamlIL.targets
@@ -22,8 +22,6 @@
   <!-- XamlIL does not make use of special Robust configurations like DebugOpt. Convert these down. -->
   <PropertyGroup>
     <RobustInjectorsConfiguration>$(Configuration)</RobustInjectorsConfiguration>
-    <RobustInjectorsConfiguration Condition="'$(Configuration)' == 'DebugOpt'">Debug</RobustInjectorsConfiguration>
-    <RobustInjectorsConfiguration Condition="'$(Configuration)' == 'Tools'">Release</RobustInjectorsConfiguration>
     <RobustInjectorsConfiguration Condition="'$(UseArtifactsOutput)' == 'true' And '$(RuntimeIdentifier)' != ''">$(RobustInjectorsConfiguration)_$(RuntimeIdentifier)</RobustInjectorsConfiguration>
     <RobustInjectorsConfiguration Condition="'$(UseArtifactsOutput)' == 'true'">$(RobustInjectorsConfiguration.ToLower())</RobustInjectorsConfiguration>
     <CompileRobustXamlTaskAssemblyFile Condition="'$(UseArtifactsOutput)' != 'true'">$(MSBuildThisFileDirectory)\..\Robust.Client.Injectors\bin\$(RobustInjectorsConfiguration)\netstandard2.0\Robust.Client.Injectors.dll</CompileRobustXamlTaskAssemblyFile>


### PR DESCRIPTION
Resolves https://github.com/space-wizards/space-station-14/issues/39077

These configuration targets seem to be vestigial. I don't fully understand what's going on here, but changing these output target directories to the expected `Tools` and `DebugOpt` instead of `Release` and `Debug`, which are not actually respected by the build process, resolves the issue. 

I have tested that `runclient-Tools.bat` works properly, as far as I can tell. I'm not entirely sure what Injectors _does,_ but things now build properly.