### PR TITLE
SpriteSystem helpers to retrieve LayerMap keys

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.LayerMap.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.LayerMap.cs
@@ -195,14 +195,16 @@ public sealed partial class SpriteSystem
         return sprite.Comp.LayerMap[key];
     }
 
-    public bool LayerMapKeys(Entity<SpriteComponent?> sprite, [NotNullWhen(true)] out List<Object>? keys)
+    public bool LayerMapKeys(Entity<SpriteComponent?> sprite, [NotNullWhen(true)] out object[] keys)
     {
         if (!_query.Resolve(sprite.Owner, ref sprite.Comp))
         {
-            keys = null;
+            keys = new object[0];
             return false;
         }
-        keys = new List<Object>(sprite.Comp.LayerMap.Keys);
+
+        keys = new object[sprite.Comp.LayerMap.Keys.Count];
+        sprite.Comp.LayerMap.Keys.CopyTo(keys, 0);
         return true;
     }
 

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.LayerMap.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.LayerMap.cs
@@ -195,17 +195,11 @@ public sealed partial class SpriteSystem
         return sprite.Comp.LayerMap[key];
     }
 
-    public bool LayerMapKeys(Entity<SpriteComponent?> sprite, [NotNullWhen(true)] out object[] keys)
+    public object[] LayerMapKeys(Entity<SpriteComponent> sprite)
     {
-        if (!_query.Resolve(sprite.Owner, ref sprite.Comp))
-        {
-            keys = new object[0];
-            return false;
-        }
-
-        keys = new object[sprite.Comp.LayerMap.Keys.Count];
+        var keys = new object[sprite.Comp.LayerMap.Keys.Count];
         sprite.Comp.LayerMap.Keys.CopyTo(keys, 0);
-        return true;
+        return keys;
     }
 
     public bool LayerExists(Entity<SpriteComponent?> sprite, string key)

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.LayerMap.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.LayerMap.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.GameObjects;
 using static Robust.Client.GameObjects.SpriteComponent;
@@ -192,6 +193,17 @@ public sealed partial class SpriteSystem
             return -1;
 
         return sprite.Comp.LayerMap[key];
+    }
+
+    public bool LayerMapKeys(Entity<SpriteComponent?> sprite, [NotNullWhen(true)] out List<Object>? keys)
+    {
+        if (!_query.Resolve(sprite.Owner, ref sprite.Comp))
+        {
+            keys = null;
+            return false;
+        }
+        keys = new List<Object>(sprite.Comp.LayerMap.Keys);
+        return true;
     }
 
     public bool LayerExists(Entity<SpriteComponent?> sprite, string key)


### PR DESCRIPTION
Adds a helper to retrieve a SpriteComp's layerMap keys. Usefull for systems working with dynamic mappings