### PR TITLE
Make run_server.bat cd to the current directory

### DIFF
--- a/Robust.Server/run_server.bat
+++ b/Robust.Server/run_server.bat
@@ -1,2 +1,5 @@
+@echo off
+
+cd /d "%~dp0"
 Robust.Server.exe
 pause


### PR DESCRIPTION
As the title says, really doesn't do anything super fancy 99% of the time. Also adds a echo off since a batch script without it hurts me physically

This really won't do anything most of the time, and as far as I'm aware the only time you can get a command prompt from explorer that isn't already in the right directory is if you run it as administrator