### PR TITLE
Add helper methods for entity fixture shape radii

### DIFF
--- a/Robust.Shared/Physics/Systems/FixtureSystem.cs
+++ b/Robust.Shared/Physics/Systems/FixtureSystem.cs
@@ -341,11 +341,11 @@ namespace Robust.Shared.Physics.Systems
         }
 
         /// <summary>
-        /// Gets the sum of the biggests fixture radii from multiply entities
+        /// Gets the sum of the biggest fixture radii from multiple entities.
         /// </summary>
-        public float SumFixtureRadii(params EntityUid[] uids)
+        public float SumMaxFixtureRadii(params EntityUid[] uids)
         {
-            float sum = 0f;
+            var sum = 0f;
             foreach (var uid in uids)
             {
                 var fixRad = GetMaxFixtureRadius(uid);
@@ -356,36 +356,38 @@ namespace Robust.Shared.Physics.Systems
         }
 
         /// <summary>
-        /// Gets the biggest radius of the fixture from multiply entities.
+        /// Gets the biggest fixture radius of multiple entities.
         /// </summary>
         public float GetMaxFixtureRadius(params EntityUid[] uids)
         {
-            List<float> radii = [];
+            var maxRad = 0f;
             foreach (var uid in uids)
             {
                 var fixRad = GetMaxFixtureRadius(uid);
-                radii.Add(fixRad);
+                if (maxRad < fixRad)
+                    maxRad = fixRad;
             }
 
-            return radii.Max();
+            return maxRad;
         }
 
         /// <summary>
-        /// Gets the biggest radius of the fixture from one entity.
+        /// Gets the biggest fixture radius from one entity.
         /// </summary>
         public float GetMaxFixtureRadius(EntityUid uid, FixturesComponent? manager = null)
         {
             if (!Resolve(uid, ref manager) || manager.FixtureCount == 0)
                 return 0f;
 
-            List<float> radii = [];
+            var maxRad = 0f;
             foreach (var fixture in manager.Fixtures.Values)
             {
                 var fixRad = fixture.Shape.Radius;
-                radii.Add(fixRad);
+                if (maxRad < fixRad)
+                    maxRad = fixRad;
             }
 
-            return radii.Max();
+            return maxRad;
         }
 
         #region Restitution

--- a/Robust.Shared/Physics/Systems/FixtureSystem.cs
+++ b/Robust.Shared/Physics/Systems/FixtureSystem.cs
@@ -340,6 +340,54 @@ namespace Robust.Shared.Physics.Systems
             }
         }
 
+        /// <summary>
+        /// Gets the sum of the biggests fixture radii from multiply entities
+        /// </summary>
+        public float SumFixtureRadii(params EntityUid[] uids)
+        {
+            float sum = 0f;
+            foreach (var uid in uids)
+            {
+                var fixRad = GetMaxFixtureRadius(uid);
+                sum += fixRad;
+            }
+
+            return sum;
+        }
+
+        /// <summary>
+        /// Gets the biggest radius of the fixture from multiply entities.
+        /// </summary>
+        public float GetMaxFixtureRadius(params EntityUid[] uids)
+        {
+            List<float> radii = [];
+            foreach (var uid in uids)
+            {
+                var fixRad = GetMaxFixtureRadius(uid);
+                radii.Add(fixRad);
+            }
+
+            return radii.Max();
+        }
+
+        /// <summary>
+        /// Gets the biggest radius of the fixture from one entity.
+        /// </summary>
+        public float GetMaxFixtureRadius(EntityUid uid, FixturesComponent? manager = null)
+        {
+            if (!Resolve(uid, ref manager) || manager.FixtureCount == 0)
+                return 0f;
+
+            List<float> radii = [];
+            foreach (var fixture in manager.Fixtures.Values)
+            {
+                var fixRad = fixture.Shape.Radius;
+                radii.Add(fixRad);
+            }
+
+            return radii.Max();
+        }
+
         #region Restitution
 
         public void SetRestitution(EntityUid uid, string fixtureId, Fixture fixture, float value, bool update = true, FixturesComponent? manager = null)


### PR DESCRIPTION
This pr adds new helper methods that makes interaction with fixture radius more comfortable and also allowing to avoid duplicating code in the future.
Required for the proper implementation of the [Make drop range same as actual interaction range #39188](https://github.com/space-wizards/space-station-14/pull/39188).