### PR TITLE
Cache dependencies in TypeSerializers

### DIFF
--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentRegistrySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentRegistrySerializer.cs
@@ -20,6 +20,9 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
     [TypeSerializer]
     public sealed class ComponentRegistrySerializer : ITypeSerializer<ComponentRegistry, SequenceDataNode>, ITypeInheritanceHandler<ComponentRegistry, SequenceDataNode>, ITypeCopier<ComponentRegistry>
     {
+        private IComponentFactory? _factory;
+        private ISawmill? _sawmill;
+
         public ComponentRegistry Read(ISerializationManager serializationManager,
             SequenceDataNode node,
             IDependencyCollection dependencies,
@@ -27,7 +30,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             ISerializationContext? context = null,
             ISerializationManager.InstantiationDelegate<ComponentRegistry>? instanceProvider = null)
         {
-            var factory = dependencies.Resolve<IComponentFactory>();
+            _factory ??= dependencies.Resolve<IComponentFactory>();
             var components = instanceProvider != null ? instanceProvider() : new ComponentRegistry();
 
             foreach (var sequenceEntry in node.Sequence)
@@ -35,7 +38,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
                 var componentMapping = (MappingDataNode)sequenceEntry;
                 string compType = ((ValueDataNode) componentMapping.Get("type")).Value;
                 // See if type exists to detect errors.
-                switch (factory.GetComponentAvailability(compType))
+                switch (_factory.GetComponentAvailability(compType))
                 {
                     case ComponentAvailability.Available:
                         break;
@@ -44,27 +47,25 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
                         continue;
 
                     case ComponentAvailability.Unknown:
-                        dependencies
-                            .Resolve<ILogManager>()
-                            .GetSawmill(SerializationManager.LogCategory)
-                            .Error($"Unknown component '{compType}' in prototype!");
+                        _sawmill ??= dependencies.Resolve<ILogManager>()
+                            .GetSawmill(SerializationManager.LogCategory);
+                        _sawmill.Error($"Unknown component '{compType}' in prototype!");
                         continue;
                 }
 
                 // Has this type already been added?
                 if (components.ContainsKey(compType))
                 {
-                    dependencies
-                        .Resolve<ILogManager>()
-                        .GetSawmill(SerializationManager.LogCategory)
-                        .Error($"Component of type '{compType}' defined twice in prototype!");
+                    _sawmill ??= dependencies.Resolve<ILogManager>()
+                        .GetSawmill(SerializationManager.LogCategory);
+                    _sawmill.Error($"Component of type '{compType}' defined twice in prototype!");
                     continue;
                 }
 
                 var copy = componentMapping.Copy()!;
                 copy.Remove("type");
 
-                var type = factory.GetRegistration(compType).Type;
+                var type = _factory.GetRegistration(compType).Type;
                 var read = (IComponent)serializationManager.Read(type, copy, hookCtx, context)!;
 
                 components[compType] = new ComponentRegistryEntry(read, copy);
@@ -74,7 +75,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             // Assert that there are no conflicting component references.
             foreach (var componentName in components.Keys)
             {
-                var registration = factory.GetRegistration(componentName);
+                var registration = _factory.GetRegistration(componentName);
                 var compType = registration.Idx;
 
                 if (referenceTypes.Contains(compType))
@@ -94,7 +95,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             IDependencyCollection dependencies,
             ISerializationContext? context = null)
         {
-            var factory = dependencies.Resolve<IComponentFactory>();
+            _factory ??= dependencies.Resolve<IComponentFactory>();
             var components = new ComponentRegistry();
             var list = new List<ValidationNode>();
 
@@ -107,7 +108,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
                 }
                 string compType = ((ValueDataNode) componentMapping.Get("type")).Value;
                 // See if type exists to detect errors.
-                switch (factory.GetComponentAvailability(compType))
+                switch (_factory.GetComponentAvailability(compType))
                 {
                     case ComponentAvailability.Available:
                         break;
@@ -131,7 +132,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
                 var copy = componentMapping.Copy()!;
                 copy.Remove("type");
 
-                var type = factory.GetRegistration(compType).Type;
+                var type = _factory.GetRegistration(compType).Type;
 
                 list.Add(serializationManager.ValidateNode(type, copy, context));
             }
@@ -141,7 +142,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             // Assert that there are no conflicting component references.
             foreach (var componentName in components.Keys)
             {
-                var registration = factory.GetRegistration(componentName);
+                var registration = _factory.GetRegistration(componentName);
                 var compType = registration.Idx;
 
                 if (referenceTypes.Contains(compType))
@@ -194,10 +195,10 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             SequenceDataNode parent,
             IDependencyCollection dependencies, ISerializationContext? context)
         {
-            var componentFactory = dependencies.Resolve<IComponentFactory>();
+            _factory ??= dependencies.Resolve<IComponentFactory>();
             var newCompReg = child.Copy();
-            var newCompRegDict = ToTypeIndexedDictionary(newCompReg, componentFactory);
-            var parentDict = ToTypeIndexedDictionary(parent, componentFactory);
+            var newCompRegDict = ToTypeIndexedDictionary(newCompReg, _factory);
+            var parentDict = ToTypeIndexedDictionary(parent, _factory);
 
             foreach (var (reg, mapping) in parentDict)
             {

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/ComponentNameSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/ComponentNameSerializer.cs
@@ -14,11 +14,13 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 /// </summary>
 public sealed class ComponentNameSerializer : ITypeSerializer<string, ValueDataNode>
 {
+    private IComponentFactory? _factory;
+
     public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
         IDependencyCollection dependencies, ISerializationContext? context = null)
     {
-        var factory = dependencies.Resolve<IComponentFactory>();
-        if (!factory.TryGetRegistration(node.Value, out _) && factory.GetComponentAvailability(node.Value) != ComponentAvailability.Ignore)
+        _factory ??= dependencies.Resolve<IComponentFactory>();
+        if (!_factory.TryGetRegistration(node.Value, out _) && _factory.GetComponentAvailability(node.Value) != ComponentAvailability.Ignore)
             return new ErrorNode(node, $"Unknown component kind: {node.Value}");
 
         return new ValidatedValueNode(node);

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/PrototypeFlagsTypeSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/PrototypeFlagsTypeSerializer.cs
@@ -22,6 +22,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
         ITypeCopier<PrototypeFlags<T>>
         where T : class, IPrototype
     {
+        private ISawmill? _sawmill;
+
         public ValidationNode Validate(ISerializationManager serializationManager, SequenceDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
@@ -47,8 +49,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
         {
             if (instanceProvider != null)
             {
-                var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
-                sawmill.Warning($"Provided value to a Read-call for a {nameof(PrototypeFlags<T>)}. Ignoring...");
+                _sawmill ??= dependencies.Resolve<ILogManager>().GetSawmill("szr");
+                _sawmill.Warning($"Provided value to a Read-call for a {nameof(PrototypeFlags<T>)}. Ignoring...");
             }
 
             var flags = new List<string>(node.Sequence.Count);
@@ -83,8 +85,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
         {
             if (instanceProvider != null)
             {
-                var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
-                sawmill.Warning($"Provided value to a Read-call for a {nameof(PrototypeFlags<T>)}. Ignoring...");
+                _sawmill ??= dependencies.Resolve<ILogManager>().GetSawmill("szr");
+                _sawmill.Warning($"Provided value to a Read-call for a {nameof(PrototypeFlags<T>)}. Ignoring...");
             }
 
             return new PrototypeFlags<T>(node.Value);

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/PrototypeIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/Prototype/PrototypeIdSerializer.cs
@@ -11,11 +11,13 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Pro
     public sealed class AbstractPrototypeIdSerializer<TPrototype> : PrototypeIdSerializer<TPrototype>
         where TPrototype : class, IPrototype, IInheritingPrototype
     {
+        private IPrototypeManager? _proto;
+
         public override ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
-            var protoMan = dependencies.Resolve<IPrototypeManager>();
-            return protoMan.TryGetKindFrom<TPrototype>(out _) && protoMan.HasMapping<TPrototype>(node.Value)
+            _proto ??= dependencies.Resolve<IPrototypeManager>();
+            return _proto.TryGetKindFrom<TPrototype>(out _) && _proto.HasMapping<TPrototype>(node.Value)
                 ? new ValidatedValueNode(node)
                 : new ErrorNode(node, $"PrototypeID {node.Value} for type {typeof(TPrototype)} not found");
         }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
@@ -19,10 +19,13 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations;
 [TypeSerializer]
 public sealed class EntProtoIdSerializer : ITypeSerializer<EntProtoId, ValueDataNode>, ITypeCopyCreator<EntProtoId>
 {
+    private IComponentFactory? _factory;
+    private IPrototypeManager? _proto;
+
     public ValidationNode Validate(ISerializationManager serialization, ValueDataNode node, IDependencyCollection dependencies, ISerializationContext? context = null)
     {
-        var prototypes = dependencies.Resolve<IPrototypeManager>();
-        if (prototypes.TryGetKindFrom<EntityPrototype>(out _) && prototypes.HasMapping<EntityPrototype>(node.Value))
+        _proto ??= dependencies.Resolve<IPrototypeManager>();
+        if (_proto.TryGetKindFrom<EntityPrototype>(out _) && _proto.HasMapping<EntityPrototype>(node.Value))
             return new ValidatedValueNode(node);
 
         return new ErrorNode(node, $"No {nameof(EntityPrototype)} found with id {node.Value}");
@@ -50,17 +53,20 @@ public sealed class EntProtoIdSerializer : ITypeSerializer<EntProtoId, ValueData
 [TypeSerializer]
 public sealed class EntProtoIdSerializer<T> : ITypeSerializer<EntProtoId<T>, ValueDataNode>, ITypeCopyCreator<EntProtoId<T>> where T : IComponent, new()
 {
+    private IComponentFactory? _factory;
+    private IPrototypeManager? _proto;
+
     public ValidationNode Validate(ISerializationManager serialization, ValueDataNode node, IDependencyCollection dependencies, ISerializationContext? context = null)
     {
-        var prototypes = dependencies.Resolve<IPrototypeManager>();
-        if (!prototypes.TryGetKindFrom<EntityPrototype>(out _) || !prototypes.TryGetMapping(typeof(EntityPrototype), node.Value, out var mapping))
+        _proto ??= dependencies.Resolve<IPrototypeManager>();
+        if (!_proto.TryGetKindFrom<EntityPrototype>(out _) || !_proto.TryGetMapping(typeof(EntityPrototype), node.Value, out var mapping))
             return new ErrorNode(node, $"No {nameof(EntityPrototype)} found with id {node.Value} that has a {typeof(T).Name}");
 
         if (!mapping.TryGet("components", out SequenceDataNode? components))
             return new ErrorNode(node, $"{nameof(EntityPrototype)} {node.Value} doesn't have a {typeof(T).Name}.");
 
-        var compFactory = dependencies.Resolve<IComponentFactory>();
-        var registration = compFactory.GetRegistration<T>();
+        _factory ??= dependencies.Resolve<IComponentFactory>();
+        var registration = _factory.GetRegistration<T>();
         foreach (var componentNode in components)
         {
             if (componentNode is MappingDataNode component &&

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/DictionarySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/DictionarySerializer.cs
@@ -26,6 +26,8 @@ public sealed class DictionarySerializer<TKey, TValue> :
     ITypeCopyCreator<FrozenDictionary<TKey, TValue>>
     where TKey : notnull
 {
+    private ISawmill? _sawmill;
+
     #region Validate
 
     public ValidationNode Validate(ISerializationManager serializationManager, MappingDataNode node,
@@ -153,8 +155,8 @@ public sealed class DictionarySerializer<TKey, TValue> :
     {
         if (instanceProvider != null)
         {
-            var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
-            sawmill.Warning(
+            _sawmill ??= dependencies.Resolve<ILogManager>().GetSawmill("szr");
+            _sawmill.Warning(
                 $"Provided value to a Read-call for a {nameof(FrozenDictionary<TKey, TValue>)}. Ignoring...");
         }
 
@@ -181,8 +183,8 @@ public sealed class DictionarySerializer<TKey, TValue> :
     {
         if (instanceProvider != null)
         {
-            var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
-            sawmill.Warning(
+            _sawmill ??= dependencies.Resolve<ILogManager>().GetSawmill("szr");
+            _sawmill.Warning(
                 $"Provided value to a Read-call for a {nameof(IReadOnlyDictionary<TKey, TValue>)}. Ignoring...");
         }
 

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/HashSetSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/HashSetSerializer.cs
@@ -22,6 +22,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
         ITypeCopyCreator<ImmutableHashSet<T>>,
         ITypeCopyCreator<FrozenSet<T>>
     {
+        private ISawmill? _sawmill;
+
         #region Read
 
         HashSet<T> ITypeReader<HashSet<T>, SequenceDataNode>.Read(ISerializationManager serializationManager,
@@ -46,8 +48,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
         {
             if (instanceProvider != null)
             {
-                var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
-                sawmill.Warning($"Provided value to a Read-call for a {nameof(FrozenSet<T>)}. Ignoring...");
+                _sawmill ??= dependencies.Resolve<ILogManager>().GetSawmill("szr");
+                _sawmill.Warning($"Provided value to a Read-call for a {nameof(FrozenSet<T>)}. Ignoring...");
             }
 
             var array = new T[node.Sequence.Count];
@@ -69,8 +71,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
         {
             if (instanceProvider != null)
             {
-                var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
-                sawmill.Warning($"Provided value to a Read-call for a {nameof(ImmutableHashSet<T>)}. Ignoring...");
+                _sawmill ??= dependencies.Resolve<ILogManager>().GetSawmill("szr");
+                _sawmill.Warning($"Provided value to a Read-call for a {nameof(ImmutableHashSet<T>)}. Ignoring...");
             }
             var set = ImmutableHashSet.CreateBuilder<T>();
 

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ListSerializers.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ListSerializers.cs
@@ -23,6 +23,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
         ITypeCopyCreator<IReadOnlyCollection<T>>,
         ITypeCopyCreator<ImmutableList<T>>
     {
+        private ISawmill? _sawmill;
+
         private DataNode WriteInternal(ISerializationManager serializationManager, IEnumerable<T> value, bool alwaysWrite = false,
             ISerializationContext? context = null)
         {
@@ -129,8 +131,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
         {
             if (instanceProvider != null)
             {
-                var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
-                sawmill.Warning($"Provided value to a Read-call for a {nameof(IReadOnlySet<T>)}. Ignoring...");
+                _sawmill ??= dependencies.Resolve<ILogManager>().GetSawmill("szr");
+                _sawmill.Warning($"Provided value to a Read-call for a {nameof(IReadOnlySet<T>)}. Ignoring...");
             }
 
             var list = new List<T>();
@@ -151,8 +153,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
         {
             if (instanceProvider != null)
             {
-                var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
-                sawmill.Warning($"Provided value to a Read-call for a {nameof(IReadOnlyCollection<T>)}. Ignoring...");
+                _sawmill ??= dependencies.Resolve<ILogManager>().GetSawmill("szr");
+                _sawmill.Warning($"Provided value to a Read-call for a {nameof(IReadOnlyCollection<T>)}. Ignoring...");
             }
 
             var list = new List<T>();
@@ -173,8 +175,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
         {
             if (instanceProvider != null)
             {
-                var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
-                sawmill.Warning($"Provided value to a Read-call for a {nameof(ImmutableList<T>)}. Ignoring...");
+                _sawmill ??= dependencies.Resolve<ILogManager>().GetSawmill("szr");
+                _sawmill.Warning($"Provided value to a Read-call for a {nameof(ImmutableList<T>)}. Ignoring...");
             }
 
             var list = ImmutableList.CreateBuilder<T>();

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ObjectSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ObjectSerializer.cs
@@ -13,18 +13,20 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
 [TypeSerializer]
 public sealed class ObjectSerializer : ITypeSerializer<object, ValueDataNode>, ITypeCopier<object>
 {
+    private IReflectionManager? _refMan;
+
     #region Validate
 
     public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
         IDependencyCollection dependencies, ISerializationContext? context = null)
     {
-        var reflection = dependencies.Resolve<IReflectionManager>();
+        _refMan ??= dependencies.Resolve<IReflectionManager>();
 
         if (node.Tag != null)
         {
             string? typeString = node.Tag[6..];
 
-            if (!reflection.TryLooseGetType(typeString, out var type))
+            if (!_refMan.TryLooseGetType(typeString, out var type))
             {
                 return new ErrorNode(node, $"Unable to find type for {typeString}");
             }
@@ -42,14 +44,14 @@ public sealed class ObjectSerializer : ITypeSerializer<object, ValueDataNode>, I
         SerializationHookContext hookCtx, ISerializationContext? context = null,
         ISerializationManager.InstantiationDelegate<object>? instanceProvider = null)
     {
-        var reflection = dependencies.Resolve<IReflectionManager>();
+        _refMan ??= dependencies.Resolve<IReflectionManager>();
         var value = instanceProvider != null ? instanceProvider() : new object();
 
         if (node.Tag != null)
         {
             string? typeString = node.Tag[6..];
 
-            if (!reflection.TryLooseGetType(typeString, out var type))
+            if (!_refMan.TryLooseGetType(typeString, out var type))
                 throw new NullReferenceException($"Found null type for {typeString}");
 
             value = serializationManager.Read(type, node, hookCtx, context);

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ProtoIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ProtoIdSerializer.cs
@@ -17,6 +17,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
 [TypeSerializer]
 public sealed class ProtoIdSerializer<T> : ITypeSerializer<ProtoId<T>, ValueDataNode>, ITypeCopyCreator<ProtoId<T>> where T : class, IPrototype
 {
+    private static IPrototypeManager? _proto;
+
     public ValidationNode Validate(ISerializationManager serialization, ValueDataNode node, IDependencyCollection dependencies, ISerializationContext? context = null)
     {
         return Validate(dependencies, node);
@@ -24,14 +26,14 @@ public sealed class ProtoIdSerializer<T> : ITypeSerializer<ProtoId<T>, ValueData
 
     public static ValidationNode Validate(IDependencyCollection deps, ValueDataNode node)
     {
-        var proto = deps.Resolve<IPrototypeManager>();
-        if (!proto.TryGetKindFrom<T>(out var kind))
+        _proto ??= deps.Resolve<IPrototypeManager>();
+        if (!_proto.TryGetKindFrom<T>(out var kind))
             return new ErrorNode(node, $"Unknown prototype kind: {typeof(T)}");
 
-        if (proto.IsIgnored(kind))
+        if (_proto.IsIgnored(kind))
             return new ErrorNode(node,$"Attempting to validate an ignored prototype: {typeof(T)}.\nDid you forget to remove the IPrototypeManager.RegisterIgnore(\"{kind}\") call when moving a prototype to Shared?");
 
-        if (proto.HasMapping<T>(node.Value))
+        if (_proto.HasMapping<T>(node.Value))
             return new ValidatedValueNode(node);
 
         return new ErrorNode(node, $"No {typeof(T)} found with id {node.Value}");

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/LocIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/LocIdSerializer.cs
@@ -16,10 +16,12 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations;
 [TypeSerializer]
 public sealed class LocIdSerializer : ITypeSerializer<LocId, ValueDataNode>, ITypeCopyCreator<LocId>
 {
+    private ILocalizationManager? _loc;
+
     public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node, IDependencyCollection dependencies, ISerializationContext? context = null)
     {
-        var loc = dependencies.Resolve<ILocalizationManager>();
-        if (loc.HasString(node.Value))
+        _loc ??= dependencies.Resolve<ILocalizationManager>();
+        if (_loc.HasString(node.Value))
             return new ValidatedValueNode(node);
 
         return new ErrorNode(node, $"No localization message found with id {node.Value}");

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/ResPathSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/ResPathSerializer.cs
@@ -16,6 +16,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations;
 [TypeSerializer]
 public sealed class ResPathSerializer : ITypeSerializer<ResPath, ValueDataNode>, ITypeCopyCreator<ResPath>
 {
+    private IResourceManager? _resMan;
+
     public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
         IDependencyCollection dependencies, ISerializationContext? context = null)
     {
@@ -35,16 +37,16 @@ public sealed class ResPathSerializer : ITypeSerializer<ResPath, ValueDataNode>,
 
         try
         {
-            var resourceManager = dependencies.Resolve<IResourceManager>();
+            _resMan ??= dependencies.Resolve<IResourceManager>();
             if (node.Value.EndsWith(ResPath.Separator))
             {
-                if (resourceManager.ContentGetDirectoryEntries(path).Any())
+                if (_resMan.ContentGetDirectoryEntries(path).Any())
                     return new ValidatedValueNode(node);
 
                 return new ErrorNode(node, $"Folder not found. ({path})");
             }
 
-            if (resourceManager.ContentFileExists(path))
+            if (_resMan.ContentFileExists(path))
                 return new ValidatedValueNode(node);
 
             return new ErrorNode(node, $"File not found. ({path})");

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/SpriteSpecifierSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/SpriteSpecifierSerializer.cs
@@ -29,6 +29,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
         // So I guess it might as well go here?
         public static readonly ResPath TextureRoot = new("/Textures");
 
+        private Prototypes.IPrototypeManager? _proto;
+
         Texture ITypeReader<Texture, ValueDataNode>.Read(ISerializationManager serializationManager,
             ValueDataNode node,
             IDependencyCollection dependencies,
@@ -102,7 +104,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             IDependencyCollection dependencies,
             ISerializationContext? context)
         {
-            return !dependencies.Resolve<Prototypes.IPrototypeManager>().HasIndex<Prototypes.EntityPrototype>(node.Value)
+            _proto ??= dependencies.Resolve<Prototypes.IPrototypeManager>();
+            return !_proto.HasIndex<Prototypes.EntityPrototype>(node.Value)
                 ? new ErrorNode(node, $"Invalid {nameof(EntityPrototype)} id")
                 : new ValidatedValueNode(node);
         }

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/TypeSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/TypeSerializer.cs
@@ -14,6 +14,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
     [TypeSerializer]
     public sealed class TypeSerializer : ITypeSerializer<Type, ValueDataNode>, ITypeCopyCreator<Type>
     {
+        private IReflectionManager? _refMan;
+
         private static readonly Dictionary<string, Type> Shortcuts = new ()
         {
             {"bool", typeof(bool)}
@@ -25,7 +27,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             if (Shortcuts.ContainsKey(node.Value))
                 return new ValidatedValueNode(node);
 
-            return dependencies.Resolve<IReflectionManager>().GetType(node.Value) == null
+            _refMan ??= dependencies.Resolve<IReflectionManager>();
+            return _refMan.GetType(node.Value) == null
                 ? new ErrorNode(node, $"Type '{node.Value}' not found.")
                 : new ValidatedValueNode(node);
         }
@@ -37,7 +40,8 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             if (Shortcuts.TryGetValue(node.Value, out var shortcutType))
                 return shortcutType;
 
-            var type = dependencies.Resolve<IReflectionManager>().GetType(node.Value);
+            _refMan ??= dependencies.Resolve<IReflectionManager>();
+            var type = _refMan.GetType(node.Value);
 
             return type == null
                 ? throw new InvalidMappingException($"Type '{node.Value}' not found.")


### PR DESCRIPTION
This is part PR, part technical question: is there any reason why TypeSerializers shouldn't cache their dependencies in private fields?

`Read`, `Validate`, etc. are passed a `DependencyCollection` as a parameter, but doing the Resolve in those collections still isn't free, and presumably due to the sheer number of times those methods are called, it starts to add up.

In my basic testing, this change reduces the runtime of content tests by 30 seconds. @deltanedas (who provided me with the patch used in this PR) reports saving 3 minutes of runtime on a fork with more map testing.

I do note that (with the exception of EntitySerializer/Deserializer) TypeSerializers don't seem to use class fields. I'm wondering if there's a reason for that, or if that's just how things happen to be.