### PR TITLE
Fix bad cast syntax with `IRobustCloneable` field deltas

### DIFF
--- a/Robust.Shared.CompNetworkGenerator/ComponentNetworkGenerator.cs
+++ b/Robust.Shared.CompNetworkGenerator/ComponentNetworkGenerator.cs
@@ -395,7 +395,7 @@ namespace Robust.Shared.CompNetworkGenerator
                     if ({name}Value == null)
                         component.{name} = null!;
                     else
-                        component.{name} = {nullCast}({name}Value.Clone());");
+                        component.{name} = ({nullCast})({name}Value.Clone());");
                                 shallowClone.Append($@"
                 {name} = this.{name},");
                                 deltaApply.Add($"fullState.{name} = {name} == null ? null! : {name}.Clone();");


### PR DESCRIPTION
Past me wasn't paying attention and assumed that `nullcast` included the parentheses like `cast` does, but past me was wrong.

Fixes https://github.com/space-wizards/RobustToolbox/issues/6535