### PR TITLE
Fix VRAM leak in MapChunk edge rendering

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
@@ -405,12 +405,10 @@ namespace Robust.Client.Graphics.Clyde
         private void DeleteChunk(MapChunkData data)
         {
             DeleteVertexArray(data.VAO);
-            CheckGlError();
             data.VBO.Delete();
             data.EBO.Delete();
 
             DeleteVertexArray(data.EdgeVAO);
-            CheckGlError();
             data.EdgeVBO.Delete();
             data.EdgeEBO.Delete();
         }

--- a/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
@@ -405,10 +405,12 @@ namespace Robust.Client.Graphics.Clyde
         private void DeleteChunk(MapChunkData data)
         {
             DeleteVertexArray(data.VAO);
+            CheckGlError();
             data.VBO.Delete();
             data.EBO.Delete();
 
             DeleteVertexArray(data.EdgeVAO);
+            CheckGlError();
             data.EdgeVBO.Delete();
             data.EdgeEBO.Delete();
         }

--- a/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
@@ -408,6 +408,11 @@ namespace Robust.Client.Graphics.Clyde
             CheckGlError();
             data.VBO.Delete();
             data.EBO.Delete();
+
+            DeleteVertexArray(data.EdgeVAO);
+            CheckGlError();
+            data.EdgeVBO.Delete();
+            data.EdgeEBO.Delete();
         }
 
         private void _updateTileMapOnUpdate(ref TileChangedEvent args)


### PR DESCRIPTION
When deleting a map chunk, the `DeleteChunk` method in `Clyde.GridRendering.cs` frees the main `VAO`/`VBO`/`EBO` but does not free `EdgeVAO`/ `EdgeVBO`/`EdgeEBO` which leads to a VRAM leak.
Just added the deletion of these objects.
