### PR TITLE
Add noSpawn property to audio entity

### DIFF
--- a/Resources/EnginePrototypes/Audio/audio_entities.yml
+++ b/Resources/EnginePrototypes/Audio/audio_entities.yml
@@ -3,7 +3,7 @@
   name: Audio
   description: Audio entity used by engine
   save: false # TODO PERSISTENCE what about looping or long sounds?
-  noSpawn: true
+  categories: [ HideSpawnMenu ]
   components:
     - type: Transform
       gridTraversal: false

--- a/Resources/EnginePrototypes/Audio/audio_entities.yml
+++ b/Resources/EnginePrototypes/Audio/audio_entities.yml
@@ -3,6 +3,7 @@
   name: Audio
   description: Audio entity used by engine
   save: false # TODO PERSISTENCE what about looping or long sounds?
+  noSpawn: true
   components:
     - type: Transform
       gridTraversal: false


### PR DESCRIPTION
Stops audio entity showing in spawn menu.

This was a very simple thing that I noticed when wiping the spawn menu.