### PR TITLE
Fix Overrides In WrapContainer

### DIFF
--- a/Robust.Client/UserInterface/Controls/WrapContainer.cs
+++ b/Robust.Client/UserInterface/Controls/WrapContainer.cs
@@ -127,12 +127,12 @@ public sealed class WrapContainer : Container
     {
         get
         {
-            if (TryGetStyleProperty(StylePropertySeparation, out int separation))
+            if (SeparationOverride is not null)
             {
-                return separation;
+                return SeparationOverride.Value;
             }
 
-            return SeparationOverride ?? 0;
+            return StylePropertyDefault(StylePropertySeparation, 0);
         }
     }
 
@@ -140,12 +140,12 @@ public sealed class WrapContainer : Container
     {
         get
         {
-            if (TryGetStyleProperty(StylePropertyCrossSeparation, out int separation))
+            if (CrossSeparationOverride is not null)
             {
-                return separation;
+                return CrossSeparationOverride.Value;
             }
 
-            return CrossSeparationOverride ?? 0;
+            return StylePropertyDefault(StylePropertyCrossSeparation, 0);
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

The documentation strings for `CrossSeparationOverride` and `SeparationOverride` both state that setting the value will override whatever the stylesheet sets, but the code currently does the opposite.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Just making it align with expectations and comments.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

N/A

## Migration(s)

N/A unless you were using based on behavior opposite of described docs for a relatively new control.

## Changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

Fix override properties in `WrapContainer` to actually override the Style Properties.