### PR TITLE
Change pixelspermeter to a cvar

### DIFF
--- a/Robust.Client/GameController/GameController.cs
+++ b/Robust.Client/GameController/GameController.cs
@@ -426,6 +426,9 @@ namespace Robust.Client
                 _configurationManager.OverrideConVars(_commandLineArgs.CVars);
             }
 
+
+            _configurationManager.OnValueChanged(CVars.DisplayPixelsPerMeter, EyeManager.SetPixelsPerMeter, invokeImmediately: true);
+
             ProfileOptSetup.Setup(_configurationManager);
 
             _prof.Initialize();

--- a/Robust.Client/Graphics/ClientEye/EyeManager.cs
+++ b/Robust.Client/Graphics/ClientEye/EyeManager.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Globalization;
 using System.Numerics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.CustomControls;
@@ -15,12 +17,36 @@ namespace Robust.Client.Graphics
     /// <inheritdoc />
     public sealed partial class EyeManager : IEyeManager
     {
-        // If you modify this make sure to edit the value in the Robust.Shared.Audio.AudioParams struct default too!
-        // No I can't be bothered to make this a shared constant.
         /// <summary>
-        /// Default scaling for the projection matrix.
+        /// Default scaling for the projection matrix: how many texture pixels map to one world meter (tile).
         /// </summary>
-        public const int PixelsPerMeter = 32;
+        /// <remarks>
+        /// Defaults to 32. It can be overridden once, at process startup, via the
+        /// <c>ROBUST_PIXELS_PER_METER</c> environment variable. This is fixed for the lifetime of the
+        /// process and is NOT safe to change at runtime.
+        /// </remarks>
+        public static readonly int PixelsPerMeter = ReadPixelsPerMeter();
+
+        /// <summary>
+        /// Environment variable used to override <see cref="PixelsPerMeter"/> at startup.
+        /// </summary>
+        public const string PixelsPerMeterEnvVar = "ROBUST_PIXELS_PER_METER";
+
+        private const int DefaultPixelsPerMeter = 32;
+
+        private static int ReadPixelsPerMeter()
+        {
+            var raw = Environment.GetEnvironmentVariable(PixelsPerMeterEnvVar);
+
+            if (!string.IsNullOrWhiteSpace(raw)
+                && int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+                && value > 0)
+            {
+                return value;
+            }
+
+            return DefaultPixelsPerMeter;
+        }
 
         [Dependency] private IClyde _displayManager = default!;
         [Dependency] private IEntityManager _entityManager = default!;

--- a/Robust.Client/Graphics/ClientEye/EyeManager.cs
+++ b/Robust.Client/Graphics/ClientEye/EyeManager.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Globalization;
 using System.Numerics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.CustomControls;
@@ -18,34 +16,24 @@ namespace Robust.Client.Graphics
     public sealed partial class EyeManager : IEyeManager
     {
         /// <summary>
-        /// Default scaling for the projection matrix: how many texture pixels map to one world meter (tile).
+        /// Defaults to 32.
+        /// How many texture pixels map to one world meter (one tile). Driven by the server-authoritative <c>display.pixels_per_meter</c> CVar (default 32).
         /// </summary>
-        /// <remarks>
-        /// Defaults to 32. It can be overridden once, at process startup, via the
-        /// <c>ROBUST_PIXELS_PER_METER</c> environment variable. This is fixed for the lifetime of the
-        /// process and is NOT safe to change at runtime.
-        /// </remarks>
-        public static readonly int PixelsPerMeter = ReadPixelsPerMeter();
+        public static int PixelsPerMeter { get; private set; } = DefaultPixelsPerMeter;
 
         /// <summary>
-        /// Environment variable used to override <see cref="PixelsPerMeter"/> at startup.
+        /// Default for <see cref="PixelsPerMeter"/>, used before the replicated CVar value is applied.
         /// </summary>
-        public const string PixelsPerMeterEnvVar = "ROBUST_PIXELS_PER_METER";
+        public const int DefaultPixelsPerMeter = 32;
 
-        private const int DefaultPixelsPerMeter = 32;
-
-        private static int ReadPixelsPerMeter()
+        /// <summary>
+        /// Applies the <c>display.pixels_per_meter</c> CVar to <see cref="PixelsPerMeter"/>. Invoked with the
+        /// local default at startup and again with the server's value on connect. Non-positive values fall
+        /// back to <see cref="DefaultPixelsPerMeter"/>.
+        /// </summary>
+        internal static void SetPixelsPerMeter(int value)
         {
-            var raw = Environment.GetEnvironmentVariable(PixelsPerMeterEnvVar);
-
-            if (!string.IsNullOrWhiteSpace(raw)
-                && int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
-                && value > 0)
-            {
-                return value;
-            }
-
-            return DefaultPixelsPerMeter;
+            PixelsPerMeter = value > 0 ? value : DefaultPixelsPerMeter;
         }
 
         [Dependency] private IClyde _displayManager = default!;

--- a/Robust.Client/Graphics/Drawing/DrawingHandleWorld.cs
+++ b/Robust.Client/Graphics/Drawing/DrawingHandleWorld.cs
@@ -10,7 +10,7 @@ namespace Robust.Client.Graphics
         {
         }
 
-        private const int Ppm = EyeManager.PixelsPerMeter;
+        private static readonly int Ppm = EyeManager.PixelsPerMeter;
 
         /// <summary>
         /// Draws an untextured colored rectangle to the world.The coordinate system is right handed.

--- a/Robust.Client/Graphics/Drawing/DrawingHandleWorld.cs
+++ b/Robust.Client/Graphics/Drawing/DrawingHandleWorld.cs
@@ -10,7 +10,7 @@ namespace Robust.Client.Graphics
         {
         }
 
-        private static readonly int Ppm = EyeManager.PixelsPerMeter;
+        private static int Ppm => EyeManager.PixelsPerMeter;
 
         /// <summary>
         /// Draws an untextured colored rectangle to the world.The coordinate system is right handed.

--- a/Robust.Client/Map/ClydeTileDefinitionManager.cs
+++ b/Robust.Client/Map/ClydeTileDefinitionManager.cs
@@ -103,7 +103,7 @@ namespace Robust.Client.Map
             if (defList.Count <= 0)
                 return;
 
-            const int tileSize = EyeManager.PixelsPerMeter;
+            var tileSize = EyeManager.PixelsPerMeter;
 
             var tileCount = defList.Select(x => x.Variants + x.EdgeSprites.Count).Sum() + 1;
 

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1022,6 +1022,13 @@ namespace Robust.Shared
         public static readonly CVarDef<bool> RenderTileEdges =
             CVarDef.Create("render.tile_edges", true, CVar.CLIENTONLY);
 
+        /// <summary>
+        /// How many texture pixels map to one world meter (one tile).
+        /// It is expected to stay fixed for a given deployment and is probably not safe to change while in-game.
+        /// </summary>
+        public static readonly CVarDef<int> DisplayPixelsPerMeter =
+            CVarDef.Create("display.pixels_per_meter", 32, CVar.REPLICATED | CVar.SERVER);
+
         /*
          *  CONTROLS
          */


### PR DESCRIPTION
I want to make the game 64x64 on a new fork im working on

> // If you modify this make sure to edit the value in the  Robust.Shared.Audio.AudioParams struct default too!

Comment has been out of date as of like 8 years ago now lol, nuking it

<img width="1951" height="1249" alt="image" src="https://github.com/user-attachments/assets/51c1bbc0-b33f-4b04-8f48-0916f4fdebe9" />
