### PR TITLE
More accurate & controllable pointlight attenuation

### DIFF
--- a/Resources/Shaders/Internal/light_shared.swsl
+++ b/Resources/Shaders/Internal/light_shared.swsl
@@ -15,6 +15,7 @@ uniform highp float lightRange;
 uniform highp float lightPower;
 uniform highp float lightSoftness;
 uniform highp float lightFalloff;
+uniform lowp int lightCurveType;
 uniform highp float lightIndex;
 uniform sampler2D shadowMap;
 
@@ -48,11 +49,15 @@ void fragment()
         discard;
     }
 
-    highp float dist = dot(diff, diff) + LIGHTING_HEIGHT;
+    // this implementation of light attenuation primarily adapted from
+    // https://lisyarus.github.io/blog/posts/point-light-attenuation.html
+    highp float sqr_dist = dot(diff, diff) + LIGHTING_HEIGHT;
 
-    highp float s = clamp(sqrt(distance) / radius, 0.0, 1.0);
+    highp float s = clamp(sqrt(sqr_dist) / lightRange, 0.0, 1.0);
     highp float s2 = s * s;
-    highp float val = clamp(((1 - s2) * (1 - s2)) / (1 + lightFalloff * s), 0.0, 1.0);
+    // curveType nonzero = quadraticinverse, 0 = inverse
+    highp float curveFactor = lightCurveType > 0 ? s2 : s;
+    highp float val = clamp(((1 - s2) * (1 - s2)) / (1 + lightFalloff * curveFactor), 0.0, 1.0);
 
     val *= lightPower;
     val *= mask;

--- a/Resources/Shaders/Internal/light_shared.swsl
+++ b/Resources/Shaders/Internal/light_shared.swsl
@@ -16,7 +16,6 @@ uniform highp float lightPower;
 uniform highp float lightSoftness;
 uniform highp float lightFalloff;
 uniform highp float lightCurveFactor;
-uniform lowp int lightCurveType;
 uniform highp float lightIndex;
 uniform sampler2D shadowMap;
 

--- a/Resources/Shaders/Internal/light_shared.swsl
+++ b/Resources/Shaders/Internal/light_shared.swsl
@@ -14,6 +14,7 @@ uniform highp vec2 lightCenter;
 uniform highp float lightRange;
 uniform highp float lightPower;
 uniform highp float lightSoftness;
+uniform highp float lightFalloff;
 uniform highp float lightIndex;
 uniform sampler2D shadowMap;
 
@@ -48,7 +49,10 @@ void fragment()
     }
 
     highp float dist = dot(diff, diff) + LIGHTING_HEIGHT;
-    highp float val = clamp((1.0 - clamp(sqrt(dist) / lightRange, 0.0, 1.0)) * (1.0 / (sqrt(dist + 1.0))), 0.0, 1.0);
+
+    highp float s = clamp(sqrt(distance) / radius, 0.0, 1.0);
+    highp float s2 = s * s;
+    highp float val = clamp(((1 - s2) * (1 - s2)) / (1 + lightFalloff * s), 0.0, 1.0);
 
     val *= lightPower;
     val *= mask;

--- a/Resources/Shaders/Internal/light_shared.swsl
+++ b/Resources/Shaders/Internal/light_shared.swsl
@@ -15,6 +15,7 @@ uniform highp float lightRange;
 uniform highp float lightPower;
 uniform highp float lightSoftness;
 uniform highp float lightFalloff;
+uniform highp float lightCurveFactor;
 uniform lowp int lightCurveType;
 uniform highp float lightIndex;
 uniform sampler2D shadowMap;
@@ -55,8 +56,8 @@ void fragment()
 
     highp float s = clamp(sqrt(sqr_dist) / lightRange, 0.0, 1.0);
     highp float s2 = s * s;
-    // curveType nonzero = quadraticinverse, 0 = inverse
-    highp float curveFactor = lightCurveType > 0 ? s2 : s;
+    // controls curve by lerping between two variants (inverse-shape and inversequadratic-shape)
+    highp float curveFactor = mix(s, s2, clamp(lightCurveFactor, 0.0, 1.0));
     highp float val = clamp(((1 - s2) * (1 - s2)) / (1 + lightFalloff * curveFactor), 0.0, 1.0);
 
     val *= lightPower;

--- a/Robust.Client/GameObjects/EntitySystems/PointLightSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/PointLightSystem.cs
@@ -30,7 +30,7 @@ namespace Robust.Client.GameObjects
             component.Offset = state.Offset;
             component.Softness = state.Softness;
             component.Falloff = state.Falloff;
-            component.CurveType = state.CurveType;
+            component.CurveFactor = state.CurveFactor;
             component.CastShadows = state.CastShadows;
             component.Energy = state.Energy;
             component.Radius = state.Radius;

--- a/Robust.Client/GameObjects/EntitySystems/PointLightSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/PointLightSystem.cs
@@ -29,6 +29,7 @@ namespace Robust.Client.GameObjects
             component.Enabled = state.Enabled;
             component.Offset = state.Offset;
             component.Softness = state.Softness;
+            component.Falloff = state.Falloff;
             component.CastShadows = state.CastShadows;
             component.Energy = state.Energy;
             component.Radius = state.Radius;

--- a/Robust.Client/GameObjects/EntitySystems/PointLightSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/PointLightSystem.cs
@@ -30,6 +30,7 @@ namespace Robust.Client.GameObjects
             component.Offset = state.Offset;
             component.Softness = state.Softness;
             component.Falloff = state.Falloff;
+            component.CurveType = state.CurveType;
             component.CastShadows = state.CastShadows;
             component.Energy = state.Energy;
             component.Radius = state.Radius;

--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -451,6 +451,7 @@ namespace Robust.Client.Graphics.Clyde
             var lastPower = float.NaN;
             var lastColor = new Color(float.NaN, float.NaN, float.NaN, float.NaN);
             var lastSoftness = float.NaN;
+            var lastFalloff = float.NaN;
             Texture? lastMask = null;
 
             using (_prof.Group("Draw Lights"))
@@ -502,6 +503,12 @@ namespace Robust.Client.Graphics.Clyde
                     {
                         lastSoftness = component.Softness;
                         lightShader.SetUniformMaybe("lightSoftness", lastSoftness);
+                    }
+
+                    if (!MathHelper.CloseToPercent(lastFalloff, component.Falloff))
+                    {
+                        lastFalloff = component.Falloff;
+                        lightShader.SetUniformMaybe("lightFalloff", lastFalloff);
                     }
 
                     lightShader.SetUniformMaybe("lightCenter", lightPos);

--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -452,6 +452,7 @@ namespace Robust.Client.Graphics.Clyde
             var lastColor = new Color(float.NaN, float.NaN, float.NaN, float.NaN);
             var lastSoftness = float.NaN;
             var lastFalloff = float.NaN;
+            var lastCurveType = (PointLightAttenuationCurveType)0;
             Texture? lastMask = null;
 
             using (_prof.Group("Draw Lights"))
@@ -509,6 +510,12 @@ namespace Robust.Client.Graphics.Clyde
                     {
                         lastFalloff = component.Falloff;
                         lightShader.SetUniformMaybe("lightFalloff", lastFalloff);
+                    }
+
+                    if (lastCurveType != component.CurveType)
+                    {
+                        lastCurveType = component.CurveType;
+                        lightShader.SetUniformMaybe("lightCurveType", lastCurveType == PointLightAttenuationCurveType.Inverse ? 0 : 1);
                     }
 
                     lightShader.SetUniformMaybe("lightCenter", lightPos);

--- a/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.LightRendering.cs
@@ -452,7 +452,7 @@ namespace Robust.Client.Graphics.Clyde
             var lastColor = new Color(float.NaN, float.NaN, float.NaN, float.NaN);
             var lastSoftness = float.NaN;
             var lastFalloff = float.NaN;
-            var lastCurveType = (PointLightAttenuationCurveType)0;
+            var lastCurveFactor = float.NaN;
             Texture? lastMask = null;
 
             using (_prof.Group("Draw Lights"))
@@ -512,10 +512,10 @@ namespace Robust.Client.Graphics.Clyde
                         lightShader.SetUniformMaybe("lightFalloff", lastFalloff);
                     }
 
-                    if (lastCurveType != component.CurveType)
+                    if (!MathHelper.CloseToPercent(lastCurveFactor, component.CurveFactor))
                     {
-                        lastCurveType = component.CurveType;
-                        lightShader.SetUniformMaybe("lightCurveType", lastCurveType == PointLightAttenuationCurveType.Inverse ? 0 : 1);
+                        lastCurveFactor = component.CurveFactor;
+                        lightShader.SetUniformMaybe("lightCurveFactor", lastCurveFactor);
                     }
 
                     lightShader.SetUniformMaybe("lightCenter", lightPos);

--- a/Robust.Shared/GameObjects/Components/Light/PointLightComponentState.cs
+++ b/Robust.Shared/GameObjects/Components/Light/PointLightComponentState.cs
@@ -16,7 +16,7 @@ public sealed class PointLightComponentState : ComponentState
 
     public float Falloff;
 
-    public PointLightAttenuationCurveType CurveType;
+    public float CurveFactor;
 
     public bool CastShadows;
 

--- a/Robust.Shared/GameObjects/Components/Light/PointLightComponentState.cs
+++ b/Robust.Shared/GameObjects/Components/Light/PointLightComponentState.cs
@@ -16,6 +16,8 @@ public sealed class PointLightComponentState : ComponentState
 
     public float Falloff;
 
+    public PointLightAttenuationCurveType CurveType;
+
     public bool CastShadows;
 
     public bool Enabled;

--- a/Robust.Shared/GameObjects/Components/Light/PointLightComponentState.cs
+++ b/Robust.Shared/GameObjects/Components/Light/PointLightComponentState.cs
@@ -14,6 +14,8 @@ public sealed class PointLightComponentState : ComponentState
 
     public float Softness;
 
+    public float Falloff;
+
     public bool CastShadows;
 
     public bool Enabled;

--- a/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
@@ -156,6 +156,6 @@ namespace Robust.Shared.GameObjects
         ///     This curve type is also generally brighter, and requires a higher <see cref="SharedPointLightComponent.Falloff"/> value
         ///     to be equivalent in brightness to <see cref="Inverse"/>.
         /// </summary>
-        QuadraticInverse = 2,
+        InverseQuadratic = 2,
     }
 }

--- a/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
@@ -39,17 +39,37 @@ namespace Robust.Shared.GameObjects
         ///     A higher value means a stronger falloff.
         /// </summary>
         /// <remarks>
-        /// The default value of 6.8 might seem suspect, but that's because this is a value which was introduced
-        /// years after SS14 already standardized its light values using an older attenuation curve, and this was the value
-        /// which, qualitatively, seemed about equivalent in brightness for the large majority of lights on the station
-        /// compared to the old function.
+        ///     The default value of 6.8 might seem suspect, but that's because this is a value which was introduced
+        ///     years after SS14 already standardized its light values using an older attenuation curve, and this was the value
+        ///     which, qualitatively, seemed about equivalent in brightness for the large majority of lights on the station
+        ///     compared to the old function.
+        ///
+        ///     See https://www.desmos.com/calculator/ck2df8quea for a demonstration of how this value affects the shape of the curve
+        ///     for different light radii and curve factors.
         /// </remarks>
         [DataField("falloff"), Animatable]
         public float Falloff { get; set; } = 6.8f;
 
-        /// <see cref="PointLightAttenuationCurveType"/>
-        [DataField("curveType")]
-        public PointLightAttenuationCurveType CurveType { get; set; } = PointLightAttenuationCurveType.Inverse;
+        /// <summary>
+        ///     Controls the shape of the curve used for point light attenuation.
+        ///     This value may vary between 0 and 1.
+        ///     A value of 0 gives a shape roughly equivalent to (1/1+distance), while
+        ///     a value of 1 gives a shape roughly equivalent to (1+distance^2).
+        ///     The former (inverse) is close to how light falls off in real life.
+        ///     The latter (inverse quadratic) is not particularly physically accurate, but is better for representing
+        ///     "spherical point lights", e.g. a glowing orb, which want some degree of consistent light in
+        ///     close to their object's center before falling off as normal.
+        /// </summary>
+        /// <remarks>
+        ///     This does not directly control the exponent of the denominator, though it might seem that way.
+        ///     Rather, it just lerps between an inverse-shaped curve and an inverse-quadratic-shaped curve.
+        ///     Values below 0 or above 1 are nonsensical.
+        ///
+        ///     See https://www.desmos.com/calculator/ck2df8quea for a demonstration of how this value affects the shape of the curve
+        ///     for different light radii and falloff values.
+        /// </remarks>
+        [DataField("curveFactor"), Animatable]
+        public float CurveFactor { get; set; } = 1.0f;
 
         /// <summary>
         ///     Whether this pointlight should cast shadows
@@ -130,32 +150,5 @@ namespace Robust.Shared.GameObjects
         {
             Enabled = enabled;
         }
-    }
-
-    /// <summary>
-    ///     Controls the curve used for point light attenuation.
-    /// </summary>
-    /// <remarks>
-    ///     See https://www.desmos.com/calculator/a3mskal3yu for a comparison of the curves for different
-    ///     light radii and falloff values, alongside a comparison with the old pointlight attenuation.
-    /// </remarks>
-    [Serializable, NetSerializable]
-    public enum PointLightAttenuationCurveType : byte
-    {
-        /// <summary>
-        ///     A curve roughly equivalent in shape to (1/(1+distance).
-        ///     This is the default behavior, and is relatively physically accurate.
-        ///     Has a consistent level of falloff across the radius of the light.
-        /// </summary>
-        Inverse = 1,
-        /// <summary>
-        ///     A curve roughly equivalent in shape to (1/(1+distance^2).
-        ///     This curve is not particularly physically accurate, but is better for representing
-        ///     "spherical point lights", e.g. a glowing orb, which want some degree of consistent light in
-        ///     close to their object's center before falling off as normal.
-        ///     This curve type is also generally brighter, and requires a higher <see cref="SharedPointLightComponent.Falloff"/> value
-        ///     to be equivalent in brightness to <see cref="Inverse"/>.
-        /// </summary>
-        InverseQuadratic = 2,
     }
 }

--- a/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
@@ -44,7 +44,7 @@ namespace Robust.Shared.GameObjects
         ///     which, qualitatively, seemed about equivalent in brightness for the large majority of lights on the station
         ///     compared to the old function.
         ///
-        ///     See https://www.desmos.com/calculator/ck2df8quea for a demonstration of how this value affects the shape of the curve
+        ///     See https://www.desmos.com/calculator/yjudaha0s6 for a demonstration of how this value affects the shape of the curve
         ///     for different light radii and curve factors.
         /// </remarks>
         [DataField("falloff"), Animatable]
@@ -65,7 +65,7 @@ namespace Robust.Shared.GameObjects
         ///     Rather, it just lerps between an inverse-shaped curve and an inverse-quadratic-shaped curve.
         ///     Values below 0 or above 1 are nonsensical.
         ///
-        ///     See https://www.desmos.com/calculator/ck2df8quea for a demonstration of how this value affects the shape of the curve
+        ///     See https://www.desmos.com/calculator/yjudaha0s6 for a demonstration of how this value affects the shape of the curve
         ///     for different light radii and falloff values.
         /// </remarks>
         [DataField("curveFactor"), Animatable]

--- a/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
@@ -65,7 +65,7 @@ namespace Robust.Shared.GameObjects
         ///     for different light radii and falloff values.
         /// </remarks>
         [DataField, Animatable]
-        public float CurveFactor { get; set; } = 1.0f;
+        public float CurveFactor { get; set; } = 0.0f;
 
         /// <summary>
         ///     Whether this pointlight should cast shadows

--- a/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
@@ -47,18 +47,14 @@ namespace Robust.Shared.GameObjects
         ///     See https://www.desmos.com/calculator/yjudaha0s6 for a demonstration of how this value affects the shape of the curve
         ///     for different light radii and curve factors.
         /// </remarks>
-        [DataField("falloff"), Animatable]
+        [DataField, Animatable]
         public float Falloff { get; set; } = 6.8f;
 
         /// <summary>
         ///     Controls the shape of the curve used for point light attenuation.
         ///     This value may vary between 0 and 1.
-        ///     A value of 0 gives a shape roughly equivalent to (1/1+distance), while
-        ///     a value of 1 gives a shape roughly equivalent to (1+distance^2).
-        ///     The former (inverse) is close to how light falls off in real life.
-        ///     The latter (inverse quadratic) is not particularly physically accurate, but is better for representing
-        ///     "spherical point lights", e.g. a glowing orb, which want some degree of consistent light in
-        ///     close to their object's center before falling off as normal.
+        ///     A value of 0 gives a shape roughly equivalent to 1/1+distance (more or less realistic),
+        ///     while a value of 1 gives a shape roughly equivalent to 1+distance^2 (closer to a sphere-shaped light)
         /// </summary>
         /// <remarks>
         ///     This does not directly control the exponent of the denominator, though it might seem that way.
@@ -68,7 +64,7 @@ namespace Robust.Shared.GameObjects
         ///     See https://www.desmos.com/calculator/yjudaha0s6 for a demonstration of how this value affects the shape of the curve
         ///     for different light radii and falloff values.
         /// </remarks>
-        [DataField("curveFactor"), Animatable]
+        [DataField, Animatable]
         public float CurveFactor { get; set; } = 1.0f;
 
         /// <summary>

--- a/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Light/SharedPointLightComponent.cs
@@ -33,6 +33,9 @@ namespace Robust.Shared.GameObjects
         [DataField("softness"), Animatable]
         public float Softness { get; set; } = 1f;
 
+        [DataField("falloff"), Animatable]
+        public float Falloff { get; set; } = 4f;
+
         /// <summary>
         ///     Whether this pointlight should cast shadows
         /// </summary>

--- a/Robust.Shared/GameObjects/Systems/SharedPointLightSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPointLightSystem.cs
@@ -98,12 +98,12 @@ public abstract class SharedPointLightSystem : EntitySystem
         Dirty(uid, comp);
     }
 
-    public void SetCurveType(EntityUid uid, PointLightAttenuationCurveType value, SharedPointLightComponent? comp = null)
+    public void SetCurveFactor(EntityUid uid, float value, SharedPointLightComponent? comp = null)
     {
-        if (!ResolveLight(uid, ref comp) || comp.CurveType == value)
+        if (!ResolveLight(uid, ref comp) || MathHelper.CloseToPercent(comp.CurveFactor, value))
             return;
 
-        comp.CurveType = value;
+        comp.CurveFactor = value;
         Dirty(uid, comp);
     }
 
@@ -121,7 +121,7 @@ public abstract class SharedPointLightSystem : EntitySystem
             Radius = component.Radius,
             Softness = component.Softness,
             Falloff = component.Falloff,
-            CurveType = component.CurveType,
+            CurveFactor = component.CurveFactor,
             CastShadows = component.CastShadows,
         };
     }

--- a/Robust.Shared/GameObjects/Systems/SharedPointLightSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPointLightSystem.cs
@@ -98,6 +98,15 @@ public abstract class SharedPointLightSystem : EntitySystem
         Dirty(uid, comp);
     }
 
+    public void SetCurveType(EntityUid uid, PointLightAttenuationCurveType value, SharedPointLightComponent? comp = null)
+    {
+        if (!ResolveLight(uid, ref comp) || comp.CurveType == value)
+            return;
+
+        comp.CurveType = value;
+        Dirty(uid, comp);
+    }
+
     protected static void OnLightGetState(
         EntityUid uid,
         SharedPointLightComponent component,
@@ -112,6 +121,7 @@ public abstract class SharedPointLightSystem : EntitySystem
             Radius = component.Radius,
             Softness = component.Softness,
             Falloff = component.Falloff,
+            CurveType = component.CurveType,
             CastShadows = component.CastShadows,
         };
     }

--- a/Robust.Shared/GameObjects/Systems/SharedPointLightSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedPointLightSystem.cs
@@ -89,6 +89,15 @@ public abstract class SharedPointLightSystem : EntitySystem
         Dirty(uid, comp);
     }
 
+    public void SetFalloff(EntityUid uid, float value, SharedPointLightComponent? comp = null)
+    {
+        if (!ResolveLight(uid, ref comp) || MathHelper.CloseToPercent(comp.Falloff, value))
+            return;
+
+        comp.Falloff = value;
+        Dirty(uid, comp);
+    }
+
     protected static void OnLightGetState(
         EntityUid uid,
         SharedPointLightComponent component,
@@ -102,6 +111,7 @@ public abstract class SharedPointLightSystem : EntitySystem
             Offset = component.Offset,
             Radius = component.Radius,
             Softness = component.Softness,
+            Falloff = component.Falloff,
             CastShadows = component.CastShadows,
         };
     }


### PR DESCRIPTION
## what why

requires https://github.com/space-wizards/space-station-14/pull/39853 (sort of, its not strictly necessary. see below)

the current pointlight attenuation function used in the light shader is pretty bad in a couple of ways.

qualitatively, lights with essentially any radius look quite strange; the way lights attenuate at the boundary just kind of seems 'wrong' in some way, like its sharper than it should be or 'not smooth'. furthermore, small lights' intensity seems to decrease basically linearly over their radius, instead of in any physically accurate way, which makes things like APC or vendor lights look weird no matter what their energy is. obviously our light attenuation doesnt *necessarily* need to be **A) physically accurate**, it just needs to **B) be artistically controllable** and **C) look good**, but the current function unfortunately meets none of these 3 conditions (imo)

with regards to the implementation, our attenuation function has a couple significant issues. firstly, there is no way to actually control the shape of the curve for artistic reasons: the only relevant parameters to be tweaked are light radius and energy, which dont really help us at all. secondly, the actual function used has a pretty big issue... **because negative light values are clamped to 0, the function is only [c0 continuous](https://en.wikipedia.org/wiki/Smoothness#Example:_continuous_(C0)_but_not_differentiable)!!** my assumption is this is the reason that the boundary behavior 'feels wrong' in some way. it's less egregious at higher light radii, but at lower ones it's really bad.

<p align="center">
<img width="326" height="219" alt="image" src="https://github.com/user-attachments/assets/123f07a7-ecfb-4a5b-805a-72faa65d1bcd" />
</p>
<p align="center">
<i>the attenuation curve currently on master<br>the function is c0 continuous, but not c1 continuous (the derivative has a discontinuity at x=1)</i>
</p>


<p align="center">
<img width="327" height="218" alt="image" src="https://github.com/user-attachments/assets/979c64ea-11f4-4bb7-aa75-cbff61b211ed" />
</p>
<p align="center">
<i>the attenuation curves in this PR<br>nice and smooth</i>
</p>

a different function could solve this problem entirely! thankfully this is not a unique problem, i tried a couple things that all felt not really correct and then googled around a bunch until i eventually stumbled upon this post: https://lisyarus.github.io/blog/posts/point-light-attenuation.html which contains two (related) pretty good pointlight attenuation functions that meet all 3 conditions above, as well as being c1 continuous!

this PR replaces the current implementation in the shader with this new function, and introduces two new parameters to pointlights that allow you to adjust the falloff parameter, as well as adjust the curve shape, which primarily affects how light falls off near its center (see below for why this is desirable), modifying it is equivalent to lerping between the two curves in the post above

**you can compare the different curves at different light radii and with different falloff values and curve factors using this desmos calculator: https://www.desmos.com/calculator/yjudaha0s6**

## uh, isn't it going to look weird in SS14 since its completely different now

yes, if it was untweaked. however, the new curves are actually not so dissimilar from the old ones in the sense that they still fill space well, so for the most part the only tweak I had to make to get them looking similar was to change the default falloff value to `6.8`, which kept "normal station lights" about the same brightness as before.

i am unconcerned with trying to "improve lighting quality" in SS14 with this PR: I went on this endeavor for a fork and I plan on using a much higher falloff value there for most lights, so the goal is to just make the uncontroversial improvements (c1 continuity and artistic control) while still looking more or less equivalent to current lights.

*however*, there is one problem. small lights. because the curve for small lights previously was so weird (it was.. basically linear, as said before, and the derivative discontinuity was extremely apparent) they looked very strange in game: like static circles of light that somehow pierce above regular station light even at very low energy levels. because of those very low energy levels, once their attenuation curves were fixed to be more reasonable, they're *veeeery* dim. 

so, this PR does have a companion content PR to increase the energies of various small point lights: https://github.com/space-wizards/space-station-14/pull/39853

it's not strictly required, but it's recommended because as I've said although I think these small lights look much better being dimmer I am not interested in trying to justify that opinion upstream and would prefer they just look about the same brightness as before. its still not perfect but I am not auditing every single light in content.

another relevant issue: the old curve actually didn't start tapering off until a little bit out from the light's center (see the desmos above). this is unrealistic but does have artistic benefits in representing "spherical" pointlights, like a glowing orb, where taking a little bit extra time to falloff makes sense (since its a sphere, not a point). this is actually the reason I decided to include `curveFactor` as an option: it lets you replicate this behavior (and anything inbetween) if you want it, so I would recommend messing with it for things of that nature.

## okay show examples

sure. here's comparisons between the old attenuation and the new attenuation + attached content PR:
https://slow.pics/c/d3RVxm4o

embedded in github (i would recommend just looking at it above though), old on the left new on the right:

<p align="center">
<img width="336" height="240" alt="2025-8-23_05 57 50" src="https://github.com/user-attachments/assets/4feaf85f-1d28-432c-a218-cc6c39d35c59" />
<img width="336" height="240" alt="2025-8-23_05 47 41" src="https://github.com/user-attachments/assets/1c27b3b5-c540-49e2-85f1-8dbeebbc248b" />
</p>

<p align="center">
<img width="336" height="240" alt="2025-8-23_05 56 40" src="https://github.com/user-attachments/assets/7acb6553-df13-43ce-8cdb-7d2e5ab1b406" />
<img width="336" height="240" alt="2025-8-23_05 46 18" src="https://github.com/user-attachments/assets/f4e22e21-bef9-4fba-9594-a38b96f276b6" />
</p>

<p align="center">
<img width="336" height="240" alt="2025-8-23_05 55 39" src="https://github.com/user-attachments/assets/157a57ed-cccc-42cd-b33b-bf52452517b8" />
<img width="336" height="240" alt="2025-8-23_05 45 31" src="https://github.com/user-attachments/assets/704c283b-f696-4dee-bec9-2a72d575d902" />
</p>

if you're having trouble spotting the difference, well, good i guess, but look at the edges of lights, and at small lights

here's a video showing the falloff for lights with curve factor  0 (left) and curve factor 1 (right) being animated from `1` to `20` and back. you can tell that the right one keeps more light around the center (the animations are desynced from eachother sorry):

https://github.com/user-attachments/assets/5d675709-3e5c-4414-9d92-6e70df4f86ff

here's a video showing curve factor being animated from 0 to 1 with a constant falloff (its kinda subtle):

https://github.com/user-attachments/assets/7db52368-7e8f-4d2c-9d04-fa12d15e143e

not going to embed this since this isn't accurate to what upstream will look like, but heres some comparisons with a higher falloff value of 20 (which is what I want to use in a fork): https://slow.pics/c/Fu2CKm54

## technical concerns

i'm pretty sure this PR is sound but there are a couple potential concerns I wasn't positive about / wanted to expound on here
- ternaries in glsl dont branch, right? they just select or whatever? im pretty sure they don't branch
- 2 more uniforms into the light shader is nontrivial i think? but for most lights (especially by default) they aren't even different so they won't change very often. i think this is worth it because I can't see an alternative really. i could remove the curve type uniform and just not let people control that since its by far the less important of the two, but i did want the option..
- the actual shader logic shouldn't realistically be any less performant, on net its probably a few more multiplications because of the mix but slightly less elsewhere idk i didnt count that hard, i can try and collapse more of the logic into one line instead of using local vars but like surely that doesnt matter right? idk how gpu optimizations work.
- the bandwidth diff from pointlights compstate being slightly beefier shouldnt matter. its two floats, and pointlights rarely change from default anyway (besides enable/disable). we can do field deltas in the future. those are a thing now right. idk im out of the loop.