### PR TITLE
Add GridGet toolshed command

### DIFF
--- a/Resources/Locale/en-US/toolshed-commands.ftl
+++ b/Resources/Locale/en-US/toolshed-commands.ftl
@@ -203,12 +203,12 @@ command-description-mappos =
     Returns an entity's coordinates relative to it's current map.
 command-description-pos =
     Returns an entity's coordinates.
+command-description-gridget-grid =
+    Returns the grid an entity is on.
 command-description-gridget-tile =
     Returns the tile an entity is on.
 command-description-gridget-tilename =
     Returns the name of the tile an entity is on.
-command-description-gridget-grid =
-    Returns the grid an entity is on.
 command-description-tp-coords =
     Teleports the given entities to the target coordinates.
 command-description-tp-to =

--- a/Resources/Locale/en-US/toolshed-commands.ftl
+++ b/Resources/Locale/en-US/toolshed-commands.ftl
@@ -203,6 +203,12 @@ command-description-mappos =
     Returns an entity's coordinates relative to it's current map.
 command-description-pos =
     Returns an entity's coordinates.
+command-description-gridget-tile =
+    Returns the tile an entity is on.
+command-description-gridget-tilename =
+    Returns the name of the tile an entity is on.
+command-description-gridget-grid =
+    Returns the grid an entity is on.
 command-description-tp-coords =
     Teleports the given entities to the target coordinates.
 command-description-tp-to =

--- a/Robust.Shared/Toolshed/Commands/Entities/World/GridGetCommand.cs
+++ b/Robust.Shared/Toolshed/Commands/Entities/World/GridGetCommand.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+
+namespace Robust.Shared.Toolshed.Commands.Entities.World;
+
+[ToolshedCommand]
+public sealed class GridGetCommand : ToolshedCommand
+{
+    private SharedMapSystem? _mapSys;
+    private SharedTransformSystem? _xForm;
+    [Dependency] private ITileDefinitionManager _tileDefMan = default!;
+
+    [CommandImplementation("tilename")]
+    public IEnumerable<string> GetTileName([PipedArgument] IEnumerable<ITileDefinition> input)
+    {
+        foreach (var tileDef in input)
+        {
+            yield return tileDef.Name;
+        }
+    }
+
+    [CommandImplementation("tilename")]
+    public IEnumerable<string> GetTileName([PipedArgument] IEnumerable<EntityUid> input)
+        => GetTileName(GetTile(input));
+
+    [CommandImplementation("grid")]
+    public IEnumerable<EntityUid> GetGrid([PipedArgument] IEnumerable<EntityUid> input)
+    {
+        _xForm ??= GetSys<SharedTransformSystem>();
+
+        foreach (var uid in input)
+        {
+            var grid = _xForm.GetGrid((uid, Transform(uid)));
+            if (grid != null)
+                yield return grid.Value;
+        }
+    }
+
+    [CommandImplementation("tile")]
+    public IEnumerable<ITileDefinition> GetTile([PipedArgument] IEnumerable<EntityUid> input)
+    {
+        _mapSys ??= GetSys<SharedMapSystem>();
+        _xForm ??= GetSys<SharedTransformSystem>();
+
+        foreach (var uid in input)
+        {
+            var grid = _xForm.GetGrid((uid, Transform(uid)));
+            if (grid is null)
+                continue;
+            if (!TryComp(grid, out MapGridComponent? gridComp))
+                continue;
+            var coords = _xForm.GetMapCoordinates(uid);
+
+            var tile = _mapSys.GetTileRef((grid.Value, gridComp), coords);
+            if (_tileDefMan.TryGetDefinition(tile.Tile.TypeId, out var tileDef))
+                yield return tileDef;
+        }
+    }
+}


### PR DESCRIPTION
I noticed there wasn't a toolshed command for getting the grid an entity was on or getting the name of the tile so I added them

Requires https://github.com/space-wizards/space-station-14/pull/39201

<img width="717" height="539" alt="image" src="https://github.com/user-attachments/assets/035bf728-4caf-4fec-aebb-6d9d812461d7" />