### PR TITLE
EntitySystem.Spawn: defer MapInitEvent in SpawnNextTo/InContainer/...OrDrop

### DIFF
--- a/Robust.Shared/GameObjects/EntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Spawn.cs
@@ -7,7 +7,6 @@ using System.Runtime.CompilerServices;
 using Robust.Shared.Collections;
 using Robust.Shared.Containers;
 using Robust.Shared.Maths;
-using Robust.Shared.Serialization;
 
 namespace Robust.Shared.GameObjects;
 
@@ -151,10 +150,13 @@ public partial class EntityManager
             return true;
         }
 
-        var doMapInit = _mapSystem.IsInitialized(xform.MapUid);
-        uid = Spawn(protoName, overrides, doMapInit);
+        uid = Spawn(protoName, overrides, doMapInit: false);
         if (_containers.Insert(uid.Value, container))
+        {
+            if (_mapSystem.IsInitialized(xform.MapUid))
+                RunMapInit(uid.Value, MetaQuery.Comp(uid.Value));
             return true;
+        }
 
         DeleteEntity(uid.Value);
         uid = null;
@@ -176,13 +178,13 @@ public partial class EntityManager
         if (!containerComp.Containers.TryGetValue(containerId, out var container))
             return false;
 
-        uid = Spawn(protoName, overrides, false);
+        uid = Spawn(protoName, overrides, doMapInit: false);
 
         if (_containers.Insert(uid.Value, container))
         {
-            if (_mapSystem.IsInitialized(TransformQuery.GetComponent(containerUid).MapUid)
-                && MetaQuery.TryComp(uid, out var metaData))
-                RunMapInit(uid.Value, metaData);
+            if (_mapSystem.IsInitialized(TransformQuery.GetComponent(containerUid).MapUid))
+                RunMapInit(uid.Value, MetaQuery.Comp(uid.Value));
+
             return true;
         }
 
@@ -197,9 +199,12 @@ public partial class EntityManager
         if (!xform.ParentUid.IsValid())
             return Spawn(protoName);
 
-        var doMapInit = _mapSystem.IsInitialized(xform.MapUid);
-        var uid = Spawn(protoName, overrides, doMapInit);
+        var uid = Spawn(protoName, overrides, doMapInit: false);
         _xforms.DropNextTo(uid, target);
+
+        if (_mapSystem.IsInitialized(xform.MapUid))
+            RunMapInit(uid, MetaQuery.Comp(uid));
+
         return uid;
     }
 
@@ -225,8 +230,7 @@ public partial class EntityManager
     {
         inserted = true;
         xform ??= TransformQuery.GetComponent(containerUid);
-        var doMapInit = _mapSystem.IsInitialized(xform.MapUid);
-        var uid = Spawn(protoName, overrides, doMapInit);
+        var uid = Spawn(protoName, overrides, doMapInit: false);
 
         if ((containerComp == null && !TryGetComponent(containerUid, out containerComp))
              || !containerComp.Containers.TryGetValue(containerId, out var container)
@@ -236,6 +240,9 @@ public partial class EntityManager
             if (xform.ParentUid.IsValid())
                 _xforms.DropNextTo(uid, (containerUid, xform));
         }
+
+        if (_mapSystem.IsInitialized(xform.MapUid))
+            RunMapInit(uid, MetaQuery.Comp(uid));
 
         return uid;
     }

--- a/Robust.Shared/GameObjects/EntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Spawn.cs
@@ -176,11 +176,15 @@ public partial class EntityManager
         if (!containerComp.Containers.TryGetValue(containerId, out var container))
             return false;
 
-        var doMapInit = _mapSystem.IsInitialized(TransformQuery.GetComponent(containerUid).MapUid);
-        uid = Spawn(protoName, overrides, doMapInit);
+        uid = Spawn(protoName, overrides, false);
 
         if (_containers.Insert(uid.Value, container))
+        {
+            if (_mapSystem.IsInitialized(TransformQuery.GetComponent(containerUid).MapUid)
+                && MetaQuery.TryComp(uid, out var metaData))
+                RunMapInit(uid.Value, metaData);
             return true;
+        }
 
         DeleteEntity(uid.Value);
         uid = null;

--- a/Robust.Shared/GameObjects/EntityManager.Spawn.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Spawn.cs
@@ -155,6 +155,7 @@ public partial class EntityManager
         {
             if (_mapSystem.IsInitialized(xform.MapUid))
                 RunMapInit(uid.Value, MetaQuery.Comp(uid.Value));
+
             return true;
         }
 


### PR DESCRIPTION
This PR changes the `EntityManager.SpawnX` functions so that the MapInitEvent is fired when the entity is on its target map, not nullspace.

## Why?

Will resolve this issue: https://github.com/space-wizards/space-station-14/issues/41502

Without this, these Spawn functions are more or less useless for spawning spawners (that tend to run on MapInit).

Gives a stronger, more consistent guarantee of when the MapInitEvent will be run between Spawn commands.

## Media

A demonstration of the issue in https://github.com/space-wizards/space-station-14/issues/41502 being resolved, which uses SpawnNextToOrDrop:

https://github.com/user-attachments/assets/21f24c12-558f-4ae0-801c-f37b36a24616