### PR TITLE
More Cursor Usage in Controls

### DIFF
--- a/Robust.Client/UserInterface/Controls/BaseButton.cs
+++ b/Robust.Client/UserInterface/Controls/BaseButton.cs
@@ -90,6 +90,7 @@ namespace Robust.Client.UserInterface.Controls
 
                 if (old != value)
                 {
+                    DefaultCursorShape = Disabled ? CursorShape.NotAllowed : CursorShape.Pointer;
                     DrawModeChanged();
                 }
             }
@@ -234,6 +235,7 @@ namespace Robust.Client.UserInterface.Controls
         protected BaseButton()
         {
             MouseFilter = MouseFilterMode.Stop;
+            DefaultCursorShape = Disabled ? CursorShape.NotAllowed : CursorShape.Pointer;
         }
 
         protected virtual void DrawModeChanged()

--- a/Robust.Client/UserInterface/Controls/ItemList.cs
+++ b/Robust.Client/UserInterface/Controls/ItemList.cs
@@ -595,14 +595,40 @@ namespace Robust.Client.UserInterface.Controls
         {
             base.MouseMove(args);
 
+            DefaultCursorShape = CursorShape.Arrow;
+
             for (var idx = 0; idx < _itemList.Count; idx++)
             {
                 var item = _itemList[idx];
                 if (item.Region == null) continue;
                 if (!item.Region.Value.Contains(args.RelativePosition)) continue;
+
+                if (SelectMode != ItemListSelectMode.None)
+                {
+                    if (item.Disabled)
+                    {
+                        DefaultCursorShape = CursorShape.NotAllowed;
+                    }
+                    else if (item.Selectable)
+                    {
+                        DefaultCursorShape = CursorShape.Pointer;
+                    }
+                    else
+                    {
+                        DefaultCursorShape = CursorShape.Arrow;
+                    }
+                }
+
                 OnItemHover?.Invoke(new ItemListHoverEventArgs(idx, this));
                 break;
             }
+        }
+
+        protected internal override void MouseExited()
+        {
+            base.MouseExited();
+
+            DefaultCursorShape = CursorShape.Arrow;
         }
 
         protected internal override void MouseWheel(GUIMouseWheelEventArgs args)

--- a/Robust.Client/UserInterface/Controls/MenuBar.cs
+++ b/Robust.Client/UserInterface/Controls/MenuBar.cs
@@ -235,6 +235,7 @@ namespace Robust.Client.UserInterface.Controls
             public MenuTopButton(Menu menu)
             {
                 MouseFilter = MouseFilterMode.Pass;
+                DefaultCursorShape = CursorShape.Pointer;
                 ChildMenu = menu;
             }
 

--- a/Robust.Client/UserInterface/Controls/ScrollBar.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollBar.cs
@@ -130,11 +130,21 @@ namespace Robust.Client.UserInterface.Controls
 
         protected internal override void MouseMove(GUIMouseMoveEventArgs args)
         {
+            DefaultCursorShape = CursorShape.Arrow;
+
+            if (_isHovered || _grabData != null)
+            {
+                DefaultCursorShape = _orientation == OrientationMode.Horizontal
+                    ? CursorShape.HResize
+                    : CursorShape.VResize;
+            }
+
             if (_grabData == null)
             {
                 var box = _getGrabberBox();
                 _isHovered = box.Contains(args.RelativePixelPosition);
                 _updatePseudoClass();
+
                 return;
             }
 

--- a/Robust.Client/UserInterface/Controls/ScrollBar.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollBar.cs
@@ -45,9 +45,7 @@ namespace Robust.Client.UserInterface.Controls
             ReservesSpace = true;
 
             _orientation = orientation;
-            DefaultCursorShape = orientation == OrientationMode.Horizontal
-                ? CursorShape.HResize
-                : CursorShape.VResize;
+            DefaultCursorShape = CursorShape.Pointer;
         }
 
         public bool IsAtEnd
@@ -134,9 +132,7 @@ namespace Robust.Client.UserInterface.Controls
 
             if (_isHovered || _grabData != null)
             {
-                DefaultCursorShape = _orientation == OrientationMode.Horizontal
-                    ? CursorShape.HResize
-                    : CursorShape.VResize;
+                DefaultCursorShape = CursorShape.Pointer;
             }
 
             if (_grabData == null)

--- a/Robust.Client/UserInterface/Controls/ScrollBar.cs
+++ b/Robust.Client/UserInterface/Controls/ScrollBar.cs
@@ -45,6 +45,9 @@ namespace Robust.Client.UserInterface.Controls
             ReservesSpace = true;
 
             _orientation = orientation;
+            DefaultCursorShape = orientation == OrientationMode.Horizontal
+                ? CursorShape.HResize
+                : CursorShape.VResize;
         }
 
         public bool IsAtEnd

--- a/Robust.Client/UserInterface/Controls/Slider.cs
+++ b/Robust.Client/UserInterface/Controls/Slider.cs
@@ -81,7 +81,7 @@ namespace Robust.Client.UserInterface.Controls
         public Slider()
         {
             MouseFilter = MouseFilterMode.Stop;
-            DefaultCursorShape = CursorShape.HResize;
+            DefaultCursorShape = CursorShape.Pointer;
 
             AddChild(new LayoutContainer
             {

--- a/Robust.Client/UserInterface/Controls/Slider.cs
+++ b/Robust.Client/UserInterface/Controls/Slider.cs
@@ -81,6 +81,7 @@ namespace Robust.Client.UserInterface.Controls
         public Slider()
         {
             MouseFilter = MouseFilterMode.Stop;
+            DefaultCursorShape = CursorShape.HResize;
 
             AddChild(new LayoutContainer
             {

--- a/Robust.Client/UserInterface/Controls/SplitContainer.cs
+++ b/Robust.Client/UserInterface/Controls/SplitContainer.cs
@@ -176,6 +176,7 @@ namespace Robust.Client.UserInterface.Controls
             set
             {
                 _orientation = value;
+                _splitDragArea.DefaultCursorShape = Vertical ? CursorShape.VResize : CursorShape.HResize;
                 InvalidateMeasure();
             }
         }
@@ -185,7 +186,7 @@ namespace Robust.Client.UserInterface.Controls
             MouseFilter = MouseFilterMode.Stop;
             AddChild(_splitDragArea);
             _splitDragArea.Visible = _resizeMode != SplitResizeMode.NotResizable;
-            _splitDragArea.DefaultCursorShape =  Vertical ? CursorShape.VResize : CursorShape.HResize;
+            _splitDragArea.DefaultCursorShape = Vertical ? CursorShape.VResize : CursorShape.HResize;
             _splitDragArea.OnMouseUp += StopDragging;
             _splitDragArea.OnMouseDown += StartDragging;
             _splitDragArea.OnMouseMove += OnMove;

--- a/Robust.Client/UserInterface/Controls/TabContainer.cs
+++ b/Robust.Client/UserInterface/Controls/TabContainer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using Robust.Client.Graphics;
 using Robust.Shared.Input;
@@ -325,14 +326,49 @@ namespace Robust.Client.UserInterface.Controls
 
             args.Handle();
 
+            if (!TryGetHoveredTab(args.RelativePixelPosition, out var index))
+            {
+                return;
+            }
+
+            CurrentTab = index.Value;
+        }
+
+        protected internal override void MouseMove(GUIMouseMoveEventArgs args)
+        {
+            base.MouseMove(args);
+
+            DefaultCursorShape = TryGetHoveredTab(args.RelativePixelPosition, out _)
+                ? CursorShape.Pointer
+                : CursorShape.Arrow;
+        }
+
+        protected internal override void MouseExited()
+        {
+            base.MouseExited();
+
+            DefaultCursorShape = CursorShape.Arrow;
+        }
+
+        private bool TryGetHoveredTab(Vector2 position, [NotNullWhen(true)] out int? index)
+        {
+            index = null;
+
+            if (!TabsVisible || position.Y < 0 || position.Y > _enclosingTabHeight)
+            {
+                return false;
+            }
+
             foreach (var box in _tabBoxes)
             {
-                if (box.Bounding.Contains(args.RelativePixelPosition))
+                if (box.Bounding.Contains(position))
                 {
-                    CurrentTab = box.Index;
-                    return;
+                    index = box.Index;
+                    return true;
                 }
             }
+
+            return false;
         }
 
         [System.Diagnostics.Contracts.Pure]

--- a/Robust.Client/UserInterface/Controls/TextEdit.cs
+++ b/Robust.Client/UserInterface/Controls/TextEdit.cs
@@ -100,7 +100,7 @@ public sealed partial class TextEdit : Control
         CanKeyboardFocus = true;
         KeyboardFocusOnClick = true;
         MouseFilter = MouseFilterMode.Stop;
-        DefaultCursorShape = CursorShape.IBeam;
+        DefaultCursorShape = Editable ? CursorShape.IBeam : CursorShape.NotAllowed;
     }
 
     /// <summary>
@@ -171,7 +171,7 @@ public sealed partial class TextEdit : Control
         set
         {
             _editable = value;
-            DefaultCursorShape = _editable ? CursorShape.IBeam : CursorShape.Arrow;
+            DefaultCursorShape = _editable ? CursorShape.IBeam : CursorShape.NotAllowed;
             UpdatePseudoClass();
         }
     }

--- a/Robust.Client/UserInterface/Controls/Tree.cs
+++ b/Robust.Client/UserInterface/Controls/Tree.cs
@@ -106,6 +106,22 @@ namespace Robust.Client.UserInterface.Controls
             }
         }
 
+        protected internal override void MouseMove(GUIMouseMoveEventArgs args)
+        {
+            base.MouseMove(args);
+
+            DefaultCursorShape = _tryFindItemAtPosition(args.RelativePixelPosition)?.Selectable == true
+                ? CursorShape.Pointer
+                : CursorShape.Arrow;
+        }
+
+        protected internal override void MouseExited()
+        {
+            base.MouseExited();
+
+            DefaultCursorShape = CursorShape.Arrow;
+        }
+
         private Item? _tryFindItemAtPosition(Vector2 position)
         {
             var font = _getFont();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Sets the cursor on more controls, mainly being the addition of pointer cursors to button-like classes, not available cursors for disabled things, and more resize cursors for the slider/scrollbar/split container. 

I don't really have strong thoughts about this, but I think using the HResize/VResize for some controls like Slider/ScrollBar to better show the relative direction of action is better than just using a pointer. Maybe it would be better to have pointer before interaction and then switch to resize after dragging? Let me know if y'all have any thoughts.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Cursors are also a great way to show that UI is interactive than just the hover pseudoclasses, so I made sure they're used a lot.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/2e044a84-03d6-4a37-be10-96812c100fc0

## Migration(s)

This might cause problems if there's stuff in Content that is trying to override these cursors as the DefaultCursor stuff overrides the CustomCursor stuff. That fix is probably better for another PR and would involve breaking changes.

## Changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

Changed the cursors on interactive controls.