### PR TITLE
Defer UI operations until UI system runs frame update

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -36,10 +36,21 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
 
     private ActorRangeCheckJob _rangeJob;
 
+    /// Update type to apply
+    private enum QueuedUpdate
+    {
+        /// Upen a UI
+        Open,
+        /// Apply new state to the UI
+        ApplyState,
+        /// Close the UI
+        Close
+    };
+
     /// <summary>
     /// Defer BUIs during state handling so client doesn't spam a BUI constantly during prediction.
     /// </summary>
-    private readonly List<(BoundUserInterface Bui, bool value)> _queuedBuis = new();
+    private readonly List<(BoundUserInterface bui, QueuedUpdate updateType)> _queuedBuis = new();
 
     public override void Initialize()
     {
@@ -82,9 +93,9 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
         SubscribeLocalEvent<UserInterfaceUserComponent, ComponentShutdown>(OnActorShutdown);
     }
 
-    private void AddQueued(BoundUserInterface bui, bool value)
+    private void AddQueued(BoundUserInterface bui, QueuedUpdate type)
     {
-        _queuedBuis.Add((bui, value));
+        _queuedBuis.Add((bui, type));
     }
 
     /// <summary>
@@ -238,7 +249,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
 
         if (ent.Comp.ClientOpenInterfaces.TryGetValue(key, out var cBui))
         {
-            AddQueued(cBui, false);
+            AddQueued(cBui, QueuedUpdate.Close);
         }
 
         if (ent.Comp.Actors.Count == 0)
@@ -280,7 +291,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
         // PlayerAttachedEvent will catch some of these.
         foreach (var (key, bui) in ent.Comp.ClientOpenInterfaces)
         {
-            AddQueued(bui, true);
+            AddQueued(bui, QueuedUpdate.Open);
         }
     }
 
@@ -300,7 +311,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
             DebugTools.Assert(!ent.Comp.Actors.ContainsKey(key));
         }
 
-        DebugTools.Assert(ent.Comp.ClientOpenInterfaces.Values.All(x => _queuedBuis.Contains((x, false))));
+        DebugTools.Assert(ent.Comp.ClientOpenInterfaces.Values.All(x => _queuedBuis.Contains((x, QueuedUpdate.Close))));
     }
 
     private void OnUserInterfaceGetState(Entity<UserInterfaceComponent> ent, ref ComponentGetState args)
@@ -462,7 +473,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
                 }
 
                 var bui = ent.Comp.ClientOpenInterfaces[key];
-                AddQueued(bui, false);
+                AddQueued(bui, QueuedUpdate.Close);
             }
         }
 
@@ -489,9 +500,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
                 if (!ent.Comp.ClientOpenInterfaces.TryGetValue(key, out var cBui) || !cBui.IsOpened)
                     continue;
 
-                cBui.State = buiState;
-                cBui.UpdateState(buiState);
-                cBui.Update();
+                AddQueued(cBui, QueuedUpdate.ApplyState);
             }
         }
 
@@ -519,7 +528,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
         // Existing BUI just keep it.
         if (entity.Comp.ClientOpenInterfaces.TryGetValue(key, out var existing))
         {
-            _queuedBuis.Remove((existing, false));
+            _queuedBuis.Remove((existing, QueuedUpdate.Close));
             return;
         }
 
@@ -544,7 +553,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
         if (!open)
             return;
 
-        AddQueued(boundUserInterface, true);
+        AddQueued(boundUserInterface, QueuedUpdate.Open);
     }
 
     /// <summary>
@@ -1101,15 +1110,18 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
     {
         if (_timing.IsFirstTimePredicted)
         {
-            foreach (var (bui, open) in _queuedBuis)
+            foreach (var (bui, updateType) in _queuedBuis)
             {
-                if (open)
+                if (updateType == QueuedUpdate.Open || updateType == QueuedUpdate.ApplyState)
                 {
 #if EXCEPTION_TOLERANCE
                     try
                     {
 #endif
-                    bui.Open();
+                    if (updateType == QueuedUpdate.Open)
+                    {
+                        bui.Open();
+                    }
 
                     if (UIQuery.TryComp(bui.Owner, out var uiComp))
                     {


### PR DESCRIPTION
Redux of https://github.com/Space-Wizards-Federation/RobustToolbox/pull/50. There's a few more comments on that issue, but here's a copy-paste of the description:

In the UI system, some updates are applied immediately, while some are deferred until the frame update. This changes all the operations to be deferred. This fixes a UI bug, but there's a more fundamental underlying bug here.

First, the bug;
1. `forcemap Packed`
2. `startround`
3. Find the R&D server, spawn some research point disks and add them to the server.
4. Open the UI of the R&D computer beside the server and press the "Research" button on one of the technologies. You'll see the UI update - available points decrease, get a new entry in "Unlocked technologies" and you get new technology options to research.
5. Close that UI.
6. Open the UI of one of the other two R&D computer and press "Research" on one of the technologies. You _don't_ get a proper UI update; the points decrease, but you don't get a new entry in the "Unlocked technologies" nor new technology options to research.
7. Close the UI and open it again - it's now updated.

For clarification:
<img width="1920" height="1080" alt="RNDComputers" src="https://github.com/user-attachments/assets/d9470f9a-b41c-4fed-b464-2b3e567b34bd" />

Two important components here; the `TechnologyDatabaseComponent` stores the information on unlocked and available technologies, and the `UserInterfaceComponent` provides the UI (uh-huh). The `ResearchConsoleBoundUserInterface.UpdateState` calls an update on the `ResearchConsoleMenu`, which in turn reads the `TechnologyDatabaseComponent` to populate the UI. When you press the "Research" button, a message is sent to the server which causes it to `Dirty()` both of these components.

For the broken computers, the `ClientGameStateManager.ApplyGameState` applies the state to the `UserInterfaceComponent` before the `TechnologyDatabaseComponent`, but because the `SharedUserInterfaceSystem` has a `ComponentHandleState` subscription, it performs the work in that callback immediately so the UI ends up reading stale values. By deferring all the UI operations until the frame render, we know that any components the UI wants to read will have had their state applied.

I didn't look into why one of the computers seems to work - suspect it's simply serialization and the order of components stored in that map.

There seems to be a more fundamental issue here; because the component state updates are unordered, any time you have a system which subscribes to `ComponentHandleState` and reads from a different component, you're in danger of getting stale data. I did a quick scan over all the subscriptions in content and most look pretty benign, though it's gonna be a bunch of work to untangle, especially with systems which raise further events in that subscription. `SharedSolutionContainerSystem` looks suspicious, for example, while `FixtureSystem` (in engine) seems to have a much clearer issue if the updates arrive out of order.