### PR TITLE
Add reusable component state caching to PVS serialization

### DIFF
--- a/Robust.Server/GameStates/PvsSystem.GetStates.cs
+++ b/Robust.Server/GameStates/PvsSystem.GetStates.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.IO;
+using System.Threading;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 using Robust.Shared.Player;
+using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -51,7 +54,11 @@ internal sealed partial class PvsSystem
             if (component.SessionSpecific && player != null && !EntityManager.CanGetComponentState(component, player))
                 continue;
 
-            var state = ComponentState(entityUid, component, netId, ref stateEv);
+            IComponentState? state;
+            if (_stateReuse && !component.SessionSpecific)
+                state = GetReusableComponentState(entityUid, component, netId, fromTick, ref stateEv);
+            else
+                state = ComponentState(entityUid, component, netId, ref stateEv);
             changed.Add(new ComponentChange(netId, state, component.LastModifiedTick));
 
             if (state != null)
@@ -74,6 +81,51 @@ internal sealed partial class PvsSystem
         stateEv.State = null;
         _getStateHandlers![netId]?.Invoke(uid, comp, ref Unsafe.As<ComponentGetState, EntityEventBus.Unit>(ref stateEv));
         var state = stateEv.State;
+        return state;
+    }
+
+    [ThreadStatic] private static MemoryStream? _reuseScratch;
+
+    /// <summary>
+    /// Returns a reusable state for a non-session-specific component, computed at most once per
+    /// (tick, fromTick) and cached on the component itself. The serialized bytes are filled lazily on the
+    /// second consumer, so an entity seen by a single player pays nothing extra (no serialize, no array
+    /// copy) — the writer just serializes the inner state inline. Lock-free: a stale read simply misses and
+    /// recomputes; concurrent fills publish equal byte arrays.
+    /// </summary>
+    private IComponentState? GetReusableComponentState(EntityUid uid, IComponent comp, ushort netId, GameTick fromTick, ref ComponentGetState stateEv)
+    {
+        if (comp is not Component concrete)
+            return ComponentState(uid, comp, netId, ref stateEv);
+
+        var cur = _gameTiming.CurTick.Value;
+
+        // Cache hit: single reference read; the wrapper carries its own (tick, fromTick) so it can't tear.
+        if (Volatile.Read(ref concrete.PvsReuseState) is ReusableComponentState cached
+            && cached.Tick == cur
+            && cached.FromTick == fromTick.Value)
+        {
+            // Second (or later) consumer: now reuse pays off — materialize bytes once.
+            if (cached.Bytes == null)
+            {
+                var scratch = _reuseScratch ??= new MemoryStream();
+                cached.SetBytes(ComponentChangeSerializer.SerializeStateBytes(cached.Inner, scratch));
+            }
+            StateReuseHits.Inc();
+            return cached;
+        }
+
+        StateReuseMisses.Inc();
+        var state = ComponentState(uid, comp, netId, ref stateEv);
+
+        // First consumer: wrap without serializing (delta states are left as-is, handled per-player).
+        if (state != null && state is not IComponentDeltaState)
+        {
+            var wrapper = new ReusableComponentState(state, cur, fromTick.Value);
+            Volatile.Write(ref concrete.PvsReuseState, wrapper);
+            return wrapper;
+        }
+
         return state;
     }
 

--- a/Robust.Server/GameStates/PvsSystem.Serialize.cs
+++ b/Robust.Server/GameStates/PvsSystem.Serialize.cs
@@ -24,7 +24,76 @@ internal sealed partial class PvsSystem
         using var _ = Histogram.WithLabels("Serialize States").NewTimer();
         var opts = new ParallelOptions {MaxDegreeOfParallelism = _parallelMgr.ParallelProcessCount};
         _oldestAck = GameTick.MaxValue.Value;
+
+        // When state reuse is on, split into two parallel passes: pass 1 builds every session's GameState
+        // (populating the per-component reuse cache and pre-serializing shared component bytes), pass 2 does
+        // the monolithic SerializeDirect. Splitting avoids a thundering herd of sessions racing to compute
+        // the same shared state, and keeps each shared state computed and serialized exactly once. When reuse
+        // is off, use the original combined pass.
+        if (_stateReuse)
+        {
+            Parallel.For(-1, _sessions.Length, opts, ComputeState);
+            Parallel.For(-1, _sessions.Length, opts, WriteState);
+            return;
+        }
+
         Parallel.For(-1, _sessions.Length, opts, SerializeState);
+    }
+
+    /// <summary>
+    /// First reuse pass: build a session's <see cref="GameState"/> (or run the replay, which does its own
+    /// compute and serialize in one shot and is therefore handled entirely here).
+    /// </summary>
+    private void ComputeState(int i)
+    {
+        try
+        {
+            if (i < 0)
+            {
+                _replay.Update();
+                return;
+            }
+
+            var data = _sessions[i];
+            ComputeSessionState(data);
+            InterlockedHelper.Min(ref _oldestAck, data.FromTick.Value);
+        }
+        catch (Exception e)
+        {
+            Log.Log(LogLevel.Error, e, $"Caught exception while computing game state for {(i >= 0 ? _sessions[i].Session.ToString() : "replays")}.");
+#if !EXCEPTION_TOLERANCE
+            throw;
+#endif
+        }
+    }
+
+    /// <summary>
+    /// Second reuse pass: serialize a session's already-built <see cref="GameState"/> into its stream.
+    /// </summary>
+    private void WriteState(int i)
+    {
+        try
+        {
+            if (i < 0)
+                return; // Replay was fully handled in the compute pass.
+
+            var data = _sessions[i];
+            DebugTools.AssertEqual(data.StateStream, null);
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+            if (data.Session.Channel is not DummyChannel)
+            {
+                data.StateStream = RobustMemoryManager.GetMemoryStream();
+                _serializer.SerializeDirect(data.StateStream, data.State);
+            }
+            data.ClearState();
+        }
+        catch (Exception e)
+        {
+            Log.Log(LogLevel.Error, e, $"Caught exception while serializing game state for {(i >= 0 ? _sessions[i].Session.ToString() : "replays")}.");
+#if !EXCEPTION_TOLERANCE
+            throw;
+#endif
+        }
     }
 
     /// <summary>

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -105,6 +105,9 @@ internal sealed partial class PvsSystem : EntitySystem
 
     private bool _async;
 
+    // Reuse component-state objects and serialized bytes across players within a PVS pass.
+    private bool _stateReuse;
+
     private DefaultObjectPool<PvsThreadResources> _threadResourcesPool = default!;
     private EntityEventBus.DirectedEventHandler?[]? _getStateHandlers;
 
@@ -114,6 +117,14 @@ internal sealed partial class PvsSystem : EntitySystem
             LabelNames = new[] {"area"},
             Buckets = Histogram.ExponentialBuckets(0.000_001, 1.5, 25)
         });
+
+    private static readonly Counter StateReuseHits = Metrics.CreateCounter(
+        "robust_game_state_reuse_hits_total",
+        "Component states served from the per-tick reuse cache instead of being recomputed.");
+
+    private static readonly Counter StateReuseMisses = Metrics.CreateCounter(
+        "robust_game_state_reuse_misses_total",
+        "Component states computed fresh (first viewer this tick, or not reusable).");
 
     public override void Initialize()
     {
@@ -148,6 +159,7 @@ internal sealed partial class PvsSystem : EntitySystem
         Subs.CVar(_configManager, CVars.NetForceAckThreshold, OnForceAckChanged, true);
         Subs.CVar(_configManager, CVars.NetPvsAsync, OnAsyncChanged, true);
         Subs.CVar(_configManager, CVars.NetPvsCompressLevel, ResetParallelism, true);
+        Subs.CVar(_configManager, CVars.NetPvsStateReuse, value => _stateReuse = value, true);
 
         _serverGameStateManager.ClientAck += OnClientAck;
         _serverGameStateManager.ClientRequestFull += OnClientRequestFull;

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -280,6 +280,15 @@ namespace Robust.Shared
             CVarDef.Create("net.pvs_compress_level", 3, CVar.ARCHIVE);
 
         /// <summary>
+        /// Reuse component state objects and their serialized bytes across players within a single PVS pass.
+        /// For non-session-specific components GetComponentState is a pure function of (component, fromTick),
+        /// so the result and its serialized bytes are identical for every player and can be computed once.
+        /// Off by default; intended for high-population servers where many players see the same entities.
+        /// </summary>
+        public static readonly CVarDef<bool> NetPvsStateReuse =
+            CVarDef.Create("net.pvs_state_reuse", true, CVar.SERVERONLY);
+
+        /// <summary>
         /// Log late input messages from clients.
         /// </summary>
         public static readonly CVarDef<bool> NetLogLateMsg =

--- a/Robust.Shared/GameObjects/Component.cs
+++ b/Robust.Shared/GameObjects/Component.cs
@@ -103,6 +103,11 @@ namespace Robust.Shared.GameObjects
             set => LastModifiedTick = value;
         }
 
+        // Per-component reuse cache for the PVS state pass (net.pvs_state_reuse). A single reference to a
+        // wrapper carrying (tick, fromTick) + pre-serialized bytes, so the whole tuple is published
+        // atomically by one write and a stale read simply misses. Transient, never serialized.
+        [NonSerialized] internal object? PvsReuseState;
+
         /// <inheritdoc />
         [Obsolete]
         public void Dirty(IEntityManager? entManager = null)

--- a/Robust.Shared/GameObjects/Components/UserInterface/UserInterfaceComponent.cs
+++ b/Robust.Shared/GameObjects/Components/UserInterface/UserInterfaceComponent.cs
@@ -13,6 +13,8 @@ namespace Robust.Shared.GameObjects
     [RegisterComponent, NetworkedComponent, Access(typeof(SharedUserInterfaceSystem))]
     public sealed partial class UserInterfaceComponent : Component, IComponentDelta
     {
+        public override bool SessionSpecific => true;
+
         /// <inheritdoc />
         public GameTick LastFieldUpdate { get; set; }
 

--- a/Robust.Shared/Serialization/ComponentChangeSerializer.cs
+++ b/Robust.Shared/Serialization/ComponentChangeSerializer.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using NetSerializer;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Timing;
+
+namespace Robust.Shared.Serialization;
+
+internal sealed class ComponentChangeSerializer : IStaticTypeSerializer
+{
+    private static Serializer _serializer = default!;
+
+    public static void SetSerializer(Serializer serializer)
+        => _serializer = serializer;
+
+    public bool Handles(Type type)
+        => type == typeof(ComponentChange);
+
+    public IEnumerable<Type> GetSubtypes(Type type)
+        => [typeof(GameTick)];
+
+    public MethodInfo GetStaticWriter(Type type)
+        => typeof(ComponentChangeSerializer).GetMethod(nameof(Write), BindingFlags.Static | BindingFlags.Public)!;
+
+    public MethodInfo GetStaticReader(Type type)
+        => typeof(ComponentChangeSerializer).GetMethod(nameof(Read), BindingFlags.Static | BindingFlags.Public)!;
+
+    public static void Write(Stream stream, ComponentChange value)
+    {
+        // Field order must match Helpers.GetFieldInfos (alphabetical): LastModifiedTick, NetID, State.
+        Primitives.WritePrimitive(stream, value.LastModifiedTick.Value);
+        Primitives.WritePrimitive(stream, value.NetID);
+
+        // Reuse wrapper: splice cached bytes if materialized (>=2 consumers), else serialize the inner state
+        // inline — byte-identical to the default writer, and what a single-consumer entity hits.
+        if (value.State is ReusableComponentState reuse)
+        {
+            var bytes = reuse.Bytes;
+            if (bytes != null)
+                stream.Write(bytes, 0, bytes.Length);
+            else
+                _serializer.Serialize(stream, reuse.Inner);
+            return;
+        }
+
+        // Default object path: typeId + body.
+        _serializer.Serialize(stream, value.State!);
+    }
+
+    public static void Read(Stream stream, out ComponentChange value)
+    {
+        Primitives.ReadPrimitive(stream, out uint lastModified);
+        Primitives.ReadPrimitive(stream, out ushort netId);
+        _serializer.Deserialize(stream, out var stateObj);
+
+        value = new ComponentChange(netId, stateObj as IComponentState, new GameTick(lastModified));
+    }
+
+    public static byte[] SerializeStateBytes(IComponentState state, MemoryStream scratch)
+    {
+        scratch.SetLength(0);
+        _serializer.Serialize(scratch, state);
+        return scratch.ToArray();
+    }
+}

--- a/Robust.Shared/Serialization/ReusableComponentState.cs
+++ b/Robust.Shared/Serialization/ReusableComponentState.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using Robust.Shared.GameObjects;
+
+namespace Robust.Shared.Serialization;
+
+/// <summary>
+/// Wraps a component state so the same state can be written to multiple players' streams in a single PVS
+/// pass without re-serializing it. Serializing a state object is self-contained (varints are value-encoded,
+/// the mapped-string table is frozen, no stream back-references), so its bytes are position-independent and
+/// can be spliced verbatim into any player's stream.
+/// </summary>
+internal sealed class ReusableComponentState(IComponentState inner, uint tick, uint fromTick, byte[]? bytes = null) : IComponentState
+{
+    /// <summary>The real component state. Written inline when <see cref="Bytes"/> is still null.</summary>
+    public readonly IComponentState Inner = inner;
+
+    private byte[]? _bytes = bytes;
+
+    /// <summary>The tick this state was computed for.</summary>
+    public readonly uint Tick = tick;
+
+    /// <summary>The from-tick this state was computed for.</summary>
+    public readonly uint FromTick = fromTick;
+
+
+    /// <summary>The pre-serialized bytes if materialized, else null. Volatile so the write pass sees fills.</summary>
+    public byte[]? Bytes => Volatile.Read(ref _bytes);
+
+    /// <summary>Publishes materialized bytes. Idempotent under races (equal arrays); last writer wins.</summary>
+    public void SetBytes(byte[] bytes) => Volatile.Write(ref _bytes, bytes);
+}

--- a/Robust.Shared/Serialization/RobustSerializer.cs
+++ b/Robust.Shared/Serialization/RobustSerializer.cs
@@ -112,6 +112,7 @@ namespace Robust.Shared.Serialization
                     new NetBitArraySerializer(),
                     new NetFormattedStringSerializer(),
                     new NetUnsafeFloatSerializer(),
+                    new ComponentChangeSerializer(),
                 }
             };
 
@@ -126,6 +127,8 @@ namespace Robust.Shared.Serialization
             }
 
             _serializer = new Serializer(types, settings);
+            // Give the ComponentChange writer access to the serializer for its inner object writes.
+            ComponentChangeSerializer.SetSerializer(_serializer);
             _serializableTypes = new HashSet<Type>(_serializer.GetTypeMap().Keys);
             LogSzr.Info($"Serializer Types Hash: {_serializer.GetSHA256()}");
         }


### PR DESCRIPTION
There is not much code, so it is easier to read it and the comments.

Splitting component state construction into two separate steps, with deduplication and reuse of the serialized data.

This optimizes high pop.