### PR TITLE
Fix start of animations being inconsistent by tweaking AnimationTrackProperty.cs.

### DIFF
--- a/Robust.Client.IntegrationTests/UserInterface/ControlTest.cs
+++ b/Robust.Client.IntegrationTests/UserInterface/ControlTest.cs
@@ -158,6 +158,7 @@ namespace Robust.UnitTesting.Client.UserInterface
                         Property = nameof(TestControl.Foo),
                         KeyFrames =
                         {
+                            new AnimationTrackProperty.KeyFrame(0f, 0f), // This is the common way to specify the first keyframe.
                             new AnimationTrackProperty.KeyFrame(1f, 1f),
                             new AnimationTrackProperty.KeyFrame(3f, 2f)
                         }

--- a/Robust.Client.IntegrationTests/UserInterface/ControlTest.cs
+++ b/Robust.Client.IntegrationTests/UserInterface/ControlTest.cs
@@ -169,7 +169,7 @@ namespace Robust.UnitTesting.Client.UserInterface
             control.PlayAnimation(animation, "foo");
             control.DoFrameUpdateRecursive(new FrameEventArgs(0.5f));
 
-            Assert.That(control.Foo, new ApproxEqualityConstraint(0f)); // Should still be 0.
+            Assert.That(control.Foo, new ApproxEqualityConstraint(0.5f)); // Should be 0.5 as half a second elapsed and our 1s keyframe is at 1.
 
             control.DoFrameUpdateRecursive(new FrameEventArgs(0.5001f));
 

--- a/Robust.Client/Animations/AnimationTrackProperty.cs
+++ b/Robust.Client/Animations/AnimationTrackProperty.cs
@@ -43,7 +43,9 @@ namespace Robust.Client.Animations
             var nextKeyFrame = keyFrameIndex + 1;
             if (nextKeyFrame == 0)
             {
-                // Still before the first keyframe, do nothing.
+                // At the start snap the anim to the first keyframe
+                value = KeyFrames[0].Value;
+                ApplyProperty(context, value);
                 return (keyFrameIndex, playingTime);
             }
 


### PR DESCRIPTION
After trying and failing to properly fix it within C# or YAML or the animation keys themselves this 2 line engine PR is the solution.
Basically the first key of the animation is just inconsistent. It might get updated instantly in which case it looks like the fixed version or it might take a split second which causes the animation to do a harsh jump. This way the start of the animation will be on the first key which shouldnt break anything. 

# before

https://github.com/user-attachments/assets/be7ec757-cf51-439e-b073-58b976c77b08


# after
https://github.com/user-attachments/assets/167a9251-f37e-448b-8fd8-22647f449aac
