### PR TITLE
Add TestPair ID to GetPair logging

### DIFF
--- a/Robust.UnitTesting/Pool/PoolManager.cs
+++ b/Robust.UnitTesting/Pool/PoolManager.cs
@@ -180,7 +180,7 @@ public class PoolManager<TPair> : BasePoolManager where TPair : class, ITestPair
             if (pair != null)
             {
                 pair.ActivateContext(testOut);
-                await testOut.WriteLineAsync($"{nameof(GetPair)}: Suitable pair found");
+                await testOut.WriteLineAsync($"{nameof(GetPair)}: Suitable pair found (Pair {pair.Id})");
 
                 if (pair.Settings.CanFastRecycle(settings))
                 {


### PR DESCRIPTION
If a test pair dies during cleanup, this saves a bit of hassle trying to figure out which pair had the problem without having to dig through the gravestones.