### PR TITLE
Skip redundant texture uploads in WebView when content unchanged

### DIFF
--- a/Robust.Client.WebView/Cef/WebViewManagerCef.Control.cs
+++ b/Robust.Client.WebView/Cef/WebViewManagerCef.Control.cs
@@ -399,15 +399,21 @@ namespace Robust.Client.WebView.Cef
                 if (_data == null)
                     return;
 
-                var bufImg = _data.Renderer.Buffer.Buffer;
+                // update texture only when CEF has rendered new content
+                if (_data.Renderer.IsDirty)
+                {
+                    _data.Renderer.IsDirty = false;
 
-                _data.Texture.SetSubImage(
-                    Vector2i.Zero,
-                    bufImg,
-                    new UIBox2i(
-                        0, 0,
-                        Math.Min(Owner.PixelWidth, bufImg.Width),
-                        Math.Min(Owner.PixelHeight, bufImg.Height)));
+                    var bufImg = _data.Renderer.Buffer.Buffer;
+
+                    _data.Texture.SetSubImage(
+                        Vector2i.Zero,
+                        bufImg,
+                        new UIBox2i(
+                            0, 0,
+                            Math.Min(Owner.PixelWidth, bufImg.Width),
+                            Math.Min(Owner.PixelHeight, bufImg.Height)));
+                }
 
                 handle.UseShader(_shaderInstance);
                 handle.DrawTexture(_data.Texture, Vector2.Zero);
@@ -533,6 +539,7 @@ namespace Robust.Client.WebView.Cef
         {
             public ImageBuffer Buffer { get; }
             private ControlImpl _control;
+            internal volatile bool IsDirty;
 
             internal ControlRenderHandler(ControlImpl control)
             {
@@ -586,6 +593,8 @@ namespace Robust.Client.WebView.Cef
                 {
                     Buffer.UpdateBuffer(width, height, buffer, dirtyRect);
                 }
+
+                IsDirty = true;
             }
 
             protected override void OnAcceleratedPaint(


### PR DESCRIPTION
WebView was uploading texture data every single frame even when nothing changed. Now we just check if CEF actually painted something before bothering with the upload.