### PR TITLE
Fix crash on startup with more than 255 CVars

### DIFF
--- a/Robust.Shared/Network/Messages/MsgConVars.cs
+++ b/Robust.Shared/Network/Messages/MsgConVars.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Lidgren.Network;
 using Robust.Shared.Log;
-using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 
@@ -11,7 +10,7 @@ namespace Robust.Shared.Network.Messages
     public sealed class MsgConVars : NetMessage
     {
         // Max buffer could potentially be 255 * 128 * 1024 = ~33MB, so if MaxMessageSize starts being a problem it can be increased.
-        private const int MaxMessageSize = 0x4000; // Arbitrarily chosen as a 'sane' value as the maximum size of the entire message.
+        private const int MaxMessageSize = 0x8000; // Arbitrarily chosen as a 'sane' value as the maximum size of the entire message.
         private const int MaxNameSize = 4 * 32; // UTF8 Max char size is 4 bytes, 32 chars.
         private const int MaxStringValSize = 4 * 256; // UTF8 Max char size is 4 bytes, 256 chars.
 
@@ -82,11 +81,11 @@ namespace Robust.Shared.Network.Messages
             if(NetworkedVars == null)
                 throw new InvalidOperationException($"{nameof(NetworkedVars)} collection is null.");
 
-            if(NetworkedVars.Count > byte.MaxValue)
+            if(NetworkedVars.Count > short.MaxValue)
                 throw new InvalidOperationException($"{nameof(NetworkedVars)} collection count is greater than {short.MaxValue}.");
 
             buffer.WriteVariableUInt32(Tick.Value);
-            buffer.Write((byte)NetworkedVars.Count);
+            buffer.Write((short)NetworkedVars.Count);
 
             foreach (var (name, value) in NetworkedVars)
             {

--- a/Robust.Shared/Network/Messages/MsgConVars.cs
+++ b/Robust.Shared/Network/Messages/MsgConVars.cs
@@ -26,7 +26,7 @@ namespace Robust.Shared.Network.Messages
                 Logger.WarningS("net", $"{MsgChannel}: received a large {nameof(MsgConVars)}, {buffer.LengthBytes}B > {MaxMessageSize}B");
 
             Tick = new GameTick(buffer.ReadVariableUInt32());
-            var nVars = buffer.ReadByte();
+            var nVars = buffer.ReadInt16();
 
             NetworkedVars = new List<(string name, object value)>(nVars);
 


### PR DESCRIPTION
Guess what overly specific dumb engine limit RMC14 just hit again
Multiplied MaxMessageSize by an arbitrary 2 because it seems slightly more sane than multiplying it by 128 at a glance