### PR TITLE
Improve error logging in SharedAudioSystem

### DIFF
--- a/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
+++ b/Robust.Shared/Audio/Systems/SharedAudioSystem.cs
@@ -437,7 +437,7 @@ public abstract partial class SharedAudioSystem : EntitySystem
     protected TimeSpan GetAudioLength(string filename)
     {
         if (!filename.StartsWith('/'))
-            throw new ArgumentException("Path must be rooted");
+            throw new ArgumentException($"Path must be rooted. Path: {filename}");
         return GetAudioLengthImpl(filename);
     }
 


### PR DESCRIPTION
A bunch of these errors are showing up on Grafana and I have no way to find out where they are coming from without the file name.