### PR TITLE
Fully obsolete methods in ContainerManagerComponent

### DIFF
--- a/Robust.Shared/Containers/ContainerManagerComponent.cs
+++ b/Robust.Shared/Containers/ContainerManagerComponent.cs
@@ -4,142 +4,128 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
-using Robust.Shared.IoC;
-using Robust.Shared.Map;
-using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
 
-namespace Robust.Shared.Containers
+namespace Robust.Shared.Containers;
+
+/// <summary>
+/// Holds data about a set of entity containers on this entity.
+/// </summary>
+[NetworkedComponent]
+[RegisterComponent, ComponentProtoName("ContainerContainer")]
+public sealed partial class ContainerManagerComponent : Component, ISerializationHooks
 {
     /// <summary>
-    /// Holds data about a set of entity containers on this entity.
+    /// Dictionary containing the containers on this entity.
+    /// The key is used as an identifier and can be freely chosen when a new container is added with <see cref="SharedContainerSystem.MakeContainer"/>.
     /// </summary>
-    [NetworkedComponent]
-    [RegisterComponent, ComponentProtoName("ContainerContainer")]
-    public sealed partial class ContainerManagerComponent : Component, ISerializationHooks
+    [DataField]
+    public Dictionary<string, BaseContainer> Containers = new();
+
+    // Requires a custom serializer + copier to get rid of. Good luck
+    void ISerializationHooks.AfterDeserialization()
     {
-        [Dependency] private readonly IEntityManager _entMan = default!;
-
-        [DataField("containers")]
-        public Dictionary<string, BaseContainer> Containers = new();
-
-        // Requires a custom serializer + copier to get rid of. Good luck
-        void ISerializationHooks.AfterDeserialization()
+        foreach (var (id, container) in Containers)
         {
-            foreach (var (id, container) in Containers)
-            {
-                container.Init(default!, id, (Owner, this));
-            }
+            container.Init(default!, id, (Owner, this));
         }
+    }
 
-        [Obsolete]
-        public bool TryGetContainer(string id, [NotNullWhen(true)] out BaseContainer? container)
-            => _entMan.System<SharedContainerSystem>().TryGetContainer(Owner, id, out container, this);
+    [Serializable, NetSerializable]
+    internal sealed class ContainerManagerComponentState : ComponentState
+    {
+        public Dictionary<string, ContainerData> Containers;
 
-        [Obsolete]
-        public bool TryGetContainer(EntityUid entity, [NotNullWhen(true)] out BaseContainer? container)
-            => _entMan.System<SharedContainerSystem>().TryGetContainingContainer(Owner, entity, out container, this);
-
-        [Obsolete]
-        public AllContainersEnumerable GetAllContainers()
-            => _entMan.System<SharedContainerSystem>().GetAllContainers(Owner, this);
+        public ContainerManagerComponentState(Dictionary<string, ContainerData> containers)
+        {
+            Containers = containers;
+        }
 
         [Serializable, NetSerializable]
-        internal sealed class ContainerManagerComponentState : ComponentState
+        public readonly struct ContainerData
         {
-            public Dictionary<string, ContainerData> Containers;
+            public readonly string ContainerType; // TODO remove this. We dont have to send a whole string.
+            public readonly bool ShowContents;
+            public readonly bool OccludesLight;
+            public readonly NetEntity[] ContainedEntities;
 
-            public ContainerManagerComponentState(Dictionary<string, ContainerData> containers)
+            public ContainerData(string containerType, bool showContents, bool occludesLight, NetEntity[] containedEntities)
             {
-                Containers = containers;
+                ContainerType = containerType;
+                ShowContents = showContents;
+                OccludesLight = occludesLight;
+                ContainedEntities = containedEntities;
             }
 
-            [Serializable, NetSerializable]
-            public readonly struct ContainerData
+            public void Deconstruct(out string type, out bool showEnts, out bool occludesLight, out NetEntity[] ents)
             {
-                public readonly string ContainerType; // TODO remove this. We dont have to send a whole string.
-                public readonly bool ShowContents;
-                public readonly bool OccludesLight;
-                public readonly NetEntity[] ContainedEntities;
-
-                public ContainerData(string containerType, bool showContents, bool occludesLight, NetEntity[] containedEntities)
-                {
-                    ContainerType = containerType;
-                    ShowContents = showContents;
-                    OccludesLight = occludesLight;
-                    ContainedEntities = containedEntities;
-                }
-
-                public void Deconstruct(out string type, out bool showEnts, out bool occludesLight, out NetEntity[] ents)
-                {
-                    type = ContainerType;
-                    showEnts = ShowContents;
-                    occludesLight = OccludesLight;
-                    ents = ContainedEntities;
-                }
+                type = ContainerType;
+                showEnts = ShowContents;
+                occludesLight = OccludesLight;
+                ents = ContainedEntities;
             }
         }
+    }
 
-        public readonly struct AllContainersEnumerable : IEnumerable<BaseContainer>
+    public readonly struct AllContainersEnumerable : IEnumerable<BaseContainer>
+    {
+        private readonly ContainerManagerComponent? _manager;
+
+        public AllContainersEnumerable(ContainerManagerComponent? manager)
         {
-            private readonly ContainerManagerComponent? _manager;
-
-            public AllContainersEnumerable(ContainerManagerComponent? manager)
-            {
-                _manager = manager;
-            }
-
-            public AllContainersEnumerator GetEnumerator()
-            {
-                return new(_manager);
-            }
-
-            IEnumerator<BaseContainer> IEnumerable<BaseContainer>.GetEnumerator()
-            {
-                return GetEnumerator();
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return GetEnumerator();
-            }
+            _manager = manager;
         }
 
-        public struct AllContainersEnumerator : IEnumerator<BaseContainer>
+        public AllContainersEnumerator GetEnumerator()
         {
-            private Dictionary<string, BaseContainer>.ValueCollection.Enumerator _enumerator;
+            return new(_manager);
+        }
 
-            public AllContainersEnumerator(ContainerManagerComponent? manager)
+        IEnumerator<BaseContainer> IEnumerable<BaseContainer>.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+
+    public struct AllContainersEnumerator : IEnumerator<BaseContainer>
+    {
+        private Dictionary<string, BaseContainer>.ValueCollection.Enumerator _enumerator;
+
+        public AllContainersEnumerator(ContainerManagerComponent? manager)
+        {
+            _enumerator = manager?.Containers.Values.GetEnumerator() ?? new();
+            Current = default;
+        }
+
+        public bool MoveNext()
+        {
+            while (_enumerator.MoveNext())
             {
-                _enumerator = manager?.Containers.Values.GetEnumerator() ?? new();
-                Current = default;
+                Current = _enumerator.Current;
+                return true;
             }
 
-            public bool MoveNext()
-            {
-                while (_enumerator.MoveNext())
-                {
-                    Current = _enumerator.Current;
-                    return true;
-                }
+            return false;
+        }
 
-                return false;
-            }
+        void IEnumerator.Reset()
+        {
+            ((IEnumerator<BaseContainer>) _enumerator).Reset();
+        }
 
-            void IEnumerator.Reset()
-            {
-                ((IEnumerator<BaseContainer>) _enumerator).Reset();
-            }
+        [AllowNull]
+        public BaseContainer Current { get; private set; }
 
-            [AllowNull]
-            public BaseContainer Current { get; private set; }
+        object IEnumerator.Current => Current;
 
-            object IEnumerator.Current => Current;
-
-            public void Dispose()
-            {
-            }
+        public void Dispose()
+        {
         }
     }
 }


### PR DESCRIPTION
They were obsoleted over 2 years ago #4622
Time to fully remove them.
In case someone is still using them it should be a simple replacement with the corresponding system API method.

I also changed the namespace to be file scoped and added a code comment.

Partially addresses #6468