### PR TITLE
Fix Non-solution Build: second attempt

### DIFF
--- a/MSBuild/XamlIL.targets
+++ b/MSBuild/XamlIL.targets
@@ -16,7 +16,10 @@
 
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Robust.Client.NameGenerator\Robust.Client.NameGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Robust.Client.Injectors\Robust.Client.Injectors.csproj" ReferenceOutputAssembly="false"/>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Robust.Client.Injectors\Robust.Client.Injectors.csproj" ReferenceOutputAssembly="false">
+      <SetConfiguration Condition="'$(Configuration)' == 'DebugOpt'">Configuration=Debug</SetConfiguration>
+      <SetConfiguration Condition="'$(Configuration)' == 'Tools'">Configuration=Release</SetConfiguration>
+    </ProjectReference>
   </ItemGroup>
 
   <!-- XamlIL does not make use of special Robust configurations like DebugOpt. Convert these down. -->


### PR DESCRIPTION
Downselect Robust.Client.Injectors to 'Debug' or 'Release' when built outside of solution context

Feedback received from https://github.com/space-wizards/RobustToolbox/pull/6093

Resolves https://github.com/space-wizards/space-station-14/issues/39077

This time with a more appropriate solution.