### PR TITLE
Improved collision filter test

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Fixtures.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Fixtures.cs
@@ -149,7 +149,7 @@ public abstract partial class SharedPhysicsSystem
             return false;
         }
 
-        // Fast check
+        // Check the collision filter on the rigid bodies
         if (!bodyA.Comp2.Hard ||
             !bodyB.Comp2.Hard ||
             ((bodyA.Comp2.CollisionLayer & bodyB.Comp2.CollisionMask) == 0x0 &&
@@ -158,28 +158,18 @@ public abstract partial class SharedPhysicsSystem
             return false;
         }
 
-        // Slow check
-        foreach (var fix in bodyA.Comp1.Fixtures.Values)
-        {
-            if (!fix.Hard)
-                continue;
+        // Check the collision filter on the fixtures
+        return IsHardCollidable(bodyA.Comp1, bodyB.Comp1);
+    }
 
-            foreach (var other in bodyB.Comp1.Fixtures.Values)
-            {
-                if (!other.Hard)
-                    continue;
-
-                if ((fix.CollisionLayer & other.CollisionMask) == 0x0 &&
-                    (fix.CollisionMask & other.CollisionLayer) == 0x0)
-                {
-                    continue;
-                }
-
-                return true;
-            }
-        }
-
-        return false;
+    /// <summary>
+    /// Returns true if collision filter on any fixture pair are hard-collidable with each other
+    /// </summary>
+    public bool IsHardCollidable(FixturesComponent fixturesA, FixturesComponent fixturesB)
+    {
+        var (aLayer, aMask) = GetHardCollision(fixturesA);
+        var (bLayer, bMask) = GetHardCollision(fixturesA);
+        return ((aLayer & bMask) | (bLayer & aMask)) != 0;
     }
 
     public void AddCollisionMask(EntityUid uid, string fixtureId, Fixture fixture, int mask, FixturesComponent? manager = null, PhysicsComponent? body = null)


### PR DESCRIPTION
Minor improvements to collision filter test:

SharedPhysicsSystem was doing an O(n*m) test for every possible fixture pair when testing two FixturesComponents for collision. But because it's not doing any narrowphase collisions, the same result can be calculated in O(n+m) steps, just by summing up the collision layers/masks.

Added an interface to check IsHardCollidable() using just the fixtures components. I wanted this when checking collision with an EntityPrototype, so didn't have an Entity yet.