### PR TITLE
Fix command ordering

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -45,6 +45,7 @@ END TEMPLATE-->
 
 * Fix DynamicTree.Clear not removing node references.
 * Reverted validation for `UiBox2i` `ctor`s as it was causing regressions in debug UIs.
+* Fix command completions not being ordered. The list will still populate by any commands that contain the supplied arg.
 
 ### Other
 

--- a/Robust.Client/UserInterface/CustomControls/DebugConsole.xaml.Completions.cs
+++ b/Robust.Client/UserInterface/CustomControls/DebugConsole.xaml.Completions.cs
@@ -263,6 +263,7 @@ public sealed partial class DebugConsole
     {
         return completions
             .Where(c => c.Value.Contains(curTyping, StringComparison.CurrentCultureIgnoreCase))
+            .OrderByDescending(c => c.Value.StartsWith(curTyping, StringComparison.CurrentCultureIgnoreCase))
             .ToArray();
     }
 


### PR DESCRIPTION
The previous commit changed it to Contains which I think is still useful but it's frying me not having my expected command be first.