### PR TITLE
Add entity ProtoId to spawn panel tooltip

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -42,6 +42,7 @@ END TEMPLATE-->
 * If a sandbox error is caused by a compiler-generated method, the engine will now attempt to point out which using code is responsible.
 * Added `OrderedDictionary<TKey, TValue>` and `System.StringComparer` to the sandbox whitelist.
 * Added more overloads to `MapLoaderSystem` taking `TextReader`/`TextWriter` where appropriate.
+* The tooltip when hovering an entry in the entity spawn panel now contains the entity's protoid as well as its description.
 
 ### Bugfixes
 

--- a/Resources/Locale/en-US/custom-controls.ftl
+++ b/Resources/Locale/en-US/custom-controls.ftl
@@ -3,6 +3,7 @@
 entity-spawn-window-title = Entity Spawn Panel
 entity-spawn-window-replace-button-text = Replace
 entity-spawn-window-override-menu-tooltip = Override placement
+entity-spawn-window-no-description = No description
 
 ## TileSpawnWindow
 

--- a/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.xaml.cs
+++ b/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.xaml.cs
@@ -8,6 +8,7 @@ using Robust.Client.Placement;
 using Robust.Client.UserInterface.XAML;
 using Robust.Shared.Graphics;
 using Robust.Shared.IoC;
+using Robust.Shared.Localization;
 using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
 
@@ -16,6 +17,9 @@ namespace Robust.Client.UserInterface.CustomControls
     [GenerateTypedNameReferences]
     public sealed partial class EntitySpawnWindow : DefaultWindow
     {
+        private static readonly LocId NoDescriptionMessage = "entity-spawn-window-no-description";
+
+        [Dependency] private readonly ILocalizationManager _loc = default!;
         [Dependency] private readonly IPlacementManager _placement = default!;
 
         public EntitySpawnButton? SelectedButton;
@@ -53,7 +57,8 @@ namespace Robust.Client.UserInterface.CustomControls
             }
 
             button.EntityLabel.Text = entityLabelText;
-            button.ActualButton.ToolTip = $"{prototype.ID}\n{prototype.Description}";
+            var desc = string.IsNullOrEmpty(prototype.Description) ? _loc.GetString(NoDescriptionMessage) : prototype.Description;
+            button.ActualButton.ToolTip = $"{prototype.ID}\n{desc}";
 
             if (prototype == SelectedPrototype)
             {

--- a/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.xaml.cs
+++ b/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.xaml.cs
@@ -53,7 +53,7 @@ namespace Robust.Client.UserInterface.CustomControls
             }
 
             button.EntityLabel.Text = entityLabelText;
-            button.ActualButton.ToolTip = prototype.Description;
+            button.ActualButton.ToolTip = $"{prototype.ID}\n{prototype.Description}";
 
             if (prototype == SelectedPrototype)
             {


### PR DESCRIPTION
The tooltip when hovering an entry in the entity spawn panel now contains the entity's protoid as well as its description.
<img width="940" height="231" alt="Screenshot 2026-02-21 at 4 48 06 PM" src="https://github.com/user-attachments/assets/8b64f16c-f22c-4c44-89ec-4c35d20635e6" />
