### PR TITLE
Fixing the limit for networked Vars.

### DIFF
--- a/Robust.Shared/Network/Messages/MsgConVars.cs
+++ b/Robust.Shared/Network/Messages/MsgConVars.cs
@@ -82,7 +82,7 @@ namespace Robust.Shared.Network.Messages
             if(NetworkedVars == null)
                 throw new InvalidOperationException($"{nameof(NetworkedVars)} collection is null.");
 
-            if(NetworkedVars.Count > byte.MaxValue)
+            if(NetworkedVars.Count > short.MaxValue)
                 throw new InvalidOperationException($"{nameof(NetworkedVars)} collection count is greater than {short.MaxValue}.");
 
             buffer.WriteVariableUInt32(Tick.Value);

--- a/Robust.Shared/Network/Messages/MsgConVars.cs
+++ b/Robust.Shared/Network/Messages/MsgConVars.cs
@@ -27,7 +27,7 @@ namespace Robust.Shared.Network.Messages
                 Logger.WarningS("net", $"{MsgChannel}: received a large {nameof(MsgConVars)}, {buffer.LengthBytes}B > {MaxMessageSize}B");
 
             Tick = new GameTick(buffer.ReadVariableUInt32());
-            var nVars = buffer.ReadByte();
+            var nVars = buffer.ReadInt16();
 
             NetworkedVars = new List<(string name, object value)>(nVars);
 
@@ -86,7 +86,7 @@ namespace Robust.Shared.Network.Messages
                 throw new InvalidOperationException($"{nameof(NetworkedVars)} collection count is greater than {short.MaxValue}.");
 
             buffer.WriteVariableUInt32(Tick.Value);
-            buffer.Write((byte)NetworkedVars.Count);
+            buffer.Write((short)NetworkedVars.Count);
 
             foreach (var (name, value) in NetworkedVars)
             {

--- a/Robust.UnitTesting/Shared/Vars/MsgConVarsTest.cs
+++ b/Robust.UnitTesting/Shared/Vars/MsgConVarsTest.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Lidgren.Network;
+using NUnit.Framework;
+using Robust.Shared.IoC;
+using Robust.Shared.Network.Messages;
+using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
+
+namespace Robust.UnitTesting.Shared.Vars;
+
+public sealed class MsgConVarsTest : RobustIntegrationTest
+{
+    [Test]
+    public async Task TestMsgConVarsSerialization_ServerToClient()
+    {
+        var server = StartServer();
+        var client = StartClient();
+
+        byte[] buffer = null!;
+
+        await server.WaitPost(() =>
+        {
+            var msg = new MsgConVars
+            {
+                Tick = new GameTick(30),
+                NetworkedVars = new List<(string name, object value)>
+                {
+                    ("intVar", 123),
+                    ("longVar", 1234567890123L),
+                    ("boolVar", true),
+                    ("stringVar", "testString"),
+                    ("floatVar", 3.14f),
+                    ("doubleVar", 2.71828)
+                }
+            };
+
+            var serializer = (RobustSerializer) IoCManager.Resolve<IRobustSerializer>();
+            var netPeer = new NetPeer(new NetPeerConfiguration("test"));
+            var outMsg = netPeer.CreateMessage();
+
+            msg.WriteToBuffer(outMsg, serializer);
+
+            buffer = new byte[outMsg.LengthBytes];
+            outMsg.Data.AsSpan(0, outMsg.LengthBytes).CopyTo(buffer);
+        });
+
+        await client.WaitPost(() =>
+        {
+            var serializer = (RobustSerializer) IoCManager.Resolve<IRobustSerializer>();
+            var inMsg = new NetIncomingMessage(NetIncomingMessageType.Data);
+            inMsg.Write(buffer, 0, buffer.Length);
+            inMsg.Position = 0;
+
+            var receivedMsg = new MsgConVars();
+            receivedMsg.ReadFromBuffer(inMsg, serializer);
+
+            Assert.That(receivedMsg.NetworkedVars.Count, Is.EqualTo(6));
+
+            foreach (var (name, value) in receivedMsg.NetworkedVars)
+            {
+                switch (name)
+                {
+                    case "intVar":
+                        Assert.That(value, Is.EqualTo(123));
+                        break;
+                    case "longVar":
+                        Assert.That(value, Is.EqualTo(1234567890123L));
+                        break;
+                    case "boolVar":
+                        Assert.That(value, Is.EqualTo(true));
+                        break;
+                    case "stringVar":
+                        Assert.That(value, Is.EqualTo("testString"));
+                        break;
+                    case "floatVar":
+                        Assert.That((float)value, Is.EqualTo(3.14f).Within(0.0001f));
+                        break;
+                    case "doubleVar":
+                        Assert.That((double)value, Is.EqualTo(2.71828).Within(0.0001));
+                        break;
+                    default:
+                        Assert.Fail($"Unexpected variable name: {name}");
+                        break;
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
I think it's a typo. Exception show limit for short.MaxValue (32767). But checked byte.MaxValue (255)
<img width="971" height="262" alt="image" src="https://github.com/user-attachments/assets/51c83d0b-5a07-40d9-84fa-669f369cdc37" />

255 network vars is terribly little, RMC already has 200+.
<img width="1051" height="188" alt="image" src="https://github.com/user-attachments/assets/00513bf1-23ac-4242-bdc4-1866ed9eaeb9" />
