### PR TITLE
Fix `SetCoordinates` causing unexpected reparenting

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -635,7 +635,8 @@ public abstract partial class SharedTransformSystem
         if (xform.ParentUid == xform.MapUid)
             DebugTools.Assert(xform.GridUid == null || xform.GridUid == uid || xform.GridUid == xform.MapUid);
 #endif
-        RaiseMoveEvent(entity, oldParentUid, oldPosition, oldRotation, oldMap);
+        // Don't check for grid traversal if we're already setting the target parent
+        RaiseMoveEvent(entity, oldParentUid, oldPosition, oldRotation, oldMap, checkTraversal: newParent == null);
     }
 
     public void SetCoordinates(

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -635,8 +635,8 @@ public abstract partial class SharedTransformSystem
         if (xform.ParentUid == xform.MapUid)
             DebugTools.Assert(xform.GridUid == null || xform.GridUid == uid || xform.GridUid == xform.MapUid);
 #endif
-        // Don't check for grid traversal if we're already setting the target parent
-        RaiseMoveEvent(entity, oldParentUid, oldPosition, oldRotation, oldMap, checkTraversal: newParent == null);
+        // No need to check for grid traversal since we've already handled it
+        RaiseMoveEvent(entity, oldParentUid, oldPosition, oldRotation, oldMap, checkTraversal: false);
     }
 
     public void SetCoordinates(


### PR DESCRIPTION
`SharedTransformSystem.SetCoordinates` no longer causes a grid traversal check. Doing so causes a problem when setting coordinates directly on a map at a position that happens to overlap a grid - the entity will be parented to the grid instead of the map. This particularly causes a problem with container insertion, which winds up incorrectly tracking the inserted entity even though it isn't parented to it (See https://github.com/space-wizards/RobustToolbox/issues/6517).

Reparenting is already handled in `SetCoordinates`, so there shouldn't be a need for a grid traversal check when raising the move event.

Fixes https://github.com/space-wizards/RobustToolbox/issues/6517.
Fixes the bugs detected by https://github.com/space-wizards/RobustToolbox/pull/6532 and allows tests to pass.