### PR TITLE
Update child controls style when a control is restyled

### DIFF
--- a/Robust.Client/UserInterface/Control.Styling.cs
+++ b/Robust.Client/UserInterface/Control.Styling.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.ViewVariables;
@@ -50,6 +50,9 @@ namespace Robust.Client.UserInterface
         // _actualStylesheetCached needs update.
         private bool _stylesheetUpdateNeeded;
         internal int RestyleGeneration;
+        // Cached value to determine if child Controls may need
+        // to be restyled when this element's style changes
+        internal bool RestyleChildElements { get; private set; }
 
         private string? _styleIdentifier;
 
@@ -152,6 +155,7 @@ namespace Robust.Client.UserInterface
         public void DoStyleUpdate()
         {
             _styleProperties.Clear();
+            RestyleChildElements = false;
 
             if (_stylesheetUpdateNeeded)
             {
@@ -184,6 +188,10 @@ namespace Robust.Client.UserInterface
                 if (rule.Selector.Matches(this))
                 {
                     ruleList.Add((index, rule));
+                }
+                if (!RestyleChildElements && rule.Selector.PotentialChildMatch(this))
+                {
+                    RestyleChildElements = true;
                 }
             }
 

--- a/Robust.Client/UserInterface/Controls/Button.cs
+++ b/Robust.Client/UserInterface/Controls/Button.cs
@@ -21,11 +21,6 @@ namespace Robust.Client.UserInterface.Controls
             AddChild(Label);
         }
 
-        protected override void StylePropertiesChanged()
-        {
-            base.StylePropertiesChanged();
-        }
-
         /// <summary>
         ///     How to align the text inside the button.
         /// </summary>

--- a/Robust.Client/UserInterface/Controls/Button.cs
+++ b/Robust.Client/UserInterface/Controls/Button.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.ViewVariables;
+using Robust.Shared.ViewVariables;
 using static Robust.Client.UserInterface.Controls.Label;
 
 namespace Robust.Client.UserInterface.Controls
@@ -24,11 +24,6 @@ namespace Robust.Client.UserInterface.Controls
         protected override void StylePropertiesChanged()
         {
             base.StylePropertiesChanged();
-
-			// Temporary workaround to fix button styles in content thanks to a lack of correct style updating for child selectors.
-			// The changing of the style class on the parent control (button in this case) doesn't cause a style update in the label correctly currently.
-			// This works around that.
-            Label.Restyle();
         }
 
         /// <summary>

--- a/Robust.Client/UserInterface/Stylesheet.cs
+++ b/Robust.Client/UserInterface/Stylesheet.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
@@ -427,7 +427,6 @@ namespace Robust.Client.UserInterface
 
     // Temporarily hidden due to performance concerns.
     // Like seriously this thing is awful performance wise.
-    // Also, you can't just enable it. The code is here but AddChild etc only do restyles one level deep.
     internal sealed class SelectorDescendant : Selector
     {
         public SelectorDescendant([NotNull] Selector ascendant, [NotNull] Selector descendant)
@@ -468,7 +467,10 @@ namespace Robust.Client.UserInterface
         }
     }
 
-    // Temporarily hidden due to performance concerns.
+    /// <summary>
+    ///     Given a pair of selectors, will match the element described by the child selector
+    ///     when the child is an immediate child of parent.
+    /// </summary>
     public sealed class SelectorChild : Selector
     {
         public SelectorChild(Selector parent, Selector child)

--- a/Robust.Client/UserInterface/Stylesheet.cs
+++ b/Robust.Client/UserInterface/Stylesheet.cs
@@ -429,7 +429,7 @@ namespace Robust.Client.UserInterface
                 return ElementType.IsInstanceOfType(control);
             }
 
-            return false;
+            return true;
         }
 
         public override StyleSpecificity CalculateSpecificity()

--- a/Robust.Client/UserInterface/UserInterfaceManager.Layout.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Layout.cs
@@ -182,6 +182,14 @@ internal sealed partial class UserInterfaceManager
         public void QueueStyleUpdate(Control control)
         {
             _styleUpdateQueue.Enqueue(control);
+
+            /// Request children to be restyled, which will recursively enqueue style updates
+            /// for all descendent child Controls. This is to propogate changed styles to any
+            /// controls which use a MutableSelectorChild rule based on the input control.
+            foreach (var child in control.Children)
+            {
+                child.Restyle();
+            }
         }
 
         /// <summary>

--- a/Robust.Client/UserInterface/UserInterfaceManager.Layout.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Layout.cs
@@ -186,9 +186,12 @@ internal sealed partial class UserInterfaceManager
             /// Request children to be restyled, which will recursively enqueue style updates
             /// for all descendent child Controls. This is to propogate changed styles to any
             /// controls which use a MutableSelectorChild rule based on the input control.
-            foreach (var child in control.Children)
+            if (control.RestyleChildElements)
             {
-                child.Restyle();
+                foreach (var child in control.Children)
+                {
+                    child.Restyle();
+                }
             }
         }
 


### PR DESCRIPTION
Mildly-controversial PR incoming.

I was looking to fix https://github.com/space-wizards/space-station-14/issues/40923 - in that issue, the problematic element is a `CollapsibleHeading`. The `CollapsibleHeading` is a `ContainerButton` with a child `TextureRect`, which is what is used to display the triangles.

So, the following style rules _should_ do the trick. Use `collapsedTexture` normally, but `expandedTexture` when the heading has been pressed:

```
            E<CollapsibleHeading>()
                .ParentOf(E<BoxContainer>())
                .ParentOf(E<TextureRect>().Class(OptionButton.StyleClassOptionTriangle))
                .Prop(TextureRect.StylePropertyTexture, collapsedTexture),

            E<CollapsibleHeading>().PseudoPressed()
                .ParentOf(E<BoxContainer>())
                .ParentOf(E<TextureRect>().Class(OptionButton.StyleClassOptionTriangle))
                .Prop(TextureRect.StylePropertyTexture, expandedTexture),
```

However, this only works once, and can't be changed once the `CollapsibleHeading` is visible. Pressing the `CollapsibleHeading` will toggle it's pressed pseudo state, which causes the `CollapsibleHeading` to be restyled. However, the style rules are targetting the child `TextureRect`, which never gets queued to refresh it's style.

This PR enqueues a style update for any child `Control`s whenever a parent `Control`'s style is updated. Potentially, this is a bunch more style re-evalulations, but not sure there's a cleverer way to do this, since `Selector.Matches` could be doing anything, so no real way to know if child styles are affected.