### PR TITLE
fix PlacementManager.CurrentMousePosition during integration tests

### DIFF
--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -562,7 +562,7 @@ namespace Robust.Client.Placement
             }
 
             coordinates = InputManager.MouseScreenPosition;
-            return coordinates.Window != WindowId.Invalid;
+            return coordinates.IsValid;
         }
 
         private bool CurrentEraserMouseCoordinates(out EntityCoordinates coordinates)

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -562,7 +562,7 @@ namespace Robust.Client.Placement
             }
 
             coordinates = InputManager.MouseScreenPosition;
-            return true;
+            return coordinates.Window != WindowId.Invalid;
         }
 
         private bool CurrentEraserMouseCoordinates(out EntityCoordinates coordinates)


### PR DESCRIPTION
I was writing an integration test for RCDs and got an error when using the RCD, which opens the placement preview.
<img width="758" height="242" alt="grafik" src="https://github.com/user-attachments/assets/dcf7d09a-9e9e-4f2f-9e3b-4f76fec7cbe9" />
```
CLIENT: 3.345s [ERRO] system.transform: Attempted to convert map coordinates with unknown map id: Map=0, X=0.00, Y=0.00. Trace:    at System.Environment.get_StackTrace()
   at Robust.Shared.GameObjects.SharedTransformSystem.ToCoordinates(MapCoordinates coordinates) in d:\Code\SS14\space-station-14\RobustToolbox\Robust.Shared\GameObjects\Systems\SharedTransformSystem.Coordinates.cs:line 140
   at Robust.Client.Placement.PlacementMode.ScreenToCursorGrid(ScreenCoordinates coords) in d:\Code\SS14\space-station-14\RobustToolbox\Robust.Client\Placement\PlacementMode.cs:line 272
   at Content.Client.RCD.AlignRCDConstruction.AlignPlacementMode(ScreenCoordinates mouseScreen) in d:\Code\SS14\space-station-14\Content.Client\RCD\AlignRCDConstruction.cs:line 48
   at Robust.Client.Placement.PlacementManager.FrameUpdate(FrameEventArgs e) in d:\Code\SS14\space-station-14\RobustToolbox\Robust.Client\Placement\PlacementManager.cs:line 625
   at Robust.Client.GameController.Update(FrameEventArgs frameEventArgs) in d:\Code\SS14\space-station-14\RobustToolbox\Robust.Client\GameController\GameController.cs:line 614
...
```
`CurrentMousePosition` should return `false` in case the mouse position is not valid to prevent the preview icon from being drawn in the frame update. However for integration tests, where the client does not have a screen and `InputManager.MouseScreenPosition` has invalid `ScreenCoordinates` as a result it was still returning true, causing errors when calculating the location for the preview sprite.

<img width="630" height="245" alt="grafik" src="https://github.com/user-attachments/assets/543bf721-5bae-4deb-9949-774dd57fd12b" />
 
To fix this we simply check if the `ScreenCoordinates` from `InputManager.MouseScreenPosition` are valid and return false if not.