### PR TITLE
DoS Exploit patch

### DIFF
--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -354,7 +354,7 @@ namespace Robust.Shared
         /// Records are only removed if they have not been seen for this many minutes.
         /// </summary>
         public static readonly CVarDef<int> NetDecryptFailCleanupInterval =
-            CVarDef.Create("net.dos_fail_cleanup_interval", 2, CVar.SERVERONLY);
+            CVarDef.Create("net.dos_fail_cleanup_interval", 10, CVar.SERVERONLY);
 
         /// <summary>
         /// Maximum number of IPs tracked for decryption failures. Prevents memory exhaustion from botnet attacks.

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -338,6 +338,31 @@ namespace Robust.Shared
             CVarDef.Create("net.lidgren_app_identifier", "RobustToolbox");
 
         /// <summary>
+        /// Whether to disconnect clients that exceed the decryption failure threshold.
+        /// </summary>
+        public static readonly CVarDef<bool> NetDecryptFailKick =
+            CVarDef.Create("net.dos_fail_kick", true, CVar.SERVERONLY);
+
+        /// <summary>
+        /// Number of decryption failures from a single IP (or /64 subnet for IPv6) before logging a ban warning and optionally disconnecting.
+        /// </summary>
+        public static readonly CVarDef<int> NetDecryptFailBanThreshold =
+            CVarDef.Create("net.dos_fail_ban_threshold", 10, CVar.SERVERONLY);
+
+        /// <summary>
+        /// How often (in minutes) to clean up stale decryption failure records.
+        /// Records are only removed if they have not been seen for this many minutes.
+        /// </summary>
+        public static readonly CVarDef<int> NetDecryptFailCleanupInterval =
+            CVarDef.Create("net.dos_fail_cleanup_interval", 2, CVar.SERVERONLY);
+
+        /// <summary>
+        /// Maximum number of IPs tracked for decryption failures. Prevents memory exhaustion from botnet attacks.
+        /// </summary>
+        public static readonly CVarDef<int> NetDecryptFailMaxTracked =
+            CVarDef.Create("net.dos_fail_max_tracked", 10000, CVar.SERVERONLY);
+
+        /// <summary>
         /// Add random fake network loss to all outgoing UDP network packets, as a ratio of how many packets to drop.
         /// 0 = no packet loss, 1 = all packets dropped
         /// </summary>

--- a/Robust.Shared/Network/NetEncryption.cs
+++ b/Robust.Shared/Network/NetEncryption.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Threading;
@@ -84,7 +84,7 @@ internal sealed class NetEncryption
             ArrayPool<byte>.Shared.Return(returnPool);
     }
 
-    public unsafe void Decrypt(NetIncomingMessage message)
+    public unsafe bool Decrypt(NetIncomingMessage message)
     {
         var nonce = message.ReadUInt64();
         var cipherText = message.Data.AsSpan(sizeof(ulong), message.LengthBytes - sizeof(ulong));
@@ -109,12 +109,12 @@ internal sealed class NetEncryption
             // key
             _key);
 
-        message.Position = 0;
-        message.LengthBytes = messageLength;
-
         ArrayPool<byte>.Shared.Return(buffer);
 
         if (!result)
-            throw new SodiumException("Decryption operation failed!");
+        return false;
+        message.Position = 0;
+        message.LengthBytes = messageLength;
+        return true;
     }
 }

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -141,6 +141,9 @@ namespace Robust.Shared.Network
         private ISawmill _logger = default!;
         private ISawmill _loggerPacket = default!;
         private ISawmill _authLogger = default!;
+        
+        private readonly Dictionary<IPAddress, int> _decryptFailCounts = new();
+        private const int DecryptFailBanThreshold = 10;
 
         private bool _clientSerializerComplete;
         private bool _clientTransferComplete;
@@ -938,7 +941,21 @@ namespace Robust.Shared.Network
                 return true;
             }
 
-            channel.Encryption?.Decrypt(msg);
+            try
+            { channel.Encryption?.Decrypt(msg); }
+            catch (Exception e)
+            {
+                var remoteEndPoint = msg.SenderConnection.RemoteEndPoint;
+                var remoteIp = remoteEndPoint.Address;
+                _decryptFailCounts.TryGetValue(remoteIp, out var failCount);
+                failCount += 1;
+                _decryptFailCounts[remoteIp] = failCount;
+                _logger.Warning($"{remoteEndPoint}: Failed to decrypt message (fail #{failCount}), disconnecting. Exception: {e.Message}");
+                if (failCount >= DecryptFailBanThreshold)
+                { _authLogger.Warning($"[DECRYPTBAN] {remoteIp} reached {failCount} decryption failures. Consider banning this IP."); }
+                channel.Disconnect("Decryption failure");
+                return true;
+            }
 
             var id = msg.ReadByte();
 

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -141,9 +142,9 @@ namespace Robust.Shared.Network
         private ISawmill _logger = default!;
         private ISawmill _loggerPacket = default!;
         private ISawmill _authLogger = default!;
-        
-        private readonly Dictionary<IPAddress, int> _decryptFailCounts = new();
-        private const int DecryptFailBanThreshold = 10;
+
+        private readonly ConcurrentDictionary<IPAddress, (int TotalCount, DateTime LastSeen)> _decryptFailCounts = new();
+        private DateTime _lastDecryptFailCleanup = DateTime.UtcNow;
 
         private bool _clientSerializerComplete;
         private bool _clientTransferComplete;
@@ -493,8 +494,27 @@ namespace Robust.Shared.Network
             _initialized = false;
         }
 
+        private static IPAddress NormalizeIp(IPAddress ip)
+        {
+            if (ip.AddressFamily != AddressFamily.InterNetworkV6) return ip;
+            var bytes = ip.GetAddressBytes();
+            for (var i = 8; i < 16; i++) bytes[i] = 0;
+            return new IPAddress(bytes);
+        }
+
+        private void CleanupDecryptFailCounts()
+        {
+            var now = DateTime.UtcNow;
+            var intervalMinutes = _config.GetCVar(CVars.NetDecryptFailCleanupInterval);
+            if ((now - _lastDecryptFailCleanup).TotalMinutes < intervalMinutes) return;
+            _lastDecryptFailCleanup = now;
+            foreach (var (ip, (_, lastSeen)) in _decryptFailCounts)
+            { if ((now - lastSeen).TotalMinutes >= intervalMinutes) _decryptFailCounts.TryRemove(ip, out _); }
+        }
+
         public void ProcessPackets()
         {
+            CleanupDecryptFailCounts();
             var sentMessages = 0L;
             var recvMessages = 0L;
             var sentBytes = 0L;
@@ -946,14 +966,20 @@ namespace Robust.Shared.Network
             catch (Exception e)
             {
                 var remoteEndPoint = msg.SenderConnection.RemoteEndPoint;
-                var remoteIp = remoteEndPoint.Address;
-                _decryptFailCounts.TryGetValue(remoteIp, out var failCount);
-                failCount += 1;
-                _decryptFailCounts[remoteIp] = failCount;
-                _logger.Warning($"{remoteEndPoint}: Failed to decrypt message (fail #{failCount}), disconnecting. Exception: {e.Message}");
-                if (failCount >= DecryptFailBanThreshold)
-                { _authLogger.Warning($"[DECRYPTBAN] {remoteIp} reached {failCount} decryption failures. Consider banning this IP."); }
-                channel.Disconnect("Decryption failure");
+                var remoteIp = NormalizeIp(remoteEndPoint.Address);
+                var now = DateTime.UtcNow;
+                var banThreshold = _config.GetCVar(CVars.NetDecryptFailBanThreshold);
+                var maxTracked = _config.GetCVar(CVars.NetDecryptFailMaxTracked);
+                // Drop silently
+                if (_decryptFailCounts.Count >= maxTracked && !_decryptFailCounts.ContainsKey(remoteIp)) return true;
+                var (failCount, _) = _decryptFailCounts.AddOrUpdate(remoteIp, _ => (1, now), (_, old) => (old.TotalCount + 1, now));
+                // Log only on first failure
+                if (failCount == 1) _logger.Warning($"{remoteEndPoint}: Decryption failure. Exception: {e.Message}");
+                if (failCount >= banThreshold)
+                {
+                    _authLogger.Warning($"[DECRYPTBAN] {remoteIp} reached {failCount} decryption failures. Consider banning this IP.");
+                    if (_config.GetCVar(CVars.NetDecryptFailKick)) channel.Disconnect("Decryption failure");
+                }
                 return true;
             }
 

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -985,35 +985,37 @@ namespace Robust.Shared.Network
             }
 
             // Attempt to decrypt the message, only logging if we fail to decrypt and we actually have encryption.
-            if (channel.Encryption != null && !channel.Encryption.TryDecrypt(msg))
+            if ((!channel.Encryption?.TryDecrypt(msg)) ?? false)
             {
-                if (IsServer)
                 var remoteEndPoint = msg.SenderConnection.RemoteEndPoint;
-                var remoteIp = NormalizeIp(remoteEndPoint.Address);
-                var now = DateTime.UtcNow;
-                var maxTracked = _config.GetCVar(CVars.NetDecryptFailMaxTracked);
-
-                // Drop silently if tracking limit reached
-                if (_decryptFailCounts.Count >= maxTracked && !_decryptFailCounts.ContainsKey(remoteIp))
-                    return true;
-
-                var (failCount, _) = _decryptFailCounts.AddOrUpdate(
-                    remoteIp,
-                    _ => (1, now),
-                    (_, old) => (old.TotalCount + 1, now));
-
-                // Log only on first failure and at threshold — avoids log I/O DoS
-                if (failCount == 1 && _logPacketIssues)
-                    _logger.Debug($"{remoteEndPoint}: Got a packet that fails to decrypt.");
-
-                var banThreshold = _config.GetCVar(CVars.NetDecryptFailBanThreshold);
-                if (failCount >= banThreshold)
+                if (IsServer)
                 {
-                    _authLogger.Warning($"[DECRYPTBAN] {remoteIp} reached {failCount} decryption failures. Consider banning this IP.");
-                    if (_config.GetCVar(CVars.NetDecryptFailKick))
-                        msg.SenderConnection.Disconnect("Failed to decrypt packet.", false);
-                }
+                    var remoteIp = NormalizeIp(remoteEndPoint.Address);
+                    var now = DateTime.UtcNow;
+                    var maxTracked = _config.GetCVar(CVars.NetDecryptFailMaxTracked);
 
+                    // Drop silently if tracking limit reached
+                    if (_decryptFailCounts.Count >= maxTracked && !_decryptFailCounts.ContainsKey(remoteIp))
+                        return true;
+                    var (failCount, _) = _decryptFailCounts.AddOrUpdate(
+                        remoteIp,
+                        _ => (1, now),
+                        (_, old) => (old.TotalCount + 1, now));
+                    if (failCount == 1 && _logPacketIssues)
+                        _logger.Debug($"{remoteEndPoint}: Got a packet that fails to decrypt.");
+
+                    var banThreshold = _config.GetCVar(CVars.NetDecryptFailBanThreshold);
+                    if (failCount >= banThreshold)
+                    {
+                        _authLogger.Warning($"[DECRYPTBAN] {remoteIp} reached {failCount} decryption failures. Consider banning this IP.");
+                        if (_config.GetCVar(CVars.NetDecryptFailKick))
+                            msg.SenderConnection.Disconnect("Failed to decrypt packet.", false);
+                        return true;
+                    }
+                }
+                else if (_logPacketIssues)
+                { _logger.Debug($"{remoteEndPoint}: Got a packet that fails to decrypt."); }
+                msg.SenderConnection.Disconnect("Failed to decrypt packet.", false);
                 return true;
             }
 

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -962,9 +962,7 @@ namespace Robust.Shared.Network
                 return true;
             }
 
-            try
-            { channel.Encryption?.Decrypt(msg); }
-            catch (Exception e)
+            if (channel.Encryption != null && !channel.Encryption.Decrypt(msg))
             {
                 var remoteEndPoint = msg.SenderConnection.RemoteEndPoint;
                 var remoteIp = NormalizeIp(remoteEndPoint.Address);
@@ -975,7 +973,7 @@ namespace Robust.Shared.Network
                 if (_decryptFailCounts.Count >= maxTracked && !_decryptFailCounts.ContainsKey(remoteIp)) return true;
                 var (failCount, _) = _decryptFailCounts.AddOrUpdate(remoteIp, _ => (1, now), (_, old) => (old.TotalCount + 1, now));
                 // Log only on first failure
-                if (failCount == 1) _logger.Warning($"{remoteEndPoint}: Decryption failure. Exception: {e.Message}");
+                if (failCount == 1) _logger.Warning($"{remoteEndPoint}: Decryption failure.");
                 if (failCount >= banThreshold)
                 {
                     _authLogger.Warning($"[DECRYPTBAN] {remoteIp} reached {failCount} decryption failures. Consider banning this IP.");

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -985,8 +985,9 @@ namespace Robust.Shared.Network
             }
 
             // Attempt to decrypt the message, only logging if we fail to decrypt and we actually have encryption.
-            if ((!channel.Encryption?.TryDecrypt(msg)) ?? true)
+            if (channel.Encryption != null && !channel.Encryption.TryDecrypt(msg))
             {
+                if (IsServer)
                 var remoteEndPoint = msg.SenderConnection.RemoteEndPoint;
                 var remoteIp = NormalizeIp(remoteEndPoint.Address);
                 var now = DateTime.UtcNow;

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -504,6 +504,7 @@ namespace Robust.Shared.Network
 
         private void CleanupDecryptFailCounts()
         {
+            if (!IsServer) return;
             var now = DateTime.UtcNow;
             var intervalMinutes = _config.GetCVar(CVars.NetDecryptFailCleanupInterval);
             if ((now - _lastDecryptFailCleanup).TotalMinutes < intervalMinutes) return;


### PR DESCRIPTION
# Fix: DoS via malicious encrypted packets

## Problem

The server accepted UDP packets from clients that had completed the Lidgren handshake, but whose contents were forged or intentionally corrupted. `NetEncryption.Decrypt()` threw a `SodiumException` that was not caught anywhere in the call chain:

```
NetEncryption.Decrypt()          < exception thrown here
NetManager.DispatchNetMessage()  < not caught
NetManager.ProcessPackets()      < not caught
BaseServer.Input()               < not caught
GameLoop.Run()                   < caught here - too late
```

`GameLoop` logged the error and continued, but all packets remaining in the current tick were dropped - legitimate clients stopped receiving state updates and disconnected with `FailedNotConnected`.

This allowed a single attacker witgh an established Lidgren connection to continuously kick all players from the server by flooding it with corrupted packets.

## Changes

**`Robust.Shared/Network/NetEncryption.cs`**

- `Decrypt()` now returns `bool` instead of throwing `SodiumException` on MAC failure. A bad packet is now a branch, not an exception.

**`Robust.Shared/Network/NetManager.cs`**

- Replaced `try/catch` with `if (!channel.Encryption.Decrypt(msg))`.
- Added `_decryptFailCounts` - tracks failures per IP. IPv6 addresses are masked to `/64` to prevent subnet hopping. Failure count never resets on cleanup to prevent threshold bypass by waiting.
- Logging only on first failure and at threshold to prevent log I/O DoS.
- Dictionary capped at `net.dos_fail_max_tracked` to prevent mewmory exhaustion from botnets.

**`Robust.Shared/CVars.cs`**

- `net.dos_fail_kick` (default: `true`) - disconnect upon reachimg threshold.
- `net.dos_fail_ban_threshold` (default: `10`) - failures before `[DECRYPTBAN]` warning and optional kick.
- `net.dos_fail_cleanup_interval` (default: `2`) - minutes between cleanup passes.
- `net.dos_fail_max_tracked` (default: `10000`) - max IPs tracked simultaneously.

## Before / Aftewr

| | Before | After |
|---|---|---|
| Malicious packet | Exception escapes to GameLoop, all clients dropped for the tick | Attacker disconnected, other clients unaffected |
| Log output | `[ERRO] runtime: Caught exception in "gameLoop Input"` | `[WARN] net: X.X.X.X: First decryption failure` |
| Repeated attacks | Every packet crashes the tick indefinitely | Counter accumulates; at threshold `[DECRYPTBAN]` is emitted |

## Why this matters

- The attack requires no authentication - completing the Lidgren handshake is sufficient
- A single connection and minimal traffic is enough to sustain the attack
- The effect is a full drop of all online players on every malicious packet
- The fix removes the exception path entirely, making the hot path allocation-free


** Media
Before:
<img width="1676" height="884" alt="MobaXterm_x7lhrjR5jK" src="https://github.com/user-attachments/assets/fe0bb1a2-125a-48a0-bd50-27d817ebf68b" />
After
<img width="1078" height="471" alt="MobaXterm_sg6QwD8IbI" src="https://github.com/user-attachments/assets/b76a0ee8-2251-43c7-8471-44c871d518ff" />
<img width="1538" height="634" alt="MobaXterm_6eo0zWEGFA" src="https://github.com/user-attachments/assets/f0cf6dfc-ed9e-4a24-86d8-9f75f3f40d25" />

Server after patch don't falling from attacks