### PR TITLE
add QueueDeleteMap to SharedMapSystem

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Added `SharedMapSystem.QueueDeleteMap`, which deletes a map with the specified MapId in the next tick.
 
 ### Bugfixes
 

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Map.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Map.cs
@@ -262,10 +262,22 @@ public abstract partial class SharedMapSystem
         return (uid, AddComp<MapComponent>(uid), meta);
     }
 
+    /// <summary>
+    /// Deletes a map with the specified map id.
+    /// </summary>
     public void DeleteMap(MapId mapId)
     {
         if (TryGetMap(mapId, out var uid))
             Del(uid);
+    }
+
+    /// <summary>
+    /// Deletes a map with the specified map id in the next tick.
+    /// </summary>
+    public void QueueDeleteMap(MapId mapId)
+    {
+        if (TryGetMap(mapId, out var uid))
+            QueueDel(uid);
     }
 
     public IEnumerable<MapId> GetAllMapIds()


### PR DESCRIPTION
Some content systems are creating new paused maps to store entities on. Examples are `PolymorphSystem` and `CryostorageSystem`, and the same is needed for the changeling.

For integration test and cleanup reasons these maps should be deleted again when no longer needed - that is when no more entities are stored on them. However, directly deleting the map using `DeleteMap` does not work, as we are doing this in an event subscription and deleting the map would instantly delete the subscribing entity.

So a deferred map deletion is needed.