### PR TITLE
Obsolete Button's StyleClassButton

### DIFF
--- a/Robust.Client/UserInterface/Controls/ContainerButton.cs
+++ b/Robust.Client/UserInterface/Controls/ContainerButton.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Numerics;
 using Robust.Client.Graphics;
 using Robust.Shared.Maths;
@@ -9,6 +9,8 @@ namespace Robust.Client.UserInterface.Controls
     public class ContainerButton : BaseButton
     {
         public const string StylePropertyStyleBox = "stylebox";
+
+        [Obsolete("Use the Element<> selector or Parent/Child selectors instead.")]
         public const string StyleClassButton = "button";
         public const string StylePseudoClassNormal = "normal";
         public const string StylePseudoClassPressed = "pressed";


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Obsoleted the `StyleClassButton` string defined in `ContainerButton` and used in `Button` and in random places in content.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

RT shouldn't be defining StyleClasses to style these buttons. This should be something that people decide within content if they'd like to use StyleClasses, but we shouldn't be adding an extra way to duplicate a style across multiple ContainerButton child classes when the content Stylesheet creator can do that themselves without dirtying up RT code.

(There's also just better ways to do these selectors than using this StyleClass.)

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

N/A

## Migration(s)

Switch to `E<T>` selectors (they support inheritance), and switch to Parent/Child selectors for the Label. `E<Button>.Class(ContainerButton.StyleClassButton)` is the same as `E<Button>`.

## Changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

Obsoleted the `StyleClassButton` string.