### PR TITLE
Replace overly restrictive (and sometimes wrong?) cast in serialization generator

### DIFF
--- a/Robust.Serialization.Generator/Generator.cs
+++ b/Robust.Serialization.Generator/Generator.cs
@@ -108,7 +108,7 @@ public class Generator : IIncrementalGenerator
         var containingTypesEnd = new StringBuilder();
         foreach (var parent in containingTypes)
         {
-            var syntax = (ClassDeclarationSyntax)parent.DeclaringSyntaxReferences[0].GetSyntax();
+            var syntax = (TypeDeclarationSyntax)parent.DeclaringSyntaxReferences[0].GetSyntax();
             if (!IsPartial(syntax))
             {
                 nonPartial = true;


### PR DESCRIPTION
# The issue

I don't fully understand the serializer generators, but after switching to engine version 282.0.0 , my SS14 fork started getting build errors because of missing generated serializer sources. I tracked it down to a crash in the generator due to a bad cast:

```
Generator 'Generator' failed to generate source. It will not contribute to the output and compilation errors may occur as a result. Exception was of type 'InvalidCastException' with message 'Unable to cast object of type 'Microsoft.CodeAnalysis.CSharp.Syntax.InterfaceDeclarationSyntax' to type 'Microsoft.CodeAnalysis.CSharp.Syntax.ClassDeclarationSyntax'.'.
```

As far as I can tell, it's that if a data definition has a parent that's an interface (or just not a class?), the generator tries to cast that interface's `InterfaceDeclarationSyntax` to a `ClassDeclarationSyntax`, which kills the generator.

Also, it seems this is new because previously `Component`s didn't use the data definition generators.

# The fix

My solution is to just change the cast to use `TypeDeclarationSyntax`, since that's the broadest type necessary for that piece of code to work.

# The context

See the https://github.com/Centronias/moff-station-14/pull/23 for an example of the crash

The interface in question is `ESBaseSparkConfigurationComponent` introduced in https://github.com/moff-station/moff-station-14/pull/1604