### PR TITLE
Fix resolve errors when networking EntityUids referencing deleted entities

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Network.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Network.cs
@@ -183,7 +183,10 @@ public partial class EntityManager
         if (uid == EntityUid.Invalid)
             return NetEntity.Invalid;
 
-        if (!MetaQuery.Resolve(uid, ref metadata))
+        // Logging is disabled because this was causing over 24000 errors each day when networking EntityUid datafields referencing deleted entities.
+        // TODO: Re-enable once we have WeakEntityReference or entity relations.
+        // See https://github.com/space-wizards/RobustToolbox/issues/6152
+        if (!MetaQuery.Resolve(uid, ref metadata, logMissing: false))
             return NetEntity.Invalid;
 
         return metadata.NetEntity;


### PR DESCRIPTION
Another approach to the problem explained in #6152

This basically just disables the resolve error log. The component state is properly generated and networked regardless. If the referenced entity is deleted then `GetNetEntity` will return an invalid `NetEntity` which in turn is converted to an invalid `EntityUid` on the client, meaning that the server and client component state are the same after networking.

<img width="1150" height="391" alt="grafik" src="https://github.com/user-attachments/assets/7d053b8c-01c4-4bbb-8225-f98fd383dece" />

For testing:
- Spawn a jukebox
- Play a song and let it finish so that the audio entity gets deleted
- Use the `dirty` console command to dirty the jukebox entity, which will network the reference to the deleted audio stream

Ideally this would be fixed with either `WeakEntityReference` or a relations system that automatically sets the datafields back to `null` when the entity is deleted. But this is causing an absolutely insane amount of over 24000 errors each day, which drowns out all other errors to the point that they become unusable and even cause lag spikes on the server. We even did not notice that admin logs were failing to save to the database for 2 weeks because no one saw the errors. And the discord relay notfying us about error spikes is constantly spamming us despite us adjusting the sensitivity multiple times, so no one even looks at it.

<img width="1433" height="228" alt="grafik" src="https://github.com/user-attachments/assets/1a9f3325-66da-40e7-a9eb-c29db65cd7be" />

All PRs so far have been closed and I don't expect a new `WeakEntityReference` or relations system implementation any time soon, so I think this is a reasonable solution for the meantime to stop the error spam.