### PR TITLE
Add API for loading OwnedTexture with texture parameters

### DIFF
--- a/Robust.Client/ResourceManagement/ResourceTypes/TextureResource.cs
+++ b/Robust.Client/ResourceManagement/ResourceTypes/TextureResource.cs
@@ -88,6 +88,18 @@ namespace Robust.Client.ResourceManagement
             data.Image.Dispose();
         }
 
+        /// <summary>
+        /// Loads a texture from path as an <see cref="OwnedTexture"/>.
+        /// Texture parameters are taken from a matching .yml file if present.
+        /// </summary>
+        public static OwnedTexture LoadOwnedTexture(IResourceManager resManager, IClyde clyde, ResPath path)
+        {
+            var loadParams = TryLoadTextureParameters(resManager, path) ?? TextureLoadParameters.Default;
+            using var stream = resManager.ContentFileRead(path);
+            using var image = Image.Load<Rgba32>(stream);
+            return clyde.LoadTextureFromImage(image, path.ToString(), loadParams);
+        }
+
         private static TextureLoadParameters? TryLoadTextureParameters(IResourceManager cache, ResPath path)
         {
             var metaPath = path.WithName(path.Filename + ".yml");


### PR DESCRIPTION
At the moment, there is no way to get an `OwnedTexture` from a `ResPath` that supports texture parameters without `ResourceCache` (which caches the result, which is not always a good thing).
So this PR solves that problem.