### PR TITLE
Adding tag filter to Entity Spawning Window

### DIFF
--- a/Robust.Client/Robust.Client.csproj
+++ b/Robust.Client/Robust.Client.csproj
@@ -40,6 +40,7 @@
     <ProjectReference Include="..\Robust.Shared.Scripting\Robust.Shared.Scripting.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\Content.Shared\Content.Shared.csproj" />
     <ProjectReference Include="..\Avalonia.Base\Avalonia.Base.csproj" />
     <ProjectReference Include="..\Lidgren.Network\Lidgren.Network.csproj" />
     <ProjectReference Include="..\OpenToolkit.GraphicsLibraryFramework\OpenToolkit.GraphicsLibraryFramework.csproj" />

--- a/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.xaml
+++ b/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.xaml
@@ -16,6 +16,7 @@
             <Button Name="EraseButton" Access="Public" ToggleMode="True" Text="{Loc window-erase-button-text}"/>
             <OptionButton Name="OverrideMenu" Access="Public" HorizontalExpand="True" ToolTip="{Loc entity-spawn-window-override-menu-tooltip}" />
         </BoxContainer>
+        <OptionButton Name="OptionTags" Access="Public" MinSize="115 0"/>
         <Label Name="RotationLabel" Access="Public"/>
         <DoNotMeasure Visible="False">
             <EntitySpawnButton Name="MeasureButton" Access="Public" />


### PR DESCRIPTION
## About the PR
Adding tag filter to Entity Spawn Window.

## Why / Balance
Task: [click](https://github.com/space-wizards/space-station-14/issues/39631)

## Technical details
Added new UI element _OptionTag_ to _EntitySpawnWindow.xaml_.
I wanted to implement filtering by each yml file but could not find the right solution for it.
This implementation is not ideal and not effective, but I think this can be improved.

## Media

<img width="400" height="450" alt="screen1" src="https://github.com/user-attachments/assets/d728798a-ed45-4ca7-87c8-aa72cfd7c7e6" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR, or it does not require an in game showcase.

**Changelog**
:cl:
- add: Added tag filter to Entity Spawn Window



