### PR TITLE
Fix text links in the guidebook being clickable if the cursor is anywhere to the right of the link, outside it's bounds

### DIFF
--- a/Robust.Client/UserInterface/RichTextEntry.cs
+++ b/Robust.Client/UserInterface/RichTextEntry.cs
@@ -66,6 +66,10 @@ namespace Robust.Client.UserInterface
                 // store state information and return the same control for each rich text entry.
                 DebugTools.Assert(handler.TryCreateControl(node, out var other) && other != control);
 
+                // Avoid children stretching to fill space after manual layout
+                control.HorizontalAlignment = Control.HAlignment.Left;
+                control.VerticalAlignment = Control.VAlignment.Top;
+
                 parent.Children.Add(control);
                 tagControls ??= new Dictionary<int, Control>();
                 tagControls.Add(nodeIndex, control);


### PR DESCRIPTION
This was originally [a pull request for the main repo](https://github.com/space-wizards/space-station-14/pull/41076) but the better fix happened to be within RobustToolbox instead.

## About the PR
Text links in the guidebook had a bug where they were were clickable/hoverable when the mouse wasn't anywhere close to them (anywhere to the right of the link).

## Technical details
TextLinkTags in the guidebook were set to the default "stretch" horizontal layout, so during layout they were all being stretched to the right side of the panel they're in. Despite not causing any visual changes, this made their clickbox huge. More intricate technical details to follow in the comment below (copypasted from my writeup in the original issue).

## Media
![bad_links](https://github.com/user-attachments/assets/1f8534b2-e61a-4b02-8b60-be893e60bf2b)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
