### PR TITLE
Get hard collision API method

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
@@ -25,6 +25,7 @@
 using System;
 using System.Linq;
 using System.Numerics;
+using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 using Robust.Shared.Map;
@@ -814,6 +815,8 @@ public partial class SharedPhysicsSystem
         return bounds;
     }
 
+    /// <returns>The collision layer and collision mask of all hard fixtures.</returns>
+    [PublicAPI]
     public (int Layer, int Mask) GetHardCollision(EntityUid uid, FixturesComponent? manager = null)
     {
         if (!_fixturesQuery.Resolve(uid, ref manager, false))
@@ -821,6 +824,13 @@ public partial class SharedPhysicsSystem
             return (0, 0);
         }
 
+        return GetHardCollision(manager);
+    }
+
+    /// <inheritdoc cref="GetHardCollision(EntityUid, FixturesComponent?)"/>
+    [PublicAPI]
+    public static (int Layer, int Mask) GetHardCollision(FixturesComponent manager)
+    {
         var layer = 0;
         var mask = 0;
 


### PR DESCRIPTION
This PR adds `GetHardCollision(FixturesComponent)`, a version of `GetHardCollision(EntityUid, FixturesComponent?)` that doesn't require an existing entity.

The specific usecase is in https://github.com/space-wizards/space-station-14/pull/41849, where the collision information is needed to pass to an API function for anchoring. Construction could possibly use it, too. The `PhysicsComponent` on a prototype doesn't have the cached mask and layer that's usually used for this, since that gets set on `ComponentInit`. What's specifically needed is the collision data for an unspawned prototype.