### PR TITLE
Fix bug where ButtonGroup would erroneously unpress buttons

### DIFF
--- a/Robust.Client/UserInterface/Controls/BaseButton.cs
+++ b/Robust.Client/UserInterface/Controls/BaseButton.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Robust.Client.Audio;
@@ -116,7 +116,7 @@ namespace Robust.Client.UserInterface.Controls
 
                 _pressed = value;
 
-                if (Group != null)
+                if (Group != null && _pressed)
                 {
                     UnsetOtherGroupButtons();
                 }
@@ -318,7 +318,10 @@ namespace Robust.Client.UserInterface.Controls
                     if (args.Function == EngineKeyFunctions.UIClick && ToggleMode)
                     {
                         OnToggled?.Invoke(new ButtonToggledEventArgs(Pressed, this, args));
-                        UnsetOtherGroupButtons();
+                        if (_pressed)
+                        {
+                            UnsetOtherGroupButtons();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Noticed this issue when fixing https://github.com/space-wizards/space-station-14/pull/41120 - even before the StyleNano change, when pressing a button in the sentry control UI, the button would only very briefly flash as enabled:

https://github.com/user-attachments/assets/df1025c5-d60e-4c85-b417-ef0199c52b4d

Issue is that the GroupedAccessLevelChecklist.xaml.cs used a ButtonGroup to ensure only one of those buttons was pushed; however, it also listened to the buttons' OnPressed event and rebuilt the UI (removing all the child controls, creating new ones, and assigning one of those controls as 'Pressed') whenever a button was pressed. This is a bad pattern, but is _really_ common in Content. Because a control is only removed from the ButtonGroup in Button.Dispose(), there were temporarily semantically duplicate buttons in the group. When the mouse-up event was triggered on the button you clicked, the new replacement button would become unpressed.

With this change, the UI behaves as expected:

https://github.com/user-attachments/assets/aa8179c9-a61a-4bcc-b093-686afe5a8f4a

