### PR TITLE
Dirty a UserInterface.Control's arrange when performing measure

### DIFF
--- a/Robust.Client/UserInterface/Control.Layout.cs
+++ b/Robust.Client/UserInterface/Control.Layout.cs
@@ -509,7 +509,6 @@ namespace Robust.Client.UserInterface
 
             IsMeasureValid = false;
             UserInterfaceManagerInternal.QueueMeasureUpdate(this);
-            InvalidateArrange();
         }
 
         /// <summary>
@@ -602,6 +601,7 @@ namespace Robust.Client.UserInterface
             measured = _margin.Inflate(measured);
             measured = Vector2.Min(measured, availableSize);
             measured = Vector2.Max(measured, Vector2.Zero);
+            InvalidateArrange();
             return measured;
         }
 

--- a/Robust.Client/UserInterface/Control.Layout.cs
+++ b/Robust.Client/UserInterface/Control.Layout.cs
@@ -573,7 +573,9 @@ namespace Robust.Client.UserInterface
         protected virtual Vector2 MeasureCore(Vector2 availableSize)
         {
             if (!(Visible || ReservesSpace))
+            {
                 return default;
+            }
 
             if (_stylingDirty)
                 ForceRunStyleUpdate();
@@ -641,10 +643,14 @@ namespace Robust.Client.UserInterface
             _arranging = true;
             try
             {
+                bool ranMeasure = false;
                 if (!IsMeasureValid)
+                {
                     Measure(PreviousMeasure ?? finalRect.Size);
+                    ranMeasure = true;
+                }
 
-                if (!IsArrangeValid || PreviousArrange != finalRect)
+                if (ranMeasure || !IsArrangeValid || PreviousArrange != finalRect)
                 {
                     IsArrangeValid = true;
                     ArrangeCore(finalRect);

--- a/Robust.UnitTesting/Client/UserInterface/Controls/LayoutContainerTest.cs
+++ b/Robust.UnitTesting/Client/UserInterface/Controls/LayoutContainerTest.cs
@@ -186,7 +186,7 @@ namespace Robust.UnitTesting.Client.UserInterface.Controls
             parent.AddChild(child);
             parent.Arrange(new UIBox2(0, 0, 100, 100));
 
-            // Child should be at -100,0.
+            // Child should be at 0,0.
             Assert.That(child.Position, Is.EqualTo(new Vector2(0, 0)));
 
             child.MinSize = new Vector2(100, 100);


### PR DESCRIPTION
The UI layout algorithm assumes that when invalidating a UserInterface.Control's Measure, it's arrange should also be invalidated. However, if a Control modifies it's own subtree in ArrangeOverride(), that invariant is violated. This PR makes a teeny-tiny-slightly-scary modification to when the arrange is invalidated.

Was observing in a live game that opening up the Ghost Roles window, it sometimes
would not be scrollable:

<img width="524" height="554" alt="2025-09-14_14-08" src="https://github.com/user-attachments/assets/c8ac9720-26ea-407e-91f1-3fd1d8254fd0" />


This doesn't normally reproduce locally, as it's dependent on network latency. I was able to reproduce it locally by adding artifical latency (via `tc qdisc add dev lo root netem delay 250ms`, and even then, it doesn't occur every time the window is opened) - to reproduce this, we need the GhostRolesEuiState to arrive exactly one render frame (one UserInterfaceManager.FrameUpdate()) after the GhostRolesEui is constructed.

The sequence of events is then:

1. GhostRolesEui constructs a window with a ScrollContainer - no contents, as the GhostRolesEuiState hasn't arrived yet
1. UserInterfaceManager.FrameUpdate runs measure and arrange for the ScrollContainer
1. The ScrollContainer's ArrangeOverride determines that it's child scrollbars are unnecessary and sets their Visibility=False
1. The scrollbar's Visibility change will InvalidateMeasure() on the parent ScrollContainer
1. The ScrollContainer's InvalidateMeasure() will attempt to InvalidateArrange(), but since we're already inside ArrangeOverride() (i.e. _arranging==true), this will no-op
1. We now have a ScrollContainer with IsMeasureValid==false, but IsArrangeValid==true, which is an invalid state
1. Next frame, the GhostRolesEuiState message arrives and we add child elements to the ScrollContainer; if enough elements are added, these would require scrollbars
1. These additional children attempt to InvalidateMeasure() on the ScrollContainer, which no-ops, as IsMeasureValid==false
1. Next UserInterfaceManager.FrameUpdate will recalculate the ScrollContainer's Measure, but not the Arrange, leaving the window in a broken state with no scrollbars

RT's ui layout algorithm is very loosely based on WPF's layout algorithm; WPF has a crucial difference which this PR reconciles - in RT, an InvalidateMeasure() also performs an InvalidateArrange(); however, in WPF, invalidating the measure will *only* invalidate the measure, but when the control is actually re-measured[0], this then triggers an invalidate arrange. This change modifies RT to do the same thing as WPF in this respect.

[0] https://github.com/dotnet/wpf/blob/main/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs#L631