### PR TITLE
Improve test CI and reduce test log spam.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Build
         run: dotnet build --no-restore /p:WarningsAsErrors=nullable
       - name: Run tests
-        run: dotnet test --no-build -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="/home/runner/work/test_results"
+        shell: pwsh
+        run: dotnet test --no-build -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="$($env:GITHUB_WORKSPACE)/test_results"
       - name: Archive NUnit3 test results.
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,8 +31,8 @@ jobs:
         shell: pwsh
         run: dotnet test --no-build -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="$(pwd)/test_results"
       - name: Archive NUnit3 test results.
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: nunit3-results
-          path: /home/runner/work/test_results/*
+          path: test_results/*

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,3 +36,4 @@ jobs:
         with:
           name: nunit3-results-${{ matrix.os }}
           path: test_results/*
+          retention-days: 7

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,5 +34,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: nunit3-results
+          name: nunit3-results-${{ matrix.os }}
           path: test_results/*

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,7 +29,7 @@ jobs:
         run: dotnet build --no-restore /p:WarningsAsErrors=nullable
       - name: Run tests
         shell: pwsh
-        run: dotnet test --no-build -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="$(pwd)/test_results"
+        run: dotnet test --no-build -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="logs" NUnit.WorkDirectory="$(pwd)/test_results"
       - name: Archive NUnit3 test results.
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,7 +29,7 @@ jobs:
         run: dotnet build --no-restore /p:WarningsAsErrors=nullable
       - name: Run tests
         shell: pwsh
-        run: dotnet test --no-build -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="$($env:GITHUB_WORKSPACE)/test_results"
+        run: dotnet test --no-build -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="$(pwd)/test_results"
       - name: Archive NUnit3 test results.
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,4 +28,10 @@ jobs:
       - name: Build
         run: dotnet build --no-restore /p:WarningsAsErrors=nullable
       - name: Run tests
-        run: dotnet test --no-build -- NUnit.ConsoleOut=0
+        run: dotnet test --no-build -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="/home/runner/work/test_results"
+      - name: Archive NUnit3 test results.
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nunit3-results
+          path: /home/runner/work/test_results/*

--- a/.github/workflows/test-content.yml
+++ b/.github/workflows/test-content.yml
@@ -37,9 +37,14 @@ jobs:
       - name: Build
         run: dotnet build --configuration DebugOpt --no-restore /m
       - name: Content.Tests
-        run: dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0
+        run: dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="$($pwd)/test_results"
       - name: Content.IntegrationTests
         shell: pwsh
         run: |
           $env:DOTNET_gcServer=1
-          dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed
+          dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="$($pwd)/test_results"
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v4
+        with:
+          name: nunit3-results
+          path: test_results/*

--- a/.github/workflows/test-content.yml
+++ b/.github/workflows/test-content.yml
@@ -45,8 +45,8 @@ jobs:
           $env:DOTNET_gcServer=1
           dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="$(pwd)/test_results"
       - name: Archive NUnit3 test results.
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: nunit3-results
-          path: /home/runner/work/test_results/*
+          path: test_results/*

--- a/.github/workflows/test-content.yml
+++ b/.github/workflows/test-content.yml
@@ -37,14 +37,15 @@ jobs:
       - name: Build
         run: dotnet build --configuration DebugOpt --no-restore /m
       - name: Content.Tests
-        run: dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="$($pwd)/test_results"
+        run: dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="/home/runner/work/test_results"
       #- name: Content.IntegrationTests
       #  shell: pwsh
       #  run: |
       #    $env:DOTNET_gcServer=1
-      #    dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="$($pwd)/test_results"
+      #    dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="/home/runner/work/test_results"
       - name: Archive NUnit3 test results.
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: nunit3-results
-          path: test_results/*
+          path: /home/runner/work/test_results/*

--- a/.github/workflows/test-content.yml
+++ b/.github/workflows/test-content.yml
@@ -43,7 +43,7 @@ jobs:
         shell: pwsh
         run: |
           $env:DOTNET_gcServer=1
-          dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="$(pwd)/test_results"
+          dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="logs" NUnit.WorkDirectory="$(pwd)/test_results"
       - name: Archive NUnit3 test results.
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-content.yml
+++ b/.github/workflows/test-content.yml
@@ -35,8 +35,10 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
       - name: Build
-        run: dotnet build --configuration Tools --no-restore
+        run: dotnet build --configuration DebugOpt --no-restore /m
       - name: Content.Tests
-        run: dotnet test --no-build Content.Tests/Content.Tests.csproj -v n
+        run: dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0
       - name: Content.IntegrationTests
-        run: COMPlus_gcServer=1 dotnet test --no-build Content.IntegrationTests/Content.IntegrationTests.csproj -v n
+        run: |
+          $env:DOTNET_gcServer=1
+          dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed

--- a/.github/workflows/test-content.yml
+++ b/.github/workflows/test-content.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Build
         run: dotnet build --configuration DebugOpt --no-restore /m
       - name: Content.Tests
-        run: dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="./test_results"
+        run: dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="$($pwd)/test_results"
       #- name: Content.IntegrationTests
       #  shell: pwsh
       #  run: |
       #    $env:DOTNET_gcServer=1
-      #    dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="./test_results"
+      #    dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="$($pwd)/test_results"
       - name: Archive NUnit3 test results.
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test-content.yml
+++ b/.github/workflows/test-content.yml
@@ -50,3 +50,4 @@ jobs:
         with:
           name: nunit3-results
           path: test_results/*
+          retention-days: 7

--- a/.github/workflows/test-content.yml
+++ b/.github/workflows/test-content.yml
@@ -38,13 +38,13 @@ jobs:
         run: dotnet build --configuration DebugOpt --no-restore /m
       - name: Content.Tests
         run: dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="/home/runner/work/test_results"
-      #- name: Content.IntegrationTests
-      #  shell: pwsh
-      #  run: |
-      #    $env:DOTNET_gcServer=1
-      #    dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="/home/runner/work/test_results"
+      - name: Content.IntegrationTests
+        shell: pwsh
+        run: |
+          $env:DOTNET_gcServer=1
+          dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="/home/runner/work/test_results"
       - name: Archive NUnit3 test results.
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: nunit3-results

--- a/.github/workflows/test-content.yml
+++ b/.github/workflows/test-content.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Build
         run: dotnet build --configuration DebugOpt --no-restore /m
       - name: Content.Tests
-        run: dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="$($pwd)/test_results"
-      - name: Content.IntegrationTests
-        shell: pwsh
-        run: |
-          $env:DOTNET_gcServer=1
-          dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="$($pwd)/test_results"
+        run: dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="./test_results"
+      #- name: Content.IntegrationTests
+      #  shell: pwsh
+      #  run: |
+      #    $env:DOTNET_gcServer=1
+      #    dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="./test_results"
       - name: Archive NUnit3 test results.
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test-content.yml
+++ b/.github/workflows/test-content.yml
@@ -38,12 +38,12 @@ jobs:
         run: dotnet build --configuration DebugOpt --no-restore /m
       - name: Content.Tests
         shell: pwsh
-        run: dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="$($env:GITHUB_WORKSPACE)/test_results"
+        run: dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="$(pwd)/test_results"
       - name: Content.IntegrationTests
         shell: pwsh
         run: |
           $env:DOTNET_gcServer=1
-          dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="$($env:GITHUB_WORKSPACE)/test_results"
+          dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="$(pwd)/test_results"
       - name: Archive NUnit3 test results.
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-content.yml
+++ b/.github/workflows/test-content.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           $env:DOTNET_gcServer=1
           dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="$($pwd)/test_results"
-      - name: Archive code coverage results
+      - name: Archive NUnit3 test results.
         uses: actions/upload-artifact@v4
         with:
           name: nunit3-results

--- a/.github/workflows/test-content.yml
+++ b/.github/workflows/test-content.yml
@@ -37,12 +37,13 @@ jobs:
       - name: Build
         run: dotnet build --configuration DebugOpt --no-restore /m
       - name: Content.Tests
-        run: dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="/home/runner/work/test_results"
+        shell: pwsh
+        run: dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="$($env:GITHUB_WORKSPACE)/test_results"
       - name: Content.IntegrationTests
         shell: pwsh
         run: |
           $env:DOTNET_gcServer=1
-          dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="/home/runner/work/test_results"
+          dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="$($env:GITHUB_WORKSPACE)/test_results"
       - name: Archive NUnit3 test results.
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-content.yml
+++ b/.github/workflows/test-content.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Content.Tests
         run: dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0
       - name: Content.IntegrationTests
+        shell: pwsh
         run: |
           $env:DOTNET_gcServer=1
           dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -48,6 +48,7 @@ END TEMPLATE-->
 - Test history now includes the GC total memory usage at time of AddToHistory() call. This is typically while the test
   is obtaining a pair.
 - ITestPair is now `[NotContentImplementable]` and future additions to the interface will not be considered breaking.
+- Erroneous logs in tests are now allowed to occur more than once, and assert a failure at the end of the test while doing pair cleanup instead of during it.
 
 ### New features
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -38,12 +38,16 @@ END TEMPLATE-->
 - ITestPair.Init() now requires a TextWriter be provided to write its gravestone to.
   This gravestone is where TestPair test history is now written to.
 - ITestPair.AddToHistory() must be used to add tests to the test history.
+- Test history is now stored in ITestPair.ExtendedTestHistory.
 - Engine and content tests relying on TestPair using NUnit will now automatically
   output gravestone files for test history. You should set the working directory for tests if you wish to
   use these artifacts.
-- Using testpairs outside of a test environment without providing an `ITestContextLike` implementor will
-  now crash due to the lack of a running test.
+- Using test pairs outside of a test environment without providing an `ITestContextLike` implementor will
+  now crash due to the lack of a running NUnit test. Use an `ExternalTestContext` for this use case.
 - Test logs no longer contain TestPair history.
+- Test history now includes the GC total memory usage at time of AddToHistory() call. This is typically while the test
+  is obtaining a pair.
+- ITestPair is now `[NotContentImplementable]` and future additions to the interface will not be considered breaking.
 
 ### New features
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,11 +35,19 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+- ITestPair.Init() now requires a TextWriter be provided to write its gravestone to.
+  This gravestone is where TestPair test history is now written to.
+- ITestPair.AddToHistory() must be used to add tests to the test history.
+- Engine and content tests relying on TestPair using NUnit will now automatically
+  output gravestone files for test history. You should set the working directory for tests if you wish to
+  use these artifacts.
+- Using testpairs outside of a test environment without providing an `ITestContextLike` implementor will
+  now crash due to the lack of a running test.
+- Test logs no longer contain TestPair history.
 
 ### New features
 
-*None yet*
+- TestPairs now automatically log their test history to a gravestone file.
 
 ### Bugfixes
 

--- a/Robust.Server.IntegrationTests/GameObjects/ComponentMapInitTest.cs
+++ b/Robust.Server.IntegrationTests/GameObjects/ComponentMapInitTest.cs
@@ -31,6 +31,8 @@ internal sealed partial class ComponentMapInitTest
         var mapSystem = entManager.System<SharedMapSystem>();
         mapSystem.CreateMap(out var mapId);
 
+        Assert.Fail("Stinky.");
+
         var ent = entManager.SpawnEntity(null, new MapCoordinates(Vector2.Zero, mapId));
         Assert.That(entManager.GetComponent<MetaDataComponent>(ent).EntityLifeStage, Is.EqualTo(EntityLifeStage.MapInitialized));
 

--- a/Robust.Server.IntegrationTests/GameObjects/ComponentMapInitTest.cs
+++ b/Robust.Server.IntegrationTests/GameObjects/ComponentMapInitTest.cs
@@ -31,8 +31,6 @@ internal sealed partial class ComponentMapInitTest
         var mapSystem = entManager.System<SharedMapSystem>();
         mapSystem.CreateMap(out var mapId);
 
-        Assert.Fail("Stinky.");
-
         var ent = entManager.SpawnEntity(null, new MapCoordinates(Vector2.Zero, mapId));
         Assert.That(entManager.GetComponent<MetaDataComponent>(ent).EntityLifeStage, Is.EqualTo(EntityLifeStage.MapInitialized));
 

--- a/Robust.Shared.IntegrationTests/Testing/EngineDummyTestPool.cs
+++ b/Robust.Shared.IntegrationTests/Testing/EngineDummyTestPool.cs
@@ -1,0 +1,11 @@
+using Robust.UnitTesting.Pool;
+
+namespace Robust.UnitTesting.Shared.Testing;
+
+/// <summary>
+///     A test pool specifically for testing testpool and testpair behavior.
+/// </summary>
+internal sealed class EngineDummyTestPool : PoolManager<RobustIntegrationTest.TestPair>
+{
+
+}

--- a/Robust.Shared.IntegrationTests/Testing/EngineTestErrorLogFails.cs
+++ b/Robust.Shared.IntegrationTests/Testing/EngineTestErrorLogFails.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using Robust.UnitTesting.Pool;
 
 namespace Robust.UnitTesting.Shared.Testing;
 
@@ -6,6 +7,7 @@ namespace Robust.UnitTesting.Shared.Testing;
 public sealed class EngineTestErrorLogFails
 {
     [Test]
+    [Description("Asserts that Error level logs in a test pair instance do not throw, but do assert during cleanup.")]
     public async Task AssertErrorLoggingFailsTest()
     {
         var pool = new EngineDummyTestPool();
@@ -14,10 +16,14 @@ public sealed class EngineTestErrorLogFails
 
         var pair = await pool.GetPair();
 
+        // Log on both sides.. nothing should happen.
         Assert.DoesNotThrow(() => pair.Server.Log.Error("Mogus"));
         Assert.DoesNotThrow(() => pair.Client.Log.Error("Mogus"));
 
+        // But it should get very mad here.
         Assert.ThrowsAsync<MultipleAssertException>(async () => await pair.CleanReturnAsync());
+
+        Assert.That(pair.State, NUnit.Framework.Is.EqualTo(PairState.Dead));
 
         pool.Shutdown();
     }

--- a/Robust.Shared.IntegrationTests/Testing/EngineTestErrorLogFails.cs
+++ b/Robust.Shared.IntegrationTests/Testing/EngineTestErrorLogFails.cs
@@ -7,8 +7,8 @@ namespace Robust.UnitTesting.Shared.Testing;
 public sealed class EngineTestErrorLogFails
 {
     [Test]
-    [Description("Asserts that Error level logs in a test pair instance do not throw, but do assert during cleanup.")]
-    public async Task AssertErrorLoggingFailsTest()
+    [Description("Asserts that Error level logs in a test pair instance do not throw, but do assert during CleanReturnAsync.")]
+    public async Task AssertErrorLoggingFailsTestCleanReturnAsync()
     {
         var pool = new EngineDummyTestPool();
 
@@ -23,7 +23,27 @@ public sealed class EngineTestErrorLogFails
         // But it should get very mad here.
         Assert.ThrowsAsync<MultipleAssertException>(async () => await pair.CleanReturnAsync());
 
-        Assert.That(pair.State, NUnit.Framework.Is.EqualTo(PairState.Dead));
+        Assert.That(pair.State, NUnit.Framework.Is.EqualTo(PairState.Dead), "Expected the pair's return to result in its death.");
+
+        pool.Shutdown();
+    }
+
+    [Test]
+    [Description("Asserts that Error level logs in a test pair instance do not throw, but do assert during DirtyDispose.")]
+    public async Task AssertErrorLoggingFailsTestDirtyDispose()
+    {
+        var pool = new EngineDummyTestPool();
+
+        pool.Startup();
+
+        var pair = await pool.GetPair();
+
+        Assert.DoesNotThrow(() => pair.Server.Log.Error("Mogus"));
+        Assert.DoesNotThrow(() => pair.Client.Log.Error("Mogus"));
+
+        Assert.ThrowsAsync<MultipleAssertException>(async () => await pair.DisposeAsync());
+
+        Assert.That(pair.State, NUnit.Framework.Is.EqualTo(PairState.Dead), "Expected the pair's return to result in its death.");
 
         pool.Shutdown();
     }

--- a/Robust.Shared.IntegrationTests/Testing/EngineTestErrorLogFails.cs
+++ b/Robust.Shared.IntegrationTests/Testing/EngineTestErrorLogFails.cs
@@ -1,0 +1,24 @@
+using NUnit.Framework;
+
+namespace Robust.UnitTesting.Shared.Testing;
+
+
+public sealed class EngineTestErrorLogFails
+{
+    [Test]
+    public async Task AssertErrorLoggingFailsTest()
+    {
+        var pool = new EngineDummyTestPool();
+
+        pool.Startup();
+
+        var pair = await pool.GetPair();
+
+        Assert.DoesNotThrow(() => pair.Server.Log.Error("Mogus"));
+        Assert.DoesNotThrow(() => pair.Client.Log.Error("Mogus"));
+
+        Assert.ThrowsAsync<MultipleAssertException>(async () => await pair.CleanReturnAsync());
+
+        pool.Shutdown();
+    }
+}

--- a/Robust.UnitTesting/Pool/ITestPair.cs
+++ b/Robust.UnitTesting/Pool/ITestPair.cs
@@ -23,11 +23,12 @@ public interface ITestPair
     void SetupSeed();
     void ClearModifiedCvars();
     void Use();
-    Task Init(int id, BasePoolManager manager, PairSettings settings, TextWriter testOut);
+    Task Init(int id, BasePoolManager manager, PairSettings settings, TextWriter testOut, TextWriter? gravestone);
     Task RecycleInternal(PairSettings next, TextWriter testOut);
     Task ApplySettings(PairSettings settings);
     Task RunTicksSync(int ticks);
     Task SyncTicks(int targetDelta = 1);
+    Task AddToHistory(string testName);
 }
 
 public enum PairState : byte

--- a/Robust.UnitTesting/Pool/ITestPair.cs
+++ b/Robust.UnitTesting/Pool/ITestPair.cs
@@ -1,10 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Robust.Shared.Timing;
 
 namespace Robust.UnitTesting.Pool;
 
+[NotContentImplementable]
 public interface ITestPair
 {
     int Id { get; }
@@ -12,7 +15,10 @@ public interface ITestPair
     public PairState State { get; }
     public bool Initialized { get; }
     void Kill();
-    List<string> TestHistory { get; }
+
+    [Obsolete("Constructed on the spot when needed, use ExtendedTestHistory instead.")]
+    List<string> TestHistory => ExtendedTestHistory.Select(x => x.TestName).ToList();
+    IReadOnlyList<TestHistoryEntry> ExtendedTestHistory { get; }
     PairSettings Settings { get; set; }
 
     int ServerSeed { get; }

--- a/Robust.UnitTesting/Pool/NUnitTestContextWrap.cs
+++ b/Robust.UnitTesting/Pool/NUnitTestContextWrap.cs
@@ -8,6 +8,7 @@ namespace Robust.UnitTesting.Pool;
 /// </summary>
 public sealed class NUnitTestContextWrap(TestContext context, TextWriter writer) : ITestContextLike
 {
-    public string FullName => context.Test.FullName;
+    public readonly TestContext Context = context;
+    public string FullName => Context.Test.FullName;
     public TextWriter Out => writer;
 }

--- a/Robust.UnitTesting/Pool/PoolManager.cs
+++ b/Robust.UnitTesting/Pool/PoolManager.cs
@@ -16,6 +16,14 @@ namespace Robust.UnitTesting.Pool;
 
 public abstract class BasePoolManager
 {
+    /// <summary>
+    ///     Stores a global count for pair IDs, so they're unique across the entire run regardless of how many pools we
+    ///     create and use.
+    ///
+    ///     This ensures things like gravestone files are truly unique.
+    /// </summary>
+    internal static int PairIdCounter = 0;
+
     internal abstract void Return(ITestPair pair);
     public abstract Assembly[] ClientAssemblies { get; }
     public abstract Assembly[] ServerAssemblies { get; }
@@ -35,7 +43,6 @@ public abstract class BasePoolManager
 [Virtual]
 public class PoolManager<TPair> : BasePoolManager where TPair : class, ITestPair, new()
 {
-    private int _nextPairId;
     private readonly Lock _pairLock = new();
     private bool _initialized;
 
@@ -279,9 +286,8 @@ we are just going to end this here to save a lot of time. This is the exception 
     {
         try
         {
-            var id = Interlocked.Increment(ref _nextPairId);
+            var id = Interlocked.Increment(ref PairIdCounter);
             var pair = new TPair();
-
 
             TextWriter? gravestone = null;
             if (context is NUnitTestContextWrap)

--- a/Robust.UnitTesting/Pool/PoolManager.cs
+++ b/Robust.UnitTesting/Pool/PoolManager.cs
@@ -128,10 +128,10 @@ public class PoolManager<TPair> : BasePoolManager where TPair : class, ITestPair
             foreach (var pair in pairs)
             {
                 var borrowed = Pairs[pair];
-                builder.AppendLine($"Pair {pair.Id}, Tests Run: {pair.TestHistory.Count}, Borrowed: {borrowed}");
-                for (var i = 0; i < pair.TestHistory.Count; i++)
+                builder.AppendLine($"Pair {pair.Id}, Tests Run: {pair.ExtendedTestHistory.Count}, Borrowed: {borrowed}");
+                for (var i = 0; i < pair.ExtendedTestHistory.Count; i++)
                 {
-                    builder.AppendLine($"#{i}: {pair.TestHistory[i]}");
+                    builder.AppendLine($"#{i}: {pair.ExtendedTestHistory[i]}");
                 }
             }
 

--- a/Robust.UnitTesting/Pool/PoolManager.cs
+++ b/Robust.UnitTesting/Pool/PoolManager.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 using Robust.Shared;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -157,64 +158,49 @@ public class PoolManager<TPair> : BasePoolManager where TPair : class, ITestPair
         var watch = new Stopwatch();
         await testOut.WriteLineAsync($"{nameof(GetPair)}: Called by test {currentTestName}");
         TPair? pair = null;
-        try
+        watch.Start();
+        if (settings.MustBeNew)
         {
-            watch.Start();
-            if (settings.MustBeNew)
+            await testOut.WriteLineAsync(
+                $"{nameof(GetPair)}: Creating pair, because settings of pool settings");
+            pair = await CreateServerClientPair(settings, testContext, testOut);
+        }
+        else
+        {
+            await testOut.WriteLineAsync($"{nameof(GetPair)}: Looking in pool for a suitable pair");
+            pair = GrabOptimalPair(settings);
+            if (pair != null)
             {
-                await testOut.WriteLineAsync(
-                    $"{nameof(GetPair)}: Creating pair, because settings of pool settings");
-                pair = await CreateServerClientPair(settings, testOut);
-            }
-            else
-            {
-                await testOut.WriteLineAsync($"{nameof(GetPair)}: Looking in pool for a suitable pair");
-                pair = GrabOptimalPair(settings);
-                if (pair != null)
+                pair.ActivateContext(testOut);
+                await testOut.WriteLineAsync($"{nameof(GetPair)}: Suitable pair found");
+
+                if (pair.Settings.CanFastRecycle(settings))
                 {
-                    pair.ActivateContext(testOut);
-                    await testOut.WriteLineAsync($"{nameof(GetPair)}: Suitable pair found");
-
-                    if (pair.Settings.CanFastRecycle(settings))
-                    {
-                        await testOut.WriteLineAsync($"{nameof(GetPair)}: Cleanup not needed, Skipping cleanup of pair");
-                        await pair.ApplySettings(settings);
-                    }
-                    else
-                    {
-                        await testOut.WriteLineAsync($"{nameof(GetPair)}: Cleaning existing pair");
-                        await pair.RecycleInternal(settings, testOut);
-                    }
-
-                    await pair.RunTicksSync(5);
-                    await pair.SyncTicks(targetDelta: 1);
+                    await testOut.WriteLineAsync($"{nameof(GetPair)}: Cleanup not needed, Skipping cleanup of pair");
+                    await pair.ApplySettings(settings);
                 }
                 else
                 {
-                    await testOut.WriteLineAsync($"{nameof(GetPair)}: Creating a new pair, no suitable pair found in pool");
-                    pair = await CreateServerClientPair(settings, testOut);
+                    await testOut.WriteLineAsync($"{nameof(GetPair)}: Cleaning existing pair");
+                    await pair.RecycleInternal(settings, testOut);
                 }
+
+                await pair.RunTicksSync(5);
+                await pair.SyncTicks(targetDelta: 1);
             }
-        }
-        finally
-        {
-            if (pair != null && pair.TestHistory.Count > 0)
+            else
             {
-                await testOut.WriteLineAsync($"{nameof(GetPair)}: Pair {pair.Id} Test History Start");
-                for (var i = 0; i < pair.TestHistory.Count; i++)
-                {
-                    await testOut.WriteLineAsync($"- Pair {pair.Id} Test #{i}: {pair.TestHistory[i]}");
-                }
-                await testOut.WriteLineAsync($"{nameof(GetPair)}: Pair {pair.Id} Test History End");
+                await testOut.WriteLineAsync($"{nameof(GetPair)}: Creating a new pair, no suitable pair found in pool");
+                pair = await CreateServerClientPair(settings, testContext, testOut);
             }
         }
 
         await testOut.WriteLineAsync($"{nameof(GetPair)}: Retrieving pair {pair.Id} from pool took {watch.Elapsed.TotalMilliseconds} ms");
 
+        await pair.AddToHistory(currentTestName);
         pair.ValidateSettings(settings);
         pair.ClearModifiedCvars();
         pair.Settings = settings;
-        pair.TestHistory.Add(currentTestName);
         pair.SetupSeed();
 
         await testOut.WriteLineAsync($"{nameof(GetPair)}: Returning pair {pair.Id} with client/server seeds: {pair.ClientSeed}/{pair.ServerSeed}");
@@ -289,13 +275,19 @@ we are just going to end this here to save a lot of time. This is the exception 
         }
     }
 
-    private async Task<TPair> CreateServerClientPair(PairSettings settings, TextWriter testOut)
+    private async Task<TPair> CreateServerClientPair(PairSettings settings, ITestContextLike context, TextWriter testOut)
     {
         try
         {
             var id = Interlocked.Increment(ref _nextPairId);
             var pair = new TPair();
-            await pair.Init(id, this, settings, testOut);
+
+
+            TextWriter? gravestone = null;
+            if (context is NUnitTestContextWrap)
+                gravestone = File.CreateText($"{TestContext.CurrentContext.WorkDirectory}/gravestone-{id}.txt");
+
+            await pair.Init(id, this, settings, testOut, gravestone);
             pair.Use();
             await pair.RunTicksSync(5);
             await pair.SyncTicks(targetDelta: 1);

--- a/Robust.UnitTesting/Pool/PoolTestLogHandler.cs
+++ b/Robust.UnitTesting/Pool/PoolTestLogHandler.cs
@@ -13,8 +13,7 @@ namespace Robust.UnitTesting.Pool;
 /// </summary>
 /// <remarks>
 /// <para>
-/// This class logs to two places: an NUnit <see cref="TestContext"/>  (so it nicely gets attributed to a test in your IDE),
-/// and an in-memory ring buffer for diagnostic purposes. If test pooling breaks, the ring buffer can be used to see what the broken instance has gone through.
+/// This class logs to one place: an NUnit <see cref="TestContext"/> (so it nicely gets attributed to a test in your IDE)
 /// </para>
 /// <para>
 /// The active test context can be swapped out so pooled instances can correctly have their logs attributed.

--- a/Robust.UnitTesting/Pool/PoolTestLogHandler.cs
+++ b/Robust.UnitTesting/Pool/PoolTestLogHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
 using Robust.Shared.Log;
@@ -28,6 +29,10 @@ public sealed class PoolTestLogHandler : ILogHandler
     public TextWriter? ActiveContext { get; private set; }
 
     public LogLevel? FailureLevel { get; set; }
+
+    public IReadOnlyList<string> FailingLogs => _failingLogs;
+
+    private List<string> _failingLogs = new();
 
     public PoolTestLogHandler(string? prefix)
     {
@@ -61,7 +66,7 @@ public sealed class PoolTestLogHandler : ILogHandler
             return;
 
         testContext.Flush();
-        Assert.Fail($"{line} Exception: {message.Exception}");
+        _failingLogs.Add($"{line} Exception: {message.Exception}");
     }
 
     public void ClearContext()

--- a/Robust.UnitTesting/Pool/PoolTestLogHandler.cs
+++ b/Robust.UnitTesting/Pool/PoolTestLogHandler.cs
@@ -32,7 +32,7 @@ public sealed class PoolTestLogHandler : ILogHandler
 
     public IReadOnlyList<string> FailingLogs => _failingLogs;
 
-    private List<string> _failingLogs = new();
+    private readonly List<string> _failingLogs = new();
 
     public PoolTestLogHandler(string? prefix)
     {
@@ -72,6 +72,7 @@ public sealed class PoolTestLogHandler : ILogHandler
     public void ClearContext()
     {
         ActiveContext = null;
+        _failingLogs.Clear();
     }
 
     public void ActivateContext(TextWriter context)

--- a/Robust.UnitTesting/Pool/PoolTestLogHandler.cs
+++ b/Robust.UnitTesting/Pool/PoolTestLogHandler.cs
@@ -41,8 +41,14 @@ public sealed class PoolTestLogHandler : ILogHandler
     public bool ShuttingDown;
 
     /// <summary>
+    /// <para>
     ///     Event handler that allows you to override a potential failing log.
     ///     Use this if you want to allow certain error logs to be considered passing.
+    /// </para>
+    /// <para>
+    ///     Has the sawmill name and <see cref="LogEvent"/> passed in, and should return a boolean
+    ///     <see langword="true"/> when the log message should not be logged as a failure.
+    /// </para>
     /// </summary>
     public event Func<string, LogEvent, bool>? JudgeLog;
 

--- a/Robust.UnitTesting/Pool/PoolTestLogHandler.cs
+++ b/Robust.UnitTesting/Pool/PoolTestLogHandler.cs
@@ -41,6 +41,12 @@ public sealed class PoolTestLogHandler : ILogHandler
 
     public bool ShuttingDown;
 
+    /// <summary>
+    ///     Event handler that allows you to override a potential failing log.
+    ///     Use this if you want to allow certain error logs to be considered passing.
+    /// </summary>
+    public event Func<string, LogEvent, bool>? JudgeLog;
+
     public void Log(string sawmillName, LogEvent message)
     {
         var level = message.Level.ToRobust();
@@ -62,7 +68,7 @@ public sealed class PoolTestLogHandler : ILogHandler
 
         testContext.WriteLine(line);
 
-        if (FailureLevel == null || level < FailureLevel)
+        if (FailureLevel == null || level < FailureLevel || (JudgeLog?.Invoke(sawmillName, message) ?? false))
             return;
 
         testContext.Flush();

--- a/Robust.UnitTesting/Pool/TestHistoryEntry.cs
+++ b/Robust.UnitTesting/Pool/TestHistoryEntry.cs
@@ -6,6 +6,7 @@ public sealed class TestHistoryEntry
     ///     The name of the test.
     /// </summary>
     public readonly string TestName;
+
     /// <summary>
     ///     The amount of memory the GC claims to be using at the time of adding this entry.
     /// </summary>

--- a/Robust.UnitTesting/Pool/TestHistoryEntry.cs
+++ b/Robust.UnitTesting/Pool/TestHistoryEntry.cs
@@ -1,0 +1,18 @@
+namespace Robust.UnitTesting.Pool;
+
+public sealed class TestHistoryEntry(string testName, long timeOfUseMemoryTotal)
+{
+    /// <summary>
+    ///     The name of the test.
+    /// </summary>
+    public readonly string TestName = testName;
+    /// <summary>
+    ///     The amount of memory the GC claims to be using at the time of adding this entry.
+    /// </summary>
+    public readonly long TimeOfUseMemoryTotal = timeOfUseMemoryTotal;
+
+    public override string ToString()
+    {
+        return $"{TestName} (started at {TimeOfUseMemoryTotal} bytes allocated.)";
+    }
+}

--- a/Robust.UnitTesting/Pool/TestHistoryEntry.cs
+++ b/Robust.UnitTesting/Pool/TestHistoryEntry.cs
@@ -1,15 +1,21 @@
 namespace Robust.UnitTesting.Pool;
 
-public sealed class TestHistoryEntry(string testName, long timeOfUseMemoryTotal)
+public sealed class TestHistoryEntry
 {
     /// <summary>
     ///     The name of the test.
     /// </summary>
-    public readonly string TestName = testName;
+    public readonly string TestName;
     /// <summary>
     ///     The amount of memory the GC claims to be using at the time of adding this entry.
     /// </summary>
-    public readonly long TimeOfUseMemoryTotal = timeOfUseMemoryTotal;
+    public readonly long TimeOfUseMemoryTotal;
+
+    internal TestHistoryEntry(string testName, long timeOfUseMemoryTotal)
+    {
+        TestName = testName;
+        TimeOfUseMemoryTotal = timeOfUseMemoryTotal;
+    }
 
     public override string ToString()
     {

--- a/Robust.UnitTesting/Pool/TestPair.Helpers.cs
+++ b/Robust.UnitTesting/Pool/TestPair.Helpers.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using Robust.Client.Timing;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
@@ -199,6 +200,23 @@ public partial class TestPair<TServer, TClient>
     public async Task RunSeconds(float seconds)
     {
         await RunTicksSync(SecondsToTicks(seconds));
+    }
+
+
+    /// <summary>
+    ///     Runs the pairs just long enough for PVS to send entities, ensuring the client's current tick is what the
+    ///     server's was at call time.
+    /// </summary>
+    public async Task RunUntilSynced()
+    {
+        var sGameTiming = Server.Timing;
+        var cGameTiming = (IClientGameTiming)Client.Timing;
+        var startTime = sGameTiming.CurTick;
+
+        while (cGameTiming.LastRealTick < startTime)
+        {
+            await RunTicksSync(1);
+        }
     }
 
     /// <summary>

--- a/Robust.UnitTesting/Pool/TestPair.Helpers.cs
+++ b/Robust.UnitTesting/Pool/TestPair.Helpers.cs
@@ -209,6 +209,13 @@ public partial class TestPair<TServer, TClient>
     /// </summary>
     public async Task RunUntilSynced()
     {
+        if (Client.Session is null)
+        {
+            // Already synced. Run a tick on server.
+            await Server.WaitRunTicks(1);
+            return;
+        }
+
         var sGameTiming = Server.Timing;
         var cGameTiming = (IClientGameTiming)Client.Timing;
         var startTime = sGameTiming.CurTick;

--- a/Robust.UnitTesting/Pool/TestPair.Helpers.cs
+++ b/Robust.UnitTesting/Pool/TestPair.Helpers.cs
@@ -211,7 +211,8 @@ public partial class TestPair<TServer, TClient>
     {
         if (Client.Session is null)
         {
-            // Already synced. Run a tick on server.
+            // Already synced, because the client isn't connected so we have nothing *to* sync.
+            // Run a tick on server.
             await Server.WaitRunTicks(1);
             return;
         }

--- a/Robust.UnitTesting/Pool/TestPair.Recycle.cs
+++ b/Robust.UnitTesting/Pool/TestPair.Recycle.cs
@@ -85,12 +85,9 @@ public partial class TestPair<TServer, TClient>
         State = PairState.Ready;
     }
 
-    private SemaphoreSlim _disposalLock = new(1);
-
     [HandlesResourceDisposal]
     public async ValueTask CleanReturnAsync()
     {
-        using var semaphore = await _disposalLock.WaitGuardAsync();
         if (State != PairState.InUse)
             throw new Exception($"{nameof(CleanReturnAsync)}: Unexpected state. Pair: {Id}. State: {State}.");
 
@@ -104,7 +101,6 @@ public partial class TestPair<TServer, TClient>
 
     public async ValueTask DisposeAsync()
     {
-        using var semaphore = await _disposalLock.WaitGuardAsync();
         switch (State)
         {
             case PairState.Dead:

--- a/Robust.UnitTesting/Pool/TestPair.Recycle.cs
+++ b/Robust.UnitTesting/Pool/TestPair.Recycle.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 using Robust.Client;
 using Robust.Shared;
 using Robust.Shared.Exceptions;
@@ -17,6 +18,22 @@ namespace Robust.UnitTesting.Pool;
 // This partial file contains logic related to recycling & disposing test pairs.
 public partial class TestPair<TServer, TClient>
 {
+    private void ReportErrorLogs()
+    {
+        using (Assert.EnterMultipleScope())
+        {
+            if (ServerLogHandler.FailingLogs.Count == 1)
+                Assert.Fail(ServerLogHandler.FailingLogs[0]);
+            else if (ServerLogHandler.FailingLogs.Count > 1)
+                Assert.Fail("Server had multiple failing logs reported, consult the game log.");
+
+            if (ClientLogHandler.FailingLogs.Count == 1)
+                Assert.Fail(ClientLogHandler.FailingLogs[0]);
+            else if (ClientLogHandler.FailingLogs.Count > 1)
+                Assert.Fail("Client had multiple failing logs reported, consult the game log.");
+        }
+    }
+
     private async Task OnDirtyDispose()
     {
         var usageTime = Watch.Elapsed;
@@ -25,6 +42,7 @@ public partial class TestPair<TServer, TClient>
         Kill();
         var disposeTime = Watch.Elapsed;
         await TestOut.WriteLineAsync($"{nameof(DisposeAsync)}: Disposed pair {Id} in {disposeTime.TotalMilliseconds} ms");
+        ReportErrorLogs();
         // Test pairs should only dirty dispose if they are failing. If they are not failing, this probably happened
         // because someone forgot to clean-return the pair.
         Assert.Warn("Test was dirty-disposed.");
@@ -79,6 +97,8 @@ public partial class TestPair<TServer, TClient>
         var cRuntimeLog = Client.Resolve<IRuntimeLog>();
         if (cRuntimeLog.ExceptionCount > 0)
             throw new Exception($"{nameof(CleanReturnAsync)}: Client logged exceptions");
+
+        ReportErrorLogs();
 
         var returnTime = Watch.Elapsed;
         await TestOut.WriteLineAsync($"{nameof(CleanReturnAsync)}: PoolManager took {returnTime.TotalMilliseconds} ms to put pair {Id} back into the pool");

--- a/Robust.UnitTesting/Pool/TestPair.Recycle.cs
+++ b/Robust.UnitTesting/Pool/TestPair.Recycle.cs
@@ -91,14 +91,25 @@ public partial class TestPair<TServer, TClient>
             return;
         }
 
-        var sRuntimeLog = Server.Resolve<IRuntimeLog>();
-        if (sRuntimeLog.ExceptionCount > 0)
-            throw new Exception($"{nameof(CleanReturnAsync)}: Server logged exceptions");
-        var cRuntimeLog = Client.Resolve<IRuntimeLog>();
-        if (cRuntimeLog.ExceptionCount > 0)
-            throw new Exception($"{nameof(CleanReturnAsync)}: Client logged exceptions");
+        try
+        {
+            var sRuntimeLog = Server.Resolve<IRuntimeLog>();
+            if (sRuntimeLog.ExceptionCount > 0)
+                throw new Exception($"{nameof(CleanReturnAsync)}: Server logged exceptions");
+            var cRuntimeLog = Client.Resolve<IRuntimeLog>();
+            if (cRuntimeLog.ExceptionCount > 0)
+                throw new Exception($"{nameof(CleanReturnAsync)}: Client logged exceptions");
 
-        ReportErrorLogs();
+            ReportErrorLogs();
+        }
+        catch (Exception)
+        {
+            Kill();
+            await ReallyBeIdle();
+            await TestOut.WriteLineAsync($"{nameof(CleanReturnAsync)}: Dirty disposed in {Watch.Elapsed.TotalMilliseconds} ms");
+            Assert.Warn("Test was dirty-disposed.");
+            throw;
+        }
 
         var returnTime = Watch.Elapsed;
         await TestOut.WriteLineAsync($"{nameof(CleanReturnAsync)}: PoolManager took {returnTime.TotalMilliseconds} ms to put pair {Id} back into the pool");

--- a/Robust.UnitTesting/Pool/TestPair.Recycle.cs
+++ b/Robust.UnitTesting/Pool/TestPair.Recycle.cs
@@ -124,10 +124,16 @@ public partial class TestPair<TServer, TClient>
 
         await TestOut.WriteLineAsync($"{nameof(CleanReturnAsync)}: Return of pair {Id} started");
         State = PairState.CleanDisposed;
-        await OnCleanDispose();
-        DebugTools.Assert(State is PairState.Dead or PairState.Ready);
-        ClearContext();
-        Manager.Return(this);
+        try
+        {
+            await OnCleanDispose();
+        }
+        finally
+        {
+            DebugTools.Assert(State is PairState.Dead or PairState.Ready);
+            ClearContext();
+            Manager.Return(this);
+        }
     }
 
     public async ValueTask DisposeAsync()
@@ -139,9 +145,15 @@ public partial class TestPair<TServer, TClient>
                 break;
             case PairState.InUse:
                 await TestOut.WriteLineAsync($"{nameof(DisposeAsync)}: Dirty return of pair {Id} started");
-                await OnDirtyDispose();
-                ClearContext();
-                Manager.Return(this);
+                try
+                {
+                    await OnDirtyDispose();
+                }
+                finally
+                {
+                    ClearContext();
+                    Manager.Return(this);
+                }
                 break;
             default:
                 throw new Exception($"{nameof(DisposeAsync)}: Unexpected state. Pair: {Id}. State: {State}.");

--- a/Robust.UnitTesting/Pool/TestPair.Recycle.cs
+++ b/Robust.UnitTesting/Pool/TestPair.Recycle.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using NUnit.Framework;
 using Robust.Client;
 using Robust.Shared;
@@ -83,6 +84,7 @@ public partial class TestPair<TServer, TClient>
         State = PairState.Ready;
     }
 
+    [HandlesResourceDisposal]
     public async ValueTask CleanReturnAsync()
     {
         if (State != PairState.InUse)
@@ -92,8 +94,8 @@ public partial class TestPair<TServer, TClient>
         State = PairState.CleanDisposed;
         await OnCleanDispose();
         DebugTools.Assert(State is PairState.Dead or PairState.Ready);
-        Manager.Return(this);
         ClearContext();
+        Manager.Return(this);
     }
 
     public async ValueTask DisposeAsync()
@@ -106,8 +108,8 @@ public partial class TestPair<TServer, TClient>
             case PairState.InUse:
                 await TestOut.WriteLineAsync($"{nameof(DisposeAsync)}: Dirty return of pair {Id} started");
                 await OnDirtyDispose();
-                Manager.Return(this);
                 ClearContext();
+                Manager.Return(this);
                 break;
             default:
                 throw new Exception($"{nameof(DisposeAsync)}: Unexpected state. Pair: {Id}. State: {State}.");

--- a/Robust.UnitTesting/Pool/TestPair.Recycle.cs
+++ b/Robust.UnitTesting/Pool/TestPair.Recycle.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using NUnit.Framework;
@@ -84,9 +85,12 @@ public partial class TestPair<TServer, TClient>
         State = PairState.Ready;
     }
 
+    private SemaphoreSlim _disposalLock = new(1);
+
     [HandlesResourceDisposal]
     public async ValueTask CleanReturnAsync()
     {
+        using var semaphore = await _disposalLock.WaitGuardAsync();
         if (State != PairState.InUse)
             throw new Exception($"{nameof(CleanReturnAsync)}: Unexpected state. Pair: {Id}. State: {State}.");
 
@@ -100,6 +104,7 @@ public partial class TestPair<TServer, TClient>
 
     public async ValueTask DisposeAsync()
     {
+        using var semaphore = await _disposalLock.WaitGuardAsync();
         switch (State)
         {
             case PairState.Dead:

--- a/Robust.UnitTesting/Pool/TestPair.cs
+++ b/Robust.UnitTesting/Pool/TestPair.cs
@@ -123,6 +123,10 @@ public abstract partial class TestPair<TServer, TClient> : ITestPair, IAsyncDisp
 
     public void ActivateContext(TextWriter testOut)
     {
+        // This is the very, very first thing that happens in prepping a pair, so wait a sec
+        // for disposal to get to finish if we got returned right this instant.
+        // Not necessary after some of the disposal changes but defensive is good.
+        using var semaphore = _disposalLock.WaitGuard();
         TestOut = testOut;
         ServerLogHandler.ActivateContext(testOut);
         ClientLogHandler.ActivateContext(testOut);

--- a/Robust.UnitTesting/Pool/TestPair.cs
+++ b/Robust.UnitTesting/Pool/TestPair.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
+using NUnit.Framework;
 using Robust.Shared.Configuration;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -23,6 +25,7 @@ public abstract partial class TestPair<TServer, TClient> : ITestPair, IAsyncDisp
     public PairState State { get; private set; } = PairState.Ready;
     public bool Initialized { get; private set; }
     protected TextWriter TestOut = default!;
+    protected TextWriter? Gravestone = default!;
     public Stopwatch Watch { get; } = new();
     public List<string> TestHistory { get; } = new();
     public PairSettings Settings { get; set; } = default!;
@@ -57,7 +60,8 @@ public abstract partial class TestPair<TServer, TClient> : ITestPair, IAsyncDisp
         int id,
         BasePoolManager manager,
         PairSettings settings,
-        TextWriter testOut)
+        TextWriter testOut,
+        TextWriter? gravestone)
     {
         if (Initialized)
             throw new InvalidOperationException("Already initialized");
@@ -66,6 +70,10 @@ public abstract partial class TestPair<TServer, TClient> : ITestPair, IAsyncDisp
         Manager = manager;
         Settings = settings;
         Initialized = true;
+        Gravestone = gravestone;
+
+        if (Gravestone is not null)
+            await Gravestone.WriteLineAsync("Test pair initialized.");
 
         ClientLogHandler.ActivateContext(testOut);
         ServerLogHandler.ActivateContext(testOut);
@@ -112,6 +120,10 @@ public abstract partial class TestPair<TServer, TClient> : ITestPair, IAsyncDisp
         ClientLogHandler.ShuttingDown = true;
         Server.Dispose();
         Client.Dispose();
+
+        Gravestone?.WriteLine("Test pair killed.");
+        Gravestone?.WriteLine(Environment.StackTrace);
+        Gravestone?.Flush();
     }
 
     private void ClearContext()
@@ -137,6 +149,16 @@ public abstract partial class TestPair<TServer, TClient> : ITestPair, IAsyncDisp
         if (State != PairState.Ready)
             throw new InvalidOperationException($"Pair is not ready to use. State: {State}");
         State = PairState.InUse;
+    }
+
+    public async Task AddToHistory(string testName)
+    {
+        TestHistory.Add(testName);
+        if (Gravestone is not null)
+        {
+            await Gravestone.WriteLineAsync($"#{TestHistory.Count}: {testName}");
+            await Gravestone.FlushAsync();
+        }
     }
 
     public void SetupSeed()

--- a/Robust.UnitTesting/Pool/TestPair.cs
+++ b/Robust.UnitTesting/Pool/TestPair.cs
@@ -27,7 +27,9 @@ public abstract partial class TestPair<TServer, TClient> : ITestPair, IAsyncDisp
     protected TextWriter TestOut = default!;
     protected TextWriter? Gravestone = default!;
     public Stopwatch Watch { get; } = new();
-    public List<string> TestHistory { get; } = new();
+
+    private List<TestHistoryEntry> _testHistory = new();
+    public IReadOnlyList<TestHistoryEntry> ExtendedTestHistory => _testHistory;
     public PairSettings Settings { get; set; } = default!;
 
     public readonly PoolTestLogHandler ServerLogHandler = new("SERVER");
@@ -153,10 +155,12 @@ public abstract partial class TestPair<TServer, TClient> : ITestPair, IAsyncDisp
 
     public async Task AddToHistory(string testName)
     {
-        TestHistory.Add(testName);
+        var memUse = GC.GetTotalMemory(false);
+        var entry = new TestHistoryEntry(testName, memUse);
+        _testHistory.Add(entry);
         if (Gravestone is not null)
         {
-            await Gravestone.WriteLineAsync($"#{TestHistory.Count}: {testName}");
+            await Gravestone.WriteLineAsync($"#{_testHistory.Count}: {entry}");
             await Gravestone.FlushAsync();
         }
     }

--- a/Robust.UnitTesting/Pool/TestPair.cs
+++ b/Robust.UnitTesting/Pool/TestPair.cs
@@ -138,7 +138,6 @@ public abstract partial class TestPair<TServer, TClient> : ITestPair, IAsyncDisp
         // This is the very, very first thing that happens in prepping a pair, so wait a sec
         // for disposal to get to finish if we got returned right this instant.
         // Not necessary after some of the disposal changes but defensive is good.
-        using var semaphore = _disposalLock.WaitGuard();
         TestOut = testOut;
         ServerLogHandler.ActivateContext(testOut);
         ClientLogHandler.ActivateContext(testOut);
@@ -148,6 +147,7 @@ public abstract partial class TestPair<TServer, TClient> : ITestPair, IAsyncDisp
     {
         if (State != PairState.Ready)
             throw new InvalidOperationException($"Pair is not ready to use. State: {State}");
+
         State = PairState.InUse;
     }
 


### PR DESCRIPTION
Implements NUnit3 XML output for our test CI, and migrates testpair logs to use "gravestones", files describing the lifespan of of a testpair.

Gravestones are only generated in NUnit3 environments, YAMLLinter/etc will not create them.

This makes breaking changes to the testpair API, namely:
- ITestPair.Init now requires a gravestone writer argument.
- Adding tests to test history must be done with AddToHistory.
- NUnit3 test running will now *always output gravestone files to the nunit working directory.*
  Configure this directory as per [this documentation](https://docs.nunit.org/articles/vs-test-adapter/Tips-And-Tricks.html), for example `dotnet test Content.IntegrationTests -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="logs" NUnit.WorkDirectory="$(pwd)/test_results"` in powershell.
- Using testpairs outside a test environment without providing an alternate context  will now crash. YAMLLinter was guilty of this.
- Error logs in testpair client/server no longer immediately assert, and instead wait for test completion so more detailed failure info can be gathered.
  
For those wondering why the working directory by default, this is just how NUnit works. Not really any better options.

https://github.com/space-wizards/space-station-14/pull/43175 is required for this PR, content-side.
