### PR TITLE
Expose access to more fields on `AudioComponent`

### DIFF
--- a/Robust.Shared/Audio/Components/AudioComponent.cs
+++ b/Robust.Shared/Audio/Components/AudioComponent.cs
@@ -51,6 +51,7 @@ public sealed partial class AudioComponent : Component, IAudioSource
 
     // We can't just start playing on audio creation as we don't have the correct position yet.
     // As such we'll wait for FrameUpdate before we start playing to avoid the position being cooked.
+    [Access(Other = AccessPermissions.ReadWriteExecute)]
     public bool Started = false;
 
     [AutoNetworkedField]
@@ -85,12 +86,15 @@ public sealed partial class AudioComponent : Component, IAudioSource
 
     #region Source
 
+    [Access(Other = AccessPermissions.Execute)]
     public void Pause() => Source.Pause();
 
     /// <inheritdoc />
+    [Access(Other = AccessPermissions.Execute)]
     public void StartPlaying() => Source.StartPlaying();
 
     /// <inheritdoc />
+    [Access(Other = AccessPermissions.Execute)]
     public void StopPlaying()
     {
         PlaybackPosition = 0f;
@@ -98,6 +102,7 @@ public sealed partial class AudioComponent : Component, IAudioSource
     }
 
     /// <inheritdoc />
+    [Access(Other = AccessPermissions.Execute)]
     public void Restart() => Source.Restart();
 
     [DataField, AutoNetworkedField]
@@ -179,6 +184,7 @@ public sealed partial class AudioComponent : Component, IAudioSource
     /// Not replicated as audio always tracks the entity's position.
     /// </remarks>
     [ViewVariables]
+    [Access(Other = AccessPermissions.ReadWriteExecute)]
     public Vector2 Position
     {
         get => Source.Position;
@@ -236,6 +242,7 @@ public sealed partial class AudioComponent : Component, IAudioSource
     /// Not replicated.
     /// </remarks>
     [ViewVariables]
+    [Access(Other = AccessPermissions.ReadWriteExecute)]
     public Vector2 Velocity
     {
         get => Source.Velocity;


### PR DESCRIPTION
with #6268 in mind (or if you just wanted to override a lot of engine audio handling in general even beyond that) it is currently impossible to actually replicate `ProcessStream`/`GetOcclusion` because of access. i dont think theres really any reason to not expose these since there aren't system methods for interfacing with these and if people want to fuck up this things in client code they might as well be allowed to (again esp with #6268 in mind)

i would enjoy simply removing the access bounds entirely, considering the above (this component is EC-ified in general and the access makes it really annoying to interact with since there arent system methods for interfacing with the low level fields and shit here)