### PR TITLE
Allow passing a reason to the shutdown command

### DIFF
--- a/Resources/Locale/en-US/commands.ftl
+++ b/Resources/Locale/en-US/commands.ftl
@@ -386,7 +386,8 @@ cmd-restart-desc = Gracefully restarts the server (not just the round).
 cmd-restart-help = Usage: {$command}
 
 cmd-shutdown-desc = Gracefully shuts down the server.
-cmd-shutdown-help = Usage: {$command}
+cmd-shutdown-help = Usage: {$command} [<Reason>]
+cmd-shutdown-arg-reason = [reason]
 
 cmd-saveconfig-desc = Saves the server configuration to the config file.
 cmd-saveconfig-help = Usage: {$command}

--- a/Resources/Locale/en-US/commands.ftl
+++ b/Resources/Locale/en-US/commands.ftl
@@ -387,7 +387,6 @@ cmd-restart-help = Usage: {$command}
 
 cmd-shutdown-desc = Gracefully shuts down the server.
 cmd-shutdown-help = Usage: {$command} [<Reason>]
-cmd-shutdown-arg-reason = [reason]
 
 cmd-saveconfig-desc = Saves the server configuration to the config file.
 cmd-saveconfig-help = Usage: {$command}

--- a/Robust.Server/Console/Commands/SysCommands.cs
+++ b/Robust.Server/Console/Commands/SysCommands.cs
@@ -30,7 +30,7 @@ namespace Robust.Server.Console.Commands
 
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            _server.Shutdown(null);
+            _server.Shutdown(argStr[$"{Command} ".Length..].Trim());
         }
     }
 


### PR DESCRIPTION
Title.

Passed down the trimmed substringed argStr into `IBaseServer.Shutdown`, `BaseServer.Shutdown` already handles null/empty input, so effectively no change unless an argument is provided