### PR TITLE
Fix component tree system crapping out taking half the game with it

### DIFF
--- a/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
+++ b/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
@@ -1,10 +1,16 @@
-using Robust.Shared.Collections;
+using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 using Robust.Shared.Map;
-using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.Collections;
+using System.Numerics;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.ComponentTrees;
@@ -299,7 +305,7 @@ public abstract class ComponentTreeSystem<TTreeComp, TComp> : EntitySystem
         // errors. Currently there is no easy way to enforce this, but this should work as long as nothing queries the
         // trees directly:
         UpdateTreePositions();
-        var trees = new ValueList<>();
+        var trees = new ValueList<(EntityUid Uid, TTreeComp Comp)>();
 
         if (mapId == MapId.Nullspace)
             return trees;


### PR DESCRIPTION
```
Jan 03 20:38:39 SS14.Watchdog[518720]: [ERRO] runtime: Caught exception in "entsys"
Jan 03 20:38:39 SS14.Watchdog[518720]: System.NullReferenceException: Object reference not set to an instance of an object.
Jan 03 20:38:39 SS14.Watchdog[518720]:    at Robust.Shared.ComponentTrees.ComponentTreeSystem`2.UpdateTreePositions() in /home/ubuntu/_work/RobustToolbox/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs:line 208
Jan 03 20:38:39 SS14.Watchdog[518720]:    at Robust.Shared.GameObjects.EntitySystemManager.TickUpdate(Single frameTime, Boolean noPredictions) in /home/ubuntu/_work/RobustToolbox/Robust.Shared/GameObjects/EntitySystemManager.cs:line 318
Jan 03 20:38:39 SS14.Watchdog[518720]: [ERRO] runtime: Caught exception in "entsys"
Jan 03 20:38:39 SS14.Watchdog[518720]: System.NullReferenceException: Object reference not set to an instance of an object.
Jan 03 20:38:39 SS14.Watchdog[518720]:    at Robust.Shared.ComponentTrees.ComponentTreeSystem`2.UpdateTreePositions() in /home/ubuntu/_work/RobustToolbox/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs:line 208
Jan 03 20:38:39 SS14.Watchdog[518720]:    at Robust.Shared.GameObjects.EntitySystemManager.TickUpdate(Single frameTime, Boolean noPredictions) in /home/ubuntu/_work/RobustToolbox/Robust.Shared/GameObjects/EntitySystemManager.cs:line 318
^C
```

Clearing the queue fixed it live