### PR TITLE
Move CleanContainer to PredictedDel

### DIFF
--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -631,7 +631,7 @@ namespace Robust.Shared.Containers
                     continue;
 
                 Remove(ent, container, force: true);
-                Del(ent);
+                PredictedDel(ent);
             }
         }
 


### PR DESCRIPTION
Changes SharedContainerSystem -> CleanContainer to use PredictedDel as opposed to Del

Slarti approved PR (Was the one to suggest the change in the first place)

<img width="614" height="132" alt="image" src="https://github.com/user-attachments/assets/27469471-9894-4b4e-a326-8a4532b41f87" />

I reproduced the following systems which use CleanContainer with the updated code and the following 

CloningSystem.cs - Okay
ImplantedSystem.cs - Okay
MicrowaveSystem.cs - Okay (I microwaved a stun baton)
InternalEncryptionKeySpawner.cs - Okay
SharedSubdermalImplantSystem.cs - Seems okay but might require additional checking by someone a little more experienced

I've never PR'd to RT before so if I did anything wrong um, sorry. 