### PR TITLE
Expand SharedUserInterfaceSystem API

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -802,6 +802,41 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
     }
 
     /// <summary>
+    /// Returns true if any of the specified UI keys are open for this entity by anyone.
+    /// </summary>
+    /// <param name="entity">The entity to check.</param>
+    /// <param name="uiKeys">The UI keys to check.</param>
+    /// <returns>True if any UI is open, false otherwise.</returns>
+    [PublicAPI]
+    public bool IsUiOpen(Entity<UserInterfaceComponent?> entity, List<Enum> uiKeys)
+    {
+        if (!UIQuery.Resolve(entity.Owner, ref entity.Comp, false))
+            return false;
+
+        foreach (var key in uiKeys)
+        {
+            if (entity.Comp.Actors.TryGetValue(key, out var actors) && actors.Count > 0)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns true if any UI is open for this entity by anyone.
+    /// </summary>
+    /// <param name="entity">The entity to check.</param>
+    /// <returns>True if any UI is open, false otherwise.</returns>
+    [PublicAPI]
+    public bool IsAnyUiOpen(Entity<UserInterfaceComponent?> entity)
+    {
+        if (!UIQuery.Resolve(entity.Owner, ref entity.Comp, false))
+            return false;
+
+        return entity.Comp.Actors.Count > 0;
+    }
+
+    /// <summary>
     /// Raises a BUI message locally (on client or server) without networking it.
     /// </summary>
     [PublicAPI]

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -808,14 +808,14 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
     /// <param name="uiKeys">The UI keys to check.</param>
     /// <returns>True if any UI is open, false otherwise.</returns>
     [PublicAPI]
-    public bool IsUiOpen(Entity<UserInterfaceComponent?> entity, List<Enum> uiKeys)
+    public bool IsUiOpen(Entity<UserInterfaceComponent?> entity, IEnumerable<Enum> uiKeys)
     {
         if (!UIQuery.Resolve(entity.Owner, ref entity.Comp, false))
             return false;
 
         foreach (var key in uiKeys)
         {
-            if (entity.Comp.Actors.TryGetValue(key, out var actors) && actors.Count > 0)
+            if (entity.Comp.Actors.ContainsKey(key))
                 return true;
         }
 


### PR DESCRIPTION
Adds `IsUiOpen` (takes a List of UI keys to check) and `IsAnyUiOpen`.

It is sometimes useful to know if any UI is open, as well as if certain UIs are open. I don't want to write boilerplate every single time I want to check a list and I'd like to expose a simple API to check if a UI is open in general.

Required by https://github.com/space-wizards/space-station-14/pull/41885