### PR TITLE
allow toolshed command `spawn:in` to work if the prototype doesn't have a `PhysicsComponent`

### DIFF
--- a/Robust.Shared/Toolshed/Commands/Entities/SpawnCommand.cs
+++ b/Robust.Shared/Toolshed/Commands/Entities/SpawnCommand.cs
@@ -50,9 +50,10 @@ internal sealed class SpawnCommand : ToolshedCommand
     {
         var spawned = SpawnOn(target, proto);
         if (!TryComp<TransformComponent>(spawned, out var transformComponent) ||
-            !TryComp<MetaDataComponent>(spawned, out var metaDataComp) ||
-            !TryComp<PhysicsComponent>(spawned, out var physicsComponent))
+            !TryComp<MetaDataComponent>(spawned, out var metaDataComp))
             return spawned;
+        // The PhysicsComponent isn't required, so continue with or without it
+        TryComp<PhysicsComponent>(spawned, out var physicsComponent);
         sharedContainerSystem ??= EntityManager.System<SharedContainerSystem>();
         var container = sharedContainerSystem.GetContainer(target, containerId);
         sharedContainerSystem.InsertOrDrop((spawned, transformComponent, metaDataComp, physicsComponent),


### PR DESCRIPTION
fixes #6150

Allows spawning of entities without physics components into containers.

Many containers in robust are made to hold "virtual" or "meta" type entities, like the new status effects system, actions, etc. The container system insert or drop function works just fine without a physics component, so just remove that restriction.