### PR TITLE
Add PhysicsBodyStatusChangedEvent

### DIFF
--- a/Robust.Shared/Physics/Events/PhysicsBodyStatusChangedEvent.cs
+++ b/Robust.Shared/Physics/Events/PhysicsBodyStatusChangedEvent.cs
@@ -6,7 +6,7 @@ namespace Robust.Shared.Physics.Events;
 // This is called PhysicsBody and not just Body to differentiate from a potential literal living body
 /// <summary>
 ///     Raised on an entity when it's <see cref="PhysicsComponent"/>'s <see cref="BodyStatus"/> is <i>being</i> changed.
-///         This is raised just before <see cref="PhysicsComponent.BodyStatus"/> is actually set to the new status.
+///         Raised after <see cref="PhysicsComponent.BodyStatus"/> is set to the new status.
 /// </summary>
 /// <param name="PhysicsComponent"><see cref="PhysicsComponent"/> of the entity which this event was directed at.</param>
 [ByRefEvent]

--- a/Robust.Shared/Physics/Events/PhysicsBodyStatusChangedEvent.cs
+++ b/Robust.Shared/Physics/Events/PhysicsBodyStatusChangedEvent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.Physics.Components;
+
+namespace Robust.Shared.Physics.Events;
+
+// This is called PhysicsBody and not just Body to differentiate from a potential literal living body
+/// <summary>
+///     Raised on an entity when it's <see cref="PhysicsComponent"/>'s <see cref="BodyStatus"/> is <i>being</i> changed.
+///         This is raised just before <see cref="PhysicsComponent.BodyStatus"/> is actually set to the new status.
+/// </summary>
+/// <param name="PhysicsComponent"><see cref="PhysicsComponent"/> of the entity which this event was directed at.</param>
+[ByRefEvent]
+public readonly record struct PhysicsBodyStatusChangedEvent(PhysicsComponent PhysicsComponent, BodyStatus OldStatus, BodyStatus NewStatus);

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
@@ -153,7 +153,7 @@ public partial class SharedPhysicsSystem
             SetSleepingAllowed(uid, component, newState.SleepingAllowed, dirty: false);
             SetFixedRotation(uid, newState.FixedRotation, body: component, dirty: false);
             SetCanCollide(uid, newState.CanCollide, body: component, dirty: false);
-            component.BodyStatus = newState.Status;
+            SetBodyStatus(uid, component, newState.Status, dirty: false);
 
             SetLinearVelocity(uid, newState.LinearVelocity, dirty: false, body: component, manager: manager);
             SetAngularVelocity(uid, newState.AngularVelocity, dirty: false, body: component, manager: manager);
@@ -224,7 +224,7 @@ public partial class SharedPhysicsSystem
             return;
         }
 
-        SetLinearVelocity(uid,body.LinearVelocity + impulse * body._invMass, body: body);
+        SetLinearVelocity(uid, body.LinearVelocity + impulse * body._invMass, body: body);
     }
 
     public void ApplyLinearImpulse(EntityUid uid, Vector2 impulse, Vector2 point, FixturesComponent? manager = null, PhysicsComponent? body = null)
@@ -342,7 +342,7 @@ public partial class SharedPhysicsSystem
         var oldCenter = body._localCenter;
         body._localCenter = localCenter;
 
-        if (((int) body.BodyType & (int) (BodyType.Kinematic | BodyType.Static)) == 0)
+        if (((int)body.BodyType & (int)(BodyType.Kinematic | BodyType.Static)) == 0)
         {
             // Update center of mass velocity.
             var comVelocityDiff = Vector2Helpers.Cross(body.AngularVelocity, localCenter - oldCenter);
@@ -549,7 +549,12 @@ public partial class SharedPhysicsSystem
         if (body.BodyStatus == status)
             return;
 
+        // Include old BodyStatus too
+        var ev = new PhysicsBodyStatusChangedEvent(body, body.BodyStatus, status);
+        RaiseLocalEvent(uid, ref ev);
+
         body.BodyStatus = status;
+
         if (dirty)
             DirtyField(uid, body, nameof(PhysicsComponent.BodyStatus));
     }
@@ -770,7 +775,7 @@ public partial class SharedPhysicsSystem
 
         var (worldPos, worldRot) = _transform.GetWorldPositionRotation(xform);
 
-        var transform = new Transform(worldPos, (float) worldRot.Theta);
+        var transform = new Transform(worldPos, (float)worldRot.Theta);
 
         var bounds = new Box2(transform.Position, transform.Position);
 
@@ -797,7 +802,7 @@ public partial class SharedPhysicsSystem
 
         var (worldPos, worldRot) = _transform.GetWorldPositionRotation(xform);
 
-        var transform = new Transform(worldPos, (float) worldRot.Theta);
+        var transform = new Transform(worldPos, (float)worldRot.Theta);
 
         var bounds = new Box2(transform.Position, transform.Position);
 

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Components.cs
@@ -549,11 +549,11 @@ public partial class SharedPhysicsSystem
         if (body.BodyStatus == status)
             return;
 
-        // Include old BodyStatus too
-        var ev = new PhysicsBodyStatusChangedEvent(body, body.BodyStatus, status);
-        RaiseLocalEvent(uid, ref ev);
-
+        var oldStatus = body.BodyStatus;
         body.BodyStatus = status;
+
+        var ev = new PhysicsBodyStatusChangedEvent(body, oldStatus, status);
+        RaiseLocalEvent(uid, ref ev);
 
         if (dirty)
             DirtyField(uid, body, nameof(PhysicsComponent.BodyStatus));


### PR DESCRIPTION
Adds an event raised on entities after their PhysicsComponent's BodyStatus is changed.
SetBodyStatus raises it with this data:
- Physics component of the entity
- Current body status
- New body status that is about to be set

Component state handler for PhysicsComponentState also now uses SetBodyStatus instead of directly setting BodyStatus on the component, so the event is raised there too.