### PR TITLE
Add ProfManager.Value guard, write first command argument as a ProfManager value in ExecuteInShell

### DIFF
--- a/Robust.Server/Console/ServerConsoleHost.cs
+++ b/Robust.Server/Console/ServerConsoleHost.cs
@@ -9,6 +9,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Network;
 using Robust.Shared.Network.Messages;
 using Robust.Shared.Player;
+using Robust.Shared.Profiling;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Utility;
 
@@ -22,6 +23,7 @@ namespace Robust.Server.Console
         [Dependency] private readonly IPlayerManager _players = default!;
         [Dependency] private readonly ISystemConsoleManager _systemConsole = default!;
         [Dependency] private readonly ToolshedManager _toolshed = default!;
+        [Dependency] private readonly ProfManager _prof = default!;
 
         public ServerConsoleHost() : base(isServer: true) {}
 
@@ -108,7 +110,8 @@ namespace Robust.Server.Console
                 if (args.Count == 0)
                     return;
 
-                string? cmdName = args[0];
+                var cmdName = args[0];
+                using var _ = _prof.Group(cmdName);
 
                 if (RegisteredCommands.TryGetValue(cmdName, out var conCmd)) // command registered
                 {

--- a/Robust.Shared/GameObjects/EntitySystemManager.cs
+++ b/Robust.Shared/GameObjects/EntitySystemManager.cs
@@ -314,9 +314,10 @@ namespace Robust.Shared.GameObjects
                 try
                 {
 #endif
-                    var sw = ProfSampler.StartNew();
-                    updReg.System.Update(frameTime);
-                    _profManager.WriteValue(updReg.System.GetType().Name, sw);
+                    using (_profManager.Value(updReg.System.GetType().Name))
+                    {
+                        updReg.System.Update(frameTime);
+                    }
 #if EXCEPTION_TOLERANCE
                 }
                 catch (Exception e)
@@ -341,9 +342,10 @@ namespace Robust.Shared.GameObjects
                 try
                 {
 #endif
-                    var sw = ProfSampler.StartNew();
-                    system.FrameUpdate(frameTime);
-                    _profManager.WriteValue(system.GetType().Name, sw);
+                    using (_profManager.Value(system.GetType().Name))
+                    {
+                        system.FrameUpdate(frameTime);
+                    }
 #if EXCEPTION_TOLERANCE
                 }
                 catch (Exception e)

--- a/Robust.Shared/Profiling/ProfManager.cs
+++ b/Robust.Shared/Profiling/ProfManager.cs
@@ -133,6 +133,14 @@ public sealed class ProfManager
     public long WriteValue(string text, long int64) => WriteValue(text, ProfData.Int64(int64));
 
     /// <summary>
+    /// Make a guarded value for usage with using blocks.
+    /// </summary>
+    public ValueGuard Value(string text)
+    {
+        return new ValueGuard(this, text);
+    }
+
+    /// <summary>
     /// Write the start of a new log group.
     /// </summary>
     /// <returns>The absolute position of the written log entry.</returns>
@@ -248,6 +256,25 @@ public sealed class ProfManager
         public void Dispose()
         {
             _mgr.WriteGroupEnd(_startIndex, _groupName, _sampler);
+        }
+    }
+
+    public readonly struct ValueGuard : IDisposable
+    {
+        private readonly ProfManager _mgr;
+        private readonly string _text;
+        private readonly ProfSampler _sampler;
+
+        public ValueGuard(ProfManager mgr, string text)
+        {
+            _mgr = mgr;
+            _text = text;
+            _sampler = ProfSampler.StartNew();
+        }
+
+        public void Dispose()
+        {
+            _mgr.WriteValue(_text, _sampler);
         }
     }
 }


### PR DESCRIPTION
Value works the same as Group, but instead of writing GroupStart and GroupEnd it just writes a value when disposed
Also made EntitySystemManager use this
The command writing won't work properly with toolshed commands, but after having a quick look at the code for those I decided that I do not want to figure out how to split those up and put them in the ProfManager