### PR TITLE
RichTextBox

### DIFF
--- a/Robust.Client/UserInterface/CustomControls/RichTextBlock.Parser.cs
+++ b/Robust.Client/UserInterface/CustomControls/RichTextBlock.Parser.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Pidgin;
+using static Pidgin.Parser;
+using static Pidgin.Parser<char>;
+
+namespace Robust.Client.UserInterface.CustomControls;
+
+public sealed partial class RichTextBox
+{
+    private abstract record Node;
+
+    private record TextNode(string Text) : Node;
+
+    private record Attribute(string? Name, string? Value);
+
+    private record OpenHeadTag(string Name, IReadOnlyList<Attribute> Attributes, bool IsSelfClosing);
+
+    private record TagNode(string Name, IReadOnlyList<Attribute> Attributes, IReadOnlyList<Node> Children) : Node;
+
+    private record Document(IReadOnlyList<Node> Children);
+
+    private static Document? TryParse(string text)
+    {
+        var result = Doc.Parse(text);
+        return result.Success ? result.Value : null;
+    }
+
+    #region Parser
+
+    private static Parser<char, Document> Doc =>
+        Rec(() => NodeParser).Many().Select(doc => new Document(doc.ToList())).Before(End);
+
+    private static Parser<char, string> Word =>
+        (Letter.Or(Digit).Or(Char('_')).Or(Char('-'))).AtLeastOnceString()
+        .Bind(s => Return(s.ToLowerInvariant()));
+
+    private static Parser<char, string> TagName => Word;
+    private static Parser<char, string> AttrName => Word;
+
+    private static Parser<char, Unit> SkipSpaces =>
+        OneOf(Char(' '), Char('\t'), Char('\r'), Char('\n')).Many().Then(Return(Unit.Value));
+
+    private static Parser<char, string> AttrValue =>
+        OneOf(
+            Char('"').Then(AnyCharExcept('"').ManyString()).Before(Char('"')),
+            Char('\'').Then(AnyCharExcept('\'').ManyString()).Before(Char('\'')),
+            AnyCharExcept(' ', '\t', '\r', '\n', ']').AtLeastOnceString()
+        );
+
+    private static Parser<char, Attribute> AttributeParser =>
+        SkipSpaces.Then(
+            OneOf(
+                Char('=').Then(AttrValue).Bind(val => Return(new Attribute(null, val))),
+                AttrName.Bind(name =>
+                    Char('=')
+                        .Then(AttrValue)
+                        .Optional()
+                        .Bind(vopt => Return(new Attribute(name, vopt.HasValue ? vopt.Value : null)))
+                )
+            )
+        );
+
+    private static Parser<char, Node> TextNodeParser =>
+        AnyCharExcept('[').AtLeastOnceString().Bind(s => Return((Node)new TextNode(s)));
+
+    private static Parser<char, OpenHeadTag> OpenTagHead =>
+        Char('[')
+            .Then(TagName)
+            .Bind(name =>
+                AttributeParser.Many()
+                    .Bind(attrs =>
+                        SkipSpaces.Then(
+                                OneOf(
+                                    Char('/').Then(Char(']')).Then(Return(true)),
+                                    Char(']').Then(Return(false))
+                                )
+                            )
+                            .Bind(isSelf => Return(new OpenHeadTag(name, attrs.ToList(), isSelf))))
+            );
+
+    private static Parser<char, Node> TagNodeParser =>
+        OpenTagHead.Bind(open =>
+        {
+            if (open.IsSelfClosing)
+                return Return<Node>(new TagNode(open.Name, open.Attributes, []));
+
+            return Rec(() => NodeParser)
+                .Many()
+                .Bind(children =>
+                    Char('[')
+                        .Then(Char('/'))
+                        .Then(TagName)
+                        .Before(Char(']'))
+                        .Bind(closeName =>
+                        {
+                            if (!string.Equals(closeName, open.Name, StringComparison.OrdinalIgnoreCase))
+                                return Fail<Node>($"Mismatched closing tag: {closeName}");
+
+                            return Return<Node>(new TagNode(open.Name, open.Attributes, children.ToList()));
+                        })
+                );
+        });
+
+    private static Parser<char, Node> NodeParser =>
+        Rec(() => OneOf(TextNodeParser, Try(TagNodeParser)));
+
+    #endregion
+}

--- a/Robust.Client/UserInterface/CustomControls/RichTextBox.cs
+++ b/Robust.Client/UserInterface/CustomControls/RichTextBox.cs
@@ -1,0 +1,152 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using Robust.Client.ResourceManagement;
+using Robust.Client.UserInterface.Controls;
+using Robust.Shared.IoC;
+using Robust.Shared.Maths;
+
+namespace Robust.Client.UserInterface.CustomControls;
+
+public sealed partial class RichTextBox : BoxContainer
+{
+    [Dependency] private readonly IResourceCache _resourceCache = null!;
+
+    private string _content = string.Empty;
+
+    public string Content
+    {
+        get => _content;
+        set
+        {
+            SetContent(value);
+            _content = value;
+        }
+    }
+
+    public RichTextBox()
+    {
+        IoCManager.InjectDependencies(this);
+
+        Orientation = LayoutOrientation.Vertical;
+        HorizontalAlignment = HAlignment.Stretch;
+        HorizontalExpand = true;
+    }
+
+    public void SetContent(string content)
+    {
+        _content = content;
+        var document = TryParse(content);
+
+        Children.Clear();
+
+        if (document is null)
+        {
+            var label = new Label() { Text = content, FontColorOverride = Color.Black };
+            AddChild(label);
+            return;
+        }
+
+        var nodes = new Stack<(Node, Control)>(
+            (document.Children.Select(n => (n, (Control)this)).Reverse()));
+
+        while (nodes.Count != 0)
+        {
+            var (node, parent) = nodes.Pop();
+
+            switch (node)
+            {
+                case TextNode textNode:
+                {
+                    var label = new Label()
+                    {
+                        Text = textNode.Text,
+                        FontColorOverride = Color.Black,
+                        HorizontalExpand = false,
+                        VerticalExpand = false,
+                        HorizontalAlignment = HAlignment.Left,
+                    };
+                    parent.AddChild(label);
+                    break;
+                }
+                case TagNode tagNode:
+                    switch (tagNode.Name)
+                    {
+                        case "center":
+                            var centeredBox = new BoxContainer()
+                            {
+                                HorizontalExpand = true,
+                                HorizontalAlignment = HAlignment.Center,
+                                Orientation = LayoutOrientation.Vertical,
+                            };
+
+                            parent.AddChild(centeredBox);
+
+                            PushChildren(tagNode.Children, nodes, centeredBox);
+
+                            break;
+
+                        case "right":
+                            var rightBox = new BoxContainer()
+                            {
+                                HorizontalExpand = true,
+                                HorizontalAlignment = HAlignment.Right,
+                                Orientation = LayoutOrientation.Vertical,
+                            };
+
+                            parent.AddChild(rightBox);
+
+                            PushChildren(tagNode.Children, nodes, rightBox);
+
+                            break;
+
+                        case "flow":
+                            var flowBox = new BoxContainer()
+                            {
+                                HorizontalExpand = true,
+                                HorizontalAlignment = HAlignment.Left,
+                            };
+
+                            parent.AddChild(flowBox);
+
+                            PushChildren(tagNode.Children, nodes, flowBox);
+
+                            break;
+
+                        case "logo":
+                            var texture =
+                                _resourceCache.GetResource<TextureResource>("/Textures/Interface/Nano/ntlogo.svg.png");
+
+                            var image = new TextureRect()
+                            {
+                                Texture = texture,
+                                Stretch = TextureRect.StretchMode.Scale,
+                                Modulate = Color.Black,
+                                HorizontalExpand = false,
+                                HorizontalAlignment = HAlignment.Left,
+                            };
+
+                            if (tagNode.Attributes.FirstOrDefault(attr => attr.Name == "size") is { } sizeAttr &&
+                                float.TryParse(sizeAttr.Value, out var size))
+                            {
+                                image.SetSize = new Vector2(size);
+                            }
+
+                            parent.AddChild(image);
+
+                            break;
+                    }
+
+                    break;
+            }
+        }
+    }
+
+    private static void PushChildren(IReadOnlyList<Node> children, Stack<(Node, Control)> context, Control parent)
+    {
+        foreach (var n in children.Reverse())
+        {
+            context.Push((n, parent));
+        }
+    }
+}


### PR DESCRIPTION
# Why

It was easier to write a new parser than to figure out and change the existing one in FormattedMessage used by RichTextLabel, especially without breaking the elements already in use in many places in the game. Also, Pidgin is prohibited outside the sandbox, so it was not possible to implement an element for one place within the game.

# Implementation

Achtung! This is a draft version until PR comes out of draft status! Currently, the parser is integrated in the RichTextBox control, and all tag processing logic is hardcoded in two switches. The plan is to rework it using the Visitor pattern and reflection. Other suggestions are welcome.