### PR TITLE
Fix RichTextEntry not allowing font tags

### DIFF
--- a/Robust.Client/UserInterface/RichTextEntry.cs
+++ b/Robust.Client/UserInterface/RichTextEntry.cs
@@ -26,7 +26,8 @@ namespace Robust.Client.UserInterface
             typeof(BulletTag),
             typeof(ColorTag),
             typeof(HeadingTag),
-            typeof(ItalicTag)
+            typeof(ItalicTag),
+            typeof(FontTag),
         ];
 
         private readonly Color _defaultColor;


### PR DESCRIPTION
Adds FontTag to the DefaultTags in RichTextEntry

Previously this stopped things such as the speech bubble from using fonts which affects forks that want to use custom fonts for speech bubbles and the custom fonts used by EE's languages

(this also means we can make the clown speak in comic sans)
<img width="381" height="236" alt="image" src="https://github.com/user-attachments/assets/e2502790-fe0f-4dc1-aa75-85bf36ee8595" />

bingles restored to their former glory
<img width="708" height="430" alt="image" src="https://github.com/user-attachments/assets/a3eec54c-981b-4744-85aa-eb85a83472fe" />
