### PR TITLE
Adds two new Component lookup functions to EntitySystem: `WithCompOrNull`

### DIFF
--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -526,6 +526,36 @@ public partial class EntitySystem
         return EntityManager.MetaQuery.TryGetComponent(uid.Value, out comp);
     }
 
+    /// <summary>
+    /// Retrieves the given entity's component of the specified type, assembled into an <see cref="Entity{T}"/>. If no
+    /// such component exists, returns null.
+    /// </summary>
+    /// <typeparam name="T">A trait or type of component to retrieve.</typeparam>
+    /// <param name="uid">The UID of the entity whose component will be retrieved.</param>
+    /// <returns>The assembled entity UID and component, if the component exists; otherwise <c>null</c>.</returns>
+    protected Entity<T>? WithCompOrNull<T>(EntityUid uid) where T : IComponent
+    {
+        return EntityManager.TryGetComponent<T>(uid, out var comp) ? new Entity<T>(uid, comp) : null;
+    }
+
+    /// <summary>
+    /// Retrieves the given entity's component of the specified type, assembled into an <see cref="Entity{T}"/>. If the
+    /// given entity already contains a component value, that is returned in the assembled return value. If the given
+    /// entity has no such component, returns null.
+    /// </summary>
+    /// <typeparam name="T">A trait or type of component to retrieve.</typeparam>
+    /// <param name="entity">
+    /// An <see cref="Entity{T}"/> containing the UID of the entity whose component will be retrieved. Note that this
+    /// MAY already contain a component value.
+    /// </param>
+    /// <returns>The assembled entity UID and component, if the component exists; otherwise <c>null</c>.</returns>
+    protected Entity<T>? WithCompOrNull<T>(Entity<T?> entity) where T : IComponent
+    {
+        return entity.Comp is { } comp || EntityManager.TryGetComponent(entity, out comp)
+            ? new Entity<T>(entity, comp)
+            : null;
+    }
+
     /// <inheritdoc cref="IEntityManager.GetComponents"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected IEnumerable<IComponent> AllComps(EntityUid uid)

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -530,7 +530,7 @@ public partial class EntitySystem
     /// Retrieves the given entity's component of the specified type, assembled into an <see cref="Entity{T}"/>. If no
     /// such component exists, returns null.
     /// </summary>
-    /// <typeparam name="T">A trait or type of component to retrieve.</typeparam>
+    /// <typeparam name="T">The type of component to retrieve.</typeparam>
     /// <param name="uid">The UID of the entity whose component will be retrieved.</param>
     /// <returns>The assembled entity UID and component, if the component exists; otherwise <c>null</c>.</returns>
     protected Entity<T>? WithCompOrNull<T>(EntityUid uid) where T : IComponent
@@ -543,7 +543,7 @@ public partial class EntitySystem
     /// given entity already contains a component value, that is returned in the assembled return value. If the given
     /// entity has no such component, returns null.
     /// </summary>
-    /// <typeparam name="T">A trait or type of component to retrieve.</typeparam>
+    /// <typeparam name="T">The type of component to retrieve.</typeparam>
     /// <param name="entity">
     /// An <see cref="Entity{T}"/> containing the UID of the entity whose component will be retrieved. Note that this
     /// MAY already contain a component value.


### PR DESCRIPTION
Adds two new functions to `EntitySystem` for retrieving component values ergonomically.

```csharp
Entity<T>? WithCompOrNull<T>(EntityUid uid) where T : IComponent
Entity<T>? WithCompOrNull<T>(Entity<T?> entity) where T : IComponent
```

There was a tiny bit of [discussion about this in the devbus](https://discord.com/channels/1401298992826159275/1401303305635758090/1405606590350098545).

### Ergonomics

Both offer ergonomics in the sense that their return values can be immediately chained with other calls/operators:
```csharp
var locked = WithCompOrNull<LockableComponent>(someEntUid)?.Locked ?? false;
```
, which is in contrast to existing functions for getting component values:
```csharp
TryComp<LockableComponent>(someEntUid, out var comp);
var locked = comp?.Locked ?? false;

// or if you're a masochist
var locked = TryComp<LockableComponent>(someEntUid, out var comp) ? comp.Locked : false;
```

### Usability for public API methods

Often, systems have public APIs that look like
```csharp
void SetEntityLockState(EntityUid entity, bool locked, LockableComponent? comp = null)
// or
void SetEntityLockState(Entity<LockableComponent?> entity, bool locked)
```
, that is the API offers "I can operate on entities which maybe don't have the component I actually deal with. Just pass me the UID and I'll deal with looking up the component for you". This commonly leads to the tops of public API functions having one or more

```csharp
if (!Resolve(entity, ref comp))
  return;
```
, which is annoying to deal with if we're working with `Entity<TComp>`s instead of separate `EntityUid`s and `TComp`s. `WithCompOrNull` alleviates this by enabling
```csharp
if (WithCompOrNull<LockableComp>(entity) is not { } lockable)
  return;
```
, where `lockable` is our useable `Entity<TComp>` for the rest of the function.


### Naming

I admittedly kind of hate the names, but I think they strike a good balance between:
- being meaningful and descriptive as to what they do
- being overloads of each other so that if you pass an `Entity<TComp?>` to `WithCompOrNull`, it'll use the one that's optimized to check for the `TComp` value already being present.

Please do come up with better name(s) if you can think of them.