### PR TITLE
sprite geometry clipping for water effect

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -215,6 +215,14 @@ namespace Robust.Client.GameObjects
         }
 
         /// <summary>
+        /// Fraction of every normal sprite layer cropped from its bottom edge before rendering.
+        /// This is applied before layer and post shaders, allowing effects such as water immersion
+        /// without consuming the sprite's single post-shader slot.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float BottomClipFraction { get; set; }
+
+        /// <summary>
         ///     Whether to pass the screen texture to the <see cref="PostShader"/>.
         /// </summary>
         /// <remarks>

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Render.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Render.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Numerics;
 using Robust.Client.Graphics;
 using Robust.Client.Graphics.Clyde;
@@ -146,6 +147,20 @@ public sealed partial class SpriteSystem
         var layerColor = layer.Owner.Comp.color * layer.Color;
         var textureSize = texture.Size / (float) EyeManager.PixelsPerMeter;
         var quad = Box2.FromDimensions(textureSize / -2, textureSize);
+        UIBox2? subRegion = null;
+
+        var bottomClip = Math.Clamp(layer.Owner.Comp.BottomClipFraction, 0f, 0.999f);
+        if (bottomClip > 0f)
+        {
+            // Crop the texture as well as its quad so the visible portion keeps its original scale.
+            // Texture sub-regions use a top-left origin while world quads use a bottom-left origin.
+            quad.Bottom = MathHelper.Lerp(quad.Bottom, quad.Top, bottomClip);
+            subRegion = new UIBox2(
+                0f,
+                0f,
+                texture.Width,
+                texture.Height * (1f - bottomClip));
+        }
 
         if (layer.UnShaded)
         {
@@ -158,7 +173,7 @@ public sealed partial class SpriteSystem
             layerColor = new(new Vector4(-1) - layerColor.RGBA);
         }
 
-        drawingHandle.DrawTextureRectRegion(texture, quad, layerColor);
+        drawingHandle.DrawTextureRectRegion(texture, quad, layerColor, subRegion);
 
         if (layer.Shader != null)
             drawingHandle.UseShader(null);


### PR DESCRIPTION
This is a PR necessary for my downstream fork. It allows the clipping of sprite geometry and in our case is an improvement over the FloorOccluder component to allow hiding parts of the players sprite without the need for rendering a sprite over the player.

Here is an example in action where we have a bobbing effect where the sprite cut is moving up and down.

https://github.com/user-attachments/assets/5530a999-2664-49a4-af65-885ee2a02ef7
