### PR TITLE
Avoid crashing client when reloading a shader with syntax errors

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Shaders.cs
@@ -115,7 +115,16 @@ namespace Robust.Client.Graphics.Clyde
 
             var (vertBody, fragBody) = GetShaderCode(newShader);
 
-            var program = _compileProgram(vertBody, fragBody, BaseShaderAttribLocations, loaded.Name);
+            GLShaderProgram? program = null;
+            try
+            {
+                program = _compileProgram(vertBody, fragBody, BaseShaderAttribLocations, loaded.Name);
+            }
+            catch (ShaderCompilationException e)
+            {
+                _clydeSawmill.Warning($"Compilation failed: {e}");
+                return;
+            }
 
             loaded.Program.Delete();
 


### PR DESCRIPTION
Minor dev QOL improvement. When iterating on a shader, if a shader fails to compile, the whole client would crash. This makes it not-crash, so a developer can fix the issue without having to restart the client.