### PR TITLE
File Dialog: Expose file name of the selected file

### DIFF
--- a/Robust.Client/UserInterface/FileDialogManager.cs
+++ b/Robust.Client/UserInterface/FileDialogManager.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Robust.Client.Graphics;
 using Robust.Shared.Console;
 using Robust.Shared.IoC;
-using Robust.Shared.Utility;
 
 namespace Robust.Client.UserInterface;
 
@@ -31,7 +30,7 @@ internal sealed class FileDialogManager(IClydeInternal clyde) : IFileDialogManag
         return null;
     }
 
-    public async Task<(Stream?, ResPath?)> GetFileAndName(
+    public async Task<(Stream?, string?)> GetFileAndName(
         FileDialogFilters? filters = null,
         FileAccess access = FileAccess.ReadWrite,
         FileShare? share = null)
@@ -40,12 +39,11 @@ internal sealed class FileDialogManager(IClydeInternal clyde) : IFileDialogManag
 
         if (name == null) return (null, null);
 
-        var path = new ResPath(name);
-        var resPath = path.GetFilename();
-        return (File.Open(name, FileMode.Open, access, Validate(access, share)), resPath);
+        var path = Path.GetFileName(name);
+        return (File.Open(name, FileMode.Open, access, Validate(access, share)), path);
     }
 
-    public async Task<ResPath?> GetName(
+    public async Task<string?> GetName(
         FileDialogFilters? filters = null,
         FileAccess access = FileAccess.ReadWrite,
         FileShare? share = null)
@@ -53,7 +51,7 @@ internal sealed class FileDialogManager(IClydeInternal clyde) : IFileDialogManag
         Validate(access, share);
         var name = await Prompt(false, filters);
 
-        return name == null ? null : new ResPath(name).GetFilename();
+        return name == null ? null : Path.GetFileName(name);
     }
 
     public async Task<Stream?> OpenFile(

--- a/Robust.Client/UserInterface/FileDialogManager.cs
+++ b/Robust.Client/UserInterface/FileDialogManager.cs
@@ -25,15 +25,8 @@ internal sealed class FileDialogManager(IClydeInternal clyde) : IFileDialogManag
 
     private async Task<string?> Prompt(bool isSave, FileDialogFilters? filters)
     {
-        try
-        {
-            if (clyde.FileDialogImpl is { } impl)
-                return isSave ? await impl.SaveFile(filters) : await impl.OpenFile(filters);
-        }
-        catch
-        {
-            return null;
-        }
+        if (clyde.FileDialogImpl is { } impl)
+            return isSave ? await impl.SaveFile(filters) : await impl.OpenFile(filters);
 
         return null;
     }

--- a/Robust.Client/UserInterface/FileDialogManager.cs
+++ b/Robust.Client/UserInterface/FileDialogManager.cs
@@ -4,33 +4,74 @@ using System.Threading.Tasks;
 using Robust.Client.Graphics;
 using Robust.Shared.Console;
 using Robust.Shared.IoC;
+using Robust.Shared.Utility;
 
 namespace Robust.Client.UserInterface;
 
 internal sealed class FileDialogManager(IClydeInternal clyde) : IFileDialogManager
 {
-    public async Task<Stream?> OpenFile(
-        FileDialogFilters? filters = null,
-        FileAccess access = FileAccess.ReadWrite,
-        FileShare? share = null)
+    private static FileShare Validate(FileAccess access, FileShare? share)
     {
         if ((access & FileAccess.ReadWrite) != access)
             throw new ArgumentException("Invalid file access specified");
 
         var realShare = share ?? (access == FileAccess.Read ? FileShare.Read : FileShare.None);
+
         if ((realShare & (FileShare.ReadWrite | FileShare.Delete)) != realShare)
             throw new ArgumentException("Invalid file share specified");
 
-        string? name;
-        if (clyde.FileDialogImpl is { } clydeImpl)
-            name = await clydeImpl.OpenFile(filters);
-        else
-            return null;
+        return realShare;
+    }
 
-        if (name == null)
+    private async Task<string?> Prompt(bool isSave, FileDialogFilters? filters)
+    {
+        try
+        {
+            if (clyde.FileDialogImpl is { } impl)
+                return isSave ? await impl.SaveFile(filters) : await impl.OpenFile(filters);
+        }
+        catch
+        {
             return null;
+        }
 
-        return File.Open(name, FileMode.Open, access, realShare);
+        return null;
+    }
+
+    public async Task<(Stream?, ResPath?)> GetFileAndName(
+        FileDialogFilters? filters = null,
+        FileAccess access = FileAccess.ReadWrite,
+        FileShare? share = null)
+    {
+        var name = await Prompt(false, filters);
+
+        if (name == null) return (null, null);
+
+        var path = new ResPath(name);
+        var resPath = path.GetFilename();
+        return (File.Open(name, FileMode.Open, access, Validate(access, share)), resPath);
+    }
+
+    public async Task<ResPath?> GetName(
+        FileDialogFilters? filters = null,
+        FileAccess access = FileAccess.ReadWrite,
+        FileShare? share = null)
+    {
+        Validate(access, share);
+        var name = await Prompt(false, filters);
+
+        return name == null ? null : new ResPath(name).GetFilename();
+    }
+
+    public async Task<Stream?> OpenFile(
+        FileDialogFilters? filters = null,
+        FileAccess access = FileAccess.ReadWrite,
+        FileShare? share = null)
+    {
+        var realShare = Validate(access, share);
+        var name = await Prompt(false, filters);
+
+        return name == null ? null : File.Open(name, FileMode.Open, access, realShare);
     }
 
     public async Task<(Stream, bool)?> SaveFile(
@@ -39,20 +80,10 @@ internal sealed class FileDialogManager(IClydeInternal clyde) : IFileDialogManag
         FileAccess access = FileAccess.ReadWrite,
         FileShare share = FileShare.None)
     {
-        if ((access & FileAccess.ReadWrite) != access)
-            throw new ArgumentException("Invalid file access specified");
+        Validate(access, share);
+        var name = await Prompt(true, filters);
 
-        if ((share & (FileShare.ReadWrite | FileShare.Delete)) != share)
-            throw new ArgumentException("Invalid file share specified");
-
-        string? name;
-        if (clyde.FileDialogImpl is { } clydeImpl)
-            name = await clydeImpl.SaveFile(filters);
-        else
-            return null;
-
-        if (name == null)
-            return null;
+        if (name == null) return null;
 
         try
         {

--- a/Robust.Client/UserInterface/IFileDialogManager.cs
+++ b/Robust.Client/UserInterface/IFileDialogManager.cs
@@ -1,61 +1,86 @@
 using System.IO;
 using System.Threading.Tasks;
 using Robust.Client.Graphics;
+using Robust.Shared.Utility;
 
-namespace Robust.Client.UserInterface
+namespace Robust.Client.UserInterface;
+
+/// <summary>
+///     Manager for opening of file dialogs.
+/// </summary>
+/// <remarks>
+///     File dialogs are native to the OS being ran on.
+///     All operations are asynchronous to prevent locking up the main thread while the user makes his pick.
+/// </remarks>
+[NotContentImplementable]
+public interface IFileDialogManager
 {
     /// <summary>
-    ///     Manager for opening of file dialogs.
+    /// Open a file dialog used for opening a single file and getting its filename.
     /// </summary>
-    /// <remarks>
-    ///     File dialogs are native to the OS being ran on.
-    ///     All operations are asynchronous to prevent locking up the main thread while the user makes his pick.
-    /// </remarks>
-    [NotContentImplementable]
-    public interface IFileDialogManager
-    {
-        /// <summary>
-        ///     Open a file dialog used for opening a single file.
-        /// </summary>
-        /// <returns>
-        /// The file stream for the file the user opened.
-        /// <see langword="null" /> if the user cancelled the action.
-        /// </returns>
-        /// <param name="filters">Filters for file types that the user can select.</param>
-        /// <param name="access">What access is desired from the file operation.</param>
-        /// <param name="share">
-        /// What sharing mode is desired from the file operation.
-        /// If null is provided and <paramref name="access"/> is <see cref="FileAccess.Read"/>,
-        /// <see cref="FileShare.Read"/> is selected, otherwise <see cref="FileShare.None"/>.
-        /// </param>
-        Task<Stream?> OpenFile(
-            FileDialogFilters? filters = null,
-            FileAccess access = FileAccess.ReadWrite,
-            FileShare? share = null);
-
-        /// <summary>
-        ///     Open a file dialog used for saving a single file.
-        /// </summary>
-        /// <returns>
-        /// The file stream the user chose to save to, and whether the file already existed.
-        /// Null if the user cancelled the action.
-        /// </returns>
-        /// <param name="truncate">Should we truncate an existing file to 0-size then write or append.</param>
-        /// <param name="access">What access is desired from the file operation.</param>
-        /// <param name="share">Sharing mode for the opened file.</param>
-        Task<(Stream fileStream, bool alreadyExisted)?> SaveFile(
-            FileDialogFilters? filters = null,
-            bool truncate = true,
-            FileAccess access = FileAccess.ReadWrite,
-            FileShare share = FileShare.None);
-    }
+    /// <returns>
+    /// The file stream and name for the file the user opened.
+    /// <see langword="null" /> if the user canceled the action.
+    /// </returns>
+    /// <param name="filters">Filters for file types that the user can select.</param>
+    /// <param name="access">What access is desired from the file operation.</param>
+    /// <param name="share">
+    /// What sharing mode is desired from the file operation.
+    /// If null is provided and <paramref name="access"/> is <see cref="FileAccess.Read"/>,
+    /// <see cref="FileShare.Read"/> is selected, otherwise <see cref="FileShare.None"/>.
+    /// </param>
+    Task<(Stream?, ResPath?)> GetFileAndName(
+        FileDialogFilters? filters = null,
+        FileAccess access = FileAccess.ReadWrite,
+        FileShare? share = null);
 
     /// <summary>
-    /// Internal implementation interface used to connect <see cref="FileDialogManager"/> and <see cref="IClydeInternal"/>.
+    /// Open a file dialog used for getting the file name of the selected file.
     /// </summary>
-    internal interface IFileDialogManagerImplementation
-    {
-        Task<string?> OpenFile(FileDialogFilters? filters);
-        Task<string?> SaveFile(FileDialogFilters? filters);
-    }
+    /// <returns>
+    /// The file name for the file the user opened.
+    /// <see langword="null" /> if the user canceled the action.
+    /// </returns>
+    /// <inheritdoc cref = "GetFileAndName"/>
+    Task<ResPath?> GetName(
+        FileDialogFilters? filters = null,
+        FileAccess access = FileAccess.ReadWrite,
+        FileShare? share = null);
+
+    /// <summary>
+    /// Open a file dialog used for opening the selected file.
+    /// </summary>
+    /// <returns>
+    /// The file stream for the file the user opened.
+    /// <see langword="null" /> if the user cancelled the action.
+    /// </returns>
+    /// <inheritdoc cref = "GetFileAndName"/>
+    Task<Stream?> OpenFile(
+        FileDialogFilters? filters = null,
+        FileAccess access = FileAccess.ReadWrite,
+        FileShare? share = null);
+
+    /// <summary>
+    ///  Open a file dialog used for saving a single file.
+    /// </summary>
+    /// <returns>
+    /// The file stream the user chose to save to, and whether the file already existed.
+    /// Null if the user canceled the action.
+    /// </returns>
+    /// <param name="truncate">Should we truncate an existing file to 0-size then write or append.</param>
+    /// <inheritdoc cref = "GetFileAndName"/>
+    Task<(Stream fileStream, bool alreadyExisted)?> SaveFile(
+        FileDialogFilters? filters = null,
+        bool truncate = true,
+        FileAccess access = FileAccess.ReadWrite,
+        FileShare share = FileShare.None);
+}
+
+/// <summary>
+/// Internal implementation interface used to connect <see cref="FileDialogManager"/> and <see cref="IClydeInternal"/>.
+/// </summary>
+internal interface IFileDialogManagerImplementation
+{
+    Task<string?> OpenFile(FileDialogFilters? filters);
+    Task<string?> SaveFile(FileDialogFilters? filters);
 }

--- a/Robust.Client/UserInterface/IFileDialogManager.cs
+++ b/Robust.Client/UserInterface/IFileDialogManager.cs
@@ -1,7 +1,6 @@
 using System.IO;
 using System.Threading.Tasks;
 using Robust.Client.Graphics;
-using Robust.Shared.Utility;
 
 namespace Robust.Client.UserInterface;
 
@@ -29,7 +28,7 @@ public interface IFileDialogManager
     /// If null is provided and <paramref name="access"/> is <see cref="FileAccess.Read"/>,
     /// <see cref="FileShare.Read"/> is selected, otherwise <see cref="FileShare.None"/>.
     /// </param>
-    Task<(Stream?, ResPath?)> GetFileAndName(
+    Task<(Stream?, string?)> GetFileAndName(
         FileDialogFilters? filters = null,
         FileAccess access = FileAccess.ReadWrite,
         FileShare? share = null);
@@ -42,7 +41,7 @@ public interface IFileDialogManager
     /// <see langword="null" /> if the user canceled the action.
     /// </returns>
     /// <inheritdoc cref = "GetFileAndName"/>
-    Task<ResPath?> GetName(
+    Task<string?> GetName(
         FileDialogFilters? filters = null,
         FileAccess access = FileAccess.ReadWrite,
         FileShare? share = null);

--- a/Robust.Shared/Utility/ResPath.cs
+++ b/Robust.Shared/Utility/ResPath.cs
@@ -603,12 +603,6 @@ public static class ResPathUtil
     }
 
     /// <summary>
-    /// Return a ResPath that only contains the filename.
-    /// Useful if you want a string that's already divided in filename/extension format.
-    /// </summary>
-    public static ResPath GetFilename(this ResPath path) => new (path.Filename);
-
-    /// <summary>
     /// Gets the segments in common with 2 paths.
     /// </summary>
     public static ResPath GetCommonSegments(this ResPath path, ResPath other)

--- a/Robust.Shared/Utility/ResPath.cs
+++ b/Robust.Shared/Utility/ResPath.cs
@@ -603,6 +603,12 @@ public static class ResPathUtil
     }
 
     /// <summary>
+    /// Return a ResPath that only contains the filename.
+    /// Useful if you want a string that's already divided in filename/extension format.
+    /// </summary>
+    public static ResPath GetFilename(this ResPath path) => new (path.Filename);
+
+    /// <summary>
     /// Gets the segments in common with 2 paths.
     /// </summary>
     public static ResPath GetCommonSegments(this ResPath path, ResPath other)


### PR DESCRIPTION
Cleans up FileDialog and adds functions to get the name of the file from the dialog. 
Previously we only exposed the file stream so content had no way of knowing the name of the file, now we also expose a sanitized filename

No breaking changes