### PR TITLE
Multi-window: Steam Overlay Memory Leak

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
@@ -332,6 +332,7 @@ namespace Robust.Client.Graphics.Clyde
             if (parameters.Owner != null)
                 owner = ((WindowHandle)parameters.Owner).Reg;
 
+            parameters.Main = isMain;
             var (reg, error) = _windowing!.WindowCreate(glSpec, parameters, share, owner);
 
             if (reg != null)

--- a/Robust.Client/Graphics/Clyde/GLContext/GLContextWindow.cs
+++ b/Robust.Client/Graphics/Clyde/GLContext/GLContextWindow.cs
@@ -219,7 +219,8 @@ namespace Robust.Client.Graphics.Clyde
                 {
                     window.BlitDoneEvent?.Set();
                 }
-                Clyde._windowing!.WindowSwapBuffers(window.Reg);
+                // Single buffered secondary windows, Steam overlay triggers memory leak with secondary double buffers
+                GL.Finish();
                 if (!window.UnlockBeforeSwap)
                 {
                     window.BlitDoneEvent?.Set();

--- a/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Window.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Window.cs
@@ -177,6 +177,11 @@ internal partial class Clyde
                 SDL.SDL_GL_SetAttribute(
                     GLAttr.SDL_GL_FRAMEBUFFER_SRGB_CAPABLE,
                     s.Profile == GLContextProfile.Es ? 0 : 1);
+
+                // Steam overlay causes memory leak with multiple double buffered windows
+                if (!parameters.Main)
+                    SDL.SDL_GL_SetAttribute(GLAttr.SDL_GL_DOUBLEBUFFER, 0);
+
                 int ctxFlags = 0;
 #if DEBUG
                 ctxFlags |= SDL.SDL_GL_CONTEXT_DEBUG_FLAG;

--- a/Robust.Client/Graphics/WindowCreateParameters.cs
+++ b/Robust.Client/Graphics/WindowCreateParameters.cs
@@ -11,6 +11,7 @@ namespace Robust.Client.Graphics
         public bool Visible = true;
         public IClydeMonitor? Monitor;
         public bool Fullscreen;
+        public bool Main;
 
         /// <summary>
         /// The window that will "own" this window.


### PR DESCRIPTION
Steam does not behave well when multiple double buffered windows exist from one parent process, this PR fixes the memory leak by disabling double buffering on all secondary windows.

Known Issues:
- If you `shift+tab` to open the overlay while having a pop-up focused the overlay will draw to the main window (at the wrong size) but leave the inputs (close interaction, buttons, etc) on the pop-up