### PR TITLE
Make TableContainer virtual and public

### DIFF
--- a/Robust.Client/UserInterface/Controls/TableContainer.cs
+++ b/Robust.Client/UserInterface/Controls/TableContainer.cs
@@ -4,7 +4,8 @@ using Robust.Shared.Maths;
 
 namespace Robust.Client.UserInterface.Controls;
 
-internal sealed class TableContainer : Container
+[Virtual]
+public class TableContainer : Container
 {
     private int _columns = 1;
 


### PR DESCRIPTION
Turning TableContainer into a public, virtual class to expose it content-side.

SS14 content-side PR: https://github.com/space-wizards/space-station-14/pull/44548

Part of https://github.com/space-wizards/space-station-14/issues/44537 resolution.