### PR TITLE
Add audio input (microphone), Opus codec, and offline speech-to-text primitives

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageVersion Include="Concentus" Version="2.2.2" />
     <PackageVersion Include="DiscordRichPresence" Version="1.2.1.24" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageVersion Include="JetBrains.Profiler.Api" Version="1.4.10" />
@@ -71,6 +72,8 @@
     <PackageVersion Include="TerraFX.Interop.Xlib" Version="6.4.0.2" />
     <!-- Intentionally kept back, there is a bug that breaks audio for systems without AVX instructions. And the fix is not yet published. -->
     <PackageVersion Include="VorbisPizza" Version="1.3.0" />
+    <PackageVersion Include="Whisper.net" Version="1.9.1" />
+    <PackageVersion Include="Whisper.net.Runtime" Version="1.9.1" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="prometheus-net" Version="8.2.1" />
     <PackageVersion Include="prometheus-net.DotNetRuntime" Version="4.4.1" />

--- a/Robust.Client/Audio/AudioManager.Public.cs
+++ b/Robust.Client/Audio/AudioManager.Public.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
 using System.Threading;
@@ -315,7 +316,7 @@ internal partial class AudioManager
     }
 
     /// <inheritdoc/>
-    IBufferedAudioSource? IAudioInternal.CreateBufferedAudioSource(int buffers, bool floatAudio)
+    public IBufferedAudioSource? CreateBufferedAudioSource(int buffers, bool floatAudio)
     {
         var source = AL.GenSource();
 
@@ -331,6 +332,82 @@ internal partial class AudioManager
         _bufferedAudioSources.Add(source, new WeakReference<BufferedAudioSource>(audioSource));
         ApplyDefaultParams(audioSource);
         return audioSource;
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<string> GetAudioInputDevices()
+    {
+        try
+        {
+            return new List<string>(ALC.GetStringList(GetEnumerationStringList.CaptureDeviceSpecifier));
+        }
+        catch (Exception e)
+        {
+            OpenALSawmill.Warning("Failed to enumerate audio capture devices: {0}", e);
+            return Array.Empty<string>();
+        }
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<string> GetAudioOutputDevices()
+    {
+        try
+        {
+            return new List<string>(ALC.GetStringList(GetEnumerationStringList.DeviceSpecifier));
+        }
+        catch (Exception e)
+        {
+            OpenALSawmill.Warning("Failed to enumerate audio output devices: {0}", e);
+            return Array.Empty<string>();
+        }
+    }
+
+    /// <inheritdoc/>
+    public IAudioInputDevice? OpenAudioInput(string? deviceName, int sampleRate, int internalBufferSamples = 0)
+    {
+        // Default the ring buffer to roughly one second of audio.
+        if (internalBufferSamples <= 0)
+            internalBufferSamples = sampleRate;
+
+        var device = ALC.CaptureOpenDevice(
+            string.IsNullOrEmpty(deviceName) ? null : deviceName,
+            sampleRate,
+            ALFormat.Mono16,
+            internalBufferSamples);
+
+        if (device == ALCaptureDevice.Null)
+        {
+            OpenALSawmill.Error("Failed to open audio capture device '{0}'", deviceName ?? "default");
+            return null;
+        }
+
+        return new OpenAlAudioInput(this, device, sampleRate);
+    }
+
+    /// <inheritdoc/>
+    public IOpusEncoder CreateOpusEncoder(int sampleRate, int channels)
+    {
+        return new OpusEncoderWrapper(sampleRate, channels);
+    }
+
+    /// <inheritdoc/>
+    public IOpusDecoder CreateOpusDecoder(int sampleRate, int channels)
+    {
+        return new OpusDecoderWrapper(sampleRate, channels);
+    }
+
+    /// <inheritdoc/>
+    public ISpeechTranscriber? CreateSpeechTranscriber(string modelPath, string language = "auto")
+    {
+        try
+        {
+            return new WhisperSpeechTranscriber(modelPath, language);
+        }
+        catch (Exception e)
+        {
+            OpenALSawmill.Error("Failed to create speech transcriber from model '{0}': {1}", modelPath, e);
+            return null;
+        }
     }
 
     private void ApplyDefaultParams(IAudioSource source)

--- a/Robust.Client/Audio/HeadlessAudioManager.cs
+++ b/Robust.Client/Audio/HeadlessAudioManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
 using Robust.Shared.Audio;
@@ -60,6 +61,43 @@ internal sealed class HeadlessAudioManager : IAudioInternal
     /// <inheritdoc />
     public void SetMasterGain(float newGain)
     {
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> GetAudioInputDevices()
+    {
+        return Array.Empty<string>();
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> GetAudioOutputDevices()
+    {
+        return Array.Empty<string>();
+    }
+
+    /// <inheritdoc />
+    public IOpusEncoder CreateOpusEncoder(int sampleRate, int channels)
+    {
+        // The codec is pure-managed and works without an audio device.
+        return new OpusEncoderWrapper(sampleRate, channels);
+    }
+
+    /// <inheritdoc />
+    public IOpusDecoder CreateOpusDecoder(int sampleRate, int channels)
+    {
+        return new OpusDecoderWrapper(sampleRate, channels);
+    }
+
+    /// <inheritdoc />
+    public IAudioInputDevice? OpenAudioInput(string? deviceName, int sampleRate, int internalBufferSamples = 0)
+    {
+        return null;
+    }
+
+    /// <inheritdoc />
+    public ISpeechTranscriber? CreateSpeechTranscriber(string modelPath, string language = "auto")
+    {
+        return null;
     }
 
     /// <inheritdoc />

--- a/Robust.Client/Audio/IAudioInputDevice.cs
+++ b/Robust.Client/Audio/IAudioInputDevice.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Robust.Client.Audio;
+
+/// <summary>
+/// A handle to an opened microphone (OpenAL capture device) that produces mono 16-bit PCM.
+/// Used by voice chat to read raw samples for encoding. Dispose to stop and release the device.
+/// </summary>
+public interface IAudioInputDevice : IDisposable
+{
+    /// <summary>
+    /// The sample rate the device was opened at, in Hz.
+    /// </summary>
+    int SampleRate { get; }
+
+    /// <summary>
+    /// Number of captured samples currently available to read from the device's internal ring buffer.
+    /// </summary>
+    int AvailableSamples { get; }
+
+    /// <summary>
+    /// Reads captured samples into <paramref name="buffer"/>, up to whichever is smaller of the buffer
+    /// length and <see cref="AvailableSamples"/>. Does not block.
+    /// </summary>
+    /// <returns>The number of samples actually read.</returns>
+    int Read(Span<short> buffer);
+}

--- a/Robust.Client/Audio/IAudioInternal.cs
+++ b/Robust.Client/Audio/IAudioInternal.cs
@@ -22,12 +22,6 @@ internal interface IAudioInternal : IAudioManager
     void FlushALDisposeQueues();
 
     /// <summary>
-    /// Returns a buffered audio source.
-    /// </summary>
-    /// <returns>null if unable to create the source.</returns>
-    IBufferedAudioSource? CreateBufferedAudioSource(int buffers, bool floatAudio=false);
-
-    /// <summary>
     /// Sets the velocity for the audio listener.
     /// </summary>
     void SetVelocity(Vector2 velocity);

--- a/Robust.Client/Audio/IAudioManager.cs
+++ b/Robust.Client/Audio/IAudioManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Robust.Shared.Audio.Sources;
 
@@ -12,6 +13,13 @@ public interface IAudioManager
 {
     IAudioSource? CreateAudioSource(AudioStream stream);
 
+    /// <summary>
+    /// Creates a streaming audio source that PCM frames can be queued into at runtime.
+    /// Used for real-time audio such as voice chat.
+    /// </summary>
+    /// <returns>null if unable to create the source.</returns>
+    IBufferedAudioSource? CreateBufferedAudioSource(int buffers, bool floatAudio = false);
+
     AudioStream LoadAudioOggVorbis(Stream stream, string? name = null);
 
     AudioStream LoadAudioWav(Stream stream, string? name = null);
@@ -19,4 +27,45 @@ public interface IAudioManager
     AudioStream LoadAudioRaw(ReadOnlySpan<short> samples, int channels, int sampleRate, string? name = null);
 
     void SetMasterGain(float gain);
+
+    /// <summary>
+    /// Lists the names of available microphone (capture) devices. The names can be passed to
+    /// <see cref="OpenAudioInput"/>.
+    /// </summary>
+    IReadOnlyList<string> GetAudioInputDevices();
+
+    /// <summary>
+    /// Lists the names of available audio output (playback) devices. A name can be set on the
+    /// <c>audio.device</c> CVar to select the output device used for all game audio (applied on next launch).
+    /// </summary>
+    IReadOnlyList<string> GetAudioOutputDevices();
+
+    /// <summary>
+    /// Opens a microphone for recording mono 16-bit PCM.
+    /// </summary>
+    /// <param name="deviceName">Capture device name, or null/empty for the system default.</param>
+    /// <param name="sampleRate">Desired sample rate in Hz.</param>
+    /// <param name="internalBufferSamples">
+    /// Size of the device's internal ring buffer in samples. 0 picks a sensible default (~1 second).
+    /// </param>
+    /// <returns>The opened device, or null on failure. Caller must dispose it.</returns>
+    IAudioInputDevice? OpenAudioInput(string? deviceName, int sampleRate, int internalBufferSamples = 0);
+
+    /// <summary>
+    /// Creates an Opus voice encoder for the given format. Caller must dispose it.
+    /// </summary>
+    IOpusEncoder CreateOpusEncoder(int sampleRate, int channels);
+
+    /// <summary>
+    /// Creates an Opus voice decoder for the given format. Caller must dispose it.
+    /// </summary>
+    IOpusDecoder CreateOpusDecoder(int sampleRate, int channels);
+
+    /// <summary>
+    /// Creates an offline speech-to-text transcriber from a local model file. Caller must dispose it.
+    /// </summary>
+    /// <param name="modelPath">Path to a Whisper ggml model file.</param>
+    /// <param name="language">Language code to transcribe (e.g. "en"), or "auto" to auto-detect.</param>
+    /// <returns>The transcriber, or null if the model could not be loaded.</returns>
+    ISpeechTranscriber? CreateSpeechTranscriber(string modelPath, string language = "auto");
 }

--- a/Robust.Client/Audio/IOpusCodec.cs
+++ b/Robust.Client/Audio/IOpusCodec.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Robust.Client.Audio;
+
+/// <summary>
+/// Opus voice encoder. Encodes 16-bit PCM frames into compressed Opus packets.
+/// </summary>
+/// <remarks>
+/// This lives in the engine because content assemblies are sandboxed and cannot reference the Concentus
+/// codec library directly. Content gets one of these via <see cref="IAudioManager.CreateOpusEncoder"/>.
+/// </remarks>
+public interface IOpusEncoder : IDisposable
+{
+    /// <summary>
+    /// Encodes a single frame of PCM (<paramref name="frameSize"/> samples per channel) into <paramref name="output"/>.
+    /// </summary>
+    /// <returns>The number of bytes written to <paramref name="output"/>, or a non-positive value on failure.</returns>
+    int Encode(ReadOnlySpan<short> pcm, int frameSize, Span<byte> output);
+}
+
+/// <summary>
+/// Opus voice decoder. See <see cref="IOpusEncoder"/> for why this lives in the engine.
+/// </summary>
+public interface IOpusDecoder : IDisposable
+{
+    /// <summary>
+    /// Decodes a single Opus packet into <paramref name="output"/>.
+    /// </summary>
+    /// <returns>The number of samples (per channel) decoded.</returns>
+    int Decode(ReadOnlySpan<byte> data, Span<short> output, int frameSize, bool decodeFec);
+}

--- a/Robust.Client/Audio/ISpeechTranscriber.cs
+++ b/Robust.Client/Audio/ISpeechTranscriber.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Robust.Client.Audio;
+
+/// <summary>
+/// Offline speech-to-text transcriber backed by a local model.
+/// </summary>
+/// <remarks>
+/// This lives in the engine because content assemblies are sandboxed and cannot reference the native
+/// transcription library directly. Content gets one of these via <see cref="IAudioManager.CreateSpeechTranscriber"/>,
+/// e.g. to transcribe captured voice-chat audio.
+/// </remarks>
+public interface ISpeechTranscriber : IDisposable
+{
+    /// <summary>
+    /// Transcribes a buffer of mono 16-bit PCM, sampled at 16 kHz, into text.
+    /// </summary>
+    /// <param name="pcm">Mono 16-bit PCM samples at 16 kHz. Other sample rates are not supported by the model.</param>
+    /// <param name="cancel">Cancels the in-progress transcription.</param>
+    /// <returns>
+    /// The recognised text (all segments concatenated), or an empty string if nothing was recognised.
+    /// </returns>
+    Task<string> TranscribeAsync(ReadOnlyMemory<short> pcm, CancellationToken cancel = default);
+}

--- a/Robust.Client/Audio/OpusCodec.cs
+++ b/Robust.Client/Audio/OpusCodec.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace Robust.Client.Audio;
+
+/// <summary>
+/// <see cref="IOpusEncoder"/> backed by the Concentus pure-managed Opus implementation.
+/// Concentus types are fully qualified to avoid colliding with the engine's own <see cref="IOpusEncoder"/>.
+/// </summary>
+internal sealed class OpusEncoderWrapper : IOpusEncoder
+{
+    private readonly Concentus.IOpusEncoder _encoder;
+
+    public OpusEncoderWrapper(int sampleRate, int channels)
+    {
+        _encoder = Concentus.OpusCodecFactory.CreateEncoder(
+            sampleRate, channels, Concentus.Enums.OpusApplication.OPUS_APPLICATION_VOIP, null);
+    }
+
+    public int Encode(ReadOnlySpan<short> pcm, int frameSize, Span<byte> output)
+    {
+        return _encoder.Encode(pcm, frameSize, output, output.Length);
+    }
+
+    public void Dispose()
+    {
+        // Concentus codecs are pure-managed; nothing unmanaged to release.
+    }
+}
+
+/// <summary>
+/// <see cref="IOpusDecoder"/> backed by the Concentus pure-managed Opus implementation.
+/// </summary>
+internal sealed class OpusDecoderWrapper : IOpusDecoder
+{
+    private readonly Concentus.IOpusDecoder _decoder;
+
+    public OpusDecoderWrapper(int sampleRate, int channels)
+    {
+        _decoder = Concentus.OpusCodecFactory.CreateDecoder(sampleRate, channels, null);
+    }
+
+    public int Decode(ReadOnlySpan<byte> data, Span<short> output, int frameSize, bool decodeFec)
+    {
+        return _decoder.Decode(data, output, frameSize, decodeFec);
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/Robust.Client/Audio/Sources/OpenAlAudioInput.cs
+++ b/Robust.Client/Audio/Sources/OpenAlAudioInput.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Runtime.InteropServices;
+using OpenTK.Audio.OpenAL;
+
+namespace Robust.Client.Audio.Sources;
+
+/// <summary>
+/// <see cref="IAudioInputDevice"/> backed by an OpenAL capture device (ALC_EXT_CAPTURE).
+/// </summary>
+internal sealed class OpenAlAudioInput : IAudioInputDevice
+{
+    private readonly AudioManager _master;
+    private ALCaptureDevice _device;
+    private bool _disposed;
+
+    public int SampleRate { get; }
+
+    public int AvailableSamples
+    {
+        get
+        {
+            if (_disposed)
+                return 0;
+
+            return ALC.GetInteger(_device, AlcGetInteger.CaptureSamples);
+        }
+    }
+
+    public OpenAlAudioInput(AudioManager master, ALCaptureDevice device, int sampleRate)
+    {
+        _master = master;
+        _device = device;
+        SampleRate = sampleRate;
+        ALC.CaptureStart(_device);
+    }
+
+    public int Read(Span<short> buffer)
+    {
+        if (_disposed)
+            return 0;
+
+        var toRead = Math.Min(AvailableSamples, buffer.Length);
+        if (toRead <= 0)
+            return 0;
+
+        // ALC.CaptureSamples will read exactly 'toRead' samples; we clamp to availability above so it never underflows.
+        ALC.CaptureSamples(_device, ref MemoryMarshal.GetReference(buffer), toRead);
+        return toRead;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        ALC.CaptureStop(_device);
+        ALC.CaptureCloseDevice(_device);
+        _device = ALCaptureDevice.Null;
+    }
+}

--- a/Robust.Client/Audio/WhisperSpeechTranscriber.cs
+++ b/Robust.Client/Audio/WhisperSpeechTranscriber.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Whisper.net;
+
+namespace Robust.Client.Audio;
+
+/// <summary>
+/// <see cref="ISpeechTranscriber"/> backed by Whisper.net (a managed wrapper around whisper.cpp), running a
+/// local ggml model. See <see cref="ISpeechTranscriber"/> for why this lives in the engine.
+/// </summary>
+internal sealed class WhisperSpeechTranscriber : ISpeechTranscriber
+{
+    private const int SampleRate = 16_000;
+
+    private readonly WhisperFactory _factory;
+    private readonly WhisperProcessor _processor;
+
+    public WhisperSpeechTranscriber(string modelPath, string language)
+    {
+        _factory = WhisperFactory.FromPath(modelPath);
+        _processor = _factory.CreateBuilder()
+            .WithLanguage(language)
+            .Build();
+    }
+
+    public async Task<string> TranscribeAsync(ReadOnlyMemory<short> pcm, CancellationToken cancel = default)
+    {
+        // Whisper expects 16 kHz mono float samples normalised to [-1, 1].
+        var span = pcm.Span;
+        var samples = new float[span.Length];
+        for (var i = 0; i < span.Length; i++)
+            samples[i] = span[i] / 32768f;
+
+        var builder = new StringBuilder();
+        await foreach (var segment in _processor.ProcessAsync(samples, cancel))
+        {
+            builder.Append(segment.Text);
+        }
+
+        return builder.ToString().Trim();
+    }
+
+    public void Dispose()
+    {
+        _processor.Dispose();
+        _factory.Dispose();
+    }
+}

--- a/Robust.Client/Robust.Client.csproj
+++ b/Robust.Client/Robust.Client.csproj
@@ -19,6 +19,9 @@
     <PackageReference Include="SixLabors.ImageSharp" />
     <PackageReference Include="OpenToolkit.Graphics" PrivateAssets="compile" />
     <PackageReference Include="OpenTK.Audio.OpenAL" PrivateAssets="compile" />
+    <PackageReference Include="Concentus" PrivateAssets="compile" />
+    <PackageReference Include="Whisper.net" PrivateAssets="compile" />
+    <PackageReference Include="Whisper.net.Runtime" PrivateAssets="compile" />
     <PackageReference Include="SpaceWizards.SharpFont" PrivateAssets="compile" />
     <PackageReference Include="SpaceWizards.Sdl" PrivateAssets="compile" />
     <PackageReference Include="Robust.Natives" />

--- a/Robust.Shared/Audio/Sources/IBufferedAudioSource.cs
+++ b/Robust.Shared/Audio/Sources/IBufferedAudioSource.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Robust.Shared.Audio.Sources;
 
-internal interface IBufferedAudioSource : IAudioSource
+public interface IBufferedAudioSource : IAudioSource
 {
     int SampleRate { get; set; }
     int GetNumberOfBuffersProcessed();


### PR DESCRIPTION
## Summary

Exposes engine-level audio capabilities that sandboxed content cannot implement itself, because content assemblies may not reference native audio/codec libraries (OpenTK/OpenAL capture, Concentus, Whisper.net) or use native interop. These are the primitives needed to build features like in-game voice chat purely in content.

### Microphone capture
- `IAudioManager.GetAudioInputDevices()` enumerates capture devices.
- `IAudioManager.OpenAudioInput(deviceName, sampleRate, internalBufferSamples)` opens a microphone as a new `IAudioInputDevice` that produces mono 16-bit PCM, backed by OpenAL `ALC_EXT_CAPTURE`.
- `IAudioManager.GetAudioOutputDevices()` enumerates output devices.

### Opus codec
- `IAudioManager.CreateOpusEncoder()` / `CreateOpusDecoder()` return `IOpusEncoder` / `IOpusDecoder`, backed by the pure-managed [Concentus](https://www.nuget.org/packages/Concentus) library.

### Streaming playback
- `IBufferedAudioSource` is now `public` and `IAudioManager.CreateBufferedAudioSource()` is exposed (moved from the internal `IAudioInternal`), so PCM frames can be queued into a streaming source at runtime.

### Offline speech-to-text
- `IAudioManager.CreateSpeechTranscriber(modelPath, language)` returns a new `ISpeechTranscriber` that transcribes 16 kHz mono PCM into text using a **local** Whisper model, backed by [Whisper.net](https://www.nuget.org/packages/Whisper.net) (whisper.cpp). The model file is supplied by the caller; nothing is sent off-device.

`HeadlessAudioManager` implements all new members (no devices; the Opus codec works without an audio device, transcription returns null).

## New dependencies
- `Concentus` (pure-managed Opus) — referenced with `PrivateAssets="compile"`.
- `Whisper.net` + `Whisper.net.Runtime` (native whisper.cpp binaries) — referenced with `PrivateAssets="compile"`.

## Notes
The speech-to-text primitive is included here for completeness but pulls in native whisper.cpp runtime binaries; happy to split it into a separate PR (or drop it) if the added dependency is unwanted in core.
