### PR TITLE
Fix BoxContainer's SeparationOverride

### DIFF
--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -37,18 +37,8 @@ namespace Robust.Client.UserInterface.Controls
             }
         }
 
-        private int ActualSeparation
-        {
-            get
-            {
-                if (TryGetStyleProperty(StylePropertySeparation, out int separation))
-                {
-                    return separation;
-                }
-
-                return SeparationOverride ?? DefaultSeparation;
-            }
-        }
+        private int ActualSeparation =>
+            SeparationOverride ?? StylePropertyDefault(StylePropertySeparation, DefaultSeparation);
 
         public int? SeparationOverride { get; set; }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Similar to how `WrapContainer`'s `SeparationOverride` didn't actually override StyleProperties, neither did `BoxContainer`'s.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

It should override the StyleProperty's value.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

N/A

## Migration(s)

N/A unless you were relying on this behavior for some reason...

## Changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

Fix `BoxContainer`'s `SeparationOverride` to overriding the Style Properties.