### PR TITLE
Add ClydeWindow API to set borderless mode

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Added the ability to set Clyde windows to borderless mode.
 
 ### Bugfixes
 

--- a/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
@@ -1,10 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Numerics;
-using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
 using Robust.Client.Input;
 using Robust.Client.UserInterface;
 using Robust.Shared;
@@ -14,13 +7,19 @@ using Robust.Shared.Maths;
 using Robust.Shared.Utility;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using System.Threading;
+using System.Threading.Tasks;
 using TerraFX.Interop.Windows;
 using FrameEventArgs = Robust.Shared.Timing.FrameEventArgs;
 using GL = OpenToolkit.Graphics.OpenGL4.GL;
 
 namespace Robust.Client.Graphics.Clyde
 {
-    internal partial class  Clyde
+    internal partial class Clyde
     {
         private readonly List<WindowReg> _windows = new();
         private readonly List<WindowHandle> _windowHandles = new();
@@ -282,6 +281,13 @@ namespace Robust.Client.Graphics.Clyde
             _windowing!.WindowSetTitle(_mainWindow!, title);
         }
 
+        private void SetWindowTitleBarVisible(WindowReg reg, bool visible)
+        {
+            DebugTools.AssertNotNull(_windowing);
+
+            _windowing!.WindowSetTitleBarVisible(reg, visible);
+        }
+
         public void SetWindowMonitor(IClydeMonitor monitor)
         {
             DebugTools.AssertNotNull(_windowing);
@@ -342,6 +348,7 @@ namespace Robust.Client.Graphics.Clyde
                     _mainWindow = reg;
 
                 reg.IsVisible = parameters.Visible;
+                reg.IsTitleBarVisible = parameters.TitleBarVisible;
 
                 _windows.Add(reg);
                 _windowHandles.Add(reg.Handle);
@@ -415,7 +422,7 @@ namespace Robust.Client.Graphics.Clyde
 
         private void WindowModeChanged(int mode)
         {
-            _windowMode = (WindowMode) mode;
+            _windowMode = (WindowMode)mode;
             _windowing?.UpdateMainWindowMode();
         }
 
@@ -495,6 +502,7 @@ namespace Robust.Client.Graphics.Clyde
             public bool IsMinimized;
             public string Title = "";
             public bool IsVisible;
+            public bool IsTitleBarVisible;
             public IClydeWindow? Owner;
 
             public bool DisposeOnClose;
@@ -554,6 +562,12 @@ namespace Robust.Client.Graphics.Clyde
                 set => _clyde.SetWindowVisible(Reg, value);
             }
 
+            public bool IsTitleBarVisible
+            {
+                get => Reg.IsTitleBarVisible;
+                set => _clyde.SetWindowTitleBarVisible(Reg, value);
+            }
+
             public Vector2 ContentScale => Reg.WindowScale;
 
             public bool DisposeOnClose
@@ -607,6 +621,7 @@ namespace Robust.Client.Graphics.Clyde
             }
 
             public nint? WindowsHWnd => _clyde._windowing!.WindowGetWin32Window(Reg);
+
         }
 
         private sealed class MonitorHandle : IClydeMonitor

--- a/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
@@ -281,11 +281,11 @@ namespace Robust.Client.Graphics.Clyde
             _windowing!.WindowSetTitle(_mainWindow!, title);
         }
 
-        private void SetWindowTitleBarVisible(WindowReg reg, bool visible)
+        private void SetWindowBordered(WindowReg reg, bool visible)
         {
             DebugTools.AssertNotNull(_windowing);
 
-            _windowing!.WindowSetTitleBarVisible(reg, visible);
+            _windowing!.WindowSetBordered(reg, visible);
         }
 
         public void SetWindowMonitor(IClydeMonitor monitor)
@@ -348,7 +348,7 @@ namespace Robust.Client.Graphics.Clyde
                     _mainWindow = reg;
 
                 reg.IsVisible = parameters.Visible;
-                reg.IsTitleBarVisible = parameters.TitleBarVisible;
+                reg.IsBordered = parameters.TitleBarVisible;
 
                 _windows.Add(reg);
                 _windowHandles.Add(reg.Handle);
@@ -502,7 +502,7 @@ namespace Robust.Client.Graphics.Clyde
             public bool IsMinimized;
             public string Title = "";
             public bool IsVisible;
-            public bool IsTitleBarVisible;
+            public bool IsBordered;
             public IClydeWindow? Owner;
 
             public bool DisposeOnClose;
@@ -562,10 +562,10 @@ namespace Robust.Client.Graphics.Clyde
                 set => _clyde.SetWindowVisible(Reg, value);
             }
 
-            public bool IsTitleBarVisible
+            public bool IsBordered
             {
-                get => Reg.IsTitleBarVisible;
-                set => _clyde.SetWindowTitleBarVisible(Reg, value);
+                get => Reg.IsBordered;
+                set => _clyde.SetWindowBordered(Reg, value);
             }
 
             public Vector2 ContentScale => Reg.WindowScale;

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -1,10 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Numerics;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Robust.Client.Audio;
 using Robust.Client.Input;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
@@ -16,6 +10,11 @@ using Robust.Shared.Maths;
 using Robust.Shared.Timing;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Numerics;
+using System.Threading.Tasks;
 using Color = Robust.Shared.Maths.Color;
 
 namespace Robust.Client.Graphics.Clyde
@@ -47,7 +46,7 @@ namespace Robust.Client.Graphics.Clyde
             SixLabors.ImageSharp.Configuration.Default.PreferContiguousImageBuffers = true;
 
             var mainRt = new DummyRenderWindow(this);
-            var window = new DummyWindow(mainRt) {Id = new WindowId(1)};
+            var window = new DummyWindow(mainRt) { Id = new WindowId(1) };
 
             _windows.Add(window);
             MainWindow = window;
@@ -109,6 +108,10 @@ namespace Robust.Client.Graphics.Clyde
         public void SetWindowTitle(string title)
         {
             // Nada.
+        }
+
+        public void SetWindowTitleBarVisible(bool visible)
+        {
         }
 
         public void SetWindowMonitor(IClydeMonitor monitor)
@@ -283,7 +286,7 @@ namespace Robust.Client.Graphics.Clyde
             // Nada.
         }
 
-        public ClydeHandle LoadShader(ParsedShader shader, string? name = null, Dictionary<string,string>? defines = null)
+        public ClydeHandle LoadShader(ParsedShader shader, string? name = null, Dictionary<string, string>? defines = null)
         {
             return default;
         }
@@ -579,6 +582,7 @@ namespace Robust.Client.Graphics.Clyde
             public bool IsFocused => false;
             public bool IsMinimized => false;
             public bool IsVisible { get; set; } = true;
+            public bool IsTitleBarVisible { get; set; } = true;
             public Vector2 ContentScale => Vector2.One;
             public bool DisposeOnClose { get; set; }
             public event Action<WindowRequestClosedEventArgs>? RequestClosed { add { } remove { } }

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -582,7 +582,7 @@ namespace Robust.Client.Graphics.Clyde
             public bool IsFocused => false;
             public bool IsMinimized => false;
             public bool IsVisible { get; set; } = true;
-            public bool IsTitleBarVisible { get; set; } = true;
+            public bool IsBordered { get; set; } = true;
             public Vector2 ContentScale => Vector2.One;
             public bool DisposeOnClose { get; set; }
             public event Action<WindowRequestClosedEventArgs>? RequestClosed { add { } remove { } }

--- a/Robust.Client/Graphics/Clyde/Windowing/IWindowingImpl.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/IWindowingImpl.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Threading.Tasks;
 using Robust.Client.Input;
 using Robust.Shared.Maths;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
+using System;
+using System.Threading.Tasks;
 
 namespace Robust.Client.Graphics.Clyde
 {
@@ -38,6 +38,7 @@ namespace Robust.Client.Graphics.Clyde
 
             void WindowDestroy(WindowReg reg);
             void WindowSetTitle(WindowReg window, string title);
+            void WindowSetTitleBarVisible(WindowReg window, bool visible);
             void WindowSetMonitor(WindowReg window, IClydeMonitor monitor);
             void WindowSetSize(WindowReg window, Vector2i size);
             void WindowSetVisible(WindowReg window, bool visible);

--- a/Robust.Client/Graphics/Clyde/Windowing/IWindowingImpl.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/IWindowingImpl.cs
@@ -21,7 +21,7 @@ namespace Robust.Client.Graphics.Clyde
             void TerminateWindowLoop();
 
             // Event pump
-            void ProcessEvents(bool single=false);
+            void ProcessEvents(bool single = false);
             void FlushDispose();
 
             // Cursor
@@ -38,7 +38,13 @@ namespace Robust.Client.Graphics.Clyde
 
             void WindowDestroy(WindowReg reg);
             void WindowSetTitle(WindowReg window, string title);
-            void WindowSetTitleBarVisible(WindowReg window, bool visible);
+            /// <summary>
+            /// Toggles the visibility of the window's border, including the title
+            /// bar.
+            /// </summary>
+            /// <param name="window">The window to affect.</param>
+            /// <param name="visible">The visibility of the border & titlebar to be set.</param>
+            void WindowSetBordered(WindowReg window, bool visible);
             void WindowSetMonitor(WindowReg window, IClydeMonitor monitor);
             void WindowSetSize(WindowReg window, Vector2i size);
             void WindowSetVisible(WindowReg window, bool visible);

--- a/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Window.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Window.cs
@@ -415,6 +415,12 @@ internal partial class Clyde
             });
         }
 
+
+        private static void WinThreadWinSetTitle(CmdWinSetTitle cmd)
+        {
+                SDL.SDL_SetWindowTitle(cmd.Window, cmd.Title);
+        }
+
         public void WindowSetTitleBarVisible(WindowReg window, bool visible)
         {
             window.IsTitleBarVisible = visible;
@@ -423,11 +429,6 @@ internal partial class Clyde
                 Window = WinPtr(window),
                 Visible = visible,
             });
-        }
-
-        private static void WinThreadWinSetTitle(CmdWinSetTitle cmd)
-        {
-            SDL.SDL_SetWindowTitle(cmd.Window, cmd.Title);
         }
 
         private static void WinThreadWinSetTitleBarVisible(CmdWinSetTitleBarVisible cmd)

--- a/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Window.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Window.cs
@@ -418,20 +418,20 @@ internal partial class Clyde
 
         private static void WinThreadWinSetTitle(CmdWinSetTitle cmd)
         {
-                SDL.SDL_SetWindowTitle(cmd.Window, cmd.Title);
+            SDL.SDL_SetWindowTitle(cmd.Window, cmd.Title);
         }
 
-        public void WindowSetTitleBarVisible(WindowReg window, bool visible)
+        public void WindowSetBordered(WindowReg window, bool visible)
         {
-            window.IsTitleBarVisible = visible;
-            SendCmd(new CmdWinSetTitleBarVisible
+            window.IsBordered = visible;
+            SendCmd(new CmdWinSetBordered
             {
                 Window = WinPtr(window),
                 Visible = visible,
             });
         }
 
-        private static void WinThreadWinSetTitleBarVisible(CmdWinSetTitleBarVisible cmd)
+        private static void WinThreadWinSetBordered(CmdWinSetBordered cmd)
         {
             SDL.SDL_SetWindowBordered(cmd.Window, cmd.Visible);
         }

--- a/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Window.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Window.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -265,14 +265,14 @@ internal partial class Clyde
                 switch (_videoDriver)
                 {
                     case SdlVideoDriver.Windows:
-                    {
-                        var hWnd = SDL.SDL_GetPointerProperty(
-                            props,
-                            SDL.SDL_PROP_WINDOW_WIN32_HWND_POINTER,
-                            0);
-                        WsiShared.SetWindowStyleNoTitleOptionsWindows((HWND)hWnd);
-                        break;
-                    }
+                        {
+                            var hWnd = SDL.SDL_GetPointerProperty(
+                                props,
+                                SDL.SDL_PROP_WINDOW_WIN32_HWND_POINTER,
+                                0);
+                            WsiShared.SetWindowStyleNoTitleOptionsWindows((HWND)hWnd);
+                            break;
+                        }
                     case SdlVideoDriver.X11:
                         unsafe
                         {
@@ -415,9 +415,24 @@ internal partial class Clyde
             });
         }
 
+        public void WindowSetTitleBarVisible(WindowReg window, bool visible)
+        {
+            window.IsTitleBarVisible = visible;
+            SendCmd(new CmdWinSetTitleBarVisible
+            {
+                Window = WinPtr(window),
+                Visible = visible,
+            });
+        }
+
         private static void WinThreadWinSetTitle(CmdWinSetTitle cmd)
         {
             SDL.SDL_SetWindowTitle(cmd.Window, cmd.Title);
+        }
+
+        private static void WinThreadWinSetTitleBarVisible(CmdWinSetTitleBarVisible cmd)
+        {
+            SDL.SDL_SetWindowBordered(cmd.Window, cmd.Visible);
         }
 
         public void WindowSetMonitor(WindowReg window, IClydeMonitor monitor)

--- a/Robust.Client/Graphics/Clyde/Windowing/Sdl3.WindowThread.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Sdl3.WindowThread.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Runtime.CompilerServices;
-using System.Threading.Channels;
-using System.Threading.Tasks;
 using Robust.Shared;
 using Robust.Shared.Maths;
 using SDL3;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 
 namespace Robust.Client.Graphics.Clyde;
 
@@ -79,6 +79,10 @@ internal partial class Clyde
 
                 case CmdWinSetTitle cmd:
                     WinThreadWinSetTitle(cmd);
+                    break;
+
+                case CmdWinSetTitleBarVisible cmd:
+                    WinThreadWinSetTitleBarVisible(cmd);
                     break;
 
                 case CmdSetClipboard cmd:
@@ -289,6 +293,12 @@ internal partial class Clyde
         {
             public nint Window;
             public required string Title;
+        }
+
+        private sealed class CmdWinSetTitleBarVisible : CmdBase
+        {
+            public nint Window;
+            public required bool Visible;
         }
 
         private sealed class CmdCursorCreate : CmdBase

--- a/Robust.Client/Graphics/Clyde/Windowing/Sdl3.WindowThread.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Sdl3.WindowThread.cs
@@ -81,8 +81,8 @@ internal partial class Clyde
                     WinThreadWinSetTitle(cmd);
                     break;
 
-                case CmdWinSetTitleBarVisible cmd:
-                    WinThreadWinSetTitleBarVisible(cmd);
+                case CmdWinSetBordered cmd:
+                    WinThreadWinSetBordered(cmd);
                     break;
 
                 case CmdSetClipboard cmd:
@@ -295,7 +295,7 @@ internal partial class Clyde
             public required string Title;
         }
 
-        private sealed class CmdWinSetTitleBarVisible : CmdBase
+        private sealed class CmdWinSetBordered : CmdBase
         {
             public nint Window;
             public required bool Visible;

--- a/Robust.Client/Graphics/IClydeWindow.cs
+++ b/Robust.Client/Graphics/IClydeWindow.cs
@@ -20,7 +20,10 @@ namespace Robust.Client.Graphics
         bool IsFocused { get; }
         bool IsMinimized { get; }
         bool IsVisible { get; set; }
-        bool IsTitleBarVisible { get; set; }
+        /// <summary>
+        ///     If set to false, then the titlebar and border of the window will be hidden.
+        /// </summary>
+        bool IsBordered { get; set; }
         Vector2 ContentScale { get; }
 
         /// <summary>

--- a/Robust.Client/Graphics/IClydeWindow.cs
+++ b/Robust.Client/Graphics/IClydeWindow.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Numerics;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using SDL3;
+using System;
+using System.Numerics;
 
 namespace Robust.Client.Graphics
 {
@@ -20,6 +20,7 @@ namespace Robust.Client.Graphics
         bool IsFocused { get; }
         bool IsMinimized { get; }
         bool IsVisible { get; set; }
+        bool IsTitleBarVisible { get; set; }
         Vector2 ContentScale { get; }
 
         /// <summary>

--- a/Robust.Client/Graphics/WindowCreateParameters.cs
+++ b/Robust.Client/Graphics/WindowCreateParameters.cs
@@ -9,6 +9,7 @@ namespace Robust.Client.Graphics
         public string Title = "";
         public bool Maximized;
         public bool Visible = true;
+        public bool TitleBarVisible = true;
         public IClydeMonitor? Monitor;
         public bool Fullscreen;
 


### PR DESCRIPTION
Adds support for borderless windows in the Clyde window engine. A window can be set to borderless by calling the `SetWindowTitleBarVisible`.

A decision needs to be made as to whether I should rename this method to `SetWindowBorderMode` or something similar.

This is required for fancy TGUI window support in OpenDream:

<img width="925" height="743" alt="image" src="https://github.com/user-attachments/assets/78c6930e-189a-4d99-aca6-594f91601c41" />
