### PR TITLE
Refactor ComponentRegistry to encourage correct usage.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,11 +35,19 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+- Engine has a new `ComponentFilter` type, which name conflicts with the one currently in content.
+  Content maintainers should apply [this patch](https://github.com/space-wizards/space-station-14/pull/43168).
+- `ComponentRegistry` no longer inherits directly from Dictionary, and only provides a subset of the dictionary API
+  that was necessary to get the Space Station 14 Wizard's Den content package compiling. All Dictionary methods are
+  additionally obsolete, and you should consult `ComponentRegistry`'s documentation and method list for replacements.
+- `IEntityLoadContext` has new required methods that take an `IComponentFactory`.
 
 ### New features
 
-*None yet*
+- Introduces `ComponentFilter`, a set of components that can be used with various filter methods on `IEntityManager`.
+  Please consult the documentation for the type, alongside `IEntityManager.Filters.cs`, for the full set of new features.
+- `ComponentRegistry` now provides an improved API that does not require users manually insert components into the
+  dictionary. Consult the documentation for the type for the full feature list.
 
 ### Bugfixes
 
@@ -47,11 +55,17 @@ END TEMPLATE-->
 
 ### Other
 
-*None yet*
+- `void AddComponents(EntityUid target, EntityPrototype prototype, bool removeExisting = true)` and
+  `void RemoveComponents(EntityUid target, EntityPrototype prototype)` were marked obsolete and will be removed without
+  replacement. Using EntityPrototype as a filter and registry is not supported. Additionally,
+  the former API has never functioned correctly with `removeExisting: true` and that functionality is not supported.
+- `void RemoveComponents(EntityUid target, ComponentRegistry registry)` is now obsolete and a ComponentFilter solution
+  should be used instead.
+- `CompRegistryEntityEnumerator` is now obsolete in favor of `ComponentFilterQuery`.
 
 ### Internal
 
-*None yet*
+- `ComponentRegistry`-dependant surfaces in the engine have been rewritten to use the new methods wherever possible.
 
 
 ## 274.0.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,18 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-- `EntityQuery<TComp1>` now implements `IEnumerable<Entity<TComp1>>` and can be used with `foreach` performantly.
-- `EntityQuery<TComp1, TComp2>`, `EntityQuery<TComp1, TComp2, TComp3>`, and `EntityQuery<TComp1, TComp2, TComp3, TComp4>`
-  have been added and implement `IEnumerable`.
-  <br/><br/>
-  They're direct counterparts to `EntityQuery<TComp1>` with similar methods and constructors.
-  Additionally, like `EntityQuery<TComp1>`, all of these types can be resolved with a `[Dependency]` in systems.
-- `DynamicEntityQuery` has been added. It implements component queries for an unbounded set of components, with the
-  ability to mark the presence of specific components as optional (may be null) or excluded (query doesn't match
-  entities with that component).
-  <br/><br/>
-  It is currently primarily an implementation detail of `EntityQuery<>` but can be used directly and will lead to
-  expanded functionality in the future.
+*None yet*
 
 ### Bugfixes
 
@@ -58,12 +47,7 @@ END TEMPLATE-->
 
 ### Other
 
-- `EntityQueryEnumerator<TComp1>`, `EntityQueryEnumerator<TComp1, TComp2>`, `EntityQueryEnumerator<TComp1, TComp2, TComp3>`,
-  `EntityQueryEnumerator<TComp1, TComp2, TComp3, TComp4>`, `AllEntityQueryEnumerator<TComp1>`, `AllEntityQueryEnumerator<TComp1, TComp2>`,
-  `AllEntityQueryEnumerator<TComp1, TComp2, TComp3>`, `AllEntityQueryEnumerator<TComp1, TComp2, TComp3, TComp4>`,
-  and `ComponentQueryEnumerator` are now obsolete.
-- The EntityManager methods `EntityQuery<TComp1>`, `EntityQuery<TComp1, TComp2>`, `EntityQuery<TComp1, TComp2, TComp3>`,
-  and `EntityQuery<TComp1, TComp2, TComp3, TComp4>` are now obsolete.
+*None yet*
 
 ### Internal
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,18 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+- `EntityQuery<TComp1>` now implements `IEnumerable<Entity<TComp1>>` and can be used with `foreach` performantly.
+- `EntityQuery<TComp1, TComp2>`, `EntityQuery<TComp1, TComp2, TComp3>`, and `EntityQuery<TComp1, TComp2, TComp3, TComp4>`
+  have been added and implement `IEnumerable`.
+  <br/><br/>
+  They're direct counterparts to `EntityQuery<TComp1>` with similar methods and constructors.
+  Additionally, like `EntityQuery<TComp1>`, all of these types can be resolved with a `[Dependency]` in systems.
+- `DynamicEntityQuery` has been added. It implements component queries for an unbounded set of components, with the
+  ability to mark the presence of specific components as optional (may be null) or excluded (query doesn't match
+  entities with that component).
+  <br/><br/>
+  It is currently primarily an implementation detail of `EntityQuery<>` but can be used directly and will lead to
+  expanded functionality in the future.
 
 ### Bugfixes
 
@@ -47,7 +58,12 @@ END TEMPLATE-->
 
 ### Other
 
-*None yet*
+- `EntityQueryEnumerator<TComp1>`, `EntityQueryEnumerator<TComp1, TComp2>`, `EntityQueryEnumerator<TComp1, TComp2, TComp3>`,
+  `EntityQueryEnumerator<TComp1, TComp2, TComp3, TComp4>`, `AllEntityQueryEnumerator<TComp1>`, `AllEntityQueryEnumerator<TComp1, TComp2>`,
+  `AllEntityQueryEnumerator<TComp1, TComp2, TComp3>`, `AllEntityQueryEnumerator<TComp1, TComp2, TComp3, TComp4>`,
+  and `ComponentQueryEnumerator` are now obsolete.
+- The EntityManager methods `EntityQuery<TComp1>`, `EntityQuery<TComp1, TComp2>`, `EntityQuery<TComp1, TComp2, TComp3>`,
+  and `EntityQuery<TComp1, TComp2, TComp3, TComp4>` are now obsolete.
 
 ### Internal
 

--- a/Robust.Shared.IntegrationTests/GameObjects/EntityManagerFilterTests.cs
+++ b/Robust.Shared.IntegrationTests/GameObjects/EntityManagerFilterTests.cs
@@ -6,7 +6,9 @@ using Robust.Shared.Serialization.Manager;
 
 namespace Robust.UnitTesting.Shared.GameObjects;
 
-[TestFixture, TestOf(typeof(EntityManager))]
+[TestFixture]
+[TestOf(typeof(EntityManager))]
+[TestOf(typeof(ComponentFilter))]
 internal sealed class EntityManagerFilterTests : OurRobustUnitTest
 {
     private const string TestEnt1 = "T_TestEnt1";
@@ -43,7 +45,8 @@ internal sealed class EntityManagerFilterTests : OurRobustUnitTest
     }
 
     [Test]
-    public void FilterEnt(
+    [TestOf(typeof(ComponentFilterQuery))]
+    public void FilterEntities(
         [Values(null, typeof(Marker1Component))]
         Type? m1,
         [Values(null, typeof(Marker2Component))]

--- a/Robust.Shared.IntegrationTests/GameObjects/EntityManagerFilterTests.cs
+++ b/Robust.Shared.IntegrationTests/GameObjects/EntityManagerFilterTests.cs
@@ -6,7 +6,6 @@ using Robust.Shared.Serialization.Manager;
 
 namespace Robust.UnitTesting.Shared.GameObjects;
 
-[TestFixture]
 [TestOf(typeof(EntityManager))]
 [TestOf(typeof(ComponentFilter))]
 internal sealed class EntityManagerFilterTests : OurRobustUnitTest
@@ -46,6 +45,10 @@ internal sealed class EntityManagerFilterTests : OurRobustUnitTest
 
     [Test]
     [TestOf(typeof(ComponentFilterQuery))]
+    [Description("""
+    Tests that filters work against some test targets with various permutations of components.
+    Covers MatchesFilter, ExactlyMatchesFilter, and ComponentFilterQuery.
+    """)]
     public void FilterEntities(
         [Values(null, typeof(Marker1Component))]
         Type? m1,
@@ -67,6 +70,7 @@ internal sealed class EntityManagerFilterTests : OurRobustUnitTest
 
             Assert.That(_entMan.MatchesFilter(target.Value, filter));
 
+            // If there's four entries, then it should be an exact match.
             if (filter.Count == 4)
                 Assert.That(_entMan.ExactlyMatchesFilter(target.Value, filter));
             else
@@ -87,6 +91,7 @@ internal sealed class EntityManagerFilterTests : OurRobustUnitTest
     }
 
     [Test]
+    [Description("Asserts that using FillMissesWithNewComponents should make the entity match the filter afterward.")]
     public void FillMisses(
         [Values(null, typeof(Marker1Component))]
         Type? m1,
@@ -114,6 +119,10 @@ internal sealed class EntityManagerFilterTests : OurRobustUnitTest
     }
 
     [Test]
+    [Description("""
+    Tests the various component-set operations, on a full (all markers) and empty (no markers) entity.
+    Ensures an edge case in EnumerateEntityMisses (xform and metadata existing) is present.
+    """)]
     public void EnumerateFilterHits(
         [Values(null, typeof(Marker1Component))]
         Type? m1,
@@ -133,11 +142,18 @@ internal sealed class EntityManagerFilterTests : OurRobustUnitTest
 
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(_entMan.EnumerateFilterHits(target, filter), NUnit.Framework.Is.EquivalentTo(filter));
-                Assert.That(_entMan.EnumerateFilterMisses(target, filter), NUnit.Framework.Is.Empty);
-                Assert.That(_entMan.EnumerateFilterMisses(target2, filter), NUnit.Framework.Is.EquivalentTo(filter));
+                Assert.That(_entMan.EnumerateFilterHits(target, filter),
+                    NUnit.Framework.Is.EquivalentTo(filter),
+                    "Expected the test entity with all markers to match the filter and the resulting set intersection to match as well.");
+                Assert.That(_entMan.EnumerateFilterMisses(target, filter),
+                    NUnit.Framework.Is.Empty,
+                    "Expected there to be no misses on an entity with every marker that can be in the filter.");
+                Assert.That(_entMan.EnumerateFilterMisses(target2, filter),
+                    NUnit.Framework.Is.EquivalentTo(filter),
+                    "Expected every item in the filter to miss on an entity with no markers.");
                 Assert.That(_entMan.EnumerateEntityMisses(target2, filter),
-                    NUnit.Framework.Is.EquivalentTo([typeof(MetaDataComponent), typeof(TransformComponent)]));
+                    NUnit.Framework.Is.EquivalentTo([typeof(MetaDataComponent), typeof(TransformComponent)]),
+                    "Expected the entity to have two components the filter does not, transform and metadata.");
             }
         }
         finally

--- a/Robust.Shared.IntegrationTests/GameObjects/EntityManagerFilterTests.cs
+++ b/Robust.Shared.IntegrationTests/GameObjects/EntityManagerFilterTests.cs
@@ -1,0 +1,132 @@
+using NUnit.Framework;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.Manager;
+
+namespace Robust.UnitTesting.Shared.GameObjects;
+
+[TestFixture, TestOf(typeof(EntityManager))]
+internal sealed class EntityManagerFilterTests : OurRobustUnitTest
+{
+    private const string TestEnt1 = "T_TestEnt1";
+
+    private const string Prototypes = $"""
+        - type: entity
+          id: {TestEnt1}
+          components:
+          - type: Marker1
+          - type: Marker2
+          - type: Marker3
+          - type: Marker4
+        """;
+
+    protected override Type[]? ExtraComponents =>
+    [
+        typeof(Marker1Component), typeof(Marker2Component), typeof(Marker3Component), typeof(Marker4Component)
+    ];
+
+    private PrototypeManager _protoMan = default!;
+    private IEntityManager _entMan = default!;
+
+    [OneTimeSetUp]
+    public void Setup()
+    {
+        IoCManager.Resolve<ISerializationManager>().Initialize();
+
+        _protoMan = (PrototypeManager) IoCManager.Resolve<IPrototypeManager>();
+        _protoMan.RegisterKind(typeof(EntityPrototype), typeof(EntityCategoryPrototype));
+        _protoMan.LoadString(Prototypes);
+        _protoMan.ResolveResults();
+
+        _entMan = IoCManager.Resolve<IEntityManager>();
+    }
+
+    [Test]
+    public void FilterEnt(
+        [Values(null, typeof(Marker1Component))]
+        Type? m1,
+        [Values(null, typeof(Marker2Component))]
+        Type? m2,
+        [Values(null, typeof(Marker3Component))]
+        Type? m3,
+        [Values(null, typeof(Marker4Component))]
+        Type? m4
+        )
+    {
+        EntityUid? target = null;
+        EntityUid? target2 = null;
+        try
+        {
+            var filter = new ComponentFilter(new [] {m1, m2, m3, m4}.Where(x => x is not null).Cast<Type>());
+
+            target = _entMan.Spawn(TestEnt1);
+
+            Assert.That(_entMan.MatchesFilter(target.Value, filter));
+
+            if (filter.Count == 4)
+                Assert.That(_entMan.ExactlyMatchesFilter(target.Value, filter));
+            else
+                Assert.That(_entMan.ExactlyMatchesFilter(target.Value, filter), NUnit.Framework.Is.False);
+
+            var query = _entMan.ComponentFilterQuery(filter);
+            Assert.That(query.Count(), NUnit.Framework.Is.EqualTo(1));
+
+            target2 = _entMan.Spawn(TestEnt1);
+
+            Assert.That(query.Count(), NUnit.Framework.Is.EqualTo(2));
+        }
+        finally
+        {
+            _entMan.DeleteEntity(target);
+            _entMan.DeleteEntity(target2);
+        }
+    }
+
+    [Test]
+    public void FillMisses(
+        [Values(null, typeof(Marker1Component))]
+        Type? m1,
+        [Values(null, typeof(Marker2Component))]
+        Type? m2,
+        [Values(null, typeof(Marker3Component))]
+        Type? m3,
+        [Values(null, typeof(Marker4Component))]
+        Type? m4
+    )
+    {
+        var target = _entMan.Spawn();
+        try
+        {
+            var filter = new ComponentFilter(new [] {m1, m2, m3, m4}.Where(x => x is not null).Cast<Type>());
+
+            _entMan.FillMissesWithNewComponents(target, filter);
+
+            Assert.That(_entMan.MatchesFilter(target, filter));
+        }
+        finally
+        {
+            _entMan.DeleteEntity(target);
+        }
+    }
+}
+
+internal sealed partial class Marker1Component : Component
+{
+
+}
+
+internal sealed partial class Marker2Component : Component
+{
+
+}
+
+internal sealed partial class Marker3Component : Component
+{
+
+}
+
+internal sealed partial class Marker4Component : Component
+{
+
+}

--- a/Robust.Shared.IntegrationTests/GameObjects/EntityManagerFilterTests.cs
+++ b/Robust.Shared.IntegrationTests/GameObjects/EntityManagerFilterTests.cs
@@ -112,6 +112,41 @@ internal sealed class EntityManagerFilterTests : OurRobustUnitTest
             _entMan.DeleteEntity(target);
         }
     }
+
+    [Test]
+    public void EnumerateFilterHits(
+        [Values(null, typeof(Marker1Component))]
+        Type? m1,
+        [Values(null, typeof(Marker2Component))]
+        Type? m2,
+        [Values(null, typeof(Marker3Component))]
+        Type? m3,
+        [Values(null, typeof(Marker4Component))]
+        Type? m4
+    )
+    {
+        var target = _entMan.Spawn(TestEnt1);
+        var target2 = _entMan.Spawn();
+        try
+        {
+            var filter = new ComponentFilter(new [] {m1, m2, m3, m4}.Where(x => x is not null).Cast<Type>());
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(_entMan.EnumerateFilterHits(target, filter), NUnit.Framework.Is.EquivalentTo(filter));
+                Assert.That(_entMan.EnumerateFilterMisses(target, filter), NUnit.Framework.Is.Empty);
+                Assert.That(_entMan.EnumerateFilterMisses(target2, filter), NUnit.Framework.Is.EquivalentTo(filter));
+                Assert.That(_entMan.EnumerateEntityMisses(target2, filter),
+                    NUnit.Framework.Is.EquivalentTo([typeof(MetaDataComponent), typeof(TransformComponent)]));
+            }
+        }
+        finally
+        {
+            _entMan.DeleteEntity(target);
+            _entMan.DeleteEntity(target2);
+        }
+    }
+
 }
 
 internal sealed partial class Marker1Component : Component

--- a/Robust.Shared.IntegrationTests/Serialization/TypeSerializers/ComponentRegistrySerializerTest.cs
+++ b/Robust.Shared.IntegrationTests/Serialization/TypeSerializers/ComponentRegistrySerializerTest.cs
@@ -25,7 +25,7 @@ namespace Robust.UnitTesting.Shared.Serialization.TypeSerializers
         public void SerializationTest()
         {
             var component = new TestComponent();
-            var registry = new ComponentRegistry {{"Test", new ComponentRegistryEntry(component, new MappingDataNode())}};
+            var registry = new ComponentRegistry(new Dictionary<string, ComponentRegistryEntry>() {{"Test", new ComponentRegistryEntry(component, new MappingDataNode())}});
             var node = Serialization.WriteValueAs<SequenceDataNode>(registry);
 
             Assert.That(node.Sequence.Count, Is.EqualTo(1));

--- a/Robust.Shared/EntitySerialization/EntityDeserializer.cs
+++ b/Robust.Shared/EntitySerialization/EntityDeserializer.cs
@@ -617,7 +617,7 @@ public sealed class EntityDeserializer :
                 }
 
                 var datanode = compData;
-                if (proto != null && proto.Components.TryGetEntry(name, out var protoData))
+                if (proto != null && proto.Components.TryGetEntry(_factory, name, out var protoData))
                     datanode = protoData?.Mapping is not null ? _seriMan.CombineMappings(compData, protoData.Mapping!) : compData;
 
                 _components.Add(name, datanode);

--- a/Robust.Shared/EntitySerialization/EntityDeserializer.cs
+++ b/Robust.Shared/EntitySerialization/EntityDeserializer.cs
@@ -617,8 +617,8 @@ public sealed class EntityDeserializer :
                 }
 
                 var datanode = compData;
-                if (proto != null && proto.Components.TryGetValue(name, out var protoData))
-                    datanode = _seriMan.CombineMappings(compData, protoData.Mapping);
+                if (proto != null && proto.Components.TryGetEntry(name, out var protoData))
+                    datanode = protoData?.Mapping is not null ? _seriMan.CombineMappings(compData, protoData.Mapping!) : compData;
 
                 _components.Add(name, datanode);
             }

--- a/Robust.Shared/EntitySerialization/EntityDeserializer.cs
+++ b/Robust.Shared/EntitySerialization/EntityDeserializer.cs
@@ -628,7 +628,7 @@ public sealed class EntityDeserializer :
         // that component from the map file
         if (proto != null)
         {
-            foreach (var (name, entry) in proto.Components)
+            foreach (var (name, toClone) in proto.Components.ComponentsAndNames(_factory))
             {
                 if (missingComps != null && missingComps.Contains(name))
                     continue;
@@ -646,9 +646,9 @@ public sealed class EntityDeserializer :
                     component = newComponent;
                 }
 
-                _seriMan.CopyTo(entry.Component, ref component, this, notNullableOverride: true);
+                _seriMan.CopyTo(toClone, ref component, this, notNullableOverride: true);
 
-                if (!entry.Component.NetSyncEnabled && compReg.NetID is { } netId)
+                if (!toClone.NetSyncEnabled && compReg.NetID is { } netId)
                     meta.NetComponents.Remove(netId);
             }
         }

--- a/Robust.Shared/EntitySerialization/EntityDeserializer.cs
+++ b/Robust.Shared/EntitySerialization/EntityDeserializer.cs
@@ -1003,7 +1003,7 @@ public sealed class EntityDeserializer :
                 continue;
             }
 
-            if (prototype.Components.ContainsKey(compName))
+            if (prototype.Components.ContainsComponentByName(_factory, compName))
             {
                 // This component is modified by the map so we have to send state.
                 // Though it's still in the prototype itself so creation doesn't need to be sent.

--- a/Robust.Shared/GameObjects/ComponentExtensions.cs
+++ b/Robust.Shared/GameObjects/ComponentExtensions.cs
@@ -1,0 +1,17 @@
+namespace Robust.Shared.GameObjects;
+
+public static class ComponentExtensions
+{
+    extension<T>(T comp)
+        where T : IComponent
+    {
+        /// <summary>
+        ///     Checks if a component is "attached" and in use by the game simulation.
+        ///     Unattached components are data (i.e. in prototypes).
+        /// </summary>
+        public bool IsUnattached()
+        {
+            return comp.LifeStage == ComponentLifeStage.PreAdd;
+        }
+    }
+}

--- a/Robust.Shared/GameObjects/ComponentFilterQuery.cs
+++ b/Robust.Shared/GameObjects/ComponentFilterQuery.cs
@@ -1,0 +1,116 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Robust.Shared.GameObjects;
+
+/// <summary>
+///     A cacheable query for every entity that fulfills <see cref="IEntityManager.MatchesFilter"/>.
+///     This provides both iteration through <see cref="IEnumerable{T}"/>, and also direct queries through <see cref="Matches"/>.
+/// </summary>
+/// <remarks>
+///     Unlike <see cref="EntityQueryEnumerator{TComp1}"/> you can in fact just use foreach with this. It's fine!
+///     A concrete implementation of <see cref="GetEnumerator"/> is provided, so the compiler knows how to optimize it.
+/// </remarks>
+public readonly struct ComponentFilterQuery : IEnumerable<EntityUid>
+{
+    private readonly Dictionary<EntityUid, IComponent> _lead;
+    private readonly Dictionary<EntityUid, IComponent>[] _tails;
+
+    internal ComponentFilterQuery(Dictionary<EntityUid, IComponent> lead, Dictionary<EntityUid, IComponent>[] tails)
+    {
+        _lead = lead;
+        _tails = tails;
+    }
+
+    /// <summary>
+    ///     Tests if an entity matches this query.
+    /// </summary>
+    /// <param name="ent">The entity to test against.</param>
+    /// <returns>True on match, false otherwise.</returns>
+    public bool Matches(EntityUid ent)
+    {
+        if (!_lead.TryGetValue(ent, out var c1) || c1.Deleted)
+            return false;
+
+        foreach (var tail in _tails)
+        {
+            if (!tail.TryGetValue(ent, out c1) || c1.Deleted)
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    ///     Returns an enumerator for this query.
+    /// </summary>
+    /// <returns></returns>
+    public Enumerator GetEnumerator()
+    {
+        return new Enumerator(this);
+    }
+
+    IEnumerator<EntityUid> IEnumerable<EntityUid>.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    public struct Enumerator : IEnumerator<EntityUid>
+    {
+        private readonly ComponentFilterQuery _query;
+        private Dictionary<EntityUid, IComponent>.Enumerator _leadEnumerator;
+        private EntityUid _current;
+
+        internal Enumerator(ComponentFilterQuery query) : this()
+        {
+            _query = query;
+            Reset();
+        }
+
+        public bool MoveNext()
+        {
+            // Loop until we find something that matches every tail.
+            while (true)
+            {
+                if (!_leadEnumerator.MoveNext())
+                    return false;
+
+                var (workingEnt, c1) = _leadEnumerator.Current;
+                if (c1.Deleted)
+                    continue;
+
+                foreach (var tail in _query._tails)
+                {
+                    if ((!tail.TryGetValue(workingEnt, out var c2)) || c2.Deleted)
+                        goto end; // Retry. We can't continue the outer loop from here easily so goto it is.
+                }
+
+                _current = workingEnt;
+                break;
+
+                end: ;
+            }
+
+            return true;
+        }
+
+        public void Reset()
+        {
+            _leadEnumerator = _query._lead.GetEnumerator();
+        }
+
+        EntityUid IEnumerator<EntityUid>.Current => _current;
+
+        object IEnumerator.Current => _current;
+
+        public void Dispose()
+        {
+            _leadEnumerator.Dispose();
+        }
+    }
+}

--- a/Robust.Shared/GameObjects/ComponentFilterQuery.cs
+++ b/Robust.Shared/GameObjects/ComponentFilterQuery.cs
@@ -13,13 +13,17 @@ namespace Robust.Shared.GameObjects;
 /// </remarks>
 public readonly struct ComponentFilterQuery : IEnumerable<EntityUid>
 {
+    private readonly Dictionary<EntityUid, IComponent> _metaData;
     private readonly Dictionary<EntityUid, IComponent> _lead;
     private readonly Dictionary<EntityUid, IComponent>[] _tails;
+    private readonly bool _matchPaused;
 
-    internal ComponentFilterQuery(Dictionary<EntityUid, IComponent> lead, Dictionary<EntityUid, IComponent>[] tails)
+    internal ComponentFilterQuery(Dictionary<EntityUid, IComponent> metaData, Dictionary<EntityUid, IComponent> lead, Dictionary<EntityUid, IComponent>[] tails, bool matchPaused)
     {
+        _metaData = metaData;
         _lead = lead;
         _tails = tails;
+        _matchPaused = matchPaused;
     }
 
     /// <summary>
@@ -30,6 +34,9 @@ public readonly struct ComponentFilterQuery : IEnumerable<EntityUid>
     public bool Matches(EntityUid ent)
     {
         if (!_lead.TryGetValue(ent, out var c1) || c1.Deleted)
+            return false;
+
+        if (!_matchPaused && ((MetaDataComponent)_metaData[ent]).EntityPaused)
             return false;
 
         foreach (var tail in _tails)
@@ -82,6 +89,9 @@ public readonly struct ComponentFilterQuery : IEnumerable<EntityUid>
 
                 var (workingEnt, c1) = _leadEnumerator.Current;
                 if (c1.Deleted)
+                    continue;
+
+                if (!_query._matchPaused && ((MetaDataComponent)_query._metaData[workingEnt]).EntityPaused)
                     continue;
 
                 foreach (var tail in _query._tails)

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -231,9 +231,9 @@ namespace Robust.Shared.GameObjects
 
             var metadata = MetaQuery.GetComponent(target);
 
-            foreach (var entry in registry.Values)
+            foreach (var entry in registry.Components())
             {
-                RemoveComponent(target, entry.Component.GetType(), metadata);
+                RemoveComponent(target, entry.GetType(), metadata);
             }
         }
 

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -35,6 +35,7 @@ namespace Robust.Shared.GameObjects
         private const int ComponentCollectionCapacity = 1024;
         private const int EntityCapacity = 1024;
         private const int NetComponentCapacity = 8;
+        private static readonly Dictionary<EntityUid, IComponent> EmptyTraitDict = new();
 
         private FrozenDictionary<Type, Dictionary<EntityUid, IComponent>> _entTraitDict
             = FrozenDictionary<Type, Dictionary<EntityUid, IComponent>>.Empty;

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -1388,6 +1388,7 @@ namespace Robust.Shared.GameObjects
         }
 
         /// <inheritdoc />
+        [Obsolete($"Use {nameof(ComponentFilterQuery)} instead.")]
         public CompRegistryEntityEnumerator CompRegistryQueryEnumerator(ComponentRegistry registry)
         {
             if (registry.Count == 0)

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -193,14 +193,14 @@ namespace Robust.Shared.GameObjects
 
             var metadata = MetaQuery.GetComponent(target);
 
-            foreach (var (name, entry) in registry)
+            foreach (var srcComp in registry.Components())
             {
-                var reg = _componentFactory.GetRegistration(name);
+                var reg = _componentFactory.GetRegistration(srcComp);
 
                 if (removeExisting)
                 {
                     var comp = _componentFactory.GetComponent(reg);
-                    _serManager.CopyTo(entry.Component, ref comp, notNullableOverride: true);
+                    _serManager.CopyTo(srcComp, ref comp, notNullableOverride: true);
                     AddComponentInternal(target, comp, reg, overwrite: true, metadata: metadata);
                 }
                 else
@@ -211,7 +211,7 @@ namespace Robust.Shared.GameObjects
                     }
 
                     var comp = _componentFactory.GetComponent(reg);
-                    _serManager.CopyTo(entry.Component, ref comp, notNullableOverride: true);
+                    _serManager.CopyTo(srcComp, ref comp, notNullableOverride: true);
                     AddComponentInternal(target, comp, reg, overwrite: false, metadata: metadata);
                 }
             }

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -2101,6 +2101,7 @@ namespace Robust.Shared.GameObjects
     /// <summary>
     /// Returns entities that match the ComponentRegistry.
     /// </summary>
+    [Obsolete($"Use {nameof(ComponentFilterQuery)} instead.")]
     public struct CompRegistryEntityEnumerator : IDisposable
     {
         private IEntityManager _entManager;

--- a/Robust.Shared/GameObjects/EntityManager.Filters.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Filters.cs
@@ -6,7 +6,7 @@ namespace Robust.Shared.GameObjects;
 
 public abstract partial class EntityManager
 {
-    public bool MatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = false)
+    public bool MatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = true)
     {
         if (!matchPaused && IsPaused(ent))
             return false;
@@ -20,7 +20,21 @@ public abstract partial class EntityManager
         return true;
     }
 
-    public bool ExactlyMatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = false)
+    public bool AnyMatchingComponent(EntityUid ent, ComponentFilter filter, bool matchPaused = true)
+    {
+        if (!matchPaused && IsPaused(ent))
+            return false;
+
+        foreach (var comp in filter)
+        {
+            if (HasComponent(ent, comp))
+                return true;
+        }
+
+        return false;
+    }
+
+    public bool ExactlyMatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = true)
     {
         if (!matchPaused && IsPaused(ent))
             return false;

--- a/Robust.Shared/GameObjects/EntityManager.Filters.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Filters.cs
@@ -6,11 +6,8 @@ namespace Robust.Shared.GameObjects;
 
 public abstract partial class EntityManager
 {
-    public bool MatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = true)
+    public bool MatchesFilter(EntityUid ent, ComponentFilter filter)
     {
-        if (!matchPaused && IsPaused(ent))
-            return false;
-
         foreach (var comp in filter)
         {
             if (!HasComponent(ent, comp))
@@ -20,11 +17,8 @@ public abstract partial class EntityManager
         return true;
     }
 
-    public bool AnyMatchingComponent(EntityUid ent, ComponentFilter filter, bool matchPaused = true)
+    public bool AnyMatchingComponent(EntityUid ent, ComponentFilter filter)
     {
-        if (!matchPaused && IsPaused(ent))
-            return false;
-
         foreach (var comp in filter)
         {
             if (HasComponent(ent, comp))
@@ -34,11 +28,8 @@ public abstract partial class EntityManager
         return false;
     }
 
-    public bool ExactlyMatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = true)
+    public bool ExactlyMatchesFilter(EntityUid ent, ComponentFilter filter)
     {
-        if (!matchPaused && IsPaused(ent))
-            return false;
-
         foreach (var comp in _entCompIndex[ent])
         {
             if (comp.Deleted)

--- a/Robust.Shared/GameObjects/EntityManager.Filters.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Filters.cs
@@ -24,6 +24,9 @@ public abstract partial class EntityManager
             if (comp.Deleted)
                 continue;
 
+            if (comp is MetaDataComponent or TransformComponent)
+                continue;
+
             if (!filter.Contains(comp.GetType()))
                 return false;
         }
@@ -95,8 +98,14 @@ public abstract partial class EntityManager
         }
     }
 
-    public ComponentFilterQuery ConstructFilterQuery(ComponentFilter filter)
+    public ComponentFilterQuery ComponentFilterQuery(ComponentFilter filter)
     {
+        if (filter.Count == 0)
+        {
+            // Iterate everything, all entities match.
+            return new ComponentFilterQuery(_entTraitDict[typeof(MetaDataComponent)], []);
+        }
+
         var tailCount = filter.Count - 1;
         var tails = new Dictionary<EntityUid, IComponent>[tailCount];
 

--- a/Robust.Shared/GameObjects/EntityManager.Filters.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Filters.cs
@@ -131,4 +131,24 @@ public abstract partial class EntityManager
 
         return new ComponentFilterQuery(meta, lead!, tails, matchPaused);
     }
+
+    public bool RemoveComponents(EntityUid target, ComponentFilter filter)
+    {
+        var didWork = false;
+
+        foreach (var c in filter)
+        {
+            didWork |= RemoveComponent(target, c);
+        }
+
+        return didWork;
+    }
+
+    public bool RemoveComponentsExact(EntityUid target, ComponentFilter filter)
+    {
+        if (!MatchesFilter(target, filter))
+            return false; // Do nothing
+
+        return RemoveComponents(target, filter);
+    }
 }

--- a/Robust.Shared/GameObjects/EntityManager.Filters.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Filters.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using Robust.Shared.Prototypes;
+
+namespace Robust.Shared.GameObjects;
+
+public abstract partial class EntityManager
+{
+    public bool MatchesFilter(EntityUid ent, ComponentFilter filter)
+    {
+        foreach (var comp in filter)
+        {
+            if (!HasComponent(ent, comp))
+                return false;
+        }
+
+        return true;
+    }
+
+    public bool ExactlyMatchesFilter(EntityUid ent, ComponentFilter filter)
+    {
+        foreach (var comp in _entCompIndex[ent])
+        {
+            if (comp.Deleted)
+                continue;
+
+            if (!filter.Contains(comp.GetType()))
+                return false;
+        }
+
+        return true;
+    }
+
+    public IEnumerable<Type> EnumerateFilterMisses(EntityUid ent, ComponentFilter filter)
+    {
+        foreach (var comp in filter)
+        {
+            if (!HasComponent(ent, comp))
+                yield return comp;
+        }
+    }
+
+    public IEnumerable<Type> EnumerateEntityMisses(EntityUid ent, ComponentFilter filter)
+    {
+        foreach (var comp in _entCompIndex[ent])
+        {
+            if (comp.Deleted)
+                continue;
+
+            var ty = comp.GetType();
+
+            if (!filter.Contains(ty))
+                yield return ty;
+        }
+    }
+
+    public IEnumerable<Type> EnumerateFilterHits(EntityUid ent, ComponentFilter filter)
+    {
+        foreach (var comp in filter)
+        {
+            if (HasComponent(ent, comp))
+                yield return comp;
+        }
+    }
+
+    public void FillMissesFromRegistry(EntityUid ent, ComponentFilter filter, ComponentRegistry registry)
+    {
+        var meta = MetaQuery.GetComponent(ent);
+
+        foreach (var comp in filter)
+        {
+            if (!HasComponent(ent, comp))
+            {
+                if (!registry.TryGetComponent(_componentFactory, comp, out var toClone))
+                    throw new InvalidOperationException(
+                        $"Tried to fill in a missing component, {comp}, from a registry, but couldn't find it.");
+
+                AddComponent(ent, new EntityPrototype.ComponentRegistryEntry(toClone), false, meta);
+            }
+        }
+    }
+
+    public void FillMissesWithNewComponents(EntityUid ent, ComponentFilter filter)
+    {
+        var meta = MetaQuery.GetComponent(ent);
+
+        foreach (var comp in filter)
+        {
+            if (!HasComponent(ent, comp))
+            {
+                AddComponent(ent, _componentFactory.GetComponent(comp), false, meta);
+            }
+        }
+    }
+}

--- a/Robust.Shared/GameObjects/EntityManager.Filters.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Filters.cs
@@ -6,8 +6,11 @@ namespace Robust.Shared.GameObjects;
 
 public abstract partial class EntityManager
 {
-    public bool MatchesFilter(EntityUid ent, ComponentFilter filter)
+    public bool MatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = false)
     {
+        if (!matchPaused && IsPaused(ent))
+            return false;
+
         foreach (var comp in filter)
         {
             if (!HasComponent(ent, comp))
@@ -17,8 +20,11 @@ public abstract partial class EntityManager
         return true;
     }
 
-    public bool ExactlyMatchesFilter(EntityUid ent, ComponentFilter filter)
+    public bool ExactlyMatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = false)
     {
+        if (!matchPaused && IsPaused(ent))
+            return false;
+
         foreach (var comp in _entCompIndex[ent])
         {
             if (comp.Deleted)
@@ -98,12 +104,13 @@ public abstract partial class EntityManager
         }
     }
 
-    public ComponentFilterQuery ComponentFilterQuery(ComponentFilter filter)
+    public ComponentFilterQuery ComponentFilterQuery(ComponentFilter filter, bool matchPaused = false)
     {
+        var meta = _entTraitDict[typeof(MetaDataComponent)];
         if (filter.Count == 0)
         {
             // Iterate everything, all entities match.
-            return new ComponentFilterQuery(_entTraitDict[typeof(MetaDataComponent)], []);
+            return new ComponentFilterQuery(meta, meta, [], matchPaused);
         }
 
         var tailCount = filter.Count - 1;
@@ -122,6 +129,6 @@ public abstract partial class EntityManager
             }
         }
 
-        return new ComponentFilterQuery(lead!, tails);
+        return new ComponentFilterQuery(meta, lead!, tails, matchPaused);
     }
 }

--- a/Robust.Shared/GameObjects/EntityManager.Filters.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Filters.cs
@@ -72,8 +72,10 @@ public abstract partial class EntityManager
             if (!HasComponent(ent, comp))
             {
                 if (!registry.TryGetComponent(_componentFactory, comp, out var toClone))
+                {
                     throw new InvalidOperationException(
                         $"Tried to fill in a missing component, {comp}, from a registry, but couldn't find it.");
+                }
 
                 AddComponent(ent, new EntityPrototype.ComponentRegistryEntry(toClone), false, meta);
             }
@@ -91,5 +93,26 @@ public abstract partial class EntityManager
                 AddComponent(ent, _componentFactory.GetComponent(comp), false, meta);
             }
         }
+    }
+
+    public ComponentFilterQuery ConstructFilterQuery(ComponentFilter filter)
+    {
+        var tailCount = filter.Count - 1;
+        var tails = new Dictionary<EntityUid, IComponent>[tailCount];
+
+        Dictionary<EntityUid, IComponent>? lead = null;
+        var tailIdx = 0;
+
+        foreach (var entry in filter)
+        {
+            if (lead is null)
+                lead = _entTraitDict[entry];
+            else
+            {
+                tails[tailIdx++] = _entTraitDict[entry];
+            }
+        }
+
+        return new ComponentFilterQuery(lead!, tails);
     }
 }

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -1785,26 +1785,26 @@ public partial class EntitySystem
     #endregion
 
     #region Filters
-    /// <inheritdoc cref="M:Robust.Shared.GameObjects.EntityManager.MatchesFilter(Robust.Shared.GameObjects.EntityUid,Robust.Shared.Prototypes.ComponentFilter,System.Boolean)"/>
+    /// <inheritdoc cref="M:Robust.Shared.GameObjects.EntityManager.MatchesFilter(Robust.Shared.GameObjects.EntityUid,Robust.Shared.Prototypes.ComponentFilter)"/>
     [ProxyFor(typeof(EntityManager))]
-    public bool MatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = true)
+    public bool MatchesFilter(EntityUid ent, ComponentFilter filter)
     {
-        return EntityManager.MatchesFilter(ent, filter, matchPaused);
+        return EntityManager.MatchesFilter(ent, filter);
     }
 
-    /// <inheritdoc cref="M:Robust.Shared.GameObjects.EntityManager.AnyMatchingComponent(Robust.Shared.GameObjects.EntityUid,Robust.Shared.Prototypes.ComponentFilter,System.Boolean)"/>
+    /// <inheritdoc cref="M:Robust.Shared.GameObjects.EntityManager.AnyMatchingComponent(Robust.Shared.GameObjects.EntityUid,Robust.Shared.Prototypes.ComponentFilter)"/>
     [ProxyFor(typeof(EntityManager))]
-    public bool AnyMatchingComponent(EntityUid ent, ComponentFilter filter, bool matchPaused = true)
+    public bool AnyMatchingComponent(EntityUid ent, ComponentFilter filter)
     {
-        return EntityManager.AnyMatchingComponent(ent, filter, matchPaused);
+        return EntityManager.AnyMatchingComponent(ent, filter);
     }
 
 
-    /// <inheritdoc cref="M:Robust.Shared.GameObjects.EntityManager.ExactlyMatchesFilter(Robust.Shared.GameObjects.EntityUid,Robust.Shared.Prototypes.ComponentFilter,System.Boolean)"/>
+    /// <inheritdoc cref="M:Robust.Shared.GameObjects.EntityManager.ExactlyMatchesFilter(Robust.Shared.GameObjects.EntityUid,Robust.Shared.Prototypes.ComponentFilter)"/>
     [ProxyFor(typeof(EntityManager))]
-    public bool ExactlyMatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = true)
+    public bool ExactlyMatchesFilter(EntityUid ent, ComponentFilter filter)
     {
-        return EntityManager.ExactlyMatchesFilter(ent, filter, matchPaused);
+        return EntityManager.ExactlyMatchesFilter(ent, filter);
     }
 
     /// <inheritdoc cref="M:Robust.Shared.GameObjects.EntityManager.EnumerateFilterMisses(Robust.Shared.GameObjects.EntityUid,Robust.Shared.Prototypes.ComponentFilter)"/>

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -1787,14 +1787,22 @@ public partial class EntitySystem
     #region Filters
     /// <inheritdoc cref="M:Robust.Shared.GameObjects.EntityManager.MatchesFilter(Robust.Shared.GameObjects.EntityUid,Robust.Shared.Prototypes.ComponentFilter,System.Boolean)"/>
     [ProxyFor(typeof(EntityManager))]
-    public bool MatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = false)
+    public bool MatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = true)
     {
         return EntityManager.MatchesFilter(ent, filter, matchPaused);
     }
 
+    /// <inheritdoc cref="M:Robust.Shared.GameObjects.EntityManager.AnyMatchingComponent(Robust.Shared.GameObjects.EntityUid,Robust.Shared.Prototypes.ComponentFilter,System.Boolean)"/>
+    [ProxyFor(typeof(EntityManager))]
+    public bool AnyMatchingComponent(EntityUid ent, ComponentFilter filter, bool matchPaused = true)
+    {
+        return EntityManager.AnyMatchingComponent(ent, filter, matchPaused);
+    }
+
+
     /// <inheritdoc cref="M:Robust.Shared.GameObjects.EntityManager.ExactlyMatchesFilter(Robust.Shared.GameObjects.EntityUid,Robust.Shared.Prototypes.ComponentFilter,System.Boolean)"/>
     [ProxyFor(typeof(EntityManager))]
-    public bool ExactlyMatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = false)
+    public bool ExactlyMatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = true)
     {
         return EntityManager.ExactlyMatchesFilter(ent, filter, matchPaused);
     }

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -1785,41 +1785,57 @@ public partial class EntitySystem
     #endregion
 
     #region Filters
+    /// <inheritdoc cref="M:Robust.Shared.GameObjects.EntityManager.MatchesFilter(Robust.Shared.GameObjects.EntityUid,Robust.Shared.Prototypes.ComponentFilter,System.Boolean)"/>
+    [ProxyFor(typeof(EntityManager))]
     public bool MatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = false)
     {
         return EntityManager.MatchesFilter(ent, filter, matchPaused);
     }
 
+    /// <inheritdoc cref="M:Robust.Shared.GameObjects.EntityManager.ExactlyMatchesFilter(Robust.Shared.GameObjects.EntityUid,Robust.Shared.Prototypes.ComponentFilter,System.Boolean)"/>
+    [ProxyFor(typeof(EntityManager))]
     public bool ExactlyMatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = false)
     {
         return EntityManager.ExactlyMatchesFilter(ent, filter, matchPaused);
     }
 
+    /// <inheritdoc cref="M:Robust.Shared.GameObjects.EntityManager.EnumerateFilterMisses(Robust.Shared.GameObjects.EntityUid,Robust.Shared.Prototypes.ComponentFilter)"/>
+    [ProxyFor(typeof(EntityManager))]
     public IEnumerable<Type> EnumerateFilterMisses(EntityUid ent, ComponentFilter filter)
     {
         return EntityManager.EnumerateFilterMisses(ent, filter);
     }
 
+    /// <inheritdoc cref="M:Robust.Shared.GameObjects.EntityManager.EnumerateEntityMisses(Robust.Shared.GameObjects.EntityUid,Robust.Shared.Prototypes.ComponentFilter)"/>
+    [ProxyFor(typeof(EntityManager))]
     public IEnumerable<Type> EnumerateEntityMisses(EntityUid ent, ComponentFilter filter)
     {
         return EntityManager.EnumerateEntityMisses(ent, filter);
     }
 
+    /// <inheritdoc cref="M:Robust.Shared.GameObjects.EntityManager.EnumerateFilterHits(Robust.Shared.GameObjects.EntityUid,Robust.Shared.Prototypes.ComponentFilter)"/>
+    [ProxyFor(typeof(EntityManager))]
     public IEnumerable<Type> EnumerateFilterHits(EntityUid ent, ComponentFilter filter)
     {
         return EntityManager.EnumerateFilterHits(ent, filter);
     }
 
+    /// <inheritdoc cref="M:Robust.Shared.GameObjects.EntityManager.FillMissesFromRegistry(Robust.Shared.GameObjects.EntityUid,Robust.Shared.Prototypes.ComponentFilter,Robust.Shared.Prototypes.ComponentRegistry)"/>
+    [ProxyFor(typeof(EntityManager))]
     public void FillMissesFromRegistry(EntityUid ent, ComponentFilter filter, ComponentRegistry registry)
     {
         EntityManager.FillMissesFromRegistry(ent, filter, registry);
     }
 
+    /// <inheritdoc cref="M:Robust.Shared.GameObjects.EntityManager.FillMissesWithNewComponents(Robust.Shared.GameObjects.EntityUid,Robust.Shared.Prototypes.ComponentFilter)"/>
+    [ProxyFor(typeof(EntityManager))]
     public void FillMissesWithNewComponents(EntityUid ent, ComponentFilter filter)
     {
         EntityManager.FillMissesWithNewComponents(ent, filter);
     }
 
+    /// <inheritdoc cref="M:Robust.Shared.GameObjects.EntityManager.ComponentFilterQuery(Robust.Shared.Prototypes.ComponentFilter,System.Boolean)"/>
+    [ProxyFor(typeof(EntityManager))]
     public ComponentFilterQuery ComponentFilterQuery(ComponentFilter filter, bool matchPaused = false)
     {
         return EntityManager.ComponentFilterQuery(filter, matchPaused);

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -1783,4 +1783,47 @@ public partial class EntitySystem
     }
 
     #endregion
+
+    #region Filters
+    public bool MatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = false)
+    {
+        return EntityManager.MatchesFilter(ent, filter, matchPaused);
+    }
+
+    public bool ExactlyMatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = false)
+    {
+        return EntityManager.ExactlyMatchesFilter(ent, filter, matchPaused);
+    }
+
+    public IEnumerable<Type> EnumerateFilterMisses(EntityUid ent, ComponentFilter filter)
+    {
+        return EntityManager.EnumerateFilterMisses(ent, filter);
+    }
+
+    public IEnumerable<Type> EnumerateEntityMisses(EntityUid ent, ComponentFilter filter)
+    {
+        return EntityManager.EnumerateEntityMisses(ent, filter);
+    }
+
+    public IEnumerable<Type> EnumerateFilterHits(EntityUid ent, ComponentFilter filter)
+    {
+        return EntityManager.EnumerateFilterHits(ent, filter);
+    }
+
+    public void FillMissesFromRegistry(EntityUid ent, ComponentFilter filter, ComponentRegistry registry)
+    {
+        EntityManager.FillMissesFromRegistry(ent, filter, registry);
+    }
+
+    public void FillMissesWithNewComponents(EntityUid ent, ComponentFilter filter)
+    {
+        EntityManager.FillMissesWithNewComponents(ent, filter);
+    }
+
+    public ComponentFilterQuery ComponentFilterQuery(ComponentFilter filter, bool matchPaused = false)
+    {
+        return EntityManager.ComponentFilterQuery(filter, matchPaused);
+    }
+
+    #endregion
 }

--- a/Robust.Shared/GameObjects/IEntityLoadContext.cs
+++ b/Robust.Shared/GameObjects/IEntityLoadContext.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
@@ -13,16 +14,34 @@ namespace Robust.Shared.GameObjects
         /// <param name="component">Found component or null.</param>
         /// <returns>True if the component was found, false otherwise.</returns>
         /// <seealso cref="TryGetComponent{T}"/>
+        [Obsolete("The IComponentFactory receiving method must be used.")]
         bool TryGetComponent(string componentName, [NotNullWhen(true)] out IComponent? component);
 
         /// <summary>Tries getting the data of the given component.</summary>
+        /// <param name="factory">The global component factory.</param>
+        /// <param name="componentName">Name of component to find.</param>
+        /// <param name="component">Found component or null.</param>
+        /// <returns>True if the component was found, false otherwise.</returns>
+        /// <seealso cref="TryGetComponent{T}"/>
+        bool TryGetComponent(IComponentFactory factory, string componentName, [NotNullWhen(true)] out IComponent? component);
+
+        /// <summary>Tries getting the data of the given component.</summary>
+        /// <param name="factory">The global component factory.</param>
+        /// <param name="componentType">Type of component to find.</param>
+        /// <param name="component">Found component or null.</param>
+        /// <returns>True if the component was found, false otherwise.</returns>
+        /// <seealso cref="TryGetComponent{T}"/>
+        bool TryGetComponent(IComponentFactory factory, Type componentType, [NotNullWhen(true)] out IComponent? component);
+
+
+        /// <summary>Tries getting the data of the given component.</summary>
         /// <typeparam name="TComponent">Type of component to be found.</typeparam>
-        /// <param name="componentFactory">Component factory required for the lookup.</param>
+        /// <param name="factory">Component factory required for the lookup.</param>
         /// <param name="component">Found component or null.</param>
         /// <returns>True if the component was found, false otherwise.</returns>
         /// <seealso cref="TryGetComponent"/>
         bool TryGetComponent<TComponent>(
-            IComponentFactory componentFactory,
+            IComponentFactory factory,
             [NotNullWhen(true)] out TComponent? component
         ) where TComponent : class, IComponent, new();
 

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -45,22 +45,51 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         /// Adds the specified components from the <see cref="EntityPrototype"/>
         /// </summary>
+        [Obsolete("Use the ComponentRegistry variant instead. Merging prototypes at runtime like this is unsupported.")]
         void AddComponents(EntityUid target, EntityPrototype prototype, bool removeExisting = true);
 
         /// <summary>
-        /// Adds the specified registry components to the target entity.
+        ///     Adds the specified registry components to the target entity.
         /// </summary>
+        /// <param name="target">The target entity to add to.</param>
+        /// <param name="registry">The registry to copy components from.</param>
+        /// <param name="removeExisting">Whether to remove and replace any components the registry contains.</param>
+        /// <remarks>
+        ///     The provided registry must not contain MetaData or Transform components.
+        /// </remarks>
+        /// <seealso cref="FillMissesFromRegistry"/>
+        /// <seealso cref="FillMissesWithNewComponents"/>
         void AddComponents(EntityUid target, ComponentRegistry registry, bool removeExisting = true);
 
         /// <summary>
         /// Removes the specified entity prototype components from the target entity.
         /// </summary>
+        [Obsolete("Use the ComponentFilter variant instead. Using EntityPrototypes as a mask is wholly unsupported.")]
         void RemoveComponents(EntityUid target, EntityPrototype prototype);
 
         /// <summary>
         /// Removes the specified registry components from the target entity.
         /// </summary>
+        [Obsolete("Use the ComponentFilter variant instead, registries are not masks.")]
         void RemoveComponents(EntityUid target, ComponentRegistry registry);
+
+        /// <summary>
+        ///     Removes all components matching a given filter from the target entity.
+        ///     This will ignore components the entity doesn't have.
+        /// </summary>
+        /// <param name="target">The target entity to remove from.</param>
+        /// <param name="filter">A filter to use as a mask.</param>
+        /// <returns>True if any components are removed, false if nothing happened.</returns>
+        bool RemoveComponents(EntityUid target, ComponentFilter filter);
+
+        /// <summary>
+        ///     Removes all components matching a given filter from the target entity, if and only if
+        ///     the entity actually has every component.
+        /// </summary>
+        /// <param name="target">The target entity to remove from.</param>
+        /// <param name="filter">A filter to use as a mask.</param>
+        /// <returns>True if all components are removed, false if nothing happened.</returns>
+        bool RemoveComponentsExact(EntityUid target, ComponentFilter filter);
 
         /// <summary>
         ///     Adds a Component type to an entity. If the entity is already Initialized, the component will

--- a/Robust.Shared/GameObjects/IEntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Components.cs
@@ -511,6 +511,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         /// <see cref="CompRegistryQueryEnumerator"/>
         /// </summary>
+        [Obsolete($"Use {nameof(ComponentFilterQuery)} instead.")]
         public CompRegistryEntityEnumerator CompRegistryQueryEnumerator(ComponentRegistry registry);
 
         AllEntityQueryEnumerator<IComponent> AllEntityQueryEnumerator(Type comp);

--- a/Robust.Shared/GameObjects/IEntityManager.Filters.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Filters.cs
@@ -69,4 +69,12 @@ public partial interface IEntityManager
     ///     Like all filter methods, this is <i>dynamic</i> and is slower than using EnsureComp if you know the types in advance.
     /// </remarks>
     public void FillMissesWithNewComponents(EntityUid ent, ComponentFilter filter);
+
+    /// <summary>
+    ///     Constructs a cacheable query for a given filter.
+    ///     This optimizes the performance of <see cref="MatchesFilter"/> slightly and allows you to iterate matches.
+    /// </summary>
+    /// <param name="filter">The filter to construct a query from.</param>
+    /// <returns>A ComponentFilterQuery</returns>
+    public ComponentFilterQuery ConstructFilterQuery(ComponentFilter filter);
 }

--- a/Robust.Shared/GameObjects/IEntityManager.Filters.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Filters.cs
@@ -13,7 +13,16 @@ public partial interface IEntityManager
     /// <param name="filter">The filter to use.</param>
     /// <param name="matchPaused">Whether this query should match paused entities.</param>
     /// <returns>True if match, false if not.</returns>
-    public bool MatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = false);
+    public bool MatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = true);
+
+    /// <summary>
+    ///     Tests whether any component on an entity is within the filter.
+    /// </summary>
+    /// <param name="ent">The entity to test against.</param>
+    /// <param name="filter">The filter to use.</param>
+    /// <param name="matchPaused">Whether this query should match paused entities.</param>
+    /// <returns>True if match, false if not.</returns>
+    public bool AnyMatchingComponent(EntityUid ent, ComponentFilter filter, bool matchPaused = true);
 
     /// <summary>
     ///     Tests whether an entity matches a filter exactly, i.e. its components are identical to the filter's.

--- a/Robust.Shared/GameObjects/IEntityManager.Filters.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Filters.cs
@@ -22,6 +22,7 @@ public partial interface IEntityManager
     /// <returns>True if match, false if not.</returns>
     /// <remarks>
     ///     For performance and technical reasons, this matches the exact type, not any shared component.
+    ///     This also does NOT match for Transform or Metadata.
     /// </remarks>
     public bool ExactlyMatchesFilter(EntityUid ent, ComponentFilter filter);
 
@@ -75,6 +76,6 @@ public partial interface IEntityManager
     ///     This optimizes the performance of <see cref="MatchesFilter"/> slightly and allows you to iterate matches.
     /// </summary>
     /// <param name="filter">The filter to construct a query from.</param>
-    /// <returns>A ComponentFilterQuery</returns>
-    public ComponentFilterQuery ConstructFilterQuery(ComponentFilter filter);
+    /// <returns>A ComponentFilterQuery.</returns>
+    public ComponentFilterQuery ComponentFilterQuery(ComponentFilter filter);
 }

--- a/Robust.Shared/GameObjects/IEntityManager.Filters.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Filters.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using Robust.Shared.Prototypes;
+
+namespace Robust.Shared.GameObjects;
+
+public partial interface IEntityManager
+{
+    /// <summary>
+    ///     Tests whether an entity matches a filter, i.e. its components are a superset of the filter's.
+    /// </summary>
+    /// <param name="ent">The entity to test against.</param>
+    /// <param name="filter">The filter to use.</param>
+    /// <returns>True if match, false if not.</returns>
+    public bool MatchesFilter(EntityUid ent, ComponentFilter filter);
+
+    /// <summary>
+    ///     Tests whether an entity matches a filter exactly, i.e. its components are identical to the filter's.
+    /// </summary>
+    /// <param name="ent">The entity to test against.</param>
+    /// <param name="filter">The filter to use.</param>
+    /// <returns>True if match, false if not.</returns>
+    /// <remarks>
+    ///     For performance and technical reasons, this matches the exact type, not any shared component.
+    /// </remarks>
+    public bool ExactlyMatchesFilter(EntityUid ent, ComponentFilter filter);
+
+    /// <summary>
+    ///     Enumerates all the components the filter has, but the entity does not.
+    /// </summary>
+    /// <param name="ent">The entity to test against.</param>
+    /// <param name="filter">The filter to use.</param>
+    /// <returns>A list of component types.</returns>
+    public IEnumerable<Type> EnumerateFilterMisses(EntityUid ent, ComponentFilter filter);
+
+    /// <summary>
+    ///     Enumerates all the components the entity has, but the filter does not.
+    /// </summary>
+    /// <param name="ent">The entity to test against.</param>
+    /// <param name="filter">The filter to use.</param>
+    /// <returns>A list of component types.</returns>
+    public IEnumerable<Type> EnumerateEntityMisses(EntityUid ent, ComponentFilter filter);
+
+    /// <summary>
+    ///     Enumerates all components the filter and the entity have in common.
+    /// </summary>
+    /// <param name="ent">The entity to test against.</param>
+    /// <param name="filter">The filter to use.</param>
+    /// <returns>A list of component types.</returns>
+    public IEnumerable<Type> EnumerateFilterHits(EntityUid ent, ComponentFilter filter);
+
+    /// <summary>
+    ///     Computes the filter misses for the given entity, and then looks up those components from a registry to add them.
+    /// </summary>
+    /// <param name="ent">The entity to test against.</param>
+    /// <param name="filter">The filter to use.</param>
+    /// <param name="registry">The registry to introduce components from.</param>
+    /// <remarks>
+    ///     Like all filter methods, this is <i>dynamic</i> and is slower than using EnsureComp if you know the types in advance.
+    /// </remarks>
+    public void FillMissesFromRegistry(EntityUid ent, ComponentFilter filter, ComponentRegistry registry);
+
+    /// <summary>
+    ///     Computes the filter misses for the given entity, and then adds the missing components.
+    /// </summary>
+    /// <param name="ent">The entity to test against.</param>
+    /// <param name="filter">The filter to use.</param>
+    /// <remarks>
+    ///     Like all filter methods, this is <i>dynamic</i> and is slower than using EnsureComp if you know the types in advance.
+    /// </remarks>
+    public void FillMissesWithNewComponents(EntityUid ent, ComponentFilter filter);
+}

--- a/Robust.Shared/GameObjects/IEntityManager.Filters.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Filters.cs
@@ -11,25 +11,22 @@ public partial interface IEntityManager
     /// </summary>
     /// <param name="ent">The entity to test against.</param>
     /// <param name="filter">The filter to use.</param>
-    /// <param name="matchPaused">Whether this query should match paused entities.</param>
     /// <returns>True if match, false if not.</returns>
-    public bool MatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = true);
+    public bool MatchesFilter(EntityUid ent, ComponentFilter filter);
 
     /// <summary>
     ///     Tests whether any component on an entity is within the filter.
     /// </summary>
     /// <param name="ent">The entity to test against.</param>
     /// <param name="filter">The filter to use.</param>
-    /// <param name="matchPaused">Whether this query should match paused entities.</param>
     /// <returns>True if match, false if not.</returns>
-    public bool AnyMatchingComponent(EntityUid ent, ComponentFilter filter, bool matchPaused = true);
+    public bool AnyMatchingComponent(EntityUid ent, ComponentFilter filter);
 
     /// <summary>
     ///     Tests whether an entity matches a filter exactly, i.e. its components are identical to the filter's.
     /// </summary>
     /// <param name="ent">The entity to test against.</param>
     /// <param name="filter">The filter to use.</param>
-    /// <param name="matchPaused">Whether this query should match paused entities.</param>
     /// <returns>True if match, false if not.</returns>
     /// <remarks>
     /// <para>
@@ -37,7 +34,7 @@ public partial interface IEntityManager
     ///     This also does NOT match for Transform or Metadata, as both are obligatory.
     /// </para>
     /// </remarks>
-    public bool ExactlyMatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = false);
+    public bool ExactlyMatchesFilter(EntityUid ent, ComponentFilter filter);
 
     /// <summary>
     ///     Enumerates all the components the filter has, but the entity does not.

--- a/Robust.Shared/GameObjects/IEntityManager.Filters.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.Filters.cs
@@ -11,20 +11,24 @@ public partial interface IEntityManager
     /// </summary>
     /// <param name="ent">The entity to test against.</param>
     /// <param name="filter">The filter to use.</param>
+    /// <param name="matchPaused">Whether this query should match paused entities.</param>
     /// <returns>True if match, false if not.</returns>
-    public bool MatchesFilter(EntityUid ent, ComponentFilter filter);
+    public bool MatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = false);
 
     /// <summary>
     ///     Tests whether an entity matches a filter exactly, i.e. its components are identical to the filter's.
     /// </summary>
     /// <param name="ent">The entity to test against.</param>
     /// <param name="filter">The filter to use.</param>
+    /// <param name="matchPaused">Whether this query should match paused entities.</param>
     /// <returns>True if match, false if not.</returns>
     /// <remarks>
+    /// <para>
     ///     For performance and technical reasons, this matches the exact type, not any shared component.
-    ///     This also does NOT match for Transform or Metadata.
+    ///     This also does NOT match for Transform or Metadata, as both are obligatory.
+    /// </para>
     /// </remarks>
-    public bool ExactlyMatchesFilter(EntityUid ent, ComponentFilter filter);
+    public bool ExactlyMatchesFilter(EntityUid ent, ComponentFilter filter, bool matchPaused = false);
 
     /// <summary>
     ///     Enumerates all the components the filter has, but the entity does not.
@@ -32,6 +36,7 @@ public partial interface IEntityManager
     /// <param name="ent">The entity to test against.</param>
     /// <param name="filter">The filter to use.</param>
     /// <returns>A list of component types.</returns>
+    /// <remarks>This does not obey the paused status of an entity. If this matters for you, you should use <see cref="IsPaused"/> yourself.</remarks>
     public IEnumerable<Type> EnumerateFilterMisses(EntityUid ent, ComponentFilter filter);
 
     /// <summary>
@@ -40,6 +45,7 @@ public partial interface IEntityManager
     /// <param name="ent">The entity to test against.</param>
     /// <param name="filter">The filter to use.</param>
     /// <returns>A list of component types.</returns>
+    /// <remarks>This does not obey the paused status of an entity. If this matters for you, you should use <see cref="IsPaused"/> yourself.</remarks>
     public IEnumerable<Type> EnumerateEntityMisses(EntityUid ent, ComponentFilter filter);
 
     /// <summary>
@@ -48,6 +54,7 @@ public partial interface IEntityManager
     /// <param name="ent">The entity to test against.</param>
     /// <param name="filter">The filter to use.</param>
     /// <returns>A list of component types.</returns>
+    /// <remarks>This does not obey the paused status of an entity. If this matters for you, you should use <see cref="IsPaused"/> yourself.</remarks>
     public IEnumerable<Type> EnumerateFilterHits(EntityUid ent, ComponentFilter filter);
 
     /// <summary>
@@ -59,6 +66,7 @@ public partial interface IEntityManager
     /// <remarks>
     ///     Like all filter methods, this is <i>dynamic</i> and is slower than using EnsureComp if you know the types in advance.
     /// </remarks>
+    /// <remarks>This does not obey the paused status of an entity. If this matters for you, you should use <see cref="IsPaused"/> yourself.</remarks>
     public void FillMissesFromRegistry(EntityUid ent, ComponentFilter filter, ComponentRegistry registry);
 
     /// <summary>
@@ -69,6 +77,7 @@ public partial interface IEntityManager
     /// <remarks>
     ///     Like all filter methods, this is <i>dynamic</i> and is slower than using EnsureComp if you know the types in advance.
     /// </remarks>
+    /// <remarks>This does not obey the paused status of an entity. If this matters for you, you should use <see cref="IsPaused"/> yourself.</remarks>
     public void FillMissesWithNewComponents(EntityUid ent, ComponentFilter filter);
 
     /// <summary>
@@ -76,6 +85,7 @@ public partial interface IEntityManager
     ///     This optimizes the performance of <see cref="MatchesFilter"/> slightly and allows you to iterate matches.
     /// </summary>
     /// <param name="filter">The filter to construct a query from.</param>
+    /// <param name="matchPaused">Whether this query should match paused entities.</param>
     /// <returns>A ComponentFilterQuery.</returns>
-    public ComponentFilterQuery ComponentFilterQuery(ComponentFilter filter);
+    public ComponentFilterQuery ComponentFilterQuery(ComponentFilter filter, bool matchPaused = false);
 }

--- a/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
@@ -40,12 +40,12 @@ internal sealed class PrototypeReloadSystem : EntitySystem
     {
         var oldPrototype = metaData.EntityPrototype;
 
-        var oldPrototypeComponents = oldPrototype?.Components.Names()
+        var oldPrototypeComponents = oldPrototype?.Components.Names(_componentFactory)
             .Where(n => n != "Transform" && n != "MetaData")
             .Select(name => (name, _componentFactory.GetRegistration(name).Type))
             .ToList() ?? new List<(string name, Type Type)>();
 
-        var newPrototypeComponents = newPrototype.Components.Names()
+        var newPrototypeComponents = newPrototype.Components.Names(_componentFactory)
             .Where(n => n != "Transform" && n != "MetaData")
             .Select(name => (name, _componentFactory.GetRegistration(name).Type))
             .ToList();
@@ -70,7 +70,7 @@ internal sealed class PrototypeReloadSystem : EntitySystem
         foreach (var (name, _) in newPrototypeComponents.Where(t => !ignoredComponents.Contains(t.name))
                      .Except(oldPrototypeComponents))
         {
-            var data = newPrototype.Components.GetComponentByName(name);
+            var data = newPrototype.Components.GetComponentByName(_componentFactory, name);
             var component = _componentFactory.GetComponent(name);
 
             if (!HasComp(entity, component.GetType()))

--- a/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
@@ -40,12 +40,12 @@ internal sealed class PrototypeReloadSystem : EntitySystem
     {
         var oldPrototype = metaData.EntityPrototype;
 
-        var oldPrototypeComponents = oldPrototype?.Components.Keys
+        var oldPrototypeComponents = oldPrototype?.Components.Names()
             .Where(n => n != "Transform" && n != "MetaData")
             .Select(name => (name, _componentFactory.GetRegistration(name).Type))
             .ToList() ?? new List<(string name, Type Type)>();
 
-        var newPrototypeComponents = newPrototype.Components.Keys
+        var newPrototypeComponents = newPrototype.Components.Names()
             .Where(n => n != "Transform" && n != "MetaData")
             .Select(name => (name, _componentFactory.GetRegistration(name).Type))
             .ToList();
@@ -55,7 +55,7 @@ internal sealed class PrototypeReloadSystem : EntitySystem
         // Find components to be removed, and remove them
         foreach (var (name, type) in oldPrototypeComponents.Except(newPrototypeComponents))
         {
-            if (newPrototype.Components.ContainsKey(name))
+            if (newPrototype.Components.ContainsComponentByName(name))
             {
                 ignoredComponents.Add(name);
                 continue;
@@ -70,7 +70,7 @@ internal sealed class PrototypeReloadSystem : EntitySystem
         foreach (var (name, _) in newPrototypeComponents.Where(t => !ignoredComponents.Contains(t.name))
                      .Except(oldPrototypeComponents))
         {
-            var data = newPrototype.Components[name];
+            var data = newPrototype.Components.GetComponentByName(name);
             var component = _componentFactory.GetComponent(name);
 
             if (!HasComp(entity, component.GetType()))

--- a/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
@@ -55,7 +55,7 @@ internal sealed class PrototypeReloadSystem : EntitySystem
         // Find components to be removed, and remove them
         foreach (var (name, type) in oldPrototypeComponents.Except(newPrototypeComponents))
         {
-            if (newPrototype.Components.ContainsComponentByName(name))
+            if (newPrototype.Components.ContainsComponentByName(_componentFactory, name))
             {
                 ignoredComponents.Add(name);
                 continue;

--- a/Robust.Shared/Prototypes/ComponentFilter.cs
+++ b/Robust.Shared/Prototypes/ComponentFilter.cs
@@ -12,9 +12,7 @@ namespace Robust.Shared.Prototypes;
 /// <summary>
 ///     A "filter" for entities, allowing you to describe a set of components they match and test for matches.
 /// </summary>
-/// <remarks>
-///     Cache your filters! Filter baking TBD.
-/// </remarks>
+/// <seealso cref="ComponentFilterQuery"/>
 public sealed class ComponentFilter : ISet<Type>
 {
     /// <summary>

--- a/Robust.Shared/Prototypes/ComponentFilter.cs
+++ b/Robust.Shared/Prototypes/ComponentFilter.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Utility;
+
+namespace Robust.Shared.Prototypes;
+
+/// <summary>
+///     A "filter" for entities, allowing you to describe a set of components they match and test for matches.
+/// </summary>
+/// <remarks>
+///     Cache your filters! Filter baking TBD.
+/// </remarks>
+public sealed class ComponentFilter : ISet<Type>
+{
+    /// <summary>
+    ///     Internals of a filter.
+    ///     Do not use outside of serialization, i beg.
+    /// </summary>
+    internal HashSet<Type> Components;
+
+    /// <summary>
+    ///     Constructs a new, blank component filter.
+    /// </summary>
+    public ComponentFilter()
+    {
+        Components = new();
+    }
+
+    /// <summary>
+    ///     Constructs a new component filter from the given set of component types.
+    /// </summary>
+    /// <param name="components">The set of components to turn into a filter.</param>
+    /// <remarks>
+    ///     Duplicates will be removed.
+    /// </remarks>
+    public ComponentFilter(params Type[] components)
+    {
+        Components = components.ToHashSet();
+        ValidateContents();
+    }
+
+    /// <summary>
+    ///     Constructs a new component filter from the given set of component types.
+    /// </summary>
+    /// <param name="components">The set of components to turn into a filter.</param>
+    /// <remarks>
+    ///     Duplicates will be removed.
+    /// </remarks>
+    public ComponentFilter(IReadOnlyCollection<Type> components)
+    {
+        Components = components.ToHashSet();
+        ValidateContents();
+    }
+
+    /// <summary>
+    ///     Constructs a new component filter from the given set of component names.
+    /// </summary>
+    /// <param name="factory">The global component factory.</param>
+    /// <param name="components">The set of components to turn into a filter.</param>
+    /// <remarks>
+    ///     Duplicates will be removed.
+    /// </remarks>
+    public ComponentFilter(IComponentFactory factory, params string[] components)
+    {
+        Components = components.Select(x => factory.GetRegistration(x).Type).ToHashSet();
+        // No need to validate.
+    }
+
+    public bool Add(Type component)
+    {
+#if DEBUG
+        var factory = IoCManager.Resolve<IComponentFactory>();
+        DebugTools.Assert(factory.TryGetRegistration(component, out _),
+            "Cannot add non-components to a filter.");
+#endif
+
+        return Components.Add(component);
+    }
+
+    /// <summary>
+    ///     Adds a given component to the filter.
+    /// </summary>
+    /// <param name="factory">The global component factory.</param>
+    /// <param name="componentName">The component to add by name.</param>
+    /// <returns>True if the component was added, false if it was already present.</returns>
+    public bool Add(IComponentFactory factory, string componentName)
+    {
+        var component = factory.GetRegistration(componentName).Type;
+        return Components.Add(component);
+    }
+
+    public void ExceptWith(IEnumerable<Type> other)
+    {
+        Components.ExceptWith(other);
+        ValidateContents();
+    }
+
+    public void IntersectWith(IEnumerable<Type> other)
+    {
+        Components.IntersectWith(other);
+        ValidateContents();
+    }
+
+    public bool IsProperSubsetOf(IEnumerable<Type> other)
+    {
+        return Components.IsProperSubsetOf(other);
+    }
+
+    public bool IsProperSupersetOf(IEnumerable<Type> other)
+    {
+        return Components.IsProperSupersetOf(other);
+    }
+
+    public bool IsSubsetOf(IEnumerable<Type> other)
+    {
+        return Components.IsSubsetOf(other);
+    }
+
+    public bool IsSupersetOf(IEnumerable<Type> other)
+    {
+        return Components.IsSupersetOf(other);
+    }
+
+    public bool Overlaps(IEnumerable<Type> other)
+    {
+        return Components.Overlaps(other);
+    }
+
+    public bool SetEquals(IEnumerable<Type> other)
+    {
+        return Components.SetEquals(other);
+    }
+
+    public void SymmetricExceptWith(IEnumerable<Type> other)
+    {
+        Components.SymmetricExceptWith(other);
+        ValidateContents();
+    }
+
+    public void UnionWith(IEnumerable<Type> other)
+    {
+        Components.UnionWith(other);
+        ValidateContents();
+    }
+
+    public void Clear()
+    {
+        Components.Clear();
+    }
+
+    public bool Contains(Type item)
+    {
+        return Components.Contains(item);
+    }
+
+    public void CopyTo(Type[] array, int arrayIndex)
+    {
+        Components.CopyTo(array, arrayIndex);
+    }
+
+    void ICollection<Type>.Add(Type item)
+    {
+        Add(item);
+    }
+
+    public bool Remove(Type component)
+    {
+#if DEBUG
+        var factory = IoCManager.Resolve<IComponentFactory>();
+        DebugTools.Assert(factory.TryGetRegistration(component, out _),
+            "Cannot remove non-components from a filter.");
+#endif
+
+        return Components.Remove(component);
+    }
+
+    public int Count => Components.Count;
+    public bool IsReadOnly => false;
+
+    public IEnumerator<Type> GetEnumerator()
+    {
+        return Components.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    /// <summary>
+    ///     Validates the component filter only contains components.
+    /// </summary>
+    [Conditional("DEBUG")]
+    private void ValidateContents()
+    {
+        var factory = IoCManager.Resolve<IComponentFactory>();
+        DebugTools.Assert(Components.All(x => factory.TryGetRegistration(x, out _)),
+            "All types in a filter list must be valid, registered components.");
+    }
+}

--- a/Robust.Shared/Prototypes/ComponentFilter.cs
+++ b/Robust.Shared/Prototypes/ComponentFilter.cs
@@ -12,8 +12,15 @@ namespace Robust.Shared.Prototypes;
 
 /// <summary>
 ///     A "filter" for entities, allowing you to describe a set of components they match and test for matches.
+///     This is intended for cases where you want to be able to see if an entity matches a given dynamically defined set
+///     of components, for example a YAML defined set.
 /// </summary>
+/// <remarks>
+///     This is adjacent to, but disjoint from <see cref="ComponentRegistry"/>. Registries contain a fully instantiated
+///     set of components, including their fields, and are intended for additive operations only.
+/// </remarks>
 /// <seealso cref="ComponentFilterQuery"/>
+/// <seealso cref="ComponentRegistry"/>
 [PublicAPI]
 public sealed class ComponentFilter : ISet<Type>
 {

--- a/Robust.Shared/Prototypes/ComponentFilter.cs
+++ b/Robust.Shared/Prototypes/ComponentFilter.cs
@@ -47,7 +47,7 @@ public sealed class ComponentFilter : ISet<Type>
     /// <remarks>
     ///     Duplicates will be removed.
     /// </remarks>
-    public ComponentFilter(IReadOnlyCollection<Type> components)
+    public ComponentFilter(IEnumerable<Type> components)
     {
         _components = components.ToHashSet();
         ValidateContents();

--- a/Robust.Shared/Prototypes/ComponentFilter.cs
+++ b/Robust.Shared/Prototypes/ComponentFilter.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Utility;
@@ -13,20 +14,17 @@ namespace Robust.Shared.Prototypes;
 ///     A "filter" for entities, allowing you to describe a set of components they match and test for matches.
 /// </summary>
 /// <seealso cref="ComponentFilterQuery"/>
+[PublicAPI]
 public sealed class ComponentFilter : ISet<Type>
 {
-    /// <summary>
-    ///     Internals of a filter.
-    ///     Do not use outside of serialization, i beg.
-    /// </summary>
-    internal HashSet<Type> Components;
+    private HashSet<Type> _components;
 
     /// <summary>
     ///     Constructs a new, blank component filter.
     /// </summary>
     public ComponentFilter()
     {
-        Components = new();
+        _components = new();
     }
 
     /// <summary>
@@ -38,7 +36,7 @@ public sealed class ComponentFilter : ISet<Type>
     /// </remarks>
     public ComponentFilter(params Type[] components)
     {
-        Components = components.ToHashSet();
+        _components = components.ToHashSet();
         ValidateContents();
     }
 
@@ -51,7 +49,7 @@ public sealed class ComponentFilter : ISet<Type>
     /// </remarks>
     public ComponentFilter(IReadOnlyCollection<Type> components)
     {
-        Components = components.ToHashSet();
+        _components = components.ToHashSet();
         ValidateContents();
     }
 
@@ -65,8 +63,28 @@ public sealed class ComponentFilter : ISet<Type>
     /// </remarks>
     public ComponentFilter(IComponentFactory factory, params string[] components)
     {
-        Components = components.Select(x => factory.GetRegistration(x).Type).ToHashSet();
+        _components = components.Select(x => factory.GetRegistration(x).Type).ToHashSet();
         // No need to validate.
+    }
+
+    /// <summary>
+    ///     Constructs a filter out of the contents of a registry.
+    /// </summary>
+    /// <param name="factory">The global component factory.</param>
+    /// <param name="registry">The registry to obtain component types from.</param>
+    /// <remarks>
+    /// <para>
+    ///     Filters do not retain any of the component's data, they only contain component types.
+    ///     There is no engine API to filter for component data.
+    /// </para>
+    /// <para>
+    ///     This is a new allocation, so if you need to do this regularly it's preferable to cache the filter.
+    /// </para>
+    /// </remarks>
+    public ComponentFilter(IComponentFactory factory, ComponentRegistry registry)
+    {
+        _components = registry.Components().Select(x => x.GetType()).ToHashSet();
+        ValidateContents();
     }
 
     public bool Add(Type component)
@@ -77,7 +95,7 @@ public sealed class ComponentFilter : ISet<Type>
             "Cannot add non-components to a filter.");
 #endif
 
-        return Components.Add(component);
+        return _components.Add(component);
     }
 
     /// <summary>
@@ -89,76 +107,76 @@ public sealed class ComponentFilter : ISet<Type>
     public bool Add(IComponentFactory factory, string componentName)
     {
         var component = factory.GetRegistration(componentName).Type;
-        return Components.Add(component);
+        return _components.Add(component);
     }
 
     public void ExceptWith(IEnumerable<Type> other)
     {
-        Components.ExceptWith(other);
+        _components.ExceptWith(other);
         ValidateContents();
     }
 
     public void IntersectWith(IEnumerable<Type> other)
     {
-        Components.IntersectWith(other);
+        _components.IntersectWith(other);
         ValidateContents();
     }
 
     public bool IsProperSubsetOf(IEnumerable<Type> other)
     {
-        return Components.IsProperSubsetOf(other);
+        return _components.IsProperSubsetOf(other);
     }
 
     public bool IsProperSupersetOf(IEnumerable<Type> other)
     {
-        return Components.IsProperSupersetOf(other);
+        return _components.IsProperSupersetOf(other);
     }
 
     public bool IsSubsetOf(IEnumerable<Type> other)
     {
-        return Components.IsSubsetOf(other);
+        return _components.IsSubsetOf(other);
     }
 
     public bool IsSupersetOf(IEnumerable<Type> other)
     {
-        return Components.IsSupersetOf(other);
+        return _components.IsSupersetOf(other);
     }
 
     public bool Overlaps(IEnumerable<Type> other)
     {
-        return Components.Overlaps(other);
+        return _components.Overlaps(other);
     }
 
     public bool SetEquals(IEnumerable<Type> other)
     {
-        return Components.SetEquals(other);
+        return _components.SetEquals(other);
     }
 
     public void SymmetricExceptWith(IEnumerable<Type> other)
     {
-        Components.SymmetricExceptWith(other);
+        _components.SymmetricExceptWith(other);
         ValidateContents();
     }
 
     public void UnionWith(IEnumerable<Type> other)
     {
-        Components.UnionWith(other);
+        _components.UnionWith(other);
         ValidateContents();
     }
 
     public void Clear()
     {
-        Components.Clear();
+        _components.Clear();
     }
 
     public bool Contains(Type item)
     {
-        return Components.Contains(item);
+        return _components.Contains(item);
     }
 
     public void CopyTo(Type[] array, int arrayIndex)
     {
-        Components.CopyTo(array, arrayIndex);
+        _components.CopyTo(array, arrayIndex);
     }
 
     void ICollection<Type>.Add(Type item)
@@ -174,15 +192,15 @@ public sealed class ComponentFilter : ISet<Type>
             "Cannot remove non-components from a filter.");
 #endif
 
-        return Components.Remove(component);
+        return _components.Remove(component);
     }
 
-    public int Count => Components.Count;
+    public int Count => _components.Count;
     public bool IsReadOnly => false;
 
     public IEnumerator<Type> GetEnumerator()
     {
-        return Components.GetEnumerator();
+        return _components.GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()
@@ -197,7 +215,7 @@ public sealed class ComponentFilter : ISet<Type>
     private void ValidateContents()
     {
         var factory = IoCManager.Resolve<IComponentFactory>();
-        DebugTools.Assert(Components.All(x => factory.TryGetRegistration(x, out _)),
+        DebugTools.Assert(_components.All(x => factory.TryGetRegistration(x, out _)),
             "All types in a filter list must be valid, registered components.");
     }
 }

--- a/Robust.Shared/Prototypes/ComponentRegistry.cs
+++ b/Robust.Shared/Prototypes/ComponentRegistry.cs
@@ -285,9 +285,10 @@ public sealed class ComponentRegistry : IEntityLoadContext, IEnumerable<KeyValue
     /// <summary>
     ///     Tests if the registry contains the given component by name. You should prefer to use types!
     /// </summary>
+    /// <param name="factory">The global component factory.</param>
     /// <param name="name">The name of the component to check for.</param>
     /// <returns>Whether the registry contains the given component.</returns>
-    public bool ContainsComponentByName(string name)
+    public bool ContainsComponentByName(IComponentFactory factory, string name)
     {
         return _inner.ContainsKey(name);
     }
@@ -319,12 +320,13 @@ public sealed class ComponentRegistry : IEntityLoadContext, IEnumerable<KeyValue
     /// <summary>
     ///     Retrieves an underlying component entry, if possible.
     /// </summary>
-    /// <param name="name"></param>
-    /// <param name="o"></param>
-    /// <returns></returns>
-    public bool TryGetEntry(string name, [NotNullWhen(true)] out EntityPrototype.ComponentRegistryEntry? o)
+    /// <param name="factory">The global component factory.</param>
+    /// <param name="name">The component name to look up.</param>
+    /// <param name="entry">The component entry, if any.</param>
+    /// <returns>True if entry was found, false otherwise.</returns>
+    public bool TryGetEntry(IComponentFactory factory, string name, [NotNullWhen(true)] out EntityPrototype.ComponentRegistryEntry? entry)
     {
-        return _inner.TryGetValue(name, out o);
+        return _inner.TryGetValue(name, out entry);
     }
 
     [Obsolete("Legacy dictionary API compatibility. Use AddComponent and TryGetComponent.")]

--- a/Robust.Shared/Prototypes/ComponentRegistry.cs
+++ b/Robust.Shared/Prototypes/ComponentRegistry.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization.TypeSerializers.Implementations;
+using Robust.Shared.Utility;
 
 namespace Robust.Shared.Prototypes;
 
@@ -58,6 +60,8 @@ public sealed class ComponentRegistry : IEntityLoadContext, IEnumerable<KeyValue
             x => factory.GetRegistration(x.GetType()).Name,
             x => new EntityPrototype.ComponentRegistryEntry(x)
         );
+
+        ValidateContents();
     }
 
     /// <summary>
@@ -113,6 +117,7 @@ public sealed class ComponentRegistry : IEntityLoadContext, IEnumerable<KeyValue
     internal void AddComponentManual(string componentName, IComponent component)
     {
         _inner[componentName] = new EntityPrototype.ComponentRegistryEntry(component);
+        ValidateContents();
     }
 
     /// <summary>
@@ -362,5 +367,15 @@ public sealed class ComponentRegistry : IEntityLoadContext, IEnumerable<KeyValue
     internal void AddEntry(string name, EntityPrototype.ComponentRegistryEntry entry)
     {
         _inner[name] = entry;
+        ValidateContents();
+    }
+
+    [Conditional("DEBUG")]
+    private void ValidateContents()
+    {
+        foreach (var (key, comp) in _inner)
+        {
+            DebugTools.Assert(comp.Component.IsUnattached(), $"Components that have been part of sim should never be in a registry. Culprit was {key}.");
+        }
     }
 }

--- a/Robust.Shared/Prototypes/ComponentRegistry.cs
+++ b/Robust.Shared/Prototypes/ComponentRegistry.cs
@@ -14,6 +14,9 @@ namespace Robust.Shared.Prototypes;
 /// <remarks>
 ///     This is distinctly <b>not</b> a filter list, and contains fully constructed components.
 ///     To filter for components, use a ComponentFilterList instead.
+///
+///     Currently, working with names in a registry is most efficient. However when all obsolete API usage has been
+///     cleaned up, registry internals will be changed and functionality used in prototypes/yaml will be split off.
 /// </remarks>
 public sealed class ComponentRegistry : IEntityLoadContext, IEnumerable<KeyValuePair<string, EntityPrototype.ComponentRegistryEntry>>
 {
@@ -30,12 +33,16 @@ public sealed class ComponentRegistry : IEntityLoadContext, IEnumerable<KeyValue
     [Obsolete("Use Components, ComponentsAndNames, or ComponentTypes instead.")]
     public IReadOnlyCollection<EntityPrototype.ComponentRegistryEntry> Values => _inner.Values;
 
+    [Obsolete("Use Components, ComponentsAndNames, or ComponentTypes instead.")]
+    public IReadOnlyCollection<string> Keys => _inner.Keys;
+
+
     public ComponentRegistry()
     {
         _inner = new();
     }
 
-    public ComponentRegistry(Dictionary<string, EntityPrototype.ComponentRegistryEntry> components)
+    internal ComponentRegistry(Dictionary<string, EntityPrototype.ComponentRegistryEntry> components)
     {
         _inner = components;
     }
@@ -48,7 +55,7 @@ public sealed class ComponentRegistry : IEntityLoadContext, IEnumerable<KeyValue
     public ComponentRegistry(IComponentFactory factory, params IEnumerable<IComponent> component)
     {
         _inner = component.ToDictionary(
-            x => factory.GetRegistration((Type)x.GetType()).Name,
+            x => factory.GetRegistration(x.GetType()).Name,
             x => new EntityPrototype.ComponentRegistryEntry(x)
         );
     }
@@ -92,10 +99,18 @@ public sealed class ComponentRegistry : IEntityLoadContext, IEnumerable<KeyValue
     /// <summary>
     ///     Manually inserts a pre-constructed component into the registry by name.
     /// </summary>
+    public void AddComponentManual(IComponentFactory factory, string componentName, IComponent component)
+    {
+        AddComponentManual(componentName, component);
+    }
+
+    /// <summary>
+    ///     Manually inserts a pre-constructed component into the registry by name.
+    /// </summary>
     /// <remarks>
     ///     You almost never want this, this is for situations where you have no choice (i.e. cannot use IoC).
     /// </remarks>
-    public void AddComponentManual(string componentName, IComponent component)
+    internal void AddComponentManual(string componentName, IComponent component)
     {
         _inner[componentName] = new EntityPrototype.ComponentRegistryEntry(component);
     }
@@ -134,15 +149,17 @@ public sealed class ComponentRegistry : IEntityLoadContext, IEnumerable<KeyValue
     /// <summary>
     ///     Gets a component out of the registry by name.
     /// </summary>
+    /// <param name="factory">The global component factory</param>
     /// <param name="name">The component to retrieve.</param>
     /// <returns>The component.</returns>
     /// <exception cref="KeyNotFoundException">Thrown when the given component is not in the registry.</exception>
-    public IComponent GetComponentByName(string name)
+    public IComponent GetComponentByName(IComponentFactory factory, string name)
     {
         return _inner[name].Component;
     }
 
     /// <inheritdoc />
+    [Obsolete("The IComponentFactory receiving method must be used.")]
     public bool TryGetComponent(string componentName, [NotNullWhen(true)] out IComponent? component)
     {
         var success = _inner.TryGetValue(componentName, out var comp);
@@ -152,14 +169,23 @@ public sealed class ComponentRegistry : IEntityLoadContext, IEnumerable<KeyValue
     }
 
     /// <inheritdoc />
+    public bool TryGetComponent(IComponentFactory factory, string componentName, [NotNullWhen(true)] out IComponent? component)
+    {
+        var success = _inner.TryGetValue(componentName, out var comp);
+        component = comp?.Component;
+
+        return success;
+    }
+
+    /// <inheritdoc />
     public bool TryGetComponent<TComponent>(
-        IComponentFactory componentFactory,
+        IComponentFactory factory,
         [NotNullWhen(true)] out TComponent? component
     ) where TComponent : class, IComponent, new()
     {
         component = null;
-        var componentName = componentFactory.GetComponentName<TComponent>();
-        if (TryGetComponent(componentName, out var foundComponent))
+        var componentName = factory.GetComponentName<TComponent>();
+        if (TryGetComponent(factory, componentName, out var foundComponent))
         {
             component = (TComponent)foundComponent;
             return true;
@@ -168,17 +194,12 @@ public sealed class ComponentRegistry : IEntityLoadContext, IEnumerable<KeyValue
         return false;
     }
 
-    /// <summary>Tries getting the data of the given component.</summary>
-    /// <param name="componentFactory">The global component factory.</param>
-    /// <param name="componentType">Type of component to find.</param>
-    /// <param name="component">Found component or null.</param>
-    /// <returns>True if the component was found, false otherwise.</returns>
-    /// <seealso cref="TryGetComponent{T}"/>
-    public bool TryGetComponent(IComponentFactory componentFactory, Type componentType, [NotNullWhen(true)] out IComponent? component)
+    /// <inheritdoc />
+    public bool TryGetComponent(IComponentFactory factory, Type componentType, [NotNullWhen(true)] out IComponent? component)
     {
         component = null;
-        var componentName = componentFactory.GetComponentName(componentType);
-        if (TryGetComponent(componentName, out component))
+        var componentName = factory.GetComponentName(componentType);
+        if (TryGetComponent(factory, componentName, out component))
         {
             return true;
         }
@@ -217,7 +238,7 @@ public sealed class ComponentRegistry : IEntityLoadContext, IEnumerable<KeyValue
     /// <summary>
     ///     Enumerate components in the registry by value, with their names.
     /// </summary>
-    public IEnumerable<(string, IComponent)> ComponentsAndNames()
+    public IEnumerable<(string, IComponent)> ComponentsAndNames(IComponentFactory factory)
     {
         return _inner.Select(x => (x.Key, x.Value.Component));
     }
@@ -225,8 +246,7 @@ public sealed class ComponentRegistry : IEntityLoadContext, IEnumerable<KeyValue
     /// <summary>
     ///     Enumerates the names of all components in the registry.
     /// </summary>
-    /// <returns></returns>
-    public IEnumerable<string> Names()
+    public IEnumerable<string> Names(IComponentFactory factory)
     {
         return _inner.Keys;
     }

--- a/Robust.Shared/Prototypes/ComponentRegistry.cs
+++ b/Robust.Shared/Prototypes/ComponentRegistry.cs
@@ -1,0 +1,344 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Serialization.TypeSerializers.Implementations;
+
+namespace Robust.Shared.Prototypes;
+
+/// <summary>
+///     A registry of instantiated, deserialized components.
+/// </summary>
+/// <remarks>
+///     This is distinctly <b>not</b> a filter list, and contains fully constructed components.
+///     To filter for components, use a ComponentFilterList instead.
+/// </remarks>
+public sealed class ComponentRegistry : IEntityLoadContext, IEnumerable<KeyValuePair<string, EntityPrototype.ComponentRegistryEntry>>
+{
+    /// <summary>
+    ///     The underlying dictionary of this registry. This stores component names mapped to entries.
+    /// </summary>
+    private readonly Dictionary<string, EntityPrototype.ComponentRegistryEntry> _inner;
+
+    /// <summary>
+    ///     The number of components contained within the registry.
+    /// </summary>
+    public int Count => _inner.Count;
+
+    [Obsolete("Use Components, ComponentsAndNames, or ComponentTypes instead.")]
+    public IReadOnlyCollection<EntityPrototype.ComponentRegistryEntry> Values => _inner.Values;
+
+    public ComponentRegistry()
+    {
+        _inner = new();
+    }
+
+    public ComponentRegistry(Dictionary<string, EntityPrototype.ComponentRegistryEntry> components)
+    {
+        _inner = components;
+    }
+
+    /// <summary>
+    ///     Constructs a new component registry from a list of components and the global component factory.
+    /// </summary>
+    /// <param name="factory">The global component factory.</param>
+    /// <param name="component">The components to build from.</param>
+    public ComponentRegistry(IComponentFactory factory, params IEnumerable<IComponent> component)
+    {
+        _inner = component.ToDictionary(
+            x => factory.GetRegistration((Type)x.GetType()).Name,
+            x => new EntityPrototype.ComponentRegistryEntry(x)
+        );
+    }
+
+    /// <summary>
+    ///     Adds a component to the registry, constructing it.
+    /// </summary>
+    /// <param name="factory">The global component factory.</param>
+    /// <param name="component">The type of component to construct.</param>
+    public IComponent AddComponent(IComponentFactory factory, Type component)
+    {
+        var name = factory.GetComponentName(component);
+        var c = factory.GetComponent(component);
+
+        AddComponentManual(name, c);
+
+        return c;
+    }
+
+    /// <summary>
+    ///     Adds a component to the registry, constructing it.
+    /// </summary>
+    /// <param name="factory">The global component factory.</param>
+    /// <typeparam name="T">The type of component to construct.</typeparam>
+    public T AddComponent<T>(IComponentFactory factory)
+        where T: IComponent
+    {
+        return (T)AddComponent(factory, typeof(T));
+    }
+
+    /// <summary>
+    ///     Adds a pre-constructed component to this registry.
+    /// </summary>
+    public void AddComponent(IComponentFactory factory, IComponent component)
+    {
+        var name = factory.GetComponentName(component.GetType());
+
+        AddComponentManual(name, component);
+    }
+
+    /// <summary>
+    ///     Manually inserts a pre-constructed component into the registry by name.
+    /// </summary>
+    /// <remarks>
+    ///     You almost never want this, this is for situations where you have no choice (i.e. cannot use IoC).
+    /// </remarks>
+    public void AddComponentManual(string componentName, IComponent component)
+    {
+        _inner[componentName] = new EntityPrototype.ComponentRegistryEntry(component);
+    }
+
+    /// <summary>
+    ///     Gets a component out of the registry by type.
+    /// </summary>
+    /// <param name="factory">The global component factory.</param>
+    /// <typeparam name="T">The component type to retrieve.</typeparam>
+    /// <returns>The component.</returns>
+    /// <exception cref="KeyNotFoundException">Thrown when the given component is not in the registry.</exception>
+    public T GetComponent<T>(IComponentFactory factory)
+        where T: class, IComponent, new()
+    {
+        if (TryGetComponent<T>(factory, out var c))
+            return c;
+
+        throw new KeyNotFoundException($"Couldn't find {typeof(T)} in the registry.");
+    }
+
+    /// <summary>
+    ///     Gets a component out of the registry by type.
+    /// </summary>
+    /// <param name="factory">The global component factory.</param>
+    /// <param name="component">The component type to retrieve.</param>
+    /// <returns>The component.</returns>
+    /// <exception cref="KeyNotFoundException">Thrown when the given component is not in the registry.</exception>
+    public IComponent GetComponent(IComponentFactory factory, Type component)
+    {
+        if (TryGetComponent(factory, component, out var c))
+            return c;
+
+        throw new KeyNotFoundException($"Couldn't find {component} in the registry.");
+    }
+
+    /// <summary>
+    ///     Gets a component out of the registry by name.
+    /// </summary>
+    /// <param name="name">The component to retrieve.</param>
+    /// <returns>The component.</returns>
+    /// <exception cref="KeyNotFoundException">Thrown when the given component is not in the registry.</exception>
+    public IComponent GetComponentByName(string name)
+    {
+        return _inner[name].Component;
+    }
+
+    /// <inheritdoc />
+    public bool TryGetComponent(string componentName, [NotNullWhen(true)] out IComponent? component)
+    {
+        var success = _inner.TryGetValue(componentName, out var comp);
+        component = comp?.Component;
+
+        return success;
+    }
+
+    /// <inheritdoc />
+    public bool TryGetComponent<TComponent>(
+        IComponentFactory componentFactory,
+        [NotNullWhen(true)] out TComponent? component
+    ) where TComponent : class, IComponent, new()
+    {
+        component = null;
+        var componentName = componentFactory.GetComponentName<TComponent>();
+        if (TryGetComponent(componentName, out var foundComponent))
+        {
+            component = (TComponent)foundComponent;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Tries getting the data of the given component.</summary>
+    /// <param name="componentFactory">The global component factory.</param>
+    /// <param name="componentType">Type of component to find.</param>
+    /// <param name="component">Found component or null.</param>
+    /// <returns>True if the component was found, false otherwise.</returns>
+    /// <seealso cref="TryGetComponent{T}"/>
+    public bool TryGetComponent(IComponentFactory componentFactory, Type componentType, [NotNullWhen(true)] out IComponent? component)
+    {
+        component = null;
+        var componentName = componentFactory.GetComponentName(componentType);
+        if (TryGetComponent(componentName, out component))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<string> GetExtraComponentTypes()
+    {
+        return _inner.Keys;
+    }
+
+    /// <inheritdoc />
+    public bool ShouldSkipComponent(string compName)
+    {
+        return false; //Registries cannot represent the "remove this component" state.
+    }
+
+    /// <summary>
+    ///     Enumerate components in the registry by type.
+    /// </summary>
+    public IEnumerable<Type> ComponentTypes()
+    {
+        return _inner.Values.Select(x => x.Component.GetType());
+    }
+
+    /// <summary>
+    ///     Enumerate components in the registry by value.
+    /// </summary>
+    public IEnumerable<IComponent> Components()
+    {
+        return _inner.Values.Select(x => x.Component);
+    }
+
+    /// <summary>
+    ///     Enumerate components in the registry by value, with their names.
+    /// </summary>
+    public IEnumerable<(string, IComponent)> ComponentsAndNames()
+    {
+        return _inner.Select(x => (x.Key, x.Value.Component));
+    }
+
+    /// <summary>
+    ///     Enumerates the names of all components in the registry.
+    /// </summary>
+    /// <returns></returns>
+    public IEnumerable<string> Names()
+    {
+        return _inner.Keys;
+    }
+
+    /// <summary>
+    ///     Enumerate components in the registry by value that are assignable to T.
+    /// </summary>
+    /// <typeparam name="T">The type to enumerate for.</typeparam>
+    /// <returns>All components assignable to T.</returns>
+    /// <example>
+    /// <code>
+    ///     // Get all components that implement the IFunny interface.
+    ///     var funnyComponents = registry.ComponentsAssignableTo&lt;IFunny&gt;();
+    /// </code>
+    /// </example>
+    public IEnumerable<T> ComponentsAssignableTo<T>()
+    {
+        return _inner.Values
+            .Where(x => x.Component is T)
+            .Select(x => (T)x.Component);
+    }
+
+    /// <summary>
+    ///     Tests if the registry contains the given component.
+    /// </summary>
+    /// <param name="factory">The global component factory.</param>
+    /// <param name="component">The type of component to check for.</param>
+    /// <returns>Whether the registry contains the given component.</returns>
+    public bool ContainsComponent(IComponentFactory factory, Type component)
+    {
+        var name = factory.GetComponentName(component);
+
+        return _inner.ContainsKey(name);
+    }
+
+    /// <summary>
+    ///     Tests if the registry contains the given component by name. You should prefer to use types!
+    /// </summary>
+    /// <param name="name">The name of the component to check for.</param>
+    /// <returns>Whether the registry contains the given component.</returns>
+    public bool ContainsComponentByName(string name)
+    {
+        return _inner.ContainsKey(name);
+    }
+
+    [Obsolete("ComponentRegistry is no longer an exposed dictionary, use the new methods like Components.")]
+    public IEnumerator<KeyValuePair<string, EntityPrototype.ComponentRegistryEntry>> GetEnumerator()
+    {
+        return _inner.GetEnumerator();
+    }
+
+    [Obsolete("ComponentRegistry is no longer an exposed dictionary, use the new methods like Components.")]
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return _inner.GetEnumerator();
+    }
+
+    [Obsolete("Legacy dictionary API compatibility. Use ContainsComponent.")]
+    public bool ContainsKey(string name)
+    {
+        return _inner.ContainsKey(name);
+    }
+
+    [Obsolete("Legacy dictionary API compatibility. Use TryGetComponent.")]
+    public bool TryGetValue(string name, [NotNullWhen(true)] out EntityPrototype.ComponentRegistryEntry? o)
+    {
+        return _inner.TryGetValue(name, out o);
+    }
+
+    /// <summary>
+    ///     Retrieves an underlying component entry, if possible.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="o"></param>
+    /// <returns></returns>
+    public bool TryGetEntry(string name, [NotNullWhen(true)] out EntityPrototype.ComponentRegistryEntry? o)
+    {
+        return _inner.TryGetValue(name, out o);
+    }
+
+    [Obsolete("Legacy dictionary API compatibility. Use AddComponent and TryGetComponent.")]
+    public EntityPrototype.ComponentRegistryEntry this[string compType]
+    {
+        get => _inner[compType];
+        set => _inner[compType] = value;
+    }
+
+    /// <summary>
+    ///     Empties the component registry entirely.
+    /// </summary>
+    public void Clear()
+    {
+        _inner.Clear();
+    }
+
+    /// <summary>
+    ///     Ensures the component registry has capacity for N components.
+    /// </summary>
+    /// <param name="count"></param>
+    /// <exception cref="NotImplementedException"></exception>
+    public void EnsureCapacity(int count)
+    {
+        _inner.EnsureCapacity(count);
+    }
+
+    /// <summary>
+    ///     Method for use by <see cref="ComponentRegistrySerializer"/> when deserializing.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="entry"></param>
+    internal void AddEntry(string name, EntityPrototype.ComponentRegistryEntry entry)
+    {
+        _inner[name] = entry;
+    }
+}

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -215,16 +215,18 @@ namespace Robust.Shared.Prototypes
 
             if (prototype != null)
             {
-                foreach (var (name, entry) in prototype.Components)
+                foreach (var comp in prototype.Components.Components())
                 {
-                    if (context != null && context.ShouldSkipComponent(name))
+                    var compReg = factory.GetRegistration(comp);
+
+                    if (context != null && context.ShouldSkipComponent(compReg.Name))
                         continue;
 
-                    var fullData = context != null && context.TryGetComponent(name, out var data) ? data : entry.Component;
-                    var compReg = factory.GetRegistration(name);
-                    EnsureCompExistsAndDeserialize(entity, compReg, factory, entityManager, serManager, name, fullData, ctx);
+                    var fullData = context != null && context.TryGetComponent(factory, comp.GetType(), out var data) ? data : comp;
 
-                    if (!entry.Component.NetSyncEnabled && compReg.NetID is {} netId)
+                    EnsureCompExistsAndDeserialize(entity, compReg, factory, entityManager, serManager, compReg.Name, fullData, ctx);
+
+                    if (!fullData.NetSyncEnabled && compReg.NetID is {} netId)
                         meta.NetComponents.Remove(netId);
                 }
             }
@@ -233,7 +235,7 @@ namespace Robust.Shared.Prototypes
             {
                 foreach (var name in context.GetExtraComponentTypes())
                 {
-                    if (prototype != null && prototype.Components.ContainsKey(name))
+                    if (prototype != null && prototype.Components.ContainsComponentByName(name))
                     {
                         // This component also exists in the prototype.
                         // This means that the previous step already caught both the prototype data AND map data.
@@ -241,7 +243,7 @@ namespace Robust.Shared.Prototypes
                         continue;
                     }
 
-                    if (!context.TryGetComponent(name, out var data))
+                    if (!context.TryGetComponent(factory, name, out var data))
                     {
                         throw new InvalidOperationException(
                             $"{nameof(IEntityLoadContext)} provided component name {name} but refused to provide data");

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -158,9 +158,9 @@ namespace Robust.Shared.Prototypes
         public EntityPrototype()
         {
             // Everybody gets a transform component!
-            Components.Add("Transform", new ComponentRegistryEntry(new TransformComponent(), new MappingDataNode()));
+            Components.AddComponentManual("Transform", new TransformComponent());
             // And a metadata component too!
-            Components.Add("MetaData", new ComponentRegistryEntry(new MetaDataComponent(), new MappingDataNode()));
+            Components.AddComponentManual("MetaData", new MetaDataComponent());
         }
 
         void ISerializationHooks.AfterDeserialization()
@@ -286,7 +286,14 @@ namespace Robust.Shared.Prototypes
         }
 
         [DataRecord]
-        public partial record ComponentRegistryEntry(IComponent Component, MappingDataNode Mapping);
+        public partial record ComponentRegistryEntry(
+            IComponent Component,
+            MappingDataNode? Mapping)
+        {
+            public ComponentRegistryEntry(IComponent component) : this(component, null)
+            {
+            }
+        }
 
         [DataDefinition]
         public sealed partial class EntityPlacementProperties
@@ -401,54 +408,5 @@ namespace Robust.Shared.Prototypes
                 return prototype.DataCache.TryGetValue(field, out value);
             }
         }*/
-    }
-
-    public sealed class ComponentRegistry : Dictionary<string, EntityPrototype.ComponentRegistryEntry>, IEntityLoadContext
-    {
-        public ComponentRegistry()
-        {
-        }
-
-        public ComponentRegistry(Dictionary<string, EntityPrototype.ComponentRegistryEntry> components) : base(components)
-        {
-        }
-
-        /// <inheritdoc />
-        public bool TryGetComponent(string componentName, [NotNullWhen(true)] out IComponent? component)
-        {
-            var success = TryGetValue(componentName, out var comp);
-            component = comp?.Component;
-
-            return success;
-        }
-
-        /// <inheritdoc />
-        public bool TryGetComponent<TComponent>(
-            IComponentFactory componentFactory,
-            [NotNullWhen(true)] out TComponent? component
-        ) where TComponent : class, IComponent, new()
-        {
-            component = null;
-            var componentName = componentFactory.GetComponentName<TComponent>();
-            if (TryGetComponent(componentName, out var foundComponent))
-            {
-                component = (TComponent)foundComponent;
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <inheritdoc />
-        public IEnumerable<string> GetExtraComponentTypes()
-        {
-            return Keys;
-        }
-
-        /// <inheritdoc />
-        public bool ShouldSkipComponent(string compName)
-        {
-            return false; //Registries cannot represent the "remove this component" state.
-        }
     }
 }

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -235,7 +235,7 @@ namespace Robust.Shared.Prototypes
             {
                 foreach (var name in context.GetExtraComponentTypes())
                 {
-                    if (prototype != null && prototype.Components.ContainsComponentByName(name))
+                    if (prototype != null && prototype.Components.ContainsComponentByName(factory, name))
                     {
                         // This component also exists in the prototype.
                         // This means that the previous step already caught both the prototype data AND map data.

--- a/Robust.Shared/Prototypes/PrototypeManager.Categories.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.Categories.cs
@@ -132,7 +132,7 @@ public abstract partial class PrototypeManager : IPrototypeManagerInternal
         }
 
         // Get automated categories inferred from components
-        foreach (var comp in protoInstance.Components.Keys)
+        foreach (var comp in protoInstance.Components.Names())
         {
             if (autoCategories.TryGetValue(comp, out var autoCats))
                 set.UnionWith(autoCats);

--- a/Robust.Shared/Prototypes/PrototypeManager.Categories.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.Categories.cs
@@ -3,6 +3,8 @@ using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.Markdown.Sequence;
 using Robust.Shared.Serialization.Markdown.Value;
@@ -13,6 +15,8 @@ namespace Robust.Shared.Prototypes;
 // This partial class handles entity prototype categories
 public abstract partial class PrototypeManager : IPrototypeManagerInternal
 {
+    [Dependency] private readonly IComponentFactory _componentFactory = default!;
+
     /// <summary>
     /// Cached array of components with the <see cref="EntityCategoryAttribute"/>
     /// </summary>
@@ -132,7 +136,7 @@ public abstract partial class PrototypeManager : IPrototypeManagerInternal
         }
 
         // Get automated categories inferred from components
-        foreach (var comp in protoInstance.Components.Names())
+        foreach (var comp in protoInstance.Components.Names(_componentFactory))
         {
             if (autoCategories.TryGetValue(comp, out var autoCats))
                 set.UnionWith(autoCats);

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentFilterSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentFilterSerializer.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Sequence;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+
+namespace Robust.Shared.Serialization.TypeSerializers.Implementations;
+
+[TypeSerializer]
+public sealed class ComponentFilterSerializer : ITypeSerializer<ComponentFilter, SequenceDataNode>, ITypeInheritanceHandler<ComponentFilter, SequenceDataNode>, ITypeCopier<ComponentFilter>
+{
+    public ValidationNode Validate(
+        ISerializationManager serializationManager,
+        SequenceDataNode node,
+        IDependencyCollection dependencies,
+        ISerializationContext? context = null)
+    {
+        var factory = dependencies.Resolve<IComponentFactory>();
+        var filter = new ComponentFilter();
+        var list = new List<ValidationNode>();
+
+        foreach (var seqEntry in node)
+        {
+            if (seqEntry is not ValueDataNode value)
+            {
+                list.Add(new ErrorNode(seqEntry, "Expected a single, scalar value."));
+                continue;
+            }
+
+            var compType = value.Value;
+
+            switch (factory.GetComponentAvailability(compType))
+            {
+                case ComponentAvailability.Available:
+                    break;
+
+                case ComponentAvailability.Ignore:
+                    list.Add(new ValidatedValueNode(seqEntry));
+                    continue;
+
+                case ComponentAvailability.Unknown:
+                    list.Add(new ErrorNode(seqEntry, $"Unknown component type {compType}."));
+                    continue;
+            }
+
+            if (!filter.Add(factory, compType))
+            {
+                list.Add(new ErrorNode(seqEntry, "Duplicate Component."));
+                continue;
+            }
+
+            list.Add(new ValidatedValueNode(seqEntry));
+        }
+
+        var referenceTypes = new List<CompIdx>();
+
+        // Assert that there are no conflicting component references.
+        foreach (var component in filter)
+        {
+            var registration = factory.GetRegistration(component);
+            var compType = registration.Idx;
+
+            if (referenceTypes.Contains(compType))
+            {
+                return new ErrorNode(node, "Contains a duplicate component reference.");
+            }
+
+            referenceTypes.Add(compType);
+        }
+
+        return new ValidatedSequenceNode(list);
+    }
+
+    public ComponentFilter Read(
+        ISerializationManager serializationManager,
+        SequenceDataNode node,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context = null,
+        ISerializationManager.InstantiationDelegate<ComponentFilter>? instanceProvider = null)
+    {
+        var factory = dependencies.Resolve<IComponentFactory>();
+        var filter = new ComponentFilter();
+
+        foreach (var seqEntry in node)
+        {
+            if (seqEntry is not ValueDataNode value)
+                throw new InvalidOperationException("ComponentFilter contained a non-value entry.");
+
+            filter.Add(factory, value.Value);
+        }
+
+        return filter;
+    }
+
+    public DataNode Write(
+        ISerializationManager serializationManager,
+        ComponentFilter value,
+        IDependencyCollection dependencies,
+        bool alwaysWrite = false,
+        ISerializationContext? context = null)
+    {
+        var factory = dependencies.Resolve<IComponentFactory>();
+        var seq = new SequenceDataNode();
+
+        foreach (var componentType in value)
+        {
+            seq.Add(new ValueDataNode(factory.GetComponentName(componentType)));
+        }
+
+        return seq;
+    }
+
+    public SequenceDataNode PushInheritance(
+        ISerializationManager serializationManager,
+        SequenceDataNode child,
+        SequenceDataNode parent,
+        IDependencyCollection dependencies,
+        ISerializationContext? context)
+    {
+        var setLeft = child.Select(x => (x as ValueDataNode)?.Value);
+        var setRight = child.Select(x => (x as ValueDataNode)?.Value);
+
+        var newSet = setLeft.Concat(setRight).ToHashSet();
+
+        if (newSet.Contains(null))
+            throw new InvalidOperationException("Pushing inheritance for filter failed due to non-value entries");
+
+        return new SequenceDataNode(newSet.Select(x => new ValueDataNode(x!)).ToArray<DataNode>());
+    }
+
+    public void CopyTo(
+        ISerializationManager serializationManager,
+        ComponentFilter source,
+        ref ComponentFilter target,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context = null)
+    {
+        target.Clear();
+        target.UnionWith(source);
+    }
+}

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentRegistrySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentRegistrySerializer.cs
@@ -12,7 +12,6 @@ using Robust.Shared.Serialization.Markdown.Sequence;
 using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
-using Robust.Shared.Utility;
 using static Robust.Shared.Prototypes.EntityPrototype;
 
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations
@@ -20,7 +19,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
     [TypeSerializer]
     public sealed class ComponentRegistrySerializer : ITypeSerializer<ComponentRegistry, SequenceDataNode>, ITypeInheritanceHandler<ComponentRegistry, SequenceDataNode>, ITypeCopier<ComponentRegistry>
     {
-        public ComponentRegistry Read(ISerializationManager serializationManager,
+        public ComponentRegistry Read(
+            ISerializationManager serializationManager,
             SequenceDataNode node,
             IDependencyCollection dependencies,
             SerializationHookContext hookCtx,
@@ -52,7 +52,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
                 }
 
                 // Has this type already been added?
-                if (components.ContainsKey(compType))
+                if (components.ContainsComponentByName(compType))
                 {
                     dependencies
                         .Resolve<ILogManager>()
@@ -61,20 +61,20 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
                     continue;
                 }
 
-                var copy = componentMapping.Copy()!;
+                var copy = componentMapping.Copy();
                 copy.Remove("type");
 
                 var type = factory.GetRegistration(compType).Type;
                 var read = (IComponent)serializationManager.Read(type, copy, hookCtx, context)!;
 
-                components[compType] = new ComponentRegistryEntry(read, copy);
+                components.AddEntry(compType, new ComponentRegistryEntry(read, copy));
             }
 
             var referenceTypes = new List<CompIdx>();
             // Assert that there are no conflicting component references.
-            foreach (var componentName in components.Keys)
+            foreach (var component in components.Components())
             {
-                var registration = factory.GetRegistration(componentName);
+                var registration = factory.GetRegistration(component);
                 var compType = registration.Idx;
 
                 if (referenceTypes.Contains(compType))
@@ -89,7 +89,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             return components;
         }
 
-        public ValidationNode Validate(ISerializationManager serializationManager,
+        public ValidationNode Validate(
+            ISerializationManager serializationManager,
             SequenceDataNode node,
             IDependencyCollection dependencies,
             ISerializationContext? context = null)
@@ -122,13 +123,13 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
                 }
 
                 // Has this type already been added?
-                if (components.ContainsKey(compType))
+                if (components.ContainsComponentByName(compType))
                 {
                     list.Add(new ErrorNode(componentMapping, "Duplicate Component."));
                     continue;
                 }
 
-                var copy = componentMapping.Copy()!;
+                var copy = componentMapping.Copy();
                 copy.Remove("type");
 
                 var type = factory.GetRegistration(compType).Type;
@@ -139,9 +140,9 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             var referenceTypes = new List<CompIdx>();
 
             // Assert that there are no conflicting component references.
-            foreach (var componentName in components.Keys)
+            foreach (var component in components.Components())
             {
-                var registration = factory.GetRegistration(componentName);
+                var registration = factory.GetRegistration(component);
                 var compType = registration.Idx;
 
                 if (referenceTypes.Contains(compType))
@@ -155,17 +156,20 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             return new ValidatedSequenceNode(list);
         }
 
-        public DataNode Write(ISerializationManager serializationManager, ComponentRegistry value,
+        public DataNode Write(
+            ISerializationManager serializationManager,
+            ComponentRegistry value,
             IDependencyCollection dependencies,
             bool alwaysWrite = false,
             ISerializationContext? context = null)
         {
             var compSequence = new SequenceDataNode();
-            foreach (var (type, component) in value)
+
+            foreach (var (type, component) in value.ComponentsAndNames())
             {
                 var node = serializationManager.WriteValue(
-                    component.Component.GetType(),
-                    component.Component,
+                    component.GetType(),
+                    component,
                     alwaysWrite,
                     context);
 
@@ -178,21 +182,30 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             return compSequence;
         }
 
-        public void CopyTo(ISerializationManager serializationManager, ComponentRegistry source, ref ComponentRegistry target,
-            IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context = null)
+        public void CopyTo(
+            ISerializationManager serializationManager,
+            ComponentRegistry source,
+            ref ComponentRegistry target,
+            IDependencyCollection dependencies,
+            SerializationHookContext hookCtx,
+            ISerializationContext? context = null)
         {
             target.Clear();
             target.EnsureCapacity(source.Count);
 
-            foreach (var (id, component) in source)
+            // We have legitimate use here for the obsolete member.
+            foreach (var (id, component) in source.ComponentsAndNames())
             {
-                target.Add(id, serializationManager.CreateCopy(component, context, notNullableOverride: true));
+                target.AddComponentManual(id, serializationManager.CreateCopy(component, context, notNullableOverride: true));
             }
         }
 
-        public SequenceDataNode PushInheritance(ISerializationManager serializationManager, SequenceDataNode child,
+        public SequenceDataNode PushInheritance(
+            ISerializationManager serializationManager,
+            SequenceDataNode child,
             SequenceDataNode parent,
-            IDependencyCollection dependencies, ISerializationContext? context)
+            IDependencyCollection dependencies,
+            ISerializationContext? context)
         {
             var componentFactory = dependencies.Resolve<IComponentFactory>();
             var newCompReg = child.Copy();

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentRegistrySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentRegistrySerializer.cs
@@ -164,8 +164,9 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             ISerializationContext? context = null)
         {
             var compSequence = new SequenceDataNode();
+            var factory = dependencies.Resolve<IComponentFactory>();
 
-            foreach (var (type, component) in value.ComponentsAndNames())
+            foreach (var (type, component) in value.ComponentsAndNames(factory))
             {
                 var node = serializationManager.WriteValue(
                     component.GetType(),
@@ -192,9 +193,10 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
         {
             target.Clear();
             target.EnsureCapacity(source.Count);
+            var factory = dependencies.Resolve<IComponentFactory>();
 
             // We have legitimate use here for the obsolete member.
-            foreach (var (id, component) in source.ComponentsAndNames())
+            foreach (var (id, component) in source.ComponentsAndNames(factory))
             {
                 target.AddComponentManual(id, serializationManager.CreateCopy(component, context, notNullableOverride: true));
             }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentRegistrySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentRegistrySerializer.cs
@@ -52,7 +52,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
                 }
 
                 // Has this type already been added?
-                if (components.ContainsComponentByName(compType))
+                if (components.ContainsComponentByName(factory, compType))
                 {
                     dependencies
                         .Resolve<ILogManager>()
@@ -123,7 +123,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
                 }
 
                 // Has this type already been added?
-                if (components.ContainsComponentByName(compType))
+                if (components.ContainsComponentByName(factory, compType))
                 {
                     list.Add(new ErrorNode(componentMapping, "Duplicate Component."));
                     continue;

--- a/Robust.UnitTesting/Pool/TestPair.Helpers.cs
+++ b/Robust.UnitTesting/Pool/TestPair.Helpers.cs
@@ -71,8 +71,17 @@ public partial class TestPair<TServer, TClient>
         bool ignoreTestPrototypes = true)
         where T : IComponent, new()
     {
-        if (!Server.Resolve<IComponentFactory>().TryGetRegistration<T>(out var reg)
-            && !Client.Resolve<IComponentFactory>().TryGetRegistration<T>(out reg))
+        IComponentFactory? factory = null;
+        if (Server.Resolve<IComponentFactory>().TryGetRegistration<T>(out var reg))
+        {
+            factory = Server.Resolve<IComponentFactory>();
+        }
+        else if (Client.Resolve<IComponentFactory>().TryGetRegistration<T>(out reg))
+        {
+            factory = Client.Resolve<IComponentFactory>();
+        }
+
+        if (factory is null || reg is null)
         {
             Assert.Fail($"Unknown component: {typeof(T).Name}");
             return new();
@@ -91,7 +100,7 @@ public partial class TestPair<TServer, TClient>
             if (ignoreTestPrototypes && IsTestPrototype(proto))
                 continue;
 
-            if (proto.Components.TryGetComponent(id, out var cmp))
+            if (proto.Components.TryGetComponent(factory, id, out var cmp))
                 list.Add((proto, (T)cmp));
         }
 


### PR DESCRIPTION
This removes all of the API surface that exposed ComponentRegistry as a dictionary, leaving the remaining necessary surface [Obsolete].

This also simplifies certain common usecases for ComponentRegistry, and pushes the user toward *not* using it as a filter list.

This also adds `ComponentFilter`, a (much more ergonomic) replacement for the ComponentRegistry-as-filters misuse.

Resolves #6440 as much as possible while requiring minimal content PRs. Further content PRs are part 2.