### PR TITLE
Add StaggeredUpdateTracker for tick spreading

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -40,6 +40,7 @@ END TEMPLATE-->
 ### New features
 
 * Added a DictionaryEquals extension method to check equality between two dictionaries.
+* Added `IStaggeredUpdate` and `EntitySystem.GetStaggeredUpdateTracker<TComp>()` for spreading component updates over time.
 
 ### Bugfixes
 

--- a/Robust.Shared.Tests/Collections/RingBufferListTest.cs
+++ b/Robust.Shared.Tests/Collections/RingBufferListTest.cs
@@ -40,6 +40,41 @@ internal sealed class RingBufferListTest
     }
 
     [Test]
+    public void TestTryPeekFrontEmpty()
+    {
+        var list = new RingBufferList<int>();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(list.TryPeekFront(out var value), Is.False);
+            Assert.That(value, Is.Default);
+        }
+    }
+
+    [Test]
+    public void TestTryPeekFrontAfterWrap()
+    {
+        var list = new RingBufferList<int>(6)
+        {
+            1,
+            2,
+            3
+        };
+        list.RemoveAt(0);
+        list.RemoveAt(0);
+        list.Add(4);
+        list.Add(5);
+        list.Add(6);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(list.TryPeekFront(out var value), Is.True);
+            Assert.That(value, Is.EqualTo(3));
+            Assert.That(list, Is.EquivalentTo([3, 4, 5, 6]));
+        }
+    }
+
+    [Test]
     public void TestMiddleRemoveAtScenario1()
     {
         var list = new RingBufferList<int>(6);

--- a/Robust.Shared/Collections/RingBufferList.cs
+++ b/Robust.Shared/Collections/RingBufferList.cs
@@ -86,6 +86,18 @@ internal sealed class RingBufferList<T> : IList<T>
         return true;
     }
 
+    public bool TryPeekFront(out T value)
+    {
+        if (Count == 0)
+        {
+            value = default!;
+            return false;
+        }
+
+        value = _items[_read];
+        return true;
+    }
+
     public int Count
     {
         get

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -1799,10 +1799,10 @@ namespace Robust.Shared.GameObjects
     /// <seealso cref="M:Robust.Shared.GameObjects.EntityManager.GetEntityQuery``1">EntityManager.GetEntityQuery()</seealso>
     public readonly struct EntityQuery<TComp1> where TComp1 : IComponent
     {
-        private readonly EntityManager _entMan;
+        private readonly EntityManager? _entMan;
         private readonly Dictionary<EntityUid, IComponent> _traitDict;
 
-        internal EntityQuery(EntityManager entMan, Dictionary<EntityUid, IComponent> traitDict)
+        internal EntityQuery(EntityManager? entMan, Dictionary<EntityUid, IComponent> traitDict)
         {
             _entMan = entMan;
             _traitDict = traitDict;
@@ -1957,7 +1957,7 @@ namespace Robust.Shared.GameObjects
             }
 
             if (logMissing)
-                _entMan.ResolveSawmill.Error($"Can't resolve \"{typeof(TComp1)}\" on entity {_entMan.ToPrettyString(uid)}!\n{Environment.StackTrace}");
+                _entMan?.ResolveSawmill.Error($"Can't resolve \"{typeof(TComp1)}\" on entity {_entMan.ToPrettyString(uid)}!\n{Environment.StackTrace}");
 
             return false;
         }
@@ -2076,7 +2076,7 @@ namespace Robust.Shared.GameObjects
             }
 
             if (logMissing)
-                _entMan.ResolveSawmill.Error($"Can't resolve \"{typeof(TComp1)}\" on entity {_entMan.ToPrettyString(uid)}!\n{new StackTrace(1, true)}");
+                _entMan?.ResolveSawmill.Error($"Can't resolve \"{typeof(TComp1)}\" on entity {_entMan.ToPrettyString(uid)}!\n{new StackTrace(1, true)}");
 
             return false;
         }

--- a/Robust.Shared/GameObjects/EntitySystem.StaggeredUpdate.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.StaggeredUpdate.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.Collections;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Robust.Shared.GameObjects;
+
+public partial class EntitySystem
+{
+    [IoC.Dependency] private IRobustRandom _rng = default!;
+    [IoC.Dependency] private IGameTiming _gameTiming = default!;
+
+    /// <summary>
+    ///     Creates a tracker for updating entities with <typeparamref name="TComp"/> staggered over time.
+    /// </summary>
+    /// <remarks>
+    ///     Entities are added to the tracker when their component receives <see cref="MapInitEvent"/>.
+    ///     Each tracked entity is returned by the tracker at <see cref="IStaggeredUpdate.UpdateInterval"/>
+    ///     intervals, with the first update randomly offset to spread work across ticks.
+    /// </remarks>
+    /// <param name="mapInit">Optional MapInit handler to invoke before the component is added to the tracker.</param>
+    /// <typeparam name="TComp">The component type to track.</typeparam>
+    /// <returns>A tracker that enumerates entities due for their staggered update.</returns>
+    protected StaggeredUpdateTracker<TComp> GetStaggeredUpdateTracker<TComp>(
+        EntityEventRefHandler<TComp, MapInitEvent>? mapInit) where TComp : IComponent, IStaggeredUpdate
+    {
+        var tracker = new StaggeredUpdateTracker<TComp>(
+            mapInit, GetEntityQuery<TComp>(), GetEntityQuery<MetaDataComponent>(), _rng, _gameTiming);
+        SubscribeLocalEvent<TComp, MapInitEvent>(tracker.OnMapInit);
+        return tracker;
+    }
+}
+
+public interface IStaggeredUpdate
+{
+    static abstract TimeSpan UpdateInterval { get; }
+    static abstract TimeSpan MaxInitialDelay { get; }
+}
+
+public sealed class StaggeredUpdateTracker<TComp>
+    where TComp : IComponent, IStaggeredUpdate
+{
+    private readonly PriorityQueue<EntityUid, TimeSpan> _insertQueue = new();
+    private readonly RingBufferList<(EntityUid entity, TimeSpan when)> _schedule = [];
+    private readonly HashSet<EntityUid> _tracked = [];
+
+    private readonly EntityQuery<TComp> _compQuery;
+    private readonly EntityQuery<MetaDataComponent> _metaQuery;
+    private readonly IRobustRandom _rng;
+    private readonly IGameTiming _timing;
+    private readonly EntityEventRefHandler<TComp, MapInitEvent>? _mapInit;
+
+    internal StaggeredUpdateTracker(
+        EntityEventRefHandler<TComp, MapInitEvent>? mapInit,
+        EntityQuery<TComp> compQuery,
+        EntityQuery<MetaDataComponent> metaQuery,
+        IRobustRandom rng,
+        IGameTiming timing)
+    {
+        var interval = TComp.UpdateInterval;
+        if (interval <= TimeSpan.Zero)
+        {
+            throw new InvalidOperationException(
+                $"{typeof(TComp)} has an invalid staggered update interval: {interval}. " +
+                "Staggered update interval must be positive and non-zero.");
+        }
+
+        _mapInit = mapInit;
+        _compQuery = compQuery;
+        _metaQuery = metaQuery;
+        _rng = rng;
+        _timing = timing;
+    }
+
+    internal void OnMapInit(Entity<TComp> ent, ref MapInitEvent args)
+    {
+        _mapInit?.Invoke(ent, ref args); // call a chained event handler if we have one
+
+        if (!_tracked.Add(ent.Owner)) return;
+
+        // randomize an offset from the current tick, up to interval
+        // we start from current tick + 1 because updates for the current tick may already have been processed
+        var when = _timing.CurTime + _timing.TickPeriod + _rng.Next(TimeSpan.Zero, TComp.MaxInitialDelay);
+        _insertQueue.Enqueue(ent.Owner, when);
+    }
+
+    public Enumerator GetEnumerator()
+    {
+        return new Enumerator(this);
+    }
+
+    public readonly struct Enumerator(StaggeredUpdateTracker<TComp> tracker)
+    {
+        private readonly PriorityQueue<EntityUid, TimeSpan> _insertQueue = tracker._insertQueue;
+        private readonly RingBufferList<(EntityUid entity, TimeSpan when)> _schedule = tracker._schedule;
+        private readonly HashSet<EntityUid> _tracked = tracker._tracked;
+        private readonly EntityQuery<TComp> _compQuery = tracker._compQuery;
+        private readonly EntityQuery<MetaDataComponent> _metaQuery = tracker._metaQuery;
+        private readonly TimeSpan _updateInterval = TComp.UpdateInterval;
+        private readonly TimeSpan _until = tracker._timing.CurTime;
+
+        public bool MoveNext(out EntityUid uid, [NotNullWhen(true)] out TComp? comp)
+        {
+            if (_insertQueue.Count != 0) return MoveNextMixed(out uid, out comp);
+
+            while (_schedule.TryPeekFront(out var sched))
+            {
+                if (sched.when > _until)
+                {
+                    uid = default;
+                    comp = default;
+                    return false;
+                }
+
+                _schedule.RemoveAt(0);
+                uid = sched.entity;
+
+                // since we only schedule when the component can be resolved, entities where the component has been
+                // deleted are dropped from the tracker
+                if (_compQuery.TryComp(uid, out comp))
+                {
+                    _schedule.Add((uid, sched.when + _updateInterval));
+
+                    if (!_metaQuery.TryGetComponentInternal(uid, out var metaComp)
+                        || metaComp.EntityPaused)
+                    {
+                        continue;
+                    }
+
+                    return true;
+                }
+
+                // if our component is missing, stop tracking this entity
+                _tracked.Remove(uid);
+            }
+
+            uid = default;
+            comp = default;
+            return false;
+        }
+
+        private bool MoveNextMixed(out EntityUid uid, [NotNullWhen(true)] out TComp? comp)
+        {
+            while (true)
+            {
+                TimeSpan when;
+
+                // the next entity may come either from the insertion list or the schedule, whichever is sooner
+                var queueWhen = _insertQueue.TryPeek(out var queueEnt, out var w)
+                    ? w
+                    : TimeSpan.MaxValue;
+                var (schedEnt, schedWhen) = _schedule.TryPeekFront(out var sched)
+                    ? sched
+                    : (default, TimeSpan.MaxValue);
+
+                if (schedWhen > _until && queueWhen > _until)
+                {
+                    uid = default;
+                    comp = default;
+                    return false;
+                }
+
+                if (queueWhen < schedWhen)
+                {
+                    _insertQueue.Dequeue();
+                    uid = queueEnt;
+                    when = queueWhen;
+                }
+                else
+                {
+                    _schedule.RemoveAt(0);
+                    uid = schedEnt;
+                    when = schedWhen;
+                }
+
+                // since we only schedule when the component can be resolved, entities where the component has been
+                // deleted are dropped from the tracker
+                if (_compQuery.TryComp(uid, out comp))
+                {
+                    _schedule.Add((uid, when + _updateInterval));
+
+                    if (!_metaQuery.TryGetComponentInternal(uid, out var metaComp)
+                        || metaComp.EntityPaused)
+                    {
+                        continue;
+                    }
+
+                    return true;
+                }
+
+                // if our component is missing, stop tracking this entity
+                _tracked.Remove(uid);
+            }
+        }
+    }
+}

--- a/Robust.UnitTesting/Shared/GameObjects/EntitySystemStaggeredUpdateTests.cs
+++ b/Robust.UnitTesting/Shared/GameObjects/EntitySystemStaggeredUpdateTests.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Collections.Generic;
+using Moq;
+using NUnit.Framework;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Random;
+using Robust.Shared.Reflection;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Robust.UnitTesting.Shared.GameObjects;
+
+[Reflect(false)]
+internal sealed partial class StaggeredUpdateComponent : Component, IStaggeredUpdate
+{
+    public static TimeSpan UpdateInterval => TimeSpan.FromSeconds(1);
+    public static TimeSpan MaxInitialDelay => UpdateInterval;
+}
+
+[Reflect(false)]
+internal sealed partial class ZeroIntervalStaggeredUpdateComponent : Component, IStaggeredUpdate
+{
+    public static TimeSpan UpdateInterval => TimeSpan.Zero;
+    public static TimeSpan MaxInitialDelay => UpdateInterval;
+}
+
+[Reflect(false)]
+internal sealed partial class NegativeIntervalStaggeredUpdateComponent : Component, IStaggeredUpdate
+{
+    public static TimeSpan UpdateInterval => TimeSpan.FromTicks(-1);
+    public static TimeSpan MaxInitialDelay => UpdateInterval;
+}
+
+[TestFixture, Parallelizable, TestOf(typeof(EntitySystem))]
+public sealed class EntitySystemStaggeredUpdateUnit
+{
+    private const int TickRate = 10;
+    private static MapInitEvent _mapInitEventInstance = new();
+
+    private readonly Dictionary<EntityUid, IComponent> _components = [];
+    private readonly Dictionary<EntityUid, IComponent> _metas = [];
+
+    private StaggeredUpdateTracker<StaggeredUpdateComponent> _updateTracker = null!;
+    private Mock<IRobustRandom> _random = null!;
+    private GameTiming _timing = null!;
+
+    [SetUp]
+    public void Before()
+    {
+        _random = new Mock<IRobustRandom>();
+        _timing = new GameTiming { TickRate = TickRate };
+        _updateTracker = CreateUpdateTracker<StaggeredUpdateComponent>();
+    }
+
+    [TearDown]
+    public void After()
+    {
+        _components.Clear();
+        _metas.Clear();
+    }
+
+    [Test]
+    public void TestRemovedComponentsAreUntracked()
+    {
+        var entity = new EntityUid(1);
+        var comp = CreateComponent(entity);
+
+        _timing.CurTick += _timing.TickRate;
+        Assert.That(ToList(_updateTracker), Contains.Item((entity, comp)));
+
+        _timing.CurTick += _timing.TickRate;
+        _components.Remove(entity);
+        Assert.That(ToList(_updateTracker), Is.Empty);
+
+        _timing.CurTick += _timing.TickRate;
+        _components.Add(entity, comp);
+        Assert.That(
+            ToList(_updateTracker),
+            Is.Empty,
+            "Do not return the entity, even when the component is added back");
+    }
+
+    [Test]
+    public void TestDoubleAdd()
+    {
+        var entity = new EntityUid(1);
+        var comp = CreateComponent(entity);
+
+        _components.Remove(entity);
+        _timing.CurTick += 1;
+        Assert.That(ToList(_updateTracker), Is.Empty);
+
+        _components.Add(entity, comp);
+        MapInit(entity, comp);
+        _timing.CurTick += _timing.TickRate;
+        Assert.That(ToList(_updateTracker), Has.Exactly(1).EqualTo((entity, comp)));
+    }
+
+    [Test]
+    public void TestRegularUpdate()
+    {
+        var entity = new EntityUid(1);
+        SetRandomOffset(1);
+        var comp = CreateComponent(entity);
+
+        _timing.CurTick += 1;
+        Assert.That(ToList(_updateTracker), Is.Empty);
+
+        _timing.CurTick += 1;
+        Assert.That(
+            ToList(_updateTracker),
+            Contains.Item((entity, comp)),
+            "Update after exactly offset + 1 ticks");
+
+        _timing.CurTick += (byte)(_timing.TickRate - 1);
+        Assert.That(
+            ToList(_updateTracker),
+            Is.Empty,
+            "Only return entity once until time is advanced by a full second");
+
+        _timing.CurTick += 1;
+        Assert.That(
+            ToList(_updateTracker),
+            Contains.Item((entity, comp)),
+            "Update exactly one second after previous update");
+    }
+
+    [Test]
+    public void TestPausedEntityIsSkippedUntilNextInterval()
+    {
+        var entity = new EntityUid(1);
+        SetRandomOffset(0);
+        var comp = CreateComponent(entity);
+
+        ((MetaDataComponent)_metas[entity]).PauseTime = TimeSpan.MinValue;
+        _timing.CurTick += 1;
+        Assert.That(
+            ToList(_updateTracker),
+            Is.Empty,
+            "Paused entities do not update even when their scheduled time has elapsed");
+
+        ((MetaDataComponent)_metas[entity]).PauseTime = null;
+        _timing.CurTick += (byte)(_timing.TickRate - 1);
+        Assert.That(
+            ToList(_updateTracker),
+            Is.Empty,
+            "The skipped update is not replayed immediately when the entity is unpaused");
+
+        _timing.CurTick += 1;
+        Assert.That(
+            ToList(_updateTracker),
+            Contains.Item((entity, comp)),
+            "The entity updates again on its next scheduled interval after being unpaused");
+    }
+
+    [Test]
+    public void TestDifferentRandomOffsetsUpdateIndependently()
+    {
+        var earlyEntity = new EntityUid(1);
+        var lateEntity = new EntityUid(2);
+
+        _random.SetupSequence(m => m.Next(TimeSpan.Zero, It.IsAny<TimeSpan>()))
+            .Returns(_timing.TickPeriod.Mul(0))
+            .Returns(_timing.TickPeriod.Mul(5));
+
+        var earlyComp = CreateComponent(earlyEntity);
+        var lateComp = CreateComponent(lateEntity);
+
+        _timing.CurTick += 1;
+        Assert.That(ToList(_updateTracker), Is.EqualTo([(earlyEntity, earlyComp)]));
+
+        _timing.CurTick += 4;
+        Assert.That(
+            ToList(_updateTracker),
+            Is.Empty,
+            "The later entity should not update before its own randomized offset has elapsed");
+
+        _timing.CurTick += 1;
+        Assert.That(ToList(_updateTracker), Is.EqualTo([(lateEntity, lateComp)]));
+    }
+
+    [Test]
+    public void TestChainedMapInitHandlerIsInvoked()
+    {
+        Entity<StaggeredUpdateComponent>? eventEntity = null;
+        var mapInitCalls = 0;
+        _updateTracker = CreateUpdateTracker<StaggeredUpdateComponent>(
+            (ent, ref _) =>
+            {
+                eventEntity = ent;
+                mapInitCalls++;
+            });
+
+        var entity = new EntityUid(1);
+        var comp = CreateComponent(entity);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(mapInitCalls, Is.EqualTo(1));
+            Assert.That(eventEntity, Is.EqualTo(WrapEnt(entity, comp)));
+        }
+    }
+
+    [Test]
+    public void TestUpdateIntervalMustBePositive()
+    {
+        Assert.Throws<InvalidOperationException>(() => CreateUpdateTracker<ZeroIntervalStaggeredUpdateComponent>());
+        Assert.Throws<InvalidOperationException>(() => CreateUpdateTracker<NegativeIntervalStaggeredUpdateComponent>());
+    }
+
+    private void SetRandomOffset(int ticks)
+    {
+        _random.Setup(m => m.Next(TimeSpan.Zero, It.IsAny<TimeSpan>()))
+            .Returns(_timing.TickPeriod.Mul(ticks));
+    }
+
+    private StaggeredUpdateTracker<TComp> CreateUpdateTracker<TComp>(
+        EntityEventRefHandler<TComp, MapInitEvent>? chainedHandler = null) where TComp : IComponent, IStaggeredUpdate
+    {
+        var compQuery = new EntityQuery<TComp>(null, _components);
+        var metaQuery = new EntityQuery<MetaDataComponent>(null, _metas);
+
+        var tracker = new StaggeredUpdateTracker<TComp>(
+            chainedHandler,
+            compQuery,
+            metaQuery,
+            _random.Object,
+            _timing);
+
+        return tracker;
+    }
+
+    private StaggeredUpdateComponent CreateComponent(EntityUid entity)
+    {
+        var comp = new StaggeredUpdateComponent();
+        _components.Add(entity, comp);
+        _metas.Add(entity, new MetaDataComponent());
+        MapInit(entity, comp);
+        return comp;
+    }
+
+    private void MapInit(EntityUid entity, StaggeredUpdateComponent comp)
+    {
+        _updateTracker.OnMapInit(WrapEnt(entity, comp), ref _mapInitEventInstance);
+    }
+
+    private static List<(EntityUid, TComp)> ToList<TComp>(StaggeredUpdateTracker<TComp> tracker)
+        where TComp : IComponent, IStaggeredUpdate
+    {
+        var ret = new List<(EntityUid, TComp)>();
+        var t = tracker.GetEnumerator();
+        while (t.MoveNext(out var uid, out var comp))
+        {
+            ret.Add((uid, comp));
+        }
+
+        return ret;
+    }
+
+    private Entity<StaggeredUpdateComponent> WrapEnt(EntityUid entity, StaggeredUpdateComponent comp)
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        comp.Owner = entity; // have to set this to pass AssertOwner check
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        return new Entity<StaggeredUpdateComponent>(entity, comp);
+    }
+}


### PR DESCRIPTION
Add an entity system helper designed to be used where a component is updated on a regular interval greater than one tick, with updates intended to be spread across multiple ticks. This is intended to replace several places today where content records a next update field on a component, then iterates all entities every tick checking to see if it is time to update that component.

The implementation in this commit efficiently keeps a sorted schedule of updates and allows the entities due to update (and only those entities) to be enumerated in amortized constant time for each. Removed components are handled lazily, and new components are handled via a priority queue. The schedule itself is implemented as a ring buffer.

A limitation of the approach is that the update interval cannot vary across individual instances of tracked components.