### PR TITLE
Make some Control properties animatable

### DIFF
--- a/Robust.Client/UserInterface/Control.Layout.cs
+++ b/Robust.Client/UserInterface/Control.Layout.cs
@@ -2,6 +2,7 @@ using System;
 using System.Numerics;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Animations;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.ViewVariables;
@@ -355,6 +356,7 @@ namespace Robust.Client.UserInterface
         /// </remarks>
         /// <seealso cref="MinWidth"/>
         /// <seealso cref="MinHeight"/>
+        [Animatable]
         public Vector2 MinSize
         {
             get => new(_minWidth, _minHeight);
@@ -378,6 +380,7 @@ namespace Robust.Client.UserInterface
         /// </remarks>
         /// <seealso cref="SetWidth"/>
         /// <seealso cref="SetHeight"/>
+        [Animatable]
         public Vector2 SetSize
         {
             get => new(_setWidth, _setHeight);
@@ -434,6 +437,7 @@ namespace Robust.Client.UserInterface
         /// Width component of <see cref="SetSize"/>.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
+        [Animatable]
         public float SetWidth
         {
             get => _setWidth;
@@ -449,6 +453,7 @@ namespace Robust.Client.UserInterface
         /// Height component of <see cref="SetSize"/>.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
+        [Animatable]
         public float SetHeight
         {
             get => _setHeight;

--- a/Robust.Client/UserInterface/Controls/Label.cs
+++ b/Robust.Client/UserInterface/Controls/Label.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Text;
@@ -44,6 +44,7 @@ namespace Robust.Client.UserInterface.Controls
         /// Thrown if <see cref="TextMemory"/> was set directly and there is no backing string instance to fetch.
         /// </exception>
         [ViewVariables]
+        [Animatable]
         public string? Text
         {
             get => _text ?? (_textMemory.Length > 0 ? throw new InvalidOperationException("Label uses TextMemory, cannot fetch string text.") : null);


### PR DESCRIPTION
Adds an animatable attribute to a few Control properties - I was using some of these for the effects in [0].

UI `Control`s have a pretty arbitrary list of properties which are `Animatable` and it's hard to predict which properties make sense to animate - I wonder if it makes sense to have an implementation of `AnimationTrackProperty` which _doesn't_ enforce that the field is `Animatable`, but does enforce that the object is a `Control`? This would make it a lot easier to add juice to UIs without having to modify RT.

[0] https://discord.com/channels/310555209753690112/1120041991753961583/1457792999273664746