### PR TITLE
Optimise sprite sorts

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
@@ -29,16 +29,31 @@ internal partial class Clyde
     {
         ProcessSpriteEntities(map, view, eye, worldBounds, _drawingSpriteList);
 
-        // We use a separate list for indexing sprites so that the sort is faster.
-        indexList = ArrayPool<int>.Shared.Rent(_drawingSpriteList.Count);
+        var count = _drawingSpriteList.Count;
 
-        // populate index list
-        for (var i = 0; i < _drawingSpriteList.Count; i++)
-            indexList[i] = i;
+        indexList = ArrayPool<int>.Shared.Rent(count);
+        var sortItems = ArrayPool<SpriteSortItem>.Shared.Rent(count);
 
-        // sort index list
+        for (var i = 0; i < count; i++)
+        {
+            ref var data = ref _drawingSpriteList[i];
+            sortItems[i] = new SpriteSortItem(
+                i,
+                data.Sprite.DrawDepth,
+                data.Sprite.RenderOrder,
+                data.SpriteScreenBB.Top,
+                data.Uid);
+        }
+
         // TODO better sorting? parallel merge sort?
-        Array.Sort(indexList, 0, _drawingSpriteList.Count, new SpriteDrawingOrderComparer(_drawingSpriteList));
+        Array.Sort(sortItems, 0, count);
+
+        for (var i = 0; i < count; i++)
+        {
+            indexList[i] = sortItems[i].Index;
+        }
+
+        ArrayPool<SpriteSortItem>.Shared.Return(sortItems);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -216,36 +231,41 @@ internal partial class Clyde
         public float Cos { get;  init; }
     }
 
-    private sealed class SpriteDrawingOrderComparer : IComparer<int>
+    private readonly struct SpriteSortItem : IComparable<SpriteSortItem>
     {
-        private readonly RefList<SpriteData> _drawList;
+        public readonly int Index;
+        private readonly int _drawDepth;
+        private readonly uint _renderOrder;
+        private readonly float _ySort;
+        private readonly EntityUid _uid;
 
-        public SpriteDrawingOrderComparer(RefList<SpriteData> drawList)
+        public SpriteSortItem(int index, int drawDepth, uint renderOrder, float ySort, EntityUid uid)
         {
-            _drawList = drawList;
+            Index = index;
+            _drawDepth = drawDepth;
+            _renderOrder = renderOrder;
+            _ySort = ySort;
+            _uid = uid;
         }
 
-        public int Compare(int x, int y)
+        public int CompareTo(SpriteSortItem other)
         {
-            var a = _drawList[x];
-            var b = _drawList[y];
-
-            var cmp = a.Sprite.DrawDepth.CompareTo(b.Sprite.DrawDepth);
+            var cmp = _drawDepth.CompareTo(other._drawDepth);
             if (cmp != 0)
                 return cmp;
 
-            cmp = a.Sprite.RenderOrder.CompareTo(b.Sprite.RenderOrder);
+            cmp = _renderOrder.CompareTo(other._renderOrder);
 
             if (cmp != 0)
                 return cmp;
 
             // compare the top of the sprite's BB for y-sorting. Because screen coordinates are flipped, the "top" of the BB is actually the "bottom".
-            cmp = a.SpriteScreenBB.Top.CompareTo(b.SpriteScreenBB.Top);
+            cmp = _ySort.CompareTo(other._ySort);
 
             if (cmp != 0)
                 return cmp;
 
-            return a.Uid.CompareTo(b.Uid);
+            return _uid.CompareTo(other._uid);
         }
     }
 }


### PR DESCRIPTION
Quick and dirty but shaved time off of total draw on debug (GetSprites -> Sort), would be less on release. Tried to get fancier but didn't pan out.

<img width="2590" height="417" alt="image" src="https://github.com/user-attachments/assets/65b0f299-5311-4085-a669-84d020551747" />
