### PR TITLE
Make the server keep track of the client's last real tick

### DIFF
--- a/Robust.Client/GameController/GameController.cs
+++ b/Robust.Client/GameController/GameController.cs
@@ -26,7 +26,6 @@ using Robust.Client.WebViewHook;
 using Robust.LoaderApi;
 using Robust.Shared;
 using Robust.Shared.Asynchronous;
-using Robust.Shared.Audio;
 using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
 using Robust.Shared.Exceptions;
@@ -45,7 +44,6 @@ using Robust.Shared.Threading;
 using Robust.Shared.Timing;
 using Robust.Shared.Upload;
 using Robust.Shared.Utility;
-using YamlDotNet.RepresentationModel;
 
 namespace Robust.Client
 {

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -379,6 +379,9 @@ namespace Robust.Client.GameStates
 
                 _timing.CurTick = _timing.LastRealTick = _timing.LastProcessedTick;
 
+                var ev = new ClientLastRealTickChanged(_timing.LastRealTick);
+                _entities.EntityNetManager.SendSystemNetworkMessage(ev);
+
                 // Update the cached server state.
                 using (_prof.Group("FullRep"))
                 {

--- a/Robust.Client/Timing/ClientGameTiming.cs
+++ b/Robust.Client/Timing/ClientGameTiming.cs
@@ -13,9 +13,6 @@ namespace Robust.Client.Timing
         public override bool InPrediction => !ApplyingState && CurTick > LastRealTick;
 
         /// <inheritdoc />
-        public GameTick LastRealTick { get; set; }
-
-        /// <inheritdoc />
         public GameTick LastProcessedTick { get; set; }
 
         public override TimeSpan ServerTime

--- a/Robust.Client/Timing/IClientGameTiming.cs
+++ b/Robust.Client/Timing/IClientGameTiming.cs
@@ -12,13 +12,6 @@ namespace Robust.Client.Timing
         /// </summary>
         GameTick LastProcessedTick { get; set; }
 
-        /// <summary>
-        /// The last real non-extrapolated server state that was applied. Without networking issues, this tick should
-        /// always correspond to <see cref="LastRealTick"/>, however if there is a missing states or the buffer has run
-        /// out, this value may be smaller..
-        /// </summary>
-        GameTick LastRealTick { get; set; }
-
         void StartPastPrediction();
         void EndPastPrediction();
 

--- a/Robust.Shared/GameStates/ClientLastRealTickChanged.cs
+++ b/Robust.Shared/GameStates/ClientLastRealTickChanged.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
+
+namespace Robust.Shared.GameStates;
+
+[Serializable, NetSerializable]
+public sealed class ClientLastRealTickChanged(GameTick tick) : EntityEventArgs
+{
+    public readonly GameTick Tick = tick;
+}

--- a/Robust.Shared/GameStates/GameStateSystem.cs
+++ b/Robust.Shared/GameStates/GameStateSystem.cs
@@ -23,6 +23,12 @@ public sealed class GameStateSystem : EntitySystem
         SetLastRealTick(args.SenderSession.UserId, msg.Tick);
     }
 
+    /// <summary>
+    ///     Gets a client's last real tick.
+    /// </summary>
+    /// <param name="session">The id of the client.</param>
+    /// <returns>The client's last real tick, or the current tick if it is not set.</returns>
+    /// <seealso cref="IGameTiming.LastRealTick"/>
     public GameTick GetLastRealTick(NetUserId? session)
     {
         if (_net.IsClient)

--- a/Robust.Shared/GameStates/GameStateSystem.cs
+++ b/Robust.Shared/GameStates/GameStateSystem.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Network;
+using Robust.Shared.Timing;
+
+namespace Robust.Shared.GameStates;
+
+public sealed class GameStateSystem : EntitySystem
+{
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    private readonly Dictionary<NetUserId, GameTick> _lastRealTicks = new();
+
+    public override void Initialize()
+    {
+        SubscribeNetworkEvent<ClientLastRealTickChanged>(OnClientLastRealTick);
+    }
+
+    private void OnClientLastRealTick(ClientLastRealTickChanged msg, EntitySessionEventArgs args)
+    {
+        SetLastRealTick(args.SenderSession.UserId, msg.Tick);
+    }
+
+    public GameTick GetLastRealTick(NetUserId? session)
+    {
+        if (_net.IsClient)
+            return _timing.LastRealTick;
+
+        return session == null ? _timing.CurTick : _lastRealTicks.GetValueOrDefault(session.Value, _timing.CurTick);
+    }
+
+    internal void SetLastRealTick(NetUserId session, GameTick tick)
+    {
+        if (_net.IsClient)
+            return;
+
+        _lastRealTicks[session] = tick;
+    }
+}

--- a/Robust.Shared/Timing/GameTiming.cs
+++ b/Robust.Shared/Timing/GameTiming.cs
@@ -125,6 +125,8 @@ namespace Robust.Shared.Timing
         /// </summary>
         public TimeSpan LastTick { get; set; }
 
+        public GameTick LastRealTick { get; set; }
+
         private ushort _tickRate;
         private TimeSpan _tickRemainder;
 

--- a/Robust.Shared/Timing/IGameTiming.cs
+++ b/Robust.Shared/Timing/IGameTiming.cs
@@ -1,5 +1,4 @@
 using System;
-using JetBrains.Annotations;
 using Robust.Shared.IoC;
 
 namespace Robust.Shared.Timing
@@ -89,6 +88,13 @@ namespace Robust.Shared.Timing
         TimeSpan LastTick { get; set; }
 
         /// <summary>
+        /// The last real non-extrapolated server state that was applied. Without networking issues, this tick should
+        /// always correspond to <see cref="LastRealTick"/>, however if there is a missing states or the buffer has run
+        /// out, this value may be smaller..
+        /// </summary>
+        GameTick LastRealTick { get; set; }
+
+        /// <summary>
         ///     The target ticks/second of the simulation.
         /// </summary>
         ushort TickRate { get; set; }
@@ -147,7 +153,7 @@ namespace Robust.Shared.Timing
         bool IsFirstTimePredicted { get; }
 
         /// <summary>
-        /// True if CurTick is ahead of LastRealTick, and <see cref="ApplyingState"/> is false.
+        /// True if CurTick is ahead of <see cref="LastRealTick"/>, and <see cref="ApplyingState"/> is false.
         /// </summary>
         bool InPrediction { get; }
 

--- a/Robust.Shared/Timing/IGameTiming.cs
+++ b/Robust.Shared/Timing/IGameTiming.cs
@@ -1,4 +1,5 @@
 using System;
+using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 
 namespace Robust.Shared.Timing
@@ -88,9 +89,11 @@ namespace Robust.Shared.Timing
         TimeSpan LastTick { get; set; }
 
         /// <summary>
-        /// The last real non-extrapolated server state that was applied. Without networking issues, this tick should
-        /// always correspond to <see cref="LastRealTick"/>, however if there is a missing states or the buffer has run
-        /// out, this value may be smaller..
+        ///     The last real non-extrapolated server state that was applied. Without networking issues, this tick should
+        ///     always correspond to <see cref="LastRealTick"/>, however if there is a missing states or the buffer has run
+        ///     out, this value may be smaller.
+        ///     On the server, this value is not changed. See <see cref="GameStateSystem.GetLastRealTick"/> if you
+        ///     need a specific client's last real tick from the server or shared code.
         /// </summary>
         GameTick LastRealTick { get; set; }
 


### PR DESCRIPTION
So for lag compensation, right now it offsets by ping which is not reliable
Much more reliable way is to keep track of the client's last real tick to know how much to rewind positions on the server
For melee and (rmc) gun prediction, you can just send that in the request shoot event or melee event
Problem is, interaction events for example are handled through input events, which are engine-only so you cannot send that data inside them
This makes the engine do the last real tick book-keeping for you without bringing the entire lag compensation system into the engine

Tiny problem with this is the engine is ahead by 1 tick compared to doing it by hand in an event on content
Also other tiny problem is it spams late msgentity (see tests)