### PR TITLE
Report all error logs on `TestPair` dispose

### DIFF
--- a/Robust.UnitTesting/Pool/TestPair.Recycle.cs
+++ b/Robust.UnitTesting/Pool/TestPair.Recycle.cs
@@ -22,23 +22,11 @@ public partial class TestPair<TServer, TClient>
     {
         using (Assert.EnterMultipleScope())
         {
-            if (ServerLogHandler.FailingLogs.Count == 1)
-                Assert.Fail(ServerLogHandler.FailingLogs[0]);
-            else if (ServerLogHandler.FailingLogs.Count > 1)
-            {
-                Assert.Fail("Server had multiple failing logs reported, consult the game log.");
-                foreach (var log in ServerLogHandler.FailingLogs)
-                    Assert.Fail(log);
-            }
+            foreach (var log in ServerLogHandler.FailingLogs)
+                Assert.Fail(log);
 
-            if (ClientLogHandler.FailingLogs.Count == 1)
-                Assert.Fail(ClientLogHandler.FailingLogs[0]);
-            else if (ClientLogHandler.FailingLogs.Count > 1)
-            {
-                Assert.Fail("Client had multiple failing logs reported, consult the game log.");
-                foreach (var log in ClientLogHandler.FailingLogs)
-                    Assert.Fail(log);
-            }
+            foreach (var log in ClientLogHandler.FailingLogs)
+                Assert.Fail(log);
         }
     }
 

--- a/Robust.UnitTesting/Pool/TestPair.Recycle.cs
+++ b/Robust.UnitTesting/Pool/TestPair.Recycle.cs
@@ -25,12 +25,20 @@ public partial class TestPair<TServer, TClient>
             if (ServerLogHandler.FailingLogs.Count == 1)
                 Assert.Fail(ServerLogHandler.FailingLogs[0]);
             else if (ServerLogHandler.FailingLogs.Count > 1)
+            {
                 Assert.Fail("Server had multiple failing logs reported, consult the game log.");
+                foreach (var log in ServerLogHandler.FailingLogs)
+                    Assert.Fail(log);
+            }
 
             if (ClientLogHandler.FailingLogs.Count == 1)
                 Assert.Fail(ClientLogHandler.FailingLogs[0]);
             else if (ClientLogHandler.FailingLogs.Count > 1)
+            {
                 Assert.Fail("Client had multiple failing logs reported, consult the game log.");
+                foreach (var log in ClientLogHandler.FailingLogs)
+                    Assert.Fail(log);
+            }
         }
     }
 


### PR DESCRIPTION
Adjusts `TestPair.ReportErrorLogs` to assert each failing log from a test run when there are multiple, instead of only the first (with a generic "consult the logs" message for multiple).