### PR TITLE
Add trust scores for localhost@ and guest@ connections

### DIFF
--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -996,6 +996,18 @@ namespace Robust.Shared
         public static readonly CVarDef<string> AuthServer =
             CVarDef.Create("auth.server", AuthManager.DefaultAuthServer, CVar.SERVERONLY);
 
+        /// <summary>
+        /// Trust score for unauthenticated localhost connections
+        /// </summary>
+        public static readonly CVarDef<float> AuthLocalTrust =
+            CVarDef.Create("auth.localtrust", 1f, CVar.SERVERONLY);
+
+        /// <summary>
+        /// Trust score for guest connections
+        /// </summary>
+        public static readonly CVarDef<float> AuthGuestTrust =
+            CVarDef.Create("auth.guesttrust", 0f, CVar.SERVERONLY);
+
         /*
          * RENDERING
          */

--- a/Robust.Shared/Network/NetManager.ServerAuth.cs
+++ b/Robust.Shared/Network/NetManager.ServerAuth.cs
@@ -220,10 +220,14 @@ namespace Robust.Shared.Network
                     _logger.Verbose(
                         $"{connection.RemoteEndPoint}: Assigned user ID: {userId}");
 
+                    var localTrust = _config.GetCVar(CVars.AuthLocalTrust);
+                    var guestTrust = _config.GetCVar(CVars.AuthGuestTrust);
+
                     userData = new NetUserData(userId, name)
                     {
                         HWId = [],
-                        ModernHWIds = []
+                        ModernHWIds = [],
+                        Trust = isLocal ? localTrust : guestTrust
                     };
                 }
 


### PR DESCRIPTION
Related to https://github.com/space-wizards/space-station-14/pull/44317, but not required for it to function

Should there ever be code implemented that uses trust scores, this will allow for testing said code without hacky solutions.

Adds 2 cvars:
- `auth.localtrust`, defaults to 1
- `auth.guesttrust`, defaults to 0