### PR TITLE
SharedBroadphaseSystem.FindPairs: exit early if passed broadphase UID is invalid

### DIFF
--- a/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
+++ b/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs
@@ -396,7 +396,7 @@ namespace Robust.Shared.Physics.Systems
             DebugTools.Assert(proxy.Body.CanCollide);
 
             // Broadphase can't intersect with entities on itself so skip.
-            if (proxy.Entity == broadphase || !_xformQuery.TryGetComponent(proxy.Entity, out var xform))
+            if (proxy.Entity == broadphase || broadphase == EntityUid.Invalid || !_xformQuery.TryGetComponent(proxy.Entity, out var xform))
             {
                 return;
             }


### PR DESCRIPTION
Preventing a KeyNotFoundException from a component lookup on an invalid EntityUid.

Think this is sane - it probably shouldn't have an AABB to pass into QueryBroadphase if there's no valid map.

If you'd like something deeper, I'll try my best, but I'm still not very familiar with the engine.

<details>
    <summary>Call tracing:</summary>

BroadphaseContactJob.Execute tries to get an entity's map UID, defaulting to EntityUid.Invalid.
    
https://github.com/space-wizards/RobustToolbox/blob/e89668c21282f1b5017929ebc5c12b97e6453b93/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs#L632-L638
    
It then eventually calls FindPairs with mapUid set to EntityUid.Invalid.
    
https://github.com/space-wizards/RobustToolbox/blob/e89668c21282f1b5017929ebc5c12b97e6453b93/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs#L663
    
Inside of FindPairs, you run GetInvWorldMatrix on broadphase (EntityUid.Invalid)
    
https://github.com/space-wizards/RobustToolbox/blob/e89668c21282f1b5017929ebc5c12b97e6453b93/Robust.Shared/Physics/Systems/SharedBroadphaseSystem.cs#L421
    
Then GetInvWorldMatrix tries to get a TransformQuery on the passed entity.
    
https://github.com/space-wizards/RobustToolbox/blob/e89668c21282f1b5017929ebc5c12b97e6453b93/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs#L1351
    
And this results in a KeyNotFoundException in EntityQuery.GetComponent
    
https://github.com/space-wizards/RobustToolbox/blob/e89668c21282f1b5017929ebc5c12b97e6453b93/Robust.Shared/GameObjects/EntityManager.Components.cs#L1826-L1832

</details>