### PR TITLE
(Try to) Fix a null reference exception in ComponentTreeSystem.UpdateTreePositions

### DIFF
--- a/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
+++ b/Robust.Shared/ComponentTrees/ComponentTreeSystem.cs
@@ -242,9 +242,9 @@ public abstract partial class ComponentTreeSystem<TTreeComp, TComp> : EntitySyst
                 {
                     (pos, rot) = XformSystem.GetRelativePositionRotation(
                         entry.Transform,
-                        newTree!.Value);
+                        newTree.Value);
 
-                    newTreeComp!.Tree.Update(entry, ExtractAabb(entry, pos, rot));
+                    newTreeComp?.Tree.Update(entry, ExtractAabb(entry, pos, rot));
                     continue;
                 }
 
@@ -258,7 +258,7 @@ public abstract partial class ComponentTreeSystem<TTreeComp, TComp> : EntitySyst
 
                 (pos, rot) = XformSystem.GetRelativePositionRotation(
                     entry.Transform,
-                    newTree!.Value);
+                    newTree.Value);
 
                 newTreeComp.Tree.Add(entry, ExtractAabb(entry, pos, rot));
             }


### PR DESCRIPTION
The error does not actually point to the correct line on local and it is one of the errors I keep seeing before a server crash on Afterlight
I have been staring at this method for an hour and I cannot see what else could possibly throw it
Also see https://github.com/space-wizards/RobustToolbox/pull/6366