### PR TITLE
add color parameter to PrototypeCopyToShaderParameters & CopyToShaderParameters

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1758,13 +1758,21 @@ namespace Robust.Client.GameObjects
         public sealed class CopyToShaderParameters(object layerKey)
         {
             public object LayerKey = layerKey;
+
+            /// <inheritdoc cref="PrototypeCopyToShaderParameters.ParameterTexture"/>
             public string? ParameterTexture;
+
+            /// <inheritdoc cref="PrototypeCopyToShaderParameters.ParameterUV"/>
             public string? ParameterUV;
+
+            /// <inheritdoc cref="PrototypeCopyToShaderParameters.ParameterColor"/>
+            public string? ParameterColor;
 
             public CopyToShaderParameters(CopyToShaderParameters toClone) : this(toClone.LayerKey)
             {
                 ParameterTexture = toClone.ParameterTexture;
                 ParameterUV = toClone.ParameterUV;
+                ParameterColor = toClone.ParameterColor;
             }
         }
 

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1757,6 +1757,7 @@ namespace Robust.Client.GameObjects
         /// </summary>
         public sealed class CopyToShaderParameters(object layerKey)
         {
+            /// <inheritdoc cref="PrototypeCopyToShaderParameters.LayerKey"/>
             public object LayerKey = layerKey;
 
             /// <inheritdoc cref="PrototypeCopyToShaderParameters.ParameterTexture"/>

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Render.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Render.cs
@@ -126,13 +126,14 @@ public sealed partial class SpriteSystem
         dir = dir.OffsetRsiDir(layer.DirOffset);
 
         var texture = state?.GetFrame(dir, layer.AnimationFrame) ?? layer.Texture ?? GetFallbackTexture();
+        var layerColor = layer.Owner.Comp.color * layer.Color;
 
         // TODO SPRITE
         // Refactor shader-param-layers to a separate layer type after layers are split into types & collections.
         // I.e., separate Layer -> RsiLayer, TextureLayer, LayerCollection, SpriteLayer, and ShaderLayer
         if (layer.CopyToShaderParameters != null)
         {
-            HandleShaderLayer(layer, texture, layer.CopyToShaderParameters);
+            HandleShaderLayer(layer, texture, layer.CopyToShaderParameters, layerColor);
             return;
         }
 
@@ -143,7 +144,6 @@ public sealed partial class SpriteSystem
         if (layer.Shader != null)
             drawingHandle.UseShader(layer.Shader);
 
-        var layerColor = layer.Owner.Comp.color * layer.Color;
         var textureSize = texture.Size / (float) EyeManager.PixelsPerMeter;
         var quad = Box2.FromDimensions(textureSize / -2, textureSize);
 
@@ -168,7 +168,7 @@ public sealed partial class SpriteSystem
     /// Handle a a "fake layer" that just exists to modify the parameters of a shader being used by some other
     /// layer.
     /// </summary>
-    private void HandleShaderLayer(Layer layer, Texture texture, CopyToShaderParameters @params)
+    private void HandleShaderLayer(Layer layer, Texture texture, CopyToShaderParameters @params, Color layerColor)
     {
         // Multiple atrocities to god being committed right here.
         var otherLayerIdx = layer._parent.LayerMap[@params.LayerKey!];
@@ -183,6 +183,9 @@ public sealed partial class SpriteSystem
 
         if (@params.ParameterTexture is { } paramTexture)
             shader.SetParameter(paramTexture, clydeTexture);
+
+        if (@params.ParameterColor is { } paramColor)
+            shader.SetParameter(paramColor, layerColor);
 
         if (@params.ParameterUV is not { } paramUV)
             return;

--- a/Robust.Shared/GameObjects/Components/Renderable/SpriteLayerData.cs
+++ b/Robust.Shared/GameObjects/Components/Renderable/SpriteLayerData.cs
@@ -72,6 +72,12 @@ public sealed partial class PrototypeCopyToShaderParameters
     /// The name of the shader parameter that will receive UVs to select the sprite in <see cref="ParameterTexture"/>.
     /// </summary>
     [DataField] public string? ParameterUV;
+
+    /// <summary>
+    /// The name of the shader parameter that will receive the color of the layer which these parameters are on.
+    /// This is usually the entity's <see cref="SpriteComponent.Color"/> multiplied by the corresponding layer's <see cref="SpriteComponent.Layer.Color"/>.
+    /// </summary>
+    [DataField] public string? ParameterColor;
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
In a similar vein to ParameterTexture and ParameterUV on CopyToShaderParameters, added ParameterColor which is the name of the shader parameter (null if it shouldn't be passed) that is passed to the target shader with its value being the color that the current layer should be rendered as.

More simply, as said in the code comments, ParameterColor is:
> The name of the shader parameter that will receive the color of the layer which these parameters are on. This is usually the entity's  SpriteComponent.Color multiplied by the corresponding layer's SpriteComponent.Layer.Color

This PR also makes CopyToShaderParameters inherit some documentation for it's fields.