### PR TITLE
Fix Robust.Benchmarks failing to compile

### DIFF
--- a/Robust.Benchmarks/Robust.Benchmarks.csproj
+++ b/Robust.Benchmarks/Robust.Benchmarks.csproj
@@ -16,7 +16,11 @@
     <ProjectReference Include="..\Robust.UnitTesting\Robust.UnitTesting.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" />
+    <!-- BenchmarkDotNet autogenerates files that attempt to reference BenchmarkDotNet through Robust.Benchmarks.
+     By default the RT project privates these files, so we have to explicitly state that these files should be made available
+     to the BenchmarkDotNet project so it can build the runner that executes the benchmark. -->
+    <PackageReference Include="BenchmarkDotNet" PrivateAssets="none" />
+
     <PackageReference Include="JetBrains.Annotations" />
     <PackageReference Include="YamlDotNet" />
     <PackageReference Include="prometheus-net" />


### PR DESCRIPTION
Sometime around `787330f5c6c256c53c2ed6f9b0909ab4265476a5`, Robust.Benchmarks (and only Robust.Benchmarks, Client.Benchmarks wasn't throwing a fit) was giving me a hard time over this error and similar missing references:

```
/home/roomba/RiderProjects/space-station-14/RobustToolbox/bin/Benchmarks/Robust.Benchmarks-Job-JMDAGQ-1.notcs(712,48):
error CS0234: The type or namespace name 'Engines' does not exist in the namespace 'BenchmarkDotNet' (are you missing an assembly reference?)
[/home/roomba/RiderProjects/space-station-14/RobustToolbox/bin/Benchmarks/Robust.Benchmarks-Job-JMDAGQ-1/BenchmarkDotNet.Autogenerated.csproj]
```

By default the RT project privates package references so the autogenerated files could not reference a built BenchmarkDotNet.dll through Robust.Benchmarks when BenchmarkDotNet needed to build its autogenerated runner.

`Client.Benchmarks` works because we don't suppress package references up there.

The fix is to just make it not private.