### PR TITLE
Pool PVS entity state collections

### DIFF
--- a/Robust.Server/GameStates/PvsSystem.GetStates.cs
+++ b/Robust.Server/GameStates/PvsSystem.GetStates.cs
@@ -22,10 +22,10 @@ internal sealed partial class PvsSystem
     /// <returns>New entity State for the given entity.</returns>
     private EntityState GetEntityState(ICommonSession? player, EntityUid entityUid, GameTick fromTick, MetaDataComponent meta)
     {
-        var changed = new List<ComponentChange>();
+        var changed = GetComponentChangeList(meta.NetComponents.Count);
 
         bool sendCompList = meta.LastComponentRemoved > fromTick;
-        HashSet<ushort>? netComps = sendCompList ? new() : null;
+        HashSet<ushort>? netComps = sendCompList ? GetNetComponentSet() : null;
         var stateEv = new ComponentGetState(player, fromTick);
 
         foreach (var (netId, component) in meta.NetComponents)
@@ -83,10 +83,10 @@ internal sealed partial class PvsSystem
     private EntityState GetFullEntityState(ICommonSession player, EntityUid entityUid, MetaDataComponent meta)
     {
         var bus = EntityManager.EventBusInternal;
-        var changed = new List<ComponentChange>();
+        var changed = GetComponentChangeList(meta.NetComponents.Count);
         var stateEv = new ComponentGetState(player, GameTick.Zero);
 
-        HashSet<ushort> netComps = new();
+        HashSet<ushort> netComps = GetNetComponentSet();
 
         foreach (var (netId, component) in meta.NetComponents)
         {
@@ -197,6 +197,7 @@ Entity: {ToPrettyString(uid)}
 Last modified: {md.EntityLastModifiedTick}
 Metadata last modified: {md.LastModifiedTick}
 Transform last modified: {Transform(uid).LastModifiedTick}");
+                        ReturnEntityState(state);
                         continue;
                     }
 
@@ -217,6 +218,8 @@ Transform last modified: {Transform(uid).LastModifiedTick}");
                     var state = GetEntityState(session, uid, fromTick, md);
                     if (!state.Empty)
                         pvsSession.States.Add(state);
+                    else
+                        ReturnEntityState(state);
                 }
             }
         }

--- a/Robust.Server/GameStates/PvsSystem.Pooling.cs
+++ b/Robust.Server/GameStates/PvsSystem.Pooling.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.ObjectPool;
 using Robust.Shared.GameObjects;
+using Robust.Shared.GameStates;
 using Robust.Shared.Utility;
 using SharpZstd.Interop;
 
@@ -19,8 +20,14 @@ internal sealed partial class PvsSystem
     private readonly ObjectPool<List<PvsIndex>> _entDataListPool
         = new DefaultObjectPool<List<PvsIndex>>(new ListPolicy<PvsIndex>(), MaxVisPoolSize);
 
+    private readonly ObjectPool<List<ComponentChange>> _componentChangeListPool
+        = new DefaultObjectPool<List<ComponentChange>>(new ListPolicy<ComponentChange>(), MaxVisPoolSize);
+
     private readonly ObjectPool<HashSet<EntityUid>> _uidSetPool
         = new DefaultObjectPool<HashSet<EntityUid>>(new SetPolicy<EntityUid>(), MaxVisPoolSize);
+
+    private readonly ObjectPool<HashSet<ushort>> _netComponentSetPool
+        = new DefaultObjectPool<HashSet<ushort>>(new SetPolicy<ushort>(), MaxVisPoolSize);
 
     private readonly ObjectPool<PvsChunk> _chunkPool =
         new DefaultObjectPool<PvsChunk>(new PvsChunkPolicy(), 256);
@@ -62,5 +69,39 @@ internal sealed partial class PvsSystem
         {
             CompressionContext.Dispose();
         }
+    }
+
+    private List<ComponentChange> GetComponentChangeList(int capacity)
+    {
+        var list = _componentChangeListPool.Get();
+        list.EnsureCapacity(capacity);
+        return list;
+    }
+
+    private HashSet<ushort> GetNetComponentSet()
+    {
+        return _netComponentSetPool.Get();
+    }
+
+    private void ReturnEntityState(EntityState state)
+    {
+        if (state.ComponentChanges.Value is List<ComponentChange> changes)
+            _componentChangeListPool.Return(changes);
+
+        if (state.NetComponents is { } netComps)
+        {
+            _netComponentSetPool.Return(netComps);
+            state.NetComponents = null;
+        }
+    }
+
+    internal void ClearSessionState(PvsSession session)
+    {
+        foreach (var state in session.States)
+        {
+            ReturnEntityState(state);
+        }
+
+        session.ClearState();
     }
 }

--- a/Robust.Server/GameStates/PvsSystem.Serialize.cs
+++ b/Robust.Server/GameStates/PvsSystem.Serialize.cs
@@ -71,6 +71,6 @@ internal sealed partial class PvsSystem
             _serializer.SerializeDirect(data.StateStream, data.State);
         }
 
-        data.ClearState();
+        ClearSessionState(data);
     }
 }

--- a/Robust.Server/GameStates/PvsSystem.ToSendSet.cs
+++ b/Robust.Server/GameStates/PvsSystem.ToSendSet.cs
@@ -112,6 +112,8 @@ internal sealed partial class PvsSystem
 
         if (!entState.Empty)
             session.States.Add(entState);
+        else
+            ReturnEntityState(entState);
     }
 
     /// <summary>
@@ -189,6 +191,8 @@ internal sealed partial class PvsSystem
 
         if (!entState.Empty)
             session.States.Add(entState);
+        else
+            ReturnEntityState(entState);
 
         return true;
     }

--- a/Robust.Server/Replays/ReplayRecordingManager.cs
+++ b/Robust.Server/Replays/ReplayRecordingManager.cs
@@ -47,7 +47,7 @@ internal sealed partial class ReplayRecordingManager : SharedReplayRecordingMana
 
         _pvs.ComputeSessionState(_pvsSession);
         Update(_pvsSession.State);
-        _pvsSession.ClearState();
+        _pvs.ClearSessionState(_pvsSession);
         _pvsSession.LastReceivedAck = Timing.CurTick;
     }
 
@@ -55,6 +55,6 @@ internal sealed partial class ReplayRecordingManager : SharedReplayRecordingMana
     {
         base.Reset();
         _pvsSession.LastReceivedAck = GameTick.Zero;
-        _pvsSession.ClearState();
+        _pvs.ClearSessionState(_pvsSession);
     }
 }


### PR DESCRIPTION
This is no.1 performance sink on the server and nothing else remotely comes close.

If we had shared compstates we would have a fraction of this allocation churn but that's much riskier. This is still useful even in that case but we wouldn't see anywhere near the benefits it can provide ATM.

RMC profile
<img width="1228" height="439" alt="image" src="https://github.com/user-attachments/assets/b0190ade-cb1b-40ab-a48f-7a6f0fcfa7f8" />

No I haven't profiled this directly as my PC would probably explode doing a serious PVS test but I can attempt to benchmark if required.