### PR TITLE
Swap toolshed.nearby_* cvars

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -48,6 +48,7 @@ END TEMPLATE-->
 ### Other
 
 * `IResourceManager.GetContentRoots()` has been obsoleted and returns no more results.
+* The default values of the `toolshed.nearby_limit` and `toolshed.nearby_entities_limit` have been swapped.
 
 ### Internal
 

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1883,14 +1883,14 @@ namespace Robust.Shared
         ///     Any higher value will cause an exception.
         /// </summary>
         public static readonly CVarDef<int> ToolshedNearbyLimit =
-            CVarDef.Create("toolshed.nearby_limit", 200, CVar.SERVER | CVar.REPLICATED);
+            CVarDef.Create("toolshed.nearby_limit", 5, CVar.SERVER | CVar.REPLICATED);
 
         /// <summary>
         ///     The max amount of entities that can be passed to the nearby toolshed command.
         ///     Any higher value will cause an exception.
         /// </summary>
         public static readonly CVarDef<int> ToolshedNearbyEntitiesLimit =
-            CVarDef.Create("toolshed.nearby_entities_limit", 5, CVar.SERVER | CVar.REPLICATED);
+            CVarDef.Create("toolshed.nearby_entities_limit", 200, CVar.SERVER | CVar.REPLICATED);
 
         /// <summary>
         ///     The max amount of prototype ids that can be sent to the client when autocompleting prototype ids.


### PR DESCRIPTION
Swaps the default values of two cvars for toolshed's nearby command. I assume they were accidentally swapped, because an entity limit of 5 with a range limit of 200 doesn't really make sense.