### PR TITLE
Change SpawnAtPoisition EntityCoordinates overload to use the rotation of the attached entity, and to allow a rotation override. 

### DIFF
--- a/Robust.Client/GameObjects/ClientEntityManager.Spawn.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.Spawn.cs
@@ -40,6 +40,13 @@ public sealed partial class ClientEntityManager
         return ent;
     }
 
+    public override EntityUid PredictedSpawnAtPosition(string? protoName, EntityCoordinates coordinates, Angle rotation, ComponentRegistry? overrides = null)
+    {
+        var ent = SpawnAtPosition(protoName, coordinates, rotation, overrides);
+        FlagPredicted(ent);
+        return ent;
+    }
+
     public override bool PredictedTrySpawnNextTo(
         string? protoName,
         EntityUid target,

--- a/Robust.Shared/GameObjects/EntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Spawn.cs
@@ -125,7 +125,11 @@ public partial class EntityManager
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public EntityUid SpawnAtPosition(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null)
-        => Spawn(protoName, _xforms.ToMapCoordinates(coordinates), overrides);
+        => Spawn(protoName, _xforms.ToMapCoordinates(coordinates), overrides, rotation: _xforms.GetWorldRotation(coordinates.EntityId));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public EntityUid SpawnAtPosition(string? protoName, EntityCoordinates coordinates, Angle rotation, ComponentRegistry? overrides = null)
+        => Spawn(protoName, _xforms.ToMapCoordinates(coordinates), overrides, rotation: rotation);
 
     public bool TrySpawnNextTo(
         string? protoName,
@@ -252,6 +256,11 @@ public partial class EntityManager
     public virtual EntityUid PredictedSpawnAtPosition(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null)
     {
         return SpawnAtPosition(protoName, coordinates, overrides);
+    }
+
+    public virtual EntityUid PredictedSpawnAtPosition(string? protoName, EntityCoordinates coordinates, Angle rotation, ComponentRegistry? overrides = null)
+    {
+        return SpawnAtPosition(protoName, coordinates, rotation, overrides);
     }
 
     public virtual bool PredictedTrySpawnNextTo(

--- a/Robust.Shared/GameObjects/EntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Spawn.cs
@@ -125,7 +125,7 @@ public partial class EntityManager
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public EntityUid SpawnAtPosition(string? protoName, EntityCoordinates coordinates, ComponentRegistry? overrides = null)
-        => Spawn(protoName, _xforms.ToMapCoordinates(coordinates), overrides, rotation: _xforms.GetWorldRotation(coordinates.EntityId));
+        => SpawnAtPosition(protoName, coordinates, _xforms.GetWorldRotation(coordinates.EntityId), overrides);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public EntityUid SpawnAtPosition(string? protoName, EntityCoordinates coordinates, Angle rotation, ComponentRegistry? overrides = null)


### PR DESCRIPTION
Title. 

I looked through content and every usecase of this spawning method except one either spawns an entity that does not rotate, hence is unaffected by receiving world rotation, or spawns at coordinates, the tries to insert into a container (should be using another API method).

The one exception is stack system, where the item spawns rotated incorrectly. 

However, I suspect other systems may want to use this override, I plan to make it so ConditionalSpawningSystem uses this override as spawning attached to the current entity seems unintentional when every usecase I could find seemed to desire it being spawned attached to the grid. 