### PR TITLE
Cache Component names in `CompIdx`

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Helpers.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Helpers.cs
@@ -82,7 +82,7 @@ public sealed partial class SpriteSystem
     private IRsiStateLike GetPrototypeIconInternal(EntityPrototype prototype)
     {
         // IconComponent takes precedence. If it has a valid icon, return that. Otherwise, continue as normal.
-        if (prototype.TryGetComponent(out IconComponent? icon, _factory))
+        if (prototype.TryGetComponent(out IconComponent? icon))
             return GetIcon(icon);
 
         // If the prototype doesn't have a SpriteComponent, then there's nothing we can do but return the fallback.
@@ -108,7 +108,7 @@ public sealed partial class SpriteSystem
         var results = new List<IDirectionalTextureProvider>();
         noRot = false;
 
-        if (proto.TryGetComponent(out IconComponent? icon, _factory))
+        if (proto.TryGetComponent(out IconComponent? icon))
         {
             results.Add(GetIcon(icon));
             return results;

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
@@ -34,7 +34,6 @@ namespace Robust.Client.GameObjects
         [Dependency] private IPrototypeManager _proto = default!;
         [Dependency] private IResourceCache _resourceCache = default!;
         [Dependency] private ILogManager _logManager = default!;
-        [Dependency] private IComponentFactory _factory = default!;
 
         // Note that any new system dependencies have to be added to RobustUnitTest.BaseSetup()
         [Dependency] private SharedTransformSystem _xforms = default!;

--- a/Robust.Server/Placement/PlacementManager.cs
+++ b/Robust.Server/Placement/PlacementManager.cs
@@ -140,7 +140,7 @@ namespace Robust.Server.Placement
             {
                 // Replace existing entities if relevant.
                 if (msg.Replacement && _prototype.Index<EntityPrototype>(entityTemplateName).Components.TryGetValue(
-                        IComponentFactory.ComponentName<PlacementReplacementComponent>(), out var compRegistry))
+                        ComponentFactory.ComponentName<PlacementReplacementComponent>(), out var compRegistry))
                 {
                     var key = ((PlacementReplacementComponent)compRegistry.Component).Key;
                     var gridUid = _xformSystem.GetGrid(coordinates);

--- a/Robust.Server/Placement/PlacementManager.cs
+++ b/Robust.Server/Placement/PlacementManager.cs
@@ -140,7 +140,7 @@ namespace Robust.Server.Placement
             {
                 // Replace existing entities if relevant.
                 if (msg.Replacement && _prototype.Index<EntityPrototype>(entityTemplateName).Components.TryGetValue(
-                        _factory.GetComponentName<PlacementReplacementComponent>(), out var compRegistry))
+                        IComponentFactory.ComponentName<PlacementReplacementComponent>(), out var compRegistry))
                 {
                     var key = ((PlacementReplacementComponent)compRegistry.Component).Key;
                     var gridUid = _xformSystem.GetGrid(coordinates);

--- a/Robust.Shared/EntitySerialization/EntitySerializer.cs
+++ b/Robust.Shared/EntitySerialization/EntitySerializer.cs
@@ -169,8 +169,8 @@ public sealed partial class EntitySerializer : ISerializationContext,
         _log = _logMan.GetSawmill("entity_serializer");
         SerializerProvider.RegisterSerializer(this);
 
-        _metaName = IComponentFactory.ComponentName<MetaDataComponent>();
-        _xformName = IComponentFactory.ComponentName<TransformComponent>();
+        _metaName = ComponentFactory.ComponentName<MetaDataComponent>();
+        _xformName = ComponentFactory.ComponentName<TransformComponent>();
         _emptyMetaNode = _serialization.WriteValueAs<MappingDataNode>(typeof(MetaDataComponent), new MetaDataComponent(), alwaysWrite: true, context: this);
 
         CurrentComponent = _xformName;

--- a/Robust.Shared/EntitySerialization/EntitySerializer.cs
+++ b/Robust.Shared/EntitySerialization/EntitySerializer.cs
@@ -169,8 +169,8 @@ public sealed partial class EntitySerializer : ISerializationContext,
         _log = _logMan.GetSawmill("entity_serializer");
         SerializerProvider.RegisterSerializer(this);
 
-        _metaName = _factory.GetComponentName<MetaDataComponent>();
-        _xformName = _factory.GetComponentName<TransformComponent>();
+        _metaName = IComponentFactory.ComponentName<MetaDataComponent>();
+        _xformName = IComponentFactory.ComponentName<TransformComponent>();
         _emptyMetaNode = _serialization.WriteValueAs<MappingDataNode>(typeof(MetaDataComponent), new MetaDataComponent(), alwaysWrite: true, context: this);
 
         CurrentComponent = _xformName;

--- a/Robust.Shared/GameObjects/CompIdx.cs
+++ b/Robust.Shared/GameObjects/CompIdx.cs
@@ -14,6 +14,8 @@ public readonly struct CompIdx : IEquatable<CompIdx>
 
     internal static CompIdx Index<T>() => Store<T>.Index;
 
+    internal static string Name<T>() => Store<T>.Name;
+
     internal static int ArrayIndex<T>() => Index<T>().Value;
 
     internal static CompIdx GetIndex(Type type)
@@ -47,6 +49,7 @@ public readonly struct CompIdx : IEquatable<CompIdx>
     {
         // ReSharper disable once StaticMemberInGenericType
         public static readonly CompIdx Index = new(Interlocked.Increment(ref _CompIdxMaster));
+        public static readonly string Name = ComponentFactory.CalculateComponentName(typeof(T));
     }
 
     internal CompIdx(int value)

--- a/Robust.Shared/GameObjects/ComponentFactory.cs
+++ b/Robust.Shared/GameObjects/ComponentFactory.cs
@@ -340,8 +340,11 @@ namespace Robust.Shared.GameObjects
         [Pure]
         public string GetComponentName<T>() where T : IComponent, new()
         {
-            return IComponentFactory.ComponentName<T>();
+            return ComponentName<T>();
         }
+
+        [Pure]
+        public static string ComponentName<T>() where T : IComponent, new() => CompIdx.Name<T>();
 
         [Pure]
         public string GetComponentName(ushort netID)

--- a/Robust.Shared/GameObjects/ComponentFactory.cs
+++ b/Robust.Shared/GameObjects/ComponentFactory.cs
@@ -141,7 +141,7 @@ namespace Robust.Shared.GameObjects
             return registration;
         }
 
-        private static string CalculateComponentName(Type type)
+        internal static string CalculateComponentName(Type type)
         {
             // Attributes can use any name they want, they are for bypassing the automatic names
             // If a parent class has this attribute, a child class will use the same name, unless it also uses this attribute
@@ -340,7 +340,7 @@ namespace Robust.Shared.GameObjects
         [Pure]
         public string GetComponentName<T>() where T : IComponent, new()
         {
-            return GetRegistration<T>().Name;
+            return IComponentFactory.ComponentName<T>();
         }
 
         [Pure]

--- a/Robust.Shared/GameObjects/IComponentFactory.cs
+++ b/Robust.Shared/GameObjects/IComponentFactory.cs
@@ -183,9 +183,6 @@ namespace Robust.Shared.GameObjects
         [Obsolete("Use IComponentFactory.ComponentName<T>()")]
         string GetComponentName<T>() where T : IComponent, new();
 
-        [Pure]
-        static string ComponentName<T>() where T : IComponent, new() => CompIdx.Name<T>();
-
         /// <summary>
         ///     Gets the name of a component, throwing an exception if it does not exist.
         /// </summary>

--- a/Robust.Shared/GameObjects/IComponentFactory.cs
+++ b/Robust.Shared/GameObjects/IComponentFactory.cs
@@ -180,7 +180,11 @@ namespace Robust.Shared.GameObjects
         string GetComponentName(Type componentType);
 
         [Pure]
+        [Obsolete("Use IComponentFactory.ComponentName<T>()")]
         string GetComponentName<T>() where T : IComponent, new();
+
+        [Pure]
+        static string ComponentName<T>() where T : IComponent, new() => CompIdx.Name<T>();
 
         /// <summary>
         ///     Gets the name of a component, throwing an exception if it does not exist.

--- a/Robust.Shared/GameObjects/IEntityLoadContext.cs
+++ b/Robust.Shared/GameObjects/IEntityLoadContext.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
@@ -21,8 +22,19 @@ namespace Robust.Shared.GameObjects
         /// <param name="component">Found component or null.</param>
         /// <returns>True if the component was found, false otherwise.</returns>
         /// <seealso cref="TryGetComponent"/>
+        [Obsolete("Use the overload without IComponentFactory.")]
         bool TryGetComponent<TComponent>(
             IComponentFactory componentFactory,
+            [NotNullWhen(true)] out TComponent? component
+        ) where TComponent : class, IComponent, new()
+            => TryGetComponent(out component);
+
+        /// <summary>Tries getting the data of the given component.</summary>
+        /// <typeparam name="TComponent">Type of component to be found.</typeparam>
+        /// <param name="component">Found component or null.</param>
+        /// <returns>True if the component was found, false otherwise.</returns>
+        /// <seealso cref="TryGetComponent"/>
+        bool TryGetComponent<TComponent>(
             [NotNullWhen(true)] out TComponent? component
         ) where TComponent : class, IComponent, new();
 

--- a/Robust.Shared/Prototypes/EntProtoId.cs
+++ b/Robust.Shared/Prototypes/EntProtoId.cs
@@ -93,11 +93,11 @@ public readonly record struct EntProtoId<T>(string Id) : IEquatable<string>, ICo
 
     public override string ToString() => Id ?? string.Empty;
 
-    public T Get(IPrototypeManager? prototypes, IComponentFactory compFactory)
+    public T Get(IPrototypeManager? prototypes)
     {
         prototypes ??= IoCManager.Resolve<IPrototypeManager>();
         var proto = prototypes.Index(this);
-        if (!proto.TryGetComponent(out T? comp, compFactory))
+        if (!proto.TryGetComponent(out T? comp))
         {
             throw new ArgumentException($"{nameof(EntityPrototype)} {proto.ID} has no {nameof(T)}");
         }
@@ -105,11 +105,23 @@ public readonly record struct EntProtoId<T>(string Id) : IEquatable<string>, ICo
         return comp;
     }
 
-    public bool TryGet([NotNullWhen(true)] out T? comp, IPrototypeManager? prototypes, IComponentFactory compFactory)
+    [Obsolete("IComponentFactory parameter is no longer needed")]
+    public T Get(IPrototypeManager? prototypes, IComponentFactory compFactory)
+    {
+        return Get(prototypes);
+    }
+
+    public bool TryGet([NotNullWhen(true)] out T? comp, IPrototypeManager? prototypes)
     {
         comp = default;
         prototypes ??= IoCManager.Resolve<IPrototypeManager>();
         return prototypes.TryIndex(this, out var proto) &&
-               proto.TryGetComponent(out comp, compFactory);
+               proto.TryGetComponent(out comp);
+    }
+
+    [Obsolete("IComponentFactory parameter is no longer needed")]
+    public bool TryGet([NotNullWhen(true)] out T? comp, IPrototypeManager? prototypes, IComponentFactory compFactory)
+    {
+        return TryGet(out comp, prototypes);
     }
 }

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -171,7 +171,7 @@ namespace Robust.Shared.Prototypes
         public bool TryGetComponent<T>([NotNullWhen(true)] out T? component)
             where T : IComponent, new()
         {
-            var compName = IComponentFactory.ComponentName<T>();
+            var compName = ComponentFactory.ComponentName<T>();
             return TryGetComponent(compName, out component);
         }
 
@@ -183,7 +183,7 @@ namespace Robust.Shared.Prototypes
 
         public bool TryGetComponent<T>(string name, [NotNullWhen(true)] out T? component) where T : IComponent, new()
         {
-            DebugTools.AssertEqual(IComponentFactory.ComponentName<T>(), name);
+            DebugTools.AssertEqual(ComponentFactory.ComponentName<T>(), name);
 
             if (!Components.TryGetValue(name, out var componentUnCast))
             {
@@ -428,7 +428,7 @@ namespace Robust.Shared.Prototypes
         ) where TComponent : class, IComponent, new()
         {
             component = null;
-            var componentName = IComponentFactory.ComponentName<TComponent>();
+            var componentName = ComponentFactory.ComponentName<TComponent>();
             if (TryGetComponent(componentName, out var foundComponent))
             {
                 component = (TComponent)foundComponent;

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -423,7 +423,6 @@ namespace Robust.Shared.Prototypes
 
         /// <inheritdoc />
         public bool TryGetComponent<TComponent>(
-            IComponentFactory componentFactory,
             [NotNullWhen(true)] out TComponent? component
         ) where TComponent : class, IComponent, new()
         {

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -168,23 +168,22 @@ namespace Robust.Shared.Prototypes
             _loc = IoCManager.Resolve<ILocalizationManager>();
         }
 
-        [Obsolete("Pass in IComponentFactory")]
         public bool TryGetComponent<T>([NotNullWhen(true)] out T? component)
             where T : IComponent, new()
         {
-            var compName = IoCManager.Resolve<IComponentFactory>().GetComponentName<T>();
+            var compName = IComponentFactory.ComponentName<T>();
             return TryGetComponent(compName, out component);
         }
 
+        [Obsolete($"{nameof(IComponentFactory)} parameter is no longer needed")]
         public bool TryGetComponent<T>([NotNullWhen(true)] out T? component, IComponentFactory factory) where T : IComponent, new()
         {
-            var compName = factory.GetComponentName<T>();
-            return TryGetComponent(compName, out component);
+            return TryGetComponent(out component);
         }
 
         public bool TryGetComponent<T>(string name, [NotNullWhen(true)] out T? component) where T : IComponent, new()
         {
-            DebugTools.AssertEqual(IoCManager.Resolve<IComponentFactory>().GetComponentName<T>(), name);
+            DebugTools.AssertEqual(IComponentFactory.ComponentName<T>(), name);
 
             if (!Components.TryGetValue(name, out var componentUnCast))
             {
@@ -429,7 +428,7 @@ namespace Robust.Shared.Prototypes
         ) where TComponent : class, IComponent, new()
         {
             component = null;
-            var componentName = componentFactory.GetComponentName<TComponent>();
+            var componentName = IComponentFactory.ComponentName<TComponent>();
             if (TryGetComponent(componentName, out var foundComponent))
             {
                 component = (TComponent)foundComponent;

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
@@ -58,8 +58,6 @@ public sealed class EntProtoIdSerializer<T> : ITypeSerializer<EntProtoId<T>, Val
 
         if (!mapping.TryGet("components", out SequenceDataNode? components))
             return new ErrorNode(node, $"{nameof(EntityPrototype)} {node.Value} doesn't have a {typeof(T).Name}.");
-
-        var compFactory = dependencies.Resolve<IComponentFactory>();
         foreach (var componentNode in components)
         {
             if (componentNode is MappingDataNode component &&

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/EntProtoIdSerializer.cs
@@ -60,12 +60,11 @@ public sealed class EntProtoIdSerializer<T> : ITypeSerializer<EntProtoId<T>, Val
             return new ErrorNode(node, $"{nameof(EntityPrototype)} {node.Value} doesn't have a {typeof(T).Name}.");
 
         var compFactory = dependencies.Resolve<IComponentFactory>();
-        var registration = compFactory.GetRegistration<T>();
         foreach (var componentNode in components)
         {
             if (componentNode is MappingDataNode component &&
                 component.TryGet("type", out ValueDataNode? compName) &&
-                compName.Value == registration.Name)
+                compName.Value == CompIdx.Name<T>())
             {
                 return new ValidatedValueNode(node);
             }


### PR DESCRIPTION
Component names are now stored by `CompIdx` for fast, static lookup. This means that an `IComponentFactory` instance reference is no longer needed to do a component name lookup.

A new static `ComponentFactory.ComponentName<T>` method has been added for content to use. The non-static `IComponentFactory.GetComponentName<T>` has been marked obsolete and changed to call the static method.

Various uses of the old method in engine have been changed to use the new method, most notably `EntityPrototype`, where the single-parameter overload for `TryGetComponent<T>` is no longer marked obsolete, and the two-parameter overload (taking an `IComponentFactory` reference) now _is_ marked as obsolete. The few uses in engine have been cleaned up, but there are 90 more in content that will need (extremely easy) cleanup.

This should give a small improvement to performance, by removing the need to resolve `IComponentFactory` in a few places, and (very minimally) converting a dictionary lookup to a simple method call. 

The main benefit is the ability to use component names without needing an `IComponentFactory` instance. This simplifies test writing a bit, and makes the easiest way of writing a component check also the most performant way - there's no longer a need to locally cache component names when doing repeated lookups.

Currently, this is inefficient (because the name lookup needs to be done every iteration):
```cs
foreach (var entProto in entProtoList)
{
    if (entProto.TryGetComponent<MyComponent>(out var comp, _compFactory))
    {
        // etc.
    }
}
```
And this is more efficient, but a bit of a nuisance:
```cs
var compName = _compFactory.GetComponentName<MyComponent>();
foreach (var entProto in entProtoList)
{
    if (entProto.TryGetComponent(compName, out var comp))
    {
        // etc.
    }
}
```
But with this change, it can just be:
```cs
foreach (var entProto in entProtoList)
{
    if (entProto.TryGetComponent<MyComponent>(out var comp))
    {
        // etc.
    }
}
```

Also also, this enables content's `GameDataScrounger.EntitiesWithComponent` to be converted to a generic method instead of needing the target component's string name to be used as the parameter (which can't be validated).