### PR TITLE
Fix a violation of measure invariants in ScrollContainer

### DIFF
--- a/Robust.Client/UserInterface/Controls/ScrollContainer.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollContainer.cs
@@ -215,6 +215,14 @@ namespace Robust.Client.UserInterface.Controls
                 return Vector2.Zero;
             }
 
+            // We need to measure our children again, to ensure they're aware of
+            // our real, final arrangement. It's a violation of invariants
+            // to measure a large space then try to draw them in something smaller.
+            //
+            // We only call our override, not Measure, to avoid infinite loops.
+            // We don't need to update ourselves after all.
+            MeasureOverride(finalSize);
+
             var maxChildMinSize = Vector2.Zero;
 
             foreach (var child in Children)

--- a/Robust.Client/UserInterface/Controls/ScrollContainer.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollContainer.cs
@@ -221,7 +221,14 @@ namespace Robust.Client.UserInterface.Controls
             //
             // We only call our override, not Measure, to avoid infinite loops.
             // We don't need to update ourselves after all.
-            MeasureOverride(finalSize);
+            //
+            // Atop that, we shouldn't remeasure if we ReturnMeasure, because then
+            // we do actually use all of our space and no invariants are getting
+            // broken unless our parent is themselves violating invariants.
+            // So measuring again using the final size may result in us
+            // mysteriously completely rearranging when we're not expected to.
+            if (!ReturnMeasure)
+                MeasureOverride(finalSize);
 
             var maxChildMinSize = Vector2.Zero;
 


### PR DESCRIPTION
Essentially, ScrollContainer would measure its children one size, and draw them another.
This *can be* fine but it is only fine if the drawn size is larger than the measured size. Which it generally never was if the outer container is a growing one (like an expandable boxcontainer)

The result of this is basically the root cause of RichTextLabel arrangement jank, as RichTextLabel relies on its measure to size and draw correctly.

So we re-measure ScrollContainer's children before arranging to ensure they're up to date on the actual, smaller layout of the container.

## Fixed
(excuse the WIP UI)
<img width="1919" height="1128" alt="image" src="https://github.com/user-attachments/assets/047b1bed-c315-4135-a252-dff2679e9a72" />
<img width="467" height="575" alt="image" src="https://github.com/user-attachments/assets/4ced030b-3d48-4d6f-87de-652a1b3cfc2e" />

## Old (broken)
<img width="1919" height="1129" alt="image" src="https://github.com/user-attachments/assets/26e2e4f5-9d7c-48df-a08e-5aa5bd441307" />
<img width="458" height="561" alt="image" src="https://github.com/user-attachments/assets/bbbfe32f-3f24-4de5-bd70-17a4b20b4c72" />
