### PR TITLE
add debug info to static protoid in generic class error

### DIFF
--- a/Robust.Shared/Prototypes/PrototypeManager.ValidateFields.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.ValidateFields.cs
@@ -94,18 +94,16 @@ public partial class PrototypeManager
     private bool TryGetIds(FieldInfo field, [NotNullWhen(true)] out string[]? ids)
     {
         ids = null;
-        object? value;
-        try
+        if (field.DeclaringType.IsGenericTypeDefinition)
         {
-            value = field.GetValue(null);
-            if (value == null)
-                return false;
-        }
-        catch (InvalidOperationException e)
-        {
-            // field has generic parameters, rethrow to say what the field is because c# is a great language and doesn't tell you anything
+            // field's class has generic parameters, rethrow to say what the field is because
+            // c# is a great language and doesn't tell you anything in its exception in GetValue
             throw new InvalidOperationException($"Field {field.FieldType} {field.Name} cannot be a static field inside a generic class");
         }
+
+        object? value = field.GetValue(null);
+        if (value == null)
+            return false;
 
         if (value is string str)
         {

--- a/Robust.Shared/Prototypes/PrototypeManager.ValidateFields.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.ValidateFields.cs
@@ -94,7 +94,7 @@ public partial class PrototypeManager
     private bool TryGetIds(FieldInfo field, [NotNullWhen(true)] out string[]? ids)
     {
         ids = null;
-        if (field.DeclaringType.IsGenericTypeDefinition)
+        if (field.DeclaringType?.IsGenericTypeDefinition == true)
         {
             // field's class has generic parameters, rethrow to say what the field is because
             // c# is a great language and doesn't tell you anything in its exception in GetValue

--- a/Robust.Shared/Prototypes/PrototypeManager.ValidateFields.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.ValidateFields.cs
@@ -94,9 +94,18 @@ public partial class PrototypeManager
     private bool TryGetIds(FieldInfo field, [NotNullWhen(true)] out string[]? ids)
     {
         ids = null;
-        var value = field.GetValue(null);
-        if (value == null)
-            return false;
+        object? value;
+        try
+        {
+            value = field.GetValue(null);
+            if (value == null)
+                return false;
+        }
+        catch (InvalidOperationException e)
+        {
+            // field has generic parameters, rethrow to say what the field is because c# is a great language and doesn't tell you anything
+            throw new InvalidOperationException($"Field {field.FieldType} {field.Name} cannot be a static field inside a generic class");
+        }
 
         if (value is string str)
         {


### PR DESCRIPTION
for this example pseudocode:
```
public sealed class EpicSystem<TComp> : EntitySystem
{
    public static readonly ProtoId<ShaderPrototype> SomeShader = "Hello";
}
```

currently when validating protoids you get a useless exception with 0 information whatsoever
this pr makes it so you have the protoid type and the field name, which makes fixing the issue fairly trivial
```
Field Robust.Shared.Prototypes.ProtoId`1[Robust.Client.Graphics.ShaderPrototype] SomeShader cannot be a static field inside a generic class
```