### PR TITLE
Fix BUI EntitySystem injection

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Fixed `EntitySystem` dependencies throwing an exception when opening a BUI.
 
 ### Other
 

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -536,7 +536,7 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
         // states. E.g., stripping UI used to throw NREs in some instances while fetching the identity of unknown
         // entities.
         var type = _reflection.LooseGetType(data.ClientType);
-        var boundUserInterface = (BoundUserInterface) _factory.CreateInstance(type, [entity.Owner, key]);
+        var boundUserInterface = (BoundUserInterface) _factory.CreateInstance(type, [entity.Owner, key], inject: false);
         entity.Comp.ClientOpenInterfaces[key] = boundUserInterface;
 
         // This is just so we don't open while applying UI states.

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -536,6 +536,7 @@ public abstract class SharedUserInterfaceSystem : EntitySystem
         // states. E.g., stripping UI used to throw NREs in some instances while fetching the identity of unknown
         // entities.
         var type = _reflection.LooseGetType(data.ClientType);
+        // No dependency injection because the BUI constructor will handle it.
         var boundUserInterface = (BoundUserInterface) _factory.CreateInstance(type, [entity.Owner, key], inject: false);
         entity.Comp.ClientOpenInterfaces[key] = boundUserInterface;
 


### PR DESCRIPTION
https://github.com/space-wizards/RobustToolbox/pull/6394 added the ability for BUIs to inject `EntitySystem` dependencies, but a bit of testing reveals that attempting to do so winds up throwing an `UnregisteredDependencyException`.

The source of this appears to be in `SharedUserInterfaceSystem.EnsureClientBui`, which calls `IDynamicTypeFactory.CreateInstance` to create an instance of the BUI class. `CreateInstance` attempts to do a second round of dependency injection, but lacks access to any `EntitySystem`s to inject, so it throws an exception.

Conveniently, `CreateInstance` has an `inject` boolean parameter, so we can simply disable this second dependency injection pass. The `BoundUserInterface` constructor handles dependency injection now, so we shouldn't have any need for it.

I did a bit of testing and this didn't appear to have broken anything (and I can't think of a logical way that it would), but help with a bit of additional testing would be appreciated!