### PR TITLE
Tracy: Add entity rendering profiling zones

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -51,7 +51,7 @@ END TEMPLATE-->
 
 ### Internal
 
-*None yet*
+* Added profiling zones splitting entity rendering into sprite gathering and drawing.
 
 
 ## 280.0.0

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -303,13 +303,18 @@ namespace Robust.Client.Graphics.Clyde
             var worldOverlays = GetOverlaysForSpace(OverlaySpace.WorldSpaceEntities);
 
             var spriteSystem = _entityManager.System<SpriteSystem>();
-            GetSprites(mapId, viewport, eye, worldBounds, out var indexList);
+            int[] indexList;
+            using (_prof.Group("Gather Sprites"))
+            {
+                GetSprites(mapId, viewport, eye, worldBounds, out indexList);
+            }
 
             var screenSize = viewport.Size;
             var overlayIndex = 0;
 
             RenderTexture? entityPostRenderTarget = null;
             bool flushed = false;
+            using var _drawZone = _prof.Group("Draw");
             for (var i = 0; i < _drawingSpriteList.Count; i++)
             {
                 ref var entry = ref _drawingSpriteList[indexList[i]];


### PR DESCRIPTION
Splits the entity render pass into two zones, gathering/sorting the sprites and drawing them, so you can tell which one the cost is in. That's #4602.

Main-thread `_prof.Group` like the rest of the render zones, no behaviour change.