### PR TITLE
Fix MapLoaderSystem.SerializeEntitiesRecursive

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -45,6 +45,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
+* Fixed `MapLoaderSystem.SerializeEntitiesRecursive()` not properly serialising when given multiple root entities (e.g., multiple maps)
 * Fixed yaml hot reloading throwing invalid path exceptions.
 * The `EntityManager.CreateEntityUninitialized` overload that uses MapCoordinates now actually attaches entities to a grid if one is present at those coordinates, as was stated in it's documentation.
 

--- a/Robust.Shared/EntitySerialization/EntitySerializer.cs
+++ b/Robust.Shared/EntitySerialization/EntitySerializer.cs
@@ -275,6 +275,7 @@ public sealed class EntitySerializer : ISerializationContext,
             var ents = new HashSet<EntityUid>();
             RecursivelyIncludeChildren(root, ents);
             entities.Add((root, ents));
+            allEntities.UnionWith(ents);
         }
 
         ReserveYamlIds(allEntities);

--- a/Robust.Shared/EntitySerialization/SerializationEnums.cs
+++ b/Robust.Shared/EntitySerialization/SerializationEnums.cs
@@ -27,6 +27,11 @@ public enum FileCategory : byte
     Map,
 
     /// <summary>
+    /// File should contain one or more maps, their children, and maybe some null-space entities.
+    /// </summary>
+    MultiMap,
+
+    /// <summary>
     /// File is a full game save, and will likely contain at least one map and a few null-space entities.
     /// </summary>
     /// <remarks>

--- a/Robust.Shared/EntitySerialization/SerializationEnums.cs
+++ b/Robust.Shared/EntitySerialization/SerializationEnums.cs
@@ -27,11 +27,6 @@ public enum FileCategory : byte
     Map,
 
     /// <summary>
-    /// File should contain one or more maps, their children, and maybe some null-space entities.
-    /// </summary>
-    MultiMap,
-
-    /// <summary>
     /// File is a full game save, and will likely contain at least one map and a few null-space entities.
     /// </summary>
     /// <remarks>

--- a/Robust.Shared/EntitySerialization/Systems/MapLoaderSystem.Save.cs
+++ b/Robust.Shared/EntitySerialization/Systems/MapLoaderSystem.Save.cs
@@ -16,7 +16,7 @@ public sealed partial class MapLoaderSystem
     public event EntitySerializer.IsSerializableDelegate? OnIsSerializable;
 
     /// <summary>
-    /// Recursively serialize the given entity and its children.
+    /// Recursively serialize the given entities and all of their children.
     /// </summary>
     public (MappingDataNode Node, FileCategory Category) SerializeEntitiesRecursive(
         HashSet<EntityUid> entities,
@@ -41,12 +41,7 @@ public sealed partial class MapLoaderSystem
 
         var serializer = new EntitySerializer(_dependency, opts);
         serializer.OnIsSerializeable += OnIsSerializable;
-
-        foreach (var ent in entities)
-        {
-            serializer.SerializeEntityRecursive(ent);
-        }
-
+        serializer.SerializeEntityRecursive(entities);
         var data = serializer.Write();
         var cat = serializer.GetCategory();
 


### PR DESCRIPTION
Fixes `MapLoaderSystem.SerializeEntitiesRecursive()` not properly serializing when given multiple root entities (e.g., multiple maps).  Previously it was calling `ReserveYamlIds()` once for each map, instead of once for all maps. So if an entity on an earlier map referenced one on a later map, it would fail to serialize that uid.