### PR TITLE
Fix casing in Sandbox.yml (2 characters changed)

### DIFF
--- a/Robust.Shared/ContentPack/Sandbox.yml
+++ b/Robust.Shared/ContentPack/Sandbox.yml
@@ -1093,7 +1093,7 @@ Types:
       - "string ToHexString(System.ReadOnlySpan`1<byte>)"
 
     Converter`2: { All: True } # Delegate
-    DateOnly: { all: True }
+    DateOnly: { All: True }
     DateTime: { All: True }
     DateTimeKind: { } # Enum
     DateTimeOffset: { All: True }

--- a/Robust.Shared/ContentPack/Sandbox.yml
+++ b/Robust.Shared/ContentPack/Sandbox.yml
@@ -1426,7 +1426,7 @@ Types:
       - "void CopyTo(int, char[], int, int)"
     StringComparison: { } # Enum
     StringSplitOptions: { } # Enum
-    TimeOnly: { all: True }
+    TimeOnly: { All: True }
     TimeSpan: { All: True }
     Type:
       # COM, marshalling, interop, etc... stuff omitted.


### PR DESCRIPTION
A typo in the 'DateOnly' property is causing a fatal error during compilation.