### PR TITLE
Add public control sawmill to UI Manager

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Added `IUserInterfaceManager.ControlSawmill` and `Control.Log` properties so that controls can easily use logging without using static methods.
 
 ### Bugfixes
 
@@ -59,7 +59,6 @@ END TEMPLATE-->
 ### New features
 
 * Sprites and Sprite layers have a new `Loop` data field that can be set to false to automatically pause animations once they have finished.
-* Added `IUserInterfaceManager.ControlSawmill` and `Control.Log` properties so that controls can easily use logging without using static methods.
 
 ### Bugfixes
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -40,6 +40,7 @@ END TEMPLATE-->
 ### New features
 
 * Sprites and Sprite layers have a new `Loop` data field that can be set to false to automatically pause animations once they have finished.
+* Added `IUserInterfaceManager.ControlSawmill` and `Control.Log` properties so that controls can easily use logging without using static methods.
 
 ### Bugfixes
 

--- a/Robust.Client/UserInterface/Control.cs
+++ b/Robust.Client/UserInterface/Control.cs
@@ -11,6 +11,7 @@ using Robust.Client.UserInterface.Themes;
 using Robust.Client.UserInterface.XAML;
 using Robust.Shared.Animations;
 using Robust.Shared.IoC;
+using Robust.Shared.Log;
 using Robust.Shared.Maths;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -73,6 +74,8 @@ namespace Robust.Client.UserInterface
         //{
         //    _nameScope = nameScope;
         //}
+
+        public virtual ISawmill Log => UserInterfaceManager.ControlSawmill;
 
         public UITheme Theme { get; internal set; }
 
@@ -380,8 +383,6 @@ namespace Robust.Client.UserInterface
         /// custom tooltip controls.
         /// </summary>
         public event EventHandler? OnShowTooltip;
-
-
 
         /// <summary>
         /// If this control is currently showing a tooltip provided via TooltipSupplier,

--- a/Robust.Client/UserInterface/IUserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/IUserInterfaceManager.cs
@@ -6,6 +6,7 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared;
 using Robust.Shared.Audio.Sources;
+using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 
@@ -157,6 +158,14 @@ namespace Robust.Client.UserInterface
         /// Render a control and all of its children.
         /// </summary>
         void RenderControl(IRenderHandle handle, Control control, Vector2i position);
+
+        /// <summary>
+        /// Sawmill for use by controls.
+        /// </summary>
+        /// <remarks>
+        /// Exists so that control don't have to inject dependencies or otherwise obtain an <see cref="ILogManager"/> instance just to log errors.
+        /// </remarks>
+        ISawmill ControlSawmill { get; }
     }
 
     public readonly struct PostDrawUIRootEventArgs

--- a/Robust.Client/UserInterface/RichText/MarkupTagManager.cs
+++ b/Robust.Client/UserInterface/RichText/MarkupTagManager.cs
@@ -4,14 +4,13 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Robust.Shared.IoC;
 using Robust.Shared.Reflection;
-using Robust.Shared.Sandboxing;
 
 namespace Robust.Client.UserInterface.RichText;
 
 public sealed class MarkupTagManager
 {
     [Dependency] private readonly IReflectionManager _reflectionManager = default!;
-    [Dependency] private readonly ISandboxHelper _sandboxHelper = default!;
+    [Dependency] private readonly IDynamicTypeFactory _factory = default!;
 
     /// <summary>
     /// Tags defined in engine need to be instantiated here because of sandboxing
@@ -50,13 +49,8 @@ public sealed class MarkupTagManager
             if (_engineTypes.Contains(type))
                 continue;
 
-            var instance = (IMarkupTagHandler)_sandboxHelper.CreateInstance(type);
+            var instance = _factory.CreateInstance<IMarkupTagHandler>(type, oneOff:true);
             _markupTagTypes[instance.Name.ToLower()] = instance;
-        }
-
-        foreach (var (_, tag) in _markupTagTypes)
-        {
-            IoCManager.InjectDependencies(tag);
         }
     }
 

--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -95,6 +95,7 @@ namespace Robust.Client.UserInterface
         private Stylesheet? _stylesheet;
 
         private ISawmill _sawmillUI = default!;
+        public ISawmill ControlSawmill { get; private set; } = default!;
 
         public event Action<Control>? OnKeyBindDown;
 
@@ -142,6 +143,7 @@ namespace Robust.Client.UserInterface
         private void _initializeCommon()
         {
             _sawmillUI = _logManager.GetSawmill("ui");
+            ControlSawmill = _logManager.GetSawmill("ctrl");
 
             RootControl = CreateWindowRoot(_clyde.MainWindow);
             RootControl.Name = "MainWindowRoot";

--- a/Robust.Shared/Log/Logger.cs
+++ b/Robust.Shared/Log/Logger.cs
@@ -19,7 +19,7 @@ namespace Robust.Shared.Log
         ///     The instance we're using.
         ///     As it's a direct proxy to IoC this will not work if IoC is not functional.
         /// </summary>
-        // TODO: Maybe cache this to improve performance.
+        // TODO: Kill
         private static ILogManager LogManagerSingleton => IoCManager.Resolve<ILogManager>();
 
         /// <summary>


### PR DESCRIPTION
A lot of controls use the static logger methods to log errors, and there's no easy way for them to use non static methods as they don't get dependencies injected. Maybe that can be changed whenever the static UI Manager resolve in the `Control` constructor is removed, but for now I think UI manager should provide a sawmill for controls. So this PR adds `IUserInterfaceManager.ControlSawmill` and `Control.Log` to try help remove static resolves.

This PR also removes the static resolves in `MarkupTagManager`.