### PR TITLE
Cleanup warnings: CS0162, CS0618, CS0649

### DIFF
--- a/Robust.Client/UserInterface/RichText/MarkupDrawingContext.cs
+++ b/Robust.Client/UserInterface/RichText/MarkupDrawingContext.cs
@@ -8,20 +8,20 @@ public sealed class MarkupDrawingContext
 {
     public readonly Stack<Color> Color;
     public readonly Stack<Font> Font;
-    public readonly List<IMarkupTag> Tags;
+    public readonly List<IMarkupTagHandler> Tags;
 
     public MarkupDrawingContext()
     {
         Color = new Stack<Color>();
         Font = new Stack<Font>();
-        Tags = new List<IMarkupTag>();
+        Tags = new List<IMarkupTagHandler>();
     }
 
     public MarkupDrawingContext(int capacity)
     {
         Color = new Stack<Color>(capacity);
         Font = new Stack<Font>(capacity);
-        Tags = new List<IMarkupTag>();
+        Tags = new List<IMarkupTagHandler>();
     }
 
     public void Clear()

--- a/Robust.Client/UserInterface/RichText/MarkupDrawingContext.cs
+++ b/Robust.Client/UserInterface/RichText/MarkupDrawingContext.cs
@@ -8,20 +8,20 @@ public sealed class MarkupDrawingContext
 {
     public readonly Stack<Color> Color;
     public readonly Stack<Font> Font;
-    public readonly List<IMarkupTagHandler> Tags;
+    public readonly List<IMarkupTag> Tags;
 
     public MarkupDrawingContext()
     {
         Color = new Stack<Color>();
         Font = new Stack<Font>();
-        Tags = new List<IMarkupTagHandler>();
+        Tags = new List<IMarkupTag>();
     }
 
     public MarkupDrawingContext(int capacity)
     {
         Color = new Stack<Color>(capacity);
         Font = new Stack<Font>(capacity);
-        Tags = new List<IMarkupTagHandler>();
+        Tags = new List<IMarkupTag>();
     }
 
     public void Clear()

--- a/Robust.Shared/GameObjects/EntityEventBus.Common.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Common.cs
@@ -97,7 +97,7 @@ internal sealed partial class EntityEventBus : IEventBus
         /// <summary>
         /// <see cref="ComponentEventAttribute"/> set?
         /// </summary>
-        public bool ComponentEvent;
+        public bool ComponentEvent = false;
         public bool IsOrdered;
         public bool OrderingUpToDate;
         public ValueList<BroadcastRegistration> BroadcastRegistrations;

--- a/Robust.Shared/GameObjects/EntityEventBus.Common.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Common.cs
@@ -94,10 +94,6 @@ internal sealed partial class EntityEventBus : IEventBus
     /// </summary>
     private sealed class EventData
     {
-        /// <summary>
-        /// <see cref="ComponentEventAttribute"/> set?
-        /// </summary>
-        public bool ComponentEvent = false;
         public bool IsOrdered;
         public bool OrderingUpToDate;
         public ValueList<BroadcastRegistration> BroadcastRegistrations;

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -212,8 +212,9 @@ namespace Robust.Shared.GameObjects
                     _sawmill.Error($"Failed to serialize {compName} component of entity prototype {prototype.ID}. Exception: {e.Message}");
 #if !EXCEPTION_TOLERANCE
                     throw;
-#endif
+#else
                     return false;
+#endif
                 }
 
                 if (compMapping.AnyExcept(protoMapping))


### PR DESCRIPTION
This PR removes 2 small and unrelated warnings

1x [CS0162](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0162): Unreachable code detected.
`Robust.Shared/GameObjects/EntityManager.cs`

1x [CS0649](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0649): Field 'EntityEventBus.EventData.ComponentEvent' is never assigned to, and will always have its default value 'false'.
`Robust.Shared/GameObjects/EntityEventBus.Common.cs`

[https://github.com/space-wizards/space-station-14/issues/33279](https://github.com/space-wizards/space-station-14/issues/33279)