### PR TITLE
Avoid NetMessage copies for MsgState

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Added a NetMessage.EstimateBufferSize() to provide an estimate of the initialCapacity required for NetMessages. This will make NetMessage take an existing adequately sized pooled buffer for your message. This is opt-in and will default to the old 4-byte size if not specified.
 
 ### Bugfixes
 

--- a/Robust.Shared/Network/Messages/MsgState.cs
+++ b/Robust.Shared/Network/Messages/MsgState.cs
@@ -21,6 +21,7 @@ namespace Robust.Shared.Network.Messages
         // TODO PVS make this a cvar
         // TODO PVS figure out optimal value
         public const int CompressionThreshold = 256;
+        private const int CompressedSizeEstimateDivisor = 4;
 
         public override MsgGroups MsgGroup => MsgGroups.Entity;
 
@@ -32,6 +33,38 @@ namespace Robust.Shared.Network.Messages
         internal bool HasWritten;
 
         internal bool ForceSendReliably;
+
+        public override int EstimateBufferSize()
+        {
+            var uncompressedLength = (int) StateStream.Length;
+            // We have no idea what the compressed size will be but we'll try and guess slightly over
+            // mostly want to avoid a small initial size and then immediately copying.
+            var payloadLength = uncompressedLength > CompressionThreshold
+                ? Math.Max(CompressionThreshold, uncompressedLength / CompressedSizeEstimateDivisor)
+                : uncompressedLength;
+            var compressedLength = uncompressedLength > CompressionThreshold ? payloadLength : 0;
+
+            // Message ID + two variable-length size prefixes + payload.
+            return 1
+                + VariableInt32Size(uncompressedLength)
+                + VariableInt32Size(compressedLength)
+                + payloadLength;
+        }
+
+        private static int VariableInt32Size(int value)
+        {
+            // Look at NetSerializer if you want to understand the zigzag.
+            var zigzag = (uint) ((value << 1) ^ (value >> 31));
+            var size = 1;
+
+            while (zigzag >= 0x80)
+            {
+                zigzag >>= 7;
+                size++;
+            }
+
+            return size;
+        }
 
         public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {

--- a/Robust.Shared/Network/NetEncryption.cs
+++ b/Robust.Shared/Network/NetEncryption.cs
@@ -9,6 +9,8 @@ namespace Robust.Shared.Network;
 
 internal sealed class NetEncryption
 {
+    public const int EncryptionOverhead = sizeof(ulong) + CryptoAeadXChaCha20Poly1305Ietf.AddBytes;
+
     // Use a counter for nonces. The counter is 64-bit, I will be impressed if you ever manage to run it out.
     // 64-bit counter (incl over the wire) is fine, don't need the whole 192-bit.
     // Server starts at 0, client starts at 1, increment by two.
@@ -31,7 +33,7 @@ internal sealed class NetEncryption
         var nonce = Interlocked.Add(ref _nonce, 2);
 
         var lengthBytes = message.LengthBytes;
-        var encryptedSize = CryptoAeadXChaCha20Poly1305Ietf.AddBytes + lengthBytes + sizeof(ulong);
+        var encryptedSize = lengthBytes + EncryptionOverhead;
 
         var data = message.Data.AsSpan(0, lengthBytes);
 

--- a/Robust.Shared/Network/NetManager.Send.cs
+++ b/Robust.Shared/Network/NetManager.Send.cs
@@ -62,7 +62,7 @@ public sealed partial class NetManager
             return;
         }
 
-        var packet = BuildMessage(message, channel.Connection.Peer);
+        var packet = BuildMessage(message, channel);
         var method = message.DeliveryMethod;
         var seqChannel = message.SequenceChannel;
 

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -1194,9 +1194,14 @@ namespace Robust.Shared.Network
             return new T();
         }
 
-        private NetOutgoingMessage BuildMessage(NetMessage message, NetPeer peer)
+        private NetOutgoingMessage BuildMessage(NetMessage message, NetChannel channel)
         {
-            var packet = peer.CreateMessage(4);
+            var initialCapacity = message.EstimateBufferSize();
+
+            if (channel.Encryption != null)
+                initialCapacity += NetEncryption.EncryptionOverhead;
+
+            var packet = channel.Connection.Peer.CreateMessage(initialCapacity);
 
             if (!_strings.TryFindStringId(message.MsgName, out int msgId))
                 throw new NetManagerException(

--- a/Robust.Shared/Network/NetMessage.cs
+++ b/Robust.Shared/Network/NetMessage.cs
@@ -86,6 +86,12 @@ namespace Robust.Shared.Network
         /// <param name="serializer"></param>
         public abstract void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer);
 
+        /// <summary>
+        /// Estimated size of the serialized payload, excluding transport encryption overhead.
+        /// Used to size Lidgren's outgoing buffer before <see cref="WriteToBuffer"/>.
+        /// </summary>
+        public virtual int EstimateBufferSize() => 4;
+
         public virtual NetDeliveryMethod DeliveryMethod
         {
             get


### PR DESCRIPTION
We have some rough idea of the final size so we'll set the NetMessage size a bit above that so we can actually use Lidgren's storage pool for these. The other NetMessages should be doing this but this is the big one so.

Currently it gets set to 4, but NetMessage uses Array.Resize if the size is inadequate, so the only way it avoids allocations is hoping it gets an already large buffer from GetStorage in Lidgren.

Hopefully with this PR it means less bloated entries into the storage pool from GameState.