### PR TITLE
Better color API

### DIFF
--- a/Robust.Client/Console/Completions.cs
+++ b/Robust.Client/Console/Completions.cs
@@ -85,7 +85,7 @@ namespace Robust.Client.Console
                 MouseFilter = MouseFilterMode.Stop;
                 Result = result;
                 var compl = new FormattedMessage();
-                var dim = Color.FromHsl(new Vector4(0f, 0f, 0.8f, 1f));
+                var dim = new Color(204, 204, 204, 255);
 
                 // warning: ew ahead
                 string basen = "default";

--- a/Robust.Client/UserInterface/Controls/ColorSelectorSliders.cs
+++ b/Robust.Client/UserInterface/Controls/ColorSelectorSliders.cs
@@ -5,6 +5,7 @@ using Robust.Shared.ColorNaming;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Maths;
+using Robust.Shared.Maths.Colors;
 
 namespace Robust.Client.UserInterface.Controls;
 
@@ -447,8 +448,8 @@ public sealed class ColorSelectorSliders : Control
         public override ColorSelectorStyleBox.ColorSliderPreset BottomSliderStyle
             => ColorSelectorStyleBox.ColorSliderPreset.Value;
 
-        public override Vector4 ToColorData(Color color) => Color.ToHsv(color);
-        public override Color FromColorData(Vector4 colorData) => Color.FromHsv(colorData);
+        public override Vector4 ToColorData(Color color) => color.ToColors().ToHsv().AsVector;
+        public override Color FromColorData(Vector4 colorData) => new HsvColor(colorData).ToSrgb().ToColor();
 
         public override float GetColorValueDivisor(ColorSliderOrder order)
         {

--- a/Robust.Client/UserInterface/Controls/ColorSelectorSliders.cs
+++ b/Robust.Client/UserInterface/Controls/ColorSelectorSliders.cs
@@ -448,8 +448,8 @@ public sealed class ColorSelectorSliders : Control
         public override ColorSelectorStyleBox.ColorSliderPreset BottomSliderStyle
             => ColorSelectorStyleBox.ColorSliderPreset.Value;
 
-        public override Vector4 ToColorData(Color color) => color.ToColors().ToHsv().AsVector;
-        public override Color FromColorData(Vector4 colorData) => new HsvColor(colorData).ToSrgb().ToColor();
+        public override Vector4 ToColorData(Color color) => color.ToHsv().AsVector;
+        public override Color FromColorData(Vector4 colorData) => new HsvColor(colorData).ToColor();
 
         public override float GetColorValueDivisor(ColorSliderOrder order)
         {

--- a/Robust.Client/UserInterface/CustomControls/TextEditRopeViz.cs
+++ b/Robust.Client/UserInterface/CustomControls/TextEditRopeViz.cs
@@ -144,8 +144,8 @@ internal sealed class TextEditRopeViz : OSWindow
 
         static void InterpColors(Span<Color> colors, Color α, Color β)
         {
-            var a = α.ToColors().ToLinear();
-            var b = β.ToColors().ToLinear();
+            var a = α.ToLinear();
+            var b = β.ToLinear();
 
             for (var i = 0; i < colors.Length; i++)
             {

--- a/Robust.Client/UserInterface/CustomControls/TextEditRopeViz.cs
+++ b/Robust.Client/UserInterface/CustomControls/TextEditRopeViz.cs
@@ -4,6 +4,7 @@ using Robust.Client.Graphics;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Input;
 using Robust.Shared.Maths;
+using Robust.Shared.Maths.Colors;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -143,16 +144,16 @@ internal sealed class TextEditRopeViz : OSWindow
 
         static void InterpColors(Span<Color> colors, Color α, Color β)
         {
-            α = Color.FromSrgb(α);
-            β = Color.FromSrgb(β);
+            var a = α.ToColors().ToLinear();
+            var b = β.ToColors().ToLinear();
 
             for (var i = 0; i < colors.Length; i++)
             {
                 var λ = (float)i / (colors.Length - 1);
 
-                var color = Color.InterpolateBetween(α, β, λ);
+                var color = LinearSrgbColor.InterpolateBetween(a, b, λ);
 
-                colors[i] = Color.ToSrgb(color);
+                colors[i] = color.ToSrgb().ToColor();
             }
         }
 

--- a/Robust.Client/UserInterface/CustomControls/TextEditRopeViz.cs
+++ b/Robust.Client/UserInterface/CustomControls/TextEditRopeViz.cs
@@ -153,7 +153,7 @@ internal sealed class TextEditRopeViz : OSWindow
 
                 var color = LinearSrgbColor.InterpolateBetween(a, b, λ);
 
-                colors[i] = color.ToSrgb().ToColor();
+                colors[i] = color.ToColor();
             }
         }
 

--- a/Robust.Shared.Maths/Color.cs
+++ b/Robust.Shared.Maths/Color.cs
@@ -390,6 +390,7 @@ namespace Robust.Shared.Maths
         ///     Alpha (which is copied to the output's Alpha value).
         ///     Each has a range of 0.0 to 1.0.
         /// </param>
+        [Obsolete("Use Colors API instead")]
         public static Color FromHsl(Vector4 hsl)
         {
             var hue = (hsl.X - MathF.Truncate(hsl.X)) * 360.0f;
@@ -459,6 +460,7 @@ namespace Robust.Shared.Maths
         ///     Each has a range of 0.0 to 1.0.
         /// </returns>
         /// <param name="rgb">Color value to convert.</param>
+        [Obsolete("Use Colors API instead")]
         [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
         public static Vector4 ToHsl(Color rgb)
         {
@@ -502,6 +504,7 @@ namespace Robust.Shared.Maths
         ///     (which is copied to the output's Alpha value).
         ///     Each has a range of 0.0 to 1.0.
         /// </param>
+        [Obsolete("Use Colors API instead")]
         public static Color FromHsv(Vector4 hsv)
         {
             var hue = (hsv.X - MathF.Truncate(hsv.X)) * 360.0f;
@@ -571,6 +574,7 @@ namespace Robust.Shared.Maths
         ///     Each has a range of 0.0 to 1.0.
         /// </returns>
         /// <param name="rgb">Color value to convert.</param>
+        [Obsolete("Use Colors API instead")]
         [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
         public static Vector4 ToHsv(Color rgb)
         {
@@ -636,6 +640,7 @@ namespace Robust.Shared.Maths
         ///     L and Alpha have a range of 0 to 1, while a and b are unbounded, but roughly -0.5 to 0.5
         /// </returns>
         /// <param name="srgb">Linear sRGB color value to convert. <see cref="FromSrgb"/> to convert an sRGB color into linear sRGB.</param>
+        [Obsolete("Use Colors API instead")]
         public static Vector4 ToLab(Color srgb)
         {
             // convert from srgb to linear lms
@@ -667,6 +672,7 @@ namespace Robust.Shared.Maths
         ///     Returns the converted color value. <see cref="ToSrgb"/> to convert an sRGB color into linear sRGB.
         /// </returns>
         /// <param name="oklab">Oklab color value to convert.</param>
+        [Obsolete("Use Colors API instead")]
         public static Color FromLab(Vector4 oklab)
         {
             var l_ = oklab.X + 0.3963377774f * oklab.Y + 0.2158037573f * oklab.Z;
@@ -695,6 +701,7 @@ namespace Robust.Shared.Maths
         ///     Returns the converted color value.
         /// </returns>
         /// <param name="oklab">Oklab color value to convert.</param>
+        [Obsolete("Use Colors API instead")]
         public static Vector4 ToLch(Vector4 oklab)
         {
             var c = MathF.Sqrt(oklab.Y * oklab.Y + oklab.Z * oklab.Z);
@@ -712,6 +719,7 @@ namespace Robust.Shared.Maths
         ///     Returns the converted color value.
         /// </returns>
         /// <param name="oklch">Oklch color value to convert.</param>
+        [Obsolete("Use Colors API instead")]
         public static Vector4 FromLch(Vector4 oklch)
         {
             var a = oklch.Y * MathF.Cos(oklch.Z);
@@ -733,6 +741,7 @@ namespace Robust.Shared.Maths
         ///     Each has a range of 0.0 to 1.0.
         /// </param>
         /// <remarks>Uses the CIE XYZ colorspace.</remarks>
+        [Obsolete("This implementation of CIEXYZ is incorrect. Use Colors API instead for correct CIEXYZ handling.")]
         public static Color FromXyz(Vector4 xyz)
         {
             var r = 0.41847f * xyz.X + -0.15866f * xyz.Y + -0.082835f * xyz.Z;
@@ -751,6 +760,7 @@ namespace Robust.Shared.Maths
         /// </returns>
         /// <param name="rgb">Color value to convert.</param>
         /// <remarks>Uses the CIE XYZ colorspace.</remarks>
+        [Obsolete("This implementation of CIEXYZ is incorrect. Use Colors API instead for correct CIEXYZ handling.")]
         public static Vector4 ToXyz(Color rgb)
         {
             var x = (0.49f * rgb.R + 0.31f * rgb.G + 0.20f * rgb.B) / 0.17697f;
@@ -772,6 +782,7 @@ namespace Robust.Shared.Maths
         ///     to the output's Alpha value).
         /// </param>
         /// <remarks>Converts using ITU-R BT.601/CCIR 601 W(r) = 0.299 W(b) = 0.114 U(max) = 0.436 V(max) = 0.615.</remarks>
+        [Obsolete("Use Colors API instead")]
         public static Color FromYcbcr(Vector4 ycbcr)
         {
             var r = 1.0f * ycbcr.X + 0.0f * ycbcr.Y + 1.402f * ycbcr.Z;
@@ -792,6 +803,7 @@ namespace Robust.Shared.Maths
         /// </returns>
         /// <param name="rgb">Color value to convert.</param>
         /// <remarks>Converts using ITU-R BT.601/CCIR 601 W(r) = 0.299 W(b) = 0.114 U(max) = 0.436 V(max) = 0.615.</remarks>
+        [Obsolete("Use Colors API instead")]
         public static Vector4 ToYcbcr(Color rgb)
         {
             var y = 0.299f * rgb.R + 0.587f * rgb.G + 0.114f * rgb.B;

--- a/Robust.Shared.Maths/Color.cs
+++ b/Robust.Shared.Maths/Color.cs
@@ -308,6 +308,12 @@ namespace Robust.Shared.Maths
             return new(R, G, B, (float) newA / byte.MaxValue);
         }
 
+        /// <summary>
+        ///     Casts a sRGB Color value to a SrgbColor value.
+        /// </summary>
+        /// <remarks>
+        ///     This expects sRGB, not Linear sRGB which is also represented via Color.
+        /// </remarks>
         public readonly SrgbColor ToColors()
         {
             return new SrgbColor(R, G, B, A);

--- a/Robust.Shared.Maths/Color.cs
+++ b/Robust.Shared.Maths/Color.cs
@@ -33,6 +33,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using JetBrains.Annotations;
+using Robust.Shared.Maths.Colors;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.Maths
@@ -305,6 +306,11 @@ namespace Robust.Shared.Maths
         public readonly Color WithAlpha(byte newA)
         {
             return new(R, G, B, (float) newA / byte.MaxValue);
+        }
+
+        public readonly SrgbColor ToColors()
+        {
+            return new SrgbColor(R, G, B, A);
         }
 
         /// <summary>

--- a/Robust.Shared.Maths/Color.cs
+++ b/Robust.Shared.Maths/Color.cs
@@ -320,6 +320,65 @@ namespace Robust.Shared.Maths
         }
 
         /// <summary>
+        ///     Converts a sRGB Color value to a LinearSrgbColor value.
+        /// </summary>
+        /// <remarks>
+        ///     This expects sRGB, not Linear sRGB which is also represented via Color.
+        /// </remarks>
+        public readonly LinearSrgbColor ToLinear()
+        {
+            return ToColors().ToLinear();
+        }
+
+        /// <summary>
+        ///     Converts a sRGB Color value to a CiexyzColor value.
+        /// </summary>
+        public readonly CiexyzColor ToXyz()
+        {
+            return ToColors().ToLinear().ToCiexyz();
+        }
+
+        /// <summary>
+        ///     Converts a sRGB Color value to a HslColor value.
+        /// </summary>
+        public readonly HslColor ToHsl()
+        {
+            return ToColors().ToHsl();
+        }
+
+        /// <summary>
+        ///     Converts a sRGB Color value to a HsvColor value.
+        /// </summary>
+        public readonly HsvColor ToHsv()
+        {
+            return ToColors().ToHsv();
+        }
+
+        /// <summary>
+        ///     Converts a sRGB Color value to an OklabColor value.
+        /// </summary>
+        public readonly OklabColor ToLab()
+        {
+            return ToColors().ToLinear().ToOklab();
+        }
+
+        /// <summary>
+        ///     Converts a sRGB Color value to an OklchColor value.
+        /// </summary>
+        public readonly OklchColor ToLch()
+        {
+            return ToColors().ToLinear().ToOklab().ToOklch();
+        }
+
+        /// <summary>
+        ///     Converts a sRGB Color value to an SyccColor value.
+        /// </summary>
+        public readonly SyccColor ToYcbcr()
+        {
+            return ToColors().ToSycc();
+        }
+
+        /// <summary>
         ///     Converts sRGB color values to linear RGB color values.
         /// </summary>
         /// <returns>

--- a/Robust.Shared.Maths/Colors/CiexyzColor.cs
+++ b/Robust.Shared.Maths/Colors/CiexyzColor.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Robust.Shared.Utility;
 
@@ -34,6 +36,26 @@ public struct CiexyzColor : IEquatable<CiexyzColor>, ISpanFormattable
         float b = +0.0557101f * X - 0.2040211f * Y + 1.0569959f * Z;
 
         return new LinearSrgbColor(r, g, b, Alpha);
+    }
+
+    private readonly Vector4 AsVector => Unsafe.BitCast<CiexyzColor, Vector4>(this);
+
+    /// <summary>
+    ///     Interpolate two colors with a lambda, AKA returning the two colors combined with a ratio of
+    ///     <paramref name="λ" />.
+    /// </summary>
+    /// <param name="α"></param>
+    /// <param name="β"></param>
+    /// <param name="λ">
+    ///     A value ranging from 0-1. The higher the value the more is taken from <paramref name="β" />,
+    ///     with 0.5 being 50% of both colors, 0.25 being 25% of <paramref name="β" /> and 75%
+    ///     <paramref name="α" />.
+    /// </param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static CiexyzColor InterpolateBetween(CiexyzColor α, CiexyzColor β, float λ)
+    {
+        var result = Vector4.Lerp(α.AsVector, β.AsVector, λ);
+        return new(result.X, result.Y, result.Z, result.W);
     }
 
     public static bool operator ==(CiexyzColor left, CiexyzColor right)

--- a/Robust.Shared.Maths/Colors/CiexyzColor.cs
+++ b/Robust.Shared.Maths/Colors/CiexyzColor.cs
@@ -44,6 +44,13 @@ public struct CiexyzColor : IEquatable<CiexyzColor>, ISpanFormattable
         return new LinearSrgbColor(r, g, b, Alpha);
     }
 
+    /// <summary>
+    ///     Converts a CiexyzColor value to a sRGB Color value.
+    /// </summary>
+    public readonly Color ToColor()
+    {
+        return ToLinear().ToSrgb().ToColor();
+    }
 
     /// <summary>
     ///     Interpolate two colors with a lambda, AKA returning the two colors combined with a ratio of

--- a/Robust.Shared.Maths/Colors/CiexyzColor.cs
+++ b/Robust.Shared.Maths/Colors/CiexyzColor.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Runtime.InteropServices;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Maths.Colors;
+
+/// <summary>
+///     Represents a color with alpha in the CIEXYZ colorspace.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct CiexyzColor : IEquatable<CiexyzColor>, ISpanFormattable
+{
+    public float X;
+    public float Y;
+    public float Z;
+    public float Alpha;
+
+    public CiexyzColor(float x, float y, float z, float alpha)
+    {
+        X = x;
+        Y = y;
+        Z = z;
+        Alpha = alpha;
+    }
+
+    /// <summary>
+    ///     Converts CIEXYZ color values to Linear sRGB color values.
+    /// </summary>
+    public readonly LinearSrgbColor ToLinear()
+    {
+        float r = +3.2406255f * X - 1.5372080f * Y - 0.4986286f * Z;
+        float g = -0.9689307f * X + 1.8757561f * Y + 0.0415175f * Z;
+        float b = +0.0557101f * X - 0.2040211f * Y + 1.0569959f * Z;
+
+        return new LinearSrgbColor(r, g, b, Alpha);
+    }
+
+    public static bool operator ==(CiexyzColor left, CiexyzColor right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(CiexyzColor left, CiexyzColor right)
+    {
+        return !left.Equals(right);
+    }
+
+    public readonly override bool Equals(object? obj)
+    {
+        if (!(obj is CiexyzColor))
+            return false;
+
+        return Equals((CiexyzColor)obj);
+    }
+
+    public readonly bool Equals(CiexyzColor other)
+            => X == other.X && Y == other.Y && Z == other.Z && Alpha == other.Alpha;
+
+    public readonly override string ToString()
+    {
+        return $"ciexyz({X}, {Y}, {Z}, {Alpha})";
+    }
+
+    public readonly override int GetHashCode()
+    {
+        return (int)(((uint)(Alpha * byte.MaxValue) << 24) |
+                ((uint)(X * byte.MaxValue) << 16) |
+                ((uint)(Y * byte.MaxValue) << 8) |
+                (uint)(Z * byte.MaxValue));
+    }
+
+    public readonly string ToString(string? format, IFormatProvider? formatProvider)
+    {
+        return ToString();
+    }
+
+    public readonly bool TryFormat(
+        Span<char> destination,
+        out int charsWritten,
+        ReadOnlySpan<char> format,
+        IFormatProvider? provider)
+    {
+        return FormatHelpers.TryFormatInto(
+            destination,
+            out charsWritten,
+            $"ciexyz({X}, {Y}, {Z}, {Alpha})");
+    }
+}

--- a/Robust.Shared.Maths/Colors/CiexyzColor.cs
+++ b/Robust.Shared.Maths/Colors/CiexyzColor.cs
@@ -17,6 +17,12 @@ public struct CiexyzColor : IEquatable<CiexyzColor>, ISpanFormattable
     public float Y;
     public float Z;
     public float Alpha;
+    public readonly Vector4 AsVector => Unsafe.BitCast<CiexyzColor, Vector4>(this);
+
+    public CiexyzColor(in Vector4 vec)
+    {
+        this = Unsafe.BitCast<Vector4, CiexyzColor>(vec);
+    }
 
     public CiexyzColor(float x, float y, float z, float alpha)
     {
@@ -38,7 +44,6 @@ public struct CiexyzColor : IEquatable<CiexyzColor>, ISpanFormattable
         return new LinearSrgbColor(r, g, b, Alpha);
     }
 
-    private readonly Vector4 AsVector => Unsafe.BitCast<CiexyzColor, Vector4>(this);
 
     /// <summary>
     ///     Interpolate two colors with a lambda, AKA returning the two colors combined with a ratio of

--- a/Robust.Shared.Maths/Colors/HslColor.cs
+++ b/Robust.Shared.Maths/Colors/HslColor.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Runtime.InteropServices;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Maths.Colors;
+
+/// <summary>
+///     Represents a color with alpha in the HSL transformation of sRGB colorspace.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct HslColor : IEquatable<HslColor>, ISpanFormattable
+{
+    public float Hue;
+    public float Saturation;
+    public float Lightness;
+    public float Alpha;
+
+    public HslColor(float r, float g, float b, float a)
+    {
+        Hue = r;
+        Saturation = g;
+        Lightness = b;
+        Alpha = a;
+    }
+
+    /// <summary>
+    ///     Converts HSL color values to RGB color values.
+    /// </summary>
+    public readonly SrgbColor ToSrgb()
+    {
+        var hue = (Hue - MathF.Truncate(Hue)) * 360.0f;
+
+        var c = (1.0f - MathF.Abs(2.0f * Lightness - 1.0f)) * Saturation;
+
+        var h = hue / 60.0f;
+        var X = c * (1.0f - MathF.Abs(h % 2.0f - 1.0f));
+
+        float r, g, b;
+        if (0.0f <= h && h < 1.0f)
+        {
+            r = c;
+            g = X;
+            b = 0.0f;
+        }
+        else if (1.0f <= h && h < 2.0f)
+        {
+            r = X;
+            g = c;
+            b = 0.0f;
+        }
+        else if (2.0f <= h && h < 3.0f)
+        {
+            r = 0.0f;
+            g = c;
+            b = X;
+        }
+        else if (3.0f <= h && h < 4.0f)
+        {
+            r = 0.0f;
+            g = X;
+            b = c;
+        }
+        else if (4.0f <= h && h < 5.0f)
+        {
+            r = X;
+            g = 0.0f;
+            b = c;
+        }
+        else if (5.0f <= h && h < 6.0f)
+        {
+            r = c;
+            g = 0.0f;
+            b = X;
+        }
+        else
+        {
+            r = 0.0f;
+            g = 0.0f;
+            b = 0.0f;
+        }
+
+        var m = Lightness - c / 2.0f;
+        return new SrgbColor(r + m, g + m, b + m, Alpha);
+    }
+
+    public static bool operator ==(HslColor left, HslColor right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(HslColor left, HslColor right)
+    {
+        return !left.Equals(right);
+    }
+
+    public readonly override bool Equals(object? obj)
+    {
+        if (!(obj is HslColor))
+            return false;
+
+        return Equals((HslColor)obj);
+    }
+
+    public readonly bool Equals(HslColor other)
+            => Hue == other.Hue && Saturation == other.Saturation && Lightness == other.Lightness && Alpha == other.Alpha;
+
+    public readonly override string ToString()
+    {
+        return $"hsl({Hue}, {Saturation}, {Lightness}, {Alpha})";
+    }
+
+    public readonly override int GetHashCode()
+    {
+        return (int) (((uint) (Alpha * byte.MaxValue) << 24) |
+                ((uint) (Hue * byte.MaxValue) << 16) |
+                ((uint) (Saturation * byte.MaxValue) << 8) |
+                (uint) (Lightness * byte.MaxValue));
+    }
+
+    public readonly string ToString(string? format, IFormatProvider? formatProvider)
+    {
+        return ToString();
+    }
+
+    public readonly bool TryFormat(
+        Span<char> destination,
+        out int charsWritten,
+        ReadOnlySpan<char> format,
+        IFormatProvider? provider)
+    {
+        return FormatHelpers.TryFormatInto(
+            destination,
+            out charsWritten,
+            $"hsl({Hue}, {Saturation}, {Lightness}, {Alpha})");
+    }
+}

--- a/Robust.Shared.Maths/Colors/HslColor.cs
+++ b/Robust.Shared.Maths/Colors/HslColor.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Robust.Shared.Utility;
 
@@ -15,7 +17,12 @@ public struct HslColor : IEquatable<HslColor>, ISpanFormattable
     public float Saturation;
     public float Lightness;
     public float Alpha;
+    public readonly Vector4 AsVector => Unsafe.BitCast<HslColor, Vector4>(this);
 
+    public HslColor(in Vector4 vec)
+    {
+        this = Unsafe.BitCast<Vector4, HslColor>(vec);
+    }
     public HslColor(float h, float s, float l, float a)
     {
         Hue = h;

--- a/Robust.Shared.Maths/Colors/HslColor.cs
+++ b/Robust.Shared.Maths/Colors/HslColor.cs
@@ -16,11 +16,11 @@ public struct HslColor : IEquatable<HslColor>, ISpanFormattable
     public float Lightness;
     public float Alpha;
 
-    public HslColor(float r, float g, float b, float a)
+    public HslColor(float h, float s, float l, float a)
     {
-        Hue = r;
-        Saturation = g;
-        Lightness = b;
+        Hue = h;
+        Saturation = s;
+        Lightness = l;
         Alpha = a;
     }
 

--- a/Robust.Shared.Maths/Colors/HslColor.cs
+++ b/Robust.Shared.Maths/Colors/HslColor.cs
@@ -91,6 +91,14 @@ public struct HslColor : IEquatable<HslColor>, ISpanFormattable
         return new SrgbColor(r + m, g + m, b + m, Alpha);
     }
 
+    /// <summary>
+    ///     Converts a HslColor value to a sRGB Color value.
+    /// </summary>
+    public readonly Color ToColor()
+    {
+        return ToSrgb().ToColor();
+    }
+
     public static bool operator ==(HslColor left, HslColor right)
     {
         return left.Equals(right);

--- a/Robust.Shared.Maths/Colors/HsvColor.cs
+++ b/Robust.Shared.Maths/Colors/HsvColor.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Runtime.InteropServices;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Maths.Colors;
+
+/// <summary>
+///     Represents a color with alpha in the HSV transformation of sRGB colorspace.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct HsvColor : IEquatable<HsvColor>, ISpanFormattable
+{
+    public float Hue;
+    public float Saturation;
+    public float Value;
+    public float Alpha;
+
+    public HsvColor(float r, float g, float b, float a)
+    {
+        Hue = r;
+        Saturation = g;
+        Value = b;
+        Alpha = a;
+    }
+
+    /// <summary>
+    ///     Converts HSV color values to RGB color values.
+    /// </summary>
+    public readonly SrgbColor ToSrgb()
+    {
+        var hue = (Hue - MathF.Truncate(Hue)) * 360.0f;
+
+        var c = Value * Saturation;
+
+        var h = hue / 60.0f;
+        var x = c * (1.0f - MathF.Abs(h % 2.0f - 1.0f));
+
+        float r, g, b;
+        if (0.0f <= h && h < 1.0f)
+        {
+            r = c;
+            g = x;
+            b = 0.0f;
+        }
+        else if (1.0f <= h && h < 2.0f)
+        {
+            r = x;
+            g = c;
+            b = 0.0f;
+        }
+        else if (2.0f <= h && h < 3.0f)
+        {
+            r = 0.0f;
+            g = c;
+            b = x;
+        }
+        else if (3.0f <= h && h < 4.0f)
+        {
+            r = 0.0f;
+            g = x;
+            b = c;
+        }
+        else if (4.0f <= h && h < 5.0f)
+        {
+            r = x;
+            g = 0.0f;
+            b = c;
+        }
+        else if (5.0f <= h && h < 6.0f)
+        {
+            r = c;
+            g = 0.0f;
+            b = x;
+        }
+        else
+        {
+            r = 0.0f;
+            g = 0.0f;
+            b = 0.0f;
+        }
+
+        var m = Value - c;
+        return new SrgbColor(r + m, g + m, b + m, Alpha);
+    }
+
+    public static bool operator ==(HsvColor left, HsvColor right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(HsvColor left, HsvColor right)
+    {
+        return !left.Equals(right);
+    }
+
+    public readonly override bool Equals(object? obj)
+    {
+        if (!(obj is HsvColor))
+            return false;
+
+        return Equals((HsvColor)obj);
+    }
+
+    public readonly bool Equals(HsvColor other)
+            => Hue == other.Hue && Saturation == other.Saturation && Value == other.Value && Alpha == other.Alpha;
+
+    public readonly override string ToString()
+    {
+        return $"hsv({Hue}, {Saturation}, {Value}, {Alpha})";
+    }
+
+    public readonly override int GetHashCode()
+    {
+        return (int) (((uint) (Alpha * byte.MaxValue) << 24) |
+                ((uint) (Hue * byte.MaxValue) << 16) |
+                ((uint) (Saturation * byte.MaxValue) << 8) |
+                (uint) (Value * byte.MaxValue));
+    }
+
+    public readonly string ToString(string? format, IFormatProvider? formatProvider)
+    {
+        return ToString();
+    }
+
+    public readonly bool TryFormat(
+        Span<char> destination,
+        out int charsWritten,
+        ReadOnlySpan<char> format,
+        IFormatProvider? provider)
+    {
+        return FormatHelpers.TryFormatInto(
+            destination,
+            out charsWritten,
+            $"hsv({Hue}, {Saturation}, {Value}, {Alpha})");
+    }
+}

--- a/Robust.Shared.Maths/Colors/HsvColor.cs
+++ b/Robust.Shared.Maths/Colors/HsvColor.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Robust.Shared.Utility;
 
@@ -15,6 +17,12 @@ public struct HsvColor : IEquatable<HsvColor>, ISpanFormattable
     public float Saturation;
     public float Value;
     public float Alpha;
+    public readonly Vector4 AsVector => Unsafe.BitCast<HsvColor, Vector4>(this);
+
+    public HsvColor(in Vector4 vec)
+    {
+        this = Unsafe.BitCast<Vector4, HsvColor>(vec);
+    }
 
     public HsvColor(float h, float s, float v, float a)
     {

--- a/Robust.Shared.Maths/Colors/HsvColor.cs
+++ b/Robust.Shared.Maths/Colors/HsvColor.cs
@@ -92,6 +92,14 @@ public struct HsvColor : IEquatable<HsvColor>, ISpanFormattable
         return new SrgbColor(r + m, g + m, b + m, Alpha);
     }
 
+    /// <summary>
+    ///     Converts a HsvColor value to a sRGB Color value.
+    /// </summary>
+    public readonly Color ToColor()
+    {
+        return ToSrgb().ToColor();
+    }
+
     public static bool operator ==(HsvColor left, HsvColor right)
     {
         return left.Equals(right);

--- a/Robust.Shared.Maths/Colors/HsvColor.cs
+++ b/Robust.Shared.Maths/Colors/HsvColor.cs
@@ -16,11 +16,11 @@ public struct HsvColor : IEquatable<HsvColor>, ISpanFormattable
     public float Value;
     public float Alpha;
 
-    public HsvColor(float r, float g, float b, float a)
+    public HsvColor(float h, float s, float v, float a)
     {
-        Hue = r;
-        Saturation = g;
-        Value = b;
+        Hue = h;
+        Saturation = s;
+        Value = v;
         Alpha = a;
     }
 

--- a/Robust.Shared.Maths/Colors/LinearSrgbColor.cs
+++ b/Robust.Shared.Maths/Colors/LinearSrgbColor.cs
@@ -17,10 +17,16 @@ public struct LinearSrgbColor : IEquatable<LinearSrgbColor>, ISpanFormattable
     public float Green;
     public float Blue;
     public float Alpha;
+    public readonly Vector4 AsVector => Unsafe.BitCast<LinearSrgbColor, Vector4>(this);
 
     public readonly bool IsInGamut
     {
         get => Red <= 1 && Green <= 1 && Blue <= 1 && Red >= 0 && Green >= 0 && Blue >= 0;
+    }
+
+    public LinearSrgbColor(in Vector4 vec)
+    {
+        this = Unsafe.BitCast<Vector4, LinearSrgbColor>(vec);
     }
 
     public LinearSrgbColor(float r, float g, float b, float a)
@@ -94,8 +100,6 @@ public struct LinearSrgbColor : IEquatable<LinearSrgbColor>, ISpanFormattable
 
         return new CiexyzColor(x, y, z, Alpha);
     }
-
-    private readonly Vector4 AsVector => Unsafe.BitCast<LinearSrgbColor, Vector4>(this);
 
     /// <summary>
     ///     Interpolate two colors with a lambda, AKA returning the two colors combined with a ratio of

--- a/Robust.Shared.Maths/Colors/LinearSrgbColor.cs
+++ b/Robust.Shared.Maths/Colors/LinearSrgbColor.cs
@@ -76,6 +76,18 @@ public struct LinearSrgbColor : IEquatable<LinearSrgbColor>, ISpanFormattable
         );
     }
 
+    /// <summary>
+    ///     Converts Linear sRGB color values to CIEXYZ color values.
+    /// </summary>
+    public readonly CiexyzColor ToCiexyz()
+    {
+        float x = +0.4124f * Red + 0.3576f * Green + 0.1805f * Blue;
+        float y = +0.2126f * Red + 0.7152f * Green + 0.0722f * Blue;
+        float z = +0.0193f * Red + 0.1192f * Green + 0.9505f * Blue;
+
+        return new CiexyzColor(x, y, z, Alpha);
+    }
+
     public static bool operator ==(LinearSrgbColor left, LinearSrgbColor right)
     {
         return left.Equals(right);

--- a/Robust.Shared.Maths/Colors/LinearSrgbColor.cs
+++ b/Robust.Shared.Maths/Colors/LinearSrgbColor.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Runtime.InteropServices;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Maths.Colors;
+
+/// <summary>
+///     Represents a color with alpha in the Linear sRGB colorspace.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct LinearSrgbColor : IEquatable<LinearSrgbColor>, ISpanFormattable
+{
+    public float Red;
+    public float Green;
+    public float Blue;
+    public float Alpha;
+
+    public LinearSrgbColor(float r, float g, float b, float a)
+    {
+        Red = r;
+        Green = g;
+        Blue = b;
+        Alpha = a;
+    }
+
+    /// <summary>
+    ///     Converts linear RGB color values to sRGB color values.
+    /// </summary>
+    public readonly SrgbColor ToSrgb()
+    {
+        float r, g, b;
+
+        if (Red <= 0.0031308)
+            r = 12.92f * Red;
+        else
+            r = (1.0f + 0.055f) * MathF.Pow(Red, 1.0f / 2.4f) - 0.055f;
+
+        if (Green <= 0.0031308)
+            g = 12.92f * Green;
+        else
+            g = (1.0f + 0.055f) * MathF.Pow(Green, 1.0f / 2.4f) - 0.055f;
+
+        if (Blue <= 0.0031308)
+            b = 12.92f * Blue;
+        else
+            b = (1.0f + 0.055f) * MathF.Pow(Blue, 1.0f / 2.4f) - 0.055f;
+
+        return new SrgbColor(r, g, b, Alpha);
+    }
+
+    /// <summary>
+    ///     Converts linear sRGB color values to Oklab color values.
+    /// </summary>
+    public readonly OklabColor ToOklab()
+    {
+        // convert from srgb to linear lms
+
+        var l = 0.4122214708f * Red + 0.5363325363f * Green + 0.0514459929f * Blue;
+        var m = 0.2119034982f * Red + 0.6806995451f * Green + 0.1073969566f * Blue;
+        var s = 0.0883024619f * Red + 0.2817188376f * Green + 0.6299787005f * Blue;
+
+        // convert from linear lms to non-linear lms
+
+        var l_ = MathF.Cbrt(l);
+        var m_ = MathF.Cbrt(m);
+        var s_ = MathF.Cbrt(s);
+
+        // convert from non-linear lms to lab
+
+        return new OklabColor(
+            0.2104542553f * l_ + 0.7936177850f * m_ - 0.0040720468f * s_,
+            1.9779984951f * l_ - 2.4285922050f * m_ + 0.4505937099f * s_,
+            0.0259040371f * l_ + 0.7827717662f * m_ - 0.8086757660f * s_,
+            Alpha
+        );
+    }
+
+    public static bool operator ==(LinearSrgbColor left, LinearSrgbColor right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(LinearSrgbColor left, LinearSrgbColor right)
+    {
+        return !left.Equals(right);
+    }
+
+    public readonly override bool Equals(object? obj)
+    {
+        if (!(obj is LinearSrgbColor))
+            return false;
+
+        return Equals((LinearSrgbColor)obj);
+    }
+
+    public readonly bool Equals(LinearSrgbColor other)
+            => Red == other.Red && Green == other.Green && Blue == other.Blue && Alpha == other.Alpha;
+
+    public readonly override string ToString()
+    {
+        return $"linear-rgba({Red}, {Green}, {Blue}, {Alpha})";
+    }
+
+    public readonly override int GetHashCode()
+    {
+        return (int)(((uint)(Alpha * byte.MaxValue) << 24) |
+                ((uint)(Red * byte.MaxValue) << 16) |
+                ((uint)(Green * byte.MaxValue) << 8) |
+                (uint)(Blue * byte.MaxValue));
+    }
+
+    public readonly string ToString(string? format, IFormatProvider? formatProvider)
+    {
+        return ToString();
+    }
+
+    public readonly bool TryFormat(
+        Span<char> destination,
+        out int charsWritten,
+        ReadOnlySpan<char> format,
+        IFormatProvider? provider)
+    {
+        return FormatHelpers.TryFormatInto(
+            destination,
+            out charsWritten,
+            $"linear-rgba({Red}, {Green}, {Blue}, {Alpha})");
+    }
+}

--- a/Robust.Shared.Maths/Colors/LinearSrgbColor.cs
+++ b/Robust.Shared.Maths/Colors/LinearSrgbColor.cs
@@ -102,6 +102,17 @@ public struct LinearSrgbColor : IEquatable<LinearSrgbColor>, ISpanFormattable
     }
 
     /// <summary>
+    ///     Converts a LinearSrgbColor value to a sRGB Color value.
+    /// </summary>
+    /// <remarks>
+    ///     This does NOT return a Linear sRGB Color. It converts the values to sRGB and returns a sRGB color. Do NOT use this if you want a Linear sRGB Color.
+    /// </remarks>
+    public readonly Color ToColor()
+    {
+        return ToSrgb().ToColor();
+    }
+
+    /// <summary>
     ///     Interpolate two colors with a lambda, AKA returning the two colors combined with a ratio of
     ///     <paramref name="λ" />.
     /// </summary>

--- a/Robust.Shared.Maths/Colors/OklabColor.Clipping.cs
+++ b/Robust.Shared.Maths/Colors/OklabColor.Clipping.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Numerics;
+
+namespace Robust.Shared.Maths.Colors;
+
+public partial struct OklabColor
+{
+    // Finds the maximum saturation possible for a given hue that fits in sRGB
+    // Saturation here is defined as S = C/L
+    // a and b must be normalized so a^2 + b^2 == 1
+    private static float ComputeMaxSaturation(float a, float b)
+    {
+        // Max saturation will be when one of r, g or b goes below zero.
+
+        // Select different coefficients depending on which component goes below zero first
+        float k0, k1, k2, k3, k4, wl, wm, ws;
+
+        if (-1.88170328f * a - 0.80936493f * b > 1)
+        {
+            // Red component
+            k0 = +1.19086277f; k1 = +1.76576728f; k2 = +0.59662641f; k3 = +0.75515197f; k4 = +0.56771245f;
+            wl = +4.0767416621f; wm = -3.3077115913f; ws = +0.2309699292f;
+        }
+        else if (1.81444104f * a - 1.19445276f * b > 1)
+        {
+            // Green component
+            k0 = +0.73956515f; k1 = -0.45954404f; k2 = +0.08285427f; k3 = +0.12541070f; k4 = +0.14503204f;
+            wl = -1.2684380046f; wm = +2.6097574011f; ws = -0.3413193965f;
+        }
+        else
+        {
+            // Blue component
+            k0 = +1.35733652f; k1 = -0.00915799f; k2 = -1.15130210f; k3 = -0.50559606f; k4 = +0.00692167f;
+            wl = -0.0041960863f; wm = -0.7034186147f; ws = +1.7076147010f;
+        }
+
+        // Approximate max saturation using a polynomial:
+        float S = k0 + k1 * a + k2 * b + k3 * a * a + k4 * a * b;
+
+        // Do one step Halley's method to get closer
+        // this gives an error less than 10e6, except for some blue hues where the dS/dh is close to infinite
+        // this should be sufficient for most applications, otherwise do two/three steps
+
+        float k_l = +0.3963377774f * a + 0.2158037573f * b;
+        float k_m = -0.1055613458f * a - 0.0638541728f * b;
+        float k_s = -0.0894841775f * a - 1.2914855480f * b;
+
+        {
+            float l_ = 1f + S * k_l;
+            float m_ = 1f + S * k_m;
+            float s_ = 1f + S * k_s;
+
+            float l = l_ * l_ * l_;
+            float m = m_ * m_ * m_;
+            float s = s_ * s_ * s_;
+
+            float l_dS = 3f * k_l * l_ * l_;
+            float m_dS = 3f * k_m * m_ * m_;
+            float s_dS = 3f * k_s * s_ * s_;
+
+            float l_dS2 = 6f * k_l * k_l * l_;
+            float m_dS2 = 6f * k_m * k_m * m_;
+            float s_dS2 = 6f * k_s * k_s * s_;
+
+            float f = wl * l + wm * m + ws * s;
+            float f1 = wl * l_dS + wm * m_dS + ws * s_dS;
+            float f2 = wl * l_dS2 + wm * m_dS2 + ws * s_dS2;
+
+            S = S - f * f1 / (f1 * f1 - 0.5f * f * f2);
+        }
+
+        return S;
+    }
+
+    private static Vector2 FindCusp(float a, float b)
+    {
+        // First, find the maximum saturation (saturation S = C/L)
+        float S_cusp = ComputeMaxSaturation(a, b);
+
+        // Convert to linear sRGB to find the first point where at least one of r,g or b >= 1:
+        var rgb_at_max = new OklabColor(1, S_cusp * a, S_cusp * b, 1).ToLinear();
+        float L_cusp = MathF.Cbrt(1f / MathF.Max(MathF.Max(rgb_at_max.Red, rgb_at_max.Green), rgb_at_max.Blue));
+        float C_cusp = L_cusp * S_cusp;
+
+        return new Vector2(L_cusp, C_cusp);
+    }
+
+    // Finds intersection of the line defined by
+    // L = L0 * (1 - t) + t * L1;
+    // C = t * C1;
+    // a and b must be normalized so a^2 + b^2 == 1
+    private static float FindGamutIntersection(float a, float b, float L1, float C1, float L0)
+    {
+        // Find the cusp of the gamut triangle
+        Vector2 cusp = FindCusp(a, b);
+
+        // Find the intersection for upper and lower half seprately
+        float t;
+        if (((L1 - L0) * cusp.Y - (cusp.X - L0) * C1) <= 0f)
+        {
+            // Lower half
+
+            t = cusp.Y * L0 / (C1 * cusp.X + cusp.Y * (L0 - L1));
+        }
+        else
+        {
+            // Upper half
+
+            // First intersect with triangle
+            t = cusp.Y * (L0 - 1f) / (C1 * (cusp.X - 1f) + cusp.Y * (L0 - L1));
+
+            // Then one step Halley's method
+            {
+                float dL = L1 - L0;
+                float dC = C1;
+
+                float k_l = +0.3963377774f * a + 0.2158037573f * b;
+                float k_m = -0.1055613458f * a - 0.0638541728f * b;
+                float k_s = -0.0894841775f * a - 1.2914855480f * b;
+
+                float l_dt = dL + dC * k_l;
+                float m_dt = dL + dC * k_m;
+                float s_dt = dL + dC * k_s;
+
+
+                // If higher accuracy is required, 2 or 3 iterations of the following block can be used:
+                {
+                    float L = L0 * (1f - t) + t * L1;
+                    float C = t * C1;
+
+                    float l_ = L + C * k_l;
+                    float m_ = L + C * k_m;
+                    float s_ = L + C * k_s;
+
+                    float l = l_ * l_ * l_;
+                    float m = m_ * m_ * m_;
+                    float s = s_ * s_ * s_;
+
+                    float ldt = 3 * l_dt * l_ * l_;
+                    float mdt = 3 * m_dt * m_ * m_;
+                    float sdt = 3 * s_dt * s_ * s_;
+
+                    float ldt2 = 6 * l_dt * l_dt * l_;
+                    float mdt2 = 6 * m_dt * m_dt * m_;
+                    float sdt2 = 6 * s_dt * s_dt * s_;
+
+                    float r = 4.0767416621f * l - 3.3077115913f * m + 0.2309699292f * s - 1;
+                    float r1 = 4.0767416621f * ldt - 3.3077115913f * mdt + 0.2309699292f * sdt;
+                    float r2 = 4.0767416621f * ldt2 - 3.3077115913f * mdt2 + 0.2309699292f * sdt2;
+
+                    float u_r = r1 / (r1 * r1 - 0.5f * r * r2);
+                    float t_r = -r * u_r;
+
+                    float g = -1.2684380046f * l + 2.6097574011f * m - 0.3413193965f * s - 1;
+                    float g1 = -1.2684380046f * ldt + 2.6097574011f * mdt - 0.3413193965f * sdt;
+                    float g2 = -1.2684380046f * ldt2 + 2.6097574011f * mdt2 - 0.3413193965f * sdt2;
+
+                    float u_g = g1 / (g1 * g1 - 0.5f * g * g2);
+                    float t_g = -g * u_g;
+
+                    float b0 = -0.0041960863f * l - 0.7034186147f * m + 1.7076147010f * s - 1;
+                    float b1 = -0.0041960863f * ldt - 0.7034186147f * mdt + 1.7076147010f * sdt;
+                    float b2 = -0.0041960863f * ldt2 - 0.7034186147f * mdt2 + 1.7076147010f * sdt2;
+
+                    float u_b = b1 / (b1 * b1 - 0.5f * b0 * b2);
+                    float t_b = -b0 * u_b;
+
+                    t_r = u_r >= 0f ? t_r : float.MaxValue;
+                    t_g = u_g >= 0f ? t_g : float.MaxValue;
+                    t_b = u_b >= 0f ? t_b : float.MaxValue;
+
+                    t += Math.Min(t_r, Math.Min(t_g, t_b));
+                }
+            }
+        }
+
+        return t;
+    }
+
+    public readonly OklabColor GamutClipPreserveChroma()
+    {
+        float eps = 0.00001f;
+        float C = Math.Max(eps, (float)Math.Sqrt(A * A + B * B));
+        float a_ = A / C;
+        float b_ = B / C;
+
+        float L0 = Math.Clamp(L, 0f, 1f);
+
+        float t = FindGamutIntersection(a_, b_, L, C, L0);
+        float L_clipped = L0 * (1 - t) + t * L;
+        float C_clipped = t * C;
+
+        return new OklabColor(L_clipped, C_clipped * a_, C_clipped * b_, Alpha);
+    }
+}

--- a/Robust.Shared.Maths/Colors/OklabColor.Clipping.cs
+++ b/Robust.Shared.Maths/Colors/OklabColor.Clipping.cs
@@ -201,6 +201,9 @@ public partial struct OklabColor
 
     public readonly OklabColor GamutClipPreserveChroma()
     {
+        if (ToLinear().IsInGamut)
+            return this;
+
         float eps = 0.00001f;
         float C = Math.Max(eps, (float)Math.Sqrt(A * A + B * B));
         float a_ = A / C;

--- a/Robust.Shared.Maths/Colors/OklabColor.Clipping.cs
+++ b/Robust.Shared.Maths/Colors/OklabColor.Clipping.cs
@@ -1,3 +1,25 @@
+// Adapted from https://bottosson.github.io/posts/gamutclipping/
+// MIT licensed, license below:
+// Copyright (c) 2021 Björn Ottosson
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using System.Numerics;
 

--- a/Robust.Shared.Maths/Colors/OklabColor.Clipping.cs
+++ b/Robust.Shared.Maths/Colors/OklabColor.Clipping.cs
@@ -217,4 +217,12 @@ public partial struct OklabColor
 
         return new OklabColor(L_clipped, C_clipped * a_, C_clipped * b_, Alpha);
     }
+
+    /// <summary>
+    ///     Converts a OklabColor value to a sRGB Color value, after doing gamut clipping.
+    /// </summary>
+    public readonly Color ToColorClipped()
+    {
+        return GamutClipPreserveChroma().ToLinear().ToSrgb().ToColor();
+    }
 }

--- a/Robust.Shared.Maths/Colors/OklabColor.cs
+++ b/Robust.Shared.Maths/Colors/OklabColor.cs
@@ -60,7 +60,7 @@ public partial struct OklabColor : IEquatable<OklabColor>, ISpanFormattable
     /// <summary>
     ///     Converts cartesian Oklab color values to polar Oklch color values.
     /// </summary>
-    public readonly OklchColor ToLch()
+    public readonly OklchColor ToOklch()
     {
         var c = MathF.Sqrt(A * A + B * B);
         var h = MathF.Atan2(B, A);

--- a/Robust.Shared.Maths/Colors/OklabColor.cs
+++ b/Robust.Shared.Maths/Colors/OklabColor.cs
@@ -79,6 +79,17 @@ public partial struct OklabColor : IEquatable<OklabColor>, ISpanFormattable
     }
 
     /// <summary>
+    ///     Converts a OklabColor value to a sRGB Color value.
+    /// </summary>
+    /// <remarks>
+    ///     Does NOT do gamut clipping, may return out-of-gamut colors. Use ToColorGamutClipped if clipping is desired.
+    /// </remarks>
+    public readonly Color ToColor()
+    {
+        return ToLinear().ToSrgb().ToColor();
+    }
+
+    /// <summary>
     ///     Interpolate two colors with a lambda, AKA returning the two colors combined with a ratio of
     ///     <paramref name="λ" />.
     /// </summary>

--- a/Robust.Shared.Maths/Colors/OklabColor.cs
+++ b/Robust.Shared.Maths/Colors/OklabColor.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Runtime.InteropServices;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Maths.Colors;
+
+/// <summary>
+///     Represents a color with alpha in the Oklab colorspace.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct OklabColor : IEquatable<OklabColor>, ISpanFormattable
+{
+    public float L;
+    public float A;
+    public float B;
+    public float Alpha;
+
+    public OklabColor(float l, float a, float b, float alpha)
+    {
+        L = l;
+        A = a;
+        B = b;
+        Alpha = alpha;
+    }
+
+    /// <summary>
+    ///     Converts Oklab color values to linear sRGB color values.
+    /// </summary>
+    public readonly LinearSrgbColor ToLinear()
+    {
+        var l_ = L + 0.3963377774f * A + 0.2158037573f * B;
+        var m_ = L - 0.1055613458f * A - 0.0638541728f * B;
+        var s_ = L - 0.0894841775f * A - 1.2914855480f * B;
+
+        // convert from non-linear lms to linear lms
+
+        var l = l_ * l_ * l_;
+        var m = m_ * m_ * m_;
+        var s = s_ * s_ * s_;
+
+        // convert from linear lms to linear srgb
+
+        var r = +4.0767416621f * l - 3.3077115913f * m + 0.2309699292f * s;
+        var g = -1.2684380046f * l + 2.6097574011f * m - 0.3413193965f * s;
+        var b = -0.0041960863f * l - 0.7034186147f * m + 1.7076147010f * s;
+
+        return new LinearSrgbColor(r, g, b, Alpha);
+    }
+
+    /// <summary>
+    ///     Converts cartesian Oklab color values to polar Oklch color values.
+    /// </summary>
+    public readonly OklchColor ToLch()
+    {
+        var c = MathF.Sqrt(A * A + B * B);
+        var h = MathF.Atan2(B, A);
+        if (h < 0)
+            h += 2 * MathF.PI;
+
+        return new OklchColor(L, c, h, Alpha);
+    }
+
+    public static bool operator ==(OklabColor left, OklabColor right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(OklabColor left, OklabColor right)
+    {
+        return !left.Equals(right);
+    }
+
+    public readonly override bool Equals(object? obj)
+    {
+        if (!(obj is OklabColor))
+            return false;
+
+        return Equals((OklabColor)obj);
+    }
+
+    public readonly bool Equals(OklabColor other)
+            => L == other.L && A == other.A && B == other.B && Alpha == other.Alpha;
+
+    public readonly override string ToString()
+    {
+        return $"oklab({L}, {A}, {B}, {Alpha})";
+    }
+
+    public readonly override int GetHashCode()
+    {
+        return (int)(((uint)(Alpha * byte.MaxValue) << 24) |
+                ((uint)(L * byte.MaxValue) << 16) |
+                ((uint)(A * byte.MaxValue) << 8) |
+                (uint)(B * byte.MaxValue));
+    }
+
+    public readonly string ToString(string? format, IFormatProvider? formatProvider)
+    {
+        return ToString();
+    }
+
+    public readonly bool TryFormat(
+        Span<char> destination,
+        out int charsWritten,
+        ReadOnlySpan<char> format,
+        IFormatProvider? provider)
+    {
+        return FormatHelpers.TryFormatInto(
+            destination,
+            out charsWritten,
+            $"oklab({L}, {A}, {B}, {Alpha})");
+    }
+}

--- a/Robust.Shared.Maths/Colors/OklabColor.cs
+++ b/Robust.Shared.Maths/Colors/OklabColor.cs
@@ -16,6 +16,15 @@ public struct OklabColor : IEquatable<OklabColor>, ISpanFormattable
     public float B;
     public float Alpha;
 
+    public float Lr
+    {
+        get => (1.170873786407767f * L - 0.206f + MathF.Sqrt(MathF.Pow(1.170873786407767f * L - 0.206f, 2) + 0.14050485436893204f * L)) / 2f;
+        set
+        {
+            L = (value * (value + 0.206f)) / (1.170873786407767f * (value + 0.03f));
+        }
+    }
+
     public OklabColor(float l, float a, float b, float alpha)
     {
         L = l;

--- a/Robust.Shared.Maths/Colors/OklabColor.cs
+++ b/Robust.Shared.Maths/Colors/OklabColor.cs
@@ -17,6 +17,7 @@ public partial struct OklabColor : IEquatable<OklabColor>, ISpanFormattable
     public float A;
     public float B;
     public float Alpha;
+    public readonly Vector4 AsVector => Unsafe.BitCast<OklabColor, Vector4>(this);
 
     public float Lr
     {
@@ -25,6 +26,11 @@ public partial struct OklabColor : IEquatable<OklabColor>, ISpanFormattable
         {
             L = (value * (value + 0.206f)) / (1.170873786407767f * (value + 0.03f));
         }
+    }
+
+    public OklabColor(in Vector4 vec)
+    {
+        this = Unsafe.BitCast<Vector4, OklabColor>(vec);
     }
 
     public OklabColor(float l, float a, float b, float alpha)
@@ -71,8 +77,6 @@ public partial struct OklabColor : IEquatable<OklabColor>, ISpanFormattable
 
         return new OklchColor(L, c, h, Alpha);
     }
-
-    private readonly Vector4 AsVector => Unsafe.BitCast<OklabColor, Vector4>(this);
 
     /// <summary>
     ///     Interpolate two colors with a lambda, AKA returning the two colors combined with a ratio of

--- a/Robust.Shared.Maths/Colors/OklabColor.cs
+++ b/Robust.Shared.Maths/Colors/OklabColor.cs
@@ -9,7 +9,7 @@ namespace Robust.Shared.Maths.Colors;
 /// </summary>
 [Serializable]
 [StructLayout(LayoutKind.Sequential)]
-public struct OklabColor : IEquatable<OklabColor>, ISpanFormattable
+public partial struct OklabColor : IEquatable<OklabColor>, ISpanFormattable
 {
     public float L;
     public float A;

--- a/Robust.Shared.Maths/Colors/OklchColor.cs
+++ b/Robust.Shared.Maths/Colors/OklchColor.cs
@@ -52,6 +52,25 @@ public struct OklchColor : IEquatable<OklchColor>, ISpanFormattable
         return new OklabColor(L, a, b, Alpha);
     }
 
+    /// <summary>
+    ///     Converts a OklchColor value to a sRGB Color value.
+    /// </summary>
+    /// <remarks>
+    ///     Does NOT do gamut clipping, may return out-of-gamut colors. Use ToColorGamutClipped if clipping is desired.
+    /// </remarks>
+    public readonly Color ToColor()
+    {
+        return ToOklab().ToLinear().ToSrgb().ToColor();
+    }
+
+    /// <summary>
+    ///     Converts a OklchColor value to a sRGB Color value, after doing gamut clipping.
+    /// </summary>
+    public readonly Color ToColorClipped()
+    {
+        return ToOklab().GamutClipPreserveChroma().ToLinear().ToSrgb().ToColor();
+    }
+
     public static bool operator ==(OklchColor left, OklchColor right)
     {
         return left.Equals(right);

--- a/Robust.Shared.Maths/Colors/OklchColor.cs
+++ b/Robust.Shared.Maths/Colors/OklchColor.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Robust.Shared.Utility;
 
@@ -15,6 +17,7 @@ public struct OklchColor : IEquatable<OklchColor>, ISpanFormattable
     public float C;
     public float H;
     public float Alpha;
+    public readonly Vector4 AsVector => Unsafe.BitCast<OklchColor, Vector4>(this);
 
     public float Lr
     {
@@ -23,6 +26,11 @@ public struct OklchColor : IEquatable<OklchColor>, ISpanFormattable
         {
             L = (value * (value + 0.206f)) / (1.170873786407767f * (value + 0.03f));
         }
+    }
+
+    public OklchColor(in Vector4 vec)
+    {
+        this = Unsafe.BitCast<Vector4, OklchColor>(vec);
     }
 
     public OklchColor(float l, float c, float h, float alpha)

--- a/Robust.Shared.Maths/Colors/OklchColor.cs
+++ b/Robust.Shared.Maths/Colors/OklchColor.cs
@@ -16,6 +16,15 @@ public struct OklchColor : IEquatable<OklchColor>, ISpanFormattable
     public float H;
     public float Alpha;
 
+    public float Lr
+    {
+        get => (1.170873786407767f * L - 0.206f + MathF.Sqrt(MathF.Pow(1.170873786407767f * L - 0.206f, 2) + 0.14050485436893204f * L)) / 2f;
+        set
+        {
+            L = (value * (value + 0.206f)) / (1.170873786407767f * (value + 0.03f));
+        }
+    }
+
     public OklchColor(float l, float a, float b, float alpha)
     {
         L = l;

--- a/Robust.Shared.Maths/Colors/OklchColor.cs
+++ b/Robust.Shared.Maths/Colors/OklchColor.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Runtime.InteropServices;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Maths.Colors;
+
+/// <summary>
+///     Represents a color with alpha in the Oklab colorspace.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct OklchColor : IEquatable<OklchColor>, ISpanFormattable
+{
+    public float L;
+    public float C;
+    public float H;
+    public float Alpha;
+
+    public OklchColor(float l, float a, float b, float alpha)
+    {
+        L = l;
+        C = a;
+        H = b;
+        Alpha = alpha;
+    }
+
+    /// <summary>
+    ///     Converts polar Oklch color values to cartesian Oklab color values.
+    /// </summary>
+    public readonly OklabColor ToOklab()
+    {
+        var a = C * MathF.Cos(H);
+        var b = C * MathF.Sin(H);
+
+        return new OklabColor(L, a, b, Alpha);
+    }
+
+    public static bool operator ==(OklchColor left, OklchColor right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(OklchColor left, OklchColor right)
+    {
+        return !left.Equals(right);
+    }
+
+    public readonly override bool Equals(object? obj)
+    {
+        if (!(obj is OklchColor))
+            return false;
+
+        return Equals((OklchColor)obj);
+    }
+
+    public readonly bool Equals(OklchColor other)
+            => L == other.L && C == other.C && H == other.H && Alpha == other.Alpha;
+
+    public readonly override string ToString()
+    {
+        return $"oklch({L}, {C}, {H}, {Alpha})";
+    }
+
+    public readonly override int GetHashCode()
+    {
+        return (int)(((uint)(Alpha * byte.MaxValue) << 24) |
+                ((uint)(L * byte.MaxValue) << 16) |
+                ((uint)(C * byte.MaxValue) << 8) |
+                (uint)(H * byte.MaxValue));
+    }
+
+    public readonly string ToString(string? format, IFormatProvider? formatProvider)
+    {
+        return ToString();
+    }
+
+    public readonly bool TryFormat(
+        Span<char> destination,
+        out int charsWritten,
+        ReadOnlySpan<char> format,
+        IFormatProvider? provider)
+    {
+        return FormatHelpers.TryFormatInto(
+            destination,
+            out charsWritten,
+            $"oklch({L}, {C}, {H}, {Alpha})");
+    }
+}

--- a/Robust.Shared.Maths/Colors/OklchColor.cs
+++ b/Robust.Shared.Maths/Colors/OklchColor.cs
@@ -7,7 +7,7 @@ using Robust.Shared.Utility;
 namespace Robust.Shared.Maths.Colors;
 
 /// <summary>
-///     Represents a color with alpha in the Oklab colorspace.
+///     Represents a color with alpha in the Oklch colorspace.
 /// </summary>
 [Serializable]
 [StructLayout(LayoutKind.Sequential)]

--- a/Robust.Shared.Maths/Colors/OklchColor.cs
+++ b/Robust.Shared.Maths/Colors/OklchColor.cs
@@ -25,11 +25,11 @@ public struct OklchColor : IEquatable<OklchColor>, ISpanFormattable
         }
     }
 
-    public OklchColor(float l, float a, float b, float alpha)
+    public OklchColor(float l, float c, float h, float alpha)
     {
         L = l;
-        C = a;
-        H = b;
+        C = c;
+        H = h;
         Alpha = alpha;
     }
 

--- a/Robust.Shared.Maths/Colors/SrgbColor.cs
+++ b/Robust.Shared.Maths/Colors/SrgbColor.cs
@@ -16,6 +16,11 @@ public struct SrgbColor : IEquatable<SrgbColor>, ISpanFormattable
     public float Blue;
     public float Alpha;
 
+    public readonly bool IsInGamut
+    {
+        get => Red <= 1 && Green <= 1 && Blue <= 1 && Red >= 0 && Green >= 0 && Blue >= 0;
+    }
+
     public SrgbColor(float r, float g, float b, float a)
     {
         Red = r;

--- a/Robust.Shared.Maths/Colors/SrgbColor.cs
+++ b/Robust.Shared.Maths/Colors/SrgbColor.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Runtime.InteropServices;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Maths.Colors;
+
+/// <summary>
+///     Represents a color with alpha in the sRGB colorspace.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct SrgbColor : IEquatable<SrgbColor>, ISpanFormattable
+{
+    public float Red;
+    public float Green;
+    public float Blue;
+    public float Alpha;
+
+    public SrgbColor(float r, float g, float b, float a)
+    {
+        Red = r;
+        Green = g;
+        Blue = b;
+        Alpha = a;
+    }
+
+    /// <summary>
+    ///     Converts RGB color values to HSL color values.
+    /// </summary>
+    public readonly HslColor ToHsl()
+    {
+        var max = MathF.Max(Red, MathF.Max(Green, Blue));
+        var min = MathF.Min(Red, MathF.Min(Green, Blue));
+        var c = max - min;
+
+        var h = 0.0f;
+        if (c != 0)
+        {
+            if (max == Red)
+                h = (Green - Blue) / c;
+            else if (max == Green)
+                h = (Blue - Red) / c + 2.0f;
+            else if (max == Blue)
+                h = (Red - Green) / c + 4.0f;
+        }
+
+        var hue = h / 6.0f;
+        if (hue < 0.0f)
+            hue += 1.0f;
+
+        var lightness = (max + min) / 2.0f;
+
+        var saturation = 0.0f;
+        if (0.0f != lightness && lightness != 1.0f)
+            saturation = c / (1.0f - MathF.Abs(2.0f * lightness - 1.0f));
+
+        return new HslColor(hue, saturation, lightness, Alpha);
+    }
+
+    /// <summary>
+    ///     Converts RGB color values to HSL color values.
+    /// </summary>
+    public readonly HsvColor ToHsv()
+    {
+        var max = MathF.Max(Red, MathF.Max(Green, Blue));
+        var min = MathF.Min(Red, MathF.Min(Green, Blue));
+        var c = max - min;
+
+        var h = 0.0f;
+        if (c != 0)
+        {
+            if (max == Red)
+            {
+                h = (Green - Blue) / c % 6.0f;
+                if (h < 0f)
+                    h += 6.0f;
+            }
+            else if (max == Green)
+                h = (Blue - Red) / c + 2.0f;
+            else if (max == Blue)
+                h = (Red - Green) / c + 4.0f;
+        }
+
+        var hue = h * 60.0f / 360.0f;
+
+        var saturation = 0.0f;
+        if (0.0f != max)
+            saturation = c / max;
+
+        return new HsvColor(hue, saturation, max, Alpha);
+    }
+
+    /// <summary>
+    ///     Converts sRGB color values to linear RGB color values.
+    /// </summary>
+    public readonly LinearSrgbColor ToLinear()
+    {
+        float r, g, b;
+        if (Red <= 0.04045f)
+            r = Red / 12.92f;
+        else
+            r = MathF.Pow((Red + 0.055f) / (1.0f + 0.055f), 2.4f);
+
+        if (Green <= 0.04045f)
+            g = Green / 12.92f;
+        else
+            g = MathF.Pow((Green + 0.055f) / (1.0f + 0.055f), 2.4f);
+
+        if (Blue <= 0.04045f)
+            b = Blue / 12.92f;
+        else
+            b = MathF.Pow((Blue + 0.055f) / (1.0f + 0.055f), 2.4f);
+
+        return new LinearSrgbColor(r, g, b, Alpha);
+    }
+
+    public readonly Color ToColor()
+    {
+        return new Color(Red, Green, Blue, Alpha);
+    }
+
+    public static bool operator ==(SrgbColor left, SrgbColor right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(SrgbColor left, SrgbColor right)
+    {
+        return !left.Equals(right);
+    }
+
+    public readonly override bool Equals(object? obj)
+    {
+        if (!(obj is SrgbColor))
+            return false;
+
+        return Equals((SrgbColor)obj);
+    }
+
+    public readonly bool Equals(SrgbColor other)
+            => Red == other.Red && Green == other.Green && Blue == other.Blue && Alpha == other.Alpha;
+
+    public readonly override string ToString()
+    {
+        return $"rgba({Red}, {Green}, {Blue}, {Alpha})";
+    }
+
+    public readonly override int GetHashCode()
+    {
+        return (int) (((uint) (Alpha * byte.MaxValue) << 24) |
+                ((uint) (Red * byte.MaxValue) << 16) |
+                ((uint) (Green * byte.MaxValue) << 8) |
+                (uint) (Blue * byte.MaxValue));
+    }
+
+    public readonly string ToString(string? format, IFormatProvider? formatProvider)
+    {
+        return ToString();
+    }
+
+    public readonly bool TryFormat(
+        Span<char> destination,
+        out int charsWritten,
+        ReadOnlySpan<char> format,
+        IFormatProvider? provider)
+    {
+        return FormatHelpers.TryFormatInto(
+            destination,
+            out charsWritten,
+            $"rgba({Red}, {Green}, {Blue}, {Alpha})");
+    }
+}

--- a/Robust.Shared.Maths/Colors/SrgbColor.cs
+++ b/Robust.Shared.Maths/Colors/SrgbColor.cs
@@ -25,7 +25,7 @@ public struct SrgbColor : IEquatable<SrgbColor>, ISpanFormattable
     }
 
     /// <summary>
-    ///     Converts RGB color values to HSL color values.
+    ///     Converts sRGB color values to HSL color values.
     /// </summary>
     public readonly HslColor ToHsl()
     {
@@ -58,7 +58,7 @@ public struct SrgbColor : IEquatable<SrgbColor>, ISpanFormattable
     }
 
     /// <summary>
-    ///     Converts RGB color values to HSL color values.
+    ///     Converts sRGB color values to HSL color values.
     /// </summary>
     public readonly HsvColor ToHsv()
     {
@@ -112,6 +112,18 @@ public struct SrgbColor : IEquatable<SrgbColor>, ISpanFormattable
             b = MathF.Pow((Blue + 0.055f) / (1.0f + 0.055f), 2.4f);
 
         return new LinearSrgbColor(r, g, b, Alpha);
+    }
+
+    /// <summary>
+    ///     Converts sRGB color values to sYCC color values.
+    /// </summary>
+    public readonly SyccColor ToSycc()
+    {
+        var y = 0.299f * Red + 0.587f * Green + 0.114f * Blue;
+        var u = -0.168736f * Red + -0.331264f * Green + 0.5f * Blue;
+        var v = 0.5f * Red + -0.418688f * Green + -0.081312f * Blue;
+
+        return new SyccColor(y, u, v, Alpha);
     }
 
     public readonly Color ToColor()

--- a/Robust.Shared.Maths/Colors/SrgbColor.cs
+++ b/Robust.Shared.Maths/Colors/SrgbColor.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Robust.Shared.Utility;
 
@@ -15,10 +17,16 @@ public struct SrgbColor : IEquatable<SrgbColor>, ISpanFormattable
     public float Green;
     public float Blue;
     public float Alpha;
+    public readonly Vector4 AsVector => Unsafe.BitCast<SrgbColor, Vector4>(this);
 
     public readonly bool IsInGamut
     {
         get => Red <= 1 && Green <= 1 && Blue <= 1 && Red >= 0 && Green >= 0 && Blue >= 0;
+    }
+
+    public SrgbColor(in Vector4 vec)
+    {
+        this = Unsafe.BitCast<Vector4, SrgbColor>(vec);
     }
 
     public SrgbColor(float r, float g, float b, float a)

--- a/Robust.Shared.Maths/Colors/SrgbColor.cs
+++ b/Robust.Shared.Maths/Colors/SrgbColor.cs
@@ -126,6 +126,12 @@ public struct SrgbColor : IEquatable<SrgbColor>, ISpanFormattable
         return new SyccColor(y, u, v, Alpha);
     }
 
+    /// <summary>
+    ///     Casts a SrgbColor value to a sRGB Color value.
+    /// </summary>
+    /// <remarks>
+    ///     This is NOT Linear sRGB. Don't put this somewhere that expects Linear sRGB.
+    /// </remarks>
     public readonly Color ToColor()
     {
         return new Color(Red, Green, Blue, Alpha);

--- a/Robust.Shared.Maths/Colors/SyccColor.cs
+++ b/Robust.Shared.Maths/Colors/SyccColor.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Robust.Shared.Utility;
 
@@ -18,6 +20,12 @@ public struct SyccColor : IEquatable<SyccColor>, ISpanFormattable
     public float Cb;
     public float Cr;
     public float Alpha;
+    public readonly Vector4 AsVector => Unsafe.BitCast<SyccColor, Vector4>(this);
+
+    public SyccColor(in Vector4 vec)
+    {
+        this = Unsafe.BitCast<Vector4, SyccColor>(vec);
+    }
 
     public SyccColor(float y, float cb, float cr, float alpha)
     {

--- a/Robust.Shared.Maths/Colors/SyccColor.cs
+++ b/Robust.Shared.Maths/Colors/SyccColor.cs
@@ -47,6 +47,14 @@ public struct SyccColor : IEquatable<SyccColor>, ISpanFormattable
         return new SrgbColor(r, g, b, Alpha);
     }
 
+    /// <summary>
+    ///     Converts a SyccColor value to a sRGB Color value.
+    /// </summary>
+    public readonly Color ToColor()
+    {
+        return ToSrgb().ToColor();
+    }
+
     public static bool operator ==(SyccColor left, SyccColor right)
     {
         return left.Equals(right);

--- a/Robust.Shared.Maths/Colors/SyccColor.cs
+++ b/Robust.Shared.Maths/Colors/SyccColor.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Runtime.InteropServices;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Maths.Colors;
+
+/// <summary>
+///     Represents a color with alpha in the sYCC colorspace.
+/// </summary>
+/// <remarks>
+///     Identical to one of the colorspaces referred to as ITU-R BT.601 YCbCr colorspace.
+/// </remarks>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct SyccColor : IEquatable<SyccColor>, ISpanFormattable
+{
+    public float Y;
+    public float Cb;
+    public float Cr;
+    public float Alpha;
+
+    public SyccColor(float y, float cb, float cr, float alpha)
+    {
+        Y = y;
+        Cb = cb;
+        Cr = cr;
+        Alpha = alpha;
+    }
+
+    /// <summary>
+    ///     Converts sYCC color values to RGB color values.
+    /// </summary>
+    public readonly SrgbColor ToSrgb()
+    {
+        var r = 1.0f * Y + 0.0f * Cb + 1.402f * Cr;
+        var g = 1.0f * Y + -0.344136f * Cb + -0.714136f * Cr;
+        var b = 1.0f * Y + 1.772f * Cb + 0.0f * Cr;
+
+        return new SrgbColor(r, g, b, Alpha);
+    }
+
+    public static bool operator ==(SyccColor left, SyccColor right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(SyccColor left, SyccColor right)
+    {
+        return !left.Equals(right);
+    }
+
+    public readonly override bool Equals(object? obj)
+    {
+        if (!(obj is SyccColor))
+            return false;
+
+        return Equals((SyccColor)obj);
+    }
+
+    public readonly bool Equals(SyccColor other)
+            => Y == other.Y && Cb == other.Cb && Cr == other.Cr && Alpha == other.Alpha;
+
+    public readonly override string ToString()
+    {
+        return $"sycc({Y}, {Cb}, {Cr}, {Alpha})";
+    }
+
+    public readonly override int GetHashCode()
+    {
+        return (int)(((uint)(Alpha * byte.MaxValue) << 24) |
+                ((uint)(Y * byte.MaxValue) << 16) |
+                ((uint)((Cb + 0.5) * byte.MaxValue) << 8) |
+                (uint)((Cr + 0.5) * byte.MaxValue));
+    }
+
+    public readonly string ToString(string? format, IFormatProvider? formatProvider)
+    {
+        return ToString();
+    }
+
+    public readonly bool TryFormat(
+        Span<char> destination,
+        out int charsWritten,
+        ReadOnlySpan<char> format,
+        IFormatProvider? provider)
+    {
+        return FormatHelpers.TryFormatInto(
+            destination,
+            out charsWritten,
+            $"sycc({Y}, {Cb}, {Cr}, {Alpha})");
+    }
+}

--- a/Robust.Shared/ColorNaming/ColorNaming.cs
+++ b/Robust.Shared/ColorNaming/ColorNaming.cs
@@ -134,7 +134,7 @@ public static class ColorNaming
     /// <param name="srgb">A Color that is assumed to be in SRGB (the default for most cases)</param>
     public static string Describe(Color srgb, ILocalizationManager localization)
     {
-        var oklch = srgb.ToColors().ToLinear().ToOklab().ToOklch();
+        var oklch = srgb.ToLch();
 
         if (oklch.L >= WhiteLightnessThreshold)
             return localization.GetString(WhiteString);


### PR DESCRIPTION
Currently the colorspace-related APIs in `Color` is a mess, putting Linear sRGB values in `Color` and all other colorspaces just using `Vector4` without any safeguards against confusing, say, HSL for HSV. This PR adds the `Colors` namespace, which holds actually typed color classes with methods for converting between them as appropriate.

Opened as Draft because I want to add more features(mainly Oklab gamut clipping) and have colorspace parity with `Color`, and then add deprecations to the existing `Color` colorspace API while making them be wrappers over the `Colors` API.