### PR TITLE
Disable obsolete warnings in event sub generated code

### DIFF
--- a/Robust.Shared.EntitySystemSubscriptionsGenerator/EntitySystemSubscriptionGenerator.cs
+++ b/Robust.Shared.EntitySystemSubscriptionsGenerator/EntitySystemSubscriptionGenerator.cs
@@ -86,6 +86,8 @@ public class EntitySystemSubscriptionGenerator : IIncrementalGenerator
 using Robust.Shared.GameObjects;
 using JetBrains.Annotations;
 
+#pragma warning disable CS0618 // Type or member is obsolete: event handlers will have their own obsoletion warnings, dont need to dupe them
+
 ");
                 partialTypeInfo.WriteHeader(builder);
                 builder.AppendLine($@"


### PR DESCRIPTION
event handlers will have their own obsoletion warnings, dont need to dupe them

this happened e.g. if you try to subscribe for DamageChangedEvent you couldnt suppress the warnings for the generated code if you suppressed the event handler.
dont need 2 warnings for 1 actual source