### PR TITLE
Add events on animation starts

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
@@ -154,6 +154,9 @@ namespace Robust.Client.GameObjects
             }
 
             ent.Comp.PlayingAnimations.Add(key, playback);
+
+            var startedEvent = new AnimationStartedEvent(ent.Owner, ent.Comp, key);
+            EntityManager.EventBus.RaiseLocalEvent(ent.Owner, startedEvent, true);
         }
 
         public bool HasRunningAnimation(EntityUid uid, string key)
@@ -196,6 +199,34 @@ namespace Robust.Client.GameObjects
         public void Stop(EntityUid uid, AnimationPlayerComponent? component, string key)
         {
             Stop((uid, component), key);
+        }
+    }
+
+    /// <summary>
+    /// Raised whenever an animation started playing.
+    /// </summary>
+    public sealed class AnimationStartedEvent : EntityEventArgs
+    {
+        /// <summary>
+        /// The entity associated with the event.
+        /// </summary>
+        public EntityUid Uid { get; init; }
+
+        /// <summary>
+        /// The animation player component associated with the entity this event was raised on.
+        /// </summary>
+        public AnimationPlayerComponent AnimationPlayer { get; init; }
+
+        /// <summary>
+        /// The key associated with the animation that was completed.
+        /// </summary>
+        public string Key { get; init; } = string.Empty;
+
+        public AnimationStartedEvent(EntityUid uid, AnimationPlayerComponent animationPlayer, string key)
+        {
+            Uid = uid;
+            AnimationPlayer = animationPlayer;
+            Key = key;
         }
     }
 

--- a/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
@@ -218,7 +218,7 @@ namespace Robust.Client.GameObjects
         public AnimationPlayerComponent AnimationPlayer { get; init; }
 
         /// <summary>
-        /// The key associated with the animation that was completed.
+        /// The key associated with the animation that was started.
         /// </summary>
         public string Key { get; init; } = string.Empty;
 

--- a/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
@@ -156,7 +156,7 @@ namespace Robust.Client.GameObjects
             ent.Comp.PlayingAnimations.Add(key, playback);
 
             var startedEvent = new AnimationStartedEvent(ent.Owner, ent.Comp, key);
-            EntityManager.EventBus.RaiseLocalEvent(ent.Owner, startedEvent, true);
+            RaiseLocalEvent(ent.Owner, startedEvent, true);
         }
 
         public bool HasRunningAnimation(EntityUid uid, string key)
@@ -222,7 +222,7 @@ namespace Robust.Client.GameObjects
         /// </summary>
         public string Key { get; init; } = string.Empty;
 
-        public AnimationStartedEvent(EntityUid uid, AnimationPlayerComponent animationPlayer, string key)
+        internal AnimationStartedEvent(EntityUid uid, AnimationPlayerComponent animationPlayer, string key)
         {
             Uid = uid;
             AnimationPlayer = animationPlayer;

--- a/Robust.Client/UserInterface/Control.Animations.cs
+++ b/Robust.Client/UserInterface/Control.Animations.cs
@@ -12,8 +12,8 @@ namespace Robust.Client.UserInterface
     {
         private Dictionary<string, AnimationPlayback>? _playingAnimations;
 
-        public Action<string>? AnimationCompleted;
         public Action<string>? AnimationStarted;
+        public Action<string>? AnimationCompleted;
 
         /// <summary>
         ///     Start playing an animation.

--- a/Robust.Client/UserInterface/Control.Animations.cs
+++ b/Robust.Client/UserInterface/Control.Animations.cs
@@ -13,6 +13,7 @@ namespace Robust.Client.UserInterface
         private Dictionary<string, AnimationPlayback>? _playingAnimations;
 
         public Action<string>? AnimationCompleted;
+        public Action<string>? AnimationStarted;
 
         /// <summary>
         ///     Start playing an animation.
@@ -27,6 +28,7 @@ namespace Robust.Client.UserInterface
 
             _playingAnimations ??= new Dictionary<string, AnimationPlayback>();
             _playingAnimations.Add(key, playback);
+            AnimationStarted?.Invoke(key);
         }
 
         public bool HasRunningAnimation(string key)


### PR DESCRIPTION
Adds an `AnimationStartedEvent` fired by the `AnimationPlayerSystem`. It's set to broadcast in order to be consistent with the existing `AnimationCompletedEvent`.
Also gives `Control` an `AnimationStarted` event for consistency's sake as well.

The reason for this is to give content systems more awareness about animations and let them react to them if desired. Also, it feels right to have this given `AnimationCompletedEvent` is already available. Finally, it would be useful for my proposed [Animation State Machine](https://github.com/space-wizards/docs/pull/560).