### PR TITLE
Replace sprite layer keys with a LayerKey struct

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,9 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Sprite layer keys now use a new LayerKey struct instead of string, enum, or object keys.
+  * The struct is backed by either a string or enum key, and supports implicit casts from those types.
+  * Arbitrary object keys are no longer supported.
 
 ### Bugfixes
 

--- a/Robust.Client/GameObjects/Components/Appearance/GenericVisualizerComponent.cs
+++ b/Robust.Client/GameObjects/Components/Appearance/GenericVisualizerComponent.cs
@@ -2,6 +2,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization.Manager.Attributes;
 using System;
 using System.Collections.Generic;
+using Robust.Shared.Sprite;
 
 namespace Robust.Client.GameObjects;
 
@@ -20,5 +21,5 @@ public sealed partial class GenericVisualizerComponent : Component
     ///     In most instances, each of these dictionaries will probably only have a single entry.
     /// </summary>
     [DataField("visuals", required:true)]
-    public Dictionary<Enum, Dictionary<string, Dictionary<string, PrototypeLayerData>>> Visuals = default!;
+    public Dictionary<Enum, Dictionary<LayerKey, Dictionary<string, PrototypeLayerData>>> Visuals = default!;
 }

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -25,6 +25,7 @@ using Robust.Shared.Reflection;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Robust.Shared.Sprite;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 using DrawDepthTag = Robust.Shared.GameObjects.DrawDepth;
@@ -62,7 +63,7 @@ namespace Robust.Client.GameObjects
         // VV convenience variable to examine layer objects using layer keys
         // ReSharper disable once UnusedMember.Local
         [ViewVariables]
-        private Dictionary<object, Layer> MappedLayers => LayerMap.ToDictionary(x => x.Key, x => Layers[x.Value]);
+        private Dictionary<LayerKey, Layer> MappedLayers => LayerMap.ToDictionary(x => x.Key, x => Layers[x.Value]);
 
         [ViewVariables(VVAccess.ReadWrite)]
         public bool Visible
@@ -231,18 +232,32 @@ namespace Robust.Client.GameObjects
         [DataField]
         public bool RaiseShaderEvent;
 
-        [ViewVariables] internal Dictionary<object, int> LayerMap { get; set; } = new();
+        [ViewVariables] internal Dictionary<LayerKey, int> LayerMap { get; set; } = new();
         [ViewVariables] internal List<Layer> Layers = new();
 
         [ViewVariables(VVAccess.ReadWrite)] public uint RenderOrder { get; set; }
 
         [ViewVariables(VVAccess.ReadWrite)] public bool IsInert { get; internal set; }
 
+        [Obsolete("Use SpriteSystem.TryGetLayer()")]
         public ISpriteLayer this[int layer] => Layers[layer];
-        public ISpriteLayer this[Index layer] => Layers[layer];
-        public ISpriteLayer this[object layerKey] => this[LayerMap[layerKey]];
-        public IEnumerable<ISpriteLayer> AllLayers => Layers;
 
+        [Obsolete("Use SpriteSystem.TryGetLayer()")]
+        public ISpriteLayer this[Index layer] => Layers[layer];
+
+        [Obsolete("Use SpriteSystem.TryGetLayer()")]
+
+        public ISpriteLayer this[object layerKey] => this[LayerMap[AsKey(layerKey)]];
+
+        private static LayerKey AsKey(object obj) => obj switch
+        {
+            string s => s,
+            Enum e => e,
+            LayerKey k => k,
+            _ => throw new Exception($"Key must be either string, enum, or LayerKey but got {obj.GetType().Name}")
+        };
+
+        public IEnumerable<ISpriteLayer> AllLayers => Layers;
         void ISerializationHooks.AfterDeserialization()
         {
             // Please somebody burn this to the ground. There is so much spaghetti.
@@ -329,25 +344,25 @@ namespace Robust.Client.GameObjects
                 throw new ArgumentOutOfRangeException();
             }
 
-            LayerMap.Add(key, layer);
+            LayerMap.Add(AsKey(key), layer);
         }
 
         [Obsolete("Use SpriteSystem.LayerMapRemove() instead.")]
         public void LayerMapRemove(object key)
         {
-            LayerMap.Remove(key);
+            LayerMap.Remove(AsKey(key));
         }
 
         [Obsolete("Use SpriteSystem.LayerMapGet() instead.")]
         public int LayerMapGet(object key)
         {
-            return LayerMap[key];
+            return LayerMap[AsKey(key)];
         }
 
         [Obsolete("Use SpriteSystem.LayerMapTryGet() instead.")]
         public bool LayerMapTryGet(object key, out int layer, bool logError = false)
         {
-            var result = LayerMap.TryGetValue(key, out layer);
+            var result = LayerMap.TryGetValue(AsKey(key), out layer);
 
             if (!result && logError)
             {
@@ -596,7 +611,7 @@ namespace Robust.Client.GameObjects
             {
                 foreach (var keyString in layerDatum.MapKeys)
                 {
-                    var key = ParseKey(keyString);
+                    var key = LayerKey.Parse(reflection, keyString);
 
                     if (LayerMap.TryGetValue(key, out var mappedIndex))
                     {
@@ -624,7 +639,7 @@ namespace Robust.Client.GameObjects
 
             if (layerDatum.CopyToShaderParameters is { } copyParameters)
             {
-                layer.CopyToShaderParameters = new CopyToShaderParameters(ParseKey(copyParameters.LayerKey))
+                layer.CopyToShaderParameters = new CopyToShaderParameters(copyParameters.LayerKey)
                 {
                     ParameterTexture = copyParameters.ParameterTexture,
                     ParameterUV = copyParameters.ParameterUV
@@ -640,14 +655,6 @@ namespace Robust.Client.GameObjects
             // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
             if (Owner != EntityUid.Invalid)
                 TreeSys?.QueueTreeUpdate((Owner, this));
-        }
-
-        private object ParseKey(string keyString)
-        {
-            if (reflection.TryParseEnumReference(keyString, out var @enum))
-                return @enum;
-
-            return keyString;
         }
 
         [Obsolete("Use SpriteSystem.LayerSetData() instead.")]
@@ -1756,9 +1763,9 @@ namespace Robust.Client.GameObjects
         /// Instantiated version of <see cref="PrototypeCopyToShaderParameters"/>.
         /// Has <see cref="LayerKey"/> actually resolved to a a real key.
         /// </summary>
-        public sealed class CopyToShaderParameters(object layerKey)
+        public sealed class CopyToShaderParameters(LayerKey layerKey)
         {
-            public object LayerKey = layerKey;
+            public LayerKey LayerKey = layerKey;
             public string? ParameterTexture;
             public string? ParameterUV;
 
@@ -1766,6 +1773,11 @@ namespace Robust.Client.GameObjects
             {
                 ParameterTexture = toClone.ParameterTexture;
                 ParameterUV = toClone.ParameterUV;
+            }
+
+            [Obsolete("Use LayerKey instead of object")]
+            public CopyToShaderParameters(object layerKey) : this(AsKey(layerKey))
+            {
             }
         }
 

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Layer.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Layer.cs
@@ -20,15 +20,48 @@ public sealed partial class SpriteSystem
         return index > 0 && index < sprite.Comp.Layers.Count;
     }
 
+    [Obsolete("Use ResolveLayer or the override without a bool argument")]
     public bool TryGetLayer(
         Entity<SpriteComponent?> sprite,
         int index,
         [NotNullWhen(true)] out Layer? layer,
         bool logMissing)
     {
-        layer = null;
+        return logMissing
+            ? ResolveLayer(sprite, index, out layer)
+            : TryGetLayer(sprite, index, out layer);
+    }
 
-        if (!_query.Resolve(sprite.Owner, ref sprite.Comp, logMissing))
+    /// <summary>
+    /// Attempt to get the layer corresponding to the given index.
+    /// </summary>
+    public bool TryGetLayer(
+        Entity<SpriteComponent?> sprite,
+        int index,
+        [NotNullWhen(true)] out Layer? layer)
+    {
+        layer = null;
+        if (!_query.Resolve(sprite.Owner, ref sprite.Comp))
+            return false;
+
+        if (index >= 0 && index < sprite.Comp.Layers.Count)
+        {
+            layer = sprite.Comp.Layers[index];
+            DebugTools.AssertEqual(layer.Owner, sprite!);
+            DebugTools.AssertEqual(layer.Index, index);
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Attempt to resolve the layer corresponding to the given index. This will log an error if there is no layer
+    /// with the given index.
+    /// </summary>
+    public bool ResolveLayer(Entity<SpriteComponent?> sprite, int index, [NotNullWhen(true)] out Layer? layer)
+    {
+        layer = null;
+        if (!_query.Resolve(sprite.Owner, ref sprite.Comp))
             return false;
 
         if (index >= 0 && index < sprite.Comp.Layers.Count)
@@ -39,9 +72,7 @@ public sealed partial class SpriteSystem
             return true;
         }
 
-        if (logMissing)
-            Log.Error($"Layer index '{index}' on entity {ToPrettyString(sprite)} does not exist! Trace:\n{Environment.StackTrace}");
-
+        Log.Error($"Layer index '{index}' on entity {ToPrettyString(sprite)} does not exist! Trace:\n{Environment.StackTrace}");
         return false;
     }
 
@@ -60,8 +91,16 @@ public sealed partial class SpriteSystem
         if (!_query.Resolve(sprite.Owner, ref sprite.Comp, logMissing))
             return false;
 
-        if (!TryGetLayer(sprite, index, out layer, logMissing))
-            return false;
+        if (logMissing)
+        {
+            if (!ResolveLayer(sprite, index, out layer))
+                return false;
+        }
+        else
+        {
+            if (!TryGetLayer(sprite, index, out layer))
+                return false;
+        }
 
         sprite.Comp.Layers.RemoveAt(index);
 

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.LayerGetters.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.LayerGetters.cs
@@ -2,6 +2,7 @@ using System;
 using Robust.Client.Graphics;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Graphics.RSI;
+using Robust.Shared.Sprite;
 using static Robust.Client.GameObjects.SpriteComponent;
 using static Robust.Client.Graphics.RSI;
 
@@ -18,34 +19,16 @@ public sealed partial class SpriteSystem
     /// </summary>
     public StateId LayerGetRsiState(Entity<SpriteComponent?> sprite, int index)
     {
-        if (TryGetLayer(sprite, index, out var layer, true))
-            return layer.StateId;
-
-        return StateId.Invalid;
+        return ResolveLayer(sprite, index, out var layer) ? layer.StateId : StateId.Invalid;
     }
 
     /// <summary>
     /// Get the RSI state being used by the current layer. Note that the return value may be an invalid state. E.g.,
     /// this might be a texture layer that does not use RSIs.
     /// </summary>
-    public StateId LayerGetRsiState(Entity<SpriteComponent?> sprite, string key, StateId state)
+    public StateId LayerGetRsiState(Entity<SpriteComponent?> sprite, LayerKey key, StateId state)
     {
-        if (TryGetLayer(sprite, key, out var layer, true))
-            return layer.StateId;
-
-        return StateId.Invalid;
-    }
-
-    /// <summary>
-    /// Get the RSI state being used by the current layer. Note that the return value may be an invalid state. E.g.,
-    /// this might be a texture layer that does not use RSIs.
-    /// </summary>
-    public StateId LayerGetRsiState(Entity<SpriteComponent?> sprite, Enum key, StateId state)
-    {
-        if (TryGetLayer(sprite, key, out var layer, true))
-            return layer.StateId;
-
-        return StateId.Invalid;
+        return ResolveLayer(sprite, key, out var layer) ? layer.StateId : StateId.Invalid;
     }
 
     #endregion
@@ -58,7 +41,7 @@ public sealed partial class SpriteSystem
     /// </summary>
     public RSI? LayerGetEffectiveRsi(Entity<SpriteComponent?> sprite, int index)
     {
-        TryGetLayer(sprite, index, out var layer, true);
+        ResolveLayer(sprite, index, out var layer);
         return layer?.ActualRsi;
     }
 
@@ -66,19 +49,9 @@ public sealed partial class SpriteSystem
     /// Returns the RSI being used by the layer to resolve it's RSI state. If the layer does not specify an RSI, this
     /// will just be the base RSI of the owning sprite (<see cref="SpriteComponent.BaseRSI"/>).
     /// </summary>
-    public RSI? LayerGetEffectiveRsi(Entity<SpriteComponent?> sprite, string key, StateId state)
+    public RSI? LayerGetEffectiveRsi(Entity<SpriteComponent?> sprite, LayerKey key, StateId state)
     {
-        TryGetLayer(sprite, key, out var layer, true);
-        return layer?.ActualRsi;
-    }
-
-    /// <summary>
-    /// Returns the RSI being used by the layer to resolve it's RSI state. If the layer does not specify an RSI, this
-    /// will just be the base RSI of the owning sprite (<see cref="SpriteComponent.BaseRSI"/>).
-    /// </summary>
-    public RSI? LayerGetEffectiveRsi(Entity<SpriteComponent?> sprite, Enum key, StateId state)
-    {
-        TryGetLayer(sprite, key, out var layer, true);
+        ResolveLayer(sprite, key, out var layer);
         return layer?.ActualRsi;
     }
 
@@ -88,22 +61,14 @@ public sealed partial class SpriteSystem
 
     public RsiDirectionType LayerGetDirections(Entity<SpriteComponent?> sprite, int index)
     {
-        return TryGetLayer(sprite, index, out var layer, true)
+        return ResolveLayer(sprite, index, out var layer)
             ? LayerGetDirections(layer)
             : RsiDirectionType.Dir1;
     }
 
-
-    public RsiDirectionType LayerGetDirections(Entity<SpriteComponent?> sprite, Enum key)
+    public RsiDirectionType LayerGetDirections(Entity<SpriteComponent?> sprite, LayerKey key)
     {
-        return TryGetLayer(sprite, key, out var layer, true)
-            ? LayerGetDirections(layer)
-            : RsiDirectionType.Dir1;
-    }
-
-    public RsiDirectionType LayerGetDirections(Entity<SpriteComponent?> sprite, string key)
-    {
-        return TryGetLayer(sprite, key, out var layer, true)
+        return ResolveLayer(sprite, key, out var layer)
             ? LayerGetDirections(layer)
             : RsiDirectionType.Dir1;
     }
@@ -122,17 +87,12 @@ public sealed partial class SpriteSystem
 
     public int LayerGetDirectionCount(Entity<SpriteComponent?> sprite, int index)
     {
-        return TryGetLayer(sprite, index, out var layer, true) ? LayerGetDirectionCount(layer) : 1;
+        return ResolveLayer(sprite, index, out var layer) ? LayerGetDirectionCount(layer) : 1;
     }
 
-    public int LayerGetDirectionCount(Entity<SpriteComponent?> sprite, Enum key)
+    public int LayerGetDirectionCount(Entity<SpriteComponent?> sprite, LayerKey key)
     {
-        return TryGetLayer(sprite, key, out var layer, true) ? LayerGetDirectionCount(layer) : 1;
-    }
-
-    public int LayerGetDirectionCount(Entity<SpriteComponent?> sprite, string key)
-    {
-        return TryGetLayer(sprite, key, out var layer, true) ? LayerGetDirectionCount(layer) : 1;
+        return ResolveLayer(sprite, key, out var layer) ? LayerGetDirectionCount(layer) : 1;
     }
 
     public int LayerGetDirectionCount(Layer layer)

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.LayerSetters.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.LayerSetters.cs
@@ -4,6 +4,7 @@ using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Maths;
+using Robust.Shared.Sprite;
 using Robust.Shared.Utility;
 using static Robust.Client.GameObjects.SpriteComponent;
 using static Robust.Client.Graphics.RSI;
@@ -19,19 +20,13 @@ public sealed partial class SpriteSystem
 
     public void LayerSetData(Entity<SpriteComponent?> sprite, int index, PrototypeLayerData data)
     {
-        if (TryGetLayer(sprite, index, out var layer, true))
+        if (ResolveLayer(sprite, index, out var layer))
             LayerSetData(layer, data);
     }
 
-    public void LayerSetData(Entity<SpriteComponent?> sprite, string key, PrototypeLayerData data)
+    public void LayerSetData(Entity<SpriteComponent?> sprite, LayerKey key, PrototypeLayerData data)
     {
-        if (TryGetLayer(sprite, key, out var layer, true))
-            LayerSetData(layer, data);
-    }
-
-    public void LayerSetData(Entity<SpriteComponent?> sprite, Enum key, PrototypeLayerData data)
-    {
-        if (TryGetLayer(sprite, key, out var layer, true))
+        if (ResolveLayer(sprite, key, out var layer))
             LayerSetData(layer, data);
     }
 
@@ -50,19 +45,13 @@ public sealed partial class SpriteSystem
 
     public void LayerSetSprite(Entity<SpriteComponent?> sprite, int index, SpriteSpecifier specifier)
     {
-        if (TryGetLayer(sprite, index, out var layer, true))
+        if (ResolveLayer(sprite, index, out var layer))
             LayerSetSprite(layer, specifier);
     }
 
-    public void LayerSetSprite(Entity<SpriteComponent?> sprite, string key, SpriteSpecifier specifier)
+    public void LayerSetSprite(Entity<SpriteComponent?> sprite, LayerKey key, SpriteSpecifier specifier)
     {
-        if (TryGetLayer(sprite, key, out var layer, true))
-            LayerSetSprite(layer, specifier);
-    }
-
-    public void LayerSetSprite(Entity<SpriteComponent?> sprite, Enum key, SpriteSpecifier specifier)
-    {
-        if (TryGetLayer(sprite, key, out var layer, true))
+        if (ResolveLayer(sprite, key, out var layer))
             LayerSetSprite(layer, specifier);
     }
 
@@ -89,19 +78,13 @@ public sealed partial class SpriteSystem
 
     public void LayerSetTexture(Entity<SpriteComponent?> sprite, int index, Texture? texture)
     {
-        if (TryGetLayer(sprite, index, out var layer, true))
+        if (ResolveLayer(sprite, index, out var layer))
             LayerSetTexture(layer, texture);
     }
 
-    public void LayerSetTexture(Entity<SpriteComponent?> sprite, string key, Texture? texture)
+    public void LayerSetTexture(Entity<SpriteComponent?> sprite, LayerKey key, Texture? texture)
     {
-        if (TryGetLayer(sprite, key, out var layer, true))
-            LayerSetTexture(layer, texture);
-    }
-
-    public void LayerSetTexture(Entity<SpriteComponent?> sprite, Enum key, Texture? texture)
-    {
-        if (TryGetLayer(sprite, key, out var layer, true))
+        if (ResolveLayer(sprite, key, out var layer))
             LayerSetTexture(layer, texture);
     }
 
@@ -113,19 +96,13 @@ public sealed partial class SpriteSystem
 
     public void LayerSetTexture(Entity<SpriteComponent?> sprite, int index, ResPath path)
     {
-        if (TryGetLayer(sprite, index, out var layer, true))
+        if (ResolveLayer(sprite, index, out var layer))
             LayerSetTexture(layer, path);
     }
 
-    public void LayerSetTexture(Entity<SpriteComponent?> sprite, string key, ResPath path)
+    public void LayerSetTexture(Entity<SpriteComponent?> sprite, LayerKey key, ResPath path)
     {
-        if (TryGetLayer(sprite, key, out var layer, true))
-            LayerSetTexture(layer, path);
-    }
-
-    public void LayerSetTexture(Entity<SpriteComponent?> sprite, Enum key, ResPath path)
-    {
-        if (TryGetLayer(sprite, key, out var layer, true))
+        if (ResolveLayer(sprite, key, out var layer))
             LayerSetTexture(layer, path);
     }
 
@@ -147,19 +124,13 @@ public sealed partial class SpriteSystem
 
     public void LayerSetRsiState(Entity<SpriteComponent?> sprite, int index, StateId state)
     {
-        if (TryGetLayer(sprite, index, out var layer, true))
+        if (ResolveLayer(sprite, index, out var layer))
             LayerSetRsiState(layer, state);
     }
 
-    public void LayerSetRsiState(Entity<SpriteComponent?> sprite, string key, StateId state)
+    public void LayerSetRsiState(Entity<SpriteComponent?> sprite, LayerKey key, StateId state)
     {
-        if (TryGetLayer(sprite, key, out var layer, true))
-            LayerSetRsiState(layer, state);
-    }
-
-    public void LayerSetRsiState(Entity<SpriteComponent?> sprite, Enum key, StateId state)
-    {
-        if (TryGetLayer(sprite, key, out var layer, true))
+        if (ResolveLayer(sprite, key, out var layer))
             LayerSetRsiState(layer, state);
     }
 
@@ -186,19 +157,13 @@ public sealed partial class SpriteSystem
 
     public void LayerSetRsi(Entity<SpriteComponent?> sprite, int index, RSI? rsi, StateId? state = null)
     {
-        if (TryGetLayer(sprite, index, out var layer, true))
+        if (ResolveLayer(sprite, index, out var layer))
             LayerSetRsi(layer, rsi, state);
     }
 
-    public void LayerSetRsi(Entity<SpriteComponent?> sprite, string key, RSI? rsi, StateId? state = null)
+    public void LayerSetRsi(Entity<SpriteComponent?> sprite, LayerKey key, RSI? rsi, StateId? state = null)
     {
-        if (TryGetLayer(sprite, key, out var layer, true))
-            LayerSetRsi(layer, rsi, state);
-    }
-
-    public void LayerSetRsi(Entity<SpriteComponent?> sprite, Enum key, RSI? rsi, StateId? state = null)
-    {
-        if (TryGetLayer(sprite, key, out var layer, true))
+        if (ResolveLayer(sprite, key, out var layer))
             LayerSetRsi(layer, rsi, state);
     }
 
@@ -210,19 +175,13 @@ public sealed partial class SpriteSystem
 
     public void LayerSetRsi(Entity<SpriteComponent?> sprite, int index, ResPath rsi, StateId? state = null)
     {
-        if (TryGetLayer(sprite, index, out var layer, true))
+        if (ResolveLayer(sprite, index, out var layer))
             LayerSetRsi(layer, rsi, state);
     }
 
-    public void LayerSetRsi(Entity<SpriteComponent?> sprite, string key, ResPath rsi, StateId? state = null)
+    public void LayerSetRsi(Entity<SpriteComponent?> sprite, LayerKey key, ResPath rsi, StateId? state = null)
     {
-        if (TryGetLayer(sprite, key, out var layer, true))
-            LayerSetRsi(layer, rsi, state);
-    }
-
-    public void LayerSetRsi(Entity<SpriteComponent?> sprite, Enum key, ResPath rsi, StateId? state = null)
-    {
-        if (TryGetLayer(sprite, key, out var layer, true))
+        if (ResolveLayer(sprite, key, out var layer))
             LayerSetRsi(layer, rsi, state);
     }
 
@@ -240,19 +199,13 @@ public sealed partial class SpriteSystem
 
     public void LayerSetScale(Entity<SpriteComponent?> sprite, int index, Vector2 value)
     {
-        if (TryGetLayer(sprite, index, out var layer, true))
+        if (ResolveLayer(sprite, index, out var layer))
             LayerSetScale(layer, value);
     }
 
-    public void LayerSetScale(Entity<SpriteComponent?> sprite, string key, Vector2 value)
+    public void LayerSetScale(Entity<SpriteComponent?> sprite, LayerKey key, Vector2 value)
     {
-        if (TryGetLayer(sprite, key, out var layer, true))
-            LayerSetScale(layer, value);
-    }
-
-    public void LayerSetScale(Entity<SpriteComponent?> sprite, Enum key, Vector2 value)
-    {
-        if (TryGetLayer(sprite, key, out var layer, true))
+        if (ResolveLayer(sprite, key, out var layer))
             LayerSetScale(layer, value);
     }
 
@@ -281,19 +234,13 @@ public sealed partial class SpriteSystem
 
     public void LayerSetRotation(Entity<SpriteComponent?> sprite, int index, Angle value)
     {
-        if (TryGetLayer(sprite, index, out var layer, true))
+        if (ResolveLayer(sprite, index, out var layer))
             LayerSetRotation(layer, value);
     }
 
-    public void LayerSetRotation(Entity<SpriteComponent?> sprite, string key, Angle value)
+    public void LayerSetRotation(Entity<SpriteComponent?> sprite, LayerKey key, Angle value)
     {
-        if (TryGetLayer(sprite, key, out var layer, true))
-            LayerSetRotation(layer, value);
-    }
-
-    public void LayerSetRotation(Entity<SpriteComponent?> sprite, Enum key, Angle value)
-    {
-        if (TryGetLayer(sprite, key, out var layer, true))
+        if (ResolveLayer(sprite, key, out var layer))
             LayerSetRotation(layer, value);
     }
 
@@ -319,19 +266,13 @@ public sealed partial class SpriteSystem
 
     public void LayerSetOffset(Entity<SpriteComponent?> sprite, int index, Vector2 value)
     {
-        if (TryGetLayer(sprite, index, out var layer, true))
+        if (ResolveLayer(sprite, index, out var layer))
             LayerSetOffset(layer, value);
     }
 
-    public void LayerSetOffset(Entity<SpriteComponent?> sprite, string key, Vector2 value)
+    public void LayerSetOffset(Entity<SpriteComponent?> sprite, LayerKey key, Vector2 value)
     {
-        if (TryGetLayer(sprite, key, out var layer, true))
-            LayerSetOffset(layer, value);
-    }
-
-    public void LayerSetOffset(Entity<SpriteComponent?> sprite, Enum key, Vector2 value)
-    {
-        if (TryGetLayer(sprite, key, out var layer, true))
+        if (ResolveLayer(sprite, key, out var layer))
             LayerSetOffset(layer, value);
     }
 
@@ -357,19 +298,13 @@ public sealed partial class SpriteSystem
 
     public void LayerSetVisible(Entity<SpriteComponent?> sprite, int index, bool value)
     {
-        if (TryGetLayer(sprite, index, out var layer, true))
+        if (ResolveLayer(sprite, index, out var layer))
             LayerSetVisible(layer, value);
     }
 
-    public void LayerSetVisible(Entity<SpriteComponent?> sprite, string key, bool value)
+    public void LayerSetVisible(Entity<SpriteComponent?> sprite, LayerKey key, bool value)
     {
-        if (TryGetLayer(sprite, key, out var layer, true))
-            LayerSetVisible(layer, value);
-    }
-
-    public void LayerSetVisible(Entity<SpriteComponent?> sprite, Enum key, bool value)
-    {
-        if (TryGetLayer(sprite, key, out var layer, true))
+        if (ResolveLayer(sprite, key, out var layer))
             LayerSetVisible(layer, value);
     }
 
@@ -394,19 +329,13 @@ public sealed partial class SpriteSystem
 
     public void LayerSetColor(Entity<SpriteComponent?> sprite, int index, Color value)
     {
-        if (TryGetLayer(sprite, index, out var layer, true))
+        if (ResolveLayer(sprite, index, out var layer))
             LayerSetColor(layer, value);
     }
 
-    public void LayerSetColor(Entity<SpriteComponent?> sprite, string key, Color value)
+    public void LayerSetColor(Entity<SpriteComponent?> sprite, LayerKey key, Color value)
     {
-        if (TryGetLayer(sprite, key, out var layer, true))
-            LayerSetColor(layer, value);
-    }
-
-    public void LayerSetColor(Entity<SpriteComponent?> sprite, Enum key, Color value)
-    {
-        if (TryGetLayer(sprite, key, out var layer, true))
+        if (ResolveLayer(sprite, key, out var layer))
             LayerSetColor(layer, value);
     }
 
@@ -425,19 +354,13 @@ public sealed partial class SpriteSystem
 
     public void LayerSetDirOffset(Entity<SpriteComponent?> sprite, int index, DirectionOffset value)
     {
-        if (TryGetLayer(sprite, index, out var layer, true))
+        if (ResolveLayer(sprite, index, out var layer))
             LayerSetDirOffset(layer, value);
     }
 
-    public void LayerSetDirOffset(Entity<SpriteComponent?> sprite, string key, DirectionOffset value)
+    public void LayerSetDirOffset(Entity<SpriteComponent?> sprite, LayerKey key, DirectionOffset value)
     {
-        if (TryGetLayer(sprite, key, out var layer, true))
-            LayerSetDirOffset(layer, value);
-    }
-
-    public void LayerSetDirOffset(Entity<SpriteComponent?> sprite, Enum key, DirectionOffset value)
-    {
-        if (TryGetLayer(sprite, key, out var layer, true))
+        if (ResolveLayer(sprite, key, out var layer))
             LayerSetDirOffset(layer, value);
     }
 
@@ -456,19 +379,13 @@ public sealed partial class SpriteSystem
 
     public void LayerSetAnimationTime(Entity<SpriteComponent?> sprite, int index, float value)
     {
-        if (TryGetLayer(sprite, index, out var layer, true))
+        if (ResolveLayer(sprite, index, out var layer))
             LayerSetAnimationTime(layer, value);
     }
 
-    public void LayerSetAnimationTime(Entity<SpriteComponent?> sprite, string key, float value)
+    public void LayerSetAnimationTime(Entity<SpriteComponent?> sprite, LayerKey key, float value)
     {
-        if (TryGetLayer(sprite, key, out var layer, true))
-            LayerSetAnimationTime(layer, value);
-    }
-
-    public void LayerSetAnimationTime(Entity<SpriteComponent?> sprite, Enum key, float value)
-    {
-        if (TryGetLayer(sprite, key, out var layer, true))
+        if (ResolveLayer(sprite, key, out var layer))
             LayerSetAnimationTime(layer, value);
     }
 
@@ -509,19 +426,13 @@ public sealed partial class SpriteSystem
 
     public void LayerSetAutoAnimated(Entity<SpriteComponent?> sprite, int index, bool value)
     {
-        if (TryGetLayer(sprite, index, out var layer, true))
+        if (ResolveLayer(sprite, index, out var layer))
             LayerSetAutoAnimated(layer, value);
     }
 
-    public void LayerSetAutoAnimated(Entity<SpriteComponent?> sprite, string key, bool value)
+    public void LayerSetAutoAnimated(Entity<SpriteComponent?> sprite, LayerKey key, bool value)
     {
-        if (TryGetLayer(sprite, key, out var layer, true))
-            LayerSetAutoAnimated(layer, value);
-    }
-
-    public void LayerSetAutoAnimated(Entity<SpriteComponent?> sprite, Enum key, bool value)
-    {
-        if (TryGetLayer(sprite, key, out var layer, true))
+        if (ResolveLayer(sprite, key, out var layer))
             LayerSetAutoAnimated(layer, value);
     }
 
@@ -544,19 +455,13 @@ public sealed partial class SpriteSystem
 
     public void LayerSetRenderingStrategy(Entity<SpriteComponent?> sprite, int index, LayerRenderingStrategy value)
     {
-        if (TryGetLayer(sprite, index, out var layer, true))
+        if (ResolveLayer(sprite, index, out var layer))
             LayerSetRenderingStrategy(layer, value);
     }
 
-    public void LayerSetRenderingStrategy(Entity<SpriteComponent?> sprite, string key, LayerRenderingStrategy value)
+    public void LayerSetRenderingStrategy(Entity<SpriteComponent?> sprite, LayerKey key, LayerRenderingStrategy value)
     {
-        if (TryGetLayer(sprite, key, out var layer, true))
-            LayerSetRenderingStrategy(layer, value);
-    }
-
-    public void LayerSetRenderingStrategy(Entity<SpriteComponent?> sprite, Enum key, LayerRenderingStrategy value)
-    {
-        if (TryGetLayer(sprite, key, out var layer, true))
+        if (ResolveLayer(sprite, key, out var layer))
             LayerSetRenderingStrategy(layer, value);
     }
 

--- a/Robust.Shared/GameObjects/Components/Renderable/SpriteLayerData.cs
+++ b/Robust.Shared/GameObjects/Components/Renderable/SpriteLayerData.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Sprite;
 
 namespace Robust.Shared.GameObjects;
 
@@ -26,7 +27,7 @@ public sealed partial class PrototypeLayerData
     [DataField("offset")] public Vector2? Offset;
     [DataField("visible")] public bool? Visible;
     [DataField("color")] public Color? Color;
-    [DataField("map")] public HashSet<string>? MapKeys;
+    [DataField("map")] public HashSet<string>? MapKeys; // TODO SPRITE repalce with LayerKey
     [DataField("renderingStrategy")] public LayerRenderingStrategy? RenderingStrategy;
 
     /// <summary>
@@ -61,7 +62,7 @@ public sealed partial class PrototypeCopyToShaderParameters
     /// <summary>
     /// The map key of the layer that will have its shader modified.
     /// </summary>
-    [DataField(required: true)] public string LayerKey;
+    [DataField(required: true)] public LayerKey LayerKey;
 
     /// <summary>
     /// The name of the shader parameter that will receive the actual selected texture.

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/LayerKeySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/LayerKeySerializer.cs
@@ -1,0 +1,51 @@
+using Robust.Shared.IoC;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Sprite;
+
+namespace Robust.Shared.Serialization.TypeSerializers.Implementations;
+
+[TypeSerializer]
+public sealed class LayerKeySerializer : ITypeSerializer<LayerKey, ValueDataNode>
+{
+    public ValidationNode Validate(
+        ISerializationManager serializationManager,
+        ValueDataNode node,
+        IDependencyCollection dependencies,
+        ISerializationContext? context = null)
+    {
+        if (LayerKey.TryParse(serializationManager.ReflectionManager, node.Value, out _))
+            return new ValidatedValueNode(node);
+
+        return new ErrorNode(node, $"Failed to parse enum {node.Value}");
+    }
+
+    public LayerKey Read(
+        ISerializationManager serializationManager,
+        ValueDataNode node,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context = null,
+        ISerializationManager.InstantiationDelegate<LayerKey>? instanceProvider = null)
+    {
+        return LayerKey.Parse(serializationManager.ReflectionManager, node.Value);
+    }
+
+    public DataNode Write(
+        ISerializationManager serializationManager,
+        LayerKey value,
+        IDependencyCollection dependencies,
+        bool alwaysWrite = false,
+        ISerializationContext? context = null)
+    {
+        var raw = value.EnumKey != null
+            ? serializationManager.ReflectionManager.GetEnumReference(value.EnumKey)
+            : value.StringKey;
+        return new ValueDataNode(raw);
+    }
+}
+

--- a/Robust.Shared/Sprite/LayerKey.cs
+++ b/Robust.Shared/Sprite/LayerKey.cs
@@ -1,0 +1,65 @@
+using System;
+using Robust.Shared.Reflection;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.Manager.Attributes;
+
+namespace Robust.Shared.Sprite;
+
+/// <summary>
+/// This struct represents a key used to reference a sprite layer. The actual underlying key may be either an enum or
+/// a string.
+/// </summary>
+[Serializable, NetSerializable, CopyByRef]
+public readonly record struct LayerKey
+{
+    public readonly string? StringKey;
+    public readonly Enum? EnumKey;
+    public static LayerKey Invalid => default;
+    public bool IsValid => StringKey != null || EnumKey != null;
+
+    public LayerKey(string key)
+    {
+        StringKey = key;
+    }
+
+    public LayerKey(Enum key)
+    {
+        EnumKey = key;
+    }
+
+    public static implicit operator LayerKey(string key)
+    {
+        return new(key);
+    }
+
+    public static implicit operator LayerKey(Enum key)
+    {
+        return new(key);
+    }
+
+    public static LayerKey Parse(IReflectionManager refMan, string raw)
+    {
+        if (TryParse(refMan, raw, out var key))
+            return key;
+
+        throw new ArgumentException($"{raw} is not a valid enum");
+    }
+
+    public static bool TryParse(IReflectionManager refMan, string raw, out LayerKey key)
+    {
+        if (!raw.StartsWith("enum."))
+        {
+            key = new (raw);
+            return true;
+        }
+
+        if (refMan.TryParseEnumReference(raw, out var @enum))
+        {
+            key = new(@enum);
+            return true;
+        }
+
+        key = default;
+        return false;
+    }
+}


### PR DESCRIPTION
This adds a new LayerKey struct that is meant to be used when working with sprite layer keys instead of working with `string`, `enum`, or `object` keys. This should generally make it easier to work with layer key data fields. Previously that always involved a decent bit of boilerplate where you would have to manually use IReflectionManager to try parse a string key as a possible enum key. Now you should be able to just have a `[DataField] LayerKey Key` and use that directly.

The new struct supports implicit casts from strings & enums. So while this is a breaking change, it doesn't seem like it actually needs a content PR.

Other changes:
- Separated various "TryGet" sprite system methods into a non-logging "TryGet" and an error logging "Resolve" method
- This also removes support for object keys, which were already disincentivized in #5602 by just not having overloads for methods that take arbitrary object keys. Now they will start throwing exceptions.

Supersedes #6025