### PR TITLE
Add `SharedOnly` attribute and analyzer

### DIFF
--- a/Robust.Analyzers.Tests/Robust.Analyzers.Tests.csproj
+++ b/Robust.Analyzers.Tests/Robust.Analyzers.Tests.csproj
@@ -18,6 +18,7 @@
     <EmbeddedResource Include="..\Robust.Shared\Analyzers\ForbidLiteralAttribute.cs" LogicalName="Robust.Shared.Analyzers.ForbidLiteralAttribute.cs" LinkBase="Implementations" />
     <EmbeddedResource Include="..\Robust.Shared\Analyzers\ObsoleteInheritanceAttribute.cs" LogicalName="Robust.Shared.Analyzers.ObsoleteInheritanceAttribute.cs" LinkBase="Implementations" />
     <EmbeddedResource Include="..\Robust.Shared\Analyzers\ValidateMemberAttribute.cs" LogicalName="Robust.Shared.Analyzers.ValidateMemberAttribute.cs" LinkBase="Implementations" />
+    <EmbeddedResource Include="..\Robust.Shared\Analyzers\SharedOnlyAttribute.cs" LogicalName="Robust.Shared.Analyzers.SharedOnlyAttribute.cs" LinkBase="Implementations" />
     <EmbeddedResource Include="..\Robust.Shared\IoC\DependencyAttribute.cs" LogicalName="Robust.Shared.IoC.DependencyAttribute.cs" LinkBase="Implementations" />
     <EmbeddedResource Include="..\Robust.Shared\GameObjects\EventBusAttributes.cs" LogicalName="Robust.Shared.GameObjects.EventBusAttributes.cs" LinkBase="Implementations" />
     <EmbeddedResource Include="..\Robust.Shared\Serialization\NetSerializableAttribute.cs" LogicalName="Robust.Shared.Serialization.NetSerializableAttribute.cs" LinkBase="Implementations" />

--- a/Robust.Analyzers.Tests/SharedOnlyAnalyzerTest.cs
+++ b/Robust.Analyzers.Tests/SharedOnlyAnalyzerTest.cs
@@ -1,0 +1,176 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+using VerifyCS =
+    Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<Robust.Analyzers.SharedOnlyAnalyzer, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+namespace Robust.Analyzers.Tests;
+
+[Parallelizable(ParallelScope.All | ParallelScope.Fixtures)]
+[TestFixture]
+[TestOf(typeof(SharedOnlyAnalyzer))]
+public sealed class SharedOnlyAnalyzerTest
+{
+    private static Task Verifier(string code, string assemblyName, params DiagnosticResult[] expected)
+    {
+        var test = new CSharpAnalyzerTest<SharedOnlyAnalyzer, DefaultVerifier>()
+        {
+            TestState =
+            {
+                Sources = { code },
+            },
+        };
+
+        TestHelper.AddEmbeddedSources(
+            test.TestState,
+            "Robust.Shared.Analyzers.SharedOnlyAttribute.cs"
+        );
+
+        test.TestState.Sources.Add(("TestTypeDefs.cs", TestTypeDefs));
+
+        test.SolutionTransforms.Add((solution, projectId) =>
+        {
+            // Since this analyzer works based on the assembly name,
+            // we need to override it per-test to make the test work
+            return solution.WithProjectAssemblyName(projectId, assemblyName);
+        });
+
+        // ExpectedDiagnostics cannot be set, so we need to AddRange here...
+        test.TestState.ExpectedDiagnostics.AddRange(expected);
+
+        return test.RunAsync();
+    }
+
+    private const string TestTypeDefs = """
+        using Robust.Shared.Analyzers;
+
+        namespace Robust.Shared.Testing
+        {
+            public sealed class Foo
+            {
+                // These types would realistically always be in Shared,
+                // but we only get one test assembly, so we just ignore the warning
+                #pragma warning disable RA0048
+                [SharedOnly]
+                public void SharedMethod() { }
+                [SharedOnly]
+                public bool SharedProperty { get; set; }
+                [SharedOnly]
+                public bool SharedField;
+                #pragma warning restore RA0048
+            }
+        }
+    """;
+
+    [Test]
+    [Description("Tests that using a [SharedOnly] method/property/field from Client code raises a warning")]
+    public async Task TestClient()
+    {
+        const string code = """
+            using Robust.Shared.Testing;
+
+            public sealed class ClientTester
+            {
+                public void Test()
+                {
+                    var foo = new Foo();
+
+                    foo.SharedMethod();
+                    var x = foo.SharedProperty;
+                    var y = foo.SharedField;
+                }
+            }
+            """;
+
+        await Verifier(code, "Robust.Client.Testing",
+            // /0/Test0.cs(11,13): warning RA0048: SharedMethod should only be used in Shared assemblies
+            VerifyCS.Diagnostic().WithSpan(9, 9, 9, 27).WithArguments("SharedMethod"),
+            // /0/Test0.cs(10,21): warning RA0048: SharedProperty should only be used in Shared assemblies
+            VerifyCS.Diagnostic().WithSpan(10, 17, 10, 35).WithArguments("SharedProperty"),
+            // /0/Test0.cs(11,21): warning RA0048: SharedField should only be used in Shared assemblies
+            VerifyCS.Diagnostic().WithSpan(11, 17, 11, 32).WithArguments("SharedField")
+        );
+    }
+
+    [Test]
+    [Description("Tests that using a [SharedOnly] method/property/field from Server code raises a warning")]
+    public async Task TestServer()
+    {
+        const string code = """
+            using Robust.Shared.Testing;
+
+            public sealed class ServerTester
+            {
+                public void Test()
+                {
+                    var foo = new Foo();
+
+                    foo.SharedMethod();
+                    var x = foo.SharedProperty;
+                    var y = foo.SharedField;
+                }
+            }
+            """;
+
+        await Verifier(code, "Robust.Server.Testing",
+            // /0/Test0.cs(9,9): warning RA0048: SharedMethod should only be used in Shared assemblies
+            VerifyCS.Diagnostic().WithSpan(9, 9, 9, 27).WithArguments("SharedMethod"),
+            // /0/Test0.cs(10,17): warning RA0048: SharedProperty should only be used in Shared assemblies
+            VerifyCS.Diagnostic().WithSpan(10, 17, 10, 35).WithArguments("SharedProperty"),
+            // /0/Test0.cs(11,17): warning RA0048: SharedField should only be used in Shared assemblies
+            VerifyCS.Diagnostic().WithSpan(11, 17, 11, 32).WithArguments("SharedField")
+        );
+    }
+
+    [Test]
+    [Description("Tests that using a [SharedOnly] method/property/field from Shared code does not raise a warning")]
+    public async Task TestShared()
+    {
+        const string code = """
+            using Robust.Shared.Testing;
+
+            public sealed class SharedTester
+            {
+                public void Test()
+                {
+                    var foo = new Foo();
+
+                    foo.SharedMethod();
+                    var x = foo.SharedProperty;
+                    var y = foo.SharedField;
+                }
+            }
+            """;
+
+        await Verifier(code, "Robust.Shared.Testing", []);
+    }
+
+    [Test]
+    [Description("Tests that marking a Client method/property/field as [SharedOnly] raises a warning")]
+    public async Task TestAttribute()
+    {
+        const string code = """
+            using Robust.Shared.Analyzers;
+
+            public sealed class Foo
+            {
+                [SharedOnly]
+                public void DoThing() { }
+                [SharedOnly]
+                public bool Bar { get; set; }
+                [SharedOnly]
+                public bool Baz;
+            }
+            """;
+
+        await Verifier(code, "Robust.Client.Testing",
+            // /0/Test0.cs(5,6): warning RA0048: SharedOnlyAttribute should only be used in Shared assemblies
+            VerifyCS.Diagnostic().WithSpan(5, 6, 5, 16).WithArguments("SharedOnlyAttribute"),
+            // /0/Test0.cs(7,6): warning RA0048: SharedOnlyAttribute should only be used in Shared assemblies
+            VerifyCS.Diagnostic().WithSpan(7, 6, 7, 16).WithArguments("SharedOnlyAttribute"),
+            // /0/Test0.cs(9,6): warning RA0048: SharedOnlyAttribute should only be used in Shared assemblies
+            VerifyCS.Diagnostic().WithSpan(9, 6, 9, 16).WithArguments("SharedOnlyAttribute")
+        );
+    }
+}

--- a/Robust.Analyzers/Robust.Analyzers.csproj
+++ b/Robust.Analyzers/Robust.Analyzers.csproj
@@ -27,6 +27,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Needed for SharedOnlyAnalyzer. -->
+    <Compile Include="..\Robust.Shared\Analyzers\SharedOnlyAttribute.cs" LinkBase="Implementations" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Needed for DataDefinitionAnalyzer. -->
     <Compile Include="..\Robust.Shared\Serialization\Manager\Definition\DataDefinitionUtility.cs" LinkBase="Implementations" />
     <Compile Include="..\Robust.Shared\ViewVariables\ViewVariablesAttribute.cs" LinkBase="Implementations" />

--- a/Robust.Analyzers/SharedOnlyAnalyzer.cs
+++ b/Robust.Analyzers/SharedOnlyAnalyzer.cs
@@ -1,0 +1,94 @@
+#nullable enable
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using Robust.Roslyn.Shared;
+
+namespace Robust.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class SharedOnlyAnalyzer : DiagnosticAnalyzer
+{
+    private const string SharedOnlyAttributeType = "Robust.Shared.Analyzers.SharedOnlyAttribute";
+
+    public static readonly DiagnosticDescriptor SharedOnlyRule = new(
+        Diagnostics.IdSharedOnly,
+        "Use is forbidden outside of Shared assemblies",
+        "{0} should only be used in Shared assemblies",
+        "Usage",
+        DiagnosticSeverity.Warning,
+        true
+    );
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+    [
+        SharedOnlyRule,
+    ];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+        context.RegisterCompilationStartAction(ctx =>
+        {
+            // Don't do anything in Shared assemblies
+            if (ctx.Compilation.AssemblyName?.Contains("Shared") == true)
+                return;
+
+            // Get the type symbol for the attribute
+            if (ctx.Compilation.GetTypeByMetadataName(SharedOnlyAttributeType) is not { } attributeType)
+                return;
+
+            ctx.RegisterOperationAction(operationContext => AnalyzeOperation(operationContext, attributeType), OperationKind.Invocation);
+            ctx.RegisterOperationAction(operationContext => AnalyzeOperation(operationContext, attributeType), OperationKind.PropertyReference);
+            ctx.RegisterOperationAction(operationContext => AnalyzeOperation(operationContext, attributeType), OperationKind.FieldReference);
+
+            // Attribute usage check
+            ctx.RegisterOperationAction(operationContext => AnalyzeAttribute(operationContext, attributeType), OperationKind.Attribute);
+        });
+    }
+
+    private void AnalyzeOperation(OperationAnalysisContext context, INamedTypeSymbol attributeType)
+    {
+        ISymbol target = context.Operation switch
+        {
+            IInvocationOperation invocation => invocation.TargetMethod,
+            IPropertyReferenceOperation propertyRef => propertyRef.Property,
+            IFieldReferenceOperation fieldRef => fieldRef.Field,
+            _ => throw new InvalidOperationException()
+        };
+
+        if (!AttributeHelper.HasAttribute(target, attributeType, out _))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            SharedOnlyRule,
+            context.Operation.Syntax.GetLocation(),
+            target.Name
+        ));
+    }
+
+    /// <summary>
+    /// Checks for correct usage of the attribute itself.
+    /// </summary>
+    private void AnalyzeAttribute(OperationAnalysisContext context, INamedTypeSymbol attributeType)
+    {
+        if (context.Operation is not IAttributeOperation operation)
+            return;
+
+        if (operation.Operation is not IObjectCreationOperation creationOperation)
+            return;
+
+        if (SymbolEqualityComparer.Default.Equals(creationOperation.Type, attributeType))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+            SharedOnlyRule,
+            context.Operation.Syntax.GetLocation(),
+            attributeType.Name
+        ));
+        }
+    }
+}

--- a/Robust.Roslyn.Shared/Diagnostics.cs
+++ b/Robust.Roslyn.Shared/Diagnostics.cs
@@ -51,6 +51,7 @@ public static class Diagnostics
     public const string IdPreferProxy = "RA0045";
     public const string IdProxyForRedundantMethodName = "RA0046";
     public const string IdProxyForTargetMethodNotFound = "RA0047";
+    public const string IdSharedOnly = "RA0048";
 
     public static SuppressionDescriptor MeansImplicitAssignment =>
         new SuppressionDescriptor("RADC1000", "CS0649", "Marked as implicitly assigned.");

--- a/Robust.Shared/Analyzers/SharedOnlyAttribute.cs
+++ b/Robust.Shared/Analyzers/SharedOnlyAttribute.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Robust.Shared.Analyzers;
+
+/// <summary>
+/// <para>
+/// Indicates that a member should only be used in Shared assemblies.
+/// Attempting to use it in a Client-only or Server-only assembly will raise a warning.
+/// </para>
+/// <para>
+/// This should be used when such usage would be nonsensical or pointless,
+/// such as calling <c>INetManager.IsClient</c> in client-only code.
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field)]
+public sealed class SharedOnlyAttribute : Attribute;

--- a/Robust.Shared/Network/INetManager.cs
+++ b/Robust.Shared/Network/INetManager.cs
@@ -13,11 +13,13 @@ namespace Robust.Shared.Network
         /// <summary>
         ///     Is this a server, or a client?
         /// </summary>
+        [SharedOnly]
         bool IsServer { get; }
 
         /// <summary>
         ///     Is this a client, or a server?
         /// </summary>
+        [SharedOnly]
         bool IsClient { get; }
 
         /// <summary>


### PR DESCRIPTION
Adds a new attribute, `SharedOnlyAttribute` that can be applied to methods, properties, and fields that should only be used in Shared assemblies. Attempting to use marked members in Client or Server assemblies will raise a warning.

This PR also applies the attribute to `INetManager.IsServer` and `INetManager.IsClient`.
Resolves https://github.com/space-wizards/RobustToolbox/issues/6506.

~~There are currently violations in Content that will need to be cleaned up before this can be merged:~~
```
Content.Client/FeedbackPopup/ClientFeedbackManager.cs(34,36): warning RA0048: IsClient should only be used in Shared assemblies [Content.Client/Content.Client.csproj]
Content.Client/FeedbackPopup/ClientFeedbackManager.cs(45,14): warning RA0048: IsClient should only be used in Shared assemblies [Content.Client/Content.Client.csproj]
Content.Server/FeedbackSystem/ServerFeedbackManager.cs(32,14): warning RA0048: IsServer should only be used in Shared assemblies [Content.Server/Content.Server.csproj]
Content.Server/FeedbackSystem/ServerFeedbackManager.cs(47,14): warning RA0048: IsServer should only be used in Shared assemblies [Content.Server/Content.Server.csproj]
Content.Server/FeedbackSystem/ServerFeedbackManager.cs(62,14): warning RA0048: IsServer should only be used in Shared assemblies [Content.Server/Content.Server.csproj]
Content.Server/FeedbackSystem/ServerFeedbackManager.cs(72,14): warning RA0048: IsServer should only be used in Shared assemblies [Content.Server/Content.Server.csproj]
Content.Server/Sound/EmitSoundSystem.cs(52,13): warning RA0048: IsClient should only be used in Shared assemblies [Content.Server/Content.Server.csproj]
```