### PR TITLE
Reduce `ReallyBeIdle` default ticks

### DIFF
--- a/Robust.UnitTesting/Pool/TestPair.Helpers.cs
+++ b/Robust.UnitTesting/Pool/TestPair.Helpers.cs
@@ -231,7 +231,7 @@ public partial class TestPair<TServer, TClient>
     /// Runs the server-client pair in sync, but also ensures they are both idle each tick.
     /// </summary>
     /// <param name="runTicks">How many ticks to run</param>
-    public async Task ReallyBeIdle(int runTicks = 25)
+    public async Task ReallyBeIdle(int runTicks = 5)
     {
         for (var i = 0; i < runTicks; i++)
         {


### PR DESCRIPTION
This function waits until the communication between client and server has been fully resolved using `WaitIdleAsync`. 
By default this currently runs for 25 ticks and is part of the testpair recycling, intended to allow any slow failures to surface.
Researching this default value has yielded no justification for 25 - it appears to have been a "looks about right" value. 
Reducing this to 5 still allows sufficient time for things to stabilize after a test without running tests significantly longer than necessary. 

As a side point - this should be handled by tests themselves. Any test should run long enough to ensure that the result reported is valid. This functionality should be purely to ensure that nothing has failed catastrophically. 

Reducing this value yields _significant_ improvement in test duration from 984s to 810s on my machine. 