### PR TITLE
Make Caps Lock bindable

### DIFF
--- a/Resources/Locale/en-US/input.ftl
+++ b/Resources/Locale/en-US/input.ftl
@@ -68,6 +68,7 @@ input-key-MouseButton6 = Mouse 6
 input-key-MouseButton7 = Mouse 7
 input-key-MouseButton8 = Mouse 8
 input-key-MouseButton9 = Mouse 9
+input-key-CapsLock = Caps Lock
 
 input-key-LSystem-win = Left Win
 input-key-RSystem-win = Right Win

--- a/Resources/Locale/pt-BR/input.ftl
+++ b/Resources/Locale/pt-BR/input.ftl
@@ -43,6 +43,7 @@ input-key-MouseButton6 = Mouse 6
 input-key-MouseButton7 = Mouse 7
 input-key-MouseButton8 = Mouse 8
 input-key-MouseButton9 = Mouse 9
+input-key-CapsLock = Caps Lock
 
 input-key-LSystem-win = Left Win
 input-key-RSystem-win = Right Win

--- a/Robust.Client/Graphics/Clyde/Windowing/Glfw.Keys.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Glfw.Keys.cs
@@ -219,6 +219,7 @@ namespace Robust.Client.Graphics.Clyde
                     {GlfwKey.F24, Key.F24},
                     {GlfwKey.Pause, Key.Pause},
                     {GlfwKey.World1, Key.World1},
+                    {GlfwKey.CapsLock, Key.CapsLock}
                 }.ToFrozenDictionary();
 
                 var keyMapReverse = new Dictionary<Key, GlfwKey>();

--- a/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Key.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Key.cs
@@ -203,6 +203,7 @@ internal partial class Clyde
             MapKey(SC.SDL_SCANCODE_F23, Key.F23);
             MapKey(SC.SDL_SCANCODE_F24, Key.F24);
             MapKey(SC.SDL_SCANCODE_PAUSE, Key.Pause);
+            MapKey(SC.SDL_SCANCODE_CAPSLOCK, Key.CapsLock);
 
             var keyMapReverse = new Dictionary<Key, SC>();
 

--- a/Robust.Client/Input/InputDevices.cs
+++ b/Robust.Client/Input/InputDevices.cs
@@ -173,6 +173,7 @@ namespace Robust.Client.Input
             F24,
             Pause,
             World1,
+            CapsLock,
         }
 
         public static bool IsMouseKey(this Key key)


### PR DESCRIPTION
Hi!

On linux we have the option to swap Caps Lock and Escape keys in the keyboard layout. So the physical escape key will toggle capitalization and the physical caps lock will be just a normal key.

Robust.Client reads keys layout independently, so it still sees the keys by their physical location, but
Robust.Client.Input.Keyboard.Key did not have a constant for Caps Lock key, so it was not bindable.

This PR adds the Caps Lock key in both glfw and sdl3 backends.