### PR TITLE
Replace OnValueChanged with SubValueChanged

### DIFF
--- a/Robust.Shared/Configuration/ConfigurationManager.cs
+++ b/Robust.Shared/Configuration/ConfigurationManager.cs
@@ -454,21 +454,20 @@ namespace Robust.Shared.Configuration
             _configVars.Add(name, cvar);
         }
 
-        public void OnValueChanged<T>(CVarDef<T> cVar, Action<T> onValueChanged, bool invokeImmediately = false)
-            where T : notnull
+        public void SubValueChanged<T>(CVarDef<T> cVar, Action<T> onValueChanged, bool invokeImmediately = false) where T : notnull
         {
-            OnValueChanged(cVar.Name, onValueChanged, invokeImmediately);
+            SubValueChanged(cVar.Name, onValueChanged, invokeImmediately);
         }
 
-        public void OnValueChanged<T>(string name, Action<T> onValueChanged, bool invokeImmediately = false)
+        public void SubValueChanged<T>(string name, Action<T> onValueChanged, bool invokeImmediately = false)
             where T : notnull
         {
             using (Lock.WriteGuard())
             {
                 var reg = _configVars[name];
 
-                reg.ValueChanged.AddInPlace(
-                    (object value, in CVarChangeInfo _) => onValueChanged((T)value),
+                reg.ValueChanged.AddInPlace((object value, in CVarChangeInfo _) =>
+                        onValueChanged((T)value),
                     onValueChanged);
             }
 
@@ -476,6 +475,18 @@ namespace Robust.Shared.Configuration
             {
                 onValueChanged(GetCVar<T>(name));
             }
+        }
+
+        public void OnValueChanged<T>(CVarDef<T> cVar, Action<T> onValueChanged, bool invokeImmediately = false)
+            where T : notnull
+        {
+            SubValueChanged(cVar, onValueChanged, invokeImmediately);
+        }
+
+        public void OnValueChanged<T>(string name, Action<T> onValueChanged, bool invokeImmediately = false)
+            where T : notnull
+        {
+            SubValueChanged(name, onValueChanged, invokeImmediately);
         }
 
         public void UnsubValueChanged<T>(CVarDef<T> cVar, Action<T> onValueChanged) where T : notnull
@@ -491,29 +502,43 @@ namespace Robust.Shared.Configuration
             reg.ValueChanged.RemoveInPlace(onValueChanged);
         }
 
-        public void OnValueChanged<T>(CVarDef<T> cVar, CVarChanged<T> onValueChanged, bool invokeImmediately = false)
+        public void SubValueChanged<T>(CVarDef<T> cVar, CVarChanged<T> onValueChanged, bool invokeImmediately = false)
             where T : notnull
         {
-            OnValueChanged(cVar.Name, onValueChanged, invokeImmediately);
+            SubValueChanged(cVar.Name, onValueChanged, invokeImmediately);
         }
 
-        public void OnValueChanged<T>(string name, CVarChanged<T> onValueChanged, bool invokeImmediately = false)
+        public void SubValueChanged<T>(string name, CVarChanged<T> onValueChanged, bool invokeImmediately = false)
             where T : notnull
         {
-            object value;
+            object newValue;
+
             using (Lock.WriteGuard())
             {
                 var reg = _configVars[name];
-                value = GetConfigVarValue(reg);
-                reg.ValueChanged.AddInPlace(
-                    (object value, in CVarChangeInfo info) => onValueChanged((T)value, info),
+                newValue = GetConfigVarValue(reg);
+
+                reg.ValueChanged.AddInPlace((object value, in CVarChangeInfo info) =>
+                        onValueChanged((T)value, info),
                     onValueChanged);
             }
 
             if (invokeImmediately)
             {
-                onValueChanged(GetCVar<T>(name), new CVarChangeInfo(name, _gameTiming.CurTick, value, value));
+                onValueChanged(GetCVar<T>(name), new CVarChangeInfo(name, _gameTiming.CurTick, newValue, newValue));
             }
+        }
+
+        public void OnValueChanged<T>(CVarDef<T> cVar, CVarChanged<T> onValueChanged, bool invokeImmediately = false)
+            where T : notnull
+        {
+            SubValueChanged(cVar.Name, onValueChanged, invokeImmediately);
+        }
+
+        public void OnValueChanged<T>(string name, CVarChanged<T> onValueChanged, bool invokeImmediately = false)
+            where T : notnull
+        {
+            SubValueChanged(name, onValueChanged, invokeImmediately);
         }
 
         public void UnsubValueChanged<T>(CVarDef<T> cVar, CVarChanged<T> onValueChanged) where T : notnull

--- a/Robust.Shared/Configuration/ConfigurationManager.cs
+++ b/Robust.Shared/Configuration/ConfigurationManager.cs
@@ -480,7 +480,7 @@ namespace Robust.Shared.Configuration
         public void OnValueChanged<T>(CVarDef<T> cVar, Action<T> onValueChanged, bool invokeImmediately = false)
             where T : notnull
         {
-            SubValueChanged(cVar, onValueChanged, invokeImmediately);
+            SubValueChanged(cVar.Name, onValueChanged, invokeImmediately);
         }
 
         public void OnValueChanged<T>(string name, Action<T> onValueChanged, bool invokeImmediately = false)

--- a/Robust.Shared/Configuration/IConfigurationManager.cs
+++ b/Robust.Shared/Configuration/IConfigurationManager.cs
@@ -172,7 +172,7 @@ namespace Robust.Shared.Configuration
         /// </param>
         /// <typeparam name="T">The type of value contained in this CVar.</typeparam>
         /// <seealso cref="UnsubValueChanged{T}(Robust.Shared.Configuration.CVarDef{T},System.Action{T})"/>
-        void OnValueChanged<T>(CVarDef<T> cVar, Action<T> onValueChanged, bool invokeImmediately = false)
+        void SubValueChanged<T>(CVarDef<T> cVar, Action<T> onValueChanged, bool invokeImmediately = false)
             where T : notnull;
 
         /// <summary>
@@ -188,6 +188,16 @@ namespace Robust.Shared.Configuration
         /// </param>
         /// <typeparam name="T">The type of value contained in this CVar.</typeparam>
         /// <seealso cref="UnsubValueChanged{T}(string,System.Action{T})"/>
+        void SubValueChanged<T>(string name, Action<T> onValueChanged, bool invokeImmediately = false)
+            where T : notnull;
+
+        /// <inheritdoc cref="SubValueChanged{T}(CVarDef{T},System.Action{T},bool)"/>
+        [Obsolete("Use SubValueChanged")]
+        void OnValueChanged<T>(CVarDef<T> cVar, Action<T> onValueChanged, bool invokeImmediately = false)
+            where T : notnull;
+
+        /// <inheritdoc cref="SubValueChanged{T}(string,System.Action{T},bool)"/>
+        [Obsolete("Use SubValueChanged")]
         void OnValueChanged<T>(string name, Action<T> onValueChanged, bool invokeImmediately = false)
             where T : notnull;
 
@@ -228,7 +238,7 @@ namespace Robust.Shared.Configuration
         /// </param>
         /// <typeparam name="T">The type of value contained in this CVar.</typeparam>
         /// <seealso cref="UnsubValueChanged{T}(Robust.Shared.Configuration.CVarDef{T},System.Action{T})"/>
-        void OnValueChanged<T>(CVarDef<T> cVar, CVarChanged<T> onValueChanged, bool invokeImmediately = false)
+        void SubValueChanged<T>(CVarDef<T> cVar, CVarChanged<T> onValueChanged, bool invokeImmediately = false)
             where T : notnull;
 
         /// <summary>
@@ -244,6 +254,16 @@ namespace Robust.Shared.Configuration
         /// </param>
         /// <typeparam name="T">The type of value contained in this CVar.</typeparam>
         /// <seealso cref="UnsubValueChanged{T}(string,System.Action{T})"/>
+        void SubValueChanged<T>(string name, CVarChanged<T> onValueChanged, bool invokeImmediately = false)
+            where T : notnull;
+
+        /// <inheritdoc cref="SubValueChanged{T}(CVarDef{T},CVarChanged{T},bool)"/>
+        [Obsolete("Use SubValueChanged")]
+        void OnValueChanged<T>(CVarDef<T> cVar, CVarChanged<T> onValueChanged, bool invokeImmediately = false)
+            where T : notnull;
+
+        /// <inheritdoc cref="SubValueChanged{T}(string,CVarChanged{T},bool)"/>
+        [Obsolete("Use SubValueChanged")]
         void OnValueChanged<T>(string name, CVarChanged<T> onValueChanged, bool invokeImmediately = false)
             where T : notnull;
 


### PR DESCRIPTION
UnsubValueChanged was added later, but their names should still be consistent with each other and use the same naming scheme to prevent confusion.

This does add a lot of warnings, but I'm willing to handle them myself.