### PR TITLE
Try fix UI state debug assert

### DIFF
--- a/Robust.Client/GameStates/GameStateProcessor.cs
+++ b/Robust.Client/GameStates/GameStateProcessor.cs
@@ -220,24 +220,32 @@ Had full state: {LastFullState != null}"
                 {
                     var compState = change.State;
 
-                    if (compState is IComponentDeltaState delta
-                        && compData.TryGetValue(change.NetID, out var old)) // May fail if relying on implicit data
+                    if (compState is not IComponentDeltaState delta)
                     {
-                        DebugTools.Assert(old is not IComponentDeltaState, "last state is not a full state");
-
-                        if (cloneDelta)
-                        {
-                            compState = delta.CreateNewFullState(old!);
-                        }
-                        else
-                        {
-                            delta.ApplyToFullState(old!);
-                            compState = old;
-                        }
-                        DebugTools.Assert(compState is not IComponentDeltaState, "newly constructed state is not a full state");
+                        compData[change.NetID] = compState;
+                        continue;
                     }
 
-                    compData[change.NetID] = compState;
+                    if (!compData.TryGetValue(change.NetID, out var old))
+                    {
+                        // Either the server needs to ensure that the initial state it sends to a client is a full
+                        // state, or the client needs to be able to construct an implicit full state (i.e., get-state
+                        // code needs to be in shared code).
+                        DebugTools.Assert("Received delta state without having received or constructed an implicit full state");
+                        continue;
+                    }
+
+                    DebugTools.Assert(old is not IComponentDeltaState, "last state is not a full state");
+
+                    if (!cloneDelta)
+                    {
+                        delta.ApplyToFullState(old!);
+                        continue;
+                    }
+
+                    var newFull = delta.CreateNewFullState(old!);
+                    compData[change.NetID] = newFull;
+                    DebugTools.Assert(newFull is not IComponentDeltaState, "constructed state is not a full state");
                 }
 
                 if (entityState.NetComponents == null)

--- a/Robust.Client/GameStates/GameStateProcessor.cs
+++ b/Robust.Client/GameStates/GameStateProcessor.cs
@@ -231,6 +231,8 @@ Had full state: {LastFullState != null}"
                         // Either the server needs to ensure that the initial state it sends to a client is a full
                         // state, or the client needs to be able to construct an implicit full state (i.e., get-state
                         // code needs to be in shared code).
+                        //
+                        // Without this, the client won't be able to reset predicted changes made to this component.
                         DebugTools.Assert("Received delta state without having received or constructed an implicit full state");
                         continue;
                     }

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -305,7 +305,7 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
 
     private void OnUserInterfaceGetState(Entity<UserInterfaceComponent> ent, ref ComponentGetState args)
     {
-        if (ent.Comp.LastFieldUpdate >= args.FromTick)
+        if (args.FromTick > ent.Comp.CreationTick && ent.Comp.LastFieldUpdate >= args.FromTick)
         {
             var fields = EntityManager.GetModifiedFields(ent.Comp, args.FromTick);
 


### PR DESCRIPTION
This is an attempt to try fix #5928

I'm not really sure what caused it, but I suspect it was due to the lack of a `args.FromTick > ent.Comp.CreationTick` check in `OnUserInterfaceGetState`, which is usually added by the source generator. I also reorganized the logic in `GameStateProcessor` and added a new debug assert which might help if it happens again.