### PR TITLE
Fix completions for entity prototypes.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,7 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+- `Prototype<T>`, a precursor to `ProtoId<T>` used by toolshed, has been removed.
 
 ### New features
 
@@ -45,7 +45,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+- Toolshed commands trying to complete `EntProtoId` fields now actually return completion results.
 
 ### Other
 

--- a/Robust.Shared/Toolshed/TypeParsers/PrototypeTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/PrototypeTypeParser.cs
@@ -51,9 +51,6 @@ public sealed class ProtoIdTypeParser<T> : TypeParser<ProtoId<T>>
 
     public override CompletionResult TryAutocomplete(ParserContext ctx, CommandArgument? arg)
     {
-        if (typeof(T) == typeof(EntityPrototype))
-            return CompletionResult.FromHint(GetArgHint(arg));
-
         var hint = ToolshedCommand.GetArgHint(arg, typeof(ProtoId<T>));
         var maxCount = _config.GetCVar(CVars.ToolshedPrototypesAutocompleteLimit);
         var options = CompletionHelper.PrototypeIdsLimited<T>(ctx.Input[ctx.Index..], proto: _proto, maxCount: maxCount);
@@ -63,6 +60,9 @@ public sealed class ProtoIdTypeParser<T> : TypeParser<ProtoId<T>>
 
 public sealed class EntProtoIdTypeParser : TypeParser<EntProtoId>
 {
+    [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+
     public override bool TryParse(ParserContext ctx, out EntProtoId result)
     {
         result = default;
@@ -73,93 +73,9 @@ public sealed class EntProtoIdTypeParser : TypeParser<EntProtoId>
         return true;
     }
 
-    public override CompletionResult? TryAutocomplete(ParserContext parserContext, CommandArgument? arg)
-    {
-        // TODO TOOLSHED Improve ProtoId completions
-        // Completion options should be able to communicate to a client that it can populate the options by itself.
-        // I.e., instead of dumping all entity prototypes on the client, tell it how to generate them locally.
-        return CompletionResult.FromHint(GetArgHint(arg));
-    }
-}
-
-public sealed class PrototypeInstanceTypeParser<T> : TypeParser<T>
-    where T : class, IPrototype
-{
-    [Dependency] private readonly IPrototypeManager _proto = default!;
-
-    public override bool TryParse(ParserContext ctx, [NotNullWhen(true)] out T? result)
-    {
-        if (!Toolshed.TryParse(ctx, out string? proto))
-            proto = ctx.GetWord(ParserContext.IsToken);
-
-        if (proto != null && _proto.TryIndex(proto, out result))
-            return true;
-
-        _proto.TryGetKindFrom<T>(out var kind);
-        DebugTools.AssertNotNull(kind);
-
-        ctx.Error = new NotAValidPrototype(proto ?? "[null]", kind!);
-        result = null;
-        return false;
-    }
-
     public override CompletionResult? TryAutocomplete(ParserContext ctx, CommandArgument? arg)
     {
-        return Toolshed.TryAutocomplete(ctx, typeof(ProtoId<T>), arg);
-    }
-}
-
-[Obsolete]
-internal sealed class PrototypeTypeParser<T> : TypeParser<Prototype<T>>
-    where T : class, IPrototype
-{
-    [Dependency] private readonly IPrototypeManager _prototype = default!;
-
-    public override bool TryParse(ParserContext ctx, out Prototype<T> result)
-    {
-        if (!Toolshed.TryParse(ctx, out string? proto))
-            proto = ctx.GetWord(ParserContext.IsToken);
-
-        if (proto is null || !_prototype.TryIndex<T>(proto, out var resolved))
-        {
-            _prototype.TryGetKindFrom<T>(out var kind);
-            DebugTools.AssertNotNull(kind);
-
-            ctx.Error = new NotAValidPrototype(proto ?? "[null]", kind!);
-            result = default;
-            return false;
-        }
-
-        result = new Prototype<T>(resolved);
-        return true;
-    }
-
-    public override CompletionResult? TryAutocomplete(ParserContext ctx, CommandArgument? arg)
-    {
-        IEnumerable<CompletionOption> options;
-
-        // todo: this should be an attribute.
-        if (typeof(T) != typeof(EntityPrototype))
-            options = CompletionHelper.PrototypeIDs<T>();
-        else
-            options = Array.Empty<CompletionOption>();
-
-        _prototype.TryGetKindFrom<T>(out var kind);
-        DebugTools.AssertNotNull(kind);
-
-        return CompletionResult.FromHintOptions(options, $"<{kind} prototype>");
-    }
-}
-
-[Obsolete("Use ProtoId<T> or EntProtoId, or the prototype directly")]
-public readonly record struct Prototype<T>(T Value) : IAsType<string>
-    where T : class, IPrototype
-{
-    public ProtoId<T> Id => Value.ID;
-
-    public string AsType()
-    {
-        return Value.ID;
+        return Toolshed.TryAutocomplete(ctx, typeof(ProtoId<EntityPrototype>), arg);
     }
 }
 


### PR DESCRIPTION
Minor maintenance patch, as this uses PrototypeIdsLimited the main cost (serializing all the info to send over the network) is no longer a major concern. Thus, remove the limitation on entity prototype autocompletion entirely so users can get completions.

# Breaking Changes
Removes the obsolete Prototype<T> types entirely. They were unused.