### PR TITLE
Fix children of nullspace entities not being serialized

### DIFF
--- a/Robust.Shared/EntitySerialization/EntitySerializer.cs
+++ b/Robust.Shared/EntitySerialization/EntitySerializer.cs
@@ -918,6 +918,8 @@ public sealed class EntitySerializer : ISerializationContext,
             case MissingEntityBehaviour.IncludeNullspace:
                 if (!EntMan.TryGetComponent(value, out TransformComponent? xform)
                     || xform.ParentUid != EntityUid.Invalid
+                    && CurrentEntity != null
+                    && xform.ParentUid != CurrentEntity.Value.Owner // Also serialize children of nullspace entities
                     || _gridQuery.HasComp(value)
                     || _mapQuery.HasComp(value))
                 {


### PR DESCRIPTION
If some entity is parented to another entity in nullspace, when saving a map it will throw an error.
This PR fixes that by adding an additional check to EntitySerializer.

**Example of what it fixes:** SS14 MindRole entities (they're parented to Mind entity which is located in nullspace)
Tested in SS14 (if you ask how that will be a long story), works

Ideally this should be added to tests, but it works already so im not sure that it's required.
