### PR TITLE
Add minimum log level to packaging

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,7 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* Robust.Packaging console logging now has a minimum level of Debug and drops logs below the specified level.
 
 ### New features
 

--- a/Robust.Packaging/PackageLoggerConsole.cs
+++ b/Robust.Packaging/PackageLoggerConsole.cs
@@ -4,8 +4,13 @@ namespace Robust.Packaging;
 
 public sealed class PackageLoggerConsole : IPackageLogger
 {
+    public LogLevel MinimumLevel { get; init; } = LogLevel.Debug;
+
     public void Log(LogLevel level, string msg)
     {
+        if (level < MinimumLevel)
+            return;
+
         Console.Write(ConsoleLogHandler.LogLevelToString(level));
         Console.WriteLine(msg);
     }


### PR DESCRIPTION
We spam verbose for assets, now no more.