### PR TITLE
Fix inverted clipboard error check in SDL3

### DIFF
--- a/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Window.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Window.cs
@@ -606,7 +606,7 @@ internal partial class Clyde
         private void WinThreadSetClipboard(CmdSetClipboard cmd)
         {
             var res = SDL.SDL_SetClipboardText(cmd.Text);
-            if (res)
+            if (!res)
                 _sawmill.Error("Failed to set clipboard text: {error}", SDL.SDL_GetError());
         }
 


### PR DESCRIPTION
This PR corrects the error logging check in `WinThreadSetClipboard`. 
It looks like the check is inverted, because when copying the text successfully, the console displayed this: `[ERRO] clyde.win: Failed to set clipboard text: ""`.
