### PR TITLE
Add missing EntitySystemSubscriptionsGenerator.targets into Server.csproj

### DIFF
--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -70,6 +70,7 @@
   </ItemGroup>
 
   <Import Project="..\MSBuild\Robust.Properties.targets" />
+  <Import Project="..\MSBuild\Robust.EntitySystemSubscriptionsGenerator.targets" />
 
   <Import Project="..\MSBuild\Robust.Trimming.targets" />
 </Project>


### PR DESCRIPTION
Content's server-side SubscribeLocalEvent attributes won't work without it.

As the simplest test, as-is, all attribute uses in Content.Server are flagged as unused by the IDE.