### PR TITLE
Change MIDI renderer gain to be at parity with VLC (fix quiet MIDI)

### DIFF
--- a/Robust.Client/Audio/Midi/MidiManager.cs
+++ b/Robust.Client/Audio/Midi/MidiManager.cs
@@ -185,7 +185,7 @@ internal sealed partial class MidiManager : IMidiManager
             _settings["player.timing-source"].StringValue = "sample";
             _settings["synth.lock-memory"].IntValue = 0;
             _settings["synth.threadsafe-api"].IntValue = 1;
-            _settings["synth.gain"].DoubleValue = 1.0d;
+            _settings["synth.gain"].DoubleValue = 2.5d;
             _settings["synth.midi-channels"].IntValue = 16;
             _settings["synth.overflow.age"].DoubleValue = 3000;
             _settings["audio.driver"].StringValue = "file";


### PR DESCRIPTION
# Summary

Sets Fluidsynth's `synth.gain` setting to 2.5, creating a loudness parity between VLC and RT's MIDI rendering, generally making all MIDI consistently audible.

This does not apply any compression; previously loud MIDI are louder. However, the game allows you to turn _down_ the volume of MIDI source, meaning the player is empowered - a loud MIDI can be turned down on the listener's end, and a quiet MIDI then turned back up.

# Technical Notes

Previous investigations into MIDI assumed that the MIDI files were at fault and attempted to apply compression to the loudness ranges. This would work to make MIDI louder, but is a data-facing solution which messes with how the MIDIs are supposed to sound.

I had a brainwave and decided to A-B test Robust (and Robust's backing Fluidsynth integration) against VLC (also backed by Fluidsynth) and noticed a major loudness disparity between the two. I also noticed a gain setting in the Fluidsynth menu in VLC that seemed to control loudness and could be set to make MIDI really quiet, just like Robust.

I took a look at what VLC was doing, and it was just doing setup of Fluidsynth's renderer's gain output to a magic number (for VLC, 0.5) to get a good level of volume - loud MIDI are loud, quiet MIDI are perfectly audible.

I found where this was set in Robust Client and then messed with the number that was being set, comparing the same MIDI rendered on both programs.

I have noted that 2.5 seems to be about the sweet spot for RT to sound the same as VLC when both MIDI are at 100% volume and the player's eye is right next to a DAW.

# Demonstration

Current:

https://github.com/user-attachments/assets/fecbeb7e-647a-41fd-8abb-7b00e58cd17e

New:

https://github.com/user-attachments/assets/f68776ee-5d7a-44a3-8e88-311be068b0e3

New, demonstration vs other audio sources:

https://github.com/user-attachments/assets/df7a9ea9-6e26-4fcd-9fee-297b8e0f5c63

# Potential Issues

The current solution does have the upside that someone outright CANNOT be blasting loud MIDI at people; the gain being at 1.0 means that "loud" is "fine".

This can be accused of being a very dumb fix. It's literally just turning gain up. The alternatives are:

* Manipulate the MIDI notes  being fed into the renderer to compress the loudness.
* Add a compressor to the MIDI renderer source to compress the loudness.

Both of these are destructive to the MIDI - they will mess with the composition and intended loudness of the MIDI and would make MIDI in RT sound more different than the same MIDI played outside in a player like VLC, but would have the upside of giving more direct control to the allowed loudness of an instrument.
