### PR TITLE
Switch buttons

### DIFF
--- a/Resources/Locale/en-US/controls.ftl
+++ b/Resources/Locale/en-US/controls.ftl
@@ -8,3 +8,6 @@ color-selector-sliders-alpha = A
 
 color-selector-sliders-rgb = RGB
 color-selector-sliders-hsv = HSV
+
+toggle-switch-default-off-state-label = Off
+toggle-switch-default-on-state-label = On

--- a/Robust.Client/UserInterface/Controls/CheckButton.cs
+++ b/Robust.Client/UserInterface/Controls/CheckButton.cs
@@ -1,7 +1,0 @@
-namespace Robust.Client.UserInterface.Controls
-{
-    [Virtual]
-    public class CheckButton : Button
-    {
-    }
-}

--- a/Robust.Client/UserInterface/Controls/CheckButton.cs
+++ b/Robust.Client/UserInterface/Controls/CheckButton.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Robust.Client.UserInterface.Controls
+{
+    /// This was only ever a synonym for a regular button. Use Button
+    /// for regular buttons and SwitchButton for switch-like buttons.
+    [Obsolete]
+    [Virtual]
+    public class CheckButton : Button
+    {
+    }
+}

--- a/Robust.Client/UserInterface/Controls/SwitchButton.cs
+++ b/Robust.Client/UserInterface/Controls/SwitchButton.cs
@@ -1,3 +1,4 @@
+using Robust.Client.Graphics;
 using Robust.Shared.ViewVariables;
 using static Robust.Client.UserInterface.Controls.Label;
 using Robust.Shared.Localization;
@@ -11,8 +12,9 @@ namespace Robust.Client.UserInterface.Controls
     public class SwitchButton : ContainerButton
     {
         public const string StyleClassSwitchButton = "switchButton";
-        public const string StyleClassSwitchButtonChecked = "switchButtonChecked";
 
+        public const string StylePropertyTextureUnchecked = "textureUnchecked";
+        public const string StylePropertyTextureChecked = "textureChecked";
 
         public Label Label { get; }
         public Label OffStateLabel { get; }
@@ -68,23 +70,7 @@ namespace Robust.Client.UserInterface.Controls
         protected override void DrawModeChanged()
         {
             base.DrawModeChanged();
-
-            if (Pressed)
-            {
-                TextureRect?.AddStyleClass(StyleClassSwitchButtonChecked);
-                if (OffStateLabel is not null)
-                    OffStateLabel.Visible = false;
-                if (OnStateLabel is not null)
-                    OnStateLabel.Visible = true;
-            }
-            else
-            {
-                TextureRect?.RemoveStyleClass(StyleClassSwitchButtonChecked);
-                if (OffStateLabel is not null)
-                    OffStateLabel.Visible = true;
-                if (OnStateLabel is not null)
-                    OnStateLabel.Visible = false;
-            }
+            UpdateAppearance();
         }
 
         /// <summary>
@@ -136,6 +122,42 @@ namespace Robust.Client.UserInterface.Controls
         {
             get => OnStateLabel.Text;
             set => OnStateLabel.Text = value;
+        }
+
+        private void UpdateAppearance()
+        {
+            if ( Pressed )
+            {
+                TryGetStyleProperty(StylePropertyTextureChecked, out Texture? texture);
+                if (texture is not null && TextureRect is not null)
+                {
+                    TextureRect.Texture = texture;
+                }
+
+                if (OffStateLabel is not null)
+                    OffStateLabel.Visible = false;
+                if (OnStateLabel is not null)
+                    OnStateLabel.Visible = true;
+            }
+            else
+            {
+                TryGetStyleProperty(StylePropertyTextureUnchecked, out Texture? texture);
+                if (texture is not null && TextureRect is not null)
+                {
+                    TextureRect.Texture = texture;
+                }
+
+                if (OffStateLabel is not null)
+                    OffStateLabel.Visible = true;
+                if (OnStateLabel is not null)
+                    OnStateLabel.Visible = false;
+            }
+        }
+
+        protected override void StylePropertiesChanged()
+        {
+            UpdateAppearance();
+            base.StylePropertiesChanged();
         }
     }
 }

--- a/Robust.Client/UserInterface/Controls/SwitchButton.cs
+++ b/Robust.Client/UserInterface/Controls/SwitchButton.cs
@@ -107,7 +107,8 @@ namespace Robust.Client.UserInterface.Controls
                 }
             }
 
-            // child selectors don't update correctly currently, force update all the children
+            // Child selectors don't update correctly currently, force update all the children.
+            // A comment in Button::DrawModeChanged() suggests this is only needed temporarily.
             Label?.Restyle();
             TextureRect?.Restyle();
             OffStateLabel?.Restyle();

--- a/Robust.Client/UserInterface/Controls/SwitchButton.cs
+++ b/Robust.Client/UserInterface/Controls/SwitchButton.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.ViewVariables;
+using Robust.Shared.ViewVariables;
 using static Robust.Client.UserInterface.Controls.Label;
 using Robust.Shared.Localization;
 
@@ -8,10 +8,10 @@ namespace Robust.Client.UserInterface.Controls
     ///     A type of toggleable button that a switch icon and a secondary text label both showing the current state
     /// </summary>
     [Virtual]
-    public class ToggleSwitch : ContainerButton
+    public class SwitchButton : ContainerButton
     {
-        public const string StyleClassToggleSwitch = "toggleSwitch";
-        public const string StyleClassToggleSwitchOn = "toggleSwitchOn";
+        public const string StyleClassSwitchButton = "switchButton";
+        public const string StyleClassSwitchButtonChecked = "switchButtonChecked";
 
 
         public Label Label { get; }
@@ -25,20 +25,20 @@ namespace Robust.Client.UserInterface.Controls
         public PanelContainer StateLabelsContainer { get; }
         public TextureRect TextureRect { get; }
 
-        public ToggleSwitch()
+        public SwitchButton()
         {
             ToggleMode = true;
 
             var hBox = new BoxContainer
             {
                 Orientation = BoxContainer.LayoutOrientation.Horizontal,
-                StyleClasses = { StyleClassToggleSwitch }
+                StyleClasses = { StyleClassSwitchButton }
             };
             AddChild(hBox);
 
             TextureRect = new TextureRect
             {
-                StyleClasses = { StyleClassToggleSwitch },
+                StyleClasses = { StyleClassSwitchButton },
                 VerticalAlignment = VAlignment.Center,
             };
 
@@ -71,7 +71,7 @@ namespace Robust.Client.UserInterface.Controls
 
             if (Pressed)
             {
-                TextureRect?.AddStyleClass(StyleClassToggleSwitchOn);
+                TextureRect?.AddStyleClass(StyleClassSwitchButtonChecked);
                 if (OffStateLabel is not null)
                     OffStateLabel.Visible = false;
                 if (OnStateLabel is not null)
@@ -79,7 +79,7 @@ namespace Robust.Client.UserInterface.Controls
             }
             else
             {
-                TextureRect?.RemoveStyleClass(StyleClassToggleSwitchOn);
+                TextureRect?.RemoveStyleClass(StyleClassSwitchButtonChecked);
                 if (OffStateLabel is not null)
                     OffStateLabel.Visible = true;
                 if (OnStateLabel is not null)
@@ -99,7 +99,7 @@ namespace Robust.Client.UserInterface.Controls
         ///     The text displayed by the button's main label.
         /// </summary>
         [ViewVariables]
-        public string? LabelText
+        public string? Text
         {
             get => Label.Text;
             set

--- a/Robust.Client/UserInterface/Controls/SwitchButton.cs
+++ b/Robust.Client/UserInterface/Controls/SwitchButton.cs
@@ -1,7 +1,9 @@
 using Robust.Client.Graphics;
-using Robust.Shared.ViewVariables;
-using static Robust.Client.UserInterface.Controls.Label;
 using Robust.Shared.Localization;
+using Robust.Shared.Maths;
+using Robust.Shared.ViewVariables;
+
+using static Robust.Client.UserInterface.Controls.Label;
 
 namespace Robust.Client.UserInterface.Controls
 {
@@ -12,9 +14,11 @@ namespace Robust.Client.UserInterface.Controls
     public class SwitchButton : ContainerButton
     {
         public const string StyleClassSwitchButton = "switchButton";
+        public new const string StylePseudoClassPressed = "pressed";
+        public new const string StylePseudoClassDisabled = "disabled";
 
-        public const string StylePropertyTextureUnchecked = "textureUnchecked";
-        public const string StylePropertyTextureChecked = "textureChecked";
+        public const string StylePropertyIconTexture = "icon-texture";
+        public const string StylePropertyFontColor = "font-color";
 
         public Label Label { get; }
         public Label OffStateLabel { get; }
@@ -69,7 +73,26 @@ namespace Robust.Client.UserInterface.Controls
 
         protected override void DrawModeChanged()
         {
-            base.DrawModeChanged();
+            if (Disabled)
+            {
+                AddStylePseudoClass(StylePseudoClassDisabled);
+            }
+            else
+            {
+                RemoveStylePseudoClass(StylePseudoClassDisabled);
+            }
+
+            if (Pressed)
+            {
+                AddStylePseudoClass(StylePseudoClassPressed);
+            }
+            else
+            {
+                RemoveStylePseudoClass(StylePseudoClassPressed);
+            }
+
+            // no base.DrawModeChanged() call - ContainerButton's pseudoclass handling
+            // doesn't support a button being both pressed and disabled
             UpdateAppearance();
         }
 
@@ -126,31 +149,37 @@ namespace Robust.Client.UserInterface.Controls
 
         private void UpdateAppearance()
         {
-            if ( Pressed )
+            TryGetStyleProperty(StylePropertyIconTexture, out Texture? texture);
+            if (texture is not null && TextureRect is not null)
             {
-                TryGetStyleProperty(StylePropertyTextureChecked, out Texture? texture);
-                if (texture is not null && TextureRect is not null)
-                {
-                    TextureRect.Texture = texture;
-                }
-
-                if (OffStateLabel is not null)
-                    OffStateLabel.Visible = false;
-                if (OnStateLabel is not null)
-                    OnStateLabel.Visible = true;
+                TextureRect.Texture = texture;
             }
-            else
-            {
-                TryGetStyleProperty(StylePropertyTextureUnchecked, out Texture? texture);
-                if (texture is not null && TextureRect is not null)
-                {
-                    TextureRect.Texture = texture;
-                }
 
+            TryGetStyleProperty(StylePropertyFontColor, out Color? fontColor);
+            if (fontColor is not null)
+            {
+                if (Label is not null)
+                {
+                    Label.FontColorOverride = fontColor;
+                }
                 if (OffStateLabel is not null)
-                    OffStateLabel.Visible = true;
+                {
+                    OffStateLabel.FontColorOverride = fontColor;
+                }
                 if (OnStateLabel is not null)
-                    OnStateLabel.Visible = false;
+                {
+                    OnStateLabel.FontColorOverride = fontColor;
+                }
+            }
+
+            if (OffStateLabel is not null)
+            {
+                OffStateLabel.Visible = !Pressed;
+            }
+
+            if (OnStateLabel is not null)
+            {
+                OnStateLabel.Visible = Pressed;
             }
         }
 

--- a/Robust.Client/UserInterface/Controls/ToggleSwitch.cs
+++ b/Robust.Client/UserInterface/Controls/ToggleSwitch.cs
@@ -1,0 +1,128 @@
+﻿using Robust.Shared.ViewVariables;
+using static Robust.Client.UserInterface.Controls.Label;
+using Robust.Shared.Localization;
+
+namespace Robust.Client.UserInterface.Controls
+{
+    /// <summary>
+    ///     A type of toggleable button that a switch icon and a secondary text label both showing the current state
+    /// </summary>
+    [Virtual]
+    public class ToggleSwitch : ContainerButton
+    {
+        public const string StyleClassToggleSwitch = "toggleSwitch";
+        public const string StyleClassToggleSwitchOn = "toggleSwitchOn";
+
+
+        public Label Label { get; }
+        public Label OffStateLabel { get; }
+        public Label OnStateLabel { get; }
+        public TextureRect TextureRect { get; }
+
+        public ToggleSwitch()
+        {
+            ToggleMode = true;
+
+            var hBox = new BoxContainer
+            {
+                Orientation = BoxContainer.LayoutOrientation.Horizontal,
+                StyleClasses = { StyleClassToggleSwitch },
+            };
+            AddChild(hBox);
+
+            TextureRect = new TextureRect
+            {
+                StyleClasses = { StyleClassToggleSwitch },
+                VerticalAlignment = VAlignment.Center,
+            };
+
+            Label = new Label();
+
+            OffStateLabel = new Label();
+            OffStateLabel.Text = Loc.GetString("toggle-switch-default-off-state-label");
+            OffStateLabel.ReservesSpace = true;
+
+            OnStateLabel = new Label();
+            OnStateLabel.Text = Loc.GetString("toggle-switch-default-on-state-label");
+            OnStateLabel.ReservesSpace = true;
+            OnStateLabel.Visible = false;
+
+            // I think PanelContainer is the simplest container; it is only used here
+            // so the labels can reserve overlapping spaces, so that switching which one is
+            // visible when the button is clicked doesn't affect the texture position or the
+            // surrounding layout
+            var stateLabelContainer = new PanelContainer();
+            stateLabelContainer.AddChild(OffStateLabel);
+            stateLabelContainer.AddChild(OnStateLabel);
+
+            Label.HorizontalExpand = true;
+            hBox.AddChild(Label);
+            hBox.AddChild(TextureRect);
+            hBox.AddChild(stateLabelContainer);
+        }
+
+        protected override void DrawModeChanged()
+        {
+            base.DrawModeChanged();
+
+            if (Pressed)
+            {
+                TextureRect?.AddStyleClass(StyleClassToggleSwitchOn);
+                if (OffStateLabel is not null)
+                    OffStateLabel.Visible = false;
+                if (OnStateLabel is not null)
+                    OnStateLabel.Visible = true;
+            }
+            else
+            {
+                TextureRect?.RemoveStyleClass(StyleClassToggleSwitchOn);
+                if (OffStateLabel is not null)
+                    OffStateLabel.Visible = true;
+                if (OnStateLabel is not null)
+                    OnStateLabel.Visible = false;
+            }
+        }
+
+        /// <summary>
+        ///     If true, the button will allow shrinking and clip text of the main
+        ///     label to prevent the text from going outside the bounds of the button.
+        ///     If false, the minimum size will always fit the contained text.
+        /// </summary>
+        [ViewVariables]
+        public bool ClipText { get => Label.ClipText; set => Label.ClipText = value; }
+
+        /// <summary>
+        ///     The text displayed by the button's main label.
+        /// </summary>
+        [ViewVariables]
+        public string? LabelText
+        {
+            get => Label.Text;
+            set
+            {
+                Label.Text = value;
+                Label.Visible = !string.IsNullOrEmpty(Label.Text);
+            }
+        }
+
+        /// <summary>
+        ///     The text displayed by the button's secondary label in the off state.
+        /// </summary>
+        [ViewVariables]
+        public string? OffStateText
+        {
+            get => OffStateLabel.Text;
+            set => OffStateLabel.Text = value;
+        }
+
+        /// <summary>
+        ///     The text displayed by the button's secondary label in the on state.
+        /// </summary>
+        [ViewVariables]
+        public string? OnStateText
+        {
+            get => OnStateLabel.Text;
+            set => OnStateLabel.Text = value;
+        }
+    }
+}

--- a/Robust.Client/UserInterface/Controls/ToggleSwitch.cs
+++ b/Robust.Client/UserInterface/Controls/ToggleSwitch.cs
@@ -17,6 +17,12 @@ namespace Robust.Client.UserInterface.Controls
         public Label Label { get; }
         public Label OffStateLabel { get; }
         public Label OnStateLabel { get; }
+
+        // I think PanelContainer is the simplest container; it is only used here
+        // so the labels can reserve overlapping spaces, so that switching which one is
+        // visible when the button is clicked doesn't affect the texture position or the
+        // surrounding layout
+        public PanelContainer StateLabelsContainer { get; }
         public TextureRect TextureRect { get; }
 
         public ToggleSwitch()
@@ -26,7 +32,7 @@ namespace Robust.Client.UserInterface.Controls
             var hBox = new BoxContainer
             {
                 Orientation = BoxContainer.LayoutOrientation.Horizontal,
-                StyleClasses = { StyleClassToggleSwitch },
+                StyleClasses = { StyleClassToggleSwitch }
             };
             AddChild(hBox);
 
@@ -37,6 +43,7 @@ namespace Robust.Client.UserInterface.Controls
             };
 
             Label = new Label();
+            Label.Visible = false;
 
             OffStateLabel = new Label();
             OffStateLabel.Text = Loc.GetString("toggle-switch-default-off-state-label");
@@ -47,18 +54,15 @@ namespace Robust.Client.UserInterface.Controls
             OnStateLabel.ReservesSpace = true;
             OnStateLabel.Visible = false;
 
-            // I think PanelContainer is the simplest container; it is only used here
-            // so the labels can reserve overlapping spaces, so that switching which one is
-            // visible when the button is clicked doesn't affect the texture position or the
-            // surrounding layout
-            var stateLabelContainer = new PanelContainer();
-            stateLabelContainer.AddChild(OffStateLabel);
-            stateLabelContainer.AddChild(OnStateLabel);
+            StateLabelsContainer = new PanelContainer();
+            StateLabelsContainer.HorizontalExpand = false;  // will change if text added for Label
+            StateLabelsContainer.AddChild(OffStateLabel);
+            StateLabelsContainer.AddChild(OnStateLabel);
 
             Label.HorizontalExpand = true;
             hBox.AddChild(Label);
             hBox.AddChild(TextureRect);
-            hBox.AddChild(stateLabelContainer);
+            hBox.AddChild(StateLabelsContainer);
         }
 
         protected override void DrawModeChanged()
@@ -101,7 +105,16 @@ namespace Robust.Client.UserInterface.Controls
             set
             {
                 Label.Text = value;
-                Label.Visible = !string.IsNullOrEmpty(Label.Text);
+                if (string.IsNullOrEmpty(value))
+                {
+                    Label.Visible = false;
+                    StateLabelsContainer.HorizontalExpand = true;
+                }
+                else
+                {
+                    Label.Visible = true;
+                    StateLabelsContainer.HorizontalExpand = false;
+                }
             }
         }
 

--- a/Robust.Client/UserInterface/Stylesheets/DefaultStylesheet.cs
+++ b/Robust.Client/UserInterface/Stylesheets/DefaultStylesheet.cs
@@ -208,11 +208,11 @@ public sealed class DefaultStylesheet
              */
 
             // Toggle switch off
-            Element<TextureRect>().Class(ToggleSwitch.StyleClassToggleSwitch)
+            Element<TextureRect>().Class(SwitchButton.StyleClassSwitchButton)
                 .Prop(TextureRect.StylePropertyTexture, Texture.Black), // TODO: Add actual texture instead of this.
 
             // Toggle switch on
-            Element<TextureRect>().Class(ToggleSwitch.StyleClassToggleSwitch, ToggleSwitch.StyleClassToggleSwitchOn)
+            Element<TextureRect>().Class(SwitchButton.StyleClassSwitchButton, SwitchButton.StyleClassSwitchButtonChecked)
                 .Prop(TextureRect.StylePropertyTexture, Texture.White), // TODO: Add actual texture instead of this.
 
             /*

--- a/Robust.Client/UserInterface/Stylesheets/DefaultStylesheet.cs
+++ b/Robust.Client/UserInterface/Stylesheets/DefaultStylesheet.cs
@@ -204,16 +204,12 @@ public sealed class DefaultStylesheet
                 .Prop(TextureRect.StylePropertyTexture, Texture.White), // TODO: Add actual texture instead of this.
 
             /*
-             * Toggle switch
+             * Switch button
              */
 
-            // Toggle switch off
-            Element<TextureRect>().Class(SwitchButton.StyleClassSwitchButton)
-                .Prop(TextureRect.StylePropertyTexture, Texture.Black), // TODO: Add actual texture instead of this.
-
-            // Toggle switch on
-            Element<TextureRect>().Class(SwitchButton.StyleClassSwitchButton, SwitchButton.StyleClassSwitchButtonChecked)
-                .Prop(TextureRect.StylePropertyTexture, Texture.White), // TODO: Add actual texture instead of this.
+            Element<SwitchButton>()
+                .Prop(SwitchButton.StylePropertyTextureUnchecked, Texture.Black)
+                .Prop(SwitchButton.StylePropertyTextureChecked, Texture.White), // TODO: Add actual textures instead of this.
 
             /*
              * LineEdit

--- a/Robust.Client/UserInterface/Stylesheets/DefaultStylesheet.cs
+++ b/Robust.Client/UserInterface/Stylesheets/DefaultStylesheet.cs
@@ -204,6 +204,18 @@ public sealed class DefaultStylesheet
                 .Prop(TextureRect.StylePropertyTexture, Texture.White), // TODO: Add actual texture instead of this.
 
             /*
+             * Toggle switch
+             */
+
+            // Toggle switch off
+            Element<TextureRect>().Class(ToggleSwitch.StyleClassToggleSwitch)
+                .Prop(TextureRect.StylePropertyTexture, Texture.Black), // TODO: Add actual texture instead of this.
+
+            // Toggle switch on
+            Element<TextureRect>().Class(ToggleSwitch.StyleClassToggleSwitch, ToggleSwitch.StyleClassToggleSwitchOn)
+                .Prop(TextureRect.StylePropertyTexture, Texture.White), // TODO: Add actual texture instead of this.
+
+            /*
              * LineEdit
              */
 

--- a/Robust.Client/UserInterface/Stylesheets/DefaultStylesheet.cs
+++ b/Robust.Client/UserInterface/Stylesheets/DefaultStylesheet.cs
@@ -208,8 +208,10 @@ public sealed class DefaultStylesheet
              */
 
             Element<SwitchButton>()
-                .Prop(SwitchButton.StylePropertyTextureUnchecked, Texture.Black)
-                .Prop(SwitchButton.StylePropertyTextureChecked, Texture.White), // TODO: Add actual textures instead of this.
+                .Prop(SwitchButton.StylePropertyIconTexture, Texture.Black), // TODO: Add actual texture instead of this.
+
+            Element<SwitchButton>().Pseudo(SwitchButton.StylePseudoClassPressed)
+                .Prop(SwitchButton.StylePropertyIconTexture, Texture.White),  // TODO: Add actual texture instead of this.
 
             /*
              * LineEdit

--- a/Robust.Client/UserInterface/Stylesheets/DefaultStylesheet.cs
+++ b/Robust.Client/UserInterface/Stylesheets/DefaultStylesheet.cs
@@ -204,14 +204,18 @@ public sealed class DefaultStylesheet
                 .Prop(TextureRect.StylePropertyTexture, Texture.White), // TODO: Add actual texture instead of this.
 
             /*
-             * Switch button
+             * SwitchButton
              */
 
-            Element<SwitchButton>()
-                .Prop(SwitchButton.StylePropertyIconTexture, Texture.Black), // TODO: Add actual texture instead of this.
+            // SwitchButton unchecked/off
+            Child().Parent(Element<SwitchButton>())
+                .Child(Element<TextureRect>())
+                .Prop(TextureRect.StylePropertyTexture, Texture.Black), // TODO: Add actual texture instead of this.
 
-            Element<SwitchButton>().Pseudo(SwitchButton.StylePseudoClassPressed)
-                .Prop(SwitchButton.StylePropertyIconTexture, Texture.White),  // TODO: Add actual texture instead of this.
+            // SwitchButton checked/on
+            Child().Parent(Element<SwitchButton>().Pseudo(SwitchButton.StylePseudoClassPressed))
+                .Child(Element<TextureRect>())
+                .Prop(TextureRect.StylePropertyTexture, Texture.White),  // TODO: Add actual texture instead of this.
 
             /*
              * LineEdit


### PR DESCRIPTION
This adds `SwitchButton`, a switch button control. This is intended mainly for power buttons in things like the APC UI and gas manipulation device UIs.

https://github.com/space-wizards/space-station-14/pull/39161 adds styles for this control to space-station-14 and changes the APC UI to use it.

## Description and technical details

I've added some screenshots that show how the control's layout works. These use the styles from https://github.com/space-wizards/space-station-14/pull/39161. That PR will not actually implement all of the UI changes shown in these screenshots. It only changes the APC menu. I plan to change the gas pump status button in a later PR, and I currently do not plan to actually change the intercom menu at all, but it makes a useful layout example.

The control has three visible components. From left to right, they are:
* an optional main label describing what the switch controls;
* a toggle switch icon;
* and a label describing the current state.

<img width="156" height="32" alt="image" src="https://github.com/user-attachments/assets/4728e226-0a78-480e-9b24-475db9923527" />

Clicking any of these toggles the button state.

The control has localizable default state labels of "Off" and "On"; I think having state labels improves usability in most of the cases where this control would be used. [Microsoft uses default "Off" and "On" labels and encourages developers to use them](https://learn.microsoft.com/en-us/windows/apps/design/controls/toggles); it seems likely they'd provide different guidance if these default labels caused many localization issues.

The default state labels can be overwritten by setting `OffStateText` and `OnStateText`.

The state label portion of the switch reserves overlapping space for both labels, so the button's size and layout don't change when the button is clicked.

If there is a main label, and the button is expanded horizontally, the excess space is put at the end of the main label. This means that if multiple switch buttons with the same labels and width are stacked, for instance in a vertical `BoxContainer`, they will all line up nicely.
<img width="197" height="71" alt="image" src="https://github.com/user-attachments/assets/ee816ee2-e242-43b7-b360-0b571e58560d" />

If the main label is empty, the icon and state label are aligned left.
<img width="221" height="89" alt="image" src="https://github.com/user-attachments/assets/44301ae6-e084-474e-9de4-7a5da8e1f15d" />

It is my understanding that RobustToolbox doesn't support right-to-left text; if I am wrong about that then `SwitchButton` will need some additional work to handle rtl layouts.

## CheckButton

The `CheckButton` class appears to have originally been intended to be this type of control. It inherits from `Button` and I do not believe it has ever had any actual differences from `Button`.

It is currently used in three places, all of which are have layouts based around it being regular button. As such, removing it or turning it into the actual switch button implementation would cause problems for old game versions.

I have added `[Obsolete]` to `CheckButton`. In https://github.com/space-wizards/space-station-14/pull/39161, all uses of `CheckButton` are replaced with `Button`.