### PR TITLE
Fix color naming crash

### DIFF
--- a/Resources/Locale/en-US/color-naming.ftl
+++ b/Resources/Locale/en-US/color-naming.ftl
@@ -21,6 +21,7 @@ color-brown = brown
 color-white = white
 color-gray = gray
 color-black = black
+color-unknown = unknown color, you should not see this
 
 color-pink-color-red = pinkish red
 color-red-color-orange = reddish orange

--- a/Robust.Shared/ColorNaming/ColorNaming.cs
+++ b/Robust.Shared/ColorNaming/ColorNaming.cs
@@ -2,6 +2,7 @@ using System;
 using System.Numerics;
 using Robust.Shared.Localization;
 using Robust.Shared.Maths;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.ColorNaming;
 
@@ -21,7 +22,8 @@ public static class ColorNaming
         (float.DegreesToRadians(285f), "color-purple"),
         (float.DegreesToRadians(330f), "color-pink"),
     };
-    private static readonly (float Hue, string Loc) HueFallback = (float.DegreesToRadians(360f), "color-pink");
+    // one past 360 because we're now inclusive on the upper for testing if we're out of bounds
+    private static readonly (float Hue, string Loc) HueFallback = (float.DegreesToRadians(361f), "color-pink");
 
     private const float BrownLightnessThreshold = 0.675f;
     private static readonly LocId OrangeString = "color-orange";
@@ -63,7 +65,7 @@ public static class ColorNaming
             var prevData = HueNames[i];
             var nextData = i+1 < HueNames.Length ? HueNames[i+1] : HueFallback;
 
-            if (prevData.Hue >= hue || hue > nextData.Hue)
+            if (prevData.Hue > hue || hue >= nextData.Hue)
                 continue;
 
             var loc = prevData.Loc;
@@ -85,7 +87,8 @@ public static class ColorNaming
             return (localization.GetString(loc), adjustedLightness);
         }
 
-        throw new ArgumentOutOfRangeException("oklch", $"colour ({oklch}) hue {hue} is outside of expected bounds");
+        DebugTools.Assert($"colour ({oklch}) hue {hue} is outside of expected bounds");
+        return (localization.GetString("color-unknown"), lightness);
     }
 
     private static string? DescribeChroma(Vector4 oklch, ILocalizationManager localization)


### PR DESCRIPTION
Colours with an OKLCH hue of exactly `0` (which is not the usual HSV/HSL/RGB gray) were not getting picked up by the loop, which caused it to run to completion and hit the exception at the end. I replaced `[prev, next)` with a `(prev, next]` check, and nudged the final `HueFallback` up by 1 to ensure we catch the other end. As we don't have any fuzzing or property-based tests, I replaced the exception with a DebugTools.Assert and a fallback for release builds to avoid future crashes, even if this code fails again.