### PR TITLE
fix error spam for AutoNetworkedField with deleted entities

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Network.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Network.cs
@@ -183,7 +183,7 @@ public partial class EntityManager
         if (uid == EntityUid.Invalid)
             return NetEntity.Invalid;
 
-        if (!MetaQuery.Resolve(uid, ref metadata))
+        if (!MetaQuery.Resolve(uid, ref metadata, false))
             return NetEntity.Invalid;
 
         return metadata.NetEntity;


### PR DESCRIPTION
Don't log missing MetaDataComponent for GetNetEntity as 1000 things in content spam errors from it, sometimes being unfeasible to track deletions properly everywhere.
AutoGenerateComponentState and AutoNetworkedField seem too difficult to refactor to support nullable NetEntity from TryGetNetEntity which already fixed this problem, so this solution is more feasible.