### PR TITLE
Fix serialization of data-records with get-only properties

### DIFF
--- a/Robust.Shared/Serialization/Manager/Definition/DataDefinition.cs
+++ b/Robust.Shared/Serialization/Manager/Definition/DataDefinition.cs
@@ -436,6 +436,9 @@ namespace Robust.Shared.Serialization.Manager.Definition
                 fieldDefinitions.Add(fieldDefinition);
             }
 
+            // There should be no duplicates
+            // I.e., we haven't accidentally included a property's backing field twice?
+            DebugTools.Assert(fieldDefinitions.Select(x=> x.FieldInfo).Distinct().Count() == fieldDefinitions.Count);
             return fieldDefinitions;
         }
     }


### PR DESCRIPTION
This PR changes `GatherFieldData()` so that it returns false when given a property with no setter and no backing field. This was preventing record structs like this from being used:
```cs
[DataRecord]
public record struct Foo
{
    public Vector2 Position;
    public float X => Position.X;
}
```

The actual change is relatively small, but this PR also inverts some if the if statements to reduce nesting and hopefully make the method easier to parse, because it left me quite confused.