### PR TITLE
Fix word wrapping on non-runed inline metrics like links

### DIFF
--- a/Robust.Client/UserInterface/RichTextEntry.cs
+++ b/Robust.Client/UserInterface/RichTextEntry.cs
@@ -219,6 +219,8 @@ namespace Robust.Client.UserInterface
             var baseLine = drawBox.TopLeft + new Vector2(0, defaultFont.GetAscent(uiScale) + verticalOffset);
             var controlYAdvance = 0f;
 
+            var spaceRune = new Rune(' ');
+
             var nodeIndex = -1;
             foreach (var node in Message)
             {
@@ -232,16 +234,25 @@ namespace Robust.Client.UserInterface
 
                 foreach (var rune in text.EnumerateRunes())
                 {
+                    bool skipSpaceBaseline = false;
+
                     if (lineBreakIndex < LineBreaks.Count &&
                         LineBreaks[lineBreakIndex] == globalBreakCounter)
                     {
                         baseLine = new Vector2(drawBox.Left, baseLine.Y + GetLineHeight(font, uiScale, lineHeightScale) + controlYAdvance);
                         controlYAdvance = 0;
                         lineBreakIndex += 1;
+
+                        // The baseline calc is kind of messed up, the newline is After the space but the space is being drawn after doing the newline
+                        // Which means if this metric Ends on a space, the next metric will use the wrong baseline when it starts, for some reason ..
+                        if (rune == spaceRune)
+                            skipSpaceBaseline = true;
                     }
 
                     var advance = font.DrawChar(handle, rune, baseLine, uiScale, color);
-                    baseLine += new Vector2(advance, 0);
+
+                    if (!skipSpaceBaseline)
+                        baseLine += new Vector2(advance, 0);
 
                     globalBreakCounter += 1;
                 }

--- a/Robust.Client/UserInterface/WordWrap.cs
+++ b/Robust.Client/UserInterface/WordWrap.cs
@@ -107,6 +107,14 @@ internal struct WordWrap
         if (PosX <= _maxSizeX)
             return;
 
+        // Break the "word" at the last word index
+        if (WordStartBreakIndex.HasValue && oldWordSizePixels != 0)
+        {
+            breakLine = WordStartBreakIndex!.Value.index;
+            MaxUsedWidth = Math.Max(MaxUsedWidth, WordStartBreakIndex.Value.lineSize);
+            PosX = WordSizePixels;
+        }
+
         if (!ForceSplitData.HasValue)
         {
             ForceSplitData = (BreakIndexCounter, oldWordSizePixels);


### PR DESCRIPTION
## About the PR
Previously non-runed inline metrics such as links would never wrap if they went partially offscreen, leading to some ugly cutoff

## Technical details
TextLinkTags were only ever using NextMetrics which wasn't inserting any breakLine's after a metric went over the bounds like ProcessRune does. I also had to modify RichTextEntry to avoid some edge cases where it would accidentally display a space as the first character on a newline after processing a non-runed metric.

I'm not super happy with the RichTextEntry changes but the entire Rich Text system seems to be barely held together and in need of a large overhaul (there's some other problem areas in the way rich text is rendered that are unchanged by my fix, you can see a period completely intersecting a "Click here to see a list of technologies" link in the "Science" job entry), so I'd rather a messy fix than none at all. If anyone can do it in a cleaner way then feel free to touch it up.

## Media
Static showcase before fix
<img width="333" height="153" alt="image" src="https://github.com/user-attachments/assets/c1e333dc-d0cc-41f4-a41e-339c5ae25968" />

Static showcase after fix
<img width="276" height="176" alt="image" src="https://github.com/user-attachments/assets/07b1852a-a7b3-40e7-b718-8c39b2118e9c" />


Animated showcase before fix
![link_wrapping_broken](https://github.com/user-attachments/assets/e693b35e-b477-4f87-a342-b2b248fc304b)

Animated showcase after fix
![link_wrapping_fixed](https://github.com/user-attachments/assets/d997077c-073c-473c-9c24-a926df7b38b1)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
