### PR TITLE
Visibility Modifiers Layers

### DIFF
--- a/Robust.Server/GameObjects/EntitySystems/VisibilitySystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/VisibilitySystem.cs
@@ -125,8 +125,7 @@ namespace Robust.Server.GameObjects
 
                 var childMask = mask;
 
-                if (_visibilityQuery.TryGetComponent(child, out var childVis))
-                    childMask |= childVis.Layer;
+                childMask |= GetVisibilityLayer(child);
 
                 RecursivelyApplyVisibility(child, childMask, childMeta);
             }
@@ -135,14 +134,23 @@ namespace Robust.Server.GameObjects
         private ushort GetParentVisibilityMask(Entity<VisibilityComponent?> ent)
         {
             ushort visMask = 1; // apparently some content expects everything to have the first bit/flag set to true.
-            if (_visibilityQuery.Resolve(ent.Owner, ref ent.Comp, false))
-                visMask |= ent.Comp.Layer;
+            visMask |= GetVisibilityLayer(ent);
 
             // Include parent vis masks
             if (_xformQuery.TryGetComponent(ent.Owner, out var xform) && xform.ParentUid.IsValid())
                 visMask |= GetParentVisibilityMask(xform.ParentUid);
 
             return visMask;
+        }
+
+        private ushort GetVisibilityLayer(Entity<VisibilityComponent?> ent)
+        {
+            if (!_visibilityQuery.Resolve(ent.Owner, ref ent.Comp, false))
+                return 0;
+
+            var ev = new RefreshVisibilityModifiersEvent(ent.Comp.Layer);
+            RaiseLocalEvent(ent.Owner, ref ev);
+            return ev.Layer;
         }
     }
 }

--- a/Robust.Shared/GameObjects/RefreshVisibilityModifiersEvent.cs
+++ b/Robust.Shared/GameObjects/RefreshVisibilityModifiersEvent.cs
@@ -1,0 +1,25 @@
+namespace Robust.Shared.GameObjects;
+
+/// <summary>
+/// Raised during <see cref="SharedVisibilitySystem.RefreshVisibility(EntityUid, VisibilityComponent?, MetaDataComponent?)"/>
+/// so systems can contribute temporary visibility layer modifiers without mutating the base layer directly.
+/// </summary>
+[ByRefEvent]
+public record struct RefreshVisibilityModifiersEvent(ushort Layer)
+{
+    /// <summary>
+    /// Adds the specified visibility bits to the refreshed layer.
+    /// </summary>
+    public void AddLayer(ushort layer)
+    {
+        Layer |= layer;
+    }
+
+    /// <summary>
+    /// Removes the specified visibility bits from the refreshed layer.
+    /// </summary>
+    public void RemoveLayer(ushort layer)
+    {
+        Layer &= (ushort) ~layer;
+    }
+}


### PR DESCRIPTION
Adds `RefreshVisibilityModifiersEvent` so that systems can modify visibility layers without affecting the base layers

Required for https://github.com/space-wizards/space-station-14/pull/43706