### PR TITLE
Enable the ` (grave) key

### DIFF
--- a/Robust.Client/Graphics/Clyde/Windowing/Glfw.Keys.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Glfw.Keys.cs
@@ -170,7 +170,7 @@ namespace Robust.Client.Graphics.Clyde
                     {GlfwKey.Apostrophe, Key.Apostrophe},
                     {GlfwKey.Slash, Key.Slash},
                     {GlfwKey.Backslash, Key.BackSlash},
-                    {GlfwKey.GraveAccent, Key.Tilde},
+                    {GlfwKey.GraveAccent, Key.Grave},
                     {GlfwKey.Equal, Key.Equal},
                     {GlfwKey.Space, Key.Space},
                     {GlfwKey.Enter, Key.Return},

--- a/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Key.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Key.cs
@@ -155,7 +155,7 @@ internal partial class Clyde
             MapKey(SC.SDL_SCANCODE_APOSTROPHE, Key.Apostrophe);
             MapKey(SC.SDL_SCANCODE_SLASH, Key.Slash);
             MapKey(SC.SDL_SCANCODE_BACKSLASH, Key.BackSlash);
-            MapKey(SC.SDL_SCANCODE_GRAVE, Key.Tilde);
+            MapKey(SC.SDL_SCANCODE_GRAVE, Key.Grave);
             MapKey(SC.SDL_SCANCODE_EQUALS, Key.Equal);
             MapKey(SC.SDL_SCANCODE_SPACE, Key.Space);
             MapKey(SC.SDL_SCANCODE_RETURN, Key.Return);

--- a/Robust.Client/Input/InputDevices.cs
+++ b/Robust.Client/Input/InputDevices.cs
@@ -125,6 +125,7 @@ namespace Robust.Client.Input
             Slash,
             BackSlash,
             Tilde,
+            Grave,
             Equal,
             Space,
             Return,


### PR DESCRIPTION
For some reason, this was mapped to tilde. 

OpenDream (specifically goonstation) needs it not to be.

I realise this will probably mess with people's flow on SS14 forks when opening the console, so it might not be a bad idea to create a keybind in the yaml for that