### PR TITLE
HRTF support through `openal-soft`

### DIFF
--- a/Robust.Client/Audio/AudioManager.cs
+++ b/Robust.Client/Audio/AudioManager.cs
@@ -67,7 +67,8 @@ internal sealed partial class AudioManager : IAudioInternal
                 attributeList =
                 [
                     (int) AlcSoftGetInteger.Hrtf, 1,
-                    // default to the first specifier,
+                    // default to the first specifier, im not even really sure in what contexts more than one of these
+                    // exists and i dont think its super valuable to expose another cvar for changing the index
                     (int) AlcSoftGetInteger.HrtfId, 0,
                     0
                 ];

--- a/Robust.Client/Audio/AudioManager.cs
+++ b/Robust.Client/Audio/AudioManager.cs
@@ -46,14 +46,7 @@ internal sealed partial class AudioManager : IAudioInternal
 
     private void _audioCreateContext()
     {
-        unsafe
-        {
-            _openALContext = ALC.CreateContext(_openALDevice, (int*) 0);
-        }
-
-        ALC.MakeContextCurrent(_openALContext);
-        _checkAlcError(_openALDevice);
-        _checkAlError();
+        var useHrtf = _cfg.GetCVar(CVars.AudioHrtf);
 
         // Load up AL context extensions.
         var s = ALC.GetString(_openALDevice, AlcGetString.Extensions) ?? "";
@@ -62,9 +55,40 @@ internal sealed partial class AudioManager : IAudioInternal
             _alContextExtensions.Add(extension);
         }
 
+        var supportsHrtf = HasAlContextExtension("ALC_SOFT_HRTF");
+        var attributeList = new [] { 0 };
+        if (useHrtf && supportsHrtf)
+        {
+            var hrtfCount = ALC.GetInteger(_openALDevice, (AlcGetInteger)AlcSoftGetInteger.NumHrtfSpecifiers);
+            OpenALSawmill.Debug("HRTF specifier count: {0}", hrtfCount);
+
+            if (hrtfCount > 0)
+            {
+                attributeList =
+                [
+                    (int) AlcSoftGetInteger.Hrtf, 1,
+                    // default to the first specifier,
+                    (int) AlcSoftGetInteger.HrtfId, 0,
+                    0
+                ];
+            }
+            else
+            {
+                OpenALSawmill.Warning("HRTF support enabled but no supported specifiers, HRTF will be disabled");
+            }
+        }
+
+        _openALContext = ALC.CreateContext(_openALDevice, attributeList);
+
+        ALC.MakeContextCurrent(_openALContext);
+        _checkAlcError(_openALDevice);
+        _checkAlError();
+
+        var hrtfEnabled = supportsHrtf ? ALC.GetInteger(_openALDevice, (AlcGetInteger)AlcSoftGetInteger.HrtfStatus) : 0;
         OpenALSawmill.Debug("OpenAL Vendor: {0}", AL.Get(ALGetString.Vendor));
         OpenALSawmill.Debug("OpenAL Renderer: {0}", AL.Get(ALGetString.Renderer));
         OpenALSawmill.Debug("OpenAL Version: {0}", AL.Get(ALGetString.Version));
+        OpenALSawmill.Debug("HRTF status: {0}", hrtfEnabled == 1 ? "Enabled" : "Disabled");
     }
 
     private bool _audioOpenDevice()
@@ -181,6 +205,19 @@ internal sealed partial class AudioManager : IAudioInternal
         {
             OpenALSawmill.Error("[{0}:{1}] AL error: {2}", callerMember, callerLineNumber, error);
         }
+    }
+
+    /// <summary>
+    ///     OpenAL Soft specific enum. OpenTK packages the regular OpenAL ones, but we use OpenAL Soft on most platforms,
+    ///     and these are used at the moment for HRTF support specifically.
+    /// </summary>
+    // https://github.com/kcat/openal-soft/blob/e9c479eb4190101bc51179afae56fc6dd5d26066/include/AL/alext.h#L471
+    public enum AlcSoftGetInteger
+    {
+        Hrtf = 0x1992,
+        HrtfStatus = 0x1993,
+        NumHrtfSpecifiers = 0x1994,
+        HrtfId = 0x1996
     }
 
     private sealed class LoadedAudioSample

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1282,7 +1282,7 @@ namespace Robust.Shared
         /// Whether to enable HRTF (head-related transfer function) support for positional audio.
         /// </summary>
         /// <remarks>
-        /// This CVar being true isn't necessarily enough to actually use HRTF. Your engine ver must be using openal-soft,
+        /// This CVar being true isn't necessarily enough to actually use HRTF. Your platform must be using openal-soft,
         /// and your device needs to actually support it (although it almost certainly does).
         /// </remarks>
         public static readonly CVarDef<bool> AudioHrtf =

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1279,6 +1279,16 @@ namespace Robust.Shared
             CVarDef.Create("audio.attenuation", (int) Attenuation.LinearDistanceClamped, CVar.REPLICATED | CVar.ARCHIVE);
 
         /// <summary>
+        /// Whether to enable HRTF (head-related transfer function) support for positional audio.
+        /// </summary>
+        /// <remarks>
+        /// This CVar being true isn't necessarily enough to actually use HRTF. Your engine ver must be using openal-soft,
+        /// and your device needs to actually support it (although it almost certainly does).
+        /// </remarks>
+        public static readonly CVarDef<bool> AudioHrtf =
+            CVarDef.Create("audio.hrtf", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+        /// <summary>
         /// Audio device to try to output audio to by default.
         /// </summary>
         public static readonly CVarDef<string> AudioDevice =


### PR DESCRIPTION
we use OpenAL thru OpenTK for our audio engine, and (maybe always?) have used `openal-soft` as the actual implementation (i vaguely remember this differing per platform, I think mac doesn't use it, maybe?), which actually supports a decent amount of things that openal normally doesn't, including HRTF ([head-related transfer function](https://en.wikipedia.org/wiki/Head-related_transfer_function)).

enabling HRTF generally just makes positional audio sound more "correct", and you can refer to the comparison videos below for what that actually means in context. this PR adds a client cvar for enabling/disabling it, and enables it by default. if the openal soft HRTF extension isnt found (either the device doesnt support it somehow or openal-soft isnt being used), then it just won't be enabled.

**Disabled:**

https://github.com/user-attachments/assets/782c0658-2090-4cca-a497-e228c36eb086

**Enabled:**

https://github.com/user-attachments/assets/3d616c9a-8ba1-43ae-bee9-5b660de693ad

the effect in this video is most noticeable in the audio positioned bottom-left, where hrtf enabled sounds considerably more natural, imo