### PR TITLE
Make EntitySystemManager.DependencyCollection inject EntityQuery, make BUIs inject systems and entity queries

### DIFF
--- a/Robust.Shared.IntegrationTests/GameObjects/EntitySystemManagerOrderTest.cs
+++ b/Robust.Shared.IntegrationTests/GameObjects/EntitySystemManagerOrderTest.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Moq;
 using NUnit.Framework;
 using Robust.Server.Configuration;
@@ -88,7 +85,6 @@ namespace Robust.UnitTesting.Shared.GameObjects
             deps.Register<IDynamicTypeFactoryInternal, DynamicTypeFactory>();
             deps.RegisterInstance<IModLoader>(new Mock<IModLoader>().Object);
             deps.Register<IEntitySystemManager, EntitySystemManager>();
-            deps.RegisterInstance<IEntityManager>(new Mock<IEntityManager>().Object);
             // WHEN WILL THE SUFFERING END
             deps.RegisterInstance<IReplayRecordingManager>(new Mock<IReplayRecordingManager>().Object);
 
@@ -103,6 +99,15 @@ namespace Robust.UnitTesting.Shared.GameObjects
                 });
 
             deps.RegisterInstance<IReflectionManager>(reflectionMock.Object);
+
+            // Never
+            var componentFactoryMock = new Mock<IComponentFactory>();
+            componentFactoryMock.Setup(p => p.AllRegisteredTypes).Returns(Enumerable.Empty<Type>());
+            deps.RegisterInstance<IComponentFactory>(componentFactoryMock.Object);
+
+            var entityManagerMock = new Mock<IEntityManager>();
+            entityManagerMock.Setup(p => p.ComponentFactory).Returns(componentFactoryMock.Object);
+            deps.RegisterInstance<IEntityManager>(entityManagerMock.Object);
 
             deps.BuildGraph();
 

--- a/Robust.Shared.IntegrationTests/GameObjects/EntitySystemManager_Tests.cs
+++ b/Robust.Shared.IntegrationTests/GameObjects/EntitySystemManager_Tests.cs
@@ -1,11 +1,10 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using NUnit.Framework;
 using Robust.Shared.Analyzers;
+using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.IoC.Exceptions;
+using Robust.Shared.Physics.Components;
 
 namespace Robust.UnitTesting.Shared.GameObjects
 {
@@ -39,6 +38,14 @@ namespace Robust.UnitTesting.Shared.GameObjects
             [Dependency] public readonly ESystemDepA ESystemDepA = default!;
         }
 
+        internal sealed class ESystemDepAll : EntitySystem
+        {
+            [Dependency] public readonly ESystemDepA ESystemDepA = default!;
+            [Dependency] public readonly IConfigurationManager Config = default!;
+            [Dependency] public readonly EntityQuery<TransformComponent> TransformQuery = default!;
+            [Dependency] public readonly EntityQuery<PhysicsComponent> PhysicsQuery = default!;
+        }
+
         /*
          ESystemBase (Abstract)
            - ESystemA
@@ -58,6 +65,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             syssy.LoadExtraSystemType<ESystemC>();
             syssy.LoadExtraSystemType<ESystemDepA>();
             syssy.LoadExtraSystemType<ESystemDepB>();
+            syssy.LoadExtraSystemType<ESystemDepAll>();
             syssy.Initialize(false);
         }
 
@@ -103,5 +111,16 @@ namespace Robust.UnitTesting.Shared.GameObjects
             Assert.That(sysB.ESystemDepA, Is.EqualTo(sysA));
         }
 
+        [Test]
+        public void DependencyInjectionTest()
+        {
+            var esm = IoCManager.Resolve<IEntitySystemManager>();
+            var sys = esm.GetEntitySystem<ESystemDepAll>();
+
+            Assert.That(sys.ESystemDepA, Is.Not.Null);
+            Assert.That(sys.Config, Is.Not.Null);
+            Assert.That(sys.TransformQuery, Is.Not.Default);
+            Assert.That(sys.PhysicsQuery, Is.Not.Default);
+        }
     }
 }

--- a/Robust.Shared/GameObjects/Components/UserInterface/BoundUserInterface.cs
+++ b/Robust.Shared/GameObjects/Components/UserInterface/BoundUserInterface.cs
@@ -32,6 +32,7 @@ namespace Robust.Shared.GameObjects
 
         protected BoundUserInterface(EntityUid owner, Enum uiKey)
         {
+            IoCManager.Resolve(ref EntMan);
             EntMan.EntitySysManager.DependencyCollection.InjectDependencies(this);
             UiSystem = EntMan.System<SharedUserInterfaceSystem>();
 

--- a/Robust.Shared/GameObjects/Components/UserInterface/BoundUserInterface.cs
+++ b/Robust.Shared/GameObjects/Components/UserInterface/BoundUserInterface.cs
@@ -32,7 +32,7 @@ namespace Robust.Shared.GameObjects
 
         protected BoundUserInterface(EntityUid owner, Enum uiKey)
         {
-            IoCManager.InjectDependencies(this);
+            EntMan.EntitySysManager.DependencyCollection.InjectDependencies(this);
             UiSystem = EntMan.System<SharedUserInterfaceSystem>();
 
             Owner = owner;

--- a/Robust.Shared/GameObjects/EntitySystemManager.cs
+++ b/Robust.Shared/GameObjects/EntitySystemManager.cs
@@ -23,11 +23,11 @@ namespace Robust.Shared.GameObjects
 {
     public sealed class EntitySystemManager : IEntitySystemManager, IPostInjectInit
     {
-        [IoC.Dependency] private readonly IReflectionManager _reflectionManager = default!;
-        [IoC.Dependency] private readonly IEntityManager _entityManager = default!;
-        [IoC.Dependency] private readonly ProfManager _profManager = default!;
-        [IoC.Dependency] private readonly IDependencyCollection _dependencyCollection = default!;
-        [IoC.Dependency] private readonly ILogManager _logManager = default!;
+        [Dependency] private readonly IReflectionManager _reflectionManager = default!;
+        [Dependency] private readonly IEntityManager _entityManager = default!;
+        [Dependency] private readonly ProfManager _profManager = default!;
+        [Dependency] private readonly IDependencyCollection _dependencyCollection = default!;
+        [Dependency] private readonly ILogManager _logManager = default!;
 
 #if EXCEPTION_TOLERANCE
         [Dependency] private readonly IRuntimeLog _runtimeLog = default!;

--- a/Robust.Shared/GameObjects/EntitySystemManager.cs
+++ b/Robust.Shared/GameObjects/EntitySystemManager.cs
@@ -23,11 +23,11 @@ namespace Robust.Shared.GameObjects
 {
     public sealed class EntitySystemManager : IEntitySystemManager, IPostInjectInit
     {
-        [Dependency] private readonly IReflectionManager _reflectionManager = default!;
-        [Dependency] private readonly IEntityManager _entityManager = default!;
-        [Dependency] private readonly ProfManager _profManager = default!;
-        [Dependency] private readonly IDependencyCollection _dependencyCollection = default!;
-        [Dependency] private readonly ILogManager _logManager = default!;
+        [IoC.Dependency] private readonly IReflectionManager _reflectionManager = default!;
+        [IoC.Dependency] private readonly IEntityManager _entityManager = default!;
+        [IoC.Dependency] private readonly ProfManager _profManager = default!;
+        [IoC.Dependency] private readonly IDependencyCollection _dependencyCollection = default!;
+        [IoC.Dependency] private readonly ILogManager _logManager = default!;
 
 #if EXCEPTION_TOLERANCE
         [Dependency] private readonly IRuntimeLog _runtimeLog = default!;
@@ -197,18 +197,22 @@ namespace Robust.Shared.GameObjects
             stopwatch.Start();
             var queryMethod = typeof(EntityManager).GetMethod(nameof(EntityManager.GetEntityQuery), 1, []);
             var registeredComponentTypes = _entityManager.ComponentFactory.AllRegisteredTypes.ToArray();
-            var queryList = new List<(Type Type, object Instance)>(registeredComponentTypes.Length);
-            Parallel.ForEach(registeredComponentTypes,
-                type =>
+            var queryArray = new (Type Type, object Instance)[registeredComponentTypes.Length];
+            Parallel.For(
+                0,
+                registeredComponentTypes.Length,
+                i =>
                 {
+                    var type = registeredComponentTypes[i];
                     var queryType = typeof(EntityQuery<>).MakeGenericType(type);
                     var query = queryMethod!.MakeGenericMethod(type).Invoke(_entityManager, null)!;
-                    queryList.Add((queryType, query));
+                    queryArray[i] = (queryType, query);
                 }
             );
 
-            foreach (var (type, instance) in queryList)
+            foreach (var (type, instance) in queryArray)
             {
+                // This runs a lock so probably no point in parallelizing it, if this changes just move it up
                 SystemDependencyCollection.RegisterInstance(type, instance);
             }
 

--- a/Robust.Shared/GameObjects/EntitySystemManager.cs
+++ b/Robust.Shared/GameObjects/EntitySystemManager.cs
@@ -212,7 +212,7 @@ namespace Robust.Shared.GameObjects
                 SystemDependencyCollection.RegisterInstance(type, instance);
             }
 
-            _sawmill.Info($"Added {nameof(EntityQuery<>)} for all component types to IoC in {stopwatch.ElapsedMilliseconds:F0} ms");
+            _sawmill.Debug($"Added {nameof(EntityQuery<>)} for all component types to IoC in {stopwatch.ElapsedMilliseconds:F0} ms");
 
             SystemDependencyCollection.BuildGraph();
 

--- a/Robust.Shared/GameObjects/EntitySystemManager.cs
+++ b/Robust.Shared/GameObjects/EntitySystemManager.cs
@@ -22,12 +22,12 @@ namespace Robust.Shared.GameObjects
 {
     public sealed class EntitySystemManager : IEntitySystemManager, IPostInjectInit
     {
-        [IoC.Dependency] private readonly IReflectionManager _reflectionManager = default!;
-        [IoC.Dependency] private readonly IEntityManager _entityManager = default!;
-        [IoC.Dependency] private readonly ProfManager _profManager = default!;
-        [IoC.Dependency] private readonly IDependencyCollection _dependencyCollection = default!;
-        [IoC.Dependency] private readonly ILogManager _logManager = default!;
-        [IoC.Dependency] private readonly IComponentFactory _compFactory = default!;
+        [Dependency] private readonly IReflectionManager _reflectionManager = default!;
+        [Dependency] private readonly IEntityManager _entityManager = default!;
+        [Dependency] private readonly ProfManager _profManager = default!;
+        [Dependency] private readonly IDependencyCollection _dependencyCollection = default!;
+        [Dependency] private readonly ILogManager _logManager = default!;
+        [Dependency] private readonly IComponentFactory _compFactory = default!;
 
 #if EXCEPTION_TOLERANCE
         [Dependency] private readonly IRuntimeLog _runtimeLog = default!;

--- a/Robust.Shared/GameObjects/EntitySystemManager.cs
+++ b/Robust.Shared/GameObjects/EntitySystemManager.cs
@@ -212,7 +212,7 @@ namespace Robust.Shared.GameObjects
                 SystemDependencyCollection.RegisterInstance(type, instance);
             }
 
-            _sawmill.Info($"Added {nameof(EntityQuery<>)} for all component types to IoC in {stopwatch.ElapsedMilliseconds:F2} ms");
+            _sawmill.Info($"Added {nameof(EntityQuery<>)} for all component types to IoC in {stopwatch.ElapsedMilliseconds:F0} ms");
 
             SystemDependencyCollection.BuildGraph();
 

--- a/Robust.Shared/IoC/DependencyCollection.cs
+++ b/Robust.Shared/IoC/DependencyCollection.cs
@@ -140,13 +140,10 @@ namespace Robust.Shared.IoC
         {
             if (!services.TryGetValue(objectType, out instance))
             {
-                if (_lazyServices.TryGetValue(objectType, out instance))
-                    return true;
-
-                if (objectType.IsGenericType && _baseGenericLazyFactories.TryGetValue(objectType.GetGenericTypeDefinition(), out var factory))
+                if (objectType.IsGenericType &&
+                    _baseGenericLazyFactories.TryGetValue(objectType.GetGenericTypeDefinition(), out var factory))
                 {
-                    instance = factory(objectType, this);
-                    _lazyServices[objectType] = instance;
+                    instance = _lazyServices.GetOrAdd(objectType, type => factory(type, this));
                     return true;
                 }
 

--- a/Robust.Shared/IoC/IDependencyCollection.cs
+++ b/Robust.Shared/IoC/IDependencyCollection.cs
@@ -133,6 +133,15 @@ namespace Robust.Shared.IoC
         void RegisterInstance(Type type, object implementation, bool overwrite = false);
 
         /// <summary>
+        ///     Adds a callback to be called when attempting to resolve an unresolved type that matches the specified
+        ///     base generic type, making it accessible to <see cref="IDependencyCollection.Resolve{T}"/>.
+        ///     This instance will only be created the first time that it is attempted to be resolved.
+        /// </summary>
+        /// <param name="genericType">The base generic type of the type that will be resolvable.</param>
+        /// <param name="factory">The callback to call to get an instance of the implementation for that generic type.</param>
+        void RegisterBaseGenericLazy(Type genericType, DependencyFactoryBaseGenericLazyDelegate<object> factory);
+
+        /// <summary>
         /// Clear all services and types.
         /// Use this between unit tests and on program shutdown.
         /// If a service implements <see cref="IDisposable"/>, <see cref="IDisposable.Dispose"/> will be called on it.


### PR DESCRIPTION
The technology is insane
No more 100 lines of boilerplate code in systems and BUIs
With this you can do the following in systems and bound user interfaces without having to assign any fields manually
```csharp
[Dependency] private readonly TransformSystem _transformSystem = default!;
[Dependency] private readonly IConfigurationManager _config = default!;
[Dependency] private readonly EntityQuery<PhysicsComponent> _physicsQuery = default!;
```
