### PR TITLE
add check if state name is empty in rsi validator

### DIFF
--- a/Schemas/validate_rsis.py
+++ b/Schemas/validate_rsis.py
@@ -135,6 +135,13 @@ def check_rsi(rsi: str, schema: Draft7Validator):
             add_error(rsi, f"{state_name}: sprite sheet of {size[0]}x{size[1]} is too small, metadata defines {frame_count} frames, but it can only fit {max_sheet_frames} at most")
             continue
 
+    # Check if state name exists
+    for state in meta_json["states"]:
+        state_name: str = state["name"]
+        if state_name == "":
+            add_error(rsi, f"state name is missing.")
+            return
+
     # We're good!
     return
 

--- a/Schemas/validate_rsis.py
+++ b/Schemas/validate_rsis.py
@@ -139,7 +139,7 @@ def check_rsi(rsi: str, schema: Draft7Validator):
     for state in meta_json["states"]:
         state_name: str = state["name"]
         if state_name == "":
-            add_error(rsi, f"state name is missing.")
+            add_error(rsi, f"state name cannot be an empty string.")
             return
 
     # We're good!


### PR DESCRIPTION
So basically, my server is crashed  when a first player try to connecting via laucnher. it happened because I accidentally left the state name in the RSI empty:

`"state": ""`

As a result, I ended up wasting a lot of time trying to track the issue. (By the way, the problem only showed up when connecting to the server through the launcher -  locally everything seemed fine.) Eventually I figured out that the new AssetPassPackRsis system breaks because of this mistake (well, at least I think so).

I don't want anyone to suffer as much, so I think this will be useful to us.
Perhaps we can add a couple of checks somewhere else.