### PR TITLE
fix webview resize

### DIFF
--- a/Robust.Client.WebView/Cef/RobustCefApp.cs
+++ b/Robust.Client.WebView/Cef/RobustCefApp.cs
@@ -41,7 +41,7 @@ namespace Robust.Client.WebView.Cef
             // commandLine.AppendSwitch("--single-process");
 
             //commandLine.AppendSwitch("--disable-gpu");
-            //commandLine.AppendSwitch("--disable-gpu-compositing");
+            commandLine.AppendSwitch("--disable-gpu-compositing");
             //commandLine.AppendSwitch("--in-process-gpu");
 
             commandLine.AppendSwitch("--off-screen-rendering-enabled");

--- a/Robust.Client.WebView/Cef/WebViewManagerCef.Control.cs
+++ b/Robust.Client.WebView/Cef/WebViewManagerCef.Control.cs
@@ -392,6 +392,7 @@ namespace Robust.Client.WebView.Cef
                 _data.Browser.GetHost().WasResized();
                 _data.Texture.Dispose();
                 _data.Texture = _clyde.CreateBlankTexture<Rgba32>((Owner.PixelWidth, Owner.PixelHeight));
+                _data.Browser.GetHost().Invalidate(CefPaintElementType.View);
             }
 
             public void Draw(DrawingHandleScreen handle)


### PR DESCRIPTION
GPU compositing causes buffer desync during resize.

before:

https://github.com/user-attachments/assets/5b1612d3-c791-4592-8738-2690c23308a0

after:

https://github.com/user-attachments/assets/0594f6e7-3e64-4e9f-8d8b-0e581fbbd95a

