### PR TITLE
Make VV work with structs in components

### DIFF
--- a/Robust.Client/ViewVariables/ViewVariableControlFactory.cs
+++ b/Robust.Client/ViewVariables/ViewVariableControlFactory.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
 using Robust.Client.ViewVariables.Editors;
 using Robust.Shared.Audio;
 using Robust.Shared.ContentPack;

--- a/Robust.Client/ViewVariables/ViewVariableControlFactory.cs
+++ b/Robust.Client/ViewVariables/ViewVariableControlFactory.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Numerics;
 using Robust.Client.ViewVariables.Editors;
 using Robust.Shared.Audio;
 using Robust.Shared.ContentPack;
@@ -56,7 +53,7 @@ internal sealed class ViewVariableControlFactory : IViewVariableControlFactory
         RegisterForType<TimeSpan>(_ =>  new VVPropEditorTimeSpan());
 
         RegisterWithCondition(
-            type => type != typeof(ViewVariablesBlobMembers.ServerValueTypeToken) && !type.IsValueType,
+            type => type != typeof(ViewVariablesBlobMembers.ServerValueTypeToken),
             _ => new VVPropEditorReference()
         );
         RegisterWithCondition(

--- a/Robust.Server/ViewVariables/IViewVariablesSession.cs
+++ b/Robust.Server/ViewVariables/IViewVariablesSession.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.Network;
+﻿using System;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
 namespace Robust.Server.ViewVariables

--- a/Robust.Server/ViewVariables/IViewVariablesSession.cs
+++ b/Robust.Server/ViewVariables/IViewVariablesSession.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Robust.Shared.Network;
+﻿using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
 namespace Robust.Server.ViewVariables
@@ -12,5 +11,6 @@ namespace Robust.Server.ViewVariables
         object Object { get; }
         uint SessionId { get; }
         Type ObjectType { get; }
+        Action<object>? ObjectChangeDelegate { get; }
     }
 }

--- a/Robust.Server/ViewVariables/ServerViewVariablesManager.cs
+++ b/Robust.Server/ViewVariables/ServerViewVariablesManager.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Robust.Server.Console;
 using Robust.Server.Player;
 using Robust.Shared.Enums;
@@ -9,6 +12,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Reflection;
 using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 
 namespace Robust.Server.ViewVariables

--- a/Robust.Server/ViewVariables/Traits/ViewVariablesTraitMembers.cs
+++ b/Robust.Server/ViewVariables/Traits/ViewVariablesTraitMembers.cs
@@ -1,12 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Reflection;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 using static Robust.Shared.ViewVariables.ViewVariablesBlobMembers;
@@ -198,6 +192,8 @@ namespace Robust.Server.ViewVariables.Traits
                     try
                     {
                         field.SetValue(Session.Object, value);
+                        Session.ObjectChangeDelegate?.Invoke(Session.Object);
+
                         return true;
                     }
                     catch (Exception e)

--- a/Robust.Server/ViewVariables/Traits/ViewVariablesTraitMembers.cs
+++ b/Robust.Server/ViewVariables/Traits/ViewVariablesTraitMembers.cs
@@ -1,6 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Reflection;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 using static Robust.Shared.ViewVariables.ViewVariablesBlobMembers;

--- a/Robust.Server/ViewVariables/ViewVariablesSession.cs
+++ b/Robust.Server/ViewVariables/ViewVariablesSession.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using Robust.Server.ViewVariables.Traits;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Log;
@@ -22,6 +19,7 @@ namespace Robust.Server.ViewVariables
         public object Object { get; }
         public uint SessionId { get; }
         public Type ObjectType { get; }
+        public Action<object>? ObjectChangeDelegate { get; }
 
         /// <param name="playerUser">The session ID of the player who opened this session.</param>
         /// <param name="o">The object we represent.</param>
@@ -29,13 +27,14 @@ namespace Robust.Server.ViewVariables
         ///     The session ID for this session. This is what the server and client use to talk about this session.
         /// </param>
         /// <param name="host">The view variables host owning this session.</param>
-        public ViewVariablesSession(NetUserId playerUser, object o, uint sessionId, IServerViewVariablesInternal host,
+        public ViewVariablesSession(NetUserId playerUser, object o, Action<object>? objectChangeDelegate, uint sessionId, IServerViewVariablesInternal host,
             IRobustSerializer robustSerializer, IEntityManager entMan, ISawmill logger)
         {
             PlayerUser = playerUser;
             Object = o;
             SessionId = sessionId;
             ObjectType = o.GetType();
+            ObjectChangeDelegate = objectChangeDelegate;
             Host = host;
             RobustSerializer = robustSerializer;
             EntityManager = entMan;

--- a/Robust.Server/ViewVariables/ViewVariablesSession.cs
+++ b/Robust.Server/ViewVariables/ViewVariablesSession.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Robust.Server.ViewVariables.Traits;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Log;


### PR DESCRIPTION
Tested by editing a field on a struct that is a field on a component
Not sure how/if I should test other cases, but that's the common one I wanted to support mainly
Please lort being able to have structs as data fields without feeling like I'm kneecapping myself and anyone with VV perms
It re-sets the object value so that the change sticks, I didn't check for value type / not value type since it will just do an extra unnecessary  assignment if it's not