### PR TITLE
Add `SharedMapSystem.GetFilledTileCount`

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -790,6 +791,18 @@ public abstract partial class SharedMapSystem
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Returns the total number of filled tiles on a grid
+    /// by summing the counts of filled tiles in each chunk.
+    /// </summary>
+    /// <param name="ent">The target map grid entity</param>
+    /// <returns>The total number of filled tiles in <paramref name="ent"/>.</returns>
+    [Pure]
+    public int GetFilledTileCount(Entity<MapGridComponent> ent)
+    {
+        return ent.Comp.Chunks.Values.Sum(chunk => chunk.FilledTiles);
     }
 
     public GridTileEnumerator GetAllTilesEnumerator(EntityUid uid, MapGridComponent grid, bool ignoreEmpty = true)

--- a/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedMapSystem.Grid.cs
@@ -794,7 +794,7 @@ public abstract partial class SharedMapSystem
     }
 
     /// <summary>
-    /// Returns the total number of filled tiles on a grid
+    /// Returns the total number of tiles on a grid.
     /// by summing the counts of filled tiles in each chunk.
     /// </summary>
     /// <param name="ent">The target map grid entity</param>


### PR DESCRIPTION
Content currently uses `_map.GetAllTiles(possibleTarget, comp).Count()` to get the total number of filled tiles on a grid ([here](https://github.com/space-wizards/space-station-14/blob/cff99716468bd8a8276d61ca4d095885a84b84dd/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs#L98))

`GetAllTiles` does a 3-level loop (every chunk, every x coordinate, and every y coordinate) checking if the tile is empty and `yield return`ing each `TileRef`. `Count()` needs to iterate over every single result to get the total. But we don't need all that info; we just need the total number of filled tiles. And each `MapChunk` keeps a running tally in `FilledTiles`.

This PR adds a public method to `SharedMapSystem` that simply returns the sum of the `FilledTiles` fields in each chunk in the grid.