### PR TITLE
Fix escaped quotes in formatted message parameters.

### DIFF
--- a/Robust.Shared.Tests/Utility/FormattedMessage_Test.cs
+++ b/Robust.Shared.Tests/Utility/FormattedMessage_Test.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NUnit.Framework;
 using Robust.Shared.Maths;
 using Robust.Shared.Utility;
@@ -61,12 +62,55 @@ namespace Robust.Shared.Tests.Utility
 
         [Test]
         [TestCase("Foo")]
+        [TestCase("foo\"bar")]
         [TestCase("[color=#FF000000]Foo[/color]")]
         [TestCase("[color=lime]Foo[/color]bar")]
         public static void TestToMarkup(string text)
         {
             var message = FormattedMessage.FromMarkupOrThrow(text);
             Assert.That(message.ToMarkup(), NUnit.Framework.Is.EqualTo(text));
+        }
+
+        [Test]
+        [TestCase("te\"xt")]
+        [TestCase("te\\\"xt")]
+        [TestCase("te\\xt")]
+        [TestCase("te[xt")]
+        [TestCase("te\"[\\xt")]
+        public static void TestEscapedStringParameters(string value)
+        {
+            var escaped = FormattedMessage.EscapeText(value).Replace("\"", "\\\"");
+            var parameterMessage = FormattedMessage.FromMarkupOrThrow($"[tag=\"{escaped}\"]");
+            var attributeMessage = FormattedMessage.FromMarkupOrThrow($"[tag attr=\"{escaped}\"]");
+
+            Assert.That(parameterMessage[0].Value.StringValue, Is.EqualTo(value));
+            Assert.That(attributeMessage[0].Attributes["attr"].StringValue, Is.EqualTo(value));
+        }
+
+        [Test]
+        public static void TestEscapedQuotesOnlyInStringParameters()
+        {
+            Assert.That(FormattedMessage.EscapeText("foo\"bar"), Is.EqualTo("foo\"bar"));
+
+            var message = FormattedMessage.FromMarkupOrThrow("[tag=\"foo\\\"bar\"]");
+            Assert.That(message[0].Value.StringValue, Is.EqualTo("foo\"bar"));
+        }
+
+        [Test]
+        [TestCase("te\"xt")]
+        [TestCase("te\\\"xt")]
+        [TestCase("te\\xt")]
+        [TestCase("te[xt")]
+        [TestCase("te\"[\\xt")]
+        public static void TestStringParameterToMarkupRoundTrip(string value)
+        {
+            var message = new FormattedMessage();
+            message.PushTag(new MarkupNode("tag",
+                new MarkupParameter(value),
+                new Dictionary<string, MarkupParameter> { { "attr", new MarkupParameter(value) } }));
+
+            var roundTrip = FormattedMessage.FromMarkupOrThrow(message.ToMarkup());
+            Assert.That(roundTrip, Is.EqualTo(message));
         }
 
         [Test]
@@ -88,6 +132,7 @@ namespace Robust.Shared.Tests.Utility
         /// </summary>
         [Test]
         [TestCase("\\[whaaaaa")]
+        [TestCase("foo\"bar")]
         public static void TestRoundTrip(string markup)
         {
             var message = FormattedMessage.FromMarkupOrThrow(markup);

--- a/Robust.Shared.Tests/Utility/FormattedMessage_Test.cs
+++ b/Robust.Shared.Tests/Utility/FormattedMessage_Test.cs
@@ -79,7 +79,7 @@ namespace Robust.Shared.Tests.Utility
         [TestCase("te\"[\\xt")]
         public static void TestEscapedStringParameters(string value)
         {
-            var escaped = FormattedMessage.EscapeText(value).Replace("\"", "\\\"");
+            var escaped = FormattedMessage.EscapeStringParameter(value);
             var parameterMessage = FormattedMessage.FromMarkupOrThrow($"[tag=\"{escaped}\"]");
             var attributeMessage = FormattedMessage.FromMarkupOrThrow($"[tag attr=\"{escaped}\"]");
 

--- a/Robust.Shared/Utility/FormattedMessage.MarkupParser.cs
+++ b/Robust.Shared/Utility/FormattedMessage.MarkupParser.cs
@@ -125,6 +125,10 @@ public sealed partial class FormattedMessage
     private static readonly Parser<char, char> EscapeSequence =
         Try(Escape.Then(OneOf(Escape, Begin, End, Slash)));
 
+    //This checks for a backslash and one reserved character inside a string parameter
+    private static readonly Parser<char, char> ParameterEscapeSequence =
+        Try(Escape.Then(OneOf(Escape, Begin, End, Quote, Slash)));
+
     //Parses text by repeatedly parsing escape sequences or any character except [ and \
     //The result is put into a new markup node representing text (it has no name)
     private static readonly Parser<char, List<MarkupNode>> Text =
@@ -140,9 +144,9 @@ public sealed partial class FormattedMessage
             Token(char.IsLetterOrDigit).ManyString()
         );
 
-    //Parses any character except ". Used for parsing a string parameter wrapped in ""
+    //Parses parameter escape sequences or any character except ". Used for parsing a string parameter wrapped in ""
     private static readonly Parser<char, string> ParameterString =
-        Token(c => c != '"').ManyString();
+        ParameterEscapeSequence.Or(Token(c => c != '"')).ManyString();
 
     //Parses eiter a string not wrapped by "" or a hexadecimal value beginning with #
     //The distinction is made by checking if the first character is a pound sign

--- a/Robust.Shared/Utility/FormattedMessage.cs
+++ b/Robust.Shared/Utility/FormattedMessage.cs
@@ -134,6 +134,14 @@ public sealed partial class FormattedMessage : IEquatable<FormattedMessage>, IRe
     }
 
     /// <summary>
+    ///     Escape a string parameter value to be able to be formatted into markup.
+    /// </summary>
+    public static string EscapeStringParameter(string parameter)
+    {
+        return EscapeText(parameter).Replace("\"", "\\\"");
+    }
+
+    /// <summary>
     ///     Remove all markup, leaving only the basic text content behind. Throws if it fails to parse the markup tags.
     /// </summary>
     /// <exception cref="ParseException">Thrown when an error occurs while trying to parse the markup.</exception>

--- a/Robust.Shared/Utility/MarkupNode.cs
+++ b/Robust.Shared/Utility/MarkupNode.cs
@@ -137,7 +137,7 @@ public readonly record struct MarkupParameter(string? StringValue = null, long? 
     public override string ToString()
     {
         if (StringValue != null)
-            return $"=\"{FormattedMessage.EscapeText(StringValue).Replace("\"", "\\\"")}\"";
+            return $"=\"{FormattedMessage.EscapeStringParameter(StringValue)}\"";
 
         if (LongValue.HasValue)
             return LongValue?.ToString().Insert(0, "=") ?? "";

--- a/Robust.Shared/Utility/MarkupNode.cs
+++ b/Robust.Shared/Utility/MarkupNode.cs
@@ -137,7 +137,7 @@ public readonly record struct MarkupParameter(string? StringValue = null, long? 
     public override string ToString()
     {
         if (StringValue != null)
-            return $"=\"{StringValue}\"";
+            return $"=\"{FormattedMessage.EscapeText(StringValue).Replace("\"", "\\\"")}\"";
 
         if (LongValue.HasValue)
             return LongValue?.ToString().Insert(0, "=") ?? "";


### PR DESCRIPTION
Fixes #6537.

Quoted string parameters now parse escaped characters correctly.
This makes markup like `[tag="te\"xt"]` parse normally instead of failing or falling back to text in permissive parsing.

String parameter serialization now escapes quotes only inside parameter values, so `ToMarkup()` round-trips quoted parameter values correctly without changing plain text escaping.