### PR TITLE
Add net message validation

### DIFF
--- a/Resources/Locale/en-US/commands.ftl
+++ b/Resources/Locale/en-US/commands.ftl
@@ -521,6 +521,19 @@ cmd-net_watchent-help = Usage: {$command} <0|EntityUid>
 cmd-net_draw_interp-desc = Toggles the debug drawing of the network interpolation.
 cmd-net_draw_interp-help = Usage: {$command} <0|EntityUid>
 
+cmd-net-size-stats-desc = Dumps maximum observed network serialization sizes.
+cmd-net-size-stats-help = Usage: {$command} [limit]
+       {$command} clear
+cmd-net-size-stats-cleared = Cleared network size stats.
+cmd-net-size-stats-invalid-limit = Expected a positive integer limit or 'clear'.
+cmd-net-size-stats-status = Network size stats are {$status}.
+cmd-net-size-stats-status-enabled = enabled
+cmd-net-size-stats-status-disabled = disabled
+cmd-net-size-stats-enable = Enable with: {$cvar} true
+cmd-net-size-stats-empty = No network size stats recorded.
+cmd-net-size-stats-unit-count = count
+cmd-net-size-stats-unit-bytes = B
+
 cmd-vram-desc = Displays video memory usage statics by the game.
 cmd-vram-help = Usage: {$command}
 

--- a/Robust.Server.Testing/RobustServerSimulation.cs
+++ b/Robust.Server.Testing/RobustServerSimulation.cs
@@ -204,6 +204,7 @@ namespace Robust.UnitTesting.Server
             container.Register<IServerNetManager, NetManager>();
             container.Register<IStatusHost, StatusHost>();
             container.Register<ITransferManager, ServerTransferManager>();
+            container.Register<INetValidationManager, NetValidationManager>();
 
             var realReflection = new ServerReflectionManager();
             realReflection.LoadAssemblies(new List<Assembly>(2)

--- a/Robust.Shared.IntegrationTests/GameObjects/EntityState_Tests.cs
+++ b/Robust.Shared.IntegrationTests/GameObjects/EntityState_Tests.cs
@@ -46,6 +46,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             container.Register<IReflectionManager, ServerReflectionManager>();
             container.Register<IRobustSerializer, ServerRobustSerializer>();
             container.Register<IRobustMappedStringSerializer, RobustMappedStringSerializer>();
+            container.Register<INetValidationManager, NetValidationManager>();
             container.Register<IAuthManager, AuthManager>();
             container.Register<IGameTiming, GameTiming>();
             container.Register<ProfManager, ProfManager>();

--- a/Robust.Shared.IntegrationTests/GameObjects/EntityState_Tests.cs
+++ b/Robust.Shared.IntegrationTests/GameObjects/EntityState_Tests.cs
@@ -42,8 +42,10 @@ namespace Robust.UnitTesting.Shared.GameObjects
             container.Register<IConfigurationManager, ServerNetConfigurationManager>();
             container.Register<IConfigurationManagerInternal, ServerNetConfigurationManager>();
             container.Register<INetManager, NetManager>();
+            container.Register<IServerNetManager, NetManager>();
             container.Register<IHWId, DummyHWId>();
             container.Register<IReflectionManager, ServerReflectionManager>();
+            container.RegisterInstance<IEntityManager>(Mock.Of<IEntityManager>());
             container.Register<IRobustSerializer, ServerRobustSerializer>();
             container.Register<IRobustMappedStringSerializer, RobustMappedStringSerializer>();
             container.Register<INetValidationManager, NetValidationManager>();

--- a/Robust.Shared.IntegrationTests/Networking/MsgEntityTests.cs
+++ b/Robust.Shared.IntegrationTests/Networking/MsgEntityTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Reflection;
+using Robust.Shared.Serialization;
+
+namespace Robust.UnitTesting.Shared.Networking;
+
+[TestFixture]
+internal sealed class MsgEntityTests : RobustIntegrationTest
+{
+    [Test]
+    public async Task UnhandledSystemMessageIsDroppedBeforeDeserializationValidation()
+    {
+        await using var pair = await StartConnectedPair(
+            new ServerIntegrationOptions {Pool = false},
+            new ClientIntegrationOptions {Pool = false});
+        await RunTicksSync(pair.Server, pair.Client, 10);
+
+        await pair.Client.WaitPost(() =>
+        {
+            var entMan = pair.Client.Resolve<IEntityManager>();
+            entMan.EntityNetManager.SendSystemNetworkMessage(new LengthLimitedTestEvent {Value = "ABC"});
+        });
+
+        await RunTicksSync(pair.Server, pair.Client, 5);
+
+        await pair.Server.WaitAssertion(() =>
+        {
+            Assert.That(pair.Server.NetMan.IsConnected, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task HandledSystemMessageIsDeserialized()
+    {
+        LengthLimitedTestEventSystem.LastValue = null;
+
+        var options = new ServerIntegrationOptions {Pool = false};
+        options.BeforeStartServices += deps =>
+        {
+            deps.Resolve<IEntitySystemManager>().LoadExtraSystemType<LengthLimitedTestEventSystem>();
+        };
+
+        await using var pair = await StartConnectedPair(
+            options,
+            new ClientIntegrationOptions {Pool = false});
+
+        await RunTicksSync(pair.Server, pair.Client, 10);
+
+        await pair.Client.WaitPost(() =>
+        {
+            var entMan = pair.Client.Resolve<IEntityManager>();
+            entMan.EntityNetManager.SendSystemNetworkMessage(new LengthLimitedTestEvent {Value = "OK"});
+        });
+
+        await RunTicksSync(pair.Server, pair.Client, 5);
+
+        await pair.Server.WaitAssertion(() =>
+        {
+            Assert.That(LengthLimitedTestEventSystem.LastValue, Is.EqualTo("OK"));
+        });
+    }
+
+    [Serializable, NetSerializable]
+    private sealed class LengthLimitedTestEvent : EntityEventArgs
+    {
+        [NetMaxLength(2)]
+        public string Value = string.Empty;
+    }
+
+    [Reflect(false)]
+    private sealed class LengthLimitedTestEventSystem : EntitySystem
+    {
+        public static string? LastValue;
+
+        public override void Initialize()
+        {
+            SubscribeNetworkEvent<LengthLimitedTestEvent>(OnLengthLimited);
+        }
+
+        private void OnLengthLimited(LengthLimitedTestEvent ev)
+        {
+            LastValue = ev.Value;
+        }
+    }
+}

--- a/Robust.Shared.IntegrationTests/Networking/MsgEntityTests.cs
+++ b/Robust.Shared.IntegrationTests/Networking/MsgEntityTests.cs
@@ -64,10 +64,50 @@ internal sealed class MsgEntityTests : RobustIntegrationTest
         });
     }
 
+    [Test]
+    public async Task HandledSystemMessageRejectsSerializedSizeBeforeDeserialization()
+    {
+        SizeLimitedTestEventSystem.Handled = false;
+
+        var options = new ServerIntegrationOptions {Pool = false};
+        options.BeforeStartServices += deps =>
+        {
+            deps.Resolve<IEntitySystemManager>().LoadExtraSystemType<SizeLimitedTestEventSystem>();
+        };
+
+        await using var pair = await StartConnectedPair(
+            options,
+            new ClientIntegrationOptions {Pool = false});
+
+        await RunTicksSync(pair.Server, pair.Client, 10);
+
+        await pair.Client.WaitPost(() =>
+        {
+            var entMan = pair.Client.Resolve<IEntityManager>();
+            entMan.EntityNetManager.SendSystemNetworkMessage(new SizeLimitedTestEvent {Value = "ABC"});
+        });
+
+        var ex = Assert.ThrowsAsync<InvalidDataException>(async () => await RunTicksSync(pair.Server, pair.Client, 5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex!.Message, Does.Contain(nameof(SizeLimitedTestEvent)));
+            Assert.That(SizeLimitedTestEventSystem.Handled, Is.False);
+        });
+    }
+
     [Serializable, NetSerializable]
     private sealed class LengthLimitedTestEvent : EntityEventArgs
     {
         [NetMaxLength(2)]
+        public string Value = string.Empty;
+    }
+
+    [Serializable, NetSerializable]
+    [NetMaxSize(2)]
+    private sealed class SizeLimitedTestEvent : EntityEventArgs
+    {
         public string Value = string.Empty;
     }
 
@@ -84,6 +124,22 @@ internal sealed class MsgEntityTests : RobustIntegrationTest
         private void OnLengthLimited(LengthLimitedTestEvent ev)
         {
             LastValue = ev.Value;
+        }
+    }
+
+    [Reflect(false)]
+    private sealed class SizeLimitedTestEventSystem : EntitySystem
+    {
+        public static bool Handled;
+
+        public override void Initialize()
+        {
+            SubscribeNetworkEvent<SizeLimitedTestEvent>(OnSizeLimited);
+        }
+
+        private void OnSizeLimited(SizeLimitedTestEvent ev)
+        {
+            Handled = true;
         }
     }
 }

--- a/Robust.Shared.IntegrationTests/Networking/MsgEntityTests.cs
+++ b/Robust.Shared.IntegrationTests/Networking/MsgEntityTests.cs
@@ -65,6 +65,39 @@ internal sealed class MsgEntityTests : RobustIntegrationTest
     }
 
     [Test]
+    public async Task HandledSystemMessageRejectsLengthAfterDeserialization()
+    {
+        LengthLimitedTestEventSystem.LastValue = null;
+
+        var options = new ServerIntegrationOptions {Pool = false};
+        options.BeforeStartServices += deps =>
+        {
+            deps.Resolve<IEntitySystemManager>().LoadExtraSystemType<LengthLimitedTestEventSystem>();
+        };
+
+        await using var pair = await StartConnectedPair(
+            options,
+            new ClientIntegrationOptions {Pool = false});
+
+        await RunTicksSync(pair.Server, pair.Client, 10);
+
+        await pair.Client.WaitPost(() =>
+        {
+            var entMan = pair.Client.Resolve<IEntityManager>();
+            entMan.EntityNetManager.SendSystemNetworkMessage(new LengthLimitedTestEvent {Value = "ABC"});
+        });
+
+        var ex = Assert.ThrowsAsync<InvalidDataException>(async () => await RunTicksSync(pair.Server, pair.Client, 5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex!.Message, Does.Contain(nameof(LengthLimitedTestEvent)));
+            Assert.That(LengthLimitedTestEventSystem.LastValue, Is.Null);
+        });
+    }
+
+    [Test]
     public async Task HandledSystemMessageRejectsSerializedSizeBeforeDeserialization()
     {
         SizeLimitedTestEventSystem.Handled = false;

--- a/Robust.Shared.IntegrationTests/Serialization/NetSerializer_Test.cs
+++ b/Robust.Shared.IntegrationTests/Serialization/NetSerializer_Test.cs
@@ -22,7 +22,7 @@ namespace Robust.UnitTesting.Shared.Serialization
         }
 
         [Serializable]
-        [NetMaxSerializedSize(2)]
+        [NetMaxSize(2)]
         private sealed class SizeLimitedPayload
         {
         }

--- a/Robust.Shared.IntegrationTests/Serialization/NetSerializer_Test.cs
+++ b/Robust.Shared.IntegrationTests/Serialization/NetSerializer_Test.cs
@@ -12,9 +12,21 @@ namespace Robust.UnitTesting.Shared.Serialization
 {
     // Tests NetSerializer itself because we have specific modifications.
     // e.g. (at the time of writing) list serialization being more compact.
-    [Parallelizable(ParallelScope.All)]
     internal sealed class NetSerializer_Test
     {
+        [Serializable]
+        private sealed class LengthLimitedPayload
+        {
+            [NetMaxLength(2)]
+            public string Value = string.Empty;
+        }
+
+        [Serializable]
+        [NetMaxSerializedSize(2)]
+        private sealed class SizeLimitedPayload
+        {
+        }
+
         public static readonly List<int>?[] ListValues =
         {
             null,
@@ -39,6 +51,23 @@ namespace Robust.UnitTesting.Shared.Serialization
             {
                 Assert.That(deserialized, Is.EquivalentTo(list));
             }
+        }
+
+        [Test]
+        public void TestListDeserializationRejectsTooManyElements()
+        {
+            var serializer = new Serializer(new[] {typeof(List<int>)}, new Settings
+            {
+                MaxCollectionLength = 2
+            });
+
+            var stream = new MemoryStream();
+            Primitives.WritePrimitive(stream, 4u);
+            stream.Position = 0;
+
+            Assert.That(
+                () => serializer.DeserializeDirect<List<int>?>(stream, out _),
+                Throws.TypeOf<InvalidDataException>());
         }
 
         public static readonly Dictionary<string, int>?[] DictionaryValues =
@@ -66,6 +95,30 @@ namespace Robust.UnitTesting.Shared.Serialization
             {
                 Assert.That(deserialized, Is.EquivalentTo(list));
             }
+        }
+
+        [Test]
+        public void TestDictionaryDeserializationRejectsTooManyElements()
+        {
+            var serializer = new Serializer(new[] {typeof(Dictionary<string, int>)}, new Settings
+            {
+                MaxCollectionLength = 2
+            });
+
+            var value = new Dictionary<string, int>
+            {
+                {"A", 1},
+                {"B", 2},
+                {"C", 3}
+            };
+
+            var stream = new MemoryStream();
+            serializer.SerializeDirect(stream, value);
+            stream.Position = 0;
+
+            Assert.That(
+                () => serializer.DeserializeDirect<Dictionary<string, int>?>(stream, out _),
+                Throws.TypeOf<InvalidDataException>());
         }
 
         public static readonly HashSet<int>?[] HashSetValues =
@@ -189,6 +242,90 @@ namespace Robust.UnitTesting.Shared.Serialization
 
             Primitives.ReadPrimitive(stream, out string? deserialized);
             Assert.That(deserialized, Is.EqualTo(str));
+        }
+
+        [Test]
+        public void TestStringDeserializationRejectsTooManyCharacters()
+        {
+            var oldLimit = Primitives.MaxStringLength;
+            Primitives.MaxStringLength = 2;
+
+            try
+            {
+                var stream = new MemoryStream();
+                Primitives.WritePrimitive(stream, "ABC");
+                stream.Position = 0;
+
+                Assert.That(() => Primitives.ReadPrimitive(stream, out string? _), Throws.TypeOf<InvalidDataException>());
+            }
+            finally
+            {
+                Primitives.MaxStringLength = oldLimit;
+            }
+        }
+
+        [Test]
+        public void TestByteArrayDeserializationRejectsTooManyBytes()
+        {
+            var oldLimit = Primitives.MaxByteArrayLength;
+            Primitives.MaxByteArrayLength = 2;
+
+            try
+            {
+                var stream = new MemoryStream();
+                Primitives.WritePrimitive(stream, new byte[] {1, 2, 3});
+                stream.Position = 0;
+
+                Assert.That(() => Primitives.ReadPrimitive(stream, out byte[]? _), Throws.TypeOf<InvalidDataException>());
+            }
+            finally
+            {
+                Primitives.MaxByteArrayLength = oldLimit;
+            }
+        }
+
+        [Test]
+        public void TestInvalidObjectTypeIdThrowsInvalidData()
+        {
+            var serializer = new Serializer([typeof(string)]);
+            var stream = new MemoryStream();
+            Primitives.WritePrimitive(stream, uint.MaxValue);
+            stream.Position = 0;
+
+            Assert.That(() => serializer.Deserialize(stream), Throws.TypeOf<InvalidDataException>());
+        }
+
+        [Test]
+        public void TestInvalidObjectTypeIdTryDeserializeReturnsFalse()
+        {
+            var serializer = new Serializer([typeof(string)]);
+            var stream = new MemoryStream();
+            Primitives.WritePrimitive(stream, uint.MaxValue);
+            stream.Position = 0;
+
+            Assert.That(serializer.TryDeserialize(stream, out var value), Is.False);
+            Assert.That(value, Is.Null);
+        }
+
+        [Test]
+        public void TestNetMaxLengthAttributeRejectsTooManyElements()
+        {
+            var validation = new NetValidationManager();
+            validation.RegisterType(typeof(LengthLimitedPayload));
+            var payload = new LengthLimitedPayload {Value = "ABC"};
+
+            Assert.That(() => validation.ValidateObject(payload), Throws.TypeOf<InvalidDataException>());
+        }
+
+        [Test]
+        public void TestNetMaxSerializedSizeAttributeRejectsTooManyBytes()
+        {
+            var validation = new NetValidationManager();
+            validation.RegisterType(typeof(SizeLimitedPayload));
+
+            Assert.That(
+                () => validation.ValidateSerializedSize(typeof(SizeLimitedPayload), 3),
+                Throws.TypeOf<InvalidDataException>());
         }
 
         [Test]

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -154,6 +154,36 @@ namespace Robust.Shared
             CVarDef.Create("net.logging", false, CVar.ARCHIVE);
 
         /// <summary>
+        /// Log sent and received NetMessages at or above this size in bytes. Set to 0 to disable.
+        /// </summary>
+        public static readonly CVarDef<int> NetMessageSizeLogThreshold =
+            CVarDef.Create("net.message_size_log_threshold", 0, CVar.ARCHIVE);
+
+        /// <summary>
+        /// Track maximum observed serialized sizes for NetMessages, EntityEventArgs, and their members.
+        /// </summary>
+        public static readonly CVarDef<bool> NetMessageSizeStats =
+            CVarDef.Create("net.message_size_stats", false, CVar.ARCHIVE);
+
+        /// <summary>
+        /// Maximum collection element count accepted by NetSerializer.
+        /// </summary>
+        public static readonly CVarDef<int> NetSerializerMaxCollectionLength =
+            CVarDef.Create("net.serializer_max_collection_length", 1024 * 1024, CVar.ARCHIVE);
+
+        /// <summary>
+        /// Maximum byte array length accepted by NetSerializer.
+        /// </summary>
+        public static readonly CVarDef<int> NetSerializerMaxByteArrayLength =
+            CVarDef.Create("net.serializer_max_byte_array_length", 16 * 1024 * 1024, CVar.ARCHIVE);
+
+        /// <summary>
+        /// Maximum string length accepted by NetSerializer.
+        /// </summary>
+        public static readonly CVarDef<int> NetSerializerMaxStringLength =
+            CVarDef.Create("net.serializer_max_string_length", 16 * 1024 * 1024, CVar.ARCHIVE);
+
+        /// <summary>
         /// Whether prediction is enabled on the client.
         /// </summary>
         /// <remarks>

--- a/Robust.Shared/Console/Commands/NetSizeStatsCommand.cs
+++ b/Robust.Shared/Console/Commands/NetSizeStatsCommand.cs
@@ -1,0 +1,53 @@
+using System;
+using Robust.Shared;
+using Robust.Shared.Serialization;
+
+namespace Robust.Shared.Console.Commands;
+
+internal sealed partial class NetSizeStatsCommand : LocalizedCommands
+{
+    public override string Command => "net_size_stats";
+
+    public override string Description => Loc.GetString("cmd-net-size-stats-desc");
+
+    public override string Help => Loc.GetString("cmd-net-size-stats-help", ("command", Command));
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length > 0 && args[0].Equals("clear", StringComparison.OrdinalIgnoreCase))
+        {
+            NetSizeStats.Clear();
+            shell.WriteLine(Loc.GetString("cmd-net-size-stats-cleared"));
+            return;
+        }
+
+        var limit = 100;
+        if (args.Length > 0 && (!int.TryParse(args[0], out limit) || limit < 1))
+        {
+            shell.WriteLine(Loc.GetString("cmd-net-size-stats-invalid-limit"));
+            return;
+        }
+
+        shell.WriteLine(Loc.GetString(
+            "cmd-net-size-stats-status",
+            ("status", Loc.GetString(NetSizeStats.Enabled
+                ? "cmd-net-size-stats-status-enabled"
+                : "cmd-net-size-stats-status-disabled"))));
+        shell.WriteLine(Loc.GetString("cmd-net-size-stats-enable", ("cvar", CVars.NetMessageSizeStats.Name)));
+
+        var stats = NetSizeStats.Snapshot();
+        if (stats.Length == 0)
+        {
+            shell.WriteLine(Loc.GetString("cmd-net-size-stats-empty"));
+            return;
+        }
+
+        foreach (var stat in stats[..Math.Min(limit, stats.Length)])
+        {
+            var unit = stat.Kind == NetSizeStatKind.MemberCount
+                ? Loc.GetString("cmd-net-size-stats-unit-count")
+                : Loc.GetString("cmd-net-size-stats-unit-bytes");
+            shell.WriteLine($"{stat.Kind,-11} {stat.Value,8} {unit,-5} {stat.Count,8}x {stat.Name}");
+        }
+    }
+}

--- a/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs
@@ -68,6 +68,8 @@ namespace Robust.Shared.GameObjects
 
         void RaiseEvent<T>(EventSource source, ref T toRaise) where T : notnull;
 
+        bool CanReceiveNetworkEvent(Type eventType);
+
         /// <summary>
         /// Queues an event to be raised at a later time.
         /// </summary>
@@ -283,6 +285,9 @@ namespace Robust.Shared.GameObjects
 
             ProcessSingleEvent(source, ref Unsafe.As<T, Unit>(ref toRaise), typeof(T));
         }
+
+        public bool CanReceiveNetworkEvent(Type eventType)
+            => _networkReceivableEvents.Contains(eventType);
 
         /// <inheritdoc />
         public void QueueEvent(EventSource source, EntityEventArgs toRaise)

--- a/Robust.Shared/GameObjects/EntityEventBus.Common.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Common.cs
@@ -19,6 +19,7 @@ internal sealed partial class EntityEventBus : IEventBus
     // Data on individual events. Used to check ordering info and fire broadcast events.
     private FrozenDictionary<Type, EventData> _eventData = FrozenDictionary<Type, EventData>.Empty;
     private readonly Dictionary<Type, EventData> _eventDataUnfrozen = new();
+    private FrozenSet<Type> _networkReceivableEvents = FrozenSet<Type>.Empty;
 
     // Inverse subscriptions to be able to unsubscribe an IEntityEventSubscriber.
     private readonly Dictionary<IEntityEventSubscriber, Dictionary<Type, BroadcastRegistration>> _inverseEventSubscriptions

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -364,6 +364,7 @@ namespace Robust.Shared.GameObjects
         {
             _subscriptionLock = true;
             _eventData = _eventDataUnfrozen.ToFrozenDictionary();
+            _networkReceivableEvents = BuildNetworkReceivableEvents();
 
             _eventSubs = TrimNull(_eventSubsUnfrozen)
                 .Select(dict => dict?.ToFrozenDictionary()!)
@@ -374,6 +375,33 @@ namespace Robust.Shared.GameObjects
                 .ToArray();
 
             CalcOrdering();
+        }
+
+        private FrozenSet<Type> BuildNetworkReceivableEvents()
+        {
+            var receiveTypes = new HashSet<Type>();
+
+            foreach (var (eventType, subs) in _eventDataUnfrozen)
+            {
+                foreach (var handler in subs.BroadcastRegistrations.Span)
+                {
+                    if ((handler.Mask & EventSource.Network) == 0)
+                        continue;
+
+                    receiveTypes.Add(UnwrapSessionEventType(eventType));
+                    break;
+                }
+            }
+
+            return receiveTypes.ToFrozenSet();
+        }
+
+        private static Type UnwrapSessionEventType(Type eventType)
+        {
+            if (eventType.IsGenericType && eventType.GetGenericTypeDefinition() == typeof(EntitySessionMessage<>))
+                return eventType.GetGenericArguments()[0];
+
+            return eventType;
         }
 
         public void OnComponentRemoved(in RemovedComponentEventArgs e)
@@ -615,6 +643,7 @@ namespace Robust.Shared.GameObjects
             _compEventSubs = default!;
             _eventSubs = default!;
             _eventData = FrozenDictionary<Type, EventData>.Empty;
+            _networkReceivableEvents = FrozenSet<Type>.Empty;
             foreach (var sub in _eventSubsUnfrozen)
             {
                 sub?.Clear();

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -13,7 +13,6 @@ using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
 using Robust.Shared.Network;
-using Robust.Shared.Network.Messages;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Player;
 using Robust.Shared.Profiling;
@@ -143,7 +142,6 @@ namespace Robust.Shared.GameObjects
                 throw new InvalidOperationException("Initialize() called multiple times");
 
             EventBusInternal = new EntityEventBus(this, _reflection);
-            MsgEntity.SetNetworkEventReceiver(EventBusInternal);
 
             InitializeComponents();
             _metaReg = _componentFactory.GetRegistration(typeof(MetaDataComponent));
@@ -266,7 +264,6 @@ namespace Robust.Shared.GameObjects
             _entitySystemManager.Clear();
             EventBusInternal.Dispose();
             EventBusInternal = null!;
-            MsgEntity.ClearNetworkEventReceiver();
             ClearComponents();
 
             ShuttingDown = false;

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -13,6 +13,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
 using Robust.Shared.Network;
+using Robust.Shared.Network.Messages;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Player;
 using Robust.Shared.Profiling;
@@ -142,6 +143,7 @@ namespace Robust.Shared.GameObjects
                 throw new InvalidOperationException("Initialize() called multiple times");
 
             EventBusInternal = new EntityEventBus(this, _reflection);
+            MsgEntity.SetNetworkEventReceiver(EventBusInternal);
 
             InitializeComponents();
             _metaReg = _componentFactory.GetRegistration(typeof(MetaDataComponent));
@@ -264,6 +266,7 @@ namespace Robust.Shared.GameObjects
             _entitySystemManager.Clear();
             EventBusInternal.Dispose();
             EventBusInternal = null!;
+            MsgEntity.ClearNetworkEventReceiver();
             ClearComponents();
 
             ShuttingDown = false;

--- a/Robust.Shared/Network/Messages/Handshake/MsgEncryptionRequest.cs
+++ b/Robust.Shared/Network/Messages/Handshake/MsgEncryptionRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Lidgren.Network;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
 #nullable disable
@@ -17,9 +18,9 @@ namespace Robust.Shared.Network.Messages.Handshake
 
         public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
-            var tokenLength = buffer.ReadVariableInt32();
+            var tokenLength = buffer.ReadVariableByteLength(nameof(VerifyToken));
             VerifyToken = buffer.ReadBytes(tokenLength);
-            var keyLength = buffer.ReadVariableInt32();
+            var keyLength = buffer.ReadVariableByteLength(nameof(PublicKey));
             PublicKey = buffer.ReadBytes(keyLength);
             WantHwid = buffer.ReadBoolean();
         }

--- a/Robust.Shared/Network/Messages/Handshake/MsgEncryptionResponse.cs
+++ b/Robust.Shared/Network/Messages/Handshake/MsgEncryptionResponse.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Lidgren.Network;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
 #nullable disable
@@ -19,9 +20,9 @@ namespace Robust.Shared.Network.Messages.Handshake
         public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             UserId = buffer.ReadGuid();
-            var keyLength = buffer.ReadVariableInt32();
+            var keyLength = buffer.ReadVariableByteLength(nameof(SealedData));
             SealedData = buffer.ReadBytes(keyLength);
-            var legacyHwidLength = buffer.ReadVariableInt32();
+            var legacyHwidLength = buffer.ReadVariableByteLength(nameof(LegacyHwid));
             LegacyHwid = buffer.ReadBytes(legacyHwidLength);
         }
 

--- a/Robust.Shared/Network/Messages/MsgConCmdAck.cs
+++ b/Robust.Shared/Network/Messages/MsgConCmdAck.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using Lidgren.Network;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 
@@ -17,7 +18,7 @@ namespace Robust.Shared.Network.Messages
 
         public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
-            int length = buffer.ReadVariableInt32();
+            int length = buffer.ReadVariableByteLength(nameof(Text));
             using var stream = RobustMemoryManager.GetMemoryStream(length);
             buffer.ReadAlignedMemory(stream, length);
             Text = serializer.Deserialize<FormattedMessage>(stream);

--- a/Robust.Shared/Network/Messages/MsgConCompletion.cs
+++ b/Robust.Shared/Network/Messages/MsgConCompletion.cs
@@ -1,4 +1,5 @@
 using Lidgren.Network;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
 namespace Robust.Shared.Network.Messages;
@@ -18,7 +19,7 @@ public sealed class MsgConCompletion : NetMessage
     {
         Seq = buffer.ReadInt32();
 
-        var len = buffer.ReadVariableInt32();
+        var len = buffer.ValidateElementCount(buffer.ReadVariableInt32(), nameof(Args));
         Args = new string[len];
         for (var i = 0; i < len; i++)
         {

--- a/Robust.Shared/Network/Messages/MsgConCompletionResp.cs
+++ b/Robust.Shared/Network/Messages/MsgConCompletionResp.cs
@@ -1,5 +1,6 @@
 using Lidgren.Network;
 using Robust.Shared.Console;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
 namespace Robust.Shared.Network.Messages;
@@ -15,7 +16,7 @@ public sealed class MsgConCompletionResp : NetMessage
     {
         Seq = buffer.ReadInt32();
 
-        var len = buffer.ReadVariableInt32();
+        var len = buffer.ValidateElementCount(buffer.ReadVariableInt32(), nameof(Result.Options));
         var options = new CompletionOption[len];
         for (var i = 0; i < len; i++)
         {

--- a/Robust.Shared/Network/Messages/MsgEntity.cs
+++ b/Robust.Shared/Network/Messages/MsgEntity.cs
@@ -44,7 +44,7 @@ namespace Robust.Shared.Network.Messages
             {
                 case EntityMessageType.SystemMessage:
                 {
-                    var length = buffer.ReadVariableInt32();
+                    var length = buffer.ReadVariableByteLength(nameof(SystemMessage));
 
                     // Length is bad validation.
                     if ((buffer.Position & 7) != 0)
@@ -53,15 +53,6 @@ namespace Robust.Shared.Network.Messages
                         Logger.GetSawmill("net").Error($"{MsgChannel}: dropping {nameof(MsgEntity)} as read position in message is not byte-aligned.");
                         break;
                     }
-
-                    // Validate the length they told us rather than allocating the memory with hopes and dreams.
-                    if (length < 0 || length > buffer.LengthBytes - buffer.PositionInBytes)
-                    {
-                        Logger.GetSawmill("net").Error($"{MsgChannel}: dropping {nameof(MsgEntity)} with invalid entity event payload length {length}.");
-                        Type = EntityMessageType.Error;
-                        break;
-                    }
-
 
                     var payloadPosition = buffer.PositionInBytes;
                     using var stream = new MemoryStream(buffer.Data, payloadPosition, length, false);
@@ -98,6 +89,8 @@ namespace Robust.Shared.Network.Messages
                         break;
                     }
 
+                    // DeSerialize runs validation separately on the EntityEventArgs.
+                    // We just check the length first before bothering to pass it through.
                     SystemMessage = serializer.Deserialize<EntityEventArgs>(stream);
                     buffer.Position += length * 8;
                     NetSizeStats.Record(NetSizeStatKind.EntityEvent, SystemMessage.GetType(), length);

--- a/Robust.Shared/Network/Messages/MsgEntity.cs
+++ b/Robust.Shared/Network/Messages/MsgEntity.cs
@@ -45,31 +45,61 @@ namespace Robust.Shared.Network.Messages
                 case EntityMessageType.SystemMessage:
                 {
                     var length = buffer.ReadVariableInt32();
-                    using var stream = RobustMemoryManager.GetMemoryStream(length);
-                    buffer.ReadAlignedMemory(stream, length);
 
+                    // Length is bad validation.
+                    if ((buffer.Position & 7) != 0)
+                    {
+                        Type = EntityMessageType.Error;
+                        Logger.GetSawmill("net").Error($"{MsgChannel}: dropping {nameof(MsgEntity)} as read position in message is not byte-aligned.");
+                        break;
+                    }
+
+                    // Validate the length they told us rather than allocating the memory with hopes and dreams.
+                    if (length < 0 || length > buffer.LengthBytes - buffer.PositionInBytes)
+                    {
+                        Logger.GetSawmill("net").Error($"{MsgChannel}: dropping {nameof(MsgEntity)} with invalid entity event payload length {length}.");
+                        Type = EntityMessageType.Error;
+                        break;
+                    }
+
+
+                    var payloadPosition = buffer.PositionInBytes;
+                    using var stream = new MemoryStream(buffer.Data, payloadPosition, length, false);
+
+                    // Check if we even know the type.
                     if (!serializer.TryGetSerializedType(stream, out var eventType))
                     {
                         Logger.GetSawmill("net").Error($"{MsgChannel}: dropping {nameof(MsgEntity)} with unknown entity event type.");
                         Type = EntityMessageType.Error;
+                        buffer.Position += length * 8;
                         break;
                     }
 
+                    // Only accept EntityEventArgs in MsgEntity (at least that's what eventbus limits it to right now).
                     if (eventType == null || !typeof(EntityEventArgs).IsAssignableFrom(eventType))
                     {
                         Logger.GetSawmill("net").Error($"{MsgChannel}: dropping invalid entity event type {eventType?.Name ?? "<null>"}.");
                         Type = EntityMessageType.Error;
+                        buffer.Position += length * 8;
                         break;
                     }
 
+                    // If EntityEventArgs has the size attribute validate it here
+                    serializer.ValidateSerializedSize(eventType, length);
+
+                    // Check if there's even any subscribers
+                    // If there are none then no point wasting time deserializing and dump it.
+                    // This may also be a legitimate content bug.
                     if (!CanReceiveNetworkEvent(eventType))
                     {
-                        Logger.GetSawmill("net").Debug($"{MsgChannel}: dropping unhandled entity event {eventType.Name}.");
+                        Logger.GetSawmill("net").Warning($"{MsgChannel}: dropping unhandled entity event {eventType.Name}.");
                         Type = EntityMessageType.Error;
+                        buffer.Position += length * 8;
                         break;
                     }
 
                     SystemMessage = serializer.Deserialize<EntityEventArgs>(stream);
+                    buffer.Position += length * 8;
                     NetSizeStats.Record(NetSizeStatKind.EntityEvent, SystemMessage.GetType(), length);
                     NetSizeStats.RecordSerializableMembers(SystemMessage, serializer);
                     break;

--- a/Robust.Shared/Network/Messages/MsgEntity.cs
+++ b/Robust.Shared/Network/Messages/MsgEntity.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using Lidgren.Network;
 using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
+using Robust.Shared.Log;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -13,13 +13,24 @@ namespace Robust.Shared.Network.Messages
 {
     public sealed class MsgEntity : NetMessage
     {
+        [ThreadStatic]
+        private static Func<Type, bool> _canReceiveNetworkEvent;
+
+        internal static void SetNetworkEventReceiver(IEventBus eventBus)
+        {
+            _canReceiveNetworkEvent = eventBus.CanReceiveNetworkEvent;
+        }
+
+        internal static void ClearNetworkEventReceiver()
+        {
+            _canReceiveNetworkEvent = null;
+        }
+
         public override MsgGroups MsgGroup => MsgGroups.EntityEvent;
 
         public EntityMessageType Type { get; set; }
 
         public EntityEventArgs SystemMessage { get; set; }
-        public EntityUid EntityUid { get; set; }
-        public uint NetId { get; set; }
         public uint Sequence { get; set; }
         public GameTick SourceTick { get; set; }
 
@@ -36,10 +47,43 @@ namespace Robust.Shared.Network.Messages
                     var length = buffer.ReadVariableInt32();
                     using var stream = RobustMemoryManager.GetMemoryStream(length);
                     buffer.ReadAlignedMemory(stream, length);
+
+                    if (!serializer.TryGetSerializedType(stream, out var eventType))
+                    {
+                        Logger.GetSawmill("net").Error($"{MsgChannel}: dropping {nameof(MsgEntity)} with unknown entity event type.");
+                        Type = EntityMessageType.Error;
+                        break;
+                    }
+
+                    if (eventType == null || !typeof(EntityEventArgs).IsAssignableFrom(eventType))
+                    {
+                        Logger.GetSawmill("net").Error($"{MsgChannel}: dropping invalid entity event type {eventType?.Name ?? "<null>"}.");
+                        Type = EntityMessageType.Error;
+                        break;
+                    }
+
+                    if (!CanReceiveNetworkEvent(eventType))
+                    {
+                        Logger.GetSawmill("net").Debug($"{MsgChannel}: dropping unhandled entity event {eventType.Name}.");
+                        Type = EntityMessageType.Error;
+                        break;
+                    }
+
                     SystemMessage = serializer.Deserialize<EntityEventArgs>(stream);
+                    NetSizeStats.Record(NetSizeStatKind.EntityEvent, SystemMessage.GetType(), length);
+                    NetSizeStats.RecordSerializableMembers(SystemMessage, serializer);
+                    break;
                 }
+                default:
+                    Type = EntityMessageType.Error;
+                    Logger.GetSawmill("net").Error($"{MsgChannel}: dropping {nameof(MsgEntity)} with unknown EntityMessageType.");
                     break;
             }
+        }
+
+        private static bool CanReceiveNetworkEvent(Type eventType)
+        {
+            return _canReceiveNetworkEvent?.Invoke(eventType) == true;
         }
 
         public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)

--- a/Robust.Shared/Network/Messages/MsgEntity.cs
+++ b/Robust.Shared/Network/Messages/MsgEntity.cs
@@ -68,7 +68,7 @@ namespace Robust.Shared.Network.Messages
                     // Check if there's even any subscribers
                     // If there are none then no point wasting time deserializing and dump it.
                     // This may also be a legitimate content bug.
-                    if (!serializer.EntityManager.CanReceiveNetworkEvent(eventType))
+                    if (!serializer.EntityManager.EventBus.CanReceiveNetworkEvent(eventType))
                     {
                         Logger.GetSawmill("net").Debug($"{MsgChannel}: dropping unhandled entity event {eventType.Name}.");
                         Type = EntityMessageType.Error;

--- a/Robust.Shared/Network/Messages/MsgEntity.cs
+++ b/Robust.Shared/Network/Messages/MsgEntity.cs
@@ -13,19 +13,6 @@ namespace Robust.Shared.Network.Messages
 {
     public sealed class MsgEntity : NetMessage
     {
-        [ThreadStatic]
-        private static Func<Type, bool> _canReceiveNetworkEvent;
-
-        internal static void SetNetworkEventReceiver(IEventBus eventBus)
-        {
-            _canReceiveNetworkEvent = eventBus.CanReceiveNetworkEvent;
-        }
-
-        internal static void ClearNetworkEventReceiver()
-        {
-            _canReceiveNetworkEvent = null;
-        }
-
         public override MsgGroups MsgGroup => MsgGroups.EntityEvent;
 
         public EntityMessageType Type { get; set; }
@@ -81,9 +68,9 @@ namespace Robust.Shared.Network.Messages
                     // Check if there's even any subscribers
                     // If there are none then no point wasting time deserializing and dump it.
                     // This may also be a legitimate content bug.
-                    if (!CanReceiveNetworkEvent(eventType))
+                    if (!serializer.EntityManager.CanReceiveNetworkEvent(eventType))
                     {
-                        Logger.GetSawmill("net").Warning($"{MsgChannel}: dropping unhandled entity event {eventType.Name}.");
+                        Logger.GetSawmill("net").Debug($"{MsgChannel}: dropping unhandled entity event {eventType.Name}.");
                         Type = EntityMessageType.Error;
                         buffer.Position += length * 8;
                         break;
@@ -102,11 +89,6 @@ namespace Robust.Shared.Network.Messages
                     Logger.GetSawmill("net").Error($"{MsgChannel}: dropping {nameof(MsgEntity)} with unknown EntityMessageType.");
                     break;
             }
-        }
-
-        private static bool CanReceiveNetworkEvent(Type eventType)
-        {
-            return _canReceiveNetworkEvent?.Invoke(eventType) == true;
         }
 
         public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)

--- a/Robust.Shared/Network/Messages/MsgMapStrServerHandshake.cs
+++ b/Robust.Shared/Network/Messages/MsgMapStrServerHandshake.cs
@@ -1,6 +1,7 @@
 using System;
 using JetBrains.Annotations;
 using Lidgren.Network;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
 namespace Robust.Shared.Network.Messages
@@ -24,11 +25,7 @@ namespace Robust.Shared.Network.Messages
 
         public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
-            var len = buffer.ReadVariableInt32();
-            if (len > 64)
-            {
-                throw new InvalidOperationException("Hash too long.");
-            }
+            var len = buffer.ReadVariableByteLength(nameof(Hash), 64);
 
             buffer.ReadBytes(Hash = new byte[len]);
         }

--- a/Robust.Shared/Network/Messages/MsgMapStrStrings.cs
+++ b/Robust.Shared/Network/Messages/MsgMapStrStrings.cs
@@ -1,6 +1,7 @@
 using System;
 using JetBrains.Annotations;
 using Lidgren.Network;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
 namespace Robust.Shared.Network.Messages
@@ -24,7 +25,7 @@ namespace Robust.Shared.Network.Messages
 
         public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
-            var size = buffer.ReadVariableInt32();
+            var size = buffer.ReadVariableByteLength(nameof(Package));
             buffer.ReadBytes(Package = new byte[size]);
         }
 

--- a/Robust.Shared/Network/Messages/MsgPlayerList.cs
+++ b/Robust.Shared/Network/Messages/MsgPlayerList.cs
@@ -2,6 +2,7 @@
 using Lidgren.Network;
 using Robust.Shared.Enums;
 using Robust.Shared.GameStates;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
 #nullable disable
@@ -16,7 +17,7 @@ namespace Robust.Shared.Network.Messages
 
         public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
-            var playerCount = buffer.ReadInt32();
+            var playerCount = buffer.ValidateElementCount(buffer.ReadInt32(), nameof(Plyrs));
             Plyrs = new List<SessionState>(playerCount);
             for (var i = 0; i < playerCount; i++)
             {

--- a/Robust.Shared/Network/Messages/MsgReloadPrototypes.cs
+++ b/Robust.Shared/Network/Messages/MsgReloadPrototypes.cs
@@ -1,4 +1,5 @@
 ﻿using Lidgren.Network;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 
@@ -12,7 +13,7 @@ namespace Robust.Shared.Network.Messages
 
         public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
-            var count = buffer.ReadInt32();
+            var count = buffer.ValidateElementCount(buffer.ReadInt32(), nameof(Paths));
             Paths = new ResPath[count];
 
             for (var i = 0; i < count; i++)

--- a/Robust.Shared/Network/Messages/MsgScriptCompletionResponse.cs
+++ b/Robust.Shared/Network/Messages/MsgScriptCompletionResponse.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using Lidgren.Network;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
 namespace Robust.Shared.Network.Messages
@@ -15,7 +16,7 @@ namespace Robust.Shared.Network.Messages
         {
             ScriptSession = buffer.ReadInt32()!;
 
-            var n = buffer.ReadInt32()!;
+            var n = buffer.ValidateElementCount(buffer.ReadInt32(), nameof(Results));
             var cli = ImmutableArray.CreateBuilder<LiteResult>();
             for (var i = 0; i < n; i++)
             {
@@ -69,14 +70,14 @@ namespace Robust.Shared.Network.Messages
                 DisplayTextSuffix = buffer.ReadString()!;
                 InlineDescription = buffer.ReadString()!;
 
-                var n = buffer.ReadInt32()!;
+                var n = buffer.ValidateElementCount(buffer.ReadInt32(), nameof(Tags));
                 var iab = ImmutableArray.CreateBuilder<string>();
                 for (var i = 0; i < n; i++)
                     iab.Add(buffer.ReadString()!);
 
                 Tags = iab.ToImmutable()!;
 
-                n = buffer.ReadInt32()!;
+                n = buffer.ValidateElementCount(buffer.ReadInt32(), nameof(Properties));
                 var idb = ImmutableDictionary.CreateBuilder<string, string>();
                 for (var i = 0; i < n; i++)
                     idb.Add(buffer.ReadString()!, buffer.ReadString()!);

--- a/Robust.Shared/Network/Messages/MsgScriptResponse.cs
+++ b/Robust.Shared/Network/Messages/MsgScriptResponse.cs
@@ -2,6 +2,7 @@ using System.IO;
 using Lidgren.Network;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 
@@ -28,7 +29,7 @@ namespace Robust.Shared.Network.Messages
             if (WasComplete)
             {
                 buffer.ReadPadBits();
-                var length = buffer.ReadVariableInt32();
+                var length = buffer.ReadVariableByteLength(nameof(Response));
                 using var stream = RobustMemoryManager.GetMemoryStream(length);
                 buffer.ReadAlignedMemory(stream, length);
                 serializer.DeserializeDirect(stream, out Echo);

--- a/Robust.Shared/Network/Messages/MsgState.cs
+++ b/Robust.Shared/Network/Messages/MsgState.cs
@@ -40,9 +40,16 @@ namespace Robust.Shared.Network.Messages
             var compressedLength = buffer.ReadVariableInt32();
             MemoryStream finalStream;
 
+            if (uncompressedLength < 0)
+                throw new InvalidDataException($"{nameof(State)} uncompressed length cannot be negative.");
+
+            if (compressedLength < 0)
+                throw new InvalidDataException($"{nameof(State)} compressed length cannot be negative.");
+
             // State is compressed.
             if (compressedLength > 0)
             {
+                buffer.ValidateByteLength(compressedLength, nameof(StateStream));
                 var stream = RobustMemoryManager.GetMemoryStream(compressedLength);
                 buffer.ReadAlignedMemory(stream, compressedLength);
 
@@ -55,6 +62,7 @@ namespace Robust.Shared.Network.Messages
             // State is uncompressed.
             else
             {
+                buffer.ValidateByteLength(uncompressedLength, nameof(StateStream));
                 finalStream = RobustMemoryManager.GetMemoryStream(uncompressedLength);
                 buffer.ReadAlignedMemory(finalStream, uncompressedLength);
             }

--- a/Robust.Shared/Network/Messages/MsgStateLeavePvs.cs
+++ b/Robust.Shared/Network/Messages/MsgStateLeavePvs.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Lidgren.Network;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Log;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 
@@ -25,7 +26,7 @@ public sealed class MsgStateLeavePvs : NetMessage
     public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
     {
         Tick = buffer.ReadGameTick();
-        var length = buffer.ReadInt32();
+        var length = buffer.ValidateElementCount(buffer.ReadInt32(), nameof(Entities));
         Entities = new(length);
 
         for (int i = 0; i < length; i++)

--- a/Robust.Shared/Network/Messages/MsgViewVariablesModifyRemote.cs
+++ b/Robust.Shared/Network/Messages/MsgViewVariablesModifyRemote.cs
@@ -2,6 +2,7 @@ using System.IO;
 using Lidgren.Network;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
@@ -42,13 +43,13 @@ namespace Robust.Shared.Network.Messages
         {
             SessionId = buffer.ReadUInt32();
             {
-                var length = buffer.ReadInt32();
+                var length = buffer.ReadInt32ByteLength(nameof(PropertyIndex));
                 using var stream = RobustMemoryManager.GetMemoryStream(length);
                 buffer.ReadAlignedMemory(stream, length);
                 PropertyIndex = serializer.Deserialize<object[]>(stream);
             }
             {
-                var length = buffer.ReadInt32();
+                var length = buffer.ReadInt32ByteLength(nameof(Value));
                 using var stream = RobustMemoryManager.GetMemoryStream(length);
                 buffer.ReadAlignedMemory(stream, length);
                 if (!serializer.TryDeserialize(stream, out var value))

--- a/Robust.Shared/Network/Messages/MsgViewVariablesModifyRemote.cs
+++ b/Robust.Shared/Network/Messages/MsgViewVariablesModifyRemote.cs
@@ -51,7 +51,10 @@ namespace Robust.Shared.Network.Messages
                 var length = buffer.ReadInt32();
                 using var stream = RobustMemoryManager.GetMemoryStream(length);
                 buffer.ReadAlignedMemory(stream, length);
-                Value = serializer.Deserialize(stream);
+                if (!serializer.TryDeserialize(stream, out var value))
+                    throw new InvalidDataException("Unknown serialized type ID in view variables value.");
+
+                Value = value;
             }
             ReinterpretValue = buffer.ReadBoolean();
         }

--- a/Robust.Shared/Network/Messages/MsgViewVariablesRemoteData.cs
+++ b/Robust.Shared/Network/Messages/MsgViewVariablesRemoteData.cs
@@ -2,6 +2,7 @@ using System.IO;
 using Lidgren.Network;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
@@ -31,7 +32,7 @@ namespace Robust.Shared.Network.Messages
         public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             RequestId = buffer.ReadUInt32();
-            var length = buffer.ReadInt32();
+            var length = buffer.ReadInt32ByteLength(nameof(Blob));
             using var stream = RobustMemoryManager.GetMemoryStream(length);
             buffer.ReadAlignedMemory(stream, length);
             Blob = serializer.Deserialize<ViewVariablesBlob>(stream);

--- a/Robust.Shared/Network/Messages/MsgViewVariablesReqData.cs
+++ b/Robust.Shared/Network/Messages/MsgViewVariablesReqData.cs
@@ -2,6 +2,7 @@ using System.IO;
 using Lidgren.Network;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
@@ -37,7 +38,7 @@ namespace Robust.Shared.Network.Messages
         {
             RequestId = buffer.ReadUInt32();
             SessionId = buffer.ReadUInt32();
-            var length = buffer.ReadInt32();
+            var length = buffer.ReadInt32ByteLength(nameof(RequestMeta));
             using var stream = RobustMemoryManager.GetMemoryStream(length);
             buffer.ReadAlignedMemory(stream, length);
             RequestMeta = serializer.Deserialize<ViewVariablesRequest>(stream);

--- a/Robust.Shared/Network/Messages/MsgViewVariablesReqSession.cs
+++ b/Robust.Shared/Network/Messages/MsgViewVariablesReqSession.cs
@@ -2,6 +2,7 @@ using System.IO;
 using Lidgren.Network;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
@@ -32,7 +33,7 @@ namespace Robust.Shared.Network.Messages
         public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
             RequestId = buffer.ReadUInt32();
-            var length = buffer.ReadInt32();
+            var length = buffer.ReadInt32ByteLength(nameof(Selector));
             using var stream = RobustMemoryManager.GetMemoryStream(length);
             buffer.ReadAlignedMemory(stream, length);
             Selector = serializer.Deserialize<ViewVariablesObjectSelector>(stream);

--- a/Robust.Shared/Network/Messages/Transfer/MsgTransferData.cs
+++ b/Robust.Shared/Network/Messages/Transfer/MsgTransferData.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Buffers;
 using Lidgren.Network;
+using Robust.Shared.Network;
 using Robust.Shared.Network.Transfer;
 using Robust.Shared.Serialization;
 
@@ -18,9 +19,7 @@ internal sealed class MsgTransferData : NetMessage
 
     public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
     {
-        var length = buffer.ReadVariableInt32();
-        if (length > BaseTransferImpl.BufferSize)
-            throw new Exception("Buffer size is too large");
+        var length = buffer.ReadVariableByteLength(nameof(Data), BaseTransferImpl.BufferSize);
 
         var arr = ArrayPool<byte>.Shared.Rent(length);
         buffer.ReadBytes(arr, 0, length);

--- a/Robust.Shared/Network/NetManager.Send.cs
+++ b/Robust.Shared/Network/NetManager.Send.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -62,7 +63,17 @@ public sealed partial class NetManager
             return;
         }
 
-        var packet = BuildMessage(message, channel.Connection.Peer);
+        NetOutgoingMessage packet;
+        try
+        {
+            packet = BuildMessage(message, channel.Connection.Peer);
+        }
+        catch (InvalidDataException e)
+        {
+            _logger.Error($"Refusing to send invalid {message.GetType().Name} to {channel}: {e.Message}");
+            return;
+        }
+
         var method = message.DeliveryMethod;
         var seqChannel = message.SequenceChannel;
 

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
@@ -114,11 +115,13 @@ namespace Robust.Shared.Network
         [Dependency] private HttpClientHolder _http = default!;
         [Dependency] private IHWId _hwId = default!;
         [Dependency] private ITransferManager _transfer = default!;
+        [Dependency] private INetValidationManager _netValidation = default!;
 
         /// <summary>
         ///     Whether we bother to log problematic packets. Set by <see cref="CVars.NetLogging"/>.
         /// </summary>
         private bool _logPacketIssues = false;
+        private int _messageSizeLogThreshold;
 
         /// <summary>
         ///     Holds lookup table for NetMessage.Id -> NetMessage.Type
@@ -272,6 +275,8 @@ namespace Robust.Shared.Network
 
             _config.OnValueChanged(CVars.NetVerbose, NetVerboseChanged);
             _config.OnValueChanged(CVars.NetLogging, NetLoggingChanged);
+            _config.OnValueChanged(CVars.NetMessageSizeLogThreshold, NetMessageSizeLogThresholdChanged, true);
+            _config.OnValueChanged(CVars.NetMessageSizeStats, NetMessageSizeStatsChanged, true);
             if (isServer)
             {
                 _config.OnValueChanged(CVars.AuthMode, OnAuthModeChanged, invokeImmediately: true);
@@ -298,6 +303,16 @@ namespace Robust.Shared.Network
         private void NetLoggingChanged(bool obj)
         {
             _logPacketIssues = obj;
+        }
+
+        private void NetMessageSizeLogThresholdChanged(int value)
+        {
+            _messageSizeLogThreshold = value;
+        }
+
+        private void NetMessageSizeStatsChanged(bool value)
+        {
+            NetSizeStats.Enabled = value;
         }
 
         private void LidgrenLogWarningChanged(bool newValue)
@@ -376,6 +391,14 @@ namespace Robust.Shared.Network
             {
                 peer.Peer.Configuration.SetMessageTypeEnabled(NetIncomingMessageType.VerboseDebugMessage, on);
             }
+        }
+
+        private void LogMessageSize(string direction, Type type, int bytes)
+        {
+            if (_messageSizeLogThreshold <= 0 || bytes < _messageSizeLogThreshold)
+                return;
+
+            _loggerPacket.Info($"{direction}: {type.Name} {bytes} bytes");
         }
 
         public void StartServer()
@@ -478,6 +501,8 @@ namespace Robust.Shared.Network
             _messages.Clear();
 
             _config.UnsubValueChanged(CVars.NetVerbose, NetVerboseChanged);
+            _config.UnsubValueChanged(CVars.NetMessageSizeLogThreshold, NetMessageSizeLogThresholdChanged);
+            _config.UnsubValueChanged(CVars.NetMessageSizeStats, NetMessageSizeStatsChanged);
             if (IsServer)
             {
                 _config.UnsubValueChanged(CVars.AuthMode, OnAuthModeChanged);
@@ -978,7 +1003,7 @@ namespace Robust.Shared.Network
             if (entry == null)
             {
                 if (_logPacketIssues)
-                    _logger.Warning($"{msg.SenderConnection.RemoteEndPoint}: Got net message with invalid ID {id}.");
+                    _logger.Error($"{msg.SenderConnection.RemoteEndPoint}: Got net message with invalid ID {id}.");
 
                 channel.Disconnect("Got NetMessage with invalid ID", false);
                 return true;
@@ -997,6 +1022,19 @@ namespace Robust.Shared.Network
 
             var type = entry.Type;
 
+            try
+            {
+                _netValidation.ValidateSerializedSize(type, msg.LengthBytes);
+            }
+            catch (InvalidDataException e)
+            {
+                if (_logPacketIssues)
+                    _logger.Error($"{msg.SenderConnection.RemoteEndPoint}: {e.Message}");
+
+                channel.Disconnect("NetMessage exceeded maximum serialized size", false);
+                return true;
+            }
+
             var instance = (NetMessage) Activator.CreateInstance(type)!;
             instance.MsgChannel = channel;
 
@@ -1010,11 +1048,20 @@ namespace Robust.Shared.Network
             try
             {
                 instance.ReadFromBuffer(msg, _serializer);
+                _netValidation.ValidateObject(instance);
             }
             catch (InvalidCastException ice)
             {
                 if (_logPacketIssues)
                     _logger.Error($"{msg.SenderConnection.RemoteEndPoint}: Wrong deserialization of {type.Name} packet:\n{ice}");
+                channel.Disconnect("Failed to deserialize packet.", false);
+                return true;
+            }
+            catch (InvalidDataException e)
+            {
+                if (_logPacketIssues)
+                    _logger.Error($"{msg.SenderConnection.RemoteEndPoint}: Invalid data in {type.Name} packet: {e.Message}");
+
                 channel.Disconnect("Failed to deserialize packet.", false);
                 return true;
             }
@@ -1028,6 +1075,8 @@ namespace Robust.Shared.Network
 
             if (_loggerPacket.IsLogLevelEnabled(LogLevel.Verbose))
                 _loggerPacket.Verbose($"RECV: {instance.GetType().Name} {msg.LengthBytes}");
+            LogMessageSize("RECV", instance.GetType(), msg.LengthBytes);
+            NetSizeStats.Record(NetSizeStatKind.NetMessage, instance.GetType(), msg.LengthBytes);
 
             try
             {
@@ -1076,6 +1125,7 @@ namespace Robust.Shared.Network
                 IsHandshake = (accept & NetMessageAccept.Handshake) != 0
             };
 
+            _netValidation.RegisterType<T>();
             _messages.Add(name, data);
 
             var thisSide = IsServer ? NetMessageAccept.Server : NetMessageAccept.Client;
@@ -1105,7 +1155,9 @@ namespace Robust.Shared.Network
                     $"[NET] No string in table with name {message.MsgName}. Was it registered?");
 
             packet.Write((byte) msgId);
+            _netValidation.ValidateObject(message);
             message.WriteToBuffer(packet, _serializer);
+            _netValidation.ValidateSerializedSize(message.GetType(), packet.LengthBytes);
             return packet;
         }
 
@@ -1145,6 +1197,8 @@ namespace Robust.Shared.Network
         {
             if (_loggerPacket.IsLogLevelEnabled(LogLevel.Verbose))
                 _loggerPacket.Verbose($"SEND: {message.GetType().Name} {method} {packet.LengthBytes}");
+
+            LogMessageSize("SEND", message.GetType(), packet.LengthBytes);
         }
 
         /// <inheritdoc />

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -1038,11 +1038,7 @@ namespace Robust.Shared.Network
             var instance = (NetMessage) Activator.CreateInstance(type)!;
             instance.MsgChannel = channel;
 
-            if (!_bandwidthUsage.TryGetValue(type, out var bandwidth))
-            {
-                bandwidth = 0;
-            }
-
+            var bandwidth = _bandwidthUsage.GetValueOrDefault(type, 0);
             _bandwidthUsage[type] = bandwidth + msg.LengthBytes;
 
             try
@@ -1065,7 +1061,7 @@ namespace Robust.Shared.Network
                 channel.Disconnect("Failed to deserialize packet.", false);
                 return true;
             }
-            catch (Exception e) // yes, we want to catch ALL exeptions for security
+            catch (Exception e) // yes, we want to catch ALL exceptions for security
             {
                 if (_logPacketIssues)
                     _logger.Error($"{msg.SenderConnection.RemoteEndPoint}: Failed to deserialize {type.Name} packet:\n{e}");

--- a/Robust.Shared/Network/NetMessageExt.cs
+++ b/Robust.Shared/Network/NetMessageExt.cs
@@ -99,6 +99,8 @@ namespace Robust.Shared.Network
         /// </exception>
         public static void ReadAlignedMemory(this NetIncomingMessage message, MemoryStream memStream, int length)
         {
+            message.ValidateByteLength(length, nameof(length));
+
             if ((message.Position & 7) != 0)
             {
                 throw new ArgumentException("Read position in message must be byte-aligned", nameof(message));
@@ -108,6 +110,60 @@ namespace Robust.Shared.Network
             memStream.Write(message.Data, message.PositionInBytes, length);
             memStream.Position = 0;
             message.Position += length * 8;
+        }
+
+        public static int ReadVariableByteLength(this NetIncomingMessage message, string name, int maxLength = int.MaxValue)
+        {
+            var length = message.ReadVariableInt32();
+            return message.ValidateByteLength(length, name, maxLength);
+        }
+
+        public static int ReadInt32ByteLength(this NetIncomingMessage message, string name, int maxLength = int.MaxValue)
+        {
+            var length = message.ReadInt32();
+            return message.ValidateByteLength(length, name, maxLength);
+        }
+
+        public static int ValidateByteLength(this NetIncomingMessage message, int length, string name, int maxLength = int.MaxValue)
+        {
+            if (length < 0)
+                throw new InvalidDataException($"{name} length cannot be negative.");
+
+            if (length > maxLength)
+                throw new InvalidDataException($"{name} length {length} exceeds maximum {maxLength}.");
+
+            var remaining = message.LengthBytes - message.PositionInBytes;
+            if (length > remaining)
+                throw new InvalidDataException($"{name} length {length} exceeds remaining packet length {remaining}.");
+
+            return length;
+        }
+
+        public static int ValidateElementCount(
+            this NetIncomingMessage message,
+            int count,
+            string name,
+            int minBytesPerElement = 1,
+            int maxCount = int.MaxValue)
+        {
+            if (count < 0)
+                throw new InvalidDataException($"{name} count cannot be negative.");
+
+            if (minBytesPerElement < 0)
+                throw new ArgumentOutOfRangeException(nameof(minBytesPerElement));
+
+            if (count > maxCount)
+                throw new InvalidDataException($"{name} count {count} exceeds maximum {maxCount}.");
+
+            // Does some level of size guessing for bytes.
+            if (minBytesPerElement > 0)
+            {
+                var remaining = message.LengthBytes - message.PositionInBytes;
+                if (count > remaining / minBytesPerElement)
+                    throw new InvalidDataException($"{name} count {count} exceeds remaining packet length {remaining}.");
+            }
+
+            return count;
         }
 
         public static TimeSpan ReadTimeSpan(this NetIncomingMessage message)

--- a/Robust.Shared/Serialization/IRobustSerializer.cs
+++ b/Robust.Shared/Serialization/IRobustSerializer.cs
@@ -54,6 +54,8 @@ namespace Robust.Shared.Serialization
         /// <typeparam name="T">Exact type of object to deserialize.</typeparam>
         void DeserializeDirect<T>(Stream stream, out T value);
         object Deserialize(Stream stream);
+        bool TryDeserialize(Stream stream, out object? value);
+        bool TryGetSerializedType(Stream stream, out Type? type);
         bool CanSerialize(Type type);
 
         /// <summary>

--- a/Robust.Shared/Serialization/IRobustSerializer.cs
+++ b/Robust.Shared/Serialization/IRobustSerializer.cs
@@ -56,6 +56,7 @@ namespace Robust.Shared.Serialization
         object Deserialize(Stream stream);
         bool TryDeserialize(Stream stream, out object? value);
         bool TryGetSerializedType(Stream stream, out Type? type);
+        void ValidateSerializedSize(Type type, int bytes);
         bool CanSerialize(Type type);
 
         /// <summary>

--- a/Robust.Shared/Serialization/IRobustSerializer.cs
+++ b/Robust.Shared/Serialization/IRobustSerializer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Robust.Shared.ContentPack;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Maths;
 using Robust.Shared.Network;
 
@@ -11,6 +12,8 @@ namespace Robust.Shared.Serialization
     [NotContentImplementable]
     public interface IRobustSerializer
     {
+        IEntityManager EntityManager { get; }
+
         /// <summary>
         /// Specifies how the serializer should handle read floating point values.
         /// </summary>

--- a/Robust.Shared/Serialization/NetSizeAttributes.cs
+++ b/Robust.Shared/Serialization/NetSizeAttributes.cs
@@ -12,7 +12,7 @@ namespace Robust.Shared.Serialization;
 /// Rejects serialized network payloads for this type above the specified byte size.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = true)]
-public sealed class NetMaxSerializedSizeAttribute(int bytes) : Attribute
+public sealed class NetMaxSizeAttribute(int bytes) : Attribute
 {
     public int Bytes { get; } = bytes;
 }
@@ -107,7 +107,7 @@ public sealed class NetValidationManager : INetValidationManager
     private static ValidationData BuildValidationData(Type type)
         => new(
             BuildLengthMembers(type),
-            type.GetCustomAttribute<NetMaxSerializedSizeAttribute>(true)?.Bytes);
+            type.GetCustomAttribute<NetMaxSizeAttribute>(true)?.Bytes);
 
     private static LengthMember[] BuildLengthMembers(Type type)
     {

--- a/Robust.Shared/Serialization/NetSizeAttributes.cs
+++ b/Robust.Shared/Serialization/NetSizeAttributes.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Robust.Shared.Collections;
+
+namespace Robust.Shared.Serialization;
+
+/// <summary>
+/// Rejects serialized network payloads for this type above the specified byte size.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = true)]
+public sealed class NetMaxSerializedSizeAttribute(int bytes) : Attribute
+{
+    public int Bytes { get; } = bytes;
+}
+
+/// <summary>
+/// Rejects deserialized network field or property values above the specified length.
+/// </summary>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, Inherited = true)]
+public sealed class NetMaxLengthAttribute(int length) : Attribute
+{
+    public int Length { get; } = length;
+}
+
+public interface INetValidationManager
+{
+    void RegisterTypes(IEnumerable<Type> types);
+    void RegisterType<T>();
+    void RegisterType(Type type);
+    void ValidateSerializedSize<T>(int bytes);
+    void ValidateSerializedSize(Type type, int bytes);
+    void ValidateObject<T>(T? value);
+}
+
+public sealed class NetValidationManager : INetValidationManager
+{
+    private sealed record LengthMember(MemberInfo Member, int MaxLength);
+
+    private sealed record ValidationData(LengthMember[] LengthMembers, int? SerializedSizeLimit);
+
+    private FrozenDictionary<Type, ValidationData> _registeredTypes =
+        new Dictionary<Type, ValidationData>().ToFrozenDictionary();
+
+    public void RegisterTypes(IEnumerable<Type> types)
+    {
+        var registeredTypes = new Dictionary<Type, ValidationData>(_registeredTypes);
+
+        foreach (var type in types)
+        {
+            registeredTypes.TryAdd(type, BuildValidationData(type));
+        }
+
+        _registeredTypes = registeredTypes.ToFrozenDictionary();
+    }
+
+    public void RegisterType<T>()
+    {
+        RegisterType(typeof(T));
+    }
+
+    public void RegisterType(Type type)
+    {
+        if (_registeredTypes.ContainsKey(type))
+            return;
+
+        var registeredTypes = new Dictionary<Type, ValidationData>(_registeredTypes)
+        {
+            [type] = BuildValidationData(type)
+        };
+
+        _registeredTypes = registeredTypes.ToFrozenDictionary();
+    }
+
+    public void ValidateSerializedSize<T>(int bytes)
+    {
+        ValidateSerializedSize(typeof(T), bytes);
+    }
+
+    public void ValidateSerializedSize(Type type, int bytes)
+    {
+        if (!_registeredTypes.TryGetValue(type, out var data) || data.SerializedSizeLimit is not { } max)
+            return;
+
+        if (bytes > max)
+            throw new InvalidDataException($"{type.Name} serialized size {bytes} exceeds maximum {max}.");
+    }
+
+    public void ValidateObject<T>(T? value)
+    {
+        if (value == null)
+            return;
+
+        var type = value.GetType();
+        if (!_registeredTypes.TryGetValue(type, out var data))
+            return;
+
+        foreach (var member in data.LengthMembers)
+        {
+            ValidateLength(type, member.Member, GetMemberValue(member.Member, value), member.MaxLength);
+        }
+    }
+
+    private static ValidationData BuildValidationData(Type type)
+        => new(
+            BuildLengthMembers(type),
+            type.GetCustomAttribute<NetMaxSerializedSizeAttribute>(true)?.Bytes);
+
+    private static LengthMember[] BuildLengthMembers(Type type)
+    {
+        var members = new ValueList<LengthMember>();
+
+        foreach (var field in GetFields(type))
+        {
+            var attr = field.GetCustomAttribute<NetMaxLengthAttribute>(true);
+            if (attr == null)
+                continue;
+
+            members.Add(new LengthMember(field, attr.Length));
+        }
+
+        foreach (var property in GetProperties(type))
+        {
+            var attr = property.GetCustomAttribute<NetMaxLengthAttribute>(true);
+            if (attr == null || property.GetIndexParameters().Length != 0)
+                continue;
+
+            members.Add(new LengthMember(property, attr.Length));
+        }
+
+        return members.ToArray();
+    }
+
+    private static object? GetMemberValue(MemberInfo member, object value)
+    {
+        return member switch
+        {
+            FieldInfo field => field.GetValue(value),
+            PropertyInfo property => property.GetValue(value),
+            _ => throw new ArgumentOutOfRangeException(nameof(member))
+        };
+    }
+
+    private static IEnumerable<FieldInfo> GetFields(Type type)
+    {
+        for (var current = type; current != null; current = current.BaseType)
+        {
+            foreach (var field in current.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+            {
+                yield return field;
+            }
+        }
+    }
+
+    private static IEnumerable<PropertyInfo> GetProperties(Type type)
+    {
+        for (var current = type; current != null; current = current.BaseType)
+        {
+            foreach (var property in current.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+            {
+                yield return property;
+            }
+        }
+    }
+
+    private static void ValidateLength(Type owner, MemberInfo member, object? value, int maxLength)
+    {
+        var length = GetLength(owner, member.Name, value);
+
+        if (length > maxLength)
+            throw new InvalidDataException($"{owner.Name}.{member.Name} length {length} exceeds maximum {maxLength}.");
+    }
+
+    private static int? GetLength(Type owner, string member, object? value)
+    {
+        return value switch
+        {
+            null => null,
+            string str => str.Length,
+            Array array => array.Length,
+            ICollection collection => collection.Count,
+            _ => throw new InvalidDataException($"{owner.Name}.{member} has {nameof(NetMaxLengthAttribute)} but is not a supported length-bearing type.")
+        };
+    }
+}

--- a/Robust.Shared/Serialization/NetSizeStats.cs
+++ b/Robust.Shared/Serialization/NetSizeStats.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Linq;
+using System.Reflection;
+
+namespace Robust.Shared.Serialization;
+
+public enum NetSizeStatKind
+{
+    NetMessage,
+    EntityEvent,
+    Member,
+    MemberCount
+}
+
+public sealed record NetSizeStat(NetSizeStatKind Kind, string Name, int Value, long Count);
+
+/*
+ * Use this for debugging NetMessage (+ EntityEventArgs via MsgEntity) stats and tuning size validation.
+ * Toggle net.message_size_stats on first and then run net_size_stats to dump the max stats.
+ */
+public static class NetSizeStats
+{
+    private sealed class MutableStat
+    {
+        public int Bytes;
+        public long Count;
+    }
+
+    private static readonly ConcurrentDictionary<(NetSizeStatKind Kind, string Name), MutableStat> Stats = new();
+
+    public static bool Enabled { get; set; }
+
+    public static void Clear()
+    {
+        Stats.Clear();
+    }
+
+    public static NetSizeStat[] Snapshot()
+    {
+        return Stats
+            .Select(x => new NetSizeStat(x.Key.Kind, x.Key.Name, x.Value.Bytes, x.Value.Count))
+            .OrderByDescending(x => x.Value)
+            .ThenBy(x => x.Kind)
+            .ThenBy(x => x.Name)
+            .ToArray();
+    }
+
+    [Conditional("DEBUG")]
+    public static void Record(NetSizeStatKind kind, Type type, int bytes)
+    {
+        Record(kind, type.FullName ?? type.Name, bytes);
+    }
+
+    [Conditional("DEBUG")]
+    public static void Record(NetSizeStatKind kind, string name, int bytes)
+    {
+        if (!Enabled)
+            return;
+
+        var stat = Stats.GetOrAdd((kind, name), _ => new MutableStat());
+        lock (stat)
+        {
+            stat.Count++;
+            if (bytes > stat.Bytes)
+                stat.Bytes = bytes;
+        }
+    }
+
+    [Conditional("DEBUG")]
+    public static void RecordSerializableMembers(object? value, IRobustSerializer serializer)
+    {
+        if (!Enabled || value == null)
+            return;
+
+        var owner = value.GetType();
+        foreach (var field in GetFields(owner))
+        {
+            if (field.IsDefined(typeof(CompilerGeneratedAttribute), false))
+                continue;
+
+            RecordMember(owner, field.Name, field.GetValue(value), serializer);
+        }
+
+        foreach (var property in GetProperties(owner))
+        {
+            if (property.GetIndexParameters().Length != 0)
+                continue;
+
+            RecordMember(owner, property.Name, property.GetValue(value), serializer);
+        }
+    }
+
+    private static void RecordMember(Type owner, string member, object? value, IRobustSerializer serializer)
+    {
+        if (value == null)
+            return;
+
+        RecordMemberCount(owner, member, value);
+
+        if (!serializer.CanSerialize(value.GetType()))
+            return;
+
+        try
+        {
+            using var stream = new MemoryStream();
+            serializer.Serialize(stream, value);
+            Record(NetSizeStatKind.Member, $"{owner.FullName ?? owner.Name}.{member}", (int) stream.Length);
+        }
+        catch
+        {
+            // Don't care if stuff dies it's a debug tool.
+        }
+    }
+
+    private static void RecordMemberCount(Type owner, string member, object value)
+    {
+        var count = value switch
+        {
+            string str => str.Length,
+            Array array => array.Length,
+            System.Collections.ICollection collection => collection.Count,
+            _ => -1
+        };
+
+        if (count < 0)
+            return;
+
+        Record(NetSizeStatKind.MemberCount, $"{owner.FullName ?? owner.Name}.{member}", count);
+    }
+
+    private static IEnumerable<FieldInfo> GetFields(Type type)
+    {
+        for (var current = type; current != null; current = current.BaseType)
+        {
+            foreach (var field in current.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+            {
+                yield return field;
+            }
+        }
+    }
+
+    private static IEnumerable<PropertyInfo> GetProperties(Type type)
+    {
+        for (var current = type; current != null; current = current.BaseType)
+        {
+            foreach (var property in current.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+            {
+                yield return property;
+            }
+        }
+    }
+}

--- a/Robust.Shared/Serialization/RobustSerializer.cs
+++ b/Robust.Shared/Serialization/RobustSerializer.cs
@@ -219,6 +219,11 @@ namespace Robust.Shared.Serialization
             }
         }
 
+        public void ValidateSerializedSize(Type type, int bytes)
+        {
+            _netValidation.ValidateSerializedSize(type, bytes);
+        }
+
         public bool CanSerialize(Type type)
             => _serializableTypes.Contains(type);
 

--- a/Robust.Shared/Serialization/RobustSerializer.cs
+++ b/Robust.Shared/Serialization/RobustSerializer.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Numerics;
 using System.Reflection;
+using Robust.Shared.Configuration;
 using Robust.Shared.Log;
 using Robust.Shared.Maths;
 using Robust.Shared.Reflection;
@@ -16,8 +17,10 @@ namespace Robust.Shared.Serialization
     internal abstract partial class RobustSerializer : IRobustSerializerInternal
     {
         [Dependency] private IReflectionManager _reflectionManager = default!;
+        [Dependency] private IConfigurationManager _configuration = default!;
         [Dependency] protected IRobustMappedStringSerializer MappedStringSerializer = default!;
         [Dependency] private ILogManager _logManager = default!;
+        [Dependency] private INetValidationManager _netValidation = default!;
 
         private readonly Dictionary<Type, Dictionary<string, Type?>> _cachedSerialized = new();
 
@@ -105,6 +108,9 @@ namespace Robust.Shared.Serialization
 
             var settings = new Settings
             {
+                MaxCollectionLength = (uint) Math.Max(0, _configuration.GetCVar(CVars.NetSerializerMaxCollectionLength)),
+                MaxByteArrayLength = (uint) Math.Max(0, _configuration.GetCVar(CVars.NetSerializerMaxByteArrayLength)),
+                MaxStringLength = (uint) Math.Max(0, _configuration.GetCVar(CVars.NetSerializerMaxStringLength)),
                 CustomTypeSerializers = new[]
                 {
                     MappedStringSerializer.TypeSerializer,
@@ -127,6 +133,7 @@ namespace Robust.Shared.Serialization
 
             _serializer = new Serializer(types, settings);
             _serializableTypes = new HashSet<Type>(_serializer.GetTypeMap().Keys);
+            _netValidation.RegisterTypes(_serializableTypes);
             LogSzr.Info($"Serializer Types Hash: {_serializer.GetSHA256()}");
         }
 
@@ -166,6 +173,7 @@ namespace Robust.Shared.Serialization
         {
             var start = StartMeasureStats(stream);
             _serializer.DeserializeDirect(stream, out value);
+            _netValidation.ValidateObject(value);
             EndMeasureDeserialize(stream, start, typeof(T));
         }
 
@@ -173,9 +181,42 @@ namespace Robust.Shared.Serialization
         {
             var start = StartMeasureStats(stream);
             var result = _serializer.Deserialize(stream);
+            _netValidation.ValidateObject(result);
             EndMeasureDeserialize(stream, start, result.GetType());
 
             return result;
+        }
+
+        public bool TryDeserialize(Stream stream, out object? value)
+        {
+            var start = StartMeasureStats(stream);
+            if (!_serializer.TryDeserialize(stream, out var result))
+            {
+                value = null;
+                return false;
+            }
+
+            _netValidation.ValidateObject(result);
+            EndMeasureDeserialize(stream, start, result?.GetType() ?? typeof(object));
+            value = result;
+            return true;
+        }
+
+        public bool TryGetSerializedType(Stream stream, out Type? type)
+        {
+            if (!stream.CanSeek)
+                throw new ArgumentException("Stream must be seekable.", nameof(stream));
+
+            var position = stream.Position;
+
+            try
+            {
+                return _serializer.TryGetTypeFromSerializedObject(stream, out type);
+            }
+            finally
+            {
+                stream.Position = position;
+            }
         }
 
         public bool CanSerialize(Type type)

--- a/Robust.Shared/Serialization/RobustSerializer.cs
+++ b/Robust.Shared/Serialization/RobustSerializer.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Numerics;
 using System.Reflection;
 using Robust.Shared.Configuration;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Log;
 using Robust.Shared.Maths;
 using Robust.Shared.Reflection;
@@ -21,6 +22,7 @@ namespace Robust.Shared.Serialization
         [Dependency] protected IRobustMappedStringSerializer MappedStringSerializer = default!;
         [Dependency] private ILogManager _logManager = default!;
         [Dependency] private INetValidationManager _netValidation = default!;
+        [Dependency] private IEntityManager _entityManager = default!;
 
         private readonly Dictionary<Type, Dictionary<string, Type?>> _cachedSerialized = new();
 
@@ -32,6 +34,8 @@ namespace Robust.Shared.Serialization
         private HashSet<Type> _serializableTypes = default!;
         private bool _initialized;
         private SerializerFloatFlags _floatFlags;
+
+        public IEntityManager EntityManager => _entityManager;
 
         private static Type[] AlwaysNetSerializable => new[]
         {

--- a/Robust.Shared/SharedIoC.cs
+++ b/Robust.Shared/SharedIoC.cs
@@ -41,6 +41,7 @@ namespace Robust.Shared
             deps.Register<ProfManager, ProfManager>();
             deps.Register<IRobustRandom, RobustRandom>();
             deps.Register<IRobustMappedStringSerializer, RobustMappedStringSerializer>();
+            deps.Register<INetValidationManager, NetValidationManager>();
             deps.Register<ISandboxHelper, SandboxHelper>();
             deps.Register<IManifoldManager, CollisionManager>();
             deps.Register<IVerticesSimplifier, RamerDouglasPeuckerSimplifier>();

--- a/Robust.Shared/Upload/NetworkResourceUploadMessage.cs
+++ b/Robust.Shared/Upload/NetworkResourceUploadMessage.cs
@@ -26,7 +26,7 @@ public sealed class NetworkResourceUploadMessage : NetMessage
 
     public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
     {
-        var dataLength = buffer.ReadVariableInt32();
+        var dataLength = buffer.ReadVariableByteLength(nameof(Data));
         Data = buffer.ReadBytes(dataLength);
         // What is the second argument here?
         RelativePath = new ResPath(buffer.ReadString());

--- a/Robust.Shared/ViewVariables/MsgViewVariablesPath.cs
+++ b/Robust.Shared/ViewVariables/MsgViewVariablesPath.cs
@@ -82,7 +82,7 @@ internal abstract class MsgViewVariablesPathRes : MsgViewVariablesPath
     {
         base.ReadFromBuffer(buffer, serializer);
         ResponseCode = (ViewVariablesResponseCode) buffer.ReadUInt16();
-        var length = buffer.ReadInt32();
+        var length = buffer.ValidateElementCount(buffer.ReadInt32(), nameof(Response));
         Response = new string[length];
 
         for (var i = 0; i < length; i++)
@@ -156,7 +156,7 @@ internal sealed class MsgViewVariablesListPathReq : MsgViewVariablesPathReq
     public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
     {
         base.ReadFromBuffer(buffer, serializer);
-        var length = buffer.ReadInt32();
+        var length = buffer.ReadInt32ByteLength(nameof(Options));
         using var stream = RobustMemoryManager.GetMemoryStream(length);
         buffer.ReadAlignedMemory(stream, length);
         Options = serializer.Deserialize<VVListPathOptions>(stream);

--- a/Robust.UnitTesting/RobustIntegrationTest.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.cs
@@ -840,6 +840,7 @@ namespace Robust.UnitTesting
 
                 if (Options != null)
                 {
+                    Options.BeforeStartServices?.Invoke(deps);
                     Options.BeforeStart?.Invoke();
                     cfg.OverrideConVars(Options.CVarOverrides.Select(p => (p.Key, p.Value)));
                     LoadExtraPrototypes(deps, Options);
@@ -1101,6 +1102,7 @@ namespace Robust.UnitTesting
 
                 if (Options != null)
                 {
+                    Options.BeforeStartServices?.Invoke(deps);
                     Options.BeforeStart?.Invoke();
                     cfg.OverrideConVars(Options.CVarOverrides.Select(p => (p.Key, p.Value)));
                     LoadExtraPrototypes(deps, Options);
@@ -1301,6 +1303,7 @@ namespace Robust.UnitTesting
         {
             public Action? InitIoC { get; set; }
             public Action? BeforeRegisterComponents { get; set; }
+            public Action<IDependencyCollection>? BeforeStartServices { get; set; }
             public Action? BeforeStart { get; set; }
             public Assembly[]? ContentAssemblies { get; set; }
 


### PR DESCRIPTION
- Adds NetMaxSize / NetMaxLength attributes to specify max NetMessage size / collection limits. Also a debug command to make it easier to tune these rather than guessing.
- MsgEntity relied on the sender to specify buffer size which is now validated first. Same with the type, whether anyone subscribes to it, and that it's a correct type. Deserialization then uses the helper attributes.
- There's many NetMessages that accept user-supplied length. For now I just added some dummy validation but we will need to go through these at some point and check lengths and set sane maximums. These can't use the helper attributes because they serialize directly and don't go through netserializer.
- Not sure on the performance cost but I think a 5% slower server would be worth validating messages more and we can profile and adjust in future.

Resolves https://github.com/space-wizards/RobustToolbox/issues/6673 but I also am not sure what else we can be doing besides reworking some of the code paths to avoid exceptions (which would be a much larger engine-only change for NetMessage in general; this at least gets the attributes for use now in the existing codepaths). At least this shouldn't cause the game to read int.MaxValue amounts of memory based on trust.

Needs https://github.com/space-wizards/netserializer/pull/9 for the collection length CVars

Tests passing locally on my machine.