### PR TITLE
Add parent check debug assert to `SharedContainerSystem.Insert`

### DIFF
--- a/Robust.Shared/Containers/SharedContainerSystem.Insert.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.Insert.cs
@@ -127,6 +127,7 @@ public abstract partial class SharedContainerSystem
         // The sheer number of asserts tells you about how little I trust container and parenting code.
         DebugTools.Assert((meta.Flags & MetaDataFlags.InContainer) != 0, "invalid metadata flags after events");
         DebugTools.Assert(!transform.Anchored, "entity is anchored");
+        DebugTools.AssertEqual(transform.ParentUid, container.Owner, "Wrong parent");
         DebugTools.AssertEqual(transform.LocalPosition, Vector2.Zero);
         DebugTools.Assert(MathHelper.CloseTo(transform.LocalRotation.Theta, Angle.Zero), "Angle is not zero");
         DebugTools.Assert(!PhysicsQuery.TryGetComponent(toInsert, out var phys) || (!phys.Awake && !phys.CanCollide), "Invalid physics");


### PR DESCRIPTION
Adds an additional debug assert to `SharedContainerSystem.Insert` to verify that the inserted entity is correctly parented to the container entity.

In certain situations (see https://github.com/space-wizards/RobustToolbox/issues/6517), this can happen, and it causes some hard-to-track bugs. This extra assertion lets us catch the problem when it happens.