### PR TITLE
Add `EntitySystem.PostInitialize()`

### DIFF
--- a/Robust.Shared.IntegrationTests/GameObjects/EntitySystemManagerOrderTest.cs
+++ b/Robust.Shared.IntegrationTests/GameObjects/EntitySystemManagerOrderTest.cs
@@ -34,6 +34,8 @@ namespace Robust.UnitTesting.Shared.GameObjects
             public virtual IEnumerable<Type> UpdatesBefore => Enumerable.Empty<Type>();
             public bool UpdatesOutsidePrediction => true;
             public void Initialize() { }
+            public void PostInitialize() { }
+
             public void Shutdown() { }
 
             public void Update(float frameTime)

--- a/Robust.Shared.IntegrationTests/GameObjects/EntitySystemManager_Tests.cs
+++ b/Robust.Shared.IntegrationTests/GameObjects/EntitySystemManager_Tests.cs
@@ -18,6 +18,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
             public virtual IEnumerable<Type> UpdatesBefore => Enumerable.Empty<Type>();
             public bool UpdatesOutsidePrediction => true;
             public void Initialize() { }
+            public void PostInitialize() { }
             public void Shutdown() { }
             public void Update(float frameTime) { }
             public void FrameUpdate(float frameTime) { }

--- a/Robust.Shared/GameObjects/EntitySystem.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.cs
@@ -95,6 +95,10 @@ namespace Robust.Shared.GameObjects
         public virtual void Initialize() { }
 
         /// <inheritdoc />
+        [MustCallBase(true)]
+        public virtual void PostInitialize() { }
+
+        /// <inheritdoc />
         /// <remarks>
         /// Not ran on the client if prediction is disabled and
         /// <see cref="UpdatesOutsidePrediction"/> is false (the default).

--- a/Robust.Shared/GameObjects/EntitySystemManager.cs
+++ b/Robust.Shared/GameObjects/EntitySystemManager.cs
@@ -49,6 +49,7 @@ namespace Robust.Shared.GameObjects
         }
 
         private readonly List<Type> _systemTypes = new();
+        private readonly List<IEntitySystem> _resolvedSystems = new();
 
         private static readonly Histogram _tickUsageHistogram = Metrics.CreateHistogram("robust_entity_systems_update_usage",
             "Amount of time spent processing each entity system", new HistogramConfiguration
@@ -147,6 +148,7 @@ namespace Robust.Shared.GameObjects
             SystemDependencyCollection = new(_dependencyCollection);
             var subTypes = new Dictionary<Type, Type>();
             _systemTypes.Clear();
+            _resolvedSystems.Clear();
             IEnumerable<Type> systems;
 
             if (discover)
@@ -212,6 +214,7 @@ namespace Robust.Shared.GameObjects
             foreach (var systemType in _systemTypes)
             {
                 var system = (IEntitySystem)SystemDependencyCollection.ResolveType(systemType);
+                _resolvedSystems.Add(system);
                 system.Initialize();
                 SystemLoaded?.Invoke(this, new SystemChangedArgs(system));
             }
@@ -227,6 +230,11 @@ namespace Robust.Shared.GameObjects
                     Monitor = _tickUsageHistogram.WithLabels(s.GetType().Name)
                 })
                 .ToArray();
+
+            foreach (var system in _resolvedSystems)
+            {
+                system.PostInitialize();
+            }
 
             _initialized = true;
         }

--- a/Robust.Shared/GameObjects/EntitySystemManager.cs
+++ b/Robust.Shared/GameObjects/EntitySystemManager.cs
@@ -231,12 +231,12 @@ namespace Robust.Shared.GameObjects
                 })
                 .ToArray();
 
+            _initialized = true;
+
             foreach (var system in _resolvedSystems)
             {
                 system.PostInitialize();
             }
-
-            _initialized = true;
         }
 
         private static (IEnumerable<IEntitySystem> frameUpd, IEnumerable<IEntitySystem> upd)

--- a/Robust.Shared/GameObjects/IEntitySystem.cs
+++ b/Robust.Shared/GameObjects/IEntitySystem.cs
@@ -28,6 +28,11 @@ namespace Robust.Shared.GameObjects
         void Initialize();
 
         /// <summary>
+        ///     Called once after the system was created to finish initializing its state.
+        /// </summary>
+        void PostInitialize();
+
+        /// <summary>
         ///     Called once before the system is destroyed so that the system can clean up.
         /// </summary>
         void Shutdown();


### PR DESCRIPTION
## About this PR
This PR adds a new method to EntitySystem and its interface - `PostInitialize()`.
It is called right after all systems were initialized, and EntitySystemManager was marked as initialized.

## Why
`PostInitialize()` can be useful for some core systems that have to setup something while also using other systems.
Right now the only example of this in SS14 is server's `GameTicker`, but it can also be useful for other systems too.

## Technical details
`EntitySystemManager.Initialize` now caches the resolved systems into `_resolvedSystem` list. After the manager is marked as initialized, the list of resolved systems gets iterated through and `IEntitySystem.PostInitialized` method gets called on all of them.