### PR TITLE
Add Track StyleProperty to ScrollBar

### DIFF
--- a/Robust.Client/UserInterface/Controls/ScrollBar.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollBar.cs
@@ -9,6 +9,7 @@ namespace Robust.Client.UserInterface.Controls
 {
     public abstract class ScrollBar : Range
     {
+        public const string StylePropertyTrack = "track";
         public const string StylePropertyGrabber = "grabber";
         public const string StylePseudoClassHover = "hover";
         public const string StylePseudoClassGrabbed = "grabbed";
@@ -80,6 +81,9 @@ namespace Robust.Client.UserInterface.Controls
 
         protected internal override void Draw(DrawingHandleScreen handle)
         {
+            var trackStyle = _getTrackStyleBox();
+            trackStyle?.Draw(handle, PixelSizeBox, UIScale);
+
             var styleBox = _getGrabberStyleBox();
             styleBox?.Draw(handle, _getGrabberBox(), UIScale);
         }
@@ -191,6 +195,12 @@ namespace Robust.Client.UserInterface.Controls
             }
 
             return null;
+        }
+
+        [System.Diagnostics.Contracts.Pure]
+        private StyleBox? _getTrackStyleBox()
+        {
+            return StylePropertyDefault<StyleBox?>(StylePropertyTrack, null);
         }
 
         [System.Diagnostics.Contracts.Pure]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

There's a new `track` StyleProperty, a la `grabber`, which is a backing track to the scrollbar that you can style.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

There's some very large scroll containers in Content that result in very small grabbers, and it can be hard to tell that there's a scrollbar there.

This also would lay the foundation for future scrollbar interactions, such as jumping to a point on the track by clicking or clicking to jump forward/backward by a stepped amount.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<details>
<summary>
New (with style changes to make clear)
</summary>

<img width="960" height="600" alt="Screenshot from 2026-05-09 10-48-12" src="https://github.com/user-attachments/assets/6db2aecc-1474-48e9-af13-c2ee1e350e05" />
<img width="960" height="600" alt="Screenshot from 2026-05-09 10-48-52" src="https://github.com/user-attachments/assets/b2aeb01a-50ab-4803-975e-57dc915a6f67" />

</details>

<details>
<summary>
New:
</summary>

<img width="960" height="600" alt="Screenshot from 2026-05-09 10-49-50" src="https://github.com/user-attachments/assets/9b2d85d0-8a52-4198-9bf9-694242644b9f" />
<img width="960" height="600" alt="Screenshot from 2026-05-09 10-50-06" src="https://github.com/user-attachments/assets/003cde70-476b-4f8f-b1fc-de07973fcf98" />


</details>

<details>
<summary>
Old:
</summary>

<img width="960" height="600" alt="Screenshot from 2026-05-09 11-04-14" src="https://github.com/user-attachments/assets/9d20853d-af96-4109-b751-bf90396d57c1" />
<img width="960" height="600" alt="Screenshot from 2026-05-09 11-04-40" src="https://github.com/user-attachments/assets/fd7b4b95-ac4f-4eaf-9519-fbe837484a26" />


</details>

## Migration(s)

No breaking style changes, as there is no default styling shipped. If it's not set, it won't render.

Theoretically if their style rules uses transparency for both grabber + track, they could theoretically bleed, but that's more of a stylesheet problem than a StyleProperty problem.

## Changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

New StyleProperty `track` to ScrollBar that takes a StyleBox and displays it as a backing track for the whole height of the ScrollBar.