### PR TITLE
Add functions for CVar stream validation to ConfigurationManager.

### DIFF
--- a/Robust.Shared/Configuration/ConfigurationManager.cs
+++ b/Robust.Shared/Configuration/ConfigurationManager.cs
@@ -74,6 +74,23 @@ namespace Robust.Shared.Configuration
             return LoadFromTomlTable(tblRoot);
         }
 
+        /// <inheritdoc />
+        public HashSet<string> ValidateTomlStream(Stream file)
+        {
+            TomlTable tblRoot;
+            try
+            {
+                tblRoot = Toml.ReadStream(file);
+            }
+            catch (Exception e)
+            {
+                _sawmill.Error("Unable to load configuration from table:\n{0}", e);
+                return [];
+            }
+
+            return ValidateTomlTable(tblRoot);
+        }
+
         private HashSet<string> LoadFromTomlTable(TomlTable table)
         {
             var loaded = new HashSet<string>();
@@ -94,6 +111,19 @@ namespace Robust.Shared.Configuration
             {
                 RunDeferredInvokeCallbacks(in callbackEvents);
             }
+
+            return loaded;
+        }
+
+        /// <summary>
+        /// Validates a TomlTable and returns the set of cvars contained.
+        /// </summary>
+        private HashSet<string> ValidateTomlTable(TomlTable table)
+        {
+            var loaded = new HashSet<string>();
+
+            foreach (var (cvar, _) in ParseCVarValuesFromToml(table))
+                loaded.Add(cvar);
 
             return loaded;
         }

--- a/Robust.Shared/Configuration/ConfigurationManager.cs
+++ b/Robust.Shared/Configuration/ConfigurationManager.cs
@@ -91,6 +91,7 @@ namespace Robust.Shared.Configuration
             return ValidateTomlTable(tblRoot);
         }
 
+        /// <inheritdoc />
         private HashSet<string> LoadFromTomlTable(TomlTable table)
         {
             var loaded = new HashSet<string>();
@@ -115,9 +116,7 @@ namespace Robust.Shared.Configuration
             return loaded;
         }
 
-        /// <summary>
-        /// Validates a TomlTable and returns the set of cvars contained.
-        /// </summary>
+        /// <inheritdoc />
         private HashSet<string> ValidateTomlTable(TomlTable table)
         {
             var loaded = new HashSet<string>();

--- a/Robust.Shared/Configuration/IConfigurationManager.cs
+++ b/Robust.Shared/Configuration/IConfigurationManager.cs
@@ -69,7 +69,23 @@ namespace Robust.Shared.Configuration
         /// </summary>
         void SaveToTomlStream(Stream stream, IEnumerable<string> cvars);
 
+        /// <summary>
+        /// Load a TOML config file, using all CVar values specified inside.
+        /// </summary>
+        /// <remarks>
+        /// All CVars in the TOML file must be registered when this function is called.
+        /// </remarks>
+        /// <returns>A set of all CVars touched.</returns>
         HashSet<string> LoadFromTomlStream(Stream stream);
+
+        /// <summary>
+        /// Load a TOML config file and try and parse its contents without side-effects.
+        /// </summary>
+        /// <remarks>
+        /// All CVars in the TOML file must be registered when this function is called.
+        /// </remarks>
+        /// <returns>A set of all CVars that would be touched by this stream.</returns>
+        HashSet<string> ValidateTomlStream(Stream stream);
 
         /// <summary>
         /// Load a TOML config file and use the CVar values specified as an <see cref="OverrideDefault"/>.


### PR DESCRIPTION
Adds methods to ConfigurationManager for CVar validation.  Should have no side effects when reading (vs. the Load functions), should be useful for testing.

Would be useful for a content-side PR testing the default SS14 server_config.toml file.  (Not blocking anything at the moment, but useful for thoroughness of testing.)