### PR TITLE
remove obsolete pvs override methods

### DIFF
--- a/Robust.Server/GameStates/PvsOverrideSystem.cs
+++ b/Robust.Server/GameStates/PvsOverrideSystem.cs
@@ -252,27 +252,6 @@ public sealed class PvsOverrideSystem : SharedPvsOverrideSystem
         }
     }
 
-    [Obsolete("Use variant that takes in an EntityUid")]
-    public void AddGlobalOverride(NetEntity entity, bool removeExistingOverride = true, bool recursive = false)
-    {
-        if (TryGetEntity(entity, out var uid))
-            AddGlobalOverride(uid.Value);
-    }
-
-    [Obsolete("Use variant that takes in an EntityUid")]
-    public void AddSessionOverride(NetEntity entity, ICommonSession session, bool removeExistingOverride = true)
-    {
-        if (TryGetEntity(entity, out var uid))
-            AddSessionOverride(uid.Value, session);
-    }
-
-    [Obsolete("Don't use this, clear specific overrides")]
-    public void ClearOverride(NetEntity entity)
-    {
-        if (TryGetEntity(entity, out var uid))
-            Clear(uid.Value);
-    }
-
     #region Map/Grid Events
 
     private void OnGridRemoved(GridRemovalEvent ev)


### PR DESCRIPTION
They have been obsoleted over two years ago #4759
Time to remove them.

If any forks still use them they can simply convert the NetEntity into an EntityUid and call the overload for that.