### PR TITLE
Normal/Hover/Focus PseudoClasses for TextEdit & LineEdit

### DIFF
--- a/Robust.Client/UserInterface/Controls/LineEdit.cs
+++ b/Robust.Client/UserInterface/Controls/LineEdit.cs
@@ -33,9 +33,9 @@ namespace Robust.Client.UserInterface.Controls
         public const string StylePseudoClassNormal = "normal";
         public const string StylePseudoClassHover = "hover";
         public const string StylePseudoClassFocus = "focus";
-        public const string StylePseudoClassDisabled = "disabled";
+        public const string StylePseudoClassNotEditable = "notEditable";
 
-        [Obsolete("Use StylePseudoClassDisabled instead")]
+        [Obsolete("Use StylePseudoClassNotEditable instead")]
         public const string StyleClassLineEditNotEditable = "notEditable";
         public const string StylePseudoClassPlaceholder = "placeholder";
 
@@ -997,7 +997,7 @@ namespace Robust.Client.UserInterface.Controls
 
             if (!Editable)
             {
-                SetOnlyStylePseudoClass(StylePseudoClassDisabled);
+                SetOnlyStylePseudoClass(StylePseudoClassNotEditable);
 #pragma warning disable CS0618
                 AddStyleClass(StyleClassLineEditNotEditable);
 #pragma warning restore CS0618

--- a/Robust.Client/UserInterface/Controls/LineEdit.cs
+++ b/Robust.Client/UserInterface/Controls/LineEdit.cs
@@ -29,6 +29,13 @@ namespace Robust.Client.UserInterface.Controls
         public const string StylePropertyStyleBox = "stylebox";
         public const string StylePropertyCursorColor = "cursor-color";
         public const string StylePropertySelectionColor = "selection-color";
+
+        public const string StylePseudoClassNormal = "normal";
+        public const string StylePseudoClassHover = "hover";
+        public const string StylePseudoClassFocus = "focus";
+        public const string StylePseudoClassDisabled = "disabled";
+
+        [Obsolete("Use StylePseudoClassDisabled instead")]
         public const string StyleClassLineEditNotEditable = "notEditable";
         public const string StylePseudoClassPlaceholder = "placeholder";
 
@@ -45,6 +52,16 @@ namespace Robust.Client.UserInterface.Controls
 
         private TextEditShared.CursorBlink _blink;
         private readonly LineEditRenderBox _renderBox;
+
+        private bool Hovered
+        {
+            get;
+            set
+            {
+                field = value;
+                _updatePseudoClass();
+            }
+        }
 
         private bool _mouseSelectingText;
         private float _lastMousePosition;
@@ -140,16 +157,9 @@ namespace Robust.Client.UserInterface.Controls
             set
             {
                 _editable = value;
-                if (_editable)
-                {
-                    DefaultCursorShape = CursorShape.IBeam;
-                    RemoveStyleClass(StyleClassLineEditNotEditable);
-                }
-                else
-                {
-                    DefaultCursorShape = CursorShape.Arrow;
-                    AddStyleClass(StyleClassLineEditNotEditable);
-                }
+                DefaultCursorShape = _editable ? CursorShape.IBeam : CursorShape.Arrow;
+
+                _updatePseudoClass();
             }
         }
 
@@ -194,7 +204,20 @@ namespace Robust.Client.UserInterface.Controls
         public int SelectionLower => Math.Min(_selectionStart, _cursorPosition);
         public int SelectionUpper => Math.Max(_selectionStart, _cursorPosition);
 
-        public bool HidePlaceHolderOnFocus { get; set; }
+        public bool HidePlaceHolderOnFocus
+        {
+            get;
+            set
+            {
+                if (field == value)
+                {
+                    return;
+                }
+
+                field = value;
+                _updatePseudoClass();
+            }
+        }
 
         public bool IgnoreNext { get; set; }
 
@@ -227,6 +250,7 @@ namespace Robust.Client.UserInterface.Controls
             DefaultCursorShape = CursorShape.IBeam;
 
             AddChild(_renderBox = new LineEditRenderBox(this));
+            _updatePseudoClass();
         }
 
         public void Clear()
@@ -790,6 +814,20 @@ namespace Robust.Client.UserInterface.Controls
             _lastMousePosition = args.RelativePosition.X;
         }
 
+        protected internal override void MouseEntered()
+        {
+            base.MouseEntered();
+
+            Hovered = true;
+        }
+
+        protected internal override void MouseExited()
+        {
+            base.MouseExited();
+
+            Hovered = false;
+        }
+
         private int GetIndexAtPos(float horizontalPos)
         {
             var style = _getStyleBox();
@@ -888,6 +926,8 @@ namespace Robust.Client.UserInterface.Controls
                 CursorPosition = _text.Length;
                 SelectionStart = 0;
             }
+
+            _updatePseudoClass();
         }
 
         protected internal override void KeyboardFocusExited()
@@ -899,6 +939,7 @@ namespace Robust.Client.UserInterface.Controls
             Root?.Window?.TextInputStop();
 
             AbortIme(delete: false);
+            _updatePseudoClass();
         }
 
         [Pure]
@@ -941,7 +982,37 @@ namespace Robust.Client.UserInterface.Controls
 
         private void _updatePseudoClass()
         {
-            SetOnlyStylePseudoClass(IsPlaceHolderVisible ? StylePseudoClassPlaceholder : null);
+            if (HasKeyboardFocus())
+            {
+                SetOnlyStylePseudoClass(StylePseudoClassFocus);
+            }
+            else if (Hovered)
+            {
+                SetOnlyStylePseudoClass(StylePseudoClassHover);
+            }
+            else
+            {
+                SetOnlyStylePseudoClass(StylePseudoClassNormal);
+            }
+
+            if (!Editable)
+            {
+                SetOnlyStylePseudoClass(StylePseudoClassDisabled);
+#pragma warning disable CS0618
+                AddStyleClass(StyleClassLineEditNotEditable);
+#pragma warning restore CS0618
+            }
+            else
+            {
+#pragma warning disable CS0618
+                RemoveStyleClass(StyleClassLineEditNotEditable);
+#pragma warning restore CS0618
+            }
+
+            if (IsPlaceHolderVisible)
+            {
+                AddStylePseudoClass(StylePseudoClassPlaceholder);
+            }
         }
 
         protected internal override void Draw(DrawingHandleScreen handle)

--- a/Robust.Client/UserInterface/Controls/TextEdit.cs
+++ b/Robust.Client/UserInterface/Controls/TextEdit.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
@@ -41,7 +41,12 @@ public sealed class TextEdit : Control
     // @formatter:off
     public const string StylePropertyCursorColor    = "cursor-color";
     public const string StylePropertySelectionColor = "selection-color";
+
+    public const string StylePseudoClassNormal = "normal";
+    public const string StylePseudoClassHover = "hover";
+    public const string StylePseudoClassFocus = "focus";
     public const string StylePseudoClassNotEditable = "notEditable";
+
     public const string StylePseudoClassPlaceholder = "placeholder";
     // @formatter:on
 
@@ -84,6 +89,19 @@ public sealed class TextEdit : Control
     private bool _mouseSelectingText;
     private Vector2 _lastMouseSelectPos;
 
+    private bool Hovered
+    {
+        get;
+        set
+        {
+            if (field == value)
+                return;
+
+            field = value;
+            UpdatePseudoClass();
+        }
+    }
+
     // Debug overlay stuff.
     internal bool DebugOverlay;
     private Vector2? _lastDebugMousePos;
@@ -101,6 +119,8 @@ public sealed class TextEdit : Control
         KeyboardFocusOnClick = true;
         MouseFilter = MouseFilterMode.Stop;
         DefaultCursorShape = CursorShape.IBeam;
+
+        UpdatePseudoClass();
     }
 
     /// <summary>
@@ -1096,11 +1116,19 @@ public sealed class TextEdit : Control
         return _lineBreaks[lineIndex - 1];
     }
 
+    protected internal override void MouseEntered()
+    {
+        base.MouseEntered();
+
+        Hovered = true;
+    }
+
     protected internal override void MouseExited()
     {
         base.MouseExited();
 
         _lastDebugMousePos = null;
+        Hovered = false;
     }
 
     protected internal override void MouseMove(GUIMouseMoveEventArgs args)
@@ -1172,9 +1200,25 @@ public sealed class TextEdit : Control
 
     private void UpdatePseudoClass()
     {
-        SetOnlyStylePseudoClass(IsPlaceholderVisible ? StylePseudoClassPlaceholder : null);
         if (!Editable)
-            AddStylePseudoClass(StylePseudoClassNotEditable);
+        {
+            SetOnlyStylePseudoClass(StylePseudoClassNotEditable);
+        }
+        else if (HasKeyboardFocus())
+        {
+            SetOnlyStylePseudoClass(StylePseudoClassFocus);
+        }
+        else if (Hovered)
+        {
+            SetOnlyStylePseudoClass(StylePseudoClassHover);
+        }
+        else
+        {
+            SetOnlyStylePseudoClass(StylePseudoClassNormal);
+        }
+
+        if (IsPlaceholderVisible)
+            AddStylePseudoClass(StylePseudoClassPlaceholder);
     }
 
 
@@ -1447,6 +1491,8 @@ public sealed class TextEdit : Control
         {
             Root?.Window?.TextInputStart();
         }
+
+        UpdatePseudoClass();
     }
 
     protected internal override void KeyboardFocusExited()
@@ -1455,6 +1501,8 @@ public sealed class TextEdit : Control
 
         Root?.Window?.TextInputStop();
         AbortIme(delete: false);
+
+        UpdatePseudoClass();
     }
 
     public sealed class TextEditEventArgs(TextEdit control, Rope.Node textRope) : EventArgs

--- a/Robust.Client/UserInterface/UserInterfaceManager.Input.cs
+++ b/Robust.Client/UserInterface/UserInterfaceManager.Input.cs
@@ -516,8 +516,8 @@ internal partial class UserInterfaceManager
     public void ReleaseKeyboardFocus()
     {
         var oldFocused = KeyboardFocused;
-        oldFocused?.KeyboardFocusExited();
         KeyboardFocused = null;
+        oldFocused?.KeyboardFocusExited();
     }
 
     public void ReleaseKeyboardFocus(Control ifControl)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

There are new `Normal`/`Hover`/`Focus`/`NotEditable` pseudoclasses available within TextEdit/LineEdit (alongside `Placeholder`).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

I wanted to style TextEdit/LineEdit more in content.

There's no way to style in Content when a TextEdit/LineEdit is being hovered or being edited, so this now lets you style it.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<details>
<summary>
New (style changes to show behavior):
</summary>

https://github.com/user-attachments/assets/48dcc1df-a174-42ee-acec-9da68bb98922

</details>

<details>
<summary>
New (no style changes):
</summary>

https://github.com/user-attachments/assets/649bdbb3-a679-42ec-8d79-d1f3fc0525a2

</details>

<details>
<summary>
Old:
</summary>

https://github.com/user-attachments/assets/0bedd1b6-8029-4428-8793-cd952db67aea

</details>

## Migration(s)

No breaking style changes unless there are badly written stylerules, such as in https://github.com/space-wizards/space-station-14/pull/43908.

## Changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

New obsolete warning on using `LineEdit`'s `StylePseudoClassNotEditable` instead of `StylePseudoClassLineEditNotEditable`, though support for it is still implemented.

`KeyboardFocused` is now cleared before calling `KeyboardFocusExited()` so it can be used for pseudoclass styling. 
- (I couldn't find anything that this broke, but I'm not 100% sure. If needed, we can just revert this change and add a new field like Hover to handle that stuff.)

Support for `Normal`/`Hover`/`Focus`/`NotEditable` pseudoclasses that are mutually exclusive and can compose with the `Placeholder` Pseudoclass.