### PR TITLE
Prevent UI update limits from causing test flaking.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,8 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+- UI styling and update limits are now disabled in testing through the `ui.obey_update_limits` cvar. This cvar is only
+  functional in debug builds of engine.
 
 ### Other
 

--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -62,6 +62,8 @@ namespace Robust.Client.UserInterface
         /// </summary>
         public const int ControlUpdateLimit = 25_000;
 
+        private bool _obeyUpdateLimits;
+
         [ViewVariables] public InterfaceTheme ThemeDefaults { get; private set; } = default!;
         [ViewVariables]
         public Stylesheet? Stylesheet
@@ -108,6 +110,7 @@ namespace Robust.Client.UserInterface
         {
             _dependencies = new DependencyCollection(_rootDependencies);
             _configurationManager.OnValueChanged(CVars.DisplayUIScale, _uiScaleChanged, true);
+            _configurationManager.OnValueChanged(CVars.UIObeyUpdateLimits, _uiObeyUpdateLimitsChanged, true);
             ThemeDefaults = new InterfaceThemeDummy();
             _initScaling();
             SetupControllers();
@@ -139,6 +142,11 @@ namespace Robust.Client.UserInterface
             _initThemes();
 
             _stylesheet = new DefaultStylesheet(_resourceCache, this).Stylesheet;
+        }
+
+        private void _uiObeyUpdateLimitsChanged(bool newValue, in CVarChangeInfo info)
+        {
+            _obeyUpdateLimits = newValue;
         }
 
         public void PostInitialize()
@@ -226,7 +234,7 @@ namespace Robust.Client.UserInterface
                 var total = 0;
                 while (_styleUpdateQueue.Count != 0)
                 {
-                    if (total >= ControlUpdateLimit)
+                    if (total >= ControlUpdateLimit && _obeyUpdateLimits)
                     {
                         _sawmillUI.Warning($"Hit style update limit. Queued: {_styleUpdateQueue.Count}. Next in queue: {_styleUpdateQueue.Peek()}. Parent: {_styleUpdateQueue.Peek().Parent}");
                         break;
@@ -249,7 +257,7 @@ namespace Robust.Client.UserInterface
                 var total = 0;
                 while (_measureUpdateQueue.Count != 0)
                 {
-                    if (total >= ControlUpdateLimit)
+                    if (total >= ControlUpdateLimit && _obeyUpdateLimits)
                     {
                         _sawmillUI.Warning($"Hit measure update limit. Queued: {_measureUpdateQueue.Count}. Next in queue: {_measureUpdateQueue.Peek()}. Parent: {_measureUpdateQueue.Peek().Parent}");
                         break;
@@ -275,7 +283,7 @@ namespace Robust.Client.UserInterface
                 var total = 0;
                 while (_arrangeUpdateQueue.Count != 0)
                 {
-                    if (total >= ControlUpdateLimit)
+                    if (total >= ControlUpdateLimit && _obeyUpdateLimits)
                     {
                         _sawmillUI.Warning($"Hit arrange update limit. Queued: {_arrangeUpdateQueue.Count}. Next in queue: {_arrangeUpdateQueue.Peek()}. Parent: {_arrangeUpdateQueue.Peek().Parent}");
                         break;

--- a/Robust.Client/UserInterface/UserInterfaceManager.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.cs
@@ -62,7 +62,7 @@ namespace Robust.Client.UserInterface
         /// </summary>
         public const int ControlUpdateLimit = 25_000;
 
-        private bool _obeyUpdateLimits;
+        private bool _obeyUpdateLimits = true;
 
         [ViewVariables] public InterfaceTheme ThemeDefaults { get; private set; } = default!;
         [ViewVariables]
@@ -110,7 +110,9 @@ namespace Robust.Client.UserInterface
         {
             _dependencies = new DependencyCollection(_rootDependencies);
             _configurationManager.OnValueChanged(CVars.DisplayUIScale, _uiScaleChanged, true);
+#if DEBUG
             _configurationManager.OnValueChanged(CVars.UIObeyUpdateLimits, _uiObeyUpdateLimitsChanged, true);
+#endif
             ThemeDefaults = new InterfaceThemeDummy();
             _initScaling();
             SetupControllers();

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1971,6 +1971,13 @@ namespace Robust.Shared
         public static readonly CVarDef<bool> UIXamlJitPreload =
             CVarDef.Create("ui.xaml_jit_preload", false, CVar.CLIENTONLY);
 
+        /// <summary>
+        ///     If false, the UI engine will not ever sleep updating controls.
+        ///     This should <b>never</b> be set outside of test frameworks, doing so worsens user experience by allowing
+        ///     the game to do excessive amounts of work in one frame, causing extra lag.
+        /// </summary>
+        public static readonly CVarDef<bool> UIObeyUpdateLimits =
+            CVarDef.Create("ui.obey_update_limits", true, CVar.CLIENTONLY);
         /*
          * FONT
          */

--- a/Robust.UnitTesting/Pool/PoolManager.cs
+++ b/Robust.UnitTesting/Pool/PoolManager.cs
@@ -27,7 +27,8 @@ public abstract class BasePoolManager
         (CVars.ThreadParallelCount.Name, "1"),
         (CVars.ReplayClientRecordingEnabled.Name, "false"),
         (CVars.ReplayServerRecordingEnabled.Name, "false"),
-        (CVars.NetBufferSize.Name, "0")
+        (CVars.NetBufferSize.Name, "0"),
+        (CVars.UIObeyUpdateLimits.Name, "false")
     ];
 }
 


### PR DESCRIPTION
This adds a new CVar for disabling the update limits, to use exclusively within tests.
It also then sets this CVar by default during testing.

This should fix a long-standing test flake from the guidebook tests, among other future UI tests.