### PR TITLE
Cleanup warnings: CS0414

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
@@ -14,9 +14,9 @@ namespace Robust.Client.GameObjects
         private EntityQuery<AnimationPlayerComponent> _playerQuery;
         private EntityQuery<MetaDataComponent> _metaQuery;
 
-#pragma warning disable CS0414
+#if DEBUG
         [Dependency] private readonly IComponentFactory _compFact = default!;
-#pragma warning restore CS0414
+#endif
 
         public override void Initialize()
         {

--- a/Robust.Client/Prototypes/ClientPrototypeManager.cs
+++ b/Robust.Client/Prototypes/ClientPrototypeManager.cs
@@ -13,9 +13,9 @@ namespace Robust.Client.Prototypes
     public sealed class ClientPrototypeManager : PrototypeManager
     {
         [Dependency] private readonly INetManager _netManager = default!;
-#pragma warning disable CS0414
+#if TOOLS
         [Dependency] private readonly IClientGameTiming _timing = default!;
-#pragma warning restore CS0414
+#endif
         [Dependency] private readonly IGameControllerInternal _controller = default!;
         [Dependency] private readonly IReloadManager _reload = default!;
 

--- a/Robust.Client/Replays/Loading/ReplayLoadManager.cs
+++ b/Robust.Client/Replays/Loading/ReplayLoadManager.cs
@@ -21,7 +21,6 @@ public sealed partial class ReplayLoadManager : IReplayLoadManager
     [Dependency] private readonly IBaseClient _client = default!;
     [Dependency] private readonly EntityManager _entMan = default!;
     [Dependency] private readonly IClientGameTiming _timing = default!;
-    [Dependency] private readonly IClientNetManager _netMan = default!;
     [Dependency] private readonly IComponentFactory _factory = default!;
     [Dependency] private readonly IPrototypeManager _protoMan = default!;
     [Dependency] private readonly ILocalizationManager _locMan = default!;

--- a/Robust.Client/Utility/ReloadManager.cs
+++ b/Robust.Client/Utility/ReloadManager.cs
@@ -20,9 +20,9 @@ internal sealed class ReloadManager : IReloadManager
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly ILogManager _logMan = default!;
     [Dependency] private readonly IResourceManagerInternal _res = default!;
-#pragma warning disable CS0414
+#if TOOLS
     [Dependency] private readonly ITaskManager _tasks = default!;
-#pragma warning restore CS0414
+#endif
 
     private readonly TimeSpan _reloadDelay = TimeSpan.FromMilliseconds(10);
     private CancellationTokenSource _reloadToken = new();

--- a/Robust.Server/Prototypes/ServerPrototypeManager.cs
+++ b/Robust.Server/Prototypes/ServerPrototypeManager.cs
@@ -13,10 +13,10 @@ namespace Robust.Server.Prototypes
 {
     public sealed class ServerPrototypeManager : PrototypeManager
     {
-#pragma warning disable CS0414
+#if TOOLS
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly IConGroupController _conGroups = default!;
-#pragma warning restore CS0414
+#endif
         [Dependency] private readonly INetManager _netManager = default!;
         [Dependency] private readonly IBaseServerInternal _server = default!;
 

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs
@@ -21,10 +21,10 @@ namespace Robust.Shared.Physics.Systems
      */
     public partial class SharedPhysicsSystem
     {
-#pragma warning disable CS0414
+#if DEBUG
         [Dependency] private readonly SharedDebugRayDrawingSystem _sharedDebugRaySystem = default!;
         [Dependency] private readonly INetManager _netMan = default!;
-#pragma warning restore CS0414
+#endif
 
         /// <summary>
         /// Checks to see if the specified collision rectangle collides with any of the physBodies under management.


### PR DESCRIPTION
Cleanup 1x `CS0414` warning.
The suppression of some warnings has also been replaced with a more correct approach.

[CS0414](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0414): The private field 'field' is assigned but its value is never used.


[https://github.com/space-wizards/space-station-14/issues/33279](https://github.com/space-wizards/space-station-14/issues/33279)