### PR TITLE
Always clean up render handle state after overlay draws

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -163,7 +163,8 @@ namespace Robust.Client.Graphics.Clyde
             }
             catch (Exception e)
             {
-                _logManager.GetSawmill("clyde.overlay").Error($"Caught exception while drawing overlay {overlay.GetType()}. Exception: {e}");
+                _logManager.GetSawmill("clyde.overlay")
+                    .Error($"Caught exception while drawing overlay {overlay.GetType()}. Exception: {e}");
             }
         }
 
@@ -227,7 +228,16 @@ namespace Robust.Client.Graphics.Clyde
                 }
                 catch (Exception e)
                 {
-                    _logManager.GetSawmill("clyde.overlay").Error($"Caught exception while drawing overlay {overlay.GetType()}. Exception: {e}");
+                    _logManager.GetSawmill("clyde.overlay")
+                        .Error($"Caught exception while drawing overlay {overlay.GetType()}. Exception: {e}");
+                }
+                finally
+                {
+                    // cleanup state so shaders/transforms dont leak into future overlays
+                    // many overlays already do cleanup manually, but ideally they don't have to at all
+                    // screen and world handles are backed by the same renderhandle, so we only need to do this for one
+                    handle.DrawingHandleScreen.SetTransform(Matrix3x2.Identity);
+                    handle.DrawingHandleScreen.UseShader(null);
                 }
             }
         }

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -166,6 +166,13 @@ namespace Robust.Client.Graphics.Clyde
                 _logManager.GetSawmill("clyde.overlay")
                     .Error($"Caught exception while drawing overlay {overlay.GetType()}. Exception: {e}");
             }
+            finally
+            {
+                // cleanup state so shaders/transforms dont leak into future overlays
+                // many overlays already do cleanup manually, but ideally they don't have to at all
+                _renderHandle.SetModelTransform(Matrix3x2.Identity);
+                _renderHandle.UseShader(null);
+            }
         }
 
         private void RenderOverlays(Viewport vp, OverlaySpace space, in Box2 worldBox, in Box2Rotated worldBounds)


### PR DESCRIPTION
in content, there are occasional bugs that popup that result from an overlay not properly calling `UseShader(null)` or `SetTransform(Matrix3x2.Identity)` after drawing something, which causes the render handle's state to leak into the next overlay drawn and potentially mess things up (assuming this overlay doesn't happen to reset it manually)

this is a pretty easy thing to forget and I don't see an immediate reason why cleaning up for the overlays can't be done automatically. these are basically zero cost even if its duplicated work afaict since all it does is just set variables in clyde and nothing more complicated