### PR TITLE
Fix sprite jittering

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.GridRendering.cs
@@ -84,7 +84,15 @@ namespace Robust.Client.Graphics.Clyde
                     gridProgram.SetUniform(UniIModUV, new Vector4(0, 0, 1, 1));
                 }
 
-                gridProgram.SetUniform(UniIModelMatrix, _transformSystem.GetWorldMatrix(mapGrid));
+                var matrix = _transformSystem.GetWorldMatrix(mapGrid);
+                matrix.Translation += GetPixelSnapOffset(
+                    matrix.Translation,
+                    eye.Position.Position + eye.Offset,
+                    eye.Rotation,
+                    eye.Scale * viewport.RenderScale *
+                        new Vector2(EyeManager.PixelsPerMeter, -EyeManager.PixelsPerMeter),
+                    viewport.Size);
+                gridProgram.SetUniform(UniIModelMatrix, matrix);
                 var enumerator = _mapSystem.GetMapChunks(mapGrid.Owner, mapGrid.Comp, worldBounds);
 
                 // Handle base texture updates.

--- a/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
@@ -8,6 +8,7 @@ using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Graphics;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Threading;
@@ -57,6 +58,7 @@ internal partial class Clyde
     private void ProcessSpriteEntities(MapId map, Viewport view, IEye eye, Box2Rotated worldBounds, RefList<SpriteData> list)
     {
         var query = _entityManager.GetEntityQuery<TransformComponent>();
+        var gridQuery = _entityManager.GetEntityQuery<MapGridComponent>();
         var viewScale = eye.Scale * view.RenderScale * new Vector2(EyeManager.PixelsPerMeter, -EyeManager.PixelsPerMeter);
         var treeData = new BatchData()
         {
@@ -77,13 +79,24 @@ internal partial class Clyde
         foreach (var (treeOwner, comp) in _spriteTreeSystem.GetIntersectingTrees(map, worldBounds))
         {
             var treeXform = query.GetComponent(treeOwner);
+            var treePos = treeXform.LocalPosition;
             var bounds = _transformSystem.GetInvWorldMatrix(treeOwner).TransformBox(worldBounds);
             DebugTools.Assert(treeXform.MapUid == treeXform.ParentUid || !treeXform.ParentUid.IsValid());
+
+            if (gridQuery.HasComponent(treeOwner))
+            {
+                treePos += GetPixelSnapOffset(
+                    treePos,
+                    treeData.ViewPosition,
+                    treeData.ViewRotation,
+                    treeData.ViewScale,
+                    view.Size);
+            }
 
             treeData = treeData with
             {
                 TreeOwner = treeOwner,
-                TreePos = treeXform.LocalPosition,
+                TreePos = treePos,
                 TreeRot = treeXform.LocalRotation,
                 Sin = MathF.Sin((float)treeXform.LocalRotation),
                 Cos = MathF.Cos((float)treeXform.LocalRotation),
@@ -115,6 +128,20 @@ internal partial class Clyde
 
             index += batches * _spriteProcessingBatchSize + remainder;
         }
+    }
+
+    internal static Vector2 GetPixelSnapOffset(
+        Vector2 worldPosition,
+        Vector2 viewPosition,
+        Angle viewRotation,
+        Vector2 viewScale,
+        Vector2 viewportSize)
+    {
+        var viewPositionRelative = viewRotation.RotateVec(worldPosition - viewPosition);
+        var screenPosition = viewPositionRelative * viewScale + viewportSize / 2f;
+        var screenOffset = screenPosition.Rounded() - screenPosition;
+        var viewOffset = screenOffset / viewScale;
+        return (-viewRotation).RotateVec(viewOffset);
     }
 
     /// <summary>


### PR DESCRIPTION
This has annoyed me for FIVE YEARS since I coded arbitrary grid rotations.

So the issue is that we transform every single sprite into world terms and then back into the viewport. The problem with this is we get rounding issues as the game world is only 32x32 px so you will get slightly different rounded positions due to floating point maths!

To get around this we just clamp the grid positions to 32x32. We still keep floating-point maths for transforms + physics and only touch the render paths.