### PR TITLE
Prevent a potential EnsureComp exception. 

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -838,18 +838,16 @@ namespace Robust.Shared.GameObjects
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool EnsureComponent<T>(ref Entity<T?> entity) where T : IComponent, new()
         {
-            if (entity.Comp != null)
-            {
-                // Check for deferred component removal.
-                if (entity.Comp.LifeStage <= ComponentLifeStage.Running)
-                {
-                    DebugTools.AssertOwner(entity, entity.Comp);
-                    return true;
-                }
+            if (entity.Comp == null)
+                return EnsureComponent<T>(entity.Owner, out entity.Comp);
 
-                RemoveComponent(entity, entity.Comp);
-            }
+            DebugTools.AssertOwner(entity, entity.Comp);
 
+            // Check for deferred component removal.
+            if (entity.Comp.LifeStage <= ComponentLifeStage.Running)
+                return true;
+
+            RemoveComponent(entity, entity.Comp);
             entity.Comp = AddComponent<T>(entity);
             return false;
         }


### PR DESCRIPTION
Noticed this while doing solutions refactor stuff, EnsureComp(ref Entity<T?>) can take a component as an argument, but if it's null, it will try to add a component without checking if one already exists. 

So if for example, you had a method that took an Entity<T?> as an argument, which called EnsureComp(ref Entity<T?>) to ensure that the component always exists, but only passed an EntityUid to your method, despite the component existing, this method would try to add the component again without checking if it already existed. 

This just changes the method so if you pass a null component, it runs the other EnsureComp method which helps remove code copypasting, and if you do pass a component, ensures it's not being deleted and adds it back if it is being deleted. 