### PR TITLE
Add AfterAppearanceChange event to AppearanceSystem

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
@@ -144,6 +144,12 @@ namespace Robust.Client.GameObjects
 
             // Give it AppearanceData so we can still keep the friend attribute on the component.
             RaiseLocalEvent(uid, ref ev);
+
+            var postEv = new AfterAppearanceChangeEvent
+            {
+                Component = appearanceComponent,
+            };
+            RaiseLocalEvent(uid, ref postEv);
         }
     }
 
@@ -156,5 +162,11 @@ namespace Robust.Client.GameObjects
         public AppearanceComponent Component;
         public IReadOnlyDictionary<Enum, object> AppearanceData;
         public SpriteComponent? Sprite;
+    }
+
+    [ByRefEvent]
+    public struct AfterAppearanceChangeEvent
+    {
+        public AppearanceComponent Component;
     }
 }

--- a/Robust.Client/GameObjects/EntitySystems/VisualizerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/VisualizerSystem.cs
@@ -18,7 +18,16 @@ public abstract partial class VisualizerSystem<T> : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<T, AppearanceChangeEvent>(OnAppearanceChange);
+        SubscribeLocalEvent<T, AfterAppearanceChangeEvent>(AfterAppearanceChange);
     }
 
     protected virtual void OnAppearanceChange(EntityUid uid, T component, ref AppearanceChangeEvent args) { }
+
+    /// <summary>
+    /// Called after all EntitySystems/Visualizers have handled AppearanceChangedEvent
+    /// </summary>
+    /// <param name="uid"></param>
+    /// <param name="component"></param>
+    /// <param name="args"></param>
+    protected virtual void AfterAppearanceChange(EntityUid uid, T component, ref AfterAppearanceChangeEvent args) { }
 }


### PR DESCRIPTION
Adds an AfterAppearanceChange event + methods in VisualiserSystem.
Very usefull for cases where someone might want to duplicate a existing ent's appearance/layer data for rendering else where (like showing an APC entity in a mirror with the current state properly created)