### PR TITLE
Clarify logMissing will log to the Error stream

### DIFF
--- a/Robust.Shared/GameObjects/EntitySystem.Resolve.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Resolve.cs
@@ -13,11 +13,11 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         /// <param name="uid">The entity where to query the components.</param>
         /// <param name="component">A reference to the variable storing the component, or null if it has to be resolved.</param>
-        /// <param name="logMissing">Whether to log missing components.</param>
+        /// <param name="logErrorIfMissing">Whether to log missing components to stderr.</param>
         /// <typeparam name="TComp">The component type to resolve.</typeparam>
         /// <returns>True if the component is not null or was resolved correctly, false if the component couldn't be resolved.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected bool Resolve<TComp>(EntityUid uid, [NotNullWhen(true)] ref TComp? component, bool logMissing = true)
+        protected bool Resolve<TComp>(EntityUid uid, [NotNullWhen(true)] ref TComp? component, bool logErrorIfMissing = true)
             where TComp : IComponent
         {
             DebugTools.AssertOwner(uid, component);
@@ -27,7 +27,7 @@ namespace Robust.Shared.GameObjects
 
             var found = EntityManager.TryGetComponent(uid, out component);
 
-            if (logMissing && !found)
+            if (logErrorIfMissing && !found)
             {
                 Log.Error($"Can't resolve \"{typeof(TComp)}\" on entity {ToPrettyString(uid)}!\n{Environment.StackTrace}");
             }
@@ -40,9 +40,9 @@ namespace Robust.Shared.GameObjects
         protected bool Resolve(
             EntityUid uid,
             [NotNullWhen(true)] ref MetaDataComponent? component,
-            bool logMissing = true)
+            bool logErrorIfMissing = true)
         {
-            return EntityManager.MetaQuery.Resolve(uid, ref component, logMissing);
+            return EntityManager.MetaQuery.Resolve(uid, ref component, logErrorIfMissing);
         }
 
         /// <inheritdoc cref="Resolve{TComp}(Robust.Shared.GameObjects.EntityUid,ref TComp?,bool)"/>
@@ -50,9 +50,9 @@ namespace Robust.Shared.GameObjects
         protected bool Resolve(
             EntityUid uid,
             [NotNullWhen(true)] ref TransformComponent? component,
-            bool logMissing = true)
+            bool logErrorIfMissing = true)
         {
-            return EntityManager.TransformQuery.Resolve(uid, ref component, logMissing);
+            return EntityManager.TransformQuery.Resolve(uid, ref component, logErrorIfMissing);
         }
 
         /// <summary>
@@ -61,16 +61,16 @@ namespace Robust.Shared.GameObjects
         /// <param name="uid">The entity where to query the components.</param>
         /// <param name="comp1">A reference to the variable storing the component, or null if it has to be resolved.</param>
         /// <param name="comp2">A reference to the variable storing the component, or null if it has to be resolved.</param>
-        /// <param name="logMissing">Whether to log missing components.</param>
+        /// <param name="logErrorIfMissing">Whether to log missing components to stderr.</param>
         /// <typeparam name="TComp1">The component type to resolve.</typeparam>
         /// <typeparam name="TComp2">The component type to resolve.</typeparam>
         /// <returns>True if the components are not null or were resolved correctly, false if any of the component couldn't be resolved.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected bool Resolve<TComp1, TComp2>(EntityUid uid, [NotNullWhen(true)] ref TComp1? comp1, [NotNullWhen(true)] ref TComp2? comp2, bool logMissing = true)
+        protected bool Resolve<TComp1, TComp2>(EntityUid uid, [NotNullWhen(true)] ref TComp1? comp1, [NotNullWhen(true)] ref TComp2? comp2, bool logErrorIfMissing = true)
             where TComp1 : IComponent
             where TComp2 : IComponent
         {
-            return Resolve(uid, ref comp1, logMissing) & Resolve(uid, ref comp2, logMissing);
+            return Resolve(uid, ref comp1, logErrorIfMissing) & Resolve(uid, ref comp2, logErrorIfMissing);
         }
 
         /// <summary>
@@ -80,18 +80,18 @@ namespace Robust.Shared.GameObjects
         /// <param name="comp1">A reference to the variable storing the component, or null if it has to be resolved.</param>
         /// <param name="comp2">A reference to the variable storing the component, or null if it has to be resolved.</param>
         /// <param name="comp3">A reference to the variable storing the component, or null if it has to be resolved.</param>
-        /// <param name="logMissing">Whether to log missing components.</param>
+        /// <param name="logErrorIfMissing">Whether to log missing components to stderr.</param>
         /// <typeparam name="TComp1">The component type to resolve.</typeparam>
         /// <typeparam name="TComp2">The component type to resolve.</typeparam>
         /// <typeparam name="TComp3">The component type to resolve.</typeparam>
         /// <returns>True if the components are not null or were resolved correctly, false if any of the component couldn't be resolved.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected bool Resolve<TComp1, TComp2, TComp3>(EntityUid uid, [NotNullWhen(true)] ref TComp1? comp1, [NotNullWhen(true)] ref TComp2? comp2, [NotNullWhen(true)] ref TComp3? comp3, bool logMissing = true)
+        protected bool Resolve<TComp1, TComp2, TComp3>(EntityUid uid, [NotNullWhen(true)] ref TComp1? comp1, [NotNullWhen(true)] ref TComp2? comp2, [NotNullWhen(true)] ref TComp3? comp3, bool logErrorIfMissing = true)
             where TComp1 : IComponent
             where TComp2 : IComponent
             where TComp3 : IComponent
         {
-            return Resolve(uid, ref comp1, ref comp2, logMissing) & Resolve(uid, ref comp3, logMissing);
+            return Resolve(uid, ref comp1, ref comp2, logErrorIfMissing) & Resolve(uid, ref comp3, logErrorIfMissing);
         }
 
         /// <summary>
@@ -102,20 +102,20 @@ namespace Robust.Shared.GameObjects
         /// <param name="comp2">A reference to the variable storing the component, or null if it has to be resolved.</param>
         /// <param name="comp3">A reference to the variable storing the component, or null if it has to be resolved.</param>
         /// <param name="comp4">A reference to the variable storing the component, or null if it has to be resolved.</param>
-        /// <param name="logMissing">Whether to log missing components.</param>
+        /// <param name="logErrorIfMissing">Whether to log missing components to stderr.</param>
         /// <typeparam name="TComp1">The component type to resolve.</typeparam>
         /// <typeparam name="TComp2">The component type to resolve.</typeparam>
         /// <typeparam name="TComp3">The component type to resolve.</typeparam>
         /// <typeparam name="TComp4">The component type to resolve.</typeparam>
         /// <returns>True if the components are not null or were resolved correctly, false if any of the component couldn't be resolved.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected bool Resolve<TComp1, TComp2, TComp3, TComp4>(EntityUid uid, [NotNullWhen(true)] ref TComp1? comp1, [NotNullWhen(true)] ref TComp2? comp2, [NotNullWhen(true)] ref TComp3? comp3, [NotNullWhen(true)] ref TComp4? comp4, bool logMissing = true)
+        protected bool Resolve<TComp1, TComp2, TComp3, TComp4>(EntityUid uid, [NotNullWhen(true)] ref TComp1? comp1, [NotNullWhen(true)] ref TComp2? comp2, [NotNullWhen(true)] ref TComp3? comp3, [NotNullWhen(true)] ref TComp4? comp4, bool logErrorIfMissing = true)
             where TComp1 : IComponent
             where TComp2 : IComponent
             where TComp3 : IComponent
             where TComp4 : IComponent
         {
-            return Resolve(uid, ref comp1, ref comp2, logMissing) & Resolve(uid, ref comp3, ref comp4, logMissing);
+            return Resolve(uid, ref comp1, ref comp2, logErrorIfMissing) & Resolve(uid, ref comp3, ref comp4, logErrorIfMissing);
         }
     }
 }


### PR DESCRIPTION
**Compare to #6690**. This suggestion does not change functionality, but instead adds clarity.

Adds clarity that resolving missing components will result in an error to the error stream. Changes no functionality really, but provides clarity to developers in IDE intellisense functionality that not setting it to `false` will log errors to the console (and can fail tests).

#### Reasoning
`logMissing` is very misleading. I expect something logged as an Info or Warning level log. This intermittently fails tests by logging to stderr as well. This changes it to still log, but log to stdout rather than stderr.