### PR TITLE
Recursively update joint relays on removing entities from containers

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -47,6 +47,7 @@ END TEMPLATE-->
 
 * Fixed yaml hot reloading throwing invalid path exceptions.
 * The `EntityManager.CreateEntityUninitialized` overload that uses MapCoordinates now actually attaches entities to a grid if one is present at those coordinates, as was stated in it's documentation.
+* Fixed physics joint relays not being properly updated when an entity is removed from a container.
 
 ### Other
 

--- a/Robust.Shared/Containers/SharedContainerSystem.Insert.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.Insert.cs
@@ -219,6 +219,9 @@ public abstract partial class SharedContainerSystem
 
     internal void RecursivelyUpdateJoints(Entity<TransformComponent> entity)
     {
+        if (_timing.ApplyingState)
+            return;
+
         if (JointQuery.TryGetComponent(entity, out var jointComp))
         {
             // TODO: This is going to be going up while joints going down, although these aren't too common

--- a/Robust.Shared/Containers/SharedContainerSystem.Remove.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.Remove.cs
@@ -95,10 +95,7 @@ public abstract partial class SharedContainerSystem
             _lookup.FindAndAddToEntityTree(toRemove, xform: xform);
         }
 
-        if (TryComp<JointComponent>(toRemove, out var jointComp))
-        {
-            _joint.RefreshRelay(toRemove, jointComp);
-        }
+        RecursivelyUpdateJoints((toRemove, xform));
 
         // Raise container events (after re-parenting and internal remove).
         RaiseLocalEvent(container.Owner, new EntRemovedFromContainerMessage(toRemove, container), true);


### PR DESCRIPTION
## About
Fixes asymmetric joint relay handling in container removal by recursively refreshing relays for all child entities, matching the behavior of container insertion.

## Change
- Added `RecursivelyUpdateJoints()` call in `Remove` method to mirror the recursive joint updates done in `Insert`
- Added `_timing.ApplyingState` check in `RecursivelyUpdateJoints` to prevent prediction conflicts

## Why
Partially fixes [#40515](https://github.com/space-wizards/space-station-14/issues/40515)

Currently, when removing an entity from a container:
- Only the root entity's joints get `RefreshRelay()` called via `TryComp<JointComponent>`
- Child entities with their own `JointComponent` are ignored

However, when inserting into a container:
- `RecursivelyUpdateJoints()` is called, updating joints for all children in the hierarchy

This asymmetry causes issues because `RefreshRelay()` relies on container hierarchy to find the appropriate relay entity. When children aren't updated, their joint relays point to invalid container references.

## In-game example of the issue
1. Place player with grappling hook in hand container into another container (e.g., crate)
2. Fire grappling hook while in container (creates joints)
3. Exit container
4. **Before**: Child entities' `JointRelayTargetComponent` doesn't update properly because their relays still reference old container hierarchy (e. g., crate)
5. **After**: All joints in hierarchy get proper relay updates
