### PR TITLE
Check for deleted contacts

### DIFF
--- a/Robust.Client/Physics/PhysicsSystem.Predict.cs
+++ b/Robust.Client/Physics/PhysicsSystem.Predict.cs
@@ -132,7 +132,10 @@ public sealed partial class PhysicsSystem
 
             // Don't evaluate deleted contacts.
             if ((contact.Flags & (ContactFlags.Deleting | ContactFlags.Deleted)) != 0x0)
+            {
+                contact.IsTouching = false;
                 continue;
+            }
 
             if (!bodyA.CanCollide || !bodyB.CanCollide)
             {

--- a/Robust.Client/Physics/PhysicsSystem.Predict.cs
+++ b/Robust.Client/Physics/PhysicsSystem.Predict.cs
@@ -130,7 +130,7 @@ public sealed partial class PhysicsSystem
             var uidA = contact.EntityA;
             var uidB = contact.EntityB;
 
-            if (!bodyA.CanCollide || !bodyB.CanCollide)
+            if ((contact.Flags & ContactFlags.Deleted) != 0x0 || !bodyA.CanCollide || !bodyB.CanCollide)
             {
                 contact.IsTouching = false;
                 continue;
@@ -204,7 +204,6 @@ public sealed partial class PhysicsSystem
         for (var i = 0; i < index; i++)
         {
             var contact = contacts[i];
-            if (contact.Flags.HasFlag(ContactFlags.Deleted)) continue;
             var uidA = contact.EntityA;
             var uidB = contact.EntityB;
             var bodyATransform = GetPhysicsTransform(uidA, xformQuery.GetComponent(uidA));

--- a/Robust.Client/Physics/PhysicsSystem.Predict.cs
+++ b/Robust.Client/Physics/PhysicsSystem.Predict.cs
@@ -130,7 +130,11 @@ public sealed partial class PhysicsSystem
             var uidA = contact.EntityA;
             var uidB = contact.EntityB;
 
-            if ((contact.Flags & ContactFlags.Deleted) != 0x0 || !bodyA.CanCollide || !bodyB.CanCollide)
+            // Don't evaluate deleted contacts.
+            if ((contact.Flags & (ContactFlags.Deleting | ContactFlags.Deleted)) != 0x0)
+                continue;
+
+            if (!bodyA.CanCollide || !bodyB.CanCollide)
             {
                 contact.IsTouching = false;
                 continue;

--- a/Robust.Client/Physics/PhysicsSystem.Predict.cs
+++ b/Robust.Client/Physics/PhysicsSystem.Predict.cs
@@ -204,6 +204,7 @@ public sealed partial class PhysicsSystem
         for (var i = 0; i < index; i++)
         {
             var contact = contacts[i];
+            if (contact.Flags.HasFlag(ContactFlags.Deleted)) continue;
             var uidA = contact.EntityA;
             var uidB = contact.EntityB;
             var bodyATransform = GetPhysicsTransform(uidA, xformQuery.GetComponent(uidA));


### PR DESCRIPTION
While making hand throwing predicted on Starlight, ran into this bit of code causing this exception to print in the client console:
```
[ERRO] runtime: Caught exception in "ResetPredictedEntities"
System.Collections.Generic.KeyNotFoundException: Entity 0 does not have a component of type Robust.Shared.GameObjects.TransformComponent
   at Robust.Client.Physics.PhysicsSystem.UpdateIsTouching(List`1 toUpdate) in /home/neomoth/src/space-station-14/RobustToolbox/Robust.Client/Physics/PhysicsSystem.Predict.cs:line 209
   at Robust.Client.GameStates.ClientGameStateManager.ResetPredictedEntities() in /home/neomoth/src/space-station-14/RobustToolbox/Robust.Client/GameStates/ClientGameStateManager.cs:line 695
   at Robust.Client.GameStates.ClientGameStateManager.ApplyGameState() in /home/neomoth/src/space-station-14/RobustToolbox/Robust.Client/GameStates/ClientGameStateManager.cs:line 357
```
and when checking with the debugger the contact point was flagged as deleted, so really there's no reason to be processing the contact point at all, especially if it's just going to flood the client console with exceptions.

Tested game after applying change, nothing seems to be affected other than avoiding the exception altogether, so as far as I can tell this shouldn't cause any issues.