### PR TITLE
Debug Console Autocompletes for Contains

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Completion filter now works by Contains instead of StartsWith
 
 ### Bugfixes
 

--- a/Robust.Client/UserInterface/CustomControls/DebugConsole.xaml.Completions.cs
+++ b/Robust.Client/UserInterface/CustomControls/DebugConsole.xaml.Completions.cs
@@ -262,7 +262,7 @@ public sealed partial class DebugConsole
     private CompletionOption[] FilterCompletions(IEnumerable<CompletionOption> completions, string curTyping)
     {
         return completions
-            .Where(c => c.Value.StartsWith(curTyping, StringComparison.CurrentCultureIgnoreCase))
+            .Where(c => c.Value.Contains(curTyping, StringComparison.CurrentCultureIgnoreCase))
             .ToArray();
     }
 


### PR DESCRIPTION
Entering commands to console now filters for commands containing, not just starting with, what you typed.

This is more approachable for new developers / admins, who are likely to know _something_ about what they want, but not what the exact verbiage is -- searching for "round" will bring up e.g. "startround" and "endround" as options, and not just "round"

IMPORTANT: this might negatively people who have a lot of muscle memory in terms of typing something and having something else come up -- I haven't found anything that's jumped out to me as an obvious problem, but if this happens to you, sorry!

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2f06c95f-9e3a-45e7-a8ab-805af5eb08d1" />
