### PR TITLE
Fix Layer constructor in SpriteComponent not properly copying unshaded sprite layers

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1336,11 +1336,10 @@ namespace Robust.Client.GameObjects
             public Layer(Layer toClone, SpriteComponent parent) : this(parent)
             {
                 if (toClone.Shader != null)
-                {
                     Shader = toClone.Shader.Mutable ? toClone.Shader.Duplicate() : toClone.Shader;
-                    UnShaded = toClone.UnShaded;
-                    ShaderPrototype = toClone.ShaderPrototype;
-                }
+
+                UnShaded = toClone.UnShaded; // this isn't included in the Shader null check, since Shader is null when UnShaded is true
+                ShaderPrototype = toClone.ShaderPrototype; // also not in null check to catch when ShaderPrototype is unshaded
                 Texture = toClone.Texture;
                 RSI = toClone.RSI;
                 State = toClone.State;

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1338,8 +1338,8 @@ namespace Robust.Client.GameObjects
                 if (toClone.Shader != null)
                     Shader = toClone.Shader.Mutable ? toClone.Shader.Duplicate() : toClone.Shader;
 
-                UnShaded = toClone.UnShaded; // this isn't included in the Shader null check, since Shader is null when UnShaded is true
-                ShaderPrototype = toClone.ShaderPrototype; // also not in null check to catch when ShaderPrototype is unshaded
+                UnShaded = toClone.UnShaded;
+                ShaderPrototype = toClone.ShaderPrototype;
                 Texture = toClone.Texture;
                 RSI = toClone.RSI;
                 State = toClone.State;


### PR DESCRIPTION
This constructor creates a new Layer by copying the contents of another Layer. This is used in SpriteSystem.CopySprite() to copy the contents of one sprite to another. Currently, the constructor checks if the source's Shader is null, and if it isn't it copies the source's Shader, UnShaded, and ShaderPrototype variables. However, since Shader is meant to be null whenever a layer is unshaded, it doesn't properly copy over the necessary information for rendering unshaded layers. This moves the UnShaded and ShaderPrototype variable setting out of the Shader null check.

Resolves https://github.com/space-wizards/space-station-14/issues/41948

Before fix:

<img width="405" height="225" alt="image" src="https://github.com/user-attachments/assets/c4b9f3c8-1fe6-448e-a55b-d26fbcf9618b" />

After fix:

<img width="403" height="225" alt="image" src="https://github.com/user-attachments/assets/bcbacf35-b901-4609-926d-a804cd112ef3" />
