### PR TITLE
Fix ColorSelectorSlider spinbox value rounding issue

### DIFF
--- a/Robust.Client/UserInterface/Controls/ColorSelectorSliders.cs
+++ b/Robust.Client/UserInterface/Controls/ColorSelectorSliders.cs
@@ -284,7 +284,7 @@ public sealed class ColorSelectorSliders : Control
         };
 
         slider.SetValueWithoutEvent(dataValue);
-        inputBox.OverrideValue((int)(dataValue * divisor));
+        inputBox.OverrideValue((int) double.Round(dataValue * divisor));
     }
 
     private void UpdateSliderVisuals()


### PR DESCRIPTION
Currently, certain numbers arent reachable with the spinbox, even after being typed in (see videos).
This PR just rounds the value being set to the input box. This shouldn't effect colors that depend on having a weird float value.

It may be preferred to use a FloatSpinBox here, though that conversion will take some more time and require changes to FloatSpinBox itself as SpinBox appears to have methods tailored to this use case (such as the one being modified here, OverrideValue.

Before:

https://github.com/user-attachments/assets/200a18aa-9c70-4799-bf94-60db1eddc08c

After:


https://github.com/user-attachments/assets/fcf9fb26-a1ce-4b05-b970-131ddae6b520

