### PR TITLE
Move release build to end of content test action

### DIFF
--- a/.github/workflows/test-content.yml
+++ b/.github/workflows/test-content.yml
@@ -40,8 +40,6 @@ jobs:
         run: cp RobustToolbox/global.json .
       - name: Install dependencies
         run: dotnet restore
-      - name: Build (Release)
-        run: dotnet build --configuration Release --no-restore /m
       - name: Build (Debug)
         run: dotnet build --configuration DebugOpt --no-restore /m
       - name: Content.Tests
@@ -59,3 +57,5 @@ jobs:
           name: nunit3-results
           path: test_results/*
           retention-days: 7
+      - name: Build (Release)
+        run: dotnet build --configuration Release --no-restore /m


### PR DESCRIPTION
Moves the attempt to build against content using the release configuration to the last step of the workflow, so that tests are still run to look for more serious errors when an unavoidable warning exists in content.