### PR TITLE
Bugfix: SharedUserInterfaceSystem stores and applies BUI states in order.

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -292,7 +292,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
         // PlayerAttachedEvent will catch some of these.
         foreach (var (key, bui) in ent.Comp.ClientOpenInterfaces)
         {
-            ent.Comp.States.TryGetValue(key, out var state);
+            var state = ent.Comp.States.GetValueOrDefault(key);
             AddQueued(bui, QueuedUpdate.Open, state);
         }
     }

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -48,7 +48,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
     /// <summary>
     /// Defer BUIs during state handling so client doesn't spam a BUI constantly during prediction.
     /// </summary>
-    private readonly List<(BoundUserInterface bui, QueuedUpdate updateType)> _queuedBuis = new();
+    private readonly List<(BoundUserInterface bui, QueuedUpdate updateType, BoundUserInterfaceState? state)> _queuedBuis = new();
 
     public override void Initialize()
     {
@@ -91,9 +91,9 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
         SubscribeLocalEvent<UserInterfaceUserComponent, ComponentShutdown>(OnActorShutdown);
     }
 
-    private void AddQueued(BoundUserInterface bui, QueuedUpdate type)
+    private void AddQueued(BoundUserInterface bui, QueuedUpdate type, BoundUserInterfaceState? state = null)
     {
-        _queuedBuis.Add((bui, type));
+        _queuedBuis.Add((bui, type, state));
     }
 
     /// <summary>
@@ -312,7 +312,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
             DebugTools.Assert(!ent.Comp.Actors.ContainsKey(key));
         }
 
-        DebugTools.Assert(ent.Comp.ClientOpenInterfaces.Values.All(x => _queuedBuis.Contains((x, QueuedUpdate.Close))));
+        DebugTools.Assert(ent.Comp.ClientOpenInterfaces.Values.All(x => _queuedBuis.Contains((x, QueuedUpdate.Close, null))));
     }
 
     private void OnUserInterfaceGetState(Entity<UserInterfaceComponent> ent, ref ComponentGetState args)
@@ -500,7 +500,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
                 if (!ent.Comp.ClientOpenInterfaces.TryGetValue(key, out var cBui) || !cBui.IsOpened)
                     continue;
 
-                AddQueued(cBui, QueuedUpdate.ApplyState);
+                AddQueued(cBui, QueuedUpdate.ApplyState, buiState);
             }
         }
 
@@ -528,7 +528,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
         // Existing BUI just keep it.
         if (entity.Comp.ClientOpenInterfaces.TryGetValue(key, out var existing))
         {
-            _queuedBuis.Remove((existing, QueuedUpdate.Close));
+            _queuedBuis.Remove((existing, QueuedUpdate.Close, null));
             return;
         }
 
@@ -1110,28 +1110,19 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
     {
         if (_timing.IsFirstTimePredicted)
         {
-            foreach (var (bui, updateType) in _queuedBuis)
+            foreach (var (bui, updateType, state) in _queuedBuis)
             {
-                if (updateType == QueuedUpdate.Open || updateType == QueuedUpdate.ApplyState)
+                switch (updateType)
                 {
+                    case QueuedUpdate.Open:
 #if EXCEPTION_TOLERANCE
                     try
                     {
 #endif
-                    if (updateType == QueuedUpdate.Open)
-                    {
-                        bui.Open();
-                    }
-
-                    if (UIQuery.TryComp(bui.Owner, out var uiComp))
-                    {
-                        if (uiComp.States.TryGetValue(bui.UiKey, out var buiState))
+                        if (updateType == QueuedUpdate.Open)
                         {
-                            bui.State = buiState;
-                            bui.UpdateState(buiState);
-                            bui.Update();
+                            bui.Open();
                         }
-                    }
 #if EXCEPTION_TOLERANCE
                     }
                     catch (Exception e)
@@ -1140,10 +1131,28 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
                             $"Caught exception while attempting to create a BUI {bui.UiKey} with type {bui.GetType()} on entity {ToPrettyString(bui.Owner)}. Exception: {e}");
                     }
 #endif
-                }
-                // Close BUI
-                else
-                {
+                    break;
+                    case QueuedUpdate.ApplyState:
+                    if (state == null)
+                        break;
+#if EXCEPTION_TOLERANCE
+                    try
+                    {
+#endif
+                        bui.State = state;
+                        bui.Update();
+                        bui.UpdateState(state);
+#if EXCEPTION_TOLERANCE
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Error(
+                            $"Caught exception while attempting to create a BUI {bui.UiKey} with type {bui.GetType()} on entity {ToPrettyString(bui.Owner)}. Exception: {e}");
+                    }
+#endif
+                    break;
+                    case QueuedUpdate.Close:
+                    default:
                     if (UIQuery.TryComp(bui.Owner, out var uiComp))
                     {
                         uiComp.ClientOpenInterfaces.Remove(bui.UiKey);
@@ -1167,6 +1176,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
                             $"Caught exception while attempting to dispose of a BUI {bui.UiKey} with type {bui.GetType()} on entity {ToPrettyString(bui.Owner)}. Exception: {e}");
                     }
 #endif
+                    break;
                 }
             }
 

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -765,10 +765,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
         // Predict the change on client
         if (state != null && _netManager.IsClient && entity.Comp.ClientOpenInterfaces.TryGetValue(key, out var bui))
         {
-            if (bui.State?.Equals(state) != true)
-            {
-                AddQueued(bui, QueuedUpdate.ApplyState, state);
-            }
+            AddQueued(bui, QueuedUpdate.ApplyState, state);
         }
 
         DirtyField(entity, nameof(UserInterfaceComponent.States));

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -767,8 +767,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
         {
             if (bui.State?.Equals(state) != true)
             {
-                bui.UpdateState(state);
-                bui.Update();
+                AddQueued(bui, QueuedUpdate.ApplyState, state);
             }
         }
 

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -292,9 +292,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
         // PlayerAttachedEvent will catch some of these.
         foreach (var (key, bui) in ent.Comp.ClientOpenInterfaces)
         {
-            if (!ent.Comp.States.TryGetValue(key, out var state))
-                state = null;
-
+            ent.Comp.States.TryGetValue(key, out var state);
             AddQueued(bui, QueuedUpdate.Open, state);
         }
     }

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -1119,10 +1119,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
                     try
                     {
 #endif
-                        if (updateType == QueuedUpdate.Open)
-                        {
-                            bui.Open();
-                        }
+                        bui.Open();
 #if EXCEPTION_TOLERANCE
                     }
                     catch (Exception e)
@@ -1147,7 +1144,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
                     catch (Exception e)
                     {
                         Log.Error(
-                            $"Caught exception while attempting to create a BUI {bui.UiKey} with type {bui.GetType()} on entity {ToPrettyString(bui.Owner)}. Exception: {e}");
+                            $"Caught exception while attempting to update a BUI {bui.UiKey} with type {bui.GetType()} with a state of type {state.GetType()} on entity {ToPrettyString(bui.Owner)}. Exception: {e}");
                     }
 #endif
                     break;

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -1134,8 +1134,9 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
                     }
                     catch (Exception e)
                     {
+                        var operationType = updateType == QueuedUpdate.Open ? "create" : "update";
                         Log.Error(
-                            $"Caught exception while attempting to {updateType == QueuedUpdate.Open ? "create" : "update"} a BUI {bui.UiKey} with type {bui.GetType()} on entity {ToPrettyString(bui.Owner)}. Exception: {e}");
+                            $"Caught exception while attempting to {operationType} a BUI {bui.UiKey} with type {bui.GetType()} on entity {ToPrettyString(bui.Owner)}. Exception: {e}");
                     }
 #endif
                 }

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -292,7 +292,10 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
         // PlayerAttachedEvent will catch some of these.
         foreach (var (key, bui) in ent.Comp.ClientOpenInterfaces)
         {
-            AddQueued(bui, QueuedUpdate.Open);
+            if (!ent.Comp.States.TryGetValue(key, out var state))
+                state = null;
+
+            AddQueued(bui, QueuedUpdate.Open, state);
         }
     }
 
@@ -1112,44 +1115,34 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
         {
             foreach (var (bui, updateType, state) in _queuedBuis)
             {
-                switch (updateType)
+                if (updateType == QueuedUpdate.Open || updateType == QueuedUpdate.ApplyState)
                 {
-                    case QueuedUpdate.Open:
 #if EXCEPTION_TOLERANCE
                     try
                     {
 #endif
+                    if (updateType == QueuedUpdate.Open)
+                    {
                         bui.Open();
-#if EXCEPTION_TOLERANCE
                     }
-                    catch (Exception e)
+
+                    if (state != null)
                     {
-                        Log.Error(
-                            $"Caught exception while attempting to create a BUI {bui.UiKey} with type {bui.GetType()} on entity {ToPrettyString(bui.Owner)}. Exception: {e}");
-                    }
-#endif
-                    break;
-                    case QueuedUpdate.ApplyState:
-                    if (state == null)
-                        break;
-#if EXCEPTION_TOLERANCE
-                    try
-                    {
-#endif
                         bui.State = state;
-                        bui.Update();
                         bui.UpdateState(state);
+                        bui.Update();
+                    }
 #if EXCEPTION_TOLERANCE
                     }
                     catch (Exception e)
                     {
                         Log.Error(
-                            $"Caught exception while attempting to update a BUI {bui.UiKey} with type {bui.GetType()} with a state of type {state.GetType()} on entity {ToPrettyString(bui.Owner)}. Exception: {e}");
+                            $"Caught exception while attempting to {updateType == QueuedUpdate.Open ? "create" : "update"} a BUI {bui.UiKey} with type {bui.GetType()} on entity {ToPrettyString(bui.Owner)}. Exception: {e}");
                     }
 #endif
-                    break;
-                    case QueuedUpdate.Close:
-                    default:
+                }
+                else // Close BUI
+                {
                     if (UIQuery.TryComp(bui.Owner, out var uiComp))
                     {
                         uiComp.ClientOpenInterfaces.Remove(bui.UiKey);
@@ -1173,7 +1166,6 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
                             $"Caught exception while attempting to dispose of a BUI {bui.UiKey} with type {bui.GetType()} on entity {ToPrettyString(bui.Owner)}. Exception: {e}");
                     }
 #endif
-                    break;
                 }
             }
 


### PR DESCRIPTION
What the title says.

Related issues
- https://github.com/space-wizards/space-station-14/issues/44758 (needs engine update to resolve)

From the solution in #6789, instead of using the most recent state in every update, we cache the intermediate states (appending a third element into the tuple) and update with each intermediate value when predicting.  In addition, all open operations are only opens.

This is particularly naive, and I don't know what lies in between the state population and that Update call.

**There's also a lingering BUI.UpdateState/Update call in UISystem.SetUiState that should possibly be deferred.**

I hate that the list Remove call uses an explicit null value, but all open/close additions should be null.

Small video of the PDA working with this change:

https://github.com/user-attachments/assets/fe248aea-e566-40fe-ac36-326f8f70bcbc