### PR TITLE
Add strict flag for keybinds to prevent key binding clashes

### DIFF
--- a/Robust.Client/Input/IKeyBinding.cs
+++ b/Robust.Client/Input/IKeyBinding.cs
@@ -19,6 +19,8 @@ namespace Robust.Client.Input
         bool CanRepeat { get; }
         bool AllowSubCombs { get; }
 
+        bool Strict { get; }
+
         /// <summary>
         ///     For a <see cref="KeyBindingType.Command"/>-type binding,
         ///     whether the binding should activate if UI is focused.

--- a/Robust.Client/Input/IKeyBinding.cs
+++ b/Robust.Client/Input/IKeyBinding.cs
@@ -19,7 +19,7 @@ namespace Robust.Client.Input
         bool CanRepeat { get; }
         bool AllowSubCombs { get; }
 
-        bool Strict { get; }
+        bool StrictModifiers { get; }
 
         /// <summary>
         ///     For a <see cref="KeyBindingType.Command"/>-type binding,

--- a/Robust.Client/Input/IKeyBinding.cs
+++ b/Robust.Client/Input/IKeyBinding.cs
@@ -18,7 +18,6 @@ namespace Robust.Client.Input
         bool CanFocus { get; }
         bool CanRepeat { get; }
         bool AllowSubCombs { get; }
-
         bool StrictModifiers { get; }
 
         /// <summary>

--- a/Robust.Client/Input/InputDevices.cs
+++ b/Robust.Client/Input/InputDevices.cs
@@ -174,6 +174,7 @@ namespace Robust.Client.Input
             Pause,
             World1,
             CapsLock,
+            AltGr
         }
 
         public static bool IsMouseKey(this Key key)

--- a/Robust.Client/Input/InputDevices.cs
+++ b/Robust.Client/Input/InputDevices.cs
@@ -174,7 +174,6 @@ namespace Robust.Client.Input
             Pause,
             World1,
             CapsLock,
-            AltGr
         }
 
         public static bool IsMouseKey(this Key key)

--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Text;
+using Avalonia.Data;
 using JetBrains.Annotations;
 using Robust.Client.UserInterface;
 using Robust.Shared.Collections;
@@ -168,7 +169,8 @@ namespace Robust.Client.Input
                     Type = p.BindingType,
                     CanFocus = p.CanFocus,
                     CanRepeat = p.CanRepeat,
-                    AllowSubCombs = p.AllowSubCombs
+                    AllowSubCombs = p.AllowSubCombs,
+                    Strict = p.Strict
                 }).ToArray();
 
             var leaveEmpty = _modifiedKeyFunctions
@@ -252,7 +254,19 @@ namespace Robust.Client.Input
                         PackedContainsKey(binding.PackedKeyCombo, args.Key))
                     {
                         matchedCombo = binding.PackedKeyCombo;
-
+                        if (binding.Strict)
+                        {
+                            for (Key i=0; i<=Key.CapsLock; i++)
+                            {
+                                if ((i != binding.BaseKey ||
+                                    i != binding.Mod1 ||
+                                    i != binding.Mod2 ||
+                                    i != binding.Mod3) && _keysPressed[(byte)i] == true)
+                                {
+                                    return;
+                                }
+                            }
+                        }
                         bindsDown.Add(binding);
 
                         hasCanFocus |= binding.CanFocus;
@@ -597,7 +611,7 @@ namespace Robust.Client.Input
             Key baseKey, Key? mod1, Key? mod2, Key? mod3)
         {
             var binding = new KeyBinding(this, function.FunctionName, bindingType, baseKey, false, false, false,
-                0, true, mod1 ?? Key.Unknown, mod2 ?? Key.Unknown, mod3 ?? Key.Unknown);
+                0, true, false, mod1 ?? Key.Unknown, mod2 ?? Key.Unknown, mod3 ?? Key.Unknown);
 
             RegisterBinding(binding);
 
@@ -608,7 +622,7 @@ namespace Robust.Client.Input
             Key baseKey, Key? mod1, Key? mod2, Key? mod3)
         {
             var binding = new KeyBinding(this, function, bindingType, baseKey, false, false, false,
-                0, true, mod1 ?? Key.Unknown, mod2 ?? Key.Unknown, mod3 ?? Key.Unknown);
+                0, true, false, mod1 ?? Key.Unknown, mod2 ?? Key.Unknown, mod3 ?? Key.Unknown);
 
             RegisterBinding(binding);
 
@@ -618,7 +632,7 @@ namespace Robust.Client.Input
         public IKeyBinding RegisterBinding(in KeyBindingRegistration reg, bool markModified = true, bool invalid = false)
         {
             var binding = new KeyBinding(this, reg.Function.FunctionName, reg.Type, reg.BaseKey, reg.CanFocus, reg.CanRepeat,
-                reg.AllowSubCombs, reg.Priority, reg.CommandWhenUIFocused, reg.Mod1, reg.Mod2, reg.Mod3);
+                reg.AllowSubCombs, reg.Priority, reg.CommandWhenUIFocused, reg.Strict, reg.Mod1, reg.Mod2, reg.Mod3);
 
             RegisterBinding(binding, markModified);
 
@@ -792,13 +806,19 @@ namespace Robust.Client.Input
 
             [ViewVariables] public int Priority { get; internal set; }
 
+            /// <summary>
+            ///     Whether the Bound Key Combination works when ONLY the specified keys are pressed.
+            /// </summary>
+            [ViewVariables]
+            public bool Strict {get; internal set; }
+
             public KeyBinding(
                 InputManager inputManager,
                 string function,
                 KeyBindingType bindingType,
                 Key baseKey,
                 bool canFocus, bool canRepeat, bool allowSubCombs, int priority,
-                bool commandWhenUIFocused,
+                bool commandWhenUIFocused, bool strict,
                 Key mod1 = Key.Unknown,
                 Key mod2 = Key.Unknown,
                 Key mod3 = Key.Unknown)
@@ -810,6 +830,7 @@ namespace Robust.Client.Input
                 AllowSubCombs = allowSubCombs;
                 Priority = priority;
                 CommandWhenUIFocused = commandWhenUIFocused;
+                Strict = strict;
                 _inputManager = inputManager;
 
                 PackedKeyCombo = new PackedKeyCombo(baseKey, mod1, mod2, mod3);

--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -258,10 +258,10 @@ namespace Robust.Client.Input
                             var isStrict = true;
                             foreach (var key in Enum.GetValues<Key>())
                             {
-                                if ((key != binding.BaseKey ||
-                                    key != binding.Mod1 ||
-                                    key != binding.Mod2 ||
-                                    key != binding.Mod3) && _keysPressed[(byte)key] == true)
+                                if (key != binding.BaseKey &&
+                                    key != binding.Mod1 &&
+                                    key != binding.Mod2 &&
+                                    key != binding.Mod3 && _keysPressed[(int)key] == true)
                                 {
                                     isStrict = false;
                                     break;

--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -231,13 +231,6 @@ namespace Robust.Client.Input
 
             _keysPressed[(int)args.Key] = true;
 
-            if (_keysPressed[(int)Key.Alt] && _keysPressed[(int)Key.Control])
-            {
-                _keysPressed[(int)Key.Alt] = false;
-                _keysPressed[(int)Key.Control] = false;
-                _keysPressed[(int)Key.AltGr] = true;
-            }
-
             PackedKeyCombo matchedCombo = default;
 
             var bindsDown = new List<KeyBinding>();

--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -256,16 +256,20 @@ namespace Robust.Client.Input
                         matchedCombo = binding.PackedKeyCombo;
                         if (binding.Strict)
                         {
-                            for (Key i=0; i<=Key.CapsLock; i++)
+                            var isStrict = true;
+                            foreach (var key in Enum.GetValues<Key>())
                             {
-                                if ((i != binding.BaseKey ||
-                                    i != binding.Mod1 ||
-                                    i != binding.Mod2 ||
-                                    i != binding.Mod3) && _keysPressed[(byte)i] == true)
+                                if ((key != binding.BaseKey ||
+                                    key != binding.Mod1 ||
+                                    key != binding.Mod2 ||
+                                    key != binding.Mod3) && _keysPressed[(byte)key] == true)
                                 {
-                                    return;
+                                    isStrict = false;
+                                    break;
                                 }
                             }
+                            if (!isStrict)
+                                continue;
                         }
                         bindsDown.Add(binding);
 

--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -231,6 +231,13 @@ namespace Robust.Client.Input
 
             _keysPressed[(int)args.Key] = true;
 
+            if (_keysPressed[(int)Key.Alt] && _keysPressed[(int)Key.Control])
+            {
+                _keysPressed[(int)Key.Alt] = false;
+                _keysPressed[(int)Key.Control] = false;
+                _keysPressed[(int)Key.AltGr] = true;
+            }
+
             PackedKeyCombo matchedCombo = default;
 
             var bindsDown = new List<KeyBinding>();

--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -169,7 +169,7 @@ namespace Robust.Client.Input
                     CanFocus = p.CanFocus,
                     CanRepeat = p.CanRepeat,
                     AllowSubCombs = p.AllowSubCombs,
-                    Strict = p.Strict
+                    StrictModifiers = p.StrictModifiers
                 }).ToArray();
 
             var leaveEmpty = _modifiedKeyFunctions
@@ -253,15 +253,14 @@ namespace Robust.Client.Input
                         PackedContainsKey(binding.PackedKeyCombo, args.Key))
                     {
                         matchedCombo = binding.PackedKeyCombo;
-                        if (binding.Strict)
+                        if (binding.StrictModifiers)
                         {
                             var isStrict = true;
-                            foreach (var key in Enum.GetValues<Key>())
+                            for (Key i=Key.Control; i<Key.LSystem; i++)
                             {
-                                if (key != binding.BaseKey &&
-                                    key != binding.Mod1 &&
-                                    key != binding.Mod2 &&
-                                    key != binding.Mod3 && _keysPressed[(int)key] == true)
+                                if (i != binding.Mod1 &&
+                                    i != binding.Mod2 &&
+                                    i != binding.Mod3 && _keysPressed[(byte)i] == true)
                                 {
                                     isStrict = false;
                                     break;
@@ -635,7 +634,7 @@ namespace Robust.Client.Input
         public IKeyBinding RegisterBinding(in KeyBindingRegistration reg, bool markModified = true, bool invalid = false)
         {
             var binding = new KeyBinding(this, reg.Function.FunctionName, reg.Type, reg.BaseKey, reg.CanFocus, reg.CanRepeat,
-                reg.AllowSubCombs, reg.Priority, reg.CommandWhenUIFocused, reg.Strict, reg.Mod1, reg.Mod2, reg.Mod3);
+                reg.AllowSubCombs, reg.Priority, reg.CommandWhenUIFocused, reg.StrictModifiers, reg.Mod1, reg.Mod2, reg.Mod3);
 
             RegisterBinding(binding, markModified);
 
@@ -810,10 +809,10 @@ namespace Robust.Client.Input
             [ViewVariables] public int Priority { get; internal set; }
 
             /// <summary>
-            ///     Whether the Bound Key Combination works when ONLY the specified keys are pressed.
+            ///     Whether the Bound Key Combination works when ONLY the specified modifier keys are pressed (prevents altgr clashes).
             /// </summary>
             [ViewVariables]
-            public bool Strict {get; internal set; }
+            public bool StrictModifiers {get; internal set; }
 
             public KeyBinding(
                 InputManager inputManager,
@@ -821,7 +820,7 @@ namespace Robust.Client.Input
                 KeyBindingType bindingType,
                 Key baseKey,
                 bool canFocus, bool canRepeat, bool allowSubCombs, int priority,
-                bool commandWhenUIFocused, bool strict,
+                bool commandWhenUIFocused, bool strictModifiers,
                 Key mod1 = Key.Unknown,
                 Key mod2 = Key.Unknown,
                 Key mod3 = Key.Unknown)
@@ -833,7 +832,7 @@ namespace Robust.Client.Input
                 AllowSubCombs = allowSubCombs;
                 Priority = priority;
                 CommandWhenUIFocused = commandWhenUIFocused;
-                Strict = strict;
+                StrictModifiers = strictModifiers;
                 _inputManager = inputManager;
 
                 PackedKeyCombo = new PackedKeyCombo(baseKey, mod1, mod2, mod3);

--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Text;
-using Avalonia.Data;
 using JetBrains.Annotations;
 using Robust.Client.UserInterface;
 using Robust.Shared.Collections;

--- a/Robust.Client/Input/KeyBindingRegistration.cs
+++ b/Robust.Client/Input/KeyBindingRegistration.cs
@@ -33,5 +33,11 @@ namespace Robust.Client.Input
         /// </summary>
         [DataField]
         public bool CommandWhenUIFocused { get; set; } = true;
+
+        /// <summary>
+        /// See <see cref="KeyBinding.Strict"/> 
+        /// </summary>
+        [DataField]
+        public bool Strict = false;
     }
 }

--- a/Robust.Client/Input/KeyBindingRegistration.cs
+++ b/Robust.Client/Input/KeyBindingRegistration.cs
@@ -35,9 +35,9 @@ namespace Robust.Client.Input
         public bool CommandWhenUIFocused { get; set; } = true;
 
         /// <summary>
-        /// See <see cref="KeyBinding.Strict"/> 
+        /// See <see cref="KeyBinding.StrictModifiers"/> 
         /// </summary>
         [DataField]
-        public bool Strict = false;
+        public bool StrictModifiers = false;
     }
 }


### PR DESCRIPTION
Adds a `strictModifiers` flag for all keybinds, making it so a keybind with this flag will work only when the specified modifier keys are pressed.

Closes https://github.com/space-wizards/RobustToolbox/issues/6592