### PR TITLE
Remove `[Virtual]` attributes from abstract/sealed classes

### DIFF
--- a/Robust.Client/UserInterface/Controls/PopupContainer.cs
+++ b/Robust.Client/UserInterface/Controls/PopupContainer.cs
@@ -7,7 +7,6 @@ namespace Robust.Client.UserInterface.Controls
     ///     Container that tries to put controls at their specified origin,
     ///     moving them around if necessary to avoid them going outside of the bounds of the container.
     /// </summary>
-    [Virtual]
     public sealed class PopupContainer : Control
     {
         /// <summary>

--- a/Robust.Client/UserInterface/Controls/Range.cs
+++ b/Robust.Client/UserInterface/Controls/Range.cs
@@ -5,7 +5,6 @@ using Robust.Shared.ViewVariables;
 
 namespace Robust.Client.UserInterface.Controls
 {
-    [Virtual]
     public abstract class Range : Control
     {
         private float _maxValue = 100;

--- a/Robust.Client/UserInterface/Controls/ScrollBar.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollBar.cs
@@ -7,7 +7,6 @@ using Robust.Shared.Timing;
 
 namespace Robust.Client.UserInterface.Controls
 {
-    [Virtual]
     public abstract class ScrollBar : Range
     {
         public const string StylePropertyGrabber = "grabber";

--- a/Robust.Client/UserInterface/Controls/UIWidget.cs
+++ b/Robust.Client/UserInterface/Controls/UIWidget.cs
@@ -2,7 +2,6 @@
 
 namespace Robust.Client.UserInterface.Controls;
 
-[Virtual]
 public abstract class UIWidget : BoxContainer
 {
     protected UIWidget()

--- a/Robust.Shared.IntegrationTests/Spawning/EntitySpawnHelpersTest.cs
+++ b/Robust.Shared.IntegrationTests/Spawning/EntitySpawnHelpersTest.cs
@@ -16,7 +16,6 @@ namespace Robust.UnitTesting.Shared.Spawning;
 /// <see cref="IEntityManager.TrySpawnNextTo"/>) work as intended.
 /// </summary>
 [TestFixture]
-[Virtual]
 public abstract partial class EntitySpawnHelpersTest : RobustIntegrationTest
 {
     protected ServerIntegrationInstance Server = default!;

--- a/Robust.Shared/GameObjects/ComponentState.cs
+++ b/Robust.Shared/GameObjects/ComponentState.cs
@@ -21,7 +21,6 @@ namespace Robust.Shared.GameObjects;
 /// </remarks>
 [RequiresSerializable]
 [Serializable, NetSerializable]
-[Virtual]
 public abstract class ComponentState : IComponentState;
 
 /// <summary>

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -30,7 +30,6 @@ namespace Robust.Shared.GameObjects
     public delegate void ComponentQueryCallback<T>(EntityUid uid, T component) where T : IComponent;
 
     /// <inheritdoc />
-    [Virtual]
     public abstract partial class EntityManager : IEntityManager
     {
         #region Dependencies

--- a/Robust.Shared/ViewVariables/ViewVariablesPath.cs
+++ b/Robust.Shared/ViewVariables/ViewVariablesPath.cs
@@ -10,7 +10,6 @@ namespace Robust.Shared.ViewVariables;
 /// <summary>
 ///     Represents a ViewVariables path. Allows you to "Get", "Set" or "Invoke" the path.
 /// </summary>
-[Virtual]
 public abstract class ViewVariablesPath
 {
     /// <summary>


### PR DESCRIPTION
`[Virtual]` is meant to be mutually exclusive with `sealed`, `abstract`, and `static`. This PR cleans up all engine violations of that rule.

This cleanup is needed before we can add an analyzer to detect these violations. See https://github.com/space-wizards/RobustToolbox/issues/6412.