### PR TITLE
Add ability to specify easings for `AnimationTrackProperty` keyframes

### DIFF
--- a/Robust.Client/Animations/AnimationTrackProperty.cs
+++ b/Robust.Client/Animations/AnimationTrackProperty.cs
@@ -18,12 +18,6 @@ namespace Robust.Client.Animations
         /// </summary>
         public AnimationInterpolationMode InterpolationMode { get; set; } = AnimationInterpolationMode.Linear;
 
-        /// <summary>
-        ///     A function applied to the time parameter of the animation (0 to 1) to modify the animation's behaviour.
-        ///     See <see cref="Easings"/> for example functions, or provide your own.
-        /// </summary>
-        public Func<float, float>? Easing { get; set; } = null;
-
         public override (int KeyFrameIndex, float FramePlayingTime) InitPlayback()
         {
             return (-1, 0);
@@ -60,12 +54,14 @@ namespace Robust.Client.Animations
             }
             else
             {
+                var next = KeyFrames[nextKeyFrame];
+
                 // Get us a scale 0 -> 1 here.
-                var t = playingTime / KeyFrames[nextKeyFrame].KeyTime;
+                var t = playingTime / next.KeyTime;
 
                 // Apply easing to time parameter, if one was specified
-                if (Easing != null)
-                    t = Easing(t);
+                if (next.Easing != null)
+                    t = next.Easing(t);
 
                 switch (InterpolationMode)
                 {
@@ -157,10 +153,20 @@ namespace Robust.Client.Animations
             /// </summary>
             public readonly float KeyTime;
 
-            public KeyFrame(object value, float keyTime)
+            /// <summary>
+            ///     An easing function to apply when interpolating to this keyframe's value.
+            ///     Modifies the time parameter (0..1) of the interpolation between the previous keyframe and this one.
+            /// </summary>
+            /// <remarks>
+            ///     See <see cref="Easings"/> for examples of easing functions, or provide your own.
+            /// </remarks>
+            public readonly Func<float, float>? Easing;
+
+            public KeyFrame(object value, float keyTime, Func<float, float>? easing = null)
             {
                 Value = value;
                 KeyTime = keyTime;
+                Easing = easing;
             }
         }
     }

--- a/Robust.Client/Animations/AnimationTrackProperty.cs
+++ b/Robust.Client/Animations/AnimationTrackProperty.cs
@@ -18,6 +18,12 @@ namespace Robust.Client.Animations
         /// </summary>
         public AnimationInterpolationMode InterpolationMode { get; set; } = AnimationInterpolationMode.Linear;
 
+        /// <summary>
+        ///     A function applied to the time parameter of the animation (0 to 1) to modify the animation's behaviour.
+        ///     See <see cref="Easings"/> for example functions, or provide your own.
+        /// </summary>
+        public Func<float, float>? Easing { get; set; } = null;
+
         public override (int KeyFrameIndex, float FramePlayingTime) InitPlayback()
         {
             return (-1, 0);
@@ -56,6 +62,10 @@ namespace Robust.Client.Animations
             {
                 // Get us a scale 0 -> 1 here.
                 var t = playingTime / KeyFrames[nextKeyFrame].KeyTime;
+
+                // Apply easing to time parameter, if one was specified
+                if (Easing != null)
+                    t = Easing(t);
 
                 switch (InterpolationMode)
                 {


### PR DESCRIPTION
lets you do something like this:
<img width="715" height="138" alt="image" src="https://github.com/user-attachments/assets/76c2521e-45c9-48e7-b97f-4fece1618134" />

the easings are specified per keyframe, and the one used for each interp is the one on the next keyframe (so above would interpolate inquad 0->0.5 and outquad 0.5->1.0)

per-keyframe made the most sense as an implementation here, since you definitely want to be able to have different easings for different parts of the animation