### PR TITLE
Cleanup: ProtoMan Part 3 - remove redundant EntitySystem IPrototypeManager, IComponentFactory instances

### DIFF
--- a/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AnimationPlayerSystem.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using Robust.Client.Animations;
 using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 using Robust.Shared.Utility;
 
 namespace Robust.Client.GameObjects
@@ -13,10 +12,6 @@ namespace Robust.Client.GameObjects
 
         private EntityQuery<AnimationPlayerComponent> _playerQuery;
         private EntityQuery<MetaDataComponent> _metaQuery;
-
-#if DEBUG
-        [Dependency] private IComponentFactory _compFact = default!;
-#endif
 
         public override void Initialize()
         {
@@ -129,7 +124,7 @@ namespace Robust.Client.GameObjects
                 if (IsClientSide(ent) || !animatedComp.NetSyncEnabled)
                     continue;
 
-                var reg = _compFact.GetRegistration(animatedComp);
+                var reg = Factory.GetRegistration(animatedComp);
 
                 // In principle there is nothing wrong with this, as long as the property of the component being
                 // animated is not part of the networked state and setting it does not dirty the component. Hence only a

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Helpers.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Helpers.cs
@@ -56,7 +56,7 @@ public sealed partial class SpriteSystem
     /// </summary>
     public IRsiStateLike GetPrototypeIcon(string prototype)
     {
-        if (!_proto.TryIndex<EntityPrototype>(prototype, out var entityPrototype))
+        if (!ProtoMan.TryIndex<EntityPrototype>(prototype, out var entityPrototype))
         {
             // The specified prototype doesn't exist, return the fallback "error" sprite.
             _sawmill.Error("Failed to load PrototypeIcon {0}", prototype);
@@ -82,7 +82,7 @@ public sealed partial class SpriteSystem
     private IRsiStateLike GetPrototypeIconInternal(EntityPrototype prototype)
     {
         // IconComponent takes precedence. If it has a valid icon, return that. Otherwise, continue as normal.
-        if (prototype.TryGetComponent(out IconComponent? icon, _factory))
+        if (prototype.TryComp(out IconComponent? icon, Factory))
             return GetIcon(icon);
 
         // If the prototype doesn't have a SpriteComponent, then there's nothing we can do but return the fallback.
@@ -108,7 +108,7 @@ public sealed partial class SpriteSystem
         var results = new List<IDirectionalTextureProvider>();
         noRot = false;
 
-        if (proto.TryGetComponent(out IconComponent? icon, _factory))
+        if (proto.TryComp(out IconComponent? icon, Factory))
         {
             results.Add(GetIcon(icon));
             return results;

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Numerics;
 using JetBrains.Annotations;
 using Robust.Client.ComponentTrees;
 using Robust.Client.Graphics;
@@ -13,7 +12,6 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Graphics.RSI;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
-using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations;
 using Robust.Shared.Timing;
@@ -31,10 +29,7 @@ namespace Robust.Client.GameObjects
         [Dependency] private IConfigurationManager _cfg = default!;
         [Dependency] private IEyeManager _eye = default!;
         [Dependency] private IGameTiming _timing = default!;
-        [Dependency] private IPrototypeManager _proto = default!;
         [Dependency] private IResourceCache _resourceCache = default!;
-        [Dependency] private ILogManager _logManager = default!;
-        [Dependency] private IComponentFactory _factory = default!;
 
         // Note that any new system dependencies have to be added to RobustUnitTest.BaseSetup()
         [Dependency] private SharedTransformSystem _xforms = default!;
@@ -64,7 +59,7 @@ namespace Robust.Client.GameObjects
             SubscribeLocalEvent<SpriteComponent, ComponentInit>(OnInit);
 
             Subs.CVar(_cfg, CVars.RenderSpriteDirectionBias, OnBiasChanged, true);
-            _sawmill = _logManager.GetSawmill("sprite");
+            _sawmill = LogManager.GetSawmill("sprite");
             _query = GetEntityQuery<SpriteComponent>();
         }
 

--- a/Robust.Client/GameObjects/EntitySystems/UserInterfaceSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/UserInterfaceSystem.cs
@@ -16,13 +16,13 @@ public sealed class UserInterfaceSystem : SharedUserInterfaceSystem
     public override void Initialize()
     {
         base.Initialize();
-        ProtoManager.PrototypesReloaded += OnProtoReload;
+        ProtoMan.PrototypesReloaded += OnProtoReload;
     }
 
     public override void Shutdown()
     {
         base.Shutdown();
-        ProtoManager.PrototypesReloaded -= OnProtoReload;
+        ProtoMan.PrototypesReloaded -= OnProtoReload;
     }
 
     /// <inheritdoc />

--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -40,6 +40,7 @@ namespace Robust.Client.Placement
         [Dependency] private IEntitySystemManager _entitySystemManager = default!;
         [Dependency] private IEntityManager _entityManager = default!;
         [Dependency] private IPrototypeManager _prototypeManager = default!;
+        [Dependency] private IComponentFactory _factory = default!;
         [Dependency] private IBaseClient _baseClient = default!;
         [Dependency] private IOverlayManager _overlayManager = default!;
         [Dependency] internal IClyde Clyde = default!;
@@ -787,7 +788,7 @@ namespace Robust.Client.Placement
 
             sc.Comp.NoRotation = noRot;
 
-            if (prototype != null && prototype.TryGetComponent<SpriteComponent>("Sprite", out var spriteComp))
+            if (prototype != null && prototype.TryComp<SpriteComponent>(out var spriteComp, _factory))
             {
                 Sprite.SetScale(sc.AsNullable(), spriteComp.Scale);
             }

--- a/Robust.Shared/GameObjects/Systems/MetaDataSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/MetaDataSystem.cs
@@ -17,6 +17,8 @@ public abstract partial class MetaDataSystem : EntitySystem
 
     public override void Initialize()
     {
+        base.Initialize();
+
         _metaQuery = GetEntityQuery<MetaDataComponent>();
         SubscribeLocalEvent<MetaDataComponent, ComponentHandleState>(OnMetaDataHandle);
         SubscribeLocalEvent<MetaDataComponent, ComponentGetState>(OnMetaDataGetState);

--- a/Robust.Shared/GameObjects/Systems/MetaDataSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/MetaDataSystem.cs
@@ -10,7 +10,6 @@ namespace Robust.Shared.GameObjects;
 public abstract partial class MetaDataSystem : EntitySystem
 {
     [Dependency] private IGameTiming _timing = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
 
     private EntityPausedEvent _pausedEvent;
 
@@ -37,7 +36,7 @@ public abstract partial class MetaDataSystem : EntitySystem
         component._entityDescription = state.Description;
 
         if(state.PrototypeId != null && state.PrototypeId != component._entityPrototype?.ID)
-            component._entityPrototype = _proto.Index<EntityPrototype>(state.PrototypeId);
+            component._entityPrototype = ProtoMan.Index<EntityPrototype>(state.PrototypeId);
 
         component.PauseTime = state.PauseTime;
     }

--- a/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Robust.Shared.IoC;
 using Robust.Shared.Prototypes;
 
 namespace Robust.Shared.GameObjects;
@@ -11,9 +10,6 @@ namespace Robust.Shared.GameObjects;
 /// </summary>
 internal sealed partial class PrototypeReloadSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _prototypes = default!;
-    [Dependency] private IComponentFactory _componentFactory = default!;
-
     public override void Initialize()
     {
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
@@ -31,7 +27,7 @@ internal sealed partial class PrototypeReloadSystem : EntitySystem
             if (id == null || !set.Modified.ContainsKey(id))
                 continue;
 
-            var proto = _prototypes.Index<EntityPrototype>(id);
+            var proto = ProtoMan.Index<EntityPrototype>(id);
             UpdateEntity(uid, metadata, proto);
         }
     }
@@ -42,12 +38,12 @@ internal sealed partial class PrototypeReloadSystem : EntitySystem
 
         var oldPrototypeComponents = oldPrototype?.Components.Keys
             .Where(n => n != "Transform" && n != "MetaData")
-            .Select(name => (name, _componentFactory.GetRegistration(name).Type))
+            .Select(name => (name, Factory.GetRegistration(name).Type))
             .ToList() ?? new List<(string name, Type Type)>();
 
         var newPrototypeComponents = newPrototype.Components.Keys
             .Where(n => n != "Transform" && n != "MetaData")
-            .Select(name => (name, _componentFactory.GetRegistration(name).Type))
+            .Select(name => (name, Factory.GetRegistration(name).Type))
             .ToList();
 
         var ignoredComponents = new List<string>();
@@ -71,7 +67,7 @@ internal sealed partial class PrototypeReloadSystem : EntitySystem
                      .Except(oldPrototypeComponents))
         {
             var data = newPrototype.Components[name];
-            var component = _componentFactory.GetComponent(name);
+            var component = Factory.GetComponent(name);
 
             if (!HasComp(entity, component.GetType()))
                 AddComp(entity, component);

--- a/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
@@ -12,6 +12,8 @@ internal sealed partial class PrototypeReloadSystem : EntitySystem
 {
     public override void Initialize()
     {
+        base.Initialize();
+
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
     }
 

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -10,7 +10,6 @@ using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Reflection;
 using Robust.Shared.Threading;
 using Robust.Shared.Timing;
@@ -24,7 +23,6 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private INetManager _netManager = default!;
     [Dependency] private IParallelManager _parallel = default!;
-    [Dependency] protected IPrototypeManager ProtoManager = default!;
     [Dependency] private IReflectionManager _reflection = default!;
     [Dependency] protected ISharedPlayerManager Player = default!;
     [Dependency] private SharedTransformSystem _transforms = default!;


### PR DESCRIPTION
Removes all redundant IPrototypeManager and IComponentFactory definitions inside EntitySystems within RobustToolbox.

Fixed three compiler warnings about EntityPrototype.TryGetPrototype.

IComponentFactory was added to PlacementManager as a dependency, otherwise fairly straightforward.

Continues the effort from https://github.com/space-wizards/space-station-14/pull/44416, this should be the last part.  Thankfully much smaller than the other two.