### PR TITLE
Basic Tracy support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -69,6 +69,7 @@
     <PackageVersion Include="System.Management" Version="10.0.0" />
     <PackageVersion Include="TerraFX.Interop.Windows" Version="10.0.26100.5" />
     <PackageVersion Include="TerraFX.Interop.Xlib" Version="6.4.0.2" />
+    <PackageVersion Include="Tracy-CSharp" Version="0.13.1" />
     <!-- Intentionally kept back, there is a bug that breaks audio for systems without AVX instructions. And the fix is not yet published. -->
     <PackageVersion Include="VorbisPizza" Version="1.3.0" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -14,7 +14,7 @@ Don't change the format without looking at the script!
 
 ### New features
 
-*None yet*
+* Added support for Tracy v0.13.1 on both the client and server. Start it by changing the prof.tracy.enabled cvar to true, and connect with a v0.13.1 Tracy client!
 
 ### Bugfixes
 

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -321,6 +321,7 @@ namespace Robust.Client.GameStates
 
             _prof.WriteValue($"State buffer size", curBufSize);
             _prof.WriteValue($"State apply count", targetProcessedTick.Value - _timing.LastProcessedTick.Value);
+            _prof.EmitEntities(_entities.EntityCount);
 
             bool processedAny = false;
 
@@ -1036,6 +1037,9 @@ namespace Robust.Client.GameStates
 
             if (metaState == null)
                 throw new MissingMetadataException(state.NetEntity);
+
+            // record the entity we created to the profiler
+            using var group = _prof.Group($"Create entity {metaState.PrototypeId}");
 
             var uid = _entities.CreateEntity(metaState.PrototypeId, out var newMeta);
             _toApply.Add(uid, new(uid, state.NetEntity, newMeta, true, false, GameTick.Zero, state, null, null));

--- a/Robust.Client/Robust.Client.csproj
+++ b/Robust.Client/Robust.Client.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.Extensions.ObjectPool" />
     <PackageReference Include="prometheus-net" />
     <PackageReference Include="Serilog" />
+    <PackageReference Include="Tracy-CSharp" />
 
     <!-- Needed to pin transitive dependency versions. -->
     <PackageReference Include="System.Text.Json" />

--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -40,6 +40,7 @@
     <!-- Needed to pin transitive dependency versions. -->
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Tracy-CSharp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Lidgren.Network\Lidgren.Network.csproj" />

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1752,6 +1752,11 @@ namespace Robust.Shared
         public static readonly CVarDef<bool> ProfEnabled = CVarDef.Create("prof.enabled", false);
 
         /// <summary>
+        /// Enables the Tracy profiling system.
+        /// </summary>
+        public static readonly CVarDef<bool> TracyProfEnabled = CVarDef.Create("prof.tracy.enabled", false);
+
+        /// <summary>
         /// Event log buffer size for the profiling system.
         /// </summary>
         public static readonly CVarDef<int> ProfBufferSize = CVarDef.Create("prof.buffer_size", 8192);

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1752,8 +1752,13 @@ namespace Robust.Shared
         public static readonly CVarDef<bool> ProfEnabled = CVarDef.Create("prof.enabled", false);
 
         /// <summary>
-        /// Enables the Tracy profiling system.
+        /// Enables the Tracy profiling system. Tracing will stay enabled for the entire runtime of the program even if
+        /// you turn this cvar off.
         /// </summary>
+        /// <remarks>
+        /// By default, this will listen for Tracy connections on all interfaces! Set the <c>TRACY_ONLY_LOCALHOST</c>
+        /// env var to 1 if you want to restrict to localhost.
+        /// </remarks>
         public static readonly CVarDef<bool> TracyProfEnabled = CVarDef.Create("prof.tracy.enabled", false);
 
         /// <summary>

--- a/Robust.Shared/Profiling/ProfManager.Tracy.cs
+++ b/Robust.Shared/Profiling/ProfManager.Tracy.cs
@@ -1,5 +1,6 @@
 using System;
 using bottlenoselabs.C2CS.Runtime;
+using Robust.Shared.Maths;
 using static Tracy.PInvoke;
 
 namespace Robust.Shared.Profiling;
@@ -27,7 +28,7 @@ public sealed partial class ProfManager
     private CString _tracyPlotGen2;
     private CString _tracyEntityCount;
 
-    public unsafe void EmitFrameImage(void* image, ushort width, ushort height, byte offset, bool flip)
+    internal unsafe void EmitFrameImage(void* image, ushort width, ushort height, byte offset, bool flip)
     {
         if (!IsTracyEnabled)
             return;
@@ -35,7 +36,7 @@ public sealed partial class ProfManager
         TracyEmitFrameImage(image, width, height, offset, flip ? 1 : 0);
     }
 
-    public void EmitMemoryPlots(int gcGen0, int gcGen1, int gcGen2)
+    internal void EmitMemoryPlots(int gcGen0, int gcGen1, int gcGen2)
     {
         if (!IsTracyEnabled)
             return;
@@ -55,7 +56,7 @@ public sealed partial class ProfManager
 
     }
 
-    public void EmitEntities(int entityCount)
+    internal void EmitEntities(int entityCount)
     {
         if (!IsTracyEnabled)
             return;
@@ -101,7 +102,7 @@ public sealed partial class ProfManager
     /// Creates a <seealso cref="CString"/> for use by Tracy. Also returns the
     /// length of the string for interop convenience.
     /// </summary>
-    public static CString GetCString(string? fromString, out ulong cLength)
+    internal static CString GetCString(string? fromString, out ulong cLength)
     {
         if (fromString == null)
         {
@@ -113,49 +114,38 @@ public sealed partial class ProfManager
         return CString.FromString(fromString);
     }
 
-    private static TracyProfilerZone BeginTracyZone(string name, int lineNumber, string? filePath, string? memberName)
+    private static TracyProfilerZone BeginTracyZone(string name, int lineNumber, Color? color, string? filePath, string? memberName)
     {
         using var fileStr = GetCString(filePath, out var fileLn);
         using var memberStr = GetCString(memberName, out var memberLn);
         using var nameStr = GetCString(name, out var nameLn);
-        var srcLocId = TracyAllocSrclocName((uint)lineNumber, fileStr, fileLn, memberStr, memberLn, nameStr, nameLn, 0);
+        var srcLocId = TracyAllocSrclocName((uint)lineNumber, fileStr, fileLn, memberStr, memberLn, nameStr, nameLn, (uint) (color?.ToArgb() ?? 0));
         var context = TracyEmitZoneBeginAlloc(srcLocId, 1);
         return new TracyProfilerZone(context);
     }
 }
 
-public readonly struct TracyProfilerZone : IDisposable
+internal readonly struct TracyProfilerZone : IDisposable
 {
-    public readonly TracyCZoneCtx Context;
+    private readonly TracyCZoneCtx _context;
 
-    public uint Id => Context.Data.Id;
+    private uint Id => _context.Data.Id;
 
-    public int Active => Context.Data.Active;
+    private int Active => _context.Data.Active;
 
     internal TracyProfilerZone(TracyCZoneCtx context)
     {
-        Context = context;
+        _context = context;
     }
 
-    public void EmitName(string name)
-    {
-        using var nameStr = ProfManager.GetCString(name, out var nameLn);
-        TracyEmitZoneName(Context, nameStr, nameLn);
-    }
-
-    public void EmitColor(uint color)
-    {
-        TracyEmitZoneColor(Context, color);
-    }
-
-    public void EmitText(string text)
+    internal void EmitText(string text)
     {
         using var textStr = ProfManager.GetCString(text, out var textLn);
-        TracyEmitZoneText(Context, textStr, textLn);
+        TracyEmitZoneText(_context, textStr, textLn);
     }
 
     public void Dispose()
     {
-        TracyEmitZoneEnd(Context);
+        TracyEmitZoneEnd(_context);
     }
 }

--- a/Robust.Shared/Profiling/ProfManager.Tracy.cs
+++ b/Robust.Shared/Profiling/ProfManager.Tracy.cs
@@ -1,0 +1,161 @@
+using System;
+using bottlenoselabs.C2CS.Runtime;
+using static Tracy.PInvoke;
+
+namespace Robust.Shared.Profiling;
+
+// Tracy-side partial ProfManager
+
+public sealed partial class ProfManager
+{
+    /// <summary>
+    /// Proxy to <c>prof.tracy.enabled</c> CVar.
+    /// </summary>
+    public bool IsTracyEnabled { get; private set; }
+
+    partial void InitializeTracyCvars()
+    {
+        _cfg.OnValueChanged(CVars.TracyProfEnabled, b => IsTracyEnabled = b, true);
+    }
+
+    private bool _tracyPlotsInitialized;
+    private long _tracyLastAllocatedBytes;
+    private CString _tracyPlotManagedHeap;
+    private CString _tracyPlotAllocRate;
+    private CString _tracyPlotGen0;
+    private CString _tracyPlotGen1;
+    private CString _tracyPlotGen2;
+    private CString _tracyEntityCount;
+
+    public unsafe void EmitFrameImage(void* image, ushort width, ushort height, byte offset, bool flip)
+    {
+        if (!IsTracyEnabled)
+            return;
+
+        TracyEmitFrameImage(image, width, height, offset, flip ? 1 : 0);
+    }
+
+    public void EmitMemoryPlots(int gcGen0, int gcGen1, int gcGen2)
+    {
+        if (!IsTracyEnabled)
+            return;
+
+        if (!_tracyPlotsInitialized)
+            InitTracyPlots();
+
+        var allocated = GC.GetTotalAllocatedBytes();
+
+        TracyEmitPlotInt(_tracyPlotManagedHeap, GC.GetTotalMemory(false));
+        TracyEmitPlotInt(_tracyPlotAllocRate, allocated - _tracyLastAllocatedBytes);
+        TracyEmitPlotInt(_tracyPlotGen0, gcGen0);
+        TracyEmitPlotInt(_tracyPlotGen1, gcGen1);
+        TracyEmitPlotInt(_tracyPlotGen2, gcGen2);
+
+        _tracyLastAllocatedBytes = allocated;
+
+    }
+
+    public void EmitEntities(int entityCount)
+    {
+        if (!IsTracyEnabled)
+            return;
+
+        if (!_tracyPlotsInitialized)
+            InitTracyPlots();
+
+        TracyEmitPlotInt(_tracyEntityCount, entityCount);
+    }
+
+    private void InitTracyPlots()
+    {
+        _tracyPlotsInitialized = true;
+        _tracyLastAllocatedBytes = GC.GetTotalAllocatedBytes();
+
+        _tracyPlotManagedHeap = CString.FromString("Managed Heap");
+        _tracyPlotAllocRate = CString.FromString("Alloc Rate");
+        _tracyPlotGen0 = CString.FromString("GC Gen 0");
+        _tracyPlotGen1 = CString.FromString("GC Gen 1");
+        _tracyPlotGen2 = CString.FromString("GC Gen 2");
+        _tracyEntityCount = CString.FromString("Entities");
+
+        const int memoryFormat = (int)TracyPlotFormatEnum.TracyPlotFormatMemory;
+        TracyEmitPlotConfig(_tracyPlotManagedHeap, memoryFormat, step: 0, fill: 1, color: 0);
+        TracyEmitPlotConfig(_tracyPlotAllocRate, memoryFormat, step: 0, fill: 1, color: 0);
+
+        const int numberFormat = (int)TracyPlotFormatEnum.TracyPlotFormatNumber;
+        TracyEmitPlotConfig(_tracyPlotGen0, numberFormat, step: 1, fill: 0, color: 0);
+        TracyEmitPlotConfig(_tracyPlotGen1, numberFormat, step: 1, fill: 0, color: 0);
+        TracyEmitPlotConfig(_tracyPlotGen2, numberFormat, step: 1, fill: 0, color: 0);
+        TracyEmitPlotConfig(_tracyEntityCount, numberFormat, step: 1, fill: 0, color: 0);
+    }
+
+    /// <summary>
+    /// Marks the boundary of a continuous Tracy frame. Used by <see cref="FrameGuard"/>.
+    /// </summary>
+    private static void EmitFrameMark()
+    {
+        TracyEmitFrameMark(null);
+    }
+
+    /// <summary>
+    /// Creates a <seealso cref="CString"/> for use by Tracy. Also returns the
+    /// length of the string for interop convenience.
+    /// </summary>
+    public static CString GetCString(string? fromString, out ulong cLength)
+    {
+        if (fromString == null)
+        {
+            cLength = 0;
+            return new CString(0);
+        }
+
+        cLength = (ulong)fromString.Length;
+        return CString.FromString(fromString);
+    }
+
+    private static TracyProfilerZone BeginTracyZone(string name, int lineNumber, string? filePath, string? memberName)
+    {
+        using var fileStr = GetCString(filePath, out var fileLn);
+        using var memberStr = GetCString(memberName, out var memberLn);
+        using var nameStr = GetCString(name, out var nameLn);
+        var srcLocId = TracyAllocSrclocName((uint)lineNumber, fileStr, fileLn, memberStr, memberLn, nameStr, nameLn, 0);
+        var context = TracyEmitZoneBeginAlloc(srcLocId, 1);
+        return new TracyProfilerZone(context);
+    }
+}
+
+public readonly struct TracyProfilerZone : IDisposable
+{
+    public readonly TracyCZoneCtx Context;
+
+    public uint Id => Context.Data.Id;
+
+    public int Active => Context.Data.Active;
+
+    internal TracyProfilerZone(TracyCZoneCtx context)
+    {
+        Context = context;
+    }
+
+    public void EmitName(string name)
+    {
+        using var nameStr = ProfManager.GetCString(name, out var nameLn);
+        TracyEmitZoneName(Context, nameStr, nameLn);
+    }
+
+    public void EmitColor(uint color)
+    {
+        TracyEmitZoneColor(Context, color);
+    }
+
+    public void EmitText(string text)
+    {
+        using var textStr = ProfManager.GetCString(text, out var textLn);
+        TracyEmitZoneText(Context, textStr, textLn);
+    }
+
+    public void Dispose()
+    {
+        TracyEmitZoneEnd(Context);
+    }
+}

--- a/Robust.Shared/Profiling/ProfManager.cs
+++ b/Robust.Shared/Profiling/ProfManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -13,6 +13,8 @@ namespace Robust.Shared.Profiling;
 // No interfaces here, don't want the interface dispatch overhead.
 
 // See ProfData.cs for description of profiling data layout.
+
+// Tracy integration lives in ProfManager.Tracy.cs.
 
 public sealed partial class ProfManager
 {
@@ -62,7 +64,10 @@ public sealed partial class ProfManager
         }, true);
 
         _cfg.OnValueChanged(CVars.ProfEnabled, b => IsEnabled = b, true);
+        InitializeTracyCvars();
     }
+
+    partial void InitializeTracyCvars();
 
     /// <summary>
     /// Write an index covering the region from <paramref name="start"/> to the current write position.
@@ -135,9 +140,13 @@ public sealed partial class ProfManager
     /// <summary>
     /// Make a guarded value for usage with using blocks.
     /// </summary>
-    public ValueGuard Value(string text)
+    public ValueGuard Value(
+        string text,
+        [CallerLineNumber] int lineNumber = 0,
+        [CallerFilePath] string? filePath = null,
+        [CallerMemberName] string? memberName = null)
     {
-        return new ValueGuard(this, text);
+        return new ValueGuard(this, text, lineNumber, filePath, memberName);
     }
 
     /// <summary>
@@ -191,10 +200,23 @@ public sealed partial class ProfManager
     /// <summary>
     /// Make a guarded group for usage with using blocks.
     /// </summary>
-    public GroupGuard Group(string name)
+    public GroupGuard Group(
+        string name,
+        [CallerLineNumber] int lineNumber = 0,
+        [CallerFilePath] string? filePath = null,
+        [CallerMemberName] string? memberName = null)
     {
         var start = WriteGroupStart();
-        return new GroupGuard(this, start, name);
+        return new GroupGuard(this, start, name, lineNumber, filePath, memberName);
+    }
+
+    /// <summary>
+    /// Make a guarded group that emits Tracy frame markers instead of a zone, for usage with using blocks.
+    /// </summary>
+    public FrameGuard Frame(string name)
+    {
+        var start = WriteGroupStart();
+        return new FrameGuard(this, start, name);
     }
 
     /// <summary>
@@ -245,7 +267,40 @@ public sealed partial class ProfManager
         private readonly string _groupName;
         private readonly ProfSampler _sampler;
 
-        public GroupGuard(ProfManager mgr, long startIndex, string groupName)
+        public TracyProfilerZone? TracyZone { get; }
+
+        public GroupGuard(
+            ProfManager mgr,
+            long startIndex,
+            string groupName,
+            int lineNumber,
+            string? filePath,
+            string? memberName)
+        {
+            _mgr = mgr;
+            _startIndex = startIndex;
+            _groupName = groupName;
+            _sampler = ProfSampler.StartNew();
+            if (_mgr.IsTracyEnabled)
+                TracyZone = BeginTracyZone(groupName, lineNumber, filePath, memberName);
+        }
+
+        public void Dispose()
+        {
+            _mgr.WriteGroupEnd(_startIndex, _groupName, _sampler);
+            if (_mgr.IsTracyEnabled)
+                TracyZone?.Dispose();
+        }
+    }
+
+    public readonly struct FrameGuard : IDisposable
+    {
+        private readonly ProfManager _mgr;
+        private readonly long _startIndex;
+        private readonly string _groupName;
+        private readonly ProfSampler _sampler;
+
+        public FrameGuard(ProfManager mgr, long startIndex, string groupName)
         {
             _mgr = mgr;
             _startIndex = startIndex;
@@ -256,6 +311,8 @@ public sealed partial class ProfManager
         public void Dispose()
         {
             _mgr.WriteGroupEnd(_startIndex, _groupName, _sampler);
+            if (_mgr.IsTracyEnabled)
+                EmitFrameMark();
         }
     }
 
@@ -264,17 +321,29 @@ public sealed partial class ProfManager
         private readonly ProfManager _mgr;
         private readonly string _text;
         private readonly ProfSampler _sampler;
+        private readonly TracyProfilerZone? _tracyZone;
 
-        public ValueGuard(ProfManager mgr, string text)
+        public TracyProfilerZone? TracyZone { get; }
+
+        public ValueGuard(
+            ProfManager mgr,
+            string text,
+            int lineNumber,
+            string? filePath,
+            string? memberName)
         {
             _mgr = mgr;
             _text = text;
             _sampler = ProfSampler.StartNew();
+            if (_mgr.IsTracyEnabled)
+                _tracyZone = BeginTracyZone(_text, lineNumber, filePath, memberName);
         }
 
         public void Dispose()
         {
             _mgr.WriteValue(_text, _sampler);
+            if (_mgr.IsTracyEnabled)
+                _tracyZone?.Dispose();
         }
     }
 }

--- a/Robust.Shared/Profiling/ProfManager.cs
+++ b/Robust.Shared/Profiling/ProfManager.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using Robust.Shared.Collections;
 using Robust.Shared.Configuration;
 using Robust.Shared.Log;
+using Robust.Shared.Maths;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.Profiling;
@@ -200,20 +201,26 @@ public sealed partial class ProfManager
     /// <summary>
     /// Make a guarded group for usage with using blocks.
     /// </summary>
+    /// <param name="name">The name of this group as it will show in the profiler.</param>
+    /// <param name="color">
+    /// The color of this zone and all of its children, as it will show in Tracy. This does
+    /// not affect the in game profiler.
+    /// </param>
     public GroupGuard Group(
         string name,
+        Color? color = null,
         [CallerLineNumber] int lineNumber = 0,
         [CallerFilePath] string? filePath = null,
         [CallerMemberName] string? memberName = null)
     {
         var start = WriteGroupStart();
-        return new GroupGuard(this, start, name, lineNumber, filePath, memberName);
+        return new GroupGuard(this, start, name, color ?? Color.Black, lineNumber, filePath, memberName);
     }
 
     /// <summary>
     /// Make a guarded group that emits Tracy frame markers instead of a zone, for usage with using blocks.
     /// </summary>
-    public FrameGuard Frame(string name)
+    internal FrameGuard Frame(string name)
     {
         var start = WriteGroupStart();
         return new FrameGuard(this, start, name);
@@ -267,12 +274,13 @@ public sealed partial class ProfManager
         private readonly string _groupName;
         private readonly ProfSampler _sampler;
 
-        public TracyProfilerZone? TracyZone { get; }
+        private TracyProfilerZone? TracyZone { get; }
 
-        public GroupGuard(
+        internal GroupGuard(
             ProfManager mgr,
             long startIndex,
             string groupName,
+            Color? color,
             int lineNumber,
             string? filePath,
             string? memberName)
@@ -282,7 +290,17 @@ public sealed partial class ProfManager
             _groupName = groupName;
             _sampler = ProfSampler.StartNew();
             if (_mgr.IsTracyEnabled)
-                TracyZone = BeginTracyZone(groupName, lineNumber, filePath, memberName);
+                TracyZone = BeginTracyZone(groupName, lineNumber, color, filePath, memberName);
+        }
+
+        /// <summary>
+        /// Adds text to show up in Tracy for this zone. </summary>
+        /// <remarks>
+        /// If Tracy is not enabled, this does nothing.
+        /// </remarks>
+        public void EmitText(string str)
+        {
+            TracyZone?.EmitText(str);
         }
 
         public void Dispose()
@@ -293,7 +311,7 @@ public sealed partial class ProfManager
         }
     }
 
-    public readonly struct FrameGuard : IDisposable
+    internal readonly struct FrameGuard : IDisposable
     {
         private readonly ProfManager _mgr;
         private readonly long _startIndex;
@@ -323,8 +341,6 @@ public sealed partial class ProfManager
         private readonly ProfSampler _sampler;
         private readonly TracyProfilerZone? _tracyZone;
 
-        public TracyProfilerZone? TracyZone { get; }
-
         public ValueGuard(
             ProfManager mgr,
             string text,
@@ -336,7 +352,7 @@ public sealed partial class ProfManager
             _text = text;
             _sampler = ProfSampler.StartNew();
             if (_mgr.IsTracyEnabled)
-                _tracyZone = BeginTracyZone(_text, lineNumber, filePath, memberName);
+                _tracyZone = BeginTracyZone(_text, lineNumber, Color.Black, filePath, memberName);
         }
 
         public void Dispose()

--- a/Robust.Shared/Robust.Shared.csproj
+++ b/Robust.Shared/Robust.Shared.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="libsodium" />
     <PackageReference Include="SixLabors.ImageSharp" />
     <PackageReference Include="TerraFX.Interop.Windows" PrivateAssets="compile" />
+    <PackageReference Include="Tracy-CSharp" />
 
     <!-- Needed to pin transitive dependency versions. -->
     <PackageReference Include="System.Reflection.Metadata" />

--- a/Robust.Shared/Timing/GameLoop.cs
+++ b/Robust.Shared/Timing/GameLoop.cs
@@ -310,7 +310,7 @@ namespace Robust.Shared.Timing
                 try
 #endif
                 {
-                    using (_prof.Group("Render"))
+                    using (_prof.Frame("Render"))
                     {
                         Render?.Invoke(this, realFrameEvent);
                     }
@@ -325,9 +325,13 @@ namespace Robust.Shared.Timing
                 {
                     using var gc = _prof.Group("GC Overview");
 
-                    _prof.WriteValue("Gen 0 Count", ProfData.Int32(GC.CollectionCount(0) - profFrameGcGen0));
-                    _prof.WriteValue("Gen 1 Count", ProfData.Int32(GC.CollectionCount(1) - profFrameGcGen1));
-                    _prof.WriteValue("Gen 2 Count", ProfData.Int32(GC.CollectionCount(2) - profFrameGcGen2));
+                    var gcGen0 = GC.CollectionCount(0);
+                    var gcGen1 = GC.CollectionCount(1);
+                    var gcGen2 = GC.CollectionCount(2);
+                    _prof.WriteValue("Gen 0 Count", ProfData.Int32(gcGen0 - profFrameGcGen0));
+                    _prof.WriteValue("Gen 1 Count", ProfData.Int32(gcGen1 - profFrameGcGen1));
+                    _prof.WriteValue("Gen 2 Count", ProfData.Int32(gcGen2 - profFrameGcGen2));
+                    _prof.EmitMemoryPlots(gcGen0, gcGen1, gcGen2);
                 }
 
                 _prof.WriteGroupEnd(profFrameGroupStart, "Frame", profFrameSw);


### PR DESCRIPTION
## Intro
This PR adds basic Tracy support to the RT engine.

The existing profiler system is untouched, both will work together.

Technically it creates a new partial ProfManager class and adds support to the already existing `GroupGuard` and `ValueGuard`
structs so adding new profilers calls will cause it to show up on both.

Download the Tracy client from their [Github releases.](https://github.com/wolfpld/tracy/releases/tag/v0.13.1) Only v0.13.1 is supported.

### Screenshots (open in new window!)
Client example:
<img width="2560" height="1400" alt="tracy-profiler_sgumhySNiI" src="https://github.com/user-attachments/assets/9be36589-454f-4eda-aeda-562e08874e60" />

Server example:
<img width="2560" height="1400" alt="tracy-profiler_GFgqmspz7I" src="https://github.com/user-attachments/assets/e54c0707-74e9-41e1-9df2-1d19670fa73e" />

## To use
Enable the `prof.tracy.enabled` cvar, `cvar prof.tracy.enabled true`, this can be done on either the client or server.
Both are supported, but I mostly focused on the client for this PR. You can run Tracy against the server though and see
rough system overview per tick! And you can get averages in the statistics or frame graph tab, too.

Afterwards, the game will hitch as Tracy initializes. You can then connect with Tracy and start seeing frame data!

CPU usage of the system, managed dotnet heap, allocation rate, and Gen0, Gen1 and Gen2 collections, along with the number
of entities the client knows about.

You'll see everything profiled with `_prof.Group("...") {}`, which isn't too much, but...

## What if I want to profile my code?
1. Add `ProfManager` as a dependency in your system:
    * `[Dependency] private ProfManager _prof = default!;`
2. Call `_prof.Group("my slow block")` to start a profiler zone.
    * This returns an `IDisposable` so you'll want to do `using (var group = _prof.Group("block") {...}` 
	or `using var group = _prof.Group("block")` to profile the entire scope.
3. That's it! If you want to add more details, you can call `group.TrazyZone?.EmitText("extra details here!");`
   and they will show up as custom text in your zone in Tracy.

### Example
This diff:
```diff
diff --git a/Robust.Client/Physics/PhysicsSystem.cs b/Robust.Client/Physics/PhysicsSystem.cs
index 6552ef272..27f239b0c 100644
--- a/Robust.Client/Physics/PhysicsSystem.cs
+++ b/Robust.Client/Physics/PhysicsSystem.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using JetBrains.Annotations;
 using Robust.Shared.Collections;
 using Robust.Shared.GameObjects;
@@ -7,6 +8,7 @@ using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Profiling;
 using Robust.Shared.Timing;
 
 namespace Robust.Client.Physics
@@ -17,9 +19,15 @@ namespace Robust.Client.Physics
         [Dependency] private IGameTiming _gameTiming = default!;
         [Dependency] private SharedTransformSystem _transform = default!;
         [Dependency] private SharedBroadphaseSystem _broadphase = default!;
+        [Dependency] private ProfManager _prof = default!;
 
         public override void Update(float frameTime)
         {
+            using (var group = _prof.Group("My Evil Sleep"))
+            {
+                Thread.Sleep(1);
+                group.TracyZone?.EmitText("Look at me, I'm evil and slept!!");
+            }
             UpdateIsPredicted();
             SimulateWorld(frameTime, _gameTiming.InPrediction);
         }
```
will produce a Tracy zone that looks like this:
<img width="961" height="459" alt="tracy-profiler_sv7JS8ZqXB" src="https://github.com/user-attachments/assets/5ccd95e9-2a65-4a12-adf8-6adb01fea879" />
	
## What still could to be done
According to the [Tracy manual,](https://github.com/wolfpld/tracy/releases/download/v0.13.1/tracy.pdf), support for profiling OpenGL calls is supported (p. 40). I have not the first idea on how to implement this in RobustToolbox, especially since we use OpenGL wrappers. I dunno graphics programming :(

An example of what that looks like in the profiler is available in the [Tracy demo,](https://tracy.nereid.pl/) though.

There's also support for sending screenshots in p. 30 with example OpenGL code.

Also, documentation for Tracy in RT, for wherever it lives now! Not sure where that's at.

Sending GC stats, start/end time as its own thread?

Auto instrument C# method calls to Tracy

### Extra
Also, thanks to [amylizzle](https://github.com/OpenDreamProject/OpenDream/pull/2127) for inspiration from OpenDream! 