### PR TITLE
Add optional modifier keys to bind command

### DIFF
--- a/Resources/Locale/en-US/commands.ftl
+++ b/Resources/Locale/en-US/commands.ftl
@@ -247,13 +247,18 @@ cmd-key-info-help = Usage: {$command} <Key>
 
 ## 'bind' command
 cmd-bind-desc = Binds an input key combination to an input command.
-cmd-bind-help = Usage: {$command} { cmd-bind-arg-key } { cmd-bind-arg-mode } { cmd-bind-arg-command }
+cmd-bind-help = Usage: {$command} { cmd-bind-arg-key } { cmd-bind-arg-mode } { cmd-bind-arg-command } { cmd-bind-arg-key-mod } { cmd-bind-arg-key-mod } { cmd-bind-arg-key-mod }
     Note that this DOES NOT automatically save bindings.
     Use the 'svbind' command to save binding configuration.
 
 cmd-bind-arg-key = <KeyName>
 cmd-bind-arg-mode = <BindMode>
 cmd-bind-arg-command = <InputCommand>
+cmd-bind-arg-key-mod = [KeyModifier]
+
+cmd-svbind-desc = Saves current binding configuration to appdata.
+cmd-svbind-help = Usage: {$command}
+    Note that bindings must first be set using the 'bind' command.
 
 cmd-net-draw-interp-desc = Toggles the debug drawing of the network interpolation.
 cmd-net-draw-interp-help = Usage: {$command}

--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -976,68 +976,107 @@ namespace Robust.Client.Input
 
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            if (args.Length != 3)
+            if (args.Length < 3 || args.Length > 6)
             {
                 shell.WriteError(Loc.GetString("cmd-invalid-arg-number-error"));
                 return;
             }
 
-            var keyName = args[0];
-
-            if (!Enum.TryParse<Key>(keyName, true, out var keyId))
+            var registration = new KeyBindingRegistration();
+            for (var i = 0; i < args.Length; i++)
             {
-                shell.WriteLine($"Key '{keyName}' is unrecognized.");
-                return;
+                switch (i)
+                {
+                    case 0: // Base key
+                        if (!Enum.TryParse<Key>(args[0], true, out var keyId))
+                        {
+                            shell.WriteLine($"Key '{args[0]}' is unrecognized.");
+                            return;
+                        }
+                        registration.BaseKey = keyId;
+                        break;
+
+                    case 1: // Types of bindings
+                        if (!Enum.TryParse<KeyBindingType>(args[1], true, out var keyMode))
+                        {
+                            shell.WriteLine($"BindMode '{args[1]}' is unrecognized.");
+                            return;
+                        }
+                        registration.Type = keyMode;
+                        break;
+
+                    case 2: // Binding functions
+                        registration.Function = args[2];
+                        break;
+
+                    case 3:  // Modifier key 1
+                        if (!Enum.TryParse<Key>(args[3], true, out var keyMod1))
+                        {
+                            shell.WriteLine($"Key '{args[3]}' is unrecognized.");
+                            return;
+                        }
+                        registration.Mod1 = keyMod1;
+                        break;
+
+                    case 4: // Modifier key 2
+                        if (!Enum.TryParse<Key>(args[4], true, out var keyMod2))
+                        {
+                            shell.WriteLine($"Key '{args[4]}' is unrecognized.");
+                            return;
+                        }
+                        registration.Mod2 = keyMod2;
+                        break;
+
+                    case 5: // Modifier key 3
+                        if (!Enum.TryParse<Key>(args[5], true, out var keyMod3))
+                        {
+                            shell.WriteLine($"Key '{args[5]}' is unrecognized.");
+                            return;
+                        }
+                        registration.Mod3 = keyMod3;
+                        break;
+                }
             }
-
-            if (!Enum.TryParse<KeyBindingType>(args[1], true, out var keyMode))
-            {
-                shell.WriteLine($"BindMode '{args[1]}' is unrecognized.");
-                return;
-            }
-
-            var inputCommand = args[2];
-
-            var registration = new KeyBindingRegistration
-            {
-                Function = inputCommand,
-                BaseKey = keyId,
-                Type = keyMode
-            };
 
             _inputManager.RegisterBinding(registration);
         }
 
         public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
         {
-            if (args.Length == 1)
+            switch (args.Length)
+            {
+                case 1: // Main Key
+                    return GetKeyCompletion();
+
+                case 2: // Types of bindings
+                    var typeOptions = Enum.GetNames<KeyBindingType>().Except(new[] { nameof(KeyBindingType.Unknown) });
+                    return CompletionResult.FromHintOptions(typeOptions, Loc.GetString("cmd-bind-arg-mode"));
+
+                case 3: // Binding functions
+                    if (!Enum.TryParse<KeyBindingType>(args[1], true, out var type))
+                        return CompletionResult.Empty;
+
+                    if (type == KeyBindingType.Command)
+                    {
+                        // Don't show completions for key functions if mode is command, it wouldn't make sense.
+                        return CompletionResult.FromHint(Loc.GetString("cmd-bind-arg-command"));
+                    }
+
+                    var funcOptions = _inputManager.NetworkBindMap.AllKeyFunctions.Select(x => x.FunctionName);
+                    return CompletionResult.FromHintOptions(funcOptions, Loc.GetString("cmd-bind-arg-command"));
+
+                case 4 or 5 or 6: // Modifier keys
+                    return GetKeyCompletion();
+
+                default:
+                    return CompletionResult.Empty;
+            }
+
+            CompletionResult GetKeyCompletion()
             {
                 var options = Enum.GetNames<Key>();
                 return CompletionResult.FromHintOptions(options, Loc.GetString("cmd-bind-arg-key"));
             }
-
-            if (args.Length == 2)
-            {
-                var options = Enum.GetNames<KeyBindingType>().Except(new[] { nameof(KeyBindingType.Unknown) });
-                return CompletionResult.FromHintOptions(options, Loc.GetString("cmd-bind-arg-mode"));
-            }
-
-            if (!Enum.TryParse<KeyBindingType>(args[1], true, out var type))
-                return CompletionResult.Empty;
-
-            if (args.Length == 3)
-            {
-                if (type == KeyBindingType.Command)
-                {
-                    // Don't show completions for key functions if mode is command, it wouldn't make sense.
-                    return CompletionResult.FromHint(Loc.GetString("cmd-bind-arg-command"));
-                }
-
-                var options = _inputManager.NetworkBindMap.AllKeyFunctions.Select(x => x.FunctionName);
-                return CompletionResult.FromHintOptions(options, Loc.GetString("cmd-bind-arg-command"));
-            }
-
-            return CompletionResult.Empty;
         }
     }
 

--- a/Robust.Client/Input/InputManager.cs
+++ b/Robust.Client/Input/InputManager.cs
@@ -1046,7 +1046,8 @@ namespace Robust.Client.Input
             switch (args.Length)
             {
                 case 1: // Main Key
-                    return GetKeyCompletion();
+                    var optionsMain = Enum.GetNames<Key>();
+                    return CompletionResult.FromHintOptions(optionsMain, Loc.GetString("cmd-bind-arg-key"));
 
                 case 2: // Types of bindings
                     var typeOptions = Enum.GetNames<KeyBindingType>().Except(new[] { nameof(KeyBindingType.Unknown) });
@@ -1066,16 +1067,11 @@ namespace Robust.Client.Input
                     return CompletionResult.FromHintOptions(funcOptions, Loc.GetString("cmd-bind-arg-command"));
 
                 case 4 or 5 or 6: // Modifier keys
-                    return GetKeyCompletion();
+                    var optionsMod = Enum.GetNames<Key>();
+                    return CompletionResult.FromHintOptions(optionsMod, Loc.GetString("cmd-bind-arg-key-mod"));
 
                 default:
                     return CompletionResult.Empty;
-            }
-
-            CompletionResult GetKeyCompletion()
-            {
-                var options = Enum.GetNames<Key>();
-                return CompletionResult.FromHintOptions(options, Loc.GetString("cmd-bind-arg-key"));
             }
         }
     }


### PR DESCRIPTION
I have a problem: I've run out of available keybinds. My solution was to use `exec` to have keybind scripts unique to each of my characters, but the command didn't support modifiers. This severely limited what I wanted to do with it, so I made this PR to add that support.

This PR adds 3 optional params to `bind` which set the modifiers for the keybind registration. It additionally adds the missing description and help for `svbind`.