### PR TITLE
feat: enable adding custom command keybinding for add text console commands keybindings

### DIFF
--- a/Robust.Client/Input/IInputManager.cs
+++ b/Robust.Client/Input/IInputManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Robust.Client.UserInterface;
@@ -40,9 +40,9 @@ namespace Robust.Client.Input
         void KeyDown(KeyEventArgs e);
         void KeyUp(KeyEventArgs e);
 
-        IKeyBinding RegisterBinding(in KeyBindingRegistration reg, bool markModified=true, bool invalid=false);
+        IKeyBinding RegisterBinding(in KeyBindingRegistration reg, bool markModified = true, bool invalid = false);
 
-        void RemoveBinding(IKeyBinding binding, bool markModified=true);
+        void RemoveBinding(IKeyBinding binding, bool markModified = true);
 
         /// <summary>
         ///     Gets a key binding according to the function it is bound to.
@@ -134,5 +134,16 @@ namespace Robust.Client.Input
         bool IsKeyDown(Keyboard.Key key);
 
         void InputModeChanged();
+
+        /// <summary>
+        /// Returns list of keybindings which are marked with custom command prefix.
+        /// </summary>
+        /// <returns></returns>
+        IReadOnlyCollection<BoundKeyFunction> GetCustomCommands();
+
+        /// <summary>
+        /// Attempt to get custom command - related function which is not yet used in keybinding.
+        /// </summary>
+        bool TryGetUnusedCustomCommand([NotNullWhen(true)] out BoundKeyFunction? result);
     }
 }

--- a/Robust.Client/Input/KeyBindingRegistration.cs
+++ b/Robust.Client/Input/KeyBindingRegistration.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Input;
+using Robust.Shared.Input;
 using Robust.Shared.Serialization.Manager.Attributes;
 
 namespace Robust.Client.Input
@@ -26,5 +26,7 @@ namespace Robust.Client.Input
         public bool CanRepeat;
         [DataField("allowSubCombs")]
         public bool AllowSubCombs;
+        [DataField("functionCommand")]
+        public string? FunctionCommand;
     }
 }

--- a/Robust.Shared/Input/KeyFunctions.cs
+++ b/Robust.Shared/Input/KeyFunctions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Robust.Shared.Serialization;
 
 namespace Robust.Shared.Input
@@ -86,6 +86,9 @@ namespace Robust.Shared.Input
         public static readonly BoundKeyFunction TextTabComplete = "TextTabComplete";
         public static readonly BoundKeyFunction TextCompleteNext = "TextCompleteNext";
         public static readonly BoundKeyFunction TextCompletePrev = "TextCompletePrev";
+
+        public static readonly string CustomCommandPrefix = "CustomCommand-";
+        public static readonly int MaxCustomCommandCount = 1024;
     }
 
     [Serializable, NetSerializable]


### PR DESCRIPTION
Prerequisite to enable adding custom console commands keybinding.
Added way to save Keybinding text for command separate from FunctionName (was same field previously)
Added methods for input manager to get next custom command function, which is free from binding, and enumerate already existing custom commands.