### PR TITLE
Invalidate the measure of BoxContainer's SeparationOverride

### DIFF
--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -40,7 +40,15 @@ namespace Robust.Client.UserInterface.Controls
         private int ActualSeparation =>
             SeparationOverride ?? StylePropertyDefault(StylePropertySeparation, DefaultSeparation);
 
-        public int? SeparationOverride { get; set; }
+        public int? SeparationOverride
+        {
+            get;
+            set
+            {
+                field = value;
+                InvalidateMeasure();
+            }
+        }
 
         protected override Vector2 MeasureOverride(Vector2 availableSize)
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Fixed `SeparationOverride` not invalidating measure. (I forgot this in the last PR...)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

It should be invalidating measure but currently isn't, so I fixed it.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

N/A

## Migration(s)

N/A

## Changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

Fixed `SeparationOverride` not invalidating measure.