### PR TITLE
Fix: entity localization parent fallback

### DIFF
--- a/Robust.Shared.IntegrationTests/Localization/LocalizationTests.cs
+++ b/Robust.Shared.IntegrationTests/Localization/LocalizationTests.cs
@@ -77,6 +77,14 @@ namespace Robust.UnitTesting.Shared.Localization
     gender: male
     proper: true
 
+# Values specified in fluent at PARENT and supplemented by empty child fluent.
+- type: entity
+  id: TestInheritEmptyValueParent
+
+- type: entity
+  id: TestInheritEmptyValueChild
+  parent: TestInheritEmptyValueParent
+
 # Attribures stored in grammar component
 - type: entity
   id: PropsInGrammar
@@ -140,6 +148,14 @@ ent-TestInheritOverridingParent = XA
   .suffix = XC
   .gender = female
   .proper = false
+
+ent-TestInheritEmptyValueParent = A
+  .desc = B
+  .gender = male
+  .proper = true
+
+ent-TestInheritEmptyValueChild =
+  .suffix = C
 
 
 test-message-gender = { GENDER($entity) ->
@@ -234,6 +250,7 @@ test-message-custom-attrib = { ATTRIB($entity, ""otherAttrib"") }
         [TestCase("PropsInLocOverriding")]
         [TestCase("PropsInGrammar")]
         [TestCase("TestInheritOverridingChild")]
+        [TestCase("TestInheritEmptyValueChild")]
         public void TestLocData(string prototype)
         {
             var loc = IoCManager.Resolve<ILocalizationManager>();

--- a/Robust.Shared/Localization/LocalizationManager.Entity.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Entity.cs
@@ -55,10 +55,6 @@ namespace Robust.Shared.Localization
             string? desc = null;
             string? suffix = null;
 
-            string? fallbackName = null;
-            string? fallbackDesc = null;
-            string? fallbackSuffix = null;
-
             Dictionary<string, string>? attributes = null;
 
             // A child can have a locale entry just to override its suffix, while
@@ -121,9 +117,9 @@ namespace Robust.Shared.Localization
                 if (prototype == null)
                     continue;
 
-                fallbackName ??= prototype.SetName;
-                fallbackDesc ??= prototype.SetDesc;
-                fallbackSuffix ??= prototype.SetSuffix;
+                name ??= prototype.SetName;
+                desc ??= prototype.SetDesc;
+                suffix ??= prototype.SetSuffix;
 
                 if (prototype.LocProperties.Count != 0)
                 {
@@ -137,10 +133,6 @@ namespace Robust.Shared.Localization
                     }
                 }
             }
-
-            name ??= fallbackName;
-            desc ??= fallbackDesc;
-            suffix ??= fallbackSuffix;
 
             // Plenty of prototypes have no description at all, such as spawners,
             // markers, and debug/admin entities. Keep the missing .desc warning

--- a/Robust.Shared/Localization/LocalizationManager.Entity.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Entity.cs
@@ -165,7 +165,7 @@ namespace Robust.Shared.Localization
                 desc ?? "",
                 suffix,
                 attributes?.ToImmutableDictionary() ?? ImmutableDictionary<string, string>.Empty);
-        }
+        } 
 
 
         public EntityLocData GetEntityData(string prototypeId)

--- a/Robust.Shared/Localization/LocalizationManager.Entity.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Entity.cs
@@ -54,11 +54,21 @@ namespace Robust.Shared.Localization
             string? name = null;
             string? desc = null;
             string? suffix = null;
+
+            string? fallbackName = null;
+            string? fallbackDesc = null;
+            string? fallbackSuffix = null;
+
             Dictionary<string, string>? attributes = null;
 
-            foreach (var prototype in _prototype.EnumerateParents<EntityPrototype>(prototypeId, true))
+            // A child can have a locale entry just to override its suffix, while
+            // still inheriting the description from a parent. Hold these errors
+            // until we know no parent supplied a description either.
+            List<(string locId, List<FluentError> errs)>? deferredDescErrors = null;
+
+            foreach (var (id, prototype) in _prototype.EnumerateAllParents<EntityPrototype>(prototypeId, true))
             {
-                var locId = prototype?.CustomLocalizationID ?? $"ent-{prototypeId}";
+                var locId = prototype?.CustomLocalizationID ?? $"ent-{id}";
 
                 if (TryGetMessage(locId, out var bundle, out var msg))
                 {
@@ -91,12 +101,13 @@ namespace Robust.Shared.Localization
                             }
                         }
 
-                        var allErrors = new List<FluentError>();
                         if (desc == null
                             && !bundle.TryGetMessage(locId, "desc", null, out var err1, out desc))
                         {
                             desc = null;
-                            allErrors.AddRange(err1);
+                            // Defer: a parent prototype may still provide .desc.
+                            deferredDescErrors ??= new List<(string, List<FluentError>)>();
+                            deferredDescErrors.Add((locId, err1.ToList()));
                         }
 
                         if (suffix == null
@@ -104,16 +115,17 @@ namespace Robust.Shared.Localization
                         {
                             suffix = null;
                         }
-
-                        WriteWarningForErrs(allErrors, locId);
                     }
                 }
 
-                name ??= prototype?.SetName;
-                desc ??= prototype?.SetDesc;
-                suffix ??= prototype?.SetSuffix;
+                if (prototype == null)
+                    continue;
 
-                if (prototype?.LocProperties != null && prototype.LocProperties.Count != 0)
+                fallbackName ??= prototype.SetName;
+                fallbackDesc ??= prototype.SetDesc;
+                fallbackSuffix ??= prototype.SetSuffix;
+
+                if (prototype.LocProperties.Count != 0)
                 {
                     foreach (var (attrib, value) in prototype.LocProperties)
                     {
@@ -122,6 +134,24 @@ namespace Robust.Shared.Localization
                         {
                             attributes[attrib] = value;
                         }
+                    }
+                }
+            }
+
+            name ??= fallbackName;
+            desc ??= fallbackDesc;
+            suffix ??= fallbackSuffix;
+
+            // Plenty of prototypes have no description at all, such as spawners,
+            // markers, and debug/admin entities. Keep the missing .desc warning
+            // visible for debugging, but don't treat it as a real localization issue.
+            if (desc == null && deferredDescErrors != null)
+            {
+                foreach (var (locId, errs) in deferredDescErrors)
+                {
+                    foreach (var err in errs)
+                    {
+                        _logSawmill.Debug("Missing .desc for `{locId}`\n{e1}", locId, err);
                     }
                 }
             }

--- a/Robust.Shared/Localization/LocalizationManager.Entity.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Entity.cs
@@ -161,7 +161,7 @@ namespace Robust.Shared.Localization
             }
 
             return new EntityLocData(
-                name ?? "",
+                name ?? prototypeId,
                 desc ?? "",
                 suffix,
                 attributes?.ToImmutableDictionary() ?? ImmutableDictionary<string, string>.Empty);

--- a/Robust.Shared/Localization/LocalizationManager.Entity.cs
+++ b/Robust.Shared/Localization/LocalizationManager.Entity.cs
@@ -75,8 +75,11 @@ namespace Robust.Shared.Localization
                     {
                         // Only set name if the value isn't empty.
                         // So that you can override *only* a desc/suffix.
-                        name = bundle.FormatPattern(msg.Value, null, out var fmtErr);
+                        var locName = bundle.FormatPattern(msg.Value, null, out var fmtErr);
                         WriteWarningForErrs(fmtErr, locId);
+
+                        if (!string.IsNullOrEmpty(locName))
+                            name = locName;
                     }
 
                     if (msgAttrs.Count != 0)

--- a/Robust.Shared/Prototypes/EntityPrototype.cs
+++ b/Robust.Shared/Prototypes/EntityPrototype.cs
@@ -36,6 +36,7 @@ namespace Robust.Shared.Prototypes
         private const int DEFAULT_RANGE = 200;
 
         [DataField("loc")]
+        [NeverPushInheritance]
         private Dictionary<string, string>? _locPropertiesSet;
 
         /// <summary>
@@ -51,12 +52,15 @@ namespace Robust.Shared.Prototypes
         /// </summary>
         /// <seealso cref="Name"/>
         [DataField("name")]
+        [NeverPushInheritance]
         public string? SetName { get; private set; }
 
         [DataField("description")]
+        [NeverPushInheritance]
         public string? SetDesc { get; private set; }
 
         [DataField("suffix")]
+        [NeverPushInheritance]
         public string? SetSuffix { get; private set; }
 
         [DataField("categories"), Access(typeof(PrototypeManager))]


### PR DESCRIPTION
When I working with a locale files for my fork, I found it troublesome when working with many different .ftl files, and my builds always were giving me errors about missing .desc and etc, not allowing me to run properly.

this PR its basically a QoL fixes when working with locales.

Keep in mind that its my first ever PR to RobustToolbox, so I may dont know some specific details about the codebase, but I hope this one works for everyone.