### PR TITLE
Add new BoxButton control

### DIFF
--- a/Robust.Client/UserInterface/Controls/BoxButton.cs
+++ b/Robust.Client/UserInterface/Controls/BoxButton.cs
@@ -54,37 +54,10 @@ public class BoxButton : ContainerButton
         var childBox = Vector2.Max(availableSize - boxSize, Vector2.Zero);
 
         var contents = Orientation == BoxContainer.LayoutOrientation.Vertical
-            ? MeasureItems<VerticalAxis>(childBox)
-            : MeasureItems<HorizontalAxis>(childBox);
+            ? BoxContainer.MeasureItems<VerticalAxis>(childBox, Children, Separation)
+            : BoxContainer.MeasureItems<HorizontalAxis>(childBox, Children, Separation);
 
         return contents + boxSize;
-    }
-
-    private Vector2 MeasureItems<TAxis>(Vector2 availableSize) where TAxis : IAxisImplementation
-    {
-        availableSize = TAxis.SizeToAxis(availableSize);
-
-        // Account for separation.
-        var separation = Separation * (Children.Count(c => c.Visible) - 1);
-        var desiredSize = new Vector2(separation, 0);
-        availableSize.X = Math.Max(0, availableSize.X) - separation;
-
-        // First, we measure non-stretching children.
-        foreach (var child in Children)
-        {
-            if (!child.Visible)
-                continue;
-
-            child.Measure(TAxis.SizeFromAxis(availableSize));
-            var childDesired = TAxis.SizeToAxis(child.DesiredSize);
-
-            desiredSize.X += childDesired.X;
-            desiredSize.Y = Math.Max(desiredSize.Y, childDesired.Y);
-
-            availableSize.X = Math.Max(0, availableSize.X - childDesired.X);
-        }
-
-        return TAxis.SizeFromAxis(desiredSize);
     }
 
     protected override Vector2 ArrangeOverride(Vector2 finalSize)

--- a/Robust.Client/UserInterface/Controls/BoxButton.cs
+++ b/Robust.Client/UserInterface/Controls/BoxButton.cs
@@ -76,8 +76,8 @@ public class BoxButton : ContainerButton
         var childBox = Vector2.Max(availableSize - boxSize, Vector2.Zero);
 
         var contents = Orientation == BoxContainer.LayoutOrientation.Vertical
-            ? BoxContainer.MeasureItems<VerticalAxis>(childBox, Children, Separation)
-            : BoxContainer.MeasureItems<HorizontalAxis>(childBox, Children, Separation);
+            ? BoxContainer.MeasureItems<VerticalAxis>(childBox, Children, 0, ChildCount, Separation)
+            : BoxContainer.MeasureItems<HorizontalAxis>(childBox, Children, 0, ChildCount, Separation);
 
         return contents + boxSize;
     }

--- a/Robust.Client/UserInterface/Controls/BoxButton.cs
+++ b/Robust.Client/UserInterface/Controls/BoxButton.cs
@@ -1,16 +1,26 @@
-using System;
 using System.Numerics;
 using Robust.Shared.Maths;
-using System.Linq;
 using Robust.Client.Graphics;
 
 namespace Robust.Client.UserInterface.Controls;
 
+/// <summary>
+/// A button with all the features but lays out children like a BoxContainer.
+/// </summary>
+/// <remarks>
+/// This control does not wrap an internal <see cref="BoxContainer"/>, all children are directly parented to this control.
+/// </remarks>
 [Virtual]
 public class BoxButton : ContainerButton
 {
+    /// <summary>
+    /// Style property for the amount of spacing inserted between visible children.
+    /// </summary>
     public const string StylePropertySeparation = BoxContainer.StylePropertySeparation;
 
+    /// <summary>
+    /// The direction in which children are laid out.
+    /// </summary>
     public BoxContainer.LayoutOrientation Orientation
     {
         get;
@@ -21,6 +31,9 @@ public class BoxButton : ContainerButton
         }
     }
 
+    /// <summary>
+    /// Changes how children are aligned along the orientation axis when there is unused space.
+    /// </summary>
     public BoxContainer.AlignMode Align
     {
         get;
@@ -31,6 +44,9 @@ public class BoxButton : ContainerButton
         }
     }
 
+    /// <summary>
+    /// Overrides <see cref="StylePropertySeparation"/>, setting the separation spacing between children.
+    /// </summary>
     public int? SeparationOverride
     {
         get;
@@ -41,13 +57,19 @@ public class BoxButton : ContainerButton
         }
     }
 
+    /// <summary>
+    /// Actual spacing between children.
+    /// </summary>
     private int Separation => SeparationOverride ?? StylePropertyDefault(StylePropertySeparation, 0);
 
+    /// <summary>
+    /// The style box, for both drawing the background and content margins.
+    /// </summary>
     private StyleBox StyleBox => StyleBoxOverride ??
                                  StylePropertyDefault(StylePropertyStyleBox,
                                      UserInterfaceManager.ThemeDefaults.ButtonStyle);
 
-
+    /// <inheritdoc />
     protected override Vector2 MeasureOverride(Vector2 availableSize)
     {
         var boxSize = StyleBox.MinimumSize;
@@ -60,6 +82,7 @@ public class BoxButton : ContainerButton
         return contents + boxSize;
     }
 
+    /// <inheritdoc />
     protected override Vector2 ArrangeOverride(Vector2 finalSize)
     {
         var box = UIBox2.FromDimensions(Vector2.Zero, finalSize);

--- a/Robust.Client/UserInterface/Controls/BoxButton.cs
+++ b/Robust.Client/UserInterface/Controls/BoxButton.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Numerics;
+using Robust.Shared.Maths;
+using System.Linq;
+using Robust.Client.Graphics;
+
+namespace Robust.Client.UserInterface.Controls;
+
+[Virtual]
+public class BoxButton : ContainerButton
+{
+    public const string StylePropertySeparation = BoxContainer.StylePropertySeparation;
+
+    public BoxContainer.LayoutOrientation Orientation
+    {
+        get;
+        set
+        {
+            field = value;
+            InvalidateMeasure();
+        }
+    }
+
+    public BoxContainer.AlignMode Align
+    {
+        get;
+        set
+        {
+            field = value;
+            InvalidateArrange();
+        }
+    }
+
+    public int? SeparationOverride
+    {
+        get;
+        set
+        {
+            field = value;
+            InvalidateMeasure();
+        }
+    }
+
+    private int Separation => SeparationOverride ?? StylePropertyDefault(StylePropertySeparation, 0);
+
+    private StyleBox StyleBox => StyleBoxOverride ??
+                                 StylePropertyDefault(StylePropertyStyleBox,
+                                     UserInterfaceManager.ThemeDefaults.ButtonStyle);
+
+
+    protected override Vector2 MeasureOverride(Vector2 availableSize)
+    {
+        var boxSize = StyleBox.MinimumSize;
+        var childBox = Vector2.Max(availableSize - boxSize, Vector2.Zero);
+
+        var contents = Orientation == BoxContainer.LayoutOrientation.Vertical
+            ? MeasureItems<VerticalAxis>(childBox)
+            : MeasureItems<HorizontalAxis>(childBox);
+
+        return contents + boxSize;
+    }
+
+    private Vector2 MeasureItems<TAxis>(Vector2 availableSize) where TAxis : IAxisImplementation
+    {
+        availableSize = TAxis.SizeToAxis(availableSize);
+
+        // Account for separation.
+        var separation = Separation * (Children.Count(c => c.Visible) - 1);
+        var desiredSize = new Vector2(separation, 0);
+        availableSize.X = Math.Max(0, availableSize.X) - separation;
+
+        // First, we measure non-stretching children.
+        foreach (var child in Children)
+        {
+            if (!child.Visible)
+                continue;
+
+            child.Measure(TAxis.SizeFromAxis(availableSize));
+            var childDesired = TAxis.SizeToAxis(child.DesiredSize);
+
+            desiredSize.X += childDesired.X;
+            desiredSize.Y = Math.Max(desiredSize.Y, childDesired.Y);
+
+            availableSize.X = Math.Max(0, availableSize.X - childDesired.X);
+        }
+
+        return TAxis.SizeFromAxis(desiredSize);
+    }
+
+    protected override Vector2 ArrangeOverride(Vector2 finalSize)
+    {
+        var box = UIBox2.FromDimensions(Vector2.Zero, finalSize);
+        var contentBox = StyleBox.GetContentBox(box, 1);
+        var separation = Separation;
+
+        if (Orientation == BoxContainer.LayoutOrientation.Vertical)
+        {
+            BoxContainer.LayOutItems<VerticalAxis>(
+                contentBox.TopLeft,
+                contentBox.Size,
+                Align,
+                Children,
+                0,
+                ChildCount,
+                separation);
+        }
+        else
+        {
+            BoxContainer.LayOutItems<HorizontalAxis>(
+                contentBox.TopLeft,
+                contentBox.Size,
+                Align,
+                Children,
+                0,
+                ChildCount,
+                separation);
+        }
+
+        return finalSize;
+    }
+}

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -56,29 +56,31 @@ namespace Robust.Client.UserInterface.Controls
         {
             if (Orientation == LayoutOrientation.Vertical)
             {
-                return MeasureItems<VerticalAxis>(availableSize, Children, ActualSeparation);
+                return MeasureItems<VerticalAxis>(availableSize, Children, 0, ChildCount, ActualSeparation);
             }
             else
             {
-                return MeasureItems<HorizontalAxis>(availableSize, Children, ActualSeparation);
+                return MeasureItems<HorizontalAxis>(availableSize, Children, 0, ChildCount, ActualSeparation);
             }
         }
 
         internal static Vector2 MeasureItems<TAxis>(
             Vector2 availableSize,
             OrderedChildCollection children,
+            int start,
+            int end,
             float separation)
             where TAxis : IAxisImplementation
         {
             availableSize = TAxis.SizeToAxis(availableSize);
 
             // Account for separation.
-            var totalSeparation = separation * (children.Count(c => c.Visible) - 1);
+            var totalSeparation = separation * (children.Skip(start).Take(end - start).Count(c => c.Visible) - 1);
             var desiredSize = new Vector2(totalSeparation, 0);
             availableSize.X = Math.Max(0, availableSize.X) - totalSeparation;
 
             // First, we measure non-stretching children.
-            foreach (var child in children)
+            foreach (var child in children.Skip(start).Take(end - start))
             {
                 if (!child.Visible)
                     continue;

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -56,25 +56,29 @@ namespace Robust.Client.UserInterface.Controls
         {
             if (Orientation == LayoutOrientation.Vertical)
             {
-                return MeasureItems<VerticalAxis>(availableSize);
+                return MeasureItems<VerticalAxis>(availableSize, Children, ActualSeparation);
             }
             else
             {
-                return MeasureItems<HorizontalAxis>(availableSize);
+                return MeasureItems<HorizontalAxis>(availableSize, Children, ActualSeparation);
             }
         }
 
-        private Vector2 MeasureItems<TAxis>(Vector2 availableSize) where TAxis : IAxisImplementation
+        internal static Vector2 MeasureItems<TAxis>(
+            Vector2 availableSize,
+            OrderedChildCollection children,
+            float separation)
+            where TAxis : IAxisImplementation
         {
             availableSize = TAxis.SizeToAxis(availableSize);
 
             // Account for separation.
-            var separation = ActualSeparation * (Children.Where(c => c.Visible).Count() - 1);
-            var desiredSize = new Vector2(separation, 0);
-            availableSize.X = Math.Max(0, availableSize.X) - separation;
+            var totalSeparation = separation * (children.Count(c => c.Visible) - 1);
+            var desiredSize = new Vector2(totalSeparation, 0);
+            availableSize.X = Math.Max(0, availableSize.X) - totalSeparation;
 
             // First, we measure non-stretching children.
-            foreach (var child in Children)
+            foreach (var child in children)
             {
                 if (!child.Visible)
                     continue;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

A new `BoxButton` control, which is a `ContainerButton` that lays out its children like a `BoxContainer` without having to use an internal child BoxContainer.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

A lot of buttons have trouble being used with the Parent/Child selectors as their restyle may need to go deeper than is automatically propagated.

This is also a common _enough_ pattern, as things like the `CollapsibleHeading`/`CheckBox` could be done as child classes of BoxButton rather than an extra internal `BoxContainer` (maybe both could be represented as a new `VisualButton` class that has both a Label and a TextureRect?).

Also, the `BoxContainer`'s methods are internal and thus aren't exposed to Content, meaning that a similar control can't be done in content. 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

N/A

## Migration(s)

New control, N/A.

## Changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

Added new `BoxButton` control, which is a `ContainerButton` that lays out its children like a `BoxContainer` without having to use an internal child BoxContainer. 