### PR TITLE
Improve map serialization error logging & exception tolerance

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -42,6 +42,7 @@ END TEMPLATE-->
 * `Control.OrderedChildCollection` (gotten from `.Children`) now implements `IReadOnlyList<Control>`, allowing it to be indexed directly.
 * `System.WeakReference<T>` is now available in the sandbox.
 * `IClydeViewport` now has an `Id` and `ClearCachedResources` event. Together, these allow you to properly cache rendering resources per viewport.
+* Added a new entity yaml deserialization option (`SerializationOptions.EntityExceptionBehaviour`) that can optionally make deserialization more exception tolerant.
 
 ### Bugfixes
 

--- a/Robust.Shared/EntitySerialization/EntityDeserializer.cs
+++ b/Robust.Shared/EntitySerialization/EntityDeserializer.cs
@@ -685,38 +685,38 @@ public sealed class EntityDeserializer :
 
         foreach (var yamlId in MapYamlIds)
         {
-            var uid = UidMap[yamlId];
-            if (_mapQuery.TryComp(uid, out var map))
+            if (UidMap.TryGetValue(yamlId, out var uid) && _mapQuery.TryComp(uid, out var map))
             {
                 Result.Maps.Add((uid, map));
                 EntMan.EnsureComponent<LoadedMapComponent>(uid);
             }
             else
-                _log.Error($"Missing map entity: {EntMan.ToPrettyString(uid)}");
+                _log.Error($"Missing map entity: {EntMan.ToPrettyString(uid)}. YamlId: {yamlId}");
         }
 
         foreach (var yamlId in GridYamlIds)
         {
-            var uid = UidMap[yamlId];
-            if (_gridQuery.TryComp(uid, out var grid))
+            if (UidMap.TryGetValue(yamlId, out var uid) && _gridQuery.TryComp(uid, out var grid))
                 Result.Grids.Add((uid, grid));
             else
-                _log.Error($"Missing grid entity: {EntMan.ToPrettyString(uid)}");
+                _log.Error($"Missing grid entity: {EntMan.ToPrettyString(uid)}. YamlId: {yamlId}");
         }
 
         foreach (var yamlId in OrphanYamlIds)
         {
-            var uid = UidMap[yamlId];
-            if (_mapQuery.HasComponent(uid) || _xformQuery.Comp(uid).ParentUid.IsValid())
-                _log.Error($"Entity {EntMan.ToPrettyString(uid)} was incorrectly labelled as an orphan?");
+            if (UidMap.TryGetValue(yamlId, out var uid))
+                _log.Error($"Missing orphan entity with YamlId: {yamlId}");
+            else if (_mapQuery.HasComponent(uid) || _xformQuery.Comp(uid).ParentUid.IsValid())
+                _log.Error($"Entity {EntMan.ToPrettyString(uid)} was incorrectly labelled as an orphan? YamlId: {yamlId}");
             else
                 Result.Orphans.Add(uid);
         }
 
         foreach (var yamlId in NullspaceYamlIds)
         {
-            var uid = UidMap[yamlId];
-            if (_mapQuery.HasComponent(uid) || _xformQuery.Comp(uid).ParentUid.IsValid())
+            if (UidMap.TryGetValue(yamlId, out var uid))
+                _log.Error($"Missing nullspace entity with YamlId: {yamlId}");
+            else if (_mapQuery.HasComponent(uid) || _xformQuery.Comp(uid).ParentUid.IsValid())
                 _log.Error($"Entity {EntMan.ToPrettyString(uid)} was incorrectly labelled as a null-space entity?");
             else
                 Result.NullspaceEntities.Add(uid);
@@ -1172,8 +1172,8 @@ public sealed class EntityDeserializer :
             return entity;
 
         msg = CurrentReadingEntity is not { } ent
-            ? "Encountered unknown EntityUid reference"
-            : $"Encountered unknown EntityUid reference wile reading entity {ent.YamlId}, component: {CurrentComponent}";
+            ? "Encountered unknown entity yaml uid"
+            : $"Encountered unknown entity yaml uid wile reading entity {ent.YamlId}, component: {CurrentComponent}";
         _log.Error(msg);
         return EntityUid.Invalid;
     }

--- a/Robust.Shared/EntitySerialization/EntityDeserializer.cs
+++ b/Robust.Shared/EntitySerialization/EntityDeserializer.cs
@@ -1152,6 +1152,7 @@ public sealed class EntityDeserializer :
         ISerializationContext? context,
         ISerializationManager.InstantiationDelegate<EntityUid>? _)
     {
+        string msg;
         if (node.Value == "invalid")
         {
             if (CurrentComponent == "Transform")
@@ -1160,7 +1161,7 @@ public sealed class EntityDeserializer :
             if (!Options.LogInvalidEntities)
                 return EntityUid.Invalid;
 
-            var msg = CurrentReadingEntity is not { } curr
+            msg = CurrentReadingEntity is not { } curr
                 ? $"Encountered invalid EntityUid reference"
                 : $"Encountered invalid EntityUid reference wile reading entity {curr.YamlId}, component: {CurrentComponent}";
             _log.Error(msg);
@@ -1170,7 +1171,10 @@ public sealed class EntityDeserializer :
         if (int.TryParse(node.Value, out var val) && UidMap.TryGetValue(val, out var entity))
             return entity;
 
-        _log.Error($"Invalid yaml entity id: '{val}'");
+        msg = CurrentReadingEntity is not { } ent
+            ? "Encountered unknown EntityUid reference"
+            : $"Encountered unknown EntityUid reference wile reading entity {ent.YamlId}, component: {CurrentComponent}";
+        _log.Error(msg);
         return EntityUid.Invalid;
     }
 

--- a/Robust.Shared/EntitySerialization/EntityDeserializer.cs
+++ b/Robust.Shared/EntitySerialization/EntityDeserializer.cs
@@ -704,7 +704,7 @@ public sealed class EntityDeserializer :
 
         foreach (var yamlId in OrphanYamlIds)
         {
-            if (UidMap.TryGetValue(yamlId, out var uid))
+            if (!UidMap.TryGetValue(yamlId, out var uid))
                 _log.Error($"Missing orphan entity with YamlId: {yamlId}");
             else if (_mapQuery.HasComponent(uid) || _xformQuery.Comp(uid).ParentUid.IsValid())
                 _log.Error($"Entity {EntMan.ToPrettyString(uid)} was incorrectly labelled as an orphan? YamlId: {yamlId}");
@@ -714,7 +714,7 @@ public sealed class EntityDeserializer :
 
         foreach (var yamlId in NullspaceYamlIds)
         {
-            if (UidMap.TryGetValue(yamlId, out var uid))
+            if (!UidMap.TryGetValue(yamlId, out var uid))
                 _log.Error($"Missing nullspace entity with YamlId: {yamlId}");
             else if (_mapQuery.HasComponent(uid) || _xformQuery.Comp(uid).ParentUid.IsValid())
                 _log.Error($"Entity {EntMan.ToPrettyString(uid)} was incorrectly labelled as a null-space entity?");

--- a/Robust.Shared/EntitySerialization/EntitySerializer.cs
+++ b/Robust.Shared/EntitySerialization/EntitySerializer.cs
@@ -498,12 +498,15 @@ public sealed class EntitySerializer : ISerializationContext,
         {
             SerializeComponents(uid, cache, components);
         }
-        catch
+        catch(Exception e)
         {
-            _log.Error($"Caught exception while serializing component {CurrentComponent} of entity {EntMan.ToPrettyString(uid)}");
             if (Options.EntityExceptionBehaviour == EntityExceptionBehaviour.Rethrow)
+            {
+                _log.Error($"Caught exception while serializing component {CurrentComponent} of entity {EntMan.ToPrettyString(uid)}");
                 throw;
+            }
 
+            _log.Error($"Caught exception while serializing component {CurrentComponent} of entity {EntMan.ToPrettyString(uid)}:\n{e}");
             CurrentEntityYamlUid = 0;
             CurrentEntity = null;
             CurrentComponent = null;

--- a/Robust.Shared/EntitySerialization/Options.cs
+++ b/Robust.Shared/EntitySerialization/Options.cs
@@ -1,5 +1,4 @@
 ﻿using System.Numerics;
-using JetBrains.Annotations;
 using Robust.Shared.EntitySerialization.Components;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Log;
@@ -21,7 +20,13 @@ public record struct SerializationOptions
     public MissingEntityBehaviour MissingEntityBehaviour = MissingEntityBehaviour.IncludeNullspace;
 
     /// <summary>
-    /// Whether or not to log an error when serializing an entity without its parent.
+    /// What to do when an exception is thrown while trying to serialize an entity. The default behaviour is to abort
+    /// the serialization.
+    /// </summary>
+    public EntityExceptionBehaviour EntityExceptionBehaviour = EntityExceptionBehaviour.Rethrow;
+
+    /// <summary>
+    /// Whether to log an error when serializing an entity without its parent.
     /// </summary>
     public bool ErrorOnOrphan = true;
 

--- a/Robust.Shared/EntitySerialization/SerializationEnums.cs
+++ b/Robust.Shared/EntitySerialization/SerializationEnums.cs
@@ -86,3 +86,27 @@ public enum MissingEntityBehaviour
     /// </summary>
     AutoInclude,
 }
+
+
+public enum EntityExceptionBehaviour
+{
+    /// <summary>
+    /// Re-throw the exception, interrupting the serialization.
+    /// </summary>
+    Rethrow,
+
+    /// <summary>
+    /// Continue serializing and simply skip/ignore this entity. May result in broken maps that log errors or simply
+    /// fail to load.
+    /// </summary>
+    IgnoreEntity,
+
+    // TODO SERIALIZATION
+    /*
+    /// <summary>
+    /// Continue the serialization while skipping over the component that caused the exception to be thrown. May result
+    /// in broken maps that log errors or simply fail to load.
+    /// </summary>
+    IgnoreComponent,
+    */
+}

--- a/Robust.Shared/EntitySerialization/SerializationEnums.cs
+++ b/Robust.Shared/EntitySerialization/SerializationEnums.cs
@@ -102,7 +102,7 @@ public enum EntityExceptionBehaviour
     IgnoreEntity,
 
     /// <summary>
-    /// Continue serializing and simply skip/ignore this entity and all ofits children.
+    /// Continue serializing and simply skip/ignore this entity and all of its children.
     /// May result in broken maps that log errors or simply fail to load.
     /// </summary>
     IgnoreEntityAndChildren,

--- a/Robust.Shared/EntitySerialization/SerializationEnums.cs
+++ b/Robust.Shared/EntitySerialization/SerializationEnums.cs
@@ -101,6 +101,12 @@ public enum EntityExceptionBehaviour
     /// </summary>
     IgnoreEntity,
 
+    /// <summary>
+    /// Continue serializing and simply skip/ignore this entity and all ofits children.
+    /// May result in broken maps that log errors or simply fail to load.
+    /// </summary>
+    IgnoreEntityAndChildren,
+
     // TODO SERIALIZATION
     /*
     /// <summary>


### PR DESCRIPTION
Wraps the code that serializes an entity's components in a try-catch block that logs an error with information about the problematic entity & component. Also adds an option to continue serializing the map while skipping over the entity. The default behaviour is still to abort the serialization (rethrow the exception)