### PR TITLE
Fix audio `ProcessStream` using the wrong entity

### DIFF
--- a/Robust.Client/Audio/AudioSystem.cs
+++ b/Robust.Client/Audio/AudioSystem.cs
@@ -372,13 +372,13 @@ public sealed partial class AudioSystem : SharedAudioSystem
             return;
         }
 
+        var parentUid = xform.ParentUid;
         Vector2 worldPos;
         component.Volume = component.Params.Volume;
 
         // Handle grid audio differently by using grid position.
         if ((component.Flags & AudioFlags.GridAudio) != 0x0)
         {
-            var parentUid = xform.ParentUid;
             worldPos = _maps.GetGridPosition(parentUid);
         }
         else
@@ -412,7 +412,7 @@ public sealed partial class AudioSystem : SharedAudioSystem
         }
         else
         {
-            var occlusion = GetOcclusion(listener, delta, distance, entity);
+            var occlusion = GetOcclusion(listener, delta, distance, parentUid);
             component.Occlusion = occlusion;
         }
 
@@ -420,11 +420,11 @@ public sealed partial class AudioSystem : SharedAudioSystem
         component.Position = worldPos;
 
         // Make race cars go NYYEEOOOOOMMMMM
-        if (_physicsQuery.TryGetComponent(entity, out var physicsComp))
+        if (_physicsQuery.TryGetComponent(parentUid, out var physicsComp))
         {
             // This actually gets the tracked entity's xform & iterates up though the parents for the second time. Bit
             // inefficient.
-            var velocity = _physics.GetMapLinearVelocity(entity, physicsComp, xform);
+            var velocity = _physics.GetMapLinearVelocity(parentUid, physicsComp);
             component.Velocity = velocity;
         }
     }


### PR DESCRIPTION
fixes #6173

correct entity in the physics check

<img width="1112" height="346" alt="image" src="https://github.com/user-attachments/assets/3466b42b-4b5d-4b15-8a88-3fd37f4d640f" />

in the case that audio is parented to a grid or map, the physics check should just work as expected (getting the grid velocity / the velocity being 0 respectively) and the occlusion check shouldnt make a difference at all