### PR TITLE
Make SpriteSystem.LayerExists say layer index 0 is valid

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Layer.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Layer.cs
@@ -17,7 +17,7 @@ public sealed partial class SpriteSystem
         if (!_query.Resolve(sprite.Owner, ref sprite.Comp))
             return false;
 
-        return index > 0 && index < sprite.Comp.Layers.Count;
+        return index >= 0 && index < sprite.Comp.Layers.Count;
     }
 
     public bool TryGetLayer(


### PR DESCRIPTION
Consider the following usage of the SpriteSystem:
```csharp
Entity<SpriteComponent?> sprite = ...;
PrototypeLayerData layerData = ...;
string layerKey = ...;

// Create a new layer and create a map key for it
var newLayerIndex = SpriteSystem.AddLayer(sprite, layerData, null);
SpriteSystem.LayerMapAdd(sprite, newLayerKey, newLayerIndex);

// Look up the layer by key
var layerExists = SpriteSystem.LayerExists(sprite, newLayerKey);

// layerExists returns false if the sprite had no layers previously and this newly added one was index 0
```

I believe this is incorrect just due to a bug in `LayerExists`, which is fixed here.