### PR TITLE
Add cvars for new lidgren stuff

### DIFF
--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -36,6 +36,44 @@ namespace Robust.Shared
             CVarDef.Create("net.max_connections", 256, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
 
         /// <summary>
+        /// How many seconds after the last message from the server or a client before we consider it timed out.
+        /// </summary>
+        public static readonly CVarDef<float> NetConnectionTimeout =
+            CVarDef.Create("net.connection_timeout", 25.0f, CVar.ARCHIVE);
+
+        /// <summary>
+        /// Hard max-cap of concurrent connections per client IP address.
+        /// Clients will always get a disconnection packet.
+        /// </summary>
+        /// <remarks>
+        /// This cannot be bypassed in any way, since it is used by Lidgren internally.
+        /// </remarks>
+        public static readonly CVarDef<int> NetMaxIpConnections =
+            CVarDef.Create("net.max_ip_connections", 8, CVar.ARCHIVE);
+
+        /// <summary>
+        /// Hard max-cap of connections a single client IP address can attempt in a window of <c>net.rapid_connection_window</c>.
+        /// Clients will only get a disconnection packet the first time, their packets are dropped afterwards.
+        /// </summary>
+        /// <remarks>
+        /// This cannot be bypassed in any way, since it is used by Lidgren internally.
+        /// </remarks>
+        public static readonly CVarDef<int> NetMaxRapidConnections =
+            CVarDef.Create("net.max_rapid_connections", 3, CVar.ARCHIVE);
+
+        /// <summary>
+        /// How many seconds until connection count decays for <c>net.max_rapid_connections</c>.
+        /// </summary>
+        public static readonly CVarDef<double> NetRapidConnectionWindow =
+            CVarDef.Create("net.rapid_connection_window", 60.0, CVar.ARCHIVE);
+
+        /// <summary>
+        /// How many connections are "forgotten" every <c>net.rapid_connection_window</c> seconds.
+        /// </summary>
+        public static readonly CVarDef<int> NetRapidConnectionDecay =
+            CVarDef.Create("net.rapid_connection_decay", 1, CVar.ARCHIVE);
+
+        /// <summary>
         /// UDP port to bind to for main game networking.
         /// Each address specified in <c>net.bindto</c> is bound with this port.
         /// </summary>
@@ -297,12 +335,6 @@ namespace Robust.Shared
         /// </summary>
         public static readonly CVarDef<int> NetTimeStartOffset =
             CVarDef.Create("net.time_start_offset", 0, CVar.SERVERONLY);
-
-        /// <summary>
-        /// How many seconds after the last message from the server before we consider it timed out.
-        /// </summary>
-        public static readonly CVarDef<float> ConnectionTimeout =
-            CVarDef.Create("net.connection_timeout", 25.0f, CVar.ARCHIVE | CVar.CLIENTONLY);
 
         /// <summary>
         /// When doing the connection handshake, how long to wait before initial connection attempt packets.

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -273,6 +273,11 @@ namespace Robust.Shared.Network
             _config.OnValueChanged(CVars.NetLidgrenLogRateLimitTargets, LidgrenLogRateLimitTargetsChanged);
             _config.OnValueChanged(CVars.NetLidgrenLogRateLimitBurst, LidgrenLogRateLimitBurstChanged);
             _config.OnValueChanged(CVars.NetLidgrenLogRateLimitWindow, LidgrenLogRateLimitWindowChanged);
+            _config.OnValueChanged(CVars.NetConnectionTimeout, ConnectionTimeoutChanged);
+            _config.OnValueChanged(CVars.NetMaxIpConnections, MaxIpConnectionsChanged);
+            _config.OnValueChanged(CVars.NetMaxRapidConnections, MaxRapidConnectionsChanged);
+            _config.OnValueChanged(CVars.NetRapidConnectionWindow, RapidConnectionWindowChanged);
+            _config.OnValueChanged(CVars.NetRapidConnectionDecay, RapidConnectionDecayChanged);
 
             _config.OnValueChanged(CVars.NetVerbose, NetVerboseChanged);
             _config.OnValueChanged(CVars.NetLogging, NetLoggingChanged);
@@ -349,6 +354,46 @@ namespace Robust.Shared.Network
             foreach (var netPeer in _netPeers)
             {
                 netPeer.Peer.Configuration.LogRateLimitWindow = newValue;
+            }
+        }
+
+        private void ConnectionTimeoutChanged(float timeout)
+        {
+            foreach (var netPeer in _netPeers)
+            {
+                netPeer.Peer.Configuration.ConnectionTimeout = timeout;
+            }
+        }
+
+        private void MaxIpConnectionsChanged(int limit)
+        {
+            foreach (var netPeer in _netPeers)
+            {
+                netPeer.Peer.Configuration.MaximumIpConnections = limit;
+            }
+        }
+
+        private void MaxRapidConnectionsChanged(int limit)
+        {
+            foreach (var netPeer in _netPeers)
+            {
+                netPeer.Peer.Configuration.MaximumRapidConnections = limit;
+            }
+        }
+
+        private void RapidConnectionWindowChanged(double time)
+        {
+            foreach (var netPeer in _netPeers)
+            {
+                netPeer.Peer.Configuration.RapidConnectionWindow = time;
+            }
+        }
+
+        private void RapidConnectionDecayChanged(int decay)
+        {
+            foreach (var netPeer in _netPeers)
+            {
+                netPeer.Peer.Configuration.RapidConnectionDecay = decay;
             }
         }
 
@@ -529,6 +574,11 @@ namespace Robust.Shared.Network
             _config.UnsubValueChanged(CVars.NetLidgrenLogRateLimitTargets, LidgrenLogRateLimitTargetsChanged);
             _config.UnsubValueChanged(CVars.NetLidgrenLogRateLimitBurst, LidgrenLogRateLimitBurstChanged);
             _config.UnsubValueChanged(CVars.NetLidgrenLogRateLimitWindow, LidgrenLogRateLimitWindowChanged);
+            _config.UnsubValueChanged(CVars.NetConnectionTimeout, ConnectionTimeoutChanged);
+            _config.UnsubValueChanged(CVars.NetMaxIpConnections, MaxIpConnectionsChanged);
+            _config.UnsubValueChanged(CVars.NetMaxRapidConnections, MaxRapidConnectionsChanged);
+            _config.UnsubValueChanged(CVars.NetRapidConnectionWindow, RapidConnectionWindowChanged);
+            _config.UnsubValueChanged(CVars.NetRapidConnectionDecay, RapidConnectionDecayChanged);
 
             _serializer.ClientHandshakeComplete -= OnSerializerOnClientHandshakeComplete;
 
@@ -732,11 +782,14 @@ namespace Robust.Shared.Network
             }
             else
             {
-                netConfig.ConnectionTimeout = _config.GetCVar(CVars.ConnectionTimeout);
                 netConfig.ResendHandshakeInterval = _config.GetCVar(CVars.ResendHandshakeInterval);
                 netConfig.MaximumHandshakeAttempts = _config.GetCVar(CVars.MaximumHandshakeAttempts);
             }
-
+            netConfig.ConnectionTimeout = _config.GetCVar(CVars.NetConnectionTimeout);
+            netConfig.MaximumIpConnections = _config.GetCVar(CVars.NetMaxIpConnections);
+            netConfig.MaximumRapidConnections = _config.GetCVar(CVars.NetMaxRapidConnections);
+            netConfig.RapidConnectionWindow = _config.GetCVar(CVars.NetRapidConnectionWindow);
+            netConfig.RapidConnectionDecay = _config.GetCVar(CVars.NetRapidConnectionDecay);
 
             //Simulate Latency
             netConfig.SimulatedLoss = _config.GetCVar(CVars.NetFakeLoss);


### PR DESCRIPTION
- added cvars for my new config fields which update when changed. technically client can use them too but it doesnt matter (in soviet russia, server ddos YOU!)
- renamed ConnectionTimeout cvar field to NetConnectionTimeout for consistency
- update NetConnectionTimeout in the config when its changed, it works and no reason not to
- made it apply to server too, maybe you think 25 seconds for a single udp packet to arrive is far too long and want to shorten it to like 5. this also means unauthenticated DOS attempts have less time to do anything before being disconnected 

basically did this so if a server owner finds limits i use to be unreasonable (realistically just for the mythical ss14 lan parties) they can change them whenever with  no friction since they apply immediately

see https://github.com/space-wizards/SpaceWizards.Lidgren.Network/pull/27

resolves https://github.com/space-wizards/SpaceWizards.Lidgren.Network/issues/34 since it's now possible to raise the limits for dev