### PR TITLE
Serialization: Make null literal check culture-invariant

### DIFF
--- a/Robust.Shared/Serialization/Markdown/Value/ValueDataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/Value/ValueDataNode.cs
@@ -58,7 +58,8 @@ namespace Robust.Shared.Serialization.Markdown.Value
 
         public override bool IsEmpty => string.IsNullOrWhiteSpace(Value);
 
-        public static bool IsNullLiteral(string? value) => value != null && value.Trim().ToLower() is "null" ;
+        public static bool IsNullLiteral(string? value) =>
+            value != null && string.Equals(value.Trim(), "null", StringComparison.OrdinalIgnoreCase);
 
         public override ValueDataNode Copy()
         {


### PR DESCRIPTION
About the PR

Make YAML null literal detection culture-invariant by replacing a culture-sensitive lowercase comparison with an ordinal, case-insensitive comparison in `ValueDataNode.IsNullLiteral`.

Why's this needed?

Using `ToLower()` can produce incorrect results under certain locales (e.g., Turkish-i), which may cause null detection to fail. Using `StringComparison.OrdinalIgnoreCase` avoids culture effects and aligns with other invariant parsing in the class.

Changelog

changelog: none