### PR TITLE
Cleanup: Warning resolution/suppression

### DIFF
--- a/Robust.Benchmarks/Serialization/Read/SerializationReadBenchmark.cs
+++ b/Robust.Benchmarks/Serialization/Read/SerializationReadBenchmark.cs
@@ -20,7 +20,7 @@ namespace Robust.Benchmarks.Serialization.Read
             InitializeSerialization();
 
             StringDataDefNode = new MappingDataNode();
-            StringDataDefNode.Add(new ValueDataNode("string"), new ValueDataNode("ABC"));
+            StringDataDefNode.Add("string", new ValueDataNode("ABC"));
 
             var yamlStream = new YamlStream();
             yamlStream.Load(new StringReader(SeedDataDefinition.Prototype));

--- a/Robust.Client.WebView/Cef/WebViewManagerCef.Control.cs
+++ b/Robust.Client.WebView/Cef/WebViewManagerCef.Control.cs
@@ -7,6 +7,7 @@ using Robust.Client.UserInterface;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Maths;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 using SixLabors.ImageSharp.PixelFormats;
 using Xilium.CefGlue;
@@ -19,16 +20,18 @@ namespace Robust.Client.WebView.Cef
     {
         private readonly List<ControlImpl> _activeControls = new();
 
+        private static readonly ProtoId<ShaderPrototype> _bgraShader = "bgra";
+
         public IWebViewControlImpl MakeControlImpl(WebViewControl owner)
         {
-            var shader = _prototypeManager.Index<ShaderPrototype>("bgra");
+            var shader = _prototypeManager.Index(_bgraShader);
             var shaderInstance = shader.Instance();
             var impl =  new ControlImpl(this, owner, shaderInstance);
             _dependencyCollection.InjectDependencies(impl);
             return impl;
         }
 
-        private sealed class ControlImpl : IWebViewControlImpl
+        private sealed partial class ControlImpl : IWebViewControlImpl
         {
             private static readonly Dictionary<Key, CefKeyCodes.ChromiumKeyboardCode> KeyMap = new()
             {

--- a/Robust.Client/Console/Commands/UITestCommand.TabSpriteView.cs
+++ b/Robust.Client/Console/Commands/UITestCommand.TabSpriteView.cs
@@ -21,6 +21,8 @@ internal sealed partial class UITestControl
 
         private readonly IEntityManager _entMan;
         private readonly IGameTiming _timing;
+        private readonly SpriteSystem _sprite;
+        private readonly SharedTransformSystem _xform;
         private readonly BoxContainer _box;
 
         private record Entry(EntityUid Uid, SpriteComponent Sprite, TransformComponent Transform,
@@ -33,6 +35,8 @@ internal sealed partial class UITestControl
         public TabSpriteView()
         {
             IoCManager.Resolve(ref _entMan, ref _timing);
+            _sprite = _entMan.System<SpriteSystem>();
+            _xform = _entMan.System<SharedTransformSystem>();
             SetValue(TabContainer.TabTitleProperty, nameof(SpriteView));
             _box = new BoxContainer
             {
@@ -178,14 +182,14 @@ internal sealed partial class UITestControl
 
             entry = AddEntry("Local Rotation", (e, time) =>
             {
-                e.Transform.LocalRotation = Angle.FromDegrees(time * _degreesPerSecond);
+                _xform.SetLocalRotation(e.Uid, Angle.FromDegrees(time * _degreesPerSecond), e.Transform);
                 e.View.InvalidateMeasure();
             });
             added.Add(entry);
 
             entry = AddEntry("Local Rotation (NoRot)", (e, time) =>
             {
-                e.Transform.LocalRotation = Angle.FromDegrees(time * _degreesPerSecond);
+                _xform.SetLocalRotation(e.Uid, Angle.FromDegrees(time * _degreesPerSecond), e.Transform);
                 e.View.InvalidateMeasure();
             });
             entry.Sprite.NoRotation = true;
@@ -193,7 +197,7 @@ internal sealed partial class UITestControl
 
             entry = AddEntry("Offset", (e, time) =>
             {
-                e.Sprite.Offset = new Vector2(MathF.Sin((float) Angle.FromDegrees(time * _degreesPerSecond)), 0);
+                _sprite.SetOffset((e.Uid, e.Sprite), new Vector2(MathF.Sin((float) Angle.FromDegrees(time * _degreesPerSecond)), 0));
                 e.View.InvalidateMeasure();
             });
             added.Add(entry);
@@ -201,24 +205,24 @@ internal sealed partial class UITestControl
             entry = AddEntry("Scaled", (e, time) =>
             {
                 var theta = (float) Angle.FromDegrees(_degreesPerSecond * time).Theta;
-                e.Sprite.Scale = Vector2.One + new Vector2(0.5f * MathF.Sin(theta), 0.5f * MathF.Cos(theta));
+                _sprite.SetScale((e.Uid, e.Sprite), Vector2.One + new Vector2(0.5f * MathF.Sin(theta), 0.5f * MathF.Cos(theta)));
                 e.View.InvalidateMeasure();
             });
             added.Add(entry);
 
             entry = AddEntry("Sprite Rotation", (e, time) =>
             {
-                e.Sprite.Rotation = Angle.FromDegrees(time * _degreesPerSecond);
+                _sprite.SetRotation((e.Uid, e.Sprite), Angle.FromDegrees(time * _degreesPerSecond));
             });
             added.Add(entry);
 
             entry = AddEntry("Combination", (e, time) =>
             {
                 var theta = (float) Angle.FromDegrees(_degreesPerSecond * time * 2).Theta;
-                e.Sprite.Scale = Vector2.One + new Vector2(0.5f * MathF.Sin(theta), 0.5f * MathF.Cos(theta));
-                e.Sprite.Offset = new(MathF.Sin((float) Angle.FromDegrees(time * _degreesPerSecond)), 0);
-                e.Sprite.Rotation = Angle.FromDegrees(0.5 * time * _degreesPerSecond);
-                e.Transform.LocalRotation = Angle.FromDegrees(0.25 * time * _degreesPerSecond);
+                _sprite.SetScale((e.Uid, e.Sprite), Vector2.One + new Vector2(0.5f * MathF.Sin(theta), 0.5f * MathF.Cos(theta)));
+                _sprite.SetOffset((e.Uid, e.Sprite), new(MathF.Sin((float) Angle.FromDegrees(time * _degreesPerSecond)), 0));
+                _sprite.SetRotation((e.Uid, e.Sprite), Angle.FromDegrees(0.5 * time * _degreesPerSecond));
+                _xform.SetLocalRotationNoLerp(e.Uid, Angle.FromDegrees(0.25 * time * _degreesPerSecond), e.Transform);
                 e.View.InvalidateMeasure();
             });
             added.Add(entry);

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.cs
@@ -71,7 +71,7 @@ namespace Robust.Client.GameObjects
         private void OnInit(EntityUid uid, SpriteComponent component, ComponentInit args)
         {
             // I'm not 100% this is needed, but I CBF with this ATM. Somebody kill server sprite component please.
-            QueueUpdateInert(uid, component);
+            QueueUpdateIsInert((uid, component));
         }
 
         private void OnBiasChanged(double value)
@@ -215,7 +215,7 @@ namespace Robust.Client.GameObjects
                     sprite ??= Frame0(spriteSpec);
                     break;
                 case SpriteSpecifier.Texture texture:
-                    sprite = texture.GetTexture(_resourceCache);
+                    sprite = GetTexture(texture);
                     break;
                 default:
                     throw new NotImplementedException();

--- a/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
@@ -1,12 +1,9 @@
 using System;
 using System.Buffers;
-using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.X86;
 using System.Threading.Tasks;
-using Robust.Client.ComponentTrees;
 using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Graphics;
@@ -139,11 +136,11 @@ internal partial class Clyde
             // To help explain the remainder of this function, it should be functionally equivalent to the following
             // three lines of code, but has been expanded & simplified to speed up the calculation:
             //
-            // (data.WorldPos, data.WorldRot) = batch.Sys.GetWorldPositionRotation(data.Xform, batch.Query);
+            // (data.WorldPos, data.WorldRot) = batch.Sys.GetWorldPositionRotation(data.Xform);
             // var spriteWorldBB = data.Sprite.CalculateRotatedBoundingBox(data.WorldPos, data.WorldRot, batch.ViewRotation);
             // data.SpriteScreenBB = Viewport.GetWorldToLocalMatrix().TransformBox(spriteWorldBB);
 
-            var (pos, rot) = batch.Sys.GetRelativePositionRotation(data.Xform, batch.TreeOwner, batch.Query);
+            var (pos, rot) = batch.Sys.GetRelativePositionRotation(data.Xform, batch.TreeOwner);
             pos = new Vector2(
                 batch.TreePos.X + batch.Cos * pos.X - batch.Sin * pos.Y,
                 batch.TreePos.Y + batch.Sin * pos.X + batch.Cos * pos.Y);

--- a/Robust.Client/ViewVariables/Editors/VVPropEditorEntityCoordinates.cs
+++ b/Robust.Client/ViewVariables/Editors/VVPropEditorEntityCoordinates.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Numerics;
+using Robust.Client.GameObjects;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.GameObjects;
@@ -24,6 +25,7 @@ namespace Robust.Client.ViewVariables.Editors
             hBoxContainer.AddChild(new Label {Text = "grid: "});
 
             var entityManager = IoCManager.Resolve<IEntityManager>();
+            var xformSystem = entityManager.System<TransformSystem>();
 
             var gridId = new LineEdit
             {
@@ -31,7 +33,7 @@ namespace Robust.Client.ViewVariables.Editors
                 HorizontalExpand = true,
                 PlaceHolder = "Grid ID",
                 ToolTip = "Grid ID",
-                Text = coords.GetGridUid(entityManager)?.ToString() ?? ""
+                Text = xformSystem.GetGrid(coords)?.ToString() ?? ""
             };
 
             hBoxContainer.AddChild(gridId);

--- a/Robust.Server.IntegrationTests/GameObjects/Components/Transform_Test.cs
+++ b/Robust.Server.IntegrationTests/GameObjects/Components/Transform_Test.cs
@@ -190,7 +190,7 @@ namespace Robust.Server.IntegrationTests.GameObjects.Components
             XformSystem.SetParent(child, childTrans, parent, parentXform: parentTrans);
 
             //Act
-            parentTrans.LocalRotation = new Angle(MathHelper.Pi / 2);
+            XformSystem.SetLocalRotationNoLerp(parent, new Angle(MathHelper.Pi / 2), parentTrans);
 
             //Assert
             var result = XformSystem.GetWorldPosition(childTrans);
@@ -217,7 +217,7 @@ namespace Robust.Server.IntegrationTests.GameObjects.Components
             XformSystem.SetParent(child, childTrans, parent, parentXform: parentTrans);
 
             //Act
-            parentTrans.LocalRotation = new Angle(MathHelper.Pi / 2);
+            XformSystem.SetLocalRotationNoLerp(parent, new Angle(MathHelper.Pi / 2), parentTrans);
 
             //Assert
             var result = XformSystem.GetWorldPosition(childTrans);
@@ -255,7 +255,7 @@ namespace Robust.Server.IntegrationTests.GameObjects.Components
             XformSystem.SetParent(node4, node4Trans, node3, parentXform: node3Trans);
 
             //Act
-            node1Trans.LocalRotation = new Angle(MathHelper.Pi / 2);
+            XformSystem.SetLocalRotationNoLerp(node1, new Angle(MathHelper.Pi / 2), node1Trans);
 
             //Assert
             var result = XformSystem.GetWorldPosition(node4Trans);
@@ -337,11 +337,12 @@ namespace Robust.Server.IntegrationTests.GameObjects.Components
             // Act
             var oldWpos = XformSystem.GetWorldPosition(node3Trans);
 
+            var angle180 = new Angle(MathHelper.Pi);
             for (var i = 0; i < 100; i++)
             {
-                node1Trans.LocalRotation += new Angle(MathHelper.Pi);
-                node2Trans.LocalRotation += new Angle(MathHelper.Pi);
-                node3Trans.LocalRotation += new Angle(MathHelper.Pi);
+                XformSystem.SetLocalRotationNoLerp(node1, node1Trans.LocalRotation + angle180, node1Trans);
+                XformSystem.SetLocalRotationNoLerp(node2, node2Trans.LocalRotation + angle180, node2Trans);
+                XformSystem.SetLocalRotationNoLerp(node3, node3Trans.LocalRotation + angle180, node3Trans);
             }
 
             var newWpos = XformSystem.GetWorldPosition(node3Trans);
@@ -386,7 +387,7 @@ namespace Robust.Server.IntegrationTests.GameObjects.Components
             XformSystem.SetParent(node4, node4Trans, node3, parentXform: node3Trans);
 
             //Act
-            node1Trans.LocalRotation = new Angle(MathHelper.Pi / 6.37);
+            XformSystem.SetLocalRotation(node1, new Angle(MathHelper.Pi / 6.37), node1Trans);
             XformSystem.SetWorldPosition(node1, new Vector2(1, 1));
 
             var worldMat = XformSystem.GetWorldMatrix(node4Trans);
@@ -425,12 +426,12 @@ namespace Robust.Server.IntegrationTests.GameObjects.Components
             XformSystem.SetParent(node2, node2Trans, node1, parentXform: node1Trans);
             XformSystem.SetParent(node3, node3Trans, node2, parentXform: node2Trans);
 
-            node1Trans.LocalRotation = Angle.FromDegrees(0);
-            node2Trans.LocalRotation = Angle.FromDegrees(45);
-            node3Trans.LocalRotation = Angle.FromDegrees(45);
+            XformSystem.SetLocalRotationNoLerp(node1, Angle.Zero, node1Trans);
+            XformSystem.SetLocalRotationNoLerp(node2, Angle.FromDegrees(45), node2Trans);
+            XformSystem.SetLocalRotationNoLerp(node3, Angle.FromDegrees(45), node3Trans);
 
             // Act
-            node1Trans.LocalRotation = Angle.FromDegrees(135);
+            XformSystem.SetLocalRotationNoLerp(node1, Angle.FromDegrees(135), node1Trans);
 
             // Assert (135 + 45 + 45 = 225)
             var result = XformSystem.GetWorldRotation(node3Trans);

--- a/Robust.Shared.IntegrationTests/GameObjects/Systems/AnchoredSystemTests.cs
+++ b/Robust.Shared.IntegrationTests/GameObjects/Systems/AnchoredSystemTests.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Numerics;
 using NUnit.Framework;
 using Robust.Shared.Containers;
@@ -83,12 +82,14 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
         private sealed partial class AnchorOnInitComponent : Component;
 
         [Reflect(false)]
-        private sealed class AnchorOnInitTestSystem : EntitySystem
+        private sealed partial class AnchorOnInitTestSystem : EntitySystem
         {
+            [Dependency] private SharedTransformSystem _transform = default!;
+
             public override void Initialize()
             {
                 base.Initialize();
-                SubscribeLocalEvent<AnchorOnInitComponent, ComponentInit>((e, _, _) => Transform(e).Anchored = true);
+                SubscribeLocalEvent<AnchorOnInitComponent, ComponentInit>((e, _, _) => _transform.AnchorEntity(e));
             }
         }
 
@@ -233,7 +234,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             mapSys.SetTile(grid, tileIndices, new Tile(1));
 
             // Act
-            sim.Transform(ent1).Anchored = true;
+            xformSys.AnchorEntity(ent1);
 
             Assert.That(mapSys.GetAnchoredEntities(grid, tileIndices).First(), Is.EqualTo(ent1));
             Assert.That(mapSys.GetTileRef(grid, tileIndices).Tile, Is.Not.EqualTo(Tile.Empty));
@@ -259,12 +260,14 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             mapSys.SetTile(grid, mapSys.TileIndicesFor(grid, coordinates), new Tile(1));
 
             var ent1 = sim.SpawnEntity(null, coordinates); // this raises MoveEvent, subscribe after
-            sim.Transform(ent1).Anchored = true;
+            xformSys.AnchorEntity(ent1);
             sim.System<MoveEventTestSystem>().FailOnMove = true;
 
             // Act
+#pragma warning disable CS0618 // Checking property setters.
             sim.Transform(ent1).WorldPosition = new Vector2(99, 99);
             sim.Transform(ent1).LocalPosition = new Vector2(99, 99);
+#pragma warning restore CS0618
 
             Assert.That(xformSys.GetMapCoordinates(ent1), Is.EqualTo(coordinates));
             sim.System<MoveEventTestSystem>().FailOnMove = false;
@@ -305,7 +308,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             var ent1 = entMan.SpawnEntity(null, coords);
             var tileIndices = mapSys.TileIndicesFor(grid, sim.Transform(ent1).Coordinates);
             mapSys.SetTile(grid, tileIndices, new Tile(1));
-            sim.Transform(ent1).Anchored = true;
+            xformSys.AnchorEntity(ent1);
 
             // Act
             xformSys.SetParent(ent1, grid.Owner);
@@ -424,7 +427,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             var tileIndices = mapSys.TileIndicesFor(grid, sim.Transform(ent1).Coordinates);
             mapSys.SetTile(grid, tileIndices, new Tile(1));
             var physComp = entMan.AddComponent<PhysicsComponent>(ent1);
-            sim.Transform(ent1).Anchored = true;
+            xformSys.AnchorEntity(ent1);
 
             // Act
             xformSys.Unanchor(ent1);

--- a/Robust.Shared.IntegrationTests/GameObjects/Systems/AnchoredSystemTests.cs
+++ b/Robust.Shared.IntegrationTests/GameObjects/Systems/AnchoredSystemTests.cs
@@ -234,7 +234,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             mapSys.SetTile(grid, tileIndices, new Tile(1));
 
             // Act
-            xformSys.AnchorEntity(ent1);
+            sim.Transform(ent1).Anchored = true;
 
             Assert.That(mapSys.GetAnchoredEntities(grid, tileIndices).First(), Is.EqualTo(ent1));
             Assert.That(mapSys.GetTileRef(grid, tileIndices).Tile, Is.Not.EqualTo(Tile.Empty));
@@ -308,7 +308,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             var ent1 = entMan.SpawnEntity(null, coords);
             var tileIndices = mapSys.TileIndicesFor(grid, sim.Transform(ent1).Coordinates);
             mapSys.SetTile(grid, tileIndices, new Tile(1));
-            xformSys.AnchorEntity(ent1);
+            sim.Transform(ent1).Anchored = true;
 
             // Act
             xformSys.SetParent(ent1, grid.Owner);
@@ -427,7 +427,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             var tileIndices = mapSys.TileIndicesFor(grid, sim.Transform(ent1).Coordinates);
             mapSys.SetTile(grid, tileIndices, new Tile(1));
             var physComp = entMan.AddComponent<PhysicsComponent>(ent1);
-            xformSys.AnchorEntity(ent1);
+            sim.Transform(ent1).Anchored = true;
 
             // Act
             xformSys.Unanchor(ent1);

--- a/Robust.Shared.IntegrationTests/GameObjects/Systems/AnchoredSystemTests.cs
+++ b/Robust.Shared.IntegrationTests/GameObjects/Systems/AnchoredSystemTests.cs
@@ -260,7 +260,7 @@ namespace Robust.UnitTesting.Shared.GameObjects.Systems
             mapSys.SetTile(grid, mapSys.TileIndicesFor(grid, coordinates), new Tile(1));
 
             var ent1 = sim.SpawnEntity(null, coordinates); // this raises MoveEvent, subscribe after
-            xformSys.AnchorEntity(ent1);
+            sim.Transform(ent1).Anchored = true;
             sim.System<MoveEventTestSystem>().FailOnMove = true;
 
             // Act

--- a/Robust.Shared.IntegrationTests/GameObjects/TransformComponent_Tests.cs
+++ b/Robust.Shared.IntegrationTests/GameObjects/TransformComponent_Tests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Numerics;
 using NUnit.Framework;
 using Robust.Server.GameObjects;
@@ -32,7 +31,7 @@ namespace Robust.UnitTesting.Shared.GameObjects
 
             xform.SetParent(ent2, ent1);
 
-            xform1.LocalRotation = MathF.PI;
+            xform.SetLocalRotationNoLerp(ent1, MathF.PI, xform1);
 
             var (worldPos, worldRot, worldMatrix) = xform.GetWorldPositionRotationMatrix(xform2);
 

--- a/Robust.Shared.IntegrationTests/Map/GridRotation_Tests.cs
+++ b/Robust.Shared.IntegrationTests/Map/GridRotation_Tests.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Linq;
 using System.Numerics;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
@@ -65,6 +62,7 @@ namespace Robust.UnitTesting.Shared.Map
 
             var entMan = server.ResolveDependency<IEntityManager>();
             var mapSystem = entMan.System<SharedMapSystem>();
+            var xformSystem = entMan.System<SharedTransformSystem>();
 
             await server.WaitAssertion(() =>
             {
@@ -93,19 +91,20 @@ namespace Robust.UnitTesting.Shared.Map
                 // With all cardinal directions these should align.
                 Assert.That(aabb, Is.EqualTo(bounds));
 
-                entMan.GetComponent<TransformComponent>(gridEnt).LocalRotation = new Angle(Math.PI);
+                var gridXform = entMan.GetComponent<TransformComponent>(gridEnt);
+                xformSystem.SetLocalRotationNoLerp(gridEnt, new Angle(Math.PI), gridXform);
                 aabb = mapSystem.CalcWorldAABB(gridEnt, grid, chunk);
                 bounds = new Box2(new Vector2(-2, -10), new Vector2(0, 0));
 
                 Assert.That(aabb.EqualsApprox(bounds), $"Expected bounds of {aabb} and got {bounds}");
 
-                entMan.GetComponent<TransformComponent>(gridEnt).LocalRotation = new Angle(-Math.PI / 2);
+                xformSystem.SetLocalRotationNoLerp(gridEnt, new Angle(-Math.PI / 2), gridXform);
                 aabb = mapSystem.CalcWorldAABB(gridEnt, grid, chunk);
                 bounds = new Box2(new Vector2(0, -2), new Vector2(10, 0));
 
                 Assert.That(aabb.EqualsApprox(bounds), $"Expected bounds of {aabb} and got {bounds}");
 
-                entMan.GetComponent<TransformComponent>(gridEnt).LocalRotation = new Angle(-Math.PI / 4);
+                xformSystem.SetLocalRotationNoLerp(gridEnt, new Angle(-Math.PI / 4), gridXform);
                 aabb = mapSystem.CalcWorldAABB(gridEnt, grid, chunk);
                 bounds = new Box2(new Vector2(0, -1.4142135f), new Vector2(8.485281f, 7.071068f));
 

--- a/Robust.Shared.IntegrationTests/Prototypes/PrototypeHasCompTest.cs
+++ b/Robust.Shared.IntegrationTests/Prototypes/PrototypeHasCompTest.cs
@@ -31,6 +31,8 @@ internal sealed class PrototypeHasCompTest : OurRobustUnitTest
     const string TestEntity = "TestEntity";
     // expected to have TestCompNameComponent
     const string TestInception = "TestInception";
+    // A bogus component name.
+    const string TestFail = "TestFail";
 
     [OneTimeSetUp]
     public void Setup()
@@ -107,7 +109,7 @@ internal sealed class PrototypeHasCompTest : OurRobustUnitTest
         Assert.That(_factory.HasRegistration(name));
 
         // gibberish component should prevent it from loading
-        Assert.That(!_proto.HasIndex<EntityPrototype>("TestFail"));
+        Assert.That(!_proto.HasIndex<EntityPrototype>(TestFail));
     }
 
     const string TestPrototypes = $@"

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using JetBrains.Annotations;
 using Robust.Shared.Animations;
@@ -8,7 +7,6 @@ using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
-using Robust.Shared.Physics;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -135,8 +133,10 @@ namespace Robust.Shared.GameObjects
             get => _noLocalRotation;
             set
             {
+#pragma warning disable CS0618
                 if (value)
                     LocalRotation = Angle.Zero;
+#pragma warning restore CS0618
 
                 _noLocalRotation = value;
                 _entMan.Dirty(Owner, this);
@@ -528,7 +528,9 @@ namespace Robust.Shared.GameObjects
 
         public string GetDebugString()
         {
+#pragma warning disable CS0618 // Accessing world coords in debug function.
             return $"pos/rot/wpos/wrot: {Coordinates}/{LocalRotation}/{WorldPosition}/{WorldRotation}";
+#pragma warning restore CS0618
         }
     }
 

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -131,7 +131,7 @@ namespace Robust.Shared.GameObjects
         public bool NoLocalRotation
         {
             get => _noLocalRotation;
-            [Obsolete("Use SharedTransformSystem.SetNoLocalRotation")]
+            [Obsolete("Use SharedTransformSystem.SetNoLocalRotation() instead")]
             set
             {
                 if (value)
@@ -150,7 +150,7 @@ namespace Robust.Shared.GameObjects
         public Angle LocalRotation
         {
             get => _localRotation;
-            [Obsolete("Use SharedTransformSystem.SetLocalRotation")]
+            [Obsolete("Use SharedTransformSystem.SetLocalRotation() instead")]
             set
             {
                 if(_noLocalRotation)
@@ -178,7 +178,7 @@ namespace Robust.Shared.GameObjects
         ///     Current world rotation of the entity.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        [Obsolete("Use the system method instead")]
+        [Obsolete("Use SharedTransformSystem.Get/SetWorldRotation() instead")]
         public Angle WorldRotation
         {
             get
@@ -219,7 +219,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         ///     Matrix for transforming points from local to world space.
         /// </summary>
-        [Obsolete("Use the system method instead")]
+        [Obsolete("Use SharedTransformSystem.GetWorldMatrix() instead")]
         public Matrix3x2 WorldMatrix
         {
             get
@@ -245,7 +245,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         ///     Matrix for transforming points from world to local space.
         /// </summary>
-        [Obsolete("Use the system method instead")]
+        [Obsolete("Use SharedTransformSystem.GetInvWorldMatrix() instead")]
         public Matrix3x2 InvWorldMatrix
         {
             get
@@ -274,7 +274,7 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         [Animatable]
         [ViewVariables(VVAccess.ReadWrite)]
-        [Obsolete("Use the system method instead")]
+        [Obsolete("Use SharedTransformSystem.Get/SetWorldPosition() instead")]
         public Vector2 WorldPosition
         {
             get
@@ -315,7 +315,7 @@ namespace Robust.Shared.GameObjects
                 var valid = _parent.IsValid();
                 return new EntityCoordinates(valid ? _parent : Owner, valid ? LocalPosition : Vector2.Zero);
             }
-            [Obsolete("Use the system's setter method instead.")]
+            [Obsolete("Use SharedTransformSystem.SetCoordinates() instead")]
             set => _entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().SetCoordinates(Owner, this, value);
         }
 
@@ -324,7 +324,7 @@ namespace Robust.Shared.GameObjects
         ///     This is effectively a more complete version of <see cref="WorldPosition"/>
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        [Obsolete("Use TransformSystem.GetMapCoordinates")]
+        [Obsolete("Use SharedTransformSystem.GetMapCoordinates() instead")]
         public MapCoordinates MapPosition => new(WorldPosition, MapID);
 
         /// <summary>
@@ -336,7 +336,7 @@ namespace Robust.Shared.GameObjects
         public Vector2 LocalPosition
         {
             get => _localPosition;
-            [Obsolete("Use the system method instead")]
+            [Obsolete("Use SharedTransformSystem.SetLocalPosition() instead")]
             set
             {
                 if(Anchored)
@@ -399,7 +399,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         /// Detaches this entity from its parent.
         /// </summary>
-        [Obsolete("Use the system's method instead.")]
+        [Obsolete("Use SharedTransformSystem.AttachToGridOrMap() instead")]
         public void AttachToGridOrMap()
         {
             _entMan.EntitySysManager.GetEntitySystem<SharedTransformSystem>().AttachToGridOrMap(Owner, this);
@@ -414,7 +414,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         /// Get the WorldPosition and WorldRotation of this entity faster than each individually.
         /// </summary>
-        [Obsolete("Use the system method instead")]
+        [Obsolete("Use SharedTransformSystem.GetWorldPositionRotation() instead")]
         public (Vector2 WorldPosition, Angle WorldRotation) GetWorldPositionRotation()
         {
             // Worldmatrix needs calculating anyway for worldpos so we'll just drop it.
@@ -425,7 +425,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         /// Get the WorldPosition, WorldRotation, and WorldMatrix of this entity faster than each individually.
         /// </summary>
-        [Obsolete("Use the system method instead")]
+        [Obsolete("Use SharedTransformSystem.GetWorldPositionRotationMatrix() instead")]
         public (Vector2 WorldPosition, Angle WorldRotation, Matrix3x2 WorldMatrix) GetWorldPositionRotationMatrix(EntityQuery<TransformComponent> xforms)
         {
             var parent = _parent;
@@ -451,7 +451,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         /// Get the WorldPosition, WorldRotation, and WorldMatrix of this entity faster than each individually.
         /// </summary>
-        [Obsolete("Use the system method instead")]
+        [Obsolete("Use SharedTransformSystem.GetWorldPositionRotationMatrix() instead")]
         public (Vector2 WorldPosition, Angle WorldRotation, Matrix3x2 WorldMatrix) GetWorldPositionRotationMatrix()
         {
             var xforms = _entMan.GetEntityQuery<TransformComponent>();
@@ -461,7 +461,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         /// Get the WorldPosition, WorldRotation, and InvWorldMatrix of this entity faster than each individually.
         /// </summary>
-        [Obsolete("Use the system method instead")]
+        [Obsolete("Use SharedTransformSystem.WorldPositionRotationInvMatrix() instead")]
         public (Vector2 WorldPosition, Angle WorldRotation, Matrix3x2 InvWorldMatrix) GetWorldPositionRotationInvMatrix(EntityQuery<TransformComponent> xformQuery)
         {
             var (worldPos, worldRot, _, invWorldMatrix) = GetWorldPositionRotationMatrixWithInv(xformQuery);
@@ -471,7 +471,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         /// Get the WorldPosition, WorldRotation, WorldMatrix, and InvWorldMatrix of this entity faster than each individually.
         /// </summary>
-        [Obsolete("Use the system method instead")]
+        [Obsolete("Use SharedTransformSystem.GetWorldPositionRotationMatrixWithInv() instead")]
         public (Vector2 WorldPosition, Angle WorldRotation, Matrix3x2 WorldMatrix, Matrix3x2 InvWorldMatrix) GetWorldPositionRotationMatrixWithInv()
         {
             var xformQuery = _entMan.GetEntityQuery<TransformComponent>();
@@ -481,7 +481,7 @@ namespace Robust.Shared.GameObjects
         /// <summary>
         /// Get the WorldPosition, WorldRotation, WorldMatrix, and InvWorldMatrix of this entity faster than each individually.
         /// </summary>
-        [Obsolete("Use the system method instead")]
+        [Obsolete("Use SharedTransformSystem.GetWorldPositionRotationMatrixWithInv() instead")]
         public (Vector2 WorldPosition, Angle WorldRotation, Matrix3x2 WorldMatrix, Matrix3x2 InvWorldMatrix) GetWorldPositionRotationMatrixWithInv(EntityQuery<TransformComponent> xformQuery)
         {
             var parent = _parent;
@@ -525,7 +525,7 @@ namespace Robust.Shared.GameObjects
             _invLocalMatrix = Matrix3Helpers.CreateInverseTransform(_localPosition, _localRotation);
         }
 
-        [Obsolete("Use the system method instead")]
+        [Obsolete("Use SharedTransformSystem.GetDebugString() instead")]
         public string GetDebugString()
         {
             return $"pos/rot/wpos/wrot: {Coordinates}/{LocalRotation}/{WorldPosition}/{WorldRotation}";

--- a/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
+++ b/Robust.Shared/GameObjects/Components/Transform/TransformComponent.cs
@@ -131,12 +131,11 @@ namespace Robust.Shared.GameObjects
         public bool NoLocalRotation
         {
             get => _noLocalRotation;
+            [Obsolete("Use SharedTransformSystem.SetNoLocalRotation")]
             set
             {
-#pragma warning disable CS0618
                 if (value)
                     LocalRotation = Angle.Zero;
-#pragma warning restore CS0618
 
                 _noLocalRotation = value;
                 _entMan.Dirty(Owner, this);
@@ -526,11 +525,10 @@ namespace Robust.Shared.GameObjects
             _invLocalMatrix = Matrix3Helpers.CreateInverseTransform(_localPosition, _localRotation);
         }
 
+        [Obsolete("Use the system method instead")]
         public string GetDebugString()
         {
-#pragma warning disable CS0618 // Accessing world coords in debug function.
             return $"pos/rot/wpos/wrot: {Coordinates}/{LocalRotation}/{WorldPosition}/{WorldRotation}";
-#pragma warning restore CS0618
         }
     }
 

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -350,7 +350,9 @@ namespace Robust.Shared.GameObjects
             if (coordinates.MapId == MapId.Nullspace)
             {
                 transform._parent = EntityUid.Invalid;
+#pragma warning disable CS0618 // AnchorEntity/Unanchor only work on initialized entities
                 transform.Anchored = false;
+#pragma warning restore CS0618
                 return newEntity;
             }
 

--- a/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Robust.Shared.IoC;
 using Robust.Shared.Prototypes;
 
 namespace Robust.Shared.GameObjects;
@@ -10,6 +11,7 @@ namespace Robust.Shared.GameObjects;
 /// </summary>
 internal sealed partial class PrototypeReloadSystem : EntitySystem
 {
+    [Dependency] private MetaDataSystem _meta = default!;
     public override void Initialize()
     {
         base.Initialize();
@@ -76,6 +78,6 @@ internal sealed partial class PrototypeReloadSystem : EntitySystem
         }
 
         // Update entity metadata
-        metaData.EntityPrototype = newPrototype;
+        _meta.SetEntityPrototype(entity, newPrototype, metaData);
     }
 }

--- a/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/PrototypeReloadSystem.cs
@@ -12,6 +12,7 @@ namespace Robust.Shared.GameObjects;
 internal sealed partial class PrototypeReloadSystem : EntitySystem
 {
     [Dependency] private MetaDataSystem _meta = default!;
+
     public override void Initialize()
     {
         base.Initialize();

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -428,7 +428,7 @@ public abstract partial class SharedTransformSystem
         if (!XformQuery.Resolve(uid, ref xform))
             return;
 
-#pragma warning disable CS0618
+#pragma warning disable CS0618 // TODO: move LocalRotation/Position manipulation into TransformSystem (don't piggyback off TransformComponent)
         xform.LocalPosition = value;
 #pragma warning restore CS0618
     }
@@ -447,7 +447,7 @@ public abstract partial class SharedTransformSystem
         if (!XformQuery.Resolve(uid, ref xform))
             return;
 
-#pragma warning disable CS0618
+#pragma warning disable CS0618 // TODO: move LocalRotation/Position manipulation into TransformSystem (don't piggyback off TransformComponent)
         xform.LocalRotation = value;
 #pragma warning restore CS0618
     }

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -447,7 +447,9 @@ public abstract partial class SharedTransformSystem
         if (!XformQuery.Resolve(uid, ref xform))
             return;
 
+#pragma warning disable CS0618
         xform.LocalRotation = value;
+#pragma warning restore CS0618
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -887,7 +889,9 @@ public abstract partial class SharedTransformSystem
             }
             else
             {
+#pragma warning disable CS0618 // AnchorEntity/Unanchored can't be used from uninitialized states.
                 xform.Anchored = newState.Anchored;
+#pragma warning restore CS0618
             }
 
             if (oldAnchored != newState.Anchored && xform.Initialized)

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Coordinates.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Coordinates.cs
@@ -239,4 +239,15 @@ public abstract partial class SharedTransformSystem
 
         return mapA.InRange(mapB, range);
     }
+
+    /// <summary>
+    /// Returns a readable string with the entity's local and world position and rotation. Useful for debugging.
+    /// </summary>
+    public string GetDebugString(Entity<TransformComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp, logMissing: false))
+            return "invalid";
+
+        return $"pos/rot/wpos/wrot: {ent.Comp.Coordinates}/{ent.Comp.LocalRotation}/{GetWorldPosition(ent.Comp)}/{GetWorldRotation(ent.Comp)}";
+    }
 }

--- a/Robust.Shared/Map/TileDefinitionManager.cs
+++ b/Robust.Shared/Map/TileDefinitionManager.cs
@@ -47,6 +47,7 @@ namespace Robust.Shared.Map
             return GetVariantTile(tileDef, random);
         }
 
+        [Obsolete("Use method with IRobustRandom parameter")]
         public Tile GetVariantTile(string name, System.Random random)
         {
             var tileDef = this[name];
@@ -58,6 +59,7 @@ namespace Robust.Shared.Map
             return new Tile(tileDef.TileId, variant: random.NextByte(tileDef.Variants));
         }
 
+        [Obsolete("Use method with IRobustRandom parameter")]
         public Tile GetVariantTile(ITileDefinition tileDef, System.Random random)
         {
             return new Tile(tileDef.TileId, variant: random.NextByte(tileDef.Variants));

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Island.cs
@@ -332,7 +332,7 @@ public abstract partial class SharedPhysicsSystem
             // when contact broke so if you want to try that then GOOD LUCK.
             if (seed.Island) continue;
 
-            var seedUid = seed.Owner;
+            var seedUid = ent.Owner;
             var mapUid = xform.MapUid;
 
             // TODO: Handle this on client.
@@ -377,7 +377,7 @@ public abstract partial class SharedPhysicsSystem
                 if (body.BodyType == BodyType.Static) continue;
 
                 // As static bodies can never be awake (unlike Farseer) we'll set this after the check.
-                SetAwake(bodyUid, body, true, updateSleepTime: false);
+                SetAwake(bodyEnt, true, updateSleepTime: false);
 
                 var node = body.Contacts.First;
 
@@ -1139,7 +1139,7 @@ public abstract partial class SharedPhysicsSystem
 
             var body = island.Bodies[i];
 
-            SetAwake(body.Owner, body, false);
+            SetAwake(body, false);
         }
     }
 }

--- a/Robust.Shared/Prototypes/EntProtoId.cs
+++ b/Robust.Shared/Prototypes/EntProtoId.cs
@@ -97,7 +97,7 @@ public readonly record struct EntProtoId<T>(string Id) : IEquatable<string>, ICo
     {
         prototypes ??= IoCManager.Resolve<IPrototypeManager>();
         var proto = prototypes.Index(this);
-        if (!proto.TryGetComponent(out T? comp, compFactory))
+        if (!proto.TryComp(out T? comp, compFactory))
         {
             throw new ArgumentException($"{nameof(EntityPrototype)} {proto.ID} has no {nameof(T)}");
         }
@@ -110,6 +110,6 @@ public readonly record struct EntProtoId<T>(string Id) : IEquatable<string>, ICo
         comp = default;
         prototypes ??= IoCManager.Resolve<IPrototypeManager>();
         return prototypes.TryIndex(this, out var proto) &&
-               proto.TryGetComponent(out comp, compFactory);
+               proto.TryComp(out comp, compFactory);
     }
 }

--- a/Robust.Shared/Prototypes/PrototypeManager.ValidateFields.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.ValidateFields.cs
@@ -177,7 +177,9 @@ public partial class PrototypeManager
     private bool TryGetFieldPrototype(FieldInfo field, [NotNullWhen(true)] out Type? proto)
     {
         // Validate anything with the attribute
+#pragma warning disable CS0618 // This is supporting the attribute, not using it
         var attrib = field.GetCustomAttribute(typeof(ValidatePrototypeIdAttribute<>), false);
+#pragma warning restore CS0618
         if (attrib != null)
         {
             proto = attrib.GetType().GetGenericArguments().First();


### PR DESCRIPTION
## About the PR
This PR resolves a handful of simpler compiler warnings.  Picks up from #5663 in spirit, though slightly broader in the scope of warnings resolved, focused _only_ on resolving warnings, and with no new API calls.

Warning count on complete solution compilation went from 201 to 151 against master at the time of opening.

Wink and a nod to https://github.com/space-wizards/space-station-14/issues/33279

## Technical details

The lion's share of the warnings involved TransformSystem setters for LocalRotation.

A few instances of warnings were suppressed with pragma blocks, though I've tried to explain why in the majority.

Uses of Anchored setter in AnchoredSystemTests left as-is, wasn't particularly confident in suppressing them with a pragma.

Tests passed locally before PR.

<img width="408" height="290" alt="image" src="https://github.com/user-attachments/assets/8746611d-5bd6-4afb-88f8-6b0571a22960" />

## Breaking changes

* Obsoleted TileDefManager.GetVariantTile versions using System.Random.