### PR TITLE
Include last applied tick in `EntitySessionEventArgs`

### DIFF
--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -162,7 +162,7 @@ namespace Robust.Client.GameObjects
 
             DebugTools.Assert(_gameTiming.InPrediction && _gameTiming.IsFirstTimePredicted || _client.RunLevel == ClientRunLevel.SinglePlayerGame);
 
-            var eventArgs = new EntitySessionEventArgs(session!);
+            var eventArgs = new EntitySessionEventArgs(session!, _gameTiming.LastRealTick);
             EventBus.RaiseEvent(EventSource.Local, msg);
             EventBus.RaiseEvent(EventSource.Local, new EntitySessionMessage<T>(eventArgs, msg));
         }
@@ -228,6 +228,7 @@ namespace Robust.Client.GameObjects
             msg.Type = EntityMessageType.SystemMessage;
             msg.SystemMessage = message;
             msg.SourceTick = _gameTiming.CurTick;
+            msg.LastAppliedTick = _gameTiming.LastRealTick;
             msg.Sequence = sequence;
 
             _networkManager.ClientSendMessage(msg);

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -255,7 +255,7 @@ namespace Robust.Client.GameStates
 
             DebugTools.Assert(_players.LocalSession != null);
 
-            var evArgs = new EntitySessionEventArgs(_players.LocalSession);
+            var evArgs = new EntitySessionEventArgs(_players.LocalSession, _timing.LastRealTick);
             _pendingSystemMessages.Enqueue((_nextInputCmdSeq, _timing.CurTick, message,
                 new EntitySessionMessage<T>(evArgs, message)));
 

--- a/Robust.Server/GameObjects/IServerEntityNetworkManager.cs
+++ b/Robust.Server/GameObjects/IServerEntityNetworkManager.cs
@@ -1,10 +1,12 @@
 using Robust.Shared.GameObjects;
 using Robust.Shared.Player;
+using Robust.Shared.Timing;
 
 namespace Robust.Server.GameObjects
 {
     public interface IServerEntityNetworkManager : IEntityNetworkManager
     {
         uint GetLastMessageSequence(ICommonSession session);
+        GameTick GetLastAppliedTick(ICommonSession session);
     }
 }

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -181,7 +181,7 @@ namespace Robust.Server.GameObjects
             return session == null ? default : _lastProcessedMessage.GetValueOrDefault(session).Sequence;
         }
 
-        public GameTick GetLastLastAppliedTick(ICommonSession? session)
+        public GameTick GetLastAppliedTick(ICommonSession? session)
         {
             return session == null ? default : _lastProcessedMessage.GetValueOrDefault(session).Applied;
         }

--- a/Robust.Shared/GameObjects/EntityEvents.cs
+++ b/Robust.Shared/GameObjects/EntityEvents.cs
@@ -1,6 +1,7 @@
 using System;
 using Robust.Shared.Player;
 using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
 
 namespace Robust.Shared.GameObjects
 {
@@ -43,12 +44,22 @@ namespace Robust.Shared.GameObjects
 
     public readonly struct EntitySessionEventArgs
     {
-        public EntitySessionEventArgs(ICommonSession senderSession)
+        public EntitySessionEventArgs(ICommonSession senderSession, GameTick lastApplied = default)
         {
             SenderSession = senderSession;
+            LastAppliedTick = lastApplied;
         }
 
         public ICommonSession SenderSession { get; }
+
+        /// <summary>
+        /// If this event was sent from a client, this is the tick of the last sever state that the client had applied
+        /// at the time that the event was initially raised.
+        /// </summary>
+        /// <remarks>
+        /// This can be used to perform some basic lag compensation.
+        /// </remarks>
+        public readonly GameTick LastAppliedTick;
     }
 
     internal readonly struct EntitySessionMessage<T>

--- a/Robust.Shared/Network/Messages/MsgEntity.cs
+++ b/Robust.Shared/Network/Messages/MsgEntity.cs
@@ -22,11 +22,13 @@ namespace Robust.Shared.Network.Messages
         public uint NetId { get; set; }
         public uint Sequence { get; set; }
         public GameTick SourceTick { get; set; }
+        public GameTick LastAppliedTick { get; set; }
 
         public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             Type = (EntityMessageType)buffer.ReadByte();
             SourceTick = buffer.ReadGameTick();
+            LastAppliedTick = buffer.ReadGameTick();
             Sequence = buffer.ReadUInt32();
 
             switch (Type)
@@ -46,6 +48,7 @@ namespace Robust.Shared.Network.Messages
         {
             buffer.Write((byte)Type);
             buffer.Write(SourceTick);
+            buffer.Write(LastAppliedTick);
             buffer.Write(Sequence);
 
             switch (Type)


### PR DESCRIPTION
Having the server know about the client's last applies server state at the time that a networked event was raised makes implementing useful lag compensation easier. The client could still intentionally lie about the last applied state and maybe use that to try abuse lag compensation, so the client's ping should maybe still be used as a sanity check.

Though I'm now having second thoughts about this, as this makes all entity-events one int larger. While I feel like this is more convenient, maybe this is information that should just be sent in specific events that actually need to use lag compensation instead of all networked events.