### PR TITLE
fully remove obsolete methods in mapgridcomponent

### DIFF
--- a/Robust.Shared/Map/Components/MapGridComponent.cs
+++ b/Robust.Shared/Map/Components/MapGridComponent.cs
@@ -1,12 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Numerics;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
-using Robust.Shared.IoC;
-using Robust.Shared.Map.Enumerators;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Serialization;
@@ -15,332 +12,152 @@ using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 
-namespace Robust.Shared.Map.Components
+namespace Robust.Shared.Map.Components;
+
+/// <summary>
+/// Component marking a grid entity, which are the "floor" in space other entities can be placed on.
+/// Grids can have their own physics and move around in space while players or other entities move on them.
+/// Examples for grids are the station, shuttles or asteroids.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class MapGridComponent : Component
 {
-    [RegisterComponent]
-    [NetworkedComponent]
-    public sealed partial class MapGridComponent : Component
-    {
-        [Dependency] private readonly IEntityManager _entManager = default!;
-        private SharedMapSystem MapSystem => _entManager.System<SharedMapSystem>();
+    // This field is used for deserialization internally in the map loader.
+    // If you want to remove this, you would have to restructure the map save file.
+    [DataField("index")]
+    internal int GridIndex;
+    // the grid section now writes the grid's EntityUID. as long as existing maps get updated (just a load+save),
+    // this can be removed
 
-        // This field is used for deserialization internally in the map loader.
-        // If you want to remove this, you would have to restructure the map save file.
-        [DataField("index")] internal int GridIndex;
-        // the grid section now writes the grid's EntityUID. as long as existing maps get updated (just a load+save),
-        // this can be removed
+    [DataField]
+    internal ushort ChunkSize = 16;
 
-        [DataField] internal ushort ChunkSize = 16;
-
-        [ViewVariables]
-        public int ChunkCount => Chunks.Count;
-
-        /// <summary>
-        ///     The length of the side of a square tile in world units.
-        /// </summary>
-        [DataField("tileSize")]
-        public ushort TileSize { get; internal set; } = 1;
-
-        public Vector2 TileSizeVector => new(TileSize, TileSize);
-
-        public Vector2 TileSizeHalfVector => new(TileSize / 2f, TileSize / 2f);
-
-        [ViewVariables] internal readonly List<(GameTick tick, Vector2i indices)> ChunkDeletionHistory = new();
-
-        /// <summary>
-        ///     Last game tick that the map was modified.
-        /// </summary>
-        [ViewVariables]
-        public GameTick LastTileModifiedTick { get; internal set; }
-
-        /// <summary>
-        /// Map DynamicTree proxy to lookup for grid intersection.
-        /// </summary>
-        internal DynamicTree.Proxy MapProxy = DynamicTree.Proxy.Free;
-
-        /// <summary>
-        ///     Grid chunks than make up this grid.
-        /// </summary>
-        [DataField("chunks")]
-        internal Dictionary<Vector2i, MapChunk> Chunks = new();
-
-        [ViewVariables]
-        public Box2 LocalAABB { get; internal set; }
-
-        /// <summary>
-        /// Set to enable or disable grid splitting.
-        /// You must ensure you handle this properly and check for splits afterwards if relevant!
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite), DataField("canSplit")]
-        public bool CanSplit = true;
-
-        #region TileAccess
-
-        [Obsolete("Use the MapSystem method")]
-        public TileRef GetTileRef(EntityCoordinates coords)
-        {
-            return MapSystem.GetTileRef(Owner, this, coords);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public TileRef GetTileRef(Vector2i tileCoordinates)
-        {
-            return MapSystem.GetTileRef(Owner, this, tileCoordinates);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public IEnumerable<TileRef> GetAllTiles(bool ignoreEmpty = true)
-        {
-            return MapSystem.GetAllTiles(Owner, this, ignoreEmpty);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public GridTileEnumerator GetAllTilesEnumerator(bool ignoreEmpty = true)
-        {
-            return MapSystem.GetAllTilesEnumerator(Owner, this, ignoreEmpty);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public void SetTile(EntityCoordinates coords, Tile tile)
-        {
-            MapSystem.SetTile(Owner, this, coords, tile);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public void SetTile(Vector2i gridIndices, Tile tile)
-        {
-            MapSystem.SetTile(Owner, this, gridIndices, tile);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public void SetTiles(List<(Vector2i GridIndices, Tile Tile)> tiles)
-        {
-            MapSystem.SetTiles(Owner, this, tiles);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public IEnumerable<TileRef> GetTilesIntersecting(Box2 worldArea, bool ignoreEmpty = true,
-            Predicate<TileRef>? predicate = null)
-        {
-            return MapSystem.GetTilesIntersecting(Owner, this, worldArea, ignoreEmpty, predicate);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public IEnumerable<TileRef> GetLocalTilesIntersecting(Box2 localArea, bool ignoreEmpty = true,
-            Predicate<TileRef>? predicate = null)
-        {
-            return MapSystem.GetLocalTilesIntersecting(Owner, this, localArea, ignoreEmpty, predicate);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public IEnumerable<TileRef> GetTilesIntersecting(Circle worldArea, bool ignoreEmpty = true,
-            Predicate<TileRef>? predicate = null)
-        {
-            return MapSystem.GetTilesIntersecting(Owner, this, worldArea, ignoreEmpty, predicate);
-        }
-
-        #endregion TileAccess
-
-        #region ChunkAccess
-
-        [Obsolete("Use the MapSystem method")]
-        internal bool TryGetChunk(Vector2i chunkIndices, [NotNullWhen(true)] out MapChunk? chunk)
-        {
-            return MapSystem.TryGetChunk(Owner, this, chunkIndices, out chunk);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        internal IReadOnlyDictionary<Vector2i, MapChunk> GetMapChunks()
-        {
-            return MapSystem.GetMapChunks(Owner, this);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        internal ChunkEnumerator GetMapChunks(Box2Rotated worldArea)
-        {
-            return MapSystem.GetMapChunks(Owner, this, worldArea);
-        }
-
-        #endregion ChunkAccess
-
-        #region SnapGridAccess
-
-        [Obsolete("Use the MapSystem method")]
-        public IEnumerable<EntityUid> GetAnchoredEntities(MapCoordinates coords)
-        {
-            return MapSystem.GetAnchoredEntities(Owner, this, coords);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public IEnumerable<EntityUid> GetAnchoredEntities(Vector2i pos)
-        {
-            return MapSystem.GetAnchoredEntities(Owner, this, pos);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public AnchoredEntitiesEnumerator GetAnchoredEntitiesEnumerator(Vector2i pos)
-        {
-            return MapSystem.GetAnchoredEntitiesEnumerator(Owner, this, pos);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public Vector2i TileIndicesFor(EntityCoordinates coords)
-        {
-            return MapSystem.TileIndicesFor(Owner, this, coords);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public Vector2i TileIndicesFor(MapCoordinates worldPos)
-        {
-            return MapSystem.TileIndicesFor(Owner, this, worldPos);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public IEnumerable<EntityUid> GetCellsInSquareArea(EntityCoordinates coords, int n)
-        {
-            return MapSystem.GetCellsInSquareArea(Owner, this, coords, n);
-        }
-
-        #endregion
-
-        [Obsolete("Use the MapSystem method")]
-        public Vector2 WorldToLocal(Vector2 posWorld)
-        {
-            return MapSystem.WorldToLocal(Owner, this, posWorld);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public EntityCoordinates MapToGrid(MapCoordinates posWorld)
-        {
-            return MapSystem.MapToGrid(Owner, posWorld);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public Vector2 LocalToWorld(Vector2 posLocal)
-        {
-            return MapSystem.LocalToWorld(Owner, this, posLocal);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public Vector2i WorldToTile(Vector2 posWorld)
-        {
-            return MapSystem.WorldToTile(Owner, this, posWorld);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public Vector2i LocalToTile(EntityCoordinates coordinates)
-        {
-            return MapSystem.LocalToTile(Owner, this, coordinates);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public Vector2i CoordinatesToTile(EntityCoordinates coords)
-        {
-            return MapSystem.CoordinatesToTile(Owner, this, coords);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public EntityCoordinates GridTileToLocal(Vector2i gridTile)
-        {
-            return MapSystem.GridTileToLocal(Owner, this, gridTile);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public Vector2 GridTileToWorldPos(Vector2i gridTile)
-        {
-            return MapSystem.GridTileToWorldPos(Owner, this, gridTile);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public bool TryGetTileRef(Vector2i indices, out TileRef tile)
-        {
-            return MapSystem.TryGetTileRef(Owner, this, indices, out tile);
-        }
-
-        [Obsolete("Use the MapSystem method")]
-        public bool TryGetTileRef(EntityCoordinates coords, out TileRef tile)
-        {
-            return MapSystem.TryGetTileRef(Owner, this, coords, out tile);
-        }
-
-        /// <returns>True if the specified chunk exists on this grid.</returns>
-        [Pure]
-        public bool HasChunk(Vector2i indices)
-        {
-            return Chunks.ContainsKey(indices);
-        }
-    }
+    [ViewVariables]
+    public int ChunkCount => Chunks.Count;
 
     /// <summary>
-    ///     Serialized state of a <see cref="MapGridComponentState"/>.
+    /// The length of the side of a square tile in world units.
     /// </summary>
-    [Serializable, NetSerializable]
-    internal sealed class MapGridComponentState(ushort chunkSize, Dictionary<Vector2i, ChunkDatum> fullGridData, GameTick lastTileModifiedTick) : ComponentState
-    {
-        /// <summary>
-        ///     The size of the chunks in the map grid.
-        /// </summary>
-        public ushort ChunkSize = chunkSize;
-
-        /// <summary>
-        /// Networked chunk data containing the full grid state.
-        /// </summary>
-        public Dictionary<Vector2i, ChunkDatum> FullGridData = fullGridData;
-
-        /// <summary>
-        /// Last game tick that the tile on the grid was modified.
-        /// </summary>
-        public GameTick LastTileModifiedTick = lastTileModifiedTick;
-    }
+    [DataField]
+    public ushort TileSize { get; internal set; } = 1;
 
     /// <summary>
-    ///     Serialized state of a <see cref="MapGridComponentState"/>.
+    /// A square the size of one tile.
     /// </summary>
-    [Serializable, NetSerializable]
-    internal sealed class MapGridComponentDeltaState(ushort chunkSize, Dictionary<Vector2i, ChunkDatum>? chunkData, GameTick lastTileModifiedTick)
-        : ComponentState, IComponentDeltaState<MapGridComponentState>
+    public Vector2 TileSizeVector => new(TileSize, TileSize);
+
+    /// <summary>
+    /// A square the size of a quarter tile.
+    /// </summary>
+    public Vector2 TileSizeHalfVector => new(TileSize / 2f, TileSize / 2f);
+
+    [ViewVariables]
+    internal readonly List<(GameTick tick, Vector2i indices)> ChunkDeletionHistory = new();
+
+    /// <summary>
+    /// Last game tick that the map was modified.
+    /// </summary>
+    [ViewVariables]
+    public GameTick LastTileModifiedTick { get; internal set; }
+
+    /// <summary>
+    /// Map DynamicTree proxy to lookup for grid intersection.
+    /// </summary>
+    internal DynamicTree.Proxy MapProxy = DynamicTree.Proxy.Free;
+
+    /// <summary>
+    /// Grid chunks than make up this grid.
+    /// </summary>
+    [DataField]
+    internal Dictionary<Vector2i, MapChunk> Chunks = new();
+
+    [ViewVariables]
+    public Box2 LocalAABB { get; internal set; }
+
+    /// <summary>
+    /// Set to enable or disable grid splitting.
+    /// You must ensure you handle this properly and check for splits afterwards if relevant!
+    /// </summary>
+    [DataField]
+    public bool CanSplit = true;
+
+    /// <returns>True if the specified chunk exists on this grid.</returns>
+    [Pure]
+    public bool HasChunk(Vector2i indices)
     {
-        /// <summary>
-        ///     The size of the chunks in the map grid.
-        /// </summary>
-        public readonly ushort ChunkSize = chunkSize;
+        return Chunks.ContainsKey(indices);
+    }
+}
 
-        /// <summary>
-        /// Networked chunk data.
-        /// </summary>
-        public readonly Dictionary<Vector2i, ChunkDatum>? ChunkData = chunkData;
+/// <summary>
+/// Serialized state of a <see cref="MapGridComponentState"/>.
+/// </summary>
+[Serializable, NetSerializable]
+internal sealed class MapGridComponentState(ushort chunkSize, Dictionary<Vector2i, ChunkDatum> fullGridData, GameTick lastTileModifiedTick) : ComponentState
+{
+    /// <summary>
+    /// The size of the chunks in the map grid.
+    /// </summary>
+    public ushort ChunkSize = chunkSize;
 
-        /// <summary>
-        /// Last game tick that the tile on the grid was modified.
-        /// </summary>
-        public GameTick LastTileModifiedTick = lastTileModifiedTick;
+    /// <summary>
+    /// Networked chunk data containing the full grid state.
+    /// </summary>
+    public Dictionary<Vector2i, ChunkDatum> FullGridData = fullGridData;
 
-        public void ApplyToFullState(MapGridComponentState state)
+    /// <summary>
+    /// Last game tick that the tile on the grid was modified.
+    /// </summary>
+    public GameTick LastTileModifiedTick = lastTileModifiedTick;
+}
+
+/// <summary>
+/// Serialized state of a <see cref="MapGridComponentState"/>.
+/// </summary>
+[Serializable, NetSerializable]
+internal sealed class MapGridComponentDeltaState(ushort chunkSize, Dictionary<Vector2i, ChunkDatum>? chunkData, GameTick lastTileModifiedTick)
+    : ComponentState, IComponentDeltaState<MapGridComponentState>
+{
+    /// <summary>
+    /// The size of the chunks in the map grid.
+    /// </summary>
+    public readonly ushort ChunkSize = chunkSize;
+
+    /// <summary>
+    /// Networked chunk data.
+    /// </summary>
+    public readonly Dictionary<Vector2i, ChunkDatum>? ChunkData = chunkData;
+
+    /// <summary>
+    /// Last game tick that the tile on the grid was modified.
+    /// </summary>
+    public GameTick LastTileModifiedTick = lastTileModifiedTick;
+
+    public void ApplyToFullState(MapGridComponentState state)
+    {
+        state.ChunkSize = ChunkSize;
+
+        if (ChunkData == null)
+            return;
+
+        foreach (var (index, data) in ChunkData)
         {
-            state.ChunkSize = ChunkSize;
-
-            if (ChunkData == null)
-                return;
-
-            foreach (var (index, data) in ChunkData)
-            {
-                if (data.IsDeleted())
-                    state.FullGridData.Remove(index);
-                else
-                    state.FullGridData[index] = data;
-            }
-
-            state.LastTileModifiedTick = LastTileModifiedTick;
+            if (data.IsDeleted())
+                state.FullGridData.Remove(index);
+            else
+                state.FullGridData[index] = data;
         }
 
-        public MapGridComponentState CreateNewFullState(MapGridComponentState state)
-        {
-            if (ChunkData == null)
-                return new(ChunkSize, state.FullGridData, state.LastTileModifiedTick);
+        state.LastTileModifiedTick = LastTileModifiedTick;
+    }
 
-            var newState = new MapGridComponentState(ChunkSize, state.FullGridData.ShallowClone(), LastTileModifiedTick);
-            ApplyToFullState(newState);
-            return newState;
-        }
+    public MapGridComponentState CreateNewFullState(MapGridComponentState state)
+    {
+        if (ChunkData == null)
+            return new(ChunkSize, state.FullGridData, state.LastTileModifiedTick);
+
+        var newState = new MapGridComponentState(ChunkSize, state.FullGridData.ShallowClone(), LastTileModifiedTick);
+        ApplyToFullState(newState);
+        return newState;
     }
 }

--- a/Robust.Shared/Map/Components/MapGridComponent.cs
+++ b/Robust.Shared/Map/Components/MapGridComponent.cs
@@ -15,9 +15,20 @@ using Robust.Shared.ViewVariables;
 namespace Robust.Shared.Map.Components;
 
 /// <summary>
-/// Component marking a grid entity, which are the "floor" in space other entities can be placed on.
-/// Grids can have their own physics and move around in space while players or other entities move on them.
-/// Examples for grids are the station, shuttles or asteroids.
+/// <para>
+///     Provides a tile grid as part of an entity, with APIs to manipulate it provided on <see cref="MapSystem"/>.
+///     Grids function as the optional second level in the physics hierarchy, and implicitly provide physics and the ability to collide with one-another.
+/// </para>
+/// <para>
+///     Map grids are an unbounded 2D grid composed of <see cref="Tile"/>s, 
+///     which have their properties defined by <see cref="ITileDefinition"/> inheriting prototypes.
+///     A tile with the id 0 is automatically assumed to be the "empty" tile and is the default state of any tile that has not been assigned to.
+/// </para>
+/// <para>
+///     Collision is automatically generated from set grid tiles (excluding tiles with id 0, i.e. empty).
+///     Map grids have an implied additional level of physics acceleration structures,
+///     functioning as an optimization for games that rely on moving grids regularly by avoiding the need to update the grids' children.
+/// </para>
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 public sealed partial class MapGridComponent : Component


### PR DESCRIPTION
It's been obsolete for more than 2 years, time to remove it.
Content does not use it anymore.
If someone still uses it it's an easy fix since it's just a direct replacement with the corresponding MapSystem API method.

Partially addresses #6468