### PR TITLE
Extend AddMessage capabilites in RobustToolbox.

### DIFF
--- a/Robust.Client/UserInterface/Controls/OutputPanel.cs
+++ b/Robust.Client/UserInterface/Controls/OutputPanel.cs
@@ -136,9 +136,14 @@ namespace Robust.Client.UserInterface.Controls
             AddMessage(msg);
         }
 
-        public void AddMessage(FormattedMessage message)
+        public void AddMessage(FormattedMessage message, Color? defaultColor = null)
         {
-            var entry = new RichTextEntry(message, this, _tagManager);
+            AddMessage(message, RichTextEntry.DefaultTags, defaultColor);
+        }
+
+        public void AddMessage(FormattedMessage message, Type[]? tagsAllowed, Color? defaultColor = null)
+        {
+            var entry = new RichTextEntry(message, this, _tagManager, tagsAllowed, defaultColor);
 
             entry.Update(_tagManager, _getFont(), _getContentBox().Width, UIScale);
 


### PR DESCRIPTION
Title. Forgot to do this in the original PR since it never had the ability to override the default tags ever it seems? 

It's needed so chat can override default sanitization by setting the tags to (null) since it already has some sanitization and really should be sanitized based on who is sending what. In the case of chat these are already sanitized so sanitizing again is useless and just causes problems. On content I'm going to set the allowedTags to null. 