### PR TITLE
set SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS to false

### DIFF
--- a/Robust.Client/Graphics/Clyde/Windowing/Sdl3.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Sdl3.cs
@@ -55,6 +55,7 @@ internal partial class Clyde
 
             SDL.SDL_SetHint(SDL.SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
             SDL.SDL_SetHint(SDL.SDL_HINT_IME_IMPLEMENTED_UI, "composition");
+            SDL.SDL_SetHint(SDL.SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");
 
             // SDL3's GameInput support is currently broken and leaving it on
             // causes a "that operation is not supported" error to be logged on startup.


### PR DESCRIPTION
Before this change, when the main game window loses focus in fullscreen mode it minimizes. After this change, when the main game window loses focus in fullscreen mode it does not minimize. It will flicker black briefly if the desktop video mode is different from the games (which it always will be) which is expected behavior. I've never known anyone that wants the game to minimize in this case, but if this is desired behavior we can close this PR.

Tested on Windows 10. SDL3 should work the same on wayland/x11/win11 in this case, but I haven't tested it.
