### PR TITLE
Minimum MIDI note volume

### DIFF
--- a/Robust.Client/Audio/Midi/IMidiRenderer.cs
+++ b/Robust.Client/Audio/Midi/IMidiRenderer.cs
@@ -213,4 +213,6 @@ public interface IMidiRenderer : IDisposable
     ///     Actually disposes of this renderer. Do NOT use outside the MIDI thread.
     /// </summary>
     internal void InternalDispose();
+
+    byte MinVolume { get; set; }
 }


### PR DESCRIPTION
Adds the ability to set the minimum note volume of a MIDI renderer. This allows for fine-tuning of a Renderer when playing MIDI sources that are too quiet, without messing with the actual audio source's settings.

The exact mechanism is a simple lerp, so you still get a range of note volumes (i.e. one note is at 50 velocity and one is at 100, and you set the minimum volume to 25, the new velocities are still the same distance from each other on the reduced range...)