### PR TITLE
Make ParsedValueRef public

### DIFF
--- a/Robust.Shared/Toolshed/Syntax/ValueRef.cs
+++ b/Robust.Shared/Toolshed/Syntax/ValueRef.cs
@@ -119,7 +119,7 @@ public sealed class WriteableVarRef<T>(VarRef<T> inner) : ValueRef<T>
 /// This class represents a <see cref="ValueRef{T}"/> command argument that simply corresponds to a specific value of
 /// some type that has already been parsed/evaluated.
 /// </summary>
-internal sealed class ParsedValueRef<T>(T? value) : ValueRef<T>
+public sealed class ParsedValueRef<T>(T? value) : ValueRef<T>
 {
     public readonly T? Value = value;
 


### PR DESCRIPTION
Currently, in a `CommandArgumentBundle` the stored Arguments are of type `ParsedValueRef` when you check them inside a `CustomTypeParser`. This makes it very annoying to get the types parsed by the previous parsers inside a `CustomTypeParser` (you would need to manually call Evaluate with a Invocation Context, very annoying). 
With this change, the resulting code would instead cast the objects inside of `Arguments` to `ParsedValueRef` where you can then check the Value contained for what type you need. 

As for concerns regarding making it internal, the class has 2 usages, none of which seem security critical if exposed.