### PR TITLE
Add exception handling to NetManager

### DIFF
--- a/Robust.Shared.IntegrationTests/GameObjects/EntityState_Tests.cs
+++ b/Robust.Shared.IntegrationTests/GameObjects/EntityState_Tests.cs
@@ -12,6 +12,7 @@ using Robust.Server.ServerStatus;
 using Robust.Shared.Asynchronous;
 using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
+using Robust.Shared.Exceptions;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
@@ -39,6 +40,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
         {
             var container = new DependencyCollection();
             container.Register<ILogManager, LogManager>();
+            container.Register<IRuntimeLog, RuntimeLog>();
             container.Register<IConfigurationManager, ServerNetConfigurationManager>();
             container.Register<IConfigurationManagerInternal, ServerNetConfigurationManager>();
             container.Register<INetManager, NetManager>();

--- a/Robust.Shared/Network/INetManager.cs
+++ b/Robust.Shared/Network/INetManager.cs
@@ -116,6 +116,12 @@ namespace Robust.Shared.Network
         ///     A client has just disconnected from the server.
         /// </summary>
         event EventHandler<NetDisconnectedArgs> Disconnect;
+        
+        /// <summary>
+        ///     A client sent a malformed packet that threw an exception while handling it.
+        ///     Invoked before it gets kicked.
+        /// </summary>
+        event Action<INetChannel>? OnMessageError;
 
         /// <summary>
         ///     Registers a NetMessage to be sent or received.

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Lidgren.Network;
 using Prometheus;
 using Robust.Shared.Configuration;
+using Robust.Shared.Exceptions;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Network.Transfer;
@@ -110,6 +111,7 @@ namespace Robust.Shared.Network
         [Dependency] private readonly IAuthManager _authManager = default!;
         [Dependency] private readonly IGameTiming _timing = default!;
         [Dependency] private readonly ILogManager _logMan = default!;
+        [Dependency] private readonly IRuntimeLog _runtimeLog = default!;
         [Dependency] private readonly ProfManager _prof = default!;
         [Dependency] private readonly HttpClientHolder _http = default!;
         [Dependency] private readonly IHWId _hwId = default!;
@@ -527,53 +529,69 @@ namespace Robust.Shared.Network
                 while ((msg = peer.Peer.ReadMessage()) != null)
                 {
                     countProcessed += 1;
-                    switch (msg.MessageType)
+                    try
                     {
-                        case NetIncomingMessageType.VerboseDebugMessage:
-                            _logger.Debug("{PeerAddress}: {Message}", peer.Peer.Configuration.LocalAddress,
-                                msg.ReadString());
-                            break;
-
-                        case NetIncomingMessageType.DebugMessage:
-                            _logger.Info("{PeerAddress}: {Message}", peer.Peer.Configuration.LocalAddress,
-                                msg.ReadString());
-                            break;
-
-                        case NetIncomingMessageType.WarningMessage:
-                            _logger.Warning("{PeerAddress}: {Message}", peer.Peer.Configuration.LocalAddress,
-                                msg.ReadString());
-                            break;
-
-                        case NetIncomingMessageType.ErrorMessage:
-                            _logger.Error("{PeerAddress}: {Message}", peer.Peer.Configuration.LocalAddress,
-                                msg.ReadString());
-                            break;
-
-                        case NetIncomingMessageType.ConnectionApproval:
-                            HandleApproval(msg);
-                            recycle = false;
-                            break;
-
-                        case NetIncomingMessageType.Data:
-                            countDataProcessed += 1;
-                            recycle = DispatchNetMessage(msg);
-                            break;
-
-                        case NetIncomingMessageType.StatusChanged:
-                            HandleStatusChanged(peer, msg);
-                            break;
-
-                        default:
-                            _logger.Warning("{0}: Unhandled incoming packet type from {1}: {2}",
-                                peer.Peer.Configuration.LocalAddress,
-                                msg.SenderConnection?.RemoteEndPoint,
-                                msg.MessageType);
-                            break;
+                        switch (msg.MessageType)
+                        {
+                            case NetIncomingMessageType.VerboseDebugMessage:
+                                _logger.Debug("{PeerAddress}: {Message}", peer.Peer.Configuration.LocalAddress,
+                                    msg.ReadString());
+                                break;
+    
+                            case NetIncomingMessageType.DebugMessage:
+                                _logger.Info("{PeerAddress}: {Message}", peer.Peer.Configuration.LocalAddress,
+                                    msg.ReadString());
+                                break;
+    
+                            case NetIncomingMessageType.WarningMessage:
+                                _logger.Warning("{PeerAddress}: {Message}", peer.Peer.Configuration.LocalAddress,
+                                    msg.ReadString());
+                                break;
+    
+                            case NetIncomingMessageType.ErrorMessage:
+                                _logger.Error("{PeerAddress}: {Message}", peer.Peer.Configuration.LocalAddress,
+                                    msg.ReadString());
+                                break;
+    
+                            case NetIncomingMessageType.ConnectionApproval:
+                                HandleApproval(msg);
+                                recycle = false;
+                                break;
+    
+                            case NetIncomingMessageType.Data:
+                                countDataProcessed += 1;
+                                recycle = DispatchNetMessage(msg);
+                                break;
+    
+                            case NetIncomingMessageType.StatusChanged:
+                                HandleStatusChanged(peer, msg);
+                                break;
+    
+                            default:
+                                _logger.Warning("{0}: Unhandled incoming packet type from {1}: {2}",
+                                    peer.Peer.Configuration.LocalAddress,
+                                    msg.SenderConnection?.RemoteEndPoint,
+                                    msg.MessageType);
+                                break;
+                        }
+    
+                        if (recycle)
+                        {
+                            peer.Peer.Recycle(msg);
+                        }
                     }
-
-                    if (recycle)
+                    catch (Exception e)
                     {
-                        peer.Peer.Recycle(msg);
+                        var localAddr = peer.Peer.Configuration.LocalAddress;
+                        var endpoint = msg.SenderConnection?.RemoteEndPoint;
+                        _runtimeLog.LogException(e, $"message handler for peer {localAddr} connection {endpoint}");
+                        if (msg.SenderConnection is { } sender)
+                        {
+                            sender.Disconnect("Your client sent a malformed packet!");
+                            // let content do whatever it wants with the probably malf client
+                            if (TryGetChannel(sender, out var channel))
+                                OnMessageError?.Invoke(channel);
+                        }
                     }
                 }
 
@@ -1240,6 +1258,9 @@ namespace Robust.Shared.Network
 
         /// <inheritdoc />
         public event EventHandler<NetDisconnectedArgs>? Disconnect;
+
+        /// <inheritdoc />
+        public event Action<INetChannel>? OnMessageError;
 
         #endregion Events
 

--- a/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
@@ -327,6 +327,7 @@ namespace Robust.UnitTesting
             public AuthMode Auth => AuthMode.Disabled;
             public Func<string, Task<NetUserId?>>? AssignUserIdCallback { get; set; }
             public IServerNetManager.NetApprovalDelegate? HandleApprovalCallback { get; set; }
+            public event Action<INetChannel>? OnMessageError;
 
             public void DisconnectChannel(INetChannel channel, string reason)
             {


### PR DESCRIPTION
When a client sends a malformed packet that (for any unforseeable reason, not just decryption) might throw an exception, currently it goes almost completely unhandled.
This PR changes it to catch and log the error, then kick the client and have an event for content to do admin alert, etc. with the channel after it's been kicked.

I have tested this with a well-behaved client and nothing bad happens to it.