### PR TITLE
Allow content to read actual auxiliary off of `AudioAuxiliaryComponent`

### DIFF
--- a/Robust.Shared/Audio/Components/AudioAuxiliaryComponent.cs
+++ b/Robust.Shared/Audio/Components/AudioAuxiliaryComponent.cs
@@ -20,5 +20,5 @@ public sealed partial class AudioAuxiliaryComponent : Component
     public EntityUid? Effect;
 
     [ViewVariables]
-    internal IAuxiliaryAudio Auxiliary = new DummyAuxiliaryAudio();
+    public IAuxiliaryAudio Auxiliary = new DummyAuxiliaryAudio();
 }


### PR DESCRIPTION
i would like to directly set the auxiliary for an audio source from the client and this is the minimal change required to allow me to do that. im not really convinced auxiliary stuff needs to be networked at all on `AudioComponent`, and if it is there should really be a more robust way for client to override it (#6358 would be nice although the fact that it even feels necessary kind of reveals that audio networking is a bit of a mess), but in the interim this allows some more direct control from content

the interface is already non-internal and this doesnt really allow you to do anything strange with the auxiliary itself as you still dont have write or execute access.