### PR TITLE
Add More Pseudoclasses To ContainerButton

### DIFF
--- a/Robust.Client/UserInterface/Controls/BaseButton.cs
+++ b/Robust.Client/UserInterface/Controls/BaseButton.cs
@@ -186,7 +186,11 @@ namespace Robust.Client.UserInterface.Controls
                 {
                     return DrawModeEnum.Disabled;
                 }
-                else if (Pressed || (_attemptingPress > 0 && IsHovered))
+                else if ((Pressed || _attemptingPress > 0) && IsHovered)
+                {
+                    return DrawModeEnum.PressedHover;
+                }
+                else if (Pressed)
                 {
                     return DrawModeEnum.Pressed;
                 }
@@ -406,7 +410,8 @@ namespace Robust.Client.UserInterface.Controls
             Normal = 0,
             Pressed = 1,
             Hover = 2,
-            Disabled = 3
+            Disabled = 3,
+            PressedHover = 4,
         }
 
         [Virtual]

--- a/Robust.Client/UserInterface/Controls/BaseButton.cs
+++ b/Robust.Client/UserInterface/Controls/BaseButton.cs
@@ -175,9 +175,15 @@ namespace Robust.Client.UserInterface.Controls
         public bool IsHovered => _beingHovered;
 
         /// <summary>
+        /// If <c>true</c>, this button is currently being pressed down by the mouse.
+        /// </summary>
+        public bool AttemptingPress => _attemptingPress > 0;
+
+        /// <summary>
         ///     Draw mode used for styling of buttons.
         /// </summary>
         [ViewVariables]
+        [Obsolete("Use BaseButton.{Disabled,Pressed,AttemptingPress,IsHovered} directly instead.")]
         public DrawModeEnum DrawMode
         {
             get
@@ -186,11 +192,11 @@ namespace Robust.Client.UserInterface.Controls
                 {
                     return DrawModeEnum.Disabled;
                 }
-                else if (Pressed || (_attemptingPress > 0 && IsHovered))
+                else if (Pressed || (AttemptingPress && IsHovered))
                 {
                     return DrawModeEnum.Pressed;
                 }
-                else if (IsHovered || _attemptingPress > 0)
+                else if (IsHovered || AttemptingPress)
                 {
                     return DrawModeEnum.Hover;
                 }

--- a/Robust.Client/UserInterface/Controls/BaseButton.cs
+++ b/Robust.Client/UserInterface/Controls/BaseButton.cs
@@ -186,11 +186,7 @@ namespace Robust.Client.UserInterface.Controls
                 {
                     return DrawModeEnum.Disabled;
                 }
-                else if ((Pressed || _attemptingPress > 0) && IsHovered)
-                {
-                    return DrawModeEnum.PressedHover;
-                }
-                else if (Pressed)
+                else if (Pressed || (_attemptingPress > 0 && IsHovered))
                 {
                     return DrawModeEnum.Pressed;
                 }
@@ -410,8 +406,7 @@ namespace Robust.Client.UserInterface.Controls
             Normal = 0,
             Pressed = 1,
             Hover = 2,
-            Disabled = 3,
-            PressedHover = 4,
+            Disabled = 3
         }
 
         [Virtual]

--- a/Robust.Client/UserInterface/Controls/ContainerButton.cs
+++ b/Robust.Client/UserInterface/Controls/ContainerButton.cs
@@ -92,6 +92,10 @@ namespace Robust.Client.UserInterface.Controls
                 case DrawModeEnum.Disabled:
                     SetOnlyStylePseudoClass(StylePseudoClassDisabled);
                     break;
+                case DrawModeEnum.PressedHover:
+                    SetOnlyStylePseudoClass(StylePseudoClassPressed);
+                    AddStylePseudoClass(StylePseudoClassHover);
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/Robust.Client/UserInterface/Controls/ContainerButton.cs
+++ b/Robust.Client/UserInterface/Controls/ContainerButton.cs
@@ -78,23 +78,13 @@ namespace Robust.Client.UserInterface.Controls
 
         protected override void DrawModeChanged()
         {
-            switch (DrawMode)
-            {
-                case DrawModeEnum.Normal:
-                    SetOnlyStylePseudoClass(StylePseudoClassNormal);
-                    break;
-                case DrawModeEnum.Pressed:
-                    SetOnlyStylePseudoClass(StylePseudoClassPressed);
-                    break;
-                case DrawModeEnum.Hover:
-                    SetOnlyStylePseudoClass(StylePseudoClassHover);
-                    break;
-                case DrawModeEnum.Disabled:
-                    SetOnlyStylePseudoClass(StylePseudoClassDisabled);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
+            SetOnlyStylePseudoClass(Pressed ? StylePseudoClassPressed : StylePseudoClassNormal);
+
+            if (Disabled)
+                AddStyleClass(StylePseudoClassDisabled);
+
+            if (IsHovered)
+                AddStyleClass(StylePseudoClassHover);
         }
     }
 }

--- a/Robust.Client/UserInterface/Controls/ContainerButton.cs
+++ b/Robust.Client/UserInterface/Controls/ContainerButton.cs
@@ -10,10 +10,32 @@ namespace Robust.Client.UserInterface.Controls
     {
         public const string StylePropertyStyleBox = "stylebox";
         public const string StyleClassButton = "button";
+
+        /// <summary>
+        /// The button is toggled off.
+        /// </summary>
+        /// <remarks>Mutually exclusive with <see cref="StylePseudoClassPressed"/></remarks>
         public const string StylePseudoClassNormal = "normal";
+
+        /// <summary>
+        /// The button is toggled on.
+        /// </summary>
+        /// <remarks>Mutually exclusive with <see cref="StylePseudoClassNormal"/></remarks>
         public const string StylePseudoClassPressed = "pressed";
+
+        /// <summary>
+        /// The mouse is actively attempting to press/toggle the button.
+        /// </summary>
         public const string StylePseudoClassPressing = "pressing";
+
+        /// <summary>
+        /// The mouse is hovering over the button.
+        /// </summary>
         public const string StylePseudoClassHover = "hover";
+
+        /// <summary>
+        /// The button is not taking any interaction.
+        /// </summary>
         public const string StylePseudoClassDisabled = "disabled";
 
         public StyleBox? StyleBoxOverride { get; set; }

--- a/Robust.Client/UserInterface/Controls/ContainerButton.cs
+++ b/Robust.Client/UserInterface/Controls/ContainerButton.cs
@@ -12,6 +12,7 @@ namespace Robust.Client.UserInterface.Controls
         public const string StyleClassButton = "button";
         public const string StylePseudoClassNormal = "normal";
         public const string StylePseudoClassPressed = "pressed";
+        public const string StylePseudoClassPressing = "pressing";
         public const string StylePseudoClassHover = "hover";
         public const string StylePseudoClassDisabled = "disabled";
 
@@ -85,6 +86,9 @@ namespace Robust.Client.UserInterface.Controls
 
             if (IsHovered)
                 AddStyleClass(StylePseudoClassHover);
+
+            if (AttemptingPress)
+                AddStyleClass(StylePseudoClassPressing);
         }
     }
 }

--- a/Robust.Client/UserInterface/Controls/ContainerButton.cs
+++ b/Robust.Client/UserInterface/Controls/ContainerButton.cs
@@ -104,13 +104,13 @@ namespace Robust.Client.UserInterface.Controls
             SetOnlyStylePseudoClass(Pressed ? StylePseudoClassPressed : StylePseudoClassNormal);
 
             if (Disabled)
-                AddStyleClass(StylePseudoClassDisabled);
+                AddStylePseudoClass(StylePseudoClassDisabled);
 
             if (IsHovered)
-                AddStyleClass(StylePseudoClassHover);
+                AddStylePseudoClass(StylePseudoClassHover);
 
             if (AttemptingPress)
-                AddStyleClass(StylePseudoClassPressing);
+                AddStylePseudoClass(StylePseudoClassPressing);
         }
     }
 }

--- a/Robust.Client/UserInterface/Controls/ContainerButton.cs
+++ b/Robust.Client/UserInterface/Controls/ContainerButton.cs
@@ -92,10 +92,6 @@ namespace Robust.Client.UserInterface.Controls
                 case DrawModeEnum.Disabled:
                     SetOnlyStylePseudoClass(StylePseudoClassDisabled);
                     break;
-                case DrawModeEnum.PressedHover:
-                    SetOnlyStylePseudoClass(StylePseudoClassPressed);
-                    AddStylePseudoClass(StylePseudoClassHover);
-                    break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/Robust.Client/UserInterface/Controls/TextureButton.cs
+++ b/Robust.Client/UserInterface/Controls/TextureButton.cs
@@ -79,6 +79,10 @@ namespace Robust.Client.UserInterface.Controls
                 case DrawModeEnum.Disabled:
                     SetOnlyStylePseudoClass(StylePseudoClassDisabled);
                     break;
+                case DrawModeEnum.PressedHover:
+                    SetOnlyStylePseudoClass(StylePseudoClassPressed);
+                    AddStylePseudoClass(StylePseudoClassHover);
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/Robust.Client/UserInterface/Controls/TextureButton.cs
+++ b/Robust.Client/UserInterface/Controls/TextureButton.cs
@@ -79,10 +79,6 @@ namespace Robust.Client.UserInterface.Controls
                 case DrawModeEnum.Disabled:
                     SetOnlyStylePseudoClass(StylePseudoClassDisabled);
                     break;
-                case DrawModeEnum.PressedHover:
-                    SetOnlyStylePseudoClass(StylePseudoClassPressed);
-                    AddStylePseudoClass(StylePseudoClassHover);
-                    break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/Robust.Client/UserInterface/Stylesheets/DefaultStylesheet.cs
+++ b/Robust.Client/UserInterface/Stylesheets/DefaultStylesheet.cs
@@ -177,6 +177,20 @@ public sealed class DefaultStylesheet
                     ContentMarginTopOverride = 3,
                 }),
 
+            // Button style pressing (same as pressed)
+            Element<ContainerButton>().Class(ContainerButton.StyleClassButton).Pseudo(ContainerButton.StylePseudoClassPressing)
+                .Prop(ContainerButton.StylePropertyStyleBox, new StyleBoxFlat
+                {
+                    BackgroundColor = theme.ResolveColorOrSpecified("buttonBackgroundPressed", Color.FromHex("#173717")),
+                    BorderThickness = new Thickness(1),
+                    BorderColor = theme.ResolveColorOrSpecified("buttonBorderPressed", Color.FromHex("#447044")),
+                    Padding = new Thickness(3),
+                    ContentMarginBottomOverride = 3,
+                    ContentMarginLeftOverride = 5,
+                    ContentMarginRightOverride = 5,
+                    ContentMarginTopOverride = 3,
+                }),
+
             // Button style disabled
             Element<ContainerButton>().Class(ContainerButton.StyleClassButton).Pseudo(ContainerButton.StylePseudoClassDisabled)
                 .Prop(ContainerButton.StylePropertyStyleBox, new StyleBoxFlat


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Instead of only allowing for one pseudoclass for a ContainerButton, I've made it set all applicable pseudoclasses.

I also added a new `Pressing` pseudoclass to cover the case that they are `AttemptingPress`.

The `DrawMode` variable is now obsoleted as they should just read the properties they want directly.

Unlike a previous version, there shouldn't be any inheritance breaking changes.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This is useful for working with the `CheckBox`, which needs a specific hover state for when it's already Pressed which is different from the normal hover. Plus, we can have it so that now hovering or trying to click a disabled button looks different.

With the pressing state, we're now able to specifically style when the user is attempting to press, which used to default to Pressed even if not toggled yet, which caused some issues when styling PressedHover vs. just Hover.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<details>
<summary>
Content with new styles (w/ RT):
</summary>

<img width="960" height="600" alt="image" src="https://github.com/user-attachments/assets/2977a136-d02b-4115-a116-9cd06c31cf4e" />

</details>

<details>
<summary>
Current (w/ RT):
</summary>

<img width="960" height="600" alt="image" src="https://github.com/user-attachments/assets/ca1ce6fb-536e-4bd7-a0b4-c639967ec1ed" />

</details>

<details>
<summary>
Content with flipped style properties (w/ RT):
</summary>

<img width="960" height="600" alt="image" src="https://github.com/user-attachments/assets/b7c31328-cf3f-49ee-a53f-1b7188117237" />

</details>

<details>
<summary>
Current:
</summary>

<img width="960" height="600" alt="image" src="https://github.com/user-attachments/assets/e3333a93-7470-42d3-a7bd-8006da7784bd" />

</details>

## Migration(s)

Most states will have no style changes, except for when it's in the new `Pressing` state. Currently it will default to StylePropertyHover + Pressed/Normal when hovered, and default to Pressed/Normal when the mouse is still pressed down but moved away, which is different from the old default to Pressed.

The rest will all be the same except if there's a conflict over selector precedence. If a fork (doesn't happen in content) defines e.g. Disabled before Pressed or Normal after Hover, it will just pick the rule that comes later iirc, which will cause visual inconsistancies. 

## Changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

Added a new `Pressing` StylePseudoClass to ContainerButton, for when the user in attempting to hover.

Changed the StylePseudoClass in ContainerButton to now set all applicable PseudoClasses (Hover/Normal/Pressed/Pressing/Disabled) for more styling opportunities. This may require some stylesheet adjustments.

Created a new public field, AttemptingPress, which tells if the user is trying to press a BaseButton.