### PR TITLE
Make rect deletion area align with camera rotation instead of world

### DIFF
--- a/Robust.Client/Placement/PlacementManager.cs
+++ b/Robust.Client/Placement/PlacementManager.cs
@@ -111,7 +111,7 @@ namespace Robust.Client.Placement
         /// <summary>
         /// Holds the selection rectangle for the eraser
         /// </summary>
-        public Box2? EraserRect { get; set; }
+        public Box2Rotated? EraserRect { get; set; }
 
         /// <summary>
         /// Drawing shader for drawing without being affected by lighting
@@ -482,12 +482,16 @@ namespace Robust.Client.Placement
             _networkManager.ClientSendMessage(msg);
         }
 
-        public void HandleRectDeletion(EntityCoordinates start, Box2 rect)
+        public void HandleRectDeletion(EntityCoordinates start, Box2Rotated rect)
         {
-            var msg = new MsgPlacement();
-            msg.PlaceType = PlacementManagerMessage.RequestRectRemove;
-            msg.NetCoordinates = new NetCoordinates(EntityManager.GetNetEntity(StartPoint.EntityId), rect.BottomLeft);
-            msg.RectSize = rect.Size;
+            var centerCoords = XformSystem.ToCoordinates(new MapCoordinates(rect.Origin, XformSystem.GetMapId(start)));
+            var msg = new MsgPlacement
+            {
+                PlaceType = PlacementManagerMessage.RequestRectRemove,
+                NetCoordinates = EntityManager.GetNetCoordinates(centerCoords),
+                RectSize = rect.Box.Size,
+                RectRotation = (float)rect.Rotation.Theta
+            };
             _networkManager.ClientSendMessage(msg);
         }
 
@@ -595,28 +599,15 @@ namespace Robust.Client.Placement
                 {
                     if (!CurrentEraserMouseCoordinates(out EntityCoordinates end))
                         return;
-                    float b, l, t, r;
-                    if (StartPoint.X < end.X)
-                    {
-                        l = StartPoint.X;
-                        r = end.X;
-                    }
-                    else
-                    {
-                        l = end.X;
-                        r = StartPoint.X;
-                    }
-                    if (StartPoint.Y < end.Y)
-                    {
-                        b = StartPoint.Y;
-                        t = end.Y;
-                    }
-                    else
-                    {
-                        b = end.Y;
-                        t = StartPoint.Y;
-                    }
-                    EraserRect = new Box2(l, b, r, t);
+
+                    var startPos = XformSystem.ToWorldPosition(StartPoint);
+                    var endPos = XformSystem.ToWorldPosition(end);
+                    var eyeRot = _eyeManager.CurrentEye.Rotation;
+
+                    var diff = eyeRot.RotateVec(endPos - startPos);
+                    var size = new Vector2(MathF.Abs(diff.X), MathF.Abs(diff.Y));
+                    var centerPos = (startPos + endPos) / 2f;
+                    EraserRect = new Box2Rotated(Box2.CenteredAround(centerPos, size), -eyeRot, centerPos);
                 }
                 return;
             }
@@ -665,7 +656,9 @@ namespace Robust.Client.Placement
                 return;
 
             StartPoint = coordinates;
-            EraserRect = new Box2(coordinates.Position, Vector2.Zero);
+            var startPos = XformSystem.ToWorldPosition(coordinates);
+            var eyeRot = _eyeManager.CurrentEye.Rotation;
+            EraserRect = new Box2Rotated(new Box2(startPos, startPos), -eyeRot, startPos);
         }
 
         private bool DeactivateSpecialPlacement()

--- a/Robust.Server/Placement/PlacementManager.cs
+++ b/Robust.Server/Placement/PlacementManager.cs
@@ -245,10 +245,13 @@ namespace Robust.Server.Placement
         /// <param name="msg"></param>
         private void HandleRectRemoveReq(MsgPlacement msg)
         {
-            var start = _entityManager.GetCoordinates(msg.NetCoordinates);
-            var rectSize = msg.RectSize;
+            var centerCoords = _xformSystem.ToMapCoordinates(msg.NetCoordinates);
+            var centerPos = centerCoords.Position;
 
-            foreach (var entity in _lookup.GetEntitiesIntersecting(_xformSystem.GetMapId(start), new Box2(start.Position, start.Position + rectSize)))
+            var box = Box2.CenteredAround(centerPos, msg.RectSize);
+            var boxRotated = new Box2Rotated(box, msg.RectRotation, centerPos);
+
+            foreach (var entity in _lookup.GetEntitiesIntersecting(centerCoords.MapId, boxRotated))
             {
                 if (_entityManager.Deleted(entity)
                     || _entityManager.HasComponent<MapGridComponent>(entity)

--- a/Robust.Shared/Network/Messages/MsgPlacement.cs
+++ b/Robust.Shared/Network/Messages/MsgPlacement.cs
@@ -33,6 +33,7 @@ namespace Robust.Shared.Network.Messages
         public string ObjType { get; set; }
         public string AlignOption { get; set; }
         public Vector2 RectSize { get; set; }
+        public float RectRotation { get; set; }
 
         /// <summary>
         /// Used to determine tile sprite mirroring
@@ -71,6 +72,7 @@ namespace Robust.Shared.Network.Messages
                 case PlacementManagerMessage.RequestRectRemove:
                     NetCoordinates = buffer.ReadNetCoordinates();
                     RectSize = buffer.ReadVector2();
+                    RectRotation = buffer.ReadFloat();
                     break;
             }
         }
@@ -107,6 +109,7 @@ namespace Robust.Shared.Network.Messages
                 case PlacementManagerMessage.RequestRectRemove:
                     buffer.Write(NetCoordinates);
                     buffer.Write(RectSize);
+                    buffer.Write(RectRotation);
                     break;
             }
         }


### PR DESCRIPTION
Should be more convenient to use on grids.

Before:
<img width="1920" height="1017" alt="before" src="https://github.com/user-attachments/assets/4502da1a-54c6-41ac-9f8e-ff888c9c4e1a" />

After:
<img width="1920" height="1017" alt="after" src="https://github.com/user-attachments/assets/9760f14f-4a96-448d-b584-9fc7880c3980" />
