### PR TITLE
Refactor BoxContainer, Expose New Properties

### DIFF
--- a/Robust.Client.IntegrationTests/UserInterface/Controls/BoxContainerTest.cs
+++ b/Robust.Client.IntegrationTests/UserInterface/Controls/BoxContainerTest.cs
@@ -5,6 +5,7 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Maths;
 using Robust.UnitTesting;
 using static Robust.Client.UserInterface.Controls.BoxContainer;
+using static Robust.Client.UserInterface.StylesheetHelpers;
 
 namespace Robust.Client.IntegrationTests.UserInterface.Controls;
 
@@ -87,9 +88,11 @@ public sealed class BoxContainerTest : RobustUnitTest
             MinSize = new Vector2(50, 30)
         };
         var control2 = new Control { MinSize = new Vector2(30, 50) };
+        var control3 = new Control { MinSize = new Vector2(30, 50), Visible = false };
 
         boxContainer.AddChild(control1);
         boxContainer.AddChild(control2);
+        boxContainer.AddChild(control3);
 
         boxContainer.Measure(new Vector2(100, 100));
 
@@ -198,5 +201,272 @@ public sealed class BoxContainerTest : RobustUnitTest
             Assert.That(boxContainer.GetChild(0).Width, Is.EqualTo(30));
             Assert.That(boxContainer.GetChild(1).Width, Is.EqualTo(70));
         }
+    }
+
+    [Test]
+    public void TestSeparationOverrides()
+    {
+        var boxContainer = new BoxContainer
+        {
+            SetSize = new Vector2(100, 10),
+        };
+        var child1 = new Control { SetSize = new Vector2(10, 10) };
+        var child2 = new Control { SetSize = new Vector2(10, 10) };
+        boxContainer.AddChild(child1);
+        boxContainer.AddChild(child2);
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+
+        Assert.That(boxContainer.IsArrangeValid, Is.True);
+
+        boxContainer.Stylesheet = new Stylesheet([
+            Element<BoxContainer>()
+                .Prop(StylePropertySeparation, 10)
+        ]);
+        boxContainer.ForceRunStyleUpdate();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(boxContainer.Separation, Is.EqualTo(10));
+            Assert.That(boxContainer.IsMeasureValid, Is.False);
+        }
+
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(child1.Position, Is.EqualTo(new Vector2(0, 0)));
+            Assert.That(child2.Position, Is.EqualTo(new Vector2(20, 0)));
+        }
+
+        boxContainer.Separation = 20;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(boxContainer.Separation, Is.EqualTo(20));
+            Assert.That(boxContainer.IsMeasureValid, Is.False);
+        }
+
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(child1.Position, Is.EqualTo(new Vector2(0, 0)));
+            Assert.That(child2.Position, Is.EqualTo(new Vector2(30, 0)));
+        }
+
+        boxContainer.Separation = 20;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(boxContainer.Separation, Is.EqualTo(20));
+            Assert.That(boxContainer.IsMeasureValid, Is.True);
+        }
+
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(child1.Position, Is.EqualTo(new Vector2(0, 0)));
+            Assert.That(child2.Position, Is.EqualTo(new Vector2(30, 0)));
+        }
+
+        boxContainer.Separation = null;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(boxContainer.Separation, Is.EqualTo(10));
+            Assert.That(boxContainer.IsMeasureValid, Is.False);
+        }
+
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(child1.Position, Is.EqualTo(new Vector2(0, 0)));
+            Assert.That(child2.Position, Is.EqualTo(new Vector2(20, 0)));
+        }
+
+        boxContainer.Stylesheet = new Stylesheet([]);
+        boxContainer.ForceRunStyleUpdate();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(boxContainer.Separation, Is.Zero);
+            Assert.That(boxContainer.IsMeasureValid, Is.False);
+        }
+
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(child1.Position, Is.EqualTo(new Vector2(0, 0)));
+            Assert.That(child2.Position, Is.EqualTo(new Vector2(10, 0)));
+        }
+    }
+
+    [Test]
+    public void TestAlignOverrides()
+    {
+        var boxContainer = new BoxContainer
+        {
+            SetSize = new Vector2(100, 10),
+        };
+        var child = new Control { SetSize = new Vector2(10, 10) };
+        boxContainer.AddChild(child);
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+
+        Assert.That(boxContainer.IsArrangeValid, Is.True);
+
+        boxContainer.Stylesheet = new Stylesheet([
+            Element<BoxContainer>()
+                .Prop(StylePropertyAlignMode, AlignMode.Center)
+        ]);
+        boxContainer.ForceRunStyleUpdate();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(boxContainer.Align, Is.EqualTo(AlignMode.Center));
+            Assert.That(boxContainer.IsArrangeValid, Is.False);
+        }
+
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+        Assert.That(child.Position, Is.EqualTo(new Vector2(45, 0)));
+
+        boxContainer.Align = AlignMode.End;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(boxContainer.Align, Is.EqualTo(AlignMode.End));
+            Assert.That(boxContainer.IsMeasureValid, Is.True);
+            Assert.That(boxContainer.IsArrangeValid, Is.False);
+        }
+
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+        Assert.That(child.Position, Is.EqualTo(new Vector2(90, 0)));
+
+        boxContainer.Align = AlignMode.End;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(boxContainer.Align, Is.EqualTo(AlignMode.End));
+            Assert.That(boxContainer.IsMeasureValid, Is.True);
+            Assert.That(boxContainer.IsArrangeValid, Is.True);
+        }
+
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+        Assert.That(child.Position, Is.EqualTo(new Vector2(90, 0)));
+
+        boxContainer.Align = (AlignMode)4;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(boxContainer.Align, Is.EqualTo((AlignMode)4));
+        }
+
+        Assert.Throws<ArgumentOutOfRangeException>( () => boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize)));
+
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+        Assert.That(child.Position, Is.EqualTo(new Vector2(90, 0)));
+
+        boxContainer.Align = null;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(boxContainer.Align, Is.EqualTo(AlignMode.Center));
+            Assert.That(boxContainer.IsMeasureValid, Is.True);
+            Assert.That(boxContainer.IsArrangeValid, Is.False);
+        }
+
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+        Assert.That(child.Position, Is.EqualTo(new Vector2(45, 0)));
+
+        boxContainer.Stylesheet = new Stylesheet([]);
+        boxContainer.ForceRunStyleUpdate();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(boxContainer.Align, Is.EqualTo(AlignMode.Begin));
+            Assert.That(boxContainer.IsArrangeValid, Is.False);
+        }
+
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+        Assert.That(child.Position, Is.EqualTo(new Vector2(0, 0)));
+    }
+
+    [Test]
+    public void TestOrientationOverrides()
+    {
+        var boxContainer = new BoxContainer
+        {
+            SetSize = new Vector2(100, 100),
+        };
+        var child = new Control { SetSize = new Vector2(10, 10) };
+        boxContainer.AddChild(child);
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+
+        Assert.That(boxContainer.IsArrangeValid, Is.True);
+
+        boxContainer.Stylesheet = new Stylesheet([
+            Element<BoxContainer>()
+                .Prop(StylePropertyOrientation, LayoutOrientation.Vertical)
+        ]);
+        boxContainer.ForceRunStyleUpdate();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(boxContainer.Orientation, Is.EqualTo(LayoutOrientation.Vertical));
+            Assert.That(boxContainer.IsMeasureValid, Is.False);
+        }
+
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+        Assert.That(child.Position, Is.EqualTo(new Vector2(45, 0)));
+
+        boxContainer.Orientation = LayoutOrientation.Horizontal;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(boxContainer.Orientation, Is.EqualTo(LayoutOrientation.Horizontal));
+            Assert.That(boxContainer.IsMeasureValid, Is.False);
+        }
+
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+        Assert.That(child.Position, Is.EqualTo(new Vector2(0, 45)));
+
+
+        boxContainer.Orientation = LayoutOrientation.Horizontal;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(boxContainer.Orientation, Is.EqualTo(LayoutOrientation.Horizontal));
+            Assert.That(boxContainer.IsMeasureValid, Is.True);
+        }
+
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+        Assert.That(child.Position, Is.EqualTo(new Vector2(0, 45)));
+
+        boxContainer.Orientation = null;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(boxContainer.Orientation, Is.EqualTo(LayoutOrientation.Vertical));
+            Assert.That(boxContainer.IsMeasureValid, Is.False);
+        }
+
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+        Assert.That(child.Position, Is.EqualTo(new Vector2(45, 0)));
+
+        boxContainer.Stylesheet = new Stylesheet([]);
+        boxContainer.ForceRunStyleUpdate();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(boxContainer.Orientation, Is.EqualTo(LayoutOrientation.Horizontal));
+            Assert.That(boxContainer.IsMeasureValid, Is.False);
+        }
+
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+        Assert.That(child.Position, Is.EqualTo(new Vector2(0, 45)));
+    }
+
+    [Test]
+    public void TestSeparationOverride()
+    {
+        var boxContainer = new BoxContainer
+        {
+            SetSize = new Vector2(100, 10),
+        };
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        boxContainer.SeparationOverride = 10;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        Assert.That(boxContainer.Separation, Is.EqualTo(10));
     }
 }

--- a/Robust.Client.IntegrationTests/UserInterface/Controls/BoxContainerTest.cs
+++ b/Robust.Client.IntegrationTests/UserInterface/Controls/BoxContainerTest.cs
@@ -117,12 +117,14 @@ public sealed class BoxContainerTest : RobustUnitTest
             VerticalExpand = true,
         };
         var control3 = new Control { MinSize = new Vector2(0, 50) };
+        var control4 = new Control { MinSize = new Vector2(0, 50), Visible = false };
 
         root.AddChild(boxContainer);
 
         boxContainer.AddChild(control1);
         boxContainer.AddChild(control3);
         boxContainer.AddChild(control2);
+        boxContainer.AddChild(control4);
 
         root.Arrange(new UIBox2(0, 0, 250, 250));
 
@@ -134,6 +136,8 @@ public sealed class BoxContainerTest : RobustUnitTest
             Assert.That(control3.Size, Is.EqualTo(new Vector2(30, 50)));
             Assert.That(control2.Position, Is.EqualTo(new Vector2(0, 65)));
             Assert.That(control2.Size, Is.EqualTo(new Vector2(30, 15)));
+            Assert.That(control4.Position, Is.EqualTo(new Vector2(0, 0)));
+            Assert.That(control4.Size, Is.EqualTo(new Vector2(0, 0)));
         }
     }
 
@@ -354,7 +358,8 @@ public sealed class BoxContainerTest : RobustUnitTest
             Assert.That(boxContainer.Align, Is.EqualTo((AlignMode)4));
         }
 
-        Assert.Throws<ArgumentOutOfRangeException>( () => boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize)));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize)));
 
         boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
         Assert.That(child.Position, Is.EqualTo(new Vector2(90, 0)));

--- a/Robust.Client.IntegrationTests/UserInterface/Controls/BoxContainerTest.cs
+++ b/Robust.Client.IntegrationTests/UserInterface/Controls/BoxContainerTest.cs
@@ -3,119 +3,128 @@ using NUnit.Framework;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Maths;
+using Robust.UnitTesting;
 using static Robust.Client.UserInterface.Controls.BoxContainer;
 
-namespace Robust.UnitTesting.Client.UserInterface.Controls
+namespace Robust.Client.IntegrationTests.UserInterface.Controls;
+
+[TestFixture]
+[TestOf(typeof(BoxContainer))]
+public sealed class BoxContainerTest : RobustUnitTest
 {
-    [TestFixture]
-    [TestOf(typeof(BoxContainer))]
-    public sealed class BoxContainerTest : RobustUnitTest
+    public override UnitTestProject Project => UnitTestProject.Client;
+
+    [Test]
+    public void TestLayoutBasic()
     {
-        public override UnitTestProject Project => UnitTestProject.Client;
-
-        [Test]
-        public void TestLayoutBasic()
+        var root = new LayoutContainer();
+        var boxContainer = new BoxContainer
         {
-            var root = new LayoutContainer();
-            var boxContainer = new BoxContainer
-            {
-                Orientation = LayoutOrientation.Vertical,
-                MinSize = new Vector2(50, 60)
-            };
-            var control1 = new Control {MinSize = new Vector2(20, 20)};
-            var control2 = new Control {MinSize = new Vector2(30, 30)};
+            Orientation = LayoutOrientation.Vertical,
+            MinSize = new Vector2(50, 60)
+        };
+        var control1 = new Control { MinSize = new Vector2(20, 20) };
+        var control2 = new Control { MinSize = new Vector2(30, 30) };
 
-            root.AddChild(boxContainer);
+        root.AddChild(boxContainer);
 
-            boxContainer.AddChild(control1);
-            boxContainer.AddChild(control2);
+        boxContainer.AddChild(control1);
+        boxContainer.AddChild(control2);
 
-            root.Arrange(new UIBox2(0, 0, 50, 60));
+        root.Arrange(new UIBox2(0, 0, 50, 60));
 
+        using (Assert.EnterMultipleScope())
+        {
             Assert.That(control1.Position, Is.EqualTo(Vector2.Zero));
             Assert.That(control1.Size, Is.EqualTo(new Vector2(50, 20)));
             Assert.That(control2.Position, Is.EqualTo(new Vector2(0, 20)));
             Assert.That(control2.Size, Is.EqualTo(new Vector2(50, 30)));
             Assert.That(boxContainer.DesiredSize, Is.EqualTo(new Vector2(50, 60)));
         }
+    }
 
-        [Test]
-        public void TestLayoutExpand()
+    [Test]
+    public void TestLayoutExpand()
+    {
+        var root = new LayoutContainer();
+        var boxContainer = new BoxContainer
         {
-            var root = new LayoutContainer();
-            var boxContainer = new BoxContainer
-            {
-                Orientation = LayoutOrientation.Vertical,
-                MinSize = new Vector2(50, 60)
-            };
-            var control1 = new Control
-            {
-                VerticalExpand = true
-            };
-            var control2 = new Control {MinSize = new Vector2(30, 30)};
+            Orientation = LayoutOrientation.Vertical,
+            MinSize = new Vector2(50, 60)
+        };
+        var control1 = new Control
+        {
+            VerticalExpand = true
+        };
+        var control2 = new Control { MinSize = new Vector2(30, 30) };
 
-            boxContainer.AddChild(control1);
-            boxContainer.AddChild(control2);
+        boxContainer.AddChild(control1);
+        boxContainer.AddChild(control2);
 
-            root.AddChild(boxContainer);
+        root.AddChild(boxContainer);
 
-            root.Arrange(new UIBox2(0, 0, 100, 100));
+        root.Arrange(new UIBox2(0, 0, 100, 100));
 
+        using (Assert.EnterMultipleScope())
+        {
             Assert.That(control1.Position, Is.EqualTo(Vector2.Zero));
             Assert.That(control1.Size, Is.EqualTo(new Vector2(50, 30)));
             Assert.That(control2.Position, Is.EqualTo(new Vector2(0, 30)));
             Assert.That(control2.Size, Is.EqualTo(new Vector2(50, 30)));
             Assert.That(boxContainer.DesiredSize, Is.EqualTo(new Vector2(50, 60)));
         }
+    }
 
-        [Test]
-        public void TestCalcMinSize()
+    [Test]
+    public void TestCalcMinSize()
+    {
+        var boxContainer = new BoxContainer
         {
-            var boxContainer = new BoxContainer
-            {
-                Orientation = LayoutOrientation.Vertical
-            };
-            var control1 = new Control
-            {
-                MinSize = new Vector2(50, 30)
-            };
-            var control2 = new Control {MinSize = new Vector2(30, 50)};
-
-            boxContainer.AddChild(control1);
-            boxContainer.AddChild(control2);
-
-            boxContainer.Measure(new Vector2(100, 100));
-
-            Assert.That(boxContainer.DesiredSize, Is.EqualTo(new Vector2(50, 80)));
-        }
-
-        [Test]
-        public void TestTwoExpand()
+            Orientation = LayoutOrientation.Vertical
+        };
+        var control1 = new Control
         {
-            var root = new LayoutContainer();
-            var boxContainer = new BoxContainer
-            {
-                Orientation = LayoutOrientation.Vertical,
-                MinSize = new Vector2(30, 80)
-            };
-            var control1 = new Control
-            {
-                VerticalExpand = true,
-            };
-            var control2 = new Control
-            {
-                VerticalExpand = true,
-            };
-            var control3 = new Control {MinSize = new Vector2(0, 50)};
+            MinSize = new Vector2(50, 30)
+        };
+        var control2 = new Control { MinSize = new Vector2(30, 50) };
 
-            root.AddChild(boxContainer);
+        boxContainer.AddChild(control1);
+        boxContainer.AddChild(control2);
 
-            boxContainer.AddChild(control1);
-            boxContainer.AddChild(control3);
-            boxContainer.AddChild(control2);
+        boxContainer.Measure(new Vector2(100, 100));
 
-            root.Arrange(new UIBox2(0, 0, 250, 250));
+        Assert.That(boxContainer.DesiredSize, Is.EqualTo(new Vector2(50, 80)));
+    }
 
+    [Test]
+    public void TestTwoExpand()
+    {
+        var root = new LayoutContainer();
+        var boxContainer = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            MinSize = new Vector2(30, 80)
+        };
+        var control1 = new Control
+        {
+            VerticalExpand = true,
+        };
+        var control2 = new Control
+        {
+            VerticalExpand = true,
+        };
+        var control3 = new Control { MinSize = new Vector2(0, 50) };
+
+        root.AddChild(boxContainer);
+
+        boxContainer.AddChild(control1);
+        boxContainer.AddChild(control3);
+        boxContainer.AddChild(control2);
+
+        root.Arrange(new UIBox2(0, 0, 250, 250));
+
+        using (Assert.EnterMultipleScope())
+        {
             Assert.That(control1.Position, Is.EqualTo(Vector2.Zero));
             Assert.That(control1.Size, Is.EqualTo(new Vector2(30, 15)));
             Assert.That(control3.Position, Is.EqualTo(new Vector2(0, 15)));
@@ -123,71 +132,71 @@ namespace Robust.UnitTesting.Client.UserInterface.Controls
             Assert.That(control2.Position, Is.EqualTo(new Vector2(0, 65)));
             Assert.That(control2.Size, Is.EqualTo(new Vector2(30, 15)));
         }
+    }
 
-        [Test]
-        public void TestTwoExpandRatio()
+    [Test]
+    public void TestTwoExpandRatio()
+    {
+        var boxContainer = new BoxContainer
         {
-            var boxContainer = new BoxContainer
+            Orientation = LayoutOrientation.Horizontal,
+            SetSize = new Vector2(100, 10),
+            Children =
             {
-                Orientation = LayoutOrientation.Horizontal,
-                SetSize = new Vector2(100, 10),
-                Children =
+                new Control
                 {
-                    new Control
-                    {
-                        MinWidth = 10,
-                        HorizontalExpand = true,
-                        SizeFlagsStretchRatio = 20,
-                    },
-                    new Control
-                    {
-                        MinWidth = 10,
-                        HorizontalExpand = true,
-                        SizeFlagsStretchRatio = 80
-                    }
+                    MinWidth = 10,
+                    HorizontalExpand = true,
+                    SizeFlagsStretchRatio = 20,
+                },
+                new Control
+                {
+                    MinWidth = 10,
+                    HorizontalExpand = true,
+                    SizeFlagsStretchRatio = 80
                 }
-            };
+            }
+        };
 
-            boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
 
-            Assert.Multiple(() =>
-            {
-                Assert.That(boxContainer.GetChild(0).Width, Is.EqualTo(20));
-                Assert.That(boxContainer.GetChild(1).Width, Is.EqualTo(80));
-            });
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(boxContainer.GetChild(0).Width, Is.EqualTo(20));
+            Assert.That(boxContainer.GetChild(1).Width, Is.EqualTo(80));
         }
+    }
 
-        [Test]
-        public void TestTwoExpandOneSmall()
+    [Test]
+    public void TestTwoExpandOneSmall()
+    {
+        var boxContainer = new BoxContainer
         {
-            var boxContainer = new BoxContainer
+            Orientation = LayoutOrientation.Horizontal,
+            SetSize = new Vector2(100, 10),
+            Children =
             {
-                Orientation = LayoutOrientation.Horizontal,
-                SetSize = new Vector2(100, 10),
-                Children =
+                new Control
                 {
-                    new Control
-                    {
-                        MinWidth = 30,
-                        HorizontalExpand = true,
-                        SizeFlagsStretchRatio = 20,
-                    },
-                    new Control
-                    {
-                        MinWidth = 30,
-                        HorizontalExpand = true,
-                        SizeFlagsStretchRatio = 80
-                    }
+                    MinWidth = 30,
+                    HorizontalExpand = true,
+                    SizeFlagsStretchRatio = 20,
+                },
+                new Control
+                {
+                    MinWidth = 30,
+                    HorizontalExpand = true,
+                    SizeFlagsStretchRatio = 80
                 }
-            };
+            }
+        };
 
-            boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
+        boxContainer.Arrange(UIBox2.FromDimensions(Vector2.Zero, boxContainer.SetSize));
 
-            Assert.Multiple(() =>
-            {
-                Assert.That(boxContainer.GetChild(0).Width, Is.EqualTo(30));
-                Assert.That(boxContainer.GetChild(1).Width, Is.EqualTo(70));
-            });
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(boxContainer.GetChild(0).Width, Is.EqualTo(30));
+            Assert.That(boxContainer.GetChild(1).Width, Is.EqualTo(70));
         }
     }
 }

--- a/Robust.Client.IntegrationTests/UserInterface/Controls/BoxContainerTest.cs
+++ b/Robust.Client.IntegrationTests/UserInterface/Controls/BoxContainerTest.cs
@@ -458,15 +458,21 @@ public sealed class BoxContainerTest : RobustUnitTest
     [Test]
     public void TestSeparationOverride()
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         var boxContainer = new BoxContainer
         {
             SetSize = new Vector2(100, 10),
         };
 
-#pragma warning disable CS0618 // Type or member is obsolete
         boxContainer.SeparationOverride = 10;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(boxContainer.Separation, Is.EqualTo(10));
+            // Evil
+            Assert.That(
+                typeof(BoxContainer).GetProperty(nameof(boxContainer.SeparationOverride))!.GetValue(boxContainer),
+                Is.EqualTo(10));
+        }
 #pragma warning restore CS0618 // Type or member is obsolete
-
-        Assert.That(boxContainer.Separation, Is.EqualTo(10));
     }
 }

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -151,17 +151,47 @@ public class BoxContainer : Container
         }
     }
 
-    private int ActualSeparation =>
-        SeparationOverride ?? StylePropertyDefault(StylePropertySeparation, 0);
-
-    public int? SeparationOverride
+    /// <summary>
+    /// The separation/gap between the child elements along the major axis.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// &lt;BoxContainer Separation="2"&gt;
+    ///     &lt;Label Text="Left" /&gt;
+    ///     &lt;Label Text="Right" /&gt;
+    /// &lt;/BoxContainer&gt;
+    /// </code>
+    /// <code>
+    /// var container = new BoxContainer
+    /// {
+    ///     Separation = 2,
+    ///     Children =
+    ///     {
+    ///         new Label { Text = "Left" },
+    ///         new Label { Text = "Right" }
+    ///     },
+    /// };
+    /// </code>
+    /// </example>
+    /// <param name="value">Overrides <see cref="StylePropertySeparation" /> and the default, 0, if non-null.</param>
+    [NotNull]
+    public int? Separation
     {
         get;
         set
         {
-            field = value;
+            field = value ?? StylePropertyDefault(StylePropertySeparation, 0);
+
             InvalidateMeasure();
         }
+    }
+
+    /// <seealso cref="Separation"/>
+    [Obsolete("Use BoxContainer.Separation directly instead.")]
+    public int? SeparationOverride
+    {
+        get => Separation;
+        set => Separation = value;
     }
 
     protected override Vector2 MeasureOverride(Vector2 availableSize)
@@ -181,7 +211,7 @@ public class BoxContainer : Container
         availableSize = TAxis.SizeToAxis(availableSize);
 
         // Account for separation.
-        var separation = ActualSeparation * (Children.Where(c => c.Visible).Count() - 1);
+        var separation = Separation.Value * (Children.Where(c => c.Visible).Count() - 1);
         var desiredSize = new Vector2(separation, 0);
         availableSize.X = Math.Max(0, availableSize.X) - separation;
 
@@ -205,7 +235,7 @@ public class BoxContainer : Container
 
     protected override Vector2 ArrangeOverride(Vector2 finalSize)
     {
-        var separation = ActualSeparation;
+        var separation = Separation.Value;
 
         if (Orientation == LayoutOrientation.Vertical)
         {

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -4,264 +4,264 @@ using System.Linq;
 using System.Numerics;
 using Robust.Shared.Maths;
 
-namespace Robust.Client.UserInterface.Controls
+namespace Robust.Client.UserInterface.Controls;
+
+/// <summary>
+///     A container that lays out its children sequentially.
+/// </summary>
+[Virtual]
+public class BoxContainer : Container
 {
+    private LayoutOrientation _orientation;
+    public const string StylePropertySeparation = "separation";
+
+    private const int DefaultSeparation = 0;
+
     /// <summary>
-    ///     A container that lays out its children sequentially.
+    /// Specifies the alignment of the controls <b>along the orientation axis.</b>
     /// </summary>
-    [Virtual]
-    public class BoxContainer : Container
+    /// <remarks>
+    /// This is along the orientation axis, not cross to it.
+    /// This means that if your orientation is vertical and you set this to center,
+    /// your controls will be laid out in the vertical <i>center</i> of the box control instead of the top.
+    /// </remarks>
+    public AlignMode Align { get; set; }
+
+    public LayoutOrientation Orientation
     {
-        private LayoutOrientation _orientation;
-        public const string StylePropertySeparation = "separation";
-
-        private const int DefaultSeparation = 0;
-
-        /// <summary>
-        /// Specifies the alignment of the controls <b>along the orientation axis.</b>
-        /// </summary>
-        /// <remarks>
-        /// This is along the orientation axis, not cross to it.
-        /// This means that if your orientation is vertical and you set this to center,
-        /// your controls will be laid out in the vertical <i>center</i> of the box control instead of the top.
-        /// </remarks>
-        public AlignMode Align { get; set; }
-
-        public LayoutOrientation Orientation
+        get => _orientation;
+        set
         {
-            get => _orientation;
-            set
-            {
-                _orientation = value;
-                InvalidateMeasure();
-            }
+            _orientation = value;
+            InvalidateMeasure();
+        }
+    }
+
+    private int ActualSeparation =>
+        SeparationOverride ?? StylePropertyDefault(StylePropertySeparation, DefaultSeparation);
+
+    public int? SeparationOverride
+    {
+        get;
+        set
+        {
+            field = value;
+            InvalidateMeasure();
+        }
+    }
+
+    protected override Vector2 MeasureOverride(Vector2 availableSize)
+    {
+        if (Orientation == LayoutOrientation.Vertical)
+        {
+            return MeasureItems<VerticalAxis>(availableSize);
+        }
+        else
+        {
+            return MeasureItems<HorizontalAxis>(availableSize);
+        }
+    }
+
+    private Vector2 MeasureItems<TAxis>(Vector2 availableSize) where TAxis : IAxisImplementation
+    {
+        availableSize = TAxis.SizeToAxis(availableSize);
+
+        // Account for separation.
+        var separation = ActualSeparation * (Children.Where(c => c.Visible).Count() - 1);
+        var desiredSize = new Vector2(separation, 0);
+        availableSize.X = Math.Max(0, availableSize.X) - separation;
+
+        // First, we measure non-stretching children.
+        foreach (var child in Children)
+        {
+            if (!child.Visible)
+                continue;
+
+            child.Measure(TAxis.SizeFromAxis(availableSize));
+            var childDesired = TAxis.SizeToAxis(child.DesiredSize);
+
+            desiredSize.X += childDesired.X;
+            desiredSize.Y = Math.Max(desiredSize.Y, childDesired.Y);
+
+            availableSize.X = Math.Max(0, availableSize.X - childDesired.X);
         }
 
-        private int ActualSeparation =>
-            SeparationOverride ?? StylePropertyDefault(StylePropertySeparation, DefaultSeparation);
+        return TAxis.SizeFromAxis(desiredSize);
+    }
 
-        public int? SeparationOverride
+    protected override Vector2 ArrangeOverride(Vector2 finalSize)
+    {
+        var separation = ActualSeparation;
+
+        if (Orientation == LayoutOrientation.Vertical)
         {
-            get;
-            set
-            {
-                field = value;
-                InvalidateMeasure();
-            }
+            LayOutItems<VerticalAxis>(default, finalSize, Align, Children, 0, ChildCount, separation);
+        }
+        else
+        {
+            LayOutItems<HorizontalAxis>(default, finalSize, Align, Children, 0, ChildCount, separation);
         }
 
-        protected override Vector2 MeasureOverride(Vector2 availableSize)
+        return finalSize;
+    }
+
+    internal static void LayOutItems<TAxis>(
+        Vector2 baseOffset,
+        Vector2 finalSize,
+        AlignMode align,
+        OrderedChildCollection children,
+        int start,
+        int end,
+        float separation,
+        Vector2? fixedSize = null)
+        where TAxis : IAxisImplementation
+    {
+        var realFinalSize = finalSize;
+        finalSize = TAxis.SizeToAxis(finalSize);
+        fixedSize = fixedSize == null ? null : TAxis.SizeToAxis(fixedSize.Value);
+
+        var visibleChildCount = 0;
+        for (var i = start; i < end; i++)
         {
-            if (Orientation == LayoutOrientation.Vertical)
+            if (children[i].Visible)
+                visibleChildCount += 1;
+        }
+
+        var stretchAvail = finalSize.X;
+        stretchAvail -= separation * (visibleChildCount - 1);
+        stretchAvail = Math.Max(0, stretchAvail);
+
+        // Step one: figure out the sizes of all our children and whether they want to stretch.
+        var sizeList = new List<(Control control, float size, bool stretch)>(visibleChildCount);
+        var totalStretchRatio = 0f;
+        for (var i = start; i < end; i++)
+        {
+            var child = children[i];
+            if (!child.Visible)
+                continue;
+
+            bool stretch = TAxis.GetMainExpandFlag(child);
+            if (!stretch)
             {
-                return MeasureItems<VerticalAxis>(availableSize);
+                var measuredSize = fixedSize ?? TAxis.SizeToAxis(child.DesiredSize);
+                var size = measuredSize.X;
+                size = Math.Clamp(size, 0, stretchAvail);
+                stretchAvail -= size;
+                sizeList.Add((child, size, false));
             }
             else
             {
-                return MeasureItems<HorizontalAxis>(availableSize);
+                totalStretchRatio += child.SizeFlagsStretchRatio;
+                sizeList.Add((child, 0, true));
             }
         }
 
-        private Vector2 MeasureItems<TAxis>(Vector2 availableSize) where TAxis : IAxisImplementation
+        stretchAvail = Math.Max(0, stretchAvail);
+
+        // Step two: allocate space for all the stretchable children.
+        float offset = 0;
+        var anyStretch = totalStretchRatio > 0;
+        if (anyStretch)
         {
-            availableSize = TAxis.SizeToAxis(availableSize);
-
-            // Account for separation.
-            var separation = ActualSeparation * (Children.Where(c => c.Visible).Count() - 1);
-            var desiredSize = new Vector2(separation, 0);
-            availableSize.X = Math.Max(0, availableSize.X) - separation;
-
-            // First, we measure non-stretching children.
-            foreach (var child in Children)
+            // We will treat stretching children that fail to reach their desired size as non-stretching.
+            // This then requires all stretching children to be re-stretched
+            bool stretchAvailChanged = true;
+            while (stretchAvailChanged)
             {
-                if (!child.Visible)
-                    continue;
-
-                child.Measure(TAxis.SizeFromAxis(availableSize));
-                var childDesired = TAxis.SizeToAxis(child.DesiredSize);
-
-                desiredSize.X += childDesired.X;
-                desiredSize.Y = Math.Max(desiredSize.Y, childDesired.Y);
-
-                availableSize.X = Math.Max(0, availableSize.X - childDesired.X);
-            }
-
-            return TAxis.SizeFromAxis(desiredSize);
-        }
-
-        protected override Vector2 ArrangeOverride(Vector2 finalSize)
-        {
-            var separation = ActualSeparation;
-
-            if (Orientation == LayoutOrientation.Vertical)
-            {
-                LayOutItems<VerticalAxis>(default, finalSize, Align, Children, 0, ChildCount, separation);
-            }
-            else
-            {
-                LayOutItems<HorizontalAxis>(default, finalSize, Align, Children, 0, ChildCount, separation);
-            }
-
-            return finalSize;
-        }
-
-        internal static void LayOutItems<TAxis>(
-            Vector2 baseOffset,
-            Vector2 finalSize,
-            AlignMode align,
-            OrderedChildCollection children,
-            int start,
-            int end,
-            float separation,
-            Vector2? fixedSize = null)
-            where TAxis : IAxisImplementation
-        {
-            var realFinalSize = finalSize;
-            finalSize = TAxis.SizeToAxis(finalSize);
-            fixedSize = fixedSize == null ? null : TAxis.SizeToAxis(fixedSize.Value);
-
-            var visibleChildCount = 0;
-            for (var i = start; i < end; i++)
-            {
-                if (children[i].Visible)
-                    visibleChildCount += 1;
-            }
-
-            var stretchAvail = finalSize.X;
-            stretchAvail -= separation * (visibleChildCount - 1);
-            stretchAvail = Math.Max(0, stretchAvail);
-
-            // Step one: figure out the sizes of all our children and whether they want to stretch.
-            var sizeList = new List<(Control control, float size, bool stretch)>(visibleChildCount);
-            var totalStretchRatio = 0f;
-            for (var i = start; i < end; i++)
-            {
-                var child = children[i];
-                if (!child.Visible)
-                    continue;
-
-                bool stretch = TAxis.GetMainExpandFlag(child);
-                if (!stretch)
+                stretchAvailChanged = false;
+                for (var i = 0; i < sizeList.Count; i++)
                 {
-                    var measuredSize = fixedSize ?? TAxis.SizeToAxis(child.DesiredSize);
-                    var size = measuredSize.X;
-                    size = Math.Clamp(size, 0, stretchAvail);
-                    stretchAvail -= size;
-                    sizeList.Add((child, size, false));
-                }
-                else
-                {
-                    totalStretchRatio += child.SizeFlagsStretchRatio;
-                    sizeList.Add((child, 0, true));
-                }
-            }
-            stretchAvail = Math.Max(0, stretchAvail);
+                    var (control, _, stretch) = sizeList[i];
+                    if (!stretch)
+                        continue;
 
-            // Step two: allocate space for all the stretchable children.
-            float offset = 0;
-            var anyStretch = totalStretchRatio > 0;
-            if (anyStretch)
-            {
-                // We will treat stretching children that fail to reach their desired size as non-stretching.
-                // This then requires all stretching children to be re-stretched
-                bool stretchAvailChanged = true;
-                while (stretchAvailChanged)
-                {
-                    stretchAvailChanged = false;
-                    for (var i = 0; i < sizeList.Count; i++)
+                    var share = stretchAvail * control.SizeFlagsStretchRatio / totalStretchRatio;
+                    var measuredSize = fixedSize ?? TAxis.SizeToAxis(control.DesiredSize);
+                    var desired = measuredSize.X;
+                    if (share >= desired)
                     {
-                        var (control, _, stretch) = sizeList[i];
-                        if (!stretch)
-                            continue;
-
-                        var share = stretchAvail * control.SizeFlagsStretchRatio / totalStretchRatio;
-                        var measuredSize = fixedSize ?? TAxis.SizeToAxis(control.DesiredSize);
-                        var desired = measuredSize.X;
-                        if (share >= desired)
-                        {
-                            sizeList[i] = (control, share, true);
-                            continue;
-                        }
-
-                        // Insufficient space -> treat as non-stretching.
-                        sizeList[i] = (control, Math.Min(stretchAvail, desired), false);
-                        stretchAvail = Math.Max(0, stretchAvail - desired);
-                        totalStretchRatio -= control.SizeFlagsStretchRatio;
-                        stretchAvailChanged = true;
+                        sizeList[i] = (control, share, true);
+                        continue;
                     }
+
+                    // Insufficient space -> treat as non-stretching.
+                    sizeList[i] = (control, Math.Min(stretchAvail, desired), false);
+                    stretchAvail = Math.Max(0, stretchAvail - desired);
+                    totalStretchRatio -= control.SizeFlagsStretchRatio;
+                    stretchAvailChanged = true;
                 }
-            }
-            else
-            {
-                // No stretching children -> offset the children based on the alignment.
-                switch (align)
-                {
-                    case AlignMode.Begin:
-                        break;
-                    case AlignMode.Center:
-                        offset = stretchAvail / 2;
-                        break;
-                    case AlignMode.End:
-                        offset = stretchAvail;
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-            }
-
-            // Step three: actually lay them out one by one.
-            var first = true;
-            foreach (var (control, size, _) in sizeList)
-            {
-                if (!first)
-                {
-                    offset += separation;
-                }
-
-                first = false;
-
-                var targetBox = TAxis.BoxFromAxis(new UIBox2(offset, 0, offset + size, finalSize.Y), realFinalSize);
-
-                targetBox = targetBox.Translated(baseOffset);
-
-                control.Arrange(targetBox);
-
-                offset += size;
             }
         }
-
-        public enum AlignMode : byte
+        else
         {
-            /// <summary>
-            ///     Controls are laid out from the begin of the box container.
-            /// </summary>
-            Begin = 0,
-
-            /// <summary>
-            ///     Controls are laid out from the center of the box container.
-            /// </summary>
-            Center = 1,
-
-            /// <summary>
-            ///     Controls are laid out from the end of the box container.
-            /// </summary>
-            End = 2
+            // No stretching children -> offset the children based on the alignment.
+            switch (align)
+            {
+                case AlignMode.Begin:
+                    break;
+                case AlignMode.Center:
+                    offset = stretchAvail / 2;
+                    break;
+                case AlignMode.End:
+                    offset = stretchAvail;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
         }
+
+        // Step three: actually lay them out one by one.
+        var first = true;
+        foreach (var (control, size, _) in sizeList)
+        {
+            if (!first)
+            {
+                offset += separation;
+            }
+
+            first = false;
+
+            var targetBox = TAxis.BoxFromAxis(new UIBox2(offset, 0, offset + size, finalSize.Y), realFinalSize);
+
+            targetBox = targetBox.Translated(baseOffset);
+
+            control.Arrange(targetBox);
+
+            offset += size;
+        }
+    }
+
+    public enum AlignMode : byte
+    {
+        /// <summary>
+        ///     Controls are laid out from the begin of the box container.
+        /// </summary>
+        Begin = 0,
 
         /// <summary>
-        /// Orientation for a box container.
+        ///     Controls are laid out from the center of the box container.
         /// </summary>
-        public enum LayoutOrientation : byte
-        {
-            /// <summary>
-            /// Controls are laid out horizontally, left to right.
-            /// </summary>
-            Horizontal,
+        Center = 1,
 
-            /// <summary>
-            /// Controls are laid out vertically, top to bottom.
-            /// </summary>
-            Vertical
-        }
+        /// <summary>
+        ///     Controls are laid out from the end of the box container.
+        /// </summary>
+        End = 2
+    }
+
+    /// <summary>
+    /// Orientation for a box container.
+    /// </summary>
+    public enum LayoutOrientation : byte
+    {
+        /// <summary>
+        /// Controls are laid out horizontally, left to right.
+        /// </summary>
+        Horizontal,
+
+        /// <summary>
+        /// Controls are laid out vertically, top to bottom.
+        /// </summary>
+        Vertical
     }
 }

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -30,7 +30,7 @@ namespace Robust.Client.UserInterface.Controls;
 /// </code>
 /// </example>
 /// <remarks>
-/// Use <see cref="WrapContainer"/> if you need wrapping along a minor axis.
+/// Use <see cref="WrapContainer"/> if you need wrapping along a cross axis.
 /// </remarks>
 [Virtual]
 public class BoxContainer : Container

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -81,8 +81,6 @@ public class BoxContainer : Container
     /// </remarks>
     public const string StylePropertyAlignMode = "align-mode";
 
-    private const int DefaultSeparation = 0;
-
     /// <summary>
     /// Specifies the alignment of the controls <b>along the orientation axis.</b>
     /// </summary>
@@ -104,7 +102,7 @@ public class BoxContainer : Container
     }
 
     private int ActualSeparation =>
-        SeparationOverride ?? StylePropertyDefault(StylePropertySeparation, DefaultSeparation);
+        SeparationOverride ?? StylePropertyDefault(StylePropertySeparation, 0);
 
     public int? SeparationOverride
     {

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -117,20 +117,36 @@ public class BoxContainer : Container
     }
 
     /// <summary>
-    /// Specifies the alignment of the controls <b>along the orientation axis.</b>
+    /// The orientation of the major axis that child controls are laid down along.
     /// </summary>
-    /// <remarks>
-    /// This is along the orientation axis, not cross to it.
-    /// This means that if your orientation is vertical and you set this to center,
-    /// your controls will be laid out in the vertical <i>center</i> of the box control instead of the top.
-    /// </remarks>
-
-    public LayoutOrientation Orientation
+    /// <example>
+    /// <code>
+    /// &lt;BoxContainer Orientation="Vertical"&gt;
+    ///     &lt;Label Text="Above" /&gt;
+    ///     &lt;Label Text="Below" /&gt;
+    /// &lt;/BoxContainer&gt;
+    /// </code>
+    /// <code>
+    /// var container = new BoxContainer
+    /// {
+    ///     Orientation = LayoutOrientation.Vertical,
+    ///     Children =
+    ///     {
+    ///         new Label { Text = "Above" },
+    ///         new Label { Text = "Below" }
+    ///     },
+    /// };
+    /// </code>
+    /// </example>
+    /// <param name="value">Overrides <see cref="StylePropertyOrientation" /> and the default, <see cref="LayoutOrientation.Horizontal" />, if non-null.</param>
+    [NotNull]
+    public LayoutOrientation? Orientation
     {
         get;
         set
         {
-            field = value;
+            field = value ?? StylePropertyDefault(StylePropertyOrientation, LayoutOrientation.Horizontal);
+
             InvalidateMeasure();
         }
     }

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -199,10 +199,20 @@ public class BoxContainer : Container
         }
     }
 
-    /// <seealso cref="Separation"/>
+    /// <summary>
+    /// Overrides the separation between children.
+    /// </summary>
+    /// <remark>
+    /// Use <see cref="Separation"/> instead.
+    /// </remark>
+    /// <remark>
+    /// Checking the nullability of this value no longer tells if it has been overridden or not, as the value is NotNull.
+    /// </remark>
     [Obsolete("Use BoxContainer.Separation directly instead.")]
+    [NotNull]
     public int? SeparationOverride
     {
+        [Obsolete("This is now NotNull and cannot be used to test for overridden separation. Switch to BoxContainer.Separation.", true)]
         get => Separation;
         set => Separation = value;
     }

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -8,7 +8,7 @@ using Robust.Shared.Maths;
 namespace Robust.Client.UserInterface.Controls;
 
 /// <summary>
-/// A container that lays its children out sequentially along a major axis, <see cref="Orientation"/>.
+/// A container that lays its children out sequentially along a main axis, <see cref="Orientation"/>.
 /// </summary>
 /// <example>
 /// <code>
@@ -51,7 +51,7 @@ public class BoxContainer : Container
     public const string StylePropertySeparation = "separation";
 
     /// <summary>
-    /// Style property modifying <see cref="Orientation"/>, which decides the major axis for children to be laid out on.
+    /// Style property modifying <see cref="Orientation"/>, which decides the main axis for children to be laid out on.
     /// </summary>
     /// <example>
     /// <code>
@@ -65,7 +65,7 @@ public class BoxContainer : Container
     public const string StylePropertyOrientation = "orientation";
 
     /// <summary>
-    /// Style property modifying <see cref="Align"/>, which decides how to layout children along the major axis when there is extra space.
+    /// Style property modifying <see cref="Align"/>, which decides how to layout children along the main axis when there is extra space.
     /// </summary>
     /// <example>
     /// If the Orientation is Vertical and Align is Center, it will align children to the center of the vertical axis.
@@ -77,7 +77,7 @@ public class BoxContainer : Container
     /// </code>
     /// </example>
     /// <remarks>
-    /// This is along the major axis, not the cross axis. Yes, this what's commonly called "justify".
+    /// This is along the main axis, not the cross axis. Yes, this what's commonly called "justify".
     /// </remarks>
     /// <remarks>
     /// This is overridden by a non-null <see cref="Align"/> value.
@@ -85,7 +85,7 @@ public class BoxContainer : Container
     public const string StylePropertyAlignMode = "align-mode";
 
     /// <summary>
-    /// The alignment of child controls <b>along the major axis</b>, defined by <see cref="Orientation"/>.
+    /// The alignment of child controls <b>along the main axis</b>, defined by <see cref="Orientation"/>.
     /// </summary>
     /// <example>
     /// If the Orientation is Vertical and Align is Center, it will align children to the center of the vertical axis.
@@ -108,7 +108,7 @@ public class BoxContainer : Container
     /// </code>
     /// </example>
     /// <remarks>
-    /// This is along the major axis, not the cross axis. Yes, this what's commonly called "justify".
+    /// This is along the main axis, not the cross axis. Yes, this what's commonly called "justify".
     /// </remarks>
     /// <param name="value">Overrides <see cref="StylePropertyAlignMode"/> and the default, <see cref="AlignMode.Begin"/>, if non-null.</param>
     [NotNull]
@@ -126,7 +126,7 @@ public class BoxContainer : Container
     }
 
     /// <summary>
-    /// The orientation/direction of the major axis that child controls are laid down along.
+    /// The orientation/direction of the main axis that child controls are laid down along.
     /// </summary>
     /// <example>
     /// <code>
@@ -163,7 +163,7 @@ public class BoxContainer : Container
     }
 
     /// <summary>
-    /// The separation/gap between the child elements along the major axis.
+    /// The separation/gap between the child elements along the main axis.
     /// </summary>
     /// <example>
     /// <code>
@@ -229,7 +229,7 @@ public class BoxContainer : Container
     /// Measures the desired size required to fit all visible children and the separation between them.
     /// </summary>
     /// <param name="availableSize">The available size to measure against.</param>
-    /// <typeparam name="TAxis">The major axis/orientation.</typeparam>
+    /// <typeparam name="TAxis">The main axis/orientation.</typeparam>
     /// <returns>The desired size for the measured children.</returns>
     private Vector2 MeasureItems<TAxis>(Vector2 availableSize) where TAxis : IAxisImplementation
     {
@@ -280,13 +280,13 @@ public class BoxContainer : Container
     /// </summary>
     /// <param name="baseOffset">Initial offset for first child position.</param>
     /// <param name="finalSize">The final available size of the arranged region.</param>
-    /// <param name="align">Mode to align children along the major axis.</param>
+    /// <param name="align">Mode to align children along the main axis.</param>
     /// <param name="children">The children to lay out.</param>
     /// <param name="start">Child index to start from.</param>
     /// <param name="end">Child index to end at.</param>
     /// <param name="separation">Amount of separation between children.</param>
     /// <param name="fixedSize">A fixed size used for each child's size rather than their individual measures.</param>
-    /// <typeparam name="TAxis">The major axis/orientation.</typeparam>
+    /// <typeparam name="TAxis">The main axis/orientation.</typeparam>
     /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="align"/> is outside <see cref="AlignMode"/>.</exception>
     internal static void LayOutItems<TAxis>(
         Vector2 baseOffset,
@@ -415,10 +415,10 @@ public class BoxContainer : Container
     }
 
     /// <summary>
-    /// The alignment of child controls <b>along the major axis</b>, dependent on a <see cref="LayoutOrientation"/>.
+    /// The alignment of child controls <b>along the main axis</b>, dependent on a <see cref="LayoutOrientation"/>.
     /// </summary>
     /// <remarks>
-    /// This is along the major axis, not the cross axis. Yes, this what's commonly called "justify".
+    /// This is along the main axis, not the cross axis. Yes, this what's commonly called "justify".
     /// If the Orientation is Vertical and Align is Center, it will align children to the center of the vertical axis.
     /// </remarks>
     /// <remarks>Defaults to <see cref="AlignMode.Begin"/></remarks>
@@ -454,7 +454,7 @@ public class BoxContainer : Container
     }
 
     /// <summary>
-    /// The orientation of the major axis that child controls are laid out along.
+    /// The orientation of the main axis that child controls are laid out along.
     /// </summary>
     /// <remarks>
     /// <see cref="AlignMode"/>'s meaning changes based on the orientation.

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -389,7 +389,7 @@ public class BoxContainer : Container
                     offset = stretchAvail;
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(AlignMode), "AlignMode is out of range");
+                    throw new ArgumentOutOfRangeException(nameof(align), align, "Align is out of range.");
             }
         }
 

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -34,10 +34,51 @@ namespace Robust.Client.UserInterface.Controls;
 [Virtual]
 public class BoxContainer : Container
 {
+    /// <summary>
+    /// Style property modifying <see cref="ActualSeparation" />, which is the amount of space between children in the
+    /// BoxContainer.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// Element&lt;BoxContainer&gt;()
+    ///     .Property(BoxContainer.StylePropertySeparation, 8);
+    /// </code>
+    /// </example>
+    /// <remarks>
+    /// This is overridden by <see cref="SeparationOverride" />
+    /// </remarks>
     public const string StylePropertySeparation = "separation";
 
+    /// <summary>
+    /// Style property modifying <see cref="Orientation" />, which decides the major axis for children to be laid out on.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// Element&lt;BoxContainer&gt;()
+    ///     .Prop(BoxContainer.StylePropertyOrientation, BoxContainer.LayoutOrientation.Vertical)
+    /// </code>
+    /// </example>
+    /// <remarks>
+    /// This is overridden by <see cref="Orientation" />
+    /// </remarks>
     public const string StylePropertyOrientation = "orientation";
 
+    /// <summary>
+    /// Style property modifying <see cref="Align"/>, which decides how to layout children along the major axis when there is extra space.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// Element&lt;BoxContainer&gt;()
+    ///     .Prop(BoxContainer.StylePropertyAlignMode, BoxContainer.AlignMode.Center)
+    /// </code>
+    /// </example>
+    /// <remarks>
+    /// This is along the major axis, not the minor axis. If the Orientation is Vertical and Align is Center, it will
+    /// align children to the center of the vertical axis.
+    /// </remarks>
+    /// <remarks>
+    /// This is overridden by <see cref="Align" />
+    /// </remarks>
     public const string StylePropertyAlignMode = "align-mode";
 
     private const int DefaultSeparation = 0;

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -7,8 +7,30 @@ using Robust.Shared.Maths;
 namespace Robust.Client.UserInterface.Controls;
 
 /// <summary>
-///     A container that lays out its children sequentially.
+/// A container that lays its children out sequentially along a major axis, <see cref="Orientation"/>.
 /// </summary>
+/// <example>
+/// <code>
+/// &lt;BoxContainer Orientation="Vertical"&gt;
+///     &lt;Label Text="Above" /&gt;
+///     &lt;Label Text="Below" /&gt;
+/// &lt;/BoxContainer&gt;
+/// </code>
+/// <code>
+/// var container = new BoxContainer
+/// {
+///     Orientation = LayoutOrientation.Vertical,
+///     Children =
+///     {
+///         new Label { Text = "Above" },
+///         new Label { Text = "Below" }
+///     },
+/// };
+/// </code>
+/// </example>
+/// <remarks>
+/// Use <see cref="WrapContainer"/> if you need wrapping along a minor axis.
+/// </remarks>
 [Virtual]
 public class BoxContainer : Container
 {

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -107,11 +107,13 @@ public class BoxContainer : Container
     [NotNull]
     public AlignMode? Align
     {
-        get;
+        get => field ?? StylePropertyDefault(StylePropertyAlignMode, AlignMode.Begin);
         set
         {
-            field = value ?? StylePropertyDefault(StylePropertyAlignMode, AlignMode.Begin);
+            if (field == value)
+                return;
 
+            field = value;
             InvalidateArrange();
         }
     }
@@ -142,11 +144,13 @@ public class BoxContainer : Container
     [NotNull]
     public LayoutOrientation? Orientation
     {
-        get;
+        get => field ?? StylePropertyDefault(StylePropertyOrientation, LayoutOrientation.Horizontal);
         set
         {
-            field = value ?? StylePropertyDefault(StylePropertyOrientation, LayoutOrientation.Horizontal);
+            if (field == value)
+                return;
 
+            field = value;
             InvalidateMeasure();
         }
     }
@@ -177,11 +181,13 @@ public class BoxContainer : Container
     [NotNull]
     public int? Separation
     {
-        get;
+        get => field ?? StylePropertyDefault(StylePropertySeparation, 0);
         set
         {
-            field = value ?? StylePropertyDefault(StylePropertySeparation, 0);
+            if (field == value)
+                return;
 
+            field = value;
             InvalidateMeasure();
         }
     }

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -25,7 +25,7 @@ namespace Robust.Client.UserInterface.Controls;
 ///     {
 ///         new Label { Text = "Above" },
 ///         new Label { Text = "Below" }
-///     },
+///     }
 /// };
 /// </code>
 /// </example>
@@ -36,7 +36,7 @@ namespace Robust.Client.UserInterface.Controls;
 public class BoxContainer : Container
 {
     /// <summary>
-    /// Style property modifying <see cref="ActualSeparation" />, which is the amount of space between children in the
+    /// Style property modifying <see cref="Separation"/>, which is the amount of space between children in the
     /// BoxContainer.
     /// </summary>
     /// <example>
@@ -46,12 +46,12 @@ public class BoxContainer : Container
     /// </code>
     /// </example>
     /// <remarks>
-    /// This is overridden by <see cref="SeparationOverride" />
+    /// This is overridden by a non-null <see cref="Separation"/> value.
     /// </remarks>
     public const string StylePropertySeparation = "separation";
 
     /// <summary>
-    /// Style property modifying <see cref="Orientation" />, which decides the major axis for children to be laid out on.
+    /// Style property modifying <see cref="Orientation"/>, which decides the major axis for children to be laid out on.
     /// </summary>
     /// <example>
     /// <code>
@@ -60,7 +60,7 @@ public class BoxContainer : Container
     /// </code>
     /// </example>
     /// <remarks>
-    /// This is overridden by <see cref="Orientation" />
+    /// This is overridden by a non-null <see cref="Orientation"/> value.
     /// </remarks>
     public const string StylePropertyOrientation = "orientation";
 
@@ -68,24 +68,28 @@ public class BoxContainer : Container
     /// Style property modifying <see cref="Align"/>, which decides how to layout children along the major axis when there is extra space.
     /// </summary>
     /// <example>
+    /// If the Orientation is Vertical and Align is Center, it will align children to the center of the vertical axis.
+    /// </example>
+    /// <example>
     /// <code>
     /// Element&lt;BoxContainer&gt;()
     ///     .Prop(BoxContainer.StylePropertyAlignMode, BoxContainer.AlignMode.Center)
     /// </code>
     /// </example>
     /// <remarks>
-    /// This is along the major axis, not the minor axis. If the Orientation is Vertical and Align is Center, it will
-    /// align children to the center of the vertical axis.
+    /// This is along the major axis, not the cross axis. Yes, this what's commonly called "justify".
     /// </remarks>
     /// <remarks>
-    /// This is overridden by <see cref="Align" />
+    /// This is overridden by a non-null <see cref="Align"/> value.
     /// </remarks>
     public const string StylePropertyAlignMode = "align-mode";
-
 
     /// <summary>
     /// The alignment of child controls <b>along the major axis</b>, defined by <see cref="Orientation"/>.
     /// </summary>
+    /// <example>
+    /// If the Orientation is Vertical and Align is Center, it will align children to the center of the vertical axis.
+    /// </example>
     /// <example>
     /// <code>
     /// &lt;BoxContainer Align="Center"&gt;
@@ -99,11 +103,14 @@ public class BoxContainer : Container
     ///     Children =
     ///     {
     ///         new Label { Text = "Child" }
-    ///     },
+    ///     }
     /// };
     /// </code>
     /// </example>
-    /// <param name="value">Overrides <see cref="StylePropertyAlignMode" /> and the default, <see cref="AlignMode.Begin" />, if non-null.</param>
+    /// <remarks>
+    /// This is along the major axis, not the cross axis. Yes, this what's commonly called "justify".
+    /// </remarks>
+    /// <param name="value">Overrides <see cref="StylePropertyAlignMode"/> and the default, <see cref="AlignMode.Begin"/>, if non-null.</param>
     [NotNull]
     public AlignMode? Align
     {
@@ -119,7 +126,7 @@ public class BoxContainer : Container
     }
 
     /// <summary>
-    /// The orientation of the major axis that child controls are laid down along.
+    /// The orientation/direction of the major axis that child controls are laid down along.
     /// </summary>
     /// <example>
     /// <code>
@@ -136,11 +143,11 @@ public class BoxContainer : Container
     ///     {
     ///         new Label { Text = "Above" },
     ///         new Label { Text = "Below" }
-    ///     },
+    ///     }
     /// };
     /// </code>
     /// </example>
-    /// <param name="value">Overrides <see cref="StylePropertyOrientation" /> and the default, <see cref="LayoutOrientation.Horizontal" />, if non-null.</param>
+    /// <param name="value">Overrides <see cref="StylePropertyOrientation"/> and the default, <see cref="LayoutOrientation.Horizontal"/>, if non-null.</param>
     [NotNull]
     public LayoutOrientation? Orientation
     {
@@ -173,11 +180,11 @@ public class BoxContainer : Container
     ///     {
     ///         new Label { Text = "Left" },
     ///         new Label { Text = "Right" }
-    ///     },
+    ///     }
     /// };
     /// </code>
     /// </example>
-    /// <param name="value">Overrides <see cref="StylePropertySeparation" /> and the default, 0, if non-null.</param>
+    /// <param name="value">Overrides <see cref="StylePropertySeparation"/> and the default, 0, if non-null.</param>
     [NotNull]
     public int? Separation
     {
@@ -200,6 +207,7 @@ public class BoxContainer : Container
         set => Separation = value;
     }
 
+    /// <inheritdoc/>
     protected override Vector2 MeasureOverride(Vector2 availableSize)
     {
         return Orientation == LayoutOrientation.Vertical
@@ -207,6 +215,12 @@ public class BoxContainer : Container
             : MeasureItems<HorizontalAxis>(availableSize);
     }
 
+    /// <summary>
+    /// Measures the desired size required to fit all visible children and the separation between them.
+    /// </summary>
+    /// <param name="availableSize">The available size to measure against.</param>
+    /// <typeparam name="TAxis">The major axis/orientation.</typeparam>
+    /// <returns>The desired size for the measured children.</returns>
     private Vector2 MeasureItems<TAxis>(Vector2 availableSize) where TAxis : IAxisImplementation
     {
         availableSize = TAxis.SizeToAxis(availableSize);
@@ -234,6 +248,7 @@ public class BoxContainer : Container
         return TAxis.SizeFromAxis(desiredSize);
     }
 
+    /// <inheritdoc/>
     protected override Vector2 ArrangeOverride(Vector2 finalSize)
     {
         var separation = Separation.Value;
@@ -250,6 +265,19 @@ public class BoxContainer : Container
         return finalSize;
     }
 
+    /// <summary>
+    /// Arranges a range of child controls sequentially along an axis.
+    /// </summary>
+    /// <param name="baseOffset">Initial offset for first child position.</param>
+    /// <param name="finalSize">The final available size of the arranged region.</param>
+    /// <param name="align">Mode to align children along the major axis.</param>
+    /// <param name="children">The children to lay out.</param>
+    /// <param name="start">Child index to start from.</param>
+    /// <param name="end">Child index to end at.</param>
+    /// <param name="separation">Amount of separation between children.</param>
+    /// <param name="fixedSize">A fixed size used for each child's size rather than their individual measures.</param>
+    /// <typeparam name="TAxis">The major axis/orientation.</typeparam>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="align"/> is outside <see cref="AlignMode"/>.</exception>
     internal static void LayOutItems<TAxis>(
         Vector2 baseOffset,
         Vector2 finalSize,
@@ -351,7 +379,7 @@ public class BoxContainer : Container
                     offset = stretchAvail;
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    throw new ArgumentOutOfRangeException(nameof(AlignMode), "AlignMode is out of range");
             }
         }
 
@@ -376,37 +404,73 @@ public class BoxContainer : Container
         }
     }
 
+    /// <summary>
+    /// The alignment of child controls <b>along the major axis</b>, dependent on a <see cref="LayoutOrientation"/>.
+    /// </summary>
+    /// <remarks>
+    /// This is along the major axis, not the cross axis. Yes, this what's commonly called "justify".
+    /// If the Orientation is Vertical and Align is Center, it will align children to the center of the vertical axis.
+    /// </remarks>
+    /// <remarks>Defaults to <see cref="AlignMode.Begin"/></remarks>
     public enum AlignMode : byte
     {
         /// <summary>
-        ///     Controls are laid out from the begin of the box container.
+        /// Child controls are laid out from the start/beginning.
         /// </summary>
+        /// <example>
+        /// <see cref="LayoutOrientation.Vertical"/> means start is the top. <br />
+        /// <see cref="LayoutOrientation.Horizontal"/> means start is the left.
+        /// </example>
+        /// <remarks>The default <see cref="AlignMode"/>.</remarks>
         Begin = 0,
 
         /// <summary>
-        ///     Controls are laid out from the center of the box container.
+        /// Child controls are laid out from the center.
         /// </summary>
+        /// <example>
+        /// <see cref="LayoutOrientation.Vertical"/> means start is the center vertically. <br />
+        /// <see cref="LayoutOrientation.Horizontal"/> means start is the center horizontally.
+        /// </example>
         Center = 1,
 
         /// <summary>
-        ///     Controls are laid out from the end of the box container.
+        /// Child controls are laid out from the end.
         /// </summary>
+        /// <example>
+        /// <see cref="LayoutOrientation.Vertical"/> means start is the bottom. <br />
+        /// <see cref="LayoutOrientation.Horizontal"/> means start is the right.
+        /// </example>
         End = 2
     }
 
     /// <summary>
-    /// Orientation for a box container.
+    /// The orientation of the major axis that child controls are laid out along.
     /// </summary>
+    /// <remarks>
+    /// <see cref="AlignMode"/>'s meaning changes based on the orientation.
+    /// </remarks>
+    /// <remarks>Defaults to <see cref="LayoutOrientation.Horizontal"/></remarks>
     public enum LayoutOrientation : byte
     {
         /// <summary>
         /// Controls are laid out horizontally, left to right.
         /// </summary>
+        /// <example>
+        /// <see cref="AlignMode.Begin"/> becomes the left. <br/>
+        /// <see cref="AlignMode.Center"/> becomes the center horizontally. <br/>
+        /// <see cref="AlignMode.End"/> becomes the right.
+        /// </example>
+        /// <remarks>The default <see cref="LayoutOrientation"/></remarks>
         Horizontal,
 
         /// <summary>
         /// Controls are laid out vertically, top to bottom.
         /// </summary>
+        /// <example>
+        /// <see cref="AlignMode.Begin"/> becomes the top. <br/>
+        /// <see cref="AlignMode.Center"/> becomes the center vertically. <br/>
+        /// <see cref="AlignMode.End"/> becomes the bottom.
+        /// </example>
         Vertical
     }
 }

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -15,6 +15,10 @@ public class BoxContainer : Container
     private LayoutOrientation _orientation;
     public const string StylePropertySeparation = "separation";
 
+    public const string StylePropertyOrientation = "orientation";
+
+    public const string StylePropertyAlignMode = "align-mode";
+
     private const int DefaultSeparation = 0;
 
     /// <summary>

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 using Robust.Shared.Maths;
+using Robust.Shared.ViewVariables;
 
 namespace Robust.Client.UserInterface.Controls;
 
@@ -111,7 +112,7 @@ public class BoxContainer : Container
     /// This is along the main axis, not the cross axis. Yes, this what's commonly called "justify".
     /// </remarks>
     /// <param name="value">Overrides <see cref="StylePropertyAlignMode"/> and the default, <see cref="AlignMode.Begin"/>, if non-null.</param>
-    [NotNull]
+    [NotNull, ViewVariables(VVAccess.ReadWrite)]
     public AlignMode? Align
     {
         get => field ?? StylePropertyDefault(StylePropertyAlignMode, AlignMode.Begin);
@@ -148,7 +149,7 @@ public class BoxContainer : Container
     /// </code>
     /// </example>
     /// <param name="value">Overrides <see cref="StylePropertyOrientation"/> and the default, <see cref="LayoutOrientation.Horizontal"/>, if non-null.</param>
-    [NotNull]
+    [NotNull, ViewVariables(VVAccess.ReadWrite)]
     public LayoutOrientation? Orientation
     {
         get => field ?? StylePropertyDefault(StylePropertyOrientation, LayoutOrientation.Horizontal);
@@ -185,7 +186,7 @@ public class BoxContainer : Container
     /// </code>
     /// </example>
     /// <param name="value">Overrides <see cref="StylePropertySeparation"/> and the default, 0, if non-null.</param>
-    [NotNull]
+    [NotNull, ViewVariables(VVAccess.ReadWrite)]
     public int? Separation
     {
         get => field ?? StylePropertyDefault(StylePropertySeparation, 0);

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -12,7 +12,6 @@ namespace Robust.Client.UserInterface.Controls;
 [Virtual]
 public class BoxContainer : Container
 {
-    private LayoutOrientation _orientation;
     public const string StylePropertySeparation = "separation";
 
     public const string StylePropertyOrientation = "orientation";
@@ -33,10 +32,10 @@ public class BoxContainer : Container
 
     public LayoutOrientation Orientation
     {
-        get => _orientation;
+        get;
         set
         {
-            _orientation = value;
+            field = value;
             InvalidateMeasure();
         }
     }

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 using Robust.Shared.Maths;
@@ -81,6 +82,40 @@ public class BoxContainer : Container
     /// </remarks>
     public const string StylePropertyAlignMode = "align-mode";
 
+
+    /// <summary>
+    /// The alignment of child controls <b>along the major axis</b>, defined by <see cref="Orientation"/>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// &lt;BoxContainer Align="Center"&gt;
+    ///     &lt;Label Text="Child" /&gt;
+    /// &lt;/BoxContainer&gt;
+    /// </code>
+    /// <code>
+    /// var container = new BoxContainer
+    /// {
+    ///     Align = AlignMode.Center,
+    ///     Children =
+    ///     {
+    ///         new Label { Text = "Child" }
+    ///     },
+    /// };
+    /// </code>
+    /// </example>
+    /// <param name="value">Overrides <see cref="StylePropertyAlignMode" /> and the default, <see cref="AlignMode.Begin" />, if non-null.</param>
+    [NotNull]
+    public AlignMode? Align
+    {
+        get;
+        set
+        {
+            field = value ?? StylePropertyDefault(StylePropertyAlignMode, AlignMode.Begin);
+
+            InvalidateArrange();
+        }
+    }
+
     /// <summary>
     /// Specifies the alignment of the controls <b>along the orientation axis.</b>
     /// </summary>
@@ -89,7 +124,6 @@ public class BoxContainer : Container
     /// This means that if your orientation is vertical and you set this to center,
     /// your controls will be laid out in the vertical <i>center</i> of the box control instead of the top.
     /// </remarks>
-    public AlignMode Align { get; set; }
 
     public LayoutOrientation Orientation
     {
@@ -159,11 +193,11 @@ public class BoxContainer : Container
 
         if (Orientation == LayoutOrientation.Vertical)
         {
-            LayOutItems<VerticalAxis>(default, finalSize, Align, Children, 0, ChildCount, separation);
+            LayOutItems<VerticalAxis>(default, finalSize, Align.Value, Children, 0, ChildCount, separation);
         }
         else
         {
-            LayOutItems<HorizontalAxis>(default, finalSize, Align, Children, 0, ChildCount, separation);
+            LayOutItems<HorizontalAxis>(default, finalSize, Align.Value, Children, 0, ChildCount, separation);
         }
 
         return finalSize;

--- a/Robust.Client/UserInterface/Controls/BoxContainer.cs
+++ b/Robust.Client/UserInterface/Controls/BoxContainer.cs
@@ -202,14 +202,9 @@ public class BoxContainer : Container
 
     protected override Vector2 MeasureOverride(Vector2 availableSize)
     {
-        if (Orientation == LayoutOrientation.Vertical)
-        {
-            return MeasureItems<VerticalAxis>(availableSize);
-        }
-        else
-        {
-            return MeasureItems<HorizontalAxis>(availableSize);
-        }
+        return Orientation == LayoutOrientation.Vertical
+            ? MeasureItems<VerticalAxis>(availableSize)
+            : MeasureItems<HorizontalAxis>(availableSize);
     }
 
     private Vector2 MeasureItems<TAxis>(Vector2 availableSize) where TAxis : IAxisImplementation
@@ -217,7 +212,7 @@ public class BoxContainer : Container
         availableSize = TAxis.SizeToAxis(availableSize);
 
         // Account for separation.
-        var separation = Separation.Value * (Children.Where(c => c.Visible).Count() - 1);
+        var separation = Separation.Value * (Children.Count(c => c.Visible) - 1);
         var desiredSize = new Vector2(separation, 0);
         availableSize.X = Math.Max(0, availableSize.X) - separation;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Most of the diff is just me adding documentation + formatting the files. I've put them in specific commits separate from my code modifications for easier review.

The main code change was that I've now exposed overrides and style properties for all of the properties of a BoxContainer. This means they all can fall back to stylesheet if it's not directly modified, which if there's no stylesheet it would default back to the original default.

This does have some breaking changes though. First, all of the properties are now nullable but marked at `[NotNull]`. If they were reference types iirc I could use `[AllowNull]`, but I couldn't in this instance. I couldn't find any instances of this being a problem in the codebase as of yet, but it's still a breaking change.

Plus, I had to explicitly obsolete error out the `SeparationOverride` getter as it used to be able to tell if there's been an explicit override by checking if it was non-null, but now it's always non-null. I could probably add another field to allow for the nullable check, but imo there's not a real benefit for what is already going to cause breaking changes anyways just for an obsolete field (ignoring the fact that separation override is implemented incorrectly in all engine builds except master, so I think it's a fair cut).

This also fixes `Align` missing an `InvalidateArrange()` on its set path.

Also, it has 100% test coverage, and everything is very well documented now.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

I want a consistent way to work with properties of controls. I found it really annoying that we had to type out `SeparationOverride` for working with what should just be a `Separation` XML property. 

Adding all of these overrides and this functionality will let us hoist up properties to the top-level of the compositional controls as we discussed in the DevBus, as now if they don't modify a hoisted property, it can default to the control's own styleproperty defaults.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

N/A

## Migration(s)

Content master requires no modifications. All instances of the `SeparationOverride` setter (in e.g. XAML, only produces a warning) can be REGEX replaced by just `Separation`.

If they relied on getting/reading any of the properties of BoxContainer (which does not happen in content), they would need to do `.Value` on it. 

If they ever read `BoxContainer.SeparationOverride` to check if it is currently using an overridden value (which was broken in all versions except master as it didn't actually override) by seeing if it is non-null, then there is no support for that behavior anymore. If they just wanted to read the current value, they can switch to `BoxContainer.Separation`'s getter. 

## Changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

New `StylePropertyOrientation` and `StylePropertyAlign` properties to set defaults for `BoxContainer`.

`BoxContainer.SeparationOverride` is now obsolete. The getter now produces an error as the semantics are now different (not used in ss14), and the setter produces a warning.

`BoxContainer.Orientation`, `BoxContainer.Align`, and `BoxContainer.Separation` are all now `[NotNull]` nullable types. This means that when getting its value (not used in ss14 content), you have to do `.Value` to read its value, but you don't need to check it's non-null first. This allows you to set its value to `null`, which will fallback from your override to the default.