### PR TITLE
Fix FOV/occlusion being skipped when DrawLighting is disabled

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -366,6 +366,12 @@ namespace Robust.Client.Graphics.Clyde
                 BindRenderTargetFull(viewport.RenderTarget);
                 GL.Viewport(0, 0, viewport.Size.X, viewport.Size.Y);
                 CheckGlError();
+                
+                // If we don't draw lighting, we still need to apply the FOV to the buffer.
+                IsStencilling = true;
+                ApplyFovToBuffer(viewport, eye);
+                IsStencilling = false;
+
                 return;
             }
 


### PR DESCRIPTION
When ILightManager.DrawLighting is set to false (eg for night vision effects), the entire FOV and occlusion path was being skipped in DrawLightsAndFov(). This allowed players could see through occluders (like tinted glass) when they shouldn't be able to, particularly when standing at corners.

lightManager.DrawLighting occurred before FOV stenciling was applied to the framebuffer, meaning occlusion geometry was calculated but never actually applied.

Instead of just returning, we now apply FOV.

For reference, the before and after: 

<img width="275" height="270" alt="Discord_diYbojLu2G" src="https://github.com/user-attachments/assets/52c33817-549b-4627-9317-cbb734711698" />


=======================================

Edit: Well, it got a bit more complicated >w< 

While this fixed the issue for two windows perpendicular to each other, it reoccurred when you add more windows next to them... 

<img width="275" height="270" alt="Content Client_2wr8SkQ9C6" src="https://github.com/user-attachments/assets/4aeffaf8-32d5-4e15-8271-2d5f98ee256c" />

The extended wall issue happened because tinted glass lacks neighbor occlusion flags (OccluderDir), causing each window to generate all 4 faces regardless of adjacent windows. This created overlapping geometry at shared edges, which interacted poorly with the face culling logic and created gaps in the FOV stencil buffer.

I've fixed this by implementing neighbor detection during occlusion geometry generation. It now detects adjacent occluders by comparing edges within a small tolerance, properly sets neighbor flags, and culls shared faces to prevent overlapping geometry.

This was not fun :c

I want to mess with this a tiny bit more, but it is working. Please hold off on merging. Feedback / input would be much appreciated. 