### PR TITLE
Fix WebView loading

### DIFF
--- a/Robust.Client/GameController/GameController.cs
+++ b/Robust.Client/GameController/GameController.cs
@@ -186,8 +186,7 @@ namespace Robust.Client
             _loadscr.LoadingStep(() =>
                 {
                     // Finish initialization of WebView if loaded.
-                    if (_webViewHook != null)
-                        _loadscr.LoadingStep(_webViewHook.Initialize, _webViewHook);
+                    _webViewHook?.Initialize();
                 },
                 "WebView init");
 


### PR DESCRIPTION
The nested `LoadingStep()` call is crashing the client as it loads due to this code:
https://github.com/space-wizards/RobustToolbox/blob/465a1fb5bd91bcb7ed17cfc8c9e3b342e5997e89/Robust.Client/Graphics/LoadingScreenManager.cs#L109-L115