### PR TITLE
Cache GetAllChildren

### DIFF
--- a/Robust.Shared/Reflection/ReflectionManager.cs
+++ b/Robust.Shared/Reflection/ReflectionManager.cs
@@ -46,6 +46,8 @@ namespace Robust.Shared.Reflection
         private readonly Dictionary<(Type BaseType, bool Inclusive), Type[]> _getAllChildrenCache = new();
         private ISawmill _sawmill = default!;
 
+        private readonly List<Type> _childrenCache = new();
+
         public void Initialize()
         {
             _sawmill = _logMan.GetSawmill("Reflection");
@@ -66,7 +68,8 @@ namespace Robust.Shared.Reflection
             if (_getAllChildrenCache.TryGetValue(key, out var cached))
                 return cached;
 
-            var children = new List<Type>();
+            _childrenCache.Clear();
+
             foreach (var type in _getAllTypesCache)
             {
                 if (!baseType.IsAssignableFrom(type) || type.IsAbstract)
@@ -75,10 +78,10 @@ namespace Robust.Shared.Reflection
                 if (baseType == type && !inclusive)
                     continue;
 
-                children.Add(type);
+                _childrenCache.Add(type);
             }
 
-            cached = children.ToArray();
+            cached = _childrenCache.ToArray();
             _getAllChildrenCache.Add(key, cached);
             return cached;
         }

--- a/Robust.Shared/Reflection/ReflectionManager.cs
+++ b/Robust.Shared/Reflection/ReflectionManager.cs
@@ -43,6 +43,7 @@ namespace Robust.Shared.Reflection
         private readonly ReaderWriterLockSlim _yamlTypeTagCacheLock = new();
 
         private readonly List<Type> _getAllTypesCache = new();
+        private readonly Dictionary<(Type BaseType, bool Inclusive), Type[]> _getAllChildrenCache = new();
         private ISawmill _sawmill = default!;
 
         public void Initialize()
@@ -61,6 +62,11 @@ namespace Robust.Shared.Reflection
         {
             EnsureGetAllTypesCache();
 
+            var key = (baseType, inclusive);
+            if (_getAllChildrenCache.TryGetValue(key, out var cached))
+                return cached;
+
+            var children = new List<Type>();
             foreach (var type in _getAllTypesCache)
             {
                 if (!baseType.IsAssignableFrom(type) || type.IsAbstract)
@@ -69,8 +75,12 @@ namespace Robust.Shared.Reflection
                 if (baseType == type && !inclusive)
                     continue;
 
-                yield return type;
+                children.Add(type);
             }
+
+            cached = children.ToArray();
+            _getAllChildrenCache.Add(key, cached);
+            return cached;
         }
 
         private void EnsureGetAllTypesCache()
@@ -114,6 +124,7 @@ namespace Robust.Shared.Reflection
 
             this.assemblies.AddRange(assembliesArray);
             _getAllTypesCache.Clear();
+            _getAllChildrenCache.Clear();
             OnAssemblyAdded?.Invoke(this, new ReflectionUpdateEventArgs(this));
         }
 


### PR DESCRIPTION
1/3 of client test runner, I think mostly from serialization reflection, but for example entityconditions would do hundreds of lookups that we can just dictionary + array for much faster.