### PR TITLE
add auth server and engine information to json apis and replays

### DIFF
--- a/Robust.Server/ServerStatus/StatusHost.Handlers.cs
+++ b/Robust.Server/ServerStatus/StatusHost.Handlers.cs
@@ -88,9 +88,12 @@ namespace Robust.Server.ServerStatus
                 buildInfo = GetExternalBuildInfo();
             }
 
+            var authServers = new JsonArray();
+            authServers.Add(_cfg.GetCVar(CVars.AuthServer));
             var authInfo = new JsonObject
             {
                 ["mode"] = _netManager.Auth.ToString(),
+                ["auth_servers"] = authServers,
                 ["public_key"] = _netManager.CryptoPublicKey != null
                     ? Convert.ToBase64String(_netManager.CryptoPublicKey)
                     : null

--- a/Robust.Server/ServerStatus/StatusHost.Handlers.cs
+++ b/Robust.Server/ServerStatus/StatusHost.Handlers.cs
@@ -45,7 +45,8 @@ namespace Robust.Server.ServerStatus
                 // Tags is optional technically but will be necessary practically for future organization.
                 // Content can override these if it wants (e.g. stealthmins).
                 ["name"] = _serverNameCache,
-                ["players"] = _playerManager.PlayerCount
+                ["players"] = _playerManager.PlayerCount,
+                ["engine_type"] = _cfg.GetCVar(CVars.BuildEngineType)
             };
 
             var tagsCache = _serverTagsCache;
@@ -137,6 +138,7 @@ namespace Robust.Server.ServerStatus
 
             return new JsonObject
             {
+                ["engine_type"] = buildInfo.Engine,
                 ["engine_version"] = buildInfo.EngineVersion,
                 ["fork_id"] = buildInfo.ForkId,
                 ["version"] = buildInfo.Version,
@@ -163,6 +165,7 @@ namespace Robust.Server.ServerStatus
             }
             return new JsonObject
             {
+                ["engine_type"] = _cfg.GetCVar(CVars.BuildEngineType),
                 ["engine_version"] = _cfg.GetCVar(CVars.BuildEngineVersion),
                 ["fork_id"] = fork,
                 ["version"] = acm.ManifestHash,

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -786,6 +786,15 @@ namespace Robust.Shared
          */
 
         /// <summary>
+        /// Name identifying this engine's client distribution.
+        /// Engine forks that change client ABI or behaviour need to change this,
+        /// so smart launchers can download and verify the correct client zip.
+        /// Also gets saved to content bundles so replays can use the correct engine.
+        /// </summary>
+        public static readonly CVarDef<string> BuildEngineType =
+            CVarDef.Create("build.engine_type", "RobustToolbox");
+
+        /// <summary>
         /// Engine version that launcher needs to connect to this server.
         /// </summary>
         public static readonly CVarDef<string> BuildEngineVersion =

--- a/Robust.Shared/Replays/SharedReplayRecordingManager.cs
+++ b/Robust.Shared/Replays/SharedReplayRecordingManager.cs
@@ -420,6 +420,7 @@ internal abstract partial class SharedReplayRecordingManager : IReplayRecordingM
         var document = new JsonObject
         {
             ["server_gc"] = ShouldEnableServerGC(recState),
+            ["engine_type"] = info.Engine,
             ["engine_version"] = info.EngineVersion,
             ["base_build"] = new JsonObject
             {

--- a/Robust.Shared/Utility/GameBuildInformation.cs
+++ b/Robust.Shared/Utility/GameBuildInformation.cs
@@ -3,6 +3,7 @@
 namespace Robust.Shared.Utility;
 
 internal sealed record GameBuildInformation(
+    string Engine,
     string EngineVersion,
     string? ZipHash,
     string? ZipDownload,
@@ -40,6 +41,7 @@ internal sealed record GameBuildInformation(
             manifestUrl = null;
 
         return new GameBuildInformation(
+            cfg.GetCVar(CVars.BuildEngineType),
             cfg.GetCVar(CVars.BuildEngineVersion),
             zipHash,
             zipDownload,


### PR DESCRIPTION
combined old swf prs, atomic commits

## engine_type

ill make my life a bit easier
its for deciding which cdn and signing key to use for multiengine launcher, doesnt do anything for you since you dont use it
uses the string engine_kind in /status and /info's build object, as well as replays

think of it like fork_id for organizing server manifests

## auth_servers

lets the launcher know what auth servers an account is allowed to have to connect
currently it adds `"auth_servers": ["<auth server cvar value>"]` to the auth object when fetching /info. it is not present in /status.
adding multiple servers e.g. if using multiauth proxy (in which case youd want to change it anyway or people cant join as the launcher would cry about not having localhost as an auth server) is trivial later on and the json "protocol" will support it to boot with no changes on launchers (assuming theyre not shitcode hoping its only ever 1 url)

"hey you need to use a different launcher / sign in on this auth server" in the launcher is infinitely better than waiting for game to start then just get "lol authentication failed"