### PR TITLE
IHandleableEvent and ICancelableEvent Interfaces for events to use.

### DIFF
--- a/Robust.Shared/GameObjects/EntityEvents.cs
+++ b/Robust.Shared/GameObjects/EntityEvents.cs
@@ -5,14 +5,20 @@ using Robust.Shared.Serialization;
 
 namespace Robust.Shared.GameObjects
 {
-    public interface IEntityEventSubscriber { }
+    public interface IEntityEventSubscriber
+    {
+    }
 
     public delegate void EntityEventHandler<in T>(T ev);
+
     public delegate void EntityEventRefHandler<T>(ref T ev);
+
     public delegate void EntitySessionEventHandler<in T>(T msg, EntitySessionEventArgs args);
 
     [Serializable, NetSerializable]
-    public abstract class EntityEventArgs { }
+    public abstract class EntityEventArgs
+    {
+    }
 
     [Obsolete]
     [Serializable, NetSerializable]
@@ -44,47 +50,51 @@ namespace Robust.Shared.GameObjects
         public void Uncancel() => Cancelled = false;
     }
 
+    /// <summary>
+    /// An interface which allows an event to be "Handled" meaning a method has successfully responded to it in some way.
+    /// </summary>
     public interface IHandleableEvent
     {
         bool Handled { get; protected set; }
 
+        /// <summary>
+        /// Handles the event, call this when your method has correctly responded to the event implementing this interface.
+        /// </summary>
         public void Handle()
         {
             Handled = true;
         }
-
-        public void Unhandle()
-        {
-            Handled = false;
-        }
     }
 
+    /// <summary>
+    /// An interface which allows an event to be "Canceled" meaning a method has negatively responded to it in some way.
+    /// This is typically used for attempt events to prevent further code from being run.
+    /// </summary>
     public interface ICancelableEvent
     {
         bool Cancelled { get; protected set; }
 
+        /// <summary>
+        /// Cancels the event, call this when your method wishes to cancel the event implementing this interface.
+        /// </summary>
         public void Cancel()
         {
             Cancelled = true;
-        }
-
-        public void Uncancel()
-        {
-            Cancelled = false;
         }
     }
 
     /// <summary>
     /// Extension methods for Events so that inheritors of these event interfaces don't need to redefine their public methods.
+    /// These are filtered by struct and interfaces respectively because you should really be using ByRef structs for your events.
     /// </summary>
     public static class EventExtensions
     {
-        extension(IHandleableEvent ev)
+        extension<T>(T ev) where T : struct, IHandleableEvent
         {
             public void Handle() => ev.Handle();
         }
 
-        extension(ICancelableEvent ev)
+        extension<T>(T ev) where T : struct, IHandleableEvent
         {
             public void Cancel() => ev.Cancel();
         }

--- a/Robust.Shared/GameObjects/EntityEvents.cs
+++ b/Robust.Shared/GameObjects/EntityEvents.cs
@@ -94,7 +94,7 @@ namespace Robust.Shared.GameObjects
             public void Handle() => ev.Handle();
         }
 
-        extension<T>(T ev) where T : struct, IHandleableEvent
+        extension<T>(T ev) where T : struct, ICancelableEvent
         {
             public void Cancel() => ev.Cancel();
         }

--- a/Robust.Shared/GameObjects/EntityEvents.cs
+++ b/Robust.Shared/GameObjects/EntityEvents.cs
@@ -4,9 +4,7 @@ using Robust.Shared.Serialization;
 
 namespace Robust.Shared.GameObjects
 {
-    public interface IEntityEventSubscriber
-    {
-    }
+    public interface IEntityEventSubscriber { }
 
     public delegate void EntityEventHandler<in T>(T ev);
     public delegate void EntityEventRefHandler<T>(ref T ev);

--- a/Robust.Shared/GameObjects/EntityEvents.cs
+++ b/Robust.Shared/GameObjects/EntityEvents.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection.Metadata;
 using Robust.Shared.Player;
 using Robust.Shared.Serialization;
 
@@ -13,6 +14,7 @@ namespace Robust.Shared.GameObjects
     [Serializable, NetSerializable]
     public abstract class EntityEventArgs { }
 
+    [Obsolete]
     [Serializable, NetSerializable]
     public abstract class HandledEntityEventArgs : EntityEventArgs
     {
@@ -22,6 +24,7 @@ namespace Robust.Shared.GameObjects
         public bool Handled { get; set; }
     }
 
+    [Obsolete]
     [Serializable, NetSerializable]
     public abstract class CancellableEntityEventArgs : EntityEventArgs
     {
@@ -39,6 +42,52 @@ namespace Robust.Shared.GameObjects
         ///     Uncancels the event. Don't call this unless you know what you're doing.
         /// </summary>
         public void Uncancel() => Cancelled = false;
+    }
+
+    public interface IHandleableEvent
+    {
+        bool Handled { get; protected set; }
+
+        public void Handle()
+        {
+            Handled = true;
+        }
+
+        public void Unhandle()
+        {
+            Handled = false;
+        }
+    }
+
+    public interface ICancelableEvent
+    {
+        bool Cancelled { get; protected set; }
+
+        public void Cancel()
+        {
+            Cancelled = true;
+        }
+
+        public void Uncancel()
+        {
+            Cancelled = false;
+        }
+    }
+
+    /// <summary>
+    /// Extension methods for Events so that inheritors of these event interfaces don't need to redefine their public methods.
+    /// </summary>
+    public static class EventExtensions
+    {
+        extension(IHandleableEvent ev)
+        {
+            public void Handle() => ev.Handle();
+        }
+
+        extension(ICancelableEvent ev)
+        {
+            public void Cancel() => ev.Cancel();
+        }
     }
 
     public readonly struct EntitySessionEventArgs

--- a/Robust.Shared/GameObjects/EntityEvents.cs
+++ b/Robust.Shared/GameObjects/EntityEvents.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection.Metadata;
 using Robust.Shared.Player;
 using Robust.Shared.Serialization;
 

--- a/Robust.Shared/GameObjects/EntityEvents.cs
+++ b/Robust.Shared/GameObjects/EntityEvents.cs
@@ -10,17 +10,13 @@ namespace Robust.Shared.GameObjects
     }
 
     public delegate void EntityEventHandler<in T>(T ev);
-
     public delegate void EntityEventRefHandler<T>(ref T ev);
-
     public delegate void EntitySessionEventHandler<in T>(T msg, EntitySessionEventArgs args);
 
     [Serializable, NetSerializable]
-    public abstract class EntityEventArgs
-    {
-    }
+    public abstract class EntityEventArgs { }
 
-    [Obsolete]
+    [Obsolete("Use IHandleableEvent instead with a by ref struct event")]
     [Serializable, NetSerializable]
     public abstract class HandledEntityEventArgs : EntityEventArgs
     {
@@ -30,7 +26,7 @@ namespace Robust.Shared.GameObjects
         public bool Handled { get; set; }
     }
 
-    [Obsolete]
+    [Obsolete("Use ICancelableEvent instead with a by ref struct event")]
     [Serializable, NetSerializable]
     public abstract class CancellableEntityEventArgs : EntityEventArgs
     {
@@ -89,12 +85,12 @@ namespace Robust.Shared.GameObjects
     /// </summary>
     public static class EventExtensions
     {
-        extension<T>(T ev) where T : struct, IHandleableEvent
+        extension<T>(ref T ev) where T : struct, IHandleableEvent
         {
             public void Handle() => ev.Handle();
         }
 
-        extension<T>(T ev) where T : struct, ICancelableEvent
+        extension<T>(ref T ev) where T : struct, ICancelableEvent
         {
             public void Cancel() => ev.Cancel();
         }


### PR DESCRIPTION
## Description
Added IHandleableEvent and ICancelableEvent interfaces which are intended to be implemented by events in content and eventually engine to replace the HandleableEntityEventArgs and CancelableEntityEventArgs. 

As such those two classes have been marked obsolete

## Why?
Some systems in content care about events being handled to cancelled and there's not unified way to handle these events, this poses problems for potential construction system refactors and the like which need to handle a lot of events and check if they've been cancelled/handled/ect. or event relays which often explicitly check for handling/canceling to cut off the relay early. 

This is problematic as most new events are by ref structs due to their better performance, and they cannot inherit from these old classes. They can however implement interfaces, hence the need for such interfaces.

This PR only makes these interfaces and marks the old events obsolete as moving engine events to these interfaces would break content pretty badly, we should have at least an engine release or many with these available before we start breaking content by properly getting rid of the old args. 