### PR TITLE
Rethrow more exceptions when EXCEPTION_TOLERANCE is false

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -361,6 +361,9 @@ namespace Robust.Client.GameStates
                     // avoid exception spam from repeatedly trying to reset the same entity.
                     _entitySystemManager.GetEntitySystem<ClientDirtySystem>().Reset();
                     _runtimeLog.LogException(e, "ResetPredictedEntities");
+#if !EXCEPTION_TOLERANCE
+                    throw;
+#endif
                 }
 
                 // If we were waiting for a new state, we are now applying it.
@@ -949,6 +952,9 @@ namespace Robust.Client.GameStates
                 {
                     _sawmill.Error($"Caught exception while deleting entities");
                     _runtimeLog.LogException(e, $"{nameof(ClientGameStateManager)}.{nameof(ApplyEntityStates)}");
+#if !EXCEPTION_TOLERANCE
+                    throw;
+#endif
                 }
             }
 

--- a/Robust.Server/GameStates/PvsSystem.Leave.cs
+++ b/Robust.Server/GameStates/PvsSystem.Leave.cs
@@ -87,6 +87,9 @@ internal sealed partial class PvsSystem
             catch (Exception e)
             {
                 _pvs.Log.Log(LogLevel.Error, e, $"Caught exception while processing pvs-leave messages.");
+#if !EXCEPTION_TOLERANCE
+                throw;
+#endif
             }
         }
     }

--- a/Robust.Server/GameStates/PvsSystem.Serialize.cs
+++ b/Robust.Server/GameStates/PvsSystem.Serialize.cs
@@ -48,6 +48,9 @@ internal sealed partial class PvsSystem
         {
             var source = i >= 0 ? _sessions[i].Session.ToString() : "replays";
             Log.Log(LogLevel.Error, e, $"Caught exception while serializing game state for {source}.");
+#if !EXCEPTION_TOLERANCE
+            throw;
+#endif
         }
     }
 

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -968,12 +968,11 @@ namespace Robust.Shared.GameObjects
             }
             catch (Exception e)
             {
-#if !EXCEPTION_TOLERANCE
-                throw;
-#endif
+#if EXCEPTION_TOLERANCE
                 // Exception during entity loading.
                 // Need to delete the entity to avoid corrupt state causing crashes later.
                 DeleteEntity(entity);
+#endif
                 throw new EntityCreationException($"Exception inside CreateEntity with prototype {prototype.ID}", e);
             }
         }
@@ -999,10 +998,9 @@ namespace Robust.Shared.GameObjects
             }
             catch (Exception e)
             {
-#if !EXCEPTION_TOLERANCE
-                throw;
-#endif
+#if EXCEPTION_TOLERANCE
                 DeleteEntity(entity);
+#endif
                 throw new EntityCreationException("Exception inside InitializeAndStartEntity", e);
             }
         }

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -968,11 +968,9 @@ namespace Robust.Shared.GameObjects
             }
             catch (Exception e)
             {
-#if EXCEPTION_TOLERANCE
                 // Exception during entity loading.
                 // Need to delete the entity to avoid corrupt state causing crashes later.
                 DeleteEntity(entity);
-#endif
                 throw new EntityCreationException($"Exception inside CreateEntity with prototype {prototype.ID}", e);
             }
         }
@@ -998,9 +996,7 @@ namespace Robust.Shared.GameObjects
             }
             catch (Exception e)
             {
-#if EXCEPTION_TOLERANCE
                 DeleteEntity(entity);
-#endif
                 throw new EntityCreationException("Exception inside InitializeAndStartEntity", e);
             }
         }

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -210,6 +210,9 @@ namespace Robust.Shared.GameObjects
                 catch (Exception e)
                 {
                     _sawmill.Error($"Failed to serialize {compName} component of entity prototype {prototype.ID}. Exception: {e.Message}");
+#if !EXCEPTION_TOLERANCE
+                    throw;
+#endif
                     return false;
                 }
 
@@ -599,6 +602,9 @@ namespace Robust.Shared.GameObjects
             catch (Exception e)
             {
                 _sawmill.Error($"Caught exception while raising event {nameof(EntityTerminatingEvent)} on entity {ToPrettyString(uid, metadata)}\n{e}");
+#if !EXCEPTION_TOLERANCE
+                throw;
+#endif
             }
 
             foreach (var child in xform._children)
@@ -641,6 +647,9 @@ namespace Robust.Shared.GameObjects
                 catch(Exception e)
                 {
                     _sawmill.Error($"Caught exception while trying to recursively delete child entity '{ToPrettyString(child)}' of '{ToPrettyString(uid, metadata)}'\n{e}");
+#if !EXCEPTION_TOLERANCE
+                    throw;
+#endif
                 }
             }
 
@@ -659,6 +668,9 @@ namespace Robust.Shared.GameObjects
                     catch (Exception e)
                     {
                         _sawmill.Error($"Caught exception while trying to call shutdown on component of entity '{ToPrettyString(uid, metadata)}'\n{e}");
+#if !EXCEPTION_TOLERANCE
+                        throw;
+#endif
                     }
                 }
             }
@@ -674,6 +686,9 @@ namespace Robust.Shared.GameObjects
             catch (Exception e)
             {
                 _sawmill.Error($"Caught exception while invoking event {nameof(EntityDeleted)} on '{ToPrettyString(uid, metadata)}'\n{e}");
+#if !EXCEPTION_TOLERANCE
+                throw;
+#endif
             }
 
             _eventBus.OnEntityDeleted(uid);
@@ -953,6 +968,9 @@ namespace Robust.Shared.GameObjects
             }
             catch (Exception e)
             {
+#if !EXCEPTION_TOLERANCE
+                throw;
+#endif
                 // Exception during entity loading.
                 // Need to delete the entity to avoid corrupt state causing crashes later.
                 DeleteEntity(entity);
@@ -981,6 +999,9 @@ namespace Robust.Shared.GameObjects
             }
             catch (Exception e)
             {
+#if !EXCEPTION_TOLERANCE
+                throw;
+#endif
                 DeleteEntity(entity);
                 throw new EntityCreationException("Exception inside InitializeAndStartEntity", e);
             }

--- a/Robust.UnitTesting/Server/GameObjects/ThrowingEntityDeletion_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/ThrowingEntityDeletion_Test.cs
@@ -50,7 +50,10 @@ namespace Robust.UnitTesting.Server.GameObjects
             Assert.That(() => entMan.SpawnEntity(prototypeName, new MapCoordinates(0, 0, map)),
                 Throws.TypeOf<EntityCreationException>());
 
+            // The exception is immediately rethrown before the entity is deleted when EXCEPTION_TOLERANCE is disabled.
+#if EXCEPTION_TOLERANCE
             Assert.That(entMan.GetEntities().Where(p => entMan.GetComponent<MetaDataComponent>(p).EntityPrototype?.ID == prototypeName), Is.Empty);
+#endif
         }
     }
 }

--- a/Robust.UnitTesting/Server/GameObjects/ThrowingEntityDeletion_Test.cs
+++ b/Robust.UnitTesting/Server/GameObjects/ThrowingEntityDeletion_Test.cs
@@ -50,10 +50,7 @@ namespace Robust.UnitTesting.Server.GameObjects
             Assert.That(() => entMan.SpawnEntity(prototypeName, new MapCoordinates(0, 0, map)),
                 Throws.TypeOf<EntityCreationException>());
 
-            // The exception is immediately rethrown before the entity is deleted when EXCEPTION_TOLERANCE is disabled.
-#if EXCEPTION_TOLERANCE
             Assert.That(entMan.GetEntities().Where(p => entMan.GetComponent<MetaDataComponent>(p).EntityPrototype?.ID == prototypeName), Is.Empty);
-#endif
         }
     }
 }


### PR DESCRIPTION
Makes more exceptions actually throw when `EXCEPTION_TOLERANCE` is false, instead of just logging an error and continuing.
I've occasionally removed or modified these try catch blocks when trying to debug an exception and it makes sense to me that they should just throw if EXCEPTION_TOLERANCE is false