### PR TITLE
Fix Erronius entity deletion on grid deletion from SetTiles()

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -876,11 +876,11 @@ public abstract partial class SharedMapSystem
             chunk.SuppressCollisionRegeneration = false;
         }
 
-        RegenerateCollision(uid, grid, modified);
-
         // Notify of all tile changes in one event
         var ev = new TileChangedEvent((uid, grid), tileChanges.ToArray());
         RaiseLocalEvent(uid, ref ev, true);
+
+        RegenerateCollision(uid, grid, modified);
 
         // Back to normal
         MapManager.SuppressOnTileChanged = false;


### PR DESCRIPTION
SetTiles has RegenerateCollisions() happen before TileChangedEvent is raised. 

TileChangedEvent is used to unanchor and unparent entities on the grid. 

RegenerateCollisions will delete the grid and everything parented to it, if there are no tiles left. 

This means if all tiles on a grid are destroyed simultaneously, all entities on that grid get deleted with no chance to save themselves. This doesn't happen with the normal SetTile method, just this one. 

I swapped the other these methods execute to fix the bug. 