### PR TITLE
Fix physics hull allocs

### DIFF
--- a/Robust.Shared/Physics/Collision/InternalPhysicsHull.cs
+++ b/Robust.Shared/Physics/Collision/InternalPhysicsHull.cs
@@ -10,7 +10,9 @@ namespace Robust.Shared.Physics;
 /// </summary>
 internal ref struct InternalPhysicsHull
 {
-    public Span<Vector2> Points;
+    private FixedArray8<Vector2> _points;
+
+    public Span<Vector2> Points => field.IsEmpty ? _points.AsSpan : field;
     public int Count;
 
     internal InternalPhysicsHull(Span<Vector2> vertices, int count) : this()
@@ -66,7 +68,6 @@ internal ref struct InternalPhysicsHull
             return hull;
         }
 
-        hull.Points = new Vector2[PhysicsConstants.MaxPolygonVertices];
         var bestPoint = ps[bestIndex];
 
         // compute hull to the right of p1-bestPoint
@@ -221,8 +222,6 @@ internal ref struct InternalPhysicsHull
 		    // all points collinear
 		    return hull;
 	    }
-
-        hull.Points = new Vector2[PhysicsConstants.MaxPolygonVertices];
 
 	    // stitch hulls together, preserving CCW winding order
 	    hull.Points[hull.Count++] = p1;

--- a/Robust.Shared/Physics/PhysicsHull.cs
+++ b/Robust.Shared/Physics/PhysicsHull.cs
@@ -8,6 +8,6 @@ public struct PhysicsHull
     public static Span<Vector2> ComputePoints(ReadOnlySpan<Vector2> points, int count)
     {
         var hull = InternalPhysicsHull.ComputeHull(points, count);
-        return hull.Points;
+        return hull.Count == 0 ? Span<Vector2>.Empty : hull.Points.ToArray();
     }
 }


### PR DESCRIPTION
Still need the span if we get passed in an invalid hull but for ideal cases it should be okey.