### PR TITLE
Dispose audio stream on resource disposal

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Dispose `AudioStream` when the `AudioResource` is disposed.
 
 ### Other
 

--- a/Robust.Client/ResourceManagement/ResourceTypes/AudioResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/AudioResource.cs
@@ -72,4 +72,10 @@ public sealed class AudioResource : BaseResource
     {
         return res.AudioStream;
     }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        AudioStream.Dispose();
+    }
 }


### PR DESCRIPTION
Technically a bug but no code paths on engine hit it at the moment as audioresources never get disposed and streams get disposed on game close.