### PR TITLE
Treat deleted `EntityUid?` as a null `NetEntity?`

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Network.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Network.cs
@@ -195,6 +195,9 @@ public partial class EntityManager
         if (uid == null)
             return null;
 
+        if (!MetaQuery.Resolve(uid.Value, ref metadata, logMissing: false))
+            return null;
+
         return GetNetEntity(uid.Value, metadata);
     }
 

--- a/Robust.UnitTesting/Shared/GameState/ComponentStateTests.cs
+++ b/Robust.UnitTesting/Shared/GameState/ComponentStateTests.cs
@@ -264,7 +264,7 @@ public sealed partial class ComponentStateTests : RobustIntegrationTest
             Assert.That(clientEntB, Is.EqualTo(EntityUid.Invalid));
             Assert.That(client.EntMan.EntityExists(clientEntA), Is.True);
             Assert.That(client.EntMan.TryGetComponent(clientEntA, out UnknownEntityTestComponent? cmp));
-            Assert.That(cmp?.Other, Is.EqualTo(EntityUid.Invalid));
+            Assert.That(cmp?.Other, Is.Null);
         });
 
         server.Post(() => server.CfgMan.SetCVar(CVars.NetPVS, false));


### PR DESCRIPTION
I'm proposing this as an alternative to [`WeakEntityReference`](https://github.com/space-wizards/RobustToolbox/pull/6114).

While trying to convert `WeakEntityReference` from being based around a `NetEntity` to being based around an `EntityUid`, I found that I was duplicating a lot of code with the way that `EntityUid`s are converted to `NetEntity`s for component state networking. I also got confused a lot about what exactly the different types represent: what are the differences between a `WeakEntityReference`, a `WeakEntityReference?`, and an `EntityUid?`; does a `WeakEntityReference?` even make sense?

The main issue that `WeakEntityReference` is trying to solve is the massive spam of PVS errors when the auto state generator tries to get state for a component with an `EntityUid?` DataField that has been deleted.

We've been working with the idea that those DataFields should be set to null when the entity they refer to has been deleted. This is a pain to handle in many cases, as it requires the referenced entity to have its own inverse reference solely to inform the referring entity when it gets deleted. 

But why? **Isn't a nullable `EntityUid` essentially a weak reference to an entity?** In purely server-side code, we use `!Deleted(comp.NullableEnt)` or similar to check that a nullable `EntityUid` field is valid before using it. Why do we need to treat it differently for PVS states?

This PR changes the behavior of `EntityManager.GetNetEntity(EntityUid?)` so that passing in a deleted entity returns null instead of logging an error and returning `NetEntity.Invalid`. Since the related methods for getting arrays, lists, etc of `NetEntity`s call that method, they are also changed. Methods working with non-nullable `EntityUid`s are not changed and will still log an error if called on a deleted entity (which I think makes sense).

This seems to me like more logical behavior - a reference to a deleted entity is a reasonable value for an `EntityUid?` and getting component state for it shouldn't be considered an error. 

My content `WeakEntityReference` conversion PRs include tests that produce component states with references to deleted entities and check for PVS errors. This change allows those tests to pass without needing any modifications to the components they test - meaning that this change should fix all of the related errors without needing to handle them individually.