### PR TITLE
Add support for layered configs

### DIFF
--- a/Robust.Server/BaseServer.cs
+++ b/Robust.Server/BaseServer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Sockets;
@@ -174,25 +175,28 @@ namespace Robust.Server
 
             if (Options.LoadConfigAndUserData)
             {
-                string? path = _commandLineArgs?.ConfigFile;
+                List<string>? paths = _commandLineArgs?.ConfigFiles;
 
                 // Sets up the configMgr
                 // If a config file path was passed, use it literally.
                 // This ensures it's working-directory relative
                 // (for people passing config file through the terminal or something).
                 // Otherwise use the one next to the executable.
-                if (string.IsNullOrEmpty(path))
+                if (paths is null || paths.Count() == 0)
                 {
-                    path = PathHelpers.ExecutableRelativeFile("server_config.toml");
+                    paths = new() { PathHelpers.ExecutableRelativeFile("server_config.toml") };
                 }
 
-                if (File.Exists(path))
+                foreach (var path in paths)
                 {
-                    _config.LoadFromFile(path);
-                }
-                else
-                {
-                    _config.SetSaveFile(path);
+                    if (File.Exists(path))
+                    {
+                        _config.LoadFromFile(path);
+                    }
+                    else
+                    {
+                        _config.SetSaveFile(path);
+                    }
                 }
             }
 

--- a/Robust.Server/CommandLineArgs.cs
+++ b/Robust.Server/CommandLineArgs.cs
@@ -9,7 +9,7 @@ namespace Robust.Server;
 internal sealed class CommandLineArgs
 {
     public MountOptions MountOptions { get; }
-    public string? ConfigFile { get; }
+    public List<string> ConfigFiles { get; } = new();
     public string? DataDir { get; }
     public IReadOnlyCollection<(string key, string value)> CVars { get; }
     public IReadOnlyCollection<(string key, string value)> LogLevels { get; }
@@ -20,7 +20,7 @@ internal sealed class CommandLineArgs
     public static bool TryParse(IReadOnlyList<string> args, [NotNullWhen(true)] out CommandLineArgs? parsed)
     {
         parsed = null;
-        string? configFile = null;
+        List<string> configFiles = new();
         string? dataDir = null;
         var cvars = new List<(string, string)>();
         var logLevels = new List<(string, string)>();
@@ -40,7 +40,7 @@ internal sealed class CommandLineArgs
                     return false;
                 }
 
-                configFile = enumerator.Current;
+                configFiles.Add(enumerator.Current);
             }
             else if (arg == "--data-dir")
             {
@@ -127,7 +127,7 @@ internal sealed class CommandLineArgs
             }
         }
 
-        parsed = new CommandLineArgs(configFile, dataDir, cvars, logLevels, mountOptions, execCommands);
+        parsed = new CommandLineArgs(configFiles, dataDir, cvars, logLevels, mountOptions, execCommands);
         return true;
     }
 
@@ -137,7 +137,7 @@ internal sealed class CommandLineArgs
 Usage: Robust.Server [options] [+command [+command]]
 
 Options:
-  --config-file     Path to the config file to read from.
+  --config-file     Path to the config file to read from. (repeatable)
   --data-dir        Path to the data directory to read/write from/to.
   --cvar            Specifies an additional cvar overriding the config file. Syntax is <key>=<value>
   --loglevel        Specifies an additional sawmill log level overriding the default values. Syntax is <key>=<value>
@@ -151,14 +151,14 @@ Options:
     }
 
     private CommandLineArgs(
-        string? configFile,
+        List<string> configFiles,
         string? dataDir,
         IReadOnlyCollection<(string, string)> cVars,
         IReadOnlyCollection<(string, string)> logLevels,
         MountOptions mountOptions,
         IReadOnlyList<string> execCommands)
     {
-        ConfigFile = configFile;
+        ConfigFiles = configFiles;
         DataDir = dataDir;
         CVars = cVars;
         LogLevels = logLevels;

--- a/Robust.Shared/Configuration/ConfigurationManager.cs
+++ b/Robust.Shared/Configuration/ConfigurationManager.cs
@@ -117,7 +117,8 @@ namespace Robust.Shared.Configuration
                 var oldValue = GetConfigVarValue(cfgVar);
 
                 var convertedValue = value;
-                if (cfgVar.Type != value.GetType())
+                // If the ConfigVar isn't registered yet, cfgVar.Type isn't fully initialized.
+                if (cfgVar.Registered && cfgVar.Type != value.GetType())
                 {
                     try
                     {


### PR DESCRIPTION
By repeatedly specifying --config-file, you can layer multiple config files on top of each other, to share base configuration for multiple servers or to handle files with different secrecy requirements.