### PR TITLE
Obliterates all System.Random APIs.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,11 +10,14 @@ Don't change the format without looking at the script!
 
 ### Breaking changes
 
-*None yet*
+- `RandomExtensions.Pick()` for `ICollection<T>` and `IReadOnlyCollection<T>` got renamed to `PickSlow`. This is due to
+  some unfortunate API conflicts that came up during removing System.Random-based APIs.
+- All `System.Random` helpers and extension methods were removed. Content should stop using it.
 
 ### New features
 
-*None yet*
+- `RobustRandom` now has a direct seed constructor, and a constructor to seed it from an existing RNG.
+- Some functions that only existed for `System.Random` were ported to `RobustRandom`.
 
 ### Bugfixes
 

--- a/Robust.Server.Testing/RobustServerSimulation.cs
+++ b/Robust.Server.Testing/RobustServerSimulation.cs
@@ -252,7 +252,7 @@ namespace Robust.UnitTesting.Server
             container.Register<INetworkedMapManager, NetworkedMapManager>();
             container.Register<IMapManagerInternal, NetworkedMapManager>();
             container.Register<ISerializationManager, SerializationManager>();
-            container.Register<IRobustRandom, RobustRandom>();
+            container.RegisterInstance<IRobustRandom>(new RobustRandom());
             container.Register<IPrototypeManager, ServerPrototypeManager>();
             container.Register<IComponentFactory, ComponentFactory>();
             container.Register<IEntitySystemManager, EntitySystemManager>();

--- a/Robust.Shared/Map/ITileDefinitionManager.cs
+++ b/Robust.Shared/Map/ITileDefinitionManager.cs
@@ -13,13 +13,7 @@ namespace Robust.Shared.Map
     {
         Tile GetVariantTile(string name, IRobustRandom random);
 
-        [Obsolete("Always use RobustRandom/IRobustRandom, System.Random does not provide any extra functionality.")]
-        Tile GetVariantTile(string name, System.Random random);
-
         Tile GetVariantTile(ITileDefinition tileDef, IRobustRandom random);
-
-        [Obsolete("Always use RobustRandom/IRobustRandom, System.Random does not provide any extra functionality.")]
-        Tile GetVariantTile(ITileDefinition tileDef, System.Random random);
 
         /// <summary>
         ///     Indexer to retrieve a tile definition by name.

--- a/Robust.Shared/Map/TileDefinitionManager.cs
+++ b/Robust.Shared/Map/TileDefinitionManager.cs
@@ -47,18 +47,7 @@ namespace Robust.Shared.Map
             return GetVariantTile(tileDef, random);
         }
 
-        public Tile GetVariantTile(string name, System.Random random)
-        {
-            var tileDef = this[name];
-            return GetVariantTile(tileDef, random);
-        }
-
         public Tile GetVariantTile(ITileDefinition tileDef, IRobustRandom random)
-        {
-            return new Tile(tileDef.TileId, variant: random.NextByte(tileDef.Variants));
-        }
-
-        public Tile GetVariantTile(ITileDefinition tileDef, System.Random random)
         {
             return new Tile(tileDef.TileId, variant: random.NextByte(tileDef.Variants));
         }

--- a/Robust.Shared/Random/IRobustRandom.cs
+++ b/Robust.Shared/Random/IRobustRandom.cs
@@ -12,11 +12,10 @@ namespace Robust.Shared.Random;
 /// </summary>
 public interface IRobustRandom
 {
-    /// <summary> Get the underlying <see cref="Random"/>.</summary>
-    [Obsolete("Do not access the underlying implementation")]
-    System.Random GetRandom();
-
     /// <summary> Set seed for underlying <see cref="Random"/>. </summary>
+    /// <remarks>
+    ///     Prefer to construct a new one over setting the seed, this is really only for tests..
+    /// </remarks>
     void SetSeed(int seed);
 
     /// <summary> Get random <see cref="float"/> value between 0 (included) and 1 (excluded). </summary>
@@ -173,48 +172,5 @@ public interface IRobustRandom
     void Shuffle<T>(ValueList<T> list)
     {
         Shuffle(list.Span);
-    }
-}
-
-[Obsolete("Always use RobustRandom/IRobustRandom, System.Random does not provide any extra functionality.")]
-public static class RandomHelpers
-{
-    [Obsolete("Always use RobustRandom/IRobustRandom, System.Random does not provide any extra functionality.")]
-    public static void Shuffle<T>(this System.Random random, IList<T> list)
-    {
-        var n = list.Count;
-        while (n > 1)
-        {
-            n -= 1;
-            var k = random.Next(n + 1);
-            (list[k], list[n]) = (list[n], list[k]);
-        }
-    }
-
-    [Obsolete("Always use RobustRandom/IRobustRandom, System.Random does not provide any extra functionality.")]
-    public static bool Prob(this System.Random random, double chance)
-    {
-        return random.NextDouble() < chance;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [Obsolete("Always use RobustRandom/IRobustRandom, System.Random does not provide any extra functionality.")]
-    public static byte NextByte(this System.Random random, byte maxValue)
-    {
-        return NextByte(random, 0, maxValue);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [Obsolete("Always use RobustRandom/IRobustRandom, System.Random does not provide any extra functionality.")]
-    public static byte NextByte(this System.Random random)
-    {
-        return NextByte(random, byte.MaxValue);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [Obsolete("Always use RobustRandom/IRobustRandom, System.Random does not provide any extra functionality.")]
-    public static byte NextByte(this System.Random random, byte minValue, byte maxValue)
-    {
-        return (byte)random.Next(minValue, maxValue);
     }
 }

--- a/Robust.Shared/Random/RandomExtensions.cs
+++ b/Robust.Shared/Random/RandomExtensions.cs
@@ -53,7 +53,7 @@ public static class RandomExtensions
     /// <remarks>
     ///     This is O(n).
     /// </remarks>
-    public static T Pick<T>(this IRobustRandom random, IReadOnlyCollection<T> collection)
+    public static T PickSlow<T>(this IRobustRandom random, IReadOnlyCollection<T> collection)
     {
         var index = random.Next(collection.Count);
         var i = 0;
@@ -84,8 +84,7 @@ public static class RandomExtensions
     /// Picks a random element from a set and returns it.
     /// This is O(n) as it has to iterate the collection until the target index.
     /// </summary>
-    [Obsolete("Always use RobustRandom/IRobustRandom, System.Random does not provide any extra functionality.")]
-    public static T Pick<T>(this System.Random random, ICollection<T> collection)
+    private static T PickSlow<T>(this IRobustRandom random, ICollection<T> collection)
     {
         var index = random.Next(collection.Count);
         var i = 0;
@@ -104,44 +103,14 @@ public static class RandomExtensions
     /// Picks a random from a collection then removes it and returns it.
     /// This is O(n) as it has to iterate the collection until the target index.
     /// </summary>
-    [Obsolete("Always use RobustRandom/IRobustRandom, System.Random does not provide any extra functionality.")]
-    public static T PickAndTake<T>(this System.Random random, ICollection<T> set)
+    public static T PickAndTakeSlow<T>(this IRobustRandom random, ICollection<T> set)
     {
-        var tile = Pick(random, set);
+        var tile = random.PickSlow(set);
         set.Remove(tile);
         return tile;
     }
 
-    /// <summary>
-    ///     Generate a random number from a normal (gaussian) distribution.
-    /// </summary>
-    /// <param name="random">The random object to generate the number from.</param>
-    /// <param name="μ">The average or "center" of the normal distribution.</param>
-    /// <param name="σ">The standard deviation of the normal distribution.</param>
-    [Obsolete("Always use RobustRandom/IRobustRandom, System.Random does not provide any extra functionality.")]
-    public static double NextGaussian(this System.Random random, double μ = 0, double σ = 1)
-    {
-        // https://stackoverflow.com/a/218600
-        var α = random.NextDouble();
-        var β = random.NextDouble();
-
-        var randStdNormal = Math.Sqrt(-2.0 * Math.Log(α)) * Math.Sin(2.0 * Math.PI * β);
-
-        return μ + σ * randStdNormal;
-    }
-
-    [Obsolete("Always use RobustRandom/IRobustRandom, System.Random does not provide any extra functionality.")]
-    public static Angle NextAngle(this System.Random random) => NextFloat(random) * MathF.Tau;
-
-    [Obsolete("Always use RobustRandom/IRobustRandom, System.Random does not provide any extra functionality.")]
-    public static Angle NextAngle(this System.Random random, Angle minAngle, Angle maxAngle)
-    {
-        DebugTools.Assert(minAngle < maxAngle);
-        return minAngle + (maxAngle - minAngle) * random.NextDouble();
-    }
-
-    [Obsolete("Always use RobustRandom/IRobustRandom, System.Random does not provide any extra functionality.")]
-    public static Vector2 NextPolarVector2(this System.Random random, float minMagnitude, float maxMagnitude)
+    public static Vector2 NextPolarVector2(this IRobustRandom random, float minMagnitude, float maxMagnitude)
         => random.NextAngle().RotateVec(new Vector2(random.NextFloat(minMagnitude, maxMagnitude), 0));
 
     [Obsolete("Exists as a method directly on IRobustRandom.")]
@@ -152,17 +121,6 @@ public static class RandomExtensions
         // Except using float instead of double.
         return random.Next() * 4.6566128752458E-10f;
     }
-
-    [Obsolete("Always use RobustRandom/IRobustRandom, System.Random does not provide any extra functionality.")]
-    public static float NextFloat(this System.Random random)
-    {
-        return random.Next() * 4.6566128752458E-10f;
-    }
-
-    [Obsolete("Always use RobustRandom/IRobustRandom, System.Random does not provide any extra functionality.")]
-    public static float NextFloat(this System.Random random, float minValue, float maxValue)
-        => random.NextFloat() * (maxValue - minValue) + minValue;
-
     /// <summary>
     ///     Have a certain chance to return a boolean.
     /// </summary>

--- a/Robust.Shared/Random/RobustRandom.cs
+++ b/Robust.Shared/Random/RobustRandom.cs
@@ -9,21 +9,44 @@ namespace Robust.Shared.Random;
 /// </summary>
 /// <example>
 /// <code>
-///     var myRng = new RobustRandom();
 ///     // Optionally, seed your RNG. By default, the RNG is seeded randomly.
-///     myRng.SetSeed(17);
+///     var myRng = new RobustRandom(17);
 ///     <br/>
 ///     var fairDiceRoll = myRng.Next(1, 6); // Will be 4 with this seed.
 /// </code>
 /// </example>
 public sealed class RobustRandom : IRobustRandom
 {
-    // This should not contain any logic, not directly related to calling specific methods of <see cref="Random"/>.
-    // To write additional logic, attached to random roll, please create interface-implemented methods on <see cref="IRobustRandom"/>
-    // or add it to <see cref="RandomExtensions"/>.
-    private System.Random _random = new();
+    // Yea this is just SmallRandom under the hood. This class exists for two reasons:
+    // - Back compat
+    // - Type safety as a global construct. You can't accidentally serialize RobustRandom
+    private System.Random _random;
 
-    public System.Random GetRandom() => _random;
+    /// <summary>
+    ///     Initialize the randomizer with a new, nondeterministic seed.
+    /// </summary>
+    public RobustRandom()
+    {
+        // Just init a new one with global seeding.
+        _random = new();
+    }
+
+    /// <summary>
+    ///     Initialize the randomizer with a specific integer seed.
+    /// </summary>
+    public RobustRandom(int seed)
+    {
+        _random = new(seed);
+    }
+
+    /// <summary>
+    ///     Initialize the randomizer by seeding it with another randomizer.
+    /// </summary>
+    /// <param name="other"></param>
+    public RobustRandom(IRobustRandom other)
+    {
+        _random = new(other.Next());
+    }
 
     public void SetSeed(int seed)
     {

--- a/Robust.Shared/Random/RobustRandom.cs
+++ b/Robust.Shared/Random/RobustRandom.cs
@@ -17,9 +17,9 @@ namespace Robust.Shared.Random;
 /// </example>
 public sealed class RobustRandom : IRobustRandom
 {
-    // Yea this is just SmallRandom under the hood. This class exists for two reasons:
-    // - Back compat
-    // - Type safety as a global construct. You can't accidentally serialize RobustRandom
+    // This should not contain any logic, not directly related to calling specific methods of <see cref="Random"/>.
+    // To write additional logic, attached to random roll, please create interface-implemented methods on <see cref="IRobustRandom"/>
+    // or add it to <see cref="RandomExtensions"/>.
     private System.Random _random;
 
     /// <summary>

--- a/Robust.Shared/SharedIoC.cs
+++ b/Robust.Shared/SharedIoC.cs
@@ -39,7 +39,7 @@ namespace Robust.Shared
             deps.Register<TaskManager, TaskManager>();
             deps.Register<ITimerManager, TimerManager>();
             deps.Register<ProfManager, ProfManager>();
-            deps.Register<IRobustRandom, RobustRandom>();
+            deps.RegisterInstance<IRobustRandom>(new RobustRandom());
             deps.Register<IRobustMappedStringSerializer, RobustMappedStringSerializer>();
             deps.Register<ISandboxHelper, SandboxHelper>();
             deps.Register<IManifoldManager, CollisionManager>();


### PR DESCRIPTION
This fully removes the obsolete APIs, and is meant to go with the companion PR #...
This shouldn't be merged yet, no engine has been released with these APIs obsoleted and people deserve at least a little heads-up.

All of the obsolete functionality can be replaced with RobustRandom cleanly.
Future work includes porting SmallRandom/RngSeed and making IRobustRandom only the interface for the *global* RNG, but one big break at a time.