### PR TITLE
Allow hex colour input

### DIFF
--- a/Resources/Locale/en-US/controls.ftl
+++ b/Resources/Locale/en-US/controls.ftl
@@ -5,6 +5,7 @@ color-selector-sliders-hue = H
 color-selector-sliders-saturation = S
 color-selector-sliders-value = V
 color-selector-sliders-alpha = A
+color-selector-input-hex = Hex
 
 color-selector-sliders-rgb = RGB
 color-selector-sliders-hsv = HSV

--- a/Robust.Client/UserInterface/Controls/ColorSelectorSliders.cs
+++ b/Robust.Client/UserInterface/Controls/ColorSelectorSliders.cs
@@ -165,7 +165,7 @@ public sealed class ColorSelectorSliders : Control
         _alphaInputBox.ValueChanged += value => { OnInputBoxValueChanged(value, ColorSliderOrder.Alpha); };
         _hexInputEdit.OnTextEntered += value => { OnHexInputValueChanged(value); };
         // The above triggers ONLY when the Enter key is pressed, which can be a bit unintuitive
-        // when making changes to multiple colors
+        // when making changes to multiple colors (e.g. editing markings)
         _hexInputEdit.OnFocusExit += value => { OnHexInputValueChanged(value); };
 
         _alphaSliderLabel.Text = Loc.GetString("color-selector-sliders-alpha");

--- a/Robust.Client/UserInterface/Controls/ColorSelectorSliders.cs
+++ b/Robust.Client/UserInterface/Controls/ColorSelectorSliders.cs
@@ -73,11 +73,13 @@ public sealed class ColorSelectorSliders : Control
     private SpinBox _middleInputBox;
     private SpinBox _bottomInputBox;
     private SpinBox _alphaInputBox;
+    private LineEdit _hexInputEdit;
 
     private Label _topSliderLabel = new();
     private Label _middleSliderLabel = new();
     private Label _bottomSliderLabel = new();
     private Label _alphaSliderLabel = new();
+    private Label _hexInputLabel = new();
     private Label _colorDescriptionLabel = new();
 
     private OptionButton _typeSelector;
@@ -151,12 +153,23 @@ public sealed class ColorSelectorSliders : Control
         };
         _alphaInputBox.InitDefaultButtons();
 
+        _hexInputEdit = new LineEdit
+        {
+            HorizontalExpand = true,
+            VerticalAlignment = VAlignment.Center,
+        };
+
         _topInputBox.ValueChanged += value => { OnInputBoxValueChanged(value, ColorSliderOrder.Top); };
         _middleInputBox.ValueChanged += value => { OnInputBoxValueChanged(value, ColorSliderOrder.Middle); };
         _bottomInputBox.ValueChanged += value => { OnInputBoxValueChanged(value, ColorSliderOrder.Bottom); };
         _alphaInputBox.ValueChanged += value => { OnInputBoxValueChanged(value, ColorSliderOrder.Alpha); };
+        _hexInputEdit.OnTextEntered += value => { OnHexInputValueChanged(value); };
+        // The above triggers ONLY when the Enter key is pressed, which can be a bit unintuitive
+        // when making changes to multiple colors
+        _hexInputEdit.OnFocusExit += value => { OnHexInputValueChanged(value); };
 
         _alphaSliderLabel.Text = Loc.GetString("color-selector-sliders-alpha");
+        _hexInputLabel.Text = Loc.GetString("color-selector-input-hex");
 
         _typeSelector = new OptionButton();
         foreach (var ty in Enum.GetValues<ColorSelectorType>())
@@ -216,10 +229,16 @@ public sealed class ColorSelectorSliders : Control
         _alphaSliderBox.AddChild(_alphaSlider);
         _alphaSliderBox.AddChild(_alphaInputBox);
 
+        var hexInputBox = new BoxContainer();
+
+        hexInputBox.AddChild(_hexInputLabel);
+        hexInputBox.AddChild(_hexInputEdit);
+
         bodyBox.AddChild(topSliderBox);
         bodyBox.AddChild(middleSliderBox);
         bodyBox.AddChild(bottomSliderBox);
         bodyBox.AddChild(_alphaSliderBox);
+        bodyBox.AddChild(hexInputBox);
 
         rootBox.AddChild(bodyBox);
 
@@ -293,6 +312,7 @@ public sealed class ColorSelectorSliders : Control
         _middleStyle.SetBaseColor(_colorData);
         _bottomStyle.SetBaseColor(_colorData);
         _colorDescriptionLabel.Text = ColorNaming.Describe(Color, _localization);
+        _hexInputEdit.Text = _currentColor.ToHex();
     }
 
     private void UpdateAllSliders()
@@ -335,6 +355,15 @@ public sealed class ColorSelectorSliders : Control
 
         UpdateSliderVisuals();
         UpdateSlider(order);
+    }
+
+    private void OnHexInputValueChanged(LineEdit.LineEditEventArgs args)
+    {
+        _currentColor = Color.FromHex(args.Text, _currentColor);
+        _colorData = GetStrategy().ToColorData(_currentColor);
+        OnColorChanged?.Invoke(_currentColor);
+
+        UpdateAllSliders();
     }
 
     private enum ColorSliderOrder

--- a/Robust.Client/UserInterface/Controls/ColorSelectorSliders.cs
+++ b/Robust.Client/UserInterface/Controls/ColorSelectorSliders.cs
@@ -163,10 +163,10 @@ public sealed class ColorSelectorSliders : Control
         _middleInputBox.ValueChanged += value => { OnInputBoxValueChanged(value, ColorSliderOrder.Middle); };
         _bottomInputBox.ValueChanged += value => { OnInputBoxValueChanged(value, ColorSliderOrder.Bottom); };
         _alphaInputBox.ValueChanged += value => { OnInputBoxValueChanged(value, ColorSliderOrder.Alpha); };
-        _hexInputEdit.OnTextEntered += value => { OnHexInputValueChanged(value); };
+        _hexInputEdit.OnTextEntered += OnHexInputValueChanged;
         // The above triggers ONLY when the Enter key is pressed, which can be a bit unintuitive
         // when making changes to multiple colors (e.g. editing markings)
-        _hexInputEdit.OnFocusExit += value => { OnHexInputValueChanged(value); };
+        _hexInputEdit.OnFocusExit += OnHexInputValueChanged;
 
         _alphaSliderLabel.Text = Loc.GetString("color-selector-sliders-alpha");
         _hexInputLabel.Text = Loc.GetString("color-selector-input-hex");
@@ -359,7 +359,14 @@ public sealed class ColorSelectorSliders : Control
 
     private void OnHexInputValueChanged(LineEdit.LineEditEventArgs args)
     {
+        var currentAlpha = _currentColor.A;
         _currentColor = Color.FromHex(args.Text, _currentColor);
+        // If alpha is not meant to be edited, don't allow hex codes to change it
+        if (!IsAlphaVisible)
+        {
+            _currentColor.A = currentAlpha;
+        }
+
         _colorData = GetStrategy().ToColorData(_currentColor);
         OnColorChanged?.Invoke(_currentColor);
 


### PR DESCRIPTION
Adds a text box for entering and copying hex codes for colour selectors.

## Why

In my experience this is a fairly standard feature for colour selectors to have. This also makes it less of a hassle to change colours when editing things like markings that allow for multiple colours, since now you can just copy and paste the hex code instead of having to do so for each channel.

## Details

**Resources/Locale/en-US/controls.ftl**

- New entry for the input label.

**Robust.Client/UserInterface/Controls/ColorSelectorSliders.cs**

- New private members for the text box and corresponding label
  - LineEdit horizontally expands and is centred like the sliders are. `IsValid` is purposely omitted in favour of using the current colour as a fallback, as this triggers as soon as any character in the text box is changed, which prevents you from typing in a code manually if you wanted to do that for whatever reason
  - Colour is updated when the user either presses the Enter key within the text box, or when it loses focus
- New private function `OnHexInputValueChanged`
  - Handles colour change logic, modified from `OnSliderValueChanged`
- `UpdateSliderVisuals` now also sets the new text box to the hex representation of the current colour

## Media

https://github.com/user-attachments/assets/968a64e0-96b7-4bee-bb43-df20a7940e0c

And of course, this doesn't bypass colour restrictions for species like Vox or Vulpkanin:

https://github.com/user-attachments/assets/d184dd0c-5932-46db-b3da-1fcf27272d86

And the field only appears when the HSV/RGB sliders are enabled (IIRC this is only relevant for human skin colour?)

<img width="1267" height="440" alt="image" src="https://github.com/user-attachments/assets/9d2066ce-166e-4c85-a1f8-8e478b7d10f9" />
