### PR TITLE
Let viewport clear when eye is missing 

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -493,6 +493,9 @@ namespace Robust.Client.Graphics.Clyde
         {
             if (viewport.Eye == null || viewport.Eye.Position.MapId == MapId.Nullspace)
             {
+                if (viewport.ClearOnMissingEye)
+                    RenderInRenderTarget(viewport.RenderTarget, () => { }, viewport.ClearColor);
+
                 return;
             }
 

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -493,7 +493,7 @@ namespace Robust.Client.Graphics.Clyde
         {
             if (viewport.Eye == null || viewport.Eye.Position.MapId == MapId.Nullspace)
             {
-                if (viewport.ClearOnMissingEye)
+                if (viewport.ClearWhenMissingEye)
                     RenderInRenderTarget(viewport.RenderTarget, () => { }, viewport.ClearColor);
 
                 return;

--- a/Robust.Client/Graphics/Clyde/Clyde.Viewport.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Viewport.cs
@@ -138,10 +138,10 @@ namespace Robust.Client.Graphics.Clyde
             public Vector2i Size { get; set; }
             public event Action<ClearCachedViewportResourcesEvent>? ClearCachedResources;
             public Color? ClearColor { get; set; } = Color.Black;
+            public bool ClearWhenMissingEye { get; set; }
             public Vector2 RenderScale { get; set; } = Vector2.One;
             public bool AutomaticRender { get; set; }
             public long Id { get; }
-            public bool ClearOnMissingEye { get; set; }
 
             void IClydeViewport.Render()
             {

--- a/Robust.Client/Graphics/Clyde/Clyde.Viewport.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Viewport.cs
@@ -141,6 +141,7 @@ namespace Robust.Client.Graphics.Clyde
             public Vector2 RenderScale { get; set; } = Vector2.One;
             public bool AutomaticRender { get; set; }
             public long Id { get; }
+            public bool ClearOnMissingEye { get; set; }
 
             void IClydeViewport.Render()
             {

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -524,6 +524,7 @@ namespace Robust.Client.Graphics.Clyde
             public Vector2i Size { get; }
             public event Action<ClearCachedViewportResourcesEvent>? ClearCachedResources;
             public Color? ClearColor { get; set; } = Color.Black;
+            public bool ClearWhenMissingEye { get; set; }
             public Vector2 RenderScale { get; set; }
             public bool AutomaticRender { get; set; }
 

--- a/Robust.Client/Graphics/IClydeViewport.cs
+++ b/Robust.Client/Graphics/IClydeViewport.cs
@@ -44,6 +44,11 @@ namespace Robust.Client.Graphics
         Color? ClearColor { get; set; }
 
         /// <summary>
+        /// On frames where Eye is null or in nullspace, whether the viewport may clear.
+        /// </summary>
+        bool ClearWhenMissingEye { get; set; }
+
+        /// <summary>
         ///     This is, effectively, a multiplier to the eye's zoom.
         /// </summary>
         Vector2 RenderScale { get; set; }


### PR DESCRIPTION
Currently when a viewport's eye is null or in nullspace, the render target won't be cleared, which means the view stays constant until the eye is no longer null or in nullspace.

This PR's goal is to allow viewports to be configured to clear the render target instead with the clear color.

Example use case: Rendering the viewport as black when eye is null/in nullspace in OD:

https://github.com/OpenDreamProject/OpenDream/pull/2477