### PR TITLE
SpriteView updates its size whenever the entity is set

### DIFF
--- a/Robust.Client/UserInterface/Controls/SpriteView.cs
+++ b/Robust.Client/UserInterface/Controls/SpriteView.cs
@@ -170,6 +170,7 @@ namespace Robust.Client.UserInterface.Controls
 
             Entity = new(uid.Value, sprite, xform);
             NetEnt = EntMan.GetNetEntity(uid);
+            UpdateSize();
         }
 
         protected override Vector2 MeasureOverride(Vector2 availableSize)

--- a/Robust.Client/UserInterface/Controls/SpriteView.cs
+++ b/Robust.Client/UserInterface/Controls/SpriteView.cs
@@ -170,7 +170,7 @@ namespace Robust.Client.UserInterface.Controls
 
             Entity = new(uid.Value, sprite, xform);
             NetEnt = EntMan.GetNetEntity(uid);
-            UpdateSize();
+            InvalidateMeasure();
         }
 
         protected override Vector2 MeasureOverride(Vector2 availableSize)


### PR DESCRIPTION
This is a fairly simple change to call ~~`UpdateSize()`~~ `InvalidateMeasure()` when a SpriteView's entity changes. This resolves an issue we were having downstream with non-standard-sized species having their heads and feet truncated. 
<img width="273" height="427" alt="An Anomalocarid person with the top and bottom of their sprite truncated" src="https://github.com/user-attachments/assets/58ce34c8-b63c-47c0-995a-f1b06b439692" />

