### PR TITLE
Obsolete static IoC methods

### DIFF
--- a/Robust.Client/ResourceManagement/ResourceCache.cs
+++ b/Robust.Client/ResourceManagement/ResourceCache.cs
@@ -7,7 +7,6 @@ using System.Runtime.CompilerServices;
 using Robust.Client.Audio;
 using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
-using Robust.Shared.Log;
 using Robust.Shared.Utility;
 
 namespace Robust.Client.ResourceManagement;
@@ -17,6 +16,7 @@ namespace Robust.Client.ResourceManagement;
 /// </summary>
 internal sealed partial class ResourceCache : ResourceManager, IResourceCacheInternal, IDisposable
 {
+    [Shared.IoC.Dependency] private readonly IDependencyCollection _deps = default!;
     private readonly Dictionary<Type, TypeData> _cachedResources = new();
     private readonly Dictionary<Type, BaseResource> _fallbacks = new();
 
@@ -36,8 +36,7 @@ internal sealed partial class ResourceCache : ResourceManager, IResourceCacheInt
         var resource = new T();
         try
         {
-            var dependencies = IoCManager.Instance!;
-            resource.Load(dependencies, path);
+            resource.Load(_deps, path);
             cache.Resources[path] = resource;
             return resource;
         }
@@ -81,8 +80,7 @@ internal sealed partial class ResourceCache : ResourceManager, IResourceCacheInt
         var _resource = new T();
         try
         {
-            var dependencies = IoCManager.Instance!;
-            _resource.Load(dependencies, path);
+            _resource.Load(_deps, path);
             resource = _resource;
             cache.Resources[path] = resource;
             return true;
@@ -123,8 +121,7 @@ internal sealed partial class ResourceCache : ResourceManager, IResourceCacheInt
 
         try
         {
-            var dependencies = IoCManager.Instance!;
-            res.Reload(dependencies, path);
+            res.Reload(_deps, path);
         }
         catch (Exception e)
         {

--- a/Robust.Shared/IoC/IoCManager.cs
+++ b/Robust.Shared/IoC/IoCManager.cs
@@ -50,6 +50,7 @@ namespace Robust.Shared.IoC
         /// <remarks>
         /// This property will be null if <see cref="InitThread()"/> has not been called on this thread yet.
         /// </remarks>
+        [Obsolete("Resolve the IDependencyCollection directly without static methods (e.g., with a [Dependency] IDependencyCollection field)")]
         public static IDependencyCollection? Instance => _container.IsValueCreated ? _container.Value : null;
 
         /// <summary>
@@ -102,6 +103,7 @@ namespace Robust.Shared.IoC
         /// Thrown if <paramref name="overwrite"/> is false and <typeparamref name="TInterface"/> has been registered before,
         /// or if an already instantiated interface (by <see cref="BuildGraph"/>) is attempting to be overwritten.
         /// </exception>
+        [Obsolete("Use an IDependencyCollection instance instead of static methods")]
         public static void Register<TInterface, [MeansImplicitUse] TImplementation>(bool overwrite = false)
             where TImplementation : class, TInterface
             where TInterface : class
@@ -123,6 +125,7 @@ namespace Robust.Shared.IoC
         /// Thrown if <paramref name="overwrite"/> is false and <typeparamref name="T"/> has been registered before,
         /// or if an already instantiated interface (by <see cref="BuildGraph"/>) is attempting to be overwritten.
         /// </exception>
+        [Obsolete("Use an IDependencyCollection instance instead of static methods")]
         public static void Register<[MeansImplicitUse] T>(bool overwrite = false) where T : class
         {
             Register<T, T>(overwrite);
@@ -143,6 +146,7 @@ namespace Robust.Shared.IoC
         /// Thrown if <paramref name="overwrite"/> is false and <typeparamref name="TInterface"/> has been registered before,
         /// or if an already instantiated interface (by <see cref="BuildGraph"/>) is attempting to be overwritten.
         /// </exception>
+        [Obsolete("Use an IDependencyCollection instance instead of static methods")]
         public static void Register<TInterface, TImplementation>(DependencyFactoryDelegate<TImplementation> factory, bool overwrite = false)
             where TImplementation : class, TInterface
             where TInterface : class
@@ -165,6 +169,7 @@ namespace Robust.Shared.IoC
         ///     If true, do not throw an <see cref="InvalidOperationException"/> if an interface is already registered,
         ///     replace the current implementation instead.
         /// </param>
+        [Obsolete("Use an IDependencyCollection instance instead of static methods")]
         public static void RegisterInstance<TInterface>(object implementation, bool overwrite = false)
             where TInterface : class
         {
@@ -193,6 +198,7 @@ namespace Robust.Shared.IoC
         /// because the object graph still needs to be constructed for it.
         /// </exception>
         [System.Diagnostics.Contracts.Pure]
+        [Obsolete("Use dependency injection or an IDependencyCollection instance instead of static methods")]
         public static T Resolve<T>()
         {
             DebugTools.Assert(_container.IsValueCreated, NoContextAssert);
@@ -202,6 +208,7 @@ namespace Robust.Shared.IoC
 
         /// <inheritdoc cref="Resolve{T}()"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Obsolete("Use dependency injection or an IDependencyCollection instance instead of static methods")]
         public static void Resolve<T>([NotNull] ref T? instance)
         {
             // Do not call into IDependencyCollection immediately for this,
@@ -214,6 +221,7 @@ namespace Robust.Shared.IoC
         /// Resolve two dependencies manually.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Obsolete("Use dependency injection or an IDependencyCollection instance instead of static methods")]
         public static void Resolve<T1, T2>([NotNull] ref T1? instance1, [NotNull] ref T2? instance2)
         {
             DebugTools.Assert(_container.IsValueCreated, NoContextAssert);
@@ -226,6 +234,7 @@ namespace Robust.Shared.IoC
         /// Resolve three dependencies manually.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Obsolete("Use dependency injection or an IDependencyCollection instance instead of static methods")]
         public static void Resolve<T1, T2, T3>([NotNull] ref T1? instance1, [NotNull] ref T2? instance2, [NotNull] ref T3? instance3)
         {
             DebugTools.Assert(_container.IsValueCreated, NoContextAssert);
@@ -238,6 +247,7 @@ namespace Robust.Shared.IoC
         /// Resolve four dependencies manually.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Obsolete("Use dependency injection or an IDependencyCollection instance instead of static methods")]
         public static void Resolve<T1, T2, T3, T4>([NotNull] ref T1? instance1, [NotNull] ref T2? instance2, [NotNull] ref T3? instance3, [NotNull] ref T4? instance4)
         {
             DebugTools.Assert(_container.IsValueCreated, NoContextAssert);
@@ -254,6 +264,7 @@ namespace Robust.Shared.IoC
         /// because the object graph still needs to be constructed for it.
         /// </exception>
         [System.Diagnostics.Contracts.Pure]
+        [Obsolete("Use dependency injection or an IDependencyCollection instance instead of static methods")]
         public static object ResolveType(Type type)
         {
             DebugTools.Assert(_container.IsValueCreated, NoContextAssert);
@@ -284,6 +295,7 @@ namespace Robust.Shared.IoC
         ///     Thrown if a dependency field on the object is not registered.
         /// </exception>
         /// <seealso cref="BuildGraph"/>
+        [Obsolete("Use an IDependencyCollection instance instead of static methods")]
         public static T InjectDependencies<T>(T obj) where T : notnull
         {
             DebugTools.Assert(_container.IsValueCreated, NoContextAssert);

--- a/Robust.Shared/Toolshed/Commands/Misc/IoCCommand.cs
+++ b/Robust.Shared/Toolshed/Commands/Misc/IoCCommand.cs
@@ -7,9 +7,10 @@ namespace Robust.Shared.Toolshed.Commands.Misc;
 [ToolshedCommand]
 internal sealed class IoCCommand : ToolshedCommand
 {
+    [Dependency] private readonly IDependencyCollection _deps = default!;
     [CommandImplementation("registered")]
-    public IEnumerable<Type> Registered() => IoCManager.Instance!.GetRegisteredTypes();
+    public IEnumerable<Type> Registered() => _deps.GetRegisteredTypes();
 
     [CommandImplementation("get")]
-    public object? Get([PipedArgument] Type t) => IoCManager.ResolveType(t);
+    public object? Get([PipedArgument] Type t) => _deps.ResolveType(t);
 }

--- a/Robust.Shared/ViewVariables/ViewVariablesManager.Domains.cs
+++ b/Robust.Shared/ViewVariables/ViewVariablesManager.Domains.cs
@@ -43,9 +43,9 @@ internal abstract partial class ViewVariablesManager
 
     private (ViewVariablesPath? Path, string[] Segments) ResolveIoCObject(string path)
     {
-        var empty = (new ViewVariablesInstancePath(IoCManager.Instance), Array.Empty<string>());
+        var empty = (new ViewVariablesInstancePath(_deps), Array.Empty<string>());
 
-        if (string.IsNullOrEmpty(path) || IoCManager.Instance == null)
+        if (string.IsNullOrEmpty(path))
             return empty;
 
         var segments = path.Split('/');
@@ -58,24 +58,24 @@ internal abstract partial class ViewVariablesManager
         if (!_reflectionMan.TryLooseGetType(service, out var type))
             return EmptyResolve;
 
-        return IoCManager.Instance.TryResolveType(type, out var obj)
+        return _deps.TryResolveType(type, out var obj)
             ? (new ViewVariablesInstancePath(obj), segments[1..])
             : EmptyResolve;
     }
 
     private IEnumerable<string>? ListIoCPaths(string[] segments)
     {
-        if (segments.Length > 1 || IoCManager.Instance is not {} deps)
+        if (segments.Length > 1)
             return null;
 
         if (segments.Length == 1
             && _reflectionMan.TryLooseGetType(segments[0], out var type)
-            && deps.TryResolveType(type, out _))
+            && _deps.TryResolveType(type, out _))
         {
             return null;
         }
 
-        return deps.GetRegisteredTypes()
+        return _deps.GetRegisteredTypes()
             .Select(t => t.Name);
     }
 
@@ -161,7 +161,7 @@ internal abstract partial class ViewVariablesManager
     {
         var empty = (new ViewVariablesInstancePath(_protoMan), Array.Empty<string>());
 
-        if (string.IsNullOrEmpty(path) || IoCManager.Instance == null)
+        if (string.IsNullOrEmpty(path))
             return empty;
 
         var segments = path.Split('/');

--- a/Robust.Shared/ViewVariables/ViewVariablesManager.cs
+++ b/Robust.Shared/ViewVariables/ViewVariablesManager.cs
@@ -22,6 +22,7 @@ internal abstract partial class ViewVariablesManager : IViewVariablesManager, IP
     [Dependency] private readonly IReflectionManager _reflectionMan = default!;
     [Dependency] private readonly INetManager _netMan = default!;
     [Dependency] private readonly ILogManager _logMan = default!;
+    [Dependency] private readonly IDependencyCollection _deps = default!;
 
     private readonly Dictionary<Type, HashSet<object>> _cachedTraits = new();
 

--- a/Robust.UnitTesting/Shared/IoC/IoCManager_Test.cs
+++ b/Robust.UnitTesting/Shared/IoC/IoCManager_Test.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using Robust.Shared.Analyzers;
 using Robust.Shared.IoC;
 using Robust.Shared.IoC.Exceptions;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace Robust.UnitTesting.Shared.IoC
 {

--- a/Robust.UnitTesting/Shared/Localization/LoadLocalizationTest.cs
+++ b/Robust.UnitTesting/Shared/Localization/LoadLocalizationTest.cs
@@ -6,6 +6,7 @@ using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Log;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace Robust.UnitTesting.Shared.Localization;
 

--- a/Robust.UnitTesting/Shared/Reflection/ReflectionManager_Test.cs
+++ b/Robust.UnitTesting/Shared/Reflection/ReflectionManager_Test.cs
@@ -3,6 +3,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Reflection;
 using System.Collections.Generic;
 using JetBrains.Annotations;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace Robust.UnitTesting.Shared.Reflection
 {


### PR DESCRIPTION
This PR marks most of the static IoCManager methods as obsolete. A lot of the time when people try to fix currently obsolete methods like the static loggers, they end up just replacing with with static ioc resolves, which just kicks the can down the road. So I'd rather just mark them as obsolete now. This PR also removes a few uses of the static methods, but there are still a lot elsewhere in the engine.

The main reason i can think of to not do this is that there are probably still a few instances where we don't currently have a great alternative (e.g., the `Control` constructor). So those instances might lead to confusion when the expected solution is to still use an obsoleted method.