### PR TITLE
Add toolshed ResPath completion suggestions

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -42,7 +42,7 @@ END TEMPLATE-->
 * `Control.OrderedChildCollection` (gotten from `.Children`) now implements `IReadOnlyList<Control>`, allowing it to be indexed directly.
 * `System.WeakReference<T>` is now available in the sandbox.
 * `IClydeViewport` now has an `Id` and `ClearCachedResources` event. Together, these allow you to properly cache rendering resources per viewport.
-* Toolshed will now generate completion suggetions when parsing ResPath arguments.
+* Toolshed will now generate completion suggestions when parsing ResPath arguments.
   * By default, this will suggest paths in the UserData directory
   * If you want  to use another directory, you can use a custom type parser for your argument (e.g., ContentPathParser)
 * Added a new "cat" toolshed command
@@ -54,7 +54,7 @@ END TEMPLATE-->
 
 ### Other
 
-*None yet*
+* `CompletionHelper.UserFilePath()` will now append trailing slashes to directories, making it consistent with other file path option helpers.
 
 ### Internal
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -42,6 +42,11 @@ END TEMPLATE-->
 * `Control.OrderedChildCollection` (gotten from `.Children`) now implements `IReadOnlyList<Control>`, allowing it to be indexed directly.
 * `System.WeakReference<T>` is now available in the sandbox.
 * `IClydeViewport` now has an `Id` and `ClearCachedResources` event. Together, these allow you to properly cache rendering resources per viewport.
+* Toolshed will now generate completion suggetions when parsing ResPath arguments.
+  * By default, this will suggest paths in the UserData directory
+  * If you want  to use another directory, you can use a custom type parser for your argument (e.g., ContentPathParser)
+* Added a new "cat" toolshed command
+* Added a new bitflag for console command completion options that will force the option to be quoted (`CompletionOptionFlags.AlwaysQuote`)
 
 ### Bugfixes
 

--- a/Resources/Locale/en-US/toolshed-commands.ftl
+++ b/Resources/Locale/en-US/toolshed-commands.ftl
@@ -428,3 +428,5 @@ command-description-cmd-info =
     On its own, this means it'll print the command's help message.
 command-description-comp-rm =
     Removes the given component from the entity.
+command-description-cat =
+    Concatenate the given files in the user directory

--- a/Robust.Client/UserInterface/CustomControls/DebugConsole.xaml.Completions.cs
+++ b/Robust.Client/UserInterface/CustomControls/DebugConsole.xaml.Completions.cs
@@ -287,6 +287,7 @@ public sealed partial class DebugConsole
 
                 // If the replacement contains a space, we must quote it to treat it as a single argument.
                 var mustQuote = (completionFlags & CompletionOptionFlags.NoQuote) == 0 && insertValue.Contains(' ');
+                mustQuote |= (completionFlags & CompletionOptionFlags.AlwaysQuote) == CompletionOptionFlags.AlwaysQuote;
 
                 if ((completionFlags & CompletionOptionFlags.PartialCompletion) == 0)
                 {

--- a/Robust.Shared/Console/CompletionHelper.cs
+++ b/Robust.Shared/Console/CompletionHelper.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using JetBrains.Annotations;
 using Robust.Shared.Audio;
-using Robust.Shared.Collections;
 using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -169,7 +167,7 @@ public static class CompletionHelper
             {
                 var full = resPath / c;
                 if (provider.IsDir(full))
-                    return new CompletionOption($"{full}", Flags: CompletionOptionFlags.PartialCompletion | flags);
+                    return new CompletionOption($"{full}/", Flags: CompletionOptionFlags.PartialCompletion | flags);
 
                 return new CompletionOption(full.ToString(), Flags: flags);
             })

--- a/Robust.Shared/Console/CompletionHelper.cs
+++ b/Robust.Shared/Console/CompletionHelper.cs
@@ -30,8 +30,11 @@ public static class CompletionHelper
     /// <summary>
     /// Special-cased file handler for audio that accounts for serverside completion.
     /// </summary>
-    public static IEnumerable<CompletionOption> AudioFilePath(string arg, IPrototypeManager protoManager,
-        IResourceManager res)
+    public static IEnumerable<CompletionOption> AudioFilePath(
+        string arg,
+        IPrototypeManager protoManager,
+        IResourceManager res,
+        CompletionOptionFlags flags = default)
     {
         var resPath = GetUpdatedPath(arg);
         var paths = new HashSet<string>();
@@ -51,7 +54,7 @@ public static class CompletionHelper
             paths.Add(hero.GetNextSegment(resPath).ToString());
         }
 
-        return GetPaths(resPath, paths, res);
+        return GetPaths(resPath, paths, flags);
     }
 
     private static ResPath GetUpdatedPath(string arg)
@@ -71,7 +74,10 @@ public static class CompletionHelper
         return resPath;
     }
 
-    private static IEnumerable<CompletionOption> GetPaths(ResPath resPath, IEnumerable<string> inputs, IResourceManager res)
+    private static IEnumerable<CompletionOption> GetPaths(
+        ResPath resPath,
+        IEnumerable<string> inputs,
+        CompletionOptionFlags flags = default)
     {
         var options = inputs
             .OrderBy(c => c)
@@ -80,25 +86,31 @@ public static class CompletionHelper
                 var opt = (resPath / c).ToString();
 
                 if (c.EndsWith("/"))
-                    return new CompletionOption(opt, Flags: CompletionOptionFlags.PartialCompletion);
+                    return new CompletionOption(opt, Flags: CompletionOptionFlags.PartialCompletion | flags);
 
-                return new CompletionOption(opt);
+                return new CompletionOption(opt, Flags: flags);
             });
 
         return options;
     }
 
-    public static IEnumerable<CompletionOption> ContentFilePath(string arg, IResourceManager res)
+    public static IEnumerable<CompletionOption> ContentFilePath(
+        string arg,
+        IResourceManager res,
+        CompletionOptionFlags flags = default)
     {
         var resPath = GetUpdatedPath(arg);
-        return GetPaths(resPath, res.ContentGetDirectoryEntries(resPath), res);
+        return GetPaths(resPath, res.ContentGetDirectoryEntries(resPath), flags);
     }
 
-    public static IEnumerable<CompletionOption> ContentDirPath(string arg, IResourceManager res)
+    public static IEnumerable<CompletionOption> ContentDirPath(
+        string arg,
+        IResourceManager res,
+        CompletionOptionFlags flags = default)
     {
         var curPath = arg;
         if (!curPath.StartsWith("/"))
-            return new[] { new CompletionOption("/") };
+            return new[] { new CompletionOption("/", Flags: flags) };
 
         var resPath = new ResPath(curPath);
 
@@ -115,13 +127,16 @@ public static class CompletionHelper
             {
                 var opt = (resPath / c).ToString();
 
-                return new CompletionOption(opt, Flags: CompletionOptionFlags.PartialCompletion);
+                return new CompletionOption(opt, Flags: CompletionOptionFlags.PartialCompletion | flags);
             });
 
         return options;
     }
 
-    public static IEnumerable<CompletionOption> UserFilePath(string arg, IWritableDirProvider provider)
+    public static IEnumerable<CompletionOption> UserFilePath(
+        string arg,
+        IWritableDirProvider provider,
+        CompletionOptionFlags flags = default)
     {
         var curPath = arg;
         if (curPath == "")
@@ -138,16 +153,25 @@ public static class CompletionHelper
             resPath = resPath.Clean();
         }
 
-        var entries = provider.DirectoryEntries(resPath);
+
+        IEnumerable<string> entries = [];
+        try
+        {
+            entries = provider.DirectoryEntries(resPath);
+        }
+        catch
+        {
+            // see TODO on DirectoryEntries()
+        }
 
         return entries
             .Select(c =>
             {
                 var full = resPath / c;
                 if (provider.IsDir(full))
-                    return new CompletionOption($"{full}", Flags: CompletionOptionFlags.PartialCompletion);
+                    return new CompletionOption($"{full}", Flags: CompletionOptionFlags.PartialCompletion | flags);
 
-                return new CompletionOption(full.ToString());
+                return new CompletionOption(full.ToString(), Flags: flags);
             })
             .OrderBy(c => c.Value);
     }

--- a/Robust.Shared/Console/CompletionResult.cs
+++ b/Robust.Shared/Console/CompletionResult.cs
@@ -74,6 +74,10 @@ public enum CompletionOptionFlags
     /// Therefore, tab completing it should keep the cursor on the current argument
     /// (instead of adding a space to go to the next one).
     /// </summary>
+    /// <remarks>
+    /// If the option should get quoted (e.g., it contains whitespaces), this flag means that only the opening quote
+    /// will be inserted.
+    /// </remarks>
     PartialCompletion = 1 << 0,
 
     /// <summary>
@@ -85,4 +89,14 @@ public enum CompletionOptionFlags
     /// Prevents suggestions from being escaped using <see cref="CommandParsing.Escape"/>.
     /// </summary>
     NoEscape = 1 << 2,
+
+    /// <summary>
+    /// Forces suggestions to always be wrapped in quotes, even if they don't contain characters that would usually
+    /// result in quotes being inserted. This takes precedence over <see cref="NoQuote"/>.
+    /// </summary>
+    /// <remarks>
+    /// Useful for commands with non-standard argument parsing, where we expect the options to potentially contain
+    /// characters with special meaning (e.g., file path parsing for toolshed commands).
+    /// </remarks>
+    AlwaysQuote = 1 << 3,
 }

--- a/Robust.Shared/ContentPack/IWritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/IWritableDirProvider.cs
@@ -46,6 +46,11 @@ namespace Robust.Shared.ContentPack
         (IEnumerable<ResPath> files, IEnumerable<ResPath> directories) Find(string pattern,
             bool recursive = true);
 
+
+        // TODO IWritableDirProvider make consistent
+        // The virtual provider throws an exception when given a non-existent directory, while the other implementation
+        // simply returns an empty enumerable. Either both should throw, or neither. And if they throw there should be
+        // a "try" variant.
         IEnumerable<string> DirectoryEntries(ResPath path);
 
         /// <summary>

--- a/Robust.Shared/ContentPack/IWritableDirProvider.cs
+++ b/Robust.Shared/ContentPack/IWritableDirProvider.cs
@@ -46,7 +46,6 @@ namespace Robust.Shared.ContentPack
         (IEnumerable<ResPath> files, IEnumerable<ResPath> directories) Find(string pattern,
             bool recursive = true);
 
-
         // TODO IWritableDirProvider make consistent
         // The virtual provider throws an exception when given a non-existent directory, while the other implementation
         // simply returns an empty enumerable. Either both should throw, or neither. And if they throw there should be

--- a/Robust.Shared/Toolshed/Commands/Misc/CatCommand.cs
+++ b/Robust.Shared/Toolshed/Commands/Misc/CatCommand.cs
@@ -1,0 +1,18 @@
+﻿using System.Linq;
+using Robust.Shared.ContentPack;
+using Robust.Shared.IoC;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Toolshed.Commands.Misc;
+
+[ToolshedCommand]
+internal sealed class CatCommand : ToolshedCommand
+{
+    [Dependency] private readonly IResourceManager _res = default!;
+
+    [CommandImplementation]
+    public string Cat(params ResPath[] path)
+    {
+        return string.Concat(path.Select(x => _res.UserData.ReadAllText(x)));
+    }
+}

--- a/Robust.Shared/Toolshed/Commands/Vfs/CdCommand.cs
+++ b/Robust.Shared/Toolshed/Commands/Vfs/CdCommand.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.Utility;
+﻿using Robust.Shared.Toolshed.TypeParsers;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Toolshed.Commands.Vfs;
 
@@ -6,7 +7,11 @@ namespace Robust.Shared.Toolshed.Commands.Vfs;
 internal sealed class CdCommand : VfsCommand
 {
     [CommandImplementation]
-    public void Cd(IInvocationContext ctx,ResPath path)
+    public void Cd(
+        IInvocationContext ctx,
+        // TODO TOOLSHED add Vfs CurrentPath() aware path parser
+        [CommandArgument(customParser:typeof(GenericPathParser))]
+        ResPath path)
     {
         var curPath = CurrentPath(ctx);
 

--- a/Robust.Shared/Toolshed/Commands/Vfs/LsCommand.cs
+++ b/Robust.Shared/Toolshed/Commands/Vfs/LsCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Robust.Shared.Toolshed.TypeParsers;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.Toolshed.Commands.Vfs;
@@ -15,7 +16,11 @@ internal sealed class LsCommand : VfsCommand
     }
 
     [CommandImplementation("in")]
-    public IEnumerable<ResPath> LsIn(IInvocationContext ctx, ResPath @in)
+    public IEnumerable<ResPath> LsIn(
+        IInvocationContext ctx,
+        // TODO TOOLSHED add Vfs CurrentPath() aware path parser
+        [CommandArgument(customParser: typeof(GenericPathParser))]
+        ResPath @in)
     {
         var curPath = CurrentPath(ctx);
         if (@in.IsRooted)

--- a/Robust.Shared/Toolshed/TypeParsers/ResPathTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/ResPathTypeParser.cs
@@ -144,3 +144,19 @@ public sealed class AudioPathParser : CustomPathParser
     protected override IEnumerable<CompletionOption> GetCompletions(ResPath path)
         => CompletionHelper.AudioFilePath(path.CanonPath, _proto, ResMan, flags: CompletionOptionFlags.AlwaysQuote);
 }
+
+/// <summary>
+/// Custom <see cref="ResPath"/> parser that does not generate any auto-completion options.
+/// </summary>
+public sealed class GenericPathParser : CustomTypeParser<ResPath>
+{
+    public override bool TryParse(ParserContext ctx, out ResPath result)
+    {
+        return Toolshed.TryParse(ctx, out result);
+    }
+
+    public override CompletionResult TryAutocomplete(ParserContext ctx, CommandArgument? arg)
+    {
+        return CompletionResult.FromHint(GetArgHint(arg));
+    }
+}

--- a/Robust.Shared/Toolshed/TypeParsers/ResPathTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/ResPathTypeParser.cs
@@ -1,24 +1,146 @@
-﻿using Robust.Shared.Console;
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using Robust.Shared.Console;
+using Robust.Shared.ContentPack;
+using Robust.Shared.IoC;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Toolshed.Syntax;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.Toolshed.TypeParsers;
 
-internal sealed class ResPathTypeParser : TypeParser<ResPath>
+/// <summary>
+/// Default parser for resource paths.
+/// </summary>
+/// <remarks>
+/// This will generate completions suggestions using <see cref="CompletionHelper.UserFilePath"/>. If you want to
+/// customize suggestions, you need to use a custom type parser. E.g., see <see cref="ContentPathParser"/>
+/// </remarks>
+public sealed class ResPathTypeParser : TypeParser<ResPath>
 {
-    public override bool TryParse(ParserContext parserContext, out ResPath result)
-    {
-        result = default;
-        if (!Toolshed.TryParse(parserContext, out string? str))
-            return false;
+    [Dependency] private readonly IResourceManager _resMan = default!;
 
-        result = new ResPath(str);
+    /// <summary>
+    /// Tokens that make up a valid unquoted path.
+    /// Paths containing other symbols (e.g., whitespace or semicolons) need to be in quotes.
+    /// </summary>
+    public static bool IsPathToken(Rune c) => ParserContext.IsToken(c)
+                                              || c == new Rune('/')
+                                              || c == new Rune('-')
+                                              || c == new Rune('.');
+
+    public override bool TryParse(ParserContext ctx, out ResPath result)
+    {
+        if (!TryParse(ctx, out var nullableResult, partial: false))
+        {
+            result = default;
+            return false;
+        }
+
+        result = nullableResult.Value;
         return true;
     }
 
-    public override CompletionResult? TryAutocomplete(ParserContext parserContext, CommandArgument? arg)
+    /// <summary>
+    /// Attempt to parse a resource path.
+    /// </summary>
+    /// <param name="ctx">The parser context.</param>
+    /// <param name="path">The parsed path.</param>
+    /// <param name="partial">If true, this will succeed even if the path is quoted but is missing a closing quote.
+    /// This is intended to be used by other path-parsers that want to generate completion options for partially
+    /// complete paths.
+    /// </param>
+    public static bool TryParse(ParserContext ctx, [NotNullWhen(true)] out ResPath? path, bool partial)
     {
-        // TODO TOOLSHED ResPath Completion
-        return CompletionResult.FromHint(GetArgHint(arg));
+        path = default;
+        string? str;
+
+        // Paths can be specified without quotes, though they may be necessary if the path contains spaces other special
+        // characters (anything that is fails IsPathToken()).
+        if (ctx.PeekRune() == new Rune('"'))
+        {
+            if (!StringTypeParser.TryParse(ctx, out str, partial))
+                return false;
+        }
+        else
+        {
+            str = ctx.GetWord(IsPathToken);
+        }
+
+        if (str == null)
+            return false;
+
+        path = new(str);
+        return true;
     }
+
+    public override CompletionResult TryAutocomplete(ParserContext ctx, CommandArgument? arg)
+    {
+        var hint = GetArgHint(arg);
+
+        if (!TryParse(ctx, out var p, partial: true) || p is not {} path)
+            return CompletionResult.FromHint(hint);
+
+
+        var opts = CompletionHelper.UserFilePath(
+            path.CanonPath,
+            _resMan.UserData,
+            flags: CompletionOptionFlags.AlwaysQuote);
+
+        return CompletionResult.FromHintOptions(opts, hint);
+    }
+}
+
+/// <summary>
+/// Parent class for custom ResPath parsers that just want to modify the completion suggestions.
+/// </summary>
+public abstract class CustomPathParser : CustomTypeParser<ResPath>
+{
+    [Dependency] protected readonly IResourceManager ResMan = default!;
+
+    protected abstract IEnumerable<CompletionOption> GetCompletions(ResPath path);
+
+    public override bool TryParse(ParserContext ctx, out ResPath result)
+    {
+        return Toolshed.TryParse(ctx, out result);
+    }
+
+    public override CompletionResult TryAutocomplete(ParserContext ctx, CommandArgument? arg)
+    {
+        var hint = GetArgHint(arg);
+        if (!ResPathTypeParser.TryParse(ctx, out var path, partial: true))
+            return CompletionResult.FromHint(hint);
+
+        return CompletionResult.FromHintOptions(GetCompletions(path.Value), hint);
+    }
+}
+
+/// <summary>
+/// Custom <see cref="ResPath"/> parser that uses <see cref="CompletionHelper.ContentFilePath"/> to generate completions.
+/// </summary>
+public sealed class ContentPathParser : CustomPathParser
+{
+    protected override IEnumerable<CompletionOption> GetCompletions(ResPath path)
+        => CompletionHelper.ContentFilePath(path.CanonPath, ResMan, flags: CompletionOptionFlags.AlwaysQuote);
+}
+
+/// <summary>
+/// Custom <see cref="ResPath"/> parser that uses <see cref="CompletionHelper.ContentDirPath"/> to generate completions.
+/// </summary>
+public sealed class ContentDirPathParser : CustomPathParser
+{
+    protected override IEnumerable<CompletionOption> GetCompletions(ResPath path)
+        => CompletionHelper.ContentDirPath(path.CanonPath, ResMan, flags: CompletionOptionFlags.AlwaysQuote);
+}
+
+/// <summary>
+/// Custom <see cref="ResPath"/> parser that uses <see cref="CompletionHelper.AudioFilePath"/> to generate completions.
+/// </summary>
+public sealed class AudioPathParser : CustomPathParser
+{
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+
+    protected override IEnumerable<CompletionOption> GetCompletions(ResPath path)
+        => CompletionHelper.AudioFilePath(path.CanonPath, _proto, ResMan, flags: CompletionOptionFlags.AlwaysQuote);
 }

--- a/Robust.Shared/Toolshed/TypeParsers/StringTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/StringTypeParser.cs
@@ -9,12 +9,25 @@ using Robust.Shared.Utility;
 
 namespace Robust.Shared.Toolshed.TypeParsers;
 
-internal sealed class StringTypeParser : TypeParser<string>
+public sealed class StringTypeParser : TypeParser<string>
 {
     // Completion option for hinting that all strings must start with a quote
     private static readonly CompletionOption[] Option = [new("\"", Flags: CompletionOptionFlags.PartialCompletion | CompletionOptionFlags.NoEscape)];
 
     public override bool TryParse(ParserContext ctx, [NotNullWhen(true)] out string? result)
+    {
+        return TryParse(ctx, out result, partial: false);
+    }
+
+    /// <summary>
+    /// Attempt to parse a string.
+    /// </summary>
+    /// <param name="ctx">The parser context.</param>
+    /// <param name="result">The parsed string, without enclosing quotes.</param>
+    /// <param name="partial">If true, this will succeed even without a matching closing quote. This is intended to be
+    /// by string-like parsers (e.g., resource paths) that want to generate completion options for partially complete strings.
+    /// </param>
+    public static bool TryParse(ParserContext ctx, [NotNullWhen(true)] out string? result, bool partial = true)
     {
         ctx.ConsumeWhitespace();
         if (!ctx.EatMatch('"'))
@@ -33,7 +46,7 @@ internal sealed class StringTypeParser : TypeParser<string>
         }
 
         var output = new StringBuilder();
-        while (ctx.GetRune() is {} r)
+        while (ctx.GetRune() is { } r)
         {
             if (r == new Rune('"'))
             {
@@ -43,6 +56,12 @@ internal sealed class StringTypeParser : TypeParser<string>
 
             if (r != new Rune('\\'))
             {
+                // TODO TOOLSHED
+                // Instead of appending each rune individually, its probably better to append whole substrings.
+                // I.e., use something like:
+                // var quoteIndex = ctx.Input.IndexOf('"', ctx.Index);
+                // var escapeIndex = ctx.Input.IndexOf('\\', ctx.Index, quoteIndex - ctx.Index);
+                // output.Append(ctx.Input.AsSpan()[ctx.Index..escapeIndex]);
                 output.Append(r);
                 continue;
             }
@@ -62,10 +81,18 @@ internal sealed class StringTypeParser : TypeParser<string>
             return false;
         }
 
+        if (partial)
+        {
+            // Partial strings don't require closing quotes.
+            result = output.ToString();
+            return true;
+        }
+
         // We ran out of input before encountering the terminating quote.
         // Either someone is trying to execute an incomplete command, or more likely, they forgot the terminating quote.
         if (!ctx.GenerateCompletions)
             ctx.Error = new StringMustEndWithQuote();
+
         result = null;
         return false;
     }
@@ -95,7 +122,7 @@ public record struct StringMustStartWithQuote : IConError
 public sealed class StringMustEndWithQuote : ConError
 {
     public override FormattedMessage DescribeInner()
-        => FormattedMessage.FromUnformatted($"String must end with a quote (\").");
+        => FormattedMessage.FromUnformatted($"Missing closing a quote (\").");
 }
 
 public sealed class UnknownEscapeSequence(Rune c) : ConError

--- a/Robust.UnitTesting/Shared/Toolshed/TestCommands.cs
+++ b/Robust.UnitTesting/Shared/Toolshed/TestCommands.cs
@@ -2,10 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using Robust.Shared.Console;
+using Robust.Shared.ContentPack;
+using Robust.Shared.IoC;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Toolshed.Syntax;
 using Robust.Shared.Toolshed.TypeParsers;
+using Robust.Shared.Utility;
 
 namespace Robust.UnitTesting.Shared.Toolshed;
 
@@ -214,4 +217,16 @@ public sealed class TestNestedEnumerableCommand : ToolshedCommand
 
     [CommandImplementation]
     public IEnumerable<ProtoId<EntityCategoryPrototype>> Impl() => _arr.OrderByDescending(x => x.Id);
+}
+
+[ToolshedCommand]
+public sealed class TestCatCommand : ToolshedCommand
+{
+    [Dependency] private readonly IResourceManager _resMan = default!;
+
+    [CommandImplementation]
+    public string Impl(ResPath path)
+    {
+        return _resMan.UserData.TryReadAllText(path, out var result) ? result : string.Empty;
+    }
 }

--- a/Robust.UnitTesting/Shared/Toolshed/ToolshedTest.cs
+++ b/Robust.UnitTesting/Shared/Toolshed/ToolshedTest.cs
@@ -126,14 +126,14 @@ public abstract class ToolshedTest : RobustIntegrationTest, IInvocationContext
         Assert.That(result.Options, Is.EquivalentTo(expected.Options));
     }
 
-    protected void AssertCompletionEmpty(string command)
+    protected void AssertCompletionEmpty(string command, bool expectHint = false)
     {
         var result = GetCompletions(command);
         if (result == null)
             return;
 
         Assert.That(result.Options.Length, Is.EqualTo(0));
-        Assert.That(result.Hint, Is.Null);
+        Assert.That(result.Hint != null, Is.EqualTo(expectHint));
     }
 
     protected void AssertCompletionHint(string command, string hint)
@@ -169,12 +169,26 @@ public abstract class ToolshedTest : RobustIntegrationTest, IInvocationContext
             return;
 
         Assert.That(result.Options.Length, Is.GreaterThanOrEqualTo(expected.Length));
-        if (result.Options.Length != 1)
-            return;
 
         foreach (var ex in expected)
         {
-            Assert.That(result.Options.Any(x => x.Value == ex));
+            Assert.That(result.Options.Any(x => x.Value == ex), $"Missing expected option: {ex}");
+        }
+    }
+
+    protected void AssertCompletions(string command, params string[] expected)
+    {
+        var result = GetCompletions(command);
+
+        Assert.That(result, Is.Not.Null);
+        if (result == null)
+            return;
+
+        Assert.That(result.Options.Length, Is.EqualTo(expected.Length));
+
+        foreach (var ex in expected)
+        {
+            Assert.That(result.Options.Any(x => x.Value == ex), $"Missing expected option: {ex}");
         }
     }
 

--- a/Robust.UnitTesting/Shared/Toolshed/ToolshedTests.cs
+++ b/Robust.UnitTesting/Shared/Toolshed/ToolshedTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -10,6 +11,7 @@ using Robust.Shared.Toolshed.Commands.Generic;
 using Robust.Shared.Toolshed.Syntax;
 using Robust.Shared.Toolshed.TypeParsers;
 using Robust.Shared.Toolshed.TypeParsers.Math;
+using Robust.Shared.Utility;
 
 namespace Robust.UnitTesting.Shared.Toolshed;
 
@@ -464,6 +466,77 @@ public sealed class ToolshedTests : ToolshedTest
 
             AssertCompletionEmpty("notarealcommand ");
             AssertCompletionEmpty("i 2 + { notarealcommand ");
+        });
+    }
+
+    /// <summary>
+    /// Test parsing and completion options for resource paths
+    /// </summary>
+    [Test]
+    public async Task TestPaths()
+    {
+        await Server.WaitAssertion(() =>
+        {
+            string[] folders =
+            [
+                "/TestPaths/folder",
+                "/TestPaths/folder 2 - electric bogaloo"
+            ];
+
+            string[] files =
+            [
+                $"{folders[0]}/test.yml",
+                $"{folders[0]}/test_-_2.yml",
+                $"{folders[0]}/test - 3.yml",
+                $"{folders[0]}/A!;.,-_'"
+            ];
+
+            // Setup files for testing
+            var resMan = Server.ResolveDependency<IResourceManager>();
+            resMan.UserData.CreateDir(new(folders[0]));
+            resMan.UserData.CreateDir(new(folders[1]));
+            resMan.UserData.WriteAllText(new(files[0]), "test1");
+            resMan.UserData.WriteAllText(new(files[1]), "test2");
+            resMan.UserData.WriteAllText(new(files[2]), "test3");
+            resMan.UserData.WriteAllText(new(files[3]), "test4");
+
+            // Currently, CompletionHelper.UserFilePath will always return the whole directory's contents as options
+
+            // Some paths can parse with or without quotes
+            AssertResult($"testcat {files[0]}", "test1");
+            AssertResult($"testcat {files[1]}", "test2");
+            AssertResult($"testcat \"{files[0]}\"", "test1");
+            AssertResult($"testcat \"{files[1]}\"", "test2");
+
+            // Other paths require quotes
+            AssertResult($"testcat \"{files[2]}\"", "test3");
+            AssertResult($"testcat \"/{files[3]}\"", "test4");
+            ParseError<NoImplementationError>($"testcat {files[2]}"); // no "-" command that takes in a string pipe
+            ParseError<UnknownCommandError>($"testcat {files[3]}");
+
+            // Paths must be rooted
+            AssertCompletionEmpty($"testcat fold", expectHint: true);
+
+            // non-existent dirs return no options
+            AssertCompletionEmpty($"testcat /folder/foo/", expectHint: true);
+
+            // CompletionHelper methods return all files/folders in the base directory. I.e., they don't do precise
+            // matching on the input
+            AssertCompletions($"testcat /TestPaths/fold", folders);
+            AssertCompletions($"testcat \"/TestPaths/fold", folders);
+            AssertCompletions($"testcat \"/TestPaths/fold\"", folders);
+            AssertCompletions($"testcat \"/TestPaths/folder ", folders);
+            AssertCompletions($"testcat \"/TestPaths/folder \"", folders);
+
+            AssertCompletions($"testcat {folders[0]}/", files);
+            AssertCompletions($"testcat {folders[0]}/test.", files);
+            AssertCompletions($"testcat \"{folders[0]}/test.", files);
+            AssertCompletions($"testcat \"{folders[0]}/test.\"", files);
+            AssertCompletions($"testcat \"{folders[0]}/test ", files);
+            AssertCompletions($"testcat \"{folders[0]}/test \"", files);
+            AssertCompletions($"testcat \"{folders[0]}/A", files);
+            AssertCompletions($"testcat \"{folders[0]}/A!;.,", files);
+            AssertCompletions($"testcat \"{folders[0]}/A!;.,\"", files);
         });
     }
 

--- a/Robust.UnitTesting/Shared/Toolshed/ToolshedTests.cs
+++ b/Robust.UnitTesting/Shared/Toolshed/ToolshedTests.cs
@@ -163,7 +163,7 @@ public sealed class ToolshedTests : ToolshedTest
 
             AssertCompletionSingle($"ent e{ent.Id} emplace ", "{");
             AssertCompletionContains($"ent e{ent.Id} emplace {{ ", "val", "var", "f");
-            AssertCompletionContains($"ent e{ent.Id} emplace {{ val EntityUi", "EntityUi");
+            AssertCompletionContains($"ent e{ent.Id} emplace {{ val EntityUi", "EntityUid");
             AssertCompletionContains($"ent e{ent.Id} emplace {{ val EntityUid", "EntityUid");
             AssertCompletionContains($"ent e{ent.Id} emplace {{ val EntityUid $", "$value");
             AssertCompletionContains($"ent e{ent.Id} emplace {{ val EntityUid $val", "$value");
@@ -180,7 +180,7 @@ public sealed class ToolshedTests : ToolshedTest
 
             AssertCompletionContains("i 2 emplace { var ", "$value");
             AssertCompletionInvalid("i 2 emplace { var ", "wx");
-            AssertCompletionContains("player:list emplace { var ", "$value", "$ent", "$paused");
+            AssertCompletionContains("player:list emplace { var ", "$value", "$ent", "$name", "$userid");
             AssertCompletionInvalid("player:list emplace { var ", "wx");
             AssertCompletionContains("i 1 emplace { var $value empla", "emplace");
             AssertCompletionSingle("i 1 emplace { var $value emplace ", "{");

--- a/Robust.UnitTesting/Shared/Toolshed/ToolshedTests.cs
+++ b/Robust.UnitTesting/Shared/Toolshed/ToolshedTests.cs
@@ -479,16 +479,16 @@ public sealed class ToolshedTests : ToolshedTest
         {
             string[] folders =
             [
-                "/TestPaths/folder",
-                "/TestPaths/folder 2 - electric bogaloo"
+                "/TestPaths/folder/",
+                "/TestPaths/folder 2 - electric bogaloo/"
             ];
 
             string[] files =
             [
-                $"{folders[0]}/test.yml",
-                $"{folders[0]}/test_-_2.yml",
-                $"{folders[0]}/test - 3.yml",
-                $"{folders[0]}/A!;.,-_'"
+                $"{folders[0]}test.yml",
+                $"{folders[0]}test_-_2.yml",
+                $"{folders[0]}test - 3.yml",
+                $"{folders[0]}A!;.,-_'"
             ];
 
             // Setup files for testing
@@ -528,15 +528,15 @@ public sealed class ToolshedTests : ToolshedTest
             AssertCompletions($"testcat \"/TestPaths/folder ", folders);
             AssertCompletions($"testcat \"/TestPaths/folder \"", folders);
 
-            AssertCompletions($"testcat {folders[0]}/", files);
-            AssertCompletions($"testcat {folders[0]}/test.", files);
-            AssertCompletions($"testcat \"{folders[0]}/test.", files);
-            AssertCompletions($"testcat \"{folders[0]}/test.\"", files);
-            AssertCompletions($"testcat \"{folders[0]}/test ", files);
-            AssertCompletions($"testcat \"{folders[0]}/test \"", files);
-            AssertCompletions($"testcat \"{folders[0]}/A", files);
-            AssertCompletions($"testcat \"{folders[0]}/A!;.,", files);
-            AssertCompletions($"testcat \"{folders[0]}/A!;.,\"", files);
+            AssertCompletions($"testcat {folders[0]}", files);
+            AssertCompletions($"testcat {folders[0]}test.", files);
+            AssertCompletions($"testcat \"{folders[0]}test.", files);
+            AssertCompletions($"testcat \"{folders[0]}test.\"", files);
+            AssertCompletions($"testcat \"{folders[0]}test ", files);
+            AssertCompletions($"testcat \"{folders[0]}test \"", files);
+            AssertCompletions($"testcat \"{folders[0]}A", files);
+            AssertCompletions($"testcat \"{folders[0]}A!;.,", files);
+            AssertCompletions($"testcat \"{folders[0]}A!;.,\"", files);
         });
     }
 


### PR DESCRIPTION
Currently the toolshed ResPath parser doesn't generate any completion options. This PR makes it default to using `CompletionHelper.UserFilePath`, and also defines some custom parsers that use other helper methods like `CompletionHelper.ContentFilePath`.

Other changes:
- Added a `cat` command that uses the new parser
- Toolshed's ResPath parser now accepts some paths without quotations E.g., both `cat /a.yml` and `cat "/a.yml"` work.
- Added a new `CompletionOptionFlags` flag for forcing quoting of completion options
- `CompletionHelper` path helpers now have an optional `CompletionOptionFlags` argument.
- `CompletionHelper.UserFilePath` now has a trailing slash for partial directory options. This makes it consistent with `CompletionHelper.ContentFilePath`
  - I.e., when completing a sugestion for a folder, you don't have to manually enter the `/` anymore.
  - This was added after I recorded the video
  - Given that this is just meant to be for console completions, I don't think this should count as a breaking change, even if it technically might break command completion tests for forks (if there even are any)?
 

https://github.com/user-attachments/assets/3a979929-ca27-4e0b-a8c7-83ac157c11dd
