### PR TITLE
Fix layouting bug in SS14 ghost role menu (space-wizards/space-station-14#41434)

### DIFF
--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -262,6 +262,7 @@ namespace Robust.Client.UserInterface
                     RunMeasure(control);
                     if (!control.IsMeasureValid && control.IsInsideTree)
                         _sawmillUI.Warning($"Control's measure is invalid after measuring. Control: {control}. Parent: {control.Parent}.");
+                    control.InvalidateArrange();
                     total += 1;
                 }
 


### PR DESCRIPTION
Fixes space-wizards/space-station-14#41434.

While debugging I also came across another UI bug where descriptions would be hidden behind buttons. This change *seems* to fix that bug as well.

<img width="564" height="565" alt="ghost-role-bug2" src="https://github.com/user-attachments/assets/f9acc250-692d-46bd-aa00-bbe3ef0832a1" />

## The short version
A dirty flag problem caused a layouting problem in the SS14 ghost role menu *sometimes*. This happens because under very specific circumstances a ScrollContainer might get queued for measuring but not for subsequent rearranging. This can be fixed by adding an `InvalidateArrange()` call into `FrameUpdate()`  so that all Controls that are remeasured will also get rearranged.

<details>
<summary>The *very very long* version</summary>

*I'd written down the what & why of this solution while debugging so I figured I might as well share it.*

## Timeline of the bug

What's special about the ghost role menu is that it receives its list entries from a network request. The bug only occurred when the network response was received one frame after creating the UI window, and even then it was an inconsistent bug.

### Frame 1
- Dispatch network request for list of ghost roles
- Create ghost role window
- In UserInterfaceManager.FrameUpdate, rearrange the ghost role menu ScrollContainer:
    - ScrollContainer.set_Visible() gets called
    - That calls ScrollContainer.InvalidateMeasure()
    - Set `IsMeasureValid = false` & add it to the measure queue
    - Call ScrollContainer.InvalidateArrange()
    - Early-out because we're currently rearranging ScrollContainer
    - `IsArrangeValid` ***does not*** get set to `false` and it is ***not*** added to the arrange queue (here's your problem)
- The ghost role window is displayed with an empty list placeholder message

### Between frame 1 & frame 2
- ScrollContainer is at the front of the measure queue
- ScrollContainer is not in the rearrange queue
- ScrollContainer.IsMeasureValid = false
- ScrollContainer.IsArrangeValid = true

### Frame 2
- Receive list of ghost roles from the server
- Add entries to the ghost role list
- In UserInterfaceManager.FrameUpdate:
    - ScrollContainer is measured first (it's at the front of the queue)
    - This involves measuring EntryContainer
    - EntryContainer calls Parent?.InvalidateMeasure(), but this earlies-out because its parent ScrollContainer is currently measuring
    - As a result, ScrollContainer is never rearranged
    - Therefore ScrollContainer never gets a chance to notice that it should make the scrollbar visible

This leads to the buggy UI seen in the bug report.

## Solutions

<details>

<summary>Solution 1 (dead end)</summary>

```csharp
public void InvalidateMeasure()
{
    if (!IsMeasureValid || _measuring || _arranging)
        return;

    IsMeasureValid = false;
    UserInterfaceManagerInternal.QueueMeasureUpdate(this);
    InvalidateArrange();
}
```

**Upside**: Solves the immediate problem.

**Downside**: With this solution, in the ghost list window, the scrollbar is always drawn on top of EntryContainer until you resize the window. I think it's because EntryContainer doesn't get a chance to remeasure/rearrange. It's a pretty subtle bug.

</details>

<details>

<summary>Solution 2 (dead end)</summary>

```csharp
public void InvalidateMeasure()
{
    if (!IsMeasureValid || _measuring)
        return;

    IsMeasureValid = false;
    UserInterfaceManagerInternal.QueueMeasureUpdate(this);

    if (IsArrangeValid)
    {
        IsArrangeValid = false;
        UserInterfaceManagerInternal.QueueArrangeUpdate(this);
    }
}
```
Ensure IsArrangeValid is always false when IsMeasureValid is false.

**Upside**: It works pretty well for the ghost list menu

**Downside**: You can get an infinite loop if an Arrange() implementation calls InvalidateMeasure() on `this` either directly or indirectly. It would keep adding itself to the arrange queue over and over. Didn't happen during my testing but hypothetically it could.

</details>

### Solution 3
Call `InvalidateArrange()` in `FrameUpdate()` so that each Control that is measured in a frame will also be rearranged in the same frame.

**Upside**: Works well.

**Downside**: A Control could keep updating itself every frame over and over if an Arrange() implementation calls InvalidateMeasure() on `this` either directly or indirectly. This is limited to one update per frame, so unlike solution 2 this would likely not be something you would notice in practice.

</details>