### PR TITLE
Introduced workflow for deploying developer packages

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,68 @@
+name: Publish nupkgs to NuGet feed/package repository
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-publish:
+    environment: dotnet
+    permissions:
+      id-token: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          submodules: true
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6.0.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install dependencies
+        run: dotnet restore
+
+      - name: Build packages
+        run: dotnet pack -c Release -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: "${{ vars.NUGET_USERNAME }}"
+
+      - name: Push NuGet packages
+        run: |
+          for pkg in $(find . -name '*.nupkg'); do
+            case "$pkg" in
+              ${{ vars.EXCLUDE_NUGET_PACKAGES }})
+                echo "Skipping $pkg"
+                continue
+                ;;
+            esac
+
+            dotnet nuget push "$pkg" \
+              --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" \
+              --source https://api.nuget.org/v3/index.json \
+              --skip-duplicate
+          done
+
+      - name: Push symbol packages
+        run: |
+          for pkg in $(find . -name '*.snupkg'); do
+            case "$pkg" in
+              ${{ vars.EXCLUDE_NUGET_PACKAGES }})
+                echo "Skipping $pkg"
+                continue
+                ;;
+            esac
+
+            dotnet nuget push "$pkg" \
+              --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" \
+              --source https://api.nuget.org/v3/index.json \
+              --skip-duplicate
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 # Build results
 bin/
 obj/
+analyzers/
 
 # ReSharper is a .NET coding add-in
 _ReSharper*/

--- a/MSBuild/Robust.Analyzers.targets
+++ b/MSBuild/Robust.Analyzers.targets
@@ -1,5 +1,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
-  <ItemGroup>
+  <ItemGroup Condition="Exists('$(MSBuildThisFileDirectory)analyzers\dotnet\cs\Robust.Analyzers.dll')">
+    <Analyzer Include="$(MSBuildThisFileDirectory)analyzers\dotnet\cs\Robust.Analyzers.dll" />
+  </ItemGroup>
+  <ItemGroup Condition="!Exists('$(MSBuildThisFileDirectory)analyzers\dotnet\cs\Robust.Analyzers.dll')">
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Robust.Analyzers\Robust.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
   </ItemGroup>
 </Project>

--- a/MSBuild/Robust.CompNetworkGenerator.targets
+++ b/MSBuild/Robust.CompNetworkGenerator.targets
@@ -1,5 +1,8 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
-  <ItemGroup>
+  <ItemGroup Condition="Exists('$(MSBuildThisFileDirectory)analyzers\dotnet\cs\Robust.Shared.CompNetworkGenerator.dll')">
+    <Analyzer Include="$(MSBuildThisFileDirectory)analyzers\dotnet\cs\Robust.Shared.CompNetworkGenerator.dll" />
+  </ItemGroup>
+  <ItemGroup Condition="!Exists('$(MSBuildThisFileDirectory)analyzers\dotnet\cs\Robust.Shared.CompNetworkGenerator.dll')">
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Robust.Shared.CompNetworkGenerator\Robust.Shared.CompNetworkGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
   </ItemGroup>
 </Project>

--- a/MSBuild/Robust.EntitySystemSubscriptionsGenerator.targets
+++ b/MSBuild/Robust.EntitySystemSubscriptionsGenerator.targets
@@ -1,5 +1,8 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
-  <ItemGroup>
+  <ItemGroup Condition="Exists('$(MSBuildThisFileDirectory)analyzers\dotnet\cs\Robust.Shared.EntitySystemSubscriptionsGenerator.dll')">
+    <Analyzer Include="$(MSBuildThisFileDirectory)analyzers\dotnet\cs\Robust.Shared.EntitySystemSubscriptionsGenerator.dll" />
+  </ItemGroup>
+  <ItemGroup Condition="!Exists('$(MSBuildThisFileDirectory)analyzers\dotnet\cs\Robust.Shared.EntitySystemSubscriptionsGenerator.dll')">
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Robust.Shared.EntitySystemSubscriptionsGenerator\Robust.Shared.EntitySystemSubscriptionsGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
   </ItemGroup>
 </Project>

--- a/MSBuild/Robust.Serialization.Generator.targets
+++ b/MSBuild/Robust.Serialization.Generator.targets
@@ -1,5 +1,8 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
-  <ItemGroup>
+  <ItemGroup Condition="Exists('$(MSBuildThisFileDirectory)analyzers\dotnet\cs\Robust.Serialization.Generator.dll')">
+    <Analyzer Include="$(MSBuildThisFileDirectory)analyzers\dotnet\cs\Robust.Serialization.Generator.dll" />
+  </ItemGroup>
+  <ItemGroup Condition="!Exists('$(MSBuildThisFileDirectory)analyzers\dotnet\cs\Robust.Serialization.Generator.dll')">
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Robust.Serialization.Generator\Robust.Serialization.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
   </ItemGroup>
 </Project>

--- a/Robust.Client/Robust.Client.csproj
+++ b/Robust.Client/Robust.Client.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>WinExe</OutputType>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/Robust.Client/Robust.Client.csproj
+++ b/Robust.Client/Robust.Client.csproj
@@ -44,7 +44,8 @@
     <ProjectReference Include="..\Robust.Shared.Scripting\Robust.Shared.Scripting.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Avalonia.Base\Avalonia.Base.csproj" />
+    <!--Not actually used yet, and has a conflicting namespace, disabled until more work is done-->
+    <!--<ProjectReference Include="..\Avalonia.Base\Avalonia.Base.csproj" />-->
     <ProjectReference Include="..\Lidgren.Network\Lidgren.Network.csproj" />
     <ProjectReference Include="..\NetSerializer\NetSerializer\NetSerializer.csproj" />
     <ProjectReference Include="..\Robust.LoaderApi\Robust.LoaderApi\Robust.LoaderApi.csproj" />

--- a/Robust.Server/Robust.Server.csproj
+++ b/Robust.Server/Robust.Server.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>../bin/Server</OutputPath>

--- a/Robust.Shared.Maths.Tests/Robust.Shared.Maths.Tests.csproj
+++ b/Robust.Shared.Maths.Tests/Robust.Shared.Maths.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\MSBuild\Robust.Engine.props"/>
 
   <PropertyGroup>
@@ -22,4 +22,6 @@
   </ItemGroup>
 
   <Import Project="..\MSBuild\Robust.Properties.targets"/>
+  <Import Project="..\MSBuild\Robust.CompNetworkGenerator.targets" />
+  <Import Project="..\MSBuild\Robust.EntitySystemSubscriptionsGenerator.targets" />
 </Project>

--- a/Robust.Shared.Maths.Tests/Robust.Shared.Maths.Tests.csproj
+++ b/Robust.Shared.Maths.Tests/Robust.Shared.Maths.Tests.csproj
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Robust.Shared.Maths/Robust.Shared.Maths.csproj
+++ b/Robust.Shared.Maths/Robust.Shared.Maths.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/Robust.Shared.Scripting/Robust.Shared.Scripting.csproj
+++ b/Robust.Shared.Scripting/Robust.Shared.Scripting.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/Robust.Shared/Robust.Shared.csproj
+++ b/Robust.Shared/Robust.Shared.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CA1416</NoWarn>

--- a/Robust.Shared/Robust.Shared.csproj
+++ b/Robust.Shared/Robust.Shared.csproj
@@ -46,6 +46,28 @@
     <EmbeddedResource Include="ContentPack\Sandbox.yml">
       <LogicalName>Robust.Shared.ContentPack.Sandbox.yml</LogicalName>
     </EmbeddedResource>
+    <None Include="..\MSBuild\Robust.Serialization.Generator.targets" Pack="true" PackagePath="build\" />
+    <None Include="..\MSBuild\Robust.CompNetworkGenerator.targets" Pack="true" PackagePath="build\" />
+    <None Include="..\MSBuild\Robust.EntitySystemSubscriptionsGenerator.targets" Pack="true" PackagePath="build\" />
+    <None Include="..\MSBuild\Robust.Analyzers.targets" Pack="true" PackagePath="build\" />
+  </ItemGroup>
+
+  <Target Name="PackAnalyzers" AfterTargets="Build">
+    <Copy SourceFiles="..\Robust.Serialization.Generator\bin\Debug\netstandard2.0\Robust.Serialization.Generator.dll" DestinationFolder="analyzers\dotnet\cs\" Condition="Exists('..\Robust.Serialization.Generator\bin\Debug\netstandard2.0\Robust.Serialization.Generator.dll')" />
+    <Copy SourceFiles="..\Robust.Serialization.Generator\bin\Release\netstandard2.0\Robust.Serialization.Generator.dll" DestinationFolder="analyzers\dotnet\cs\" Condition="Exists('..\Robust.Serialization.Generator\bin\Release\netstandard2.0\Robust.Serialization.Generator.dll')" />
+    <Copy SourceFiles="..\Robust.Shared.CompNetworkGenerator\bin\Debug\netstandard2.0\Robust.Shared.CompNetworkGenerator.dll" DestinationFolder="analyzers\dotnet\cs\" Condition="Exists('..\Robust.Shared.CompNetworkGenerator\bin\Debug\netstandard2.0\Robust.Shared.CompNetworkGenerator.dll')" />
+    <Copy SourceFiles="..\Robust.Shared.CompNetworkGenerator\bin\Release\netstandard2.0\Robust.Shared.CompNetworkGenerator.dll" DestinationFolder="analyzers\dotnet\cs\" Condition="Exists('..\Robust.Shared.CompNetworkGenerator\bin\Release\netstandard2.0\Robust.Shared.CompNetworkGenerator.dll')" />
+    <Copy SourceFiles="..\Robust.Shared.EntitySystemSubscriptionsGenerator\bin\Debug\netstandard2.0\Robust.Shared.EntitySystemSubscriptionsGenerator.dll" DestinationFolder="analyzers\dotnet\cs\" Condition="Exists('..\Robust.Shared.EntitySystemSubscriptionsGenerator\bin\Debug\netstandard2.0\Robust.Shared.EntitySystemSubscriptionsGenerator.dll')" />
+    <Copy SourceFiles="..\Robust.Shared.EntitySystemSubscriptionsGenerator\bin\Release\netstandard2.0\Robust.Shared.EntitySystemSubscriptionsGenerator.dll" DestinationFolder="analyzers\dotnet\cs\" Condition="Exists('..\Robust.Shared.EntitySystemSubscriptionsGenerator\bin\Release\netstandard2.0\Robust.Shared.EntitySystemSubscriptionsGenerator.dll')" />
+    <Copy SourceFiles="..\Robust.Analyzers\bin\Debug\netstandard2.0\Robust.Analyzers.dll" DestinationFolder="analyzers\dotnet\cs\" Condition="Exists('..\Robust.Analyzers\bin\Debug\netstandard2.0\Robust.Analyzers.dll')" />
+    <Copy SourceFiles="..\Robust.Analyzers\bin\Release\netstandard2.0\Robust.Analyzers.dll" DestinationFolder="analyzers\dotnet\cs\" Condition="Exists('..\Robust.Analyzers\bin\Release\netstandard2.0\Robust.Analyzers.dll')" />
+  </Target>
+
+  <ItemGroup>
+    <None Include="analyzers\dotnet\cs\Robust.Serialization.Generator.dll" Pack="true" PackagePath="analyzers\dotnet\cs\" Visible="false" />
+    <None Include="analyzers\dotnet\cs\Robust.Shared.CompNetworkGenerator.dll" Pack="true" PackagePath="analyzers\dotnet\cs\" Visible="false" />
+    <None Include="analyzers\dotnet\cs\Robust.Shared.EntitySystemSubscriptionsGenerator.dll" Pack="true" PackagePath="analyzers\dotnet\cs\" Visible="false" />
+    <None Include="analyzers\dotnet\cs\Robust.Analyzers.dll" Pack="true" PackagePath="analyzers\dotnet\cs\" Visible="false" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Input\CommandBindMapping.cs" />

--- a/Robust.UnitTesting/Robust.UnitTesting.csproj
+++ b/Robust.UnitTesting/Robust.UnitTesting.csproj
@@ -27,6 +27,4 @@
     <ProjectReference Include="..\Robust.Server\Robust.Server.csproj" />
   </ItemGroup>
   <Import Project="..\MSBuild\Robust.Properties.targets" />
-  <Import Project="..\MSBuild\Robust.CompNetworkGenerator.targets" />
-  <Import Project="..\MSBuild\Robust.EntitySystemSubscriptionsGenerator.targets" />
 </Project>

--- a/Robust.UnitTesting/Robust.UnitTesting.csproj
+++ b/Robust.UnitTesting/Robust.UnitTesting.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\MSBuild\Robust.Engine.props" />
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Adds a GitHub workflow which builds all projects as packages, and pushes
them to NuGet.org
The workflow introduced provides new additional options to
consumers/developers for dependency management.
Developers now can cotntinue as-is with their submodule setup, or given
some work, the option for loading nupkgs is available, via the official
NuGet feed.
This change introduces a new stateful dependency upon the repository.
The owner or one in charge is expected to visit
https://www.nuget.org/account/trustedpublishing and configure an entry
for the repository that is deploying said nupkgs.

There is two additional units of state that the owner or one in charge is
expected to add. The `NUGET_USERNAME` secret to the GitHub repository
configuration, and `EXCLUDE_NUGET_PACKAGES` which is a matching operator
to nupkg file names. Two examples are as follows:
\*Avalonia\*
\*Robust\*|\*Avalonia\*
This is available due to the fact that most likely not all package namespaces
maintained by the robust team are actually owned by the team. Said convention
violation results in a collision with claimed/protected namespaces on upload.
Also, forks may wish to be able to be able to use this for debugging and developing
purposes, like myself, so this is available.
To what is known currently, the only namespace that collides with a protected
namespace currently is `Avalonia`, however it *shouldn't* be an absolute
requirement for this scope.
As for everyone besides the robust team, most namespaces are available, except
for of course, `Avalonia`, but also `SpaceWizards`.

This workflow is dependent upon GitHub and NuGet, both owned by
Microsoft.
-# Also, this builds snupkgs too, the symbols files.