### PR TITLE
[Proposal] Add support for using a specific sprite for the placement overlay

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -167,7 +167,7 @@ namespace Robust.Client.GameObjects
         }
 
         [DataField("sprite", readOnly: true)] private string? rsi;
-        [DataField("placementOverlaySprite", readOnly: true)] public SpriteSpecifier? placementOverlaySprite;
+        [DataField(readOnly: true)] public SpriteSpecifier? placementOverlaySprite;
         [DataField("layers", readOnly: true)] private List<PrototypeLayerData> layerDatums = new();
 
         [DataField(readOnly: true)] private string? state;

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -167,6 +167,7 @@ namespace Robust.Client.GameObjects
         }
 
         [DataField("sprite", readOnly: true)] private string? rsi;
+        [DataField("placementOverlaySprite", readOnly: true)] public SpriteSpecifier? placementOverlaySprite;
         [DataField("layers", readOnly: true)] private List<PrototypeLayerData> layerDatums = new();
 
         [DataField(readOnly: true)] private string? state;

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -167,7 +167,6 @@ namespace Robust.Client.GameObjects
         }
 
         [DataField("sprite", readOnly: true)] private string? rsi;
-        [DataField(readOnly: true)] public SpriteSpecifier? placementOverlaySprite;
         [DataField("layers", readOnly: true)] private List<PrototypeLayerData> layerDatums = new();
 
         [DataField(readOnly: true)] private string? state;

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -743,7 +743,18 @@ namespace Robust.Client.Placement
             CurrentPrototype = prototype;
             IsActive = true;
 
-            CurrentPlacementOverlayEntity = EntityManager.SpawnEntity(templateName, MapCoordinates.Nullspace);
+            //does prototype uses a specific placement overlay sprite?
+            if (prototype.TryGetComponent<SpriteComponent>(out var prototypeSprite, IoCManager.Resolve<IComponentFactory>())
+                && prototypeSprite.placementOverlaySprite != null)
+            {
+                CurrentPlacementOverlayEntity = EntityManager.SpawnEntity(null, MapCoordinates.Nullspace);
+                SetPlacementOverlaySprite(prototypeSprite, Sprite.RsiStateLike(prototypeSprite.placementOverlaySprite));
+            }
+            else
+            {
+                CurrentPlacementOverlayEntity = EntityManager.SpawnEntity(templateName, MapCoordinates.Nullspace);
+            }
+
             EntityManager.RunMapInit(
                 CurrentPlacementOverlayEntity.Value,
                 EntityManager.GetComponent<MetaDataComponent>(CurrentPlacementOverlayEntity.Value));
@@ -858,6 +869,25 @@ namespace Robust.Client.Placement
             message.DirRcv = Direction;
 
             _networkManager.ClientSendMessage(message);
+        }
+
+        private void SetPlacementOverlaySprite(SpriteComponent prototypeSprite, IRsiStateLike overlayTexture)
+        {
+            if (CurrentPlacementOverlayEntity == null)
+                return;
+
+            if (overlayTexture is not RSI.State overlayRSI)
+            {
+                //Fallback
+                Sprite.AddTextureLayer(CurrentPlacementOverlayEntity.Value, overlayTexture.Default);
+                return;
+            }
+
+            EntityManager.EnsureComponent<SpriteComponent>(CurrentPlacementOverlayEntity.Value, out var overlaySprite);
+            Sprite.AddRsiLayer(CurrentPlacementOverlayEntity.Value, overlayRSI.StateId, overlayRSI.RSI);
+
+            overlaySprite.NoRotation = prototypeSprite.NoRotation;
+            Sprite.SetScale(CurrentPlacementOverlayEntity.Value, prototypeSprite.Scale);
         }
 
         public enum PlacementTypes : byte

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Numerics;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
@@ -11,19 +8,22 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Input;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.IoC;
+using Robust.Shared.Log;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
 using Robust.Shared.Network;
 using Robust.Shared.Network.Messages;
+using Robust.Shared.Placement;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Reflection;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
-using Robust.Shared.Log;
-using Robust.Shared.Placement;
-using Direction = Robust.Shared.Maths.Direction;
-using Robust.Shared.Map.Components;
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
+using Direction = Robust.Shared.Maths.Direction;
 
 namespace Robust.Client.Placement
 {
@@ -748,7 +748,7 @@ namespace Robust.Client.Placement
             if (prototype.TryGetComponent<PlacementOverlayComponent>(out var placementOverlay, _componentFactory))
             {
                 CurrentPlacementOverlayEntity = EntityManager.SpawnEntity(null, MapCoordinates.Nullspace);
-                SetPlacementOverlaySprite(prototype, Sprite.RsiStateLike(placementOverlay.Sprite));
+                SetPlacementOverlaySprite(placementOverlay);
             }
             else
             {
@@ -871,26 +871,23 @@ namespace Robust.Client.Placement
             _networkManager.ClientSendMessage(message);
         }
 
-        private void SetPlacementOverlaySprite(EntityPrototype prototype, IRsiStateLike overlayTexture)
+        private void SetPlacementOverlaySprite(PlacementOverlayComponent placementOverlay)
         {
             if (CurrentPlacementOverlayEntity == null)
                 return;
 
-            if (overlayTexture is not RSI.State overlayRSI)
+            if (Sprite.RsiStateLike(placementOverlay.Sprite) is not RSI.State overlayRSI)
             {
                 //Fallback
-                Sprite.AddTextureLayer(CurrentPlacementOverlayEntity.Value, overlayTexture.Default);
+                Sprite.AddTextureLayer(CurrentPlacementOverlayEntity.Value, Sprite.RsiStateLike(placementOverlay.Sprite).Default);
                 return;
             }
 
             EntityManager.EnsureComponent<SpriteComponent>(CurrentPlacementOverlayEntity.Value, out var overlaySprite);
             Sprite.AddRsiLayer(CurrentPlacementOverlayEntity.Value, overlayRSI.StateId, overlayRSI.RSI);
 
-            if(prototype.TryGetComponent<SpriteComponent>(out var prototypeSprite, _componentFactory))
-            {
-                overlaySprite.NoRotation = prototypeSprite.NoRotation;
-                Sprite.SetScale(CurrentPlacementOverlayEntity.Value, prototypeSprite.Scale);
-            }
+            overlaySprite.NoRotation = placementOverlay.NoRotation;
+            Sprite.SetScale(CurrentPlacementOverlayEntity.Value, placementOverlay.Scale);
         }
 
         public enum PlacementTypes : byte

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -20,6 +20,7 @@ using Robust.Shared.Reflection;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Robust.Shared.Log;
+using Robust.Shared.Placement;
 using Direction = Robust.Shared.Maths.Direction;
 using Robust.Shared.Map.Components;
 using System.Linq;
@@ -743,12 +744,10 @@ namespace Robust.Client.Placement
             CurrentPrototype = prototype;
             IsActive = true;
 
-            //does prototype uses a specific placement overlay sprite?
-            if (prototype.TryGetComponent<SpriteComponent>(out var prototypeSprite, IoCManager.Resolve<IComponentFactory>())
-                && prototypeSprite.placementOverlaySprite != null)
+            if (prototype.TryGetComponent<PlacementOverlayComponent>(out var placementOverlay, IoCManager.Resolve<IComponentFactory>()))
             {
                 CurrentPlacementOverlayEntity = EntityManager.SpawnEntity(null, MapCoordinates.Nullspace);
-                SetPlacementOverlaySprite(prototypeSprite, Sprite.RsiStateLike(prototypeSprite.placementOverlaySprite));
+                SetPlacementOverlaySprite(prototype, Sprite.RsiStateLike(placementOverlay.sprite));
             }
             else
             {
@@ -871,7 +870,7 @@ namespace Robust.Client.Placement
             _networkManager.ClientSendMessage(message);
         }
 
-        private void SetPlacementOverlaySprite(SpriteComponent prototypeSprite, IRsiStateLike overlayTexture)
+        private void SetPlacementOverlaySprite(EntityPrototype prototype, IRsiStateLike overlayTexture)
         {
             if (CurrentPlacementOverlayEntity == null)
                 return;
@@ -886,8 +885,11 @@ namespace Robust.Client.Placement
             EntityManager.EnsureComponent<SpriteComponent>(CurrentPlacementOverlayEntity.Value, out var overlaySprite);
             Sprite.AddRsiLayer(CurrentPlacementOverlayEntity.Value, overlayRSI.StateId, overlayRSI.RSI);
 
-            overlaySprite.NoRotation = prototypeSprite.NoRotation;
-            Sprite.SetScale(CurrentPlacementOverlayEntity.Value, prototypeSprite.Scale);
+            if(prototype.TryGetComponent<SpriteComponent>(out var prototypeSprite, IoCManager.Resolve<IComponentFactory>()))
+            {
+                overlaySprite.NoRotation = prototypeSprite.NoRotation;
+                Sprite.SetScale(CurrentPlacementOverlayEntity.Value, prototypeSprite.Scale);
+            }
         }
 
         public enum PlacementTypes : byte

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -29,21 +29,22 @@ namespace Robust.Client.Placement
 {
     public sealed partial class PlacementManager : IPlacementManager, IDisposable, IEntityEventSubscriber
     {
-        [Dependency] private readonly ILogManager _logManager = default!;
-        [Dependency] private readonly IClientNetManager _networkManager = default!;
-        [Dependency] internal readonly IPlayerManager PlayerManager = default!;
-        [Dependency] internal readonly IResourceCache ResourceCache = default!;
-        [Dependency] private readonly IReflectionManager _reflectionManager = default!;
-        [Dependency] private readonly IMapManager _mapManager = default!;
-        [Dependency] private readonly IGameTiming _time = default!;
-        [Dependency] private readonly IEyeManager _eyeManager = default!;
-        [Dependency] internal readonly IInputManager InputManager = default!;
-        [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
-        [Dependency] private readonly IEntityManager _entityManager = default!;
-        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly IBaseClient _baseClient = default!;
-        [Dependency] private readonly IOverlayManager _overlayManager = default!;
+        [Dependency] private readonly IClientNetManager _networkManager = default!;
         [Dependency] internal readonly IClyde Clyde = default!;
+        [Dependency] private readonly IComponentFactory _componentFactory = default!;
+        [Dependency] private readonly IEntityManager _entityManager = default!;
+        [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
+        [Dependency] private readonly IEyeManager _eyeManager = default!;
+        [Dependency] private readonly IGameTiming _time = default!;
+        [Dependency] internal readonly IInputManager InputManager = default!;
+        [Dependency] private readonly ILogManager _logManager = default!;
+        [Dependency] private readonly IMapManager _mapManager = default!;
+        [Dependency] private readonly IOverlayManager _overlayManager = default!;
+        [Dependency] internal readonly IPlayerManager PlayerManager = default!;
+        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        [Dependency] private readonly IReflectionManager _reflectionManager = default!;
+        [Dependency] internal readonly IResourceCache ResourceCache = default!;
 
         private static readonly ProtoId<ShaderPrototype> UnshadedShader = "unshaded";
 
@@ -744,7 +745,7 @@ namespace Robust.Client.Placement
             CurrentPrototype = prototype;
             IsActive = true;
 
-            if (prototype.TryGetComponent<PlacementOverlayComponent>(out var placementOverlay, IoCManager.Resolve<IComponentFactory>()))
+            if (prototype.TryGetComponent<PlacementOverlayComponent>(out var placementOverlay, _componentFactory))
             {
                 CurrentPlacementOverlayEntity = EntityManager.SpawnEntity(null, MapCoordinates.Nullspace);
                 SetPlacementOverlaySprite(prototype, Sprite.RsiStateLike(placementOverlay.Sprite));
@@ -885,7 +886,7 @@ namespace Robust.Client.Placement
             EntityManager.EnsureComponent<SpriteComponent>(CurrentPlacementOverlayEntity.Value, out var overlaySprite);
             Sprite.AddRsiLayer(CurrentPlacementOverlayEntity.Value, overlayRSI.StateId, overlayRSI.RSI);
 
-            if(prototype.TryGetComponent<SpriteComponent>(out var prototypeSprite, IoCManager.Resolve<IComponentFactory>()))
+            if(prototype.TryGetComponent<SpriteComponent>(out var prototypeSprite, _componentFactory))
             {
                 overlaySprite.NoRotation = prototypeSprite.NoRotation;
                 Sprite.SetScale(CurrentPlacementOverlayEntity.Value, prototypeSprite.Scale);

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -747,7 +747,7 @@ namespace Robust.Client.Placement
             if (prototype.TryGetComponent<PlacementOverlayComponent>(out var placementOverlay, IoCManager.Resolve<IComponentFactory>()))
             {
                 CurrentPlacementOverlayEntity = EntityManager.SpawnEntity(null, MapCoordinates.Nullspace);
-                SetPlacementOverlaySprite(prototype, Sprite.RsiStateLike(placementOverlay.sprite));
+                SetPlacementOverlaySprite(prototype, Sprite.RsiStateLike(placementOverlay.Sprite));
             }
             else
             {

--- a/Robust.Shared/Placement/PlacementOverlayComponent.cs
+++ b/Robust.Shared/Placement/PlacementOverlayComponent.cs
@@ -2,13 +2,16 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Utility;
 
-namespace Robust.Shared.Placement
+namespace Robust.Shared.Placement;
+
+/// <summary>
+///    That component allows modifying the overlay used by the placement system.
+/// </summary>
+[RegisterComponent]
+public sealed partial class PlacementOverlayComponent : Component
 {
-    [RegisterComponent]
-    public sealed partial class PlacementOverlayComponent : Component
-    {        /// <summary>
-             ///     A SpriteSpecifier that will be used while in placement mode for this prototype
-             /// </summary>
-        [DataField(readOnly: true, required: true)] public SpriteSpecifier sprite;
-    }
+    /// <summary>
+    ///     Specific sprite for the placement overlay.
+    /// </summary>
+    [DataField(readOnly: true, required: true)] public SpriteSpecifier Sprite;
 }

--- a/Robust.Shared/Placement/PlacementOverlayComponent.cs
+++ b/Robust.Shared/Placement/PlacementOverlayComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Placement
+{
+    [RegisterComponent]
+    public sealed partial class PlacementOverlayComponent : Component
+    {        /// <summary>
+             ///     A SpriteSpecifier that will be used while in placement mode for this prototype
+             /// </summary>
+        [DataField(readOnly: true, required: true)] public SpriteSpecifier sprite;
+    }
+}

--- a/Robust.Shared/Placement/PlacementOverlayComponent.cs
+++ b/Robust.Shared/Placement/PlacementOverlayComponent.cs
@@ -1,6 +1,7 @@
 using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Utility;
+using System.Numerics;
 
 namespace Robust.Shared.Placement;
 
@@ -14,4 +15,14 @@ public sealed partial class PlacementOverlayComponent : Component
     ///     Specific sprite for the placement overlay.
     /// </summary>
     [DataField(readOnly: true, required: true)] public SpriteSpecifier Sprite;
+
+    /// <summary>
+    ///     Whether the placement overlay should rotate (default: false).
+    /// </summary>
+    [DataField(readOnly: true)] public bool NoRotation;
+
+    /// <summary>
+    ///     Scaling vector for the placement overlay (default: Vector2.One).
+    /// </summary>
+    [DataField(readOnly: true)] public Vector2 Scale = Vector2.One;
 }


### PR DESCRIPTION
## Rationale

The current Placement system is handling the placement overlay pretty straightforward : when entering placement mode the global placement overlay entity's sprite is generated from the associated prototype.

Content systems that needs more (construction, pipe layering, etc) can hijack the engine placement system to change its default behavior, but there's no way to change the Sandbox/Mapping native placement behavior.

While this is pretty often enough, situations arise when that limitation becomes problematic : for example, turnstiles can be a pain to place correctly because the default icon/sprite is used (while there are specific sprites showing the turnstill orientation that could be better used in placement mode).

## What's proposed here

This PR propose a basic system to allows using a specific sprite on placement mode for a given prototype :

* a new optional `placementOverlaySprite` field is added to `SpriteComponent` (could be its own component too), specifying a RSI/State texture.
* if that field is set, the placement system is slightly modified to use this specific texture when building the placement overlay.

## Showcase

Placing turnstills on Sandbox mode, using forementioned sprites for placement overlay :


https://github.com/user-attachments/assets/dcf27efe-9c59-4a4a-89fa-4bbab6f3cbf3


Adapting the (content) construction system to use this feature :

https://github.com/user-attachments/assets/f776a126-a8e5-48a8-a78a-bf833b08d60a


