### PR TITLE
fix console warning spam

### DIFF
--- a/Resources/Locale/en-US/replays.ftl
+++ b/Resources/Locale/en-US/replays.ftl
@@ -9,6 +9,9 @@ cmd-replay-pause-help = replay_pause
 cmd-replay-toggle-desc = Resume or pause replay playback.
 cmd-replay-toggle-help = replay_toggle
 
+cmd-replay-toggle-screenshot-mode-desc = Toggles screenshot mode for replays, hiding the replay control widget.
+cmd-replay-toggle-screenshot-mode-help = replay_toggle_screenshot_mode
+
 cmd-replay-stop-desc = Stop and unload a replay.
 cmd-replay-stop-help = replay_stop
 


### PR DESCRIPTION
Follow-up to #6361

The good news is that it's working as expected and we are finding missing loc strings.
The bad news is that it's spamming the console because a command description is missing a loc string.

Turns out that the console is resolving every single command description every time you type a single letter.
Ideally that would not be the case but for now we just fix it by adding the missing loc string.