### PR TITLE
Changed Resolve to log a Warning instead of an Error

### DIFF
--- a/Robust.Shared/GameObjects/EntitySystem.Resolve.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Resolve.cs
@@ -29,7 +29,7 @@ namespace Robust.Shared.GameObjects
 
             if (logMissing && !found)
             {
-                Log.Error($"Can't resolve \"{typeof(TComp)}\" on entity {ToPrettyString(uid)}!\n{Environment.StackTrace}");
+                Log.Warning($"Can't resolve \"{typeof(TComp)}\" on entity {ToPrettyString(uid)}!\n{Environment.StackTrace}");
             }
 
             return found;


### PR DESCRIPTION
~~**Compare to #6691**~~. This PR changes functionality of logMissing slightly by logging to a different output stream.

logMissing can fail tests because it logs to the stderr stream instead of stdout.

#### Reasoning
`logMissing` is very misleading. I expect something logged as an Info or Warning level log. This intermittently fails tests by logging to stderr as well, so clarifying that this is an Error-level log may help.
For example, a recently failed test of ours fails because:

```
  1) SERVER: 8.449s [ERRO] system.entity_storage: Can't resolve "Content.Shared.Storage.Components.EntityStorageComponent" on entity space carp (790) (1034204/n1034204, MobCarp)!
   at System.Environment.get_StackTrace()
   at Content.Shared.Storage.EntitySystems.SharedEntityStorageSystem.CanOpen(EntityUid user, EntityUid target, Boolean silent, EntityStorageComponent component) in /home/runner/work/Delta-v/Delta-v/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs:line 418
   at Content.Shared.Storage.EntitySystems.SharedEntityStorageSystem.TryOpenStorage(EntityUid user, EntityUid target, Boolean silent) in /home/runner/work/Delta-v/Delta-v/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs:line 390
   at Content.Server.NPC.HTN.PrimitiveTasks.Operators.Combat.Melee.EscapeOperator.Plan(NPCBlackboard blackboard, CancellationToken cancelToken) in /home/runner/work/Delta-v/Delta-v/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Combat/EscapeOperator.cs:line 60
```

The `EscapeOperator` class contains a call to Resolve but since the entity does not have the component, it logs and error and just completely fails the test, even though that is expected behavior. We could just set `logMissing` to false in this case, **but** there may be cases where we want to log missing components *without* having to set `logMissing` to false just to get tests to not fail randomly.