### PR TITLE
Tracy: Add PVS game state profiling zones

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -51,7 +51,7 @@ END TEMPLATE-->
 
 ### Internal
 
-*None yet*
+* Added profiling zones covering the PVS game-state send pipeline (chunks, serialization and sending), including a thread-safe Tracy-only zone helper for the parallel per-session work.
 
 
 ## 280.0.0

--- a/Robust.Server/GameStates/PvsSystem.Ack.cs
+++ b/Robust.Server/GameStates/PvsSystem.Ack.cs
@@ -55,6 +55,7 @@ internal sealed partial class PvsSystem
         if (!_async)
         {
             using var _= Histogram.WithLabels("Process Acks").NewTimer();
+            using var _pz = _prof.Group("Process Acks");
             _parallelManager.ProcessNow(_ackJob, _ackJob.Count);
             return null;
         }

--- a/Robust.Server/GameStates/PvsSystem.Chunks.cs
+++ b/Robust.Server/GameStates/PvsSystem.Chunks.cs
@@ -83,6 +83,7 @@ internal sealed partial class PvsSystem
     internal void GetVisibleChunks()
     {
         using var _= Histogram.WithLabels("Get Chunks").NewTimer();
+        using var _pz = _prof.Group("Get Chunks");
 
         DebugTools.Assert(!_chunks.Values.Any(x=> x.UpdateQueued));
         _dirtyChunks.Clear();
@@ -213,6 +214,7 @@ internal sealed partial class PvsSystem
     private void ProcessVisibleChunks()
     {
         using var _= Histogram.WithLabels("Update Chunks & Overrides").NewTimer();
+        using var _pz = _prof.Group("Update Chunks & Overrides");
         var task = _parallelMgr.Process(_chunkJob, _chunkJob.Count);
 
         UpdateCleanChunks();

--- a/Robust.Server/GameStates/PvsSystem.Dirty.cs
+++ b/Robust.Server/GameStates/PvsSystem.Dirty.cs
@@ -78,6 +78,7 @@ namespace Robust.Server.GameStates
         private void CleanupDirty()
         {
             using var _ = Histogram.WithLabels("Clean Dirty").NewTimer();
+            using var _pz = _prof.Group("Clean Dirty");
             if (!CullingEnabled)
             {
                 _seenAllEnts.Clear();

--- a/Robust.Server/GameStates/PvsSystem.Leave.cs
+++ b/Robust.Server/GameStates/PvsSystem.Leave.cs
@@ -31,6 +31,7 @@ internal sealed partial class PvsSystem
         }
 
         using var _ = Histogram.WithLabels("Process Leave").NewTimer();
+        using var _pz = _prof.Group("Process Leave");
         _parallelMgr.ProcessNow(_leaveJob, _leaveJob.Count);
     }
 

--- a/Robust.Server/GameStates/PvsSystem.Send.cs
+++ b/Robust.Server/GameStates/PvsSystem.Send.cs
@@ -23,6 +23,7 @@ internal sealed partial class PvsSystem
         // the sessions array
 
         using var _ = Histogram.WithLabels("Send States").NewTimer();
+        using var _pz = _prof.Group("Send States");
         var opts = new ParallelOptions {MaxDegreeOfParallelism = _parallelMgr.ParallelProcessCount};
         Parallel.ForEach(_sessions, opts, _threadResourcesPool.Get, SendSessionState, _threadResourcesPool.Return);
     }
@@ -43,6 +44,7 @@ internal sealed partial class PvsSystem
 
     private void SendSessionState(PvsSession data, ZStdCompressionContext ctx)
     {
+        using var _tz = _prof.BeginThreadZone("Send Session");
         DebugTools.AssertEqual(data.State, null);
 
         // PVS benchmarks use dummy sessions.

--- a/Robust.Server/GameStates/PvsSystem.Send.cs
+++ b/Robust.Server/GameStates/PvsSystem.Send.cs
@@ -44,7 +44,7 @@ internal sealed partial class PvsSystem
 
     private void SendSessionState(PvsSession data, ZStdCompressionContext ctx)
     {
-        using var _tz = _prof.BeginThreadZone("Send Session");
+        using var _tz = _prof.Group("Send Session");
         DebugTools.AssertEqual(data.State, null);
 
         // PVS benchmarks use dummy sessions.

--- a/Robust.Server/GameStates/PvsSystem.Serialize.cs
+++ b/Robust.Server/GameStates/PvsSystem.Serialize.cs
@@ -40,14 +40,14 @@ internal sealed partial class PvsSystem
 
             if (i >= 0)
             {
-                using (_prof.BeginThreadZone("Serialize Session"))
+                using (_prof.Group("Serialize Session"))
                 {
                     SerializeSessionState(_sessions[i]);
                 }
             }
             else
             {
-                using (_prof.BeginThreadZone("Serialize Replay"))
+                using (_prof.Group("Serialize Replay"))
                 {
                     _replay.Update();
                 }
@@ -70,7 +70,7 @@ internal sealed partial class PvsSystem
     /// </summary>
     private void SerializeSessionState(PvsSession data)
     {
-        using (_prof.BeginThreadZone("Compute State"))
+        using (_prof.Group("Compute State"))
         {
             ComputeSessionState(data);
         }
@@ -82,7 +82,7 @@ internal sealed partial class PvsSystem
         if (data.Session.Channel is not DummyChannel)
         {
             data.StateStream = RobustMemoryManager.GetMemoryStream();
-            using (_prof.BeginThreadZone("Write State"))
+            using (_prof.Group("Write State"))
             {
                 _serializer.SerializeDirect(data.StateStream, data.State);
             }

--- a/Robust.Server/GameStates/PvsSystem.Serialize.cs
+++ b/Robust.Server/GameStates/PvsSystem.Serialize.cs
@@ -22,6 +22,7 @@ internal sealed partial class PvsSystem
     private void SerializeStates()
     {
         using var _ = Histogram.WithLabels("Serialize States").NewTimer();
+        using var _pz = _prof.Group("Serialize States");
         var opts = new ParallelOptions {MaxDegreeOfParallelism = _parallelMgr.ParallelProcessCount};
         _oldestAck = GameTick.MaxValue.Value;
         Parallel.For(-1, _sessions.Length, opts, SerializeState);
@@ -38,9 +39,19 @@ internal sealed partial class PvsSystem
             ServerGameStateManager.PvsEventSource.Log.WorkStart(_gameTiming.CurTick.Value, i, guid);
 
             if (i >= 0)
-                SerializeSessionState(_sessions[i]);
+            {
+                using (_prof.BeginThreadZone("Serialize Session"))
+                {
+                    SerializeSessionState(_sessions[i]);
+                }
+            }
             else
-                _replay.Update();
+            {
+                using (_prof.BeginThreadZone("Serialize Replay"))
+                {
+                    _replay.Update();
+                }
+            }
 
             ServerGameStateManager.PvsEventSource.Log.WorkStop(_gameTiming.CurTick.Value, i, guid);
         }
@@ -59,7 +70,10 @@ internal sealed partial class PvsSystem
     /// </summary>
     private void SerializeSessionState(PvsSession data)
     {
-        ComputeSessionState(data);
+        using (_prof.BeginThreadZone("Compute State"))
+        {
+            ComputeSessionState(data);
+        }
         InterlockedHelper.Min(ref _oldestAck, data.FromTick.Value);
         DebugTools.AssertEqual(data.StateStream, null);
 
@@ -68,7 +82,10 @@ internal sealed partial class PvsSystem
         if (data.Session.Channel is not DummyChannel)
         {
             data.StateStream = RobustMemoryManager.GetMemoryStream();
-            _serializer.SerializeDirect(data.StateStream, data.State);
+            using (_prof.BeginThreadZone("Write State"))
+            {
+                _serializer.SerializeDirect(data.StateStream, data.State);
+            }
         }
 
         data.ClearState();

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -306,7 +306,7 @@ internal sealed partial class PvsSystem : EntitySystem
     private void GetEntityStates(PvsSession session)
     {
         // First, we send the client's own viewers. we want to ALWAYS send these, regardless of any pvs budget.
-        using (_prof.BeginThreadZone("Forced"))
+        using (_prof.Group("Forced"))
         {
             AddForcedEntities(session);
         }
@@ -325,13 +325,13 @@ internal sealed partial class PvsSystem : EntitySystem
         }
 
         // Process all PVS overrides.
-        using (_prof.BeginThreadZone("Overrides"))
+        using (_prof.Group("Overrides"))
         {
             AddAllOverrides(session);
         }
 
         // Process all entities in visible PVS chunks
-        using (_prof.BeginThreadZone("Chunks"))
+        using (_prof.Group("Chunks"))
         {
             AddPvsChunks(session);
         }

--- a/Robust.Server/GameStates/PvsSystem.cs
+++ b/Robust.Server/GameStates/PvsSystem.cs
@@ -18,6 +18,7 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
+using Robust.Shared.Profiling;
 using Robust.Shared.Threading;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -40,6 +41,7 @@ internal sealed partial class PvsSystem : EntitySystem
     [Dependency] private PvsOverrideSystem _pvsOverride = default!;
     [Dependency] private IServerReplayRecordingManager _replay = default!;
     [Dependency] private SharedMapSystem _maps = default!;
+    [Dependency] private ProfManager _prof = default!;
 
     // TODO make this a cvar. Make it in terms of seconds and tie it to tick rate?
     // Main issue is that I CBF figuring out the logic for handling it changing mid-game.
@@ -190,6 +192,8 @@ internal sealed partial class PvsSystem : EntitySystem
     {
         _getStateHandlers ??= EntityManager.EventBusInternal.GetNetCompEventHandlers<ComponentGetState>();
 
+        using var _pvs = _prof.Group("PVS");
+
         // Wait for pending jobs and process disconnected players
         ProcessDisconnections();
 
@@ -294,6 +298,7 @@ internal sealed partial class PvsSystem : EntitySystem
     private void CullDeletionHistory(GameTick oldestAck)
     {
         using var _ = Histogram.WithLabels("Cull History").NewTimer();
+        using var _pz = _prof.Group("Cull History");
         CullDeletionHistoryUntil(oldestAck);
         _maps.CullDeletionHistory(oldestAck);
     }
@@ -301,7 +306,10 @@ internal sealed partial class PvsSystem : EntitySystem
     private void GetEntityStates(PvsSession session)
     {
         // First, we send the client's own viewers. we want to ALWAYS send these, regardless of any pvs budget.
-        AddForcedEntities(session);
+        using (_prof.BeginThreadZone("Forced"))
+        {
+            AddForcedEntities(session);
+        }
 
         // After processing the entity's viewers, we set actual, budget limits.
         // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
@@ -317,10 +325,16 @@ internal sealed partial class PvsSystem : EntitySystem
         }
 
         // Process all PVS overrides.
-        AddAllOverrides(session);
+        using (_prof.BeginThreadZone("Overrides"))
+        {
+            AddAllOverrides(session);
+        }
 
         // Process all entities in visible PVS chunks
-        AddPvsChunks(session);
+        using (_prof.BeginThreadZone("Chunks"))
+        {
+            AddPvsChunks(session);
+        }
 
 #if DEBUG
         VerifySessionData(session);

--- a/Robust.Shared/Profiling/ProfManager.Tracy.cs
+++ b/Robust.Shared/Profiling/ProfManager.Tracy.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using bottlenoselabs.C2CS.Runtime;
 using Robust.Shared.Maths;
 using static Tracy.PInvoke;
@@ -122,6 +123,25 @@ public sealed partial class ProfManager
         var srcLocId = TracyAllocSrclocName((uint)lineNumber, fileStr, fileLn, memberStr, memberLn, nameStr, nameLn, (uint) (color?.ToArgb() ?? 0));
         var context = TracyEmitZoneBeginAlloc(srcLocId, 1);
         return new TracyProfilerZone(context);
+    }
+
+    /// <summary>
+    /// Begins a Tracy-only zone that is safe to call from any thread. Unlike <see cref="Group"/> this does NOT
+    /// write to the profiling buffer, so it will only show up in Tracy and not the in-game profiler. Use it
+    /// inside parallel regions (e.g. parallel job bodies) where the single-threaded prof buffer would
+    /// otherwise be corrupted. Returns null when Tracy is disabled.
+    /// </summary>
+    internal TracyProfilerZone? BeginThreadZone(
+        string name,
+        Color? color = null,
+        [CallerLineNumber] int lineNumber = 0,
+        [CallerFilePath] string? filePath = null,
+        [CallerMemberName] string? memberName = null)
+    {
+        if (!IsTracyEnabled)
+            return null;
+
+        return BeginTracyZone(name, lineNumber, color ?? Color.Black, filePath, memberName);
     }
 }
 

--- a/Robust.Shared/Profiling/ProfManager.Tracy.cs
+++ b/Robust.Shared/Profiling/ProfManager.Tracy.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.CompilerServices;
 using bottlenoselabs.C2CS.Runtime;
 using Robust.Shared.Maths;
 using static Tracy.PInvoke;
@@ -123,25 +122,6 @@ public sealed partial class ProfManager
         var srcLocId = TracyAllocSrclocName((uint)lineNumber, fileStr, fileLn, memberStr, memberLn, nameStr, nameLn, (uint) (color?.ToArgb() ?? 0));
         var context = TracyEmitZoneBeginAlloc(srcLocId, 1);
         return new TracyProfilerZone(context);
-    }
-
-    /// <summary>
-    /// Begins a Tracy-only zone that is safe to call from any thread. Unlike <see cref="Group"/> this does NOT
-    /// write to the profiling buffer, so it will only show up in Tracy and not the in-game profiler. Use it
-    /// inside parallel regions (e.g. parallel job bodies) where the single-threaded prof buffer would
-    /// otherwise be corrupted. Returns null when Tracy is disabled.
-    /// </summary>
-    internal TracyProfilerZone? BeginThreadZone(
-        string name,
-        Color? color = null,
-        [CallerLineNumber] int lineNumber = 0,
-        [CallerFilePath] string? filePath = null,
-        [CallerMemberName] string? memberName = null)
-    {
-        if (!IsTracyEnabled)
-            return null;
-
-        return BeginTracyZone(name, lineNumber, color ?? Color.Black, filePath, memberName);
     }
 }
 

--- a/Robust.Shared/Profiling/ProfManager.cs
+++ b/Robust.Shared/Profiling/ProfManager.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Threading;
 using Robust.Shared.Collections;
 using Robust.Shared.Configuration;
 using Robust.Shared.Log;
@@ -28,8 +27,11 @@ public sealed partial class ProfManager
     /// </summary>
     public bool IsEnabled { get; private set; }
 
-    // The profiling buffer is not thread-safe; only the thread we were initialized on writes to it.
-    private Thread? _owningThread;
+    // The profiling buffer is not thread-safe, so only the thread driving the frame writes to it.
+    // Stamped each frame by the game loop rather than at init, since ProfManager can be resolved from
+    // other dependency collections or used with no game loop at all. 0 means unset (no game loop), which
+    // allows writes from any thread so standalone usage keeps working.
+    private int _owningThreadId;
 
     // I don't care that this isn't a tree I will call upon the string tree just like in BYOND.
     private readonly Dictionary<string, int> _stringTreeIndices = new();
@@ -41,7 +43,6 @@ public sealed partial class ProfManager
 
     internal void Initialize()
     {
-        _owningThread = Thread.CurrentThread;
         _sawmill = _logManager.GetSawmill("prof");
 
         _cfg.OnValueChanged(CVars.ProfIndexSize, i =>
@@ -74,6 +75,16 @@ public sealed partial class ProfManager
     }
 
     partial void InitializeTracyCvars();
+
+    /// <summary>
+    /// Records the calling thread as the one driving the profiling buffer, so that <see cref="Group"/>
+    /// calls from any other thread (e.g. parallel job bodies) skip the buffer and only emit a Tracy zone.
+    /// Called once per frame by the game loop.
+    /// </summary>
+    internal void MarkFrameThread()
+    {
+        _owningThreadId = Environment.CurrentManagedThreadId;
+    }
 
     /// <summary>
     /// Write an index covering the region from <paramref name="start"/> to the current write position.
@@ -220,7 +231,8 @@ public sealed partial class ProfManager
         [CallerFilePath] string? filePath = null,
         [CallerMemberName] string? memberName = null)
     {
-        var writeBuffer = Thread.CurrentThread == _owningThread;
+        // 0 == no game loop has stamped an owner, so allow the write (single-threaded / standalone use).
+        var writeBuffer = _owningThreadId == 0 || Environment.CurrentManagedThreadId == _owningThreadId;
         var start = writeBuffer ? WriteGroupStart() : 0;
         return new GroupGuard(this, start, name, color ?? Color.Black, lineNumber, filePath, memberName, writeBuffer);
     }

--- a/Robust.Shared/Profiling/ProfManager.cs
+++ b/Robust.Shared/Profiling/ProfManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Robust.Shared.Collections;
 using Robust.Shared.Configuration;
 using Robust.Shared.Log;
@@ -27,6 +28,9 @@ public sealed partial class ProfManager
     /// </summary>
     public bool IsEnabled { get; private set; }
 
+    // The profiling buffer is not thread-safe; only the thread we were initialized on writes to it.
+    private Thread? _owningThread;
+
     // I don't care that this isn't a tree I will call upon the string tree just like in BYOND.
     private readonly Dictionary<string, int> _stringTreeIndices = new();
     private ValueList<string> _stringTree;
@@ -37,6 +41,7 @@ public sealed partial class ProfManager
 
     internal void Initialize()
     {
+        _owningThread = Thread.CurrentThread;
         _sawmill = _logManager.GetSawmill("prof");
 
         _cfg.OnValueChanged(CVars.ProfIndexSize, i =>
@@ -199,7 +204,9 @@ public sealed partial class ProfManager
     }
 
     /// <summary>
-    /// Make a guarded group for usage with using blocks.
+    /// Make a guarded group for usage with using blocks. Safe to call from any thread: groups made
+    /// off the owning thread (e.g. in parallel job bodies) skip the profiling buffer and only emit
+    /// a Tracy zone.
     /// </summary>
     /// <param name="name">The name of this group as it will show in the profiler.</param>
     /// <param name="color">
@@ -213,8 +220,9 @@ public sealed partial class ProfManager
         [CallerFilePath] string? filePath = null,
         [CallerMemberName] string? memberName = null)
     {
-        var start = WriteGroupStart();
-        return new GroupGuard(this, start, name, color ?? Color.Black, lineNumber, filePath, memberName);
+        var writeBuffer = Thread.CurrentThread == _owningThread;
+        var start = writeBuffer ? WriteGroupStart() : 0;
+        return new GroupGuard(this, start, name, color ?? Color.Black, lineNumber, filePath, memberName, writeBuffer);
     }
 
     /// <summary>
@@ -273,6 +281,8 @@ public sealed partial class ProfManager
         private readonly long _startIndex;
         private readonly string _groupName;
         private readonly ProfSampler _sampler;
+        // Decided once at creation so start/end writes always pair up.
+        private readonly bool _writeBuffer;
 
         private TracyProfilerZone? TracyZone { get; }
 
@@ -283,12 +293,14 @@ public sealed partial class ProfManager
             Color? color,
             int lineNumber,
             string? filePath,
-            string? memberName)
+            string? memberName,
+            bool writeBuffer)
         {
             _mgr = mgr;
             _startIndex = startIndex;
             _groupName = groupName;
-            _sampler = ProfSampler.StartNew();
+            _writeBuffer = writeBuffer;
+            _sampler = writeBuffer ? ProfSampler.StartNew() : default;
             if (_mgr.IsTracyEnabled)
                 TracyZone = BeginTracyZone(groupName, lineNumber, color, filePath, memberName);
         }
@@ -305,7 +317,8 @@ public sealed partial class ProfManager
 
         public void Dispose()
         {
-            _mgr.WriteGroupEnd(_startIndex, _groupName, _sampler);
+            if (_writeBuffer)
+                _mgr.WriteGroupEnd(_startIndex, _groupName, _sampler);
             if (_mgr.IsTracyEnabled)
                 TracyZone?.Dispose();
         }

--- a/Robust.Shared/Timing/GameLoop.cs
+++ b/Robust.Shared/Timing/GameLoop.cs
@@ -149,6 +149,7 @@ namespace Robust.Shared.Timing
 
             while (Running)
             {
+                _prof.MarkFrameThread();
                 var profFrameStart = _prof.WriteValue(ProfTextStartFrame, ProfData.Int64(_timing.CurFrame));
                 var profFrameGroupStart = _prof.WriteGroupStart();
                 var profFrameSw = ProfSampler.StartNew();


### PR DESCRIPTION
Adds profiling zones to the PVS game state send pipeline, which was mostly dark before (only `PvsSystem.Update` showed up, not the actual `SendGameStates` work). Server side of #6701.

Adds a top-level PVS zone plus one per phase matching the existing Prometheus histogram labels, and splits each session's serialize work into computing the visible set and serializing it.

The per-session serialize/send runs in `Parallel.For` and the prof buffer is single-threaded, so those use a new `BeginThreadZone` helper that emits a Tracy-only zone without touching the buffer. No behaviour change.