### PR TITLE
Typed Style Properties

### DIFF
--- a/Robust.Client.IntegrationTests/UserInterface/StylesheetTest.cs
+++ b/Robust.Client.IntegrationTests/UserInterface/StylesheetTest.cs
@@ -50,7 +50,7 @@ namespace Robust.UnitTesting.Client.UserInterface
         [Test]
         public void TestStyleProperties()
         {
-            var foo = new StyleProperty<string>("foo");
+            var foo = new StylePropertyKey<string>("foo");
 
             var sheet = new Stylesheet(new[]
             {
@@ -89,7 +89,7 @@ namespace Robust.UnitTesting.Client.UserInterface
         [Test]
         public void TestStylesheetOverride()
         {
-            var foo = new StyleProperty<string>("foo");
+            var foo = new StylePropertyKey<string>("foo");
 
             var sheetA = new Stylesheet(new[]
             {

--- a/Robust.Client.IntegrationTests/UserInterface/StylesheetTest.cs
+++ b/Robust.Client.IntegrationTests/UserInterface/StylesheetTest.cs
@@ -50,19 +50,21 @@ namespace Robust.UnitTesting.Client.UserInterface
         [Test]
         public void TestStyleProperties()
         {
+            var foo = new StyleProperty<string>("foo");
+
             var sheet = new Stylesheet(new[]
             {
                 new StyleRule(new SelectorElement(typeof(Label), null, "baz", null), new[]
                 {
-                    new StyleProperty("foo", "honk"),
+                    new StyleProperty(foo, "honk"),
                 }),
                 new StyleRule(new SelectorElement(typeof(Label), null, null, null), new[]
                 {
-                    new StyleProperty("foo", "heh"),
+                    new StyleProperty(foo, "heh"),
                 }),
                 new StyleRule(new SelectorElement(typeof(Label), null, null, null), new[]
                 {
-                    new StyleProperty("foo", "bar"),
+                    new StyleProperty(foo, "bar"),
                 }),
             });
 
@@ -74,27 +76,29 @@ namespace Robust.UnitTesting.Client.UserInterface
             uiMgr.StateRoot.AddChild(control);
             control.ForceRunStyleUpdate();
 
-            control.TryGetStyleProperty("foo", out string? value);
+            control.TryGetStyleProperty(foo, out string? value);
             Assert.That(value, Is.EqualTo("bar"));
 
             control.StyleIdentifier = "baz";
             control.ForceRunStyleUpdate();
 
-            control.TryGetStyleProperty("foo", out value);
+            control.TryGetStyleProperty(foo, out value);
             Assert.That(value, Is.EqualTo("honk"));
         }
 
         [Test]
         public void TestStylesheetOverride()
         {
+            var foo = new StyleProperty<string>("foo");
+
             var sheetA = new Stylesheet(new[]
             {
-                new StyleRule(SelectorElement.Class("A"), new[] {new StyleProperty("foo", "bar")}),
+                new StyleRule(SelectorElement.Class("A"), new[] {new StyleProperty(foo, "bar")}),
             });
 
             var sheetB = new Stylesheet(new[]
             {
-                new StyleRule(SelectorElement.Class("A"), new[] {new StyleProperty("foo", "honk!")})
+                new StyleRule(SelectorElement.Class("A"), new[] {new StyleProperty(foo, "honk!")})
             });
 
             // Set style sheet to null, property shouldn't exist.
@@ -116,7 +120,7 @@ namespace Robust.UnitTesting.Client.UserInterface
 
             baseControl.ForceRunStyleUpdate();
 
-            Assert.That(baseControl.TryGetStyleProperty("foo", out object? _), Is.False);
+            Assert.That(baseControl.TryGetStyleProperty(foo, out _), Is.False);
 
             uiMgr.RootControl.Stylesheet = sheetA;
             childA.Stylesheet = sheetB;
@@ -124,13 +128,13 @@ namespace Robust.UnitTesting.Client.UserInterface
             // Assign sheets.
             baseControl.ForceRunStyleUpdate();
 
-            baseControl.TryGetStyleProperty("foo", out object? value);
+            baseControl.TryGetStyleProperty(foo, out var value);
             Assert.That(value, Is.EqualTo("bar"));
 
-            childA.TryGetStyleProperty("foo", out value);
+            childA.TryGetStyleProperty(foo, out value);
             Assert.That(value, Is.EqualTo("honk!"));
 
-            childB.TryGetStyleProperty("foo", out value);
+            childB.TryGetStyleProperty(foo, out value);
             Assert.That(value, Is.EqualTo("honk!"));
         }
     }

--- a/Robust.Client/Graphics/FontManagement/SystemFontDebugWindow.xaml.cs
+++ b/Robust.Client/Graphics/FontManagement/SystemFontDebugWindow.xaml.cs
@@ -53,7 +53,7 @@ internal sealed partial class SystemFontDebugWindow : DefaultWindow
                 var richTextLabel = new RichTextLabel
                 {
                     Stylesheet = new Stylesheet([
-                        StylesheetHelpers.Element<RichTextLabel>().Prop("font", fontInstance)
+                        StylesheetHelpers.Element<RichTextLabel>().Prop(Label.StylePropertyFont, fontInstance)
                     ]),
                 };
                 richTextLabel.SetMessage(FormattedMessage.FromUnformatted(ExampleString));

--- a/Robust.Client/UserInterface/Control.Layout.Styling.cs
+++ b/Robust.Client/UserInterface/Control.Layout.Styling.cs
@@ -81,7 +81,7 @@ public partial class Control
         return;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        void UpdateField<T>(ref T field, object value, LayoutStyleProperties flag)
+        void UpdateField<T>(ref T field, object? value, LayoutStyleProperties flag)
         {
             if ((_layoutStyleOverride & flag) != 0)
                 return;

--- a/Robust.Client/UserInterface/Control.Styling.cs
+++ b/Robust.Client/UserInterface/Control.Styling.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.Maths;
 using Robust.Shared.ViewVariables;
 
 namespace Robust.Client.UserInterface
@@ -9,7 +10,7 @@ namespace Robust.Client.UserInterface
     // ReSharper disable once RequiredBaseTypesIsNotInherited
     public partial class Control
     {
-        public const string StylePropertyModulateSelf = "modulate-self";
+        public static readonly StyleProperty<Color> StylePropertyModulateSelf = "modulate-self";
 
         /// <summary>
         ///     Overrides the style sheet used for this control and its descendants.
@@ -51,6 +52,7 @@ namespace Robust.Client.UserInterface
 
         // Styling needs to be updated.
         private bool _stylingDirty;
+
         // _actualStylesheetCached needs update.
         private bool _stylesheetUpdateNeeded;
         internal int RestyleGeneration;
@@ -95,6 +97,7 @@ namespace Robust.Client.UserInterface
             _stylePseudoClass.Add(className);
             Restyle();
         }
+
         public bool HasStyleClass(string className)
         {
             return _styleClasses.Contains(className);

--- a/Robust.Client/UserInterface/Control.Styling.cs
+++ b/Robust.Client/UserInterface/Control.Styling.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.ViewVariables;
@@ -44,7 +45,7 @@ namespace Robust.Client.UserInterface
             }
         }
 
-        private readonly Dictionary<string, object> _styleProperties = new();
+        private readonly Dictionary<string, object?> _styleProperties = new();
         private readonly HashSet<string> _styleClasses = new();
         private readonly HashSet<string> _stylePseudoClass = new();
 
@@ -256,6 +257,7 @@ namespace Robust.Client.UserInterface
             }
         }
 
+        [Obsolete("Use TryGetStyleProperty(StyleProperty<T>, out T) with a typed style property key.")]
         public bool TryGetStyleProperty<T>(string param, [MaybeNullWhen(false)] out T value)
         {
             if (_styleProperties.TryGetValue(param, out var val) && val is T cast)
@@ -268,12 +270,30 @@ namespace Robust.Client.UserInterface
             return false;
         }
 
+        public bool TryGetStyleProperty<T>(StyleProperty<T> property, [MaybeNullWhen(false)] out T value)
+        {
+            if (_styleProperties.TryGetValue(property.Name, out var val) && val is T cast)
+            {
+                value = cast;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+
+        [Obsolete("Use StylePropertyDefault(StyleProperty<T>, T) with a typed style property key.")]
         public T StylePropertyDefault<T>(string param, T defaultValue)
         {
-            if (TryGetStyleProperty<T>(param, out var value))
-                return value;
+            if (_styleProperties.TryGetValue(param, out var value) && value is T typedValue)
+                return typedValue;
 
             return defaultValue;
+        }
+
+        public T StylePropertyDefault<T>(StyleProperty<T> property, T defaultValue)
+        {
+            return TryGetStyleProperty(property, out var value) ? value : defaultValue;
         }
 
         private sealed class StyleClassCollection : ICollection<string>, IReadOnlyCollection<string>

--- a/Robust.Client/UserInterface/Control.Styling.cs
+++ b/Robust.Client/UserInterface/Control.Styling.cs
@@ -10,7 +10,7 @@ namespace Robust.Client.UserInterface
     // ReSharper disable once RequiredBaseTypesIsNotInherited
     public partial class Control
     {
-        public static readonly StyleProperty<Color> StylePropertyModulateSelf = "modulate-self";
+        public static readonly StylePropertyKey<Color> StylePropertyModulateSelf = "modulate-self";
 
         /// <summary>
         ///     Overrides the style sheet used for this control and its descendants.
@@ -260,7 +260,7 @@ namespace Robust.Client.UserInterface
             }
         }
 
-        [Obsolete("Use TryGetStyleProperty(StyleProperty<T>, out T) with a typed style property key.")]
+        [Obsolete("Use TryGetStyleProperty(StylePropertyKey<T>, out T) with a typed style property key.")]
         public bool TryGetStyleProperty<T>(string param, [MaybeNullWhen(false)] out T value)
         {
             if (_styleProperties.TryGetValue(param, out var val) && val is T cast)
@@ -273,9 +273,9 @@ namespace Robust.Client.UserInterface
             return false;
         }
 
-        public bool TryGetStyleProperty<T>(StyleProperty<T> property, [MaybeNullWhen(false)] out T value)
+        public bool TryGetStyleProperty<T>(StylePropertyKey<T> propertyKey, [MaybeNullWhen(false)] out T value)
         {
-            if (_styleProperties.TryGetValue(property.Name, out var val) && val is T cast)
+            if (_styleProperties.TryGetValue(propertyKey.Name, out var val) && val is T cast)
             {
                 value = cast;
                 return true;
@@ -285,7 +285,7 @@ namespace Robust.Client.UserInterface
             return false;
         }
 
-        [Obsolete("Use StylePropertyDefault(StyleProperty<T>, T) with a typed style property key.")]
+        [Obsolete("Use StylePropertyDefault(StylePropertyKey<T>, T) with a typed style property key.")]
         public T StylePropertyDefault<T>(string param, T defaultValue)
         {
             if (_styleProperties.TryGetValue(param, out var value) && value is T typedValue)
@@ -294,9 +294,9 @@ namespace Robust.Client.UserInterface
             return defaultValue;
         }
 
-        public T StylePropertyDefault<T>(StyleProperty<T> property, T defaultValue)
+        public T StylePropertyDefault<T>(StylePropertyKey<T> propertyKey, T defaultValue)
         {
-            return TryGetStyleProperty(property, out var value) ? value : defaultValue;
+            return TryGetStyleProperty(propertyKey, out var value) ? value : defaultValue;
         }
 
         private sealed class StyleClassCollection : ICollection<string>, IReadOnlyCollection<string>

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -13,7 +13,7 @@ namespace Robust.Client.UserInterface.Controls
     public class BoxContainer : Container
     {
         private LayoutOrientation _orientation;
-        public static readonly StyleProperty<int> StylePropertySeparation = "separation";
+        public static readonly StylePropertyKey<int> StylePropertySeparation = "separation";
 
         private const int DefaultSeparation = 0;
 

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -13,7 +13,7 @@ namespace Robust.Client.UserInterface.Controls
     public class BoxContainer : Container
     {
         private LayoutOrientation _orientation;
-        public const string StylePropertySeparation = "separation";
+        public static readonly StyleProperty<int> StylePropertySeparation = "separation";
 
         private const int DefaultSeparation = 0;
 

--- a/Robust.Client/UserInterface/Controls/ColorableSlider.cs
+++ b/Robust.Client/UserInterface/Controls/ColorableSlider.cs
@@ -6,8 +6,8 @@ namespace Robust.Client.UserInterface.Controls;
 
 public sealed class ColorableSlider : Slider
 {
-    public static readonly StyleProperty<StyleBox> StylePropertyFillWhite = "fillWhite"; // needs to be filled with white
-    public static readonly StyleProperty<StyleBox> StylePropertyBackgroundWhite = "backgroundWhite"; // also needs to be filled with white
+    public static readonly StylePropertyKey<StyleBox> StylePropertyFillWhite = "fillWhite"; // needs to be filled with white
+    public static readonly StylePropertyKey<StyleBox> StylePropertyBackgroundWhite = "backgroundWhite"; // also needs to be filled with white
 
     public Color Color { get; private set; } = Color.White;
     public PartSelector Part
@@ -39,9 +39,9 @@ public sealed class ColorableSlider : Slider
 
     protected override void UpdateStyleBoxes()
     {
-        StyleBox? GetStyleBox(StyleProperty<StyleBox> property)
+        StyleBox? GetStyleBox(StylePropertyKey<StyleBox> propertyKey)
         {
-            if (TryGetStyleProperty(property, out var box))
+            if (TryGetStyleProperty(propertyKey, out var box))
             {
                 return box;
             }

--- a/Robust.Client/UserInterface/Controls/ColorableSlider.cs
+++ b/Robust.Client/UserInterface/Controls/ColorableSlider.cs
@@ -6,8 +6,8 @@ namespace Robust.Client.UserInterface.Controls;
 
 public sealed class ColorableSlider : Slider
 {
-    public const string StylePropertyFillWhite = "fillWhite"; // needs to be filled with white
-    public const string StylePropertyBackgroundWhite = "backgroundWhite"; // also needs to be filled with white
+    public static readonly StyleProperty<StyleBox> StylePropertyFillWhite = "fillWhite"; // needs to be filled with white
+    public static readonly StyleProperty<StyleBox> StylePropertyBackgroundWhite = "backgroundWhite"; // also needs to be filled with white
 
     public Color Color { get; private set; } = Color.White;
     public PartSelector Part
@@ -39,9 +39,9 @@ public sealed class ColorableSlider : Slider
 
     protected override void UpdateStyleBoxes()
     {
-        StyleBox? GetStyleBox(string name)
+        StyleBox? GetStyleBox(StyleProperty<StyleBox> property)
         {
-            if (TryGetStyleProperty<StyleBox>(name, out var box))
+            if (TryGetStyleProperty(property, out var box))
             {
                 return box;
             }
@@ -49,8 +49,8 @@ public sealed class ColorableSlider : Slider
             return null;
         }
 
-        string backBox = StylePropertyBackground;
-        string fillBox = StylePropertyFill;
+        var backBox = StylePropertyBackground;
+        var fillBox = StylePropertyFill;
 
         switch (Part)
         {

--- a/Robust.Client/UserInterface/Controls/ContainerButton.cs
+++ b/Robust.Client/UserInterface/Controls/ContainerButton.cs
@@ -8,7 +8,7 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class ContainerButton : BaseButton
     {
-        public const string StylePropertyStyleBox = "stylebox";
+        public static readonly StyleProperty<StyleBox> StylePropertyStyleBox = "stylebox";
         public const string StyleClassButton = "button";
         public const string StylePseudoClassNormal = "normal";
         public const string StylePseudoClassPressed = "pressed";

--- a/Robust.Client/UserInterface/Controls/ContainerButton.cs
+++ b/Robust.Client/UserInterface/Controls/ContainerButton.cs
@@ -8,7 +8,7 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class ContainerButton : BaseButton
     {
-        public static readonly StyleProperty<StyleBox> StylePropertyStyleBox = "stylebox";
+        public static readonly StylePropertyKey<StyleBox> StylePropertyStyleBox = "stylebox";
         public const string StyleClassButton = "button";
         public const string StylePseudoClassNormal = "normal";
         public const string StylePseudoClassPressed = "pressed";

--- a/Robust.Client/UserInterface/Controls/ItemList.cs
+++ b/Robust.Client/UserInterface/Controls/ItemList.cs
@@ -28,10 +28,10 @@ namespace Robust.Client.UserInterface.Controls
         public event Action<ItemListDeselectedEventArgs>? OnItemDeselected;
         public event Action<ItemListHoverEventArgs>? OnItemHover;
 
-        public static readonly StyleProperty<StyleBox> StylePropertyBackground = "itemlist-background";
-        public static readonly StyleProperty<StyleBox> StylePropertyItemBackground = "item-background";
-        public static readonly StyleProperty<StyleBox> StylePropertySelectedItemBackground = "selected-item-background";
-        public static readonly StyleProperty<StyleBox> StylePropertyDisabledItemBackground = "disabled-item-background";
+        public static readonly StylePropertyKey<StyleBox> StylePropertyBackground = "itemlist-background";
+        public static readonly StylePropertyKey<StyleBox> StylePropertyItemBackground = "item-background";
+        public static readonly StylePropertyKey<StyleBox> StylePropertySelectedItemBackground = "selected-item-background";
+        public static readonly StylePropertyKey<StyleBox> StylePropertyDisabledItemBackground = "disabled-item-background";
 
         /// <summary>
         /// Gets or sets the ItemSeparation of individual list items

--- a/Robust.Client/UserInterface/Controls/ItemList.cs
+++ b/Robust.Client/UserInterface/Controls/ItemList.cs
@@ -28,10 +28,10 @@ namespace Robust.Client.UserInterface.Controls
         public event Action<ItemListDeselectedEventArgs>? OnItemDeselected;
         public event Action<ItemListHoverEventArgs>? OnItemHover;
 
-        public const string StylePropertyBackground = "itemlist-background";
-        public const string StylePropertyItemBackground = "item-background";
-        public const string StylePropertySelectedItemBackground = "selected-item-background";
-        public const string StylePropertyDisabledItemBackground = "disabled-item-background";
+        public static readonly StyleProperty<StyleBox> StylePropertyBackground = "itemlist-background";
+        public static readonly StyleProperty<StyleBox> StylePropertyItemBackground = "item-background";
+        public static readonly StyleProperty<StyleBox> StylePropertySelectedItemBackground = "selected-item-background";
+        public static readonly StyleProperty<StyleBox> StylePropertyDisabledItemBackground = "disabled-item-background";
 
         /// <summary>
         /// Gets or sets the ItemSeparation of individual list items
@@ -367,7 +367,7 @@ namespace Robust.Client.UserInterface.Controls
         {
             get
             {
-                if (TryGetStyleProperty<Font>("font", out var font))
+                if (TryGetStyleProperty(Label.StylePropertyFont, out var font))
                 {
                     return font;
                 }
@@ -380,7 +380,7 @@ namespace Robust.Client.UserInterface.Controls
         {
             get
             {
-                if (TryGetStyleProperty("font-color", out Color fontColor))
+                if (TryGetStyleProperty(Label.StylePropertyFontColor, out Color fontColor))
                 {
                     return fontColor;
                 }

--- a/Robust.Client/UserInterface/Controls/Label.cs
+++ b/Robust.Client/UserInterface/Controls/Label.cs
@@ -16,9 +16,9 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class Label : Control
     {
-        public static readonly StyleProperty<Color> StylePropertyFontColor = "font-color";
-        public static readonly StyleProperty<Font> StylePropertyFont = "font";
-        public static readonly StyleProperty<AlignMode> StylePropertyAlignMode = "alignMode";
+        public static readonly StylePropertyKey<Color> StylePropertyFontColor = "font-color";
+        public static readonly StylePropertyKey<Font> StylePropertyFont = "font";
+        public static readonly StylePropertyKey<AlignMode> StylePropertyAlignMode = "alignMode";
 
         private int _cachedTextHeight;
         private readonly List<int> _cachedTextWidths = new();

--- a/Robust.Client/UserInterface/Controls/Label.cs
+++ b/Robust.Client/UserInterface/Controls/Label.cs
@@ -16,9 +16,9 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class Label : Control
     {
-        public const string StylePropertyFontColor = "font-color";
-        public const string StylePropertyFont = "font";
-        public const string StylePropertyAlignMode = "alignMode";
+        public static readonly StyleProperty<Color> StylePropertyFontColor = "font-color";
+        public static readonly StyleProperty<Font> StylePropertyFont = "font";
+        public static readonly StyleProperty<AlignMode> StylePropertyAlignMode = "alignMode";
 
         private int _cachedTextHeight;
         private readonly List<int> _cachedTextWidths = new();

--- a/Robust.Client/UserInterface/Controls/LayeredTextureRect.cs
+++ b/Robust.Client/UserInterface/Controls/LayeredTextureRect.cs
@@ -13,7 +13,7 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class LayeredTextureRect : Control
     {
-        public const string StylePropertyShader = "shader";
+        public static readonly StyleProperty<ShaderInstance?> StylePropertyShader = "shader";
 
         private bool _canShrink;
         private List<Texture> _textures = new();

--- a/Robust.Client/UserInterface/Controls/LayeredTextureRect.cs
+++ b/Robust.Client/UserInterface/Controls/LayeredTextureRect.cs
@@ -13,7 +13,7 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class LayeredTextureRect : Control
     {
-        public static readonly StyleProperty<ShaderInstance?> StylePropertyShader = "shader";
+        public static readonly StylePropertyKey<ShaderInstance?> StylePropertyShader = "shader";
 
         private bool _canShrink;
         private List<Texture> _textures = new();

--- a/Robust.Client/UserInterface/Controls/LineEdit.cs
+++ b/Robust.Client/UserInterface/Controls/LineEdit.cs
@@ -26,9 +26,9 @@ namespace Robust.Client.UserInterface.Controls
 
         private const float MouseScrollDelay = 0.001f;
 
-        public static readonly StyleProperty<StyleBox> StylePropertyStyleBox = "stylebox";
-        public static readonly StyleProperty<Color> StylePropertyCursorColor = "cursor-color";
-        public static readonly StyleProperty<Color> StylePropertySelectionColor = "selection-color";
+        public static readonly StylePropertyKey<StyleBox> StylePropertyStyleBox = "stylebox";
+        public static readonly StylePropertyKey<Color> StylePropertyCursorColor = "cursor-color";
+        public static readonly StylePropertyKey<Color> StylePropertySelectionColor = "selection-color";
         public const string StyleClassLineEditNotEditable = "notEditable";
         public const string StylePseudoClassPlaceholder = "placeholder";
 

--- a/Robust.Client/UserInterface/Controls/LineEdit.cs
+++ b/Robust.Client/UserInterface/Controls/LineEdit.cs
@@ -26,9 +26,9 @@ namespace Robust.Client.UserInterface.Controls
 
         private const float MouseScrollDelay = 0.001f;
 
-        public const string StylePropertyStyleBox = "stylebox";
-        public const string StylePropertyCursorColor = "cursor-color";
-        public const string StylePropertySelectionColor = "selection-color";
+        public static readonly StyleProperty<StyleBox> StylePropertyStyleBox = "stylebox";
+        public static readonly StyleProperty<Color> StylePropertyCursorColor = "cursor-color";
+        public static readonly StyleProperty<Color> StylePropertySelectionColor = "selection-color";
         public const string StyleClassLineEditNotEditable = "notEditable";
         public const string StylePseudoClassPlaceholder = "placeholder";
 
@@ -904,7 +904,7 @@ namespace Robust.Client.UserInterface.Controls
         [Pure]
         private Font _getFont()
         {
-            if (TryGetStyleProperty<Font>("font", out var font))
+            if (TryGetStyleProperty(Label.StylePropertyFont, out var font))
             {
                 return font;
             }
@@ -931,7 +931,7 @@ namespace Robust.Client.UserInterface.Controls
         [Pure]
         private Color _getFontColor()
         {
-            if (TryGetStyleProperty("font-color", out Color color))
+            if (TryGetStyleProperty(Label.StylePropertyFontColor, out Color color))
             {
                 return color;
             }

--- a/Robust.Client/UserInterface/Controls/OutputPanel.cs
+++ b/Robust.Client/UserInterface/Controls/OutputPanel.cs
@@ -21,7 +21,7 @@ namespace Robust.Client.UserInterface.Controls
 
         [Dependency] private readonly MarkupTagManager _tagManager = default!;
 
-        public const string StylePropertyStyleBox = "stylebox";
+        public static readonly StyleProperty<StyleBox> StylePropertyStyleBox = "stylebox";
 
         public bool ShowScrollDownButton
         {
@@ -297,7 +297,7 @@ namespace Robust.Client.UserInterface.Controls
         [Pure]
         private Font _getFont()
         {
-            if (TryGetStyleProperty<Font>("font", out var font))
+            if (TryGetStyleProperty(Label.StylePropertyFont, out var font))
             {
                 return font;
             }

--- a/Robust.Client/UserInterface/Controls/OutputPanel.cs
+++ b/Robust.Client/UserInterface/Controls/OutputPanel.cs
@@ -21,7 +21,7 @@ namespace Robust.Client.UserInterface.Controls
 
         [Dependency] private readonly MarkupTagManager _tagManager = default!;
 
-        public static readonly StyleProperty<StyleBox> StylePropertyStyleBox = "stylebox";
+        public static readonly StylePropertyKey<StyleBox> StylePropertyStyleBox = "stylebox";
 
         public bool ShowScrollDownButton
         {

--- a/Robust.Client/UserInterface/Controls/PanelContainer.cs
+++ b/Robust.Client/UserInterface/Controls/PanelContainer.cs
@@ -7,7 +7,7 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class PanelContainer : Container
     {
-        public static readonly StyleProperty<StyleBox> StylePropertyPanel = "panel";
+        public static readonly StylePropertyKey<StyleBox> StylePropertyPanel = "panel";
 
         public StyleBox? PanelOverride { get; set; }
 

--- a/Robust.Client/UserInterface/Controls/PanelContainer.cs
+++ b/Robust.Client/UserInterface/Controls/PanelContainer.cs
@@ -7,7 +7,7 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class PanelContainer : Container
     {
-        public const string StylePropertyPanel = "panel";
+        public static readonly StyleProperty<StyleBox> StylePropertyPanel = "panel";
 
         public StyleBox? PanelOverride { get; set; }
 

--- a/Robust.Client/UserInterface/Controls/ProgressBar.cs
+++ b/Robust.Client/UserInterface/Controls/ProgressBar.cs
@@ -8,8 +8,8 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class ProgressBar : Range
     {
-        public static readonly StyleProperty<StyleBox> StylePropertyBackground = "background";
-        public static readonly StyleProperty<StyleBox> StylePropertyForeground = "foreground";
+        public static readonly StylePropertyKey<StyleBox> StylePropertyBackground = "background";
+        public static readonly StylePropertyKey<StyleBox> StylePropertyForeground = "foreground";
 
         private StyleBox? _backgroundStyleBoxOverride;
         private StyleBox? _foregroundStyleBoxOverride;

--- a/Robust.Client/UserInterface/Controls/ProgressBar.cs
+++ b/Robust.Client/UserInterface/Controls/ProgressBar.cs
@@ -8,8 +8,8 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class ProgressBar : Range
     {
-        public const string StylePropertyBackground = "background";
-        public const string StylePropertyForeground = "foreground";
+        public static readonly StyleProperty<StyleBox> StylePropertyBackground = "background";
+        public static readonly StyleProperty<StyleBox> StylePropertyForeground = "foreground";
 
         private StyleBox? _backgroundStyleBoxOverride;
         private StyleBox? _foregroundStyleBoxOverride;

--- a/Robust.Client/UserInterface/Controls/RichTextLabel.cs
+++ b/Robust.Client/UserInterface/Controls/RichTextLabel.cs
@@ -15,6 +15,8 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class RichTextLabel : Control
     {
+        public static readonly StyleProperty<float> StylePropertyLineHeightScale = nameof(LineHeightScale);
+
         [Dependency] private readonly MarkupTagManager _tagManager = default!;
 
         private RichTextEntry? _entry;
@@ -26,7 +28,7 @@ namespace Robust.Client.UserInterface.Controls
         {
             get
             {
-                if (!_lineHeightOverride && TryGetStyleProperty(nameof(LineHeightScale), out float value))
+                if (!_lineHeightOverride && TryGetStyleProperty(StylePropertyLineHeightScale, out float value))
                     return value;
 
                 return _lineHeightScale;
@@ -156,7 +158,7 @@ namespace Robust.Client.UserInterface.Controls
         [Pure]
         private Font _getFont()
         {
-            if (TryGetStyleProperty<Font>("font", out var font))
+            if (TryGetStyleProperty(Label.StylePropertyFont, out var font))
             {
                 return font;
             }

--- a/Robust.Client/UserInterface/Controls/RichTextLabel.cs
+++ b/Robust.Client/UserInterface/Controls/RichTextLabel.cs
@@ -15,7 +15,7 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class RichTextLabel : Control
     {
-        public static readonly StyleProperty<float> StylePropertyLineHeightScale = nameof(LineHeightScale);
+        public static readonly StylePropertyKey<float> StylePropertyLineHeightScale = nameof(LineHeightScale);
 
         [Dependency] private readonly MarkupTagManager _tagManager = default!;
 

--- a/Robust.Client/UserInterface/Controls/ScrollBar.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollBar.cs
@@ -9,7 +9,7 @@ namespace Robust.Client.UserInterface.Controls
 {
     public abstract class ScrollBar : Range
     {
-        public const string StylePropertyGrabber = "grabber";
+        public static readonly StyleProperty<StyleBox> StylePropertyGrabber = "grabber";
         public const string StylePseudoClassHover = "hover";
         public const string StylePseudoClassGrabbed = "grabbed";
 

--- a/Robust.Client/UserInterface/Controls/ScrollBar.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollBar.cs
@@ -9,7 +9,7 @@ namespace Robust.Client.UserInterface.Controls
 {
     public abstract class ScrollBar : Range
     {
-        public static readonly StyleProperty<StyleBox> StylePropertyGrabber = "grabber";
+        public static readonly StylePropertyKey<StyleBox> StylePropertyGrabber = "grabber";
         public const string StylePseudoClassHover = "hover";
         public const string StylePseudoClassGrabbed = "grabbed";
 

--- a/Robust.Client/UserInterface/Controls/ScrollContainer.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollContainer.cs
@@ -8,8 +8,8 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class ScrollContainer : Container
     {
-        public static readonly StyleProperty<bool> StylePropertyVScrollBarHidden = nameof(VScrollBarHidden);
-        public static readonly StyleProperty<bool> StylePropertyHScrollBarHidden = nameof(HScrollBarHidden);
+        public static readonly StylePropertyKey<bool> StylePropertyVScrollBarHidden = nameof(VScrollBarHidden);
+        public static readonly StylePropertyKey<bool> StylePropertyHScrollBarHidden = nameof(HScrollBarHidden);
 
         private bool _queueScrolled = false;
         private bool _vScrollEnabled = true;

--- a/Robust.Client/UserInterface/Controls/ScrollContainer.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollContainer.cs
@@ -8,6 +8,9 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class ScrollContainer : Container
     {
+        public static readonly StyleProperty<bool> StylePropertyVScrollBarHidden = nameof(VScrollBarHidden);
+        public static readonly StyleProperty<bool> StylePropertyHScrollBarHidden = nameof(HScrollBarHidden);
+
         private bool _queueScrolled = false;
         private bool _vScrollEnabled = true;
         private bool _hScrollEnabled = true;
@@ -163,10 +166,10 @@ namespace Robust.Client.UserInterface.Controls
         }
 
         private bool StyleVScrollBarHidden =>
-            _vScrollBarHidden ?? TryGetStyleProperty<bool>(nameof(VScrollBarHidden), out var v) && v;
+            _vScrollBarHidden ?? TryGetStyleProperty(StylePropertyVScrollBarHidden, out var v) && v;
 
         private bool StyleHScrollBarHidden =>
-            _hScrollBarHidden ?? TryGetStyleProperty<bool>(nameof(HScrollBarHidden), out var v) && v;
+            _hScrollBarHidden ?? TryGetStyleProperty(StylePropertyHScrollBarHidden, out var v) && v;
 
         protected override Vector2 MeasureOverride(Vector2 availableSize)
         {

--- a/Robust.Client/UserInterface/Controls/Slider.cs
+++ b/Robust.Client/UserInterface/Controls/Slider.cs
@@ -11,10 +11,10 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class Slider : Range
     {
-        public const string StylePropertyBackground = "background";
-        public const string StylePropertyForeground = "foreground";
-        public const string StylePropertyFill = "fill";
-        public const string StylePropertyGrabber = "grabber";
+        public static readonly StyleProperty<StyleBox> StylePropertyBackground = "background";
+        public static readonly StyleProperty<StyleBox> StylePropertyForeground = "foreground";
+        public static readonly StyleProperty<StyleBox> StylePropertyFill = "fill";
+        public static readonly StyleProperty<StyleBox> StylePropertyGrabber = "grabber";
 
         public event Action<Slider>? OnGrabbed;
         public event Action<Slider>? OnReleased;
@@ -184,9 +184,9 @@ namespace Robust.Client.UserInterface.Controls
 
         protected virtual void UpdateStyleBoxes()
         {
-            StyleBox? GetStyleBox(string name)
+            StyleBox? GetStyleBox(StyleProperty<StyleBox> property)
             {
-                if (TryGetStyleProperty<StyleBox>(name, out var box))
+                if (TryGetStyleProperty(property, out var box))
                 {
                     return box;
                 }

--- a/Robust.Client/UserInterface/Controls/Slider.cs
+++ b/Robust.Client/UserInterface/Controls/Slider.cs
@@ -11,10 +11,10 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class Slider : Range
     {
-        public static readonly StyleProperty<StyleBox> StylePropertyBackground = "background";
-        public static readonly StyleProperty<StyleBox> StylePropertyForeground = "foreground";
-        public static readonly StyleProperty<StyleBox> StylePropertyFill = "fill";
-        public static readonly StyleProperty<StyleBox> StylePropertyGrabber = "grabber";
+        public static readonly StylePropertyKey<StyleBox> StylePropertyBackground = "background";
+        public static readonly StylePropertyKey<StyleBox> StylePropertyForeground = "foreground";
+        public static readonly StylePropertyKey<StyleBox> StylePropertyFill = "fill";
+        public static readonly StylePropertyKey<StyleBox> StylePropertyGrabber = "grabber";
 
         public event Action<Slider>? OnGrabbed;
         public event Action<Slider>? OnReleased;
@@ -184,9 +184,9 @@ namespace Robust.Client.UserInterface.Controls
 
         protected virtual void UpdateStyleBoxes()
         {
-            StyleBox? GetStyleBox(StyleProperty<StyleBox> property)
+            StyleBox? GetStyleBox(StylePropertyKey<StyleBox> propertyKey)
             {
-                if (TryGetStyleProperty(property, out var box))
+                if (TryGetStyleProperty(propertyKey, out var box))
                 {
                     return box;
                 }

--- a/Robust.Client/UserInterface/Controls/TabContainer.cs
+++ b/Robust.Client/UserInterface/Controls/TabContainer.cs
@@ -14,11 +14,11 @@ namespace Robust.Client.UserInterface.Controls
         public static readonly AttachedProperty<bool> TabVisibleProperty = AttachedProperty<bool>.Create("TabVisible", typeof(TabContainer), true);
         public static readonly AttachedProperty<string?> TabTitleProperty = AttachedProperty<string?>.CreateNull("TabTitle", typeof(TabContainer));
 
-        public const string StylePropertyTabStyleBox = "tab-stylebox";
-        public const string StylePropertyTabStyleBoxInactive = "tab-stylebox-inactive";
-        public const string stylePropertyTabFontColor = "tab-font-color";
-        public const string StylePropertyTabFontColorInactive = "tab-font-color-inactive";
-        public const string StylePropertyPanelStyleBox = "panel-stylebox";
+        public static readonly StyleProperty<StyleBox> StylePropertyTabStyleBox = "tab-stylebox";
+        public static readonly StyleProperty<StyleBox> StylePropertyTabStyleBoxInactive = "tab-stylebox-inactive";
+        public static readonly StyleProperty<Color> stylePropertyTabFontColor = "tab-font-color";
+        public static readonly StyleProperty<Color> StylePropertyTabFontColorInactive = "tab-font-color-inactive";
+        public static readonly StyleProperty<StyleBox> StylePropertyPanelStyleBox = "panel-stylebox";
 
         private int _currentTab;
         private bool _tabsVisible = true;
@@ -388,7 +388,7 @@ namespace Robust.Client.UserInterface.Controls
         [System.Diagnostics.Contracts.Pure]
         private Font _getFont()
         {
-            if (TryGetStyleProperty<Font>("font", out var font))
+            if (TryGetStyleProperty(Label.StylePropertyFont, out var font))
             {
                 return font;
             }

--- a/Robust.Client/UserInterface/Controls/TabContainer.cs
+++ b/Robust.Client/UserInterface/Controls/TabContainer.cs
@@ -14,11 +14,11 @@ namespace Robust.Client.UserInterface.Controls
         public static readonly AttachedProperty<bool> TabVisibleProperty = AttachedProperty<bool>.Create("TabVisible", typeof(TabContainer), true);
         public static readonly AttachedProperty<string?> TabTitleProperty = AttachedProperty<string?>.CreateNull("TabTitle", typeof(TabContainer));
 
-        public static readonly StyleProperty<StyleBox> StylePropertyTabStyleBox = "tab-stylebox";
-        public static readonly StyleProperty<StyleBox> StylePropertyTabStyleBoxInactive = "tab-stylebox-inactive";
-        public static readonly StyleProperty<Color> stylePropertyTabFontColor = "tab-font-color";
-        public static readonly StyleProperty<Color> StylePropertyTabFontColorInactive = "tab-font-color-inactive";
-        public static readonly StyleProperty<StyleBox> StylePropertyPanelStyleBox = "panel-stylebox";
+        public static readonly StylePropertyKey<StyleBox> StylePropertyTabStyleBox = "tab-stylebox";
+        public static readonly StylePropertyKey<StyleBox> StylePropertyTabStyleBoxInactive = "tab-stylebox-inactive";
+        public static readonly StylePropertyKey<Color> stylePropertyTabFontColor = "tab-font-color";
+        public static readonly StylePropertyKey<Color> StylePropertyTabFontColorInactive = "tab-font-color-inactive";
+        public static readonly StylePropertyKey<StyleBox> StylePropertyPanelStyleBox = "panel-stylebox";
 
         private int _currentTab;
         private bool _tabsVisible = true;

--- a/Robust.Client/UserInterface/Controls/TextEdit.cs
+++ b/Robust.Client/UserInterface/Controls/TextEdit.cs
@@ -39,8 +39,8 @@ public sealed class TextEdit : Control
     [Dependency] private readonly IClipboardManager _clipboard = null!;
 
     // @formatter:off
-    public static readonly StyleProperty<Color> StylePropertyCursorColor    = "cursor-color";
-    public static readonly StyleProperty<Color> StylePropertySelectionColor = "selection-color";
+    public static readonly StylePropertyKey<Color> StylePropertyCursorColor    = "cursor-color";
+    public static readonly StylePropertyKey<Color> StylePropertySelectionColor = "selection-color";
     public const string StylePseudoClassNotEditable = "notEditable";
     public const string StylePseudoClassPlaceholder = "placeholder";
     // @formatter:on

--- a/Robust.Client/UserInterface/Controls/TextEdit.cs
+++ b/Robust.Client/UserInterface/Controls/TextEdit.cs
@@ -39,8 +39,8 @@ public sealed class TextEdit : Control
     [Dependency] private readonly IClipboardManager _clipboard = null!;
 
     // @formatter:off
-    public const string StylePropertyCursorColor    = "cursor-color";
-    public const string StylePropertySelectionColor = "selection-color";
+    public static readonly StyleProperty<Color> StylePropertyCursorColor    = "cursor-color";
+    public static readonly StyleProperty<Color> StylePropertySelectionColor = "selection-color";
     public const string StylePseudoClassNotEditable = "notEditable";
     public const string StylePseudoClassPlaceholder = "placeholder";
     // @formatter:on
@@ -824,13 +824,13 @@ public sealed class TextEdit : Control
     [Pure]
     private Font GetFont()
     {
-        return StylePropertyDefault("font", UserInterfaceManager.ThemeDefaults.DefaultFont);
+        return StylePropertyDefault(Label.StylePropertyFont, UserInterfaceManager.ThemeDefaults.DefaultFont);
     }
 
     [Pure]
     private Color GetFontColor()
     {
-        return StylePropertyDefault("font-color", Color.White);
+        return StylePropertyDefault(Label.StylePropertyFontColor, Color.White);
     }
 
     internal void QueueLineBreakUpdate()

--- a/Robust.Client/UserInterface/Controls/TextureButton.cs
+++ b/Robust.Client/UserInterface/Controls/TextureButton.cs
@@ -14,7 +14,7 @@ namespace Robust.Client.UserInterface.Controls
     {
         private Vector2 _scale = new(1, 1);
         private Texture? _textureNormal;
-        public const string StylePropertyTexture = "texture";
+        public static readonly StyleProperty<Texture?> StylePropertyTexture = "texture";
         public const string StylePseudoClassNormal = "normal";
         public const string StylePseudoClassHover = "hover";
         public const string StylePseudoClassDisabled = "disabled";

--- a/Robust.Client/UserInterface/Controls/TextureButton.cs
+++ b/Robust.Client/UserInterface/Controls/TextureButton.cs
@@ -14,7 +14,7 @@ namespace Robust.Client.UserInterface.Controls
     {
         private Vector2 _scale = new(1, 1);
         private Texture? _textureNormal;
-        public static readonly StyleProperty<Texture?> StylePropertyTexture = "texture";
+        public static readonly StylePropertyKey<Texture?> StylePropertyTexture = "texture";
         public const string StylePseudoClassNormal = "normal";
         public const string StylePseudoClassHover = "hover";
         public const string StylePseudoClassDisabled = "disabled";

--- a/Robust.Client/UserInterface/Controls/TextureRect.cs
+++ b/Robust.Client/UserInterface/Controls/TextureRect.cs
@@ -15,11 +15,11 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class TextureRect : Control
     {
-        public static readonly StyleProperty<Texture?> StylePropertyTexture = "texture";
-        public static readonly StyleProperty<ShaderInstance?> StylePropertyShader = "shader";
-        public static readonly StyleProperty<StretchMode> StylePropertyTextureStretch = "texture-stretch";
-        public static readonly StyleProperty<Vector2> StylePropertyTextureScale = "texture-scale";
-        public static readonly StyleProperty<Vector2> StylePropertyTextureSizeTarget = "texture-size-target";
+        public static readonly StylePropertyKey<Texture?> StylePropertyTexture = "texture";
+        public static readonly StylePropertyKey<ShaderInstance?> StylePropertyShader = "shader";
+        public static readonly StylePropertyKey<StretchMode> StylePropertyTextureStretch = "texture-stretch";
+        public static readonly StylePropertyKey<Vector2> StylePropertyTextureScale = "texture-scale";
+        public static readonly StylePropertyKey<Vector2> StylePropertyTextureSizeTarget = "texture-size-target";
 
         private bool _canShrink;
         private Texture? _texture;

--- a/Robust.Client/UserInterface/Controls/TextureRect.cs
+++ b/Robust.Client/UserInterface/Controls/TextureRect.cs
@@ -15,11 +15,11 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class TextureRect : Control
     {
-        public const string StylePropertyTexture = "texture";
-        public const string StylePropertyShader = "shader";
-        public const string StylePropertyTextureStretch = "texture-stretch";
-        public const string StylePropertyTextureScale = "texture-scale";
-        public const string StylePropertyTextureSizeTarget = "texture-size-target";
+        public static readonly StyleProperty<Texture?> StylePropertyTexture = "texture";
+        public static readonly StyleProperty<ShaderInstance?> StylePropertyShader = "shader";
+        public static readonly StyleProperty<StretchMode> StylePropertyTextureStretch = "texture-stretch";
+        public static readonly StyleProperty<Vector2> StylePropertyTextureScale = "texture-scale";
+        public static readonly StyleProperty<Vector2> StylePropertyTextureSizeTarget = "texture-size-target";
 
         private bool _canShrink;
         private Texture? _texture;

--- a/Robust.Client/UserInterface/Controls/Tree.cs
+++ b/Robust.Client/UserInterface/Controls/Tree.cs
@@ -10,8 +10,8 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class Tree : Control
     {
-        public static readonly StyleProperty<StyleBox> StylePropertyItemBoxSelected = "item-selected";
-        public static readonly StyleProperty<StyleBox> StylePropertyBackground = "background";
+        public static readonly StylePropertyKey<StyleBox> StylePropertyItemBoxSelected = "item-selected";
+        public static readonly StylePropertyKey<StyleBox> StylePropertyBackground = "background";
 
         private readonly List<Item> _itemList = new();
 

--- a/Robust.Client/UserInterface/Controls/Tree.cs
+++ b/Robust.Client/UserInterface/Controls/Tree.cs
@@ -10,8 +10,8 @@ namespace Robust.Client.UserInterface.Controls
     [Virtual]
     public class Tree : Control
     {
-        public const string StylePropertyItemBoxSelected = "item-selected";
-        public const string StylePropertyBackground = "background";
+        public static readonly StyleProperty<StyleBox> StylePropertyItemBoxSelected = "item-selected";
+        public static readonly StyleProperty<StyleBox> StylePropertyBackground = "background";
 
         private readonly List<Item> _itemList = new();
 
@@ -287,7 +287,7 @@ namespace Robust.Client.UserInterface.Controls
 
         private Font? _getFont()
         {
-            if (TryGetStyleProperty<Font>("font", out var font))
+            if (TryGetStyleProperty(Label.StylePropertyFont, out var font))
             {
                 return font;
             }

--- a/Robust.Client/UserInterface/Controls/UIRoot.cs
+++ b/Robust.Client/UserInterface/Controls/UIRoot.cs
@@ -6,7 +6,7 @@ namespace Robust.Client.UserInterface.Controls
 {
     public abstract class UIRoot : Control
     {
-        public static readonly StyleProperty<Color> StylePropBackground = "background";
+        public static readonly StylePropertyKey<Color> StylePropBackground = "background";
 
         public override UIRoot? Root
         {

--- a/Robust.Client/UserInterface/Controls/UIRoot.cs
+++ b/Robust.Client/UserInterface/Controls/UIRoot.cs
@@ -6,7 +6,7 @@ namespace Robust.Client.UserInterface.Controls
 {
     public abstract class UIRoot : Control
     {
-        public const string StylePropBackground = "background";
+        public static readonly StyleProperty<Color> StylePropBackground = "background";
 
         public override UIRoot? Root
         {

--- a/Robust.Client/UserInterface/Controls/WrapContainer.cs
+++ b/Robust.Client/UserInterface/Controls/WrapContainer.cs
@@ -13,12 +13,12 @@ public sealed class WrapContainer : Container
     /// <summary>
     /// Specifies the amount of space between two children, on the main axis.
     /// </summary>
-    public const string StylePropertySeparation = "separation";
+    public static readonly StyleProperty<int> StylePropertySeparation = "separation";
 
     /// <summary>
     /// Specifies the amount of space between two children, on the cross axis.
     /// </summary>
-    public const string StylePropertyCrossSeparation = "cross-separation";
+    public static readonly StyleProperty<int> StylePropertyCrossSeparation = "cross-separation";
 
     // Parameters.
     private Axis _layoutAxis;

--- a/Robust.Client/UserInterface/Controls/WrapContainer.cs
+++ b/Robust.Client/UserInterface/Controls/WrapContainer.cs
@@ -13,12 +13,12 @@ public sealed class WrapContainer : Container
     /// <summary>
     /// Specifies the amount of space between two children, on the main axis.
     /// </summary>
-    public static readonly StyleProperty<int> StylePropertySeparation = "separation";
+    public static readonly StylePropertyKey<int> StylePropertySeparation = "separation";
 
     /// <summary>
     /// Specifies the amount of space between two children, on the cross axis.
     /// </summary>
-    public static readonly StyleProperty<int> StylePropertyCrossSeparation = "cross-separation";
+    public static readonly StylePropertyKey<int> StylePropertyCrossSeparation = "cross-separation";
 
     // Parameters.
     private Axis _layoutAxis;

--- a/Robust.Client/UserInterface/DevWindow/ProfAltBackground.cs
+++ b/Robust.Client/UserInterface/DevWindow/ProfAltBackground.cs
@@ -5,6 +5,8 @@ namespace Robust.Client.UserInterface;
 
 internal sealed class ProfAltBackground : Control
 {
+    public static readonly StyleProperty<Color> StylePropertyColor = "color";
+
     public bool IsAltBackground { get; set; }
     public Color Color = DefaultColor;
     public static readonly Color DefaultColor = Color.FromHex("#222222");
@@ -12,7 +14,7 @@ internal sealed class ProfAltBackground : Control
     protected override void StylePropertiesChanged()
     {
         base.StylePropertiesChanged();
-        if (!TryGetStyleProperty("color", out Color))
+        if (!TryGetStyleProperty(StylePropertyColor, out Color))
             Color = DefaultColor;
     }
 

--- a/Robust.Client/UserInterface/DevWindow/ProfAltBackground.cs
+++ b/Robust.Client/UserInterface/DevWindow/ProfAltBackground.cs
@@ -5,7 +5,7 @@ namespace Robust.Client.UserInterface;
 
 internal sealed class ProfAltBackground : Control
 {
-    public static readonly StyleProperty<Color> StylePropertyColor = "color";
+    public static readonly StylePropertyKey<Color> StylePropertyColor = "color";
 
     public bool IsAltBackground { get; set; }
     public Color Color = DefaultColor;

--- a/Robust.Client/UserInterface/DevWindow/ProfTreeEntry.xaml.cs
+++ b/Robust.Client/UserInterface/DevWindow/ProfTreeEntry.xaml.cs
@@ -9,6 +9,9 @@ namespace Robust.Client.UserInterface;
 [GenerateTypedNameReferences]
 internal sealed partial class ProfTreeEntry : Control
 {
+    public static readonly StyleProperty<Color> StylePropertyArrowColor = "arrowColor";
+    public static readonly StyleProperty<Color> StylePropertyArrowOutline = "arrowOutline";
+
     private readonly ProfTree _tab;
     private readonly ProfTree.TreeExpand _parentExpand;
     public readonly (int str, int i) Id;
@@ -17,11 +20,13 @@ internal sealed partial class ProfTreeEntry : Control
     {
         base.StylePropertiesChanged();
 
-        if (!TryGetStyleProperty("arrowColor", out Arrow.Color))
-            Arrow.Color = Color.White;
+        Arrow.Color = !TryGetStyleProperty(StylePropertyArrowColor, out var arrowColor)
+            ? Color.White
+            : arrowColor;
 
-        if (!TryGetStyleProperty("arrowOutline", out Arrow.OutlineColor))
-            Arrow.OutlineColor = Color.Black;
+        Arrow.OutlineColor = !TryGetStyleProperty(StylePropertyArrowOutline, out var arrowOutline)
+            ? Color.Black
+            : arrowOutline;
     }
 
     public ProfTreeEntry(

--- a/Robust.Client/UserInterface/DevWindow/ProfTreeEntry.xaml.cs
+++ b/Robust.Client/UserInterface/DevWindow/ProfTreeEntry.xaml.cs
@@ -9,8 +9,8 @@ namespace Robust.Client.UserInterface;
 [GenerateTypedNameReferences]
 internal sealed partial class ProfTreeEntry : Control
 {
-    public static readonly StyleProperty<Color> StylePropertyArrowColor = "arrowColor";
-    public static readonly StyleProperty<Color> StylePropertyArrowOutline = "arrowOutline";
+    public static readonly StylePropertyKey<Color> StylePropertyArrowColor = "arrowColor";
+    public static readonly StylePropertyKey<Color> StylePropertyArrowOutline = "arrowOutline";
 
     private readonly ProfTree _tab;
     private readonly ProfTree.TreeExpand _parentExpand;

--- a/Robust.Client/UserInterface/Stylesheet.cs
+++ b/Robust.Client/UserInterface/Stylesheet.cs
@@ -98,7 +98,7 @@ namespace Robust.Client.UserInterface
     {
         private readonly List<StyleProperty> _props = new();
 
-        [Obsolete("Use Prop(StyleProperty<T>, T) with a typed style property key.")]
+        [Obsolete("Use Prop(StylePropertyKey<T>, T) with a typed style property key.")]
         public MutableSelector Prop<T>(string key, T value)
         {
             _props.Add(new StyleProperty(key, value));
@@ -321,7 +321,7 @@ namespace Robust.Client.UserInterface
             Name = name;
         }
 
-        [Obsolete("Use typed StyleProperty<T> key instead of string key.")]
+        [Obsolete("Use typed StylePropertyKey<T> instead of string key.")]
         public StyleProperty(string name, object? value)
             : this(name)
         {

--- a/Robust.Client/UserInterface/Stylesheet.cs
+++ b/Robust.Client/UserInterface/Stylesheet.cs
@@ -310,6 +310,9 @@ namespace Robust.Client.UserInterface
     [Virtual]
     public class StyleProperty
     {
+        public string Name { get; }
+        public object? Value { get; }
+
         protected StyleProperty(string name)
         {
             ArgumentNullException.ThrowIfNull(name);
@@ -329,9 +332,6 @@ namespace Robust.Client.UserInterface
             Name = property.Name;
             Value = value;
         }
-
-        public string Name { get; }
-        public object? Value { get; }
     }
 
     /// <summary>

--- a/Robust.Client/UserInterface/Stylesheet.cs
+++ b/Robust.Client/UserInterface/Stylesheet.cs
@@ -98,9 +98,16 @@ namespace Robust.Client.UserInterface
     {
         private readonly List<StyleProperty> _props = new();
 
-        public MutableSelector Prop(string key, object value)
+        [Obsolete("Use Prop(StyleProperty<T>, T) with a typed style property key.")]
+        public MutableSelector Prop<T>(string key, T value)
         {
-            _props.Add(new StyleProperty(key, value));
+            _props.Add(new StyleProperty((StyleProperty<T>)key, value));
+            return this;
+        }
+
+        public MutableSelector Prop<T>(StyleProperty<T> property, T value)
+        {
+            _props.Add(new StyleProperty(property, value));
             return this;
         }
 
@@ -298,18 +305,45 @@ namespace Robust.Client.UserInterface
     }
 
     /// <summary>
-    ///     A single property in a rule, with a name and an object value.
+    /// A single property in a rule, with a name and object value.
     /// </summary>
-    public readonly struct StyleProperty
+    [Virtual]
+    public class StyleProperty
     {
-        public StyleProperty(string name, object value)
+        protected StyleProperty(string name)
         {
+            ArgumentNullException.ThrowIfNull(name);
             Name = name;
+        }
+
+        [Obsolete("Use typed StyleProperty<T> key instead of string key.")]
+        public StyleProperty(string name, object? value)
+            : this(name)
+        {
+            Value = value;
+        }
+
+        public StyleProperty(StyleProperty property, object? value)
+        {
+            ArgumentNullException.ThrowIfNull(property);
+            Name = property.Name;
             Value = value;
         }
 
         public string Name { get; }
-        public object Value { get; }
+        public object? Value { get; }
+    }
+
+    /// <summary>
+    /// A typed StyleProperty to ensure the correct type of value is provided.
+    /// </summary>
+    /// <typeparam name="T">Type</typeparam>
+    public sealed class StyleProperty<T>(string name) : StyleProperty(name)
+    {
+        public static implicit operator StyleProperty<T>(string name)
+        {
+            return new StyleProperty<T>(name);
+        }
     }
 
     public abstract class Selector

--- a/Robust.Client/UserInterface/Stylesheet.cs
+++ b/Robust.Client/UserInterface/Stylesheet.cs
@@ -74,7 +74,7 @@ namespace Robust.Client.UserInterface
         /// <seealso cref="SelectorElement"/>
         public static MutableSelectorElement Element<T>() where T : Control
         {
-            return new() {Type = typeof(T)};
+            return new() { Type = typeof(T) };
         }
 
         /// <summary>
@@ -101,13 +101,15 @@ namespace Robust.Client.UserInterface
         [Obsolete("Use Prop(StyleProperty<T>, T) with a typed style property key.")]
         public MutableSelector Prop<T>(string key, T value)
         {
-            _props.Add(new StyleProperty((StyleProperty<T>)key, value));
+            _props.Add(new StyleProperty(key, value));
             return this;
         }
 
-        public MutableSelector Prop<T>(StyleProperty<T> property, T value)
+        public MutableSelector Prop<T>(StylePropertyKey<T> propertyKey, T value)
         {
-            _props.Add(new StyleProperty(property, value));
+#pragma warning disable CS0618
+            _props.Add(new StyleProperty(propertyKey.Name, value));
+#pragma warning enable CS0618
             return this;
         }
 
@@ -326,7 +328,7 @@ namespace Robust.Client.UserInterface
             Value = value;
         }
 
-        public StyleProperty(StyleProperty property, object? value)
+        public StyleProperty(IStylePropertyKey property, object? value)
         {
             ArgumentNullException.ThrowIfNull(property);
             Name = property.Name;
@@ -335,14 +337,24 @@ namespace Robust.Client.UserInterface
     }
 
     /// <summary>
-    /// A typed StyleProperty to ensure the correct type of value is provided.
+    /// A style property key.
+    /// </summary>
+    public interface IStylePropertyKey
+    {
+        string Name { get; }
+    }
+
+    /// <summary>
+    /// A typed key to ensure the correct type of the value for the StyleProperty is provided.
     /// </summary>
     /// <typeparam name="T">Type</typeparam>
-    public sealed class StyleProperty<T>(string name) : StyleProperty(name)
+    public readonly struct StylePropertyKey<T>(string name) : IStylePropertyKey
     {
-        public static implicit operator StyleProperty<T>(string name)
+        public string Name { get; } = name;
+
+        public static implicit operator StylePropertyKey<T>(string name)
         {
-            return new StyleProperty<T>(name);
+            return new StylePropertyKey<T>(name);
         }
     }
 

--- a/Robust.Client/UserInterface/Stylesheets/DefaultStylesheet.cs
+++ b/Robust.Client/UserInterface/Stylesheets/DefaultStylesheet.cs
@@ -47,14 +47,14 @@ public sealed class DefaultStylesheet
              */
 
             Element().Class("monospace")
-                .Prop("font", notoSansMono12),
+                .Prop(Label.StylePropertyFont, notoSansMono12),
 
             /*
              * OS Window defaults
              */
 
             Element<WindowRoot>()
-                .Prop("background", theme.ResolveColorOrSpecified("rootBackground", Color.Black)),
+                .Prop(UIRoot.StylePropBackground, theme.ResolveColorOrSpecified("rootBackground", Color.Black)),
 
             /*
              * Scrollbars
@@ -90,7 +90,7 @@ public sealed class DefaultStylesheet
 
             // Background
             Element().Class(DefaultWindow.StyleClassWindowPanel)
-                .Prop("panel", new StyleBoxFlat
+                .Prop(PanelContainer.StylePropertyPanel, new StyleBoxFlat
                 {
                     BackgroundColor = theme.ResolveColorOrSpecified("windowBackground", Color.FromHex("#111111")),
                     BorderColor = theme.ResolveColorOrSpecified("windowBorder", Color.FromHex("#444444")),
@@ -128,8 +128,8 @@ public sealed class DefaultStylesheet
              */
 
             Element()
-                .Prop("font", notoSansFont12)
-                .Prop("font-color", Color.White),
+                .Prop(Label.StylePropertyFont, notoSansFont12)
+                .Prop(Label.StylePropertyFontColor, Color.White),
 
             /*
              * Buttons
@@ -221,16 +221,16 @@ public sealed class DefaultStylesheet
                     ContentMarginTopOverride = 3,
                 })
                 // default font color
-                .Prop("font-color", Color.White)
-                .Prop("cursor-color", Color.White),
+                .Prop(Label.StylePropertyFontColor, Color.White)
+                .Prop(LineEdit.StylePropertyCursorColor, Color.White),
 
             // LineEdit non-editable text color
             Element<LineEdit>().Class(LineEdit.StyleClassLineEditNotEditable)
-                .Prop("font-color", theme.ResolveColorOrSpecified("lineEditUneditableText", Color.FromHex("#444444"))),
+                .Prop(Label.StylePropertyFontColor, theme.ResolveColorOrSpecified("lineEditUneditableText", Color.FromHex("#444444"))),
 
             // LineEdit placeholder text color
             Element<LineEdit>().Pseudo(LineEdit.StylePseudoClassPlaceholder)
-                .Prop("font-color",  theme.ResolveColorOrSpecified("lineEditPlaceholderText", Color.FromHex("#7d7d7d"))),
+                .Prop(Label.StylePropertyFontColor,  theme.ResolveColorOrSpecified("lineEditPlaceholderText", Color.FromHex("#7d7d7d"))),
 
             /*
              * TabContainer
@@ -268,7 +268,7 @@ public sealed class DefaultStylesheet
                     ContentMarginRightOverride = 5,
                     ContentMarginTopOverride = 3,
                 })
-                .Prop("font", notoSansFont12),
+                .Prop(Label.StylePropertyFont, notoSansFont12),
         });
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Added new `StylePropertyKey<T>` type to ensure style properties are correctly set to the right type, and a bunch of warnings to help enforce a better style (e.g. don't hard-code strings as StyleProperty inside of Prop<T>)

## Why
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

I've been doing a lot of stylesheet work recently and I've had a few times where I accidentally set a property to an invalid value, and it would just silently fail within `TryGetStyleProperty<T>`. Now, when writing stylesheet code, it'll give you better auto-completion for the value for a property as well as compile-time errors when you put an invalid value for a type.

## Technical details

The [Extract typed style properties](https://github.com/space-wizards/RobustToolbox/commit/875c547cdbaca8fc7fca437bead8b4c0bc3f8ccd) commit is the only one with substantive changes, the rest are all either style or fixing warnings.

`StylePropertyKey<T>` is really just a thin wrapper around a string with a phantom type.

It is possible to bypass the type checking using `StylePropertyKey<T>` by constructing untyped `StyleProperty` values directly, as older stylesheet code did this and removing support would cause a breaking change. The string-based key compatibility stuff produces warnings but can't provide type checking.

Memory-wise, it shouldn't be an issue as it's just a struct wrapped around a single string that it implicitly transforms between.

## Migration

It generally tends to be that most warnings are because a string is used as a key. Instead of hard-coding a string in the Stylesheet, define a `StylePropertyKey<T>` field in your `Control` class (or reuse another Control's) and use it. If you already had a string defined, just change the type.

Here's some examples of diffs to resolve some warnings in Content:

> warning CS0618: 'MutableSelector.Prop<T>(string, T)' is obsolete: 'Use Prop(StylePropertyKey<T>, T) with a typed style property key.'
```diff
            E<LineEdit>()
                .Class(LineEdit.StyleClassLineEditNotEditable)
-                .Prop("font-color", new Color(192, 192, 192)),
+                .Prop(Label.StylePropertyFontColor, new Color(192, 192, 192)),
            E<LineEdit>()
                .Pseudo(LineEdit.StylePseudoClassPlaceholder)
-                .Prop("font-color", Color.Gray),
+                .Prop(Label.StylePropertyFontColor, Color.Gray),
            E<TextEdit>()
                .Pseudo(TextEdit.StylePseudoClassPlaceholder)
-                .Prop("font-color", Color.Gray),
+                .Prop(Label.StylePropertyFontColor, Color.Gray),
```

> warning CS0618: 'Control.TryGetStyleProperty<T>(string, out T)' is obsolete: 'Use TryGetStyleProperty(StylePropertyKey<T>, out T) with a typed style property key.'
```diff
-        public const string StylePropertySeparation = "separation";
+        public static readonly StyleProperty<int> StylePropertySeparation = "separation";

        private const int DefaultSeparation = 0;

        private int ActualSeparation
        {
            get
            {
                if (TryGetStyleProperty(StylePropertySeparation, out int separation))
                {
                    return separation;
                }

                return SeparationOverride ?? DefaultSeparation;
            }
        }
```

## Breaking changes

Content (space-wizards/space-station-14) builds successfully without any changes and any new errors. The build will still succeed unless a type error was already present within the style code. 

**Changelog**

Added a new `StylePropertyKey<T>` class to be used to define style properties in controls. This provides type safety for styling, but can break builds if type errors are present.

Lots of new warnings for directly using strings instead of `StylePropertyKey<T>` as `StyleProperty` keys/names.