### PR TITLE
Try to make connection failure msg useful

### DIFF
--- a/Robust.Shared/Network/NetManager.ClientConnect.cs
+++ b/Robust.Shared/Network/NetManager.ClientConnect.cs
@@ -323,7 +323,7 @@ namespace Robust.Shared.Network
                         // Connection failed, clean up and yeet an exception
                         peer.Shutdown(reason);
                         _toCleanNetPeers.Add(peer);
-                        throw new Exception($"Connection failed: {reason}");
+                        throw new ConnectionFailedException(reason);
                     }
 
                     return new ConnectionAttempt(peerData, connection, this);
@@ -377,11 +377,30 @@ namespace Robust.Shared.Network
             catch (AggregateException ae)
             {
                 // ParallelTask throws AggregateException with all connection failures
-                // We just take the first one
-                var message = ae.InnerExceptions.First().Message;
+                // We'll try to take the most useful one.
+                var message = SelectConnectionFailureMessage(ae);
                 OnConnectFailed(message);
                 return null;
             }
+        }
+
+        private static string SelectConnectionFailureMessage(AggregateException aggregateException)
+        {
+            var connectionFailures = aggregateException.InnerExceptions
+                .OfType<ConnectionFailedException>()
+                .ToArray();
+
+            if (connectionFailures.Length == 0)
+                return aggregateException.InnerExceptions.First().Message;
+
+            return connectionFailures.FirstOrDefault(e => !e.IsNoResponseFromRemoteHost)?.Message
+                   ?? connectionFailures[0].Message;
+        }
+
+        private sealed class ConnectionFailedException(string reason) : Exception($"Connection failed: {reason}")
+        {
+            public bool IsNoResponseFromRemoteHost { get; } =
+                reason.Contains("no response from remote host", StringComparison.OrdinalIgnoreCase);
         }
 
         private Task<string> AwaitStatusChange(NetConnection connection, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Right now we just get an aggregateexception of IPV4 + IPV6 and roll the dice on which exception to use. The issue is if we get a generic "no response from remote host" because no IPV6 (or something else occurring) for example it can bulldoze an actually useful exception log. I would wager 90% of the time this is why connection messages aren't being useful because IPV6 is failing fast and being picked for the first exception but I could also be wrong.

Falls back to old behavior if it's an unknown reason.