### PR TITLE
Fix yaml hotreloading

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Fixed yaml hot reloading throwing invalid path exceptions.
 
 ### Other
 

--- a/Robust.Client/Utility/ReloadManager.cs
+++ b/Robust.Client/Utility/ReloadManager.cs
@@ -58,13 +58,11 @@ internal sealed class ReloadManager : IReloadManager
     {
         foreach (var file in _reloadQueue)
         {
-            var rootedFile = file.ToRootedPath();
-
-            if (!_res.ContentFileExists(rootedFile))
+            if (!_res.ContentFileExists(file))
                 continue;
 
-            _sawmill.Info($"Reloading {rootedFile}");
-            OnChanged?.Invoke(rootedFile);
+            _sawmill.Info($"Reloading {file}");
+            OnChanged?.Invoke(file);
         }
 
         _reloadQueue.Clear();
@@ -133,12 +131,13 @@ internal sealed class ReloadManager : IReloadManager
                     var relPath = Path.GetRelativePath(rootIter, args.FullPath);
                     if (relPath == args.FullPath)
                     {
-                        // Not relative.
+                        // Different root (i.e., "C:/" and "D:/")
                         continue;
                     }
 
-                    var file = ResPath.FromRelativeSystemPath(relPath);
-                    _reloadQueue.Add(file);
+                    var file = ResPath.FromRelativeSystemPath(relPath).ToRootedPath();
+                    if (!file.CanonPath.Contains("/../"))
+                        _reloadQueue.Add(file);
                 }
             });
         }

--- a/Robust.Shared/ContentPack/PathHelpers.cs
+++ b/Robust.Shared/ContentPack/PathHelpers.cs
@@ -68,7 +68,11 @@ namespace Robust.Shared.ContentPack
         internal static string SafeGetResourcePath(string baseDir, ResPath path)
         {
             var relSysPath = path.ToRelativeSystemPath();
-            if (relSysPath.Contains("\\..") || relSysPath.Contains("/.."))
+
+            // This also blocks files like "..foo.yml". But whatever, I CBF fixing that.
+            if (relSysPath.Contains("\\..")
+                || relSysPath.Contains("/..")
+                || relSysPath.StartsWith(".."))
             {
                 // Hard cap on any exploit smuggling a .. in there.
                 // Since that could allow leaving sandbox.


### PR DESCRIPTION
Fixes #6236

Currently whenever a file is changed it tries to reload it twice, once relative to the engine's resource directory, and once relative to content's resource directory. After the path validation changes, one of those will throw an exception when they contain '..'.