### PR TITLE
feat: duplicate localization keys in downstream namespaces no longer generate error logs

### DIFF
--- a/Robust.Shared/Localization/LocalizationManager.cs
+++ b/Robust.Shared/Localization/LocalizationManager.cs
@@ -467,6 +467,13 @@ namespace Robust.Shared.Localization
             {
                 var errors = resource.Errors;
                 WriteWarningForErrs(path, errors, data);
+
+                if (path.CanonPath.StartsWith($"{LocaleDirPath}/{culture.Name}/_"))
+                {
+                    context.AddResourceOverriding(resource);
+                    continue;
+                }
+
                 if (!context.InsertResourcesAndReport(resource, path, out var errs))
                 {
                     resErrors.AddRange(errs);


### PR DESCRIPTION
Previously the code collected occurrences of duplicate localization keys and generated log errors which induced test failure. This is good for discovering unintended duplicates, but downstream codebases sometimes intend to override localizations.

This change checks if the resource directory begins with an underscore (as is custom in downstream codebases) and does not attempt to emit log errors for duplicate keys. Consequently they will no longer be informed of duplicated keys even outside of the main namespace. Perhaps this is an acceptable tradeoff.