### PR TITLE
Fix bug wrapping wide utf16 characters in RichTextLabel

### DIFF
--- a/Robust.Client/UserInterface/WordWrap.cs
+++ b/Robust.Client/UserInterface/WordWrap.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.Contracts;
 using System.Text;
 using Robust.Client.Graphics;
@@ -36,10 +36,18 @@ internal struct WordWrap
         LastRune = new Rune('A');
     }
 
+    /// <summary>
+    /// Add <paramref name="rune" /> as the next glyph in the sequence and update internal line break state.
+    /// </summary>
+    /// <param name="breakLine">If non-null, indicates that a line break needs to be added at this rune
+    /// index within the string. This index will refer to the offset of a previously-entered rune</param>
+    /// <param name="breakNewLine">If non-null, indicates the rune index of an entered newline</param>
+    /// <param name="skip">If true, indicates that the rune should occupy zero space. Currently only used
+    /// for newlines.</param>
     public void NextRune(Rune rune, out int? breakLine, out int? breakNewLine, out bool skip)
     {
         BreakIndexCounter = NextBreakIndexCounter;
-        NextBreakIndexCounter += rune.Utf16SequenceLength;
+        NextBreakIndexCounter += 1;
 
         breakLine = null;
         breakNewLine = null;


### PR DESCRIPTION
Fixes a bug when UI elements attempt to wrap text which contains wide UTF16 characters (i.e. characters which require more than two bytes).

The bug arises because Robust.Clinet.WordWrap calculates line breaks and outputs those locations at offsets of the rune's Utf16SequenceLength. However, when applying those line breaks, the Robust.Client.UserInterface.RichTextEntry uses the rune index. If a string contains characters whose Utf16SequenceLength is not 1, it applies breaks at the wrong location.

Demo before this change:

https://github.com/user-attachments/assets/6b61b975-a0f3-45c8-bd82-15dc0a5342ec

And after:


https://github.com/user-attachments/assets/f01a69cd-190a-4d98-a49f-ed81c5ddc072

In both instances, I've just got a RichTextLabel whose Text is:

> This UI is all one single RichTextLabel. In the following paragraph, I'm going to use the character OSAGE CAPITAL LETTER TSHA, which shows as a question mark here as it's not in the default NotoSans font.\n\nDEMO:\n\n𐓌𐓌𐓌𐓌𐓌𐓌𐓌𐓌𐓌𐓌𐓌𐓌 and now we fail to wrap this line correctly!\n\nThis sentence is is all one line and is preceeded by two line breaks. But due to the bug, we end up applying the line breaks in all the wrong places -- manual line breaks have been ignored, new breaks have been added at places where the text didn't need wrapping!
