### PR TITLE
fix MarkupNode.ToString mangling tags

### DIFF
--- a/Robust.Shared/Utility/MarkupNode.cs
+++ b/Robust.Shared/Utility/MarkupNode.cs
@@ -40,7 +40,7 @@ public sealed class MarkupNode : IComparable<MarkupNode>, IEquatable<MarkupNode>
         var attributesString = "";
         foreach (var (k, v) in Attributes)
         {
-            attributesString += $"{k}{v}";
+            attributesString += $" {k}{v}";
         }
 
         return $"[{(Closing ? "/" : "")}{Name}{Value.ToString().ReplaceLineEndings("\\n")}{attributesString}]";


### PR DESCRIPTION
parsing and then using ToString on `[font size=10]hi[/font]` currently gives back `[fontsize=10]hi[/font]`
apparently this has existed for 3 years now because MarkupNode.ToString never put spaces to separate the attributes from 1. the tag name 2. eachother

before:
<img width="512" height="114" alt="18:13:22" src="https://github.com/user-attachments/assets/ae994ab8-acbf-43ab-aa3f-fc5b1b6b02f1" />

an WAAAY before:
<img width="505" height="142" alt="image" src="https://github.com/user-attachments/assets/31e8124b-ded8-46b2-8732-b8a2f5d5d148" />
