### PR TITLE
Add CVar attribute to register on value changed automatically for fields, properties, and methods on systems, services, and controllers

### DIFF
--- a/Robust.Client/UserInterface/Controllers/UserInterfaceManager.Controllers.cs
+++ b/Robust.Client/UserInterface/Controllers/UserInterfaceManager.Controllers.cs
@@ -262,6 +262,11 @@ internal partial class UserInterfaceManager
         _stateManager.OnStateChanged += OnStateChanged;
 
         _dependencies.BuildGraph();
+
+        foreach (var controller in _uiControllers.Values)
+        {
+            _configurationManager.RegisterCVarAttributes(controller);
+        }
     }
 
     private void InitializeControllers()

--- a/Robust.Shared.IntegrationTests/GameObjects/EntitySystemManagerOrderTest.cs
+++ b/Robust.Shared.IntegrationTests/GameObjects/EntitySystemManagerOrderTest.cs
@@ -82,6 +82,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             deps.Register<IGameTiming, GameTiming>();
             deps.RegisterInstance<INetManager>(new Mock<INetManager>().Object);
             deps.Register<IConfigurationManager, ServerNetConfigurationManager>();
+            deps.Register<IConfigurationManagerInternal, ServerNetConfigurationManager>();
             deps.Register<IServerNetConfigurationManager, ServerNetConfigurationManager>();
             deps.Register<ProfManager, ProfManager>();
             deps.Register<IDynamicTypeFactory, DynamicTypeFactory>();

--- a/Robust.Shared/Configuration/CVarAttribute.cs
+++ b/Robust.Shared/Configuration/CVarAttribute.cs
@@ -1,0 +1,35 @@
+using System;
+using JetBrains.Annotations;
+
+namespace Robust.Shared.Configuration;
+
+/// <summary>
+/// Marks a field or property to be automatically assigned when the associated CVar value changes.
+/// </summary>
+/// <typeparam name="T">The type containing the CVar definition.</typeparam>
+/// <param name="cVarPath">The name of the field of the CVar definition on <see cref="T"/></param>
+/// <seealso cref="IConfigurationManagerInternal.RegisterCVarAttributesInternal"/>
+/// <example>
+/// How to use this to read the initial value of, and any changes to, <see cref="CVars.NetMaxConnections"/>
+/// <code>
+///     [CVar&lt;CVars&gt;(nameof(CVars.NetMaxConnections))]
+///     public int Value;
+///
+///     [CVar&lt;CVars&gt;(nameof(CVars.NetMaxConnections))]
+///     public void Test(int v)
+///     {
+///         Assert.That(v, Is.EqualTo(Value));
+///     }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method)]
+[MeansImplicitAssignment]
+[MeansImplicitUse(ImplicitUseKindFlags.Assign)]
+public sealed class CVarAttribute<T>(string cVarPath) : CVarAttribute(typeof(T), cVarPath);
+
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method)]
+public abstract class CVarAttribute(Type type, string cVarPath) : Attribute
+{
+    internal readonly Type Type = type;
+    internal readonly string CVarPath = cVarPath;
+}

--- a/Robust.Shared/Configuration/ConfigurationManager.cs
+++ b/Robust.Shared/Configuration/ConfigurationManager.cs
@@ -1120,7 +1120,7 @@ namespace Robust.Shared.Configuration
             }
         }
 
-        public void PostInject()
+        void IPostInjectInit.PostInject()
         {
             foreach (var type in _dependencyCollection.GetRegisteredTypes())
             {

--- a/Robust.Shared/Configuration/IConfigurationManager.cs
+++ b/Robust.Shared/Configuration/IConfigurationManager.cs
@@ -274,6 +274,14 @@ namespace Robust.Shared.Configuration
 
         public event Action<CVarChangeInfo>? OnCVarValueChanged;
 
+        /// <summary>
+        /// Registers any fields and properties with the <see cref="CVarAttribute"/> on the
+        /// given <see cref="obj"/>.
+        /// These fields and properties will be automatically assigned when the CVar value
+        /// changes, including their current value when calling this method.
+        /// </summary>
+        void RegisterCVarAttributes(object obj);
+
         //
         // Rollback
         //

--- a/Robust.Shared/GameObjects/EntitySystemManager.cs
+++ b/Robust.Shared/GameObjects/EntitySystemManager.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Prometheus;
+using Robust.Shared.Configuration;
 using Robust.Shared.IoC;
 using Robust.Shared.IoC.Exceptions;
 using Robust.Shared.Log;
@@ -27,6 +28,7 @@ namespace Robust.Shared.GameObjects
         [Dependency] private readonly ProfManager _profManager = default!;
         [Dependency] private readonly IDependencyCollection _dependencyCollection = default!;
         [Dependency] private readonly ILogManager _logManager = default!;
+        [Dependency] private readonly IConfigurationManagerInternal _config = default!;
 
 #if EXCEPTION_TOLERANCE
         [Dependency] private readonly IRuntimeLog _runtimeLog = default!;
@@ -197,6 +199,7 @@ namespace Robust.Shared.GameObjects
             foreach (var systemType in _systemTypes)
             {
                 var system = (IEntitySystem)SystemDependencyCollection.ResolveType(systemType);
+                _config.RegisterCVarAttributes(system);
                 system.Initialize();
                 SystemLoaded?.Invoke(this, new SystemChangedArgs(system));
             }


### PR DESCRIPTION
Example usage:
```csharp
[CVar<CVars>(nameof(CVars.NetMaxConnections))]
public int Value;

[CVar<CVars>(nameof(CVars.NetMaxConnections))]
public void OnMaxConnectionsChanged(int val)
{
    ...
}
```

Now I don't need to remind every contributor to pass true to OnValueChanged forget 1 time and be hit by the curse of Ra
