### PR TITLE
fix sensor logic

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
@@ -407,8 +407,8 @@ namespace Robust.Shared.Physics.Systems
 
             QueryBroadphase(broadphaseComp.DynamicTree, state, aabb);
 
-            if ((proxy.Body.BodyType & BodyType.Static) != 0x0)
-                return;
+            // Static proxies still need to query the static tree so anchored/static bodies can
+            // rediscover sensor contacts after RegenerateContacts.
 
             QueryBroadphase(broadphaseComp.StaticTree, state, aabb);
         }

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs
@@ -461,9 +461,11 @@ public abstract partial class SharedPhysicsSystem
 
             bool activeA = bodyA.Awake && bodyA.BodyType != BodyType.Static;
             bool activeB = bodyB.Awake && bodyB.BodyType != BodyType.Static;
+            var sensorContact = !fixtureA.Hard || !fixtureB.Hard;
 
-            // At least one body must be awake and it must be dynamic or kinematic.
-            if (activeA == false && activeB == false)
+            // Hard contacts need at least one active non-static body.
+            // Sensors still need to update while asleep/static so they can raise Start/EndCollide.
+            if (!sensorContact &&  activeA == false && activeB == false)
             {
                 continue;
             }


### PR DESCRIPTION
The PR got rejected because the branch contained too many unrelated/follow-up commits, which made the diff very hard to review.
I’ll repeat what I said in the previous PR.
In the Goob build, there is an interactor, but it cannot interact with anchored objects.

This happens because the interactor’s collider is also anchored, meaning both objects are static and have awake = false, which is required for static objects. As a result, contacts between them are not processed. Additionally, when an object becomes anchored, all existing contacts are destroyed.

The main solution to this issue was to add a condition that still allows contact calculation when both objects are anchored, as long as one of them is a sensor (hard = false). In that case, the contact is still processed.

I hope this issue gets fixed. Sorry for my inexperience and for not noticing this earlier.
