### PR TITLE
Fix race condition in HappyEyeballs leaving extra connections alive

### DIFF
--- a/Robust.Shared/Network/HappyEyeballsHttp.cs
+++ b/Robust.Shared/Network/HappyEyeballsHttp.cs
@@ -236,13 +236,15 @@ internal static class HappyEyeballsHttp
         cancel.ThrowIfCancellationRequested();
         await successCts.CancelAsync().ConfigureAwait(false);
 
-        try
-        {
-            await Task.WhenAll(allTasks.Where(t => t != successTask)).ConfigureAwait(false);
-        }
-        catch
-        {
-        }
+        await Task.WhenAll(  
+            allTasks  
+                .Where(t => t != successTask)  
+                .Select(static t => t.ContinueWith(  
+                    static _ => { },  
+                    CancellationToken.None,  
+                    TaskContinuationOptions.ExecuteSynchronously,  
+                    TaskScheduler.Default)))  
+            .ConfigureAwait(false);
 
         if (successTask == null)
         {

--- a/Robust.Shared/Network/HappyEyeballsHttp.cs
+++ b/Robust.Shared/Network/HappyEyeballsHttp.cs
@@ -236,6 +236,14 @@ internal static class HappyEyeballsHttp
         cancel.ThrowIfCancellationRequested();
         await successCts.CancelAsync().ConfigureAwait(false);
 
+        try
+        {
+            await Task.WhenAll(allTasks.Where(t => t != successTask)).ConfigureAwait(false);
+        }
+        catch
+        {
+        }
+
         if (successTask == null)
         {
             // We didn't get a single successful connection. Well heck.

--- a/Robust.Shared/Network/HappyEyeballsHttp.cs
+++ b/Robust.Shared/Network/HappyEyeballsHttp.cs
@@ -236,21 +236,21 @@ internal static class HappyEyeballsHttp
         cancel.ThrowIfCancellationRequested();
         await successCts.CancelAsync().ConfigureAwait(false);
 
-        await Task.WhenAll(  
-            allTasks  
-                .Where(t => t != successTask)  
-                .Select(static t => t.ContinueWith(  
-                    static _ => { },  
-                    CancellationToken.None,  
-                    TaskContinuationOptions.ExecuteSynchronously,  
-                    TaskScheduler.Default)))  
-            .ConfigureAwait(false);
-
         if (successTask == null)
         {
             // We didn't get a single successful connection. Well heck.
             throw new AggregateException(
                 allTasks.Where(x => x.IsFaulted).SelectMany(x => x.Exception!.InnerExceptions));
+        }
+
+        // Wait for losing tasks to finish before cleanup.
+        try
+        {
+            await Task.WhenAll(allTasks.Where(t => t != successTask)).ConfigureAwait(false);
+        }
+        catch
+        {
+            // We don't care if losing tasks throw.
         }
 
         // I don't know if this is possible but MAKE SURE that we don't get two sockets completing at once.


### PR DESCRIPTION
Title.

The issue is that after calling `successCts.CancelAsync()` in `HappyEyeballsHttp.cs`, the current code does not wait for the losing tasks to actually complete. As a result, in the cleanup loop a task may not yet have `IsCompletedSuccessfully` set. This causes `Dispose()` to be skipped and the extra connection to remain alive.
In debug build, the leftover connection triggers an assert that corrupts the connection state (which happens to me about every 10th time I launch SS14, and it's really annoying).