### PR TITLE
Make IReplayRecordingManager.StopRecording return the file path of the saved replay file

### DIFF
--- a/Robust.Shared/Replays/IReplayRecordingManager.cs
+++ b/Robust.Shared/Replays/IReplayRecordingManager.cs
@@ -120,7 +120,7 @@ public interface IReplayRecordingManager
     /// <summary>
     /// Stops an ongoing replay recording.
     /// </summary>
-    void StopRecording();
+    ResPath? StopRecording();
 
     /// <summary>
     /// Returns information about the currently ongoing replay recording.

--- a/Robust.Shared/Replays/IReplayRecordingManager.cs
+++ b/Robust.Shared/Replays/IReplayRecordingManager.cs
@@ -120,6 +120,7 @@ public interface IReplayRecordingManager
     /// <summary>
     /// Stops an ongoing replay recording.
     /// </summary>
+    /// <returns>Returns the file path the replay was saved at.</returns>
     ResPath? StopRecording();
 
     /// <summary>

--- a/Robust.Shared/Replays/SharedReplayRecordingManager.cs
+++ b/Robust.Shared/Replays/SharedReplayRecordingManager.cs
@@ -109,15 +109,16 @@ internal abstract partial class SharedReplayRecordingManager : IReplayRecordingM
     }
 
     /// <inheritdoc/>
-    public void StopRecording()
+    public ResPath? StopRecording()
     {
         if (!IsRecording)
-            return;
+            return null;
 
+        var path = _recState!.DestPath;
         try
         {
             WriteBatch(continueRecording: false);
-            _sawmill.Info("Replay recording stopped!");
+            _sawmill.Info($"Replay recording stopped! File path: {path}");
         }
         catch
         {
@@ -126,6 +127,7 @@ internal abstract partial class SharedReplayRecordingManager : IReplayRecordingM
         }
 
         UpdateWriteTasks();
+        return path;
     }
 
     public void Update(GameState? state)
@@ -248,7 +250,7 @@ internal abstract partial class SharedReplayRecordingManager : IReplayRecordingM
             throw;
         }
 
-        _sawmill.Info("Started recording replay...");
+        _sawmill.Info($"Started recording replay. File path: {filePath}");
         UpdateWriteTasks();
         return true;
     }


### PR DESCRIPTION
I am currently trying to make integration tests be able to record a replay, and I need the full file path to be able to attach it to the test results.

The file path is constructed in `TryStartRecording` from a cvar and time stamp, so there is currently no way to know which name was picked.