### PR TITLE
Chat Message Spacing Offset

### DIFF
--- a/Robust.Client/UserInterface/Controls/OutputPanel.cs
+++ b/Robust.Client/UserInterface/Controls/OutputPanel.cs
@@ -23,6 +23,8 @@ namespace Robust.Client.UserInterface.Controls
 
         public const string StylePropertyStyleBox = "stylebox";
 
+        public float LineSpacing { get; set; }
+
         public bool ShowScrollDownButton
         {
             get => _showScrollDownButton;
@@ -42,6 +44,8 @@ namespace Robust.Client.UserInterface.Controls
         private StyleBox? _styleBoxOverride;
         private VScrollBar _scrollBar;
         private Button _scrollDownButton;
+
+
 
         public bool ScrollFollowing { get; set; } = true;
 
@@ -229,7 +233,7 @@ namespace Robust.Client.UserInterface.Controls
                     // run, and then setting RectClipContent = true to use scissor box testing to handle the controls
                     // visibility
                     entry.HideControls();
-                    entryOffset += entry.Height + lineSeparation;
+                    entryOffset += entry.Height + lineSeparation + LineSpacing;
                     continue;
                 }
 
@@ -244,7 +248,7 @@ namespace Robust.Client.UserInterface.Controls
 
                 entry.Draw(_tagManager, handle, font, contentBox, entryOffset, context, UIScale);
 
-                entryOffset += entry.Height + lineSeparation;
+                entryOffset += entry.Height + lineSeparation + LineSpacing;
             }
         }
 


### PR DESCRIPTION
## About the PR
This PR adds a public message spacing offset variable to the Output Panel.

## Technical details

The current chatbox renders using not controls but a bespoke custom drawpass with Rich Text Entries. This has an issue of pixel rounding on spacing, where at smaller font sizes, you will have issues regarding pixel spacing. A message spacing offset is added to the previous GetLineSeparation to add the float to the spacing. It's rather simple.

## Breaking changes

None.