### PR TITLE
Change audio cvars to use InverseDistanceClamped by default

### DIFF
--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1221,7 +1221,7 @@ namespace Robust.Shared
             CVarDef.Create("audio.default_concurrent", 16, CVar.CLIENTONLY | CVar.ARCHIVE);
 
         public static readonly CVarDef<int> AudioAttenuation =
-            CVarDef.Create("audio.attenuation", (int) Attenuation.LinearDistanceClamped, CVar.REPLICATED | CVar.ARCHIVE);
+            CVarDef.Create("audio.attenuation", (int) Attenuation.InverseDistanceClamped, CVar.REPLICATED | CVar.ARCHIVE);
 
         /// <summary>
         /// Audio device to try to output audio to by default.
@@ -1255,7 +1255,7 @@ namespace Robust.Shared
             CVarDef.Create("audio.tick_rate", 30, CVar.CLIENTONLY);
 
         public static readonly CVarDef<float> AudioZOffset =
-            CVarDef.Create("audio.z_offset", -5f, CVar.REPLICATED);
+            CVarDef.Create("audio.z_offset", -2f, CVar.REPLICATED);
 
         /*
          * PLAYER


### PR DESCRIPTION
`InverseDistanceClamped` is essentially the standard that every game uses and so it makes sense for it to be the engine default.

I also adjusted the z_offset to compensate for the change. Things should sound a lot better now.

Also see:
https://github.com/space-wizards/space-station-14/issues/5156