### PR TITLE
record bandwidth usage on release

### DIFF
--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -1000,16 +1000,12 @@ namespace Robust.Shared.Network
             var instance = (NetMessage) Activator.CreateInstance(type)!;
             instance.MsgChannel = channel;
 
-#if DEBUG
-
             if (!_bandwidthUsage.TryGetValue(type, out var bandwidth))
             {
                 bandwidth = 0;
             }
 
             _bandwidthUsage[type] = bandwidth + msg.LengthBytes;
-
-#endif
 
             try
             {


### PR DESCRIPTION
Removed DEBUG check around NetManager bandwidth recording

This is the exact thing you need easy to use ingame methods for debugging issues players are having live...