### PR TITLE
Validate ViewVariables `EntProtoId` values

### DIFF
--- a/Robust.Client/ViewVariables/Editors/VVPropEditorEntProtoId.cs
+++ b/Robust.Client/ViewVariables/Editors/VVPropEditorEntProtoId.cs
@@ -1,16 +1,24 @@
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
+using Robust.Shared.IoC;
 using Robust.Shared.Prototypes;
 
 namespace Robust.Client.ViewVariables.Editors;
 
 internal sealed class VVPropEditorEntProtoId : VVPropEditor
 {
+    [Dependency] private readonly IPrototypeManager _protoMan = default!;
+
+    public VVPropEditorEntProtoId()
+    {
+        IoCManager.InjectDependencies(this);
+    }
+
     protected override Control MakeUI(object? value)
     {
         var lineEdit = new LineEdit
         {
-            Text = (EntProtoId) (value ?? ""),
+            Text = (EntProtoId)(value ?? ""),
             Editable = !ReadOnly,
             HorizontalExpand = true,
         };
@@ -19,7 +27,9 @@ internal sealed class VVPropEditorEntProtoId : VVPropEditor
         {
             lineEdit.OnTextEntered += e =>
             {
-                ValueChanged((EntProtoId) e.Text);
+                var id = (EntProtoId)e.Text;
+                if (_protoMan.HasIndex(id))
+                    ValueChanged(id);
             };
         }
 

--- a/Robust.Client/ViewVariables/Editors/VVPropEditorNullableEntProtoId.cs
+++ b/Robust.Client/ViewVariables/Editors/VVPropEditorNullableEntProtoId.cs
@@ -1,16 +1,24 @@
 ﻿using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
+using Robust.Shared.IoC;
 using Robust.Shared.Prototypes;
 
 namespace Robust.Client.ViewVariables.Editors;
 
 internal sealed class VVPropEditorNullableEntProtoId : VVPropEditor
 {
+    [Dependency] private readonly IPrototypeManager _protoMan = default!;
+
+    public VVPropEditorNullableEntProtoId()
+    {
+        IoCManager.InjectDependencies(this);
+    }
+
     protected override Control MakeUI(object? value)
     {
         var lineEdit = new LineEdit
         {
-            Text = value is EntProtoId protoId ?  protoId.Id : "",
+            Text = value is EntProtoId protoId ? protoId.Id : "",
             Editable = !ReadOnly,
             HorizontalExpand = true,
         };
@@ -25,7 +33,9 @@ internal sealed class VVPropEditorNullableEntProtoId : VVPropEditor
                 }
                 else
                 {
-                    ValueChanged((EntProtoId) e.Text);
+                    var id = (EntProtoId)e.Text;
+                    if (_protoMan.HasIndex(id))
+                        ValueChanged(id);
                 }
             };
         }


### PR DESCRIPTION
Adds checks that strings input to `EntProtoId` and `EntProtoId?` fields through ViewVariables windows are valid IDs. This prevents typos while using VV from causing errors.

The editor for `ProtoId<T>` already has this check.