### PR TITLE
Allow content to override ProcessStream and GetOcclusion in AudioSystem

### DIFF
--- a/Robust.Client/Audio/AudioSystem.cs
+++ b/Robust.Client/Audio/AudioSystem.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
+using JetBrains.Annotations;
 using OpenTK.Audio.OpenAL;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
@@ -44,6 +45,26 @@ public sealed partial class AudioSystem : SharedAudioSystem
     [Dependency] private readonly SharedMapSystem _maps = default!;
     [Dependency] private readonly SharedTransformSystem _xformSys = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+
+    /// <summary>
+    /// An optional method that, if provided, will override the behavior of <see cref="ProcessStream"/>.
+    /// Contains the same parameters in the same order as the method it overrides.
+    /// </summary>
+    /// <remarks>
+    /// This event only supports a single invocation target.
+    /// </remarks>
+    [PublicAPI]
+    public event Action<EntityUid, AudioComponent, TransformComponent, MapCoordinates>? ProcessStreamOverride;
+
+    /// <summary>
+    /// An optional method that, if provided, will override the behavior of <see cref="GetOcclusion"/>.
+    /// Contains the same parameters in the same order as the method it overrides.
+    /// </summary>
+    /// <remarks>
+    /// This event only supports a single invocation target.
+    /// </remarks>
+    [PublicAPI]
+    public event Func<MapCoordinates, Vector2, float, EntityUid?, float>? GetOcclusionOverride;
 
     /// <summary>
     /// Per-tick cache of relevant streams.
@@ -341,6 +362,15 @@ public sealed partial class AudioSystem : SharedAudioSystem
 
     private void ProcessStream(EntityUid entity, AudioComponent component, TransformComponent xform, MapCoordinates listener)
     {
+        // If content wants to process the stream in their own special way, we simply let them handle that.
+        if (ProcessStreamOverride is not null)
+        {
+            // Assert that we are not processing audio multiple times.
+            DebugTools.Assert(ProcessStreamOverride.HasSingleTarget, $"Event {nameof(ProcessStreamOverride)} has multiple invocation targets. This is not permitted.");
+            ProcessStreamOverride.Invoke(entity, component, xform, listener);
+            return; // Exit and do not perform remaining function behavior
+        }
+
         // TODO:
         // I Originally tried to be fancier here but it caused audio issues so just trying
         // to replicate the old behaviour for now.
@@ -434,6 +464,14 @@ public sealed partial class AudioSystem : SharedAudioSystem
     /// </summary>
     public float GetOcclusion(MapCoordinates listener, Vector2 delta, float distance, EntityUid? ignoredEnt = null)
     {
+        // If content has defined a custom occlusion method, use that instead.
+        if (GetOcclusionOverride is not null)
+        {
+            // There can only be one occlusion override defined.
+            DebugTools.Assert(GetOcclusionOverride.HasSingleTarget, $"Event {nameof(GetOcclusionOverride)} has multiple invocation targets. This is not permitted.");
+            return GetOcclusionOverride.Invoke(listener, delta, distance, ignoredEnt);
+        }
+
         float occlusion = 0;
 
         if (distance > 0.1)

--- a/Robust.Client/Audio/AudioSystem.cs
+++ b/Robust.Client/Audio/AudioSystem.cs
@@ -54,7 +54,7 @@ public sealed partial class AudioSystem : SharedAudioSystem
     /// This event only supports a single invocation target.
     /// </remarks>
     [PublicAPI]
-    public event Action<EntityUid, AudioComponent, TransformComponent, MapCoordinates>? ProcessStreamOverride;
+    public static event Action<EntityUid, AudioComponent, TransformComponent, MapCoordinates>? ProcessStreamOverride;
 
     /// <summary>
     /// An optional method that, if provided, will override the behavior of <see cref="GetOcclusion"/>.
@@ -64,7 +64,7 @@ public sealed partial class AudioSystem : SharedAudioSystem
     /// This event only supports a single invocation target.
     /// </remarks>
     [PublicAPI]
-    public event Func<MapCoordinates, Vector2, float, EntityUid?, float>? GetOcclusionOverride;
+    public static event Func<MapCoordinates, Vector2, float, EntityUid?, float>? GetOcclusionOverride;
 
     /// <summary>
     /// Per-tick cache of relevant streams.

--- a/Robust.Client/Audio/AudioSystem.cs
+++ b/Robust.Client/Audio/AudioSystem.cs
@@ -54,7 +54,7 @@ public sealed partial class AudioSystem : SharedAudioSystem
     /// This event only supports a single invocation target.
     /// </remarks>
     [PublicAPI]
-    public static event Action<EntityUid, AudioComponent, TransformComponent, MapCoordinates>? ProcessStreamOverride;
+    public event Action<EntityUid, AudioComponent, TransformComponent, MapCoordinates>? ProcessStreamOverride;
 
     /// <summary>
     /// An optional method that, if provided, will override the behavior of <see cref="GetOcclusion"/>.
@@ -64,7 +64,7 @@ public sealed partial class AudioSystem : SharedAudioSystem
     /// This event only supports a single invocation target.
     /// </remarks>
     [PublicAPI]
-    public static event Func<MapCoordinates, Vector2, float, EntityUid?, float>? GetOcclusionOverride;
+    public event Func<MapCoordinates, Vector2, float, EntityUid?, float>? GetOcclusionOverride;
 
     /// <summary>
     /// Per-tick cache of relevant streams.


### PR DESCRIPTION
On my server, we want the ability to be able to handle audio based on some more particular content-specific elements and decisions. However, this is largely impossible due to the audio processing being largely relegated to the engine. Rather than trying to create a web of CVAR options for different audio processes in the engine, I think it's better to just expose more parts of audio to content.

This PR adds the ability for content to define custom handlers for the `ProcessStream` and `GetOcclusion` methods (the two main areas where audio values are determined) that are used in place of the typical function behavior. This is done with static C# events which cause early returns in their corresponding functions. In a more traditional setup these would simply be virtual method calls, but I think this is a fair-enough compromise to achieve that same behavior in the given framework.

Two small implementation notes:
- The `ProcessStream` function is entirely overridden, despite some of the top-most behavior arguably being something that should stay the same no matter what. I think it's better, though, to allow people to have the specificity at the cost of (at worst) minor duplication being needed at the content-level to preserve that behavior.
- Both events are limited to a single invocation target via the use of debug asserts. This obviously makes sense for the `GetOcclusion` function but is more dubious for `ProcessStream`. I do think it's worthwhile considering what the expected use case of this is, however, as I don't really see why someone would want to split up the work of audio processing across multiple functions and I think preventing someone from processing the audio twice is a more likely issue that would want to be avoided.
