### PR TITLE
Downgrade vorbispizza to 1.3.0 electric boogaloo

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,7 +67,7 @@
     <PackageVersion Include="System.Management" Version="10.0.0" />
     <PackageVersion Include="TerraFX.Interop.Windows" Version="10.0.26100.5" />
     <PackageVersion Include="TerraFX.Interop.Xlib" Version="6.4.0.2" />
-    <PackageVersion Include="VorbisPizza" Version="1.4.2" />
+    <PackageVersion Include="VorbisPizza" Version="1.3.0" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="prometheus-net" Version="8.2.1" />
     <PackageVersion Include="prometheus-net.DotNetRuntime" Version="4.4.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,6 +67,7 @@
     <PackageVersion Include="System.Management" Version="10.0.0" />
     <PackageVersion Include="TerraFX.Interop.Windows" Version="10.0.26100.5" />
     <PackageVersion Include="TerraFX.Interop.Xlib" Version="6.4.0.2" />
+    <!-- Intentionally kept back, there is a bug that breaks audio for systems without AVX instructions. And the fix is not yet published. -->
     <PackageVersion Include="VorbisPizza" Version="1.3.0" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="prometheus-net" Version="8.2.1" />


### PR DESCRIPTION
#5607 again

Even though a fix on vorbispizza was made by pjb **this version was never actually released**

Unless we can get in contact with the dev of vorbispizza this is the easiest way to solve the issue with audio missing again