### PR TITLE
Add two new custom yaml serializers

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -47,7 +47,7 @@ END TEMPLATE-->
 
 ### Other
 
-*None yet*
+* ComponentNameSerializer will now ignore any components that have been ignored via `IComponentFactory.RegisterIgnore`.
 
 ### Internal
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Added two new custom yaml serializers `CustomListSerializer` and `CustomArraySerializer`.
 
 ### Bugfixes
 

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/ComponentNameSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/ComponentNameSerializer.cs
@@ -9,7 +9,8 @@ using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 /// <summary>
-/// Simple string serializer that just validates that strings correspond to valid component names
+/// Simple string serializer that just validates that strings correspond to valid component names.
+/// This will not fail when it encounters explicitly ignored components.
 /// </summary>
 public sealed class ComponentNameSerializer : ITypeSerializer<string, ValueDataNode>
 {
@@ -17,7 +18,7 @@ public sealed class ComponentNameSerializer : ITypeSerializer<string, ValueDataN
         IDependencyCollection dependencies, ISerializationContext? context = null)
     {
         var factory = dependencies.Resolve<IComponentFactory>();
-        if (!factory.TryGetRegistration(node.Value, out _))
+        if (!factory.TryGetRegistration(node.Value, out _) && factory.GetComponentAvailability(node.Value) != ComponentAvailability.Ignore)
             return new ErrorNode(node, $"Unknown component kind: {node.Value}");
 
         return new ValidatedValueNode(node);

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/CustomArraySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/CustomArraySerializer.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using Robust.Shared.IoC;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Sequence;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+
+namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
+
+/// <summary>
+/// This is a variant of the normal array serializer that uses a custom type serializer to handle the values.
+/// </summary>
+public sealed class CustomArraySerializer<T, TCustomSerializer> : ITypeSerializer<T[], SequenceDataNode>
+    where TCustomSerializer : ITypeSerializer<T, ValueDataNode>
+{
+    T[] ITypeReader<T[], SequenceDataNode>.Read(
+        ISerializationManager serializationManager,
+        SequenceDataNode node,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context,
+        ISerializationManager.InstantiationDelegate<T[]>? instanceProvider)
+    {
+        var list = new T[node.Count];
+        var i = 0;
+        foreach (var dataNode in node)
+        {
+            list[i++] = serializationManager.Read<T, ValueDataNode, TCustomSerializer>((ValueDataNode)dataNode, hookCtx, context);
+        }
+
+        return list;
+    }
+
+    ValidationNode ITypeValidator<T[], SequenceDataNode>.Validate(
+        ISerializationManager seri,
+        SequenceDataNode node,
+        IDependencyCollection deps,
+        ISerializationContext? ctx)
+    {
+        var list = new List<ValidationNode>(node.Count);
+        foreach (var elem in node)
+        {
+            list.Add(seri.ValidateNode<T, ValueDataNode, TCustomSerializer>((ValueDataNode)elem, ctx));
+        }
+        return new ValidatedSequenceNode(list);
+    }
+
+    public DataNode Write(
+        ISerializationManager seri,
+        T[] value,
+        IDependencyCollection deps,
+        bool alwaysWrite = false,
+        ISerializationContext? ctx = null)
+    {
+        var sequence = new SequenceDataNode();
+        foreach (var elem in value)
+        {
+            sequence.Add(seri.WriteValue<T, TCustomSerializer>(elem, alwaysWrite, ctx));
+        }
+        return sequence;
+    }
+}
+

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/CustomListSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/CustomListSerializer.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using Robust.Shared.IoC;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Sequence;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+
+namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
+
+/// <summary>
+/// This is a variation of the <see cref="ListSerializers{T}"/> that uses a custom type serializer to handle the values.
+/// </summary>
+public sealed class CustomListSerializer<T, TCustomSerializer>
+    : ITypeSerializer<List<T>, SequenceDataNode>
+    where TCustomSerializer : ITypeSerializer<T, ValueDataNode>
+{
+    List<T> ITypeReader<List<T>, SequenceDataNode>.Read(
+        ISerializationManager seri,
+        SequenceDataNode node,
+        IDependencyCollection deps,
+        SerializationHookContext hookCtx,
+        ISerializationContext? ctx,
+        ISerializationManager.InstantiationDelegate<List<T>>? instanceProvider)
+    {
+        var list = instanceProvider != null ? instanceProvider() : new(node.Count);
+        foreach (var dataNode in node)
+        {
+            var value = seri.Read<T, ValueDataNode, TCustomSerializer>((ValueDataNode)dataNode, hookCtx, ctx);
+            list.Add(value);
+        }
+
+        return list;
+    }
+
+    ValidationNode ITypeValidator<List<T>, SequenceDataNode>.Validate(
+        ISerializationManager seri,
+        SequenceDataNode node,
+        IDependencyCollection deps,
+        ISerializationContext? ctx)
+    {
+        var list = new List<ValidationNode>(node.Count);
+        foreach (var elem in node)
+        {
+            list.Add(seri.ValidateNode<T, ValueDataNode, TCustomSerializer>((ValueDataNode)elem, ctx));
+        }
+        return new ValidatedSequenceNode(list);
+    }
+
+    public DataNode Write(
+        ISerializationManager seri,
+        List<T> value,
+        IDependencyCollection deps,
+        bool alwaysWrite = false,
+        ISerializationContext? ctx = null)
+    {
+        var sequence = new SequenceDataNode();
+        foreach (var elem in value)
+        {
+            sequence.Add(seri.WriteValue<T, TCustomSerializer>(elem, alwaysWrite, ctx));
+        }
+        return sequence;
+    }
+}
+


### PR DESCRIPTION
Requires so that content's entity whitelists can use a `[DataField(customTypeSerializer:typeof(CustomArraySerializer<string, ComponentNameSerializer>))]`