### PR TITLE
Modular Resources

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -13,6 +13,7 @@ using Robust.Client.Utility;
 using Robust.Shared;
 using Robust.Shared.Animations;
 using Robust.Shared.ComponentTrees;
+using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Graphics.RSI;
 using Robust.Shared.IoC;
@@ -253,7 +254,7 @@ namespace Robust.Client.GameObjects
             IoCManager.InjectDependencies(this);
             if (!string.IsNullOrWhiteSpace(rsi))
             {
-                var rsiPath = new ResPath(rsi).IsRooted ? new ResPath(rsi) : TextureRoot / rsi;
+                var rsiPath = PathHelpers.ApparentPath(rsi, TextureRoot.ToString());
                 if (resourceCache.TryGetResource(rsiPath, out RSIResource? resource))
                     _baseRsi = resource.RSI;
                 else
@@ -500,9 +501,7 @@ namespace Robust.Client.GameObjects
 
             if (!string.IsNullOrWhiteSpace(layerDatum.RsiPath))
             {
-                var rawPath = new ResPath(layerDatum.RsiPath);
-                var path = rawPath.IsRooted ? rawPath : TextureRoot / layerDatum.RsiPath;
-
+                var path = PathHelpers.ApparentPath(layerDatum.RsiPath, TextureRoot.ToString());
                 if (resourceCache.TryGetResource(path, out RSIResource? resource))
                 {
                     layer.RSI = resource.RSI;
@@ -552,8 +551,7 @@ namespace Robust.Client.GameObjects
                 }
                 else
                 {
-                    var rawTexPath = new ResPath(layerDatum.TexturePath);
-                    var texPath = rawTexPath.IsRooted ? rawTexPath : TextureRoot / layerDatum.TexturePath;
+                    var texPath = PathHelpers.ApparentPath(layerDatum.TexturePath, TextureRoot.ToString());
                     layer.Texture = resourceCache.GetResource<TextureResource>(texPath);
                 }
             }

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -253,7 +253,7 @@ namespace Robust.Client.GameObjects
             IoCManager.InjectDependencies(this);
             if (!string.IsNullOrWhiteSpace(rsi))
             {
-                var rsiPath = TextureRoot / rsi;
+                var rsiPath = new ResPath(rsi).IsRooted ? new ResPath(rsi) : TextureRoot / rsi;
                 if (resourceCache.TryGetResource(rsiPath, out RSIResource? resource))
                     _baseRsi = resource.RSI;
                 else
@@ -500,7 +500,8 @@ namespace Robust.Client.GameObjects
 
             if (!string.IsNullOrWhiteSpace(layerDatum.RsiPath))
             {
-                var path = TextureRoot / layerDatum.RsiPath;
+                var rawPath = new ResPath(layerDatum.RsiPath);
+                var path = rawPath.IsRooted ? rawPath : TextureRoot / layerDatum.RsiPath;
 
                 if (resourceCache.TryGetResource(path, out RSIResource? resource))
                 {
@@ -551,8 +552,9 @@ namespace Robust.Client.GameObjects
                 }
                 else
                 {
-                    layer.Texture =
-                        resourceCache.GetResource<TextureResource>(TextureRoot / layerDatum.TexturePath);
+                    var rawTexPath = new ResPath(layerDatum.TexturePath);
+                    var texPath = rawTexPath.IsRooted ? rawTexPath : TextureRoot / layerDatum.TexturePath;
+                    layer.Texture = resourceCache.GetResource<TextureResource>(texPath);
                 }
             }
 

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Helpers.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Helpers.cs
@@ -171,9 +171,10 @@ public sealed partial class SpriteSystem
     [Pure]
     public RSI.State GetState(SpriteSpecifier.Rsi rsiSpecifier)
     {
-        if (_resourceCache.TryGetResource<RSIResource>(
-                TextureRoot / rsiSpecifier.RsiPath,
-                out var theRsi) &&
+        var path = rsiSpecifier.RsiPath;
+        var actualPath = path.IsRooted ? path : TextureRoot / path;
+
+        if (_resourceCache.TryGetResource<RSIResource>(actualPath, out var theRsi) &&
             theRsi.RSI.TryGetState(rsiSpecifier.RsiState, out var state))
         {
             return state;
@@ -185,10 +186,14 @@ public sealed partial class SpriteSystem
 
     public Texture GetTexture(SpriteSpecifier.Texture texSpecifier)
     {
+        var path = texSpecifier.TexturePath;
+        var actualPath = path.IsRooted ? path : TextureRoot / path;
+
         return _resourceCache
-            .GetResource<TextureResource>(TextureRoot / texSpecifier.TexturePath)
+            .GetResource<TextureResource>(actualPath)
             .Texture;
     }
+
 
     private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)
     {

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Helpers.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Helpers.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using JetBrains.Annotations;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
+using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
@@ -171,10 +172,8 @@ public sealed partial class SpriteSystem
     [Pure]
     public RSI.State GetState(SpriteSpecifier.Rsi rsiSpecifier)
     {
-        var path = rsiSpecifier.RsiPath;
-        var actualPath = path.IsRooted ? path : TextureRoot / path;
-
-        if (_resourceCache.TryGetResource<RSIResource>(actualPath, out var theRsi) &&
+        var path = PathHelpers.ApparentPath(rsiSpecifier.RsiPath, TextureRoot);
+        if (_resourceCache.TryGetResource<RSIResource>(path, out var theRsi) &&
             theRsi.RSI.TryGetState(rsiSpecifier.RsiState, out var state))
         {
             return state;
@@ -186,11 +185,9 @@ public sealed partial class SpriteSystem
 
     public Texture GetTexture(SpriteSpecifier.Texture texSpecifier)
     {
-        var path = texSpecifier.TexturePath;
-        var actualPath = path.IsRooted ? path : TextureRoot / path;
-
+        var path = PathHelpers.ApparentPath(texSpecifier.TexturePath, TextureRoot);
         return _resourceCache
-            .GetResource<TextureResource>(actualPath)
+            .GetResource<TextureResource>(path)
             .Texture;
     }
 

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Layer.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Layer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
+using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Utility;
 using static Robust.Client.GameObjects.SpriteComponent;
@@ -190,8 +191,8 @@ public sealed partial class SpriteSystem
         if (!_query.Resolve(sprite.Owner, ref sprite.Comp))
             return -1;
 
-        var actualPath = path.IsRooted ? path : TextureRoot / path;
-        if (!_resourceCache.TryGetResource<RSIResource>(actualPath, out var res))
+        var rsiPath = PathHelpers.ApparentPath(path, TextureRoot);
+        if (!_resourceCache.TryGetResource<RSIResource>(rsiPath, out var res))
             Log.Error($"Unable to load RSI '{path}'. Trace:\n{Environment.StackTrace}");
 
         if (path.Extension != "rsi")
@@ -202,8 +203,8 @@ public sealed partial class SpriteSystem
 
     public int AddTextureLayer(Entity<SpriteComponent?> sprite, ResPath path, int? index = null)
     {
-        var actualPath = path.IsRooted ? path : TextureRoot / path;
-        if (_resourceCache.TryGetResource<TextureResource>(actualPath, out var texture))
+        var texPath = PathHelpers.ApparentPath(path, TextureRoot);
+        if (_resourceCache.TryGetResource<TextureResource>(texPath, out var texture))
             return AddTextureLayer(sprite, texture?.Texture, index);
 
         if (path.Extension == "rsi")

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Layer.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Layer.cs
@@ -190,7 +190,8 @@ public sealed partial class SpriteSystem
         if (!_query.Resolve(sprite.Owner, ref sprite.Comp))
             return -1;
 
-        if (!_resourceCache.TryGetResource<RSIResource>(TextureRoot / path, out var res))
+        var actualPath = path.IsRooted ? path : TextureRoot / path;
+        if (!_resourceCache.TryGetResource<RSIResource>(actualPath, out var res))
             Log.Error($"Unable to load RSI '{path}'. Trace:\n{Environment.StackTrace}");
 
         if (path.Extension != "rsi")
@@ -201,7 +202,8 @@ public sealed partial class SpriteSystem
 
     public int AddTextureLayer(Entity<SpriteComponent?> sprite, ResPath path, int? index = null)
     {
-        if (_resourceCache.TryGetResource<TextureResource>(TextureRoot / path, out var texture))
+        var actualPath = path.IsRooted ? path : TextureRoot / path;
+        if (_resourceCache.TryGetResource<TextureResource>(actualPath, out var texture))
             return AddTextureLayer(sprite, texture?.Texture, index);
 
         if (path.Extension == "rsi")

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.LayerSetters.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.LayerSetters.cs
@@ -2,6 +2,7 @@ using System;
 using System.Numerics;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
+using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Maths;
 using Robust.Shared.Utility;
@@ -131,7 +132,7 @@ public sealed partial class SpriteSystem
 
     private void LayerSetTexture(Layer layer, ResPath path)
     {
-        var actualPath = path.IsRooted ? path : TextureRoot / path;
+        var actualPath = PathHelpers.ApparentPath(path, TextureRoot);
         if (!_resourceCache.TryGetResource<TextureResource>(actualPath, out var texture))
         {
             if (path.Extension == "rsi")
@@ -229,8 +230,8 @@ public sealed partial class SpriteSystem
 
     public void LayerSetRsi(Layer layer, ResPath rsi, StateId? state = null)
     {
-        var actualPath = rsi.IsRooted ? rsi : TextureRoot / rsi;
-        if (!_resourceCache.TryGetResource<RSIResource>(actualPath, out var res))
+        var rsiPath = PathHelpers.ApparentPath(rsi, TextureRoot);
+        if (!_resourceCache.TryGetResource<RSIResource>(rsiPath, out var res))
             Log.Error($"Unable to load RSI '{rsi}' for entity {ToPrettyString(layer.Owner)}. Trace:\n{Environment.StackTrace}");
 
         LayerSetRsi(layer, res?.RSI, state);

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.LayerSetters.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.LayerSetters.cs
@@ -131,7 +131,8 @@ public sealed partial class SpriteSystem
 
     private void LayerSetTexture(Layer layer, ResPath path)
     {
-        if (!_resourceCache.TryGetResource<TextureResource>(TextureRoot / path, out var texture))
+        var actualPath = path.IsRooted ? path : TextureRoot / path;
+        if (!_resourceCache.TryGetResource<TextureResource>(actualPath, out var texture))
         {
             if (path.Extension == "rsi")
                 Log.Error($"Expected texture but got rsi '{path}', did you mean 'sprite:' instead of 'texture:'?");
@@ -228,7 +229,8 @@ public sealed partial class SpriteSystem
 
     public void LayerSetRsi(Layer layer, ResPath rsi, StateId? state = null)
     {
-        if (!_resourceCache.TryGetResource<RSIResource>(TextureRoot / rsi, out var res))
+        var actualPath = rsi.IsRooted ? rsi : TextureRoot / rsi;
+        if (!_resourceCache.TryGetResource<RSIResource>(actualPath, out var res))
             Log.Error($"Unable to load RSI '{rsi}' for entity {ToPrettyString(layer.Owner)}. Trace:\n{Environment.StackTrace}");
 
         LayerSetRsi(layer, res?.RSI, state);

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
@@ -9,6 +9,7 @@ using Robust.Client.ResourceManagement;
 using Robust.Client.Utility;
 using Robust.Shared;
 using Robust.Shared.Configuration;
+using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Graphics.RSI;
 using Robust.Shared.IoC;
@@ -187,9 +188,8 @@ namespace Robust.Client.GameObjects
             switch (spriteSpec)
             {
                 case SpriteSpecifier.Rsi rsi:
-                    var path = rsi.RsiPath;
-                    var actualPath = path.IsRooted ? path : TextureRoot / path;
-                    var rsiActual = _resourceCache.GetResource<RSIResource>(actualPath).RSI;
+                    var path = PathHelpers.ApparentPath(rsi.RsiPath, TextureRoot);
+                    var rsiActual = _resourceCache.GetResource<RSIResource>(path).RSI;
                     rsiActual.TryGetState(rsi.RsiState, out var state);
                     var frames = state!.GetFrames(RsiDirection.South);
                     var delays = state.GetDelays();

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
@@ -187,7 +187,9 @@ namespace Robust.Client.GameObjects
             switch (spriteSpec)
             {
                 case SpriteSpecifier.Rsi rsi:
-                    var rsiActual = _resourceCache.GetResource<RSIResource>(rsi.RsiPath).RSI;
+                    var path = rsi.RsiPath;
+                    var actualPath = path.IsRooted ? path : TextureRoot / path;
+                    var rsiActual = _resourceCache.GetResource<RSIResource>(actualPath).RSI;
                     rsiActual.TryGetState(rsi.RsiState, out var state);
                     var frames = state!.GetFrames(RsiDirection.South);
                     var delays = state.GetDelays();

--- a/Robust.Client/Graphics/Texture.cs
+++ b/Robust.Client/Graphics/Texture.cs
@@ -84,7 +84,7 @@ public abstract class Texture : IRsiStateLike
     /// <param name="name">The "name" of this texture. This can be referred to later to aid debugging.</param>
     /// <param name="loadParameters">
     ///     Parameters that influence the loading of textures.
-    ///     Defaults to <see cref="Robust.Client.Graphics.TextureLoadParameters.Default"/> if <c>null</c>.
+    ///     Defaults to <see cref="TextureLoadParameters.Default"/> if <c>null</c>.
     /// </param>
     /// <typeparam name="T">The type of pixels of the image. At the moment, images must be <see cref="Rgba32"/>.</typeparam>
     public static Texture LoadFromImage<T>(Image<T> image, string? name = null,
@@ -101,7 +101,7 @@ public abstract class Texture : IRsiStateLike
     /// <param name="name">The "name" of this texture. This can be referred to later to aid debugging.</param>
     /// <param name="loadParameters">
     ///     Parameters that influence the loading of textures.
-    ///     Defaults to <see cref="Robust.Client.Graphics.TextureLoadParameters.Default"/> if <c>null</c>.
+    ///     Defaults to <see cref="TextureLoadParameters.Default"/> if <c>null</c>.
     /// </param>
     public static Texture LoadFromPNGStream(Stream stream, string? name = null,
         TextureLoadParameters? loadParameters = null)

--- a/Robust.Client/Prototypes/ClientPrototypeManager.cs
+++ b/Robust.Client/Prototypes/ClientPrototypeManager.cs
@@ -35,15 +35,7 @@ namespace Robust.Client.Prototypes
         {
             LoadDirectory(new("/EnginePrototypes/"), changed: changed);
             LoadDirectory(_controller.Options.PrototypeDirectory, changed: changed);
-            var manifest = ResourceManifestData.LoadResourceManifest(Resources);
-            if (manifest.ModularResources != null)
-            {
-                foreach (var path in manifest.ModularResources.Keys)
-                {
-                    LoadDirectory(new ResPath($"/{path}/Prototypes/"), changed: changed);
-                }
-            }
-
+            LoadModularPrototypes(_controller.Options.PrototypeDirectory, changed);
             ResolveResults();
         }
 

--- a/Robust.Client/Prototypes/ClientPrototypeManager.cs
+++ b/Robust.Client/Prototypes/ClientPrototypeManager.cs
@@ -2,11 +2,13 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using Robust.Client.Timing;
+using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
 using Robust.Shared.Network;
 using Robust.Shared.Network.Messages;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+using TerraFX.Interop.Windows;
 
 namespace Robust.Client.Prototypes
 {
@@ -33,6 +35,15 @@ namespace Robust.Client.Prototypes
         {
             LoadDirectory(new("/EnginePrototypes/"), changed: changed);
             LoadDirectory(_controller.Options.PrototypeDirectory, changed: changed);
+            var manifest = ResourceManifestData.LoadResourceManifest(Resources);
+            if (manifest.ModularResources != null)
+            {
+                foreach (var mod in manifest.ModularResources)
+                {
+                    LoadDirectory(new ResPath($"/{mod}/Prototypes/"), changed: changed);
+                }
+            }
+
             ResolveResults();
         }
 

--- a/Robust.Client/Prototypes/ClientPrototypeManager.cs
+++ b/Robust.Client/Prototypes/ClientPrototypeManager.cs
@@ -38,9 +38,9 @@ namespace Robust.Client.Prototypes
             var manifest = ResourceManifestData.LoadResourceManifest(Resources);
             if (manifest.ModularResources != null)
             {
-                foreach (var mod in manifest.ModularResources)
+                foreach (var path in manifest.ModularResources.Keys)
                 {
-                    LoadDirectory(new ResPath($"/{mod}/Prototypes/"), changed: changed);
+                    LoadDirectory(new ResPath($"/{path}/Prototypes/"), changed: changed);
                 }
             }
 

--- a/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
+++ b/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
@@ -30,18 +30,6 @@ namespace Robust.Client.ResourceManagement
         [field: Dependency] public IFontManager FontManager { get; } = default!;
         [Dependency] private readonly ILogManager _logManager = default!;
         [Dependency] private readonly IConfigurationManager _configurationManager = default!;
-        private IEnumerable<ResPath> GetTextureSearchPaths()
-        {
-            yield return new ResPath("/Textures/");
-
-            var manifest = ResourceManifestData.LoadResourceManifest(_manager);
-            if (manifest.ModularResources == null) yield break;
-            foreach (var path in manifest.ModularResources.Keys)
-            {
-
-                yield return new ResPath(path).ToRootedPath() / "Textures";
-            }
-        }
 
         public void PreloadTextures()
         {
@@ -407,6 +395,19 @@ namespace Robust.Client.ResourceManagement
         private static bool ShouldMetaAtlas(RSIResource.LoadStepData rsi)
         {
             return rsi.MetaAtlas && rsi.LoadParameters == TextureLoadParameters.Default;
+        }
+
+        private IEnumerable<ResPath> GetTextureSearchPaths()
+        {
+            yield return new ResPath("/Textures/");
+
+            var manifest = ResourceManifestData.LoadResourceManifest(_manager);
+            if (manifest.ModularResources == null) yield break;
+            foreach (var path in manifest.ModularResources.Keys)
+            {
+
+                yield return new ResPath(path).ToRootedPath() / "Textures";
+            }
         }
     }
 

--- a/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
+++ b/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
@@ -30,16 +30,16 @@ namespace Robust.Client.ResourceManagement
         [field: Dependency] public IFontManager FontManager { get; } = default!;
         [Dependency] private readonly ILogManager _logManager = default!;
         [Dependency] private readonly IConfigurationManager _configurationManager = default!;
-
         private IEnumerable<ResPath> GetTextureSearchPaths()
         {
             yield return new ResPath("/Textures/");
 
             var manifest = ResourceManifestData.LoadResourceManifest(_manager);
             if (manifest.ModularResources == null) yield break;
-            foreach (var mod in manifest.ModularResources)
+            foreach (var path in manifest.ModularResources.Keys)
             {
-                yield return new ResPath($"/{mod}/Textures/");
+
+                yield return new ResPath(path).ToRootedPath() / "Textures";
             }
         }
 

--- a/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
+++ b/Robust.Client/ResourceManagement/ResourceCache.Preload.cs
@@ -151,19 +151,15 @@ namespace Robust.Client.ResourceManagement
             var sw = Stopwatch.StartNew();
             var resList = GetTypeData<RSIResource>().Resources;
 
-            /*            var rsiList = GetTextureSearchPaths()
-                .SelectMany(path => _manager.ContentFindFiles(path))
-                .Where(p => p.ToString().EndsWith(".rsi/meta.json"))
-                .Select(c => c.Directory)
-                .Where(p => !resList.ContainsKey(p))
-                .Select(p => new RSIResource.LoadStepData {Path = p})
-                .ToArray();*/
+            var searchPaths = GetTextureSearchPaths().ToArray();
 
-            var foundRsiList = _manager.ContentFindFiles("/Textures/")
+            var foundRsiList = searchPaths
+                .SelectMany(path => _manager.ContentFindFiles(path))
                 .Where(p => p.ToString().EndsWith(".rsi/meta.json"))
                 .Select(c => c.Directory);
 
-            var foundRsicList = _manager.ContentFindFiles("/Textures/")
+            var foundRsicList = searchPaths
+                .SelectMany(path => _manager.ContentFindFiles(path))
                 .Where(p => p.Extension == "rsic")
                 .Select(c => c.WithExtension("rsi"));
 

--- a/Robust.Client/Serialization/ClientSpriteSpecifierSerializer.cs
+++ b/Robust.Client/Serialization/ClientSpriteSpecifierSerializer.cs
@@ -1,4 +1,5 @@
 using Robust.Client.ResourceManagement;
+using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Attributes;
@@ -28,9 +29,8 @@ public sealed class ClientSpriteSpecifierSerializer : SpriteSpecifierSerializer
             return new ErrorNode(node, "Sprite specifier has missing/invalid state node");
         }
 
-        var rawPath = new ResPath(valuePathNode.Value);
         var res = dependencies.Resolve<IResourceCache>();
-        var rsiPath = rawPath.IsRooted ? rawPath : TextureRoot / rawPath;
+        var rsiPath = PathHelpers.ApparentPath(new ResPath(valuePathNode.Value), TextureRoot);
         if (!res.TryGetResource(rsiPath, out RSIResource? resource))
         {
             return new ErrorNode(node, "Failed to load RSI");

--- a/Robust.Client/Serialization/ClientSpriteSpecifierSerializer.cs
+++ b/Robust.Client/Serialization/ClientSpriteSpecifierSerializer.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Implementations;
+using Robust.Shared.Utility;
 
 namespace Robust.Client.Serialization;
 
@@ -27,8 +28,9 @@ public sealed class ClientSpriteSpecifierSerializer : SpriteSpecifierSerializer
             return new ErrorNode(node, "Sprite specifier has missing/invalid state node");
         }
 
+        var rawPath = new ResPath(valuePathNode.Value);
         var res = dependencies.Resolve<IResourceCache>();
-        var rsiPath = TextureRoot / valuePathNode.Value;
+        var rsiPath = rawPath.IsRooted ? rawPath : TextureRoot / rawPath;
         if (!res.TryGetResource(rsiPath, out RSIResource? resource))
         {
             return new ErrorNode(node, "Failed to load RSI");

--- a/Robust.Client/Utility/ReloadManager.cs
+++ b/Robust.Client/Utility/ReloadManager.cs
@@ -139,11 +139,10 @@ internal sealed class ReloadManager : IReloadManager
                         // Different root (i.e., "C:/" and "D:/")
                         continue;
                     }
-                    if (relPath.Contains(".."))
-                        continue;
+
                     var file = ResPath.FromRelativeSystemPath(relPath).ToRootedPath();
-                    if (!file.CanonPath.Contains("/../"))
-                        _reloadQueue.Add(file);
+                    if (file.CanonPath.Contains("/../"))
+                        continue;
                     var path = ResolveModularPath(file, rootIter);
                     _reloadQueue.Add(path);
                 }

--- a/Robust.Client/Utility/ReloadManager.cs
+++ b/Robust.Client/Utility/ReloadManager.cs
@@ -31,7 +31,7 @@ internal sealed class ReloadManager : IReloadManager
     private CancellationTokenSource _reloadToken = new();
     private readonly HashSet<ResPath> _reloadQueue = new();
     private List<FileSystemWatcher> _watchers = new(); // this list is never used but needed to prevent them from being garbage collected
-    private ResourceManifestData _manifest = ResourceManifestData.Default; // cache it
+    private ResourceManifestData _manifest = ResourceManifestData.Default;
 
     public event Action<ResPath>? OnChanged;
 

--- a/Robust.Client/Utility/ReloadManager.cs
+++ b/Robust.Client/Utility/ReloadManager.cs
@@ -78,11 +78,6 @@ internal sealed class ReloadManager : IReloadManager
         Register(directory.ToRelativeSystemPath(), filter);
     }
 
-    private void ResolveDirectory()
-    {
-
-    }
-
     public void Register(string directory, string filter)
     {
         if (!_cfg.GetCVar(CVars.ResPrototypeReloadWatch))
@@ -163,7 +158,7 @@ internal sealed class ReloadManager : IReloadManager
         var rootName = new DirectoryInfo(rootIter).Name;
 
         if (_manifest.ModularResources == null)
-            return finalPath;
+            return relative;
 
         foreach (var (vfsPath, diskPath) in _manifest.ModularResources)
         {

--- a/Robust.Client/Utility/ReloadManager.cs
+++ b/Robust.Client/Utility/ReloadManager.cs
@@ -12,6 +12,7 @@ using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Utility;
+using TerraFX.Interop.Windows;
 using Timer = Robust.Shared.Timing.Timer;
 
 namespace Robust.Client.Utility;
@@ -143,24 +144,23 @@ internal sealed class ReloadManager : IReloadManager
                         // Different root (i.e., "C:/" and "D:/")
                         continue;
                     }
-
+                    if (relPath.Contains(".."))
+                        continue;
                     var file = ResPath.FromRelativeSystemPath(relPath).ToRootedPath();
                     if (!file.CanonPath.Contains("/../"))
                         _reloadQueue.Add(file);
-                    /*
-                    var path = ResolvePath(relative.Value, rootIter);
+                    var path = ResolveModularPath(file, rootIter);
                     _reloadQueue.Add(path);
-                    */
                 }
             });
         }
 #endif
     }
 
-    private ResPath ResolvePath(ResPath relative, ResPath rootIter)
+    private ResPath ResolveModularPath(ResPath relative, string rootIter)
     {
         var finalPath = relative;
-        var rootName = new DirectoryInfo(rootIter.ToString()).Name;
+        var rootName = new DirectoryInfo(rootIter).Name;
 
         if (_manifest.ModularResources == null)
             return finalPath;

--- a/Robust.Client/Utility/SpriteSpecifierExt.cs
+++ b/Robust.Client/Utility/SpriteSpecifierExt.cs
@@ -20,15 +20,19 @@ namespace Robust.Client.Utility
         [Obsolete("Use SpriteSystem.GetTexture() instead")]
         public static Texture GetTexture(this SpriteSpecifier.Texture texSpecifier, IResourceCache cache)
         {
+            var path = texSpecifier.TexturePath;
+            var actualPath = path.IsRooted ? path : SpriteSpecifierSerializer.TextureRoot / path;
             return cache
-                .GetResource<TextureResource>(SpriteSpecifierSerializer.TextureRoot / texSpecifier.TexturePath)
+                .GetResource<TextureResource>(actualPath)
                 .Texture;
         }
 
         [Obsolete("Use SpriteSystem.GetState() instead")]
         public static RSI.State GetState(this SpriteSpecifier.Rsi rsiSpecifier, IResourceCache cache)
         {
-            if (!cache.TryGetResource<RSIResource>(SpriteSpecifierSerializer.TextureRoot / rsiSpecifier.RsiPath, out var theRsi))
+            var path = rsiSpecifier.RsiPath;
+            var actualPath = path.IsRooted ? path : SpriteSpecifierSerializer.TextureRoot / path;
+            if (!cache.TryGetResource<RSIResource>(actualPath, out var theRsi))
             {
                 var sys = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SpriteSystem>();
                 Logger.Error("SpriteSpecifier failed to load RSI {0}", rsiSpecifier.RsiPath);

--- a/Robust.Client/Utility/SpriteSpecifierExt.cs
+++ b/Robust.Client/Utility/SpriteSpecifierExt.cs
@@ -2,6 +2,7 @@ using System;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
+using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Graphics;
 using Robust.Shared.IoC;
@@ -20,19 +21,17 @@ namespace Robust.Client.Utility
         [Obsolete("Use SpriteSystem.GetTexture() instead")]
         public static Texture GetTexture(this SpriteSpecifier.Texture texSpecifier, IResourceCache cache)
         {
-            var path = texSpecifier.TexturePath;
-            var actualPath = path.IsRooted ? path : SpriteSpecifierSerializer.TextureRoot / path;
+            var texPath = PathHelpers.ApparentPath(texSpecifier.TexturePath, SpriteSpecifierSerializer.TextureRoot);
             return cache
-                .GetResource<TextureResource>(actualPath)
+                .GetResource<TextureResource>(texPath)
                 .Texture;
         }
 
         [Obsolete("Use SpriteSystem.GetState() instead")]
         public static RSI.State GetState(this SpriteSpecifier.Rsi rsiSpecifier, IResourceCache cache)
         {
-            var path = rsiSpecifier.RsiPath;
-            var actualPath = path.IsRooted ? path : SpriteSpecifierSerializer.TextureRoot / path;
-            if (!cache.TryGetResource<RSIResource>(actualPath, out var theRsi))
+            var rsiPath = PathHelpers.ApparentPath(rsiSpecifier.RsiPath, SpriteSpecifierSerializer.TextureRoot);
+            if (!cache.TryGetResource<RSIResource>(rsiPath, out var theRsi))
             {
                 var sys = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SpriteSystem>();
                 Logger.Error("SpriteSpecifier failed to load RSI {0}", rsiSpecifier.RsiPath);

--- a/Robust.Packaging/RobustClientPackaging.cs
+++ b/Robust.Packaging/RobustClientPackaging.cs
@@ -1,4 +1,5 @@
 ﻿using Robust.Packaging.AssetProcessing;
+using Robust.Shared.ContentPack;
 
 namespace Robust.Packaging;
 
@@ -22,5 +23,29 @@ public sealed class RobustClientPackaging
         var ignoreSet = ClientIgnoredResources.Union(RobustSharedPackaging.SharedIgnoredResources).ToHashSet();
 
         await RobustSharedPackaging.DoResourceCopy(Path.Combine(contentDir, "Resources"), pass, ignoreSet, cancel: cancel);
+
+        var manifestPath = Path.Combine(contentDir, "Resources", "manifest.yml");
+        var manifest = ResourceManifestData.LoadFromFile(manifestPath); // load from disk no VFS
+
+        if (manifest.ModularResources != null)
+        {
+            foreach (var (vfsPath,diskName) in manifest.ModularResources)
+            {
+                var modPath = Path.Combine(contentDir, diskName);
+                if (!Directory.Exists(modPath))
+                    continue;
+                var files = Directory.EnumerateFiles(modPath, "*", SearchOption.AllDirectories);
+                foreach (var file in files)
+                {
+                    var filename = Path.GetFileName(file);
+                    if (ignoreSet.Contains(filename)) continue;
+                    var relative = Path.GetRelativePath(modPath, file);
+                    var zipRoot = vfsPath.TrimStart('/');
+                    var targetPath = Path.Combine(zipRoot, relative).Replace('\\', '/');
+                    await using var stream = File.OpenRead(file);
+                    pass.InjectFileFromDisk(targetPath, file);
+                }
+            }
+        }
     }
 }

--- a/Robust.Packaging/RobustClientPackaging.cs
+++ b/Robust.Packaging/RobustClientPackaging.cs
@@ -35,29 +35,6 @@ public sealed class RobustClientPackaging
             .ToHashSet();
 
         await RobustSharedPackaging.DoResourceCopy(Path.Combine(contentDir, "Resources"), pass, ignoreSet, cancel: cancel);
-
-        var manifestPath = Path.Combine(contentDir, "Resources", "manifest.yml");
-        var manifest = ResourceManifestData.LoadFromFile(manifestPath); // load from disk no VFS
-
-        if (manifest.ModularResources != null)
-        {
-            foreach (var (vfsPath,diskName) in manifest.ModularResources)
-            {
-                var modPath = Path.Combine(contentDir, diskName);
-                if (!Directory.Exists(modPath))
-                    continue;
-                var files = Directory.EnumerateFiles(modPath, "*", SearchOption.AllDirectories);
-                foreach (var file in files)
-                {
-                    var filename = Path.GetFileName(file);
-                    if (ignoreSet.Contains(filename)) continue;
-                    var relative = Path.GetRelativePath(modPath, file);
-                    var zipRoot = vfsPath.TrimStart('/');
-                    var targetPath = Path.Combine(zipRoot, relative).Replace('\\', '/');
-                    await using var stream = File.OpenRead(file);
-                    pass.InjectFileFromDisk(targetPath, file);
-                }
-            }
-        }
+        await RobustSharedPackaging.DoModularResourceCopy(contentDir, pass, ignoreSet);
     }
 }

--- a/Robust.Packaging/RobustServerPackaging.cs
+++ b/Robust.Packaging/RobustServerPackaging.cs
@@ -40,5 +40,7 @@ public sealed class RobustServerPackaging
             pass,
             ignoreSet,
             cancel: cancel);
+
+        await RobustSharedPackaging.DoModularResourceCopy(contentDir, pass, ignoreSet);
     }
 }

--- a/Robust.Server/Prototypes/ServerPrototypeManager.cs
+++ b/Robust.Server/Prototypes/ServerPrototypeManager.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Robust.Server.Console;
 using Robust.Server.Player;
+using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Network;
 using Robust.Shared.Network.Messages;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Robust.Server.Prototypes
 {
@@ -55,6 +57,14 @@ namespace Robust.Server.Prototypes
         {
             LoadDirectory(new("/EnginePrototypes/"), changed: changed);
             LoadDirectory(_server.Options.PrototypeDirectory, changed: changed);
+            var manifest = ResourceManifestData.LoadResourceManifest(Resources);
+            if (manifest.ModularResources != null)
+            {
+                foreach (var mod in manifest.ModularResources)
+                {
+                    LoadDirectory(new ResPath($"/{mod}/Prototypes/"), changed: changed);
+                }
+            }
             ResolveResults();
         }
     }

--- a/Robust.Server/Prototypes/ServerPrototypeManager.cs
+++ b/Robust.Server/Prototypes/ServerPrototypeManager.cs
@@ -60,9 +60,9 @@ namespace Robust.Server.Prototypes
             var manifest = ResourceManifestData.LoadResourceManifest(Resources);
             if (manifest.ModularResources != null)
             {
-                foreach (var mod in manifest.ModularResources)
+                foreach (var path in manifest.ModularResources.Keys)
                 {
-                    LoadDirectory(new ResPath($"/{mod}/Prototypes/"), changed: changed);
+                    LoadDirectory(new ResPath($"/{path}/Prototypes/"), changed: changed);
                 }
             }
             ResolveResults();

--- a/Robust.Server/Prototypes/ServerPrototypeManager.cs
+++ b/Robust.Server/Prototypes/ServerPrototypeManager.cs
@@ -57,14 +57,7 @@ namespace Robust.Server.Prototypes
         {
             LoadDirectory(new("/EnginePrototypes/"), changed: changed);
             LoadDirectory(_server.Options.PrototypeDirectory, changed: changed);
-            var manifest = ResourceManifestData.LoadResourceManifest(Resources);
-            if (manifest.ModularResources != null)
-            {
-                foreach (var path in manifest.ModularResources.Keys)
-                {
-                    LoadDirectory(new ResPath($"/{path}/Prototypes/"), changed: changed);
-                }
-            }
+            LoadModularPrototypes(_server.Options.PrototypeDirectory, changed);
             ResolveResults();
         }
     }

--- a/Robust.Server/Serialization/ServerSpriteSpecifierSerializer.cs
+++ b/Robust.Server/Serialization/ServerSpriteSpecifierSerializer.cs
@@ -31,9 +31,10 @@ public sealed class ServerSpriteSpecifierSerializer : SpriteSpecifierSerializer
         {
             return new ErrorNode(node, "Sprite specifier has missing/invalid state node");
         }
-
+        var rawPath = new ResPath(valuePathNode.Value);
+        var actualPath = rawPath.IsRooted ? rawPath : TextureRoot / rawPath;
         var path = serializationManager.ValidateNode<ResPath>(
-            new ValueDataNode($"{TextureRoot / valuePathNode.Value}"), context);
+            new ValueDataNode($"{actualPath}"), context);
 
         if (path is ErrorNode) return path;
 
@@ -43,7 +44,7 @@ public sealed class ServerSpriteSpecifierSerializer : SpriteSpecifierSerializer
         // meta.json
 
         var statePath = serializationManager.ValidateNode<ResPath>(
-            new ValueDataNode($"{TextureRoot / valuePathNode.Value / valueStateNode.Value}.png"),
+            new ValueDataNode($"{actualPath / valueStateNode.Value}.png"),
             context);
 
         if (statePath is ErrorNode) return statePath;

--- a/Robust.Server/Serialization/ServerSpriteSpecifierSerializer.cs
+++ b/Robust.Server/Serialization/ServerSpriteSpecifierSerializer.cs
@@ -1,3 +1,4 @@
+using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Attributes;
@@ -31,8 +32,7 @@ public sealed class ServerSpriteSpecifierSerializer : SpriteSpecifierSerializer
         {
             return new ErrorNode(node, "Sprite specifier has missing/invalid state node");
         }
-        var rawPath = new ResPath(valuePathNode.Value);
-        var actualPath = rawPath.IsRooted ? rawPath : TextureRoot / rawPath;
+        var actualPath = PathHelpers.ApparentPath(new ResPath(valuePathNode.Value), TextureRoot);
         var path = serializationManager.ValidateNode<ResPath>(
             new ValueDataNode($"{actualPath}"), context);
 

--- a/Robust.Shared/ContentPack/PathHelpers.cs
+++ b/Robust.Shared/ContentPack/PathHelpers.cs
@@ -2,66 +2,74 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
+using Robust.Shared.Utility;
 
-namespace Robust.Shared.ContentPack
+namespace Robust.Shared.ContentPack;
+
+/// <summary>
+///     Utility functions
+/// </summary>
+internal static class PathHelpers
 {
     /// <summary>
-    ///     Utility functions
+    ///     Get the full directory path that the executable is located in.
     /// </summary>
-    internal static class PathHelpers
+    internal static string GetExecutableDirectory()
     {
-        /// <summary>
-        ///     Get the full directory path that the executable is located in.
-        /// </summary>
-        internal static string GetExecutableDirectory()
+        // TODO: remove this shitty hack, either through making it less hardcoded into shared,
+        //   or by making our file structure less spaghetti somehow.
+        var assembly = typeof(PathHelpers).Assembly;
+        var location = assembly.Location;
+        if (location == string.Empty)
         {
-            // TODO: remove this shitty hack, either through making it less hardcoded into shared,
-            //   or by making our file structure less spaghetti somehow.
-            var assembly = typeof(PathHelpers).Assembly;
-            var location = assembly.Location;
-            if (location == string.Empty)
-            {
-                // See https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.location?view=net-5.0#remarks
-                // This doesn't apply to us really because we don't do that kind of publishing, but whatever.
-                throw new InvalidOperationException("Cannot find path of executable.");
-            }
-            return Path.GetDirectoryName(location)!;
+            // See https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.location?view=net-5.0#remarks
+            // This doesn't apply to us really because we don't do that kind of publishing, but whatever.
+            throw new InvalidOperationException("Cannot find path of executable.");
         }
 
-        /// <summary>
-        ///     Turns a relative path from the executable directory into a full path.
-        /// </summary>
-        public static string ExecutableRelativeFile(string file)
-        {
-            return Path.GetFullPath(Path.Combine(GetExecutableDirectory(), file));
-        }
-
-        /// <summary>
-        ///     Recursively gets all files in a directory and all sub directories.
-        /// </summary>
-        /// <param name="path">Directory to start in.</param>
-        /// <returns>Enumerable of all file paths in that directory and sub directories.</returns>
-        public static IEnumerable<string> GetFiles(string path)
-        {
-            return Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories);
-        }
-
-        public static bool IsFileInUse(IOException exception)
-        {
-            var errorCode = exception.HResult & 0xFFFF;
-            return errorCode switch
-            {
-                // TODO: verify works on non-win systems
-                32 => /* sharing not allowed */ true,
-                33 => /* file is locked */ true,
-                _ => false
-            };
-        }
-
-        // TODO: gaf
-        public static bool IsFileSystemCaseSensitive() =>
-            !OperatingSystem.IsWindows()
-            && !OperatingSystem.IsMacOS();
-
+        return Path.GetDirectoryName(location)!;
     }
+
+    /// <summary>
+    ///     Turns a relative path from the executable directory into a full path.
+    /// </summary>
+    public static string ExecutableRelativeFile(string file)
+    {
+        return Path.GetFullPath(Path.Combine(GetExecutableDirectory(), file));
+    }
+
+    /// <summary>
+    ///     Recursively gets all files in a directory and all sub directories.
+    /// </summary>
+    /// <param name="path">Directory to start in.</param>
+    /// <returns>Enumerable of all file paths in that directory and sub directories.</returns>
+    public static IEnumerable<string> GetFiles(string path)
+    {
+        return Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories);
+    }
+
+    public static bool IsFileInUse(IOException exception)
+    {
+        var errorCode = exception.HResult & 0xFFFF;
+        return errorCode switch
+        {
+            // TODO: verify works on non-win systems
+            32 => /* sharing not allowed */ true,
+            33 => /* file is locked */ true,
+            _ => false
+        };
+    }
+
+    // TODO: gaf
+    public static bool IsFileSystemCaseSensitive() =>
+        !OperatingSystem.IsWindows()
+        && !OperatingSystem.IsMacOS();
+
+    /// <summary>
+    ///     Resolves a path for a given root path.
+    ///     If the path is absolute (starts with /), it returns it as-is (ex: /ModResources/...).
+    ///     If the path is relative, it prepends /RootPathName/.
+    /// </summary>
+    public static ResPath ApparentPath(ResPath path, ResPath root) => path.IsRooted ? path : root / path;
+    public static ResPath ApparentPath(string path, string root) => ApparentPath(new ResPath(path), new ResPath(root));
 }

--- a/Robust.Shared/ContentPack/ResourceManifestData.cs
+++ b/Robust.Shared/ContentPack/ResourceManifestData.cs
@@ -88,7 +88,7 @@ public sealed record ResourceManifestData(
         var clientAssemblies = ReadStringArray(mapping, "clientAssemblies");
 
         // Use the new Dictionary reader
-        var modularResources = ReadResourceMods(mapping, "resourceMods");
+        var modularResources = ReadResourceMods(mapping, "modularResources");
 
         return new ResourceManifestData(
             modules,

--- a/Robust.Shared/ContentPack/ResourceManifestData.cs
+++ b/Robust.Shared/ContentPack/ResourceManifestData.cs
@@ -88,7 +88,7 @@ public sealed record ResourceManifestData(
         var clientAssemblies = ReadStringArray(mapping, "clientAssemblies");
 
         // Use the new Dictionary reader
-        var modularResources = ReadResourceMods(mapping, "modularResources");
+        var modularResources = ReadResourceMods(mapping, "resources");
 
         return new ResourceManifestData(
             modules,

--- a/Robust.Shared/ContentPack/ResourceManifestData.cs
+++ b/Robust.Shared/ContentPack/ResourceManifestData.cs
@@ -5,18 +5,19 @@ using YamlDotNet.RepresentationModel;
 
 namespace Robust.Shared.ContentPack;
 
-internal sealed record ResourceManifestData(
+public sealed record ResourceManifestData(
     string[] Modules,
     string? AssemblyPrefix,
     string? DefaultWindowTitle,
     string? WindowIconSet,
     string? SplashLogo,
     bool AutoConnect,
-    string[]? ClientAssemblies
+    string[]? ClientAssemblies,
+    string[]? ModularResources
 )
 {
     public static readonly ResourceManifestData Default =
-        new ResourceManifestData(Array.Empty<string>(), null, null, null, null, true, null);
+        new ([], null, null, null, null, true, null, null);
 
     public static ResourceManifestData LoadResourceManifest(IResourceManager res)
     {
@@ -63,6 +64,7 @@ internal sealed record ResourceManifestData(
             autoConnect = autoConnectNode.AsBool();
 
         var clientAssemblies = ReadStringArray(mapping, "clientAssemblies");
+        var modularResources = ReadStringArray(mapping, "resources");
 
         return new ResourceManifestData(
             modules,
@@ -71,7 +73,8 @@ internal sealed record ResourceManifestData(
             windowIconSet,
             splashLogo,
             autoConnect,
-            clientAssemblies
+            clientAssemblies,
+            modularResources
         );
 
         static string[]? ReadStringArray(YamlMappingNode mapping, string key)

--- a/Robust.Shared/ProgramShared.cs
+++ b/Robust.Shared/ProgramShared.cs
@@ -29,14 +29,10 @@ internal static class ProgramShared
 
 #if !FULL_RELEASE
     private static string FindContentRootDir(bool contentStart)
-    {
-        return PathOffset + (contentStart ? "../../" : "../../../");
-    }
+        => PathOffset + (contentStart ? "../../" : "../../../");
 
     private static string FindEngineRootDir(bool contentStart)
-    {
-        return PathOffset + (contentStart ? "../../RobustToolbox/" : "../../");
-    }
+        => PathOffset + (contentStart ? "../../RobustToolbox/" : "../../");
 #endif
 
     internal static void PrintRuntimeInfo(ISawmill sawmill)

--- a/Robust.Shared/ProgramShared.cs
+++ b/Robust.Shared/ProgramShared.cs
@@ -62,14 +62,15 @@ internal static class ProgramShared
         var manifest = ResourceManifestData.LoadResourceManifest(res);
         if (manifest.ModularResources != null)
         {
-            foreach (var (vfsPath,diskName) in manifest.ModularResources)
+            foreach (var (vfsPath, diskPath) in manifest.ModularResources)
             {
                 var virtualPath = new ResPath($"/{vfsPath}/");
+                var cleanDiskPath = diskPath.Trim('/', '\\');
 #if FULL_RELEASE
-                res.MountContentDirectory($@"{diskName}/", virtualPath);
+                res.MountContentDirectory($@"{diskPath}/", virtualPath);
 #else
                 var contentRootDir = FindContentRootDir(contentStart);
-                res.MountContentDirectory($@"{contentRootDir}{diskName}/", virtualPath);
+                res.MountContentDirectory($@"{contentRootDir}/{cleanDiskPath}/", virtualPath);
 #endif
             }
         }

--- a/Robust.Shared/ProgramShared.cs
+++ b/Robust.Shared/ProgramShared.cs
@@ -62,15 +62,14 @@ internal static class ProgramShared
         var manifest = ResourceManifestData.LoadResourceManifest(res);
         if (manifest.ModularResources != null)
         {
-            foreach (var mod in manifest.ModularResources)
+            foreach (var (vfsPath,diskName) in manifest.ModularResources)
             {
-                var virtualPath = new ResPath($"/{mod}/");
-
+                var virtualPath = new ResPath($"/{vfsPath}/");
 #if FULL_RELEASE
-                res.MountContentDirectory($@"{mod}/", virtualPath);
+                res.MountContentDirectory($@"{diskName}/", virtualPath);
 #else
                 var contentRootDir = FindContentRootDir(contentStart);
-                res.MountContentDirectory($@"{contentRootDir}{mod}/", virtualPath);
+                res.MountContentDirectory($@"{contentRootDir}{diskName}/", virtualPath);
 #endif
             }
         }

--- a/Robust.Shared/ProgramShared.cs
+++ b/Robust.Shared/ProgramShared.cs
@@ -63,6 +63,22 @@ internal static class ProgramShared
             res.MountContentDirectory($@"{contentRootDir}Resources/");
         }
 #endif
+        var manifest = ResourceManifestData.LoadResourceManifest(res);
+        if (manifest.ModularResources != null)
+        {
+            foreach (var mod in manifest.ModularResources)
+            {
+                var virtualPath = new ResPath($"/{mod}/");
+
+#if FULL_RELEASE
+                res.MountContentDirectory($@"{mod}/", virtualPath);
+#else
+                var contentRootDir = FindContentRootDir(contentStart);
+                res.MountContentDirectory($@"{contentRootDir}{mod}/", virtualPath);
+#endif
+            }
+        }
+
 
         if (options == null)
             return;

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -1273,6 +1273,16 @@ namespace Robust.Shared.Prototypes
 
             throw new ArgumentOutOfRangeException($"Unable to pick valid prototype for {typeof(T)}?");
         }
+
+        public void LoadModularPrototypes(ResPath protoDir, Dictionary<Type, HashSet<string>>? changed)
+        {
+            var manifest = ResourceManifestData.LoadResourceManifest(Resources);
+            if (manifest.ModularResources == null) return;
+            foreach (var path in manifest.ModularResources.Keys)
+            {
+                LoadDirectory(new ResPath($"/{path}{protoDir}"), changed: changed);
+            }
+        }
     }
 
     public sealed class InvalidPrototypeNameException : Exception

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -37,6 +37,7 @@ namespace Robust.Shared.Prototypes
         [Dependency] private readonly IComponentFactory _factory = default!;
         [Dependency] private readonly IEntityManager _entMan = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
+        private ResourceManifestData _manifest = ResourceManifestData.Default;
 
         private readonly Dictionary<string, Dictionary<string, MappingDataNode>> _prototypeDataCache = new();
         private EntityDiffContext _context = new();
@@ -65,6 +66,7 @@ namespace Robust.Shared.Prototypes
             _initialized = true;
             ReloadPrototypeKinds();
             PrototypesReloaded += OnReload;
+            _manifest = ResourceManifestData.LoadResourceManifest(Resources);
         }
 
         /// <inheritdoc />
@@ -1276,9 +1278,8 @@ namespace Robust.Shared.Prototypes
 
         public void LoadModularPrototypes(ResPath protoDir, Dictionary<Type, HashSet<string>>? changed)
         {
-            var manifest = ResourceManifestData.LoadResourceManifest(Resources);
-            if (manifest.ModularResources == null) return;
-            foreach (var path in manifest.ModularResources.Keys)
+            if (_manifest.ModularResources == null) return;
+            foreach (var path in _manifest.ModularResources.Keys)
             {
                 LoadDirectory(new ResPath($"/{path}{protoDir}"), changed: changed);
             }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/MapPathSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/MapPathSerializer.cs
@@ -1,0 +1,45 @@
+﻿using Robust.Shared.ContentPack;
+using Robust.Shared.IoC;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Serialization.TypeSerializers.Implementations;
+
+public sealed class MapPathSerializer : ITypeSerializer<ResPath, ValueDataNode>
+{
+    private static readonly ResPath MapRoot = new("/Maps");
+
+    public ValidationNode Validate(
+        ISerializationManager serializationManager,
+        ValueDataNode node,
+        IDependencyCollection dependencies,
+        ISerializationContext? context = null)
+    {
+        var path = PathHelpers.ApparentPath(new ResPath(node.Value), MapRoot);
+        var res = dependencies.Resolve<IResourceManager>();
+        if (res.ContentFileExists(path))
+            return new ValidatedValueNode(node);
+
+        return new ErrorNode(node, $"Map file not found: {path}");
+    }
+
+    public ResPath Read(
+        ISerializationManager serializationManager,
+        ValueDataNode node,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context = null,
+        ISerializationManager.InstantiationDelegate<ResPath>? instanceProvider = null)
+        => PathHelpers.ApparentPath(new ResPath(node.Value), MapRoot);
+
+    public DataNode Write(
+        ISerializationManager serializationManager,
+        ResPath value,
+        IDependencyCollection dependencies,
+        bool alwaysWrite = false, ISerializationContext? context = null)
+        => new ValueDataNode(value.ToString());
+}

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/ResPathSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/ResPathSerializer.cs
@@ -47,7 +47,6 @@ public sealed class ResPathSerializer : ITypeSerializer<ResPath, ValueDataNode>,
         }
     }
 
-
     public ResPath Read(ISerializationManager serializationManager, ValueDataNode node,
         IDependencyCollection dependencies,
         SerializationHookContext hookCtx, ISerializationContext? context = null,

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/ResPathSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/ResPathSerializer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using Robust.Shared.ContentPack;
-using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Attributes;
@@ -19,18 +18,12 @@ public sealed class ResPathSerializer : ITypeSerializer<ResPath, ValueDataNode>,
     public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
         IDependencyCollection dependencies, ISerializationContext? context = null)
     {
+        // 1. Normalize separators (fixes Windows backslashes)
         var path = ResPath.FromRelativeSystemPath(node.Value);
-
         if (path.Extension.Equals("rsi"))
         {
             path /= "meta.json";
         }
-
-        if (!path.IsRooted && !path.CanonPath.Split('/').First().Equals("Textures", StringComparison.InvariantCultureIgnoreCase))
-        {
-            path = SpriteSpecifierSerializer.TextureRoot / path;
-        }
-
         path = path.ToRootedPath();
 
         try
@@ -43,7 +36,6 @@ public sealed class ResPathSerializer : ITypeSerializer<ResPath, ValueDataNode>,
 
                 return new ErrorNode(node, $"Folder not found. ({path})");
             }
-
             if (resourceManager.ContentFileExists(path))
                 return new ValidatedValueNode(node);
 
@@ -54,6 +46,7 @@ public sealed class ResPathSerializer : ITypeSerializer<ResPath, ValueDataNode>,
             return new ErrorNode(node, $"Failed parsing filepath. ({path}) ({e.Message})");
         }
     }
+
 
     public ResPath Read(ISerializationManager serializationManager, ValueDataNode node,
         IDependencyCollection dependencies,

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/ResPathSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/ResPathSerializer.cs
@@ -26,7 +26,7 @@ public sealed class ResPathSerializer : ITypeSerializer<ResPath, ValueDataNode>,
             path /= "meta.json";
         }
 
-        if (!path.CanonPath.Split('/').First().Equals("Textures", StringComparison.InvariantCultureIgnoreCase))
+        if (!path.IsRooted && !path.CanonPath.Split('/').First().Equals("Textures", StringComparison.InvariantCultureIgnoreCase))
         {
             path = SpriteSpecifierSerializer.TextureRoot / path;
         }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/SpriteSpecifierSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/SpriteSpecifierSerializer.cs
@@ -112,7 +112,9 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             IDependencyCollection dependencies,
             ISerializationContext? context)
         {
-            return serializationManager.ValidateNode<ResPath>(new ValueDataNode($"{TextureRoot / node.Value}"), context);
+            var path = new ResPath(node.Value);
+            var actualPath = path.IsRooted ? path : TextureRoot / path;
+            return serializationManager.ValidateNode<ResPath>(new ValueDataNode($"{actualPath}"), context);
         }
 
         ValidationNode ITypeValidator<SpriteSpecifier, MappingDataNode>.Validate(

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/SpriteSpecifierSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/SpriteSpecifierSerializer.cs
@@ -1,4 +1,5 @@
 using System;
+using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Serialization.Manager;
@@ -112,9 +113,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             IDependencyCollection dependencies,
             ISerializationContext? context)
         {
-            var path = new ResPath(node.Value);
-            var actualPath = path.IsRooted ? path : TextureRoot / path;
-            return serializationManager.ValidateNode<ResPath>(new ValueDataNode($"{actualPath}"), context);
+            var path = PathHelpers.ApparentPath(new ResPath(node.Value), TextureRoot);
+            return serializationManager.ValidateNode<ResPath>(new ValueDataNode($"{path}"), context);
         }
 
         ValidationNode ITypeValidator<SpriteSpecifier, MappingDataNode>.Validate(


### PR DESCRIPTION
## Motivation for this Pull Request
Currently, downstreams are forced to mix their custom assets into the monolithic `Resources/` directory. To keep files organized, resorting to what I will dub the "Underscore Hack"--prefixing folders with `_` (e.g., `_Goobstation`, `_Corvax`) just to group files together.

**The Results:**
Features are split across multiple of `Resources/` "root" directories instead of being contained in a single module, which is less than ideal to maintain.

**The Solution:**
This PR introduces **Modular Resource Loading**. It allows a fork to mount entirely separate physical directories (e.g., `ModResources/`) alongside the standard `Resources/` folder. The engine treats these as native VFS roots without forcing them to live inside the standard directory structure.

## Tested
*   [x] Regular resources folder still loads correctly (Backward compatibility).
*   [x] Modular textures and rsis load via `SpriteComponent`.
*   [x] Verified maps load from modular directories.
*   [x] Verified packaging release builds preserve the folder structure and run without crashing.
*   [x] Verified Hot Reloading detects changes in modular folders.
*   [ ] MacOS and Linux working

[Technical Analysis](https://hackmd.io/@gusx/Sk6EhpXf-l)

This may not have been implemented in the best way so any suggestions are very welcome.