### PR TITLE
Add sundries + static sundries to grid traversal

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* Static + StaticSundries will now also be considered for grid-traversal when a grid moves over these entities.
 
 ### Other
 

--- a/Robust.Shared.IntegrationTests/Physics/GridMovement_Test.cs
+++ b/Robust.Shared.IntegrationTests/Physics/GridMovement_Test.cs
@@ -75,4 +75,46 @@ internal sealed class GridMovement_Test : RobustIntegrationTest
             Assert.That(onGridBody.ContactCount, Is.EqualTo(1));
         });
     }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task TestMovingGridAttachesMapEntity(bool canCollide)
+    {
+        var server = StartServer();
+
+        await server.WaitIdleAsync();
+
+        var systems = server.ResolveDependency<IEntitySystemManager>();
+        var fixtureSystem = systems.GetEntitySystem<FixtureSystem>();
+        var mapManager = server.ResolveDependency<IMapManager>();
+        var entManager = server.ResolveDependency<IEntityManager>();
+        var physSystem = systems.GetEntitySystem<SharedPhysicsSystem>();
+        var transformSystem = entManager.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
+        var mapSystem = entManager.EntitySysManager.GetEntitySystem<SharedMapSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            entManager.System<SharedMapSystem>().CreateMap(out var mapId);
+            var grid = mapManager.CreateGridEntity(mapId);
+            mapSystem.SetTile(grid, Vector2i.Zero, new Tile(1));
+
+            var entity = entManager.SpawnEntity(null, new MapCoordinates(new Vector2(10.5f, 10.5f), mapId));
+            var body = entManager.AddComponent<PhysicsComponent>(entity);
+            physSystem.SetBodyType(entity, BodyType.Dynamic, body: body);
+
+            var shape = new PolygonShape();
+            shape.SetAsBox(0.25f, 0.25f);
+            fixtureSystem.CreateFixture(entity, "fix1", new Fixture(shape, 0, 0, false), body: body);
+            physSystem.SetCanCollide(entity, canCollide, body: body);
+
+            var xform = entManager.GetComponent<TransformComponent>(entity);
+            Assert.That(xform.ParentUid, Is.Not.EqualTo(grid.Owner));
+
+            physSystem.Update(0.001f);
+            transformSystem.SetLocalPosition(grid.Owner, new Vector2(10f, 10f));
+            physSystem.Update(0.001f);
+
+            Assert.That(xform.ParentUid, Is.EqualTo(grid.Owner));
+        });
+    }
 }

--- a/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
@@ -33,6 +33,7 @@ namespace Robust.Shared.Physics.Systems
         private EntityQuery<TransformComponent> _xformQuery;
 
         private readonly HashSet<FixtureProxy> _gridMoveBuffer = new();
+        private readonly HashSet<EntityUid> _gridSundriesMoveBuffer = new();
 
         private float _frameTime;
 
@@ -106,6 +107,7 @@ namespace Robust.Shared.Physics.Systems
             // we move over is getting checked for collisions, and putting it on the movebuffer is the easiest way to do so.
             var moveBuffer = _physicsSystem.MoveBuffer;
             _gridMoveBuffer.Clear();
+            _gridSundriesMoveBuffer.Clear();
 
             foreach (var gridUid in movedGrids)
             {
@@ -122,6 +124,10 @@ namespace Robust.Shared.Physics.Systems
 
                 QueryMapBroadphase(mapBroadphase.DynamicTree, ref state, enlargedAABB);
                 QueryMapBroadphase(mapBroadphase.StaticTree, ref state, enlargedAABB);
+
+                var sundriesState = _gridSundriesMoveBuffer;
+                QueryMapSundries(mapBroadphase.SundriesTree, ref sundriesState, enlargedAABB);
+                QueryMapSundries(mapBroadphase.StaticSundriesTree, ref sundriesState, enlargedAABB);
             }
 
             foreach (var proxy in _gridMoveBuffer)
@@ -129,6 +135,11 @@ namespace Robust.Shared.Physics.Systems
                 moveBuffer.Add(proxy);
                 // If something is in our AABB then try grid traversal for it
                 _traversal.CheckTraverse((proxy.Entity, _xformQuery.GetComponent(proxy.Entity)));
+            }
+
+            foreach (var uid in _gridSundriesMoveBuffer)
+            {
+                _traversal.CheckTraverse((uid, _xformQuery.GetComponent(uid)));
             }
         }
 
@@ -156,6 +167,15 @@ namespace Robust.Shared.Physics.Systems
                 // To avoid updating during iteration.
                 // Don't need to transform as it's already in map terms.
                 tuple.gridMoveBuffer.Add(value);
+                return true;
+            }, enlargedAABB, true);
+        }
+
+        private void QueryMapSundries(DynamicTree<EntityUid> sundriesTree, ref HashSet<EntityUid> state, Box2 enlargedAABB)
+        {
+            sundriesTree.QueryAabb(ref state, static (ref HashSet<EntityUid> moveBuffer, in EntityUid value) =>
+            {
+                moveBuffer.Add(value);
                 return true;
             }, enlargedAABB, true);
         }


### PR DESCRIPTION
Ideally these are never getting hit but just in case.

Needs separate buffer list just because it stores entityuids not fixtureproxy.