### PR TITLE
fix: use the actual top anchor in SetMarginsPreset

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* `LayoutContainer.SetMarginsPreset` and `SetAnchorAndMarginPreset` now correctly use the provided control's top anchor when calculating the margins for its presets; it previously used the bottom anchor instead. This may result in a few UI differences, by a few pixels at most.
 
 ### Other
 

--- a/Robust.Client/UserInterface/Controls/LayoutContainer.cs
+++ b/Robust.Client/UserInterface/Controls/LayoutContainer.cs
@@ -326,7 +326,7 @@ namespace Robust.Client.UserInterface.Controls
             var parentSize = control.Parent?.Size ?? Vector2.Zero;
 
             var anchorLeft = control.GetValue<float>(AnchorLeftProperty);
-            var anchorTop = control.GetValue<float>(AnchorBottomProperty);
+            var anchorTop = control.GetValue<float>(AnchorTopProperty);
             var anchorRight = control.GetValue<float>(AnchorRightProperty);
             var anchorBottom = control.GetValue<float>(AnchorBottomProperty);
 


### PR DESCRIPTION
LayoutContainer was referencing the bottom instead of the top anchor when setting the margins for a preset; probably just a copy-paste error. Only UI difference I could find in Content was with the strip menu's margin on the right side:

<details>
<summary>Comparison</summary>

Before:
<img width="476" height="778" alt="image" src="https://github.com/user-attachments/assets/010b78d0-e561-4391-a8dd-7e20cff035db" />

After:
<img width="478" height="806" alt="image" src="https://github.com/user-attachments/assets/1df7a72f-9326-4aa8-b044-c91ac454a76a" />

</details>


is this what robust players mean when they say to get good at pixel hunting am I doing it right am I robust