### PR TITLE
Update .gitignore to ignore C# Dev Kit cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ MSBuild/Robust.Custom.targets
 release/
 Robust.Docfx/*-site
 Robust.Docfx/api
+
+# C# Dev Kit cache file
+*.lscache


### PR DESCRIPTION
Because Microsoft decided that it's a good idea to spam projects with tons of cached files that differ from system to system and are not even deterministic.

<img width="336" height="719" alt="grafik" src="https://github.com/user-attachments/assets/c1e5c572-3af5-45f0-947f-bc31e7e30996" />

See https://github.com/github/gitignore/pull/4839
