### PR TITLE
Add BUI helper overloads supporting constructor parameters

### DIFF
--- a/Robust.Client/UserInterface/BoundUserInterfaceExt.cs
+++ b/Robust.Client/UserInterface/BoundUserInterfaceExt.cs
@@ -7,12 +7,33 @@ namespace Robust.Client.UserInterface;
 
 public static class BoundUserInterfaceExt
 {
-    private static T GetWindow<T>(BoundUserInterface bui) where T : BaseWindow, new()
+    /// <summary>
+    /// Internal method to create a window with default constructor and register it with the BUI system.
+    /// </summary>
+    private static T GetWindow<T>(BoundUserInterface bui, UserInterfaceSystem system) where T : BaseWindow, new()
     {
         var window = bui.CreateDisposableControl<T>();
+
         window.OnClose += bui.Close;
-        var system = bui.EntMan.System<UserInterfaceSystem>();
         system.RegisterControl(bui, window);
+
+        return window;
+    }
+
+    /// <summary>
+    /// Internal method to create a window with constructor parameters and register it with the BUI system.
+    /// </summary>
+    private static T GetWindow<T>(BoundUserInterface bui, object[] args, UserInterfaceSystem system) where T : BaseWindow, IDisposable
+    {
+        var window = (T?)Activator.CreateInstance(typeof(T), args)
+            ?? throw new InvalidOperationException($"Failed to create window of type {typeof(T)}");
+
+        window.OnClose += bui.Close;
+        system.RegisterControl(bui, window);
+
+        bui.Disposals ??= [];
+        bui.Disposals.Add(window);
+
         return window;
     }
 
@@ -21,9 +42,10 @@ public static class BoundUserInterfaceExt
     /// </summary>
     public static T CreateWindow<T>(this BoundUserInterface bui) where T : BaseWindow, new()
     {
-        var window = GetWindow<T>(bui);
+        var system = bui.EntMan.System<UserInterfaceSystem>();
+        var window = GetWindow<T>(bui, system);
 
-        if (bui.EntMan.System<UserInterfaceSystem>().TryGetPosition(bui.Owner, bui.UiKey, out var position))
+        if (system.TryGetPosition(bui.Owner, bui.UiKey, out var position))
         {
             window.Open(position);
         }
@@ -35,11 +57,36 @@ public static class BoundUserInterfaceExt
         return window;
     }
 
+    /// <summary>
+    /// Helper method to create a window with constructor parameters and also handle closing the BUI when it's closed.
+    /// </summary>
+    /// <param name="args">Arguments to pass to the window constructor.</param>
+    public static T CreateWindow<T>(this BoundUserInterface bui, params object[] args) where T : BaseWindow, IDisposable
+    {
+        var system = bui.EntMan.System<UserInterfaceSystem>();
+        var window = GetWindow<T>(bui, args, system);
+
+        if (system.TryGetPosition(bui.Owner, bui.UiKey, out var position))
+        {
+            window.Open(position);
+        }
+        else
+        {
+            window.OpenCentered();
+        }
+
+        return window;
+    }
+
+    /// <summary>
+    /// Creates a window centered to the left.
+    /// </summary>
     public static T CreateWindowCenteredLeft<T>(this BoundUserInterface bui) where T : BaseWindow, new()
     {
-        var window = GetWindow<T>(bui);
+        var system = bui.EntMan.System<UserInterfaceSystem>();
+        var window = GetWindow<T>(bui, system);
 
-        if (bui.EntMan.System<UserInterfaceSystem>().TryGetPosition(bui.Owner, bui.UiKey, out var position))
+        if (system.TryGetPosition(bui.Owner, bui.UiKey, out var position))
         {
             window.Open(position);
         }
@@ -51,11 +98,57 @@ public static class BoundUserInterfaceExt
         return window;
     }
 
+    /// <summary>
+    /// Creates a window centered to the left with constructor parameters.
+    /// </summary>
+    /// <param name="args">Arguments to pass to the window constructor.</param>
+    public static T CreateWindowCenteredLeft<T>(this BoundUserInterface bui, params object[] args) where T : BaseWindow, IDisposable
+    {
+        var system = bui.EntMan.System<UserInterfaceSystem>();
+        var window = GetWindow<T>(bui, args, system);
+
+        if (system.TryGetPosition(bui.Owner, bui.UiKey, out var position))
+        {
+            window.Open(position);
+        }
+        else
+        {
+            window.OpenCenteredLeft();
+        }
+
+        return window;
+    }
+
+    /// <summary>
+    /// Creates a window centered to the right.
+    /// </summary>
     public static T CreateWindowCenteredRight<T>(this BoundUserInterface bui) where T : BaseWindow, new()
     {
-        var window = GetWindow<T>(bui);
+        var system = bui.EntMan.System<UserInterfaceSystem>();
+        var window = GetWindow<T>(bui, system);
 
-        if (bui.EntMan.System<UserInterfaceSystem>().TryGetPosition(bui.Owner, bui.UiKey, out var position))
+        if (system.TryGetPosition(bui.Owner, bui.UiKey, out var position))
+        {
+            window.Open(position);
+        }
+        else
+        {
+            window.OpenCenteredRight();
+        }
+
+        return window;
+    }
+
+    /// <summary>
+    /// Creates a window centered to the right with constructor parameters.
+    /// </summary>
+    /// <param name="args">Arguments to pass to the window constructor.</param>
+    public static T CreateWindowCenteredRight<T>(this BoundUserInterface bui, params object[] args) where T : BaseWindow, IDisposable
+    {
+        var system = bui.EntMan.System<UserInterfaceSystem>();
+        var window = GetWindow<T>(bui, args, system);
+
+        if (system.TryGetPosition(bui.Owner, bui.UiKey, out var position))
         {
             window.Open(position);
         }
@@ -70,14 +163,28 @@ public static class BoundUserInterfaceExt
     /// <summary>
     /// Creates a control for this BUI that will be disposed when it is disposed.
     /// </summary>
-    /// <param name="bui"></param>
-    /// <typeparam name="T"></typeparam>
-    /// <returns></returns>
     public static T CreateDisposableControl<T>(this BoundUserInterface bui) where T : Control, IDisposable, new()
     {
         var control = new T();
+
         bui.Disposals ??= [];
         bui.Disposals.Add(control);
+
+        return control;
+    }
+
+    /// <summary>
+    /// Creates a control for this BUI with constructor parameters that will be disposed when it is disposed.
+    /// </summary>
+    /// <param name="args">Arguments to pass to the control constructor.</param>
+    public static T CreateDisposableControl<T>(this BoundUserInterface bui, params object[] args) where T : Control, IDisposable
+    {
+        var control = (T?)Activator.CreateInstance(typeof(T), args)
+            ?? throw new InvalidOperationException($"Failed to create control of type {typeof(T)}");
+
+        bui.Disposals ??= [];
+        bui.Disposals.Add(control);
+
         return control;
     }
 }


### PR DESCRIPTION
This PR adds BUI helper overloads with support for passing constructor parameters.  It also makes a few stylistic changes.

Now there is a problem that the old method of creating a window (example: `_window = new IdCardConsoleWindow(this, _prototypeManager, accessLevels)`) supports passing constructor parameters, but helpers do not. It's very inconvenient.. so this PR fixes it.

As an example, this allows you to pass `IDependencyCollection` as a parameter to replace `IoCManager.InjectDependencies(this)` with `dependencies.InjectDependencies(this)`.

All new overloads have been tested on SS14 content and everything is working as intended.