### PR TITLE
Fix `EntitySystemSubscriptionsGeneratorAttributes` xmldocs

### DIFF
--- a/Robust.Shared/Analyzers/EntitySystemSubscriptionsGeneratorAttributes.cs
+++ b/Robust.Shared/Analyzers/EntitySystemSubscriptionsGeneratorAttributes.cs
@@ -7,49 +7,55 @@ namespace Robust.Shared.Analyzers;
 // These annotations direct the operation of `Robust.Shared.EntitySystemSubscriptionsGenerator`'s
 // `EntitySystemSubscriptionGenerator` and `EntitySystemSubscriptionGeneratorErrorAnalyser`.
 
+/// <summary>
 /// This attribute indicates that the annotated method is a handler for an event subscription. Methods annotated with
-/// this attribute will have a <c>EntitySystem.SubscribeLocalEvent</c> call generated, using the method as the handler,
+/// this attribute will have a <see cref="EntitySystem.SubscribeLocalEvent"/> call generated, using the method as the handler,
 /// with the event type (and component, as relevant) inferred from the method signature.
-/// <br/>
+/// </summary>
+/// <remarks>
 /// For this to work, the annotated method must be compatible with one of the following delegate types:
-/// <ul>
-/// <li><see cref="EntityEventHandler{TEvent}"/></li>
-/// <li><see cref="EntityEventRefHandler{TComp,TEvent}"/></li>
-/// <li><see cref="ComponentEventHandler{TComp,TEvent}"/></li>
-/// <li><see cref="ComponentEventRefHandler{TComp,TEvent}"/></li>
-/// </ul>
-/// <br/>
-/// Note that this is <b>not</b> any different from the normal requirements to use <c>EntitySystem.SubscribeLocalEvent</c>.
+/// <list type="bullet">
+/// <item><see cref="EntityEventHandler{TEvent}"/></item>
+/// <item><see cref="EntityEventRefHandler{TComp,TEvent}"/></item>
+/// <item><see cref="ComponentEventHandler{TComp,TEvent}"/></item>
+/// <item><see cref="ComponentEventRefHandler{TComp,TEvent}"/></item>
+/// </list>
+/// Note that this is <b>not</b> any different from the normal requirements to use <see cref="EntitySystem.SubscribeLocalEvent"/>.
+/// </remarks>
 [AttributeUsage(AttributeTargets.Method)]
 [MeansImplicitUse]
 public sealed class SubscribeLocalEventAttribute : Attribute;
 
+/// <summary>
 /// This attribute indicates that the annotated method is a handler for an event subscription. Methods annotated with
-/// this attribute will have a <c>EntitySystem.SubscribeNetworkEvent</c> call generated, using the method as the handler,
+/// this attribute will have a <see cref="EntitySystem.SubscribeNetworkEvent"/> call generated, using the method as the handler,
 /// with the event type inferred from the method signature.
-/// <br/>
+/// </summary>
+/// <remarks>
 /// For this to work, the annotated method must be compatible with one of the following delegate types:
-/// <ul>
-/// <li><see cref="EntityEventHandler{TEvent}"/></li>
-/// <li><see cref="EntitySessionEventHandler{TEvent}"/></li>
-/// </ul>
-/// <br/>
-/// Note that this is <b>not</b> any different from the normal requirements to use <c>EntitySystem.SubscribeNetworkEvent</c>.
+/// <list type="bullet">
+/// <item><see cref="EntityEventHandler{TEvent}"/></item>
+/// <item><see cref="EntitySessionEventHandler{TEvent}"/></item>
+/// </list>
+/// Note that this is <b>not</b> any different from the normal requirements to use <see cref="EntitySystem.SubscribeNetworkEvent"/>.
+/// </remarks>
 [AttributeUsage(AttributeTargets.Method)]
 [MeansImplicitUse]
 public sealed class SubscribeNetworkEventAttribute : Attribute;
 
+/// <summary>
 /// This attribute indicates that the annotated method is a handler for an event subscription. Methods annotated with
-/// this attribute will have a <c>EntitySystem.SubscribeAllEvent</c> call generated, using the method as the handler,
+/// this attribute will have a <see cref="EntitySystem.SubscribeAllEvent"/> call generated, using the method as the handler,
 /// with the event type inferred from the method signature.
-/// <br/>
+/// </summary>
+/// <remarks>
 /// For this to work, the annotated method must be compatible with one of the following delegate types:
-/// <ul>
-/// <li><see cref="EntityEventHandler{TEvent}"/></li>
-/// <li><see cref="EntitySessionEventHandler{TEvent}"/></li>
-/// </ul>
-/// <br/>
-/// Note that this is <b>not</b> any different from the normal requirements to use <c>EntitySystem.SubscribeAllEvent</c>.
+/// <list type="bullet">
+/// <item><see cref="EntityEventHandler{TEvent}"/></item>
+/// <item><see cref="EntitySessionEventHandler{TEvent}"/></item>
+/// </list>
+/// Note that this is <b>not</b> any different from the normal requirements to use <see cref="EntitySystem.SubscribeAllEvent"/>.
+/// </remarks>
 [AttributeUsage(AttributeTargets.Method)]
 [MeansImplicitUse]
 public sealed class EventSubscriptionAttribute : Attribute;


### PR DESCRIPTION
Slight touchup to the xmldoc formatting on these attributes so they display correctly (tested in vscode).

- Adds `<summary>` and `<remarks>` tags. Without at least one, no documentation is shown on hover.
- Converts `<ul>` and `<li>` to `<list>` and `<item>` respectively. Vscode does not recognize the former elements and displays the list as a single line with no formatting. 
- Swapped `<c>` tags on method references with `<see>` tags pointing to the referenced methods. This makes it easier to control-click through to see more documentation.