### PR TITLE
Fix BaseWindow jittering on resize

### DIFF
--- a/Robust.Client/UserInterface/Controls/LayoutContainer.cs
+++ b/Robust.Client/UserInterface/Controls/LayoutContainer.cs
@@ -462,20 +462,19 @@ namespace Robust.Client.UserInterface.Controls
         protected override Vector2 MeasureOverride(Vector2 availableSize)
         {
             var min = Vector2.Zero;
-            var uiScale = UIScale;
 
             foreach (var child in Children)
             {
                 var growH = child.GetValue<GrowDirection>(GrowHorizontalProperty);
                 var growV = child.GetValue<GrowDirection>(GrowVerticalProperty);
 
-                var anchorMargins = CalcAnchorMargins(availableSize, uiScale, child);
+                var anchorMargins = CalcAnchorMargins(availableSize, child);
                 var size = availableSize;
                 if (growH == GrowDirection.Constrain)
-                    size.X = anchorMargins.Width / uiScale;
+                    size.X = anchorMargins.Width;
 
                 if (growV == GrowDirection.Constrain)
-                    size.Y = anchorMargins.Height / uiScale;
+                    size.Y = anchorMargins.Height;
 
                 child.Measure(size);
                 min = Vector2.Max(min, child.DesiredSize);
@@ -488,7 +487,7 @@ namespace Robust.Client.UserInterface.Controls
         {
             foreach (var child in Children)
             {
-                child.Arrange(CalcChildRect(finalSize, UIScale, child, out _));
+                child.Arrange(CalcChildRect(finalSize, child, out _));
             }
 
             return finalSize;
@@ -509,7 +508,7 @@ namespace Robust.Client.UserInterface.Controls
                     continue;
                 }
 
-                var rect = CalcChildRect(Size, UIScale, child, out var anchorSize);
+                var rect = CalcChildRect(Size, child, out var anchorSize);
 
                 var left = rect.Left * UIScale;
                 var right = rect.Right * UIScale;
@@ -542,24 +541,22 @@ namespace Robust.Client.UserInterface.Controls
             }
         }
 
-        private static UIBox2 CalcAnchorMargins(Vector2 ourSize, float uiScale, Control child)
+        private static UIBox2 CalcAnchorMargins(Vector2 ourSize, Control child)
         {
-            var (pSizeX, pSizeY) = ourSize * uiScale;
-
             var anchorLeft = child.GetValue<float>(AnchorLeftProperty);
             var anchorTop = child.GetValue<float>(AnchorTopProperty);
             var anchorRight = child.GetValue<float>(AnchorRightProperty);
             var anchorBottom = child.GetValue<float>(AnchorBottomProperty);
 
-            var marginLeft = child.GetValue<float>(MarginLeftProperty) * uiScale;
-            var marginTop = child.GetValue<float>(MarginTopProperty) * uiScale;
-            var marginRight = child.GetValue<float>(MarginRightProperty) * uiScale;
-            var marginBottom = child.GetValue<float>(MarginBottomProperty) * uiScale;
+            var marginLeft = child.GetValue<float>(MarginLeftProperty);
+            var marginTop = child.GetValue<float>(MarginTopProperty);
+            var marginRight = child.GetValue<float>(MarginRightProperty);
+            var marginBottom = child.GetValue<float>(MarginBottomProperty);
 
-            var left = anchorLeft * pSizeX + marginLeft;
-            var top = anchorTop * pSizeY + marginTop;
-            var right = anchorRight * pSizeX + marginRight;
-            var bottom = anchorBottom * pSizeY + marginBottom;
+            var left = anchorLeft * ourSize.X + marginLeft;
+            var top = anchorTop * ourSize.Y + marginTop;
+            var right = anchorRight * ourSize.X + marginRight;
+            var bottom = anchorBottom * ourSize.Y + marginBottom;
 
             // Yes, this can return boxes with left > right (and top > bottom).
             // This is "intentional", see comment in CalcChildRect.
@@ -567,23 +564,23 @@ namespace Robust.Client.UserInterface.Controls
             return new UIBox2(left, top, right, bottom);
         }
 
-        private static UIBox2 CalcChildRect(Vector2 ourSize, float uiScale, Control child, out UIBox2 anchorSize)
+        private static UIBox2 CalcChildRect(Vector2 ourSize, Control child, out UIBox2 anchorSize)
         {
             // Calculate where the control "wants" to be by its anchors/margins.
             var growHorizontal = child.GetValue<GrowDirection>(GrowHorizontalProperty);
             var growVertical = child.GetValue<GrowDirection>(GrowVerticalProperty);
 
-            anchorSize = CalcAnchorMargins(ourSize, uiScale, child);
+            anchorSize = CalcAnchorMargins(ourSize, child);
 
             // This intentionally results in negatives if the right bound is < the left bound.
             // Which then causes HandleLayoutOverflow to CORRECTLY work from the right bound instead.
             var (wSizeX, wSizeY) = (anchorSize.Right - anchorSize.Left, anchorSize.Bottom - anchorSize.Top);
-            var (minSizeX, minSizeY) = child.DesiredPixelSize;
+            var (minSizeX, minSizeY) = child.DesiredSize;
 
             HandleLayoutOverflow(growHorizontal, minSizeX, anchorSize.Left, wSizeX, out var posX, out var sizeX);
             HandleLayoutOverflow(growVertical, minSizeY, anchorSize.Top, wSizeY, out var posY, out var sizeY);
 
-            return UIBox2.FromDimensions(posX / uiScale, posY / uiScale, sizeX / uiScale, sizeY / uiScale);
+            return UIBox2.FromDimensions(posX, posY, sizeX, sizeY);
         }
 
         private static void HandleLayoutOverflow(GrowDirection direction, float minSize, float wPos, float wSize,


### PR DESCRIPTION
Look at this:

https://github.com/user-attachments/assets/4a497f96-f5f9-44b4-9507-ad216a4c2e7a

When you drag the bottom right of the window, the top-left jitters. If you're not seeing the same, try resizing the whole game window or changing the ui scale either via the settings or running `cvar display uiScale 0.9-or-whatever`

BaseWindow's resizing code will call LayoutContainer.SetPosition, which sets the margin properties on the Control. Then, CalcAnchorMargins would the anchor and margin properties, scale each of them by `UiScale`, and add them. Finally, the calling code would divide the result by `UiScale`, essentially `(anchorLeft * uiScale + marginLeft * uiScale) / uiScale)` - this was unstable and was resulting in jittery positions.

I've just taken out those ui scale and done the calculations in a consistent space.

After this PR, rock solid windows:

https://github.com/user-attachments/assets/1c46f034-ff1e-4576-96b4-4684c36f6135

