### PR TITLE
Make UserInterfaceComponent#Interfaces AlwaysPushInheritance

### DIFF
--- a/Robust.Shared/GameObjects/Components/UserInterface/UserInterfaceComponent.cs
+++ b/Robust.Shared/GameObjects/Components/UserInterface/UserInterfaceComponent.cs
@@ -25,7 +25,7 @@ namespace Robust.Shared.GameObjects
         [ViewVariables, Access(Friend = AccessPermissions.ReadWriteExecute, Other = AccessPermissions.ReadWriteExecute)]
         public readonly Dictionary<Enum, BoundUserInterface> ClientOpenInterfaces = new();
 
-        [DataField]
+        [DataField, AlwaysPushInheritance]
         internal Dictionary<Enum, InterfaceData> Interfaces = new();
 
         /// <summary>


### PR DESCRIPTION
We have a lot of places in content where we inherit user interfaces but have to manually compose the fields; this makes us not need to do that anymore