### PR TITLE
Double-buffer contact events

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,7 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* StartCollide and EndCollide events are now buffered until the end of physics substeps instead of being raised during the CollideContacts step. EndCollide events are double-buffered and any new ones raised while the events are being dispatched will now go out on the next tick / substep.
 
 ### New features
 

--- a/Robust.Client/Physics/PhysicsSystem.Predict.cs
+++ b/Robust.Client/Physics/PhysicsSystem.Predict.cs
@@ -106,6 +106,7 @@ public sealed partial class PhysicsSystem
         }
 
         UpdateIsTouching(contacts);
+        DispatchEvents();
     }
 
     /// <summary>

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
@@ -353,8 +353,8 @@ public abstract partial class SharedPhysicsSystem
         {
             var ev1 = new EndCollideEvent(aUid, bUid, contact.FixtureAId, contact.FixtureBId, fixtureA, fixtureB, bodyA, bodyB);
             var ev2 = new EndCollideEvent(bUid, aUid, contact.FixtureBId, contact.FixtureAId, fixtureB, fixtureA, bodyB, bodyA);
-            RaiseLocalEvent(aUid, ref ev1);
-            RaiseLocalEvent(bUid, ref ev2);
+            _endCollideEvents[_endEventIndex].Add(ev1);
+            _endCollideEvents[_endEventIndex].Add(ev2);
         }
 
         if (contact.Manifold.PointCount > 0 && contact.FixtureA?.Hard == true && contact.FixtureB?.Hard == true)
@@ -603,8 +603,9 @@ public abstract partial class SharedPhysicsSystem
                 var ev1 = new StartCollideEvent(uidA, uidB, contact.FixtureAId, contact.FixtureBId, fixtureA, fixtureB, bodyA, bodyB, points, contact.Manifold.PointCount, worldNormal);
                 var ev2 = new StartCollideEvent(uidB, uidA, contact.FixtureBId, contact.FixtureAId, fixtureB, fixtureA, bodyB, bodyA, points, contact.Manifold.PointCount, worldNormal);
 
-                RaiseLocalEvent(uidA, ref ev1, true);
-                RaiseLocalEvent(uidB, ref ev2, true);
+                _startCollideEvents.Add(ev1);
+                _startCollideEvents.Add(ev2);
+
                 break;
             }
             case ContactStatus.Touching:
@@ -626,8 +627,8 @@ public abstract partial class SharedPhysicsSystem
                 var ev1 = new EndCollideEvent(uidA, uidB, contact.FixtureAId, contact.FixtureBId, fixtureA, fixtureB, bodyA, bodyB);
                 var ev2 = new EndCollideEvent(uidB, uidA, contact.FixtureBId, contact.FixtureAId, fixtureB, fixtureA, bodyB, bodyA);
 
-                RaiseLocalEvent(uidA, ref ev1);
-                RaiseLocalEvent(uidB, ref ev2);
+                _endCollideEvents[_endEventIndex].Add(ev1);
+                _endCollideEvents[_endEventIndex].Add(ev2);
                 break;
             }
             case ContactStatus.NoContact:

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Events.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Events.cs
@@ -24,7 +24,7 @@ public abstract partial class SharedPhysicsSystem
             var elem = ev;
             RaiseLocalEvent(ev.OurEntity, ref elem);
         }
-        
+
         _endCollideEvents[1 - _endEventIndex].Clear();
     }
 }

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Events.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Events.cs
@@ -1,0 +1,27 @@
+namespace Robust.Shared.Physics.Systems;
+
+public abstract partial class SharedPhysicsSystem
+{
+    protected void DispatchEvents()
+    {
+        // This will raise events even if the contact is gone which is fine I think
+        // because otherwise we may get issues with events not getting raised in some cases.
+
+        // Raises all the buffered events once physics step is done.
+        foreach (var ev in _startCollideEvents)
+        {
+            var elem = ev;
+            RaiseLocalEvent(ev.OurEntity, ref elem);
+        }
+
+        foreach (var ev in _endCollideEvents[_endEventIndex])
+        {
+            var elem = ev;
+            RaiseLocalEvent(ev.OurEntity, ref elem);
+        }
+
+        _endEventIndex = 1 - _endEventIndex;
+        _startCollideEvents.Clear();
+        _endCollideEvents[_endEventIndex].Clear();
+    }
+}

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Events.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Events.cs
@@ -7,6 +7,9 @@ public abstract partial class SharedPhysicsSystem
         // This will raise events even if the contact is gone which is fine I think
         // because otherwise we may get issues with events not getting raised in some cases.
 
+        // Swap the end index over so new events happen next tick.
+        _endEventIndex = 1 - _endEventIndex;
+
         // Raises all the buffered events once physics step is done.
         foreach (var ev in _startCollideEvents)
         {
@@ -14,14 +17,14 @@ public abstract partial class SharedPhysicsSystem
             RaiseLocalEvent(ev.OurEntity, ref elem);
         }
 
-        foreach (var ev in _endCollideEvents[_endEventIndex])
+        _startCollideEvents.Clear();
+
+        foreach (var ev in _endCollideEvents[1 - _endEventIndex])
         {
             var elem = ev;
             RaiseLocalEvent(ev.OurEntity, ref elem);
         }
-
-        _endEventIndex = 1 - _endEventIndex;
-        _startCollideEvents.Clear();
-        _endCollideEvents[_endEventIndex].Clear();
+        
+        _endCollideEvents[1 - _endEventIndex].Clear();
     }
 }

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Prometheus;
 using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
@@ -49,6 +50,25 @@ namespace Robust.Shared.Physics.Systems
         [Dependency] private readonly SharedJointSystem _joints = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
         [Dependency] private readonly CollisionWakeSystem _wakeSystem = default!;
+
+        /*
+         * Events
+         */
+
+        // Buffer events to avoid enumeration issues.
+
+        private readonly List<StartCollideEvent> _startCollideEvents = new();
+
+        // Double-buffer end-collide events like box2d-v3 because we can raise these while destroying contacts
+        // whereas with start events they only ever get made during the collision step.
+        private readonly List<EndCollideEvent>[]
+            _endCollideEvents =
+            [
+                new List<EndCollideEvent>(),
+                new List<EndCollideEvent>()
+            ];
+
+        private int _endEventIndex = 0;
 
         private int _substeps;
 
@@ -301,6 +321,8 @@ namespace Robust.Shared.Physics.Systems
                 CollideContacts();
 
                 Step(frameTime, prediction);
+
+                DispatchEvents();
 
                 var updateAfterSolve = new PhysicsUpdateAfterSolveEvent(prediction, frameTime);
                 RaiseLocalEvent(ref updateAfterSolve);

--- a/Robust.UnitTesting/Shared/Physics/Collision_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Collision_Test.cs
@@ -32,6 +32,7 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Reflection;
 using Robust.UnitTesting.Server;
 
 namespace Robust.UnitTesting.Shared.Physics;
@@ -90,6 +91,7 @@ public sealed partial class Collision_Test
         Assert.That(sub._counter, Is.GreaterThan(0));
     }
 
+    [Reflect(false)]
     private sealed class CollisionSubSystem : EntitySystem
     {
         public int _counter;

--- a/Robust.UnitTesting/Shared/Physics/Collision_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Collision_Test.cs
@@ -30,6 +30,7 @@ using Robust.Shared.Physics;
 using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
+using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
 using Robust.UnitTesting.Server;
 
@@ -38,6 +39,57 @@ namespace Robust.UnitTesting.Shared.Physics;
 [TestFixture]
 public sealed class Collision_Test
 {
+    /// <summary>
+    /// Asserts that collision events even go out.
+    /// </summary>
+    [Test]
+    public void CollisionEvents()
+    {
+        var sim = RobustServerSimulation.NewSimulation()
+            .RegisterEntitySystems(fac =>
+            {
+                fac.LoadExtraSystemType<CollisionSubSystem>();
+            })
+            .RegisterComponents(fac =>
+            {
+                fac.RegisterClass<CollisionSubComponent>();
+            })
+            .InitializeInstance();
+
+        var entManager = sim.Resolve<IEntityManager>();
+
+        var broadphase = entManager.System<SharedBroadphaseSystem>();
+        var fixtures = entManager.System<FixtureSystem>();
+        var physics = entManager.System<SharedPhysicsSystem>();
+        var sub = entManager.System<CollisionSubSystem>();
+
+        var map = sim.CreateMap();
+
+        var bodyAUid = entManager.SpawnAttachedTo(null, new EntityCoordinates(map.Uid, Vector2.Zero));
+        var bodyBUid = entManager.SpawnAttachedTo(null, new EntityCoordinates(map.Uid, Vector2.Zero));
+        var bodyA = entManager.AddComponent<PhysicsComponent>(bodyAUid);
+        var bodyB = entManager.AddComponent<PhysicsComponent>(bodyBUid);
+        entManager.AddComponent<CollisionSubComponent>(bodyAUid);
+        physics.SetBodyType(bodyAUid, BodyType.Dynamic);
+        physics.SetBodyType(bodyBUid, BodyType.Dynamic);
+
+        fixtures.CreateFixture(bodyAUid, "fix1", new Fixture(new PhysShapeCircle(0.5f), 1, 1, true));
+        fixtures.CreateFixture(bodyBUid, "fix1", new Fixture(new PhysShapeCircle(0.5f), 1, 1, true));
+
+        physics.SetCanCollide(bodyAUid, true, body: bodyA);
+        physics.SetCanCollide(bodyBUid, true, body: bodyB);
+        physics.WakeBody(bodyAUid);
+
+        Assert.That(physics.IsHardCollidable(bodyAUid, bodyBUid));
+        broadphase.FindNewContacts();
+
+        Assert.That(bodyA.ContactCount, Is.EqualTo(1));
+        Assert.That(bodyB.ContactCount, Is.EqualTo(1));
+
+        physics.Update(0.016f);
+        Assert.That(sub._counter, Is.GreaterThan(0));
+    }
+
     [Test]
     public void TestHardCollidable()
     {
@@ -156,4 +208,26 @@ public sealed class Collision_Test
 
         Assert.That(body1.ContactCount == 0 && body2.ContactCount == 0);
     }
+}
+
+internal sealed class CollisionSubSystem : EntitySystem
+{
+    public int _counter;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<CollisionSubComponent, StartCollideEvent>(OnStartCollide);
+    }
+
+    private void OnStartCollide(Entity<CollisionSubComponent> ent, ref StartCollideEvent args)
+    {
+        _counter++;
+        return;
+    }
+}
+
+internal sealed partial class CollisionSubComponent : Component
+{
+
 }

--- a/Robust.UnitTesting/Shared/Physics/Collision_Test.cs
+++ b/Robust.UnitTesting/Shared/Physics/Collision_Test.cs
@@ -37,7 +37,7 @@ using Robust.UnitTesting.Server;
 namespace Robust.UnitTesting.Shared.Physics;
 
 [TestFixture]
-public sealed class Collision_Test
+public sealed partial class Collision_Test
 {
     /// <summary>
     /// Asserts that collision events even go out.
@@ -88,6 +88,28 @@ public sealed class Collision_Test
 
         physics.Update(0.016f);
         Assert.That(sub._counter, Is.GreaterThan(0));
+    }
+
+    private sealed class CollisionSubSystem : EntitySystem
+    {
+        public int _counter;
+
+        public override void Initialize()
+        {
+            base.Initialize();
+            SubscribeLocalEvent<CollisionSubComponent, StartCollideEvent>(OnStartCollide);
+        }
+
+        private void OnStartCollide(Entity<CollisionSubComponent> ent, ref StartCollideEvent args)
+        {
+            _counter++;
+            return;
+        }
+    }
+
+    private sealed partial class CollisionSubComponent : Component
+    {
+
     }
 
     [Test]
@@ -208,26 +230,4 @@ public sealed class Collision_Test
 
         Assert.That(body1.ContactCount == 0 && body2.ContactCount == 0);
     }
-}
-
-internal sealed class CollisionSubSystem : EntitySystem
-{
-    public int _counter;
-
-    public override void Initialize()
-    {
-        base.Initialize();
-        SubscribeLocalEvent<CollisionSubComponent, StartCollideEvent>(OnStartCollide);
-    }
-
-    private void OnStartCollide(Entity<CollisionSubComponent> ent, ref StartCollideEvent args)
-    {
-        _counter++;
-        return;
-    }
-}
-
-internal sealed partial class CollisionSubComponent : Component
-{
-
 }


### PR DESCRIPTION
It's how box2d v3 has it (though in their case you have to manually iterate events). StartCollide isn't actually double-buffered because they are only every raised during FindNewContacts.

Will probably just slap some massive credit on everything towards the end as parity gets closer but can add something now.

This will also eventually mean we can remove the contact linkedlist and just use a flat list, I just split this out so we can get it tested sooner.