### PR TITLE
Toolshed accept and return type commands for searching through toolshed commands

### DIFF
--- a/Resources/Locale/en-US/toolshed-commands.ftl
+++ b/Resources/Locale/en-US/toolshed-commands.ftl
@@ -28,8 +28,6 @@ command-description-search =
     Searches through the input for the provided value.
 command-description-stopwatch =
     Measures the execution time of the given expression.
-command-description-types-consumers =
-    Provides all commands that can consume the given type.
 command-description-types-tree =
     Debug tool to return all types the command interpreter can downcast the input to.
 command-description-types-gettype =
@@ -426,6 +424,14 @@ command-description-tee =
 command-description-cmd-info =
     Returns a CommandSpec for the given command.
     On its own, this means it'll print the command's help message.
+command-description-cmd-accepts =
+    Filters commands based on what type they accept as a piped argument
+command-description-cmd-accepts_generic =
+    Filters commands based on what type they accept as a piped argument, allowing commands that broadly accept most types
+command-description-cmd-returns =
+    Filters commands based on what type they return as a result
+command-description-cmd-returns_generic =
+    Filters commands based on what type they return as a result, allowing commands that broadly accept most types
 command-description-comp-rm =
     Removes the given component from the entity.
 

--- a/Robust.Shared/Toolshed/Commands/Misc/CmdCommand.cs
+++ b/Robust.Shared/Toolshed/Commands/Misc/CmdCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Robust.Shared.Toolshed.Syntax;
@@ -21,6 +22,103 @@ public sealed class CmdCommand : ToolshedCommand
 
     [CommandImplementation("info")]
     public CommandSpec Info(CommandSpec cmd) => cmd;
+
+    [CommandImplementation("accepts")]
+    public IEnumerable<CommandSpec> Accepts([PipedArgument] IEnumerable<CommandSpec> specs, Type pipedArgument)
+        => Accepts_Impl(specs, pipedArgument, false);
+
+    // TODO: This should be an optional parameter, --generic, instead.
+    [CommandImplementation("accepts_generic")]
+    public IEnumerable<CommandSpec> AcceptsGeneric([PipedArgument] IEnumerable<CommandSpec> specs, Type pipedArgument)
+        => Accepts_Impl(specs, pipedArgument, true);
+
+    private IEnumerable<CommandSpec> Accepts_Impl([PipedArgument] IEnumerable<CommandSpec> specs, Type pipedArgument, bool allowGeneric)
+    {
+        // This did not get made into methods on ToolshedCommand because of the fitness thing.
+        // For user-friendliness reasons this always orders the most exactly matching commands first.
+        return specs.Select(cmd =>
+        {
+            var fitness = -1; // unfit, ditch.
+
+            var impls = cmd.Cmd.CommandImplementors[cmd.SubCommand ?? string.Empty]
+                .MethodsByPipedType(pipedArgument, allowGeneric);
+
+            var anyNonGeneric = false;
+
+            foreach (var impl in impls)
+            {
+                // if any commands at all, raise it to 0, but don't modify higher fitness.
+                fitness = int.Max(fitness, 0);
+
+                // We treat object like a generic param because that's "probably what the user wants"
+                if (!impl.PipeGeneric && (impl.PipeArg!.ParameterType != typeof(object)))
+                {
+                    if (impl.PipeArg!.ParameterType == pipedArgument)
+                        fitness = int.Max(fitness, 2); // Exact match
+                    else
+                        fitness = int.Max(fitness, 1);
+
+                    anyNonGeneric = true;
+                }
+            }
+
+            if (!anyNonGeneric && !allowGeneric)
+                return (cmd, fitness: -1);
+
+            return (cmd, fitness); // command + fitness
+        })
+        .Where(x => x.fitness >= 0)
+        .OrderByDescending(x => x.fitness)
+        .Select(x => x.cmd);
+    }
+
+    [CommandImplementation("returns")]
+    public IEnumerable<CommandSpec> Returns([PipedArgument] IEnumerable<CommandSpec> specs, Type pipedArgument)
+        => Returns_Impl(specs, pipedArgument, false);
+
+    // TODO: This should be an optional parameter, --generic, instead.
+    [CommandImplementation("returns_generic")]
+    public IEnumerable<CommandSpec> ReturnsGeneric([PipedArgument] IEnumerable<CommandSpec> specs, Type pipedArgument)
+        => Returns_Impl(specs, pipedArgument, true);
+
+    private IEnumerable<CommandSpec> Returns_Impl(IEnumerable<CommandSpec> specs, Type returnType, bool allowGeneric)
+    {
+        // This did not get made into methods on ToolshedCommand because of the fitness thing.
+        // For user-friendliness reasons this always orders the most exactly matching commands first.
+        return specs.Select(cmd =>
+            {
+                var fitness = -1; // unfit, ditch.
+
+                var impls = cmd.Cmd.CommandImplementors[cmd.SubCommand ?? string.Empty]
+                    .MethodsByReturnType(returnType, allowGeneric);
+
+                var anyNonGeneric = false;
+
+                foreach (var impl in impls)
+                {
+                    // if any commands at all, raise it to 0, but don't modify higher fitness.
+                    fitness = int.Max(fitness, 0);
+
+                    if (!impl.Info.ReturnType.IsGenericParameter && (impl.Info.ReturnType != typeof(object)))
+                    {
+                        if (impl.Info.ReturnType == returnType)
+                            fitness = int.Max(fitness, 2); // Exact match
+                        else
+                            fitness = int.Max(fitness, 1);
+
+                        anyNonGeneric = true;
+                    }
+                }
+
+                if (!anyNonGeneric && !allowGeneric)
+                    return (cmd, fitness: -1);
+
+                return (cmd, fitness); // command + fitness
+            })
+            .Where(x => x.fitness >= 0)
+            .OrderByDescending(x => x.fitness)
+            .Select(x => x.cmd);
+    }
 
 #if CLIENT_SCRIPTING
     [CommandImplementation("getshim")]

--- a/Robust.Shared/Toolshed/Commands/Misc/TypesCommand.cs
+++ b/Robust.Shared/Toolshed/Commands/Misc/TypesCommand.cs
@@ -6,22 +6,6 @@ namespace Robust.Shared.Toolshed.Commands.Misc;
 [ToolshedCommand]
 internal sealed class TypesCommand : ToolshedCommand
 {
-    [CommandImplementation("consumers")]
-    public void Consumers(IInvocationContext ctx, [PipedArgument] object? input)
-    {
-        var t = input is Type ? (Type)input : input!.GetType();
-
-        ctx.WriteLine($"Valid intakers for {t.PrettyName()}:");
-
-        foreach (var (command, subCommand) in ctx.Environment.CommandsTakingType(t))
-        {
-            if (subCommand is null)
-                ctx.WriteLine($"{command.Name}");
-            else
-                ctx.WriteLine($"{command.Name}:{subCommand}");
-        }
-    }
-
     [CommandImplementation("tree")]
     public IEnumerable<Type> Tree(IInvocationContext ctx, [PipedArgument] object? input)
     {

--- a/Robust.Shared/Toolshed/ToolshedCommand.cs
+++ b/Robust.Shared/Toolshed/ToolshedCommand.cs
@@ -70,6 +70,9 @@ public abstract partial class ToolshedCommand
     /// </summary>
     public IEnumerable<string> Subcommands => CommandImplementors.Keys;
 
+    /// <summary>
+    ///     The mapping between subcommands and the implementors describing them.
+    /// </summary>
     internal readonly Dictionary<string, ToolshedCommandImplementor> CommandImplementors = new();
 
     private readonly Dictionary<string, HashSet<Type>> _acceptedTypes = new();

--- a/Robust.Shared/Toolshed/ToolshedCommandImplementor.cs
+++ b/Robust.Shared/Toolshed/ToolshedCommandImplementor.cs
@@ -400,7 +400,7 @@ internal sealed class ToolshedCommandImplementor
         return parser;
     }
 
-    private (CommandMethod, MethodInfo)? GetConcreteMethodInternal(Type? pipedType, Type[]? typeArguments)
+    internal IEnumerable<CommandMethod> MethodsByPipedType(Type? pipedType, bool allowGeneric = true)
     {
         return Methods
             .Where(x =>
@@ -411,8 +411,28 @@ internal sealed class ToolshedCommandImplementor
                 if (pipedType == null)
                     return false;
 
-                return x.Generic || _toolshed.IsTransformableTo(pipedType, param.ParameterType);
-            })
+                return _toolshed.IsTransformableTo(pipedType, param.ParameterType, allowGeneric);
+            });
+    }
+
+    internal IEnumerable<CommandMethod> MethodsByReturnType(Type? returnType, bool allowGeneric = true)
+    {
+        return Methods
+            .Where(x =>
+            {
+                if (x.Info.ReturnType is not { } type)
+                    return returnType is null;
+
+                if (returnType == null)
+                    return false;
+
+                return _toolshed.IsTransformableTo(type, returnType, allowGeneric);
+            });
+    }
+
+    private (CommandMethod, MethodInfo)? GetConcreteMethodInternal(Type? pipedType, Type[]? typeArguments)
+    {
+        return MethodsByPipedType(pipedType)
             .OrderByDescending(x =>
             {
                 if (x.PipeArg is not { } param)

--- a/Robust.Shared/Toolshed/ToolshedManager.Types.cs
+++ b/Robust.Shared/Toolshed/ToolshedManager.Types.cs
@@ -10,8 +10,11 @@ namespace Robust.Shared.Toolshed;
 public sealed partial class ToolshedManager
 {
     // If this gets updated, ensure that GetTransformer() is also updated
-    internal bool IsTransformableTo(Type left, Type right)
+    internal bool IsTransformableTo(Type left, Type right, bool allowGeneric = true)
     {
+        if ((left.IsGenericParameter || right.IsGenericParameter) && !allowGeneric)
+            return false;
+
         if (left.IsAssignableToGeneric(right, this))
             return true;
 


### PR DESCRIPTION
This is a patch from @moonheart08

This PR adds four new commands:
cmd:accepts = Filters commands based on what type they accept as a piped argument
cmd:accepts_generic = Filters commands based on what type they accept as a piped argument, allowing commands that broadly accept most types

cmd:returns = Filters commands based on what type they return as a result
cmd:returns_generic = Filters commands based on what type they return as a result, allowing commands that broadly accept most types