### PR TITLE
FovRenderTarget

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.Viewport.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Viewport.cs
@@ -252,6 +252,7 @@ namespace Robust.Client.Graphics.Clyde
 
             IRenderTexture IClydeViewport.RenderTarget => RenderTarget;
             IRenderTexture IClydeViewport.LightRenderTarget => LightRenderTarget;
+            IRenderTexture IClydeViewport.FovRenderTarget => _clyde._fovRenderTarget;
             public IEye? Eye { get; set; }
         }
 

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -522,6 +522,9 @@ namespace Robust.Client.Graphics.Clyde
             public IRenderTexture LightRenderTarget { get; } =
                 new DummyRenderTexture(Vector2i.One, new DummyTexture(Vector2i.One));
 
+            public IRenderTexture FovRenderTarget { get; } =
+                new DummyRenderTexture(Vector2i.One, new DummyTexture(Vector2i.One));
+
             public IEye? Eye { get; set; }
             public Vector2i Size { get; }
             public event Action<ClearCachedViewportResourcesEvent>? ClearCachedResources;

--- a/Robust.Client/Graphics/IClydeViewport.cs
+++ b/Robust.Client/Graphics/IClydeViewport.cs
@@ -25,6 +25,13 @@ namespace Robust.Client.Graphics
         IRenderTexture RenderTarget { get; }
         IRenderTexture LightRenderTarget { get; }
 
+        /// <summary>
+        ///     The render target holding the FOV shadow-depth map for this viewport's eye.
+        ///     Can be sampled by world-space shaders (together with the eye position) to
+        ///     determine per-pixel whether a world point is occluded by FOV.
+        /// </summary>
+        IRenderTexture FovRenderTarget { get; }
+
         IEye? Eye { get; set; }
         Vector2i Size { get; }
 


### PR DESCRIPTION
This PR exposes the viewport's FOV shadow-depth render target, allowing world-space shaders to sample FOV occlusion.
For https://github.com/space-wizards/space-station-14/pull/44601