### PR TITLE
make SharedAudioSystem.Stop not return early when the current tick has already been predicted

### DIFF
--- a/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
+++ b/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
@@ -455,7 +455,7 @@ public abstract partial class SharedAudioSystem : EntitySystem
         if (uid == null || !Resolve(uid.Value, ref component, false))
             return null;
 
-        if (!Timing.IsFirstTimePredicted || (_netManager.IsClient && !IsClientSide(uid.Value)))
+        if (_netManager.IsClient && !IsClientSide(uid.Value))
             return null;
 
         QueueDel(uid);


### PR DESCRIPTION
title; if unclear about what i'm doing, read diff

tested on latest ss14 and did not observe any difference at all so it was infact something that needed to be fixed ( as said in https://github.com/space-wizards/space-station-14/pull/37573#discussion_r2108987468 )

would fix https://github.com/space-wizards/space-station-14/issues/35081 if merged with https://github.com/space-wizards/space-station-14/pull/37573