### PR TITLE
Fix YAML linter not printing the erroring file when failing to load it

### DIFF
--- a/Robust.Shared/Prototypes/PrototypeManager.YamlValidate.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlValidate.cs
@@ -39,7 +39,14 @@ public partial class PrototypeManager
             }
 
             var yamlStream = new YamlStream();
-            yamlStream.Load(reader);
+            try
+            {
+                yamlStream.Load(reader);
+            }
+            catch (Exception e)
+            {
+                throw new PrototypeLoadException($"Error loading file: '{resourcePath}'\n{e}");
+            }
 
             foreach (var doc in yamlStream.Documents)
             {


### PR DESCRIPTION
Example with this PR:
```
Unhandled exception. Robust.Shared.Prototypes.PrototypeLoadException: Error loading file: '/Prototypes/Species/slime.yml'
(Line: 29, Col: 14, Idx: 773) - (Line: 29, Col: 14, Idx: 773): While scanning a plain scalar value, found invalid mapping.
   at Robust.Shared.Prototypes.PrototypeManager.ValidateDirectory(ResPath path, Dictionary`2& protos) in C:\Projects\space-station-14\RobustToolbox\Robust.Shared\Prototypes\PrototypeManager.YamlValidate.cs:line 48
   at Content.YAMLLinter.Program.<>c__DisplayClass3_0.<ValidateInstance>b__0() in C:\Projects\space-station-14\Content.YAMLLinter\Program.cs:line 85
   at Robust.UnitTesting.RobustIntegrationTest.IntegrationGameLoop.SingleThreadRunUntilEmpty() in C:\Projects\space-station-14\RobustToolbox\Robust.UnitTesting\RobustIntegrationTest.cs:line 1168
   at Robust.UnitTesting.RobustIntegrationTest.IntegrationGameLoop.Run() in C:\Projects\space-station-14\RobustToolbox\Robust.UnitTesting\RobustIntegrationTest.cs:line 1132
   at Robust.UnitTesting.RobustIntegrationTest.ServerIntegrationInstance._serverMain() in C:\Projects\space-station-14\RobustToolbox\Robust.UnitTesting\RobustIntegrationTest.cs:line 685
--- End of stack trace from previous location ---
   at Robust.UnitTesting.RobustIntegrationTest.IntegrationInstance.WaitIdleImplAsync(Boolean throwOnUnhandled, CancellationToken cancellationToken) in C:\Projects\space-station-14\RobustToolbox\Robust.UnitTesting\RobustIntegrationTest.cs:line 477
   at Robust.UnitTesting.RobustIntegrationTest.IntegrationInstance.WaitPost(Action post) in C:\Projects\space-station-14\RobustToolbox\Robust.UnitTesting\RobustIntegrationTest.cs:line 590
   at Content.YAMLLinter.Program.ValidateInstance(IntegrationInstance instance) in C:\Projects\space-station-14\Content.YAMLLinter\Program.cs:line 82
   at Content.YAMLLinter.Program.ValidateServer() in C:\Projects\space-station-14\Content.YAMLLinter\Program.cs:line 70
   at Content.YAMLLinter.Program.ValidateServer() in C:\Projects\space-station-14\Content.YAMLLinter\Program.cs:line 72
   at Content.YAMLLinter.Program.RunValidation() in C:\Projects\space-station-14\Content.YAMLLinter\Program.cs:line 119
   at Content.YAMLLinter.Program.Main(String[] _) in C:\Projects\space-station-14\Content.YAMLLinter\Program.cs:line 24
   at Content.YAMLLinter.Program.<Main>(String[] _)
```

Previously it only printed `Unhandled exception. (Line: 29, Col: 14, Idx: 773) - (Line: 29, Col: 14, Idx: 773): While scanning a plain scalar value, found invalid mapping.`