### PR TITLE
Fix TimeSpan overflow on Read

### DIFF
--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/TimeOffsetSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/TimeOffsetSerializer.cs
@@ -37,7 +37,13 @@ public sealed class TimeOffsetSerializer : ITypeSerializer<TimeSpan, ValueDataNo
 
         var timing = ctx.Timing;
         var seconds = double.Parse(node.Value, CultureInfo.InvariantCulture);
-        return TimeSpan.FromSeconds(seconds) + timing.CurTime;
+        var time = TimeSpan.FromSeconds(seconds);
+        
+        // Checks if adding time and curTime will overflow.
+        if(time > TimeSpan.MaxValue - timing.CurTime)
+            return TimeSpan.MaxValue;
+        
+        return time + timing.CurTime;
     }
 
     public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,


### PR DESCRIPTION
Adds a check to TimeOffsetSerializer to prevent overflow.

A lot of areas use TimeSpan.MaxValue but when saved and read the current time is added which results in an overflow. 
Notably an issue for #2406