### PR TITLE
Add localization support for TileSpawnWindow and unifying some elemets for spawn windows

### DIFF
--- a/Resources/Locale/en-US/custom-controls.ftl
+++ b/Resources/Locale/en-US/custom-controls.ftl
@@ -1,8 +1,6 @@
 ## EntitySpawnWindow
 
 entity-spawn-window-title = Entity Spawn Panel
-entity-spawn-window-search-bar-placeholder = search
-entity-spawn-window-clear-button = Clear
 entity-spawn-window-replace-button-text = Replace
 entity-spawn-window-override-menu-tooltip = Override placement
 
@@ -22,3 +20,5 @@ output-panel-scroll-down-button-text = Scroll Down
 ## Common Used
 
 window-erase-button-text = Erase Mode
+window-search-bar-placeholder = Search
+window-clear-button = Clear

--- a/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.xaml
+++ b/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.xaml
@@ -5,8 +5,8 @@
     MinSize="350 200">
     <BoxContainer Orientation="Vertical">
         <BoxContainer Orientation="Horizontal">
-            <LineEdit Name="SearchBar" Access="Public" HorizontalExpand="True" PlaceHolder="{Loc entity-spawn-window-search-bar-placeholder}"/>
-            <Button Name="ClearButton" Access="Public" Disabled="True" Text="{Loc entity-spawn-window-clear-button}" />
+            <LineEdit Name="SearchBar" Access="Public" HorizontalExpand="True" PlaceHolder="{Loc window-search-bar-placeholder}"/>
+            <Button Name="ClearButton" Access="Public" Disabled="True" Text="{Loc window-clear-button}" />
         </BoxContainer>
         <ScrollContainer Name="PrototypeScrollContainer" Access="Public" MinSize="200 0" VerticalExpand="True">
             <PrototypeListContainer Name="PrototypeList" Access="Public"/>

--- a/Robust.Client/UserInterface/CustomControls/TileSpawnWindow.xaml
+++ b/Robust.Client/UserInterface/CustomControls/TileSpawnWindow.xaml
@@ -5,8 +5,8 @@
     MinSize="300 200">
     <BoxContainer Orientation="Vertical">
         <BoxContainer Orientation="Horizontal">
-            <LineEdit Name="SearchBar" Access="Public" HorizontalExpand="True" PlaceHolder="Search"/>
-            <Button Name="ClearButton" Access="Public" Text="Clear"/>
+            <LineEdit Name="SearchBar" Access="Public" HorizontalExpand="True" PlaceHolder="{Loc window-search-bar-placeholder}"/>
+            <Button Name="ClearButton" Access="Public" Text="{Loc window-clear-button}"/>
         </BoxContainer>
         <ItemList Name="TileList" Access="Public" VerticalExpand="True"/>
         <BoxContainer Orientation="Horizontal">


### PR DESCRIPTION
It’s unclear why EntitySpawnWindow supports localization but TileSpawnWindow was deemed not to need it. To prevent duplication, repeated fields were unified.

_Reopened for some reason..._