### PR TITLE
Remove NotImplementedException from DummySession.SendMessage

### DIFF
--- a/Robust.Shared/Player/DummySession.cs
+++ b/Robust.Shared/Player/DummySession.cs
@@ -113,7 +113,7 @@ internal sealed class DummyChannel(DummySession session) : INetChannel
 
     public void SendMessage(NetMessage message)
     {
-        throw new NotImplementedException();
+        // Do nothing
     }
 
     public void Disconnect(string reason)


### PR DESCRIPTION
Hi!

My fork includes content that indirectly automatically calls this method after
some time passes. This causes issues with tests failing that should not when
our CI runs for too long. This method should not throw an exception but rather
do nothing when it is called.

Let me know if you want me to do the same for the other methods in this class
since I think it is very plausible other folks might run into similar issues.

Let me know if you guys also want a regression test and I can distill the issue down to a minimal reproducible form. Although, I think that would have to be content side if you want an exact replication of our issue.
