### PR TITLE
Make Toolshed ProtoId autocomplete use PrototypeIdsLimited instead of caching completions

### DIFF
--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -4,6 +4,7 @@ using Lidgren.Network;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
+using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Log;
 using Robust.Shared.Maths;
@@ -1486,7 +1487,7 @@ namespace Robust.Shared
         /// Non-default seek modes WILL result in worse performance.
         /// </remarks>
         public static readonly CVarDef<int> ResStreamSeekMode =
-            CVarDef.Create("res.stream_seek_mode", (int)ContentPack.StreamSeekMode.None);
+            CVarDef.Create("res.stream_seek_mode", (int)StreamSeekMode.None);
 
         /// <summary>
         /// Whether to watch prototype files for prototype reload on the client. Only applies to development builds.
@@ -1881,6 +1882,12 @@ namespace Robust.Shared
         /// </summary>
         public static readonly CVarDef<int> ToolshedNearbyEntitiesLimit =
             CVarDef.Create("toolshed.nearby_entities_limit", 5, CVar.SERVER | CVar.REPLICATED);
+
+        /// <summary>
+        ///     The max amount of prototype ids that can be sent to the client when autocompleting prototype ids.
+        /// </summary>
+        public static readonly CVarDef<int> ToolshedPrototypesAutocompleteLimit =
+            CVarDef.Create("toolshed.prototype_autocomplete_limit", 256, CVar.SERVER | CVar.REPLICATED);
 
         /*
          * Localization

--- a/Robust.Shared/Toolshed/TypeParsers/PrototypeTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/PrototypeTypeParser.cs
@@ -51,6 +51,9 @@ public sealed class ProtoIdTypeParser<T> : TypeParser<ProtoId<T>>
 
     public override CompletionResult TryAutocomplete(ParserContext ctx, CommandArgument? arg)
     {
+        if (typeof(T) == typeof(EntityPrototype))
+            return CompletionResult.FromHint(GetArgHint(arg));
+
         var hint = ToolshedCommand.GetArgHint(arg, typeof(ProtoId<T>));
         var maxCount = _config.GetCVar(CVars.ToolshedPrototypesAutocompleteLimit);
         var options = CompletionHelper.PrototypeIdsLimited<T>(ctx.Input[ctx.Index..], proto: _proto, maxCount: maxCount);

--- a/Robust.Shared/Toolshed/TypeParsers/PrototypeTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/PrototypeTypeParser.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using Robust.Shared.Configuration;
 using Robust.Shared.Console;
 using Robust.Shared.IoC;
 using Robust.Shared.Prototypes;
@@ -14,9 +15,8 @@ namespace Robust.Shared.Toolshed.TypeParsers;
 public sealed class ProtoIdTypeParser<T> : TypeParser<ProtoId<T>>
     where T : class, IPrototype
 {
+    [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
-
-    private CompletionResult? _completions;
 
     public override bool TryParse(ParserContext ctx, out ProtoId<T> result)
     {
@@ -49,18 +49,12 @@ public sealed class ProtoIdTypeParser<T> : TypeParser<ProtoId<T>>
         return true;
     }
 
-    public override CompletionResult? TryAutocomplete(ParserContext ctx, CommandArgument? arg)
+    public override CompletionResult TryAutocomplete(ParserContext ctx, CommandArgument? arg)
     {
-        if (_completions != null)
-            return _completions;
-
-        _proto.TryGetKindFrom<T>(out var kind);
         var hint = ToolshedCommand.GetArgHint(arg, typeof(ProtoId<T>));
-
-        _completions = _proto.Count<T>() < 256
-            ? CompletionResult.FromHintOptions( CompletionHelper.PrototypeIDs<T>(proto: _proto), hint)
-            : CompletionResult.FromHint(hint);
-        return _completions;
+        var maxCount = _config.GetCVar(CVars.ToolshedPrototypesAutocompleteLimit);
+        var options = CompletionHelper.PrototypeIdsLimited<T>(ctx.Input[ctx.Index..], proto: _proto, maxCount: maxCount);
+        return CompletionResult.FromHintOptions(options, hint);
     }
 }
 


### PR DESCRIPTION
Moved the limit to a CVar
RMC14 just hit >256 jobs so we lost completions which is suboptimal
Uses the new method PJB added instead
A quick stopwatch check (in Debug) shows the first run on my computer took 5 ms, then 0.3 ms for any after, when autocompleting all available job prototypes
One day we will have the client just fill in the autocomplete for these itself (like the EntProtoId autocompleter mentions) but I would like my RMC14 gamemasters to not grow tumors trying to run job commands in the meantime
Also adds a check for EntityPrototype in case someone does that accidentally